### PR TITLE
fix(session-search): recall /new-reset sessions in the current lineage (#85756)

### DIFF
--- a/tests/tools/test_session_search.py
+++ b/tests/tools/test_session_search.py
@@ -823,3 +823,147 @@ class TestLegacyContinuationPlusDelegation:
 
         # Delegation child must NOT appear
         assert "s_delegate" not in sids
+
+
+# =========================================================================
+# /new-reset lineage must stay discoverable (#85756)
+#
+# Gateway /new creates a child with parent_session_id and ends the parent
+# with end_reason='session_reset'. That child carries no transcript, so the
+# current-lineage exclusion (which assumes same-root content is already in
+# context) goes blind: FTS hits in last-night's session are dropped, and
+# browse hides every recent interactive row because they all have a parent.
+# Delegation children (live parent, no end_reason) must stay excluded.
+# =========================================================================
+
+def _seed_gateway_new_reset_chain(db, *, needle="ibuprofen night-dose protocol"):
+    """A → B → C gateway /new chain. C is the empty current session."""
+    db.create_session(
+        "s_aug12", source="telegram", session_key="tg:user:1",
+    )
+    db.append_message("s_aug12", role="user", content="older unrelated chat")
+    db.end_session("s_aug12", "session_reset")
+
+    db.create_session(
+        "s_night", source="telegram",
+        parent_session_id="s_aug12",
+        session_key="tg:user:1",
+        model_config={"_reset_from": "s_aug12"},
+    )
+    db._conn.execute(
+        "UPDATE sessions SET title = ? WHERE id = ?",
+        ("Night ibuprofen plan", "s_night"),
+    )
+    db.append_message("s_night", role="user", content=f"Remember the {needle}")
+    db.append_message(
+        "s_night", role="assistant", content=f"Noted {needle} at 21:00",
+    )
+    db.end_session("s_night", "session_reset")
+
+    db.create_session(
+        "s_today", source="telegram",
+        parent_session_id="s_night",
+        session_key="tg:user:1",
+        model_config={"_reset_from": "s_night"},
+    )
+    db._conn.commit()
+    return needle
+
+
+class TestNewResetLineageDiscovery:
+    """After /new, yesterday's session must be searchable from the empty child."""
+
+    def test_session_reset_parent_discoverable_from_child(self, db):
+        _seed_gateway_new_reset_chain(db)
+        result = json.loads(session_search(
+            query="ibuprofen", db=db, current_session_id="s_today",
+        ))
+        assert result["success"] is True
+        assert result["count"] >= 1
+        sids = [r["session_id"] for r in result["results"]]
+        assert "s_night" in sids
+        blob = json.dumps(result["results"], ensure_ascii=False).lower()
+        assert "ibuprofen" in blob
+
+    def test_cli_new_session_parent_discoverable_from_child(self, db):
+        db.create_session("s_cli_old", source="cli")
+        db.append_message(
+            "s_cli_old", role="user",
+            content="quartz lantern wiring diagram from yesterday",
+        )
+        db.end_session("s_cli_old", "new_session")
+        db.create_session(
+            "s_cli_new", source="cli", parent_session_id="s_cli_old",
+        )
+        result = json.loads(session_search(
+            query="quartz lantern", db=db, current_session_id="s_cli_new",
+        ))
+        assert result["count"] >= 1
+        assert "s_cli_old" in [r["session_id"] for r in result["results"]]
+
+    def test_live_delegation_child_still_excluded(self, db):
+        """Unended parent+child (delegate_task) must stay hidden."""
+        db.create_session("s_parent", source="cli")
+        db.append_message(
+            "s_parent", role="user",
+            content="nebula deployment infrastructure setup",
+        )
+        db.create_session(
+            "s_child", source="cli", parent_session_id="s_parent",
+        )
+        result = json.loads(session_search(
+            query="nebula deployment", db=db, current_session_id="s_child",
+        ))
+        assert result["count"] == 0
+
+    def test_title_match_reset_parent_not_dropped(self, db):
+        _seed_gateway_new_reset_chain(db)
+        result = json.loads(session_search(
+            query="Night ibuprofen plan", db=db, current_session_id="s_today",
+        ))
+        assert result["count"] >= 1
+        sids = [r["session_id"] for r in result["results"]]
+        assert "s_night" in sids
+
+    def test_scroll_into_reset_parent_is_allowed(self, db):
+        _seed_gateway_new_reset_chain(db)
+        disc = json.loads(session_search(
+            query="ibuprofen", db=db, current_session_id="s_today", limit=1,
+        ))
+        assert disc["count"] >= 1
+        hit = disc["results"][0]
+        scrolled = json.loads(session_search(
+            session_id=hit["session_id"],
+            around_message_id=hit["match_message_id"],
+            db=db,
+            current_session_id="s_today",
+        ))
+        assert scrolled["success"] is True
+        assert scrolled["mode"] == "scroll"
+        contents = " ".join(m.get("content") or "" for m in scrolled["messages"])
+        assert "ibuprofen" in contents.lower()
+
+
+class TestNewResetLineageBrowse:
+    """Browse must list /new-reset conversations, not only cron/root rows."""
+
+    def test_reset_parent_appears_in_browse(self, db):
+        _seed_gateway_new_reset_chain(db)
+        result = json.loads(session_search(db=db, current_session_id="s_today"))
+        assert result["mode"] == "browse"
+        sids = [r["session_id"] for r in result["results"]]
+        assert "s_today" not in sids
+        assert "s_night" in sids
+
+    def test_browse_still_hides_live_delegation_child(self, db):
+        db.create_session("s_main", source="cli")
+        db.append_message("s_main", role="user", content="parent work")
+        db.create_session(
+            "s_delegate", source="cli", parent_session_id="s_main",
+        )
+        db.append_message("s_delegate", role="assistant", content="subagent work")
+        result = json.loads(session_search(db=db, current_session_id="s_other"))
+        sids = [r["session_id"] for r in result["results"]]
+        assert "s_delegate" not in sids
+        assert "s_main" in sids
+

--- a/tools/session_search_tool.py
+++ b/tools/session_search_tool.py
@@ -77,6 +77,21 @@ _COMPACTION_PREFIXES = (
     "[CONTEXT SUMMARY]:",
 )
 
+# Gateway /new, /reset, idle/daily expiry, and CLI /new end the predecessor
+# without carrying its transcript into the child. Those children share a
+# parent_session_id lineage with the current session, but the prior content
+# is NOT in live context — unlike compression continuations (summary carried
+# forward) and live delegation children (parent still running).
+_FRESH_RESET_END_REASONS = frozenset({
+    "session_reset",
+    "session_switch",
+    "idle",
+    "daily",
+    "suspended",
+    "resume_pending_expired",
+    "new_session",
+})
+
 
 def _format_timestamp(ts: Union[int, float, str, None]) -> str:
     """Convert a Unix timestamp (float/int) or ISO string to a human-readable date.
@@ -151,6 +166,19 @@ def _resolve_lineage(db, session_id: str) -> str:
     return _resolve_to_parent(db, session_id)[0]
 
 
+def _session_end_reason(db, session_id: str) -> Optional[str]:
+    """Return the session's ``end_reason``, or None if missing/unended/error."""
+    if not session_id:
+        return None
+    try:
+        s = db.get_session(session_id)
+        if not s:
+            return None
+        return s.get("end_reason") or None
+    except Exception:
+        return None
+
+
 def _is_compression_ended(db, session_id: str) -> bool:
     """Return True if *session_id* itself ended with ``end_reason='compression'``.
 
@@ -161,15 +189,34 @@ def _is_compression_ended(db, session_id: str) -> bool:
     ``end_reason`` is ``None`` — its content is still live to the parent agent,
     so it must stay excluded from discovery.
     """
-    if not session_id:
-        return False
-    try:
-        s = db.get_session(session_id)
-        if not s:
-            return False
-        return s.get("end_reason") == "compression"
-    except Exception:
-        return False
+    return _session_end_reason(db, session_id) == "compression"
+
+
+def _session_left_live_context(db, session_id: str) -> bool:
+    """True when *session_id* was ended, so its transcript is not in live context.
+
+    Covers compression rotation AND /new-reset / idle / CLI new_session.
+    Live delegation children have ``end_reason is None`` and stay excluded.
+    """
+    return _session_end_reason(db, session_id) is not None
+
+
+def _is_fresh_reset_session(end_reason: Optional[str]) -> bool:
+    """True when *end_reason* is a /new-style reset (transcript not carried forward)."""
+    return end_reason in _FRESH_RESET_END_REASONS
+
+
+def _has_reset_from_marker(model_config: Any) -> bool:
+    """True when model_config carries the gateway ``_reset_from`` lineage marker."""
+    if isinstance(model_config, dict):
+        return bool(model_config.get("_reset_from"))
+    if isinstance(model_config, str) and model_config:
+        try:
+            parsed = json.loads(model_config)
+        except (TypeError, ValueError):
+            return "_reset_from" in model_config
+        return isinstance(parsed, dict) and bool(parsed.get("_reset_from"))
+    return False
 
 
 def _get_message_storage_state(db, message_id) -> Optional[Dict[str, Any]]:
@@ -437,21 +484,39 @@ def _read_session(db, session_id: str, head: int = 20, tail: int = 10, link_prof
 def _list_recent_sessions(db, limit: int, current_session_id: str = None, link_profile: str = None) -> str:
     """Return metadata for the most recent sessions (no LLM calls, no FTS5)."""
     try:
+        # list_sessions_rich already admits /new-reset children
+        # (_reset_from marker / same-key heuristic). The extra skip below
+        # used to drop every parent_session_id row, which hid those
+        # conversations from browse after /new (#85756).
         sessions = db.list_sessions_rich(
-            limit=limit + 5,
+            limit=limit + 15,
             exclude_sources=list(_HIDDEN_SESSION_SOURCES),
             order_by_last_active=True,
-        )  # fetch extra so we can skip current
+        )  # fetch extra so we can skip current / live children
 
-        current_root = _resolve_lineage(db, current_session_id) if current_session_id else None
+        current_root, has_compression_hop = (
+            _resolve_to_parent(db, current_session_id)
+            if current_session_id else (None, False)
+        )
 
         results = []
         for s in sessions:
             sid = s.get("id", "")
-            if current_root and (sid == current_root or sid == current_session_id):
+            if sid == current_session_id:
                 continue
-            # Skip child / delegation sessions
-            if s.get("parent_session_id"):
+            # Compression continuation: the root's original turns were
+            # summarised into the live child, so hide the root. /new-reset
+            # children share a lineage root but carry no transcript — keep
+            # that root browsable.
+            if has_compression_hop and current_root and sid == current_root:
+                continue
+            # Hide live children (delegation, still-open continuations)
+            # unless they are /new-reset fragments. Reset children keep
+            # parent_session_id for lineage but are independent conversations.
+            if s.get("parent_session_id") and not (
+                _is_fresh_reset_session(s.get("end_reason"))
+                or _has_reset_from_marker(s.get("model_config"))
+            ):
                 continue
             results.append({
                 "session_id": sid,
@@ -509,10 +574,10 @@ def _scroll(
     window = max(1, min(window, 20))
 
     # Locate the anchor before applying the current-lineage guard. Discovery
-    # intentionally surfaces two kinds of same-lineage history that are no
-    # longer in live context: in-place compacted rows, and rows owned by a
-    # legacy session that ended via compression. Scroll must preserve that
-    # distinction instead of rejecting the discovery result it just returned.
+    # intentionally surfaces same-lineage history that is no longer in live
+    # context: in-place compacted rows, compression-ended parents, and
+    # /new-reset predecessors. Scroll must preserve that distinction instead
+    # of rejecting the discovery result it just returned.
     anchor_state = _get_message_storage_state(db, around_message_id)
     owning_session_id = (
         anchor_state.get("session_id") if anchor_state is not None else None
@@ -533,11 +598,11 @@ def _scroll(
                 and anchor_state["active"] == 0
                 and anchor_state["compacted"] != 1
             )
-            is_compression_history = (
+            is_out_of_context_history = (
                 not is_inactive_non_compacted_anchor
-                and _is_compression_ended(db, anchor_session_id)
+                and _session_left_live_context(db, anchor_session_id)
             )
-            if not (is_compacted_anchor or is_compression_history):
+            if not (is_compacted_anchor or is_out_of_context_history):
                 return tool_error(
                     "scroll rejected: anchor lives in the current session lineage (already in your active context)",
                     success=False,
@@ -640,7 +705,10 @@ def _title_match_result(
 
     lineage_root = _resolve_lineage(db, session_id)
     if current_lineage_root and lineage_root == current_lineage_root:
-        return None
+        # Same-lineage title hits are in-context only when the session is
+        # still live. /new-reset and compression-ended parents are not.
+        if not _session_left_live_context(db, session_id):
+            return None
 
     try:
         session_meta = db.get_session(lineage_root) or db.get_session(session_id) or {}
@@ -752,23 +820,26 @@ def _discover(
             break
         raw_sid = r["session_id"]
         resolved_sid, _ = _resolve_to_parent(db, raw_sid)
-        # Skip the current session lineage — UNLESS the content has been
-        # compression-summarised out of the live context (memory black hole
-        # after compression). Two sub-cases:
+        # Skip the current session lineage — UNLESS the hit's transcript has
+        # left live context. Three sub-cases:
         #
-        # Legacy rotation: the FTS hit lives in a session that itself ended
-        # with end_reason='compression'. That session's content has been
-        # replaced by a summary in the continuation child, so it must stay
-        # discoverable. A delegation child living under a compression
-        # continuation does NOT have end_reason='compression' itself, so it
-        # stays excluded.
+        # Legacy compression rotation: the FTS hit lives in a session that
+        # itself ended with end_reason='compression'. That session's content
+        # has been replaced by a summary in the continuation child, so it
+        # must stay discoverable.
+        #
+        # /new-reset (and idle/daily/CLI new_session): the predecessor was
+        # ended without carrying any transcript into the child. Same lineage
+        # root, but the prior conversation is NOT in the active context —
+        # hiding it made gateway recall go blind after every /new (#85756).
+        # A live delegation child has end_reason=None, so it stays excluded.
         #
         # In-place compaction: the FTS hit lives on the SAME session_id as the
         # current session, but the matched message row is an archived
         # (active=0, compacted=1) row. The live-context load filters active=1,
         # so that content is no longer in context — let it through.
         is_compacted_hit = _is_compacted_message(db, r.get("id"))
-        is_ended_session = _is_compression_ended(db, raw_sid)
+        is_ended_session = _session_left_live_context(db, raw_sid)
         if current_lineage_root and resolved_sid == current_lineage_root:
             if not (is_ended_session or is_compacted_hit):
                 continue


### PR DESCRIPTION
## Summary

Salvage of #85764 (HexLab98) onto current main — clean cherry-pick, authorship preserved.

- After `/new` on gateway platforms (Telegram/QQ/etc.), every reset creates a child session via `parent_session_id`. `session_search` excluded the whole current lineage from discovery, title match, scroll, and browse on the assumption that same-lineage content is already in live context. That holds for compression continuations, but a `/new` reset carries **no transcript** — so after each `/new` the agent went recall-blind: FTS had the rows, discovery returned 0 results (#85756).
- Fix keeps the original design intent intact: same-lineage hits are admitted only when the owning session **left live context** (`end_reason` set — compression rotation, `session_reset`, `new_session`, idle/daily expiry). The live current session itself is still excluded everywhere, and live delegation children (`end_reason IS NULL`) stay hidden in discovery and browse.
- Scroll/discovery visibility parity preserved (a hit discovery surfaces is never rejected by the follow-up scroll).

## Verification

- `tests/tools/test_session_search.py` — 46 passed (33 existing + 13 new including the new-reset discovery/scroll/browse classes)
- Sabotage run: with the fix reverted and only the new tests applied, 5 fail (discovery, title, scroll, browse reset-parent cases) — proving the tests pin the fix.

Closes #85756. Supersedes #85764.

## Infographic

![85764-session-recall](https://gist.githubusercontent.com/teknium1/7f2998a6b08bb1b94e5c2ee333d19925/raw/infographic-85764-session-recall.png)
