### PR TITLE
feat(discord): command registry sync parity

### DIFF
--- a/contributors/emails/andrexibiza@gmail.com
+++ b/contributors/emails/andrexibiza@gmail.com
@@ -1,0 +1,2 @@
+andrexibiza
+# Discord omniscience I1

--- a/plugins/platforms/discord/command_registry.py
+++ b/plugins/platforms/discord/command_registry.py
@@ -1,0 +1,104 @@
+"""Discord command registry - pure logic for command sync parity.
+
+Feature I1: command registry sync parity. No network, no side effects.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Optional
+
+
+class CommandRegistryError(ValueError):
+    """Raised when a command definition is invalid."""
+
+
+@dataclass
+class CommandDef:
+    """A Discord application command definition.
+
+    Attributes:
+        name: Command name (surrounding whitespace is normalized away on use).
+        command_type: Discord command type int (1 = chat input, etc.).
+        integration_types: Discord integration type ints (0 = guild install);
+            defaults to [0] when None/empty via normalize_command.
+        guild_id: Optional guild scope; None means global.
+    """
+
+    name: str
+    command_type: int
+    integration_types: Optional[list[int]] = None
+    guild_id: Optional[str] = None
+
+
+def normalize_command(cmd: CommandDef) -> CommandDef:
+    """Return a normalized copy of ``cmd``.
+
+    - name is stripped; empty/whitespace-only names raise CommandRegistryError
+    - command_type must be an int (bool excluded); otherwise CommandRegistryError
+    - integration_types defaults to [0] when None/empty
+    - integration_types are deduped and sorted ascending
+    """
+    if not isinstance(cmd.name, str):
+        raise CommandRegistryError("command name must be a non-empty string")
+    name = cmd.name.strip()
+    if not name:
+        raise CommandRegistryError("command name must be a non-empty string")
+
+    if not isinstance(cmd.command_type, int) or isinstance(cmd.command_type, bool):
+        raise CommandRegistryError("command_type must be an int")
+
+    integration_types = sorted(set(cmd.integration_types or [0]))
+
+    return CommandDef(
+        name=name,
+        command_type=cmd.command_type,
+        integration_types=integration_types,
+        guild_id=cmd.guild_id,
+    )
+
+
+def command_fingerprint(cmd: CommandDef) -> str:
+    """Stable string key for a (normalized) command definition.
+
+    Combines (command_type, name.lower(), sorted integration_types,
+    guild_id or 'global'). Two commands with the same fingerprint are
+    considered duplicates / unchanged for sync purposes. JSON encoding
+    keeps the key unambiguous and deterministic.
+    """
+    norm = normalize_command(cmd)
+    payload = [
+        norm.command_type,
+        norm.name.lower(),
+        norm.integration_types,
+        norm.guild_id or "global",
+    ]
+    return json.dumps(payload, separators=(",", ":"))
+
+
+def duplicate_diagnostics(commands: list[CommandDef]) -> dict[str, list[str]]:
+    """Map fingerprint -> [names] for fingerprints seen more than once.
+
+    Empty dict when every command is unique. Detection operates on the
+    normalized (type, name) identity via command_fingerprint.
+    """
+    seen: dict[str, list[str]] = {}
+    for c in commands:
+        fp = command_fingerprint(c)
+        seen.setdefault(fp, []).append(c.name.strip())
+    return {fp: names for fp, names in seen.items() if len(names) > 1}
+
+
+def should_sync(current: CommandDef, deployed_fingerprint: Optional[str]) -> bool:
+    """Whether ``current`` must be (re)synced given the deployed fingerprint.
+
+    True when never deployed (deployed_fingerprint is None) or the current
+    fingerprint differs (changed); False when identical (unchanged, skip sync).
+    Raises CommandRegistryError on invalid name (empty/whitespace) or
+    command_type not int.
+    """
+    current_fp = command_fingerprint(current)  # validates name/command_type
+    if deployed_fingerprint is None:
+        return True
+    return current_fp != deployed_fingerprint

--- a/tests/tools/test_discord_command_registry.py
+++ b/tests/tools/test_discord_command_registry.py
@@ -1,0 +1,148 @@
+"""Tests for plugins.platforms.discord.command_registry (feature I1)."""
+
+import pytest
+
+from plugins.platforms.discord.command_registry import (
+    CommandDef,
+    CommandRegistryError,
+    command_fingerprint,
+    duplicate_diagnostics,
+    normalize_command,
+    should_sync,
+)
+
+
+def make_cmd(name="ping", command_type=1, integration_types=None, guild_id=None):
+    return CommandDef(
+        name=name,
+        command_type=command_type,
+        integration_types=integration_types,
+        guild_id=guild_id,
+    )
+
+
+# --- normalize_command -------------------------------------------------------
+
+
+def test_normalize_strips_name():
+    assert normalize_command(make_cmd(name="  ping  ")).name == "ping"
+
+
+def test_normalize_defaults_integration_types_to_zero():
+    assert normalize_command(make_cmd(integration_types=None)).integration_types == [0]
+    assert normalize_command(make_cmd(integration_types=[])).integration_types == [0]
+
+
+def test_normalize_dedupes_and_sorts_integration_types():
+    norm = normalize_command(make_cmd(integration_types=[2, 0, 2, 1, 0]))
+    assert norm.integration_types == [0, 1, 2]
+
+
+def test_normalize_preserves_type_and_guild():
+    norm = normalize_command(make_cmd(command_type=3, guild_id="123456"))
+    assert norm.command_type == 3
+    assert norm.guild_id == "123456"
+
+
+# --- command_fingerprint -----------------------------------------------------
+
+
+def test_fingerprint_stable_for_equal_commands():
+    a = command_fingerprint(make_cmd(name="ping", integration_types=[1, 0], guild_id="g1"))
+    b = command_fingerprint(make_cmd(name="ping", integration_types=[0, 1], guild_id="g1"))
+    assert a == b
+
+
+def test_fingerprint_is_case_insensitive_on_name():
+    assert command_fingerprint(make_cmd(name="Ping")) == command_fingerprint(
+        make_cmd(name="ping")
+    )
+
+
+def test_fingerprint_treats_none_guild_as_global():
+    assert command_fingerprint(make_cmd(guild_id=None)) == command_fingerprint(
+        make_cmd(guild_id="global")
+    )
+
+
+def test_fingerprint_differs_on_any_change():
+    base = make_cmd()
+    assert command_fingerprint(make_cmd(name="pong")) != command_fingerprint(base)
+    assert command_fingerprint(make_cmd(command_type=2)) != command_fingerprint(base)
+    assert command_fingerprint(make_cmd(integration_types=[1])) != command_fingerprint(base)
+    assert command_fingerprint(make_cmd(guild_id="123")) != command_fingerprint(base)
+
+
+# --- duplicate_diagnostics ---------------------------------------------------
+
+
+def test_duplicate_diagnostics_empty_when_unique():
+    cmds = [
+        make_cmd(name="ping"),
+        make_cmd(name="pong"),
+        make_cmd(name="slash", command_type=2),
+    ]
+    assert duplicate_diagnostics(cmds) == {}
+
+
+def test_duplicate_diagnostics_finds_duplicates_by_normalized_type_name():
+    cmds = [
+        make_cmd(name="ping"),
+        make_cmd(name="  PING  "),
+        make_cmd(name="ping", guild_id="123"),  # different guild -> not a duplicate
+    ]
+    diag = duplicate_diagnostics(cmds)
+    assert len(diag) == 1
+    (fp, names) = next(iter(diag.items()))
+    assert set(names) == {"ping", "PING"}
+    assert fp == command_fingerprint(make_cmd(name="ping"))
+
+
+def test_duplicate_diagnostics_distinguishes_by_type():
+    cmds = [make_cmd(name="ping"), make_cmd(name="ping", command_type=2)]
+    assert duplicate_diagnostics(cmds) == {}
+
+
+# --- should_sync -------------------------------------------------------------
+
+
+def test_should_sync_true_when_never_deployed():
+    assert should_sync(make_cmd(), None) is True
+
+
+def test_should_sync_false_when_unchanged():
+    fp = command_fingerprint(make_cmd())
+    assert should_sync(make_cmd(), fp) is False
+
+
+def test_should_sync_true_when_changed():
+    deployed = command_fingerprint(make_cmd(name="ping"))
+    assert should_sync(make_cmd(name="pong"), deployed) is True
+    assert should_sync(make_cmd(command_type=2), deployed) is True
+    assert should_sync(make_cmd(integration_types=[1]), deployed) is True
+
+
+# --- validation --------------------------------------------------------------
+
+
+@pytest.mark.parametrize("bad_name", ["", "   ", "\t\n "])
+def test_invalid_name_raises_in_should_sync(bad_name):
+    with pytest.raises(CommandRegistryError):
+        should_sync(make_cmd(name=bad_name), None)
+
+
+@pytest.mark.parametrize("bad_type", ["1", None, 1.5, True])
+def test_invalid_command_type_raises_in_should_sync(bad_type):
+    with pytest.raises(CommandRegistryError):
+        should_sync(make_cmd(command_type=bad_type), None)
+
+
+def test_command_registry_error_is_value_error():
+    assert issubclass(CommandRegistryError, ValueError)
+
+
+def test_invalid_input_raises_in_normalize_too():
+    with pytest.raises(ValueError):
+        normalize_command(make_cmd(name="  "))
+    with pytest.raises(CommandRegistryError):
+        normalize_command(make_cmd(command_type="1"))


### PR DESCRIPTION
## Summary

Command registry sync parity for the Discord slash-command surface — normalized `(type, name)` fingerprinting, duplicate diagnostics, integration-types normalization, and a fingerprint-skip sync decision.

## Motivation

Fixes #86549 · Part of #79564

## Changes

- New module `plugins/platforms/discord/command_registry.py` implementing normalized command fingerprinting, duplicate detection, integration-type normalization, and unchanged-fingerprint sync-skip.

## Test Plan

- [x] Unit tests pass (`pytest`)
- [x] Focused regression tests: `tests/tools/test_discord_command_registry.py` — 23 passed
- [ ] Manual testing of new functionality
- [x] No regressions in existing behavior

## Notes for Reviewers

- New module only — no god-file growth; `plugins/platforms/discord/adapter.py` untouched.
