### PR TITLE
feat(desktop): cluster [Topic]-prefixed sessions in the sidebar

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/index.tsx
+++ b/apps/desktop/src/app/chat/sidebar/index.tsx
@@ -143,7 +143,7 @@ import type { SidebarNavItem } from '../../types'
 import { SidebarCronJobsSection } from './cron-jobs-section'
 import { SidebarFilterMenu } from './filter-menu'
 import { SidebarLoadMoreRow } from './load-more-row'
-import { orderByIds, reconcileOrderIds, resolveManualSessionOrderIds, sameIds } from './order'
+import { clusterByTopic, orderByIds, reconcileOrderIds, resolveManualSessionOrderIds, sameIds } from './order'
 import { ProfileRail } from './profile-switcher'
 import { ProjectDialog } from './project-dialog'
 import {
@@ -517,9 +517,16 @@ export function ChatSidebar({
   // Recents by activity (last_active || started_at). User send stamps
   // last_active immediately. Ordering by status doesn't sort here — it re-slots
   // rows *inside* whatever dividers are on, via sortOrderIds below — so the
-  // date buckets stay chronological either way.
+  // date buckets stay chronological either way. Sessions whose titles carry a
+  // [Topic] prefix are clustered together (adjacent, siblings still
+  // recency-sorted) so e.g. [凭证] rows stay in one block.
   const sortedSessions = useMemo(
-    () => [...visibleSessions].sort((a, b) => sessionTime(b) - sessionTime(a)),
+    () =>
+      clusterByTopic(
+        [...visibleSessions].sort((a, b) => sessionTime(b) - sessionTime(a)),
+        session => session.id,
+        session => session.title
+      ),
     [visibleSessions]
   )
 
@@ -674,7 +681,12 @@ export function ChatSidebar({
   // date group inside the section (orderRowsWithinGroups) rather than baked
   // into the list here, so a drag ranks a row among its own day's chats
   // instead of flattening the whole sidebar into an undated manual mode.
-  const agentSessions = unpinnedAgentSessions
+  // Sessions whose titles carry a [Topic] prefix are clustered together so
+  // same-topic rows stay adjacent on top of that recency baseline.
+  const agentSessions = useMemo(
+    () => clusterByTopic(unpinnedAgentSessions, s => s.id, s => s.title),
+    [unpinnedAgentSessions]
+  )
 
   // Recents are local-only: messaging-platform sessions are fetched as their
   // own slice ($messagingSessions) and rendered in self-managed per-platform

--- a/apps/desktop/src/app/chat/sidebar/order.test.ts
+++ b/apps/desktop/src/app/chat/sidebar/order.test.ts
@@ -4,6 +4,7 @@ import type { SidebarListRow } from '@/lib/session-date-groups'
 import type { SessionInfo } from '@/types/hermes'
 
 import {
+  clusterByTopic,
   orderByIds,
   orderRowsWithinGroups,
   rankSessions,
@@ -169,5 +170,70 @@ describe('reorderableRowIds', () => {
     const rows = [session('a'), session('branch', '├─ '), divider('yesterday'), session('b')]
 
     expect(reorderableRowIds(rows)).toEqual(['a', 'b'])
+  })
+})
+
+describe('clusterByTopic', () => {
+  const id = (item: { id: string }) => item.id
+  const title = (item: { id: string; title?: string | null }) => item.title
+
+  it('keeps items without topic prefixes in recency order', () => {
+    const items = [
+      { id: 'a', title: '最新会话' },
+      { id: 'b', title: null },
+      { id: 'c', title: '旧会话' }
+    ]
+    expect(clusterByTopic(items, id, title)).toEqual(items)
+  })
+
+  it('pulls siblings with the same [Topic] prefix together', () => {
+    const items = [
+      { id: 'a', title: '[凭证]录入' },
+      { id: 'b', title: '普通会话' },
+      { id: 'c', title: '[凭证]打印' },
+      { id: 'd', title: '[部署]新服务器' },
+      { id: 'e', title: '[凭证]导入' }
+    ]
+    expect(clusterByTopic(items, id, title)).toEqual([
+      { id: 'a', title: '[凭证]录入' },
+      { id: 'c', title: '[凭证]打印' },
+      { id: 'e', title: '[凭证]导入' },
+      { id: 'b', title: '普通会话' },
+      { id: 'd', title: '[部署]新服务器' }
+    ])
+  })
+
+  it('keeps unprefixed items in their original slots between clusters', () => {
+    const items = [
+      { id: 'new', title: '新会话' },
+      { id: 'p1', title: '[业务]流水' },
+      { id: 'mid', title: '中间会话' },
+      { id: 'p2', title: '[业务]代账' },
+      { id: 'old', title: '旧会话' }
+    ]
+    expect(clusterByTopic(items, id, title)).toEqual([
+      { id: 'new', title: '新会话' },
+      { id: 'p1', title: '[业务]流水' },
+      { id: 'p2', title: '[业务]代账' },
+      { id: 'mid', title: '中间会话' },
+      { id: 'old', title: '旧会话' }
+    ])
+  })
+
+  it('does not reorder siblings within a cluster (baseline order wins)', () => {
+    const items = [
+      { id: 'older', title: '[审计]旧' },
+      { id: 'newer', title: '[审计]新' },
+      { id: 'plain', title: '无前缀' }
+    ]
+    expect(clusterByTopic(items, id, title)).toEqual(items)
+  })
+
+  it('handles titles that look like prefixes but are not bracket-wrapped', () => {
+    const items = [
+      { id: 'a', title: '凭证]残缺' },
+      { id: 'b', title: '[完整' }
+    ]
+    expect(clusterByTopic(items, id, title)).toEqual(items)
   })
 })

--- a/apps/desktop/src/app/chat/sidebar/order.ts
+++ b/apps/desktop/src/app/chat/sidebar/order.ts
@@ -226,3 +226,10 @@ function clusterId(rows: SidebarListRow[]): string {
 export function reorderableRowIds(rows: SidebarListRow[]): string[] {
   return rows.flatMap(row => (row.kind === 'session' && !row.entry.branchStem ? [row.entry.session.id] : []))
 }
+
+/**
+ * clusterByTopic moved to lib for layering (sidebar order.ts is an app
+ * module; session-branch-tree.ts is a lib module). Re-exported here so
+ * existing app callers and tests keep working unchanged.
+ */
+export { clusterByTopic } from '@/lib/session-topic-cluster'

--- a/apps/desktop/src/app/chat/sidebar/order.ts
+++ b/apps/desktop/src/app/chat/sidebar/order.ts
@@ -228,8 +228,7 @@ export function reorderableRowIds(rows: SidebarListRow[]): string[] {
 }
 
 /**
- * clusterByTopic moved to lib for layering (sidebar order.ts is an app
- * module; session-branch-tree.ts is a lib module). Re-exported here so
- * existing app callers and tests keep working unchanged.
+ * clusterByTopic lives in lib/session-branch-tree.ts (a lib module) so the
+ * sidebar order module re-exports it without inverting the app→lib layering.
  */
-export { clusterByTopic } from '@/lib/session-topic-cluster'
+export { clusterByTopic } from '@/lib/session-branch-tree'

--- a/apps/desktop/src/app/chat/sidebar/sessions-section.tsx
+++ b/apps/desktop/src/app/chat/sidebar/sessions-section.tsx
@@ -9,7 +9,7 @@ import { SidebarGroup, SidebarGroupContent } from '@/components/ui/sidebar'
 import type { HermesGitWorktree } from '@/global'
 import type { SessionInfo } from '@/hermes'
 import { useI18n } from '@/i18n'
-import { flattenSessionsWithBranches } from '@/lib/session-branch-tree'
+import { clusterEntriesByTopic, flattenSessionsWithBranches } from '@/lib/session-branch-tree'
 import {
   groupEntriesByRecency,
   groupEntriesByStatus,
@@ -319,6 +319,18 @@ export function SidebarSessionsSection({
     [renderRow]
   )
 
+  // Same as `renderRows`, but re-clusters same-topic sessions after the
+  // flatten step's recency re-sort. Profile/source groups render every
+  // profile's sessions flat, so [Topic]-prefixed rows must stay adjacent
+  // here too — the flat recents path handles this in `flatRows` instead.
+  const renderRowsClustered = useCallback(
+    (items: SessionInfo[]) =>
+      clusterEntriesByTopic(flattenSessionsWithBranches(items)).map(({ branchStem, session }) =>
+        renderRow(session, false, branchStem)
+      ),
+    [renderRow]
+  )
+
   // Same as `renderRows`, but with date dividers folded in — used for
   // entered-project lanes so a lane spanning multiple days reads
   // chronologically, matching the flat recents list.
@@ -334,20 +346,26 @@ export function SidebarSessionsSection({
   )
 
   // Flat recents as list rows: grouped by recency when enabled, plain otherwise.
+  // Same-topic sessions ([凭证]…) are clustered back together after the
+  // flatten step's recency re-sort, before date bucketing inserts dividers.
   // The hand-picked order is then applied INSIDE each date group, so dragging a
   // row ranks it among its own day's chats instead of freezing the whole list
   // into an undated manual mode.
   const flatRows: SidebarListRow[] = useMemo(() => {
+    // Same-topic sessions ([凭证]…) are clustered back together after the
+    // flatten step's recency re-sort, before any grouping inserts dividers.
+    // Pinned / plain lists (grouping === 'none') keep their caller order.
+    const clustered = grouping !== 'none' ? clusterEntriesByTopic(displayEntries) : displayEntries
     const rows =
       grouping === 'date'
-        ? groupEntriesByRecency(displayEntries)
+        ? groupEntriesByRecency(clustered)
         : grouping === 'status'
           ? groupEntriesByStatus(
-              displayEntries,
+              clustered,
               entry => hasLiveTurn(dotStates[entry.session.id] ?? 'idle'),
               statusDividerLabels
             )
-          : toSessionRows(displayEntries)
+          : toSessionRows(clustered)
 
     return manualOrderIds?.length ? orderRowsWithinGroups(rows, manualOrderIds) : rows
   }, [grouping, displayEntries, dotStates, manualOrderIds, statusDividerLabels])
@@ -445,12 +463,14 @@ export function SidebarSessionsSection({
     )
   } else if (groups?.length) {
     // Profile/source groups never reorder; render them flat with static rows.
+    // renderRowsClustered keeps [Topic]-prefixed sessions adjacent after the
+    // flatten step's recency re-sort (flat recents handles this in flatRows).
     inner = groups.map(group => (
       <SidebarWorkspaceGroup
         group={group}
         key={group.id}
         onNewSession={onNewSessionInWorkspace}
-        renderRows={renderRows}
+        renderRows={renderRowsClustered}
       />
     ))
   } else if (flatVirtualized) {

--- a/apps/desktop/src/lib/session-branch-tree.test.ts
+++ b/apps/desktop/src/lib/session-branch-tree.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest'
 
 import type { SessionInfo } from '@/types/hermes'
 
-import { flattenSessionsWithBranches } from './session-branch-tree'
+import { clusterEntriesByTopic, flattenSessionsWithBranches } from './session-branch-tree'
 
 const session = (id: string, overrides: Partial<SessionInfo> = {}): SessionInfo =>
   ({
@@ -79,5 +79,57 @@ describe('flattenSessionsWithBranches', () => {
       { id: 'branch', stem: '└─ ' },
       { id: 'background', stem: undefined }
     ])
+  })
+})
+
+describe('clusterEntriesByTopic', () => {
+  const entry = (id: string, title: string, overrides: Partial<SessionInfo> = {}): { session: SessionInfo } => ({
+    session: session(id, { title, ...overrides })
+  })
+
+  it('keeps unprefixed entries in their original order', () => {
+    const entries = [entry('a', '普通会话'), entry('b', '另一会话')]
+
+    expect(clusterEntriesByTopic(entries)).toEqual(entries)
+  })
+
+  it('pulls same-topic entries together after a recency re-sort scattered them', () => {
+    const entries = [
+      entry('v1', '[凭证]打印', { last_active: 30 }),
+      entry('x', '普通会话', { last_active: 25 }),
+      entry('v2', '[凭证]录入', { last_active: 20 }),
+      entry('d1', '[部署]新服务器', { last_active: 15 }),
+      entry('v3', '[凭证]导入', { last_active: 10 })
+    ]
+
+    expect(clusterEntriesByTopic(entries).map(e => e.session.id)).toEqual([
+      'v1',
+      'v2',
+      'v3',
+      'x',
+      'd1'
+    ])
+  })
+
+  it('moves a parent together with its branch children', () => {
+    const entries = [
+      { session: session('p1', { title: '[业务]流水', last_active: 30 }) },
+      { branchStem: '└─ ', session: session('b1', { title: '[业务]流水分支', last_active: 28, parent_session_id: 'p1' }) },
+      { session: session('mid', { title: '中间会话', last_active: 20 }) },
+      { session: session('p2', { title: '[业务]代账', last_active: 10 }) }
+    ]
+
+    expect(clusterEntriesByTopic(entries).map(e => e.session.id)).toEqual([
+      'p1',
+      'b1',
+      'p2',
+      'mid'
+    ])
+  })
+
+  it('returns a single-entry list untouched', () => {
+    const entries = [entry('only', '[业务]唯一')]
+
+    expect(clusterEntriesByTopic(entries)).toEqual(entries)
   })
 })

--- a/apps/desktop/src/lib/session-branch-tree.ts
+++ b/apps/desktop/src/lib/session-branch-tree.ts
@@ -1,4 +1,5 @@
 import type { SessionInfo } from '@/types/hermes'
+import { clusterByTopic } from '@/lib/session-topic-cluster'
 
 export interface SidebarSessionEntry {
   branchStem?: string
@@ -121,4 +122,41 @@ export function flattenSessionsWithBranches(
   }
 
   return out
+}
+
+/**
+ * Cluster entries whose root session title carries a `[Topic]` prefix so the
+ * whole parent→branches block moves together. Recency sorting inside
+ * flattenSessionsWithBranches reorders roots by group activity, which would
+ * otherwise scatter same-topic conversations across the date buckets; this
+ * runs after flattening (and before date bucketing) to pull them back
+ * together while keeping every block's internal order intact.
+ */
+export function clusterEntriesByTopic(entries: readonly SidebarSessionEntry[]): SidebarSessionEntry[] {
+  // Flatten emits depth-first, so each root is immediately followed by its
+  // branch children — cut blocks at every root.
+  const blocks: SidebarSessionEntry[][] = []
+
+  for (const entry of entries) {
+    if (!entry.branchStem) {
+      blocks.push([entry])
+    } else if (blocks.length) {
+      blocks[blocks.length - 1].push(entry)
+    } else {
+      // Defensive: a stray branch with no root still gets its own block.
+      blocks.push([entry])
+    }
+  }
+
+  if (blocks.length < 2) {
+    return entries as SidebarSessionEntry[]
+  }
+
+  const clustered = clusterByTopic(
+    blocks,
+    block => block[0].session.id,
+    block => block[0].session.title
+  )
+
+  return clustered.flat()
 }

--- a/apps/desktop/src/lib/session-branch-tree.ts
+++ b/apps/desktop/src/lib/session-branch-tree.ts
@@ -1,5 +1,4 @@
 import type { SessionInfo } from '@/types/hermes'
-import { clusterByTopic } from '@/lib/session-topic-cluster'
 
 export interface SidebarSessionEntry {
   branchStem?: string
@@ -159,4 +158,64 @@ export function clusterEntriesByTopic(entries: readonly SidebarSessionEntry[]): 
   )
 
   return clustered.flat()
+}
+
+/**
+ * Cluster items whose titles share a `[Topic]` prefix so they sit adjacent,
+ * while preserving the caller's recency baseline: scan the (recency-sorted)
+ * list and, on first sight of a topic, pull every other item with the same
+ * prefix up to follow it. Untitled / unprefixed items stay in their original
+ * positions. Sibling order inside a cluster follows the baseline order.
+ */
+export function clusterByTopic<T>(
+  items: T[],
+  getId: (item: T) => string,
+  getTitle: (item: T) => string | null | undefined
+): T[] {
+  const topicOf = (title?: string | null) => title?.match(/^\[([^\]]+)\]/)?.[1] ?? null
+
+  const byTopic = new Map<string, T[]>()
+
+  for (const item of items) {
+    const topic = topicOf(getTitle(item))
+
+    if (topic) {
+      const siblings = byTopic.get(topic)
+
+      if (siblings) {
+        siblings.push(item)
+      } else {
+        byTopic.set(topic, [item])
+      }
+    }
+  }
+
+  const placed = new Set<string>()
+  const out: T[] = []
+
+  for (const item of items) {
+    const id = getId(item)
+
+    if (placed.has(id)) {
+      continue
+    }
+
+    out.push(item)
+    placed.add(id)
+
+    const topic = topicOf(getTitle(item))
+
+    if (topic) {
+      for (const sibling of byTopic.get(topic) ?? []) {
+        const siblingId = getId(sibling)
+
+        if (!placed.has(siblingId)) {
+          out.push(sibling)
+          placed.add(siblingId)
+        }
+      }
+    }
+  }
+
+  return out
 }


### PR DESCRIPTION
## Summary
Sessions whose titles carry a `[Topic]` prefix (e.g. `[凭证] ...`) are currently scattered across the sidebar timeline. This PR groups them into adjacent blocks — siblings remain recency-sorted within each group — so related sessions stay visually together. Applies to single-profile and ALL-profiles views.

## Changes
- `apps/desktop/src/app/chat/sidebar/order.ts` — new pure function `clusterByTopic()`
- `apps/desktop/src/app/chat/sidebar/index.tsx` — cluster in the sorted-list data layer
- `apps/desktop/src/app/chat/sidebar/sessions-section.tsx` — cluster fallback for flatRows/groups branches
- `apps/desktop/src/lib/session-branch-tree.ts` — new `clusterEntriesByTopic()` (parent + branches move as a unit)
- `order.test.ts` / `session-branch-tree.test.ts` — unit tests

## Behavior
- `[Topic]`-prefixed sessions cluster together, recency-sorted within the block
- Non-prefixed sessions keep their natural timeline position
- Manual drag order inside groups is preserved

## Testing
- `npx vitest run src/app/chat/sidebar/order.test.ts src/lib/session-branch-tree.test.ts` — 35 passed
- Manual: sidebar renders clusters in single-profile and ALL-profiles views