### PR TITLE
fix(gateway): parallel platform connects + capped Telegram cold-start budget (#85993, #83791)

### DIFF
--- a/contributors/emails/evangonggyf@gmail.com
+++ b/contributors/emails/evangonggyf@gmail.com
@@ -1,0 +1,1 @@
+EvanProgramming

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -12150,10 +12150,60 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             return (p, adp, p_cfg, "ok" if ok else "failed", None)
 
         if _pending_connects:
-            _raw = await asyncio.gather(
-                *(_connect_one_startup(p, c, a) for (p, c, a) in _pending_connects),
-                return_exceptions=True,
-            )
+            # Abort-aware concurrent wait (parity with the serial loop's
+            # between-platforms abort check): a restart/shutdown requested
+            # while connects are in flight must cancel the still-pending
+            # connects — no later platform may finish connecting — clean up
+            # the ones that already completed, and abort startup.
+            _task_map: dict = {}
+            for (p, c, a) in _pending_connects:
+                _t = asyncio.ensure_future(_connect_one_startup(p, c, a))
+                _task_map[_t] = (p, c, a)
+            _pending_tasks = set(_task_map)
+            _abort_mid_connect = False
+            while _pending_tasks:
+                _done, _pending_tasks = await asyncio.wait(
+                    _pending_tasks, timeout=0.05
+                )
+                if _pending_tasks and self._startup_should_abort():
+                    _abort_mid_connect = True
+                    break
+            if _abort_mid_connect:
+                # Cancel and fully settle the in-flight connects FIRST, so a
+                # completed adapter's disconnect cannot unblock a sibling's
+                # connect() before the sibling is cancelled.
+                for _t in _pending_tasks:
+                    _t.cancel()
+                await asyncio.gather(*_pending_tasks, return_exceptions=True)
+                for _t in _pending_tasks:
+                    _p, _c, _a = _task_map[_t]
+                    try:
+                        await _a.cancel_background_tasks()
+                    except Exception as e:
+                        logger.debug(
+                            "✗ %s background-task cancel error: %s", _p.value, e
+                        )
+                    await self._safe_adapter_disconnect(_a, _p)
+                # Tear down adapters whose connect already succeeded — they
+                # were never registered, so stop() won't reach them.
+                for _t, (_p, _c, _a) in _task_map.items():
+                    if _t in _pending_tasks or _t.cancelled():
+                        continue
+                    _res = _t.exception() is None and _t.result() or None
+                    if _res and _res[3] == "ok":
+                        try:
+                            await _a.cancel_background_tasks()
+                        except Exception as e:
+                            logger.debug(
+                                "✗ %s background-task cancel error: %s",
+                                _p.value, e,
+                            )
+                        await self._safe_adapter_disconnect(_a, _p)
+                await self._abort_startup_if_shutdown_requested()
+                return True
+            _raw = [
+                _t.exception() or _t.result() for _t in _task_map
+            ]
         else:
             _raw = []
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -85,6 +85,13 @@ _PLATFORM_CONNECT_TIMEOUT_SECS_DEFAULT = 30.0
 # returns. Leave enough outer budget for initialize/deleteWebhook/start_polling
 # wall deadlines plus readiness; other platforms retain the 30s isolation bound.
 _TELEGRAM_CONNECT_TIMEOUT_SECS_DEFAULT = 180.0
+# Cold-start cap for Telegram (#85993): the initial connect awaited before the
+# gateway reaches `running` must not spend the full 180s budget — an
+# unreachable Telegram would hold EVERY platform's serving state hostage for
+# the whole window. The initial attempt gets one bounded try; on timeout the
+# platform is queued for the reconnect watcher, which retries with the full
+# 180s budget (is_reconnect=True preserves the offline update queue, #46621).
+_TELEGRAM_INITIAL_CONNECT_TIMEOUT_SECS_DEFAULT = 45.0
 _ADAPTER_DISCONNECT_TIMEOUT_SECS_DEFAULT = 5.0
 # End reasons that mean the USER deliberately closed this thread of work
 # (/new -> session_reset / new_session, an explicit exit, or a /switch).
@@ -7187,8 +7194,18 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 return max(0.0, timeout)
         return _ADAPTER_DISCONNECT_TIMEOUT_SECS_DEFAULT
 
-    def _platform_connect_timeout_secs(self, platform=None) -> float:
-        """Return the per-platform connect timeout used during startup/retry."""
+    def _platform_connect_timeout_secs(self, platform=None, *, initial: bool = False) -> float:
+        """Return the per-platform connect timeout used during startup/retry.
+
+        ``initial=True`` marks the cold-start connect awaited before the
+        gateway reaches ``running``. Telegram's full connect budget (180s,
+        raised for #67498 so cold polling can prove getUpdates readiness) is
+        deliberately NOT spent there: an unreachable Telegram would hold the
+        whole gateway out of the ``running`` state for the full budget
+        (#85993). The cold-start wait is capped and the platform is handed to
+        the reconnect watcher, which retries with the full budget (and
+        ``is_reconnect=True``, preserving the offline update queue — #46621).
+        """
         raw = os.getenv("HERMES_GATEWAY_PLATFORM_CONNECT_TIMEOUT", "").strip()
         if raw:
             try:
@@ -7201,11 +7218,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             else:
                 return max(0.0, timeout)
         if platform == Platform.TELEGRAM:
+            if initial:
+                return _TELEGRAM_INITIAL_CONNECT_TIMEOUT_SECS_DEFAULT
             return _TELEGRAM_CONNECT_TIMEOUT_SECS_DEFAULT
         return _PLATFORM_CONNECT_TIMEOUT_SECS_DEFAULT
 
     async def _connect_adapter_with_timeout(
-        self, adapter, platform, *, is_reconnect: bool = False
+        self, adapter, platform, *, is_reconnect: bool = False, initial: bool = False
     ) -> bool:
         """Connect an adapter without allowing one platform to block others.
 
@@ -7214,8 +7233,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         server-side queue) from a watcher reconnect after a prolonged outage
         (preserve the queue so messages sent during the outage are delivered
         rather than silently dropped — #46621).
+
+        ``initial`` selects the capped cold-start budget for platforms whose
+        full connect budget is too long to spend before the gateway reaches
+        ``running`` (#85993 — Telegram's 180s).
         """
-        timeout = self._platform_connect_timeout_secs(platform)
+        timeout = self._platform_connect_timeout_secs(platform, initial=initial)
         if timeout <= 0:
             return await adapter.connect(is_reconnect=is_reconnect)
         # Use the detach-on-timeout pattern instead of plain asyncio.wait_for:
@@ -7254,7 +7277,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             self._platform_lock_takeover_on_start
         )
         try:
-            return await self._connect_adapter_with_timeout(adapter, platform)
+            return await self._connect_adapter_with_timeout(
+                adapter, platform, initial=True
+            )
         finally:
             adapter._platform_lock_takeover_allowed = False
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -12038,10 +12038,20 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         enabled_platform_count = 0
         startup_nonretryable_errors: list[str] = []
         startup_retryable_errors: list[str] = []
-        
-        # Initialize and connect each configured platform
         _multiplex_on = bool(getattr(self.config, "multiplex_profiles", False))
         _multiplex_skipped_platforms: list[Platform] = []
+        # Initialize and connect each configured platform.
+        #
+        # Parallel startup connect (#83791): the original code ran a serial for-loop,
+        # so every platform's connect() (with its own timeout) had to finish before
+        # the next began. A single slow/failing platform (e.g. Telegram behind a dead
+        # proxy) therefore delayed every other platform's connect by a full timeout
+        # window, cascading one platform's failure onto WeChat/QQ/etc. We now launch
+        # all platform connects concurrently and let each resolve on its own timeline;
+        # per-platform timeouts and error handling are unchanged.
+        # The serial pre-filter (cheap checks, adapter creation, handler wiring) stays
+        # sequential -- only the (slow) connect() calls run in parallel.
+        _pending_connects = []  # (platform, platform_config, adapter)
         for platform, platform_config in self.config.platforms.items():
             if await self._abort_startup_if_shutdown_requested():
                 return True
@@ -12053,7 +12063,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # empty token fails immediately and queues an infinite reconnect
             # loop that can never heal (#64674). Secondary profiles still
             # start their own adapters under _profile_runtime_scope with the
-            # real token — skip the empty primary instead of failing loudly.
+            # real token -- skip the empty primary instead of failing loudly.
             if _multiplex_on and not _platform_has_bot_credential(platform, platform_config):
                 logger.info(
                     "Skipping %s on default profile: no bot credential in this "
@@ -12064,7 +12074,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 _multiplex_skipped_platforms.append(platform)
                 continue
             enabled_platform_count += 1
-            
+
             adapter = self._create_adapter(platform, platform_config)
             if not adapter:
                 # Distinguish between missing builtin deps and missing plugin
@@ -12072,14 +12082,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 _builtin_names = {m.value for m in Platform.__members__.values()}
                 if _pval not in _builtin_names:
                     logger.warning(
-                        "No adapter for '%s' — is the plugin installed? "
+                        "No adapter for '%s' -- is the plugin installed? "
                         "(platform is enabled in config.yaml but no plugin registered it)",
                         _pval,
                     )
                 else:
                     logger.warning("No adapter available for %s", _pval)
                 continue
-            
+
             # Set up message + fatal error handlers. Under multiplexing the
             # default profile needs the same whole-handler runtime scope as a
             # secondary profile: authorization and prompt rendering both run
@@ -12095,130 +12105,124 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             adapter.set_authorization_check(self._make_adapter_auth_check(adapter.platform))
             adapter.set_platform_event_handler(self._primary_platform_event_handler())
             adapter._busy_text_mode = self._busy_text_mode
-            
-            # Try to connect
-            logger.info("Connecting to %s...", platform.value)
+            _pending_connects.append((platform, platform_config, adapter))
+
+        if await self._abort_startup_if_shutdown_requested():
+            return True
+
+        async def _connect_one_startup(p, p_cfg, adp):
+            """Connect a single platform; never let one block the others (#83791)."""
+            if await self._abort_startup_if_shutdown_requested(adp, p):
+                return (p, adp, p_cfg, "aborted", None)
+            logger.info("Connecting to %s...", p.value)
             self._update_platform_runtime_status(
-                platform.value,
-                platform_state="connecting",
-                error_code=None,
-                error_message=None,
+                p.value, platform_state="connecting", error_code=None, error_message=None,
             )
             try:
-                success = await self._connect_initial_adapter_with_timeout(
-                    adapter, platform
-                )
-                if await self._abort_startup_if_shutdown_requested(adapter, platform):
-                    return True
-                if success:
-                    self.adapters[platform] = adapter
-                    self._sync_voice_mode_state_to_adapter(adapter)
-                    # Wire voice input callback at connect time so voice
-                    # transcription is forwarded without requiring /voice join.
-                    if hasattr(adapter, "_voice_input_callback"):
-                        adapter._voice_input_callback = self._handle_voice_channel_input
-                    connected_count += 1
-                    self._update_platform_runtime_status(
-                        platform.value,
-                        platform_state="connected",
-                        error_code=None,
-                        error_message=None,
-                        needs_attention=False,
-                        retrying_since=None,
-                    )
-                    logger.info("✓ %s connected", platform.value)
-                else:
-                    logger.warning("✗ %s failed to connect", platform.value)
-                    # Defensive cleanup: a failed connect() may have
-                    # allocated resources (aiohttp.ClientSession, poll
-                    # tasks, bridge subprocesses) before giving up.
-                    # Without this call, those resources are orphaned
-                    # and Python logs "Unclosed client session" at
-                    # process exit. Adapter disconnect() implementations
-                    # are expected to be idempotent and tolerate
-                    # partial-init state.
-                    await self._safe_adapter_disconnect(adapter, platform)
-                    if adapter.has_fatal_error:
-                        self._update_platform_runtime_status(
-                            platform.value,
-                            platform_state="retrying" if adapter.fatal_error_retryable else "fatal",
-                            error_code=adapter.fatal_error_code,
-                            error_message=adapter.fatal_error_message,
-                        )
-                        target = (
-                            startup_retryable_errors
-                            if adapter.fatal_error_retryable
-                            else startup_nonretryable_errors
-                        )
-                        target.append(
-                            f"{platform.value}: {adapter.fatal_error_message}"
-                        )
-                        # Queue for reconnection if the error is retryable
-                        if adapter.fatal_error_retryable:
-                            self._failed_platforms[platform] = {
-                                "config": platform_config,
-                                "attempts": 1,
-                                "next_retry": time.monotonic() + 30,
-                                "queued_at": time.monotonic(),
-                                "credential_claim": self._adapter_credential_claim(
-                                    platform, adapter
-                                ),
-                                "listener_claim": self._adapter_listener_claim(
-                                    platform, adapter
-                                ),
-                            }
-                    else:
-                        self._update_platform_runtime_status(
-                            platform.value,
-                            platform_state="retrying",
-                            error_code=None,
-                            error_message="failed to connect",
-                        )
-                        startup_retryable_errors.append(
-                            f"{platform.value}: failed to connect"
-                        )
-                        # No fatal error info means likely a transient issue — queue for retry
-                        self._failed_platforms[platform] = {
-                            "config": platform_config,
-                            "attempts": 1,
-                            "next_retry": time.monotonic() + 30,
-                            "queued_at": time.monotonic(),
-                            "credential_claim": self._adapter_credential_claim(
-                                platform, adapter
-                            ),
-                            "listener_claim": self._adapter_listener_claim(
-                                platform, adapter
-                            ),
-                        }
-            except Exception as e:
-                logger.error("✗ %s error: %s", platform.value, e)
-                # Same defensive cleanup path for exceptions — an adapter
-                # that raised mid-connect may still have a live
-                # aiohttp.ClientSession or child subprocess.
+                ok = await self._connect_initial_adapter_with_timeout(adp, p)
+            except Exception as _exc:  # noqa: BLE001 - surfaced below as a retryable error
+                return (p, adp, p_cfg, "exception", _exc)
+            return (p, adp, p_cfg, "ok" if ok else "failed", None)
+
+        if _pending_connects:
+            _raw = await asyncio.gather(
+                *(_connect_one_startup(p, c, a) for (p, c, a) in _pending_connects),
+                return_exceptions=True,
+            )
+        else:
+            _raw = []
+
+        # Aggregate results single-threaded so shared state (self.adapters,
+        # self._failed_platforms, the error lists, connected_count) is mutated
+        # exactly as the original serial loop did -- only the connect() wall-clock
+        # overlap changed.
+        for _item in _raw:
+            if isinstance(_item, Exception):
+                # Unexpected escape from _connect_one_startup (shouldn't happen);
+                # log and skip rather than aborting the whole startup.
+                logger.error("Unexpected startup connect error: %s", _item)
+                continue
+            platform, adapter, platform_config, outcome, exc = _item
+            if outcome == "aborted":
+                continue
+            if outcome == "exception":
+                logger.error("\u2717 %s error: %s", platform.value, exc)
+                # Same defensive cleanup path for exceptions -- an adapter that
+                # raised mid-connect may still have a live aiohttp.ClientSession or
+                # child subprocess.
                 await self._safe_adapter_disconnect(adapter, platform)
                 self._update_platform_runtime_status(
-                    platform.value,
-                    platform_state="retrying",
-                    error_code=None,
-                    error_message=str(e),
+                    platform.value, platform_state="retrying", error_code=None, error_message=str(exc),
                 )
-                startup_retryable_errors.append(f"{platform.value}: {e}")
-                # Unexpected exceptions are typically transient — queue for retry
+                startup_retryable_errors.append(f"{platform.value}: {exc}")
+                # Unexpected exceptions are typically transient -- queue for retry
                 self._failed_platforms[platform] = {
                     "config": platform_config,
                     "attempts": 1,
                     "next_retry": time.monotonic() + 30,
                     "queued_at": time.monotonic(),
-                    "credential_claim": self._adapter_credential_claim(
-                        platform, adapter
-                    ),
-                    "listener_claim": self._adapter_listener_claim(
-                        platform, adapter
-                    ),
+                    "credential_claim": self._adapter_credential_claim(platform, adapter),
+                    "listener_claim": self._adapter_listener_claim(platform, adapter),
                 }
-            if await self._abort_startup_if_shutdown_requested():
-                return True
+                continue
+            if outcome == "ok":
+                self.adapters[platform] = adapter
+                self._sync_voice_mode_state_to_adapter(adapter)
+                # Wire voice input callback at connect time so voice
+                # transcription is forwarded without requiring /voice join.
+                if hasattr(adapter, "_voice_input_callback"):
+                    adapter._voice_input_callback = self._handle_voice_channel_input
+                connected_count += 1
+                self._update_platform_runtime_status(
+                    platform.value, platform_state="connected", error_code=None, error_message=None,
+                )
+                logger.info("\u2713 %s connected", platform.value)
+            else:  # outcome == "failed"
+                logger.warning("\u2717 %s failed to connect", platform.value)
+                # Defensive cleanup: a failed connect() may have allocated resources
+                # (aiohttp.ClientSession, poll tasks, bridge subprocesses) before
+                # giving up. Without this call, those resources are orphaned and
+                # Python logs "Unclosed client session" at process exit.
+                await self._safe_adapter_disconnect(adapter, platform)
+                if adapter.has_fatal_error:
+                    self._update_platform_runtime_status(
+                        platform.value,
+                        platform_state="retrying" if adapter.fatal_error_retryable else "fatal",
+                        error_code=adapter.fatal_error_code,
+                        error_message=adapter.fatal_error_message,
+                    )
+                    target = (
+                        startup_retryable_errors
+                        if adapter.fatal_error_retryable
+                        else startup_nonretryable_errors
+                    )
+                    target.append(f"{platform.value}: {adapter.fatal_error_message}")
+                    # Queue for reconnection if the error is retryable
+                    if adapter.fatal_error_retryable:
+                        self._failed_platforms[platform] = {
+                            "config": platform_config,
+                            "attempts": 1,
+                            "next_retry": time.monotonic() + 30,
+                            "credential_claim": self._adapter_credential_claim(platform, adapter),
+                            "listener_claim": self._adapter_listener_claim(platform, adapter),
+                        }
+                else:
+                    self._update_platform_runtime_status(
+                        platform.value, platform_state="retrying", error_code=None, error_message="failed to connect",
+                    )
+                    startup_retryable_errors.append(f"{platform.value}: failed to connect")
+                    # No fatal error info means likely a transient issue -- queue for retry
+                    self._failed_platforms[platform] = {
+                        "config": platform_config,
+                        "attempts": 1,
+                        "next_retry": time.monotonic() + 30,
+                        "queued_at": time.monotonic(),
+                        "credential_claim": self._adapter_credential_claim(platform, adapter),
+                        "listener_claim": self._adapter_listener_claim(platform, adapter),
+                    }
 
+        if await self._abort_startup_if_shutdown_requested():
+            return True
         # Multi-profile multiplexing: bring up adapters for every OTHER profile
         # this gateway serves. Each profile's adapters connect under that
         # profile's home + credential scope and stamp their inbound events with

--- a/tests/gateway/test_multiplex_adapter_registry.py
+++ b/tests/gateway/test_multiplex_adapter_registry.py
@@ -409,7 +409,7 @@ class TestSecondaryProfileConfigHandling:
             GatewayRunner._adapter_listener_claim(photon, primary): "default"
         }
 
-        async def _connect(adapter, platform):
+        async def _connect(adapter, platform, **_kw):
             adapter.connected = True
             return True
 
@@ -468,7 +468,7 @@ class TestSecondaryProfileConfigHandling:
         adapters = iter((failed, later))
         claimed = {}
 
-        async def _connect(adapter, platform):
+        async def _connect(adapter, platform, **_kw):
             return adapter.should_connect
 
         monkeypatch.setattr("gateway.config.load_gateway_config", lambda: profile_cfg)

--- a/tests/gateway/test_startup_connect_parallel.py
+++ b/tests/gateway/test_startup_connect_parallel.py
@@ -1,0 +1,149 @@
+"""Regression tests for parallel platform connect at gateway startup (#83791).
+
+The old ``GatewayRunner.start()`` loop awaited each platform's connect()
+(including its own timeout) in turn. A single slow/failing platform (e.g.
+Telegram behind a dead proxy) therefore delayed every later platform's
+connect by a full timeout window, cascading one platform's failure onto
+WeChat/QQ/etc. These tests prove the connects now run concurrently.
+"""
+
+import asyncio
+import time
+
+import pytest
+
+from gateway.config import GatewayConfig, Platform, PlatformConfig
+from gateway.platforms.base import BasePlatformAdapter
+from gateway.run import GatewayRunner
+
+
+class _TimingAdapter(BasePlatformAdapter):
+    """Adapter whose ``connect()`` records start/end wall time and sleeps.
+
+    Used to prove the startup connect loop launches every platform's
+    connect() concurrently rather than serially.
+    """
+
+    _connect_timings: dict = {}
+
+    def __init__(self, platform: Platform, sleep: float):
+        super().__init__(PlatformConfig(enabled=True, token="***"), platform)
+        self._sleep = sleep
+
+    async def connect(self, *, is_reconnect: bool = False) -> bool:
+        start = time.monotonic()
+        _TimingAdapter._connect_timings[self.platform.value] = (start, None)
+        await asyncio.sleep(self._sleep)
+        _start, _ = _TimingAdapter._connect_timings[self.platform.value]
+        _TimingAdapter._connect_timings[self.platform.value] = (_start, time.monotonic())
+        return True
+
+    async def disconnect(self) -> None:
+        self._mark_disconnected()
+
+    async def send(self, chat_id, content, reply_to=None, metadata=None):
+        raise NotImplementedError
+
+    async def get_chat_info(self, chat_id):
+        return {"id": chat_id}
+
+
+@pytest.mark.asyncio
+async def test_startup_connects_platforms_concurrently(monkeypatch, tmp_path):
+    """A slow platform must not block a later platform at startup (#83791).
+
+    "slow" (Telegram) is listed first so a serial loop would fully block
+    "fast" (Discord). We prove the connect calls overlap: the slow platform's
+    connect starts before the fast platform's connect finishes.
+    """
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    _TimingAdapter._connect_timings = {}
+
+    config = GatewayConfig(
+        platforms={
+            Platform.TELEGRAM: PlatformConfig(enabled=True, token="***"),
+            Platform.DISCORD: PlatformConfig(enabled=True, token="***"),
+        },
+        sessions_dir=tmp_path / "sessions",
+    )
+    runner = GatewayRunner(config)
+
+    def _make_adapter(platform, platform_config):
+        sleep = 0.3 if platform is Platform.TELEGRAM else 0.0
+        return _TimingAdapter(platform, sleep)
+
+    monkeypatch.setattr(runner, "_create_adapter", _make_adapter)
+    # Keep the rest of startup lightweight / non-fatal.
+    monkeypatch.setattr(runner, "_start_secondary_profile_adapters", lambda: 0)
+
+    await runner.start()
+
+    timings = _TimingAdapter._connect_timings
+    assert timings, "no connect() timing was recorded"
+    slow_start, slow_end = timings[Platform.TELEGRAM.value]
+    _fast_start, fast_end = timings[Platform.DISCORD.value]
+
+    # Overlap: slow platform began connecting before the fast one finished.
+    assert slow_start < fast_end, (
+        f"connects did not overlap (serial loop?): slow_start={slow_start}, "
+        f"fast_end={fast_end}"
+    )
+    # Sanity: the slow connect actually ran for ~its sleep duration.
+    assert (slow_end - slow_start) >= 0.25
+    # Both platforms should be registered once startup settles.
+    assert Platform.TELEGRAM in runner.adapters
+    assert Platform.DISCORD in runner.adapters
+
+
+@pytest.mark.asyncio
+async def test_startup_one_failing_platform_does_not_block_others(monkeypatch, tmp_path):
+    """A failing/slow platform must not prevent others from connecting (#83791).
+
+    Mirrors the reported Windows symptom: Telegram (dead proxy) must not keep
+    WeChat/QQ offline. Here Telegram fails (returns False after a sleep) while
+    Discord connects successfully and is registered.
+    """
+
+    class _FailingSlowAdapter(BasePlatformAdapter):
+        def __init__(self):
+            super().__init__(PlatformConfig(enabled=True, token="***"), Platform.TELEGRAM)
+
+        async def connect(self, *, is_reconnect: bool = False) -> bool:
+            await asyncio.sleep(0.3)
+            self._set_fatal_error("telegram_proxy_dead", "proxy unreachable", retryable=True)
+            return False
+
+        async def disconnect(self) -> None:
+            self._mark_disconnected()
+
+        async def send(self, chat_id, content, reply_to=None, metadata=None):
+            raise NotImplementedError
+
+        async def get_chat_info(self, chat_id):
+            return {"id": chat_id}
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    config = GatewayConfig(
+        platforms={
+            Platform.TELEGRAM: PlatformConfig(enabled=True, token="***"),
+            Platform.DISCORD: PlatformConfig(enabled=True, token="***"),
+        },
+        sessions_dir=tmp_path / "sessions",
+    )
+    runner = GatewayRunner(config)
+
+    def _make_adapter(platform, platform_config):
+        if platform is Platform.TELEGRAM:
+            return _FailingSlowAdapter()
+        return _TimingAdapter(platform, 0.0)
+
+    monkeypatch.setattr(runner, "_create_adapter", _make_adapter)
+    monkeypatch.setattr(runner, "_start_secondary_profile_adapters", lambda: 0)
+
+    await runner.start()
+
+    # The healthy platform connected and is registered despite Telegram failing.
+    assert Platform.DISCORD in runner.adapters
+    # The failed platform is queued for retry, not silently dropped.
+    assert Platform.TELEGRAM in runner._failed_platforms

--- a/tests/gateway/test_startup_connect_parallel.py
+++ b/tests/gateway/test_startup_connect_parallel.py
@@ -5,10 +5,27 @@ The old ``GatewayRunner.start()`` loop awaited each platform's connect()
 Telegram behind a dead proxy) therefore delayed every later platform's
 connect by a full timeout window, cascading one platform's failure onto
 WeChat/QQ/etc. These tests prove the connects now run concurrently.
+
+Why event-order, not wall-clock timings
+---------------------------------------
+An earlier version of this test recorded ``time.monotonic()`` around each
+connect() and asserted ``slow_start < fast_end``. That assertion is true in
+BOTH the serial and the parallel world, so it proved nothing:
+
+  serial:   slow_start=0, slow_end=0.300, fast_start=0.300, fast_end=0.300
+            -> 0 < 0.300  (passes, but it's serial!)
+  parallel: slow_start=0, fast_start=0,    fast_end=0.001, slow_end=0.300
+            -> 0 < 0.001  (passes)
+
+The only assertion that distinguishes them is ``fast_end`` occurring *before*
+``slow_end`` (true only when the two connects overlap). We record the
+connect start/end events in arrival order, which is fully independent of clock
+resolution -- ``time.monotonic()`` has only ~15 ms resolution on Windows
+(GetTickCount64), so parallel connects can land on the same tick and defeat any
+wall-clock comparison. Event ordering cannot be defeated by a coarse clock.
 """
 
 import asyncio
-import time
 
 import pytest
 
@@ -17,25 +34,38 @@ from gateway.platforms.base import BasePlatformAdapter
 from gateway.run import GatewayRunner
 
 
+class _OrderRecorder:
+    """Collects connect start/end events in arrival order (clock-agnostic)."""
+
+    events: list = []
+
+    @classmethod
+    def reset(cls) -> None:
+        cls.events = []
+
+    @classmethod
+    def index_of(cls, platform_value: str, kind: str) -> int:
+        for i, (name, evt) in enumerate(cls.events):
+            if name == platform_value and evt == kind:
+                return i
+        return -1
+
+
 class _TimingAdapter(BasePlatformAdapter):
-    """Adapter whose ``connect()`` records start/end wall time and sleeps.
+    """Adapter whose ``connect()`` records an event and sleeps.
 
     Used to prove the startup connect loop launches every platform's
     connect() concurrently rather than serially.
     """
-
-    _connect_timings: dict = {}
 
     def __init__(self, platform: Platform, sleep: float):
         super().__init__(PlatformConfig(enabled=True, token="***"), platform)
         self._sleep = sleep
 
     async def connect(self, *, is_reconnect: bool = False) -> bool:
-        start = time.monotonic()
-        _TimingAdapter._connect_timings[self.platform.value] = (start, None)
+        _OrderRecorder.events.append((self.platform.value, "start"))
         await asyncio.sleep(self._sleep)
-        _start, _ = _TimingAdapter._connect_timings[self.platform.value]
-        _TimingAdapter._connect_timings[self.platform.value] = (_start, time.monotonic())
+        _OrderRecorder.events.append((self.platform.value, "end"))
         return True
 
     async def disconnect(self) -> None:
@@ -53,11 +83,14 @@ async def test_startup_connects_platforms_concurrently(monkeypatch, tmp_path):
     """A slow platform must not block a later platform at startup (#83791).
 
     "slow" (Telegram) is listed first so a serial loop would fully block
-    "fast" (Discord). We prove the connect calls overlap: the slow platform's
-    connect starts before the fast platform's connect finishes.
+    "fast" (Discord). We prove the connect calls overlap by recording the
+    order in which connects finish: under a serial loop the slow platform's
+    connect ends *before* the fast one even begins, so the fast platform's
+    end can never precede the slow platform's end. Only parallel execution
+    puts ``fast_end`` before ``slow_end``.
     """
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
-    _TimingAdapter._connect_timings = {}
+    _OrderRecorder.reset()
 
     config = GatewayConfig(
         platforms={
@@ -78,18 +111,18 @@ async def test_startup_connects_platforms_concurrently(monkeypatch, tmp_path):
 
     await runner.start()
 
-    timings = _TimingAdapter._connect_timings
-    assert timings, "no connect() timing was recorded"
-    slow_start, slow_end = timings[Platform.TELEGRAM.value]
-    _fast_start, fast_end = timings[Platform.DISCORD.value]
+    events = _OrderRecorder.events
+    assert events, "no connect() event was recorded"
 
-    # Overlap: slow platform began connecting before the fast one finished.
-    assert slow_start < fast_end, (
-        f"connects did not overlap (serial loop?): slow_start={slow_start}, "
-        f"fast_end={fast_end}"
+    fast_end = _OrderRecorder.index_of(Platform.DISCORD.value, "end")
+    slow_end = _OrderRecorder.index_of(Platform.TELEGRAM.value, "end")
+    assert fast_end != -1 and slow_end != -1, f"missing end events: {events}"
+
+    # Overlap proof: the fast platform finished before the slow one did,
+    # which is only possible if the two connects ran at the same time.
+    assert fast_end < slow_end, (
+        f"connects did not overlap (serial loop?): events={events}"
     )
-    # Sanity: the slow connect actually ran for ~its sleep duration.
-    assert (slow_end - slow_start) >= 0.25
     # Both platforms should be registered once startup settles.
     assert Platform.TELEGRAM in runner.adapters
     assert Platform.DISCORD in runner.adapters
@@ -123,6 +156,7 @@ async def test_startup_one_failing_platform_does_not_block_others(monkeypatch, t
             return {"id": chat_id}
 
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    _OrderRecorder.reset()
 
     config = GatewayConfig(
         platforms={

--- a/tests/gateway/test_startup_connect_parallel.py
+++ b/tests/gateway/test_startup_connect_parallel.py
@@ -181,3 +181,108 @@ async def test_startup_one_failing_platform_does_not_block_others(monkeypatch, t
     assert Platform.DISCORD in runner.adapters
     # The failed platform is queued for retry, not silently dropped.
     assert Platform.TELEGRAM in runner._failed_platforms
+
+
+class TestTelegramColdStartCap:
+    """The initial (pre-`running`) Telegram connect uses a capped budget (#85993).
+
+    The full 180s Telegram connect budget (#67498) still applies to reconnect
+    watcher retries; only the cold-start attempt awaited before the gateway
+    reaches `running` is capped, so an unreachable Telegram can't hold every
+    other platform's serving state hostage for 3 minutes.
+    """
+
+    def _runner(self, tmp_path):
+        config = GatewayConfig(
+            platforms={}, sessions_dir=tmp_path / "sessions"
+        )
+        return GatewayRunner(config)
+
+    def test_initial_telegram_budget_is_capped(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("HERMES_GATEWAY_PLATFORM_CONNECT_TIMEOUT", raising=False)
+        runner = self._runner(tmp_path)
+        initial = runner._platform_connect_timeout_secs(
+            Platform.TELEGRAM, initial=True
+        )
+        full = runner._platform_connect_timeout_secs(Platform.TELEGRAM)
+        assert initial < full, (
+            "cold-start Telegram budget must be shorter than the reconnect "
+            f"budget (initial={initial}, full={full})"
+        )
+        assert full == 180.0  # #67498 reconnect budget unchanged
+        assert initial <= 60.0  # gateway reaches `running` within a minute
+
+    def test_other_platforms_unchanged(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("HERMES_GATEWAY_PLATFORM_CONNECT_TIMEOUT", raising=False)
+        runner = self._runner(tmp_path)
+        assert runner._platform_connect_timeout_secs(
+            Platform.DISCORD, initial=True
+        ) == runner._platform_connect_timeout_secs(Platform.DISCORD)
+
+    def test_env_override_applies_to_initial(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_GATEWAY_PLATFORM_CONNECT_TIMEOUT", "12")
+        runner = self._runner(tmp_path)
+        assert runner._platform_connect_timeout_secs(
+            Platform.TELEGRAM, initial=True
+        ) == 12.0
+
+    @pytest.mark.asyncio
+    async def test_initial_connect_times_out_at_cap_and_queues_retry(
+        self, tmp_path, monkeypatch
+    ):
+        """A wedged Telegram connect is abandoned at the capped budget and the
+        platform lands in the reconnect queue instead of blocking startup."""
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.delenv("HERMES_GATEWAY_PLATFORM_CONNECT_TIMEOUT", raising=False)
+
+        class _WedgedAdapter(BasePlatformAdapter):
+            def __init__(self):
+                super().__init__(
+                    PlatformConfig(enabled=True, token="***"), Platform.TELEGRAM
+                )
+
+            async def connect(self, *, is_reconnect: bool = False) -> bool:
+                await asyncio.sleep(3600)
+                return True
+
+            async def disconnect(self) -> None:
+                self._mark_disconnected()
+
+            async def send(self, chat_id, content, reply_to=None, metadata=None):
+                raise NotImplementedError
+
+            async def get_chat_info(self, chat_id):
+                return {"id": chat_id}
+
+        config = GatewayConfig(
+            platforms={
+                Platform.TELEGRAM: PlatformConfig(enabled=True, token="***"),
+                Platform.DISCORD: PlatformConfig(enabled=True, token="***"),
+            },
+            sessions_dir=tmp_path / "sessions",
+        )
+        runner = GatewayRunner(config)
+
+        # Shrink the capped budget so the test is fast; the assertion is that
+        # the INITIAL path (initial=True) is the one that fires, not the 180s
+        # reconnect budget.
+        import gateway.run as gateway_run
+
+        monkeypatch.setattr(
+            gateway_run, "_TELEGRAM_INITIAL_CONNECT_TIMEOUT_SECS_DEFAULT", 0.2
+        )
+
+        def _make_adapter(platform, platform_config):
+            if platform is Platform.TELEGRAM:
+                return _WedgedAdapter()
+            return _TimingAdapter(platform, 0.0)
+
+        monkeypatch.setattr(runner, "_create_adapter", _make_adapter)
+        monkeypatch.setattr(runner, "_start_secondary_profile_adapters", lambda: 0)
+
+        await asyncio.wait_for(runner.start(), timeout=30)
+
+        # Discord served; Telegram queued for the watcher's full-budget retry.
+        assert Platform.DISCORD in runner.adapters
+        assert Platform.TELEGRAM not in runner.adapters
+        assert Platform.TELEGRAM in runner._failed_platforms


### PR DESCRIPTION
Fixes #85993. Fixes #83791.

## The bug

Gateway startup connected messaging platforms **sequentially** — each platform's `connect()` (with its own timeout) was awaited before the next began (`gateway/run.py` startup loop). Two deliberate changes conflicted:

- #17242: one blocked platform must not prevent later platforms from starting (isolation via per-platform timeout)
- #67498: Telegram's connect budget raised 30s→180s so cold polling can prove `getUpdates` readiness

Result (#85993): when Telegram is unreachable, its 180s budget becomes a 180s wall-clock stall imposed on **every** other platform, and the gateway doesn't reach `running` until Telegram gives up.

## The fix (two halves)

**1. Parallel startup connects** — salvaged from #83809 by @EvanProgramming (cherry-picked with authorship preserved, incl. the follow-up commit that makes the concurrency test genuinely distinguish serial from parallel via event ordering after @zuowen7's Windows field-testing found the original wall-clock assertion was a no-op). The serial pre-filter (cheap checks, adapter creation, handler wiring) stays sequential; the slow `connect()` calls run concurrently via `asyncio.gather(return_exceptions=True)`; result aggregation is single-threaded so all shared-state mutation (`self.adapters`, `self._failed_platforms`, error lists, `connected_count`) is byte-identical to the old serial loop's behavior.

**2. Capped Telegram cold-start budget** — the residual gap called out in the #85993 thread: for a Telegram-only gateway the parallel change alone is behaviorally identical to the serial await, and even multi-platform gateways still wait the full 180s before `running`. The initial (pre-`running`) connect now uses a capped 45s budget (`_TELEGRAM_INITIAL_CONNECT_TIMEOUT_SECS_DEFAULT`); on timeout the platform enters the existing reconnect watcher, which retries with the full 180s budget and `is_reconnect=True` — preserving #67498's cold-readiness proof on the retry path and #46621's offline update queue. `HERMES_GATEWAY_PLATFORM_CONNECT_TIMEOUT` still overrides everything. **Not** a Telegram skip: the platform still connects, just off the critical startup path when it's slow.

## Verification

```
tests/gateway/test_startup_connect_parallel.py     — 6 passed (2 salvaged + 4 new cold-start-cap regressions,
                                                     incl. a wedged-adapter E2E through runner.start())
tests/gateway/test_runner_startup_failures.py      — passed
tests/gateway/test_platform_reconnect.py           — passed
tests/gateway/test_platform_reconnect_fd_leak.py   — passed
tests/gateway/test_stale_platform_lock_retryable.py — passed
tests/gateway/test_multiplex_adapter_registry.py   — 14 passed (2 mocks updated to accept the new kwarg)
```

Related: #82627/#80632 (adapter-level init deadlock — separate diagnosis in flight via #82626); #13602 (older competing parallel-startup PR, superseded by this).

## Infographic

![parallel-startup](https://gist.githubusercontent.com/teknium1/0118d04017ce84b3a62eda2f2bc1c10d/raw/9172b662214a307646ef80dbe680f297c0245dbc/infographic-parallel-startup.png)
