### PR TITLE
fix(desktop): localize read-aloud placeholders and announce omitted tables

### DIFF
--- a/apps/desktop/src/i18n/ar.ts
+++ b/apps/desktop/src/i18n/ar.ts
@@ -2325,7 +2325,10 @@ export const ar = defineLocale({
       restoreNext: 'استعادة التالي',
       goForward: 'تقدم',
       sendEdited: 'إرسال التعديل',
-      attachingFile: 'جار إرفاق الملف'
+      attachingFile: 'جار إرفاق الملف',
+      speechCodeBlockOmitted: ' تم حذف كتلة الكود ',
+      speechLink: ' رابط ',
+      speechTableOmitted: ' تم حذف الجدول '
     },
     approval: {
       gatewayDisconnected: 'البوابة غير متصلة',

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -2830,7 +2830,10 @@ export const en: Translations = {
       restoreNext: 'Restore next checkpoint',
       goForward: 'Go forward',
       sendEdited: 'Send edited message',
-      attachingFile: 'Attaching…'
+      attachingFile: 'Attaching…',
+      speechCodeBlockOmitted: ' code block omitted ',
+      speechLink: ' link ',
+      speechTableOmitted: ' table omitted '
     },
     approval: {
       gatewayDisconnected: 'Hermes gateway is not connected',

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -2596,7 +2596,10 @@ export const ja = defineLocale({
       restoreNext: '次のチェックポイントに戻す',
       goForward: '進む',
       sendEdited: '編集済みメッセージを送信',
-      attachingFile: '添付中…'
+      attachingFile: '添付中…',
+      speechCodeBlockOmitted: ' コードブロックを省略しました ',
+      speechLink: ' リンク ',
+      speechTableOmitted: ' 表を省略しました '
     },
     approval: {
       gatewayDisconnected: 'Hermes ゲートウェイが接続されていません',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -2415,6 +2415,9 @@ export interface Translations {
       goForward: string
       sendEdited: string
       attachingFile: string
+      speechCodeBlockOmitted: string
+      speechLink: string
+      speechTableOmitted: string
     }
     approval: {
       gatewayDisconnected: string

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -2514,7 +2514,10 @@ export const zhHant = defineLocale({
       restoreNext: '還原至下一個檢查點',
       goForward: '前進',
       sendEdited: '傳送編輯後的訊息',
-      attachingFile: '正在附加…'
+      attachingFile: '正在附加…',
+      speechCodeBlockOmitted: ' 程式碼區塊已省略 ',
+      speechLink: ' 連結 ',
+      speechTableOmitted: ' 表格已省略 '
     },
     approval: {
       gatewayDisconnected: 'Hermes 閘道未連線',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -3002,7 +3002,10 @@ export const zh: Translations = {
       restoreNext: '恢复下一个检查点',
       goForward: '前进',
       sendEdited: '发送编辑后的消息',
-      attachingFile: '正在附加…'
+      attachingFile: '正在附加…',
+      speechCodeBlockOmitted: ' 代码块已省略 ',
+      speechLink: ' 链接 ',
+      speechTableOmitted: ' 表格已省略 '
     },
     approval: {
       gatewayDisconnected: 'Hermes 网关未连接',

--- a/apps/desktop/src/lib/speech-text.test.ts
+++ b/apps/desktop/src/lib/speech-text.test.ts
@@ -1,12 +1,35 @@
-import { describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { setRuntimeI18nLocale } from '@/i18n'
 
 import { sanitizeTextForSpeech } from './speech-text'
 
 describe('sanitizeTextForSpeech', () => {
+  afterEach(() => {
+    setRuntimeI18nLocale('en')
+  })
+
   it('summarizes fenced code blocks instead of reading them literally', () => {
     expect(sanitizeTextForSpeech('Here is code:\n```ts\nconst x = 1\n```\nDone.')).toBe(
       'Here is code: code block omitted Done.'
     )
+  })
+
+  it('speaks code blocks, links, and omitted tables in the active locale', () => {
+    setRuntimeI18nLocale('zh')
+
+    expect(sanitizeTextForSpeech('Here is code:\n```ts\nconst x = 1\n```\nDone.')).toBe('Here is code: 代码块已省略 Done.')
+    expect(sanitizeTextForSpeech('See https://example.com for details.')).toBe('See 链接 for details.')
+
+    const text = `Before the table.
+
+| Item | Value |
+| --- | ---: |
+| Example A | 10 |
+
+After the table.`
+
+    expect(sanitizeTextForSpeech(text)).toBe('Before the table. 表格已省略. After the table.')
   })
 
   it('still keeps normal prose and inline code readable', () => {
@@ -24,7 +47,7 @@ describe('sanitizeTextForSpeech', () => {
 Full detail stays visible on screen.`
 
     expect(sanitizeTextForSpeech(text)).toBe(
-      'Here is the quick takeaway: the totals remain unchanged. Full detail stays visible on screen.'
+      'Here is the quick takeaway: the totals remain unchanged. table omitted. Full detail stays visible on screen.'
     )
   })
 
@@ -60,7 +83,7 @@ Example B | 20
 
 Done.`
 
-    expect(sanitizeTextForSpeech(text)).toBe('Main takeaway: total is unchanged. Done.')
+    expect(sanitizeTextForSpeech(text)).toBe('Main takeaway: total is unchanged. table omitted. Done.')
   })
 
   it('skips markdown tables nested inside blockquotes', () => {
@@ -73,7 +96,7 @@ Done.`
 
 After the table.`
 
-    expect(sanitizeTextForSpeech(text)).toBe('Before the table. After the table.')
+    expect(sanitizeTextForSpeech(text)).toBe('Before the table. table omitted. After the table.')
   })
 
   it('allows marker padding plus three spaces in blockquoted tables', () => {
@@ -85,7 +108,7 @@ After the table.`
 
 After the table.`
 
-    expect(sanitizeTextForSpeech(text)).toBe('Before the table. After the table.')
+    expect(sanitizeTextForSpeech(text)).toBe('Before the table. table omitted. After the table.')
   })
 
   it('skips explicit single-column markdown tables', () => {
@@ -97,7 +120,7 @@ After the table.`
 
 After the table.`
 
-    expect(sanitizeTextForSpeech(text)).toBe('Before the table. After the table.')
+    expect(sanitizeTextForSpeech(text)).toBe('Before the table. table omitted. After the table.')
   })
 
   it('preserves rows outside a table blockquote', () => {
@@ -106,7 +129,7 @@ After the table.`
 > | Example A | 10 |
 Outside | prose`
 
-    expect(sanitizeTextForSpeech(text)).toBe('Outside | prose')
+    expect(sanitizeTextForSpeech(text)).toBe('table omitted Outside | prose')
   })
 
   it('preserves malformed tables with mismatched column counts', () => {
@@ -127,7 +150,7 @@ Keep this prose.`
 
 After the table.`
 
-    expect(sanitizeTextForSpeech(text)).toBe('Before the table. After the table.')
+    expect(sanitizeTextForSpeech(text)).toBe('Before the table. table omitted. After the table.')
   })
 
   it('skips tables containing escaped pipe characters', () => {
@@ -139,7 +162,7 @@ After the table.`
 
 After the table.`
 
-    expect(sanitizeTextForSpeech(text)).toBe('Before the table. After the table.')
+    expect(sanitizeTextForSpeech(text)).toBe('Before the table. table omitted. After the table.')
   })
 
   it('preserves indented code that resembles a table', () => {

--- a/apps/desktop/src/lib/speech-text.test.ts
+++ b/apps/desktop/src/lib/speech-text.test.ts
@@ -1,12 +1,22 @@
-import { afterEach, describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 
-import { setRuntimeI18nLocale } from '@/i18n'
+import type * as I18nModule from '@/i18n'
 
 import { sanitizeTextForSpeech } from './speech-text'
+
+vi.mock('@/i18n', async importOriginal => {
+  const actual = await importOriginal<typeof I18nModule>()
+
+  return { ...actual, translateNow: vi.fn(actual.translateNow) }
+})
+
+const { setRuntimeI18nLocale, translateNow } = await import('@/i18n')
+const actualI18n = await vi.importActual<typeof I18nModule>('@/i18n')
 
 describe('sanitizeTextForSpeech', () => {
   afterEach(() => {
     setRuntimeI18nLocale('en')
+    vi.mocked(translateNow).mockImplementation(actualI18n.translateNow)
   })
 
   it('summarizes fenced code blocks instead of reading them literally', () => {
@@ -30,6 +40,12 @@ describe('sanitizeTextForSpeech', () => {
 After the table.`
 
     expect(sanitizeTextForSpeech(text)).toBe('Before the table. 表格已省略. After the table.')
+  })
+
+  it('treats a translated placeholder as literal text, not a $-pattern', () => {
+    vi.mocked(translateNow).mockImplementation(key => (key === 'assistant.thread.speechCodeBlockOmitted' ? '$&' : ''))
+
+    expect(sanitizeTextForSpeech('Here is code:\n```ts\nconst x = 1\n```\nDone.')).toBe('Here is code: $& Done.')
   })
 
   it('still keeps normal prose and inline code readable', () => {
@@ -86,7 +102,7 @@ Done.`
     expect(sanitizeTextForSpeech(text)).toBe('Main takeaway: total is unchanged. table omitted. Done.')
   })
 
-  it('skips markdown tables nested inside blockquotes', () => {
+  it('announces omitted markdown tables nested inside blockquotes', () => {
     const text = `Before the table.
 
 > | Item | Value |
@@ -111,7 +127,7 @@ After the table.`
     expect(sanitizeTextForSpeech(text)).toBe('Before the table. table omitted. After the table.')
   })
 
-  it('skips explicit single-column markdown tables', () => {
+  it('announces omission of explicit single-column markdown tables', () => {
     const text = `Before the table.
 
 | Item |

--- a/apps/desktop/src/lib/speech-text.ts
+++ b/apps/desktop/src/lib/speech-text.ts
@@ -1,7 +1,8 @@
+import { translateNow } from '@/i18n'
+
 const EMOJI_RE = /(?:[\u{1F000}-\u{1FAFF}\u{2600}-\u{27BF}]|[\u{FE0F}\u{200D}]|[\u{E0020}-\u{E007F}])+/gu
 
 const FENCED_CODE_RE = /```[\s\S]*?(?:```|$)/g
-const CODE_BLOCK_SUMMARY = ' code block omitted '
 const INLINE_CODE_RE = /`([^`]+)`/g
 const MARKDOWN_LINK_RE = /\[([^\]]+)\]\(([^)]+)\)/g
 const PARAGRAPH_BREAK_RE = /[ \t]*\n{2,}[ \t]*/g
@@ -102,6 +103,7 @@ function parseMarkdownTableRow(line: string): MarkdownTableRow | null {
 function stripMarkdownTables(text: string): string {
   const lines = text.replace(/\r\n?/g, '\n').split('\n')
   const tableLines = new Set<number>()
+  const tableStarts = new Set<number>()
 
   let index = 1
 
@@ -121,6 +123,7 @@ function stripMarkdownTables(text: string): string {
       continue
     }
 
+    tableStarts.add(index - 1)
     tableLines.add(index - 1)
     tableLines.add(index)
 
@@ -139,7 +142,13 @@ function stripMarkdownTables(text: string): string {
     index = rowIndex
   }
 
-  return lines.filter((_, index) => !tableLines.has(index)).join('\n')
+  // Replace each table's header line with a spoken notice instead of removing
+  // it silently — otherwise table content vanishes from the audio with no
+  // indication anything was there.
+  return lines
+    .map((line, lineIndex) => (tableStarts.has(lineIndex) ? translateNow('assistant.thread.speechTableOmitted') : line))
+    .filter((_, lineIndex) => !tableLines.has(lineIndex) || tableStarts.has(lineIndex))
+    .join('\n')
 }
 
 function normalizeLineBreaks(text: string): string {
@@ -153,11 +162,11 @@ function normalizeLineBreaks(text: string): string {
 
 export function sanitizeTextForSpeech(text: string): string {
   return normalizeLineBreaks(stripMarkdownTables(text))
-    .replace(FENCED_CODE_RE, CODE_BLOCK_SUMMARY)
+    .replace(FENCED_CODE_RE, translateNow('assistant.thread.speechCodeBlockOmitted'))
     .replace(THINKING_PREFIX_RE, ' ')
     .replace(MARKDOWN_LINK_RE, '$1')
     .replace(INLINE_CODE_RE, '$1')
-    .replace(URL_RE, ' link ')
+    .replace(URL_RE, translateNow('assistant.thread.speechLink'))
     .replace(EMOJI_RE, ' ')
     .replace(/^#{1,6}\s+/gm, '')
     .replace(/[*_~>#]/g, '')

--- a/apps/desktop/src/lib/speech-text.ts
+++ b/apps/desktop/src/lib/speech-text.ts
@@ -160,13 +160,16 @@ function normalizeLineBreaks(text: string): string {
     .replace(SOFT_BREAK_RE, ' ')
 }
 
+/** Locale-dependent: placeholders come from `translateNow`, which reads the
+ *  runtime i18n locale — callers outside the i18n runtime (or before locale
+ *  init) get the default locale's copy. */
 export function sanitizeTextForSpeech(text: string): string {
   return normalizeLineBreaks(stripMarkdownTables(text))
-    .replace(FENCED_CODE_RE, translateNow('assistant.thread.speechCodeBlockOmitted'))
+    .replace(FENCED_CODE_RE, () => translateNow('assistant.thread.speechCodeBlockOmitted'))
     .replace(THINKING_PREFIX_RE, ' ')
     .replace(MARKDOWN_LINK_RE, '$1')
     .replace(INLINE_CODE_RE, '$1')
-    .replace(URL_RE, translateNow('assistant.thread.speechLink'))
+    .replace(URL_RE, () => translateNow('assistant.thread.speechLink'))
     .replace(EMOJI_RE, ' ')
     .replace(/^#{1,6}\s+/gm, '')
     .replace(/[*_~>#]/g, '')


### PR DESCRIPTION
## What does this PR do?

Desktop **Read Aloud** hardcoded English placeholder text instead of going through the existing desktop i18n system:

- `apps/desktop/src/lib/speech-text.ts` spoke the literal English words **"code block omitted"** for fenced code blocks and **"link"** for URLs, regardless of the active locale/voice.
- Markdown **tables were silently dropped** from the spoken text with no notice at all — content just vanished from the audio.

This fix:
- Adds `assistant.thread.speechCodeBlockOmitted`, `assistant.thread.speechLink`, and `assistant.thread.speechTableOmitted` to the `Translations` contract (`src/i18n/types.ts`) and provides translations for all 5 shipped locales (`en`, `zh`, `zh-hant`, `ja`, `ar`).
- Routes the code-block and URL placeholders in `speech-text.ts` through `translateNow(...)` instead of hardcoded English constants.
- Changes `stripMarkdownTables()` to replace a detected table's header line with a localized "table omitted" notice instead of removing the whole table with no trace, while still stripping the remaining table rows from the spoken text.

## Related Issue

Fixes #86602

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/src/i18n/types.ts` — add 3 new string keys under `assistant.thread`
- `apps/desktop/src/i18n/{en,zh,zh-hant,ja,ar}.ts` — add localized copy for the 3 new keys
- `apps/desktop/src/lib/speech-text.ts` — use `translateNow()` for the code-block/link placeholders; emit a localized notice for omitted tables instead of silent removal
- `apps/desktop/src/lib/speech-text.test.ts` — update existing table-stripping assertions to expect the new spoken notice, and add a test proving the placeholders follow the active runtime locale (`setRuntimeI18nLocale('zh')`)

## How to Test

1. `cd apps/desktop && npx vitest run --project ui src/lib/speech-text.test.ts` — 18/18 pass.
2. Confirmed the new/updated assertions fail on the pre-fix code: checked out the previous version of `speech-text.ts` (`git checkout HEAD~1 -- apps/desktop/src/lib/speech-text.ts`) against the new test file and got 9 failures (the localized-placeholder test and every table-stripping test that now expects a spoken notice), then restored the fix and reran — all 18 pass again.
3. `npx tsc -p . --noEmit` (apps/desktop) — passes.
4. `npx eslint src/lib/speech-text.ts src/lib/speech-text.test.ts src/i18n/types.ts src/i18n/en.ts src/i18n/zh.ts src/i18n/zh-hant.ts src/i18n/ja.ts src/i18n/ar.ts` (apps/desktop) — no findings.
5. `npx vitest run --project ui src/lib` (apps/desktop) — 674/674 pass (no regressions in the broader lib suite).

### Test output (targeted run)

```
 Test Files  1 passed (1)
      Tests  18 passed (18)
```

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix (no unrelated commits)
- [x] I've added tests for my changes
- [ ] I've tested on my platform — not run on a physical machine; verified via the Vitest suite only (no TTS provider / audio device in this environment)

### Documentation & Housekeeping

- [x] N/A — no config keys, docs, or tool schemas changed

---

This change was written with AI assistance (Claude Code) and verified by running the project's real test suite, typecheck, and lint locally before pushing.
