### PR TITLE
fix(tui): emit Desktop session activation hooks

### DIFF
--- a/hermes_cli/lifecycle.py
+++ b/hermes_cli/lifecycle.py
@@ -19,6 +19,10 @@ def invoke_hook(hook_name: str, **kwargs: Any) -> List[Any]:
 
     from hermes_cli import plugins
 
+    # Session boundaries can precede agent construction, which is otherwise the
+    # first plugin-discovery consumer. Complete the profile-keyed, idempotent
+    # discovery sweep before dispatch so the first lifecycle event is not lost.
+    plugins.discover_plugins()
     return plugins.invoke_hook(hook_name, **kwargs)
 
 

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -210,6 +210,10 @@ VALID_HOOKS: Set[str] = {
     # docs/plugins/hook-taxonomy.md.
     "transform_api_error_classification",
     "on_session_start",
+    # A frontend attached to an already-live or newly resumed session. Unlike
+    # on_session_start, this describes UI focus/attachment rather than a new
+    # agent lifecycle.
+    "on_session_activate",
     "on_session_end",
     "on_session_finalize",
     "on_session_reset",

--- a/tests/hermes_cli/test_lifecycle.py
+++ b/tests/hermes_cli/test_lifecycle.py
@@ -22,6 +22,26 @@ def test_invoke_hook_notifies_builtin_observers_before_plugins(monkeypatch):
     assert [call[0] for call in calls] == ["builtin", "plugin"]
 
 
+def test_invoke_hook_discovers_plugins_before_first_dispatch(monkeypatch):
+    calls = []
+    monkeypatch.setattr(observability, "observe_lifecycle", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(
+        plugins,
+        "discover_plugins",
+        lambda: calls.append("discover"),
+    )
+    monkeypatch.setattr(
+        plugins,
+        "invoke_hook",
+        lambda _name, **_kwargs: calls.append("invoke") or ["ok"],
+    )
+
+    result = lifecycle.invoke_hook("on_session_activate", session_id="session-1")
+
+    assert result == ["ok"]
+    assert calls == ["discover", "invoke"]
+
+
 def test_finalize_session_closes_core_before_plugin_export(monkeypatch):
     calls = []
     manager = SimpleNamespace(

--- a/tests/test_model_tools.py
+++ b/tests/test_model_tools.py
@@ -126,10 +126,10 @@ class TestHandleFunctionCall:
         monkeypatch.setattr("hermes_cli.plugins.get_plugin_manager", lambda: manager)
         hook_calls = []
         monkeypatch.setattr(
-            "hermes_cli.plugins.invoke_hook",
+            "hermes_cli.lifecycle.invoke_hook",
             lambda hook_name, **kwargs: hook_calls.append((hook_name, kwargs)) or [],
         )
-        monkeypatch.setattr("hermes_cli.plugins.has_hook", lambda name: True)
+        monkeypatch.setattr("hermes_cli.lifecycle.has_hook", lambda name: True)
         monkeypatch.setattr("model_tools.registry.dispatch", fake_dispatch)
 
         result = json.loads(

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -13013,6 +13013,353 @@ def test_session_create_lazy_info_reports_desktop_contract(monkeypatch):
     server._sessions.pop(resp["result"]["session_id"], None)
 
 
+def test_session_create_notifies_lifecycle_plugins(monkeypatch, tmp_path):
+    """A new Desktop session must notify plugins in its selected profile scope."""
+    from hermes_cli import lifecycle
+    from hermes_constants import get_hermes_home_override
+
+    class _FakeWorker:
+        def __init__(self, key, model, profile_home=None):
+            self.key = key
+
+        def close(self):
+            return None
+
+    profile_home = tmp_path / "profiles" / "work"
+    calls = []
+    monkeypatch.setattr(server, "_SlashWorker", _FakeWorker)
+    monkeypatch.setattr(server, "_get_db", lambda: None)
+    monkeypatch.setattr(server, "_profile_home", lambda profile: profile_home)
+    monkeypatch.setattr(server, "_emit", lambda *a, **kw: None)
+    monkeypatch.setattr(server, "_new_session_key", lambda: "stored-create-hook")
+    monkeypatch.setattr(server, "_start_agent_build", lambda *a, **kw: None)
+    monkeypatch.setattr(
+        lifecycle,
+        "invoke_hook",
+        lambda hook_name, **kwargs: calls.append(
+            (get_hermes_home_override(), hook_name, kwargs)
+        ),
+    )
+
+    resp = server.handle_request(
+        {
+            "id": "create-hook",
+            "method": "session.create",
+            "params": {"cols": 80, "source": "desktop", "profile": "work"},
+        }
+    )
+    assert resp is not None
+    runtime_session_id = resp["result"]["session_id"]
+    try:
+        assert calls == [
+            (
+                str(profile_home),
+                "on_session_activate",
+                {
+                    "session_id": "stored-create-hook",
+                    "runtime_session_id": runtime_session_id,
+                    "platform": "desktop",
+                    "reason": "create",
+                    "running": False,
+                },
+            )
+        ]
+        assert get_hermes_home_override() is None
+    finally:
+        server._sessions.pop(runtime_session_id, None)
+
+
+def test_session_resume_notifies_lifecycle_plugins(monkeypatch, tmp_path):
+    """A cold Desktop resume must notify plugins in its selected profile scope."""
+    import hermes_state
+    from hermes_cli import lifecycle
+    from hermes_constants import get_hermes_home_override
+
+    target = "stored-resume-hook"
+
+    class _FakeDB:
+        def get_session(self, session_id):
+            return {"id": session_id}
+
+        def resolve_resume_session_id(self, session_id):
+            return session_id
+
+        def reopen_session(self, session_id):
+            assert session_id == target
+
+        def get_resume_conversations(self, session_id):
+            assert session_id == target
+            history = [{"role": "user", "content": "hello"}]
+            return history, history
+
+        def get_ancestor_display_prefix(self, session_id):
+            assert session_id == target
+            return []
+
+        def close(self):
+            return None
+
+    profile_home = tmp_path / "profiles" / "work"
+    other_profile_home = tmp_path / "profiles" / "personal"
+    other_runtime_id = "personal-runtime-collision"
+    server._sessions[other_runtime_id] = {
+        "agent": None,
+        "created_at": 123.0,
+        "history": [],
+        "history_lock": threading.RLock(),
+        "last_active": 123.0,
+        "profile_home": str(other_profile_home),
+        "running": False,
+        "session_key": target,
+        "source": "desktop",
+        "transport": server._stdio_transport,
+    }
+
+    calls = []
+    monkeypatch.setattr(server, "_profile_home", lambda profile: profile_home)
+    monkeypatch.setattr(
+        hermes_state,
+        "SessionDB",
+        lambda db_path=None: _FakeDB(),
+    )
+    monkeypatch.setattr(server, "_enable_gateway_prompts", lambda: None)
+    monkeypatch.setattr(server, "_schedule_agent_build", lambda *a, **kw: None)
+    monkeypatch.setattr(server, "_schedule_session_cap_enforcement", lambda: None)
+    monkeypatch.setattr(server, "_maybe_schedule_auto_continue", lambda *a: None)
+    monkeypatch.setattr(
+        lifecycle,
+        "invoke_hook",
+        lambda hook_name, **kwargs: calls.append(
+            (get_hermes_home_override(), hook_name, kwargs)
+        ),
+    )
+
+    resp = server.handle_request(
+        {
+            "id": "resume-hook",
+            "method": "session.resume",
+            "params": {
+                "session_id": target,
+                "source": "desktop",
+                "profile": "work",
+            },
+        }
+    )
+    assert resp is not None
+    assert "result" in resp, resp
+    runtime_session_id = resp["result"]["session_id"]
+    try:
+        assert runtime_session_id != other_runtime_id
+        assert calls == [
+            (
+                str(profile_home),
+                "on_session_activate",
+                {
+                    "session_id": target,
+                    "runtime_session_id": runtime_session_id,
+                    "platform": "desktop",
+                    "reason": "resume",
+                    "running": False,
+                },
+            )
+        ]
+        assert get_hermes_home_override() is None
+    finally:
+        server._sessions.pop(runtime_session_id, None)
+        server._sessions.pop(other_runtime_id, None)
+
+
+def test_session_resume_live_reuse_notifies_outside_resume_lock(monkeypatch, tmp_path):
+    """Plugin callbacks must not run while the global resume lock is held."""
+    import hermes_state
+    from hermes_cli import lifecycle
+
+    target = "stored-resume-lock-free-hook"
+    rotated_target = "rotated-resume-lock-free-hook"
+    runtime_session_id = "runtime-resume-lock-free-hook"
+    profile_home = tmp_path / "profiles" / "work"
+
+    class _FakeDB:
+        def get_session(self, session_id):
+            return {"id": session_id}
+
+        def resolve_resume_session_id(self, session_id):
+            return session_id
+
+        def close(self):
+            return None
+
+    class _LiveAgent:
+        session_id = target
+
+    live_agent = _LiveAgent()
+    live_session = {
+        "agent": live_agent,
+        "created_at": 123.0,
+        "history": [],
+        "history_lock": threading.RLock(),
+        "last_active": 123.0,
+        "profile_home": str(profile_home),
+        "running": False,
+        "session_key": target,
+        "source": "desktop",
+        "transport": server._stdio_transport,
+    }
+    server._sessions[runtime_session_id] = live_session
+    callback_lock_free = []
+    callback_session_ids = []
+
+    def _rotating_live_payload(sid, session, **kwargs):
+        assert sid == runtime_session_id
+        assert session is live_session
+        live_agent.session_id = rotated_target
+        return {"session_id": sid, "running": False}
+
+    def _record_lock_state(hook_name, **kwargs):
+        acquired = server._session_resume_lock.acquire(blocking=False)
+        callback_lock_free.append(acquired)
+        callback_session_ids.append(kwargs["session_id"])
+        if acquired:
+            server._session_resume_lock.release()
+
+    monkeypatch.setattr(server, "_profile_home", lambda profile: profile_home)
+    monkeypatch.setattr(
+        hermes_state,
+        "SessionDB",
+        lambda db_path=None: _FakeDB(),
+    )
+    monkeypatch.setattr(server, "_live_session_payload", _rotating_live_payload)
+    monkeypatch.setattr(lifecycle, "invoke_hook", _record_lock_state)
+
+    try:
+        resp = server.handle_request(
+            {
+                "id": "resume-lock-free-hook",
+                "method": "session.resume",
+                "params": {
+                    "session_id": target,
+                    "source": "desktop",
+                    "profile": "work",
+                },
+            }
+        )
+
+        assert resp is not None
+        assert "result" in resp, resp
+        assert resp["result"]["session_id"] == runtime_session_id
+        assert callback_lock_free == [True]
+        assert callback_session_ids == [rotated_target]
+    finally:
+        server._sessions.pop(runtime_session_id, None)
+
+
+def test_session_resume_eager_race_loser_notifies_outside_resume_lock(
+    monkeypatch, tmp_path
+):
+    """The eager-build race loser must notify only after releasing the resume lock."""
+    import hermes_state
+    from hermes_cli import lifecycle
+
+    target = "stored-eager-race-lock-free-hook"
+    rotated_target = "rotated-eager-race-lock-free-hook"
+    winner_sid = "runtime-eager-race-winner"
+    profile_home = tmp_path / "profiles" / "work"
+
+    class _FakeDB:
+        def get_session(self, session_id):
+            return {"id": session_id}
+
+        def resolve_resume_session_id(self, session_id):
+            return session_id
+
+        def reopen_session(self, session_id):
+            assert session_id == target
+
+        def get_resume_conversations(self, session_id):
+            history = [{"role": "user", "content": "hello"}]
+            return history, history
+
+        def get_ancestor_display_prefix(self, session_id):
+            return []
+
+        def close(self):
+            return None
+
+    class _BuiltAgent:
+        def close(self):
+            agent_closed.append(True)
+
+    callback_lock_free = []
+    callback_session_ids = []
+    agent_closed = []
+
+    class _LiveAgent:
+        session_id = target
+
+    live_agent = _LiveAgent()
+
+    def _make_agent(*args, **kwargs):
+        server._sessions[winner_sid] = {
+            "agent": live_agent,
+            "created_at": 123.0,
+            "history": [],
+            "history_lock": threading.RLock(),
+            "last_active": 123.0,
+            "profile_home": str(profile_home),
+            "running": False,
+            "session_key": target,
+            "source": "desktop",
+            "transport": server._stdio_transport,
+        }
+        return _BuiltAgent()
+
+    def _rotating_live_payload(sid, session, **kwargs):
+        assert sid == winner_sid
+        live_agent.session_id = rotated_target
+        return {"session_id": sid, "running": False}
+
+    def _record_lock_state(hook_name, **kwargs):
+        acquired = server._session_resume_lock.acquire(blocking=False)
+        callback_lock_free.append(acquired)
+        callback_session_ids.append(kwargs["session_id"])
+        if acquired:
+            server._session_resume_lock.release()
+
+    monkeypatch.setattr(server, "_profile_home", lambda profile: profile_home)
+    monkeypatch.setattr(
+        hermes_state,
+        "SessionDB",
+        lambda db_path=None: _FakeDB(),
+    )
+    monkeypatch.setattr(server, "_enable_gateway_prompts", lambda: None)
+    monkeypatch.setattr(server, "_make_agent", _make_agent)
+    monkeypatch.setattr(server, "_live_session_payload", _rotating_live_payload)
+    monkeypatch.setattr(lifecycle, "invoke_hook", _record_lock_state)
+
+    try:
+        resp = server.handle_request(
+            {
+                "id": "resume-eager-race-lock-free-hook",
+                "method": "session.resume",
+                "params": {
+                    "eager_build": True,
+                    "session_id": target,
+                    "source": "desktop",
+                    "profile": "work",
+                },
+            }
+        )
+
+        assert resp is not None
+        assert "result" in resp, resp
+        assert resp["result"]["session_id"] == winner_sid
+        assert agent_closed == [True]
+        assert callback_lock_free == [True]
+        assert callback_session_ids == [rotated_target]
+    finally:
+        server._sessions.pop(winner_sid, None)
+
+
 def test_session_activate_lazy_info_reports_desktop_contract():
     """Activating an already-live *lazy* session (agent not built yet) must
     still advertise desktop_contract. _live_session_payload falls back to
@@ -13044,6 +13391,184 @@ def test_session_activate_lazy_info_reports_desktop_contract():
         info = resp["result"]["info"]
         assert info["lazy"] is True
         assert info["desktop_contract"] == server.DESKTOP_BACKEND_CONTRACT
+    finally:
+        server._sessions.pop(sid, None)
+
+
+def test_session_activate_notifies_lifecycle_plugins(monkeypatch, tmp_path):
+    """Selecting a warm session must notify plugins in its profile scope."""
+    from agent.secret_scope import current_secret_scope
+    from hermes_cli import lifecycle
+    from hermes_cli.plugins import VALID_HOOKS
+    from hermes_constants import get_hermes_home_override
+
+    profile_home = tmp_path / "profiles" / "work"
+    profile_home.mkdir(parents=True)
+    (profile_home / ".env").write_text(
+        "HOOK_SECRET=profile-hook-secret\n", encoding="utf-8"
+    )
+    calls = []
+    monkeypatch.setattr(
+        lifecycle,
+        "has_hook",
+        lambda hook_name: hook_name == "on_session_activate",
+    )
+    monkeypatch.setattr(
+        lifecycle,
+        "invoke_hook",
+        lambda hook_name, **kwargs: calls.append(
+            (
+                get_hermes_home_override(),
+                dict(current_secret_scope() or {}),
+                hook_name,
+                kwargs,
+            )
+        ),
+    )
+
+    sid = "runtime-activate-hook"
+    server._sessions[sid] = {
+        "agent": None,
+        "created_at": 123.0,
+        "history": [],
+        "history_lock": threading.RLock(),
+        "last_active": 123.0,
+        "profile_home": str(profile_home),
+        "running": True,
+        "session_key": "stored-activate-hook",
+        "source": "desktop",
+        "transport": server._stdio_transport,
+    }
+    try:
+        resp = server.handle_request(
+            {
+                "id": "activate-hook",
+                "method": "session.activate",
+                "params": {"session_id": sid},
+            }
+        )
+
+        assert resp is not None
+        assert "result" in resp
+        assert "on_session_activate" in VALID_HOOKS
+        assert calls == [
+            (
+                str(profile_home),
+                {"HOOK_SECRET": "profile-hook-secret"},
+                "on_session_activate",
+                {
+                    "session_id": "stored-activate-hook",
+                    "runtime_session_id": sid,
+                    "platform": "desktop",
+                    "reason": "activate",
+                    "running": True,
+                },
+            )
+        ]
+        assert get_hermes_home_override() is None
+    finally:
+        server._sessions.pop(sid, None)
+
+
+def test_session_boundary_restores_profile_scope_after_hook_exception(
+    monkeypatch, tmp_path
+):
+    from agent.secret_scope import (
+        current_secret_scope,
+        reset_secret_scope,
+        set_secret_scope,
+    )
+    from hermes_cli import lifecycle
+    from hermes_constants import get_hermes_home_override
+
+    outer_home = tmp_path / "outer-home"
+    outer_home.mkdir()
+    profile_home = tmp_path / "profiles" / "mlperf"
+    profile_home.mkdir(parents=True)
+    (profile_home / ".env").write_text(
+        "HOOK_SECRET=profile-hook-secret\n", encoding="utf-8"
+    )
+
+    observed = {}
+
+    def failing_hook(*args, **kwargs):
+        observed["profile_home"] = get_hermes_home_override()
+        observed["secret_scope"] = dict(current_secret_scope() or {})
+        raise RuntimeError("plugin failed")
+
+    monkeypatch.setattr(lifecycle, "invoke_hook", failing_hook)
+    home_token = set_hermes_home_override(outer_home)
+    secret_token = set_secret_scope({"OUTER_SECRET": "still-active"})
+    try:
+        server._notify_session_boundary(
+            "on_session_activate",
+            "durable-session",
+            platform="desktop",
+            profile_home=profile_home,
+            reason="activate",
+            running=False,
+        )
+
+        assert observed == {
+            "profile_home": str(profile_home),
+            "secret_scope": {"HOOK_SECRET": "profile-hook-secret"},
+        }
+        assert get_hermes_home_override() == str(outer_home)
+        assert current_secret_scope() == {"OUTER_SECRET": "still-active"}
+    finally:
+        reset_secret_scope(secret_token)
+        reset_hermes_home_override(home_token)
+
+
+def test_session_activate_notifies_current_rotated_canonical_id(monkeypatch):
+    """Warm activation follows the agent's current durable ID after rotation."""
+    from types import SimpleNamespace
+
+    from hermes_cli import lifecycle
+
+    calls = []
+    monkeypatch.setattr(
+        server,
+        "_live_session_payload",
+        lambda *args, **kwargs: {"running": False},
+    )
+    monkeypatch.setattr(
+        lifecycle,
+        "invoke_hook",
+        lambda hook_name, **kwargs: calls.append((hook_name, kwargs)),
+    )
+
+    sid = "runtime-rotated-hook"
+    server._sessions[sid] = {
+        "agent": SimpleNamespace(session_id="stored-rotated-tip"),
+        "profile_home": None,
+        "running": False,
+        "session_key": "stored-stale-parent",
+        "source": "desktop",
+    }
+    try:
+        resp = server.handle_request(
+            {
+                "id": "activate-rotated-hook",
+                "method": "session.activate",
+                "params": {"session_id": sid},
+            }
+        )
+
+        assert resp is not None
+        assert "result" in resp
+        assert calls == [
+            (
+                "on_session_activate",
+                {
+                    "session_id": "stored-rotated-tip",
+                    "runtime_session_id": sid,
+                    "platform": "desktop",
+                    "reason": "activate",
+                    "running": False,
+                },
+            )
+        ]
     finally:
         server._sessions.pop(sid, None)
 

--- a/tests/tui_gateway/test_session_resume_db_ownership.py
+++ b/tests/tui_gateway/test_session_resume_db_ownership.py
@@ -98,7 +98,9 @@ def profile_dbs(monkeypatch, tmp_path):
     # The handler builds nothing on the paths under test; keep it hermetic and
     # off the real agent/secret/HERMES_HOME machinery.
     monkeypatch.setattr(server, "_enable_gateway_prompts", lambda: None)
-    monkeypatch.setattr(server, "_find_live_session_by_key", lambda _key: None)
+    monkeypatch.setattr(
+        server, "_find_live_session_by_key", lambda _key, **_kwargs: None
+    )
     monkeypatch.setattr(server, "_schedule_agent_build", lambda *a, **k: None)
     monkeypatch.setattr(server, "_schedule_session_cap_enforcement", lambda *a, **k: None)
     monkeypatch.setattr(server, "_maybe_schedule_auto_continue", lambda *a, **k: None)
@@ -159,7 +161,11 @@ def test_resume_closes_profile_db_on_live_session_fast_path(profile_dbs, monkeyp
         return db
 
     monkeypatch.setattr("hermes_state.SessionDB", _factory)
-    monkeypatch.setattr(server, "_find_live_session_by_key", lambda _key: ("live-sid", {}))
+    monkeypatch.setattr(
+        server,
+        "_find_live_session_by_key",
+        lambda _key, **_kwargs: ("live-sid", {}),
+    )
     monkeypatch.setattr(
         server,
         "_live_session_payload",

--- a/tui_gateway/methods_session.py
+++ b/tui_gateway/methods_session.py
@@ -124,6 +124,15 @@ def _(rid, params: dict) -> dict:
     # without requiring the user to submit a first prompt.
     _schedule_agent_build(sid)
     _schedule_session_cap_enforcement()  # trim detached idle sessions over the cap
+    _notify_session_boundary(
+        "on_session_activate",
+        key,
+        source,
+        runtime_session_id=sid,
+        reason="create",
+        running=False,
+        profile_home=profile_home,
+    )
 
     return _ok(
         rid,
@@ -421,6 +430,17 @@ def _(rid, params: dict) -> dict:
             profile_home
         )
 
+        def _notify_resume_activation(sid: str, payload: dict, session: dict) -> None:
+            _notify_session_boundary(
+                "on_session_activate",
+                _session_lookup_key(session, fallback=target),
+                session.get("source"),
+                runtime_session_id=sid,
+                reason="resume",
+                running=bool(payload.get("running")),
+                profile_home=profile_home,
+            )
+
         def _reuse_live_payload(sid: str, session: dict) -> dict:
             payload = _live_session_payload(
                 sid,
@@ -445,11 +465,16 @@ def _(rid, params: dict) -> dict:
                 payload["status"] = "streaming"
             return payload
 
-        # Fast path: if the session is already live, reuse it under the lock.
+        # Fast path: select the live session and snapshot its payload atomically,
+        # then invoke lifecycle observers after releasing the resume lock.
         with _session_resume_lock:
-            live = _find_live_session_by_key(target)
-            if live is not None:
-                return _ok(rid, _reuse_live_payload(*live))
+            live = _find_live_session_by_key(target, profile_home=profile_home)
+            payload = _reuse_live_payload(*live) if live is not None else None
+        if live is not None:
+            live_sid, live_session = live
+            assert payload is not None
+            _notify_resume_activation(live_sid, payload, live_session)
+            return _ok(rid, payload)
 
         # Lazy/watch resume: register the live session WITHOUT building an agent.
         # Used by the desktop's subagent windows — the child runs inside the
@@ -490,7 +515,10 @@ def _(rid, params: dict) -> dict:
                 lazy=True,
             )
             if (live := _claim_or_reuse_live(sid, target, record, lease)) is not None:
-                return _ok(rid, _reuse_live_payload(*live))
+                live_sid, live_session = live
+                payload = _reuse_live_payload(live_sid, live_session)
+                _notify_resume_activation(live_sid, payload, live_session)
+                return _ok(rid, payload)
             # A delegated child mid-run emits no session events of its own — report
             # its liveness from the relay registry so the window shows a busy turn.
             child_running = _child_run_active(target)
@@ -508,22 +536,21 @@ def _(rid, params: dict) -> dict:
                 logger.debug("child-watch display projection read failed", exc_info=True)
                 display_history = history
             messages = [] if omit_messages else _history_to_messages(display_history)
-            return _ok(
-                rid,
-                {
-                    "session_id": sid,
-                    "resumed": target,
-                    "message_count": len(display_history) if omit_messages else len(messages),
-                    "messages": messages,
-                    "messages_omitted": omit_messages,
-                    "info": _lazy_resume_info(cwd, profile=profile),
-                    "inflight": None,
-                    "running": child_running,
-                    "session_key": target,
-                    "started_at": record["created_at"],
-                    "status": "streaming" if child_running else "idle",
-                },
-            )
+            payload = {
+                "session_id": sid,
+                "resumed": target,
+                "message_count": len(display_history) if omit_messages else len(messages),
+                "messages": messages,
+                "messages_omitted": omit_messages,
+                "info": _lazy_resume_info(cwd, profile=profile),
+                "inflight": None,
+                "running": child_running,
+                "session_key": target,
+                "started_at": record["created_at"],
+                "status": "streaming" if child_running else "idle",
+            }
+            _notify_resume_activation(sid, payload, record)
+            return _ok(rid, payload)
 
         # Desktop can ask for a bounded acknowledgement and hydrate the display
         # transcript through the paginated REST endpoint. Register the runtime now,
@@ -654,7 +681,10 @@ def _(rid, params: dict) -> dict:
                 resume_runtime_overrides=overrides or None,
             )
             if (live := _claim_or_reuse_live(sid, target, record, lease)) is not None:
-                return _ok(rid, _reuse_live_payload(*live))
+                live_sid, live_session = live
+                payload = _reuse_live_payload(live_sid, live_session)
+                _notify_resume_activation(live_sid, payload, live_session)
+                return _ok(rid, payload)
 
             _schedule_agent_build(sid)
             _schedule_session_cap_enforcement()  # trim detached idle sessions over the cap
@@ -681,6 +711,7 @@ def _(rid, params: dict) -> dict:
             }
             if auto_continue is not None:
                 payload["auto_continue"] = auto_continue
+            _notify_resume_activation(sid, payload, record)
             return _ok(rid, payload)
 
         # Build the agent OUTSIDE the lock — _make_agent can block for seconds
@@ -754,16 +785,13 @@ def _(rid, params: dict) -> dict:
         # Double-checked locking: another concurrent resume may have created the
         # live session while we were building. Re-check under the lock; if it won,
         # discard our just-built agent and reuse theirs (no worker/poller wired yet).
-        with _session_resume_lock:
-            live = _find_live_session_by_key(target)
+        resume_lock_held = True
+        _session_resume_lock.acquire()
+        try:
+            live = _find_live_session_by_key(target, profile_home=profile_home)
             if live is not None:
-                try:
-                    if hasattr(agent, "close"):
-                        agent.close()
-                except Exception:
-                    pass
-                if lease is not None:
-                    lease.release()
+                # Snapshot the winner under the lock, then release before cleanup
+                # or invoking any external/plugin code.
                 other_sid, other_session = live
                 payload = _live_session_payload(
                     other_sid,
@@ -774,6 +802,16 @@ def _(rid, params: dict) -> dict:
                     omit_messages=omit_messages,
                 )
                 payload["resumed"] = target
+                _session_resume_lock.release()
+                resume_lock_held = False
+                try:
+                    if hasattr(agent, "close"):
+                        agent.close()
+                except Exception:
+                    pass
+                if lease is not None:
+                    lease.release()
+                _notify_resume_activation(other_sid, payload, other_session)
                 return _ok(rid, payload)
             try:
                 init_home_token = (
@@ -854,6 +892,9 @@ def _(rid, params: dict) -> dict:
                     lease.release()
                 return _err(rid, 5000, f"resume failed: {e}")
             session = _sessions.get(sid) or {}
+        finally:
+            if resume_lock_held:
+                _session_resume_lock.release()
     finally:
         # Every return that does NOT reach the transfer above abandons this
         # handle — session-not-found, both "resume failed" paths, the live-session
@@ -886,6 +927,7 @@ def _(rid, params: dict) -> dict:
     }
     if auto_continue is not None:
         payload["auto_continue"] = auto_continue
+    _notify_resume_activation(sid, payload, session)
     return _ok(rid, payload)
 
 
@@ -1040,16 +1082,23 @@ def _(rid, params: dict) -> dict:
         return err
     assert session is not None
 
-    return _ok(
-        rid,
-        _live_session_payload(
-            sid,
-            session,
-            touch=True,
-            transport=current_transport() or _stdio_transport,
-            omit_messages=is_truthy_value(params.get("omit_messages", False)),
-        ),
+    payload = _live_session_payload(
+        sid,
+        session,
+        touch=True,
+        transport=current_transport() or _stdio_transport,
+        omit_messages=is_truthy_value(params.get("omit_messages", False)),
     )
+    _notify_session_boundary(
+        "on_session_activate",
+        _session_lookup_key(session, fallback=sid),
+        session.get("source"),
+        runtime_session_id=sid,
+        reason="activate",
+        running=bool(payload.get("running")),
+        profile_home=session.get("profile_home"),
+    )
+    return _ok(rid, payload)
 
 
 @method("session.delete")

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -557,10 +557,21 @@ def _load_interim_assistant_messages() -> bool:
 
 
 def _notify_session_boundary(
-    event_type: str, session_id: str | None, platform: str | None = None
+    event_type: str,
+    session_id: str | None,
+    platform: str | None = None,
+    profile_home: str | Path | None = None,
+    **kwargs,
 ) -> None:
     """Fire session lifecycle hooks with CLI parity."""
+    home_token = None
+    secret_token = None
     try:
+        if profile_home is not None:
+            home_token = set_hermes_home_override(str(profile_home))
+            secret_token = set_secret_scope(
+                build_profile_secret_scope(Path(str(profile_home)))
+            )
         from hermes_cli.lifecycle import finalize_session, invoke_hook
 
         if event_type == "on_session_finalize":
@@ -573,9 +584,15 @@ def _notify_session_boundary(
                 event_type,
                 session_id=session_id,
                 platform=_resolve_agent_platform(platform),
+                **kwargs,
             )
     except Exception:
         pass
+    finally:
+        if secret_token is not None:
+            reset_secret_scope(secret_token)
+        if home_token is not None:
+            reset_hermes_home_override(home_token)
 
 
 def _claim_active_session_slot(
@@ -8439,7 +8456,10 @@ def _claim_or_reuse_live(
     resume lock, or — if a concurrent resume already won — release ``lease`` and
     return the winner for the caller to reuse."""
     with _session_resume_lock:
-        live = _find_live_session_by_key(session_key)
+        live = _find_live_session_by_key(
+            session_key,
+            profile_home=record.get("profile_home"),
+        )
         if live is not None:
             if lease is not None:
                 lease.release()
@@ -8613,9 +8633,32 @@ def _session_lookup_key(session: dict, *, fallback: str = "") -> str:
     )
 
 
-def _find_live_session_by_key(session_key: str) -> tuple[str, dict] | None:
+_PROFILE_HOME_UNFILTERED = object()
+
+
+def _profile_home_identity(profile_home) -> str | None:
+    if profile_home is None or not str(profile_home).strip():
+        return None
+    return str(Path(str(profile_home)).expanduser().resolve())
+
+
+def _find_live_session_by_key(
+    session_key: str,
+    *,
+    profile_home=_PROFILE_HOME_UNFILTERED,
+) -> tuple[str, dict] | None:
+    requested_profile = (
+        _profile_home_identity(profile_home)
+        if profile_home is not _PROFILE_HOME_UNFILTERED
+        else _PROFILE_HOME_UNFILTERED
+    )
     for sid, session in list(_sessions.items()):
         if session.get("_finalized"):
+            continue
+        if (
+            requested_profile is not _PROFILE_HOME_UNFILTERED
+            and _profile_home_identity(session.get("profile_home")) != requested_profile
+        ):
             continue
         if _session_lookup_key(session, fallback=sid) == session_key:
             return sid, session


### PR DESCRIPTION
## What does this PR do?

Adds one generic observer hook, `on_session_activate`, for Desktop session attachment boundaries that were previously invisible to plugins.

Desktop can enter a selected session through three different RPC paths:

- `session.create` for a new draft
- `session.activate` for an already-live session
- `session.resume` for a persisted or reconnecting session

Before this change, none of those paths emitted a lifecycle event describing the session the user had selected. Plugins that maintain per-session UI or observability state therefore remained attached to the prior session until a model/tool hook happened later.

The hook carries only bounded session metadata: canonical `session_id`, `runtime_session_id`, normalized `platform`, `reason` (`create`, `activate`, or `resume`), and `running`.

The change also closes a startup race found during live verification. Session creation can emit the new boundary before deferred agent construction performs plugin discovery. `hermes_cli.lifecycle.invoke_hook()` now completes the existing profile-keyed, idempotent discovery sweep before dispatch, so the first lifecycle event is not silently dropped. Subsequent calls remain cache hits. Gateway notification temporarily applies both the selected profile's `HERMES_HOME` context and profile secret scope, then restores both in `finally`, including when discovery or a callback fails.

A concrete standalone consumer is SidePulse PR [inteliwear/sidepulse#13](https://github.com/inteliwear/sidepulse/pull/13), which reasserts the selected session's observable state without adding product-specific behavior to Hermes core.

## Related Issue

No Hermes issue currently tracks this missing Desktop lifecycle boundary. This PR was reproduced against a concrete standalone plugin consumer and live-tested on macOS.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/plugins.py` — register `on_session_activate` as a valid lifecycle hook.
- `hermes_cli/lifecycle.py` — complete profile-keyed plugin discovery before first lifecycle dispatch.
- `tui_gateway/methods_session.py` — emit activation from create, warm activate, and every cold/fast resume path.
- `tui_gateway/server.py` — expose the lifecycle dispatch helper and scope dispatch to the selected profile.
- `tests/hermes_cli/test_lifecycle.py` — prove discovery precedes first dispatch.
- `tests/test_tui_gateway_server.py` — cover create, warm activate, every resume branch, normal and exception-path profile restoration, same-ID cross-profile isolation, post-rotation canonical identity, and callback dispatch outside the resume lock.

## How to Test

1. Register an observer plugin for `on_session_activate`.
2. Create a Desktop session, switch to an already-live session, and resume a persisted session.
3. Confirm each path emits the selected canonical/runtime identities, `platform=desktop`, the correct reason, and the actual `running` flag.
4. Start from a fresh plugin manager and confirm the first create event is delivered rather than raced by deferred agent construction.
5. Resume colliding stored IDs from two profiles and confirm the selected profile never reuses the other profile's live runtime.
6. Confirm live-reuse and eager-race-loser callbacks execute after `_session_resume_lock` is released.
7. Run:

```bash
scripts/run_tests.sh tests/hermes_cli/test_lifecycle.py tests/test_tui_gateway_server.py -q
uv run ruff check hermes_cli/lifecycle.py hermes_cli/plugins.py tests/hermes_cli/test_lifecycle.py tests/test_tui_gateway_server.py tui_gateway/methods_session.py tui_gateway/server.py
```

Affected suite result against frozen upstream base `f92accd05`: **566 passed**. Ruff, `py_compile`, static security scan, conflict-marker scan, and `git diff --check` also pass.

Independent read-only exact-byte review approved commit `bd37151af` / diff digest `a9dbcf50d14ed0d59a1a6a2517656158be721a78c03dbf79fb7ba312d4ec6bc7` with no logic, security, or scope findings.

Live macOS Desktop verification with the standalone consumer produced explicit `SessionActivate` events for new-session creation, warm switching, and cold resume. Inactive sessions reported idle; running/waiting recovery is covered by the consumer's tests.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — the full repository gate was attempted but encountered unrelated platform failures in untouched modules; all 566 affected tests pass through the repository's clean-environment harness
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 27.0, Apple silicon

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A; the hook payload is documented at its dispatch helper and tests
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A; no config keys
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A; existing lifecycle/plugin architecture
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A; no model tool changes

## Screenshots / Logs

No UI change. The externally observable result is the lifecycle payload asserted by the automated tests and live consumer event log.
