### PR TITLE
feat(discord): streaming-delivery state machine

### DIFF
--- a/contributors/emails/andrexibiza@gmail.com
+++ b/contributors/emails/andrexibiza@gmail.com
@@ -1,0 +1,2 @@
+andrexibiza
+# Discord omniscience M7

--- a/plugins/platforms/discord/delivery_state.py
+++ b/plugins/platforms/discord/delivery_state.py
@@ -1,0 +1,130 @@
+"""Discord streaming-delivery state machine (feature M7).
+
+Pure state machine -- no network I/O. Guards the lifecycle of streaming a
+Discord message: typing indicator -> streaming chunks -> done/failed.
+
+States:
+    IDLE      -- no delivery session in progress
+    TYPING    -- delivery began, typing indicator active
+    STREAMING -- chunks may be appended
+    DONE      -- delivery finished (terminal, not re-entered)
+    FAILED    -- delivery aborted (terminal, not re-entered)
+
+Invariants:
+    * ``finish()`` may only be called once per session (duplicate final
+      response guard): a second call raises :class:`DeliveryStateError`.
+    * Empty chunks are no-ops and never drop previously appended content.
+    * Finishing with empty content is allowed only when no non-empty chunk
+      was appended; otherwise the stream transitions to DONE with its
+      content intact (never silently dropped).
+"""
+
+from __future__ import annotations
+
+
+class DeliveryStateError(ValueError):
+    """Raised when a delivery-state transition is invalid."""
+
+
+class DeliveryState:
+    """State machine for a single Discord streaming-delivery session."""
+
+    IDLE = "IDLE"
+    TYPING = "TYPING"
+    STREAMING = "STREAMING"
+    DONE = "DONE"
+    FAILED = "FAILED"
+
+    # States in which a delivery session is considered active.
+    _ACTIVE = frozenset((TYPING, STREAMING))
+
+    def __init__(self) -> None:
+        self._state = self.IDLE
+        self._chunks: list[str] = []
+        self._error: object | None = None
+
+    # ------------------------------------------------------------------
+    # Transitions
+    # ------------------------------------------------------------------
+
+    def begin(self) -> str:
+        """IDLE -> TYPING. Start a delivery session."""
+        if self._state is not self.IDLE:
+            raise DeliveryStateError(
+                f"begin() requires IDLE state, got {self._state!r}"
+            )
+        self._state = self.TYPING
+        return self._state
+
+    def start_stream(self) -> str:
+        """TYPING -> STREAMING. Chunks may now be appended."""
+        if self._state is not self.TYPING:
+            raise DeliveryStateError(
+                f"start_stream() requires TYPING state, got {self._state!r}"
+            )
+        self._state = self.STREAMING
+        return self._state
+
+    def append(self, chunk: str) -> str:
+        """STREAMING -> STREAMING. Append a chunk; empty chunks are no-ops."""
+        if self._state is not self.STREAMING:
+            raise DeliveryStateError(
+                f"append() requires STREAMING state, got {self._state!r}"
+            )
+        if chunk is None:
+            raise DeliveryStateError("append() requires a str chunk, got None")
+        chunk = str(chunk)
+        if chunk:
+            self._chunks.append(chunk)
+        return self._state
+
+    def finish(self) -> str:
+        """STREAMING -> DONE. May be called only once per session."""
+        if self._state is not self.STREAMING:
+            raise DeliveryStateError(
+                f"finish() requires STREAMING state, got {self._state!r} "
+                "(duplicate final-response guard)"
+            )
+        self._state = self.DONE
+        return self._state
+
+    def fail(self, err: object | None = None) -> str:
+        """Any active state -> FAILED. Aborts the delivery session."""
+        if self._state not in self._ACTIVE:
+            raise DeliveryStateError(
+                f"fail() requires an active state (TYPING/STREAMING), "
+                f"got {self._state!r}"
+            )
+        self._state = self.FAILED
+        self._error = err
+        return self._state
+
+    def reset(self) -> str:
+        """Any state -> IDLE. Clears all session state."""
+        self._state = self.IDLE
+        self._chunks = []
+        self._error = None
+        return self._state
+
+    # ------------------------------------------------------------------
+    # Observers
+    # ------------------------------------------------------------------
+
+    @property
+    def state(self) -> str:
+        return self._state
+
+    @property
+    def delivered_chunks(self) -> int:
+        """Number of non-empty chunks appended in this session."""
+        return len(self._chunks)
+
+    @property
+    def has_content(self) -> bool:
+        """True if any non-empty chunk was appended."""
+        return bool(self._chunks)
+
+    @property
+    def error(self) -> object | None:
+        """Error recorded by the most recent ``fail()`` call, if any."""
+        return self._error

--- a/tests/tools/test_discord_streaming_delivery.py
+++ b/tests/tools/test_discord_streaming_delivery.py
@@ -1,0 +1,236 @@
+"""Tests for the Discord streaming-delivery state machine (feature M7)."""
+
+import pytest
+
+from plugins.platforms.discord.delivery_state import (
+    DeliveryState,
+    DeliveryStateError,
+)
+
+
+def make_stream():
+    """Helper: fresh state machine advanced to STREAMING."""
+    ds = DeliveryState()
+    ds.begin()
+    ds.start_stream()
+    return ds
+
+
+# ----------------------------------------------------------------------
+# Happy path
+# ----------------------------------------------------------------------
+
+def test_initial_state_is_idle():
+    ds = DeliveryState()
+    assert ds.state == DeliveryState.IDLE
+
+
+def test_begin_transitions_to_typing():
+    ds = DeliveryState()
+    ds.begin()
+    assert ds.state == DeliveryState.TYPING
+
+
+def test_happy_path_begin_start_append_finish():
+    ds = make_stream()
+    assert ds.state == DeliveryState.STREAMING
+
+    ds.append("Hello, ")
+    ds.append("world!")
+    assert ds.state == DeliveryState.STREAMING
+    assert ds.delivered_chunks == 2
+    assert ds.has_content is True
+
+    ds.finish()
+    assert ds.state == DeliveryState.DONE
+    assert ds.delivered_chunks == 2
+    assert ds.has_content is True
+
+
+# ----------------------------------------------------------------------
+# Invalid transitions raise DeliveryStateError
+# ----------------------------------------------------------------------
+
+def test_begin_raises_when_not_idle():
+    ds = DeliveryState()
+    ds.begin()
+    with pytest.raises(DeliveryStateError):
+        ds.begin()
+
+
+def test_begin_raises_after_done():
+    ds = make_stream()
+    ds.append("hello")
+    ds.finish()
+    with pytest.raises(DeliveryStateError):
+        ds.begin()
+
+
+def test_start_stream_requires_typing():
+    ds = DeliveryState()
+    with pytest.raises(DeliveryStateError):
+        ds.start_stream()
+
+
+def test_append_requires_streaming():
+    ds = DeliveryState()
+    with pytest.raises(DeliveryStateError):
+        ds.append("nope")
+
+
+def test_finish_requires_streaming():
+    ds = DeliveryState()
+    with pytest.raises(DeliveryStateError):
+        ds.finish()
+
+
+def test_delivery_state_error_is_value_error():
+    assert issubclass(DeliveryStateError, ValueError)
+
+
+# ----------------------------------------------------------------------
+# Duplicate-final-response guard
+# ----------------------------------------------------------------------
+
+def test_duplicate_finish_raises():
+    ds = make_stream()
+    ds.append("content")
+    ds.finish()
+    assert ds.state == DeliveryState.DONE
+    with pytest.raises(DeliveryStateError):
+        ds.finish()
+
+
+def test_operations_after_finish_raise():
+    ds = make_stream()
+    ds.append("content")
+    ds.finish()
+    with pytest.raises(DeliveryStateError):
+        ds.append("more")
+    with pytest.raises(DeliveryStateError):
+        ds.start_stream()
+
+
+# ----------------------------------------------------------------------
+# fail(err) from active states
+# ----------------------------------------------------------------------
+
+def test_fail_from_streaming():
+    ds = make_stream()
+    ds.append("partial")
+    ds.fail(RuntimeError("boom"))
+    assert ds.state == DeliveryState.FAILED
+    assert isinstance(ds.error, RuntimeError)
+    # no further transitions from FAILED
+    with pytest.raises(DeliveryStateError):
+        ds.append("more")
+    with pytest.raises(DeliveryStateError):
+        ds.finish()
+
+
+def test_fail_from_typing():
+    ds = DeliveryState()
+    ds.begin()
+    ds.fail(ValueError("bad"))
+    assert ds.state == DeliveryState.FAILED
+    assert isinstance(ds.error, ValueError)
+
+
+def test_fail_from_idle_raises():
+    ds = DeliveryState()
+    with pytest.raises(DeliveryStateError):
+        ds.fail("nope")
+
+
+def test_fail_after_done_raises():
+    ds = make_stream()
+    ds.append("x")
+    ds.finish()
+    with pytest.raises(DeliveryStateError):
+        ds.fail("nope")
+
+
+# ----------------------------------------------------------------------
+# reset()
+# ----------------------------------------------------------------------
+
+def test_reset_returns_to_idle():
+    ds = make_stream()
+    ds.append("abc")
+    ds.finish()
+    ds.reset()
+    assert ds.state == DeliveryState.IDLE
+    assert ds.delivered_chunks == 0
+    assert ds.has_content is False
+
+
+def test_reset_makes_machine_reusable():
+    ds = make_stream()
+    ds.append("first run")
+    ds.finish()
+    ds.reset()
+    ds.begin()
+    assert ds.state == DeliveryState.TYPING
+    ds.start_stream()
+    ds.append("second run")
+    ds.finish()
+    assert ds.state == DeliveryState.DONE
+    assert ds.delivered_chunks == 1
+
+
+def test_reset_clears_error():
+    ds = make_stream()
+    ds.fail(OSError("network"))
+    ds.reset()
+    assert ds.state == DeliveryState.IDLE
+    assert ds.error is None
+
+
+# ----------------------------------------------------------------------
+# has_content / empty-content handling
+# ----------------------------------------------------------------------
+
+def test_has_content_tracks_non_empty_chunks():
+    ds = make_stream()
+    assert ds.has_content is False
+    ds.append("")
+    assert ds.has_content is False
+    ds.append("data")
+    assert ds.has_content is True
+    ds.append("")
+    assert ds.has_content is True  # empty chunk never drops prior content
+
+
+def test_empty_append_is_noop():
+    ds = make_stream()
+    ds.append("")
+    assert ds.delivered_chunks == 0
+    ds.append("real")
+    assert ds.delivered_chunks == 1
+    assert ds.has_content is True
+
+
+def test_delivered_chunks_counts_only_non_empty():
+    ds = make_stream()
+    ds.append("a")
+    ds.append("")
+    ds.append("b")
+    assert ds.delivered_chunks == 2
+
+
+def test_empty_content_finish_allowed_when_nothing_appended():
+    ds = make_stream()
+    ds.finish()  # empty finish with no non-empty chunks is allowed
+    assert ds.state == DeliveryState.DONE
+    assert ds.has_content is False
+    assert ds.delivered_chunks == 0
+
+
+def test_content_is_never_silently_dropped_at_finish():
+    ds = make_stream()
+    ds.append("kept")
+    ds.append("")  # trailing empty chunk must not erase prior content
+    ds.finish()
+    assert ds.state == DeliveryState.DONE
+    assert ds.has_content is True
+    assert ds.delivered_chunks == 1


### PR DESCRIPTION
## Summary

Streaming-delivery state machine for Discord — a typed IDLE/TYPING/STREAMING/DONE/FAILED lifecycle with a duplicate-final-response guard and no silent content drops.

## Motivation

Fixes #86500 · Part of #79564

## Changes

- New module `plugins/platforms/discord/delivery_state.py` implementing the streaming-delivery state machine with duplicate-final guard.

## Test Plan

- [x] Unit tests pass (`pytest`)
- [x] Focused regression tests: `tests/tools/test_discord_streaming_delivery.py` — 23 passed
- [ ] Manual testing of new functionality
- [x] No regressions in existing behavior

## Notes for Reviewers

- New module only — no god-file growth; `plugins/platforms/discord/adapter.py` untouched.