### PR TITLE
fix(state): drain stale read-only pool after 'file is not a database' self-heal

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -3788,6 +3788,31 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 exc,
             )
             return False
+        # The write connection is healthy again, but the read-only pool is
+        # NOT: those connections were opened against the same file that was
+        # replaced/truncated out from under us, so every pooled reader holds a
+        # stale descriptor that will keep raising "file is not a database" on
+        # checkout. Without this drain, the write path self-heals while the
+        # read path (session_search, transcript reload, recall) stays broken
+        # until process restart — the gateway serves messages fine (writer)
+        # but every FTS/read query fails, exactly the confusing split
+        # symptom seen in production 2026-08-15.
+        with self._read_conns_lock:
+            while True:
+                try:
+                    conn = self._read_pool.get_nowait()
+                except queue.Empty:
+                    break
+                self._close_read_conn(conn)
+            # Readers that were in flight when the corruption hit may also
+            # be mid-checkout; the pool is now empty so their return path
+            # closes them as surplus (put_nowait succeeds into an empty pool
+            # only if they were checked out before this drain; the closed-flag
+            # is deliberately NOT set here — we still want future reads to
+            # open fresh connections, just not reuse stale ones).
+        # Reset the open-failure backoff so a read that raced the corruption
+        # doesn't wait out the stamp before retrying on a fresh connection.
+        self._read_open_failed_at = 0.0
         logger.warning(
             "state.db connection reopened successfully; retrying the failed write."
         )

--- a/tests/test_state_db_notadb_selfheal.py
+++ b/tests/test_state_db_notadb_selfheal.py
@@ -96,6 +96,43 @@ class TestReconnectAfterNotADb:
             db._conn = None
             db.close()
 
+    def test_reconnect_drains_stale_read_pool(self, tmp_path):
+        """After self-heal, stale read-only pool connections are discarded.
+
+        A sibling process replacing/truncating the backing file breaks every
+        connection, not just the writer.  The write path reconnects via
+        ``_reconnect_after_notadb``; without draining ``_read_pool`` the
+        pooled readers keep raising ``file is not a database`` on checkout and
+        the read path (session_search / transcript reload) stays broken until
+        process restart — the confusing write-OK/read-broken split symptom.
+        """
+        db = SessionDB(db_path=tmp_path / "state.db")
+        try:
+            db.create_session(session_id="s1", source="cli", model="test")
+
+            # Prime the read pool with a live connection (WAL read path).
+            conn = db._checkout_read_conn()
+            assert conn is not None
+            with db._read_conns_lock:
+                db._read_pool.put_nowait(conn)
+
+            # Simulate the runtime corruption class on the writer; the pooled
+            # reader is opened against the same now-stale file.
+            db._conn = _NotADbOnce(db._conn)
+
+            # Self-heal: write path reconnects.
+            db.create_session(session_id="s2", source="cli", model="test")
+            assert db._notadb_reconnect_attempted is True
+
+            # The stale pooled reader must have been drained — otherwise the
+            # next checkout returns the poisoned connection.
+            with db._read_conns_lock:
+                assert db._read_pool.empty()
+            # And a fresh read works (new connection against the healthy file).
+            assert db.get_session("s2") is not None
+        finally:
+            db.close()
+
 
 class TestOnDiskJournalModeEioRetry:
     def _conn_raising_then(self, failures, result_rows):


### PR DESCRIPTION
## Problem

When a sibling process replaces/truncates the state.db backing file out from under the live gateway process, SQLite raises `file is not a database` on **every** connection opened against that file — including the read-only pool.

The write path already self-heals: `_reconnect_after_notadb()` closes the broken writer and reopens the DB file. But the **read-only pool is never drained**. Pooled connections are returned unconditionally to `_read_pool` in `_read_ctx`'s `finally` (see `put_nowait`), so a stale reader is checked out again on the next read and keeps raising `file is not a database`.

Net effect in production (2026-08-15): after a WAL-over-threshold checkpoint was triggered by an external sqlite3 CLI opening the live DB, the gateway served messages fine (writer reconnected) but every read path — `session_search`, transcript reload, recall — stayed broken until process restart. Disk file was perfectly healthy; only the pooled connections were stale.

## Fix

In `_reconnect_after_notadb()`, after the writer reconnects successfully:

- Drain `_read_pool`, closing each stale connection (and implicitly releasing its permit).
- Reset `_read_open_failed_at` so a read that raced the corruption doesn't wait out the backoff stamp before opening a fresh connection.
- Do **not** set `_read_conns_closed` — future reads must still be able to open fresh connections.

## Test

Adds `test_reconnect_drains_stale_read_pool`: primes the read pool with a live connection, simulates the corruption on the writer, triggers self-heal, asserts the pool is drained and a subsequent read works.

```
tests/test_state_db_notadb_selfheal.py .......... 10 passed
```

`tests/test_hermes_state.py`: 229 passed, 1 failed — the failure (`test_search_projection_skips_context_enrichment_queries`) reproduces on clean upstream `main` (pre-existing, unrelated to this change).