### PR TITLE
feat(gateway): parse multi-account Telegram config (#8287, 1/6)

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -731,6 +731,26 @@ class PlatformConfig:
         if _typing_text is None:
             _typing_text = extra.get("typing_status_text")
 
+        # Multi-account blocks (#8287): ``accounts:`` may arrive top-level
+        # (``platforms.telegram.accounts`` in YAML) or bridged into extra by
+        # the shared-key loop. Normalize account names (lowercased) into
+        # ``extra["accounts"]`` so the adapter registry has a single read
+        # path. Tokens are secrets and load from ``<PLATFORM>_BOT_TOKEN_<ACCOUNT>``
+        # env vars in ``_apply_env_overrides`` — a ``token`` key inside a YAML
+        # account block is honored for parity but ``.env`` is the supported
+        # home for credentials.
+        _accounts = data.get("accounts")
+        if _accounts is None:
+            _accounts = extra.get("accounts")
+        if isinstance(_accounts, dict):
+            _norm_accounts: Dict[str, Any] = {}
+            for _acct_name, _acct_block in _accounts.items():
+                _acct_key = str(_acct_name).strip().lower()
+                if _acct_key:
+                    _norm_accounts[_acct_key] = _coerce_dict(_acct_block)
+            if _norm_accounts:
+                extra["accounts"] = _norm_accounts
+
         channel_overrides: Dict[str, ChannelOverride] = {}
         raw_overrides = data.get("channel_overrides") or {}
         if isinstance(raw_overrides, dict):
@@ -1911,6 +1931,32 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
     if telegram_token:
         telegram_config = _enable_from_env(Platform.TELEGRAM)
         telegram_config.token = telegram_token
+
+    # Multi-account tokens (#8287): ``TELEGRAM_BOT_TOKEN_<ACCOUNT>`` declares
+    # an additional bot account named ``<account>`` (lowercased). The
+    # unsuffixed ``TELEGRAM_BOT_TOKEN`` remains the default account, so
+    # single-bot setups are byte-identical to before. Candidate names are
+    # enumerated from the process env (dotenv loads ``.env`` there) and each
+    # value is read back through ``getenv`` so profile-scoped secrets win
+    # when a scope is active. Behavioral per-account settings (allowlists,
+    # home channels, display names) belong in ``platforms.telegram.accounts``
+    # in config.yaml — env vars carry only the credential.
+    _tg_account_prefix = "TELEGRAM_BOT_TOKEN_"
+    for _env_name in sorted(os.environ):
+        if not _env_name.startswith(_tg_account_prefix):
+            continue
+        _acct_name = _env_name[len(_tg_account_prefix):].strip().lower()
+        _acct_token = getenv(_env_name)
+        if not _acct_name or not _acct_token:
+            continue
+        _tg_cfg = _enable_from_env(Platform.TELEGRAM)
+        _tg_accounts = _tg_cfg.extra.setdefault("accounts", {})
+        if not isinstance(_tg_accounts, dict):
+            _tg_accounts = {}
+            _tg_cfg.extra["accounts"] = _tg_accounts
+        _acct_block = _tg_accounts.setdefault(_acct_name, {})
+        if isinstance(_acct_block, dict):
+            _acct_block["token"] = _acct_token
     
     # Reply threading mode for Telegram (off/first/all)
     telegram_reply_mode = getenv("TELEGRAM_REPLY_TO_MODE", "").lower()

--- a/tests/gateway/test_telegram_multi_account_config.py
+++ b/tests/gateway/test_telegram_multi_account_config.py
@@ -1,0 +1,122 @@
+"""Multi-account Telegram configuration parsing — #8287.
+
+One gateway, N Telegram bot accounts: tokens arrive as
+``TELEGRAM_BOT_TOKEN_<ACCOUNT>`` env vars (secrets stay in .env), behavioral
+settings as ``platforms.telegram.accounts.<name>`` in config.yaml. The
+unsuffixed ``TELEGRAM_BOT_TOKEN`` remains the default account, so single-bot
+configurations parse byte-identically to before.
+"""
+
+import pytest
+
+from gateway.config import Platform, PlatformConfig, load_gateway_config
+
+
+def test_single_bot_config_has_no_accounts_key(monkeypatch, tmp_path):
+    """Backward compatibility: an unsuffixed token must not grow an
+    accounts block — existing single-bot setups stay byte-identical."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "123:default-token")
+
+    config = load_gateway_config()
+    tg = config.platforms[Platform.TELEGRAM]
+    assert tg.token == "123:default-token"
+    assert "accounts" not in tg.extra
+
+
+def test_suffixed_env_tokens_declare_accounts(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "123:default-token")
+    monkeypatch.setenv("TELEGRAM_BOT_TOKEN_SUPPORT", "456:support-token")
+    monkeypatch.setenv("TELEGRAM_BOT_TOKEN_SALES", "789:sales-token")
+
+    config = load_gateway_config()
+    tg = config.platforms[Platform.TELEGRAM]
+
+    # Default account untouched.
+    assert tg.token == "123:default-token"
+    # Suffix names are lowercased account names carrying only the credential.
+    accounts = tg.extra["accounts"]
+    assert accounts["support"]["token"] == "456:support-token"
+    assert accounts["sales"]["token"] == "789:sales-token"
+
+
+def test_suffixed_token_alone_enables_platform(monkeypatch, tmp_path):
+    """A gateway configured with only account tokens (no default) still
+    enables Telegram — the registry decides which accounts to start."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.delenv("TELEGRAM_BOT_TOKEN", raising=False)
+    monkeypatch.setenv("TELEGRAM_BOT_TOKEN_SUPPORT", "456:support-token")
+
+    config = load_gateway_config()
+    tg = config.platforms[Platform.TELEGRAM]
+    assert tg.enabled
+    assert tg.token is None
+    assert tg.extra["accounts"]["support"]["token"] == "456:support-token"
+
+
+def test_empty_suffix_or_value_is_ignored(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "123:default-token")
+    monkeypatch.setenv("TELEGRAM_BOT_TOKEN_", "999:no-name")
+    monkeypatch.setenv("TELEGRAM_BOT_TOKEN_EMPTY", "")
+
+    config = load_gateway_config()
+    tg = config.platforms[Platform.TELEGRAM]
+    assert "accounts" not in tg.extra
+
+
+def test_yaml_accounts_block_parses_and_normalizes_names():
+    cfg = PlatformConfig.from_dict({
+        "enabled": True,
+        "accounts": {
+            "Support": {"display_name": "Support Bot", "allowed_users": [1, 2]},
+            "  SALES ": {"home_channel": {"chat_id": "-100123"}},
+        },
+    })
+    accounts = cfg.extra["accounts"]
+    assert set(accounts) == {"support", "sales"}
+    assert accounts["support"]["display_name"] == "Support Bot"
+    assert accounts["support"]["allowed_users"] == [1, 2]
+
+
+def test_yaml_accounts_survive_via_extra_bridge():
+    """The shared-key loop can bridge accounts into extra — both routes
+    normalize identically (the gateway_restart_notification pattern)."""
+    cfg = PlatformConfig.from_dict({
+        "enabled": True,
+        "extra": {"accounts": {"Support": {"display_name": "S"}}},
+    })
+    assert cfg.extra["accounts"]["support"]["display_name"] == "S"
+
+
+def test_env_token_merges_into_yaml_account_block(monkeypatch, tmp_path):
+    """config.yaml declares the behavioral block; .env supplies the token.
+    The two merge on the same account name."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    (tmp_path / "config.yaml").write_text(
+        "gateway:\n"
+        "  platforms:\n"
+        "    telegram:\n"
+        "      enabled: true\n"
+        "      accounts:\n"
+        "        support:\n"
+        "          display_name: Support Bot\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("TELEGRAM_BOT_TOKEN_SUPPORT", "456:support-token")
+
+    config = load_gateway_config()
+    tg = config.platforms[Platform.TELEGRAM]
+    support = tg.extra["accounts"]["support"]
+    assert support["token"] == "456:support-token"
+    assert support.get("display_name") == "Support Bot"
+
+
+def test_accounts_round_trip_through_to_dict():
+    cfg = PlatformConfig.from_dict({
+        "enabled": True,
+        "accounts": {"support": {"display_name": "S"}},
+    })
+    rebuilt = PlatformConfig.from_dict(cfg.to_dict())
+    assert rebuilt.extra["accounts"]["support"]["display_name"] == "S"


### PR DESCRIPTION
First slice of #67455, which triage recorded as the `best fix` for #8287 (with #10455 superseded) but which has sat at 1,750 lines across 17 files for 26 days. Splitting it into independently reviewable pieces so each can be judged on its own.

**This PR: config parsing only. 46 lines of `gateway/config.py` + 122 lines of tests.**

## What it does

Normalizes multi-account declarations into a single read path, `platforms.telegram.extra["accounts"]`, from two sources:

- **`platforms.telegram.accounts` in config.yaml** — behavioral settings per account (display name, home channel). Account names are lowercased; the block may arrive top-level or bridged into `extra` by the shared-key loop, so both are normalized to one shape.
- **`TELEGRAM_BOT_TOKEN_<ACCOUNT>` env vars** — the credential, read via `getenv` so profile-scoped secrets win when a scope is active.

The unsuffixed `TELEGRAM_BOT_TOKEN` remains the default account, so **single-bot setups are byte-identical to before**.

Credentials stay in `.env` and behavioral settings stay in config.yaml. A `token` key inside a YAML account block is honored for parity, but `.env` is the supported home.

## Being upfront: this slice is inert on its own

Nothing reads `extra["accounts"]` yet — that lands in 2/6. I'd rather say so than have a reviewer discover it. The alternative was one 1,750-line PR, which is what stalled.

Planned sequence, each its own PR:

| | Slice | Approx |
|---|---|---|
| **1/6** | **config parsing (this PR)** | **168 L** |
| 2/6 | per-account session identity | ~200 L |
| 3/6 | account-aware adapter registry + inbound stamping | ~440 L |
| 4/6 | per-account delivery routing + reconnect recovery | ~410 L |
| 5/6 | per-account `send_message` routing | ~320 L |
| 6/6 | cron account targets, home broadcasts, setup UX | ~180 L |

If you'd rather see a different cut — or would rather I keep it as the single #67455 — say so and I'll re-slice. #67455 stays open until this sequence supersedes it.

## Tests

`tests/gateway/test_telegram_multi_account_config.py` — 8 tests: YAML and env sources, name normalization/lowercasing, the top-level-vs-`extra` bridge, token precedence, and that a single-bot config is unchanged.

Verified against current main with the project venv. Full `tests/gateway/` collection-error set is byte-identical to pristine `upstream/main` (pre-existing optional-dep gaps on my Windows box, unrelated to this change).
