### PR TITLE
fix(desktop): reliable clarify & approval prompts (salvage #79707 #76873 #82087 #84151 + clarify reconnect replay)

### DIFF
--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-submit.test.tsx
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-submit.test.tsx
@@ -199,7 +199,13 @@ describe('useComposerSubmit with a clarify parked on the session', () => {
 
   const parkClarify = (sessionId: string) => {
     $clarifyRequests.set({
-      [sessionId]: { requestId: `req-${sessionId}`, question: 'which one?', choices: ['a', 'b'], sessionId }
+      [sessionId]: {
+        requestId: `req-${sessionId}`,
+        question: 'which one?',
+        choices: ['a', 'b'],
+        multiSelect: false,
+        sessionId
+      }
     })
     $gateway.set({ request: gatewayRequest } as unknown as ReturnType<typeof $gateway.get>)
   }

--- a/apps/desktop/src/app/session/hooks/use-message-stream/clarify-hydration.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/clarify-hydration.test.tsx
@@ -6,6 +6,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { ClientSessionState } from '@/app/types'
 import { createClientSessionState } from '@/lib/chat-runtime'
 import { clearClarifyRequest } from '@/store/clarify'
+import { onScrollToBottomRequest } from '@/store/thread-scroll'
 import type { RpcEvent } from '@/types/hermes'
 
 import { useMessageStream } from './index'
@@ -19,6 +20,9 @@ const SID = 'session-1'
 
 let handleEvent: ((event: RpcEvent) => void) | null = null
 let stateRef: MutableRefObject<Map<string, ClientSessionState>> | null = null
+let stopScrollListener: (() => void) | null = null
+
+const scrollToBottom = vi.fn()
 
 function Harness() {
   const activeSessionIdRef = useRef<string | null>(SID)
@@ -71,11 +75,15 @@ describe('clarify.request stream hydration', () => {
     handleEvent = null
     stateRef = null
     clearClarifyRequest()
+    scrollToBottom.mockClear()
+    stopScrollListener = onScrollToBottomRequest(scrollToBottom)
   })
 
   afterEach(() => {
     cleanup()
     clearClarifyRequest()
+    stopScrollListener?.()
+    stopScrollListener = null
     vi.restoreAllMocks()
   })
 
@@ -91,6 +99,28 @@ describe('clarify.request stream hydration', () => {
       choices: ['yes', 'no'],
       question: 'Ship it?'
     })
+  })
+
+  it('reveals a clarify prompt raised by the active session', async () => {
+    await mountStream()
+
+    clarifyRequest({ choices: ['yes', 'no'], question: 'Ship it?', request_id: 'req-reveal' })
+
+    expect(scrollToBottom).toHaveBeenCalledOnce()
+  })
+
+  it('does not move the active thread for a background session clarify', async () => {
+    await mountStream()
+
+    act(() =>
+      handleEvent!({
+        payload: { choices: ['yes', 'no'], question: 'Ship it?', request_id: 'req-background' },
+        session_id: 'session-background',
+        type: 'clarify.request'
+      })
+    )
+
+    expect(scrollToBottom).not.toHaveBeenCalled()
   })
 
   it('merges with the real tool.start row even though its id differs from the request id', async () => {

--- a/apps/desktop/src/app/session/hooks/use-message-stream/clarify-hydration.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/clarify-hydration.test.tsx
@@ -5,7 +5,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { ClientSessionState } from '@/app/types'
 import { createClientSessionState } from '@/lib/chat-runtime'
-import { clearClarifyRequest } from '@/store/clarify'
+import { $clarifyRequests, clearClarifyRequest } from '@/store/clarify'
 import { onScrollToBottomRequest } from '@/store/thread-scroll'
 import type { RpcEvent } from '@/types/hermes'
 
@@ -121,6 +121,32 @@ describe('clarify.request stream hydration', () => {
     )
 
     expect(scrollToBottom).not.toHaveBeenCalled()
+  })
+
+  it('preserves multi-select through the store and hydrated tool row', async () => {
+    await mountStream()
+
+    clarifyRequest({
+      choices: ['read', 'write'],
+      multi_select: true,
+      question: 'Which permissions?',
+      request_id: 'req-multi'
+    })
+
+    expect($clarifyRequests.get()[SID]?.multiSelect).toBe(true)
+
+    const part = clarifyParts()[0]
+    expect(part?.type).toBe('tool-call')
+
+    if (part?.type !== 'tool-call') {
+      throw new Error('Expected a hydrated clarify tool call')
+    }
+
+    expect(part.args).toMatchObject({
+      choices: ['read', 'write'],
+      multi_select: true,
+      question: 'Which permissions?'
+    })
   })
 
   it('merges with the real tool.start row even though its id differs from the request id', async () => {

--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event.ts
@@ -957,6 +957,7 @@ export function useGatewayEventHandler(deps: GatewayEventDeps) {
         const question = typeof payload?.question === 'string' ? payload.question : ''
         const rawChoices = payload?.choices
         const choices = normalizeChoices(rawChoices)
+        const multiSelect = payload?.multi_select === true
 
         if (requestId && question) {
           if (rawChoices != null && choices.length === 0) {
@@ -967,6 +968,7 @@ export function useGatewayEventHandler(deps: GatewayEventDeps) {
             requestId,
             question,
             choices: choices.length > 0 ? choices : null,
+            multiSelect,
             sessionId: sessionId ?? null
           })
 
@@ -978,7 +980,15 @@ export function useGatewayEventHandler(deps: GatewayEventDeps) {
             // choices. Upsert a stable pending clarify tool row from the request
             // itself so the prompt stays answerable; a real tool.start/complete
             // with the same request id merges rather than duplicates.
-            upsertToolCall(sessionId, { args: { choices, question }, name: 'clarify', tool_id: requestId }, 'running')
+            upsertToolCall(
+              sessionId,
+              {
+                args: { choices, ...(multiSelect ? { multi_select: true } : {}), question },
+                name: 'clarify',
+                tool_id: requestId
+              },
+              'running'
+            )
 
             // The transcript only renders the active session, so a background
             // clarify is otherwise invisible (the row just keeps spinning like

--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event.ts
@@ -324,6 +324,7 @@ export function useGatewayEventHandler(deps: GatewayEventDeps) {
       const isActiveEvent = !!sessionId && sessionId === activeSessionIdRef.current
 
       const replaySessionId = approvalReplaySessionId(event.type, activeSessionIdRef.current, sessionId)
+
       if (replaySessionId) {
         void replayPendingApproval($gateway.get(), replaySessionId).catch(() => undefined)
       }

--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event.ts
@@ -12,7 +12,7 @@ import { translateNow } from '@/i18n'
 import { type GatewayEventPayload, textPart } from '@/lib/chat-messages'
 import { coerceGatewayText, coerceThinkingText, normalizePersonalityValue } from '@/lib/chat-runtime'
 import { playCompletionSound } from '@/lib/completion-sound'
-import { resolveGatewayEventSessionId } from '@/lib/gateway-events'
+import { approvalReplaySessionId, resolveGatewayEventSessionId } from '@/lib/gateway-events'
 import { triggerHaptic } from '@/lib/haptics'
 import { modelOptionsQueryKey } from '@/lib/model-options'
 import { isProviderSetupErrorMessage } from '@/lib/provider-setup-errors'
@@ -42,7 +42,13 @@ import { revealDesktopPane } from '@/store/pane-focus'
 import { flashPetActivity, markPetUnread, setPetActivity } from '@/store/pet'
 import { $activeGatewayProfile, normalizeProfileKey } from '@/store/profile'
 import { followActiveSessionCwd } from '@/store/projects'
-import { clearAllPrompts, setApprovalRequest, setSecretRequest, setSudoRequest } from '@/store/prompts'
+import {
+  clearAllPrompts,
+  receiveApprovalRequest,
+  replayPendingApproval,
+  setSecretRequest,
+  setSudoRequest
+} from '@/store/prompts'
 import { recordAgentReaction } from '@/store/reactions-local'
 import {
   $currentCwd,
@@ -315,6 +321,11 @@ export function useGatewayEventHandler(deps: GatewayEventDeps) {
 
       const sessionId = route.sessionId
       const isActiveEvent = !!sessionId && sessionId === activeSessionIdRef.current
+
+      const replaySessionId = approvalReplaySessionId(event.type, activeSessionIdRef.current, sessionId)
+      if (replaySessionId) {
+        void replayPendingApproval($gateway.get(), replaySessionId).catch(() => undefined)
+      }
 
       // Mid-turn compaction does not emit another message.start. The first
       // model output or tool event proves summarization has finished and the
@@ -1024,7 +1035,7 @@ export function useGatewayEventHandler(deps: GatewayEventDeps) {
         const command = typeof payload?.command === 'string' ? payload.command : ''
         const description = typeof payload?.description === 'string' ? payload.description : 'dangerous command'
 
-        setApprovalRequest({
+        void receiveApprovalRequest($gateway.get(), {
           // false only when a tirith warning forbids it; backend omits the field otherwise.
           allowPermanent: payload?.allow_permanent !== false,
           choices: Array.isArray(payload?.choices)
@@ -1032,9 +1043,10 @@ export function useGatewayEventHandler(deps: GatewayEventDeps) {
             : undefined,
           command,
           description,
+          requestId: typeof payload?.request_id === 'string' ? payload.request_id : undefined,
           sessionId: sessionId ?? null,
           smartDenied: payload?.smart_denied === true
-        })
+        }).catch(() => undefined)
 
         if (sessionId) {
           updateSessionState(sessionId, state => ({ ...state, needsInput: true }))

--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event.ts
@@ -75,6 +75,7 @@ import { dropSessionState } from '@/store/session-states'
 import { pruneDelegateFallbackSubagents, pruneFinishedSessionSubagents, upsertSubagent } from '@/store/subagents'
 import { reportMcpToolResult } from '@/store/suggestion-providers/repair'
 import { invalidateSkillSuggestionIndex } from '@/store/suggestion-providers/skill'
+import { requestScrollToBottom } from '@/store/thread-scroll'
 import { clearActiveSessionTodos } from '@/store/todos'
 import { recordToolDiff } from '@/store/tool-diffs'
 import { setSessionDraftingTool } from '@/store/tool-drafting'
@@ -985,6 +986,10 @@ export function useGatewayEventHandler(deps: GatewayEventDeps) {
             // "needs input" indicator on its row — works for the active session
             // too, and survives alt-tab / window blur (unlike a toast).
             updateSessionState(sessionId, state => ({ ...state, needsInput: true }))
+
+            if (sessionId === activeSessionIdRef.current) {
+              requestScrollToBottom()
+            }
           }
 
           dispatchNativeNotification({

--- a/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
@@ -9,12 +9,12 @@ import { type ChatMessage, preserveLocalAssistantErrors, toChatMessages } from '
 import { isMissingRpcMethod } from '@/lib/gateway-rpc'
 import { recoverInFlightTurnJournal } from '@/lib/inflight-turn-journal'
 import { setSessionYolo } from '@/lib/yolo-session'
+import { normalizeChoices, setClarifyRequest } from '@/store/clarify'
 import { migrateSessionDraft } from '@/store/composer'
 import { clearQueuedPrompts, migrateQueuedPrompts } from '@/store/composer-queue'
 import { $pinnedSessionIds } from '@/store/layout'
 import { clearNotifications, notify, notifyError } from '@/store/notifications'
 import { $activeGatewayProfile, $newChatProfile, ensureGatewayProfile, normalizeProfileKey } from '@/store/profile'
-import { setApprovalRequest } from '@/store/prompts'
 import {
   beginSessionMutation,
   endSessionMutation,
@@ -22,6 +22,7 @@ import {
   tombstoneSessions,
   untombstoneSessions
 } from '@/store/projects'
+import { setApprovalRequest } from '@/store/prompts'
 import {
   $activeSessionStoredIdRotation,
   $currentCwd,
@@ -205,9 +206,34 @@ function restorePendingApproval(response: SessionResumeResponse, sessionId: stri
     choices: pending.choices,
     command: pending.command ?? '',
     description: pending.description ?? 'dangerous command',
+    requestId: typeof pending.request_id === 'string' ? pending.request_id : undefined,
     sessionId,
     smartDenied: pending.smart_denied === true
   })
+
+  return true
+}
+
+function restorePendingClarify(response: SessionResumeResponse, sessionId: string): boolean {
+  // Same replay class as pending_approval: the clarify.request event was
+  // emitted while this client's transport was detached, so without the resume
+  // snapshot the question stays invisible until it times out server-side.
+  const pending = response.pending_clarify
+
+  if (!pending || typeof pending.request_id !== 'string' || typeof pending.question !== 'string') {
+    return false
+  }
+
+  const choices = normalizeChoices(pending.choices)
+
+  setClarifyRequest({
+    choices: choices.length > 0 ? choices : null,
+    multiSelect: pending.multi_select === true,
+    question: pending.question,
+    requestId: pending.request_id,
+    sessionId
+  })
+
   return true
 }
 
@@ -787,6 +813,7 @@ export function useSessionActions({
               dropSessionState(cachedRuntimeId)
             } else {
               const pendingApproval = restorePendingApproval(activated, cachedRuntimeId)
+              const pendingClarify = restorePendingClarify(activated, cachedRuntimeId)
               const runtimeInfo = applyRuntimeInfo(activated.info)
 
               // `omit_messages` means the response carries NO transcript, not
@@ -837,7 +864,7 @@ export function useSessionActions({
                   messages: activatedMessages,
                   busy: running,
                   awaitingResponse: running,
-                  needsInput: pendingApproval || state.needsInput,
+                  needsInput: pendingApproval || pendingClarify || state.needsInput,
                   // Adopting someone else's turn: we'll stream its reply
                   // without ever having received its prompt, so the settle
                   // path must not take the "I saw it all" shortcut.
@@ -1055,6 +1082,7 @@ export function useSessionActions({
         setActiveSessionId(resumed.session_id)
         activeSessionIdRef.current = resumed.session_id
         const pendingApproval = restorePendingApproval(resumed, resumed.session_id)
+        const pendingClarify = restorePendingClarify(resumed, resumed.session_id)
         const runtimeInfo = applyRuntimeInfo(resumed.info)
 
         patchSessionWorkspace(storedSessionId, runtimeInfo?.cwd)
@@ -1067,7 +1095,7 @@ export function useSessionActions({
             messages: messagesForView,
             busy: resumedRunning,
             awaitingResponse: resumedRunning && !recoveredInFlightTail,
-            needsInput: pendingApproval || state.needsInput,
+            needsInput: pendingApproval || pendingClarify || state.needsInput,
             adoptedRunningTurn: state.adoptedRunningTurn || resumedRunning,
             ...(inFlightRecovery.applied
               ? {

--- a/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
@@ -14,6 +14,7 @@ import { clearQueuedPrompts, migrateQueuedPrompts } from '@/store/composer-queue
 import { $pinnedSessionIds } from '@/store/layout'
 import { clearNotifications, notify, notifyError } from '@/store/notifications'
 import { $activeGatewayProfile, $newChatProfile, ensureGatewayProfile, normalizeProfileKey } from '@/store/profile'
+import { setApprovalRequest } from '@/store/prompts'
 import {
   beginSessionMutation,
   endSessionMutation,
@@ -190,6 +191,24 @@ interface FreshSessionDraftOptions {
   preserveRoute?: boolean
   replaceRoute?: boolean
   workspaceTarget?: NewChatWorkspaceTarget
+}
+
+function restorePendingApproval(response: SessionResumeResponse, sessionId: string): boolean {
+  const pending = response.pending_approval
+
+  if (!pending) {
+    return false
+  }
+
+  setApprovalRequest({
+    allowPermanent: pending.allow_permanent !== false,
+    choices: pending.choices,
+    command: pending.command ?? '',
+    description: pending.description ?? 'dangerous command',
+    sessionId,
+    smartDenied: pending.smart_denied === true
+  })
+  return true
 }
 
 function normalizeNewChatWorkspaceTarget(target: NewChatWorkspaceTarget): NewChatWorkspaceTarget {
@@ -767,6 +786,7 @@ export function useSessionActions({
               sessionStateByRuntimeIdRef.current.delete(cachedRuntimeId)
               dropSessionState(cachedRuntimeId)
             } else {
+              const pendingApproval = restorePendingApproval(activated, cachedRuntimeId)
               const runtimeInfo = applyRuntimeInfo(activated.info)
 
               // `omit_messages` means the response carries NO transcript, not
@@ -817,6 +837,7 @@ export function useSessionActions({
                   messages: activatedMessages,
                   busy: running,
                   awaitingResponse: running,
+                  needsInput: pendingApproval || state.needsInput,
                   // Adopting someone else's turn: we'll stream its reply
                   // without ever having received its prompt, so the settle
                   // path must not take the "I saw it all" shortcut.
@@ -1033,6 +1054,7 @@ export function useSessionActions({
 
         setActiveSessionId(resumed.session_id)
         activeSessionIdRef.current = resumed.session_id
+        const pendingApproval = restorePendingApproval(resumed, resumed.session_id)
         const runtimeInfo = applyRuntimeInfo(resumed.info)
 
         patchSessionWorkspace(storedSessionId, runtimeInfo?.cwd)
@@ -1045,6 +1067,7 @@ export function useSessionActions({
             messages: messagesForView,
             busy: resumedRunning,
             awaitingResponse: resumedRunning && !recoveredInFlightTail,
+            needsInput: pendingApproval || state.needsInput,
             adoptedRunningTurn: state.adoptedRunningTurn || resumedRunning,
             ...(inFlightRecovery.applied
               ? {

--- a/apps/desktop/src/components/assistant-ui/clarify-tool.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/clarify-tool.test.tsx
@@ -377,6 +377,7 @@ describe('ClarifyTool recommended option', () => {
     $gateway.set({ request } as never)
     setClarifyRequest({
       choices: ['staging (Recommended)', 'production'],
+      multiSelect: false,
       question: 'Which deployment target?',
       requestId: 'request-1',
       sessionId: 'session-1'

--- a/apps/desktop/src/components/assistant-ui/clarify-tool.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/clarify-tool.test.tsx
@@ -323,6 +323,26 @@ describe('ClarifyTool keyboard navigation', () => {
     })
   })
 
+  it('stages a highlighted multi-select choice with Enter and submits it with Continue', async () => {
+    const request = renderLiveClarify({ multiSelect: true })
+    const production = screen.getByRole('button', { name: /production/ })
+
+    fireEvent.keyDown(window, { key: 'ArrowDown' })
+    fireEvent.keyDown(window, { key: 'Enter' })
+
+    expect(production.getAttribute('aria-pressed')).toBe('true')
+    expect(request).not.toHaveBeenCalled()
+
+    fireEvent.click(screen.getByRole('button', { name: /Continue/ }))
+
+    await waitFor(() => {
+      expect(request).toHaveBeenCalledWith('clarify.respond', {
+        answer: JSON.stringify(['production']),
+        request_id: 'request-1'
+      })
+    })
+  })
+
   it('focuses Other when its number is pressed and leaves typing keys alone', () => {
     renderLiveClarify()
 

--- a/apps/desktop/src/components/assistant-ui/clarify-tool.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/clarify-tool.test.tsx
@@ -71,13 +71,14 @@ function liveClarifyProps(choices = ['staging', 'production']): ToolCallMessageP
   }
 }
 
-function renderLiveClarify() {
+function renderLiveClarify({ multiSelect = false }: { multiSelect?: boolean } = {}) {
   const request = vi.fn().mockResolvedValue({ ok: true })
 
   $activeSessionId.set('session-1')
   $gateway.set({ request } as never)
   setClarifyRequest({
     choices: ['staging', 'production'],
+    multiSelect,
     question: 'Which deployment target?',
     requestId: 'request-1',
     sessionId: 'session-1'
@@ -86,6 +87,57 @@ function renderLiveClarify() {
 
   return request
 }
+
+describe('ClarifyTool choice selection', () => {
+  it('selects independently, deselects and submits multi-select choices as a JSON array', async () => {
+    const request = renderLiveClarify({ multiSelect: true })
+    const staging = screen.getByRole('button', { name: /staging/ })
+    const production = screen.getByRole('button', { name: /production/ })
+
+    fireEvent.click(staging)
+    fireEvent.click(production)
+    expect(staging.getAttribute('aria-pressed')).toBe('true')
+    expect(production.getAttribute('aria-pressed')).toBe('true')
+
+    fireEvent.keyDown(window, { key: 'ArrowDown' })
+    expect(staging.getAttribute('aria-pressed')).toBe('true')
+    expect(production.getAttribute('aria-pressed')).toBe('true')
+
+    fireEvent.click(staging)
+    expect(staging.getAttribute('aria-pressed')).toBe('false')
+    fireEvent.click(staging)
+
+    fireEvent.click(screen.getByRole('button', { name: /Continue/ }))
+
+    await waitFor(() => {
+      expect(request).toHaveBeenCalledWith('clarify.respond', {
+        answer: JSON.stringify(['production', 'staging']),
+        request_id: 'request-1'
+      })
+    })
+  })
+
+  it('keeps single-select replacement and plain-string submission', async () => {
+    const request = renderLiveClarify()
+    const staging = screen.getByRole('button', { name: /staging/ })
+    const production = screen.getByRole('button', { name: /production/ })
+
+    fireEvent.click(staging)
+    fireEvent.click(production)
+
+    expect(staging.getAttribute('aria-pressed')).toBe('false')
+    expect(production.getAttribute('aria-pressed')).toBe('true')
+
+    fireEvent.click(screen.getByRole('button', { name: /Continue/ }))
+
+    await waitFor(() => {
+      expect(request).toHaveBeenCalledWith('clarify.respond', {
+        answer: 'production',
+        request_id: 'request-1'
+      })
+    })
+  })
+})
 
 describe('readClarifyResult', () => {
   it('reads question + user_response from the tool JSON payload', () => {
@@ -348,6 +400,7 @@ describe('ClarifyTool pending marker', () => {
     $gateway.set({ request: vi.fn().mockResolvedValue({ ok: true }) } as never)
     setClarifyRequest({
       choices: null,
+      multiSelect: false,
       question: 'Anything else?',
       requestId: 'request-1',
       sessionId: 'session-1'

--- a/apps/desktop/src/components/assistant-ui/clarify-tool.tsx
+++ b/apps/desktop/src/components/assistant-ui/clarify-tool.tsx
@@ -447,6 +447,16 @@ function ClarifyToolPending({ args }: ToolCallMessagePartProps) {
   }, [pendingAnswer, respond])
 
   const activateActive = useCallback(() => {
+    const choice = choices[activeIndex]
+
+    // Multi-select Enter toggles the highlighted choice. The user confirms the
+    // staged set explicitly with Continue so this path never submits a scalar.
+    if (multiSelect && choice) {
+      selectChoice(choice, activeIndex)
+
+      return
+    }
+
     // A staged answer (picked choice or typed text) wins — confirm it.
     if (pendingAnswer) {
       submitAnswer()
@@ -456,8 +466,6 @@ function ClarifyToolPending({ args }: ToolCallMessagePartProps) {
 
     // Otherwise act on the highlighted row: a choice responds immediately, and
     // the trailing "Other" row focuses the free-text field.
-    const choice = choices[activeIndex]
-
     if (choice) {
       void respond(choice)
 
@@ -465,7 +473,7 @@ function ClarifyToolPending({ args }: ToolCallMessagePartProps) {
     }
 
     textareaRef.current?.focus()
-  }, [activeIndex, choices, pendingAnswer, respond, submitAnswer])
+  }, [activeIndex, choices, multiSelect, pendingAnswer, respond, selectChoice, submitAnswer])
 
   const handleTextareaKey = useCallback(
     (event: KeyboardEvent<HTMLTextAreaElement>) => {

--- a/apps/desktop/src/components/assistant-ui/clarify-tool.tsx
+++ b/apps/desktop/src/components/assistant-ui/clarify-tool.tsx
@@ -42,6 +42,7 @@ import { parseMaybeObject } from './tool/fallback-model/format'
 interface ClarifyArgs {
   question?: string
   choices?: string[] | null
+  multiSelect?: boolean
 }
 
 interface ClarifyResult {
@@ -73,7 +74,8 @@ function readClarifyArgs(args: unknown): ClarifyArgs {
 
   return {
     question,
-    choices: choices.length > 0 ? choices : null
+    choices: choices.length > 0 ? choices : null,
+    multiSelect: row.multi_select === true
   }
 }
 
@@ -167,7 +169,7 @@ function ChoiceButton({
   disabled,
   keyShortcuts,
   onClick,
-  selected = false,
+  selected,
   title
 }: {
   active?: boolean
@@ -192,6 +194,7 @@ function ChoiceButton({
       <button
         aria-current={active || undefined}
         aria-keyshortcuts={keyShortcuts}
+        aria-pressed={selected}
         className={cn(
           OPTION_ROW_CLASS,
           'text-(--ui-text-secondary) hover:bg-(--chrome-action-hover) hover:text-(--ui-text-primary)',
@@ -204,7 +207,7 @@ function ChoiceButton({
         onClick={onClick}
         type="button"
       >
-        <KeyBadge char={char} preview={active} selected={selected} />
+        <KeyBadge char={char} preview={active} selected={Boolean(selected)} />
         <span className="flex-1 wrap-anywhere">
           <ChoiceLabel choice={choice} />
         </span>
@@ -335,10 +338,11 @@ function ClarifyToolPending({ args }: ToolCallMessagePartProps) {
   )
 
   const hasChoices = choices.length > 0
+  const multiSelect = hasChoices && Boolean(matchingRequest?.multiSelect ?? fromArgs.multiSelect)
 
   const [draft, setDraft] = useState('')
   const [submitting, setSubmitting] = useState(false)
-  const [selectedChoice, setSelectedChoice] = useState<string | null>(null)
+  const [selectedChoices, setSelectedChoices] = useState<string[]>([])
   // The keyboard cursor. Indices 0..choices.length-1 are the options; the
   // trailing index (=== choices.length) is the "Other" free-text row.
   const [activeIndex, setActiveIndex] = useState(0)
@@ -388,14 +392,30 @@ function ClarifyToolPending({ args }: ToolCallMessagePartProps) {
   // The answer is whichever input is active: a picked choice, or typed text.
   // Picking a choice no longer fires immediately — it selects, then the user
   // confirms with Continue (or Enter from the field).
-  const pendingAnswer = selectedChoice ?? (trimmedDraft || null)
 
-  const selectChoice = useCallback((choice: string, index: number) => {
-    // Picking a choice and typing are mutually exclusive answers.
-    setDraft('')
-    setSelectedChoice(choice)
-    setActiveIndex(index)
-  }, [])
+  const selectedAnswer = multiSelect
+    ? selectedChoices.length > 0
+      ? JSON.stringify(selectedChoices)
+      : null
+    : (selectedChoices[0] ?? null)
+
+  const pendingAnswer = selectedAnswer ?? (trimmedDraft || null)
+
+  const selectChoice = useCallback(
+    (choice: string, index: number) => {
+      // Picking a choice and typing are mutually exclusive answers.
+      setDraft('')
+      setSelectedChoices(selected => {
+        if (!multiSelect) {
+          return [choice]
+        }
+
+        return selected.includes(choice) ? selected.filter(value => value !== choice) : [...selected, choice]
+      })
+      setActiveIndex(index)
+    },
+    [multiSelect]
+  )
 
   // Keep the cursor in range when the choice set changes (never past "Other").
   useEffect(() => {
@@ -406,26 +426,25 @@ function ClarifyToolPending({ args }: ToolCallMessagePartProps) {
     (delta: number) => {
       const itemCount = choices.length + 1
 
-      // Arrow navigation is a move, not a pick — clear any staged answer so the
-      // cursor and the selection can't disagree.
+      // Arrow navigation is a move, not a pick. Multi-select keeps staged
+      // choices while the cursor moves so the user can build a set; the
+      // single-select path retains its existing clear-on-navigation behaviour.
       setDraft('')
-      setSelectedChoice(null)
+
+      if (!multiSelect) {
+        setSelectedChoices([])
+      }
+
       setActiveIndex(index => (index + delta + itemCount) % itemCount)
     },
-    [choices.length]
+    [choices.length, multiSelect]
   )
 
   const submitAnswer = useCallback(() => {
-    if (selectedChoice !== null) {
-      void respond(selectedChoice)
-
-      return
+    if (pendingAnswer) {
+      void respond(pendingAnswer)
     }
-
-    if (trimmedDraft) {
-      void respond(trimmedDraft)
-    }
-  }, [respond, selectedChoice, trimmedDraft])
+  }, [pendingAnswer, respond])
 
   const activateActive = useCallback(() => {
     // A staged answer (picked choice or typed text) wins — confirm it.
@@ -562,7 +581,7 @@ function ClarifyToolPending({ args }: ToolCallMessagePartProps) {
     // Typing is its own answer — drop any picked choice so the two inputs can't
     // both look selected.
     if (value.trim()) {
-      setSelectedChoice(null)
+      setSelectedChoices([])
     }
   }
 
@@ -600,7 +619,7 @@ function ClarifyToolPending({ args }: ToolCallMessagePartProps) {
                 key={`${index}-${choice}`}
                 keyShortcuts={`${letterFor(index)} ${index + 1}`}
                 onClick={() => selectChoice(choice, index)}
-                selected={selectedChoice === choice}
+                selected={selectedChoices.includes(choice)}
               />
             ))}
             <label
@@ -624,7 +643,7 @@ function ClarifyToolPending({ args }: ToolCallMessagePartProps) {
                 onBlur={() => setOtherFocused(false)}
                 onChange={event => onDraftChange(event.target.value)}
                 onFocus={() => {
-                  setSelectedChoice(null)
+                  setSelectedChoices([])
                   setActiveIndex(choices.length)
                   setOtherFocused(true)
                 }}

--- a/apps/desktop/src/components/assistant-ui/tool/approval.tsx
+++ b/apps/desktop/src/components/assistant-ui/tool/approval.tsx
@@ -24,6 +24,7 @@ import {
   type ApprovalRequest,
   clearApprovalRequest,
   registerApprovalInlineAnchor,
+  replayPendingApproval,
   sessionApprovalInlineVisible,
   sessionApprovalRequest
 } from '@/store/prompts'
@@ -144,16 +145,18 @@ const ApprovalBar: FC<{ request: ApprovalRequest; surface: 'floating' | 'inline'
       try {
         await gateway.request<{ resolved?: boolean }>('approval.respond', {
           choice,
+          request_id: request.requestId,
           session_id: request.sessionId ?? undefined
         })
         triggerHaptic(choice === 'deny' ? 'cancel' : 'submit')
-        clearApprovalRequest(request.sessionId)
+        clearApprovalRequest(request.sessionId, request.requestId)
+        void replayPendingApproval(gateway, request.sessionId).catch(() => undefined)
       } catch (error) {
         notifyError(error, copy.sendFailed)
         setSubmitting(null)
       }
     },
-    [busy, copy.gatewayDisconnected, copy.sendFailed, gateway, request.sessionId]
+    [busy, copy.gatewayDisconnected, copy.sendFailed, gateway, request.requestId, request.sessionId]
   )
 
   // ⌘/Ctrl+Enter → Run, Esc → Reject.

--- a/apps/desktop/src/lib/chat-messages.ts
+++ b/apps/desktop/src/lib/chat-messages.ts
@@ -73,6 +73,7 @@ export type GatewayEventPayload = {
   request_id?: string
   question?: string
   choices?: string[] | null
+  multi_select?: boolean
   // mcp.setup.request (setup_mcp tool — inline MCP consent card)
   server?: string
   action?: string

--- a/apps/desktop/src/lib/gateway-events.test.ts
+++ b/apps/desktop/src/lib/gateway-events.test.ts
@@ -1,8 +1,14 @@
 import { describe, expect, it } from 'vitest'
 
-import { gatewayEventRequiresSessionId, resolveGatewayEventSessionId } from './gateway-events'
+import { approvalReplaySessionId, gatewayEventRequiresSessionId, resolveGatewayEventSessionId } from './gateway-events'
 
 describe('gateway event routing', () => {
+  it('rehydrates pending approvals on reconnect ready and resumed session info', () => {
+    expect(approvalReplaySessionId('gateway.ready', 'active-1', null)).toBe('active-1')
+    expect(approvalReplaySessionId('session.info', 'active-1', 'routed-1')).toBe('routed-1')
+    expect(approvalReplaySessionId('message.delta', 'active-1', 'routed-1')).toBeNull()
+  })
+
   it('drops only unscoped subagent events (genuinely background work)', () => {
     expect(gatewayEventRequiresSessionId('subagent.progress')).toBe(true)
     expect(gatewayEventRequiresSessionId('subagent.start')).toBe(true)

--- a/apps/desktop/src/lib/gateway-events.ts
+++ b/apps/desktop/src/lib/gateway-events.ts
@@ -78,9 +78,11 @@ export function approvalReplaySessionId(
   if (eventType === 'gateway.ready') {
     return activeSessionId
   }
+
   if (eventType === 'session.info') {
     return routedSessionId
   }
+
   return null
 }
 

--- a/apps/desktop/src/lib/gateway-events.ts
+++ b/apps/desktop/src/lib/gateway-events.ts
@@ -70,6 +70,20 @@ export interface GatewayEventSessionRoute {
   sessionId: null | string
 }
 
+export function approvalReplaySessionId(
+  eventType: string | undefined,
+  activeSessionId: null | string,
+  routedSessionId: null | string
+): null | string {
+  if (eventType === 'gateway.ready') {
+    return activeSessionId
+  }
+  if (eventType === 'session.info') {
+    return routedSessionId
+  }
+  return null
+}
+
 /**
  * Resolve which runtime session owns a gateway event.
  *

--- a/apps/desktop/src/store/clarify.test.ts
+++ b/apps/desktop/src/store/clarify.test.ts
@@ -18,6 +18,7 @@ function clarify(sessionId: string | null, requestId: string): ClarifyRequest {
     requestId,
     question: `question-${requestId}`,
     choices: null,
+    multiSelect: false,
     sessionId
   }
 }

--- a/apps/desktop/src/store/clarify.ts
+++ b/apps/desktop/src/store/clarify.ts
@@ -7,6 +7,7 @@ export interface ClarifyRequest {
   requestId: string
   question: string
   choices: string[] | null
+  multiSelect: boolean
   sessionId: string | null
 }
 

--- a/apps/desktop/src/store/prompts.test.ts
+++ b/apps/desktop/src/store/prompts.test.ts
@@ -10,6 +10,8 @@ import {
   clearApprovalRequest,
   clearSecretRequest,
   clearSudoRequest,
+  receiveApprovalRequest,
+  replayPendingApproval,
   setApprovalRequest,
   setSecretRequest,
   setSudoRequest
@@ -66,6 +68,61 @@ describe('approval prompt store', () => {
     })
 
     expect($approvalRequest.get()?.allowPermanent).toBe(false)
+  })
+
+  it('correlates clearing to the exact approval request id', () => {
+    setApprovalRequest({ command: 'x', description: 'd', requestId: 'r1', sessionId: 's1' })
+
+    clearApprovalRequest('s1', 'stale')
+    expect($approvalRequest.get()?.requestId).toBe('r1')
+    clearApprovalRequest('s1', 'r1')
+    expect($approvalRequest.get()).toBeNull()
+  })
+
+  it('acknowledges an approval only after parking it', async () => {
+    const calls: Array<[string, Record<string, unknown>]> = []
+    const gateway = {
+      request: async (method: string, params: Record<string, unknown>) => {
+        calls.push([method, params])
+        return { acknowledged: true }
+      }
+    }
+
+    await receiveApprovalRequest(gateway, {
+      command: 'x',
+      description: 'd',
+      requestId: 'r1',
+      sessionId: 's1'
+    })
+
+    expect($approvalRequest.get()?.requestId).toBe('r1')
+    expect(calls).toEqual([['approval.received', { request_id: 'r1', session_id: 's1' }]])
+  })
+
+  it('replays and acknowledges the oldest unresolved approval after reconnect', async () => {
+    const calls: Array<[string, Record<string, unknown>]> = []
+    const gateway = {
+      request: async (method: string, params: Record<string, unknown>) => {
+        calls.push([method, params])
+        if (method === 'approval.pending') {
+          return {
+            approvals: [
+              { command: 'first', description: 'd1', request_id: 'r1' },
+              { command: 'second', description: 'd2', request_id: 'r2' }
+            ]
+          }
+        }
+        return { acknowledged: true }
+      }
+    }
+
+    await replayPendingApproval(gateway, 's1')
+
+    expect($approvalRequest.get()?.requestId).toBe('r1')
+    expect(calls).toEqual([
+      ['approval.pending', { session_id: 's1' }],
+      ['approval.received', { request_id: 'r1', session_id: 's1' }]
+    ])
   })
 })
 

--- a/apps/desktop/src/store/prompts.test.ts
+++ b/apps/desktop/src/store/prompts.test.ts
@@ -201,7 +201,7 @@ describe('$activeSessionAwaitingInput', () => {
     clearApprovalRequest('s1')
     expect($activeSessionAwaitingInput.get()).toBe(false)
 
-    setClarifyRequest({ choices: null, question: 'q', requestId: 'c1', sessionId: 's1' })
+    setClarifyRequest({ choices: null, multiSelect: false, question: 'q', requestId: 'c1', sessionId: 's1' })
     expect($activeSessionAwaitingInput.get()).toBe(true)
   })
 

--- a/apps/desktop/src/store/prompts.test.ts
+++ b/apps/desktop/src/store/prompts.test.ts
@@ -81,9 +81,11 @@ describe('approval prompt store', () => {
 
   it('acknowledges an approval only after parking it', async () => {
     const calls: Array<[string, Record<string, unknown>]> = []
+
     const gateway = {
       request: async (method: string, params: Record<string, unknown>) => {
         calls.push([method, params])
+
         return { acknowledged: true }
       }
     }
@@ -101,9 +103,11 @@ describe('approval prompt store', () => {
 
   it('replays and acknowledges the oldest unresolved approval after reconnect', async () => {
     const calls: Array<[string, Record<string, unknown>]> = []
+
     const gateway = {
       request: async (method: string, params: Record<string, unknown>) => {
         calls.push([method, params])
+
         if (method === 'approval.pending') {
           return {
             approvals: [
@@ -112,6 +116,7 @@ describe('approval prompt store', () => {
             ]
           }
         }
+
         return { acknowledged: true }
       }
     }

--- a/apps/desktop/src/store/prompts.ts
+++ b/apps/desktop/src/store/prompts.ts
@@ -67,16 +67,30 @@ function keyedPromptStore<T extends KeyedPrompt>(): PromptStore<T> {
   }
 }
 
-// Approval is session-keyed on the backend (one in-flight approval per session,
-// resolved via approval.respond {choice, session_id}). It carries no request_id,
-// unlike sudo/secret which are _block()-style request/response.
+// Approval is session-keyed on the backend and correlated by `request_id` when
+// available (legacy ID-free responses remain FIFO-compatible). Resolved via
+// approval.respond {choice, request_id, session_id}.
 export interface ApprovalRequest extends KeyedPrompt {
   // false when the backend won't honor a permanent allow (tirith warning) → hide "Always allow".
   allowPermanent?: boolean
   choices?: string[]
   command: string
   description: string
+  requestId?: string
   smartDenied?: boolean
+}
+
+interface ApprovalGateway {
+  request: (method: string, params: Record<string, unknown>) => Promise<unknown>
+}
+
+interface PendingApprovalPayload {
+  allow_permanent?: boolean
+  choices?: unknown
+  command?: unknown
+  description?: unknown
+  request_id?: unknown
+  smart_denied?: boolean
 }
 
 export interface SudoRequest extends KeyedPrompt {
@@ -100,6 +114,39 @@ const $approvalInlineAnchors = atom<Record<string, number>>({})
 export const $approvalRequest = approval.$active
 export const setApprovalRequest = approval.set
 export const clearApprovalRequest = approval.clear
+
+export async function receiveApprovalRequest(gateway: ApprovalGateway | null, request: ApprovalRequest): Promise<void> {
+  setApprovalRequest(request)
+  if (gateway && request.requestId && request.sessionId) {
+    await gateway.request('approval.received', {
+      request_id: request.requestId,
+      session_id: request.sessionId
+    })
+  }
+}
+
+export async function replayPendingApproval(gateway: ApprovalGateway | null, sessionId: string | null): Promise<void> {
+  if (!gateway || !sessionId) {
+    return
+  }
+  const rawResult = await gateway.request('approval.pending', {
+    session_id: sessionId
+  })
+  const result = rawResult && typeof rawResult === 'object' ? (rawResult as { approvals?: PendingApprovalPayload[] }) : {}
+  const pending = Array.isArray(result?.approvals) ? result.approvals[0] : undefined
+  if (!pending || typeof pending.request_id !== 'string') {
+    return
+  }
+  await receiveApprovalRequest(gateway, {
+    allowPermanent: pending.allow_permanent !== false,
+    choices: Array.isArray(pending.choices) ? pending.choices.filter(choice => typeof choice === 'string') : undefined,
+    command: typeof pending.command === 'string' ? pending.command : '',
+    description: typeof pending.description === 'string' ? pending.description : 'dangerous command',
+    requestId: pending.request_id,
+    sessionId,
+    smartDenied: pending.smart_denied === true
+  })
+}
 
 /** The prompt request for one specific session — the tile counterpart of the
  *  active-session `$*Request` views (same map, fixed key). */

--- a/apps/desktop/src/store/prompts.ts
+++ b/apps/desktop/src/store/prompts.ts
@@ -117,6 +117,7 @@ export const clearApprovalRequest = approval.clear
 
 export async function receiveApprovalRequest(gateway: ApprovalGateway | null, request: ApprovalRequest): Promise<void> {
   setApprovalRequest(request)
+
   if (gateway && request.requestId && request.sessionId) {
     await gateway.request('approval.received', {
       request_id: request.requestId,
@@ -129,14 +130,18 @@ export async function replayPendingApproval(gateway: ApprovalGateway | null, ses
   if (!gateway || !sessionId) {
     return
   }
+
   const rawResult = await gateway.request('approval.pending', {
     session_id: sessionId
   })
+
   const result = rawResult && typeof rawResult === 'object' ? (rawResult as { approvals?: PendingApprovalPayload[] }) : {}
   const pending = Array.isArray(result?.approvals) ? result.approvals[0] : undefined
+
   if (!pending || typeof pending.request_id !== 'string') {
     return
   }
+
   await receiveApprovalRequest(gateway, {
     allowPermanent: pending.allow_permanent !== false,
     choices: Array.isArray(pending.choices) ? pending.choices.filter(choice => typeof choice === 'string') : undefined,

--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -624,7 +624,17 @@ export interface SessionResumeResponse {
     choices?: string[]
     command?: string
     description?: string
+    request_id?: string
     smart_denied?: boolean
+  }
+  // The clarify question still blocking this session, if any. Same replay
+  // class as pending_approval: emitted-while-detached prompts are restored
+  // from the resume snapshot instead of being lost until server-side timeout.
+  pending_clarify?: {
+    choices?: null | string[]
+    multi_select?: boolean
+    question?: string
+    request_id?: string
   }
   info?: SessionRuntimeInfo
   message_count: number

--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -616,6 +616,16 @@ export interface SessionResumeResponse {
   queued?: null | {
     user?: string
   }
+  // The oldest gateway approval still waiting for a response. This is returned
+  // on resume so a reconnect can restore a prompt whose original event was
+  // emitted while the client transport was detached.
+  pending_approval?: {
+    allow_permanent?: boolean
+    choices?: string[]
+    command?: string
+    description?: string
+    smart_denied?: boolean
+  }
   info?: SessionRuntimeInfo
   message_count: number
   messages: SessionMessage[]

--- a/contributors/emails/iammotivated@gmail.com
+++ b/contributors/emails/iammotivated@gmail.com
@@ -1,0 +1,1 @@
+tomatau

--- a/contributors/emails/richard@workflowgroup.com
+++ b/contributors/emails/richard@workflowgroup.com
@@ -1,0 +1,1 @@
+richardhowes

--- a/contributors/emails/voodoo-pixels@Mac.localdomain
+++ b/contributors/emails/voodoo-pixels@Mac.localdomain
@@ -1,0 +1,1 @@
+Raven26-VooDoo

--- a/tests/tools/test_approval.py
+++ b/tests/tools/test_approval.py
@@ -1311,6 +1311,64 @@ class TestApprovalTimeoutIsNotConsent:
         ]
         assert hook_calls[-1][1]["choice"] == "notify_failed"
 
+    def test_pending_approval_is_replayable_and_acknowledged(self, monkeypatch):
+        from tools import approval as mod
+
+        self._force_short_timeout(monkeypatch, seconds=2)
+        notified = []
+        mod.register_gateway_notify(self.SESSION_KEY, lambda data: notified.append(data))
+        result_holder = {}
+
+        thread = threading.Thread(
+            target=lambda: result_holder.setdefault(
+                "result", mod.check_all_command_guards("rm -rf .git", "local")
+            )
+        )
+        thread.start()
+        for _ in range(200):
+            if notified:
+                break
+            time.sleep(0.005)
+
+        request_id = notified[0]["request_id"]
+        assert request_id
+        assert mod.list_gateway_approvals(self.SESSION_KEY) == [notified[0]]
+        assert mod.ack_gateway_approval(self.SESSION_KEY, request_id) is True
+        assert mod.resolve_gateway_approval(
+            self.SESSION_KEY, "once", request_id=request_id
+        ) == 1
+        thread.join(timeout=5)
+        assert result_holder["result"]["approved"] is True
+
+    def test_stale_request_id_cannot_resolve_current_approval(self, monkeypatch):
+        from tools import approval as mod
+
+        self._force_short_timeout(monkeypatch, seconds=2)
+        notified = []
+        mod.register_gateway_notify(self.SESSION_KEY, lambda data: notified.append(data))
+        result_holder = {}
+        thread = threading.Thread(
+            target=lambda: result_holder.setdefault(
+                "result", mod.check_all_command_guards("rm -rf .git", "local")
+            )
+        )
+        thread.start()
+        for _ in range(200):
+            if notified:
+                break
+            time.sleep(0.005)
+
+        request_id = notified[0]["request_id"]
+        assert mod.resolve_gateway_approval(
+            self.SESSION_KEY, "once", request_id="stale-request"
+        ) == 0
+        assert mod.list_gateway_approvals(self.SESSION_KEY)
+        assert mod.resolve_gateway_approval(
+            self.SESSION_KEY, "deny", request_id=request_id
+        ) == 1
+        thread.join(timeout=5)
+        assert result_holder["result"]["approved"] is False
+
 class TestTirithImportErrorFailOpenPolicy:
     """Regression guard for #20733.
 

--- a/tests/tui_gateway/test_protocol.py
+++ b/tests/tui_gateway/test_protocol.py
@@ -274,6 +274,66 @@ def test_late_prompt_response_is_idempotent(server, method, value_key):
     assert response["result"] == {"status": "expired"}
 
 
+def test_approval_pending_replays_unresolved_requests(server, monkeypatch):
+    from tools import approval
+
+    server._sessions["ui-1"] = {"session_key": "agent-1", "history": []}
+    pending = [{"request_id": "req-1", "command": "danger"}]
+    monkeypatch.setattr(approval, "list_gateway_approvals", lambda key: pending if key == "agent-1" else [])
+
+    response = server.handle_request(
+        {"id": "r1", "method": "approval.pending", "params": {"session_id": "ui-1"}}
+    )
+
+    assert response["result"] == {"approvals": pending}
+
+
+def test_approval_received_acknowledges_exact_request(server, monkeypatch):
+    from tools import approval
+
+    server._sessions["ui-1"] = {"session_key": "agent-1", "history": []}
+    calls = []
+    monkeypatch.setattr(
+        approval,
+        "ack_gateway_approval",
+        lambda key, request_id: calls.append((key, request_id)) or True,
+    )
+
+    response = server.handle_request(
+        {
+            "id": "r2",
+            "method": "approval.received",
+            "params": {"session_id": "ui-1", "request_id": "req-1"},
+        }
+    )
+
+    assert response["result"] == {"acknowledged": True}
+    assert calls == [("agent-1", "req-1")]
+
+
+def test_approval_response_correlates_request_id(server, monkeypatch):
+    from tools import approval
+
+    server._sessions["ui-1"] = {"session_key": "agent-1", "history": []}
+    calls = []
+    monkeypatch.setattr(
+        approval,
+        "resolve_gateway_approval",
+        lambda key, choice, **kwargs: calls.append((key, choice, kwargs)) or 1,
+    )
+
+    response = server.handle_request(
+        {
+            "id": "r3",
+            "method": "approval.respond",
+            "params": {"session_id": "ui-1", "request_id": "req-1", "choice": "once"},
+        }
+    )
+
+    assert response["result"] == {"resolved": 1}
+    assert calls == [("agent-1", "once", {"resolve_all": False, "request_id": "req-1"})]
+
+
 def test_clear_pending(server):
     ev = threading.Event()
     # _pending values are (sid, Event) tuples

--- a/tests/tui_gateway/test_protocol.py
+++ b/tests/tui_gateway/test_protocol.py
@@ -207,8 +207,50 @@ def test_live_session_payload_replays_pending_approval(server, monkeypatch):
         if saved_queue is not None:
             approval._gateway_queues["stored-session"] = saved_queue
 
-    assert payload["pending_approval"] == first
     assert payload["pending_approval"] is not first
+    replayed = payload["pending_approval"]
+    # request_id is injected by _ApprovalEntry so reconnecting clients can
+    # correlate their approval.respond with the exact queued request.
+    assert replayed.pop("request_id")
+    assert replayed == first
+
+
+def test_live_session_payload_replays_pending_clarify(server):
+    """A reattached client also receives a clarify question emitted while detached."""
+    session = {
+        "agent": types.SimpleNamespace(),
+        "cols": 80,
+        "created_at": 1.0,
+        "history": [],
+        "history_lock": threading.Lock(),
+        "running": True,
+        "session_key": "stored-session",
+    }
+    clarify_payload = {
+        "choices": ["staging", "production"],
+        "question": "Which deployment target?",
+        "request_id": "rid-clarify",
+    }
+    with server._prompt_lock:
+        server._pending["rid-clarify"] = ("runtime-session", threading.Event())
+        server._pending_prompt_payloads["rid-clarify"] = (
+            "clarify.request",
+            dict(clarify_payload),
+        )
+
+    try:
+        payload = server._live_session_payload("runtime-session", session)
+        other = server._live_session_payload("other-session", session)
+    finally:
+        with server._prompt_lock:
+            server._pending.pop("rid-clarify", None)
+            server._pending_prompt_payloads.pop("rid-clarify", None)
+
+    assert payload["pending_clarify"] == clarify_payload
+    # Snapshot, not a live reference into the registry.
+    assert payload["pending_clarify"] is not clarify_payload
+    # Scoped to the owning runtime session only.
+    assert "pending_clarify" not in other
 
 
 def test_disable_flush_env_var_actually_wires_to_module_constant(monkeypatch):

--- a/tests/tui_gateway/test_protocol.py
+++ b/tests/tui_gateway/test_protocol.py
@@ -174,6 +174,43 @@ def test_write_json(capture):
     assert json.loads(buf.getvalue()) == {"test": True}
 
 
+def test_live_session_payload_replays_pending_approval(server, monkeypatch):
+    """A reattached client receives the approval that was emitted while detached."""
+    from tools import approval
+
+    session = {
+        "agent": types.SimpleNamespace(),
+        "cols": 80,
+        "created_at": 1.0,
+        "history": [],
+        "history_lock": threading.Lock(),
+        "running": True,
+        "session_key": "stored-session",
+    }
+    first = {
+        "choices": ["once", "deny"],
+        "command": "rm -rf /tmp/example",
+        "description": "recursive delete",
+    }
+    second = {"command": "rm -rf /tmp/later", "description": "later"}
+    saved_queue = approval._gateway_queues.pop("stored-session", None)
+    approval._gateway_queues["stored-session"] = [
+        approval._ApprovalEntry(first),
+        approval._ApprovalEntry(second),
+    ]
+    monkeypatch.setattr(server, "_approval_request_payload", lambda data: dict(data or {}))
+
+    try:
+        payload = server._live_session_payload("runtime-session", session)
+    finally:
+        approval._gateway_queues.pop("stored-session", None)
+        if saved_queue is not None:
+            approval._gateway_queues["stored-session"] = saved_queue
+
+    assert payload["pending_approval"] == first
+    assert payload["pending_approval"] is not first
+
+
 def test_disable_flush_env_var_actually_wires_to_module_constant(monkeypatch):
     """End-to-end: setting `HERMES_TUI_GATEWAY_NO_FLUSH=1` and importing
     `tui_gateway.transport` fresh actually flips `_DISABLE_FLUSH` true.
@@ -821,4 +858,3 @@ def test_unregister_live_transport_stops_delivery(capture):
     assert a.frames == []
     # No live transports left → fell back to stdio.
     assert json.loads(buf.getvalue())["params"]["type"] == "skin.changed"
-

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -2670,6 +2670,22 @@ def has_blocking_approval(session_key: str) -> bool:
         return bool(_gateway_queues.get(session_key))
 
 
+def get_pending_gateway_approval(session_key: str) -> dict | None:
+    """Return a copy of the oldest unresolved gateway approval for a session.
+
+    Reconnectable clients use this to restore an approval prompt whose original
+    notification was sent while their transport was detached.  The queue remains
+    authoritative: this is a read-only snapshot, not a claim on the approval.
+    """
+    if not session_key:
+        return None
+    with _lock:
+        queue = _gateway_queues.get(session_key)
+        if not queue:
+            return None
+        return dict(queue[0].data)
+
+
 def submit_pending(session_key: str, approval: dict):
     """Store a pending approval request for a session."""
     with _lock:

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -22,6 +22,7 @@ import tempfile
 import threading
 import time
 import unicodedata
+import uuid
 from typing import Optional
 from hermes_cli.config import cfg_get
 
@@ -2562,11 +2563,13 @@ def _denial_breaker_addendum(session_key: str) -> str:
 
 class _ApprovalEntry:
     """One pending dangerous-command approval inside a gateway session."""
-    __slots__ = ("event", "data", "result", "reason")
+    __slots__ = ("event", "data", "result", "reason", "acknowledged")
 
     def __init__(self, data: dict):
         self.event = threading.Event()
-        self.data = data          # command, description, pattern_keys, …
+        self.data = dict(data)
+        self.data.setdefault("request_id", uuid.uuid4().hex)
+        self.acknowledged = False
         self.result: Optional[str] = None  # "once"|"session"|"always"|"deny"
         # Optional free-text reason supplied with an explicit deny
         # (``/deny <reason>``) so the agent can adapt instead of only
@@ -2605,7 +2608,8 @@ def unregister_gateway_notify(session_key: str) -> None:
 
 def resolve_gateway_approval(session_key: str, choice: str,
                              resolve_all: bool = False,
-                             reason: Optional[str] = None) -> int:
+                             reason: Optional[str] = None,
+                             request_id: Optional[str] = None) -> int:
     """Called by the gateway's /approve or /deny handler to unblock
     waiting agent thread(s).
 
@@ -2623,7 +2627,12 @@ def resolve_gateway_approval(session_key: str, choice: str,
         queue = _gateway_queues.get(session_key)
         if not queue:
             return 0
-        if resolve_all:
+        if request_id:
+            targets = [entry for entry in queue if entry.data.get("request_id") == request_id]
+            if not targets:
+                return 0
+            queue[:] = [entry for entry in queue if entry not in targets]
+        elif resolve_all:
             targets = list(queue)
             queue.clear()
         else:
@@ -2637,6 +2646,22 @@ def resolve_gateway_approval(session_key: str, choice: str,
             entry.reason = reason
         entry.event.set()
     return len(targets)
+
+
+def list_gateway_approvals(session_key: str) -> list[dict]:
+    """Return replay-safe snapshots of unresolved approvals for one session."""
+    with _lock:
+        return [dict(entry.data) for entry in _gateway_queues.get(session_key, [])]
+
+
+def ack_gateway_approval(session_key: str, request_id: str) -> bool:
+    """Record that a client received a particular pending approval request."""
+    with _lock:
+        for entry in _gateway_queues.get(session_key, []):
+            if entry.data.get("request_id") == request_id:
+                entry.acknowledged = True
+                return True
+    return False
 
 
 def has_blocking_approval(session_key: str) -> bool:
@@ -3930,7 +3955,7 @@ def _await_gateway_decision(session_key: str, notify_cb, approval_data: dict,
 
     # Notify the user (bridges sync agent thread → async gateway)
     try:
-        notify_cb(approval_data)
+        notify_cb(dict(entry.data))
     except Exception as exc:
         logger.warning("Gateway approval notify failed: %s", exc)
         _drop_entry()

--- a/tui_gateway/methods_prompt.py
+++ b/tui_gateway/methods_prompt.py
@@ -1347,6 +1347,38 @@ def _(rid, params: dict) -> dict:
     return _respond(rid, params, "value", allow_expired=True)
 
 
+@method("approval.pending")
+def _(rid, params: dict) -> dict:
+    session, err = _sess(params, rid)
+    if err:
+        return err
+    try:
+        from tools.approval import list_gateway_approvals
+
+        return _ok(rid, {"approvals": list_gateway_approvals(session["session_key"])})
+    except Exception as e:
+        return _err(rid, 5004, str(e))
+
+
+@method("approval.received")
+def _(rid, params: dict) -> dict:
+    session, err = _sess(params, rid)
+    if err:
+        return err
+    request_id = params.get("request_id")
+    if not isinstance(request_id, str) or not request_id:
+        return _err(rid, 4006, "request_id required")
+    try:
+        from tools.approval import ack_gateway_approval
+
+        return _ok(
+            rid,
+            {"acknowledged": ack_gateway_approval(session["session_key"], request_id)},
+        )
+    except Exception as e:
+        return _err(rid, 5004, str(e))
+
+
 @method("approval.respond")
 def _(rid, params: dict) -> dict:
     session, err = _sess(params, rid)
@@ -1362,6 +1394,7 @@ def _(rid, params: dict) -> dict:
                     session["session_key"],
                     params.get("choice", "deny"),
                     resolve_all=params.get("all", False),
+                    request_id=params.get("request_id"),
                 )
             },
         )

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -1891,13 +1891,8 @@ def _send_compute_host_control(
     )
 
 
-def _emit_approval_request(sid: str, data: dict | None) -> None:
-    """Emit an ``approval.request`` event to the TUI client with the command
-    redacted. The approval payload is built from the RAW command string, so a
-    credential-shaped value Tirith flagged would otherwise be echoed verbatim
-    to the TUI client (#48456 — third egress transport alongside the chat
-    platforms and the SSE/API stream fixed in #50767). Reuse the shared gateway
-    seam so all approval transports redact consistently."""
+def _approval_request_payload(data: dict | None) -> dict:
+    """Build the client-safe representation of a pending approval."""
     payload = dict(data or {})
     if "choices" not in payload:
         if payload.get("smart_denied"):
@@ -1910,6 +1905,29 @@ def _emit_approval_request(sid: str, data: dict | None) -> None:
         from gateway.run import _redact_approval_command
 
         payload["command"] = _redact_approval_command(payload.get("command"))
+    return payload
+
+
+def _pending_approval_request_payload(session_key: str) -> dict | None:
+    """Read the oldest unresolved approval in a session, if there is one."""
+    try:
+        from tools.approval import get_pending_gateway_approval
+
+        approval = get_pending_gateway_approval(session_key)
+    except Exception:
+        logger.debug("failed to read pending approval for %s", session_key, exc_info=True)
+        return None
+    return _approval_request_payload(approval) if approval else None
+
+
+def _emit_approval_request(sid: str, data: dict | None) -> None:
+    """Emit an ``approval.request`` event to the TUI client with the command
+    redacted. The approval payload is built from the RAW command string, so a
+    credential-shaped value Tirith flagged would otherwise be echoed verbatim
+    to the TUI client (#48456 — third egress transport alongside the chat
+    platforms and the SSE/API stream fixed in #50767). Reuse the shared gateway
+    seam so all approval transports redact consistently."""
+    payload = _approval_request_payload(data)
     _emit("approval.request", sid, payload)
 
 
@@ -8344,6 +8362,8 @@ def _live_session_payload(
         payload["inflight"] = inflight
     if queued:
         payload["queued"] = queued
+    if approval := _pending_approval_request_payload(str(session.get("session_key") or "")):
+        payload["pending_approval"] = approval
     return payload
 
 

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -1908,6 +1908,26 @@ def _approval_request_payload(data: dict | None) -> dict:
     return payload
 
 
+def _pending_clarify_request_payload(sid: str) -> dict | None:
+    """Read the clarify prompt still blocking a session, if there is one.
+
+    Clarify prompts share `_block()`'s pending registry, so a reconnecting
+    client whose transport was detached when `clarify.request` was emitted
+    would otherwise never see the question — the agent thread stays parked on
+    the Event until timeout. Same replay contract as `pending_approval`: a
+    read-only snapshot, the registry stays authoritative and `clarify.respond`
+    with the embedded request_id resolves it.
+    """
+    with _prompt_lock:
+        for rid, (owner_sid, _ev) in _pending.items():
+            if owner_sid != sid:
+                continue
+            event, prompt_payload = _pending_prompt_payloads.get(rid, ("", {}))
+            if event == "clarify.request":
+                return dict(prompt_payload)
+    return None
+
+
 def _pending_approval_request_payload(session_key: str) -> dict | None:
     """Read the oldest unresolved approval in a session, if there is one."""
     try:
@@ -8364,6 +8384,8 @@ def _live_session_payload(
         payload["queued"] = queued
     if approval := _pending_approval_request_payload(str(session.get("session_key") or "")):
         payload["pending_approval"] = approval
+    if clarify := _pending_clarify_request_payload(sid):
+        payload["pending_clarify"] = clarify
     return payload
 
 


### PR DESCRIPTION
## Summary

Salvages the Desktop clarify/approval interaction cluster into one coherent branch: interactive prompts (clarify questions and dangerous-command approvals) are now reliably visible and answerable in the Desktop app — including after a WebSocket reconnect.

Salvaged with authorship preserved (cherry-picked):

- **#79707** (@richardhowes) — `fix(desktop): reveal active clarify prompts`: a clarify raised by the active session scrolls the thread to the prompt; background-session clarifies keep the needs-input indicator without moving the active thread.
- **#76873** (@tomatau) — `fix(desktop): support multi-select clarifications` (2 commits, incl. keyboard staging): `multi_select` rides the clarify payload through the store and hydrated tool row; the clarify card toggles choices independently (aria-pressed), stages via keyboard, and submits the set as a JSON array while single-select keeps its exact prior behaviour.
- **#82087** (@konsisumer) — `fix(desktop): replay pending approvals after reconnect`: `_live_session_payload` carries `pending_approval` (oldest unresolved gateway approval, redacted through the shared seam) and both Desktop resume paths restore the prompt + `needsInput`.
- **#84151** (@Raven26-VooDoo) — `fix: make desktop approval routing reliable`: every gateway approval gets a `request_id`; `approval.pending` / `approval.received` RPCs plus `approval.respond {request_id}` give exact-request correlation (stale responses can no longer resolve the wrong approval), and the renderer replays pending approvals on `gateway.ready` / `session.info` and after resolving one.

### Widened (new work in this PR)

Pending **clarify** prompts had the same emitted-while-detached failure class as approvals in #82087: `clarify.request` rides `_block()`'s pending registry, so a client that reconnects after the event fired never sees the question and the agent thread stays parked until timeout. This PR widens the resume snapshot:

- `tui_gateway/server.py`: `_live_session_payload` now includes `pending_clarify` (read-only snapshot, scoped to the owning runtime sid; registry stays authoritative and `clarify.respond` with the embedded `request_id` resolves it).
- Desktop resume/activate paths restore the parked clarify into the clarify store (multi-select preserved) and flag `needsInput`, mirroring `restorePendingApproval`.
- `pending_approval` replay now also forwards the queue-injected `request_id` so a restored approval responds with exact-request correlation.

### #82087 / #84151 overlap resolution

Both PRs touch approval replay and were kept together as the coherent combination: #84151 provides request-id correlation + pull-based replay RPCs; #82087 provides the push-based resume snapshot. Nothing was excluded from either — the only reconciliation was the #82087 protocol test, updated to expect the `request_id` that #84151's `_ApprovalEntry` now injects into replayed payloads.

## Tests

- `tests/tui_gateway/test_protocol.py` — 52 passed (includes new `test_live_session_payload_replays_pending_clarify`, the salvaged approval replay/ack/correlate tests, and the harmonized `test_live_session_payload_replays_pending_approval`).
- `apps/desktop` vitest — 212 passed across `prompts.test.ts`, `clarify.test.ts`, `gateway-events.test.ts`, `clarify-tool.test.tsx`, `clarify-hydration.test.tsx`, `use-composer-submit.test.tsx`, `use-session-actions` suites.
- `tsc --noEmit` clean; eslint clean on all touched files (one salvaged test needed the now-required `multiSelect` field).
- `tests/tools/test_approval.py`: the two new #84151 tests fail locally only because this workstation's approval store auto-approves the fixture command — the entire pre-existing `TestApprovalTimeoutIsNotConsent` class fails identically on pristine `origin/main` here; expected green in CI.

## Credits

Salvaged contributions by @richardhowes (#79707), @tomatau (#76873), @konsisumer (#82087), and @Raven26-VooDoo (#84151) — authorship preserved via cherry-pick; contributor email mappings added per `scripts/audit_pr_attribution.py --fix`.

## Infographic

![desktop-clarify-approvals](https://files.catbox.moe/64vfsq.png)
