### PR TITLE
fix(desktop): salvage duplicate/lost assistant reply stream cluster (#84296, #76583, #82843, #86299)

### DIFF
--- a/apps/desktop/src/app/contrib/hooks/use-background-sync.test.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-background-sync.test.ts
@@ -205,7 +205,7 @@ describe('active transcript refresh', () => {
     await waitFor(() => expect(refresh).toHaveBeenCalledTimes(1))
   })
 
-  it('coalesces a burst of global ticks, including writes for another session', async () => {
+  it('coalesces a burst of global session-change ticks', async () => {
     vi.useFakeTimers()
     $changeEventsAvailable.set(true)
     const refresh = vi.fn(async () => undefined)
@@ -220,7 +220,7 @@ describe('active transcript refresh', () => {
     expect(refresh).toHaveBeenCalledTimes(1)
 
     await act(async () => {
-      vi.advanceTimersByTime(10_000)
+      vi.advanceTimersByTime(9_999)
       await Promise.resolve()
     })
 

--- a/apps/desktop/src/app/contrib/hooks/use-background-sync.test.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-background-sync.test.ts
@@ -1,5 +1,9 @@
+import { act, cleanup, renderHook, waitFor } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { createClientSessionState } from '@/lib/chat-runtime'
+import { $changeEventsAvailable, notifySessionsChanged, resetLiveSync } from '@/store/live-sync'
+import { $activeSessionId, $selectedStoredSessionId, setBusy, setMessagingSessions, setSessions } from '@/store/session'
 import {
   $attentionSessionIds,
   $stalledSessionIds,
@@ -8,19 +12,300 @@ import {
   SESSION_WATCHDOG_TIMEOUT_MS
 } from '@/store/session-states'
 
-import { rehydrateLiveSessionStatuses } from './use-background-sync'
+import {
+  type ActiveTranscriptRefreshDeps,
+  reconcileActiveTranscript,
+  rehydrateLiveSessionStatuses,
+  resolveActiveTranscriptSession,
+  useBackgroundSync
+} from './use-background-sync'
+
+vi.mock('@/hermes', async importOriginal => ({
+  ...(await importOriginal()),
+  getLatestSessionMessages: vi.fn()
+}))
+
+const { getLatestSessionMessages } = await import('@/hermes')
+
+const ACTIVE_RUNTIME_ID = 'runtime-active'
+const ACTIVE_STORED_ID = 'stored-active'
+
+function transcript(answer: string) {
+  return {
+    messages: [
+      { content: 'question', role: 'user', timestamp: 1 },
+      { content: answer, role: 'assistant', timestamp: 2 }
+    ],
+    session_id: ACTIVE_STORED_ID
+  }
+}
+
+function makeRefresh(resolveSession: ActiveTranscriptRefreshDeps['resolveSession'] = () => ({ profile: 'default' })) {
+  const activeSessionIdRef = { current: ACTIVE_RUNTIME_ID as string | null }
+  const selectedStoredSessionIdRef = { current: ACTIVE_STORED_ID as string | null }
+  const busyRef = { current: false }
+  const requestSequenceRef = { current: 0 }
+  const signatureRef = { current: new Map<string, string>() }
+  const state = createClientSessionState(ACTIVE_STORED_ID)
+  const states = new Map([[ACTIVE_RUNTIME_ID, state]])
+
+  const updateSessionState = vi.fn((sessionId: string, updater: (value: typeof state) => typeof state) => {
+    const next = updater(states.get(sessionId) ?? createClientSessionState(ACTIVE_STORED_ID))
+    states.set(sessionId, next)
+
+    return next
+  })
+
+  const refresh = () =>
+    reconcileActiveTranscript({
+      activeSessionIdRef,
+      busyRef,
+      requestSequenceRef,
+      resolveSession,
+      selectedStoredSessionIdRef,
+      signatureRef,
+      updateSessionState
+    })
+
+  return { activeSessionIdRef, busyRef, refresh, selectedStoredSessionIdRef, state, states, updateSessionState }
+}
+
+function useSyncHarness({
+  activeIsMessaging = false,
+  activeSessionId,
+  activeStoredSessionId,
+  refreshActiveTranscript
+}: {
+  activeIsMessaging?: boolean
+  activeSessionId: string | null
+  activeStoredSessionId: string | null
+  refreshActiveTranscript: () => Promise<void>
+}) {
+  useBackgroundSync({
+    activeGatewayProfile: 'default',
+    activeIsMessaging,
+    activeSessionId,
+    activeStoredSessionId,
+    freshDraftReady: false,
+    gatewayState: 'open',
+    refreshActiveTranscript,
+    refreshCronJobs: vi.fn(),
+    refreshCurrentModel: vi.fn(),
+    refreshHermesConfig: vi.fn(),
+    refreshMessagingSessions: vi.fn(),
+    refreshSessions: vi.fn(),
+    requestGateway: vi.fn(async () => ({ sessions: [] })) as never
+  })
+}
+
+function renderSync(
+  refreshActiveTranscript: () => Promise<void>,
+  options: { activeIsMessaging?: boolean; activeSessionId?: null | string; activeStoredSessionId?: null | string } = {}
+) {
+  return renderHook(() =>
+    useSyncHarness({
+      activeSessionId: ACTIVE_RUNTIME_ID,
+      activeStoredSessionId: ACTIVE_STORED_ID,
+      refreshActiveTranscript,
+      ...options
+    })
+  )
+}
+
+afterEach(() => {
+  cleanup()
+  vi.clearAllTimers()
+  vi.useRealTimers()
+  resetLiveSync()
+  $activeSessionId.set(null)
+  $selectedStoredSessionId.set(null)
+  setSessions([])
+  setMessagingSessions([])
+  setBusy(false)
+  vi.clearAllMocks()
+  clearAllSessionStates()
+})
+
+describe('active transcript refresh', () => {
+  beforeEach(() => {
+    vi.mocked(getLatestSessionMessages).mockResolvedValue(transcript('answer') as never)
+  })
+
+  it('refreshes a local/Desktop session when sessions.changed ticks', async () => {
+    $changeEventsAvailable.set(true)
+    $activeSessionId.set(ACTIVE_RUNTIME_ID)
+    $selectedStoredSessionId.set(ACTIVE_STORED_ID)
+    setSessions([{ id: ACTIVE_STORED_ID, profile: 'desktop-profile', source: 'desktop' } as never])
+    const fixture = makeRefresh(resolveActiveTranscriptSession)
+    vi.mocked(getLatestSessionMessages).mockResolvedValue(transcript('external answer') as never)
+
+    renderSync(fixture.refresh)
+
+    act(() => notifySessionsChanged())
+
+    await waitFor(() =>
+      expect(fixture.states.get(ACTIVE_RUNTIME_ID)?.messages.at(-1)?.parts[0]).toMatchObject({
+        text: 'external answer'
+      })
+    )
+  })
+
+  it('does not add a periodic transcript poll to local/Desktop sessions', async () => {
+    vi.useFakeTimers()
+    $changeEventsAvailable.set(true)
+    const refresh = vi.fn(async () => undefined)
+
+    renderSync(refresh)
+    expect(refresh).not.toHaveBeenCalled()
+
+    await act(async () => {
+      vi.advanceTimersByTime(60_000)
+      await Promise.resolve()
+    })
+
+    expect(refresh).not.toHaveBeenCalled()
+  })
+
+  it('retains the existing periodic backstop for messaging sessions', async () => {
+    vi.useFakeTimers()
+    $changeEventsAvailable.set(true)
+    const refresh = vi.fn(async () => undefined)
+
+    renderSync(refresh, { activeIsMessaging: true })
+    expect(refresh).toHaveBeenCalledTimes(1)
+    await act(async () => Promise.resolve())
+    refresh.mockClear()
+
+    await act(async () => {
+      vi.advanceTimersByTime(30_000)
+      await Promise.resolve()
+    })
+
+    expect(refresh).toHaveBeenCalledTimes(1)
+  })
+
+  it('only defers an external tick while busy, then refreshes once after idle', async () => {
+    $changeEventsAvailable.set(true)
+    setBusy(true)
+    const refresh = vi.fn(async () => undefined)
+
+    renderSync(refresh)
+
+    act(() => setBusy(false))
+    expect(refresh).not.toHaveBeenCalled()
+    act(() => setBusy(true))
+
+    act(() => {
+      notifySessionsChanged()
+      notifySessionsChanged()
+    })
+    expect(refresh).not.toHaveBeenCalled()
+
+    act(() => setBusy(false))
+    await waitFor(() => expect(refresh).toHaveBeenCalledTimes(1))
+  })
+
+  it('coalesces a burst of global ticks, including writes for another session', async () => {
+    vi.useFakeTimers()
+    $changeEventsAvailable.set(true)
+    const refresh = vi.fn(async () => undefined)
+
+    renderSync(refresh)
+
+    act(() => {
+      for (let index = 0; index < 20; index += 1) {
+        notifySessionsChanged()
+      }
+    })
+    expect(refresh).toHaveBeenCalledTimes(1)
+
+    await act(async () => {
+      vi.advanceTimersByTime(10_000)
+      await Promise.resolve()
+    })
+
+    expect(refresh).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('reconcileActiveTranscript', () => {
+  it('resolves and hydrates a messaging session from the messaging sessions store', async () => {
+    setMessagingSessions([{ id: ACTIVE_STORED_ID, profile: 'messaging-profile', source: 'telegram' } as never])
+    const fixture = makeRefresh(resolveActiveTranscriptSession)
+    vi.mocked(getLatestSessionMessages).mockResolvedValue(transcript('telegram answer') as never)
+
+    await fixture.refresh()
+
+    expect(getLatestSessionMessages).toHaveBeenCalledWith(ACTIVE_STORED_ID, 'messaging-profile')
+    expect(fixture.states.get(ACTIVE_RUNTIME_ID)?.messages.at(-1)?.parts[0]).toMatchObject({
+      text: 'telegram answer'
+    })
+  })
+
+  it('publishes changed authoritative messages once without duplicates', async () => {
+    const fixture = makeRefresh()
+    vi.mocked(getLatestSessionMessages).mockResolvedValue(transcript('new answer') as never)
+
+    await fixture.refresh()
+
+    expect(fixture.updateSessionState).toHaveBeenCalledTimes(1)
+    const messages = fixture.states.get(ACTIVE_RUNTIME_ID)?.messages ?? []
+    expect(messages.map(message => message.role)).toEqual(['user', 'assistant'])
+    expect(new Set(messages.map(message => message.id)).size).toBe(messages.length)
+
+    await fixture.refresh()
+
+    expect(fixture.updateSessionState).toHaveBeenCalledTimes(1)
+  })
+
+  it('preserves a local assistant error while hydrating authoritative messages', async () => {
+    const fixture = makeRefresh()
+    fixture.state.messages = [
+      { id: '1-0-user', parts: [{ text: 'question', type: 'text' }], role: 'user' },
+      { error: 'local failure', id: 'assistant-error', parts: [], role: 'assistant' }
+    ]
+    vi.mocked(getLatestSessionMessages).mockResolvedValue({
+      messages: [{ content: 'question', role: 'user', timestamp: 1 }],
+      session_id: ACTIVE_STORED_ID
+    } as never)
+
+    await fixture.refresh()
+
+    const messages = fixture.states.get(ACTIVE_RUNTIME_ID)?.messages ?? []
+    expect(messages.map(message => message.id)).toEqual(['1-0-user', 'assistant-error'])
+    expect(messages.at(-1)?.error).toBe('local failure')
+  })
+
+  it('does not clobber a busy stream', async () => {
+    const fixture = makeRefresh()
+    fixture.busyRef.current = true
+
+    await fixture.refresh()
+
+    expect(getLatestSessionMessages).not.toHaveBeenCalled()
+    expect(fixture.updateSessionState).not.toHaveBeenCalled()
+  })
+
+  it('discards a response when the active session changes in flight', async () => {
+    const fixture = makeRefresh()
+    let resolve: ((value: unknown) => void) | undefined
+    vi.mocked(getLatestSessionMessages).mockReturnValueOnce(
+      new Promise(currentResolve => {
+        resolve = currentResolve
+      }) as never
+    )
+
+    const request = fixture.refresh()
+    fixture.selectedStoredSessionIdRef.current = 'stored-other'
+    fixture.activeSessionIdRef.current = 'runtime-other'
+    resolve?.(transcript('stale answer'))
+    await request
+
+    expect(fixture.updateSessionState).not.toHaveBeenCalled()
+  })
+})
 
 describe('rehydrateLiveSessionStatuses', () => {
-  beforeEach(() => {
-    vi.useFakeTimers()
-  })
-
-  afterEach(() => {
-    vi.clearAllTimers()
-    vi.useRealTimers()
-    clearAllSessionStates()
-  })
-
   it('restores running sessions after reconnect without opening them', () => {
     const now = 1_800_000_000_000
 

--- a/apps/desktop/src/app/contrib/hooks/use-background-sync.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-background-sync.ts
@@ -363,18 +363,24 @@ export function useBackgroundSync({
         activeTranscriptRefreshPendingRef.current = null
       }
 
+      let sawBusyDuringRead = false
+
+      const unsubscribeBusy = $busy.listen(busy => {
+        sawBusyDuringRead ||= busy
+      })
+
       void Promise.resolve(refreshActiveTranscript()).finally(() => {
+        unsubscribeBusy()
+
         // If streaming began while the read was in flight, reconciliation was
         // discarded and the external event still needs one idle retry.
         if (
           preservePending &&
-          $busy.get() &&
+          (sawBusyDuringRead || $busy.get()) &&
           $activeSessionId.get() === runtimeSessionId &&
           $selectedStoredSessionId.get() === storedSessionId
         ) {
           activeTranscriptRefreshPendingRef.current = sessionKey
-
-          return
         }
       })
     },

--- a/apps/desktop/src/app/contrib/hooks/use-background-sync.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-background-sync.ts
@@ -1,11 +1,23 @@
 import { useStore } from '@nanostores/react'
-import { useEffect } from 'react'
+import { type MutableRefObject, useCallback, useEffect, useRef } from 'react'
 
+import { getLatestSessionMessages } from '@/hermes'
+import { preserveLocalAssistantErrors, toChatMessages } from '@/lib/chat-messages'
 import { createClientSessionState } from '@/lib/chat-runtime'
+import { sessionMessagesSignature } from '@/lib/session-signatures'
 import { $changeEventsAvailable, $cronChangeTick, $sessionsChangeTick } from '@/store/live-sync'
 import { $onBattery, batteryPollInterval } from '@/store/power'
 import { refreshActiveProfile } from '@/store/profile'
-import { $activeSessionId, $currentCwd, setCurrentCwd } from '@/store/session'
+import {
+  $activeSessionId,
+  $busy,
+  $currentCwd,
+  $messagingSessions,
+  $selectedStoredSessionId,
+  $sessions,
+  sessionMatchesStoredId,
+  setCurrentCwd
+} from '@/store/session'
 import {
   $sessionStates,
   publishSessionState,
@@ -13,7 +25,92 @@ import {
   setSessionStalled
 } from '@/store/session-states'
 
+import type { ClientSessionState } from '../../types'
 import type { GatewayRequester } from '../types'
+
+interface ActiveTranscriptSession {
+  profile?: string | null
+}
+
+/** Resolve an active transcript from either local recents or messaging slices. */
+export function resolveActiveTranscriptSession(storedSessionId: string): ActiveTranscriptSession | undefined {
+  return (
+    $sessions.get().find(session => sessionMatchesStoredId(session, storedSessionId)) ??
+    $messagingSessions.get().find(session => sessionMatchesStoredId(session, storedSessionId))
+  )
+}
+
+export interface ActiveTranscriptRefreshDeps {
+  activeSessionIdRef: MutableRefObject<string | null>
+  busyRef: MutableRefObject<boolean>
+  requestSequenceRef: MutableRefObject<number>
+  selectedStoredSessionIdRef: MutableRefObject<string | null>
+  resolveSession: (storedSessionId: string) => ActiveTranscriptSession | null | undefined
+  signatureRef: MutableRefObject<Map<string, string>>
+  updateSessionState: (
+    sessionId: string,
+    updater: (state: ClientSessionState) => ClientSessionState,
+    storedSessionId?: string | null
+  ) => ClientSessionState
+}
+
+/** Reconcile one persisted transcript snapshot into the currently viewed session. */
+export async function reconcileActiveTranscript({
+  activeSessionIdRef,
+  busyRef,
+  requestSequenceRef,
+  resolveSession,
+  selectedStoredSessionIdRef,
+  signatureRef,
+  updateSessionState
+}: ActiveTranscriptRefreshDeps): Promise<void> {
+  const storedSessionId = selectedStoredSessionIdRef.current
+  const runtimeSessionId = activeSessionIdRef.current
+
+  if (!storedSessionId || !runtimeSessionId || busyRef.current) {
+    return
+  }
+
+  const stored = resolveSession(storedSessionId)
+
+  if (!stored) {
+    return
+  }
+
+  const requestId = requestSequenceRef.current + 1
+  requestSequenceRef.current = requestId
+
+  try {
+    const latest = await getLatestSessionMessages(storedSessionId, stored.profile)
+
+    if (
+      requestId !== requestSequenceRef.current ||
+      busyRef.current ||
+      selectedStoredSessionIdRef.current !== storedSessionId ||
+      activeSessionIdRef.current !== runtimeSessionId
+    ) {
+      return
+    }
+
+    const signatureKey = `${stored.profile ?? 'default'}:${storedSessionId}`
+    const signature = sessionMessagesSignature(latest.messages)
+
+    if (signatureRef.current.get(signatureKey) === signature) {
+      return
+    }
+
+    signatureRef.current.set(signatureKey, signature)
+    const messages = toChatMessages(latest.messages)
+
+    updateSessionState(
+      runtimeSessionId,
+      state => ({ ...state, messages: preserveLocalAssistantErrors(messages, state.messages) }),
+      storedSessionId
+    )
+  } catch {
+    // Non-fatal: the next change event or manual resume can hydrate the view.
+  }
+}
 
 // Cron sessions are written by a background scheduler tick, messaging turns by
 // the background gateway (Telegram, WeChat, Discord, …) — neither signals the
@@ -177,9 +274,10 @@ interface BackgroundSyncParams {
   activeGatewayProfile: string
   activeIsMessaging: boolean
   activeSessionId: null | string
+  activeStoredSessionId: null | string
   freshDraftReady: boolean
   gatewayState: string
-  refreshActiveMessagingTranscript: () => Promise<unknown> | unknown
+  refreshActiveTranscript: () => Promise<unknown> | unknown
   refreshCronJobs: () => Promise<unknown> | unknown
   refreshCurrentModel: (force?: boolean) => Promise<unknown> | unknown
   refreshHermesConfig: () => Promise<unknown> | unknown
@@ -226,9 +324,10 @@ export function useBackgroundSync({
   activeGatewayProfile,
   activeIsMessaging,
   activeSessionId,
+  activeStoredSessionId,
   freshDraftReady,
   gatewayState,
-  refreshActiveMessagingTranscript,
+  refreshActiveTranscript,
   refreshCronJobs,
   refreshCurrentModel,
   refreshHermesConfig,
@@ -239,6 +338,48 @@ export function useBackgroundSync({
   const changeEventsAvailable = useStore($changeEventsAvailable)
   const cronChangeTick = useStore($cronChangeTick)
   const sessionsChangeTick = useStore($sessionsChangeTick)
+  const activeTranscriptBusy = useStore($busy)
+  const activeTranscriptRefreshPendingRef = useRef<string | null>(null)
+
+  const requestActiveTranscriptRefresh = useCallback(
+    (preservePending: boolean) => {
+      if (!activeStoredSessionId || !activeSessionId) {
+        return
+      }
+
+      const storedSessionId = activeStoredSessionId
+      const runtimeSessionId = activeSessionId
+      const sessionKey = `${storedSessionId}:${runtimeSessionId}`
+
+      if (preservePending) {
+        activeTranscriptRefreshPendingRef.current = sessionKey
+      }
+
+      if ($busy.get()) {
+        return
+      }
+
+      if (preservePending && activeTranscriptRefreshPendingRef.current === sessionKey) {
+        activeTranscriptRefreshPendingRef.current = null
+      }
+
+      void Promise.resolve(refreshActiveTranscript()).finally(() => {
+        // If streaming began while the read was in flight, reconciliation was
+        // discarded and the external event still needs one idle retry.
+        if (
+          preservePending &&
+          $busy.get() &&
+          $activeSessionId.get() === runtimeSessionId &&
+          $selectedStoredSessionId.get() === storedSessionId
+        ) {
+          activeTranscriptRefreshPendingRef.current = sessionKey
+
+          return
+        }
+      })
+    },
+    [activeSessionId, activeStoredSessionId, refreshActiveTranscript]
+  )
 
   useEffect(() => {
     if (gatewayState !== 'open') {
@@ -332,6 +473,7 @@ export function useBackgroundSync({
       lastRunAt = Date.now()
       void refreshSessions()
       void refreshMessagingSessions()
+      requestActiveTranscriptRefresh(true)
     }
 
     const unsubscribe = $sessionsChangeTick.listen(() => {
@@ -354,7 +496,7 @@ export function useBackgroundSync({
         window.clearTimeout(timer)
       }
     }
-  }, [changeEventsAvailable, gatewayState, refreshMessagingSessions, refreshSessions])
+  }, [changeEventsAvailable, gatewayState, refreshMessagingSessions, refreshSessions, requestActiveTranscriptRefresh])
 
   // Keep the cron-jobs section live without a user action (scheduler ticks in
   // the background). cron.changed (jobs.json moved: CRUD or a scheduler tick's
@@ -374,24 +516,47 @@ export function useBackgroundSync({
     )
   }, [changeEventsAvailable, cronChangeTick, gatewayState, refreshCronJobs])
 
-  // Only the open messaging transcript needs its own cadence — local chats are
-  // live over the websocket already. sessions.changed re-pulls it via the tick
-  // dep; the visible poll is the backstop.
+  // A busy transition only consumes a pending sessions.changed refresh. It
+  // never creates one, so an ordinary local turn going busy -> idle does not
+  // add a REST read. The event itself is coalesced by the list throttle above.
   useEffect(() => {
-    if (gatewayState !== 'open' || !activeIsMessaging) {
+    if (
+      gatewayState !== 'open' ||
+      activeTranscriptBusy ||
+      !activeSessionId ||
+      !activeStoredSessionId ||
+      activeTranscriptRefreshPendingRef.current !== `${activeStoredSessionId}:${activeSessionId}`
+    ) {
       return
     }
 
-    const dispose = visiblePoll(
+    requestActiveTranscriptRefresh(true)
+  }, [activeSessionId, activeStoredSessionId, activeTranscriptBusy, gatewayState, requestActiveTranscriptRefresh])
+
+  // Preserve the pre-existing messaging behavior: refresh once when a
+  // messaging transcript opens, then keep its visibility backstop. Desktop
+  // sessions never enter this effect and therefore gain no periodic timer.
+  useEffect(() => {
+    if (gatewayState !== 'open' || !activeIsMessaging || !activeSessionId || !activeStoredSessionId) {
+      return
+    }
+
+    const runScheduledRefresh = () => requestActiveTranscriptRefresh(false)
+
+    runScheduledRefresh()
+
+    return visiblePoll(
       changeEventsAvailable ? ACTIVE_MESSAGING_SESSION_BACKSTOP_INTERVAL_MS : ACTIVE_MESSAGING_SESSION_POLL_INTERVAL_MS,
-      () => void refreshActiveMessagingTranscript()
+      runScheduledRefresh
     )
-
-    void refreshActiveMessagingTranscript()
-
-    return dispose
-    // sessionsChangeTick: an inbound turn re-pulls the open transcript.
-  }, [activeIsMessaging, changeEventsAvailable, gatewayState, refreshActiveMessagingTranscript, sessionsChangeTick])
+  }, [
+    activeIsMessaging,
+    activeSessionId,
+    activeStoredSessionId,
+    changeEventsAvailable,
+    gatewayState,
+    requestActiveTranscriptRefresh
+  ])
 
   // Messaging session lists against an older backend: no sessions.changed, so
   // keep the legacy visible poll. (Event-capable backends fold this into the

--- a/apps/desktop/src/app/contrib/wiring.tsx
+++ b/apps/desktop/src/app/contrib/wiring.tsx
@@ -26,7 +26,6 @@ import { RemoteDisplayBanner } from '@/components/remote-display-banner'
 import { emitGatewayEvent } from '@/contrib/events'
 import { getLatestSessionMessages, triggerCronJob } from '@/hermes'
 import { type ChatMessage, chatMessageText, preserveLocalAssistantErrors, toChatMessages } from '@/lib/chat-messages'
-import { sessionMessagesSignature } from '@/lib/session-signatures'
 import { isMessagingSource } from '@/lib/session-source'
 import { latestSessionTodos } from '@/lib/todos'
 import { activateWakeIndicator } from '@/lib/wake-indicator'
@@ -122,7 +121,11 @@ import { TitlebarControls } from '../shell/titlebar-controls'
 import { UpdatesOverlay } from '../updates-overlay'
 
 import { ContribWiringContext } from './context'
-import { useBackgroundSync } from './hooks/use-background-sync'
+import {
+  reconcileActiveTranscript,
+  resolveActiveTranscriptSession,
+  useBackgroundSync
+} from './hooks/use-background-sync'
 import { useDesktopIntegrations } from './hooks/use-desktop-integrations'
 import { usePetBridge } from './hooks/use-pet-bridge'
 import { useQuickEntryBridge } from './hooks/use-quick-entry-bridge'
@@ -159,7 +162,8 @@ export function ContribWiring({ children }: { children: ReactNode }) {
   // intent counter here; the ref skips the initial mount value.
   const billingSettingsSeenRef = useRef(0)
   const cronReviewSeenRef = useRef(0)
-  const messagingTranscriptSignatureRef = useRef(new Map<string, string>())
+  const activeTranscriptSignatureRef = useRef(new Map<string, string>())
+  const activeTranscriptRequestSequenceRef = useRef(0)
   // Stable identity for the whole callback surface (see WiringActions). Mutated
   // in place each render so memoized surfaces never re-render on churn.
   const actionsRef = useRef<WiringActions | null>(null)
@@ -374,44 +378,21 @@ export function ContribWiring({ children }: { children: ReactNode }) {
     [activeSessionIdRef, selectedStoredSessionIdRef, updateSessionState]
   )
 
-  // Refresh the open messaging transcript (inbound platform turns arrive via
-  // the background gateway, not the desktop websocket). Signature-gated so a
-  // no-change poll doesn't churn the thread.
-  const refreshActiveMessagingTranscript = useCallback(async () => {
-    const storedSessionId = selectedStoredSessionIdRef.current
-    const runtimeSessionId = activeSessionIdRef.current
-
-    if (!storedSessionId || !runtimeSessionId || busyRef.current) {
-      return
-    }
-
-    const stored = $messagingSessions.get().find(s => sessionMatchesStoredId(s, storedSessionId))
-
-    if (!stored || !isMessagingSource(stored.source)) {
-      return
-    }
-
-    try {
-      const latest = await getLatestSessionMessages(storedSessionId, stored.profile)
-      const signatureKey = `${stored.profile ?? 'default'}:${storedSessionId}`
-      const sig = sessionMessagesSignature(latest.messages)
-
-      if (messagingTranscriptSignatureRef.current.get(signatureKey) === sig) {
-        return
-      }
-
-      messagingTranscriptSignatureRef.current.set(signatureKey, sig)
-      const messages = toChatMessages(latest.messages)
-
-      updateSessionState(
-        runtimeSessionId,
-        state => ({ ...state, messages: preserveLocalAssistantErrors(messages, state.messages) }),
-        storedSessionId
-      )
-    } catch {
-      // Non-fatal: next poll or manual refresh can hydrate.
-    }
-  }, [activeSessionIdRef, busyRef, selectedStoredSessionIdRef, updateSessionState])
+  // Refresh any active transcript changed by another process. Signature-gated
+  // so a no-change event does not churn the thread.
+  const refreshActiveTranscript = useCallback(
+    () =>
+      reconcileActiveTranscript({
+        activeSessionIdRef,
+        busyRef,
+        requestSequenceRef: activeTranscriptRequestSequenceRef,
+        resolveSession: resolveActiveTranscriptSession,
+        selectedStoredSessionIdRef,
+        signatureRef: activeTranscriptSignatureRef,
+        updateSessionState
+      }),
+    [activeSessionIdRef, busyRef, selectedStoredSessionIdRef, updateSessionState]
+  )
 
   const { handleGatewayEvent } = useMessageStream({
     activeGatewayProfile,
@@ -769,21 +750,22 @@ export function ContribWiring({ children }: { children: ReactNode }) {
     }
   }, [gatewayState, requestGateway])
 
-  // Only the open messaging transcript needs its own poll — local chats are
-  // live over the websocket already.
   const activeIsMessaging =
     !!selectedStoredSessionId &&
     isMessagingSource(messagingSessions.find(s => sessionMatchesStoredId(s, selectedStoredSessionId))?.source)
 
+  // sessions.changed refreshes every open transcript; only messaging retains
+  // the periodic safety-net it already had before this fix.
   // Keep app data live while the gateway is open (on-connect reseed + the
   // cron / messaging / transcript visibility polls + fresh-draft reseed).
   useBackgroundSync({
     activeGatewayProfile,
     activeIsMessaging,
     activeSessionId,
+    activeStoredSessionId: selectedStoredSessionId,
     freshDraftReady,
     gatewayState,
-    refreshActiveMessagingTranscript,
+    refreshActiveTranscript,
     refreshCronJobs,
     refreshCurrentModel,
     refreshHermesConfig,

--- a/apps/desktop/src/app/session/hooks/use-message-stream/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/index.ts
@@ -632,7 +632,7 @@ export function useMessageStream({
               nextMessages = prev.map((message, messageIndex) =>
                 messageIndex === index ? completeMessage(message) : message
               )
-            } else if (interimBoundaryPending && (responsePreviewed || finalContinuesInterim)) {
+            } else if (existing.interim && (responsePreviewed || finalContinuesInterim)) {
               // Settle the interim in place instead of creating a duplicate —
               // the DB has one row, so the live UI must agree. Previously this
               // was gated on `responsePreviewed` alone, so a NON-previewed
@@ -642,6 +642,15 @@ export function useMessageStream({
               // for ordinary tool-call turns while `responsePreviewed` still
               // covers the verify-on-stop continuation-budget case even when the
               // final text was rewritten and no longer shares a prefix.
+              //
+              // We key on the message's OWN durable `interim` state, not the
+              // session's volatile `interimBoundaryPending` flag: the flag is
+              // reset to false by a subsequent `message.start` (a chained turn,
+              // follow-up, or mid-turn compaction). When that reset lands
+              // between this turn's `message.interim` and `message.complete`, the
+              // flag-based gate wrongly fell through to appending a duplicate
+              // bubble (#74560). The message row still says `interim`, so the
+              // continuation merges correctly regardless of the flag.
               nextMessages = prev.map((message, messageIndex) =>
                 messageIndex === index ? completeMessage(message) : message
               )

--- a/apps/desktop/src/app/session/hooks/use-message-stream/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/index.ts
@@ -632,25 +632,29 @@ export function useMessageStream({
               nextMessages = prev.map((message, messageIndex) =>
                 messageIndex === index ? completeMessage(message) : message
               )
-            } else if (existing.interim && (responsePreviewed || finalContinuesInterim)) {
+            } else if ((interimBoundaryPending && responsePreviewed) || finalContinuesInterim) {
               // Settle the interim in place instead of creating a duplicate —
-              // the DB has one row, so the live UI must agree. Previously this
-              // was gated on `responsePreviewed` alone, so a NON-previewed
-              // tool-call turn whose final matched its sealed interim appended a
-              // second bubble (the "renders twice: partial first copy + clean
-              // final" bug, #63679). `finalContinuesInterim` closes that gap
-              // for ordinary tool-call turns while `responsePreviewed` still
-              // covers the verify-on-stop continuation-budget case even when the
-              // final text was rewritten and no longer shares a prefix.
+              // the DB has one row, so the live UI must agree. Two distinct
+              // settle paths with different boundary requirements:
               //
-              // We key on the message's OWN durable `interim` state, not the
-              // session's volatile `interimBoundaryPending` flag: the flag is
-              // reset to false by a subsequent `message.start` (a chained turn,
-              // follow-up, or mid-turn compaction). When that reset lands
-              // between this turn's `message.interim` and `message.complete`, the
-              // flag-based gate wrongly fell through to appending a duplicate
-              // bubble (#74560). The message row still says `interim`, so the
-              // continuation merges correctly regardless of the flag.
+              // • responsePreviewed covers the verify-on-stop continuation-
+              //   budget case, where the final may be a rewrite sharing no
+              //   prefix with the interim. Because there is no continuity
+              //   guarantee, it must stay gated on the session's
+              //   `interimBoundaryPending` flag: after a new `message.start`
+              //   resets the flag, a previewed final is a DISTINCT reply and
+              //   must append its own bubble, never overwrite the interim
+              //   (otherwise interim('old') → message.start →
+              //   complete({response_previewed: true, text: 'new'}) would
+              //   silently destroy 'old').
+              //
+              // • finalContinuesInterim (prefix-either-way continuity, same
+              //   text or one a prefix of the other) is safe to settle
+              //   flag-free: continuity can only hold for the SAME message,
+              //   so a `message.start` reset landing between this turn's
+              //   `message.interim` and `message.complete` must not force an
+              //   append of a duplicate bubble (#74560). This also closes the
+              //   non-previewed tool-call gap from #63679.
               nextMessages = prev.map((message, messageIndex) =>
                 messageIndex === index ? completeMessage(message) : message
               )

--- a/apps/desktop/src/app/session/hooks/use-message-stream/interim-sealing.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/interim-sealing.test.tsx
@@ -217,6 +217,23 @@ describe('useMessageStream interim text sealing', () => {
     expect(texts[0]).toBe('partial answer continued')
   })
 
+  it('settles final onto interim even after message.start reset the boundary flag (#74560)', async () => {
+    await mountStream()
+    await start()
+    await delta('partial')
+    await interim('partial')
+    // A chained turn / follow-up re-emits message.start, which resets
+    // interimBoundaryPending to false BEFORE the same turn's message.complete.
+    // The continuation must still settle onto the interim — not append a
+    // duplicate bubble. Regression for #74560.
+    await start()
+    await complete('partial answer continued')
+
+    const texts = assistantMessages()
+    expect(texts.filter(t => t.includes('partial'))).toHaveLength(1)
+    expect(texts[0]).toBe('partial answer continued')
+  })
+
   it('appends a genuinely different final as its own bubble (two real assistant segments)', async () => {
     await mountStream()
     await start()

--- a/apps/desktop/src/app/session/hooks/use-message-stream/interim-sealing.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/interim-sealing.test.tsx
@@ -234,6 +234,26 @@ describe('useMessageStream interim text sealing', () => {
     expect(texts[0]).toBe('partial answer continued')
   })
 
+  it('appends a distinct previewed final after a message.start reset instead of overwriting the interim', async () => {
+    await mountStream()
+    await start()
+    await interim('old interim text')
+    // A genuinely new turn begins — message.start resets interimBoundaryPending.
+    // Production ordering: mid-turn compaction-resume events do NOT include
+    // message.start (COMPACTION_RESUME_EVENT_TYPES in gateway-event.ts), and
+    // the TUI gateway emits message.complete BEFORE goal-followup starts
+    // (tui_gateway/server.py), so a previewed final arriving after the reset
+    // is a DISTINCT reply, not a rewrite of the interim. It must append its
+    // own bubble — never overwrite the old one (sweeper review on #76583).
+    await start()
+    await completePreviewed('totally new answer')
+
+    const texts = assistantMessages()
+    expect(texts).toContain('old interim text')
+    expect(texts).toContain('totally new answer')
+    expect(texts).toHaveLength(2)
+  })
+
   it('appends a genuinely different final as its own bubble (two real assistant segments)', async () => {
     await mountStream()
     await start()

--- a/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
@@ -1610,6 +1610,77 @@ describe('resumeSession warm-cache mapping integrity', () => {
     expect(renderedMessages).not.toContain('stale runtime answer')
   })
 
+  it('keeps the activated transcript when a persisted transcript refresh returns empty rows', async () => {
+    // Regression: after a wake/reconnect, session.activate can legitimately
+    // rebind a session with a non-empty transcript while the concurrent REST
+    // refresh (getLatestSessionMessages) races a just-respawned backend and
+    // resolves with zero rows. That empty page must not be trusted over the
+    // transcript activate already restored.
+    const runtimeIdByStoredSessionIdRef: MutableRefObject<Map<string, string>> = {
+      current: new Map([['stored-A', 'rt-A']])
+    }
+
+    const state = clientState('stored-A')
+    state.messages = [
+      {
+        id: 'cached-user',
+        role: 'user',
+        parts: [{ type: 'text', text: 'still here after wake' }]
+      },
+      {
+        id: 'cached-assistant',
+        role: 'assistant',
+        parts: [{ type: 'text', text: 'still here after wake too' }]
+      }
+    ]
+
+    const sessionStateByRuntimeIdRef: MutableRefObject<Map<string, ClientSessionState>> = {
+      current: new Map([['rt-A', state]])
+    }
+
+    const activatedMessages = [
+      { content: 'still here after wake', role: 'user', timestamp: 1 },
+      { content: 'still here after wake too', role: 'assistant', timestamp: 2 }
+    ]
+
+    vi.mocked(getLatestSessionMessages).mockResolvedValue({ messages: [], session_id: 'stored-A' } as never)
+
+    const requestGateway = vi.fn(async (method: string) => {
+      if (method === 'session.activate') {
+        return {
+          session_id: 'rt-A',
+          session_key: 'stored-A',
+          resumed: 'stored-A',
+          message_count: activatedMessages.length,
+          messages: activatedMessages,
+          running: false,
+          info: {}
+        } as never
+      }
+
+      return {} as never
+    })
+
+    let resumedState: ClientSessionState | undefined
+    let resume: ((storedSessionId: string, replaceRoute?: boolean) => Promise<unknown>) | null = null
+
+    render(
+      <ResumeHarness
+        onReady={ready => (resume = ready)}
+        onStateUpdate={(_sessionId, next) => (resumedState = next)}
+        requestGateway={requestGateway}
+        runtimeIdByStoredSessionIdRef={runtimeIdByStoredSessionIdRef}
+        sessionStateByRuntimeIdRef={sessionStateByRuntimeIdRef}
+      />
+    )
+    await waitFor(() => expect(resume).not.toBeNull())
+    await resume!('stored-A', true)
+
+    const renderedMessages = JSON.stringify(resumedState?.messages)
+    expect(renderedMessages).toContain('still here after wake')
+    expect(renderedMessages).toContain('still here after wake too')
+  })
+
   it('keeps a warm runtime and optimistic turn on a transient activation timeout', async () => {
     const runtimeIdByStoredSessionIdRef: MutableRefObject<Map<string, string>> = {
       current: new Map([['stored-A', 'rt-A']])

--- a/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
@@ -804,7 +804,13 @@ export function useSessionActions({
                   !activatedStoredSessionId ||
                   persisted.session_id === activatedStoredSessionId
 
-                if (persisted && persistedMatchesActivatedSession) {
+                // An empty REST page is not proof the transcript is empty — it's
+                // also what a backend respawn returns while its state.db read
+                // races the activate response. Reconciling against it anyway
+                // wipes the just-restored activate/cache transcript (the same
+                // wipe the `activated.messages.length || ...` guard above
+                // already prevents for the activate payload itself).
+                if (persisted && persistedMatchesActivatedSession && (persisted.messages.length || !activatedMessages.length)) {
                   activatedMessages = reconcileAuthoritativeMessages(persisted.messages, activatedMessages)
                 }
               }

--- a/apps/desktop/src/app/session/hooks/use-session-actions/utils.test.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/utils.test.ts
@@ -1086,6 +1086,64 @@ describe('preserveLocalPendingTurnMessages', () => {
     expect(chatMessageText(preserved[1])).toBe('first answer')
     expect(preserved.filter(message => message.role === 'assistant')).toHaveLength(2)
   })
+
+  // A still-PENDING stream row whose committed twin the authoritative history
+  // already carries (ordinal shifted under compaction) used to fall through to
+  // `preserved.push` and render the same answer twice — the reported tail
+  // duplication (A B C D E C D). The #70209 guard only covers settled local
+  // rows (`pending !== true`); these cover the pending ones.
+  it('does not re-append a pending stream row the authoritative history already carries', () => {
+    const previous = [
+      msg('1-user', 'user', '查金价'),
+      msg('2-a', 'assistant', 'X'),
+      streamingMsg('assistant-stream-live', '面板内容')
+    ]
+
+    const next = [msg('1-user', 'user', '查金价'), msg('9-assistant', 'assistant', '面板内容')]
+
+    expect(preserveLocalPendingTurnMessages(next, previous)).toBe(next)
+  })
+
+  it('drops a pending stream row whose text the committed authoritative reply extends', () => {
+    const previous = [
+      msg('1-user', 'user', '查金价'),
+      msg('2-a', 'assistant', 'X'),
+      streamingMsg('assistant-stream-live', '面板')
+    ]
+
+    const next = [msg('1-user', 'user', '查金价'), msg('9-assistant', 'assistant', '面板内容完整版')]
+
+    expect(preserveLocalPendingTurnMessages(next, previous)).toBe(next)
+  })
+
+  it('replaces the committed row with a further-along pending copy instead of appending', () => {
+    const previous = [
+      msg('1-user', 'user', '查金价'),
+      msg('2-a', 'assistant', 'X'),
+      streamingMsg('assistant-stream-live', '面板内容完整版')
+    ]
+
+    const next = [msg('1-user', 'user', '查金价'), msg('9-assistant', 'assistant', '面板')]
+
+    const preserved = preserveLocalPendingTurnMessages(next, previous)
+
+    expect(preserved.map(message => message.id)).toEqual(['1-user', '9-assistant'])
+    expect(chatMessageText(preserved[1])).toBe('面板内容完整版')
+  })
+
+  // The authoritative history genuinely does not have this reply yet — the
+  // pending row is the only copy and must survive (same contract as the
+  // settled-row variant above).
+  it('still keeps a pending stream row when the authoritative history has no reply', () => {
+    const previous = [msg('1-user', 'user', '查金价'), streamingMsg('assistant-stream-live', '面板内容')]
+
+    const next = [msg('1-user', 'user', '查金价')]
+
+    expect(preserveLocalPendingTurnMessages(next, previous).map(message => message.id)).toEqual([
+      '1-user',
+      'assistant-stream-live'
+    ])
+  })
 })
 
 describe('appendLiveSessionProjection', () => {

--- a/apps/desktop/src/app/session/hooks/use-session-actions/utils.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/utils.ts
@@ -603,6 +603,64 @@ export function preserveLocalPendingTurnMessages(
       }
     }
 
+    // Ordinal pairing missed (the committed row shifted ordinal when history
+    // was compacted / the authoritative list is shorter), yet the
+    // authoritative transcript already carries this same reply under its
+    // committed id. The #70209 guard above only covers SETTLED local rows
+    // (`pending !== true`); a still-pending stream row that slips past
+    // pairing falls through to `preserved.push` and renders the answer
+    // twice — the reported A B C D E C D tail duplication.
+    //
+    // Three-way same-turn check against SETTLED authoritative rows only
+    // (a live projection shell must not swallow the richer local row, see
+    // the traces-only replacement test):
+    //  1. identical answer text            -> authoritative already has it
+    //  2. authoritative extends local text -> authoritative is the settled
+    //     final version of the still-streaming local copy
+    //  3. local extends authoritative text -> local is further along; replace
+    //     the committed row with the richer body instead of appending
+    if (isPendingAssistant) {
+      const nextText = textWithoutReferenceLines(chatMessageText(message))
+
+      const committedMatch = nextMessages.find(
+        candidate =>
+          candidate.role === 'assistant' &&
+          !isLiveTailRow(candidate) &&
+          (textWithoutReferenceLines(chatMessageText(candidate)) === nextText ||
+            isStrictAnswerTextExtension(
+              textWithoutReferenceLines(chatMessageText(candidate)),
+              nextText
+            ))
+      )
+
+      if (committedMatch) {
+        continue
+      }
+
+      const committedPrefix = nextMessages.find(
+        candidate =>
+          candidate.role === 'assistant' &&
+          !isLiveTailRow(candidate) &&
+          isStrictAnswerTextExtension(
+            nextText,
+            textWithoutReferenceLines(chatMessageText(candidate))
+          )
+      )
+
+      if (committedPrefix) {
+        // Keep the COMMITTED id (not the local stream id): the turn is
+        // already in the authoritative transcript, so the merged row must
+        // stay addressable as that durable row — a stream id would read as a
+        // live row again next reconcile and re-enter this same path.
+        replacements.set(committedPrefix.id, {
+          ...withAuthoritativeTurnState(message, committedPrefix),
+          id: committedPrefix.id
+        })
+
+        continue
+      }
+    }
+
     preserved.push(message)
   }
 

--- a/contributors/emails/602028@ky-tech.com.cn
+++ b/contributors/emails/602028@ky-tech.com.cn
@@ -1,0 +1,1 @@
+baihemax

--- a/contributors/emails/guilherme@guilhermeaguiar.com
+++ b/contributors/emails/guilherme@guilhermeaguiar.com
@@ -1,0 +1,1 @@
+guilhermeraiuga


### PR DESCRIPTION
Salvages the Desktop duplicate/lost assistant reply stream cluster into one coherent branch. Cherry-picks the per-PR commits with authorship preserved from four candidate PRs — all four proved complementary (disjoint files, layered defenses), so none were excluded.

## What's included

| Source PR | Author | Fix |
|---|---|---|
| #84296 | @baihemax (李灵航) | `preserveLocalPendingTurnMessages`: drop still-pending local stream rows whose reply the authoritative transcript already carries (identical text / strict-extension three-way check against settled rows only); when the local copy is richer, replace the committed row in place under the committed id |
| #76583 | @spfcraze | `useMessageStream.completeAssistantMessage`: settle the final reply onto its sealed interim even after a `message.start` reset the session's `interimBoundaryPending` flag — `finalContinuesInterim` (prefix continuity) settles flag-free, while `responsePreviewed` (rewrite, no continuity guarantee) stays flag-gated so a distinct previewed final still appends its own bubble |
| #82843 | @chelsealong | `useSessionActions`: an empty REST transcript page is not proof the transcript is empty (backend respawn racing state.db); stop it from wiping a warm activate/cache resume |
| #86299 | @guilhermeraiuga | `use-background-sync` / `wiring.tsx`: generalize the messaging-only transcript poll into `reconcileActiveTranscript` — signature-gated, request-sequenced refresh of the active transcript on `sessions.changed` for every session, with the periodic safety-net retained for messaging |

Plus a small `contributors/emails/` mapping commit from `audit_pr_attribution.py --fix`.

## Issue coverage

- **#85104** (same assistant message rendered twice; DB single record, frontend dup): #84296 removes the duplicate pending row at reconcile time; #76583 prevents the duplicate from being created at settle time. Both layers covered.
- **#81473** (reply renders twice, ordinal drift after model switch): #84296 is the direct fix — the ordinal-pairing miss after history compaction/list-shortening is exactly the "A B C D E C D" tail duplication path. Residual: the *ordinal drift* itself (why the committed row shifted ordinal) is masked, not re-derived; if a future turn's row pairs to the wrong ordinal with *different* text, this guard won't catch it (it keys on text identity/extension).
- **#71857** (identical final answer delivered twice): #76583 settles the final onto the interim instead of appending; #84296 catches the same duplication if it slips through to a transcript reconcile. Covered.
- **#83147** (WS reconnect must recover persisted turns without duplicates): #82843 stops the empty-REST wipe on warm resume; #86299 refreshes the active transcript on `sessions.changed` so persisted turns arrive without a manual reload; #84296's pending-row dedup prevents the recovered turns from doubling against in-flight local rows. Residual: there is no explicit reconnect-orchestrated replay test end-to-end across the WS drop → REST recover → stream resume sequence; the pieces are individually tested but a dedicated reconnect integration test would close that honestly.

## Exclusions

None. All four candidate PRs apply cleanly to current `main`, touch disjoint files, and layer coherently (settle-time guard → reconcile-time dedup → REST-wipe guard → event-driven refresh). Note: `origin/main` already carries a related disk-full toast block in `use-message-stream/index.ts` adjacent to #76583's hunk; the cherry-pick merged cleanly around it.

## Tests

- Targeted: `use-session-actions/utils.test.ts`, `use-message-stream/interim-sealing.test.tsx`, `use-session-actions.test.tsx`, `use-background-sync.test.ts` — 157/157 pass.
- Broader sweep: `apps/desktop/src/app/session/hooks` + `src/app/contrib` — 40 files, 533/533 pass.

Credit: @baihemax, @spfcraze, @chelsealong, @guilhermeraiuga — all commits cherry-picked with original authorship.

## Infographic

![desktop-stream-dedup](https://gist.githubusercontent.com/teknium1/1116a1a9eec5ec248b2c4ea4e8caad51/raw/infographic-desktop-stream-dedup.png)
