### PR TITLE
feat(discord): native voice-message validation

### DIFF
--- a/contributors/emails/andrexibiza@gmail.com
+++ b/contributors/emails/andrexibiza@gmail.com
@@ -1,0 +1,2 @@
+andrexibiza
+# Discord omniscience V1

--- a/plugins/platforms/discord/voice_message.py
+++ b/plugins/platforms/discord/voice_message.py
@@ -1,0 +1,102 @@
+"""Discord native voice-message container validation (pure logic, no audio processing).
+
+Discord native voice messages are OGG containers (Opus codec) uploaded with
+content type ``audio/ogg`` or ``application/ogg``.  This module decides, from
+metadata alone, whether an attachment may be treated as a native Discord voice
+message or must fall back to a normal attachment.  It never inspects or
+transcodes audio bytes.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+# Content types Discord serves native voice messages with.
+NATIVE_OGG_CONTENT_TYPES = frozenset({"audio/ogg", "application/ogg"})
+
+# Discord's practical cap for voice-message uploads (25 MiB).
+DEFAULT_MAX_BYTES = 25 * 1024 * 1024
+
+
+class VoiceMessageError(ValueError):
+    """Raised when an attachment cannot be handled as a native voice message."""
+
+
+@dataclass(frozen=True)
+class VoiceAttachment:
+    """Metadata describing a single attachment (no binary payload)."""
+
+    filename: str
+    size_bytes: int | None = None
+    content_type: str | None = None
+
+
+def is_native_ogg(filename: str) -> bool:
+    """Return True if *filename* ends in ``.ogg`` (case-insensitive)."""
+    return filename.lower().endswith(".ogg")
+
+
+def validate_native_voice_attachment(att: VoiceAttachment) -> str:
+    """Return *att.filename* if the attachment is already a Discord-native OGG.
+
+    A native voice message must have an ``.ogg`` extension and, when a content
+    type is present, it must be ``audio/ogg`` or ``application/ogg``.  Any
+    other combination (e.g. an MP3 or WAV renamed to ``.ogg``, or a plain
+    MP3/WAV) raises :class:`VoiceMessageError`: arbitrary audio cannot be
+    renamed and relabeled as a native voice message -- it must travel as a
+    normal attachment instead.
+    """
+    if not is_native_ogg(att.filename):
+        raise VoiceMessageError(
+            f"attachment {att.filename!r} is not a native Discord voice message: "
+            f"expected an .ogg container"
+        )
+    if (
+        att.content_type is not None
+        and att.content_type not in NATIVE_OGG_CONTENT_TYPES
+    ):
+        raise VoiceMessageError(
+            f"attachment {att.filename!r} cannot be labeled as a native voice "
+            f"message: content type {att.content_type!r} is not Discord-native OGG"
+        )
+    return att.filename
+
+
+def voice_attachment_policy(
+    att: VoiceAttachment, *, max_bytes: int = DEFAULT_MAX_BYTES
+) -> str:
+    """Return the routing policy for *att*: ``'native'`` or ``'normal_attachment'``.
+
+    - ``'native'``: the attachment is valid native OGG (extension + content
+      type, when given) and its size is within *max_bytes*.
+    - ``'normal_attachment'``: the attachment is not native OGG -- it falls
+      back to a normal attachment (never a silent drop).
+    - :class:`VoiceMessageError` is raised when the size exceeds *max_bytes*.
+    """
+    if att.size_bytes is not None and att.size_bytes > max_bytes:
+        raise VoiceMessageError(
+            f"attachment {att.filename!r} is {att.size_bytes} bytes, "
+            f"exceeding the {max_bytes}-byte voice-message limit"
+        )
+    if is_native_ogg(att.filename) and (
+        att.content_type is None or att.content_type in NATIVE_OGG_CONTENT_TYPES
+    ):
+        return "native"
+    return "normal_attachment"
+
+
+def enforce_single_audio(attachments: list) -> None:
+    """Raise :class:`VoiceMessageError` if *attachments* holds >1 audio file.
+
+    Audio attachments are identified by a content type starting with
+    ``audio/``.  A single audio attachment (or none) is allowed.
+    """
+    audio = [
+        a for a in attachments
+        if a.content_type is not None and a.content_type.startswith("audio/")
+    ]
+    if len(audio) > 1:
+        raise VoiceMessageError(
+            f"expected at most one audio attachment per message, "
+            f"got {len(audio)}"
+        )

--- a/tests/tools/test_discord_native_voice_message.py
+++ b/tests/tools/test_discord_native_voice_message.py
@@ -1,0 +1,197 @@
+"""Tests for Discord native voice-message container validation (feature V1)."""
+
+import pytest
+
+from plugins.platforms.discord.voice_message import (
+    DEFAULT_MAX_BYTES,
+    VoiceAttachment,
+    VoiceMessageError,
+    enforce_single_audio,
+    is_native_ogg,
+    validate_native_voice_attachment,
+    voice_attachment_policy,
+)
+
+
+# ---------------------------------------------------------------------------
+# validate_native_voice_attachment
+# ---------------------------------------------------------------------------
+
+def test_native_ogg_audio_ogg_accepted():
+    att = VoiceAttachment(
+        filename="voice-message.ogg", size_bytes=4096, content_type="audio/ogg"
+    )
+    assert validate_native_voice_attachment(att) == "voice-message.ogg"
+
+
+def test_native_ogg_application_ogg_accepted():
+    att = VoiceAttachment(
+        filename="voice-message.ogg", size_bytes=4096, content_type="application/ogg"
+    )
+    assert validate_native_voice_attachment(att) == "voice-message.ogg"
+
+
+def test_native_ogg_without_content_type_accepted():
+    att = VoiceAttachment(filename="voice-message.ogg", size_bytes=4096, content_type=None)
+    assert validate_native_voice_attachment(att) == "voice-message.ogg"
+
+
+def test_mp3_rejected():
+    att = VoiceAttachment(filename="recording.mp3", size_bytes=4096, content_type="audio/mpeg")
+    with pytest.raises(VoiceMessageError):
+        validate_native_voice_attachment(att)
+
+
+def test_wav_rejected():
+    att = VoiceAttachment(filename="recording.wav", size_bytes=4096, content_type="audio/wav")
+    with pytest.raises(VoiceMessageError):
+        validate_native_voice_attachment(att)
+
+
+def test_mp3_renamed_to_ogg_rejected():
+    # An MP3 cannot be renamed + labeled as a native voice message.
+    att = VoiceAttachment(filename="recording.ogg", size_bytes=4096, content_type="audio/mpeg")
+    with pytest.raises(VoiceMessageError):
+        validate_native_voice_attachment(att)
+
+
+def test_validate_error_is_value_error():
+    att = VoiceAttachment(filename="recording.mp3", size_bytes=4096, content_type="audio/mpeg")
+    with pytest.raises(ValueError):
+        validate_native_voice_attachment(att)
+
+
+# ---------------------------------------------------------------------------
+# is_native_ogg
+# ---------------------------------------------------------------------------
+
+def test_is_native_ogg_lowercase():
+    assert is_native_ogg("voice.ogg") is True
+
+
+def test_is_native_ogg_case_insensitive():
+    assert is_native_ogg("voice.OGG") is True
+    assert is_native_ogg("voice.Ogg") is True
+
+
+def test_is_native_ogg_rejects_other_extensions():
+    assert is_native_ogg("voice.mp3") is False
+    assert is_native_ogg("voice.wav") is False
+    assert is_native_ogg("voice") is False
+    assert is_native_ogg("voice.ogg.mp3") is False
+
+
+# ---------------------------------------------------------------------------
+# voice_attachment_policy
+# ---------------------------------------------------------------------------
+
+def test_policy_native_for_valid_ogg():
+    att = VoiceAttachment(filename="voice.ogg", size_bytes=1024, content_type="audio/ogg")
+    assert voice_attachment_policy(att) == "native"
+
+
+def test_policy_native_without_size():
+    att = VoiceAttachment(filename="voice.ogg", size_bytes=None, content_type="audio/ogg")
+    assert voice_attachment_policy(att) == "native"
+
+
+def test_policy_fallback_mp3_to_normal_attachment():
+    att = VoiceAttachment(filename="recording.mp3", size_bytes=1024, content_type="audio/mpeg")
+    assert voice_attachment_policy(att) == "normal_attachment"
+
+
+def test_policy_fallback_wav_to_normal_attachment():
+    att = VoiceAttachment(filename="recording.wav", size_bytes=1024, content_type="audio/wav")
+    assert voice_attachment_policy(att) == "normal_attachment"
+
+
+def test_policy_fallback_renamed_mp3_to_normal_attachment():
+    # Not silently dropped and not labeled native: falls back to a normal attachment.
+    att = VoiceAttachment(filename="recording.ogg", size_bytes=1024, content_type="audio/mpeg")
+    assert voice_attachment_policy(att) == "normal_attachment"
+
+
+def test_policy_fallback_no_content_type_non_ogg():
+    att = VoiceAttachment(filename="clip.mp4", size_bytes=1024, content_type=None)
+    assert voice_attachment_policy(att) == "normal_attachment"
+
+
+def test_policy_raises_when_over_default_max():
+    att = VoiceAttachment(
+        filename="voice.ogg",
+        size_bytes=DEFAULT_MAX_BYTES + 1,
+        content_type="audio/ogg",
+    )
+    with pytest.raises(VoiceMessageError):
+        voice_attachment_policy(att)
+
+
+def test_policy_raises_when_over_custom_max():
+    att = VoiceAttachment(filename="voice.ogg", size_bytes=2048, content_type="audio/ogg")
+    with pytest.raises(VoiceMessageError):
+        voice_attachment_policy(att, max_bytes=1024)
+
+
+def test_policy_at_max_is_allowed():
+    att = VoiceAttachment(filename="voice.ogg", size_bytes=DEFAULT_MAX_BYTES, content_type="audio/ogg")
+    assert voice_attachment_policy(att) == "native"
+
+
+def test_policy_oversized_non_native_also_raises():
+    # The size bound is enforced regardless of native-ness.
+    att = VoiceAttachment(filename="recording.mp3", size_bytes=DEFAULT_MAX_BYTES + 1, content_type="audio/mpeg")
+    with pytest.raises(VoiceMessageError):
+        voice_attachment_policy(att)
+
+
+# ---------------------------------------------------------------------------
+# enforce_single_audio
+# ---------------------------------------------------------------------------
+
+def test_single_audio_allowed():
+    attachments = [
+        VoiceAttachment(filename="voice.ogg", size_bytes=1024, content_type="audio/ogg"),
+    ]
+    enforce_single_audio(attachments)  # no raise
+
+
+def test_single_audio_with_non_audio_attachment_allowed():
+    attachments = [
+        VoiceAttachment(filename="voice.ogg", size_bytes=1024, content_type="audio/ogg"),
+        VoiceAttachment(filename="photo.png", size_bytes=1024, content_type="image/png"),
+    ]
+    enforce_single_audio(attachments)  # no raise
+
+
+def test_no_audio_attachment_allowed():
+    enforce_single_audio([])  # no raise
+    enforce_single_audio(
+        [VoiceAttachment(filename="doc.pdf", size_bytes=1024, content_type="application/pdf")]
+    )  # no raise
+
+
+def test_two_audio_attachments_raise():
+    attachments = [
+        VoiceAttachment(filename="a.mp3", size_bytes=1024, content_type="audio/mpeg"),
+        VoiceAttachment(filename="b.wav", size_bytes=1024, content_type="audio/wav"),
+    ]
+    with pytest.raises(VoiceMessageError):
+        enforce_single_audio(attachments)
+
+
+def test_two_native_ogg_attachments_raise():
+    attachments = [
+        VoiceAttachment(filename="a.ogg", size_bytes=1024, content_type="audio/ogg"),
+        VoiceAttachment(filename="b.ogg", size_bytes=1024, content_type="audio/ogg"),
+    ]
+    with pytest.raises(VoiceMessageError):
+        enforce_single_audio(attachments)
+
+
+def test_missing_content_type_not_counted_as_audio():
+    # Attachment with no content type cannot be identified as audio; allowed.
+    attachments = [
+        VoiceAttachment(filename="a.ogg", size_bytes=1024, content_type=None),
+        VoiceAttachment(filename="b.mp3", size_bytes=1024, content_type="audio/mpeg"),
+    ]
+    enforce_single_audio(attachments)  # no raise


### PR DESCRIPTION
## Summary

Native voice-message validation for Discord — only native OGG accepted as a voice message; other audio falls back to a normal attachment (never silently relabeled).

## Motivation

Fixes #86537 · Part of #79564

## Changes

- New module `plugins/platforms/discord/voice_message.py` implementing native-OGG validation, fallback-to-normal-attachment policy, size bounds, and the single-audio-attachment contract.

## Test Plan

- [x] Unit tests pass (`pytest`)
- [x] Focused regression tests: `tests/tools/test_discord_native_voice_message.py` — 26 passed
- [ ] Manual testing of new functionality
- [x] No regressions in existing behavior

## Notes for Reviewers

- New module only — no god-file growth; `plugins/platforms/discord/adapter.py` untouched.