### PR TITLE
fix(cron): pass response metadata to adapters

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -1762,6 +1762,7 @@ def run_conversation(
     # Main conversation loop counters (pure locals consumed by the loop below).
     api_call_count = 0
     final_response = None
+    response_id = None
     interrupted = False
     failed = False
     codex_ack_continuations = 0
@@ -2993,6 +2994,12 @@ def run_conversation(
                     else:
                         interrupted = True
                     break
+
+                candidate_response_id = getattr(response, "id", None)
+                if candidate_response_id is None and isinstance(response, dict):
+                    candidate_response_id = response.get("id")
+                if candidate_response_id:
+                    response_id = str(candidate_response_id)
                 
                 api_duration = time.time() - api_start_time
                 
@@ -8063,6 +8070,7 @@ def run_conversation(
         _turn_exit_reason=_turn_exit_reason,
         _pending_verification_response=_pending_verification_response,
         _pending_verification_response_previewed=_pending_verification_response_previewed,
+        response_id=response_id,
     )
 
 

--- a/agent/turn_finalizer.py
+++ b/agent/turn_finalizer.py
@@ -85,6 +85,7 @@ def finalize_turn(
     _turn_exit_reason,
     _pending_verification_response=None,
     _pending_verification_response_previewed=False,
+    response_id=None,
 ):
     """Run the post-loop finalization and return the turn ``result`` dict.
 
@@ -696,6 +697,8 @@ def finalize_turn(
         ).get("service_tier"),
         "session_id": agent.session_id,
     }
+    if response_id:
+        result["response_id"] = response_id
     if agent._tool_guardrail_halt_decision is not None:
         result["guardrail"] = agent._tool_guardrail_halt_decision.to_metadata()
     # Persistence failures already set failed=True + an explanation in

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -2266,7 +2266,37 @@ def _is_channel_dm_topic(
     return is_channel
 
 
-def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Optional[str]:
+def _cron_delivery_metadata(job: dict, run_metadata: Optional[dict] = None) -> dict:
+    """Build the structured cron context exposed to live platform adapters."""
+    if run_metadata is None:
+        run_metadata = job.get("_cron_run_metadata")
+    metadata = {
+        "job_id": job["id"],
+        "job_name": job.get("name") or job["id"],
+        "schedule": job.get("schedule"),
+        "deliver": job.get("deliver", "local"),
+    }
+    origin = _resolve_origin(job)
+    if origin:
+        metadata["origin"] = {
+            key: origin[key]
+            for key in ("platform", "chat_id", "thread_id")
+            if origin.get(key) is not None
+        }
+    for key in ("status", "ran_at", "response_id", "session_id", "model", "provider"):
+        value = (run_metadata or {}).get(key)
+        if value is not None:
+            metadata[key] = value
+    return metadata
+
+
+def _deliver_result(
+    job: dict,
+    content: str,
+    adapters=None,
+    loop=None,
+    run_metadata: Optional[dict] = None,
+) -> Optional[str]:
     """
     Deliver job output to the configured target(s) (origin chat, specific platform, etc.).
 
@@ -2583,10 +2613,13 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                 route_metadata = {
                     "direct_messages_topic_id": str(thread_id),
                     "job_id": job["id"],
+                    "cron": _cron_delivery_metadata(job, run_metadata),
                 }
                 # Media metadata mirrors the text routing so attachments land in
                 # the same DM topic instead of the General lane (#22773).
-                media_metadata = {"direct_messages_topic_id": str(thread_id)}
+                media_metadata = {
+                    "direct_messages_topic_id": str(thread_id),
+                }
             else:
                 # Forum-style topic (private chat / supergroup) or non-topic
                 # target: route via message_thread_id (#52060).  Put thread_id in
@@ -2597,7 +2630,10 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                 # anchor, so the metadata key bypasses that check and lets the
                 # adapter route via a plain message_thread_id.
                 route_thread_id = str(thread_id) if thread_id is not None else None
-                route_metadata = {"job_id": job["id"]}
+                route_metadata = {
+                    "job_id": job["id"],
+                    "cron": _cron_delivery_metadata(job, run_metadata),
+                }
                 if route_thread_id:
                     route_metadata["thread_id"] = route_thread_id
                 media_metadata = {"thread_id": thread_id} if thread_id else None
@@ -5344,6 +5380,13 @@ def run_job(
             )
 
         final_response = result.get("final_response", "") or ""
+        agent._cron_result_metadata = {
+            key: result[key]
+            for key in (
+                "response_id", "session_id", "model", "provider",
+            )
+            if result.get(key) is not None
+        }
         # Strip leaked placeholder text that upstream may inject on empty completions.
         if final_response.strip() == "(No response generated)":
             final_response = ""
@@ -5877,6 +5920,7 @@ def _run_one_job_body(
         # below once delivery is done. Defense-in-depth alongside the
         # interpreter-shutdown guard in _deliver_result.
         _deferred_agents: list = []
+        run_metadata: dict = {}
         try:
             if fire_claim_lost is None:
                 success, output, final_response, error = run_job(
@@ -5902,6 +5946,19 @@ def _run_one_job_body(
             raise
         finally:
             reset_secret_scope(_scope_token)
+
+        # This body invokes run_job exactly once, so its (sole) deferred agent
+        # owns the primary conversation response. Delegated agents run inline
+        # and are never added to this teardown holder; choose the first entry
+        # defensively if a future caller contributes more than one.
+        if _deferred_agents:
+            _agent_metadata = getattr(
+                _deferred_agents[0], "_cron_result_metadata", None
+            )
+            if isinstance(_agent_metadata, dict):
+                run_metadata.update(_agent_metadata)
+        run_metadata["status"] = "completed" if success else "failed"
+        run_metadata["ran_at"] = _utcnow_iso_ms()
 
         if _fire_claim_ownership_lost():
             for _deferred_agent in _deferred_agents:
@@ -6052,7 +6109,7 @@ def _run_one_job_body(
                             raise _FireClaimLostDuringSideEffect
                         delivery_attempted = True
                         delivery_error = _deliver_result(
-                            job,
+                            {**job, "_cron_run_metadata": run_metadata},
                             deliver_content,
                             adapters=adapters,
                             loop=loop,
@@ -6191,7 +6248,13 @@ def _run_one_job_body(
             try:
                 delivery_attempted = True
                 delivery_error = _deliver_result(
-                    job,
+                    {
+                        **job,
+                        "_cron_run_metadata": {
+                            "status": "failed",
+                            "ran_at": _utcnow_iso_ms(),
+                        },
+                    },
                     _summarize_cron_failure_for_delivery(job, _err_text),
                     adapters=adapters,
                     loop=loop,

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -3906,7 +3906,11 @@ class BasePlatformAdapter(ABC):
             chat_id: The chat/channel ID to send to
             content: Message content (may be markdown)
             reply_to: Optional message ID to reply to
-            metadata: Additional platform-specific options
+            metadata: Additional platform-specific options. Live cron deliveries
+                include ``metadata["cron"]`` with ``job_id``, ``job_name``,
+                ``schedule``, ``deliver``, and (when available) ``origin``,
+                run ``status``/``ran_at``, ``response_id``, ``session_id``,
+                ``model``, and ``provider``.
         
         Returns:
             SendResult with success status and message ID

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -1,10 +1,12 @@
 """Tests for cron/scheduler.py — origin resolution, delivery routing, and error logging."""
 
+import asyncio
 import contextlib
 import itertools
 import json
 import logging
 import os
+from concurrent.futures import Future
 from unittest.mock import AsyncMock, patch, MagicMock
 
 import pytest
@@ -160,6 +162,126 @@ class TestResolveOrigin:
         """
         job = {"origin": non_dict_origin}
         assert _resolve_origin(job) is None
+
+
+class TestCronDeliveryMetadata:
+    def test_live_adapter_receives_structured_cron_run_metadata(self):
+        """Cron context must cross the scheduler-to-adapter boundary intact."""
+        from gateway.config import GatewayConfig, Platform, PlatformConfig
+
+        job = {
+            "id": "nightly-report",
+            "name": "Nightly report",
+            "schedule": {"kind": "cron", "expr": "0 9 * * *"},
+            "deliver": "origin",
+            "origin": {
+                "platform": "telegram",
+                "chat_id": "12345",
+                "thread_id": "77",
+                "chat_name": "Operations",
+            },
+        }
+        sent_metadata = []
+
+        class RecordingAdapter:
+            async def send(self, chat_id, content, metadata=None):
+                sent_metadata.append(metadata)
+                return {"success": True}
+
+        loop = MagicMock()
+        loop.is_running.return_value = True
+
+        def run_coro(coro, _loop):
+            future = Future()
+            try:
+                future.set_result(asyncio.run(coro))
+            except BaseException as exc:  # noqa: BLE001 - preserve future behavior
+                future.set_exception(exc)
+            return future
+
+        config = GatewayConfig(
+            platforms={Platform.TELEGRAM: PlatformConfig(enabled=True)}
+        )
+        run_metadata = {
+            "status": "completed",
+            "ran_at": "2026-08-15T12:00:00.000+00:00",
+            "response_id": "resp_123",
+            "session_id": "cron_nightly-report_20260815",
+            "model": "gpt-5.6",
+            "provider": "openai",
+        }
+
+        with patch("gateway.config.load_gateway_config", return_value=config), \
+             patch("cron.scheduler.load_config", return_value={"cron": {"wrap_response": False}}), \
+             patch("asyncio.run_coroutine_threadsafe", side_effect=run_coro):
+            assert _deliver_result(
+                job,
+                "The report is ready.",
+                adapters={Platform.TELEGRAM: RecordingAdapter()},
+                loop=loop,
+                run_metadata=run_metadata,
+            ) is None
+
+        assert sent_metadata == [{
+            "job_id": "nightly-report",
+            "thread_id": "77",
+            "cron": {
+                "job_id": "nightly-report",
+                "job_name": "Nightly report",
+                "schedule": {"kind": "cron", "expr": "0 9 * * *"},
+                "deliver": "origin",
+                "origin": {
+                    "platform": "telegram",
+                    "chat_id": "12345",
+                    "thread_id": "77",
+                },
+                **run_metadata,
+            },
+        }]
+
+    def test_delivery_uses_primary_deferred_agent_metadata(self, monkeypatch):
+        """A defensive multi-agent holder must retain the job's own response."""
+        import cron.scheduler as scheduler
+
+        primary_agent = MagicMock()
+        primary_agent._cron_result_metadata = {
+            "response_id": "resp_primary",
+            "session_id": "cron_primary",
+        }
+        secondary_agent = MagicMock()
+        secondary_agent._cron_result_metadata = {
+            "response_id": "resp_secondary",
+            "session_id": "cron_secondary",
+        }
+        delivered_metadata = []
+
+        def fake_run_job(_job, *, defer_agent_teardown, **_kwargs):
+            defer_agent_teardown.extend((primary_agent, secondary_agent))
+            return True, "output", "response", None
+
+        monkeypatch.setattr(
+            scheduler, "create_execution", lambda *_args, **_kwargs: {"id": "exec-1"}
+        )
+        monkeypatch.setattr(scheduler, "claim_dispatch", lambda _job_id: True)
+        monkeypatch.setattr(scheduler, "mark_execution_running", lambda _execution_id: None)
+        monkeypatch.setattr(scheduler, "run_job", fake_run_job)
+        monkeypatch.setattr(scheduler, "save_job_output", lambda *_args: "/tmp/output.md")
+        monkeypatch.setattr(
+            scheduler,
+            "_deliver_result",
+            lambda delivery_job, *_args, **_kwargs: (
+                delivered_metadata.append(delivery_job["_cron_run_metadata"]) or None
+            ),
+        )
+        monkeypatch.setattr(scheduler, "_teardown_cron_agent", lambda *_args: None)
+        monkeypatch.setattr(scheduler, "mark_job_run", lambda *_args, **_kwargs: True)
+        monkeypatch.setattr(scheduler, "finish_execution", lambda *_args, **_kwargs: None)
+
+        assert scheduler.run_one_job({"id": "primary", "deliver": "telegram"}) is True
+        assert delivered_metadata[0]["response_id"] == "resp_primary"
+        assert delivered_metadata[0]["session_id"] == "cron_primary"
+        assert delivered_metadata[0]["status"] == "completed"
+        assert "ran_at" in delivered_metadata[0]
 
 
 class TestResolveDeliveryTarget:
@@ -479,6 +601,7 @@ class TestDeliverResultWrapping:
                 f"Here is TTS\nMEDIA:{media_path}",
                 adapters={Platform.DISCORD: adapter},
                 loop=loop,
+                run_metadata={"status": "completed", "response_id": "resp_123"},
             )
 
         # Text should be sent without the MEDIA tag
@@ -486,11 +609,21 @@ class TestDeliverResultWrapping:
         text_sent = adapter.send.call_args[0][1]
         assert "MEDIA:" not in text_sent
         assert "Here is TTS" in text_sent
+        assert adapter.send.call_args.kwargs["metadata"]["cron"] == {
+            "job_id": "tts-job",
+            "job_name": "tts-job",
+            "schedule": None,
+            "deliver": "origin",
+            "origin": {"platform": "discord", "chat_id": "9876"},
+            "status": "completed",
+            "response_id": "resp_123",
+        }
 
         # Audio file should be sent as a voice attachment
         adapter.send_voice.assert_called_once()
         voice_call = adapter.send_voice.call_args
         assert voice_call[1]["audio_path"] == str(media_path)
+        assert voice_call.kwargs["metadata"] is None
 
 
 class TestDeliverResultErrorReturns:
@@ -563,6 +696,33 @@ class TestRunJobSessionPersistence:
         assert call_args[0][1] == "cron_complete"
         fake_db.close.assert_called_once()
         mock_agent.close.assert_called_once()
+
+    def test_run_job_keeps_response_context_for_deferred_delivery(self, tmp_path):
+        job = {"id": "response-context", "name": "test", "prompt": "hello"}
+
+        with self._run_job_patches(tmp_path) as (_, mock_agent_cls):
+            mock_agent = mock_agent_cls.return_value
+            mock_agent.run_conversation.return_value = {
+                "final_response": "ok",
+                "response_id": "resp_123",
+                "session_id": "cron_response-context_20260815",
+                "model": "gpt-5.6",
+                "provider": "openai",
+            }
+            deferred_agents = []
+            success, _, _, error = run_job(
+                job, defer_agent_teardown=deferred_agents
+            )
+
+        assert success is True
+        assert error is None
+        assert deferred_agents == [mock_agent]
+        assert mock_agent._cron_result_metadata == {
+            "response_id": "resp_123",
+            "session_id": "cron_response-context_20260815",
+            "model": "gpt-5.6",
+            "provider": "openai",
+        }
 
 
     @contextlib.contextmanager
@@ -2555,4 +2715,3 @@ class TestSetCronSessionTitle:
         out = _set_cron_session_title(db, "sess-1", "Nightly Synthesis")
         assert out == "Nightly Synthesis #2"
         db.get_next_title_in_lineage.assert_called_once_with("Nightly Synthesis")
-


### PR DESCRIPTION
## What changed and why

Per the follow-up on 2026-07-31, this restores the structured cron-delivery metadata proposed by closed PR #26012 and completes the missing response-ID path. The agent result now exposes a provider response ID when one is available; cron retains that short-lived result metadata until delivery and supplies it to live adapters as `metadata["cron"]`.

The nested metadata includes the job ID/name, schedule, delivery mode, sanitized origin routing fields, run status/time, and available response/session/model/provider identifiers. `BasePlatformAdapter.send()` now documents this additive contract. The two agent-result files are necessary only to surface the provider ID already present on the final response object; the scheduler carries it across the existing delivery boundary.

## Related work

#26012 (closed) established the partial structured-metadata approach but did not forward a response ID. This split keeps that approach and adds the missing propagation without changing existing adapter behavior for metadata consumers that ignore unknown keys.

## How to test

- `/opt/homebrew/bin/timeout -k 30 180 pytest tests/cron/test_scheduler.py -q -x --timeout=60`
- `/opt/homebrew/bin/timeout -k 30 180 pytest tests/cron/test_codex_execution_paths.py -q -x --timeout=60`

Both passed (90 and 2 tests respectively). The prescribed full `pytest tests/` command could not collect in this sandbox because the global Python lacks FastAPI/uvicorn and dependency installation cannot write to its cache.

## What platforms tested on

- macOS 15 (local sandbox)

Fixes #26004

<!-- autocontrib:worker-id=issue-followup-73250fb2 kind=pr-open -->