### PR TITLE
fix(display): avoid false failure status for successful web_extract

### DIFF
--- a/agent/display.py
+++ b/agent/display.py
@@ -1347,6 +1347,19 @@ def _detect_tool_failure(tool_name: str, result: str | None) -> tuple[bool, str]
 
     data = safe_json_loads(result)
 
+    # web_extract always returns a structured results list whose entries include
+    # an ``error`` key on both success (null) and failure (message).  The generic
+    # string heuristic below therefore produces a false positive for every
+    # successful extraction.  Honor the tool's canonical per-result error value
+    # instead, while preserving failures for mixed or all-error batches.
+    if tool_name == "web_extract" and isinstance(data, dict):
+        results = data.get("results")
+        if isinstance(results, list):
+            for entry in results:
+                if isinstance(entry, dict) and entry.get("error"):
+                    return True, f" [{_trim_error(str(entry['error']))}]"
+            return False, ""
+
     # Terminal: non-zero exit code is the canonical failure signal.
     if tool_name == "terminal":
         if isinstance(data, dict):

--- a/tests/agent/test_display_tool_failure.py
+++ b/tests/agent/test_display_tool_failure.py
@@ -96,6 +96,18 @@ class TestDetectToolFailureStructured:
         result = json.dumps({"success": True, "data": "hello"})
         assert _detect_tool_failure("web_search", result) == (False, "")
 
+    def test_web_extract_null_nested_error_not_flagged(self):
+        result = json.dumps({
+            "results": [
+                {
+                    "url": "https://example.com",
+                    "content": "Example Domain",
+                    "error": None,
+                }
+            ]
+        })
+        assert _detect_tool_failure("web_extract", result) == (False, "")
+
 
 
 class TestGetCuteToolMessageFailureSuffix:


### PR DESCRIPTION
## Summary
- classify `web_extract` results using the structured per-result `error` field
- avoid false failure suffixes when successful extraction entries contain `"error": null`
- preserve failure reporting for mixed/all-error extraction batches

## Tests
- `python -m py_compile agent/display.py`
- `PYTHONPATH="$CLONE" python -m pytest -o 'addopts=' tests/agent/test_display_tool_failure.py::TestDetectToolFailureStructured::test_web_extract_null_nested_error_not_flagged -q`
- `ruff check agent/display.py tests/agent/test_display_tool_failure.py`