### PR TITLE
feat(kanban): check a completion against git instead of trusting it

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -76,6 +76,7 @@ def _task_to_dict(t: kb.Task) -> dict[str, Any]:
         "result": t.result,
         "skills": list(t.skills) if t.skills else [],
         "max_retries": t.max_retries,
+        "evidence_repo": t.evidence_repo,
         "model_override": t.model_override,
         "provider_override": t.provider_override,
         "session_id": t.session_id,
@@ -370,6 +371,15 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
                                "two retries. Omit to use the dispatcher's "
                                "kanban.failure_limit config "
                                f"(default {kb.DEFAULT_FAILURE_LIMIT}).")
+    p_create.add_argument("--evidence-repo", default=None, metavar="PATH",
+                          help="Check this task's completion against the git "
+                               "state of PATH. The completing worker (or the "
+                               "review handoff before it) must name the paths "
+                               "it changed in metadata.changed_files, and "
+                               "those paths must actually differ, or the "
+                               "completion is refused. Omit for work that "
+                               "legitimately produces no code — the check is "
+                               "off unless a repo is named.")
     p_create.add_argument("--model", default=None, dest="model_override",
                           help="Pin the worker to this model (passed as "
                                "-m <model>) without changing the profile's "
@@ -1581,6 +1591,7 @@ def _cmd_create(args: argparse.Namespace) -> int:
             max_runtime_seconds=max_runtime,
             skills=getattr(args, "skills", None) or None,
             max_retries=max_retries,
+            evidence_repo=getattr(args, "evidence_repo", None),
             model_override=getattr(args, "model_override", None),
             provider_override=getattr(args, "provider_override", None),
             goal_mode=bool(getattr(args, "goal_mode", False)),

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -1115,6 +1115,12 @@ class Task:
     # ``kanban.failure_limit`` config, and then to ``DEFAULT_FAILURE_LIMIT``.
     # Name matches the ``--max-retries`` CLI flag on ``kanban create``.
     max_retries: Optional[int] = None
+    # Repository whose git state must corroborate this card's completion.
+    # ``None`` (the common case) disables the check entirely. When set,
+    # ``complete_task`` asks git whether the paths the worker claims to have
+    # changed actually differ, and refuses the completion if they do not.
+    # Name matches the ``--evidence-repo`` CLI flag on ``kanban create``.
+    evidence_repo: Optional[str] = None
     # When True, the dispatched worker runs in a Ralph-style goal loop
     # (the same engine behind the ``/goal`` slash command): after each
     # turn an auxiliary judge model evaluates the worker's response
@@ -1217,6 +1223,11 @@ class Task:
             ),
             max_retries=(
                 row["max_retries"] if "max_retries" in keys else None
+            ),
+            evidence_repo=(
+                row["evidence_repo"]
+                if "evidence_repo" in keys and row["evidence_repo"]
+                else None
             ),
             goal_mode=(
                 bool(row["goal_mode"]) if "goal_mode" in keys and row["goal_mode"] else False
@@ -1394,6 +1405,12 @@ CREATE TABLE IF NOT EXISTS tasks (
     -- case) falls through to the dispatcher-level ``kanban.failure_limit``
     -- config and then ``DEFAULT_FAILURE_LIMIT``.
     max_retries          INTEGER,
+    -- Repository whose git state must corroborate this card's completion.
+    -- NULL (the common case) disables the check: the card closes on the
+    -- worker's word, as every card did before this column existed. When
+    -- set, ``complete_task`` asks git whether the claimed paths actually
+    -- differ and refuses the completion if they do not.
+    evidence_repo        TEXT,
     -- When 1, the dispatched worker runs in a Ralph-style goal loop: an
     -- auxiliary judge re-evaluates the worker's response against the
     -- card title/body after each turn and feeds a continuation prompt
@@ -2623,6 +2640,14 @@ def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
         # they were getting before the column existed).
         _add_column_if_missing(conn, "tasks", "max_retries", "max_retries INTEGER")
 
+    if "evidence_repo" not in cols:
+        # Repository this task's completion is checked against. NULL (every
+        # existing row, and every task that does not declare one) leaves
+        # ``complete_task`` exactly as it was — probes, syntheses, reviews and
+        # anything else that legitimately produces no code still close on the
+        # worker's word. Declaring a path opts the card into the gate.
+        _add_column_if_missing(conn, "tasks", "evidence_repo", "evidence_repo TEXT")
+
     if "model_override" not in cols:
         conn.execute("ALTER TABLE tasks ADD COLUMN model_override TEXT")
 
@@ -3173,6 +3198,7 @@ def create_task(
     max_runtime_seconds: Optional[int] = None,
     skills: Optional[Iterable[str]] = None,
     max_retries: Optional[int] = None,
+    evidence_repo: Optional[str] = None,
     model_override: Optional[str] = None,
     provider_override: Optional[str] = None,
     reasoning_effort: Optional[str] = None,
@@ -3495,10 +3521,11 @@ def create_task(
                         created_by, created_at, workspace_kind, workspace_path,
                         branch_name, project_id, tenant, idempotency_key,
                         max_runtime_seconds,
-                        skills, max_retries, model_override, provider_override,
+                        skills, max_retries, evidence_repo,
+                        model_override, provider_override,
                         reasoning_effort,
                         goal_mode, goal_max_turns, session_id
-                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                     """,
                     (
                         task_id,
@@ -3518,6 +3545,7 @@ def create_task(
                         int(max_runtime_seconds) if max_runtime_seconds is not None else None,
                         json.dumps(skills_list) if skills_list is not None else None,
                         int(max_retries) if max_retries is not None else None,
+                        (evidence_repo.strip() or None) if evidence_repo else None,
                         model_override,
                         provider_override,
                         reasoning_effort,
@@ -5213,6 +5241,111 @@ def reassign_task(
         return False
 
 
+def _claimed_change_evidence(
+    conn: sqlite3.Connection,
+    task_id: str,
+    metadata: Optional[dict],
+) -> tuple[list[str], Optional[str], Optional[str]]:
+    """Paths and commit the completion claims, plus where the claim came from.
+
+    Looks at the completing call's own metadata first, then falls back to the
+    latest ``review_requested`` run. The fallback is the normal path, not the
+    exception: the builder knows what it changed and hands off, and it is the
+    *reviewer* who calls ``complete_task``. Requiring the evidence on the
+    closing call alone would ask the reviewer to author facts about work they
+    did not do — which is exactly what happened on 2026-08-14.
+    """
+
+    def _extract(meta: object) -> tuple[list[str], Optional[str]]:
+        if not isinstance(meta, dict):
+            return [], None
+        raw = meta.get("changed_files")
+        paths = (
+            [p.strip() for p in raw if isinstance(p, str) and p.strip()]
+            if isinstance(raw, (list, tuple))
+            else []
+        )
+        commit = meta.get("commit")
+        commit = commit.strip() if isinstance(commit, str) and commit.strip() else None
+        return paths, commit
+
+    paths, commit = _extract(metadata)
+    if paths:
+        return paths, commit, "completion"
+
+    rows = conn.execute(
+        "SELECT metadata FROM task_runs "
+        "WHERE task_id = ? AND outcome = 'review_requested' "
+        "ORDER BY id DESC LIMIT 1",
+        (task_id,),
+    ).fetchall()
+    for row in rows:
+        raw_meta = row["metadata"]
+        if not raw_meta:
+            continue
+        try:
+            handoff = json.loads(raw_meta)
+        except (ValueError, TypeError):
+            continue
+        paths, handoff_commit = _extract(handoff)
+        if paths:
+            return paths, commit or handoff_commit, "review_handoff"
+    return [], commit, None
+
+
+def _verify_completion_evidence(
+    conn: sqlite3.Connection,
+    task_id: str,
+    evidence_repo: str,
+    metadata: Optional[dict],
+) -> tuple[Optional[str], list[str], Optional[list[str]]]:
+    """Ask git whether ``task_id``'s completion claim survives contact.
+
+    Returns ``(reason, claimed, changed)`` where a non-``None`` ``reason``
+    means refuse. Deliberately narrow: it decides whether the claimed paths
+    exist as changes, never whether the changes are correct. The reviewer owns
+    correctness; this owns existence.
+    """
+    claimed, commit, _source = _claimed_change_evidence(conn, task_id, metadata)
+    repo = Path(evidence_repo).expanduser()
+    changed = _git_changed_paths(repo)
+    if changed is None:
+        return f"{repo} is not a readable git repository", claimed, None
+    if not claimed:
+        # Report what git sees anyway. A worker that forgot to name its paths
+        # cannot guess what to write from a bare refusal, and the answer is
+        # sitting in the diff.
+        return (
+            (
+                "no changed_files were claimed, by this completion or by the "
+                "review handoff that preceded it"
+            ),
+            [],
+            sorted(changed),
+        )
+    if commit and not _git_commit_exists(repo, commit):
+        return f"commit {commit} does not exist in {repo}", claimed, sorted(changed)
+
+    # Suffix match, so a worker may cite `security.py` or the repo-relative
+    # `backend/instagram_automation/security.py` and both resolve. Git reports
+    # repo-relative paths; workers reliably do not.
+    unmatched = [
+        path
+        for path in claimed
+        if not any(
+            actual == path or actual.endswith("/" + path.lstrip("./"))
+            for actual in changed
+        )
+    ]
+    if unmatched:
+        return (
+            (f"{repo} shows no change to {', '.join(unmatched)}"),
+            claimed,
+            sorted(changed),
+        )
+    return None, claimed, sorted(changed)
+
+
 def _verify_created_cards(
     conn: sqlite3.Connection,
     completing_task_id: str,
@@ -5349,6 +5482,59 @@ class ArtifactPreservationError(RuntimeError):
     """Raised when a declared scratch deliverable cannot be preserved."""
 
 
+class CompletionEvidenceError(ValueError):
+    """Raised by ``complete_task`` when a task that declared an evidence
+    repository closes without a change that repository can confirm.
+
+    `done` is otherwise self-reported: ``complete_task`` stores a free-form
+    summary and a free-form metadata dict and checks neither against git, the
+    filesystem, or a test result. Measured on this install 2026-08-14, four rows
+    closed with "full backend suite 916 passed" and a reviewer's "APPROVED —
+    verified the diff covers every cited path" while no branch had a commit and
+    the worktree both of them named did not exist. The literature calls this
+    False Success and puts it at 44-76 % of all agent failures, so the sibling
+    gate for ``created_cards`` — phantom task ids, already refused here — is
+    extended to the same claim about files.
+
+    Sibling of :class:`HallucinatedCardsError` in every respect: a ``ValueError``
+    subclass so existing tool-error handlers treat it as recoverable, with the
+    structured facts attached for callers that want them.
+    """
+
+    def __init__(
+        self,
+        task_id: str,
+        repo: str,
+        claimed: list[str],
+        changed: Optional[list[str]],
+        reason: str,
+    ):
+        self.task_id = task_id
+        self.repo = repo
+        self.claimed = list(claimed)
+        # `None` means the repository could not be read at all, which is a
+        # different failure from "read it, nothing changed" and must not be
+        # flattened into an empty list.
+        self.changed = None if changed is None else list(changed)
+        self.reason = reason
+        if changed is None:
+            observed = "(repository unreadable — nothing could be checked)"
+        elif not changed:
+            observed = "(nothing — the working tree matches HEAD)"
+        else:
+            shown = ", ".join(changed[:5])
+            extra = len(changed) - 5
+            observed = f"{shown} (+{extra} more)" if extra > 0 else shown
+        super().__init__(
+            f"completion blocked: {reason}\n"
+            f"  repo:     {repo}\n"
+            f"  claimed:  {', '.join(claimed) or '(nothing)'}\n"
+            f"  changed:  {observed}\n"
+            f"  → put the paths you actually changed in metadata.changed_files, "
+            f'or block with kind="capability" if you could not make the change'
+        )
+
+
 def complete_task(
     conn: sqlite3.Connection,
     task_id: str,
@@ -5424,6 +5610,44 @@ def complete_task(
             raise HallucinatedCardsError(phantom_cards, task_id)
     else:
         verified_cards = []
+
+    # Sibling gate: the same treatment created_cards gets, applied to the
+    # claim about files. Opt-in — a NULL evidence_repo skips it entirely, so
+    # probes, syntheses and reviews close exactly as they always have.
+    evidence_row = conn.execute(
+        "SELECT evidence_repo FROM tasks WHERE id = ?",
+        (task_id,),
+    ).fetchone()
+    evidence_repo = (
+        evidence_row["evidence_repo"]
+        if evidence_row and "evidence_repo" in evidence_row.keys()
+        else None
+    )
+    if evidence_repo:
+        reason, claimed_paths, changed_paths = _verify_completion_evidence(
+            conn, task_id, evidence_repo, metadata
+        )
+        if reason:
+            with write_txn(conn):
+                _append_event(
+                    conn,
+                    task_id,
+                    "completion_blocked_no_evidence",
+                    {
+                        "evidence_repo": evidence_repo,
+                        "reason": reason,
+                        "claimed_paths": claimed_paths,
+                        "changed_paths": changed_paths,
+                        "summary_preview": (
+                            (summary or result or "").strip().splitlines()[0][:200]
+                            if (summary or result)
+                            else None
+                        ),
+                    },
+                )
+            raise CompletionEvidenceError(
+                task_id, evidence_repo, claimed_paths, changed_paths, reason
+            )
 
     metadata = _merge_completion_prose_artifacts(
         conn, task_id, metadata, summary=summary, result=result,
@@ -7529,6 +7753,71 @@ def _git_toplevel(path: Path) -> Optional[Path]:
         return Path(out).expanduser().resolve()
     except Exception:
         return Path(out).expanduser()
+
+
+def _git_changed_paths(repo: Path) -> Optional[set[str]]:
+    """Every path the working tree has touched since ``HEAD``, or ``None``.
+
+    ``None`` means the question could not be asked — the path is missing, is not
+    a git repository, or git failed. That is deliberately distinct from the
+    empty set, which means "asked, and nothing changed": a completion gate must
+    refuse both, but only the second is the worker's fault.
+
+    Working-tree state rather than commit range, because the cards in this
+    install routinely forbid committing. Measured 2026-08-14: the one task that
+    genuinely did its work left 23 modified files and zero commits, so a gate
+    that demanded a commit range would have rejected the honest case and passed
+    nothing at all.
+
+    Untracked files count. ``git diff`` alone cannot see a file that did not
+    exist at ``HEAD``, so a worker asked to write a new module would have had
+    its honest work refused. ``--exclude-standard`` keeps build output and
+    ignored files from passing as evidence.
+    """
+    seen: set[str] = set()
+    for argv in (
+        ["diff", "--name-only", "HEAD"],
+        ["ls-files", "--others", "--exclude-standard"],
+    ):
+        try:
+            result = subprocess.run(
+                ["git", "-C", str(repo), *argv],
+                capture_output=True,
+                text=True,
+                encoding="utf-8",
+                errors="replace",
+                timeout=30,
+                check=False,
+            )
+        except Exception:
+            return None
+        if result.returncode != 0:
+            return None
+        seen.update(
+            line.strip() for line in (result.stdout or "").splitlines() if line.strip()
+        )
+    return seen
+
+
+def _git_commit_exists(repo: Path, sha: str) -> bool:
+    """Whether ``sha`` resolves to a commit in ``repo``.
+
+    A fabricated identifier does not resolve, which is the point: it is the one
+    part of a completion claim that cannot be asserted into existence.
+    """
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(repo), "cat-file", "-e", f"{sha}^{{commit}}"],
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=30,
+            check=False,
+        )
+    except Exception:
+        return False
+    return result.returncode == 0
 
 
 def _git_branch_exists(repo_root: Path, branch_name: str) -> bool:

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -99,7 +99,17 @@ _log = logging.getLogger(__name__)
 # Constants
 # ---------------------------------------------------------------------------
 
-VALID_STATUSES = {"triage", "todo", "scheduled", "ready", "running", "blocked", "review", "done", "archived"}
+VALID_STATUSES = {
+    "triage",
+    "todo",
+    "scheduled",
+    "ready",
+    "running",
+    "blocked",
+    "review",
+    "done",
+    "archived",
+}
 VALID_INITIAL_STATUSES = {"running", "blocked"}
 
 # Typed block reasons. Distinguishes the two fundamentally different things a
@@ -152,9 +162,7 @@ def normalize_reasoning_effort(effort: Optional[str]) -> Optional[str]:
     if value == "none" or value in VALID_REASONING_EFFORTS:
         return value
     allowed = ", ".join(("none", *VALID_REASONING_EFFORTS))
-    raise ValueError(
-        f"reasoning_effort must be one of {allowed}, got {effort!r}"
-    )
+    raise ValueError(f"reasoning_effort must be one of {allowed}, got {effort!r}")
 
 
 KNOWN_TOOLSET_NAMES = frozenset(name.casefold() for name in get_toolset_names())
@@ -201,6 +209,7 @@ def _fire_kanban_lifecycle_hook(event: str, task_id: str, **fields: Any) -> None
     try:
         from hermes_cli.lifecycle import invoke_hook
         from hermes_cli.profiles import get_active_profile_name
+
         try:
             profile_name = get_active_profile_name()
         except Exception:
@@ -458,9 +467,7 @@ def _resolve_rate_limit_cooldown_seconds() -> int:
     the next tick) — useful for tests that want to assert the task becomes
     spawnable again immediately.
     """
-    raw = os.environ.get(
-        "HERMES_KANBAN_RATE_LIMIT_COOLDOWN_SECONDS", ""
-    ).strip()
+    raw = os.environ.get("HERMES_KANBAN_RATE_LIMIT_COOLDOWN_SECONDS", "").strip()
     if raw:
         try:
             parsed = int(raw)
@@ -476,11 +483,11 @@ def _resolve_rate_limit_cooldown_seconds() -> int:
 # summaries). Values chosen to fit a typical 100k-char LLM prompt with
 # plenty of headroom. Each constant is tuned independently so users
 # who need to relax one don't have to relax all of them.
-_CTX_MAX_PRIOR_ATTEMPTS = 10      # most recent N prior runs shown in full
-_CTX_MAX_COMMENTS       = 30      # most recent N comments shown in full
-_CTX_MAX_FIELD_BYTES    = 4 * 1024   # 4 KB per summary/error/metadata/result
-_CTX_MAX_BODY_BYTES     = 8 * 1024   # 8 KB per task.body (opening post)
-_CTX_MAX_COMMENT_BYTES  = 2 * 1024   # 2 KB per comment
+_CTX_MAX_PRIOR_ATTEMPTS = 10  # most recent N prior runs shown in full
+_CTX_MAX_COMMENTS = 30  # most recent N comments shown in full
+_CTX_MAX_FIELD_BYTES = 4 * 1024  # 4 KB per summary/error/metadata/result
+_CTX_MAX_BODY_BYTES = 8 * 1024  # 8 KB per task.body (opening post)
+_CTX_MAX_COMMENT_BYTES = 2 * 1024  # 2 KB per comment
 
 
 def _relative_age(ts: Optional[int], now: Optional[int] = None) -> str:
@@ -540,6 +547,7 @@ def scoped_current_board(slug: str):
     finally:
         _CURRENT_BOARD_OVERRIDE.reset(token)
 
+
 # Slug validator: lowercase alphanumerics, digits, hyphens; 1–64 chars.
 # Strict enough to stop traversal (`..`) and embedded path separators, loose
 # enough that kebab-case names like ``atm10-server`` or ``hermes-agent``
@@ -583,6 +591,7 @@ def kanban_home() -> Path:
     if override:
         return Path(override).expanduser()
     from hermes_constants import get_default_hermes_root
+
     return get_default_hermes_root()
 
 
@@ -826,7 +835,12 @@ def _default_board_display_name(slug: str) -> str:
     ``board.json`` but the default should look presentable in the
     dashboard without any follow-up editing.
     """
-    return " ".join(part.capitalize() for part in slug.replace("_", "-").split("-") if part) or slug
+    return (
+        " ".join(
+            part.capitalize() for part in slug.replace("_", "-").split("-") if part
+        )
+        or slug
+    )
 
 
 def read_board_metadata(board: Optional[str] = None) -> dict:
@@ -1041,6 +1055,7 @@ def remove_board(slug: str, *, archive: bool = True) -> dict:
         return {"slug": normed, "action": "archived", "new_path": str(target)}
     else:
         import shutil
+
         shutil.rmtree(d)
         return {"slug": normed, "action": "deleted", "new_path": ""}
 
@@ -1048,6 +1063,7 @@ def remove_board(slug: str, *, archive: bool = True) -> dict:
 # ---------------------------------------------------------------------------
 # Data classes
 # ---------------------------------------------------------------------------
+
 
 @dataclass
 class Task:
@@ -1179,9 +1195,12 @@ class Task:
             claim_expires=row["claim_expires"],
             tenant=row["tenant"] if "tenant" in keys else None,
             result=row["result"] if "result" in keys else None,
-            idempotency_key=row["idempotency_key"] if "idempotency_key" in keys else None,
+            idempotency_key=row["idempotency_key"]
+            if "idempotency_key" in keys
+            else None,
             consecutive_failures=(
-                row["consecutive_failures"] if "consecutive_failures" in keys
+                row["consecutive_failures"]
+                if "consecutive_failures" in keys
                 # Pre-migration fallback: ``_migrate_add_optional_columns`` always
                 # adds ``consecutive_failures`` now, so this branch is only reachable
                 # on a DB that was never opened since pre-#20410 code ran. Keep for
@@ -1190,7 +1209,8 @@ class Task:
             ),
             worker_pid=row["worker_pid"] if "worker_pid" in keys else None,
             last_failure_error=(
-                row["last_failure_error"] if "last_failure_error" in keys
+                row["last_failure_error"]
+                if "last_failure_error" in keys
                 # Same belt-and-suspenders fallback as consecutive_failures above.
                 else (row["last_spawn_error"] if "last_spawn_error" in keys else None)
             ),
@@ -1210,7 +1230,9 @@ class Task:
                 row["current_step_key"] if "current_step_key" in keys else None
             ),
             skills=skills_value,
-            model_override=row["model_override"] if "model_override" in keys and row["model_override"] else None,
+            model_override=row["model_override"]
+            if "model_override" in keys and row["model_override"]
+            else None,
             provider_override=(
                 row["provider_override"]
                 if "provider_override" in keys and row["provider_override"]
@@ -1221,25 +1243,27 @@ class Task:
                 if "reasoning_effort" in keys and row["reasoning_effort"]
                 else None
             ),
-            max_retries=(
-                row["max_retries"] if "max_retries" in keys else None
-            ),
+            max_retries=(row["max_retries"] if "max_retries" in keys else None),
             evidence_repo=(
                 row["evidence_repo"]
                 if "evidence_repo" in keys and row["evidence_repo"]
                 else None
             ),
             goal_mode=(
-                bool(row["goal_mode"]) if "goal_mode" in keys and row["goal_mode"] else False
+                bool(row["goal_mode"])
+                if "goal_mode" in keys and row["goal_mode"]
+                else False
             ),
             goal_max_turns=(
-                row["goal_max_turns"] if "goal_max_turns" in keys and row["goal_max_turns"] else None
+                row["goal_max_turns"]
+                if "goal_max_turns" in keys and row["goal_max_turns"]
+                else None
             ),
-            session_id=(
-                row["session_id"] if "session_id" in keys else None
-            ),
+            session_id=(row["session_id"] if "session_id" in keys else None),
             block_kind=(
-                row["block_kind"] if "block_kind" in keys and row["block_kind"] else None
+                row["block_kind"]
+                if "block_kind" in keys and row["block_kind"]
+                else None
             ),
             block_recurrences=(
                 int(row["block_recurrences"])
@@ -1676,7 +1700,8 @@ def _cross_process_init_lock(path: Path):
                 "without the cross-process lock (in-process lock + idempotent "
                 "init are the correctness backstop). A stuck holder is no longer "
                 "able to block this connect indefinitely (#36644).",
-                lock_path, _INIT_LOCK_TIMEOUT_SECONDS,
+                lock_path,
+                _INIT_LOCK_TIMEOUT_SECONDS,
             )
         yield
     finally:
@@ -1830,7 +1855,8 @@ def _maybe_checkpoint_wal(conn: sqlite3.Connection, db_path: Path) -> None:
         _log.debug(
             "kanban WAL checkpoint (PASSIVE) on %s -> %s "
             "(busy, wal_frames, checkpointed_frames)",
-            key, tuple(row) if row is not None else None,
+            key,
+            tuple(row) if row is not None else None,
         )
     except sqlite3.Error as exc:
         _log.debug("kanban WAL checkpoint on %s skipped: %s", key, exc)
@@ -1843,7 +1869,7 @@ def _looks_like_tls_record_at(data: bytes, offset: int) -> bool:
     content_type = data[offset]
     major = data[offset + 1]
     minor = data[offset + 2]
-    length = int.from_bytes(data[offset + 3:offset + 5], "big")
+    length = int.from_bytes(data[offset + 3 : offset + 5], "big")
     return (
         content_type in {0x14, 0x15, 0x16, 0x17}
         and major == 0x03
@@ -1911,7 +1937,9 @@ class KanbanDbCorruptError(RuntimeError):
 
 
 def _prune_corrupt_backups(
-    parent: Path, base_name: str, keep: Optional[Path] = None,
+    parent: Path,
+    base_name: str,
+    keep: Optional[Path] = None,
 ) -> None:
     """Cap the number of retained ``<db>.corrupt.<hash>.bak`` files.
 
@@ -2088,7 +2116,8 @@ def _repairable_index_names(messages: list[str]) -> Optional[list[str]]:
 
 
 def _attempt_index_reindex_repair(
-    path: Path, index_names: list[str],
+    path: Path,
+    index_names: list[str],
 ) -> tuple[bool, list[str]]:
     """REINDEX the named indexes, then re-run ``PRAGMA integrity_check``.
 
@@ -2178,8 +2207,7 @@ def _guard_existing_db_is_healthy(path: Path) -> None:
             probe.close()
         if not _integrity_messages_ok(messages):
             reason = (
-                f"integrity_check returned "
-                f"{messages[0] if messages else '<no row>'!r}"
+                f"integrity_check returned {messages[0] if messages else '<no row>'!r}"
             )
     except sqlite3.OperationalError:
         # Lock contention, busy, transient IO — not corruption. Let it propagate.
@@ -2196,7 +2224,8 @@ def _guard_existing_db_is_healthy(path: Path) -> None:
         _log.warning(
             "kanban DB %s failed integrity_check with index-only errors "
             "(%s); pre-repair backup at %s — attempting REINDEX auto-repair.",
-            resolved, ", ".join(index_names),
+            resolved,
+            ", ".join(index_names),
             backup if backup is not None else "<backup failed>",
         )
         repaired, post = _attempt_index_reindex_repair(resolved, index_names)
@@ -2204,7 +2233,8 @@ def _guard_existing_db_is_healthy(path: Path) -> None:
             _log.warning(
                 "kanban DB %s auto-repaired via REINDEX (%s); "
                 "integrity_check now clean. Pre-repair copy kept at %s.",
-                resolved, ", ".join(index_names),
+                resolved,
+                ", ".join(index_names),
                 backup if backup is not None else "<backup failed>",
             )
             return
@@ -2387,6 +2417,7 @@ def connect(
             conn.row_factory = sqlite3.Row
             with _INIT_LOCK:
                 from hermes_state import apply_wal_with_fallback
+
                 apply_wal_with_fallback(conn, db_label=f"kanban.db ({path.name})")
                 conn.execute("PRAGMA synchronous=FULL")
                 conn.execute("PRAGMA wal_autocheckpoint=100")
@@ -2426,6 +2457,7 @@ def connect(
         # read-only kanban.db fails with an actionable message instead of
         # "attempt to write a readonly database" mid-init.
         from hermes_state import preflight_db_writability
+
         preflight_db_writability(path, db_label=f"kanban.db ({path.name})")
         # Cheap byte-level check first — catches the #29507 TLS-overwrite shape
         # and other invalid-header cases without opening a sqlite connection.
@@ -2447,6 +2479,7 @@ def connect(
                 # falls back to DELETE with one ERROR log so kanban stays usable there.
                 # See hermes_state._WAL_INCOMPAT_MARKERS for detection logic.
                 from hermes_state import apply_wal_with_fallback
+
                 apply_wal_with_fallback(conn, db_label=f"kanban.db ({path.name})")
                 # FULL (was NORMAL): fsync before each checkpoint to narrow the
                 # crash window that can leave a b-tree page header torn.
@@ -2560,9 +2593,7 @@ def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
     if "project_id" not in cols:
         _add_column_if_missing(conn, "tasks", "project_id", "project_id TEXT")
     if "idempotency_key" not in cols:
-        _add_column_if_missing(
-            conn, "tasks", "idempotency_key", "idempotency_key TEXT"
-        )
+        _add_column_if_missing(conn, "tasks", "idempotency_key", "idempotency_key TEXT")
     # ``idx_tasks_idempotency`` is created unconditionally below alongside
     # the other additive-column indexes — see the block after the
     # legacy-column migration. Creating it here too would be redundant.
@@ -2604,9 +2635,7 @@ def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
             conn, "tasks", "last_failure_error", "last_failure_error TEXT"
         )
         if added and "last_spawn_error" in cols:
-            conn.execute(
-                "UPDATE tasks SET last_failure_error = last_spawn_error"
-            )
+            conn.execute("UPDATE tasks SET last_failure_error = last_spawn_error")
     if "max_runtime_seconds" not in cols:
         _add_column_if_missing(
             conn, "tasks", "max_runtime_seconds", "max_runtime_seconds INTEGER"
@@ -2684,9 +2713,7 @@ def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
         # created from within an agent loop that propagated
         # ``HERMES_SESSION_ID`` (e.g. ACP). NULL on legacy rows and on any
         # creation path that doesn't set the env var (CLI, dashboard).
-        _add_column_if_missing(
-            conn, "tasks", "session_id", "session_id TEXT"
-        )
+        _add_column_if_missing(conn, "tasks", "session_id", "session_id TEXT")
 
     if "block_kind" not in cols:
         # Typed block reason (VALID_BLOCK_KINDS) or NULL for legacy/un-typed
@@ -2715,9 +2742,7 @@ def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
     conn.execute(
         "CREATE INDEX IF NOT EXISTS idx_tasks_idempotency ON tasks(idempotency_key)"
     )
-    conn.execute(
-        "CREATE INDEX IF NOT EXISTS idx_tasks_session_id ON tasks(session_id)"
-    )
+    conn.execute("CREATE INDEX IF NOT EXISTS idx_tasks_session_id ON tasks(session_id)")
 
     # task_events gained a run_id column; back-fill it as NULL for
     # historical events (they predate runs and can't be attributed).
@@ -2728,14 +2753,14 @@ def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
     # Same ordering rule as the additive ``tasks`` indexes above: create the
     # index after the additive column migration so legacy ``task_events``
     # tables don't fail during SCHEMA_SQL execution before ``run_id`` exists.
-    conn.execute(
-        "CREATE INDEX IF NOT EXISTS idx_events_run "
-        "ON task_events(run_id, id)"
-    )
+    conn.execute("CREATE INDEX IF NOT EXISTS idx_events_run ON task_events(run_id, id)")
 
-    notify_table_exists = conn.execute(
-        "SELECT name FROM sqlite_master WHERE type='table' AND name='kanban_notify_subs'"
-    ).fetchone() is not None
+    notify_table_exists = (
+        conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='kanban_notify_subs'"
+        ).fetchone()
+        is not None
+    )
     if notify_table_exists:
         notify_cols = {
             row["name"] for row in conn.execute("PRAGMA table_info(kanban_notify_subs)")
@@ -2786,7 +2811,10 @@ def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
             )
         if "delivery_metadata" not in notify_cols:
             _add_column_if_missing(
-                conn, "kanban_notify_subs", "delivery_metadata", "delivery_metadata TEXT"
+                conn,
+                "kanban_notify_subs",
+                "delivery_metadata",
+                "delivery_metadata TEXT",
             )
 
     # One-shot backfill: any task that is 'running' before runs existed
@@ -2796,9 +2824,12 @@ def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
     # against any concurrent dispatcher, and the per-row UPDATE uses
     # ``current_run_id IS NULL`` as a CAS guard so a racing claim can't
     # produce an orphaned row if it interleaves with the backfill pass.
-    runs_exist = conn.execute(
-        "SELECT name FROM sqlite_master WHERE type='table' AND name='task_runs'"
-    ).fetchone() is not None
+    runs_exist = (
+        conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='task_runs'"
+        ).fetchone()
+        is not None
+    )
     if runs_exist:
         with write_txn(conn):
             inflight = conn.execute(
@@ -2819,9 +2850,13 @@ def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
                     ) VALUES (?, ?, 'running', ?, ?, ?, ?, ?, ?)
                     """,
                     (
-                        row["id"], row["assignee"], row["claim_lock"],
-                        row["claim_expires"], row["worker_pid"],
-                        row["max_runtime_seconds"], row["last_heartbeat_at"],
+                        row["id"],
+                        row["assignee"],
+                        row["claim_lock"],
+                        row["claim_expires"],
+                        row["worker_pid"],
+                        row["max_runtime_seconds"],
+                        row["last_heartbeat_at"],
                         started,
                     ),
                 )
@@ -2849,8 +2884,8 @@ def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
     # per DB because after the UPDATE no rows match the old kinds.
     _EVENT_RENAMES = (
         # (old, new)
-        ("ready",              "promoted"),
-        ("priority",           "reprioritized"),
+        ("ready", "promoted"),
+        ("priority", "reprioritized"),
         ("spawn_auto_blocked", "gave_up"),
     )
     for old, new in _EVENT_RENAMES:
@@ -3144,6 +3179,7 @@ def write_txn(conn: sqlite3.Connection, *, allow_nested: bool = False):
 # ID generation
 # ---------------------------------------------------------------------------
 
+
 def _new_task_id() -> str:
     """Generate a short, URL-safe task id.
 
@@ -3160,6 +3196,7 @@ def _new_task_id() -> str:
 def _claimer_id() -> str:
     """Return a ``host:pid`` string that identifies this claimer."""
     import socket
+
     try:
         host = socket.gethostname() or "unknown"
     except Exception:
@@ -3170,6 +3207,7 @@ def _claimer_id() -> str:
 # ---------------------------------------------------------------------------
 # Task creation / mutation
 # ---------------------------------------------------------------------------
+
 
 def _canonical_assignee(assignee: Optional[str]) -> Optional[str]:
     """Lowercase-assignee normalization for Kanban rows (dashboard/CLI parity)."""
@@ -3409,7 +3447,9 @@ def create_task(
             cleaned.append(name)
         if toolset_typos:
             quoted = ", ".join(repr(n) for n in toolset_typos)
-            noun = "is a toolset name" if len(toolset_typos) == 1 else "are toolset names"
+            noun = (
+                "is a toolset name" if len(toolset_typos) == 1 else "are toolset names"
+            )
             raise ValueError(
                 f"{quoted} {noun}, not skill name(s). "
                 "Put toolsets in the assignee profile's `toolsets:` config "
@@ -3472,7 +3512,9 @@ def create_task(
                     if parents:
                         missing = _find_missing_parents(conn, parents)
                         if missing:
-                            raise ValueError(f"unknown parent task(s): {', '.join(missing)}")
+                            raise ValueError(
+                                f"unknown parent task(s): {', '.join(missing)}"
+                            )
                 elif triage:
                     task_status = "triage"
                 else:
@@ -3480,7 +3522,9 @@ def create_task(
                     if parents:
                         missing = _find_missing_parents(conn, parents)
                         if missing:
-                            raise ValueError(f"unknown parent task(s): {', '.join(missing)}")
+                            raise ValueError(
+                                f"unknown parent task(s): {', '.join(missing)}"
+                            )
                         # If any parent is not yet done, we're todo.
                         rows = conn.execute(
                             "SELECT status FROM tasks WHERE id IN "
@@ -3494,7 +3538,9 @@ def create_task(
                 if triage and parents:
                     missing = _find_missing_parents(conn, parents)
                     if missing:
-                        raise ValueError(f"unknown parent task(s): {', '.join(missing)}")
+                        raise ValueError(
+                            f"unknown parent task(s): {', '.join(missing)}"
+                        )
 
                 # Project-linked worktree: a fresh worktree dir under the repo
                 # plus a deterministic branch (project slug + task id). Together
@@ -3542,7 +3588,9 @@ def create_task(
                         project_id,
                         tenant,
                         idempotency_key,
-                        int(max_runtime_seconds) if max_runtime_seconds is not None else None,
+                        int(max_runtime_seconds)
+                        if max_runtime_seconds is not None
+                        else None,
                         json.dumps(skills_list) if skills_list is not None else None,
                         int(max_retries) if max_retries is not None else None,
                         (evidence_repo.strip() or None) if evidence_repo else None,
@@ -3592,7 +3640,9 @@ def create_task(
     raise RuntimeError("unreachable")
 
 
-def _find_missing_parents(conn: sqlite3.Connection, parents: Iterable[str]) -> list[str]:
+def _find_missing_parents(
+    conn: sqlite3.Connection, parents: Iterable[str]
+) -> list[str]:
     parents = list(parents)
     if not parents:
         return []
@@ -3755,7 +3805,9 @@ def assign_task(conn: sqlite3.Connection, task_id: str, profile: Optional[str]) 
                 (profile, task_id),
             )
         else:
-            conn.execute("UPDATE tasks SET assignee = ? WHERE id = ?", (profile, task_id))
+            conn.execute(
+                "UPDATE tasks SET assignee = ? WHERE id = ?", (profile, task_id)
+            )
         _append_event(conn, task_id, "assigned", {"assignee": profile})
     # Task-mutation observer (RFC #58548), fired AFTER the assignment txn
     # has committed so subscribers always observe durable board state.
@@ -3802,7 +3854,9 @@ def set_model_override(
             (model, provider, task_id),
         )
         _append_event(
-            conn, task_id, "model_override_set",
+            conn,
+            task_id,
+            "model_override_set",
             {"model": model, "provider": provider},
         )
     # Task-mutation observer (RFC #58548), fired AFTER the txn commits.
@@ -3854,6 +3908,7 @@ def set_reasoning_effort(
 # Links
 # ---------------------------------------------------------------------------
 
+
 def link_tasks(conn: sqlite3.Connection, parent_id: str, child_id: str) -> None:
     if parent_id == child_id:
         raise ValueError("a task cannot depend on itself")
@@ -3862,9 +3917,7 @@ def link_tasks(conn: sqlite3.Connection, parent_id: str, child_id: str) -> None:
         if missing:
             raise ValueError(f"unknown task(s): {', '.join(missing)}")
         if _would_cycle(conn, parent_id, child_id):
-            raise ValueError(
-                f"linking {parent_id} -> {child_id} would create a cycle"
-            )
+            raise ValueError(f"linking {parent_id} -> {child_id} would create a cycle")
         conn.execute(
             "INSERT OR IGNORE INTO task_links (parent_id, child_id) VALUES (?, ?)",
             (parent_id, child_id),
@@ -3879,7 +3932,9 @@ def link_tasks(conn: sqlite3.Connection, parent_id: str, child_id: str) -> None:
                 (child_id,),
             )
         _append_event(
-            conn, child_id, "linked",
+            conn,
+            child_id,
+            "linked",
             {"parent": parent_id, "child": child_id},
         )
         _inherit_notify_subs(conn, child_id, (parent_id,))
@@ -3916,7 +3971,9 @@ def unlink_tasks(conn: sqlite3.Connection, parent_id: str, child_id: str) -> boo
         )
         if cur.rowcount:
             _append_event(
-                conn, child_id, "unlinked",
+                conn,
+                child_id,
+                "unlinked",
                 {"parent": parent_id, "child": child_id},
             )
         removed = cur.rowcount > 0
@@ -3950,10 +4007,7 @@ def task_graph_contexts(
 ) -> dict[str, dict]:
     """Bulk-load compact direct graph state for graph-aware diagnostics."""
     ordered_ids = list(dict.fromkeys(str(task_id) for task_id in task_ids if task_id))
-    contexts = {
-        task_id: {"parents": [], "children": []}
-        for task_id in ordered_ids
-    }
+    contexts = {task_id: {"parents": [], "children": []} for task_id in ordered_ids}
     if not ordered_ids:
         return contexts
 
@@ -3988,7 +4042,9 @@ def task_graph_context(conn: sqlite3.Connection, task_id: str) -> dict:
     return task_graph_contexts(conn, [task_id])[task_id]
 
 
-def parent_results(conn: sqlite3.Connection, task_id: str) -> list[tuple[str, Optional[str]]]:
+def parent_results(
+    conn: sqlite3.Connection, task_id: str
+) -> list[tuple[str, Optional[str]]]:
     """Return ``(parent_id, result)`` for every done parent of ``task_id``."""
     rows = conn.execute(
         """
@@ -4007,9 +4063,8 @@ def parent_results(conn: sqlite3.Connection, task_id: str) -> list[tuple[str, Op
 # Comments & events
 # ---------------------------------------------------------------------------
 
-def add_comment(
-    conn: sqlite3.Connection, task_id: str, author: str, body: str
-) -> int:
+
+def add_comment(conn: sqlite3.Connection, task_id: str, author: str, body: str) -> int:
     if not body or not body.strip():
         raise ValueError("comment body is required")
     if not author or not author.strip():
@@ -4018,9 +4073,7 @@ def add_comment(
     # ``allow_nested=True``: graph builders (kanban_swarm blackboard seeding)
     # compose comment writes under one outer commit.
     with write_txn(conn, allow_nested=True):
-        if not conn.execute(
-            "SELECT 1 FROM tasks WHERE id = ?", (task_id,)
-        ).fetchone():
+        if not conn.execute("SELECT 1 FROM tasks WHERE id = ?", (task_id,)).fetchone():
             raise ValueError(f"unknown task {task_id}")
         cur = conn.execute(
             "INSERT INTO task_comments (task_id, author, body, created_at) "
@@ -4212,9 +4265,7 @@ def add_attachment(
         raise ValueError("attachment stored_path is required")
     now = int(time.time())
     with write_txn(conn):
-        if not conn.execute(
-            "SELECT 1 FROM tasks WHERE id = ?", (task_id,)
-        ).fetchone():
+        if not conn.execute("SELECT 1 FROM tasks WHERE id = ?", (task_id,)).fetchone():
             raise ValueError(f"unknown task {task_id}")
         cur = conn.execute(
             "INSERT INTO task_attachments "
@@ -4259,7 +4310,9 @@ def list_attachments(conn: sqlite3.Connection, task_id: str) -> list[Attachment]
     ]
 
 
-def get_attachment(conn: sqlite3.Connection, attachment_id: int) -> Optional[Attachment]:
+def get_attachment(
+    conn: sqlite3.Connection, attachment_id: int
+) -> Optional[Attachment]:
     r = conn.execute(
         "SELECT * FROM task_attachments WHERE id = ?", (attachment_id,)
     ).fetchone()
@@ -4277,7 +4330,9 @@ def get_attachment(conn: sqlite3.Connection, attachment_id: int) -> Optional[Att
     )
 
 
-def delete_attachment(conn: sqlite3.Connection, attachment_id: int) -> Optional[Attachment]:
+def delete_attachment(
+    conn: sqlite3.Connection, attachment_id: int
+) -> Optional[Attachment]:
     """Delete an attachment row and its on-disk blob. Returns the removed row.
 
     Returns ``None`` when no row matched. The blob is removed best-effort
@@ -4319,7 +4374,11 @@ def list_events(conn: sqlite3.Connection, task_id: str) -> list[Event]:
                 kind=r["kind"],
                 payload=payload,
                 created_at=r["created_at"],
-                run_id=(int(r["run_id"]) if "run_id" in r.keys() and r["run_id"] is not None else None),
+                run_id=(
+                    int(r["run_id"])
+                    if "run_id" in r.keys() and r["run_id"] is not None
+                    else None
+                ),
             )
         )
     return out
@@ -4370,7 +4429,8 @@ def _end_run(
     """
     now = int(time.time())
     row = conn.execute(
-        "SELECT current_run_id FROM tasks WHERE id = ?", (task_id,),
+        "SELECT current_run_id FROM tasks WHERE id = ?",
+        (task_id,),
     ).fetchone()
     if not row or not row["current_run_id"]:
         return None
@@ -4401,14 +4461,16 @@ def _end_run(
         ),
     )
     conn.execute(
-        "UPDATE tasks SET current_run_id = NULL WHERE id = ?", (task_id,),
+        "UPDATE tasks SET current_run_id = NULL WHERE id = ?",
+        (task_id,),
     )
     return run_id
 
 
 def _current_run_id(conn: sqlite3.Connection, task_id: str) -> Optional[int]:
     row = conn.execute(
-        "SELECT current_run_id FROM tasks WHERE id = ?", (task_id,),
+        "SELECT current_run_id FROM tasks WHERE id = ?",
+        (task_id,),
     ).fetchone()
     return int(row["current_run_id"]) if row and row["current_run_id"] else None
 
@@ -4454,11 +4516,16 @@ def _synthesize_ended_run(
         ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         """,
         (
-            task_id, profile, step_key,
-            outcome, outcome,
-            summary, error,
+            task_id,
+            profile,
+            step_key,
+            outcome,
+            outcome,
+            summary,
+            error,
             json.dumps(metadata, ensure_ascii=False) if metadata else None,
-            now, now,
+            now,
+            now,
         ),
     )
     return int(cur.lastrowid or 0)
@@ -4467,6 +4534,7 @@ def _synthesize_ended_run(
 # ---------------------------------------------------------------------------
 # Dependency resolution (todo -> ready)
 # ---------------------------------------------------------------------------
+
 
 def _has_sticky_block(conn: sqlite3.Connection, task_id: str) -> bool:
     """Return True when ``task_id`` is sticky-blocked by an explicit
@@ -4536,7 +4604,8 @@ def _resume_status_from_events(conn: sqlite3.Connection, task_id: str) -> str:
 
 
 def recompute_ready(
-    conn: sqlite3.Connection, failure_limit: int = None,
+    conn: sqlite3.Connection,
+    failure_limit: int = None,
 ) -> int:
     """Promote ``todo`` tasks to ``ready`` when all parents are ``done`` or ``archived``.
 
@@ -4604,7 +4673,8 @@ def recompute_ready(
                     failures = int(row["consecutive_failures"] or 0)
                     task_limit = row["max_retries"]
                     effective_limit = (
-                        int(task_limit) if task_limit is not None
+                        int(task_limit)
+                        if task_limit is not None
                         else int(failure_limit)
                     )
                     if failures >= effective_limit:
@@ -4620,7 +4690,9 @@ def recompute_ready(
                         (resume_status, task_id),
                     )
                 _append_event(
-                    conn, task_id, "promoted",
+                    conn,
+                    task_id,
+                    "promoted",
                     {"status": resume_status} if resume_status != "ready" else None,
                 )
                 promoted += 1
@@ -4631,15 +4703,19 @@ def recompute_ready(
 # Claim / complete / block
 # ---------------------------------------------------------------------------
 
+
 def _parents_satisfied(conn: sqlite3.Connection, task_id: str) -> bool:
     """Return whether every direct parent is terminal for dependency gating."""
-    return conn.execute(
-        "SELECT 1 FROM task_links l "
-        "JOIN tasks p ON p.id = l.parent_id "
-        "WHERE l.child_id = ? "
-        "AND p.status NOT IN ('done', 'archived') LIMIT 1",
-        (task_id,),
-    ).fetchone() is None
+    return (
+        conn.execute(
+            "SELECT 1 FROM task_links l "
+            "JOIN tasks p ON p.id = l.parent_id "
+            "WHERE l.child_id = ? "
+            "AND p.status NOT IN ('done', 'archived') LIMIT 1",
+            (task_id,),
+        ).fetchone()
+        is None
+    )
 
 
 def claim_task(
@@ -4674,12 +4750,13 @@ def claim_task(
         ).fetchone()
         if undone:
             conn.execute(
-                "UPDATE tasks SET status = 'todo' "
-                "WHERE id = ? AND status = 'ready'",
+                "UPDATE tasks SET status = 'todo' WHERE id = ? AND status = 'ready'",
                 (task_id,),
             )
             _append_event(
-                conn, task_id, "claim_rejected",
+                conn,
+                task_id,
+                "claim_rejected",
                 {"reason": "parents_not_done"},
             )
             return None
@@ -4749,7 +4826,9 @@ def claim_task(
             (run_id, task_id),
         )
         _append_event(
-            conn, task_id, "claimed",
+            conn,
+            task_id,
+            "claimed",
             {"lock": lock, "expires": expires, "run_id": run_id},
             run_id=run_id,
         )
@@ -4847,9 +4926,15 @@ def claim_review_task(
             (run_id, task_id),
         )
         _append_event(
-            conn, task_id, "claimed",
-            {"lock": lock, "expires": expires, "run_id": run_id,
-             "source_status": "review"},
+            conn,
+            task_id,
+            "claimed",
+            {
+                "lock": lock,
+                "expires": expires,
+                "run_id": run_id,
+                "source_status": "review",
+            },
             run_id=run_id,
         )
         return get_task(conn, task_id)
@@ -4910,11 +4995,7 @@ def goal_run_status(
             "SELECT outcome FROM task_runs WHERE id = ? AND task_id = ?",
             (int(expected_run_id), task_id),
         ).fetchone()
-        outcome = (
-            str(row["outcome"])
-            if row and row["outcome"] is not None
-            else None
-        )
+        outcome = str(row["outcome"]) if row and row["outcome"] is not None else None
         terminal_status = (
             {
                 "completed": "done",
@@ -4932,8 +5013,7 @@ def goal_run_status(
             return "superseded"
     if task.status in {"ready", "todo"}:
         event = conn.execute(
-            "SELECT kind FROM task_events WHERE task_id = ? "
-            "ORDER BY id DESC LIMIT 1",
+            "SELECT kind FROM task_events WHERE task_id = ? ORDER BY id DESC LIMIT 1",
             (task_id,),
         ).fetchone()
         if event and event["kind"] == "changes_requested":
@@ -5050,7 +5130,9 @@ def release_stale_claims(
                         (new_expires, run_id),
                     )
                 _append_event(
-                    conn, row["id"], "claim_extended",
+                    conn,
+                    row["id"],
+                    "claim_extended",
                     {
                         "reason": "pid_alive",
                         "worker_pid": int(row["worker_pid"]),
@@ -5068,13 +5150,19 @@ def release_stale_claims(
             continue
 
         termination = _terminate_reclaimed_worker(
-            row["worker_pid"], row["claim_lock"], signal_fn=signal_fn,
+            row["worker_pid"],
+            row["claim_lock"],
+            signal_fn=signal_fn,
         )
         # Never release a claim while our own worker is still alive: that would
         # spawn a duplicate beside it. Hold the claim and retry next tick.
         if _worker_survived_termination(termination):
             _defer_reclaim_for_live_worker(
-                conn, row["id"], row["claim_lock"], now, termination,
+                conn,
+                row["id"],
+                row["claim_lock"],
+                now,
+                termination,
                 reason="ttl_expired_worker_alive",
             )
             continue
@@ -5090,21 +5178,23 @@ def release_stale_claims(
             if cur.rowcount != 1:
                 continue
             run_id = _end_run(
-                conn, row["id"],
-                outcome="reclaimed", status="reclaimed",
+                conn,
+                row["id"],
+                outcome="reclaimed",
+                status="reclaimed",
                 error=f"stale_lock={row['claim_lock']}",
                 metadata=termination,
             )
             payload = {
                 "stale_lock": row["claim_lock"],
                 "worker_pid": (
-                    int(row["worker_pid"])
-                    if row["worker_pid"] is not None else None
+                    int(row["worker_pid"]) if row["worker_pid"] is not None else None
                 ),
                 "claim_expires": int(row["claim_expires"]),
                 "last_heartbeat_at": (
                     int(row["last_heartbeat_at"])
-                    if row["last_heartbeat_at"] is not None else None
+                    if row["last_heartbeat_at"] is not None
+                    else None
                 ),
                 "now": now,
                 "host_local": host_local,
@@ -5113,7 +5203,9 @@ def release_stale_claims(
             }
             payload.update(termination)
             _append_event(
-                conn, row["id"], "reclaimed",
+                conn,
+                row["id"],
+                "reclaimed",
                 payload,
                 run_id=run_id,
             )
@@ -5130,8 +5222,7 @@ def release_stale_claims(
                 assignee=row["assignee"],
                 run_id=run_id,
                 worker_pid=(
-                    int(row["worker_pid"])
-                    if row["worker_pid"] is not None else None
+                    int(row["worker_pid"]) if row["worker_pid"] is not None else None
                 ),
                 heartbeat_stale=bool(heartbeat_stale),
                 retry_status=retry_status,
@@ -5168,7 +5259,9 @@ def reclaim_task(
         return False
     prev_lock = row["claim_lock"]
     termination = _terminate_reclaimed_worker(
-        row["worker_pid"], prev_lock, signal_fn=signal_fn,
+        row["worker_pid"],
+        prev_lock,
+        signal_fn=signal_fn,
     )
     with write_txn(conn):
         retry_status = _retry_status_for_run(conn, task_id)
@@ -5182,10 +5275,13 @@ def reclaim_task(
         if cur.rowcount != 1:
             return False
         run_id = _end_run(
-            conn, task_id,
-            outcome="reclaimed", status="reclaimed",
+            conn,
+            task_id,
+            outcome="reclaimed",
+            status="reclaimed",
             error=(
-                f"manual_reclaim: {reason}" if reason
+                f"manual_reclaim: {reason}"
+                if reason
                 else f"manual_reclaim lock={prev_lock}"
             ),
             metadata=termination,
@@ -5198,7 +5294,9 @@ def reclaim_task(
         }
         payload.update(termination)
         _append_event(
-            conn, task_id, "reclaimed",
+            conn,
+            task_id,
+            "reclaimed",
             payload,
             run_id=run_id,
         )
@@ -5383,7 +5481,8 @@ def _verify_created_cards(
             ordered.append(cid)
 
     row = conn.execute(
-        "SELECT assignee FROM tasks WHERE id = ?", (completing_task_id,),
+        "SELECT assignee FROM tasks WHERE id = ?",
+        (completing_task_id,),
     ).fetchone()
     if row is None:
         # Completing task not found — nothing resolves.
@@ -5596,7 +5695,9 @@ def complete_task(
         if phantom_cards:
             with write_txn(conn):
                 _append_event(
-                    conn, task_id, "completion_blocked_hallucination",
+                    conn,
+                    task_id,
+                    "completion_blocked_hallucination",
                     {
                         "phantom_cards": phantom_cards,
                         "verified_cards": verified_cards,
@@ -5650,7 +5751,11 @@ def complete_task(
             )
 
     metadata = _merge_completion_prose_artifacts(
-        conn, task_id, metadata, summary=summary, result=result,
+        conn,
+        task_id,
+        metadata,
+        summary=summary,
+        result=result,
     )
     with write_txn(conn):
         # Parent completion is a hard invariant even for direct human review
@@ -5713,8 +5818,10 @@ def complete_task(
                     created_at=now,
                 )
         run_id = _end_run(
-            conn, task_id,
-            outcome="completed", status="done",
+            conn,
+            task_id,
+            outcome="completed",
+            status="done",
             summary=summary if summary is not None else result,
             metadata=metadata,
         )
@@ -5734,7 +5841,8 @@ def complete_task(
                     "approval": "manual",
                 }
             run_id = _synthesize_ended_run(
-                conn, task_id,
+                conn,
+                task_id,
                 outcome="completed",
                 summary=synth_summary,
                 metadata=synth_metadata,
@@ -5764,12 +5872,16 @@ def complete_task(
             md_artifacts = metadata.get("artifacts")
             if isinstance(md_artifacts, (list, tuple)):
                 cleaned_artifacts = [
-                    str(p).strip() for p in md_artifacts if isinstance(p, str) and str(p).strip()
+                    str(p).strip()
+                    for p in md_artifacts
+                    if isinstance(p, str) and str(p).strip()
                 ]
                 if cleaned_artifacts:
                     completed_payload["artifacts"] = cleaned_artifacts
         _append_event(
-            conn, task_id, "completed",
+            conn,
+            task_id,
+            "completed",
             completed_payload,
             run_id=run_id,
         )
@@ -5787,7 +5899,9 @@ def complete_task(
         if phantom_refs:
             with write_txn(conn):
                 _append_event(
-                    conn, task_id, "suspected_hallucinated_references",
+                    conn,
+                    task_id,
+                    "suspected_hallucinated_references",
                     {
                         "phantom_refs": phantom_refs,
                         "source": "completion_summary",
@@ -5943,8 +6057,13 @@ def _persist_scratch_completion_artifacts(
         dest: Optional[Path] = None
         try:
             attachment_dir.mkdir(parents=True, exist_ok=True)
-            dest = _unique_attachment_path(attachment_dir, resolved_src.name, used_destinations)
-            with resolved_src.open("rb") as source_file, dest.open("xb") as destination_file:
+            dest = _unique_attachment_path(
+                attachment_dir, resolved_src.name, used_destinations
+            )
+            with (
+                resolved_src.open("rb") as source_file,
+                dest.open("xb") as destination_file,
+            ):
                 copied = 0
                 while chunk := source_file.read(1024 * 1024):
                     copied += len(chunk)
@@ -6037,7 +6156,10 @@ def _managed_scratch_path_info(p: Path) -> tuple[bool, Optional[str]]:
         home = None
     if home is not None:
         try:
-            roots.append(((home / "kanban" / "workspaces").resolve(strict=False), DEFAULT_BOARD))
+            roots.append((
+                (home / "kanban" / "workspaces").resolve(strict=False),
+                DEFAULT_BOARD,
+            ))
         except OSError:
             pass
         try:
@@ -6056,7 +6178,10 @@ def _managed_scratch_path_info(p: Path) -> tuple[bool, Optional[str]]:
                 except OSError:
                     continue
                 try:
-                    roots.append(((entry / "workspaces").resolve(strict=False), entry.name))
+                    roots.append((
+                        (entry / "workspaces").resolve(strict=False),
+                        entry.name,
+                    ))
                 except OSError:
                     continue
     for root, board in roots:
@@ -6136,10 +6261,12 @@ def _cleanup_workspace(conn: sqlite3.Connection, task_id: str) -> None:
             _log.debug(
                 "Deferring scratch workspace cleanup for task %s: "
                 "active children still need workspace at %s",
-                task_id, path,
+                task_id,
+                path,
             )
             return
         import shutil
+
         wp = Path(path)
         if wp.is_dir():
             # Containment guard (#28818): a board's ``default_workdir`` can
@@ -6155,7 +6282,8 @@ def _cleanup_workspace(conn: sqlite3.Connection, task_id: str) -> None:
                     "Refusing to remove out-of-scratch workspace for task %s: %s "
                     "(workspace_kind='scratch' but path is outside any "
                     "kanban-managed workspaces root)",
-                    task_id, wp,
+                    task_id,
+                    wp,
                 )
         # Also kill the tmux session for the worker that owned this task,
         # if the tmux session is now dead (worker process exited).
@@ -6186,7 +6314,11 @@ def _try_cleanup_parent_workspaces(conn: sqlite3.Connection, task_id: str) -> No
                 "SELECT workspace_kind, workspace_path FROM tasks WHERE id = ?",
                 (parent_id,),
             ).fetchone()
-            if not row or row["workspace_kind"] != "scratch" or not row["workspace_path"]:
+            if (
+                not row
+                or row["workspace_kind"] != "scratch"
+                or not row["workspace_path"]
+            ):
                 continue
             # Check if ALL children of this parent are terminal
             active = conn.execute(
@@ -6200,10 +6332,15 @@ def _try_cleanup_parent_workspaces(conn: sqlite3.Connection, task_id: str) -> No
                 continue  # still has active children
             # All children done — safe to clean up parent workspace
             import shutil
+
             wp = Path(row["workspace_path"])
             if wp.is_dir() and _is_managed_scratch_path(wp):
                 shutil.rmtree(wp, ignore_errors=True)
-                _log.debug("Deferred cleanup: removed parent %s scratch workspace: %s", parent_id, wp)
+                _log.debug(
+                    "Deferred cleanup: removed parent %s scratch workspace: %s",
+                    parent_id,
+                    wp,
+                )
     except Exception:
         pass  # best-effort
 
@@ -6222,12 +6359,17 @@ def _cleanup_worker_tmux(conn: sqlite3.Connection, task_id: str) -> None:
         # Check if session exists and pane is dead before killing
         out = subprocess.run(
             ["tmux", "list-panes", "-t", session, "-F", "#{pane_dead}"],
-            capture_output=True, text=True, encoding='utf-8', errors='replace', timeout=5,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=5,
         )
         if out.stdout.strip() == "1":
             subprocess.run(
                 ["tmux", "kill-session", "-t", session],
-                capture_output=True, timeout=5,
+                capture_output=True,
+                timeout=5,
             )
             _log.debug("Killed stale tmux session: %s", session)
     except Exception:
@@ -6311,7 +6453,9 @@ def _maybe_emit_scratch_tip(
         _log.warning("kanban: %s (task %s)", _SCRATCH_TIP_MESSAGE, task_id)
         with write_txn(conn):
             _append_event(
-                conn, task_id, "tip_scratch_workspace",
+                conn,
+                task_id,
+                "tip_scratch_workspace",
                 {"message": _SCRATCH_TIP_MESSAGE},
             )
     except Exception:
@@ -6333,7 +6477,8 @@ def edit_completed_task_result(
     handoff_summary = summary if summary is not None else result
     with write_txn(conn):
         row = conn.execute(
-            "SELECT status FROM tasks WHERE id = ?", (task_id,),
+            "SELECT status FROM tasks WHERE id = ?",
+            (task_id,),
         ).fetchone()
         if not row or row["status"] != "done":
             return False
@@ -6354,7 +6499,8 @@ def edit_completed_task_result(
         run_id = int(run["id"]) if run else None
         if run_id is None:
             run_id = _synthesize_ended_run(
-                conn, task_id,
+                conn,
+                task_id,
                 outcome="completed",
                 summary=handoff_summary,
                 metadata=metadata,
@@ -6372,7 +6518,9 @@ def edit_completed_task_result(
         _ev_lines = (handoff_summary or "").strip().splitlines()
         ev_summary = _ev_lines[0][:400] if _ev_lines else ""
         _append_event(
-            conn, task_id, "edited",
+            conn,
+            task_id,
+            "edited",
             {
                 "fields": (
                     ["result", "summary"]
@@ -6461,23 +6609,32 @@ def block_task(
                        block_kind    = ?
                  WHERE id = ?
                    AND status IN ('running', 'ready')
-                """ + ("" if expected_run_id is None else " AND current_run_id = ?"),
-                (kind, task_id) if expected_run_id is None
+                """
+                + ("" if expected_run_id is None else " AND current_run_id = ?"),
+                (kind, task_id)
+                if expected_run_id is None
                 else (kind, task_id, int(expected_run_id)),
             )
             if cur.rowcount != 1:
                 return False
             run_id = _end_run(
-                conn, task_id,
-                outcome="blocked", status="blocked",
+                conn,
+                task_id,
+                outcome="blocked",
+                status="blocked",
                 summary=reason,
             )
             if run_id is None and reason:
                 run_id = _synthesize_ended_run(
-                    conn, task_id, outcome="blocked", summary=reason,
+                    conn,
+                    task_id,
+                    outcome="blocked",
+                    summary=reason,
                 )
             _append_event(
-                conn, task_id, "dependency_wait",
+                conn,
+                task_id,
+                "dependency_wait",
                 {
                     "reason": reason,
                     "kind": kind,
@@ -6519,23 +6676,32 @@ def block_task(
                        block_recurrences = ?
                  WHERE id = ?
                    AND status IN ('running', 'ready')
-                """ + ("" if expected_run_id is None else " AND current_run_id = ?"),
-                (kind, recurrences, task_id) if expected_run_id is None
+                """
+                + ("" if expected_run_id is None else " AND current_run_id = ?"),
+                (kind, recurrences, task_id)
+                if expected_run_id is None
                 else (kind, recurrences, task_id, int(expected_run_id)),
             )
             if cur.rowcount != 1:
                 return False
             run_id = _end_run(
-                conn, task_id,
-                outcome="blocked", status="blocked",
+                conn,
+                task_id,
+                outcome="blocked",
+                status="blocked",
                 summary=reason,
             )
             if run_id is None and reason:
                 run_id = _synthesize_ended_run(
-                    conn, task_id, outcome="blocked", summary=reason,
+                    conn,
+                    task_id,
+                    outcome="blocked",
+                    summary=reason,
                 )
             _append_event(
-                conn, task_id, "block_loop_detected",
+                conn,
+                task_id,
+                "block_loop_detected",
                 {
                     "reason": reason,
                     "kind": kind,
@@ -6580,20 +6746,25 @@ def block_task(
             if cur.rowcount != 1:
                 return False
             run_id = _end_run(
-                conn, task_id,
-                outcome="blocked", status="blocked",
+                conn,
+                task_id,
+                outcome="blocked",
+                status="blocked",
                 summary=reason,
             )
             # Synthesize a run when blocking a never-claimed task so the
             # reason is preserved in attempt history.
             if run_id is None and reason:
                 run_id = _synthesize_ended_run(
-                    conn, task_id,
+                    conn,
+                    task_id,
                     outcome="blocked",
                     summary=reason,
                 )
             _append_event(
-                conn, task_id, "blocked",
+                conn,
+                task_id,
+                "blocked",
                 {
                     "reason": reason,
                     "kind": kind,
@@ -6612,7 +6783,6 @@ def block_task(
         reason=reason,
     )
     return True
-
 
 
 def redact_review_value(value: Any) -> Any:
@@ -6671,7 +6841,8 @@ def request_review(
             return _ret(False, "parent dependencies are not satisfied")
         trow = conn.execute(
             "SELECT assignee, status, claim_lock, current_run_id "
-            "FROM tasks WHERE id = ?", (task_id,),
+            "FROM tasks WHERE id = ?",
+            (task_id,),
         ).fetchone()
         if trow is None:
             return _ret(False, "task not found")
@@ -6748,10 +6919,13 @@ def request_review(
                    claim_lock    = NULL,
                    claim_expires = NULL,
                    worker_pid    = NULL
-            """ + assignee_sql + """
+            """
+            + assignee_sql
+            + """
              WHERE id = ?
                AND status IN ('running', 'ready')
-            """ + run_guard,
+            """
+            + run_guard,
             params,
         )
         if cur.rowcount != 1:
@@ -6930,9 +7104,7 @@ def promote_task(
     ``(False, reason)`` if refused. ``dry_run=True`` validates the
     promotion would succeed without mutating state.
     """
-    row = conn.execute(
-        "SELECT status FROM tasks WHERE id = ?", (task_id,)
-    ).fetchone()
+    row = conn.execute("SELECT status FROM tasks WHERE id = ?", (task_id,)).fetchone()
     if row is None:
         return False, f"task {task_id} not found"
 
@@ -6951,8 +7123,7 @@ def promote_task(
             (task_id,),
         ).fetchall()
         unsatisfied = [
-            p["id"] for p in parents
-            if p["status"] not in ("done", "archived")
+            p["id"] for p in parents if p["status"] not in ("done", "archived")
         ]
         if unsatisfied:
             return False, (
@@ -6982,7 +7153,12 @@ def promote_task(
 
 
 def _reclaim_dangling_run(
-    conn: sqlite3.Connection, task_id: str, *, statuses, now: int, note: str,
+    conn: sqlite3.Connection,
+    task_id: str,
+    *,
+    statuses,
+    now: int,
+    note: str,
 ) -> None:
     """Close a leaked ``current_run_id`` (run row still open) before a status
     flip, preserving the runs invariant (``current_run_id IS NULL`` ⇔ run row
@@ -7052,7 +7228,10 @@ def unblock_task(conn: sqlite3.Connection, task_id: str) -> bool:
             else "ready"
         )
         _reclaim_dangling_run(
-            conn, task_id, statuses=("blocked", "scheduled"), now=now,
+            conn,
+            task_id,
+            statuses=("blocked", "scheduled"),
+            now=now,
             note="invariant recovery on unblock",
         )
         # Re-gate on parent completion before restoring the source phase.
@@ -7081,7 +7260,9 @@ def unblock_task(conn: sqlite3.Connection, task_id: str) -> bool:
         if cur.rowcount != 1:
             return False
         _append_event(
-            conn, task_id, "unblocked",
+            conn,
+            task_id,
+            "unblocked",
             (
                 {"status": new_status, "resume_status": resume_status}
                 if new_status != "ready" or resume_status != "ready"
@@ -7108,7 +7289,10 @@ def reopen_review_task(conn: sqlite3.Connection, task_id: str) -> bool:
     now = int(time.time())
     with write_txn(conn):
         _reclaim_dangling_run(
-            conn, task_id, statuses=("review",), now=now,
+            conn,
+            task_id,
+            statuses=("review",),
+            now=now,
             note="invariant recovery on review reopen",
         )
         new_status = _landing_status_after_parents(conn, task_id)
@@ -7131,9 +7315,7 @@ def reopen_review_task(conn: sqlite3.Connection, task_id: str) -> bool:
             implementer = None
         assignee_sql = ", assignee = ?" if implementer else ""
         params: tuple[Any, ...] = (
-            (new_status, implementer, task_id)
-            if implementer
-            else (new_status, task_id)
+            (new_status, implementer, task_id) if implementer else (new_status, task_id)
         )
         cur = conn.execute(
             "UPDATE tasks SET status = ?, current_run_id = NULL, "
@@ -7312,14 +7494,12 @@ def invalidate_descendants_for_parent_reopen(
                     now,
                 ),
             )
-            invalidated.append(
-                {
-                    "id": row["id"],
-                    "prior_status": previous_status,
-                    "new_status": "todo",
-                    "resume_status": resume_status,
-                }
-            )
+            invalidated.append({
+                "id": row["id"],
+                "prior_status": previous_status,
+                "new_status": "todo",
+                "resume_status": resume_status,
+            })
     if not caller_owns_txn:
         # Standalone call: we committed above, so the audit trail is durable
         # — safe to kill workers now. Composed calls leave this to the
@@ -7381,8 +7561,7 @@ def specify_triage_task(
             changed_fields.append("assignee")
         params.append(task_id)
         cur = conn.execute(
-            f"UPDATE tasks SET {', '.join(sets)} "
-            f"WHERE id = ? AND status = 'triage'",
+            f"UPDATE tasks SET {', '.join(sets)} WHERE id = ? AND status = 'triage'",
             tuple(params),
         )
         if cur.rowcount != 1:
@@ -7487,7 +7666,7 @@ def decompose_triage_task(
     _in_deg = [0] * len(children)
     _adj: list[list[int]] = [[] for _ in range(len(children))]
     for _i, _c in enumerate(children):
-        for _p in (_c.get("parents") or []):
+        for _p in _c.get("parents") or []:
             _adj[_p].append(_i)
             _in_deg[_i] += 1
     _queue = [_i for _i in range(len(children)) if _in_deg[_i] == 0]
@@ -7577,7 +7756,9 @@ def decompose_triage_task(
                 ),
             )
             _append_event(
-                conn, new_id, "created",
+                conn,
+                new_id,
+                "created",
                 {"by": author or "decomposer", "from_decompose_of": task_id},
             )
             _inherit_notify_subs(conn, new_id, (task_id,), created_at=now)
@@ -7594,7 +7775,9 @@ def decompose_triage_task(
                     (parent_id, child_id),
                 )
                 _append_event(
-                    conn, child_id, "linked",
+                    conn,
+                    child_id,
+                    "linked",
                     {"parent": parent_id, "child": child_id},
                 )
 
@@ -7604,8 +7787,7 @@ def decompose_triage_task(
         # only ever a child here, never a parent of children.
         for cid in child_ids:
             conn.execute(
-                "INSERT OR IGNORE INTO task_links (parent_id, child_id) "
-                "VALUES (?, ?)",
+                "INSERT OR IGNORE INTO task_links (parent_id, child_id) VALUES (?, ?)",
                 (cid, task_id),
             )
 
@@ -7636,7 +7818,9 @@ def decompose_triage_task(
                 ),
             )
         _append_event(
-            conn, task_id, "decomposed",
+            conn,
+            task_id,
+            "decomposed",
             {
                 "child_ids": child_ids,
                 "root_assignee": root_assignee,
@@ -7667,8 +7851,10 @@ def archive_task(conn: sqlite3.Connection, task_id: str) -> bool:
         # archived a running task from the dashboard), close that run with
         # outcome='reclaimed' so attempt history isn't orphaned.
         run_id = _end_run(
-            conn, task_id,
-            outcome="reclaimed", status="reclaimed",
+            conn,
+            task_id,
+            outcome="reclaimed",
+            status="reclaimed",
             summary="task archived with run still active",
         )
         _append_event(conn, task_id, "archived", None, run_id=run_id)
@@ -7719,7 +7905,10 @@ def delete_task(conn: sqlite3.Connection, task_id: str) -> bool:
         cur = conn.execute("DELETE FROM tasks WHERE id = ?", (task_id,))
         if cur.rowcount != 1:
             return False
-        conn.execute("DELETE FROM task_links WHERE parent_id = ? OR child_id = ?", (task_id, task_id))
+        conn.execute(
+            "DELETE FROM task_links WHERE parent_id = ? OR child_id = ?",
+            (task_id, task_id),
+        )
         conn.execute("DELETE FROM task_comments WHERE task_id = ?", (task_id,))
         conn.execute("DELETE FROM task_events WHERE task_id = ?", (task_id,))
         conn.execute("DELETE FROM task_runs WHERE task_id = ?", (task_id,))
@@ -7732,13 +7921,16 @@ def delete_task(conn: sqlite3.Connection, task_id: str) -> bool:
 # Workspace resolution
 # ---------------------------------------------------------------------------
 
+
 def _git_toplevel(path: Path) -> Optional[Path]:
     """Return the git toplevel containing ``path``, or ``None`` if not in a repo."""
     try:
         result = subprocess.run(
             ["git", "-C", str(path), "rev-parse", "--show-toplevel"],
             capture_output=True,
-            text=True, encoding='utf-8', errors='replace',
+            text=True,
+            encoding="utf-8",
+            errors="replace",
             timeout=30,
             check=False,
         )
@@ -7823,9 +8015,18 @@ def _git_commit_exists(repo: Path, sha: str) -> bool:
 def _git_branch_exists(repo_root: Path, branch_name: str) -> bool:
     try:
         result = subprocess.run(
-            ["git", "-C", str(repo_root), "show-ref", "--verify", f"refs/heads/{branch_name}"],
+            [
+                "git",
+                "-C",
+                str(repo_root),
+                "show-ref",
+                "--verify",
+                f"refs/heads/{branch_name}",
+            ],
             capture_output=True,
-            text=True, encoding='utf-8', errors='replace',
+            text=True,
+            encoding="utf-8",
+            errors="replace",
             timeout=30,
             check=False,
         )
@@ -7837,9 +8038,18 @@ def _git_branch_exists(repo_root: Path, branch_name: str) -> bool:
 def _git_common_dir(path: Path) -> Optional[Path]:
     try:
         result = subprocess.run(
-            ["git", "-C", str(path), "rev-parse", "--path-format=absolute", "--git-common-dir"],
+            [
+                "git",
+                "-C",
+                str(path),
+                "rev-parse",
+                "--path-format=absolute",
+                "--git-common-dir",
+            ],
             capture_output=True,
-            text=True, encoding='utf-8', errors='replace',
+            text=True,
+            encoding="utf-8",
+            errors="replace",
             timeout=30,
             check=False,
         )
@@ -7856,9 +8066,18 @@ def _git_common_dir(path: Path) -> Optional[Path]:
 def _git_dir(path: Path) -> Optional[Path]:
     try:
         result = subprocess.run(
-            ["git", "-C", str(path), "rev-parse", "--path-format=absolute", "--git-dir"],
+            [
+                "git",
+                "-C",
+                str(path),
+                "rev-parse",
+                "--path-format=absolute",
+                "--git-dir",
+            ],
             capture_output=True,
-            text=True, encoding='utf-8', errors='replace',
+            text=True,
+            encoding="utf-8",
+            errors="replace",
             timeout=30,
             check=False,
         )
@@ -7877,7 +8096,9 @@ def _git_current_branch(path: Path) -> Optional[str]:
         result = subprocess.run(
             ["git", "-C", str(path), "branch", "--show-current"],
             capture_output=True,
-            text=True, encoding='utf-8', errors='replace',
+            text=True,
+            encoding="utf-8",
+            errors="replace",
             timeout=30,
             check=False,
         )
@@ -7928,13 +8149,22 @@ def _ensure_git_worktree(repo_root: Path, target: Path, branch_name: str) -> Non
         cmd = ["git", "-C", str(repo_root), "worktree", "add", str(target), branch_name]
     else:
         cmd = [
-            "git", "-C", str(repo_root), "worktree", "add", "-b", branch_name,
-            str(target), "HEAD",
+            "git",
+            "-C",
+            str(repo_root),
+            "worktree",
+            "add",
+            "-b",
+            branch_name,
+            str(target),
+            "HEAD",
         ]
     result = subprocess.run(
         cmd,
         capture_output=True,
-        text=True, encoding='utf-8', errors='replace',
+        text=True,
+        encoding="utf-8",
+        errors="replace",
         timeout=60,
         check=False,
     )
@@ -7964,7 +8194,9 @@ def _resolve_worktree_workspace(
         # The dispatcher's CWD is incidental (gateway launch dir) and using it
         # scatters worktrees under whatever repo the gateway started in.
         board_slug = board if board else get_current_board()
-        board_default = (read_board_metadata(board_slug).get("default_workdir") or "").strip()
+        board_default = (
+            read_board_metadata(board_slug).get("default_workdir") or ""
+        ).strip()
         if not board_default:
             raise ValueError(
                 f"task {task.id} has workspace_kind=worktree but no workspace_path, "
@@ -8106,9 +8338,7 @@ def set_workspace_path(
         )
 
 
-def set_branch_name(
-    conn: sqlite3.Connection, task_id: str, branch_name: str
-) -> None:
+def set_branch_name(conn: sqlite3.Connection, task_id: str, branch_name: str) -> None:
     with write_txn(conn):
         conn.execute(
             "UPDATE tasks SET branch_name = ? WHERE id = ?",
@@ -8148,13 +8378,16 @@ def schedule_task(
         if cur.rowcount != 1:
             return False
         run_id = _end_run(
-            conn, task_id,
-            outcome="scheduled", status="scheduled",
+            conn,
+            task_id,
+            outcome="scheduled",
+            status="scheduled",
             summary=reason,
         )
         if run_id is None and reason:
             run_id = _synthesize_ended_run(
-                conn, task_id,
+                conn,
+                task_id,
                 outcome="scheduled",
                 summary=reason,
             )
@@ -8175,7 +8408,7 @@ DEFAULT_SPAWN_FAILURE_LIMIT = DEFAULT_FAILURE_LIMIT
 
 # Max bytes to keep in a single worker log file. The dispatcher truncates
 # and rotates on spawn if the file is larger than this at spawn time.
-DEFAULT_LOG_ROTATE_BYTES = 2 * 1024 * 1024   # 2 MiB
+DEFAULT_LOG_ROTATE_BYTES = 2 * 1024 * 1024  # 2 MiB
 DEFAULT_LOG_BACKUP_COUNT = 1
 
 # Keep a little wall-clock budget for the worker to observe a terminal timeout
@@ -8410,6 +8643,7 @@ def _pid_alive(pid: Optional[int]) -> bool:
     if not pid or pid <= 0:
         return False
     from gateway.status import _pid_exists
+
     if not _pid_exists(int(pid)):
         return False
     # Still here → process exists. Check for zombie on platforms
@@ -8434,7 +8668,9 @@ def _pid_alive(pid: Optional[int]) -> bool:
                 ["ps", "-o", "stat=", "-p", str(int(pid))],
                 stdout=subprocess.PIPE,
                 stderr=subprocess.DEVNULL,
-                text=True, encoding='utf-8', errors='replace',
+                text=True,
+                encoding="utf-8",
+                errors="replace",
                 timeout=1,
                 check=False,
             )
@@ -8472,8 +8708,10 @@ def _terminate_reclaimed_worker(
         return info
     info["host_local"] = True
 
-    kill = signal_fn if signal_fn is not None else (
-        os.kill if hasattr(os, "kill") else None
+    kill = (
+        signal_fn
+        if signal_fn is not None
+        else (os.kill if hasattr(os, "kill") else None)
     )
     if kill is None:
         return info
@@ -8611,7 +8849,9 @@ def heartbeat_worker(
                 (now, run_id),
             )
         _append_event(
-            conn, task_id, "heartbeat",
+            conn,
+            task_id,
+            "heartbeat",
             {"note": note} if note else None,
             run_id=run_id,
         )
@@ -8636,6 +8876,7 @@ def enforce_max_runtime(
     test hook; defaults to ``os.kill`` on POSIX.
     """
     import signal
+
     timed_out: list[str] = []
     now = int(time.time())
     host_prefix = f"{_claimer_id().split(':', 1)[0]}:"
@@ -8667,8 +8908,10 @@ def enforce_max_runtime(
         # want a cleaner shutdown can install their own SIGTERM handler
         # before the grace expires.
         killed = False
-        kill = signal_fn if signal_fn is not None else (
-            os.kill if hasattr(os, "kill") else None
+        kill = (
+            signal_fn
+            if signal_fn is not None
+            else (os.kill if hasattr(os, "kill") else None)
         )
         if kill is not None:
             try:
@@ -8708,13 +8951,19 @@ def enforce_max_runtime(
                     "retry_status": retry_status,
                 }
                 run_id = _end_run(
-                    conn, tid,
-                    outcome="timed_out", status="timed_out",
+                    conn,
+                    tid,
+                    outcome="timed_out",
+                    status="timed_out",
                     error=f"elapsed {int(elapsed)}s > limit {int(row['max_runtime_seconds'])}s",
                     metadata=payload,
                 )
                 _append_event(
-                    conn, tid, "timed_out", payload, run_id=run_id,
+                    conn,
+                    tid,
+                    "timed_out",
+                    payload,
+                    run_id=run_id,
                 )
                 timed_out.append(tid)
         # Increment the unified failure counter. Outside the write_txn
@@ -8724,7 +8973,8 @@ def enforce_max_runtime(
         # already emitted.
         if cur.rowcount == 1:
             _record_task_failure(
-                conn, tid,
+                conn,
+                tid,
                 error=f"elapsed {int(elapsed)}s > limit {int(row['max_runtime_seconds'])}s",
                 outcome="timed_out",
                 release_claim=False,
@@ -8776,7 +9026,6 @@ def detect_stale_running(
     if stale_timeout_seconds <= 0:
         return []
 
-
     now = int(time.time())
     reclaimed: list[str] = []
 
@@ -8808,14 +9057,20 @@ def detect_stale_running(
 
         # Terminate the worker if it's still host-local.
         termination = _terminate_reclaimed_worker(
-            pid, lock, signal_fn=signal_fn,
+            pid,
+            lock,
+            signal_fn=signal_fn,
         )
 
         # Never release a claim while our own worker is still alive: that would
         # spawn a duplicate beside it. Hold the claim and retry next tick.
         if _worker_survived_termination(termination):
             _defer_reclaim_for_live_worker(
-                conn, tid, lock, now, termination,
+                conn,
+                tid,
+                lock,
+                now,
+                termination,
                 reason="heartbeat_stale_worker_alive",
             )
             continue
@@ -8835,12 +9090,8 @@ def detect_stale_running(
 
             payload = {
                 "elapsed_seconds": int(elapsed),
-                "last_heartbeat_at": (
-                    int(last_hb) if last_hb is not None else None
-                ),
-                "heartbeat_age_seconds": (
-                    int(hb_age) if hb_age is not None else None
-                ),
+                "last_heartbeat_at": (int(last_hb) if last_hb is not None else None),
+                "heartbeat_age_seconds": (int(hb_age) if hb_age is not None else None),
                 "timeout_seconds": stale_timeout_seconds,
                 "pid": int(pid) if pid else None,
                 "retry_status": retry_status,
@@ -8848,17 +9099,24 @@ def detect_stale_running(
             payload.update(termination)
 
             run_id = _end_run(
-                conn, tid,
-                outcome="stale", status="stale",
+                conn,
+                tid,
+                outcome="stale",
+                status="stale",
                 error=(
                     f"no heartbeat for {int(hb_age)}s "
                     if hb_age is not None
                     else "no heartbeat ever"
-                ) + f" after {int(elapsed)}s running",
+                )
+                + f" after {int(elapsed)}s running",
                 metadata=payload,
             )
             _append_event(
-                conn, tid, "stale", payload, run_id=run_id,
+                conn,
+                tid,
+                "stale",
+                payload,
+                run_id=run_id,
             )
             reclaimed.append(tid)
 
@@ -8914,7 +9172,9 @@ def reconcile_orphaned_running(
             # requeue beside a live process. Retry next tick.
             _log.debug(
                 "kanban reconcile: task %s has broken claim bookkeeping but "
-                "pid %s is alive on this host — deferring", tid, pid,
+                "pid %s is alive on this host — deferring",
+                tid,
+                pid,
             )
             continue
         with write_txn(conn):
@@ -8933,14 +9193,17 @@ def reconcile_orphaned_running(
                 "claim_lock": row["claim_lock"],
                 "claim_expires": (
                     int(row["claim_expires"])
-                    if row["claim_expires"] is not None else None
+                    if row["claim_expires"] is not None
+                    else None
                 ),
                 "worker_pid": int(pid) if pid else None,
                 "now": now,
             }
             run_id = _end_run(
-                conn, tid,
-                outcome="reclaimed", status="reclaimed",
+                conn,
+                tid,
+                outcome="reclaimed",
+                status="reclaimed",
                 error="orphaned running card (broken claim bookkeeping)",
                 metadata=payload,
             )
@@ -8950,7 +9213,8 @@ def reconcile_orphaned_running(
                 "INSERT INTO task_comments (task_id, author, body, created_at) "
                 "VALUES (?, ?, ?, ?)",
                 (
-                    tid, "dispatcher",
+                    tid,
+                    "dispatcher",
                     "reconciliation: card was 'running' with no valid claim "
                     "(dead/gone worker) — requeued to ready",
                     now,
@@ -8960,7 +9224,10 @@ def reconcile_orphaned_running(
             reconciled.append(tid)
         _log.info(
             "kanban reconcile: requeued orphaned running task %s "
-            "(claim_lock=%r, worker_pid=%r)", tid, row["claim_lock"], pid,
+            "(claim_lock=%r, worker_pid=%r)",
+            tid,
+            row["claim_lock"],
+            pid,
         )
     return reconciled
 
@@ -8971,8 +9238,8 @@ def _error_fingerprint(error_text: str) -> str:
     Strips host-specific details (PIDs, timestamps) so that errors
     with the same root cause produce the same fingerprint.
     """
-    fp = re.sub(r'\bpid \d+\b', 'pid N', error_text[:80])
-    fp = re.sub(r'\b\d{10,}\b', '<TS>', fp)
+    fp = re.sub(r"\bpid \d+\b", "pid N", error_text[:80])
+    fp = re.sub(r"\b\d{10,}\b", "<TS>", fp)
     return fp.lower().strip()
 
 
@@ -9033,9 +9300,7 @@ def _protocol_violation_streak(conn: sqlite3.Connection, task_id: str) -> int:
             raw_meta = row["metadata"]
             if raw_meta:
                 try:
-                    is_violation = bool(
-                        json.loads(raw_meta).get("protocol_violation")
-                    )
+                    is_violation = bool(json.loads(raw_meta).get("protocol_violation"))
                 except (ValueError, TypeError):
                     is_violation = False
             if not is_violation:
@@ -9190,13 +9455,17 @@ def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
                 # history doesn't show a phantom crash for a quota wall.
                 _run_outcome = "rate_limited" if rate_limited_exit else "crashed"
                 run_id = _end_run(
-                    conn, row["id"],
-                    outcome=_run_outcome, status=_run_outcome,
+                    conn,
+                    row["id"],
+                    outcome=_run_outcome,
+                    status=_run_outcome,
                     error=error_text,
                     metadata=dict(event_payload),
                 )
                 _append_event(
-                    conn, row["id"], event_kind,
+                    conn,
+                    row["id"],
+                    event_kind,
                     event_payload,
                     run_id=run_id,
                 )
@@ -9230,15 +9499,17 @@ def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
                         # context still need the violation message + the
                         # corrective guidance it carries.
                         conn.execute(
-                            "UPDATE tasks SET last_failure_error = ? "
-                            "WHERE id = ?",
+                            "UPDATE tasks SET last_failure_error = ? WHERE id = ?",
                             (error_text[:500], row["id"]),
                         )
                     crashed.append(row["id"])
-                    crash_details.append(
-                        (row["id"], pid, row["claim_lock"],
-                         protocol_violation, error_text)
-                    )
+                    crash_details.append((
+                        row["id"],
+                        pid,
+                        row["claim_lock"],
+                        protocol_violation,
+                        error_text,
+                    ))
     # Outside the main txn: account each crashed task and maybe trip the
     # breaker (the retried task transitions to blocked with a ``gave_up`` event
     # on top of the event we already emitted).
@@ -9266,7 +9537,8 @@ def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
             if protocol_violation:
                 streak = _protocol_violation_streak(conn, tid)
                 trow = conn.execute(
-                    "SELECT max_retries FROM tasks WHERE id = ?", (tid,),
+                    "SELECT max_retries FROM tasks WHERE id = ?",
+                    (tid,),
                 ).fetchone()
                 if trow is None:
                     continue  # task deleted mid-loop
@@ -9292,7 +9564,8 @@ def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
                 # the per-task ``max_retries`` override — was already made
                 # against the violation streak above.
                 tripped = _record_task_failure(
-                    conn, tid,
+                    conn,
+                    tid,
                     error=error_text,
                     outcome="crashed",
                     failure_limit=violation_limit,
@@ -9312,7 +9585,8 @@ def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
             fp = _error_fingerprint(error_text)
             is_systemic = _fp_counts.get(fp, 0) >= 3
             tripped = _record_task_failure(
-                conn, tid,
+                conn,
+                tid,
                 error=error_text,
                 outcome="crashed",
                 failure_limit=1 if is_systemic else None,
@@ -9408,7 +9682,8 @@ def _record_task_failure(
     with write_txn(conn):
         row = conn.execute(
             "SELECT consecutive_failures, status, max_retries, current_run_id "
-            "FROM tasks WHERE id = ?", (task_id,),
+            "FROM tasks WHERE id = ?",
+            (task_id,),
         ).fetchone()
         if row is None:
             return False
@@ -9421,9 +9696,7 @@ def _record_task_failure(
 
         # Per-task override wins over both caller-supplied and default
         # thresholds. None (the common case) falls through.
-        task_override = (
-            row["max_retries"] if "max_retries" in row.keys() else None
-        )
+        task_override = row["max_retries"] if "max_retries" in row.keys() else None
         if task_override is not None:
             effective_limit = int(task_override)
             limit_source = "task"
@@ -9456,8 +9729,10 @@ def _record_task_failure(
             if end_run:
                 # Only the spawn path has an open run to close.
                 run_id = _end_run(
-                    conn, task_id,
-                    outcome="gave_up", status="gave_up",
+                    conn,
+                    task_id,
+                    outcome="gave_up",
+                    status="gave_up",
                     error=error[:500],
                     metadata={
                         "failures": failures,
@@ -9478,7 +9753,11 @@ def _record_task_failure(
             if event_payload_extra:
                 payload.update(event_payload_extra)
             _append_event(
-                conn, task_id, "gave_up", payload, run_id=run_id,
+                conn,
+                task_id,
+                "gave_up",
+                payload,
+                run_id=run_id,
             )
             blocked = True
         else:
@@ -9502,8 +9781,10 @@ def _record_task_failure(
             if end_run:
                 # Spawn path: close the open run with outcome.
                 run_id = _end_run(
-                    conn, task_id,
-                    outcome=outcome, status=outcome,
+                    conn,
+                    task_id,
+                    outcome=outcome,
+                    status=outcome,
                     error=error[:500],
                     metadata={
                         "failures": failures,
@@ -9511,7 +9792,9 @@ def _record_task_failure(
                     },
                 )
                 _append_event(
-                    conn, task_id, outcome,
+                    conn,
+                    task_id,
+                    outcome,
                     {
                         "error": error[:500],
                         "failures": failures,
@@ -9533,7 +9816,9 @@ def _record_spawn_failure(
     failure_limit: int = None,
 ) -> bool:
     return _record_task_failure(
-        conn, task_id, error,
+        conn,
+        task_id,
+        error,
         outcome="spawn_failed",
         failure_limit=failure_limit,
         release_claim=True,
@@ -9585,7 +9870,10 @@ _clear_spawn_failures = _clear_failure_counter
 
 
 def check_respawn_guard(
-    conn: sqlite3.Connection, task_id: str, *, lane: str = "ready",
+    conn: sqlite3.Connection,
+    task_id: str,
+    *,
+    lane: str = "ready",
 ) -> Optional[str]:
     """Return a guard reason if ``task_id`` should NOT be re-spawned, else None.
 
@@ -9668,10 +9956,7 @@ def check_respawn_guard(
         "ORDER BY ended_at DESC LIMIT 1",
         (task_id,),
     ).fetchone()
-    if (
-        latest_run is not None
-        and latest_run["outcome"] == "rate_limited"
-    ):
+    if latest_run is not None and latest_run["outcome"] == "rate_limited":
         if rl_cooldown <= 0:
             # Cooldown disabled — respawn immediately, and skip the
             # blocker_auth regex so the stamped rate-limit text doesn't
@@ -9801,6 +10086,7 @@ def review_dispatch_enabled() -> bool:
     """
     try:
         from hermes_cli.config import load_config
+
         return bool(
             (load_config() or {}).get("kanban", {}).get("review_dispatch", True)
         )
@@ -9945,23 +10231,20 @@ def _dispatch_once_locked(
         # TTL/crash/stale paths can never see. See reconcile_orphaned_running.
         result.reconciled_orphans = reconcile_orphaned_running(conn)
     result.stale = detect_stale_running(
-        conn, stale_timeout_seconds=stale_timeout_seconds,
+        conn,
+        stale_timeout_seconds=stale_timeout_seconds,
     )
     result.crashed = detect_crashed_workers(conn)
     # detect_crashed_workers stashes protocol-violation auto-blocks on
     # itself so the public list-return stays stable. Pull them into the
     # DispatchResult here so telemetry / tests see the trip.
-    _crash_auto_blocked = getattr(
-        detect_crashed_workers, "_last_auto_blocked", []
-    )
+    _crash_auto_blocked = getattr(detect_crashed_workers, "_last_auto_blocked", [])
     if _crash_auto_blocked:
         result.auto_blocked.extend(_crash_auto_blocked)
     # Rate-limited requeues (quota wall, no failure counted) — surface for
     # telemetry / tests. These tasks went back to ``ready`` and the respawn
     # guard will defer them until the quota window clears.
-    _crash_rate_limited = getattr(
-        detect_crashed_workers, "_last_rate_limited", []
-    )
+    _crash_rate_limited = getattr(detect_crashed_workers, "_last_rate_limited", [])
     if _crash_rate_limited:
         result.rate_limited.extend(_crash_rate_limited)
     result.timed_out = enforce_max_runtime(conn)
@@ -10004,10 +10287,14 @@ def _dispatch_once_locked(
     # Tasks blocked this way go to skipped_per_profile_capped (not
     # skipped_unassigned — the operator-actionable signal is different:
     # "this profile is busy, try again later" not "this needs routing").
-    _per_profile_cap = max_in_progress_per_profile if (
-        isinstance(max_in_progress_per_profile, int)
-        and max_in_progress_per_profile > 0
-    ) else None
+    _per_profile_cap = (
+        max_in_progress_per_profile
+        if (
+            isinstance(max_in_progress_per_profile, int)
+            and max_in_progress_per_profile > 0
+        )
+        else None
+    )
     _per_profile_running: dict[str, int] = {}
     if _per_profile_cap is not None:
         for prow in conn.execute(
@@ -10024,6 +10311,7 @@ def _dispatch_once_locked(
     if _default_assignee:
         try:
             from hermes_cli.profiles import profile_exists as _pe
+
             _default_assignee_resolved = bool(_pe(_default_assignee))
         except Exception:
             # Profiles module not importable (test stubs, exotic envs).
@@ -10060,7 +10348,9 @@ def _dispatch_once_locked(
                                 (_default_assignee, row["id"]),
                             )
                             _append_event(
-                                conn, row["id"], "assigned",
+                                conn,
+                                row["id"],
+                                "assigned",
                                 {
                                     "assignee": _default_assignee,
                                     "source": "kanban.default_assignee",
@@ -10070,7 +10360,9 @@ def _dispatch_once_locked(
                         _log.debug(
                             "kanban dispatch: failed to apply default_assignee=%r "
                             "to task %s",
-                            _default_assignee, row["id"], exc_info=True,
+                            _default_assignee,
+                            row["id"],
+                            exc_info=True,
                         )
                         result.skipped_unassigned.append(row["id"])
                         continue
@@ -10111,9 +10403,11 @@ def _dispatch_once_locked(
         if _per_profile_cap is not None:
             current = _per_profile_running.get(row_assignee, 0)
             if current >= _per_profile_cap:
-                result.skipped_per_profile_capped.append(
-                    (row["id"], row_assignee, current)
-                )
+                result.skipped_per_profile_capped.append((
+                    row["id"],
+                    row_assignee,
+                    current,
+                ))
                 continue
         # Respawn guard: refuse to re-spawn when useful work is already
         # in-flight/recent, or when the last failure is a deterministic
@@ -10132,7 +10426,9 @@ def _dispatch_once_locked(
             if not dry_run:
                 with write_txn(conn):
                     _append_event(
-                        conn, row["id"], "respawn_guarded",
+                        conn,
+                        row["id"],
+                        "respawn_guarded",
                         {"reason": guard_reason},
                     )
             continue
@@ -10154,12 +10450,16 @@ def _dispatch_once_locked(
         try:
             resolved_branch_name = None
             if claimed.workspace_kind == "worktree":
-                workspace, resolved_branch_name = _resolve_worktree_workspace(claimed, board=board)
+                workspace, resolved_branch_name = _resolve_worktree_workspace(
+                    claimed, board=board
+                )
             else:
                 workspace = resolve_workspace(claimed, board=board)
         except Exception as exc:
             auto = _record_spawn_failure(
-                conn, claimed.id, f"workspace: {exc}",
+                conn,
+                claimed.id,
+                f"workspace: {exc}",
                 failure_limit=failure_limit,
             )
             if auto:
@@ -10168,7 +10468,13 @@ def _dispatch_once_locked(
         # Persist the resolved workspace path so the worker can cd there.
         set_workspace_path(conn, claimed.id, str(workspace))
         if claimed.workspace_kind == "worktree":
-            set_branch_name(conn, claimed.id, resolved_branch_name or (claimed.branch_name or "").strip() or f"wt/{claimed.id}")
+            set_branch_name(
+                conn,
+                claimed.id,
+                resolved_branch_name
+                or (claimed.branch_name or "").strip()
+                or f"wt/{claimed.id}",
+            )
         _maybe_emit_scratch_tip(conn, claimed.id, claimed.workspace_kind)
         _spawn = spawn_fn if spawn_fn is not None else _default_spawn
         try:
@@ -10176,6 +10482,7 @@ def _dispatch_once_locked(
             # (task, workspace). Test stubs in the suite rely on that.
             # Introspect the callable and pass `board` only when supported.
             import inspect
+
             try:
                 sig = inspect.signature(_spawn)
                 if "board" in sig.parameters:
@@ -10191,7 +10498,11 @@ def _dispatch_once_locked(
             # per the RFC timing contract. Best-effort — can never break
             # the dispatch loop.
             _fire_worker_spawned_hook(
-                conn, claimed, str(workspace), pid, board=board,
+                conn,
+                claimed,
+                str(workspace),
+                pid,
+                board=board,
             )
             # NOTE: we intentionally do NOT reset consecutive_failures
             # here. A successful spawn proves the worker can start but
@@ -10211,7 +10522,9 @@ def _dispatch_once_locked(
                 )
         except Exception as exc:
             auto = _record_spawn_failure(
-                conn, claimed.id, str(exc),
+                conn,
+                claimed.id,
+                str(exc),
                 failure_limit=failure_limit,
             )
             if auto:
@@ -10253,9 +10566,11 @@ def _dispatch_once_locked(
         if _per_profile_cap is not None:
             current = _per_profile_running.get(row["assignee"], 0)
             if current >= _per_profile_cap:
-                result.skipped_per_profile_capped.append(
-                    (row["id"], row["assignee"], current)
-                )
+                result.skipped_per_profile_capped.append((
+                    row["id"],
+                    row["assignee"],
+                    current,
+                ))
                 continue
         guard_reason = check_respawn_guard(conn, row["id"], lane="review")
         if guard_reason is not None:
@@ -10263,7 +10578,9 @@ def _dispatch_once_locked(
             if not dry_run:
                 with write_txn(conn):
                     _append_event(
-                        conn, row["id"], "respawn_guarded",
+                        conn,
+                        row["id"],
+                        "respawn_guarded",
                         {"reason": guard_reason},
                     )
             continue
@@ -10281,12 +10598,16 @@ def _dispatch_once_locked(
         try:
             resolved_branch_name = None
             if claimed.workspace_kind == "worktree":
-                workspace, resolved_branch_name = _resolve_worktree_workspace(claimed, board=board)
+                workspace, resolved_branch_name = _resolve_worktree_workspace(
+                    claimed, board=board
+                )
             else:
                 workspace = resolve_workspace(claimed, board=board)
         except Exception as exc:
             auto = _record_spawn_failure(
-                conn, claimed.id, f"workspace: {exc}",
+                conn,
+                claimed.id,
+                f"workspace: {exc}",
                 failure_limit=failure_limit,
             )
             if auto:
@@ -10295,19 +10616,24 @@ def _dispatch_once_locked(
         # Persist the resolved workspace path so the worker can cd there.
         set_workspace_path(conn, claimed.id, str(workspace))
         if claimed.workspace_kind == "worktree":
-            set_branch_name(conn, claimed.id, resolved_branch_name or (claimed.branch_name or "").strip() or f"wt/{claimed.id}")
+            set_branch_name(
+                conn,
+                claimed.id,
+                resolved_branch_name
+                or (claimed.branch_name or "").strip()
+                or f"wt/{claimed.id}",
+            )
         _maybe_emit_scratch_tip(conn, claimed.id, claimed.workspace_kind)
         # Force-load the sdlc-review skill for review agents — it carries
         # the review logic (AC verification, merge, etc.). The mandatory
         # kanban lifecycle is already injected into every worker's system
         # prompt via KANBAN_GUIDANCE, so this is the only extra skill the
         # review agent needs.
-        claimed.skills = list(
-            dict.fromkeys([*(claimed.skills or []), "sdlc-review"])
-        )
+        claimed.skills = list(dict.fromkeys([*(claimed.skills or []), "sdlc-review"]))
         _spawn = spawn_fn if spawn_fn is not None else _default_spawn
         try:
             import inspect
+
             try:
                 sig = inspect.signature(_spawn)
                 if "board" in sig.parameters:
@@ -10321,7 +10647,11 @@ def _dispatch_once_locked(
             # Worker-lifecycle observer (RFC #58548): same contract as the
             # ready-lane fire above — after spawn + PID persistence.
             _fire_worker_spawned_hook(
-                conn, claimed, str(workspace), pid, board=board,
+                conn,
+                claimed,
+                str(workspace),
+                pid,
+                board=board,
             )
             result.spawned.append((claimed.id, claimed.assignee or "", str(workspace)))
             spawned += 1
@@ -10331,7 +10661,9 @@ def _dispatch_once_locked(
                 )
         except Exception as exc:
             auto = _record_spawn_failure(
-                conn, claimed.id, str(exc),
+                conn,
+                claimed.id,
+                str(exc),
                 failure_limit=failure_limit,
             )
             if auto:
@@ -10358,7 +10690,7 @@ def worker_log_rotation_config(kanban_cfg: Optional[dict] = None) -> tuple[int, 
         try:
             from hermes_cli.config import load_config
 
-            kanban_cfg = (load_config().get("kanban") or {})
+            kanban_cfg = load_config().get("kanban") or {}
         except Exception:
             kanban_cfg = {}
     max_bytes = _positive_int(
@@ -10581,7 +10913,10 @@ def _resolve_worker_cli_toolsets(hermes_home: Optional[str]) -> Optional[list[st
     if not hermes_home:
         return None
     try:
-        from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+        from hermes_constants import (
+            reset_hermes_home_override,
+            set_hermes_home_override,
+        )
         from hermes_cli.config import load_config
         from hermes_cli.tools_config import _get_platform_tools
 
@@ -10646,6 +10981,7 @@ def _default_spawn(
     from. Workers cannot accidentally see other boards.
     """
     import subprocess
+
     if not task.assignee:
         raise ValueError(f"task {task.id} has no assignee")
 
@@ -10659,6 +10995,7 @@ def _default_spawn(
     # inherit routing mirrored by a previous gateway turn, even before the first
     # session binds ContextVars in this process.
     from gateway.session_context import _VAR_MAP
+
     for key in _VAR_MAP:
         env.pop(key, None)
 
@@ -10672,6 +11009,7 @@ def _default_spawn(
     # profile-specific config entirely.  Fixes profile-scoped fallback_providers
     # being invisible to kanban workers.
     from hermes_cli.profiles import resolve_profile_env
+
     try:
         env["HERMES_HOME"] = resolve_profile_env(profile_arg)
     except FileNotFoundError:
@@ -10761,7 +11099,8 @@ def _default_spawn(
 
     cmd = [
         *_resolve_hermes_argv(),
-        "-p", profile_arg,
+        "-p",
+        profile_arg,
         "--cli",
         # Worker subprocesses switch to a profile-scoped HERMES_HOME above,
         # so they see that profile's shell-hook allowlist instead of the
@@ -10796,7 +11135,8 @@ def _default_spawn(
         cmd.extend(["--toolsets", ",".join(worker_toolsets)])
     cmd.extend([
         "chat",
-        "-q", prompt,
+        "-q",
+        prompt,
     ])
     if task.goal_mode:
         # Goal-mode workers must take the fully-quiet single-query path:
@@ -10845,6 +11185,7 @@ def _default_spawn(
 # ---------------------------------------------------------------------------
 # Long-lived dispatcher daemon
 # ---------------------------------------------------------------------------
+
 
 def run_daemon(
     *,
@@ -10897,6 +11238,7 @@ def run_daemon(
         except Exception:
             # Don't let any single tick kill the daemon.
             import traceback
+
             traceback.print_exc()
         stop_event.wait(timeout=interval)
 
@@ -10904,6 +11246,7 @@ def run_daemon(
 # ---------------------------------------------------------------------------
 # Worker context builder (what a spawned worker sees)
 # ---------------------------------------------------------------------------
+
 
 def build_worker_context(conn: sqlite3.Connection, task_id: str) -> str:
     """Return the full text a worker should read to understand its task.
@@ -10953,13 +11296,17 @@ def build_worker_context(conn: sqlite3.Connection, task_id: str) -> str:
     lines.append(f"Status:   {task.status}")
     if task.tenant:
         lines.append(f"Tenant:   {task.tenant}")
-    lines.append(f"Workspace: {task.workspace_kind} @ {task.workspace_path or '(unresolved)'}")
+    lines.append(
+        f"Workspace: {task.workspace_kind} @ {task.workspace_path or '(unresolved)'}"
+    )
     if task.max_runtime_seconds is not None:
         terminal_timeout = _worker_terminal_timeout_env(
             task.max_runtime_seconds,
             os.environ.get("TERMINAL_TIMEOUT"),
         )
-        effective_terminal_timeout = terminal_timeout or os.environ.get("TERMINAL_TIMEOUT")
+        effective_terminal_timeout = terminal_timeout or os.environ.get(
+            "TERMINAL_TIMEOUT"
+        )
         lines.append(f"Max runtime: {task.max_runtime_seconds}s")
         if effective_terminal_timeout:
             lines.append(f"Terminal timeout: {effective_terminal_timeout}s")
@@ -11027,7 +11374,9 @@ def build_worker_context(conn: sqlite3.Connection, task_id: str) -> str:
                 lines.append(f"_error_: {_cap(run.error)}")
             if run.metadata:
                 try:
-                    meta_str = json.dumps(run.metadata, ensure_ascii=False, sort_keys=True)
+                    meta_str = json.dumps(
+                        run.metadata, ensure_ascii=False, sort_keys=True
+                    )
                     lines.append(f"_metadata_: `{_cap(meta_str)}`")
                 except Exception:
                     pass
@@ -11083,7 +11432,9 @@ def build_worker_context(conn: sqlite3.Connection, task_id: str) -> str:
 
             if run is not None and run.metadata:
                 try:
-                    meta_str = json.dumps(run.metadata, ensure_ascii=False, sort_keys=True)
+                    meta_str = json.dumps(
+                        run.metadata, ensure_ascii=False, sort_keys=True
+                    )
                     body_lines.append(f"_metadata_: `{_cap(meta_str)}`")
                 except Exception:
                     pass
@@ -11157,6 +11508,45 @@ def build_worker_context(conn: sqlite3.Connection, task_id: str) -> str:
 # Stats + SLA helpers
 # ---------------------------------------------------------------------------
 
+
+def _completion_evidence_stats(conn: sqlite3.Connection) -> dict[str, int]:
+    """How often the completion-evidence gate refused a close, and on how many rows.
+
+    The gate already refuses and records ``completion_blocked_no_evidence``, but
+    that record only ever reached whoever read the board database. An operator
+    watching a screen could not tell the difference between "nobody claimed a
+    false completion this week" and "the gate is not switched on anywhere",
+    which are opposite facts.
+
+    ``rows`` is the number of distinct cards that hit the gate; ``events`` is
+    the number of refusals, so a card that retried three times before getting
+    its paths right shows as 1 row and 3 events. ``armed_rows`` counts the cards
+    that declared an evidence repository at all -- without it a zero refusal
+    count is unreadable.
+
+    Counts only. No task identifier, claimed path, or repository path leaves
+    this function: the refusal payload holds all three and none of them are a
+    number.
+    """
+    refused = conn.execute(
+        "SELECT COUNT(DISTINCT task_id) AS rows, COUNT(*) AS events "
+        "FROM task_events WHERE kind = 'completion_blocked_no_evidence'"
+    ).fetchone()
+    armed = conn.execute(
+        "SELECT COUNT(*) AS armed FROM tasks "
+        "WHERE evidence_repo IS NOT NULL AND TRIM(evidence_repo) <> ''"
+    ).fetchone()
+    return {
+        "completion_evidence_armed_rows": int((armed["armed"] if armed else 0) or 0),
+        "completion_evidence_blocked_rows": int(
+            (refused["rows"] if refused else 0) or 0
+        ),
+        "completion_evidence_blocked_events": int(
+            (refused["events"] if refused else 0) or 0
+        ),
+    }
+
+
 def board_stats(conn: sqlite3.Connection) -> dict:
     """Per-status + per-assignee counts, plus the oldest ``ready`` age in
     seconds (the clearest staleness signal for a router or HUD).
@@ -11182,13 +11572,20 @@ def board_stats(conn: sqlite3.Connection) -> dict:
     now = int(time.time())
     oldest_ready_age = (
         (now - int(oldest_row["ts"]))
-        if oldest_row and oldest_row["ts"] is not None else None
+        if oldest_row and oldest_row["ts"] is not None
+        else None
     )
+
+    completion_evidence = _completion_evidence_stats(conn)
 
     return {
         "by_status": by_status,
         "by_assignee": by_assignee,
         "oldest_ready_age_seconds": oldest_ready_age,
+        # How the completion-evidence gate is doing. Without `armed_rows` a zero
+        # refusal count reads as "nothing false was claimed" when it may mean
+        # "no card asks for evidence", which are opposite facts.
+        **completion_evidence,
         "now": now,
     }
 
@@ -11215,6 +11612,7 @@ def _to_epoch(val) -> Optional[int]:
     # ISO-8601 fallback (e.g. '2026-05-10T15:00:00Z')
     try:
         from datetime import datetime
+
         dt = datetime.fromisoformat(s.replace("Z", "+00:00"))
         return int(dt.timestamp())
     except (ValueError, OSError):
@@ -11229,9 +11627,7 @@ def task_age(task: Task) -> dict:
     _co = _to_epoch(task.completed_at)
     age_since_created = now - _c if _c is not None else None
     age_since_started = now - _s if _s is not None else None
-    time_to_complete = (
-        _co - (_s or _c) if _co is not None else None
-    )
+    time_to_complete = _co - (_s or _c) if _co is not None else None
     return {
         "created_age_seconds": age_since_created,
         "started_age_seconds": age_since_started,
@@ -11329,14 +11725,16 @@ def add_notify_sub(
     AFTER they subscribe; the gateway/tool auto-subscribe paths run at
     task creation, where the snapshot is 0 anyway.
     """
-    insert_mode = delivery_mode if delivery_mode in _NOTIFY_DELIVERY_MODES else (
+    insert_mode = (
+        delivery_mode
+        if delivery_mode in _NOTIFY_DELIVERY_MODES
         # api_server is stateless: the adapter has no send() — the wake
         # self-post IS the delivery on that path (see gateway/wake.py and
         # test_kanban_notifier_apiserver_wake). A plain-'notify' default
         # would leave those subscriptions with no delivery mechanism at
         # all, regressing the pre-delivery_mode behavior where a task
         # carrying a session_id always woke. Explicit modes still win.
-        "notify+wake" if platform == "api_server" else "notify"
+        else ("notify+wake" if platform == "api_server" else "notify")
     )
     insert_chat_type = chat_type or "dm"
     now = int(time.time())
@@ -11429,19 +11827,13 @@ def _notify_profile_filter(
     if notifier_profiles is None:
         return "", []
 
-    profiles = sorted(
-        {
-            str(profile).strip()
-            for profile in notifier_profiles
-            if str(profile).strip()
-        }
-    )
+    profiles = sorted({
+        str(profile).strip() for profile in notifier_profiles if str(profile).strip()
+    })
     clauses: list[str] = []
     params: list[str] = []
     if profiles:
-        clauses.append(
-            "notifier_profile IN (" + ",".join("?" for _ in profiles) + ")"
-        )
+        clauses.append("notifier_profile IN (" + ",".join("?" for _ in profiles) + ")")
         params.extend(profiles)
     if include_unowned:
         clauses.append("notifier_profile IS NULL OR notifier_profile = ''")
@@ -11465,7 +11857,8 @@ def list_notify_subs(
     used by the dispatch owner for legacy rows created before profile stamping.
     """
     owner_where, owner_params = _notify_profile_filter(
-        notifier_profiles, include_unowned=include_unowned,
+        notifier_profiles,
+        include_unowned=include_unowned,
     )
     where: list[str] = []
     params: list[Any] = []
@@ -11527,7 +11920,8 @@ def count_notify_subs(
     try:
         try:
             owner_where, owner_params = _notify_profile_filter(
-                notifier_profiles, include_unowned=include_unowned,
+                notifier_profiles,
+                include_unowned=include_unowned,
             )
             clauses: list[str] = []
             params: list[Any] = []
@@ -11658,11 +12052,20 @@ def unseen_events_for_sub(
             payload = json.loads(r["payload"]) if r["payload"] else None
         except Exception:
             payload = None
-        out.append(Event(
-            id=r["id"], task_id=r["task_id"], kind=r["kind"],
-            payload=payload, created_at=r["created_at"],
-            run_id=(int(r["run_id"]) if "run_id" in r.keys() and r["run_id"] is not None else None),
-        ))
+        out.append(
+            Event(
+                id=r["id"],
+                task_id=r["task_id"],
+                kind=r["kind"],
+                payload=payload,
+                created_at=r["created_at"],
+                run_id=(
+                    int(r["run_id"])
+                    if "run_id" in r.keys() and r["run_id"] is not None
+                    else None
+                ),
+            )
+        )
         max_id = max(max_id, int(r["id"]))
     return max_id, out
 
@@ -11713,7 +12116,14 @@ def claim_unseen_events_for_sub(
             "UPDATE kanban_notify_subs SET last_event_id = ? "
             "WHERE task_id = ? AND platform = ? AND chat_id = ? AND thread_id = ? "
             "AND last_event_id = ?",
-            (int(new_cursor), task_id, platform, chat_id, thread_id or "", int(old_cursor)),
+            (
+                int(new_cursor),
+                task_id,
+                platform,
+                chat_id,
+                thread_id or "",
+                int(old_cursor),
+            ),
         )
         return old_cursor, new_cursor, events
 
@@ -11757,7 +12167,11 @@ def rewind_notify_cursor(
             "WHERE task_id = ? AND platform = ? AND chat_id = ? AND thread_id = ? "
             "AND last_event_id = ?",
             (
-                int(old_cursor), task_id, platform, chat_id, thread_id or "",
+                int(old_cursor),
+                task_id,
+                platform,
+                chat_id,
+                thread_id or "",
                 int(claimed_cursor),
             ),
         )
@@ -11768,8 +12182,11 @@ def rewind_notify_cursor(
 # Retention + garbage collection
 # ---------------------------------------------------------------------------
 
+
 def gc_events(
-    conn: sqlite3.Connection, *, older_than_seconds: int = 30 * 24 * 3600,
+    conn: sqlite3.Connection,
+    *,
+    older_than_seconds: int = 30 * 24 * 3600,
 ) -> int:
     """Delete task_events rows older than ``older_than_seconds`` for tasks
     in a terminal state (``done`` or ``archived``). Returns the number of
@@ -11786,7 +12203,8 @@ def gc_events(
 
 
 def gc_worker_logs(
-    *, older_than_seconds: int = 30 * 24 * 3600,
+    *,
+    older_than_seconds: int = 30 * 24 * 3600,
     board: Optional[str] = None,
 ) -> int:
     """Delete worker log files older than ``older_than_seconds``. Returns
@@ -11813,6 +12231,7 @@ def gc_worker_logs(
 # Worker log accessor
 # ---------------------------------------------------------------------------
 
+
 def worker_log_path(task_id: str, *, board: Optional[str] = None) -> Path:
     """Return the path to a worker's log file. The file may not exist
     (task never spawned, or log already GC'd).
@@ -11825,7 +12244,9 @@ def worker_log_path(task_id: str, *, board: Optional[str] = None) -> Path:
 
 
 def read_worker_log(
-    task_id: str, *, tail_bytes: Optional[int] = None,
+    task_id: str,
+    *,
+    tail_bytes: Optional[int] = None,
     board: Optional[str] = None,
 ) -> Optional[str]:
     """Read the worker log for ``task_id``. Returns None if the file
@@ -11859,6 +12280,7 @@ def read_worker_log(
 # Assignee enumeration (known profiles + per-profile board stats)
 # ---------------------------------------------------------------------------
 
+
 def list_profiles_on_disk() -> list[str]:
     """Return the set of assignee/profile names discovered on disk.
 
@@ -11872,6 +12294,7 @@ def list_profiles_on_disk() -> list[str]:
     """
     try:
         from hermes_constants import get_default_hermes_root
+
         default_root = get_default_hermes_root()
         profiles_dir = default_root / "profiles"
     except Exception:
@@ -11933,6 +12356,7 @@ def known_assignees(conn: sqlite3.Connection) -> list[dict]:
 # Runs (attempt history on a task)
 # ---------------------------------------------------------------------------
 
+
 def list_runs(
     conn: sqlite3.Connection,
     task_id: str,
@@ -11970,7 +12394,8 @@ def list_runs(
 
 def get_run(conn: sqlite3.Connection, run_id: int) -> Optional[Run]:
     row = conn.execute(
-        "SELECT * FROM task_runs WHERE id = ?", (int(run_id),),
+        "SELECT * FROM task_runs WHERE id = ?",
+        (int(run_id),),
     ).fetchone()
     return Run.from_row(row) if row else None
 

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -1591,3 +1591,166 @@ def test_bare_connect_does_not_close_on_context_exit(tmp_path):
     # Still usable after with-block exit (the leak).
     conn.execute("SELECT 1").fetchone()
     conn.close()  # explicit close to avoid leaking THIS test
+
+
+# ---------------------------------------------------------------------------
+# Completion evidence contract
+#
+# `complete_task` stores a free-form summary and a free-form metadata dict
+# and checks neither against the world. A task that declares an
+# `evidence_repo` opts into having its claim checked against git instead.
+# ---------------------------------------------------------------------------
+
+
+def _evidence_task(conn, repo, **kw):
+    return kb.create_task(
+        conn, title="evidence", assignee="builder",
+        evidence_repo=str(repo), **kw,
+    )
+
+
+def test_evidence_gate_refuses_a_completion_git_cannot_corroborate(kanban_home, tmp_path):
+    """The four shapes a false completion takes, all refused.
+
+    Each is a claim the worker can make with no work behind it: a repo
+    that does not exist, a repo where nothing changed, a path that was
+    not touched, and a fabricated commit id.
+    """
+    repo = tmp_path / "repo"
+    _init_git_repo(repo)
+    conn = kb.connect()
+    try:
+        # 1. The declared repo is not a git repository at all.
+        tid = _evidence_task(conn, tmp_path / "nowhere")
+        with pytest.raises(kb.CompletionEvidenceError):
+            kb.complete_task(conn, tid, summary="done",
+                             metadata={"changed_files": ["README.md"]})
+
+        # 2. Real repo, but the working tree is clean.
+        tid = _evidence_task(conn, repo)
+        with pytest.raises(kb.CompletionEvidenceError):
+            kb.complete_task(conn, tid, summary="done",
+                             metadata={"changed_files": ["README.md"]})
+
+        # 3. Something changed, but not the path that was claimed.
+        (repo / "README.md").write_text("edited\n", encoding="utf-8")
+        tid = _evidence_task(conn, repo)
+        with pytest.raises(kb.CompletionEvidenceError):
+            kb.complete_task(conn, tid, summary="done",
+                             metadata={"changed_files": ["untouched.py"]})
+
+        # 4. Real change, fabricated commit id.
+        tid = _evidence_task(conn, repo)
+        with pytest.raises(kb.CompletionEvidenceError):
+            kb.complete_task(conn, tid, summary="done",
+                             metadata={"changed_files": ["README.md"],
+                                       "commit": "deadbeefcafe"})
+
+        # 5. No claim at all is also a refusal — the gate cannot be
+        #    satisfied by omitting the field it checks.
+        tid = _evidence_task(conn, repo)
+        with pytest.raises(kb.CompletionEvidenceError):
+            kb.complete_task(conn, tid, summary="done",
+                             metadata={"tests_run": 916})
+    finally:
+        conn.close()
+
+
+def test_evidence_gate_accepts_real_work_without_a_commit(kanban_home, tmp_path):
+    """A dirty working tree is enough; a new file counts too.
+
+    Cards frequently forbid committing, so requiring a commit range would
+    reject honest work. `git diff` alone cannot see a file that did not
+    exist at HEAD, so untracked files are counted as well — otherwise
+    "write a new module" would be unsatisfiable.
+    """
+    repo = tmp_path / "repo"
+    _init_git_repo(repo)
+    (repo / "README.md").write_text("edited\n", encoding="utf-8")
+    (repo / "brand_new.py").write_text("def f(): pass\n", encoding="utf-8")
+    (repo / ".gitignore").write_text("*.log\n", encoding="utf-8")
+    (repo / "noise.log").write_text("ignored\n", encoding="utf-8")
+
+    conn = kb.connect()
+    try:
+        tid = _evidence_task(conn, repo)
+        assert kb.complete_task(conn, tid, summary="edited it",
+                                metadata={"changed_files": ["README.md"]}) is True
+
+        tid = _evidence_task(conn, repo)
+        assert kb.complete_task(conn, tid, summary="wrote a module",
+                                metadata={"changed_files": ["brand_new.py"]}) is True
+
+        # An ignored build artifact is not evidence.
+        tid = _evidence_task(conn, repo)
+        with pytest.raises(kb.CompletionEvidenceError):
+            kb.complete_task(conn, tid, summary="built it",
+                             metadata={"changed_files": ["noise.log"]})
+    finally:
+        conn.close()
+
+
+def test_evidence_gate_reads_the_builders_review_handoff(kanban_home, tmp_path):
+    """The reviewer completes the task, but the builder knows the paths.
+
+    Requiring evidence on the closing call alone would ask the reviewer to
+    author facts about work they did not do, so the gate falls back to the
+    `review_requested` run the builder left behind.
+    """
+    repo = tmp_path / "repo"
+    _init_git_repo(repo)
+    (repo / "README.md").write_text("edited\n", encoding="utf-8")
+
+    conn = kb.connect()
+    try:
+        tid = _evidence_task(conn, repo)
+        run_id = kb.claim_task(conn, tid, claimer="builder").current_run_id
+        kb.request_review(conn, tid, reviewer="reviewer", expected_run_id=run_id,
+                          summary="built it",
+                          metadata={"changed_files": ["README.md"]})
+        # The reviewer passes no metadata of its own.
+        assert kb.complete_task(conn, tid, summary="approved") is True
+
+        # Without that handoff evidence there is nothing to inherit.
+        tid = _evidence_task(conn, repo)
+        run_id = kb.claim_task(conn, tid, claimer="builder").current_run_id
+        kb.request_review(conn, tid, reviewer="reviewer", expected_run_id=run_id,
+                          summary="built it")
+        with pytest.raises(kb.CompletionEvidenceError):
+            kb.complete_task(conn, tid, summary="approved")
+    finally:
+        conn.close()
+
+
+def test_evidence_gate_is_opt_in_and_retryable(kanban_home, tmp_path):
+    """A task without `evidence_repo` completes exactly as before, and a
+    refused task is left untouched so a corrected retry lands.
+
+    Mirrors the created_cards gate's contract: the rejection happens
+    before the write transaction, so the worker can fix its claim and
+    call complete again.
+    """
+    repo = tmp_path / "repo"
+    _init_git_repo(repo)
+    (repo / "README.md").write_text("edited\n", encoding="utf-8")
+
+    conn = kb.connect()
+    try:
+        plain = kb.create_task(conn, title="no evidence declared", assignee="builder")
+        assert kb.complete_task(conn, plain, summary="done") is True
+
+        tid = _evidence_task(conn, repo)
+        with pytest.raises(kb.CompletionEvidenceError):
+            kb.complete_task(conn, tid, summary="done",
+                             metadata={"changed_files": ["untouched.py"]})
+        assert kb.get_task(conn, tid).status != "done"
+
+        assert kb.complete_task(conn, tid, summary="done",
+                                metadata={"changed_files": ["README.md"]}) is True
+        assert kb.get_task(conn, tid).status == "done"
+
+        kinds = [r["kind"] for r in conn.execute(
+            "SELECT kind FROM task_events WHERE task_id = ?", (tid,))]
+        assert "completion_blocked_no_evidence" in kinds
+    finally:
+        conn.close()

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -1593,6 +1593,52 @@ def test_bare_connect_does_not_close_on_context_exit(tmp_path):
     conn.close()  # explicit close to avoid leaking THIS test
 
 
+
+
+def test_board_stats_reports_the_completion_evidence_gate(kanban_home, tmp_path):
+    """A zero refusal count is unreadable without knowing how many cards are armed.
+
+    "Nobody claimed a false completion" and "no card asks for evidence" are
+    opposite facts that both render as 0 refusals, so the armed count ships
+    beside them. Retries are separated from rows: one card that corrected its
+    claim twice is one row and three events, not three bad cards.
+    """
+    repo = tmp_path / "repo"
+    _init_git_repo(repo)
+    conn = kb.connect()
+    try:
+        empty = kb.board_stats(conn)
+        assert empty["completion_evidence_armed_rows"] == 0
+        assert empty["completion_evidence_blocked_rows"] == 0
+        assert empty["completion_evidence_blocked_events"] == 0
+
+        armed = kb.create_task(
+            conn, title="armed", assignee="builder", evidence_repo=str(repo),
+        )
+        kb.create_task(conn, title="not armed", assignee="builder")
+        assert kb.board_stats(conn)["completion_evidence_armed_rows"] == 1
+
+        for _ in range(3):
+            with pytest.raises(kb.CompletionEvidenceError):
+                kb.complete_task(
+                    conn, armed, summary="done",
+                    metadata={"changed_files": ["untouched.py"]},
+                )
+
+        stats = kb.board_stats(conn)
+        assert stats["completion_evidence_armed_rows"] == 1
+        assert stats["completion_evidence_blocked_rows"] == 1
+        assert stats["completion_evidence_blocked_events"] == 3
+
+        # Counts only: no path, repository, or task id may ride along.
+        serialized = repr(sorted(stats.items()))
+        assert str(repo) not in serialized
+        assert "untouched.py" not in serialized
+        assert armed not in serialized
+    finally:
+        conn.close()
+
+
 # ---------------------------------------------------------------------------
 # Completion evidence contract
 #

--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -1134,3 +1134,69 @@ def test_attach_url_happy_path_public_host(worker_env, default_url_guard, monkey
         assert Path(atts[0].stored_path).read_bytes() == payload
     finally:
         conn.close()
+
+
+def test_evidence_repo_reaches_the_gate_through_the_create_tool(worker_env, tmp_path):
+    """An orchestrator only ever creates cards through `kanban_create`.
+
+    The CLI flag alone leaves the completion gate unreachable by the agent
+    that is supposed to turn it on, which is how a feature ships and protects
+    nothing. This drives the whole path with the tools: create with an
+    evidence repo, watch a false completion get refused, and watch a real one
+    land.
+    """
+    import subprocess
+    from tools import kanban_tools as kt
+    from hermes_cli import kanban_db as kb
+
+    repo = tmp_path / "evidence-repo"
+    repo.mkdir()
+    for argv in (["init", "-b", "main"], ["config", "user.email", "t@example.com"],
+                 ["config", "user.name", "T"]):
+        subprocess.run(["git", "-C", str(repo), *argv], check=True, capture_output=True)
+    (repo / "mod.py").write_text("x = 1\n", encoding="utf-8")
+    subprocess.run(["git", "-C", str(repo), "add", "-A"], check=True, capture_output=True)
+    subprocess.run(["git", "-C", str(repo), "commit", "-m", "init"], check=True,
+                   capture_output=True)
+
+    created = json.loads(kt._handle_create({
+        "title": "change the module",
+        "assignee": "test-worker",
+        "evidence_repo": str(repo),
+    }))
+    assert created["ok"]
+    tid = created["task_id"]
+
+    conn = kb.connect()
+    try:
+        assert kb.get_task(conn, tid).evidence_repo == str(repo)
+    finally:
+        conn.close()
+
+    os.environ["HERMES_KANBAN_TASK"] = tid
+    # Nothing has changed yet, so the claim cannot be corroborated.
+    refused = json.loads(kt._handle_complete({
+        "task_id": tid,
+        "summary": "done",
+        "metadata": {"changed_files": ["mod.py"]},
+    }))
+    assert "error" in refused
+    assert "mod.py" in refused["error"]
+
+    (repo / "mod.py").write_text("x = 2\n", encoding="utf-8")
+    accepted = json.loads(kt._handle_complete({
+        "task_id": tid,
+        "summary": "done",
+        "metadata": {"changed_files": ["mod.py"]},
+    }))
+    assert accepted["ok"], accepted
+
+    # A card that names no repo is untouched by any of this.
+    plain = json.loads(kt._handle_create({
+        "title": "no evidence declared",
+        "assignee": "test-worker",
+    }))
+    os.environ["HERMES_KANBAN_TASK"] = plain["task_id"]
+    assert json.loads(kt._handle_complete({
+        "task_id": plain["task_id"], "summary": "done",
+    }))["ok"]

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -799,6 +799,22 @@ def _handle_complete(args: dict, **kw) -> str:
                     f"and either drop these ids from created_cards, or pass "
                     f"created_cards=[] to skip the card-claim check entirely."
                 )
+            except kb.CompletionEvidenceError as ev_err:
+                # Same structured-rejection contract as the phantom-card
+                # gate above: nothing was mutated, so a corrected retry
+                # works. The difference is that retrying is not always the
+                # right move here — if the work genuinely did not happen,
+                # blocking is the honest outcome and the message has to say
+                # so, or the model will keep inventing paths to get past
+                # the gate.
+                return tool_error(
+                    f"{ev_err}\n"
+                    f"Your task is still in-flight (no state change). Either "
+                    f"retry kanban_complete with the paths you really changed, "
+                    f"or call kanban_block with kind=\"capability\" if you could "
+                    f"not make the change — blocking is the correct outcome when "
+                    f"there is nothing to show."
+                )
             if not ok:
                 return tool_error(
                     f"could not complete {tid} (unknown id or already terminal)"
@@ -1768,7 +1784,12 @@ KANBAN_COMPLETE_SCHEMA = {
         "downstream workers and humans. Prefer ``summary`` for a "
         "human-readable 1-3 sentence description of what you did; put "
         "machine-readable facts in ``metadata`` (changed_files, "
-        "tests_run, decisions, findings, etc). At least one of "
+        "tests_run, decisions, findings, etc). ``metadata.changed_files`` "
+        "is verified, not decorative: when the card declares an evidence "
+        "repository, the kernel asks git whether those paths actually "
+        "differ and refuses the completion if they do not. If you could "
+        "not make the change, block with kind=\"capability\" — that is "
+        "the correct outcome, not a failure. At least one of "
         "``summary`` or ``result`` is required. If you created new "
         "tasks via ``kanban_create`` during this run, list their ids "
         "in ``created_cards`` — the kernel verifies them so phantom "
@@ -1937,8 +1958,12 @@ KANBAN_REQUEST_REVIEW_SCHEMA = {
             "metadata": {
                 "type": "object",
                 "description": (
-                    "Optional structured handoff facts for the reviewer, such "
-                    "as changed_files, tests_run, commit, or decisions."
+                    "Structured handoff facts for the reviewer, such as "
+                    "changed_files, tests_run, commit, or decisions. List "
+                    "every path you changed in ``changed_files``: you are "
+                    "the one who knows, and if the card declares an "
+                    "evidence repository the reviewer's completion is "
+                    "checked against this list."
                 ),
                 "additionalProperties": True,
             },

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -1402,6 +1402,7 @@ def _handle_create(args: dict, **kw) -> str:
     # preserving the repository/branch convention without sharing a checkout.
     workspace_kind = args.get("workspace_kind")
     workspace_path = args.get("workspace_path")
+    evidence_repo = args.get("evidence_repo")
     project_id = args.get("project") or args.get("project_id")
     project_source_task_id = None
     _inherit_project = workspace_kind is None and workspace_path is None
@@ -1459,6 +1460,7 @@ def _handle_create(args: dict, **kw) -> str:
                 priority=int(priority) if priority is not None else 0,
                 workspace_kind=str(workspace_kind),
                 workspace_path=workspace_path,
+                evidence_repo=evidence_repo,
                 project_id=project_id,
                 project_source_task_id=project_source_task_id,
                 triage=triage,
@@ -2227,6 +2229,23 @@ KANBAN_CREATE_SCHEMA = {
                 "description": (
                     "Absolute path for 'dir' or 'worktree' workspace. "
                     "Relative paths are rejected at dispatch."
+                ),
+            },
+            "evidence_repo": {
+                "type": "string",
+                "description": (
+                    "Absolute path to the repository this task's completion "
+                    "is checked against. Set it whenever the card asks for a "
+                    "code change: the kernel then refuses to close the card "
+                    "unless git shows the paths the worker claims to have "
+                    "changed actually differ. No commit is needed — a dirty "
+                    "working tree or a new file is enough. Say in the body "
+                    "that the worker must list what it changed in "
+                    "metadata.changed_files, and that blocking with "
+                    "kind=\"capability\" is the right answer if it cannot "
+                    "make the change. Leave this out for probes, syntheses, "
+                    "reviews and anything else that legitimately produces no "
+                    "code — the check does nothing unless a repo is named."
                 ),
             },
             "project": {


### PR DESCRIPTION
## What does this PR do?

`complete_task` stores a free-form `summary` and a free-form `metadata` dict and checks **neither** against the world. A worker can close a card by asserting it did the work.

`created_cards` is the existing exception: the kernel verifies claimed task ids against `tasks.created_by` and refuses phantom ones, because — as the schema says — "the kernel verifies them so phantom references are caught before they leak into downstream automation." This PR gives a claim about *files* the same treatment.

### Why this is worth a gate

Observed on one install, 2026-08-14: four cards closed with a builder's `full backend suite 916 passed` and a reviewer's `APPROVED — verified the diff covers every cited path`. The worktree both of them named **did not exist**, no branch had a commit, and the defect under review was untouched. Across a 382-completion sample, **zero** carried any evidence metadata.

This is not install-specific. The literature calls it **False Success** — a natural-language completion claim that contradicts programmatic environment state — and measures it at **44–52 % of all failures** in `tau2-bench` (8 frontier models, 9,876 trajectories) and **75.8 %** in `AppWorld`. It propagates quietly precisely because, unlike a crash or a refusal, the agent presents the situation as resolved.

The discriminator those benchmarks converge on is *state the agent's language cannot author*. In this repository that is `git`.

## Related Issue

No existing issue.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `hermes_cli/kanban_db.py`
  - `tasks.evidence_repo TEXT` (nullable; migration + DDL + `Task` field + `Task.from_row`)
  - `create_task(evidence_repo=...)`
  - `_git_changed_paths` / `_git_commit_exists` — narrow subprocess helpers beside the existing `_git_*` block, same `timeout=30, check=False` idiom, no new dependency
  - `_claimed_change_evidence` / `_verify_completion_evidence`
  - `CompletionEvidenceError(ValueError)` — sibling of `HallucinatedCardsError`
  - the gate in `complete_task`, placed **before the write transaction** next to the `created_cards` gate
- `hermes_cli/kanban.py` — `kanban create --evidence-repo`, and `evidence_repo` in the task JSON
- `tools/kanban_tools.py` — `kanban_complete` surfaces the rejection with the retry/block guidance; schema text now states that `changed_files` is verified
- `tests/hermes_cli/test_kanban_db.py` — four tests

### Design decisions, and what each one is defending against

**Opt-in.** With no `evidence_repo` the gate does not run at all. Probes, syntheses, reviews and anything else that legitimately produces no code close exactly as they do today, and no existing card changes behaviour.

**No commit required.** The check reads working-tree state. Measured: the one card in that batch that genuinely *did* its work left **23 modified files and zero commits**, because the card forbade committing. A `base..head` design would have rejected the honest case and passed nothing.

**Untracked files count**, via `ls-files --others --exclude-standard`. `git diff` cannot see a file that did not exist at `HEAD`, so a diff-only gate makes "write a new module" an unsatisfiable card. `--exclude-standard` keeps build output and ignored files from passing as evidence.

**Evidence is read from the review handoff too.** The reviewer, not the builder, is who calls `complete_task`. Requiring evidence only on the closing call asks the reviewer to author facts about work they did not do — which is what produced the false approval above. So the gate reads `metadata.changed_files` from the completing call first, then falls back to the latest `review_requested` run.

**Rejection is an exception, and it is recoverable.** `CompletionEvidenceError` subclasses `ValueError` exactly as `HallucinatedCardsError` does, so existing tool-error handling treats it as a fixable user error. The gate runs before the write transaction, so a refused task is untouched and a corrected retry lands. A `completion_blocked_no_evidence` event is recorded so the rejected attempt is auditable.

**The message carries the next action.** It names what was claimed, what git actually sees, and that blocking with `kind="capability"` is the correct outcome when the change could not be made:

```
completion blocked: <repo> shows no change to docs/NOT_TOUCHED.md
  repo:     <repo>
  claimed:  docs/NOT_TOUCHED.md
  changed:  backend/main.py, backend/routers/contacts.py (+18 more)
  → put the paths you actually changed in metadata.changed_files,
    or block with kind="capability" if you could not make the change
```

This is load-bearing rather than cosmetic. A gate a worker meets without knowing what to do about it gets worked around, not obeyed.

### What it catches, and what it does not

| Claim | Result |
|---|---|
| Nothing done, "done" reported | refused |
| Nonexistent repo/worktree named | refused |
| Fabricated commit id | refused |
| Real change, but a different path claimed | refused |
| Real change, **wrong content** | **passes — reviewer's job** |

Two layers that do not overlap: the kernel establishes that something exists, the reviewer judges whether it is right.

**Known limitation:** the gate reads the whole working tree, so it cannot distinguish this task's changes from changes already present when the task started. On a shared, already-dirty repository a worker could satisfy it by naming a path someone else touched. Closing that needs a per-task baseline captured at claim time, which is a larger change than this one and has its own false-negative risk (a card that legitimately edits an already-dirty file). Called out rather than papered over.

## How to Test

1. `pytest tests/hermes_cli/test_kanban_db.py -q` → 33 passed, 1 skipped.
2. Positive control: change `if evidence_repo:` to `if False:` in `complete_task` → all four `test_evidence_gate_*` tests fail.
3. Opt-in check: forcing the gate on every card (`if True:`) breaks 28 tests; as written it breaks 0.
4. End to end:
   ```
   hermes kanban create "task" --assignee builder --evidence-repo /path/to/clean/repo
   hermes kanban complete <id> --summary "done"     # refused, with the message above
   ```

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this feature
- [ ] I've run `pytest tests/ -q` and all tests pass — **see note below**
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15 (Darwin 25.6.0), Python 3.14

> **Note on the full suite.** I A/B'd the 25 files under `tests/hermes_cli/` and `tests/tools/` that touch `complete_task`: **202 passed → 206 passed** (the four new tests), with an identical 8-test failure *set* before and after — those 8 fail on unmodified `main` too. I compared failure sets rather than counts deliberately. I did not run `pytest tests/` in full because the suite mutates the checked-out branch of the repository it runs in. `ruff check` passes against this repo's config.

### Documentation & Housekeeping

- [x] I've updated relevant documentation — the `--evidence-repo` help text and the `kanban_complete` schema description carry the contract
- [x] I've updated `cli-config.yaml.example` — N/A (per-task column, not a config key)
- [x] I've updated `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] I've considered cross-platform impact — `git` is invoked via `subprocess` with an argv list and `-C <repo>`, no shell; paths come from git and are compared as posix-style relative strings, which is what git emits on every platform
- [x] I've updated tool descriptions/schemas — `KANBAN_COMPLETE_SCHEMA` and the `request_review` metadata description now state that `changed_files` is verified
