### PR TITLE
fix(tui): route quick aliases through native handlers

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -11198,6 +11198,130 @@ def test_file_attach_quotes_ref_with_spaces(monkeypatch, tmp_path):
         server._sessions.pop("sid", None)
 
 
+def _slash_exec(command: str) -> dict:
+    return server.handle_request(
+        {
+            "id": command,
+            "method": "slash.exec",
+            "params": {"session_id": "sid", "command": command},
+        }
+    )
+
+
+def test_slash_exec_routes_only_native_quick_alias_to_dispatch(monkeypatch):
+    calls = []
+    monkeypatch.setattr(
+        server,
+        "_load_cfg",
+        lambda: {
+            "quick_commands": {
+                "capture": {"type": "alias", "target": "/image latest.png"}
+            }
+        },
+    )
+
+    def _dispatch(rid, params):
+        calls.append(params)
+        return {"id": rid, "result": {"type": "alias", "target": "/image latest.png"}}
+
+    monkeypatch.setitem(server._methods, "command.dispatch", _dispatch)
+    server._sessions["sid"] = _session()
+    try:
+        assert _slash_exec("capture describe this image")["result"] == {
+            "type": "alias",
+            "target": "/image latest.png",
+        }
+        assert calls == [
+            {"name": "capture", "arg": "describe this image", "session_id": "sid"}
+        ]
+    finally:
+        server._sessions.pop("sid", None)
+
+
+@pytest.mark.parametrize(
+    "quick_commands",
+    [
+        {"capture": {"type": "alias", "target": "/not-native arg"}},
+        {
+            "capture": {"type": "alias", "target": "other-quick"},
+            "other-quick": {"type": "exec", "command": "printf chained"},
+        },
+        {"capture": {"type": "alias", "target": "/research"}},
+        {"capture": {"type": "exec", "command": "printf shell"}},
+        {},
+    ],
+    ids=("non-native-alias", "chained-alias", "skill-alias", "shell", "unknown"),
+)
+def test_slash_exec_keeps_extensions_in_worker(monkeypatch, quick_commands):
+    class _Worker:
+        commands = []
+
+        def run(self, command):
+            self.commands.append(command)
+            return "handled by worker"
+
+    worker = _Worker()
+    monkeypatch.setattr(server, "_load_cfg", lambda: {"quick_commands": quick_commands})
+    server._sessions["sid"] = _session(slash_worker=worker)
+    try:
+        assert _slash_exec("capture keep worker routing")["result"] == {
+            "output": "handled by worker"
+        }
+        assert worker.commands == ["capture keep worker routing"]
+    finally:
+        server._sessions.pop("sid", None)
+
+
+def test_slash_exec_loads_quick_config_only_for_extension_names(monkeypatch):
+    class _Worker:
+        def run(self, command):
+            return f"worker: {command}"
+
+    loads = 0
+
+    def _load():
+        nonlocal loads
+        loads += 1
+        return {"quick_commands": {}}
+
+    monkeypatch.setattr(server, "_load_cfg", _load)
+    monkeypatch.setattr(server, "_mirror_slash_side_effects", lambda *_args: "")
+    server._sessions["sid"] = _session(slash_worker=_Worker())
+    try:
+        assert _slash_exec("model")["result"]["output"] == "Current model: (unknown)"
+        assert loads == 0
+        assert _slash_exec("unknown-one")["result"]["output"] == "worker: unknown-one"
+        assert _slash_exec("unknown-two")["result"]["output"] == "worker: unknown-two"
+        assert loads == 2
+    finally:
+        server._sessions.pop("sid", None)
+
+
+def test_slash_exec_uses_catalog_case_canonicalization_for_quick_alias(monkeypatch):
+    calls = []
+    monkeypatch.setattr(
+        server,
+        "_load_cfg",
+        lambda: {
+            "quick_commands": {
+                "CaptureLatest": {"type": "alias", "target": "/image latest.png"}
+            }
+        },
+    )
+    monkeypatch.setitem(
+        server._methods,
+        "command.dispatch",
+        lambda rid, params: calls.append(params)
+        or {"id": rid, "result": {"type": "alias", "target": "/image latest.png"}},
+    )
+    server._sessions["sid"] = _session()
+    try:
+        assert _slash_exec("capturelatest describe")["result"]["type"] == "alias"
+        assert calls[0]["name"] == "CaptureLatest"
+    finally:
+        server._sessions.pop("sid", None)
+
+
 def test_commands_catalog_surfaces_quick_commands(monkeypatch):
     monkeypatch.setattr(
         server,

--- a/tui_gateway/methods_tools.py
+++ b/tui_gateway/methods_tools.py
@@ -522,6 +522,31 @@ def _bundle_key_for(name: str):
         return None
 
 
+def _native_quick_alias(raw: str, base: str):
+    """Configured name of the ``quick_commands`` alias ``raw`` (case-insensitive fallback on ``base``)
+    when its target is a registry command; None otherwise / on failure. Built-ins win without a config
+    read; aliases onto skills, other quick commands or unknown targets stay with the slash worker."""
+    try:
+        resolve_command = _tools_mod("hermes_cli.commands").resolve_command
+        if not base or resolve_command(base) is not None:
+            return None
+        quick_commands = _load_cfg().get("quick_commands", {}) or {}
+        if not isinstance(quick_commands, dict):
+            return None
+        name, qc = raw, quick_commands.get(raw)
+        if qc is None:
+            name, qc = next(
+                ((k, v) for k, v in sorted(quick_commands.items()) if isinstance(k, str) and k.lower() == base),
+                (raw, None))
+        if not isinstance(qc, dict) or qc.get("type") != "alias":
+            return None
+        target = qc.get("target", "")
+        target_parts = target.lstrip("/").split(maxsplit=1) if isinstance(target, str) else []
+        return name if target_parts and resolve_command(target_parts[0]) is not None else None
+    except Exception:
+        return None
+
+
 def _dispatch_bundle(rid, params, session, name, arg):
     bundle_key = _bundle_key_for(name)
     if bundle_key is None:
@@ -836,9 +861,14 @@ def _(rid, params: dict) -> dict:
     # Skill/bundle and _PENDING_INPUT_COMMANDS must NOT reach the slash worker. Plugin
     # commands also bypass it but return normal slash.exec output (TUI keeps the pager path).
     parts = cmd.lstrip("/").split(maxsplit=1)
-    base = (parts[0] if parts else "").lower()
+    raw = parts[0] if parts else ""
+    base = raw.lower()
     arg = parts[1] if len(parts) > 1 else ""
     sid = params.get("session_id", "")
+    # A quick alias onto a registry command belongs to the TUI's native handler (command.dispatch
+    # returns the alias directive); aliases to skills/quick/unknown targets keep the worker path.
+    if (alias := _native_quick_alias(raw, base)) is not None:
+        return _methods["command.dispatch"](rid, {"name": alias, "arg": arg, "session_id": sid})
     live_output = _live_slash_command_output(sid, session, base, arg)
     if live_output is not None:
         return _ok(rid, {"output": live_output or "(no output)"})

--- a/ui-tui/src/__tests__/createSlashHandler.test.ts
+++ b/ui-tui/src/__tests__/createSlashHandler.test.ts
@@ -837,6 +837,26 @@ describe('createSlashHandler', () => {
     })
   })
 
+  it('preserves trailing text when slash.exec returns a slash-prefixed image alias', async () => {
+    const ctx = buildCtx({
+      gateway: {
+        gw: {
+          getLogTail: vi.fn(() => ''),
+          request: vi.fn((method: string) =>
+            Promise.resolve(method === 'slash.exec' ? { type: 'alias', target: '/image latest.png' } : {})
+          )
+        },
+        rpc: vi.fn(() => Promise.resolve({}))
+      }
+    })
+
+    expect(createSlashHandler(ctx)('/capture describe this image')).toBe(true)
+
+    await vi.waitFor(() => {
+      expect(ctx.composer.attachImagePath).toHaveBeenCalledWith('latest.png describe this image')
+    })
+  })
+
   it('resolves unique local aliases through the catalog', () => {
     const ctx = buildCtx({
       local: {
@@ -1150,6 +1170,8 @@ const buildCtx = (overrides: Partial<Ctx> = {}): Ctx => ({
 })
 
 const buildComposer = () => ({
+  attachClipboardImage: vi.fn(),
+  attachImagePath: vi.fn(),
   enqueue: vi.fn(),
   hasSelection: false,
   openEditor: vi.fn(async () => {}),

--- a/ui-tui/src/app/createSlashHandler.ts
+++ b/ui-tui/src/app/createSlashHandler.ts
@@ -108,7 +108,7 @@ export function createSlashHandler(ctx: SlashHandlerContext): (cmd: string) => b
       }
 
       if (d.type === 'alias') {
-        return void handler(`/${d.target}${argTail}`)
+        return void handler(`/${d.target.replace(/^\/+/, '')}${argTail}`)
       }
 
       // A skill/bundle dispatch's `message` is the expanded skill body —


### PR DESCRIPTION
## Summary

- route user-defined TUI quick-command aliases through the existing native command dispatcher before the isolated slash worker
- preserve trailing user text when an alias targets a native TUI command such as `/image`
- add backend and frontend regression coverage for the full structured-alias contract

## Problem

The TUI sends non-local slash commands to `slash.exec`. User-defined aliases were not recognized there, so they entered the isolated slash worker instead of returning the structured alias payload already understood by the frontend.

That breaks generic workflows such as a Taildrop-style “latest image” alias:

```yaml
quick_commands:
  capture:
    type: alias
    target: image latest.png
```

`/capture describe this image` should attach `latest.png` and preserve `describe this image` in the composer. On current `main`, the backend regression test fails because `slash.exec` returns an error rather than an alias result.

This is separate from the messaging-gateway alias path fixed in #19588; the TUI uses `tui_gateway` and its own native handlers.

## Validation

- RED confirmed on current `origin/main` with the new backend regression
- `scripts/run_tests.sh tests/test_tui_gateway_server.py` — 556 passed
- `scripts/run_tests.sh tests/tui_gateway/test_protocol.py` — 47 passed
- `npm --prefix ui-tui test -- src/__tests__/createSlashHandler.test.ts` — 79 passed
- `npm --prefix ui-tui run typecheck`
- `npm --prefix ui-tui run build`
- `ruff check tui_gateway/methods_tools.py tests/test_tui_gateway_server.py`
- Prettier check for the modified TypeScript test
