### PR TITLE
fix(state): discard poisoned read-conn on 'file is not a database' instead of returning it

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -3298,28 +3298,51 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         """
         conn = self._checkout_read_conn()
         if conn is not None:
+            discarded = False
             try:
                 yield conn
+            except sqlite3.DatabaseError as exc:
+                # Runtime connection corruption (#20260809): a sibling
+                # process replaced/truncated the backing file. The write
+                # path self-heals via _reconnect_after_notadb, but a pooled
+                # reader raised here is currently returned to the pool by
+                # the finally below, so the NEXT checkout reuses the same
+                # stale descriptor and fails again — reads stay broken until
+                # process restart while writes look healthy. Discard the
+                # poisoned connection (close + release its permit) instead
+                # of returning it, and clear the open-failure backoff so the
+                # next read opens a fresh connection immediately.
+                if _is_not_a_database_error(exc):
+                    discarded = True
+                    with self._read_conns_lock:
+                        self._read_open_failed_at = 0.0
+                raise
             finally:
-                returned = False
-                with self._read_conns_lock:
-                    if not self._read_conns_closed:
-                        try:
-                            self._read_pool.put_nowait(conn)
-                            returned = True
-                        except queue.Full:
-                            pass
-                if not returned:
-                    # close() has already drained the pool, so this connection
-                    # is surplus. Close it here — dropping it on the floor is
-                    # what leaked the fd.
-                    #
-                    # queue.Full is now unreachable in practice (permits and
-                    # maxsize are both _READ_POOL_MAX, so there can never be a
-                    # ninth connection to return), but the branch stays: it is
-                    # load-bearing if those two ever drift apart, and a leak is
-                    # the failure mode it prevents.
+                if discarded:
+                    # Do NOT return here — a return in a finally block
+                    # swallows the exception re-raised in the except above.
                     self._close_read_conn(conn)
+                else:
+                    returned = False
+                    with self._read_conns_lock:
+                        if not self._read_conns_closed:
+                            try:
+                                self._read_pool.put_nowait(conn)
+                                returned = True
+                            except queue.Full:
+                                pass
+                    if not returned:
+                        # close() has already drained the pool, so this
+                        # connection is surplus. Close it here — dropping it
+                        # on the floor is what leaked the fd.
+                        #
+                        # queue.Full is now unreachable in practice (permits
+                        # and maxsize are both _READ_POOL_MAX, so there can
+                        # never be a ninth connection to return), but the
+                        # branch stays: it is load-bearing if those two ever
+                        # drift apart, and a leak is the failure mode it
+                        # prevents.
+                        self._close_read_conn(conn)
             return
         with self._lock:
             yield self._conn

--- a/tests/test_session_db_read_conn_pool.py
+++ b/tests/test_session_db_read_conn_pool.py
@@ -35,6 +35,7 @@ holds POSIX locks on that inode, so raw descriptor counts lag the real
 connection count and make such assertions flaky.
 """
 
+import sqlite3
 import threading
 
 import pytest
@@ -384,3 +385,87 @@ def test_close_returns_every_permit(db):
     for _ in range(_READ_POOL_MAX):
         assert db._read_permits.acquire(blocking=False), "close() stranded a permit"
     assert not db._read_permits.acquire(blocking=False), "close() over-released"
+
+
+@pytest.mark.requires_wal
+def test_notadb_reader_is_discarded_not_returned(db, monkeypatch):
+    """A pooled reader that hits 'file is not a database' must be discarded.
+
+    Runtime connection corruption (#20260809) breaks every connection opened
+    against the replaced/truncated file. The write path self-heals via
+    ``_reconnect_after_notadb``, but without this fix the poisoned reader is
+    returned to ``_read_pool`` by ``_read_ctx``'s finally, so the next
+    checkout reuses the same stale descriptor and fails again — reads stay
+    broken until process restart while writes look healthy.
+    """
+    import sqlite3 as _sqlite3
+
+    from hermes_state import _is_not_a_database_error
+
+    class _PoisonedConn:
+        """Proxy that raises on execute when armed, otherwise delegates."""
+
+        def __init__(self, real):
+            self._real = real
+            self._poisoned = True
+
+        def execute(self, *a, **kw):
+            if self._poisoned:
+                raise _sqlite3.DatabaseError("file is not a database")
+            return self._real.execute(*a, **kw)
+
+        def __getattr__(self, name):
+            return getattr(self._real, name)
+
+    # Prime the pool with a poisoned connection (as a sibling process
+    # replacing the backing file would leave it).
+    real = db._checkout_read_conn()
+    assert real is not None
+    db._read_pool.put_nowait(_PoisonedConn(real))
+    assert db._read_pool.qsize() >= 1, "pool should hold the primed reader"
+
+    # A read through the poisoned pooled connection must raise the corruption
+    # error AND leave the pool drained (the broken conn was closed, not
+    # returned).
+    with pytest.raises(_sqlite3.DatabaseError, match="not a database"):
+        with db._read_ctx() as conn:
+            conn.execute("SELECT 1")
+    assert db._read_pool.qsize() == 0, (
+        "poisoned reader was returned to the pool; next checkout would "
+        "reuse the stale descriptor"
+    )
+
+    # The next read must open a fresh, healthy connection and succeed.
+    assert db.get_session("s1") is not None
+
+
+@pytest.mark.requires_wal
+def test_non_notadb_error_still_returns_conn(db, monkeypatch):
+    """Unrelated DatabaseErrors keep the normal return-to-pool behaviour."""
+    import sqlite3 as _sqlite3
+
+    class _BoomConn:
+        """Proxy that raises a non-corruption error when armed."""
+
+        def __init__(self, real):
+            self._real = real
+            self._boom = True
+
+        def execute(self, *a, **kw):
+            if self._boom:
+                raise _sqlite3.DatabaseError("database is locked")
+            return self._real.execute(*a, **kw)
+
+        def __getattr__(self, name):
+            return getattr(self._real, name)
+
+    real = db._checkout_read_conn()
+    assert real is not None
+    db._read_pool.put_nowait(_BoomConn(real))
+    assert db._read_pool.qsize() >= 1
+
+    with pytest.raises(_sqlite3.DatabaseError, match="database is locked"):
+        with db._read_ctx() as conn:
+            conn.execute("SELECT 1")
+    # Not the corruption class: normal pool semantics preserved.
+    assert db._read_pool.qsize() >= 1


### PR DESCRIPTION
## Problem

The read-only pool returns every connection to `_read_pool` in `_read_ctx`'s `finally`, including one that raised `file is not a database` after a sibling process replaced/truncated the backing file (the `#20260809` runtime connection-corruption class). The next checkout reuses the same stale descriptor and fails again, so **reads stay broken until process restart while the write path looks healthy** — the confusing write-OK/read-broken split.

The write path already self-heals via `_reconnect_after_notadb` (see #86599 for the pool-drain half). This PR closes the read-path gap: a poisoned pooled reader is now discarded, not recycled.

## Fix

In `_read_ctx`, detect the corruption class:

- On `sqlite3.DatabaseError` where `_is_not_a_database_error(exc)` is true, mark the connection `discarded`.
- In `finally`, a discarded connection is closed (releasing its permit) instead of returned to the pool; `_read_open_failed_at` is cleared so the next read opens a fresh connection immediately.
- **Do not** `return` inside the `finally` — a finally-return swallows the exception re-raised in the `except` handler.

## Tests

- `test_notadb_reader_is_discarded_not_returned`: primes the pool with a poisoned reader, asserts the read raises, the pool is drained (broken conn closed, not returned), and the next read works.
- `test_non_notadb_error_still_returns_conn`: unrelated `DatabaseError` keeps normal return-to-pool semantics.

```
tests/test_session_db_read_conn_pool.py ............... 15 passed
tests/test_state_db_notadb_selfheal.py tests/test_session_db_read_path_split.py ..... 17 passed
```