### PR TITLE
feat(dashboard): expose skill deletion on the Skills page (port of centaur#1393)

### DIFF
--- a/hermes_cli/web_routers/skills.py
+++ b/hermes_cli/web_routers/skills.py
@@ -509,3 +509,36 @@ async def update_skill_content(body: SkillContentUpdate):
         raise HTTPException(status_code=status, detail=err)
     _clear_skills_prompt_cache()
     return result
+
+
+@router.delete("/api/skills")
+async def delete_skill(name: str, profile: Optional[str] = None):
+    """Delete a skill from the dashboard (port of paradigmxyz/centaur#1393).
+
+    Routes through the same guarded delete path as the agent's
+    ``skill_manage`` tool — pinned-skill guard, org-mirror guard, and the
+    skills-root/symlink defense-in-depth all apply. ``absorbed_into=""``
+    declares an explicit user-directed prune (no consolidation target), so
+    the curator classification pipeline doesn't log a legacy warning.
+    A delete from the authenticated dashboard IS the user acting directly,
+    matching the create/update endpoints above.
+    """
+    from tools.skill_manager_tool import _delete_skill
+
+    def _run():
+        with _profile_scope(profile):
+            return _delete_skill(name, absorbed_into="")
+
+    result = await asyncio.to_thread(_run)
+    if not result.get("success"):
+        err = result.get("error", "Failed to delete skill.")
+        err_l = str(err).lower()
+        if "not found" in err_l:
+            status = 404
+        elif "pinned" in err_l:
+            status = 409
+        else:
+            status = 400
+        raise HTTPException(status_code=status, detail=err)
+    _clear_skills_prompt_cache()
+    return result

--- a/tests/hermes_cli/test_web_server_skill_editor.py
+++ b/tests/hermes_cli/test_web_server_skill_editor.py
@@ -144,6 +144,46 @@ class TestSkillUpdate:
         assert resp.status_code == 400
 
 
+class TestSkillDelete:
+    """DELETE /api/skills — port of paradigmxyz/centaur#1393."""
+
+    def test_delete_removes_skill_dir(self, client, isolated_profiles):
+        skill_dir = isolated_profiles["default"] / "skills" / "dashboard-skill"
+        assert skill_dir.exists()
+        resp = client.delete("/api/skills", params={"name": "dashboard-skill"})
+        assert resp.status_code == 200
+        assert resp.json()["success"] is True
+        assert not skill_dir.exists()
+
+    def test_delete_unknown_skill_404(self, client, isolated_profiles):
+        resp = client.delete("/api/skills", params={"name": "no-such-skill"})
+        assert resp.status_code == 404
+
+    def test_delete_scopes_to_profile(self, client, isolated_profiles):
+        worker_dir = isolated_profiles["worker_alpha"] / "skills" / "worker-skill"
+        # Invisible without the profile param...
+        resp = client.delete("/api/skills", params={"name": "worker-skill"})
+        assert resp.status_code == 404
+        assert worker_dir.exists()
+        # ...deleted with it.
+        resp = client.delete(
+            "/api/skills", params={"name": "worker-skill", "profile": "worker_alpha"}
+        )
+        assert resp.status_code == 200
+        assert not worker_dir.exists()
+
+    def test_delete_pinned_skill_409(self, client, isolated_profiles, monkeypatch):
+        import tools.skill_manager_tool as smt
+
+        monkeypatch.setattr(
+            smt, "_pinned_guard", lambda name: f"Skill '{name}' is pinned and cannot be deleted."
+        )
+        skill_dir = isolated_profiles["default"] / "skills" / "dashboard-skill"
+        resp = client.delete("/api/skills", params={"name": "dashboard-skill"})
+        assert resp.status_code == 409
+        assert skill_dir.exists()
+
+
 class TestEditorEndpointsAuth:
     @pytest.mark.parametrize(
         "method,path,kwargs",
@@ -151,6 +191,7 @@ class TestEditorEndpointsAuth:
             ("get", "/api/skills/content?name=dashboard-skill", {}),
             ("post", "/api/skills", {"json": {"name": "x", "content": "y"}}),
             ("put", "/api/skills/content", {"json": {"name": "x", "content": "y"}}),
+            ("delete", "/api/skills?name=dashboard-skill", {}),
         ],
     )
     def test_endpoints_401_without_token(

--- a/web/src/i18n/en.ts
+++ b/web/src/i18n/en.ts
@@ -442,6 +442,11 @@ export const en: Translations = {
     currentProfile: "current ({name})",
     managingProfile:
       "Managing profile \u201c{name}\u201d — toggles apply to that profile, not this dashboard\u2019s.",
+    deleteSkill: "Delete skill",
+    deleteSkillConfirmTitle: "Delete skill \u201c{name}\u201d?",
+    deleteSkillConfirmMessage:
+      "This permanently deletes the skill's folder (SKILL.md plus any scripts and references). Cannot be undone.",
+    skillDeleted: "{name} deleted",
   },
 
   config: {

--- a/web/src/i18n/types.ts
+++ b/web/src/i18n/types.ts
@@ -458,6 +458,10 @@ export interface Translations {
     profileSelector?: string;
     currentProfile?: string;
     managingProfile?: string;
+    deleteSkill?: string;
+    deleteSkillConfirmTitle?: string;
+    deleteSkillConfirmMessage?: string;
+    skillDeleted?: string;
   };
 
   // ── Config page ──

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -764,6 +764,11 @@ export const api = {
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ name, content, profile: profile || undefined }),
     }),
+  deleteSkill: (name: string, profile?: string) =>
+    fetchJSON<SkillWriteResult>(
+      `/api/skills?name=${encodeURIComponent(name)}${profile ? `&profile=${encodeURIComponent(profile)}` : ""}`,
+      { method: "DELETE" },
+    ),
   getToolsets: (profile?: string) =>
     fetchJSON<ToolsetInfo[]>(`/api/tools/toolsets${profileQuery(profile)}`),
   toggleToolset: (name: string, enabled: boolean, profile?: string) =>
@@ -2305,6 +2310,8 @@ export interface SkillInfo {
   description: string;
   category: string;
   enabled: boolean;
+  /** "hub" | "bundled" | "agent" — agent covers agent-authored + hand-made. */
+  provenance?: string;
 }
 
 export interface SkillContent {

--- a/web/src/pages/SkillsPage.tsx
+++ b/web/src/pages/SkillsPage.tsx
@@ -28,6 +28,7 @@ import {
   Loader2,
   Pencil,
   Plus,
+  Trash2,
 } from "lucide-react";
 import { api } from "@/lib/api";
 import type {
@@ -42,6 +43,7 @@ import type {
 import { useProfileScope } from "@/contexts/useProfileScope";
 import { ToolsetConfigDrawer } from "@/components/ToolsetConfigDrawer";
 import { SkillEditorDialog } from "@/components/SkillEditorDialog";
+import { DeleteConfirmDialog } from "@/components/DeleteConfirmDialog";
 import { useToast } from "@nous-research/ui/hooks/use-toast";
 import { Toast } from "@nous-research/ui/ui/components/toast";
 import { Card, CardContent, CardHeader, CardTitle } from "@nous-research/ui/ui/components/card";
@@ -260,6 +262,30 @@ export default function SkillsPage() {
     },
     [selectedProfile, showToast],
   );
+
+  /* ---- Skill delete (port of paradigmxyz/centaur#1393) ---- */
+  // Only agent-authored / hand-made skills get the delete affordance;
+  // bundled and hub skills are managed by their manifests (hub uninstall
+  // lives in the Hub tab; bundled skills are re-seeded on update).
+  const [deleteTarget, setDeleteTarget] = useState<string | null>(null);
+  const [deleting, setDeleting] = useState(false);
+  const handleDeleteSkill = useCallback(async () => {
+    if (!deleteTarget) return;
+    setDeleting(true);
+    try {
+      await api.deleteSkill(deleteTarget, selectedProfile || undefined);
+      setSkills((prev) => prev.filter((s) => s.name !== deleteTarget));
+      showToast(
+        (t.skills.skillDeleted ?? "{name} deleted").replace("{name}", deleteTarget),
+        "success",
+      );
+      setDeleteTarget(null);
+    } catch (e) {
+      showToast(String(e), "error");
+    } finally {
+      setDeleting(false);
+    }
+  }, [deleteTarget, selectedProfile, showToast, t]);
 
   /* ---- Derived data ---- */
   const lowerSearch = search.toLowerCase();
@@ -497,6 +523,8 @@ export default function SkillsPage() {
                         toggling={togglingSkills.has(skill.name)}
                         onToggle={() => handleToggleSkill(skill)}
                         onEdit={() => openEditEditor(skill.name)}
+                        onDelete={() => setDeleteTarget(skill.name)}
+                        deleteLabel={t.skills.deleteSkill ?? "Delete skill"}
                         noDescriptionLabel={t.skills.noDescription}
                       />
                     ))}
@@ -559,6 +587,8 @@ export default function SkillsPage() {
                         toggling={togglingSkills.has(skill.name)}
                         onToggle={() => handleToggleSkill(skill)}
                         onEdit={() => openEditEditor(skill.name)}
+                        onDelete={() => setDeleteTarget(skill.name)}
+                        deleteLabel={t.skills.deleteSkill ?? "Delete skill"}
                         noDescriptionLabel={t.skills.noDescription}
                       />
                     ))}
@@ -670,6 +700,20 @@ export default function SkillsPage() {
         onClose={() => setEditorOpen(false)}
         onSaved={handleEditorSaved}
       />
+      <DeleteConfirmDialog
+        open={deleteTarget !== null}
+        loading={deleting}
+        title={(t.skills.deleteSkillConfirmTitle ?? "Delete skill \u201c{name}\u201d?").replace(
+          "{name}",
+          deleteTarget ?? "",
+        )}
+        description={
+          t.skills.deleteSkillConfirmMessage ??
+          "This permanently deletes the skill's folder (SKILL.md plus any scripts and references). Cannot be undone."
+        }
+        onCancel={() => setDeleteTarget(null)}
+        onConfirm={handleDeleteSkill}
+      />
       <Dialog open={learnOpen} onOpenChange={setLearnOpen}>
         <DialogContent className="max-w-lg">
           <DialogHeader>
@@ -738,6 +782,8 @@ function SkillRow({
   toggling,
   onToggle,
   onEdit,
+  onDelete,
+  deleteLabel,
   noDescriptionLabel,
 }: SkillRowProps) {
   return (
@@ -773,6 +819,21 @@ function SkillRow({
       >
         <Pencil />
       </Button>
+      {/* Delete: only user/agent-authored skills (port of centaur#1393).
+          Bundled skills are re-seeded by updates; hub skills uninstall
+          through the Hub tab so the installed-manifest stays consistent. */}
+      {skill.provenance === "agent" && onDelete && (
+        <Button
+          ghost
+          size="icon"
+          className="shrink-0 text-muted-foreground opacity-0 transition-opacity group-hover:opacity-100 focus-visible:opacity-100 hover:text-destructive"
+          title={deleteLabel}
+          aria-label={`${deleteLabel}: ${skill.name}`}
+          onClick={onDelete}
+        >
+          <Trash2 />
+        </Button>
+      )}
     </div>
   );
 }
@@ -802,7 +863,9 @@ interface PanelItemProps {
 }
 
 interface SkillRowProps {
+  deleteLabel: string;
   noDescriptionLabel: string;
+  onDelete?: () => void;
   onToggle: () => void;
   onEdit: () => void;
   skill: SkillInfo;


### PR DESCRIPTION
## Summary
The dashboard Skills page can now delete agent/hand-authored skills — closing the last gap in its SKILL.md lifecycle (create and edit already existed; removal previously required SSH + `rm -rf`).

Ported from [paradigmxyz/centaur#1393](https://github.com/paradigmxyz/centaur/pull/1393) ("feat: expose skill deletion"), which wired skill archival through their console/CLI surface. Adapted to our architecture: instead of a new endpoint stack, `DELETE /api/skills` reuses the agent's guarded `_delete_skill` path, so every existing safety net applies to dashboard deletes too.

## Ours vs theirs
| | Centaur | This port |
|---|---|---|
| Surface | `centaur-skills` CLI + sandbox DELETE endpoint | Dashboard Skills page + `DELETE /api/skills` |
| Semantics | Archival (recoverable) | Hard delete for user-directed action (matches `skill_manage` foreground semantics); curator-pass deletes stay archival |
| Guards | Owner-only authz | Pinned-skill guard (→ 409), org-mirror guard, skills-root/symlink defense-in-depth, profile scoping |
| Scope | All skills, owner-gated | Only `provenance == "agent"` skills get the affordance — bundled skills are re-seeded by updates, hub skills uninstall via the Hub tab |

## Changes
- `hermes_cli/web_routers/skills.py`: `DELETE /api/skills?name=&profile=` → `_delete_skill(name, absorbed_into="")`; 404 not-found, 409 pinned, 400 guard refusals; clears the skills prompt cache on success.
- `web/src/pages/SkillsPage.tsx`: hover trash button on agent-authored rows, `DeleteConfirmDialog` confirm, optimistic list update.
- `web/src/lib/api.ts`: `deleteSkill()`; `SkillInfo.provenance` typed (the backend already returned it).
- `web/src/i18n/en.ts` + `types.ts`: optional `skills.deleteSkill*` keys (all other locales fall back via `defineLocale`).
- `tests/hermes_cli/test_web_server_skill_editor.py`: delete happy path, unknown-skill 404, profile scoping, pinned 409, 401 without session token.

## Validation
| Check | Result |
|---|---|
| `tests/hermes_cli/test_web_server_skill_editor.py` | 17/17 pass (13 existing + 4 new) |
| `tsc -p web --noEmit` | clean |
| `eslint` on touched files | 0 errors (2 pre-existing warnings in untouched hub code) |

## Infographic

![Dashboard skill deletion infographic](https://files.catbox.moe/w25iij.png)
