### PR TITLE
feat(discord): slash-command autocomplete option fidelity

### DIFF
--- a/contributors/emails/andrexibiza@gmail.com
+++ b/contributors/emails/andrexibiza@gmail.com
@@ -1,0 +1,2 @@
+andrexibiza
+# Discord omniscience I3

--- a/plugins/platforms/discord/autocomplete.py
+++ b/plugins/platforms/discord/autocomplete.py
@@ -1,0 +1,87 @@
+"""Discord slash-command autocomplete option fidelity (feature I3).
+
+Pure logic helpers for building Discord autocomplete choices and
+normalizing a clicked suggestion back to a canonical option, so values
+round-trip exactly through the picker.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+__all__ = [
+    "AutocompleteChoice",
+    "AutocompleteError",
+    "MAX_CHOICES",
+    "build_choices",
+    "normalize_clicked_value",
+    "roundtrip_value",
+]
+
+# Discord's hard limit on the number of autocomplete choices per response.
+MAX_CHOICES = 25
+
+
+class AutocompleteError(ValueError):
+    """Raised when a clicked autocomplete value cannot be normalized."""
+
+
+@dataclass(frozen=True)
+class AutocompleteChoice:
+    """A single Discord autocomplete choice.
+
+    ``name`` is what the user sees in the picker and ``value`` is what gets
+    submitted; for option fidelity they are always identical.
+    """
+
+    name: str
+    value: str
+
+
+def build_choices(
+    options: list[str], *, max_choices: int = MAX_CHOICES, query: str = ""
+) -> list[AutocompleteChoice]:
+    """Build Discord autocomplete choices from canonical option strings.
+
+    Every option is stripped; only options containing the query as a
+    case-insensitive substring are kept (empty query keeps everything); and
+    the result is clamped to ``max_choices``. Each choice has ``name ==
+    value`` so the picker round-trips exactly.
+    """
+    normalized = [option.strip() for option in options]
+    needle = query.strip().lower()
+    if needle:
+        matched = [option for option in normalized if needle in option.lower()]
+    else:
+        matched = normalized
+    choices = [AutocompleteChoice(name=option, value=option) for option in matched]
+    return choices[:max_choices]
+
+
+def normalize_clicked_value(clicked: str, options: list[str]) -> str:
+    """Map a clicked slash-command suggestion back to a canonical option.
+
+    Resolution order: exact match wins, then case-insensitive match, then the
+    clicked value itself (trimmed). Raises :class:`AutocompleteError` when the
+    clicked value is empty (or whitespace only).
+    """
+    clicked = clicked.strip()
+    if not clicked:
+        raise AutocompleteError("clicked autocomplete value must not be empty")
+    for option in options:
+        if option == clicked:
+            return option
+    lowered = clicked.lower()
+    for option in options:
+        if option.lower() == lowered:
+            return option
+    return clicked
+
+
+def roundtrip_value(model_value: str) -> str:
+    """Return the value unchanged.
+
+    Identity by design: the value submitted through the picker must equal the
+    canonical model value exactly.
+    """
+    return model_value

--- a/tests/tools/test_discord_autocomplete.py
+++ b/tests/tools/test_discord_autocomplete.py
@@ -1,0 +1,81 @@
+"""Tests for Discord slash-command autocomplete option fidelity (feature I3)."""
+
+import pytest
+
+from plugins.platforms.discord.autocomplete import (
+    AutocompleteChoice,
+    AutocompleteError,
+    build_choices,
+    normalize_clicked_value,
+    roundtrip_value,
+)
+
+
+class TestBuildChoices:
+    def test_filters_by_case_insensitive_substring(self):
+        options = ["Alpha", "beta", "alphabet", "Gamma", "Delta"]
+        choices = build_choices(options, query="ALP")
+        assert [c.value for c in choices] == ["Alpha", "alphabet"]
+
+    def test_empty_query_returns_all_options(self):
+        options = ["a", "b", "c"]
+        choices = build_choices(options, query="")
+        assert [c.value for c in choices] == options
+
+    def test_strips_options(self):
+        options = ["  spaced  ", "clean"]
+        choices = build_choices(options)
+        assert [c.name for c in choices] == ["spaced", "clean"]
+        assert all(c.name == c.value for c in choices)
+
+    def test_clamps_to_discord_max_of_25(self):
+        options = [f"option-{i}" for i in range(40)]
+        choices = build_choices(options)
+        assert len(choices) == 25
+        assert choices[0].value == "option-0"
+        assert choices[-1].value == "option-24"
+
+    def test_respects_custom_max_choices(self):
+        choices = build_choices(["a", "b", "c"], max_choices=2)
+        assert [c.value for c in choices] == ["a", "b"]
+
+    def test_returns_choice_objects(self):
+        choices = build_choices(["x"], query="x")
+        assert isinstance(choices[0], AutocompleteChoice)
+
+    def test_whitespace_query_matches_all(self):
+        choices = build_choices(["a", "b"], query="   ")
+        assert [c.value for c in choices] == ["a", "b"]
+
+
+class TestNormalizeClickedValue:
+    def test_exact_match_wins(self):
+        assert normalize_clicked_value("Alpha", ["Alpha", "beta"]) == "Alpha"
+
+    def test_case_insensitive_match(self):
+        assert normalize_clicked_value("ALPHA", ["Alpha", "beta"]) == "Alpha"
+
+    def test_fallback_returns_clicked_trimmed(self):
+        assert normalize_clicked_value("  unknown-value  ", ["Alpha"]) == "unknown-value"
+
+    def test_empty_raises_autocomplete_error(self):
+        with pytest.raises(AutocompleteError):
+            normalize_clicked_value("", ["Alpha"])
+
+    def test_whitespace_only_raises(self):
+        with pytest.raises(ValueError):
+            normalize_clicked_value("   ", ["Alpha"])
+
+    def test_exact_match_preferred_over_case_insensitive(self):
+        assert normalize_clicked_value("FOO", ["foo", "FOO"]) == "FOO"
+
+
+class TestRoundtripValue:
+    def test_identity(self):
+        assert roundtrip_value("some-model-value") == "some-model-value"
+
+    def test_identity_preserves_whitespace(self):
+        assert roundtrip_value("  with whitespace  ") == "  with whitespace  "
+
+    def test_identity_empty(self):
+        assert roundtrip_value("") == ""


### PR DESCRIPTION
## Summary

Slash-command autocomplete option fidelity — choice building with filtering and clamping, clicked-suggestion normalization, and exact value round-trip.

## Motivation

Fixes #86535 · Part of #79564

## Changes

- New module `plugins/platforms/discord/autocomplete.py` implementing autocomplete choice building, clicked-value normalization, and value round-trip.

## Test Plan

- [x] Unit tests pass (`pytest`)
- [x] Focused regression tests: `tests/tools/test_discord_autocomplete.py` — 16 passed
- [ ] Manual testing of new functionality
- [x] No regressions in existing behavior

## Notes for Reviewers

- New module only — no god-file growth; `plugins/platforms/discord/adapter.py` untouched.