### PR TITLE
fix(mattermost): standalone send crashes on MEDIA attachments (tuple path)

### DIFF
--- a/plugins/platforms/mattermost/adapter.py
+++ b/plugins/platforms/mattermost/adapter.py
@@ -1077,8 +1077,16 @@ async def _standalone_send(
             # 1. Upload media (if any) and collect file_ids.
             file_ids: List[str] = []
             for media in media_files:
-                file_path = media.get("path") if isinstance(media, dict) else media
-                if not file_path or not os.path.exists(file_path):
+                if isinstance(media, dict):
+                    file_path = media.get("path")
+                elif isinstance(media, (tuple, list)) and media:
+                    # extract_media returns (path, is_voice) pairs
+                    file_path = media[0]
+                else:
+                    file_path = media
+                if not isinstance(file_path, str) or not file_path:
+                    continue
+                if not os.path.exists(file_path):
                     continue
                 form = aiohttp.FormData()
                 # Mattermost requires channel_id on file uploads so the


### PR DESCRIPTION
## Problem

`hermes send --to mattermost \"MEDIA:/path/to/file\"` fails with:

```
hermes send: Mattermost send failed: stat: path should be string, bytes, os.PathLike or integer, not tuple
```

## Root cause

`plugins/platforms/mattermost/adapter.py::_standalone_send` assumed `media_files` entries are dicts:

```python
file_path = media.get("path") if isinstance(media, dict) else media
```

But `BasePlatformAdapter.extract_media` returns `(path, is_voice)` tuples (see `gateway/platforms/base.py`). So `os.path.exists(tuple)` raises `TypeError: stat: path should be string... not tuple`.

Affects: CLI `hermes send` with MEDIA attachments, cron out-of-process delivery to Mattermost.

## Fix

Normalize all three shapes `extract_media` can produce (dict / `(path, is_voice)` tuple / plain str) and skip non-string paths:

```python
for media in media_files:
    if isinstance(media, dict):
        file_path = media.get("path")
    elif isinstance(media, (tuple, list)) and media:
        file_path = media[0]  # (path, is_voice)
    else:
        file_path = media
    if not isinstance(file_path, str) or not file_path:
        continue
    ...
```

## Verification

- `hermes send --to mattermost \"MEDIA:/tmp/test.png\"` → success, post carries `file_ids`
- `hermes send --to mattermost \"plain text\"` → success
- Confirmed uploaded file_id appears on the post via Mattermost v4 API