### PR TITLE
fix(memory/honcho): inject curated peer cards before summaries/representations

### DIFF
--- a/plugins/memory/honcho/__init__.py
+++ b/plugins/memory/honcho/__init__.py
@@ -651,26 +651,32 @@ class HonchoMemoryProvider(MemoryProvider):
         """Format the prefetch context dict into a readable system prompt block."""
         parts = []
 
-        # Session summary — session-scoped context, placed first for relevance
-        summary = ctx.get("summary", "")
-        if summary:
-            parts.append(f"## Session Summary\n{summary}")
-
-        rep = ctx.get("representation", "")
-        if rep:
-            parts.append(f"## User Representation\n{rep}")
-
-        card = ctx.get("card", "")
+        # Curated cards are the durable, high-signal layer. Keep them ahead of
+        # summaries and free-form representations so final context-budget
+        # truncation can shorten episodic context without discarding standing facts.
+        card = (ctx.get("card") or "").strip()
         if card:
             parts.append(f"## User Peer Card\n{card}")
 
-        ai_rep = ctx.get("ai_representation", "")
-        if ai_rep:
-            parts.append(f"## AI Self-Representation\n{ai_rep}")
-
-        ai_card = ctx.get("ai_card", "")
+        ai_card = (ctx.get("ai_card") or "").strip()
         if ai_card:
             parts.append(f"## AI Identity Card\n{ai_card}")
+
+        # Session summary is useful but episodic; it follows both curated cards.
+        summary = (ctx.get("summary") or "").strip()
+        if summary:
+            parts.append(f"## Session Summary\n{summary}")
+
+        # A peer card supersedes the free-form representation for automatic
+        # injection. The full representation remains available through Honcho
+        # context/search/reasoning tools; use it here only as a cold-start fallback.
+        rep = (ctx.get("representation") or "").strip()
+        if rep and not card:
+            parts.append(f"## User Representation (fallback context)\n{rep}")
+
+        ai_rep = (ctx.get("ai_representation") or "").strip()
+        if ai_rep and not ai_card:
+            parts.append(f"## AI Self-Representation (fallback context)\n{ai_rep}")
 
         if not parts:
             return ""

--- a/tests/honcho_plugin/test_session.py
+++ b/tests/honcho_plugin/test_session.py
@@ -600,8 +600,8 @@ class TestDialecticCadenceDefaults:
 class TestBaseContextSummary:
     """Base context injection should include session summary when available."""
 
-    def test_format_includes_summary(self):
-        """Session summary should appear first in the formatted context."""
+    def test_format_prioritizes_cards_then_summary_before_representations(self):
+        """Curated cards should survive before summary and secondary context."""
         provider = HonchoMemoryProvider()
         ctx = {
             "summary": "Testing Honcho tools and dialectic depth.",
@@ -610,7 +610,65 @@ class TestBaseContextSummary:
         }
         formatted = provider._format_first_turn_context(ctx)
         assert "## Session Summary" in formatted
-        assert formatted.index("Session Summary") < formatted.index("User Representation")
+        assert formatted.index("User Peer Card") < formatted.index("Session Summary")
+        assert "User Representation" not in formatted
+
+
+    def test_curated_cards_survive_when_summary_and_raw_representations_exhaust_budget(self):
+        provider = HonchoMemoryProvider()
+        provider._config = SimpleNamespace(context_tokens=60)  # type: ignore[assignment]
+        budget_chars = 240
+        ctx = {
+            "summary": "session event summary " * 100,
+            "representation": "episodic user observation " * 100,
+            "card": "Standing rule: one-off approvals are task-scoped only.",
+            "ai_representation": "episodic assistant observation " * 100,
+            "ai_card": "Identity rule: verify before claiming completion.",
+        }
+
+        formatted = provider._format_first_turn_context(ctx)
+        injected = provider._truncate_to_budget(formatted)
+
+        assert "User Peer Card" in formatted
+        assert "AI Identity Card" in formatted
+        assert "User Representation" not in formatted
+        assert "AI Self-Representation" not in formatted
+        assert "Standing rule: one-off approvals are task-scoped only." in injected
+        assert "Identity rule: verify before claiming completion." in injected
+        assert len(injected) <= budget_chars + 2
+
+    def test_whitespace_only_card_falls_back_to_representation(self):
+        provider = HonchoMemoryProvider()
+        formatted = provider._format_first_turn_context({
+            "card": "   \n  ",
+            "representation": "Real user context.",
+        })
+        assert "User Peer Card" not in formatted
+        assert "## User Representation (fallback context)" in formatted
+        assert "Real user context." in formatted
+
+    def test_mixed_state_user_card_only_keeps_ai_fallback(self):
+        provider = HonchoMemoryProvider()
+        formatted = provider._format_first_turn_context({
+            "card": "Standing fact.",
+            "representation": "Raw user rep.",
+            "ai_representation": "AI fallback rep.",
+        })
+        assert "## User Peer Card" in formatted
+        assert "User Representation" not in formatted
+        assert "## AI Self-Representation (fallback context)" in formatted
+
+    def test_representations_remain_cold_start_fallbacks_without_cards(self):
+        provider = HonchoMemoryProvider()
+        formatted = provider._format_first_turn_context({
+            "representation": "User fallback context.",
+            "ai_representation": "AI fallback context.",
+        })
+
+        assert "## User Representation (fallback context)" in formatted
+        assert "User fallback context." in formatted
+        assert "## AI Self-Representation (fallback context)" in formatted
+        assert "AI fallback context." in formatted
 
 
     def test_timed_out_first_turn_context_surfaces_next_turn(self):


### PR DESCRIPTION
## Problem

`HonchoMemoryProvider._format_first_turn_context` builds the first-turn system-prompt block by concatenating, in order: session summary → user representation → user peer card → AI self-representation → AI identity card.

Curated peer **cards** are the durable, high-signal layer, but they were placed *after* the session summary and the free-form representation. When the downstream `_truncate_to_budget` step shortens the injected block to fit `context_tokens`, it truncates from the end — so a curated card could be dropped while lower-signal episodic text (summary, raw representation) survived. In practice a user whose curated card sat behind a large representation lost the card entirely on every injected turn.

## Fix

- **Curated cards first.** User Peer Card and AI Identity Card are emitted ahead of the session summary and representations, so budget truncation shortens episodic context without discarding standing facts.
- **Representations become cold-start fallbacks.** The free-form user/AI representations are auto-injected only when no corresponding curated card exists (`if rep and not card`). The full representation is unchanged and still retrievable on demand through Honcho's context/search/reasoning tools — this only changes what is injected *automatically* on the first turn.
- **Whitespace-only values treated as absent.** All card/summary/representation fields are `.strip()`-normalized so an empty-looking card can't suppress a meaningful fallback.

No public API, config, or stored data changes — only the ordering and gating of the automatically-injected first-turn block.

## Tests

Added/updated `tests/honcho_plugin/test_session.py`:
- cards ordered ahead of summary; representation absent when a card exists
- curated cards survive `_truncate_to_budget` when summary + raw representations would otherwise exhaust the budget
- representations still injected as fallbacks when no card exists
- whitespace-only card falls back to representation
- mixed state (user card only) keeps the AI representation fallback

The honcho-plugin suite passes locally.
