### PR TITLE
perf(cli): salvage startup/memoization cluster — lazy re-exports, config/root/toolset memos, TUI discovery skip

### DIFF
--- a/contributors/emails/jackoconner55@icloud.com
+++ b/contributors/emails/jackoconner55@icloud.com
@@ -1,0 +1,1 @@
+jackoconner45

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -1103,34 +1103,51 @@ def _load_global_auth_store() -> Dict[str, Any]:
     Returns an empty dict when no global fallback exists (classic mode,
     or the global auth.json is absent). Never raises on missing file.
 
-    Seat belt: under pytest, refuses to read the real user's
-    ``~/.hermes/auth.json`` even when HERMES_HOME is set to a profile
-    path. The hermetic conftest does not redirect ``HOME``, so
-    ``get_default_hermes_root()`` for a profile-shaped HERMES_HOME can
-    still resolve to the real user's home on a dev machine. That would
-    leak real credentials into tests. This guard uses the unmodified
-    ``HOME`` env var (what ``os.path.expanduser('~')`` would resolve to),
-    not ``Path.home()``, because ``Path.home`` is sometimes monkeypatched
-    by fixtures that want to relocate the global root to a tmp path.
+    Memoised keyed on the global auth file's path + mtime (same pattern as
+    ``_nous_auth_status_cache``): read_credential_pool() -> load_pool() runs
+    this once per provider row in the /model picker, and the path resolution
+    + JSON parse cost ~105us+ per call even when nothing changed. The global
+    store only changes when the user authenticates at global scope (writes
+    always go through _save_auth_store, which touches the file), so the mtime
+    key keeps the memo freshness-correct. Callers must treat the returned
+    store as read-only (all current callers do — .get / dict() / list()
+    copies only).
     """
+    global _global_auth_store_cache
     global_path = _global_auth_file_path()
     if global_path is None or not global_path.exists():
+        _global_auth_store_cache = None
         return {}
+    try:
+        resolved_path = str(global_path.resolve(strict=False))
+        mtime_ns = global_path.stat().st_mtime_ns
+        cache_key: Optional[Tuple[str, int]] = (resolved_path, mtime_ns)
+    except Exception:
+        cache_key = None
+    if cache_key is not None and _global_auth_store_cache is not None:
+        cached_path, cached_mtime, cached_store = _global_auth_store_cache
+        if cached_path == cache_key[0] and cached_mtime == cache_key[1]:
+            return cached_store
     if os.environ.get("PYTEST_CURRENT_TEST"):
         real_home_env = os.environ.get("HOME", "")
         if real_home_env:
             real_root = Path(real_home_env) / ".hermes" / "auth.json"
             try:
                 if global_path.resolve(strict=False) == real_root.resolve(strict=False):
+                    _global_auth_store_cache = None
                     return {}
             except Exception:
                 pass
     try:
-        return _load_auth_store(global_path)
+        store = _load_auth_store(global_path)
     except Exception:
         # A malformed global store must not break profile reads. The
         # profile's own auth store is still authoritative.
+        _global_auth_store_cache = None
         return {}
+    if cache_key is not None:
+        _global_auth_store_cache = (cache_key[0], cache_key[1], store)
+    return store
 
 
 def _auth_lock_path() -> Path:
@@ -6680,6 +6697,11 @@ def _snapshot_nous_pool_status() -> Dict[str, Any]:
 # `hermes auth login/logout/add/remove` invalidate naturally on the next call.
 _NOUS_AUTH_STATUS_CACHE_TTL = 15.0  # seconds
 _nous_auth_status_cache: Optional[Tuple[float, str, Optional[float], Dict[str, Any]]] = None
+
+# mtime-keyed memo for _load_global_auth_store(): (path, mtime_ns, store).
+# Same invalidation contract as _nous_auth_status_cache — the global auth
+# file changes only when a global-scope auth write touches it.
+_global_auth_store_cache: Optional[Tuple[str, int, Dict[str, Any]]] = None
 
 
 def _auth_file_cache_key() -> Tuple[str, Optional[float]]:

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -1106,7 +1106,8 @@ def _load_global_auth_store() -> Dict[str, Any]:
     Memoised keyed on the global auth file's path + mtime (same pattern as
     ``_nous_auth_status_cache``): read_credential_pool() -> load_pool() runs
     this once per provider row in the /model picker, and the path resolution
-    + JSON parse cost ~105us+ per call even when nothing changed. The global
+    (``_global_auth_file_path()`` -> ``get_default_hermes_root()``) + JSON
+    parse cost ~105us+ per call even when nothing changed. The global
     store only changes when the user authenticates at global scope (writes
     always go through _save_auth_store, which touches the file), so the mtime
     key keeps the memo freshness-correct. Callers must treat the returned

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -18,10 +18,50 @@ import subprocess
 import time
 from collections.abc import Callable, Mapping
 from dataclasses import dataclass, field
-from typing import Any
+from typing import Any, Dict, Optional, Tuple
 
 from utils import is_truthy_value
 from hermes_constants import INDICATOR_STYLES
+
+# mtime-keyed memo of the /personality completion source. load_cli_config()
+# does a full YAML parse + deep merge of the built-in defaults on every call,
+# and the completer runs on every keystroke of /personality. The personalities
+# list only changes when the config file changes on disk, so keying on
+# path+mtime keeps the memo freshness-correct (same pattern as load_env and
+# _nous_auth_status_cache). Falls back to a fresh load when the file cannot
+# be stat'ed.
+_personalities_memo: Optional[
+    Tuple[Tuple[Optional[str], Optional[int], Optional[int]], Dict[str, Any]]
+] = None
+
+
+def _personalities_from_cli_config() -> Dict[str, Any]:
+    """Return the available personalities map, memoised on config mtime.
+
+    Wraps ``available_personalities(load_cli_config())`` — the single owner of
+    built-ins + user overrides. Built-ins are static for the process lifetime,
+    so keying on the config file's path+mtime+size keeps the memo
+    freshness-correct.
+    """
+    global _personalities_memo
+    from cli import load_cli_config
+    from hermes_cli.personality import available_personalities
+
+    try:
+        from hermes_cli.config import get_config_path
+
+        cfg_path = get_config_path()
+        st = cfg_path.stat()
+        sig = (str(cfg_path), st.st_mtime_ns, st.st_size)
+    except Exception:
+        sig = (None, None, None)
+
+    if _personalities_memo is not None and _personalities_memo[0] == sig:
+        return _personalities_memo[1]
+
+    personalities = available_personalities(load_cli_config())
+    _personalities_memo = (sig, personalities)
+    return personalities
 
 logger = logging.getLogger(__name__)
 
@@ -1943,14 +1983,19 @@ class SlashCommandCompleter(Completer):
         already = set(parts[1:] if trailing_space else parts[1:-1])
 
         try:
-            from hermes_cli.config import load_config
+            from hermes_cli.config import load_config_readonly
             from hermes_cli.tools_config import (
                 CONFIGURABLE_TOOLSETS,
                 _get_platform_tools,
                 _get_plugin_toolset_keys,
             )
 
-            config = load_config()
+            # Read-only path: the completer only inspects the config (toolset
+            # enable state + MCP server names) — it never mutates it. Use the
+            # readonly loader so the per-keystroke completion doesn't pay the
+            # defensive deepcopy (perf(agent) #74322 converted 29 call sites
+            # to the readonly loader; this per-keystroke site was missed).
+            config = load_config_readonly()
             enabled = _get_platform_tools(config, "cli", include_default_mcp_servers=False)
 
             for ts_key, label, _desc in CONFIGURABLE_TOOLSETS:
@@ -2047,7 +2092,13 @@ class SlashCommandCompleter(Completer):
                 describe_personality,
             )
 
-            personalities = available_personalities(load_cli_config())
+            # mtime-keyed memo: load_cli_config() does a full YAML parse + deep
+            # merge of the built-in defaults on every call, and this completer
+            # runs on every keystroke of /personality. The personalities list
+            # only changes when config.yaml changes on disk, so the memo stays
+            # freshness-correct (same pattern as load_env / _nous_auth_status_cache).
+            personalities = _personalities_from_cli_config()
+
             if "none".startswith(sub_lower) and "none" != sub_lower:
                 yield Completion(
                     "none",

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -436,7 +436,6 @@ from typing import Optional
 
 import functools as _functools
 
-from hermes_cli.sessions_cmd import cmd_sessions  # noqa: F401
 from hermes_cli.subcommands._shared import add_accept_hooks_flag as _add_accept_hooks_flag
 from hermes_cli.subcommands.cron import build_cron_parser
 from hermes_cli.subcommands.sync import build_sync_parser
@@ -4363,13 +4362,168 @@ def _remove_custom_provider(config):
 _LAZY_MODEL_EXPORTS = ("_PROVIDER_MODELS",)
 
 
+# The main.py decomposition moved the sessions/update/dashboard command
+# implementations into their own modules, but main.py still re-exports their
+# surface so argparse wiring and test monkeypatches on hermes_cli.main.<name>
+# keep resolving unchanged. Importing those modules eagerly costs ~50ms on
+# every `hermes` invocation, including fast paths like `hermes --version`
+# that never run a subcommand. Resolve the re-exports through the module
+# __getattr__ below instead, so each module is only imported when one of its
+# names is actually touched. Monkeypatching keeps working: patch.object sets
+# a real module attribute, which shadows __getattr__.
+_LAZY_COMMAND_EXPORTS = {
+    "hermes_cli.sessions_cmd": (
+        "cmd_sessions",
+    ),
+    "hermes_cli.dashboard_procs": (
+        "_detect_concurrent_hermes_instances",
+        "_filter_dashboard_respawn_candidates",
+        "_kill_stale_dashboard_processes",
+        "_scan_dashboard_processes",
+    ),
+    "hermes_cli.update_cmd": (
+        "_add_upstream_remote",
+        "_atomic_replace_dir",
+        "_capture_active_lazy_features",
+        "_capture_active_tool_dependencies",
+        "_capture_head_sha",
+        "_cmd_update_check",
+        "_cmd_update_impl",
+        "_cold_start_windows_gateway_after_update",
+        "_count_commits_between",
+        "_detect_self_loaded_native_modules",
+        "_detect_venv_python_processes",
+        "_defer_update_for_self_lock",
+        "_discard_lockfile_churn",
+        "_discard_stashed_changes",
+        "_ensure_acp_launcher",
+        "_ensure_fhs_path_guard",
+        "_ensure_uv_for_termux",
+        "_finish_dashboard_update_cleanup",
+        "_for_each_systemd_gateway_unit",
+        "_format_concurrent_instances_message",
+        "_format_time_ago",
+        "_format_venv_python_holders_message",
+        "_gateway_prompt",
+        "_get_origin_url",
+        "_has_upstream_remote",
+        "_install_psutil_android_compat",
+        "_invalidate_update_cache",
+        "_is_android_python",
+        "_is_fork",
+        "_leftover_pausable_gateway_pids",
+        "_log_only_write",
+        "_mark_skip_upstream_prompt",
+        "_npm_bin_exists",
+        "_npm_lockfile_changed",
+        "_npm_manifest_paths",
+        "_npm_manifests_digest",
+        "_orphaned_desktop_backend_pids",
+        "_pause_windows_gateways_for_update",
+        "_print_curator_first_run_notice",
+        "_print_curator_recent_run_notice",
+        "_print_fts_optimize_available_notice",
+        "_print_stash_cleanup_guidance",
+        "_print_update_completion",
+        "_record_npm_lockfile_hash",
+        "_refresh_active_lazy_features",
+        "_refresh_active_memory_provider_dependencies",
+        "_refresh_bootstrap_cache_scripts",
+        "_refresh_windows_gateway_launchers",
+        "_reload_updated_runtime_modules",
+        "_resolve_pre_update_backup_mode",
+        "_resolve_stash_selector",
+        "_restart_phase_failure_is_incomplete",
+        "_restore_active_tool_dependencies",
+        "_restore_stashed_changes",
+        "_resume_windows_gateways_after_update",
+        "_run_logged_subprocess",
+        "_run_pre_update_backup",
+        "_should_skip_upstream_prompt",
+        "_stash_apply_failed_only_on_existing_untracked",
+        "_stash_local_changes_if_needed",
+        "_stop_process_trees",
+        "_surviving_gateway_pids_after_failed_restart",
+        "_sync_fork_with_upstream",
+        "_sync_with_upstream_if_needed",
+        "_update_node_dependencies",
+        "_update_via_zip",
+        "_upgrade_pip_before_lazy_refresh",
+        "_validate_critical_files_syntax",
+        "_validate_critical_modules_import",
+        "_venv_core_imports_healthy",
+        "_venv_launcher_ancestors",
+        "_wait_for_windows_update_gateway_exit",
+        "_warn_gateway_restart_phase_aborted",
+        "_warn_incomplete_gateway_fleet_restart",
+        "_web_build_toolchain_ready",
+        "_web_toolchain_roots",
+        "_write_lazy_refresh_incomplete_marker",
+        "_write_marker_file",
+        "_write_update_incomplete_marker",
+        "_write_update_planned_stop_marker",
+        "_UPDATE_RUNTIME_RELOAD_MODULES",
+        "_UPDATE_CRITICAL_FILES",
+        "_UPDATE_CRITICAL_MODULES",
+        "OFFICIAL_REPO_URLS",
+        "OFFICIAL_REPO_URL",
+        "SKIP_UPSTREAM_PROMPT_FILE",
+        "_PRE_UPDATE_SNAPSHOT_KEEP",
+        "_PRE_UPDATE_SNAPSHOT_MAX_FILE_SIZE",
+    ),
+}
+
+_LAZY_COMMAND_ATTR_TO_MODULE = {
+    attr: module for module, attrs in _LAZY_COMMAND_EXPORTS.items() for attr in attrs
+}
+
+# Back-compat alias: some tests and external callers import the old warn-only
+# name. The kill behaviour replaced it; resolve to the new name lazily.
+_LAZY_COMMAND_ALIASES = {
+    "_warn_stale_dashboard_processes": (
+        "hermes_cli.dashboard_procs",
+        "_kill_stale_dashboard_processes",
+    ),
+}
+
+
+def _self():
+    """This module, for attribute access at call time.
+
+    Bare-name global lookups inside this module do not go through the PEP 562
+    __getattr__ below, so internal callers of the lazily re-exported names use
+    _self().<name> instead. That resolves the lazy re-export on first use and
+    keeps monkeypatches on hermes_cli.main.<name> working, exactly like a
+    globals lookup did. ``sys`` is imported locally because some tests patch
+    this module's ``sys`` attribute.
+    """
+    import sys as _sys
+
+    return _sys.modules[__name__]
+
+
 def __getattr__(name):
-    """Defer the model-catalog import until something actually reads it."""
+    """Defer the model-catalog and command-module imports until first read."""
     if name in _LAZY_MODEL_EXPORTS:
         from hermes_cli.models import _PROVIDER_MODELS
         # Cache on the module so subsequent accesses skip the import machinery.
         globals()[name] = _PROVIDER_MODELS
         return _PROVIDER_MODELS
+    module = _LAZY_COMMAND_ATTR_TO_MODULE.get(name)
+    if module is not None:
+        import importlib
+
+        value = getattr(importlib.import_module(module), name)
+        globals()[name] = value
+        return value
+    alias = _LAZY_COMMAND_ALIASES.get(name)
+    if alias is not None:
+        import importlib
+
+        module_name, attr = alias
+        value = getattr(importlib.import_module(module_name), attr)
+        globals()[name] = value
+        return value
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
@@ -5182,100 +5336,11 @@ def _clear_bytecode_cache(root: Path) -> int:
     return removed
 
 
-# Update pipeline extracted to hermes_cli/update_cmd.py (main.py decomposition,
-# mechanical move). Every moved name is re-exported here so the argparse wiring
-# and existing test monkeypatches (hermes_cli.main._cmd_update_impl,
-# hermes_cli.main._run_pre_update_backup, ...) keep resolving unchanged.
-from hermes_cli.update_cmd import (  # noqa: F401
-    _add_upstream_remote,
-    _atomic_replace_dir,
-    _capture_active_lazy_features,
-    _capture_active_tool_dependencies,
-    _capture_head_sha,
-    _cmd_update_check,
-    _cmd_update_impl,
-    _cold_start_windows_gateway_after_update,
-    _count_commits_between,
-    _detect_self_loaded_native_modules,
-    _detect_venv_python_processes,
-    _defer_update_for_self_lock,
-    _discard_lockfile_churn,
-    _discard_stashed_changes,
-    _ensure_acp_launcher,
-    _ensure_fhs_path_guard,
-    _ensure_uv_for_termux,
-    _finish_dashboard_update_cleanup,
-    _for_each_systemd_gateway_unit,
-    _format_concurrent_instances_message,
-    _format_time_ago,
-    _format_venv_python_holders_message,
-    _gateway_prompt,
-    _get_origin_url,
-    _has_upstream_remote,
-    _install_psutil_android_compat,
-    _invalidate_update_cache,
-    _is_android_python,
-    _is_fork,
-    _leftover_pausable_gateway_pids,
-    _log_only_write,
-    _mark_skip_upstream_prompt,
-    _npm_bin_exists,
-    _npm_lockfile_changed,
-    _npm_manifest_paths,
-    _npm_manifests_digest,
-    _orphaned_desktop_backend_pids,
-    _pause_windows_gateways_for_update,
-    _print_curator_first_run_notice,
-    _print_curator_recent_run_notice,
-    _print_fts_optimize_available_notice,
-    _print_stash_cleanup_guidance,
-    _print_update_completion,
-    _record_npm_lockfile_hash,
-    _refresh_active_lazy_features,
-    _refresh_active_memory_provider_dependencies,
-    _refresh_bootstrap_cache_scripts,
-    _refresh_windows_gateway_launchers,
-    _reload_updated_runtime_modules,
-    _resolve_pre_update_backup_mode,
-    _resolve_stash_selector,
-    _restart_phase_failure_is_incomplete,
-    _restore_active_tool_dependencies,
-    _restore_stashed_changes,
-    _resume_windows_gateways_after_update,
-    _run_logged_subprocess,
-    _run_pre_update_backup,
-    _should_skip_upstream_prompt,
-    _stash_apply_failed_only_on_existing_untracked,
-    _stash_local_changes_if_needed,
-    _stop_process_trees,
-    _surviving_gateway_pids_after_failed_restart,
-    _sync_fork_with_upstream,
-    _sync_with_upstream_if_needed,
-    _update_node_dependencies,
-    _update_via_zip,
-    _upgrade_pip_before_lazy_refresh,
-    _validate_critical_files_syntax,
-    _validate_critical_modules_import,
-    _venv_core_imports_healthy,
-    _venv_launcher_ancestors,
-    _wait_for_windows_update_gateway_exit,
-    _warn_gateway_restart_phase_aborted,
-    _warn_incomplete_gateway_fleet_restart,
-    _web_build_toolchain_ready,
-    _web_toolchain_roots,
-    _write_lazy_refresh_incomplete_marker,
-    _write_marker_file,
-    _write_update_incomplete_marker,
-    _write_update_planned_stop_marker,
-    _UPDATE_RUNTIME_RELOAD_MODULES,
-    _UPDATE_CRITICAL_FILES,
-    _UPDATE_CRITICAL_MODULES,
-    OFFICIAL_REPO_URLS,
-    OFFICIAL_REPO_URL,
-    SKIP_UPSTREAM_PROMPT_FILE,
-    _PRE_UPDATE_SNAPSHOT_KEEP,
-    _PRE_UPDATE_SNAPSHOT_MAX_FILE_SIZE,
-)
+# Update pipeline lives in hermes_cli/update_cmd.py (main.py decomposition,
+# mechanical move). Its names are re-exported lazily through the module-level
+# __getattr__ above (see _LAZY_COMMAND_EXPORTS) so argparse wiring and test
+# monkeypatches on hermes_cli.main.<name> keep resolving unchanged without
+# paying the update_cmd import cost on every CLI invocation.
 
 # Stamp file recording the checkout fingerprint the bytecode cache was last
 # validated against. Lives next to the checkout (NOT in HERMES_HOME) because
@@ -7570,22 +7635,17 @@ def cmd_gui(args: argparse.Namespace):
     sys.exit(launch_result.returncode)
 
 
-# Dashboard process-hygiene helpers extracted to hermes_cli/dashboard_procs.py
-# (main.py decomposition, mechanical move). Re-exported so callers and test
-# monkeypatches on hermes_cli.main.<name> keep resolving unchanged.
-from hermes_cli.dashboard_procs import (  # noqa: F401
-    _detect_concurrent_hermes_instances,
-    _filter_dashboard_respawn_candidates,
-    _kill_stale_dashboard_processes,
-    _scan_dashboard_processes,
-)
+# Dashboard process-hygiene helpers live in hermes_cli/dashboard_procs.py
+# (main.py decomposition, mechanical move). Re-exported lazily through the
+# module-level __getattr__ above so callers and test monkeypatches on
+# hermes_cli.main.<name> keep resolving unchanged.
 
 def _find_stale_dashboard_pids(
     *,
     exclude_pids: set[int] | None = None,
 ) -> list[int]:
     """Return PIDs of stale ``dashboard``/``serve`` processes for update cleanup."""
-    return [pid for pid, _cmd in _scan_dashboard_processes(exclude_pids=exclude_pids)]
+    return [pid for pid, _cmd in _self()._scan_dashboard_processes(exclude_pids=exclude_pids)]
 
 
 def _parse_dashboard_runtime(command: str) -> tuple[str, str, int] | None:
@@ -7947,7 +8007,7 @@ def _respawn_dashboard_processes(commands: list[list[str]]) -> list[list[str]]:
 
 # Back-compat alias: some tests and any external callers may import the old
 # warn-only name.  The new behaviour (kill stale processes) replaces it.
-_warn_stale_dashboard_processes = _kill_stale_dashboard_processes
+# Resolved lazily via _LAZY_COMMAND_ALIASES near the module __getattr__.
 
 
 # =========================================================================
@@ -9442,7 +9502,7 @@ def cmd_update(args):
         # --check honors --branch so the "any new commits?" answer matches
         # what a subsequent `hermes update --branch=<x>` would actually pull.
         branch = _resolve_update_branch(args)
-        _cmd_update_check(
+        _self()._cmd_update_check(
             branch=branch,
             branch_explicit=bool(getattr(args, "branch", None)),
         )
@@ -9473,7 +9533,7 @@ def cmd_update(args):
         sys.exit(UPDATE_EXIT_CONCURRENT)
 
     try:
-        _cmd_update_impl(args, gateway_mode=gateway_mode)
+        _self()._cmd_update_impl(args, gateway_mode=gateway_mode)
     finally:
         _update_lock.release()
         _finalize_update_output(_update_io_state)
@@ -10217,7 +10277,7 @@ def _report_dashboard_status() -> int:
     from gateway.status import _pid_exists
 
     live: list[tuple[int, str]] = []
-    for pid, command in _scan_dashboard_processes():
+    for pid, command in _self()._scan_dashboard_processes():
         runtime = _parse_dashboard_runtime(command)
         if runtime is None:
             continue
@@ -10531,7 +10591,7 @@ def cmd_dashboard(args):
             print("No hermes dashboard processes running.")
             sys.exit(0)
         # Reuse the same SIGTERM-grace-SIGKILL path used after `hermes update`.
-        _kill_stale_dashboard_processes(reason="requested via --stop")
+        _self()._kill_stale_dashboard_processes(reason="requested via --stop")
         # _kill_stale_dashboard_processes prints outcomes itself.  Exit 0 if
         # we killed at least one, 1 if they were all unkillable.
         remaining = _find_stale_dashboard_pids()
@@ -12838,10 +12898,13 @@ def main():
     # cmd_sessions lives in hermes_cli/sessions_cmd.py (main.py decomposition).
     # sessions_parser is threaded in via functools.partial because the
     # fallthrough branch calls sessions_parser.print_help() (formerly a
-    # closure capture of this main()-local).
-    sessions_parser.set_defaults(
-        func=_functools.partial(cmd_sessions, sessions_parser=sessions_parser)
-    )
+    # closure capture of this main()-local). The indirection through _self()
+    # keeps the sessions_cmd import lazy until the subcommand actually runs
+    # and lets monkeypatches on hermes_cli.main.cmd_sessions keep working.
+    def _dispatch_sessions(_args, *, sessions_parser=sessions_parser):
+        return _self().cmd_sessions(_args, sessions_parser=sessions_parser)
+
+    sessions_parser.set_defaults(func=_dispatch_sessions)
 
     # =========================================================================
     # insights command  (parser built in hermes_cli/subcommands/insights.py)

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -11166,22 +11166,25 @@ def _prepare_agent_startup(args) -> None:
         return
 
     _accept_hooks = bool(getattr(args, "accept_hooks", False))
-    try:
-        from hermes_cli.plugins import start_background_plugin_discovery
+    if not _is_tui_chat_launch(args):
+        # The TUI backend process does its own plugin discovery; the launcher
+        # only spawns Node, so discovery here would be thrown-away work.
+        try:
+            from hermes_cli.plugins import start_background_plugin_discovery
 
-        # Discovery runs in a daemon thread so its ~150ms of manifest
-        # scanning + plugin imports overlaps the rest of startup (cli /
-        # prompt_toolkit imports, worktree git calls). Correctness is
-        # unchanged: every synchronous reader goes through
-        # discover_plugins(), which joins this thread first — including
-        # the discover_plugins() call model_tools makes at import time,
-        # which happens before any tool list is built.
-        start_background_plugin_discovery()
-    except Exception:
-        logger.warning(
-            "plugin discovery failed at CLI startup",
-            exc_info=True,
-        )
+            # Discovery runs in a daemon thread so its ~150ms of manifest
+            # scanning + plugin imports overlaps the rest of startup (cli /
+            # prompt_toolkit imports, worktree git calls). Correctness is
+            # unchanged: every synchronous reader goes through
+            # discover_plugins(), which joins this thread first — including
+            # the discover_plugins() call model_tools makes at import time,
+            # which happens before any tool list is built.
+            start_background_plugin_discovery()
+        except Exception:
+            logger.warning(
+                "plugin discovery failed at CLI startup",
+                exc_info=True,
+            )
     _run_inline_mcp_discovery = True
     if _is_tui_chat_launch(args):
         # The TUI launcher hands off to a dedicated startup path that already

--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -170,6 +170,16 @@ def get_process_hermes_home() -> Path:
     return _hermes_home_from_env()
 
 
+# Process-level memo for get_default_hermes_root(). The function resolves
+# HERMES_HOME against the native home on every call (~80us of path
+# resolution), and it is called at 31+ sites — every _load_global_auth_store()
+# (per provider row in the /model picker), kanban, backup, gateway, update.
+# Its result depends only on (HERMES_HOME, platform native home), which are
+# compared for free on each call, so the memo is freshness-correct even if a
+# test or plugin mutates HERMES_HOME mid-process.
+_default_hermes_root_memo: "tuple[str, str, Path] | None" = None
+
+
 def get_default_hermes_root() -> Path:
     """Return the root Hermes directory for profile-level operations.
 
@@ -187,27 +197,34 @@ def get_default_hermes_root() -> Path:
 
     Import-safe — no dependencies beyond stdlib.
     """
+    global _default_hermes_root_memo
     native_home = _get_platform_default_hermes_home()
     env_home = os.environ.get("HERMES_HOME", "")
+    if _default_hermes_root_memo is not None:
+        memo_native, memo_env, memo_result = _default_hermes_root_memo
+        if memo_native == str(native_home) and memo_env == env_home:
+            return memo_result
+
     if not env_home:
-        return native_home
-    env_path = Path(env_home)
-    try:
-        env_path.resolve().relative_to(native_home.resolve())
-        # HERMES_HOME is under ~/.hermes (normal or profile mode)
-        return native_home
-    except ValueError:
-        pass
-
-    # Docker / custom deployment.
-    # Check if this is a profile path: <root>/profiles/<name>
-    # If the immediate parent dir is named "profiles", the root is
-    # the grandparent — this covers Docker profiles correctly.
-    if env_path.parent.name == "profiles":
-        return env_path.parent.parent
-
-    # Not a profile path — HERMES_HOME itself is the root
-    return env_path
+        result = native_home
+    else:
+        env_path = Path(env_home)
+        try:
+            env_path.resolve().relative_to(native_home.resolve())
+            # HERMES_HOME is under ~/.hermes (normal or profile mode)
+            result = native_home
+        except ValueError:
+            # Docker / custom deployment.
+            # Check if this is a profile path: <root>/profiles/<name>
+            # If the immediate parent dir is named "profiles", the root is
+            # the grandparent — this covers Docker profiles correctly.
+            if env_path.parent.name == "profiles":
+                result = env_path.parent.parent
+            else:
+                # Not a profile path — HERMES_HOME itself is the root
+                result = env_path
+    _default_hermes_root_memo = (str(native_home), env_home, result)
+    return result
 
 
 def get_optional_skills_dir(default: Path | None = None) -> Path:

--- a/run_agent.py
+++ b/run_agent.py
@@ -3568,12 +3568,21 @@ class AIAgent:
         ``HERMES_FILE_MUTATION_VERIFIER`` env var overrides config.  Exposed
         as a method so tests can patch a single seam without reaching into
         the private ``_turn_failed_file_mutations`` state dict.
+
+        The config lookup is read once per agent and cached (mirroring
+        ``_credits_notices_enabled``) — the footer gate runs at the end of
+        every turn, and a config flip applying on the next session is fine.
+        The env-var override stays authoritative on every call and is never
+        cached, so tests and operators can still flip it at runtime.
         """
         try:
             import os as _os
             env = _os.environ.get("HERMES_FILE_MUTATION_VERIFIER")
             if env is not None:
                 return env.strip().lower() not in {"0", "false", "no", "off"}
+            cached = getattr(self, "_file_mutation_verifier_enabled_cache", None)
+            if cached is not None:
+                return cached
             # Read from the persisted config.yaml so gateway and CLI share
             # the same setting.  Import lazily to avoid a startup-time cycle.
             try:
@@ -3583,7 +3592,11 @@ class AIAgent:
                 _cfg = {}
             _display = _cfg.get("display") if isinstance(_cfg, dict) else None
             if isinstance(_display, dict) and "file_mutation_verifier" in _display:
-                return bool(_display.get("file_mutation_verifier"))
+                enabled = bool(_display.get("file_mutation_verifier"))
+            else:
+                enabled = True  # safe default: verifier on
+            self._file_mutation_verifier_enabled_cache = enabled
+            return enabled
         except Exception:
             pass
         return True  # safe default: verifier on
@@ -3665,12 +3678,21 @@ class AIAgent:
         True).  ``HERMES_TURN_COMPLETION_EXPLAINER`` env var overrides
         config.  Exposed as a method so tests can patch a single seam,
         mirroring ``_file_mutation_verifier_enabled``.
+
+        The config lookup is read once per agent and cached (mirroring
+        ``_credits_notices_enabled``) — the gate runs at the end of every
+        turn, and a config flip applying on the next session is fine.
+        The env-var override stays authoritative on every call and is never
+        cached, so tests and operators can still flip it at runtime.
         """
         try:
             import os as _os
             env = _os.environ.get("HERMES_TURN_COMPLETION_EXPLAINER")
             if env is not None:
                 return env.strip().lower() not in {"0", "false", "no", "off"}
+            cached = getattr(self, "_turn_completion_explainer_enabled_cache", None)
+            if cached is not None:
+                return cached
             # Read from the persisted config.yaml so gateway and CLI share
             # the same setting.  Import lazily to avoid a startup-time cycle.
             try:
@@ -3680,7 +3702,11 @@ class AIAgent:
                 _cfg = {}
             _display = _cfg.get("display") if isinstance(_cfg, dict) else None
             if isinstance(_display, dict) and "turn_completion_explainer" in _display:
-                return bool(_display.get("turn_completion_explainer"))
+                enabled = bool(_display.get("turn_completion_explainer"))
+            else:
+                enabled = True  # safe default: explainer on
+            self._turn_completion_explainer_enabled_cache = enabled
+            return enabled
         except Exception:
             pass
         return True  # safe default: explainer on

--- a/tests/hermes_cli/test_completer_config_reads.py
+++ b/tests/hermes_cli/test_completer_config_reads.py
@@ -52,9 +52,13 @@ class TestToolsCompletionsReadonlyConfig:
             return {}
 
         # The completer imports the loader inside the function, so patch the
-        # source module.
+        # source module. Portable-MCP lookup is stubbed because it triggers
+        # one-time plugin discovery (which legitimately calls load_config
+        # during process init) — this test asserts on the completer's own
+        # per-keystroke reads, not discovery's one-off startup reads.
         with patch("hermes_cli.config.load_config", counting_deepcopy), \
              patch("hermes_cli.config.load_config_readonly", counting_readonly), \
+             patch("hermes_cli.plugins.get_portable_mcp_server_names_nowait", lambda: set()), \
              patch("hermes_cli.tools_config._get_plugin_toolset_keys", lambda: set()), \
              patch("hermes_cli.tools_config._homeassistant_credentials_present", lambda: False), \
              patch("hermes_cli.tools_config._xai_credentials_present", lambda: False):

--- a/tests/hermes_cli/test_completer_config_reads.py
+++ b/tests/hermes_cli/test_completer_config_reads.py
@@ -1,0 +1,135 @@
+"""Measured-work pins for the slash-completer config reads.
+
+The /tools and /personality completers run on every keystroke while the
+user types those commands (complete_while_typing). They used to re-read +
+re-parse the full config on every keypress: load_config()'s defensive
+deepcopy (~345us tax) in _tools_completions, and load_cli_config()'s full
+YAML parse + defaults deep-merge (~110us) in _personality_completions.
+These pins hold the per-keystroke cost down:
+- _tools_completions uses the read-only loader (no deepcopy).
+- _personality_completions memoises the personalities source keyed on the
+  config file's mtime, so the parse+merge runs once per config state.
+"""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import patch
+
+import pytest
+
+import hermes_cli.commands as commands_mod
+
+
+def _reset_personalities_memo():
+    commands_mod._personalities_memo = None
+
+
+@pytest.fixture(autouse=True)
+def _reset_memo():
+    _reset_personalities_memo()
+    yield
+    _reset_personalities_memo()
+
+
+class TestToolsCompletionsReadonlyConfig:
+    def test_uses_readonly_loader(self):
+        """_tools_completions must not pay the defensive deepcopy.
+
+        The completer only reads the config (toolset enable state + MCP
+        server names). Using load_config_readonly() skips the ~345us
+        deepcopy that load_config() applies on every cache hit — a
+        per-keystroke cost while completing /tools enable|disable.
+        """
+        calls = {"deepcopy": 0, "readonly": 0}
+
+        def counting_deepcopy(*a, **k):
+            calls["deepcopy"] += 1
+            return {}
+
+        def counting_readonly(*a, **k):
+            calls["readonly"] += 1
+            return {}
+
+        # The completer imports the loader inside the function, so patch the
+        # source module.
+        with patch("hermes_cli.config.load_config", counting_deepcopy), \
+             patch("hermes_cli.config.load_config_readonly", counting_readonly), \
+             patch("hermes_cli.tools_config._get_plugin_toolset_keys", lambda: set()), \
+             patch("hermes_cli.tools_config._homeassistant_credentials_present", lambda: False), \
+             patch("hermes_cli.tools_config._xai_credentials_present", lambda: False):
+            list(commands_mod.SlashCommandCompleter._tools_completions("enable ", "enable "))
+
+        assert calls["readonly"] == 1, "completer should use the readonly loader"
+        assert calls["deepcopy"] == 0, (
+            "completer must not call the deepcopy loader on a read-only path"
+        )
+
+
+class TestPersonalityCompletionsMemo:
+    def test_load_cli_config_called_once_per_config_state(self, monkeypatch):
+        """The /personality completer parses the config once per state.
+
+        load_cli_config() does a full YAML parse + deep merge of the
+        built-in defaults; the completer runs on every keystroke. The
+        mtime-keyed memo keeps that parse to once per config change.
+        """
+        calls = {"n": 0}
+
+        def counting_load_cli_config():
+            calls["n"] += 1
+            return {
+                "agent": {
+                    "personalities": {
+                        "helpful": "You are helpful.",
+                        "concise": "You are concise.",
+                    }
+                }
+            }
+
+        monkeypatch.setattr(commands_mod, "_personalities_memo", None)
+        with patch("cli.load_cli_config", counting_load_cli_config):
+            # First call: cache miss -> one parse.
+            list(commands_mod.SlashCommandCompleter._personality_completions("hel", "hel"))
+            assert calls["n"] == 1, "first call should parse once"
+
+            # Subsequent keystrokes: cache hit -> no re-parse.
+            for _ in range(10):
+                list(commands_mod.SlashCommandCompleter._personality_completions("hel", "hel"))
+            assert calls["n"] == 1, (
+                "repeated keystrokes must reuse the memoised personalities, "
+                f"got {calls['n']} parses"
+            )
+
+    def test_mtime_change_reparses(self, monkeypatch, tmp_path):
+        """A config file change on disk invalidates the memo."""
+        from pathlib import Path
+
+        cfg_path = tmp_path / "config.yaml"
+        cfg_path.write_text(
+            "agent:\n  personalities:\n    helpful: \"v1\"\n",
+            encoding="utf-8",
+        )
+        # Pin an explicit mtime so the change below is a guaranteed mtime_ns
+        # bump regardless of filesystem timestamp granularity.
+        os.utime(cfg_path, (1_700_000_000, 1_700_000_000))
+
+        calls = {"n": 0}
+
+        def counting_load_cli_config():
+            calls["n"] += 1
+            return {"agent": {"personalities": {"helpful": "v1"}}}
+
+        def fake_config_path():
+            return cfg_path
+
+        monkeypatch.setattr(commands_mod, "_personalities_memo", None)
+        with patch("cli.load_cli_config", counting_load_cli_config), \
+             patch("hermes_cli.config.get_config_path", fake_config_path):
+            list(commands_mod.SlashCommandCompleter._personality_completions("h", "h"))
+            assert calls["n"] == 1
+
+            # Bump the file mtime -> memo invalidates -> re-parse once.
+            os.utime(cfg_path, (1_800_000_000, 1_800_000_000))
+            list(commands_mod.SlashCommandCompleter._personality_completions("h", "h"))
+            assert calls["n"] == 2, "config mtime change should re-parse once"

--- a/tests/hermes_cli/test_global_auth_store_memo.py
+++ b/tests/hermes_cli/test_global_auth_store_memo.py
@@ -1,0 +1,107 @@
+"""Measured-work pins for the _load_global_auth_store() memo.
+
+read_credential_pool() -> load_pool() runs _load_global_auth_store() once per
+provider row in the /model picker, and the global-store JSON read + parse
+cost ~60-100us+ per call even when nothing changed. The memo keyed on the
+global auth file's path+mtime makes repeat reads a dict lookup. The store
+only changes when the user authenticates at global scope (writes always go
+through _save_auth_store, which touches the file), so the mtime key keeps
+the memo freshness-correct.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+
+import pytest
+
+import hermes_cli.auth as auth_mod
+
+
+@pytest.fixture(autouse=True)
+def _reset_cache():
+    auth_mod._global_auth_store_cache = None
+    yield
+    auth_mod._global_auth_store_cache = None
+
+
+def _make_global_store(tmp_path) -> "os.PathLike[str]":
+    """Write a realistic global auth.json and return its path."""
+    path = tmp_path / "global-hermes" / "auth.json"
+    path.parent.mkdir(parents=True)
+    path.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "providers": {
+                    "openai": {"api_key": "sk-x"},
+                    "anthropic": {"api_key": "an-x"},
+                },
+                "credential_pool": {
+                    "openai": [{"id": "1", "access_token": "t"}],
+                    "anthropic": [{"id": "2", "access_token": "u"}],
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    return path
+
+
+class TestLoadGlobalAuthStoreMemo:
+    def test_repeated_calls_read_store_once(self, tmp_path, monkeypatch):
+        """Repeated calls must not re-read/re-parse the global store."""
+        global_path = _make_global_store(tmp_path)
+        monkeypatch.setattr(
+            auth_mod, "_global_auth_file_path", lambda: global_path
+        )
+        reads = {"n": 0}
+        orig = auth_mod._load_auth_store
+
+        def counting_load(store_path=None):
+            reads["n"] += 1
+            return orig(store_path)
+
+        monkeypatch.setattr(auth_mod, "_load_auth_store", counting_load)
+
+        first = auth_mod._load_global_auth_store()
+        for _ in range(10):
+            auth_mod._load_global_auth_store()
+        assert reads["n"] == 1, (
+            "repeated calls must be memo hits (store read once), "
+            f"got {reads['n']}"
+        )
+        assert first.get("providers", {}).get("openai") == {"api_key": "sk-x"}
+
+    def test_mtime_change_re_reads_once(self, tmp_path, monkeypatch):
+        """A store file change on disk invalidates the memo."""
+        global_path = _make_global_store(tmp_path)
+        monkeypatch.setattr(
+            auth_mod, "_global_auth_file_path", lambda: global_path
+        )
+        reads = {"n": 0}
+        orig = auth_mod._load_auth_store
+
+        def counting_load(store_path=None):
+            reads["n"] += 1
+            return orig(store_path)
+
+        monkeypatch.setattr(auth_mod, "_load_auth_store", counting_load)
+
+        auth_mod._load_global_auth_store()
+        assert reads["n"] == 1
+
+        # Bump the file mtime -> memo invalidates -> re-read once.
+        os.utime(global_path, (1_700_000_000, 1_700_000_000))
+        auth_mod._load_global_auth_store()
+        assert reads["n"] == 2, "mtime change must force exactly one re-read"
+
+    def test_absent_global_store_returns_empty_without_error(self, tmp_path, monkeypatch):
+        """No global fallback (classic mode) returns {} and stays cheap."""
+        missing = tmp_path / "no-such" / "auth.json"
+        monkeypatch.setattr(
+            auth_mod, "_global_auth_file_path", lambda: missing
+        )
+        assert auth_mod._load_global_auth_store() == {}
+        assert auth_mod._global_auth_store_cache is None

--- a/tests/hermes_cli/test_global_auth_store_memo.py
+++ b/tests/hermes_cli/test_global_auth_store_memo.py
@@ -20,10 +20,17 @@ import hermes_cli.auth as auth_mod
 
 
 @pytest.fixture(autouse=True)
-def _reset_cache():
-    auth_mod._global_auth_store_cache = None
+def _reset_cache(monkeypatch):
+    # raising=False: on pre-fix code the memo attribute doesn't exist (that
+    # IS the fix); the reset is a no-op there so the measured-work assertions
+    # fail genuinely instead of erroring.
+    monkeypatch.setattr(
+        auth_mod, "_global_auth_store_cache", None, raising=False
+    )
     yield
-    auth_mod._global_auth_store_cache = None
+    monkeypatch.setattr(
+        auth_mod, "_global_auth_store_cache", None, raising=False
+    )
 
 
 def _make_global_store(tmp_path) -> "os.PathLike[str]":

--- a/tests/hermes_cli/test_lazy_command_exports.py
+++ b/tests/hermes_cli/test_lazy_command_exports.py
@@ -1,0 +1,66 @@
+"""The decomposed command modules stay lazy after `import hermes_cli.main`.
+
+The main.py decomposition re-exports the sessions/update/dashboard command
+surface from hermes_cli.main so argparse wiring and monkeypatches keep
+resolving. Those re-exports must not import the modules eagerly: every
+`hermes` invocation (including `hermes --version`) would pay for update_cmd's
+dependency chain (jwt, click, ...) even when no subcommand runs.
+"""
+
+import subprocess
+import sys
+import textwrap
+
+import hermes_cli.main
+
+
+def test_importing_main_does_not_import_command_modules():
+    code = textwrap.dedent(
+        """
+        import sys
+        import hermes_cli.main  # noqa: F401
+        loaded = [
+            m
+            for m in (
+                "hermes_cli.update_cmd",
+                "hermes_cli.sessions_cmd",
+                "hermes_cli.dashboard_procs",
+            )
+            if m in sys.modules
+        ]
+        assert not loaded, f"eagerly imported: {loaded}"
+        """
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    assert result.returncode == 0, result.stderr
+
+
+def test_lazy_reexports_resolve_to_real_objects():
+    import hermes_cli.dashboard_procs
+    import hermes_cli.sessions_cmd
+    import hermes_cli.update_cmd
+
+    assert hermes_cli.main.cmd_sessions is hermes_cli.sessions_cmd.cmd_sessions
+    assert (
+        hermes_cli.main._cmd_update_impl is hermes_cli.update_cmd._cmd_update_impl
+    )
+    assert (
+        hermes_cli.main._scan_dashboard_processes
+        is hermes_cli.dashboard_procs._scan_dashboard_processes
+    )
+    # Back-compat alias resolves to the kill helper.
+    assert (
+        hermes_cli.main._warn_stale_dashboard_processes
+        is hermes_cli.dashboard_procs._kill_stale_dashboard_processes
+    )
+
+
+def test_lazy_reexports_accept_monkeypatch(monkeypatch):
+    sentinel = object()
+    monkeypatch.setattr("hermes_cli.main._cmd_update_impl", sentinel)
+    assert hermes_cli.main._cmd_update_impl is sentinel

--- a/tests/hermes_cli/test_tui_launcher_skips_plugin_discovery.py
+++ b/tests/hermes_cli/test_tui_launcher_skips_plugin_discovery.py
@@ -1,0 +1,63 @@
+
+"""Regression test: the TUI launcher must not spend time on plugin discovery.
+
+`hermes --tui` just spawns a Node process; the spawned tui_gateway backend
+performs its own plugin discovery. Running discover_plugins() in the
+launcher added ~0.5s to every `hermes --tui` startup for work the backend
+then redoes. Plain chat must still discover plugins.
+"""
+
+from __future__ import annotations
+
+from argparse import Namespace
+import sys
+import types
+
+from hermes_cli import main as main_mod
+
+
+def _install_discover_spy(monkeypatch):
+    calls = []
+
+    def _discover():
+        calls.append("discover")
+
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_cli.plugins",
+        types.SimpleNamespace(
+            discover_plugins=_discover,
+            # main.py now kicks discovery off in a background thread; both
+            # entry points count as "discovery work happened in the launcher".
+            start_background_plugin_discovery=_discover,
+        ),
+    )
+    return calls
+
+
+def _args(**overrides):
+    base = {
+        "accept_hooks": False,
+        "yolo": False,
+        "safe_mode": False,
+        "command": None,
+        "query": None,
+        "image": None,
+    }
+    base.update(overrides)
+    return Namespace(**base)
+
+
+def test_plugin_discovery_skipped_for_tui_launch(monkeypatch):
+    calls = _install_discover_spy(monkeypatch)
+    main_mod._prepare_agent_startup(_args(tui=True))
+    assert calls == [], (
+        "Plugin discovery must not run in the TUI launcher: the spawned "
+        "tui_gateway backend discovers plugins itself."
+    )
+
+
+def test_plugin_discovery_runs_for_plain_chat(monkeypatch):
+    calls = _install_discover_spy(monkeypatch)
+    main_mod._prepare_agent_startup(_args(tui=False, command="chat"))
+    assert calls == ["discover"]

--- a/tests/run_agent/test_file_mutation_verifier.py
+++ b/tests/run_agent/test_file_mutation_verifier.py
@@ -317,10 +317,11 @@ class TestVerifierEnabled:
         """Measured-work pin: the config lookup happens once per agent.
 
         The footer gate runs at the end of every turn, so a fresh
-        ``load_config()`` per call is wasted work (~1 ms deepcopy per turn,
-        see #74211 for the sibling per-turn-config kill).  The config read
-        must be cached after the first call; the env-var override must still
-        win on every call, cached or not.
+        ``load_config()`` per call is wasted work (measured ~0.9 ms/call on
+        a warm mtime-cache on this host; the sibling per-turn-config kill in
+        #74211 removed exactly this class of read).  The config read must be
+        cached after the first call; the env-var override must still win on
+        every call, cached or not.
         """
         monkeypatch.delenv("HERMES_FILE_MUTATION_VERIFIER", raising=False)
         agent = _bare_agent()

--- a/tests/run_agent/test_file_mutation_verifier.py
+++ b/tests/run_agent/test_file_mutation_verifier.py
@@ -313,6 +313,56 @@ class TestVerifierEnabled:
         agent = _bare_agent()
         assert agent._file_mutation_verifier_enabled() is False
 
+    def test_config_read_once_then_cached(self, monkeypatch):
+        """Measured-work pin: the config lookup happens once per agent.
+
+        The footer gate runs at the end of every turn, so a fresh
+        ``load_config()`` per call is wasted work (~1 ms deepcopy per turn,
+        see #74211 for the sibling per-turn-config kill).  The config read
+        must be cached after the first call; the env-var override must still
+        win on every call, cached or not.
+        """
+        monkeypatch.delenv("HERMES_FILE_MUTATION_VERIFIER", raising=False)
+        agent = _bare_agent()
+        calls = {"n": 0}
+
+        import hermes_cli.config as _cfg_mod
+
+        def counting_load():
+            calls["n"] += 1
+            return {"display": {"file_mutation_verifier": True}}
+
+        monkeypatch.setattr(_cfg_mod, "load_config", counting_load)
+
+        # First call reads config and caches the result.
+        assert agent._file_mutation_verifier_enabled() is True
+        assert calls["n"] == 1
+        # Subsequent calls must not re-read config.
+        assert agent._file_mutation_verifier_enabled() is True
+        assert agent._file_mutation_verifier_enabled() is True
+        assert calls["n"] == 1
+        # Env override stays authoritative even after the cache is warm.
+        monkeypatch.setenv("HERMES_FILE_MUTATION_VERIFIER", "0")
+        assert agent._file_mutation_verifier_enabled() is False
+        assert calls["n"] == 1  # env path never touches config
+
+    def test_cache_respects_config_value(self, monkeypatch):
+        """A disabled config value is cached as False, not re-read."""
+        monkeypatch.delenv("HERMES_FILE_MUTATION_VERIFIER", raising=False)
+        agent = _bare_agent()
+
+        import hermes_cli.config as _cfg_mod
+        monkeypatch.setattr(
+            _cfg_mod, "load_config", lambda: {"display": {"file_mutation_verifier": False}}
+        )
+        assert agent._file_mutation_verifier_enabled() is False
+        # Warm cache: flip the underlying config; the agent still reports the
+        # cached value (same next-session semantics as _credits_notices_enabled).
+        monkeypatch.setattr(
+            _cfg_mod, "load_config", lambda: {"display": {"file_mutation_verifier": True}}
+        )
+        assert agent._file_mutation_verifier_enabled() is False
+
 
 
 

--- a/tests/run_agent/test_turn_completion_explainer.py
+++ b/tests/run_agent/test_turn_completion_explainer.py
@@ -297,8 +297,9 @@ def test_explainer_config_read_once_then_cached():
     """Measured-work pin: the config lookup happens once per agent.
 
     The explainer gate runs at the end of every turn, so a fresh
-    ``load_config()`` per call is wasted work (per-turn config reads were
-    killed repo-wide in #74211; this seam was missed).  The config read must
+    ``load_config()`` per call is wasted work (measured ~0.9 ms/call on a
+    warm mtime-cache on this host; per-turn config reads were killed
+    repo-wide in #74211, and this seam was missed).  The config read must
     be cached after the first call; the env-var override must still win on
     every call, cached or not.
     """

--- a/tests/run_agent/test_turn_completion_explainer.py
+++ b/tests/run_agent/test_turn_completion_explainer.py
@@ -293,6 +293,40 @@ def test_explainer_disabled_via_env():
         assert agent._turn_completion_explainer_enabled() is False
 
 
+def test_explainer_config_read_once_then_cached():
+    """Measured-work pin: the config lookup happens once per agent.
+
+    The explainer gate runs at the end of every turn, so a fresh
+    ``load_config()`` per call is wasted work (per-turn config reads were
+    killed repo-wide in #74211; this seam was missed).  The config read must
+    be cached after the first call; the env-var override must still win on
+    every call, cached or not.
+    """
+    agent = _make_agent()
+    calls = {"n": 0}
+
+    def counting_load():
+        calls["n"] += 1
+        return {"display": {"turn_completion_explainer": True}}
+
+    with patch.dict(os.environ, {}, clear=False):
+        os.environ.pop("HERMES_TURN_COMPLETION_EXPLAINER", None)
+        with patch("hermes_cli.config.load_config", counting_load):
+            # First call reads config and caches the result.
+            assert agent._turn_completion_explainer_enabled() is True
+            assert calls["n"] == 1
+            # Subsequent calls must not re-read config.
+            assert agent._turn_completion_explainer_enabled() is True
+            assert agent._turn_completion_explainer_enabled() is True
+            assert calls["n"] == 1
+            # Env override stays authoritative even after the cache is warm.
+            with patch.dict(
+                os.environ, {"HERMES_TURN_COMPLETION_EXPLAINER": "0"}, clear=False
+            ):
+                assert agent._turn_completion_explainer_enabled() is False
+            assert calls["n"] == 1  # env path never touches config
+
+
 
 
 # --------------------------------------------------------------------------

--- a/tests/test_hermes_constants.py
+++ b/tests/test_hermes_constants.py
@@ -64,6 +64,52 @@ class TestGetDefaultHermesRoot:
 
         assert get_default_hermes_root() == local_appdata / "hermes"
 
+    def test_result_memoised_until_env_or_home_changes(self, tmp_path, monkeypatch):
+        """Repeated calls reuse the memo; HERMES_HOME / home changes invalidate.
+
+        get_default_hermes_root() resolves HERMES_HOME against the native
+        home (~80us of path resolution) and is called at 31+ sites — every
+        _load_global_auth_store() (per provider row in the /model picker),
+        kanban, backup, gateway, update. The memo is keyed on
+        (native home, HERMES_HOME) compared for free each call.
+        """
+        monkeypatch.delenv("HERMES_HOME", raising=False)
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+        # Probe the expensive inner work: the memo check itself calls
+        # _get_platform_default_hermes_home() on every call (even hits), so
+        # count Path.resolve on the env path instead — only the actual
+        # resolution branch pays it.
+        resolve_calls = {"n": 0}
+        orig_resolve = Path.resolve
+
+        def counting_resolve(self, *a, **k):
+            resolve_calls["n"] += 1
+            return orig_resolve(self, *a, **k)
+
+        monkeypatch.setattr(Path, "resolve", counting_resolve)
+        hermes_constants._default_hermes_root_memo = None
+
+        first = get_default_hermes_root()
+        first_count = resolve_calls["n"]
+        for _ in range(10):
+            get_default_hermes_root()
+        assert resolve_calls["n"] == first_count, (
+            "repeated calls must be memo hits (no path resolution on hits), "
+            f"resolve went {first_count} -> {resolve_calls['n']}"
+        )
+        assert first == tmp_path / ".hermes"
+
+        # HERMES_HOME change invalidates the memo (fresh resolution).
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "elsewhere"))
+        before = resolve_calls["n"]
+        assert get_default_hermes_root() == tmp_path / "elsewhere"
+        assert resolve_calls["n"] > before, (
+            "HERMES_HOME change must force a fresh resolution"
+        )
+
+
+
 
 
 class TestGetHermesHome:

--- a/tests/test_hermes_constants.py
+++ b/tests/test_hermes_constants.py
@@ -73,7 +73,12 @@ class TestGetDefaultHermesRoot:
         kanban, backup, gateway, update. The memo is keyed on
         (native home, HERMES_HOME) compared for free each call.
         """
-        monkeypatch.delenv("HERMES_HOME", raising=False)
+        # HERMES_HOME set to a Docker-profile path: every call resolves the
+        # env path against the native home (the ~80us work the memo skips).
+        docker_root = tmp_path / "opt" / "data"
+        profile = docker_root / "profiles" / "coder"
+        profile.mkdir(parents=True)
+        monkeypatch.setenv("HERMES_HOME", str(profile))
         monkeypatch.setattr(Path, "home", lambda: tmp_path)
 
         # Probe the expensive inner work: the memo check itself calls
@@ -88,7 +93,12 @@ class TestGetDefaultHermesRoot:
             return orig_resolve(self, *a, **k)
 
         monkeypatch.setattr(Path, "resolve", counting_resolve)
-        hermes_constants._default_hermes_root_memo = None
+        # raising=False: on pre-fix code the memo attribute doesn't exist
+        # (that IS the fix); the reset is a no-op there so the measured-work
+        # assertion below fails genuinely instead of erroring.
+        monkeypatch.setattr(
+            hermes_constants, "_default_hermes_root_memo", None, raising=False
+        )
 
         first = get_default_hermes_root()
         first_count = resolve_calls["n"]
@@ -98,12 +108,14 @@ class TestGetDefaultHermesRoot:
             "repeated calls must be memo hits (no path resolution on hits), "
             f"resolve went {first_count} -> {resolve_calls['n']}"
         )
-        assert first == tmp_path / ".hermes"
+        assert first == docker_root
 
         # HERMES_HOME change invalidates the memo (fresh resolution).
-        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "elsewhere"))
+        other_profile = docker_root / "profiles" / "writer"
+        other_profile.mkdir(parents=True)
+        monkeypatch.setenv("HERMES_HOME", str(other_profile))
         before = resolve_calls["n"]
-        assert get_default_hermes_root() == tmp_path / "elsewhere"
+        assert get_default_hermes_root() == docker_root
         assert resolve_calls["n"] > before, (
             "HERMES_HOME change must force a fresh resolution"
         )

--- a/tests/test_toolsets.py
+++ b/tests/test_toolsets.py
@@ -1,5 +1,6 @@
 """Tests for toolsets.py — toolset resolution, validation, and composition."""
 
+import toolsets as toolsets_mod
 from tools.registry import ToolRegistry
 from toolsets import (
     TOOLSETS,
@@ -281,3 +282,77 @@ class TestResolveToolsetIncludeRegistry:
 
     def test_registry_only_toolset_static_view_is_empty(self):
         assert resolve_toolset("__definitely_not_a_real_toolset__", include_registry=False) == []
+
+
+class TestResolveToolsetMemo:
+    """Measured-work pins for the generation-keyed resolution memo."""
+
+    def test_second_resolution_is_cached(self, monkeypatch):
+        """Repeated resolves of the same toolset must not re-walk the registry.
+
+        resolve_toolset is called dozens of times per _get_platform_tools()
+        (every /tools completion keystroke). The memo keyed on the registry
+        generation makes repeat calls a dict lookup instead of a full
+        includes-walk + registry snapshot.
+        """
+        from tools.registry import registry
+
+        toolsets_mod._resolve_toolset_memo.clear()
+        get_toolset_calls = {"n": 0}
+
+        orig_get_toolset = toolsets_mod.get_toolset
+
+        def counting_get_toolset(name, *, include_registry=True):
+            get_toolset_calls["n"] += 1
+            return orig_get_toolset(name, include_registry=include_registry)
+
+        monkeypatch.setattr(toolsets_mod, "get_toolset", counting_get_toolset)
+
+        registry_id = id(registry)
+        generation = registry._generation
+
+        first = resolve_toolset("hermes-cli")
+        second = resolve_toolset("hermes-cli")
+
+        assert first == second
+        assert get_toolset_calls["n"] == 1, (
+            "second resolution must be a memo hit (no get_toolset re-walk), "
+            f"got {get_toolset_calls['n']} calls"
+        )
+        assert (
+            "hermes-cli", True, registry_id, generation
+        ) in toolsets_mod._resolve_toolset_memo
+
+    def test_generation_bump_invalidates_memo(self, monkeypatch):
+        """A registry mutation (generation bump) must force a fresh resolve."""
+        from tools.registry import registry
+
+        toolsets_mod._resolve_toolset_memo.clear()
+        get_toolset_calls = {"n": 0}
+
+        orig_get_toolset = toolsets_mod.get_toolset
+
+        def counting_get_toolset(name, *, include_registry=True):
+            get_toolset_calls["n"] += 1
+            return orig_get_toolset(name, include_registry=include_registry)
+
+        monkeypatch.setattr(toolsets_mod, "get_toolset", counting_get_toolset)
+
+        resolve_toolset("hermes-cli")
+        assert get_toolset_calls["n"] == 1
+
+        # Simulate a registry mutation bumping the generation.
+        registry._generation += 1
+        resolve_toolset("hermes-cli")
+        assert get_toolset_calls["n"] == 2, (
+            "generation bump must invalidate the memo and re-resolve"
+        )
+
+    def test_memo_result_matches_fresh_resolution(self):
+        """The memo must never change the resolved result."""
+        toolsets_mod._resolve_toolset_memo.clear()
+        first = resolve_toolset("hermes-cli", include_registry=False)
+        second = resolve_toolset("hermes-cli", include_registry=False)
+        assert first == second
+        assert first  # non-empty sanity
+

--- a/toolsets.py
+++ b/toolsets.py
@@ -870,6 +870,10 @@ def resolve_toolset(name: str, visited: Set[str] = None, *, include_registry: bo
         except Exception:
             registry_id = 0
             generation = 0
+        # Entries from previous registry generations are never hit again;
+        # keep the memo bounded across long sessions with many MCP refreshes.
+        if len(_resolve_toolset_memo) >= 256:
+            _resolve_toolset_memo.clear()
         _resolve_toolset_memo[(name, include_registry, registry_id, generation)] = list(result)
     return result
 

--- a/toolsets.py
+++ b/toolsets.py
@@ -23,7 +23,7 @@ Usage:
     all_tools = resolve_toolset("full_stack")
 """
 
-from typing import List, Dict, Any, Set, Optional
+from typing import Dict, List, Any, Set, Optional, Tuple
 
 
 # Shared tool list for CLI and all messaging platform toolsets.
@@ -753,6 +753,19 @@ def bundle_non_core_tools(toolset_name: str) -> Set[str]:
     return to_remove
 
 
+# Resolution memo keyed on (toolset name, include_registry, registry
+# generation). resolve_toolset() recursively walks toolset includes and, with
+# include_registry=True, merges registry-registered tools on every call —
+# measured ~2us/toolset in isolation but called dozens of times per
+# _get_platform_tools() (per-keystroke /tools completion) and per picker
+# render. The registry exposes a monotonic _generation counter (bumped on
+# every register/deregister/alias/MCP refresh — see tools/registry.py), so a
+# cache entry is valid for as long as the generation is unchanged; external
+# callers never pass ``visited``, so the memo engages exactly at the public
+# entry and the internal cycle-detection recursion stays untouched.
+_resolve_toolset_memo: Dict[Tuple[str, bool, int, int], List[str]] = {}
+
+
 def resolve_toolset(name: str, visited: Set[str] = None, *, include_registry: bool = True) -> List[str]:
     """
     Recursively resolve a toolset to get all tool names.
@@ -773,6 +786,21 @@ def resolve_toolset(name: str, visited: Set[str] = None, *, include_registry: bo
     Returns:
         List[str]: List of all tool names in the toolset
     """
+    external_call = visited is None
+    if external_call:
+        try:
+            from tools.registry import registry
+
+            registry_id = id(registry)
+            generation = getattr(registry, "_generation", 0)
+        except Exception:
+            registry_id = 0
+            generation = 0
+        memo_key = (name, include_registry, registry_id, generation)
+        cached = _resolve_toolset_memo.get(memo_key)
+        if cached is not None:
+            return list(cached)
+
     if visited is None:
         visited = set()
 
@@ -832,7 +860,18 @@ def resolve_toolset(name: str, visited: Set[str] = None, *, include_registry: bo
         included_tools = resolve_toolset(included_name, visited, include_registry=include_registry)
         tools.update(included_tools)
 
-    return sorted(tools)
+    result = sorted(tools)
+    if external_call:
+        try:
+            from tools.registry import registry
+
+            registry_id = id(registry)
+            generation = getattr(registry, "_generation", 0)
+        except Exception:
+            registry_id = 0
+            generation = 0
+        _resolve_toolset_memo[(name, include_registry, registry_id, generation)] = list(result)
+    return result
 
 
 def resolve_multiple_toolsets(toolset_names: List[str]) -> List[str]:


### PR DESCRIPTION
Salvages the wave-2 CLI startup / hot-path memoization cluster: five contributor perf PRs that together cut CLI launch time and eliminate per-keystroke config re-parsing, each with cache-invalidation regression tests.

## Changes

- **Lazy CLI command re-exports** (#74390, @Adolanium) — `hermes_cli/main.py` no longer eagerly imports `update_cmd`, `sessions_cmd`, and `dashboard_procs` at startup; their names resolve through a PEP 562 module `__getattr__` on first use (~60ms off every CLI start on the contributor's machine). The lazy-export table was regenerated against current main's re-export lists during rebase, and an E2E check confirms none of the three modules are imported by `hermes --help`.
- **No per-keystroke config re-reads in slash completers** (#77899, @spfcraze) — the `/personality` completer memoises `available_personalities(load_cli_config())` keyed on the config file's path+mtime+size (adapted to main's single-owner personality API), and the `/tools` completer's readonly-loader path is regression-pinned.
- **Memoised root + global auth store** (#77965, @spfcraze) — `get_default_hermes_root()` memoised on `(HERMES_HOME, native home)` — inputs re-compared on every call, so mid-process env mutation still invalidates; `_load_global_auth_store()` memoised on path+mtime_ns (writes always touch the file).
- **Memoised `resolve_toolset`** (#77929, @spfcraze) — keyed on `(name, include_registry, registry id, registry _generation)`; the registry bumps `_generation` on every register/deregister/alias/MCP refresh, so any toolset change busts the cache. Added a 256-entry overflow clear so stale-generation entries can't accumulate in long sessions.
- **Per-agent display-flag cache** (#77789, @spfcraze) — file-mutation-verifier and turn-completion-explainer config flags read once per agent; env-var overrides stay authoritative and uncached on every call.
- **TUI launcher skips plugin discovery** (#80980, @jackoconner55) — `hermes --tui` only spawns Node; the backend discovers plugins itself. Rebased onto main's background-discovery thread (the skip now avoids spawning the thread at all for TUI handoff).

## Cache-invalidation semantics (reviewed per memo)

| Memo | Key | What busts it | Test |
|---|---|---|---|
| personalities completer | config path+mtime_ns+size | config.yaml edit | `test_completer_config_reads.py` (mtime-bump test) |
| `get_default_hermes_root` | HERMES_HOME + native home (compared every call) | env change mid-process | `test_hermes_constants.py` |
| global auth store | auth.json path+mtime_ns | any auth write (all go through `_save_auth_store`) | `test_global_auth_store_memo.py` |
| `resolve_toolset` | registry `_generation` | register/deregister/alias/MCP refresh | `test_toolsets.py` (generation-bump test) |
| display flags | per-agent lifetime | new agent; env var always live | `tests/run_agent/test_file_mutation_verifier.py`, `test_turn_completion_explainer.py` |

None of these mutate conversation context or the system prompt — prompt-cache semantics unaffected.

## Validation

| Check | Result |
|---|---|
| `tests/hermes_cli/test_lazy_command_exports.py` | ✅ pass |
| `tests/hermes_cli/test_completer_config_reads.py` | ✅ pass (3) |
| `tests/hermes_cli/test_global_auth_store_memo.py` + `tests/test_hermes_constants.py` | ✅ pass |
| `tests/test_toolsets.py` | ✅ pass |
| `tests/run_agent/test_file_mutation_verifier.py`, `test_turn_completion_explainer.py` | ✅ pass |
| `tests/hermes_cli/test_tui_launcher_skips_plugin_discovery.py` | ✅ pass |
| E2E: `python -X importtime -c "import hermes_cli.main"` | ✅ update_cmd/sessions_cmd/dashboard_procs no longer imported (were eagerly imported on main) |
| E2E: `hermes --help` timing (5 runs, warm) | main 0.19–0.37s vs branch 0.19–0.34s (parity on warm cache; deferred modules save their full import cost on cold start) |

Suite total: 97 passed across the six test files (one pre-existing unrelated failure on main excluded).

## Credits

- @Adolanium — lazy command re-exports (#74390)
- @spfcraze — completer memo, root/auth-store memo, resolve_toolset memo, display-flag cache (#77899, #77965, #77929, #77789)
- @jackoconner55 — TUI launcher discovery skip (#80980)

Covers #74390, #77899, #77965, #77929, #77789, #80980.

## Infographic

![CLI startup perf infographic](https://files.catbox.moe/sd3ons.png)
