### PR TITLE
perf(desktop/dashboard): salvage idle & polling CPU fixes — unfocused UI pause, sidebar scan bounds, pet poll, PTY back-off, kanban WS zombie reap

### DIFF
--- a/apps/desktop/src/app/contrib/hooks/use-background-sync.test.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-background-sync.test.ts
@@ -17,7 +17,8 @@ import {
   reconcileActiveTranscript,
   rehydrateLiveSessionStatuses,
   resolveActiveTranscriptSession,
-  useBackgroundSync
+  useBackgroundSync,
+  windowIsActivelyViewed
 } from './use-background-sync'
 
 vi.mock('@/hermes', async importOriginal => ({
@@ -302,6 +303,14 @@ describe('reconcileActiveTranscript', () => {
     await request
 
     expect(fixture.updateSessionState).not.toHaveBeenCalled()
+  })
+})
+
+describe('windowIsActivelyViewed', () => {
+  it('requires both DOM visibility and keyboard focus', () => {
+    expect(windowIsActivelyViewed({ focused: true, visibilityState: 'visible' })).toBe(true)
+    expect(windowIsActivelyViewed({ focused: false, visibilityState: 'visible' })).toBe(false)
+    expect(windowIsActivelyViewed({ focused: true, visibilityState: 'hidden' })).toBe(false)
   })
 })
 

--- a/apps/desktop/src/app/contrib/hooks/use-background-sync.test.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-background-sync.test.ts
@@ -113,6 +113,12 @@ function renderSync(
   )
 }
 
+beforeEach(() => {
+  // visiblePoll only ticks while the window is actively viewed; jsdom's
+  // document.hasFocus() is not reliably true, so pin it for these tests.
+  vi.spyOn(document, 'hasFocus').mockReturnValue(true)
+})
+
 afterEach(() => {
   cleanup()
   vi.clearAllTimers()
@@ -124,6 +130,7 @@ afterEach(() => {
   setMessagingSessions([])
   setBusy(false)
   vi.clearAllMocks()
+  vi.restoreAllMocks()
   clearAllSessionStates()
 })
 

--- a/apps/desktop/src/app/contrib/hooks/use-background-sync.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-background-sync.ts
@@ -296,9 +296,24 @@ interface BackgroundSyncParams {
  *  safety-net refreshes, not the live path, so they're the right thing to slow
  *  when the machine is spending its charge. Returns nothing — meant to live
  *  inside an effect. */
+export function windowIsActivelyViewed({
+  focused,
+  visibilityState
+}: {
+  focused: boolean
+  visibilityState: DocumentVisibilityState
+}): boolean {
+  return visibilityState === 'visible' && focused
+}
+
 function visiblePoll(intervalMs: number, tick: () => void): () => void {
   const run = () => {
-    if (document.visibilityState === 'visible') {
+    // On macOS an unfocused or app-hidden BrowserWindow commonly remains
+    // `visibilityState === "visible"`. Visibility alone therefore kept every
+    // safety-net gateway poll alive while the user was in another app. These
+    // are stale-data backstops, not the live event path, so pause them until
+    // the window is actually being viewed and catch up immediately on focus.
+    if (windowIsActivelyViewed({ focused: document.hasFocus(), visibilityState: document.visibilityState })) {
       tick()
     }
   }
@@ -311,11 +326,13 @@ function visiblePoll(intervalMs: number, tick: () => void): () => void {
   })
 
   document.addEventListener('visibilitychange', run)
+  window.addEventListener('focus', run)
 
   return () => {
     unsubscribeBattery()
     window.clearInterval(intervalId)
     document.removeEventListener('visibilitychange', run)
+    window.removeEventListener('focus', run)
   }
 }
 

--- a/apps/desktop/src/app/shell/hooks/use-status-snapshot.test.ts
+++ b/apps/desktop/src/app/shell/hooks/use-status-snapshot.test.ts
@@ -31,6 +31,7 @@ async function flushAsync() {
 
 beforeEach(() => {
   vi.useFakeTimers()
+  vi.spyOn(document, 'hasFocus').mockReturnValue(true)
   vi.mocked(getStatus)
     .mockReset()
     .mockResolvedValue({} as never)
@@ -38,10 +39,34 @@ beforeEach(() => {
 
 afterEach(() => {
   cleanup()
+  vi.restoreAllMocks()
   vi.useRealTimers()
 })
 
 describe('useStatusSnapshot', () => {
+  it('pauses status RPCs while visible but unfocused, then catches up on focus', async () => {
+    vi.mocked(document.hasFocus).mockReturnValue(false)
+    const requestGateway = vi.fn().mockResolvedValue({}) as unknown as GatewayRequester
+
+    renderHook(() => useStatusSnapshot('open', requestGateway))
+    await flushAsync()
+
+    expect(getStatus).not.toHaveBeenCalled()
+    expect(requestGateway).not.toHaveBeenCalled()
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(60_000)
+    })
+    expect(getStatus).not.toHaveBeenCalled()
+
+    vi.mocked(document.hasFocus).mockReturnValue(true)
+    window.dispatchEvent(new Event('focus'))
+    await flushAsync()
+
+    expect(getStatus).toHaveBeenCalledOnce()
+    expect(requestGateway).toHaveBeenCalledTimes(2)
+  })
+
   it('keeps the last authoritative readiness through a transient RPC failure', async () => {
     let refresh = 0
 

--- a/apps/desktop/src/app/shell/hooks/use-status-snapshot.ts
+++ b/apps/desktop/src/app/shell/hooks/use-status-snapshot.ts
@@ -5,9 +5,8 @@ import { evaluateRuntimeReadiness, type RuntimeReadinessResult } from '@/lib/run
 import type { StatusResponse } from '@/types/hermes'
 
 // Statusbar health is ambient chrome, not live data — nothing the user acts on
-// within seconds. 60s + a hidden-tab skip keeps it honest at a quarter of the
-// old traffic; the visibility listener refreshes immediately on return so a
-// backgrounded window never shows stale health after re-focus.
+// within seconds. 60s + an actively-viewed check keeps traffic low; focus and
+// visibility listeners refresh immediately on return.
 const REFRESH_MS = 60_000
 
 type GatewayRequester = <T = unknown>(method: string, params?: Record<string, unknown>) => Promise<T>
@@ -34,9 +33,10 @@ export function useStatusSnapshot(gatewayState: string | undefined, requestGatew
     }
 
     const refresh = async () => {
-      // Hidden window: skip the round-trips, keep the timer alive; the
-      // visibilitychange listener repaints immediately on return.
-      if (document.visibilityState !== 'visible') {
+      // macOS commonly leaves an occluded BrowserWindow `visible`; focus is
+      // the missing signal that prevents status + readiness RPCs while the
+      // user is working in another app.
+      if (document.visibilityState !== 'visible' || !document.hasFocus()) {
         scheduleRefresh()
 
         return
@@ -79,8 +79,8 @@ export function useStatusSnapshot(gatewayState: string | undefined, requestGatew
       }
     }
 
-    const onVisible = () => {
-      if (document.visibilityState === 'visible' && !cancelled) {
+    const onReturn = () => {
+      if (document.visibilityState === 'visible' && document.hasFocus() && !cancelled) {
         if (timer !== undefined) {
           window.clearTimeout(timer)
         }
@@ -89,12 +89,14 @@ export function useStatusSnapshot(gatewayState: string | undefined, requestGatew
       }
     }
 
-    document.addEventListener('visibilitychange', onVisible)
+    document.addEventListener('visibilitychange', onReturn)
+    window.addEventListener('focus', onReturn)
     void refresh()
 
     return () => {
       cancelled = true
-      document.removeEventListener('visibilitychange', onVisible)
+      document.removeEventListener('visibilitychange', onReturn)
+      window.removeEventListener('focus', onReturn)
 
       if (timer !== undefined) {
         window.clearTimeout(timer)

--- a/apps/desktop/src/components/assistant-ui/thread/status.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/status.test.tsx
@@ -19,6 +19,10 @@ describe('ResponseLoadingIndicator timer', () => {
   beforeEach(() => {
     vi.useFakeTimers()
     vi.setSystemTime(new Date('2026-01-01T00:00:00.000Z'))
+    // useViewedInterval gates ticking on document focus + visibility; jsdom's
+    // hasFocus() is unreliable across runners, so pin it (same as the
+    // background-sync backstop tests).
+    vi.spyOn(document, 'hasFocus').mockReturnValue(true)
     __resetElapsedTimerRegistryForTests()
   })
 
@@ -27,6 +31,7 @@ describe('ResponseLoadingIndicator timer', () => {
     $activeSessionId.set(null)
     $turnStartedAt.set(null)
     __resetElapsedTimerRegistryForTests()
+    vi.restoreAllMocks()
     vi.useRealTimers()
   })
 

--- a/apps/desktop/src/components/chat/activity-timer.test.tsx
+++ b/apps/desktop/src/components/chat/activity-timer.test.tsx
@@ -19,10 +19,12 @@ describe('useElapsedSeconds', () => {
   beforeEach(() => {
     vi.useFakeTimers()
     vi.setSystemTime(new Date('2026-01-01T00:00:00.000Z'))
+    vi.spyOn(document, 'hasFocus').mockReturnValue(true)
     __resetElapsedTimerRegistryForTests()
   })
 
   afterEach(() => {
+    vi.restoreAllMocks()
     vi.useRealTimers()
     __resetElapsedTimerRegistryForTests()
   })
@@ -72,16 +74,33 @@ describe('useElapsedSeconds', () => {
 
     expect(screen.getByTestId('elapsed').textContent).toBe('0')
   })
+
+  it('pauses UI ticks without focus and catches up immediately on return', () => {
+    render(<Probe active timerKey="tool:background" />)
+    vi.mocked(document.hasFocus).mockReturnValue(false)
+    window.dispatchEvent(new Event('blur'))
+
+    act(() => {
+      vi.advanceTimersByTime(5_000)
+    })
+    expect(screen.getByTestId('elapsed').textContent).toBe('0')
+
+    vi.mocked(document.hasFocus).mockReturnValue(true)
+    act(() => window.dispatchEvent(new Event('focus')))
+    expect(screen.getByTestId('elapsed').textContent).toBe('5')
+  })
 })
 
 describe('useMeasuredDuration', () => {
   beforeEach(() => {
     vi.useFakeTimers()
     vi.setSystemTime(new Date('2026-01-01T00:00:00.000Z'))
+    vi.spyOn(document, 'hasFocus').mockReturnValue(true)
     __resetElapsedTimerRegistryForTests()
   })
 
   afterEach(() => {
+    vi.restoreAllMocks()
     vi.useRealTimers()
     __resetElapsedTimerRegistryForTests()
   })
@@ -152,5 +171,18 @@ describe('useMeasuredDuration', () => {
     second.rerender(<DurationProbe active={false} timerKey="reasoning:m1:7" />)
 
     expect(screen.getByTestId('measured').textContent).toBe('2')
+  })
+
+  it('records the real finish time even if the UI clock was paused', () => {
+    const probe = render(<DurationProbe active timerKey="reasoning:background" />)
+    vi.mocked(document.hasFocus).mockReturnValue(false)
+    window.dispatchEvent(new Event('blur'))
+
+    act(() => {
+      vi.advanceTimersByTime(5_000)
+    })
+    probe.rerender(<DurationProbe active={false} timerKey="reasoning:background" />)
+
+    expect(screen.getByTestId('measured').textContent).toBe('5')
   })
 })

--- a/apps/desktop/src/components/chat/activity-timer.ts
+++ b/apps/desktop/src/components/chat/activity-timer.ts
@@ -1,5 +1,7 @@
 import { useEffect, useRef, useState } from 'react'
 
+import { useViewedInterval } from '@/hooks/use-viewed-interval'
+
 // Module-level registry so timers survive component unmount/remount (e.g.
 // when a tool row scrolls out and back). Keyed by caller-supplied timerKey;
 // anonymous timers (no key) start fresh each mount.
@@ -53,24 +55,24 @@ export function useElapsedSeconds(active = true, timerKey?: string, since?: numb
     lastKey.current = timerKey
   }
 
-  // eslint-disable-next-line no-restricted-syntax -- legitimate non-atom ref write (see eslint rule comment)
+  // eslint-disable-next-line no-restricted-syntax -- timer origin is imperative state, not an atom mirror
   useEffect(() => {
-    if (!active) {
-      return
-    }
-
     if (since !== undefined) {
       start.current = since
     } else if (timerKey) {
       start.current = startedAt(timerKey)
     }
 
-    const tick = () => setElapsed(Math.max(0, Math.floor((Date.now() - start.current) / 1000)))
-    tick()
-    const id = window.setInterval(tick, 1000)
-
-    return () => window.clearInterval(id)
+    if (active) {
+      setElapsed(Math.max(0, Math.floor((Date.now() - start.current) / 1000)))
+    }
   }, [active, since, timerKey])
+
+  useViewedInterval(
+    () => setElapsed(Math.max(0, Math.floor((Date.now() - start.current) / 1000))),
+    1000,
+    active
+  )
 
   return elapsed
 }
@@ -100,9 +102,11 @@ export function useMeasuredDuration(active: boolean, timerKey: string): null | n
     if (active) {
       setWatching(true)
     } else if (watching) {
+      const finalElapsed = Math.max(elapsed, Math.floor((Date.now() - startedAt(timerKey)) / 1000))
+
       setWatching(false)
-      durationByKey.set(timerKey, elapsed)
-      setMeasured(elapsed)
+      durationByKey.set(timerKey, finalElapsed)
+      setMeasured(finalElapsed)
     }
   }, [active, elapsed, timerKey, watching])
 

--- a/apps/desktop/src/hooks/use-viewed-interval.ts
+++ b/apps/desktop/src/hooks/use-viewed-interval.ts
@@ -1,0 +1,57 @@
+import { useEffect, useRef } from 'react'
+
+/** Run a UI-only clock while this document is actually being viewed.
+ *
+ * macOS can leave an occluded BrowserWindow `visible`, and active streaming
+ * deliberately disables Chromium's background timer throttling. Pairing focus
+ * with visibility avoids waking React for elapsed labels nobody can see while
+ * a leading tick on return catches the UI up immediately.
+ */
+export function useViewedInterval(callback: () => void, intervalMs: number, enabled = true): void {
+  const callbackRef = useRef(callback)
+
+  // eslint-disable-next-line no-restricted-syntax -- latest-callback ref avoids restarting the interval each render
+  useEffect(() => {
+    callbackRef.current = callback
+  }, [callback])
+
+  useEffect(() => {
+    if (!enabled) {
+      return
+    }
+
+    let intervalId: null | number = null
+    const stop = () => {
+      if (intervalId !== null) {
+        window.clearInterval(intervalId)
+        intervalId = null
+      }
+    }
+    const sync = () => {
+      const viewed = document.visibilityState === 'visible' && document.hasFocus()
+
+      if (!viewed) {
+        stop()
+
+        return
+      }
+
+      if (intervalId === null) {
+        callbackRef.current()
+        intervalId = window.setInterval(() => callbackRef.current(), intervalMs)
+      }
+    }
+
+    window.addEventListener('focus', sync)
+    window.addEventListener('blur', sync)
+    document.addEventListener('visibilitychange', sync)
+    sync()
+
+    return () => {
+      stop()
+      window.removeEventListener('focus', sync)
+      window.removeEventListener('blur', sync)
+      document.removeEventListener('visibilitychange', sync)
+    }
+  }, [enabled, intervalMs])
+}

--- a/apps/desktop/src/lib/statusbar.tsx
+++ b/apps/desktop/src/lib/statusbar.tsx
@@ -1,6 +1,7 @@
-import { useEffect, useState } from 'react'
+import { useState } from 'react'
 
 import { StableText } from '@/components/chat/stable-text'
+import { useViewedInterval } from '@/hooks/use-viewed-interval'
 import { compactNumber } from '@/lib/format'
 import type { UsageStats } from '@/types/hermes'
 
@@ -61,17 +62,7 @@ export function contextBarLabel(usage: UsageStats): string {
 export function LiveDuration({ since }: { since: number | null | undefined }) {
   const [now, setNow] = useState(() => Date.now())
 
-  useEffect(() => {
-    if (!since) {
-      return
-    }
-
-    const tick = () => setNow(Date.now())
-    tick()
-    const timer = window.setInterval(tick, 1000)
-
-    return () => window.clearInterval(timer)
-  }, [since])
+  useViewedInterval(() => setNow(Date.now()), 1000, Boolean(since))
 
   if (!since) {
     return null

--- a/contributors/emails/g.atkinson112@gmail.com
+++ b/contributors/emails/g.atkinson112@gmail.com
@@ -1,0 +1,1 @@
+bananawalnut

--- a/contributors/emails/tugrulgunr@gmail.com
+++ b/contributors/emails/tugrulgunr@gmail.com
@@ -1,0 +1,1 @@
+tugrulguner

--- a/contributors/emails/{ID}+{username}@users.noreply.github.com
+++ b/contributors/emails/{ID}+{username}@users.noreply.github.com
@@ -1,0 +1,1 @@
+alexdev03

--- a/hermes_cli/web_routers/profiles.py
+++ b/hermes_cli/web_routers/profiles.py
@@ -84,23 +84,10 @@ _write_profile_mcp_servers = late("_write_profile_mcp_servers")
 _write_profile_model = late("_write_profile_model")
 
 
-def _read_sidebar_cache_ttl() -> float:
-    """Return the bounded cache lifetime for the expensive sidebar scan."""
-    raw = os.environ.get("HERMES_DASHBOARD_SIDEBAR_CACHE_TTL", "5")
-    try:
-        value = float(raw)
-        if not math.isfinite(value):
-            raise ValueError("non-finite TTL")
-    except (TypeError, ValueError):
-        _log.warning(
-            "invalid HERMES_DASHBOARD_SIDEBAR_CACHE_TTL=%r; using 5s",
-            raw,
-        )
-        value = 5.0
-    return min(max(value, 0.0), 30.0)
-
-
-_SIDEBAR_CACHE_TTL_SECONDS = _read_sidebar_cache_ttl()
+# Bounded cache lifetime for the expensive sidebar scan. Short enough that the
+# UI never shows meaningfully stale data, long enough to coalesce the desktop's
+# reconnect/focus/change poll bursts into one scan.
+_SIDEBAR_CACHE_TTL_SECONDS = 5.0
 _SIDEBAR_CACHE_MAX_ENTRIES = 32
 _SIDEBAR_PROFILE_CACHE_MAX_ENTRIES = 256
 _SIDEBAR_PROFILE_CACHE = OrderedDict()

--- a/hermes_cli/web_routers/profiles.py
+++ b/hermes_cli/web_routers/profiles.py
@@ -13,12 +13,17 @@ late-binding seam in :mod:`hermes_cli.web_deps` so tests that
 """
 
 import asyncio  # noqa: F401 — used by handlers
+import copy
+import functools
+import inspect
 import json
 import logging
 import re
 import subprocess  # noqa: F401
 import sys  # noqa: F401
+import threading
 import time  # noqa: F401
+from collections import OrderedDict
 from pathlib import Path  # noqa: F401
 from typing import Any, Dict, List, Optional, Tuple  # noqa: F401
 
@@ -79,6 +84,151 @@ _write_profile_mcp_servers = late("_write_profile_mcp_servers")
 _write_profile_model = late("_write_profile_model")
 
 
+def _read_sidebar_cache_ttl() -> float:
+    """Return the bounded cache lifetime for the expensive sidebar scan."""
+    raw = os.environ.get("HERMES_DASHBOARD_SIDEBAR_CACHE_TTL", "5")
+    try:
+        value = float(raw)
+        if not math.isfinite(value):
+            raise ValueError("non-finite TTL")
+    except (TypeError, ValueError):
+        _log.warning(
+            "invalid HERMES_DASHBOARD_SIDEBAR_CACHE_TTL=%r; using 5s",
+            raw,
+        )
+        value = 5.0
+    return min(max(value, 0.0), 30.0)
+
+
+_SIDEBAR_CACHE_TTL_SECONDS = _read_sidebar_cache_ttl()
+_SIDEBAR_CACHE_MAX_ENTRIES = 32
+_SIDEBAR_PROFILE_CACHE_MAX_ENTRIES = 256
+_SIDEBAR_PROFILE_CACHE = OrderedDict()
+_SIDEBAR_PROFILE_CACHE_LOCK = threading.Lock()
+
+
+def _stat_fingerprint(path: Path):
+    """Return identity + mutation metadata without opening the file."""
+    try:
+        stat = path.stat()
+    except OSError:
+        return None
+    return (stat.st_dev, stat.st_ino, stat.st_size, stat.st_mtime_ns)
+
+
+def _sidebar_db_fingerprint(db_path: Path):
+    """Track SQLite content changes through the main DB and its WAL."""
+    wal_path = Path(f"{db_path}-wal")
+    return (_stat_fingerprint(db_path), _stat_fingerprint(wal_path))
+
+
+def _sidebar_profile_cache_get(key):
+    with _SIDEBAR_PROFILE_CACHE_LOCK:
+        value = _SIDEBAR_PROFILE_CACHE.get(key)
+        if value is None:
+            return None
+        _SIDEBAR_PROFILE_CACHE.move_to_end(key)
+        return copy.deepcopy(value)
+
+
+def _sidebar_profile_cache_put(key, value):
+    db_path, fingerprint = key[:2]
+    snapshot = copy.deepcopy(value)
+    with _SIDEBAR_PROFILE_CACHE_LOCK:
+        # A changed DB/WAL makes all older parameter variants for that profile
+        # obsolete. Remove them eagerly rather than waiting for LRU pressure.
+        stale = [
+            existing
+            for existing in _SIDEBAR_PROFILE_CACHE
+            if existing[0] == db_path and existing[1] != fingerprint
+        ]
+        for existing in stale:
+            _SIDEBAR_PROFILE_CACHE.pop(existing, None)
+        _SIDEBAR_PROFILE_CACHE[key] = snapshot
+        _SIDEBAR_PROFILE_CACHE.move_to_end(key)
+        while len(_SIDEBAR_PROFILE_CACHE) > _SIDEBAR_PROFILE_CACHE_MAX_ENTRIES:
+            _SIDEBAR_PROFILE_CACHE.popitem(last=False)
+
+
+def _sidebar_profile_cache_clear():
+    with _SIDEBAR_PROFILE_CACHE_LOCK:
+        _SIDEBAR_PROFILE_CACHE.clear()
+
+
+def _sidebar_singleflight_cache(func):
+    """Coalesce concurrent sidebar scans and briefly reuse their response.
+
+    Every uncached refresh opens every profile database and runs up to three
+    session queries per profile. Desktop reconnect/focus/change bursts can
+    therefore overlap several identical scans in AnyIO worker threads, which
+    amplifies YAML/SQLite work and starves the uvicorn event loop for the GIL.
+
+    The short TTL bounds UI staleness while the single-flight lock guarantees
+    only one expensive scan runs at a time. Cached values are copied on store
+    and hit so FastAPI serialization or a caller cannot mutate shared state.
+    """
+    signature = inspect.signature(func)
+    cache = OrderedDict()
+    cache_lock = threading.Lock()
+    refresh_lock = threading.Lock()
+    miss = object()
+
+    def _key(args, kwargs):
+        bound = signature.bind(*args, **kwargs)
+        bound.apply_defaults()
+        return tuple(bound.arguments.items())
+
+    def _lookup(key):
+        now = time.monotonic()
+        with cache_lock:
+            item = cache.get(key)
+            if item is None:
+                return miss
+            expires_at, value = item
+            if now >= expires_at:
+                cache.pop(key, None)
+                return miss
+            cache.move_to_end(key)
+            return copy.deepcopy(value)
+
+    @functools.wraps(func)
+    def wrapped(*args, **kwargs):
+        ttl = _SIDEBAR_CACHE_TTL_SECONDS
+        if ttl <= 0:
+            return func(*args, **kwargs)
+
+        key = _key(args, kwargs)
+        cached = _lookup(key)
+        if cached is not miss:
+            return cached
+
+        # A plain Lock is intentional: FastAPI executes this sync handler in
+        # the AnyIO worker pool, so contenders sleep without holding the GIL.
+        with refresh_lock:
+            cached = _lookup(key)
+            if cached is not miss:
+                return cached
+            result = func(*args, **kwargs)
+            try:
+                snapshot = copy.deepcopy(result)
+            except Exception:
+                _log.exception("sidebar response could not be cached")
+                return result
+            with cache_lock:
+                cache[key] = (time.monotonic() + ttl, snapshot)
+                cache.move_to_end(key)
+                while len(cache) > _SIDEBAR_CACHE_MAX_ENTRIES:
+                    cache.popitem(last=False)
+            return result
+
+    def cache_clear():
+        with cache_lock:
+            cache.clear()
+
+    wrapped.cache_clear = cache_clear
+    return wrapped
+
+
 @sessions_router.get("/api/profiles/sessions")
 def get_profiles_sessions(
     # ``le=500`` caps the per-request page size (idea from #39200) — this
@@ -123,8 +273,9 @@ def get_profiles_sessions(
         targets.append((name, home))
     else:
         try:
-            infos = profiles_mod.list_profiles()
-            targets = [(info.name, info.path) for info in infos]
+            # This endpoint only needs name/path. Avoid list_profiles(), which
+            # parses config/meta and probes gateways/skills per profile.
+            targets = profiles_mod.profiles_to_serve(multiplex=True)
         except Exception:
             _log.exception("GET /api/profiles/sessions: list_profiles failed")
             targets = []
@@ -230,6 +381,7 @@ def get_profiles_sessions(
 
 
 @sessions_router.get("/api/profiles/sessions/sidebar")
+@_sidebar_singleflight_cache
 def get_profiles_sessions_sidebar(
     recents_profile: str = "all",
     recents_limit: int = 20,
@@ -263,8 +415,9 @@ def get_profiles_sessions_sidebar(
     from hermes_cli import profiles as profiles_mod
 
     try:
-        infos = profiles_mod.list_profiles()
-        targets: List[Tuple[str, Path]] = [(info.name, info.path) for info in infos]
+        # Session aggregation only needs name/path; the lightweight enumerator
+        # avoids YAML/meta/gateway/skill probes for all profiles per refresh.
+        targets: List[Tuple[str, Path]] = profiles_mod.profiles_to_serve(multiplex=True)
     except Exception:
         _log.exception("GET /api/profiles/sessions/sidebar: list_profiles failed")
         targets = []
@@ -323,38 +476,61 @@ def get_profiles_sessions_sidebar(
         db_path = Path(home) / "state.db"
         if not db_path.exists():
             continue
-        try:
-            # Read-only with the stale-schema heal — same contract as the
-            # per-slice endpoint above (one-time writable reconcile when the
-            # store predates a schema addition, plain read-only otherwise).
-            db = _open_session_db_at_path(db_path, read_only=True)
-        except Exception as exc:
-            _warn_profile_read_error(name, exc)
-            errors.append({"profile": name, "error": str(exc)})
-            continue
-        try:
-            profile_rows = _slice(db, exclude=recents_exclude_list, cap=recents_cap)
-            # A full window means more rows remain on disk. That is all the
-            # sidebar's "load more" needs, and unlike an exact COUNT(*) per
-            # profile per refresh it costs nothing beyond the rows already
-            # read. Discount pinned back-fills — they arrive past the LIMIT
-            # and would otherwise fake a full page on a short list.
-            unpinned_count = sum(1 for s in profile_rows if not s.get("pinned"))
-            recents_truncated[name] = unpinned_count >= recents_cap
-            recents_rows.extend(_tag(profile_rows, name))
-            # Aggregated in SQL rather than over the window above: the window is
-            # a page, and a total that shrank when you scrolled would be worse
-            # than no total at all.
-            profile_totals[name] = db.usage_totals()
-            cron_rows.extend(_tag(_slice(db, source="cron", cap=cron_cap), name))
-            messaging_rows.extend(
-                _tag(_slice(db, exclude=messaging_exclude_list, cap=messaging_cap), name)
-            )
-        except Exception as exc:
-            _warn_profile_read_error(name, exc)
-            errors.append({"profile": name, "error": str(exc)})
-        finally:
-            db.close()
+        fingerprint = _sidebar_db_fingerprint(db_path)
+        profile_cache_key = (
+            str(db_path),
+            fingerprint,
+            recents_cap,
+            tuple(recents_exclude_list),
+            cron_cap,
+            messaging_cap,
+            tuple(messaging_exclude_list),
+        )
+        slices = _sidebar_profile_cache_get(profile_cache_key)
+        if slices is None:
+            try:
+                # Read-only with the stale-schema heal — same contract as the
+                # per-slice endpoint above (one-time writable reconcile when the
+                # store predates a schema addition, plain read-only otherwise).
+                db = _open_session_db_at_path(db_path, read_only=True)
+            except Exception as exc:
+                _warn_profile_read_error(name, exc)
+                errors.append({"profile": name, "error": str(exc)})
+                continue
+            try:
+                slices = {
+                    "recents": _slice(db, exclude=recents_exclude_list, cap=recents_cap),
+                    # Aggregated in SQL rather than over the recents window: the
+                    # window is a page, and a total that shrank when you scrolled
+                    # would be worse than no total at all.
+                    "usage": db.usage_totals(),
+                    "cron": _slice(db, source="cron", cap=cron_cap),
+                    "messaging": _slice(
+                        db,
+                        exclude=messaging_exclude_list,
+                        cap=messaging_cap,
+                    ),
+                }
+                _sidebar_profile_cache_put(profile_cache_key, slices)
+            except Exception as exc:
+                _warn_profile_read_error(name, exc)
+                errors.append({"profile": name, "error": str(exc)})
+                continue
+            finally:
+                db.close()
+
+        profile_rows = slices["recents"]
+        # A full window means more rows remain on disk. That is all the
+        # sidebar's "load more" needs, and unlike an exact COUNT(*) per
+        # profile per refresh it costs nothing beyond the rows already
+        # read. Discount pinned back-fills — they arrive past the LIMIT
+        # and would otherwise fake a full page on a short list.
+        unpinned_count = sum(1 for s in profile_rows if not s.get("pinned"))
+        recents_truncated[name] = unpinned_count >= recents_cap
+        recents_rows.extend(_tag(profile_rows, name))
+        profile_totals[name] = slices["usage"]
+        cron_rows.extend(_tag(slices["cron"], name))
+        messaging_rows.extend(_tag(slices["messaging"], name))
 
     def _window(rows: List[Dict[str, Any]], cap: int) -> List[Dict[str, Any]]:
         rows.sort(key=lambda s: s.get("last_active") or s.get("started_at") or 0, reverse=True)

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -15136,6 +15136,10 @@ else:
 
 _RESIZE_RE = re.compile(rb"\x1b\[RESIZE:(\d+);(\d+)\]")
 _PTY_READ_CHUNK_TIMEOUT = 0.2
+# Back-off delay between idle PTY reads so a quiet terminal does not spin
+# the event loop.  A positive sleep lets other coroutines run and keeps
+# dashboard idle CPU low (#42627).
+_PTY_IDLE_BACKOFF = 0.05
 
 # Keep-alive PTY sessions: a terminal connecting with ``?attach=<token>`` is
 # bound to a process that survives disconnect/refresh and is reattachable.
@@ -15170,7 +15174,7 @@ async def _legacy_pump(ws: "WebSocket", bridge) -> None:
                 if chunk is None:  # EOF
                     return
                 if not chunk:  # no data this tick; yield control and retry
-                    await asyncio.sleep(0)
+                    await asyncio.sleep(_PTY_IDLE_BACKOFF)
                     continue
                 try:
                     await ws.send_bytes(chunk)

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -11997,10 +11997,23 @@ def _validate_dashboard_cron_context_from(
 
 
 def _cron_profile_dicts() -> List[Dict[str, Any]]:
-    """Return dashboard profile records, falling back to a directory scan."""
+    """Return the minimal profile records needed by cron aggregation.
+
+    The two callers only consume ``name``.  ``list_profiles()`` also parses
+    config/distribution metadata, probes gateway processes, and counts skills
+    for every profile; polling cron jobs through that path creates avoidable
+    GIL pressure on large profile pools.
+    """
     from hermes_cli import profiles as profiles_mod
     try:
-        return [_profile_to_dict(p) for p in profiles_mod.list_profiles()]
+        return [
+            {
+                "name": name,
+                "path": str(home),
+                "is_default": name == "default",
+            }
+            for name, home in profiles_mod.profiles_to_serve(multiplex=True)
+        ]
     except Exception:
         _log.exception("Failed to list profiles for cron dashboard; falling back to directory scan")
         return _fallback_profile_dicts(profiles_mod)

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -2946,10 +2946,24 @@ async def stream_events(ws: WebSocket):
                 conn.close()
 
         while True:
+            # Race receive() against the poll interval to detect client
+            # disconnect even when no events are being sent. Without this,
+            # a disconnect is only detected via send_json() raising
+            # WebSocketDisconnect, so an idle board leaks zombie poll tasks.
+            try:
+                msg = await asyncio.wait_for(
+                    ws.receive(), timeout=_EVENT_POLL_SECONDS
+                )
+                if msg["type"] == "websocket.disconnect":
+                    return
+                # Any other client message (pong, text) is ignored; we
+                # continue polling.
+            except asyncio.TimeoutError:
+                pass  # no client message — poll the DB
+
             cursor, events = await asyncio.to_thread(_fetch_new, cursor)
             if events:
                 await ws.send_json({"events": events, "cursor": cursor})
-            await asyncio.sleep(_EVENT_POLL_SECONDS)
     except WebSocketDisconnect:
         return
     except asyncio.CancelledError:

--- a/tests/hermes_cli/test_cron_profile_enumeration_lightweight.py
+++ b/tests/hermes_cli/test_cron_profile_enumeration_lightweight.py
@@ -1,0 +1,37 @@
+"""Cron aggregation must not perform full profile metadata scans."""
+
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from hermes_cli import web_server
+
+
+class CronProfileEnumerationTests(unittest.TestCase):
+    def test_uses_lightweight_name_path_enumerator(self):
+        with tempfile.TemporaryDirectory() as root:
+            homes = [
+                ("default", Path(root)),
+                ("coder-01", Path(root) / "profiles" / "coder-01"),
+            ]
+            with (
+                mock.patch(
+                    "hermes_cli.profiles.profiles_to_serve",
+                    return_value=homes,
+                ) as lightweight,
+                mock.patch(
+                    "hermes_cli.profiles.list_profiles",
+                    side_effect=AssertionError("full profile scan is forbidden"),
+                ),
+            ):
+                result = web_server._cron_profile_dicts()
+
+        lightweight.assert_called_once_with(multiplex=True)
+        self.assertEqual([item["name"] for item in result], ["default", "coder-01"])
+        self.assertTrue(result[0]["is_default"])
+        self.assertFalse(result[1]["is_default"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/hermes_cli/test_profiles_sidebar_cache.py
+++ b/tests/hermes_cli/test_profiles_sidebar_cache.py
@@ -1,0 +1,159 @@
+"""Regression tests for dashboard sidebar scan coalescing."""
+
+import inspect
+import tempfile
+import threading
+import time
+import unittest
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+from unittest import mock
+
+from hermes_cli.web_routers import profiles
+
+
+class SidebarCacheTests(unittest.TestCase):
+    def setUp(self):
+        patcher = mock.patch.object(profiles, "_SIDEBAR_CACHE_TTL_SECONDS", 5.0)
+        patcher.start()
+        self.addCleanup(patcher.stop)
+        profiles._sidebar_profile_cache_clear()
+        self.addCleanup(profiles._sidebar_profile_cache_clear)
+
+    def test_invalid_or_non_finite_ttl_falls_back_to_default(self):
+        for raw in ("invalid", "nan", "inf", "-inf"):
+            with self.subTest(raw=raw):
+                with mock.patch.dict(profiles.os.environ, {"HERMES_DASHBOARD_SIDEBAR_CACHE_TTL": raw}):
+                    self.assertEqual(profiles._read_sidebar_cache_ttl(), 5.0)
+
+    def test_profile_cache_uses_db_and_wal_fingerprint_and_defensive_copies(self):
+        with tempfile.TemporaryDirectory() as root:
+            db_path = Path(root) / "state.db"
+            wal_path = Path(f"{db_path}-wal")
+            db_path.write_bytes(b"db-v1")
+            wal_path.write_bytes(b"wal-v1")
+            first_fingerprint = profiles._sidebar_db_fingerprint(db_path)
+            first_key = (str(db_path), first_fingerprint, False, 0, (), 50, 100, ())
+            payload = {"recents": None, "cron": [{"id": "one"}], "messaging": []}
+
+            profiles._sidebar_profile_cache_put(first_key, payload)
+            cached = profiles._sidebar_profile_cache_get(first_key)
+            cached["cron"][0]["id"] = "mutated"
+            self.assertEqual(
+                profiles._sidebar_profile_cache_get(first_key)["cron"][0]["id"],
+                "one",
+            )
+
+            wal_path.write_bytes(b"wal-v2-is-different")
+            second_fingerprint = profiles._sidebar_db_fingerprint(db_path)
+            second_key = (str(db_path), second_fingerprint, False, 0, (), 50, 100, ())
+            self.assertNotEqual(first_fingerprint, second_fingerprint)
+            self.assertIsNone(profiles._sidebar_profile_cache_get(second_key))
+
+            profiles._sidebar_profile_cache_put(second_key, payload)
+            self.assertIsNone(profiles._sidebar_profile_cache_get(first_key))
+
+    def test_profile_cache_is_lru_bounded(self):
+        with mock.patch.object(profiles, "_SIDEBAR_PROFILE_CACHE_MAX_ENTRIES", 2):
+            for index in range(3):
+                key = (f"/db/{index}", (index, None), False, 0, (), 50, 100, ())
+                profiles._sidebar_profile_cache_put(key, {"index": index})
+            self.assertEqual(len(profiles._SIDEBAR_PROFILE_CACHE), 2)
+
+    def test_applies_defaults_and_returns_defensive_copies(self):
+        calls = 0
+
+        @profiles._sidebar_singleflight_cache
+        def scan(profile="all", limit=20):
+            nonlocal calls
+            calls += 1
+            return {"profile": profile, "rows": [{"limit": limit}]}
+
+        first = scan()
+        first["rows"][0]["limit"] = 999
+        second = scan(profile="all", limit=20)
+
+        self.assertEqual(calls, 1)
+        self.assertEqual(second, {"profile": "all", "rows": [{"limit": 20}]})
+
+    def test_coalesces_concurrent_identical_scans(self):
+        workers = 12
+        entered = threading.Event()
+        release = threading.Event()
+        calls = 0
+        calls_lock = threading.Lock()
+
+        @profiles._sidebar_singleflight_cache
+        def scan(profile="all"):
+            nonlocal calls
+            with calls_lock:
+                calls += 1
+            entered.set()
+            self.assertTrue(release.wait(timeout=2))
+            return {"profile": profile, "rows": []}
+
+        with ThreadPoolExecutor(max_workers=workers) as pool:
+            futures = [pool.submit(scan, "default") for _ in range(workers)]
+            self.assertTrue(entered.wait(timeout=1))
+            time.sleep(0.05)
+            release.set()
+            results = [future.result(timeout=2) for future in futures]
+
+        self.assertEqual(calls, 1)
+        self.assertEqual(results, [{"profile": "default", "rows": []}] * workers)
+
+    def test_expires(self):
+        clock = iter((100.0, 100.0, 100.0, 106.0, 106.0, 106.0))
+        calls = 0
+
+        @profiles._sidebar_singleflight_cache
+        def scan():
+            nonlocal calls
+            calls += 1
+            return {"generation": calls}
+
+        with mock.patch.object(profiles.time, "monotonic", side_effect=clock):
+            self.assertEqual(scan(), {"generation": 1})
+            self.assertEqual(scan(), {"generation": 2})
+        self.assertEqual(calls, 2)
+
+    def test_does_not_cache_failures(self):
+        calls = 0
+
+        @profiles._sidebar_singleflight_cache
+        def scan():
+            nonlocal calls
+            calls += 1
+            if calls == 1:
+                raise RuntimeError("transient")
+            return {"ok": True}
+
+        with self.assertRaisesRegex(RuntimeError, "transient"):
+            scan()
+        self.assertEqual(scan(), {"ok": True})
+        self.assertEqual(scan(), {"ok": True})
+        self.assertEqual(calls, 2)
+
+    def test_can_be_disabled(self):
+        calls = 0
+
+        @profiles._sidebar_singleflight_cache
+        def scan():
+            nonlocal calls
+            calls += 1
+            return calls
+
+        with mock.patch.object(profiles, "_SIDEBAR_CACHE_TTL_SECONDS", 0.0):
+            self.assertEqual((scan(), scan()), (1, 2))
+
+    def test_preserves_fastapi_signature(self):
+        def scan(profile: str = "all", limit: int = 20):
+            return profile, limit
+
+        wrapped = profiles._sidebar_singleflight_cache(scan)
+
+        self.assertEqual(inspect.signature(wrapped), inspect.signature(scan))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/hermes_cli/test_profiles_sidebar_cache.py
+++ b/tests/hermes_cli/test_profiles_sidebar_cache.py
@@ -20,12 +20,6 @@ class SidebarCacheTests(unittest.TestCase):
         profiles._sidebar_profile_cache_clear()
         self.addCleanup(profiles._sidebar_profile_cache_clear)
 
-    def test_invalid_or_non_finite_ttl_falls_back_to_default(self):
-        for raw in ("invalid", "nan", "inf", "-inf"):
-            with self.subTest(raw=raw):
-                with mock.patch.dict(profiles.os.environ, {"HERMES_DASHBOARD_SIDEBAR_CACHE_TTL": raw}):
-                    self.assertEqual(profiles._read_sidebar_cache_ttl(), 5.0)
-
     def test_profile_cache_uses_db_and_wal_fingerprint_and_defensive_copies(self):
         with tempfile.TemporaryDirectory() as root:
             db_path = Path(root) / "state.db"

--- a/tests/hermes_cli/test_web_server_pty_idle_backoff.py
+++ b/tests/hermes_cli/test_web_server_pty_idle_backoff.py
@@ -1,0 +1,73 @@
+"""Regression: dashboard PTY pump must back off when the terminal is idle."""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import patch
+
+import pytest
+
+from hermes_cli.web_server import _legacy_pump
+
+
+class _FakeBridge:
+    def __init__(self, reads):
+        self._reads = list(reads)
+        self.closed = False
+
+    def read(self, timeout):
+        if self._reads:
+            return self._reads.pop(0)
+        return None
+
+    def write(self, data):
+        pass
+
+    def resize(self, cols, rows):
+        pass
+
+    def close(self):
+        self.closed = True
+
+
+@pytest.mark.asyncio
+async def test_legacy_pump_sleeps_on_idle_pty():
+    """An empty PTY read must not spin with ``asyncio.sleep(0)``."""
+    sleeps: list[float] = []
+    first_idle_seen = asyncio.Event()
+    real_sleep = asyncio.sleep
+
+    async def fake_sleep(delay: float) -> None:
+        sleeps.append(delay)
+        first_idle_seen.set()
+        # Yield with the real sleep so we don't recurse through the patch.
+        await real_sleep(0)
+
+    bridge = _FakeBridge([b"", b"", None])
+
+    class _FakeWebSocket:
+        def __init__(self):
+            self.sent: list[bytes] = []
+
+        async def send_bytes(self, data):
+            self.sent.append(data)
+
+        async def receive(self):
+            await first_idle_seen.wait()
+            return {"type": "websocket.disconnect"}
+
+        async def close(self):
+            pass
+
+    ws = _FakeWebSocket()
+
+    with patch("hermes_cli.web_server.asyncio.sleep", side_effect=fake_sleep):
+        # _legacy_pump is typed against starlette WebSocket; our fake is an
+        # intentional behavioral shim.  # type: ignore[invalid-argument-type]
+        await _legacy_pump(ws, bridge)
+
+    assert bridge.closed
+    assert sleeps, "pty pump did not call asyncio.sleep on idle ticks"
+    assert all(d > 0 for d in sleeps), (
+        f"idle pump used zero or negative sleeps: {sleeps}"
+    )

--- a/tests/plugins/test_kanban_ws_idle_disconnect.py
+++ b/tests/plugins/test_kanban_ws_idle_disconnect.py
@@ -1,0 +1,70 @@
+"""Regression: kanban events WS must notice client disconnect on an idle board.
+
+Before the fix (#77833), ``stream_events`` only awaited ``asyncio.sleep``
+between DB polls, so a disconnect was detected solely when ``send_json``
+raised — which never happens on a board with no new events. Every closed
+dashboard tab therefore left a zombie poll task querying SQLite forever.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+
+def _load_plugin_module():
+    repo_root = Path(__file__).resolve().parents[2]
+    plugin_file = repo_root / "plugins" / "kanban" / "dashboard" / "plugin_api.py"
+    assert plugin_file.exists(), f"plugin file missing: {plugin_file}"
+    spec = importlib.util.spec_from_file_location(
+        "hermes_dashboard_plugin_kanban_ws_test", plugin_file,
+    )
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+class _IdleDisconnectingWebSocket:
+    """Accepts, then reports a client disconnect on the first receive()."""
+
+    def __init__(self):
+        self.accepted = False
+        self.sent: list[dict] = []
+        self.query_params: dict[str, str] = {}
+        self.receive_calls = 0
+
+    async def accept(self):
+        self.accepted = True
+
+    async def receive(self):
+        self.receive_calls += 1
+        return {"type": "websocket.disconnect"}
+
+    async def send_json(self, payload):
+        self.sent.append(payload)
+
+    async def close(self, code=None):
+        pass
+
+
+@pytest.mark.asyncio
+async def test_stream_events_exits_on_idle_disconnect(monkeypatch, tmp_path):
+    mod = _load_plugin_module()
+    monkeypatch.setattr(mod, "_ws_upgrade_authorized", lambda ws: True)
+
+    ws = _IdleDisconnectingWebSocket()
+
+    # The disconnect must terminate the handler even though the board is idle
+    # and no event is ever sent. Before the fix this call never returned
+    # (the loop only slept between polls), so bound it with a timeout.
+    await asyncio.wait_for(mod.stream_events(ws), timeout=5)
+
+    assert ws.accepted
+    assert ws.receive_calls == 1
+    assert ws.sent == []  # returned before any poll, no zombie loop

--- a/ui-tui/src/__tests__/petPolling.test.ts
+++ b/ui-tui/src/__tests__/petPolling.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { createPetSingleFlight, requestPetUpdate } from '../lib/petPolling.js'
+
+const gateway = (request: ReturnType<typeof vi.fn>) => ({ request }) as never
+
+describe('requestPetUpdate', () => {
+  it('does not enqueue pet.cells while pets are disabled', async () => {
+    const request = vi.fn().mockResolvedValue({ enabled: false })
+    const needsCells = vi.fn(() => true)
+
+    const update = await requestPetUpdate(gateway(request), 'idle', false, needsCells)
+
+    expect(update).toEqual({ cells: null, meta: { enabled: false } })
+    expect(request).toHaveBeenCalledTimes(1)
+    expect(request).toHaveBeenCalledWith('pet.info.meta')
+    expect(needsCells).not.toHaveBeenCalled()
+  })
+
+  it('uses metadata only when the enabled state is already cached', async () => {
+    const request = vi.fn().mockResolvedValue({
+      enabled: true,
+      scale: 0.33,
+      slug: 'boba',
+      spritesheetRevision: '1:2'
+    })
+
+    const update = await requestPetUpdate(gateway(request), 'idle', false, () => false)
+
+    expect(update?.cells).toBeNull()
+    expect(request).toHaveBeenCalledTimes(1)
+  })
+
+  it('fetches cells only for an enabled uncached state', async () => {
+    const cells = { enabled: true, frames: [], slug: 'boba' }
+    const request = vi.fn().mockResolvedValueOnce({ enabled: true, slug: 'boba' }).mockResolvedValueOnce(cells)
+
+    const update = await requestPetUpdate(gateway(request), 'review', false, () => true)
+
+    expect(update?.cells).toEqual(cells)
+    expect(request).toHaveBeenNthCalledWith(1, 'pet.info.meta')
+    expect(request).toHaveBeenNthCalledWith(2, 'pet.cells', {
+      graphics: false,
+      state: 'review'
+    })
+  })
+
+  it('silently drops cosmetic gateway failures', async () => {
+    const request = vi.fn().mockRejectedValue(new Error('timeout: pet.info.meta'))
+
+    await expect(requestPetUpdate(gateway(request), 'idle', false, () => true)).resolves.toBeNull()
+  })
+})
+
+describe('createPetSingleFlight', () => {
+  it('suppresses overlapping polls and permits the next completed poll', async () => {
+    let release = () => undefined
+
+    const blocked = new Promise<void>(resolve => {
+      release = resolve
+    })
+
+    const operation = vi.fn(() => blocked)
+    const run = createPetSingleFlight()
+
+    const first = run(operation)
+    await expect(run(operation)).resolves.toBe(false)
+    expect(operation).toHaveBeenCalledTimes(1)
+
+    release()
+    await expect(first).resolves.toBe(true)
+    await expect(run(async () => undefined)).resolves.toBe(true)
+  })
+})

--- a/ui-tui/src/app/usePet.ts
+++ b/ui-tui/src/app/usePet.ts
@@ -2,6 +2,7 @@ import { useStdout } from '@hermes/ink'
 import { useCallback, useEffect, useRef, useState } from 'react'
 
 import type { PetGrid } from '../components/petSprite.js'
+import { createPetSingleFlight, requestPetUpdate } from '../lib/petPolling.js'
 
 import { useGateway } from './gatewayContext.js'
 import { $overlayState, getOverlayState } from './overlayStore.js'
@@ -104,10 +105,11 @@ export interface PetRender {
  *
  * A steady poll keeps it reactive to config changes made elsewhere (`/pet`, the
  * picker, `hermes pets select`) so adopting/switching/disabling takes effect
- * live. The frame cache is keyed by `slug:state` so a switch re-pulls cleanly.
+ * live. Disabled/cached pets use the cheap inline `pet.info.meta` probe; only
+ * uncached enabled states request `pet.cells` from the long-handler pool.
  */
 export function usePet(): PetRender {
-  const { rpc } = useGateway()
+  const { gw } = useGateway()
   const { write } = useStdout()
   const [enabled, setEnabled] = useState(false)
   const [grid, setGrid] = useState<PetGrid | null>(null)
@@ -116,9 +118,11 @@ export function usePet(): PetRender {
   const cache = useRef<Map<string, CacheEntry>>(new Map())
   const slugRef = useRef('')
   const scaleRef = useRef(0)
+  const revisionRef = useRef('')
   const imageIdRef = useRef(0)
   const stateRef = useRef<PetState>('idle')
   const frameRef = useRef(0)
+  const runSingleFlight = useRef(createPetSingleFlight()).current
 
   const [petState, setPetState] = useState<PetState>('idle')
 
@@ -189,38 +193,76 @@ export function usePet(): PetRender {
     }
   }, [write])
 
-  // Fetch + cache one (slug, state). `pet.cells` resolves the active pet from
-  // config, so its `slug`/`enabled` are the source of truth.
+  const disablePet = useCallback(() => {
+    releaseKitty()
+    slugRef.current = ''
+    scaleRef.current = 0
+    revisionRef.current = ''
+    cache.current.clear()
+    setGrid(null)
+    setKitty(null)
+    setEnabled(false)
+  }, [releaseKitty])
+
+  // Probe the active selection cheaply, then fetch + cache one uncached state.
   const sync = useCallback(
-    async (state: PetState) => {
-      try {
-        const res = (await rpc('pet.cells', { graphics: IS_TTY, state })) as PetCellsResult | null
+    (state: PetState) =>
+      runSingleFlight(async () => {
+        const update = await requestPetUpdate<PetCellsResult>(gw, state, IS_TTY, meta => {
+          const slug = meta.slug ?? ''
+          const scale = meta.scale ?? 0
+          const revision = meta.spritesheetRevision ?? ''
+
+          const selectionChanged =
+            slug !== slugRef.current || scale !== scaleRef.current || revision !== revisionRef.current
+
+          if (selectionChanged) {
+            releaseKitty()
+            slugRef.current = slug
+            scaleRef.current = scale
+            revisionRef.current = revision
+            cache.current.clear()
+            frameRef.current = 0
+          }
+
+          return !cache.current.has(`${slug}:${state}`)
+        })
+
+        if (!update) {
+          return
+        }
+
+        if (!update.meta.enabled) {
+          disablePet()
+
+          return
+        }
+
+        const res = update.cells
 
         if (!res) {
+          setEnabled(true)
+
           return
         }
 
         if (!res.enabled) {
-          releaseKitty()
-          slugRef.current = ''
-          cache.current.clear()
-          setGrid(null)
-          setKitty(null)
-          setEnabled(false)
+          disablePet()
 
           return
         }
 
-        const slug = res.slug ?? ''
-        const scale = res.scale ?? 0
+        const slug = res.slug ?? update.meta.slug ?? ''
+        const scale = res.scale ?? update.meta.scale ?? 0
 
-        // A switch OR a live `/pet scale` change invalidates the cached frames
-        // (they're rendered at the old size), so the steady poll repaints at the
-        // new scale without a restart.
-        if (slug !== slugRef.current || (scale > 0 && scale !== scaleRef.current)) {
+        // Config may change between the metadata and frame calls. Keep the
+        // frame response authoritative and force a fresh metadata revision on
+        // the next poll when the response moved to another selection.
+        if (slug !== slugRef.current || scale !== scaleRef.current) {
           releaseKitty()
           slugRef.current = slug
           scaleRef.current = scale
+          revisionRef.current = slug === update.meta.slug ? revisionRef.current : ''
           cache.current.clear()
           frameRef.current = 0
         }
@@ -243,11 +285,8 @@ export function usePet(): PetRender {
         }
 
         setEnabled(true)
-      } catch {
-        // cosmetic — ignore RPC failures
-      }
-    },
-    [rpc, releaseKitty]
+      }),
+    [disablePet, gw, releaseKitty, runSingleFlight]
   )
 
   // Pull frames whenever the state changes (if not already cached for the

--- a/ui-tui/src/lib/petPolling.ts
+++ b/ui-tui/src/lib/petPolling.ts
@@ -1,0 +1,73 @@
+import type { GatewayClient } from '../gatewayClient.js'
+
+import { asRpcResult } from './rpc.js'
+
+export interface PetMetaResult {
+  enabled?: boolean
+  scale?: number
+  slug?: string
+  spritesheetRevision?: string
+}
+
+interface PetUpdate<TCells> {
+  cells: TCells | null
+  meta: PetMetaResult
+}
+
+type PetGateway = Pick<GatewayClient, 'request'>
+
+/**
+ * Suppress overlapping cosmetic polls so a slow gateway can never accumulate
+ * a queue of pet requests. Returning false tells callers that an existing
+ * probe is still in flight.
+ */
+export function createPetSingleFlight() {
+  let active = false
+
+  return async (operation: () => Promise<void>): Promise<boolean> => {
+    if (active) {
+      return false
+    }
+
+    active = true
+
+    try {
+      await operation()
+
+      return true
+    } finally {
+      active = false
+    }
+  }
+}
+
+/**
+ * Probe cheap pet metadata on the gateway reader thread, then request the
+ * expensive frame payload only when the active selection/state is not cached.
+ * This deliberately bypasses the transcript-logging RPC wrapper: pet display
+ * is cosmetic, so an unavailable gateway must not print an error.
+ */
+export async function requestPetUpdate<TCells>(
+  gateway: PetGateway,
+  state: string,
+  graphics: boolean,
+  needsCells: (meta: PetMetaResult) => boolean
+): Promise<PetUpdate<TCells> | null> {
+  try {
+    const meta = asRpcResult(await gateway.request('pet.info.meta')) as PetMetaResult | null
+
+    if (!meta) {
+      return null
+    }
+
+    if (!meta.enabled || !needsCells(meta)) {
+      return { cells: null, meta }
+    }
+
+    const cells = asRpcResult(await gateway.request('pet.cells', { graphics, state })) as TCells | null
+
+    return { cells, meta }
+  } catch {
+    return null
+  }
+}


### PR DESCRIPTION
Salvages five contributor fixes that stop the desktop app, dashboard, TUI, and kanban plugin from burning CPU while idle — pausing unfocused UI work, coalescing sidebar scans, skipping disabled-pet polling, backing off the idle PTY pump, and reaping zombie kanban WS poll tasks.

## Changes

- **Desktop: pause background UI work while unfocused** (#81902, @alexdev03) — macOS commonly leaves an occluded BrowserWindow `visibilityState === 'visible'`, so visibility-only gating kept 1s elapsed-timer ticks, safety-net gateway polls, and 60s status RPCs alive while the user worked in another app. Adds a shared `useViewedInterval` hook (visibility **and** `document.hasFocus()`), gates `visiblePoll` and the status snapshot on active viewing, and catches up immediately on focus. `useMeasuredDuration` records the real wall-clock finish even when the UI clock was paused. Complements merged #86587 (animations/renderer loops) with zero file overlap — this covers the timer/RPC layer #86587 left running.
- **Dashboard: bound multi-profile sidebar polling** (#77727, @trismegisto639) — `/api/profiles/sessions/sidebar` re-opened every profile DB and ran up to three queries per profile on every poll, and desktop reconnect/focus bursts overlapped identical scans in AnyIO worker threads. Adds a 5s TTL single-flight response cache plus a per-profile slice cache keyed by DB+WAL stat fingerprint, and switches profile enumeration (sidebar + cron aggregation) to the lightweight `profiles_to_serve()` instead of full `list_profiles()` metadata/gateway/skill probes.
- **TUI: stop disabled pet cell polling** (#70311, @bananawalnut) — the pet poll requested full `pet.cells` spritesheets every tick even when pets were disabled or the state was cached. Now a cheap `pet.info.meta` probe runs first, `pet.cells` is fetched only for enabled uncached states, and a single-flight guard prevents poll pile-up on a slow gateway.
- **Dashboard: PTY pump idle back-off** (#81755, @Christopher-Schulze) — the legacy PTY pump's empty-read path used `asyncio.sleep(0)`, spinning the event loop flat-out on a quiet terminal. Now sleeps 50ms between idle reads.
- **Kanban: reap zombie WS poll tasks** (#77884, @tugrulguner) — the events WS only detected client disconnect when `send_json` raised, so every closed tab on an idle board leaked a poll task querying SQLite forever. The loop now races `ws.receive()` against the poll interval and exits on `websocket.disconnect`. Fixes #77833.

### Salvage adjustments on top of the cherry-picks

- Rebased the sidebar cache onto current main's sidebar handler (kept the stale-schema-healing `_open_session_db_at_path`, per-profile `usage_totals`, and scope-filter semantics added since the PR branched); dropped the PR's redundant `include_recents` re-check inside the loop.
- Replaced the PR's `HERMES_DASHBOARD_SIDEBAR_CACHE_TTL` env var with a fixed 5s constant per the repo rule that non-secret config never rides `HERMES_*` env vars.
- Pinned `document.hasFocus()` in the pre-existing background-sync backstop tests (jsdom does not reliably report focus).
- Added a regression test for the kanban idle-board WS disconnect path.

## Validation

| Check | Result |
|---|---|
| `pytest tests/hermes_cli/test_profiles_sidebar_cache.py tests/hermes_cli/test_profiles_sidebar_scope.py tests/hermes_cli/test_cron_profile_enumeration_lightweight.py tests/hermes_cli/test_web_server_pty_idle_backoff.py` | 18 passed |
| `pytest tests/plugins/test_kanban_dashboard_plugin.py tests/plugins/test_kanban_ws_idle_disconnect.py` | 26 passed |
| `apps/desktop: npx vitest run` (background-sync, status-snapshot, activity-timer) | 30 passed |
| `ui-tui: npx vitest run src/__tests__/petPolling.test.ts` | 5 passed |
| `ui-tui: npx tsc --noEmit` | clean |
| `scripts/audit_pr_attribution.py` | all emails mapped |

## Credits

- @alexdev03 — #81902 (desktop unfocused UI pause)
- @trismegisto639 — #77727 (sidebar polling bounds)
- @bananawalnut — #70311 (disabled pet cell polling)
- @Christopher-Schulze — #81755 (PTY pump idle back-off)
- @tugrulguner — #77884 (kanban WS zombie poll reaping)

## Issues

- Fixes #77833 (kanban zombie poll tasks)
- Related but **not** covered here: #83134 (reconnect storm), #85838 / #85935 (CPU spins) — none of the salvaged fixes addresses those mechanisms; #65003 (SSE poll→push) excluded as an architectural change.

## Infographic

![Idle & Polling CPU Fixes](https://files.catbox.moe/vggqeo.png)
