### PR TITLE
fix(desktop): scope custom-endpoint writes to the child profile (#84451)

### DIFF
--- a/apps/desktop/src/hermes.ts
+++ b/apps/desktop/src/hermes.ts
@@ -922,7 +922,9 @@ export function saveCustomEndpoint(endpoint: CustomEndpointUpdate): Promise<Cust
     ...profileScoped(),
     path: '/api/providers/custom-endpoints',
     method: 'POST',
-    body: endpoint
+    // Carry the profile in the body too, so the server scopes the write to the
+    // child profile regardless of backend pooling (issue #84451).
+    body: { ...endpoint, ...profileScoped() }
   })
 }
 

--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -190,6 +190,10 @@ export interface CustomEndpointUpdate {
   model: string
   models?: string[]
   name: string
+  /** The child profile this write targets — the server scopes the write to it
+   *  (issue #84451: a child-profile endpoint must land in the child's
+   *  config.yaml, not Default). */
+  profile?: string
 }
 
 export interface CustomEndpointValidationResponse {

--- a/hermes_cli/web_models.py
+++ b/hermes_cli/web_models.py
@@ -60,6 +60,11 @@ class CustomEndpointUpdate(BaseModel):
     discover_models: bool = True
     make_default: bool = False
     models: Optional[List[str]] = None
+    # Explicit body profile beats the query param injected by the global
+    # dashboard profile switcher (same precedence as other scoped writes) —
+    # issue #84451: a custom endpoint written for a child profile must land
+    # in that profile's config.yaml, not Default.
+    profile: Optional[str] = None
 
 
 class MessagingPlatformUpdate(BaseModel):

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -7582,9 +7582,14 @@ def list_custom_endpoints(profile: Optional[str] = None):
 
 @app.post("/api/providers/custom-endpoints")
 def upsert_custom_endpoint(body: CustomEndpointUpdate, profile: Optional[str] = None):
-    """Create or update a v12+ ``providers`` custom endpoint entry."""
+    """Create or update a v12+ ``providers`` custom endpoint entry.
+
+    The explicit body ``profile`` beats the query param (issue #84451): a
+    custom endpoint written for a child profile lands in that profile's
+    config.yaml, not the Default profile's."""
+    effective_profile = body.profile or profile
     try:
-        with _config_profile_scope(profile):
+        with _config_profile_scope(effective_profile):
             cfg = load_config()
             endpoint_id, _entry = _write_custom_endpoint(cfg, body)
             save_config(cfg)

--- a/tests/hermes_cli/test_web_server_custom_endpoints_profiles.py
+++ b/tests/hermes_cli/test_web_server_custom_endpoints_profiles.py
@@ -1,0 +1,153 @@
+"""Regression test for upstream issue #84451.
+
+A custom provider endpoint configured for a CHILD profile must land in that
+profile's config.yaml, be listed under that profile, and leave the Default
+profile unchanged. These tests pin the profile-scoping of
+/api/providers/custom-endpoints (POST upsert + GET list + activate) to a
+named child profile.
+"""
+import pytest
+import yaml
+
+
+@pytest.fixture
+def isolated_profiles(tmp_path, monkeypatch, _isolate_hermes_home):
+    """Isolated default home + one named profile, each with config + .env."""
+    from hermes_constants import get_hermes_home
+    from hermes_cli import profiles
+
+    default_home = get_hermes_home()
+    profiles_root = default_home / "profiles"
+    worker_home = profiles_root / "worker_beta"
+    for home in (default_home, worker_home):
+        home.mkdir(parents=True, exist_ok=True)
+        (home / "config.yaml").write_text("{}\n", encoding="utf-8")
+    (worker_home / ".env").write_text("", encoding="utf-8")
+
+    monkeypatch.setattr(profiles, "_get_default_hermes_home", lambda: default_home)
+    monkeypatch.setattr(profiles, "_get_profiles_root", lambda: profiles_root)
+    return {"default": default_home, "worker_beta": worker_home}
+
+
+@pytest.fixture
+def client(monkeypatch, isolated_profiles):
+    try:
+        from starlette.testclient import TestClient
+    except ImportError:
+        pytest.skip("fastapi/starlette not installed")
+
+    import hermes_state
+    from hermes_constants import get_hermes_home
+    from hermes_cli.web_server import app, _SESSION_HEADER_NAME, _SESSION_TOKEN
+
+    monkeypatch.setattr(hermes_state, "DEFAULT_DB_PATH", get_hermes_home() / "state.db")
+    c = TestClient(app)
+    c.headers[_SESSION_HEADER_NAME] = _SESSION_TOKEN
+    return c
+
+
+def _cfg(home):
+    return yaml.safe_load((home / "config.yaml").read_text()) or {}
+
+
+def _providers(home):
+    providers = _cfg(home).get("providers")
+    return providers if isinstance(providers, dict) else {}
+
+
+_BODY = {
+    "name": "Worker Endpoint",
+    "base_url": "http://127.0.0.1:9999/v1",
+    "model": "worker-model",
+}
+
+
+def test_custom_endpoint_written_for_child_lands_in_child(client, isolated_profiles):
+    """POST ?profile=worker_beta must write the endpoint into worker_beta's
+    config.yaml, not the default profile's."""
+    resp = client.post(
+        "/api/providers/custom-endpoints?profile=worker_beta",
+        json=dict(_BODY),
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    endpoint_id = body.get("id")
+    assert endpoint_id
+
+    # The endpoint landed in the CHILD profile.
+    child_providers = _providers(isolated_profiles["worker_beta"])
+    assert endpoint_id in child_providers, \
+        f"endpoint {endpoint_id} not in child config: {child_providers}"
+    assert child_providers[endpoint_id]["base_url"] == "http://127.0.0.1:9999/v1"
+
+    # The DEFAULT profile's config is untouched.
+    default_providers = _providers(isolated_profiles["default"])
+    assert endpoint_id not in default_providers, \
+        f"endpoint leaked into Default: {default_providers}"
+
+
+def test_custom_endpoint_body_profile_scopes_write(client, isolated_profiles):
+    """#84451: an explicit body ``profile`` scopes the write even with no
+    query param (the desktop carries the child profile in the body)."""
+    resp = client.post(
+        "/api/providers/custom-endpoints",
+        json={**_BODY, "profile": "worker_beta"},
+    )
+    assert resp.status_code == 200, resp.text
+    endpoint_id = resp.json()["id"]
+    assert endpoint_id in _providers(isolated_profiles["worker_beta"])
+    assert endpoint_id not in _providers(isolated_profiles["default"])
+
+
+def test_body_profile_beats_query_profile(client, isolated_profiles):
+    """The explicit body profile wins over the query param (the repo's
+    scoped-write precedence: MessagingPlatformUpdate et al.)."""
+    resp = client.post(
+        "/api/providers/custom-endpoints?profile=default",
+        json={**_BODY, "profile": "worker_beta"},
+    )
+    assert resp.status_code == 200, resp.text
+    endpoint_id = resp.json()["id"]
+    assert endpoint_id in _providers(isolated_profiles["worker_beta"])
+    assert endpoint_id not in _providers(isolated_profiles["default"])
+
+
+def test_custom_endpoint_list_scoped_to_child(client, isolated_profiles):
+    """GET ?profile=worker_beta lists the child's endpoint; Default's list
+    stays empty."""
+    client.post("/api/providers/custom-endpoints?profile=worker_beta",
+                json=dict(_BODY))
+    listed = client.get(
+        "/api/providers/custom-endpoints?profile=worker_beta").json()
+    child_ids = [e["id"] for e in listed.get("endpoints", [])]
+    assert "worker-endpoint" in child_ids
+
+    default_listed = client.get(
+        "/api/providers/custom-endpoints?profile=default").json()
+    default_ids = [e["id"] for e in default_listed.get("endpoints", [])]
+    assert "worker-endpoint" not in default_ids
+
+
+def test_no_profile_writes_to_default_unchanged(client, isolated_profiles):
+    """Single-profile behavior is unchanged: no profile -> Default home."""
+    resp = client.post("/api/providers/custom-endpoints", json=dict(_BODY))
+    assert resp.status_code == 200, resp.text
+    endpoint_id = resp.json()["id"]
+    assert endpoint_id in _providers(isolated_profiles["default"])
+    assert endpoint_id not in _providers(isolated_profiles["worker_beta"])
+
+
+def test_activate_scoped_to_child(client, isolated_profiles):
+    """The activate path also honors the child profile: it sets the child's
+    model.provider, not Default's."""
+    client.post("/api/providers/custom-endpoints?profile=worker_beta",
+                json=dict(_BODY))
+    resp = client.post(
+        "/api/providers/custom-endpoints/worker-endpoint/activate"
+        "?profile=worker_beta")
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["ok"] is True
+    child_model = _cfg(isolated_profiles["worker_beta"]).get("model", {})
+    assert child_model.get("provider") == "worker-endpoint"
+    default_model = _cfg(isolated_profiles["default"]).get("model", {})
+    assert default_model.get("provider") != "worker-endpoint"


### PR DESCRIPTION
## What & why

Fixes #84451. A custom endpoint provider configured from a child profile's settings was written to the **Default** profile's config.yaml instead of the active child profile — the child couldn't use it, and the Default profile unexpectedly gained (and applied) a provider it never asked for.

**Root cause:** `POST /api/providers/custom-endpoints` scoped the write via `_config_profile_scope(profile)` where `profile` came only from the query param. The desktop's `saveCustomEndpoint` carried the active profile in the request `profileScoped()` envelope, which did not reach the body, so under backend pooling the write fell back to Default.

## What changed

- `hermes_cli/web_models.py` — `CustomEndpointUpdate` gains an optional `profile` field.
- `hermes_cli/web_server.py` — `upsert_custom_endpoint` computes `effective_profile = body.profile or profile` (body beats query, the repo's scoped-write precedence) and passes that to `_config_profile_scope`.
- `apps/desktop/src/hermes.ts` + `types/hermes.ts` — `saveCustomEndpoint` spreads the profile into the request body so the write is scoped regardless of backend pooling.
- NEW `tests/hermes_cli/test_web_server_custom_endpoints_profiles.py` — regression coverage.

## Verification

- 6 new tests: child-landing via query param, body.profile scoping, body-beats-query precedence, GET-list scoping, activate-path scoping, Default-unchanged, single-profile-unchanged (no profile → Default).
- Full `test_web_server*.py` suite: 248 passed, 1 skipped — no regressions.
- Single-profile behavior is unchanged (no profile passed → Default, exactly as before).