### PR TITLE
fix(desktop): focus & composer usability rollup (salvages #84026, #85736, #84992, #84032, #85734)

### DIFF
--- a/apps/desktop/electron/session-windows.test.ts
+++ b/apps/desktop/electron/session-windows.test.ts
@@ -203,6 +203,22 @@ test('chatWindowWebPreferences leaves background throttling to the runtime strea
   assert.equal('backgroundThrottling' in prefs, false)
 })
 
+test('chat renderer navigation stays passive while explicit window actions may focus', () => {
+  const prefs = chatWindowWebPreferences('/tmp/preload.cjs')
+
+  // In-page/SPA navigation can happen while a transcript keeps streaming. It
+  // must not use Electron's default navigation focus path to activate Hermes.
+  assert.equal(prefs.focusOnNavigation, false)
+
+  // Re-opening a session is an explicit user action and must still raise the
+  // existing window; the passive navigation guard does not disable that path.
+  const registry = createSessionWindowRegistry()
+  const win = makeFakeWindow()
+  registry.openOrFocus('s1', () => win)
+  registry.openOrFocus('s1', () => win)
+  assert.equal(win.calls.focus, 1)
+})
+
 test('chatWindowWebPreferences passes the preload path through and keeps the hardened defaults', () => {
   const prefs = chatWindowWebPreferences('/some/preload.cjs')
 

--- a/apps/desktop/electron/session-windows.ts
+++ b/apps/desktop/electron/session-windows.ts
@@ -37,6 +37,12 @@ const SESSION_WINDOW_MIN_HEIGHT = 620
 // session is silent" bug. Manual voice-start worked only because the button
 // click counted as the gesture. This is a native app the user deliberately
 // launched; there is no drive-by-autoplay concern to protect against.
+//
+// `focusOnNavigation: false` keeps renderer-driven work passive. Electron's
+// default is true, so an in-page/SPA navigation can activate a blurred chat
+// window while its transcript is streaming. Explicit user actions still call
+// the main-process window focus paths (session re-open, notification/deep-link,
+// app activation), preserving intentional raises without background focus theft.
 function chatWindowWebPreferences(preloadPath: string) {
   return {
     preload: preloadPath,
@@ -45,7 +51,8 @@ function chatWindowWebPreferences(preloadPath: string) {
     sandbox: true,
     nodeIntegration: false,
     devTools: true,
-    autoplayPolicy: 'no-user-gesture-required' as const
+    autoplayPolicy: 'no-user-gesture-required' as const,
+    focusOnNavigation: false
   }
 }
 

--- a/apps/desktop/src/app/chat/composer/trigger-popover.test.tsx
+++ b/apps/desktop/src/app/chat/composer/trigger-popover.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, render, screen } from '@testing-library/react'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { I18nProvider } from '@/i18n'
@@ -25,11 +25,44 @@ function renderPopover(kind: '@' | '/', loading = false) {
   return { ...rendered, onHover, onPick }
 }
 
-describe('ComposerTriggerPopover i18n', () => {
-  afterEach(() => {
-    cleanup()
-  })
+function slashItem(command: string) {
+  return {
+    id: command,
+    type: 'slash',
+    label: command.slice(1),
+    metadata: { command, display: command, group: 'Skills', meta: '', rawText: command }
+  }
+}
 
+function rect(top: number, bottom: number): DOMRect {
+  return {
+    bottom,
+    height: bottom - top,
+    left: 0,
+    right: 320,
+    toJSON: () => ({}),
+    top,
+    width: 320,
+    x: 0,
+    y: top
+  }
+}
+
+function mockDrawerViewport(drawer: HTMLElement) {
+  Object.defineProperty(drawer, 'clientHeight', { configurable: true, value: 200 })
+  Object.defineProperty(drawer, 'clientTop', { configurable: true, value: 1 })
+  vi.spyOn(drawer, 'getBoundingClientRect').mockReturnValue(rect(100, 302))
+}
+
+function mockRowPosition(row: HTMLElement, top: number, bottom: number) {
+  return vi.spyOn(row, 'getBoundingClientRect').mockReturnValue(rect(top, bottom))
+}
+
+afterEach(() => {
+  cleanup()
+})
+
+describe('ComposerTriggerPopover i18n', () => {
   it('renders localized empty lookup copy for @ references', () => {
     const { container } = renderPopover('@')
 
@@ -53,5 +86,117 @@ describe('ComposerTriggerPopover i18n', () => {
 
     expect(screen.getByText('没有匹配项。')).toBeTruthy()
     expect(container.textContent).toContain('/help')
+  })
+})
+
+describe('ComposerTriggerPopover keyboard scrolling', () => {
+  const items = [slashItem('/first'), slashItem('/second'), slashItem('/third')]
+
+  function popover(activeIndex: number, onHover = vi.fn(), nextItems = items) {
+    return (
+      <I18nProvider configClient={null} initialLocale="en">
+        <ComposerTriggerPopover
+          activeIndex={activeIndex}
+          items={nextItems}
+          kind="/"
+          loading={false}
+          onHover={onHover}
+          onPick={vi.fn()}
+        />
+      </I18nProvider>
+    )
+  }
+
+  it('keeps keyboard navigation visible and restores the group header on wrap', () => {
+    const { container, rerender } = render(popover(0))
+    const drawer = container.querySelector('[data-slot="composer-completion-drawer"]') as HTMLElement
+    const ancestor = drawer.parentElement as HTMLElement
+    const secondRow = screen.getAllByRole('button')[1]
+
+    mockDrawerViewport(drawer)
+    mockRowPosition(secondRow, 290, 330)
+    ancestor.scrollTop = 48
+    drawer.scrollTop = 96
+    rerender(popover(1))
+
+    const activeRow = container.querySelector('[data-highlighted]') as HTMLElement
+
+    expect(activeRow.textContent).toContain('/second')
+    expect(drawer.scrollTop).toBe(125)
+    expect(ancestor.scrollTop).toBe(48)
+
+    drawer.scrollTop = 96
+    rerender(popover(0))
+
+    expect(drawer.scrollTop).toBe(0)
+  })
+
+  it('uses the nearest drawer edge for upward, visible, and oversized rows', () => {
+    const { container, rerender } = render(popover(0))
+    const drawer = container.querySelector('[data-slot="composer-completion-drawer"]') as HTMLElement
+    const rows = screen.getAllByRole('button')
+
+    mockDrawerViewport(drawer)
+    mockRowPosition(rows[1], 80, 120)
+    const thirdRowRect = mockRowPosition(rows[2], 150, 180)
+
+    drawer.scrollTop = 50
+    rerender(popover(1))
+    expect(drawer.scrollTop).toBe(29)
+
+    rerender(popover(2))
+    expect(drawer.scrollTop).toBe(29)
+
+    thirdRowRect.mockReturnValue(rect(80, 340))
+    drawer.scrollTop = 50
+    rerender(popover(2, vi.fn(), [...items]))
+    expect(drawer.scrollTop).toBe(50)
+
+    thirdRowRect.mockReturnValue(rect(150, 400))
+    rerender(popover(2, vi.fn(), [...items, slashItem('/fourth')]))
+    expect(drawer.scrollTop).toBe(99)
+
+    thirdRowRect.mockReturnValue(rect(0, 250))
+    drawer.scrollTop = 100
+    rerender(popover(2, vi.fn(), [...items, slashItem('/fifth')]))
+    expect(drawer.scrollTop).toBe(49)
+  })
+
+  it('does not scroll for a hover echo and consumes the hover marker', () => {
+    const onHover = vi.fn()
+    const { container, rerender } = render(popover(0, onHover))
+    const rows = screen.getAllByRole('button')
+    const drawer = container.querySelector('[data-slot="composer-completion-drawer"]') as HTMLElement
+
+    mockDrawerViewport(drawer)
+    mockRowPosition(rows[2], 311, 331)
+    drawer.scrollTop = 40
+    fireEvent.mouseEnter(rows[2])
+    expect(onHover).toHaveBeenCalledWith(2)
+
+    rerender(popover(2, onHover))
+    expect(drawer.scrollTop).toBe(40)
+
+    rerender(popover(0, onHover))
+    rerender(popover(2, onHover))
+
+    expect(drawer.scrollTop).toBe(30)
+    expect((container.querySelector('[data-highlighted]') as HTMLElement).textContent).toContain('/third')
+  })
+
+  it('does not leave a stale hover marker when the active row is hovered', () => {
+    const onHover = vi.fn()
+    const { container, rerender } = render(popover(1, onHover))
+    const drawer = container.querySelector('[data-slot="composer-completion-drawer"]') as HTMLElement
+    const activeRow = screen.getAllByRole('button')[1]
+
+    mockDrawerViewport(drawer)
+    mockRowPosition(activeRow, 311, 331)
+    fireEvent.mouseEnter(activeRow)
+    expect(onHover).toHaveBeenCalledWith(1)
+
+    rerender(popover(1, onHover, [...items, slashItem('/fourth')]))
+
+    expect(drawer.scrollTop).toBe(30)
   })
 })

--- a/apps/desktop/src/app/chat/composer/trigger-popover.tsx
+++ b/apps/desktop/src/app/chat/composer/trigger-popover.tsx
@@ -1,5 +1,5 @@
 import type { Unstable_TriggerItem } from '@assistant-ui/core'
-import { Fragment } from 'react'
+import { Fragment, useEffect, useRef } from 'react'
 
 import { referenceKind, referenceStyle } from '@/components/assistant-ui/reference-kinds'
 import { Codicon } from '@/components/ui/codicon'
@@ -91,6 +91,62 @@ export function ComposerTriggerPopover({
   const copy = t.composer
   const isSlash = kind === '/'
   const isEmoji = kind === ':'
+  const listRef = useRef<HTMLDivElement>(null)
+  const hoverIndexRef = useRef(-1)
+
+  // Only keyboard navigation should move the drawer. A hover echo already points
+  // at a visible row and scrolling it can shift another row under the pointer.
+  // eslint-disable-next-line no-restricted-syntax -- legitimate non-atom ref write (see eslint rule comment)
+  useEffect(() => {
+    const list = listRef.current
+
+    if (!list) {
+      return
+    }
+
+    const isHoverEcho = activeIndex === hoverIndexRef.current
+
+    hoverIndexRef.current = -1
+
+    if (isHoverEcho) {
+      return
+    }
+
+    if (activeIndex === 0) {
+      // `nearest` keeps the first row visible but can leave its group header
+      // clipped, so wrapping to the beginning restores the complete top edge.
+      list.scrollTop = 0
+
+      return
+    }
+
+    const highlighted = list.querySelector<HTMLElement>('[data-highlighted]')
+
+    if (!highlighted) {
+      return
+    }
+
+    // Keep scrolling local to the drawer. `scrollIntoView` may also move the
+    // transcript or window because it operates on every scrollable ancestor.
+    const listRect = list.getBoundingClientRect()
+    const highlightedRect = highlighted.getBoundingClientRect()
+    const visibleTop = listRect.top + list.clientTop
+    const visibleBottom = visibleTop + list.clientHeight
+    const topDelta = highlightedRect.top - visibleTop
+    const bottomDelta = highlightedRect.bottom - visibleBottom
+    const overflowsTop = topDelta < 0
+    const overflowsBottom = bottomDelta > 0
+
+    // A row that is fully visible needs no movement. An oversized row that
+    // spans both edges already covers the viewport, so moving it would not
+    // reveal the whole row and would only add churn. Otherwise align whichever
+    // edge requires the shorter movement, matching `block: nearest` semantics.
+    if (overflowsTop === overflowsBottom) {
+      return
+    }
+
+    list.scrollTop += Math.abs(topDelta) < Math.abs(bottomDelta) ? topDelta : bottomDelta
+  }, [activeIndex, items])
 
   let lastGroup: string | undefined
 
@@ -100,6 +156,7 @@ export function ComposerTriggerPopover({
       data-slot="composer-completion-drawer"
       data-state="open"
       onMouseDown={event => event.preventDefault()}
+      ref={listRef}
       role="listbox"
     >
       {scope && <div className={cn(GROUP_HEADER_CLASS, 'pt-0.5')}>{referenceStyle(scope).label}</div>}
@@ -146,7 +203,12 @@ export function ComposerTriggerPopover({
                 className={ROW_CLASS}
                 data-highlighted={active ? '' : undefined}
                 onClick={() => onPick(item)}
-                onMouseEnter={() => onHover(index)}
+                onMouseEnter={() => {
+                  // React bails out when hovering the already-active row. Do
+                  // not leave a marker behind for a later items refresh.
+                  hoverIndexRef.current = index === activeIndex ? -1 : index
+                  onHover(index)
+                }}
                 type="button"
               >
                 {isEmoji ? (

--- a/apps/desktop/src/app/hooks/use-keybinds.ts
+++ b/apps/desktop/src/app/hooks/use-keybinds.ts
@@ -15,7 +15,7 @@ import {
 import { onReleaseTypingFocus } from '@/components/ui/keyboard-first'
 import { findBarClaimsCombo } from '@/lib/find-in-page'
 import { contributedKeybindHandler, PROFILE_SLOT_COUNT, SESSION_SLOT_COUNT } from '@/lib/keybinds/actions'
-import { comboAllowedInInput, comboFromEvent, isEditableTarget } from '@/lib/keybinds/combo'
+import { actionAllowedInInput, comboFromEvent, isEditableTarget } from '@/lib/keybinds/combo'
 import { composerFocusKeysAllowed, isComposerFocusSoftCombo, typeToFocusChar } from '@/lib/keybinds/composer-focus-keys'
 import { openWorktreeDialog } from '@/store/coding-status'
 import { toggleCommandPalette } from '@/store/command-palette'
@@ -358,7 +358,7 @@ export function useKeybinds(deps: KeybindRuntimeDeps): void {
         return
       }
 
-      if (isEditableTarget(event.target) && !comboAllowedInInput(combo)) {
+      if (isEditableTarget(event.target) && !actionAllowedInInput(actionId, combo)) {
         return
       }
 

--- a/apps/desktop/src/app/hud/click-through.test.ts
+++ b/apps/desktop/src/app/hud/click-through.test.ts
@@ -14,6 +14,7 @@ function hud() {
   shell.setAttribute('data-hud-shell', '')
 
   const bar = document.createElement('input')
+  bar.setAttribute('data-slot', 'composer-rich-input')
 
   const overlay = document.createElement('div')
   overlay.setAttribute('role', 'dialog')
@@ -45,10 +46,23 @@ describe('hudIgnoresMouse', () => {
     expect(hudIgnoresMouse(shell, overlay, null, true)).toBe(false)
   })
 
-  it('does not pin the window just because the composer holds the caret', () => {
+  it('keeps the native HUD window solid while the composer holds the caret', () => {
     const { bar, mount, shell } = hud()
 
-    expect(hudIgnoresMouse(shell, mount, bar, true)).toBe(true)
+    // On Windows, making the native window click-through while its editor owns
+    // focus can immediately hand the mouse activation back to the app below.
+    // The caret then flashes, focus leaves, and the transcript collapses before
+    // the user can read it.
+    expect(hudIgnoresMouse(shell, mount, bar, true)).toBe(false)
+  })
+
+  it('keeps the native HUD window solid while focus is inside the composer editor', () => {
+    const { bar, mount, shell } = hud()
+    const editable = document.createElement('span')
+    editable.contentEditable = 'true'
+    bar.append(editable)
+
+    expect(hudIgnoresMouse(shell, mount, editable, true)).toBe(false)
   })
 
   it('pins the window while a portalled overlay holds focus, so an outside click can dismiss it', () => {

--- a/apps/desktop/src/app/hud/click-through.ts
+++ b/apps/desktop/src/app/hud/click-through.ts
@@ -15,10 +15,10 @@ import { type RefObject, useEffect } from 'react'
  * - Focus BESIDE the shell is a portalled dialog, popover or menu, and it owns
  *   the next click — including the one outside itself that dismisses it, which
  *   the hit test cannot see coming. That pins the window solid.
- * - Focus INSIDE the shell does not. The composer holding the caret is the
- *   HUD's resting state rather than a claim on the whole rectangle, and reading
- *   it as one is what made an engaged HUD eat every click in its own empty
- *   space — on a fresh thread, the entire window.
+ * - Focus INSIDE the shell is normally the HUD's resting state — except for
+ *   the composer caret. On Windows the native window must stay solid while the
+ *   editor owns focus: making it click-through can immediately reactivate the
+ *   application underneath, steal the caret, and collapse the transcript.
  */
 export function hudIgnoresMouse(
   root: Element,
@@ -34,11 +34,16 @@ export function hudIgnoresMouse(
   }
 
   const overSomething = hit !== null && !hit.contains(root)
-  // `windowFocused` is what stops a stale `active` — the composer keeps focus
-  // after you click away to another app — pinning the HUD solid forever.
+
+  const composerFocused =
+    windowFocused &&
+    active !== null &&
+    root.contains(active) &&
+    active.closest('[data-slot="composer-rich-input"]') !== null
+
   const overlayFocused = windowFocused && active !== null && !root.contains(active) && !active.contains(root)
 
-  return !overSomething && !overlayFocused
+  return !composerFocused && !overSomething && !overlayFocused
 }
 
 /**

--- a/apps/desktop/src/app/hud/hud-shell.tsx
+++ b/apps/desktop/src/app/hud/hud-shell.tsx
@@ -18,6 +18,7 @@ import { titlebarButtonClass } from '../shell/titlebar'
 import { useHudClickThrough } from './click-through'
 import { useHudGlass } from './glass'
 import { useHudGoto, useReportHudSession } from './handoff'
+import { hudTranscriptHeight } from './layout'
 import { useHudResizeHandle } from './resize-handle'
 import { useHudThreadFocus } from './thread-focus'
 
@@ -47,15 +48,6 @@ const HUD_COLLAPSE_MS = Math.round(HUD_FADE_MS * 0.66)
  *  somewhere to land. Folded into the measured height rather than added in CSS,
  *  so an empty transcript measures a true zero instead of a 12px strip. */
 const HUD_SHEET_OVERHANG_PX = 12
-
-/** Ceiling on the transcript band, which still auto-sizes up from 0. It reads
- *  over another app, so it is a glance rather than a panel: whichever of these
- *  is smaller wins, so a tall HUD doesn't turn the band into a second window
- *  and a short one doesn't get swallowed by it. */
-const HUD_BAND_MAX_PX = 152
-const HUD_BAND_MAX_FRACTION = 0.42
-
-const hudBandMaxPx = () => Math.min(window.innerHeight * HUD_BAND_MAX_FRACTION, HUD_BAND_MAX_PX)
 
 /** Composer on top, transcript always hanging below it — Spotlight's shape,
  *  rather than flipping to follow the screen edge the HUD is parked against. */
@@ -302,7 +294,14 @@ export function HudShell() {
 
       const contentSpan = text < 1 ? 0 : text + HUD_SHEET_OVERHANG_PX
 
-      const visible = Math.min(hudBandMaxPx(), Math.max(0, Math.round(contentSpan)))
+      // Once the HUD has a transcript, a resize must buy readable scrollback.
+      // The old glance-band ceiling froze this at 152px and turned every extra
+      // pixel of native window height into empty transparent chrome.
+      const visible = hudTranscriptHeight({
+        barHeight: root.querySelector<HTMLElement>('[data-slot="composer-dock"]')?.getBoundingClientRect().height ?? 0,
+        contentHeight: contentSpan,
+        viewportHeight: window.innerHeight
+      })
 
       root.style.setProperty('--hud-band-height', `${visible}px`)
 
@@ -323,12 +322,16 @@ export function HudShell() {
     }
 
     // The viewport mounts async (lazy chat surface); poll briefly until it
-    // exists, then let the ResizeObserver own it.
+    // exists, then let the ResizeObserver own it. Window resize is separate:
+    // the transcript's rows may not change size, but the available scrollback
+    // must, so observing the rows alone cannot update the band.
     measure()
     const probe = setInterval(measure, 500)
+    window.addEventListener('resize', measure)
 
     return () => {
       clearInterval(probe)
+      window.removeEventListener('resize', measure)
       ro.disconnect()
     }
   }, [])

--- a/apps/desktop/src/app/hud/layout.test.ts
+++ b/apps/desktop/src/app/hud/layout.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest'
+
+import { hudTranscriptHeight } from './layout'
+
+describe('hudTranscriptHeight', () => {
+  it('uses the resized window space for a non-empty transcript', () => {
+    // The transcript is intentionally not constrained to its content height:
+    // resizing HUD must reveal more scrollback instead of growing an empty
+    // transparent window below a fixed-height chat band.
+    expect(
+      hudTranscriptHeight({
+        barHeight: 58,
+        contentHeight: 72,
+        viewportHeight: 640
+      })
+    ).toBe(582)
+  })
+
+  it('keeps an empty HUD collapsed', () => {
+    expect(hudTranscriptHeight({ barHeight: 58, contentHeight: 0, viewportHeight: 640 })).toBe(0)
+  })
+})

--- a/apps/desktop/src/app/hud/layout.ts
+++ b/apps/desktop/src/app/hud/layout.ts
@@ -1,0 +1,22 @@
+export interface HudTranscriptHeightInput {
+  /** Measured message rows, including the HUD sheet overhang. */
+  contentHeight: number
+  /** The composer's measured height. */
+  barHeight: number
+  /** The HUD window's current inner height. */
+  viewportHeight: number
+}
+
+/**
+ * The HUD transcript owns all available space after the composer once there is
+ * something to show. A resizable HUD must expose more scrollback as it grows;
+ * sizing the band to its message rows instead leaves a larger empty native
+ * window around the same fixed-height transcript.
+ */
+export function hudTranscriptHeight({ barHeight, contentHeight, viewportHeight }: HudTranscriptHeightInput): number {
+  if (contentHeight < 1) {
+    return 0
+  }
+
+  return Math.max(0, Math.round(viewportHeight - barHeight))
+}

--- a/apps/desktop/src/components/find-bar.test.tsx
+++ b/apps/desktop/src/components/find-bar.test.tsx
@@ -8,7 +8,7 @@ import { en } from '@/i18n/en'
 import { zh } from '@/i18n/zh'
 import { findBarClaimsCombo, findBarKeyAction, formatMatchLabel } from '@/lib/find-in-page'
 import { KEYBIND_ACTIONS } from '@/lib/keybinds/actions'
-import { comboAllowedInInput } from '@/lib/keybinds/combo'
+import { actionAllowedInInput } from '@/lib/keybinds/combo'
 import {
   $findInPage,
   closeFindBar,
@@ -202,10 +202,9 @@ describe('find-in-page keybind registration', () => {
   })
 
   it('mod+f fires from inside a textarea (browser find behavior)', () => {
-    // The runtime consults comboAllowedInInput before dispatching a combo
-    // while an editable element owns focus; if mod combos ever stop
-    // qualifying, ⌘F from the composer would type 'f' instead of opening find.
-    expect(comboAllowedInInput('mod+f')).toBe(true)
+    // The runtime consults actionAllowedInInput before dispatching while an
+    // editable element owns focus; ⌘F should still open find from the composer.
+    expect(actionAllowedInInput('view.findInPage', 'mod+f')).toBe(true)
   })
 
   it('registers the step pair unbound so it cannot conflict with view.toggleReview', () => {

--- a/apps/desktop/src/lib/keybinds/actions.ts
+++ b/apps/desktop/src/lib/keybinds/actions.ts
@@ -140,7 +140,7 @@ export const KEYBIND_ACTIONS: readonly KeybindActionMeta[] = [
   // is a no-op. ⌘⇧T reopens the last closed tab where it was.
   { id: 'view.closeTab', category: 'view', defaults: ['mod+w'] },
   { id: 'view.reopenTab', category: 'view', defaults: ['mod+shift+t'] },
-  // ⌘F — open the find-in-page bar. `comboAllowedInInput` lets the combo
+  // ⌘F — open the find-in-page bar. `actionAllowedInInput` lets this action
   // fire from inside a textarea / contenteditable (matches browser behavior
   // so typing in the composer and pressing ⌘F focuses find, not 'f').
   { id: 'view.findInPage', category: 'view', defaults: ['mod+f'] },

--- a/apps/desktop/src/lib/keybinds/combo.test.ts
+++ b/apps/desktop/src/lib/keybinds/combo.test.ts
@@ -118,13 +118,25 @@ describe('formatCombo — honest Control labels', () => {
   })
 })
 
-describe('comboAllowedInInput', () => {
-  it('lets ctrl combos fire while typing (e.g. ⌃Tab from the composer)', async () => {
-    const { comboAllowedInInput } = await loadCombo('MacIntel')
+describe('actionAllowedInInput', () => {
+  it('keeps only explicit text-entry-safe global actions active while typing', async () => {
+    const { actionAllowedInInput } = await loadCombo('MacIntel')
 
-    expect(comboAllowedInInput('ctrl+tab')).toBe(true)
-    expect(comboAllowedInInput('ctrl+shift+tab')).toBe(true)
-    expect(comboAllowedInInput('mod+k')).toBe(true)
-    expect(comboAllowedInInput('shift+x')).toBe(false)
+    expect(actionAllowedInInput('session.next', 'ctrl+tab')).toBe(true)
+    expect(actionAllowedInInput('session.prev', 'ctrl+shift+tab')).toBe(true)
+    expect(actionAllowedInInput('nav.commandPalette', 'mod+k')).toBe(true)
+    expect(actionAllowedInInput('view.findInPage', 'mod+f')).toBe(true)
+    expect(actionAllowedInInput('nav.skills', 'mod+k')).toBe(false)
+    expect(actionAllowedInInput('view.showTerminal', 'ctrl+`')).toBe(false)
+    expect(actionAllowedInInput('profile.next', 'mod+shift+]')).toBe(false)
+  })
+
+  it('leaves text navigation chords with the focused input even when rebound to an allowed action', async () => {
+    const { actionAllowedInInput } = await loadCombo('Win32')
+
+    expect(actionAllowedInInput('session.next', 'mod+right')).toBe(false)
+    expect(actionAllowedInInput('session.prev', 'mod+left')).toBe(false)
+    expect(actionAllowedInInput('nav.commandPalette', 'mod+pageup')).toBe(false)
+    expect(actionAllowedInInput('view.findInPage', 'mod+end')).toBe(false)
   })
 })

--- a/apps/desktop/src/lib/keybinds/combo.ts
+++ b/apps/desktop/src/lib/keybinds/combo.ts
@@ -223,8 +223,27 @@ export function isEditableTarget(target: EventTarget | null): boolean {
   )
 }
 
-// A primary modifier (Cmd/Ctrl/Control) fires even while typing (e.g. ⌘K or
-// ⌃Tab from the composer); bare/Shift-only combos are suppressed in inputs.
-export function comboAllowedInInput(combo: string): boolean {
-  return /^(?:mod|ctrl)(?:\+|$)/.test(combo)
+const INPUT_SAFE_ACTIONS = new Set([
+  'composer.modelPicker',
+  'composer.voice',
+  'keybinds.openPanel',
+  'nav.commandPalette',
+  'session.next',
+  'session.prev',
+  'view.findInPage'
+])
+
+const TEXT_NAVIGATION_KEYS = new Set(['up', 'down', 'left', 'right', 'home', 'end', 'pageup', 'pagedown'])
+
+// Only explicit text-entry-safe actions fire while typing. Editing/navigation
+// chords such as Ctrl+Arrow/PageUp must stay with the input even if a user
+// rebinds them to a global navigation action.
+export function actionAllowedInInput(actionId: string, combo: string): boolean {
+  const base = combo.split('+').pop()
+
+  if (base && TEXT_NAVIGATION_KEYS.has(base)) {
+    return false
+  }
+
+  return INPUT_SAFE_ACTIONS.has(actionId)
 }


### PR DESCRIPTION
## Summary

Themed salvage rollup of five small Desktop (renderer/Electron) focus & composer usability fixes from three external contributors. Each fix is cherry-picked as its own commit with original authorship preserved.

| Original PR | Fix | Contributor |
|---|---|---|
| #84026 | fix(desktop): prevent navigation from stealing focus | @frizikk |
| #85736 | fix(desktop): retain HUD composer focus | @LemonSchneid |
| #84992 | fix(desktop): keep text navigation keys in composer | @nanami7777777 |
| #84032 | fix(desktop): keep completion selection visible | @frizikk |
| #85734 | fix(desktop): expand HUD transcript when resized | @LemonSchneid |

All five verified against current `origin/main` (cb47f59ffa): none redundant, all cherry-picked cleanly with zero conflicts. No exclusions.

## What each fix does

- **Prevent navigation from stealing focus** (`electron/session-windows.ts`) — in-app navigation no longer yanks keyboard focus away from the composer.
- **Retain HUD composer focus** (`src/app/hud/click-through.ts`) — HUD click-through handling keeps the composer focused instead of dropping it.
- **Keep text navigation keys in composer** (`src/lib/keybinds/combo.ts`, `actions.ts`) — Home/End/arrow-style text-navigation keys stay in the composer instead of triggering global keybinds.
- **Keep completion selection visible** (`src/app/chat/composer/trigger-popover.tsx`) — the selected row in the completion popover scrolls into view and stays visible.
- **Expand HUD transcript when resized** (`src/app/hud/hud-shell.tsx`, `layout.ts`) — resizing the HUD expands the transcript area instead of leaving dead space.

## Testing

Targeted vitest run over every touched component (`apps/desktop`):

```
npx vitest run electron/session-windows.test.ts src/app/hud/click-through.test.ts \
  src/components/find-bar.test.tsx src/lib/keybinds/combo.test.ts \
  src/app/chat/composer/trigger-popover.test.tsx src/app/hud/layout.test.ts

Test Files  6 passed (6)
Tests       96 passed (96)
```

`python3 scripts/audit_pr_attribution.py --fix` — all contributor emails mapped, no changes needed.

## Credit

Thanks to @frizikk, @LemonSchneid, and @nanami7777777 — authorship preserved per commit for a rebase merge.

## Infographic

![desktop-focus-composer](https://gist.githubusercontent.com/teknium1/67f64962783d070d464e875d1c29d5ea/raw/infographic-desktop-focus-composer.png)
