### PR TITLE
fix(gateway): drain floor for in-flight cron + interrupted-cron notices before adapter disconnect

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -913,6 +913,19 @@ agent:
   # window on /restart, and keep it well under systemd's TimeoutStopSec.
   # restart_drain_timeout: 0
 
+  # Cron-only floor under the same drain (seconds). Default 30.
+  # restart_drain_timeout above is written for chat turns, which are cheap to
+  # interrupt: the user is told the gateway is restarting and the session
+  # resumes on their next message. A cron run has no such safety net — it is
+  # recorded in jobs.json as a permanent failure, nobody is waiting on it, and
+  # a recurring job simply skips to its next schedule. So in-flight cron work
+  # gets its own grace window instead of inheriting the 0 above.
+  # Clamped at runtime to the shutdown-watchdog leash (restart_drain_timeout
+  # + 60s) minus teardown headroom, so values past ~50s need a matching
+  # TimeoutStopSec bump to take effect. Set 0 to opt out and drain cron on
+  # restart_drain_timeout like before.
+  # cron_drain_timeout: 30
+
   # Upper bound (seconds) a submitted prompt waits for the deferred agent
   # build (MCP discovery, model metadata, skills scan) before failing with a
   # visible error. The wait is patient — the message is delivered as soon as

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -5825,6 +5825,23 @@ def _run_one_job_body(
 
         interrupted = _consume_interrupted_flag(job["id"], execution_token)
         if interrupted:
+            if delivery_error:
+                # The gateway shutdown already wrote last_status for this run,
+                # so mark_job_run is skipped below — but it could not know that
+                # the notice we just tried to send never left the process (the
+                # adapters were torn down first, #82232). Record the delivery
+                # failure on its own via update_job: mark_job_run also advances
+                # next_run_at and the repeat counter, and running that a second
+                # time for one run would skip a fire or auto-delete the job
+                # early.
+                try:
+                    from cron.jobs import update_job
+                    update_job(job["id"], {"last_delivery_error": delivery_error})
+                except Exception as _rec_err:
+                    logger.debug(
+                        "Failed recording delivery_error for interrupted job %s: %s",
+                        job["id"], _rec_err,
+                    )
             finish_execution(
                 execution_id,
                 success=False,

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -939,6 +939,12 @@ def mark_running_jobs_interrupted(
                 "leaving persisted state untouched",
                 job_id,
             )
+            # Still report the interruption to the caller: the gateway
+            # shutdown path uses the returned IDs to send the
+            # interrupted-cron notice while adapters are still connected
+            # (#82232). The in-memory interrupt flag WAS recorded above —
+            # only the persisted last_status write is skipped here.
+            marked.append(job_id)
             continue
         try:
             with use_cron_store(profile_home):

--- a/gateway/restart.py
+++ b/gateway/restart.py
@@ -33,6 +33,24 @@ DEFAULT_GATEWAY_RESTART_AFTER_TURN_TIMEOUT = float(
     DEFAULT_CONFIG["agent"]["restart_after_turn_timeout"]
 )
 
+# Cron-only floor under the ``stop()`` drain. ``restart_drain_timeout``
+# defaults to 0 because interrupting a *chat* turn is cheap and recoverable:
+# the user is told the gateway is restarting and the session is pre-marked
+# resume_pending. An interrupted *cron* run has neither property — nobody is
+# waiting on it, it lands in jobs.json as a permanent failure, and a recurring
+# job just waits for its next schedule — so a zero-second drain silently
+# destroys work. See #82161.
+DEFAULT_GATEWAY_CRON_DRAIN_TIMEOUT = float(
+    DEFAULT_CONFIG["agent"]["cron_drain_timeout"]
+)
+
+# Seconds of the shutdown watchdog leash held back for the work that still has
+# to happen after the drain returns: interrupt agents, kill tool subprocesses,
+# mark in-flight jobs interrupted, disconnect adapters. Waiting for cron past
+# that point trades a job that is killed *and recorded* for one that is
+# SIGKILLed mid-write and stays wedged at ``last_status=running`` forever.
+CRON_DRAIN_CLEANUP_RESERVE_S = 10.0
+
 
 def is_gateway_supervisor_process(
     environ: Mapping[str, str] | None = None,
@@ -90,6 +108,64 @@ def parse_restart_after_turn_timeout(raw: object) -> float:
     except (TypeError, ValueError):
         return DEFAULT_GATEWAY_RESTART_AFTER_TURN_TIMEOUT
     return max(0.0, value)
+
+
+def parse_cron_drain_timeout(raw: object) -> float:
+    """Parse the cron-only drain floor, falling back to the shared default.
+
+    ``0`` is a deliberate opt-out — cron work is then interrupted on the same
+    budget as chat work, the pre-#82161 behaviour — and must not fall through
+    to the default, unlike empty/missing input.
+    """
+    if raw is None:
+        return DEFAULT_GATEWAY_CRON_DRAIN_TIMEOUT
+    if isinstance(raw, str) and not raw.strip():
+        return DEFAULT_GATEWAY_CRON_DRAIN_TIMEOUT
+    try:
+        value = float(raw)
+    except (TypeError, ValueError):
+        return DEFAULT_GATEWAY_CRON_DRAIN_TIMEOUT
+    return max(0.0, value)
+
+
+def resolve_cron_drain_budget(
+    drain_timeout: float,
+    cron_drain_timeout: float,
+    *,
+    watchdog_delay: float,
+    elapsed: float = 0.0,
+    cleanup_reserve_s: float = CRON_DRAIN_CLEANUP_RESERVE_S,
+) -> float:
+    """Seconds the shutdown drain may spend waiting on in-flight cron work.
+
+    The configured floor is clamped to what this process can actually honour.
+    The shutdown watchdog hard-exits at ``watchdog_delay`` and the service
+    manager's ``TimeoutStopSec`` is sized from the same drain timeout, so
+    waiting past that leash (minus ``cleanup_reserve_s`` for the teardown that
+    follows the drain) would swap a cleanly-interrupted job for a SIGKILL that
+    leaves it wedged mid-run — strictly worse than the bug being fixed.
+
+    Never returns less than ``drain_timeout``: the cron floor only ever
+    extends the wait, so an operator who deliberately configured a long
+    ``restart_drain_timeout`` keeps it.
+    """
+
+    def _seconds(value: object, fallback: float = 0.0) -> float:
+        try:
+            return max(float(value), 0.0)  # type: ignore[arg-type]
+        except (TypeError, ValueError):
+            return fallback
+
+    drain = _seconds(drain_timeout)
+    floor = _seconds(cron_drain_timeout)
+    if floor <= 0.0:
+        return drain
+    ceiling = (
+        _seconds(watchdog_delay)
+        - _seconds(elapsed)
+        - _seconds(cleanup_reserve_s, CRON_DRAIN_CLEANUP_RESERVE_S)
+    )
+    return max(drain, min(floor, ceiling))
 
 
 def resolve_restart_exit_wait_budget(

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -13946,9 +13946,15 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # In-flight cron work gets its own floor, clamped to the watchdog
             # leash we're already running under so the extra wait can never
             # cost us the post-drain cleanup window (#82161).
+            # getattr-guard: shutdown-path tests drive _stop_impl_body from
+            # bare doubles that aren't GatewayRunner instances, so they don't
+            # pick up the class-level default.
+            _cron_drain_cfg = getattr(
+                self, "_cron_drain_timeout", DEFAULT_GATEWAY_CRON_DRAIN_TIMEOUT
+            )
             _cron_timeout = resolve_cron_drain_budget(
                 timeout,
-                self._cron_drain_timeout,
+                _cron_drain_cfg,
                 watchdog_delay=resolve_shutdown_watchdog_delay(timeout),
                 elapsed=_phase_elapsed(),
             )
@@ -13959,7 +13965,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     "restart_drain_timeout=%.0fs)",
                     _cron_at_start,
                     _cron_timeout,
-                    self._cron_drain_timeout,
+                    _cron_drain_cfg,
                     timeout,
                 )
             _drain_started_at = time.monotonic()

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -10171,6 +10171,103 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         if interrupted_api:
             logger.debug("Interrupted %d api_server run(s) during shutdown", interrupted_api)
 
+    async def _notify_interrupted_cron_jobs(self, job_ids) -> int:
+        """Tell the owner of each just-interrupted cron job that its run died.
+
+        The cron worker cannot do this itself. Its thread reaches
+        ``_deliver_result`` asynchronously, and by then
+        ``_bounded_adapter_teardown`` has closed the transport — so the notice
+        never leaves the process, and ``_consume_interrupted_flag`` discards
+        the resulting ``delivery_error`` along with it. The run's only trace is
+        a line in jobs.json nobody reads (#82232).
+
+        Must therefore be called from the post-interrupt phase, while adapters
+        are still connected — the same window
+        ``_notify_active_sessions_of_shutdown`` relies on for chat sessions,
+        which is blind to cron work because cron runs on the scheduler's own
+        thread pool rather than ``self._running_agents`` (#60432).
+
+        Best-effort by construction: every failure is swallowed so a wedged
+        adapter can never extend shutdown. Returns the number of notices sent.
+        """
+        if not job_ids:
+            return 0
+        try:
+            from cron.jobs import get_job
+            from cron.scheduler import _resolve_delivery_targets
+        except Exception as e:
+            logger.debug("Cron interrupt notification unavailable: %s", e)
+            return 0
+
+        action = "restarting" if self._restart_requested else "shutting down"
+        notified: set = set()
+        for job_id in job_ids:
+            try:
+                job = get_job(job_id)
+                if not job:
+                    continue
+                # deliver=local jobs — and deliver=origin jobs with no
+                # resolvable origin (#43014) — resolve to zero targets and
+                # must stay silent rather than fall back to a home channel.
+                targets = _resolve_delivery_targets(job)
+            except Exception as e:
+                logger.debug("Cron interrupt targets unresolved for %s: %s", job_id, e)
+                continue
+            if not targets:
+                continue
+
+            msg = (
+                f"⚠️ Cron job '{job.get('name') or job_id}' was interrupted — "
+                f"the gateway is {action} and killed the run before it "
+                "finished. No result was produced for this run."
+            )
+            for target in targets:
+                try:
+                    platform = Platform(str(target.get("platform", "")).lower())
+                except Exception:
+                    continue
+                adapter = self.adapters.get(platform)
+                if adapter is None:
+                    continue
+                platform_cfg = self.config.platforms.get(platform)
+                if platform_cfg is not None and not platform_cfg.gateway_restart_notification:
+                    continue
+
+                chat_id = str(target.get("chat_id"))
+                thread_id = target.get("thread_id")
+                dedup_key = (
+                    job_id,
+                    platform.value,
+                    chat_id,
+                    str(thread_id) if thread_id else None,
+                )
+                if dedup_key in notified:
+                    continue
+                try:
+                    metadata = self._thread_metadata_for_target(
+                        platform, chat_id, thread_id, adapter=adapter
+                    )
+                    result = await adapter.send(chat_id, msg, metadata=metadata)
+                    if result is not None and getattr(result, "success", True) is False:
+                        logger.debug(
+                            "Cron interrupt notice to %s:%s failed: %s",
+                            platform.value, chat_id,
+                            getattr(result, "error", "send returned success=False"),
+                        )
+                        continue
+                    notified.add(dedup_key)
+                except Exception as e:
+                    logger.debug(
+                        "Cron interrupt notice to %s:%s raised: %s",
+                        platform.value, chat_id, e,
+                    )
+        if notified:
+            logger.info(
+                "Shutdown: delivered %d interrupted-cron-job notice(s)",
+                len(notified),
+            )
+        return len(notified)
+
     async def _notify_active_sessions_of_shutdown(self) -> None:
         """Send shutdown/restart notifications to active chats and home channels.
 
@@ -13784,8 +13881,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             return
 
         async def _stop_impl() -> None:
-            def _kill_tool_subprocesses(phase: str) -> None:
+            def _kill_tool_subprocesses(phase: str) -> list:
                 """Kill tool subprocesses + tear down terminal envs + browsers.
+
+                Returns the cron job IDs this phase marked interrupted, so the
+                caller can notify their owners while adapters are still up
+                (#82232). Empty list when no cron work was in flight.
 
                 Called twice in the shutdown path: once eagerly after a
                 drain timeout forces agent interrupt (so we reclaim bash/
@@ -13807,6 +13908,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         )
                 except Exception as _e:
                     logger.debug("process_registry.kill_all (%s) error: %s", phase, _e)
+                _marked_cron_jobs: list = []
                 try:
                     # Any cron job still dispatched at this instant just had
                     # its tool subprocess killed above (kill_all() has no
@@ -13817,7 +13919,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     # the scheduler can never report that as success (#60432).
                     # No-op when no cron job is in flight.
                     from cron.scheduler import mark_running_jobs_interrupted
-                    _interrupted = mark_running_jobs_interrupted(
+                    _interrupted = _marked_cron_jobs = mark_running_jobs_interrupted(
                         f"Gateway shutdown ({phase}) killed the job's tool "
                         "subprocess before the run finished."
                     )
@@ -13848,6 +13950,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     cleanup_all_browsers()
                 except Exception as _e:
                     logger.debug("cleanup_all_browsers (%s) error: %s", phase, _e)
+                return _marked_cron_jobs
 
             # Thread-based shutdown watchdog (#66892): asyncio timeouts cannot
             # recover a frozen loop. Arm a plain OS thread at the start of
@@ -14090,9 +14193,21 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 # children left behind by an interrupted terminal tool get
                 # killed by systemd instead of us (issue #8202).  The final
                 # catch-all cleanup below still runs for the graceful path.
-                _kill_tool_subprocesses("post-interrupt")
+                _interrupted_cron_jobs = _kill_tool_subprocesses("post-interrupt")
                 logger.info(
                     "Shutdown phase: post-interrupt tool kill done at +%.2fs",
+                    _phase_elapsed(),
+                )
+                # Last window where the transport is still up. The cron worker
+                # whose run we just killed will try to deliver its own
+                # "interrupted" notice, but it gets there after the adapter
+                # teardown below and the message is lost (#82232).
+                try:
+                    await self._notify_interrupted_cron_jobs(_interrupted_cron_jobs)
+                except Exception as _e:
+                    logger.debug("Cron interrupt notification failed: %s", _e)
+                logger.info(
+                    "Shutdown phase: cron interrupt notices done at +%.2fs",
                     _phase_elapsed(),
                 )
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2271,6 +2271,8 @@ if _config_path.exists():
                 )
             if "restart_drain_timeout" in _agent_cfg:
                 os.environ["HERMES_RESTART_DRAIN_TIMEOUT"] = str(_agent_cfg["restart_drain_timeout"])
+            if "cron_drain_timeout" in _agent_cfg:
+                os.environ["HERMES_CRON_DRAIN_TIMEOUT"] = str(_agent_cfg["cron_drain_timeout"])
             if "gateway_auto_continue_freshness" in _agent_cfg:
                 os.environ["HERMES_AUTO_CONTINUE_FRESHNESS"] = str(
                     _agent_cfg["gateway_auto_continue_freshness"]
@@ -2491,12 +2493,15 @@ from gateway.shutdown_watchdog import (
     start_loop_liveness_watchdog,
 )
 from gateway.restart import (
+    DEFAULT_GATEWAY_CRON_DRAIN_TIMEOUT,
     DEFAULT_GATEWAY_RESTART_AFTER_TURN_TIMEOUT,
     DEFAULT_GATEWAY_RESTART_DRAIN_TIMEOUT,
     GATEWAY_FATAL_CONFIG_EXIT_CODE,
     GATEWAY_SERVICE_RESTART_EXIT_CODE,
+    parse_cron_drain_timeout,
     parse_restart_after_turn_timeout,
     parse_restart_drain_timeout,
+    resolve_cron_drain_budget,
 )
 
 
@@ -6355,6 +6360,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
     _busy_text_mode: str = "interrupt"
     _restart_drain_timeout: float = DEFAULT_GATEWAY_RESTART_DRAIN_TIMEOUT
     _restart_after_turn_timeout: float = DEFAULT_GATEWAY_RESTART_AFTER_TURN_TIMEOUT
+    _cron_drain_timeout: float = DEFAULT_GATEWAY_CRON_DRAIN_TIMEOUT
     _exit_code: Optional[int] = None
     _draining: bool = False
     _external_drain_active: bool = False
@@ -6497,6 +6503,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         self._busy_text_modes_by_profile: Dict[str, str] = {}
         self._restart_drain_timeout = self._load_restart_drain_timeout()
         self._restart_after_turn_timeout = self._load_restart_after_turn_timeout()
+        self._cron_drain_timeout = self._load_cron_drain_timeout()
         self._provider_routing = self._load_provider_routing()
         self._fallback_model = self._load_fallback_model()
 
@@ -9200,6 +9207,29 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         return value
 
     @staticmethod
+    def _load_cron_drain_timeout() -> float:
+        """Load the cron-only floor under the stop()/drain wait (#82161)."""
+        env_raw = os.getenv("HERMES_CRON_DRAIN_TIMEOUT")
+        if env_raw is not None and str(env_raw).strip() != "":
+            raw: object = env_raw
+        else:
+            cfg = _load_gateway_runtime_config()
+            raw = cfg_get(cfg, "agent", "cron_drain_timeout", default=None)
+        value = parse_cron_drain_timeout(raw)
+        # Warn only when the user supplied a non-empty value that failed to
+        # parse (parser falls back to the default). ``0`` is valid.
+        if raw is not None and str(raw).strip() != "":
+            try:
+                float(raw)
+            except (TypeError, ValueError):
+                logger.warning(
+                    "Invalid cron_drain_timeout '%s', using default %.0fs",
+                    raw,
+                    DEFAULT_GATEWAY_CRON_DRAIN_TIMEOUT,
+                )
+        return value
+
+    @staticmethod
     def _load_background_notifications_mode() -> str:
         """Load background process notification mode from config or env var.
 
@@ -10050,7 +10080,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         return True
 
-    async def _drain_active_agents(self, timeout: float) -> tuple[Dict[str, Any], bool]:
+    async def _drain_active_agents(
+        self, timeout: float, cron_timeout: Optional[float] = None
+    ) -> tuple[Dict[str, Any], bool]:
         snapshot = self._snapshot_running_agents()
         last_active_count = self._running_agent_count()
         last_cron_count = self._active_cron_job_count()
@@ -10087,18 +10119,32 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             return snapshot, False
 
         _maybe_update_status(force=True)
-        if timeout <= 0:
-            return snapshot, True
 
-        deadline = asyncio.get_running_loop().time() + timeout
-        while (
-            (
-                len(self._running_agents)
-                or self._active_cron_job_count()
-                or self._active_api_run_count()
-            )
-            and asyncio.get_running_loop().time() < deadline
-        ):
+        # Cron work drains on its own deadline. ``timeout``
+        # (``restart_drain_timeout``) defaults to 0 because interrupting a
+        # chat turn is announced and resumable; a cron run killed mid-flight
+        # is recorded in jobs.json as a permanent failure nobody is waiting
+        # on. Sharing one budget meant the default config could report
+        # ``timed_out=True`` after 0.00s with a cron job in flight and kill
+        # it — the drain never even entered this loop (#82161).
+        loop = asyncio.get_running_loop()
+        started = loop.time()
+        deadline = started + timeout
+        cron_deadline = started + (timeout if cron_timeout is None else cron_timeout)
+
+        def _still_draining() -> bool:
+            now = loop.time()
+            if (
+                len(self._running_agents) or self._active_api_run_count()
+            ) and now < deadline:
+                return True
+            return bool(self._active_cron_job_count()) and now < cron_deadline
+
+        # Both budgets at 0 leave this loop unentered, which is the legacy
+        # "interrupt immediately" behaviour — expressed as an expired
+        # deadline rather than a special case, so the timed_out value below
+        # is always computed from real state instead of asserted up front.
+        while _still_draining():
             _maybe_update_status()
             await asyncio.sleep(0.1)
         timed_out = (
@@ -13897,15 +13943,37 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
             _cron_at_start = self._active_cron_job_count()
             _api_at_start = self._active_api_run_count()
+            # In-flight cron work gets its own floor, clamped to the watchdog
+            # leash we're already running under so the extra wait can never
+            # cost us the post-drain cleanup window (#82161).
+            _cron_timeout = resolve_cron_drain_budget(
+                timeout,
+                self._cron_drain_timeout,
+                watchdog_delay=resolve_shutdown_watchdog_delay(timeout),
+                elapsed=_phase_elapsed(),
+            )
+            if _cron_at_start and _cron_timeout > timeout:
+                logger.info(
+                    "Shutdown drain: %d in-flight cron job(s) — waiting up to "
+                    "%.0fs for them (cron_drain_timeout=%.0fs, "
+                    "restart_drain_timeout=%.0fs)",
+                    _cron_at_start,
+                    _cron_timeout,
+                    self._cron_drain_timeout,
+                    timeout,
+                )
             _drain_started_at = time.monotonic()
-            active_agents, timed_out = await self._drain_active_agents(timeout)
+            active_agents, timed_out = await self._drain_active_agents(
+                timeout, _cron_timeout
+            )
+            _drain_elapsed = time.monotonic() - _drain_started_at
             logger.info(
                 "Shutdown phase: drain done at +%.2fs (drain took %.2fs, "
                 "timed_out=%s, active_at_start=%d, active_now=%d, "
                 "cron_at_start=%d, cron_now=%d, "
                 "api_at_start=%d, api_now=%d)",
                 _phase_elapsed(),
-                time.monotonic() - _drain_started_at,
+                _drain_elapsed,
                 timed_out,
                 len(active_agents),
                 self._running_agent_count(),
@@ -13934,7 +14002,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     "Gateway drain timed out after %.1fs with %d active agent(s), "
                     "%d in-flight cron job(s), and %d api_server run(s); "
                     "interrupting remaining work.",
-                    timeout,
+                    _drain_elapsed,
                     self._running_agent_count(),
                     self._active_cron_job_count(),
                     self._active_api_run_count(),

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -78,6 +78,15 @@ DEFAULT_CONFIG = {
         # (/restart, SIGUSR1), prefer restart_after_turn_timeout below so
         # active turns finish *before* stop() begins (#77184).
         "restart_drain_timeout": 0,
+        # Cron-only floor under the stop()/drain wait (seconds). A chat turn
+        # interrupted by a restart is announced to the user and resumed on
+        # their next message; an interrupted cron run is written to jobs.json
+        # as a permanent failure that nobody is waiting on, so it must not
+        # inherit restart_drain_timeout's 0 (#82161). Clamped at runtime to
+        # the shutdown-watchdog leash minus teardown headroom, so raising it
+        # past ~50s has no effect unless TimeoutStopSec is raised too.
+        # 0 = opt out (cron drains on restart_drain_timeout, legacy).
+        "cron_drain_timeout": 30,
         # In-band restart wait for active turns to finish before stop()
         # (seconds). /restart and SIGUSR1 refuse new work, then wait up to
         # this cap for in-flight agents/cron/api runs to complete naturally

--- a/tests/gateway/restart_test_helpers.py
+++ b/tests/gateway/restart_test_helpers.py
@@ -5,6 +5,7 @@ from unittest.mock import AsyncMock, MagicMock
 from gateway.config import GatewayConfig, Platform, PlatformConfig
 from gateway.platforms.base import BasePlatformAdapter, SendResult
 from gateway.restart import (
+    DEFAULT_GATEWAY_CRON_DRAIN_TIMEOUT,
     DEFAULT_GATEWAY_RESTART_AFTER_TURN_TIMEOUT,
     DEFAULT_GATEWAY_RESTART_DRAIN_TIMEOUT,
 )
@@ -77,6 +78,7 @@ def make_restart_runner(
     runner._restart_command_source = None
     runner._restart_drain_timeout = DEFAULT_GATEWAY_RESTART_DRAIN_TIMEOUT
     runner._restart_after_turn_timeout = DEFAULT_GATEWAY_RESTART_AFTER_TURN_TIMEOUT
+    runner._cron_drain_timeout = DEFAULT_GATEWAY_CRON_DRAIN_TIMEOUT
     runner._stop_task = None
     runner._busy_input_mode = "interrupt"
     runner._update_prompt_pending = {}

--- a/tests/gateway/test_cron_active_work_drain.py
+++ b/tests/gateway/test_cron_active_work_drain.py
@@ -87,6 +87,7 @@ class TestKillToolSubprocessesMarksCronInterrupted:
 
         runner, adapter = make_restart_runner()
         runner._restart_drain_timeout = 0.01  # force the timeout path
+        runner._cron_drain_timeout = 0.01  # ...past the cron floor too (#82161)
         adapter.disconnect = _make_async_noop()
 
         sched._running_job_ids.add("job-1")

--- a/tests/gateway/test_cron_drain_floor.py
+++ b/tests/gateway/test_cron_drain_floor.py
@@ -1,0 +1,158 @@
+"""Regression tests for #82161.
+
+``restart_drain_timeout`` defaults to ``0``, and the drain applied that single
+budget to every class of in-flight work. That default is deliberate for chat
+turns — the user is told the gateway is restarting and the session is
+pre-marked resume_pending, so interrupting one is cheap and recoverable — but
+a cron run has neither property: it is written to jobs.json as a permanent
+failure that nobody is waiting on, and a recurring job just skips to its next
+schedule.
+
+With the shared budget the drain short-circuited on ``timeout <= 0`` before
+the wait loop, producing the reported log line: ``drain took 0.00s,
+timed_out=True, cron_at_start=1, cron_now=1`` — it detected the job and killed
+it anyway. Cron work now drains on its own floor (``cron_drain_timeout``),
+clamped to the shutdown-watchdog leash so the extra wait can never eat the
+post-drain cleanup window.
+"""
+
+import asyncio
+
+import pytest
+
+from gateway.restart import (
+    CRON_DRAIN_CLEANUP_RESERVE_S,
+    DEFAULT_GATEWAY_CRON_DRAIN_TIMEOUT,
+    parse_cron_drain_timeout,
+    resolve_cron_drain_budget,
+)
+from tests.gateway.restart_test_helpers import make_restart_runner
+
+
+@pytest.fixture(autouse=True)
+def _reset_cron_running_set():
+    import cron.scheduler as sched
+
+    sched._running_job_ids.clear()
+    sched._interrupted_job_ids.clear()
+    yield
+    sched._running_job_ids.clear()
+    sched._interrupted_job_ids.clear()
+
+
+class TestDrainWaitsForCronOnDefaultConfig:
+    """The reported repro: default config, cron-only workload."""
+
+    @pytest.mark.asyncio
+    async def test_zero_drain_timeout_still_waits_for_cron(self):
+        import cron.scheduler as sched
+
+        runner, _adapter = make_restart_runner()
+        sched._running_job_ids.add("be62d36a9914")
+
+        async def finish_job():
+            await asyncio.sleep(0.12)
+            sched._running_job_ids.discard("be62d36a9914")
+
+        task = asyncio.create_task(finish_job())
+        # restart_drain_timeout=0 (the shipped default) with a 2s cron floor.
+        _snapshot, timed_out = await runner._drain_active_agents(0.0, 2.0)
+        await task
+
+        assert timed_out is False, (
+            "drain returned timed_out=True with a cron job in flight — this is "
+            "the 0.00s drain from #82161"
+        )
+        assert runner._active_cron_job_count() == 0
+
+    @pytest.mark.asyncio
+    async def test_cron_floor_is_bounded_not_indefinite(self):
+        """A job that never finishes must still lose, or a cron-triggered
+        restart (the reporter's `hermes update` job) would deadlock: the job
+        waits for the gateway to exit while the gateway waits for the job."""
+        import cron.scheduler as sched
+
+        runner, _adapter = make_restart_runner()
+        sched._running_job_ids.add("never-finishes")
+
+        _snapshot, timed_out = await runner._drain_active_agents(0.0, 0.2)
+
+        assert timed_out is True
+        assert runner._active_cron_job_count() == 1
+
+    @pytest.mark.asyncio
+    async def test_chat_only_workload_keeps_the_zero_second_drain(self):
+        """The cron floor must not silently become a chat-turn grace window —
+        `restart_drain_timeout: 0` still means "interrupt chat immediately"."""
+        runner, _adapter = make_restart_runner()
+        runner._running_agents = {"sess-1": object()}
+
+        loop = asyncio.get_running_loop()
+        before = loop.time()
+        _snapshot, timed_out = await runner._drain_active_agents(0.0, 30.0)
+        elapsed = loop.time() - before
+
+        assert timed_out is True
+        assert elapsed < 1.0, f"chat-only drain waited {elapsed:.2f}s on a 0s budget"
+
+    @pytest.mark.asyncio
+    async def test_cron_timeout_defaults_to_the_shared_budget(self):
+        """Callers that pass one argument keep the pre-#82161 semantics."""
+        import cron.scheduler as sched
+
+        runner, _adapter = make_restart_runner()
+        sched._running_job_ids.add("job-1")
+
+        _snapshot, timed_out = await runner._drain_active_agents(0.0)
+
+        assert timed_out is True
+
+
+class TestParseCronDrainTimeout:
+    def test_missing_and_blank_fall_back_to_default(self):
+        assert parse_cron_drain_timeout(None) == DEFAULT_GATEWAY_CRON_DRAIN_TIMEOUT
+        assert parse_cron_drain_timeout("") == DEFAULT_GATEWAY_CRON_DRAIN_TIMEOUT
+        assert parse_cron_drain_timeout("   ") == DEFAULT_GATEWAY_CRON_DRAIN_TIMEOUT
+
+    def test_zero_is_a_deliberate_opt_out_not_a_missing_value(self):
+        assert parse_cron_drain_timeout(0) == 0.0
+        assert parse_cron_drain_timeout("0") == 0.0
+
+    def test_garbage_falls_back_and_negatives_clamp(self):
+        assert parse_cron_drain_timeout("soon") == DEFAULT_GATEWAY_CRON_DRAIN_TIMEOUT
+        assert parse_cron_drain_timeout(-5) == 0.0
+
+
+class TestResolveCronDrainBudget:
+    def test_extends_a_zero_drain_up_to_the_configured_floor(self):
+        assert resolve_cron_drain_budget(
+            0.0, 30.0, watchdog_delay=60.0, elapsed=1.0
+        ) == 30.0
+
+    def test_clamped_to_the_watchdog_leash_minus_cleanup_reserve(self):
+        # Watchdog hard-exits at 60s; waiting 300s would guarantee a SIGKILL
+        # mid-cleanup, leaving the job wedged at last_status=running.
+        budget = resolve_cron_drain_budget(
+            0.0, 300.0, watchdog_delay=60.0, elapsed=5.0
+        )
+        assert budget == pytest.approx(60.0 - 5.0 - CRON_DRAIN_CLEANUP_RESERVE_S)
+
+    def test_never_shortens_an_explicitly_configured_drain_timeout(self):
+        assert resolve_cron_drain_budget(
+            120.0, 30.0, watchdog_delay=180.0, elapsed=0.0
+        ) == 120.0
+
+    def test_no_headroom_left_falls_back_to_the_drain_timeout(self):
+        assert resolve_cron_drain_budget(
+            0.0, 30.0, watchdog_delay=60.0, elapsed=59.0
+        ) == 0.0
+
+    def test_zero_floor_opts_out_entirely(self):
+        assert resolve_cron_drain_budget(
+            0.0, 0.0, watchdog_delay=60.0, elapsed=0.0
+        ) == 0.0
+
+    def test_non_numeric_inputs_degrade_instead_of_raising(self):
+        assert resolve_cron_drain_budget(
+            None, "30", watchdog_delay=60.0, elapsed=None
+        ) == 30.0

--- a/tests/gateway/test_cron_interrupt_notification.py
+++ b/tests/gateway/test_cron_interrupt_notification.py
@@ -1,0 +1,229 @@
+"""Regression tests for #82232.
+
+When the shutdown interrupts an in-flight cron job, the job's own worker
+thread tries to deliver an "interrupted" notice — and loses, because
+``_bounded_adapter_teardown`` has already closed the transport by the time it
+gets there. The notice is dropped, and ``_consume_interrupted_flag`` discards
+the resulting ``delivery_error`` with it, so the run's only trace is a line in
+jobs.json.
+
+The gateway now sends that notice itself in the post-interrupt phase, while
+adapters are still connected — the same window
+``_notify_active_sessions_of_shutdown`` uses for chat sessions, which never
+saw cron work because cron runs outside ``_running_agents`` (#60432).
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+from gateway.config import Platform
+from tests.gateway.restart_test_helpers import make_restart_runner
+
+
+@pytest.fixture(autouse=True)
+def _reset_cron_running_set():
+    import cron.scheduler as sched
+
+    sched._running_job_ids.clear()
+    sched._interrupted_job_ids.clear()
+    yield
+    sched._running_job_ids.clear()
+    sched._interrupted_job_ids.clear()
+
+
+def _telegram_job(job_id="be62d36a9914", name="daily-digest", chat_id="123456"):
+    return {
+        "id": job_id,
+        "name": name,
+        "deliver": f"telegram:{chat_id}",
+    }
+
+
+def _telegram_target(chat_id="123456"):
+    return {"platform": "telegram", "chat_id": chat_id, "thread_id": None}
+
+
+def _bind_notifier(runner):
+    from gateway.run import GatewayRunner
+
+    runner._notify_interrupted_cron_jobs = (
+        GatewayRunner._notify_interrupted_cron_jobs.__get__(runner, GatewayRunner)
+    )
+    runner._thread_metadata_for_target = (
+        GatewayRunner._thread_metadata_for_target.__get__(runner, GatewayRunner)
+    )
+    return runner
+
+
+class TestNotifyInterruptedCronJobs:
+    @pytest.mark.asyncio
+    async def test_owner_is_told_the_run_was_killed(self):
+        runner, adapter = make_restart_runner()
+        _bind_notifier(runner)
+        job = _telegram_job()
+
+        with patch("cron.jobs.get_job", return_value=job), \
+             patch("cron.scheduler._resolve_delivery_targets",
+                   return_value=[_telegram_target()]):
+            sent = await runner._notify_interrupted_cron_jobs([job["id"]])
+
+        assert sent == 1
+        assert len(adapter.sent) == 1
+        body = adapter.sent[0]
+        assert "daily-digest" in body
+        assert "interrupted" in body.lower()
+        assert adapter.sent_calls[0][0] == "123456"
+
+    @pytest.mark.asyncio
+    async def test_says_restarting_when_restart_was_requested(self):
+        runner, adapter = make_restart_runner()
+        _bind_notifier(runner)
+        runner._restart_requested = True
+        job = _telegram_job()
+
+        with patch("cron.jobs.get_job", return_value=job), \
+             patch("cron.scheduler._resolve_delivery_targets",
+                   return_value=[_telegram_target()]):
+            await runner._notify_interrupted_cron_jobs([job["id"]])
+
+        assert "restarting" in adapter.sent[0]
+
+    @pytest.mark.asyncio
+    async def test_local_only_job_stays_silent(self):
+        """deliver=local, and deliver=origin with no resolvable origin
+        (#43014), resolve to zero targets and must not fall back to a home
+        channel."""
+        runner, adapter = make_restart_runner()
+        _bind_notifier(runner)
+        job = {"id": "j1", "name": "local-job", "deliver": "local"}
+
+        with patch("cron.jobs.get_job", return_value=job), \
+             patch("cron.scheduler._resolve_delivery_targets", return_value=[]):
+            sent = await runner._notify_interrupted_cron_jobs(["j1"])
+
+        assert sent == 0
+        assert adapter.sent == []
+
+    @pytest.mark.asyncio
+    async def test_respects_platform_gateway_restart_notification_false(self):
+        runner, adapter = make_restart_runner()
+        _bind_notifier(runner)
+        runner.config.platforms[Platform.TELEGRAM].gateway_restart_notification = False
+        job = _telegram_job()
+
+        with patch("cron.jobs.get_job", return_value=job), \
+             patch("cron.scheduler._resolve_delivery_targets",
+                   return_value=[_telegram_target()]):
+            sent = await runner._notify_interrupted_cron_jobs([job["id"]])
+
+        assert sent == 0
+        assert adapter.sent == []
+
+    @pytest.mark.asyncio
+    async def test_empty_job_list_is_a_noop(self):
+        runner, adapter = make_restart_runner()
+        _bind_notifier(runner)
+
+        assert await runner._notify_interrupted_cron_jobs([]) == 0
+        assert adapter.sent == []
+
+    @pytest.mark.asyncio
+    async def test_a_raising_adapter_cannot_block_shutdown(self):
+        """Best-effort by construction: a wedged adapter must not propagate."""
+        runner, adapter = make_restart_runner()
+        _bind_notifier(runner)
+        job = _telegram_job()
+
+        async def _boom(*_a, **_kw):
+            raise RuntimeError("transport already closed")
+
+        adapter.send = _boom
+
+        with patch("cron.jobs.get_job", return_value=job), \
+             patch("cron.scheduler._resolve_delivery_targets",
+                   return_value=[_telegram_target()]):
+            sent = await runner._notify_interrupted_cron_jobs([job["id"]])
+
+        assert sent == 0
+
+    @pytest.mark.asyncio
+    async def test_duplicate_targets_send_once_per_job(self):
+        runner, adapter = make_restart_runner()
+        _bind_notifier(runner)
+        job = _telegram_job()
+
+        with patch("cron.jobs.get_job", return_value=job), \
+             patch("cron.scheduler._resolve_delivery_targets",
+                   return_value=[_telegram_target(), _telegram_target()]):
+            sent = await runner._notify_interrupted_cron_jobs([job["id"]])
+
+        assert sent == 1
+        assert len(adapter.sent) == 1
+
+
+class TestShutdownDeliversNoticeBeforeDisconnect:
+    @pytest.mark.asyncio
+    async def test_notice_is_sent_while_the_adapter_is_still_connected(self, monkeypatch):
+        """The whole point is ordering: a notice sent after teardown is lost,
+        which is the bug."""
+        import cron.scheduler as sched
+        import tools.browser_tool as _bt
+        import tools.process_registry as _pr
+        import tools.terminal_tool as _tt
+
+        runner, adapter = make_restart_runner()
+        runner._restart_drain_timeout = 0.01  # force the interrupt path
+        sched._running_job_ids.add("be62d36a9914")
+
+        monkeypatch.setattr(_pr.process_registry, "kill_all", lambda task_id=None: 1)
+        monkeypatch.setattr(_tt, "cleanup_all_environments", lambda: None)
+        monkeypatch.setattr(_bt, "cleanup_all_browsers", lambda: None)
+
+        events: list[str] = []
+        real_send = adapter.send
+
+        async def _tracking_send(chat_id, content, reply_to=None, metadata=None):
+            if "was interrupted" in content:
+                events.append("cron_notice")
+            return await real_send(chat_id, content, reply_to=reply_to, metadata=metadata)
+
+        async def _tracking_disconnect():
+            events.append("disconnect")
+
+        adapter.send = _tracking_send
+        adapter.disconnect = _tracking_disconnect
+
+        with patch("gateway.status.remove_pid_file"), \
+             patch("gateway.status.write_runtime_status"), \
+             patch("cron.scheduler.mark_job_run"), \
+             patch("cron.jobs.get_job", return_value=_telegram_job()), \
+             patch("cron.scheduler._resolve_delivery_targets",
+                   return_value=[_telegram_target()]):
+            await runner.stop()
+
+        assert "cron_notice" in events, "interrupted-cron notice was never sent"
+        assert "disconnect" in events
+        assert events.index("cron_notice") < events.index("disconnect"), (
+            f"notice sent after adapter teardown — it would be lost: {events}"
+        )
+
+
+class TestDeliveryErrorIsRecordedWhenTheNoticeCannotBeSent:
+    def test_interrupted_run_records_delivery_error_without_mark_job_run(self):
+        """``_consume_interrupted_flag`` short-circuits ``mark_job_run``,
+        which used to discard ``delivery_error`` along with it. The recovery
+        path must use ``update_job`` so the repeat counter and next_run_at
+        bookkeeping that ``mark_job_run`` owns is not run twice for one run.
+        """
+        import inspect
+
+        import cron.scheduler as sched
+
+        src = inspect.getsource(sched.run_one_job)
+        assert 'update_job(job["id"], {"last_delivery_error": delivery_error})' in src, (
+            "interrupted runs must still persist the delivery failure"
+        )
+        # The recovery branch hangs off the interrupted-flag short-circuit,
+        # not off a second mark_job_run call.
+        assert "elif delivery_error:" in src

--- a/tests/gateway/test_cron_interrupt_notification.py
+++ b/tests/gateway/test_cron_interrupt_notification.py
@@ -220,10 +220,10 @@ class TestDeliveryErrorIsRecordedWhenTheNoticeCannotBeSent:
 
         import cron.scheduler as sched
 
-        src = inspect.getsource(sched.run_one_job)
+        src = inspect.getsource(sched._run_one_job_body)
         assert 'update_job(job["id"], {"last_delivery_error": delivery_error})' in src, (
             "interrupted runs must still persist the delivery failure"
         )
         # The recovery branch hangs off the interrupted-flag short-circuit,
         # not off a second mark_job_run call.
-        assert "elif delivery_error:" in src
+        assert "if interrupted:" in src and "if delivery_error:" in src

--- a/tests/gateway/test_shutdown_cache_cleanup.py
+++ b/tests/gateway/test_shutdown_cache_cleanup.py
@@ -87,7 +87,7 @@ class _FakeGateway:
     async def _cancel_secondary_profile_reconnect_tasks(self):
         pass
 
-    async def _drain_active_agents(self, timeout):
+    async def _drain_active_agents(self, timeout, cron_timeout=None):
         return {}, False
 
     async def _finalize_shutdown_agents(self, agents):


### PR DESCRIPTION
## Summary

Consolidated salvage of the gateway-shutdown × in-flight-cron contract — fixes #82161 and #82232:

1. **Cron drain floor** (from #82224 by @JoaoMarcos44, issue #82161 by @ZenGraphix). `agent.restart_drain_timeout` defaults to 0 — deliberate for chat turns (announced + `resume_pending`), catastrophic for cron: `_drain_active_agents()` short-circuited on `timeout <= 0` before entering the wait loop, so the drain reported `drain took 0.00s, timed_out=True, cron_at_start=1, cron_now=1` and killed the job it had just detected. Cron work now drains on its own budget, `agent.cron_drain_timeout` (default 30s, 0 opts out), clamped to the shutdown-watchdog leash minus a teardown reserve so a long wait can never consume the post-drain cleanup window. Chat-only shutdowns are unchanged. The drain-timeout warning now reports elapsed time, not the configured budget.
2. **Interrupted-cron notices delivered while adapters are still connected** (from #82244 by @JoaoMarcos44, issue #82232 by @JoaoMarcos44). The cron worker's own "interrupted" notice raced adapter teardown and lost (measured 6 ms in the #82161 report). The gateway now sends the notice from the post-interrupt phase — the last window with a live transport — resolving each job's configured delivery target, honoring `restart_notification=false` and local/no-origin targets. When the notice still can't be sent, the delivery failure is persisted (`last_delivery_error` via `update_job`, without re-running `mark_job_run`'s next_run/repeat bookkeeping), so jobs.json records both the interruption and the lost alert.
3. **Ownerless interrupted fires still notify** (maintainer follow-up). `mark_running_jobs_interrupted` skips the persisted `last_status` write for legacy fires with no registered durable owner — correct, but it also dropped them from the returned ID list, which the notification path consumes. They're now included in the return value so the user is still told, while the persistence skip stays.

Composes with the drain contract on current main (post-#70638 owner-fenced completion flow): the #82244 delivery-error recovery was rewoven into the fenced `interrupted` short-circuit rather than the old flag-consume shape.

## Closes

Closes #82161. Closes #82232.

## Testing

- `tests/gateway/test_cron_interrupt_notification.py` (new, salvaged): 9 passed
- `tests/gateway/test_cron_drain_floor.py` (new, salvaged): passed
- `tests/gateway/test_update_cron_drain.py`, `test_shutdown_cache_cleanup.py`, `test_cron_active_work_drain.py`, `tests/cron/test_shutdown_interrupt.py`: **44 passed** combined
- `tests/cron/` full suite: 681 passed, 1 skipped
- `ruff check` clean; attribution audit clean

## Notes for review

- #82282 (@JonthanaHanh) proposed a narrower fix for the same `timeout <= 0` short-circuit (30s constant for background work); superseded by the configurable drain floor here — closing with credit.
- The salvaged source-inspection test was retargeted from `run_one_job` to `_run_one_job_body` (main's extraction).

## Infographic

![gateway-drain-cron-contract](https://gist.githubusercontent.com/teknium1/ee33edd5804689243f974536ef7aecb9/raw/infographic-cron-drain.png)
