### PR TITLE
fix(desktop): preserve Copy Image for large remote media (salvage #65817)

### DIFF
--- a/apps/desktop/electron/image-context-menu.test.ts
+++ b/apps/desktop/electron/image-context-menu.test.ts
@@ -1,0 +1,64 @@
+import assert from 'node:assert/strict'
+
+import { test } from 'vitest'
+
+import { imageContextMenuItems } from './image-context-menu'
+
+function createActions() {
+  const calls = {
+    copyImageAt: [],
+    openImage: [],
+    copyImageAddress: [],
+    saveImage: []
+  }
+
+  return {
+    calls,
+    actions: {
+      copyImageAt: (x, y) => calls.copyImageAt.push([x, y]),
+      openImage: url => calls.openImage.push(url),
+      copyImageAddress: url => calls.copyImageAddress.push(url),
+      saveImage: url => calls.saveImage.push(url)
+    }
+  }
+}
+
+test('keeps Copy Image available when Chromium omits a large image srcURL', () => {
+  const { actions, calls } = createActions()
+  const items = imageContextMenuItems({ mediaType: 'image', srcURL: '', x: 100, y: 120 }, actions)
+
+  assert.deepEqual(
+    items.map(item => item.label),
+    ['Copy Image']
+  )
+
+  items[0].click()
+  assert.deepEqual(calls.copyImageAt, [[100, 120]])
+})
+
+test('keeps URL-dependent image actions when srcURL is available', () => {
+  const { actions, calls } = createActions()
+  const url = 'https://example.com/image.png'
+  const items = imageContextMenuItems({ mediaType: 'image', srcURL: url, x: 5, y: 8 }, actions)
+
+  assert.deepEqual(
+    items.map(item => item.label),
+    ['Open Image', 'Copy Image', 'Copy Image Address', 'Save Image As...']
+  )
+
+  items[0].click()
+  items[1].click()
+  items[2].click()
+  items[3].click()
+
+  assert.deepEqual(calls.openImage, [url])
+  assert.deepEqual(calls.copyImageAt, [[5, 8]])
+  assert.deepEqual(calls.copyImageAddress, [url])
+  assert.deepEqual(calls.saveImage, [url])
+})
+
+test('does not add image actions for a non-image target', () => {
+  const { actions } = createActions()
+
+  assert.deepEqual(imageContextMenuItems({ mediaType: 'none', srcURL: '', x: 0, y: 0 }, actions), [])
+})

--- a/apps/desktop/electron/image-context-menu.test.ts
+++ b/apps/desktop/electron/image-context-menu.test.ts
@@ -25,7 +25,11 @@ function createActions() {
 
 test('keeps Copy Image available when Chromium omits a large image srcURL', () => {
   const { actions, calls } = createActions()
-  const items = imageContextMenuItems({ mediaType: 'image', srcURL: '', x: 100, y: 120 }, actions)
+
+  const items = imageContextMenuItems(
+    { mediaType: 'image', hasImageContents: true, srcURL: '', x: 100, y: 120 },
+    actions
+  )
 
   assert.deepEqual(
     items.map(item => item.label),
@@ -39,7 +43,11 @@ test('keeps Copy Image available when Chromium omits a large image srcURL', () =
 test('keeps URL-dependent image actions when srcURL is available', () => {
   const { actions, calls } = createActions()
   const url = 'https://example.com/image.png'
-  const items = imageContextMenuItems({ mediaType: 'image', srcURL: url, x: 5, y: 8 }, actions)
+
+  const items = imageContextMenuItems(
+    { mediaType: 'image', hasImageContents: true, srcURL: url, x: 5, y: 8 },
+    actions
+  )
 
   assert.deepEqual(
     items.map(item => item.label),
@@ -60,5 +68,17 @@ test('keeps URL-dependent image actions when srcURL is available', () => {
 test('does not add image actions for a non-image target', () => {
   const { actions } = createActions()
 
-  assert.deepEqual(imageContextMenuItems({ mediaType: 'none', srcURL: '', x: 0, y: 0 }, actions), [])
+  assert.deepEqual(
+    imageContextMenuItems({ mediaType: 'none', hasImageContents: false, srcURL: '', x: 0, y: 0 }, actions),
+    []
+  )
+})
+
+test('does not offer Copy Image when the target has no decoded image contents', () => {
+  const { actions } = createActions()
+
+  assert.deepEqual(
+    imageContextMenuItems({ mediaType: 'image', hasImageContents: false, srcURL: '', x: 0, y: 0 }, actions),
+    []
+  )
 })

--- a/apps/desktop/electron/image-context-menu.ts
+++ b/apps/desktop/electron/image-context-menu.ts
@@ -1,0 +1,40 @@
+export function imageContextMenuItems(params, actions) {
+  if (params.mediaType !== 'image') {
+    return []
+  }
+
+  const items = []
+  const srcURL = params.srcURL || ''
+
+  if (srcURL) {
+    items.push({
+      label: 'Open Image',
+      click: () => {
+        if (!srcURL.startsWith('data:')) {
+          actions.openImage(srcURL)
+        }
+      },
+      enabled: !srcURL.startsWith('data:')
+    })
+  }
+
+  items.push({
+    label: 'Copy Image',
+    click: () => actions.copyImageAt(params.x, params.y)
+  })
+
+  if (srcURL) {
+    items.push(
+      {
+        label: 'Copy Image Address',
+        click: () => actions.copyImageAddress(srcURL)
+      },
+      {
+        label: 'Save Image As...',
+        click: () => actions.saveImage(srcURL)
+      }
+    )
+  }
+
+  return items
+}

--- a/apps/desktop/electron/image-context-menu.ts
+++ b/apps/desktop/electron/image-context-menu.ts
@@ -1,5 +1,5 @@
 export function imageContextMenuItems(params, actions) {
-  if (params.mediaType !== 'image') {
+  if (params.mediaType !== 'image' || !params.hasImageContents) {
     return []
   }
 

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -17,7 +17,6 @@ import {
   globalShortcut,
   ipcMain,
   Menu,
-  nativeImage,
   nativeTheme,
   Notification,
   powerMonitor,
@@ -160,6 +159,7 @@ import { cursorPointInWindow } from './hud-cursor'
 import { snapHudBounds } from './hud-snap'
 import { createHudSnapShortcut } from './hud-snap-shortcut'
 import { buildHudWindowUrl } from './hud-url'
+import { imageContextMenuItems } from './image-context-menu'
 import { createLinkTitleWindow, guardLinkTitleSession, readLinkTitleWindowTitle } from './link-title-window'
 import { ensureMainWindow } from './main-window-lifecycle'
 import {
@@ -5114,17 +5114,6 @@ async function resourceBufferFromUrl(rawUrl) {
   })
 }
 
-async function copyImageFromUrl(rawUrl) {
-  const { buffer } = (await resourceBufferFromUrl(rawUrl)) as any
-  const image = nativeImage.createFromBuffer(buffer)
-
-  if (image.isEmpty()) {
-    throw new Error('Could not read image')
-  }
-
-  clipboard.writeImage(image)
-}
-
 async function saveImageFromUrl(rawUrl) {
   const { buffer, mimeType } = (await resourceBufferFromUrl(rawUrl)) as any
   const extension = extensionForMimeType(mimeType) || '.png'
@@ -5976,39 +5965,19 @@ function installContextMenu(window) {
   window.webContents.on('context-menu', (_event, params) => {
     const template = []
     const hasSelection = Boolean(params.selectionText?.trim())
-    const hasImage = params.mediaType === 'image' && Boolean(params.srcURL)
     const hasLink = Boolean(params.linkURL)
     const isEditable = Boolean(params.isEditable)
 
-    if (hasImage) {
-      template.push(
-        {
-          label: 'Open Image',
-          click: () => {
-            if (params.srcURL && !params.srcURL.startsWith('data:')) {
-              openExternalUrl(params.srcURL)
-            }
-          },
-          enabled: !params.srcURL.startsWith('data:')
-        },
-        {
-          label: 'Copy Image',
-          click: () => {
-            void copyImageFromUrl(params.srcURL).catch(error => rememberLog(`Copy image failed: ${error.message}`))
-          }
-        },
-        {
-          label: 'Copy Image Address',
-          click: () => clipboard.writeText(params.srcURL)
-        },
-        {
-          label: 'Save Image As...',
-          click: () => {
-            void saveImageFromUrl(params.srcURL).catch(error => rememberLog(`Save image failed: ${error.message}`))
-          }
+    template.push(
+      ...imageContextMenuItems(params, {
+        copyImageAt: (x, y) => window.webContents.copyImageAt(x, y),
+        openImage: openExternalUrl,
+        copyImageAddress: url => clipboard.writeText(url),
+        saveImage: url => {
+          void saveImageFromUrl(url).catch(error => rememberLog(`Save image failed: ${error.message}`))
         }
-      )
-    }
+      })
+    )
 
     if (hasLink) {
       if (template.length) {


### PR DESCRIPTION
## Summary
Copy Image no longer disappears from the desktop context menu when Chromium omits `srcURL` for a large rendered `data:` image — salvage of #65817 by @locker95, fixes #65767.

Image detection now keys on `mediaType === 'image'` + `hasImageContents` instead of requiring a URL, and copying goes through coordinate-based `webContents.copyImageAt(x, y)` (decoded pixels, no refetch). URL-dependent actions (Open Image, Copy Image Address, Save Image As...) stay gated on a usable `srcURL`, and broken/undecoded images get no no-op copy action.

## Changes
- `apps/desktop/electron/image-context-menu.ts`: new pure builder for the image section of the native context menu.
- `apps/desktop/electron/main.ts`: `installContextMenu` delegates to the builder; drops the URL-refetching `copyImageFromUrl()`.
- `apps/desktop/electron/image-context-menu.test.ts`: regression coverage for empty `srcURL`, decoded-content gating, and URL-backed behavior.

## Validation
| Check | Result |
|---|---|
| `npx vitest run electron/image-context-menu.test.ts` | 4/4 pass |
| `npm run check:lint` (tsc ×3 + eslint) | 0 errors |
| Attribution audit | all mapped (@locker95 authorship preserved) |

Salvaged from #65817 (stale base) via cherry-pick; #65840 is a later duplicate of the same fix.

## Infographic

![Copy Image works for large media](https://files.catbox.moe/j6xkcz.png)
