### PR TITLE
fix(desktop-update): wait for rebuilt executable before relaunch

### DIFF
--- a/scripts/desktop-update/windows.ps1
+++ b/scripts/desktop-update/windows.ps1
@@ -447,7 +447,19 @@ function Start-DesktopRelaunch {
     # the pid exists, or the fallback spawn returned a live process). The
     # finally block downgrades the on-screen/on-disk outcome when it didn't
     # — the sibling truth contract to posix.sh's launch acceptance.
-    if (-not ($RelaunchExe -and (Test-Path -LiteralPath $RelaunchExe))) { return $false }
+    if (-not $RelaunchExe) { return $false }
+    # electron-builder replaces win-unpacked in place. After a successful
+    # update it can remove the old Hermes.exe before writing the replacement,
+    # so a one-shot existence check races the rebuild and strands the user.
+    $relaunchDeadline = (Get-Date).AddSeconds(120)
+    while (-not (Test-Path -LiteralPath $RelaunchExe)) {
+        if ((Get-Date) -ge $relaunchDeadline) {
+            Write-HandoffLog "WARNING: desktop relaunch executable did not reappear within 120s: $RelaunchExe"
+            return $false
+        }
+        Start-Sleep -Milliseconds 500
+        if ($script:Ui) { [System.Windows.Forms.Application]::DoEvents() }
+    }
     Write-HandoffLog "relaunching desktop: $RelaunchExe"
     # DO NOT spawn Hermes.exe as our child: Electron/Chromium calls
     # AttachConsole(ATTACH_PARENT_PROCESS) at boot, so a Desktop launched

--- a/tests/test_desktop_update_windows_python_handoff.py
+++ b/tests/test_desktop_update_windows_python_handoff.py
@@ -87,3 +87,21 @@ def test_update_no_longer_invokes_the_hermes_exe_shim() -> None:
         "exact self-lock this fix removes -- route it through $pythonExe "
         "instead."
     )
+
+
+def test_desktop_relaunch_waits_for_an_in_place_rebuild() -> None:
+    source = _read()
+    relaunch = re.search(
+        r"function Start-DesktopRelaunch \{(?P<body>.*?)\n\}\n\nfunction Invoke-HermesStep",
+        source,
+        re.DOTALL,
+    )
+    assert relaunch, "Expected Start-DesktopRelaunch in the Windows hand-off script."
+
+    body = relaunch.group("body")
+    assert "if (-not $RelaunchExe) { return $false }" in body
+    assert "$relaunchDeadline = (Get-Date).AddSeconds(120)" in body
+    assert "while (-not (Test-Path -LiteralPath $RelaunchExe))" in body
+    assert "if ((Get-Date) -ge $relaunchDeadline)" in body
+    assert "Start-Sleep -Milliseconds 500" in body
+    assert "[System.Windows.Forms.Application]::DoEvents()" in body


### PR DESCRIPTION
## What does this PR do?

Fixes the Windows Desktop restart race after an in-place electron-builder rebuild. The detached updater now waits up to 120 seconds for the rebuilt `Hermes.exe` to reappear, keeps the update UI responsive while it waits, and preserves the existing manual-recovery outcome if the executable never returns.

## Related Issue

Refs #86223

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `scripts/desktop-update/windows.ps1`: wait for the packaged Desktop executable during the short removal-and-rebuild window before attempting relaunch.
- `tests/test_desktop_update_windows_python_handoff.py`: lock the bounded-wait, timeout, and responsive-UI hand-off contract with a source-level regression test.

## How to Test

1. Run `/opt/homebrew/bin/timeout -k 30 480 "$VIRTUAL_ENV/bin/pytest" tests/test_desktop_update_windows_python_handoff.py -q --timeout=60`.
2. On Windows, start a Desktop self-update that rebuilds `apps/desktop/release/win-unpacked`; verify the updater relaunches Hermes when `Hermes.exe` returns during the 120-second window.
3. Run the full test command: `/opt/homebrew/bin/timeout -k 30 480 "$VIRTUAL_ENV/bin/pytest" tests/ -q -x --timeout=60`. In this local environment it stopped during collection at the unrelated `tests/gateway/test_teams.py` requirement check before reaching this module; the focused test passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.6 (Darwin arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

<!-- autocontrib:worker-id=issue-new-7745045c kind=pr-open -->