### PR TITLE
feat(discord): thread session isolation + history partition

### DIFF
--- a/contributors/emails/andrexibiza@gmail.com
+++ b/contributors/emails/andrexibiza@gmail.com
@@ -1,0 +1,2 @@
+andrexibiza
+# Discord omniscience T2

--- a/plugins/platforms/discord/thread_context.py
+++ b/plugins/platforms/discord/thread_context.py
@@ -1,0 +1,122 @@
+"""Discord thread session isolation and history partition (pure logic, no I/O).
+
+Feature T2: each (channel_id, thread_id) pair owns an isolated session key so a
+thread's conversation never bleeds into the parent channel's, and history is
+partitioned so thread messages are not double-counted in parent history.
+"""
+
+from __future__ import annotations
+
+from typing import Dict, List, Optional
+
+
+class ThreadContextError(ValueError):
+    """Raised when thread-context input is invalid."""
+
+
+_SNOWFLAKE_MAX = 2**63 - 1
+
+
+def _validate_snowflake(value, name: str) -> str:
+    """Validate a Discord snowflake id; return its normalized string form."""
+    if isinstance(value, bool):
+        raise ThreadContextError(f"{name} must be a snowflake id, got {value!r}")
+    if isinstance(value, int):
+        number = value
+        text = str(value)
+    elif isinstance(value, str):
+        text = value.strip()
+        if not text or not text.isdigit():
+            raise ThreadContextError(
+                f"{name} must be a numeric snowflake id, got {value!r}"
+            )
+        number = int(text)
+    else:
+        raise ThreadContextError(
+            f"{name} must be an int or str snowflake id, got {value!r}"
+        )
+    if number < 0 or number > _SNOWFLAKE_MAX:
+        raise ThreadContextError(f"{name} out of snowflake range: {value!r}")
+    return text
+
+
+class ThreadSessionRegistry:
+    """Tracks which session id owns each (channel_id, thread_id) pair."""
+
+    def __init__(self) -> None:
+        self._sessions: Dict[str, str] = {}
+
+    def key_for(self, channel_id, thread_id) -> str:
+        """Return the stable session key for a channel/thread pair."""
+        channel = _validate_snowflake(channel_id, "channel_id")
+        thread = _validate_snowflake(thread_id, "thread_id")
+        return f"{channel}:{thread}"
+
+    def is_isolated(self, key_a: str, key_b: str) -> bool:
+        """True when the two keys belong to different sessions.
+
+        Different thread or different channel => different session => isolated.
+        """
+        if not isinstance(key_a, str) or not isinstance(key_b, str):
+            raise ThreadContextError("is_isolated expects string session keys")
+        return key_a != key_b
+
+    def register(self, channel_id, thread_id, session_id: str) -> str:
+        """Associate a session id with a channel/thread pair; return its key."""
+        if not isinstance(session_id, str) or not session_id.strip():
+            raise ThreadContextError(
+                f"session_id must be a non-empty string, got {session_id!r}"
+            )
+        key = self.key_for(channel_id, thread_id)
+        self._sessions[key] = session_id
+        return key
+
+    def session_for(self, channel_id, thread_id) -> Optional[str]:
+        """Return the session id registered for a channel/thread pair, if any."""
+        return self._sessions.get(self.key_for(channel_id, thread_id))
+
+    def unregister(self, channel_id, thread_id) -> None:
+        """Remove a channel/thread pair's session mapping (idempotent)."""
+        self._sessions.pop(self.key_for(channel_id, thread_id), None)
+
+
+def _validate_message(message, name: str) -> str:
+    """Validate a history message dict; return its normalized id."""
+    if not isinstance(message, dict):
+        raise ThreadContextError(
+            f"{name} items must be message dicts, got {message!r}"
+        )
+    if "id" not in message:
+        raise ThreadContextError(
+            f"{name} items must contain an 'id', got {message!r}"
+        )
+    return _validate_snowflake(message["id"], f"{name} item id")
+
+
+class HistoryPartition:
+    """Separates parent-channel history from a thread's own history."""
+
+    def partition(
+        self, parent_messages: list, thread_messages: list, *, thread_id
+    ) -> Dict[str, list]:
+        """Split history into {'parent': [...], 'thread': [...]}.
+
+        A message id present in both lists is placed ONLY in 'thread' so
+        thread replies that also appear in the parent channel are not
+        double-counted.
+        """
+        _validate_snowflake(thread_id, "thread_id")
+        if not isinstance(parent_messages, list):
+            raise ThreadContextError("parent_messages must be a list")
+        if not isinstance(thread_messages, list):
+            raise ThreadContextError("thread_messages must be a list")
+
+        thread_ids = {
+            _validate_message(message, "thread_messages") for message in thread_messages
+        }
+        parent = [
+            message
+            for message in parent_messages
+            if _validate_message(message, "parent_messages") not in thread_ids
+        ]
+        return {"parent": parent, "thread": list(thread_messages)}

--- a/tests/tools/test_discord_thread_context.py
+++ b/tests/tools/test_discord_thread_context.py
@@ -1,0 +1,154 @@
+"""Tests for Discord feature T2: thread session isolation + history partition."""
+
+import pytest
+
+from plugins.platforms.discord.thread_context import (
+    HistoryPartition,
+    ThreadContextError,
+    ThreadSessionRegistry,
+)
+
+
+def msg(message_id, **extra):
+    data = {"id": message_id}
+    data.update(extra)
+    return data
+
+
+class TestThreadContextError:
+    def test_is_value_error_subclass(self):
+        assert issubclass(ThreadContextError, ValueError)
+
+
+class TestThreadSessionRegistry:
+    def test_distinct_keys_for_different_threads(self):
+        registry = ThreadSessionRegistry()
+        assert registry.key_for(100, 1) != registry.key_for(100, 2)
+
+    def test_distinct_keys_for_different_channels(self):
+        registry = ThreadSessionRegistry()
+        assert registry.key_for(100, 1) != registry.key_for(200, 1)
+
+    def test_key_is_stable_and_normalized(self):
+        registry = ThreadSessionRegistry()
+        assert registry.key_for(100, 1) == registry.key_for("100", "1")
+        assert registry.key_for(100, 1) == registry.key_for(100, 1)
+
+    def test_is_isolated_same_key_false(self):
+        registry = ThreadSessionRegistry()
+        key = registry.key_for(100, 1)
+        assert registry.is_isolated(key, key) is False
+
+    def test_is_isolated_different_thread_true(self):
+        registry = ThreadSessionRegistry()
+        assert (
+            registry.is_isolated(
+                registry.key_for(100, 1), registry.key_for(100, 2)
+            )
+            is True
+        )
+
+    def test_is_isolated_different_channel_true(self):
+        registry = ThreadSessionRegistry()
+        assert (
+            registry.is_isolated(
+                registry.key_for(100, 1), registry.key_for(200, 1)
+            )
+            is True
+        )
+
+    def test_register_session_for_unregister_roundtrip(self):
+        registry = ThreadSessionRegistry()
+        key = registry.register(100, 1, "session-a")
+        assert key == registry.key_for(100, 1)
+        assert registry.session_for(100, 1) == "session-a"
+        registry.unregister(100, 1)
+        assert registry.session_for(100, 1) is None
+
+    def test_unregister_missing_is_idempotent(self):
+        registry = ThreadSessionRegistry()
+        registry.unregister(999, 888)  # must not raise
+
+    def test_register_overwrites_session(self):
+        registry = ThreadSessionRegistry()
+        registry.register(100, 1, "session-a")
+        registry.register(100, 1, "session-b")
+        assert registry.session_for(100, 1) == "session-b"
+
+    def test_sessions_stay_isolated_between_threads(self):
+        registry = ThreadSessionRegistry()
+        registry.register(100, 1, "session-a")
+        registry.register(100, 2, "session-b")
+        assert registry.session_for(100, 1) == "session-a"
+        assert registry.session_for(100, 2) == "session-b"
+
+    def test_invalid_channel_raises(self):
+        registry = ThreadSessionRegistry()
+        with pytest.raises(ThreadContextError):
+            registry.key_for("not-a-snowflake", 1)
+
+    def test_invalid_thread_raises(self):
+        registry = ThreadSessionRegistry()
+        with pytest.raises(ThreadContextError):
+            registry.register(100, -5, "session-a")
+
+    def test_invalid_session_id_raises(self):
+        registry = ThreadSessionRegistry()
+        with pytest.raises(ThreadContextError):
+            registry.register(100, 1, "  ")
+
+
+class TestHistoryPartition:
+    def test_partition_empty(self):
+        partitioner = HistoryPartition()
+        assert partitioner.partition([], [], thread_id=42) == {
+            "parent": [],
+            "thread": [],
+        }
+
+    def test_partition_dedup_message_in_both_only_in_thread(self):
+        partitioner = HistoryPartition()
+        shared = msg(7, content="thread reply")
+        parent_messages = [msg(1), shared, msg(2)]
+        thread_messages = [msg(8), shared]
+        result = partitioner.partition(
+            parent_messages, thread_messages, thread_id=42
+        )
+        assert [m["id"] for m in result["parent"]] == [1, 2]
+        assert [m["id"] for m in result["thread"]] == [8, 7]
+        assert shared not in result["parent"]
+
+    def test_partition_thread_messages_kept_whole(self):
+        partitioner = HistoryPartition()
+        thread_messages = [msg(5), msg(6)]
+        result = partitioner.partition(
+            [msg(1), msg(2)], thread_messages, thread_id=42
+        )
+        assert result["thread"] == thread_messages
+
+    def test_partition_disjoint_lists_unchanged(self):
+        partitioner = HistoryPartition()
+        parent_messages = [msg(1), msg(2)]
+        thread_messages = [msg(3), msg(4)]
+        result = partitioner.partition(
+            parent_messages, thread_messages, thread_id=42
+        )
+        assert [m["id"] for m in result["parent"]] == [1, 2]
+        assert [m["id"] for m in result["thread"]] == [3, 4]
+
+    def test_invalid_thread_id_raises(self):
+        partitioner = HistoryPartition()
+        with pytest.raises(ThreadContextError):
+            partitioner.partition([], [], thread_id="abc")
+        with pytest.raises(ValueError):
+            partitioner.partition([], [], thread_id=-5)
+
+    def test_invalid_message_raises(self):
+        partitioner = HistoryPartition()
+        with pytest.raises(ThreadContextError):
+            partitioner.partition([{"no_id": True}], [], thread_id=42)
+
+    def test_non_list_input_raises(self):
+        partitioner = HistoryPartition()
+        with pytest.raises(ThreadContextError):
+            partitioner.partition("nope", [], thread_id=42)


### PR DESCRIPTION
## Summary

Thread session isolation and history partition for Discord — per-channel/thread session-key registry and parent/thread history partition with dedup.

## Motivation

Fixes #86502 · Part of #79564

## Changes

- New module `plugins/platforms/discord/thread_context.py` implementing session-key isolation and parent/thread history partitioning.

## Test Plan

- [x] Unit tests pass (`pytest`)
- [x] Focused regression tests: `tests/tools/test_discord_thread_context.py` — 21 passed
- [ ] Manual testing of new functionality
- [x] No regressions in existing behavior

## Notes for Reviewers

- New module only — no god-file growth; `plugins/platforms/discord/adapter.py` untouched.