### PR TITLE
fix(approval): collapse whitespace before matching approvals.deny globs

### DIFF
--- a/tests/tools/test_approval_deny_rules.py
+++ b/tests/tools/test_approval_deny_rules.py
@@ -56,6 +56,35 @@ class TestMatchUserDenyRule:
         deny_config(["git push --force*"])
         assert mod._match_user_deny_rule('git pu""sh --force origin main') is not None
 
+    def test_whitespace_variants_still_match(self, deny_config):
+        """Repeated spaces / tabs can't sidestep a single-space deny glob.
+
+        fnmatch has no "one-or-more whitespace" metacharacter, so a deny
+        rule written with literal single spaces was previously bypassed by a
+        double space or a tab between arguments (#86568). Both the candidate
+        and the glob are whitespace-collapsed before matching, and the
+        ORIGINAL user-written glob is still returned.
+        """
+        deny_config(["git push --force origin main", "gh repo delete *"])
+        cases = {
+            "git push --force origin main": "git push --force origin main",
+            "git  push --force origin main": "git push --force origin main",
+            "git\tpush --force origin main": "git push --force origin main",
+            "git   push --force origin main": "git push --force origin main",
+            "git\tpush\t--force origin main": "git push --force origin main",
+            " git  push --force origin main ": "git push --force origin main",
+            "GIT  PUSH --FORCE origin main": "git push --force origin main",
+            "gh  repo  delete someorg/somerepo": "gh repo delete *",
+        }
+        for variant, expected in cases.items():
+            assert mod._match_user_deny_rule(variant) == expected, variant
+
+    def test_whitespace_normalization_no_false_positive(self, deny_config):
+        """Whitespace collapse must not broaden a rule beyond its glob."""
+        deny_config(["git push --force origin main"])
+        assert mod._match_user_deny_rule("git status") is None
+        assert mod._match_user_deny_rule("git  push --force origin main2") is None
+
 
 class TestDenyBeatsYolo:
     def test_deny_blocks_under_yolo_env(self, deny_config, clean_env, monkeypatch):

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -607,7 +607,10 @@ def _match_user_deny_rule(command: str) -> str | None:
     Matching is case-insensitive and runs over the same normalized /
     deobfuscated command variants the dangerous-pattern detector uses, so
     quoting tricks (``r\\m``, ``git st""atus``) can't sidestep a rule any
-    more easily than they sidestep detection. Empty/absent list = no-op.
+    more easily than they sidestep detection. Whitespace runs are collapsed
+    to a single space on both the candidate and the glob before matching, so
+    a rule with single spaces also matches double-spaced / tab-separated
+    variants. Empty/absent list = no-op.
     """
     try:
         deny_patterns = _get_approval_config().get("deny") or []
@@ -619,10 +622,17 @@ def _match_user_deny_rule(command: str) -> str | None:
              if isinstance(p, str) and p.strip()]
     if not globs:
         return None
+    # Collapse whitespace runs to a single space on BOTH the candidate and
+    # each glob before matching. fnmatch has no "one-or-more whitespace"
+    # metacharacter, so a rule written with literal single spaces (`git push
+    # --force origin main`) is otherwise sidestepped by `git  push` (double
+    # space) or a tab between arguments (#86568). The ORIGINAL pattern string
+    # is still returned below so the block message echoes the user's rule.
+    normalized_globs = [" ".join(p.lower().split()) for p in globs]
     for command_variant in _command_detection_variants(command):
-        candidate = command_variant.lower().strip()
-        for pattern in globs:
-            if fnmatch.fnmatchcase(candidate, pattern.lower()):
+        candidate = " ".join(command_variant.lower().split())
+        for pattern, pattern_normalized in zip(globs, normalized_globs):
+            if fnmatch.fnmatchcase(candidate, pattern_normalized):
                 return pattern
     return None
 


### PR DESCRIPTION
## Problem

`approvals.deny` globs are the user-editable "never run this, even under yolo" floor. They are matched with `fnmatch.fnmatchcase`, which has **no metacharacter for "one or more whitespace"**. A rule written with literal single spaces (`git push --force origin main`) is therefore sidestepped by inserting a second space or a tab between arguments:

```text
git  push --force origin main   # double space → NOT blocked
git	push --force origin main    # tab          → NOT blocked
```

The deobfuscation pipeline (`_normalize_command_for_detection`) already collapses quote-splitting, ANSI sequences, `\`-escapes, empty-string literals, and `${IFS}`, but never whitespace runs — so the deny floor (evaluated ahead of `--yolo` / `/yolo` / `approvals.mode=off`) is bypassable for dangerous or irreversible commands.

Fixes #86568.

## Fix

Collapse whitespace runs to a single space on **both** the candidate and each glob before `fnmatch.fnmatchcase` in `_match_user_deny_rule`, and return the *original* pattern string so the block message still echoes exactly what the user configured:

```python
normalized_globs = [" ".join(p.lower().split()) for p in globs]
for command_variant in _command_detection_variants(command):
    candidate = " ".join(command_variant.lower().split())
    for pattern, pattern_normalized in zip(globs, normalized_globs):
        if fnmatch.fnmatchcase(candidate, pattern_normalized):
            return pattern
```

The hardline floor is **unaffected** — its patterns already use `\s+` / `\s*` / `\b` and are whitespace-robust. The docstring now states that deny globs are evaluated against whitespace-collapsed strings.

## Tests

Two tests added in `tests/tools/test_approval_deny_rules.py`:

- `test_whitespace_variants_still_match` — 8 variants (double/triple space, tabs, mixed, leading/trailing whitespace, uppercase, `gh repo delete`) all match their single-space globs, and the original glob string is returned.
- `test_whitespace_normalization_no_false_positive` — whitespace collapse does not broaden a rule beyond its glob.

Full approval test surface passes (`test_approval_deny_rules.py`, `test_approvals_test.py`, `test_approval_transport.py`, `test_approval_config_readonly.py`).
