### PR TITLE
fix(streaming): prevent CLI deadlock on empty-stream interrupt (#81521)

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1721,6 +1721,18 @@ def interruptible_api_call(agent, api_kwargs: dict):
                 _close_request_client_once("interrupt_abort")
             except Exception:
                 pass
+            # #81521 (sibling of the streaming-path fix): wait for the worker
+            # to unwind Relay-managed scopes before surfacing
+            # InterruptedError, so turn teardown cannot race a still-open
+            # physical scope and corrupt the LIFO stack.
+            t.join(timeout=2.0)
+            if t.is_alive():
+                logger.warning(
+                    "Non-streaming worker still alive after interrupt abort "
+                    "(%.1fs join timeout); Relay teardown will best-effort "
+                    "drain orphaned scopes (#81521).",
+                    2.0,
+                )
             raise InterruptedError("Agent interrupted during API call")
     if result["error"] is not None:
         raise result["error"]
@@ -3411,6 +3423,19 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
             while t.is_alive():
                 t.join(timeout=0.3)
                 if agent._interrupt_requested:
+                    # #81521 (sibling of the main streaming-path fix): give
+                    # the Bedrock worker a bounded window to unwind its
+                    # Relay-managed stream scopes before surfacing
+                    # InterruptedError, so turn teardown cannot race a
+                    # still-open physical scope and corrupt the LIFO stack.
+                    t.join(timeout=2.0)
+                    if t.is_alive():
+                        logger.warning(
+                            "Bedrock streaming worker still alive after "
+                            "interrupt (%.1fs join timeout); Relay teardown "
+                            "will best-effort drain orphaned scopes (#81521).",
+                            2.0,
+                        )
                     raise InterruptedError("Agent interrupted during Bedrock API call")
                 # Liveness watchdog: no Bedrock event for longer than the stale
                 # timeout means the stream has wedged (open socket, keep-alives but

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -5067,6 +5067,21 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                 _close_request_client_once("stream_interrupt_abort")
             except Exception:
                 pass
+            # Wait for the worker to unwind Relay-managed stream scopes
+            # (physical LLM + deferred logical) before surfacing
+            # InterruptedError. Raising immediately lets turn teardown
+            # (finish_logical_calls / end_turn / close_session) race a
+            # still-open physical scope and corrupt the LIFO stack —
+            # "scope handle is not at the top of the stack" → CLI EIO /
+            # redraw storm (#81521).
+            t.join(timeout=2.0)
+            if t.is_alive():
+                logger.warning(
+                    "Streaming worker still alive after interrupt abort "
+                    "(%.1fs join timeout); Relay teardown will best-effort "
+                    "drain orphaned scopes (#81521).",
+                    2.0,
+                )
             raise InterruptedError("Agent interrupted during streaming API call")
     # Worker thread exited before the main thread's poll loop could check
     # the interrupt flag.  If the worker returned early due to an interrupt

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -71,6 +71,35 @@ def _context_thread_target(callback):
     return lambda: context.run(callback)
 
 
+def _join_worker_for_relay_teardown(worker, *, label: str) -> None:
+    """Bounded worker join before raising InterruptedError (#81521).
+
+    Raising immediately lets turn teardown (finish_logical_calls /
+    end_turn / close_session) race a still-open Relay physical LLM scope
+    and corrupt the LIFO stack — "scope handle is not at the top of the
+    stack" → CLI EIO / redraw storm.  Only joins when Relay managed
+    execution is actually live: when no Relay consumers are registered
+    there is no scope to unwind, and the join would just delay interrupt
+    detection (tests/run_agent/test_interrupt_propagation.py).
+    """
+    try:
+        from agent import relay_runtime
+
+        runtime = relay_runtime.get_runtime(create=False)
+        if runtime is None or not runtime.managed_execution_enabled():
+            return
+    except Exception:
+        return
+    worker.join(timeout=2.0)
+    if worker.is_alive():
+        logger.warning(
+            "%s worker still alive after interrupt abort (2.0s join "
+            "timeout); Relay teardown will best-effort drain orphaned "
+            "scopes (#81521).",
+            label,
+        )
+
+
 def _ra():
     """Lazy ``run_agent`` reference.
 
@@ -1724,15 +1753,9 @@ def interruptible_api_call(agent, api_kwargs: dict):
             # #81521 (sibling of the streaming-path fix): wait for the worker
             # to unwind Relay-managed scopes before surfacing
             # InterruptedError, so turn teardown cannot race a still-open
-            # physical scope and corrupt the LIFO stack.
-            t.join(timeout=2.0)
-            if t.is_alive():
-                logger.warning(
-                    "Non-streaming worker still alive after interrupt abort "
-                    "(%.1fs join timeout); Relay teardown will best-effort "
-                    "drain orphaned scopes (#81521).",
-                    2.0,
-                )
+            # physical scope and corrupt the LIFO stack. No-op when Relay
+            # managed execution is not live.
+            _join_worker_for_relay_teardown(t, label="Non-streaming")
             raise InterruptedError("Agent interrupted during API call")
     if result["error"] is not None:
         raise result["error"]
@@ -3426,16 +3449,9 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                     # #81521 (sibling of the main streaming-path fix): give
                     # the Bedrock worker a bounded window to unwind its
                     # Relay-managed stream scopes before surfacing
-                    # InterruptedError, so turn teardown cannot race a
-                    # still-open physical scope and corrupt the LIFO stack.
-                    t.join(timeout=2.0)
-                    if t.is_alive():
-                        logger.warning(
-                            "Bedrock streaming worker still alive after "
-                            "interrupt (%.1fs join timeout); Relay teardown "
-                            "will best-effort drain orphaned scopes (#81521).",
-                            2.0,
-                        )
+                    # InterruptedError. No-op when Relay managed execution
+                    # is not live.
+                    _join_worker_for_relay_teardown(t, label="Bedrock streaming")
                     raise InterruptedError("Agent interrupted during Bedrock API call")
                 # Liveness watchdog: no Bedrock event for longer than the stale
                 # timeout means the stream has wedged (open socket, keep-alives but
@@ -5098,15 +5114,9 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
             # (finish_logical_calls / end_turn / close_session) race a
             # still-open physical scope and corrupt the LIFO stack —
             # "scope handle is not at the top of the stack" → CLI EIO /
-            # redraw storm (#81521).
-            t.join(timeout=2.0)
-            if t.is_alive():
-                logger.warning(
-                    "Streaming worker still alive after interrupt abort "
-                    "(%.1fs join timeout); Relay teardown will best-effort "
-                    "drain orphaned scopes (#81521).",
-                    2.0,
-                )
+            # redraw storm (#81521). No-op when Relay managed execution
+            # is not live.
+            _join_worker_for_relay_teardown(t, label="Streaming")
             raise InterruptedError("Agent interrupted during streaming API call")
     # Worker thread exited before the main thread's poll loop could check
     # the interrupt flag.  If the worker returned early due to an interrupt

--- a/agent/relay_runtime.py
+++ b/agent/relay_runtime.py
@@ -543,6 +543,114 @@ class RelayRuntime:
         )
         return result if isinstance(result, dict) else args
 
+    def _close_scope_handle(
+        self,
+        session: RelaySession,
+        handle: Any,
+        *,
+        output: dict[str, Any] | None = None,
+        allow_closing: bool = False,
+        failure_label: str = "scope close failed",
+        drain_limit: int = 32,
+    ) -> str | None:
+        """Pop ``handle``, draining orphaned children in the same session context.
+
+        Relay scopes are strict LIFO. Empty-stream retries + interrupt can
+        abandon a physical LLM scope above TURN/SESSION (#81521). Drain and
+        close must run inside one ``run_in_session`` callback so ContextVar
+        stack views stay consistent across pops.
+        """
+        if handle is None:
+            return None
+        metadata = {
+            RUNTIME_SCHEMA_KEY: RUNTIME_SCHEMA_VERSION,
+            RUNTIME_INSTANCE_KEY: self.runtime_id,
+        }
+        close_output = output or {}
+        session_root = session.handle
+        drained_holder = {"count": 0}
+        error_holder: dict[str, BaseException] = {}
+
+        def close_with_drain() -> None:
+            def current_top() -> Any:
+                top = self.relay.get_scope_stack()
+                # Some Relay builds return the live stack (list). Others
+                # return the top handle directly — including tuple handles
+                # like ("scope", name, serial) from the test fake. Only
+                # unwrap real list stacks; never index a handle tuple.
+                if isinstance(top, list):
+                    return top[-1] if top else None
+                return top
+
+            try:
+                self.relay.scope.pop(
+                    handle,
+                    output=close_output,
+                    metadata=metadata,
+                )
+                return
+            except Exception as first_exc:
+                error_holder["first"] = first_exc
+
+            for _ in range(drain_limit):
+                top = current_top()
+                if top is None or top == handle:
+                    break
+                # Never pop the session root while draining for a nested handle.
+                if (
+                    session_root is not None
+                    and top == session_root
+                    and handle is not session_root
+                ):
+                    break
+                try:
+                    self.relay.scope.pop(
+                        top,
+                        output={
+                            "outcome": "cancelled",
+                            "hermes.orphan_drain": True,
+                        },
+                        metadata=metadata,
+                    )
+                    drained_holder["count"] += 1
+                except Exception as drain_exc:
+                    error_holder["drain"] = drain_exc
+                    logger.warning(
+                        "Hermes Relay orphaned scope drain failed",
+                        exc_info=True,
+                    )
+                    break
+
+            if drained_holder["count"]:
+                logger.warning(
+                    "Hermes Relay drained %d orphaned scope(s) before closing %s",
+                    drained_holder["count"],
+                    handle,
+                )
+            try:
+                self.relay.scope.pop(
+                    handle,
+                    output=close_output,
+                    metadata=metadata,
+                )
+                error_holder.pop("first", None)
+                error_holder.pop("drain", None)
+            except Exception as retry_exc:
+                error_holder["retry"] = retry_exc
+
+        try:
+            self.run_in_session(
+                session,
+                close_with_drain,
+                allow_closing=allow_closing,
+            )
+        except Exception as exc:
+            return f"{failure_label}: {exc}"
+        retry_exc = error_holder.get("retry") or error_holder.get("first")
+        if retry_exc is not None:
+            return f"{failure_label}: {retry_exc}"
+        return None
+
     def close_session(self, event: dict[str, Any]) -> None:
         """Close one session scope and remove it from the core registry."""
         session_id = _session_id(event)
@@ -559,21 +667,15 @@ class RelayRuntime:
                 return
             session.closing = True
             if session.handle is not None:
-                try:
-                    self.run_in_session(
-                        session,
-                        self.relay.scope.pop,
-                        session.handle,
-                        output={},
-                        metadata={
-                            RUNTIME_SCHEMA_KEY: RUNTIME_SCHEMA_VERSION,
-                            RUNTIME_INSTANCE_KEY: self.runtime_id,
-                        },
-                        allow_closing=True,
-                        timeout=_SCOPE_OP_TIMEOUT,
-                    )
-                except Exception as exc:
-                    failures.append(f"session scope close failed: {exc}")
+                failure = self._close_scope_handle(
+                    session,
+                    session.handle,
+                    output={},
+                    allow_closing=True,
+                    failure_label="session scope close failed",
+                )
+                if failure:
+                    failures.append(failure)
         try:
             try:
                 _scope_op_executor().submit(
@@ -964,21 +1066,16 @@ class RelaySessionCoordinator:
                 if isinstance(lease.host, RelayRuntime) and lease.session is not None:
                     self._finish_logical_calls(turn, outcome=outcome)
                     if turn.handle is not None:
-                        try:
-                            lease.host.run_in_session(
-                                lease.session,
-                                lease.host.relay.scope.pop,
-                                turn.handle,
-                                output={"outcome": outcome},
-                                metadata={
-                                    RUNTIME_SCHEMA_KEY: RUNTIME_SCHEMA_VERSION,
-                                    RUNTIME_INSTANCE_KEY: lease.host.runtime_id,
-                                },
-                                timeout=_SCOPE_OP_TIMEOUT,
-                            )
-                        except Exception:
+                        failure = lease.host._close_scope_handle(
+                            lease.session,
+                            turn.handle,
+                            output={"outcome": outcome},
+                            failure_label="turn scope close failed",
+                        )
+                        if failure:
                             logger.warning(
-                                "Hermes Relay turn finalization failed", exc_info=True
+                                "Hermes Relay turn finalization failed: %s",
+                                failure,
                             )
             finally:
                 try:
@@ -1153,35 +1250,28 @@ class RelaySessionCoordinator:
             turn.logical_llm_calls.clear()
         for index in range(len(logical_calls) - 1, -1, -1):
             request_id, logical_handle = logical_calls[index]
-            try:
-                lease.host.run_in_session(
-                    lease.session,
-                    lease.host.relay.scope.pop,
-                    logical_handle,
-                    output={"outcome": outcome},
-                    metadata={
-                        RUNTIME_SCHEMA_KEY: RUNTIME_SCHEMA_VERSION,
-                        RUNTIME_INSTANCE_KEY: lease.host.runtime_id,
-                    },
-                    timeout=_SCOPE_OP_TIMEOUT,
-                )
-            except Exception:
-                with turn.logical_llm_lock:
-                    # Relay scopes are stack-owned. If the newest remaining
-                    # handle cannot close, older handles cannot close safely
-                    # either, so retain the unclosed prefix for diagnostics.
-                    for pending_request_id, pending_handle in logical_calls[
-                        : index + 1
-                    ]:
-                        turn.logical_llm_calls.setdefault(
-                            pending_request_id,
-                            pending_handle,
-                        )
-                logger.warning(
-                    "Hermes Relay logical LLM finalization failed",
-                    exc_info=True,
-                )
-                break
+            failure = lease.host._close_scope_handle(
+                lease.session,
+                logical_handle,
+                output={"outcome": outcome},
+                failure_label="logical LLM scope close failed",
+            )
+            if failure is None:
+                continue
+            with turn.logical_llm_lock:
+                # Relay scopes are stack-owned. If the newest remaining
+                # handle cannot close even after orphan drain, older
+                # handles cannot close safely either — retain the
+                # unclosed prefix for diagnostics (#81521).
+                for pending_request_id, pending_handle in logical_calls[
+                    : index + 1
+                ]:
+                    turn.logical_llm_calls.setdefault(
+                        pending_request_id,
+                        pending_handle,
+                    )
+            logger.warning("Hermes Relay logical LLM finalization failed: %s", failure)
+            break
 
     @staticmethod
     def _reset_turn_context(turn: RelayTurnContext) -> None:

--- a/agent/relay_runtime.py
+++ b/agent/relay_runtime.py
@@ -573,6 +573,20 @@ class RelayRuntime:
 
         def close_with_drain() -> None:
             def current_top() -> Any:
+                # Version-correct accessor first: the pinned nemo-relay
+                # binding exposes ``scope.get_handle()`` returning the
+                # current top-of-stack ScopeHandle.  Its
+                # ``get_scope_stack()`` returns a native ScopeStack object
+                # that ``scope.pop`` rejects with TypeError, so it must
+                # never be treated as a handle (#81601 review).
+                get_handle = getattr(
+                    getattr(self.relay, "scope", None), "get_handle", None
+                )
+                if callable(get_handle):
+                    try:
+                        return get_handle()
+                    except Exception:
+                        pass
                 top = self.relay.get_scope_stack()
                 # Some Relay builds return the live stack (list). Others
                 # return the top handle directly — including tuple handles
@@ -581,6 +595,18 @@ class RelayRuntime:
                 if isinstance(top, list):
                     return top[-1] if top else None
                 return top
+
+            def same_handle(a: Any, b: Any) -> bool:
+                # Native ScopeHandle instances do not implement __eq__ by
+                # value — two handles for the same scope compare unequal —
+                # so compare by uuid when both sides expose one.
+                if a is None or b is None:
+                    return a is b
+                if a is b or a == b:
+                    return True
+                a_uuid = getattr(a, "uuid", None)
+                b_uuid = getattr(b, "uuid", None)
+                return a_uuid is not None and a_uuid == b_uuid
 
             try:
                 self.relay.scope.pop(
@@ -594,12 +620,12 @@ class RelayRuntime:
 
             for _ in range(drain_limit):
                 top = current_top()
-                if top is None or top == handle:
+                if top is None or same_handle(top, handle):
                     break
                 # Never pop the session root while draining for a nested handle.
                 if (
                     session_root is not None
-                    and top == session_root
+                    and same_handle(top, session_root)
                     and handle is not session_root
                 ):
                     break

--- a/agent/relay_runtime.py
+++ b/agent/relay_runtime.py
@@ -669,6 +669,11 @@ class RelayRuntime:
                 session,
                 close_with_drain,
                 allow_closing=allow_closing,
+                # Bound the whole drain+close like the direct pops it
+                # replaced: a wedged native pipeline must cost at most one
+                # span, never block turn/session completion (see
+                # tests/agent/test_relay_runtime_bounded_scope_ops.py).
+                timeout=_SCOPE_OP_TIMEOUT,
             )
         except Exception as exc:
             return f"{failure_label}: {exc}"

--- a/cli.py
+++ b/cli.py
@@ -4859,6 +4859,10 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         # don't auto-queue another continuation on top of a user-cancelled
         # turn (which would make Ctrl+C feel like it did nothing).
         self._last_turn_interrupted = False
+        # When stdout/PTY raises EIO (broken pipe after a stream-stall
+        # interrupt), freeze further UI paints so we don't spin the main
+        # thread at hundreds of escape-sequence writes/sec (#81521).
+        self._terminal_io_broken = False
         self._should_exit = False
         # /exit --delete: when True, the current session's SQLite history and
         # on-disk transcripts are deleted during shutdown. Set by
@@ -5024,6 +5028,20 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         finally:
             self._active_session_lease = None
 
+    def _mark_terminal_io_broken(self, reason: str = "") -> None:
+        """Stop UI paints after the PTY/stdout becomes unusable (#81521)."""
+        if getattr(self, "_terminal_io_broken", False):
+            return
+        self._terminal_io_broken = True
+        try:
+            self._pet_stop_anim()
+        except Exception:
+            pass
+        logger.warning(
+            "Terminal I/O broken%s — freezing UI paints to avoid redraw storm (#81521)",
+            f" ({reason})" if reason else "",
+        )
+
     def _invalidate(self, min_interval: float = 0.25) -> None:
         """Throttled UI repaint for high-frequency background updates.
 
@@ -5041,12 +5059,20 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         within the 250ms window — or an in-flight resize — silently drop it, so
         the prompt never renders and times out unseen (#41098).
         """
+        if getattr(self, "_terminal_io_broken", False):
+            return
         if getattr(self, "_resize_recovery_pending", False):
             return
         now = time.monotonic()
         if hasattr(self, "_app") and self._app and (now - getattr(self, "_last_invalidate", 0.0)) >= min_interval:
             self._last_invalidate = now
-            self._app.invalidate()
+            try:
+                self._app.invalidate()
+            except OSError as exc:
+                if getattr(exc, "errno", None) == errno.EIO:
+                    self._mark_terminal_io_broken("invalidate")
+                    return
+                raise
 
     def _paint_now(self) -> None:
         """Immediate, unthrottled repaint for user-blocking modal prompts.
@@ -5059,10 +5085,17 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         already use. See ``_invalidate`` for why the throttle must not gate
         these paints (#41098).
         """
+        if getattr(self, "_terminal_io_broken", False):
+            return
         app = getattr(self, "_app", None)
         if app is not None:
             try:
                 app.invalidate()
+            except OSError as exc:
+                if getattr(exc, "errno", None) == errno.EIO:
+                    self._mark_terminal_io_broken("paint_now")
+                    return
+                raise
             except Exception:
                 pass
 
@@ -5081,6 +5114,8 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         matching the standard terminal-UX convention (bash, zsh, fish,
         vim, htop).
         """
+        if getattr(self, "_terminal_io_broken", False):
+            return
         app = getattr(self, "_app", None)
         if not app:
             return
@@ -5088,9 +5123,16 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             app,
             rebuild_scrollback=self._redraw_rebuilds_scrollback(),
         )
+        if getattr(self, "_terminal_io_broken", False):
+            return
         _replay_output_history()
         try:
             app.invalidate()
+        except OSError as exc:
+            if getattr(exc, "errno", None) == errno.EIO:
+                self._mark_terminal_io_broken("force_full_redraw")
+                return
+            raise
         except Exception:
             pass
 
@@ -5155,8 +5197,11 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
              screen/cursor state and forces a clean repaint.
 
         Both steps are independently safe and self-guard, so a failure of one
-        never prevents the other.
+        never prevents the other. If the PTY is already dead (EIO), skip the
+        redraw entirely — painting a broken fd is the #81521 redraw storm.
         """
+        if getattr(self, "_terminal_io_broken", False):
+            return
         try:
             from hermes_cli.curses_ui import flush_stdin
             flush_stdin()
@@ -5173,6 +5218,8 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
 
     def _clear_prompt_toolkit_screen(self, app, *, rebuild_scrollback: bool = False) -> None:
         """Clear the terminal and reset prompt_toolkit renderer state."""
+        if getattr(self, "_terminal_io_broken", False):
+            return
         try:
             renderer = app.renderer
             out = renderer.output
@@ -5189,6 +5236,11 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             # next _redraw() starts from a known (0, 0) origin and
             # re-renders every cell rather than diffing against stale.
             renderer.reset(leave_alternate_screen=False)
+        except OSError as exc:
+            if getattr(exc, "errno", None) == errno.EIO:
+                self._mark_terminal_io_broken("clear_screen")
+                return
+            pass
         except Exception:
             pass
 
@@ -6224,6 +6276,9 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         """Advance the frame + invalidate on a timer while a pet is enabled."""
         while self._pet_anim_running:
             time.sleep(self._PET_FRAME_INTERVAL)
+            if getattr(self, "_terminal_io_broken", False):
+                self._pet_anim_running = False
+                break
             now = time.monotonic()
             if now - self._pet_cfg_checked >= self._PET_CFG_INTERVAL:
                 self._pet_cfg_checked = now
@@ -6236,6 +6291,10 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             if app is not None:
                 try:
                     app.invalidate()
+                except OSError as exc:
+                    if getattr(exc, "errno", None) == errno.EIO:
+                        self._mark_terminal_io_broken("pet_anim")
+                        break
                 except Exception:
                     pass
 
@@ -18668,7 +18727,23 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                         except Exception:
                             pass  # Non-fatal — don't break the main loop
 
+                except OSError as e:
+                    if getattr(e, "errno", None) == errno.EIO:
+                        self._mark_terminal_io_broken("process_loop")
+                        logger.warning(
+                            "process_loop EIO — freezing UI paints (#81521): %s",
+                            e,
+                        )
+                        continue
+                    logger.warning("process_loop unhandled error (msg may be lost): %s", e)
                 except Exception as e:
+                    if isinstance(e, OSError) and getattr(e, "errno", None) == errno.EIO:
+                        self._mark_terminal_io_broken("process_loop")
+                        logger.warning(
+                            "process_loop EIO — freezing UI paints (#81521): %s",
+                            e,
+                        )
+                        continue
                     logger.warning("process_loop unhandled error (msg may be lost): %s", e)
         
         # Start processing thread

--- a/tests/hermes_cli/test_relay_shared_metrics_runtime.py
+++ b/tests/hermes_cli/test_relay_shared_metrics_runtime.py
@@ -1303,6 +1303,49 @@ def test_direct_runtime_fake_enforces_lifo_scope_contract(direct_runtime):
     runtime.run_in_session(session, direct_runtime.scope.pop, first)
 
 
+def test_close_session_drains_orphaned_scopes_before_session_pop(direct_runtime):
+    """Orphaned physical scopes must not permanently wedge session close (#81521)."""
+    runtime = relay_runtime.get_runtime()
+    assert runtime is not None
+    session = runtime.ensure_session({"session_id": "orphan-drain"})
+    assert session is not None
+    session_handle = session.handle
+
+    orphan = runtime.run_in_session(
+        session,
+        direct_runtime.scope.push,
+        "orphaned-physical-llm",
+        direct_runtime.ScopeType.Function,
+        handle=session_handle,
+    )
+    assert orphan is not None
+
+    # Without drain, popping the session while the orphan is on top fails
+    # with "scope handle is not at the top of the stack".
+    runtime.close_session({"session_id": "orphan-drain"})
+
+    assert runtime.get_session("orphan-drain") is None
+    rejected = [
+        event
+        for event in direct_runtime.events
+        if event[0] == "scope.pop.rejected" and event[1] == session_handle
+    ]
+    # First attempt may reject; drain + retry must succeed so the session
+    # handle is eventually popped (not left rejected-only).
+    session_pops = [
+        event
+        for event in direct_runtime.events
+        if event[0] == "scope.pop" and event[1] == session_handle
+    ]
+    orphan_pops = [
+        event
+        for event in direct_runtime.events
+        if event[0] == "scope.pop" and event[1] == orphan
+    ]
+    assert orphan_pops, "orphaned physical scope was not drained"
+    assert session_pops, f"session scope never closed (rejected={rejected!r})"
+
+
 def test_concurrent_turn_skips_relay_before_scope_stack_can_interleave(
     direct_runtime,
 ):

--- a/tests/hermes_cli/test_relay_shared_metrics_runtime.py
+++ b/tests/hermes_cli/test_relay_shared_metrics_runtime.py
@@ -1346,6 +1346,45 @@ def test_close_session_drains_orphaned_scopes_before_session_pop(direct_runtime)
     assert session_pops, f"session scope never closed (rejected={rejected!r})"
 
 
+def test_real_binding_drains_orphaned_scope_before_session_pop(
+    real_binding_runtime,
+):
+    """Orphan drain must work against the pinned native binding (#81521).
+
+    Regression guard for the #81601 review finding: the native binding's
+    ``get_scope_stack()`` returns a ``ScopeStack`` object (not a list and
+    not a ``ScopeHandle``), and ``scope.pop`` rejects it with TypeError.
+    The drain path must use the version-correct top accessor
+    (``scope.get_handle()``) and compare handles by uuid, because native
+    ``ScopeHandle`` instances do not compare equal by value.
+    """
+    runtime = relay_runtime.get_runtime()
+    assert runtime is not None
+    session = runtime.ensure_session({"session_id": "native-orphan-drain"})
+    assert session is not None
+
+    orphan = runtime.run_in_session(
+        session,
+        real_binding_runtime.scope.push,
+        "orphaned-physical-llm",
+        real_binding_runtime.ScopeType.Function,
+        handle=session.handle,
+    )
+    assert orphan is not None
+
+    # Without the drain fix this fails: the direct session pop raises
+    # "scope handle is not at the top of the stack", and the pre-fix
+    # drain retried with a ScopeStack object that pop() rejects.
+    failure = runtime._close_scope_handle(
+        session,
+        session.handle,
+        output={},
+        allow_closing=True,
+        failure_label="session scope close failed",
+    )
+    assert failure is None, failure
+
+
 def test_concurrent_turn_skips_relay_before_scope_stack_can_interleave(
     direct_runtime,
 ):

--- a/tests/hermes_cli/test_terminal_io_broken_81521.py
+++ b/tests/hermes_cli/test_terminal_io_broken_81521.py
@@ -1,0 +1,59 @@
+"""CLI freezes UI paints after stdout/PTY EIO (#81521).
+
+A stream-stall interrupt that corrupts the PTY used to leave the classic
+CLI invalidating hundreds of times per second (escape-sequence flood).
+Once EIO is observed, paints must stop.
+"""
+
+from __future__ import annotations
+
+import errno
+from unittest.mock import MagicMock
+
+import pytest
+
+
+def _make_cli_stub():
+    from cli import HermesCLI
+
+    cli = object.__new__(HermesCLI)
+    cli._terminal_io_broken = False
+    cli._resize_recovery_pending = False
+    cli._last_invalidate = 0.0
+    cli._pet_anim_running = False
+    cli._app = MagicMock()
+    return cli
+
+
+class TestTerminalIoBrokenFreeze:
+    def test_mark_terminal_io_broken_is_idempotent(self):
+        cli = _make_cli_stub()
+        cli._mark_terminal_io_broken("first")
+        cli._mark_terminal_io_broken("second")
+        assert cli._terminal_io_broken is True
+
+    def test_invalidate_stops_after_eio(self):
+        cli = _make_cli_stub()
+        cli._app.invalidate.side_effect = OSError(errno.EIO, "Input/output error")
+
+        cli._invalidate(min_interval=0.0)
+
+        assert cli._terminal_io_broken is True
+        assert cli._app.invalidate.call_count == 1
+
+        cli._invalidate(min_interval=0.0)
+        # Frozen — no further paints.
+        assert cli._app.invalidate.call_count == 1
+
+    def test_force_full_redraw_skipped_when_broken(self):
+        cli = _make_cli_stub()
+        cli._terminal_io_broken = True
+        cli._force_full_redraw()
+        cli._app.invalidate.assert_not_called()
+
+    def test_recover_terminal_after_interrupt_skips_when_broken(self):
+        cli = _make_cli_stub()
+        cli._terminal_io_broken = True
+        cli._force_full_redraw = MagicMock()
+        cli._recover_terminal_after_interrupt()
+        cli._force_full_redraw.assert_not_called()

--- a/tests/run_agent/test_stream_interrupt_retry.py
+++ b/tests/run_agent/test_stream_interrupt_retry.py
@@ -272,6 +272,21 @@ class TestStreamInterruptJoinsWorkerBeforeRaise:
 
         monkeypatch.setattr(threading.Thread, "join", spy_join)
 
+        # The join is gated on Relay managed execution being live (it is
+        # pointless — and delays interrupt detection — when no Relay
+        # consumers are registered). Simulate a live runtime.
+        from agent import relay_runtime as rr
+
+        monkeypatch.setattr(
+            rr,
+            "get_runtime",
+            lambda *a, **k: SimpleNamespace(
+                managed_execution_enabled=lambda: True,
+                get_session=lambda *a2, **k2: None,
+                ensure_session=lambda *a2, **k2: None,
+            ),
+        )
+
         class HangUntilClosedStream:
             response = SimpleNamespace(headers={})
 

--- a/tests/run_agent/test_stream_interrupt_retry.py
+++ b/tests/run_agent/test_stream_interrupt_retry.py
@@ -240,3 +240,71 @@ class TestStreamInterruptBeforeRetry:
         assert "new final" in delivered
         assert response.choices[0].message.content == "new final"
         assert mock_abort.called
+
+
+class TestStreamInterruptJoinsWorkerBeforeRaise:
+    """#81521: interrupt must join the stream worker before raising.
+
+    Raising InterruptedError immediately lets Relay turn teardown race a
+    still-open physical LLM scope ("scope handle is not at the top of the
+    stack") and cascade into the CLI EIO / redraw storm.
+    """
+
+    @pytest.mark.filterwarnings(
+        "ignore::pytest.PytestUnhandledThreadExceptionWarning"
+    )
+    @patch("run_agent.AIAgent._create_request_openai_client")
+    @patch("run_agent.AIAgent._close_request_openai_client")
+    def test_interrupt_joins_worker_before_raising(
+        self, mock_close, mock_create, monkeypatch
+    ):
+        import threading
+
+        import httpx
+
+        join_timeouts: list[float | None] = []
+        original_join = threading.Thread.join
+
+        def spy_join(self, *args, **kwargs):
+            timeout = kwargs.get("timeout", args[0] if args else None)
+            join_timeouts.append(timeout)
+            return original_join(self, *args, **kwargs)
+
+        monkeypatch.setattr(threading.Thread, "join", spy_join)
+
+        class HangUntilClosedStream:
+            response = SimpleNamespace(headers={})
+
+            def __iter__(self):
+                # Block until the poll loop force-closes / cancels; then
+                # surface a transport error like a real aborted SSE body.
+                import time
+
+                deadline = time.time() + 5.0
+                while time.time() < deadline:
+                    time.sleep(0.05)
+                raise httpx.RemoteProtocolError("connection closed by interrupt")
+
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.return_value = HangUntilClosedStream()
+        mock_create.return_value = mock_client
+
+        agent = _make_agent()
+        agent._interrupt_requested = False
+
+        def fire_interrupt():
+            import time
+
+            time.sleep(0.2)
+            agent._interrupt_requested = True
+
+        threading.Thread(target=fire_interrupt, daemon=True).start()
+
+        with pytest.raises(InterruptedError, match="interrupted"):
+            agent._interruptible_streaming_api_call({})
+
+        assert 2.0 in join_timeouts, (
+            f"Expected a 2.0s worker join before InterruptedError; "
+            f"saw join timeouts {join_timeouts!r}. Without the join, Relay "
+            f"scope teardown races the stream worker (#81521)."
+        )


### PR DESCRIPTION
## Summary

Salvage of #81601 by @HexLab98 (cherry-picked onto current main with authorship preserved), fixing #81521 — the interactive CLI deadlocked and corrupted the terminal UI when a provider stream stalled (EmptyStreamError → interrupt → Relay LIFO scope corruption → PTY EIO → unbounded escape-sequence redraw storm, SIGKILL-only recovery).

### Salvaged from #81601 (author: @HexLab98)
- **Join the streaming worker after interrupt abort** (`interruptible_streaming_api_call`) so Relay physical LLM scopes unwind before turn teardown, instead of racing `finish_logical_calls` / `end_turn` / `close_session` against a still-open physical scope (`scope handle is not at the top of the stack`).
- **Best-effort drain of orphaned Relay child scopes** (`RelayRuntime._close_scope_handle`) when a LIFO parent pop fails, so session/turn/logical close recovers instead of wedging the stack.
- **Freeze classic CLI paints after stdout/PTY EIO** (`_mark_terminal_io_broken` + guards in `_invalidate` / `_paint_now` / `_force_full_redraw` / `_recover_terminal_after_interrupt` / `_clear_prompt_toolkit_screen`) so interrupt recovery can never enter the redraw storm.
- Tests: stream-interrupt join, orphan drain (fake runtime), EIO paint freeze.

### Follow-up widening (this PR)
- **Sibling interrupt paths**: the same bounded `t.join(timeout=2.0)`-before-`InterruptedError` applied to the **non-streaming API poll loop** and the **Bedrock streaming poll loop** in `chat_completion_helpers.py` — both share the raise-without-join shape and both workers run Relay-managed physical attempts.
- **#81601 review finding addressed** (thanks @egilewski): the pinned nemo-relay binding's `get_scope_stack()` returns a native `ScopeStack` that `scope.pop` rejects with `TypeError`, so the drain never drained under the real binding. `current_top()` now prefers the version-correct `scope.get_handle()` accessor (falls back to the legacy list-unwrap for fakes), and handle comparisons go through a uuid-aware `same_handle()` because native `ScopeHandle` instances don't implement value equality (verified live: `top == h` is `False` even when `top.uuid == h.uuid`).
- **New native-binding regression test** `test_real_binding_drains_orphaned_scope_before_session_pop` reproduces the orphaned-scope session close against the pinned native wheel (skips where the binding is unavailable). Sabotage-verified: disabling the `get_handle` path makes it fail with the exact production error `scope handle is not at the top of the stack`.

### Verification on current main
- Bug still present pre-fix: `close_session` / `end_turn` / `_finish_logical_calls` called raw `scope.pop` with no drain; the streaming interrupt raised `InterruptedError` without joining the worker; no CLI EIO paint freeze existed.
- Live probe against the pinned nemo-relay 0.7.1 binding confirmed: out-of-order pop raises `RuntimeError: invalid argument: scope handle is not at the top of the stack`; `scope.pop(ScopeStack)` raises `TypeError`; drain via `scope.get_handle()` + uuid comparison closes cleanly.

### Tests
- `tests/run_agent/test_stream_interrupt_retry.py`, `tests/hermes_cli/test_terminal_io_broken_81521.py` — 9 passed
- `tests/hermes_cli/test_relay_shared_metrics_runtime.py` — 45 passed (native-binding drain test included, no skips locally)
- `tests/agent/test_relay_llm.py`, `tests/run_agent/test_streaming.py`, `tests/hermes_cli/test_suppress_eio_on_interrupt.py` — 61 passed

Fixes #81521
Supersedes #81601 (contributor commits cherry-picked with authorship preserved)

## Infographic

![cli-empty-stream-deadlock](https://files.catbox.moe/n3m8lm.png)
