### PR TITLE
fix(agent): close the empty tool_calls 400 class at all three chokepoints (#83312, #77921)

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -650,6 +650,22 @@ def repair_message_sequence(agent, messages: List[Dict]) -> int:
                 prev["tool_calls"] = prev_calls + new_calls
             elif prev_calls:
                 prev["tool_calls"] = prev_calls
+            else:
+                # Neither turn carries tool calls, but the surviving turn may
+                # still carry a stale ``tool_calls: []`` from the earlier
+                # message.  An empty array is semantically "no tool calls",
+                # yet strict OpenAI-compatible providers (DeepSeek v4,
+                # Moonshot/Kimi) reject it with HTTP 400 ("Invalid
+                # 'messages[N].tool_calls': empty array...").  Drop the key
+                # HERE, at the source: ``sanitize_api_messages`` only fixes
+                # the per-call wire copy, so a ``[]`` left on the repaired
+                # turn survives in the live/persisted trajectory returned to
+                # callers (gateway/WebUI transcripts, session resume,
+                # subagents, cron) and is replayed on the next turn — which
+                # is how #58755 kept reproducing after the chokepoint fix
+                # (#77921).  Popping is non-destructive: an empty array
+                # carries no information.
+                prev.pop("tool_calls", None)
             # Concatenate plain-text content; leave multimodal (list)
             # content on either side alone to avoid mangling attachment
             # blocks — fall back to keeping the existing content.

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -3570,8 +3570,10 @@ def sanitize_api_messages(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]
                 if cid:
                     seen_assistant_call_ids.add(cid)
                 kept_tcs.append(tc)
-            if len(kept_tcs) != len(msg.get("tool_calls") or []):
+            if kept_tcs:
                 msg = {**msg, "tool_calls": kept_tcs}
+            elif len(kept_tcs) != len(msg.get("tool_calls") or []):
+                msg = {k: v for k, v in msg.items() if k != "tool_calls"}
             deduped.append(msg)
         elif role == "tool":
             cid = (msg.get("tool_call_id") or "").strip()

--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -277,10 +277,13 @@ class ChatCompletionsTransport(ProviderTransport):
                 # message carrying ``tool_calls: []`` (empty array) with
                 # HTTP 400 "Empty tool_calls is not supported in message."
                 # The pre-API sanitizer in agent_runtime_helpers drops these,
-                # but only on the conversation_loop path — auxiliary / custom
-                # provider routes can reach the wire without it. Normalize here
-                # so any empty/invalid tool_calls array is stripped at the
-                # transport layer on every call. (#58755 follow-up)
+                # but only on the conversation_loop path — other routes can
+                # reach the wire without it. For every request that
+                # serializes through this transport (conversation loop and
+                # any caller using it), this is the last boundary, so
+                # normalize here. Requests built by fully separate payload
+                # paths (e.g. some auxiliary clients) never pass through
+                # this layer and are out of scope for it. (#58755 follow-up)
                 if (
                     msg.get("role") == "assistant"
                     and "tool_calls" in msg

--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -272,6 +272,22 @@ class ChatCompletionsTransport(ProviderTransport):
                 break
             tool_calls = msg.get("tool_calls")
             if isinstance(tool_calls, list):
+                # Defense-in-depth: a strict OpenAI-compatible provider
+                # (e.g. onerouter / Qwen, DeepSeek v4) rejects an assistant
+                # message carrying ``tool_calls: []`` (empty array) with
+                # HTTP 400 "Empty tool_calls is not supported in message."
+                # The pre-API sanitizer in agent_runtime_helpers drops these,
+                # but only on the conversation_loop path — auxiliary / custom
+                # provider routes can reach the wire without it. Normalize here
+                # so any empty/invalid tool_calls array is stripped at the
+                # transport layer on every call. (#58755 follow-up)
+                if (
+                    msg.get("role") == "assistant"
+                    and "tool_calls" in msg
+                    and not tool_calls
+                ):
+                    needs_sanitize = True
+                    break
                 for tc in tool_calls:
                     if isinstance(tc, dict) and (
                         "call_id" in tc
@@ -282,6 +298,15 @@ class ChatCompletionsTransport(ProviderTransport):
                         break
                 if needs_sanitize:
                     break
+            elif (
+                isinstance(tool_calls, type(None))
+                and msg.get("role") == "assistant"
+                and "tool_calls" in msg
+            ):
+                # Explicit ``tool_calls: null`` is equally invalid on strict
+                # providers — treat it like the empty-array case.
+                needs_sanitize = True
+                break
 
         if not needs_sanitize:
             return messages
@@ -328,6 +353,19 @@ class ChatCompletionsTransport(ProviderTransport):
 
             tool_calls = msg.get("tool_calls")
             if isinstance(tool_calls, list):
+                # Strip empty/invalid tool_calls arrays at the transport
+                # layer (see detection above). Strict OpenAI-compatible
+                # providers reject ``tool_calls: []`` with HTTP 400; dropping
+                # the key keeps the message schema-valid. Matches the
+                # pre-API sanitizer's behaviour so all routes agree.
+                if (
+                    msg.get("role") == "assistant"
+                    and "tool_calls" in msg
+                    and not tool_calls
+                ):
+                    out_msg = mutable_msg()
+                    out_msg.pop("tool_calls", None)
+                    continue
                 copied_tool_calls: list[Any] | None = None
                 for tc_idx, tc in enumerate(tool_calls):
                     if isinstance(tc, dict):
@@ -347,6 +385,14 @@ class ChatCompletionsTransport(ProviderTransport):
                             copied_tool_calls[tc_idx] = copied_tc
                 if copied_tool_calls is not None:
                     mutable_msg()["tool_calls"] = copied_tool_calls
+            elif (
+                isinstance(tool_calls, type(None))
+                and msg.get("role") == "assistant"
+                and "tool_calls" in msg
+            ):
+                # Explicit ``tool_calls: null`` is invalid on strict
+                # providers — drop the key entirely.
+                mutable_msg().pop("tool_calls", None)
         return sanitized
 
     def convert_tools(self, tools: list[dict[str, Any]]) -> list[dict[str, Any]]:

--- a/tests/agent/transports/test_chat_completions_empty_tool_calls.py
+++ b/tests/agent/transports/test_chat_completions_empty_tool_calls.py
@@ -1,0 +1,128 @@
+"""Tests for empty / null ``tool_calls`` stripping in ChatCompletionsTransport.
+
+Strict OpenAI-compatible providers (onerouter / Qwen, DeepSeek v4) reject an
+assistant message carrying ``tool_calls: []`` (or ``null``) with HTTP 400
+"Empty tool_calls is not supported in message."  The pre-API sanitizer in
+``agent_runtime_helpers.sanitize_api_messages`` already drops these on the
+conversation_loop path, but the transport layer must also normalize them so
+auxiliary / custom-provider routes that bypass that sanitizer cannot reach the
+wire with an invalid array.  See #58755 (follow-up).
+"""
+
+import pytest
+
+from agent.transports import get_transport
+
+
+@pytest.fixture
+def transport():
+    import agent.transports.chat_completions  # noqa: F401
+    return get_transport("chat_completions")
+
+
+class TestEmptyToolCallsStripping:
+    """Assistant messages with empty/invalid tool_calls must be normalized."""
+
+    def test_assistant_empty_list_dropped(self, transport):
+        msgs = [{"role": "assistant", "content": "ok", "tool_calls": []}]
+        out = transport.convert_messages(msgs)
+        assert "tool_calls" not in out[0]
+        assert out[0]["content"] == "ok"
+
+    def test_assistant_null_dropped(self, transport):
+        msgs = [{"role": "assistant", "content": "ok", "tool_calls": None}]
+        out = transport.convert_messages(msgs)
+        assert "tool_calls" not in out[0]
+
+    def test_assistant_real_calls_preserved(self, transport):
+        real_tc = [{
+            "id": "call_abc",
+            "type": "function",
+            "function": {"name": "read_file", "arguments": "{}"},
+        }]
+        msgs = [{"role": "assistant", "content": "c", "tool_calls": real_tc}]
+        out = transport.convert_messages(msgs)
+        assert out[0]["tool_calls"] == real_tc
+
+    def test_only_empty_assistant_stripped_in_mixed_batch(self, transport):
+        msgs = [
+            {"role": "user", "content": "hi"},
+            {"role": "assistant", "content": "thinking", "tool_calls": []},
+            {
+                "role": "assistant",
+                "content": "acting",
+                "tool_calls": [{
+                    "id": "call_x",
+                    "type": "function",
+                    "function": {"name": "f", "arguments": "{}"},
+                }],
+            },
+        ]
+        out = transport.convert_messages(msgs)
+        assert "tool_calls" not in out[1]
+        assert out[1]["content"] == "thinking"
+        assert out[2]["tool_calls"] and out[2]["tool_calls"][0]["id"] == "call_x"
+
+    def test_user_role_empty_tool_calls_untouched(self, transport):
+        # User messages should not carry tool_calls at all, but if a stray
+        # empty array is present we must NOT strip it (it's not the invalid
+        # assistant shape, and mutating unrelated roles risks breaking the
+        # schema assumptions elsewhere). The transport only normalizes
+        # assistant messages.
+        msgs = [{"role": "user", "content": "hi", "tool_calls": []}]
+        out = transport.convert_messages(msgs)
+        assert "tool_calls" in out[0]
+        assert out[0]["tool_calls"] == []
+
+    def test_empty_array_with_codex_fields_still_dropped(self, transport):
+        # When an empty tool_calls array also carries codex scaffolding
+        # markers, the empty array takes precedence and is stripped outright.
+        msgs = [{
+            "role": "assistant",
+            "content": "ok",
+            "tool_calls": [{
+                "id": "fc_1",
+                "call_id": "call_1",
+                "response_item_id": "fc_1",
+                "type": "function",
+                "function": {"name": "f", "arguments": "{}"},
+            }],
+        }]
+        out = transport.convert_messages(msgs, model="gpt-4o")
+        # Non-empty array: codex fields stripped, call preserved.
+        assert out[0]["tool_calls"]
+        tc = out[0]["tool_calls"][0]
+        assert "call_id" not in tc
+        assert "response_item_id" not in tc
+
+    def test_clean_list_is_identity(self, transport):
+        msgs = [
+            {"role": "user", "content": "hi"},
+            {
+                "role": "assistant",
+                "content": "c",
+                "tool_calls": [{
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {"name": "f", "arguments": "{}"},
+                }],
+            },
+        ]
+        assert transport.convert_messages(msgs) is msgs
+
+    def test_empty_array_triggers_copy_on_write(self, transport):
+        msgs = [{"role": "assistant", "content": "ok", "tool_calls": []}]
+        out = transport.convert_messages(msgs)
+        # Original list/message must not be mutated in place.
+        assert msgs[0]["tool_calls"] == []
+        assert "tool_calls" not in out[0]
+        assert out is not msgs
+
+    @pytest.mark.parametrize(
+        "model",
+        ["qwen/qwen3.8-max-preview:free", "deepseek/deepseek-v4-flash", "gpt-4o"],
+    )
+    def test_empty_array_stripped_across_providers(self, transport, model):
+        msgs = [{"role": "assistant", "content": "ok", "tool_calls": []}]
+        out = transport.convert_messages(msgs, model=model)
+        assert "tool_calls" not in out[0]

--- a/tests/agent/transports/test_chat_completions_empty_tool_calls.py
+++ b/tests/agent/transports/test_chat_completions_empty_tool_calls.py
@@ -74,9 +74,10 @@ class TestEmptyToolCallsStripping:
         assert "tool_calls" in out[0]
         assert out[0]["tool_calls"] == []
 
-    def test_empty_array_with_codex_fields_still_dropped(self, transport):
-        # When an empty tool_calls array also carries codex scaffolding
-        # markers, the empty array takes precedence and is stripped outright.
+    def test_nonempty_array_codex_fields_stripped(self, transport):
+        # A non-empty tool_calls array carrying codex scaffolding markers
+        # (call_id, response_item_id) must have those fields stripped while
+        # the call itself is preserved.
         msgs = [{
             "role": "assistant",
             "content": "ok",

--- a/tests/run_agent/test_message_sequence_repair.py
+++ b/tests/run_agent/test_message_sequence_repair.py
@@ -356,6 +356,33 @@ def test_sanitize_drops_empty_tool_calls_array():
     assert assistant["content"] == "answer"
 
 
+def test_repair_drops_stale_empty_tool_calls_on_merged_assistant():
+    """repair_message_sequence must drop a stale ``tool_calls: []`` on the
+    surviving message of a consecutive-assistant merge (#77921).
+
+    The chokepoint sanitizer (sanitize_api_messages) only patches the per-call
+    wire copy — a ``[]`` left on the repaired live/persisted trajectory is
+    replayed on the next turn and 400s strict providers (DeepSeek v4). The
+    merge's union branches only ever set non-empty lists or leave the key
+    untouched, so the empty array survives into the persisted state."""
+    from agent.agent_runtime_helpers import repair_message_sequence
+
+    messages = [
+        {"role": "user", "content": "hi"},
+        # surviving turn carries a stale empty tool_calls from an earlier pass
+        {"role": "assistant", "content": "first", "tool_calls": []},
+        {"role": "assistant", "content": "second"},
+    ]
+    # A dummy agent object is enough — repair only reads message roles/content.
+    agent = type("Agent", (), {})()
+    n = repair_message_sequence(agent, messages)
+    assert n >= 0
+    assistants = [m for m in messages if m.get("role") == "assistant"]
+    assert len(assistants) == 1
+    assert "tool_calls" not in assistants[0]
+    assert "second" in assistants[0]["content"]
+
+
 
 
 

--- a/tests/run_agent/test_message_sequence_repair.py
+++ b/tests/run_agent/test_message_sequence_repair.py
@@ -370,13 +370,46 @@ def test_sanitize_drops_empty_tool_calls_array():
 # such turns on the per-call copy so the session recovers itself in memory.
 
 
+def test_sanitize_dedup_drops_tool_calls_key_when_all_removed():
+    """When dedup removes ALL tool_calls from an assistant message,
+    the key is dropped instead of writing tool_calls: [].
 
+    DeepSeek v4 and newer OpenAI reject empty tool_calls with HTTP 400.
+    The dedup pass introduced by #58327 can produce this state when
+    all tool_call_ids are duplicates of earlier messages in a long
+    history. The fix (#64335) drops the key entirely rather than
+    writing an empty array.
+    """
+    from agent.agent_runtime_helpers import sanitize_api_messages
 
+    # Simulate a long conversation where the same tool_call_id appears
+    # in multiple assistant messages (e.g., crash/resume glitch or
+    # compression window re-emission). The first occurrence is kept,
+    # later duplicates are removed.
+    messages = [
+        {"role": "user", "content": "step 1"},
+        {"role": "assistant", "content": "running",
+         "tool_calls": [{"id": "call_A", "type": "function",
+                         "function": {"name": "foo", "arguments": "{}"}}]},
+        {"role": "tool", "tool_call_id": "call_A", "content": "result 1"},
+        # Simulate a later assistant message that reuses call_A
+        # (this would be invalid, but the dedup pass handles it)
+        {"role": "assistant", "content": "retrying",
+         "tool_calls": [{"id": "call_A", "type": "function",
+                         "function": {"name": "foo", "arguments": "{}"}}]},
+    ]
 
+    out = sanitize_api_messages(list(messages))
 
+    # First assistant should keep tool_calls (first occurrence)
+    assistant1 = [m for m in out if m.get("role") == "assistant"][0]
+    assert "tool_calls" in assistant1
+    assert len(assistant1["tool_calls"]) == 1
+    assert assistant1["tool_calls"][0]["id"] == "call_A"
 
-
-
-
-
-
+    # Second assistant should have tool_calls key DROPPED
+    # (all tool_calls were deduped as duplicates of call_A)
+    assistant2 = [m for m in out if m.get("role") == "assistant"][1]
+    assert "tool_calls" not in assistant2
+    # Content should be preserved
+    assert assistant2["content"] == "retrying"


### PR DESCRIPTION
Fixes #83312. Fixes #77921. Closes #64335-class empty-`tool_calls` 400s on strict providers (DeepSeek v4, Moonshot/Kimi, Qwen/onerouter) at every layer that can create or forward the invalid shape.

## The bug class

Strict OpenAI-compatible providers reject an assistant message carrying `tool_calls: []` (or `null`) with a non-retryable HTTP 400 (`Invalid 'messages[N].tool_calls': empty array`). Because the poisoned message stays in the replayed in-memory history, **every subsequent turn in the session fails the same way** — the session is permanently wedged until the agent cache is cleared (#83312 observed this across 6 sessions; #77921 reproduced it three times in v0.19.1 despite the #59110 chokepoint fix).

The #58755/#59110 sanitizer strips `tool_calls: []` where it sees it — but two later passes **re-create** the empty array after the strip has run, and some routes bypass the sanitizer entirely:

1. **`sanitize_api_messages` tool_call_id dedup (runs after the empty-array drop):** when every call on an assistant turn is a duplicate, `kept_tcs` collapses to `[]` and was written back as `tool_calls: []` — re-creating the exact payload deleted a few passes earlier. This is the mechanism behind #83312's "sanitizer works in isolation but the array still reaches the wire", and it correlates with the `Repaired N message-alternation violations` log line because `repair_message_sequence`'s consecutive-assistant merge is what produces the all-duplicates shape.
2. **`repair_message_sequence` consecutive-assistant merge:** the union branch preserved a stale `tool_calls: []` on the surviving turn (and the repaired list is the *live/persisted* trajectory, so the `[]` was replayed every turn — #77921's finding that `tool_calls = NULL` rows become `[]` on load and survive the merge).
3. **Transport boundary:** auxiliary/custom-provider routes can reach `ChatCompletionsTransport.convert_messages()` without passing through `sanitize_api_messages` at all.

## The fix (three chokepoints, salvaged from the three earliest PRs for each site)

- **Dedup pass** (`agent/agent_runtime_helpers.py`): when dedup removes ALL calls, drop the `tool_calls` key entirely instead of writing `[]` — salvaged from #64345 by @liuhao1024 (earliest fix for this site, filed 2026-07-14).
- **Repair merge** (`agent/agent_runtime_helpers.py`): when neither merged turn carries calls, pop the stale `tool_calls` key at the source so the live/persisted trajectory is clean — salvaged from #77944 by @webtecnica (earliest fix for this site).
- **Wire boundary** (`agent/transports/chat_completions.py`): strip empty/`null` `tool_calls` on assistant messages in `convert_messages()`, the last transformation before the request — salvaged from #72591 by @TurgutKural (earliest transport-boundary fix).

All three commits are cherry-picked with original authorship preserved.

## Verification

```
tests/run_agent/test_message_sequence_repair.py            — 40 passed (incl. 3 new regressions)
tests/agent/transports/test_chat_completions_empty_tool_calls.py — new, passed
tests/agent/transports/test_chat_completions.py            — 46 passed (no regressions)
tests/run_agent/test_run_agent_codex_responses.py          — 47 passed (codex interim-turn exemption intact)
```

## Duplicate/overlapping PRs covered by this class fix

#64345 (salvaged), #77944 (salvaged, was already closed into #78063), #72591 (salvaged), #83600, #83315, #86020, #77377 (agent_runtime_helpers portion), #64843, #82252 — all address subsets of the same class at one of these three sites.

## Infographic

![empty-toolcalls-class](https://gist.githubusercontent.com/teknium1/0118d04017ce84b3a62eda2f2bc1c10d/raw/infographic-empty-toolcalls.png)
