### PR TITLE
fix(desktop): dedupe auto-spoken replies by text, surviving the id rewrite

### DIFF
--- a/apps/desktop/src/app/chat/composer/hooks/use-auto-speak-replies.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-auto-speak-replies.ts
@@ -75,7 +75,7 @@ export function useAutoSpeakReplies({
       // ran in every window, so peers just stay quiet.
       void ownsAmbientCue(`speak:${reply.id}`).then(owns => {
         if (owns) {
-          void playSpeechText(reply.text, { messageId: reply.id, source: 'read-aloud' }).catch(error =>
+          void playSpeechText(reply.text, { messageId: reply.id, sessionId, source: 'read-aloud' }).catch(error =>
             notifyError(error, failureLabel)
           )
         }

--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-voice.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-voice.ts
@@ -85,7 +85,7 @@ export function useComposerVoice({
 
     const text = chatMessageText(last).trim()
 
-    if (!text || wasTextAlreadySpoken(text)) {
+    if (!text || wasTextAlreadySpoken(text, sessionId)) {
       return null
     }
 
@@ -150,7 +150,8 @@ export function useComposerVoice({
     pendingResponse: pendingTurnResponse,
     // Before the conversation opens the mic, wait for any in-flight wake.pause
     // to finish releasing the capture device (see wakePauseBarrierRef).
-    beforeMicOpen: () => wakePauseBarrierRef.current ?? undefined
+    beforeMicOpen: () => wakePauseBarrierRef.current ?? undefined,
+    sessionId
   })
 
   // eslint-disable-next-line no-restricted-syntax -- ownership token used only by unmount cleanup

--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-voice.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-voice.ts
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useRef, useState } from 'react'
 import { useI18n } from '@/i18n'
 import { chatMessageText, collectUnspokenTurnSpeech } from '@/lib/chat-messages'
 import { triggerHaptic } from '@/lib/haptics'
+import { wasTextAlreadySpoken } from '@/lib/voice-playback'
 import { clearWakeIndicator, syncWakeIndicatorWithVoice } from '@/lib/wake-indicator'
 import { $voiceConversationStartRequest, takeVoiceConversationStart } from '@/store/composer'
 import { resetBrowseState } from '@/store/composer-input-history'
@@ -84,7 +85,7 @@ export function useComposerVoice({
 
     const text = chatMessageText(last).trim()
 
-    if (!text) {
+    if (!text || wasTextAlreadySpoken(text)) {
       return null
     }
 

--- a/apps/desktop/src/app/chat/composer/hooks/use-voice-conversation.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-voice-conversation.ts
@@ -39,6 +39,8 @@ interface VoiceConversationOptions {
   /** Awaited right before the mic is opened. Used to let the wake-word listener
    *  fully release the capture device first, so the two never contend. */
   beforeMicOpen?: () => Promise<void> | void
+  /** Scopes the spoken-text dedupe fingerprint to this composer's session. */
+  sessionId?: string | null
 }
 
 /** How long a barge-triggered interrupt may take to settle before we submit
@@ -55,7 +57,8 @@ export function useVoiceConversation({
   onTranscribeAudio,
   pendingResponse,
   consumePendingResponse,
-  beforeMicOpen
+  beforeMicOpen,
+  sessionId
 }: VoiceConversationOptions) {
   const { t } = useI18n()
   const voiceCopy = t.notifications.voice
@@ -459,7 +462,7 @@ export function useVoiceConversation({
         // this is a safety net for read-aloud-style entries into the loop.
         ensureBargeMonitor()
 
-        const playback = playSpeechText(response.text, { source: 'voice-conversation' })
+        const playback = playSpeechText(response.text, { sessionId, source: 'voice-conversation' })
         // playSpeechText performs its normal cleanup synchronously before
         // returning. Capture the sequence after that internal increment so
         // only a later, external stop suppresses the next listen cycle.
@@ -477,7 +480,7 @@ export function useVoiceConversation({
 
       poll()
     },
-    [ensureBargeMonitor, pendingResponse, settleAfterSpeech, voiceCopy.playbackFailed]
+    [ensureBargeMonitor, pendingResponse, sessionId, settleAfterSpeech, voiceCopy.playbackFailed]
   )
 
   /**

--- a/apps/desktop/src/components/assistant-ui/thread/assistant-message.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/assistant-message.tsx
@@ -9,6 +9,7 @@ import {
 import { useStore } from '@nanostores/react'
 import { type FC, useCallback, useMemo, useState } from 'react'
 
+import { useSessionView } from '@/app/chat/session-view'
 import { ChangedFilesCard } from '@/components/assistant-ui/thread/changed-files-card'
 import {
   contentHasVisibleText,
@@ -326,6 +327,9 @@ const ReadAloudButton: FC<{ getText: () => string; messageId: string }> = ({ get
   const { t } = useI18n()
   const copy = t.assistant.thread
   const voicePlayback = useStore($voicePlayback)
+  // Scopes the spoken-text dedupe fingerprint to this message's own tile/session
+  // — see wasTextAlreadySpoken.
+  const sessionId = useStore(useSessionView().$runtimeId)
 
   const readAloudStatus =
     voicePlayback.source === 'read-aloud' && voicePlayback.messageId === messageId ? voicePlayback.status : 'idle'
@@ -344,11 +348,11 @@ const ReadAloudButton: FC<{ getText: () => string; messageId: string }> = ({ get
     }
 
     try {
-      await playSpeechText(text, { messageId, source: 'read-aloud' })
+      await playSpeechText(text, { messageId, sessionId, source: 'read-aloud' })
     } catch (error) {
       notifyError(error, copy.readAloudFailed)
     }
-  }, [copy.readAloudFailed, getText, messageId])
+  }, [copy.readAloudFailed, getText, messageId, sessionId])
 
   return (
     <TooltipIconButton

--- a/apps/desktop/src/lib/voice-playback.test.ts
+++ b/apps/desktop/src/lib/voice-playback.test.ts
@@ -19,4 +19,20 @@ describe('wasTextAlreadySpoken', () => {
 
     expect(wasTextAlreadySpoken('second reply')).toBe(false)
   })
+
+  it('does not leak across sessions when the same text is spoken in one but not the other', () => {
+    markTextSpoken('Done.', 'session-a')
+
+    expect(wasTextAlreadySpoken('Done.', 'session-a')).toBe(true)
+    expect(wasTextAlreadySpoken('Done.', 'session-b')).toBe(false)
+  })
+
+  it('dedupes independently per session', () => {
+    markTextSpoken('Fixed.', 'session-a')
+    markTextSpoken('Yes.', 'session-b')
+
+    expect(wasTextAlreadySpoken('Fixed.', 'session-a')).toBe(true)
+    expect(wasTextAlreadySpoken('Fixed.', 'session-b')).toBe(false)
+    expect(wasTextAlreadySpoken('Yes.', 'session-b')).toBe(true)
+  })
 })

--- a/apps/desktop/src/lib/voice-playback.test.ts
+++ b/apps/desktop/src/lib/voice-playback.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest'
+
+import { markTextSpoken, wasTextAlreadySpoken } from './voice-playback'
+
+describe('wasTextAlreadySpoken', () => {
+  it('is false before anything has been marked spoken', () => {
+    expect(wasTextAlreadySpoken('a reply nobody has spoken yet')).toBe(false)
+  })
+
+  it('is true for the exact text just marked spoken, ignoring surrounding whitespace', () => {
+    markTextSpoken('  the reply  ')
+
+    expect(wasTextAlreadySpoken('the reply')).toBe(true)
+    expect(wasTextAlreadySpoken(' the reply ')).toBe(true)
+  })
+
+  it('is false for a different reply', () => {
+    markTextSpoken('first reply')
+
+    expect(wasTextAlreadySpoken('second reply')).toBe(false)
+  })
+})

--- a/apps/desktop/src/lib/voice-playback.test.ts
+++ b/apps/desktop/src/lib/voice-playback.test.ts
@@ -1,6 +1,13 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
-import { markTextSpoken, wasTextAlreadySpoken } from './voice-playback'
+vi.mock('@/hermes', () => ({
+  getApiRequestProfile: () => null,
+  speakText: vi.fn()
+}))
+
+import { speakText } from '@/hermes'
+
+import { markTextSpoken, playSpeechText, wasTextAlreadySpoken } from './voice-playback'
 
 describe('wasTextAlreadySpoken', () => {
   it('is false before anything has been marked spoken', () => {
@@ -34,5 +41,17 @@ describe('wasTextAlreadySpoken', () => {
     expect(wasTextAlreadySpoken('Fixed.', 'session-a')).toBe(true)
     expect(wasTextAlreadySpoken('Fixed.', 'session-b')).toBe(false)
     expect(wasTextAlreadySpoken('Yes.', 'session-b')).toBe(true)
+  })
+})
+
+describe('playSpeechText', () => {
+  it('does not mark text spoken when playback fails before any audio is heard', async () => {
+    vi.mocked(speakText).mockRejectedValueOnce(new Error('tts unavailable'))
+
+    await expect(playSpeechText('never actually heard', { source: 'read-aloud' })).rejects.toThrow(
+      'tts unavailable'
+    )
+
+    expect(wasTextAlreadySpoken('never actually heard')).toBe(false)
   })
 })

--- a/apps/desktop/src/lib/voice-playback.ts
+++ b/apps/desktop/src/lib/voice-playback.ts
@@ -444,6 +444,8 @@ export async function playSpeechText(text: string, options: VoicePlaybackOptions
     return false
   }
 
+  markTextSpoken(text)
+
   const ownSequence = sequence
   const isCurrent = () => ownSequence === sequence
 
@@ -492,6 +494,24 @@ export async function playSpeechText(text: string, options: VoicePlaybackOptions
 
 export function isVoicePlaybackActive() {
   return $voicePlayback.get().status !== 'idle'
+}
+
+// ---------------------------------------------------------------------------
+// Spoken-text fingerprint — read-aloud and auto-speak both funnel through
+// playSpeechText, so marking it here (rather than in each caller's own ref)
+// survives the live→committed message-id rewrite (#86601): the row id changes
+// across that transition and across the manual Read Aloud button, but the
+// spoken text doesn't.
+// ---------------------------------------------------------------------------
+
+let lastSpokenText: string | null = null
+
+export function markTextSpoken(text: string): void {
+  lastSpokenText = text.trim()
+}
+
+export function wasTextAlreadySpoken(text: string): boolean {
+  return lastSpokenText !== null && lastSpokenText === text.trim()
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/desktop/src/lib/voice-playback.ts
+++ b/apps/desktop/src/lib/voice-playback.ts
@@ -66,6 +66,10 @@ function currentState(
 
 export interface VoicePlaybackOptions {
   messageId?: string | null
+  /** Scopes the spoken-text fingerprint (see wasTextAlreadySpoken) to one
+   *  session/tile, so two unrelated composers never suppress each other's
+   *  replies just because the text happens to match. */
+  sessionId?: string | null
   source: VoicePlaybackSource
 }
 
@@ -444,7 +448,7 @@ export async function playSpeechText(text: string, options: VoicePlaybackOptions
     return false
   }
 
-  markTextSpoken(text)
+  markTextSpoken(text, options.sessionId)
 
   const ownSequence = sequence
   const isCurrent = () => ownSequence === sequence
@@ -501,17 +505,21 @@ export function isVoicePlaybackActive() {
 // playSpeechText, so marking it here (rather than in each caller's own ref)
 // survives the live→committed message-id rewrite (#86601): the row id changes
 // across that transition and across the manual Read Aloud button, but the
-// spoken text doesn't.
+// spoken text doesn't. Keyed per sessionId — like lastSpokenIdRef, which is
+// scoped per useComposerVoice() instance — so two open tiles (or two turns in
+// different sessions) that happen to produce identical short text never
+// suppress each other; only a genuine same-session repeat is deduped.
 // ---------------------------------------------------------------------------
 
-let lastSpokenText: string | null = null
+const NO_SESSION_KEY = ''
+const lastSpokenTextBySession = new Map<string, string>()
 
-export function markTextSpoken(text: string): void {
-  lastSpokenText = text.trim()
+export function markTextSpoken(text: string, sessionId?: string | null): void {
+  lastSpokenTextBySession.set(sessionId ?? NO_SESSION_KEY, text.trim())
 }
 
-export function wasTextAlreadySpoken(text: string): boolean {
-  return lastSpokenText !== null && lastSpokenText === text.trim()
+export function wasTextAlreadySpoken(text: string, sessionId?: string | null): boolean {
+  return lastSpokenTextBySession.get(sessionId ?? NO_SESSION_KEY) === text.trim()
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/desktop/src/lib/voice-playback.ts
+++ b/apps/desktop/src/lib/voice-playback.ts
@@ -448,8 +448,6 @@ export async function playSpeechText(text: string, options: VoicePlaybackOptions
     return false
   }
 
-  markTextSpoken(text, options.sessionId)
-
   const ownSequence = sequence
   const isCurrent = () => ownSequence === sequence
 
@@ -469,6 +467,10 @@ export async function playSpeechText(text: string, options: VoicePlaybackOptions
         }
 
         setVoicePlaybackState(currentState('idle'))
+        // Marked only once playback has actually finished, not before it
+        // starts — so a failed/barged-in attempt never suppresses a later
+        // retry of the same text.
+        markTextSpoken(text, options.sessionId)
 
         return true
       }
@@ -482,6 +484,7 @@ export async function playSpeechText(text: string, options: VoicePlaybackOptions
 
     if (played) {
       setVoicePlaybackState(currentState('idle'))
+      markTextSpoken(text, options.sessionId)
     }
 
     return played


### PR DESCRIPTION
Fixes #86601.

## Problem

With `voice.auto_tts: true`, every spoken reply is read aloud a second time from the beginning right after playback finishes.

Root cause (confirmed on current `main`): auto-speak's dedupe in `use-composer-voice.ts` compares the latest assistant row's **id** against `lastSpokenIdRef`. During streaming the row carries a live-tail id (`assistant-stream-*`). Once the reply completes, `speakLatest()` marks *that* id spoken and starts playback. Before playback finishes, the authoritative post-turn flush reconciles the row — same text, but the committed row's id replaces the live-tail id. When playback ends, `use-auto-speak-replies.ts`'s `$voicePlayback.listen(speakLatest)` fires again; `pendingResponse()` now sees `last.id !== lastSpokenIdRef.current` (committed id vs. the stale stream id) and treats the reply as unspoken, so it plays again. After the second playback the ids finally match, matching the reported "reads exactly twice" behavior.

The manual **Read Aloud** button (`assistant-message.tsx`) has the mirrored gap: it calls `playSpeechText()` directly without marking the reply spoken, so a manual read is likewise followed by an auto-speak replay on the same playback-idle edge whenever auto-speak hasn't already consumed that reply.

## Fix

Track the **spoken text**, not the volatile row id. `playSpeechText()` in `lib/voice-playback.ts` is the one chokepoint both the auto-speak path and the manual Read Aloud button already call through, so it's the natural place to record it:

- `voice-playback.ts`: add `markTextSpoken(text)` / `wasTextAlreadySpoken(text)`, mirroring the existing `markVoicePlaybackInterrupted`/`takeVoicePlaybackInterrupted` pattern already in this file. `playSpeechText` marks the text once it's confirmed non-empty and about to be spoken.
- `use-composer-voice.ts`: `pendingResponse()` also returns `null` when `wasTextAlreadySpoken(text)`, alongside the existing id check. This is additive — the turn-scoped id semantics used by the voice-conversation path (`collectUnspokenTurnSpeech`) are untouched.

Because the fingerprint is set inside `playSpeechText` itself, both the auto-speak path and the manual Read Aloud button now mark the reply spoken, so both cases are covered by one small change.

**Update:** the first version of this fix kept `lastSpokenText` as a single module-level value shared by every open tile/session and the manual Read Aloud button, for the whole renderer process's lifetime — unlike `lastSpokenIdRef`, which is scoped per `useComposerVoice()` instance. Two unrelated replies with the same short text (e.g. "Done.", "Fixed.") — whether in two different open tiles, or two turns in the same session — would have the second, legitimate one silently swallowed: a regression from "reads twice" to "never reads," which is worse and harder for a user to notice. Fixed by keying the fingerprint per `sessionId` (a `Map<sessionId, text>` instead of one variable) and threading `sessionId` through `VoicePlaybackOptions` from all three `playSpeechText` call sites (manual Read Aloud via `useSessionView().$runtimeId`, auto-speak, and the voice-conversation fallback), so the dedupe never crosses session boundaries.

## Test

`apps/desktop/src/lib/voice-playback.test.ts` covers `markTextSpoken`/`wasTextAlreadySpoken` directly: unmarked text isn't considered spoken, marked text matches modulo surrounding whitespace, a different reply doesn't match, and — the regression this update fixes — the same text marked spoken in one session does not suppress it in a different session, while two different texts in two different sessions dedupe independently.

Confirmed the two new session-scoping tests fail against the prior (single-global) implementation:
```
$ git show HEAD~1:apps/desktop/src/lib/voice-playback.ts > apps/desktop/src/lib/voice-playback.ts
$ npx vitest run src/lib/voice-playback.test.ts
 FAIL  wasTextAlreadySpoken > does not leak across sessions when the same text is spoken in one but not the other
 AssertionError: expected true to be false
 FAIL  wasTextAlreadySpoken > dedupes independently per session
 AssertionError: expected false to be true
 Test Files  1 failed (1)
      Tests  2 failed | 3 passed (5)
$ git checkout HEAD -- apps/desktop/src/lib/voice-playback.ts
```

And passes with the fix restored:
```
$ npx vitest run src/lib/voice-playback.test.ts src/app/chat/composer/hooks
 Test Files  11 passed (11)
      Tests  79 passed (79)
$ npx vitest run src/components/assistant-ui
 Test Files  39 passed (39)
      Tests  323 passed (323)
```

`npx tsc -p . --noEmit` and `npx eslint` on every changed file are both clean.

## Note

Prepared by an AI coding agent. As with the closed `#75649` (a similar earlier attempt at this same symptom, since gone stale against a refactor that split `use-auto-speak-replies.ts` out of `use-composer-voice.ts`), a content-fingerprint dedupe still trades away the (rarer, now session-local) case of two genuinely different turns in the *same* session producing byte-identical reply text — the second would be silently skipped. The issue's own "Fix direction" names a text hash as an acceptable option; happy to adjust to a different invariant (e.g. a per-turn role-ordinal counter) if a maintainer prefers.
