### PR TITLE
feat(mcp-catalog): add dexi (hosted notes MCP, OAuth 2.1 + DCR)

### DIFF
--- a/optional-mcps/dexi/manifest.yaml
+++ b/optional-mcps/dexi/manifest.yaml
@@ -1,0 +1,35 @@
+# Nous-approved MCP catalog entry.
+# Presence in this directory = approval. Merged via PR review.
+manifest_version: 1
+
+name: dexi
+description: Search, read, and save your Dexi notes — clipped pages, emailed articles, feeds, typed notes (OAuth).
+source: https://dexi.net/mcp/hermes
+
+# Dexi ships a hosted remote MCP server (Streamable HTTP) with native MCP
+# OAuth 2.1 + Dynamic Client Registration (loopback redirects accepted, so
+# Hermes's paste-back flow works on headless hosts). Twelve tools:
+# search_notes, semantic_search, list_notes, get_note, find_similar,
+# list_tags, list_folders, create_note, update_note, delete_note,
+# get_due_reviews, grade_review — all annotated (readOnlyHint /
+# destructiveHint). Small enough to enable in full.
+transport:
+  type: http
+  url: https://mcp.dexi.net/mcp
+
+auth:
+  type: oauth
+  # Native MCP OAuth (case 1). Hermes registers itself; the user approves on
+  # Dexi's consent page, where the connection can be restricted to one
+  # folder or tag.
+
+post_install: |
+  On first connection, Hermes prints an authorize URL (and opens a browser
+  when it can). Sign in to Dexi and approve — you can restrict the
+  connection to a single folder or tag on that page. On a headless server,
+  open the URL elsewhere, approve, and paste the redirect URL back.
+  After auth, restart your Hermes session so the dexi tools are loaded.
+
+  Try: "Search my Dexi notes for everything about vector databases."
+  Dexi also ships a memory-provider plugin (auto-recall before each turn):
+  https://github.com/dexi/hermes-plugin


### PR DESCRIPTION
## What does this PR do?

Adds a catalog entry for **Dexi** (`optional-mcps/dexi/manifest.yaml`) — a hosted notes app whose remote MCP server (`https://mcp.dexi.net/mcp`, Streamable HTTP) speaks native MCP OAuth 2.1 with Dynamic Client Registration. Same shape as the `linear` and `comfy-cloud` entries: nothing to install locally, Hermes's `mcp_oauth_manager` handles discovery/PKCE/refresh, and the server accepts loopback redirect URIs so the paste-back flow works on headless hosts.

The server exposes twelve annotated tools (`readOnlyHint`/`destructiveHint`) over the user's notes library — clipped web pages, emailed articles, RSS entries, typed notes: `search_notes`, `semantic_search`, `list_notes`, `get_note`, `find_similar`, `list_tags`, `list_folders`, `create_note`, `update_note`, `delete_note`, `get_due_reviews`, `grade_review`. Small enough to enable in full (no `tools.default_enabled` curation needed). Users can restrict a connection to one folder or tag on the consent page.

Disclosure: I'm the maintainer of Dexi. Server docs: https://docs.dexi.net/mcp/overview · Hermes setup page: https://dexi.net/mcp/hermes · The server is also listed in the official MCP Registry (`net.dexi/mcp`) and Smithery.

## Related Issue

N/A (catalog addition).

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `optional-mcps/dexi/manifest.yaml` — new catalog entry (http transport, native OAuth, `post_install` guidance incl. headless paste-back).

## How to Test

1. `hermes mcp catalog` — `dexi` is listed as available.
2. `hermes mcp install dexi` (or toggle it in `hermes mcp picker`), then start a session: Hermes prints the authorize URL / opens the browser; sign in to Dexi (free account at https://app.dexi.net) and approve.
3. Ask: "What did I save in Dexi this week?" — the agent calls `mcp_dexi_list_notes`.
4. `pytest tests/hermes_cli/test_mcp_catalog.py -q` — the shipped-manifest contract tests pass (21 passed).

Tested on macOS 15 with an editable install of `main` (`hermes-agent[mcp]`, mcp 1.28.1): DCR + PKCE + loopback callback completed against the live server, tools listed and callable.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass — the catalog suite; the manifest is data-only
- [x] I've added tests for my changes — N/A, covered by the existing shipped-manifest contract tests
- [x] I've tested on my platform: macOS 15

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A (catalog entries are self-describing; user docs list the catalog dynamically)
- [x] I've updated `cli-config.yaml.example` — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` — N/A
- [x] I've considered cross-platform impact — N/A (http transport, no local process)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
