### PR TITLE
fix(desktop): clear stale busy state, keep delegating sessions in-progress, and stop resume snapshots marking open chats idle

### DIFF
--- a/apps/desktop/src/app/contrib/hooks/live-status-reap.test.ts
+++ b/apps/desktop/src/app/contrib/hooks/live-status-reap.test.ts
@@ -98,9 +98,7 @@ describe('rehydrateLiveSessionStatuses — reaping vanished runtimes', () => {
       ...createClientSessionState('stored-tools'),
       busy: true,
       awaitingResponse: true,
-      messages: [
-        { id: 'a1', role: 'assistant', parts: [openTool], pending: false } as never
-      ]
+      messages: [{ id: 'a1', role: 'assistant', parts: [openTool], pending: false } as never]
     })
 
     // Keep the runtime referenced so the settled state stays in the store

--- a/apps/desktop/src/app/contrib/hooks/live-status-reap.test.ts
+++ b/apps/desktop/src/app/contrib/hooks/live-status-reap.test.ts
@@ -1,7 +1,14 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { $selectedStoredSessionId, $unreadFinishedSessionIds } from '@/store/session'
-import { $attentionSessionIds, $workingSessionIds, clearAllSessionStates } from '@/store/session-states'
+import { createClientSessionState } from '@/lib/chat-runtime'
+import { $activeSessionId, $selectedStoredSessionId, $unreadFinishedSessionIds } from '@/store/session'
+import {
+  $attentionSessionIds,
+  $sessionStates,
+  $workingSessionIds,
+  clearAllSessionStates,
+  publishSessionState
+} from '@/store/session-states'
 
 import { rehydrateLiveSessionStatuses } from './use-background-sync'
 
@@ -25,6 +32,7 @@ describe('rehydrateLiveSessionStatuses — reaping vanished runtimes', () => {
     vi.useRealTimers()
     clearAllSessionStates()
     $unreadFinishedSessionIds.set([])
+    $activeSessionId.set(null)
   })
 
   it('clears a working session that disappears from the live snapshot', () => {
@@ -75,5 +83,56 @@ describe('rehydrateLiveSessionStatuses — reaping vanished runtimes', () => {
     rehydrateLiveSessionStatuses({ sessions: [] }, Date.now(), 'default')
 
     expect($workingSessionIds.get()).toEqual(['stored-other'])
+  })
+
+  it('seals open tool parts and clears awaitingResponse when a session vanishes', () => {
+    const openTool = {
+      type: 'tool-call',
+      toolCallId: 'call-1',
+      toolName: 'patch',
+      args: {},
+      argsText: '{}'
+    } as never
+
+    publishSessionState('runtime-tools', {
+      ...createClientSessionState('stored-tools'),
+      busy: true,
+      awaitingResponse: true,
+      messages: [
+        { id: 'a1', role: 'assistant', parts: [openTool], pending: false } as never
+      ]
+    })
+
+    // Keep the runtime referenced so the settled state stays in the store
+    // instead of being evicted as no-longer-needed.
+    $activeSessionId.set('runtime-tools')
+
+    rehydrateLiveSessionStatuses({
+      sessions: [{ id: 'runtime-tools', session_key: 'stored-tools', status: 'working' }]
+    })
+    rehydrateLiveSessionStatuses({ sessions: [] })
+
+    const state = $sessionStates.get()['runtime-tools']
+
+    expect(state.busy).toBe(false)
+    expect(state.awaitingResponse).toBe(false)
+    expect((state.messages[0].parts[0] as { result?: unknown }).result).toBeDefined()
+  })
+
+  it('clears a session stuck awaiting a response without the busy flag', () => {
+    publishSessionState('runtime-await', {
+      ...createClientSessionState('stored-await'),
+      awaitingResponse: true,
+      busy: false
+    })
+
+    $activeSessionId.set('runtime-await')
+
+    rehydrateLiveSessionStatuses({
+      sessions: [{ id: 'runtime-await', session_key: 'stored-await', status: 'working' }]
+    })
+    rehydrateLiveSessionStatuses({ sessions: [] })
+
+    expect($sessionStates.get()['runtime-await'].awaitingResponse).toBe(false)
   })
 })

--- a/apps/desktop/src/app/contrib/hooks/use-background-sync.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-background-sync.ts
@@ -2,7 +2,7 @@ import { useStore } from '@nanostores/react'
 import { type MutableRefObject, useCallback, useEffect, useRef } from 'react'
 
 import { getLatestSessionMessages } from '@/hermes'
-import { preserveLocalAssistantErrors, toChatMessages } from '@/lib/chat-messages'
+import { preserveLocalAssistantErrors, sealOpenToolParts, toChatMessages } from '@/lib/chat-messages'
 import { createClientSessionState } from '@/lib/chat-runtime'
 import { sessionMessagesSignature } from '@/lib/session-signatures'
 import { $changeEventsAvailable, $cronChangeTick, $sessionsChangeTick } from '@/store/live-sync'
@@ -247,14 +247,19 @@ export function rehydrateLiveSessionStatuses(
 
       const existing = $sessionStates.get()[runtimeSessionId]
 
-      if (existing?.busy || existing?.needsInput) {
+      if (existing?.busy || existing?.needsInput || existing?.awaitingResponse) {
         publishSessionState(runtimeSessionId, {
           ...existing,
           awaitingResponse: false,
           busy: false,
           needsInput: false,
           streamId: null,
-          turnStartedAt: null
+          turnStartedAt: null,
+          // The turn ended without its completion events reaching us — a lost
+          // `tool.complete` would otherwise leave a spinning tool row in an
+          // idle session. Seal open tool parts the same way the settle path
+          // does, so the transcript matches the state.
+          messages: sealOpenToolParts(existing.messages)
         })
       }
     }

--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event.ts
@@ -12,7 +12,7 @@ import { translateNow } from '@/i18n'
 import { type GatewayEventPayload, textPart } from '@/lib/chat-messages'
 import { coerceGatewayText, coerceThinkingText, normalizePersonalityValue } from '@/lib/chat-runtime'
 import { playCompletionSound } from '@/lib/completion-sound'
-import { approvalReplaySessionId, resolveGatewayEventSessionId } from '@/lib/gateway-events'
+import { approvalReplaySessionId, resolveGatewayEventSessionId, UNSCOPED_STREAM_EVENT_TYPES } from '@/lib/gateway-events'
 import { triggerHaptic } from '@/lib/haptics'
 import { modelOptionsQueryKey } from '@/lib/model-options'
 import { isProviderSetupErrorMessage } from '@/lib/provider-setup-errors'
@@ -321,6 +321,32 @@ export function useGatewayEventHandler(deps: GatewayEventDeps) {
       }
 
       const sessionId = route.sessionId
+
+      // Late stragglers: an unscoped stream event attributed via the
+      // active-session fallback (no pin) to a session that has no live turn
+      // belongs to a turn that already ended elsewhere. Dropping it keeps the
+      // previous session's tail events (a delayed `thinking.delta` or
+      // `status.update`) from landing in a freshly opened chat (#43142 family:
+      // busy/streaming UI inherited when switching sessions).
+      if (
+        sessionId &&
+        !explicitSid &&
+        !route.pinned &&
+        event.type &&
+        event.type !== 'message.start' &&
+        UNSCOPED_STREAM_EVENT_TYPES.has(event.type)
+      ) {
+        const state = sessionStateByRuntimeIdRef.current.get(sessionId)
+
+        const hasLiveTurn = Boolean(
+          state && (state.awaitingResponse || state.busy || state.streamId || state.sawAssistantPayload)
+        )
+
+        if (!hasLiveTurn) {
+          return
+        }
+      }
+
       const isActiveEvent = !!sessionId && sessionId === activeSessionIdRef.current
 
       const replaySessionId = approvalReplaySessionId(event.type, activeSessionIdRef.current, sessionId)

--- a/apps/desktop/src/app/session/hooks/use-message-stream/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/index.ts
@@ -13,6 +13,7 @@ import {
   mergeFinalAssistantText,
   reasoningPart,
   renderMediaTags,
+  sealOpenToolParts,
   upsertToolPart
 } from '@/lib/chat-messages'
 import {
@@ -665,6 +666,12 @@ export function useMessageStream({
             nextMessages = [...prev, newAssistantFromCompletion()]
           }
         }
+
+        // Turn-settle reconciliation: a `tool.complete` event lost to a
+        // degraded websocket leaves its tool row spinning forever. The turn is
+        // provably done here — nothing can still be running — so seal any
+        // tool-call parts that never saw their completion event.
+        nextMessages = sealOpenToolParts(nextMessages)
 
         const hasInlineError = nextMessages.some(m => m.role === 'assistant' && m.error && !m.hidden)
         const lastVisible = [...nextMessages].reverse().find(m => !m.hidden)

--- a/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
@@ -86,6 +86,7 @@ import {
   patchSessionWorkspace,
   preserveLocalPendingTurnMessages,
   reconcileResumeMessages,
+  resolveResumedBusy,
   resolveSessionProfile,
   resolveStoredSession,
   sessionMatchesStoredId,
@@ -830,7 +831,13 @@ export function useSessionActions({
                   ? reconcileAuthoritativeMessages(activated.messages, cachedViewState.messages, activated)
                   : cachedViewState.messages
 
-              const running = Boolean(activated.running ?? cachedViewState.busy)
+              // #70449: never let the activate snapshot's stale running:false
+              // rewind a turn that started while the RPC was in flight — read
+              // the freshest cache entry, not the pre-await cachedViewState.
+              const running = resolveResumedBusy(
+                activated.running ?? cachedViewState.busy,
+                Boolean(sessionStateByRuntimeIdRef.current.get(cachedRuntimeId)?.busy)
+              )
 
               // While idle, the persisted REST transcript is the display
               // authority: session.activate returns the runtime's compressed
@@ -1047,7 +1054,14 @@ export function useSessionActions({
                 return chatMessageArraysEquivalent(currentMessages, resumedMessages) ? currentMessages : resumedMessages
               })()
 
-        resumedRunning = Boolean((resumed as { running?: boolean }).running)
+        // #70449: same stale-snapshot guard as the warm path — a turn that
+        // started while the resume RPC was in flight has already marked the
+        // rebound runtime busy via gateway events; the snapshot must not
+        // rewind it to idle just because the user opened the chat.
+        resumedRunning = resolveResumedBusy(
+          (resumed as { running?: boolean }).running,
+          Boolean(sessionStateByRuntimeIdRef.current.get(resumed.session_id)?.busy)
+        )
 
         // Crash-survivable turn progress: fold a journaled in-flight tail
         // (persisted by use-session-state-cache while the turn streamed;

--- a/apps/desktop/src/app/session/hooks/use-session-actions/utils.test.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/utils.test.ts
@@ -25,6 +25,7 @@ import {
   isSessionGoneError,
   preserveLocalPendingTurnMessages,
   reconcileResumeMessages,
+  resolveResumedBusy,
   sessionMatchesStoredId,
   sessionShouldHaveTranscript,
   toBranchMessages
@@ -1426,5 +1427,23 @@ describe('appendLiveSessionProjection', () => {
       id: 'assistant-stream-runtime-1',
       pending: true
     })
+  })
+})
+
+describe('resolveResumedBusy', () => {
+  it('keeps a live busy turn when the resume snapshot stalely reports idle (#70449)', () => {
+    expect(resolveResumedBusy(false, true)).toBe(true)
+    expect(resolveResumedBusy(undefined, true)).toBe(true)
+    expect(resolveResumedBusy(null, true)).toBe(true)
+  })
+
+  it('clears busy when both the snapshot and the live cache agree the turn ended', () => {
+    expect(resolveResumedBusy(false, false)).toBe(false)
+    expect(resolveResumedBusy(undefined, false)).toBe(false)
+  })
+
+  it('adopts a running turn reported by the snapshot even without live state', () => {
+    expect(resolveResumedBusy(true, false)).toBe(true)
+    expect(resolveResumedBusy(true, true)).toBe(true)
   })
 })

--- a/apps/desktop/src/app/session/hooks/use-session-actions/utils.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/utils.ts
@@ -1261,3 +1261,23 @@ export function isSessionGoneError(err: unknown): boolean {
 
   return message.includes('404') || /session not found/i.test(message)
 }
+
+/**
+ * The busy value a resume/activate response should land with (#70449).
+ *
+ * `running` in a `session.activate` / `session.resume` payload is a snapshot
+ * taken when the RPC was issued. A turn that started — or streamed — after
+ * that snapshot has already marked the runtime busy in the live cache, so a
+ * stale `running: false` must never rewind it: that is exactly how opening an
+ * in-progress chat cleared its working indicator while the agent was still
+ * going. Preserving the newer live busy is safe, because the turn's own
+ * terminal signal (running:false via session.info / the settle path) remains
+ * the only authority that ends it, and the background-sync reaper clears
+ * truly lost turns.
+ *
+ * A snapshot that says `running: true` always wins — adopting a live turn is
+ * never stale.
+ */
+export function resolveResumedBusy(snapshotRunning: boolean | null | undefined, liveBusy: boolean): boolean {
+  return Boolean(snapshotRunning) || liveBusy
+}

--- a/apps/desktop/src/lib/chat-messages.test.ts
+++ b/apps/desktop/src/lib/chat-messages.test.ts
@@ -12,6 +12,7 @@ import {
   preserveLocalAssistantErrors,
   reasoningPart,
   renderMediaTags,
+  sealOpenToolParts,
   toChatMessages,
   upsertToolPart
 } from './chat-messages'
@@ -1164,5 +1165,67 @@ describe('collectUnspokenTurnSpeech', () => {
     expect(collectUnspokenTurnSpeech([], null)).toBeNull()
     expect(collectUnspokenTurnSpeech([assistant('a1', 'Done.')], 'a1')).toBeNull()
     expect(collectUnspokenTurnSpeech([user('u1', 'hello'), assistant('a1', '')], null)).toBeNull()
+  })
+})
+
+describe('sealOpenToolParts', () => {
+  const toolPart = (over: Partial<ChatMessagePart> = {}): ChatMessagePart =>
+    ({
+      type: 'tool-call',
+      toolCallId: 'call-1',
+      toolName: 'terminal',
+      args: {},
+      argsText: '{}',
+      ...over
+    }) as ChatMessagePart
+
+  const assistantWithParts = (parts: ChatMessagePart[], over: Partial<ChatMessage> = {}): ChatMessage =>
+    ({
+      id: 'a1',
+      role: 'assistant',
+      parts,
+      ...over
+    }) as ChatMessage
+
+  it('seals open tool-call parts in settled assistant messages', () => {
+    const messages = [assistantWithParts([toolPart()])]
+
+    const next = sealOpenToolParts(messages)
+
+    expect(next[0].parts[0]).toHaveProperty('result')
+  })
+
+  it('leaves already-completed tool parts untouched', () => {
+    const done = toolPart({ result: { code: 0 } })
+    const messages = [assistantWithParts([done])]
+
+    const next = sealOpenToolParts(messages)
+
+    expect(next[0].parts[0]).toBe(done)
+  })
+
+  it('leaves pending messages alone', () => {
+    const messages = [assistantWithParts([toolPart()], { pending: true })]
+
+    const next = sealOpenToolParts(messages)
+
+    expect(next[0].parts[0]).not.toHaveProperty('result')
+  })
+
+  it('leaves non-tool parts untouched', () => {
+    const text = { type: 'text', text: 'hello' } as ChatMessagePart
+    const messages = [assistantWithParts([text, toolPart()])]
+
+    const next = sealOpenToolParts(messages)
+
+    expect(next[0].parts[0]).toBe(text)
+    expect(next[0].parts[1]).toHaveProperty('result')
+  })
+
+  it('returns the same array reference when nothing needs sealing', () => {
+    const done = toolPart({ result: { code: 0 } })
+    const messages = [assistantWithParts([done])]
+
+    expect(sealOpenToolParts(messages)).toBe(messages)
   })
 })

--- a/apps/desktop/src/lib/chat-messages.ts
+++ b/apps/desktop/src/lib/chat-messages.ts
@@ -711,6 +711,47 @@ export function upsertToolPart(
   return next
 }
 
+/**
+ * Turn-settle reconciliation: close every tool-call part that never received
+ * its completion event. A `tool.complete` lost to a degraded websocket
+ * (reconnect, profile swap, hidden window) leaves the part without a `result`,
+ * which renders as a permanently spinning tool row even though the turn itself
+ * completed. A settled session cannot have tools still running, so an open
+ * part at settle time is a lost event, not live work. Pending messages are
+ * left alone, and no-op calls return the input array unchanged.
+ */
+export function sealOpenToolParts(messages: ChatMessage[]): ChatMessage[] {
+  let changed = false
+
+  const next = messages.map(message => {
+    if (message.role !== 'assistant' || message.pending) {
+      return message
+    }
+
+    let partChanged = false
+
+    const parts = message.parts.map(part => {
+      if (part.type !== 'tool-call' || Object.hasOwn(part, 'result')) {
+        return part
+      }
+
+      partChanged = true
+
+      return { ...part, result: {} }
+    })
+
+    if (!partChanged) {
+      return message
+    }
+
+    changed = true
+
+    return { ...message, parts }
+  })
+
+  return changed ? next : messages
+}
+
 function recordFromUnknown(value: unknown): Record<string, unknown> | null {
   return value && typeof value === 'object' ? (value as Record<string, unknown>) : null
 }

--- a/apps/desktop/src/lib/gateway-events.test.ts
+++ b/apps/desktop/src/lib/gateway-events.test.ts
@@ -43,6 +43,7 @@ describe('gateway event routing', () => {
     expect(started).toEqual({
       drop: false,
       nextUnscopedStreamSessionId: 'session-a',
+      pinned: false,
       sessionId: 'session-a'
     })
 
@@ -56,6 +57,7 @@ describe('gateway event routing', () => {
     expect(delta).toEqual({
       drop: false,
       nextUnscopedStreamSessionId: 'session-a',
+      pinned: true,
       sessionId: 'session-a'
     })
 
@@ -69,6 +71,7 @@ describe('gateway event routing', () => {
     expect(completed).toEqual({
       drop: false,
       nextUnscopedStreamSessionId: null,
+      pinned: true,
       sessionId: 'session-a'
     })
   })
@@ -84,6 +87,27 @@ describe('gateway event routing', () => {
     expect(routed).toEqual({
       drop: false,
       nextUnscopedStreamSessionId: 'session-b',
+      pinned: false,
+      sessionId: 'session-b'
+    })
+  })
+
+  it('attributes an unpinned stream event to the active session without the pin flag', () => {
+    // A late straggler (no pin left after the previous turn completed) falls
+    // back to the active session. The handler drops this case when the target
+    // session has no live turn — the straggler belongs to a turn that already
+    // ended elsewhere (#43142 family).
+    const routed = resolveGatewayEventSessionId({
+      activeSessionId: 'session-b',
+      eventType: 'thinking.delta',
+      explicitSessionId: '',
+      unscopedStreamSessionId: null
+    })
+
+    expect(routed).toEqual({
+      drop: false,
+      nextUnscopedStreamSessionId: null,
+      pinned: false,
       sessionId: 'session-b'
     })
   })
@@ -99,6 +123,7 @@ describe('gateway event routing', () => {
     expect(routed).toEqual({
       drop: false,
       nextUnscopedStreamSessionId: null,
+      pinned: true,
       sessionId: 'session-a'
     })
   })

--- a/apps/desktop/src/lib/gateway-events.ts
+++ b/apps/desktop/src/lib/gateway-events.ts
@@ -17,7 +17,12 @@ function asRecord(payload: unknown): Record<string, unknown> {
  * Without this, ``explicitSid || activeSessionId`` reattributes live deltas to
  * the newly focused chat.
  */
-const UNSCOPED_STREAM_EVENT_TYPES = new Set([
+/** Unscoped stream events that must stay pinned to the session that received
+ * ``message.start`` after the user switches chats mid-turn (#47709 / #48281).
+ * Without this, ``explicitSid || activeSessionId`` reattributes live deltas to
+ * the newly focused chat. Exported so the event handler can tell which events
+ * are pin-eligible when deciding whether an unpinned straggler is legitimate. */
+export const UNSCOPED_STREAM_EVENT_TYPES = new Set([
   'approval.request',
   'browser.progress',
   'clarify.request',
@@ -67,6 +72,11 @@ export interface GatewayEventSessionRouteInput {
 export interface GatewayEventSessionRoute {
   drop: boolean
   nextUnscopedStreamSessionId: null | string
+  /** True when the event was attributed via the pinned stream session rather
+   *  than the active-session fallback. The caller uses this to drop late
+   *  stragglers: an unpinned stream event landing on a session that has no
+   *  live turn belongs to a turn that already ended elsewhere. */
+  pinned: boolean
   sessionId: null | string
 }
 
@@ -108,6 +118,7 @@ export function resolveGatewayEventSessionId({
     return {
       drop: false,
       nextUnscopedStreamSessionId,
+      pinned: true,
       sessionId: explicitSessionId
     }
   }
@@ -116,6 +127,7 @@ export function resolveGatewayEventSessionId({
     return {
       drop: true,
       nextUnscopedStreamSessionId: unscopedStreamSessionId,
+      pinned: false,
       sessionId: null
     }
   }
@@ -140,6 +152,7 @@ export function resolveGatewayEventSessionId({
   return {
     drop: false,
     nextUnscopedStreamSessionId,
+    pinned: streamEvent && eventType !== 'message.start' && Boolean(unscopedStreamSessionId),
     sessionId
   }
 }

--- a/apps/desktop/src/store/session-dot-state.test.ts
+++ b/apps/desktop/src/store/session-dot-state.test.ts
@@ -1,6 +1,11 @@
-import { describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it } from 'vitest'
 
-import { hasLiveTurn, showsRunningArc } from './session-dot-state'
+import { createClientSessionState } from '@/lib/chat-runtime'
+
+import { $sessions } from './session'
+import { $delegatingSessionIds, hasLiveTurn, showsRunningArc } from './session-dot-state'
+import { clearAllSessionStates, publishSessionState } from './session-states'
+import { $subagentsBySession, type SubagentProgress } from './subagents'
 
 describe('showsRunningArc', () => {
   it('keeps the arc when an authoritative turn goes quiet', () => {
@@ -33,5 +38,48 @@ describe('hasLiveTurn', () => {
   it('excludes work that outlived the turn', () => {
     expect(hasLiveTurn('background')).toBe(false)
     expect(hasLiveTurn('unread')).toBe(false)
+  })
+})
+
+describe('$delegatingSessionIds', () => {
+  const subagent = (status: SubagentProgress['status']): SubagentProgress => ({
+    id: 'sub-1',
+    parentId: null,
+    goal: 'do a thing',
+    status,
+    taskCount: 1,
+    taskIndex: 0,
+    startedAt: 0,
+    updatedAt: 0,
+    filesRead: [],
+    filesWritten: [],
+    stream: []
+  })
+
+  afterEach(() => {
+    clearAllSessionStates()
+    $subagentsBySession.set({})
+    $sessions.set([])
+  })
+
+  it('claims the stored id while a subagent is running after the parent turn ended', () => {
+    publishSessionState('runtime-1', { ...createClientSessionState('stored-1'), busy: false })
+    $subagentsBySession.set({ 'runtime-1': [subagent('running')] })
+
+    expect($delegatingSessionIds.get()).toContain('stored-1')
+  })
+
+  it('drops the session once every subagent reaches a terminal status', () => {
+    publishSessionState('runtime-1', { ...createClientSessionState('stored-1'), busy: false })
+    $subagentsBySession.set({ 'runtime-1': [subagent('running')] })
+    $subagentsBySession.set({ 'runtime-1': [subagent('completed')] })
+
+    expect($delegatingSessionIds.get()).not.toContain('stored-1')
+  })
+
+  it('falls back to the runtime id for a not-yet-persisted conversation', () => {
+    $subagentsBySession.set({ 'runtime-fresh': [subagent('queued')] })
+
+    expect($delegatingSessionIds.get()).toContain('runtime-fresh')
   })
 })

--- a/apps/desktop/src/store/session-dot-state.ts
+++ b/apps/desktop/src/store/session-dot-state.ts
@@ -19,11 +19,46 @@
 
 import { computed } from 'nanostores'
 
-import { stableRecord } from '@/lib/stable-array'
+import { stableArray, stableRecord } from '@/lib/stable-array'
 
 import { $backgroundRunningSessionIds } from './composer-status'
 import { $sessions, $unreadFinishedSessionIds, lineageAliases } from './session'
-import { $attentionSessionIds, $draftSessionIds, $stalledSessionIds, $workingSessionIds } from './session-states'
+import {
+  $attentionSessionIds,
+  $draftSessionIds,
+  $sessionStates,
+  $stalledSessionIds,
+  $workingSessionIds
+} from './session-states'
+import { $subagentsBySession, activeSubagentCount } from './subagents'
+
+// Sessions parked in async delegation: the parent turn has ended (busy=false —
+// delegate_task(background=true) returns its handle the moment the children
+// are spawned) while those subagents keep working for minutes. Without this
+// input the sidebar row dropped to a plain idle dot mid-delegation, reading as
+// "done" while work was still running in child sessions. Same runtime→stored
+// bridge and fresh-chat fallback as $backgroundRunningSessionIds:
+// $subagentsBySession is keyed by runtime id, surfaces key on stored ids, and
+// lineageAliases covers whichever tip of the conversation a surface holds.
+let delegatingIds: readonly string[] = []
+export const $delegatingSessionIds = computed(
+  [$subagentsBySession, $sessionStates, $sessions],
+  (bySession, states, sessions) => {
+    const ids = new Set<string>()
+
+    for (const [runtimeId, items] of Object.entries(bySession)) {
+      if (activeSubagentCount(items) === 0) {
+        continue
+      }
+
+      for (const alias of lineageAliases(states[runtimeId]?.storedSessionId ?? runtimeId, sessions)) {
+        ids.add(alias)
+      }
+    }
+
+    return (delegatingIds = stableArray(delegatingIds, [...ids]))
+  }
+)
 
 export type SessionDotState = 'background' | 'draft' | 'idle' | 'needs-input' | 'stalled' | 'unread' | 'working'
 
@@ -63,11 +98,12 @@ export const $sessionDotStateById = computed(
     $workingSessionIds,
     $stalledSessionIds,
     $backgroundRunningSessionIds,
+    $delegatingSessionIds,
     $unreadFinishedSessionIds,
     $draftSessionIds,
     $sessions
   ],
-  (attention, working, stalled, background, unread, draft, sessions) => {
+  (attention, working, stalled, background, delegating, unread, draft, sessions) => {
     const next: Record<string, SessionDotState> = {}
 
     const claim = (ids: readonly string[], state: SessionDotState) => {
@@ -87,6 +123,11 @@ export const $sessionDotStateById = computed(
     claim(draft, 'draft')
     claim(unread, 'unread')
     claim(background, 'background')
+    // Async delegation: the parent turn has ended but its subagents are still
+    // running, so the session's work continues in child sessions. Same visual
+    // claim as background processes — and it yields to `working` below the
+    // moment the parent turn itself is live (synchronous orchestrator children).
+    claim(delegating, 'background')
     claim(working, 'working')
 
     // Stalled REFINES working rather than rivalling it — the turn is still

--- a/contributors/emails/razultull@gmail.com
+++ b/contributors/emails/razultull@gmail.com
@@ -1,0 +1,1 @@
+razultull


### PR DESCRIPTION
Salvages the Desktop stale-busy-state cluster into one green branch: finished chats no longer look busy, and busy chats no longer look finished. Three fixes land together — lost stream events can't leave spinning tool rows or phantom busy state behind (#85073), a session that delegated to background subagents keeps its in-progress affordance until the last child finishes (#51358, rebuilt), and opening/viewing a chat mid-turn no longer clears its working indicator (#70449).

## What changed

### 1. Clear stale busy state after lost stream events — salvaged from #85073, credit @KIAgent01
Cherry-picked clean onto main (zero conflicts, nothing partially landed):
- **Turn-settle sealing**: a `tool.complete` lost to a degraded websocket left its tool row spinning forever. New `sealOpenToolParts` helper closes any tool-call part without a `result` when the turn provably settles — both on the stream settle path and in the background-sync reaper.
- **Reaper covers `awaitingResponse`**: a vanished runtime stuck awaiting its first token (busy=false, awaitingResponse=true) is now cleared too, and its open tool parts sealed so the transcript matches the state.
- **Late-straggler guard**: an unscoped stream event attributed via the active-session fallback to a session with no live turn is dropped, so a previous session's delayed `thinking.delta`/`status.update` tail can't land in a freshly opened chat.

### 2. Keep session in-progress during async delegation — salvaged from #51358, credit @Razultull
The original patched `setSessionWorking`/`noteSessionActivity` and split the statusbar counter — all of which main has since rewritten (busy now lives in `session-states.ts`, the watchdog only marks `stalled` instead of clearing working, and the statusbar Agents item already shows a pure subagent count, so the counter-split half is implemented on main). The still-valid core bug was rebuilt against the current architecture, preserving @Razultull's authorship on the commit:
- `delegate_task(background=true)` ends the parent turn the moment the handle returns, so the sidebar row dropped to a plain idle dot while subagents kept working for minutes.
- New `$delegatingSessionIds` projection (sessions with queued/running subagents) feeds the session dot state, claiming the `background` treatment — visible work indicator — and yielding to `working` while the parent turn itself is live. Clears by construction when the last subagent reaches a terminal status.

### 3. Opening a running chat no longer marks it idle — fixes #70449
Still reproduced on main by code-reading and not covered by the two salvaged commits: `session.activate`/`session.resume` report `running` as a snapshot from when the RPC was issued, and both resume paths overwrote the live cache's newer busy=true with that stale `running: false` — exactly the "view a running chat and its working indicator clears" symptom. New `resolveResumedBusy` helper: a snapshot saying running always wins, but a snapshot saying idle can no longer rewind a live busy. The turn's own terminal signal stays the only authority that ends busy, and the background-sync reaper (hardened by fix 1) still clears truly lost turns.

## Issue coverage
- **#70449** — fixed by commit 3 (both warm-activate and cold-resume paths), with fixes 1–2 closing the adjacent false-idle/false-busy gaps around it.
- **#83239** (explicit authoritative turn-state indicator) — feature request, intentionally **not** built here. This PR does improve turn-state *fidelity* (the dot/arc states it proposes surfacing are now much less likely to lie: no false idle on open, no false idle during delegation, no false busy after lost events), but the persistent text-backed indicator it asks for remains open work.

## Tests
- `session-dot-state.test.ts` — new `$delegatingSessionIds` coverage (claims while subagents run, drops on terminal status, fresh-chat runtime-id fallback)
- `utils.test.ts` — new `resolveResumedBusy` coverage (stale idle snapshot can't rewind live busy; both-idle clears; snapshot-running adopts)
- From #85073: `chat-messages.test.ts` (`sealOpenToolParts`), `live-status-reap.test.ts` (reaper seals + clears awaiting), `gateway-events.test.ts`
- Full targeted run: **108 files / 1341 tests passing** across `apps/desktop/src/{app/session/hooks,store,lib,app/contrib/hooks}`; `tsc --noEmit` clean; `npm run fix` applied.

Credit: @KIAgent01 (#85073) and @Razultull (#51358) — authorship preserved per commit.

## Infographic

![desktop-busy-state](https://gist.githubusercontent.com/teknium1/c852940b8e6e6f3f2d53c578d0076aed/raw/infographic-desktop-busy-state.png)
