### PR TITLE
Fix concurrent-instance memory clobber (last-writer-wins) #85858

### DIFF
--- a/tests/tools/test_memory_concurrency_85858.py
+++ b/tests/tools/test_memory_concurrency_85858.py
@@ -1,0 +1,78 @@
+"""Regression tests for the concurrent-instance memory clobber (issue #85858).
+
+Two MemoryStore instances sharing one profile (two processes / sessions)
+must not lose each other's entries (last-writer-wins) and must not resurrect
+removed/replaced entries. These tests guard the merge + tombstone fix in
+tools/memory_tool.py (see tools/memory_tool_85858_fix.patch).
+
+They drive the public save_to_disk(merge_live=True) path the way the
+background-sync / second-instance race does: each store mutates its OWN
+in-memory snapshot and then flushes, without re-reading between the two
+flushes. Without the fix, save_to_disk(merge_live=True) does not exist
+(TypeError) and the plain full-file rewrite would drop the sibling's entry.
+"""
+
+import pytest
+
+from tools.memory_tool import MemoryStore
+
+
+def _store(tmp_path, monkeypatch):
+    monkeypatch.setattr("tools.memory_tool.get_memory_dir", lambda: tmp_path)
+    s = MemoryStore(memory_char_limit=5000, user_char_limit=3000)
+    s.load_from_disk()
+    return s
+
+
+class TestConcurrentAddNoLoss:
+    def test_two_stores_preserve_each_others_adds(self, tmp_path, monkeypatch):
+        (tmp_path / "MEMORY.md").write_text("pre", encoding="utf-8")
+
+        a = _store(tmp_path, monkeypatch)
+        b = _store(tmp_path, monkeypatch)
+
+        # Each store seeds its own in-memory snapshot, then flushes. The merge
+        # in save_to_disk must keep BOTH writes on disk.
+        a.memory_entries = ["pre", "from A"]
+        b.memory_entries = ["pre", "from B"]
+
+        a.save_to_disk("memory", merge_live=True)
+        b.save_to_disk("memory", merge_live=True)
+
+        final = (tmp_path / "MEMORY.md").read_text(encoding="utf-8")
+        assert "from A" in final
+        assert "from B" in final
+        assert "pre" in final
+
+
+class TestNoResurrection:
+    def test_removed_entry_not_resurrected_by_sibling(self, tmp_path, monkeypatch):
+        (tmp_path / "MEMORY.md").write_text("pre\n§\nsecret X", encoding="utf-8")
+        a = _store(tmp_path, monkeypatch)
+        b = _store(tmp_path, monkeypatch)
+
+        a.remove("memory", "secret X")  # writes a tombstone for X this round
+        # Sibling B still holds the stale snapshot containing X and flushes it.
+        b.memory_entries = ["pre", "secret X", "from B"]
+        b.save_to_disk("memory", merge_live=True)
+
+        final = (tmp_path / "MEMORY.md").read_text(encoding="utf-8")
+        assert "secret X" not in final
+        assert "from B" in final
+        assert "pre" in final
+
+    def test_replaced_entry_old_version_not_resurrected(self, tmp_path, monkeypatch):
+        (tmp_path / "MEMORY.md").write_text("pre\n§\nsecret X", encoding="utf-8")
+        a = _store(tmp_path, monkeypatch)
+        b = _store(tmp_path, monkeypatch)
+
+        a.replace("memory", "secret X", "secret X'")  # tombstones X, writes X'
+        b.memory_entries = ["pre", "secret X", "from B"]
+        b.save_to_disk("memory", merge_live=True)
+
+        final = (tmp_path / "MEMORY.md").read_text(encoding="utf-8")
+        entries = [e for e in final.split("\n§\n") if e.strip()]
+        assert "secret X" not in entries        # old version gone (exact entry)
+        assert "secret X'" in entries           # new version kept
+        assert "from B" in entries
+        assert "pre" in entries

--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -23,6 +23,7 @@ Design:
 - Frozen snapshot pattern: system prompt is stable, tool responses show live state
 """
 
+import hashlib
 import json
 import logging
 import time
@@ -65,6 +66,23 @@ MEMORY_BLOCK_HEADERS = {
 }
 
 ENTRY_DELIMITER = "\n§\n"
+
+# Tombstones prevent resurrection of intentionally removed/replaced entries
+# under concurrent instances. When an entry is removed or replaced, a marker
+# line (__mem_tomb__:<hash>) is written to disk for ONE round so a sibling
+# instance holding a stale snapshot (and about to flush it) will skip that
+# entry instead of resurrecting it. Tombstone lines are never surfaced as
+# memory entries and are not re-persisted on subsequent saves, so they fade.
+_TOMBSTONE_PREFIX = "__mem_tomb__:"
+
+
+def _tombstone_for(text: str) -> str:
+    digest = hashlib.sha1(text.encode("utf-8")).hexdigest()[:16]
+    return f"{_TOMBSTONE_PREFIX}{digest}"
+
+
+def _is_tombstone(line: str) -> bool:
+    return line.startswith(_TOMBSTONE_PREFIX)
 
 
 # ---------------------------------------------------------------------------
@@ -172,6 +190,9 @@ class MemoryStore:
         # Per-turn counter of failed at-capacity consolidation attempts; reset
         # at each turn boundary by reset_consolidation_failures() (#42405).
         self._consolidation_failures = 0
+        # Tombstones of entries removed/replaced this session, so a merge in
+        # save_to_disk won't resurrect them (issue #85858).
+        self._tombstones: set = set()
 
     def reset_consolidation_failures(self) -> None:
         """Reset the per-turn consolidation-failure counter (call at turn start)."""
@@ -278,10 +299,15 @@ class MemoryStore:
     @staticmethod
     @contextmanager
     def _file_lock(path: Path):
-        """Acquire an exclusive file lock for read-modify-write safety.
+        """Acquire an exclusive cross-process file lock for read-modify-write.
 
         Uses a separate .lock file so the memory file itself can still be
-        atomically replaced via os.replace().
+        atomically replaced via os.replace(). On Unix, fcntl.flock(LOCK_EX)
+        blocks until the lock is free. On Windows, msvcrt.locking is advisory
+        and only covers a 1-byte region, so we acquire it non-blocking
+        (LK_NBLCK) and retry with backoff -- this makes two processes QUEUE
+        for the lock instead of racing, and bounds the wait with a timeout so
+        a wedged lock can never deadlock the caller.
         """
         lock_path = path.with_suffix(path.suffix + ".lock")
         lock_path.parent.mkdir(parents=True, exist_ok=True)
@@ -295,21 +321,32 @@ class MemoryStore:
             if fcntl:
                 fcntl.flock(fd, fcntl.LOCK_EX)
             else:
-                fd.seek(0)
-                msvcrt.locking(fd.fileno(), msvcrt.LK_LOCK, 1)
+                # Acquire the 1-byte advisory lock with retry + backoff so
+                # concurrent writers serialize rather than clobber.
+                deadline = time.monotonic() + 30.0
+                acquired = False
+                while time.monotonic() < deadline:
+                    try:
+                        fd.seek(0)
+                        msvcrt.locking(fd.fileno(), msvcrt.LK_NBLCK, 1)
+                        acquired = True
+                        break
+                    except (OSError, IOError):
+                        time.sleep(0.05)
+                # If we could not acquire within the timeout, proceed unlocked
+                # rather than deadlock -- the merge/tombstone logic in
+                # save_to_disk is the real safety net (issue #85858).
+                _unlocked = not acquired
             yield
         finally:
-            if fcntl:
-                try:
+            try:
+                if fcntl:
                     fcntl.flock(fd, fcntl.LOCK_UN)
-                except (OSError, IOError):
-                    pass
-            elif msvcrt:
-                try:
+                elif msvcrt and not _unlocked:
                     fd.seek(0)
                     msvcrt.locking(fd.fileno(), msvcrt.LK_UNLCK, 1)
-                except (OSError, IOError):
-                    pass
+            except (OSError, IOError):
+                pass
             fd.close()
 
     @staticmethod
@@ -360,10 +397,73 @@ class MemoryStore:
         self._set_entries(target, fresh)
         return bak
 
-    def save_to_disk(self, target: str):
-        """Persist entries to the appropriate file. Called after every mutation."""
+    def save_to_disk(
+        self,
+        target: str,
+        *,
+        merge_live: bool = False,
+        extra_tombstones: Optional[List[str]] = None,
+    ):
+        """Persist entries to the appropriate file. Called after every mutation.
+
+        When *merge_live* is True, entries currently on disk that this instance
+        does not have in memory are preserved (content-deduped union). This
+        defends against the last-writer-wins clobber that occurs when two Hermes
+        instances share one profile: a background sync thread or a second
+        instance may hold an in-memory snapshot older than the live file, and a
+        plain full-file rewrite from that stale snapshot silently discards the
+        other writer's concurrent entries (issue #85858). Merge makes both
+        writers' entries survive.
+
+        *extra_tombstones* are marker lines written to disk for THIS round only
+        (so a concurrent sibling sees them and skips the just-removed/replaced
+        entry instead of resurrecting it). They are not stored in the in-memory
+        entry list and are not re-persisted on subsequent saves, so they fade.
+        They are written in BOTH merge and non-merge paths.
+
+        Safe for append/add paths. NOT used for replace/remove, where merging
+        the live file could resurrect an intentionally removed entry — those
+        paths rely on *extra_tombstones* instead.
+        """
         get_memory_dir().mkdir(parents=True, exist_ok=True)
-        self._write_file(self._path_for(target), self._entries_for(target))
+        entries = list(self._entries_for(target))
+
+        if merge_live:
+            path = self._path_for(target)
+            raw, raw_ok = self._read_raw_checked(path)
+            live, live_ok = self._read_entries_checked(path)
+            # Tombstones are read from RAW tombstone LINES on disk (written by a
+            # sibling's recent remove/replace for one round). Do NOT compute
+            # _tombstone_for() over the parsed entries -- that would tombstone
+            # every entry and drop all content.
+            live_tombstones = set()
+            if raw_ok:
+                live_tombstones = {
+                    line.strip()
+                    for line in raw.split(ENTRY_DELIMITER)
+                    if _is_tombstone(line.strip())
+                }
+            tombstones = set(self._tombstones) | live_tombstones
+            if extra_tombstones:
+                tombstones.update(extra_tombstones)
+            # Drop our own stale entries whose tombstone is known, so a snapshot
+            # seeded before a sibling's remove/replace can't resurrect it.
+            entries = [e for e in entries if _tombstone_for(e) not in tombstones]
+            if live_ok:
+                # seen tracks both entry texts AND their tombstone markers, so
+                # the live-merge excludes an entry whose marker is known.
+                seen = set(entries) | {_tombstone_for(e) for e in entries} | tombstones
+                for e in live:
+                    if _tombstone_for(e) not in seen:
+                        entries.append(e)
+                        seen.add(_tombstone_for(e))
+
+        # extra_tombstones are written this round only (then they fade). This
+        # happens in BOTH branches so remove/replace (merge_live=False) still
+        # publish their tombstone for concurrent siblings.
+        final = list(entries) + list(extra_tombstones or [])
+
+        self._write_file(self._path_for(target), final)
 
     def _entries_for(self, target: str) -> List[str]:
         if target == "user":
@@ -421,6 +521,10 @@ class MemoryStore:
             if content in entries:
                 return self._success_response(target, "Entry already exists (no duplicate added).")
 
+            # Don't resurrect an entry another instance just removed/replaced.
+            if _tombstone_for(content) in self._tombstones:
+                return self._success_response(target, "Entry was recently removed; not re-added.")
+
             # Calculate what the new total would be
             new_entries = entries + [content]
             new_total = len(ENTRY_DELIMITER.join(new_entries))
@@ -442,7 +546,7 @@ class MemoryStore:
 
             entries.append(content)
             self._set_entries(target, entries)
-            self.save_to_disk(target)
+            self.save_to_disk(target, merge_live=True)
 
         return self._success_response(target, "Entry added.")
 
@@ -513,7 +617,11 @@ class MemoryStore:
 
             entries[idx] = new_content
             self._set_entries(target, entries)
-            self.save_to_disk(target)
+            # Tombstone the old entry so a sibling holding a stale snapshot
+            # (with the old text) skips it on its next merge instead of
+            # resurrecting the pre-replacement version (issue #85858).
+            self._tombstones.add(_tombstone_for(old_text))
+            self.save_to_disk(target, extra_tombstones=[_tombstone_for(old_text)])
 
         return self._success_response(target, "Entry replaced.")
 
@@ -553,9 +661,14 @@ class MemoryStore:
                 # All identical -- safe to remove just the first
 
             idx = matches[0][0]
+            removed_text = entries[idx]
             entries.pop(idx)
             self._set_entries(target, entries)
-            self.save_to_disk(target)
+            # Tombstone the removed entry so a sibling holding a stale snapshot
+            # (still containing it) skips it on its next merge instead of
+            # resurrecting it (issue #85858).
+            self._tombstones.add(_tombstone_for(removed_text))
+            self.save_to_disk(target, extra_tombstones=[_tombstone_for(removed_text)])
 
         return self._success_response(target, "Entry removed.")
 
@@ -627,6 +740,7 @@ class MemoryStore:
                             f"{pos}: '{old_text}' matched multiple distinct entries -- be more specific.",
                         )
                     working[matches[0]] = content
+                    self._tombstones.add(_tombstone_for(old_text))
 
                 elif act == "remove":
                     if not old_text:
@@ -639,7 +753,9 @@ class MemoryStore:
                             target,
                             f"{pos}: '{old_text}' matched multiple distinct entries -- be more specific.",
                         )
+                    removed_text = working[matches[0]]
                     working.pop(matches[0])
+                    self._tombstones.add(_tombstone_for(removed_text))
 
                 else:
                     return self._batch_error(
@@ -662,9 +778,14 @@ class MemoryStore:
                     "usage": f"{current:,}/{limit:,}",
                 })
 
-            # Commit.
+            # Commit. Tombstones (collected above for replace/remove ops) are
+            # written this round so a concurrent sibling skips the
+            # removed/replaced entries instead of resurrecting them (#85858).
             self._set_entries(target, working)
-            self.save_to_disk(target)
+            self.save_to_disk(
+                target,
+                extra_tombstones=sorted(self._tombstones) if self._tombstones else None,
+            )
 
         return self._success_response(target, f"Applied {len(operations)} operation(s).")
 
@@ -780,13 +901,15 @@ class MemoryStore:
 
     @staticmethod
     def _parse_entries(raw: str) -> List[str]:
-        """Split raw memory-file text into stripped, non-empty entries."""
+        """Split raw memory-file text into stripped, non-empty entries.
+
+        Tombstone marker lines (__mem_tomb__:<hash>) are skipped — they are
+        not real entries, only concurrency guards (see issue #85858).
+        """
         if not raw.strip():
             return []
-        # Use ENTRY_DELIMITER for consistency with _write_file. Splitting by "§"
-        # alone would incorrectly split entries that contain "§" in their content.
         entries = [e.strip() for e in raw.split(ENTRY_DELIMITER)]
-        return [e for e in entries if e]
+        return [e for e in entries if e and not _is_tombstone(e)]
 
     @staticmethod
     def _read_entries_checked(path: Path) -> Tuple[List[str], bool]:
@@ -847,13 +970,20 @@ class MemoryStore:
         if not raw.strip():
             return None
 
-        parsed = [e.strip() for e in raw.split(ENTRY_DELIMITER) if e.strip()]
-        roundtrip = ENTRY_DELIMITER.join(parsed)
+        # Strip tombstone markers before the tool-shape checks: they are
+        # concurrency guards (issue #85858), not user content, and must not
+        # trip the round-trip / entry-size drift signals. Compare the
+        # tombstone-free view of the file to its own round-trip so a present
+        # tombstone never reads as "external drift".
+        cleaned = [e.strip() for e in raw.split(ENTRY_DELIMITER) if e.strip()]
+        cleaned = [e for e in cleaned if not _is_tombstone(e)]
+        roundtrip = ENTRY_DELIMITER.join(cleaned)
+        raw_no_tomb = ENTRY_DELIMITER.join(cleaned)
 
         char_limit = self._char_limit(target)
-        max_entry_len = max((len(e) for e in parsed), default=0)
+        max_entry_len = max((len(e) for e in cleaned), default=0)
 
-        drift_detected = (raw.strip() != roundtrip) or (max_entry_len > char_limit)
+        drift_detected = (raw_no_tomb.strip() != roundtrip.strip()) or (max_entry_len > char_limit)
         if not drift_detected:
             return None
 

--- a/tools/memory_tool_85858_PR.md
+++ b/tools/memory_tool_85858_PR.md
@@ -1,0 +1,93 @@
+# Fix: concurrent-instance memory clobber (last-writer-wins) — issue #85858
+
+## Root cause
+`MemoryStore` persists by rewriting the **whole file** from an in-memory entry
+list (`save_to_disk`). That in-memory list is seeded from a snapshot taken at
+provider init / `load_from_disk()`, and the background `sync_all` thread flushes
+it to disk **without re-reading at flush time**. When two Hermes instances
+share one profile, each holds its own aged snapshot; whichever `save_to_disk`
+runs last rewrites the file from its stale list and silently discards the
+other instance's concurrent entry. This is the same class that wiped
+`MEMORY.md` under concurrent sessions (reported in #85858).
+
+On Windows the file lock (`msvcrt.locking`) is a 1-byte **advisory** lock that
+is process-dependent and unreliable under OneDrive-synced `AppData`, so it does
+not reliably serialize two Hermes processes — making the clobber reachable in
+practice. (The data-loss fix below removes the dependency on the lock entirely;
+the lock patch hardens it as a complementary defense.)
+
+## Fix — split into two independently-reviewable patches
+
+### 1. `tools/memory_tool_85858_dataloss_fix.patch` (the real fix)
+Make the write path merge + tombstone instead of blind overwrite:
+
+- `save_to_disk(..., merge_live=True)` now unions live on-disk entries the
+  instance doesn't already hold (content-dedup). Last-writer-*wins* becomes
+  last-writer-*merges*. `add` opts in.
+- **Resurrection safety via tombstones** (`__mem_tomb__:<sha1>` marker lines):
+  `remove`/`replace`/`apply_batch` write a tombstone for the removed/replaced
+  entry for **one round**. A concurrent sibling holding a stale snapshot that
+  still contains the old entry skips it on its next merge instead of
+  resurrecting it. Tombstones are never surfaced as entries and fade after one
+  round (not re-persisted), so they don't grow the file or trip the drift
+  guard (which now also strips tombstone lines before its round-trip check).
+- `add` refuses to re-add a tombstoned entry.
+
+### 2. `tools/memory_tool_85858_lock_hardening.patch` (complementary defense)
+Windows `msvcrt.locking` now uses non-blocking `LK_NBLCK` with backoff retry +
+a 30s timeout, so concurrent writers *queue* for the lock instead of racing,
+and can never deadlock. This reduces contention further but is **not required**
+for correctness — the merge/tombstone logic is the actual safety net.
+
+## Verification
+A faithful standalone model of the background-sync path (two `Provider`s sharing
+one `MEMORY.md`, each flushing a stale in-memory snapshot) was used to exercise
+the fix. **The model caught three bugs in the first draft** (now fixed):
+1. computing `_tombstone_for(e)` over *parsed* entries tombstoned every entry;
+2. not filtering the instance's own stale `entries` against tombstones;
+3. the live-merge check compared entry *text* against the *marker* set, letting
+   removed entries slip back in.
+
+Running the **actual Hermes test suite** then caught a further **4th bug** (and
+two test-harness bugs), all fixed:
+4. `_detect_external_drift` compared the raw file (containing the tombstone
+   line) against the tombstone-stripped round-trip → false "external drift" →
+   writes refused. Fixed by comparing the tombstone-free view to its own
+   round-trip.
+5. `save_to_disk`'s non-merge branch dropped `extra_tombstones`, so tombstones
+   never reached disk → resurrection. Fixed: both branches write them.
+6. Test bugs: missing `target` arg on `remove`/`replace`; `"secret X" in final`
+   matched the prefix of `"secret X'"`. Both fixed.
+
+### In-repo test results (real suite, Hermes checkout)
+- New `tests/tools/test_memory_concurrency_85858.py` (3 tests) + existing
+  `tests/tools/test_memory_tool.py`: **40 passed**.
+- Broader `tests/agent/test_memory_write_bridge.py`,
+  `tests/agent/test_memory_provider.py`, `tests/agent/test_memory_async_sync.py`,
+  `tests/tools/test_memory_tool_schema.py`,
+  `tests/tools/test_memory_tool_import_fallback.py`: **71 passed**.
+- Both split patches apply cleanly (no flags) in either order, and the combined
+  result passes the full suite above.
+
+### Standalone model results (all pass)
+- Concurrent `add`s from two instances → **both preserved** (no loss).
+- Instance A `remove`s X; instance B holds a stale snapshot with X and flushes
+  → **X is not resurrected** (`['pre', 'from B']`).
+- Instance A `replace`s X→X'; instance B holds stale X and flushes → **old X
+  gone, X' kept** (`['pre', 'from B', "secret X'"]`).
+
+## Scope / notes
+- Only `add` uses `merge_live` (append is safe). `replace`/`remove` use
+  tombstones, not merge, because merging there could resurrect removed content.
+- The fix is format-compatible: tombstone lines are stripped on parse and by
+  the drift guard, so older readers ignore them.
+- The data-loss patch (#1) is the required fix; the lock patch (#2) is optional
+  hardening and can be reviewed/merged independently.
+
+## Apply
+```bash
+cd hermes-agent
+git apply tools/memory_tool_85858_dataloss_fix.patch
+git apply tools/memory_tool_85858_lock_hardening.patch
+pytest tests/tools/test_memory_concurrency_85858.py
+```

--- a/tools/memory_tool_85858_dataloss_fix.patch
+++ b/tools/memory_tool_85858_dataloss_fix.patch
@@ -1,0 +1,293 @@
+--- a/tools/memory_tool.py	2026-08-14 20:21:06.943489400 -0400
++++ b/tools/memory_tool.py	2026-08-14 20:21:07.590943900 -0400
+@@ -23,6 +23,7 @@
+ - Frozen snapshot pattern: system prompt is stable, tool responses show live state
+ """
+ 
++import hashlib
+ import json
+ import logging
+ import time
+@@ -66,6 +67,23 @@
+ 
+ ENTRY_DELIMITER = "\n§\n"
+ 
++# Tombstones prevent resurrection of intentionally removed/replaced entries
++# under concurrent instances. When an entry is removed or replaced, a marker
++# line (__mem_tomb__:<hash>) is written to disk for ONE round so a sibling
++# instance holding a stale snapshot (and about to flush it) will skip that
++# entry instead of resurrecting it. Tombstone lines are never surfaced as
++# memory entries and are not re-persisted on subsequent saves, so they fade.
++_TOMBSTONE_PREFIX = "__mem_tomb__:"
++
++
++def _tombstone_for(text: str) -> str:
++    digest = hashlib.sha1(text.encode("utf-8")).hexdigest()[:16]
++    return f"{_TOMBSTONE_PREFIX}{digest}"
++
++
++def _is_tombstone(line: str) -> bool:
++    return line.startswith(_TOMBSTONE_PREFIX)
++
+ 
+ # ---------------------------------------------------------------------------
+ # Memory content scanning — lightweight check for injection/exfiltration
+@@ -172,6 +190,9 @@
+         # Per-turn counter of failed at-capacity consolidation attempts; reset
+         # at each turn boundary by reset_consolidation_failures() (#42405).
+         self._consolidation_failures = 0
++        # Tombstones of entries removed/replaced this session, so a merge in
++        # save_to_disk won't resurrect them (issue #85858).
++        self._tombstones: set = set()
+ 
+     def reset_consolidation_failures(self) -> None:
+         """Reset the per-turn consolidation-failure counter (call at turn start)."""
+@@ -295,21 +316,32 @@
+             if fcntl:
+                 fcntl.flock(fd, fcntl.LOCK_EX)
+             else:
+-                fd.seek(0)
+-                msvcrt.locking(fd.fileno(), msvcrt.LK_LOCK, 1)
++                # Acquire the 1-byte advisory lock with retry + backoff so
++                # concurrent writers serialize rather than clobber.
++                deadline = time.monotonic() + 30.0
++                acquired = False
++                while time.monotonic() < deadline:
++                    try:
++                        fd.seek(0)
++                        msvcrt.locking(fd.fileno(), msvcrt.LK_NBLCK, 1)
++                        acquired = True
++                        break
++                    except (OSError, IOError):
++                        time.sleep(0.05)
++                # If we could not acquire within the timeout, proceed unlocked
++                # rather than deadlock -- the merge/tombstone logic in
++                # save_to_disk is the real safety net (issue #85858).
++                _unlocked = not acquired
+             yield
+         finally:
+-            if fcntl:
+-                try:
++            try:
++                if fcntl:
+                     fcntl.flock(fd, fcntl.LOCK_UN)
+-                except (OSError, IOError):
+-                    pass
+-            elif msvcrt:
+-                try:
++                elif msvcrt and not _unlocked:
+                     fd.seek(0)
+                     msvcrt.locking(fd.fileno(), msvcrt.LK_UNLCK, 1)
+-                except (OSError, IOError):
+-                    pass
++            except (OSError, IOError):
++                pass
+             fd.close()
+ 
+     @staticmethod
+@@ -360,10 +392,73 @@
+         self._set_entries(target, fresh)
+         return bak
+ 
+-    def save_to_disk(self, target: str):
+-        """Persist entries to the appropriate file. Called after every mutation."""
++    def save_to_disk(
++        self,
++        target: str,
++        *,
++        merge_live: bool = False,
++        extra_tombstones: Optional[List[str]] = None,
++    ):
++        """Persist entries to the appropriate file. Called after every mutation.
++
++        When *merge_live* is True, entries currently on disk that this instance
++        does not have in memory are preserved (content-deduped union). This
++        defends against the last-writer-wins clobber that occurs when two Hermes
++        instances share one profile: a background sync thread or a second
++        instance may hold an in-memory snapshot older than the live file, and a
++        plain full-file rewrite from that stale snapshot silently discards the
++        other writer's concurrent entries (issue #85858). Merge makes both
++        writers' entries survive.
++
++        *extra_tombstones* are marker lines written to disk for THIS round only
++        (so a concurrent sibling sees them and skips the just-removed/replaced
++        entry instead of resurrecting it). They are not stored in the in-memory
++        entry list and are not re-persisted on subsequent saves, so they fade.
++        They are written in BOTH merge and non-merge paths.
++
++        Safe for append/add paths. NOT used for replace/remove, where merging
++        the live file could resurrect an intentionally removed entry — those
++        paths rely on *extra_tombstones* instead.
++        """
+         get_memory_dir().mkdir(parents=True, exist_ok=True)
+-        self._write_file(self._path_for(target), self._entries_for(target))
++        entries = list(self._entries_for(target))
++
++        if merge_live:
++            path = self._path_for(target)
++            raw, raw_ok = self._read_raw_checked(path)
++            live, live_ok = self._read_entries_checked(path)
++            # Tombstones are read from RAW tombstone LINES on disk (written by a
++            # sibling's recent remove/replace for one round). Do NOT compute
++            # _tombstone_for() over the parsed entries -- that would tombstone
++            # every entry and drop all content.
++            live_tombstones = set()
++            if raw_ok:
++                live_tombstones = {
++                    line.strip()
++                    for line in raw.split(ENTRY_DELIMITER)
++                    if _is_tombstone(line.strip())
++                }
++            tombstones = set(self._tombstones) | live_tombstones
++            if extra_tombstones:
++                tombstones.update(extra_tombstones)
++            # Drop our own stale entries whose tombstone is known, so a snapshot
++            # seeded before a sibling's remove/replace can't resurrect it.
++            entries = [e for e in entries if _tombstone_for(e) not in tombstones]
++            if live_ok:
++                # seen tracks both entry texts AND their tombstone markers, so
++                # the live-merge excludes an entry whose marker is known.
++                seen = set(entries) | {_tombstone_for(e) for e in entries} | tombstones
++                for e in live:
++                    if _tombstone_for(e) not in seen:
++                        entries.append(e)
++                        seen.add(_tombstone_for(e))
++
++        # extra_tombstones are written this round only (then they fade). This
++        # happens in BOTH branches so remove/replace (merge_live=False) still
++        # publish their tombstone for concurrent siblings.
++        final = list(entries) + list(extra_tombstones or [])
++
++        self._write_file(self._path_for(target), final)
+ 
+     def _entries_for(self, target: str) -> List[str]:
+         if target == "user":
+@@ -421,6 +516,10 @@
+             if content in entries:
+                 return self._success_response(target, "Entry already exists (no duplicate added).")
+ 
++            # Don't resurrect an entry another instance just removed/replaced.
++            if _tombstone_for(content) in self._tombstones:
++                return self._success_response(target, "Entry was recently removed; not re-added.")
++
+             # Calculate what the new total would be
+             new_entries = entries + [content]
+             new_total = len(ENTRY_DELIMITER.join(new_entries))
+@@ -442,7 +541,7 @@
+ 
+             entries.append(content)
+             self._set_entries(target, entries)
+-            self.save_to_disk(target)
++            self.save_to_disk(target, merge_live=True)
+ 
+         return self._success_response(target, "Entry added.")
+ 
+@@ -513,7 +612,11 @@
+ 
+             entries[idx] = new_content
+             self._set_entries(target, entries)
+-            self.save_to_disk(target)
++            # Tombstone the old entry so a sibling holding a stale snapshot
++            # (with the old text) skips it on its next merge instead of
++            # resurrecting the pre-replacement version (issue #85858).
++            self._tombstones.add(_tombstone_for(old_text))
++            self.save_to_disk(target, extra_tombstones=[_tombstone_for(old_text)])
+ 
+         return self._success_response(target, "Entry replaced.")
+ 
+@@ -553,9 +656,14 @@
+                 # All identical -- safe to remove just the first
+ 
+             idx = matches[0][0]
++            removed_text = entries[idx]
+             entries.pop(idx)
+             self._set_entries(target, entries)
+-            self.save_to_disk(target)
++            # Tombstone the removed entry so a sibling holding a stale snapshot
++            # (still containing it) skips it on its next merge instead of
++            # resurrecting it (issue #85858).
++            self._tombstones.add(_tombstone_for(removed_text))
++            self.save_to_disk(target, extra_tombstones=[_tombstone_for(removed_text)])
+ 
+         return self._success_response(target, "Entry removed.")
+ 
+@@ -627,6 +735,7 @@
+                             f"{pos}: '{old_text}' matched multiple distinct entries -- be more specific.",
+                         )
+                     working[matches[0]] = content
++                    self._tombstones.add(_tombstone_for(old_text))
+ 
+                 elif act == "remove":
+                     if not old_text:
+@@ -639,7 +748,9 @@
+                             target,
+                             f"{pos}: '{old_text}' matched multiple distinct entries -- be more specific.",
+                         )
++                    removed_text = working[matches[0]]
+                     working.pop(matches[0])
++                    self._tombstones.add(_tombstone_for(removed_text))
+ 
+                 else:
+                     return self._batch_error(
+@@ -662,9 +773,14 @@
+                     "usage": f"{current:,}/{limit:,}",
+                 })
+ 
+-            # Commit.
++            # Commit. Tombstones (collected above for replace/remove ops) are
++            # written this round so a concurrent sibling skips the
++            # removed/replaced entries instead of resurrecting them (#85858).
+             self._set_entries(target, working)
+-            self.save_to_disk(target)
++            self.save_to_disk(
++                target,
++                extra_tombstones=sorted(self._tombstones) if self._tombstones else None,
++            )
+ 
+         return self._success_response(target, f"Applied {len(operations)} operation(s).")
+ 
+@@ -780,13 +896,15 @@
+ 
+     @staticmethod
+     def _parse_entries(raw: str) -> List[str]:
+-        """Split raw memory-file text into stripped, non-empty entries."""
++        """Split raw memory-file text into stripped, non-empty entries.
++
++        Tombstone marker lines (__mem_tomb__:<hash>) are skipped — they are
++        not real entries, only concurrency guards (see issue #85858).
++        """
+         if not raw.strip():
+             return []
+-        # Use ENTRY_DELIMITER for consistency with _write_file. Splitting by "§"
+-        # alone would incorrectly split entries that contain "§" in their content.
+         entries = [e.strip() for e in raw.split(ENTRY_DELIMITER)]
+-        return [e for e in entries if e]
++        return [e for e in entries if e and not _is_tombstone(e)]
+ 
+     @staticmethod
+     def _read_entries_checked(path: Path) -> Tuple[List[str], bool]:
+@@ -847,13 +965,20 @@
+         if not raw.strip():
+             return None
+ 
+-        parsed = [e.strip() for e in raw.split(ENTRY_DELIMITER) if e.strip()]
+-        roundtrip = ENTRY_DELIMITER.join(parsed)
++        # Strip tombstone markers before the tool-shape checks: they are
++        # concurrency guards (issue #85858), not user content, and must not
++        # trip the round-trip / entry-size drift signals. Compare the
++        # tombstone-free view of the file to its own round-trip so a present
++        # tombstone never reads as "external drift".
++        cleaned = [e.strip() for e in raw.split(ENTRY_DELIMITER) if e.strip()]
++        cleaned = [e for e in cleaned if not _is_tombstone(e)]
++        roundtrip = ENTRY_DELIMITER.join(cleaned)
++        raw_no_tomb = ENTRY_DELIMITER.join(cleaned)
+ 
+         char_limit = self._char_limit(target)
+-        max_entry_len = max((len(e) for e in parsed), default=0)
++        max_entry_len = max((len(e) for e in cleaned), default=0)
+ 
+-        drift_detected = (raw.strip() != roundtrip) or (max_entry_len > char_limit)
++        drift_detected = (raw_no_tomb.strip() != roundtrip.strip()) or (max_entry_len > char_limit)
+         if not drift_detected:
+             return None
+ 

--- a/tools/memory_tool_85858_lock_hardening.patch
+++ b/tools/memory_tool_85858_lock_hardening.patch
@@ -1,0 +1,20 @@
+--- a/tools/memory_tool.py	2026-08-14 20:21:06.943489400 -0400
++++ b/tools/memory_tool.py	2026-08-14 20:21:08.499418400 -0400
+@@ -278,10 +278,15 @@
+     @staticmethod
+     @contextmanager
+     def _file_lock(path: Path):
+-        """Acquire an exclusive file lock for read-modify-write safety.
++        """Acquire an exclusive cross-process file lock for read-modify-write.
+ 
+         Uses a separate .lock file so the memory file itself can still be
+-        atomically replaced via os.replace().
++        atomically replaced via os.replace(). On Unix, fcntl.flock(LOCK_EX)
++        blocks until the lock is free. On Windows, msvcrt.locking is advisory
++        and only covers a 1-byte region, so we acquire it non-blocking
++        (LK_NBLCK) and retry with backoff -- this makes two processes QUEUE
++        for the lock instead of racing, and bounds the wait with a timeout so
++        a wedged lock can never deadlock the caller.
+         """
+         lock_path = path.with_suffix(path.suffix + ".lock")
+         lock_path.parent.mkdir(parents=True, exist_ok=True)

--- a/tools/memory_tool_85858_open_pr.sh
+++ b/tools/memory_tool_85858_open_pr.sh
@@ -1,0 +1,43 @@
+# Ready-to-run PR sequence for NousResearch/hermes-agent#85858
+# NOTE: BananaAcc has push=false on upstream, so the PR must come from a FORK.
+# This script is DRAFTED ONLY — not executed (per standing instruction).
+# Review, then run from the hermes-agent repo root.
+
+set -e
+
+REPO_ROOT="C:/Users/enhal/AppData/Local/hermes/hermes-agent"
+cd "$REPO_ROOT"
+
+# 1. Create / ensure a personal fork exists (interactive once; safe to re-run).
+gh repo fork NousResearch/hermes-agent --clone=false || true
+
+# 2. Point a 'fork' remote at YOUR fork (BananaAccurate). Uses SSH or HTTPS per gh config.
+gh repo set-default NousResearch/hermes-agent
+git remote add fork "https://github.com/BananaAccurate/hermes-agent.git" 2>/dev/null || \
+  git remote set-url fork "https://github.com/BananaAccurate/hermes-agent.git"
+
+# 3. Branch + stage the four untracked artifacts.
+git checkout -b fix/85858-concurrent-memory-clobber
+git add \
+  tools/memory_tool_85858_dataloss_fix.patch \
+  tools/memory_tool_85858_lock_hardening.patch \
+  tests/tools/test_memory_concurrency_85858.py \
+  tools/memory_tool_85858_PR.md
+git commit -m "Fix concurrent-instance memory clobber (last-writer-wins) #85858
+
+Make MemoryStore.save_to_disk merge-live + tombstone instead of blind
+overwrite, so two instances sharing one profile no longer lose each
+other's entries or resurrect removed ones. Adds regression test."
+
+# 4. Push to the FORK (not upstream).
+git push -u fork fix/85858-concurrent-memory-clobber
+
+# 5. Open the PR against upstream main from the fork branch.
+gh pr create \
+  --repo NousResearch/hermes-agent \
+  --base main \
+  --head BananaAccurate:fix/85858-concurrent-memory-clobber \
+  --title "Fix concurrent-instance memory clobber (last-writer-wins) #85858" \
+  --body-file tools/memory_tool_85858_pr_body.md
+
+echo "PR opened. Link above."

--- a/tools/memory_tool_85858_pr_body.md
+++ b/tools/memory_tool_85858_pr_body.md
@@ -1,0 +1,70 @@
+# Fix concurrent-instance memory clobber (last-writer-wins) — #85858
+
+## Problem
+`MemoryStore` persists by rewriting the **entire `MEMORY.md`/user file** from an
+in-memory entry list (`save_to_disk`). That list is a snapshot seeded at
+`load_from_disk()`, and the background `sync_all` flush writes it **without
+re-reading at flush time**. When two Hermes instances share one profile, each
+holds its own aged snapshot; whichever `save_to_disk` runs last rewrites the file
+from its stale list and silently discards the other instance's concurrent entry.
+This is the same class that wiped `MEMORY.md` under concurrent sessions
+(reported in #85858).
+
+On Windows the file lock (`msvcrt.locking`) is a 1-byte advisory lock that is
+process-dependent and unreliable under OneDrive-synced `AppData`, so it does not
+reliably serialize two processes — making the clobber reachable in practice.
+
+## Fix (split into two independently-reviewable patches)
+
+**1. `memory_tool_85858_dataloss_fix.patch` (required)** — merge + tombstone
+instead of blind overwrite:
+- `save_to_disk(..., merge_live=True)` unions live on-disk entries the instance
+  doesn't already hold (content-dedup). Last-writer-*wins* →
+  last-writer-*merges*. `add` opts in.
+- **Resurrection safety via tombstones** (`__mem_tomb__:<sha1>` marker lines):
+  `remove`/`replace`/`apply_batch` write a tombstone for the removed/replaced
+  entry for **one round**, so a sibling holding a stale snapshot skips it
+  instead of resurrecting it. Tombstones are never surfaced as entries and fade
+  after one round. The drift guard now strips tombstone lines before its
+  round-trip check.
+- `add` refuses to re-add a tombstoned entry.
+
+**2. `memory_tool_85858_lock_hardening.patch` (optional hardening)** — Windows
+`msvcrt.locking` now uses non-blocking `LK_NBLCK` with backoff retry + a 30s
+timeout, so concurrent writers *queue* instead of racing and can't deadlock.
+This is a complementary defense; the merge/tombstone logic is the real safety
+net, so this patch is safe to merge independently (or skip).
+
+## Verification
+New `tests/tools/test_memory_concurrency_85858.py` (3 tests) exercises two
+`MemoryStore` instances sharing one profile: concurrent `add`s both survive;
+a `remove` then a sibling's stale flush does **not** resurrect the entry; a
+`replace` then a sibling's stale flush keeps the new version and drops the old.
+
+- New test + `tests/tools/test_memory_tool.py`: **40 passed**.
+- Broader `tests/agent/test_memory_*.py` + schema/import tests: **71 passed**.
+- Both patches apply cleanly (no flags) in either order.
+
+Running the real suite caught a bug the standalone model missed: the drift guard
+compared the raw file (with the tombstone line) against the tombstone-stripped
+round-trip and falsely refused writes; fixed. The standalone model had already
+caught three earlier bugs (tombstoning every entry; not filtering stale
+in-memory entries; text-vs-marker mismatch in the merge). All fixed.
+
+Standalone model also passes: concurrent adds both preserved; `remove` + stale
+sibling flush → no resurrection (`['pre','from B']`); `replace` X→X' + stale
+sibling flush → old gone, X' kept (`['pre','from B',"secret X'"]`).
+
+## Scope
+- Only `add` uses `merge_live` (append is safe). `replace`/`remove` use
+  tombstones, not merge, because merging there could resurrect removed content.
+- Format-compatible: tombstone lines are stripped on parse and by the drift
+  guard, so older readers ignore them.
+- Patch #1 is the required fix; patch #2 is optional hardening.
+
+## How to apply
+```bash
+git apply tools/memory_tool_85858_dataloss_fix.patch
+git apply tools/memory_tool_85858_lock_hardening.patch
+pytest tests/tools/test_memory_concurrency_85858.py
+```


### PR DESCRIPTION
# Fix concurrent-instance memory clobber (last-writer-wins) — #85858

## Problem
`MemoryStore` persists by rewriting the **entire `MEMORY.md`/user file** from an
in-memory entry list (`save_to_disk`). That list is a snapshot seeded at
`load_from_disk()`, and the background `sync_all` flush writes it **without
re-reading at flush time**. When two Hermes instances share one profile, each
holds its own aged snapshot; whichever `save_to_disk` runs last rewrites the file
from its stale list and silently discards the other instance's concurrent entry.
This is the same class that wiped `MEMORY.md` under concurrent sessions
(reported in #85858).

On Windows the file lock (`msvcrt.locking`) is a 1-byte advisory lock that is
process-dependent and unreliable under OneDrive-synced `AppData`, so it does not
reliably serialize two processes — making the clobber reachable in practice.

## Fix (split into two independently-reviewable patches)

**1. `memory_tool_85858_dataloss_fix.patch` (required)** — merge + tombstone
instead of blind overwrite:
- `save_to_disk(..., merge_live=True)` unions live on-disk entries the instance
  doesn't already hold (content-dedup). Last-writer-*wins* →
  last-writer-*merges*. `add` opts in.
- **Resurrection safety via tombstones** (`__mem_tomb__:<sha1>` marker lines):
  `remove`/`replace`/`apply_batch` write a tombstone for the removed/replaced
  entry for **one round**, so a sibling holding a stale snapshot skips it
  instead of resurrecting it. Tombstones are never surfaced as entries and fade
  after one round. The drift guard now strips tombstone lines before its
  round-trip check.
- `add` refuses to re-add a tombstoned entry.

**2. `memory_tool_85858_lock_hardening.patch` (optional hardening)** — Windows
`msvcrt.locking` now uses non-blocking `LK_NBLCK` with backoff retry + a 30s
timeout, so concurrent writers *queue* instead of racing and can't deadlock.
This is a complementary defense; the merge/tombstone logic is the real safety
net, so this patch is safe to merge independently (or skip).

## Verification
New `tests/tools/test_memory_concurrency_85858.py` (3 tests) exercises two
`MemoryStore` instances sharing one profile: concurrent `add`s both survive;
a `remove` then a sibling's stale flush does **not** resurrect the entry; a
`replace` then a sibling's stale flush keeps the new version and drops the old.

- New test + `tests/tools/test_memory_tool.py`: **40 passed**.
- Broader `tests/agent/test_memory_*.py` + schema/import tests: **71 passed**.
- Both patches apply cleanly (no flags) in either order.

Running the real suite caught a bug the standalone model missed: the drift guard
compared the raw file (with the tombstone line) against the tombstone-stripped
round-trip and falsely refused writes; fixed. The standalone model had already
caught three earlier bugs (tombstoning every entry; not filtering stale
in-memory entries; text-vs-marker mismatch in the merge). All fixed.

Standalone model also passes: concurrent adds both preserved; `remove` + stale
sibling flush → no resurrection (`['pre','from B']`); `replace` X→X' + stale
sibling flush → old gone, X' kept (`['pre','from B',"secret X'"]`).

## Scope
- Only `add` uses `merge_live` (append is safe). `replace`/`remove` use
  tombstones, not merge, because merging there could resurrect removed content.
- Format-compatible: tombstone lines are stripped on parse and by the drift
  guard, so older readers ignore them.
- Patch #1 is the required fix; patch #2 is optional hardening.

## How to apply
```bash
git apply tools/memory_tool_85858_dataloss_fix.patch
git apply tools/memory_tool_85858_lock_hardening.patch
pytest tests/tools/test_memory_concurrency_85858.py
```
