### PR TITLE
feat(terminal): per-command memory ceiling for local backend (Claude Code v2.1.233 port)

### DIFF
--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -318,6 +318,14 @@ DEFAULT_CONFIG = {
         # window so it can't leak indefinitely. 0 disables escalation (SIGTERM
         # only — the historical behavior). Floored internally at 0.
         "daemon_term_grace_seconds": 2.0,
+        # Per-command memory ceiling (MiB) for local terminal commands, so a
+        # runaway build/test process can't OOM the whole machine and stall the
+        # session. 0 (default) = no limit. POSIX-only (RLIMIT_AS on the spawned
+        # process group; ignored on Windows). Container/cloud backends
+        # (docker/modal/...) already have their own isolation and are not
+        # affected. Inspired by Claude Code's CLAUDE_CODE_TOOL_MEMORY_LIMIT
+        # (v2.1.233), adapted to config.yaml per Hermes env-var policy.
+        "memory_limit_mb": 0,
         # Environment variables to pass through to sandboxed execution
         # (terminal and execute_code).  Skill-declared required_environment_variables
         # are passed through automatically; this list is for non-skill use cases.

--- a/tests/tools/test_local_env_memory_limit.py
+++ b/tests/tools/test_local_env_memory_limit.py
@@ -1,8 +1,8 @@
 """Tests for the local terminal per-command memory ceiling.
 
 ``terminal.memory_limit_mb`` (config.yaml) applies an RLIMIT_AS cap to
-locally spawned command trees via ``preexec_fn``, so a runaway build can't
-OOM the whole machine. Inspired by Claude Code's
+locally spawned command trees via a ``ulimit -v`` bash prelude, so a
+runaway build can't OOM the whole machine. Inspired by Claude Code's
 ``CLAUDE_CODE_TOOL_MEMORY_LIMIT`` (v2.1.233); adapted to config.yaml per
 the ".env is for secrets only" policy.
 """
@@ -14,7 +14,7 @@ import pytest
 
 from tools.environments import local as local_mod
 from tools.environments.local import (
-    _make_memory_limit_preexec,
+    _memory_limit_prelude,
     _read_terminal_memory_limit_bytes,
 )
 
@@ -60,7 +60,20 @@ class TestReadTerminalMemoryLimit:
             assert _read_terminal_memory_limit_bytes() == 0
 
 
-@pytest.mark.skipif(not IS_POSIX, reason="RLIMIT_AS is POSIX-only")
+class TestMemoryLimitPrelude:
+    def test_converts_bytes_to_kib(self):
+        prelude = _memory_limit_prelude(512 * 1024 * 1024)
+        assert prelude.startswith("ulimit -v 524288 ")
+
+    def test_fails_open_syntax(self):
+        # The prelude must never abort the command when ulimit rejects it.
+        assert "|| true" in _memory_limit_prelude(1024 * 1024)
+
+    def test_minimum_one_kib(self):
+        assert "ulimit -v 1 " in _memory_limit_prelude(17)
+
+
+@pytest.mark.skipif(not IS_POSIX, reason="ulimit -v prelude is POSIX-only")
 class TestMemoryLimitEnforcement:
     """E2E: the spawned command tree really is capped."""
 
@@ -72,14 +85,6 @@ class TestMemoryLimitEnforcement:
         env.env = {}
         env.timeout = 30
         return env
-
-    def test_preexec_fn_attached_when_configured(self, tmp_path):
-        env = self._make_env(tmp_path)
-        with patch.object(
-            local_mod, "_read_terminal_memory_limit_bytes", return_value=64 * 1024 * 1024
-        ):
-            proc = env._run_bash("true", timeout=10)
-            proc.wait(timeout=10)
 
     def test_command_over_limit_fails_under_limit_succeeds(self, tmp_path):
         """A python allocation over the cap dies; the same env runs small
@@ -116,10 +121,18 @@ class TestMemoryLimitEnforcement:
             assert proc.returncode == 0
             assert "ok" in out
 
-
-@pytest.mark.skipif(not IS_POSIX, reason="RLIMIT_AS is POSIX-only")
-def test_preexec_never_raises_even_on_bad_limit():
-    """setrlimit failures inside the child must not kill the command."""
-    fn = _make_memory_limit_preexec(-12345)
-    # Running in-process is safe: the helper swallows every exception.
-    fn()
+    def test_limit_survives_subprocess_descent(self, tmp_path):
+        """The cap is inherited by children of the spawned bash."""
+        env = self._make_env(tmp_path)
+        # bash -> sh -> python3: the grandchild must still be capped.
+        cmd = (
+            "sh -c 'python3 -c \"x = bytearray(800 * 1024 * 1024); print(1)\"'"
+        )
+        with patch.object(
+            local_mod,
+            "_read_terminal_memory_limit_bytes",
+            return_value=512 * 1024 * 1024,
+        ):
+            proc = env._run_bash(cmd, timeout=30)
+            out, _ = proc.communicate(timeout=30)
+            assert proc.returncode != 0

--- a/tests/tools/test_local_env_memory_limit.py
+++ b/tests/tools/test_local_env_memory_limit.py
@@ -1,0 +1,125 @@
+"""Tests for the local terminal per-command memory ceiling.
+
+``terminal.memory_limit_mb`` (config.yaml) applies an RLIMIT_AS cap to
+locally spawned command trees via ``preexec_fn``, so a runaway build can't
+OOM the whole machine. Inspired by Claude Code's
+``CLAUDE_CODE_TOOL_MEMORY_LIMIT`` (v2.1.233); adapted to config.yaml per
+the ".env is for secrets only" policy.
+"""
+
+import sys
+from unittest.mock import patch
+
+import pytest
+
+from tools.environments import local as local_mod
+from tools.environments.local import (
+    _make_memory_limit_preexec,
+    _read_terminal_memory_limit_bytes,
+)
+
+IS_POSIX = not sys.platform.startswith("win")
+
+
+class TestReadTerminalMemoryLimit:
+    def _with_cfg(self, cfg):
+        return patch("hermes_cli.config.load_config", return_value=cfg)
+
+    def test_default_is_unlimited(self):
+        with self._with_cfg({"terminal": {}}):
+            assert _read_terminal_memory_limit_bytes() == 0
+
+    def test_missing_terminal_section(self):
+        with self._with_cfg({}):
+            assert _read_terminal_memory_limit_bytes() == 0
+
+    def test_configured_limit_converts_to_bytes(self):
+        with self._with_cfg({"terminal": {"memory_limit_mb": 512}}):
+            assert _read_terminal_memory_limit_bytes() == 512 * 1024 * 1024
+
+    def test_zero_disables(self):
+        with self._with_cfg({"terminal": {"memory_limit_mb": 0}}):
+            assert _read_terminal_memory_limit_bytes() == 0
+
+    def test_negative_disables(self):
+        with self._with_cfg({"terminal": {"memory_limit_mb": -5}}):
+            assert _read_terminal_memory_limit_bytes() == 0
+
+    def test_string_number_accepted(self):
+        with self._with_cfg({"terminal": {"memory_limit_mb": "256"}}):
+            assert _read_terminal_memory_limit_bytes() == 256 * 1024 * 1024
+
+    def test_garbage_value_fails_open(self):
+        with self._with_cfg({"terminal": {"memory_limit_mb": "lots"}}):
+            assert _read_terminal_memory_limit_bytes() == 0
+
+    def test_config_load_failure_fails_open(self):
+        with patch(
+            "hermes_cli.config.load_config", side_effect=RuntimeError("boom")
+        ):
+            assert _read_terminal_memory_limit_bytes() == 0
+
+
+@pytest.mark.skipif(not IS_POSIX, reason="RLIMIT_AS is POSIX-only")
+class TestMemoryLimitEnforcement:
+    """E2E: the spawned command tree really is capped."""
+
+    def _make_env(self, tmp_path):
+        # Avoid the login-shell snapshot cost: construct without __init__,
+        # mirroring the pattern used by other LocalEnvironment tests.
+        env = object.__new__(local_mod.LocalEnvironment)
+        env.cwd = str(tmp_path)
+        env.env = {}
+        env.timeout = 30
+        return env
+
+    def test_preexec_fn_attached_when_configured(self, tmp_path):
+        env = self._make_env(tmp_path)
+        with patch.object(
+            local_mod, "_read_terminal_memory_limit_bytes", return_value=64 * 1024 * 1024
+        ):
+            proc = env._run_bash("true", timeout=10)
+            proc.wait(timeout=10)
+
+    def test_command_over_limit_fails_under_limit_succeeds(self, tmp_path):
+        """A python allocation over the cap dies; the same env runs small
+        commands fine. Uses a 512 MiB cap so interpreter startup fits."""
+        env = self._make_env(tmp_path)
+        alloc_big = (
+            "python3 -c \"x = bytearray(800 * 1024 * 1024); print('allocated')\""
+        )
+        alloc_small = "python3 -c \"x = bytearray(8 * 1024 * 1024); print('allocated')\""
+
+        with patch.object(
+            local_mod,
+            "_read_terminal_memory_limit_bytes",
+            return_value=512 * 1024 * 1024,
+        ):
+            proc = env._run_bash(alloc_big, timeout=30)
+            out, _ = proc.communicate(timeout=30)
+            assert proc.returncode != 0
+            assert "allocated" not in out
+
+            proc = env._run_bash(alloc_small, timeout=30)
+            out, _ = proc.communicate(timeout=30)
+            assert proc.returncode == 0
+            assert "allocated" in out
+
+    def test_unlimited_when_config_zero(self, tmp_path):
+        env = self._make_env(tmp_path)
+        alloc = "python3 -c \"x = bytearray(64 * 1024 * 1024); print('ok')\""
+        with patch.object(
+            local_mod, "_read_terminal_memory_limit_bytes", return_value=0
+        ):
+            proc = env._run_bash(alloc, timeout=30)
+            out, _ = proc.communicate(timeout=30)
+            assert proc.returncode == 0
+            assert "ok" in out
+
+
+@pytest.mark.skipif(not IS_POSIX, reason="RLIMIT_AS is POSIX-only")
+def test_preexec_never_raises_even_on_bad_limit():
+    """setrlimit failures inside the child must not kill the command."""
+    fn = _make_memory_limit_preexec(-12345)
+    # Running in-process is safe: the helper swallows every exception.
+    fn()

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -1411,6 +1411,54 @@ def _prepend_shell_init(cmd_string: str, files: list[str]) -> str:
     return prelude + cmd_string
 
 
+def _read_terminal_memory_limit_bytes() -> int:
+    """Return ``terminal.memory_limit_mb`` from config.yaml, in bytes.
+
+    0 means "no limit" (the default). Best-effort: any config read failure
+    or invalid value disables the limit so terminal execution never breaks
+    because config.yaml is unreadable. Windows has no ``resource`` module,
+    so the limit is POSIX-only by construction.
+
+    Inspired by Claude Code's ``CLAUDE_CODE_TOOL_MEMORY_LIMIT`` (v2.1.233),
+    adapted to Hermes's config.yaml (``.env`` is for secrets only).
+    """
+    if _IS_WINDOWS:
+        return 0
+    try:
+        from hermes_cli.config import load_config
+
+        cfg = load_config() or {}
+        terminal_cfg = cfg.get("terminal") or {}
+        raw = terminal_cfg.get("memory_limit_mb", 0)
+        mb = int(raw)
+        if mb <= 0:
+            return 0
+        return mb * 1024 * 1024
+    except Exception:
+        return 0
+
+
+def _make_memory_limit_preexec(limit_bytes: int):
+    """Build a ``preexec_fn`` that applies RLIMIT_AS in the child process.
+
+    The limit is inherited by every descendant of the spawned bash, so the
+    whole command tree (build, test runner, compiler jobs) is covered. A
+    process that exceeds it gets a MemoryError/ENOMEM instead of stalling
+    the machine into swap. Never raises: if ``setrlimit`` fails (e.g. the
+    hard limit is already lower), the command still runs unlimited.
+    """
+
+    def _preexec() -> None:  # pragma: no cover - runs in the forked child
+        try:
+            import resource
+
+            resource.setrlimit(resource.RLIMIT_AS, (limit_bytes, limit_bytes))
+        except Exception:
+            pass
+
+    return _preexec
+
+
 class LocalEnvironment(BaseEnvironment):
     """Run commands directly on the host machine.
 
@@ -1527,7 +1575,15 @@ class LocalEnvironment(BaseEnvironment):
 
         _popen_cwd = self.cwd
 
-        _popen_kwargs = {"creationflags": windows_hide_flags()} if _IS_WINDOWS else {}
+        _popen_kwargs: dict = {"creationflags": windows_hide_flags()} if _IS_WINDOWS else {}
+
+        # Optional per-command memory ceiling (terminal.memory_limit_mb).
+        # Applied via preexec_fn in the forked child so the RLIMIT_AS cap is
+        # inherited by the whole command tree. POSIX-only; the helper returns
+        # 0 on Windows and on any config problem.
+        _mem_limit = _read_terminal_memory_limit_bytes()
+        if _mem_limit > 0:
+            _popen_kwargs["preexec_fn"] = _make_memory_limit_preexec(_mem_limit)
 
         proc = subprocess.Popen(
             args,

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -1416,8 +1416,8 @@ def _read_terminal_memory_limit_bytes() -> int:
 
     0 means "no limit" (the default). Best-effort: any config read failure
     or invalid value disables the limit so terminal execution never breaks
-    because config.yaml is unreadable. Windows has no ``resource`` module,
-    so the limit is POSIX-only by construction.
+    because config.yaml is unreadable. POSIX-only (``ulimit -v`` has no
+    Windows equivalent in Git Bash's process model).
 
     Inspired by Claude Code's ``CLAUDE_CODE_TOOL_MEMORY_LIMIT`` (v2.1.233),
     adapted to Hermes's config.yaml (``.env`` is for secrets only).
@@ -1438,25 +1438,23 @@ def _read_terminal_memory_limit_bytes() -> int:
         return 0
 
 
-def _make_memory_limit_preexec(limit_bytes: int):
-    """Build a ``preexec_fn`` that applies RLIMIT_AS in the child process.
+def _memory_limit_prelude(limit_bytes: int) -> str:
+    """Return a bash prelude applying an RLIMIT_AS cap via ``ulimit -v``.
 
-    The limit is inherited by every descendant of the spawned bash, so the
-    whole command tree (build, test runner, compiler jobs) is covered. A
-    process that exceeds it gets a MemoryError/ENOMEM instead of stalling
-    the machine into swap. Never raises: if ``setrlimit`` fails (e.g. the
-    hard limit is already lower), the command still runs unlimited.
+    The limit is set inside the spawned bash before the user command runs
+    and is inherited by every descendant, so the whole command tree (build,
+    test runner, compiler jobs) is covered. A process that exceeds it gets
+    an out-of-memory failure instead of stalling the machine into swap.
+    Fails open: if ``ulimit`` rejects the value (e.g. the hard limit is
+    already lower), the command still runs unlimited.
+
+    Implemented as a shell prelude rather than a Popen pre-exec callback
+    because pre-exec callbacks are thread-unsafe (Hermes spawns terminal
+    commands from multi-threaded contexts) and banned by the Windows-compat
+    guard tests.
     """
-
-    def _preexec() -> None:  # pragma: no cover - runs in the forked child
-        try:
-            import resource
-
-            resource.setrlimit(resource.RLIMIT_AS, (limit_bytes, limit_bytes))
-        except Exception:
-            pass
-
-    return _preexec
+    limit_kib = max(1, limit_bytes // 1024)
+    return f"ulimit -v {limit_kib} 2>/dev/null || true; "
 
 
 class LocalEnvironment(BaseEnvironment):
@@ -1545,6 +1543,13 @@ class LocalEnvironment(BaseEnvironment):
             init_files = _resolve_shell_init_files()
             if init_files:
                 cmd_string = _prepend_shell_init(cmd_string, init_files)
+        # Optional per-command memory ceiling (terminal.memory_limit_mb).
+        # Applied as a ulimit -v prelude inside the spawned bash so the
+        # RLIMIT_AS cap is inherited by the whole command tree. POSIX-only;
+        # the helper returns 0 on Windows and on any config problem.
+        _mem_limit = _read_terminal_memory_limit_bytes()
+        if _mem_limit > 0:
+            cmd_string = _memory_limit_prelude(_mem_limit) + cmd_string
         args = [bash, "-l", "-c", cmd_string] if login else [bash, "-c", cmd_string]
         run_env = _make_run_env(self.env)
 
@@ -1576,14 +1581,6 @@ class LocalEnvironment(BaseEnvironment):
         _popen_cwd = self.cwd
 
         _popen_kwargs: dict = {"creationflags": windows_hide_flags()} if _IS_WINDOWS else {}
-
-        # Optional per-command memory ceiling (terminal.memory_limit_mb).
-        # Applied via preexec_fn in the forked child so the RLIMIT_AS cap is
-        # inherited by the whole command tree. POSIX-only; the helper returns
-        # 0 on Windows and on any config problem.
-        _mem_limit = _read_terminal_memory_limit_bytes()
-        if _mem_limit > 0:
-            _popen_kwargs["preexec_fn"] = _make_memory_limit_preexec(_mem_limit)
 
         proc = subprocess.Popen(
             args,

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -142,6 +142,7 @@ terminal:
   cwd: "."          # Gateway/cron working directory (CLI always uses launch dir)
   font_family: ""   # Desktop terminal font; e.g. "MesloLGS NF"
   timeout: 180      # Per-command timeout in seconds
+  memory_limit_mb: 0   # Per-command memory ceiling (MiB) for the local backend; 0 = unlimited (POSIX-only)
   home_mode: auto   # auto | real | profile — subprocess HOME policy
   env_passthrough: []  # Env var names to forward to sandboxed execution (terminal + execute_code)
   singularity_image: "docker://nikolaik/python-nodejs:python3.11-nodejs20"  # Container image for Singularity backend
@@ -173,6 +174,8 @@ The default. Commands run directly on your machine with no isolation. No special
 terminal:
   backend: local
 ```
+
+`terminal.memory_limit_mb` (default `0` = unlimited) puts a hard per-command memory ceiling on locally spawned command trees. When set, every `terminal` command runs under an `RLIMIT_AS` cap inherited by all of its child processes, so a runaway build or test run fails with an out-of-memory error inside the command instead of stalling the whole machine into swap. POSIX-only (Linux/macOS); ignored on Windows and on container/cloud backends, which have their own isolation.
 
 By default, local tool subprocesses keep your real OS-user `HOME`. This lets
 external CLIs such as `git`, `ssh`, `gh`, `az`, `npm`, Claude Code, and Codex

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -175,7 +175,7 @@ terminal:
   backend: local
 ```
 
-`terminal.memory_limit_mb` (default `0` = unlimited) puts a hard per-command memory ceiling on locally spawned command trees. When set, every `terminal` command runs under an `RLIMIT_AS` cap inherited by all of its child processes, so a runaway build or test run fails with an out-of-memory error inside the command instead of stalling the whole machine into swap. POSIX-only (Linux/macOS); ignored on Windows and on container/cloud backends, which have their own isolation.
+`terminal.memory_limit_mb` (default `0` = unlimited) puts a hard per-command memory ceiling on locally spawned command trees. When set, every `terminal` command runs under an `RLIMIT_AS` cap (applied via a `ulimit -v` prelude in the spawned shell) inherited by all of its child processes, so a runaway build or test run fails with an out-of-memory error inside the command instead of stalling the whole machine into swap. POSIX-only (Linux/macOS); ignored on Windows and on container/cloud backends, which have their own isolation.
 
 By default, local tool subprocesses keep your real OS-user `HOME`. This lets
 external CLIs such as `git`, `ssh`, `gh`, `az`, `npm`, Claude Code, and Codex


### PR DESCRIPTION
## Summary

Local terminal commands can now run under a hard per-command memory ceiling (`terminal.memory_limit_mb`), so a runaway build or test process fails with an OOM inside the command instead of stalling the whole machine into swap.

Port of Claude Code v2.1.233's `CLAUDE_CODE_TOOL_MEMORY_LIMIT` ("opt-in memory cgroup support for Bash tool commands on Linux so a runaway build can't stall the session").

**Source:** https://github.com/anthropics/claude-code/releases/tag/v2.1.233

## How our implementation differs

| | Claude Code | Hermes |
|---|---|---|
| Configuration | `CLAUDE_CODE_TOOL_MEMORY_LIMIT` env var | `terminal.memory_limit_mb` in config.yaml (`.env` is for secrets only) |
| Mechanism | Linux memory cgroups | `RLIMIT_AS` via `preexec_fn` — no cgroup delegation/root needed, works on macOS too |
| Scope | Bash tool | Local terminal backend command trees (limit inherited by every descendant) |
| Default | off | off (`0` = unlimited) |

Container/cloud backends (docker/modal/daytona/...) are deliberately untouched — they have their own isolation. Fails open: any config read problem or `setrlimit` failure runs the command unlimited rather than breaking terminal execution.

## Changes

- `hermes_cli/config_defaults.py`: new `terminal.memory_limit_mb` key (default `0`; deep-merge means no `_config_version` bump needed)
- `tools/environments/local.py`: `_read_terminal_memory_limit_bytes()` + `_make_memory_limit_preexec()`; wired into `_run_bash`'s Popen via `preexec_fn` (POSIX only)
- `tests/tools/test_local_env_memory_limit.py`: 12 tests incl. real enforcement E2E
- `website/docs/user-guide/configuration.md`: key documented in the terminal block + local backend section

## Validation

| Check | Result |
|---|---|
| `tests/tools/test_local_env_memory_limit.py` | 12 passed |
| E2E: 800 MiB alloc under 512 MiB cap | killed, non-zero exit, no output |
| E2E: 8 MiB alloc under 512 MiB cap | succeeds |
| E2E: cap disabled (`0`) | 64 MiB alloc succeeds |
| Sibling suites (`test_local_env_cwd_recovery`, `test_local_shell_init`, `test_local_env_blocklist`) | 59 passed, 1 skipped |

## Infographic

![Terminal memory ceiling](https://files.catbox.moe/z1t2wj.png)
