### PR TITLE
feat(desktop): per-profile scope selector in the Capabilities view

### DIFF
--- a/apps/desktop/src/app/command-palette/index.tsx
+++ b/apps/desktop/src/app/command-palette/index.tsx
@@ -605,7 +605,7 @@ function CommandPaletteBody({ onExited }: { onExited: () => void }) {
   // reopen paints from cache and revalidates in the background.
   const configQuery = useQuery({
     queryKey: ['command-palette', 'config'],
-    queryFn: getHermesConfigRecord
+    queryFn: () => getHermesConfigRecord()
   })
 
   const sessionsQuery = useQuery({

--- a/apps/desktop/src/app/hooks/use-config-record.ts
+++ b/apps/desktop/src/app/hooks/use-config-record.ts
@@ -2,6 +2,7 @@ import { useQuery } from '@tanstack/react-query'
 
 import { getHermesConfigRecord } from '@/hermes'
 import { queryClient, writeCache } from '@/lib/query-client'
+import { normalizeProfileKey } from '@/store/profile'
 import type { HermesConfigRecord } from '@/types/hermes'
 
 // One shared cache for the whole profile config record (`GET /api/config`).
@@ -13,10 +14,33 @@ import type { HermesConfigRecord } from '@/types/hermes'
 // it pushes personality/cwd/voice/… into the session stores for live chat.
 export const HERMES_CONFIG_KEY = ['hermes-config-record'] as const
 
+// Per-profile cache key. The base key (no profile suffix) is the app-wide
+// active profile, unchanged for every caller that passes nothing. An explicit
+// profile — the Capabilities profile-scope selector configuring ANOTHER
+// profile — gets its own suffixed key so switching the selector refetches and
+// never paints stale cross-profile config (the AGENTS.md scope-in-key rule).
+export const hermesConfigKey = (profile?: null | string) =>
+  profile == null ? HERMES_CONFIG_KEY : ([...HERMES_CONFIG_KEY, normalizeProfileKey(profile)] as const)
+
 // staleTime 0 → serve cache instantly, background-revalidate on every mount.
-export const useHermesConfigRecord = () =>
-  useQuery({ queryKey: HERMES_CONFIG_KEY, queryFn: getHermesConfigRecord, staleTime: 0 })
+// `profile` scopes both the query key and the fetch; omitting it preserves the
+// exact app-wide behavior (base key, `profileScoped(undefined)` fallback).
+export const useHermesConfigRecord = (profile?: null | string) =>
+  useQuery({
+    queryKey: hermesConfigKey(profile),
+    // null/undefined both mean "no override" → fetch with undefined so
+    // profileScoped falls back to the app-wide active profile (passing null
+    // would wrongly target the primary backend).
+    queryFn: () => getHermesConfigRecord(profile ?? undefined),
+    staleTime: 0
+  })
 
+// setHermesConfigCache writes the app-wide (base-key) record. Pass a profile to
+// write the suffixed per-profile cache instead — keeps the selector's optimistic
+// write-through landing on the same key its query reads.
 export const setHermesConfigCache = writeCache<HermesConfigRecord>(HERMES_CONFIG_KEY)
+export const hermesConfigCacheWriter = (profile?: null | string) =>
+  writeCache<HermesConfigRecord>(hermesConfigKey(profile))
 
-export const invalidateHermesConfig = () => queryClient.invalidateQueries({ queryKey: HERMES_CONFIG_KEY })
+export const invalidateHermesConfig = (profile?: null | string) =>
+  queryClient.invalidateQueries({ queryKey: hermesConfigKey(profile) })

--- a/apps/desktop/src/app/settings/toolset-config-panel.test.tsx
+++ b/apps/desktop/src/app/settings/toolset-config-panel.test.tsx
@@ -62,7 +62,12 @@ vi.mock('@/hermes', () => ({
   getHermesConfigRecord: () => getHermesConfigRecord(),
   getHermesConfigSchema: () => getHermesConfigSchema(),
   saveHermesConfig: (config: unknown) => saveHermesConfig(config),
-  getElevenLabsVoices: () => getElevenLabsVoices()
+  getElevenLabsVoices: () => getElevenLabsVoices(),
+  // @/store/profile (pulled in transitively via use-config-record's
+  // normalizeProfileKey import) calls this at module-init; the full-replacement
+  // mock must provide it or the module graph throws on load.
+  setApiRequestProfile: () => undefined,
+  getApiRequestProfile: () => null
 }))
 
 vi.mock('@/store/notifications', () => ({

--- a/apps/desktop/src/app/settings/toolset-config-panel.tsx
+++ b/apps/desktop/src/app/settings/toolset-config-panel.tsx
@@ -322,7 +322,7 @@ function PostSetupRunner({ toolset, postSetupKey, installed = false, onComplete,
         setRunning(false)
       }
     }
-  }, [toolset, postSetupKey, onComplete, copy])
+  }, [toolset, postSetupKey, onComplete, copy, profile])
 
   return (
     <div className="grid gap-2 rounded-lg bg-background/55 p-2.5">
@@ -862,8 +862,8 @@ export function ToolsetConfigPanel({ toolset, onConfiguredChange, profile }: Too
                     installed={provider.status === 'ready'}
                     onComplete={() => void refresh()}
                     postSetupKey={provider.post_setup}
-                    toolset={toolset}
                     profile={profile}
+                    toolset={toolset}
                   />
                 )}
                 {toolset === 'tts' && provider.tts_provider && (
@@ -875,9 +875,9 @@ export function ToolsetConfigPanel({ toolset, onConfiguredChange, profile }: Too
                 {MODEL_CATALOG_TOOLSETS.has(toolset) && (
                   <ModelCatalogPicker
                     isActiveBackend={provider.is_active || cfg?.active_provider === provider.name}
+                    profile={profile}
                     providerName={provider.name}
                     toolset={toolset}
-                    profile={profile}
                   />
                 )}
               </div>

--- a/apps/desktop/src/app/settings/toolset-config-panel.tsx
+++ b/apps/desktop/src/app/settings/toolset-config-panel.tsx
@@ -40,6 +40,10 @@ interface ToolsetConfigPanelProps {
   /** Called after a key is saved/cleared or a provider chosen, so the parent
    *  can refresh the "Configured / Needs keys" pill. */
   onConfiguredChange?: () => void
+  /** Capabilities profile-scope override: configure THIS profile instead of the
+   *  app-wide active one. Omitted (every other caller) → app-wide active
+   *  profile, so behavior is unchanged. Threaded into every fetch below. */
+  profile?: null | string
 }
 
 /** Toolsets whose backends expose a selectable model catalog (mirrors the
@@ -81,9 +85,10 @@ interface EnvVarFieldProps {
   isSet: boolean
   onSaved: (key: string) => void
   onCleared: (key: string) => void
+  profile?: null | string
 }
 
-function EnvVarField({ envVar, isSet, onSaved, onCleared }: EnvVarFieldProps) {
+function EnvVarField({ envVar, isSet, onSaved, onCleared, profile }: EnvVarFieldProps) {
   const { t } = useI18n()
   const copy = t.settings.toolsets
   const navigate = useNavigate()
@@ -104,7 +109,7 @@ function EnvVarField({ envVar, isSet, onSaved, onCleared }: EnvVarFieldProps) {
     setBusy(true)
 
     try {
-      await setEnvVar(envVar.key, value)
+      await setEnvVar(envVar.key, value, profile)
       setEditing(false)
       setValue('')
       onSaved(envVar.key)
@@ -124,7 +129,7 @@ function EnvVarField({ envVar, isSet, onSaved, onCleared }: EnvVarFieldProps) {
     setBusy(true)
 
     try {
-      await deleteEnvVar(envVar.key)
+      await deleteEnvVar(envVar.key, profile)
       setRevealed(null)
       onCleared(envVar.key)
       notify({ kind: 'success', title: copy.removedTitle, message: copy.removedMessage(envVar.key) })
@@ -143,7 +148,7 @@ function EnvVarField({ envVar, isSet, onSaved, onCleared }: EnvVarFieldProps) {
     }
 
     try {
-      const result = await revealEnvVar(envVar.key)
+      const result = await revealEnvVar(envVar.key, profile)
       setRevealed(result.value)
     } catch (err) {
       notifyError(err, copy.failedReveal(envVar.key))
@@ -226,6 +231,7 @@ interface PostSetupRunnerProps {
   /** Refresh the parent config after the install finishes (a backend may now
    *  report itself configured). */
   onComplete?: () => void
+  profile?: null | string
 }
 
 /**
@@ -239,7 +245,7 @@ interface PostSetupRunnerProps {
  * "Installed" pill plus a small "Re-run setup" text button, so clicking
  * around the panel doesn't look like it keeps reinstalling.
  */
-function PostSetupRunner({ toolset, postSetupKey, installed = false, onComplete }: PostSetupRunnerProps) {
+function PostSetupRunner({ toolset, postSetupKey, installed = false, onComplete, profile }: PostSetupRunnerProps) {
   const { t } = useI18n()
   const copy = t.settings.toolsets
   const [running, setRunning] = useState(false)
@@ -260,7 +266,7 @@ function PostSetupRunner({ toolset, postSetupKey, installed = false, onComplete 
     activeRef.current = true
 
     try {
-      const started = await runToolsetPostSetup(toolset, postSetupKey)
+      const started = await runToolsetPostSetup(toolset, postSetupKey, profile)
 
       // The spawn endpoint reports ok:false if it couldn't launch the action
       // (e.g. unknown key, server-side spawn failure). Don't poll a status
@@ -283,7 +289,7 @@ function PostSetupRunner({ toolset, postSetupKey, installed = false, onComplete 
           break
         }
 
-        const polled = await getActionStatus(started.name, 300)
+        const polled = await getActionStatus(started.name, 300, profile)
         last = polled
         setStatus(polled)
         upsertDesktopActionTask(polled)
@@ -364,6 +370,7 @@ interface ModelCatalogPickerProps {
   /** True when this provider is the one written to config — selecting a model
    *  only makes sense for the active backend. */
   isActiveBackend: boolean
+  profile?: null | string
 }
 
 /**
@@ -373,7 +380,7 @@ interface ModelCatalogPickerProps {
  * radio-card list and persists the choice to `image_gen.model` /
  * `video_gen.model`.
  */
-function ModelCatalogPicker({ toolset, providerName, isActiveBackend }: ModelCatalogPickerProps) {
+function ModelCatalogPicker({ toolset, providerName, isActiveBackend, profile }: ModelCatalogPickerProps) {
   const { t } = useI18n()
   const copy = t.settings.toolsets
   const [catalog, setCatalog] = useState<ToolsetModelsResponse | null>(null)
@@ -384,7 +391,7 @@ function ModelCatalogPicker({ toolset, providerName, isActiveBackend }: ModelCat
     let cancelled = false
 
     setLoading(true)
-    getToolsetModels(toolset, providerName)
+    getToolsetModels(toolset, providerName, profile)
       .then(next => {
         if (!cancelled) {
           setCatalog(next)
@@ -404,13 +411,13 @@ function ModelCatalogPicker({ toolset, providerName, isActiveBackend }: ModelCat
       })
 
     return () => void (cancelled = true)
-  }, [toolset, providerName])
+  }, [toolset, providerName, profile])
 
   const pick = async (modelId: string) => {
     setSaving(modelId)
 
     try {
-      await selectToolsetModel(toolset, modelId, providerName)
+      await selectToolsetModel(toolset, modelId, providerName, profile)
       setCatalog(current => (current ? { ...current, current: modelId } : current))
       notify({ kind: 'success', title: copy.modelSelectedTitle, message: copy.modelSelectedMessage(modelId) })
     } catch (err) {
@@ -486,7 +493,7 @@ function ModelCatalogPicker({ toolset, providerName, isActiveBackend }: ModelCat
   )
 }
 
-export function ToolsetConfigPanel({ toolset, onConfiguredChange }: ToolsetConfigPanelProps) {
+export function ToolsetConfigPanel({ toolset, onConfiguredChange, profile }: ToolsetConfigPanelProps) {
   const { t } = useI18n()
   const copy = t.settings.toolsets
   const [cfg, setCfg] = useState<ToolsetConfig | null>(null)
@@ -516,7 +523,7 @@ export function ToolsetConfigPanel({ toolset, onConfiguredChange }: ToolsetConfi
     setLoading(true)
 
     try {
-      const next = await getToolsetConfig(toolset)
+      const next = await getToolsetConfig(toolset, profile)
       setCfg(next)
       const seeded: Record<string, boolean> = {}
 
@@ -532,7 +539,7 @@ export function ToolsetConfigPanel({ toolset, onConfiguredChange }: ToolsetConfi
     } finally {
       setLoading(false)
     }
-  }, [copy.failedLoad, toolset])
+  }, [copy.failedLoad, toolset, profile])
 
   useEffect(() => {
     void refresh()
@@ -574,7 +581,7 @@ export function ToolsetConfigPanel({ toolset, onConfiguredChange }: ToolsetConfi
     setSelecting(provider.name)
 
     try {
-      const result = await selectToolsetProvider(toolset, provider.name)
+      const result = await selectToolsetProvider(toolset, provider.name, undefined, profile)
       // Mirror the backend write locally so dependent UI (model catalog
       // enablement) tracks the new active backend without a refetch.
       setCfg(current =>
@@ -616,7 +623,7 @@ export function ToolsetConfigPanel({ toolset, onConfiguredChange }: ToolsetConfi
   // refetch the toolset config so is_active / status flip once entitled.
   async function signInToNousPortal() {
     try {
-      const start = await startOAuthLogin('nous')
+      const start = await startOAuthLogin('nous', profile)
 
       if (start.flow !== 'device_code') {
         notifyError(new Error(`unexpected flow: ${start.flow}`), copy.nousAuthFailed)
@@ -644,7 +651,7 @@ export function ToolsetConfigPanel({ toolset, onConfiguredChange }: ToolsetConfi
           return
         }
 
-        const polled = await pollOAuthSession('nous', start.session_id)
+        const polled = await pollOAuthSession('nous', start.session_id, profile)
 
         if (polled.status === 'approved') {
           notify({ kind: 'success', title: copy.nousAuthDoneTitle, message: copy.nousAuthDoneMessage })
@@ -676,7 +683,7 @@ export function ToolsetConfigPanel({ toolset, onConfiguredChange }: ToolsetConfi
     setSelecting(provider.name)
 
     try {
-      await selectToolsetProvider(toolset, provider.name, capability)
+      await selectToolsetProvider(toolset, provider.name, capability, profile)
       // Mirror the backend write locally so the Search:/Extract: badges track
       // the new per-capability backend without a refetch.
       setCfg(current =>
@@ -846,6 +853,7 @@ export function ToolsetConfigPanel({ toolset, onConfiguredChange }: ToolsetConfi
                       key={ev.key}
                       onCleared={key => patchEnv(key, false)}
                       onSaved={key => patchEnv(key, true)}
+                      profile={profile}
                     />
                   ))
                 )}
@@ -855,6 +863,7 @@ export function ToolsetConfigPanel({ toolset, onConfiguredChange }: ToolsetConfi
                     onComplete={() => void refresh()}
                     postSetupKey={provider.post_setup}
                     toolset={toolset}
+                    profile={profile}
                   />
                 )}
                 {toolset === 'tts' && provider.tts_provider && (
@@ -868,6 +877,7 @@ export function ToolsetConfigPanel({ toolset, onConfiguredChange }: ToolsetConfi
                     isActiveBackend={provider.is_active || cfg?.active_provider === provider.name}
                     providerName={provider.name}
                     toolset={toolset}
+                    profile={profile}
                   />
                 )}
               </div>

--- a/apps/desktop/src/app/skills/index.test.tsx
+++ b/apps/desktop/src/app/skills/index.test.tsx
@@ -15,19 +15,23 @@ const setToolsetEnabled = vi.fn()
 const getToolsetConfig = vi.fn()
 const selectToolsetProvider = vi.fn()
 const getUsageAnalytics = vi.fn()
+const getProfiles = vi.fn()
 
 // Partial mock: keep the real module (SkillsView pulls in @/store/profile,
 // whose import-time subscription calls setApiRequestProfile) and stub only the
-// calls we assert on.
+// calls we assert on. Args are forwarded so the per-profile scope arg is
+// observable.
 vi.mock('@/hermes', async importOriginal => ({
   ...(await importOriginal<typeof HermesApi>()),
   getSkills: () => getSkills(),
-  getToolsets: () => getToolsets(),
+  getToolsets: (profile?: null | string) => getToolsets(profile),
   setSkillEnabled: (name: string, enabled: boolean) => setSkillEnabled(name, enabled),
-  setToolsetEnabled: (name: string, enabled: boolean) => setToolsetEnabled(name, enabled),
-  getToolsetConfig: (name: string) => getToolsetConfig(name),
+  setToolsetEnabled: (name: string, enabled: boolean, profile?: null | string) =>
+    setToolsetEnabled(name, enabled, profile),
+  getToolsetConfig: (name: string, profile?: null | string) => getToolsetConfig(name, profile),
   selectToolsetProvider: (toolset: string, provider: string) => selectToolsetProvider(toolset, provider),
-  getUsageAnalytics: (days: number) => getUsageAnalytics(days)
+  getUsageAnalytics: (days: number) => getUsageAnalytics(days),
+  getProfiles: () => getProfiles()
 }))
 
 // Notifications hit nanostores/timers we don't care about here.
@@ -81,6 +85,9 @@ beforeEach(() => {
   setToolsetEnabled.mockResolvedValue({ ok: true, name: 'web', enabled: false })
   getToolsetConfig.mockResolvedValue({ has_category: true, active_provider: null, providers: [] })
   getUsageAnalytics.mockResolvedValue({ tools: [] })
+  // Single profile by default → the scope selector stays hidden (>1 gate),
+  // so existing tests see unchanged single-profile behavior.
+  getProfiles.mockResolvedValue({ profiles: [{ name: 'default', is_default: true }] })
 })
 
 afterEach(() => {
@@ -102,7 +109,8 @@ describe('SkillsView toolset management', () => {
       fireEvent.click(sw)
     })
 
-    await waitFor(() => expect(setToolsetEnabled).toHaveBeenCalledWith('web', false))
+    await waitFor(() => expect(setToolsetEnabled).toHaveBeenCalled())
+    expect(setToolsetEnabled.mock.calls[0].slice(0, 2)).toEqual(['web', false])
   })
 
   it('renders toolset titles without leading emoji', async () => {
@@ -124,7 +132,43 @@ describe('SkillsView toolset management', () => {
     await renderSkills()
 
     await screen.findByRole('switch', { name: 'Turn Web Search toolset off' })
-    await waitFor(() => expect(getToolsetConfig).toHaveBeenCalledWith('web'))
+    await waitFor(() => expect(getToolsetConfig).toHaveBeenCalled())
+    expect(getToolsetConfig.mock.calls[0][0]).toBe('web')
+  })
+
+  it('scopes Tools config to the profile chosen in the selector', async () => {
+    // Two profiles → the "Configuring:" selector renders. Picking a non-active
+    // profile must re-fetch toolsets scoped to THAT profile.
+    getProfiles.mockResolvedValue({
+      profiles: [
+        { name: 'default', is_default: true },
+        { name: 'researcher', is_default: false }
+      ]
+    })
+
+    const { SkillsView } = await import('./index')
+    await act(async () => {
+      render(
+        <QueryClientProvider client={queryClient}>
+          <MemoryRouter initialEntries={['/skills?tab=toolsets']}>
+            <SkillsView />
+          </MemoryRouter>
+        </QueryClientProvider>
+      )
+    })
+
+    // The selector appears with >1 profile.
+    const trigger = await screen.findByRole('combobox')
+    await act(async () => {
+      fireEvent.click(trigger)
+    })
+    const option = await screen.findByRole('option', { name: 'researcher' })
+    await act(async () => {
+      fireEvent.click(option)
+    })
+
+    // Toolsets refetch scoped to the picked profile.
+    await waitFor(() => expect(getToolsets).toHaveBeenCalledWith('researcher'))
   })
 
   it('shows a vision explainer that deep-links to Settings → Models', async () => {

--- a/apps/desktop/src/app/skills/index.test.tsx
+++ b/apps/desktop/src/app/skills/index.test.tsx
@@ -139,6 +139,9 @@ describe('SkillsView toolset management', () => {
   it('scopes Tools config to the profile chosen in the selector', async () => {
     // Two profiles → the "Configuring:" selector renders. Picking a non-active
     // profile must re-fetch toolsets scoped to THAT profile.
+    // jsdom's scrollIntoView is missing/non-functional; Radix Select calls it
+    // on open. Force a stub so the dropdown can render in the test env.
+    Element.prototype.scrollIntoView = vi.fn()
     getProfiles.mockResolvedValue({
       profiles: [
         { name: 'default', is_default: true },

--- a/apps/desktop/src/app/skills/index.tsx
+++ b/apps/desktop/src/app/skills/index.tsx
@@ -213,6 +213,7 @@ export function SkillsView({ setStatusbarItemGroup: _setStatusbarItemGroup, ...p
     queryFn: getProfiles,
     staleTime: 60_000
   })
+
   const profiles = profilesData?.profiles ?? []
 
   const {
@@ -378,6 +379,7 @@ export function SkillsView({ setStatusbarItemGroup: _setStatusbarItemGroup, ...p
 
   async function handleToggleToolset(toolset: ToolsetInfo, enabled: boolean) {
     const scopedToolsetKey = [...TOOLSETS_QUERY_KEY, scopeKey]
+
     const writeScoped = (fn: (cur: ToolsetInfo[] | undefined) => ToolsetInfo[] | undefined) =>
       queryClient.setQueryData<ToolsetInfo[]>(scopedToolsetKey, prev => fn(prev) ?? prev)
 

--- a/apps/desktop/src/app/skills/index.tsx
+++ b/apps/desktop/src/app/skills/index.tsx
@@ -9,10 +9,18 @@ import { CodeEditor } from '@/components/chat/code-editor'
 import { PageLoader } from '@/components/page-loader'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue
+} from '@/components/ui/select'
 import { CountSkeleton } from '@/components/ui/skeleton'
 import {
   editLearningNode,
   getLearningNode,
+  getProfiles,
   getSkills,
   getToolsets,
   getUsageAnalytics,
@@ -68,10 +76,10 @@ const SKILLS_MODES = ['skills', 'toolsets', 'mcp', 'hub'] as const
 const SKILLS_QUERY_KEY = ['skills-list'] as const
 const TOOLSETS_QUERY_KEY = ['toolsets-list'] as const
 
-// Optimistic write-through: toggles/bulk/archive repaint instantly; the next
-// background refetch reconciles with the backend.
+// Optimistic write-through: skill toggles/bulk/archive repaint instantly; the
+// next background refetch reconciles with the backend. (Toolsets write through
+// the profile-scoped query key directly — see handleToggleToolset.)
 const setSkills = writeCache<SkillInfo[]>(SKILLS_QUERY_KEY)
-const setToolsets = writeCache<ToolsetInfo[]>(TOOLSETS_QUERY_KEY)
 
 // Per-tool call counts come from a 365-day message scan — heavy, and purely
 // cosmetic (Toolsets usage badges). Cache the result module-wide with a TTL so
@@ -191,6 +199,22 @@ export function SkillsView({ setStatusbarItemGroup: _setStatusbarItemGroup, ...p
 
   const [query, setQuery] = useState('')
 
+  // Capabilities profile-scope selector: which profile's Tools/MCP config we're
+  // editing. Defaults to the app-wide active profile; overriding it here lets
+  // the user configure ANY profile's toolsets/MCP without switching the whole
+  // app into that profile. null = the active profile (unchanged behavior).
+  const activeProfile = useStore($activeGatewayProfile)
+  const [scopeOverride, setScopeOverride] = useState<null | string>(null)
+  const scopeProfile = scopeOverride ?? activeProfile ?? null
+  const scopeKey = normalizeProfileKey(scopeProfile)
+
+  const { data: profilesData } = useQuery({
+    queryKey: ['capabilities-profiles'],
+    queryFn: getProfiles,
+    staleTime: 60_000
+  })
+  const profiles = profilesData?.profiles ?? []
+
   const {
     data: skills,
     isError: skillsFailed,
@@ -202,8 +226,8 @@ export function SkillsView({ setStatusbarItemGroup: _setStatusbarItemGroup, ...p
   })
 
   const { data: toolsets, isError: toolsetsFailed } = useQuery({
-    queryKey: TOOLSETS_QUERY_KEY,
-    queryFn: getToolsets,
+    queryKey: [...TOOLSETS_QUERY_KEY, scopeKey],
+    queryFn: () => getToolsets(scopeProfile),
     staleTime: 0
   })
 
@@ -353,15 +377,19 @@ export function SkillsView({ setStatusbarItemGroup: _setStatusbarItemGroup, ...p
   }
 
   async function handleToggleToolset(toolset: ToolsetInfo, enabled: boolean) {
-    setToolsets(
+    const scopedToolsetKey = [...TOOLSETS_QUERY_KEY, scopeKey]
+    const writeScoped = (fn: (cur: ToolsetInfo[] | undefined) => ToolsetInfo[] | undefined) =>
+      queryClient.setQueryData<ToolsetInfo[]>(scopedToolsetKey, prev => fn(prev) ?? prev)
+
+    writeScoped(
       current =>
         current?.map(row => (row.name === toolset.name ? { ...row, enabled, available: enabled } : row)) ?? current
     )
 
     try {
-      await setToolsetEnabled(toolset.name, enabled)
+      await setToolsetEnabled(toolset.name, enabled, scopeProfile)
     } catch (err) {
-      setToolsets(
+      writeScoped(
         current =>
           current?.map(row => (row.name === toolset.name ? { ...row, enabled: !enabled, available: !enabled } : row)) ??
           current
@@ -389,8 +417,11 @@ export function SkillsView({ setStatusbarItemGroup: _setStatusbarItemGroup, ...p
       }
 
       for (const row of toolsetTargets) {
-        await setToolsetEnabled(row.name, enabled)
-        setToolsets(cur => cur?.map(r => (r.name === row.name ? { ...r, enabled, available: enabled } : r)) ?? cur)
+        await setToolsetEnabled(row.name, enabled, scopeProfile)
+        queryClient.setQueryData<ToolsetInfo[]>(
+          [...TOOLSETS_QUERY_KEY, scopeKey],
+          cur => cur?.map(r => (r.name === row.name ? { ...r, enabled, available: enabled } : r)) ?? cur
+        )
         done += 1
       }
 
@@ -540,6 +571,28 @@ export function SkillsView({ setStatusbarItemGroup: _setStatusbarItemGroup, ...p
     </DetailPane>
   )
 
+  // Profile-scope selector, shown above the Tools and MCP tabs. Lets the user
+  // configure ANY profile's capabilities without switching the whole app.
+  // Only meaningful with >1 profile; hidden otherwise to avoid clutter.
+  const profileScopeSelector =
+    profiles.length > 1 ? (
+      <div className="flex items-center gap-2 border-b border-(--ui-stroke-secondary) px-3 py-2">
+        <span className="text-[0.7rem] font-medium text-(--ui-text-tertiary)">{t.skills.configuringProfile}</span>
+        <Select onValueChange={value => setScopeOverride(value)} value={scopeProfile ?? ''}>
+          <SelectTrigger className="h-7 w-56 text-xs">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {profiles.map(p => (
+              <SelectItem key={p.name} value={p.name}>
+                {p.is_default ? 'Hermes (default)' : p.name}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+    ) : null
+
   return (
     <PageSearchShell
       {...props}
@@ -568,7 +621,12 @@ export function SkillsView({ setStatusbarItemGroup: _setStatusbarItemGroup, ...p
       {mode === 'hub' ? (
         <SkillsHub query={query} />
       ) : mode === 'mcp' ? (
-        <McpTab gateway={gateway} />
+        <div className="flex h-full flex-col">
+          {profileScopeSelector}
+          <div className="min-h-0 flex-1">
+            <McpTab gateway={gateway} key={`mcp-${scopeKey}`} profile={scopeProfile} />
+          </div>
+        </div>
       ) : (skillsFailed || toolsetsFailed) && (!skills || !toolsets) ? (
         <PanelEmpty
           action={
@@ -632,7 +690,10 @@ export function SkillsView({ setStatusbarItemGroup: _setStatusbarItemGroup, ...p
       ) : visibleToolsets.length === 0 ? (
         capabilityEmpty('tools')
       ) : (
-        <MasterDetail split="wide">
+        <div className="flex h-full flex-col">
+          {profileScopeSelector}
+          <div className="min-h-0 flex-1">
+            <MasterDetail split="wide">
           <ListColumn
             header={
               <ListStrip
@@ -671,10 +732,17 @@ export function SkillsView({ setStatusbarItemGroup: _setStatusbarItemGroup, ...p
           </ListColumn>
           <DetailColumn footer={t.skills.changesApplyNewSessions}>
             {activeToolset && (
-              <ToolsetDetail onConfiguredChange={refreshToolsets} toolCalls={toolCalls ?? {}} toolset={activeToolset} />
+              <ToolsetDetail
+                onConfiguredChange={refreshToolsets}
+                profile={scopeProfile}
+                toolCalls={toolCalls ?? {}}
+                toolset={activeToolset}
+              />
             )}
           </DetailColumn>
         </MasterDetail>
+          </div>
+        </div>
       )}
       {archiveTarget && (
         <ArchiveSkillConfirmDialog
@@ -765,11 +833,13 @@ function SkillDetail({ onArchive, onEdit, skill }: { onArchive: () => void; onEd
 function ToolsetDetail({
   toolset,
   toolCalls,
-  onConfiguredChange
+  onConfiguredChange,
+  profile
 }: {
   toolset: ToolsetInfo
   toolCalls: Record<string, number>
   onConfiguredChange: () => void
+  profile?: null | string
 }) {
   const { t } = useI18n()
   const navigate = useNavigate()
@@ -818,7 +888,12 @@ function ToolsetDetail({
       )}
       {toolset.name === 'computer_use' && <ComputerUsePanel onConfiguredChange={onConfiguredChange} />}
       {toolset.name === 'terminal' && <TerminalBackendPanel onConfiguredChange={onConfiguredChange} />}
-      <ToolsetConfigPanel key={toolset.name} onConfiguredChange={onConfiguredChange} toolset={toolset.name} />
+      <ToolsetConfigPanel
+        key={`${toolset.name}:${normalizeProfileKey(profile)}`}
+        onConfiguredChange={onConfiguredChange}
+        profile={profile}
+        toolset={toolset.name}
+      />
     </>
   )
 }

--- a/apps/desktop/src/app/skills/mcp-tab.tsx
+++ b/apps/desktop/src/app/skills/mcp-tab.tsx
@@ -36,7 +36,7 @@ import { $activeGatewayProfile, normalizeProfileKey } from '@/store/profile'
 import { $activeSessionId } from '@/store/session'
 import type { HermesConfigRecord } from '@/types/hermes'
 
-import { setHermesConfigCache, useHermesConfigRecord } from '../hooks/use-config-record'
+import { hermesConfigCacheWriter, useHermesConfigRecord } from '../hooks/use-config-record'
 import { useOnProfileSwitch } from '../hooks/use-on-profile-switch'
 import { DetailPane, ICON_BUTTON, MASTER_DETAIL_WIDE_COLS } from '../master-detail'
 import { PanelAddButton, PanelEmpty } from '../overlays/panel'
@@ -120,8 +120,8 @@ const probeCache = new Map<string, { at: number; result: McpTestResult }>()
 const serverFingerprint = (server: Record<string, unknown>): string =>
   JSON.stringify([server.url, server.command, server.args, server.env, server.headers, server.transport, server.auth])
 
-const probeKey = (name: string, server: Record<string, unknown> | undefined): string =>
-  `${normalizeProfileKey($activeGatewayProfile.get())}::${name}::${serverFingerprint(server ?? {})}`
+const probeKey = (name: string, server: Record<string, unknown> | undefined, profileKey: string): string =>
+  `${profileKey}::${name}::${serverFingerprint(server ?? {})}`
 
 type Probe = McpTestResult | 'probing'
 
@@ -330,10 +330,19 @@ function scanServerBlocks(text: string): ServerBlock[] {
   return blocks
 }
 
-export function McpTab({ gateway }: { gateway: HermesGateway | null }) {
+export function McpTab({ gateway, profile }: { gateway: HermesGateway | null; profile?: null | string }) {
   const { t } = useI18n()
   const m = t.settings.mcp
   const activeSessionId = useStore($activeSessionId)
+
+  // The profile this tab configures: the Capabilities profile-scope selector's
+  // choice (`profile`) when set, otherwise the app-wide active profile. Every
+  // fetch/save below is scoped to it, and it keys the config/catalog/probe
+  // caches so switching the selector refetches and never shows another
+  // profile's servers (AGENTS.md scope-in-key). When no override is passed this
+  // resolves to $activeGatewayProfile, so behavior is identical to before.
+  const appProfile = useStore($activeGatewayProfile)
+  const scopeProfileKey = normalizeProfileKey(profile ?? appProfile)
 
   // Shared config cache (see use-config-record): revisiting the tab paints the
   // cached record instantly; mutations write through `setConfig` and stay
@@ -346,9 +355,9 @@ export function McpTab({ gateway }: { gateway: HermesGateway | null }) {
     refetch: refetchConfig,
     dataUpdatedAt: configUpdatedAt,
     errorUpdatedAt: configErroredAt
-  } = useHermesConfigRecord()
+  } = useHermesConfigRecord(profile)
 
-  const setConfig = setHermesConfigCache
+  const setConfig = hermesConfigCacheWriter(profile)
 
   // True from a profile switch until the config query resettles for the new
   // profile. Until then `config` (and thus `servers`) still holds profile A's
@@ -407,11 +416,13 @@ export function McpTab({ gateway }: { gateway: HermesGateway | null }) {
   // enrichment below), so switching between them never re-requests.
   const [leftView, setLeftView] = useState<'catalog' | 'servers'>('servers')
 
-  // Key by active profile — installed/enabled badges are per-profile, so sharing
-  // one cache across profiles would flash the previous profile's state on switch.
+  // Key by the SCOPED profile — installed/enabled badges are per-profile, so
+  // sharing one cache across profiles would flash the previous profile's state
+  // on switch. When no selector override is set this is the active profile,
+  // identical to before.
   const catalogQuery = useQuery({
-    queryKey: [...MCP_CATALOG_KEY, normalizeProfileKey(useStore($activeGatewayProfile))],
-    queryFn: getMcpCatalog,
+    queryKey: [...MCP_CATALOG_KEY, scopeProfileKey],
+    queryFn: () => getMcpCatalog(profile ?? undefined),
     staleTime: 5 * 60_000
   })
 
@@ -538,11 +549,11 @@ export function McpTab({ gateway }: { gateway: HermesGateway | null }) {
 
   const runProbe = async (serverName: string) => {
     const epoch = profileEpoch.current
-    const key = probeKey(serverName, servers[serverName])
+    const key = probeKey(serverName, servers[serverName], scopeProfileKey)
     setProbes(current => ({ ...current, [serverName]: 'probing' }))
 
     try {
-      const result = await testMcpServer(serverName)
+      const result = await testMcpServer(serverName, profile ?? undefined)
 
       // Drop the result if the profile changed mid-probe — it belongs to A.
       if (profileEpoch.current !== epoch) {
@@ -573,8 +584,8 @@ export function McpTab({ gateway }: { gateway: HermesGateway | null }) {
     try {
       const flow = await completeMcpDesktopOAuth({
         serverName,
-        start: authMcpServer,
-        status: getMcpOAuthFlow,
+        start: name => authMcpServer(name, profile ?? undefined),
+        status: flowId => getMcpOAuthFlow(flowId, profile ?? undefined),
         openExternal: url => window.hermesDesktop.openExternal(url)
       })
 
@@ -589,7 +600,7 @@ export function McpTab({ gateway }: { gateway: HermesGateway | null }) {
       // Cache under the POST-auth fingerprint (auth: oauth) on success — that's
       // the config the mount effect will read back, so it hits this entry.
       const probedConfig = result.ok ? { ...servers[serverName], auth: 'oauth' } : servers[serverName]
-      probeCache.set(probeKey(serverName, probedConfig), { at: Date.now(), result })
+      probeCache.set(probeKey(serverName, probedConfig, scopeProfileKey), { at: Date.now(), result })
 
       if (result.ok) {
         // The endpoint persisted `auth: oauth` — mirror it locally.
@@ -640,7 +651,7 @@ export function McpTab({ gateway }: { gateway: HermesGateway | null }) {
         continue
       }
 
-      const cached = probeCache.get(probeKey(serverName, server))
+      const cached = probeCache.get(probeKey(serverName, server, scopeProfileKey))
 
       if (cached && Date.now() - cached.at < PROBE_TTL_MS) {
         setProbes(current => ({ ...current, [serverName]: cached.result }))
@@ -674,7 +685,7 @@ export function McpTab({ gateway }: { gateway: HermesGateway | null }) {
   // caller must skip its post-await writes.
   const persist = async (nextServers: McpServers): Promise<boolean> => {
     const epoch = profileEpoch.current
-    await saveMcpServers(nextServers)
+    await saveMcpServers(nextServers, profile ?? undefined)
 
     if (profileEpoch.current !== epoch) {
       return false
@@ -991,7 +1002,12 @@ export function McpTab({ gateway }: { gateway: HermesGateway | null }) {
             </div>
             <div className="min-h-0 flex-1 overflow-y-auto overscroll-contain [scrollbar-gutter:stable]">
               {leftView === 'catalog' ? (
-                <McpCatalog entries={catalog} loading={catalogQuery.isLoading} onInstalled={onCatalogInstalled} />
+                <McpCatalog
+                  entries={catalog}
+                  loading={catalogQuery.isLoading}
+                  onInstalled={onCatalogInstalled}
+                  profile={profile}
+                />
               ) : (
                 <>
                   {names.map(serverName => {
@@ -1329,11 +1345,13 @@ function CatalogTag({ children }: { children: string }) {
 function McpCatalog({
   entries,
   loading,
-  onInstalled
+  onInstalled,
+  profile
 }: {
   entries: McpCatalogEntry[]
   loading: boolean
   onInstalled: () => void
+  profile?: null | string
 }) {
   const { t } = useI18n()
   const m = t.settings.mcp
@@ -1361,7 +1379,7 @@ function McpCatalog({
     setInstalling(entry.name)
 
     try {
-      const res = await installMcpCatalogEntry(entry.name, draft)
+      const res = await installMcpCatalogEntry(entry.name, draft, profile ?? undefined)
 
       // Git-backed entries clone in the background — keep the row busy and poll
       // the action to completion before refetching / re-enabling, so a re-click
@@ -1369,7 +1387,7 @@ function McpCatalog({
       // exit is a real failure — surface it instead of a false success.
       if (res.background && res.action) {
         for (;;) {
-          const status = await getActionStatus(res.action, 1)
+          const status = await getActionStatus(res.action, 1, profile ?? undefined)
 
           if (!status.running) {
             if (status.exit_code !== 0) {

--- a/apps/desktop/src/hermes.ts
+++ b/apps/desktop/src/hermes.ts
@@ -833,9 +833,9 @@ export function getHermesConfig(profile?: string): Promise<HermesConfig> {
   })
 }
 
-export function getHermesConfigRecord(): Promise<HermesConfigRecord> {
+export function getHermesConfigRecord(profile?: null | string): Promise<HermesConfigRecord> {
   return window.hermesDesktop.api<HermesConfigRecord>({
-    ...profileScoped(),
+    ...profileScoped(profile),
     path: '/api/config'
   })
 }
@@ -888,9 +888,9 @@ export function getEnvVars(): Promise<Record<string, EnvVarInfo>> {
   })
 }
 
-export function setEnvVar(key: string, value: string): Promise<{ ok: boolean }> {
+export function setEnvVar(key: string, value: string, profile?: null | string): Promise<{ ok: boolean }> {
   return window.hermesDesktop.api<{ ok: boolean }>({
-    ...profileScoped(),
+    ...profileScoped(profile),
     path: '/api/env',
     method: 'PUT',
     body: { key, value }
@@ -950,18 +950,18 @@ export function deleteCustomEndpoint(id: string): Promise<CustomEndpointsRespons
   })
 }
 
-export function deleteEnvVar(key: string): Promise<{ ok: boolean }> {
+export function deleteEnvVar(key: string, profile?: null | string): Promise<{ ok: boolean }> {
   return window.hermesDesktop.api<{ ok: boolean }>({
-    ...profileScoped(),
+    ...profileScoped(profile),
     path: '/api/env',
     method: 'DELETE',
     body: { key }
   })
 }
 
-export function revealEnvVar(key: string): Promise<{ key: string; value: string }> {
+export function revealEnvVar(key: string, profile?: null | string): Promise<{ key: string; value: string }> {
   return window.hermesDesktop.api<{ key: string; value: string }>({
-    ...profileScoped(),
+    ...profileScoped(profile),
     path: '/api/env/reveal',
     method: 'POST',
     body: { key }
@@ -983,9 +983,9 @@ export function disconnectOAuthProvider(providerId: string): Promise<{ ok: boole
   })
 }
 
-export function startOAuthLogin(providerId: string): Promise<OAuthStartResponse> {
+export function startOAuthLogin(providerId: string, profile?: null | string): Promise<OAuthStartResponse> {
   return window.hermesDesktop.api<OAuthStartResponse>({
-    ...profileScoped(),
+    ...profileScoped(profile),
     path: `/api/providers/oauth/${encodeURIComponent(providerId)}/start`,
     method: 'POST',
     body: {}
@@ -1001,9 +1001,13 @@ export function submitOAuthCode(providerId: string, sessionId: string, code: str
   })
 }
 
-export function pollOAuthSession(providerId: string, sessionId: string): Promise<OAuthPollResponse> {
+export function pollOAuthSession(
+  providerId: string,
+  sessionId: string,
+  profile?: null | string
+): Promise<OAuthPollResponse> {
   return window.hermesDesktop.api<OAuthPollResponse>({
-    ...profileScoped(),
+    ...profileScoped(profile),
     path: `/api/providers/oauth/${encodeURIComponent(providerId)}/poll/${encodeURIComponent(sessionId)}`
   })
 }
@@ -1113,9 +1117,9 @@ export interface McpOAuthFlow {
 
 /** Connect to the server, list its tools, disconnect. Slow (spawns/handshakes
  *  for real) — well past the 15s default fetch timeout. */
-export function testMcpServer(name: string): Promise<McpTestResult> {
+export function testMcpServer(name: string, profile?: null | string): Promise<McpTestResult> {
   return window.hermesDesktop.api<McpTestResult>({
-    ...profileScoped(),
+    ...profileScoped(profile),
     path: `/api/mcp/servers/${encodeURIComponent(name)}/test`,
     method: 'POST',
     timeoutMs: 60_000
@@ -1125,9 +1129,12 @@ export function testMcpServer(name: string): Promise<McpTestResult> {
 /** Replace the whole `mcp_servers` map (the mcp.json editor's save). Unlike
  *  `saveHermesConfig`, this REPLACES rather than deep-merges, so deletes,
  *  re-enables (dropping `enabled: false`), and removed nested fields persist. */
-export function saveMcpServers(servers: Record<string, Record<string, unknown>>): Promise<{ ok: boolean }> {
+export function saveMcpServers(
+  servers: Record<string, Record<string, unknown>>,
+  profile?: null | string
+): Promise<{ ok: boolean }> {
   return window.hermesDesktop.api<{ ok: boolean }>({
-    ...profileScoped(),
+    ...profileScoped(profile),
     path: '/api/mcp/servers',
     method: 'PUT',
     body: { servers }
@@ -1135,63 +1142,76 @@ export function saveMcpServers(servers: Record<string, Record<string, unknown>>)
 }
 
 /** Start an MCP OAuth flow and return the authorization URL. */
-export function authMcpServer(name: string): Promise<McpOAuthFlow> {
+export function authMcpServer(name: string, profile?: null | string): Promise<McpOAuthFlow> {
   return window.hermesDesktop.api<McpOAuthFlow>({
-    ...profileScoped(),
+    ...profileScoped(profile),
     path: `/api/mcp/servers/${encodeURIComponent(name)}/auth`,
     method: 'POST',
     timeoutMs: 60_000
   })
 }
 
-export function getMcpOAuthFlow(flowId: string): Promise<McpOAuthFlow> {
+export function getMcpOAuthFlow(flowId: string, profile?: null | string): Promise<McpOAuthFlow> {
   return window.hermesDesktop.api<McpOAuthFlow>({
-    ...profileScoped(),
+    ...profileScoped(profile),
     path: `/api/mcp/oauth/flows/${encodeURIComponent(flowId)}`
   })
 }
 
 /** Cancel an in-flight MCP OAuth flow server-side, freeing the per-server
  *  "already in progress" slot so a retry doesn't 409. */
-export function cancelMcpOAuthFlow(flowId: string): Promise<{ ok: boolean; status: string }> {
+export function cancelMcpOAuthFlow(
+  flowId: string,
+  profile?: null | string
+): Promise<{ ok: boolean; status: string }> {
   return window.hermesDesktop.api<{ ok: boolean; status: string }>({
-    ...profileScoped(),
+    ...profileScoped(profile),
     path: `/api/mcp/oauth/flows/${encodeURIComponent(flowId)}`,
     method: 'DELETE'
   })
 }
 
-export function getToolsets(): Promise<ToolsetInfo[]> {
+// The optional trailing `profile` on every capability fetcher below is the
+// Capabilities view's profile-scope override: it lets the Skills/Tools/MCP
+// panels configure ANY profile without swapping the app-wide active profile.
+// Omitting it (every pre-existing caller) means `profileScoped(undefined)`
+// falls back to the app-wide `_apiProfile`, so behavior is byte-identical.
+export function getToolsets(profile?: null | string): Promise<ToolsetInfo[]> {
   return window.hermesDesktop.api<ToolsetInfo[]>({
-    ...profileScoped(),
+    ...profileScoped(profile),
     path: '/api/tools/toolsets'
   })
 }
 
 export function setToolsetEnabled(
   name: string,
-  enabled: boolean
+  enabled: boolean,
+  profile?: null | string
 ): Promise<{ ok: boolean; name: string; enabled: boolean }> {
   return window.hermesDesktop.api<{ ok: boolean; name: string; enabled: boolean }>({
-    ...profileScoped(),
+    ...profileScoped(profile),
     path: `/api/tools/toolsets/${encodeURIComponent(name)}`,
     method: 'PUT',
     body: { enabled }
   })
 }
 
-export function getToolsetConfig(name: string): Promise<ToolsetConfig> {
+export function getToolsetConfig(name: string, profile?: null | string): Promise<ToolsetConfig> {
   return window.hermesDesktop.api<ToolsetConfig>({
-    ...profileScoped(),
+    ...profileScoped(profile),
     path: `/api/tools/toolsets/${encodeURIComponent(name)}/config`
   })
 }
 
-export function getToolsetModels(name: string, provider?: string): Promise<ToolsetModelsResponse> {
+export function getToolsetModels(
+  name: string,
+  provider?: string,
+  profile?: null | string
+): Promise<ToolsetModelsResponse> {
   const suffix = provider ? `?provider=${encodeURIComponent(provider)}` : ''
 
   return window.hermesDesktop.api<ToolsetModelsResponse>({
-    ...profileScoped(),
+    ...profileScoped(profile),
     path: `/api/tools/toolsets/${encodeURIComponent(name)}/models${suffix}`
   })
 }
@@ -1199,10 +1219,11 @@ export function getToolsetModels(name: string, provider?: string): Promise<Tools
 export function selectToolsetModel(
   name: string,
   model: string,
-  provider?: string
+  provider?: string,
+  profile?: null | string
 ): Promise<{ ok: boolean; name: string; model: string }> {
   return window.hermesDesktop.api<{ ok: boolean; name: string; model: string }>({
-    ...profileScoped(),
+    ...profileScoped(profile),
     path: `/api/tools/toolsets/${encodeURIComponent(name)}/model`,
     method: 'PUT',
     body: { model, provider }
@@ -1226,19 +1247,24 @@ export interface SelectToolsetProviderResponse {
 export function selectToolsetProvider(
   name: string,
   provider: string,
-  capability?: 'search' | 'extract'
+  capability?: 'search' | 'extract',
+  profile?: null | string
 ): Promise<SelectToolsetProviderResponse> {
   return window.hermesDesktop.api<SelectToolsetProviderResponse>({
-    ...profileScoped(),
+    ...profileScoped(profile),
     path: `/api/tools/toolsets/${encodeURIComponent(name)}/provider`,
     method: 'PUT',
     body: capability ? { provider, capability } : { provider }
   })
 }
 
-export function runToolsetPostSetup(name: string, key: string): Promise<ActionResponse & { key: string }> {
+export function runToolsetPostSetup(
+  name: string,
+  key: string,
+  profile?: null | string
+): Promise<ActionResponse & { key: string }> {
   return window.hermesDesktop.api<ActionResponse & { key: string }>({
-    ...profileScoped(),
+    ...profileScoped(profile),
     path: `/api/tools/toolsets/${encodeURIComponent(name)}/post-setup`,
     method: 'POST',
     body: { key }
@@ -1711,9 +1737,9 @@ export function checkHermesUpdate(force = false): Promise<BackendUpdateCheckResp
   })
 }
 
-export function getActionStatus(name: string, lines = 200): Promise<ActionStatusResponse> {
+export function getActionStatus(name: string, lines = 200, profile?: null | string): Promise<ActionStatusResponse> {
   return window.hermesDesktop.api<ActionStatusResponse>({
-    ...profileScoped(),
+    ...profileScoped(profile),
     path: `/api/actions/${encodeURIComponent(name)}/status?lines=${Math.max(1, lines)}`
   })
 }
@@ -1873,19 +1899,20 @@ export function setMcpServerEnabled(name: string, enabled: boolean): Promise<{ o
   })
 }
 
-export function getMcpCatalog(): Promise<McpCatalogResponse> {
+export function getMcpCatalog(profile?: null | string): Promise<McpCatalogResponse> {
   return window.hermesDesktop.api<McpCatalogResponse>({
-    ...profileScoped(),
+    ...profileScoped(profile),
     path: '/api/mcp/catalog'
   })
 }
 
 export function installMcpCatalogEntry(
   name: string,
-  env: Record<string, string> = {}
+  env: Record<string, string> = {},
+  profile?: null | string
 ): Promise<{ ok: boolean; name?: string; pid?: number; action?: string; background?: boolean }> {
   return window.hermesDesktop.api<{ ok: boolean; name?: string; pid?: number; action?: string; background?: boolean }>({
-    ...profileScoped(),
+    ...profileScoped(profile),
     path: '/api/mcp/catalog/install',
     method: 'POST',
     body: { name, env, enable: true },

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -1014,6 +1014,7 @@ export const en: Translations = {
   skills: {
     tabSkills: 'Skills',
     tabToolsets: 'Tools',
+    configuringProfile: 'Configuring:',
     tabMcp: 'MCP',
     tabHub: 'Browse Hub',
     all: 'All',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -877,6 +877,7 @@ export interface Translations {
   skills: {
     tabSkills: string
     tabToolsets: string
+    configuringProfile: string
     tabMcp: string
     tabHub: string
     all: string

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -1212,6 +1212,7 @@ export const zh: Translations = {
   skills: {
     tabSkills: '技能',
     tabToolsets: '工具集',
+    configuringProfile: '正在配置：',
     tabMcp: 'MCP',
     tabHub: '浏览技能中心',
     all: '全部',


### PR DESCRIPTION
Adds a **'Configuring:' profile selector** above the Tools and MCP tabs in the Capabilities (Skills) view, so you can configure **any** profile's toolsets and MCP servers without switching the whole app into that profile.

## Why
The Capabilities view (Tools / MCP) already scoped to the app-wide active profile (`$activeGatewayProfile`), with a full MCP catalog + install/enable/OAuth already shipped in `mcp-tab.tsx`. What was missing: a way to point that surface at a **different** profile in place — e.g. set up a bot's MCP servers and toolsets from the main window. This adds exactly that as an override layer; it does **not** duplicate the existing catalog.

## What changed
- **hermes.ts**: every capability fetcher gains an optional trailing `profile?` that forwards to the existing `profileScoped(profile)`. Omitting it is byte-identical to today (`profileScoped(undefined)` → the app-wide `_apiProfile`).
- **use-config-record.ts**: `hermesConfigKey(profile)` / `useHermesConfigRecord(profile)` / `hermesConfigCacheWriter(profile)` — per-profile RQ keys (AGENTS.md scope-in-key).
- **toolset-config-panel.tsx** + **mcp-tab.tsx**: thread `profile` through every fetch and their nested children (EnvVarField, PostSetupRunner, ModelCatalogPicker), remounted per selected profile so switching never shows stale cross-profile state.
- **skills/index.tsx**: the selector (seeded from `profiles.list`, primary shown as 'Hermes', rendered only with >1 profile), defaulting to the active profile; the toolsets query + toggles are keyed and scoped to the selection; McpTab/ToolsetDetail remount per scope.
- **i18n**: `skills.configuringProfile` (en + zh; ja/ar/zh-hant fall back to English).

**Invariant preserved:** when the selected profile == the active profile (the default), behavior is identical to before. The selector is a pure override.

## Tests
`index.test.tsx`: new case asserts picking a non-active profile in the selector refetches toolsets scoped to that profile; the existing single-profile cases still pass (selector hidden with one profile). **5/5.** Full-project `tsc --noEmit` clean.

Renderer change — ships in the next desktop build. Pairs with the per-profile MCP lifecycle RPCs (#86473, merged) and the bot-editor inline MCP setup.