### PR TITLE
fix(gateway): drop stale session /model override when provider is unresolvable

### DIFF
--- a/gateway/run_agent_cache.py
+++ b/gateway/run_agent_cache.py
@@ -182,6 +182,11 @@ class GatewayAgentCacheMixin:
                     session_key, provider,
                 )
                 return
+            if not override.get("api_key"):
+                # Resolution succeeded without a credential: a keyless-but-valid provider
+                # (e.g. local Ollama). Mark it so the apply gates don't mistake it for a
+                # stale credential-less override.
+                override["keyless"] = True
         self._session_state(session_key).conversation.model_override = override
         logger.info(
             "Rehydrated persisted /model override for session=%s: model=%s provider=%s",
@@ -197,10 +202,11 @@ class GatewayAgentCacheMixin:
             return model, runtime_kwargs
         model = override.get("model", model)
         # Only apply the provider/runtime keys if the override still carries a resolvable
-        # credential. A credential-less override (e.g. the provider was removed from config
+        # credential or was validated as keyless-but-legitimate (e.g. local Ollama resolves
+        # api_key=''). A credential-less override (e.g. the provider was removed from config
         # after the switch) would otherwise poison runtime_kwargs with a stale provider and
         # produce an "UNKNOWN <provider>" failure downstream.
-        if override.get("api_key"):
+        if override.get("api_key") or override.get("keyless"):
             for key in _OVERRIDE_APPLY_KEYS:
                 val = override.get(key)
                 if val is not None:

--- a/gateway/run_agent_cache.py
+++ b/gateway/run_agent_cache.py
@@ -163,9 +163,10 @@ class GatewayAgentCacheMixin:
         override: Dict[str, Any] = {k: persisted.get(k) for k in ("model", "provider", "base_url")}
         provider = persisted.get("provider")
         if provider:
-            # Re-resolve credentials for the persisted provider. On failure (e.g. credentials removed
-            # since the switch) keep the credential-less override — _resolve_session_agent_runtime
-            # falls back to env resolution and layers model/provider.
+            # Re-resolve credentials for the persisted provider. If the provider is no longer
+            # configured or its credentials were removed, do not apply the override — falling
+            # back to the global default model and provider prevents a stale "UNKNOWN <provider>"
+            # failure on the next turn.
             try:
                 runtime = _resolve_runtime_agent_kwargs_for_provider(provider)
                 for k in ("api_key", "api_mode", "credential_pool", "requested_provider", "max_tokens"):
@@ -175,10 +176,12 @@ class GatewayAgentCacheMixin:
                 if not override.get("base_url"):
                     override["base_url"] = runtime.get("base_url")
             except Exception:
-                logger.debug(
-                    "Credential re-resolution failed for persisted override "
-                    "(provider=%s); using credential-less override", provider, exc_info=True,
+                logger.info(
+                    "Dropping stale persisted /model override for session=%s "
+                    "because provider %r can no longer be resolved",
+                    session_key, provider,
                 )
+                return
         self._session_state(session_key).conversation.model_override = override
         logger.info(
             "Rehydrated persisted /model override for session=%s: model=%s provider=%s",
@@ -193,22 +196,27 @@ class GatewayAgentCacheMixin:
         if not override:
             return model, runtime_kwargs
         model = override.get("model", model)
-        for key in _OVERRIDE_APPLY_KEYS:
-            val = override.get(key)
-            if val is not None:
-                runtime_kwargs[key] = val
-        # request_overrides reflects the switched-to provider; apply whenever the override recorded
-        # it (even as None) so switching to a provider without configured overrides clears a stale
-        # value left by the default provider's runtime resolution.
-        if "request_overrides" in override:
-            ro = override.get("request_overrides")
-            runtime_kwargs["request_overrides"] = dict(ro) if isinstance(ro, dict) and ro else ro
-        if (
-            runtime_kwargs.get("api_key")
-            and runtime_kwargs.get("credential_pool") is None
-            and override.get("provider")
-        ):
-            runtime_kwargs["credential_pool"] = _credential_pool_for_provider(override.get("provider"))
+        # Only apply the provider/runtime keys if the override still carries a resolvable
+        # credential. A credential-less override (e.g. the provider was removed from config
+        # after the switch) would otherwise poison runtime_kwargs with a stale provider and
+        # produce an "UNKNOWN <provider>" failure downstream.
+        if override.get("api_key"):
+            for key in _OVERRIDE_APPLY_KEYS:
+                val = override.get(key)
+                if val is not None:
+                    runtime_kwargs[key] = val
+            # request_overrides reflects the switched-to provider; apply whenever the override
+            # recorded it (even as None) so switching to a provider without configured overrides
+            # clears a stale value left by the default provider's runtime resolution.
+            if "request_overrides" in override:
+                ro = override.get("request_overrides")
+                runtime_kwargs["request_overrides"] = dict(ro) if isinstance(ro, dict) and ro else ro
+            if (
+                runtime_kwargs.get("api_key")
+                and runtime_kwargs.get("credential_pool") is None
+                and override.get("provider")
+            ):
+                runtime_kwargs["credential_pool"] = _credential_pool_for_provider(override.get("provider"))
         return model, runtime_kwargs
 
     def _snapshot_session_model_override(self, session_key: str) -> dict:

--- a/gateway/run_turn.py
+++ b/gateway/run_turn.py
@@ -73,7 +73,11 @@ class GatewayTurnMixin:
                 )
             }
             override_runtime["capabilities"] = dict(override_runtime["capabilities"] or {})
-            if override_runtime.get("api_key"):
+            override_runtime["keyless"] = bool(override.get("keyless"))
+            # A keyless marker means the provider was validated to resolve without a credential
+            # (e.g. local Ollama resolves api_key='') — legitimate, unlike a stale credential-less
+            # override.
+            if override_runtime.get("api_key") or override_runtime.get("keyless"):
                 if override_runtime.get("credential_pool") is None:
                     override_runtime["credential_pool"] = _credential_pool_for_provider(override.get("provider"))
                 logger.debug(
@@ -81,7 +85,8 @@ class GatewayTurnMixin:
                     skey or "", model, override_model, override_runtime.get("provider"),
                 )
                 return override_model, override_runtime
-            # No api_key on the override: env-based resolution below, override model/provider on top.
+            # No api_key on the override and not marked keyless: env-based resolution below,
+            # override model/provider on top.
             logger.debug(
                 "Session model override (no api_key, fallback): session=%s config_model=%s override_model=%s",
                 skey or "", model, override_model,

--- a/gateway/slash_commands_model.py
+++ b/gateway/slash_commands_model.py
@@ -265,6 +265,9 @@ class GatewayModelCommandsMixin:
             "base_url": result.base_url, "api_mode": result.api_mode,
             "request_overrides": dict(result.request_overrides or {}),
             "capabilities": dict(result.runtime_capabilities or {}),
+            # The switch validated this provider; an empty api_key means it
+            # legitimately resolves without one (e.g. local Ollama).
+            "keyless": not result.api_key,
         }
         if one_turn:
             if not hasattr(self, "_pending_one_turn_model_restores"):

--- a/tests/gateway/test_model_switch_persistence.py
+++ b/tests/gateway/test_model_switch_persistence.py
@@ -145,6 +145,35 @@ class TestApplySessionModelOverride:
         # stale provider keys must not clobber the valid runtime kwargs
         assert rt == orig_rt
 
+    def test_keyless_local_provider_override_applies(self):
+        """A keyless-but-valid local provider (e.g. Ollama, which resolves
+        api_key='') is legitimate: its provider/base_url must still apply."""
+        runner = _make_runner()
+        sk = build_session_key(_make_source())
+
+        runner._session_model_overrides[sk] = {
+            "model": "qwen3:8b",
+            "provider": "ollama",
+            "api_key": "",
+            "base_url": "http://127.0.0.1:11434/v1",
+            "api_mode": "chat_completions",
+            # Resolution succeeded without a credential -> not stale.
+            "keyless": True,
+        }
+
+        orig_rt = {
+            "provider": "anthropic",
+            "api_key": "ant-key",
+            "base_url": "https://api.anthropic.com",
+            "api_mode": "anthropic_messages",
+        }
+        model, rt = runner._apply_session_model_override(sk, "anthropic/claude-sonnet-4", dict(orig_rt))
+
+        assert model == "qwen3:8b"
+        assert rt["provider"] == "ollama"
+        assert rt["base_url"] == "http://127.0.0.1:11434/v1"
+        assert rt["api_mode"] == "chat_completions"
+
 
 # ---------------------------------------------------------------------------
 # Tests: _is_intentional_model_switch

--- a/tests/gateway/test_model_switch_persistence.py
+++ b/tests/gateway/test_model_switch_persistence.py
@@ -120,6 +120,31 @@ class TestApplySessionModelOverride:
         assert model == orig_model
         assert rt == orig_rt
 
+    def test_stale_override_without_api_key_skips_provider(self):
+        """A credential-less override must not poison runtime_kwargs."""
+        runner = _make_runner()
+        sk = build_session_key(_make_source())
+
+        runner._session_model_overrides[sk] = {
+            "model": "gpt-5.4-turbo",
+            "provider": "removed-provider",
+            "base_url": "https://removed.example/v1",
+            "api_mode": "chat_completions",
+            # no api_key -> provider cannot be resolved anymore
+        }
+
+        orig_rt = {
+            "provider": "anthropic",
+            "api_key": "ant-key",
+            "base_url": "https://api.anthropic.com",
+            "api_mode": "anthropic_messages",
+        }
+        model, rt = runner._apply_session_model_override(sk, "anthropic/claude-sonnet-4", dict(orig_rt))
+
+        assert model == "gpt-5.4-turbo"
+        # stale provider keys must not clobber the valid runtime kwargs
+        assert rt == orig_rt
+
 
 # ---------------------------------------------------------------------------
 # Tests: _is_intentional_model_switch

--- a/tests/gateway/test_session_model_override_persistence.py
+++ b/tests/gateway/test_session_model_override_persistence.py
@@ -150,3 +150,29 @@ def test_sanitize_model_override():
         "provider": "openai",
         "base_url": "https://api.openai.example/v1",
     }
+
+
+def test_runner_drops_stale_override_after_restart(store_factory, caplog):
+    store = store_factory()
+    entry = store.get_or_create_session(_make_source())
+    session_key = entry.session_key
+    store.set_model_override(
+        session_key,
+        {
+            "model": "claude-sonnet",
+            "provider": "removed-provider",
+            "base_url": "https://removed.example/v1",
+        },
+    )
+
+    runner = _make_runner(store_factory())
+    with patch(
+        "gateway.run._resolve_runtime_agent_kwargs_for_provider",
+        side_effect=RuntimeError("Provider removed from config"),
+    ):
+        with caplog.at_level("INFO", logger="gateway.run"):
+            runner._rehydrate_session_model_override(session_key)
+
+    # A stale override whose provider can no longer be resolved must be
+    assert runner._session_model_overrides.get(session_key) is None
+    assert "Dropping stale persisted /model override" in caplog.text

--- a/tests/gateway/test_session_model_override_persistence.py
+++ b/tests/gateway/test_session_model_override_persistence.py
@@ -176,3 +176,47 @@ def test_runner_drops_stale_override_after_restart(store_factory, caplog):
     # A stale override whose provider can no longer be resolved must be
     assert runner._session_model_overrides.get(session_key) is None
     assert "Dropping stale persisted /model override" in caplog.text
+
+
+def test_runner_rehydrates_keyless_local_override(store_factory):
+    """A keyless-but-valid provider (Ollama resolves api_key='') is
+    legitimate: rehydration must keep it and the apply gate must honor it."""
+    store = store_factory()
+    entry = store.get_or_create_session(_make_source())
+    session_key = entry.session_key
+    store.set_model_override(
+        session_key,
+        {
+            "model": "qwen3:8b",
+            "provider": "ollama",
+            "base_url": "http://127.0.0.1:11434/v1",
+        },
+    )
+
+    runner = _make_runner(store_factory())
+    with patch(
+        "gateway.run._resolve_runtime_agent_kwargs_for_provider",
+        return_value={
+            "api_key": "",
+            "api_mode": "chat_completions",
+            "base_url": "http://127.0.0.1:11434/v1",
+            "provider": "custom",
+        },
+    ):
+        runner._rehydrate_session_model_override(session_key)
+
+    override = runner._session_model_overrides[session_key]
+    assert override["model"] == "qwen3:8b"
+    assert override["provider"] == "ollama"
+    assert override["base_url"] == "http://127.0.0.1:11434/v1"
+    # Marked keyless so the apply gates treat it as valid, not stale.
+    assert override["keyless"] is True
+
+    model, rt = runner._apply_session_model_override(
+        session_key,
+        "default-model",
+        {"provider": "anthropic", "api_key": "ant-key"},
+    )
+    assert model == "qwen3:8b"
+    assert rt["provider"] == "ollama"
+    assert rt["base_url"] == "http://127.0.0.1:11434/v1"


### PR DESCRIPTION
## What does this PR do?

When a session has a /model override that points to a provider that can no longer be resolved (e.g. provider was removed from config), the gateway was keeping the stale override and failing. This PR:

1. Drops stale persisted /model override when provider is unresolvable
2. Keeps keyless-but-valid overrides applicable (provider-less overrides that are intentionally set)
3. Adds `keyless` marker to distinguish intentional provider-less overrides from stale ones

## Related Issue

Fixes #83123

## Type of Change

- [x] 🐛 Bug fix

## Changes Made

- `gateway/run_agent_cache.py`: Drop stale override, keyless marker, conditional application.
- `gateway/run_turn.py`: Keyless fast-path.
- `gateway/slash_commands_model.py`: Keyless marker at switch time.

## How to Test

1. `scripts/run_tests.sh tests/gateway/` — gateway tests pass.
2. Full project checker passes.

## Checklist

- [x] Code follows the project's style and conventions
- [x] Self-review completed
- [x] Tests added/updated and passing