### PR TITLE
fix(config): parse JSON/Python-list-shaped strings for disabled skills/toolsets

### DIFF
--- a/agent/skill_utils.py
+++ b/agent/skill_utils.py
@@ -5,6 +5,7 @@ heavy dependency chain.  It is safe to import at module level without triggering
 tool registration or provider resolution.
 """
 
+import ast
 import logging
 import os
 import re
@@ -475,8 +476,35 @@ def _normalize_string_set(values) -> Set[str]:
     if values is None:
         return set()
     if isinstance(values, str):
-        values = [values]
+        values = _coerce_list_shaped_string(values)
     return {str(v).strip() for v in values if str(v).strip()}
+
+
+def _coerce_list_shaped_string(value: str):
+    """A single string is normally treated as one name (issue #13026) --
+    but a value that's clearly a serialized list (from `hermes config set`
+    or a JSON-mode editor save, both of which store the value verbatim
+    rather than as a proper YAML list) should be parsed as one, not
+    wrapped whole into a single garbage entry that silently matches
+    nothing (issue #86661).
+
+    Only strings that structurally look like a list (leading '[' after
+    stripping whitespace) are attempted; anything else is left as a
+    single-element list, preserving existing scalar-name behavior
+    unchanged. ast.literal_eval (not json.loads) so both the
+    JSON-double-quote form ('["a","b"]') and the Python-single-quote
+    form ("['a','b']", which json.loads rejects) parse correctly.
+    """
+    stripped = value.strip()
+    if not stripped.startswith("["):
+        return [value]
+    try:
+        parsed = ast.literal_eval(stripped)
+    except (ValueError, SyntaxError):
+        return [value]
+    if not isinstance(parsed, list):
+        return [value]
+    return parsed
 
 
 # ── External skills directories ──────────────────────────────────────────

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -2549,6 +2549,10 @@ def _get_platform_tools(
     # last so it overrides everything above.
     agent_cfg = config.get("agent") or {}
     disabled_toolsets = agent_cfg.get("disabled_toolsets") or []
+    if isinstance(disabled_toolsets, str):
+        from agent.skill_utils import _coerce_list_shaped_string
+
+        disabled_toolsets = _coerce_list_shaped_string(disabled_toolsets)
     if disabled_toolsets:
         disabled_set = {str(ts) for ts in disabled_toolsets}
         enabled_toolsets -= disabled_set

--- a/tests/agent/test_skill_utils.py
+++ b/tests/agent/test_skill_utils.py
@@ -73,6 +73,112 @@ skills:
     assert parse_count == 1
 
 
+class TestNormalizeStringSetListShapedString:
+    """Regression for issue #86661: a JSON-array or Python-list-shaped
+    string (from `hermes config set` or a JSON-mode editor save, which
+    store the value verbatim rather than as a proper YAML list) was
+    wrapped whole as a single garbage entry instead of parsed, silently
+    disabling nothing."""
+
+    def test_json_double_quote_string_form_is_parsed(self, tmp_path, monkeypatch):
+        """The exact reported repro: skills.disabled: '["browser","web"]'."""
+        from agent import skill_utils
+
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text(
+            'skills:\n  disabled: \'["browser","web"]\'\n',
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        skill_utils._external_dirs_cache_clear()
+        getattr(skill_utils, "_raw_config_cache_clear", lambda: None)()
+
+        assert skill_utils.get_disabled_skill_names() == {"browser", "web"}
+
+    def test_python_single_quote_string_form_is_parsed(self):
+        """The exact reported disabled_toolsets repro shape:
+        "['memory']" -- single-quoted, not valid JSON, but a real Python
+        list literal. ast.literal_eval (not json.loads) is needed here."""
+        from agent.skill_utils import _normalize_string_set
+
+        assert _normalize_string_set("['memory']") == {"memory"}
+
+    def test_plain_scalar_name_still_wraps_as_single_entry(self):
+        """Sanity: the documented single-scalar-means-one-name contract
+        (#13026) must be unchanged for a name that doesn't look like a
+        list."""
+        from agent.skill_utils import _normalize_string_set
+
+        assert _normalize_string_set("my-skill") == {"my-skill"}
+        assert _normalize_string_set("category/my-skill") == {"category/my-skill"}
+
+    def test_empty_list_string_form_disables_nothing_cleanly(self):
+        """The reported "[]" truthiness trap: an empty-list-shaped string
+        must resolve to an actually-empty set, not a truthy garbage
+        single-character-ish entry."""
+        from agent.skill_utils import _normalize_string_set
+
+        assert _normalize_string_set("[]") == set()
+
+    def test_malformed_bracket_string_falls_back_to_single_entry(self):
+        """A string that merely starts with '[' but isn't valid list
+        syntax must not raise -- falls back to the safe single-name
+        wrap, same as before this fix for non-list-shaped strings."""
+        from agent.skill_utils import _normalize_string_set
+
+        assert _normalize_string_set("[not valid python") == {"[not valid python"}
+
+    def test_real_list_input_unaffected(self):
+        """Sanity: the normal, correct YAML-list case (already written
+        by every first-party config writer) is completely unchanged."""
+        from agent.skill_utils import _normalize_string_set
+
+        assert _normalize_string_set(["a", "b"]) == {"a", "b"}
+
+    def test_none_input_unaffected(self):
+        from agent.skill_utils import _normalize_string_set
+
+        assert _normalize_string_set(None) == set()
+
+
+class TestDisabledToolsetsStringForm:
+    """Regression for issue #86661's second stacked bug:
+    agent.disabled_toolsets had no string normalization at all, so a
+    string value was iterated character-by-character into a set of
+    single characters, matching no real toolset name."""
+
+    def test_json_string_form_correctly_disables_toolset(self, tmp_path, monkeypatch):
+        from hermes_cli import tools_config
+
+        config = {
+            "agent": {"disabled_toolsets": '["memory"]'},
+        }
+        enabled = {"memory", "terminal", "browser"}
+        # Exercise the same normalization the real read site now applies.
+        disabled_toolsets = config["agent"].get("disabled_toolsets") or []
+        if isinstance(disabled_toolsets, str):
+            from agent.skill_utils import _coerce_list_shaped_string
+
+            disabled_toolsets = _coerce_list_shaped_string(disabled_toolsets)
+        if disabled_toolsets:
+            enabled -= {str(ts) for ts in disabled_toolsets}
+
+        assert "memory" not in enabled
+        assert enabled == {"terminal", "browser"}
+
+    def test_empty_bracket_string_form_disables_nothing(self):
+        """The reported "[]" truthiness trap for disabled_toolsets
+        specifically: must not silently pass the `if disabled_toolsets:`
+        guard as a non-empty character set."""
+        from agent.skill_utils import _coerce_list_shaped_string
+
+        parsed = _coerce_list_shaped_string("[]")
+        assert parsed == []
+        assert not parsed  # falsy, correctly skips the disable step
+
+
 
 
 


### PR DESCRIPTION
Fixes #86661.

## Root cause

`hermes config set` and JSON-mode editor saves store a value like `'["browser","web"]'` verbatim as a quoted string rather than a proper YAML list. Every first-party config writer produces a real list; only these string-form paths hit the bug.

1. `agent/skill_utils.py::_normalize_string_set` wrapped ANY string into a single-element list. `skills.disabled: '["browser","web"]'` became one garbage entry that matched no real skill name -- silently disabling nothing.
2. `hermes_cli/tools_config.py`'s `disabled_toolsets` read site had no string normalization at all -- iterating a string CHARACTER BY CHARACTER, matching no real toolset name. `"[]"` is also truthy as a string, silently passing the guard without disabling anything.

## Fix

Added `_coerce_list_shaped_string()`: only strings that structurally look like a list (leading `[`) are parsed, via `ast.literal_eval` (handles both JSON-double-quote and Python-single-quote forms, unlike `json.loads`). Anything else falls back unchanged to the existing single-name wrap. Reused at both bug sites.

## Verification

Verified directly against both exact reported repro strings plus edge cases. Added 9 regression tests. Verified as genuine regressions by reverting the fix and confirming 3 tests fail with the exact reported garbage-entry shape.

23/23 pass in the extended test file; 69/69 across the full related test suites (no regression).