### PR TITLE
fix(agent): escalate repeated stream-drop stalls to the fallback chain

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -3438,6 +3438,68 @@ def run_conversation(
                                 f"(may re-hit filter)...",
                                 force=True,
                             )
+                        # ── Repeated stream-drop stall → fallback ──
+                        # A partial-stream stub arriving AGAIN after a
+                        # continuation retry means the primary's stream path
+                        # is unhealthy (provider/edge outage), not a one-off
+                        # network blip.  Burning the remaining continuation
+                        # retries against the same provider replays the
+                        # failure at full context cost and stitches N
+                        # restarted partials into one garbled reply (the
+                        # model re-answers from scratch each pass, so the
+                        # user sees the same sentence repeated 4-5x followed
+                        # by the truncation notice).  Same economics as the
+                        # content-filter escalation above — but keep ONE
+                        # retry on the primary first: a single retry rides
+                        # the provider-side prompt cache and absorbs the
+                        # routine transient blip, while failing over
+                        # immediately would pay a guaranteed cache-cold
+                        # marshal on every hiccup.
+                        _is_repeat_stream_stall = (
+                            getattr(response, "id", "") == PARTIAL_STREAM_STUB_ID
+                            and length_continue_retries >= 1
+                        )
+                        if (
+                            _is_repeat_stream_stall
+                            and agent._fallback_index < len(agent._fallback_chain)
+                        ):
+                            agent._vprint(
+                                f"{agent.log_prefix}🔌 Stream dropped again after a "
+                                f"continuation retry — activating fallback provider...",
+                                force=True,
+                            )
+                            agent._emit_status(
+                                "Stream kept dropping; switching to fallback..."
+                            )
+                            if agent._try_activate_fallback():
+                                # Roll partials appended by the prior
+                                # continuation pass back to the last clean
+                                # turn so the fallback provider gets a
+                                # coherent continuation point (mirrors the
+                                # content-filter escalation above).
+                                if truncated_response_parts:
+                                    messages = agent._get_messages_up_to_last_assistant(messages)
+                                # Unmark survivors: their text left the stitched partial.
+                                for _frag in messages:
+                                    if isinstance(_frag, dict):
+                                        _frag.pop("_length_continuation_fragment", None)
+                                        _frag.pop("_length_continuation_nudge", None)
+                                agent._session_messages = messages
+                                length_continue_retries = 0
+                                truncated_response_parts = []
+                                retry_count = 0
+                                compression_attempts = 0
+                                _retry.primary_recovery_attempted = False
+                                _retry.restart_with_rebuilt_messages = True
+                                break
+                            # Chain exhausted/unavailable — fall through to
+                            # the normal continuation (best-effort, may loop).
+                            agent._vprint(
+                                f"{agent.log_prefix}⚠️  No fallback provider "
+                                f"available — continuing with same provider "
+                                f"(stream may keep dropping)...",
+                                force=True,
+                            )
                         if assistant_message is not None and not _trunc_has_tool_calls:
                             length_continue_retries += 1
                             # An EMPTY partial-stream stub (stream dropped
@@ -3554,6 +3616,40 @@ def run_conversation(
                             _is_stub_stall = (
                                 getattr(response, "id", "") == PARTIAL_STREAM_STUB_ID
                             )
+                            # Same policy as the text path above: one retry
+                            # on the primary absorbs a transient blip; a
+                            # SECOND stub stall means the stream path is
+                            # down — escalate to the fallback chain instead
+                            # of burning the remaining retries against it.
+                            # (Broken responses are never appended in this
+                            # path, so no message rollback is needed.)
+                            if (
+                                _is_stub_stall
+                                and truncated_tool_call_retries >= 1
+                                and agent._fallback_index < len(agent._fallback_chain)
+                            ):
+                                agent._flush_status_buffer()
+                                agent._vprint(
+                                    f"{agent.log_prefix}🔌 Stream dropped mid "
+                                    f"tool-call again — activating fallback "
+                                    f"provider...",
+                                    force=True,
+                                )
+                                agent._emit_status(
+                                    "Stream kept dropping; switching to fallback..."
+                                )
+                                if agent._try_activate_fallback():
+                                    truncated_tool_call_retries = 0
+                                    retry_count = 0
+                                    _retry.primary_recovery_attempted = False
+                                    _retry.restart_with_rebuilt_messages = True
+                                    break
+                                agent._vprint(
+                                    f"{agent.log_prefix}⚠️  No fallback provider "
+                                    f"available — continuing with same provider "
+                                    f"(stream may keep dropping)...",
+                                    force=True,
+                                )
                             if truncated_tool_call_retries < 4:
                                 truncated_tool_call_retries += 1
                                 if _is_stub_stall:

--- a/tests/run_agent/test_partial_stream_finish_reason.py
+++ b/tests/run_agent/test_partial_stream_finish_reason.py
@@ -497,6 +497,193 @@ class TestContentFilterStallActivatesFallback:
 
 
 
+class TestRepeatedStreamDropActivatesFallback:
+    """A partial-stream stub that arrives AGAIN after one continuation retry
+    escalates to the fallback chain instead of burning the remaining retries
+    against the same broken provider.
+
+    During a provider/edge streaming outage every retry restarts the reply
+    from scratch and stalls again, so the old behavior stitched 4-5 identical
+    partials into one garbled response ("Didn't go through. Let me check...
+    Didn't go through. Let me check...") at full context cost per pass, and
+    the configured fallback chain was never consulted.  Policy: ONE retry on
+    the primary (rides the provider-side prompt cache, absorbs transient
+    blips), then fall back.
+    """
+
+    @staticmethod
+    def _text_stub(content="Let me check the API docs."):
+        from tests.run_agent.test_run_agent import _mock_assistant_msg
+        return SimpleNamespace(
+            id=PARTIAL_STREAM_STUB_ID,
+            model="test/model",
+            choices=[SimpleNamespace(
+                index=0,
+                message=_mock_assistant_msg(content=content),
+                finish_reason=FINISH_REASON_LENGTH,
+            )],
+            usage=None,
+        )
+
+    def test_second_stub_activates_fallback_after_one_retry(self, loop_agent):
+        from tests.run_agent.test_run_agent import _mock_assistant_msg, _mock_response
+
+        recovery = _mock_response(
+            content="Recovered on the fallback provider.", finish_reason="stop",
+        )
+        loop_agent.client.chat.completions.create.side_effect = [
+            self._text_stub(), self._text_stub(), recovery,
+        ]
+        loop_agent._fallback_chain = [
+            {"provider": "anthropic", "model": "claude-sonnet-4-6"},
+        ]
+        loop_agent._fallback_index = 0
+        fb_calls = {"n": 0}
+
+        def _fake_activate(reason=None):
+            fb_calls["n"] += 1
+            loop_agent._fallback_index = len(loop_agent._fallback_chain)
+            return True
+
+        with (
+            patch.object(loop_agent, "_persist_session"),
+            patch.object(loop_agent, "_save_trajectory"),
+            patch.object(loop_agent, "_cleanup_task_resources"),
+            patch.object(loop_agent, "_try_activate_fallback",
+                         side_effect=_fake_activate),
+        ):
+            result = loop_agent.run_conversation("draft the post")
+
+        assert fb_calls["n"] == 1, (
+            "A second consecutive stream-drop stub must activate fallback "
+            "exactly once — after ONE primary retry, not after exhausting "
+            "all continuation retries."
+        )
+        # primary + one continuation retry + fallback recovery
+        assert loop_agent.client.chat.completions.create.call_count == 3
+        assert result["completed"] is True
+        # The rollback must wipe the stitched partials: the reply is the
+        # fallback's clean answer, not "Let me check... Let me check...".
+        assert result["final_response"] == "Recovered on the fallback provider."
+
+    def test_first_stub_retries_primary_without_fallback(self, loop_agent):
+        """One stub is a routine blip: the primary gets its continuation
+        retry and the fallback chain is NOT consulted."""
+        from tests.run_agent.test_run_agent import _mock_assistant_msg, _mock_response
+
+        continuation = _mock_response(
+            content="and here is the rest.", finish_reason="stop",
+        )
+        loop_agent.client.chat.completions.create.side_effect = [
+            self._text_stub("The first half "), continuation,
+        ]
+        loop_agent._fallback_chain = [
+            {"provider": "anthropic", "model": "claude-sonnet-4-6"},
+        ]
+        loop_agent._fallback_index = 0
+        fb_calls = {"n": 0}
+
+        def _fake_activate(reason=None):
+            fb_calls["n"] += 1
+            return True
+
+        with (
+            patch.object(loop_agent, "_persist_session"),
+            patch.object(loop_agent, "_save_trajectory"),
+            patch.object(loop_agent, "_cleanup_task_resources"),
+            patch.object(loop_agent, "_try_activate_fallback",
+                         side_effect=_fake_activate),
+        ):
+            result = loop_agent.run_conversation("tell me something")
+
+        assert fb_calls["n"] == 0, (
+            "A single stream-drop stub must NOT fail over — the one primary "
+            "retry is kept to ride the provider-side prompt cache."
+        )
+        assert loop_agent.client.chat.completions.create.call_count == 2
+        assert "first half" in result["final_response"]
+        assert "rest" in result["final_response"]
+
+    def test_repeat_stub_without_chain_keeps_giveup_behavior(self, loop_agent):
+        """No fallback configured: the loop keeps the existing bounded
+        continuation behavior and gives up with the truncation error."""
+        loop_agent.client.chat.completions.create.side_effect = [
+            self._text_stub() for _ in range(4)
+        ]
+        loop_agent._fallback_chain = []
+        loop_agent._fallback_index = 0
+
+        with (
+            patch.object(loop_agent, "_persist_session"),
+            patch.object(loop_agent, "_save_trajectory"),
+            patch.object(loop_agent, "_cleanup_task_resources"),
+        ):
+            result = loop_agent.run_conversation("draft the post")
+
+        assert loop_agent.client.chat.completions.create.call_count == 4
+        assert result["completed"] is False
+        assert "remained truncated" in (result.get("error") or "")
+
+    def test_second_tool_call_stall_activates_fallback(self, loop_agent):
+        """Same policy on the truncated-tool-call path: a second stub stall
+        mid tool-call escalates instead of burning retries 2-4."""
+        from tests.run_agent.test_run_agent import _mock_assistant_msg, _mock_response
+
+        partial_tc = SimpleNamespace(
+            id="call_1",
+            type="function",
+            function=SimpleNamespace(name="write_file", arguments='{"path": "/tmp/x'),
+        )
+
+        def _tc_stub():
+            return SimpleNamespace(
+                id=PARTIAL_STREAM_STUB_ID,
+                model="test/model",
+                choices=[SimpleNamespace(
+                    index=0,
+                    message=_mock_assistant_msg(
+                        content="", tool_calls=[partial_tc],
+                    ),
+                    finish_reason=FINISH_REASON_LENGTH,
+                )],
+                usage=None,
+            )
+
+        recovery = _mock_response(
+            content="Done on the fallback provider.", finish_reason="stop",
+        )
+        loop_agent.client.chat.completions.create.side_effect = [
+            _tc_stub(), _tc_stub(), recovery,
+        ]
+        loop_agent._fallback_chain = [
+            {"provider": "anthropic", "model": "claude-sonnet-4-6"},
+        ]
+        loop_agent._fallback_index = 0
+        fb_calls = {"n": 0}
+
+        def _fake_activate(reason=None):
+            fb_calls["n"] += 1
+            loop_agent._fallback_index = len(loop_agent._fallback_chain)
+            return True
+
+        with (
+            patch.object(loop_agent, "_persist_session"),
+            patch.object(loop_agent, "_save_trajectory"),
+            patch.object(loop_agent, "_cleanup_task_resources"),
+            patch.object(loop_agent, "_try_activate_fallback",
+                         side_effect=_fake_activate),
+        ):
+            result = loop_agent.run_conversation("write me a file")
+
+        assert fb_calls["n"] == 1, (
+            "A second stub stall mid tool-call must activate fallback after "
+            "ONE primary retry."
+        )
+        assert loop_agent.client.chat.completions.create.call_count == 3
+        assert result["final_response"] == "Done on the fallback provider."
+        assert result["completed"] is True
+
+
 class TestEmptyPartialStreamStubNotPersisted:
     """Regression for the session-poisoning bug hit with moonshotai/kimi-k3
     via OpenRouter (2026-07-20): a stream dropped mid-``write_file`` tool


### PR DESCRIPTION
## Problem

When a provider's streaming path goes unhealthy (observed live: an OpenRouter streaming incident for `anthropic/claude-sonnet-4.6`, 2026-08-14 ~22:45–23:30 UTC, ~100% of chat turns affected at peak), every request dies mid-stream and comes back as a `PARTIAL_STREAM_STUB_ID` stub. The length-continuation loop then burns all 4 continuation retries against that same dead provider. Each pass:

- re-marshals the full conversation context (paid input tokens, up to 5 requests per user turn),
- restarts the reply from scratch and stalls again, so `truncated_response_parts` stitches 4–5 identical partials into one garbled reply — the user literally sees `"Didn't go through. Let me check the exact API shape required.Didn't go through. Let me check the exact API shape required.…"` ×5 followed by `"Response truncated due to output length limit"`,
- and the configured `_fallback_chain` is **never consulted** — a healthy fallback provider sat unused in the same deployment for the whole incident.

This is the same economics that motivated the content-filter escalation (#32421): retrying a failure mode that is deterministic-for-this-provider just burns paid attempts.

## Fix

Keep **one** continuation retry on the primary, then escalate. A single primary retry rides the provider-side prompt cache and absorbs the routine one-off network drop (the common case); failing over on the *first* stub would pay a guaranteed cache-cold context marshal on the fallback for every transient blip. A **second consecutive stub in the same turn** is treated as an unhealthy stream path → `_try_activate_fallback()`, with the same rollback/reset/restart sequence as the content-filter escalation (partials rolled back to the last clean turn so the fallback gets a coherent continuation point and the stitched-duplicate reply can't render).

Applied to both stall paths:

- text length-continuation (`length_continue_retries >= 1` + stub → escalate),
- truncated-tool-call stall (`truncated_tool_call_retries >= 1` + stub → escalate; no rollback needed since broken responses are never appended there).

Genuine `finish_reason=length` truncations (healthy provider, real output cap) keep the existing 4-retry continuation behavior, distinguished as before via `PARTIAL_STREAM_STUB_ID`. With no chain configured, behavior is unchanged (bounded retries, honest give-up message).

## Tests

`TestRepeatedStreamDropActivatesFallback` in `tests/run_agent/test_partial_stream_finish_reason.py` (mirrors `TestContentFilterStallActivatesFallback`):

- second stub → fallback activated exactly once, after exactly one primary retry; final reply is the fallback's clean answer (no stitched duplicates)
- first stub → primary retry only, fallback NOT consulted
- no chain configured → existing bounded give-up behavior preserved
- second stub mid tool-call → escalates on the tool path too

`tests/run_agent/`: 1603 passed, 3 pre-existing failures in `test_callable_api_key.py::TestTruncateTokenCallable` (fail identically on clean main in my environment, unrelated to this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)