### PR TITLE
fix(install.ps1): surface uv installer errors and add GitHub + existing-uv fallbacks (#69216)

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -760,7 +760,65 @@ function Install-Uv {
         # than a bare `powershell`, which isn't guaranteed to be on PATH under
         # PowerShell 7 / pwsh-only setups.
         $psHostExe = Get-PowerShellHostExe
-        & $psHostExe -ExecutionPolicy ByPass -c "irm https://astral.sh/uv/install.ps1 | iex" 2>&1 | Out-Null
+
+        # Rungs 1 + 2: run the uv installer -- astral.sh first, then the
+        # byte-identical copy published on GitHub releases.  Corporate
+        # proxies and AV products frequently block astral.sh while
+        # github.com is reachable (issue #69216), so a second source turns
+        # a hard failure into a working install.  Capture the installer
+        # output (Tee-Object) instead of discarding it: when every source
+        # fails, the real error (download blocked, AV quarantine,
+        # permissions) must reach the user instead of only the generic
+        # "installed but not found" message.
+        $installerOutput = @()
+        $astralOut = @()
+        & $psHostExe -ExecutionPolicy ByPass -c "irm https://astral.sh/uv/install.ps1 | iex" 2>&1 | Tee-Object -Variable astralOut | Out-Null
+        $installerOutput += "--- uv installer source: astral.sh ---"
+        $installerOutput += @($astralOut | ForEach-Object { "$_" })
+        if (Test-Path $managedUv) {
+            Write-Info "uv installer succeeded via astral.sh"
+        } else {
+            Write-Info "astral.sh uv installer did not produce $managedUv; trying GitHub releases mirror ..."
+            $ghOut = @()
+            & $psHostExe -ExecutionPolicy ByPass -c "irm https://github.com/astral-sh/uv/releases/latest/download/uv-installer.ps1 | iex" 2>&1 | Tee-Object -Variable ghOut | Out-Null
+            $installerOutput += "--- uv installer source: GitHub releases ---"
+            $installerOutput += @($ghOut | ForEach-Object { "$_" })
+            if (Test-Path $managedUv) {
+                Write-Info "uv installer succeeded via GitHub releases"
+            }
+        }
+
+        # Rung 3: salvage an existing uv.exe.  When the installer cannot run
+        # at all (network fully blocked) but a working uv already exists --
+        # on PATH, or at ~/.local/bin (the astral default location when
+        # UV_INSTALL_DIR was ignored by an older installer) -- copy it into
+        # the managed location so the managed-first invariant holds
+        # (hermes_cli/managed_uv.py looks only at $HermesHome\bin\uv.exe).
+        if (-not (Test-Path $managedUv)) {
+            $existingUv = $null
+            $uvOnPath = Get-Command uv -CommandType Application -ErrorAction SilentlyContinue |
+                Select-Object -First 1
+            if ($uvOnPath -and $uvOnPath.Source -and (Test-Path $uvOnPath.Source)) {
+                $existingUv = $uvOnPath.Source
+            }
+            if (-not $existingUv) {
+                $defaultUv = Join-Path $env:USERPROFILE ".local\bin\uv.exe"
+                if (Test-Path $defaultUv) { $existingUv = $defaultUv }
+            }
+            if ($existingUv) {
+                Write-Info "Salvaging existing uv from $existingUv"
+                try {
+                    Copy-Item $existingUv $managedUv -Force
+                    # Verify the salvaged binary actually runs before
+                    # trusting it as the managed uv.
+                    $null = & $managedUv --version
+                } catch {
+                    Write-Info "Existing uv at $existingUv could not be salvaged: $_"
+                    Remove-Item $managedUv -Force -ErrorAction SilentlyContinue
+                }
+            }
+        }
+
         $ErrorActionPreference = $prevEAP
 
         if (Test-Path $managedUv) {
@@ -771,6 +829,10 @@ function Install-Uv {
         }
 
         Write-Err "uv installed but not found at $managedUv"
+        if ($installerOutput.Count -gt 0) {
+            Write-Info "uv installer output (last 15 lines):"
+            $installerOutput | Select-Object -Last 15 | ForEach-Object { Write-Info "  $_" }
+        }
         Write-Info "Install manually: https://docs.astral.sh/uv/getting-started/installation/"
         return $false
     } catch {

--- a/tests/test_install_ps1_uv_install_fallback.py
+++ b/tests/test_install_ps1_uv_install_fallback.py
@@ -1,0 +1,130 @@
+"""Regression: Install-Uv must surface installer errors and have fallbacks.
+
+Issue #69216: Windows installs died with only the generic message
+``uv installed but not found at ...\\bin\\uv.exe``.  Two root causes:
+
+1. ``Install-Uv`` piped the astral installer's entire output straight into
+   ``Out-Null`` (``2>&1 | Out-Null``), so any real failure -- download error,
+   corporate proxy block, AV quarantine, permissions -- was swallowed and
+   the user only ever saw the generic post-condition failure (first
+   identified in #69366).
+2. There was exactly one install source, ``astral.sh``.  Corporate proxies
+   commonly block astral.sh while the byte-identical installer published at
+   GitHub releases downloads fine (diagnosed by @gakugaku on #69216).
+
+The fix installs a three-rung ladder inside ``Install-Uv``:
+
+- Rung 1: astral.sh installer, output captured via ``Tee-Object``.
+- Rung 2: GitHub releases installer mirror, same ``UV_INSTALL_DIR``.
+- Rung 3: salvage an existing ``uv.exe`` (``Get-Command uv`` or
+  ``%USERPROFILE%\\.local\\bin\\uv.exe``) by copying it into
+  ``$HermesHome\\bin\\uv.exe`` so the managed-first invariant holds.
+
+Only after all three rungs fail does it error out -- and then it prints the
+tail of the captured installer output so the real cause reaches the user.
+
+install.ps1 only runs on Windows, so these tests lock the contract at the
+source-text level (same style as test_install_ps1_uv_powershell_host.py).
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+
+_INSTALL_PS1 = Path(__file__).resolve().parents[1] / "scripts" / "install.ps1"
+
+_GITHUB_INSTALLER_URL = (
+    "https://github.com/astral-sh/uv/releases/latest/download/uv-installer.ps1"
+)
+
+
+@pytest.fixture(scope="module")
+def source() -> str:
+    return _INSTALL_PS1.read_text(encoding="utf-8")
+
+
+def _install_uv_body(source: str) -> str:
+    """Extract the text of Install-Uv up to the next top-level function."""
+    start = source.index("function Install-Uv")
+    tail = source[start + 1 :]
+    match = re.search(r"^function ", tail, flags=re.MULTILINE)
+    end = start + 1 + (match.start() if match else len(tail))
+    return source[start:end]
+
+
+def test_astral_installer_output_not_swallowed_by_out_null(source: str):
+    """Regression pin for the suppression bug (#69366 / #69216).
+
+    The astral invocation must not discard the installer's merged output
+    stream; a failed download/AV block has to reach the user.
+    """
+    forbidden = 'irm https://astral.sh/uv/install.ps1 | iex" 2>&1 | Out-Null'
+    assert forbidden not in source, (
+        "Install-Uv pipes the astral uv installer's output straight to "
+        "Out-Null again -- failures become the generic 'uv installed but "
+        "not found' message. Capture the output (e.g. Tee-Object) instead."
+    )
+
+
+def test_astral_installer_output_is_captured(source: str):
+    body = _install_uv_body(source)
+    astral_lines = [
+        ln
+        for ln in body.splitlines()
+        if "irm https://astral.sh/uv/install.ps1 | iex" in ln
+    ]
+    assert astral_lines, "astral uv installer invocation not found in Install-Uv"
+    for ln in astral_lines:
+        assert "Tee-Object" in ln, (
+            "astral uv installer output must be captured (Tee-Object) so the "
+            f"failure path can show it to the user, got: {ln.strip()!r}"
+        )
+
+
+def test_github_releases_fallback_installer_present(source: str):
+    """Rung 2: the GitHub releases mirror of the installer must be tried."""
+    body = _install_uv_body(source)
+    assert _GITHUB_INSTALLER_URL in body, (
+        "Install-Uv must fall back to the GitHub releases uv installer "
+        f"({_GITHUB_INSTALLER_URL}) when astral.sh is blocked "
+        "(corporate proxies, #69216)."
+    )
+    fallback_lines = [ln for ln in body.splitlines() if _GITHUB_INSTALLER_URL in ln and "irm " in ln]
+    for ln in fallback_lines:
+        stripped = ln.strip()
+        assert stripped.startswith("& $"), (
+            "GitHub fallback installer must be invoked via the resolved "
+            f"PowerShell host variable (`& $...`), got: {stripped!r}"
+        )
+        assert "Tee-Object" in ln, (
+            f"GitHub fallback installer output must be captured too: {stripped!r}"
+        )
+
+
+def test_existing_uv_salvage_rung_present(source: str):
+    """Rung 3: probe PATH and the astral default dir, copy into managed bin."""
+    body = _install_uv_body(source)
+    assert "Get-Command uv" in body, (
+        "Install-Uv must probe for an existing uv on PATH (Get-Command uv) "
+        "before failing."
+    )
+    assert '".local\\bin\\uv.exe"' in body and "$env:USERPROFILE" in body, (
+        "Install-Uv must probe the astral default install location "
+        "(%USERPROFILE%\\.local\\bin\\uv.exe)."
+    )
+    assert "Copy-Item" in body and "$managedUv" in body, (
+        "A salvaged uv.exe must be copied into the managed location "
+        "($HermesHome\\bin\\uv.exe) so managed-first resolution holds."
+    )
+
+
+def test_failure_path_keeps_manual_install_pointer_and_shows_output(source: str):
+    body = _install_uv_body(source)
+    assert "https://docs.astral.sh/uv/getting-started/installation/" in body, (
+        "the manual-install pointer must survive in the failure path"
+    )
+    assert "$installerOutput" in body and "Select-Object -Last" in body, (
+        "the failure path must print the tail of the captured installer "
+        "output so the real error reaches the user"
+    )


### PR DESCRIPTION
Closes #69216

## Problem

Windows installs failed at the uv step with only the generic message `uv installed but not found at ...\bin\uv.exe`, no matter what actually went wrong. Two root causes:

1. **Suppressed output.** `Install-Uv` ran the astral installer with `2>&1 | Out-Null`, discarding every error (download failure, corporate proxy block, AV quarantine, permissions). First identified by @webtecnica in #69366.
2. **Single install source.** Only `astral.sh` was tried. @gakugaku showed on the issue thread that corporate proxies block astral.sh entirely while the byte-identical installer at `https://github.com/astral-sh/uv/releases/latest/download/uv-installer.ps1` downloads fine.

Reported by @BitBernd.

## Fix: a three-rung install ladder inside `Install-Uv`

1. **astral.sh** installer, with output captured via `Tee-Object` instead of discarded.
2. **GitHub releases mirror** of the same installer (same `UV_INSTALL_DIR=$HermesHome\bin`), tried when rung 1 leaves no `uv.exe`. The script logs which source succeeded.
3. **Salvage an existing uv.exe**: probe `Get-Command uv` and `%USERPROFILE%\.local\bin\uv.exe` (the astral default when `UV_INSTALL_DIR` was ignored by an older installer), copy it into `$HermesHome\bin\uv.exe`, and verify with `--version`. This keeps the managed-first invariant — `hermes_cli/managed_uv.py` looks only at `HERMES_HOME\bin`.

Only after all three rungs fail does it error out, and the failure now prints the **last 15 lines of captured installer output** plus the existing manual-install pointer, so the real cause finally reaches the user.

Existing conventions preserved: `Write-Info`/`Write-Err`/`Write-Success`, `$script:UvCmd` assignment, the `$ErrorActionPreference` save/restore pattern, `Get-PowerShellHostExe` for spawns, ASCII-only, CRLF line endings.

## Tests

New `tests/test_install_ps1_uv_install_fallback.py` (text-based pins, same style as `test_install_ps1_uv_powershell_host.py` since Linux CI cannot execute the script):

- the astral invocation is no longer piped to `Out-Null` (regression pin) and its output is captured;
- the GitHub releases fallback URL exists inside `Install-Uv`, invoked via the resolved host variable with capture;
- the salvage rung probes `Get-Command uv` and `%USERPROFILE%\.local\bin\uv.exe` and copies into the managed location;
- the failure path keeps the docs.astral.sh manual-install pointer and prints the captured output tail.

Sabotage-verified: with `scripts/install.ps1` reverted to origin/main, all 5 new tests fail; green after restore. Full run: `test_install_ps1_uv_install_fallback.py` + `test_install_ps1_ascii_only.py` + `test_install_ps1_uv_powershell_host.py` — 9 passed.

**Residue:** `pwsh` is not available on this Linux box, so local ps1 syntax parsing was not run — CI's ps1 syntax job covers it. Real proxy/AV behavior needs Windows hardware; the script logic is pinned by the text tests. `file scripts/install.ps1` still reports ASCII text with CRLF line terminators.

## Infographic

![uv install ladder](https://files.catbox.moe/xnub3m.png)
