### PR TITLE
fix(ui): steady TUI scrollbar after shrink + sidebar wheel dead-zone at 25+ sessions

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/virtual-session-list.test.tsx
+++ b/apps/desktop/src/app/chat/sidebar/virtual-session-list.test.tsx
@@ -82,4 +82,29 @@ describe('VirtualSessionList', () => {
     expect(spacer?.style.paddingTop).toBe('')
     expect(spacer?.style.paddingBottom).toBe('')
   })
+
+  it('lets wheel overscroll chain to the outer sidebar scroller (#84964)', () => {
+    const { getByTestId } = render(
+      <VirtualSessionList
+        activeSessionId={null}
+        onArchiveSession={noop}
+        onDeleteSession={noop}
+        onResumeSession={noop}
+        onTogglePin={noop}
+        pinned={false}
+        rows={rows}
+        sortable={false}
+      />
+    )
+
+    const scroller = getByTestId('divider-Today').parentElement?.parentElement?.parentElement
+
+    // The inner virtualized scroller must NOT contain overscroll: it is nested
+    // inside the sidebar's own scroll container, and containing it swallowed
+    // wheel events at the inner scroll boundary — the mid-list wheel dead-zone
+    // at 25+ sessions. Chaining stays inside the sidebar because the OUTER
+    // scroller keeps overscroll-contain.
+    expect(scroller?.className).toContain('overflow-y-auto')
+    expect(scroller?.className).not.toContain('overscroll-contain')
+  })
 })

--- a/apps/desktop/src/app/chat/sidebar/virtual-session-list.tsx
+++ b/apps/desktop/src/app/chat/sidebar/virtual-session-list.tsx
@@ -155,10 +155,16 @@ export const VirtualSessionList: FC<VirtualSessionListProps> = ({
       // fade bar reserves its 4px on every platform but stays invisible until
       // hover — and the wrapper no longer stacks a second scroller, so the
       // double-gutter this class change was reaching for is already gone.
-      className={cn(
-        'scrollbar-fade relative min-h-0 flex-1 overflow-x-hidden overflow-y-auto overscroll-contain',
-        className
-      )}
+      //
+      // No `overscroll-contain` here: this scroller is NESTED inside the
+      // sidebar's own scroll container (index.tsx SCROLL_Y). Containing
+      // overscroll on the inner scroller swallowed wheel events at its scroll
+      // boundaries instead of chaining them to the outer sidebar scroller,
+      // which read as a wheel dead-zone mid-list once 25+ sessions
+      // virtualized (#84964) — the scrollbar still dragged, only the wheel
+      // died. The outer sidebar scroller keeps its own overscroll-contain, so
+      // the gesture still never escapes the sidebar.
+      className={cn('scrollbar-fade relative min-h-0 flex-1 overflow-x-hidden overflow-y-auto', className)}
       ref={scrollerRef}
     >
       <div className="relative" style={{ height: `${totalSize}px` }}>{rows}</div>

--- a/ui-tui/src/__tests__/viewportStore.test.ts
+++ b/ui-tui/src/__tests__/viewportStore.test.ts
@@ -87,4 +87,22 @@ describe('viewportStore', () => {
 
     expect(getScrollbarSnapshot(handle as any).top).toBe(10)
   })
+
+  it('uses fresh scroll height to clear stale scrollbar non-bottom state after shrink', () => {
+    const handle = {
+      getFreshScrollHeight: () => 40,
+      getScrollHeight: () => 60,
+      getScrollTop: () => 20,
+      getViewportHeight: () => 20
+    }
+
+    const snap = getScrollbarSnapshot(handle as any)
+
+    expect(snap).toEqual({
+      scrollHeight: 40,
+      top: 20,
+      viewportHeight: 20
+    })
+    expect(scrollbarSnapshotKey(snap)).toBe('20:20:40')
+  })
 })

--- a/ui-tui/src/lib/viewportStore.ts
+++ b/ui-tui/src/lib/viewportStore.ts
@@ -70,12 +70,24 @@ export function getScrollbarSnapshot(s?: ScrollBoxHandle | null): ScrollbarSnaps
   }
 
   const viewportHeight = Math.max(0, s.getViewportHeight())
-  const scrollHeight = Math.max(viewportHeight, s.getScrollHeight())
-  const maxTop = Math.max(0, scrollHeight - viewportHeight)
+  const top = Math.max(0, s.getScrollTop())
+  const cachedScrollHeight = Math.max(viewportHeight, s.getScrollHeight())
+  let scrollHeight = cachedScrollHeight
+  let maxTop = Math.max(0, scrollHeight - viewportHeight)
+
+  if (top < maxTop) {
+    const freshScrollHeight = Math.max(viewportHeight, s.getFreshScrollHeight?.() ?? cachedScrollHeight)
+    const freshMaxTop = Math.max(0, freshScrollHeight - viewportHeight)
+
+    if (top >= freshMaxTop) {
+      scrollHeight = freshScrollHeight
+      maxTop = freshMaxTop
+    }
+  }
 
   return {
     scrollHeight,
-    top: Math.max(0, Math.min(maxTop, s.getScrollTop())),
+    top: Math.max(0, Math.min(maxTop, top)),
     viewportHeight
   }
 }


### PR DESCRIPTION
Salvages the scroll/scrollbar cluster into one green-ready PR: the TUI scrollbar no longer renders a false mid-track state after a transcript shrink, and the desktop sidebar's mouse wheel no longer dies mid-list once 25+ sessions virtualize.

## Changes

- **fix(tui): steady scrollbar after transcript shrink** — cherry-picked from #25632 by @LeonSGP43. `getScrollbarSnapshot()` now falls back to the fresh scroll height when the cached height is one frame stale after a wrap/resize shrink, keeping the committed thumb pinned to the real bottom instead of briefly rendering a false mid-track state. Includes the contributor's targeted regression test. Addresses the resize-shrink scrollbar symptom of #24137 (the streaming-jump portion of that issue is a separate layout concern and remains open).
- **fix(desktop): let sidebar wheel scrolling chain past the virtualized list** — fixes #84964. With 25+ sessions the recents list virtualizes into its own nested scroller inside the sidebar's scroll container, and both carried `overscroll-contain`; when the inner scroller sat at a scroll boundary the wheel gesture was consumed instead of chaining outward — the reported mid-list wheel dead-zone (scrollbar drag kept working). The containment is dropped on the inner scroller only; the outer sidebar scroller keeps `overscroll-contain`, so the gesture still never escapes the sidebar. Regression test added to the existing `virtual-session-list.test.tsx`.

## Excluded candidates (verified against current main first)

| PR | Author | Verdict |
|---|---|---|
| #83040 | @BigFaceCat5233 | **Redundant** — merged #86589 already ships an asymmetric sash grab band (1px into the leading pane) in `tree-split.tsx` that solves the same scrollbar-occlusion symptom of #83026 while keeping the boundary hairline centered; #83040's variant would also revert three later fixes in the same region (guest-pointer guard #7267adaf, blur/lostpointercapture cleanup, stacked-zone clamp fix #d67337ee). |
| #39564 | @markw362 | **Not portable** — both target files (`thread-virtualizer.tsx`, `composer/index.tsx` expansion logic) were removed/rewritten; scroll ownership moved to `use-stick-to-bottom` in `thread/list.tsx` with its own disarm + resize-follow design, and composer stacking moved to `use-composer-metrics.ts` with edge-gated ResizeObserver expansion. The bugs it fixed no longer exist in that form. |

#38669 (web chat can't scroll to bottom) was assessed: the dashboard chat is an xterm.js PTY surface whose stick-to-bottom pin already releases/re-pins via `pty-scroll.ts` (#59591); the reported thumb-teleport behavior needs a live repro against xterm's scrollback trimming and is not cheaply fixable in this cluster's area, so it stays open.

## Validation

| Check | Result |
|---|---|
| `npx vitest run ui-tui/src/__tests__/viewportStore.test.ts` | ✅ 6 passed (incl. new shrink regression test) |
| `npx vitest run src/app/chat/sidebar/virtual-session-list.test.tsx` (apps/desktop) | ✅ 2 passed (incl. new #84964 regression test) |
| `npx tsc --noEmit` (apps/desktop) | ✅ clean |
| `npx eslint` on all touched files | ✅ clean |
| `scripts/audit_pr_attribution.py --fix` | ✅ all contributor emails mapped |

## Credits

- @LeonSGP43 — TUI scrollbar shrink fix (#25632), authorship preserved via cherry-pick.

## Issues covered

- Fixes #84964 (sidebar wheel dead-zone at 25+ sessions)
- Addresses the resize-shrink scrollbar portion of #24137
- #83026 already resolved on main by #86589
- #38669 assessed, not covered (see above)

## Infographic

![Scroll & Scrollbar Fixes](https://files.catbox.moe/vqjs1x.png)
