### PR TITLE
fix(kanban): tolerate string timestamps in _fmt_ts

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -43,9 +43,17 @@ _STATUS_ICONS = {
 }
 
 
-def _fmt_ts(ts: Optional[int]) -> str:
+def _fmt_ts(ts: Optional[int | str]) -> str:
     if not ts:
         return ""
+    if isinstance(ts, str):
+        # Tolerate string timestamps: an ISO-8601 datetime (e.g. produced by a
+        # worker writing completed_at as a str) or an epoch encoded as a str.
+        iso = ts.replace("T", " ")
+        try:
+            return time.strftime("%Y-%m-%d %H:%M", time.localtime(int(iso[:10])))
+        except ValueError:
+            return iso[:16]
     return time.strftime("%Y-%m-%d %H:%M", time.localtime(ts))
 
 

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -49,11 +49,12 @@ def _fmt_ts(ts: Optional[int | str]) -> str:
     if isinstance(ts, str):
         # Tolerate string timestamps: an ISO-8601 datetime (e.g. produced by a
         # worker writing completed_at as a str) or an epoch encoded as a str.
+        # Only treat purely-numeric strings as epochs so a compact ISO form or
+        # a short/odd epoch isn't mis-parsed and rendered as a wrong year.
+        if ts.isdigit():
+            return time.strftime("%Y-%m-%d %H:%M", time.localtime(int(ts)))
         iso = ts.replace("T", " ")
-        try:
-            return time.strftime("%Y-%m-%d %H:%M", time.localtime(int(iso[:10])))
-        except ValueError:
-            return iso[:16]
+        return iso[:16]
     return time.strftime("%Y-%m-%d %H:%M", time.localtime(ts))
 
 

--- a/tests/hermes_cli/test_kanban_cli.py
+++ b/tests/hermes_cli/test_kanban_cli.py
@@ -40,6 +40,17 @@ def kanban_home(tmp_path, monkeypatch):
 
 
 
+def test_fmt_ts_tolerates_string_timestamps():
+    """A worker writing `completed_at` as an ISO string (or epoch-as-str) must
+    not crash `_fmt_ts` — it should render like any numeric timestamp."""
+    assert kc._fmt_ts("2026-08-04T21:05:15.679975") == "2026-08-04 21:05"
+    assert kc._fmt_ts("2026-08-04 21:05:15") == "2026-08-04 21:05"
+    assert kc._fmt_ts("1785902715") == "2026-08-04 21:05"
+    assert kc._fmt_ts(1785902715) == "2026-08-04 21:05"
+    assert kc._fmt_ts(None) == ""
+    assert kc._fmt_ts(0) == ""
+
+
 def test_kanban_list_json_includes_session_id(kanban_home):
     """JSON output exposes `session_id` so external clients (Scarf, web
     dashboards) don't need a side query to filter by chat session."""

--- a/tests/hermes_cli/test_kanban_cli.py
+++ b/tests/hermes_cli/test_kanban_cli.py
@@ -6,6 +6,7 @@ import argparse
 import json
 import os
 import threading
+import time
 from pathlib import Path
 
 import pytest
@@ -49,6 +50,18 @@ def test_fmt_ts_tolerates_string_timestamps():
     assert kc._fmt_ts(1785902715) == "2026-08-04 21:05"
     assert kc._fmt_ts(None) == ""
     assert kc._fmt_ts(0) == ""
+
+
+def test_fmt_ts_does_not_misparse_compact_or_short_strings():
+    """Only purely-numeric strings are treated as epochs; compact-ISO and
+    short/odd strings fall through to the ISO branch instead of rendering a
+    wrong year."""
+    # Compact ISO without separators must NOT be parsed as an epoch.
+    assert kc._fmt_ts("20260804T210515") == "20260804 210515"
+    # A short numeric epoch (pre-2001) is still a valid epoch -> a date.
+    assert kc._fmt_ts("987654321") == time.strftime(
+        "%Y-%m-%d %H:%M", time.localtime(987654321)
+    )
 
 
 def test_kanban_list_json_includes_session_id(kanban_home):


### PR DESCRIPTION
## What

`hermes kanban show` crashes with `TypeError: 'str' object cannot be interpreted as an integer` when a task's `completed_at` (or `started_at`) is stored as a string.

A worker can write `completed_at` as an ISO-8601 datetime string (e.g. `'2026-08-04T21:05:15.679975'`) or an epoch encoded as a str. The DB column is INTEGER-typed, but upstream already anticipates string timestamps flowing through the codebase — `_to_epoch` in `kanban_db.py` explicitly accepts ISO-8601 and numeric strings. The display layer `_fmt_ts`, however, only accepts `int`, so a string reaching it crashes the `show` command.

## Change

Widen `_fmt_ts` to accept `str | int`, render ISO-8601 and epoch-as-str timestamps the same as ints, and add a regression test covering the crash input and related shapes (ISO string, space-separated string, epoch-as-str, int, `None`, `0`).

## Test

`pytest tests/hermes_cli/test_kanban_cli.py -q` — 5 passed, including the new `test_fmt_ts_tolerates_string_timestamps`.