### PR TITLE
fix(desktop): stop retry/restore from truncating unpersisted failed turns

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/rewind.test.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/rewind.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest'
 
 import { type ChatMessage, textPart } from '@/lib/chat-messages'
 
-import { rebindSurvivorRowIds, survivorRowIdsFrom, truncateSubmitParams } from './rewind'
+import { planReload, planRestore, rebindSurvivorRowIds, survivorRowIdsFrom, truncateSubmitParams } from './rewind'
 
 describe('truncateSubmitParams', () => {
   it('omits truncation fields when no ordinal is set', () => {
@@ -124,5 +124,72 @@ describe('rebindSurvivorRowIds', () => {
     const messages = [user('u0', 7)]
 
     expect(rebindSurvivorRowIds(messages, [7])[0]).toBe(messages[0])
+  })
+})
+
+describe('planReload', () => {
+  const user = (id: string, rowId?: number): ChatMessage => ({
+    id,
+    role: 'user',
+    parts: [textPart(`text ${id}`)],
+    ...(rowId !== undefined ? { rowId } : {})
+  })
+
+  const assistant = (id: string, opts?: { branchGroupId?: string; error?: string; rowId?: number }): ChatMessage => ({
+    id,
+    role: 'assistant',
+    parts: [textPart(`reply ${id}`)],
+    ...(opts?.branchGroupId !== undefined ? { branchGroupId: opts.branchGroupId } : {}),
+    ...(opts?.error !== undefined ? { error: opts.error } : {}),
+    ...(opts?.rowId !== undefined ? { rowId: opts.rowId } : {})
+  })
+
+  it('sends ordinal, message id, and row id for a normal (persisted) reload', () => {
+    const messages = [user('u0', 1), assistant('a0', { rowId: 2 })]
+
+    const plan = planReload(messages, null)
+
+    expect(plan?.truncateOrdinal).toBe(0)
+    expect(plan?.truncateMessageId).toBe('u0')
+    expect(plan?.truncateRowId).toBe(1)
+  })
+
+  it('nulls out every truncate field when the target turn failed and was never persisted', () => {
+    // A failed turn's user message has no row id on the gateway, so its client
+    // ordinal is a positional guess that can point at the wrong row (#86573).
+    const messages = [user('u0', 1), assistant('a0', { error: 'boom' })]
+
+    const plan = planReload(messages, null)
+
+    expect(plan?.truncateOrdinal).toBeUndefined()
+    expect(plan?.truncateMessageId).toBeUndefined()
+    expect(plan?.truncateRowId).toBeUndefined()
+  })
+})
+
+describe('planRestore', () => {
+  const user = (id: string, rowId?: number): ChatMessage => ({
+    id,
+    role: 'user',
+    parts: [textPart(`text ${id}`)],
+    ...(rowId !== undefined ? { rowId } : {})
+  })
+
+  const assistant = (id: string, opts?: { error?: string; rowId?: number }): ChatMessage => ({
+    id,
+    role: 'assistant',
+    parts: [textPart(`reply ${id}`)],
+    ...(opts?.error !== undefined ? { error: opts.error } : {}),
+    ...(opts?.rowId !== undefined ? { rowId: opts.rowId } : {})
+  })
+
+  it('nulls out every truncate field when restoring to a failed, never-persisted turn', () => {
+    const messages = [user('u0', 1), assistant('a0', { error: 'boom' })]
+
+    const plan = planRestore(messages, 'u0')
+
+    expect(plan.truncateOrdinal).toBeUndefined()
+    expect(plan.truncateMessageId).toBeUndefined()
+    expect(plan.truncateRowId).toBeUndefined()
   })
 })

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/rewind.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/rewind.ts
@@ -216,7 +216,7 @@ export function finalizeInterruptedMessages(messages: ChatMessage[], streamId?: 
 export interface ReloadPlan {
   branchGroupId: string
   text: string
-  truncateOrdinal: number
+  truncateOrdinal: number | undefined
   truncateMessageId?: string
   truncateRowId?: number
   userIndex: number
@@ -246,12 +246,14 @@ export function planReload(messages: ChatMessage[], parentId: null | string): nu
       ? messages[parentIndex]
       : messages.slice(userIndex + 1).find(m => m.role === 'assistant')
 
+  const isFailedTurn = targetAssistant?.role === 'assistant' && Boolean(targetAssistant.error)
+
   return {
     branchGroupId: targetAssistant?.branchGroupId ?? branchGroupForUser(userMessage),
     text,
-    truncateOrdinal: visibleUserOrdinal(messages, userIndex),
-    truncateMessageId: userMessage.id,
-    truncateRowId: userMessage.rowId,
+    truncateOrdinal: isFailedTurn ? undefined : visibleUserOrdinal(messages, userIndex),
+    truncateMessageId: isFailedTurn ? undefined : userMessage.id,
+    truncateRowId: isFailedTurn ? undefined : userMessage.rowId,
     userIndex
   }
 }
@@ -289,7 +291,7 @@ export interface RestoreTarget {
 export interface RestorePlan {
   sourceIndex: number
   text: string
-  truncateOrdinal: number
+  truncateOrdinal: number | undefined
   truncateMessageId?: string
   truncateRowId?: number
 }
@@ -316,12 +318,23 @@ export function planRestore(messages: ChatMessage[], messageId: string, target?:
     throw new Error('Cannot restore an empty message.')
   }
 
+  // Failed turn: the target user msg never reached the gateway, so a
+  // truncate-by-ordinal would mis-aim (#86573) — resubmit plainly instead.
+  const nextMessage = messages[sourceIndex + 1]
+  const isFailedTurn = nextMessage?.role === 'assistant' && Boolean(nextMessage.error)
+
   const truncateOrdinal =
     target?.userOrdinal === null || target?.userOrdinal === undefined
       ? visibleUserOrdinal(messages, sourceIndex)
       : target.userOrdinal
 
-  return { sourceIndex, text, truncateOrdinal, truncateMessageId: source.id, truncateRowId: source.rowId }
+  return {
+    sourceIndex,
+    text,
+    truncateOrdinal: isFailedTurn ? undefined : truncateOrdinal,
+    truncateMessageId: isFailedTurn ? undefined : source.id,
+    truncateRowId: isFailedTurn ? undefined : source.rowId
+  }
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR do?

`planReload` (Retry) and `planRestore` (restore-to-message) computed a truncate ordinal unconditionally, even when the target turn's user message never reached the gateway (e.g. a request that died on an HTTP 429 before the turn was ever persisted). With no durable row id to anchor it, that request travels the legacy `truncate_before_user_ordinal`-only path, whose address space can drift from the gateway's after compaction/rebuilds — silently truncating the wrong turn.

### Root cause

`planEdit` already guards this exact case with an `isFailedTurn` check (`nextMessage?.role === 'assistant' && Boolean(nextMessage.error)`) that resubmits plainly instead of requesting a truncation it can't safely address. `planReload` and `planRestore` are the two remaining `ReloadPlan`/`RestorePlan` builders that never got the same guard — this PR applies the identical, already-proven pattern to both.

### Why a client-side fix, not just a gateway guard

#86605 addresses this from the gateway side: it fails closed (`4004`) whenever an ordinal-only truncation request targets a session that has *any* durable row ids in its history. That's a reasonable defense-in-depth net, but on its own it does not fix the actual bug — it just turns "silently truncates the wrong turn" into "the Retry button now hard-fails" for the exact retry-after-failure scenario the issue describes, since `planReload`/`planRestore` (pre-fix) genuinely do emit ordinal-only requests for unpersisted failed turns. That PR's own "ruled out" section states failed-turn planning "does not request truncation," which this repro shows is not accurate for `planReload`/`planRestore` prior to this fix.

This PR fixes the producer instead: the client simply stops asking the gateway to truncate by position when it has no durable identity to offer, exactly like `planEdit` already does. Retry and Restore keep working after a failed turn; they resubmit plainly with no truncation at all, matching the safe, already-shipped behavior of Edit. This is complementary to (not a duplicate of) any gateway-side hardening.

## Changes Made

- `apps/desktop/src/app/session/hooks/use-prompt-actions/rewind.ts`
  - `ReloadPlan.truncateOrdinal` and `RestorePlan.truncateOrdinal` widened to `number | undefined`.
  - `planReload` and `planRestore` now null out `truncateOrdinal` / `truncateMessageId` / `truncateRowId` when the target turn's assistant response carries an `error` (the same `isFailedTurn` heuristic `planEdit` already uses).
- `apps/desktop/src/app/session/hooks/use-prompt-actions/rewind.test.ts`
  - New `planReload` and `planRestore` describe blocks covering the normal (persisted) case and the failed-turn case.

## Related Issue

Fixes #86573

## Test plan

- [x] Added unit tests for `planReload` and `planRestore` covering both the persisted and failed-turn cases (`rewind.test.ts`).
- [ ] Manual: trigger a 429/failed turn on Desktop, click Retry, verify no truncation is requested and the turn resubmits cleanly.

## Diagram

```mermaid
%%{init: {'theme': 'dark', 'themeVariables': { 'primaryColor': '#00f0ff', 'mainBkg': '#0a0a16', 'primaryTextColor': '#ffffff', 'primaryBorderColor': '#ff007f', 'lineColor': '#00f0ff'}}}%%
graph TD
    A[User clicks Retry / Restore] --> B{Target turn's assistant reply has error?}
    B -->|No - persisted turn| C[Attach durable row id + ordinal]
    B -->|Yes - never reached gateway| D[isFailedTurn guard]
    D --> E[Send plain resubmit - no truncation params]
    C --> F[prompt.submit with truncate_before_row_id]
    E --> G[Gateway: no truncation requested - safe]
    F --> H[Gateway: durable target - safe]
```
