### PR TITLE
feat(discord): component authorization seam

### DIFF
--- a/contributors/emails/andrexibiza@gmail.com
+++ b/contributors/emails/andrexibiza@gmail.com
@@ -1,0 +1,2 @@
+andrexibiza
+# Discord omniscience I4

--- a/plugins/platforms/discord/component_auth.py
+++ b/plugins/platforms/discord/component_auth.py
@@ -1,0 +1,104 @@
+"""Discord component authorization seam (feature I4).
+
+Pure-logic guards for Discord interaction components:
+
+* :class:`ComponentAuthPolicy` decides whether an actor may drive a
+  component (allowlist, owner, or privileged roles) and whether the
+  component's originating view is stale.
+* :func:`reused_custom_id` detects reuse of a custom id across the
+  session, which is a classic replay vector for button components.
+
+All checks fail closed: anything that is not explicitly allowed is denied.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Iterable, Optional, Set, Union
+
+UserId = Union[str, int]
+RoleId = Union[str, int]
+
+
+class ComponentAuthError(ValueError):
+    """Raised when the component authorization seam receives invalid input."""
+
+
+def _canonical(ids: Optional[Iterable[Union[str, int]]]) -> Set[str]:
+    """Normalize ids to strings so str/int variants compare equal."""
+    return {str(i) for i in (ids or ())}
+
+
+class ComponentAuthPolicy:
+    """Authorization policy for Discord component interactions.
+
+    An actor is authorized when any of these hold:
+
+    1. their user id is in the configured ``allowlist``,
+    2. they are the ``owner_id`` of the component interaction, or
+    3. any role they hold (passed via ``allowed_role_ids``) is in the
+       policy's ``admin_role_ids``.
+
+    Everything else is denied (fail closed).
+    """
+
+    def __init__(
+        self,
+        allowlist: Optional[Set[UserId]] = None,
+        admin_role_ids: Optional[Set[RoleId]] = None,
+    ) -> None:
+        self.allowlist: Set[str] = _canonical(allowlist)
+        self.admin_role_ids: Set[str] = _canonical(admin_role_ids)
+
+    def authorize(
+        self,
+        actor_user_id: UserId,
+        *,
+        owner_id: Optional[UserId] = None,
+        allowed_role_ids: Optional[Set[RoleId]] = None,
+    ) -> bool:
+        """Return True if ``actor_user_id`` may act on the component.
+
+        ``allowed_role_ids`` carries the roles the actor actually holds;
+        authorization requires one of them to be a configured admin role.
+        """
+        actor = str(actor_user_id)
+        if actor in self.allowlist:
+            return True
+        if owner_id is not None and actor == str(owner_id):
+            return True
+        actor_roles = _canonical(allowed_role_ids)
+        if actor_roles & self.admin_role_ids:
+            return True
+        return False
+
+    def is_expired(self, created_at_ts: float, *, max_age_seconds: float = 900) -> bool:
+        """Return True when the component view is stale.
+
+        A view created at ``created_at_ts`` is expired once more than
+        ``max_age_seconds`` have elapsed. ``created_at_ts`` must be a
+        non-negative number, otherwise :class:`ComponentAuthError` is raised.
+        """
+        if isinstance(created_at_ts, bool) or not isinstance(created_at_ts, (int, float)):
+            raise ComponentAuthError(
+                f"created_at_ts must be a non-negative number, got {created_at_ts!r}"
+            )
+        if created_at_ts < 0:
+            raise ComponentAuthError(
+                f"created_at_ts must be non-negative, got {created_at_ts!r}"
+            )
+        return time.time() - created_at_ts > max_age_seconds
+
+
+def reused_custom_id(custom_id: str, seen_ids: Set[str]) -> bool:
+    """Return True if ``custom_id`` was already seen (reuse/replay).
+
+    New ids are recorded in ``seen_ids`` and return False. An empty
+    ``custom_id`` raises :class:`ComponentAuthError`.
+    """
+    if not isinstance(custom_id, str) or not custom_id:
+        raise ComponentAuthError("custom_id must be a non-empty string")
+    if custom_id in seen_ids:
+        return True
+    seen_ids.add(custom_id)
+    return False

--- a/tests/tools/test_discord_component_auth.py
+++ b/tests/tools/test_discord_component_auth.py
@@ -1,0 +1,101 @@
+"""Tests for the Discord component authorization seam (feature I4)."""
+
+import time
+
+import pytest
+
+from plugins.platforms.discord.component_auth import (
+    ComponentAuthError,
+    ComponentAuthPolicy,
+    reused_custom_id,
+)
+
+
+class TestComponentAuthPolicyAuthorize:
+    def test_allowlist_allows_known_actor(self):
+        policy = ComponentAuthPolicy(allowlist={"111", "222"})
+        assert policy.authorize("111") is True
+        assert policy.authorize("222") is True
+
+    def test_allowlist_denies_unknown_actor(self):
+        policy = ComponentAuthPolicy(allowlist={"111"})
+        assert policy.authorize("999") is False
+
+    def test_allowlist_ignores_int_str_mismatch(self):
+        policy = ComponentAuthPolicy(allowlist={111})
+        assert policy.authorize("111") is True
+        assert policy.authorize(222) is False
+
+    def test_owner_allows(self):
+        policy = ComponentAuthPolicy()
+        assert policy.authorize("111", owner_id="111") is True
+
+    def test_owner_denies_other_actor(self):
+        policy = ComponentAuthPolicy()
+        assert policy.authorize("111", owner_id="222") is False
+
+    def test_role_allows(self):
+        policy = ComponentAuthPolicy(admin_role_ids={"role-admin"})
+        assert policy.authorize("111", allowed_role_ids={"role-admin"}) is True
+
+    def test_role_denies_unprivileged_role(self):
+        policy = ComponentAuthPolicy(admin_role_ids={"role-admin"})
+        assert policy.authorize("111", allowed_role_ids={"role-user"}) is False
+
+    def test_fail_closed_default(self):
+        policy = ComponentAuthPolicy()
+        assert policy.authorize("111") is False
+        assert policy.authorize("111", owner_id="222") is False
+        assert policy.authorize("111", allowed_role_ids={"role-admin"}) is False
+
+
+class TestComponentAuthPolicyIsExpired:
+    def test_fresh_view_not_expired(self):
+        policy = ComponentAuthPolicy()
+        assert policy.is_expired(time.time() - 60) is False
+
+    def test_stale_view_expired(self):
+        policy = ComponentAuthPolicy()
+        assert policy.is_expired(time.time() - 1800) is True
+
+    def test_custom_max_age(self):
+        policy = ComponentAuthPolicy()
+        assert policy.is_expired(time.time() - 120, max_age_seconds=60) is True
+        assert policy.is_expired(time.time() - 30, max_age_seconds=60) is False
+
+    def test_negative_timestamp_raises(self):
+        policy = ComponentAuthPolicy()
+        with pytest.raises(ComponentAuthError):
+            policy.is_expired(-1.0)
+
+    def test_non_numeric_timestamp_raises(self):
+        policy = ComponentAuthPolicy()
+        with pytest.raises(ComponentAuthError):
+            policy.is_expired("now")
+
+    def test_error_is_value_error(self):
+        assert issubclass(ComponentAuthError, ValueError)
+
+
+class TestReusedCustomId:
+    def test_new_custom_id_recorded(self):
+        seen = set()
+        assert reused_custom_id("button:123", seen) is False
+        assert "button:123" in seen
+
+    def test_stale_reused_custom_id_detected(self):
+        seen = {"button:123"}
+        assert reused_custom_id("button:123", seen) is True
+
+    def test_second_use_is_reuse(self):
+        seen = set()
+        reused_custom_id("button:123", seen)
+        assert reused_custom_id("button:123", seen) is True
+
+    def test_empty_custom_id_raises(self):
+        with pytest.raises(ComponentAuthError):
+            reused_custom_id("", set())
+
+    def test_none_custom_id_raises(self):
+        with pytest.raises(ComponentAuthError):
+            reused_custom_id(None, set())


### PR DESCRIPTION
## Summary

Component authorization seam for Discord interactions — fail-closed actor authorization, stale/expired-view guard, and reused-custom-id detection.

## Motivation

Fixes #86536 · Part of #79564

## Changes

- New module `plugins/platforms/discord/component_auth.py` implementing allowlist/owner/role authorization (fail-closed deny), expiry guard, and reused-custom-id detection.

## Test Plan

- [x] Unit tests pass (`pytest`)
- [x] Focused regression tests: `tests/tools/test_discord_component_auth.py` — 19 passed
- [ ] Manual testing of new functionality
- [x] No regressions in existing behavior

## Notes for Reviewers

- New module only — no god-file growth; `plugins/platforms/discord/adapter.py` untouched.