### PR TITLE
fix(desktop): context gauge fills as soon as you turn it on

### DIFF
--- a/apps/desktop/src/app/shell/context-usage-panel.test.tsx
+++ b/apps/desktop/src/app/shell/context-usage-panel.test.tsx
@@ -1,12 +1,13 @@
-import { act, cleanup, render, waitFor } from '@testing-library/react'
-import { useState } from 'react'
+import { cleanup, render, screen, waitFor } from '@testing-library/react'
+import { renderHook } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import type { ContextBreakdown, UsageStats } from '@/types/hermes'
 
 import { ContextUsagePanel } from './context-usage-panel'
+import { useContextBreakdown } from './hooks/use-context-breakdown'
 
-const initialUsage: UsageStats = {
+const usage: UsageStats = {
   calls: 1,
   context_max: 272_000,
   context_percent: 47,
@@ -30,64 +31,86 @@ afterEach(() => {
   vi.restoreAllMocks()
 })
 
-describe('ContextUsagePanel', () => {
-  it('publishes once without refetching when publication recreates the callback', async () => {
+describe('useContextBreakdown', () => {
+  it('fetches for a session that has not run a turn yet', async () => {
     const requestGateway = vi.fn().mockResolvedValue(breakdown)
-    const published = vi.fn()
-    const renderedUsage: UsageStats[] = []
 
-    function Harness() {
-      const [currentUsage, setCurrentUsage] = useState(initialUsage)
-      renderedUsage.push(currentUsage)
+    const { result } = renderHook(() =>
+      useContextBreakdown({ busy: false, enabled: true, requestGateway, sessionId: 'runtime-1' })
+    )
 
-      return (
-        <ContextUsagePanel
-          currentUsage={currentUsage}
-          onUsageSnapshot={snapshot => {
-            published(snapshot)
-            setCurrentUsage(current => ({ ...current, ...snapshot }))
-          }}
-          requestGateway={requestGateway}
-          sessionId="runtime-1"
-        />
-      )
-    }
-
-    render(<Harness />)
-
-    await waitFor(() => {
-      expect(published).toHaveBeenCalledWith({
-        context_max: 272_000,
-        context_percent: 89,
-        context_used: 241_400
-      })
-      expect(renderedUsage.at(-1)?.context_used).toBe(241_400)
-    })
-    await act(async () => {})
-
-    expect(requestGateway).toHaveBeenCalledTimes(1)
+    await waitFor(() => expect(result.current.breakdown).toEqual(breakdown))
     expect(requestGateway).toHaveBeenCalledWith('session.context_breakdown', { session_id: 'runtime-1' })
   })
 
-  it('refetches when the session or gateway requester changes', async () => {
-    const firstGateway = vi.fn().mockResolvedValue(breakdown)
-    const secondGateway = vi.fn().mockResolvedValue(breakdown)
+  it('does not fetch while the gauge is hidden, and fetches once it is shown', async () => {
+    const requestGateway = vi.fn().mockResolvedValue(breakdown)
 
-    const { rerender } = render(
-      <ContextUsagePanel currentUsage={initialUsage} requestGateway={firstGateway} sessionId="runtime-1" />
+    const { rerender } = renderHook(
+      ({ enabled }) => useContextBreakdown({ busy: false, enabled, requestGateway, sessionId: 'runtime-1' }),
+      { initialProps: { enabled: false } }
     )
 
-    await waitFor(() => expect(firstGateway).toHaveBeenCalledTimes(1))
+    expect(requestGateway).not.toHaveBeenCalled()
 
-    rerender(<ContextUsagePanel currentUsage={initialUsage} requestGateway={firstGateway} sessionId="runtime-2" />)
+    rerender({ enabled: true })
 
-    await waitFor(() => {
-      expect(firstGateway).toHaveBeenCalledTimes(2)
-      expect(firstGateway).toHaveBeenLastCalledWith('session.context_breakdown', { session_id: 'runtime-2' })
-    })
+    await waitFor(() => expect(requestGateway).toHaveBeenCalledTimes(1))
+  })
 
-    rerender(<ContextUsagePanel currentUsage={initialUsage} requestGateway={secondGateway} sessionId="runtime-2" />)
+  it('skips the estimate mid-turn — the gateway streams measured usage then', () => {
+    const requestGateway = vi.fn().mockResolvedValue(breakdown)
 
-    await waitFor(() => expect(secondGateway).toHaveBeenCalledTimes(1))
+    renderHook(() => useContextBreakdown({ busy: true, enabled: true, requestGateway, sessionId: 'runtime-1' }))
+
+    expect(requestGateway).not.toHaveBeenCalled()
+  })
+
+  it('refetches on a session switch and never reports the previous session numbers', async () => {
+    const requestGateway = vi.fn().mockResolvedValue(breakdown)
+
+    const { rerender, result } = renderHook(
+      ({ sessionId }) => useContextBreakdown({ busy: false, enabled: true, requestGateway, sessionId }),
+      { initialProps: { sessionId: 'runtime-1' } }
+    )
+
+    await waitFor(() => expect(result.current.breakdown).toEqual(breakdown))
+
+    // Switching sessions must drop the numbers immediately — painting them
+    // under the new session's name would be a lie until its own fetch lands.
+    requestGateway.mockImplementation(() => new Promise(() => undefined))
+    rerender({ sessionId: 'runtime-2' })
+
+    expect(result.current.breakdown).toBeNull()
+    expect(requestGateway).toHaveBeenLastCalledWith('session.context_breakdown', { session_id: 'runtime-2' })
+  })
+
+  it('reports the measured occupancy the backend sends, not just the estimate', async () => {
+    // `context_used` on the payload is already the measured figure once a turn
+    // has run — the estimate is the backend's own fallback, not a second value
+    // the client has to choose between.
+    const measured: ContextBreakdown = { ...breakdown, context_used: 12_000 }
+    const requestGateway = vi.fn().mockResolvedValue(measured)
+
+    const { result } = renderHook(() =>
+      useContextBreakdown({ busy: false, enabled: true, requestGateway, sessionId: 'runtime-1' })
+    )
+
+    await waitFor(() => expect(result.current.breakdown?.context_used).toBe(12_000))
+  })
+})
+
+describe('ContextUsagePanel', () => {
+  it('renders the usage it is handed, so the popover matches the bar', () => {
+    render(<ContextUsagePanel breakdown={breakdown} loading={false} usage={usage} />)
+
+    expect(screen.getByText('47% Full')).toBeTruthy()
+    expect(screen.getByText('Conversation')).toBeTruthy()
+  })
+
+  it('says so when there is no breakdown rather than painting an empty bar', () => {
+    render(<ContextUsagePanel breakdown={null} loading={false} usage={usage} />)
+
+    expect(screen.getByText('No context data yet')).toBeTruthy()
   })
 })

--- a/apps/desktop/src/app/shell/context-usage-panel.tsx
+++ b/apps/desktop/src/app/shell/context-usage-panel.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from 'react'
+import { useMemo } from 'react'
 
 import { useI18n } from '@/i18n'
 import { compactNumber } from '@/lib/format'
@@ -6,70 +6,22 @@ import { cn } from '@/lib/utils'
 import type { ContextBreakdown, ContextUsageCategory, UsageStats } from '@/types/hermes'
 
 interface ContextUsagePanelProps {
-  currentUsage: UsageStats
-  onUsageSnapshot?: (usage: Pick<UsageStats, 'context_max' | 'context_percent' | 'context_used'>) => void
-  requestGateway: <T = unknown>(method: string, params?: Record<string, unknown>) => Promise<T>
-  sessionId: string | null
+  breakdown: ContextBreakdown | null
+  loading: boolean
+  usage: UsageStats
 }
 
-export function ContextUsagePanel({
-  currentUsage,
-  onUsageSnapshot,
-  requestGateway,
-  sessionId
-}: ContextUsagePanelProps) {
+/** Presentational: the breakdown is fetched by the statusbar (see
+ *  `useContextBreakdown`) because the gauge's own label needs it, so the
+ *  popover opens with its numbers already in hand. `usage` is the gauge's
+ *  merged figure — measured occupancy when the backend has it, the estimate
+ *  otherwise — so the header and the bar can never disagree. */
+export function ContextUsagePanel({ breakdown, loading, usage }: ContextUsagePanelProps) {
   const { t } = useI18n()
   const copy = t.shell.statusbar.contextUsagePanel
-  const [breakdown, setBreakdown] = useState<ContextBreakdown | null>(null)
-  const [loading, setLoading] = useState(false)
-  const onUsageSnapshotRef = useRef(onUsageSnapshot)
-  onUsageSnapshotRef.current = onUsageSnapshot
-
-  useEffect(() => {
-    if (!sessionId) {
-      setBreakdown(null)
-      setLoading(false)
-
-      return
-    }
-
-    let cancelled = false
-    setLoading(true)
-
-    void requestGateway<ContextBreakdown>('session.context_breakdown', { session_id: sessionId })
-      .then(data => {
-        if (!cancelled) {
-          setBreakdown(data)
-          onUsageSnapshotRef.current?.({
-            context_max: data.context_max,
-            context_percent: data.context_percent,
-            context_used: data.context_used
-          })
-        }
-      })
-      .catch(() => {
-        if (!cancelled) {
-          setBreakdown(null)
-        }
-      })
-      .finally(() => {
-        if (!cancelled) {
-          setLoading(false)
-        }
-      })
-
-    return () => {
-      cancelled = true
-    }
-  }, [requestGateway, sessionId])
-
-  const contextMax = breakdown?.context_max ?? currentUsage.context_max ?? 0
-  const contextUsed = breakdown?.context_used ?? currentUsage.context_used ?? 0
-
-  const contextPercent = Math.max(
-    0,
-    Math.min(100, Math.round(breakdown?.context_percent ?? currentUsage.context_percent ?? 0))
-  )
+  const contextMax = usage.context_max ?? 0
+  const contextUsed = usage.context_used ?? 0
+  const contextPercent = Math.max(0, Math.min(100, Math.round(usage.context_percent ?? 0)))
 
   const categories = useMemo(
     () =>
@@ -110,7 +62,7 @@ export function ContextUsagePanel({
         ))}
       </ul>
 
-      {loading && <p className="text-[0.6875rem] text-muted-foreground">{copy.loading}</p>}
+      {loading && !categories.length && <p className="text-[0.6875rem] text-muted-foreground">{copy.loading}</p>}
 
       {!loading && !categories.length && <p className="text-[0.6875rem] text-muted-foreground">{copy.empty}</p>}
     </div>

--- a/apps/desktop/src/app/shell/hooks/use-context-breakdown.ts
+++ b/apps/desktop/src/app/shell/hooks/use-context-breakdown.ts
@@ -1,0 +1,63 @@
+import { useEffect, useState } from 'react'
+
+import type { ContextBreakdown } from '@/types/hermes'
+
+interface ContextBreakdownOptions {
+  busy: boolean
+  enabled: boolean
+  requestGateway: <T = unknown>(method: string, params?: Record<string, unknown>) => Promise<T>
+  sessionId: null | string
+}
+
+/** The focused session's context breakdown, fetched as soon as the statusbar
+ *  gauge is on screen rather than when its popover opens.
+ *
+ *  The backend only reports measured context occupancy (`last_prompt_tokens`)
+ *  once a turn has run in THIS process, so a resumed session reports none —
+ *  which is why turning the gauge on used to do nothing at all until you sent
+ *  a message. `session.context_breakdown` estimates the same figure from the
+ *  live system prompt + tools + transcript, so it answers for a session that
+ *  hasn't spoken yet. It is a read-only chars/4 pass: no provider call, no
+ *  prompt-cache impact.
+ *
+ *  Refetches when the focused session changes and when a turn ends (the
+ *  transcript just grew). Held keyed by the session it describes so switching
+ *  sessions drops the previous numbers instead of painting them under the new
+ *  session's name. */
+export function useContextBreakdown({ busy, enabled, requestGateway, sessionId }: ContextBreakdownOptions) {
+  const [fetched, setFetched] = useState<{ breakdown: ContextBreakdown; sessionId: string } | null>(null)
+  const [loading, setLoading] = useState(false)
+
+  useEffect(() => {
+    // Mid-turn the transcript changes on every delta and the gateway already
+    // streams measured usage, so an estimate would be both stale and wasteful.
+    if (!enabled || !sessionId || busy) {
+      return
+    }
+
+    let cancelled = false
+    setLoading(true)
+
+    void requestGateway<ContextBreakdown>('session.context_breakdown', { session_id: sessionId })
+      .then(breakdown => {
+        if (!cancelled && breakdown) {
+          setFetched({ breakdown, sessionId })
+        }
+      })
+      .catch(() => undefined)
+      .finally(() => {
+        if (!cancelled) {
+          setLoading(false)
+        }
+      })
+
+    return () => {
+      cancelled = true
+    }
+  }, [busy, enabled, requestGateway, sessionId])
+
+  return {
+    breakdown: fetched && fetched.sessionId === sessionId ? fetched.breakdown : null,
+    loading
+  }
+}

--- a/apps/desktop/src/app/shell/hooks/use-statusbar-items.tsx
+++ b/apps/desktop/src/app/shell/hooks/use-statusbar-items.tsx
@@ -1,10 +1,11 @@
 import { useStore } from '@nanostores/react'
-import { useCallback, useMemo } from 'react'
+import { useMemo } from 'react'
 
 import type { CommandCenterSection } from '@/app/command-center'
 import { useApprovalModeStatusbarItem } from '@/app/shell/approval-mode-menu'
 import { ContextUsagePanel } from '@/app/shell/context-usage-panel'
 import { GatewayMenuPanel } from '@/app/shell/gateway-menu-panel'
+import { useContextBreakdown } from '@/app/shell/hooks/use-context-breakdown'
 import { $paneVisible, togglePaneVisible } from '@/components/pane-shell/tree/store'
 import { Codicon } from '@/components/ui/codicon'
 import { GlyphSpinner } from '@/components/ui/glyph-spinner'
@@ -31,10 +32,10 @@ import {
   $sessionStartedAt,
   $turnStartedAt,
   idsShareLineage,
-  sessionMatchesStoredId,
-  setCurrentUsage
+  sessionMatchesStoredId
 } from '@/store/session'
 import { $focusedRuntimeId, $focusedSessionState, $focusedStoredSessionId } from '@/store/session-states'
+import { $statusbarHiddenIds } from '@/store/statusbar-prefs'
 import { $subagentsBySession, activeSubagentCount, failedSubagentCount } from '@/store/subagents'
 import { $gatewayRestarting } from '@/store/system-actions'
 import {
@@ -50,7 +51,7 @@ import type { StatusResponse, UsageStats } from '@/types/hermes'
 import { CRON_ROUTE, SETTINGS_ROUTE, WEBHOOKS_ROUTE } from '../../routes'
 import type { StatusbarItem } from '../statusbar-controls'
 
-const EMPTY_USAGE = { calls: 0, input: 0, output: 0, total: 0 } as const
+const EMPTY_USAGE: UsageStats = { calls: 0, input: 0, output: 0, total: 0 }
 
 interface StatusbarItemsOptions {
   agentsOpen: boolean
@@ -223,15 +224,44 @@ export function useStatusbarItems({
       ? focusedRowStartedAt * 1000
       : null
 
-  const contextUsage = useMemo(() => usageContextLabel(currentUsage), [currentUsage])
-  const contextBar = useMemo(() => contextBarLabel(currentUsage), [currentUsage])
+  // The backend only knows a session's MEASURED occupancy once a turn has run
+  // in this process, so a resumed conversation reports none and the gauge had
+  // nothing to paint — turning it on looked like it did nothing until you sent
+  // a message. Estimate from the live prompt + transcript instead, on the same
+  // read-only RPC the popover uses, so the readout is right the moment it's on
+  // screen. Gated on the gauge being shown — the bar itself is unmounted while
+  // toggled off, so this covers the rest.
+  const contextItemHidden = useStore($statusbarHiddenIds).includes('context-usage')
 
-  const publishContextUsage = useCallback(
-    (snapshot: Pick<UsageStats, 'context_max' | 'context_percent' | 'context_used'>) => {
-      setCurrentUsage(current => ({ ...current, ...snapshot }))
-    },
-    []
+  const { breakdown: contextBreakdown, loading: contextBreakdownLoading } = useContextBreakdown({
+    busy,
+    enabled: !contextItemHidden,
+    requestGateway,
+    sessionId: activeSessionId
+  })
+
+  // The breakdown wins whenever we have one, for two reasons: it reports the
+  // MEASURED occupancy once the backend has it (falling back to the estimate
+  // only before that), and it is keyed to the session it describes. The global
+  // `$currentUsage` is neither — a resumed session reports no context fields,
+  // and the store merges rather than replaces, so the PREVIOUS session's gauge
+  // numbers survive the switch. Mid-turn there's no breakdown by design and
+  // the streamed usage carries the gauge.
+  const gaugeUsage = useMemo<UsageStats>(
+    () =>
+      contextBreakdown
+        ? {
+            ...currentUsage,
+            context_max: contextBreakdown.context_max,
+            context_percent: contextBreakdown.context_percent,
+            context_used: contextBreakdown.context_used
+          }
+        : currentUsage,
+    [contextBreakdown, currentUsage]
   )
+
+  const contextUsage = useMemo(() => usageContextLabel(gaugeUsage), [gaugeUsage])
+  const contextBar = useMemo(() => contextBarLabel(gaugeUsage), [gaugeUsage])
 
   const approvalModeItem = useApprovalModeStatusbarItem(activeGatewayProfile, requestGateway)
 
@@ -535,10 +565,9 @@ export function useStatusbarItems({
         menuClassName: 'w-auto border-(--ui-stroke-secondary) p-0',
         menuContent: (
           <ContextUsagePanel
-            currentUsage={currentUsage}
-            onUsageSnapshot={publishContextUsage}
-            requestGateway={requestGateway}
-            sessionId={activeSessionId}
+            breakdown={contextBreakdown}
+            loading={contextBreakdownLoading}
+            usage={gaugeUsage}
           />
         ),
         toggleLabel: copy.toggleContextUsage,
@@ -572,18 +601,17 @@ export function useStatusbarItems({
       ...(backendVersionItem ? [backendVersionItem] : [])
     ],
     [
-      activeSessionId,
       approvalModeItem,
       backendVersionItem,
       busy,
       chatOpen,
       clientVersionItem,
       contextBar,
+      contextBreakdown,
+      contextBreakdownLoading,
       contextUsage,
       copy,
-      currentUsage,
-      publishContextUsage,
-      requestGateway,
+      gaugeUsage,
       sessionStartedAt,
       gatewayState,
       terminalShowing,


### PR DESCRIPTION
## What does this PR do?

The desktop statusbar's context gauge only painted what the backend reported as
*measured* occupancy, and a session has none of that until a turn runs in the
current process. So turning the gauge on mid-conversation, or resuming a chat
and looking at it, showed nothing at all — the readout stayed blank until the
next message, which reads as the toggle being broken.

`session.context_breakdown` already answers for a session that hasn't spoken
yet: it estimates from the live system prompt, tool schemas and transcript
(chars/4, read-only, no provider call, no prompt-cache impact) and returns the
measured figure once the backend has one. It was only being called when the
popover opened, so the bar itself never benefited. This fetches it as soon as
the gauge is on screen and feeds one merged figure to both the bar label and the
popover, so the two can't disagree.

Keying the breakdown to the session it describes fixes a second staleness bug
along the way: `$currentUsage` is a global the store *merges* into, so after
switching to a session with no reported context the previous session's numbers
stayed on the gauge under the new session's name.

## Related Issue

<!-- No filed issue — found while using the gauge. -->

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/src/app/shell/hooks/use-context-breakdown.ts` (new) — fetches
  the breakdown for the focused session while the gauge is shown; skips
  mid-turn, when the gateway is already streaming measured usage; drops the
  previous session's numbers immediately on a switch.
- `apps/desktop/src/app/shell/hooks/use-statusbar-items.tsx` — owns the fetch
  and merges it over `$currentUsage` for both the gauge label and the popover.
- `apps/desktop/src/app/shell/context-usage-panel.tsx` — now presentational; it
  renders the usage it's handed instead of fetching on open.

## How to Test

1. Open a chat that already has history and send at least one message, then
   right-click the statusbar and turn **Context usage** off.
2. Reload the app (⌘R) and reopen that chat, so no turn has run in this process.
3. Right-click the statusbar → turn **Context usage** back on. Before: blank
   until you sent a message. After: the gauge fills immediately, and its popover
   shows the same figures.
4. Switch to a different session — the numbers change with it rather than
   carrying over.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.7.3

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
