### PR TITLE
feat(discord): recovery cursor correctness

### DIFF
--- a/contributors/emails/andrexibiza@gmail.com
+++ b/contributors/emails/andrexibiza@gmail.com
@@ -1,0 +1,2 @@
+andrexibiza
+# Discord omniscience R3

--- a/plugins/platforms/discord/recovery_cursor.py
+++ b/plugins/platforms/discord/recovery_cursor.py
@@ -1,0 +1,119 @@
+"""Discord recovery cursor correctness (R3).
+
+Pure logic for tracking per-channel recovery cursors while draining
+Discord message history. A cursor records the highest (by numeric
+value) message id seen for a channel and whether more pages remain.
+
+Cursors are monotonic: a new ``advance`` for a channel must never move
+``last_message_id`` backward. Attempting to do so raises
+:class:`RecoveryCursorError`.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, List, Optional, Set
+
+
+class RecoveryCursorError(ValueError):
+    """Raised when a recovery cursor would move backward."""
+
+
+def _is_snowflake(value: object) -> bool:
+    """Return True if *value* is a Discord snowflake (int or digit string)."""
+    if isinstance(value, int):
+        return True
+    return isinstance(value, str) and value.isdigit()
+
+
+def _validate_snowflake(value: object, *, what: str) -> None:
+    if not _is_snowflake(value):
+        raise ValueError(
+            f"{what} must be a snowflake (int or digit string), got {value!r}"
+        )
+
+
+@dataclass(frozen=True)
+class Cursor:
+    """Recovery position for a single channel."""
+
+    channel_id: str
+    last_message_id: Optional[str]
+    has_more: bool
+
+
+class RecoveryCursorManager:
+    """Tracks monotonic recovery cursors and per-channel dedup state."""
+
+    def __init__(self) -> None:
+        self._cursors: Dict[str, Cursor] = {}
+        self._seen_per_channel: Dict[str, Set[str]] = {}
+
+    def advance(
+        self,
+        channel_id: str,
+        message_ids: List[str],
+        *,
+        has_more: bool,
+    ) -> Cursor:
+        """Record the newest batch of message ids for a channel.
+
+        Sets ``last_message_id`` to the numerically largest id in the
+        batch. Raises :class:`RecoveryCursorError` if that would move
+        the recorded cursor backward.
+        """
+        _validate_snowflake(channel_id, what="channel_id")
+        if not message_ids:
+            raise ValueError("message_ids must not be empty")
+        for message_id in message_ids:
+            _validate_snowflake(message_id, what="message_id")
+
+        new_max = str(max(int(mid) for mid in message_ids))
+
+        prev = self._cursors.get(channel_id)
+        if prev is not None and prev.last_message_id is not None:
+            prev_max = int(prev.last_message_id)
+            if int(new_max) < prev_max:
+                raise RecoveryCursorError(
+                    f"recovery cursor for channel {channel_id} moved backward: "
+                    f"{prev.last_message_id} -> {new_max}"
+                )
+
+        cursor = Cursor(
+            channel_id=channel_id,
+            last_message_id=new_max,
+            has_more=has_more,
+        )
+        self._cursors[channel_id] = cursor
+        return cursor
+
+    def dedup(
+        self,
+        channel_id: str,
+        message_ids: List[str],
+        seen_ids: Set[str],
+    ) -> List[str]:
+        """Return the ids in *message_ids* not seen before.
+
+        An id is filtered out if it is already in *seen_ids* (the
+        caller's global set) or if it was already seen for this channel
+        (the manager's per-channel set). Newly returned ids are added to
+        both sets.
+        """
+        _validate_snowflake(channel_id, what="channel_id")
+        channel_seen = self._seen_per_channel.setdefault(channel_id, set())
+
+        result: List[str] = []
+        for message_id in message_ids:
+            _validate_snowflake(message_id, what="message_id")
+            key = str(message_id)
+            if key in seen_ids or key in channel_seen:
+                continue
+            seen_ids.add(key)
+            channel_seen.add(key)
+            result.append(message_id)
+        return result
+
+    def cursor_for(self, channel_id: str) -> Optional[Cursor]:
+        """Return the recorded cursor for a channel, or None."""
+        return self._cursors.get(channel_id)

--- a/tests/tools/test_discord_recovery_cursor.py
+++ b/tests/tools/test_discord_recovery_cursor.py
@@ -1,0 +1,120 @@
+"""Tests for Discord recovery cursor correctness (R3)."""
+
+import pytest
+
+from plugins.platforms.discord.recovery_cursor import (
+    Cursor,
+    RecoveryCursorError,
+    RecoveryCursorManager,
+)
+
+
+class TestAdvance:
+    def test_sets_max_of_message_ids(self):
+        mgr = RecoveryCursorManager()
+        cursor = mgr.advance("111", ["5", "3", "9"], has_more=True)
+        assert cursor.channel_id == "111"
+        assert cursor.last_message_id == "9"
+        assert cursor.has_more is True
+
+    def test_accepts_int_message_ids(self):
+        mgr = RecoveryCursorManager()
+        cursor = mgr.advance("111", [5, 9, 3], has_more=False)
+        assert cursor.last_message_id == "9"
+
+    def test_monotonic_forward_moves(self):
+        mgr = RecoveryCursorManager()
+        mgr.advance("111", ["10"], has_more=True)
+        cursor = mgr.advance("111", ["11", "12"], has_more=False)
+        assert cursor.last_message_id == "12"
+        assert cursor.has_more is False
+
+    def test_equal_max_is_allowed(self):
+        mgr = RecoveryCursorManager()
+        mgr.advance("111", ["10"], has_more=True)
+        cursor = mgr.advance("111", ["10"], has_more=False)
+        assert cursor.last_message_id == "10"
+        assert cursor.has_more is False
+
+    def test_backward_move_raises(self):
+        mgr = RecoveryCursorManager()
+        mgr.advance("111", ["100"], has_more=True)
+        with pytest.raises(RecoveryCursorError):
+            mgr.advance("111", ["99"], has_more=True)
+
+    def test_backward_error_is_value_error(self):
+        mgr = RecoveryCursorManager()
+        mgr.advance("111", ["100"], has_more=True)
+        with pytest.raises(ValueError):
+            mgr.advance("111", ["1"], has_more=True)
+
+    def test_channels_are_independent(self):
+        mgr = RecoveryCursorManager()
+        mgr.advance("111", ["100"], has_more=True)
+        cursor = mgr.advance("222", ["1"], has_more=True)
+        assert cursor.last_message_id == "1"
+
+    def test_empty_message_ids_raises(self):
+        mgr = RecoveryCursorManager()
+        with pytest.raises(ValueError):
+            mgr.advance("111", [], has_more=True)
+
+    def test_invalid_channel_id_raises(self):
+        mgr = RecoveryCursorManager()
+        with pytest.raises(ValueError):
+            mgr.advance("not-a-snowflake", ["1"], has_more=True)
+
+    @pytest.mark.parametrize("bad", ["abc", "12a", "1.5", "-3", ""])
+    def test_invalid_message_id_raises(self, bad):
+        mgr = RecoveryCursorManager()
+        with pytest.raises(ValueError):
+            mgr.advance("111", ["1", bad], has_more=True)
+
+
+class TestDedup:
+    def test_filters_global_seen_ids(self):
+        mgr = RecoveryCursorManager()
+        seen = {"5"}
+        result = mgr.dedup("111", ["1", "5", "9"], seen)
+        assert result == ["1", "9"]
+        assert seen == {"5", "1", "9"}
+
+    def test_filters_per_channel_even_with_fresh_seen_set(self):
+        mgr = RecoveryCursorManager()
+        mgr.dedup("111", ["1", "2"], set())
+        fresh = set()
+        result = mgr.dedup("111", ["2", "3"], fresh)
+        assert result == ["3"]
+        assert fresh == {"3"}
+
+    def test_per_channel_isolation(self):
+        mgr = RecoveryCursorManager()
+        mgr.dedup("111", ["1"], set())
+        fresh = set()
+        result = mgr.dedup("222", ["1", "2"], fresh)
+        assert result == ["1", "2"]
+
+    def test_invalid_message_id_raises(self):
+        mgr = RecoveryCursorManager()
+        with pytest.raises(ValueError):
+            mgr.dedup("111", ["1", "nope"], set())
+
+    def test_invalid_channel_id_raises(self):
+        mgr = RecoveryCursorManager()
+        with pytest.raises(ValueError):
+            mgr.dedup("bad", ["1"], set())
+
+
+class TestCursorFor:
+    def test_returns_none_for_unknown_channel(self):
+        mgr = RecoveryCursorManager()
+        assert mgr.cursor_for("111") is None
+
+    def test_returns_recorded_cursor(self):
+        mgr = RecoveryCursorManager()
+        mgr.advance("111", ["1", "2"], has_more=True)
+        cursor = mgr.cursor_for("111")
+        assert isinstance(cursor, Cursor)
+        assert cursor.channel_id == "111"
+        assert cursor.last_message_id == "2"
+        assert cursor.has_more is True


### PR DESCRIPTION
## Summary

Recovery cursor correctness for Discord history backfill — monotonic per-channel cursors, backward-move rejection, and per-channel dedup.

## Motivation

Fixes #86539 · Part of #79564

## Changes

- New module `plugins/platforms/discord/recovery_cursor.py` implementing monotonic cursor advance, per-channel dedup, and `cursor_for`.

## Test Plan

- [x] Unit tests pass (`pytest`)
- [x] Focused regression tests: `tests/tools/test_discord_recovery_cursor.py` — 21 passed
- [ ] Manual testing of new functionality
- [x] No regressions in existing behavior

## Notes for Reviewers

- New module only — no god-file growth; `plugins/platforms/discord/adapter.py` untouched.