### PR TITLE
fix(desktop): pet overlay salvage — sharp HiDPI rendering, backstop, tool-failure state, quoted-false toggle, send-once spritesheet

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event.ts
@@ -925,6 +925,13 @@ export function useGatewayEventHandler(deps: GatewayEventDeps) {
 
           if (isActiveEvent) {
             setPetActivity({ toolRunning: false })
+
+            // A tool can fail without ending the turn when the agent recovers
+            // and continues. Surface that failure as a short pet beat too;
+            // otherwise only turn-level errors ever reach the failed state.
+            if (payload?.error) {
+              flashPetActivity({ error: true })
+            }
           }
 
           // A pending clarify blocks the turn, so the first tool.complete after

--- a/apps/desktop/src/app/session/hooks/use-message-stream/pet-tool-failure-event.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/pet-tool-failure-event.test.tsx
@@ -1,0 +1,94 @@
+import { QueryClient } from '@tanstack/react-query'
+import { act, cleanup, render, waitFor } from '@testing-library/react'
+import { useEffect, useRef } from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { ClientSessionState } from '@/app/types'
+import { createClientSessionState } from '@/lib/chat-runtime'
+import { $petActivity, $petState, setPetActivity } from '@/store/pet'
+import type { RpcEvent } from '@/types/hermes'
+
+import { useMessageStream } from './index'
+
+const SID = 'session-1'
+const OTHER_SID = 'session-2'
+
+let handleEvent: ((event: RpcEvent) => void) | null = null
+
+function Harness() {
+  const activeSessionIdRef = useRef<string | null>(SID)
+  const sessionStateByRuntimeIdRef = useRef(new Map<string, ClientSessionState>())
+  const queryClientRef = useRef(new QueryClient())
+
+  const stream = useMessageStream({
+    activeSessionIdRef,
+    hydrateFromStoredSession: vi.fn(async () => undefined),
+    queryClient: queryClientRef.current,
+    refreshHermesConfig: vi.fn(async () => undefined),
+    refreshSessions: vi.fn(async () => undefined),
+    sessionStateByRuntimeIdRef,
+    updateSessionState: (sessionId, updater) => {
+      const current = sessionStateByRuntimeIdRef.current.get(sessionId) ?? createClientSessionState()
+      const next = updater(current)
+      sessionStateByRuntimeIdRef.current.set(sessionId, next)
+
+      return next
+    }
+  })
+
+  useEffect(() => {
+    handleEvent = stream.handleGatewayEvent
+  }, [stream.handleGatewayEvent])
+
+  return null
+}
+
+async function mountStream() {
+  render(<Harness />)
+  await waitFor(() => expect(handleEvent).not.toBeNull())
+}
+
+function emit(type: RpcEvent['type'], payload: RpcEvent['payload'] = {}, sessionId = SID) {
+  act(() => handleEvent!({ payload, session_id: sessionId, type }))
+}
+
+describe('pet tool-failure reaction', () => {
+  beforeEach(() => {
+    handleEvent = null
+    setPetActivity({
+      busy: false,
+      awaitingInput: false,
+      toolRunning: false,
+      reasoning: false,
+      error: false,
+      justCompleted: false,
+      celebrate: false
+    })
+  })
+
+  afterEach(() => {
+    cleanup()
+    setPetActivity({ error: false, toolRunning: false })
+    vi.restoreAllMocks()
+  })
+
+  it('briefly shows failed when the active session has an isolated tool error', async () => {
+    await mountStream()
+
+    emit('tool.start', { name: 'terminal', tool_id: 'tool-1' })
+    emit('tool.complete', { name: 'terminal', tool_id: 'tool-1', error: 'exit code 1' })
+
+    expect($petActivity.get().error).toBe(true)
+    expect($petState.get()).toBe('failed')
+  })
+
+  it('does not show failed for a successful tool or a background-session failure', async () => {
+    await mountStream()
+
+    emit('tool.complete', { name: 'terminal', tool_id: 'tool-1' })
+    expect($petActivity.get().error).toBe(false)
+
+    emit('tool.complete', { name: 'terminal', tool_id: 'tool-2', error: 'exit code 1' }, OTHER_SID)
+    expect($petActivity.get().error).toBe(false)
+  })
+})

--- a/apps/desktop/src/components/pet/floating-pet-poll.test.ts
+++ b/apps/desktop/src/components/pet/floating-pet-poll.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest'
+
+import { petInfoPollIntervalMs } from './pet-info-poll'
+
+describe('petInfoPollIntervalMs', () => {
+  it('uses the slow backstop on event-capable backends (active or not)', () => {
+    expect(petInfoPollIntervalMs(true, false)).toBe(15_000)
+    expect(petInfoPollIntervalMs(true, true)).toBe(15_000)
+  })
+
+  it('keeps the legacy fast-while-inactive cadence without change events', () => {
+    expect(petInfoPollIntervalMs(false, false)).toBe(3_000)
+    expect(petInfoPollIntervalMs(false, true)).toBe(15_000)
+  })
+})

--- a/apps/desktop/src/components/pet/floating-pet.tsx
+++ b/apps/desktop/src/components/pet/floating-pet.tsx
@@ -26,6 +26,7 @@ import { $gatewayState } from '@/store/session'
 import { isSecondaryWindow } from '@/store/windows'
 import { useTheme } from '@/themes/context'
 
+import { PET_STARTUP_RETRY_MS, petInfoPollIntervalMs } from './pet-info-poll'
 import { PetSprite, roamWalkRow } from './pet-sprite'
 import { usePetRoam } from './use-pet-roam'
 import { type PetZoomAnchor, usePetZoomGesture } from './use-pet-zoom-gesture'
@@ -89,12 +90,15 @@ function loadPosition(): Point {
  * pets rewritten on disk (or renamed/rebuilt by the hatch flow) repaint without
  * restarting the app.
  *
+ * Event-capable backends also drive refreshes via `pet.changed`, but a slow
+ * backstop poll stays in place: the watcher seeds the pet signature silently
+ * at gateway boot and only broadcasts when it *moves*, and the one-shot
+ * connect pull can race a still-warming `pet.info` (fail-open enabled:false).
+ * Without the backstop the mascot stays hidden until Settings re-seeds it.
+ *
  * Promotion to a separate frameless OS-level window is a follow-up — the
  * sprite + state logic here is reused as-is, only the host changes.
  */
-const PET_POLL_MS = 3000
-const PET_ACTIVE_REFRESH_MS = 15000
-
 export function FloatingPet() {
   const { requestGateway } = useGatewayRequest()
   const { resolvedMode } = useTheme()
@@ -129,11 +133,9 @@ export function FloatingPet() {
   // edge can't leave the window cropping it. Shared by drag + the reclamp effect.
   const clamp = useCallback(({ x, y }: Point): Point => clampPoint(x, y, petW, petH), [petW, petH])
 
-  // Fetch pet.info on connect, then let pet.changed drive refreshes: the
-  // change watcher broadcasts when /pet (de)activates a pet or the hatch flow
-  // rewrites a sheet, so event-capable backends need no interval at all —
-  // users with no pet especially (this used to poll hardest for them). Older
-  // backends keep the legacy fast-while-inactive poll.
+  // Fetch pet.info on connect. pet.changed re-runs this effect when the
+  // signature moves; a slow backstop covers silent seed + cold-start races.
+  // Older backends (no change_events) keep the legacy fast-while-inactive poll.
   const active = info.enabled && Boolean(info.spritesheetBase64)
   useEffect(() => {
     if (gatewayState !== 'open') {
@@ -208,29 +210,50 @@ export function FloatingPet() {
       }
     }
 
+    const pullIfVisible = () => {
+      if (document.visibilityState === 'visible') {
+        void pull()
+      }
+    }
+
     void pull()
     window.addEventListener('focus', pull)
 
-    // Event-capable backend: pet.changed re-runs this effect (petChange dep),
-    // so no timer. Legacy backend: the historical poll.
-    const timer = changeEventsAvailable
-      ? null
-      : window.setInterval(
-          () => {
-            if (document.visibilityState === 'visible') {
-              void pull()
-            }
-          },
-          active ? PET_ACTIVE_REFRESH_MS : PET_POLL_MS
-        )
+    // Cover the cold-start race where the first pull hit fail-open enabled:false
+    // before the pet store was warm. Skip further retries once the mascot is live.
+    const startupRetryTimers = PET_STARTUP_RETRY_MS.map(delay =>
+      window.setTimeout(() => {
+        if (cancelled) {
+          return
+        }
+
+        const current = $petInfo.get()
+
+        if (current.enabled && current.spritesheetBase64) {
+          return
+        }
+
+        pullIfVisible()
+      }, delay)
+    )
+
+    // Always keep a timer. Event-capable backends use the slow backstop (same
+    // contract as cron/sessions in use-background-sync); legacy keeps the
+    // historical fast-while-inactive cadence.
+    const timer = window.setInterval(
+      pullIfVisible,
+      petInfoPollIntervalMs(changeEventsAvailable, active)
+    )
 
     return () => {
       cancelled = true
       window.removeEventListener('focus', pull)
 
-      if (timer !== null) {
-        window.clearInterval(timer)
+      for (const id of startupRetryTimers) {
+        window.clearTimeout(id)
       }
+
+      window.clearInterval(timer)
     }
   }, [gatewayState, active, changeEventsAvailable, petChange, requestGateway])
 

--- a/apps/desktop/src/components/pet/floating-pet.tsx
+++ b/apps/desktop/src/components/pet/floating-pet.tsx
@@ -186,10 +186,23 @@ export function FloatingPet() {
           }
         }
 
-        const next = await requestGateway<PetInfo>('pet.info', { profile: petProfile() })
+        // Send-once semantics (#54730): tell the gateway which spritesheet
+        // revision we already hold so an unchanged multi-MB sheet is not
+        // re-sent over the WebSocket on every backstop refresh.
+        const held = $petInfo.get()
+        const knownRevision = held.enabled && held.spritesheetBase64 ? held.spritesheetRevision : undefined
+        const next = await requestGateway<PetInfo & { spritesheetUnchanged?: boolean }>('pet.info', {
+          knownRevision,
+          profile: petProfile()
+        })
 
         if (!cancelled && next) {
           const current = $petInfo.get()
+
+          if (next.enabled && next.spritesheetUnchanged && !next.spritesheetBase64) {
+            // Gateway confirmed our held sheet is current; keep the bytes.
+            next.spritesheetBase64 = current.spritesheetBase64
+          }
 
           if (
             next.enabled &&

--- a/apps/desktop/src/components/pet/pet-info-poll.ts
+++ b/apps/desktop/src/components/pet/pet-info-poll.ts
@@ -1,0 +1,25 @@
+/** Cadences for the floating-pet `pet.info` refresh timer.
+
+Event-capable backends rely on `pet.changed` for live updates but still need
+a slow backstop: the gateway seeds the pet signature silently at boot and only
+broadcasts when it *moves*, and the one-shot connect pull can race a still-
+warming backend (`pet.info` fail-opens to `enabled:false`).
+*/
+
+export const PET_POLL_MS = 3_000
+export const PET_ACTIVE_REFRESH_MS = 15_000
+/** Slow safety net when `pet.changed` is available. */
+export const PET_BACKSTOP_MS = 15_000
+/** Cold-start retries after the first connect pull (fail-open recovery). */
+export const PET_STARTUP_RETRY_MS = [1_000, 3_000, 8_000] as const
+
+export function petInfoPollIntervalMs(
+  changeEventsAvailable: boolean,
+  active: boolean
+): number {
+  if (changeEventsAvailable) {
+    return PET_BACKSTOP_MS
+  }
+
+  return active ? PET_ACTIVE_REFRESH_MS : PET_POLL_MS
+}

--- a/apps/desktop/src/components/pet/pet-sprite.test.tsx
+++ b/apps/desktop/src/components/pet/pet-sprite.test.tsx
@@ -246,7 +246,27 @@ describe('PetSprite RAF scheduling', () => {
     render(<PetSprite info={INFO} pauseWhenUnfocused={false} />)
 
     act(() => window.dispatchEvent(new Event('blur')))
-
     expect(raf.pending()).toBe(1)
+  })
+
+  it('draws sprite frames with bicubic smoothing for illustration art', () => {
+    const raf = installRaf()
+    const ctxMock = {
+      clearRect: vi.fn(),
+      drawImage: vi.fn(),
+      imageSmoothingEnabled: false,
+      imageSmoothingQuality: 'low'
+    } as unknown as CanvasRenderingContext2D
+    vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue(ctxMock)
+
+    render(<PetSprite info={INFO} />)
+    act(() => raf.runNext(0))
+
+    // Petdex sheets are illustration frames, not pixel art — nearest-neighbour
+    // (the old default) makes zoomed pets look blocky. The renderer must opt
+    // into bicubic smoothing before the first draw.
+    expect(ctxMock.imageSmoothingEnabled).toBe(true)
+    expect(ctxMock.imageSmoothingQuality).toBe('high')
+    expect(ctxMock.drawImage).toHaveBeenCalledTimes(1)
   })
 })

--- a/apps/desktop/src/components/pet/pet-sprite.test.tsx
+++ b/apps/desktop/src/components/pet/pet-sprite.test.tsx
@@ -35,6 +35,7 @@ const INFO = {
 let root: Root | null = null
 let container: HTMLDivElement | null = null
 let windowStateCallback: ((payload: { isMinimized?: boolean; isVisible?: boolean }) => void) | null = null
+let drawImage: ReturnType<typeof vi.fn>
 
 function render(ui: ReactNode) {
   container = document.createElement('div')
@@ -122,6 +123,7 @@ describe('PetSprite RAF scheduling', () => {
     ;(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
     vi.useFakeTimers()
     setVisibility(false)
+    Object.defineProperty(window, 'devicePixelRatio', { configurable: true, value: 1 })
     vi.spyOn(document, 'hasFocus').mockReturnValue(true)
     installWindowStateBridge()
     vi.stubGlobal(
@@ -132,9 +134,10 @@ describe('PetSprite RAF scheduling', () => {
         src = ''
       } as unknown as typeof Image
     )
+    drawImage = vi.fn()
     vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue({
       clearRect: vi.fn(),
-      drawImage: vi.fn(),
+      drawImage,
       imageSmoothingEnabled: false
     } as unknown as CanvasRenderingContext2D)
   })
@@ -168,6 +171,27 @@ describe('PetSprite RAF scheduling', () => {
     })
 
     expect(raf.request).toHaveBeenCalledTimes(2)
+  })
+
+  it('uses a DPR-sized backing store while preserving the CSS footprint', () => {
+    Object.defineProperty(window, 'devicePixelRatio', { configurable: true, value: 2 })
+    const raf = installRaf()
+
+    render(<PetSprite info={INFO} />)
+
+    const canvas = container?.querySelector('canvas')
+
+    expect(canvas).not.toBeNull()
+    expect(canvas?.width).toBe(32)
+    expect(canvas?.height).toBe(32)
+    expect(canvas?.style.width).toBe('16px')
+    expect(canvas?.style.height).toBe('16px')
+
+    act(() => {
+      raf.runNext(0)
+    })
+
+    expect(drawImage).toHaveBeenCalledWith(expect.anything(), 0, 0, 16, 16, 0, 0, 32, 32)
   })
 
   it('cancels pending RAF work while the Electron window is paused and resumes when visible', () => {

--- a/apps/desktop/src/components/pet/pet-sprite.tsx
+++ b/apps/desktop/src/components/pet/pet-sprite.tsx
@@ -369,7 +369,10 @@ function PetSpriteImpl({ info, zoom = 1, stateOverride, rowOverride, pauseWhenUn
         const sx = frame * frameW
         const sy = row * frameH
         ctx.clearRect(0, 0, canvas.width, canvas.height)
-        ctx.imageSmoothingEnabled = false
+        // Smooth (bicubic) upscale: petdex sheets are illustration art, not
+        // pixel art — nearest-neighbour makes zoomed frames look blocky.
+        ctx.imageSmoothingEnabled = true
+        ctx.imageSmoothingQuality = 'high'
         ctx.drawImage(image, sx, sy, frameW, frameH, 0, 0, backingW, backingH)
         drawnFrame = frame
         drawnRow = row

--- a/apps/desktop/src/components/pet/pet-sprite.tsx
+++ b/apps/desktop/src/components/pet/pet-sprite.tsx
@@ -1,4 +1,4 @@
-import { memo, useEffect, useMemo, useRef } from 'react'
+import { memo, useEffect, useMemo, useRef, useState } from 'react'
 
 import { createRendererLoopPauseController } from '@/lib/renderer-loop-pause'
 import { $petState, type PetInfo, type PetState } from '@/store/pet'
@@ -10,6 +10,47 @@ const DEFAULT_LOOP_MS = 1100
 // Mirrors agent.pet.constants.DEFAULT_SCALE — fallback only; the gateway sends
 // the configured scale.
 const DEFAULT_SCALE = 0.33
+
+function readDevicePixelRatio(): number {
+  const ratio = window.devicePixelRatio
+
+  return Number.isFinite(ratio) && ratio > 0 ? ratio : 1
+}
+
+/**
+ * Track the effective renderer pixel ratio. Electron page zoom and moving a
+ * window between displays can both change it without remounting the pet.
+ */
+function useDevicePixelRatio(): number {
+  const [ratio, setRatio] = useState(readDevicePixelRatio)
+
+  useEffect(() => {
+    let resolutionQuery: MediaQueryList | null = null
+
+    const update = () => {
+      resolutionQuery?.removeEventListener('change', update)
+
+      const next = readDevicePixelRatio()
+
+      setRatio(current => (current === next ? current : next))
+
+      resolutionQuery = typeof window.matchMedia === 'function' ? window.matchMedia(`(resolution: ${next}dppx)`) : null
+      resolutionQuery?.addEventListener('change', update)
+    }
+
+    window.addEventListener('resize', update)
+    window.visualViewport?.addEventListener('resize', update)
+    update()
+
+    return () => {
+      resolutionQuery?.removeEventListener('change', update)
+      window.removeEventListener('resize', update)
+      window.visualViewport?.removeEventListener('resize', update)
+    }
+  }, [])
+
+  return ratio
+}
 
 // Mirrors agent.pet.constants.CODEX_STATE_ROWS (Petdex current taxonomy).
 export const DEFAULT_STATE_ROWS = [
@@ -145,9 +186,12 @@ function PetSpriteImpl({ info, zoom = 1, stateOverride, rowOverride, pauseWhenUn
   const loopMs = info.loopMs ?? DEFAULT_LOOP_MS
   const scale = (info.scale ?? DEFAULT_SCALE) * zoom
   const rows = info.stateRows ?? DEFAULT_STATE_ROWS
+  const pixelRatio = useDevicePixelRatio()
 
   const drawW = Math.round(frameW * scale)
   const drawH = Math.round(frameH * scale)
+  const backingW = Math.max(1, Math.round(drawW * pixelRatio))
+  const backingH = Math.max(1, Math.round(drawH * pixelRatio))
 
   const image = useMemo(() => {
     if (!info.spritesheetBase64) {
@@ -326,7 +370,7 @@ function PetSpriteImpl({ info, zoom = 1, stateOverride, rowOverride, pauseWhenUn
         const sy = row * frameH
         ctx.clearRect(0, 0, canvas.width, canvas.height)
         ctx.imageSmoothingEnabled = false
-        ctx.drawImage(image, sx, sy, frameW, frameH, 0, 0, drawW, drawH)
+        ctx.drawImage(image, sx, sy, frameW, frameH, 0, 0, backingW, backingH)
         drawnFrame = frame
         drawnRow = row
       }
@@ -353,15 +397,15 @@ function PetSpriteImpl({ info, zoom = 1, stateOverride, rowOverride, pauseWhenUn
       pauseController?.dispose()
       unsubState()
     }
-  }, [image, frameW, frameH, frames, framesByState, framesByRow, loopMs, drawW, drawH, rows, pauseWhenUnfocused])
+  }, [image, frameW, frameH, frames, framesByState, framesByRow, loopMs, backingW, backingH, rows, pauseWhenUnfocused])
 
   return (
     <canvas
       aria-label={info.displayName ? `${info.displayName} pet` : 'pet'}
-      height={drawH}
+      height={backingH}
       ref={canvasRef}
       style={{ height: drawH, width: drawW }}
-      width={drawW}
+      width={backingW}
     />
   )
 }

--- a/cli.py
+++ b/cli.py
@@ -6115,7 +6115,9 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             display = cfg.get("display", {}) if isinstance(cfg.get("display"), dict) else {}
             pet_cfg = display.get("pet", {}) if isinstance(display.get("pet"), dict) else {}
 
-            enabled = bool(pet_cfg.get("enabled"))
+            from utils import is_truthy_value
+
+            enabled = is_truthy_value(pet_cfg.get("enabled"), default=False)
             slug = str(pet_cfg.get("slug", "") or "")
             scale = float(pet_cfg.get("scale", constants.DEFAULT_SCALE) or constants.DEFAULT_SCALE)
             cols = constants.resolve_cols(scale, pet_cfg.get("unicode_cols", 0))

--- a/contributors/emails/lavinia.beghini@genialcare.com.br
+++ b/contributors/emails/lavinia.beghini@genialcare.com.br
@@ -1,0 +1,1 @@
+LBeghini

--- a/hermes_cli/pets.py
+++ b/hermes_cli/pets.py
@@ -13,6 +13,8 @@ from __future__ import annotations
 import argparse
 import sys
 
+from utils import is_truthy_value
+
 
 def _print(msg: str = "") -> None:
     print(msg)
@@ -249,7 +251,7 @@ def _cmd_doctor(args) -> int:
     from agent.pet.render import detect_terminal_graphics, resolve_mode
 
     cfg = _pet_config()
-    enabled = bool(cfg.get("enabled"))
+    enabled = is_truthy_value(cfg.get("enabled"), default=False)
     configured_slug = str(cfg.get("slug", "") or "")
     mode_cfg = str(cfg.get("render_mode", "auto") or "auto")
 
@@ -300,7 +302,9 @@ def _pet_config() -> dict:
 
 
 def _has_active_pet() -> bool:
-    return bool(_pet_config().get("enabled")) and bool(_pet_config().get("slug"))
+    return is_truthy_value(_pet_config().get("enabled"), default=False) and bool(
+        _pet_config().get("slug")
+    )
 
 
 def _set_active(slug: str) -> None:
@@ -364,7 +368,7 @@ def toggle_pet_display() -> tuple[bool, str | None, str | None]:
     slug = str(cfg.get("slug", "") or "")
     pet = store.resolve_active_pet(slug)
 
-    if bool(cfg.get("enabled")):
+    if is_truthy_value(cfg.get("enabled"), default=False):
         _set_enabled(False)
         return False, pet.display_name if pet else None, None
 

--- a/tests/hermes_cli/test_pet_toggle.py
+++ b/tests/hermes_cli/test_pet_toggle.py
@@ -50,6 +50,35 @@ def test_toggle_pet_display_errors_with_no_installed_pets(tmp_path, monkeypatch)
     assert err is not None
 
 
+def test_pets_cli_quoted_false_disables_and_toggle_enables(tmp_path, monkeypatch):
+    """Quoted `display.pet.enabled: "false"` must read as disabled.
+
+    bool('false') is True — before the is_truthy_value fix, _has_active_pet
+    reported an active pet and /pet toggle DISABLED instead of enabling.
+    """
+    import yaml
+
+    from hermes_cli.pets import _has_active_pet, toggle_pet_display
+
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    (home / "config.yaml").write_text(
+        yaml.safe_dump(
+            {"display": {"pet": {"enabled": "false", "slug": "", "scale": 0.33}}}
+        ),
+        encoding="utf-8",
+    )
+
+    assert _has_active_pet() is False
+    # Toggle must take the ENABLE branch (reaching the "no pets installed"
+    # error), not the disable branch (which would return err=None).
+    enabled, name, err = toggle_pet_display()
+    assert err is not None and "no pets installed" in err
+    assert enabled is False
+    assert name is None
+
+
 @pytest.fixture
 def empty_home(tmp_path, monkeypatch):
     home = tmp_path / ".hermes"

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -6778,6 +6778,27 @@ def test_config_set_approval_mode_persists_three_way_value_and_emits_live_status
     assert emitted[0][2]["approval_mode"] == "manual"
 
 
+def test_pet_gallery_quoted_false_enabled_reports_disabled(tmp_path, monkeypatch):
+    """display.pet.enabled: "false" (quoted) must report enabled=False.
+
+    The old check was bool(value) — bool('false') is True, so a hand-edited
+    quoted YAML value kept the petdex mascot enabled against the operator's
+    explicit intent.
+    """
+    import yaml
+
+    monkeypatch.setattr(server, "_hermes_home", tmp_path)
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    (tmp_path / "config.yaml").write_text(
+        yaml.safe_dump({"display": {"pet": {"enabled": "false"}}})
+    )
+
+    response = server.handle_request(
+        {"id": "1", "method": "pet.gallery", "params": {}}
+    )
+    assert response["result"]["enabled"] is False
+
+
 def test_desktop_contract_includes_approval_mode_rpc():
     assert server.DESKTOP_BACKEND_CONTRACT >= 3
 

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -6799,6 +6799,55 @@ def test_pet_gallery_quoted_false_enabled_reports_disabled(tmp_path, monkeypatch
     assert response["result"]["enabled"] is False
 
 
+def test_pet_info_known_revision_elides_spritesheet(monkeypatch):
+    """pet.info with a matching knownRevision must not resend the sheet bytes.
+
+    The spritesheet payload is multi-MB; resending it on every backstop
+    refresh stalls the WS write loop (#54730). A caller passing the revision
+    it already holds gets metadata plus spritesheetUnchanged instead.
+    """
+
+    class _FakePet:
+        slug = "codex"
+        display_name = "Codex"
+        exists = True
+        spritesheet = None
+
+    payload = {
+        "slug": "codex",
+        "displayName": "Codex",
+        "mime": "image/png",
+        "spritesheetBase64": "A" * 1024,
+        "spritesheetRevision": "123:456",
+        "frameW": 192,
+        "frameH": 208,
+        "scale": 0.33,
+    }
+
+    monkeypatch.setattr(server, "_pet_active_selection", lambda: (True, _FakePet(), 0.33))
+    monkeypatch.setattr(server, "_pet_sprite_payload", lambda pet, *, scale: dict(payload))
+
+    # Matching revision: bytes elided, unchanged marker set.
+    resp = server.handle_request(
+        {"id": "1", "method": "pet.info", "params": {"knownRevision": "123:456"}}
+    )
+    assert resp["result"]["enabled"] is True
+    assert "spritesheetBase64" not in resp["result"]
+    assert resp["result"]["spritesheetUnchanged"] is True
+    assert resp["result"]["spritesheetRevision"] == "123:456"
+
+    # Stale revision: full payload still flows.
+    resp = server.handle_request(
+        {"id": "2", "method": "pet.info", "params": {"knownRevision": "999:999"}}
+    )
+    assert resp["result"]["spritesheetBase64"] == "A" * 1024
+    assert "spritesheetUnchanged" not in resp["result"]
+
+    # No revision (legacy callers): full payload.
+    resp = server.handle_request({"id": "3", "method": "pet.info", "params": {}})
+    assert resp["result"]["spritesheetBase64"] == "A" * 1024
+
+
 def test_desktop_contract_includes_approval_mode_rpc():
     assert server.DESKTOP_BACKEND_CONTRACT >= 3
 

--- a/tui_gateway/methods_session.py
+++ b/tui_gateway/methods_session.py
@@ -1484,7 +1484,7 @@ def _(rid, params: dict) -> dict:
         except Exception:
             pet_cfg = {}
 
-        if not bool(pet_cfg.get("enabled")):
+        if not is_truthy_value(pet_cfg.get("enabled"), default=False):
             return _ok(rid, {"enabled": False})
 
         pet = store.resolve_active_pet(str(pet_cfg.get("slug", "") or ""))
@@ -1637,7 +1637,7 @@ def _(rid, params: dict) -> dict:
         return _ok(
             rid,
             {
-                "enabled": bool(pet_cfg.get("enabled")),
+                "enabled": is_truthy_value(pet_cfg.get("enabled"), default=False),
                 "active": str(pet_cfg.get("slug", "") or ""),
                 "pets": gallery,
             },

--- a/tui_gateway/methods_session.py
+++ b/tui_gateway/methods_session.py
@@ -1430,7 +1430,17 @@ def _(rid, params: dict) -> dict:
         if not enabled or pet is None or not pet.exists:
             return _ok(rid, {"enabled": False})
 
-        return _ok(rid, {"enabled": True, **_pet_sprite_payload(pet, scale=scale)})
+        payload = {"enabled": True, **_pet_sprite_payload(pet, scale=scale)}
+
+        # Send-once semantics for the multi-MB spritesheet (#54730): a caller
+        # that already holds the sheet passes the revision it has, and an
+        # unchanged sheet comes back as metadata only (spritesheetUnchanged).
+        known_revision = str(params.get("knownRevision", "") or "")
+        if known_revision and known_revision == payload.get("spritesheetRevision"):
+            payload.pop("spritesheetBase64", None)
+            payload["spritesheetUnchanged"] = True
+
+        return _ok(rid, payload)
     except Exception as exc:  # noqa: BLE001 - cosmetic, never break the surface
         logger.debug("pet.info failed: %s", exc)
         return _ok(rid, {"enabled": False})

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -3554,7 +3554,7 @@ def _pet_sig() -> tuple:
     hatch flow rebuilds a sheet, or the scale changes."""
     display = _load_cfg().get("display") or {}
     pet_cfg = display.get("pet") if isinstance(display.get("pet"), dict) else {}
-    if not pet_cfg or not pet_cfg.get("enabled"):
+    if not pet_cfg or not is_truthy_value(pet_cfg.get("enabled"), default=False):
         return ("off",)
     try:
         enabled, pet, scale = _pet_active_selection()

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -8729,7 +8729,7 @@ def _pet_active_selection():
     except Exception:
         pet_cfg = {}
 
-    enabled = bool(pet_cfg.get("enabled"))
+    enabled = is_truthy_value(pet_cfg.get("enabled"), default=False)
     configured_slug = str(pet_cfg.get("slug", "") or "")
     pet = store.resolve_active_pet(configured_slug) if enabled else None
     scale = float(pet_cfg.get("scale", constants.DEFAULT_SCALE) or constants.DEFAULT_SCALE)


### PR DESCRIPTION
Salvages the pet-overlay contributor cluster into one green branch: sharp HiDPI + smooth-scaled sprite rendering, restored `pet.info` backstop, tool-failure pet reactions, quoted-`'false'` config handling on every surface, and send-once spritesheet semantics that stop the 3.2MB WS resend storms.

## Changes

- **Sharp HiDPI rendering** (from #75307, @NorethSea — earliest of the rendering pair): the pet canvas backing store is now sized by `devicePixelRatio` (tracked live across zoom/display changes) while the CSS footprint stays constant. Cherry-picked as the rendering-fix subset only — the overlay-placement/settings feature portion of #75307 is intentionally not carried here. Covers the DPR half of #83216.
- **Bicubic smooth scaling** (from #84156, @fanfan343): petdex sheets are 192×208 illustration frames, not pixel art — `imageSmoothingEnabled=true` + `imageSmoothingQuality='high'` replaces nearest-neighbour, composed on top of the DPR backing store. Covers the smoothing half of #83216.
- **`pet.info` backstop restored** (#81635, @Adolanium): event-capable backends keep a slow backstop poll plus short cold-start retries, so a fail-open `enabled:false` during backend warm-up no longer hides the mascot until Settings re-seeds it.
- **Tool failures surface in pet state** (#81908, @LBeghini): `tool.complete` events carrying `error` reuse the existing transient error beat, scoped to the active session. Fixes #81907.
- **Quoted `'false'` disables the pet everywhere** (#81357, @thatssoheil): all eight `display.pet.enabled` read sites (TUI gateway, CLI pane, status line, pets CLI, `/pet` toggle) go through `utils.is_truthy_value`, so a hand-edited `enabled: "false"` actually disables the mascot.
- **Send-once spritesheet semantics** (#54730 follow-up, ~40 LOC): `pet.info` accepts `knownRevision`; when it matches the active sheet the multi-MB `spritesheetBase64` is elided and `spritesheetUnchanged: true` returned. The desktop passes the revision it holds and keeps its cached bytes. Legacy callers omitting the param get the full payload unchanged.

## Validation

| Check | Result |
| --- | --- |
| `pytest tests/test_tui_gateway_server.py tests/hermes_cli/test_pet_toggle.py` | 574 passed |
| `vitest run pet-sprite.test.tsx floating-pet-poll.test.ts pet-tool-failure-event.test.tsx` | 10 passed |
| `npx tsc --noEmit` (apps/desktop) | clean |
| `scripts/audit_pr_attribution.py --fix` | all emails mapped |

## Credits

- @NorethSea — DPR backing-store rendering fix (#75307)
- @fanfan343 — bicubic smoothing (#84156)
- @Adolanium — pet.info backstop (#81635)
- @LBeghini — tool-failure pet state (#81908)
- @thatssoheil — quoted-'false' truthiness fixes (#81357)

## Issues

- Fixes #81907 (pet ignores isolated tool failures)
- Fixes #83216 (blurry pet on Retina — DPR + smoothing both land here)
- Addresses the pet.info payload path of #54730 (send-once spritesheet); broadcast-side behavior for other WS consumers is unchanged, so leaving the issue for the reporter to confirm before closing.

## Infographic

![Desktop Pet Overlay — Salvage Pack](https://files.catbox.moe/q5ygcz.png)
