### PR TITLE
feat(approvals): let plugins narrow approval lifetime

### DIFF
--- a/acp_adapter/permissions.py
+++ b/acp_adapter/permissions.py
@@ -40,12 +40,19 @@ def _permission_option_supports_kind(kind: str) -> bool:
 
 def _build_permission_options(
     *, allow_permanent: bool, smart_denied: bool = False,
+    allowed_scopes: object = None,
 ) -> list[PermissionOption]:
     """Return ACP options that match Hermes approval semantics."""
+    if allowed_scopes is None:
+        scopes = {"once", "session", "always"}
+    else:
+        from tools.approval import _normalize_allowed_scopes
+
+        scopes = _normalize_allowed_scopes(allowed_scopes)
     options = [PermissionOption(
         option_id="allow_once", kind="allow_once", name="Allow once",
     )]
-    if not smart_denied:
+    if not smart_denied and "session" in scopes:
         options.append(PermissionOption(
             option_id="allow_session",
             # ACP has no session-scoped kind, so use the closest persistent
@@ -53,7 +60,7 @@ def _build_permission_options(
             kind="allow_always",
             name="Allow for session",
         ))
-    if allow_permanent and not smart_denied:
+    if allow_permanent and not smart_denied and "always" in scopes:
         options.append(
             PermissionOption(
                 option_id="allow_always",
@@ -62,7 +69,11 @@ def _build_permission_options(
             ),
         )
     options.append(PermissionOption(option_id="deny", kind="reject_once", name="Deny"))
-    if not smart_denied and _permission_option_supports_kind("reject_always"):
+    if (
+        not smart_denied
+        and scopes != {"once"}
+        and _permission_option_supports_kind("reject_always")
+    ):
         options.append(
             PermissionOption(
                 option_id="deny_always",
@@ -133,6 +144,7 @@ def make_approval_callback(
         *,
         allow_permanent: bool = True,
         smart_denied: bool = False,
+        allowed_scopes: object = None,
         **_: object,
     ) -> str:
         from agent.async_utils import safe_schedule_threadsafe
@@ -140,6 +152,7 @@ def make_approval_callback(
         options = _build_permission_options(
             allow_permanent=allow_permanent,
             smart_denied=smart_denied,
+            allowed_scopes=allowed_scopes,
         )
 
         tool_call = _build_permission_tool_call(command, description)

--- a/cli.py
+++ b/cli.py
@@ -14321,7 +14321,8 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
 
     def _approval_callback(self, command: str, description: str,
                            *, allow_permanent: bool = True,
-                           smart_denied: bool = False) -> str:
+                           smart_denied: bool = False,
+                           allowed_scopes=None) -> str:
         """
         Prompt for dangerous command approval through the prompt_toolkit UI.
 
@@ -14349,6 +14350,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                     command,
                     allow_permanent=allow_permanent,
                     smart_denied=smart_denied,
+                    allowed_scopes=allowed_scopes,
                 ),
                 "selected": 0,
                 "response_queue": response_queue,
@@ -14399,10 +14401,20 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             return "timeout"
 
     def _approval_choices(self, command: str, *, allow_permanent: bool = True,
-                          smart_denied: bool = False) -> list[str]:
+                          smart_denied: bool = False,
+                          allowed_scopes=None) -> list[str]:
         """Return approval choices for a dangerous command prompt."""
         if smart_denied:
             choices = ["once", "deny"]
+        elif allowed_scopes is not None:
+            from tools.approval import _normalize_allowed_scopes
+
+            scopes = _normalize_allowed_scopes(allowed_scopes)
+            choices = [
+                scope for scope in ("once", "session", "always")
+                if scope in scopes and (scope != "always" or allow_permanent)
+            ]
+            choices.append("deny")
         else:
             choices = ["once", "session", "always", "deny"] if allow_permanent else ["once", "session", "deny"]
         if len(command) > 70:

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -71,8 +71,12 @@ _api_request_profile: ContextVar[Optional[str]] = ContextVar(
     "api_server_request_profile", default=None
 )
 
-def _approval_event_choices(*, smart_denied: bool, allow_permanent: bool) -> list[str]:
+def _approval_event_choices(
+    *, smart_denied: bool, allow_permanent: bool, allow_session: bool = True,
+) -> list[str]:
     if smart_denied:
+        return ["once", "deny"]
+    if not allow_session:
         return ["once", "deny"]
     return ["once", "session", "always", "deny"] if allow_permanent else ["once", "session", "deny"]
 
@@ -6743,6 +6747,7 @@ class APIServerAdapter(BasePlatformAdapter):
                         "choices": _approval_event_choices(
                             smart_denied=bool(event.get("smart_denied")),
                             allow_permanent=event.get("allow_permanent") is not False,
+                            allow_session=event.get("allow_session") is not False,
                         ),
                     })
                     self._set_run_status(

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -5782,6 +5782,7 @@ def fire_pre_command_hook(
 
 
 _thread_tool_whitelist = threading.local()
+_DIRECTIVE_SCOPES_UNSET = object()
 
 
 @dataclass(frozen=True)
@@ -5789,6 +5790,7 @@ class _PreToolCallDirective:
     action: Optional[str] = None
     message: Optional[str] = None
     rule_key: Optional[str] = None
+    allowed_scopes: Any = _DIRECTIVE_SCOPES_UNSET
 
 
 def set_thread_tool_whitelist(
@@ -5821,6 +5823,7 @@ def _get_pre_tool_call_directive_details(
         {"action": "block",   "message": "Reason the tool was blocked"}
         {"action": "approve", "message": "Why this needs human confirmation"}
         {"action": "approve", "message": "...", "rule_key": "write_file:ssh"}
+        {"action": "approve", "message": "...", "allowed_scopes": ["once"]}
 
     from their ``pre_tool_call`` callback.
 
@@ -5835,6 +5838,10 @@ def _get_pre_tool_call_directive_details(
       :func:`tools.approval.request_tool_approval`).
     - ``rule_key`` is optional and only honored for ``approve`` directives. It
       lets plugins choose the allowlist grain for `[a]lways` approvals.
+    - ``allowed_scopes`` is optional and only honored for ``approve``
+      directives. Supported values are ``once``, ``once + session``, or the
+      full current set. Absence preserves current behavior; malformed or
+      widening values fail closed at the approval backend.
 
     The first valid directive wins. Invalid or irrelevant hook return values
     are silently ignored so existing observer-only hooks are unaffected.
@@ -5877,7 +5884,15 @@ def _get_pre_tool_call_directive_details(
         rule_key = rule_key.strip() if isinstance(rule_key, str) else None
         if not rule_key:
             rule_key = None
-        return _PreToolCallDirective(action=action, message=message, rule_key=rule_key)
+        allowed_scopes = _DIRECTIVE_SCOPES_UNSET
+        if action == "approve" and "allowed_scopes" in result:
+            allowed_scopes = result.get("allowed_scopes")
+        return _PreToolCallDirective(
+            action=action,
+            message=message,
+            rule_key=rule_key,
+            allowed_scopes=allowed_scopes,
+        )
 
     return _PreToolCallDirective()
 
@@ -5981,10 +5996,15 @@ def resolve_pre_tool_block(
             except Exception:
                 pass
             try:
+                approval_kwargs: Dict[str, Any] = {
+                    "rule_key": details.rule_key or tool_name,
+                }
+                if details.allowed_scopes is not _DIRECTIVE_SCOPES_UNSET:
+                    approval_kwargs["allowed_scopes"] = details.allowed_scopes
                 result = request_tool_approval(
                     tool_name,
                     details.message or "",
-                    rule_key=details.rule_key or tool_name,
+                    **approval_kwargs,
                 )
             finally:
                 if approval_tokens is not None:

--- a/tests/acp/test_permissions.py
+++ b/tests/acp/test_permissions.py
@@ -24,6 +24,7 @@ def _invoke_callback(
     *,
     allow_permanent=True,
     smart_denied=False,
+    allowed_scopes=None,
     timeout=60.0,
     use_prompt_path=False,
 ):
@@ -42,19 +43,29 @@ def _invoke_callback(
     with patch("agent.async_utils.asyncio.run_coroutine_threadsafe", side_effect=_schedule):
         cb = make_approval_callback(request_permission, loop, session_id="s1", timeout=timeout)
         if use_prompt_path:
+            prompt_kwargs = {
+                "allow_permanent": allow_permanent,
+                "smart_denied": smart_denied,
+                "approval_callback": cb,
+            }
+            if allowed_scopes is not None:
+                prompt_kwargs["allowed_scopes"] = allowed_scopes
             result = prompt_dangerous_approval(
                 "rm -rf /",
                 "dangerous command",
-                allow_permanent=allow_permanent,
-                smart_denied=smart_denied,
-                approval_callback=cb,
+                **prompt_kwargs,
             )
         else:
+            callback_kwargs = {
+                "allow_permanent": allow_permanent,
+                "smart_denied": smart_denied,
+            }
+            if allowed_scopes is not None:
+                callback_kwargs["allowed_scopes"] = allowed_scopes
             result = cb(
                 "rm -rf /",
                 "dangerous command",
-                allow_permanent=allow_permanent,
-                smart_denied=smart_denied,
+                **callback_kwargs,
             )
 
     scheduled["coro"].close()
@@ -63,6 +74,18 @@ def _invoke_callback(
 
 
 class TestApprovalBridge:
+    def test_once_only_offers_once_and_deny_and_rejects_forged_always(self):
+        result, kwargs, _, _, _ = _invoke_callback(
+            AllowedOutcome(option_id="allow_always", outcome="selected"),
+            allowed_scopes=("once",),
+        )
+
+        assert [option.option_id for option in kwargs["options"]] == [
+            "allow_once",
+            "deny",
+        ]
+        assert result == "deny"
+
     def test_bridge_schedules_request_on_the_given_loop(self):
         result, kwargs, scheduled, _, loop = _invoke_callback(
             AllowedOutcome(option_id="allow_once", outcome="selected"),

--- a/tests/cli/test_cli_approval_ui.py
+++ b/tests/cli/test_cli_approval_ui.py
@@ -67,6 +67,14 @@ def _make_background_cli_stub():
 
 
 class TestCliApprovalUi:
+    def test_once_only_callback_offers_only_once_and_deny(self):
+        cli = _make_cli_stub()
+
+        assert cli._approval_choices(
+            "write file",
+            allowed_scopes=("once",),
+        ) == ["once", "deny"]
+
     def test_smart_denied_callback_offers_only_once_and_deny(self):
         cli = _make_cli_stub()
         result = {}

--- a/tests/gateway/test_api_server_runs.py
+++ b/tests/gateway/test_api_server_runs.py
@@ -34,20 +34,22 @@ from tools import approval as approval_mod
 
 
 @pytest.mark.parametrize(
-    ("smart_denied", "allow_permanent", "expected"),
+    ("smart_denied", "allow_permanent", "allow_session", "expected"),
     [
-        (False, True, ["once", "session", "always", "deny"]),
-        (False, False, ["once", "session", "deny"]),
-        (True, True, ["once", "deny"]),
-        (True, False, ["once", "deny"]),
+        (False, True, True, ["once", "session", "always", "deny"]),
+        (False, False, True, ["once", "session", "deny"]),
+        (False, False, False, ["once", "deny"]),
+        (True, True, True, ["once", "deny"]),
+        (True, False, False, ["once", "deny"]),
     ],
 )
 def test_approval_event_choices_follow_backend_capabilities(
-    smart_denied, allow_permanent, expected
+    smart_denied, allow_permanent, allow_session, expected
 ):
     assert _approval_event_choices(
         smart_denied=smart_denied,
         allow_permanent=allow_permanent,
+        allow_session=allow_session,
     ) == expected
 
 

--- a/tests/gateway/test_telegram_approval_buttons.py
+++ b/tests/gateway/test_telegram_approval_buttons.py
@@ -82,6 +82,26 @@ class TestTelegramExecApproval:
     """Test the send_exec_approval method sends InlineKeyboard buttons."""
 
     @pytest.mark.asyncio
+    async def test_once_only_hides_session_and_always(self, monkeypatch):
+        adapter = _make_adapter()
+        adapter._bot.send_message = AsyncMock(return_value=SimpleNamespace(message_id=42))
+        buttons = []
+        monkeypatch.setattr(
+            "plugins.platforms.telegram.adapter.InlineKeyboardButton",
+            lambda text, callback_data: buttons.append(text) or text,
+        )
+        monkeypatch.setattr(
+            "plugins.platforms.telegram.adapter.InlineKeyboardMarkup", lambda rows: rows
+        )
+
+        await adapter.send_exec_approval(
+            chat_id="12345", command="curl example.test", session_key="test-session",
+            allow_permanent=False, allow_session=False,
+        )
+
+        assert buttons == ["✅ Allow Once", "❌ Deny"]
+
+    @pytest.mark.asyncio
     async def test_sends_inline_keyboard(self):
         adapter = _make_adapter()
         mock_msg = MagicMock()

--- a/tests/hermes_cli/test_plugins.py
+++ b/tests/hermes_cli/test_plugins.py
@@ -1108,6 +1108,48 @@ class TestResolvePreToolBlock:
             "rule_key": "write_file:ssh",
         }
 
+    def test_approve_passes_allowed_scopes_to_gate(self, monkeypatch):
+        from hermes_cli.plugins import resolve_pre_tool_block
+
+        seen = {}
+        monkeypatch.setattr(
+            "hermes_cli.plugins.invoke_hook",
+            lambda hook_name, **kwargs: [{
+                "action": "approve",
+                "allowed_scopes": ["once"],
+            }],
+        )
+
+        def _approve(*args, **kwargs):
+            seen.update(kwargs)
+            return {"approved": True, "message": None}
+
+        monkeypatch.setattr("tools.approval.request_tool_approval", _approve)
+
+        assert resolve_pre_tool_block("write_file", {}) is None
+        assert seen["allowed_scopes"] == ["once"]
+
+    def test_approve_omits_allowed_scopes_when_directive_field_is_absent(
+        self, monkeypatch
+    ):
+        from hermes_cli.plugins import resolve_pre_tool_block
+
+        seen = {}
+        monkeypatch.setattr(
+            "hermes_cli.plugins.invoke_hook",
+            lambda hook_name, **kwargs: [{"action": "approve"}],
+        )
+        monkeypatch.setattr(
+            "tools.approval.request_tool_approval",
+            lambda *args, **kwargs: seen.update(kwargs) or {
+                "approved": True,
+                "message": None,
+            },
+        )
+
+        assert resolve_pre_tool_block("write_file", {}) is None
+        assert "allowed_scopes" not in seen
+
 
     def test_approve_gate_exception_fails_closed(self, monkeypatch):
         from hermes_cli.plugins import resolve_pre_tool_block

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -16610,6 +16610,23 @@ def test_clarify_callback_uses_configured_timeout(monkeypatch):
     assert captured["payload"] == {"question": "Pick one", "choices": ["a", "b"]}
 
 
+def test_approval_request_once_only_choices(monkeypatch):
+    events = []
+    monkeypatch.setattr(
+        server,
+        "_emit",
+        lambda event_type, sid, payload: events.append((event_type, sid, payload)),
+    )
+
+    server._emit_approval_request("sid", {
+        "command": "synthetic",
+        "allow_permanent": False,
+        "allow_session": False,
+    })
+
+    assert events[0][2]["choices"] == ["once", "deny"]
+
+
 def test_clarify_callback_multi_select_hint(monkeypatch):
     """multi_select=True adds the hint to the payload; the single-select
     payload shape stays byte-identical to the pre-multi-select protocol

--- a/tests/tools/test_request_tool_approval.py
+++ b/tests/tools/test_request_tool_approval.py
@@ -95,6 +95,148 @@ class TestRequestToolApproval:
         assert calls["session"] == ["plugin_rule:ssh-writes"]
         assert calls["permanent"] == []  # session != always
 
+    def test_once_only_rejects_forged_always_without_persistence(self, monkeypatch):
+        monkeypatch.setattr(approval, "_is_interactive_cli", lambda: True)
+        monkeypatch.setattr(approval, "_is_gateway_approval_context", lambda: False)
+        seen = {}
+
+        def _prompt(*args, **kwargs):
+            seen.update(kwargs)
+            return "always"
+
+        monkeypatch.setattr(approval, "prompt_dangerous_approval", _prompt)
+        session = []
+        permanent = []
+        monkeypatch.setattr(approval, "approve_session", lambda *args: session.append(args))
+        monkeypatch.setattr(approval, "approve_permanent", lambda *args: permanent.append(args))
+        monkeypatch.setattr(
+            approval,
+            "save_permanent_allowlist",
+            lambda *args: pytest.fail("forged always must not be saved"),
+        )
+
+        result = request_tool_approval(
+            "write_file", "reason", allowed_scopes=["once"]
+        )
+
+        assert result["approved"] is False
+        assert result["outcome"] == "invalid_scope"
+        assert seen["allow_permanent"] is False
+        assert seen["allowed_scopes"] == ("once",)
+        assert session == []
+        assert permanent == []
+
+    @pytest.mark.parametrize(
+        "value",
+        [[], ["always"], ["once", "always"], ["once", "future"], "once", None,
+         [["once"]]],
+    )
+    def test_invalid_allowed_scopes_fail_closed_to_once(self, monkeypatch, value):
+        monkeypatch.setattr(approval, "_is_interactive_cli", lambda: True)
+        monkeypatch.setattr(approval, "_is_gateway_approval_context", lambda: False)
+        seen = {}
+
+        def _prompt(*args, **kwargs):
+            seen.update(kwargs)
+            return "once"
+
+        monkeypatch.setattr(approval, "prompt_dangerous_approval", _prompt)
+        result = request_tool_approval("write_file", "reason", allowed_scopes=value)
+
+        assert result["approved"] is True
+        assert seen["allowed_scopes"] == ("once",)
+        assert seen["allow_permanent"] is False
+
+    @pytest.mark.parametrize(
+        ("value", "expected"),
+        [
+            (["once"], ("once",)),
+            (["session", "once"], ("once", "session")),
+            (["always", "once", "session"], None),
+        ],
+    )
+    def test_supported_exact_scope_sets_are_ordered_and_enforced(
+        self, monkeypatch, value, expected
+    ):
+        monkeypatch.setattr(approval, "_is_interactive_cli", lambda: True)
+        monkeypatch.setattr(approval, "_is_gateway_approval_context", lambda: False)
+        seen = {}
+
+        def _prompt(*args, **kwargs):
+            seen.update(kwargs)
+            return "once"
+
+        monkeypatch.setattr(approval, "prompt_dangerous_approval", _prompt)
+        result = request_tool_approval("write_file", "reason", allowed_scopes=value)
+
+        assert result["approved"] is True
+        if expected is None:
+            assert "allowed_scopes" not in seen
+            assert "allow_permanent" not in seen
+        else:
+            assert seen["allowed_scopes"] == expected
+
+    def test_absent_allowed_scopes_preserves_legacy_callback_shape(self, monkeypatch):
+        monkeypatch.setattr(approval, "_is_interactive_cli", lambda: True)
+        monkeypatch.setattr(approval, "_is_gateway_approval_context", lambda: False)
+        calls = []
+
+        def _legacy_callback(command, description, *, allow_permanent=True):
+            calls.append((command, description, allow_permanent))
+            return "once"
+
+        result = request_tool_approval(
+            "write_file", "reason", approval_callback=_legacy_callback
+        )
+
+        assert result["approved"] is True
+        assert calls and calls[0][2] is True
+
+    def test_gateway_once_only_payload_and_forged_always_fail_closed(self, monkeypatch):
+        monkeypatch.setattr(approval, "_is_interactive_cli", lambda: False)
+        monkeypatch.setattr(approval, "_is_gateway_approval_context", lambda: True)
+        captured = {}
+        monkeypatch.setitem(approval._gateway_notify_cbs, "test-session", lambda data: None)
+
+        def _decision(session_key, notify_cb, approval_data, *, surface):
+            captured.update(approval_data)
+            return {"resolved": True, "choice": "always"}
+
+        monkeypatch.setattr(approval, "_await_gateway_decision", _decision)
+        monkeypatch.setattr(
+            approval,
+            "approve_permanent",
+            lambda *args: pytest.fail("forged always must not persist"),
+        )
+
+        result = request_tool_approval(
+            "write_file", "reason", allowed_scopes=["once"]
+        )
+
+        assert result["approved"] is False
+        assert result["outcome"] == "invalid_scope"
+        assert captured["allowed_scopes"] == ["once"]
+        assert captured["allow_session"] is False
+        assert captured["allow_permanent"] is False
+
+    def test_once_only_does_not_reuse_cached_broad_approval(self, monkeypatch):
+        monkeypatch.setattr(approval, "_is_interactive_cli", lambda: True)
+        monkeypatch.setattr(approval, "_is_gateway_approval_context", lambda: False)
+        monkeypatch.setattr(approval, "is_approved", lambda *args: True)
+        prompted = []
+
+        def _prompt(*args, **kwargs):
+            prompted.append(kwargs)
+            return "once"
+
+        monkeypatch.setattr(approval, "prompt_dangerous_approval", _prompt)
+        result = request_tool_approval(
+            "write_file", "reason", allowed_scopes=["once"]
+        )
+
+        assert result["approved"] is True
+        assert len(prompted) == 1
+
 
     def test_cron_deny_mode_blocks(self, monkeypatch):
         monkeypatch.setattr(approval, "_is_interactive_cli", lambda: False)

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -30,6 +30,35 @@ from utils import env_var_enabled, is_truthy_value
 
 logger = logging.getLogger(__name__)
 
+_APPROVAL_SCOPE_ORDER = ("once", "session", "always")
+_ALL_APPROVAL_SCOPES = frozenset(_APPROVAL_SCOPE_ORDER)
+_VALID_APPROVAL_SCOPE_SETS = {
+    frozenset({"once"}),
+    frozenset({"once", "session"}),
+    _ALL_APPROVAL_SCOPES,
+}
+_ALLOWED_SCOPES_UNSET = object()
+
+
+def _normalize_allowed_scopes(value: object = _ALLOWED_SCOPES_UNSET) -> frozenset[str]:
+    """Normalize a narrowing-only scope set; malformed values become once-only."""
+    if value is _ALLOWED_SCOPES_UNSET:
+        return _ALL_APPROVAL_SCOPES
+    if not isinstance(value, (list, tuple, set, frozenset)):
+        return frozenset({"once"})
+    try:
+        requested = frozenset(value)
+    except TypeError:
+        return frozenset({"once"})
+    if requested not in _VALID_APPROVAL_SCOPE_SETS:
+        return frozenset({"once"})
+    return requested
+
+
+def _ordered_allowed_scopes(scopes: frozenset[str]) -> tuple[str, ...]:
+    return tuple(scope for scope in _APPROVAL_SCOPE_ORDER if scope in scopes)
+
+
 # Freeze YOLO mode at module import time. Reading os.environ on every call
 # would allow any skill running inside the process to set this variable and
 # instantly bypass all approval checks — a prompt-injection escalation path.
@@ -2739,6 +2768,50 @@ def is_approved(session_key: str, pattern_key: str) -> bool:
         return any(alias in session_approvals for alias in aliases)
 
 
+def _is_approved_within_scopes(
+    session_key: str,
+    pattern_key: str,
+    allowed_scopes: frozenset[str],
+) -> bool:
+    """Reuse only approvals whose stored lifetime remains permitted."""
+    if allowed_scopes == _ALL_APPROVAL_SCOPES:
+        return is_approved(session_key, pattern_key)
+    aliases = _approval_key_aliases(pattern_key)
+    with _lock:
+        if "always" in allowed_scopes and any(
+            alias in _permanent_approved for alias in aliases
+        ):
+            return True
+        if "session" in allowed_scopes:
+            session_approvals = _session_approved.get(session_key, set())
+            return any(alias in session_approvals for alias in aliases)
+    return False
+
+
+def _disallowed_scope_result(
+    pattern_key: str,
+    description: str,
+    choice: object,
+) -> dict:
+    """Deny a forged or stale approval choice outside the current scope set."""
+    logger.warning(
+        "Rejected approval choice outside allowed scopes: %r (pattern: %s)",
+        choice,
+        pattern_key,
+    )
+    return {
+        "approved": False,
+        "message": (
+            "BLOCKED: The approval response selected a scope that was not "
+            "offered for this action. The action was not executed."
+        ),
+        "pattern_key": pattern_key,
+        "description": description,
+        "outcome": "invalid_scope",
+        "user_consent": False,
+    }
+
+
 def approve_permanent(pattern_key: str):
     """Add a pattern to the permanent allowlist."""
     with _lock:
@@ -2830,7 +2903,8 @@ def prompt_dangerous_approval(command: str, description: str,
                               timeout_seconds: int | None = None,
                               allow_permanent: bool = True,
                               approval_callback=None,
-                              *, smart_denied: bool = False) -> str:
+                              *, smart_denied: bool = False,
+                              allowed_scopes: object = _ALLOWED_SCOPES_UNSET) -> str:
     """Prompt the user to approve a dangerous command (CLI only).
 
     Args:
@@ -2839,6 +2913,8 @@ def prompt_dangerous_approval(command: str, description: str,
             is inappropriate for content-level security findings).
         smart_denied: When True, this is an owner override of a Smart DENY.
             Offer only one-operation approval or denial.
+        allowed_scopes: Optional narrowing-only set supplied by a plugin
+            approval directive. Invalid sets offer once-only.
         approval_callback: Optional callback registered by the CLI for
             prompt_toolkit integration. Signature:
             (command, description, *, allow_permanent=True,
@@ -2865,6 +2941,7 @@ def prompt_dangerous_approval(command: str, description: str,
             allow_permanent,
             approval_callback,
             smart_denied=smart_denied,
+            allowed_scopes=allowed_scopes,
         )
 
 
@@ -2872,7 +2949,8 @@ def _prompt_dangerous_approval_inner(command: str, description: str,
                                      timeout_seconds: int,
                                      allow_permanent: bool = True,
                                      approval_callback=None,
-                                     *, smart_denied: bool = False) -> str:
+                                     *, smart_denied: bool = False,
+                                     allowed_scopes: object = _ALLOWED_SCOPES_UNSET) -> str:
     # Redact secrets before any user-visible rendering. The original
     # `command` is still what executes after approval; only the displayed
     # copy is scrubbed. Reuses the same redaction module used for memory
@@ -2880,12 +2958,22 @@ def _prompt_dangerous_approval_inner(command: str, description: str,
     from agent.redact import redact_sensitive_text
     display_command = redact_sensitive_text(command)
     display_description = redact_sensitive_text(description)
+    scopes = _normalize_allowed_scopes(allowed_scopes)
+    if smart_denied:
+        scopes = frozenset({"once"})
+    elif not allow_permanent:
+        scopes = scopes & frozenset({"once", "session"})
+    once_only = scopes == frozenset({"once"})
 
     if approval_callback is not None:
         try:
-            callback_kwargs = {"allow_permanent": allow_permanent}
+            callback_kwargs: dict[str, object] = {
+                "allow_permanent": "always" in scopes
+            }
             if smart_denied:
                 callback_kwargs["smart_denied"] = True
+            if allowed_scopes is not _ALLOWED_SCOPES_UNSET:
+                callback_kwargs["allowed_scopes"] = _ordered_allowed_scopes(scopes)
             return approval_callback(
                 display_command, display_description, **callback_kwargs
             )
@@ -2930,9 +3018,9 @@ def _prompt_dangerous_approval_inner(command: str, description: str,
             print(f"  {t('approval.dangerous_header', description=display_description)}")
             print(f"      {display_command}")
             print()
-            if smart_denied:
+            if once_only:
                 print(t("approval.choose_smart_deny"))
-            elif allow_permanent:
+            elif "always" in scopes:
                 print(t("approval.choose_long"))
             else:
                 print(t("approval.choose_short"))
@@ -2943,10 +3031,10 @@ def _prompt_dangerous_approval_inner(command: str, description: str,
 
             def get_input():
                 try:
-                    if smart_denied:
+                    if once_only:
                         prompt = t("approval.prompt_smart_deny")
                     else:
-                        prompt = t("approval.prompt_long") if allow_permanent else t("approval.prompt_short")
+                        prompt = t("approval.prompt_long") if "always" in scopes else t("approval.prompt_short")
                     result["choice"] = input(prompt).strip().lower()
                 except (EOFError, OSError):
                     result["choice"] = ""
@@ -2963,7 +3051,7 @@ def _prompt_dangerous_approval_inner(command: str, description: str,
                 return "timeout"
 
             choice = result["choice"]
-            if smart_denied:
+            if once_only:
                 choice_map = {
                     **{
                         value: "once"
@@ -2982,12 +3070,15 @@ def _prompt_dangerous_approval_inner(command: str, description: str,
                 print(t("approval.allowed_once"))
                 return "once"
             elif choice in {'s', 'session'}:
+                if "session" not in scopes:
+                    print(t("approval.denied"))
+                    return "deny"
                 print(t("approval.allowed_session"))
                 return "session"
             elif choice in {'a', 'always'}:
-                if not allow_permanent:
-                    print(t("approval.allowed_session"))
-                    return "session"
+                if "always" not in scopes:
+                    print(t("approval.denied"))
+                    return "deny"
                 print(t("approval.allowed_always"))
                 return "always"
             else:
@@ -3274,6 +3365,7 @@ def _run_approval_gate(
     autoapprove_log_prefix: str,
     fail_closed_when_no_human: bool = False,
     no_human_block_message: str = "",
+    allowed_scopes: object = _ALLOWED_SCOPES_UNSET,
 ) -> dict:
     """Shared human-approval gate for a flagged action (command or tool).
 
@@ -3310,11 +3402,16 @@ def _run_approval_gate(
             plugin-flagged action never runs ungated without a human.
         no_human_block_message: Message returned when
             ``fail_closed_when_no_human`` blocks.
+        allowed_scopes: Narrowing-only approval scopes. Absence preserves the
+            historical once/session/always behavior; invalid values are
+            once-only.
 
     Returns:
         ``{"approved": bool, "message": str|None, ...}`` — shape shared with
         ``check_dangerous_command`` so all callers handle it uniformly.
     """
+    scopes = _normalize_allowed_scopes(allowed_scopes)
+
     # --yolo bypasses all approval prompts (session- or process-scoped).
     # Hardline blocks are handled by the caller BEFORE this gate, so yolo
     # here only skips the recoverable approval layer.
@@ -3322,7 +3419,7 @@ def _run_approval_gate(
         return {"approved": True, "message": None}
 
     session_key = get_current_session_key()
-    if is_approved(session_key, pattern_key):
+    if _is_approved_within_scopes(session_key, pattern_key, scopes):
         return {"approved": True, "message": None}
 
     approval_callback = _resolve_cli_approval_callback(approval_callback)
@@ -3386,8 +3483,9 @@ def _run_approval_gate(
                 "pattern_key": pattern_key,
                 "pattern_keys": [pattern_key],
                 "description": redact_sensitive_text(description),
-                "allow_permanent": True,
-                "allow_session": True,
+                "allow_permanent": "always" in scopes,
+                "allow_session": "session" in scopes,
+                "allowed_scopes": list(_ordered_allowed_scopes(scopes)),
             }
             decision = _await_gateway_decision(
                 session_key, notify_cb, approval_data, surface="gateway"
@@ -3426,6 +3524,8 @@ def _run_approval_gate(
                     "user_consent": False,
                 }
 
+            if choice not in scopes:
+                return _disallowed_scope_result(pattern_key, description, choice)
             if choice == "session":
                 approve_session(session_key, pattern_key)
             elif choice == "always":
@@ -3448,6 +3548,9 @@ def _run_approval_gate(
                 "command": display_target,
                 "pattern_key": pattern_key,
                 "description": description,
+                "allow_permanent": "always" in scopes,
+                "allow_session": "session" in scopes,
+                "allowed_scopes": list(_ordered_allowed_scopes(scopes)),
             })
             return {
                 "approved": False,
@@ -3470,8 +3573,20 @@ def _run_approval_gate(
         session_key=session_key,
         surface="cli",
     )
-    choice = prompt_dangerous_approval(display_target, description,
-                                       approval_callback=approval_callback)
+    if scopes != _ALL_APPROVAL_SCOPES:
+        choice = prompt_dangerous_approval(
+            display_target,
+            description,
+            allow_permanent="always" in scopes,
+            approval_callback=approval_callback,
+            allowed_scopes=_ordered_allowed_scopes(scopes),
+        )
+    else:
+        choice = prompt_dangerous_approval(
+            display_target,
+            description,
+            approval_callback=approval_callback,
+        )
     _fire_approval_hook(
         "post_approval_response",
         command=display_target,
@@ -3511,6 +3626,9 @@ def _run_approval_gate(
             "outcome": "denied",
             "user_consent": False,
         }
+
+    if choice not in scopes:
+        return _disallowed_scope_result(pattern_key, description, choice)
 
     if choice == "session":
         approve_session(session_key, pattern_key)
@@ -3612,6 +3730,7 @@ def request_tool_approval(
     *,
     rule_key: str = "",
     approval_callback=None,
+    allowed_scopes: object = _ALLOWED_SCOPES_UNSET,
 ) -> dict:
     """Escalate an arbitrary tool call to the human-approval gate.
 
@@ -3639,6 +3758,10 @@ def request_tool_approval(
             on the same tool).
         approval_callback: Optional CLI callback for interactive prompts
             (same contract as ``check_dangerous_command``).
+        allowed_scopes: Optional narrowing-only scope set from the plugin.
+            Supported sets are once, once+session, and the full current set.
+            Malformed, empty, widening, or always-without-session values fail
+            closed to once-only.
 
     Returns:
         ``{"approved": True, "message": None}`` when allowed, or
@@ -3690,6 +3813,7 @@ def request_tool_approval(
             "but no interactive user or gateway is present to approve it. "
             "A plugin flagged this action for human confirmation."
         ),
+        allowed_scopes=allowed_scopes,
     )
 
 

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -1867,6 +1867,8 @@ def _emit_approval_request(sid: str, data: dict | None) -> None:
     if "choices" not in payload:
         if payload.get("smart_denied"):
             payload["choices"] = ["once", "deny"]
+        elif payload.get("allow_session") is False:
+            payload["choices"] = ["once", "deny"]
         elif payload.get("allow_permanent") is False:
             payload["choices"] = ["once", "session", "deny"]
         elif "allow_permanent" in payload:


### PR DESCRIPTION
## Summary

Let `pre_tool_call` approval directives optionally narrow the approval lifetimes a user may choose.

A plugin can now return `allowed_scopes` with one of three exact capability sets:

- `once`
- `once`, `session`
- `once`, `session`, `always`

When the field is absent, Hermes preserves the existing once/session/always behaviour.

## Why

Plugins can currently escalate any tool call into Hermes' native approval gate and choose a stable `rule_key`, but they cannot say that an action must remain one-shot or session-only. Every plugin-triggered approval therefore exposes all lifetimes, even when the plugin deliberately uses a one-use rule key.

That creates a UI/backend mismatch: a user may be offered a broader approval choice that the plugin cannot safely honour on later calls.

## Behaviour

- Accept only the three monotonic scope sets above.
- Fail empty, malformed, unknown, unhashable, widening, or `always`-without-`session` values closed to once-only.
- Keep the legacy callback shape unchanged when `allowed_scopes` is absent.
- Ignore cached session or permanent grants when the current request excludes that lifetime.
- Reject forged or stale out-of-scope choices before execution or persistence.
- Project the effective capabilities through CLI, ACP, API, TUI, and existing gateway approval payloads.

Backend validation is authoritative; filtering UI choices is not treated as the security boundary.

## Relationship to #61378

This is complementary to #61378 rather than a replacement. That PR propagates `allow_permanent` produced by existing approval policies through gateway transports. This change adds the upstream contract that lets a plugin directive define its permitted lifetime set and enforces that set at the approval backend.

## Compatibility

Existing plugins do not need to change. Omitting `allowed_scopes` preserves current behaviour.

## Validation

- Deterministic current-main RED reproduced dropped scope metadata and acceptance/persistence of a forged `always` response.
- The same harness passes with no admitted bypass and no session, permanent, or config persistence from a disallowed response.
- 695 changed-surface tests passed.
- Independent security and minimality review passed.
- Syntax, path, mode, diff, callback-compatibility, malformed-input, cache-lifetime, and private-data fences passed.

This PR adds only the generic plugin contract and tests. It contains no deployment-specific policy or plugin implementation.
