### PR TITLE
feat(discord): thread permission correctness

### DIFF
--- a/contributors/emails/andrexibiza@gmail.com
+++ b/contributors/emails/andrexibiza@gmail.com
@@ -1,0 +1,2 @@
+andrexibiza
+# Discord omniscience T5

--- a/plugins/platforms/discord/thread_permissions.py
+++ b/plugins/platforms/discord/thread_permissions.py
@@ -1,0 +1,91 @@
+"""Pure-logic helpers for Discord thread permission correctness.
+
+Discord models thread-related permissions as bits in a 64-bit permission
+value.  These helpers answer three questions:
+
+* can the bot create a thread of the requested visibility at all?
+* can it fall back to sending messages in the parent channel / existing
+  threads instead?
+* what is the specific permission gap, if any?
+"""
+
+CREATE_PUBLIC_THREADS = 1 << 43
+"""Permission to create public threads (Discord permission bit 43)."""
+
+CREATE_PRIVATE_THREADS = 1 << 44
+"""Permission to create private threads (Discord permission bit 44)."""
+
+SEND_MESSAGES_IN_THREADS = 1 << 38
+"""Permission to send messages in threads (Discord permission bit 38)."""
+
+
+class ThreadPermissionError(ValueError):
+    """Raised when ``permission_bits`` is not a non-negative integer."""
+
+
+def _validate(permission_bits):
+    if isinstance(permission_bits, bool) or not isinstance(permission_bits, int):
+        raise ThreadPermissionError(
+            "permission_bits must be a non-negative integer, "
+            f"got {permission_bits!r}"
+        )
+    if permission_bits < 0:
+        raise ThreadPermissionError(
+            f"permission_bits must be non-negative, got {permission_bits!r}"
+        )
+
+
+def can_create_thread(permission_bits, *, private):
+    """Return True when a thread of the requested visibility can be created.
+
+    Creating a private thread requires CREATE_PRIVATE_THREADS; creating a
+    public thread requires CREATE_PUBLIC_THREADS.  Either way the caller
+    must also hold SEND_MESSAGES_IN_THREADS.
+    """
+    _validate(permission_bits)
+    if not (permission_bits & SEND_MESSAGES_IN_THREADS):
+        return False
+    create_bit = CREATE_PRIVATE_THREADS if private else CREATE_PUBLIC_THREADS
+    return bool(permission_bits & create_bit)
+
+
+def fallback_eligible(permission_bits):
+    """Return True when the caller can still send in existing threads.
+
+    Holding SEND_MESSAGES_IN_THREADS means the bot can fall back to
+    messaging in the parent channel / existing threads even when it cannot
+    create a new thread.
+    """
+    _validate(permission_bits)
+    return bool(permission_bits & SEND_MESSAGES_IN_THREADS)
+
+
+def classify_thread_permission_failure(permission_bits, *, private):
+    """Classify why thread creation is not possible, or return ``'ok'``.
+
+    Returns one of:
+
+    * ``'ok'`` -- thread creation is permitted.
+    * ``'missing_create_private'`` -- a private thread was requested but
+      CREATE_PRIVATE_THREADS is absent (sending in threads is still
+      possible).
+    * ``'missing_create_public'`` -- a public thread was requested but
+      CREATE_PUBLIC_THREADS is absent (sending in threads is still
+      possible).
+    * ``'missing_send_threads'`` -- the required create bit is present but
+      SEND_MESSAGES_IN_THREADS is absent.
+    * ``'no_fallback'`` -- neither the required create bit nor
+      SEND_MESSAGES_IN_THREADS is present: creation is impossible and there
+      is no fallback channel either.
+    """
+    _validate(permission_bits)
+    if can_create_thread(permission_bits, private=private):
+        return "ok"
+    create_bit = CREATE_PRIVATE_THREADS if private else CREATE_PUBLIC_THREADS
+    has_create = bool(permission_bits & create_bit)
+    has_send = bool(permission_bits & SEND_MESSAGES_IN_THREADS)
+    if not has_create and not has_send:
+        return "no_fallback"
+    if not has_create:
+        return "missing_create_private" if private else "missing_create_public"
+    return "missing_send_threads"

--- a/tests/tools/test_discord_thread_permissions.py
+++ b/tests/tools/test_discord_thread_permissions.py
@@ -1,0 +1,136 @@
+"""Tests for plugins.platforms.discord.thread_permissions."""
+
+import pytest
+
+from plugins.platforms.discord.thread_permissions import (
+    CREATE_PRIVATE_THREADS,
+    CREATE_PUBLIC_THREADS,
+    SEND_MESSAGES_IN_THREADS,
+    ThreadPermissionError,
+    can_create_thread,
+    classify_thread_permission_failure,
+    fallback_eligible,
+)
+
+FULL_PUBLIC = CREATE_PUBLIC_THREADS | SEND_MESSAGES_IN_THREADS
+FULL_PRIVATE = CREATE_PRIVATE_THREADS | SEND_MESSAGES_IN_THREADS
+
+
+class TestBitConstants:
+    def test_values_match_discord(self):
+        assert CREATE_PUBLIC_THREADS == 1 << 43
+        assert CREATE_PRIVATE_THREADS == 1 << 44
+        assert SEND_MESSAGES_IN_THREADS == 1 << 38
+
+
+class TestCanCreateThread:
+    def test_public_create_with_send(self):
+        assert can_create_thread(FULL_PUBLIC, private=False) is True
+
+    def test_private_create_with_send(self):
+        assert can_create_thread(FULL_PRIVATE, private=True) is True
+
+    def test_public_requires_public_bit(self):
+        assert (
+            can_create_thread(
+                CREATE_PRIVATE_THREADS | SEND_MESSAGES_IN_THREADS,
+                private=False,
+            )
+            is False
+        )
+
+    def test_private_requires_private_bit(self):
+        assert (
+            can_create_thread(
+                CREATE_PUBLIC_THREADS | SEND_MESSAGES_IN_THREADS,
+                private=True,
+            )
+            is False
+        )
+
+    def test_send_threads_required_for_public(self):
+        assert can_create_thread(CREATE_PUBLIC_THREADS, private=False) is False
+
+    def test_send_threads_required_for_private(self):
+        assert can_create_thread(CREATE_PRIVATE_THREADS, private=True) is False
+
+    def test_zero_bits_never_allowed(self):
+        assert can_create_thread(0, private=False) is False
+        assert can_create_thread(0, private=True) is False
+
+    def test_invalid_bits_raise(self):
+        for bad in (-1, "abc", 1.5, None, True):
+            with pytest.raises(ThreadPermissionError):
+                can_create_thread(bad, private=False)
+            with pytest.raises(ThreadPermissionError):
+                can_create_thread(bad, private=True)
+
+
+class TestFallbackEligible:
+    def test_send_bit_means_eligible(self):
+        assert fallback_eligible(SEND_MESSAGES_IN_THREADS) is True
+        assert fallback_eligible(FULL_PUBLIC) is True
+        assert fallback_eligible(FULL_PRIVATE) is True
+
+    def test_missing_send_bit_means_not_eligible(self):
+        assert fallback_eligible(0) is False
+        assert fallback_eligible(CREATE_PUBLIC_THREADS) is False
+        assert fallback_eligible(CREATE_PRIVATE_THREADS) is False
+
+    def test_invalid_bits_raise(self):
+        for bad in (-1, "abc", 1.5, None, False):
+            with pytest.raises(ThreadPermissionError):
+                fallback_eligible(bad)
+
+
+class TestClassifyThreadPermissionFailure:
+    def test_ok_public(self):
+        assert classify_thread_permission_failure(FULL_PUBLIC, private=False) == "ok"
+
+    def test_ok_private(self):
+        assert classify_thread_permission_failure(FULL_PRIVATE, private=True) == "ok"
+
+    def test_missing_create_private(self):
+        bits = CREATE_PUBLIC_THREADS | SEND_MESSAGES_IN_THREADS
+        assert classify_thread_permission_failure(bits, private=True) == "missing_create_private"
+
+    def test_missing_create_public(self):
+        bits = CREATE_PRIVATE_THREADS | SEND_MESSAGES_IN_THREADS
+        assert classify_thread_permission_failure(bits, private=False) == "missing_create_public"
+
+    def test_missing_send_threads(self):
+        assert (
+            classify_thread_permission_failure(CREATE_PUBLIC_THREADS, private=False)
+            == "missing_send_threads"
+        )
+        assert (
+            classify_thread_permission_failure(CREATE_PRIVATE_THREADS, private=True)
+            == "missing_send_threads"
+        )
+
+    def test_no_fallback_when_nothing_available(self):
+        assert classify_thread_permission_failure(0, private=True) == "no_fallback"
+        assert classify_thread_permission_failure(0, private=False) == "no_fallback"
+        # Irrelevant create bit for the requested visibility, and no send bit.
+        assert (
+            classify_thread_permission_failure(CREATE_PRIVATE_THREADS, private=False)
+            == "no_fallback"
+        )
+
+    def test_invalid_bits_raise(self):
+        for bad in (-1, "abc", 1.5, None, True):
+            with pytest.raises(ThreadPermissionError):
+                classify_thread_permission_failure(bad, private=False)
+
+
+class TestThreadPermissionError:
+    def test_is_value_error(self):
+        assert issubclass(ThreadPermissionError, ValueError)
+
+    def test_negative_bits_raise(self):
+        with pytest.raises(ThreadPermissionError):
+            can_create_thread(-1, private=False)
+        with pytest.raises(ThreadPermissionError):
+            fallback_eligible(-1)
+        with pytest.raises(ThreadPermissionError):
+            classify_thread_permission_failure(-1, private=True)


### PR DESCRIPTION
## Summary

Thread permission correctness for Discord — public/private thread creation bits, send-in-threads requirement, fallback eligibility, and failure classification.

## Motivation

Fixes #86521 · Part of #79564

## Changes

- New module `plugins/platforms/discord/thread_permissions.py` implementing thread-permission checks (create-public/private, send-in-threads, fallback) and failure classification.

## Test Plan

- [x] Unit tests pass (`pytest`)
- [x] Focused regression tests: `tests/tools/test_discord_thread_permissions.py` — 21 passed
- [ ] Manual testing of new functionality
- [x] No regressions in existing behavior

## Notes for Reviewers

- New module only — no god-file growth; `plugins/platforms/discord/adapter.py` untouched.