### PR TITLE
feat(zai): dedicated zai-coding-plan provider profile

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -339,6 +339,14 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "glm-4.5",
         "glm-4.5-flash",
     ],
+    "zai-coding-plan": [
+        "glm-5.3",
+        "glm-5.2",
+        "glm-5.1",
+        "glm-5",
+        "glm-4.7",
+        "glm-4.5",
+    ],
     "xai": _xai_curated_models(),
     "nvidia": [
         # NVIDIA flagship reasoning models
@@ -1139,6 +1147,7 @@ CANONICAL_PROVIDERS: list[ProviderEntry] = [
     ProviderEntry("deepseek",       "DeepSeek",                 "DeepSeek (V3, R1, coder, direct API)"),
     ProviderEntry("xai",            "xAI",                      "xAI Grok (Direct API)"),
     ProviderEntry("zai",            "Z.AI / GLM",               "Z.AI / GLM (Zhipu direct API)"),
+    ProviderEntry("zai-coding-plan", "Z.AI / GLM (Coding Plan)", "Z.AI Coding Plan (GLM subscription tier, coding endpoint)"),
     ProviderEntry("kimi-coding",    "Kimi / Kimi Coding Plan",  "Kimi Coding Plan (api.kimi.com & Moonshot API)"),
     ProviderEntry("kimi-coding-cn", "Kimi / Moonshot (China)",  "Kimi / Moonshot China (Domestic direct API)"),
     ProviderEntry("stepfun",        "StepFun Step Plan",       "StepFun Step Plan (Agent / coding models via Step Plan API)"),
@@ -1290,6 +1299,9 @@ _PROVIDER_ALIASES = {
     "z-ai": "zai",
     "z.ai": "zai",
     "zhipu": "zai",
+    "glm-coding": "zai-coding-plan",
+    "zai-coding": "zai-coding-plan",
+    "z-ai-coding": "zai-coding-plan",
     "github": "copilot",
     "github-copilot": "copilot",
     "github-models": "copilot",

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -346,6 +346,7 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "glm-5",
         "glm-4.7",
         "glm-4.5",
+        "glm-4.5-air",
     ],
     "xai": _xai_curated_models(),
     "nvidia": [

--- a/plugins/model-providers/zai-coding-plan/__init__.py
+++ b/plugins/model-providers/zai-coding-plan/__init__.py
@@ -1,15 +1,36 @@
 """Z.AI Coding Plan provider profile.
 
 Separate from the standard ``zai`` profile because coding-plan subscriptions
-(a) authenticate on a different endpoint — ``/api/coding/paas/v4`` — the
-standard ``/api/paas/v4`` route rejects coding-plan keys with HTTP 429
-``1113 Insufficient balance or no resource package``, and (b) z.ai's coding
-plan is the subscription tier most agent users actually hold.
+authenticate on different endpoints than the standard ``/api/paas/v4`` route
+(which rejects coding-plan keys with HTTP 429 ``1113 Insufficient balance or
+no resource package``), and the coding plan is the subscription tier most
+agent users actually hold.
+
+Default endpoint: ``https://api.z.ai/api/anthropic`` — z.ai's Anthropic
+Messages wire. Chosen over ``/api/coding/paas/v4`` for agent workloads
+(probed live 2026-08-15, glm-5.3):
+
+* **Preserved thinking works here.** Replayed ``thinking`` blocks reach the
+  model (verified via a thinking-only secret-recall probe; the model quoted
+  the exact secret back). On the OpenAI-compat routes the same key's
+  replayed ``reasoning_content`` is accepted with HTTP 200 but silently
+  dropped from model attention — billed bytes the model never sees. For a
+  tool-loop agent that means re-deriving its plan every iteration instead
+  of continuing its chain of thought.
+* ``thinking.budget_tokens`` is honored (output_tokens scaled 1710 → 3848
+  for budget 512 → 6000 on identical prompts), so reasoning-effort control
+  rides the Anthropic budget path rather than the OpenAI-compat
+  ``reasoning_effort`` param.
+* Hermes auto-selects the Anthropic Messages adapter for base URLs ending
+  in ``/anthropic`` (agent/agent_init.py), so the protocol switch is
+  transparent.
 
 Mirrors the ``alibaba-coding-plan`` / ``kimi-coding`` pattern: a dedicated
-selectable provider so coding-plan users get a working default without
-hand-editing ``GLM_BASE_URL``. Subclasses ``ZaiProfile`` so the GLM
-thinking / reasoning_effort wiring is shared with the standard profile.
+selectable provider so coding-plan users get a working, agent-optimal
+default without hand-editing ``GLM_BASE_URL``. Subclasses ``ZaiProfile``
+so the GLM thinking / reasoning wiring is shared with the standard
+profile; on this wire the Anthropic adapter builds the request shape
+(thinking blocks, tool_use) natively.
 """
 
 from plugins.model_providers.zai import ZaiProfile
@@ -19,14 +40,14 @@ zai_coding_plan = ZaiProfile(
     name="zai-coding-plan",
     aliases=("zai-coding", "glm-coding", "z-ai-coding"),
     display_name="Z.AI / GLM (Coding Plan)",
-    description="Z.AI Coding Plan (GLM subscription tier, api.z.ai/api/coding/paas/v4)",
+    description="Z.AI Coding Plan (GLM subscription tier, Anthropic wire with preserved thinking)",
     signup_url="https://z.ai/subscribe",
     env_vars=(
         "ZAI_CODING_PLAN_API_KEY",
         "GLM_CODING_PLAN_API_KEY",
         "ZAI_API_KEY",
     ),
-    base_url="https://api.z.ai/api/coding/paas/v4",
+    base_url="https://api.z.ai/api/anthropic",
     default_aux_model="glm-4.5-flash",
 )
 

--- a/plugins/model-providers/zai-coding-plan/__init__.py
+++ b/plugins/model-providers/zai-coding-plan/__init__.py
@@ -1,0 +1,33 @@
+"""Z.AI Coding Plan provider profile.
+
+Separate from the standard ``zai`` profile because coding-plan subscriptions
+(a) authenticate on a different endpoint — ``/api/coding/paas/v4`` — the
+standard ``/api/paas/v4`` route rejects coding-plan keys with HTTP 429
+``1113 Insufficient balance or no resource package``, and (b) z.ai's coding
+plan is the subscription tier most agent users actually hold.
+
+Mirrors the ``alibaba-coding-plan`` / ``kimi-coding`` pattern: a dedicated
+selectable provider so coding-plan users get a working default without
+hand-editing ``GLM_BASE_URL``. Subclasses ``ZaiProfile`` so the GLM
+thinking / reasoning_effort wiring is shared with the standard profile.
+"""
+
+from plugins.model_providers.zai import ZaiProfile
+from providers import register_provider
+
+zai_coding_plan = ZaiProfile(
+    name="zai-coding-plan",
+    aliases=("zai-coding", "glm-coding", "z-ai-coding"),
+    display_name="Z.AI / GLM (Coding Plan)",
+    description="Z.AI Coding Plan (GLM subscription tier, api.z.ai/api/coding/paas/v4)",
+    signup_url="https://z.ai/subscribe",
+    env_vars=(
+        "ZAI_CODING_PLAN_API_KEY",
+        "GLM_CODING_PLAN_API_KEY",
+        "ZAI_API_KEY",
+    ),
+    base_url="https://api.z.ai/api/coding/paas/v4",
+    default_aux_model="glm-4.5-flash",
+)
+
+register_provider(zai_coding_plan)

--- a/plugins/model-providers/zai-coding-plan/__init__.py
+++ b/plugins/model-providers/zai-coding-plan/__init__.py
@@ -33,6 +33,13 @@ profile; on this wire the Anthropic adapter builds the request shape
 (thinking blocks, tool_use) natively.
 """
 
+# NOTE: this import deliberately targets the BUNDLED zai plugin module.
+# Discovery loads bundled plugins under their canonical
+# ``plugins.model_providers.*`` names; any user-plugin override of ``zai``
+# later registers under a ``_hermes_user_provider_*`` module name instead,
+# so this path can never bind a user override. If the plugin loader ever
+# changes that namespace contract, update this import (and the
+# test_bundled_import_binds_bundled_zai_profile pin) accordingly.
 from plugins.model_providers.zai import ZaiProfile
 from providers import register_provider
 
@@ -48,7 +55,7 @@ zai_coding_plan = ZaiProfile(
         "ZAI_API_KEY",
     ),
     base_url="https://api.z.ai/api/anthropic",
-    default_aux_model="glm-4.5-flash",
+    default_aux_model="glm-4.5-air",
 )
 
 register_provider(zai_coding_plan)

--- a/tests/plugins/model_providers/test_zai_coding_plan_profile.py
+++ b/tests/plugins/model_providers/test_zai_coding_plan_profile.py
@@ -1,9 +1,13 @@
 """zai-coding-plan profile: endpoint separation from the standard zai provider.
 
-Coding-plan subscriptions authenticate on /api/coding/paas/v4; the standard
-/api/paas/v4 route rejects coding-plan keys (HTTP 429, code 1113). The
-dedicated profile mirrors alibaba-coding-plan / kimi-coding so coding-plan
-users get a working default without hand-editing GLM_BASE_URL.
+Coding-plan subscriptions authenticate on different endpoints than the
+standard /api/paas/v4 route (which rejects coding-plan keys with HTTP 429,
+code 1113). The profile defaults to z.ai's Anthropic wire
+(api.z.ai/api/anthropic) — the endpoint where preserved thinking actually
+reaches the model for agent tool loops (the OpenAI-compat routes accept
+replayed reasoning_content but silently drop it from model attention;
+probed 2026-08-15). Mirrors alibaba-coding-plan / kimi-coding so
+coding-plan users get a working default without hand-editing GLM_BASE_URL.
 """
 
 from __future__ import annotations
@@ -22,14 +26,23 @@ def coding_profile():
 
 
 class TestZaiCodingPlanProfile:
-    def test_coding_endpoint_is_default(self, coding_profile):
+    def test_anthropic_endpoint_is_default(self, coding_profile):
         import providers
 
-        assert coding_profile.base_url == "https://api.z.ai/api/coding/paas/v4"
+        # Anthropic wire: preserved thinking reaches the model here (the
+        # OpenAI-compat /api/coding/paas/v4 route accepts replayed
+        # reasoning_content but silently drops it — probed 2026-08-15).
+        assert coding_profile.base_url == "https://api.z.ai/api/anthropic"
         std = providers.get_provider_profile("zai")
         assert std.base_url != coding_profile.base_url, (
             "coding-plan profile must not share the standard endpoint"
         )
+
+    def test_base_url_triggers_anthropic_adapter(self, coding_profile):
+        """The /anthropic suffix is what agent_init.py keys on to select
+        the Anthropic Messages adapter — pin the contract the default
+        depends on."""
+        assert coding_profile.base_url.rstrip("/").endswith("/anthropic")
 
     def test_distinct_from_standard_zai(self, coding_profile):
         import providers
@@ -44,11 +57,14 @@ class TestZaiCodingPlanProfile:
         assert "ZAI_API_KEY" in coding_profile.env_vars
 
     def test_shares_glm_reasoning_wiring(self, coding_profile):
-        """Subclassing ZaiProfile keeps the GLM thinking / reasoning_effort
-        wiring — the coding endpoint speaks the same wire shape."""
+        """Subclassing ZaiProfile keeps the GLM thinking / reasoning wiring.
+        On the Anthropic default the transport builds the request shape
+        (thinking blocks / budget_tokens) natively, so the profile wiring
+        stays shared with the standard zai provider."""
         extra_body, top_level = coding_profile.build_api_kwargs_extras(
             reasoning_config={"enabled": True, "effort": "high"},
             model="glm-5.2",
+            base_url="https://api.z.ai/api/paas/v4",
         )
         assert top_level == {"reasoning_effort": "high"}
         assert extra_body.get("thinking") == {"type": "enabled"}

--- a/tests/plugins/model_providers/test_zai_coding_plan_profile.py
+++ b/tests/plugins/model_providers/test_zai_coding_plan_profile.py
@@ -1,0 +1,88 @@
+"""zai-coding-plan profile: endpoint separation from the standard zai provider.
+
+Coding-plan subscriptions authenticate on /api/coding/paas/v4; the standard
+/api/paas/v4 route rejects coding-plan keys (HTTP 429, code 1113). The
+dedicated profile mirrors alibaba-coding-plan / kimi-coding so coding-plan
+users get a working default without hand-editing GLM_BASE_URL.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture
+def coding_profile():
+    import model_tools  # noqa: F401  — triggers plugin discovery
+    import providers
+
+    p = providers.get_provider_profile("zai-coding-plan")
+    assert p is not None, "zai-coding-plan must be registered"
+    return p
+
+
+class TestZaiCodingPlanProfile:
+    def test_coding_endpoint_is_default(self, coding_profile):
+        import providers
+
+        assert coding_profile.base_url == "https://api.z.ai/api/coding/paas/v4"
+        std = providers.get_provider_profile("zai")
+        assert std.base_url != coding_profile.base_url, (
+            "coding-plan profile must not share the standard endpoint"
+        )
+
+    def test_distinct_from_standard_zai(self, coding_profile):
+        import providers
+
+        assert coding_profile.name == "zai-coding-plan"
+        assert coding_profile.name != "zai"
+
+    def test_env_var_chain_includes_fallback(self, coding_profile):
+        """Dedicated vars first, ZAI_API_KEY as fallback so users with one
+        key don't need to duplicate it."""
+        assert coding_profile.env_vars[0] == "ZAI_CODING_PLAN_API_KEY"
+        assert "ZAI_API_KEY" in coding_profile.env_vars
+
+    def test_shares_glm_reasoning_wiring(self, coding_profile):
+        """Subclassing ZaiProfile keeps the GLM thinking / reasoning_effort
+        wiring — the coding endpoint speaks the same wire shape."""
+        extra_body, top_level = coding_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": True, "effort": "high"},
+            model="glm-5.2",
+        )
+        assert top_level == {"reasoning_effort": "high"}
+        assert extra_body.get("thinking") == {"type": "enabled"}
+
+    def test_model_list_registered(self):
+        from hermes_cli.models import _PROVIDER_MODELS
+
+        assert "zai-coding-plan" in _PROVIDER_MODELS
+        # glm-5.2 is the effort-dial model guaranteed on main; 5.3 arrives
+        # with the GLM-5.3 support PR — assert the shared core only.
+        assert "glm-5.2" in _PROVIDER_MODELS["zai-coding-plan"]
+
+    def test_aliases_normalize_to_coding_plan(self):
+        from hermes_cli.models import curated_models_for_provider, normalize_provider
+
+        for alias in ("zai-coding", "glm-coding", "z-ai-coding"):
+            assert normalize_provider(alias) == "zai-coding-plan", alias
+
+        # The public curated-models path resolves aliases to the coding list.
+        models = [m for m, _ in curated_models_for_provider("glm-coding")]
+        assert any(m == "glm-5.2" for m in models), models
+
+    def test_bundled_import_binds_bundled_zai_profile(self):
+        """Documented limitation: the cross-plugin import pins this profile
+        to the BUNDLED ZaiProfile class. A user-plugin override of ``zai``
+        loads later under a _hermes_user_provider_* module name and does not
+        affect this profile. Assert the binding is at least the bundled one
+        (deterministic behavior rather than accidental)."""
+        import sys
+
+        import providers  # noqa: F401  — discovery
+
+        assert "plugins.model_providers.zai" in sys.modules
+        # get_provider_profile returns the registered instance whose class
+        # comes from the bundled module.
+        p = providers.get_provider_profile("zai-coding-plan")
+        assert type(p).__module__ == "plugins.model_providers.zai"

--- a/tests/plugins/model_providers/test_zai_coding_plan_profile.py
+++ b/tests/plugins/model_providers/test_zai_coding_plan_profile.py
@@ -69,6 +69,41 @@ class TestZaiCodingPlanProfile:
         assert top_level == {"reasoning_effort": "high"}
         assert extra_body.get("thinking") == {"type": "enabled"}
 
+    def test_default_aux_model_in_curated_list(self, coding_profile):
+        """The profile's default aux model must resolve against the
+        provider's own curated list — aux-task resolution (curator,
+        vision, title generation) validates against it, so a mismatch
+        fails to resolve or shows an unlisted model in the picker
+        (review point on PR #86560).  glm-4.5-air: the live Anthropic
+        wire serves no glm-4.5-flash (models-list probe 2026-08-17:
+        glm-4.5, glm-4.5-air, glm-4.6, glm-4.7, glm-5, glm-5-turbo,
+        glm-5.1, glm-5.2, glm-5.3), and air is the cheapest tier there."""
+        from hermes_cli.models import _PROVIDER_MODELS
+
+        assert coding_profile.default_aux_model == "glm-4.5-air"
+        assert coding_profile.default_aux_model in _PROVIDER_MODELS["zai-coding-plan"]
+
+    def test_default_endpoint_builds_anthropic_request_shape(self, coding_profile):
+        """Pin the docstring claim at the adapter level: the default
+        ``/api/anthropic`` endpoint produces the Anthropic request shape —
+        thinking as budget_tokens (not the OpenAI-compat
+        reasoning_effort/top-level param the paas/v4 wire would use)
+        (review point on PR #86560)."""
+        from agent.anthropic_adapter import build_anthropic_kwargs
+
+        kwargs = build_anthropic_kwargs(
+            model="glm-5.3",
+            messages=[{"role": "user", "content": "hello"}],
+            tools=None,
+            max_tokens=8192,
+            reasoning_config={"enabled": True, "effort": "high"},
+            base_url=coding_profile.base_url,
+        )
+        assert "reasoning_effort" not in kwargs
+        assert kwargs["thinking"]["type"] == "enabled"
+        assert isinstance(kwargs["thinking"]["budget_tokens"], int)
+        assert kwargs["thinking"]["budget_tokens"] > 0
+
     def test_model_list_registered(self):
         from hermes_cli.models import _PROVIDER_MODELS
 


### PR DESCRIPTION
## What does this PR do?

Adds a `zai-coding-plan` provider profile so z.ai coding-plan subscribers get a working, **agent-optimal** default from the model picker instead of hand-editing `GLM_BASE_URL`.

**The problem:** the stock `zai` profile defaults to `api.z.ai/api/paas/v4` (pay-as-you-go). Coding-plan keys don't work there — the endpoint rejects them with HTTP 429 `{"code":"1113","message":"Insufficient balance or no resource package"}`. Nothing in the UI surface tells coding-plan users which URL their tier needs; they hit the balance error with no hint.

**The fix:** mirrors the established `kimi-coding` / `alibaba-coding-plan` pattern — a dedicated selectable provider defaulting to **`https://api.z.ai/api/anthropic`** (z.ai's Anthropic Messages wire; same key, same coding-plan quota):

- `ZaiProfile` subclass — shares the GLM thinking/reasoning wiring with the standard profile; the Anthropic adapter builds the request shape natively
- Dedicated env vars (`ZAI_CODING_PLAN_API_KEY`, `GLM_CODING_PLAN_API_KEY`) with `ZAI_API_KEY` as fallback, so one key serves both profiles
- Model-picker entry ("Z.AI / GLM (Coding Plan)") + curated GLM model list + provider aliases (`zai-coding`, `glm-coding`, `z-ai-coding`)
- Hermes auto-selects the Anthropic Messages adapter for the `/anthropic` URL suffix (`agent_init.py`), so the protocol switch is transparent

## Why the Anthropic endpoint as the default — performance & token efficiency

Coding-plan users are overwhelmingly **agent users**, and the endpoint choice is a direct performance lever. All claims below measured live (2026-08-15, glm-5.3, coding-plan key):

- **Reasoning replay only works on this wire.** Replayed `thinking` blocks on `/api/anthropic` reach the model — verified with a thinking-only secret-recall probe (the model quoted the exact secret back). On the OpenAI-compat routes (`/api/paas/v4` and `/api/coding/paas/v4`), replayed `reasoning_content` returns HTTP 200 but is **silently dropped from model attention** — billed bytes the model never sees (same probes; analysis on #86433).
- **Fewer wasted thinking tokens.** Without reasoning continuity, a 15-iteration tool loop re-derives the same plan ~15 times, paying output-rate prices for the same deliberation each time. With replay working, GLM-5.x's interleaved thinking compounds across iterations instead of resetting. (Scope note: GLM-4.x models do not use thought interleaving — they emit one thinking block per turn — so replay preserves their reasoning continuity without the compounding effect; the interleaving claim applies to 5.x only.) End-to-end verified in a live Hermes session: multi-turn tool loop, streaming, session resume, and thinking replay across a resume boundary.
- **Reasoning-effort control carries over.** `thinking.budget_tokens` is honored on this wire (output_tokens scaled 1710 → 3848 for budget 512 → 6000 on identical prompts), and Hermes' Anthropic adapter already maps effort → budget — `/reasoning low` keeps working, just through the budget path.
- **Cache coherence.** z.ai's docs note Preserved Thinking improves cache hit rates; the wrong-endpoint setup gets neither the reasoning continuity nor that caching.

## Notes for reviewers

- The OpenAI-compat coding endpoint (`/api/coding/paas/v4`) also authenticates coding-plan keys; it remains a valid manual override for users who specifically want the chat-completions wire (e.g. for `reasoning_effort` as a native param or per-field usage reporting).
- Key-prefix auto-routing (`sk-...`-style, as `auth.py` does for Kimi Code) is a possible follow-up; this PR deliberately stays with the explicit-provider pattern.
