### PR TITLE
fix(desktop): give chat images native right-click and proper save filenames

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -5127,11 +5127,29 @@ async function copyImageFromUrl(rawUrl) {
 
 async function saveImageFromUrl(rawUrl) {
   const { buffer, mimeType } = (await resourceBufferFromUrl(rawUrl)) as any
-  const fallbackName = filenameFromUrl(rawUrl, `image${extensionForMimeType(mimeType) || '.png'}`)
+  const extension = extensionForMimeType(mimeType) || '.png'
+  // Generated-image URLs (fal.media etc.) usually end in an extensionless
+  // content hash. Keep the name but always guarantee an extension — without
+  // one Windows saves an unopenable "All Files" blob (#image18 report).
+  const baseName = filenameFromUrl(rawUrl, `image${extension}`)
+  const fallbackName = path.extname(baseName) ? baseName : `${baseName}${extension}`
+
+  let downloadsDir = ''
+
+  try {
+    downloadsDir = app.getPath('downloads')
+  } catch {
+    // Leave the dialog at its last-used location when the OS has no
+    // Downloads directory to offer.
+  }
 
   const result = await dialog.showSaveDialog(mainWindow, {
     title: 'Save Image',
-    defaultPath: fallbackName
+    defaultPath: downloadsDir ? path.join(downloadsDir, fallbackName) : fallbackName,
+    filters: [
+      { name: 'Images', extensions: ['png', 'jpg', 'jpeg', 'gif', 'webp', 'bmp', 'svg'] },
+      { name: 'All Files', extensions: ['*'] }
+    ]
   })
 
   if (result.canceled || !result.filePath) {
@@ -6095,6 +6113,36 @@ function isMediaCapturePermission(permission, details) {
   }
 
   return mediaTypes.includes('audio') || mediaTypes.includes('video')
+}
+
+// Chromium-initiated downloads (renderer anchor/blob downloads, drag-outs)
+// land here. Without a handler the OS save dialog opens with the process cwd
+// as the default directory (win-unpacked in packaged installs) and whatever
+// extensionless name the anchor carried. Route every download to the user's
+// Downloads directory and guarantee a MIME-derived extension.
+function installDownloadHandling() {
+  session.defaultSession.on('will-download', (_event, item) => {
+    const suggested = item.getFilename() || 'download'
+    const hasExtension = Boolean(path.extname(suggested))
+    const extension = hasExtension ? '' : extensionForMimeType(item.getMimeType())
+    const filename = `${suggested}${extension}`
+
+    try {
+      item.setSaveDialogOptions({
+        title: 'Save File',
+        defaultPath: path.join(app.getPath('downloads'), filename),
+        filters:
+          extension || /^image\//i.test(item.getMimeType() || '')
+            ? [
+                { name: 'Images', extensions: ['png', 'jpg', 'jpeg', 'gif', 'webp', 'bmp', 'svg'] },
+                { name: 'All Files', extensions: ['*'] }
+              ]
+            : undefined
+      })
+    } catch {
+      // No Downloads directory to offer — keep Chromium's default prompt.
+    }
+  })
 }
 
 function installMediaPermissions() {
@@ -13212,6 +13260,7 @@ app.whenReady().then(() => {
   }
 
   installMediaPermissions()
+  installDownloadHandling()
   registerMediaProtocol()
   installEmbedReferer()
   registerDeepLinkProtocol()

--- a/apps/desktop/src/app/shell/shell-context-menu.tsx
+++ b/apps/desktop/src/app/shell/shell-context-menu.tsx
@@ -82,13 +82,20 @@ export function ShellContextMenu({ children }: { children: React.ReactNode }) {
 }
 
 /** Right-clicks that already have an owner keep it: a surface with its own
- *  context menu, an editable, or a live selection (Electron's native edit menu).
- *  Never `preventDefault` — that is what would swallow the native menu. */
+ *  context menu, an editable, a live selection (Electron's native edit menu),
+ *  or an image/media element (Electron's native image menu — Copy Image,
+ *  Save Image As...). Never `preventDefault` — that is what would swallow the
+ *  native menu. */
 function guard(event: React.MouseEvent<HTMLDivElement>) {
   const target = event.target as HTMLElement | null
   const owner = target?.closest('[data-slot="context-menu-trigger"]')
 
-  if ((owner && !owner.hasAttribute('data-shell-context-menu')) || isEditableTarget(target) || hasTextSelection()) {
+  if (
+    (owner && !owner.hasAttribute('data-shell-context-menu')) ||
+    target?.closest('img, picture, video, canvas') ||
+    isEditableTarget(target) ||
+    hasTextSelection()
+  ) {
     event.stopPropagation()
   }
 }

--- a/apps/desktop/src/hooks/use-image-download.test.ts
+++ b/apps/desktop/src/hooks/use-image-download.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest'
+
+import { downloadFilename, imageFilename } from './use-image-download'
+
+describe('imageFilename', () => {
+  it('takes the last path segment of a URL', () => {
+    expect(imageFilename('https://v3.fal.media/files/kangaroo/pic.png')).toBe('pic.png')
+  })
+
+  it('falls back to "image" when there is no usable segment', () => {
+    expect(imageFilename('https://example.com/')).toBe('image')
+    expect(imageFilename(undefined)).toBe('image')
+  })
+})
+
+describe('downloadFilename', () => {
+  it('keeps a name that already has a known image extension', () => {
+    expect(downloadFilename('https://example.com/a/photo.jpg', 'image/jpeg')).toBe('photo.jpg')
+    expect(downloadFilename('https://example.com/a/photo.webp', '')).toBe('photo.webp')
+  })
+
+  it('appends a MIME-derived extension to extensionless content hashes', () => {
+    expect(downloadFilename('https://v3.fal.media/files/x/MKZV6h-RrKLVCOKp9bGfE_YuJPemAQ', 'image/jpeg')).toBe(
+      'MKZV6h-RrKLVCOKp9bGfE_YuJPemAQ.jpg'
+    )
+    expect(downloadFilename('https://cdn.example.com/abc123', 'image/webp')).toBe('abc123.webp')
+  })
+
+  it('handles MIME parameters and unknown types', () => {
+    expect(downloadFilename('https://cdn.example.com/abc123', 'image/png; charset=binary')).toBe('abc123.png')
+    expect(downloadFilename('https://cdn.example.com/abc123', 'application/octet-stream')).toBe('abc123.png')
+    expect(downloadFilename('https://cdn.example.com/abc123', undefined)).toBe('abc123.png')
+  })
+
+  it('does not treat a dotted hash suffix as an extension', () => {
+    // A name like "photo.v2" has an extname but not a known image one — the
+    // MIME extension still gets appended so the OS can open the file.
+    expect(downloadFilename('https://cdn.example.com/photo.v2', 'image/png')).toBe('photo.v2.png')
+  })
+})

--- a/apps/desktop/src/hooks/use-image-download.ts
+++ b/apps/desktop/src/hooks/use-image-download.ts
@@ -3,6 +3,17 @@ import { useCallback, useState } from 'react'
 import { useI18n } from '@/i18n'
 import { notify, notifyError } from '@/store/notifications'
 
+const MIME_EXTENSIONS: Record<string, string> = {
+  'image/bmp': '.bmp',
+  'image/gif': '.gif',
+  'image/jpeg': '.jpg',
+  'image/png': '.png',
+  'image/svg+xml': '.svg',
+  'image/webp': '.webp'
+}
+
+const KNOWN_IMAGE_EXTENSION_RE = /\.(?:apng|avif|bmp|gif|ico|jpe?g|png|svg|tiff?|webp)$/i
+
 export function imageFilename(src?: string): string {
   if (!src) {
     return 'image'
@@ -13,6 +24,25 @@ export function imageFilename(src?: string): string {
   } catch {
     return src.split(/[\\/]/).filter(Boolean).pop() || 'image'
   }
+}
+
+/** Filename for a browser-anchor download. Generated-image URLs (fal.media
+ *  etc.) often end in an extensionless content hash — without an extension the
+ *  OS save dialog shows "All Files" and the saved file won't open by
+ *  double-click, so append one derived from the blob's MIME type. */
+export function downloadFilename(src: string, mimeType?: string): string {
+  const base = imageFilename(src)
+
+  if (KNOWN_IMAGE_EXTENSION_RE.test(base)) {
+    return base
+  }
+
+  const type = String(mimeType || '')
+    .split(';')[0]
+    .trim()
+    .toLowerCase()
+
+  return `${base}${MIME_EXTENSIONS[type] || '.png'}`
 }
 
 function isMissingIpcHandler(error: unknown): boolean {
@@ -28,10 +58,11 @@ async function startBrowserDownload(src: string) {
     throw new Error(`Could not fetch image: ${response.status}`)
   }
 
-  const blobUrl = URL.createObjectURL(await response.blob())
+  const blob = await response.blob()
+  const blobUrl = URL.createObjectURL(blob)
   const link = document.createElement('a')
   link.href = blobUrl
-  link.download = imageFilename(src)
+  link.download = downloadFilename(src, blob.type)
   link.rel = 'noopener noreferrer'
   document.body.appendChild(link)
   link.click()


### PR DESCRIPTION
## Summary
Chat images in the desktop app can now be right-click copied, and saving them produces a real, openable file (proper extension, Downloads folder default) instead of an extensionless hash blob dumped next to `win-unpacked`.

Root cause, per the community report screenshots: (1) the shell's fallback context menu wrapper stopped right-clicks on images before Electron's native image menu could open; (2) generated-image URLs (fal.media) end in an extensionless content hash, and neither the save dialog nor the browser-anchor fallback appended a MIME-derived extension; (3) no `will-download` handling and no `defaultPath` directory, so the save dialog opened in the process cwd.

## Changes
- `src/app/shell/shell-context-menu.tsx`: guard now yields right-clicks on `img`/`picture`/`video`/`canvas` to Electron's native image menu (Copy Image, Copy Image Address, Save Image As...), same pattern as the existing editable/selection carve-outs.
- `electron/main.ts` `saveImageFromUrl()`: guarantees a MIME-derived extension on the suggested name, adds image type filters, defaults the dialog to the user's Downloads directory.
- `electron/main.ts` new `installDownloadHandling()`: `will-download` on the default session routes Chromium-initiated downloads (anchor/blob fallback, drag-outs) through the same Downloads-dir + guaranteed-extension policy.
- `src/hooks/use-image-download.ts`: browser-anchor fallback derives the filename from the blob's MIME type (`downloadFilename()`), exported and unit-tested.
- `src/hooks/use-image-download.test.ts`: new tests for hash-name/extension/MIME-parameter cases.

## Validation
| Check | Result |
|---|---|
| `npx vitest run src/hooks/use-image-download.test.ts` | 6/6 pass |
| `npm run check:lint` (tsc ×3 + eslint) | 0 errors |
| `MKZV6h-RrKLVCOKp9bGfE_YuJPemAQ` + `image/jpeg` | saves as `...AQ.jpg` |

## Infographic

![Desktop chat image save and right-click fixes](https://files.catbox.moe/b891mw.png)
