### PR TITLE
feat(gateway): per-account session identity (#8287, 2/6)

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -731,6 +731,26 @@ class PlatformConfig:
         if _typing_text is None:
             _typing_text = extra.get("typing_status_text")
 
+        # Multi-account blocks (#8287): ``accounts:`` may arrive top-level
+        # (``platforms.telegram.accounts`` in YAML) or bridged into extra by
+        # the shared-key loop. Normalize account names (lowercased) into
+        # ``extra["accounts"]`` so the adapter registry has a single read
+        # path. Tokens are secrets and load from ``<PLATFORM>_BOT_TOKEN_<ACCOUNT>``
+        # env vars in ``_apply_env_overrides`` — a ``token`` key inside a YAML
+        # account block is honored for parity but ``.env`` is the supported
+        # home for credentials.
+        _accounts = data.get("accounts")
+        if _accounts is None:
+            _accounts = extra.get("accounts")
+        if isinstance(_accounts, dict):
+            _norm_accounts: Dict[str, Any] = {}
+            for _acct_name, _acct_block in _accounts.items():
+                _acct_key = str(_acct_name).strip().lower()
+                if _acct_key:
+                    _norm_accounts[_acct_key] = _coerce_dict(_acct_block)
+            if _norm_accounts:
+                extra["accounts"] = _norm_accounts
+
         channel_overrides: Dict[str, ChannelOverride] = {}
         raw_overrides = data.get("channel_overrides") or {}
         if isinstance(raw_overrides, dict):
@@ -1911,6 +1931,32 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
     if telegram_token:
         telegram_config = _enable_from_env(Platform.TELEGRAM)
         telegram_config.token = telegram_token
+
+    # Multi-account tokens (#8287): ``TELEGRAM_BOT_TOKEN_<ACCOUNT>`` declares
+    # an additional bot account named ``<account>`` (lowercased). The
+    # unsuffixed ``TELEGRAM_BOT_TOKEN`` remains the default account, so
+    # single-bot setups are byte-identical to before. Candidate names are
+    # enumerated from the process env (dotenv loads ``.env`` there) and each
+    # value is read back through ``getenv`` so profile-scoped secrets win
+    # when a scope is active. Behavioral per-account settings (allowlists,
+    # home channels, display names) belong in ``platforms.telegram.accounts``
+    # in config.yaml — env vars carry only the credential.
+    _tg_account_prefix = "TELEGRAM_BOT_TOKEN_"
+    for _env_name in sorted(os.environ):
+        if not _env_name.startswith(_tg_account_prefix):
+            continue
+        _acct_name = _env_name[len(_tg_account_prefix):].strip().lower()
+        _acct_token = getenv(_env_name)
+        if not _acct_name or not _acct_token:
+            continue
+        _tg_cfg = _enable_from_env(Platform.TELEGRAM)
+        _tg_accounts = _tg_cfg.extra.setdefault("accounts", {})
+        if not isinstance(_tg_accounts, dict):
+            _tg_accounts = {}
+            _tg_cfg.extra["accounts"] = _tg_accounts
+        _acct_block = _tg_accounts.setdefault(_acct_name, {})
+        if isinstance(_acct_block, dict):
+            _acct_block["token"] = _acct_token
     
     # Reply threading mode for Telegram (off/first/all)
     telegram_reply_mode = getenv("TELEGRAM_REPLY_TO_MODE", "").lower()

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -11,6 +11,7 @@ Handles loading and validating configuration for:
 import logging
 import os
 import json
+import re
 from pathlib import Path
 from dataclasses import asdict, dataclass, field, is_dataclass
 from typing import Dict, List, Optional, Any, Callable
@@ -746,8 +747,20 @@ class PlatformConfig:
             _norm_accounts: Dict[str, Any] = {}
             for _acct_name, _acct_block in _accounts.items():
                 _acct_key = str(_acct_name).strip().lower()
-                if _acct_key:
-                    _norm_accounts[_acct_key] = _coerce_dict(_acct_block)
+                if not _acct_key:
+                    continue
+                # Account names become a session-key namespace suffix
+                # (``agent:main@<account>``), so the charset is restricted:
+                # ``:`` would break key splitting, ``@`` the suffix parse.
+                if not re.fullmatch(r"[a-z0-9][a-z0-9_-]*", _acct_key):
+                    logger.warning(
+                        "Ignoring platform account %r: names must match "
+                        "[a-z0-9][a-z0-9_-]* (they become session-key "
+                        "namespace suffixes)",
+                        _acct_name,
+                    )
+                    continue
+                _norm_accounts[_acct_key] = _coerce_dict(_acct_block)
             if _norm_accounts:
                 extra["accounts"] = _norm_accounts
 
@@ -1948,6 +1961,14 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
         _acct_name = _env_name[len(_tg_account_prefix):].strip().lower()
         _acct_token = getenv(_env_name)
         if not _acct_name or not _acct_token:
+            continue
+        # Same charset rule as the YAML block: names become session-key
+        # namespace suffixes.
+        if not re.fullmatch(r"[a-z0-9][a-z0-9_-]*", _acct_name):
+            logger.warning(
+                "Ignoring %s: account names must match [a-z0-9][a-z0-9_-]*",
+                _env_name,
+            )
             continue
         _tg_cfg = _enable_from_env(Platform.TELEGRAM)
         _tg_accounts = _tg_cfg.extra.setdefault("accounts", {})

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2450,6 +2450,7 @@ from gateway.session import (
     build_session_key,
     is_shared_multi_user_session,
     neutralize_untrusted_inline_text,
+    split_key_namespace,
 )
 from gateway.delivery import (
     DeliveryRouter,
@@ -3542,12 +3543,19 @@ def _parse_session_key(session_key: str) -> "dict | None":
     thread_id, so we leave ``thread_id`` out to avoid mis-routing.
     """
     parts = session_key.split(":")
-    if len(parts) >= 5 and parts[0] == "agent" and parts[1] == "main":
+    # Accept the default namespace with or without a multi-account suffix
+    # (``agent:main`` / ``agent:main@support``, #8287) — the positional
+    # layout after the namespace slot is identical. Named-profile keys stay
+    # excluded, as before.
+    _ns, _account = split_key_namespace(parts[1]) if len(parts) > 1 else ("", None)
+    if len(parts) >= 5 and parts[0] == "agent" and _ns == "main":
         result = {
             "platform": parts[2],
             "chat_type": parts[3],
             "chat_id": parts[4],
         }
+        if _account:
+            result["account"] = _account
         if len(parts) > 5 and parts[3] in {"dm", "thread"}:
             result["thread_id"] = parts[5]
         return result

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -186,6 +186,14 @@ class SessionSource:
     # target is not served. Excluded from repr/equality and wire serialization.
     profile_route_rejected: bool = field(default=False, repr=False, compare=False)
 
+    # Bot account this inbound message arrived on (#8287). A gateway can run
+    # multiple bot accounts on one platform (TELEGRAM_BOT_TOKEN_<ACCOUNT>);
+    # the receiving adapter stamps its account name here so session keys,
+    # busy guards, and outbound delivery all route per account. None => the
+    # platform's default account — byte-identical behavior to a single-bot
+    # gateway.
+    account: Optional[str] = None
+
     # Discord auto-thread metadata.  Newly auto-created Discord threads start
     # with a fast placeholder title from the raw message, then the gateway can
     # rename them after the first agent turn using the generated session title.
@@ -279,6 +287,8 @@ class SessionSource:
             d["message_id"] = self.message_id
         if self.profile:
             d["profile"] = self.profile
+        if self.account:
+            d["account"] = self.account
         if self.auto_thread_created:
             d["auto_thread_created"] = True
         if self.auto_thread_initial_name:
@@ -306,6 +316,7 @@ class SessionSource:
             parent_chat_id=data.get("parent_chat_id"),
             message_id=data.get("message_id"),
             profile=data.get("profile"),
+            account=data.get("account"),
             auto_thread_created=bool(data.get("auto_thread_created", False)),
             auto_thread_initial_name=data.get("auto_thread_initial_name"),
             prospective_thread_id=data.get("prospective_thread_id"),
@@ -1067,7 +1078,9 @@ def is_shared_multi_user_session(
     return not group_sessions_per_user
 
 
-def _session_key_namespace(profile: Optional[str]) -> str:
+def _session_key_namespace(
+    profile: Optional[str], account: Optional[str] = None
+) -> str:
     """Return the ``agent:<ns>`` namespace prefix for a session key.
 
     The historical key format is ``agent:main:<platform>:<chat_type>:...`` where
@@ -1081,10 +1094,36 @@ def _session_key_namespace(profile: Optional[str]) -> str:
     - named profile ``coder`` → ``agent:coder`` — keeps the same positional
       layout, just a different namespace, so two profiles serving the same
       platform/chat never collide.
+
+    Multi-account gateways (#8287) reuse the slot the same way: a non-default
+    bot account is appended as ``@<account>`` (``agent:main@support``,
+    ``agent:coder@support``), so the same chat reached through two bots yields
+    two sessions while every positional parser keeps its layout. ``:`` stays
+    the only separator, and account names are charset-restricted at config
+    parse time so ``@`` cannot appear inside a name. Readers that map the
+    namespace back to a profile must strip the suffix via
+    :func:`split_key_namespace`.
     """
     if not profile or profile == "default":
-        return "agent:main"
-    return f"agent:{profile}"
+        ns = "agent:main"
+    else:
+        ns = f"agent:{profile}"
+    if account and account != "default":
+        return f"{ns}@{account}"
+    return ns
+
+
+def split_key_namespace(namespace: str) -> tuple[str, Optional[str]]:
+    """Split a session-key namespace component into ``(profile_ns, account)``.
+
+    ``main`` → ``("main", None)``; ``main@support`` → ``("main", "support")``.
+    The account suffix was introduced for multi-account gateways (#8287);
+    every reader that compares or maps the namespace (profile resolution,
+    key parsers) must strip it through here rather than assuming the raw
+    slot equals a profile name.
+    """
+    base, sep, account = (namespace or "").partition("@")
+    return base, (account or None) if sep else None
 
 
 def build_session_key(
@@ -1125,7 +1164,13 @@ def build_session_key(
         shared session per chat.
       - Without identifiers, messages fall back to one session per platform/chat_type.
     """
-    ns = _session_key_namespace(profile)
+    # Account comes from the SOURCE, not a caller parameter: which bot
+    # received the message is intrinsic to the event, and reading it here
+    # guarantees the adapter-level guard and the session store derive the
+    # same key for the same event (per-key guards diverging is the #64934
+    # bug class). ``getattr`` guards bare test fixtures (AGENTS.md pitfall).
+    account = getattr(source, "account", None)
+    ns = _session_key_namespace(profile, account)
     platform = source.platform.value
     slack_scope_id = (
         str(source.scope_id)
@@ -1788,7 +1833,10 @@ class SessionStore:
         parts = str(session_key).split(":")
         if len(parts) < 2 or parts[0] != "agent":
             return None
-        namespace = parts[1] or "main"
+        # Strip a multi-account suffix (agent:main@support) — the account is
+        # not a profile and must not be resolved as one (#8287).
+        namespace, _account = split_key_namespace(parts[1] or "main")
+        namespace = namespace or "main"
         return "default" if namespace == "main" else namespace
 
     @staticmethod

--- a/tests/gateway/test_telegram_multi_account_config.py
+++ b/tests/gateway/test_telegram_multi_account_config.py
@@ -1,0 +1,122 @@
+"""Multi-account Telegram configuration parsing — #8287.
+
+One gateway, N Telegram bot accounts: tokens arrive as
+``TELEGRAM_BOT_TOKEN_<ACCOUNT>`` env vars (secrets stay in .env), behavioral
+settings as ``platforms.telegram.accounts.<name>`` in config.yaml. The
+unsuffixed ``TELEGRAM_BOT_TOKEN`` remains the default account, so single-bot
+configurations parse byte-identically to before.
+"""
+
+import pytest
+
+from gateway.config import Platform, PlatformConfig, load_gateway_config
+
+
+def test_single_bot_config_has_no_accounts_key(monkeypatch, tmp_path):
+    """Backward compatibility: an unsuffixed token must not grow an
+    accounts block — existing single-bot setups stay byte-identical."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "123:default-token")
+
+    config = load_gateway_config()
+    tg = config.platforms[Platform.TELEGRAM]
+    assert tg.token == "123:default-token"
+    assert "accounts" not in tg.extra
+
+
+def test_suffixed_env_tokens_declare_accounts(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "123:default-token")
+    monkeypatch.setenv("TELEGRAM_BOT_TOKEN_SUPPORT", "456:support-token")
+    monkeypatch.setenv("TELEGRAM_BOT_TOKEN_SALES", "789:sales-token")
+
+    config = load_gateway_config()
+    tg = config.platforms[Platform.TELEGRAM]
+
+    # Default account untouched.
+    assert tg.token == "123:default-token"
+    # Suffix names are lowercased account names carrying only the credential.
+    accounts = tg.extra["accounts"]
+    assert accounts["support"]["token"] == "456:support-token"
+    assert accounts["sales"]["token"] == "789:sales-token"
+
+
+def test_suffixed_token_alone_enables_platform(monkeypatch, tmp_path):
+    """A gateway configured with only account tokens (no default) still
+    enables Telegram — the registry decides which accounts to start."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.delenv("TELEGRAM_BOT_TOKEN", raising=False)
+    monkeypatch.setenv("TELEGRAM_BOT_TOKEN_SUPPORT", "456:support-token")
+
+    config = load_gateway_config()
+    tg = config.platforms[Platform.TELEGRAM]
+    assert tg.enabled
+    assert tg.token is None
+    assert tg.extra["accounts"]["support"]["token"] == "456:support-token"
+
+
+def test_empty_suffix_or_value_is_ignored(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "123:default-token")
+    monkeypatch.setenv("TELEGRAM_BOT_TOKEN_", "999:no-name")
+    monkeypatch.setenv("TELEGRAM_BOT_TOKEN_EMPTY", "")
+
+    config = load_gateway_config()
+    tg = config.platforms[Platform.TELEGRAM]
+    assert "accounts" not in tg.extra
+
+
+def test_yaml_accounts_block_parses_and_normalizes_names():
+    cfg = PlatformConfig.from_dict({
+        "enabled": True,
+        "accounts": {
+            "Support": {"display_name": "Support Bot", "allowed_users": [1, 2]},
+            "  SALES ": {"home_channel": {"chat_id": "-100123"}},
+        },
+    })
+    accounts = cfg.extra["accounts"]
+    assert set(accounts) == {"support", "sales"}
+    assert accounts["support"]["display_name"] == "Support Bot"
+    assert accounts["support"]["allowed_users"] == [1, 2]
+
+
+def test_yaml_accounts_survive_via_extra_bridge():
+    """The shared-key loop can bridge accounts into extra — both routes
+    normalize identically (the gateway_restart_notification pattern)."""
+    cfg = PlatformConfig.from_dict({
+        "enabled": True,
+        "extra": {"accounts": {"Support": {"display_name": "S"}}},
+    })
+    assert cfg.extra["accounts"]["support"]["display_name"] == "S"
+
+
+def test_env_token_merges_into_yaml_account_block(monkeypatch, tmp_path):
+    """config.yaml declares the behavioral block; .env supplies the token.
+    The two merge on the same account name."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    (tmp_path / "config.yaml").write_text(
+        "gateway:\n"
+        "  platforms:\n"
+        "    telegram:\n"
+        "      enabled: true\n"
+        "      accounts:\n"
+        "        support:\n"
+        "          display_name: Support Bot\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("TELEGRAM_BOT_TOKEN_SUPPORT", "456:support-token")
+
+    config = load_gateway_config()
+    tg = config.platforms[Platform.TELEGRAM]
+    support = tg.extra["accounts"]["support"]
+    assert support["token"] == "456:support-token"
+    assert support.get("display_name") == "Support Bot"
+
+
+def test_accounts_round_trip_through_to_dict():
+    cfg = PlatformConfig.from_dict({
+        "enabled": True,
+        "accounts": {"support": {"display_name": "S"}},
+    })
+    rebuilt = PlatformConfig.from_dict(cfg.to_dict())
+    assert rebuilt.extra["accounts"]["support"]["display_name"] == "S"

--- a/tests/gateway/test_telegram_multi_account_sessions.py
+++ b/tests/gateway/test_telegram_multi_account_sessions.py
@@ -1,0 +1,108 @@
+"""Per-account session identity — #8287.
+
+A gateway hosting multiple bot accounts on one platform must keep their
+conversations apart: the same chat reached through two bots is two sessions.
+The account rides in the session-key namespace slot (``agent:main@support``)
+— the same mechanism profiles use — so every positional parser
+(``parts[2] == platform`` etc.) keeps its layout, and single-bot gateways
+produce byte-identical keys to before.
+"""
+
+from gateway.config import Platform
+from gateway.run import _parse_session_key
+from gateway.session import (
+    SessionSource,
+    build_session_key,
+    split_key_namespace,
+)
+
+
+def _source(account=None, **kw):
+    defaults = dict(
+        platform=Platform.TELEGRAM, chat_id="777", chat_type="dm", user_id="777"
+    )
+    defaults.update(kw)
+    return SessionSource(account=account, **defaults)
+
+
+def test_same_chat_two_bots_two_sessions():
+    """The #10455-review isolation requirement: identical chat + user via
+    two different bot accounts must never share a session key."""
+    key_default = build_session_key(_source(account=None))
+    key_support = build_session_key(_source(account="support"))
+    key_sales = build_session_key(_source(account="sales"))
+    assert len({key_default, key_support, key_sales}) == 3
+
+
+def test_default_account_key_is_byte_identical_to_legacy():
+    """Single-bot gateways must keep every key they have ever generated."""
+    assert build_session_key(_source(account=None)) == "agent:main:telegram:dm:777"
+    assert build_session_key(_source(account="default")) == "agent:main:telegram:dm:777"
+
+
+def test_account_key_keeps_positional_layout():
+    """The account lives in the namespace slot — platform/chat_type/chat_id
+    stay at parts[2:5], so positional parsers are unaffected."""
+    key = build_session_key(_source(account="support"))
+    parts = key.split(":")
+    assert parts[0] == "agent"
+    assert parts[1] == "main@support"
+    assert parts[2] == "telegram"
+    assert parts[3] == "dm"
+    assert parts[4] == "777"
+
+
+def test_profile_and_account_compose():
+    key = build_session_key(_source(account="support"), profile="coder")
+    assert key.startswith("agent:coder@support:telegram:")
+
+
+def test_group_and_thread_keys_carry_account():
+    group_a = build_session_key(
+        _source(account="support", chat_type="group", chat_id="-100", user_id="9")
+    )
+    group_b = build_session_key(
+        _source(account=None, chat_type="group", chat_id="-100", user_id="9")
+    )
+    assert group_a != group_b
+    assert group_a.split(":")[1] == "main@support"
+
+
+def test_source_account_round_trips_serialization():
+    src = _source(account="support")
+    rebuilt = SessionSource.from_dict(src.to_dict())
+    assert rebuilt.account == "support"
+    # Default account stays wire-invisible (no key emitted), like profile.
+    assert "account" not in _source(account=None).to_dict()
+
+
+def test_split_key_namespace():
+    assert split_key_namespace("main") == ("main", None)
+    assert split_key_namespace("main@support") == ("main", "support")
+    assert split_key_namespace("coder@support") == ("coder", "support")
+    assert split_key_namespace("") == ("", None)
+
+
+def test_profile_resolution_ignores_account_suffix():
+    from gateway.session import SessionStore
+
+    resolve = SessionStore._profile_from_session_key
+    assert resolve("agent:main:telegram:dm:1") == "default"
+    assert resolve("agent:main@support:telegram:dm:1") == "default"
+    assert resolve("agent:coder@support:telegram:dm:1") == "coder"
+
+
+def test_parse_session_key_accepts_account_namespace():
+    parsed = _parse_session_key("agent:main@support:telegram:dm:777:42")
+    assert parsed == {
+        "platform": "telegram",
+        "chat_type": "dm",
+        "chat_id": "777",
+        "account": "support",
+        "thread_id": "42",
+    }
+    # Default-namespace behavior unchanged.
+    legacy = _parse_session_key("agent:main:telegram:dm:777")
+    assert legacy == {"platform": "telegram", "chat_type": "dm", "chat_id": "777"}
+    # Named-profile keys stay excluded, as before.
+    assert _parse_session_key("agent:coder:telegram:dm:777") is None


### PR DESCRIPTION
Second slice of the #67455 split (#8287, triage-recorded `best fix`). Follows #86497.

**Stacks on 1/6.** GitHub won't let a fork PR target another fork branch, so this contains #86497's commit as well as its own. **Once #86497 merges this shrinks to its own ~190 lines automatically** — review just the second commit (`per-account session identity`) if 1/6 is still open.

| | |
|---|---|
| This slice alone | 191 lines, 3 files |
| Cumulative with 1/6 | 359 lines, 5 files |

## What it does

Makes the account part of session identity, so two bots sharing a chat id don't collide.

`SessionSource` carries an `account` field, and the session key derivation folds it in. Without this, a message to the support bot and a message to the sales bot in the same Telegram chat resolve to the **same** session — they'd share transcript history and interleave turns. That's the same class of many-to-one key collision as #64934, just reached through a different door.

`account` is `None` for the default/single-bot adapter, and the derived key is **byte-identical to today** in that case. Single-bot deployments are unaffected.

## Why it isn't independently useful yet

Nothing populates `source.account` until 3/6 (adapter registry + `build_source()` stamping) — so on its own this widens the identity contract without exercising it. Same disclosure as 1/6: I'd rather state it than have it found in review.

Worth flagging that 3/6 is where your earlier review finding lands — the original PR stamped `account` only on Telegram's auth-helper paths, so ordinary inbound traffic kept `account=None` and the whole feature silently no-op'd for real messages. The stamp moves into `BasePlatformAdapter.build_source()`, the single construction site every platform's normal event flows through.

## Sequence

1/6 config parsing (#86497) → **2/6 session identity (this)** → 3/6 adapter registry + inbound stamping → 4/6 delivery routing + reconnect → 5/6 per-account `send_message` → 6/6 cron targets, home broadcasts, setup UX.

## Tests

`tests/gateway/test_telegram_multi_account_sessions.py` — 9 tests: account folded into the key, distinct accounts in one chat get distinct sessions, `account=None` reproduces the current key byte-for-byte, and round-tripping through `SessionSource`.

17 passed across both slices' test files. Full `tests/gateway/` run: the sorted set of erroring modules is **identical** to pristine `upstream/main` (13 either way — pre-existing optional-dep gaps on my Windows box). Compared by test-id set rather than count, since collection aborts early and raw counts drift between runs.
