### PR TITLE
fix(cron): out-of-process relay-fronted delivery via gateway loopback

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -2279,9 +2279,10 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
 
         # Relay-fronted logical platforms (credential in the connector) are
         # deliberately not natively enabled. Detect that from the same env
-        # stamp the live adapter uses so out-of-process cron (adapters=None)
-        # can still skip the native gate and deliver via gateway loopback
-        # (#86249) instead of dying with "not configured/enabled".
+        # stamp the live adapter uses so out-of-process cron (no live relay
+        # adapter in *this* process) can still skip the native gate and
+        # deliver via gateway loopback instead of dying with
+        # "not configured/enabled".
         relay_fronted = False
         try:
             from gateway.relay import relay_fronted_platforms
@@ -2292,7 +2293,11 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                 "relay_fronted_platforms lookup failed for %r",
                 platform_name, exc_info=True,
             )
-        no_live_adapters = not adapters
+        # Gate on the resolved runtime adapter, not `not adapters`. A non-empty
+        # adapters map that lacks Platform.RELAY (or any handle for this
+        # logical platform) must still take the loopback path — `not adapters`
+        # is too coarse and would re-hit the native credential gate.
+        no_live_relay_adapter = runtime_adapter is None
 
         if transport is not None and transport.is_relay:
             # A relay transport carries the RELAY adapter's config, and
@@ -2305,11 +2310,11 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
             if pconfig is None:
                 from gateway.config import PlatformConfig
                 pconfig = PlatformConfig(enabled=True)
-        elif relay_fronted and no_live_adapters:
-            # Out-of-process: no live relay handle in *this* process, but the
-            # deploy stamp says the connector fronts this platform. Synthesize
-            # an enabled config so we reach the loopback send below rather
-            # than the native credential gate.
+        elif relay_fronted and no_live_relay_adapter:
+            # No live relay handle for this logical platform in *this*
+            # process, but the deploy stamp says the connector fronts it.
+            # Synthesize an enabled config so we reach the loopback send
+            # below rather than the native credential gate.
             if pconfig is None or not pconfig.enabled:
                 from gateway.config import PlatformConfig
                 pconfig = PlatformConfig(enabled=True)
@@ -2724,10 +2729,10 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                     )
 
         if not delivered:
-            if relay_fronted and no_live_adapters:
-                # Out-of-process + relay-fronted: the only working transport is
-                # the live gateway's relay socket. POST to api_server on
-                # loopback (option 2 in #86249) — never open a second connector
+            if relay_fronted and no_live_relay_adapter:
+                # Relay-fronted with no live relay handle here: the only
+                # working transport is the live gateway's relay socket. POST
+                # to api_server on loopback — never open a second connector
                 # handshake, and never fall through to the native Discord/
                 # Slack standalone HTTP path (no bot token on this host).
                 from gateway.loopback_delivery import deliver_via_gateway_loopback

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -2277,6 +2277,23 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
             pconfig = config.platforms.get(platform)
             runtime_adapter = None
 
+        # Relay-fronted logical platforms (credential in the connector) are
+        # deliberately not natively enabled. Detect that from the same env
+        # stamp the live adapter uses so out-of-process cron (adapters=None)
+        # can still skip the native gate and deliver via gateway loopback
+        # (#86249) instead of dying with "not configured/enabled".
+        relay_fronted = False
+        try:
+            from gateway.relay import relay_fronted_platforms
+
+            relay_fronted = platform_name.lower() in relay_fronted_platforms()
+        except Exception:
+            logger.debug(
+                "relay_fronted_platforms lookup failed for %r",
+                platform_name, exc_info=True,
+            )
+        no_live_adapters = not adapters
+
         if transport is not None and transport.is_relay:
             # A relay transport carries the RELAY adapter's config, and
             # resolve_delivery_transport already applied relay's enablement
@@ -2286,6 +2303,14 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
             # configured/enabled gate below must not apply — it used to
             # reject exactly the targets the relay was resolved to serve.
             if pconfig is None:
+                from gateway.config import PlatformConfig
+                pconfig = PlatformConfig(enabled=True)
+        elif relay_fronted and no_live_adapters:
+            # Out-of-process: no live relay handle in *this* process, but the
+            # deploy stamp says the connector fronts this platform. Synthesize
+            # an enabled config so we reach the loopback send below rather
+            # than the native credential gate.
+            if pconfig is None or not pconfig.enabled:
                 from gateway.config import PlatformConfig
                 pconfig = PlatformConfig(enabled=True)
         elif not pconfig or not pconfig.enabled:
@@ -2699,6 +2724,45 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                     )
 
         if not delivered:
+            if relay_fronted and no_live_adapters:
+                # Out-of-process + relay-fronted: the only working transport is
+                # the live gateway's relay socket. POST to api_server on
+                # loopback (option 2 in #86249) — never open a second connector
+                # handshake, and never fall through to the native Discord/
+                # Slack standalone HTTP path (no bot token on this host).
+                from gateway.loopback_delivery import deliver_via_gateway_loopback
+
+                loopback_err = deliver_via_gateway_loopback(
+                    platform_name,
+                    chat_id,
+                    cleaned_delivery_content,
+                    thread_id=thread_id,
+                )
+                if loopback_err is None:
+                    logger.info(
+                        "Job '%s': delivered to %s:%s via gateway loopback",
+                        job["id"], platform_name, chat_id,
+                    )
+                    delivered = True
+                    if media_files:
+                        # Loopback currently ships text only; attachments need
+                        # the live-adapter media path. Surface the drop so it
+                        # is not silent (#86249).
+                        msg = (
+                            f"{len(media_files)} media attachment(s) not delivered "
+                            f"to {platform_name}:{chat_id} via gateway loopback"
+                        )
+                        logger.warning("Job '%s': %s", job["id"], msg)
+                        delivery_errors.append(msg)
+                    _maybe_mirror_cron_delivery(
+                        job, platform_name, chat_id, mirror_text,
+                        thread_id=thread_id, user_id=origin_user_id,
+                        enabled=mirror_this_target,
+                    )
+                else:
+                    target_errors.append(loopback_err)
+                    delivery_errors.extend(target_errors)
+                continue
             if transport is not None and transport.is_relay:
                 # Relay owns the logical destination and its connector owns the
                 # platform credential. A native retry could duplicate delivery

--- a/gateway/loopback_delivery.py
+++ b/gateway/loopback_delivery.py
@@ -1,0 +1,139 @@
+"""Loopback delivery to the live gateway's api_server.
+
+Out-of-process cron (``hermes cron run``, a separate Chronos worker, etc.)
+has no live platform adapters. Relay-fronted logical platforms (Discord /
+Slack / … whose credential lives in the Team Gateway connector) have no
+native standalone sender either — the only working transport is the live
+gateway process's relay websocket.
+
+This module POSTs to the local api_server's ``/api/delivery/send`` route so
+delivery reuses that socket instead of opening a second connector handshake
+(see issue #86249, fix option 2).
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from pathlib import Path
+from typing import Any, Optional
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_API_SERVER_PORT = 8642
+
+
+def resolve_api_server_loopback_base(home: Optional[Path] = None) -> str:
+    """Return ``http://127.0.0.1:<port>`` for the local gateway api_server.
+
+    Port resolution mirrors the Chronos fire-forward helper
+    (``hermes_cli.web_server._gateway_fire_endpoint``): config.yaml
+    ``platforms.api_server.extra.port`` → ``API_SERVER_PORT`` → 8642.
+    """
+    port = 0
+    try:
+        from hermes_cli.config import cfg_get, load_config
+        from hermes_constants import (
+            reset_hermes_home_override,
+            set_hermes_home_override,
+        )
+
+        token = None
+        if home is not None:
+            token = set_hermes_home_override(str(home))
+        try:
+            cfg = load_config()
+        finally:
+            if token is not None:
+                reset_hermes_home_override(token)
+        raw = cfg_get(cfg, "platforms", "api_server", "extra", "port", default=None)
+        if raw:
+            port = int(raw)
+    except Exception:
+        port = 0
+
+    if not port:
+        raw = os.getenv("API_SERVER_PORT", "").strip()
+        try:
+            port = int(raw) if raw else 0
+        except ValueError:
+            port = 0
+    if not port:
+        port = _DEFAULT_API_SERVER_PORT
+    return f"http://127.0.0.1:{port}"
+
+
+def _api_server_key() -> str:
+    """Bearer key for loopback calls (``API_SERVER_KEY`` / config mirror)."""
+    key = (os.getenv("API_SERVER_KEY") or "").strip()
+    if key:
+        return key
+    try:
+        from hermes_cli.config import cfg_get, load_config
+
+        cfg = load_config()
+        raw = cfg_get(cfg, "platforms", "api_server", "extra", "key", default="") or ""
+        return str(raw).strip()
+    except Exception:
+        return ""
+
+
+def deliver_via_gateway_loopback(
+    platform: str,
+    chat_id: str,
+    content: str,
+    *,
+    thread_id: Optional[str] = None,
+    timeout: float = 60.0,
+) -> Optional[str]:
+    """Deliver ``content`` through the live gateway on loopback.
+
+    Returns ``None`` on success, or an error string on failure (unreachable
+    gateway, auth failure, or upstream send error). Never raises.
+    """
+    platform_name = (platform or "").strip().lower()
+    chat = str(chat_id or "").strip()
+    if not platform_name or not chat:
+        return "gateway loopback delivery requires platform and chat_id"
+
+    url = f"{resolve_api_server_loopback_base()}/api/delivery/send"
+    headers: dict[str, str] = {"Content-Type": "application/json"}
+    key = _api_server_key()
+    if key:
+        headers["Authorization"] = f"Bearer {key}"
+
+    payload: dict[str, Any] = {
+        "platform": platform_name,
+        "chat_id": chat,
+        "content": content if isinstance(content, str) else str(content or ""),
+    }
+    if thread_id is not None and str(thread_id).strip():
+        payload["thread_id"] = str(thread_id).strip()
+
+    try:
+        import httpx
+
+        resp = httpx.post(url, json=payload, headers=headers, timeout=timeout)
+    except Exception as exc:
+        msg = (
+            f"gateway loopback unreachable at {url} ({type(exc).__name__}: {exc}). "
+            "Is the gateway running with api_server enabled? Relay-fronted "
+            "platforms can only deliver from the live gateway process."
+        )
+        logger.warning(msg)
+        return msg
+
+    try:
+        body = resp.json()
+    except Exception:
+        body = {"raw": (resp.text or "")[:500]}
+    if not isinstance(body, dict):
+        body = {"raw": body}
+
+    if resp.status_code == 200 and body.get("success"):
+        return None
+
+    err = body.get("error") or body.get("raw") or f"HTTP {resp.status_code}"
+    msg = f"gateway loopback delivery failed: {err}"
+    logger.warning(msg)
+    return msg

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -2088,6 +2088,11 @@ class APIServerAdapter(BasePlatformAdapter):
             ("POST", "/api/jobs/{job_id}/pause", self._handle_pause_job),
             ("POST", "/api/jobs/{job_id}/resume", self._handle_resume_job),
             ("POST", "/api/jobs/{job_id}/run", self._handle_run_job),
+            # Out-of-process cron delivery for relay-fronted platforms (#86249).
+            # Authenticated by API_SERVER_KEY — loopback clients (standalone
+            # cron / hermes cron run) hold the same key as every other
+            # api_server caller.
+            ("POST", "/api/delivery/send", self._handle_delivery_send),
             ("POST", "/v1/runs", self._handle_runs),
             ("GET", "/v1/runs/{run_id}", self._handle_get_run),
             ("GET", "/v1/runs/{run_id}/events", self._handle_run_events),
@@ -5856,6 +5861,126 @@ class APIServerAdapter(BasePlatformAdapter):
             return web.json_response({"job": job})
         except Exception as e:
             return web.json_response({"error": _redact_api_error_text(e)}, status=500)
+
+    async def _handle_delivery_send(self, request: "web.Request") -> "web.Response":
+        """POST /api/delivery/send — deliver via live adapters (loopback cron).
+
+        Used by out-of-process cron delivery when the logical platform is
+        relay-fronted and has no native standalone credentials (#86249). The
+        live gateway owns the relay websocket; this route reuses it so a
+        second connector handshake is never opened from the scheduler process.
+        """
+        auth_err = self._check_auth(request)
+        if auth_err:
+            return auth_err
+        draining = self._draining_response()
+        if draining is not None:
+            return draining
+
+        try:
+            body = await request.json()
+        except Exception:
+            body = {}
+        if not isinstance(body, dict):
+            body = {}
+
+        platform_name = str(body.get("platform") or "").strip().lower()
+        chat_id = str(body.get("chat_id") or "").strip()
+        content = body.get("content", "")
+        if not isinstance(content, str):
+            content = str(content or "")
+        thread_id = body.get("thread_id")
+        if thread_id is not None:
+            thread_id = str(thread_id).strip() or None
+
+        if not platform_name or not chat_id:
+            return web.json_response(
+                {"error": "platform and chat_id are required"},
+                status=400,
+            )
+
+        from gateway.config import Platform, load_gateway_config
+        from gateway.delivery import resolve_delivery_transport
+
+        try:
+            platform = Platform(platform_name)
+        except (ValueError, KeyError):
+            return web.json_response(
+                {"error": f"unknown platform '{platform_name}'"},
+                status=400,
+            )
+
+        runner = self.gateway_runner or request.app.get("gateway_runner")
+        if runner is None:
+            try:
+                from gateway.run import _gateway_runner_ref
+
+                runner = _gateway_runner_ref()
+            except Exception:
+                runner = None
+        adapters = getattr(runner, "adapters", None) or None
+        if not adapters:
+            return web.json_response(
+                {
+                    "error": (
+                        "no live gateway adapters available for delivery; "
+                        "is the gateway connected?"
+                    )
+                },
+                status=503,
+            )
+
+        try:
+            config = load_gateway_config()
+        except Exception as exc:
+            return web.json_response(
+                {"error": f"failed to load gateway config: {_redact_api_error_text(exc)}"},
+                status=500,
+            )
+
+        transport = resolve_delivery_transport(platform, config, adapters)
+        if transport is None:
+            return web.json_response(
+                {
+                    "error": (
+                        f"no live transport for platform '{platform_name}' "
+                        "(native adapter missing and relay does not front it)"
+                    )
+                },
+                status=503,
+            )
+
+        metadata = {"thread_id": thread_id} if thread_id else None
+        try:
+            result = await transport.send(
+                platform, chat_id, content, metadata=metadata,
+            )
+        except Exception as exc:
+            logger.exception(
+                "delivery send failed for %s:%s", platform_name, chat_id,
+            )
+            return web.json_response(
+                {"error": _redact_api_error_text(exc)},
+                status=502,
+            )
+
+        if isinstance(result, dict):
+            ok = bool(result.get("success"))
+            message_id = result.get("message_id")
+            err = result.get("error")
+        else:
+            ok = bool(getattr(result, "success", False))
+            message_id = getattr(result, "message_id", None)
+            err = getattr(result, "error", None)
+
+        if ok:
+            return web.json_response(
+                {"success": True, "message_id": message_id},
+            )
+        return web.json_response(
+            {"error": err or "adapter send failed"},
+            status=502,
+        )
 
     async def _handle_cron_fire(self, request: "web.Request") -> "web.Response":
         """POST /api/cron/fire — Chronos managed-cron fire webhook (NAS → agent).

--- a/gateway/relay/__init__.py
+++ b/gateway/relay/__init__.py
@@ -954,6 +954,39 @@ def register_relay_adapter(force: bool = False, url: Optional[str] = None) -> bo
             )
         return RelayAdapter(config, placeholder, transport=transport)
 
+    async def _standalone_send(
+        pconfig,
+        chat_id,
+        message,
+        *,
+        thread_id=None,
+        media_files=None,
+        force_document=False,
+        **kwargs,
+    ):
+        """Out-of-process send via gateway loopback (no second relay socket).
+
+        Cron / ``send_message`` running outside the gateway process cannot
+        hold the live relay websocket. Option 2 from #86249: POST to the
+        local api_server and let the live gateway deliver on its existing
+        connector socket. A second handshake would risk the connector's
+        buffered-flip drain against the already-connected gateway.
+        """
+        from gateway.loopback_delivery import deliver_via_gateway_loopback
+
+        # Logical platform for deliver=relay:<chat_id> is "relay" itself;
+        # callers that need a fronted logical platform (discord/…) go through
+        # cron._deliver_result's loopback path with that platform name.
+        err = deliver_via_gateway_loopback(
+            "relay",
+            chat_id,
+            message if isinstance(message, str) else str(message or ""),
+            thread_id=thread_id,
+        )
+        if err is None:
+            return {"success": True}
+        return {"error": err}
+
     platform_registry.register(
         PlatformEntry(
             name="relay",
@@ -962,6 +995,7 @@ def register_relay_adapter(force: bool = False, url: Optional[str] = None) -> bo
             check_fn=lambda: True,
             source="builtin",
             emoji="\U0001f50c",
+            standalone_sender_fn=_standalone_send,
         )
     )
     return True

--- a/tests/cron/test_out_of_process_relay_delivery.py
+++ b/tests/cron/test_out_of_process_relay_delivery.py
@@ -1,0 +1,182 @@
+"""Out-of-process cron delivery for relay-fronted platforms (#86249).
+
+When cron runs outside the gateway process (``adapters=None``),
+``resolve_delivery_transport`` cannot see the live relay socket. Previously
+the native configured/enabled gate rejected Discord/Slack with
+``platform 'discord' not configured/enabled`` even though
+``GATEWAY_RELAY_PLATFORMS`` stamped those platforms as connector-fronted.
+
+Fix (option 2): skip the native gate for relay-fronted platforms and POST
+to the local gateway api_server's ``/api/delivery/send``, which delivers
+via the live relay adapter — no second connector handshake.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from cron.scheduler import _deliver_result
+from gateway.config import Platform, PlatformConfig
+
+
+def _clear_home_env(monkeypatch):
+    for var in (
+        "DISCORD_HOME_CHANNEL",
+        "DISCORD_HOME_CHANNEL_THREAD_ID",
+        "GATEWAY_RELAY_PLATFORMS",
+        "API_SERVER_KEY",
+        "API_SERVER_PORT",
+    ):
+        monkeypatch.delenv(var, raising=False)
+
+
+def _relay_only_config():
+    """Gateway config with no native Discord credentials (connector owns them)."""
+    config = MagicMock()
+    config.platforms = {
+        Platform.RELAY: PlatformConfig(enabled=True),
+    }
+    config.get_home_channel = lambda p: None
+    return config
+
+
+def _job():
+    return {
+        "id": "c588c14f3abf",
+        "name": "Nightly",
+        "deliver": "origin",
+        "origin": {"platform": "discord", "chat_id": "1517373704248758474"},
+    }
+
+
+class TestOutOfProcessRelayFrontedDelivery:
+    def test_adapters_none_uses_gateway_loopback(self, monkeypatch):
+        """adapters=None + GATEWAY_RELAY_PLATFORMS=discord → loopback, not gate."""
+        _clear_home_env(monkeypatch)
+        monkeypatch.setenv("GATEWAY_RELAY_PLATFORMS", "discord")
+
+        with patch("gateway.config.load_gateway_config",
+                   return_value=_relay_only_config()), \
+             patch("cron.scheduler.load_config",
+                   return_value={"cron": {"wrap_response": False}}), \
+             patch(
+                 "gateway.loopback_delivery.deliver_via_gateway_loopback",
+                 return_value=None,
+             ) as loopback:
+            err = _deliver_result(_job(), "Nightly report.", adapters=None, loop=None)
+
+        assert err is None
+        loopback.assert_called_once()
+        args, kwargs = loopback.call_args
+        assert args[0] == "discord"
+        assert args[1] == "1517373704248758474"
+        assert "Nightly report" in args[2]
+
+    def test_adapters_none_without_relay_stamp_still_rejects(self, monkeypatch):
+        """No GATEWAY_RELAY_PLATFORMS → historical native gate still fires."""
+        _clear_home_env(monkeypatch)
+
+        with patch("gateway.config.load_gateway_config",
+                   return_value=_relay_only_config()), \
+             patch("cron.scheduler.load_config",
+                   return_value={"cron": {"wrap_response": False}}), \
+             patch(
+                 "gateway.loopback_delivery.deliver_via_gateway_loopback",
+             ) as loopback:
+            err = _deliver_result(_job(), "Nightly report.", adapters=None, loop=None)
+
+        assert err is not None
+        assert "not configured/enabled" in err
+        loopback.assert_not_called()
+
+    def test_loopback_unreachable_fails_closed(self, monkeypatch):
+        """Gateway down → clear error; never fall through to Discord HTTP."""
+        _clear_home_env(monkeypatch)
+        monkeypatch.setenv("GATEWAY_RELAY_PLATFORMS", "discord")
+
+        with patch("gateway.config.load_gateway_config",
+                   return_value=_relay_only_config()), \
+             patch("cron.scheduler.load_config",
+                   return_value={"cron": {"wrap_response": False}}), \
+             patch(
+                 "gateway.loopback_delivery.deliver_via_gateway_loopback",
+                 return_value="gateway loopback unreachable at http://127.0.0.1:8642/api/delivery/send",
+             ), \
+             patch("tools.send_message_tool._send_to_platform") as standalone:
+            err = _deliver_result(_job(), "Nightly report.", adapters=None, loop=None)
+
+        assert err is not None
+        assert "loopback" in err.lower() or "unreachable" in err.lower()
+        standalone.assert_not_called()
+
+
+class TestLoopbackDeliveryHelper:
+    def test_resolve_default_port(self, monkeypatch):
+        from gateway.loopback_delivery import resolve_api_server_loopback_base
+
+        _clear_home_env(monkeypatch)
+        with patch("hermes_cli.config.load_config", return_value={}):
+            assert resolve_api_server_loopback_base() == "http://127.0.0.1:8642"
+
+    def test_deliver_posts_bearer_and_payload(self, monkeypatch):
+        from gateway.loopback_delivery import deliver_via_gateway_loopback
+
+        _clear_home_env(monkeypatch)
+        monkeypatch.setenv("API_SERVER_KEY", "test-key-sixteen-chars")
+        monkeypatch.setenv("API_SERVER_PORT", "8700")
+
+        class _Resp:
+            status_code = 200
+
+            def json(self):
+                return {"success": True, "message_id": "m1"}
+
+        posted = {}
+
+        def fake_post(url, json=None, headers=None, timeout=None):
+            posted["url"] = url
+            posted["json"] = json
+            posted["headers"] = headers
+            posted["timeout"] = timeout
+            return _Resp()
+
+        with patch("hermes_cli.config.load_config", return_value={}), \
+             patch("httpx.post", side_effect=fake_post):
+            err = deliver_via_gateway_loopback(
+                "discord", "123", "hi", thread_id="t1",
+            )
+
+        assert err is None
+        assert posted["url"] == "http://127.0.0.1:8700/api/delivery/send"
+        assert posted["json"] == {
+            "platform": "discord",
+            "chat_id": "123",
+            "content": "hi",
+            "thread_id": "t1",
+        }
+        assert posted["headers"]["Authorization"] == "Bearer test-key-sixteen-chars"
+
+    def test_deliver_connection_error_message(self, monkeypatch):
+        from gateway.loopback_delivery import deliver_via_gateway_loopback
+
+        _clear_home_env(monkeypatch)
+
+        with patch("hermes_cli.config.load_config", return_value={}), \
+             patch("httpx.post", side_effect=ConnectionError("refused")):
+            err = deliver_via_gateway_loopback("discord", "123", "hi")
+
+        assert err is not None
+        assert "unreachable" in err.lower()
+
+
+class TestRelayStandaloneSenderRegistration:
+    def test_relay_entry_registers_standalone_sender(self):
+        from gateway.platform_registry import platform_registry
+        from gateway.relay import register_relay_adapter
+
+        register_relay_adapter(force=True)
+        entry = platform_registry.get("relay")
+        assert entry is not None
+        assert callable(entry.standalone_sender_fn)

--- a/tests/cron/test_out_of_process_relay_delivery.py
+++ b/tests/cron/test_out_of_process_relay_delivery.py
@@ -91,6 +91,33 @@ class TestOutOfProcessRelayFrontedDelivery:
         assert "not configured/enabled" in err
         loopback.assert_not_called()
 
+    def test_nonempty_adapters_without_relay_still_loopbacks(self, monkeypatch):
+        """Non-empty adapters map without a Discord/relay handle → loopback.
+
+        ``not adapters`` is too coarse: a process can hold other platform
+        adapters and still lack a live transport for the relay-fronted
+        logical platform.
+        """
+        _clear_home_env(monkeypatch)
+        monkeypatch.setenv("GATEWAY_RELAY_PLATFORMS", "discord")
+        # Other platform present, but no RELAY / Discord runtime adapter.
+        adapters = {Platform.TELEGRAM: MagicMock()}
+
+        with patch("gateway.config.load_gateway_config",
+                   return_value=_relay_only_config()), \
+             patch("cron.scheduler.load_config",
+                   return_value={"cron": {"wrap_response": False}}), \
+             patch(
+                 "gateway.loopback_delivery.deliver_via_gateway_loopback",
+                 return_value=None,
+             ) as loopback:
+            err = _deliver_result(
+                _job(), "Nightly report.", adapters=adapters, loop=None,
+            )
+
+        assert err is None
+        loopback.assert_called_once()
+
     def test_loopback_unreachable_fails_closed(self, monkeypatch):
         """Gateway down → clear error; never fall through to Discord HTTP."""
         _clear_home_env(monkeypatch)

--- a/tests/gateway/test_delivery_send_api.py
+++ b/tests/gateway/test_delivery_send_api.py
@@ -1,0 +1,87 @@
+"""Tests for POST /api/delivery/send — loopback cron delivery (#86249)."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+
+from gateway.config import Platform, PlatformConfig
+from gateway.platforms.api_server import APIServerAdapter, cors_middleware
+
+
+def _make_adapter() -> APIServerAdapter:
+    return APIServerAdapter(PlatformConfig(enabled=True, extra={"key": "sk-secret-sixteen"}))
+
+
+def _create_app(adapter: APIServerAdapter) -> web.Application:
+    app = web.Application(middlewares=[cors_middleware])
+    app["api_server_adapter"] = adapter
+    app.router.add_post("/api/delivery/send", adapter._handle_delivery_send)
+    return app
+
+
+@pytest.mark.asyncio
+async def test_delivery_send_uses_live_relay_transport():
+    adapter = _make_adapter()
+    send_result = SimpleNamespace(success=True, message_id="m-1", error=None)
+    transport = MagicMock()
+    transport.send = AsyncMock(return_value=send_result)
+
+    runner = SimpleNamespace(adapters={Platform.RELAY: MagicMock()})
+    adapter.gateway_runner = runner
+    app = _create_app(adapter)
+
+    with patch(
+        "gateway.delivery.resolve_delivery_transport", return_value=transport,
+    ), patch(
+        "gateway.config.load_gateway_config", return_value=MagicMock(),
+    ):
+        async with TestClient(TestServer(app)) as client:
+            resp = await client.post(
+                "/api/delivery/send",
+                json={
+                    "platform": "discord",
+                    "chat_id": "1517373704248758474",
+                    "content": "Nightly report.",
+                },
+                headers={"Authorization": "Bearer sk-secret-sixteen"},
+            )
+            body = await resp.json()
+
+    assert resp.status == 200
+    assert body == {"success": True, "message_id": "m-1"}
+    transport.send.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_delivery_send_rejects_bad_auth():
+    adapter = _make_adapter()
+    app = _create_app(adapter)
+    async with TestClient(TestServer(app)) as client:
+        resp = await client.post(
+            "/api/delivery/send",
+            json={"platform": "discord", "chat_id": "1", "content": "x"},
+            headers={"Authorization": "Bearer wrong"},
+        )
+    assert resp.status == 401
+
+
+@pytest.mark.asyncio
+async def test_delivery_send_503_without_adapters():
+    adapter = _make_adapter()
+    adapter.gateway_runner = SimpleNamespace(adapters={})
+    app = _create_app(adapter)
+    with patch("gateway.run._gateway_runner_ref", lambda: None):
+        async with TestClient(TestServer(app)) as client:
+            resp = await client.post(
+                "/api/delivery/send",
+                json={"platform": "discord", "chat_id": "1", "content": "x"},
+                headers={"Authorization": "Bearer sk-secret-sixteen"},
+            )
+            body = await resp.json()
+    assert resp.status == 503
+    assert "adapters" in body["error"].lower() or "live" in body["error"].lower()

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -880,6 +880,29 @@ async def _send_via_adapter(
             )
         }
 
+    # Relay-fronted logical platform with no native standalone usable from
+    # this process (e.g. Discord on a connector-only host): try gateway
+    # loopback before giving up (#86249).
+    try:
+        from gateway.relay import relay_fronted_platforms
+
+        if platform_name.lower() in relay_fronted_platforms():
+            from gateway.loopback_delivery import deliver_via_gateway_loopback
+
+            err = deliver_via_gateway_loopback(
+                platform_name,
+                chat_id,
+                chunk,
+                thread_id=thread_id,
+            )
+            if err is None:
+                return {"success": True}
+            return {"error": err}
+    except Exception:
+        logger.debug(
+            "relay-fronted loopback probe failed for %s", platform_name, exc_info=True,
+        )
+
     return {
         "error": (
             f"No live adapter for platform '{platform_name}'. Is the gateway "


### PR DESCRIPTION
## What does this PR do?

On relay-only deployments (Team Gateway connector holds Discord/Slack credentials; `config.yaml` has no native platform block), cron jobs that run out-of-process (`hermes cron run`, Chronos fire with `adapters=None`) fail delivery with `platform 'discord' not configured/enabled` even though the same job succeeds in-process via `resolve_delivery_transport` + relay.

This implements issue option 2: when `GATEWAY_RELAY_PLATFORMS` stamps the logical platform and this process has no live runtime adapter for it, skip the native configured/enabled gate and POST text delivery to the live gateway's `POST /api/delivery/send` so the existing relay websocket is reused. No second connector handshake. Fail closed if the loopback call fails (do not fall through to native Discord HTTP with no bot token).

## Related Issue

Fixes #86249

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `cron/scheduler.py` — for relay-fronted targets with no live runtime adapter, synthesize an enabled config past the native gate and deliver via gateway loopback; gate on `runtime_adapter is None` (not merely `not adapters`); warn when MEDIA attachments cannot ride the text-only loopback path
- `gateway/loopback_delivery.py` — resolve local api_server base/port + Bearer key; `deliver_via_gateway_loopback()` helper
- `gateway/platforms/api_server.py` — authenticated `POST /api/delivery/send` that uses live `resolve_delivery_transport` + adapters
- `gateway/relay/__init__.py` — register `standalone_sender_fn` that loopbacks `deliver=relay:…` sends
- `tools/send_message_tool.py` — relay-fronted fallback in `_send_via_adapter` when no live/native standalone path works
- `tests/cron/test_out_of_process_relay_delivery.py` — gate skip, non-empty adapters without relay, loopback success/fail-closed, helper auth/payload, relay registry hook
- `tests/gateway/test_delivery_send_api.py` — API route uses live relay transport

## How to Test

1. Relay-only config (platforms: relay only; no `platforms.discord`). Set `GATEWAY_RELAY_PLATFORMS=discord`. Create a cron job with `deliver=origin` / `origin.platform=discord` from a Discord session.
2. From a process without live adapters, run `hermes cron run <id>` (or wait for Chronos). Before: `last_delivery_error: platform 'discord' not configured/enabled`. After: loopback POST succeeds when the gateway api_server is up and the relay socket is connected; message arrives in Discord.
3. Focused suite: `scripts/run_tests.sh tests/cron/test_out_of_process_relay_delivery.py tests/gateway/test_delivery_send_api.py -q` (11 passed; also existing `tests/cron/test_relay_fronted_delivery.py` for the in-process path).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux; focused `scripts/run_tests.sh` (11 passed); Discord REST control path exercised; full connector E2E needs live gateway + `GATEWAY_RELAY_URL`

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Repro on `upstream/main` with `adapters=None` + `GATEWAY_RELAY_PLATFORMS=discord` + relay-only config produced: