### PR TITLE
fix(config): parse JSON-string lists for skills.disabled and agent.disabled_toolsets

### DIFF
--- a/agent/skill_utils.py
+++ b/agent/skill_utils.py
@@ -5,6 +5,8 @@ heavy dependency chain.  It is safe to import at module level without triggering
 tool registration or provider resolution.
 """
 
+import ast
+import json
 import logging
 import os
 import re
@@ -456,11 +458,55 @@ def get_disabled_skill_names(platform: str | None = None) -> Set[str]:
 
 
 def _normalize_string_set(values) -> Set[str]:
+    """Normalize a config value into a set of names.
+
+    ``None`` (YAML null) means empty, a bare scalar (``disabled: my-skill``)
+    means a single-item set — NOT a set of its characters (#13026). A
+    JSON-array string (``disabled: '["skill-a","skill-b"]'``, e.g. written by
+    ``hermes config set`` or a JSON-mode editor save) is parsed into its
+    entries instead of being wrapped as one garbage name that filters nothing
+    (#86661). If the JSON-looking string fails to parse, it falls back to the
+    scalar single-name behavior with a warning — never a silent no-op.
+    """
     if values is None:
         return set()
     if isinstance(values, str):
-        values = [values]
+        stripped = values.strip()
+        if stripped.startswith("["):
+            raw = values
+            parsed = _try_parse_list_literal(stripped)
+            if isinstance(parsed, list):
+                values = parsed
+            else:
+                values = [values]
+                if parsed is None:
+                    logger.warning(
+                        "config value %r looks like a JSON array but failed to parse; "
+                        "treating it as a single literal name (it will likely match "
+                        "nothing). Use a real YAML list or a valid JSON/Python array "
+                        "literal. (#86661)",
+                        raw,
+                    )
+        else:
+            values = [values]
     return {str(v).strip() for v in values if str(v).strip()}
+
+
+def _try_parse_list_literal(text: str):
+    """Parse a list-literal config string, or return None if it is not one.
+
+    Accepts both strict JSON arrays (``'["a","b"]'``) and Python-style
+    single-quoted literals (``"['a','b']"``, see #86661).  ``ast.literal_eval``
+    is safe: it only evaluates literal syntax and never executes code.
+    """
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError:
+        pass
+    try:
+        return ast.literal_eval(text)
+    except (ValueError, SyntaxError, TypeError):
+        return None
 
 
 # ── External skills directories ──────────────────────────────────────────

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -19265,6 +19265,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             enabled_toolsets = sorted(_get_platform_tools(user_config, platform_key))
             agent_cfg = user_config.get("agent") or {}
             disabled_toolsets = agent_cfg.get("disabled_toolsets") or None
+            if disabled_toolsets:
+                # Normalize JSON-array strings (config set / JSON editor saves) so
+                # downstream `in` checks see real names, not chars (#86661).
+                from agent.skill_utils import _normalize_string_set
+
+                disabled_toolsets = _normalize_string_set(disabled_toolsets) or None
 
             pr = self._provider_routing
             max_iterations = _current_max_iterations()
@@ -24063,6 +24069,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         enabled_toolsets = sorted(_get_platform_tools(user_config, platform_key))
         agent_cfg_local = user_config.get("agent") or {}
         disabled_toolsets = agent_cfg_local.get("disabled_toolsets") or None
+        if disabled_toolsets:
+            # Normalize JSON-array strings (config set / JSON editor saves) so
+            # downstream `in` checks see real names, not chars (#86661).
+            from agent.skill_utils import _normalize_string_set
+
+            disabled_toolsets = _normalize_string_set(disabled_toolsets) or None
 
         display_config = user_config.get("display", {})
         if not isinstance(display_config, dict):

--- a/hermes_cli/skills_config.py
+++ b/hermes_cli/skills_config.py
@@ -29,14 +29,13 @@ def _normalize_skill_names(values) -> Set[str]:
 
     Mirrors ``agent.skill_utils._normalize_string_set``: ``None`` (YAML null)
     means empty, a bare scalar (``disabled: my-skill``) means a single-item
-    list — NOT a set of its characters (#13026).
+    list — NOT a set of its characters (#13026). JSON-array strings
+    (``disabled: '["skill-a"]'``) are parsed into their entries (#86661).
     """
-    if values is None:
-        return set()
-    if isinstance(values, str):
-        values = [values]
+    from agent.skill_utils import _normalize_string_set
+
     try:
-        return {str(v).strip() for v in values if str(v).strip()}
+        return _normalize_string_set(values)
     except TypeError:
         return set()
 

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -2487,7 +2487,13 @@ def _get_platform_tools(
     agent_cfg = config.get("agent") or {}
     disabled_toolsets = agent_cfg.get("disabled_toolsets") or []
     if disabled_toolsets:
-        disabled_set = {str(ts) for ts in disabled_toolsets}
+        # Normalize like skills.disabled: a JSON-array string (e.g. written by
+        # `hermes config set` or a JSON-mode editor save) must be parsed into
+        # its entries — iterating a bare str would produce a set of characters
+        # that matches nothing, silently re-enabling every toolset (#86661).
+        from agent.skill_utils import _normalize_string_set
+
+        disabled_set = _normalize_string_set(disabled_toolsets)
         enabled_toolsets -= disabled_set
 
     # #38798: if this platform was explicitly configured but every toolset name

--- a/tests/agent/test_skill_utils.py
+++ b/tests/agent/test_skill_utils.py
@@ -302,3 +302,69 @@ class TestBOMToleranceSiblingSites:
         assert fm is not None
         assert fm.get("name") == "bp"
 
+
+# ---------------------------------------------------------------------------
+# _normalize_string_set / get_disabled_skill_names — JSON-array strings (#86661)
+# ---------------------------------------------------------------------------
+
+class TestNormalizeStringSetJsonString:
+    """`skills.disabled: '["skill-a","skill-b"]'` must be parsed, not wrapped
+    as a single garbage name that silently filters nothing (#86661)."""
+
+    def test_json_array_string_is_parsed(self):
+        from agent.skill_utils import _normalize_string_set
+
+        assert _normalize_string_set('["skill-a","skill-b"]') == {
+            "skill-a",
+            "skill-b",
+        }
+
+    def test_json_array_string_empty_list(self):
+        from agent.skill_utils import _normalize_string_set
+
+        assert _normalize_string_set("[]") == set()
+
+    def test_json_array_string_single_quote_inner(self):
+        # YAML single-quoted scalar with double-quoted JSON entries
+        from agent.skill_utils import _normalize_string_set
+
+        assert _normalize_string_set("['memory']") == {"memory"}
+
+    def test_bare_scalar_stays_single_name(self):
+        # #13026: scalar means ONE name, never a char set
+        from agent.skill_utils import _normalize_string_set
+
+        assert _normalize_string_set("hidden-skill") == {"hidden-skill"}
+
+    def test_none_and_real_list(self):
+        from agent.skill_utils import _normalize_string_set
+
+        assert _normalize_string_set(None) == set()
+        assert _normalize_string_set(["a", " b "]) == {"a", "b"}
+
+    def test_malformed_json_list_warns_and_falls_back_to_scalar(self, caplog):
+        from agent.skill_utils import _normalize_string_set
+
+        with caplog.at_level("WARNING", logger="agent.skill_utils"):
+            result = _normalize_string_set('["broken')
+        assert result == {'["broken'}
+        assert any("#86661" in r.getMessage() for r in caplog.records)
+
+    def test_get_disabled_skill_names_parses_json_string_config(self, tmp_path, monkeypatch):
+        """End-to-end: a JSON-array string in config.yaml now disables the skills."""
+        from agent import skill_utils
+
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text(
+            """
+skills:
+  disabled: '["hidden-skill","other-skill"]'
+""".strip(),
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        skill_utils._raw_config_cache_clear()
+        assert get_disabled_skill_names() == {"hidden-skill", "other-skill"}
+

--- a/tests/hermes_cli/test_skills_config.py
+++ b/tests/hermes_cli/test_skills_config.py
@@ -21,6 +21,41 @@ class TestGetDisabledSkills:
         assert get_disabled_skills({"skills": None}, platform="telegram") == set()
 
 
+    def test_json_array_string_disabled_is_parsed(self):
+        """``skills.disabled: '["a","b"]'`` (JSON-array string from `hermes
+        config set` or a JSON-mode editor) must filter, not be a dead no-op
+        (#86661)."""
+        from hermes_cli.skills_config import get_disabled_skills
+        config = {"skills": {"disabled": '["skill-a","skill-b"]'}}
+        assert get_disabled_skills(config) == {"skill-a", "skill-b"}
+
+    def test_python_list_literal_string_disabled_is_parsed(self):
+        """``skills.disabled: "['a','b']"`` single-quoted literal also parses."""
+        from hermes_cli.skills_config import get_disabled_skills
+        config = {"skills": {"disabled": "['skill-a','skill-b']"}}
+        assert get_disabled_skills(config) == {"skill-a", "skill-b"}
+
+    def test_empty_json_array_string_disables_nothing(self):
+        from hermes_cli.skills_config import get_disabled_skills
+        config = {"skills": {"disabled": "[]"}}
+        assert get_disabled_skills(config) == set()
+
+    def test_json_array_string_platform_disabled_is_parsed(self):
+        from hermes_cli.skills_config import get_disabled_skills
+        config = {
+            "skills": {
+                "platform_disabled": {"telegram": '["tg-skill"]'},
+            }
+        }
+        assert get_disabled_skills(config, platform="telegram") == {"tg-skill"}
+
+    def test_bare_scalar_stays_single_name(self):
+        """#13026: ``disabled: my-skill`` is one name, not a char set."""
+        from hermes_cli.skills_config import get_disabled_skills
+        config = {"skills": {"disabled": "hidden-skill"}}
+        assert get_disabled_skills(config) == {"hidden-skill"}
+
+
 
 
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_tools_config.py
+++ b/tests/hermes_cli/test_tools_config.py
@@ -132,6 +132,42 @@ def test_discord_toolsets_do_not_leak_to_other_platforms():
     assert "discord_admin" not in enabled
 
 
+def test_disabled_toolsets_json_array_string_is_parsed():
+    """agent.disabled_toolsets as a JSON-array string ('["memory"]', as written
+    by `hermes config set` or a JSON-mode editor) must disable the toolset.
+    Before #86661 the string was iterated into a set of characters, matching
+    nothing, so the toolset stayed enabled."""
+    config = {
+        "agent": {"disabled_toolsets": '["memory"]'},
+        "platform_toolsets": {"cli": ["memory", "file"]},
+    }
+    enabled = _get_platform_tools(config, "cli")
+    assert "memory" not in enabled
+
+
+def test_disabled_toolsets_python_list_literal_string_is_parsed():
+    """The issue's exact repro: disabled_toolsets: "['memory']" (single-quoted
+    Python list literal) must also disable the toolset."""
+    config = {
+        "agent": {"disabled_toolsets": "['memory']"},
+        "platform_toolsets": {"cli": ["memory", "file"]},
+    }
+    enabled = _get_platform_tools(config, "cli")
+    assert "memory" not in enabled
+
+
+def test_disabled_toolsets_bare_scalar_disables_one_toolset():
+    """A scalar value disables exactly that one toolset (#13026 semantics) —
+    never a set of its characters."""
+    config = {
+        "agent": {"disabled_toolsets": "memory"},
+        "platform_toolsets": {"cli": ["memory", "file"]},
+    }
+    enabled = _get_platform_tools(config, "cli")
+    assert "memory" not in enabled
+    assert "file" in enabled
+
+
 
 
 


### PR DESCRIPTION
## Summary

`skills.disabled` and `agent.disabled_toolsets` accepted a JSON-array string
(e.g. `disabled: '["skill-a","skill-b"]'` or `disabled_toolsets: "['memory']"`
in config.yaml) and silently filtered nothing — a curated-looking disabled
list could be completely dead for months with zero diagnostics (#86661).

## Root causes (all read paths fixed here)

1. **`agent/skill_utils.py::_normalize_string_set`** wrapped any `str` into a
   single-element list, so a quoted JSON array became one garbage name and no
   skill was ever disabled. The single-scalar-means-one-name behavior is
   correct (#13026) — but a string that is clearly a list literal should be
   parsed, not wrapped.
2. **`hermes_cli/skills_config.py::_normalize_skill_names`** (the CLI mirror
   used by `hermes skills` / `get_disabled_skills`) had the same bug.
3. **`hermes_cli/tools_config.py::_get_platform_tools`** iterated a string
   value into a set of characters, which matches no toolset; `"[]"` is truthy,
   so even the empty-string form passed the `if disabled_toolsets:` guard.
4. **`gateway/run.py`** (2 sites) forwarded the raw string to `AIAgent`,
   where `memory_manager` / `tool_executor` do `in`-membership checks on it.

## Fix

One shared helper (`_normalize_string_set`) now normalizes list-shaped strings
in every read path:

- Strict JSON arrays (`'["a","b"]'`) parse via `json.loads`.
- Python-style single-quoted literals (`"['memory']"` — the issue's exact
  repro, common from hand-edited YAML) parse via `ast.literal_eval` fallback
  (safe: literals only, no code execution).
- A list-looking string that fails to parse **logs a warning** instead of
  silently no-opping.
- Bare scalars still mean exactly one name (#13026 semantics preserved);
  real YAML lists pass through unchanged.

## Tests

- `tests/agent/test_skill_utils.py` — `_normalize_string_set` JSON/single-quote
  parsing, empty list, scalar fallback, malformed-list warning, and an
  end-to-end `get_disabled_skill_names()` test with a JSON-string config.
- `tests/hermes_cli/test_skills_config.py` — `get_disabled_skills` parses
  JSON-array strings for `disabled` and `platform_disabled`.
- `tests/hermes_cli/test_tools_config.py` — `_get_platform_tools` excludes the
  toolset for the JSON-array string, the single-quoted literal, and bare
  scalar forms; real-list behavior unchanged.

```
$ pytest tests/agent/test_skill_utils.py tests/hermes_cli/test_skills_config.py \
         tests/hermes_cli/test_tools_config.py \
         tests/agent/test_prompt_builder.py \
         tests/gateway/test_stacked_skill_platform_disabled.py \
         tests/gateway/test_unavailable_skill_hint.py \
         tests/tools/test_skills_tool_discovery_cache.py \
         tests/hermes_cli/test_skills_hub.py \
         tests/cli/test_cli_tools_command.py tests/hermes_cli/test_commands.py
190 passed
```

## Relationship to #44226

PR #44226 (`fix(cli): coerce JSON-array and comma-separated strings to lists
in 'config set'`) fixes the **write** path — `hermes config set` will store a
real YAML list. This PR fixes the **read** path, so any JSON-string form
already in config files (hand-edits, JSON-mode editor saves, or values written
before #44226 lands) is parsed correctly instead of being a silent no-op. The
two are complementary; both are needed for full coverage.

Closes #86661
