### PR TITLE
fix(cron): wait for hermes cron run instead of detaching

### DIFF
--- a/hermes_cli/cron.py
+++ b/hermes_cli/cron.py
@@ -462,7 +462,18 @@ def cron_edit(args):
 
 
 def _job_action(action: str, job_id: str, success_verb: str) -> int:
-    result = _cron_api(action=action, job_id=job_id)
+    extra = {}
+    if action == "run":
+        # This process is one-shot. Detaching the job into a background
+        # thread would kill the runner on exit (#86721). Force inline run.
+        extra["allow_background"] = False
+        try:
+            from cron.executions import recover_interrupted_executions
+
+            recover_interrupted_executions()
+        except Exception:
+            pass
+    result = _cron_api(action=action, job_id=job_id, **extra)
     if not result.get("success"):
         print(color(f"Failed to {action} job: {result.get('error', 'unknown error')}", Colors.RED))
         return 1

--- a/tests/hermes_cli/test_cron.py
+++ b/tests/hermes_cli/test_cron.py
@@ -357,3 +357,33 @@ class TestCronRunBackgroundDispatch:
         assert rc == 0
         assert "Running in background (delegation del-xyz)." in out
         assert "failed" not in out.lower()
+
+    def test_oneshot_run_forces_inline_and_reaps_dead_claims(self, monkeypatch, capsys):
+        """`hermes cron run` must wait in this process (#86721)."""
+        seen = {}
+        recovered = {"called": False}
+
+        def fake_api(**kwargs):
+            seen.update(kwargs)
+            return {
+                "success": True,
+                "job": {
+                    "id": "job-1",
+                    "name": "Watchdog",
+                    "executed": True,
+                    "execution_success": True,
+                },
+            }
+
+        monkeypatch.setattr(cron_cli, "_cron_api", fake_api)
+        monkeypatch.setattr(
+            "cron.executions.recover_interrupted_executions",
+            lambda: recovered.__setitem__("called", True) or 0,
+        )
+
+        rc, out = self._run_cmd(capsys)
+
+        assert rc == 0
+        assert seen.get("allow_background") is False
+        assert recovered["called"] is True
+        assert "Ran now: succeeded." in out

--- a/tests/tools/test_cronjob_run_background.py
+++ b/tests/tools/test_cronjob_run_background.py
@@ -167,6 +167,36 @@ class TestBackgroundDispatch:
 
 
 class TestSyncFallbacks:
+    def test_allow_background_false_stays_inline_even_with_session_key(self):
+        """One-shot `hermes cron run` must wait, even if HERMES_SESSION_KEY is set.
+
+        A leftover Desktop or gateway env would otherwise claim the job, start
+        a background thread, then exit and kill the runner (#86721).
+        """
+        claimed = {**_job("job-bg-cli-wait"), "fire_claim": {"by": "cli-owner"}}
+        with _bound_session_key():
+            with patch("tools.cronjob_tools.resolve_job_ref", return_value=_job("job-bg-cli-wait")), \
+                 patch("tools.cronjob_tools.claim_job_for_fire", return_value=claimed), \
+                 patch("tools.async_delegation.dispatch_async_delegation") as m_disp, \
+                 patch("cron.scheduler.run_one_job", return_value=True) as m_run, \
+                 patch("tools.cronjob_tools.get_job",
+                       return_value={"last_status": "ok", "last_error": None}):
+                out = json.loads(
+                    cronjob(
+                        action="run",
+                        job_id="job-bg-cli-wait",
+                        allow_background=False,
+                    )
+                )
+
+        assert out["success"] is True
+        assert out["job"]["executed"] is True
+        assert out["job"]["execution_success"] is True
+        assert out["job"].get("execution_mode") != "background"
+        assert out["job"].get("delegation_id") is None
+        m_disp.assert_not_called()
+        m_run.assert_called_once()
+
     def test_no_session_key_falls_back_to_sync(self):
         """Direct Python callers (no agent session) keep the sync path."""
         res = _try_dispatch_background_run(_job('job-bg-05'))

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -1138,6 +1138,7 @@ def cronjob(
     monitor_url: Optional[str] = None,
     task_id: str = None,
     session_id: Optional[str] = None,
+    allow_background: bool = True,
 ) -> str:
     """Unified cron job management tool."""
     del task_id  # unused but kept for handler signature compatibility
@@ -1338,9 +1339,17 @@ def cronjob(
             # batches of manual runs (#80xxx — the "stuck Telegram session"
             # incident). Falls back to inline execution when the session
             # runtime can't receive detached completions.
-            bg = _try_dispatch_background_run(
-                job, session_id=session_id, extra_prompt=extra_prompt
-            )
+            #
+            # One-shot `hermes cron run` passes allow_background=False. That
+            # process exits as soon as the command returns, so a detached
+            # runner thread dies mid-job and leaves the fire claim hanging
+            # (#86721). Stay on the inline path even if a leftover
+            # HERMES_SESSION_KEY is in the environment.
+            bg = None
+            if allow_background:
+                bg = _try_dispatch_background_run(
+                    job, session_id=session_id, extra_prompt=extra_prompt
+                )
             if bg is not None and bg.get("dispatched"):
                 _notify_provider_jobs_changed_safe()
                 result = _format_job(get_job(job_id) or {"id": job_id})


### PR DESCRIPTION
## What does this PR do?

`hermes cron run` is a one shot command. The process ends as soon as the command returns.

If the shell still has a leftover Desktop or gateway session key, the run was sent to a background thread in that same process. The process then exited. The thread died. The job stayed claimed. The next `hermes cron run` failed.

This PR makes `hermes cron run` wait in the current process until the job finishes. A leftover session key cannot detach it.

Gateway and live agent `cronjob(action="run")` still use the background path. Those processes stay alive.

Before the new run, the CLI also marks leftover execution rows as unknown when their owner process is already dead.

## Related Issue

Fixes #86721

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- `tools/cronjob_tools.py`: add `allow_background` (default true). `hermes cron run` sets it false so the job runs inline.
- `hermes_cli/cron.py`: one shot `run` always passes `allow_background=False`. It also calls `recover_interrupted_executions()` first.
- `tests/tools/test_cronjob_run_background.py`: with a session key bound, `allow_background=False` still runs inline and never dispatches.
- `tests/hermes_cli/test_cron.py`: the CLI run command forces inline and reaps dead claims.

## How to Test

1. On current main, if `HERMES_SESSION_KEY` is set, `hermes cron run <id>` can return at once, leave `executions.status=claimed`, and leave a dead `async_delegations` row. The next run can fail.
2. On this branch, `hermes cron run <id>` waits until the job finishes and prints `Ran now: succeeded.` or `Ran now: failed.`
3. `python -m pytest tests/tools/test_cronjob_run_background.py tests/hermes_cli/test_cron.py -q` (28 passed on Windows 11).
4. A live gateway or Desktop `cronjob(action="run")` still returns a background handle.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the focused cron run suites and they pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior or N/A
