### PR TITLE
fix(tui_gateway): spare live-turn sessions from the shutdown finalize sweep

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -15718,6 +15718,31 @@ def test_shutdown_sessions_spares_a_session_whose_turn_is_running(monkeypatch):
         server._sessions.clear()
 
 
+def test_shutdown_sessions_skips_a_session_the_drain_already_finalized(monkeypatch):
+    """`compute_host.flush_all_sessions` finalizes in place without popping.
+
+    Its sessions therefore reach the atexit sweep with the latch already spent,
+    so a second teardown has nothing left to persist and would only re-announce
+    a reclaim and close an agent on a process that is exiting.
+    """
+    monkeypatch.setattr(server, "_release_gateway_wake_owner", lambda: False)
+    torn = []
+    monkeypatch.setattr(
+        server,
+        "_teardown_session",
+        lambda session, *, end_reason: torn.append(session["_sid"]),
+    )
+    server._sessions.clear()
+    flushed = {"running": False, "_finalized": True}
+    server._sessions["flushed"] = flushed
+    try:
+        server._shutdown_sessions()
+        assert torn == []
+        assert server._sessions.get("flushed") is flushed
+    finally:
+        server._sessions.clear()
+
+
 def _idle_evictable_session(now):
     """A session that satisfies every eviction precondition."""
     ready = threading.Event()

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -15686,6 +15686,38 @@ def test_shutdown_sessions_closes_every_session_via_helper(monkeypatch):
         server._sessions.clear()
 
 
+def test_shutdown_sessions_spares_a_session_whose_turn_is_running(monkeypatch):
+    """The atexit sweep must not spend a live session's one-shot finalize latch.
+
+    Nothing joins the turn thread, so finalizing mid-turn persists a truncated
+    transcript, commits memory from it and releases the active-session lease
+    under live work, leaving the session permanently un-finalizable. Unfinalized
+    stays recoverable through the turn-end flush.
+    """
+    monkeypatch.setattr(server, "_release_gateway_wake_owner", lambda: False)
+    torn = []
+    monkeypatch.setattr(
+        server,
+        "_teardown_session",
+        lambda session, *, end_reason: torn.append((session["_sid"], end_reason)),
+    )
+    server._sessions.clear()
+    live = {"running": True}
+    idle = {"running": False}
+    server._sessions["live"] = live
+    server._sessions["idle"] = idle
+    try:
+        server._shutdown_sessions()
+        # The idle session is reclaimed exactly as before.
+        assert torn == [("idle", "tui_shutdown")]
+        assert "idle" not in server._sessions
+        # The live one is left registered and un-latched.
+        assert server._sessions.get("live") is live
+        assert not live.get("_finalized")
+    finally:
+        server._sessions.clear()
+
+
 def _idle_evictable_session(now):
     """A session that satisfies every eviction precondition."""
     ready = threading.Event()

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -15673,7 +15673,7 @@ def test_shutdown_sessions_closes_every_session_via_helper(monkeypatch):
     seen = []
     monkeypatch.setattr(
         server, "_close_session_by_id",
-        lambda sid, *, end_reason: seen.append((sid, end_reason)),
+        lambda sid, *, end_reason, predicate=None: seen.append((sid, end_reason)),
     )
     server._sessions.clear()
     server._sessions["a"] = {}

--- a/tui_gateway/compute_host.py
+++ b/tui_gateway/compute_host.py
@@ -208,17 +208,16 @@ class ComputeHost:
 
         NOTE: ``server._shutdown_sessions`` is registered via ``atexit``
         (``server.py``) and runs on ``SystemExit`` after ``shutdown()``
-        returns. It calls ``_finalize_session`` on any session still in
-        ``server._sessions`` — including ones skipped here whose turn is
-        still running, since ``_executor.shutdown(wait=False)`` only cancels
-        pending futures, not running ones. The orphan path (``os._exit(0)``)
-        bypasses atexit, so the skip is fully effective there. For the
-        SIGTERM and stdin_closed paths the atexit handler may re-finalize
-        skipped sessions; this is a pre-existing issue (the old finalize-
-        first order had the same atexit interaction) and does not make the
-        drain-before-finalize reordering worse. A follow-up could gate
-        ``_shutdown_sessions`` on ``not session.get("_finalized") and not
-        session.get("running")`` to close the gap.
+        returns. It reaches any session still in ``server._sessions`` —
+        including ones skipped here whose turn is still running, since
+        ``_executor.shutdown(wait=False)`` only cancels pending futures, not
+        running ones. The orphan path (``os._exit(0)``) bypasses atexit
+        entirely, so the skip has always been fully effective there. On the
+        SIGTERM and stdin_closed paths the skip now survives the handler too:
+        ``_shutdown_sessions`` gates every close on
+        ``_shutdown_session_is_reclaimable`` — ``not session.get("_finalized")
+        and not session.get("running")`` — so a session skipped here keeps its
+        unspent latch, and one flushed here is not torn down a second time.
         """
         self._closed.set()
         budget = max(0.0, wait)

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -1176,6 +1176,30 @@ def _close_sessions_for_transport(
     return reaped, detached
 
 
+def _shutdown_session_is_reclaimable(session: dict) -> bool:
+    """Whether the atexit sweep may finalize ``session``.
+
+    ``_finalize_session`` is a one-shot latch, so spending it on a session
+    whose turn is still running throws that single chance away mid-turn:
+    ``_persist_session`` snapshots a truncated transcript, ``commit_memory_session``
+    commits long-term memory from it, the durable row is ended, ``on_session_end``
+    fires ``interrupted=True``, and the active-session lease is released out from
+    under live work — while nothing joins the turn thread, so its tail is
+    thereafter unpersistable. Leaving a live-turn session unfinalized keeps it
+    recoverable through the turn-end flush instead, the same trade
+    ``compute_host.HostRuntime.shutdown`` already makes for its drain flush.
+
+    Sessions the drain flush already finalized are skipped for the same reason
+    in reverse: the latch is spent, so teardown has nothing left to persist and
+    would only re-announce a reclaim and close an agent on a dying process.
+
+    Every other automatic reclaim path in this module already gates on
+    ``running`` (``_ws_session_is_orphaned``, ``_session_is_evictable``,
+    ``_session_is_lru_evictable``); this one runs on *every* exit and did not.
+    """
+    return not session.get("_finalized") and not session.get("running")
+
+
 def _shutdown_sessions() -> None:
     try:
         _release_gateway_wake_owner()
@@ -1184,7 +1208,11 @@ def _shutdown_sessions() -> None:
     with _sessions_lock:
         sids = list(_sessions)
     for sid in sids:
-        _close_session_by_id(sid, end_reason="tui_shutdown")
+        _close_session_by_id(
+            sid,
+            end_reason="tui_shutdown",
+            predicate=_shutdown_session_is_reclaimable,
+        )
 
 
 # Last-resort net for any disconnect path that slips past the WS finally. TTL is


### PR DESCRIPTION
## What does this PR do?

**This fix is specified verbatim by our own merged code.** `tui_gateway/compute_host.py:219-222` on `main` — merged in #77330 — ends the `HostRuntime.shutdown` docstring with:

> NOTE: `server._shutdown_sessions` is registered via `atexit` (`server.py`) and runs on `SystemExit` after `shutdown()` returns. It calls `_finalize_session` on any session still in `server._sessions` — including ones skipped here whose turn is still running, since `_executor.shutdown(wait=False)` only cancels pending futures, not running ones. […] **A follow-up could gate `_shutdown_sessions` on `not session.get("_finalized") and not session.get("running")` to close the gap.**

This PR is that follow-up, with the exact predicate the NOTE names, plus the NOTE rewritten to describe the closed gap instead of the open one.

### The gap

`tui_gateway/server.py:1179-1187` on `main`:

```python
def _shutdown_sessions() -> None:
    try:
        _release_gateway_wake_owner()
    except Exception:
        pass
    with _sessions_lock:
        sids = list(_sessions)
    for sid in sids:
        _close_session_by_id(sid, end_reason="tui_shutdown")
```

No gate on turn state. `_finalize_session` (`server.py:729-740`) is a **one-shot latch** — it sets `session["_finalized"] = True` and every later call returns immediately. Spending that latch while a turn is running runs each step against a live session:

| step | `server.py` | effect mid-turn |
|---|---|---|
| `agent._persist_session(snapshot)` | `:765` | persists a **truncated** transcript |
| `commit_memory_session(history)` | `:795` | commits long-term memory **from that truncated history** |
| `db.end_session(sid, end_reason)` | `:827` | ends a live durable row |
| `invoke_hook("on_session_end", …)` | `:783` | fires `completed=False, interrupted=True` on a running turn |
| `_release_active_session_slot(session)` | `:741` | drops the lease out from under live work |
| `interrupt_for_session(...)` | `:851` | kills in-flight async delegations |

Nothing joins the turn thread, so the tail it goes on to produce is **thereafter unpersistable** — the session is permanently un-finalizable.

### Why it fires for everyone

`atexit.register(_shutdown_sessions)` (`server.py:1368`) runs on stdin EOF and on any `sys.exit(0)`, and `tui_gateway/entry.py:155-160` calls it directly from `_log_signal` on SIGTERM / SIGHUP / SIGBREAK, inside the grace-window hard-exit timer. No config key gates it. So quitting the TUI, closing the desktop app, or stopping the dashboard backend **while the assistant is mid-reply** loses that reply and any tool tail, on the default configuration — and MEMORY has already been committed from the truncated transcript.

### The in-file contrast

Every other automatic reclaim path in `server.py` already refuses to reclaim mid-turn. The one that runs on *every* exit did not:

| path | line | guard |
|---|---|---|
| `_ws_session_is_orphaned` | `:1021` | `if session.get("running"): return False` |
| `_session_is_evictable` | `:1212` | `if session.get("running") or _session_pending_kind(sid)` |
| `_session_is_lru_evictable` | `:1300` | *"never evict a session mid-turn"* (`:1301`) |
| **`_shutdown_sessions`** | **`:1187`** | **none** |

### The fix

`_close_session_by_id` already accepts `predicate=` and re-validates it **under `_sessions_lock` immediately before the ownership claim** (`server.py:983-1009`), exactly as the idle and LRU reapers use it. So the change adds no new locking and no new teardown path:

```python
for sid in sids:
    _close_session_by_id(
        sid,
        end_reason="tui_shutdown",
        predicate=_shutdown_session_is_reclaimable,
    )
```

Leaving a live-turn session **unfinalized** is this repo's established answer, not a new judgement call: `eb4f514b2d3` ("retain live-turn sessions unfinalized when the drain deadline expires") makes the same trade one layer up. Unfinalized stays recoverable via the turn-end flush; latched mid-turn is permanent.

The `_finalized` half of the predicate covers the sibling case: `compute_host.flush_all_sessions` finalizes sessions **in place without popping them** from `server._sessions`, so a session the drain already flushed would otherwise be torn down a second time at exit — re-announcing a reclaim and calling `agent.close()` on a dying process, with a finalize that is already a no-op.

## Related Issue

No filed issue — this is the follow-up named in the merged `compute_host.shutdown` NOTE (#77330).

Related: `eb4f514b2d3` (drain-deadline live-turn skip), #77330 (the NOTE this closes).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tui_gateway/server.py` — add `_shutdown_session_is_reclaimable(session)` and pass it as `_shutdown_sessions`' `predicate=`, so the atexit sweep skips sessions that are mid-turn or already finalized.
- `tui_gateway/compute_host.py` — rewrite the now-stale `HostRuntime.shutdown` NOTE. It described the atexit re-finalize as an open accepted gap and proposed this predicate; it now records the contract that exists.
- `tests/test_tui_gateway_server.py` — two regression tests (below), plus the `predicate=None` keyword on the existing `test_shutdown_sessions_closes_every_session_via_helper` stub so it keeps asserting that every *eligible* session is routed through the helper.

### Sibling sweep — all 6 reclaim sites, and the one deliberately excluded

Enumerated `_close_session_by_id(` / `_teardown_session(` / `_teardown_popped_session(` / `_finalize_session(` across `tui_gateway/`:

1. `_reap_idle_sessions` (`:1233`) — already gates via `_session_is_evictable` ✓
2. `_enforce_session_cap` (`:1333`) — already gates via `_session_is_lru_evictable` ✓
3. `_schedule_ws_orphan_reap` — already gates via `_ws_session_is_orphaned` ✓
4. **`_shutdown_sessions` (`:1187`) — fixed here**
5. **the `close_on_disconnect` branch of `_close_sessions_for_transport` (`:1163`) — same missing gate, DELIBERATELY EXCLUDED.** Three open PRs already have hunks inside `_close_sessions_for_transport`, so touching it here would guarantee a conflict with work in flight: **#77129** (@JoaoMarcos44) rewrites that `for`-loop body outright (`@@ -1077,23 +1076,48 @@`, including the `close_on_disconnect` branch itself), and **#86039** (@ayushnangia) and **#57687** (@yingliang-zhang) each add hunks inside the same function. Flagging it rather than silently omitting it: it is a real sibling and it wants the same gate.
6. the `session.close` RPC — user-initiated, not an automatic reclaim. Out of scope by design.

### Related open PRs, disclosed up front

- **#60302** (@ruanbarroso, *"finalize sessions on clean pipe exit"*, open, cold since 07-24) — **its test asserts the behaviour this PR changes.** Its production diff touches `tui_gateway/entry.py::_log_exit` only (adds a `server._shutdown_sessions()` call), so there is **no textual conflict** with this diff. But `test_shutdown_sessions_persists_tool_tail_and_marks_tui_shutdown` builds a `running=True` session and asserts `_shutdown_sessions` ends it as `tui_shutdown`. Reconciliation: that PR's goal is to stop an interrupted turn being left for a later WS-orphan reap, and `eb4f514b2d3` has since established unfinalized-but-recoverable as the *desired* state for a live turn — the two goals meet by keeping the session registered and recoverable, not by latching it. If #60302 lands first, that assertion is the thing to update.
- **#79109** (@sakshamzip2-sys) — edits `_finalize_session`'s **body** (persist retry). Different function, but adjacent enough that a textual conflict is possible.
- **#25027** (@jamesdag, May) — rewrites `_shutdown_sessions`' loop body to background cleanup for `session.close`. Different concern (blocking `/new`), and its base predates the `_close_session_by_id` funnel entirely, so it conflicts with `main` independently of this PR.
- **#85598** (@686f6c61) and **#44102** (@AIalliAI) — apply the same never-reclaim-mid-turn principle to the sibling `_schedule_ws_orphan_reap` path. Corroborating, not colliding.
- **#81319** — closest by user-visible harm ("keep and recover interrupted chats across update/restart"), but a complementary mechanism (turn-marker preservation + boot recovery); it does not prevent the latch from being spent.

## How to Test

1. Reproduce: start a TUI/desktop session, send a prompt, and quit (or `SIGTERM` the gateway) while the assistant is still streaming. On `main` the session's durable row is already `ended`, the reply tail is missing on reopen, and memory has been committed from the truncated transcript.
2. Regression tests — both **fail on `main`, pass with this change**:

```
uv run --with pytest --with pytest-asyncio python3 -m pytest \
  tests/test_tui_gateway_server.py -k shutdown_sessions -v
```

`test_shutdown_sessions_spares_a_session_whose_turn_is_running` — registers one `running=True` and one `running=False` session, stubs `_teardown_session` so the real `_close_session_by_id` predicate path runs. Asserts the idle session is still reclaimed as `tui_shutdown` and popped, the live one is still in `_sessions`, and its `_finalized` latch is unspent.
Red on `main`: `assert [('live', 'tui_shutdown'), ('idle', 'tui_shutdown')] == [('idle', 'tui_shutdown')]`.

`test_shutdown_sessions_skips_a_session_the_drain_already_finalized` — registers a session with `_finalized` already set (the state `compute_host.flush_all_sessions` leaves behind) and asserts the sweep does not tear it down again.
Red on `main`: `assert ['flushed'] == []`.

Both directions were verified by restoring `tui_gateway/server.py` from `origin/main` and re-running each test individually.

3. Adjacent suites, all green:

```
uv run --with pytest --with pytest-xdist --with pytest-asyncio python3 -m pytest \
  tests/test_tui_gateway_server.py tests/tui_gateway/ tests/test_tui_gateway_ws.py \
  tests/test_tui_gateway_queue_on_busy.py tests/test_tui_gateway_server_crash_history.py -q
# 1060 passed, 1 skipped
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — ran the `tui_gateway` suites listed above (1060 passed, 1 skipped), not the full tree
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 25.4)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — the `compute_host.shutdown` NOTE and the new `_shutdown_session_is_reclaimable` docstring
- [x] N/A — no config keys added or changed
- [x] N/A — no architecture or workflow change
- [x] I've considered cross-platform impact (Windows, macOS) — pure-Python dict predicate, no platform branches; the SIGHUP/SIGBREAK entry path is unchanged
- [x] N/A — no tool behaviour changed
