### PR TITLE
fix(packaging): ship bundled plugin manifests (salvage #82977)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -424,6 +424,10 @@ hermes_cli = ["observability/schemas/*.json", "data/*.json"]
 # topic-setup image disappears. Loaded via Path(__file__).parent / "assets"
 # in gateway/status_phrases.py and gateway/run.py.
 gateway = ["assets/**/*"]
+# Bundled plugin discovery reads these manifests at runtime. Keep them in
+# sealed wheels with the plugin Python modules; without this declaration the
+# wheel contains adapters but discovery finds zero bundled plugins.
+plugins = ["**/plugin.yaml", "**/plugin.yml"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/tests/test_packaging_build_guard.py
+++ b/tests/test_packaging_build_guard.py
@@ -3,6 +3,8 @@
 import os
 import subprocess
 import sys
+import tarfile
+import zipfile
 from pathlib import Path
 
 import pytest
@@ -69,4 +71,26 @@ def test_artifact_build_allows_explicit_nix_package_build_marker(kind, artifact_
     result = _build_artifact(kind, tmp_path, nix_build=True)
 
     assert result.returncode == 0, result.stderr
-    assert list(tmp_path.glob(artifact_glob))
+    artifacts = list(tmp_path.glob(artifact_glob))
+    assert artifacts
+
+    expected = {
+        path.relative_to(PROJECT_ROOT).as_posix()
+        for pattern in ("plugin.yaml", "plugin.yml")
+        for path in (PROJECT_ROOT / "plugins").rglob(pattern)
+    }
+    assert expected, "expected bundled plugin manifests under plugins/"
+
+    if kind == "wheel":
+        with zipfile.ZipFile(artifacts[0]) as wheel:
+            shipped = set(wheel.namelist())
+    else:
+        with tarfile.open(artifacts[0]) as sdist:
+            shipped = {
+                name.split("/", 1)[1]
+                for name in sdist.getnames()
+                if "/" in name
+            }
+
+    missing = sorted(expected - shipped)
+    assert not missing, f"{kind} omits bundled plugin manifests: {missing}"


### PR DESCRIPTION
## Summary

Salvages PR #82977 by @JoaoMarcos44 onto current main (cherry-picked with authorship preserved). Fixes #82916 and #83991.

Released wheels/sdists (2026.8.3 / v0.20.x, brew + pip) ship the bundled plugin **Python modules** but omit every `plugin.yaml`/`plugin.yml` **manifest** — `[tool.setuptools.package-data]` has entries for `hermes_cli` and `gateway` data but nothing for `plugins`. Plugin discovery (`hermes_cli/plugins.py`) requires a manifest per plugin directory, so installed builds register **zero** bundled plugins: `[plugins] DEBUG bundled/platforms: 0 manifest(s)` → `WARNING gateway.run: No adapter available for feishu` (and telegram, discord, slack, teams, …). The gateway silently starts in cron-only mode.

This is the third recurrence of the wheel-drops-data-files packaging class (#34034, #28149; regressed when packaging config was simplified in #68217).

## Fix

`pyproject.toml`:

```toml
[tool.setuptools.package-data]
plugins = ["**/plugin.yaml", "**/plugin.yml"]
```

Plus artifact-level regression coverage in `tests/test_packaging_build_guard.py`: the existing nix-marker build test now builds the real PEP 517 wheel **and** sdist, enumerates every manifest under the source `plugins/` tree, and asserts each one ships in the artifact.

## Verification (rebuilt on current main, 2026-08-14)

Empirical A/B — wheel built from `origin/main` (pre-fix) vs this branch, `HERMES_NIX_BUILD=1 uv build`:

```text
main   wheel plugin manifests: 0     ← bug reproduces on current main
fixed  wheel plugin manifests: 97
fixed  sdist plugin manifests: 97    (matches all 97 manifests in the source tree)
```

Guard test verified in both directions:

- On this branch: `pytest tests/test_packaging_build_guard.py` → **4 passed**
- With `pyproject.toml` reverted to main's version (fix stripped): the two nix-marker build tests **fail**, naming the omitted manifests — the guard actually catches the bug class.
- `tests/test_packaging_metadata.py` → 6 passed.
- No dependency changes → `uv lock --check` clean (no lockfile regeneration needed).

## Credit

All substantive work by @JoaoMarcos44 (#82977), cherry-picked with authorship preserved; contributor email mapping already present. Reported by @kelvinhbk (#82916) and @sfeham (#83991) with excellent root-cause analyses.

Closes #82916
Closes #83991

## Infographic

![ship bundled plugin manifests](https://gist.githubusercontent.com/teknium1/796e292c23cbf38400383c907ea1e90f/raw/infographic-plugin-manifests.png)
