### PR TITLE
fix(gateway): stop Desktop retries from silently truncating session history

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -4703,6 +4703,52 @@ def test_prompt_submit_refuses_ordinal_and_message_id_mismatch(monkeypatch):
         server._sessions.pop("mismatch-trunc-sid", None)
 
 
+def test_prompt_submit_refuses_ordinal_only_when_history_has_row_ids(monkeypatch):
+    """A durable session must not trust an ordinal without a row-id target."""
+    replaced = []
+
+    class _FakeDB:
+        def replace_messages(self, key, messages, active_only=False, archive_dropped=False):
+            replaced.append((key, list(messages)))
+
+    history = [
+        {"_row_id": 101, "role": "user", "content": "first"},
+        {"_row_id": 102, "role": "assistant", "content": "reply 1"},
+        {"_row_id": 103, "role": "user", "content": "second"},
+        {"_row_id": 104, "role": "assistant", "content": "reply 2"},
+    ]
+    server._sessions["ordinal-only-durable-sid"] = _session(history=list(history))
+    monkeypatch.setattr(server, "_get_db", lambda: _FakeDB())
+    monkeypatch.setattr(
+        server, "_start_agent_build", lambda *a, **k: pytest.fail("must not start a turn")
+    )
+    monkeypatch.setattr(
+        server, "_start_inflight_turn", lambda *a, **k: pytest.fail("must not start a turn")
+    )
+
+    try:
+        resp = server.handle_request(
+            {
+                "id": "1",
+                "method": "prompt.submit",
+                "params": {
+                    "session_id": "ordinal-only-durable-sid",
+                    "text": "retry",
+                    "truncate_before_user_ordinal": 1,
+                    "confirm_truncate": True,
+                },
+            }
+        )
+
+        assert resp["error"]["code"] == 4004
+        assert "truncate_before_row_id" in resp["error"]["message"]
+        assert server._sessions["ordinal-only-durable-sid"]["history"] == history
+        assert server._sessions["ordinal-only-durable-sid"]["running"] is False
+        assert replaced == []
+    finally:
+        server._sessions.pop("ordinal-only-durable-sid", None)
+
+
 def test_prompt_submit_truncates_by_row_id(monkeypatch):
     """#82959: prompt.submit with truncate_before_row_id must cut at the target row id."""
     replaced = []

--- a/tui_gateway/methods_prompt.py
+++ b/tui_gateway/methods_prompt.py
@@ -495,6 +495,24 @@ def _(rid, params: dict) -> dict:
                 if err is not None:
                     return err
             else:
+                # Once active user turns carry durable row ids, an ordinal-only
+                # target is an unsafe downgrade: renderer and gateway ordinals
+                # can diverge after compaction/rebuild while the row id remains
+                # stable. Require the client to prove which durable turn it
+                # means instead of persisting a potentially mis-aimed cut.
+                if any(_message_row_id(history[h_idx]) is not None for h_idx in user_indices):
+                    logger.warning(
+                        "prompt.submit: REFUSED ordinal-only truncation of durable "
+                        "session %s (ordinal=%d); truncate_before_row_id required",
+                        sid,
+                        client_ordinal,
+                    )
+                    return _err(
+                        rid,
+                        4004,
+                        "ordinal-only truncation is unsafe for durable session history; "
+                        "include truncate_before_row_id",
+                    )
                 ordinal = client_ordinal
 
             # Reject out-of-range ordinals on BOTH ends. A negative value would


### PR DESCRIPTION
## What does this PR do?

Desktop retries and resubmits could silently truncate a durable session at the wrong user turn when the client supplied only a renderer ordinal. This could discard active model context while the Desktop transcript still showed those messages. The gateway now fails closed for ordinal-only truncation when durable user row IDs are available, while preserving ordinal-only compatibility for ephemeral histories without durable row IDs.

### Symptom

After a failed Desktop turn, retrying or resubmitting could reduce the gateway history at an earlier user turn even though the Desktop transcript still displayed the dropped messages.

### Impact

The Desktop transcript and the model's persisted context could silently diverge. In the reported session, 68 active context records were dropped from the model history until recovery from the archive.

### Bug Cause

**Trigger:** `tui_gateway/methods_prompt.py` in the `prompt.submit` ordinal fallback when `confirm_truncate` is true and only `truncate_before_user_ordinal` is supplied.

**Causal chain:**
1. A Desktop retry or resubmit supplies a renderer-visible user ordinal without a durable row ID.
2. After history compaction or rebuild, renderer and gateway ordinals can refer to different user turns, but the gateway trusted the ordinal and persisted the selected prefix.
3. The model loses active context from the incorrectly selected turn onward while the Desktop transcript can continue to show those messages.

**Why it is wrong:** Durable row IDs are stable across rebuilds, while ordinals are positional and can drift. Trusting the weaker positional target when durable identities exist permits an ambiguous destructive operation.

**Working sibling / contrast:** Requests with `truncate_before_row_id` or a message ID already resolve a durable target and reconcile the client ordinal before truncating. Ephemeral histories without durable row IDs retain the legacy ordinal-only compatibility path.

**Ruled out:** Failed-turn prompt planning itself does not request truncation. Explicit Desktop restore, reload, and edit paths use the shared truncation helper and attach a row ID when one is available, so the unsafe behavior was isolated to the gateway's ordinal-only fallback.

### Fix

Reject ordinal-only truncation before any in-memory or database mutation when an active user turn has a durable row ID. A regression test exercises the real `prompt.submit` handler and verifies the request returns error 4004 without replacing persisted messages, mutating history, or starting a turn.

## Related Issue

Fixes #86573

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tui_gateway/methods_prompt.py` - fail closed when ordinal-only truncation targets durable session history.
- `tests/test_tui_gateway_server.py` - prove the unsafe request cannot mutate memory or persistence and cannot start a turn.

## How to Test

1. Create a gateway session history whose user turns carry durable row IDs.
2. Submit a confirmed truncation request with only `truncate_before_user_ordinal`.
3. Verify error 4004 is returned and no history, persistence, or turn state changes.

```bash
scripts/run_tests.sh tests/test_tui_gateway_server.py -k test_prompt_submit_refuses_ordinal_only_when_history_has_row_ids
scripts/run_tests.sh tests/test_tui_gateway_server.py
```

The targeted regression passed (1 test). The related file passed all 556 tests; the wrapper retried one unrelated scheduling timeout and the fresh retry passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repository test entry on the relevant gateway test file and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Documentation updates are N/A because the public interface is unchanged
- [x] `cli-config.yaml.example` updates are N/A because no config keys changed
- [x] `CONTRIBUTING.md` and `AGENTS.md` updates are N/A because architecture and workflows are unchanged
- [x] I've considered cross-platform impact; the changed handler logic is platform-independent
- [x] Tool description and schema updates are N/A because no model tool behavior changed

## Screenshots / Logs

N/A. The automated regression verifies the failure response and absence of state mutation directly.
