### PR TITLE
fix(install): provision Node 26 so managed npm satisfies engines (#80769)

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -57,7 +57,7 @@ else
     INSTALL_DIR_EXPLICIT=false
 fi
 PYTHON_VERSION="3.11"
-NODE_VERSION="22"
+NODE_VERSION="26"
 
 # FHS-style root install layout (set by resolve_install_layout when applicable):
 #   code at /usr/local/lib/hermes-agent, command at /usr/local/bin/hermes,

--- a/tests/test_engines_satisfiable.py
+++ b/tests/test_engines_satisfiable.py
@@ -131,6 +131,31 @@ class TestEnginesAreSatisfiable:
             "declare, or the install we just performed cannot install deps."
         )
 
+    def test_managed_node_bundles_an_npm_the_engines_accept(self):
+        """The Node major install.sh fetches must ship an npm that clears
+        engines.npm. Node 22 bundles 11.16.0, which is in the excluded
+        11.10–11.16 band — fresh Hermes-managed installs then die at
+        `npm ci` with EBADENGINE (#80769).
+        """
+        npm_range = _root_manifest()["engines"]["npm"]
+        install_sh = (REPO_ROOT / "scripts" / "install.sh").read_text()
+        for line in install_sh.splitlines():
+            if line.startswith("NODE_VERSION="):
+                managed_major = int(line.split("=", 1)[1].strip().strip('"').strip("'"))
+                break
+        else:  # pragma: no cover
+            pytest.fail("install.sh does not define NODE_VERSION")
+        stock_npm = _STOCK_NPM_BY_NODE_MAJOR.get(managed_major)
+        assert stock_npm is not None, (
+            f"install.sh NODE_VERSION={managed_major} is not in the known "
+            f"stock map {_STOCK_NPM_BY_NODE_MAJOR}"
+        )
+        assert _satisfies_range(stock_npm, npm_range), (
+            f"install.sh provisions Node {managed_major}.x (stock npm "
+            f"{stock_npm}), but engines.npm is {npm_range!r}. A fresh "
+            "Hermes-managed install cannot run npm ci."
+        )
+
     def test_desktop_node_floor_is_not_stricter_than_its_toolchain(self):
         """apps/desktop must not demand more Node than its own build tools do.
 


### PR DESCRIPTION
## What does this PR do?

Salvages **Christopher-Schulze**'s PR #85299 with authorship preserved: `scripts/install.sh` still provisioned Hermes-managed **Node 22**, but root `engines.node` is `>=22.22.0` with `engines.npm <11.10.0 || >=11.17.0`, and the script itself already warns "Hermes requires Node >=26". Node 26 ships npm ≥11.17.0, satisfying the floor.

**Premise verified against live data before salvaging** (the Aug 1 engines churn burned us once — per the ship-provisioning-before-pin rule, the runtime must actually ship before/with any pin):

- `nodejs.org/dist/index.json` today: v26.7.0 bundles npm **11.19.0**, v26.5.1 was the first to bundle 11.17.0 — the provisioned `latest-v26.x` tarball satisfies `engines.npm` with margin.
- Node 22.23.2 bundles npm 10.9.8 (also in-range via the `<11.10.0` arm) — so this is a *hardening* against the trap where a user's or a future Node 22.x's npm lands in the fatal 11.10–11.16 band (npm there ignores `.npmrc` `min-release-age-exclude`; `engine-strict=true` makes it fatal), and aligns the managed runtime with the "requires Node >=26" warning `install.sh` already prints.
- **No engines pin changes in this PR** — it only upgrades what the installer provisions. Existing installs are untouched (managed-tree heal/force-re-provision paths from #76464/#76558 handle them); this changes fresh managed installs only, which is the safe ordering.
- `_STOCK_NPM_BY_NODE_MAJOR` in the test maps 26 → 11.17.0, matching the real first-26.x-bundle.

The new test locks the invariant for good: the Node major `install.sh` fetches must ship a stock npm that clears `engines.npm`, so a future engines bump without a matching `NODE_VERSION` bump fails CI instead of bricking fresh installs (#80769's failure shape).

## Related Issues

Fixes #80769. Supersedes #85299 (cherry-picked with authorship preserved).

## Verification (Linux)

- `scripts/run_tests.sh tests/test_engines_satisfiable.py` — **11 passed, 0 failed**.
- `bash -n scripts/install.sh` — syntax OK.
- Live check: `curl https://nodejs.org/dist/latest-v26.x/` resolves node-v26.7.0 tarballs for linux-x64 (the exact URL pattern install.sh uses).
- `python3 scripts/audit_pr_attribution.py` — contributor mapped (GitHub-noreply email, auto-resolved).

## Infographic

![node26](https://files.catbox.moe/q65gxa.png)
