### PR TITLE
fix: purge resource-leak cluster — thread output FDs, browser daemons, pet image cache, Relay scope pop, session leases

### DIFF
--- a/agent/pet/generate/orchestrate.py
+++ b/agent/pet/generate/orchestrate.py
@@ -246,6 +246,7 @@ def hatch_pet(
             if cancelled():
                 return state, None
             strict = attempt < _ROW_GEN_ATTEMPTS - 1
+            strips: list[Path] = []
             try:
                 strips = imagegen.generate(
                     prompts.build_row_prompt(state, count, label, style=style),
@@ -274,6 +275,18 @@ def hatch_pet(
                     "pet hatch %r: row %r attempt %d/%d failed: %s",
                     slug, state, attempt + 1, _ROW_GEN_ATTEMPTS, exc,
                 )
+            finally:
+                # The strip is an intermediate. extract_strip_frames has already
+                # decoded its frames into memory, so drop the row image after
+                # every attempt (success or failure). Nothing prunes
+                # cache/images outside the gateway housekeeping loop, so a CLI
+                # or desktop hatch would otherwise leave each strip behind for
+                # good and grow the cache without bound.
+                for strip in strips:
+                    try:
+                        Path(strip).unlink(missing_ok=True)
+                    except OSError:
+                        pass
         logger.warning(
             "pet hatch %r: row %r gave up after %.1fs: %s",
             slug, state, time.monotonic() - t0, last_exc,

--- a/agent/pet/generate/orchestrate.py
+++ b/agent/pet/generate/orchestrate.py
@@ -71,8 +71,24 @@ def _harden_transparency(path: Path) -> Path:
         # Zero the RGB of any leftover semi-transparent edge pixels so a keyed
         # draft has no colored halo when composited on the dark UI.
         keyed = atlas._clear_transparent_rgb(keyed)
-        out = path.with_suffix(".png")
+        # PNG inputs are hardened in place, including mixed-case suffixes like
+        # .PNG. with_suffix(".png") would name a different Path string that still
+        # resolves to the same file on case-insensitive filesystems (macOS APFS,
+        # Windows), and unlinking path after save would delete the hardened output.
+        if path.suffix.lower() == ".png":
+            out = path
+        else:
+            out = path.with_suffix(".png")
         keyed.save(out, format="PNG")
+        if out != path:
+            # The hardened PNG stands in for the draft. When the provider handed
+            # back a non-PNG file (webp, jpg, gif), out is a different path, so
+            # remove the original instead of leaving it behind in cache/images
+            # (nothing prunes that directory outside the gateway loop).
+            try:
+                path.unlink(missing_ok=True)
+            except OSError:
+                pass
         return out
     except Exception as exc:  # noqa: BLE001 - cosmetic; fall back to the raw image
         logger.debug("base draft transparency hardening failed for %s: %s", path, exc)

--- a/agent/relay_llm.py
+++ b/agent/relay_llm.py
@@ -897,7 +897,8 @@ def _complete_logical(
                     output["response_model"] = response_model_name
             lease.host.run_in_session(
                 lease.session,
-                lease.host.relay.scope.pop,
+                relay_runtime.pop_relay_scope,
+                lease.host.relay,
                 handle,
                 output=output,
                 metadata={

--- a/agent/relay_runtime.py
+++ b/agent/relay_runtime.py
@@ -94,6 +94,40 @@ def _run_bounded_on_exit_thread(fn: Callable[[], Any], timeout: float) -> Any:
     return result[0] if result else None
 
 
+def pop_relay_scope(
+    relay: Any,
+    handle: Any,
+    *,
+    output: Any = None,
+    metadata: Any = None,
+    timestamp: Any = None,
+) -> Any:
+    """Pop a Relay scope without passing kwargs the binding rejects.
+
+    NeMo Relay ``scope.pop`` gained ``metadata`` in 0.4+. Older wheels (e.g.
+    0.3.x) raise ``TypeError: pop() got an unexpected keyword argument
+    'metadata'`` when Hermes finalization forwards runtime metadata. Filter to
+    parameters the live binding accepts so turn/session close can complete.
+    """
+    pop = relay.scope.pop
+    kwargs: dict[str, Any] = {}
+    if output is not None:
+        kwargs["output"] = output
+    if metadata is not None:
+        kwargs["metadata"] = metadata
+    if timestamp is not None:
+        kwargs["timestamp"] = timestamp
+    try:
+        params = inspect.signature(pop).parameters
+    except (TypeError, ValueError):
+        params = {}
+    if params and not any(
+        param.kind == inspect.Parameter.VAR_KEYWORD for param in params.values()
+    ):
+        kwargs = {key: value for key, value in kwargs.items() if key in params}
+    return pop(handle, **kwargs)
+
+
 @dataclass
 class RelaySession:
     """One isolated Relay scope stack owned by a Hermes session."""
@@ -609,7 +643,8 @@ class RelayRuntime:
                 return a_uuid is not None and a_uuid == b_uuid
 
             try:
-                self.relay.scope.pop(
+                pop_relay_scope(
+                    self.relay,
                     handle,
                     output=close_output,
                     metadata=metadata,
@@ -630,7 +665,8 @@ class RelayRuntime:
                 ):
                     break
                 try:
-                    self.relay.scope.pop(
+                    pop_relay_scope(
+                        self.relay,
                         top,
                         output={
                             "outcome": "cancelled",
@@ -654,7 +690,8 @@ class RelayRuntime:
                     handle,
                 )
             try:
-                self.relay.scope.pop(
+                pop_relay_scope(
+                    self.relay,
                     handle,
                     output=close_output,
                     metadata=metadata,

--- a/agent/thread_scoped_output.py
+++ b/agent/thread_scoped_output.py
@@ -30,6 +30,20 @@ _install_lock = threading.Lock()
 # Maps the proxy we installed for a given attribute ("stdout"/"stderr") so we
 # never double-wrap and so we can recover the original stream.
 _installed: dict[str, "_ThreadRoutingStream"] = {}
+# One process-lifetime sink per stream. Temporary process-global redirects can
+# displace and later restore a routing proxy; they must not allocate another
+# permanent /dev/null descriptor every time that happens.
+_sinks: dict[str, TextIO] = {}
+_routing_states: dict[str, "_RoutingState"] = {}
+
+
+class _RoutingState:
+    """Silencing registry shared by every proxy generation for one stream."""
+
+    def __init__(self, sink: TextIO) -> None:
+        self.sink = sink
+        self.silenced: dict[int, int] = {}
+        self.lock = threading.Lock()
 
 
 class _ThreadRoutingStream:
@@ -42,32 +56,27 @@ class _ThreadRoutingStream:
     ``.fileno()`` behave like the underlying stream for the calling thread.
     """
 
-    def __init__(self, passthrough: TextIO, sink: TextIO) -> None:
+    def __init__(self, passthrough: TextIO, state: _RoutingState) -> None:
         self._passthrough = passthrough
-        self._sink = sink
-        # ident -> nesting depth.  A thread is silenced while depth > 0, so
-        # nested ``thread_scoped_silence()`` on the same thread composes
-        # correctly (the inner exit decrements rather than fully clearing).
-        self._silenced: dict[int, int] = {}
-        self._lock = threading.Lock()
+        self._state = state
 
     def _target(self) -> TextIO:
-        if self._silenced.get(threading.get_ident(), 0) > 0:
-            return self._sink
+        if self._state.silenced.get(threading.get_ident(), 0) > 0:
+            return self._state.sink
         return self._passthrough
 
     # --- registration -----------------------------------------------------
     def silence(self, ident: int) -> None:
-        with self._lock:
-            self._silenced[ident] = self._silenced.get(ident, 0) + 1
+        with self._state.lock:
+            self._state.silenced[ident] = self._state.silenced.get(ident, 0) + 1
 
     def unsilence(self, ident: int) -> None:
-        with self._lock:
-            depth = self._silenced.get(ident, 0) - 1
+        with self._state.lock:
+            depth = self._state.silenced.get(ident, 0) - 1
             if depth > 0:
-                self._silenced[ident] = depth
+                self._state.silenced[ident] = depth
             else:
-                self._silenced.pop(ident, None)
+                self._state.silenced.pop(ident, None)
 
     # --- file-like surface ------------------------------------------------
     def write(self, data):  # type: ignore[no-untyped-def]
@@ -109,14 +118,28 @@ def _ensure_installed(attr: str, passthrough: TextIO) -> "_ThreadRoutingStream":
     with _install_lock:
         proxy = _installed.get(attr)
         current = getattr(sys, attr, None)
+        if isinstance(current, _ThreadRoutingStream):
+            # A redirect context can restore an older routing proxy after a
+            # temporary replacement. Adopt it instead of wrapping it and
+            # growing an unbounded proxy chain.
+            _installed[attr] = current
+            _routing_states[attr] = current._state
+            return current
         if proxy is not None and current is proxy:
             return proxy
         # Capture whatever is currently bound as the passthrough. If a prior
         # global redirect_stdout is active, route non-silenced threads to that
         # stream to preserve the old behavior.
         passthrough = current if current is not None else passthrough
-        sink = open(os.devnull, "w", encoding="utf-8")
-        proxy = _ThreadRoutingStream(passthrough, sink)
+        sink = _sinks.get(attr)
+        if sink is None or sink.closed:
+            sink = open(os.devnull, "w", encoding="utf-8")
+            _sinks[attr] = sink
+        state = _routing_states.get(attr)
+        if state is None or state.sink is not sink:
+            state = _RoutingState(sink)
+            _routing_states[attr] = state
+        proxy = _ThreadRoutingStream(passthrough, state)
         setattr(sys, attr, proxy)
         _installed[attr] = proxy
         return proxy

--- a/contributors/emails/andy@andydeMac-mini-2.local
+++ b/contributors/emails/andy@andydeMac-mini-2.local
@@ -1,0 +1,1 @@
+Hangzian

--- a/hermes_cli/active_sessions.py
+++ b/hermes_cli/active_sessions.py
@@ -261,6 +261,14 @@ class ActiveSessionLease:
     surface: str
     enabled: bool = True
     released: bool = False
+    # Registry paths pinned at acquisition time. A lease acquired under the
+    # root ``HERMES_HOME`` must release against the same registry even when
+    # ``release()`` runs inside a profile home override (native multiplex
+    # routes turns under ``_profile_runtime_scope``), otherwise the root
+    # entry survives until process exit and the session cap fills with
+    # phantom leases (#85431).
+    state_path: Optional[Path] = None
+    lock_path: Optional[Path] = None
 
     def release(self) -> None:
         if self.released or not self.enabled:
@@ -331,13 +339,18 @@ def try_acquire_active_session(
         lease_id=lease_id,
         session_id=str(session_id),
         surface=str(surface),
+        state_path=state_path,
+        lock_path=_lock_path(),
     ), None
 
 
 def release_active_session(lease: ActiveSessionLease) -> None:
-    state_path = _state_path()
+    # Prefer the registry the lease was acquired against: the caller may be
+    # running under a profile HERMES_HOME override (#85431).
+    state_path = lease.state_path or _state_path()
+    lock_path = lease.lock_path or _lock_path()
     try:
-        with _FileLock(_lock_path()):
+        with _FileLock(lock_path):
             entries = _prune_dead(_read_entries(state_path))
             kept = [
                 entry
@@ -366,8 +379,9 @@ def transfer_active_session(
         lease.session_id = new_session_id
         return True
 
-    state_path = _state_path()
-    with _FileLock(_lock_path()):
+    state_path = lease.state_path or _state_path()
+    lock_path = lease.lock_path or _lock_path()
+    with _FileLock(lock_path):
         entries = _prune_dead(_read_entries(state_path))
         updated = False
         for entry in entries:

--- a/hermes_cli/observability/relay_shared_metrics.py
+++ b/hermes_cli/observability/relay_shared_metrics.py
@@ -1026,7 +1026,8 @@ class _Runtime:
         try:
             self._run_in_task(
                 task,
-                self.relay.scope.pop,
+                relay_runtime.pop_relay_scope,
+                self.relay,
                 task.handle,
                 output=fields,
                 metadata=self._event_metadata(),

--- a/tests/agent/test_pet_generate.py
+++ b/tests/agent/test_pet_generate.py
@@ -231,6 +231,55 @@ def test_generate_base_drafts_hardens_opaque_background(monkeypatch, tmp_path):
     assert rgba.getpixel((rgba.width // 2, rgba.height // 2))[3] > 0
 
 
+def test_harden_transparency_removes_non_png_original(tmp_path):
+    """A non-PNG base draft is replaced by a hardened PNG, and the original
+    draft file is not left behind in the image cache."""
+    from agent.pet.generate import orchestrate
+
+    src = tmp_path / "pet_base_sample.webp"
+    _strip(1).save(src, format="WEBP")
+
+    out = orchestrate._harden_transparency(src)
+
+    assert out.suffix == ".png"
+    assert out.exists()
+    assert not src.exists()
+
+
+def test_harden_transparency_keeps_png_input_in_place(tmp_path):
+    """A PNG base draft is hardened in place, so the returned path is the input
+    path and there is no separate original to remove."""
+    from agent.pet.generate import orchestrate
+
+    src = tmp_path / "pet_base_sample.png"
+    _strip(1).save(src, format="PNG")
+
+    out = orchestrate._harden_transparency(src)
+
+    assert out == src
+    assert out.exists()
+
+
+def test_harden_transparency_keeps_mixed_case_png_in_place(tmp_path):
+    """A PNG path with a mixed-case suffix is hardened in place.
+
+    path.with_suffix('.png') yields a different Path string than 'pet.PNG', but
+    on case-insensitive filesystems (macOS APFS, Windows) both resolve to the
+    same file. Unlinking the input after save would delete the hardened output.
+    """
+    from agent.pet.generate import orchestrate
+
+    src = tmp_path / "pet_base_sample.PNG"
+    _strip(1).save(src, format="PNG")
+
+    out = orchestrate._harden_transparency(src)
+
+    assert out == src
+    assert out.suffix == ".PNG"
+    assert out.exists()
+    assert src.exists()
+
+
 def test_hatch_pet_end_to_end(monkeypatch, tmp_path):
     from agent.pet import store
     from agent.pet.generate import atlas as atlas_mod

--- a/tests/agent/test_pet_generate.py
+++ b/tests/agent/test_pet_generate.py
@@ -8,6 +8,7 @@ exercised hermetically.
 from __future__ import annotations
 
 import os
+from pathlib import Path
 
 import pytest
 
@@ -267,6 +268,96 @@ def test_hatch_pet_end_to_end(monkeypatch, tmp_path):
     assert store.load_pet("mocky").exists
 
 
+def test_hatch_pet_removes_row_strips_after_extraction(monkeypatch, tmp_path):
+    """Row strips are intermediates. Once their frames are decoded, the strip
+    files are removed so the image cache does not grow on every hatch (nothing
+    prunes cache/images outside the gateway housekeeping loop)."""
+    from agent.pet.generate import atlas as atlas_mod
+    from agent.pet.generate import imagegen, orchestrate
+
+    base = tmp_path / "base.png"
+    _strip(1).save(base)
+
+    produced: list = []
+
+    def fake_generate(prompt, *, n=1, reference_images=None, provider=None, prefix="pet", aspect_ratio="square"):
+        state = prefix.replace("pet_row_", "")
+        count = atlas_mod.FRAME_COUNTS.get(state, 6)
+        p = tmp_path / f"{prefix}.png"
+        _strip(count).save(p)
+        produced.append(p)
+        return [p]
+
+    monkeypatch.setattr(imagegen, "resolve_provider", lambda **_: object())
+    monkeypatch.setattr(imagegen, "generate", fake_generate)
+
+    orchestrate.hatch_pet(base_image=base, slug="cleanup", concept="a fox")
+
+    assert produced, "expected row strips to be generated"
+    leftover = [p for p in produced if p.exists()]
+    assert leftover == [], f"row strips left in cache: {leftover}"
+
+
+def test_hatch_pet_removes_row_strips_after_failed_attempt(monkeypatch, tmp_path):
+    from agent.pet.generate import atlas as atlas_mod
+    from agent.pet.generate import imagegen, orchestrate
+
+    base = tmp_path / "base.png"
+    _strip(1).save(base)
+
+    attempts: dict[str, int] = {}
+
+    def fake_generate(prompt, *, n=1, reference_images=None, provider=None, prefix="pet", aspect_ratio="square"):
+        attempts[prefix] = attempts.get(prefix, 0) + 1
+        state = prefix.replace("pet_row_", "")
+        count = atlas_mod.FRAME_COUNTS.get(state, 6)
+        path = tmp_path / f"{prefix}_{attempts[prefix]}.png"
+        _strip(count).save(path)
+        return [path]
+
+    extract_strip_frames = atlas_mod.extract_strip_frames
+    failed_once = False
+
+    def flaky_extract(strip, count, *args, **kwargs):
+        nonlocal failed_once
+        if Path(strip).name.startswith("pet_row_idle_") and not failed_once:
+            failed_once = True
+            raise ValueError("retry idle row")
+        return extract_strip_frames(strip, count, *args, **kwargs)
+
+    monkeypatch.setattr(imagegen, "resolve_provider", lambda **_: object())
+    monkeypatch.setattr(imagegen, "generate", fake_generate)
+    monkeypatch.setattr(atlas_mod, "extract_strip_frames", flaky_extract)
+
+    orchestrate.hatch_pet(base_image=base, slug="retry-cleanup", concept="a fox")
+
+    assert failed_once
+    assert attempts["pet_row_idle"] == 2
+    assert not list(tmp_path.glob("pet_row_*"))
+
+
+def test_hatch_pet_idle_fallback_when_row_fails(monkeypatch, tmp_path):
+    from agent.pet.generate import atlas as atlas_mod
+    from agent.pet.generate import imagegen, orchestrate
+    from agent.pet.generate.imagegen import GenerationError
+
+    base = tmp_path / "base.png"
+    _strip(1).save(base)
+
+    def fake_generate(prompt, *, n=1, reference_images=None, provider=None, prefix="pet", aspect_ratio="square"):
+        if prefix == "pet_row_idle":
+            raise GenerationError("boom")
+        state = prefix.replace("pet_row_", "")
+        count = atlas_mod.FRAME_COUNTS.get(state, 6)
+        p = tmp_path / f"{prefix}.png"
+        _strip(count).save(p)
+        return [p]
+
+    monkeypatch.setattr(imagegen, "resolve_provider", lambda **_: object())
+    monkeypatch.setattr(imagegen, "generate", fake_generate)
+
+    result = orchestrate.hatch_pet(base_image=base, slug="fallbacky", concept="a fox")
+    assert "idle" in result.states  # filled by the base-image fallback
 
 
 

--- a/tests/agent/test_relay_scope_pop_metadata.py
+++ b/tests/agent/test_relay_scope_pop_metadata.py
@@ -1,0 +1,121 @@
+"""Regression for #78993: scope.pop metadata kwarg on older NeMo Relay."""
+
+from __future__ import annotations
+
+import inspect
+import logging
+import tempfile
+from types import SimpleNamespace
+
+import pytest
+
+from agent import relay_runtime
+
+
+def test_pop_relay_scope_omits_unsupported_metadata_kwarg():
+    calls: list[tuple[object, dict]] = []
+
+    def pop_without_metadata(handle, *, output=None):
+        calls.append((handle, {"output": output}))
+
+    relay = SimpleNamespace(scope=SimpleNamespace(pop=pop_without_metadata))
+    handle = ("scope", "hermes.turn", 1)
+
+    relay_runtime.pop_relay_scope(
+        relay,
+        handle,
+        output={"outcome": "success"},
+        metadata={"hermes.relay.schema_version": "hermes.relay.runtime.v1"},
+    )
+
+    assert calls == [(handle, {"output": {"outcome": "success"}})]
+
+
+def test_pop_relay_scope_forwards_metadata_when_supported():
+    calls: list[tuple[object, dict]] = []
+
+    def pop_with_metadata(handle, *, output=None, metadata=None, timestamp=None):
+        calls.append(
+            (
+                handle,
+                {
+                    "output": output,
+                    "metadata": metadata,
+                    "timestamp": timestamp,
+                },
+            )
+        )
+
+    relay = SimpleNamespace(scope=SimpleNamespace(pop=pop_with_metadata))
+    handle = ("scope", "hermes.turn", 2)
+    metadata = {"hermes.relay.runtime_instance": "abc"}
+
+    relay_runtime.pop_relay_scope(
+        relay,
+        handle,
+        output={"outcome": "error"},
+        metadata=metadata,
+    )
+
+    assert calls == [
+        (
+            handle,
+            {
+                "output": {"outcome": "error"},
+                "metadata": metadata,
+                "timestamp": None,
+            },
+        )
+    ]
+
+
+def test_end_turn_finalization_survives_pop_without_metadata(monkeypatch, caplog):
+    """Mirror #78993: nemo-relay 0.3.x rejects metadata= on scope.pop."""
+    pytest.importorskip("nemo_relay")
+
+    monkeypatch.setenv("HERMES_HOME", tempfile.mkdtemp())
+    relay_runtime._reset_for_tests()
+    lease = relay_runtime.SESSION_COORDINATOR.acquire_conversation(
+        profile_key=relay_runtime.current_profile_key(),
+        session_id="session-78993",
+        platform="cli",
+    )
+    turn = relay_runtime.SESSION_COORDINATOR.begin_turn(
+        lease,
+        turn_id="turn-1",
+        task_id="task-1",
+    )
+    lease.host.retain_managed_execution("test.relay_scope_pop")
+
+    original_pop = lease.host.relay.scope.pop
+    assert "metadata" in inspect.signature(original_pop).parameters
+
+    def pop_without_metadata(handle, *, output=None, timestamp=None):
+        return original_pop(handle, output=output, timestamp=timestamp)
+
+    monkeypatch.setattr(lease.host.relay.scope, "pop", pop_without_metadata)
+
+    logical = lease.host.run_in_session(
+        lease.session,
+        lease.host.relay.scope.push,
+        "logical-llm",
+        lease.host.relay.ScopeType.Custom,
+        handle=turn.handle,
+        input={},
+        metadata={"hermes.test": True},
+    )
+    turn.logical_llm_calls["api-1"] = logical
+
+    with caplog.at_level(logging.WARNING, logger="agent.relay_runtime"):
+        relay_runtime.SESSION_COORDINATOR.end_turn(turn, outcome="success")
+
+    joined = "\n".join(record.getMessage() for record in caplog.records)
+    assert "unexpected keyword argument 'metadata'" not in joined
+    assert "turn finalization failed" not in joined
+    assert "logical LLM finalization failed" not in joined
+    assert turn.logical_llm_calls == {}
+    assert turn.closed is True
+
+    lease.host.release_managed_execution("test.relay_scope_pop")
+    relay_runtime.SESSION_COORDINATOR.release_conversation(lease)
+    relay_runtime._reset_for_tests()

--- a/tests/agent/test_thread_scoped_output.py
+++ b/tests/agent/test_thread_scoped_output.py
@@ -7,11 +7,13 @@ context.  This is the property the old process-global
 ``contextlib.redirect_stdout(devnull)`` violated (issue #55769 / #55925).
 """
 
+import contextlib
 import io
 import sys
 import threading
 import time
 
+import agent.thread_scoped_output as thread_output
 from agent.thread_scoped_output import thread_scoped_silence
 
 
@@ -94,3 +96,73 @@ def test_repeated_contexts_never_write_to_a_closed_sink():
             sys.stdout.fileno()
     finally:
         sys.stdout = original
+
+
+def test_temporary_global_redirects_do_not_allocate_new_sinks(monkeypatch):
+    """A displaced proxy is temporary, not a reason to leak another FD pair."""
+    opened_sinks = []
+
+    def fake_open(*_args, **_kwargs):
+        sink = io.StringIO()
+        opened_sinks.append(sink)
+        return sink
+
+    monkeypatch.setattr(thread_output, "_installed", {})
+    monkeypatch.setattr(thread_output, "_sinks", {}, raising=False)
+    monkeypatch.setattr(thread_output, "open", fake_open, raising=False)
+    original_stdout, original_stderr = sys.stdout, sys.stderr
+    sys.stdout, sys.stderr = io.StringIO(), io.StringIO()
+    try:
+        with thread_scoped_silence():
+            pass
+        assert len(opened_sinks) == 2
+        original_proxies = dict(thread_output._installed)
+
+        for _ in range(20):
+            with contextlib.redirect_stdout(io.StringIO()), contextlib.redirect_stderr(io.StringIO()):
+                with thread_scoped_silence():
+                    print("hidden")
+
+        with thread_scoped_silence():
+            pass
+        assert len(opened_sinks) == 2
+        assert thread_output._installed == original_proxies
+    finally:
+        sys.stdout, sys.stderr = original_stdout, original_stderr
+
+
+def test_silence_survives_redirect_restoring_an_older_proxy(monkeypatch):
+    """Silencing is stream-wide, even when a redirect swaps proxy generations."""
+    monkeypatch.setattr(thread_output, "_installed", {})
+    monkeypatch.setattr(thread_output, "_sinks", {}, raising=False)
+    original_stdout, original_stderr = sys.stdout, sys.stderr
+    passthrough = io.StringIO()
+    sys.stdout = passthrough
+    entered = threading.Event()
+    release = threading.Event()
+
+    try:
+        with thread_scoped_silence():
+            pass
+
+        def worker():
+            with thread_scoped_silence():
+                entered.set()
+                assert release.wait(timeout=10)
+                print("must-stay-silenced")
+
+        redirected = io.StringIO()
+        with contextlib.redirect_stdout(redirected):
+            thread = threading.Thread(target=worker)
+            thread.start()
+            assert entered.wait(timeout=10)
+
+        release.set()
+        thread.join(timeout=10)
+
+        assert not thread.is_alive()
+        assert "must-stay-silenced" not in passthrough.getvalue()
+        assert "must-stay-silenced" not in redirected.getvalue()
+    finally:
+        release.set()
+        sys.stdout, sys.stderr = original_stdout, original_stderr

--- a/tests/hermes_cli/test_active_sessions.py
+++ b/tests/hermes_cli/test_active_sessions.py
@@ -167,3 +167,76 @@ def test_release_orphaned_leases_reclaims_only_unowned_own_pid_entries(tmp_path,
         for entry in active_sessions.active_session_registry_snapshot()
     ) == ["kept", "other"]
     assert orphan is not None
+
+
+def test_release_under_profile_home_override_targets_acquisition_registry(
+    tmp_path, monkeypatch
+):
+    """Regression for #85431: a lease acquired against the root HERMES_HOME
+    must release from the root registry even when ``release()`` runs inside a
+    profile home override (native multiplex runs agent cleanup under
+    ``_profile_runtime_scope``). Before the fix the root entry survived and
+    the session cap filled with phantom leases."""
+    from hermes_constants import (
+        reset_hermes_home_override,
+        set_hermes_home_override,
+    )
+
+    root = tmp_path / "hermes"
+    profile = root / "profiles" / "worker"
+    profile.mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(root))
+
+    lease, error = active_sessions.try_acquire_active_session(
+        session_id="agent:worker:telegram:dm:synthetic",
+        surface="gateway:telegram",
+        config={"max_concurrent_sessions": 2},
+    )
+    assert lease is not None and error is None
+    root_registry = root / "runtime" / "active_sessions.json"
+    assert root_registry.exists()
+
+    token = set_hermes_home_override(str(profile))
+    try:
+        lease.release()
+    finally:
+        reset_hermes_home_override(token)
+
+    assert lease.released is True
+    remaining = active_sessions._read_entries(root_registry)
+    assert remaining == []
+    # No phantom registry created under the profile home.
+    assert not (profile / "runtime" / "active_sessions.json").exists()
+
+
+def test_transfer_under_profile_home_override_targets_acquisition_registry(
+    tmp_path, monkeypatch
+):
+    """Sibling site of #85431: transfer must also update the registry the
+    lease was acquired against, not one resolved from the current override."""
+    from hermes_constants import (
+        reset_hermes_home_override,
+        set_hermes_home_override,
+    )
+
+    root = tmp_path / "hermes"
+    profile = root / "profiles" / "worker"
+    profile.mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(root))
+
+    lease, error = active_sessions.try_acquire_active_session(
+        session_id="before",
+        surface="gateway:telegram",
+        config={"max_concurrent_sessions": 2},
+    )
+    assert lease is not None and error is None
+
+    token = set_hermes_home_override(str(profile))
+    try:
+        assert active_sessions.transfer_active_session(lease, session_id="after")
+    finally:
+        reset_hermes_home_override(token)
+
+    root_registry = root / "runtime" / "active_sessions.json"
+    entries = active_sessions._read_entries(root_registry)
+    assert [entry["session_id"] for entry in entries] == ["after"]

--- a/tests/tools/test_browser_orphan_reaper.py
+++ b/tests/tools/test_browser_orphan_reaper.py
@@ -2,6 +2,7 @@
 daemons whose Python parent exited without cleaning up."""
 
 import os
+import time
 from unittest.mock import patch
 
 import pytest
@@ -355,3 +356,211 @@ class TestEmergencyCleanupRunsReaper:
         assert reaper_called, (
             "Reaper must run on exit even with no active sessions"
         )
+
+
+def _age_socket_dir(d, seconds):
+    """Backdate every mtime under ``d`` so it looks idle for ``seconds``."""
+    old = time.time() - seconds
+    for p in d.iterdir():
+        os.utime(p, (old, old))
+    os.utime(d, (old, old))
+
+
+class TestSocketDirIdleSeconds:
+    """Unit tests for the idle-age signal backing the leak escape hatch."""
+
+    def test_missing_dir_returns_none(self, tmp_path):
+        from tools.browser_tool import _socket_dir_idle_seconds
+        assert _socket_dir_idle_seconds(str(tmp_path / "nope")) is None
+
+    def test_fresh_dir_is_near_zero(self, tmp_path):
+        from tools.browser_tool import _socket_dir_idle_seconds
+        d = tmp_path / "agent-browser-h_fresh"
+        d.mkdir()
+        assert _socket_dir_idle_seconds(str(d)) < 5
+
+    def test_entry_mtime_beats_stale_dir_mtime(self, tmp_path):
+        """Rewriting an existing file must count as activity.
+
+        Command names repeat (``_stdout_click`` is rewritten on every click),
+        and overwriting an existing file does NOT bump the *directory* mtime.
+        Reading only the directory mtime would therefore report a busy session
+        as idle and reap it.  The reaper must scan entries too.
+        """
+        from tools.browser_tool import _socket_dir_idle_seconds
+        d = tmp_path / "agent-browser-h_reuse"
+        d.mkdir()
+        f = d / "_stdout_click"
+        f.write_text("x")
+        _age_socket_dir(d, 7200)
+        assert _socket_dir_idle_seconds(str(d)) > 7000
+
+        f.write_text("y")  # rewrite in place — dir mtime stays stale
+        assert time.time() - os.path.getmtime(d) > 7000, "precondition"
+        assert _socket_dir_idle_seconds(str(d)) < 5
+
+
+class TestLeakedDaemonWithLiveOwner:
+    """Idle-age escape hatch for untracked daemons whose owner is still alive.
+
+    ``owner_alive is True`` alone made a leaked daemon immortal: in-memory
+    tracking is lost on any exception path between spawn and registration,
+    yet the owner PID stays up, so the reaper skipped it forever.  Observed in
+    the wild — five agent-browser daemons accumulated over 10 days inside one
+    long-lived hermes process, pinning ~5 CPU cores and driving load to 100+.
+
+    The daemon-side ``AGENT_BROWSER_IDLE_TIMEOUT_MS`` is not a backstop here:
+    it does not fire when the daemon itself is wedged (e.g. Chrome's framework
+    was replaced underneath it by an auto-update).
+    """
+
+    def test_fresh_untracked_daemon_with_live_owner_is_spared(self, fake_tmpdir):
+        """Within the grace window, cross-process safety still wins."""
+        from tools.browser_tool import _reap_orphaned_browser_sessions
+
+        d = _make_socket_dir(
+            fake_tmpdir, "h_fresh_owner", pid=12345, owner_pid=os.getpid()
+        )
+        kill_calls = []
+
+        with patch("gateway.status._pid_exists", return_value=True), \
+             patch("tools.browser_tool._verify_reapable_browser_daemon", return_value=True), \
+             patch("tools.process_registry.ProcessRegistry._terminate_host_pid",
+                   side_effect=kill_calls.append):
+            _reap_orphaned_browser_sessions()
+
+        assert 12345 not in kill_calls
+        assert d.exists()
+
+    def test_idle_untracked_daemon_with_live_owner_is_reaped(self, fake_tmpdir):
+        """Past the grace window, an untracked daemon is treated as leaked."""
+        from tools.browser_tool import (
+            BROWSER_ORPHAN_GRACE_SECONDS,
+            _reap_orphaned_browser_sessions,
+        )
+
+        d = _make_socket_dir(
+            fake_tmpdir, "h_leaked_owner", pid=12345, owner_pid=os.getpid()
+        )
+        _age_socket_dir(d, BROWSER_ORPHAN_GRACE_SECONDS + 600)
+        kill_calls = []
+
+        with patch("gateway.status._pid_exists", return_value=True), \
+             patch("tools.browser_tool._verify_reapable_browser_daemon", return_value=True), \
+             patch("tools.process_registry.ProcessRegistry._terminate_host_pid",
+                   side_effect=kill_calls.append):
+            _reap_orphaned_browser_sessions()
+
+        assert 12345 in kill_calls
+        assert not d.exists()
+
+    def test_tracked_daemon_with_live_owner_is_spared_at_any_age(self, fake_tmpdir):
+        """A session this process still tracks is never reaped, however old.
+
+        Idle age is a fallback for *lost* bookkeeping, not an override of
+        bookkeeping that is present and says the session is live.
+        """
+        import tools.browser_tool as bt
+        from tools.browser_tool import (
+            BROWSER_ORPHAN_GRACE_SECONDS,
+            _reap_orphaned_browser_sessions,
+        )
+
+        d = _make_socket_dir(
+            fake_tmpdir, "h_tracked_old", pid=12345, owner_pid=os.getpid()
+        )
+        _age_socket_dir(d, BROWSER_ORPHAN_GRACE_SECONDS * 10)
+        bt._active_sessions["task-1"] = {"session_name": "h_tracked_old"}
+        kill_calls = []
+
+        with patch("gateway.status._pid_exists", return_value=True), \
+             patch("tools.browser_tool._verify_reapable_browser_daemon", return_value=True), \
+             patch("tools.process_registry.ProcessRegistry._terminate_host_pid",
+                   side_effect=kill_calls.append):
+            _reap_orphaned_browser_sessions()
+
+        assert 12345 not in kill_calls
+        assert d.exists()
+
+    def test_unknown_idle_age_fails_safe(self, fake_tmpdir):
+        """Unreadable mtime => treat as too young to reap, never guess."""
+        from tools.browser_tool import _reap_orphaned_browser_sessions
+
+        d = _make_socket_dir(
+            fake_tmpdir, "h_unknown_age", pid=12345, owner_pid=os.getpid()
+        )
+        kill_calls = []
+
+        with patch("gateway.status._pid_exists", return_value=True), \
+             patch("tools.browser_tool._socket_dir_idle_seconds", return_value=None), \
+             patch("tools.browser_tool._verify_reapable_browser_daemon", return_value=True), \
+             patch("tools.process_registry.ProcessRegistry._terminate_host_pid",
+                   side_effect=kill_calls.append):
+            _reap_orphaned_browser_sessions()
+
+        assert 12345 not in kill_calls
+        assert d.exists()
+
+    def test_identity_guard_still_gates_the_new_path(self, fake_tmpdir):
+        """The escape hatch must not bypass _verify_reapable_browser_daemon.
+
+        That guard is the anti-spoof / anti-PID-recycle defense (issue #14073);
+        an idle daemon is still only reapable if it verifies.
+        """
+        from tools.browser_tool import (
+            BROWSER_ORPHAN_GRACE_SECONDS,
+            _reap_orphaned_browser_sessions,
+        )
+
+        d = _make_socket_dir(
+            fake_tmpdir, "h_unverified", pid=12345, owner_pid=os.getpid()
+        )
+        _age_socket_dir(d, BROWSER_ORPHAN_GRACE_SECONDS + 600)
+        kill_calls = []
+
+        with patch("gateway.status._pid_exists", return_value=True), \
+             patch("tools.browser_tool._verify_reapable_browser_daemon", return_value=False), \
+             patch("tools.process_registry.ProcessRegistry._terminate_host_pid",
+                   side_effect=kill_calls.append):
+            _reap_orphaned_browser_sessions()
+
+        assert 12345 not in kill_calls
+        assert d.exists()
+
+
+class TestPeriodicOrphanReap:
+    """The reaper must run repeatedly, not only at cleanup-thread startup.
+
+    A startup-only reap can never recover from a leak that appears *after*
+    boot — which is exactly what happens in a hermes process that stays up
+    for days.
+    """
+
+    def test_reaper_runs_on_every_interval_not_just_startup(self):
+        import tools.browser_tool as bt
+
+        cycles_to_run = 21
+        reap_calls = []
+        remaining = {"n": cycles_to_run}
+
+        def fake_cleanup():
+            remaining["n"] -= 1
+            if remaining["n"] <= 0:
+                bt._cleanup_running = False
+
+        orig_running = bt._cleanup_running
+        bt._cleanup_running = True
+        try:
+            with patch("tools.browser_tool._reap_orphaned_browser_sessions",
+                       side_effect=lambda: reap_calls.append(1)), \
+                 patch("tools.browser_tool._cleanup_inactive_browser_sessions",
+                       side_effect=fake_cleanup), \
+                 patch("tools.browser_tool.time.sleep"):
+                bt._browser_cleanup_thread_worker()
+        finally:
+            bt._cleanup_running = orig_running
+
+        every = max(1, round(bt.BROWSER_ORPHAN_REAP_INTERVAL / 30))
+        expected = len([c for c in range(cycles_to_run) if c % every == 0])
+        assert len(reap_calls) == expected
+        assert len(reap_calls) > 1, "startup-only reap would give exactly 1"

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -1642,6 +1642,22 @@ def _get_session_inactivity_timeout() -> int:
 
 BROWSER_SESSION_INACTIVITY_TIMEOUT = _get_session_inactivity_timeout()
 
+# How often the cleanup thread re-runs the orphan reaper.  The reaper used to
+# run exactly once, before the cleanup loop started, which meant a hermes
+# process that stays up for days could never recover from a leak that appeared
+# *after* boot.  Observed in the wild: five agent-browser daemons accumulated
+# over 10 days in a single 18-day-uptime process, pinning ~5 CPU cores.
+BROWSER_ORPHAN_REAP_INTERVAL = 300  # seconds
+
+# Hard ceiling for a daemon whose owning hermes process is still alive but
+# which has fallen out of that process's in-memory session tracking.  The
+# owner-alive check alone makes such a daemon immortal: in-memory tracking is
+# lost on any exception path, yet the owner PID stays up, so the reaper skips
+# it forever.  Idle age (see ``_socket_dir_idle_seconds``) is the escape hatch.
+# Deliberately a large multiple of the inactivity timeout so a legitimately
+# busy session is never touched.
+BROWSER_ORPHAN_GRACE_SECONDS = max(3600, BROWSER_SESSION_INACTIVITY_TIMEOUT * 20)
+
 # Track last activity time per session
 _session_last_activity: Dict[str, float] = {}
 
@@ -1872,6 +1888,40 @@ def _verify_reapable_browser_daemon(daemon_pid: int, socket_dir: str,
     return True
 
 
+def _socket_dir_idle_seconds(socket_dir: str) -> Optional[float]:
+    """Seconds since anything in ``socket_dir`` was last written.
+
+    Every browser command writes ``_stdout_<cmd>`` / ``_stderr_<cmd>`` temp
+    files into the session's socket dir, so the newest mtime under that dir is
+    a last-activity marker that — unlike ``_session_last_activity`` — survives
+    hermes restarts and does not depend on in-memory bookkeeping surviving an
+    exception path.
+
+    The directory's own mtime is not sufficient: command names repeat, so
+    rewriting an existing ``_stdout_click`` updates that file's mtime but not
+    the directory's.  Scan the entries too.
+
+    Returns ``None`` when the age cannot be determined, so callers can fail
+    safe (treat unknown age as "too young to reap").
+    """
+    try:
+        latest = os.path.getmtime(socket_dir)
+    except OSError:
+        return None
+
+    try:
+        with os.scandir(socket_dir) as entries:
+            for entry in entries:
+                try:
+                    latest = max(latest, entry.stat().st_mtime)
+                except OSError:
+                    continue
+    except OSError:
+        pass  # dir mtime alone is still a usable lower bound
+
+    return max(0.0, time.time() - latest)
+
+
 def _reap_orphaned_browser_sessions():
     """Scan for orphaned agent-browser daemon processes from previous runs.
 
@@ -1926,6 +1976,7 @@ def _reap_orphaned_browser_sessions():
 
         # Ownership check: prefer owner_pid file (cross-process safe).
         owner_pid_file = os.path.join(socket_dir, f"{session_name}.owner_pid")
+        owner_pid: Optional[int] = None
         owner_alive: Optional[bool] = None  # None = owner_pid missing/unreadable
         if os.path.isfile(owner_pid_file):
             try:
@@ -1935,11 +1986,34 @@ def _reap_orphaned_browser_sessions():
                 from gateway.status import _pid_exists
                 owner_alive = _pid_exists(owner_pid)
             except (ValueError, OSError):
+                owner_pid = None
                 owner_alive = None  # corrupt file — fall through
 
         if owner_alive is True:
-            # Owner is alive — this session belongs to a live hermes process.
-            continue
+            # Owner is alive.  Normally that means the session belongs to a
+            # live hermes process and must not be touched — but "owner alive"
+            # alone made leaked daemons immortal: if the owner lost its
+            # in-memory tracking (any exception path between spawn and
+            # registration), nothing would ever reap the daemon, and the
+            # daemon-side AGENT_BROWSER_IDLE_TIMEOUT_MS does not fire when the
+            # daemon itself is wedged (e.g. Chrome's framework was swapped out
+            # from under it by an auto-update).
+            #
+            # So: still trust live tracking, but fall back to idle age.
+            if session_name in tracked_names:
+                continue
+
+            idle_s = _socket_dir_idle_seconds(socket_dir)
+            if idle_s is None or idle_s < BROWSER_ORPHAN_GRACE_SECONDS:
+                # Unknown age, or still within the grace window — fail safe.
+                continue
+
+            logger.warning(
+                "Browser session %s has a live owner (PID %s) but is untracked "
+                "and idle for %ds (grace %ds) — treating as leaked and reaping",
+                session_name, owner_pid, int(idle_s),
+                BROWSER_ORPHAN_GRACE_SECONDS)
+            # fall through to the reap path below
 
         if owner_alive is None:
             # No owner_pid file (legacy daemon).  Fall back to in-process
@@ -2003,15 +2077,26 @@ def _browser_cleanup_thread_worker():
 
     Runs every 30 seconds and checks for sessions that haven't been used
     within the BROWSER_SESSION_INACTIVITY_TIMEOUT period.
-    On first run, also reaps orphaned sessions from previous process lifetimes.
+
+    Also reaps orphaned daemons — on startup (sessions left by previous
+    process lifetimes) *and* every BROWSER_ORPHAN_REAP_INTERVAL seconds
+    thereafter.  The periodic pass matters because a leak is not only a
+    across-restart phenomenon: a daemon can fall out of in-memory tracking
+    at any point in a long-lived process, and a startup-only reap can never
+    recover from that.
     """
-    # One-time orphan reap on startup
-    try:
-        _reap_orphaned_browser_sessions()
-    except Exception as e:
-        logger.warning("Orphan reap error: %s", e)
+    reap_every_cycles = max(1, round(BROWSER_ORPHAN_REAP_INTERVAL / 30))
+    cycle = 0
 
     while _cleanup_running:
+        # cycle 0 is the startup reap; then every reap_every_cycles.
+        if cycle % reap_every_cycles == 0:
+            try:
+                _reap_orphaned_browser_sessions()
+            except Exception as e:
+                logger.warning("Orphan reap error: %s", e)
+        cycle += 1
+
         try:
             _cleanup_inactive_browser_sessions()
         except Exception as e:


### PR DESCRIPTION
Purges five independent resource leaks — thread output descriptors, immortal browser daemons, pet image-cache intermediates, Relay scope-pop finalization failures, and phantom active-session leases — in one salvage PR with regression tests for every cleanup path.

## Changes

- **Thread output descriptor leak** (`agent/thread_scoped_output.py`) — from #81753 by @Reksely. After #80770 made sinks persistent, each `redirect_stdout`/`redirect_stderr` displacement caused the next `thread_scoped_silence()` to open another permanent `/dev/null` sink pair and wrap the old proxy (observed: 56 leaked FDs / 28 generations on a live macOS gateway hitting the launchd 256-FD ceiling). Now one process-lifetime sink per stream is reused, restored routing proxies are adopted instead of chained, and silencing state is shared across proxy generations.
- **Leaked browser daemons** (`tools/browser_tool.py`) — from #82145 by @Hangzian. The orphan reaper ran exactly once at startup and unconditionally skipped daemons whose owner PID was alive, so a daemon whose in-memory tracking was lost (exception between spawn and registration) was immortal (observed: 5 daemons / 96 Chrome processes / load average >100). The reaper now runs every 300s inside the cleanup loop, and untracked daemons with a live owner are reaped past an idle grace period (`max(1h, 20× inactivity timeout)`) measured from socket-dir entry mtimes; tracked sessions are never reaped and unknown age fails safe.
- **Pet image cache leak** (`agent/pet/generate/orchestrate.py`) — from #52603 by @Adolanium. `_gen_row` never deleted row strips after frame extraction, and `_harden_transparency` left the non-PNG original behind next to the hardened PNG; nothing prunes `cache/images/` outside the gateway housekeeping loop, so CLI/desktop/cron grew it without bound. Both intermediates are now removed the moment their pixels are decoded. Fixes #52602.
- **Relay scope.pop finalization failure → memory leak** (`agent/relay_runtime.py`, `agent/relay_llm.py`, `hermes_cli/observability/relay_shared_metrics.py`) — from #79016 by @rainbowgore. Older NeMo Relay bindings (0.3.x) reject `scope.pop(..., metadata=...)` with `TypeError`, leaving turn/session/logical scopes unclosed every turn — the gateway then retains per-turn state until OOM (reported: OOM kills on 3 hosts, 15.5 GB total-vm on a 3.6 GB host, corrupted `state.db`). `pop_relay_scope()` filters kwargs to what the live binding accepts; rebased onto the current drain-and-close finalizer so all pops (direct close, orphan drain, retry) go through it. Fixes #78993.
- **Active-session lease leak under multiplex** (`hermes_cli/active_sessions.py`) — fixes #85431. A lease acquired against the root `HERMES_HOME` re-resolved the registry from the *current* `HERMES_HOME` on release/transfer; under native multiplex, cleanup runs inside `_profile_runtime_scope`, so releases targeted the profile registry while root entries survived until every new session hit `Hermes is at the active session limit`. State/lock paths are now pinned on the lease at acquisition and preferred on release and transfer (both sibling sites). Fixes #85431.

## Validation

| Check | Result |
|---|---|
| `pytest tests/agent/test_thread_scoped_output.py` | 5 passed |
| `pytest tests/tools/test_browser_orphan_reaper.py` | 22 passed (9 new) |
| `HERMES_RUN_SLOW_PET_TESTS=1 pytest tests/agent/test_pet_generate.py` | 17 passed |
| `pytest tests/agent/test_relay_scope_pop_metadata.py` | 3 passed |
| `pytest tests/agent/test_relay_runtime_bounded_scope_ops.py` | 6 passed |
| `pytest tests/agent/test_relay_llm.py` | 18 passed |
| `pytest tests/hermes_cli/test_relay_shared_metrics_runtime.py tests/agent/test_relay_nested_execution.py tests/agent/test_relay_session_segments.py` | 61 passed |
| `pytest tests/hermes_cli/test_active_sessions.py` | 5 passed (2 new; RED confirmed with fix stashed) |
| `ruff check` on all touched files | clean |

## Issue coverage

- Fixes #78993 (relay pop TypeError → swap/OOM), #52602 (pet cache growth), #85431 (multiplex lease leak).
- #83092 (gateway 16 SQLite FDs + CLOSE-WAIT sockets): **not covered** — distinct leak class (SQLite connection pooling + HTTP client lifecycle), none of the candidate PRs touch it; needs its own diagnosis.
- #81837 (idle sessions never fire `on_session_end`): **not covered** — the fix is the `_transport_is_dead()` gate removal already proposed in PR #63551 (open); duplicating it here would conflict.

## Credits

- @Reksely — thread output descriptor fix (#81753)
- @Hangzian — browser daemon reaper (#82145)
- @Adolanium — pet image cache cleanup (#52603)
- @rainbowgore — Relay scope.pop compatibility (#79016)

## Infographic

![Resource Leak Purge](https://files.catbox.moe/0dxiyq.png)
