### PR TITLE
fix(cron): notify users when scheduled model calls fail

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -5136,6 +5136,8 @@ def run_one_job(
     execution_id = job.get("execution_id")
     if not execution_id:
         execution_id = create_execution(job["id"], source="direct")["id"]
+    delivery_attempted = False
+    delivery_error = None
     try:
         # Pre-run dispatch claim (issue #38758): atomically commit a finite
         # one-shot's dispatch BEFORE its side effect runs, so a tick that dies
@@ -5207,7 +5209,6 @@ def run_one_job(
         # / empty-response computation, or _deliver_result itself — raises, the
         # deferred agent is still torn down. Otherwise the outer `except` would
         # swallow the error and leak the agent's subprocesses/clients (#10200).
-        delivery_error = None
         blocked_config = False
         try:
             output_file = save_job_output(job["id"], output)
@@ -5304,6 +5305,7 @@ def run_one_job(
                     and not _resolve_delivery_targets(job)
                 )
                 try:
+                    delivery_attempted = True
                     delivery_error = _deliver_result(job, deliver_content, adapters=adapters, loop=loop)
                 except Exception as de:
                     delivery_error = str(de)
@@ -5359,9 +5361,42 @@ def run_one_job(
         # anything that isn't a plain Exception.
         _err_text = str(e) or type(e).__name__
         logger.error("Error processing job %s: %s", job['id'], _err_text)
+        delivery_outcome = "suppressed"
+        if isinstance(e, Exception) and not delivery_attempted:
+            normalized_deliver = _normalize_deliver_value(
+                job.get("deliver", "local")
+            )
+            unresolved_origin = False
+            try:
+                delivery_attempted = True
+                delivery_error = _deliver_result(
+                    job,
+                    _summarize_cron_failure_for_delivery(job, _err_text),
+                    adapters=adapters,
+                    loop=loop,
+                )
+            except Exception as delivery_exc:
+                delivery_error = str(delivery_exc)
+                logger.error(
+                    "Delivery failed for job %s: %s", job["id"], delivery_exc
+                )
+            if not delivery_error and normalized_deliver == "origin":
+                unresolved_origin = not _resolve_delivery_targets(job)
+            if delivery_error:
+                delivery_outcome = "failed"
+            elif unresolved_origin:
+                delivery_outcome = "not_configured"
+            elif normalized_deliver != "local":
+                delivery_outcome = "delivered"
         try:
             if not _consume_interrupted_flag(job["id"]):
-                mark_job_run(job["id"], False, _err_text)
+                if isinstance(e, Exception):
+                    mark_job_run(
+                        job["id"], False, _err_text,
+                        delivery_error=delivery_error,
+                    )
+                else:
+                    mark_job_run(job["id"], False, _err_text)
         except Exception as record_err:
             # Never let bookkeeping mask the original interruption.
             logger.error(
@@ -5369,7 +5404,12 @@ def run_one_job(
                 job["id"], record_err,
             )
         try:
-            finish_execution(execution_id, success=False, error=_err_text)
+            finish_execution(
+                execution_id,
+                success=False,
+                error=_err_text,
+                delivery_outcome=delivery_outcome,
+            )
         except Exception as record_err:
             logger.error(
                 "Failed to finish execution record for job %s: %s",

--- a/tests/cron/test_run_one_job.py
+++ b/tests/cron/test_run_one_job.py
@@ -10,6 +10,8 @@ The first test characterizes the sequence as driven through `tick()` (proving
 the extraction didn't change `tick`'s behavior); the rest unit-test the
 extracted helper directly.
 """
+import pytest
+
 import cron.scheduler as s
 
 
@@ -146,6 +148,96 @@ def test_run_one_job_exception_records_failure_alert_delivery_error(monkeypatch)
     assert s.run_one_job({"id": "j4", "deliver": "telegram"}) is False
     assert marked == [
         (("j4", False, "provider failed"), {"delivery_error": "send failed: 502"})
+    ]
+
+
+def test_run_one_job_exception_after_delivery_does_not_redeliver(monkeypatch):
+    """Once delivery has been attempted, the outer handler must not send again."""
+    delivered = []
+    mark_calls = []
+
+    monkeypatch.setattr(
+        s, "create_execution", lambda *_a, **_kw: {"id": "exec-j5"}
+    )
+    monkeypatch.setattr(s, "claim_dispatch", lambda _job_id: True)
+    monkeypatch.setattr(s, "mark_execution_running", lambda _execution_id: None)
+    monkeypatch.setattr(
+        s,
+        "run_job",
+        lambda *_a, **_kw: (True, "out", "final response", None),
+    )
+    monkeypatch.setattr(s, "save_job_output", lambda jid, out: f"/tmp/{jid}.txt")
+    monkeypatch.setattr(
+        s,
+        "_deliver_result",
+        lambda job, content, **_kw: delivered.append((job["id"], content)) or None,
+    )
+
+    def fake_mark(*args, **kwargs):
+        mark_calls.append((args, kwargs))
+        if len(mark_calls) == 1:
+            raise RuntimeError("bookkeeping boom")
+
+    monkeypatch.setattr(s, "mark_job_run", fake_mark)
+    monkeypatch.setattr(s, "finish_execution", lambda *_a, **_kw: None)
+
+    ok = s.run_one_job({"id": "j5", "name": "once", "deliver": "telegram"})
+
+    assert ok is False
+    assert delivered == [("j5", "final response")]
+    assert mark_calls[0] == (("j5", True, None), {"delivery_error": None})
+    assert mark_calls[1] == (
+        ("j5", False, "bookkeeping boom"),
+        {"delivery_error": None},
+    )
+
+
+def test_run_one_job_keyboard_interrupt_skips_delivery_and_reraises(monkeypatch):
+    """Hard interrupts must not attempt failure delivery; they re-raise."""
+    delivered = []
+    marked = []
+    finished = []
+
+    monkeypatch.setattr(
+        s, "create_execution", lambda *_a, **_kw: {"id": "exec-j6"}
+    )
+    monkeypatch.setattr(s, "claim_dispatch", lambda _job_id: True)
+    monkeypatch.setattr(s, "mark_execution_running", lambda _execution_id: None)
+    monkeypatch.setattr(
+        s,
+        "run_job",
+        lambda *_a, **_kw: (_ for _ in ()).throw(KeyboardInterrupt()),
+    )
+    monkeypatch.setattr(
+        s,
+        "_deliver_result",
+        lambda job, content, **_kw: delivered.append((job["id"], content)) or None,
+    )
+    monkeypatch.setattr(
+        s,
+        "mark_job_run",
+        lambda *args, **kwargs: marked.append((args, kwargs)),
+    )
+    monkeypatch.setattr(
+        s,
+        "finish_execution",
+        lambda *args, **kwargs: finished.append((args, kwargs)),
+    )
+
+    with pytest.raises(KeyboardInterrupt):
+        s.run_one_job({"id": "j6", "name": "interrupt", "deliver": "telegram"})
+
+    assert delivered == []
+    assert marked == [(("j6", False, "KeyboardInterrupt"), {})]
+    assert finished == [
+        (
+            ("exec-j6",),
+            {
+                "success": False,
+                "error": "KeyboardInterrupt",
+                "delivery_outcome": "suppressed",
+            },
+        )
     ]
 
 

--- a/tests/cron/test_run_one_job.py
+++ b/tests/cron/test_run_one_job.py
@@ -66,6 +66,89 @@ def test_run_one_job_success_sequence(monkeypatch):
     assert calls[-1] == ("mark", "j2", True)
 
 
+def test_run_one_job_exception_delivers_failure_alert(monkeypatch):
+    """An exception escaping the run body must not become a silent error row."""
+    delivered = []
+    marked = []
+    finished = []
+
+    monkeypatch.setattr(
+        s, "create_execution", lambda *_a, **_kw: {"id": "exec-j3"}
+    )
+    monkeypatch.setattr(s, "claim_dispatch", lambda _job_id: True)
+    monkeypatch.setattr(s, "mark_execution_running", lambda _execution_id: None)
+    monkeypatch.setattr(
+        s,
+        "run_job",
+        lambda *_a, **_kw: (_ for _ in ()).throw(
+            RuntimeError("Gemini HTTP 503 (UNAVAILABLE)")
+        ),
+    )
+    monkeypatch.setattr(
+        s,
+        "_deliver_result",
+        lambda job, content, **_kw: delivered.append((job["id"], content)) or None,
+    )
+    monkeypatch.setattr(
+        s,
+        "mark_job_run",
+        lambda *args, **kwargs: marked.append((args, kwargs)),
+    )
+    monkeypatch.setattr(
+        s,
+        "finish_execution",
+        lambda *args, **kwargs: finished.append((args, kwargs)),
+    )
+
+    ok = s.run_one_job({"id": "j3", "name": "morning", "deliver": "telegram"})
+
+    assert ok is False
+    assert delivered == [
+        ("j3", "⚠️ Cron 'morning' failed: Gemini HTTP 503 (UNAVAILABLE)")
+    ]
+    assert marked == [
+        (("j3", False, "Gemini HTTP 503 (UNAVAILABLE)"), {"delivery_error": None})
+    ]
+    assert finished == [
+        (
+            ("exec-j3",),
+            {
+                "success": False,
+                "error": "Gemini HTTP 503 (UNAVAILABLE)",
+                "delivery_outcome": "delivered",
+            },
+        )
+    ]
+
+
+def test_run_one_job_exception_records_failure_alert_delivery_error(monkeypatch):
+    """A failed fallback alert must populate last_delivery_error."""
+    marked = []
+
+    monkeypatch.setattr(
+        s, "create_execution", lambda *_a, **_kw: {"id": "exec-j4"}
+    )
+    monkeypatch.setattr(s, "claim_dispatch", lambda _job_id: True)
+    monkeypatch.setattr(s, "mark_execution_running", lambda _execution_id: None)
+    monkeypatch.setattr(
+        s,
+        "run_job",
+        lambda *_a, **_kw: (_ for _ in ()).throw(RuntimeError("provider failed")),
+    )
+    monkeypatch.setattr(s, "_deliver_result", lambda *_a, **_kw: "send failed: 502")
+    monkeypatch.setattr(
+        s,
+        "mark_job_run",
+        lambda *args, **kwargs: marked.append((args, kwargs)),
+    )
+    monkeypatch.setattr(s, "finish_execution", lambda *_a, **_kw: None)
+
+    assert s.run_one_job({"id": "j4", "deliver": "telegram"}) is False
+    assert marked == [
+        (("j4", False, "provider failed"), {"delivery_error": "send failed: 502"})
+    ]
+
+
 def test_run_one_job_installs_secret_scope_under_multiplex(monkeypatch, tmp_path):
     """Regression: under profile isolation (multiplex active), run_one_job must
     execute run_job inside a profile secret scope so credential reads


### PR DESCRIPTION
## What does this PR do?

Cron jobs now deliver a compact failure alert when an exception escapes the run pipeline before normal delivery. Without this fix, the job records `last_status=error` and `last_error`, but users can receive no notification and `last_delivery_error` remains empty even though delivery was never attempted.

### Symptom

A scheduled job whose model/provider call fails can be recorded as failed without sending its configured Telegram or other gateway alert.

### Impact

Operators can miss failed scheduled work and may not discover the failure until they inspect cron state manually. The affected outer exception path also provides no delivery failure detail when the alert itself cannot be sent.

### Bug Cause

**Trigger:** `cron/scheduler.py:5352` / `run_one_job` / a normal exception escapes before `_deliver_result` runs.

**Causal chain:**
1. A provider or another run-pipeline operation raises an exception.
2. The outer handler records the failed run and execution, but previously skipped `_deliver_result`.
3. The configured alert is never attempted, while the persisted job state contains no delivery error.

**Why it is wrong:** The exception path bypassed the delivery contract used by ordinary unsuccessful results, silently separating failure bookkeeping from user notification.

**Working sibling / contrast:** Failures returned normally as `(False, output, "", error)` already pass through `_summarize_cron_failure_for_delivery` and `_deliver_result` before bookkeeping.

**Ruled out:** Target resolution and adapter send failures already return a delivery error that is persisted. They do not explain an error row with `last_delivery_error=null` and no send attempt.

### Fix

Track whether delivery has already been attempted. When a normal exception reaches the outer handler first, send the existing compact failure summary exactly once, persist any returned or raised delivery error, and record the execution delivery outcome. `KeyboardInterrupt`, `SystemExit`, and other non-`Exception` interruptions retain their existing non-delivery and re-raise semantics.

## Related Issue

Closes #86357

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `cron/scheduler.py` - deliver and record compact alerts from the outer normal-exception path without duplicating prior delivery attempts.
- `tests/cron/test_run_one_job.py` - cover successful fallback delivery and persisted fallback delivery failures.

## How to Test

1. Run a cron job whose model/provider call raises before the normal delivery path.
2. Confirm exactly one compact failure alert is attempted and the job records any delivery error.
3. Run the focused and related regression suites:

```bash
scripts/run_tests.sh tests/cron/test_run_one_job.py -q
scripts/run_tests.sh tests/cron/test_shutdown_interrupt.py tests/cron/test_execution_ledger.py tests/cron/test_scheduler.py -q
```

Verified locally: 5 focused tests passed and 104 related tests passed. Real-environment verification also observed exactly one compact alert through a connected gateway adapter and confirmed both successful and failed delivery bookkeeping.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repository test entry on the relevant suites and all affected tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Relevant documentation is unchanged because this corrects the existing cron failure-delivery contract
- [x] `cli-config.yaml.example` is N/A because no config keys changed
- [x] `CONTRIBUTING.md` and `AGENTS.md` are N/A because no architecture or workflow changed
- [x] Cross-platform impact was considered; the fix is platform-independent and adapter-neutral
- [x] Tool descriptions and schemas are N/A because no model tool contract changed
