### PR TITLE
fix: respect A2A task state in orchestration

### DIFF
--- a/plugins/platforms/a2a/tools.py
+++ b/plugins/platforms/a2a/tools.py
@@ -379,18 +379,30 @@ def _match_peers_by_capability(capability: str) -> list[tuple[str, dict]]:
     return matches
 
 
-def _call_peer_sync(agent_name: str, peer_entry: dict, message: str, context_id: str = "") -> tuple[str, str]:
-    """Call a single peer synchronously. Returns (agent_name, reply_text)."""
+def _call_peer_sync(agent_name: str, peer_entry: dict, message: str, context_id: str = "") -> tuple[str, str, str]:
+    """Call a single peer synchronously. Returns (agent_name, reply_text, state)."""
     try:
         peer = {
             "url": peer_entry.get("url", ""),
             "auth": peer_entry.get("auth", {}) or {},
             "timeout": int(peer_entry.get("timeout", _DEFAULT_TIMEOUT)),
         }
-        reply, _ctx, _state = _send_task(agent_name, peer, message, context_id)
-        return (agent_name, reply or "(no reply)")
+        reply, _ctx, state = _send_task(agent_name, peer, message, context_id)
+        return (agent_name, reply or "(no reply)", state)
     except Exception as e:
-        return (agent_name, f"Error: {e}")
+        return (agent_name, f"Error: {e}", protocol.STATE_FAILED)
+
+
+def _orchestrate_success(reply: str, state: str) -> bool:
+    """A peer only succeeded when the A2A task completed, or legacy peers omit state."""
+    return not reply.startswith("Error:") and state in ("", protocol.STATE_COMPLETED)
+
+
+def _orchestrate_display(reply: str, state: str) -> str:
+    """Make non-completed task states visible in fan-out output."""
+    if state and state != protocol.STATE_COMPLETED:
+        return f"[{_short_state(state)}] {reply}"
+    return reply
 
 
 def a2a_orchestrate(args: dict, **_: Any) -> str:
@@ -430,7 +442,7 @@ def a2a_orchestrate(args: dict, **_: Any) -> str:
         mode = "all"
 
     # Fan-out
-    results: list[tuple[str, str]] = []
+    results: list[tuple[str, str, str]] = []
     with ThreadPoolExecutor(max_workers=min(len(matches), _ORCHESTRATE_MAX_WORKERS)) as pool:
         futures = {
             pool.submit(_call_peer_sync, name, entry, message, context_id): name
@@ -439,23 +451,24 @@ def a2a_orchestrate(args: dict, **_: Any) -> str:
         for fut in as_completed(futures):
             name = futures[fut]
             try:
-                results.append(fut.result())
-                if mode == "first" and not results[-1][1].startswith("Error:"):
-                    # Got a good reply; cancel peers that haven't started yet.
+                result = fut.result()
+                results.append(result)
+                if mode == "first" and _orchestrate_success(result[1], result[2]):
+                    # Got a completed peer task; cancel peers that haven't started yet.
                     for f in futures:
                         f.cancel()
                     break
             except Exception as e:
-                results.append((name, f"Error: {e}"))
+                results.append((name, f"Error: {e}", protocol.STATE_FAILED))
 
     # Sort results by peer name for deterministic output
     results.sort(key=lambda r: r[0])
-    successes = [(name, reply) for name, reply in results if not reply.startswith("Error:")]
+    successes = [(name, reply, state) for name, reply, state in results if _orchestrate_success(reply, state)]
 
     def _all_failed() -> str:
         lines = ["All peers failed:"]
-        for name, reply in results:
-            lines.append(f"  {name}: {reply}")
+        for name, reply, state in results:
+            lines.append(f"  {name}: {_orchestrate_display(reply, state)}")
         return "\n".join(lines)
 
     if mode == "best":
@@ -466,13 +479,13 @@ def a2a_orchestrate(args: dict, **_: Any) -> str:
     elif mode == "first":
         if not successes:
             return _all_failed()
-        name, reply = successes[0]
+        name, reply, _state = successes[0]
         return f"[first: {name}]\n{reply}"
     else:  # mode == "all"
         lines = [f"Orchestrated '{capability}' to {len(matches)} peer(s):"]
-        for name, reply in results:
+        for name, reply, state in results:
             lines.append(f"\n--- {name} ---")
-            lines.append(reply)
+            lines.append(_orchestrate_display(reply, state))
         return "\n".join(lines)
 
 

--- a/tests/plugins/test_a2a_phase23.py
+++ b/tests/plugins/test_a2a_phase23.py
@@ -592,7 +592,7 @@ class TestA2AOrchestrate:
     def test_all_mode_returns_every_reply(self, monkeypatch):
         monkeypatch.setattr(tools, "_load_config", lambda: _TWO_PEERS)
         monkeypatch.setattr(tools, "_call_peer_sync",
-                            lambda name, entry, msg, ctx="": (name, f"reply from {name}"))
+                            lambda name, entry, msg, ctx="": (name, f"reply from {name}", protocol.STATE_COMPLETED))
         out = tools.a2a_orchestrate({"capability": "research", "message": "go"})
         assert "reply from researcher" in out
         assert "reply from generalist" in out
@@ -604,7 +604,7 @@ class TestA2AOrchestrate:
             "generalist": "a much longer and more detailed reply",
         }
         monkeypatch.setattr(tools, "_call_peer_sync",
-                            lambda name, entry, msg, ctx="": (name, replies[name]))
+                            lambda name, entry, msg, ctx="": (name, replies[name], protocol.STATE_COMPLETED))
         out = tools.a2a_orchestrate({"capability": "research", "message": "go", "mode": "best"})
         assert out.startswith("[best: generalist]")
 
@@ -616,7 +616,7 @@ class TestA2AOrchestrate:
             "generalist": "Error: " + "x" * 500,
         }
         monkeypatch.setattr(tools, "_call_peer_sync",
-                            lambda name, entry, msg, ctx="": (name, replies[name]))
+                            lambda name, entry, msg, ctx="": (name, replies[name], protocol.STATE_COMPLETED))
         out = tools.a2a_orchestrate({"capability": "research", "message": "go", "mode": "best"})
         assert out.startswith("[best: researcher]")
         assert "ok" in out
@@ -626,22 +626,66 @@ class TestA2AOrchestrate:
         with a misleading [best: ...] header."""
         monkeypatch.setattr(tools, "_load_config", lambda: _TWO_PEERS)
         monkeypatch.setattr(tools, "_call_peer_sync",
-                            lambda name, entry, msg, ctx="": (name, "Error: connection refused"))
+                            lambda name, entry, msg, ctx="": (name, "Error: connection refused", protocol.STATE_FAILED))
         out = tools.a2a_orchestrate({"capability": "research", "message": "go", "mode": "best"})
         assert out.startswith("All peers failed:")
         assert "[best:" not in out
 
+    def test_best_mode_ignores_failed_task_with_plain_text(self, monkeypatch):
+        """A failed A2A task with non-error text must not beat a completed task."""
+        monkeypatch.setattr(tools, "_load_config", lambda: _TWO_PEERS)
+
+        def fake_call(name, entry, msg, ctx=""):
+            if name == "generalist":
+                return (name, "this failed but has a very long explanatory body " * 20, protocol.STATE_FAILED)
+            return (name, "ok", protocol.STATE_COMPLETED)
+
+        monkeypatch.setattr(tools, "_call_peer_sync", fake_call)
+        out = tools.a2a_orchestrate({"capability": "research", "message": "go", "mode": "best"})
+        assert out.startswith("[best: researcher]")
+        assert "this failed" not in out
+
+    def test_first_mode_skips_rejected_task_with_plain_text(self, monkeypatch):
+        """First mode should require completed peer tasks, not just non-Error text."""
+        monkeypatch.setattr(tools, "_load_config", lambda: _TWO_PEERS)
+
+        def fake_call(name, entry, msg, ctx=""):
+            if name == "generalist":
+                return (name, "not authorized for this task", protocol.STATE_REJECTED)
+            return (name, "completed answer", protocol.STATE_COMPLETED)
+
+        monkeypatch.setattr(tools, "_call_peer_sync", fake_call)
+        out = tools.a2a_orchestrate({"capability": "research", "message": "go", "mode": "first"})
+        assert out.startswith("[first: researcher]")
+        assert "completed answer" in out
+        assert "not authorized" not in out
+
+    def test_all_mode_shows_non_completed_task_state(self, monkeypatch):
+        monkeypatch.setattr(tools, "_load_config", lambda: _TWO_PEERS)
+
+        def fake_call(name, entry, msg, ctx=""):
+            if name == "generalist":
+                return (name, "need project id", protocol.STATE_INPUT_REQUIRED)
+            return (name, "done", protocol.STATE_COMPLETED)
+
+        monkeypatch.setattr(tools, "_call_peer_sync", fake_call)
+        out = tools.a2a_orchestrate({"capability": "research", "message": "go", "mode": "all"})
+        assert "--- generalist ---" in out
+        assert "[input-required] need project id" in out
+        assert "--- researcher ---" in out
+        assert "done" in out
+
     def test_first_mode_all_errors_reports_failure(self, monkeypatch):
         monkeypatch.setattr(tools, "_load_config", lambda: _TWO_PEERS)
         monkeypatch.setattr(tools, "_call_peer_sync",
-                            lambda name, entry, msg, ctx="": (name, "Error: nope"))
+                            lambda name, entry, msg, ctx="": (name, "Error: nope", protocol.STATE_FAILED))
         out = tools.a2a_orchestrate({"capability": "code", "message": "go", "mode": "first"})
         assert out.startswith("All peers failed:")
 
     def test_first_mode_returns_a_success(self, monkeypatch):
         monkeypatch.setattr(tools, "_load_config", lambda: _TWO_PEERS)
         monkeypatch.setattr(tools, "_call_peer_sync",
-                            lambda name, entry, msg, ctx="": (name, f"win {name}"))
+                            lambda name, entry, msg, ctx="": (name, f"win {name}", protocol.STATE_COMPLETED))
         out = tools.a2a_orchestrate({"capability": "code", "message": "go", "mode": "first"})
         assert out.startswith("[first: ")
         assert "win" in out


### PR DESCRIPTION
## Summary

- preserve A2A peer task state through `a2a_orchestrate()` fan-out
- require completed/no-state legacy peer tasks for `first` / `best` success selection
- show non-completed peer states in `all` mode output, e.g. `[input-required] ...`
- add regressions for failed/rejected/input-required task states with normal-looking text

## Why

`a2a_orchestrate()` previously discarded the peer task state and treated any reply that did not start with `Error:` as successful. A peer could return `TASK_STATE_FAILED`, `TASK_STATE_REJECTED`, or `TASK_STATE_INPUT_REQUIRED` with normal text and still be selected as `first`/`best`.

That conflates transport/tool invocation success with peer task completion.

## Verification

Passed:

```text
python -m py_compile plugins/platforms/a2a/tools.py tests/plugins/test_a2a_phase23.py
git diff --check
uv run --with pytest pytest tests/plugins/test_a2a_phase23.py -q
# 48 passed, 7 deselected
```

Broader check:

```text
uv run --with pytest pytest tests/plugins/test_a2a_plugin.py -q
# 105 passed, 10 deselected, 1 failed
```

The broader failure is in `TestV1SpecRegressionFixes.test_forward_to_profile_first_contact_creates_then_resumes_fake_hermes`, where the fake session store schema is missing `parent_session_id`. This path is `_forward_to_profile` / session-store fixture setup and is not touched by this patch.
