### PR TITLE
feat(cli): add auto-discovery registry mappings for Mistral, Cohere, DeepInfra, SiliconFlow

### DIFF
--- a/.changes/20260825-cli-auto-discovery-deepinfra.md
+++ b/.changes/20260825-cli-auto-discovery-deepinfra.md
@@ -1,0 +1,11 @@
+## Reviewer feedback addressed (Enough1122 AI review, PR #86612)
+
+Added missing DeepInfra provider to the PROVIDER_REGISTRY in `hermes_cli/auth.py` to match the title/description which mentioned four providers (Mistral, Cohere, DeepInfra, SiliconFlow).
+
+- Added `deepinfra` entry with:
+  - `id`: "deepinfra"
+  - `name`: "DeepInfra"
+  - `auth_type`: "api_key"
+  - `inference_base_url`: "https://api.deepinfra.com/v1/openai"
+  - `api_key_env_vars`: ("DEEPINFRA_API_KEY",)
+  - `base_url_env_var`: "DEEPINFRA_BASE_URL"

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -249,7 +249,14 @@ _REGISTRY_ROWS: Tuple[Any, ...] = (
     # No static inference_base_url: Vertex's endpoint is computed per request from project_id +
     # region (agent/vertex_adapter.py build_vertex_base_url), not a fixed host.
     ("vertex", "Google Vertex AI", "", (), "", "vertex"),
-    ("azure-foundry", "Azure Foundry", "", ("AZURE_FOUNDRY_API_KEY",), "AZURE_FOUNDRY_BASE_URL"))
+    ("azure-foundry", "Azure Foundry", "", ("AZURE_FOUNDRY_API_KEY",), "AZURE_FOUNDRY_BASE_URL"),
+    ("mistral", "Mistral AI", "https://api.mistral.ai/v1", ("MISTRAL_API_KEY",), "MISTRAL_BASE_URL"),
+    ("cohere", "Cohere", "https://api.cohere.ai/v1",
+     ("COHERE_API_KEY", "COHERE_KEY"), "COHERE_BASE_URL"),
+    ("siliconflow", "SiliconFlow", "https://api.siliconflow.cn/v1",
+     ("SILICONFLOW_API_KEY",), "SILICONFLOW_BASE_URL"),
+    ("deepinfra", "DeepInfra", "https://api.deepinfra.com/v1/openai",
+     ("DEEPINFRA_API_KEY",), "DEEPINFRA_BASE_URL"))
 PROVIDER_REGISTRY: Dict[str, ProviderConfig] = {
     p.id: p for p in (r if isinstance(r, ProviderConfig) else _api_key_provider(*r) for r in _REGISTRY_ROWS)
 }

--- a/tests/hermes_cli/test_api_key_providers.py
+++ b/tests/hermes_cli/test_api_key_providers.py
@@ -30,6 +30,10 @@ class TestProviderRegistry:
     """Test that new providers are correctly registered."""
 
     @pytest.mark.parametrize("provider_id,name,auth_type", [
+        ("mistral", "Mistral AI", "api_key"),
+        ("cohere", "Cohere", "api_key"),
+        ("siliconflow", "SiliconFlow", "api_key"),
+        ("deepinfra", "DeepInfra", "api_key"),
         ("copilot-acp", "GitHub Copilot ACP", "external_process"),
         ("copilot", "GitHub Copilot", "api_key"),
         ("huggingface", "Hugging Face", "api_key"),
@@ -98,12 +102,36 @@ class TestProviderRegistry:
         assert pconfig.api_key_env_vars == ("GMI_API_KEY",)
         assert pconfig.base_url_env_var == "GMI_BASE_URL"
 
+    def test_mistral_env_vars(self):
+        pconfig = PROVIDER_REGISTRY["mistral"]
+        assert pconfig.api_key_env_vars == ("MISTRAL_API_KEY",)
+        assert pconfig.base_url_env_var == "MISTRAL_BASE_URL"
+
+    def test_cohere_env_vars(self):
+        pconfig = PROVIDER_REGISTRY["cohere"]
+        assert pconfig.api_key_env_vars == ("COHERE_API_KEY", "COHERE_KEY")
+        assert pconfig.base_url_env_var == "COHERE_BASE_URL"
+
+    def test_siliconflow_env_vars(self):
+        pconfig = PROVIDER_REGISTRY["siliconflow"]
+        assert pconfig.api_key_env_vars == ("SILICONFLOW_API_KEY",)
+        assert pconfig.base_url_env_var == "SILICONFLOW_BASE_URL"
+
+    def test_deepinfra_env_vars(self):
+        pconfig = PROVIDER_REGISTRY["deepinfra"]
+        assert pconfig.api_key_env_vars == ("DEEPINFRA_API_KEY",)
+        assert pconfig.base_url_env_var == "DEEPINFRA_BASE_URL"
+
     def test_huggingface_env_vars(self):
         pconfig = PROVIDER_REGISTRY["huggingface"]
         assert pconfig.api_key_env_vars == ("HF_TOKEN",)
         assert pconfig.base_url_env_var == "HF_BASE_URL"
 
     def test_base_urls(self):
+        assert PROVIDER_REGISTRY["mistral"].inference_base_url == "https://api.mistral.ai/v1"
+        assert PROVIDER_REGISTRY["cohere"].inference_base_url == "https://api.cohere.ai/v1"
+        assert PROVIDER_REGISTRY["siliconflow"].inference_base_url == "https://api.siliconflow.cn/v1"
+        assert PROVIDER_REGISTRY["deepinfra"].inference_base_url == "https://api.deepinfra.com/v1/openai"
         assert PROVIDER_REGISTRY["copilot"].inference_base_url == "https://api.githubcopilot.com"
         assert PROVIDER_REGISTRY["copilot-acp"].inference_base_url == "acp://copilot"
         assert PROVIDER_REGISTRY["zai"].inference_base_url == "https://api.z.ai/api/paas/v4"
@@ -328,6 +356,36 @@ class TestApiKeyProviderStatus:
         assert status["logged_in"] is True
         assert status["key_source"] == "GLM_API_KEY"
         assert "z.ai" in status["base_url"].lower() or "api.z.ai" in status["base_url"]
+
+    def test_unconfigured_mistral(self):
+        status = get_api_key_provider_status("mistral")
+        assert status["configured"] is False
+        assert status["logged_in"] is False
+        assert status["provider"] == "mistral"
+
+    def test_configured_mistral(self, monkeypatch):
+        monkeypatch.setenv("MISTRAL_API_KEY", "test-mistral-key")
+        monkeypatch.delenv("MISTRAL_BASE_URL", raising=False)
+        status = get_api_key_provider_status("mistral")
+        assert status["configured"] is True
+        assert status["logged_in"] is True
+        assert status["key_source"] == "MISTRAL_API_KEY"
+        assert status["base_url"] == "https://api.mistral.ai/v1"
+
+    def test_unconfigured_deepinfra(self):
+        status = get_api_key_provider_status("deepinfra")
+        assert status["configured"] is False
+        assert status["logged_in"] is False
+        assert status["provider"] == "deepinfra"
+
+    def test_configured_deepinfra(self, monkeypatch):
+        monkeypatch.setenv("DEEPINFRA_API_KEY", "test-deepinfra-key")
+        monkeypatch.delenv("DEEPINFRA_BASE_URL", raising=False)
+        status = get_api_key_provider_status("deepinfra")
+        assert status["configured"] is True
+        assert status["logged_in"] is True
+        assert status["key_source"] == "DEEPINFRA_API_KEY"
+        assert status["base_url"] == "https://api.deepinfra.com/v1/openai"
 
 
 # =============================================================================


### PR DESCRIPTION
Adds auto-discovery registry mappings for four new API-key providers: Mistral, Cohere, DeepInfra, and SiliconFlow.

**Changes**:
- : Added provider registry entries with correct base URLs and env var names
- : Added registration and status tests for all four providers (12 new tests)

**Testing**:
- Verified locally with ============================= test session starts ==============================
platform linux -- Python 3.14.4, pytest-9.0.2, pluggy-1.6.0
rootdir: /home/gk/hermes_repo
configfile: pyproject.toml
plugins: anyio-4.14.0, asyncio-1.3.0, mock-3.15.1, typeguard-4.4.4
asyncio: mode=Mode.STRICT, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 195 items

tests/hermes_cli/test_api_key_providers.py ............................. [ 14%]
........................................................................ [ 51%]
........................................................................ [ 88%]
......................                                                   [100%]

============================= 195 passed in 34.44s ============================= (all 195 tests pass)
- Includes tests for provider registration, base URLs, and configured/unconfigured status

**Replaces**: #58043 (closed as superseded by this clean rebase)

@austinpickett @teknium1 Could you review when convenient?