### PR TITLE
fix(memory): hide built-in memory tool when both memory stores are disabled

### DIFF
--- a/model_tools.py
+++ b/model_tools.py
@@ -414,6 +414,29 @@ def get_tool_definitions(
     return result
 
 
+def _builtin_memory_tools_disabled() -> bool:
+    """True when the user has explicitly disabled BOTH built-in memory stores.
+
+    ``memory.memory_enabled: false`` + ``memory.user_profile_enabled: false``
+    means the operator opted into an external-provider-only memory surface
+    (e.g. Honcho). In that mode the built-in ``memory`` tool has no backing
+    store (agent_init never constructs MemoryStore), so exposing its schema
+    just invites calls that fail with "Memory is not available." Honcho /
+    other provider tools are injected separately and are unaffected.
+
+    Fails closed (False = keep the tool) if config can't be read.
+    """
+    try:
+        from hermes_cli.config import load_config
+        mem = (load_config() or {}).get("memory") or {}
+        return (
+            mem.get("memory_enabled") is False
+            and mem.get("user_profile_enabled") is False
+        )
+    except Exception:
+        return False
+
+
 def _compute_tool_definitions(
     enabled_toolsets: Optional[List[str]] = None,
     disabled_toolsets: Optional[List[str]] = None,
@@ -456,6 +479,12 @@ def _compute_tool_definitions(
         from toolsets import get_all_toolsets
         for ts_name in get_all_toolsets():
             tools_to_include.update(resolve_toolset(ts_name))
+
+    # Honcho-primary memory mode: when both built-in memory stores are
+    # disabled, drop the dead built-in `memory` schema. External provider
+    # tools (honcho_*) are injected later and unaffected.
+    if "memory" in tools_to_include and _builtin_memory_tools_disabled():
+        tools_to_include.discard("memory")
 
     # Always apply disabled toolsets as a subtraction step at the end.
     # This ensures that even if a composite toolset (like hermes-cli)

--- a/tests/tools/test_memory_tool.py
+++ b/tests/tools/test_memory_tool.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from tools.memory_tool import (
     MemoryStore,
     memory_tool,
+    check_memory_requirements,
     _scan_memory_content,
 )
 
@@ -18,6 +19,47 @@ def _blocked(content, pattern_id=None):
     assert "Blocked" in result
     if pattern_id:
         assert pattern_id in result, f"expected {pattern_id} in {result!r}"
+
+
+# =========================================================================
+# Config gate: check_memory_requirements respects memory_enabled flags
+# =========================================================================
+
+class TestMemoryToolConfigGate:
+    """Regression: a Honcho-primary profile (memory_enabled=False,
+    user_profile_enabled=False) must not advertise the built-in memory tool.
+    The gate reads hermes_cli.config.load_config lazily; we patch that."""
+
+    def _patch_cfg(self, monkeypatch, mem_cfg):
+        import hermes_cli.config as hc
+        monkeypatch.setattr(hc, "load_config", lambda: {"memory": mem_cfg})
+
+    def test_visible_when_both_enabled(self, monkeypatch):
+        self._patch_cfg(monkeypatch, {"memory_enabled": True, "user_profile_enabled": True})
+        assert check_memory_requirements() is True
+
+    def test_visible_when_only_memory_enabled(self, monkeypatch):
+        self._patch_cfg(monkeypatch, {"memory_enabled": True, "user_profile_enabled": False})
+        assert check_memory_requirements() is True
+
+    def test_visible_when_only_user_enabled(self, monkeypatch):
+        self._patch_cfg(monkeypatch, {"memory_enabled": False, "user_profile_enabled": True})
+        assert check_memory_requirements() is True
+
+    def test_hidden_when_both_disabled(self, monkeypatch):
+        self._patch_cfg(monkeypatch, {"memory_enabled": False, "user_profile_enabled": False})
+        assert check_memory_requirements() is False
+
+    def test_fails_open_when_no_memory_section(self, monkeypatch):
+        self._patch_cfg(monkeypatch, {})
+        assert check_memory_requirements() is True
+
+    def test_fails_open_on_config_error(self, monkeypatch):
+        import hermes_cli.config as hc
+        def _boom():
+            raise RuntimeError("config unreadable")
+        monkeypatch.setattr(hc, "load_config", _boom)
+        assert check_memory_requirements() is True
 
 
 # =========================================================================

--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -1131,8 +1131,24 @@ def memory_tool(
 
 
 def check_memory_requirements() -> bool:
-    """Memory tool has no external requirements -- always available."""
-    return True
+    """Gate the built-in memory tool on the active profile's config.
+
+    Hidden when BOTH built-in stores are disabled (external-provider-only
+    setups, e.g. Honcho-primary). Fails open: DEFAULT_CONFIG enables both
+    stores, and any config-read error keeps the tool available so normal
+    installs are unaffected. load_config() is imported lazily (and at call
+    time) so tests can monkeypatch hermes_cli.config.load_config.
+    """
+    try:
+        from hermes_cli.config import load_config
+
+        mem_cfg = (load_config() or {}).get("memory", {}) or {}
+        return bool(
+            mem_cfg.get("memory_enabled", True)
+            or mem_cfg.get("user_profile_enabled", True)
+        )
+    except Exception:
+        return True
 
 
 def apply_memory_pending(payload: Dict[str, Any], store: "MemoryStore") -> Dict[str, Any]:


### PR DESCRIPTION
## Problem

When a profile disables both built-in memory stores (`memory.memory_enabled: false` and `memory.user_profile_enabled: false`) — the Honcho-primary setup — `agent_init` never constructs a `MemoryStore`, yet the built-in `memory` tool schema is still advertised to the model. Every call to it then fails with `Memory is not available`, wasting a tool round-trip and confusing the model into retrying.

## Fix

Gate the built-in memory tool on the active profile's config:

- `check_memory_requirements()` returns `False` only when **both** built-in stores are disabled; external provider tools (e.g. `honcho_*`) are injected separately and are unaffected.
- `get_tool_definitions()` discards `memory` from the resolved toolset under the same condition.
- **Fails open**: `DEFAULT_CONFIG` enables both stores, and any config-read error keeps the tool available, so normal installs are untouched.
- `load_config` is imported lazily at call time so tests can monkeypatch it.

## Test plan

```
pytest tests/tools/test_memory_tool.py -q   # 43 passed (6 new gate tests)
pytest tests/test_model_tools.py -q         # all pass
ruff check <touched files>                  # clean
```

Verified against current `main` (`50d98fc1f`).