### PR TITLE
feat(discord): attachment routing and preflight

### DIFF
--- a/contributors/emails/andrexibiza@gmail.com
+++ b/contributors/emails/andrexibiza@gmail.com
@@ -1,0 +1,2 @@
+andrexibiza
+# Discord omniscience M6

--- a/plugins/platforms/discord/attachment_io.py
+++ b/plugins/platforms/discord/attachment_io.py
@@ -1,0 +1,120 @@
+"""Discord attachment routing, preflight, and bounded-read contracts (feature M6).
+
+Pure logic — no network I/O. Every function validates its inputs and raises
+:class:`AttachmentError` (a :class:`ValueError` subclass) on contract
+violations.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+__all__ = [
+    "AttachmentMeta",
+    "AttachmentError",
+    "THREAD_TARGETS",
+    "route_attachment",
+    "preflight_attachment",
+    "bounded_read_request",
+]
+
+
+class AttachmentError(ValueError):
+    """Raised when an attachment routing/preflight/bounded-read contract is violated."""
+
+
+@dataclass(frozen=True)
+class AttachmentMeta:
+    """Metadata describing a Discord message attachment."""
+
+    url: str
+    size_bytes: Optional[int] = None
+    content_type: Optional[str] = None
+    filename: Optional[str] = None
+
+
+#: Target kinds whose attachments are delivered into a thread context.
+THREAD_TARGETS = frozenset({"text", "file", "image", "video", "document", "voice"})
+
+_SNOWFLAKE_MAX = 2**63 - 1
+
+
+def _is_snowflake(value: object) -> bool:
+    """Return True if *value* looks like a Discord snowflake (int or digit string)."""
+    if isinstance(value, bool):
+        return False
+    if isinstance(value, int):
+        return 0 <= value <= _SNOWFLAKE_MAX
+    if isinstance(value, str):
+        return value.isdigit() and 0 <= int(value) <= _SNOWFLAKE_MAX
+    return False
+
+
+def route_attachment(
+    meta: AttachmentMeta,
+    *,
+    thread_id: Optional[str] = None,
+    parent_channel_id: Optional[str] = None,
+    target: str = "text",
+) -> str:
+    """Decide which Discord channel/thread an attachment should be routed to.
+
+    Thread-related targets (``text``/``file``/``image``/``video``/``document``/
+    ``voice``) keep the attachment in the thread whenever a ``thread_id`` is
+    available; any other target falls back to ``parent_channel_id``.
+
+    Raises :class:`AttachmentError` when both ``thread_id`` and
+    ``parent_channel_id`` are None, or when a provided id is not a snowflake.
+    """
+    # ``meta`` is part of the contract signature (callers pass what they have);
+    # routing decisions depend on the target kind and the channel context.
+    if thread_id is not None and not _is_snowflake(thread_id):
+        raise AttachmentError(f"thread_id is not a valid snowflake: {thread_id!r}")
+    if parent_channel_id is not None and not _is_snowflake(parent_channel_id):
+        raise AttachmentError(
+            f"parent_channel_id is not a valid snowflake: {parent_channel_id!r}"
+        )
+    if thread_id is None and parent_channel_id is None:
+        raise AttachmentError(
+            "cannot route attachment: neither thread_id nor parent_channel_id given"
+        )
+    if target in THREAD_TARGETS and thread_id is not None:
+        return thread_id
+    return parent_channel_id  # type: ignore[return-value]  # at least one is set
+
+
+def preflight_attachment(
+    meta: AttachmentMeta,
+    *,
+    max_bytes: int = 8 * 1024 * 1024,
+) -> None:
+    """Reject attachments whose declared size exceeds *max_bytes*.
+
+    Attachments with an unknown size (``size_bytes is None``) always pass.
+    """
+    if meta.size_bytes is not None and meta.size_bytes > max_bytes:
+        raise AttachmentError(
+            f"attachment {meta.url!r} is {meta.size_bytes} bytes, "
+            f"exceeds limit of {max_bytes} bytes"
+        )
+
+
+def bounded_read_request(
+    meta: AttachmentMeta,
+    *,
+    limit_bytes: int = 4 * 1024 * 1024,
+) -> dict:
+    """Build a bounded read request for an attachment URL.
+
+    The returned ``limit_bytes`` never exceeds *limit_bytes*; when the
+    declared size is known and smaller, the smaller value is used so the
+    downloader can stop early.
+
+    Raises :class:`AttachmentError` if the URL is not http(s).
+    """
+    url = meta.url
+    if not (url.startswith("http://") or url.startswith("https://")):
+        raise AttachmentError(f"attachment URL is not http(s): {url!r}")
+    read_limit = min(meta.size_bytes or limit_bytes, limit_bytes)
+    return {"url": url, "limit_bytes": read_limit}

--- a/tests/tools/test_discord_attachment_io.py
+++ b/tests/tools/test_discord_attachment_io.py
@@ -1,0 +1,133 @@
+"""Tests for Discord attachment routing/preflight/bounded-read contracts (feature M6)."""
+
+import pytest
+
+from plugins.platforms.discord.attachment_io import (
+    THREAD_TARGETS,
+    AttachmentError,
+    AttachmentMeta,
+    bounded_read_request,
+    preflight_attachment,
+    route_attachment,
+)
+
+THREAD = "112233445566778899"
+PARENT = "998877665544332211"
+CDN_URL = "https://cdn.discordapp.com/attachments/112233445566778899/1234/image.png"
+
+
+def meta(
+    url=CDN_URL,
+    size=None,
+    ctype=None,
+    fname=None,
+):
+    return AttachmentMeta(url=url, size_bytes=size, content_type=ctype, filename=fname)
+
+
+class TestRouteAttachment:
+    @pytest.mark.parametrize("target", sorted(THREAD_TARGETS))
+    def test_thread_target_preserves_thread_id(self, target):
+        assert (
+            route_attachment(
+                meta(), thread_id=THREAD, parent_channel_id=PARENT, target=target
+            )
+            == THREAD
+        )
+
+    @pytest.mark.parametrize("target", ["channel", "dm", "guild", ""])
+    def test_non_thread_target_routes_to_parent(self, target):
+        assert (
+            route_attachment(
+                meta(), thread_id=THREAD, parent_channel_id=PARENT, target=target
+            )
+            == PARENT
+        )
+
+    def test_thread_target_without_thread_id_falls_back_to_parent(self):
+        assert (
+            route_attachment(
+                meta(), thread_id=None, parent_channel_id=PARENT, target="image"
+            )
+            == PARENT
+        )
+
+    def test_thread_id_may_be_int_snowflake(self):
+        assert (
+            route_attachment(meta(), thread_id=12345, parent_channel_id=PARENT, target="text")
+            == 12345
+        )
+
+    def test_both_none_raises(self):
+        with pytest.raises(AttachmentError):
+            route_attachment(meta(), thread_id=None, parent_channel_id=None)
+
+    def test_both_none_raises_even_for_non_thread_target(self):
+        with pytest.raises(AttachmentError):
+            route_attachment(meta(), thread_id=None, parent_channel_id=None, target="channel")
+
+    def test_invalid_thread_id_raises(self):
+        with pytest.raises(AttachmentError):
+            route_attachment(meta(), thread_id="not-a-snowflake", parent_channel_id=PARENT)
+
+    def test_invalid_parent_id_raises(self):
+        with pytest.raises(AttachmentError):
+            route_attachment(meta(), thread_id=THREAD, parent_channel_id="-1")
+
+    def test_error_is_value_error_subclass(self):
+        with pytest.raises(ValueError):
+            route_attachment(meta(), thread_id=None, parent_channel_id=None)
+
+
+class TestPreflightAttachment:
+    def test_under_limit_ok(self):
+        assert preflight_attachment(meta(size=1024), max_bytes=2048) is None
+
+    def test_at_limit_ok(self):
+        assert preflight_attachment(meta(size=2048), max_bytes=2048) is None
+
+    def test_over_limit_raises(self):
+        with pytest.raises(AttachmentError):
+            preflight_attachment(meta(size=2049), max_bytes=2048)
+
+    def test_default_limit_is_8mb(self):
+        assert preflight_attachment(meta(size=8 * 1024 * 1024)) is None
+        with pytest.raises(AttachmentError):
+            preflight_attachment(meta(size=8 * 1024 * 1024 + 1))
+
+    def test_unknown_size_passes(self):
+        assert preflight_attachment(meta(size=None)) is None
+
+
+class TestBoundedReadRequest:
+    def test_caps_to_limit_when_size_unknown(self):
+        assert bounded_read_request(meta(size=None)) == {
+            "url": CDN_URL,
+            "limit_bytes": 4 * 1024 * 1024,
+        }
+
+    def test_caps_when_size_exceeds_limit(self):
+        req = bounded_read_request(meta(size=10 * 1024 * 1024), limit_bytes=4 * 1024 * 1024)
+        assert req["limit_bytes"] == 4 * 1024 * 1024
+
+    def test_smaller_declared_size_wins(self):
+        req = bounded_read_request(meta(size=1024), limit_bytes=4 * 1024 * 1024)
+        assert req["limit_bytes"] == 1024
+
+    def test_https_url_ok(self):
+        req = bounded_read_request(meta(url="https://cdn.example.com/x.png"))
+        assert req["url"] == "https://cdn.example.com/x.png"
+
+    @pytest.mark.parametrize(
+        "bad_url",
+        [
+            "ftp://cdn.example.com/x.png",
+            "file:///etc/passwd",
+            "not-a-url",
+            "",
+            "HTTP://cdn.example.com/x.png",  # scheme must be lowercase per contract
+        ],
+    )
+    def test_non_http_url_raises(self, bad_url):
+        with pytest.raises(AttachmentError):
+            bounded_read_request(meta(url=bad_url))


### PR DESCRIPTION
## Summary

Attachment routing, preflight, and bounded reads for Discord — thread-target retention, size preflight, and capped URL reads.

## Motivation

Fixes #86498 · Part of #79564

## Changes

- New module `plugins/platforms/discord/attachment_io.py` implementing attachment routing, preflight size bounds, and bounded-read caps.

## Test Plan

- [x] Unit tests pass (`pytest`)
- [x] Focused regression tests: `tests/tools/test_discord_attachment_io.py` — 31 passed
- [ ] Manual testing of new functionality
- [x] No regressions in existing behavior

## Notes for Reviewers

- New module only — no god-file growth; `plugins/platforms/discord/adapter.py` untouched.