### PR TITLE
fix(desktop): keep launching when the setuid sandbox helper cannot be configured

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -7110,11 +7110,66 @@ def _desktop_linux_needs_no_sandbox() -> bool:
         return False
     if hasattr(os, "geteuid") and os.geteuid() == 0:
         return False
+    return _linux_restricts_unprivileged_userns()
+
+
+def _linux_restricts_unprivileged_userns() -> bool:
+    """Return True when AppArmor's sysctl blocks unprivileged user namespaces.
+
+    Ubuntu 23.10+ only. Absence of the sysctl does NOT prove the userns sandbox
+    works - use _linux_userns_sandbox_available() for that.
+    """
+    if sys.platform != "linux":
+        return False
     try:
         with open("/proc/sys/kernel/apparmor_restrict_unprivileged_userns", encoding="utf-8") as f:
             return f.read().strip() == "1"
     except OSError:
         return False
+
+
+_CLONE_NEWUSER = 0x10000000
+
+
+def _linux_userns_sandbox_available() -> bool:
+    """Return True when this process can actually create a user namespace.
+
+    Chromium consults the setuid ``chrome-sandbox`` helper only when the
+    unprivileged user-namespace sandbox is unavailable, and it then *aborts*
+    (LOG(FATAL) in setuid_sandbox_host.cc) rather than dropping the sandbox if
+    the helper is not root:root 4755. So before continuing past a failed
+    fixup we must know the namespace sandbox really works. AppArmor's sysctl
+    being absent does not show that: ``kernel.unprivileged_userns_clone=0``
+    (Debian, Arch linux-hardened), ``user.max_user_namespaces=0``, a kernel
+    without CONFIG_USER_NS, and container seccomp policy all block it too.
+
+    Mirror Chromium's own probe (sandbox::Credentials::CanCreateProcessInNewUserNS):
+    fork and try ``unshare(CLONE_NEWUSER)``. Fail closed if we cannot probe.
+    """
+    if sys.platform != "linux":
+        return False
+    if _linux_restricts_unprivileged_userns():
+        return False
+
+    import ctypes
+
+    try:
+        # Load libc before forking so the child only makes one syscall.
+        libc = ctypes.CDLL("libc.so.6", use_errno=True)
+        pid = os.fork()
+    except (OSError, AttributeError):
+        return False
+    if pid == 0:
+        try:
+            rc = libc.unshare(_CLONE_NEWUSER)
+        except BaseException:
+            os._exit(1)
+        os._exit(0 if rc == 0 else 1)
+    try:
+        _, status = os.waitpid(pid, 0)
+    except OSError:
+        return False
+    return os.WIFEXITED(status) and os.WEXITSTATUS(status) == 0
 
 
 def _desktop_linux_sandbox_helper_is_regular_file(packaged_executable: Path) -> bool:
@@ -7530,10 +7585,21 @@ def cmd_gui(args: argparse.Namespace):
 
     launch_command = [str(packaged_executable)]
     if not _desktop_linux_sandbox_fixup(packaged_executable):
-        if _desktop_linux_needs_no_sandbox() and _desktop_linux_sandbox_helper_is_regular_file(packaged_executable):
+        helper_present = _desktop_linux_sandbox_helper_is_regular_file(packaged_executable)
+        if _desktop_linux_needs_no_sandbox() and helper_present:
             print("⚠ Falling back to --no-sandbox because this Linux host restricts unprivileged user namespaces and the Electron sandbox helper could not be configured.")
             launch_command.append("--no-sandbox")
+        # No root guard here, unlike _desktop_linux_needs_no_sandbox(): that
+        # guard exists because root + --no-sandbox is the risky combination,
+        # and this branch keeps Chromium's sandbox.
+        elif helper_present and _linux_userns_sandbox_available():
+            print("⚠ Continuing with Chromium's unprivileged user-namespace sandbox: the setuid helper could not be configured from this launch context, and this host does not restrict user namespaces.")
         else:
+            if helper_present:
+                sandbox = packaged_executable.parent / "chrome-sandbox"
+                print("✗ Electron's setuid sandbox helper is not configured and this host does not")
+                print("  allow unprivileged user namespaces, so Chromium would abort at startup.")
+                print(f"  Fix with: sudo chown root:root {sandbox} && sudo chmod 4755 {sandbox}")
             sys.exit(1)
 
     launch_command.extend(config_electron_flags)

--- a/tests/hermes_cli/test_gui_command.py
+++ b/tests/hermes_cli/test_gui_command.py
@@ -779,3 +779,144 @@ def test_gui_password_store_bridge_is_linux_only(tmp_path, monkeypatch):
     mock_detect.assert_not_called()
     launch_env = mock_run.call_args_list[1].kwargs["env"]
     assert "HERMES_DESKTOP_PASSWORD_STORE" not in launch_env
+
+
+# ── Linux sandbox-helper gate ─────────────────────────────────────────
+# Restores the fixup-failure coverage pruned in 6b81590c5 and covers the
+# userns-sandbox continuation added for non-TTY launch contexts.
+
+
+@pytest.mark.skipif(sys.platform != "linux", reason="Linux sandbox gate")
+def test_gui_linux_falls_back_to_no_sandbox_when_userns_is_restricted(tmp_path, monkeypatch):
+    root = _make_desktop_tree(tmp_path)
+    monkeypatch.setattr(cli_main, "PROJECT_ROOT", root)
+    packaged_exe = _make_packaged_executable(root, monkeypatch)
+    (packaged_exe.parent / "chrome-sandbox").write_text("", encoding="utf-8")
+
+    launch_ok = subprocess.CompletedProcess([str(packaged_exe), "--no-sandbox"], 0)
+
+    with patch("hermes_cli.main._desktop_linux_sandbox_fixup", return_value=False), \
+         patch("hermes_cli.main._desktop_linux_needs_no_sandbox", return_value=True), \
+         patch("hermes_cli.main._desktop_macos_relaunchable_fixup"), \
+         patch("hermes_cli.config.load_config", return_value={}), \
+         patch("hermes_cli.linux_desktop_entry.install_desktop_entry", return_value=None), \
+         patch("hermes_cli.main._detect_linux_password_store"), \
+         patch("hermes_cli.main.subprocess.run", return_value=launch_ok) as mock_run, \
+         pytest.raises(SystemExit) as exc:
+        cli_main.cmd_gui(_ns(skip_build=True))
+
+    assert exc.value.code == 0
+    mock_run.assert_called_once()
+    assert mock_run.call_args.args[0] == [str(packaged_exe), "--no-sandbox"]
+
+
+@pytest.mark.skipif(sys.platform != "linux", reason="Linux sandbox gate")
+def test_gui_continues_with_userns_sandbox_when_helper_unconfigurable(tmp_path, monkeypatch):
+    root = _make_desktop_tree(tmp_path)
+    monkeypatch.setattr(cli_main, "PROJECT_ROOT", root)
+    packaged_exe = _make_packaged_executable(root, monkeypatch)
+    (packaged_exe.parent / "chrome-sandbox").write_text("", encoding="utf-8")
+
+    launch_ok = subprocess.CompletedProcess([str(packaged_exe)], 0)
+
+    with patch("hermes_cli.main._desktop_linux_sandbox_fixup", return_value=False), \
+         patch("hermes_cli.main._linux_userns_sandbox_available", return_value=True), \
+         patch("hermes_cli.main._desktop_macos_relaunchable_fixup"), \
+         patch("hermes_cli.config.load_config", return_value={}), \
+         patch("hermes_cli.linux_desktop_entry.install_desktop_entry", return_value=None), \
+         patch("hermes_cli.main._detect_linux_password_store"), \
+         patch("hermes_cli.main.subprocess.run", return_value=launch_ok) as mock_run, \
+         pytest.raises(SystemExit) as exc:
+        cli_main.cmd_gui(_ns(skip_build=True))
+
+    assert exc.value.code == 0
+    mock_run.assert_called_once()
+    # Chromium's namespace sandbox needs no flag: the launch command is bare.
+    assert mock_run.call_args.args[0] == [str(packaged_exe)]
+
+
+@pytest.mark.skipif(sys.platform != "linux", reason="Linux sandbox gate")
+def test_gui_linux_exits_when_userns_unavailable_and_helper_unconfigurable(tmp_path, monkeypatch):
+    """linux-hardened / unprivileged_userns_clone=0: neither sandbox works."""
+    root = _make_desktop_tree(tmp_path)
+    monkeypatch.setattr(cli_main, "PROJECT_ROOT", root)
+    packaged_exe = _make_packaged_executable(root, monkeypatch)
+    (packaged_exe.parent / "chrome-sandbox").write_text("", encoding="utf-8")
+
+    with patch("hermes_cli.main._desktop_linux_sandbox_fixup", return_value=False), \
+         patch("hermes_cli.main._linux_userns_sandbox_available", return_value=False), \
+         patch("hermes_cli.main._desktop_macos_relaunchable_fixup"), \
+         patch("hermes_cli.config.load_config", return_value={}), \
+         patch("hermes_cli.linux_desktop_entry.install_desktop_entry", return_value=None), \
+         patch("hermes_cli.main._detect_linux_password_store"), \
+         patch("hermes_cli.main.subprocess.run") as mock_run, \
+         pytest.raises(SystemExit) as exc:
+        cli_main.cmd_gui(_ns(skip_build=True))
+
+    assert exc.value.code == 1
+    mock_run.assert_not_called()
+
+
+@pytest.mark.skipif(sys.platform != "linux", reason="Linux sandbox gate")
+def test_gui_linux_exits_when_sandbox_helper_missing_even_with_userns(tmp_path, monkeypatch):
+    root = _make_desktop_tree(tmp_path)
+    monkeypatch.setattr(cli_main, "PROJECT_ROOT", root)
+    packaged_exe = _make_packaged_executable(root, monkeypatch)
+    (packaged_exe.parent / "chrome-sandbox").unlink()
+
+    with patch("hermes_cli.main._desktop_linux_sandbox_fixup", return_value=False), \
+         patch("hermes_cli.main._linux_userns_sandbox_available", return_value=True), \
+         patch("hermes_cli.main._desktop_macos_relaunchable_fixup"), \
+         patch("hermes_cli.config.load_config", return_value={}), \
+         patch("hermes_cli.linux_desktop_entry.install_desktop_entry", return_value=None), \
+         patch("hermes_cli.main._detect_linux_password_store"), \
+         patch("hermes_cli.main.subprocess.run") as mock_run, \
+         pytest.raises(SystemExit) as exc:
+        cli_main.cmd_gui(_ns(skip_build=True))
+
+    assert exc.value.code == 1
+    mock_run.assert_not_called()
+
+
+@pytest.mark.skipif(sys.platform != "linux", reason="Linux sandbox gate")
+def test_gui_electron_disable_sandbox_still_wins_on_unrestricted_host(tmp_path, monkeypatch):
+    """The explicit env override must beat the userns continuation."""
+    root = _make_desktop_tree(tmp_path)
+    monkeypatch.setattr(cli_main, "PROJECT_ROOT", root)
+    packaged_exe = _make_packaged_executable(root, monkeypatch)
+    (packaged_exe.parent / "chrome-sandbox").write_text("", encoding="utf-8")
+    monkeypatch.setenv("ELECTRON_DISABLE_SANDBOX", "1")
+    monkeypatch.setattr(cli_main, "_linux_restricts_unprivileged_userns", lambda: False)
+
+    launch_ok = subprocess.CompletedProcess([str(packaged_exe), "--no-sandbox"], 0)
+
+    with patch("hermes_cli.main._desktop_linux_sandbox_fixup", return_value=False), \
+         patch("hermes_cli.main._desktop_macos_relaunchable_fixup"), \
+         patch("hermes_cli.config.load_config", return_value={}), \
+         patch("hermes_cli.linux_desktop_entry.install_desktop_entry", return_value=None), \
+         patch("hermes_cli.main._detect_linux_password_store"), \
+         patch("hermes_cli.main.subprocess.run", return_value=launch_ok) as mock_run, \
+         pytest.raises(SystemExit) as exc:
+        cli_main.cmd_gui(_ns(skip_build=True))
+
+    assert exc.value.code == 0
+    mock_run.assert_called_once()
+    assert "--no-sandbox" in mock_run.call_args.args[0]
+
+
+def test_linux_userns_probe_false_off_linux(monkeypatch):
+    monkeypatch.setattr(cli_main.sys, "platform", "darwin")
+    assert cli_main._linux_userns_sandbox_available() is False
+
+
+def test_linux_userns_probe_skips_fork_when_apparmor_restricted(monkeypatch):
+    monkeypatch.setattr(cli_main, "_linux_restricts_unprivileged_userns", lambda: True)
+    with patch("hermes_cli.main.os.fork", side_effect=AssertionError("must not fork")):
+        assert cli_main._linux_userns_sandbox_available() is False
+
+
+@pytest.mark.skipif(sys.platform != "linux", reason="needs os.fork")
+def test_linux_userns_probe_fails_closed_on_fork_error(monkeypatch):
+    monkeypatch.setattr(cli_main, "_linux_restricts_unprivileged_userns", lambda: False)
+    with patch("hermes_cli.main.os.fork", side_effect=OSError("no fork")):
+        assert cli_main._linux_userns_sandbox_available() is False


### PR DESCRIPTION
## Problem

On Linux hosts where Chromium's unprivileged user-namespace sandbox works, `hermes desktop` fails on every launch whose context has no TTY — the `.desktop` entry (app grid, rofi, etc.) and the post-update detached relaunch. `_desktop_linux_sandbox_fixup` tries `sudo chown/chmod` when `chrome-sandbox` isn't `root:root 4755`; sudo cannot prompt; `cmd_gui` exits 1 with nothing visible, because GUI launches have no stdout. An in-app update rebuild resets the helper to user-owned and `--build-only` returns before the fixup, so nothing re-provisions it — every content-changing update re-manufactures the failure.

## Fix

When the fixup fails, probe whether this process can actually create a user namespace — fork + `unshare(CLONE_NEWUSER)`, mirroring Chromium's own `sandbox::Credentials::CanCreateProcessInNewUserNS` (~3 ms measured) — and if so, warn and continue with Chromium's namespace sandbox instead of exiting. Absence of `apparmor_restrict_unprivileged_userns` is deliberately not treated as evidence: `kernel.unprivileged_userns_clone=0` (Debian, Arch `linux-hardened`), `user.max_user_namespaces=0`, kernels without `CONFIG_USER_NS`, and container seccomp policy all break userns without that sysctl.

The exit arm now prints the exact `sudo chown/chmod` recovery command.

## Why this is safe

Chromium consults the setuid helper only when the userns sandbox is unavailable, and when neither is available it aborts (`LOG(FATAL)` in `setuid_sandbox_host.cc`, exit 133) rather than running unsandboxed. So this change cannot cause an unsandboxed launch; the worst case of a wrong host check is a crash, never a silent sandbox drop. The setuid helper and the userns sandbox are two implementations of the same layer-1 isolation, not two layers.

Unchanged: the `--no-sandbox` fallback for AppArmor-restricted hosts (54ea05991), the `ELECTRON_DISABLE_SANDBOX=1` override (pinned by a new test), root behavior, and the missing/symlink-helper rejection.

## Behavior matrix

| Host | Terminal launch | GUI launch (main) | GUI launch (this PR) |
|---|---|---|---|
| macOS / Windows | no gate | no gate | no gate |
| Ubuntu 23.10+ (AppArmor restricts userns) | sudo prompts once, works | `--no-sandbox` fallback | unchanged |
| Arch/Fedora, userns available | sudo prompts once, works | exit 1, silently | **works, sandboxed** |
| `linux-hardened` / Debian `unprivileged_userns_clone=0` / container | sudo prompts once, works | exit 1 with printed reason | unchanged (probe fails closed) |

One intentional interactive-path change: on userns-capable hosts, declining the sudo prompt in a terminal launch now warns and continues instead of hard-failing, so the helper may stay unprovisioned. Acceptable — the namespace sandbox provides the same layer-1 isolation.

## Testing

- Restores the fixup-failure tests pruned in 6b81590c5 and adds coverage for the new branch: userns continuation, userns-unavailable exit, missing-helper exit, env-override precedence, and probe unit tests (off-linux, AppArmor short-circuit, fail-closed on fork error).
- `tests/hermes_cli/test_gui_command.py`: 34 passed, 5 skipped (26/5 before, with zero tests reaching the changed branch).
- Verified end-to-end on EndeavourOS/Hyprland: the `.desktop` Exec path launched detached with no TTY, sudo failed exactly as in the rofi case, and the app started with sandboxed zygote children while `chrome-sandbox` was user-owned `0755`. One host confirms the mechanism, not a host class — hence the probe.

## History

- 46e513ef5 introduced the gate (closes #37529)
- #51327 routed launcher entries through the CLI so the fixup always runs
- 54ea05991 added the restricted-host `--no-sandbox` fallback
- this closes the remaining quadrant