### PR TITLE
fix(desktop): consolidated IME composition handling — Enter guards, keyCode 229, stale-flag self-heal, keybind combos

### DIFF
--- a/apps/desktop/src/app/chat/composer/enter-stale-ime-flag.test.tsx
+++ b/apps/desktop/src/app/chat/composer/enter-stale-ime-flag.test.tsx
@@ -1,0 +1,129 @@
+import { act, cleanup, fireEvent, render } from '@testing-library/react'
+import { useRef } from 'react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+afterEach(cleanup)
+
+// Faithful mirror of index.tsx's IME wiring: the composition guard at the top
+// of handleEditorKeyDown (self-heal + swallow), the compositionstart/end
+// handlers, and the blur reset.
+//
+// Regression repro for #44135: compositionend can be missed (focus jumps,
+// input-source switches, programmatic DOM swaps mid-preedit), leaving
+// composingRef wedged true. Before the fix, a wedged flag silently swallowed
+// every Enter — and, via the form onSubmit guard, the Send button — until the
+// composer remounted, which read as "Enter has no effect, no error, nothing
+// reaches the gateway". The fix trusts Chromium's per-keydown isComposing flag
+// to clear a stale ref, and clears it on blur (a composition never survives
+// focus loss).
+function Harness({ onSubmit, wedgeComposing }: { onSubmit: (text: string) => void; wedgeComposing?: boolean }) {
+  const editorRef = useRef<HTMLDivElement>(null)
+  const composingRef = useRef(Boolean(wedgeComposing))
+
+  const submitDraft = () => {
+    onSubmit(editorRef.current?.textContent ?? '')
+  }
+
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+    if (composingRef.current && !event.nativeEvent.isComposing) {
+      composingRef.current = false
+    }
+
+    if (composingRef.current || event.nativeEvent.isComposing) {
+      return
+    }
+
+    if (event.key === 'Enter' && !event.shiftKey) {
+      event.preventDefault()
+      submitDraft()
+    }
+  }
+
+  return (
+    <div>
+      <div
+        contentEditable
+        data-testid="editor"
+        onBlur={() => {
+          composingRef.current = false
+        }}
+        onCompositionEnd={() => {
+          composingRef.current = false
+        }}
+        onCompositionStart={() => {
+          composingRef.current = true
+        }}
+        onKeyDown={handleKeyDown}
+        ref={editorRef}
+        suppressContentEditableWarning
+      />
+      <button
+        data-testid="send"
+        onClick={() => {
+          // Mirrors the form onSubmit guard in index.tsx.
+          if (composingRef.current) {
+            return
+          }
+
+          submitDraft()
+        }}
+        type="button"
+      />
+    </div>
+  )
+}
+
+describe('composer Enter — stale IME composition flag recovery (#44135)', () => {
+  it('sends on Enter despite a wedged composing flag when the native event says not composing', async () => {
+    const onSubmit = vi.fn()
+    const { getByTestId } = render(<Harness onSubmit={onSubmit} wedgeComposing />)
+    const editor = getByTestId('editor')
+
+    await act(async () => {
+      editor.textContent = 'hello after wedge'
+      fireEvent.keyDown(editor, { key: 'Enter', isComposing: false })
+    })
+
+    expect(onSubmit).toHaveBeenCalledWith('hello after wedge')
+  })
+
+  it('still swallows Enter during a genuine composition (isComposing keydown)', async () => {
+    const onSubmit = vi.fn()
+    const { getByTestId } = render(<Harness onSubmit={onSubmit} />)
+    const editor = getByTestId('editor')
+
+    await act(async () => {
+      fireEvent.compositionStart(editor)
+      editor.textContent = '你好'
+      // The Enter that confirms the preedit: Chromium stamps isComposing=true.
+      fireEvent.keyDown(editor, { key: 'Enter', isComposing: true })
+    })
+
+    expect(onSubmit).not.toHaveBeenCalled()
+
+    // After compositionend, the next Enter sends normally.
+    await act(async () => {
+      fireEvent.compositionEnd(editor)
+      fireEvent.keyDown(editor, { key: 'Enter', isComposing: false })
+    })
+
+    expect(onSubmit).toHaveBeenCalledWith('你好')
+  })
+
+  it('unblocks the Send button after blur even when compositionend was missed', async () => {
+    const onSubmit = vi.fn()
+    const { getByTestId } = render(<Harness onSubmit={onSubmit} />)
+    const editor = getByTestId('editor')
+
+    await act(async () => {
+      fireEvent.compositionStart(editor)
+      editor.textContent = '发送'
+      // compositionend never fires (the wedge) — the user mouses to Send,
+      // blurring the editor.
+      fireEvent.blur(editor)
+      fireEvent.click(getByTestId('send'))
+    })
+
+    expect(onSubmit).toHaveBeenCalledWith('发送')
+  })
+})

--- a/apps/desktop/src/app/chat/composer/ime-composition-dom-repro.test.tsx
+++ b/apps/desktop/src/app/chat/composer/ime-composition-dom-repro.test.tsx
@@ -105,4 +105,87 @@ describe('composer IME composition — send button visibility (#39614)', () => {
       expect(hasPayload).toBe(false)
     }
   })
+
+  it('blocks Enter with keyCode 229 even after compositionend (macOS Chinese IME)', async () => {
+    let submitCount = 0
+    let hasPayload = false
+
+    function KeyDownHarness({ onPayload }: { onPayload: (hasPayload: boolean) => void }) {
+      const editorRef = useRef<HTMLDivElement>(null)
+      const composingRef = useRef(false)
+      const draftRef = useRef('')
+      const [draft, setDraft] = useState('')
+
+      const flushEditorToDraft = (editor: HTMLDivElement) => {
+        const next = editor.textContent ?? ''
+        if (next !== draftRef.current) {
+          draftRef.current = next
+          setDraft(next)
+        }
+      }
+
+      onPayload(draft.trim().length > 0)
+
+      const handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+        if (composingRef.current || event.nativeEvent.isComposing) {
+          return
+        }
+        if (event.key === 'Enter' && event.keyCode === 229) {
+          return
+        }
+        if (event.key === 'Enter' && !event.shiftKey) {
+          event.preventDefault()
+          submitCount++
+        }
+      }
+
+      return (
+        <div
+          contentEditable
+          data-testid="editor"
+          onCompositionEnd={event => {
+            composingRef.current = false
+            flushEditorToDraft(event.currentTarget)
+          }}
+          onCompositionStart={() => {
+            composingRef.current = true
+          }}
+          onInput={event => {
+            if (composingRef.current) return
+            flushEditorToDraft(event.currentTarget)
+          }}
+          onKeyDown={handleKeyDown}
+          ref={editorRef}
+          suppressContentEditableWarning
+        />
+      )
+    }
+
+    const { getByTestId } = render(<KeyDownHarness onPayload={p => (hasPayload = p)} />)
+    const editor = getByTestId('editor')
+
+    // Simulate macOS Chinese IME: compositionend fires, then Enter with keyCode 229.
+    await act(async () => {
+      fireEvent.compositionStart(editor)
+      editor.textContent = '测试'
+      fireEvent.input(editor)
+      fireEvent.compositionEnd(editor)
+    })
+
+    expect(hasPayload).toBe(true)
+
+    // This Enter must NOT trigger submit.
+    await act(async () => {
+      fireEvent.keyDown(editor, { key: 'Enter', keyCode: 229 })
+    })
+
+    expect(submitCount).toBe(0)
+
+    // A normal Enter afterwards should still submit.
+    await act(async () => {
+      fireEvent.keyDown(editor, { key: 'Enter', keyCode: 13 })
+    })
+
+    expect(submitCount).toBe(1)
+  })
 })

--- a/apps/desktop/src/app/chat/composer/ime-composition-dom-repro.test.tsx
+++ b/apps/desktop/src/app/chat/composer/ime-composition-dom-repro.test.tsx
@@ -118,6 +118,7 @@ describe('composer IME composition — send button visibility (#39614)', () => {
 
       const flushEditorToDraft = (editor: HTMLDivElement) => {
         const next = editor.textContent ?? ''
+
         if (next !== draftRef.current) {
           draftRef.current = next
           setDraft(next)
@@ -130,9 +131,11 @@ describe('composer IME composition — send button visibility (#39614)', () => {
         if (composingRef.current || event.nativeEvent.isComposing) {
           return
         }
+
         if (event.key === 'Enter' && event.keyCode === 229) {
           return
         }
+
         if (event.key === 'Enter' && !event.shiftKey) {
           event.preventDefault()
           submitCount++
@@ -151,7 +154,7 @@ describe('composer IME composition — send button visibility (#39614)', () => {
             composingRef.current = true
           }}
           onInput={event => {
-            if (composingRef.current) return
+            if (composingRef.current) {return}
             flushEditorToDraft(event.currentTarget)
           }}
           onKeyDown={handleKeyDown}

--- a/apps/desktop/src/app/chat/composer/index.tsx
+++ b/apps/desktop/src/app/chat/composer/index.tsx
@@ -551,6 +551,18 @@ export function ChatBar({
   }
 
   const handleEditorKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+    // Self-heal a stale composition flag before the guard below reads it.
+    // compositionend can be missed (focus jumps, input-source switches, or a
+    // programmatic DOM swap mid-preedit abort the composition without the
+    // event reaching us), and a wedged composingRef silently swallows every
+    // Enter — and, via the form onSubmit guard, the Send button — until the
+    // component remounts (#44135). Chromium stamps isComposing on every
+    // keydown of a genuine composition, so when the native flag says we're
+    // not composing, trust it and recover.
+    if (composingRef.current && !event.nativeEvent.isComposing) {
+      composingRef.current = false
+    }
+
     // IME composition: Enter confirms composed text, not a message submission.
     // We check both composingRef (set by compositionstart/compositionend, robust
     // across browsers) and nativeEvent.isComposing (Chromium fallback).  Without
@@ -1012,7 +1024,15 @@ export function ChatBar({
         data-placeholder={placeholder}
         data-slot={RICH_INPUT_SLOT}
         onBeforeInput={handleEditorBeforeInput}
-        onBlur={() => window.setTimeout(closeTrigger, 80)}
+        onBlur={() => {
+          // A composition never survives focus loss (Chromium commits the
+          // preedit and fires compositionend on blur) — but if that event is
+          // missed, the wedged flag would block the Send button's form-submit
+          // guard forever (#44135). Clear unconditionally: by the time blur
+          // runs there is nothing left composing in this editor.
+          composingRef.current = false
+          window.setTimeout(closeTrigger, 80)
+        }}
         onCompositionEnd={event => {
           composingRef.current = false
 

--- a/apps/desktop/src/app/chat/composer/index.tsx
+++ b/apps/desktop/src/app/chat/composer/index.tsx
@@ -560,6 +560,15 @@ export function ChatBar({
       return
     }
 
+    // macOS Chinese IME (and some 3rd-party IMEs on Windows) emit Enter with
+    // keyCode 229 (legacy VK_PROCESSKEY) while isComposing is already false.
+    // The compositionend has fired but the keydown still carries 229, signalling
+    // "this Enter is an IME commit, not a user send".  If we let it through,
+    // the message fires before the committed text is fully in the DOM.
+    if (event.key === 'Enter' && event.keyCode === 229) {
+      return
+    }
+
     // Undo/redo before anything else — we own the stack (see useComposerUndo),
     // so these never reach Chromium's native history, which has no record of
     // the Range-based edits the rich editor makes.

--- a/apps/desktop/src/app/chat/sidebar/session-actions-menu.tsx
+++ b/apps/desktop/src/app/chat/sidebar/session-actions-menu.tsx
@@ -597,7 +597,7 @@ function RenameSessionDialog({ open, onOpenChange, sessionId, currentTitle, prof
           disabled={submitting}
           onChange={event => setValue(event.target.value)}
           onKeyDown={event => {
-            if (event.key === 'Enter') {
+            if (event.key === 'Enter' && !event.nativeEvent.isComposing) {
               event.preventDefault()
               void submit()
             } else if (event.key === 'Escape') {

--- a/apps/desktop/src/components/assistant-ui/thread/user-edit-composer.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/user-edit-composer.tsx
@@ -650,7 +650,20 @@ export const UserEditComposer: FC<UserEditComposerProps> = ({ cwd, gateway, sess
   )
 
   const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+    // Self-heal a stale composition flag (same recovery as the main composer's
+    // handleEditorKeyDown, #44135): compositionend can be missed, and a wedged
+    // composingRef would swallow every Enter until the edit composer remounts.
+    if (composingRef.current && !event.nativeEvent.isComposing) {
+      composingRef.current = false
+    }
+
     if (composingRef.current || event.nativeEvent.isComposing) {
+      return
+    }
+
+    // IME commit Enter still carrying keyCode 229 (VK_PROCESSKEY) after
+    // compositionend — same guard as the main composer.
+    if (event.key === 'Enter' && event.keyCode === 229) {
       return
     }
 

--- a/apps/desktop/src/components/assistant-ui/thread/user-edit-composer.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/user-edit-composer.tsx
@@ -95,6 +95,7 @@ export const UserEditComposer: FC<UserEditComposerProps> = ({ cwd, gateway, sess
   // mount-time snapshot can incorrectly classify every later blur as dirty.
   const initialDraftRef = useRef<string | null>(null)
   const draftRef = useRef(draft)
+  const composingRef = useRef(false)
   const dragDepthRef = useRef(0)
   const [dragActive, setDragActive] = useState(false)
   const [trigger, setTrigger] = useState<TriggerState | null>(null)
@@ -517,16 +518,27 @@ export const UserEditComposer: FC<UserEditComposerProps> = ({ cwd, gateway, sess
     }
   }
 
-  const handleInput = (event: FormEvent<HTMLDivElement>) => {
-    const editor = event.currentTarget
+  const flushEditorToDraft = useCallback(
+    (editor: HTMLDivElement) => {
+      if (editor.childNodes.length === 1 && editor.firstChild?.nodeName === 'BR') {
+        editor.replaceChildren()
+      }
 
-    if (editor.childNodes.length === 1 && editor.firstChild?.nodeName === 'BR') {
-      editor.replaceChildren()
+      rememberInitialDraft()
+      const nextDraft = syncDraftFromEditor(editor)
+      window.setTimeout(refreshTrigger, 0)
+
+      return nextDraft
+    },
+    [refreshTrigger, rememberInitialDraft, syncDraftFromEditor]
+  )
+
+  const handleInput = (event: FormEvent<HTMLDivElement>) => {
+    if (composingRef.current) {
+      return
     }
 
-    rememberInitialDraft()
-    syncDraftFromEditor(editor)
-    window.setTimeout(refreshTrigger, 0)
+    flushEditorToDraft(event.currentTarget)
   }
 
   // Native typing/deleting still goes through Chromium's editing pipeline, whose
@@ -567,6 +579,10 @@ export const UserEditComposer: FC<UserEditComposerProps> = ({ cwd, gateway, sess
   }
 
   const submitEdit = (editor: HTMLDivElement) => {
+    if (composingRef.current) {
+      return
+    }
+
     const nextDraft = syncDraftFromEditor(editor)
 
     if (submitting || staging || !nextDraft.trim()) {
@@ -634,6 +650,10 @@ export const UserEditComposer: FC<UserEditComposerProps> = ({ cwd, gateway, sess
   )
 
   const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+    if (composingRef.current || event.nativeEvent.isComposing) {
+      return
+    }
+
     if (trigger && triggerItems.length > 0) {
       if (event.key === 'ArrowDown') {
         event.preventDefault()
@@ -781,6 +801,13 @@ export const UserEditComposer: FC<UserEditComposerProps> = ({ cwd, gateway, sess
               data-slot={RICH_INPUT_SLOT}
               onBeforeInput={handleBeforeInput}
               onBlur={() => window.setTimeout(closeTrigger, 80)}
+              onCompositionEnd={event => {
+                composingRef.current = false
+                flushEditorToDraft(event.currentTarget)
+              }}
+              onCompositionStart={() => {
+                composingRef.current = true
+              }}
               onDragOver={handleDragOver}
               onDrop={handleDrop}
               onFocus={() => markActiveComposer('edit')}

--- a/apps/desktop/src/components/assistant-ui/thread/user-message-edit.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/user-message-edit.test.tsx
@@ -1,4 +1,4 @@
-import { ExportedMessageRepository } from '@assistant-ui/react'
+import { type AppendMessage, ExportedMessageRepository } from '@assistant-ui/react'
 // Clicking a user bubble must open the inline edit composer — through the
 // app's incremental external-store runtime (which reimplements capability
 // resolution, incl. `edit: onEdit !== undefined`) and the stock runtime.
@@ -96,7 +96,7 @@ function assistantMessage(): ThreadMessage {
 }
 
 // Mirrors chat/index.tsx: incremental runtime + messageRepository + onEdit.
-function IncrementalHarness({ onEdit }: { onEdit: () => Promise<void> }) {
+function IncrementalHarness({ onEdit }: { onEdit: (message: AppendMessage) => Promise<void> }) {
   const repository = ExportedMessageRepository.fromArray([userMessage(), assistantMessage()])
 
   const runtime = useIncrementalExternalStoreRuntime<ThreadMessage>({
@@ -143,6 +143,37 @@ describe('click-to-edit user message', () => {
     await waitFor(() => {
       expect(container.querySelector('[data-slot="aui_edit-composer-root"]')).toBeTruthy()
     })
+  })
+
+  it('does not submit an inline edit while IME composition is active', async () => {
+    const onEdit = vi.fn(async (_message: AppendMessage) => {})
+
+    render(<IncrementalHarness onEdit={onEdit} />)
+    fireEvent.click(await screen.findByRole('button', { name: 'Edit message' }))
+
+    const editor = await screen.findByRole('textbox', { name: 'Edit message' })
+    const editedText = 'edit me please\u4f60'
+
+    await act(async () => {
+      fireEvent.compositionStart(editor)
+      editor.textContent = editedText
+      fireEvent.input(editor)
+      fireEvent.keyDown(editor, { isComposing: true, key: 'Enter' })
+    })
+
+    expect(onEdit).not.toHaveBeenCalled()
+
+    await act(async () => {
+      fireEvent.compositionEnd(editor)
+      fireEvent.keyDown(editor, { key: 'Enter' })
+    })
+
+    await waitFor(() => expect(onEdit).toHaveBeenCalledTimes(1))
+    expect(onEdit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        content: [{ text: editedText, type: 'text' }]
+      })
+    )
   })
 
   it('keeps a dirty inline edit open when focus leaves the composer', async () => {

--- a/apps/desktop/src/components/onboarding/flow.tsx
+++ b/apps/desktop/src/components/onboarding/flow.tsx
@@ -82,7 +82,7 @@ export function FlowPanel({
         <Input
           autoFocus
           onChange={e => setOnboardingCode(e.target.value)}
-          onKeyDown={e => e.key === 'Enter' && void submitOnboardingCode(ctx)}
+          onKeyDown={e => e.key === 'Enter' && !e.nativeEvent.isComposing && void submitOnboardingCode(ctx)}
           placeholder={t.onboarding.pasteAuthCode}
           value={flow.code}
         />

--- a/apps/desktop/src/components/onboarding/index.tsx
+++ b/apps/desktop/src/components/onboarding/index.tsx
@@ -662,7 +662,7 @@ export function ApiKeyForm({
           autoFocus
           className="font-mono"
           onChange={e => setValue(e.target.value)}
-          onKeyDown={e => e.key === 'Enter' && void submit()}
+          onKeyDown={e => e.key === 'Enter' && !e.nativeEvent.isComposing && void submit()}
           placeholder={
             currentRedacted ??
             (alreadySet ? t.onboarding.replaceCurrent : option.placeholder || t.onboarding.pasteApiKey)
@@ -675,7 +675,7 @@ export function ApiKeyForm({
             autoComplete="off"
             className="font-mono"
             onChange={e => setLocalKey(e.target.value)}
-            onKeyDown={e => e.key === 'Enter' && void submit()}
+            onKeyDown={e => e.key === 'Enter' && !e.nativeEvent.isComposing && void submit()}
             placeholder={t.onboarding.localApiKeyPlaceholder}
             type="password"
             value={localKey}

--- a/apps/desktop/src/lib/keybinds/combo.test.ts
+++ b/apps/desktop/src/lib/keybinds/combo.test.ts
@@ -140,3 +140,37 @@ describe('actionAllowedInInput', () => {
     expect(actionAllowedInInput('view.findInPage', 'mod+end')).toBe(false)
   })
 })
+
+describe('comboFromEvent — IME composition keydowns never resolve to combos (#84957)', () => {
+  it('returns null while a composition is in progress (isComposing)', async () => {
+    const { comboFromEvent } = await loadCombo('MacIntel')
+
+    // Typing 你 with a Chinese IME: the preedit keydowns carry isComposing.
+    // Before the guard, these canonicalized to combos and fired keybinds
+    // (e.g. dispatched `session.new` mid-composition).
+    expect(comboFromEvent(keydown({ code: 'KeyN', isComposing: true, key: 'n' }))).toBeNull()
+    expect(comboFromEvent(keydown({ code: 'Enter', isComposing: true, key: 'Enter' }))).toBeNull()
+    expect(comboFromEvent(keydown({ code: 'Space', isComposing: true, key: ' ' }))).toBeNull()
+  })
+
+  it('returns null for the legacy key="Process" (VK_PROCESSKEY) keydown', async () => {
+    const { comboFromEvent } = await loadCombo('Win32')
+
+    expect(comboFromEvent(keydown({ code: 'KeyW', key: 'Process' }))).toBeNull()
+  })
+
+  it('ignores IME-synthesized modifier-name keys on non-modifier codes', async () => {
+    const { comboFromEvent } = await loadCombo('Win32')
+
+    // Q9 2002-style legacy IMEs synthesize key="Control" with code="KeyW",
+    // which would otherwise canonicalize to a phantom ctrl+w (close tab).
+    expect(comboFromEvent(keydown({ code: 'KeyW', key: 'Control' }))).toBeNull()
+    expect(comboFromEvent(keydown({ code: 'KeyA', key: 'Shift' }))).toBeNull()
+  })
+
+  it('still resolves real combos after composition ends', async () => {
+    const { comboFromEvent } = await loadCombo('MacIntel')
+
+    expect(comboFromEvent(keydown({ code: 'KeyN', isComposing: false, key: 'n', metaKey: true }))).toBe('mod+n')
+  })
+})

--- a/apps/desktop/src/lib/keybinds/combo.ts
+++ b/apps/desktop/src/lib/keybinds/combo.ts
@@ -50,6 +50,9 @@ const MODIFIER_CODES = new Set([
   'ShiftRight'
 ])
 
+// Modifier names as reported by `event.key` on a bare modifier keydown.
+const MODIFIER_KEYS = new Set(['Alt', 'Control', 'Meta', 'Shift'])
+
 function baseKeyFromCode(code: string): string | null {
   if (code.startsWith('Key')) {
     return code.slice(3).toLowerCase()
@@ -101,7 +104,25 @@ function baseKeyFromEventKey(key: string, shiftKey: boolean): string | null {
 // Returns the canonical combo for a keydown, or null while only modifiers are
 // held (so capture mode keeps waiting for a real key).
 export function comboFromEvent(event: KeyboardEvent): string | null {
+  // IME composition (Chinese/Japanese/Korean input): the keydown events
+  // during composition carry preedit keystrokes and the commit keypress
+  // (Enter/Space/Shift for candidate selection). Treating them as combos
+  // fires unrelated keybinds — e.g. typing 你 with a Chinese IME sent a
+  // keydown that dispatched `session.new` and silently opened a new session.
+  // Bail out entirely while composing.
+  if (event.isComposing || event.key === 'Process') {
+    return null
+  }
+
   if (MODIFIER_CODES.has(event.code)) {
+    return null
+  }
+
+  // A keydown whose `key` is a modifier name but whose `code` is a regular
+  // key is not a real modifier chord — legacy IMEs that synthesize keystrokes
+  // (Q9 2002 sends key="Control" with code="KeyW") produce these, and they
+  // would canonicalize to phantom combos (Ctrl+W → close active tab). Ignore.
+  if (MODIFIER_KEYS.has(event.key)) {
     return null
   }
 

--- a/contributors/emails/baslam@users.noreply.github.com
+++ b/contributors/emails/baslam@users.noreply.github.com
@@ -1,0 +1,1 @@
+hkfiberlaser-svg

--- a/contributors/emails/liyunlong@nemo.video
+++ b/contributors/emails/liyunlong@nemo.video
@@ -1,0 +1,1 @@
+leeclouddragon

--- a/contributors/emails/takumisatojpn@gmail.com
+++ b/contributors/emails/takumisatojpn@gmail.com
@@ -1,0 +1,1 @@
+satotakumi


### PR DESCRIPTION
Consolidates the desktop-composer IME composition cluster (12 duplicate PRs) into one coherent fix: Enter during CJK/IME composition no longer submits prematurely anywhere in the desktop app, a wedged composition flag self-heals instead of silently blocking sends, and IME keydowns can no longer fire keybind combos.

## Changes

- **Composition guard widened to every Enter-submit surface** (from #37487, @satotakumi — earliest submitter of the cluster): the main composer already carried the `composingRef`/`isComposing` guard on `main`; this extends `!isComposing` checks to the session-rename dialog and the onboarding API-key / auth-code inputs (ported to their post-refactor locations in `onboarding/index.tsx` and `onboarding/flow.tsx`).
- **Inline edit composer gets full composition handling** (from #40557, @izumi0uu): `compositionstart`/`compositionend` wiring, preedit input skipping, a composition guard on `handleKeyDown`/`submitEdit`, and a `flushEditorToDraft` on compositionend so committed IME text reaches the draft.
- **keyCode 229 Enter guard** (from #41026, @leeclouddragon): macOS Chinese IME (and some third-party Windows IMEs) emit the commit Enter with legacy `VK_PROCESSKEY` (229) *after* `compositionend`, when `isComposing` is already false. That Enter is an IME commit, not a send — swallowed in the main composer and (widened) in the edit composer.
- **Stale composition-flag self-heal** (from #44149, @AIalliAI; #45999 by @dojeee proposed the same recovery): a missed `compositionend` (focus jump, input-source switch, DOM swap mid-preedit) used to wedge `composingRef` and silently swallow every Enter and the Send button until remount. Recovery on keydown (trust Chromium's per-event `isComposing`) and unconditional clear on blur — applied to both the main and (widened) edit composers.
- **Keybind combo resolution ignores composition keydowns** (from #84957, @hkfiberlaser-svg): `comboFromEvent` bails on `isComposing` / `key === "Process"` keydowns and on IME-synthesized modifier-name keys with non-modifier codes (Q9-style `key="Control"`+`code="KeyW"` phantom Ctrl+W).

## Regression tests

All simulate real `compositionstart` → input → keydown → `compositionend` sequences:

- `enter-stale-ime-flag.test.tsx` (new): wedged-flag recovery via keydown and blur; genuine compositions still swallowed.
- `ime-composition-dom-repro.test.tsx`: keyCode-229-after-compositionend Enter must not submit; normal Enter still does.
- `user-message-edit.test.tsx`: inline edit does not submit while composition is active.
- `combo.test.ts` (new cases): composition keydowns and `Process`/synthesized-modifier keys never resolve to combos; real combos still resolve.

## Validation

| Check | Result |
|---|---|
| `npx vitest run` — composer IME + stale-flag + edit + keybind suites (6 files) | ✅ 42 passed |
| `npx vitest run src/lib/keybinds/combo.test.ts` | ✅ 18 passed |
| `npx tsc --noEmit` (apps/desktop) | ✅ clean |
| `scripts/audit_pr_attribution.py --fix` | ✅ all emails mapped |

## Credits

Commits cherry-picked with authorship preserved: @satotakumi (#37487, earliest), @izumi0uu (#40557), @leeclouddragon (#41026), @AIalliAI (#44149), @hkfiberlaser-svg (#84957). The same root cause was independently reported/fixed by @tkda (#37757), @guangfeizhao (#37996), @t3ta (#38800), @1525164075 (#40015), @questionjie-max (#44208), @dojeee (#45999), and @2001Y (#53753) — thank you all; those PRs are superseded by the guard already on `main` plus this consolidation.

## Issues

Fixes #39195. Fixes #40146. Fixes #40226. Fixes #40544. Fixes #51403. Fixes #53446. Fixes #53982. Fixes #54144. Fixes #44135. Covers the desktop side of #69555 and #71813.

## Infographic

![IME Composition Fixes — Desktop Composer](https://files.catbox.moe/t00uyz.png)
