### PR TITLE
fix(desktop): FindBar no longer overlaps native window controls

### DIFF
--- a/apps/desktop/src/components/find-bar.tsx
+++ b/apps/desktop/src/components/find-bar.tsx
@@ -159,7 +159,13 @@ export function FindBar() {
   return (
     <div
       className={cn(
-        'pointer-events-auto fixed right-4 top-[calc(var(--titlebar-height,0px)+0.5rem)] z-50',
+        // Floats BELOW the titlebar band. The bar mounts at the overlay root,
+        // outside the app-shell subtree that defines --titlebar-height, so the
+        // fallback must be the real titlebar height (34px, matching
+        // floating-hud.ts / notifications.tsx) — a 0px fallback parks the bar
+        // inside the titlebar strip, underneath the native min/max/close
+        // window-controls overlay on Windows/Linux.
+        'pointer-events-auto fixed right-4 top-[calc(var(--titlebar-height,34px)+0.5rem)] z-50',
         'flex items-center gap-1 rounded-lg border border-(--ui-stroke-tertiary) bg-(--ui-surface-background) px-2 py-1 shadow-md'
       )}
       role="search"


### PR DESCRIPTION
## Summary
The desktop Ctrl+F/⌘F find bar now floats below the titlebar instead of rendering inside the titlebar strip underneath the native min/max/close window-controls overlay.

Root cause: `FindBar` positions itself with `top-[calc(var(--titlebar-height,0px)+0.5rem)]`, but it mounts at the overlay root in `ContribWiring` — outside any subtree that defines `--titlebar-height` (the contrib shell even zeroes it for content areas). The `0px` fallback parked the bar at the very top edge, where Windows/Linux draw the native window controls: two ✕ buttons side by side, with the bar's border clipping into the window close button.

## Changes
- `apps/desktop/src/components/find-bar.tsx`: fallback `0px` → `34px` (the real `TITLEBAR_HEIGHT`), matching the established pattern in `floating-hud.ts` and `notifications.tsx` which face the same unset-var mount point.

## Validation
| | Before | After |
|---|---|---|
| Find bar top | 0.5rem from window top edge, under native min/max/close | 34px + 0.5rem — below the titlebar band, clear of window controls |
| `find-bar.test.tsx` | 48 passed | 48 passed |
| eslint on file | clean | clean |

## Infographic

![FindBar clears the window controls](https://files.catbox.moe/ojh895.png)
