### PR TITLE
fix(desktop): resolve react/react-dom from one origin to fix blank window (#84018)

### DIFF
--- a/apps/desktop/scripts/assert-root-install.mjs
+++ b/apps/desktop/scripts/assert-root-install.mjs
@@ -1,11 +1,35 @@
-import { accessSync } from "fs"
+import { accessSync, readFileSync } from "fs"
+import { createRequire } from "module"
 import { resolve, join } from "path"
 
-const root = resolve(import.meta.dirname, "..", "..", "..")
+const app = resolve(import.meta.dirname, "..")
+const root = resolve(app, "..", "..")
 
 try {
   accessSync(join(root, "node_modules", "vite", "package.json"))
 } catch {
   console.error(`Run from repo root: cd ${root} && npm ci`)
+  process.exit(1)
+}
+
+// `vite.config.ts` aliases react/react-dom to whatever this workspace resolves,
+// and React refuses to run when the two come from different installed copies
+// ("Minified React error #527" — it throws before the first paint, so the app
+// window stays blank). npm stays silent about the split because the hoisted
+// react still satisfies react-dom's caret peer range. Fail the build loudly
+// instead of shipping a white screen.
+const requireFromApp = createRequire(join(app, "package.json"))
+const installedVersion = (pkg) =>
+  JSON.parse(readFileSync(requireFromApp.resolve(`${pkg}/package.json`), "utf8")).version
+
+const react = installedVersion("react")
+const reactDom = installedVersion("react-dom")
+
+if (react !== reactDom) {
+  console.error(
+    `react@${react} / react-dom@${reactDom} version mismatch — React would fail ` +
+      `with error #527 and render a blank window. Pin both to the same version ` +
+      `in ${join(app, "package.json")}, then reinstall: cd ${root} && npm ci`
+  )
   process.exit(1)
 }

--- a/apps/desktop/vite.config.ts
+++ b/apps/desktop/vite.config.ts
@@ -3,6 +3,7 @@ import react from '@vitejs/plugin-react'
 import tailwindcss from '@tailwindcss/vite'
 import path from 'path'
 import fs from 'fs'
+import { createRequire } from 'module'
 
 // `hgui` symlinks a worktree's node_modules to the main checkout. Vite realpaths
 // those before enforcing server.fs.allow, so codicon/font assets resolve outside
@@ -24,6 +25,20 @@ const fsAllow = [
     ].filter((p): p is string => p !== null)
   )
 ]
+
+// React refuses to run when `react` and `react-dom` come from two different
+// installed copies ("Minified React error #527" — a blank window, since it
+// throws before the first paint). Both packages are pinned to one version in
+// this workspace's package.json, but npm hoists whatever *it* considers
+// compatible to the monorepo root: a root dependency whose react peer is a
+// loose range (e.g. `^18 || ^19`) pulls the newest react up there, while
+// react-dom stays at the pinned one. `^19.2.7` accepts `19.2.8`, so npm never
+// warns. Resolving from this workspace instead of a hardcoded root path yields
+// the versions declared here — npm nests a copy under the workspace exactly
+// when the hoisted one differs, so the pair can only ever match.
+const requireFromApp = createRequire(path.join(__dirname, 'vite.config.ts'))
+const reactDir = path.dirname(requireFromApp.resolve('react/package.json'))
+const reactDomDir = path.dirname(requireFromApp.resolve('react-dom/package.json'))
 
 // The dev-only render/state churn counters (src/debug) must be imported
 // STATICALLY above react-dom — react-dom captures the devtools hook at module
@@ -147,10 +162,10 @@ export default defineConfig(({ command }) => ({
       '@hermes/plugin-sdk': path.resolve(__dirname, './src/sdk/index.ts'),
       '@hermes/shared/billing': path.resolve(__dirname, '../shared/src/billing-types.ts'),
       '@hermes/shared': path.resolve(__dirname, '../shared/src'),
-      react: path.resolve(__dirname, '../../node_modules/react'),
-      'react-dom': path.resolve(__dirname, '../../node_modules/react-dom'),
-      'react/jsx-dev-runtime': path.resolve(__dirname, '../../node_modules/react/jsx-dev-runtime.js'),
-      'react/jsx-runtime': path.resolve(__dirname, '../../node_modules/react/jsx-runtime.js')
+      react: reactDir,
+      'react-dom': reactDomDir,
+      'react/jsx-dev-runtime': path.join(reactDir, 'jsx-dev-runtime.js'),
+      'react/jsx-runtime': path.join(reactDir, 'jsx-runtime.js')
     },
     dedupe: ['react', 'react-dom', 'react-router']
   },

--- a/tests-js/react-dom-pair-compat.test.ts
+++ b/tests-js/react-dom-pair-compat.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Invariant: every workspace that renders React ships one react/react-dom pair.
+ *
+ * React validates at import time that ``react`` and ``react-dom`` come from the
+ * same installed copy. When they don't, it throws "Minified React error #527"
+ * *before* the first paint — the Electron window just stays blank white, with
+ * the only clue buried in the devtools console of a packaged build.
+ *
+ * npm never warns about this. ``apps/desktop`` pins both packages to one exact
+ * version, but a root dependency whose react peer is a loose range (e.g.
+ * ``^18.0.0 || ^19.0.0``, and with no react-dom peer to keep the two in step)
+ * makes npm hoist the newest react to the monorepo root while react-dom stays
+ * at the pinned version. react-dom's own peer range is a caret, so the newer
+ * react still "satisfies" it and the install reports success.
+ *
+ * ``apps/desktop/vite.config.ts`` used to alias both packages to a hardcoded
+ * ``../../node_modules/<pkg>`` — i.e. straight into the split — so the bundle
+ * shipped the mismatched pair. It now resolves them from the workspace itself,
+ * where npm guarantees the declared versions are reachable.
+ *
+ * This is a *contract* test: it asserts no specific version, only that the two
+ * halves of the pair can never drift apart again — neither through a loosened
+ * manifest spec, nor by re-pinning the bundler at the hoisted copy.
+ */
+
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import path from 'node:path'
+
+import { test } from 'vitest'
+
+const REPO_ROOT = path.resolve(__dirname, '..')
+const DESKTOP_VITE_CONFIG = path.join(REPO_ROOT, 'apps', 'desktop', 'vite.config.ts')
+
+interface Manifest {
+  dependencies?: Record<string, string>
+  devDependencies?: Record<string, string>
+  workspaces?: string[]
+}
+
+function readManifest(file: string): Manifest {
+  return JSON.parse(fs.readFileSync(file, 'utf-8')) as Manifest
+}
+
+/** Every workspace manifest, resolved from the root ``workspaces`` globs. */
+function workspaceManifests(): { name: string, manifest: Manifest }[] {
+  const patterns = readManifest(path.join(REPO_ROOT, 'package.json')).workspaces ?? []
+  const found: { name: string, manifest: Manifest }[] = []
+
+  for (const pattern of patterns) {
+    // The globs in use are plain paths or a single trailing ``/*``.
+    const parent = pattern.endsWith('/*') ? path.join(REPO_ROOT, pattern.slice(0, -2)) : null
+    const dirs = parent === null
+      ? [pattern]
+      : fs.existsSync(parent)
+        ? fs.readdirSync(parent).map((entry) => `${pattern.slice(0, -2)}/${entry}`)
+        : []
+
+    for (const dir of dirs) {
+      const file = path.join(REPO_ROOT, dir, 'package.json')
+
+      if (fs.existsSync(file)) {found.push({ name: dir, manifest: readManifest(file) })}
+    }
+  }
+
+  return found
+}
+
+test('workspaces declaring react and react-dom pin them to the same exact version', () => {
+  const offenders: string[] = []
+
+  for (const { name, manifest } of workspaceManifests()) {
+    const deps = { ...manifest.devDependencies, ...manifest.dependencies }
+    const react = deps['react']
+    const reactDom = deps['react-dom']
+
+    if (!react || !reactDom) {continue}
+
+    if (react !== reactDom) {
+      offenders.push(`${name} declares react"${react}" but react-dom"${reactDom}"`)
+      continue
+    }
+
+    if (!/^\d/.test(react)) {
+      offenders.push(`${name} declares a floating range react/react-dom"${react}"`)
+    }
+  }
+
+  assert.deepEqual(
+    offenders,
+    [],
+    'react and react-dom must be pinned to the same exact version per workspace, ' +
+      'otherwise npm can hoist a newer react next to the older react-dom and React ' +
+      `throws error #527 (blank window): ${offenders.join('; ')}`
+  )
+})
+
+test('the desktop bundler does not alias react at the hoisted root copy', () => {
+  const config = fs.readFileSync(DESKTOP_VITE_CONFIG, 'utf-8')
+
+  assert.ok(
+    !config.includes('node_modules/react'),
+    'apps/desktop/vite.config.ts hardcodes a node_modules path for react/react-dom. ' +
+      'That pins the bundle to the hoisted copies, which npm is free to resolve to a ' +
+      'different version than the pinned react-dom. Resolve both from the workspace ' +
+      "instead (see this test's module docstring)."
+  )
+})


### PR DESCRIPTION
Salvage of #84048 by @JoaoMarcos44, cherry-picked onto current `main` with authorship preserved.

## What this fixes

Fixes #84018: on Windows the Desktop app could launch to a completely blank white window — React throws "Minified React error #527" (`react: 19.2.8, react-dom: 19.2.7` incompatible pair) before the first paint. Reproduced on two machines and on a clean official-installer install, so this was a real packaging-class bug, not a corrupted local tree.

**Root cause:** `apps/desktop/vite.config.ts` aliased `react`/`react-dom` at the hardcoded hoisted root `../../node_modules/<pkg>`. npm is free to hoist a *newer* react to the monorepo root (a root dependency with a loose `^18 || ^19` react peer pulls it up) while react-dom stays at the workspace-pinned version — and react-dom's caret peer range means npm never warns about the split.

**Verified NOT already fixed on main:** current `main` still hardcodes the four `../../node_modules/react*` aliases in `vite.config.ts` (checked at `efc3cd8697`); the package.json pins alone don't prevent the hoist split.

## The fix

- `vite.config.ts` resolves both packages via `createRequire` **from the desktop workspace** — npm nests a local copy exactly when the hoisted one differs, so the pair can only ever match.
- `assert-root-install.mjs` fails the build loudly with an actionable message if the installed react/react-dom versions differ, instead of shipping a white screen.
- New contract test `tests-js/react-dom-pair-compat.test.ts`: every workspace declaring the pair must pin both to the same exact version, and the desktop bundler must not alias react at the hoisted root copy.

## Verification (current main + this change)

- `npx vitest run tests-js/react-dom-pair-compat.test.ts` — 2 passed.
- `node apps/desktop/scripts/assert-root-install.mjs` — passes; workspace resolution yields `react 19.2.7 / react-dom 19.2.7`.

## Credit

All substantive work by @JoaoMarcos44.

## Infographic

![infographic](https://gist.githubusercontent.com/teknium1/c154ba1bec36062b15198994eaf464a5/raw/infographic-84048.png)
