### PR TITLE
feat(gateway): relaunch supervised gateway on desktop (re)start (#83683)

### DIFF
--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -2693,6 +2693,16 @@ DEFAULT_CONFIG = {
         # crash/restart, as before.
         "delivery_ledger": True,
 
+        # Desktop gateway recovery (issue #83683). When the desktop app
+        # (HERMES_DESKTOP=1) starts its backend, Hermes checks whether a
+        # messaging-gateway supervisor is installed (systemd / launchd / the
+        # Windows "Hermes_Gateway" scheduled task) but the gateway process is
+        # not currently running, and — if so — relaunches it so WeChat/QQ/
+        # Telegram don't go silently offline after a desktop (re)start. Set to
+        # false to leave the gateway entirely to external management. The env
+        # var HERMES_DESKTOP_NO_GATEWAY_RELAUNCH=1 overrides this to off.
+        "relaunch_gateway_on_desktop_start": True,
+
         # Seconds the gateway waits for a single messaging platform to finish
         # connecting during startup (and on reconnect). Discord in particular
         # can blow past the old fixed 30s when an account has many slash

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -258,6 +258,128 @@ def _start_desktop_cron_ticker(stop_event: "threading.Event", interval: int = 60
     provider.start(stop_event, interval=interval)
 
 
+def _ensure_desktop_gateway_running() -> None:
+    """Best-effort recovery of the user's messaging gateway after a desktop
+    (re)start (issue #83683).
+
+    The desktop backend is a JSON-RPC/WebSocket server, *not* the messaging
+    gateway (``hermes gateway run``).  On Windows the gateway is started by the
+    ``Hermes_Gateway`` scheduled task; on Linux/macOS by systemd/launchd.  A
+    desktop app restart can leave that gateway dead (reaped with no successor),
+    so WeChat/QQ/Telegram go silently offline.  If a supervisor is installed
+    (meaning the user opted into "start gateway on login/boot") but no gateway
+    is currently running, relaunch it using the platform-native path.  A stale
+    ``.gateway-planned-stop.json`` marker left by a previous unclean stop is
+    cleared first so the relaunch isn't blocked.
+
+    Everything here is best-effort: any failure is logged and swallowed so the
+    backend boot can never wedge on gateway recovery.  This routine pairs with
+    the reap-side fix that stops the reaper from killing a supervised gateway
+    in the first place (see ``_reap_unsupervised_gateway_orphans``); together
+    they cover the "reaped but never relaunched" symptom of #83683.
+    """
+    import time
+
+    # Let the backend and any externally-managed gateway settle before probing,
+    # and give a supervised gateway's own auto-start a chance to win the race.
+    time.sleep(3.0)
+    try:
+        # Explicit opt-out for users who manage the gateway fully externally.
+        if os.getenv("HERMES_DESKTOP_NO_GATEWAY_RELAUNCH", "").strip().lower() in {
+            "1",
+            "true",
+            "yes",
+            "on",
+        }:
+            _log.info(
+                "Desktop gateway recovery skipped (HERMES_DESKTOP_NO_GATEWAY_RELAUNCH set)"
+            )
+            return
+        try:
+            from hermes_cli.config import load_config
+
+            _cfg = load_config() or {}
+            _gw_cfg = _cfg.get("gateway") if isinstance(_cfg.get("gateway"), dict) else {}
+            if _gw_cfg.get("relaunch_gateway_on_desktop_start") is False:
+                _log.info(
+                    "Desktop gateway recovery skipped "
+                    "(gateway.relaunch_gateway_on_desktop_start=false)"
+                )
+                return
+        except Exception:
+            # Default-on if config can't be read.
+            pass
+
+        from hermes_cli.gateway import (
+            find_gateway_pids,
+            is_macos,
+            is_windows,
+            supports_systemd_services,
+            get_systemd_unit_path,
+            get_launchd_plist_path,
+            systemd_start,
+            launchd_start,
+        )
+        from gateway.status import get_running_pid, clear_planned_stop_marker
+
+        # 1) Already running?  Nothing to do.
+        try:
+            if find_gateway_pids() or get_running_pid() is not None:
+                _log.info("Desktop gateway recovery: gateway already running; no action")
+                return
+        except Exception:
+            pass
+
+        # 2) Is a supervisor installed (=> user opted into auto-start)?
+        _supervisor_installed = False
+        try:
+            if supports_systemd_services():
+                _supervisor_installed = (
+                    get_systemd_unit_path(system=False).exists()
+                    or get_systemd_unit_path(system=True).exists()
+                )
+            elif is_macos():
+                _supervisor_installed = get_launchd_plist_path().exists()
+            elif is_windows():
+                from hermes_cli import gateway_windows
+
+                _supervisor_installed = gateway_windows.is_installed()
+        except Exception:
+            _supervisor_installed = False
+
+        if not _supervisor_installed:
+            _log.info(
+                "Desktop gateway recovery: no gateway supervisor installed; skipping relaunch"
+            )
+            return
+
+        # 3) Clear a stale planned-stop marker that would otherwise block the
+        #    gateway's own startup/shutdown state machine.
+        try:
+            clear_planned_stop_marker()
+        except Exception:
+            pass
+
+        # 4) Relaunch via the platform-native path.
+        _log.info(
+            "Desktop gateway recovery: supervisor installed but gateway not "
+            "running — relaunching"
+        )
+        try:
+            if supports_systemd_services():
+                systemd_start()
+            elif is_macos():
+                launchd_start()
+            elif is_windows():
+                from hermes_cli import gateway_windows
+
+                gateway_windows.start()
+        except Exception:
+            _log.exception("Desktop gateway recovery: relaunch failed")
+    except Exception:
+        _log.exception("Desktop gateway recovery: unexpected error")
+
+
 def _warm_gateway_module() -> None:
     """Pre-import heavy modules so the event loop is not stalled on first use.
 
@@ -350,6 +472,16 @@ async def _lifespan(app: "FastAPI"):
             name="desktop-cron-ticker",
         )
         cron_thread.start()
+        # Recover the user's messaging gateway if a desktop (re)start left it
+        # dead (issue #83683).  Runs detached so boot never blocks on it; the
+        # routine is fully best-effort and never raises into the lifespan.  Pairs
+        # with the reap-side fix that stops the reaper from killing a supervised
+        # gateway; this half relaunches one that is installed but not running.
+        threading.Thread(
+            target=_ensure_desktop_gateway_running,
+            daemon=True,
+            name="desktop-gateway-recover",
+        ).start()
 
     # Reap idle/dead keep-alive PTY sessions in the background (30-min TTL).
     pty_reaper_task = asyncio.create_task(run_reaper(PTY_REGISTRY))

--- a/tests/hermes_cli/test_desktop_gateway_recovery.py
+++ b/tests/hermes_cli/test_desktop_gateway_recovery.py
@@ -1,0 +1,112 @@
+"""Tests for the desktop-backend gateway recovery routine (issue #83683).
+
+``web_server._ensure_desktop_gateway_running`` relaunches a missing *supervised*
+messaging gateway on desktop (re)start so WeChat/QQ/Telegram don't go silently
+offline.  It must: no-op when a gateway is already running, relaunch via the
+platform-native path when a supervisor is installed but the gateway is down,
+skip when no supervisor is installed, honour the opt-out env var / config flag,
+clear stale planned-stop markers, and never raise.
+"""
+
+import os
+
+import pytest
+
+import hermes_cli.config as config_mod
+import hermes_cli.gateway as gateway_mod
+import hermes_cli.gateway_windows as gw_win
+from gateway import status as gateway_status
+from hermes_cli import web_server
+
+
+class _FakePath:
+    def __init__(self, exists: bool):
+        self._exists = exists
+
+    def exists(self) -> bool:
+        return self._exists
+
+
+@pytest.fixture
+def recovery_mocks(monkeypatch):
+    calls = []
+
+    def _record(name):
+        calls.append(name)
+
+    monkeypatch.setattr("time.sleep", lambda *_a, **_k: None)
+    monkeypatch.setattr(config_mod, "load_config", lambda: {})
+    monkeypatch.setattr(gateway_mod, "supports_systemd_services", lambda: False)
+    monkeypatch.setattr(gateway_mod, "is_macos", lambda: False)
+    monkeypatch.setattr(gateway_mod, "is_windows", lambda: False)
+    monkeypatch.setattr(gateway_mod, "find_gateway_pids", lambda **k: [])
+    monkeypatch.setattr(gateway_status, "get_running_pid", lambda: None)
+    monkeypatch.setattr(gateway_status, "clear_planned_stop_marker", lambda: None)
+    monkeypatch.setattr(
+        gateway_mod, "get_systemd_unit_path", lambda system=False: _FakePath(False)
+    )
+    monkeypatch.setattr(gateway_mod, "get_launchd_plist_path", lambda: _FakePath(False))
+    monkeypatch.setattr(gateway_mod, "systemd_start", lambda *a, **k: _record("systemd_start"))
+    monkeypatch.setattr(gateway_mod, "launchd_start", lambda *a, **k: _record("launchd_start"))
+    monkeypatch.setattr(gw_win, "is_installed", lambda: False)
+    monkeypatch.setattr(gw_win, "start", lambda: _record("windows_start"))
+    return calls
+
+
+class TestEnsureDesktopGatewayRunning:
+    def test_no_relaunch_when_already_running(self, monkeypatch, recovery_mocks):
+        monkeypatch.setattr(gateway_mod, "find_gateway_pids", lambda **k: [123])
+        web_server._ensure_desktop_gateway_running()
+        assert recovery_mocks == []
+
+    def test_relaunch_when_windows_scheduled_task_installed(self, monkeypatch, recovery_mocks):
+        monkeypatch.setattr(gateway_mod, "is_windows", lambda: True)
+        monkeypatch.setattr(gw_win, "is_installed", lambda: True)
+        web_server._ensure_desktop_gateway_running()
+        assert recovery_mocks == ["windows_start"]
+
+    def test_relaunch_when_systemd_unit_installed(self, monkeypatch, recovery_mocks):
+        monkeypatch.setattr(gateway_mod, "supports_systemd_services", lambda: True)
+        monkeypatch.setattr(
+            gateway_mod, "get_systemd_unit_path", lambda system=False: _FakePath(True)
+        )
+        web_server._ensure_desktop_gateway_running()
+        assert recovery_mocks == ["systemd_start"]
+
+    def test_relaunch_when_launchd_installed(self, monkeypatch, recovery_mocks):
+        monkeypatch.setattr(gateway_mod, "is_macos", lambda: True)
+        monkeypatch.setattr(gateway_mod, "get_launchd_plist_path", lambda: _FakePath(True))
+        web_server._ensure_desktop_gateway_running()
+        assert recovery_mocks == ["launchd_start"]
+
+    def test_no_relaunch_when_no_supervisor(self, monkeypatch, recovery_mocks):
+        # default fixtures: not running, no supervisor installed
+        web_server._ensure_desktop_gateway_running()
+        assert recovery_mocks == []
+
+    def test_env_var_disables_relaunch(self, monkeypatch, recovery_mocks):
+        monkeypatch.setenv("HERMES_DESKTOP_NO_GATEWAY_RELAUNCH", "1")
+        monkeypatch.setattr(gateway_mod, "is_windows", lambda: True)
+        monkeypatch.setattr(gw_win, "is_installed", lambda: True)
+        web_server._ensure_desktop_gateway_running()
+        assert recovery_mocks == []
+
+    def test_config_false_disables_relaunch(self, monkeypatch, recovery_mocks):
+        monkeypatch.setattr(
+            config_mod,
+            "load_config",
+            lambda: {"gateway": {"relaunch_gateway_on_desktop_start": False}},
+        )
+        monkeypatch.setattr(gateway_mod, "is_windows", lambda: True)
+        monkeypatch.setattr(gw_win, "is_installed", lambda: True)
+        web_server._ensure_desktop_gateway_running()
+        assert recovery_mocks == []
+
+    def test_recovery_never_raises(self, monkeypatch, recovery_mocks):
+        # Even if every helper throws, the function must swallow it.
+        def _boom(**k):
+            raise RuntimeError("boom")
+
+        monkeypatch.setattr(gateway_mod, "find_gateway_pids", _boom)
+        # Should not raise.
+        web_server._ensure_desktop_gateway_running()


### PR DESCRIPTION
## Summary

Split out from the reap-side fix for #83683. When the desktop backend (`HERMES_DESKTOP=1`) boots, if a gateway supervisor is installed (**systemd / launchd / the Windows `Hermes_Gateway` scheduled task**) but the gateway process is **not currently running**, relaunch it via the platform-native path so WeChat/QQ/Telegram don't go silently offline after a desktop (re)start.

This is the **"never relaunches"** half of #83683. The **reap-side** half — stop the orphan reaper from killing a supervised gateway in the first place — is handled separately in #86658 (exclusion-based, which also preserves the #51325/#75936 duplicate-port protection that a full-bail guard would disable). The two halves are independent and compose: #86658 keeps the reaper from murdering the supervised gateway, and this PR brings a missing-but-installed one back.

### Guards (so it's safe on its own)
- **Idempotent**: no-op if a gateway is already live (`find_gateway_pids()` / `get_running_pid()`).
- **Opt-out**: `gateway.relaunch_gateway_on_desktop_start = false` (config) or `HERMES_DESKTOP_NO_GATEWAY_RELAUNCH=1` (env).
- **Only acts when a supervisor is installed** — it never spawns a gateway the user didn't opt into auto-starting.
- Clears a stale `.gateway-planned-stop.json` before relaunch (so an unclean prior stop can't block startup).
- Fully best-effort: every failure is logged and swallowed; boot can never wedge on recovery.

## Changes
- `hermes_cli/web_server.py`: `_ensure_desktop_gateway_running()` + a detached `desktop-gateway-recover` thread in the desktop lifespan (after the existing cron ticker / reap call).
- `hermes_cli/config_defaults.py`: `gateway.relaunch_gateway_on_desktop_start` (default `true`).
- `tests/hermes_cli/test_desktop_gateway_recovery.py`: 8 cases (already-running no-op, no-supervisor skip, per-platform relaunch, opt-out env/config, stale-marker clear, supervisor-installed-but-down relaunch).

## Validation
`tests/hermes_cli/test_desktop_gateway_recovery.py` — 8 passed.

Supersedes the relaunch half of #83720 (the reap half of #83720 is superseded by #86658). Fixes #83683 (relaunch half).

## Infographic
N/A — behavior is the relaunch complement to #86658's reap diagram.