### PR TITLE
fix(cli): preserve interpreter during self-relaunch

### DIFF
--- a/hermes_cli/relaunch.py
+++ b/hermes_cli/relaunch.py
@@ -51,6 +51,18 @@ def _build_inherited_flag_table() -> list[tuple[str, bool]]:
 _INHERITED_FLAGS_TABLE = _build_inherited_flag_table()
 
 
+def _is_python_script(path: str) -> bool:
+    """Return whether *path* is a Python script, including extensionless ones."""
+    if path.lower().endswith((".py", ".pyc")):
+        return True
+    try:
+        with open(path, "rb") as stream:
+            first_line = stream.readline(256).decode("utf-8", errors="replace")
+    except OSError:
+        return False
+    return first_line.startswith("#!") and "python" in first_line.lower()
+
+
 def _extract_inherited_flags(argv: Sequence[str]) -> list[str]:
     """Pull out flags that should carry over into a self-relaunched hermes."""
     flags: list[str] = []
@@ -139,7 +151,18 @@ def build_relaunch_argv(
     bin_path = resolve_hermes_bin()
 
     if bin_path:
-        argv = [bin_path]
+        # When a Python launcher was entered through a wrapper, Python keeps
+        # the implementation script in sys.argv[0]. Executing that script
+        # directly would let its shebang select a different interpreter on
+        # POSIX. Reuse the interpreter that is already running Hermes instead.
+        current_script = os.path.abspath(sys.argv[0])
+        if (
+            _is_python_script(bin_path)
+            and os.path.abspath(bin_path) == current_script
+        ):
+            argv = [sys.executable, bin_path]
+        else:
+            argv = [bin_path]
     else:
         argv = [sys.executable, "-m", "hermes_cli.main"]
 

--- a/tests/hermes_cli/test_relaunch.py
+++ b/tests/hermes_cli/test_relaunch.py
@@ -73,6 +73,26 @@ class TestBuildRelaunchArgv:
         argv = relaunch_mod.build_relaunch_argv(["--resume", "abc"])
         assert argv[0] == "/usr/bin/hermes"
 
+    def test_runs_python_argv0_with_current_interpreter(self, monkeypatch, tmp_path):
+        """An extensionless Python launcher must not bypass the active venv.
+
+        The installed wrapper invokes the repository's ``hermes`` script with
+        the managed interpreter, but ``sys.argv[0]`` points at that script.
+        Executing it directly during a relaunch would let its shebang select
+        system Python instead.
+        """
+        script = tmp_path / "hermes"
+        script.write_text("#!/usr/bin/env python3\n")
+        script.chmod(0o755)
+        managed_python = "/venv/bin/python"
+        monkeypatch.setattr(relaunch_mod.sys, "argv", [str(script)])
+        monkeypatch.setattr(relaunch_mod.sys, "executable", managed_python)
+
+        argv = relaunch_mod.build_relaunch_argv(
+            ["update"], preserve_inherited=False
+        )
+
+        assert argv == [managed_python, str(script), "update"]
 
     def test_preserves_inherited_flags(self, monkeypatch):
         monkeypatch.setattr(relaunch_mod, "resolve_hermes_bin", lambda: "/usr/bin/hermes")

--- a/tests/hermes_cli/test_relaunch.py
+++ b/tests/hermes_cli/test_relaunch.py
@@ -85,6 +85,7 @@ class TestBuildRelaunchArgv:
         script.write_text("#!/usr/bin/env python3\n")
         script.chmod(0o755)
         managed_python = "/venv/bin/python"
+        monkeypatch.setattr(relaunch_mod, "resolve_hermes_bin", lambda: str(script))
         monkeypatch.setattr(relaunch_mod.sys, "argv", [str(script)])
         monkeypatch.setattr(relaunch_mod.sys, "executable", managed_python)
 


### PR DESCRIPTION
## Summary
- Preserve the active Python interpreter when self-relaunching the current Python launcher script.
- Prevent `/update` from executing the extensionless repository launcher through its system-Python shebang.
- Add a regression test covering the managed-venv launcher layout.

## Root cause
When the installed shell wrapper starts Hermes, Python reports the repository `hermes` script as `sys.argv[0]`. The relaunch code executed that script directly with `os.execvp`, causing its `#!/usr/bin/env python3` shebang to select system Python instead of the active managed venv. Dependencies such as `python-dotenv` were therefore missing.

## Testing
- `./venv/bin/python -m pytest tests/hermes_cli/test_relaunch.py tests/cli/test_update_command.py -q`
  - 33 passed, 4 skipped
- `./venv/bin/python -m ruff check hermes_cli/relaunch.py tests/hermes_cli/test_relaunch.py`
- Python compile check and `git diff --check`