### PR TITLE
fix(file-ops): skip per-file tsc when an ancestor tsconfig.json exists

### DIFF
--- a/tests/agent/lsp/test_shell_linter_lsp_skip.py
+++ b/tests/agent/lsp/test_shell_linter_lsp_skip.py
@@ -114,5 +114,55 @@ def test_tsx_default_check_lint_returns_skipped(tmp_path):
     assert not exec_mock.called, "no shell linter should run for .tsx"
 
 
+def test_ts_shell_linter_skipped_when_ancestor_tsconfig_present(tmp_path):
+    """A .ts file under a dir tree containing tsconfig.json skips the per-file
+    shell tsc EVEN WHEN LSP is inactive — single-file tsc can't read the
+    project config, so its diagnostics are pure noise. This closes the
+    LSP-disabled gap (the common default).
+
+    _exec is patched to raise so any accidental shell-linter invocation fails
+    the test.
+    """
+    fops = _make_fops()
+    (tmp_path / "tsconfig.json").write_text('{"compilerOptions":{}}\n')
+    sub = tmp_path / "src" / "app"
+    sub.mkdir(parents=True)
+    src = sub / "thing.ts"
+    src.write_text("import { x } from '@/store'\nexport const y = x\n")
+
+    def _exec_must_not_run(*args, **kwargs):  # pragma: no cover
+        raise AssertionError("shell tsc ran despite an ancestor tsconfig.json")
+
+    with patch.object(fops, "_lsp_local_only", return_value=True), \
+         patch.object(fops, "_lsp_will_handle", return_value=False), \
+         patch.object(fops, "_exec", side_effect=_exec_must_not_run), \
+         patch.object(fops, "_has_command", return_value=True):
+        result = fops._check_lint(str(src))
+
+    assert result.skipped is True
+    assert "tsconfig.json" in (result.message or "")
+
+
+def test_ts_shell_linter_runs_when_no_ancestor_tsconfig(tmp_path):
+    """Without any ancestor tsconfig.json (a standalone .ts file), the shell
+    tsc still runs — the ancestor-skip must not suppress lint for non-project
+    files. We assert _exec IS reached (LSP inactive)."""
+    fops = _make_fops()
+    src = tmp_path / "loose.ts"
+    src.write_text("const x: number = 'nope'\n")
+
+    exec_result = MagicMock()
+    exec_result.exit_code = 2
+    exec_result.stdout = "loose.ts(1,7): error TS2322: Type 'string' ...\n"
+
+    with patch.object(fops, "_lsp_local_only", return_value=True), \
+         patch.object(fops, "_lsp_will_handle", return_value=False), \
+         patch.object(fops, "_has_command", return_value=True), \
+         patch.object(fops, "_exec", return_value=exec_result) as exec_mock:
+        fops._check_lint(str(src))
+
+    assert exec_mock.called, "shell tsc should run when there's no project tsconfig"
+
+
 if __name__ == "__main__":  # pragma: no cover
     pytest.main([__file__, "-v"])

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -2287,6 +2287,28 @@ class ShellFileOperations(FileOperations):
         if ext not in LINTERS:
             return LintResult(skipped=True, message=f"No linter for {ext} files")
 
+        # A per-file `tsc --noEmit <file>` cannot read the project's
+        # tsconfig.json, so for any .ts that belongs to a TS project it floods
+        # phantom errors — unresolved path aliases (`@/…` → TS2307) and ambient
+        # globals (`Window.hermesDesktop` → TS2339) that are defined by the
+        # config it never loads. The delta filter then reports the misleading
+        # "pre-existing lint errors … the file is still broken", which carries
+        # no signal and wastes the caller's turns. When an ancestor
+        # tsconfig.json exists, skip the shell tsc entirely; real diagnostics
+        # come from the LSP tier (below) or an explicit `tsc -p tsconfig.json`
+        # the caller runs deliberately. (.tsx already returns above via the
+        # `ext not in LINTERS` branch.)
+        if ext == '.ts' and self._has_ancestor_tsconfig(path):
+            return LintResult(
+                skipped=True,
+                message=(
+                    "Project tsconfig.json detected — per-file tsc skipped "
+                    "(single-file tsc can't resolve project aliases/globals; "
+                    "use the LSP tier or `tsc -p tsconfig.json` for real "
+                    "diagnostics)."
+                ),
+            )
+
         # If a real LSP server is active and claims this file, skip the
         # shell linter for extensions whose per-file shell invocation is
         # structurally weaker / floods phantom errors.  See
@@ -2466,6 +2488,33 @@ class ShellFileOperations(FileOperations):
             if ext_lower in srv.extensions:
                 return True
         return False
+
+    def _has_ancestor_tsconfig(self, path: str) -> bool:
+        """True iff a tsconfig.json exists in *path*'s directory or any ancestor.
+
+        A single-file ``tsc`` invocation can't read that config, so its
+        diagnostics for such a file are pure noise (unresolved aliases /
+        ambient globals). Used by :meth:`_check_lint` to skip the per-file
+        shell tsc for project TypeScript files.
+
+        Best-effort and local-host only: a host-side ``os.path`` walk. On a
+        remote/sandboxed backend the project tree isn't on this host, so the
+        walk returns False and the shell linter runs exactly as before — never
+        suppress lint based on a probe that couldn't answer.
+        """
+        if not self._lsp_local_only():
+            return False
+        try:
+            d = os.path.dirname(os.path.abspath(path))
+            while True:
+                if os.path.isfile(os.path.join(d, "tsconfig.json")):
+                    return True
+                parent = os.path.dirname(d)
+                if parent == d:
+                    return False
+                d = parent
+        except Exception:  # noqa: BLE001
+            return False
 
     def _lsp_will_handle(self, path: str) -> bool:
         """Return True iff the LSP service is active AND will lint this file.


### PR DESCRIPTION
The post-write lint runs `npx tsc --noEmit <file>` on a single .ts file with no `-p tsconfig`. tsc ignores tsconfig.json for explicit file args, so for any file in a real TS project it floods phantom diagnostics — unresolved path aliases (`@/…` → TS2307) and ambient globals (`Window.hermesDesktop` → TS2339) that the project config defines. The delta filter sees the same phantom errors before and after the edit, finds no NEW ones, and returns the misleading **'pre-existing lint errors … the file is still broken'** on a perfectly correct one-line edit — wasting the caller's turns.

Existing code already skips shell tsc when an LSP server claims the file, but that only fires with LSP configured+enabled (not the default), leaving the common LSP-disabled case exposed.

**Fix:** when an ancestor `tsconfig.json` exists (local host only), skip the per-file shell tsc for `.ts` — its verdict carries zero signal for project files. Real diagnostics still come from the LSP tier or an explicit `tsc -p tsconfig.json`. Best-effort ancestor walk; remote/sandbox backends fall back to running the linter as before. (`.tsx` already returns skipped via the ext-not-in-LINTERS branch.)

**Tests:** ancestor-tsconfig `.ts` → skipped even with LSP off; standalone `.ts` with no ancestor tsconfig → shell tsc still runs. 7/7 in the LSP-skip suite.