### PR TITLE
feat(discord): profile routing acceptance matrix

### DIFF
--- a/contributors/emails/andrexibiza@gmail.com
+++ b/contributors/emails/andrexibiza@gmail.com
@@ -1,0 +1,2 @@
+andrexibiza
+# Discord omniscience W3

--- a/plugins/platforms/discord/profile_routing.py
+++ b/plugins/platforms/discord/profile_routing.py
@@ -1,0 +1,63 @@
+"""Discord profile routing acceptance matrix (W3).
+
+Pure logic: routes message deliveries to a registered, adapter-ready profile.
+Fail-closed: unknown profiles and unready adapters always raise
+:class:`ProfileRoutingError` (a ``ValueError`` subclass).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict
+
+
+class ProfileRoutingError(ValueError):
+    """Raised when a delivery cannot be routed to a profile/adapter."""
+
+
+@dataclass(frozen=True)
+class ProfileRoute:
+    """A resolved route target: a profile id and its adapter readiness."""
+
+    profile_id: str
+    adapter_ready: bool
+
+
+class ProfileRouter:
+    """Routes deliveries to registered, adapter-ready profiles."""
+
+    def __init__(self) -> None:
+        self._routes: Dict[str, ProfileRoute] = {}
+
+    def register(self, profile_id: str, adapter_ready: bool = True) -> None:
+        """Register (or re-register) a profile with its adapter readiness."""
+        self._routes[profile_id] = ProfileRoute(
+            profile_id=profile_id, adapter_ready=adapter_ready
+        )
+
+    def resolve(self, profile_id: str) -> ProfileRoute:
+        """Return the route for a profile, or raise if unknown/unready."""
+        route = self._routes.get(profile_id)
+        if route is None or not route.adapter_ready:
+            raise ProfileRoutingError(
+                f"profile {profile_id!r} is not registered or its adapter is not ready"
+            )
+        return route
+
+    def has_profile(self, profile_id: str) -> bool:
+        """True if the profile has been registered (regardless of readiness)."""
+        return profile_id in self._routes
+
+    def route_for(self, channel_id: str, profile_map: dict) -> str:
+        """Map a channel id to a profile id, fail-closed on any gap.
+
+        Raises :class:`ProfileRoutingError` if the channel is missing from
+        ``profile_map`` or the mapped profile is not registered/ready.
+        """
+        if channel_id not in profile_map:
+            raise ProfileRoutingError(
+                f"channel {channel_id!r} is not present in the profile map"
+            )
+        profile_id = profile_map[channel_id]
+        route = self.resolve(profile_id)
+        return route.profile_id

--- a/tests/tools/test_discord_profile_routing.py
+++ b/tests/tools/test_discord_profile_routing.py
@@ -1,0 +1,90 @@
+"""Tests for the W3 Discord profile routing acceptance matrix."""
+
+import pytest
+
+from plugins.platforms.discord.profile_routing import (
+    ProfileRoute,
+    ProfileRouter,
+    ProfileRoutingError,
+)
+
+
+def test_register_resolve_roundtrip():
+    router = ProfileRouter()
+    router.register("alice")
+    route = router.resolve("alice")
+    assert isinstance(route, ProfileRoute)
+    assert route == ProfileRoute(profile_id="alice", adapter_ready=True)
+    assert route.profile_id == "alice"
+    assert route.adapter_ready is True
+
+
+def test_unregistered_profile_raises():
+    router = ProfileRouter()
+    with pytest.raises(ProfileRoutingError):
+        router.resolve("ghost")
+    # ProfileRoutingError must remain a ValueError for fail-closed callers.
+    with pytest.raises(ValueError):
+        router.resolve("ghost")
+
+
+def test_unready_adapter_raises():
+    router = ProfileRouter()
+    router.register("bob", adapter_ready=False)
+    # Registered but unready -> still fail closed.
+    assert router.has_profile("bob")
+    with pytest.raises(ProfileRoutingError):
+        router.resolve("bob")
+
+
+def test_reregister_ready_to_unready_fails_closed():
+    router = ProfileRouter()
+    router.register("alice")
+    assert router.resolve("alice").adapter_ready is True
+    router.register("alice", adapter_ready=False)
+    with pytest.raises(ProfileRoutingError):
+        router.resolve("alice")
+
+
+def test_has_profile():
+    router = ProfileRouter()
+    assert router.has_profile("nobody") is False
+    router.register("carol")
+    assert router.has_profile("carol") is True
+    router.register("dave", adapter_ready=False)
+    assert router.has_profile("dave") is True
+
+
+def test_route_for_mapping():
+    router = ProfileRouter()
+    router.register("alice")
+    router.register("bob")
+    profile_map = {"channel-1": "alice", "channel-2": "bob"}
+    assert router.route_for("channel-1", profile_map) == "alice"
+    assert router.route_for("channel-2", profile_map) == "bob"
+
+
+def test_route_for_missing_channel_raises():
+    router = ProfileRouter()
+    router.register("alice")
+    with pytest.raises(ProfileRoutingError):
+        router.route_for("unknown-channel", {"channel-1": "alice"})
+
+
+def test_route_for_unregistered_profile_fail_closed():
+    router = ProfileRouter()
+    router.register("alice")
+    # Mapped profile was never registered.
+    with pytest.raises(ProfileRoutingError):
+        router.route_for("channel-9", {"channel-9": "ghost"})
+    # Mapped profile registered but adapter unready.
+    router.register("bob", adapter_ready=False)
+    with pytest.raises(ProfileRoutingError):
+        router.route_for("channel-8", {"channel-8": "bob"})
+
+
+def test_route_for_empty_map_fail_closed():
+    router = ProfileRouter()
+    router.register("alice")
+    with pytest.raises(ProfileRoutingError):
+        router.route_for("channel-1", {})


### PR DESCRIPTION
## Summary

Profile routing acceptance matrix for Discord multi-profile delivery — fail-closed profile/adapter resolution.

## Motivation

Fixes #86538 · Part of #79564

## Changes

- New module `plugins/platforms/discord/profile_routing.py` implementing profile registration, fail-closed resolution, and channel-to-profile routing.

## Test Plan

- [x] Unit tests pass (`pytest`)
- [x] Focused regression tests: `tests/tools/test_discord_profile_routing.py` — 9 passed
- [ ] Manual testing of new functionality
- [x] No regressions in existing behavior

## Notes for Reviewers

- New module only — no god-file growth; `plugins/platforms/discord/adapter.py` untouched.