### PR TITLE
fix(session-search): label discovery result route scope

### DIFF
--- a/tests/tools/test_session_search.py
+++ b/tests/tools/test_session_search.py
@@ -20,6 +20,7 @@ from tools.session_search_tool import (
     _is_compression_ended,
     _resolve_to_parent,
     _session_link,
+    _session_route_key,
     session_search,
 )
 
@@ -157,6 +158,121 @@ class TestDiscoveryShape:
         result = json.loads(session_search(query="modpack", db=db, current_session_id="s_newest"))
         sids = [r["session_id"] for r in result["results"]]
         assert "s_newest" not in sids
+
+
+class TestDiscoveryScopeRelation:
+    """Discovery results identify their route relationship without exposing keys."""
+
+    CURRENT_ROUTE = "route:telegram:group-a:topic-1"
+    OTHER_ROUTE = "route:telegram:group-a:topic-2"
+
+    def _seed_duplicate_topic_hits(self, db):
+        db.create_session(
+            "s_current",
+            source="telegram",
+            session_key=self.CURRENT_ROUTE,
+        )
+        db.create_session(
+            "s_same_topic_history",
+            source="telegram",
+            session_key=self.CURRENT_ROUTE,
+        )
+        db.create_session(
+            "s_other_topic_history",
+            source="telegram",
+            session_key=self.OTHER_ROUTE,
+        )
+        for sid in ("s_same_topic_history", "s_other_topic_history"):
+            db.append_message(
+                sid,
+                role="user",
+                content="identical closeout prompt",
+            )
+        db._conn.commit()
+
+    def test_duplicate_topic_hits_are_bound_to_the_current_route(self, db):
+        self._seed_duplicate_topic_hits(db)
+
+        result = json.loads(session_search(
+            query="identical closeout prompt",
+            limit=5,
+            db=db,
+            current_session_id="s_current",
+        ))
+
+        relations = {
+            entry["session_id"]: entry["scope_relation"]
+            for entry in result["results"]
+        }
+        assert relations == {
+            "s_same_topic_history": "current_route",
+            "s_other_topic_history": "other_route",
+        }
+
+    def test_missing_current_route_key_fails_closed_to_unknown(self, db):
+        self._seed_duplicate_topic_hits(db)
+        db.create_session("s_current_without_key", source="telegram")
+
+        result = json.loads(session_search(
+            query="identical closeout prompt",
+            limit=5,
+            db=db,
+            current_session_id="s_current_without_key",
+        ))
+
+        assert result["results"]
+        assert {entry["scope_relation"] for entry in result["results"]} == {"unknown"}
+
+    def test_missing_result_route_key_fails_closed_to_unknown(self, db):
+        db.create_session(
+            "s_current",
+            source="telegram",
+            session_key=self.CURRENT_ROUTE,
+        )
+        db.create_session("s_history_without_key", source="telegram")
+        db.append_message(
+            "s_history_without_key",
+            role="user",
+            content="unbound closeout prompt",
+        )
+        db._conn.commit()
+
+        result = json.loads(session_search(
+            query="unbound closeout prompt",
+            db=db,
+            current_session_id="s_current",
+        ))
+
+        assert result["results"][0]["scope_relation"] == "unknown"
+
+    def test_keyless_child_does_not_borrow_parent_route(self, db):
+        route = "route:telegram:group-a:topic-1"
+        db.create_session("s_parent", source="telegram", session_key=route)
+        db.create_session(
+            "s_delegate", source="delegate", parent_session_id="s_parent"
+        )
+
+        assert _session_route_key(db, "s_delegate") is None
+
+    def test_route_lookup_error_is_unknown(self):
+        class BrokenSessionLookup:
+            def get_session(self, session_id):
+                raise RuntimeError("synthetic lookup failure")
+
+        assert _session_route_key(BrokenSessionLookup(), "s_result") is None
+
+    def test_scope_relation_does_not_expose_route_keys(self, db):
+        self._seed_duplicate_topic_hits(db)
+
+        rendered = session_search(
+            query="identical closeout prompt",
+            limit=5,
+            db=db,
+            current_session_id="s_current",
+        )
+
+        assert self.CURRENT_ROUTE not in rendered
+        assert self.OTHER_ROUTE not in rendered
 
 
 class TestDiscoverySort:
@@ -379,6 +495,33 @@ class TestCrossProfileRead:
         assert result["success"] is True
         assert result["mode"] == "read"
         assert result["profile"] == "asdf"
+
+    def test_cross_profile_discovery_scope_is_unknown(
+        self, db, tmp_path, monkeypatch
+    ):
+        other_home = tmp_path / "asdf_home"
+        other_home.mkdir()
+        other = SessionDB(other_home / "state.db")
+        route = "route:telegram:group-a:topic-1"
+        # Deliberately collide with the caller's current_session_id. A named
+        # profile read must still discard current-profile route authority.
+        other.create_session("s_current", source="telegram", session_key=route)
+        other.append_message(
+            "s_current", role="user", content="cross profile scope evidence"
+        )
+        assert other._conn is not None
+        other._conn.commit()
+        other.close()
+
+        self._patch_profiles(monkeypatch, other_home)
+        result = json.loads(session_search(
+            query="cross profile scope evidence",
+            profile="asdf",
+            db=db,
+            current_session_id="s_current",
+        ))
+
+        assert result["results"][0]["scope_relation"] == "unknown"
 
 
     def test_combined_value_autosplits(self, db, tmp_path, monkeypatch):

--- a/tools/session_search_tool.py
+++ b/tools/session_search_tool.py
@@ -151,6 +151,36 @@ def _resolve_lineage(db, session_id: str) -> str:
     return _resolve_to_parent(db, session_id)[0]
 
 
+def _session_route_key(db, session_id: str) -> Optional[str]:
+    """Return a persisted route key for comparison without exposing it."""
+    if not session_id:
+        return None
+    try:
+        session = db.get_session(session_id) or {}
+        route_key = session.get("session_key")
+        return str(route_key) if route_key else None
+    except Exception as e:
+        logging.debug(
+            "Unable to resolve route key for session %s: %s",
+            session_id,
+            e,
+            exc_info=True,
+        )
+        return None
+
+
+def _scope_relation(db, current_route_key: Optional[str], session_id: str) -> str:
+    """Classify a result relative to the current route without leaking keys."""
+    if not current_route_key:
+        return "unknown"
+    result_route_key = _session_route_key(db, session_id)
+    if not result_route_key:
+        return "unknown"
+    if result_route_key == current_route_key:
+        return "current_route"
+    return "other_route"
+
+
 def _is_compression_ended(db, session_id: str) -> bool:
     """Return True if *session_id* itself ended with ``end_reason='compression'``.
 
@@ -699,6 +729,7 @@ def _discover(
     """Discovery shape: FTS5 + anchored window + bookends per hit. Single call."""
     role_list = role_filter if role_filter else ["user", "assistant"]
     current_lineage_root = _resolve_lineage(db, current_session_id) if current_session_id else None
+    current_route_key = _session_route_key(db, current_session_id)
     title_result = _title_match_result(db, query, current_lineage_root)
 
     try:
@@ -831,6 +862,11 @@ def _discover(
         results.append(entry)
 
     for entry in results:
+        entry["scope_relation"] = _scope_relation(
+            db,
+            current_route_key,
+            entry.get("session_id"),
+        )
         entry["link"] = _session_link(entry["session_id"], link_profile)
 
     _final_payload = {
@@ -996,12 +1032,21 @@ SESSION_SEARCH_SCHEMA = {
         "and why before falling back to session history. Do not conclude 'not found' "
         "or 'no prior correspondence' from session_search alone when a direct source "
         "was provided.\n\n"
+        "CURRENT-SCOPE LIMIT\n\n"
+        "  Discovery results carry `scope_relation`: `current_route` means the same "
+        "canonical conversation route, `other_route` means a different route, and "
+        "`unknown` means the relationship could not be proved. Same-route history is "
+        "still historical context, not proof of current state or an explicit user "
+        "action. Never use another-route or unknown history to establish the current "
+        "conversation's state, and never infer that the user issued `/reset` from "
+        "session history or reset-like metadata alone.\n\n"
         "FOUR CALLING SHAPES\n\n"
         "  1) DISCOVERY — pass `query`:\n"
         "     session_search(query=\"auth refactor\", limit=3)\n"
         "     Runs FTS5, dedupes hits by session lineage, returns the top N sessions. "
         "Each result carries:\n"
         "       - session_id, title, when, source\n"
+        "       - scope_relation: current_route, other_route, or unknown\n"
         "       - snippet: FTS5-highlighted match excerpt\n"
         "       - bookend_start: first 3 user+assistant messages of the session "
         "(the goal / kickoff)\n"


### PR DESCRIPTION
## What does this PR do?

`session_search` discovery can return semantically identical history from several messaging routes, but today the model receives no trusted relationship between each result and the current conversation. That makes it easy to import another topic's task or reset state into the current topic.

This change uses the `current_session_id` and session DB already owned by the tool to add one model-safe field to each discovery result:

- `current_route` — the result belongs to the same canonical conversation route
- `other_route` — it belongs to a different route
- `unknown` — the relationship cannot be proved

The persisted route keys are compared internally and never serialized. Missing rows, missing keys, cross-profile reads, and lookup failures fail closed to `unknown`. The tool description also makes clear that same-route history is still historical context and cannot prove current state or a user-issued `/reset`.

No new tool, config, service, store, model call, or serialized route identifier is added.

## Related Issue

No linked issue; this PR includes a deterministic regression reproducer.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/session_search_tool.py`: classify discovery results against the current route without exposing persisted keys; document the evidence limit.
- `tests/tools/test_session_search.py`: cover identical prompts across routes, same-route history, missing evidence, and route-key non-disclosure.

## How to Test

1. Run `scripts/run_tests.sh tests/tools/test_session_search.py`.
2. Run `scripts/run_tests.sh tests/hermes_cli/test_web_server_session_search.py`.
3. Run `scripts/run_tests.sh tests/tools/` and compare any unrelated failures with clean `origin/main`.

## Checklist

### Code

- [x] I've read the Contributing Guide and repository agent guidance
- [x] My commit message follows Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [ ] Full repository suite passes — clean `origin/main` currently has unrelated tool-suite failures in this environment; the touched-area suite is green and the same broader failures reproduced unchanged on a detached baseline
- [x] I've added tests for the bug class
- [x] I've tested on macOS

### Documentation & Housekeeping

- [x] Relevant behavior is documented in the existing tool description
- [x] Config example update: N/A — no config changes
- [x] CONTRIBUTING/AGENTS update: N/A — no architecture or workflow change
- [x] Cross-platform impact considered — pure Python and SQLite session metadata
- [x] Tool description/schema updated for the changed result behavior

## Screenshots / Logs

A read-only canary against the commissioning session's real history returned four duplicate-text matches and classified them as one `current_route` and three `other_route`, with no route-key fields serialized.

Focused verification: 47 tests passed across the session-search tool and web-server integration files, including fail-closed coverage for keyless lineage children, lookup errors, and cross-profile reads. The broader `tests/tools/` suite produced the same 69 unrelated failures in 16 files on both this branch and a clean detached `origin/main` baseline.
