### PR TITLE
fix(desktop): report waiting status when a session is blocked on approval

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -15280,6 +15280,29 @@ def test_session_not_evictable_violating_each_exemption(monkeypatch):
     assert server._session_is_evictable("s", _idle_evictable_session(now), now) is False
 
 
+def test_session_live_status_waiting_on_blocking_approval(monkeypatch):
+    """A session blocked on a dangerous-command approval must report
+    `waiting`, not `working` — the sidebar `needs-input` dot depends on
+    this status, and clarify/sudo already report `waiting` via
+    `_session_pending_kind`, but approvals live in a separate registry
+    (`tools/approval.py`) that this status previously never consulted."""
+    monkeypatch.setattr(server, "_session_pending_kind", lambda sid: "")
+    from tools import approval
+
+    monkeypatch.setattr(approval, "_gateway_queues", {"sess-key-1": ["entry"]})
+    session = {"running": True, "session_key": "sess-key-1"}
+    assert server._session_live_status("s", session) == "waiting"
+
+
+def test_session_live_status_working_without_pending_approval(monkeypatch):
+    monkeypatch.setattr(server, "_session_pending_kind", lambda sid: "")
+    from tools import approval
+
+    monkeypatch.setattr(approval, "_gateway_queues", {})
+    session = {"running": True, "session_key": "sess-key-1"}
+    assert server._session_live_status("s", session) == "working"
+
+
 def test_reap_idle_sessions_closes_only_evictable(monkeypatch):
     closed = []
     monkeypatch.setattr(server, "_session_pending_kind", lambda sid: "")

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -15303,6 +15303,67 @@ def test_session_live_status_working_without_pending_approval(monkeypatch):
     assert server._session_live_status("s", session) == "working"
 
 
+def test_session_live_status_waiting_on_real_gateway_approval_binding(monkeypatch):
+    """Integration check for the key agreement the mocked tests above don't
+    exercise: queue an approval through the actual gateway approval path
+    (``check_all_command_guards`` binding ``session_key`` via the
+    ``HERMES_SESSION_KEY``/contextvar route, not a hand-set dict key) and
+    confirm the matching live session reports `waiting`."""
+    monkeypatch.setattr(server, "_session_pending_kind", lambda sid: "")
+    from tools import approval
+
+    session_key = "real-binding-session"
+    approval._gateway_queues.clear()
+    approval._gateway_notify_cbs.clear()
+    approval._session_approved.clear()
+    approval._permanent_approved.clear()
+    approval._pending.clear()
+    saved_env = {
+        k: os.environ.get(k)
+        for k in ("HERMES_GATEWAY_SESSION", "HERMES_CRON_SESSION",
+                  "HERMES_YOLO_MODE", "HERMES_SESSION_KEY", "HERMES_INTERACTIVE")
+    }
+    os.environ.pop("HERMES_YOLO_MODE", None)
+    os.environ.pop("HERMES_INTERACTIVE", None)
+    os.environ.pop("HERMES_CRON_SESSION", None)
+    os.environ["HERMES_GATEWAY_SESSION"] = "1"
+    os.environ["HERMES_SESSION_KEY"] = session_key
+    monkeypatch.setattr(
+        approval, "_get_approval_config",
+        lambda: {"mode": "manual", "timeout": 60},
+    )
+    approval.register_gateway_notify(session_key, lambda data: None)
+    try:
+        result_holder = {}
+
+        def _check():
+            result_holder["r"] = approval.check_all_command_guards("rm -rf .git", "local")
+
+        t = threading.Thread(target=_check)
+        t.start()
+        try:
+            for _ in range(200):
+                if approval._gateway_queues.get(session_key):
+                    break
+                time.sleep(0.005)
+            else:
+                raise AssertionError("approval queue entry never appeared")
+
+            session = {"running": True, "session_key": session_key}
+            assert server._session_live_status("s", session) == "waiting"
+        finally:
+            approval.resolve_gateway_approval(session_key, "deny")
+            t.join(timeout=5)
+    finally:
+        approval._gateway_queues.clear()
+        approval._gateway_notify_cbs.clear()
+        for k, v in saved_env.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+
+
 def test_reap_idle_sessions_closes_only_evictable(monkeypatch):
     closed = []
     monkeypatch.setattr(server, "_session_pending_kind", lambda sid: "")

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -8122,6 +8122,11 @@ def _session_pending_kind(sid: str) -> str:
 def _session_live_status(sid: str, session: dict) -> str:
     if _session_pending_kind(sid):
         return "waiting"
+    session_key = str(session.get("session_key") or "")
+    if session_key:
+        from tools.approval import has_blocking_approval
+        if has_blocking_approval(session_key):
+            return "waiting"
     ready = session.get("agent_ready")
     # Unset + build never started = a lazy watch session sitting idle, not a
     # session stuck mid-construction.


### PR DESCRIPTION
## Summary

Fixes #86565: a background session blocked on a dangerous-command approval kept its Desktop sidebar dot **blue** ("Session running") indefinitely instead of turning **amber** ("Needs your input"). Clarify prompts already worked correctly — only approvals were affected.

## Root cause

Desktop's `use-background-sync.ts` polls `session.active_list` and maps `status === 'waiting'` to `needsInput: true`; any other status republishes `needsInput: false` on the next poll.

The backend's `_session_live_status()` (`tui_gateway/server.py`) only asked `_session_pending_kind()`, which inspects `tui_gateway`'s own `_pending` registry — the bridge used by `clarify` / `sudo` / `secret` prompts via `_block()`. Dangerous-command **approvals** are tracked in a completely separate registry, `tools/approval.py`'s `_gateway_queues`, which `_session_live_status()` never consulted. So a session blocked on an approval reported `status: "working"`, and even though the one-shot `approval.request` gateway event flips `needsInput: true` for a moment, the next `active_list` poll (every 1.5s/30s) republished `working` / `needsInput: false` and the dot flipped back to blue — for the entire duration of the pending approval.

Root-caused in the issue thread by @linfeng961 with the exact registry mismatch; this PR implements the suggested backend fix (option 1 in that comment).

## Fix

`_session_live_status()` now also checks `tools/approval.has_blocking_approval(session_key)` — an existing helper already used elsewhere (`gateway/run.py`, `gateway/slash_commands.py`) to detect a pending gateway approval for a session — and reports `"waiting"` when one is pending, matching the clarify/sudo behavior.

```python
def _session_live_status(sid: str, session: dict) -> str:
    if _session_pending_kind(sid):
        return "waiting"
    session_key = str(session.get("session_key") or "")
    if session_key:
        from tools.approval import has_blocking_approval
        if has_blocking_approval(session_key):
            return "waiting"
    ...
```

## Test plan

Added `test_session_live_status_waiting_on_blocking_approval` and `test_session_live_status_working_without_pending_approval` to `tests/test_tui_gateway_server.py`.

Confirmed the new test fails without the fix:

```
$ git checkout HEAD~1 -- tui_gateway/server.py
$ python -m pytest tests/test_tui_gateway_server.py -k session_live_status -q
F.
AssertionError: assert 'working' == 'waiting'
1 failed, 1 passed
$ git checkout HEAD -- tui_gateway/server.py
```

And passes with it:

```
$ python -m pytest tests/test_tui_gateway_server.py -k session_live_status -q
2 passed
```

Full file and related suites:

```
$ python -m pytest tests/test_tui_gateway_server.py -q
557 passed, 1 warning
$ python -m pytest tests/tools/test_approval.py -q
96 passed
$ ruff check tui_gateway/server.py tests/test_tui_gateway_server.py
All checks passed!
```

## Notes

- Backend-only change; no Desktop frontend files touched, since `session.active_list`'s `status` field is the single source of truth the frontend already trusts.
- Does not touch the tui_gateway `_pending` registry or clarify/sudo behavior, which already worked correctly.

## AI disclosure

This change was prepared with AI assistance (Claude).
