### PR TITLE
fix: honor HERMES_HOME_MODE in secure_parent_dir

### DIFF
--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -809,7 +809,16 @@ def display_hermes_home() -> str:
 
 
 def secure_parent_dir(path: Path) -> None:
-    """Chmod ``0o700`` on the parent directory of *path*, but only if safe.
+    """Chmod the parent directory of *path* to ``HERMES_HOME_MODE``, but only
+    if safe.
+
+    Honors the ``HERMES_HOME_MODE`` environment variable (octal string,
+    default ``0o700``) so multi-user hosts that intentionally relax the
+    Hermes home permissions — e.g. POSIX ACL peers granted via
+    ``setfacl u:<peer>:r-x`` — don't have their ACL mask silently reset on
+    every credential write. ``os.chmod`` rewrites the POSIX ACL mask to
+    match the new group bits, which revokes traversal for any peer user
+    holding only a named ACE (no supplemental group membership).
 
     Refuses to chmod ``/`` or any top-level directory (resolved parent with
     fewer than 3 parts, i.e. ``/`` or any direct child like ``/usr``) to
@@ -823,7 +832,12 @@ def secure_parent_dir(path: Path) -> None:
     if parent == Path("/") or len(parent.parts) < 3:
         return
     try:
-        os.chmod(parent, 0o700)
+        mode_str = os.environ.get("HERMES_HOME_MODE", "").strip()
+        mode = int(mode_str, 8) if mode_str else 0o700
+    except ValueError:
+        mode = 0o700
+    try:
+        os.chmod(parent, mode)
     except OSError:
         pass
 


### PR DESCRIPTION
## Summary

`secure_parent_dir()` hardcodes `0o700` on the parent directory of auth files. On multi-user hosts that intentionally share the Hermes home via POSIX ACLs (`setfacl u:<peer>:r-x`), every credential write (`auth.json` save) resets the POSIX ACL mask to match the new group bits — silently revoking traversal for any peer user holding only a named ACE (no supplemental group membership).

`HERMES_HOME_MODE` already exists as the sanctioned mode override consumed by the rest of the home-dir permission logic; this PR makes `secure_parent_dir` honor it too, with the default remaining `0o700` (no behavior change for single-user installs).

## Repro

```bash
# host with a peer user granted traversal via ACL
setfacl -m u:peer:r-x ~/.hermes
setfacl -m m::r-x ~/.hermes

sudo -u peer ls ~/.hermes   # works

# any Hermes credential write (auth.json refresh, login, etc.)
# → secure_parent_dir() → os.chmod(~/.hermes, 0o700)
# → ACL mask rewritten to ---

sudo -u peer ls ~/.hermes   # Permission denied, no error surfaced to owner
```

## Behavior

| HERMES_HOME_MODE | chmod applied | ACL peers |
|---|---|---|
| unset (default) | 0o700 | unchanged from today |
| 0750 | 0o750 | mask stays effective, peers keep traversal |
| garbage | falls back to 0o700 | unchanged from today |

Invalid values fall back to the `0o700` default rather than raising, matching the defensive posture of the surrounding code.

## Test plan

- [x] Default (env unset): parent dir chmod'd to `0o700` — identical to current behavior
- [x] `HERMES_HOME_MODE=0750`: parent chmod'd to `0o750`, ACL mask stays effective, peer user retains traversal
- [x] `HERMES_HOME_MODE=GARBAGE`: falls back to `0o700`, no exception
- [x] Root/direct-child refusal (safety check from #25821) still fires: `/` and single-level dirs are never chmod'd
- [x] OSError still swallowed as before

Relates to #25821 (original host-bricking guard that introduced this function).