### PR TITLE
fix(desktop): stop finished turns from showing stale approval prompts

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event.ts
@@ -88,6 +88,11 @@ function firstBillingLine(text: string): string {
   return (text || '').split('\n')[0]?.trim() ?? ''
 }
 
+function clearTurnPrompts(sessionId: string): void {
+  clearAllPrompts(sessionId)
+  clearClarifyRequest(undefined, sessionId)
+}
+
 /**
  * Whether a `session.info` payload's `stored_session_id` may be treated as the
  * selected conversation's, so its cwd can be claimed for it (#71254).
@@ -387,6 +392,7 @@ export function useGatewayEventHandler(deps: GatewayEventDeps) {
         const reclaimedRuntimeId = String((payload as { session_id?: string } | undefined)?.session_id ?? '')
 
         if (reclaimedRuntimeId) {
+          clearTurnPrompts(reclaimedRuntimeId)
           dropSessionState(reclaimedRuntimeId)
         }
 
@@ -515,6 +521,14 @@ export function useGatewayEventHandler(deps: GatewayEventDeps) {
         // mutates the per-runtime cache entry, and syncSessionStateToView
         // guards the view publish to the active session, so this is safe.
         if (runningChanged && sessionId) {
+          // The agent loop's finally block emits running=false even when a
+          // reconnect gap or timeout swallowed message.complete. Treat it as
+          // the authoritative turn-end edge for prompt state too, otherwise
+          // the sidebar becomes idle while a stale approval remains actionable.
+          if (!payload!.running) {
+            clearTurnPrompts(sessionId)
+          }
+
           updateSessionState(
             sessionId,
             state => {
@@ -760,8 +774,7 @@ export function useGatewayEventHandler(deps: GatewayEventDeps) {
         // (e.g. interrupted, or the approval already resolved). Scoped to the
         // session so a background turn finishing can't wipe the active chat's
         // prompt, and vice versa.
-        clearAllPrompts(sessionId)
-        clearClarifyRequest(undefined, sessionId)
+        clearTurnPrompts(sessionId)
         // Turn ended without a final `todo` update — drop a still-unfinished
         // list so "Tasks N/M" doesn't stay pinned above the composer with the
         // last item stuck pending/in_progress. Finished lists keep their linger.
@@ -1295,8 +1308,7 @@ export function useGatewayEventHandler(deps: GatewayEventDeps) {
         // for this session so an approval/sudo/secret overlay can't linger past
         // the failed turn (same intent as the message.complete clear).
         if (sessionId) {
-          clearAllPrompts(sessionId)
-          clearClarifyRequest(undefined, sessionId)
+          clearTurnPrompts(sessionId)
           clearActiveSessionTodos(sessionId)
           setSessionCompacting(sessionId, false)
           compactedTurnRef.current.delete(sessionId)

--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event.ts
@@ -555,8 +555,12 @@ export function useGatewayEventHandler(deps: GatewayEventDeps) {
                 }
               }
 
-              if (state.awaitingResponse && !state.sawAssistantPayload) {
-                return state.needsInput ? { ...state, needsInput: false } : state
+              // A running=false snapshot can race ahead of a freshly submitted
+              // turn, so keep waiting until the first assistant payload. A
+              // blocking prompt is itself proof that the turn advanced; once
+              // that prompt's terminal edge arrives, settle the whole runtime.
+              if (state.awaitingResponse && !state.sawAssistantPayload && !state.needsInput) {
+                return state
               }
 
               return {

--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event.ts
@@ -534,7 +534,7 @@ export function useGatewayEventHandler(deps: GatewayEventDeps) {
             state => {
               const busy = Boolean(payload!.running)
 
-              if (state.busy === busy && (busy || !state.awaitingResponse)) {
+              if (state.busy === busy && (busy || (!state.awaitingResponse && !state.needsInput))) {
                 return state
               }
 
@@ -556,13 +556,14 @@ export function useGatewayEventHandler(deps: GatewayEventDeps) {
               }
 
               if (state.awaitingResponse && !state.sawAssistantPayload) {
-                return state
+                return state.needsInput ? { ...state, needsInput: false } : state
               }
 
               return {
                 ...state,
                 awaitingResponse: false,
                 busy,
+                needsInput: false,
                 // The turn is over but its streaming bubble may still say
                 // pending — running=false from the agent loop's finally block
                 // is the ONLY settle signal when message.complete never

--- a/apps/desktop/src/app/session/hooks/use-message-stream/session-reclaimed.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/session-reclaimed.test.tsx
@@ -5,6 +5,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { ClientSessionState } from '@/app/types'
 import { createClientSessionState } from '@/lib/chat-runtime'
+import { clearAllPrompts, sessionApprovalRequest, setApprovalRequest } from '@/store/prompts'
 import { $sessionStates, publishSessionState } from '@/store/session-states'
 import type { RpcEvent } from '@/types/hermes'
 
@@ -66,11 +67,13 @@ beforeEach(() => {
   handleEvent = null
   queryClient = new QueryClient()
   $sessionStates.set({})
+  clearAllPrompts()
 })
 
 afterEach(() => {
   cleanup()
   $sessionStates.set({})
+  clearAllPrompts()
   vi.restoreAllMocks()
 })
 
@@ -96,6 +99,17 @@ describe('session.reclaimed', () => {
     // only the survivor would pass with no handler at all.
     expect($sessionStates.get()['live-gone']).toBeUndefined()
     expect($sessionStates.get()['live-kept']).toBeDefined()
+  })
+
+  it('retires only the reclaimed runtime approval', async () => {
+    await mountStream()
+    setApprovalRequest({ command: 'rm stale', description: 'stale request', sessionId: 'live-gone' })
+    setApprovalRequest({ command: 'rm kept', description: 'kept request', sessionId: 'live-kept' })
+
+    reclaim('live-gone')
+
+    expect(sessionApprovalRequest('live-gone').get()).toBeNull()
+    expect(sessionApprovalRequest('live-kept').get()?.command).toBe('rm kept')
   })
 
   it('ignores a payload with no runtime id instead of clearing everything', async () => {

--- a/apps/desktop/src/app/session/hooks/use-message-stream/stale-pending-settle.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/stale-pending-settle.test.tsx
@@ -147,6 +147,8 @@ describe('turn end without message.complete (session.info running=false)', () =>
 
     expect(sessionApprovalRequest(SID).get()).toBeNull()
     expect(sessionApprovalRequest(OTHER_SID).get()?.command).toBe('rm other')
+    expect(states.get(SID)?.awaitingResponse).toBe(false)
+    expect(states.get(SID)?.busy).toBe(false)
     expect(states.get(SID)?.needsInput).toBe(false)
   })
 })

--- a/apps/desktop/src/app/session/hooks/use-message-stream/stale-pending-settle.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/stale-pending-settle.test.tsx
@@ -11,6 +11,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { ClientSessionState } from '@/app/types'
 import { createClientSessionState } from '@/lib/chat-runtime'
+import { clearAllPrompts, sessionApprovalRequest, setApprovalRequest } from '@/store/prompts'
 import type { RpcEvent } from '@/types/hermes'
 
 import { STREAM_DELTA_FLUSH_MS } from './utils'
@@ -18,6 +19,7 @@ import { STREAM_DELTA_FLUSH_MS } from './utils'
 import { useMessageStream } from './index'
 
 const SID = 'stale-pending-session'
+const OTHER_SID = 'other-session'
 
 let handleEvent: ((event: RpcEvent) => void) | null = null
 let states: Map<string, ClientSessionState>
@@ -71,10 +73,12 @@ describe('turn end without message.complete (session.info running=false)', () =>
   beforeEach(() => {
     handleEvent = null
     states = new Map()
+    clearAllPrompts()
   })
 
   afterEach(() => {
     cleanup()
+    clearAllPrompts()
     vi.useRealTimers()
     vi.restoreAllMocks()
   })
@@ -124,5 +128,18 @@ describe('turn end without message.complete (session.info running=false)', () =>
     // pending, and the stream binding is released.
     expect(state?.messages.every(message => !message.pending)).toBe(true)
     expect(state?.streamId).toBeNull()
+  })
+
+  it('retires only the finished session approval when message.complete was missed', async () => {
+    await mountHarness()
+
+    emit({ session_id: SID, type: 'message.start', payload: {} })
+    setApprovalRequest({ command: 'rm stale', description: 'stale request', sessionId: SID })
+    setApprovalRequest({ command: 'rm other', description: 'other request', sessionId: OTHER_SID })
+
+    emit({ payload: { running: false }, session_id: SID, type: 'session.info' })
+
+    expect(sessionApprovalRequest(SID).get()).toBeNull()
+    expect(sessionApprovalRequest(OTHER_SID).get()?.command).toBe('rm other')
   })
 })

--- a/apps/desktop/src/app/session/hooks/use-message-stream/stale-pending-settle.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/stale-pending-settle.test.tsx
@@ -134,12 +134,19 @@ describe('turn end without message.complete (session.info running=false)', () =>
     await mountHarness()
 
     emit({ session_id: SID, type: 'message.start', payload: {} })
-    setApprovalRequest({ command: 'rm stale', description: 'stale request', sessionId: SID })
+    emit({
+      payload: { command: 'rm stale', description: 'stale request' },
+      session_id: SID,
+      type: 'approval.request'
+    })
     setApprovalRequest({ command: 'rm other', description: 'other request', sessionId: OTHER_SID })
+
+    expect(states.get(SID)?.needsInput).toBe(true)
 
     emit({ payload: { running: false }, session_id: SID, type: 'session.info' })
 
     expect(sessionApprovalRequest(SID).get()).toBeNull()
     expect(sessionApprovalRequest(OTHER_SID).get()?.command).toBe('rm other')
+    expect(states.get(SID)?.needsInput).toBe(false)
   })
 })


### PR DESCRIPTION
## What does this PR do?

Finished Desktop turns no longer keep showing a stale "needs approval" floating bar when `message.complete` is missed. The fallback terminal `session.info` edge and runtime reclamation now retire blocking prompts for only the affected runtime, preventing users from seeing an approval action for a turn that has already ended while preserving prompts in other sessions.

### Symptom

After an approval-gated turn finishes, scrolling the virtualized transcript away from the original tool row can make the floating "needs approval" bar reappear even though the sidebar reports the session as finished.

### Impact

The Desktop presents an approval action that is no longer meaningful for the completed turn. The stale state can repeatedly appear and disappear with scroll position, making the session look actionable after it has ended.

### Bug Cause

**Trigger:** `apps/desktop/src/app/session/hooks/use-message-stream/gateway-event.ts` / `session.info` with `running: false` or `session.reclaimed` after an approval request

**Causal chain:**
1. An `approval.request` stores a blocking prompt under the live runtime session id.
2. A timeout, reconnect gap, smart resolution, or runtime reclaim reaches a terminal event without the normal `message.complete` cleanup for that runtime.
3. The sidebar becomes idle, but the prompt and `needsInput` state remain. When virtualization unmounts the inline approval anchor, the floating fallback renders the stale request again.

**Why it is wrong:** Terminal session edges settled cached busy/message state or dropped runtime state without retiring the corresponding prompt state. The prompt map and runtime attention state could therefore disagree with the completed turn.

**Working sibling / contrast:** The normal `message.complete` and `error` paths already clear prompts for the affected session. This change shares that scoped cleanup with the fallback terminal and reclaim paths.

**Ruled out:** Runtime id rotation is intentional and does not need to change. Clearing prompt state when the old runtime is retired prevents the orphan without coupling prompts to durable stored-session identity.

### Fix

- Centralize turn-prompt cleanup so approval, sudo, secret, and clarify prompts retire consistently.
- Treat `session.info` with `running: false` as the authoritative fallback turn-end edge, clearing only that runtime's prompts and attention state.
- Clear prompts before dropping a reclaimed runtime.
- Preserve the fresh-submit stale-snapshot guard while allowing a blocking prompt to prove that the turn advanced and must now settle.
- Add regression coverage for terminal and reclaimed-runtime cleanup, including bystander-session preservation.

## Related Issue

Closes #86577

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/src/app/session/hooks/use-message-stream/gateway-event.ts` - retire scoped prompt and attention state on fallback terminal and reclaim events.
- `apps/desktop/src/app/session/hooks/use-message-stream/stale-pending-settle.test.tsx` - cover approval cleanup when `message.complete` is missed.
- `apps/desktop/src/app/session/hooks/use-message-stream/session-reclaimed.test.tsx` - cover reclaimed-runtime cleanup without affecting another session.

## How to Test

1. From `apps/desktop`, run the focused message-stream tests:

```bash
npx vitest run src/app/session/hooks/use-message-stream
```

2. Run Desktop type checking:

```bash
npm run typecheck
```

3. Run ESLint on the changed Desktop files. The focused suite passes 81 tests across 17 files, type checking passes, and targeted ESLint passes.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - N/A, no user-facing contract changed
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - N/A, no config keys changed
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - N/A, no architecture or workflow changed
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) - session-state logic is platform-independent
- [x] I've updated tool descriptions/schemas if I changed tool behavior - N/A, no model tool changed

## Screenshots / Logs

N/A - the renderer state-machine regression is covered by the focused event-handler tests.
