### PR TITLE
fix(desktop): stabilize virtualized scrolling (sidebar flicker, transcript reanchor, sash-blocked scrollbar)

### DIFF
--- a/apps/desktop/e2e/mock-server.ts
+++ b/apps/desktop/e2e/mock-server.ts
@@ -120,6 +120,9 @@ let _correctionSwitchIndex = 0
 /** Per-server counter for the verify-on-stop script. */
 let _verificationStopIndex = 0
 
+/** Per-server counter for the task-panel warm-resume script. */
+let _taskPanelResumeIndex = 0
+
 /** User messages received by the mock, for E2E assertions on real submits. */
 const _receivedUserTexts: string[] = []
 
@@ -131,6 +134,7 @@ function resetScriptIndex(): void {
   _queueStopIndex = 0
   _correctionSwitchIndex = 0
   _verificationStopIndex = 0
+  _taskPanelResumeIndex = 0
   _receivedUserTexts.length = 0
 }
 
@@ -295,6 +299,41 @@ export const VERIFICATION_STOP_TEXT = 'I cannot provide fresh verification evide
 export const BLOCKING_CLARIFY_TRIGGER = 'E2E_BLOCKING_CLARIFY_TRIGGER'
 export const BLOCKING_CLARIFY_QUESTION = 'Keep this test turn running?'
 
+/**
+ * A long live response with a five-row todo card, held open by a foreground tool.
+ * The transcript is deliberately taller than the viewport so warm-session
+ * tests can detect when re-opening the session leaves it above the true bottom.
+ */
+export const TASK_PANEL_RESUME_TRIGGER = 'E2E_TASK_PANEL_RESUME_TRIGGER'
+export const TASK_PANEL_RESUME_TEXT = Array.from(
+  { length: 24 },
+  (_, index) => `Task-panel clearance line ${index + 1}: inspect the restored working session geometry.`,
+).join('\n\n')
+
+const TASK_PANEL_RESUME_SCRIPT: ScriptedTurn[] = [
+  {
+    text: TASK_PANEL_RESUME_TEXT,
+    toolCalls: [
+      {
+        name: 'todo',
+        args: {
+          todos: [
+            { id: 'design', content: 'Design the restored layout', status: 'completed' },
+            { id: 'implement', content: 'Implement the measured clearance', status: 'in_progress' },
+            { id: 'verify', content: 'Verify the latest message stays visible', status: 'pending' },
+            { id: 'review', content: 'Review the visual regression', status: 'pending' },
+            { id: 'ship', content: 'Ship the focused fix', status: 'pending' },
+          ],
+        },
+      },
+      {
+        name: 'terminal',
+        args: { command: 'sleep 60' },
+      },
+    ],
+  },
+]
+
 const BLOCKING_CLARIFY_TURN: ScriptedTurn = {
   text: '',
   toolCalls: [{ name: 'clarify', args: { question: BLOCKING_CLARIFY_QUESTION, choices: ['Yes', 'No'] } }],
@@ -414,12 +453,36 @@ export function startMockServer(options: MockServerOptions = {}): Promise<MockSe
           const isSidebarTrigger = userText.includes('E2E_SIDEBAR_TRIGGER')
           const isSidebarCrossTrigger = userText.includes('E2E_SIDEBAR_CROSS')
           const isQueueStopTrigger = userText.includes('E2E_QUEUE_STOP_TRIGGER')
+          const isTaskPanelResumeTrigger = userText.includes(TASK_PANEL_RESUME_TRIGGER)
           const isVerificationStopTrigger = messages.some(
             message => typeof message?.content === 'string' && message.content.includes(VERIFICATION_STOP_TRIGGER),
           )
           const isCorrectionSwitchTrigger = messages.some(
             message => typeof message?.content === 'string' && message.content.includes(CORRECTION_SWITCH_TRIGGER),
           )
+
+          if (isTaskPanelResumeTrigger) {
+            const turn =
+              TASK_PANEL_RESUME_SCRIPT[_taskPanelResumeIndex] ??
+              TASK_PANEL_RESUME_SCRIPT[TASK_PANEL_RESUME_SCRIPT.length - 1]
+            _taskPanelResumeIndex++
+            const respond = () => {
+              if (stream) {
+                streamScriptedTurn(res, model, turn)
+              } else {
+                nonStreamingScriptedTurn(res, model, turn)
+              }
+            }
+
+            if (holdThisCompletion) {
+              heldCompletionCount++
+              resolveHeldStreamStarted?.()
+              void heldStreamReleased.then(respond)
+            } else {
+              respond()
+            }
+            return
+          }
 
           if (includesBlockingClarifyTrigger(parsed.messages)) {
             if (stream) {

--- a/apps/desktop/e2e/task-panel-clearance.spec.ts
+++ b/apps/desktop/e2e/task-panel-clearance.spec.ts
@@ -1,0 +1,145 @@
+/**
+ * Regression coverage for returning to a working session as its task panel
+ * expands. The transcript must reconcile to the composer's full measured
+ * height without needing a manual scroll to repair the position.
+ */
+
+import { expect, test, type Page } from './test'
+
+import { type MockBackendFixture, setupMockBackend, waitForAppReady } from './fixtures'
+import { TASK_PANEL_RESUME_TRIGGER } from './mock-server'
+
+const SURFACE = '[data-composer-target]:visible'
+const PROMPT = `${TASK_PANEL_RESUME_TRIGGER}: keep the task panel expanded while this session is reopened.`
+
+function activeSurface(page: Page) {
+  return page.locator(SURFACE).last()
+}
+
+async function send(page: Page, text: string): Promise<void> {
+  const composer = activeSurface(page).locator('[contenteditable="true"]').first()
+
+  await composer.waitFor({ state: 'visible', timeout: 15_000 })
+  await composer.click()
+  await composer.type(text, { delay: 5 })
+  await page.keyboard.press('Enter')
+}
+
+async function openFreshDraft(page: Page): Promise<void> {
+  await page.locator('[data-slot="sidebar"] button[aria-label="New session"]').first().click()
+  await expect(activeSurface(page).locator('[data-slot="aui_thread-viewport"]')).not.toContainText(PROMPT)
+  await page.waitForTimeout(1_000)
+}
+
+async function reopenWorkingSession(page: Page): Promise<void> {
+  const sidebar = page.locator('[data-slot="sidebar"]')
+  const row = sidebar.getByRole('button', { name: /^(?:Session running|Needs your input|Working)\b/ }).first()
+
+  await row.waitFor({ state: 'visible', timeout: 30_000 })
+  await row.click()
+  await expect(activeSurface(page).locator('[data-slot="aui_thread-viewport"]')).toContainText(
+    'Task-panel clearance line 24',
+    { timeout: 30_000 },
+  )
+}
+
+interface ClearanceMetrics {
+  composerHeight: number
+  distanceFromBottom: number
+  latestMessageBottom: number
+  statusPanelTop: number
+  viewportHeight: number
+}
+
+async function clearanceMetrics(page: Page): Promise<ClearanceMetrics> {
+  return activeSurface(page).evaluate(surface => {
+    const chatSurface = surface.closest<HTMLElement>('[data-chat-surface]')!
+    const viewport = surface.querySelector<HTMLElement>('[data-slot="aui_thread-viewport"]')!
+    const latest = Array.from(surface.querySelectorAll<HTMLElement>('[data-role="assistant"]')).at(-1)!
+    const status = surface.querySelector<HTMLElement>('[data-slot="composer-status-stack"]')!
+    const styles = getComputedStyle(chatSurface)
+
+    return {
+      composerHeight: Number.parseFloat(styles.getPropertyValue('--composer-measured-height')),
+      distanceFromBottom: viewport.scrollHeight - viewport.clientHeight - viewport.scrollTop,
+      latestMessageBottom: latest.getBoundingClientRect().bottom,
+      statusPanelTop: status.getBoundingClientRect().top,
+      viewportHeight: viewport.clientHeight,
+    }
+  })
+}
+
+test.describe('working-session task-panel clearance', () => {
+  let fixture: MockBackendFixture | null = null
+
+  test.beforeEach(async () => {
+    fixture = await setupMockBackend({
+      mockServer: { holdFirstCompletionContaining: TASK_PANEL_RESUME_TRIGGER },
+    })
+    await waitForAppReady(fixture, 120_000)
+  })
+
+  test.afterEach(async () => {
+    await fixture?.cleanup()
+    fixture = null
+  })
+
+  test('window focus reanchors a working session above the expanded task panel', async ({}, testInfo) => {
+    const page = fixture!.page
+
+    await send(page, PROMPT)
+    await fixture!.mock.waitForHeldCompletion()
+    await openFreshDraft(page)
+
+    // Re-open while the long response is still streaming. Its todo call lands
+    // afterward, so the already-visible composer grows only after the initial
+    // session-load scroll settle has finished.
+    fixture!.mock.releaseHeldStream()
+    await page.waitForTimeout(1_000)
+    await reopenWorkingSession(page)
+    await expect(activeSurface(page).getByText('Tasks 1/5')).toBeVisible({ timeout: 30_000 })
+
+    // Reproduce the stale geometry at the foreground boundary. Active turns
+    // disable Chromium's background throttling, so visibility can stay `visible`
+    // and window focus is the only foreground edge that can repair it.
+    await page.waitForTimeout(750)
+    const staleState = await activeSurface(page)
+      .locator('[data-slot="aui_thread-viewport"]')
+      .evaluate(viewport => {
+        // Grow scrollHeight before the observed thread-content node. This
+        // shifts the transcript behind the dock without resizing the observed
+        // node or synthesizing a user scroll (which must escape the lock).
+        const staleClearance = document.createElement('div')
+        staleClearance.style.height = '160px'
+        staleClearance.setAttribute('aria-hidden', 'true')
+        viewport.prepend(staleClearance)
+
+        const distance = viewport.scrollHeight - viewport.clientHeight - viewport.scrollTop
+        const surface = viewport.closest<HTMLElement>('[data-composer-target]')!
+        const latest = Array.from(surface.querySelectorAll<HTMLElement>('[data-role="assistant"]')).at(-1)!
+        const status = surface.querySelector<HTMLElement>('[data-slot="composer-status-stack"]')!
+
+        window.dispatchEvent(new Event('focus'))
+
+        return {
+          distance,
+          following: viewport.dataset.following,
+          latestMessageBottom: latest.getBoundingClientRect().bottom,
+          statusPanelTop: status.getBoundingClientRect().top,
+          visibility: document.visibilityState,
+        }
+      })
+
+    expect(staleState.visibility, JSON.stringify(staleState)).toBe('visible')
+    expect(staleState.following, JSON.stringify(staleState)).toBe('true')
+    expect(staleState.distance).toBeGreaterThan(100)
+    expect(staleState.latestMessageBottom, JSON.stringify(staleState)).toBeGreaterThan(staleState.statusPanelTop)
+    await page.waitForTimeout(1_000)
+    const metrics = await clearanceMetrics(page)
+    await page.screenshot({ path: testInfo.outputPath('task-panel-after-resume.png') })
+
+    expect(metrics.composerHeight, JSON.stringify(metrics)).toBeGreaterThanOrEqual(190)
+    expect(metrics.distanceFromBottom, JSON.stringify(metrics)).toBeLessThan(staleState.distance / 2)
+    expect(metrics.latestMessageBottom, JSON.stringify(metrics)).toBeLessThanOrEqual(metrics.statusPanelTop)
+  })
+})

--- a/apps/desktop/src/app/chat/composer/status-stack/index.tsx
+++ b/apps/desktop/src/app/chat/composer/status-stack/index.tsx
@@ -240,6 +240,7 @@ export function ComposerStatusStack({ queue, sessionId }: ComposerStatusStackPro
       // bottom-anchored, so this grows upward over the thread without needing
       // to be positioned — and it shares the dock's left edge for free.
       className="flex max-h-[40vh] min-h-0 flex-col overflow-y-auto"
+      data-slot="composer-status-stack"
       onPointerDownCapture={() => blurComposerInput()}
     >
       {/* The card paints the shared --composer-fill (rest / scrolled / focused

--- a/apps/desktop/src/app/chat/sidebar/virtual-session-list.test.tsx
+++ b/apps/desktop/src/app/chat/sidebar/virtual-session-list.test.tsx
@@ -1,0 +1,85 @@
+import { cleanup, render } from '@testing-library/react'
+import type * as React from 'react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import type { SidebarListRow } from '@/lib/session-date-groups'
+
+import { VirtualSessionList } from './virtual-session-list'
+
+const virtualizer = {
+  getTotalSize: () => 68,
+  getVirtualItems: () => [
+    { end: 26, index: 0, start: 0 },
+    { end: 68, index: 1, start: 26 }
+  ],
+  measureElement: vi.fn()
+}
+
+vi.mock('@dnd-kit/sortable', () => ({ useSortable: vi.fn() }))
+vi.mock('@dnd-kit/utilities', () => ({ CSS: { Transform: { toString: vi.fn() } } }))
+vi.mock('@tanstack/react-virtual', () => ({ useVirtualizer: () => virtualizer }))
+
+vi.mock('@/i18n', () => ({
+  useI18n: () => ({
+    t: {
+      sidebar: {
+        dateDivider: {
+          earlierThisMonth: 'Earlier this month',
+          lastMonth: 'Last month',
+          lastWeek: 'Last week',
+          older: 'Older',
+          today: 'Today',
+          yesterday: 'Yesterday'
+        }
+      }
+    }
+  })
+}))
+
+vi.mock('./chrome', () => ({
+  SidebarDateDivider: ({ label, ...props }: { label: string } & React.ComponentProps<'div'>) => (
+    <div data-testid={`divider-${label}`} {...props} />
+  )
+}))
+
+vi.mock('./session-row', () => ({ SidebarSessionRow: () => null }))
+
+afterEach(cleanup)
+
+const rows: SidebarListRow[] = [
+  { key: 'today', kind: 'divider', label: 'Today' },
+  { key: 'older', kind: 'divider', label: 'Older' }
+]
+
+const noop = () => {}
+
+describe('VirtualSessionList', () => {
+  it('positions measured rows independently within a total-size spacer', () => {
+    const { getByTestId } = render(
+      <VirtualSessionList
+        activeSessionId={null}
+        onArchiveSession={noop}
+        onDeleteSession={noop}
+        onResumeSession={noop}
+        onTogglePin={noop}
+        pinned={false}
+        rows={rows}
+        sortable={false}
+      />
+    )
+
+    const firstItem = getByTestId('divider-Today').parentElement
+    const secondItem = getByTestId('divider-Older').parentElement
+    const spacer = firstItem?.parentElement
+
+    expect(firstItem?.dataset.index).toBe('0')
+    expect(firstItem?.style.position).toBe('absolute')
+    expect(firstItem?.style.transform).toBe('translateY(0px)')
+    expect(secondItem?.dataset.index).toBe('1')
+    expect(secondItem?.style.transform).toBe('translateY(26px)')
+    expect(spacer?.className).toBe('relative')
+    expect(spacer?.style.height).toBe('68px')
+    expect(spacer?.style.paddingTop).toBe('')
+    expect(spacer?.style.paddingBottom).toBe('')
+  })
+})

--- a/apps/desktop/src/app/chat/sidebar/virtual-session-list.tsx
+++ b/apps/desktop/src/app/chat/sidebar/virtual-session-list.tsx
@@ -2,7 +2,7 @@ import { useSortable } from '@dnd-kit/sortable'
 import { CSS } from '@dnd-kit/utilities'
 import { useVirtualizer } from '@tanstack/react-virtual'
 import type * as React from 'react'
-import { type FC, useCallback, useRef } from 'react'
+import { type FC, useRef } from 'react'
 
 import type { SessionInfo } from '@/hermes'
 import { useI18n } from '@/i18n'
@@ -88,8 +88,6 @@ export const VirtualSessionList: FC<VirtualSessionListProps> = ({
 
   const virtualItems = virtualizer.getVirtualItems()
   const totalSize = virtualizer.getTotalSize()
-  const paddingTop = virtualItems[0]?.start ?? 0
-  const paddingBottom = Math.max(0, totalSize - (virtualItems[virtualItems.length - 1]?.end ?? 0))
 
   const rows = virtualItems.map(virtualItem => {
     const row = listRows[virtualItem.index]
@@ -98,16 +96,23 @@ export const VirtualSessionList: FC<VirtualSessionListProps> = ({
       return null
     }
 
+    const itemStyle: React.CSSProperties = {
+      left: 0,
+      position: 'absolute',
+      top: 0,
+      transform: `translateY(${virtualItem.start}px)`,
+      width: '100%'
+    }
+
     // Dividers are non-sortable, self-measured rows interleaved with sessions.
     if (row.kind === 'divider') {
       return (
-        <SidebarDateDivider
-          action={dividerAction}
-          data-index={virtualItem.index}
-          key={row.key}
-          label={'label' in row ? row.label : sessionBucketLabel(row.bucket, dividerLabels)}
-          ref={virtualizer.measureElement}
-        />
+        <div data-index={virtualItem.index} key={row.key} ref={virtualizer.measureElement} style={itemStyle}>
+          <SidebarDateDivider
+            action={dividerAction}
+            label={'label' in row ? row.label : sessionBucketLabel(row.bucket, dividerLabels)}
+          />
+        </div>
       )
     }
 
@@ -129,21 +134,13 @@ export const VirtualSessionList: FC<VirtualSessionListProps> = ({
     }
 
     return reorderable ? (
-      <VirtualSortableRow
-        index={virtualItem.index}
-        key={session.id}
-        measureRef={virtualizer.measureElement}
-        rowProps={commonProps}
-        session={session}
-      />
+      <div data-index={virtualItem.index} key={session.id} ref={virtualizer.measureElement} style={itemStyle}>
+        <VirtualSortableRow rowProps={commonProps} session={session} />
+      </div>
     ) : (
-      <SidebarSessionRow
-        {...commonProps}
-        data-index={virtualItem.index}
-        key={session.id}
-        ref={virtualizer.measureElement}
-        session={session}
-      />
+      <div data-index={virtualItem.index} key={session.id} ref={virtualizer.measureElement} style={itemStyle}>
+        <SidebarSessionRow {...commonProps} session={session} />
+      </div>
     )
   })
 
@@ -164,41 +161,25 @@ export const VirtualSessionList: FC<VirtualSessionListProps> = ({
       )}
       ref={scrollerRef}
     >
-      <div className="grid gap-px" style={{ paddingBottom: `${paddingBottom}px`, paddingTop: `${paddingTop}px` }}>
-        {rows}
-      </div>
+      <div className="relative" style={{ height: `${totalSize}px` }}>{rows}</div>
     </div>
   )
 }
 
 interface VirtualSortableRowProps {
-  index: number
-  measureRef: (node: Element | null) => void
   rowProps: SessionRowCommonProps
   session: SessionInfo
 }
 
-function VirtualSortableRow({ index, measureRef, rowProps, session }: VirtualSortableRowProps) {
+function VirtualSortableRow({ rowProps, session }: VirtualSortableRowProps) {
   const { attributes, isDragging, listeners, setNodeRef, transform, transition } = useSortable({ id: session.id })
-
-  // Merge dnd-kit's setNodeRef with the virtualizer's measureElement so
-  // the row participates in both DnD hit-testing and TanStack height
-  // measurement.
-  const refMerged = useCallback(
-    (node: HTMLDivElement | null) => {
-      setNodeRef(node)
-      measureRef(node)
-    },
-    [measureRef, setNodeRef]
-  )
 
   return (
     <SidebarSessionRow
       {...rowProps}
-      data-index={index}
       dragging={isDragging}
       dragHandleProps={{ ...attributes, ...listeners }}
-      ref={refMerged}
+      ref={setNodeRef}
       reorderable
       session={session}
       style={{ transform: CSS.Transform.toString(transform), transition }}

--- a/apps/desktop/src/components/assistant-ui/thread/list.test.ts
+++ b/apps/desktop/src/components/assistant-ui/thread/list.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import {
   buildGroups,
@@ -9,8 +9,81 @@ import {
   liveTailStart,
   type MessageGroup,
   resolveThreadScrollTarget,
+  subscribeToThreadForeground,
   transcriptPaneBudget
 } from './list'
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('subscribeToThreadForeground', () => {
+  it('reanchors on focus when an active turn keeps document visibility pinned visible', () => {
+    const reanchor = vi.fn()
+
+    const raf = vi.spyOn(window, 'requestAnimationFrame').mockImplementation(callback => {
+      callback(0)
+
+      return 1
+    })
+
+    const unsubscribe = subscribeToThreadForeground(() => true, reanchor)
+
+    window.dispatchEvent(new Event('focus'))
+
+    expect(raf).toHaveBeenCalledOnce()
+    expect(reanchor).toHaveBeenCalledOnce()
+    unsubscribe()
+  })
+
+  it('leaves a scrolled-up reader in place when the window focuses', () => {
+    const reanchor = vi.fn()
+    const raf = vi.spyOn(window, 'requestAnimationFrame')
+    const unsubscribe = subscribeToThreadForeground(() => false, reanchor)
+
+    window.dispatchEvent(new Event('focus'))
+
+    expect(raf).not.toHaveBeenCalled()
+    expect(reanchor).not.toHaveBeenCalled()
+    unsubscribe()
+  })
+
+  it('drops a queued reanchor when the reader scrolls away before the frame', () => {
+    const frames: FrameRequestCallback[] = []
+    let following = true
+    const reanchor = vi.fn()
+
+    vi.spyOn(window, 'requestAnimationFrame').mockImplementation(callback => {
+      frames.push(callback)
+
+      return 7
+    })
+
+    const unsubscribe = subscribeToThreadForeground(() => following, reanchor)
+
+    window.dispatchEvent(new Event('focus'))
+    following = false
+    frames[0]?.(0)
+
+    expect(reanchor).not.toHaveBeenCalled()
+    unsubscribe()
+  })
+
+  it('cancels a queued reanchor when its thread unmounts', () => {
+    const cancel = vi.spyOn(window, 'cancelAnimationFrame')
+    const reanchor = vi.fn()
+
+    vi.spyOn(window, 'requestAnimationFrame').mockReturnValue(9)
+
+    const unsubscribe = subscribeToThreadForeground(() => true, reanchor)
+
+    window.dispatchEvent(new Event('focus'))
+    unsubscribe()
+
+    expect(cancel).toHaveBeenCalledWith(9)
+    expect(reanchor).not.toHaveBeenCalled()
+  })
+})
 
 // Signature rows are `${index}:${id}:${role}:${weight}` (see the useAuiState
 // selector in list.tsx).

--- a/apps/desktop/src/components/assistant-ui/thread/list.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/list.tsx
@@ -22,7 +22,6 @@ import { useI18n } from '@/i18n'
 import { messagePaintWeight } from '@/lib/render-weight'
 import { cn } from '@/lib/utils'
 import {
-  $threadScrolledUp,
   onScrollToBottomRequest,
   onThreadEditClose,
   onThreadEditOpen,
@@ -123,6 +122,49 @@ export const resolveThreadScrollTarget: GetTargetScrollTop = (targetScrollTop, {
   const remaining = targetScrollTop - currentScrollTop
 
   return remaining >= 0 && remaining <= SCROLL_TARGET_EPSILON_PX ? currentScrollTop : targetScrollTop
+}
+
+export function subscribeToThreadForeground(shouldReanchor: () => boolean, onReanchor: () => void): () => void {
+  let frameId: number | null = null
+  let framePending = false
+
+  const onForeground = () => {
+    if (framePending || document.visibilityState !== 'visible' || !shouldReanchor()) {
+      return
+    }
+
+    framePending = true
+
+    const scheduledId = requestAnimationFrame(() => {
+      frameId = null
+      framePending = false
+
+      if (document.visibilityState === 'visible' && shouldReanchor()) {
+        onReanchor()
+      }
+    })
+
+    // Browser callbacks are asynchronous; the guard also keeps synchronous
+    // requestAnimationFrame test doubles from leaving a completed frame pending.
+    if (framePending) {
+      frameId = scheduledId
+    }
+  }
+
+  document.addEventListener('visibilitychange', onForeground)
+  window.addEventListener('focus', onForeground)
+
+  return () => {
+    document.removeEventListener('visibilitychange', onForeground)
+    window.removeEventListener('focus', onForeground)
+
+    if (frameId !== null) {
+      cancelAnimationFrame(frameId)
+    }
+
+    frameId = null
+    framePending = false
+  }
 }
 
 interface ThreadMessageListProps {
@@ -526,21 +568,18 @@ const ThreadMessageListInner: FC<ThreadMessageListProps> = ({
   useEffect(() => onScrollToBottomRequest(() => void scrollToBottom()), [scrollToBottom])
 
   // Waking from display: hidden (HUD mode hides the main window; OS hide does
-  // the same to any window): rAF and ResizeObserver were frozen the whole
-  // time, so the virtualizer's measurements — and scrollTop itself — are
-  // stale. If the user was following the bottom, re-anchor once visible;
-  // leave a scrolled-up reader exactly where they were.
-  useEffect(() => {
-    const onVisible = () => {
-      if (document.visibilityState === 'visible' && !$threadScrolledUp.get()) {
-        requestAnimationFrame(() => void scrollToBottom())
-      }
-    }
-
-    document.addEventListener('visibilitychange', onVisible)
-
-    return () => document.removeEventListener('visibilitychange', onVisible)
-  }, [scrollToBottom])
+  // the same to any window): rAF and ResizeObserver may have been frozen, so
+  // the virtualizer's measurements — and scrollTop itself — are stale. Active
+  // turns disable Chromium's background throttling, which can keep visibility
+  // pinned at `visible`; window focus is then the only foreground edge. If the
+  // user was following the bottom, re-anchor on either signal. Consult this
+  // thread's local state rather than the composer-facing global mirror, which
+  // can be overwritten by another mounted pane; leave a scrolled-up reader
+  // exactly where they were.
+  useEffect(
+    () => subscribeToThreadForeground(() => isAtBottom, () => void scrollToBottom()),
+    [isAtBottom, scrollToBottom]
+  )
 
   const endEditHold = useCallback(() => {
     scrollRef.current?.removeAttribute('data-editing')

--- a/apps/desktop/src/components/pane-shell/tree/renderer/tree-split.tsx
+++ b/apps/desktop/src/components/pane-shell/tree/renderer/tree-split.tsx
@@ -647,7 +647,12 @@ function Sash({
     <div
       className={cn(
         'group absolute z-20 [-webkit-app-region:no-drag]',
-        horizontal ? 'inset-y-0 left-0 w-[9px] -translate-x-1/2' : 'inset-x-0 top-0 h-[9px] -translate-y-1/2',
+        // Asymmetric grab band: only 1px reaches into the leading pane so its
+        // edge-hugging 4px scrollbar stays clickable (the old centered 9px band
+        // swallowed it entirely — the pointer got col-resize instead of the
+        // thumb). The trailing side keeps a generous 7px reach; total grab
+        // width stays ~8px so the sash is no harder to hit.
+        horizontal ? 'inset-y-0 left-0 w-[8px] -translate-x-[1px]' : 'inset-x-0 top-0 h-[8px] -translate-y-[1px]',
         disabled ? 'pointer-events-none' : horizontal ? 'cursor-col-resize' : 'cursor-row-resize'
       )}
       onDoubleClick={disabled ? undefined : onDoubleClick}
@@ -661,7 +666,7 @@ function Sash({
       <span
         className={cn(
           'absolute bg-(--ui-stroke-secondary) opacity-10 transition-opacity duration-100 group-hover:opacity-100',
-          horizontal ? 'inset-y-0 left-1/2 w-px -translate-x-1/2' : 'inset-x-0 top-1/2 h-px -translate-y-1/2'
+          horizontal ? 'inset-y-0 left-[1px] w-px -translate-x-1/2' : 'inset-x-0 top-[1px] h-px -translate-y-1/2'
         )}
       />
       {!disabled && (
@@ -669,8 +674,8 @@ function Sash({
           className={cn(
             'absolute bg-(--ui-sash-hover-border) opacity-0 transition-opacity duration-100 group-hover:opacity-100',
             horizontal
-              ? 'inset-y-0 left-1/2 w-(--vscode-sash-hover-size,0.25rem) -translate-x-1/2'
-              : 'inset-x-0 top-1/2 h-(--vscode-sash-hover-size,0.25rem) -translate-y-1/2'
+              ? 'inset-y-0 left-[1px] w-(--vscode-sash-hover-size,0.25rem) -translate-x-1/2'
+              : 'inset-x-0 top-[1px] h-(--vscode-sash-hover-size,0.25rem) -translate-y-1/2'
           )}
         />
       )}

--- a/contributors/emails/nicolasdmolina76@gmail.com
+++ b/contributors/emails/nicolasdmolina76@gmail.com
@@ -1,0 +1,1 @@
+nicolasdmolina


### PR DESCRIPTION
Salvages the Desktop virtualized-scrolling cluster into one green-ready branch. Credit to @konsisumer (#84804) and @nicolasdmolina (#83070) — both commits cherry-picked with authorship preserved.

## What's here

### 1. `fix(desktop): stabilize virtual session scrolling` (from #84804, by @konsisumer)

The sidebar session list positioned virtual rows with `paddingTop`/`paddingBottom` on a `grid gap-px` wrapper. Every scroll frame re-measured rows whose offsets the padding had just shifted, feeding TanStack Virtual a measurement-correction loop: visible rows flickered/jumped, worse the further you scrolled (#83813), and the scrollbar thumb jittered against the relayout (#71156).

Fix: standard TanStack absolute-positioning contract — one `position: relative` spacer at `getTotalSize()`, each row `position: absolute` + `translateY(virtualItem.start)`. Measurement no longer moves what it measures. Also un-merges the dnd-kit ref from the measure ref (the measure wrapper is now a dedicated element), removing double-measure churn while dragging. Adds a regression test suite (`virtual-session-list.test.tsx`).

### 2. `fix(desktop): reanchor transcript on window focus` (from #83070, by @nicolasdmolina)

The transcript re-anchored to bottom only on `visibilitychange`, and consulted the global `$threadScrolledUp` mirror which another mounted pane can overwrite. Active turns disable Chromium background throttling, which can keep `visibilityState` pinned at `visible` — so waking a window produced no re-anchor edge, and the stale virtualizer measurements left sessions where scrolling up rubber-banded or refused to move (#70447).

Fix: extracted `subscribeToThreadForeground()` listening on both `visibilitychange` **and** `window focus`, rAF-coalesced, consulting this thread's local `isAtBottom` instead of the global mirror. Scrolled-up readers stay exactly where they were. Unit tests + an e2e spec (`task-panel-clearance.spec.ts`) included.

Cherry-picked cleanly onto current `main` (the `list.tsx` conflict from the intervening delivery/message work auto-merged; deletion audit run — every removed line is the intended replacement).

### 3. `fix(desktop): keep session-list scrollbar clickable beside pane sash` (new, #79157)

The pane-resize sash's 9px grab band was centered on the split boundary, so ~4.5px overlapped the leading pane's 4px scrollbar — the pointer always hit the sash (`col-resize`) and the scrollbar was unclickable. Same virtualized-list area, trivial hit-target fix: asymmetric grab band (1px into the leading pane, 7px trailing, ~8px total), hairline/hover strip repositioned onto the actual boundary. Sash stays an easy target; the scrollbar regains its full hit area.

## Issue coverage

| Issue | Status |
|---|---|
| #83813 sidebar list flickers (measurement-correction loop) | ✅ fixed (commit 1) |
| #71156 sidebar scrollbar jitter on Windows | ✅ fixed (commit 1 — same loop, jitter was its scrollbar-side symptom) |
| #70447 cannot scroll up in some sessions | ✅ fixed (commit 2) |
| #79157 scrollbar unclickable (sash overlap) | ✅ fixed (commit 3) |
| #69180 renderer OOM crash-loop on empty chat | ⚠️ **residual** — the issue's own CDP evidence points at the transcript's `content-visibility:auto` / `contain-intrinsic-size` native-layout thrash (commit `3de91c697`), a different loop from the sidebar's padding feedback fixed here. Main has since gained the live-tail exemption mitigations, but the empty-chat native-RSS ramp is not addressed by this cluster and needs its own investigation. |

## Testing

- `vitest run src/app/chat/sidebar/virtual-session-list.test.tsx src/components/assistant-ui/thread/list.test.ts` — 25/25 pass
- `npm run typecheck` (all three tsconfigs) — clean
- `eslint` on all touched `src/` files — 0 errors, 0 warnings

## Infographic

![Desktop: Stable Virtualized Scrolling](https://files.catbox.moe/2l6cep.png)

Nous Research
