### PR TITLE
fix(memory): handle JSON null action/target in memory tool handler

### DIFF
--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -1233,8 +1233,8 @@ registry.register(
     toolset="memory",
     schema=MEMORY_SCHEMA,
     handler=lambda args, **kw: memory_tool(
-        action=args.get("action", ""),
-        target=args.get("target", "memory"),
+        action=args.get("action") or "",
+        target=args.get("target") or "memory",
         content=args.get("content"),
         old_text=args.get("old_text"),
         operations=args.get("operations"),


### PR DESCRIPTION
## Bug Description

The memory tool returns `"Unknown action None"` when LLM backends send `action: null` (JSON null) instead of omitting the field entirely. This prevents memory CRUD operations from working with certain model providers.

Fixes #86703

## Root Cause

In `tools/memory_tool.py` line 1254, the handler uses:

```python
action=args.get("action", ""),
```

When an LLM backend sends `action: null`, the key EXISTS in the args dict with value `None`. The default `""` in `dict.get(key, default)` only applies when the key is **missing**, so `args.get("action", "")` returns `None` instead of `""`.

This `None` value falls through all action checks (`"add"`, `"replace"`, `"remove"`) and triggers the error: `"Unknown action None"`.

## Fix

Changed two lines in the registry handler at `tools/memory_tool.py` lines 1254-1255:

```python
action=args.get("action") or "",
target=args.get("target") or "memory",
```

The `or` operator handles all three cases: key missing, key is `null`, or key is empty string. This is the standard Python idiom for this pattern.

## How to Verify

1. Confirm the diff contains only the two `or` operator changes in `tools/memory_tool.py`
2. Verify no other files are modified
3. The fix is minimal and does not change any logic — only null-safety

## Test Plan

- [x] Diff reviewed — only 2 lines changed, both null-safety fixes
- [x] No other files modified — minimal blast radius
- [x] Fix follows existing Python conventions (`or` for null-coalescing)
- [x] No API surface changes — backward compatible

## Risk Assessment

**Low** — This is a two-line defensive fix that only affects null handling in the memory tool handler. It does not change any logic, add new features, or modify any other files. The `or` operator pattern is standard Python and handles the exact same cases as before, plus the previously broken `null` case.
