### PR TITLE
fix(deps): stop exclude-newer from bricking installs on no-date and exact-pinned packages

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -386,7 +386,27 @@ exclude-newer = "14 days"
 # request-smuggling) fix in 4.4.1, published 2026-08-03. Remove after 2026-08-17.
 # aiohttp, cryptography: same shape — the advisory fixes are newer than the
 # 14-day window, so the resolver cannot see them without an exception.
-exclude-newer-package = { vercel = false, nemo-relay = false, huggingface_hub = false, h2 = false, aiohttp = false, cryptography = false }
+#
+# defusedxml, python-olm, unpaddedbase64: the OPPOSITE shape (#80387, #79434,
+# #78227 family). These are ancient, effectively frozen releases (2021-2023)
+# whose upload dates are frequently absent from mirror indexes and stale uv
+# HTTP caches. uv treats a missing upload date as "newer than the cutoff" and
+# excludes the package, bricking [youtube]/[wecom]/[matrix] resolution
+# ("there are no versions of defusedxml"). Exempting them carries zero aging
+# risk — their newest releases are years old — and unbricks resolvers that
+# cannot see upload dates.
+#
+# setuptools, pillow, mcp: exact-pinned bricks (#78227, #75992, #76020). uv
+# applies exclude-newer to build-system.requires and core deps too; when a
+# resolver cannot see an upload date (old uv, mirror index, stale HTTP cache)
+# it filters the pinned version and the package cannot even BUILD
+# ("No solution found when resolving: setuptools==83.0.0"). These deps are
+# exact-pinned (==X.Y.Z), so exclude-newer adds zero float protection for
+# them — the version cannot move without a reviewed pin bump — while the
+# cutoff can still brick installs. Exempting exact pins is pure brick-risk
+# removal at no supply-chain cost. Guarded by
+# tests/test_packaging_metadata.py::test_build_system_requires_exempt_from_exclude_newer.
+exclude-newer-package = { vercel = false, nemo-relay = false, huggingface_hub = false, h2 = false, aiohttp = false, cryptography = false, defusedxml = false, python-olm = false, unpaddedbase64 = false, setuptools = false, pillow = false, mcp = false }
 
 [tool.setuptools]
 # Top-level single-file modules (not packages). Without this, uv2nix's

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1700,7 +1700,7 @@ PY
         exit 1
     fi
 
-    if [ "$_tier_name" != "all (with RL/matrix extras)" ]; then
+    if [ "$_tier_name" != "all" ]; then
         log_warn "Note: installed via fallback tier ($_tier_name)."
         log_info "Some optional features may be missing. After resolving any"
         log_info "PyPI/network issue, re-run: $UV_CMD pip install -e '.[all]'"

--- a/tests/test_packaging_metadata.py
+++ b/tests/test_packaging_metadata.py
@@ -248,6 +248,44 @@ def test_pyproject_pins_are_internally_consistent():
     )
 
 
+def test_build_system_requires_exempt_from_exclude_newer():
+    """Regression guard for the #78227 / #75992 exclude-newer brick class.
+
+    ``[tool.uv].exclude-newer`` applies to ``[build-system].requires`` too.
+    When a resolver cannot see a package's upload date (old uv, mirror
+    index, stale HTTP cache) it treats the release as newer than the cutoff
+    and filters it — and because build requirements are exact-pinned there
+    is no older candidate to fall back to, so the project cannot even be
+    BUILT from a git checkout ("No solution found when resolving:
+    setuptools==83.0.0", observed on released v0.20.0).
+
+    Exempting an exact-pinned build requirement costs nothing: the version
+    cannot move without a reviewed pin bump, so exclude-newer adds no float
+    protection for it. Every build requirement must therefore appear in the
+    ``exclude-newer-package`` whitelist (set to ``false``) for as long as a
+    relative ``exclude-newer`` cutoff is configured.
+    """
+    data = tomllib.loads((REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+    uv_cfg = data.get("tool", {}).get("uv", {})
+    if "exclude-newer" not in uv_cfg:
+        pytest.skip("no exclude-newer cutoff configured — nothing to exempt")
+    whitelist = {
+        _canonical(name)
+        for name, enabled in uv_cfg.get("exclude-newer-package", {}).items()
+        if enabled is False
+    }
+    build_requires = {
+        _canonical(_distribution_name(req))
+        for req in data.get("build-system", {}).get("requires", [])
+    }
+    missing = sorted(build_requires - whitelist)
+    assert not missing, (
+        "build-system.requires packages are subject to the exclude-newer "
+        "cutoff but missing from the [tool.uv].exclude-newer-package "
+        f"whitelist — fresh builds brick when upload dates are invisible: {missing}"
+    )
+
+
 
 
 def _lazy_deps_by_feature():

--- a/uv.lock
+++ b/uv.lock
@@ -12,12 +12,18 @@ exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for 
 exclude-newer-span = "P14D"
 
 [options.exclude-newer-package]
+setuptools = false
+h2 = false
 vercel = false
+pillow = false
+unpaddedbase64 = false
+defusedxml = false
 aiohttp = false
 cryptography = false
+mcp = false
+python-olm = false
 nemo-relay = false
 huggingface-hub = false
-h2 = false
 
 [manifest]
 overrides = [


### PR DESCRIPTION
## Summary

Fixes the `exclude-newer` install-bricking class: #80387, #79434 (root cause B + bonus), #78227, #75992, #76020.

`[tool.uv] exclude-newer = "14 days"` is a supply-chain aging gate, but it bricks installs whenever the resolver **cannot see (or accept) a package's upload date** — uv then filters the release entirely, and for exact-pinned deps there is no older candidate to fall back to.

Two shapes, one whitelist mechanism (`exclude-newer-package`, already used for vercel/nemo-relay/huggingface_hub/h2/aiohttp/cryptography):

1. **Frozen ancient releases** — `defusedxml` 0.7.1 (2021), `python-olm` 3.2.16 (2023), `unpaddedbase64` 2.1.0 (2021). Upload dates for these are frequently absent from mirror indexes / stale uv HTTP caches; uv treats "no date" as "newer than cutoff" → `[youtube]`/`[wecom]`/`[matrix]` resolution fails with *"there are no versions of defusedxml"* (#80387, #79434). Whitelisting is zero-risk: their newest releases are years old, there's nothing fresh to let through.
2. **Exact-pinned deps the cutoff can filter** — `setuptools==83.0.0` (in `[build-system].requires` — on released v0.20.0 the project **could not even be built** from a git checkout, #78227 error 2), `pillow==12.3.0`, `mcp==1.28.1` (#78227 error 1, #75992). Exempting an exact pin costs nothing: the version cannot float without a reviewed pin bump, so exclude-newer adds zero protection for it while retaining full brick potential.

## Changes

- **pyproject.toml** — add the six packages to `exclude-newer-package`, with per-class rationale comments.
- **uv.lock** — regenerated in the same PR (Teknium's standing rule). Diff is whitelist metadata only: still 249 packages, **zero version drift** (verified line-by-line — no non-whitelist lines in the lock diff).
- **tests/test_packaging_metadata.py** — new standing guard `test_build_system_requires_exempt_from_exclude_newer`: while a relative `exclude-newer` cutoff is configured, every `[build-system].requires` package must be whitelisted. This closes the *class* — a future build-requires bump without a whitelist entry fails CI instead of a user's fresh git install. Verified both directions: passes on this branch, fails naming `setuptools` when the whitelist entry is stripped.
- **scripts/install.sh** — #79434's bonus finding: the success-path check compared `_tier_name` against the legacy label `"all (with RL/matrix extras)"` but the tier is named `"all"` since the 2026-05-12 lazy-install rename, so every perfect Tier-1 install printed *"Note: installed via fallback tier (all)."* Compare against `"all"`.

## What I verified on current main (2026-08-14) before changing anything

- `uv lock --check` and `uv sync --extra all --locked` are currently **green** on uv 0.11.19 and 0.12.x with warm PyPI access — #79434's daily `--locked` drift (root cause A) does not reproduce on main today: the lock's `exclude-newer = "0001-01-01T00:00:00Z"` no-op + `exclude-newer-span = "P14D"` form (lockfile revision 3) is what current uv emits and accepts. No absolute-date pin needed anymore; the remaining live risk is exactly the no-date/exact-pin filtering fixed here.
- All six packages **do** have upload dates on pypi.org today — the failures hit resolvers that can't see them (mirrors, stale caches, older uv), which is why main "works here" while #78227 reports v0.20.0 broken.

## Empirical A/B of the whitelist mechanism

Minimal project, hostile cutoff (`exclude-newer` predating the pinned versions):

```text
without whitelist: × No solution found … defusedxml was filtered by exclude-newer
with whitelist:    Resolved 3 packages ✓

build-requires variant (setuptools==83.0.0, cutoff 2026-07-02):
without whitelist: × Failed to resolve requirements from build-system.requires
with whitelist:    Successfully built dist/…whl ✓
```

Full-project checks after the change: `uv lock --check` green (uv 0.11.19 + 0.12.5), `uv sync --extra all --locked --dry-run` green, `uv pip install --dry-run -e '.[all]'` resolves, `bash -n scripts/install.sh` clean, `pytest tests/test_packaging_metadata.py` → 7 passed, `ruff check` clean.

## Credit

Reported and root-caused by @MichaelClawHub (#80387), @liujianqiu (#79434 — including the install.sh tier-label find), @maxonliu (#78227), and the #75992/#76020 reporters.

Closes #80387
Closes #79434
Closes #78227
Closes #75992
Closes #76020

## Infographic

![exclude-newer unbrick](https://gist.githubusercontent.com/teknium1/796e292c23cbf38400383c907ea1e90f/raw/2618174d7a5a9b6a6071981dc83da27011c12d51/infographic-exclude-newer.png)
