### PR TITLE
fix(gateway): stop force-killing the gateway inside the service manager's graceful-stop budget (supersedes #17292)

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -4958,7 +4958,9 @@ def launchd_stop():
         # rather than returning early and reporting a stop that has not
         # happened. Mirrors launchd_restart(), which likewise passes
         # force_after=None.
-        _wait_for_gateway_exit(timeout=_GATEWAY_STOP_WAIT_SECONDS, force_after=None)
+        exited = _wait_for_gateway_exit(
+            timeout=_GATEWAY_STOP_WAIT_SECONDS, force_after=None
+        )
     else:
         # Nothing is supervising this process — launchd never took the job, or
         # the domain is unmanageable and the gateway is a detached fallback
@@ -4972,10 +4974,22 @@ def launchd_stop():
                 terminate_pid(pid, force=False)
             except (ProcessLookupError, PermissionError, OSError):
                 pass
-        _wait_for_gateway_exit(
+        exited = _wait_for_gateway_exit(
             timeout=_GATEWAY_STOP_WAIT_SECONDS,
             force_after=_GATEWAY_STOP_GRACE_SECONDS,
         )
+    if not exited:
+        # The wait has already named the surviving PID ("still running after
+        # Ns — restart may fail"); following that with "✓ Service stopped"
+        # tells the operator the opposite of what just happened. Report the
+        # stop we actually observed instead. Mirrors systemd_stop(), which
+        # returns with "still stopping after 90s" rather than its ✓ line, and
+        # launchd_restart(), which already branches on this same result.
+        print(
+            f"⚠ Gateway is still running after {_GATEWAY_STOP_WAIT_SECONDS:.0f}s; "
+            "check `hermes gateway status` or logs for final shutdown state."
+        )
+        return
     print("✓ Service stopped")
 
 

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -4849,11 +4849,65 @@ def launchd_install(force: bool = False):
 def launchd_uninstall():
     plist_path = get_launchd_plist_path()
     label = get_launchd_label()
-    subprocess.run(
-        ["launchctl", "bootout", f"{_launchd_domain()}/{label}"],
-        check=False,
-        timeout=90,
-    )
+    target = f"{_launchd_domain()}/{label}"
+
+    pid = None
+    try:
+        from gateway.status import get_running_pid, write_planned_stop_marker
+
+        pid = get_running_pid(cleanup_stale=False)
+        if pid is not None:
+            write_planned_stop_marker(pid)
+    except Exception:
+        pid = None
+
+    # Same bootout fall-through launchd_stop() handles: "job already unloaded"
+    # (3/113/125) and "domain unmanageable" (5/125 — the macOS 26+ detached
+    # fallback process, #23387) both mean launchd never took the job, so it
+    # will not send SIGTERM and will not escalate. Uninstall previously sent
+    # nothing at all on that path, leaving the gateway running.
+    #
+    # Any other launchctl failure is left to launchd: uninstall has always
+    # tolerated a failing bootout (it ran with check=False), and pre-empting
+    # a job launchd may still be supervising would just get the process
+    # respawned by KeepAlive.
+    launchd_owns_exit = True
+    try:
+        subprocess.run(["launchctl", "bootout", target], check=True, timeout=90)
+    except subprocess.CalledProcessError as e:
+        if _launchd_error_indicates_unloaded(e) or _launchctl_domain_unsupported(
+            e.returncode
+        ):
+            launchd_owns_exit = False
+
+    if launchd_owns_exit:
+        exited = _wait_for_gateway_exit(
+            timeout=_GATEWAY_STOP_WAIT_SECONDS, force_after=None
+        )
+    else:
+        if pid is not None:
+            try:
+                terminate_pid(pid, force=False)
+            except (ProcessLookupError, PermissionError, OSError):
+                pass
+        exited = _wait_for_gateway_exit(
+            timeout=_GATEWAY_STOP_WAIT_SECONDS,
+            force_after=_GATEWAY_STOP_GRACE_SECONDS,
+        )
+
+    if not exited:
+        # Keep the plist. Removing the service definition out from under a
+        # live gateway strands the operator: `hermes gateway stop` then takes
+        # this same unsupervised fall-through, and `hermes gateway start`
+        # bootstraps a SECOND instance against the same bot token and port.
+        # systemd_uninstall() does not have this problem because `systemctl
+        # stop` is synchronous — it does not return until the unit is down.
+        print(
+            f"⚠ Gateway is still running after {_GATEWAY_STOP_WAIT_SECONDS:.0f}s; "
+            f"keeping {plist_path} so the service can still be stopped."
+        )
+        print("  Stop it, then re-run: hermes gateway stop && hermes gateway uninstall")
+        return
 
     if plist_path.exists():
         plist_path.unlink()

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -7608,7 +7608,12 @@ def _gateway_command_inner(args):
                 print(
                     f"✓ Killed {killed} stale gateway process(es) across all profiles"
                 )
-                _wait_for_gateway_exit(timeout=10.0, force_after=5.0)
+                # kill_gateway_processes() sends SIGTERM; give those drains the
+                # service manager's own budget before escalating to SIGKILL.
+                _wait_for_gateway_exit(
+                    timeout=_GATEWAY_STOP_WAIT_SECONDS,
+                    force_after=_GATEWAY_STOP_GRACE_SECONDS,
+                )
 
         if is_termux():
             print(
@@ -7811,7 +7816,12 @@ def _gateway_command_inner(args):
             total = killed + (1 if service_stopped else 0)
             if total:
                 print(f"✓ Stopped {total} gateway process(es) across all profiles")
-            _wait_for_gateway_exit(timeout=10.0, force_after=5.0)
+            # The service stop above and kill_gateway_processes() both signal
+            # gracefully; escalate only once the manager's own budget is spent.
+            _wait_for_gateway_exit(
+                timeout=_GATEWAY_STOP_WAIT_SECONDS,
+                force_after=_GATEWAY_STOP_GRACE_SECONDS,
+            )
 
             # Start the current profile's service fresh
             print("Starting gateway...")
@@ -7905,7 +7915,13 @@ def _gateway_command_inner(args):
             if stop_profile_gateway():
                 print("✓ Stopped gateway for this profile")
 
-            _wait_for_gateway_exit(timeout=10.0, force_after=5.0)
+            # stop_profile_gateway() sends SIGTERM and polls for ~10s; keep
+            # escalating no earlier than the service manager's own budget so a
+            # slow drain finishes its teardown instead of being SIGKILLed.
+            _wait_for_gateway_exit(
+                timeout=_GATEWAY_STOP_WAIT_SECONDS,
+                force_after=_GATEWAY_STOP_GRACE_SECONDS,
+            )
 
             # Start fresh
             print("Starting gateway...")

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -5124,6 +5124,33 @@ def _wait_for_gateway_exit(
     return True
 
 
+def _abort_on_surviving_gateway(action: str) -> None:
+    """Stop a start/restart that the preceding stop did not actually clear.
+
+    ``_wait_for_gateway_exit`` returns False only once its own force-kill
+    deadline has passed and the PID is *still* alive — it has already sent
+    SIGKILL and printed "still running after Ns — restart may fail". Naming
+    the restart in that warning is the whole point: the caller is about to
+    start a replacement, and doing so is worse than failing here.
+    gateway/run.py writes gateway.pid at startup, so the new process takes
+    over the survivor's record and the survivor becomes precisely the orphan
+    stop_profile_gateway() has to sweep for afterwards (#75936) — no longer
+    reachable through `hermes gateway stop`, still holding the webhook port
+    and the same bot token.
+
+    Never returns; exits non-zero the same way the service-restart failure
+    below it does.
+    """
+    print()
+    print(f"✗ Gateway {action} aborted — the previous gateway is still running.")
+    print(
+        "  Starting a second instance would take over the PID file and leave the"
+    )
+    print("  survivor unreachable from the CLI, holding the same port.")
+    print("  Check `hermes gateway status`, then retry once it is down.")
+    sys.exit(1)
+
+
 def launchd_restart():
     label = get_launchd_label()
     target = f"{_launchd_domain()}/{label}"
@@ -7886,10 +7913,14 @@ def _gateway_command_inner(args):
                 print(f"✓ Stopped {total} gateway process(es) across all profiles")
             # The service stop above and kill_gateway_processes() both signal
             # gracefully; escalate only once the manager's own budget is spent.
-            _wait_for_gateway_exit(
+            # A False here means the PID outlived even that SIGKILL, so the
+            # fresh start below would stack a second gateway on the first.
+            exited = _wait_for_gateway_exit(
                 timeout=_GATEWAY_STOP_WAIT_SECONDS,
                 force_after=_GATEWAY_STOP_GRACE_SECONDS,
             )
+            if not exited:
+                _abort_on_surviving_gateway("restart")
 
             # Start the current profile's service fresh
             print("Starting gateway...")

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -8017,10 +8017,15 @@ def _gateway_command_inner(args):
             # stop_profile_gateway() sends SIGTERM and polls for ~10s; keep
             # escalating no earlier than the service manager's own budget so a
             # slow drain finishes its teardown instead of being SIGKILLed.
-            _wait_for_gateway_exit(
+            # Nothing supervises this path, so an unheeded False here is worse
+            # than on the service branches: run_gateway() below runs the
+            # replacement in the foreground of this very shell.
+            exited = _wait_for_gateway_exit(
                 timeout=_GATEWAY_STOP_WAIT_SECONDS,
                 force_after=_GATEWAY_STOP_GRACE_SECONDS,
             )
+            if not exited:
+                _abort_on_surviving_gateway("restart")
 
             # Start fresh
             print("Starting gateway...")

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -4951,6 +4951,31 @@ def launchd_stop():
     print("✓ Service stopped")
 
 
+# Graceful-stop budget the CLI must not pre-empt.
+#
+# Every service manager we install already grants the gateway a drain window
+# before escalating SIGTERM -> SIGKILL itself: the launchd plist sets
+# ``ExitTimeOut`` to 25s (see the template in ``generate_launchd_plist``) and
+# the systemd unit sets ``TimeoutStopSec`` to ``max(60, drain + 30)``. 25s is
+# therefore the smallest budget any installed manager honours, and the CLI
+# must not force-kill inside it.
+#
+# The budget is not cosmetic. ``gateway/run.py`` runs its post-drain teardown
+# after the drain completes -- closing the SQLite session databases (releasing
+# the WAL write lock), removing the PID file, releasing the runtime lock, and
+# finally touching the ``.clean_shutdown`` marker. A SIGKILL sent inside the
+# budget skips all of it, so the next start finds a held WAL lock
+# ("database is locked"), a stale PID ("bot token already in use (PID ...)"),
+# and a missing ``.clean_shutdown`` marker, which suspends recently-active
+# sessions.
+_GATEWAY_STOP_GRACE_SECONDS = 25.0
+
+# Total time to wait for exit: the grace budget plus headroom to observe the
+# escalation actually land. The wait returns as soon as the PID is gone, so
+# this is a ceiling on a wedged stop, not an added delay on a healthy one.
+_GATEWAY_STOP_WAIT_SECONDS = _GATEWAY_STOP_GRACE_SECONDS + 5.0
+
+
 def _wait_for_gateway_exit(
     timeout: float = 10.0, force_after: float | None = 5.0
 ) -> bool:

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -7705,10 +7705,15 @@ def _gateway_command_inner(args):
                 )
                 # kill_gateway_processes() sends SIGTERM; give those drains the
                 # service manager's own budget before escalating to SIGKILL.
-                _wait_for_gateway_exit(
+                # If one outlives that too, do not go on to bootstrap a second
+                # instance against the same bot token and port — the outcome
+                # launchd_uninstall() keeps its plist to avoid.
+                exited = _wait_for_gateway_exit(
                     timeout=_GATEWAY_STOP_WAIT_SECONDS,
                     force_after=_GATEWAY_STOP_GRACE_SECONDS,
                 )
+                if not exited:
+                    _abort_on_surviving_gateway("start")
 
         if is_termux():
             print(

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -4923,6 +4923,7 @@ def launchd_start():
 def launchd_stop():
     label = get_launchd_label()
     target = f"{_launchd_domain()}/{label}"
+    pid = None
     try:
         from gateway.status import get_running_pid, write_planned_stop_marker
 
@@ -4930,24 +4931,51 @@ def launchd_stop():
         if pid is not None:
             write_planned_stop_marker(pid)
     except Exception:
-        pass
+        pid = None
     # bootout unloads the service definition so KeepAlive doesn't respawn
     # the process.  A plain `kill SIGTERM` only signals the process — launchd
     # immediately restarts it because KeepAlive is unconditionally true.
     # `hermes gateway start` re-bootstraps when it detects the job is unloaded.
+    launchd_owns_exit = True
     try:
         subprocess.run(["launchctl", "bootout", target], check=True, timeout=90)
     except subprocess.CalledProcessError as e:
         # Job already unloaded (3/113/125), or the domain can't be managed at
         # all (5/125, macOS 26+ detached-fallback process, issue #23387) — in
-        # both cases just fall through to the PID-based kill below.
+        # both cases launchd is not supervising this exit, so the CLI owns the
+        # stop and falls through to the PID-based path below.
         if _launchd_error_indicates_unloaded(e) or _launchctl_domain_unsupported(
             e.returncode
         ):
-            pass
+            launchd_owns_exit = False
         else:
             raise
-    _wait_for_gateway_exit(timeout=10.0, force_after=5.0)
+    if launchd_owns_exit:
+        # bootout succeeded, so launchd sent SIGTERM and will escalate to
+        # SIGKILL on its own once the plist's ExitTimeOut expires. Forcing from
+        # here would pre-empt that budget and amputate the post-drain teardown,
+        # so only wait — long enough to actually observe launchd's escalation
+        # rather than returning early and reporting a stop that has not
+        # happened. Mirrors launchd_restart(), which likewise passes
+        # force_after=None.
+        _wait_for_gateway_exit(timeout=_GATEWAY_STOP_WAIT_SECONDS, force_after=None)
+    else:
+        # Nothing is supervising this process — launchd never took the job, or
+        # the domain is unmanageable and the gateway is a detached fallback
+        # process (#23387). The CLI is the only thing that will ever signal it,
+        # and previously the only signal it sent was a SIGKILL 5s in, so the
+        # gateway never got a graceful stop at all on this path. Terminate
+        # gracefully first, then escalate no sooner than the budget launchd
+        # itself would have granted.
+        if pid is not None:
+            try:
+                terminate_pid(pid, force=False)
+            except (ProcessLookupError, PermissionError, OSError):
+                pass
+        _wait_for_gateway_exit(
+            timeout=_GATEWAY_STOP_WAIT_SECONDS,
+            force_after=_GATEWAY_STOP_GRACE_SECONDS,
+        )
     print("✓ Service stopped")
 
 

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -1732,6 +1732,12 @@ def _reap_unsupervised_gateway_orphans(extra_exclude: set | None = None) -> bool
     running gateway — gating on ``supports_systemd_services()`` keeps the
     orphan-aware scan from killing live management processes there.
 
+    On Windows ``os.kill(pid, SIGTERM)`` is TerminateProcess, so the
+    planned-stop marker written for each orphan is the only graceful stop
+    request that exists there. The marker is written and the immediate kill
+    is skipped; the survivor window below is the escalation, which makes
+    Windows match POSIX exactly — graceful request, 5 seconds, force-kill.
+
     Args:
         extra_exclude: Additional PIDs to skip (e.g. a PID already killed by
             the caller so the sweep doesn't send a redundant SIGTERM/SIGKILL).
@@ -1823,11 +1829,25 @@ def _reap_unsupervised_gateway_orphans(extra_exclude: set | None = None) -> bool
         return False
 
     reaped = False
+    windows = is_windows()
     for pid in orphans:
         try:
             write_planned_stop_marker(pid)
         except Exception:
             pass
+        if windows:
+            # On Windows the marker IS the stop request, and it is the only
+            # one there is: os.kill(pid, SIGTERM) below is TerminateProcess,
+            # which would destroy the orphan microseconds after the marker
+            # lands — before the planned-stop watcher's 0.5s poll can
+            # consume it — so the drain never runs and ``resume_pending`` is
+            # never set. Let the survivor window below supply the wait that
+            # the POSIX SIGTERM handler gets for free, then escalate. This
+            # spends the function's own existing 5s budget rather than
+            # adding one, so Windows now matches POSIX exactly: graceful
+            # request, 5 seconds, force-kill.
+            reaped = True
+            continue
         try:
             os.kill(pid, signal.SIGTERM)
         except ProcessLookupError:
@@ -1848,7 +1868,16 @@ def _reap_unsupervised_gateway_orphans(extra_exclude: set | None = None) -> bool
             time.sleep(0.2)
     for pid in survivors:
         try:
-            os.kill(pid, getattr(signal, "SIGKILL", signal.SIGTERM))
+            if windows:
+                # SIGKILL does not exist on Windows and the getattr fallback
+                # to SIGTERM is another bare TerminateProcess that strands
+                # the detached gateway's children. Use the same bounded
+                # tree-kill the Windows backend escalates with.
+                from gateway.status import terminate_pid
+
+                terminate_pid(pid, force=True)
+            else:
+                os.kill(pid, getattr(signal, "SIGKILL", signal.SIGTERM))
         except (ProcessLookupError, PermissionError, OSError):
             pass
 

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -1680,6 +1680,45 @@ def _reaper_candidate_is_supervisor_owned(pid: int) -> bool:
     return False
 
 
+def _drain_windows_gateway_pid(pid: int) -> bool:
+    """Ask a running Windows gateway to drain, and WAIT for it to exit.
+
+    ``os.kill(pid, signal.SIGTERM)`` is not a signal on Windows: only
+    ``CTRL_C_EVENT``/``CTRL_BREAK_EVENT`` map to a deliverable console
+    event, and every other value goes straight to OpenProcess +
+    TerminateProcess.  So a call site that writes the planned-stop marker
+    and then calls ``os.kill`` on the next statement destroys the gateway
+    microseconds after the marker lands — before the gateway's
+    planned-stop watcher (``gateway/run.py``, 0.5s poll) can consume it.
+    The drain never runs, the in-flight turn dies mid-generation, the
+    transcript tail is never flushed and ``resume_pending`` is never set,
+    so the next start does not auto-resume.
+
+    ``hermes_cli.gateway_windows._drain_gateway_pid()`` is the reference
+    implementation of the correct sequence — it writes the same marker and
+    then waits — so reuse it here instead of racing it.  The window is the
+    Windows backend's own configured stop budget, the same one
+    ``gateway_windows.stop()`` already spends on this exact operation.
+
+    Returns True only when the PID actually exited inside the window.
+    False — including on any import or backend error — means the caller
+    must escalate to a force-kill.
+    """
+    if not pid or pid <= 0:
+        return False
+    try:
+        from hermes_cli.gateway_windows import (
+            _drain_gateway_pid,
+            _windows_stop_drain_timeout,
+        )
+    except Exception:
+        return False
+    try:
+        return bool(_drain_gateway_pid(pid, _windows_stop_drain_timeout()))
+    except Exception:
+        return False
+
+
 def _reap_unsupervised_gateway_orphans(extra_exclude: set | None = None) -> bool:
     """Kill no-supervisor gateway orphans the pidfile/runtime record can't see.
 
@@ -1835,6 +1874,11 @@ def stop_profile_gateway() -> bool:
     the old process exited. After killing the recorded PID, also sweep for
     any remaining orphans so each restart produces at most one live gateway
     (#75936).
+
+    On Windows the planned-stop marker is the ONLY way to ask a running
+    gateway to drain, and ``os.kill(pid, SIGTERM)`` there is
+    TerminateProcess — so the marker is drained-for via
+    ``_drain_windows_gateway_pid()`` before any termination is attempted.
     """
     try:
         from gateway.status import get_running_pid, remove_pid_file
@@ -1845,20 +1889,41 @@ def stop_profile_gateway() -> bool:
     if pid is None:
         return _reap_unsupervised_gateway_orphans()
 
-    try:
-        from gateway.status import write_planned_stop_marker
+    # On Windows the marker written below is inert: os.kill(pid, SIGTERM)
+    # is TerminateProcess, so the gateway dies before its planned-stop
+    # watcher can poll for the marker and the drain is skipped entirely.
+    # Route through the Windows backend's drain helper, which writes the
+    # same marker and then waits, and escalate only once that bounded
+    # window is spent.
+    drained = _drain_windows_gateway_pid(pid) if is_windows() else False
 
-        write_planned_stop_marker(pid)
-    except Exception:
-        pass
+    if not drained:
+        try:
+            from gateway.status import write_planned_stop_marker
 
-    try:
-        os.kill(pid, signal.SIGTERM)
-    except ProcessLookupError:
-        pass  # Already gone
-    except PermissionError:
-        print(f"⚠ Permission denied to kill PID {pid}")
-        return False
+            write_planned_stop_marker(pid)
+        except Exception:
+            pass
+
+        try:
+            if is_windows():
+                from gateway.status import terminate_pid
+
+                # The drain window is spent — escalate with the same
+                # bounded tree-kill the Windows backend uses
+                # (``taskkill /T /F``), not a bare TerminateProcess that
+                # would strand the detached gateway's children.
+                terminate_pid(pid, force=True)
+            else:
+                os.kill(pid, signal.SIGTERM)
+        except ProcessLookupError:
+            pass  # Already gone
+        except PermissionError:
+            print(f"⚠ Permission denied to kill PID {pid}")
+            return False
+        except OSError as exc:
+            print(f"⚠ Failed to stop gateway PID {pid}: {exc}")
+            return False
 
     # Wait briefly for it to exit. On Windows, os.kill(pid, 0) is NOT
     # a no-op — route through the cross-platform existence check.

--- a/tests/hermes_cli/test_gateway.py
+++ b/tests/hermes_cli/test_gateway.py
@@ -587,19 +587,27 @@ class TestReapUnsupervisedGatewayOrphansWindows:
         )
 
         killed_pids = []
+        marked_pids = []
         monkeypatch.setattr(gateway.os, "kill", lambda pid, sig: killed_pids.append((pid, sig)))
         monkeypatch.setattr("gateway.status._pid_exists", lambda pid: False)
-        monkeypatch.setattr("gateway.status.write_planned_stop_marker", lambda pid: None)
+        monkeypatch.setattr(
+            "gateway.status.write_planned_stop_marker", lambda pid: marked_pids.append(pid)
+        )
         monkeypatch.setattr("time.sleep", lambda _: None)
         monkeypatch.setattr("time.monotonic", lambda: 1.0)
 
         result = gateway._reap_unsupervised_gateway_orphans()
 
         assert result is True  # at least one orphan was reaped
+        # On Windows the planned-stop marker IS the stop request — os.kill
+        # there is TerminateProcess, so observing the marker (not the kill)
+        # is what tells us the orphan was acted on.
         killed = [pid for pid, _ in killed_pids]
-        assert orphan_pid in killed       # the real orphan was killed
-        assert recorded_pid not in killed  # the recorded gateway was NOT killed
-        assert bootstrap_pid not in killed  # its supervision chain was NOT killed
+        assert orphan_pid in marked_pids      # the real orphan was asked to drain
+        assert recorded_pid not in marked_pids   # the recorded gateway was NOT touched
+        assert recorded_pid not in killed        # ... by either route
+        assert bootstrap_pid not in marked_pids  # its supervision chain was NOT touched
+        assert bootstrap_pid not in killed
 
     def test_windows_no_orphans_when_only_recorded_gateway_running(self, monkeypatch):
         """If the only gateway processes are the recorded one and its
@@ -695,19 +703,26 @@ class TestReaperCandidateIsSupervisorOwned:
         )
 
         killed_pids = []
+        marked_pids = []
         monkeypatch.setattr(gateway.os, "kill", lambda pid, sig: killed_pids.append((pid, sig)))
         monkeypatch.setattr("gateway.status._pid_exists", lambda pid: False)
-        monkeypatch.setattr("gateway.status.write_planned_stop_marker", lambda pid: None)
+        monkeypatch.setattr(
+            "gateway.status.write_planned_stop_marker", lambda pid: marked_pids.append(pid)
+        )
         monkeypatch.setattr("time.sleep", lambda _: None)
         monkeypatch.setattr("time.monotonic", lambda: 1.0)
 
         result = gateway._reap_unsupervised_gateway_orphans()
 
         assert result is True              # the genuine orphan was reaped
+        # Windows acts on an orphan by writing the planned-stop marker; the
+        # hard kill is the escalation for whatever outlives the drain window.
         killed = [pid for pid, _ in killed_pids]
-        assert orphan_pid in killed          # orphan killed
-        assert gateway_pid not in killed     # supervisor-owned gateway spared (no pidfile!)
-        assert bootstrap_pid not in killed   # its bootstrap spared too
+        assert orphan_pid in marked_pids       # orphan asked to drain
+        assert gateway_pid not in marked_pids  # supervisor-owned gateway spared (no pidfile!)
+        assert gateway_pid not in killed
+        assert bootstrap_pid not in marked_pids  # its bootstrap spared too
+        assert bootstrap_pid not in killed
 
     def test_macos_orphan_reparented_to_launchd_is_still_reaped(self, monkeypatch):
         """POSIX inertness guard: a genuine macOS orphan is reparented directly
@@ -846,16 +861,21 @@ class TestWindowsScheduledTaskSupervisorGuard:
             ],
         )
         killed_pids = []
+        marked_pids = []
         monkeypatch.setattr(gateway.os, "kill", lambda pid, sig: killed_pids.append((pid, sig)))
         monkeypatch.setattr("gateway.status._pid_exists", lambda pid: False)
-        monkeypatch.setattr("gateway.status.write_planned_stop_marker", lambda pid: None)
+        monkeypatch.setattr(
+            "gateway.status.write_planned_stop_marker", lambda pid: marked_pids.append(pid)
+        )
         monkeypatch.setattr("time.sleep", lambda _: None)
         monkeypatch.setattr("time.monotonic", lambda: 1.0)
 
         result = gateway._reap_unsupervised_gateway_orphans()
 
         assert result is True
-        assert orphan_pid in [pid for pid, _ in killed_pids]
+        # The reaper's Windows stop request is the planned-stop marker — which
+        # is exactly what this class's own docstring already describes it doing.
+        assert orphan_pid in marked_pids
 
     def test_windows_scheduled_task_running_returns_false_off_windows(self, monkeypatch):
         """The state helper is inert on POSIX (no subprocess spawned)."""

--- a/tests/hermes_cli/test_gateway.py
+++ b/tests/hermes_cli/test_gateway.py
@@ -461,6 +461,131 @@ class TestStopProfileGateway:
         assert killed_pid in reap_extra_excludes[0]
 
 
+class TestStopProfileGatewayWindowsDrain:
+    """``hermes gateway stop`` must let a Windows gateway drain, not kill it.
+
+    ``os.kill(pid, signal.SIGTERM)`` is not a signal on Windows: only
+    ``CTRL_C_EVENT``/``CTRL_BREAK_EVENT`` map to a deliverable console event
+    and everything else goes straight to OpenProcess + TerminateProcess. So
+    writing the planned-stop marker and killing on the next statement
+    destroys the gateway microseconds later — before the planned-stop
+    watcher in ``gateway/run.py`` (0.5s poll) can consume the marker. The
+    drain is skipped: the in-flight turn dies mid-generation, the transcript
+    tail is never flushed and ``resume_pending`` is never set, so the next
+    start does not auto-resume.
+
+    This is reachable at the default install state. The stop dispatcher only
+    routes to ``gateway_windows.stop()`` behind ``is_installed()``
+    (``is_task_registered() or is_startup_entry_installed()``), both of which
+    require an explicit ``hermes gateway install`` — so a Windows user who
+    started with ``hermes gateway`` or the Desktop app lands here instead.
+
+    Host-agnostic: ``is_windows()`` is monkeypatched, so these run on POSIX CI.
+    """
+
+    @staticmethod
+    def _arrange_stop(monkeypatch, pid, *, windows, drained):
+        """Wire stop_profile_gateway's seams; returns the ordered event log."""
+        events = []
+
+        monkeypatch.setattr(gateway, "is_windows", lambda: windows)
+        monkeypatch.setattr("gateway.status.get_running_pid", lambda: pid)
+        monkeypatch.setattr("gateway.status.remove_pid_file", lambda: None)
+        monkeypatch.setattr("gateway.status._pid_exists", lambda _pid: False)
+        monkeypatch.setattr("time.sleep", lambda _s: None)
+        monkeypatch.setattr(
+            gateway,
+            "_reap_unsupervised_gateway_orphans",
+            lambda extra_exclude=None: False,
+        )
+
+        def _fake_drain(drain_pid):
+            events.append(("drain", drain_pid))
+            return drained
+
+        # raising=False keeps the arrangement itself neutral: the assertions
+        # below are about the ORDER of the recorded events, so a build that
+        # never consults the drain seam must fail on "marker then os.kill",
+        # not on the stub failing to install.
+        monkeypatch.setattr(
+            gateway, "_drain_windows_gateway_pid", _fake_drain, raising=False
+        )
+        monkeypatch.setattr(
+            "gateway.status.write_planned_stop_marker",
+            lambda marker_pid: events.append(("marker", marker_pid)),
+        )
+        monkeypatch.setattr(
+            "gateway.status.terminate_pid",
+            lambda term_pid, force=False: events.append(("terminate", term_pid, force)),
+        )
+        monkeypatch.setattr(
+            gateway.os,
+            "kill",
+            lambda kill_pid, sig: events.append(("os.kill", kill_pid, sig)),
+        )
+        return events
+
+    def test_windows_stop_drains_and_never_terminates(self, monkeypatch):
+        """A gateway that exits inside the drain window is never killed at all."""
+        events = self._arrange_stop(monkeypatch, 4242, windows=True, drained=True)
+
+        assert gateway.stop_profile_gateway() is True
+        # Nothing but the drain: no marker rewrite, no TerminateProcess, no
+        # taskkill. This is the assertion that fails on the pre-fix code path,
+        # where os.kill lands microseconds after the marker.
+        assert events == [("drain", 4242)]
+
+    def test_windows_stop_drains_before_escalating(self, monkeypatch):
+        """Only once the bounded window is spent may the stop escalate."""
+        events = self._arrange_stop(monkeypatch, 4242, windows=True, drained=False)
+
+        assert gateway.stop_profile_gateway() is True
+        kinds = [event[0] for event in events]
+        assert "drain" in kinds and "terminate" in kinds
+        assert kinds.index("drain") < kinds.index("terminate")
+        # Escalation is the backend's bounded tree-kill, not a bare
+        # TerminateProcess that strands the detached gateway's children.
+        assert ("terminate", 4242, True) in events
+        assert not any(event[0] == "os.kill" for event in events)
+
+    def test_posix_stop_path_is_unchanged(self, monkeypatch):
+        """POSIX still signals directly — the drain helper is Windows-only."""
+        events = self._arrange_stop(monkeypatch, 4242, windows=False, drained=True)
+
+        assert gateway.stop_profile_gateway() is True
+        assert not any(event[0] == "drain" for event in events)
+        assert ("marker", 4242) in events
+        assert ("os.kill", 4242, signal.SIGTERM) in events
+        kinds = [event[0] for event in events]
+        assert kinds.index("marker") < kinds.index("os.kill")
+
+    def test_drain_helper_delegates_to_the_windows_backend(self, monkeypatch):
+        """Reuse gateway_windows' drain and its configured stop budget.
+
+        ``_drain_gateway_pid`` is the reference implementation of the correct
+        sequence (write the marker, then WAIT); re-implementing the wait here
+        would be a second mechanism to keep in step.
+        """
+        import hermes_cli.gateway_windows as gateway_windows
+
+        seen = {}
+        monkeypatch.setattr(gateway_windows, "_windows_stop_drain_timeout", lambda: 7.5)
+
+        def _fake_drain(pid, drain_timeout):
+            seen["args"] = (pid, drain_timeout)
+            return True
+
+        monkeypatch.setattr(gateway_windows, "_drain_gateway_pid", _fake_drain)
+
+        assert gateway._drain_windows_gateway_pid(4242) is True
+        assert seen["args"] == (4242, 7.5)
+
+    def test_drain_helper_reports_failure_for_an_unusable_pid(self):
+        """A non-PID must report "not drained" so the caller still escalates."""
+        assert gateway._drain_windows_gateway_pid(0) is False
+        assert gateway._drain_windows_gateway_pid(-1) is False
+
+
 class TestReapUnsupervisedGatewayOrphansMacOS:
     """Tests that the orphan reaper excludes launchd-managed PIDs on macOS.
 

--- a/tests/hermes_cli/test_gateway.py
+++ b/tests/hermes_cli/test_gateway.py
@@ -771,6 +771,108 @@ class TestReapUnsupervisedGatewayOrphansWindows:
         assert killed_pids == []  # nothing was killed
 
 
+class TestReapUnsupervisedGatewayOrphansWindowsDrain:
+    """The orphan reaper must let a Windows orphan consume its marker.
+
+    ``_reap_unsupervised_gateway_orphans()`` writes the planned-stop marker
+    for every orphan and then signals it — and it is not POSIX-only, so on
+    Windows that signal is TerminateProcess and the marker it just wrote is
+    destroyed before the gateway's planned-stop watcher can poll for it.
+
+    The corrected sequence spends no new time budget. POSIX is SIGTERM (the
+    handler drains) -> 5s survivor wait -> SIGKILL; Windows now writes the
+    marker, skips the immediate kill, and reuses that same 5s survivor
+    window as the drain before escalating.
+
+    Host-agnostic: ``is_windows()`` is monkeypatched, so these run on POSIX CI.
+    """
+
+    @staticmethod
+    def _arrange_reap(monkeypatch, orphan_pid, *, windows, alive):
+        """Reduce the reaper to a single orphan; returns the ordered event log."""
+        events = []
+
+        monkeypatch.setattr(gateway, "is_windows", lambda: windows)
+        monkeypatch.setattr(gateway, "is_macos", lambda: False)
+        monkeypatch.setattr(gateway, "supports_systemd_services", lambda: False)
+        monkeypatch.setattr(
+            gateway, "_windows_scheduled_task_running", lambda _name: False
+        )
+        monkeypatch.setattr("gateway.status.get_running_pid", lambda: None)
+        monkeypatch.setattr(gateway, "_get_service_pids", lambda: set())
+        monkeypatch.setattr(
+            gateway, "_reaper_candidate_is_supervisor_owned", lambda _pid: False
+        )
+        monkeypatch.setattr(
+            gateway,
+            "find_gateway_pids",
+            lambda exclude_pids=None: [
+                p for p in [orphan_pid] if p not in (exclude_pids or set())
+            ],
+        )
+        monkeypatch.setattr(
+            "gateway.status.write_planned_stop_marker",
+            lambda marker_pid: events.append(("marker", marker_pid)),
+        )
+        monkeypatch.setattr(
+            gateway.os,
+            "kill",
+            lambda kill_pid, sig: events.append(("os.kill", kill_pid, sig)),
+        )
+        monkeypatch.setattr(
+            "gateway.status.terminate_pid",
+            lambda term_pid, force=False: events.append(("terminate", term_pid, force)),
+        )
+        monkeypatch.setattr("time.sleep", lambda _s: None)
+        monkeypatch.setattr("gateway.status._pid_exists", lambda _pid: alive)
+        if alive:
+            # Advance the clock on every read so the survivor window closes.
+            clock = {"now": 0.0}
+
+            def _monotonic():
+                clock["now"] += 1.0
+                return clock["now"]
+
+            monkeypatch.setattr("time.monotonic", _monotonic)
+        else:
+            monkeypatch.setattr("time.monotonic", lambda: 1.0)
+        return events
+
+    def test_windows_orphan_is_asked_to_drain_not_terminated(self, monkeypatch):
+        """An orphan that honours the marker exits without ever being killed."""
+        events = self._arrange_reap(monkeypatch, 99998, windows=True, alive=False)
+
+        assert gateway._reap_unsupervised_gateway_orphans() is True
+        # Pre-fix this reads [("marker", ...), ("os.kill", ..., SIGTERM)] —
+        # the marker and the TerminateProcess that makes it unreadable.
+        assert events == [("marker", 99998)]
+
+    def test_windows_orphan_outliving_the_window_is_force_killed(self, monkeypatch):
+        """The survivor window is the escalation, not a reason to skip it."""
+        events = self._arrange_reap(monkeypatch, 99998, windows=True, alive=True)
+
+        assert gateway._reap_unsupervised_gateway_orphans() is True
+        kinds = [event[0] for event in events]
+        assert "marker" in kinds and "terminate" in kinds
+        assert kinds.index("marker") < kinds.index("terminate")
+        # SIGKILL does not exist on Windows and the SIGTERM fallback is
+        # another bare TerminateProcess; escalate with the backend's
+        # bounded tree-kill instead.
+        assert ("terminate", 99998, True) in events
+        assert not any(event[0] == "os.kill" for event in events)
+
+    def test_posix_orphan_reap_is_unchanged(self, monkeypatch):
+        """POSIX still signals immediately — a guard on the untouched path."""
+        events = self._arrange_reap(monkeypatch, 99998, windows=False, alive=False)
+
+        assert gateway._reap_unsupervised_gateway_orphans() is True
+        assert ("marker", 99998) in events
+        assert ("os.kill", 99998, signal.SIGTERM) in events
+        kinds = [event[0] for event in events]
+        assert kinds.index("marker") < kinds.index("os.kill")
+        assert not any(event[0] == "terminate" for event in events)
+
+
 class TestReaperCandidateIsSupervisorOwned:
     """Regression for the Windows pidfile-less supervisor-owned case (#83683).
 

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -2,6 +2,7 @@
 
 import os
 import plistlib
+import re
 import subprocess
 from pathlib import Path
 from types import SimpleNamespace
@@ -2060,3 +2061,180 @@ class TestRetryLaunchctlBootstrapUntilRegistered:
         )
         assert ok is False
         assert list_calls["n"] >= 1
+
+
+class TestGatewayStopGraceBudget:
+    """The CLI must not force-kill the gateway inside the service manager's
+    own graceful-stop budget.
+
+    The installed launchd plist sets ``ExitTimeOut`` to 25s and the systemd
+    unit sets ``TimeoutStopSec`` to ``max(60, drain + 30)``, both so the
+    gateway can finish draining and run gateway/run.py's post-drain teardown
+    (closing the SQLite session DBs to release the WAL write lock, removing
+    the PID file, releasing the runtime lock, writing ``.clean_shutdown``).
+    Every CLI stop path used to SIGKILL 5s in, skipping all of it.
+    """
+
+    LABEL = "ai.hermes.gateway"
+    DOMAIN = "gui/501"
+    PID = 4242
+    # The smallest graceful-stop budget any service manager we install grants
+    # (the launchd plist's ExitTimeOut; the systemd unit's TimeoutStopSec is
+    # never below 60s). The CLI's escalation must not land before this.
+    MIN_PLATFORM_STOP_BUDGET = 25.0
+
+    def _stub_launchd_stop(self, monkeypatch, *, bootout_error=None):
+        """Drive launchd_stop() with launchctl and the exit wait instrumented."""
+        waits = []
+        terminations = []
+
+        monkeypatch.setattr(gateway_cli, "get_launchd_label", lambda: self.LABEL)
+        monkeypatch.setattr(gateway_cli, "_launchd_domain", lambda: self.DOMAIN)
+        monkeypatch.setattr(
+            "gateway.status.get_running_pid", lambda *_a, **_k: self.PID
+        )
+        monkeypatch.setattr(
+            "gateway.status.write_planned_stop_marker", lambda *_a, **_k: None
+        )
+
+        def fake_run(cmd, **_kwargs):
+            assert cmd == ["launchctl", "bootout", f"{self.DOMAIN}/{self.LABEL}"]
+            if bootout_error is not None:
+                raise bootout_error
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
+        monkeypatch.setattr(
+            gateway_cli,
+            "_wait_for_gateway_exit",
+            lambda timeout=None, force_after=None: (
+                waits.append((timeout, force_after)) or True
+            ),
+        )
+        monkeypatch.setattr(
+            gateway_cli,
+            "terminate_pid",
+            lambda pid, force=False: terminations.append((pid, force)),
+        )
+        return waits, terminations
+
+    def test_stop_leaves_escalation_to_launchd_after_successful_bootout(
+        self, monkeypatch
+    ):
+        """bootout succeeded, so launchd owns the SIGTERM -> SIGKILL escalation.
+
+        The CLI must not send a kill of its own inside ExitTimeOut, and must
+        wait long enough to actually observe launchd's escalation instead of
+        returning at 10s and reporting a stop that has not happened.
+        """
+        waits, terminations = self._stub_launchd_stop(monkeypatch)
+
+        gateway_cli.launchd_stop()
+
+        assert len(waits) == 1
+        timeout, force_after = waits[0]
+        assert force_after is None, "CLI must not pre-empt launchd's ExitTimeOut"
+        assert timeout >= self.MIN_PLATFORM_STOP_BUDGET
+        assert terminations == [], "no signal is owed; bootout already sent SIGTERM"
+
+    @pytest.mark.parametrize(
+        "returncode, why",
+        [
+            (3, "job already unloaded"),
+            (5, "domain unmanageable, detached fallback process (#23387)"),
+        ],
+    )
+    def test_stop_signals_gracefully_when_launchd_is_not_supervising(
+        self, monkeypatch, returncode, why
+    ):
+        """When bootout falls through, nothing else will ever signal the process.
+
+        The CLI owns the whole stop here. It previously sent no SIGTERM at all
+        on this path -- the only signal was a SIGKILL 5s in -- so a detached
+        fallback gateway never got a graceful stop. It must now terminate
+        gracefully first and escalate no sooner than the budget launchd itself
+        would have granted.
+        """
+        waits, terminations = self._stub_launchd_stop(
+            monkeypatch,
+            bootout_error=subprocess.CalledProcessError(
+                returncode, ["launchctl", "bootout"]
+            ),
+        )
+
+        gateway_cli.launchd_stop()
+
+        assert terminations == [(self.PID, False)], f"expected a SIGTERM ({why})"
+        assert len(waits) == 1
+        timeout, force_after = waits[0]
+        assert force_after >= self.MIN_PLATFORM_STOP_BUDGET
+        assert timeout > force_after, "the wait must outlast its own escalation"
+
+    def test_stop_still_reraises_unexpected_launchctl_failures(self, monkeypatch):
+        """Only the unloaded/unmanageable codes fall through to the PID path."""
+        self._stub_launchd_stop(
+            monkeypatch,
+            bootout_error=subprocess.CalledProcessError(
+                1, ["launchctl", "bootout"]
+            ),
+        )
+
+        with pytest.raises(subprocess.CalledProcessError):
+            gateway_cli.launchd_stop()
+
+    def test_start_all_waits_out_the_budget_before_force_killing(self, monkeypatch):
+        """`gateway start --all` SIGTERMs every stale gateway, then escalates.
+
+        kill_gateway_processes() terminates with force=False, so this wait is
+        purely the escalation backstop and must sit at the platform budget.
+        """
+        waits = []
+
+        monkeypatch.setattr(
+            gateway_cli, "kill_gateway_processes", lambda **_kwargs: 2
+        )
+        monkeypatch.setattr(
+            gateway_cli,
+            "_wait_for_gateway_exit",
+            lambda timeout=None, force_after=None: (
+                waits.append((timeout, force_after)) or True
+            ),
+        )
+        monkeypatch.setattr(gateway_cli, "is_termux", lambda: False)
+        monkeypatch.setattr(gateway_cli, "supports_systemd_services", lambda: True)
+        monkeypatch.setattr(gateway_cli, "systemd_start", lambda system=False: None)
+
+        gateway_cli.gateway_command(
+            SimpleNamespace(gateway_command="start", all=True)
+        )
+
+        assert len(waits) == 1
+        timeout, force_after = waits[0]
+        assert force_after >= self.MIN_PLATFORM_STOP_BUDGET, (
+            "force-kill must not land inside the service manager's own budget"
+        )
+        assert timeout > force_after
+
+    def test_cli_grace_never_pre_empts_the_installed_plist_exit_timeout(
+        self, tmp_path, monkeypatch
+    ):
+        """Drift guard tying the CLI's grace to the plist the CLI installs.
+
+        This is the invariant the whole change rests on: whatever ExitTimeOut
+        the generated plist carries, the CLI must not escalate before it. The
+        assertion is one-sided on purpose -- raising ExitTimeOut is always safe,
+        while lowering it below the CLI's grace silently reintroduces the
+        force-kill-inside-the-budget defect this class exists to prevent.
+        """
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+        plist = gateway_cli.generate_launchd_plist()
+        match = re.search(
+            r"<key>ExitTimeOut</key>\s*<integer>(\d+)</integer>", plist
+        )
+        assert match is not None, "plist no longer declares ExitTimeOut"
+        exit_timeout = float(match.group(1))
+        assert exit_timeout >= gateway_cli._GATEWAY_STOP_GRACE_SECONDS, (
+            "the CLI would force-kill before launchd's own escalation"
+        )
+        assert exit_timeout >= self.MIN_PLATFORM_STOP_BUDGET

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -2083,8 +2083,13 @@ class TestGatewayStopGraceBudget:
     # never below 60s). The CLI's escalation must not land before this.
     MIN_PLATFORM_STOP_BUDGET = 25.0
 
-    def _stub_launchd_stop(self, monkeypatch, *, bootout_error=None):
-        """Drive launchd_stop() with launchctl and the exit wait instrumented."""
+    def _stub_launchd_stop(self, monkeypatch, *, bootout_error=None, exit_result=True):
+        """Drive launchd_stop() with launchctl and the exit wait instrumented.
+
+        ``exit_result`` is what the stubbed ``_wait_for_gateway_exit`` returns:
+        True for a gateway that exited inside the budget, False for one whose
+        PID is still alive when the wait gives up.
+        """
         waits = []
         terminations = []
 
@@ -2108,7 +2113,7 @@ class TestGatewayStopGraceBudget:
             gateway_cli,
             "_wait_for_gateway_exit",
             lambda timeout=None, force_after=None: (
-                waits.append((timeout, force_after)) or True
+                waits.append((timeout, force_after)) or exit_result
             ),
         )
         monkeypatch.setattr(
@@ -2136,6 +2141,35 @@ class TestGatewayStopGraceBudget:
         assert force_after is None, "CLI must not pre-empt launchd's ExitTimeOut"
         assert timeout >= self.MIN_PLATFORM_STOP_BUDGET
         assert terminations == [], "no signal is owed; bootout already sent SIGTERM"
+
+    @pytest.mark.parametrize("exited", [True, False])
+    def test_stop_claims_success_only_when_launchd_actually_reaped_the_process(
+        self, monkeypatch, capsys, exited
+    ):
+        """The success line must follow the wait's verdict, not just its return.
+
+        Waiting out launchd's ExitTimeOut instead of force-killing inside it
+        makes "the budget expired and the PID is still alive" a reachable
+        outcome rather than the near-impossibility it was when the CLI
+        SIGKILLed 5s in. _wait_for_gateway_exit() reports that by printing the
+        surviving PID and returning False, so an unconditional "✓ Service
+        stopped" prints directly underneath its own warning and tells the
+        operator the opposite of what happened -- who then restarts onto a
+        gateway still holding the WAL write lock, the PID file and the
+        runtime lock.
+        """
+        self._stub_launchd_stop(monkeypatch, exit_result=exited)
+
+        gateway_cli.launchd_stop()
+
+        out = capsys.readouterr().out
+        assert ("✓ Service stopped" in out) is exited, (
+            "the stop reported success without observing the process exit"
+            if not exited
+            else "a clean stop must still report success"
+        )
+        if not exited:
+            assert "still running" in out, "a failed stop must say so"
 
     @pytest.mark.parametrize(
         "returncode, why",

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -2551,3 +2551,41 @@ class TestStartsRefuseToStackOnASurvivingGateway:
             if not exited
             else "a cleared restart must still start the replacement"
         )
+
+    @pytest.mark.parametrize("exited", [True, False])
+    def test_start_all_starts_only_once_the_stale_process_is_gone(
+        self, monkeypatch, capsys, exited
+    ):
+        """`gateway start --all` sweeps stale processes, then starts one.
+
+        The wait is scoped to the current profile's pid record, so a False
+        here means the very profile about to be started is the one still
+        running -- the case where starting bootstraps the second instance
+        against the same bot token and port that launchd_uninstall() keeps
+        its plist to avoid.
+        """
+        monkeypatch.delenv("_HERMES_GATEWAY", raising=False)
+        started = self._record_starts(monkeypatch)
+        monkeypatch.setattr(gateway_cli, "kill_gateway_processes", lambda **_k: 2)
+        monkeypatch.setattr(gateway_cli, "is_termux", lambda: False)
+        monkeypatch.setattr(gateway_cli, "supports_systemd_services", lambda: True)
+        monkeypatch.setattr(
+            gateway_cli, "_wait_for_gateway_exit", lambda **_k: exited
+        )
+
+        args = SimpleNamespace(gateway_command="start", all=True)
+        if exited:
+            gateway_cli.gateway_command(args)
+        else:
+            with pytest.raises(SystemExit) as excinfo:
+                gateway_cli.gateway_command(args)
+            assert excinfo.value.code == 1, "a refused start must exit non-zero"
+
+        assert (started == ["systemd"]) is exited, (
+            "a second gateway was started over the stale one"
+            if not exited
+            else "a cleared sweep must still start the service"
+        )
+        if not exited:
+            out = capsys.readouterr().out
+            assert "still running" in out, "the operator needs to know why"

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -2249,6 +2249,89 @@ class TestGatewayStopGraceBudget:
         with pytest.raises(subprocess.CalledProcessError):
             gateway_cli.launchd_stop()
 
+    def _stub_launchd_uninstall(
+        self, monkeypatch, plist_path, *, bootout_returncode=0, exit_result=True
+    ):
+        """Drive launchd_uninstall() with launchctl and the exit wait instrumented.
+
+        ``fake_run`` honours the ``check`` kwarg the way subprocess.run does,
+        so the same stub faithfully models the pre-fix call (``check=False``,
+        which never raises and hands back a returncode nobody reads) and the
+        fixed one (``check=True``, which raises CalledProcessError).
+        """
+        waits = []
+        terminations = []
+
+        monkeypatch.setattr(gateway_cli, "get_launchd_label", lambda: self.LABEL)
+        monkeypatch.setattr(gateway_cli, "_launchd_domain", lambda: self.DOMAIN)
+        monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: plist_path)
+        monkeypatch.setattr(
+            "gateway.status.get_running_pid", lambda *_a, **_k: self.PID
+        )
+        monkeypatch.setattr(
+            "gateway.status.write_planned_stop_marker", lambda *_a, **_k: None
+        )
+
+        def fake_run(cmd, check=False, **_kwargs):
+            assert cmd == ["launchctl", "bootout", f"{self.DOMAIN}/{self.LABEL}"]
+            if bootout_returncode:
+                if check:
+                    raise subprocess.CalledProcessError(bootout_returncode, cmd)
+                return SimpleNamespace(
+                    returncode=bootout_returncode, stdout="", stderr=""
+                )
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
+        monkeypatch.setattr(
+            gateway_cli,
+            "_wait_for_gateway_exit",
+            lambda timeout=None, force_after=None: (
+                waits.append((timeout, force_after)) or exit_result
+            ),
+        )
+        monkeypatch.setattr(
+            gateway_cli,
+            "terminate_pid",
+            lambda pid, force=False: terminations.append((pid, force)),
+        )
+        return waits, terminations
+
+    @pytest.mark.parametrize(
+        "returncode, why",
+        [
+            (3, "job already unloaded"),
+            (5, "domain unmanageable, detached fallback process (#23387)"),
+        ],
+    )
+    def test_uninstall_owns_the_stop_when_launchd_is_not_supervising(
+        self, monkeypatch, tmp_path, returncode, why
+    ):
+        """Uninstall took the same bootout fall-through as stop, sending nothing.
+
+        `launchctl bootout` ran with check=False and its result was discarded,
+        so on the fall-through -- where launchd never took the job and will
+        never signal it -- uninstall removed the service definition without
+        ever asking the process to exit. It must own the stop here exactly as
+        launchd_stop() does: SIGTERM first, then escalate no sooner than the
+        budget launchd itself would have granted.
+        """
+        plist_path = tmp_path / "ai.hermes.gateway.plist"
+        plist_path.write_text("<plist/>")
+        waits, terminations = self._stub_launchd_uninstall(
+            monkeypatch, plist_path, bootout_returncode=returncode
+        )
+
+        gateway_cli.launchd_uninstall()
+
+        assert terminations == [(self.PID, False)], f"expected a SIGTERM ({why})"
+        assert len(waits) == 1
+        timeout, force_after = waits[0]
+        assert force_after >= self.MIN_PLATFORM_STOP_BUDGET, (
+            "force-kill must not land inside the service manager's own budget"
+        )
+        assert timeout > force_after, "the wait must outlast its own escalation"
+
     def test_start_all_waits_out_the_budget_before_force_killing(self, monkeypatch):
         """`gateway start --all` SIGTERMs every stale gateway, then escalates.
 

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -2332,6 +2332,47 @@ class TestGatewayStopGraceBudget:
         )
         assert timeout > force_after, "the wait must outlast its own escalation"
 
+    @pytest.mark.parametrize(
+        "bootout_returncode, ownership",
+        [
+            (0, "launchd owns the escalation"),
+            (5, "the CLI owns it — detached fallback process (#23387)"),
+        ],
+    )
+    def test_uninstall_keeps_the_plist_when_the_gateway_survives(
+        self, monkeypatch, tmp_path, capsys, bootout_returncode, ownership
+    ):
+        """Deleting the service definition under a live gateway strands the user.
+
+        With the plist gone there is no supported way back: `hermes gateway
+        stop` takes the same unsupervised fall-through, and `hermes gateway
+        start` bootstraps a SECOND instance against the same bot token and
+        port. So when the wait reports the PID still alive, uninstall must
+        keep the plist and say so rather than printing its two success lines.
+        The rule holds whichever side owned the escalation.
+        """
+        plist_path = tmp_path / "ai.hermes.gateway.plist"
+        plist_path.write_text("<plist/>")
+        self._stub_launchd_uninstall(
+            monkeypatch,
+            plist_path,
+            bootout_returncode=bootout_returncode,
+            exit_result=False,
+        )
+
+        gateway_cli.launchd_uninstall()
+
+        out = capsys.readouterr().out
+        assert plist_path.exists(), (
+            f"the plist is the only way left to stop the gateway ({ownership})"
+        )
+        assert "✓ Removed" not in out
+        assert "✓ Service uninstalled" not in out, (
+            "uninstall reported success for a gateway that is still running"
+        )
+        assert "still running" in out
+        assert "hermes gateway stop" in out, "the operator needs the way out"
+
     def test_start_all_waits_out_the_budget_before_force_killing(self, monkeypatch):
         """`gateway start --all` SIGTERMs every stale gateway, then escalates.
 

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -2429,3 +2429,125 @@ class TestGatewayStopGraceBudget:
             "the CLI would force-kill before launchd's own escalation"
         )
         assert exit_timeout >= self.MIN_PLATFORM_STOP_BUDGET
+
+
+class TestStartsRefuseToStackOnASurvivingGateway:
+    """No start/restart path may bring a second gateway up over a live one.
+
+    ``_wait_for_gateway_exit`` returns False only once it has already sent
+    SIGKILL and watched the PID outlive the deadline, and it says exactly
+    what is at stake: "still running after Ns -- restart may fail". The
+    start/restart callers discarded that bool and printed "Starting
+    gateway..." anyway.
+
+    Starting is the worse branch. gateway/run.py writes gateway.pid at
+    startup, so the replacement takes over the survivor's record and the
+    survivor becomes the orphan ``stop_profile_gateway`` has to sweep for
+    afterwards (#75936) -- invisible to ``hermes gateway stop`` and still
+    holding the webhook port (#51325). ``launchd_uninstall`` already refuses
+    to proceed on this same signal.
+
+    Every case is parametrized on the wait's verdict so the guard is pinned
+    in both directions: a fix that simply always aborted would fail the
+    ``exited=True`` half.
+    """
+
+    def _no_service_manager(self, monkeypatch):
+        """Drive the paths that fall through to the CLI's own start."""
+        monkeypatch.delenv("_HERMES_GATEWAY", raising=False)
+        monkeypatch.setattr(gateway_cli, "is_termux", lambda: False)
+        monkeypatch.setattr(gateway_cli, "is_macos", lambda: False)
+        monkeypatch.setattr(gateway_cli, "is_windows", lambda: False)
+        monkeypatch.setattr(gateway_cli, "supports_systemd_services", lambda: False)
+        monkeypatch.setattr(
+            gateway_cli,
+            "_dispatch_via_service_manager_if_s6",
+            lambda *_a, **_k: False,
+        )
+        monkeypatch.setattr(
+            gateway_cli,
+            "_dispatch_all_via_service_manager_if_s6",
+            lambda *_a, **_k: False,
+        )
+
+    @staticmethod
+    def _record_starts(monkeypatch):
+        started = []
+        monkeypatch.setattr(
+            gateway_cli, "run_gateway", lambda **_k: started.append("foreground")
+        )
+        monkeypatch.setattr(
+            gateway_cli, "systemd_start", lambda system=False: started.append("systemd")
+        )
+        monkeypatch.setattr(
+            gateway_cli, "launchd_start", lambda: started.append("launchd")
+        )
+        return started
+
+    @pytest.mark.parametrize("exited", [True, False])
+    def test_restart_all_starts_only_once_every_profile_is_down(
+        self, monkeypatch, capsys, exited
+    ):
+        """`gateway restart --all` stops across profiles, then starts one.
+
+        The stop is a best-effort broadcast: the service stop and
+        kill_gateway_processes() both only signal. When the wait then reports
+        the PID still alive, the "Starting gateway..." underneath it stacks a
+        second instance on the first.
+        """
+        self._no_service_manager(monkeypatch)
+        started = self._record_starts(monkeypatch)
+        monkeypatch.setattr(gateway_cli, "kill_gateway_processes", lambda **_k: 1)
+        monkeypatch.setattr(
+            gateway_cli, "_wait_for_gateway_exit", lambda **_k: exited
+        )
+
+        args = SimpleNamespace(gateway_command="restart", all=True, system=False)
+        if exited:
+            gateway_cli.gateway_command(args)
+        else:
+            with pytest.raises(SystemExit) as excinfo:
+                gateway_cli.gateway_command(args)
+            assert excinfo.value.code == 1, "a refused restart must exit non-zero"
+
+        out = capsys.readouterr().out
+        assert ("Starting gateway..." in out) is exited
+        assert (started == ["foreground"]) is exited, (
+            "a second gateway was started over the surviving one"
+            if not exited
+            else "a cleared restart must still start the replacement"
+        )
+
+    @pytest.mark.parametrize("exited", [True, False])
+    def test_manual_restart_starts_only_once_the_old_gateway_is_gone(
+        self, monkeypatch, capsys, exited
+    ):
+        """The no-service fallback is the sharper of the two restart sites.
+
+        systemd and launchd at least have their own view of what is already
+        running; here nothing supervises either process, so run_gateway()
+        brings the replacement up in the foreground of this very shell while
+        the survivor still holds the port.
+        """
+        self._no_service_manager(monkeypatch)
+        started = self._record_starts(monkeypatch)
+        monkeypatch.setattr(gateway_cli, "stop_profile_gateway", lambda: True)
+        monkeypatch.setattr(
+            gateway_cli, "_wait_for_gateway_exit", lambda **_k: exited
+        )
+
+        args = SimpleNamespace(gateway_command="restart", all=False, system=False)
+        if exited:
+            gateway_cli.gateway_command(args)
+        else:
+            with pytest.raises(SystemExit) as excinfo:
+                gateway_cli.gateway_command(args)
+            assert excinfo.value.code == 1, "a refused restart must exit non-zero"
+
+        out = capsys.readouterr().out
+        assert ("Starting gateway..." in out) is exited
+        assert (started == ["foreground"]) is exited, (
+            "run_gateway() brought a second gateway up over the survivor"
+            if not exited
+            else "a cleared restart must still start the replacement"
+        )

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -2204,6 +2204,39 @@ class TestGatewayStopGraceBudget:
         assert force_after >= self.MIN_PLATFORM_STOP_BUDGET
         assert timeout > force_after, "the wait must outlast its own escalation"
 
+    @pytest.mark.parametrize("exited", [True, False])
+    def test_cli_owned_stop_claims_success_only_when_the_kill_took(
+        self, monkeypatch, capsys, exited
+    ):
+        """The fall-through branch owes the same honesty as the supervised one.
+
+        Fixing only the launchd-owned branch would leave the worse half
+        unfixed: here nothing is supervising the process, so if the CLI's own
+        SIGTERM -> SIGKILL escalation does not take (an unkillable process
+        wedged in uninterruptible I/O, or a PID the CLI may not signal),
+        nothing else will ever reap it. Reporting "✓ Service stopped" for a
+        detached fallback gateway that is demonstrably still alive is the
+        report an operator is least able to check.
+        """
+        self._stub_launchd_stop(
+            monkeypatch,
+            bootout_error=subprocess.CalledProcessError(
+                5, ["launchctl", "bootout"]
+            ),
+            exit_result=exited,
+        )
+
+        gateway_cli.launchd_stop()
+
+        out = capsys.readouterr().out
+        assert ("✓ Service stopped" in out) is exited, (
+            "the stop reported success without observing the process exit"
+            if not exited
+            else "a clean stop must still report success"
+        )
+        if not exited:
+            assert "still running" in out, "a failed stop must say so"
+
     def test_stop_still_reraises_unexpected_launchctl_failures(self, monkeypatch):
         """Only the unloaded/unmanageable codes fall through to the PID path."""
         self._stub_launchd_stop(


### PR DESCRIPTION
## What does this PR do?

`hermes gateway stop` on macOS SIGKILLs the gateway **5 seconds** in, 20 seconds inside the graceful-drain budget the repo's own launchd plist declares — and 12× more aggressively than the same command on Linux.

The repo states this budget against itself in three places:

| path | grace before SIGKILL | anchor |
|---|---|---|
| launchd plist `ExitTimeOut` | **25 s** | `hermes_cli/gateway.py:4296` |
| systemd `TimeoutStopSec` = `max(60, drain + 30)` | **60 s** at the stock config | `hermes_cli/gateway.py:2976-2977` |
| `launchd_restart()` | `force_after=None` — never force-kills | `hermes_cli/gateway.py:4759` |
| `update_cmd`'s gateway stop | `force_after=None` | `hermes_cli/update_cmd.py:5682` |
| **`launchd_stop()` + 3 subcommand sites** | **5 s** | **4675, 7269, 7472, 7566** |

The plist generator's own comment says it plainly:

> `ExitTimeOut` gives the gateway 25s of graceful-drain headroom before launchd escalates from SIGTERM to SIGKILL on stop.

So the four `_wait_for_gateway_exit(timeout=10.0, force_after=5.0)` call sites are the outliers — every other stop path in the tree already declines to force-kill.

**Why the budget matters.** `gateway/run.py` runs its teardown *after* the drain: `shutdown_cached_clients()` → close the SQLite session DBs (releasing the WAL write lock) → `remove_pid_file()` → `release_gateway_runtime_lock()` → touch `.clean_shutdown`. A SIGKILL at t=5s skips all of it, producing:

- **`database is locked`** on the next start, from the retained WAL lock — predicted verbatim by the repo's own comment above that SQLite close;
- **recently-active sessions suspended**, because `run.py` gates on the `.clean_shutdown` marker that was never written (its comment names restart as a path this is meant to protect);
- **`bot token already in use (PID …)`**, from the PID file that was never removed.

Commit `715d26cdf49` auto-installs the gateway service during setup, so the launchd branch is now the default path rather than an opt-in.

### Approach

The fix splits on **who actually owns the escalation**, rather than picking a bigger number:

- **`launchd_stop()` after a successful `bootout`** — launchd already sent SIGTERM and will escalate to SIGKILL itself at `ExitTimeOut`. The CLI passes `force_after=None` and simply waits long enough to observe that escalation, instead of returning at 10 s and printing `✓ Service stopped` for a process that is still running.
- **`launchd_stop()` when `bootout` falls through** (job already unloaded, or the domain is unmanageable and the gateway is a detached fallback process, #23387) — launchd is *not* supervising this exit. This path needs care: the existing 5 s force-kill is the **only** signal it ever sent, so simply passing `force_after=None` here would turn `stop` into a no-op. Instead the CLI now sends SIGTERM first — which this path never did, so a detached-fallback gateway previously got no graceful stop at all — and escalates only after the same budget launchd would have granted.
- **The three subcommand sites** (`start --all`, `restart --all`, manual restart) — all three already SIGTERM before the wait (`kill_gateway_processes()` terminates with `force=False`; `stop_profile_gateway()` sends SIGTERM and polls ~10 s), so the force-kill is purely the escalation backstop. It keeps the backstop — unlike `launchd_stop()` after `bootout`, nothing guarantees a service manager is escalating behind these, and dropping it could leave a wedged process holding the webhook port — but floors it at the platform budget.

- **`launchd_uninstall()` — the same `bootout` fall-through, one function up** (`hermes_cli/gateway.py:4574` on current `main`). It ran `bootout` with `check=False`, discarded the result, then unlinked the plist and printed `✓ Removed …` and `✓ Service uninstalled` unconditionally. On the fall-through it sent **no signal at all**, so `hermes gateway uninstall` reported success while the gateway kept answering, kept the port bound and kept holding the PID and runtime locks. Removing the service definition in that state also blocks the recovery: `hermes gateway stop` takes this same fall-through, and `hermes gateway start` bootstraps a **second** instance against the same bot token and port. It now uses the identical classification helpers and terminate-then-wait shape as `launchd_stop()`, and unlinks the plist only once the process is confirmed gone — otherwise it keeps the plist and prints the recovery command instead of a success line. An unexpected `launchctl` exit code is still tolerated rather than raised, since uninstall has always run `bootout` with `check=False` and signalling a job launchd may still be supervising would only get it respawned by `KeepAlive`. `systemd_uninstall()` never had this problem: its `systemctl stop` is synchronous, so the unit is down before the unit file is removed. This brings launchd to the same guarantee.
- **Reporting the stop honestly.** `_wait_for_gateway_exit()` returns `False` only after printing `⚠ Gateway PID N still running after Ns — restart may fail`, and both `launchd_stop()` branches discarded that result before printing `✓ Service stopped` — so a wedged stop emitted the warning and the success line back to back. This barely mattered on `main`, where force-killing 5 s into a 10 s ceiling makes a surviving PID nearly impossible; declining to pre-empt the budget is precisely what makes it reachable, so the PR that introduces the window also closes the truthfulness gap it opens. Both branches now gate the ✓ line on the result, as `launchd_restart()` already does with the same helper and as `systemd_stop()` already does by returning with "still stopping after 90s".

- **Not starting a second gateway on top of the first.** The discarded verdict has one further consequence at the three subcommand sites, which is why they are fixed here too: each is a *start* path. `start --all` sweeps stale processes and then starts the profile's service; `restart --all` and the manual restart both print `Starting gateway…` on the next line. `_wait_for_gateway_exit()` returns `False` only once it has already sent SIGKILL and watched the PID outlive the deadline — a narrow case (a process wedged uninterruptibly, realistically one blocked flushing its session DB or transcripts to slow storage, or one this user cannot signal), and narrower than `launchd_stop()`'s `force_after=None` branch — but it is precisely the case where starting is wrong. `gateway/run.py` writes `gateway.pid` at startup, so the replacement takes over the survivor's record and the survivor becomes the orphan `stop_profile_gateway()` documents having to sweep for afterwards (#75936): no longer reachable through `hermes gateway stop`, still holding the webhook port (#51325) and the same bot token. It is the same outcome `launchd_uninstall()` above keeps its plist to avoid, in that path's own words — *"`hermes gateway start` bootstraps a **second** instance against the same bot token and port"*. All three now capture the result and exit non-zero with the recovery command instead, matching the `✗ Gateway service restart failed` exit the manual-restart branch already uses.

  To be exact about scope: this PR does **not** create that reachability at the three subcommand sites — they force-kill on `main` too, and this PR only moves the escalation later. It *does* create it at `launchd_stop()`'s `bootout` branch, which is why the ✓-gating above ships alongside it.

The grace is a named constant deliberately **not** derived from `restart_drain_timeout` (its default is `0`; see "Related PRs" below).

Timing: the wait returns as soon as the PID is gone, so a healthy stop is unchanged. The raised ceiling is only reachable by a gateway that is genuinely still draining, which is exactly the case the budget exists for.

## Related Issue

No open issue — this is a supersede of a stale PR (see below). The user-visible symptom originates in #17198 (closed as `not_planned`) and recurs in #22418 and #31890; those are referenced as the origin of the report, not claimed as fixed here.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/gateway.py` — added `_GATEWAY_STOP_GRACE_SECONDS` / `_GATEWAY_STOP_WAIT_SECONDS` next to `_wait_for_gateway_exit`, documenting the platform-budget invariant.
- `hermes_cli/gateway.py:4675` (`launchd_stop`) — split the wait on whether `bootout` succeeded; leave escalation to launchd when it did, and send a graceful SIGTERM before escalating when it did not.
- `hermes_cli/gateway.py:7269` (`gateway start --all`), `:7472` (`gateway restart --all`), `:7566` (manual restart) — floored the force-kill grace at the platform budget.
- `hermes_cli/gateway.py` (`launchd_stop`) — both branches now capture `_wait_for_gateway_exit()`'s result and report a surviving process instead of printing `✓ Service stopped` over the top of the wait's own warning.
- `hermes_cli/gateway.py:4574` (`launchd_uninstall`) — stops the gateway before removing the service definition, and keeps the plist when the stop does not complete.
- `hermes_cli/gateway.py` (those same three sites) — capture `_wait_for_gateway_exit()`'s result and abort with a non-zero exit rather than starting a second gateway over one that outlived the stop. The shared reporter `_abort_on_surviving_gateway()` sits next to the wait it enforces.
- `tests/hermes_cli/test_gateway_service.py` — `TestGatewayStopGraceBudget` (9 tests / 14 cases) and `TestStartsRefuseToStackOnASurvivingGateway` (3 tests / 6 cases), **20 cases total**. `launchd_stop()` and `launchd_uninstall()` previously had **zero** test coverage.

**Coverage of the root cause is complete.** `grep -n "force_after" hermes_cli/gateway.py` returns exactly four call sites that force-kill, and all four are fixed here. `grep -n "_wait_for_gateway_exit(" hermes_cli/gateway.py hermes_cli/update_cmd.py` returns every consumer of the wait, and each is accounted for:

| site | disposition |
|---|---|
| `launchd_stop()`, both branches | fixed — captures the result, gates the ✓ line |
| `launchd_uninstall()` | fixed — did not call the wait at all; now owns the stop and gates the plist unlink |
| `launchd_restart()` | already branched on the result; untouched, and the precedent this follows |
| `start --all`, `restart --all`, manual restart | fixed — all three discarded the result and went on to start a gateway; each now captures it and refuses to start over a survivor |
| `update_cmd.py:5682` | best-effort ~5 s courtesy delay before the watcher relaunches; its own comment defers the remainder to the Telegram adapter's retry path, and it claims nothing |
| `systemd_stop()` | does not share the defect — `systemctl stop` is synchronous under `check=True` and already returns early with a truthful "still stopping after 90s" |

## How to Test

1. On macOS with the service installed (`hermes gateway install && hermes gateway start`), start a long-running agent turn so the gateway has something to drain.
2. `hermes gateway stop`. **Before:** the gateway is SIGKILLed 5 s in; `~/.hermes/.clean_shutdown` is absent and the session DB's `-wal` file is left un-checkpointed. **After:** the gateway drains, `.clean_shutdown` is written, and the WAL lock is released.
3. `hermes gateway start` — before this change the next start reports `database is locked` / `bot token already in use (PID …)` and suspends recently-active sessions.
4. Regression suite:
   ```
   pytest tests/hermes_cli/test_gateway_service.py \
     -k "TestGatewayStopGraceBudget or TestStartsRefuseToStackOnASurvivingGateway" -v
   ```
   Reverting only `hermes_cli/gateway.py` to `main` turns these red on the behaviour, not on a missing symbol: `assert 5.0 is None` (the launchd pre-emption), `assert [] == [(4242, False)]` ×2 (the missing SIGTERM on `launchd_stop`'s fall-through), `assert 5.0 >= 25.0` (`start --all`), `assert [] == [(4242, False)]` ×2 again for `launchd_uninstall`'s fall-through — which additionally captures `✓ Removed …plist` / `✓ Service uninstalled` on stdout for a gateway that was never asked to exit — and `assert plist_path.exists()` ×2 for the plist deleted under a live process. The success-line assertions are parametrized in both directions, so the fix cannot degenerate into deleting the ✓ lines.

   The six `TestStartsRefuseToStackOnASurvivingGateway` cases go red the same way against `main`: each `exited=False` case fails with `Failed: DID NOT RAISE SystemExit`, and the captured stdout shows the defect directly — `✓ Stopped gateway for this profile` / `Starting gateway...` for the restart paths, `✓ Killed 2 stale gateway process(es) across all profiles` followed by the service start for `start --all`. All six are parametrized on the wait's verdict, so a guard that fired unconditionally would fail the `exited=True` half.
5. Adjacent suites — `tests/hermes_cli/test_gateway.py`, `tests/gateway/test_status.py`, `tests/gateway/test_restart_drain.py`, `tests/gateway/test_clean_shutdown_marker.py`, `tests/gateway/test_gateway_shutdown.py`, `tests/gateway/test_restart_service_detection.py`: **185 passed, 5 skipped**.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass <!-- ran the gateway/CLI service suites listed under "How to Test", not the full tree -->
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 25.4)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A <!-- invariant documented at the constants -->
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A <!-- no config keys added -->
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A <!-- launchd_stop and launchd_uninstall are macOS-only; the three subcommand sites are cross-platform and only move the escalation later, never earlier -->
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Related / Positioning

**Supersedes #17292** (`fix: use configured drain timeout for gateway restart wait`, open since 2026-04-29, +4/−2, 1 file, no tests). It identified the right symptom, and this PR credits that; but as written it cannot land, for three independent reasons:

1. **It regresses the stock config into an immediate SIGKILL.** It substitutes `force_after=min(_drain * 0.5, 10.0)`, and `hermes_cli/config_defaults.py:80` sets `"restart_drain_timeout": 0`. So on a default install `_drain = 0.0` → `force_after = 0.0`, and the force-kill branch fires on the **first loop iteration** — strictly worse than `main`'s 5 s. This is why the constant here is deliberately *not* derived from `restart_drain_timeout`.
2. **It patches 2 of the 4 sites, and misses the one that fires first on the path it targets.** It changes :7472 and :7566 but not :4675 — and `restart --all` reaches `launchd_stop()` at :7455 *before* the wait it patched, so on macOS the 5 s SIGKILL still lands. The linked reporter is on macOS. It also misses :7269. And at the two sites it does change, it changes only the *arguments* — it still discards the wait's return, so the start-over-a-survivor defect fixed here survives its patch intact.
3. No tests.

This PR ships the superset: all four force-killing sites, the branch-aware `launchd_stop()` handling (including the fall-through path, which no prior PR addresses), the same fall-through in `launchd_uninstall()`, honest reporting when a stop does not complete, and regression coverage.

**Textual overlap to flag — #62630** (@gservat, *"show 'Hermes Gateway' instead of 'python' in macOS Login Items"*, open since 2026-07-11). Different concern entirely, but it is the one other open PR that edits `launchd_uninstall()`: its hunk inserts a single `remove_launchd_launcher()` call between the `plist_path.unlink()` block and `print("✓ Service uninstalled")` — exactly the seam this PR restructures. Whichever lands second will hit a small, mechanical conflict. There is no semantic disagreement: their line belongs inside the confirmed-exited path this PR introduces. Happy to rebase on top of theirs if it goes first.

**Not in conflict with, and does not overlap:**

- **#81652** — adds a force-kill to `launchd_restart()` at :4759. That is a different function addressing the opposite failure (a wedged gateway that never dies); this PR deliberately leaves :4759 untouched and cites it as precedent.
- **#83530 / #82669 / #28530** — retune the plist's `ExitTimeOut` inside `generate_launchd_plist`. This PR does not touch that function. The drift guard added here is deliberately **one-sided** (`ExitTimeOut >= grace`), so raising `ExitTimeOut` — which is what all three do — keeps it green.
- **#84716 / #82161** — concern `launchd_restart`; context only.


