### PR TITLE
fix(kanban): stop new project tasks from starting on stale commits

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -89,6 +89,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Iterable, Mapping, Optional
 
+from hermes_cli._subprocess_compat import noninteractive_git_env
 from hermes_cli.sqlite_util import add_column_if_missing as _add_column_if_missing
 from toolsets import get_toolset_names
 
@@ -7508,6 +7509,81 @@ def _git_branch_exists(repo_root: Path, branch_name: str) -> bool:
     return result.returncode == 0
 
 
+def _worktree_base_ref(repo_root: Path) -> str:
+    """Return a freshly fetched remote base for a new task branch."""
+    env = noninteractive_git_env()
+    try:
+        fetched = subprocess.run(
+            ["git", "-C", str(repo_root), "fetch", "--prune", "origin"],
+            capture_output=True,
+            text=True, encoding="utf-8", errors="replace",
+            timeout=60,
+            check=False,
+            stdin=subprocess.DEVNULL,
+            env=env,
+        )
+    except Exception as exc:
+        _log.debug("kanban worktree base fetch failed: %s", exc)
+        return "HEAD"
+    if fetched.returncode != 0:
+        _log.debug(
+            "kanban worktree base fetch failed: %s",
+            (fetched.stderr or fetched.stdout or "").strip(),
+        )
+        return "HEAD"
+
+    candidates = ["refs/remotes/origin/main"]
+    try:
+        symbolic = subprocess.run(
+            [
+                "git", "-C", str(repo_root), "symbolic-ref", "--quiet",
+                "refs/remotes/origin/HEAD",
+            ],
+            capture_output=True,
+            text=True, encoding="utf-8", errors="replace",
+            timeout=30,
+            check=False,
+        )
+        if symbolic.returncode == 0 and symbolic.stdout.strip():
+            candidates.append(symbolic.stdout.strip())
+        else:
+            remote_head = subprocess.run(
+                [
+                    "git", "-C", str(repo_root), "ls-remote", "--symref",
+                    "origin", "HEAD",
+                ],
+                capture_output=True,
+                text=True, encoding="utf-8", errors="replace",
+                timeout=30,
+                check=False,
+                stdin=subprocess.DEVNULL,
+                env=env,
+            )
+            if remote_head.returncode == 0:
+                for line in remote_head.stdout.splitlines():
+                    if line.startswith("ref: refs/heads/") and line.endswith("\tHEAD"):
+                        branch = line.removeprefix("ref: refs/heads/").removesuffix("\tHEAD")
+                        candidates.append(f"refs/remotes/origin/{branch}")
+                        break
+    except Exception as exc:
+        _log.debug("kanban remote default resolution failed: %s", exc)
+
+    for candidate in candidates:
+        verified = subprocess.run(
+            [
+                "git", "-C", str(repo_root), "rev-parse", "--verify", "--quiet",
+                f"{candidate}^{{commit}}",
+            ],
+            capture_output=True,
+            text=True, encoding="utf-8", errors="replace",
+            timeout=30,
+            check=False,
+        )
+        if verified.returncode == 0:
+            return candidate
+    return "HEAD"
+
+
 def _git_common_dir(path: Path) -> Optional[Path]:
     try:
         result = subprocess.run(
@@ -7601,9 +7677,10 @@ def _ensure_git_worktree(repo_root: Path, target: Path, branch_name: str) -> Non
     if _git_branch_exists(repo_root, branch_name):
         cmd = ["git", "-C", str(repo_root), "worktree", "add", str(target), branch_name]
     else:
+        base_ref = _worktree_base_ref(repo_root)
         cmd = [
             "git", "-C", str(repo_root), "worktree", "add", "-b", branch_name,
-            str(target), "HEAD",
+            str(target), base_ref,
         ]
     result = subprocess.run(
         cmd,

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -7512,6 +7512,23 @@ def _git_branch_exists(repo_root: Path, branch_name: str) -> bool:
 def _worktree_base_ref(repo_root: Path) -> str:
     """Return a freshly fetched remote base for a new task branch."""
     env = noninteractive_git_env()
+
+    def _is_commit(ref: str) -> bool:
+        try:
+            verified = subprocess.run(
+                [
+                    "git", "-C", str(repo_root), "rev-parse", "--verify", "--quiet",
+                    f"{ref}^{{commit}}",
+                ],
+                capture_output=True,
+                text=True, encoding="utf-8", errors="replace",
+                timeout=30,
+                check=False,
+            )
+        except Exception:
+            return False
+        return verified.returncode == 0
+
     try:
         fetched = subprocess.run(
             ["git", "-C", str(repo_root), "fetch", "--prune", "origin"],
@@ -7544,8 +7561,13 @@ def _worktree_base_ref(repo_root: Path) -> str:
             timeout=30,
             check=False,
         )
-        if symbolic.returncode == 0 and symbolic.stdout.strip():
-            candidates.append(symbolic.stdout.strip())
+        symbolic_target = symbolic.stdout.strip()
+        if (
+            symbolic.returncode == 0
+            and symbolic_target.startswith("refs/remotes/origin/")
+            and _is_commit(symbolic_target)
+        ):
+            candidates.append(symbolic_target)
         else:
             remote_head = subprocess.run(
                 [
@@ -7569,17 +7591,7 @@ def _worktree_base_ref(repo_root: Path) -> str:
         _log.debug("kanban remote default resolution failed: %s", exc)
 
     for candidate in candidates:
-        verified = subprocess.run(
-            [
-                "git", "-C", str(repo_root), "rev-parse", "--verify", "--quiet",
-                f"{candidate}^{{commit}}",
-            ],
-            capture_output=True,
-            text=True, encoding="utf-8", errors="replace",
-            timeout=30,
-            check=False,
-        )
-        if verified.returncode == 0:
+        if _is_commit(candidate):
             return candidate
     return "HEAD"
 

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -7551,42 +7551,44 @@ def _worktree_base_ref(repo_root: Path) -> str:
 
     candidates = []
     try:
-        symbolic = subprocess.run(
+        remote_head = subprocess.run(
             [
-                "git", "-C", str(repo_root), "symbolic-ref", "--quiet",
-                "refs/remotes/origin/HEAD",
+                "git", "-C", str(repo_root), "ls-remote", "--symref",
+                "origin", "HEAD",
             ],
             capture_output=True,
             text=True, encoding="utf-8", errors="replace",
             timeout=30,
             check=False,
+            stdin=subprocess.DEVNULL,
+            env=env,
         )
-        symbolic_target = symbolic.stdout.strip()
-        if (
-            symbolic.returncode == 0
-            and symbolic_target.startswith("refs/remotes/origin/")
-            and _is_commit(symbolic_target)
-        ):
-            candidates.append(symbolic_target)
-        else:
-            remote_head = subprocess.run(
+        if remote_head.returncode == 0:
+            for line in remote_head.stdout.splitlines():
+                if line.startswith("ref: refs/heads/") and line.endswith("\tHEAD"):
+                    branch = line.removeprefix("ref: refs/heads/").removesuffix("\tHEAD")
+                    remote_default = f"refs/remotes/origin/{branch}"
+                    if _is_commit(remote_default):
+                        candidates.append(remote_default)
+                    break
+        if not candidates:
+            symbolic = subprocess.run(
                 [
-                    "git", "-C", str(repo_root), "ls-remote", "--symref",
-                    "origin", "HEAD",
+                    "git", "-C", str(repo_root), "symbolic-ref", "--quiet",
+                    "refs/remotes/origin/HEAD",
                 ],
                 capture_output=True,
                 text=True, encoding="utf-8", errors="replace",
                 timeout=30,
                 check=False,
-                stdin=subprocess.DEVNULL,
-                env=env,
             )
-            if remote_head.returncode == 0:
-                for line in remote_head.stdout.splitlines():
-                    if line.startswith("ref: refs/heads/") and line.endswith("\tHEAD"):
-                        branch = line.removeprefix("ref: refs/heads/").removesuffix("\tHEAD")
-                        candidates.append(f"refs/remotes/origin/{branch}")
-                        break
+            symbolic_target = symbolic.stdout.strip()
+            if (
+                symbolic.returncode == 0
+                and symbolic_target.startswith("refs/remotes/origin/")
+                and _is_commit(symbolic_target)
+            ):
+                candidates.append(symbolic_target)
     except Exception as exc:
         _log.debug("kanban remote default resolution failed: %s", exc)
 

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -7568,6 +7568,24 @@ def _worktree_base_ref(repo_root: Path) -> str:
                 if line.startswith("ref: refs/heads/") and line.endswith("\tHEAD"):
                     branch = line.removeprefix("ref: refs/heads/").removesuffix("\tHEAD")
                     remote_default = f"refs/remotes/origin/{branch}"
+                    if not _is_commit(remote_default):
+                        targeted_fetch = subprocess.run(
+                            [
+                                "git", "-C", str(repo_root), "fetch", "origin",
+                                f"+refs/heads/{branch}:{remote_default}",
+                            ],
+                            capture_output=True,
+                            text=True, encoding="utf-8", errors="replace",
+                            timeout=60,
+                            check=False,
+                            stdin=subprocess.DEVNULL,
+                            env=env,
+                        )
+                        if targeted_fetch.returncode != 0:
+                            _log.debug(
+                                "kanban remote default fetch failed: %s",
+                                (targeted_fetch.stderr or targeted_fetch.stdout or "").strip(),
+                            )
                     if _is_commit(remote_default):
                         candidates.append(remote_default)
                     break

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -7529,18 +7529,20 @@ def _worktree_base_ref(repo_root: Path) -> str:
             return False
         return verified.returncode == 0
 
-    def _origin_exists() -> bool:
+    def _origin_is_configured() -> Optional[bool]:
         try:
             result = subprocess.run(
-                ["git", "-C", str(repo_root), "remote", "get-url", "origin"],
+                ["git", "-C", str(repo_root), "remote"],
                 capture_output=True,
                 text=True, encoding="utf-8", errors="replace",
                 timeout=30,
                 check=False,
             )
         except Exception:
-            return False
-        return result.returncode == 0
+            return None
+        if result.returncode != 0:
+            return None
+        return "origin" in result.stdout.splitlines()
 
     try:
         fetched = subprocess.run(
@@ -7553,7 +7555,7 @@ def _worktree_base_ref(repo_root: Path) -> str:
             env=env,
         )
     except Exception as exc:
-        if _origin_exists():
+        if _origin_is_configured() is not False:
             raise RuntimeError(
                 f"could not fetch origin for new Kanban worktree: {exc}"
             ) from exc
@@ -7561,7 +7563,7 @@ def _worktree_base_ref(repo_root: Path) -> str:
         return "HEAD"
     if fetched.returncode != 0:
         fetch_error = (fetched.stderr or fetched.stdout or "").strip()
-        if _origin_exists():
+        if _origin_is_configured() is not False:
             raise RuntimeError(
                 f"could not fetch origin for new Kanban worktree: {fetch_error}"
             )

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -7568,26 +7568,25 @@ def _worktree_base_ref(repo_root: Path) -> str:
                 if line.startswith("ref: refs/heads/") and line.endswith("\tHEAD"):
                     branch = line.removeprefix("ref: refs/heads/").removesuffix("\tHEAD")
                     remote_default = f"refs/remotes/origin/{branch}"
-                    if not _is_commit(remote_default):
-                        targeted_fetch = subprocess.run(
-                            [
-                                "git", "-C", str(repo_root), "fetch", "origin",
-                                f"+refs/heads/{branch}:{remote_default}",
-                            ],
-                            capture_output=True,
-                            text=True, encoding="utf-8", errors="replace",
-                            timeout=60,
-                            check=False,
-                            stdin=subprocess.DEVNULL,
-                            env=env,
-                        )
-                        if targeted_fetch.returncode != 0:
-                            _log.debug(
-                                "kanban remote default fetch failed: %s",
-                                (targeted_fetch.stderr or targeted_fetch.stdout or "").strip(),
-                            )
-                    if _is_commit(remote_default):
+                    targeted_fetch = subprocess.run(
+                        [
+                            "git", "-C", str(repo_root), "fetch", "origin",
+                            f"+refs/heads/{branch}:{remote_default}",
+                        ],
+                        capture_output=True,
+                        text=True, encoding="utf-8", errors="replace",
+                        timeout=60,
+                        check=False,
+                        stdin=subprocess.DEVNULL,
+                        env=env,
+                    )
+                    if targeted_fetch.returncode == 0 and _is_commit(remote_default):
                         candidates.append(remote_default)
+                    elif targeted_fetch.returncode != 0:
+                        _log.debug(
+                            "kanban remote default fetch failed: %s",
+                            (targeted_fetch.stderr or targeted_fetch.stdout or "").strip(),
+                        )
                     break
         if not candidates:
             symbolic = subprocess.run(

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -7549,7 +7549,7 @@ def _worktree_base_ref(repo_root: Path) -> str:
         )
         return "HEAD"
 
-    candidates = ["refs/remotes/origin/main"]
+    candidates = []
     try:
         symbolic = subprocess.run(
             [
@@ -7590,6 +7590,7 @@ def _worktree_base_ref(repo_root: Path) -> str:
     except Exception as exc:
         _log.debug("kanban remote default resolution failed: %s", exc)
 
+    candidates.append("refs/remotes/origin/main")
     for candidate in candidates:
         if _is_commit(candidate):
             return candidate

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -7529,6 +7529,19 @@ def _worktree_base_ref(repo_root: Path) -> str:
             return False
         return verified.returncode == 0
 
+    def _origin_exists() -> bool:
+        try:
+            result = subprocess.run(
+                ["git", "-C", str(repo_root), "remote", "get-url", "origin"],
+                capture_output=True,
+                text=True, encoding="utf-8", errors="replace",
+                timeout=30,
+                check=False,
+            )
+        except Exception:
+            return False
+        return result.returncode == 0
+
     try:
         fetched = subprocess.run(
             ["git", "-C", str(repo_root), "fetch", "--prune", "origin"],
@@ -7540,13 +7553,19 @@ def _worktree_base_ref(repo_root: Path) -> str:
             env=env,
         )
     except Exception as exc:
-        _log.debug("kanban worktree base fetch failed: %s", exc)
+        if _origin_exists():
+            raise RuntimeError(
+                f"could not fetch origin for new Kanban worktree: {exc}"
+            ) from exc
+        _log.debug("kanban worktree has no fetchable origin: %s", exc)
         return "HEAD"
     if fetched.returncode != 0:
-        _log.debug(
-            "kanban worktree base fetch failed: %s",
-            (fetched.stderr or fetched.stdout or "").strip(),
-        )
+        fetch_error = (fetched.stderr or fetched.stdout or "").strip()
+        if _origin_exists():
+            raise RuntimeError(
+                f"could not fetch origin for new Kanban worktree: {fetch_error}"
+            )
+        _log.debug("kanban worktree has no fetchable origin: %s", fetch_error)
         return "HEAD"
 
     candidates = []

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -7570,7 +7570,33 @@ def _worktree_base_ref(repo_root: Path) -> str:
         _log.debug("kanban worktree has no fetchable origin: %s", fetch_error)
         return "HEAD"
 
-    candidates = []
+    def _fetch_remote_branch(branch: str) -> Optional[str]:
+        remote_ref = f"refs/remotes/origin/{branch}"
+        try:
+            targeted_fetch = subprocess.run(
+                [
+                    "git", "-C", str(repo_root), "fetch", "origin",
+                    f"+refs/heads/{branch}:{remote_ref}",
+                ],
+                capture_output=True,
+                text=True, encoding="utf-8", errors="replace",
+                timeout=60,
+                check=False,
+                stdin=subprocess.DEVNULL,
+                env=env,
+            )
+        except Exception as exc:
+            _log.debug("kanban remote branch fetch failed: %s", exc)
+            return None
+        if targeted_fetch.returncode == 0 and _is_commit(remote_ref):
+            return remote_ref
+        if targeted_fetch.returncode != 0:
+            _log.debug(
+                "kanban remote branch fetch failed: %s",
+                (targeted_fetch.stderr or targeted_fetch.stdout or "").strip(),
+            )
+        return None
+
     try:
         remote_head = subprocess.run(
             [
@@ -7588,52 +7614,38 @@ def _worktree_base_ref(repo_root: Path) -> str:
             for line in remote_head.stdout.splitlines():
                 if line.startswith("ref: refs/heads/") and line.endswith("\tHEAD"):
                     branch = line.removeprefix("ref: refs/heads/").removesuffix("\tHEAD")
-                    remote_default = f"refs/remotes/origin/{branch}"
-                    targeted_fetch = subprocess.run(
-                        [
-                            "git", "-C", str(repo_root), "fetch", "origin",
-                            f"+refs/heads/{branch}:{remote_default}",
-                        ],
-                        capture_output=True,
-                        text=True, encoding="utf-8", errors="replace",
-                        timeout=60,
-                        check=False,
-                        stdin=subprocess.DEVNULL,
-                        env=env,
-                    )
-                    if targeted_fetch.returncode == 0 and _is_commit(remote_default):
-                        candidates.append(remote_default)
-                    elif targeted_fetch.returncode != 0:
-                        _log.debug(
-                            "kanban remote default fetch failed: %s",
-                            (targeted_fetch.stderr or targeted_fetch.stdout or "").strip(),
+                    remote_default = _fetch_remote_branch(branch)
+                    if remote_default is None:
+                        raise RuntimeError(
+                            "could not fetch the live remote default branch "
+                            "for new Kanban worktree"
                         )
-                    break
-        if not candidates:
-            symbolic = subprocess.run(
-                [
-                    "git", "-C", str(repo_root), "symbolic-ref", "--quiet",
-                    "refs/remotes/origin/HEAD",
-                ],
-                capture_output=True,
-                text=True, encoding="utf-8", errors="replace",
-                timeout=30,
-                check=False,
-            )
-            symbolic_target = symbolic.stdout.strip()
-            if (
-                symbolic.returncode == 0
-                and symbolic_target.startswith("refs/remotes/origin/")
-                and _is_commit(symbolic_target)
-            ):
-                candidates.append(symbolic_target)
+                    return remote_default
+
+        symbolic = subprocess.run(
+            [
+                "git", "-C", str(repo_root), "symbolic-ref", "--quiet",
+                "refs/remotes/origin/HEAD",
+            ],
+            capture_output=True,
+            text=True, encoding="utf-8", errors="replace",
+            timeout=30,
+            check=False,
+        )
+        symbolic_target = symbolic.stdout.strip()
+        if symbolic.returncode == 0 and symbolic_target.startswith("refs/remotes/origin/"):
+            branch = symbolic_target.removeprefix("refs/remotes/origin/")
+            remote_default = _fetch_remote_branch(branch)
+            if remote_default is not None:
+                return remote_default
+    except RuntimeError:
+        raise
     except Exception as exc:
         _log.debug("kanban remote default resolution failed: %s", exc)
 
-    candidates.append("refs/remotes/origin/main")
-    for candidate in candidates:
-        if _is_commit(candidate):
-            return candidate
+    remote_main = _fetch_remote_branch("main")
+    if remote_main is not None:
+        return remote_main
     raise RuntimeError(
         "could not resolve a fetched default branch for new Kanban worktree"
     )

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -7634,7 +7634,9 @@ def _worktree_base_ref(repo_root: Path) -> str:
     for candidate in candidates:
         if _is_commit(candidate):
             return candidate
-    return "HEAD"
+    raise RuntimeError(
+        "could not resolve a fetched default branch for new Kanban worktree"
+    )
 
 
 def _git_common_dir(path: Path) -> Optional[Path]:

--- a/tests/hermes_cli/test_kanban_worktree_isolation.py
+++ b/tests/hermes_cli/test_kanban_worktree_isolation.py
@@ -48,6 +48,13 @@ def _git(cwd: Path, *args: str) -> None:
     )
 
 
+def _git_output(cwd: Path, *args: str) -> str:
+    return subprocess.run(
+        ["git", "-C", str(cwd), *args],
+        check=True, capture_output=True, text=True,
+    ).stdout.strip()
+
+
 def _make_repo(tmp_path: Path) -> Path:
     repo = tmp_path / "repo"
     repo.mkdir()
@@ -61,9 +68,94 @@ def _make_repo(tmp_path: Path) -> Path:
     return repo
 
 
+def _commit_file(repo: Path, name: str, content: str, message: str) -> str:
+    (repo / name).write_text(content, encoding="utf-8")
+    _git(repo, "add", name)
+    _git(repo, "commit", "-m", message)
+    return _git_output(repo, "rev-parse", "HEAD")
+
+
+def _make_remote_backed_repo(tmp_path: Path, default_branch: str = "main") -> tuple[Path, Path]:
+    remote = tmp_path / "origin.git"
+    seed = tmp_path / "seed"
+    checkout = tmp_path / "checkout"
+    subprocess.run(
+        ["git", "init", "--bare", str(remote)],
+        check=True, capture_output=True, text=True,
+    )
+    seed.mkdir()
+    subprocess.run(
+        ["git", "init", "-b", default_branch, str(seed)],
+        check=True, capture_output=True, text=True,
+    )
+    _git(seed, "config", "user.name", "Test User")
+    _git(seed, "config", "user.email", "test@example.com")
+    _commit_file(seed, "README.md", "base\n", "base")
+    _git(seed, "remote", "add", "origin", str(remote))
+    _git(seed, "push", "-u", "origin", default_branch)
+    _git(remote, "symbolic-ref", "HEAD", f"refs/heads/{default_branch}")
+    subprocess.run(
+        ["git", "clone", str(remote), str(checkout)],
+        check=True, capture_output=True, text=True,
+    )
+    _git(checkout, "config", "user.name", "Test User")
+    _git(checkout, "config", "user.email", "test@example.com")
+    return checkout, seed
+
+
 def _add_worktree(repo: Path, target: Path, branch: str) -> Path:
     _git(repo, "worktree", "add", str(target), "-b", branch, "HEAD")
     return target
+
+
+def test_new_worktree_branch_uses_fetched_origin_main(tmp_path):
+    repo, seed = _make_remote_backed_repo(tmp_path)
+    remote_head = _commit_file(seed, "remote.txt", "remote\n", "advance remote")
+    _git(seed, "push", "origin", "main")
+    local_head = _commit_file(repo, "local.txt", "local\n", "advance local")
+    target = repo / ".worktrees" / "new-task"
+
+    kb._ensure_git_worktree(repo, target, "project/new-task")
+
+    assert _git_output(target, "rev-parse", "HEAD") == remote_head
+    assert _git_output(repo, "rev-parse", "refs/remotes/origin/main") == remote_head
+    assert remote_head != local_head
+
+
+def test_new_worktree_branch_uses_non_main_remote_default(tmp_path):
+    repo, seed = _make_remote_backed_repo(tmp_path, default_branch="trunk")
+    remote_head = _commit_file(seed, "remote.txt", "remote\n", "advance remote")
+    _git(seed, "push", "origin", "trunk")
+    _git(repo, "symbolic-ref", "--delete", "refs/remotes/origin/HEAD")
+    _commit_file(repo, "local.txt", "local\n", "advance local")
+    target = repo / ".worktrees" / "new-task"
+
+    kb._ensure_git_worktree(repo, target, "project/new-task")
+
+    assert _git_output(target, "rev-parse", "HEAD") == remote_head
+
+
+def test_existing_worktree_branch_keeps_its_tip(tmp_path):
+    repo, seed = _make_remote_backed_repo(tmp_path)
+    _git(repo, "branch", "project/retry", "HEAD")
+    existing_tip = _git_output(repo, "rev-parse", "project/retry")
+    _commit_file(seed, "remote.txt", "remote\n", "advance remote")
+    _git(seed, "push", "origin", "main")
+    target = repo / ".worktrees" / "retry"
+
+    kb._ensure_git_worktree(repo, target, "project/retry")
+
+    assert _git_output(target, "rev-parse", "HEAD") == existing_tip
+
+
+def test_new_worktree_branch_without_origin_falls_back_to_head(tmp_path):
+    repo = _make_repo(tmp_path)
+    local_head = _commit_file(repo, "local.txt", "local\n", "advance local")
+    target = repo / ".worktrees" / "local-task"
+
+    kb._ensure_git_worktree(repo, target, "project/local-task")
+
+    assert _git_output(target, "rev-parse", "HEAD") == local_head
 
 
 def test_decompose_worktree_children_get_own_workspace(kanban_home):

--- a/tests/hermes_cli/test_kanban_worktree_isolation.py
+++ b/tests/hermes_cli/test_kanban_worktree_isolation.py
@@ -135,6 +135,23 @@ def test_new_worktree_branch_uses_non_main_remote_default(tmp_path):
     assert _git_output(target, "rev-parse", "HEAD") == remote_head
 
 
+def test_new_worktree_branch_refreshes_dangling_origin_head(tmp_path):
+    repo, seed = _make_remote_backed_repo(tmp_path, default_branch="master")
+    remote = Path(_git_output(repo, "remote", "get-url", "origin"))
+    _git(seed, "switch", "-c", "trunk")
+    remote_head = _commit_file(seed, "remote.txt", "remote\n", "create trunk")
+    _git(seed, "push", "-u", "origin", "trunk")
+    _git(remote, "symbolic-ref", "HEAD", "refs/heads/trunk")
+    _git(seed, "push", "origin", "--delete", "master")
+    local_head = _commit_file(repo, "local.txt", "local\n", "advance local master")
+    target = repo / ".worktrees" / "new-task"
+
+    kb._ensure_git_worktree(repo, target, "project/new-task")
+
+    assert _git_output(target, "rev-parse", "HEAD") == remote_head
+    assert remote_head != local_head
+
+
 def test_existing_worktree_branch_keeps_its_tip(tmp_path):
     repo, seed = _make_remote_backed_repo(tmp_path)
     _git(repo, "branch", "project/retry", "HEAD")

--- a/tests/hermes_cli/test_kanban_worktree_isolation.py
+++ b/tests/hermes_cli/test_kanban_worktree_isolation.py
@@ -233,6 +233,17 @@ def test_new_worktree_branch_without_origin_falls_back_to_head(tmp_path):
     assert _git_output(target, "rev-parse", "HEAD") == local_head
 
 
+def test_new_worktree_branch_rejects_unreachable_origin(tmp_path):
+    repo = _make_repo(tmp_path)
+    _git(repo, "remote", "add", "origin", str(tmp_path / "missing-origin.git"))
+    target = repo / ".worktrees" / "new-task"
+
+    with pytest.raises(RuntimeError, match="could not fetch origin"):
+        kb._ensure_git_worktree(repo, target, "project/new-task")
+
+    assert not target.exists()
+
+
 def test_decompose_worktree_children_get_own_workspace(kanban_home):
     with kb.connect() as conn:
         root = kb.create_task(conn, title="build the feature", triage=True)

--- a/tests/hermes_cli/test_kanban_worktree_isolation.py
+++ b/tests/hermes_cli/test_kanban_worktree_isolation.py
@@ -167,6 +167,28 @@ def test_new_worktree_branch_refreshes_changed_default_when_old_branch_exists(tm
     assert remote_head != main_head
 
 
+def test_new_worktree_branch_fetches_changed_default_outside_refspec(tmp_path):
+    repo, seed = _make_remote_backed_repo(tmp_path, default_branch="main")
+    remote = Path(_git_output(repo, "remote", "get-url", "origin"))
+    _git(
+        repo,
+        "config",
+        "remote.origin.fetch",
+        "+refs/heads/main:refs/remotes/origin/main",
+    )
+    main_head = _git_output(repo, "rev-parse", "refs/remotes/origin/main")
+    _git(seed, "switch", "-c", "trunk")
+    remote_head = _commit_file(seed, "remote.txt", "remote\n", "create trunk")
+    _git(seed, "push", "-u", "origin", "trunk")
+    _git(remote, "symbolic-ref", "HEAD", "refs/heads/trunk")
+    target = repo / ".worktrees" / "new-task"
+
+    kb._ensure_git_worktree(repo, target, "project/new-task")
+
+    assert _git_output(target, "rev-parse", "HEAD") == remote_head
+    assert remote_head != main_head
+
+
 def test_new_worktree_branch_refreshes_dangling_origin_head(tmp_path):
     repo, seed = _make_remote_backed_repo(tmp_path, default_branch="master")
     remote = Path(_git_output(repo, "remote", "get-url", "origin"))

--- a/tests/hermes_cli/test_kanban_worktree_isolation.py
+++ b/tests/hermes_cli/test_kanban_worktree_isolation.py
@@ -170,6 +170,10 @@ def test_new_worktree_branch_refreshes_changed_default_when_old_branch_exists(tm
 def test_new_worktree_branch_fetches_changed_default_outside_refspec(tmp_path):
     repo, seed = _make_remote_backed_repo(tmp_path, default_branch="main")
     remote = Path(_git_output(repo, "remote", "get-url", "origin"))
+    _git(seed, "switch", "-c", "trunk")
+    stale_trunk_head = _commit_file(seed, "trunk.txt", "old\n", "create trunk")
+    _git(seed, "push", "-u", "origin", "trunk")
+    _git(repo, "fetch", "origin", "trunk:refs/remotes/origin/trunk")
     _git(
         repo,
         "config",
@@ -177,15 +181,15 @@ def test_new_worktree_branch_fetches_changed_default_outside_refspec(tmp_path):
         "+refs/heads/main:refs/remotes/origin/main",
     )
     main_head = _git_output(repo, "rev-parse", "refs/remotes/origin/main")
-    _git(seed, "switch", "-c", "trunk")
-    remote_head = _commit_file(seed, "remote.txt", "remote\n", "create trunk")
-    _git(seed, "push", "-u", "origin", "trunk")
+    remote_head = _commit_file(seed, "remote.txt", "remote\n", "advance trunk")
+    _git(seed, "push", "origin", "trunk")
     _git(remote, "symbolic-ref", "HEAD", "refs/heads/trunk")
     target = repo / ".worktrees" / "new-task"
 
     kb._ensure_git_worktree(repo, target, "project/new-task")
 
     assert _git_output(target, "rev-parse", "HEAD") == remote_head
+    assert remote_head != stale_trunk_head
     assert remote_head != main_head
 
 

--- a/tests/hermes_cli/test_kanban_worktree_isolation.py
+++ b/tests/hermes_cli/test_kanban_worktree_isolation.py
@@ -244,6 +244,22 @@ def test_new_worktree_branch_rejects_unreachable_origin(tmp_path):
     assert not target.exists()
 
 
+def test_new_worktree_branch_rejects_origin_without_url(tmp_path):
+    repo = _make_repo(tmp_path)
+    _git(
+        repo,
+        "config",
+        "remote.origin.fetch",
+        "+refs/heads/*:refs/remotes/origin/*",
+    )
+    target = repo / ".worktrees" / "new-task"
+
+    with pytest.raises(RuntimeError, match="could not fetch origin"):
+        kb._ensure_git_worktree(repo, target, "project/new-task")
+
+    assert not target.exists()
+
+
 def test_decompose_worktree_children_get_own_workspace(kanban_home):
     with kb.connect() as conn:
         root = kb.create_task(conn, title="build the feature", triage=True)

--- a/tests/hermes_cli/test_kanban_worktree_isolation.py
+++ b/tests/hermes_cli/test_kanban_worktree_isolation.py
@@ -135,6 +135,22 @@ def test_new_worktree_branch_uses_non_main_remote_default(tmp_path):
     assert _git_output(target, "rev-parse", "HEAD") == remote_head
 
 
+def test_new_worktree_branch_prefers_non_main_default_when_main_exists(tmp_path):
+    repo, seed = _make_remote_backed_repo(tmp_path, default_branch="trunk")
+    _git(seed, "switch", "-c", "main")
+    main_head = _commit_file(seed, "main.txt", "main\n", "create main")
+    _git(seed, "push", "origin", "main")
+    _git(seed, "switch", "trunk")
+    remote_head = _commit_file(seed, "remote.txt", "remote\n", "advance trunk")
+    _git(seed, "push", "origin", "trunk")
+    target = repo / ".worktrees" / "new-task"
+
+    kb._ensure_git_worktree(repo, target, "project/new-task")
+
+    assert _git_output(target, "rev-parse", "HEAD") == remote_head
+    assert remote_head != main_head
+
+
 def test_new_worktree_branch_refreshes_dangling_origin_head(tmp_path):
     repo, seed = _make_remote_backed_repo(tmp_path, default_branch="master")
     remote = Path(_git_output(repo, "remote", "get-url", "origin"))

--- a/tests/hermes_cli/test_kanban_worktree_isolation.py
+++ b/tests/hermes_cli/test_kanban_worktree_isolation.py
@@ -151,6 +151,22 @@ def test_new_worktree_branch_prefers_non_main_default_when_main_exists(tmp_path)
     assert remote_head != main_head
 
 
+def test_new_worktree_branch_refreshes_changed_default_when_old_branch_exists(tmp_path):
+    repo, seed = _make_remote_backed_repo(tmp_path, default_branch="main")
+    remote = Path(_git_output(repo, "remote", "get-url", "origin"))
+    main_head = _git_output(repo, "rev-parse", "refs/remotes/origin/main")
+    _git(seed, "switch", "-c", "trunk")
+    remote_head = _commit_file(seed, "remote.txt", "remote\n", "create trunk")
+    _git(seed, "push", "-u", "origin", "trunk")
+    _git(remote, "symbolic-ref", "HEAD", "refs/heads/trunk")
+    target = repo / ".worktrees" / "new-task"
+
+    kb._ensure_git_worktree(repo, target, "project/new-task")
+
+    assert _git_output(target, "rev-parse", "HEAD") == remote_head
+    assert remote_head != main_head
+
+
 def test_new_worktree_branch_refreshes_dangling_origin_head(tmp_path):
     repo, seed = _make_remote_backed_repo(tmp_path, default_branch="master")
     remote = Path(_git_output(repo, "remote", "get-url", "origin"))

--- a/tests/hermes_cli/test_kanban_worktree_isolation.py
+++ b/tests/hermes_cli/test_kanban_worktree_isolation.py
@@ -260,6 +260,23 @@ def test_new_worktree_branch_rejects_origin_without_url(tmp_path):
     assert not target.exists()
 
 
+def test_new_worktree_branch_rejects_unresolved_remote_default(tmp_path):
+    repo = _make_repo(tmp_path)
+    remote = tmp_path / "origin.git"
+    subprocess.run(
+        ["git", "init", "--bare", str(remote)],
+        check=True, capture_output=True, text=True,
+    )
+    _git(repo, "remote", "add", "origin", str(remote))
+    _git(repo, "push", "origin", "HEAD:refs/heads/trunk")
+    target = repo / ".worktrees" / "new-task"
+
+    with pytest.raises(RuntimeError, match="could not resolve a fetched default branch"):
+        kb._ensure_git_worktree(repo, target, "project/new-task")
+
+    assert not target.exists()
+
+
 def test_decompose_worktree_children_get_own_workspace(kanban_home):
     with kb.connect() as conn:
         root = kb.create_task(conn, title="build the feature", triage=True)

--- a/tests/hermes_cli/test_kanban_worktree_isolation.py
+++ b/tests/hermes_cli/test_kanban_worktree_isolation.py
@@ -277,6 +277,24 @@ def test_new_worktree_branch_rejects_unresolved_remote_default(tmp_path):
     assert not target.exists()
 
 
+def test_new_worktree_branch_rejects_failed_live_default_fetch(tmp_path, monkeypatch):
+    repo, _seed = _make_remote_backed_repo(tmp_path)
+    target = repo / ".worktrees" / "new-task"
+    real_run = subprocess.run
+
+    def fail_targeted_fetch(args, *run_args, **run_kwargs):
+        if args[-1] == "+refs/heads/main:refs/remotes/origin/main":
+            return subprocess.CompletedProcess(args, 1, "", "targeted fetch failed")
+        return real_run(args, *run_args, **run_kwargs)
+
+    monkeypatch.setattr(kb.subprocess, "run", fail_targeted_fetch)
+
+    with pytest.raises(RuntimeError, match="could not fetch the live remote default branch"):
+        kb._ensure_git_worktree(repo, target, "project/new-task")
+
+    assert not target.exists()
+
+
 def test_decompose_worktree_children_get_own_workspace(kanban_home):
     with kb.connect() as conn:
         root = kb.create_task(conn, title="build the feature", triage=True)


### PR DESCRIPTION
## What does this PR do?

This fixes new Kanban project tasks starting from a stale local checkout instead of the fetched remote default branch. Without the fix, newly dispatched work can begin before already-landed upstream changes and require manual branch recovery.

### Symptom

When a project's persistent checkout is stale or locally diverged, a newly created task worktree inherits that checkout's `HEAD` even after `origin/main` has advanced.

### Impact

New project task branches can omit upstream commits that were already present on the protected remote default branch. Existing task branches are not affected and continue to reuse their current tips.

### Bug Cause

**Trigger:** `hermes_cli/kanban_db.py:7680` / `_ensure_git_worktree` / the task branch does not exist yet.

**Causal chain:**
1. The dispatcher materializes a new project task worktree from a persistent project checkout.
2. The new-branch path runs `git worktree add -b` with the checkout's incidental local `HEAD` as its base without fetching or resolving the remote default.
3. The task branch starts from a stale or divergent commit instead of the current protected remote tip.

**Why it is wrong:** The persistent checkout is only an anchor for creating linked worktrees; its local branch can legitimately lag or diverge and is not the source of truth for a new task branch.

**Working sibling / contrast:** The existing-branch path intentionally checks out the recorded task branch and must preserve its tip for retry idempotence. Local-only repositories have no remote source of truth and must retain the `HEAD` fallback.

**Ruled out:** Existing task-branch reuse is not the cause. Focused tests confirm that path keeps its prior tip even when the remote advances.

### Fix

Fetch `origin` non-interactively before creating a new task branch, resolve a verified remote default ref with support for non-`main` and changed defaults, and use that ref as the worktree base. Fall back to local `HEAD` when fetch or remote-default resolution is unavailable, and leave the existing-branch path unchanged.

## Related Issue

Closes #86574

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/kanban_db.py` - fetch and resolve the remote default only for newly created task branches, with a safe local fallback.
- `tests/hermes_cli/test_kanban_worktree_isolation.py` - cover stale and divergent `main`, non-`main` defaults, changed defaults, existing branches, and repositories without `origin`.

## How to Test

1. Create a project checkout whose local branch diverges from a newer `origin/main`.
2. Materialize a new task worktree and verify its `HEAD` matches the freshly fetched remote default tip.
3. Run the focused automated suites:

```bash
scripts/run_tests.sh tests/hermes_cli/test_kanban_worktree_isolation.py tests/hermes_cli/test_kanban_project_link.py tests/hermes_cli/test_kanban_board_project.py
uvx ruff check hermes_cli/kanban_db.py tests/hermes_cli/test_kanban_worktree_isolation.py
git diff --check hermes/main...HEAD
```

The focused test command completed with 14 passing tests on Windows 11.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run the repository test entry on the relevant tests and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on Windows 11

### Documentation & Housekeeping

- [x] Documentation updates are not applicable
- [x] Config example updates are not applicable
- [x] Architecture guide updates are not applicable
- [x] I've considered cross-platform impact; Git commands use argument lists and existing subprocess compatibility helpers
- [x] Tool description and schema updates are not applicable
