### PR TITLE
feat(discord): proactive/home/cron delivery targeting

### DIFF
--- a/contributors/emails/andrexibiza@gmail.com
+++ b/contributors/emails/andrexibiza@gmail.com
@@ -1,0 +1,2 @@
+andrexibiza
+# Discord omniscience W4

--- a/plugins/platforms/discord/proactive_delivery.py
+++ b/plugins/platforms/discord/proactive_delivery.py
@@ -1,0 +1,134 @@
+"""Proactive / home / cron delivery targeting for the Discord platform.
+
+Pure logic module: no I/O, no discord.py imports, no config access. All
+resolution is fail-closed: a missing or invalid target raises
+:class:`ProactiveDeliveryError` instead of silently falling back (see
+issue #7206 — no silent origin fallback when home delivery is requested).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Optional
+
+__all__ = [
+    "DeliveryTarget",
+    "ProactiveDeliveryError",
+    "continuable_thread_target",
+    "resolve_home_target",
+    "resolve_profile_adapter",
+]
+
+# Discord snowflakes are non-negative integers that fit in a signed 64-bit
+# field (snowflake generation is monotonic and well below 2**63).
+_MAX_SNOWFLAKE = (1 << 63) - 1
+
+
+class ProactiveDeliveryError(ValueError):
+    """Raised when a proactive delivery target cannot be resolved.
+
+    Subclasses ``ValueError`` so callers can catch either class.
+    """
+
+
+@dataclass(frozen=True)
+class DeliveryTarget:
+    """A resolved delivery location: a channel and/or a thread."""
+
+    channel_id: Optional[str]
+    thread_id: Optional[str]
+
+
+def _is_valid_snowflake(value: object) -> bool:
+    """Return True when *value* is a snowflake-shaped string.
+
+    A valid snowflake is a string of decimal digits (no sign, no
+    whitespace, no separators) whose integer value fits in a signed
+    64-bit range. Non-strings are rejected.
+    """
+    if not isinstance(value, str) or not value.isdigit():
+        return False
+    try:
+        return 0 <= int(value) <= _MAX_SNOWFLAKE
+    except ValueError:  # pragma: no cover - isdigit() precludes this
+        return False
+
+
+def resolve_home_target(
+    origin_channel: Optional[str],
+    home_channel: Optional[str],
+    *,
+    deliver_home: bool,
+) -> DeliveryTarget:
+    """Resolve where a proactive message should be delivered.
+
+    When ``deliver_home`` is True the home channel is used and *must* be a
+    valid snowflake; a missing home channel raises
+    :class:`ProactiveDeliveryError` — there is no silent fallback to the
+    origin channel (#7206). When ``deliver_home`` is False the origin
+    channel is used; it may be ``None``.
+    """
+    if deliver_home:
+        if home_channel is None:
+            raise ProactiveDeliveryError(
+                "deliver_home is enabled but no home channel is configured"
+            )
+        if not _is_valid_snowflake(home_channel):
+            raise ProactiveDeliveryError(
+                f"home channel is not a valid snowflake: {home_channel!r}"
+            )
+        return DeliveryTarget(channel_id=home_channel, thread_id=None)
+
+    if origin_channel is not None and not _is_valid_snowflake(origin_channel):
+        raise ProactiveDeliveryError(
+            f"origin channel is not a valid snowflake: {origin_channel!r}"
+        )
+    return DeliveryTarget(channel_id=origin_channel, thread_id=None)
+
+
+def continuable_thread_target(
+    thread_id: Optional[str],
+    *,
+    cron_thread_identity: Optional[str],
+) -> DeliveryTarget:
+    """Resolve the thread a cron delivery should continue in.
+
+    A live ``thread_id`` wins when it is a valid snowflake. Otherwise the
+    ``cron_thread_identity`` recorded for the cron job is used (it is
+    validated when used; a broken identity is fail-closed). When neither is
+    available the result is ``DeliveryTarget(None, None)`` — no thread.
+    """
+    if thread_id is not None and _is_valid_snowflake(thread_id):
+        return DeliveryTarget(channel_id=None, thread_id=thread_id)
+
+    if cron_thread_identity is not None:
+        if not _is_valid_snowflake(cron_thread_identity):
+            raise ProactiveDeliveryError(
+                "cron thread identity is not a valid snowflake: "
+                f"{cron_thread_identity!r}"
+            )
+        return DeliveryTarget(channel_id=None, thread_id=cron_thread_identity)
+
+    return DeliveryTarget(channel_id=None, thread_id=None)
+
+
+def resolve_profile_adapter(profile_id: str, adapters: dict) -> str:
+    """Resolve the adapter registered for *profile_id*.
+
+    Fail-closed: a missing profile raises :class:`ProactiveDeliveryError`
+    rather than silently falling back to a default adapter. *adapters* must
+    be a mapping and its resolved value must be a string.
+    """
+    if not isinstance(adapters, dict):
+        raise ProactiveDeliveryError("adapters must be a mapping")
+    try:
+        adapter = adapters[profile_id]
+    except KeyError:
+        raise ProactiveDeliveryError(
+            f"no delivery adapter registered for profile {profile_id!r}"
+        ) from None
+    if not isinstance(adapter, str):
+        raise ProactiveDeliveryError(
+            f"adapter for profile {profile_id!r} is not a string: {adapter!r}"
+        )
+    return adapter

--- a/tests/tools/test_discord_proactive_delivery.py
+++ b/tests/tools/test_discord_proactive_delivery.py
@@ -1,0 +1,146 @@
+"""Tests for W4: Discord proactive/home/cron delivery targeting.
+
+Covers home target resolution (deliver_home requires a home channel, no
+silent origin fallback per #7206), continuable-thread resolution, profile
+adapter resolution (found / missing / fail-closed), and snowflake
+validation.
+"""
+
+import pytest
+
+from plugins.platforms.discord.proactive_delivery import (
+    DeliveryTarget,
+    ProactiveDeliveryError,
+    continuable_thread_target,
+    resolve_home_target,
+    resolve_profile_adapter,
+)
+
+VALID = "123456789012345678"
+VALID_2 = "987654321098765432"
+
+INVALID_SNOWFLAKES = [
+    "",
+    "abc",
+    "12a34",
+    "12.5",
+    "-123",
+    " 123",
+    "99999999999999999999",  # exceeds signed 64-bit range
+]
+
+
+class TestProactiveDeliveryError:
+    def test_is_value_error_subclass(self):
+        assert issubclass(ProactiveDeliveryError, ValueError)
+
+
+class TestResolveHomeTarget:
+    def test_deliver_home_uses_home_channel(self):
+        target = resolve_home_target(VALID, VALID_2, deliver_home=True)
+        assert target == DeliveryTarget(channel_id=VALID_2, thread_id=None)
+
+    def test_deliver_home_works_without_origin(self):
+        target = resolve_home_target(None, VALID, deliver_home=True)
+        assert target == DeliveryTarget(channel_id=VALID, thread_id=None)
+
+    def test_deliver_home_without_home_raises_no_silent_fallback(self):
+        # No silent origin fallback (#7206).
+        with pytest.raises(ProactiveDeliveryError):
+            resolve_home_target(VALID, None, deliver_home=True)
+
+    def test_deliver_home_invalid_home_raises(self):
+        with pytest.raises(ProactiveDeliveryError):
+            resolve_home_target(VALID, "not-a-snowflake", deliver_home=True)
+
+    def test_origin_used_when_deliver_home_false(self):
+        target = resolve_home_target(VALID, VALID_2, deliver_home=False)
+        assert target == DeliveryTarget(channel_id=VALID, thread_id=None)
+
+    def test_origin_none_when_deliver_home_false(self):
+        target = resolve_home_target(None, VALID_2, deliver_home=False)
+        assert target == DeliveryTarget(channel_id=None, thread_id=None)
+
+    def test_origin_invalid_raises_when_deliver_home_false(self):
+        with pytest.raises(ProactiveDeliveryError):
+            resolve_home_target("nope", None, deliver_home=False)
+
+
+class TestContinuableThreadTarget:
+    def test_valid_thread_id_used(self):
+        target = continuable_thread_target(VALID, cron_thread_identity=VALID_2)
+        assert target == DeliveryTarget(channel_id=None, thread_id=VALID)
+
+    def test_none_thread_id_falls_back_to_cron_identity(self):
+        target = continuable_thread_target(None, cron_thread_identity=VALID_2)
+        assert target == DeliveryTarget(channel_id=None, thread_id=VALID_2)
+
+    def test_both_none_returns_empty_target(self):
+        target = continuable_thread_target(None, cron_thread_identity=None)
+        assert target == DeliveryTarget(channel_id=None, thread_id=None)
+
+    def test_invalid_thread_id_falls_back_to_cron_identity(self):
+        # A stale/non-snowflake thread id does not crash the delivery; the
+        # cron identity recorded for the job is used instead.
+        target = continuable_thread_target("stale", cron_thread_identity=VALID_2)
+        assert target == DeliveryTarget(channel_id=None, thread_id=VALID_2)
+
+    def test_invalid_cron_identity_raises_when_used(self):
+        with pytest.raises(ProactiveDeliveryError):
+            continuable_thread_target(None, cron_thread_identity="bad")
+
+    def test_invalid_cron_identity_raises_on_fallback(self):
+        with pytest.raises(ProactiveDeliveryError):
+            continuable_thread_target("stale", cron_thread_identity="bad")
+
+    def test_valid_thread_wins_over_invalid_cron_identity(self):
+        target = continuable_thread_target(VALID, cron_thread_identity="bad")
+        assert target == DeliveryTarget(channel_id=None, thread_id=VALID)
+
+
+class TestResolveProfileAdapter:
+    def test_adapter_found(self):
+        adapters = {"main": "adapter-main", "alt": "adapter-alt"}
+        assert resolve_profile_adapter("alt", adapters) == "adapter-alt"
+
+    def test_missing_profile_raises(self):
+        with pytest.raises(ProactiveDeliveryError):
+            resolve_profile_adapter("missing", {"main": "adapter-main"})
+
+    def test_missing_profile_raises_fail_closed_on_empty(self):
+        # Fail-closed: no silent fallback to a default adapter.
+        with pytest.raises(ProactiveDeliveryError):
+            resolve_profile_adapter("main", {})
+
+    def test_non_dict_adapters_raises(self):
+        with pytest.raises(ProactiveDeliveryError):
+            resolve_profile_adapter("main", ["not", "a", "dict"])
+
+    def test_non_str_adapter_value_raises(self):
+        with pytest.raises(ProactiveDeliveryError):
+            resolve_profile_adapter("main", {"main": 123})
+
+
+class TestSnowflakeValidation:
+    @pytest.mark.parametrize("bad", INVALID_SNOWFLAKES)
+    def test_invalid_home_channel_raises(self, bad):
+        with pytest.raises(ProactiveDeliveryError):
+            resolve_home_target(None, bad, deliver_home=True)
+
+    @pytest.mark.parametrize("bad", INVALID_SNOWFLAKES)
+    def test_invalid_origin_channel_raises(self, bad):
+        with pytest.raises(ProactiveDeliveryError):
+            resolve_home_target(bad, None, deliver_home=False)
+
+    @pytest.mark.parametrize("bad", INVALID_SNOWFLAKES)
+    def test_invalid_cron_thread_identity_raises(self, bad):
+        with pytest.raises(ProactiveDeliveryError):
+            continuable_thread_target(None, cron_thread_identity=bad)
+
+    def test_non_str_snowflake_rejected(self):
+        with pytest.raises(ProactiveDeliveryError):
+            resolve_home_target(123456, None, deliver_home=False)
+
+    def test_zero_is_valid_snowflake(self):
+        target = resolve_home_target("0", None, deliver_home=False)
+        assert target == DeliveryTarget(channel_id="0", thread_id=None)


### PR DESCRIPTION
**Discord W4** (Part of #79564, Fixes #86486): proactive/home/cron delivery targeting in `plugins/platforms/discord/proactive_delivery.py`. 43/43 tests pass. New module only.