### PR TITLE
fix(gateway): route delivery-ledger owner-liveness probe through _pid_exists (#41662)

### DIFF
--- a/gateway/delivery_ledger.py
+++ b/gateway/delivery_ledger.py
@@ -158,16 +158,32 @@ def _owner_alive(pid: Any, started_at: Any) -> bool:
         current_start = None
     if current_start is None:
         # No such process (or unreadable) — treat unreadable-but-extant
-        # processes as alive only if the pid exists.
+        # processes as alive only if the pid exists. Route through the
+        # cross-platform probe: ``os.kill(pid, 0)`` on Windows is NOT a
+        # no-op (bpo-14484 — CPython maps sig=0 to
+        # ``GenerateConsoleCtrlEvent(0, pid)``), so a raw probe here could
+        # Ctrl+C the gateway's own console group whenever psutil failed to
+        # read the start time of a live pid. ``_pid_exists`` keeps the
+        # EPERM-means-alive semantics (exists but owned by another user).
         try:
-            os.kill(pid, 0)  # windows-footgun: ok — EPERM counts as alive below
-        except ProcessLookupError:
-            return False
-        except PermissionError:
+            from gateway.status import _pid_exists
+        except Exception:
+            if os.name == "nt":
+                # Never fall back to a raw sig-0 probe on Windows.
+                return False
+            try:
+                os.kill(pid, 0)  # windows-footgun: ok — POSIX-only fallback branch
+            except ProcessLookupError:
+                return False
+            except PermissionError:
+                return True
+            except OSError:
+                return False
             return True
-        except OSError:
+        try:
+            return bool(_pid_exists(pid))
+        except Exception:
             return False
-        return True
     if started_at is None:
         return True
     try:

--- a/tests/gateway/test_delivery_ledger.py
+++ b/tests/gateway/test_delivery_ledger.py
@@ -297,3 +297,59 @@ class TestUnconnectedPlatformKeepsItsBudget:
         )
         assert _row("ob-1")["attempts"] == 0
 
+
+
+class TestOwnerAlivePidProbe:
+    """_owner_alive's no-start-time fallback must route through
+    gateway.status._pid_exists, never a raw ``os.kill(pid, 0)`` probe.
+
+    On Windows ``os.kill(pid, 0)`` is NOT a no-op: CPython maps sig=0 to
+    ``GenerateConsoleCtrlEvent(0, pid)`` (bpo-14484), so probing a LIVE pid
+    whose start time psutil could not read would Ctrl+C its console group.
+    Pattern per the windows-native-support reference: patch
+    ``gateway.status._pid_exists``, not ``os.kill``.
+    """
+
+    def _no_start_time(self, monkeypatch):
+        from gateway import status
+
+        monkeypatch.setattr(status, "get_process_start_time", lambda pid: None)
+
+    def test_alive_when_pid_exists(self, monkeypatch):
+        from gateway import status
+
+        self._no_start_time(monkeypatch)
+        monkeypatch.setattr(status, "_pid_exists", lambda pid: True)
+        assert dl._owner_alive(12345, 999) is True
+
+    def test_dead_when_pid_gone(self, monkeypatch):
+        from gateway import status
+
+        self._no_start_time(monkeypatch)
+        monkeypatch.setattr(status, "_pid_exists", lambda pid: False)
+        assert dl._owner_alive(12345, 999) is False
+
+    def test_raw_os_kill_probe_never_used(self, monkeypatch):
+        """Regression guard: the probe must not touch os.kill when
+        gateway.status._pid_exists is importable (i.e. always in-tree)."""
+        from gateway import status
+
+        self._no_start_time(monkeypatch)
+        calls = []
+        monkeypatch.setattr(status, "_pid_exists", lambda pid: calls.append(pid) or True)
+        monkeypatch.setattr(
+            dl.os, "kill", lambda *a, **k: (_ for _ in ()).throw(AssertionError("raw os.kill probe used"))
+        )
+        assert dl._owner_alive(4242, 999) is True
+        assert calls == [4242]
+
+    def test_probe_exception_means_dead(self, monkeypatch):
+        from gateway import status
+
+        self._no_start_time(monkeypatch)
+
+        def boom(pid):
+            raise RuntimeError("probe blew up")
+
+        monkeypatch.setattr(status, "_pid_exists", boom)
+        assert dl._owner_alive(12345, 999) is False


### PR DESCRIPTION
## Summary

Fixes the last genuinely Windows-unsafe `os.kill(pid, 0)` liveness probe remaining on main after the `_pid_exists` migration (issue #41662, os.kill half).

`gateway/delivery_ledger.py::_owner_alive` fell back to a raw `os.kill(pid, 0)` probe whenever a process start time was unreadable. On Windows that call is **not** a no-op: CPython maps `sig=0` to `GenerateConsoleCtrlEvent(0, pid)` (bpo-14484), so probing a **live** pid whose start time psutil couldn't read would Ctrl+C the target's entire console group. The site carried a `# windows-footgun: ok` annotation, but the annotation only justified the EPERM-means-alive exception semantics — not the Ctrl+C side effect on live pids. Unlike the other two remaining annotated sites (`hermes_cli/tools_config.py:1265` early-returns on win32; `gateway/run.py` watcher carries its own inline ctypes `OpenProcess` check), this one had no platform guard.

## Changes

- `_owner_alive` now routes its pid-exists fallback through `gateway.status._pid_exists` (psutil-first; ctypes `OpenProcess`/`WaitForSingleObject` on Windows), preserving the EPERM-means-alive semantics (`_pid_exists` returns True for alive-but-other-user).
- A POSIX-only raw-probe fallback remains for the (practically unreachable) case where `gateway.status` cannot be imported; on Windows that path reports dead instead of firing a sig-0 probe.
- 4 new tests in `tests/gateway/test_delivery_ledger.py::TestOwnerAlivePidProbe`, patterned on the windows-native-support rule (patch `gateway.status._pid_exists`, never `os.kill`), including a regression guard asserting `os.kill` is never touched by the probe.

## Verification

- `tests/gateway/test_delivery_ledger.py` — 17 passed; `test_delivery_ledger_producer.py` — 22 passed total with siblings.
- Sabotage run: reverted the source fix → 2 of the new tests go red; restored → green.
- `ruff check` clean; `scripts/check-windows-footguns.py gateway/delivery_ledger.py` clean.

Part of #41662 (does not close it — the watchdog/auto-recovery half is tracked separately).

## Infographic

![infographic-41662-pid-exists](https://gist.githubusercontent.com/teknium1/24c2c14ec0e270dfdc9b762e5a0f98d1/raw/infographic-41662-pid-exists.png)
