### PR TITLE
feat(delegation): raise subagent iteration cap default 50 -> 250 (+migration)

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -1382,7 +1382,7 @@ code_execution:
 # The delegate_task tool spawns child agents with isolated context.
 # Supports single tasks and batch mode (default 3 parallel, configurable).
 delegation:
-  max_iterations: 50                          # Max tool-calling turns per child (default: 50)
+  max_iterations: 250                         # Max tool-calling turns per child (default: 250)
   # max_concurrent_children: 3                # Max parallel child agents per batch (default: 3, floor: 1, no ceiling).
                                               # WARNING: values above 10 multiply API cost linearly.
   # max_spawn_depth: 1                        # Delegation tree depth cap (range: 1-3, default: 1 = flat).

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1779,7 +1779,7 @@ DEFAULT_CONFIG = {
         # extras" without silently stripping MCP tools the parent already has.
         # Set to false for strict intersection.
         "inherit_mcp_toolsets": True,
-        "max_iterations": 50,  # per-subagent iteration cap (each subagent gets its own budget,
+        "max_iterations": 250,  # per-subagent iteration cap (each subagent gets its own budget,
                                # independent of the parent's max_iterations)
         # Subagent summaries return to the parent's context verbatim. A batch
         # fan-out (N children) returns N summaries at once, which can exceed
@@ -3393,7 +3393,7 @@ DEFAULT_CONFIG = {
     },
 
     # Config schema version - bump this when adding new required fields
-    "_config_version": 35,
+    "_config_version": 36,
 }
 
 # Optional environment variables that enhance functionality

--- a/hermes_cli/config_migrations.py
+++ b/hermes_cli/config_migrations.py
@@ -754,9 +754,38 @@ def _migrate_to_35(results: Dict[str, Any], quiet: bool) -> None:
                 )
 
 
+def _migrate_to_36(results: Dict[str, Any], quiet: bool) -> None:
+    # ── Version 35 → 36: raise the subagent iteration cap default 50 → 250 ──
+    # delegation.max_iterations is the per-subagent tool-call budget. The old
+    # default of 50 truncated substantial delegated work (leaf agents spend
+    # ~15-20 turns on recon before producing output, then ran out mid-task).
+    # The shipped default is now 250. Configs still pinned at exactly the old
+    # default 50 — almost always the inherited default rather than a deliberate
+    # choice — are lifted to 250 so existing installs get the same headroom on
+    # update. Any OTHER explicit value (a deliberate override, high or low) is
+    # the user's own and is preserved; unset inherits 250 at read time.
+    _c = _cfg()
+    read_raw_config = _c.read_raw_config
+    _persist_migration = _c._persist_migration
+
+    config = read_raw_config()
+    raw_deleg = config.get("delegation")
+    if isinstance(raw_deleg, dict) and raw_deleg.get("max_iterations") == 50:
+        raw_deleg["max_iterations"] = 250
+        config["delegation"] = raw_deleg
+        _persist_migration(config)
+        results["config_added"].append("delegation.max_iterations=250 (was: 50)")
+        if not quiet:
+            print(
+                "  ✓ Raised delegation.max_iterations from 50 to 250 — subagents "
+                "now get a larger per-child tool-call budget so delegated work "
+                "finishes instead of truncating. Set delegation.max_iterations "
+                "back to 50 to restore the old cap."
+            )
+
+
 #: Registry of (target_version, migration_fn), strictly ascending. The driver
 #: applies every entry whose target version is greater than the on-disk
-#: version captured before the ladder started. Order matters: later steps may
 #: observe earlier steps' writes via read_raw_config() (filesystem state).
 MIGRATIONS: Tuple[Tuple[int, Callable[[Dict[str, Any], bool], None]], ...] = (
     # v12 is the support floor: configs already AT v12 (or newer) still get
@@ -777,6 +806,7 @@ MIGRATIONS: Tuple[Tuple[int, Callable[[Dict[str, Any], bool], None]], ...] = (
     (33, _migrate_to_33),
     (34, _migrate_to_34),
     (35, _migrate_to_35),
+    (36, _migrate_to_36),
 )
 
 

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -977,7 +977,7 @@ def _preserve_parent_mcp_toolsets(
     return preserved
 
 
-DEFAULT_MAX_ITERATIONS = 50
+DEFAULT_MAX_ITERATIONS = 250
 # Hard per-summary character ceiling layered on top of the dynamic
 # headroom budget (see _apply_summary_budget). Belt-and-suspenders for
 # models that ignore the "be concise" instruction. 0 disables the ceiling.


### PR DESCRIPTION
`delegation.max_iterations` is the per-subagent tool-call budget. The old default of **50** truncated substantial delegated work: leaf agents spend ~15-20 turns on reconnaissance before producing output, then ran out of budget mid-task and returned 'completed but unfinished' summaries (exit_reason=max_iterations while status=completed). **250** gives delegated work room to actually finish.

## Changes
- `config_defaults.py`: `delegation.max_iterations` 50 → **250**; `_config_version` 35 → 36
- `tools/delegate_tool.py`: `DEFAULT_MAX_ITERATIONS` fallback 50 → 250 (kept in sync with the shipped default to prevent drift)
- `config_migrations.py`: **`_migrate_to_36`** lifts configs still pinned at *exactly* the old default 50 → 250 on update, so existing installs inherit the new headroom automatically. Any **other** explicit value (a deliberate override, high or low) is preserved; an unset key inherits 250 at read time.
- `cli-config.yaml.example`: documents the new default

## Why a migration (not just a default bump)
Config values, once written, aren't overwritten by default changes — so every existing install with `delegation.max_iterations: 50` on disk (the inherited old default) would stay at 50 forever. The migration is what makes 'raise it for everyone on their next update' actually happen, while respecting deliberate overrides.

## Risk / guardrails
The cap is **per child** and children run concurrently (`max_concurrent_children` default 3), so this raises worst-case fan-out cost. `delegation.child_timeout_seconds` (default 0 = off) remains available as a wall-clock backstop, and users can still pin a lower `max_iterations` explicitly.

## Verification
- Migration harness: 50→250 ✓, deliberate 120 preserved ✓, unset untouched ✓ (3/3)
- `DEFAULT_CONFIG` reads `_config_version=36`, `delegation.max_iterations=250`; `DEFAULT_MAX_ITERATIONS=250`
- py_compile clean on all four files

Reaches users via `hermes update` (default + migration apply on next config version check); no restart needed for CLI delegation, though a running gateway picks it up on its next restart.