### PR TITLE
fix(gateway): stop Desktop retries from silently truncating session history (#86573)

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -5031,6 +5031,52 @@ def test_prompt_submit_refuses_ordinal_and_message_id_mismatch(monkeypatch):
         server._sessions.pop("mismatch-trunc-sid", None)
 
 
+def test_prompt_submit_refuses_ordinal_only_when_history_has_row_ids(monkeypatch):
+    """A durable session must not trust an ordinal without a row-id target."""
+    replaced = []
+
+    class _FakeDB:
+        def replace_messages(self, key, messages, active_only=False, archive_dropped=False):
+            replaced.append((key, list(messages)))
+
+    history = [
+        {"_row_id": 101, "role": "user", "content": "first"},
+        {"_row_id": 102, "role": "assistant", "content": "reply 1"},
+        {"_row_id": 103, "role": "user", "content": "second"},
+        {"_row_id": 104, "role": "assistant", "content": "reply 2"},
+    ]
+    server._sessions["ordinal-only-durable-sid"] = _session(history=list(history))
+    monkeypatch.setattr(server, "_get_db", lambda: _FakeDB())
+    monkeypatch.setattr(
+        server, "_start_agent_build", lambda *a, **k: pytest.fail("must not start a turn")
+    )
+    monkeypatch.setattr(
+        server, "_start_inflight_turn", lambda *a, **k: pytest.fail("must not start a turn")
+    )
+
+    try:
+        resp = server.handle_request(
+            {
+                "id": "1",
+                "method": "prompt.submit",
+                "params": {
+                    "session_id": "ordinal-only-durable-sid",
+                    "text": "retry",
+                    "truncate_before_user_ordinal": 1,
+                    "confirm_truncate": True,
+                },
+            }
+        )
+
+        assert resp["error"]["code"] == 4004
+        assert "truncate_before_row_id" in resp["error"]["message"]
+        assert server._sessions["ordinal-only-durable-sid"]["history"] == history
+        assert server._sessions["ordinal-only-durable-sid"]["running"] is False
+        assert replaced == []
+    finally:
+        server._sessions.pop("ordinal-only-durable-sid", None)
+
+
 def test_prompt_submit_truncates_by_row_id(monkeypatch):
     """#82959: prompt.submit with truncate_before_row_id must cut at the target row id."""
     replaced = []

--- a/tui_gateway/methods_prompt.py
+++ b/tui_gateway/methods_prompt.py
@@ -495,6 +495,24 @@ def _(rid, params: dict) -> dict:
                 if err is not None:
                     return err
             else:
+                # Once active user turns carry durable row ids, an ordinal-only
+                # target is an unsafe downgrade: renderer and gateway ordinals
+                # can diverge after compaction/rebuild while the row id remains
+                # stable. Require the client to prove which durable turn it
+                # means instead of persisting a potentially mis-aimed cut.
+                if any(_message_row_id(history[h_idx]) is not None for h_idx in user_indices):
+                    logger.warning(
+                        "prompt.submit: REFUSED ordinal-only truncation of durable "
+                        "session %s (ordinal=%d); truncate_before_row_id required",
+                        sid,
+                        client_ordinal,
+                    )
+                    return _err(
+                        rid,
+                        4004,
+                        "ordinal-only truncation is unsafe for durable session history; "
+                        "include truncate_before_row_id",
+                    )
                 ordinal = client_ordinal
 
             # Reject out-of-range ordinals on BOTH ends. A negative value would


### PR DESCRIPTION
Salvage of #86605 by @fangliquanflq, cherry-picked onto current `main` with authorship preserved.

## What this fixes

Fixes #86573: a Desktop retry/resubmit of a failed turn could silently truncate durable session history at the wrong user turn. The retry path traveled the ordinal-only back-compat branch of `prompt.submit`, and after in-place compactions/rebuilds the renderer's and gateway's ordinal address spaces drift — in the reported incident a stale ordinal cut 68 messages (4 user-turns deeper than intended) out of the model's active context while the Desktop transcript still showed them.

This is the residual hole of #82959 that the row-id guard from #83785 explicitly did not cover: #83785 protects requests that carry `truncate_before_row_id` / message-id targets, but the ordinal-only fallback still trusted the client's positional ordinal unconditionally.

## The fix

`tui_gateway/methods_prompt.py`: when the session's active user turns carry durable row ids, an ordinal-only truncation request is refused with error **4004** ("include truncate_before_row_id") *before* any in-memory or DB mutation. Ephemeral histories without row ids keep the legacy ordinal-only compatibility path unchanged.

## Verification

- New regression test `test_prompt_submit_refuses_ordinal_only_when_history_has_row_ids` exercises the real `prompt.submit` handler: asserts error 4004, no history mutation, no `replace_messages` call, no turn started.
- Full file green: `tests/test_tui_gateway_server.py` — 567 passed.

## Credit

All substantive work by @fangliquanflq (reliable repeat contributor); reported with a full production forensic trace by @CCXXXI in #86573.

## Infographic

![infographic](https://gist.githubusercontent.com/teknium1/c154ba1bec36062b15198994eaf464a5/raw/infographic-86605.png)
