### PR TITLE
fix(kanban): stop workers from passing CLI-rejected toolsets

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -4661,9 +4661,15 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         self.disabled_toolsets = CLI_CONFIG["agent"].get("disabled_toolsets") or []
 
         if toolsets and "all" not in toolsets and "*" not in toolsets:
+            from hermes_cli.tools_config import enabled_mcp_server_names
             from hermes_cli.toolset_validation import partition_cli_toolsets
 
-            _accepted, invalid = partition_cli_toolsets(CLI_CONFIG, toolsets, validate_toolset)
+            _accepted, invalid = partition_cli_toolsets(
+                CLI_CONFIG,
+                toolsets,
+                validate_toolset,
+                enabled_mcp_server_names(CLI_CONFIG),
+            )
             if invalid:
                 self._console_print(f"[bold red]Warning: Unknown toolsets: {', '.join(invalid)}[/]")
         

--- a/cli.py
+++ b/cli.py
@@ -4661,11 +4661,9 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         self.disabled_toolsets = CLI_CONFIG["agent"].get("disabled_toolsets") or []
 
         if toolsets and "all" not in toolsets and "*" not in toolsets:
-            # Validate each toolset — MCP server names are resolved via
-            # live registry aliases (registered during discover_mcp_tools),
-            # but discovery hasn't run yet at this point, so exclude them.
-            mcp_names = set((CLI_CONFIG.get("mcp_servers") or {}).keys())
-            invalid = [t for t in toolsets if not validate_toolset(t) and t not in mcp_names]
+            from hermes_cli.toolset_validation import partition_cli_toolsets
+
+            _accepted, invalid = partition_cli_toolsets(CLI_CONFIG, toolsets, validate_toolset)
             if invalid:
                 self._console_print(f"[bold red]Warning: Unknown toolsets: {', '.join(invalid)}[/]")
         

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -10258,11 +10258,14 @@ def _resolve_worker_cli_toolsets(hermes_home: Optional[str]) -> Optional[list[st
         from hermes_constants import reset_hermes_home_override, set_hermes_home_override
         from hermes_cli.config import load_config
         from hermes_cli.tools_config import _get_platform_tools
+        from hermes_cli.toolset_validation import partition_cli_toolsets
+        from toolsets import validate_toolset
 
         token = set_hermes_home_override(hermes_home)
         try:
             cfg = load_config()
-            toolsets = sorted(_get_platform_tools(cfg, "cli"))
+            resolved = sorted(_get_platform_tools(cfg, "cli"))
+            toolsets, _rejected = partition_cli_toolsets(cfg, resolved, validate_toolset)
         finally:
             reset_hermes_home_override(token)
         return toolsets or None

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -10257,7 +10257,7 @@ def _resolve_worker_cli_toolsets(hermes_home: Optional[str]) -> Optional[list[st
     try:
         from hermes_constants import reset_hermes_home_override, set_hermes_home_override
         from hermes_cli.config import load_config
-        from hermes_cli.tools_config import _get_platform_tools
+        from hermes_cli.tools_config import _get_platform_tools, enabled_mcp_server_names
         from hermes_cli.toolset_validation import partition_cli_toolsets
         from toolsets import validate_toolset
 
@@ -10265,7 +10265,12 @@ def _resolve_worker_cli_toolsets(hermes_home: Optional[str]) -> Optional[list[st
         try:
             cfg = load_config()
             resolved = sorted(_get_platform_tools(cfg, "cli"))
-            toolsets, _rejected = partition_cli_toolsets(cfg, resolved, validate_toolset)
+            toolsets, _rejected = partition_cli_toolsets(
+                cfg,
+                resolved,
+                validate_toolset,
+                enabled_mcp_server_names(cfg),
+            )
         finally:
             reset_hermes_home_override(token)
         return toolsets or None

--- a/hermes_cli/toolset_validation.py
+++ b/hermes_cli/toolset_validation.py
@@ -12,22 +12,24 @@ significant debugging to find. Surfacing invalid toolset names (and the
 zero-tools end state) loudly turns that silent failure into an actionable one.
 """
 
-from typing import Callable, List
+from typing import Callable, Iterable, List
 
 
 def partition_cli_toolsets(
     config: dict,
     toolsets: List[str],
     is_valid_toolset: Callable[[str], bool],
+    pre_discovery_names: Iterable[str] = (),
 ) -> tuple[List[str], List[str]]:
     """Split names by the CLI ``--toolsets`` acceptance contract.
 
-    Configured MCP server names are accepted before live MCP discovery registers
-    their aliases. Every other name must already resolve as a built-in, plugin,
-    or registry-backed toolset.
+    Configured and caller-provided MCP server names are accepted before live MCP
+    discovery registers their aliases. Every other name must already resolve as
+    a built-in, plugin, or registry-backed toolset.
     """
     mcp_servers = config.get("mcp_servers") or {}
     mcp_names = set(mcp_servers) if isinstance(mcp_servers, dict) else set()
+    mcp_names.update(pre_discovery_names)
     accepted = []
     rejected = []
     for toolset in toolsets:

--- a/hermes_cli/toolset_validation.py
+++ b/hermes_cli/toolset_validation.py
@@ -15,6 +15,27 @@ zero-tools end state) loudly turns that silent failure into an actionable one.
 from typing import Callable, List
 
 
+def partition_cli_toolsets(
+    config: dict,
+    toolsets: List[str],
+    is_valid_toolset: Callable[[str], bool],
+) -> tuple[List[str], List[str]]:
+    """Split names by the CLI ``--toolsets`` acceptance contract.
+
+    Configured MCP server names are accepted before live MCP discovery registers
+    their aliases. Every other name must already resolve as a built-in, plugin,
+    or registry-backed toolset.
+    """
+    mcp_servers = config.get("mcp_servers") or {}
+    mcp_names = set(mcp_servers) if isinstance(mcp_servers, dict) else set()
+    accepted = []
+    rejected = []
+    for toolset in toolsets:
+        target = accepted if is_valid_toolset(toolset) or toolset in mcp_names else rejected
+        target.append(toolset)
+    return accepted, rejected
+
+
 def validate_platform_toolsets(
     platform_toolsets: object,
     is_valid_toolset: Callable[[str], bool],

--- a/tests/hermes_cli/test_kanban_worker_spawn_toolsets.py
+++ b/tests/hermes_cli/test_kanban_worker_spawn_toolsets.py
@@ -180,3 +180,30 @@ def test_resolve_worker_cli_toolsets_drops_names_the_cli_rejects(monkeypatch, tm
     assert resolved is not None
     assert "terminal" in resolved
     assert "platform" not in resolved
+
+
+def test_resolve_worker_cli_toolsets_retains_portable_mcp_names(monkeypatch, tmp_path):
+    root = tmp_path / ".hermes"
+    profile = root / "profiles" / "elias"
+    profile.mkdir(parents=True)
+    profile.joinpath("config.yaml").write_text(
+        "platform_toolsets:\n  cli:\n    - terminal\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(root))
+
+    from hermes_cli import plugins
+
+    portable_name = "portable-mcp-worker-fixture"
+    monkeypatch.setattr(
+        plugins,
+        "get_portable_mcp_server_names_nowait",
+        lambda: {portable_name},
+    )
+
+    from hermes_cli import kanban_db as kb
+
+    resolved = kb._resolve_worker_cli_toolsets(str(profile))
+
+    assert resolved is not None
+    assert portable_name in resolved

--- a/tests/hermes_cli/test_kanban_worker_spawn_toolsets.py
+++ b/tests/hermes_cli/test_kanban_worker_spawn_toolsets.py
@@ -161,3 +161,22 @@ toolsets:
     assert "web" in resolved
     assert "kanban" in resolved  # recovered worker lifecycle surface
     assert resolved != ["kanban"]
+
+
+def test_resolve_worker_cli_toolsets_drops_names_the_cli_rejects(monkeypatch, tmp_path):
+    root = tmp_path / ".hermes"
+    profile = root / "profiles" / "elias"
+    profile.mkdir(parents=True)
+    profile.joinpath("config.yaml").write_text(
+        "platform_toolsets:\n  cli:\n    - terminal\n    - platform\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(root))
+
+    from hermes_cli import kanban_db as kb
+
+    resolved = kb._resolve_worker_cli_toolsets(str(profile))
+
+    assert resolved is not None
+    assert "terminal" in resolved
+    assert "platform" not in resolved


### PR DESCRIPTION
## What does this PR do?

Kanban workers can currently pass internal or stale toolset names such as `platform` through the explicit `--toolsets` pin. The child CLI rejects those names and prints `Warning: Unknown toolsets: platform`, obscuring whether the worker received its intended tool surface. This change gives worker pin generation and CLI startup one shared acceptance contract: valid built-in, plugin, configured MCP, and portable MCP names remain available, while names the receiving CLI would reject are omitted.

The bug starts in `hermes_cli/kanban_db.py::_resolve_worker_cli_toolsets`: platform resolution intentionally preserves passthrough names, but worker launch serialized the full result without applying the child CLI's validation rules. The CLI then validated the same list independently and warned. Centralizing the partition in `hermes_cli/toolset_validation.py` fixes that producer/consumer drift without changing global platform resolution or suppressing useful CLI warnings.

## Related Issue

Closes #86394

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/toolset_validation.py` - add a shared CLI toolset acceptance partition that preserves configured and pre-discovery MCP names.
- `cli.py` - use the shared partition for unknown-toolset warnings.
- `hermes_cli/kanban_db.py` - filter worker `--toolsets` pins through the same acceptance contract.
- `tests/hermes_cli/test_kanban_worker_spawn_toolsets.py` - cover rejected internal names and portable MCP preservation.

## How to Test

1. Configure a worker profile with mixed `terminal` and `platform` CLI toolsets.
2. Resolve the worker CLI pin and verify `terminal` remains while `platform` is omitted.
3. Run the related validation and worker-spawn tests:

```bash
scripts/run_tests.sh tests/hermes_cli/test_kanban_worker_spawn_toolsets.py tests/hermes_cli/test_toolset_validation.py
uvx ruff check cli.py hermes_cli/kanban_db.py hermes_cli/toolset_validation.py tests/hermes_cli/test_kanban_worker_spawn_toolsets.py
```

Result: 7 tests passed; Ruff passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - N/A; no user-facing documentation changed
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - N/A; no config keys changed
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - N/A; no workflow contract changed
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior - N/A; no model tool schema changed

## Screenshots / Logs

N/A; the automated regression tests cover the deterministic CLI validation boundary.
