### PR TITLE
fix(mcp): retain profile secret scope during discovery

### DIFF
--- a/hermes_cli/mcp_startup.py
+++ b/hermes_cli/mcp_startup.py
@@ -76,15 +76,36 @@ def start_background_mcp_discovery(*, logger, thread_name: str) -> None:
             home_override = get_hermes_home_override()
         except Exception:
             home_override = None
+        # Profile routing installs credentials in a ContextVar rather than
+        # process-global os.environ. Carry that scope into the bare discovery
+        # thread too: HERMES_HOME alone selects the right config.yaml, but
+        # `${MCP_API_KEY}` interpolation would otherwise see no profile secret
+        # and send the literal placeholder as the authorization header.
+        try:
+            from agent.secret_scope import current_secret_scope
+
+            secret_scope = current_secret_scope()
+            if secret_scope is not None:
+                secret_scope = dict(secret_scope)
+        except Exception:
+            secret_scope = None
 
         def _discover() -> None:
             token = None
+            secret_token = None
             try:
                 from hermes_constants import set_hermes_home_override
 
                 token = set_hermes_home_override(home_override)
             except Exception:
                 token = None
+            if secret_scope is not None:
+                try:
+                    from agent.secret_scope import set_secret_scope
+
+                    secret_token = set_secret_scope(secret_scope)
+                except Exception:
+                    secret_token = None
             try:
                 _discover_mcp_tools_without_interactive_oauth()
                 try:
@@ -104,6 +125,13 @@ def start_background_mcp_discovery(*, logger, thread_name: str) -> None:
                         from hermes_constants import reset_hermes_home_override
 
                         reset_hermes_home_override(token)
+                    except Exception:
+                        pass
+                if secret_token is not None:
+                    try:
+                        from agent.secret_scope import reset_secret_scope
+
+                        reset_secret_scope(secret_token)
                     except Exception:
                         pass
                 with _mcp_discovery_lock:

--- a/tests/hermes_cli/test_mcp_startup.py
+++ b/tests/hermes_cli/test_mcp_startup.py
@@ -146,6 +146,46 @@ def test_background_mcp_discovery_suppresses_interactive_oauth(monkeypatch):
     assert state["active"] is False
 
 
+def test_background_mcp_discovery_propagates_profile_secret_scope(monkeypatch):
+    """A dashboard-profile discovery thread must retain that profile's secrets."""
+    from agent.secret_scope import current_secret_scope, reset_secret_scope, set_secret_scope
+
+    seen = []
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_cli.config",
+        types.SimpleNamespace(
+            read_raw_config=lambda: {"mcp_servers": {"demo": {"url": "https://mcp.example.test/mcp"}}},
+        ),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "tools.mcp_oauth",
+        types.SimpleNamespace(suppress_interactive_oauth=lambda: nullcontext()),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "tools.mcp_tool",
+        types.SimpleNamespace(
+            discover_mcp_tools=lambda: seen.append(dict(current_secret_scope() or {})),
+        ),
+    )
+
+    expected_scope = {"MCP_DEMO_TOKEN": "profile-only-secret"}
+    token = set_secret_scope(expected_scope)
+    try:
+        mcp_startup.start_background_mcp_discovery(
+            logger=types.SimpleNamespace(debug=lambda *_a, **_k: None),
+            thread_name="test-mcp-discovery",
+        )
+        assert mcp_startup._mcp_discovery_thread is not None
+        mcp_startup._mcp_discovery_thread.join(timeout=1.0)
+    finally:
+        reset_secret_scope(token)
+
+    assert seen == [expected_scope]
+
+
 def test_portable_only_mcp_configuration_opens_startup_gate(monkeypatch):
     monkeypatch.setitem(
         sys.modules,


### PR DESCRIPTION
## Summary

The Desktop/dashboard backend starts MCP discovery on a bare background thread. In a profile-routed session, that thread already receives the selected profile's `HERMES_HOME` override, but it did not receive the accompanying profile secret scope.

As a result, a profile's MCP configuration could load while `${VAR}` credentials used by its MCP server configuration resolved outside the selected profile scope. The same MCP worked through the profile CLI, but failed through a Desktop/dashboard session.

This change snapshots the active secret scope before spawning discovery, installs it only for that thread, and resets it when discovery finishes. It does not log, persist, or export secret values.

## Scope

Related to #67605. This is a narrow follow-up for the background MCP-discovery thread; it does not attempt to solve the remaining multi-profile registry or config-expansion work tracked there.

## Tests

- `uv run --extra dev pytest tests/hermes_cli/test_mcp_startup.py tests/test_tui_gateway_server.py::test_profile_scoped_mcp_discovery_uses_target_home tests/test_tui_gateway_server.py::test_profile_scoped_agent_build_installs_secret_scope -q -o 'addopts='`
- `uv run --extra dev ruff check hermes_cli/mcp_startup.py tests/hermes_cli/test_mcp_startup.py`

The new regression test uses a vendor-neutral fake `MCP_DEMO_TOKEN`; no real credential, host, profile, or user-specific configuration is included.
