### PR TITLE
Inspired by Cursor: pre-built Docker sandbox images (sandbox builds)

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -3349,6 +3349,8 @@ TERMINAL_CONFIG_ENV_MAP = {
     "docker_run_as_host_user": "TERMINAL_DOCKER_RUN_AS_HOST_USER",
     "docker_persist_across_processes": "TERMINAL_DOCKER_PERSIST_ACROSS_PROCESSES",
     "docker_orphan_reaper": "TERMINAL_DOCKER_ORPHAN_REAPER",
+    "docker_build_command": "TERMINAL_DOCKER_BUILD_COMMAND",
+    "docker_build_refresh_hours": "TERMINAL_DOCKER_BUILD_REFRESH_HOURS",
     "sandbox_dir": "TERMINAL_SANDBOX_DIR",
     "persistent_shell": "TERMINAL_PERSISTENT_SHELL",
 }

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -405,6 +405,19 @@ DEFAULT_CONFIG = {
         # When on, SETUID/SETGID caps are omitted from the container since
         # no privilege drop is needed.
         "docker_run_as_host_user": False,
+        # Sandbox builds (Cursor-inspired, opt-in): a command Hermes bakes into
+        # a committed Docker image ahead of sessions (docker run + commit) so
+        # sandbox containers boot with dependencies pre-installed instead of
+        # reinstalling at session start. Runs via `bash -lc` from docker_image.
+        # Example: "pip install requests pandas && npm install -g typescript"
+        # A failed build never replaces the last successful one; with no
+        # successful build yet, sessions use docker_image directly.
+        # Manage with `hermes sandbox build|status|clear`.
+        "docker_build_command": "",
+        # Rebuild in the background when the active build is older than this
+        # many hours (checked at session start; the running session keeps the
+        # current image). 0 disables automatic refresh.
+        "docker_build_refresh_hours": 24,
         # Persistent shell — keep a long-lived bash shell across execute() calls
         # so cwd/env vars/shell variables survive between commands.
         # Enabled by default for non-local backends (SSH); local is always opt-in

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -461,6 +461,7 @@ from hermes_cli.subcommands.approvals import build_approvals_parser
 from hermes_cli.subcommands.dump import build_dump_parser
 from hermes_cli.subcommands.debug import build_debug_parser
 from hermes_cli.subcommands.backup import build_backup_parser
+from hermes_cli.subcommands.sandbox import build_sandbox_parser
 from hermes_cli.subcommands.import_cmd import build_import_cmd_parser
 from hermes_cli.subcommands.import_agent import build_import_agent_parser
 from hermes_cli.subcommands.config import build_config_parser
@@ -10915,7 +10916,7 @@ _BUILTIN_SUBCOMMANDS = frozenset(
         "project", "proxy",
         "prompt-size",
         "resume",
-        "send", "sessions", "setup",
+        "send", "sessions", "setup", "sandbox",
         "skin", "skills", "slack", "status", "sync", "tools", "uninstall", "update",
         "version", "webhook", "whatsapp", "whatsapp-cloud", "chat", "secrets", "security",
         "verify",
@@ -11971,6 +11972,7 @@ def main():
     # backup command  (parser built in hermes_cli/subcommands/backup.py)
     # =========================================================================
     build_backup_parser(subparsers, cmd_backup=cmd_backup)
+    build_sandbox_parser(subparsers)
 
     # =========================================================================
     # checkpoints command

--- a/hermes_cli/subcommands/sandbox.py
+++ b/hermes_cli/subcommands/sandbox.py
@@ -1,0 +1,130 @@
+"""``hermes sandbox`` subcommand — manage pre-built Docker sandbox images.
+
+Sandbox builds (Cursor-inspired) bake ``terminal.docker_build_command`` into
+a committed Docker image ahead of sessions so containers boot with their
+dependencies already installed. This module carries both the parser and the
+handlers; the heavy lifting lives in ``tools.sandbox_builds``.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Any, Dict
+
+
+def _terminal_cfg() -> Dict[str, Any]:
+    from hermes_cli.config import load_config
+
+    cfg = load_config()
+    terminal = cfg.get("terminal", {})
+    return terminal if isinstance(terminal, dict) else {}
+
+
+def _build_inputs() -> tuple[str, str, Dict[str, Any]]:
+    terminal = _terminal_cfg()
+    base_image = str(
+        terminal.get("docker_image") or "nikolaik/python-nodejs:python3.11-nodejs20"
+    )
+    command = str(terminal.get("docker_build_command") or "").strip()
+    return base_image, command, terminal
+
+
+def cmd_sandbox_build(args) -> int:  # noqa: ANN001
+    from tools.sandbox_builds import run_build
+
+    base_image, command, terminal = _build_inputs()
+    if not command:
+        print("No build command configured.")
+        print("Set one with:  hermes config set terminal.docker_build_command \"<command>\"")
+        return 1
+    print(f"Building sandbox image from {base_image}")
+    print(f"  command: {command}")
+    record = run_build(
+        base_image, command, container_config=terminal, stream_output=True,
+    )
+    if record["status"] == "success":
+        print(f"\n✓ Build succeeded: {record['image_tag']}")
+        print("  New Docker sandbox sessions will boot from this image.")
+        return 0
+    print(f"\n✗ Build failed (exit={record.get('exit_code')}).")
+    print(f"  Log: {record.get('log_path')}")
+    print("  Sessions keep using the previous successful build (or the base image).")
+    return 1
+
+
+def cmd_sandbox_status(args) -> int:  # noqa: ANN001
+    from tools.sandbox_builds import status_summary
+
+    base_image, command, _terminal = _build_inputs()
+    info = status_summary(base_image, command)
+    print("Sandbox builds")
+    print(f"  Base image:    {base_image}")
+    if not info["configured"]:
+        print("  Build command: (not configured)")
+        print("  Enable with:   hermes config set terminal.docker_build_command \"<command>\"")
+        return 0
+    print(f"  Build command: {command}")
+    active = info.get("active")
+    if active:
+        age_h = (time.time() - (active.get("finished_at") or 0)) / 3600
+        print(f"  Active build:  {active.get('image_tag')} ({age_h:.1f}h old)")
+    else:
+        print("  Active build:  none — sessions boot from the base image")
+        print("  Run:           hermes sandbox build")
+    records = info.get("records") or []
+    if records:
+        print("  Recent builds:")
+        for r in records[-5:]:
+            when = time.strftime(
+                "%Y-%m-%d %H:%M", time.localtime(r.get("finished_at") or r.get("started_at") or 0)
+            )
+            print(f"    {when}  {r.get('status'):8s}  {r.get('fingerprint')}  {r.get('log_path', '')}")
+    return 0
+
+
+def cmd_sandbox_clear(args) -> int:  # noqa: ANN001
+    from tools.sandbox_builds import clear_builds
+
+    removed = clear_builds()
+    print(f"Removed {removed} sandbox build image(s) and cleared build metadata.")
+    return 0
+
+
+def cmd_sandbox(args) -> int:  # noqa: ANN001
+    sub = getattr(args, "sandbox_command", None)
+    if sub in ("build",):
+        return cmd_sandbox_build(args)
+    if sub in ("status", "st"):
+        return cmd_sandbox_status(args)
+    if sub in ("clear", "clean"):
+        return cmd_sandbox_clear(args)
+    # No subcommand: show status (cheap, informative default).
+    return cmd_sandbox_status(args)
+
+
+def build_sandbox_parser(subparsers) -> None:
+    """Attach the ``sandbox`` subcommand to ``subparsers``."""
+    sandbox_parser = subparsers.add_parser(
+        "sandbox",
+        help="Manage pre-built Docker sandbox images (sandbox builds)",
+        description=(
+            "Sandbox builds bake terminal.docker_build_command into a committed "
+            "Docker image ahead of sessions, so Docker sandbox containers boot "
+            "with dependencies already installed. A failed build never replaces "
+            "the last successful one."
+        ),
+    )
+    sandbox_subparsers = sandbox_parser.add_subparsers(dest="sandbox_command")
+    sandbox_subparsers.add_parser(
+        "build",
+        help="Run the configured build command and commit the prepared image now",
+    )
+    sandbox_subparsers.add_parser(
+        "status", aliases=["st"],
+        help="Show the active build, configuration, and recent build history",
+    )
+    sandbox_subparsers.add_parser(
+        "clear", aliases=["clean"],
+        help="Remove all sandbox build images and metadata",
+    )
+    sandbox_parser.set_defaults(func=cmd_sandbox)

--- a/tests/tools/test_sandbox_builds.py
+++ b/tests/tools/test_sandbox_builds.py
@@ -1,0 +1,283 @@
+"""Tests for tools.sandbox_builds (pre-built Docker sandbox images)."""
+
+import json
+import time
+from unittest import mock
+
+import pytest
+
+import tools.sandbox_builds as sb
+
+
+@pytest.fixture(autouse=True)
+def _isolated_builds_dir(tmp_path, monkeypatch):
+    """Point the builds dir at a temp location and reset per-process state."""
+    builds = tmp_path / "builds"
+    builds.mkdir()
+    monkeypatch.setattr(sb, "_builds_dir", lambda: builds)
+    monkeypatch.setattr(sb, "_refresh_started", set())
+    yield builds
+
+
+def _record(fingerprint, status="success", finished_at=None, image_tag=None):
+    return {
+        "fingerprint": fingerprint,
+        "status": status,
+        "finished_at": finished_at if finished_at is not None else time.time(),
+        "image_tag": image_tag or sb.image_tag_for(fingerprint),
+        "base_image": "base:img",
+        "command": "true",
+    }
+
+
+class TestFingerprint:
+    def test_stable(self):
+        assert sb.build_fingerprint("img", "cmd") == sb.build_fingerprint("img", "cmd")
+
+    def test_varies_with_image_and_command(self):
+        base = sb.build_fingerprint("img", "cmd")
+        assert sb.build_fingerprint("img2", "cmd") != base
+        assert sb.build_fingerprint("img", "cmd2") != base
+
+    def test_no_separator_collision(self):
+        # ("ab", "c") must not fingerprint like ("a", "bc")
+        assert sb.build_fingerprint("ab", "c") != sb.build_fingerprint("a", "bc")
+
+
+class TestLatestSuccessful:
+    def test_none_when_empty(self):
+        assert sb.latest_successful([], "f1") is None
+
+    def test_ignores_failed_and_other_fingerprints(self):
+        records = [
+            _record("f1", status="failed"),
+            _record("f2", status="success"),
+        ]
+        assert sb.latest_successful(records, "f1") is None
+
+    def test_picks_newest_success(self):
+        old = _record("f1", finished_at=100)
+        new = _record("f1", finished_at=200)
+        assert sb.latest_successful([old, new], "f1") is new
+
+
+class TestResolveImage:
+    def test_passthrough_without_command(self):
+        assert sb.resolve_image("base:img", {}) == "base:img"
+        assert sb.resolve_image("base:img", None) == "base:img"
+        assert sb.resolve_image("base:img", {"docker_build_command": "  "}) == "base:img"
+
+    def test_no_build_yet_returns_base_and_schedules(self, monkeypatch):
+        started = []
+        monkeypatch.setattr(
+            sb, "_maybe_refresh_async",
+            lambda *a, **k: started.append(k.get("reason")),
+        )
+        cc = {"docker_build_command": "pip install x"}
+        assert sb.resolve_image("base:img", cc) == "base:img"
+        assert started == ["initial"]
+
+    def test_successful_build_returns_tag(self, monkeypatch):
+        cc = {"docker_build_command": "pip install x", "docker_build_refresh_hours": 0}
+        fp = sb.build_fingerprint("base:img", "pip install x")
+        sb._save_metadata([_record(fp)])
+        monkeypatch.setattr(sb, "_image_exists", lambda tag: True)
+        assert sb.resolve_image("base:img", cc) == sb.image_tag_for(fp)
+
+    def test_missing_image_falls_back(self, monkeypatch):
+        cc = {"docker_build_command": "pip install x"}
+        fp = sb.build_fingerprint("base:img", "pip install x")
+        sb._save_metadata([_record(fp)])
+        monkeypatch.setattr(sb, "_image_exists", lambda tag: False)
+        scheduled = []
+        monkeypatch.setattr(
+            sb, "_maybe_refresh_async",
+            lambda *a, **k: scheduled.append(k.get("reason")),
+        )
+        assert sb.resolve_image("base:img", cc) == "base:img"
+        assert scheduled == ["missing-image"]
+
+    def test_failed_build_never_used(self, monkeypatch):
+        cc = {"docker_build_command": "pip install x"}
+        fp = sb.build_fingerprint("base:img", "pip install x")
+        sb._save_metadata([_record(fp, status="failed")])
+        monkeypatch.setattr(sb, "_maybe_refresh_async", lambda *a, **k: None)
+        assert sb.resolve_image("base:img", cc) == "base:img"
+
+    def test_config_change_ignores_old_build(self, monkeypatch):
+        old_fp = sb.build_fingerprint("base:img", "old command")
+        sb._save_metadata([_record(old_fp)])
+        monkeypatch.setattr(sb, "_image_exists", lambda tag: True)
+        monkeypatch.setattr(sb, "_maybe_refresh_async", lambda *a, **k: None)
+        cc = {"docker_build_command": "new command"}
+        assert sb.resolve_image("base:img", cc) == "base:img"
+
+    def test_stale_build_triggers_refresh_but_keeps_image(self, monkeypatch):
+        cc = {"docker_build_command": "pip install x", "docker_build_refresh_hours": 1}
+        fp = sb.build_fingerprint("base:img", "pip install x")
+        sb._save_metadata([_record(fp, finished_at=time.time() - 7200)])
+        monkeypatch.setattr(sb, "_image_exists", lambda tag: True)
+        scheduled = []
+        monkeypatch.setattr(
+            sb, "_maybe_refresh_async",
+            lambda *a, **k: scheduled.append(k.get("reason")),
+        )
+        assert sb.resolve_image("base:img", cc) == sb.image_tag_for(fp)
+        assert scheduled == ["stale"]
+
+    def test_refresh_zero_disables_staleness(self, monkeypatch):
+        cc = {"docker_build_command": "pip install x", "docker_build_refresh_hours": 0}
+        fp = sb.build_fingerprint("base:img", "pip install x")
+        sb._save_metadata([_record(fp, finished_at=0)])  # ancient
+        monkeypatch.setattr(sb, "_image_exists", lambda tag: True)
+        scheduled = []
+        monkeypatch.setattr(
+            sb, "_maybe_refresh_async",
+            lambda *a, **k: scheduled.append(k.get("reason")),
+        )
+        assert sb.resolve_image("base:img", cc) == sb.image_tag_for(fp)
+        assert scheduled == []
+
+    def test_resolve_never_raises(self, monkeypatch):
+        monkeypatch.setattr(
+            sb, "_load_metadata", mock.Mock(side_effect=RuntimeError("boom"))
+        )
+        cc = {"docker_build_command": "pip install x"}
+        assert sb.resolve_image("base:img", cc) == "base:img"
+
+
+class TestRefreshDedup:
+    def test_one_background_build_per_fingerprint(self, monkeypatch):
+        calls = []
+        monkeypatch.setattr(sb, "run_build", lambda *a, **k: calls.append(a))
+        threads = []
+
+        class _FakeThread:
+            def __init__(self, target=None, **kwargs):
+                self._target = target
+                threads.append(self)
+
+            def start(self):
+                self._target()
+
+        monkeypatch.setattr(sb.threading, "Thread", _FakeThread)
+        cc = {"docker_build_command": "x"}
+        sb._maybe_refresh_async("img", "x", cc, reason="initial")
+        sb._maybe_refresh_async("img", "x", cc, reason="initial")
+        assert len(calls) == 1
+
+
+class TestMetadataRoundTrip:
+    def test_save_and_load(self, _isolated_builds_dir):
+        records = [_record("f1"), _record("f2", status="failed")]
+        sb._save_metadata(records)
+        loaded = sb._load_metadata()
+        assert [r["fingerprint"] for r in loaded] == ["f1", "f2"]
+
+    def test_corrupt_metadata_returns_empty(self, _isolated_builds_dir):
+        (_isolated_builds_dir / "builds.json").write_text("{not json", encoding="utf-8")
+        assert sb._load_metadata() == []
+
+
+class TestRunBuild:
+    def _mock_popen(self, exit_code=0, output="ok\n"):
+        proc = mock.Mock()
+        proc.stdout = iter(output.splitlines(keepends=True))
+        proc.wait = mock.Mock(return_value=exit_code)
+        return proc
+
+    def test_success_commits_and_records(self, monkeypatch):
+        monkeypatch.setattr(sb, "_docker_exe", lambda: "docker")
+        popen = mock.Mock(return_value=self._mock_popen(0))
+        monkeypatch.setattr(sb.subprocess, "Popen", popen)
+        run_calls = []
+
+        def fake_run(cmd, **kwargs):
+            run_calls.append(cmd)
+            return mock.Mock(returncode=0, stderr="")
+
+        monkeypatch.setattr(sb.subprocess, "run", fake_run)
+        record = sb.run_build("base:img", "true")
+        assert record["status"] == "success"
+        assert any(c[:2] == ["docker", "commit"] for c in run_calls)
+        # rm -f cleanup always happens
+        assert any(c[:3] == ["docker", "rm", "-f"] for c in run_calls)
+        stored = sb._load_metadata()
+        assert stored[-1]["status"] == "success"
+
+    def test_failed_command_records_failure_and_skips_commit(self, monkeypatch):
+        monkeypatch.setattr(sb, "_docker_exe", lambda: "docker")
+        popen = mock.Mock(return_value=self._mock_popen(3, "boom\n"))
+        monkeypatch.setattr(sb.subprocess, "Popen", popen)
+        run_calls = []
+
+        def fake_run(cmd, **kwargs):
+            run_calls.append(cmd)
+            return mock.Mock(returncode=0, stderr="")
+
+        monkeypatch.setattr(sb.subprocess, "run", fake_run)
+        record = sb.run_build("base:img", "false")
+        assert record["status"] == "failed"
+        assert record["exit_code"] == 3
+        assert not any(c[:2] == ["docker", "commit"] for c in run_calls)
+        # A prior success for the same fingerprint stays active.
+        fp = record["fingerprint"]
+        sb._save_metadata(sb._load_metadata() + [_record(fp, finished_at=1)])
+        active = sb.latest_successful(sb._load_metadata(), fp)
+        assert active is not None and active["status"] == "success"
+
+
+class TestStatusSummary:
+    def test_unconfigured(self):
+        info = sb.status_summary("base:img", "")
+        assert info["configured"] is False
+        assert info["active"] is None
+
+    def test_active_build_reported(self, monkeypatch):
+        fp = sb.build_fingerprint("base:img", "cmd")
+        sb._save_metadata([_record(fp)])
+        monkeypatch.setattr(sb, "_image_exists", lambda tag: True)
+        info = sb.status_summary("base:img", "cmd")
+        assert info["configured"] is True
+        assert info["active"]["fingerprint"] == fp
+
+
+class TestCreateEnvironmentIntegration:
+    def test_docker_env_uses_resolved_image(self, monkeypatch):
+        """_create_environment routes the image through sandbox build resolution."""
+        import tools.terminal_tool as tt
+
+        captured = {}
+
+        class FakeDockerEnv:
+            def __init__(self, image=None, **kwargs):
+                captured["image"] = image
+
+        monkeypatch.setattr(tt, "_DockerEnvironment", FakeDockerEnv)
+        monkeypatch.setattr(tt, "_maybe_reap_docker_orphans", lambda cc: None)
+        monkeypatch.setattr(sb, "_image_exists", lambda tag: True)
+        monkeypatch.setattr(sb, "_maybe_refresh_async", lambda *a, **k: None)
+        fp = sb.build_fingerprint("base:img", "pip install x")
+        sb._save_metadata([_record(fp)])
+        tt._create_environment(
+            "docker", "base:img", "/root", 60,
+            container_config={
+                "docker_build_command": "pip install x",
+                "docker_build_refresh_hours": 0,
+            },
+        )
+        assert captured["image"] == sb.image_tag_for(fp)
+
+    def test_docker_env_unchanged_without_command(self, monkeypatch):
+        import tools.terminal_tool as tt
+
+        captured = {}
+
+        class FakeDockerEnv:
+            def __init__(self, image=None, **kwargs):
+                captured["image"] = image
+
+        monkeypatch.setattr(tt, "_DockerEnvironment", FakeDockerEnv)
+        monkeypatch.setattr(tt, "_maybe_reap_docker_orphans", lambda cc: None)
+        tt._create_environment("docker", "base:img", "/root", 60, container_config={})
+        assert captured["image"] == "base:img"

--- a/tools/sandbox_builds.py
+++ b/tools/sandbox_builds.py
@@ -1,0 +1,399 @@
+"""Pre-built Docker sandbox images ("sandbox builds").
+
+Inspired by Cursor's Cloud Agent Builds (Aug 2026): instead of every fresh
+sandbox container paying the clone/install cost at session start, Hermes can
+bake a user-configured build command into a committed Docker image ahead of
+time. Containers then boot from the prepared image, and the agent starts with
+its tooling already installed.
+
+Design properties (mirroring the upstream feature, adapted to a local-first
+architecture):
+
+- **Opt-in.** Nothing happens unless ``terminal.docker_build_command`` is set.
+- **Fail-safe.** A failed build never replaces the active one — resolution
+  only ever returns the latest *successful* build, so a broken install
+  command degrades to the previous good image (or the raw base image).
+- **Fingerprinted.** A build is keyed by (base image, build command). Change
+  either and the stale build is ignored until a new one succeeds.
+- **Staleness refresh.** When the active build is older than
+  ``terminal.docker_build_refresh_hours`` (default 24, ``0`` disables), a
+  background rebuild is kicked off at resolve time. The running session keeps
+  the warm image; the *next* session picks up the refreshed one.
+- **Observable.** Metadata + per-build logs live under
+  ``<sandbox_dir>/builds/`` and are surfaced by ``hermes sandbox status``.
+
+The build itself is intentionally simple: run the build command in a
+container from the base image, ``docker commit`` the result, tag it
+``hermes-sandbox-build:<fingerprint>``. Disk state only — running processes
+do not survive the commit (same contract as Cursor's builds).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import os
+import shlex
+import subprocess
+import threading
+import time
+import uuid
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+_IMAGE_REPO = "hermes-sandbox-build"
+_BUILD_TIMEOUT_DEFAULT = 1800  # seconds; generous — installs can be slow
+_LOCK = threading.Lock()
+_refresh_started: set = set()  # fingerprints with an in-process background refresh
+
+
+# ---------------------------------------------------------------------------
+# Paths / metadata
+# ---------------------------------------------------------------------------
+
+
+def _builds_dir() -> Path:
+    from tools.environments.base import get_sandbox_dir
+
+    d = get_sandbox_dir() / "builds"
+    d.mkdir(parents=True, exist_ok=True)
+    return d
+
+
+def _metadata_path() -> Path:
+    return _builds_dir() / "builds.json"
+
+
+def _load_metadata() -> List[Dict[str, Any]]:
+    path = _metadata_path()
+    try:
+        with open(path, "r", encoding="utf-8") as fh:
+            data = json.load(fh)
+        if isinstance(data, list):
+            return data
+    except FileNotFoundError:
+        pass
+    except Exception:
+        logger.warning("sandbox builds: unreadable metadata at %s", path, exc_info=True)
+    return []
+
+
+def _save_metadata(records: List[Dict[str, Any]]) -> None:
+    path = _metadata_path()
+    tmp = path.with_suffix(".json.tmp")
+    with open(tmp, "w", encoding="utf-8") as fh:
+        json.dump(records, fh, indent=2)
+    os.replace(tmp, path)
+
+
+def build_fingerprint(base_image: str, command: str) -> str:
+    """Stable fingerprint for a (base image, build command) pair."""
+    digest = hashlib.sha256(
+        f"{base_image}\0{command}".encode("utf-8")
+    ).hexdigest()
+    return digest[:12]
+
+
+def image_tag_for(fingerprint: str) -> str:
+    return f"{_IMAGE_REPO}:{fingerprint}"
+
+
+# ---------------------------------------------------------------------------
+# Docker helpers
+# ---------------------------------------------------------------------------
+
+
+def _docker_exe() -> str:
+    try:
+        from tools.environments.docker import find_docker
+
+        return find_docker() or "docker"
+    except Exception:
+        return "docker"
+
+
+def _image_exists(tag: str) -> bool:
+    try:
+        proc = subprocess.run(
+            [_docker_exe(), "image", "inspect", tag],
+            capture_output=True, timeout=30,
+        )
+        return proc.returncode == 0
+    except Exception:
+        return False
+
+
+# ---------------------------------------------------------------------------
+# Resolution (called from terminal_tool._create_environment)
+# ---------------------------------------------------------------------------
+
+
+def latest_successful(records: List[Dict[str, Any]], fingerprint: str) -> Optional[Dict[str, Any]]:
+    hits = [
+        r for r in records
+        if r.get("fingerprint") == fingerprint and r.get("status") == "success"
+    ]
+    if not hits:
+        return None
+    return max(hits, key=lambda r: r.get("finished_at") or 0)
+
+
+def resolve_image(base_image: str, container_config: Optional[Dict[str, Any]] = None) -> str:
+    """Return the image a new Docker sandbox should boot from.
+
+    When a successful sandbox build exists for the configured
+    (base image, build command) pair, its committed tag is returned;
+    otherwise *base_image* passes through unchanged. Never raises.
+    """
+    cc = container_config or {}
+    command = str(cc.get("docker_build_command") or "").strip()
+    if not command:
+        return base_image
+    try:
+        fingerprint = build_fingerprint(base_image, command)
+        record = latest_successful(_load_metadata(), fingerprint)
+        if record is None:
+            # No build yet — kick one off in the background so a future
+            # session benefits; this session uses the base image (standard
+            # startup flow, same as Cursor pre-first-build).
+            _maybe_refresh_async(base_image, command, cc, reason="initial")
+            return base_image
+        tag = record.get("image_tag") or image_tag_for(fingerprint)
+        if not _image_exists(tag):
+            logger.info("sandbox builds: image %s missing, falling back to base", tag)
+            _maybe_refresh_async(base_image, command, cc, reason="missing-image")
+            return base_image
+        _maybe_refresh_if_stale(base_image, command, cc, record)
+        logger.info("sandbox builds: booting from prepared image %s", tag)
+        return tag
+    except Exception:
+        logger.warning("sandbox builds: resolve failed, using base image", exc_info=True)
+        return base_image
+
+
+def _refresh_hours(cc: Dict[str, Any]) -> float:
+    try:
+        return max(float(cc.get("docker_build_refresh_hours", 24) or 0), 0.0)
+    except (TypeError, ValueError):
+        return 24.0
+
+
+def _maybe_refresh_if_stale(
+    base_image: str, command: str, cc: Dict[str, Any], record: Dict[str, Any],
+) -> None:
+    hours = _refresh_hours(cc)
+    if hours <= 0:
+        return
+    finished_at = record.get("finished_at") or 0
+    if (time.time() - finished_at) < hours * 3600:
+        return
+    _maybe_refresh_async(base_image, command, cc, reason="stale")
+
+
+def _maybe_refresh_async(
+    base_image: str, command: str, cc: Dict[str, Any], *, reason: str,
+) -> None:
+    """Start at most one background build per fingerprint per process."""
+    fingerprint = build_fingerprint(base_image, command)
+    with _LOCK:
+        if fingerprint in _refresh_started:
+            return
+        _refresh_started.add(fingerprint)
+
+    def _worker() -> None:
+        try:
+            logger.info("sandbox builds: background build (%s) for %s", reason, fingerprint)
+            run_build(base_image, command, container_config=cc)
+        except Exception:
+            logger.warning("sandbox builds: background build failed", exc_info=True)
+
+    threading.Thread(
+        target=_worker, name=f"sandbox-build-{fingerprint}", daemon=True,
+    ).start()
+
+
+# ---------------------------------------------------------------------------
+# Build execution
+# ---------------------------------------------------------------------------
+
+
+def run_build(
+    base_image: str,
+    command: str,
+    *,
+    container_config: Optional[Dict[str, Any]] = None,
+    timeout: int = _BUILD_TIMEOUT_DEFAULT,
+    stream_output: bool = False,
+) -> Dict[str, Any]:
+    """Run *command* in a container from *base_image* and commit the result.
+
+    Returns the metadata record for the build (status ``success`` or
+    ``failed``). A failed build leaves any previous successful build active.
+    """
+    cc = container_config or {}
+    docker = _docker_exe()
+    fingerprint = build_fingerprint(base_image, command)
+    tag = image_tag_for(fingerprint)
+    container_name = f"hermes-sandbox-build-{fingerprint}-{uuid.uuid4().hex[:8]}"
+    log_path = _builds_dir() / f"build-{fingerprint}-{int(time.time())}.log"
+
+    record: Dict[str, Any] = {
+        "fingerprint": fingerprint,
+        "base_image": base_image,
+        "command": command,
+        "image_tag": tag,
+        "container_name": container_name,
+        "started_at": time.time(),
+        "finished_at": None,
+        "status": "running",
+        "log_path": str(log_path),
+    }
+
+    run_cmd = [
+        docker, "run", "--name", container_name,
+        # Deterministic entry: bash login shell so PATH setup in the image
+        # (nvm, venvs) applies, mirroring how sandbox commands execute later.
+        base_image, "bash", "-lc", command,
+    ]
+    shm = str(cc.get("docker_shm_size") or "").strip()
+    if shm and shm != "0":
+        run_cmd[2:2] = ["--shm-size", shm]
+
+    status = "failed"
+    exit_code: Optional[int] = None
+    try:
+        with open(log_path, "w", encoding="utf-8") as log_fh:
+            log_fh.write(f"$ {' '.join(shlex.quote(c) for c in run_cmd)}\n")
+            log_fh.flush()
+            proc = subprocess.Popen(
+                run_cmd,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                text=True,
+                errors="replace",
+            )
+            assert proc.stdout is not None
+            for line in proc.stdout:
+                log_fh.write(line)
+                if stream_output:
+                    print(line, end="")
+            exit_code = proc.wait(timeout=timeout)
+        if exit_code == 0:
+            commit = subprocess.run(
+                [docker, "commit",
+                 "-c", 'CMD ["bash"]',
+                 container_name, tag],
+                capture_output=True, text=True, timeout=600,
+            )
+            if commit.returncode == 0:
+                status = "success"
+            else:
+                with open(log_path, "a", encoding="utf-8") as log_fh:
+                    log_fh.write(f"\ndocker commit failed: {commit.stderr}\n")
+    except subprocess.TimeoutExpired:
+        with open(log_path, "a", encoding="utf-8") as log_fh:
+            log_fh.write(f"\nbuild timed out after {timeout}s\n")
+        try:
+            subprocess.run([docker, "kill", container_name], capture_output=True, timeout=60)
+        except Exception:
+            pass
+    except Exception as exc:
+        try:
+            with open(log_path, "a", encoding="utf-8") as log_fh:
+                log_fh.write(f"\nbuild error: {exc}\n")
+        except Exception:
+            pass
+        logger.warning("sandbox builds: build execution failed", exc_info=True)
+    finally:
+        # Always remove the build container; the committed image carries the state.
+        try:
+            subprocess.run([docker, "rm", "-f", container_name], capture_output=True, timeout=60)
+        except Exception:
+            pass
+
+    record["status"] = status
+    record["exit_code"] = exit_code
+    record["finished_at"] = time.time()
+
+    with _LOCK:
+        records = _load_metadata()
+        records.append(record)
+        # Bound growth: keep the newest 50 records.
+        _save_metadata(records[-50:])
+
+    if status == "success":
+        logger.info("sandbox builds: build %s succeeded -> %s", fingerprint, tag)
+        _prune_superseded_images(records, fingerprint, keep_tag=tag)
+    else:
+        logger.warning(
+            "sandbox builds: build %s failed (exit=%s); previous build stays active. Log: %s",
+            fingerprint, exit_code, log_path,
+        )
+    return record
+
+
+def _prune_superseded_images(
+    records: List[Dict[str, Any]], fingerprint: str, *, keep_tag: str,
+) -> None:
+    """Best-effort removal of images from other fingerprints (config changed)."""
+    docker = _docker_exe()
+    stale_tags = {
+        r.get("image_tag") for r in records
+        if r.get("status") == "success"
+        and r.get("fingerprint") != fingerprint
+        and r.get("image_tag")
+    }
+    for tag in stale_tags:
+        try:
+            subprocess.run([docker, "rmi", tag], capture_output=True, timeout=120)
+        except Exception:
+            pass
+
+
+# ---------------------------------------------------------------------------
+# CLI support
+# ---------------------------------------------------------------------------
+
+
+def clear_builds() -> int:
+    """Remove all built images and metadata. Returns count of images removed."""
+    docker = _docker_exe()
+    records = _load_metadata()
+    tags: set = {
+        str(r.get("image_tag")) for r in records if r.get("image_tag")
+    }
+    removed = 0
+    for tag in sorted(tags):
+        try:
+            proc = subprocess.run([docker, "rmi", tag], capture_output=True, timeout=120)
+            if proc.returncode == 0:
+                removed += 1
+        except Exception:
+            pass
+    try:
+        _metadata_path().unlink()
+    except FileNotFoundError:
+        pass
+    return removed
+
+
+def status_summary(base_image: str, command: str) -> Dict[str, Any]:
+    """Structured status for ``hermes sandbox status``."""
+    records = _load_metadata()
+    result: Dict[str, Any] = {
+        "configured": bool(command.strip()),
+        "base_image": base_image,
+        "command": command,
+        "records": records[-10:],
+        "active": None,
+    }
+    if command.strip():
+        fingerprint = build_fingerprint(base_image, command)
+        result["fingerprint"] = fingerprint
+        active = latest_successful(records, fingerprint)
+        if active and _image_exists(active.get("image_tag") or ""):
+            result["active"] = active
+    return result

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -1698,6 +1698,12 @@ def _get_env_config() -> Dict[str, Any]:
         "docker_orphan_reaper": os.getenv(
             "TERMINAL_DOCKER_ORPHAN_REAPER", "true"
         ).lower() in {"true", "1", "yes"},
+        # Sandbox builds (Cursor-inspired): optional command baked into a
+        # committed image ahead of sessions so containers boot pre-provisioned.
+        "docker_build_command": os.getenv("TERMINAL_DOCKER_BUILD_COMMAND", ""),
+        "docker_build_refresh_hours": _parse_env_var(
+            "TERMINAL_DOCKER_BUILD_REFRESH_HOURS", "24", float, "number"
+        ),
     }
 
 
@@ -1749,6 +1755,8 @@ def _container_config_from_config(config: Dict[str, Any]) -> dict:
         "docker_network": config.get("docker_network", True),
         "docker_persist_across_processes": config.get("docker_persist_across_processes", True),
         "docker_orphan_reaper": config.get("docker_orphan_reaper", True),
+        "docker_build_command": config.get("docker_build_command", ""),
+        "docker_build_refresh_hours": config.get("docker_build_refresh_hours", 24),
     }
 
 
@@ -1807,6 +1815,15 @@ def _create_environment(env_type: str, image: str, cwd: str, timeout: int,
             and task_id != "default"
             and not _has_isolation_overrides(task_id)
         )
+        # Sandbox builds (Cursor-inspired): when a build command is configured
+        # and a successful pre-built image exists, boot from it instead of the
+        # raw base image. Fail-safe passthrough — resolve_image never raises
+        # and returns `image` unchanged when builds are unconfigured/broken.
+        try:
+            from tools.sandbox_builds import resolve_image as _resolve_build_image
+            image = _resolve_build_image(image, cc)
+        except Exception:
+            logger.debug("sandbox builds: resolve unavailable", exc_info=True)
         docker_env_obj = _DockerEnvironment(
             image=image, cwd=cwd, timeout=timeout,
             cpu=cpu, memory=memory, disk=disk,

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -275,6 +275,26 @@ terminal:
 
 **`terminal.docker_network`** (default `true`; env: `TERMINAL_DOCKER_NETWORK`) — set to `false` to run the sandbox container with `--network=none`, cutting off all network egress from agent commands. This applies to the execution container used by `terminal`, `execute_code`, and the file tools. Because containers persist across Hermes processes, flipping this to `false` while an older networked container exists will remove that container and start a fresh air-gapped one (a warning is logged); background processes running inside it are lost. Prefer this key over passing `--network=none` through `docker_extra_args`.
 
+#### Sandbox builds — pre-provisioned images
+
+When your sandbox needs setup work (pip/npm installs, toolchain downloads), you can bake it into a **pre-built image** so containers boot ready instead of reinstalling on every fresh container:
+
+```yaml
+terminal:
+  backend: docker
+  docker_build_command: "pip install requests pandas && npm install -g typescript"
+  docker_build_refresh_hours: 24   # background rebuild when the active build is older; 0 disables
+```
+
+Hermes runs `docker_build_command` (via `bash -lc`) in a container from `docker_image`, commits the result as `hermes-sandbox-build:<fingerprint>`, and new Docker sandboxes boot from that image. Key behaviors:
+
+- **Fail-safe** — a failed build never replaces the last successful one; sessions keep using the previous good image (or the raw `docker_image` if no build has ever succeeded).
+- **Fingerprinted** — builds are keyed to the (base image, build command) pair; changing either invalidates the old build until a new one succeeds.
+- **Background refresh** — at session start, a build older than `docker_build_refresh_hours` triggers a rebuild in the background; the running session keeps the current image and the *next* session picks up the refresh.
+- **Observable** — `hermes sandbox status` shows the active build, its age, and recent build history with per-build logs; `hermes sandbox build` runs a build in the foreground; `hermes sandbox clear` removes all built images and metadata.
+
+Builds capture **disk state only** — put services and background processes in your session workflow, not the build command.
+
 **Requirements:** Docker Desktop or Docker Engine installed and running. Hermes probes `$PATH` plus common macOS install locations (`/usr/local/bin/docker`, `/opt/homebrew/bin/docker`, Docker Desktop app bundle). Podman is supported out of the box: set `HERMES_DOCKER_BINARY=podman` (or the full path) to force it when both are installed.
 
 #### Container lifecycle
@@ -329,6 +349,8 @@ Every key under `terminal:` has an env-var override of the form `TERMINAL_<KEY_U
 | `TERMINAL_DOCKER_NETWORK` | `docker_network` | `true` / `false` — default `true`; `false` = `--network=none` |
 | `TERMINAL_DOCKER_PERSIST_ACROSS_PROCESSES` | `docker_persist_across_processes` | `true` / `false` — default `true` |
 | `TERMINAL_DOCKER_ORPHAN_REAPER` | `docker_orphan_reaper` | `true` / `false` — default `true` |
+| `TERMINAL_DOCKER_BUILD_COMMAND` | `docker_build_command` | Sandbox build command (empty = disabled) |
+| `TERMINAL_DOCKER_BUILD_REFRESH_HOURS` | `docker_build_refresh_hours` | Hours before background rebuild — default `24`, `0` disables |
 | `TERMINAL_CONTAINER_CPU` | `container_cpu` | CPU cores |
 | `TERMINAL_CONTAINER_MEMORY` | `container_memory` | MB |
 | `TERMINAL_CONTAINER_DISK` | `container_disk` | MB |


### PR DESCRIPTION
## Summary
Docker sandbox containers can now boot from a **pre-built image** with dependencies already installed, instead of reinstalling at session start — a local-first port of Cursor's Cloud Agent "Builds" (announced Aug 13, 2026).

## Source
- Cursor changelog: https://cursor.com/changelog/08-13-26
- Announcement: https://cursor.com/blog/builds
- Docs: https://cursor.com/docs/cloud-agent/builds

**Their mechanism:** Cursor continuously prepares bootable snapshots of cloud-agent environments (clone + `install` command → disk snapshot). Agents start from the latest *successful* build; a broken install never replaces the working one; stale builds refresh on a threshold; builds are observable in a dashboard tab.

**Our adaptation:** Hermes' Docker terminal backend is local, so the snapshot primitive is `docker run` + `docker commit`. Everything else maps 1:1 — fail-safe resolution, fingerprint invalidation, staleness refresh, observability. No cloud infra, no new model tool (CLI command + config keys only, per the footprint ladder).

## Changes
- `tools/sandbox_builds.py` (new): build runner (`bash -lc` in a container from `docker_image` → `docker commit` → `hermes-sandbox-build:<fingerprint>`), fail-safe `resolve_image()`, staleness-triggered background rebuilds (deduped per fingerprint per process), metadata + per-build logs under `<sandbox_dir>/builds/`, superseded-image pruning.
- `tools/terminal_tool.py`: `_create_environment("docker", ...)` routes the image through `resolve_image()` — pure passthrough when unconfigured; wrapped so resolution can never break sandbox creation. New config keys surfaced in `_get_env_config()` / container-config plumbing.
- `hermes_cli/config_defaults.py` + `config.py`: `terminal.docker_build_command` (opt-in, default `""`), `terminal.docker_build_refresh_hours` (default 24, `0` disables) + `TERMINAL_DOCKER_BUILD_COMMAND` / `TERMINAL_DOCKER_BUILD_REFRESH_HOURS` env bridge entries.
- `hermes_cli/subcommands/sandbox.py` (new) + `main.py` wiring: `hermes sandbox build|status|clear` (bare `hermes sandbox` = status).
- `website/docs/user-guide/configuration.md`: "Sandbox builds" section + env-var table rows.
- `tests/tools/test_sandbox_builds.py` (new): 24 tests — fingerprint stability/collision, fail-safe resolution (failed builds never used, config change invalidates, missing image falls back), staleness triggers, refresh dedup, metadata round-trip/corruption, build success/failure recording, and `_create_environment` integration.

## Key behaviors
- **Opt-in:** nothing changes unless `docker_build_command` is set.
- **Fail-safe:** only the latest *successful* build is ever booted; a failed build logs and leaves the previous good image (or the raw base image) active.
- **Fingerprinted:** builds keyed to (base image, build command); changing either ignores the stale build until a new one succeeds.
- **Background refresh:** stale builds rebuild off the session path; the running session keeps its warm image, the next one picks up the refresh.
- **Disk state only:** same contract as Cursor's builds — services belong in the session, not the build command.

## Validation
| Check | Result |
|---|---|
| Unit tests (`tests/tools/test_sandbox_builds.py`) | 24/24 pass |
| Sibling suites (`test_terminal_config_env_sync`, `test_terminal_env_bridge`, `test_docker_environment`, `test_docker_session_isolation`, env-ref parity) | 125/125 pass |
| E2E (real `run_build`/`resolve_image` subprocess paths via docker shim: build → resolve → fail-safe → logs → status) | pass |
| Real CLI `hermes sandbox status` with isolated HERMES_HOME | pass |
| `py_compile` on all touched files | pass |

## Infographic

![Sandbox builds — pre-provisioned Docker sandbox images](https://files.catbox.moe/crxp2s.png)
