### PR TITLE
fix(installer): transactional Windows venv recreation with dependency-stage rollback (#83149)

### DIFF
--- a/hermes_cli/_scan_venv_blockers.py
+++ b/hermes_cli/_scan_venv_blockers.py
@@ -28,14 +28,28 @@ _SENSITIVE_LONG_FLAGS: list[str] = [
 ]
 
 
-def _probe_fail_json() -> str:
-    """Return the standard probe-failure JSON document."""
-    return json.dumps({"ok": False, "blocked": False, "processes": []})
+def _probe_fail_json(diagnostic: str = "probe failed") -> str:
+    """Return the standard probe-failure JSON document.
+
+    ``ok: false`` plus ``probe_failed: true`` means the detector itself could
+    not run — this is *not* a clear scan. Callers must treat
+    ``ok is not True`` / non-zero exit as probe failure, never as
+    ``blocked: false`` "clear" (#83149).
+    """
+    return json.dumps(
+        {
+            "ok": False,
+            "probe_failed": True,
+            "blocked": False,
+            "processes": [],
+            "error": diagnostic,
+        }
+    )
 
 
 def _emit_probe_fail(diagnostic: str) -> NoReturn:
     """Print one JSON to stdout, diagnostic to stderr, exit non-zero."""
-    print(_probe_fail_json())
+    print(_probe_fail_json(diagnostic))
     print(diagnostic, file=sys.stderr)
     sys.exit(1)
 

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -2268,22 +2268,26 @@ function Install-Venv {
     # exits. Populated only with tasks that were ENABLED before we touched
     # them, so a task the user deliberately disabled is never re-armed.
     $gatewayTasksDisabled = @()
+    $venvHadExistingVenv = $false
+    $venvBackupName = $null
+    $venvParked = $false
     try {
-    if (Test-Path "venv") {
+    if (Test-Path -LiteralPath "venv") {
+        $venvHadExistingVenv = $true
         Write-Info "Virtual environment already exists, recreating..."
         # On Windows, native Python extensions (e.g. _bcrypt.pyd, tornado's
         # speedups.pyd) are loaded as DLLs by any running hermes process.
         # Windows denies deletion of loaded DLLs, so every process running out
-        # of this venv must be stopped before removing it -- otherwise
-        # Remove-Item fails with "Access to the path '...' is denied" and the
-        # whole install/update aborts at this stage.
+        # of this venv must be stopped before retiring it. This keeps cleanup
+        # from accumulating locked stale trees and avoids carrying a live
+        # gateway into the replacement venv.
         if ($env:OS -eq "Windows_NT") {
             $myPid = $PID
             Write-Info "Stopping any running hermes processes before recreating venv..."
             # Disarm the respawner FIRST: the gateway autostart Scheduled Task
             # relaunches a killed gateway within seconds, and losing that race
             # re-locks the venv's .pyd files between our kill sweep and
-            # Remove-Item (the July 2026 _brotlicffi.pyd incident). schtasks
+            # venv parking/cleanup (the July 2026 _brotlicffi.pyd incident). schtasks
             # /End stops a running task instance; /Change /DISABLE stops it
             # from re-firing mid-install. (The Startup-folder .vbs fallback is
             # NOT touched: it only fires at logon, so it cannot respawn a
@@ -2329,7 +2333,7 @@ function Install-Venv {
             #
             # The sweep is a bounded LOOP, not single-shot: supervised processes
             # (the Desktop app's backend, a watchdog-managed gateway) respawn in
-            # the window between one kill pass and the delete. Each pass re-
+            # the window between one kill pass and venv parking. Each pass re-
             # enumerates; three consecutive clean passes (or the attempt cap)
             # ends the loop.
             $venvPrefix = [System.IO.Path]::GetFullPath((Join-Path $InstallDir "venv")).TrimEnd('\') + '\'
@@ -2353,42 +2357,18 @@ function Install-Venv {
                 Start-Sleep -Milliseconds 400
             }
         }
-        # Rename-then-delete: on Windows a directory RENAME succeeds even while
-        # files inside it are mapped as DLLs (only in-place delete/replace of
-        # the mapped file is denied, and only same-volume renames are atomic
-        # moves). Moving the old venv aside means `uv venv` can create a fresh
-        # one immediately even if some straggler still holds a .pyd from the
-        # old tree; the renamed dir is deleted best-effort (now, and by the
-        # cleanup pass below on the NEXT install if a handle outlives this one).
-        $staleName = "venv.stale.{0}" -f (Get-Date -Format "yyyyMMddHHmmss")
-        $renamed = $false
+        # Move the old venv aside before creating its replacement. A directory
+        # rename is atomic on the same volume and does not require deleting
+        # files mapped as DLLs. Never fall back to deleting the live venv:
+        # Windows can remove unlocked files first, then fail on one locked
+        # file, leaving no usable interpreter and no rollback source.
+        $venvBackupName = "venv.stale.{0}-{1}" -f (Get-Date -Format "yyyyMMddHHmmss"), ([Guid]::NewGuid().ToString("N"))
         try {
-            Rename-Item -Path "venv" -NewName $staleName -ErrorAction Stop
-            $renamed = $true
+            Rename-Item -LiteralPath "venv" -NewName $venvBackupName -ErrorAction Stop
+            $venvParked = $true
         } catch {
-            Write-Warn "Could not rename venv aside ($($_.Exception.Message)); falling back to in-place delete"
+            throw "Could not move existing venv aside without deleting it. Close running Hermes processes and retry. $($_.Exception.Message)"
         }
-        if ($renamed) {
-            Remove-Item -Recurse -Force $staleName -ErrorAction SilentlyContinue
-            if (Test-Path $staleName) {
-                Write-Warn "Old venv parked at $staleName (a process still holds files in it); it will be cleaned up on the next install"
-            }
-        } else {
-            Remove-Item -Recurse -Force "venv" -ErrorAction SilentlyContinue
-            # A killed process can take a moment to release its file handles, so a
-            # first Remove-Item may still hit a locked .pyd. Retry once after a short
-            # pause before giving up and letting the stage fail loudly.
-            if (Test-Path "venv") {
-                Start-Sleep -Seconds 2
-                Remove-Item -Recurse -Force "venv"
-            }
-        }
-    }
-
-    # Clean up parked venvs from previous installs whose handles have since
-    # been released. Best-effort -- a still-held tree just stays for next time.
-    Get-ChildItem -Directory -Filter "venv.stale.*" -ErrorAction SilentlyContinue | ForEach-Object {
-        Remove-Item -Recurse -Force $_.FullName -ErrorAction SilentlyContinue
     }
     
     # uv creates the venv and pins the Python version in one step.  uv emits
@@ -2405,6 +2385,32 @@ function Install-Venv {
         throw "Failed to create virtual environment (uv venv exited with $venvExitCode)"
     }
 
+    # uv can return success without leaving the interpreter expected by the
+    # installer (for example after an interrupted filesystem operation). Treat
+    # that as a failed transaction so the previous venv can be restored.
+    $venvPythonExe = Join-Path $InstallDir "venv\Scripts\python.exe"
+    if (-not (Test-Path -LiteralPath $venvPythonExe -PathType Leaf)) {
+        throw "uv reported success but venv interpreter is missing at $venvPythonExe"
+    }
+
+    # The replacement is usable. The old tree is no longer needed for rollback;
+    # deletion is safe here because it cannot gut the live venv. A locked old
+    # tree remains parked and is retried by the cleanup pass below.
+    if ($venvParked) {
+        Remove-Item -LiteralPath $venvBackupName -Recurse -Force -ErrorAction SilentlyContinue
+        if (Test-Path -LiteralPath $venvBackupName) {
+            Write-Warn "Old venv parked at $venvBackupName (a process still holds files in it); it will be cleaned up on the next install"
+        } else {
+            $venvParked = $false
+        }
+    }
+
+    # Clean up parked venvs from previous installs whose handles have since
+    # been released. Best-effort -- a still-held tree just stays for next time.
+    Get-ChildItem -Directory -Filter "venv.stale.*" -ErrorAction SilentlyContinue | ForEach-Object {
+        Remove-Item -Recurse -Force $_.FullName -ErrorAction SilentlyContinue
+    }
+
     # Neutralize any inherited UV_PYTHON (e.g. $env:UV_PYTHON = "3.14" left in
     # the user's shell). uv honours UV_PYTHON over an existing venv for the
     # later `uv sync` / `uv pip install` tiers, so without this it would
@@ -2412,10 +2418,43 @@ function Install-Venv {
     # -- building Rust transitives that have no wheel for that version from
     # source via maturin, which fails. Pinning UV_PYTHON to the interpreter we
     # just created forces every subsequent uv command onto it.
-    $venvPythonExe = Join-Path $InstallDir "venv\Scripts\python.exe"
-    if (Test-Path $venvPythonExe) {
-        $env:UV_PYTHON = $venvPythonExe
-    }
+    $env:UV_PYTHON = $venvPythonExe
+    } catch {
+        $originalError = $_
+        $rollbackError = $null
+
+        if ($venvParked -and $venvBackupName -and (Test-Path -LiteralPath $venvBackupName)) {
+            try {
+                if (Test-Path -LiteralPath "venv") {
+                    $failedVenvName = "venv.failed.{0}-{1}" -f (Get-Date -Format "yyyyMMddHHmmss"), ([Guid]::NewGuid().ToString("N"))
+                    Rename-Item -LiteralPath "venv" -NewName $failedVenvName -ErrorAction Stop
+                    Write-Warn "Failed replacement parked at $failedVenvName"
+                }
+                Rename-Item -LiteralPath $venvBackupName -NewName "venv" -ErrorAction Stop
+                Write-Warn "Restored previous virtual environment after failed recreate"
+            } catch {
+                $rollbackError = $_.Exception.Message
+            }
+
+            if ($rollbackError) {
+                throw "Virtual environment recreate failed: $($originalError.Exception.Message). Rollback failed: $rollbackError. Previous venv remains at $venvBackupName."
+            }
+        } elseif (-not $venvHadExistingVenv -and (Test-Path -LiteralPath "venv")) {
+            # Preserve a partial first install too. This branch must not touch a
+            # pre-existing venv whose move-aside failed above.
+            try {
+                $failedVenvName = "venv.failed.{0}-{1}" -f (Get-Date -Format "yyyyMMddHHmmss"), ([Guid]::NewGuid().ToString("N"))
+                Rename-Item -LiteralPath "venv" -NewName $failedVenvName -ErrorAction Stop
+                Write-Warn "Partial virtual environment parked at $failedVenvName"
+            } catch {
+                $rollbackError = $_.Exception.Message
+            }
+            if ($rollbackError) {
+                throw "Virtual environment creation failed: $($originalError.Exception.Message). Could not park partial venv: $rollbackError"
+            }
+        }
+
+        throw $originalError
     } finally {
         Pop-Location
         # Re-arm the gateway autostart tasks disabled during the venv teardown
@@ -2586,7 +2625,7 @@ except Exception:
     if (-not $NoVenv) {
         $venvPython = "$InstallDir\venv\Scripts\python.exe"
         if (-not (Test-Path $venvPython)) {
-            throw "Install reported success but $venvPython does not exist. The dependency sync likely landed in a sibling .venv\ directory. Re-run the installer; if it persists, manually: cd '$InstallDir'; Remove-Item -Recurse -Force venv,.venv; uv venv venv --python $PythonVersion; `$env:UV_PROJECT_ENVIRONMENT='$InstallDir\venv'; uv sync --extra all --locked"
+            throw "Install reported success but $venvPython does not exist. The dependency sync likely landed in a sibling .venv\ directory. Re-run the installer; if it persists, close Hermes processes and preserve existing venv directories before retrying. Do not delete venv in place."
         }
         # Relax EAP=Stop while running the import probe.  Python writes
         # deprecation warnings and import-system info to stderr; under
@@ -2602,7 +2641,7 @@ except Exception:
         if ($importExitCode -ne 0) {
             $sibling = "$InstallDir\.venv"
             $hint = if (Test-Path $sibling) {
-                "Detected sibling .venv\ at $sibling -- uv synced there instead of venv\. Recover with: cd '$InstallDir'; Remove-Item -Recurse -Force venv; Move-Item .venv venv"
+                "Detected sibling .venv\ at $sibling -- uv synced there instead of venv\. Close Hermes processes, preserve the existing venv, and rerun the installer so the transactional recovery path can move directories safely."
             } else {
                 "Recover with: cd '$InstallDir'; `$env:UV_PROJECT_ENVIRONMENT='$InstallDir\venv'; uv sync --extra all --locked"
             }

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -2401,23 +2401,25 @@ function Install-Venv {
         throw "uv reported success but venv interpreter is missing at $venvPythonExe"
     }
 
-    # The replacement is usable. The old tree is no longer needed for rollback;
-    # deletion is safe here because it cannot gut the live venv. A locked old
-    # tree remains parked and is retried by the cleanup pass below.
+    # The replacement has a working interpreter, but the transaction is only
+    # committed after Install-Dependencies' baseline-import gate passes -- the
+    # bootstrap runs the stages as separate processes, and every dependency
+    # tier (or the import validation) can still fail after this stage
+    # succeeds. Record the parked backup so the dependency stage can restore
+    # it on failure and commit its cleanup only after validation (#83149).
     if ($venvParked) {
-        Remove-Item -LiteralPath $venvBackupName -Recurse -Force -ErrorAction SilentlyContinue
-        if (Test-Path -LiteralPath $venvBackupName) {
-            Write-Warn "Old venv parked at $venvBackupName (a process still holds files in it); it will be cleaned up on the next install"
-        } else {
-            $venvParked = $false
-        }
+        Set-Content -LiteralPath (Join-Path $InstallDir "venv.pending-backup") -Value $venvBackupName -Encoding ascii
+        Write-Info "Previous venv parked at $venvBackupName until the dependency install is verified"
     }
 
     # Clean up parked venvs from previous installs whose handles have since
     # been released. Best-effort -- a still-held tree just stays for next time.
-    Get-ChildItem -Directory -Filter "venv.stale.*" -ErrorAction SilentlyContinue | ForEach-Object {
-        Remove-Item -Recurse -Force $_.FullName -ErrorAction SilentlyContinue
-    }
+    # The backup parked THIS run is excluded: it is the rollback source until
+    # Install-Dependencies commits the transaction.
+    Get-ChildItem -Directory -Filter "venv.stale.*" -ErrorAction SilentlyContinue |
+        Where-Object { $_.Name -ne $venvBackupName } | ForEach-Object {
+            Remove-Item -Recurse -Force $_.FullName -ErrorAction SilentlyContinue
+        }
 
     # Neutralize any inherited UV_PYTHON (e.g. $env:UV_PYTHON = "3.14" left in
     # the user's shell). uv honours UV_PYTHON over an existing venv for the
@@ -2483,6 +2485,55 @@ function Install-Venv {
     Write-Success "Virtual environment ready (Python $PythonVersion)"
 }
 
+function Get-PendingVenvBackup {
+    # Rollback source recorded by Install-Venv (#83149). Returns the parked
+    # directory name, or $null when there is nothing to roll back to. A marker
+    # pointing at a directory that no longer exists is stale -- drop it.
+    $markerPath = Join-Path $InstallDir "venv.pending-backup"
+    if (-not (Test-Path -LiteralPath $markerPath -PathType Leaf)) { return $null }
+    $name = (Get-Content -LiteralPath $markerPath -ErrorAction SilentlyContinue | Select-Object -First 1)
+    if ($name) { $name = $name.Trim() }
+    if (-not $name -or -not (Test-Path -LiteralPath (Join-Path $InstallDir $name))) {
+        Remove-Item -LiteralPath $markerPath -Force -ErrorAction SilentlyContinue
+        return $null
+    }
+    return $name
+}
+
+function Complete-VenvTransaction {
+    # Commit: dependency install + baseline imports passed, so the previous
+    # venv is no longer needed as a rollback source. Best-effort delete; a
+    # tree still held open just stays parked for the next install's sweep.
+    $backupName = Get-PendingVenvBackup
+    if (-not $backupName) { return }
+    $backupPath = Join-Path $InstallDir $backupName
+    Remove-Item -LiteralPath $backupPath -Recurse -Force -ErrorAction SilentlyContinue
+    if (Test-Path -LiteralPath $backupPath) {
+        Write-Warn "Old venv parked at $backupName (a process still holds files in it); it will be cleaned up on the next install"
+    }
+    Remove-Item -LiteralPath (Join-Path $InstallDir "venv.pending-backup") -Force -ErrorAction SilentlyContinue
+}
+
+function Restore-VenvBackup {
+    # Rollback: the dependency stage failed after Install-Venv replaced the
+    # venv. Park the unusable replacement and restore the previous working
+    # venv so Hermes (and the venv-blocker probe) stay usable (#83149).
+    $backupName = Get-PendingVenvBackup
+    if (-not $backupName) { return }
+    try {
+        if (Test-Path -LiteralPath (Join-Path $InstallDir "venv")) {
+            $failedVenvName = "venv.failed.{0}-{1}" -f (Get-Date -Format "yyyyMMddHHmmss"), ([Guid]::NewGuid().ToString("N"))
+            Rename-Item -LiteralPath (Join-Path $InstallDir "venv") -NewName $failedVenvName -ErrorAction Stop
+            Write-Warn "Failed replacement parked at $failedVenvName"
+        }
+        Rename-Item -LiteralPath (Join-Path $InstallDir $backupName) -NewName "venv" -ErrorAction Stop
+        Remove-Item -LiteralPath (Join-Path $InstallDir "venv.pending-backup") -Force -ErrorAction SilentlyContinue
+        Write-Warn "Restored previous virtual environment after failed dependency install"
+    } catch {
+        Write-Warn "Could not restore previous venv (still parked at $backupName): $($_.Exception.Message)"
+    }
+}
+
 function Install-Dependencies {
     Write-Info "Installing dependencies..."
     
@@ -2517,6 +2568,12 @@ function Install-Dependencies {
     # without any hash verification -- they exist to keep installs working
     # when the lockfile is stale, missing, or out-of-sync with the
     # current extras spec, NOT because they're equivalent in posture.
+    #
+    # Everything through the baseline-import gate runs inside the venv
+    # transaction opened by Install-Venv (#83149): on any failure the parked
+    # previous venv is restored before the error propagates, and the parked
+    # tree is deleted only after the imports prove the replacement usable.
+    try {
     if (Test-Path "uv.lock") {
         Write-Info "Trying tier: hash-verified (uv.lock) ..."
         # Critical flag choice: `--extra all`, NOT `--all-extras`.
@@ -2656,6 +2713,19 @@ except Exception:
             throw "Baseline imports failed in $InstallDir\venv (dotenv/openai/rich/prompt_toolkit). The install completed but dependencies are not in the venv. $hint"
         }
         Write-Success "Baseline imports verified in venv"
+    }
+
+    # Commit the venv transaction: the dependency install completed and the
+    # baseline imports passed, so the previous venv is no longer needed as a
+    # rollback source (#83149).
+    Complete-VenvTransaction
+    } catch {
+        # Dependency install or import validation failed: restore the previous
+        # working venv (parked by Install-Venv) before surfacing the error, so
+        # a failed update leaves Hermes and its blocker probe usable.
+        Restore-VenvBackup
+        Pop-Location
+        throw
     }
 
     if (-not $NoVenv) {

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -2359,15 +2359,23 @@ function Install-Venv {
         }
         # Move the old venv aside before creating its replacement. A directory
         # rename is atomic on the same volume and does not require deleting
-        # files mapped as DLLs. Never fall back to deleting the live venv:
-        # Windows can remove unlocked files first, then fail on one locked
-        # file, leaving no usable interpreter and no rollback source.
+        # files mapped as DLLs. NEVER fall back to deleting the live venv
+        # (#83149): Remove-Item -Recurse can delete most of site-packages and
+        # then fail on one locked .pyd, leaving a gutted venv with no usable
+        # interpreter and no rollback source. Abort with the previous install
+        # intact so the user can close holders and retry.
         $venvBackupName = "venv.stale.{0}-{1}" -f (Get-Date -Format "yyyyMMddHHmmss"), ([Guid]::NewGuid().ToString("N"))
         try {
             Rename-Item -LiteralPath "venv" -NewName $venvBackupName -ErrorAction Stop
             $venvParked = $true
         } catch {
-            throw "Could not move existing venv aside without deleting it. Close running Hermes processes and retry. $($_.Exception.Message)"
+            $renameErr = $_.Exception.Message
+            throw (
+                "Could not move the existing venv aside ($renameErr). " +
+                "A process still has the install directory open (often a non-Hermes " +
+                "python.exe that resolved into this venv via PATH). Close those " +
+                "processes and retry - the previous install was left intact."
+            )
         }
     }
     

--- a/tests/hermes_cli/test_scan_venv_blockers.py
+++ b/tests/hermes_cli/test_scan_venv_blockers.py
@@ -18,6 +18,7 @@ import pytest
 import agent.redact as redact_module
 from hermes_cli._scan_venv_blockers import (
     _is_pausable_gateway,
+    _probe_fail_json,
     _redact_sensitive_cmdline,
     main,
 )
@@ -162,6 +163,43 @@ def _run_main_with_detector(monkeypatch, capsys, matches):
         main()
     out = capsys.readouterr().out
     return excinfo.value.code, json.loads(out)
+
+
+def test_probe_fail_json_is_unambiguous_failure() -> None:
+    """A failed probe must not look like a clear scan (#83149).
+
+    Humans and naive callers used to read ``blocked: false`` as "no holders"
+    when psutil was missing after a gutted venv. The document must mark
+    ``probe_failed`` and keep ``ok`` false.
+    """
+    data = json.loads(_probe_fail_json("psutil is not available: No module named 'psutil'"))
+    assert data["ok"] is False
+    assert data["probe_failed"] is True
+    assert data["blocked"] is False
+    assert data["processes"] == []
+    assert "psutil" in data["error"]
+
+
+def test_main_psutil_missing_is_probe_failure_not_clear(monkeypatch, capsys):
+    """Missing psutil exits non-zero with probe_failed JSON — never a clear scan."""
+    real_import = builtins.__import__
+
+    def _no_psutil(name, *args, **kwargs):
+        if name == "psutil" or name.startswith("psutil."):
+            raise ImportError("No module named 'psutil'")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", _no_psutil)
+    monkeypatch.delitem(sys.modules, "psutil", raising=False)
+
+    with pytest.raises(SystemExit) as excinfo:
+        main()
+    captured = capsys.readouterr()
+    assert excinfo.value.code == 1
+    data = json.loads(captured.out)
+    assert data["ok"] is False
+    assert data["probe_failed"] is True
+    assert "psutil" in captured.err.lower()
 
 
 def test_main_exempts_gateway_chain_but_keeps_other_holders(monkeypatch, capsys):

--- a/tests/test_install_ps1_venv_recreate_safety.py
+++ b/tests/test_install_ps1_venv_recreate_safety.py
@@ -1,0 +1,75 @@
+"""Regression tests for transactional Windows venv recreation (#83149).
+
+The installer must never delete the live venv in place. Windows can remove
+unlocked files before it reaches a locked interpreter or native extension,
+leaving a half-installed venv that the next health/blocker probe cannot use.
+"""
+
+from pathlib import Path
+
+
+INSTALL_PS1 = Path(__file__).resolve().parents[1] / "scripts" / "install.ps1"
+
+
+def _function_body(source: str, function_name: str) -> str:
+    start = source.index(f"function {function_name}")
+    opening_brace = source.index("{", start)
+    depth = 0
+    for index in range(opening_brace, len(source)):
+        if source[index] == "{":
+            depth += 1
+        elif source[index] == "}":
+            depth -= 1
+            if depth == 0:
+                return source[opening_brace : index + 1]
+    raise AssertionError(f"unterminated function: {function_name}")
+
+
+def _install_venv_body() -> str:
+    return _function_body(INSTALL_PS1.read_text(encoding="ascii"), "Install-Venv")
+
+
+def test_rename_failure_cannot_fall_back_to_destructive_delete() -> None:
+    body = _install_venv_body()
+
+    assert "falling back to in-place delete" not in body.lower()
+    assert 'Remove-Item -Recurse -Force "venv"' not in body
+
+
+def test_manual_recovery_hints_do_not_delete_live_venv() -> None:
+    source = INSTALL_PS1.read_text(encoding="ascii")
+
+    assert "Remove-Item -Recurse -Force venv" not in source
+    assert "Do not delete venv in place" in source
+
+
+def test_previous_venv_survives_until_replacement_is_ready() -> None:
+    body = _install_venv_body()
+
+    create = body.index("& $UvCmd venv venv")
+    stale_cleanup = body.index('Get-ChildItem -Directory -Filter "venv.stale.*"')
+    assert create < stale_cleanup, (
+        "stale backups must not be cleaned before uv can succeed or rollback"
+    )
+
+
+def test_recreate_restores_parked_venv_after_failure() -> None:
+    body = _install_venv_body()
+
+    failure = body.index("Failed to create virtual environment")
+    restore = body.index(
+        'Rename-Item -LiteralPath $venvBackupName -NewName "venv"'
+    )
+    assert failure < restore
+    assert "rollback failed" in body.lower()
+
+
+def test_recreate_rejects_success_without_venv_interpreter() -> None:
+    body = _install_venv_body()
+
+    missing_python = body.index("$venvPythonExe")
+    success = body.index("Virtual environment ready")
+    assert "Test-Path -LiteralPath $venvPythonExe -PathType Leaf" in body[
+        missing_python:success
+    ]
+    assert "throw" in body[missing_python:success]

--- a/tests/test_install_ps1_venv_rename_abort.py
+++ b/tests/test_install_ps1_venv_rename_abort.py
@@ -1,0 +1,64 @@
+"""Regression: Windows installer must not gut the venv on rename failure (#83149).
+
+When recreating an existing venv, ``Install-Venv`` renames the directory aside
+first. An older fallback deleted the tree in place when rename was denied; a
+partial ``Remove-Item`` could wipe most of ``site-packages`` and then fail on
+one locked ``.pyd``, leaving Hermes unusable with no rollback.
+
+These tests lock the contract at the source level (the script only runs on
+Windows, so Linux CI cannot execute the PowerShell path).
+"""
+
+from pathlib import Path
+
+import pytest
+
+_INSTALL_PS1 = Path(__file__).resolve().parents[1] / "scripts" / "install.ps1"
+
+
+@pytest.fixture(scope="module")
+def source() -> str:
+    return _INSTALL_PS1.read_text(encoding="utf-8")
+
+
+def _function_body(source: str, name: str) -> str:
+    """Return the text of a PowerShell ``function <name> { ... }`` block."""
+    start = source.index(f"function {name}")
+    brace = source.index("{", start)
+    depth = 0
+    for i in range(brace, len(source)):
+        if source[i] == "{":
+            depth += 1
+        elif source[i] == "}":
+            depth -= 1
+            if depth == 0:
+                return source[brace : i + 1]
+    raise AssertionError(f"unterminated function body for {name}")
+
+
+def test_install_venv_aborts_when_rename_aside_fails(source: str):
+    """Rename failure must throw with the previous install left intact."""
+    body = _function_body(source, "Install-Venv")
+    assert (
+        "Rename-Item -LiteralPath \"venv\"" in body
+        or "Rename-Item -LiteralPath 'venv'" in body
+    )
+    assert "falling back to in-place delete" not in body
+    throw_at = body.find("Could not move the existing venv aside")
+    assert throw_at != -1, "rename failure must abort with an actionable error"
+    assert "throw" in body[max(0, throw_at - 80) : throw_at + 40]
+
+
+def test_install_venv_never_removes_live_venv_in_place_on_rename_fail(source: str):
+    """After a failed rename, Install-Venv must not Remove-Item the live venv.
+
+    Parked ``venv.stale.*`` trees may still be deleted best-effort; the live
+    ``venv`` directory must only disappear via Rename-Item.
+    """
+    body = _function_body(source, "Install-Venv")
+    # The only Remove-Item targeting the active tree used to be the fallback:
+    #   Remove-Item -Recurse -Force "venv"
+    # That path must be gone. Stale-parking cleanup uses $staleName / filter.
+    assert 'Remove-Item -Recurse -Force "venv"' not in body
+    assert "Remove-Item -Recurse -Force 'venv'" not in body
+    assert "venv.stale." in body

--- a/tests/test_install_ps1_venv_transaction_boundary.py
+++ b/tests/test_install_ps1_venv_transaction_boundary.py
@@ -1,0 +1,106 @@
+"""Transaction-boundary regression for Windows venv recreation (#83149).
+
+Review finding on PR #83194 (egilewski): the rollback source (the parked
+previous venv) was deleted as soon as ``Install-Venv`` saw a working
+interpreter in the replacement — but ``Install-Dependencies`` is a separate,
+later stage (a separate *process* under the stage-per-process bootstrap) and
+every dependency tier or the baseline-import gate can still fail after that
+point. Deleting the backup early re-creates exactly the availability failure
+the transactional recreate exists to prevent.
+
+The contract locked here:
+
+* ``Install-Venv`` records the parked backup in ``venv.pending-backup``
+  instead of deleting it, and its stale-tree sweep excludes that backup.
+* ``Install-Dependencies`` restores the previous venv on failure
+  (``Restore-VenvBackup``) and commits the cleanup only after the
+  baseline-import gate passes (``Complete-VenvTransaction``).
+
+The script only runs on Windows, so Linux CI locks the contract at the
+source level, same approach as tests/test_install_ps1_venv_recreate_safety.py.
+"""
+
+from pathlib import Path
+
+INSTALL_PS1 = Path(__file__).resolve().parents[1] / "scripts" / "install.ps1"
+
+
+def _function_body(source: str, function_name: str) -> str:
+    start = source.index(f"function {function_name}")
+    opening_brace = source.index("{", start)
+    depth = 0
+    for index in range(opening_brace, len(source)):
+        if source[index] == "{":
+            depth += 1
+        elif source[index] == "}":
+            depth -= 1
+            if depth == 0:
+                return source[opening_brace : index + 1]
+    raise AssertionError(f"unterminated function: {function_name}")
+
+
+def _source() -> str:
+    return INSTALL_PS1.read_text(encoding="ascii")
+
+
+def test_install_venv_does_not_delete_backup_before_dependency_stage() -> None:
+    """The parked previous venv must survive Install-Venv's success path."""
+    body = _function_body(_source(), "Install-Venv")
+
+    # The success path records the rollback source instead of deleting it.
+    assert "venv.pending-backup" in body
+    # The only backup deletion allowed inside Install-Venv is the *rollback*
+    # rename in the catch block; a Remove-Item of the backup must not appear.
+    assert "Remove-Item -LiteralPath $venvBackupName" not in body
+
+
+def test_install_venv_stale_sweep_excludes_current_backup() -> None:
+    """The venv.stale.* sweep must not delete this run's rollback source."""
+    body = _function_body(_source(), "Install-Venv")
+
+    sweep_at = body.index('Get-ChildItem -Directory -Filter "venv.stale.*"')
+    window = body[sweep_at : sweep_at + 400]
+    assert "$_.Name -ne $venvBackupName" in window, (
+        "the stale-tree sweep must exclude the backup parked by this run"
+    )
+
+
+def test_install_dependencies_restores_backup_on_failure() -> None:
+    """A failed dependency tier or import gate must restore the parked venv."""
+    body = _function_body(_source(), "Install-Dependencies")
+
+    assert "Restore-VenvBackup" in body
+    catch_at = body.index("Restore-VenvBackup")
+    assert "throw" in body[catch_at : catch_at + 400], (
+        "rollback must rethrow the original failure after restoring"
+    )
+
+
+def test_install_dependencies_commits_only_after_import_gate() -> None:
+    """Backup cleanup must come after the baseline-import verification."""
+    body = _function_body(_source(), "Install-Dependencies")
+
+    import_gate = body.index("Baseline imports verified in venv")
+    commit = body.index("Complete-VenvTransaction")
+    assert import_gate < commit, (
+        "the venv transaction must commit only after imports prove the "
+        "replacement usable"
+    )
+
+
+def test_restore_helper_parks_failed_replacement_and_restores_previous() -> None:
+    body = _function_body(_source(), "Restore-VenvBackup")
+
+    park = body.index("venv.failed.")
+    restore = body.index('-NewName "venv"')
+    assert park < restore, (
+        "the failed replacement must be parked before the previous venv is "
+        "renamed back into place"
+    )
+
+
+def test_commit_helper_deletes_backup_and_clears_marker() -> None:
+    body = _function_body(_source(), "Complete-VenvTransaction")
+
+    assert "Remove-Item" in body
+    assert "venv.pending-backup" in body

--- a/tests/test_install_unmerged_index.py
+++ b/tests/test_install_unmerged_index.py
@@ -152,9 +152,9 @@ def test_install_sh_clears_unmerged_index_before_stash_source_order() -> None:
     assert idx_unmerged < idx_stash
 
 
-def test_install_ps1_stops_venv_resident_processes_before_removing_venv() -> None:
+def test_install_ps1_stops_venv_resident_processes_before_parking_venv() -> None:
     """The Windows venv-recreate path must stop every process running out of the
-    old venv before deleting it.
+    old venv before moving it aside.
 
     A gateway autostarted by a scheduled task runs as
     ``venv\\Scripts\\pythonw.exe -m hermes_cli.main gateway run`` — image name
@@ -179,8 +179,8 @@ def test_install_ps1_stops_venv_resident_processes_before_removing_venv() -> Non
         "the -like wildcard match must not be used for venv path scoping"
     )
 
-    # The process sweep must run before the venv is removed, or it is a no-op.
-    idx_remove = text.index('Remove-Item -Recurse -Force "venv"', idx_recreate)
-    assert idx_sweep < idx_remove, (
-        "venv-resident processes must be stopped before Remove-Item deletes the venv"
+    # The process sweep must run before the venv is parked, or it is a no-op.
+    idx_park = text.index('Rename-Item -LiteralPath "venv"', idx_recreate)
+    assert idx_sweep < idx_park, (
+        "venv-resident processes must be stopped before Rename-Item parks the venv"
     )

--- a/tests/test_install_unmerged_index.py
+++ b/tests/test_install_unmerged_index.py
@@ -159,9 +159,10 @@ def test_install_ps1_stops_venv_resident_processes_before_parking_venv() -> None
     A gateway autostarted by a scheduled task runs as
     ``venv\\Scripts\\pythonw.exe -m hermes_cli.main gateway run`` — image name
     ``pythonw``, not ``hermes.exe`` — so the ``taskkill /IM hermes.exe`` guard
-    misses it, the loaded ``.pyd`` stays locked, and ``Remove-Item venv`` fails
-    mid-recursion (issues #47036/#47557/#47910). The recreate branch must also
-    sweep by venv path prefix, and that sweep must run before the delete.
+    misses it and the loaded ``.pyd`` stays locked (issues #47036/#47557/#47910).
+    The recreate branch must sweep by venv path prefix before Rename-Item, and
+    must never fall back to an in-place ``Remove-Item`` of the live ``venv``
+    (#83149 — that path can gut site-packages with no rollback).
     """
     text = INSTALL_PS1.read_text()
 
@@ -184,3 +185,7 @@ def test_install_ps1_stops_venv_resident_processes_before_parking_venv() -> None
     assert idx_sweep < idx_park, (
         "venv-resident processes must be stopped before Rename-Item parks the venv"
     )
+    assert 'Remove-Item -Recurse -Force "venv"' not in text[idx_recreate:], (
+        "must not fall back to in-place delete of the live venv (#83149)"
+    )
+    assert "Could not move the existing venv aside" in text[idx_recreate:]

--- a/website/docs/getting-started/updating.md
+++ b/website/docs/getting-started/updating.md
@@ -110,7 +110,7 @@ A second, separate guard refuses to touch the venv while any process is running 
 
 #### Windows venv recreation is transactional
 
-When the Windows installer must recreate an existing `venv`, it first moves the old directory to a unique `venv.stale.*` name, then creates and verifies the replacement. The old tree is deleted only after `venv\Scripts\python.exe` exists in the new tree.
+When the Windows installer must recreate an existing `venv`, it first moves the old directory to a unique `venv.stale.*` name, then creates and verifies the replacement. The old tree is deleted only after the dependency install completes and the baseline imports pass in the new tree — until then it is the rollback source (recorded in `venv.pending-backup`).
 
 If the move cannot be completed, the installer stops and leaves the live `venv` untouched. If `uv` fails or reports success without creating the interpreter, any partial replacement is moved to `venv.failed.*` and the previous venv is restored. This keeps the health and blocker checks usable after a failed install.
 

--- a/website/docs/getting-started/updating.md
+++ b/website/docs/getting-started/updating.md
@@ -108,6 +108,14 @@ Close the listed processes and re-run. If you're sure the concurrent process won
 
 A second, separate guard refuses to touch the venv while any process is running from its Python interpreter (the Desktop app's backend, a gateway, a Python REPL). Those processes keep native extension files (`.pyd`) locked, and a dependency sync that dies partway on an access-denied error strands the install between versions. This guard is **not** bypassed by `--force`; if you're certain the detected holders are false positives, use the explicit `hermes update --force-venv`.
 
+#### Windows venv recreation is transactional
+
+When the Windows installer must recreate an existing `venv`, it first moves the old directory to a unique `venv.stale.*` name, then creates and verifies the replacement. The old tree is deleted only after `venv\Scripts\python.exe` exists in the new tree.
+
+If the move cannot be completed, the installer stops and leaves the live `venv` untouched. If `uv` fails or reports success without creating the interpreter, any partial replacement is moved to `venv.failed.*` and the previous venv is restored. This keeps the health and blocker checks usable after a failed install.
+
+A `venv.stale.*` or `venv.failed.*` directory can remain when another process still owns a file handle. Close Hermes Desktop, gateways, and Python processes using the install, then retry the install/update; parked directories are cleaned up best-effort after a successful recreation.
+
 Expected output looks like:
 
 ```


### PR DESCRIPTION
## What does this PR do?

Consolidates the two competing fixes for **#83149** (Windows installer's failed venv recreate falls back to a destructive in-place delete) into one transactional recreate, preserving both contributors' authorship, and closes the transaction-boundary gap review found on #83194.

**Composition (by commit):**

- **JoaoMarcos44** (PR #83194, earliest, 4 commits): the transactional structure — park the old `venv` under a unique `venv.stale.<ts>-<guid>` name, verify the replacement's interpreter actually exists (uv can exit 0 without one), park a failed replacement as `venv.failed.*`, restore the previous venv on failure, `-LiteralPath` hardening, docs, and source-contract regression tests.
- **HexLab98** (PR #83191, 2 commits): the fail-closed abort — rename failure **throws** with an actionable message instead of falling back to `Remove-Item -Recurse -Force "venv"` (which deletes unlocked files first, then dies on one locked `.pyd`, leaving a gutted venv). Also: `_scan_venv_blockers.py` now emits `probe_failed: true` + the diagnostic in its failure JSON so a broken detector can never read as a *clear* scan, with tests (incl. missing-psutil path).
- **Follow-up (this PR, addressing egilewski's review blocker on #83194):** the rollback source was committed too early — `Install-Venv` deleted the parked backup as soon as the new tree had `python.exe`, but `Install-Dependencies` is a separate later stage (separate *process* under the stage-per-process bootstrap) and can still fail through every tier or the baseline-import gate. Now `Install-Venv` records the backup in `venv.pending-backup` (and excludes it from the stale sweep); `Install-Dependencies` restores the previous venv on failure (`Restore-VenvBackup`) and commits the cleanup only after the baseline imports pass (`Complete-VenvTransaction`). New source-contract tests lock the boundary.

Per standing policy the correct direction is TRANSACTIONAL (rename-aside, install, atomic swap, rollback on failure) and ABORT rather than destructive in-place delete when rename fails — this PR is exactly that composition.

## Related Issues

Fixes #83149. Supersedes #83194 and #83191 (both cherry-picked here with authorship preserved).

## Verification

Verified on Linux (install.ps1 is Windows-only, so runtime execution needs a Windows smoke):

- `scripts/run_tests.sh tests/test_install_ps1_venv_recreate_safety.py tests/test_install_ps1_venv_rename_abort.py tests/test_install_ps1_venv_transaction_boundary.py tests/test_install_unmerged_index.py tests/hermes_cli/test_scan_venv_blockers.py` — **43 passed, 0 failed**.
- PowerShell brace-balance + ASCII-encoding check on `install.ps1` (the recreate-safety test reads it with `encoding="ascii"`).
- `python3 scripts/audit_pr_attribution.py` — all contributor emails mapped.

**Needs Windows smoke** (not executable on this box): a real `install.ps1` run over an existing venv with (a) a locked `.pyd` holder → abort, previous install intact; (b) a dependency-tier failure → previous venv restored, failed replacement parked as `venv.failed.*`.

## Infographic

![transactional-venv](https://files.catbox.moe/imxcyq.png)
