### PR TITLE
fix(desktop): salvage compaction transcript-visibility cluster — surface archived turns + preserve running-session transcripts (#67871)

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
@@ -2083,7 +2083,6 @@ describe('resumeSession warm-cache mapping integrity', () => {
 
     expect(currentPromptRows).toHaveLength(1)
     expect(JSON.stringify(resumedState?.messages)).toContain('partial answer')
->>>>>>> bfb973e25c (fix(desktop): preserve full transcripts for running sessions)
   })
 
   it('keeps a warm runtime and optimistic turn on a transient activation timeout', async () => {

--- a/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
@@ -612,6 +612,8 @@ function ResumeHarness({
   sessionStateByRuntimeIdRef?: MutableRefObject<Map<string, ClientSessionState>>
 }) {
   const ref = <T,>(value: T): MutableRefObject<T> => ({ current: value })
+  const runtimeMapRef = runtimeIdByStoredSessionIdRef ?? ref(new Map<string, string>())
+  const stateMapRef = sessionStateByRuntimeIdRef ?? ref(new Map<string, ClientSessionState>())
 
   const actions = useSessionActions({
     activeSessionId: null,
@@ -624,13 +626,16 @@ function ResumeHarness({
     navigate: vi.fn() as never,
     requestGateway,
     resetViewSync: vi.fn(),
-    runtimeIdByStoredSessionIdRef: runtimeIdByStoredSessionIdRef ?? ref(new Map<string, string>()),
+    runtimeIdByStoredSessionIdRef: runtimeMapRef,
     selectedStoredSessionId,
     selectedStoredSessionIdRef: ref<string | null>(selectedStoredSessionId),
-    sessionStateByRuntimeIdRef: sessionStateByRuntimeIdRef ?? ref(new Map<string, ClientSessionState>()),
+    sessionStateByRuntimeIdRef: stateMapRef,
     syncSessionStateToView: vi.fn(),
     updateSessionState: (sessionId, updater) => {
-      const next = updater({} as ClientSessionState)
+      const current = stateMapRef.current.get(sessionId) ?? ({} as ClientSessionState)
+      const next = updater(current)
+
+      stateMapRef.current.set(sessionId, next)
       onStateUpdate?.(sessionId, next)
 
       return next
@@ -767,11 +772,15 @@ describe('resumeSession failure recovery', () => {
     expect($messages.get().map(message => message.id)).toContain('user-optimistic')
   })
 
-  it('restores the in-flight turn and queued user prompt after a full renderer restart', async () => {
+  it('keeps the complete transcript with the live tail after a full renderer restart', async () => {
     const storedMessages = [
-      { content: 'earlier question', role: 'user', timestamp: 1 },
-      { content: 'earlier answer', role: 'assistant', timestamp: 2 }
+      { content: 'older question removed by compression', role: 'user', timestamp: 1 },
+      { content: 'older answer removed by compression', role: 'assistant', timestamp: 2 },
+      { content: 'recent question', role: 'user', timestamp: 3 },
+      { content: 'recent answer', role: 'assistant', timestamp: 4 }
     ]
+
+    const compressedRuntimeMessages = storedMessages.slice(-2)
 
     vi.mocked(getLatestSessionMessages).mockResolvedValue({ messages: storedMessages, session_id: 'stored-1' } as never)
 
@@ -781,8 +790,8 @@ describe('resumeSession failure recovery', () => {
           session_id: 'runtime-1',
           session_key: 'stored-1',
           resumed: 'stored-1',
-          message_count: storedMessages.length,
-          messages: storedMessages,
+          message_count: compressedRuntimeMessages.length,
+          messages: compressedRuntimeMessages,
           running: true,
           inflight: {
             user: 'current prompt',
@@ -810,9 +819,97 @@ describe('resumeSession failure recovery', () => {
     await resume!('stored-1', true)
 
     const renderedMessages = JSON.stringify(resumedState?.messages)
+    expect(renderedMessages).toContain('older question removed by compression')
     expect(renderedMessages).toContain('current prompt')
     expect(renderedMessages).toContain('partial answer')
     expect(renderedMessages).toContain('newest prompt')
+  })
+
+  it('preserves a runtime-cache delta that arrives while cold resume waits for REST', async () => {
+    const persisted = deferred<Awaited<ReturnType<typeof getLatestSessionMessages>>>()
+
+    const sessionStateByRuntimeIdRef: MutableRefObject<Map<string, ClientSessionState>> = {
+      current: new Map()
+    }
+
+    const compressedRuntimeMessages = [
+      { content: 'recent question', role: 'user', timestamp: 3 },
+      { content: 'recent answer', role: 'assistant', timestamp: 4 }
+    ]
+
+    vi.mocked(getLatestSessionMessages).mockReturnValue(persisted.promise)
+
+    const requestGateway = vi.fn(async (method: string) => {
+      if (method === 'session.resume') {
+        return {
+          session_id: 'runtime-1',
+          session_key: 'stored-1',
+          resumed: 'stored-1',
+          message_count: compressedRuntimeMessages.length,
+          messages: compressedRuntimeMessages,
+          running: true,
+          inflight: {
+            user: 'current prompt',
+            assistant: 'partial A',
+            streaming: true
+          },
+          info: {}
+        } as never
+      }
+
+      return {} as never
+    })
+
+    let resumedState: ClientSessionState | undefined
+    let resume: ((storedSessionId: string, replaceRoute?: boolean) => Promise<unknown>) | null = null
+
+    render(
+      <ResumeHarness
+        onReady={ready => (resume = ready)}
+        onStateUpdate={(_sessionId, state) => (resumedState = state)}
+        requestGateway={requestGateway}
+        sessionStateByRuntimeIdRef={sessionStateByRuntimeIdRef}
+      />
+    )
+    await waitFor(() => expect(resume).not.toBeNull())
+
+    const resumePromise = resume!('stored-1', true)
+
+    await waitFor(() => expect(requestGateway).toHaveBeenCalledWith('session.resume', expect.anything()))
+
+    const runtimeState = clientState('stored-1')
+    runtimeState.messages = [
+      {
+        id: 'assistant-stream-live-cold',
+        role: 'assistant',
+        parts: [{ type: 'text', text: ' + delta B' }],
+        pending: true
+      }
+    ]
+    runtimeState.streamId = 'assistant-stream-live-cold'
+    sessionStateByRuntimeIdRef.current.set('runtime-1', runtimeState)
+
+    await act(async () => {
+      persisted.resolve({
+        messages: [
+          { content: 'older question removed by compression', role: 'user', timestamp: 1 },
+          { content: 'older answer removed by compression', role: 'assistant', timestamp: 2 },
+          ...compressedRuntimeMessages
+        ],
+        session_id: 'stored-1'
+      } as never)
+      await resumePromise
+    })
+
+    const renderedText = JSON.stringify(resumedState?.messages)
+
+    const streamingAssistantRows = resumedState?.messages.filter(message => message.id.startsWith('assistant-stream-'))
+
+    expect(renderedText).toContain('older question removed by compression')
+    expect(renderedText).toContain('partial A')
+    expect(renderedText).toContain('delta B')
+    expect(streamingAssistantRows).toHaveLength(1)
+    expect(streamingAssistantRows?.[0].id).toBe('assistant-stream-live-cold')
   })
 
   it('uses the continuation projection when resume rotates an equal-length stored transcript', async () => {
@@ -1679,6 +1776,314 @@ describe('resumeSession warm-cache mapping integrity', () => {
     const renderedMessages = JSON.stringify(resumedState?.messages)
     expect(renderedMessages).toContain('still here after wake')
     expect(renderedMessages).toContain('still here after wake too')
+  })
+
+  it('keeps the complete persisted transcript when activating a compressed running session', async () => {
+    const runtimeIdByStoredSessionIdRef: MutableRefObject<Map<string, string>> = {
+      current: new Map([['stored-A', 'rt-A']])
+    }
+
+    const state = clientState('stored-A')
+    state.messages = [
+      {
+        id: 'runtime-user',
+        role: 'user',
+        parts: [{ type: 'text', text: 'recent prompt' }]
+      },
+      {
+        id: 'runtime-assistant',
+        role: 'assistant',
+        parts: [{ type: 'text', text: 'recent answer' }]
+      }
+    ]
+
+    const sessionStateByRuntimeIdRef: MutableRefObject<Map<string, ClientSessionState>> = {
+      current: new Map([['rt-A', state]])
+    }
+
+    const persistedMessages = [
+      { content: 'older prompt that compression removed', role: 'user', timestamp: 1 },
+      { content: 'older answer that compression removed', role: 'assistant', timestamp: 2 },
+      { content: 'recent prompt', role: 'user', timestamp: 3 },
+      { content: 'recent answer', role: 'assistant', timestamp: 4 }
+    ]
+
+    const compressedRuntimeMessages = persistedMessages.slice(2)
+
+    vi.mocked(getLatestSessionMessages).mockResolvedValue({
+      messages: persistedMessages,
+      session_id: 'stored-A'
+    } as never)
+
+    const requestGateway = vi.fn(async (method: string) => {
+      if (method === 'session.activate') {
+        return {
+          session_id: 'rt-A',
+          session_key: 'stored-A',
+          resumed: 'stored-A',
+          message_count: compressedRuntimeMessages.length,
+          messages: compressedRuntimeMessages,
+          running: true,
+          inflight: {
+            user: 'current prompt',
+            assistant: 'partial answer',
+            streaming: true
+          },
+          info: {}
+        } as never
+      }
+
+      return {} as never
+    })
+
+    let resumedState: ClientSessionState | undefined
+    let resume: ((storedSessionId: string, replaceRoute?: boolean) => Promise<unknown>) | null = null
+
+    render(
+      <ResumeHarness
+        onReady={ready => (resume = ready)}
+        onStateUpdate={(_sessionId, next) => (resumedState = next)}
+        requestGateway={requestGateway}
+        runtimeIdByStoredSessionIdRef={runtimeIdByStoredSessionIdRef}
+        sessionStateByRuntimeIdRef={sessionStateByRuntimeIdRef}
+      />
+    )
+    await waitFor(() => expect(resume).not.toBeNull())
+    await resume!('stored-A', true)
+
+    const renderedMessages = resumedState?.messages ?? []
+    const renderedText = JSON.stringify(renderedMessages)
+
+    expect(renderedText).toContain('older prompt that compression removed')
+    expect(renderedText).toContain('older answer that compression removed')
+    expect(renderedText).toContain('recent prompt')
+    expect(renderedText).toContain('recent answer')
+    expect(renderedText).toContain('partial answer')
+    expect(renderedMessages.filter(message => JSON.stringify(message).includes('current prompt'))).toHaveLength(1)
+  })
+
+  it('preserves live cache updates that arrive while the persisted transcript is loading', async () => {
+    const runtimeIdByStoredSessionIdRef: MutableRefObject<Map<string, string>> = {
+      current: new Map([['stored-A', 'rt-A']])
+    }
+
+    const state = clientState('stored-A')
+    state.messages = [
+      {
+        id: 'runtime-user',
+        role: 'user',
+        parts: [{ type: 'text', text: 'recent prompt' }],
+        timestamp: 3
+      },
+      {
+        id: 'runtime-assistant',
+        role: 'assistant',
+        parts: [{ type: 'text', text: 'recent answer' }],
+        timestamp: 4
+      },
+      {
+        id: 'user-inflight-rt-A',
+        role: 'user',
+        parts: [{ type: 'text', text: 'current prompt' }]
+      },
+      {
+        id: 'assistant-stream-live-123',
+        role: 'assistant',
+        parts: [{ type: 'text', text: 'partial A' }],
+        pending: true
+      }
+    ]
+
+    const sessionStateByRuntimeIdRef: MutableRefObject<Map<string, ClientSessionState>> = {
+      current: new Map([['rt-A', state]])
+    }
+
+    const persisted = deferred<Awaited<ReturnType<typeof getLatestSessionMessages>>>()
+
+    const compressedRuntimeMessages = [
+      { content: 'recent prompt', role: 'user', timestamp: 3 },
+      { content: 'recent answer', role: 'assistant', timestamp: 4 }
+    ]
+
+    vi.mocked(getLatestSessionMessages).mockReturnValue(persisted.promise)
+
+    const requestGateway = vi.fn(async (method: string) => {
+      if (method === 'session.activate') {
+        return {
+          session_id: 'rt-A',
+          session_key: 'stored-A',
+          resumed: 'stored-A',
+          message_count: compressedRuntimeMessages.length,
+          messages: compressedRuntimeMessages,
+          running: true,
+          inflight: {
+            user: 'current prompt',
+            assistant: 'partial A',
+            streaming: true
+          },
+          info: {}
+        } as never
+      }
+
+      return {} as never
+    })
+
+    let resumedState: ClientSessionState | undefined
+    let resume: ((storedSessionId: string, replaceRoute?: boolean) => Promise<unknown>) | null = null
+
+    render(
+      <ResumeHarness
+        onReady={ready => (resume = ready)}
+        onStateUpdate={(_sessionId, next) => (resumedState = next)}
+        requestGateway={requestGateway}
+        runtimeIdByStoredSessionIdRef={runtimeIdByStoredSessionIdRef}
+        sessionStateByRuntimeIdRef={sessionStateByRuntimeIdRef}
+      />
+    )
+    await waitFor(() => expect(resume).not.toBeNull())
+
+    const resumePromise = resume!('stored-A', true)
+
+    await waitFor(() => expect(requestGateway).toHaveBeenCalledWith('session.activate', expect.anything()))
+
+    const liveState = sessionStateByRuntimeIdRef.current.get('rt-A')!
+
+    const liveMessages = liveState.messages.map(message =>
+      message.id === 'assistant-stream-live-123'
+        ? { ...message, parts: [{ type: 'text' as const, text: 'partial A + delta B' }] }
+        : message
+    )
+
+    sessionStateByRuntimeIdRef.current.set('rt-A', {
+      ...liveState,
+      messages: [
+        ...liveMessages,
+        {
+          id: 'user-racing',
+          role: 'user',
+          parts: [{ type: 'text', text: 'racing prompt' }]
+        }
+      ]
+    })
+
+    await act(async () => {
+      persisted.resolve({
+        messages: [
+          { content: 'older prompt', role: 'user', timestamp: 1 },
+          { content: 'older answer', role: 'assistant', timestamp: 2 },
+          ...compressedRuntimeMessages
+        ],
+        session_id: 'stored-A'
+      } as never)
+      await resumePromise
+    })
+
+    const renderedText = JSON.stringify(resumedState?.messages)
+
+    expect(renderedText).toContain('older prompt')
+    expect(renderedText).toContain('partial A + delta B')
+    expect(renderedText).toContain('racing prompt')
+
+    const streamingAssistantRows = resumedState?.messages.filter(message => message.id.startsWith('assistant-stream-'))
+
+    expect(streamingAssistantRows).toHaveLength(1)
+    expect(streamingAssistantRows?.[0].id).toBe('assistant-stream-live-123')
+  })
+
+  it('does not duplicate an in-flight user prompt already present in the persisted suffix', async () => {
+    const runtimeIdByStoredSessionIdRef: MutableRefObject<Map<string, string>> = {
+      current: new Map([['stored-A', 'rt-A']])
+    }
+
+    const state = clientState('stored-A')
+    state.messages = [
+      {
+        id: 'runtime-user',
+        role: 'user',
+        parts: [{ type: 'text', text: 'earlier prompt' }]
+      },
+      {
+        id: 'runtime-assistant',
+        role: 'assistant',
+        parts: [{ type: 'text', text: 'earlier answer' }]
+      },
+      {
+        id: 'user-optimistic',
+        role: 'user',
+        parts: [{ type: 'text', text: 'current prompt' }]
+      },
+      {
+        id: 'assistant-stream-rt-A',
+        role: 'assistant',
+        parts: [{ type: 'text', text: 'partial answer' }],
+        pending: true
+      }
+    ]
+
+    const sessionStateByRuntimeIdRef: MutableRefObject<Map<string, ClientSessionState>> = {
+      current: new Map([['rt-A', state]])
+    }
+
+    const compressedRuntimeMessages = [
+      { content: 'earlier prompt', role: 'user', timestamp: 1 },
+      { content: 'earlier answer', role: 'assistant', timestamp: 2 }
+    ]
+
+    const persistedMessages = [
+      { content: 'older prompt removed by compression', role: 'user', timestamp: -1 },
+      { content: 'older answer removed by compression', role: 'assistant', timestamp: 0 },
+      ...compressedRuntimeMessages,
+      { content: 'current prompt', role: 'user', timestamp: 3 }
+    ]
+
+    vi.mocked(getLatestSessionMessages).mockResolvedValue({
+      messages: persistedMessages,
+      session_id: 'stored-A'
+    } as never)
+
+    const requestGateway = vi.fn(async (method: string) => {
+      if (method === 'session.activate') {
+        return {
+          session_id: 'rt-A',
+          session_key: 'stored-A',
+          resumed: 'stored-A',
+          message_count: compressedRuntimeMessages.length,
+          messages: compressedRuntimeMessages,
+          running: true,
+          inflight: {
+            user: 'current prompt',
+            assistant: 'partial answer',
+            streaming: true
+          },
+          info: {}
+        } as never
+      }
+
+      return {} as never
+    })
+
+    let resumedState: ClientSessionState | undefined
+    let resume: ((storedSessionId: string, replaceRoute?: boolean) => Promise<unknown>) | null = null
+
+    render(
+      <ResumeHarness
+        onReady={ready => (resume = ready)}
+        onStateUpdate={(_sessionId, next) => (resumedState = next)}
+        requestGateway={requestGateway}
+        runtimeIdByStoredSessionIdRef={runtimeIdByStoredSessionIdRef}
+        sessionStateByRuntimeIdRef={sessionStateByRuntimeIdRef}
+      />
+    )
+    await waitFor(() => expect(resume).not.toBeNull())
+    await resume!('stored-A', true)
+
+    const currentPromptRows = (resumedState?.messages ?? []).filter(message =>
+      JSON.stringify(message).includes('current prompt')
+    )
+
+    expect(currentPromptRows).toHaveLength(1)
+    expect(JSON.stringify(resumedState?.messages)).toContain('partial answer')
+>>>>>>> bfb973e25c (fix(desktop): preserve full transcripts for running sessions)
   })
 
   it('keeps a warm runtime and optimistic turn on a transient activation timeout', async () => {

--- a/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
@@ -82,10 +82,13 @@ import {
   applyStoredSessionPreviewRuntimeInfo,
   type BranchMessage,
   chatMessageArraysEquivalent,
+  dedupeInflightUserAgainstTranscript,
   isSessionGoneError,
+  overlayConcurrentMessageChanges,
   patchSessionWorkspace,
   preserveLocalPendingTurnMessages,
   reconcileResumeMessages,
+  removeRepresentedLocalLiveProjection,
   resolveResumedBusy,
   resolveSessionProfile,
   resolveStoredSession,
@@ -137,17 +140,27 @@ function applyStoredUsage(stored: { input_tokens?: number | null; output_tokens?
   setCurrentUsage(current => ({ ...current, input, output, total: input + output }))
 }
 
+function reconcileAuthoritativeChatMessages(
+  authoritativeMessages: ChatMessage[],
+  previousMessages: ChatMessage[],
+  liveProjection?: Pick<SessionResumeResponse, 'inflight' | 'queued' | 'session_id'>
+): ChatMessage[] {
+  const withLiveProjection = liveProjection
+    ? appendLiveSessionProjection(authoritativeMessages, liveProjection)
+    : authoritativeMessages
+
+  const reconciled = reconcileResumeMessages(withLiveProjection, previousMessages)
+  const withPendingTurn = preserveLocalPendingTurnMessages(reconciled, previousMessages)
+
+  return preserveLocalAssistantErrors(withPendingTurn, previousMessages)
+}
+
 function reconcileAuthoritativeMessages(
   authoritativeMessages: SessionResumeResponse['messages'],
   previousMessages: ChatMessage[],
   liveProjection?: Pick<SessionResumeResponse, 'inflight' | 'queued' | 'session_id'>
 ): ChatMessage[] {
-  const authoritative = toChatMessages(authoritativeMessages)
-  const withLiveProjection = liveProjection ? appendLiveSessionProjection(authoritative, liveProjection) : authoritative
-  const reconciled = reconcileResumeMessages(withLiveProjection, previousMessages)
-  const withPendingTurn = preserveLocalPendingTurnMessages(reconciled, previousMessages)
-
-  return preserveLocalAssistantErrors(withPendingTurn, previousMessages)
+  return reconcileAuthoritativeChatMessages(toChatMessages(authoritativeMessages), previousMessages, liveProjection)
 }
 
 // `session.create` params from the current profile + sticky-UI model/effort/fast,
@@ -839,12 +852,12 @@ export function useSessionActions({
                 Boolean(sessionStateByRuntimeIdRef.current.get(cachedRuntimeId)?.busy)
               )
 
-              // While idle, the persisted REST transcript is the display
-              // authority: session.activate returns the runtime's compressed
-              // context projection, not necessarily the complete conversation.
-              // During a live turn, keep the runtime/cache projection so an
-              // accepted but not-yet-persisted prompt or stream is never lost.
-              if (!running && persistedTranscriptPromise) {
+              // The persisted REST transcript is the display authority: a live
+              // runtime may carry only the agent's compressed context projection,
+              // which is intentionally smaller than the user-visible conversation.
+              // Reconcile its in-flight/queued tail onto the complete transcript
+              // instead of replacing durable history while the turn is running.
+              if (persistedTranscriptPromise) {
                 const persisted = await persistedTranscriptPromise
 
                 if (!isCurrentResume()) {
@@ -869,8 +882,32 @@ export function useSessionActions({
                   persistedMatchesActivatedSession &&
                   (persisted.messages.length || !activatedMessages.length)
                 ) {
-                  activatedMessages = reconcileAuthoritativeMessages(persisted.messages, activatedMessages)
+                  const persistedMessages = toChatMessages(persisted.messages)
+                  const runtimeMessages = toChatMessages(activated.messages)
+                  const previousMessages = removeRepresentedLocalLiveProjection(cachedViewState.messages, activated)
+
+                  const liveProjection = dedupeInflightUserAgainstTranscript(
+                    persistedMessages,
+                    runtimeMessages,
+                    activated
+                  )
+
+                  activatedMessages = reconcileAuthoritativeChatMessages(
+                    persistedMessages,
+                    previousMessages,
+                    liveProjection
+                  )
                 }
+              }
+
+              const currentMessages = sessionStateByRuntimeIdRef.current.get(cachedRuntimeId)?.messages
+
+              if (currentMessages) {
+                activatedMessages = overlayConcurrentMessageChanges(
+                  activatedMessages,
+                  cachedViewState.messages,
+                  currentMessages
+                )
               }
 
               const activatedState = updateSessionState(
@@ -967,6 +1004,7 @@ export function useSessionActions({
 
         let prefetchApplied = false
         let prefetchedStoredSessionId: string | null = null
+        let prefetchedTranscriptMessages: ChatMessage[] | null = null
 
         // REST transcript prefetch and the gateway resume RPC are independent
         // — run them concurrently so a big session's wall time is
@@ -974,6 +1012,8 @@ export function useSessionActions({
         // transcript as soon as it lands; the RPC binds the runtime id.
         // Watch windows skip the prefetch — lazy resume attaches the live mirror.
         const prefetchPromise = watchWindow ? null : getLatestSessionMessages(storedSessionId, sessionProfile)
+
+        let resumeRuntimeBaselineMessages: ChatMessage[] = []
 
         const resumePromise = requestGateway<SessionResumeResponse>('session.resume', {
           session_id: storedSessionId,
@@ -988,6 +1028,11 @@ export function useSessionActions({
           // background while the prefetch above paints the transcript.
           ...(watchWindow ? { lazy: true } : { omit_messages: true }),
           ...(sessionProfile ? { profile: sessionProfile } : {})
+        }).then(resumed => {
+          resumeRuntimeBaselineMessages =
+            sessionStateByRuntimeIdRef.current.get(resumed.session_id)?.messages ?? resumeRuntimeBaselineMessages
+
+          return resumed
         })
 
         // The rejection is consumed by the `await` below; this guard only
@@ -1018,7 +1063,8 @@ export function useSessionActions({
             ? preserveLocalPendingTurnMessages($messages.get(), resumeStartMessages)
             : $messages.get()
 
-          localSnapshot = reconcileAuthoritativeMessages(prefetchedResult.messages, previousMessages)
+          prefetchedTranscriptMessages = toChatMessages(prefetchedResult.messages)
+          localSnapshot = reconcileAuthoritativeChatMessages(prefetchedTranscriptMessages, previousMessages)
           prefetchApplied = true
           prefetchedStoredSessionId = prefetchedResult.session_id || storedSessionId
         }
@@ -1037,26 +1083,63 @@ export function useSessionActions({
 
         const hasLiveProjection = Boolean(resumed.inflight || resumed.queued)
 
-        const preferredMessages =
-          prefetchApplied && prefetchMatchesResumedSession && !hasLiveProjection
-            ? localSnapshot
-            : (() => {
-                const previousMessages = resumedSameSelectedSession
-                  ? preserveLocalPendingTurnMessages(currentMessages, resumeStartMessages)
-                  : currentMessages
+        const preferredMessages = (() => {
+          if (prefetchApplied && prefetchMatchesResumedSession) {
+            if (hasLiveProjection && prefetchedTranscriptMessages) {
+              const runtimeMessages = toChatMessages(resumed.messages)
+              const previousMessages = removeRepresentedLocalLiveProjection(currentMessages, resumed)
 
-                // Omitted, not empty — same trap as the activate path above.
-                // The REST prefetch IS the transcript here; the resume payload
-                // only contributes the live tail, so graft rather than rebuild.
-                // (Without a usable prefetch there is nothing better to stand
-                // on, so the projection alone remains the degraded fallback.)
-                const resumedMessages =
-                  resumed.messages_omitted && prefetchApplied && prefetchMatchesResumedSession
-                    ? appendLiveSessionProjection(localSnapshot, resumed)
-                    : reconcileAuthoritativeMessages(resumed.messages, previousMessages, resumed)
+              // Omitted-messages resumes stay safe here: `resumed.messages`
+              // is empty, so `runtimeMessages` has no anchor and the dedupe
+              // helper returns the projection unchanged, while the REST
+              // prefetch below remains the authoritative transcript — the
+              // same "graft, don't rebuild" outcome the pre-restructure
+              // messages_omitted branch produced.
+              const liveProjection = dedupeInflightUserAgainstTranscript(
+                prefetchedTranscriptMessages,
+                runtimeMessages,
+                resumed
+              )
 
-                return chatMessageArraysEquivalent(currentMessages, resumedMessages) ? currentMessages : resumedMessages
-              })()
+              const resumedMessages = reconcileAuthoritativeChatMessages(
+                prefetchedTranscriptMessages,
+                previousMessages,
+                liveProjection
+              )
+
+              const withConcurrentChanges = overlayConcurrentMessageChanges(
+                resumedMessages,
+                localSnapshot,
+                currentMessages
+              )
+
+              return chatMessageArraysEquivalent(currentMessages, withConcurrentChanges)
+                ? currentMessages
+                : withConcurrentChanges
+            }
+
+            if (!hasLiveProjection) {
+              return localSnapshot
+            }
+          }
+
+          const previousMessages = resumedSameSelectedSession
+            ? preserveLocalPendingTurnMessages(currentMessages, resumeStartMessages)
+            : currentMessages
+
+          const resumedMessages = reconcileAuthoritativeMessages(resumed.messages, previousMessages, resumed)
+
+          return chatMessageArraysEquivalent(currentMessages, resumedMessages) ? currentMessages : resumedMessages
+        })()
+
+        const currentRuntimeMessages =
+          sessionStateByRuntimeIdRef.current.get(resumed.session_id)?.messages ?? resumeRuntimeBaselineMessages
+
+        const preferredWithRuntimeChanges = overlayConcurrentMessageChanges(
+          preferredMessages,
+          resumeRuntimeBaselineMessages,
+          currentRuntimeMessages
+        )
 
         // #70449: same stale-snapshot guard as the warm path — a turn that
         // started while the resume RPC was in flight has already marked the
@@ -1071,20 +1154,16 @@ export function useSessionActions({
         // (persisted by use-session-state-cache while the turn streamed;
         // survives renderer/app death) back onto the restored transcript. The
         // backend's own inflight projection is already inside
-        // `preferredMessages` (appendLiveSessionProjection), so this merge only
-        // adds the locally recorded structure — tool calls, sealed interim
-        // rows — that the backend's text-only snapshot cannot carry. A no-op
-        // returns `preferredMessages` by reference, keeping the fast path
-        // below intact.
-        const inFlightRecovery = recoverInFlightTurnJournal(storedSessionId, preferredMessages, {
+        // `preferredWithRuntimeChanges`, so this merge only adds the locally
+        // recorded structure that the backend's text-only snapshot cannot carry.
+        const inFlightRecovery = recoverInFlightTurnJournal(storedSessionId, preferredWithRuntimeChanges, {
           keepPending: resumedRunning
         })
 
         recoveredInFlightTail = inFlightRecovery.applied
 
-        // Prefetch-hit fast path: `preferredMessages` IS the live `$messages`
-        // array (already error-merged when `localSnapshot` was built), so reuse
-        // the ref instead of rebuilding a throwaway transcript+Map every switch.
+        // Prefetch-hit fast path: reuse the live array when neither runtime
+        // changes nor in-flight recovery changed the reconciled transcript.
         const messagesForView =
           inFlightRecovery.messages === currentMessages
             ? currentMessages

--- a/apps/desktop/src/app/session/hooks/use-session-actions/utils.test.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/utils.test.ts
@@ -13,7 +13,7 @@ import {
   setSelectedStoredSessionId,
   workspaceCwdBelongsToSelectedSession
 } from '@/store/session'
-import type { SessionInfo } from '@/types/hermes'
+import type { SessionInfo, SessionResumeResponse } from '@/types/hermes'
 
 import {
   appendLiveSessionProjection,
@@ -22,9 +22,12 @@ import {
   chatMessageArraysEquivalent,
   chatMessagesEquivalent,
   chatPartsEquivalent,
+  dedupeInflightUserAgainstTranscript,
   isSessionGoneError,
+  overlayConcurrentMessageChanges,
   preserveLocalPendingTurnMessages,
   reconcileResumeMessages,
+  removeRepresentedLocalLiveProjection,
   resolveResumedBusy,
   sessionMatchesStoredId,
   sessionShouldHaveTranscript,
@@ -1445,5 +1448,179 @@ describe('resolveResumedBusy', () => {
   it('adopts a running turn reported by the snapshot even without live state', () => {
     expect(resolveResumedBusy(true, false)).toBe(true)
     expect(resolveResumedBusy(true, true)).toBe(true)
+  })
+})
+
+const runningProjection = (user: string): SessionResumeResponse =>
+  ({
+    session_id: 'runtime-1',
+    session_key: 'stored-1',
+    resumed: 'stored-1',
+    message_count: 2,
+    messages: [],
+    running: true,
+    inflight: { user, assistant: 'partial answer', streaming: true }
+  }) as SessionResumeResponse
+
+describe('dedupeInflightUserAgainstTranscript', () => {
+  it('retains the in-flight user source only when it already exists after the runtime anchor', () => {
+    const runtime = [
+      msg('runtime-user', 'user', 'earlier prompt', { timestamp: 1 }),
+      msg('runtime-assistant', 'assistant', 'earlier answer', { timestamp: 2 })
+    ]
+
+    const persisted = [...runtime, msg('persisted-current', 'user', 'current prompt', { timestamp: 3 })]
+
+    const deduped = dedupeInflightUserAgainstTranscript(persisted, runtime, runningProjection('current prompt'))
+
+    expect(deduped.inflight?.user).toBe('current prompt')
+    expect(deduped.inflight?.assistant).toBe('partial answer')
+  })
+
+  it('preserves the assistant boundary before a queued turn when the persisted in-flight user has no delta', () => {
+    const runtime = [
+      msg('runtime-user', 'user', 'earlier prompt', { timestamp: 1 }),
+      msg('runtime-assistant', 'assistant', 'earlier answer', { timestamp: 2 })
+    ]
+
+    const persisted = [...runtime, msg('persisted-current', 'user', 'current prompt', { timestamp: 3 })]
+
+    const projection = {
+      ...runningProjection('current prompt'),
+      inflight: { user: 'current prompt', assistant: '', streaming: false },
+      queued: { user: 'queued prompt' }
+    }
+
+    const deduped = dedupeInflightUserAgainstTranscript(persisted, runtime, projection)
+    const restored = appendLiveSessionProjection(persisted, deduped)
+
+    expect(restored.map(message => message.role)).toEqual(['user', 'assistant', 'user', 'assistant', 'user'])
+    expect(restored.slice(-2).map(message => message.id)).toEqual([
+      'assistant-stream-runtime-1',
+      'user-queued-runtime-1'
+    ])
+  })
+
+  it('preserves an intentionally repeated prompt when the match is before the runtime anchor', () => {
+    const runtime = [
+      msg('runtime-user', 'user', 'repeat this', { timestamp: 1 }),
+      msg('runtime-assistant', 'assistant', 'finished answer', { timestamp: 2 })
+    ]
+
+    const projection = runningProjection('repeat this')
+    const unchanged = dedupeInflightUserAgainstTranscript(runtime, runtime, projection)
+
+    expect(unchanged).toBe(projection)
+    expect(unchanged.inflight?.user).toBe('repeat this')
+  })
+
+  it('preserves a repeated in-flight prompt when the persisted match already has an answer', () => {
+    const runtime = [
+      msg('runtime-user', 'user', 'earlier prompt', { timestamp: 1 }),
+      msg('runtime-assistant', 'assistant', 'earlier answer', { timestamp: 2 })
+    ]
+
+    const persisted = [
+      ...runtime,
+      msg('persisted-repeat', 'user', 'repeat this', { timestamp: 3 }),
+      msg('persisted-repeat-answer', 'assistant', 'finished repeat answer', { timestamp: 4 })
+    ]
+
+    const projection = runningProjection('repeat this')
+    const unchanged = dedupeInflightUserAgainstTranscript(persisted, runtime, projection)
+
+    expect(unchanged).toBe(projection)
+    expect(unchanged.inflight?.user).toBe('repeat this')
+  })
+})
+
+describe('removeRepresentedLocalLiveProjection', () => {
+  it('removes only matched synthetic rows from the open local tail', () => {
+    const previous = [
+      msg('user-old-optimistic', 'user', 'current prompt'),
+      msg('assistant-complete', 'assistant', 'finished answer'),
+      msg('user-current', 'user', 'current prompt'),
+      msg('assistant-stream-current', 'assistant', 'partial answer', { pending: true }),
+      msg('user-queued-runtime', 'user', 'queued prompt'),
+      msg('user-racing', 'user', 'new racing prompt')
+    ]
+
+    const projection = {
+      ...runningProjection('current prompt'),
+      queued: { user: 'queued prompt' }
+    }
+
+    const remaining = removeRepresentedLocalLiveProjection(previous, projection)
+
+    expect(remaining.map(message => message.id)).toEqual(['user-old-optimistic', 'assistant-complete', 'user-racing'])
+  })
+
+  it('preserves an ambiguous text-identical local race prompt without a matching stream boundary', () => {
+    const previous = [
+      msg('runtime-assistant', 'assistant', 'finished answer'),
+      msg('user-racing', 'user', 'repeat this')
+    ]
+
+    const projection = runningProjection('repeat this')
+
+    expect(removeRepresentedLocalLiveProjection(previous, projection)).toBe(previous)
+  })
+
+  it('does not consume a generic racing user as the activation-owned queued row', () => {
+    const previous = [
+      msg('runtime-assistant', 'assistant', 'finished answer'),
+      msg('user-current', 'user', 'current prompt'),
+      msg('assistant-stream-current', 'assistant', 'partial answer', { pending: true }),
+      msg('user-racing', 'user', 'repeat this')
+    ]
+
+    const projection = {
+      ...runningProjection('current prompt'),
+      queued: { user: 'repeat this' }
+    }
+
+    const remaining = removeRepresentedLocalLiveProjection(previous, projection)
+
+    expect(remaining.map(message => message.id)).toEqual(['runtime-assistant', 'user-racing'])
+  })
+})
+
+describe('overlayConcurrentMessageChanges', () => {
+  it('does not replace an authoritative row with an unchanged baseline cache row', () => {
+    const baseline = [msg('shared-assistant', 'assistant', 'stale cached answer')]
+    const authoritative = [msg('shared-assistant', 'assistant', 'completed persisted answer')]
+
+    const overlaid = overlayConcurrentMessageChanges(authoritative, baseline, baseline)
+
+    expect(overlaid).toBe(authoritative)
+    expect(overlaid[0].parts).toEqual([{ type: 'text', text: 'completed persisted answer' }])
+  })
+
+  it('replaces an activation stream placeholder and appends rows created after the baseline', () => {
+    const baseline = [msg('assistant-stream-runtime', 'assistant', 'partial A', { pending: true })]
+    const authoritative = [msg('assistant-stream-activation', 'assistant', 'partial A', { pending: true })]
+
+    const current = [
+      msg('assistant-stream-runtime', 'assistant', 'partial A + delta B', { pending: true }),
+      msg('user-racing', 'user', 'racing prompt')
+    ]
+
+    const overlaid = overlayConcurrentMessageChanges(authoritative, baseline, current)
+
+    expect(overlaid.map(message => message.id)).toEqual(['assistant-stream-runtime', 'user-racing'])
+    expect(overlaid[0].parts).toEqual([{ type: 'text', text: 'partial A + delta B' }])
+  })
+
+  it('merges an activation prefix with a baseline-new runtime delta chunk', () => {
+    const authoritative = [msg('assistant-stream-activation', 'assistant', 'partial A', { pending: true })]
+    const current = [msg('assistant-stream-runtime', 'assistant', ' + delta B', { pending: true })]
+
+    const overlaid = overlayConcurrentMessageChanges(authoritative, [], current)
+
+    expect(overlaid.map(message => message.id)).toEqual(['assistant-stream-runtime'])
+    expect(overlaid[0].parts).toEqual([
+      { type: 'text', text: 'partial A' },
+      { type: 'text', text: ' + delta B' }
+    ])
   })
 })

--- a/apps/desktop/src/app/session/hooks/use-session-actions/utils.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/utils.ts
@@ -683,10 +683,17 @@ export function preserveLocalPendingTurnMessages(
  * memory. Stable ids let repeated activate/resume hydration reconcile instead
  * of growing duplicate rows.
  */
-export function appendLiveSessionProjection(
-  messages: ChatMessage[],
-  projection: Pick<SessionResumeResponse, 'inflight' | 'queued' | 'session_id'>
-): ChatMessage[] {
+const safelyPersistedInflightUser = Symbol('safelyPersistedInflightUser')
+
+type LiveSessionProjection = Pick<SessionResumeResponse, 'inflight' | 'queued' | 'session_id'> & {
+  [safelyPersistedInflightUser]?: true
+}
+
+type ReconciledSessionResumeResponse = SessionResumeResponse & {
+  [safelyPersistedInflightUser]?: true
+}
+
+export function appendLiveSessionProjection(messages: ChatMessage[], projection: LiveSessionProjection): ChatMessage[] {
   const inflightUser = projection.inflight?.user?.trim() ?? ''
   const inflightAssistant = projection.inflight?.assistant ?? ''
   const inflightStreaming = Boolean(projection.inflight?.streaming)
@@ -762,7 +769,8 @@ export function appendLiveSessionProjection(
       message => textWithoutReferenceLines(chatMessageText(message)) === textWithoutReferenceLines(text)
     )
 
-  const inflightUserAlreadyPersisted = Boolean(inflightUser) && persistedInLatestRun(inflightUser)
+  const inflightUserAlreadyPersisted =
+    projection[safelyPersistedInflightUser] === true || (Boolean(inflightUser) && persistedInLatestRun(inflightUser))
 
   if (inflightUser && !inflightUserAlreadyPersisted) {
     projected.push({
@@ -892,6 +900,224 @@ export function appendLiveSessionProjection(
   }
 
   return projected.length ? [...messages, ...projected] : messages
+}
+
+function normalizedMessageText(message: ChatMessage): string {
+  return chatMessageText(message).replace(/\s+/g, ' ').trim()
+}
+
+function transcriptAnchorMatches(a: ChatMessage, b: ChatMessage): boolean {
+  if (a.role !== b.role) {
+    return false
+  }
+
+  const aText = normalizedMessageText(a)
+  const bText = normalizedMessageText(b)
+
+  if (a.timestamp !== undefined && b.timestamp !== undefined) {
+    return a.timestamp === b.timestamp && aText === bText
+  }
+
+  return Boolean(aText) && aText === bText
+}
+
+/**
+ * Mark only an already-materialized `inflight.user` for visual suppression.
+ *
+ * A running gateway returns two independent truths: its compressed runtime
+ * history plus the current in-flight turn, while REST may already have flushed
+ * that user row into the complete persisted transcript. Global text dedupe is
+ * unsafe because users may intentionally submit the same prompt twice. Instead,
+ * find the last runtime message inside the persisted transcript and inspect only
+ * the newer persisted suffix.
+ *
+ * Keep `inflight.user` intact because it also carries turn structure: a queued
+ * prompt needs its assistant boundary even when the persisted user has no
+ * assistant delta yet. The private marker lets the renderer suppress only that
+ * duplicate bubble. If the histories have no safe common anchor, keep the
+ * projection unchanged — a duplicate is recoverable, but dropping a real
+ * accepted prompt is not.
+ */
+export function dedupeInflightUserAgainstTranscript(
+  persistedMessages: ChatMessage[],
+  runtimeMessages: ChatMessage[],
+  projection: SessionResumeResponse
+): ReconciledSessionResumeResponse {
+  const inflightUser = projection.inflight?.user?.replace(/\s+/g, ' ').trim() ?? ''
+
+  if (!inflightUser) {
+    return projection
+  }
+
+  let suffixStart = 0
+
+  if (runtimeMessages.length) {
+    const runtimeAnchor = runtimeMessages[runtimeMessages.length - 1]
+    let persistedAnchorIndex = -1
+
+    for (let index = persistedMessages.length - 1; index >= 0; index -= 1) {
+      if (transcriptAnchorMatches(persistedMessages[index], runtimeAnchor)) {
+        persistedAnchorIndex = index
+
+        break
+      }
+    }
+
+    if (persistedAnchorIndex < 0) {
+      return projection
+    }
+
+    suffixStart = persistedAnchorIndex + 1
+  }
+
+  const persistedTail = persistedMessages.slice(suffixStart)
+  const lastPersistedMessage = persistedTail[persistedTail.length - 1]
+
+  const persistedUserPresent =
+    lastPersistedMessage?.role === 'user' && normalizedMessageText(lastPersistedMessage) === inflightUser
+
+  if (!persistedUserPresent) {
+    return projection
+  }
+
+  return { ...projection, [safelyPersistedInflightUser]: true }
+}
+
+/**
+ * Drop only synthetic local tail rows that the activation snapshot replaces.
+ * Unmatched optimistic rows survive so a submit racing with activation is not
+ * lost; completed transcript rows before the open tail are never considered.
+ */
+export function removeRepresentedLocalLiveProjection(
+  previousMessages: ChatMessage[],
+  projection: Pick<SessionResumeResponse, 'inflight' | 'queued'>
+): ChatMessage[] {
+  const inflightUser = projection.inflight?.user?.replace(/\s+/g, ' ').trim() ?? ''
+  const inflightAssistant = projection.inflight?.assistant?.replace(/\s+/g, ' ').trim() ?? ''
+  const queuedUser = projection.queued?.user?.replace(/\s+/g, ' ').trim() ?? ''
+
+  const hasAssistantProjection = Boolean(
+    projection.inflight?.assistant || projection.inflight?.streaming || (inflightUser && queuedUser)
+  )
+
+  if (!inflightUser || !hasAssistantProjection) {
+    return previousMessages
+  }
+
+  let openTailStart = 0
+
+  for (let index = previousMessages.length - 1; index >= 0; index -= 1) {
+    const message = previousMessages[index]
+
+    if (message.role === 'assistant' && !message.pending) {
+      openTailStart = index + 1
+
+      break
+    }
+  }
+
+  const inflightUserIndex = previousMessages.findIndex(
+    (message, index) =>
+      index >= openTailStart &&
+      message.role === 'user' &&
+      message.id.startsWith('user-') &&
+      normalizedMessageText(message) === inflightUser
+  )
+
+  const assistantIndex = inflightUserIndex + 1
+  const assistant = previousMessages[assistantIndex]
+
+  const assistantMatches =
+    inflightUserIndex >= openTailStart &&
+    assistant?.role === 'assistant' &&
+    assistant.id.startsWith('assistant-stream-') &&
+    normalizedMessageText(assistant) === inflightAssistant
+
+  if (!assistantMatches) {
+    return previousMessages
+  }
+
+  let queuedUserIndex = -1
+
+  if (queuedUser) {
+    queuedUserIndex = previousMessages.findIndex(
+      (message, index) =>
+        index > assistantIndex &&
+        message.role === 'user' &&
+        message.id.startsWith('user-queued-') &&
+        normalizedMessageText(message) === queuedUser
+    )
+  }
+
+  return previousMessages.filter(
+    (_message, index) => index !== inflightUserIndex && index !== assistantIndex && index !== queuedUserIndex
+  )
+}
+
+/**
+ * Overlay messages that changed while activation waited on REST. Existing ids
+ * replace the older activation row; only rows added or changed since the warm
+ * cache baseline are appended. This is identity-based, never text-based.
+ */
+export function overlayConcurrentMessageChanges(
+  nextMessages: ChatMessage[],
+  baselineMessages: ChatMessage[],
+  currentMessages: ChatMessage[]
+): ChatMessage[] {
+  const baselineById = new Map(baselineMessages.map(message => [message.id, message]))
+  const nextIndexById = new Map(nextMessages.map((message, index) => [message.id, index]))
+  let changed = false
+  const overlaid = [...nextMessages]
+
+  let activationStreamIndex = overlaid.findIndex(
+    message =>
+      message.role === 'assistant' && message.id.startsWith('assistant-stream-') && !baselineById.has(message.id)
+  )
+
+  for (const current of currentMessages) {
+    const baseline = baselineById.get(current.id)
+    const changedSinceBaseline = !baseline || !chatMessagesEquivalent(baseline, current)
+
+    if (!changedSinceBaseline) {
+      continue
+    }
+
+    const nextIndex = nextIndexById.get(current.id)
+
+    if (nextIndex !== undefined) {
+      if (!chatMessagesEquivalent(overlaid[nextIndex], current)) {
+        overlaid[nextIndex] = current
+        changed = true
+      }
+
+      continue
+    }
+
+    if (activationStreamIndex >= 0 && current.role === 'assistant' && current.id.startsWith('assistant-stream-')) {
+      const activationStream = overlaid[activationStreamIndex]
+      const activationText = chatMessageText(activationStream)
+      const currentText = chatMessageText(current)
+
+      const replacement =
+        activationText && !currentText.startsWith(activationText)
+          ? { ...current, parts: [...activationStream.parts, ...current.parts] }
+          : current
+
+      nextIndexById.delete(activationStream.id)
+      nextIndexById.set(current.id, activationStreamIndex)
+      overlaid[activationStreamIndex] = replacement
+      activationStreamIndex = -1
+      changed = true
+
+      continue
+    }
+
+    nextIndexById.set(current.id, overlaid.length)
+    overlaid.push(current)
+    changed = true
+  }
+
+  return changed ? overlaid : nextMessages
 }
 
 export interface BranchMessage {

--- a/apps/desktop/src/hermes.test.ts
+++ b/apps/desktop/src/hermes.test.ts
@@ -366,11 +366,11 @@ describe('Hermes REST helpers', () => {
 
     expect(result.messages).toEqual([{ id: 1 }, { id: 2 }, { id: 3 }])
     expect(api).toHaveBeenNthCalledWith(1, {
-      path: '/api/sessions/session-1/messages?profile=xiaoxuxu&limit=500&offset=0&order=oldest',
+      path: '/api/sessions/session-1/messages?profile=xiaoxuxu&limit=500&offset=0&order=oldest&include_compacted=true',
       profile: 'xiaoxuxu'
     })
     expect(api).toHaveBeenNthCalledWith(2, {
-      path: '/api/sessions/session-1/messages?profile=xiaoxuxu&limit=500&offset=2&order=oldest',
+      path: '/api/sessions/session-1/messages?profile=xiaoxuxu&limit=500&offset=2&order=oldest&include_compacted=true',
       profile: 'xiaoxuxu'
     })
   })

--- a/apps/desktop/src/hermes.ts
+++ b/apps/desktop/src/hermes.ts
@@ -679,7 +679,7 @@ export function getSession(id: string, profile?: string | null): Promise<Session
 export function getSessionMessages(
   id: string,
   profile?: string | null,
-  page: { limit?: number; offset?: number; order?: 'latest' | 'oldest' } = {}
+  page: { limit?: number; offset?: number; order?: 'latest' | 'oldest'; includeCompacted?: boolean } = {}
 ): Promise<SessionMessagesResponse> {
   const query = new URLSearchParams()
 
@@ -699,6 +699,10 @@ export function getSessionMessages(
     query.set('order', page.order)
   }
 
+  if (page.includeCompacted !== undefined) {
+    query.set('include_compacted', String(page.includeCompacted))
+  }
+
   const suffix = query.size ? `?${query.toString()}` : ''
 
   return window.hermesDesktop.api<SessionMessagesResponse>({
@@ -708,7 +712,10 @@ export function getSessionMessages(
 }
 
 export function getLatestSessionMessages(id: string, profile?: string | null): Promise<SessionMessagesResponse> {
-  return getSessionMessages(id, profile, { limit: 500, order: 'latest' })
+  // includeCompacted: durable display history must include rows preserved by
+  // in-place compaction (active=0, compacted=1); without them the transcript
+  // silently ends at the compaction boundary and earlier turns are unreachable.
+  return getSessionMessages(id, profile, { limit: 500, order: 'latest', includeCompacted: true })
 }
 
 export async function getAllSessionMessages(
@@ -727,7 +734,8 @@ export async function getAllSessionMessages(
     const page = await getSessionMessages(id, profile, {
       limit: pageSize,
       offset,
-      order: 'oldest'
+      order: 'oldest',
+      includeCompacted: true
     })
 
     resolvedSessionId = page.session_id

--- a/hermes_cli/web_routers/sessions.py
+++ b/hermes_cli/web_routers/sessions.py
@@ -605,6 +605,7 @@ async def get_session_messages(
     limit: Optional[int] = Query(None, ge=0),
     offset: int = Query(0, ge=0),
     order: Optional[str] = Query(None),
+    include_compacted: bool = Query(False),
 ):
     if order not in (None, "oldest", "latest"):
         raise HTTPException(
@@ -632,6 +633,7 @@ async def get_session_messages(
                 limit=_limit,
                 offset=offset,
                 latest=latest_page,
+                include_compacted=include_compacted,
             )
         finally:
             db.close()

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -9219,7 +9219,18 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 all_rows = cursor.fetchall()
             seen: dict = {}
             for row in all_rows:
-                key = (row["role"], row["content"], row["timestamp"])
+                # Tool fields participate in the dedupe key: compaction copies
+                # them verbatim, so identical tool messages across generations
+                # still collapse, while distinct tool calls that happen to
+                # share role/content/timestamp are never merged.
+                key = (
+                    row["role"],
+                    row["content"],
+                    row["timestamp"],
+                    row["tool_call_id"],
+                    row["tool_calls"],
+                    row["tool_name"],
+                )
                 cur = seen.get(key)
                 if cur is None or (row["active"], row["id"]) > (cur["active"], cur["id"]):
                     seen[key] = row

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -9142,6 +9142,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         self,
         session_id: str,
         include_inactive: bool = False,
+        include_compacted: bool = False,
         limit: Optional[int] = None,
         offset: int = 0,
         latest: bool = False,
@@ -9153,6 +9154,14 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         ``include_inactive=True`` to load soft-deleted rows (e.g. for
         audit / debug views of rewound history). See
         :meth:`rewind_to_message` for the soft-delete mechanic.
+
+        Pass ``include_compacted=True`` to additionally load rows preserved
+        by in-place context compaction (``active=0, compacted=1``). Those are
+        durable display history, not soft-deleted rows — a user-visible
+        transcript read must not drop them, or earlier turns silently become
+        unreachable once the UI exhausts its active-only window. Soft-deleted
+        Undo/Rewind rows (``active=0, compacted=0``) stay excluded; use
+        ``include_inactive`` for those.
 
         Ordered by AUTOINCREMENT id (true insertion order) rather than
         timestamp — see c03acca50 for the WSL2 clock-regression rationale.
@@ -9172,7 +9181,18 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         """
         if after_id is not None and (latest or offset):
             raise ValueError("after_id is incompatible with latest/offset paging")
-        active_clause = "" if include_inactive else " AND active = 1"
+        if after_id is not None and include_compacted:
+            raise ValueError("after_id is incompatible with include_compacted (deduped display reads use offset paging)")
+        if include_inactive:
+            # Audit / debug reads: every row, including soft-deleted.
+            active_clause = ""
+        elif include_compacted:
+            # Display history: active rows plus rows preserved by in-place
+            # compaction (active=0, compacted=1), but never soft-deleted
+            # Undo/Rewind rows (active=0, compacted=0).
+            active_clause = " AND (active = 1 OR compacted = 1)"
+        else:
+            active_clause = " AND active = 1"
         keyset_clause = " AND id > ?" if after_id is not None else ""
         sql = (
             "SELECT * FROM messages WHERE session_id = ?"
@@ -9181,15 +9201,46 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         params: list = [session_id]
         if after_id is not None:
             params.append(after_id)
-        if limit is not None or offset:
-            # SQLite's OFFSET requires LIMIT; -1 means "no limit".
-            sql += " LIMIT ? OFFSET ?"
-            params.extend([-1 if limit is None else limit, offset])
-        with self._read_ctx() as conn:
-            cursor = conn.execute(sql, params)
-            rows = cursor.fetchall()
-        if latest:
-            rows.reverse()
+        if include_compacted:
+            # Compaction epochs copy the protected tail into each new
+            # generation, so the same logical message can exist as several
+            # rows (identical role/content/timestamp) with different active
+            # flags and ids. A display read must surface each message exactly
+            # once: prefer the live row, then the newest generation. Read the
+            # full display set (a session's rows are bounded; the UI-level
+            # 500-row cap lives in the endpoint, not here), dedupe in Python,
+            # then apply paging.
+            with self._read_ctx() as conn:
+                cursor = conn.execute(
+                    "SELECT * FROM messages WHERE session_id = ?" + active_clause
+                    + " ORDER BY id ASC",
+                    [session_id],
+                )
+                all_rows = cursor.fetchall()
+            seen: dict = {}
+            for row in all_rows:
+                key = (row["role"], row["content"], row["timestamp"])
+                cur = seen.get(key)
+                if cur is None or (row["active"], row["id"]) > (cur["active"], cur["id"]):
+                    seen[key] = row
+            rows = sorted(seen.values(), key=lambda r: r["id"])
+            if latest:
+                rows = rows[::-1]
+            rows = rows[offset:]
+            if limit is not None:
+                rows = rows[:limit]
+            if latest:
+                rows = rows[::-1]
+        else:
+            if limit is not None or offset:
+                # SQLite's OFFSET requires LIMIT; -1 means "no limit".
+                sql += " LIMIT ? OFFSET ?"
+                params.extend([-1 if limit is None else limit, offset])
+            with self._read_ctx() as conn:
+                cursor = conn.execute(sql, params)
+                rows = cursor.fetchall()
+            if latest:
+                rows.reverse()
         result = []
         for row in rows:
             msg = dict(row)

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -1945,6 +1945,45 @@ class TestWebServerEndpoints:
         contents = [m["content"] for m in resp.json()["messages"]]
         assert contents == ["old q", "old a", "summary", "live q", "live a"]
 
+    def test_get_session_messages_latest_page_with_compacted_rows(self):
+        """The desktop's real read path (getLatestSessionMessages: limit +
+        order=latest + include_compacted=true) pages back from the newest
+        message and returns the window in chronological order.
+        """
+        from hermes_state import SessionDB
+
+        db = SessionDB()
+        try:
+            db.create_session(session_id="compacted-latest", source="cli")
+            db.append_messages_batch(
+                "compacted-latest",
+                [
+                    {"role": "user", "content": "old q"},
+                    {"role": "assistant", "content": "old a"},
+                ],
+            )
+            db.archive_and_compact(
+                "compacted-latest",
+                [
+                    {"role": "assistant", "content": "summary"},
+                    {"role": "user", "content": "live q"},
+                    {"role": "assistant", "content": "live a"},
+                ],
+            )
+        finally:
+            db.close()
+
+        # Display history: old q, old a, summary, live q, live a (5 rows).
+        resp = self.client.get(
+            "/api/sessions/compacted-latest/messages"
+            "?include_compacted=true&limit=2&offset=1&order=latest"
+        )
+        assert resp.status_code == 200
+        contents = [m["content"] for m in resp.json()["messages"]]
+        # Newest-first window of 2, skipping the newest (live a):
+        # summary, live q — chronological order, matching the non-compacted path.
+        assert contents == ["summary", "live q"]
+
     def test_get_session_messages_omitted_limit_defaults_to_500(self):
         """The dashboard must never load an entire unbounded transcript."""
         from hermes_state import SessionDB

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -1877,6 +1877,74 @@ class TestWebServerEndpoints:
         assert resp.status_code == 200
         assert resp.json()["pagination"]["limit"] == 500
 
+    def test_get_session_messages_default_hides_compacted_rows(self):
+        """The endpoint default matches get_messages: active rows only.
+
+        Guards the #80680 contract — display reads opt into compacted history
+        explicitly; the dashboard default view stays as it was.
+        """
+        from hermes_state import SessionDB
+
+        db = SessionDB()
+        try:
+            db.create_session(session_id="compacted-default", source="cli")
+            db.append_messages_batch(
+                "compacted-default",
+                [
+                    {"role": "user", "content": "old q"},
+                    {"role": "assistant", "content": "old a"},
+                ],
+            )
+            db.archive_and_compact(
+                "compacted-default",
+                [
+                    {"role": "assistant", "content": "summary"},
+                    {"role": "user", "content": "live q"},
+                    {"role": "assistant", "content": "live a"},
+                ],
+            )
+        finally:
+            db.close()
+
+        resp = self.client.get("/api/sessions/compacted-default/messages")
+        assert resp.status_code == 200
+        contents = [m["content"] for m in resp.json()["messages"]]
+        assert contents == ["summary", "live q", "live a"]
+
+    def test_get_session_messages_include_compacted_surfaces_archived_rows(self):
+        """include_compacted=true returns the full display history: archived
+        (active=0, compacted=1) rows plus live rows, in insertion order.
+        """
+        from hermes_state import SessionDB
+
+        db = SessionDB()
+        try:
+            db.create_session(session_id="compacted-visible", source="cli")
+            db.append_messages_batch(
+                "compacted-visible",
+                [
+                    {"role": "user", "content": "old q"},
+                    {"role": "assistant", "content": "old a"},
+                ],
+            )
+            db.archive_and_compact(
+                "compacted-visible",
+                [
+                    {"role": "assistant", "content": "summary"},
+                    {"role": "user", "content": "live q"},
+                    {"role": "assistant", "content": "live a"},
+                ],
+            )
+        finally:
+            db.close()
+
+        resp = self.client.get(
+            "/api/sessions/compacted-visible/messages?include_compacted=true"
+        )
+        assert resp.status_code == 200
+        contents = [m["content"] for m in resp.json()["messages"]]
+        assert contents == ["old q", "old a", "summary", "live q", "live a"]
+
     def test_get_session_messages_omitted_limit_defaults_to_500(self):
         """The dashboard must never load an entire unbounded transcript."""
         from hermes_state import SessionDB

--- a/tests/hermes_state/test_get_messages_include_compacted.py
+++ b/tests/hermes_state/test_get_messages_include_compacted.py
@@ -1,0 +1,207 @@
+"""Tests for SessionDB.get_messages(include_compacted=...).
+
+In-place compaction archives earlier turns as ``active=0, compacted=1`` rows
+that are durable display history, not soft-deleted rows. A transcript read
+that drops them silently cuts the user-visible conversation off at the
+compaction boundary (#80680): the UI exhausts its active-only window, "Show
+earlier messages" disappears, and earlier turns become unreachable even
+though they are still on disk.
+
+``include_compacted=True`` must surface those rows while still excluding
+soft-deleted Undo/Rewind rows (``active=0, compacted=0``) — that remains the
+job of ``include_inactive`` (audit / debug reads).
+"""
+
+import pytest
+
+from hermes_state import SessionDB
+
+
+@pytest.fixture
+def db(tmp_path):
+    return SessionDB(tmp_path / "state.db")
+
+
+def _seed(db, sid="s1"):
+    """Session with 4 archived (compacted) turns + 2 live turns + 1 rewound row."""
+    db.create_session(sid, source="cli")
+    old = [
+        {"role": "user", "content": "old q1"},
+        {"role": "assistant", "content": "old a1"},
+        {"role": "user", "content": "old q2"},
+        {"role": "assistant", "content": "old a2"},
+    ]
+    db.append_messages_batch(sid, old)
+    db.archive_and_compact(
+        sid,
+        [
+            {"role": "assistant", "content": "summary of old turns"},
+            {"role": "user", "content": "live q1"},
+            {"role": "assistant", "content": "live a1"},
+        ],
+    )
+    # Soft-delete the last live user turn (active=0, compacted=0) so every
+    # row class is present: active=1/compacted=0, active=0/compacted=1,
+    # active=0/compacted=0. rewind_to_message requires a user target.
+    live = db.get_messages(sid)
+    user_msg = next(m for m in reversed(live) if m["role"] == "user")
+    db.rewind_to_message(sid, user_msg["id"])
+    return db
+
+
+def _row_ids(db, sid, **kwargs):
+    return [m["id"] for m in db.get_messages(sid, **kwargs)]
+
+
+class TestIncludeCompacted:
+    def test_default_returns_only_active_rows(self, db):
+        """Regression guard: the default read must not change behaviour."""
+        sid = "s1"
+        db = _seed(db, sid)
+        msgs = db.get_messages(sid)
+        assert all(m["active"] for m in msgs)
+        # Only the compaction summary survived (the rewind soft-deleted
+        # the live user turn AND everything after it); the 4 archived rows
+        # stay hidden.
+        assert len(msgs) == 1
+
+    def test_include_compacted_surfaces_archived_rows(self, db):
+        sid = "s1"
+        db = _seed(db, sid)
+        msgs = db.get_messages(sid, include_compacted=True)
+        # 4 archived + 1 live (the summary); the 2 rewound rows are excluded.
+        assert len(msgs) == 5
+        assert all(m["active"] or m["compacted"] for m in msgs)
+        # Archived rows are the oldest — they come first in insertion order.
+        assert msgs[0]["content"] == "old q1"
+        assert msgs[-1]["content"] == "summary of old turns"
+
+    def test_include_compacted_excludes_soft_deleted_rows(self, db):
+        """Undo/Rewind rows (active=0, compacted=0) stay hidden."""
+        sid = "s1"
+        db = _seed(db, sid)
+        msgs = db.get_messages(sid, include_compacted=True)
+        assert not any(not m["active"] and not m["compacted"] for m in msgs)
+
+    def test_include_inactive_still_returns_everything(self, db):
+        """Audit semantics are unchanged: include_inactive wins."""
+        sid = "s1"
+        db = _seed(db, sid)
+        msgs = db.get_messages(sid, include_inactive=True)
+        assert len(msgs) == 7  # 4 archived + 1 live + 2 rewound
+
+    def test_latest_page_with_compacted_rows(self, db):
+        """latest=True pages back from the newest message, still in order."""
+        sid = "s1"
+        db = _seed(db, sid)
+        ids = _row_ids(db, sid, include_compacted=True, latest=True)
+        all_ids = _row_ids(db, sid, include_compacted=True)
+        # The whole display history fits one page; latest pages are returned
+        # in chronological order (offset measured back from the newest row).
+        assert ids == all_ids
+        # A bounded page still lands on the newest rows.
+        tail = db.get_messages(sid, include_compacted=True, latest=True, limit=3)
+        assert [m["id"] for m in tail] == all_ids[-3:]
+
+    def test_pagination_with_compacted_rows(self, db):
+        """limit/offset pages over the combined display history."""
+        sid = "s1"
+        db = _seed(db, sid)
+        page = db.get_messages(sid, include_compacted=True, limit=3, offset=2)
+        all_ids = _row_ids(db, sid, include_compacted=True)
+        assert [m["id"] for m in page] == all_ids[2:5]
+
+
+class TestDisplayDedupe:
+    """Compaction epochs copy the protected tail into each new generation, so
+    the same logical message exists as several rows (identical
+    role/content/timestamp). The display read must surface it exactly once.
+    """
+
+    def _copy_tail_as_new_generation(self, db, sid, ids):
+        """Simulate one compaction epoch: duplicate rows as active=0,
+        compacted=1 with the SAME content and timestamp (the real
+        copy-protected-tail behaviour)."""
+
+        def _do(conn):
+            placeholders = ",".join("?" * len(ids))
+            conn.execute(
+                f"""
+                INSERT INTO messages
+                    (session_id, role, content, tool_call_id, tool_calls,
+                     tool_name, timestamp, active, compacted)
+                SELECT session_id, role, content, tool_call_id, tool_calls,
+                       tool_name, timestamp, 0, 1
+                FROM messages
+                WHERE session_id = ? AND id IN ({placeholders})
+                """,
+                [sid, *ids],
+            )
+
+        db._execute_write(_do)
+
+    def test_copied_protected_tail_is_surfaced_once(self, db):
+        """A message copied across compaction epochs appears exactly once."""
+        sid = "s1"
+        db.create_session(sid, source="cli")
+        db.append_messages_batch(
+            sid,
+            [
+                {"role": "user", "content": "turn 1"},
+                {"role": "assistant", "content": "answer 1"},
+            ],
+        )
+        orig = _row_ids(db, sid)
+        self._copy_tail_as_new_generation(db, sid, orig)
+        msgs = db.get_messages(sid, include_compacted=True)
+        # 2 logical messages, not 4 (the copies are duplicates).
+        assert len(msgs) == 2
+        assert [m["content"] for m in msgs] == ["turn 1", "answer 1"]
+
+    def test_dedupe_prefers_live_row_then_newest_generation(self, db):
+        """When generations conflict, the live row wins; otherwise the newest
+        generation (highest id) wins."""
+        sid = "s1"
+        db.create_session(sid, source="cli")
+        db.append_messages_batch(sid, [{"role": "user", "content": "dup q"}])
+        gen1 = _row_ids(db, sid)
+        self._copy_tail_as_new_generation(db, sid, gen1)  # compacted copy
+        msgs = db.get_messages(sid, include_compacted=True)
+        assert len(msgs) == 1
+        assert msgs[0]["active"] == 1  # live row wins
+
+        # Archive the live row and copy again: the newest compacted copy wins.
+        db._execute_write(
+            lambda conn: conn.execute(
+                "UPDATE messages SET active = 0, compacted = 1 WHERE session_id = ?",
+                [sid],
+            )
+        )
+        self._copy_tail_as_new_generation(db, sid, gen1)
+        newest_id = max(m["id"] for m in db.get_messages(sid, include_inactive=True))
+        msgs = db.get_messages(sid, include_compacted=True)
+        assert len(msgs) == 1
+        assert msgs[0]["id"] == newest_id  # newest generation wins
+
+    def test_dedupe_applies_before_paging(self, db):
+        """Deduping happens over the full display set, not per page, so
+        offset paging never surfaces a duplicate."""
+        sid = "s1"
+        db.create_session(sid, source="cli")
+        db.append_messages_batch(
+            sid,
+            [
+                {"role": "user", "content": "q1"},
+                {"role": "assistant", "content": "a1"},
+                {"role": "user", "content": "q2"},
+                {"role": "assistant", "content": "a2"},
+            ],
+        )
+        orig = _row_ids(db, sid)
+        self._copy_tail_as_new_generation(db, sid, orig)
+        all_ids = _row_ids(db, sid, include_compacted=True)
+        assert len(all_ids) == 4  # deduped, no copies
+        # Paginate past where the copies would have landed.
+        page = db.get_messages(sid, include_compacted=True, limit=2, offset=2)
+        assert [m["id"] for m in page] == all_ids[2:]
+        assert len(page) == 2

--- a/tests/hermes_state/test_get_messages_include_compacted.py
+++ b/tests/hermes_state/test_get_messages_include_compacted.py
@@ -205,3 +205,47 @@ class TestDisplayDedupe:
         page = db.get_messages(sid, include_compacted=True, limit=2, offset=2)
         assert [m["id"] for m in page] == all_ids[2:]
         assert len(page) == 2
+
+    def test_distinct_tool_calls_with_same_content_are_not_merged(self, db):
+        """Two real tool messages that happen to share role/content/timestamp
+        must stay separate: the dedupe key includes the tool fields, so only
+        genuine compaction copies (which copy those fields verbatim) collapse.
+        """
+        sid = "s1"
+        db.create_session(sid, source="cli")
+
+        def _seed_tool_rows(conn):
+            ts = 1700000000.0
+            for cid in ("call-1", "call-2"):
+                conn.execute(
+                    "INSERT INTO messages (session_id, role, content, tool_call_id,"
+                    " tool_name, timestamp, active, compacted)"
+                    " VALUES (?, ?, ?, ?, ?, ?, 1, 0)",
+                    (sid, "tool", "identical result", cid, "search", ts),
+                )
+
+        db._execute_write(_seed_tool_rows)
+        msgs = db.get_messages(sid, include_compacted=True)
+        assert len(msgs) == 2
+        assert {m["tool_call_id"] for m in msgs} == {"call-1", "call-2"}
+
+    def test_compaction_copies_of_tool_messages_still_collapse(self, db):
+        """Tool rows copied by a compaction epoch (identical tool fields) are
+        deduped like any other message, not split by the widened key."""
+        sid = "s1"
+        db.create_session(sid, source="cli")
+
+        def _seed_tool_row(conn):
+            conn.execute(
+                "INSERT INTO messages (session_id, role, content, tool_call_id,"
+                " tool_name, timestamp, active, compacted)"
+                " VALUES (?, ?, ?, ?, ?, ?, 1, 0)",
+                (sid, "tool", "result", "call-1", "search", 1700000000.0),
+            )
+
+        db._execute_write(_seed_tool_row)
+        orig = _row_ids(db, sid)
+        self._copy_tail_as_new_generation(db, sid, orig)
+        msgs = db.get_messages(sid, include_compacted=True)
+        assert len(msgs) == 1
+        assert msgs[0]["tool_call_id"] == "call-1"


### PR DESCRIPTION
# Salvage: Desktop compaction/compression transcript visibility (#67871)

Consolidates the Desktop "compression eats the chat transcript" cluster into one coherent, green-ready branch. After context compression rotates/archives rows, the Desktop chat view silently lost everything before the compaction boundary (#67871, #80680). This PR fixes the **display read path only** — the model-facing conversation history, compression subsystem, and prompt caching are untouched.

## What's included (cherry-picked, authorship preserved)

### PR #83757 — surface compaction-archived messages in transcript reads (@zuowen7)
- `hermes_state.py`: `get_messages(..., include_compacted=True)` — display reads now include rows preserved by in-place compaction (`active=0, compacted=1`) while still excluding soft-deleted Undo/Rewind rows (`active=0, compacted=0`). Cross-generation duplicates (compaction copies the protected tail into each new generation) are deduped on `(role, content, timestamp, tool_call_id, tool_calls, tool_name)`, preferring the live row then the newest generation.
- `hermes_cli/web_routers/sessions.py`: `include_compacted` query param on `GET /api/sessions/{id}/messages`.
- `apps/desktop/src/hermes.ts`: `getLatestSessionMessages` / `getAllSessionMessages` opt in, so the REST transcript prefetch stops ending at the compaction boundary.
- +2 targeted test files (SQL-level and endpoint-level).

### PR #67879 — preserve full transcripts for running sessions (@Kinkoolino-Hermes)
- `apps/desktop/.../use-session-actions/`: when a session is resumed **while running**, the renderer previously rebuilt the view from the gateway's compressed runtime projection, replacing the complete REST-prefetched transcript. Now the prefetched transcript stays authoritative and only the live tail (inflight/queued turn) is grafted on via `dedupeInflightUserAgainstTranscript` + `reconcileAuthoritativeChatMessages` — anchored dedupe so an intentionally repeated prompt is never dropped, fail-open when no safe anchor exists.
- Conflicts resolved against current main (the hook was restructured since the PR was authored): the main-side `messages_omitted` graft semantics are preserved by the new structure (empty runtime messages → no anchor → projection passes through unchanged), and the PR's `getSessionMessages` test references were renamed to today's `getLatestSessionMessages` API.

### Reconciliation commit (maintainer)
- `test(desktop): align transcript paging expectations with include_compacted reads` — updates two REST-path test expectations for the new `include_compacted=true` query param and the conflict-weave fallout above.

## Invariant: model context and prompt caching untouched
Every change is on the UI read path (SQLite display reads, REST router, renderer reconciliation). No writes to `messages`, no change to `get_messages_as_conversation` / `get_resume_conversations` (the model-history feeders), no live-agent history mutation, no system-prompt or context changes — the cached prefix is byte-identical before and after.

## Excluded candidates and why

- **PR #76286 (preserve pre-compaction history, @DannyFengTianYu)** — overlaps the same symptom via a much larger surface (~1,167 lines across `hermes_state.py` display-projection filtering, branch snapshots, `tui_gateway/server.py` reconciliation). Conflicts with current main in 4 files and with #83757's approach (a second, different display-dedupe scheme in `hermes_state.py`). The minimal read-side fix in #83757 + the renderer fix in #67879 cover the reported symptom without two competing dedupe layers. The branch-snapshot improvements in it are separable follow-up work.
- **PR #81904 (surface compacted session prompts safely, @jdgg777)** — adds a different, conflicting API design (`scope=compacted` param + `compacted_only` on `get_messages`, plus an unrelated `session_key` NULL-FK fix). Directly conflicts with #83757's `include_compacted` design on the same endpoint and the same `get_messages` clause; picking both would ship two overlapping query contracts. The `session_key` FK fix is real but out of scope for this cluster and should be salvaged separately.
- **PR #80707 (recover transitive compression continuations, @upperagent)** — touches the **live compression adoption path** (`agent/conversation_compression.py`'s `_adopt_live_compression_child`), i.e. the model-facing runtime context, not the display read path. That violates this PR's invariant boundary and addresses a different sub-bug (stale contender adoption across multiple durable-id rotations). Worth an independent review/salvage on its own merits.

## Issue coverage
- **#67871** (Running compressed Desktop sessions replace the complete transcript) — covered: renderer keeps the complete persisted transcript authoritative during running-session resume (#67879 half) and the persisted transcript itself now includes compaction-archived turns (#83757 half).
- **#80680** (transcript reads end at the compaction boundary) — covered by the #83757 half.

## Tests
- `tests/hermes_state/test_get_messages_include_compacted.py` — 11 passed
- `tests/hermes_cli/test_web_server.py` — 152 passed
- `tests/test_hermes_state.py` — 229 passed, 1 pre-existing failure (`test_search_projection_skips_context_enrichment_queries`) reproduced identically on clean `origin/main`
- Desktop vitest: `use-session-actions.test.tsx`, `use-session-actions/utils.test.ts`, `hermes.test.ts` — 159 passed
- `npx tsc --noEmit` (apps/desktop) — clean; eslint + prettier clean on all touched JS/TS
- `python3 scripts/audit_pr_attribution.py --fix` — all contributor emails mapped

Credits: @zuowen7 (#83757), @Kinkoolino-Hermes (#67879). Thanks also to @DannyFengTianYu (#76286), @jdgg777 (#81904), and @upperagent (#80707), whose PRs mapped this bug cluster; their excluded work is noted above for separate follow-up.

Closes #67871. Closes #80680.

## Infographic

![Surface compaction-archived messages infographic](https://gist.githubusercontent.com/teknium1/7ede60d62349101bfc98f148685d97c6/raw/infographic-desktop-compaction-transcript.png)

<sub>Nous Research</sub>
