### PR TITLE
fix(streaming): raise ProviderStreamError for choiceless in-stream error chunks

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -3926,9 +3926,19 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                 _err_type = getattr(chunk, "error_type", None)
                 _err_msg = getattr(chunk, "error_message", None)
                 if _err_type or _err_msg:
-                    raise RuntimeError(
-                        f"Provider in-stream error"
-                        f" ({_err_type or 'unknown'}): {_err_msg or chunk}"
+                    _status = _status_code_from_payload(
+                        {"code": _err_type, "message": _err_msg}
+                    ) or _status_code_from_value(_err_type)
+                    raise ProviderStreamError(
+                        status_code=_status,
+                        body=_provider_error_body(
+                            {
+                                "code": _err_type or "provider_in_stream_error",
+                                "message": str(_err_msg or chunk),
+                            },
+                            _status,
+                        ),
+                        raw_text=f"{_err_type}: {_err_msg}",
                     )
                 continue
 

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -3916,6 +3916,20 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                 # Usage comes in the final chunk with empty choices
                 if hasattr(chunk, "usage") and chunk.usage:
                     usage_obj = chunk.usage
+                # Some OpenAI-compatible providers (DeepInfra, etc.)
+                # return validation errors as in-stream error chunks:
+                # choices=None with error_type/error_message in
+                # model_extra.  Without this check the error is
+                # silently dropped and the stream ends empty →
+                # EmptyStreamError → misleading "empty stream" message
+                # and pointless retries on the same bad request. (#65631)
+                _err_type = getattr(chunk, "error_type", None)
+                _err_msg = getattr(chunk, "error_message", None)
+                if _err_type or _err_msg:
+                    raise RuntimeError(
+                        f"Provider in-stream error"
+                        f" ({_err_type or 'unknown'}): {_err_msg or chunk}"
+                    )
                 continue
 
             delta = chunk.choices[0].delta

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -5652,6 +5652,49 @@ class TestStreamingApiCall:
         assert "Rate limit exceeded" in str(exc)
         agent.stream_delta_callback.assert_not_called()
 
+    def test_choiceless_error_chunk_raises_provider_stream_error(self, agent):
+        """DeepInfra-style in-stream error: choices=None + error_type/error_message.
+
+        Regression for #65631: the choiceless-chunk skip silently dropped
+        error-bearing chunks, the stream ended empty, and the caller got a
+        misleading EmptyStreamError plus pointless retries of the same bad
+        request. The chunk must instead surface as ProviderStreamError so
+        the classifier sees the real provider error.
+        """
+        err_chunk = SimpleNamespace(
+            model="test/model",
+            choices=None,
+            error_type="400 BadRequestError",
+            error_message="context length exceeded",
+        )
+        agent.client.chat.completions.create.return_value = iter([err_chunk])
+        agent.stream_delta_callback = MagicMock()
+
+        with pytest.raises(Exception) as exc_info:
+            agent._interruptible_streaming_api_call({"messages": []})
+
+        exc = exc_info.value
+        assert type(exc).__name__ == "ProviderStreamError"
+        assert getattr(exc, "status_code", None) == 400
+        assert "context length exceeded" in str(exc)
+        agent.stream_delta_callback.assert_not_called()
+
+    def test_choiceless_usage_only_chunk_still_skipped(self, agent):
+        """Usage-only final chunks (choices empty, no error fields) keep flowing."""
+        usage = SimpleNamespace(prompt_tokens=1, completion_tokens=2, total_tokens=3)
+        chunks = [
+            _make_chunk(content="Hi"),
+            _make_chunk(finish_reason="stop"),
+            SimpleNamespace(model="test/model", choices=[], usage=usage),
+        ]
+        agent.client.chat.completions.create.return_value = iter(chunks)
+        agent.stream_delta_callback = MagicMock()
+
+        resp = agent._interruptible_streaming_api_call({"messages": []})
+
+        assert resp.choices[0].message.content == "Hi"
+        assert resp.choices[0].finish_reason == "stop"
+
     def test_named_non_json_sse_error_preserves_provider_message(self, agent):
         """SDK-level plain-text SSE errors retain their actionable message."""
         import httpx


### PR DESCRIPTION
## Summary
Error chunks with `choices=None` carrying provider-specific `error_type` / `error_message` fields (DeepInfra et al.) now raise `ProviderStreamError` instead of being silently skipped by the choiceless-chunk guard — so the real provider error (e.g. context-length 400) reaches the classifier instead of surfacing as a misleading `EmptyStreamError` with blind retries of the same bad request.

Fixes #65631. Salvaged from #65643 by @AlexFucuson9 with authorship preserved. Sibling variant of #86496 (merged earlier today): that fix covered errors encoded as SSE **text frames**; this one covers errors encoded as chunk **object fields**. Follow-up commit upgrades the raise from the original `RuntimeError` to the `ProviderStreamError` plumbing #86496 introduced, so both variants flow through one classification path with status/normalized body.

## Changes
- `agent/chat_completion_helpers.py`: choiceless-chunk skip inspects `error_type`/`error_message` first; raises `ProviderStreamError` with extracted status + OpenAI-shape body
- `tests/run_agent/test_run_agent.py`: choiceless error chunk → ProviderStreamError w/ status 400 (sabotage-verified: fails without the fix); usage-only choiceless chunk still skipped

## Validation
| | Before | After |
|---|---|---|
| choices=None + error fields | dropped → EmptyStreamError → blind retries | ProviderStreamError(400) → classifier |
| usage-only final chunk | skipped | skipped (regression-tested) |
| targeted tests | — | 335 passed (run_agent 256 + error_classifier 79) |

## Infographic

![choiceless error chunks](https://files.catbox.moe/wow327.png)
