### PR TITLE
fix(desktop): suppress skill suggestion pill when the session already touched the skill

### DIFF
--- a/apps/desktop/src/store/suggestion-providers/skill.test.ts
+++ b/apps/desktop/src/store/suggestion-providers/skill.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from 'vitest'
 
-import { collidesWithWorkspace, skillHit, skillPattern } from './skill'
+import type { ChatMessage } from '@/lib/chat-messages'
+
+import { collidesWithWorkspace, skillHit, skillPattern, skillTouchedInMessages } from './skill'
 
 // skillHit is the provider's real predicate: a whole-word match that the user
 // has finished typing (at least one character follows it).
@@ -60,5 +62,66 @@ describe('collidesWithWorkspace', () => {
 
   it('never collides when detached (empty cwd)', () => {
     expect(collidesWithWorkspace('hermes-agent', '')).toBe(false)
+  })
+})
+
+// -- skillTouchedInMessages ---------------------------------------------------
+
+const toolCall = (toolName: string, args?: unknown, argsText = ''): ChatMessage => ({
+  id: 't',
+  role: 'assistant',
+  parts: [{ args: args as never, argsText, toolCallId: 'x', toolName, type: 'tool-call' }]
+})
+
+const userText = (text: string): ChatMessage => ({
+  id: 'u',
+  role: 'user',
+  parts: [{ text, type: 'text' }]
+})
+
+describe('skillTouchedInMessages', () => {
+  it('detects a skill_view load of the skill', () => {
+    expect(skillTouchedInMessages('pr-ready', [toolCall('skill_view', { name: 'pr-ready' })])).toBe(true)
+  })
+
+  it('detects a skill_manage touch of the skill', () => {
+    expect(skillTouchedInMessages('pr-ready', [toolCall('skill_manage', { action: 'patch', name: 'pr-ready' })])).toBe(
+      true
+    )
+  })
+
+  it('matches qualified skill names (category/name, plugin:name)', () => {
+    expect(skillTouchedInMessages('hermes-agent-dev', [toolCall('skill_view', { name: 'github/hermes-agent-dev' })])).toBe(
+      true
+    )
+    expect(skillTouchedInMessages('writing-plans', [toolCall('skill_view', { name: 'superpowers:writing-plans' })])).toBe(
+      true
+    )
+  })
+
+  it('falls back to argsText when args were not parsed', () => {
+    expect(skillTouchedInMessages('pr-ready', [toolCall('skill_view', undefined, '{"name":"pr-ready"}')])).toBe(true)
+  })
+
+  it('detects the user loading the skill via its slash command', () => {
+    expect(skillTouchedInMessages('pr-ready', [userText('/pr-ready check this branch')])).toBe(true)
+    expect(skillTouchedInMessages('pr-ready', [userText('/pr-ready')])).toBe(true)
+  })
+
+  it('ignores touches of OTHER skills and non-skill tools', () => {
+    expect(skillTouchedInMessages('pr-ready', [toolCall('skill_view', { name: 'clean' })])).toBe(false)
+    expect(skillTouchedInMessages('pr-ready', [toolCall('read_file', { path: 'pr-ready' })])).toBe(false)
+    // Slash prefix must be exact — /pr-ready-extra is a different command.
+    expect(skillTouchedInMessages('pr-ready', [userText('/pr-ready-extra go')])).toBe(false)
+    // Merely mentioning the name in prose is not a load.
+    expect(skillTouchedInMessages('pr-ready', [userText('is pr-ready any good?')])).toBe(false)
+  })
+
+  it('is case-insensitive on the stored arg', () => {
+    expect(skillTouchedInMessages('pr-ready', [toolCall('skill_view', { name: 'PR-Ready' })])).toBe(true)
+  })
+
+  it('empty transcript touches nothing', () => {
+    expect(skillTouchedInMessages('pr-ready', [])).toBe(false)
   })
 })

--- a/apps/desktop/src/store/suggestion-providers/skill.ts
+++ b/apps/desktop/src/store/suggestion-providers/skill.ts
@@ -1,8 +1,10 @@
 import { requestComposerFocus, requestComposerInsert } from '@/app/chat/composer/focus'
 import { getSkills } from '@/hermes'
 import { translateNow } from '@/i18n'
+import type { ChatMessage } from '@/lib/chat-messages'
 import { type ComposerSuggestion, registerDraftProvider } from '@/store/composer-suggestions'
-import { $currentCwd } from '@/store/session'
+import { $activeSessionId, $currentCwd, $messages } from '@/store/session'
+import { $sessionStates } from '@/store/session-states'
 
 /**
  * Skill-match draft provider: the draft names a skill the user has, so offer
@@ -90,6 +92,98 @@ async function loadIndex(): Promise<SkillIndexEntry[]> {
   return index
 }
 
+// ---------------------------------------------------------------------------
+// Already-in-context guard: a skill the session has engaged with must not be
+// re-offered. skill_view loads the whole SKILL.md into the conversation and
+// skill_manage implies the agent is already working with it — clicking the
+// pill would just re-inject content the context already carries (the reported
+// annoyance: a "Use skill" pill for a skill loaded at session start).
+// ---------------------------------------------------------------------------
+
+const SKILL_TOOL_NAMES = new Set(['skill_manage', 'skill_view'])
+
+/** The `name` argument of a skill tool call, however the transcript stored
+ *  it: live rows carry a parsed `args` object, hydrated rows may only have
+ *  the JSON `argsText`. */
+function skillArgName(part: { args?: unknown; argsText?: unknown }): string {
+  const record = part.args && typeof part.args === 'object' ? (part.args as Record<string, unknown>) : null
+
+  if (record && typeof record.name === 'string') {
+    return record.name
+  }
+
+  if (typeof part.argsText === 'string' && part.argsText) {
+    try {
+      const parsed: unknown = JSON.parse(part.argsText)
+
+      if (parsed && typeof parsed === 'object' && typeof (parsed as { name?: unknown }).name === 'string') {
+        return (parsed as { name: string }).name
+      }
+    } catch {
+      // Non-JSON argsText carries no name.
+    }
+  }
+
+  return ''
+}
+
+/** True when the tool-call arg names this skill — exactly, or as the final
+ *  segment of a qualified form (`github/hermes-agent-dev`, `plugin:skill`). */
+function argNamesSkill(arg: string, skillName: string): boolean {
+  const value = arg.trim().toLowerCase()
+
+  if (!value) {
+    return false
+  }
+
+  const target = skillName.toLowerCase()
+
+  return value === target || (value.split(/[/:]/).pop() ?? '') === target
+}
+
+/** Session already touched this skill: the agent loaded it (`skill_view`),
+ *  edited it (`skill_manage`), or the user sent its `/name` command.
+ *  Exported for tests. */
+export function skillTouchedInMessages(skillName: string, messages: readonly ChatMessage[]): boolean {
+  const slash = new RegExp(`^/${escape(skillName.toLowerCase())}(?:\\s|$)`)
+
+  for (const message of messages) {
+    for (const part of message.parts) {
+      if (part.type === 'tool-call' && SKILL_TOOL_NAMES.has(part.toolName) && argNamesSkill(skillArgName(part), skillName)) {
+        return true
+      }
+
+      if (
+        message.role === 'user' &&
+        part.type === 'text' &&
+        typeof part.text === 'string' &&
+        slash.test(part.text.trimStart().toLowerCase())
+      ) {
+        return true
+      }
+    }
+  }
+
+  return false
+}
+
+/** This session's transcript, wherever it currently lives: the per-runtime
+ *  mirror ($sessionStates) for any session, falling back to the active view
+ *  ($messages) for a session whose mirror hasn't populated yet. */
+function sessionTranscript(sessionId: string | null): readonly ChatMessage[] {
+  const cached = sessionId ? $sessionStates.get()[sessionId]?.messages : undefined
+
+  if (cached?.length) {
+    return cached
+  }
+
+  if (sessionId && sessionId === $activeSessionId.get()) {
+    return $messages.get()
+  }
+
+  return cached ?? []
+}
+
 function toSuggestion(name: string): ComposerSuggestion {
   const copy = (key: string, ...args: unknown[]) => translateNow(`composer.skillSuggestions.${key}`, ...args)
 
@@ -112,7 +206,7 @@ function toSuggestion(name: string): ComposerSuggestion {
   }
 }
 
-registerDraftProvider('skill', async ({ text }) => {
+registerDraftProvider('skill', async ({ sessionId, text }) => {
   const trimmed = text.trimStart()
 
   // Already a slash command (possibly ours from a previous click) — stand
@@ -124,8 +218,15 @@ registerDraftProvider('skill', async ({ text }) => {
   const haystack = text.toLowerCase()
   const cwd = $currentCwd.get()
   const skills = await loadIndex()
+  const matched = skills.filter(skill => skillHit(skill.pattern, haystack) && !collidesWithWorkspace(skill.name, cwd))
 
-  return skills
-    .filter(skill => skillHit(skill.pattern, haystack) && !collidesWithWorkspace(skill.name, cwd))
-    .map(skill => toSuggestion(skill.name))
+  if (matched.length === 0) {
+    return []
+  }
+
+  // Transcript scan only for actual matches — the common no-match sample
+  // never pays for it.
+  const transcript = sessionTranscript(sessionId)
+
+  return matched.filter(skill => !skillTouchedInMessages(skill.name, transcript)).map(skill => toSuggestion(skill.name))
 })


### PR DESCRIPTION
## Summary
The desktop composer's "Use skill: X" pill no longer re-offers a skill this session has already loaded, edited, or invoked — clicking it previously re-injected a full SKILL.md the context already carried.

## Changes
- `apps/desktop/src/store/suggestion-providers/skill.ts`: new `skillTouchedInMessages()` guard — scans the session transcript for `skill_view`/`skill_manage` tool calls naming the skill (exact or qualified `category/name` / `plugin:name`, from parsed `args` or hydrated `argsText`) and for user turns starting with the skill's `/name` slash command; the draft provider filters matches through it. Transcript comes from the per-runtime `$sessionStates` mirror (works for tiles), falling back to `$messages` for the active session. The scan only runs when a draft actually matched a skill, so ordinary typing pays nothing.
- `apps/desktop/src/store/suggestion-providers/skill.test.ts`: 8 new cases — view/manage touches, qualified names, argsText fallback, slash-command loads, case-insensitivity, and negatives (other skills, non-skill tools, prose mentions, prefix-only slash).

## Validation
| | Before | After |
|---|---|---|
| Skill loaded via skill_view earlier in session | pill re-offered | suppressed |
| Skill edited via skill_manage | pill re-offered | suppressed |
| User already sent /skill-name | pill re-offered | suppressed |
| Untouched skill named in draft | pill offered | pill offered (unchanged) |

`vitest src/store/suggestion-providers/` 58/58 pass; `npm run check:lint` (all three tsconfigs + eslint) clean.

## Infographic

![Skill pill learns what's already loaded](https://files.catbox.moe/igb4fz.png)
