### PR TITLE
fix(terminal-tool): classify timeout exceptions as non-retriable, return 124

### DIFF
--- a/tests/tools/test_terminal_tool.py
+++ b/tests/tools/test_terminal_tool.py
@@ -124,10 +124,12 @@ def test_is_timeout_error_recognizes_subprocess_timeout_expired():
 def test_is_timeout_error_recognizes_timeout_messages():
     assert terminal_tool._is_timeout_error(RuntimeError("connection timeout")) is True
     assert terminal_tool._is_timeout_error(RuntimeError("request timed out")) is True
+    assert terminal_tool._is_timeout_error(RuntimeError("timeout: 5 seconds")) is True
 
 
 def test_is_timeout_error_does_not_flag_unrelated_errors():
     assert terminal_tool._is_timeout_error(RuntimeError("something went wrong")) is False
+    assert terminal_tool._is_timeout_error(RuntimeError("timeout must be positive")) is False
 
 
 class _FakeTimeoutEnv:
@@ -163,3 +165,36 @@ def test_terminal_tool_subprocess_timeout_expired_returns_124_without_retry(monk
     result = _run_terminal_with_timeout_exc(monkeypatch, exc)
     assert result["exit_code"] == 124
     assert "timed out after 5 seconds" in result["error"].lower()
+
+
+class _FakeTransientEnv:
+    def __init__(self):
+        self.calls = 0
+        self.cwd = None
+
+    def execute(self, *args, **kwargs):
+        self.calls += 1
+        if self.calls <= 3:
+            raise RuntimeError("connection reset")
+        return {"output": "ok", "returncode": 0}
+
+
+def test_terminal_tool_retries_non_timeout_transient_error(monkeypatch):
+    terminal_tool._active_environments.clear()
+    fake_env = _FakeTransientEnv()
+    monkeypatch.setenv("TERMINAL_ENV", "local")
+    monkeypatch.setenv("TERMINAL_CWD", "/tmp")
+    monkeypatch.setattr(terminal_tool.time, "sleep", lambda _x: None)
+    monkeypatch.setattr(
+        terminal_tool,
+        "_acquire_env",
+        lambda plan, task_id: fake_env,
+    )
+
+    result = json.loads(
+        terminal_tool.terminal_tool("printf ok", force=True, timeout=5)
+    )
+
+    assert result["output"] == "ok"
+    assert result["exit_code"] == 0
+    assert fake_env.calls == 4

--- a/tests/tools/test_terminal_tool.py
+++ b/tests/tools/test_terminal_tool.py
@@ -1,4 +1,7 @@
-"""Regression tests for sudo detection and sudo password handling."""
+"""Regression tests for the terminal tool (sudo handling, workdir validation, and timeout classification)."""
+
+import json
+import subprocess
 
 import tools.terminal_tool as terminal_tool
 import tools.terminal_tool_sudo as terminal_tool_sudo
@@ -107,3 +110,56 @@ def test_validate_workdir_still_blocks_metachars_in_unicode_paths():
 def test_count_real_sudo_invocations_ignores_mentions(monkeypatch):
     assert terminal_tool_sudo._count_real_sudo_invocations("grep sudo README.md") == 0
     assert terminal_tool_sudo._count_real_sudo_invocations("sudo a; sudo b") == 2
+
+
+def test_is_timeout_error_recognizes_builtin_timeout():
+    assert terminal_tool._is_timeout_error(TimeoutError()) is True
+
+
+def test_is_timeout_error_recognizes_subprocess_timeout_expired():
+    exc = subprocess.TimeoutExpired("sleep 10", timeout=5)
+    assert terminal_tool._is_timeout_error(exc) is True
+
+
+def test_is_timeout_error_recognizes_timeout_messages():
+    assert terminal_tool._is_timeout_error(RuntimeError("connection timeout")) is True
+    assert terminal_tool._is_timeout_error(RuntimeError("request timed out")) is True
+
+
+def test_is_timeout_error_does_not_flag_unrelated_errors():
+    assert terminal_tool._is_timeout_error(RuntimeError("something went wrong")) is False
+
+
+class _FakeTimeoutEnv:
+    def __init__(self, exc):
+        self.exc = exc
+        self.cwd = None
+
+    def execute(self, *args, **kwargs):
+        raise self.exc
+
+
+def _run_terminal_with_timeout_exc(monkeypatch, exc):
+    terminal_tool._active_environments.clear()
+    monkeypatch.setenv("TERMINAL_ENV", "local")
+    monkeypatch.setenv("TERMINAL_CWD", "/tmp")
+    monkeypatch.setattr(terminal_tool.time, "sleep", lambda _x: None)
+    monkeypatch.setattr(
+        terminal_tool,
+        "_acquire_env",
+        lambda plan, task_id: _FakeTimeoutEnv(exc),
+    )
+    return json.loads(terminal_tool.terminal_tool("sleep 10", force=True, timeout=5))
+
+
+def test_terminal_tool_timeout_error_returns_124_without_retry(monkeypatch):
+    result = _run_terminal_with_timeout_exc(monkeypatch, TimeoutError())
+    assert result["exit_code"] == 124
+    assert "timed out after 5 seconds" in result["error"].lower()
+
+
+def test_terminal_tool_subprocess_timeout_expired_returns_124_without_retry(monkeypatch):
+    exc = subprocess.TimeoutExpired("sleep 10", timeout=5)
+    result = _run_terminal_with_timeout_exc(monkeypatch, exc)
+    assert result["exit_code"] == 124
+    assert "timed out after 5 seconds" in result["error"].lower()

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -38,6 +38,20 @@ def _redact_terminal_error_text(value: Any) -> str:
     return redact_sensitive_text("" if value is None else str(value), force=True)
 
 
+def _is_timeout_error(exc: BaseException) -> bool:
+    """Return True if *exc* is a timeout from any terminal backend.
+
+    Python's timeout exception texts vary across backends:
+    - concurrent.futures.TimeoutError / asyncio.TimeoutError / builtins.TimeoutError: str() is empty
+    - subprocess.TimeoutExpired: "Command ... timed out after N seconds"
+    Some third-party backends include "timeout" or "timed out" in their message.
+    """
+    if isinstance(exc, (TimeoutError, subprocess.TimeoutExpired)):
+        return True
+    error_str = str(exc).lower()
+    return "timed out" in error_str or "timeout" in error_str
+
+
 from tools.registry import tool_error
 from tools.terminal_tool_lifecycle import (
     _check_disk_usage_warning, _cleanup_inactive_envs, _create_configured_env,
@@ -1048,7 +1062,7 @@ def _run_foreground(
             )
             break
         except Exception as e:
-            if "timeout" in str(e).lower():
+            if _is_timeout_error(e):
                 return _error_json(f"Command timed out after {effective_timeout} seconds", exit_code=124)
             # Retry on transient errors
             if retry_count < max_retries:

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -46,10 +46,21 @@ def _is_timeout_error(exc: BaseException) -> bool:
     - subprocess.TimeoutExpired: "Command ... timed out after N seconds"
     Some third-party backends include "timeout" or "timed out" in their message.
     """
+    # Check the exception type first: built-in, asyncio, and concurrent.futures
+    # timeout exceptions commonly stringify to an empty message.
     if isinstance(exc, (TimeoutError, subprocess.TimeoutExpired)):
         return True
     error_str = str(exc).lower()
-    return "timed out" in error_str or "timeout" in error_str
+    return bool(
+        re.search(
+            r"\btimed out\b|"
+            r"\b(?:connection|command|execution|operation|process|read|request|"
+            r"rpc|socket|ssh|sandbox|session|subprocess|wait)\s+timeout\b|"
+            r"\btimeout\s+(?:occurred|expired|while|during|after|waiting)\b|"
+            r"\btimeout\s*[:=]\s*\d",
+            error_str,
+        )
+    )
 
 
 from tools.registry import tool_error


### PR DESCRIPTION
## What does this PR do?

When a terminal command times out, the timeout exception was treated as a retriable error. This PR:

1. Adds `_is_timeout_error()` to classify `TimeoutError`, `subprocess.TimeoutExpired`, and message-based timeout detection
2. `_run_foreground()` uses `_is_timeout_error(e)` instead of string matching
3. Timeout exceptions return exit code 124 (standard timeout code) and are classified as non-retriable
4. Tightens the regex in the second commit to avoid false positives

## Related Issue

Fixes #86481

## Type of Change

- [x] 🐛 Bug fix

## Changes Made

- `tools/terminal_tool.py`: `_is_timeout_error()` function, timeout classification in `_run_foreground()`.
- `tests/tools/test_terminal_tool.py`: Unit and integration tests for timeout behavior.

## How to Test

1. `scripts/run_tests.sh tests/tools/test_terminal_tool.py` — terminal tool tests pass.
2. Full project checker passes.

## Checklist

- [x] Code follows the project's style and conventions
- [x] Self-review completed
- [x] Tests added/updated and passing