### PR TITLE
fix(tui,cli): salvage editing shortcuts — paste/copy/word-delete, CLI multiline defaults, Alt-shortcut prompt_toolkit crash

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -43,7 +43,7 @@ from urllib.parse import unquote, urlparse
 from contextlib import contextmanager
 from pathlib import Path
 from datetime import datetime
-from typing import List, Dict, Any, Optional
+from typing import List, Dict, Any, Optional, Mapping
 
 logger = logging.getLogger(__name__)
 
@@ -3777,6 +3777,97 @@ _TERMINAL_INPUT_MODE_RESET_SEQ = (
     "\x1b[0m"      # reset text attributes
     "\x1b[?25h"    # ensure cursor visible
 )
+_EXTENDED_ENTER_KEYS_SEQ = "\x1b[>1u\x1b[>4;2m"
+
+
+_BACKSLASH_LINE_CONTINUATION_RE = re.compile(r"\\[ \t]*$")
+
+
+def _terminal_supports_extended_enter_keys(env: Optional[Mapping[str, str]] = None) -> bool:
+    """Whether it is safe/useful to request modified Enter key reporting.
+
+    The classic CLI already maps Kitty CSI-u / xterm modifyOtherKeys Shift+Enter
+    byte sequences to the newline handler. Some terminals (notably iTerm2) only
+    emit those distinct sequences after the application asks for extended key
+    mode. Keep this allowlist aligned with the Ink TUI, which enables the same
+    modes for these terminals.
+    """
+    if env is None:
+        env = os.environ
+    term_program = (env.get("TERM_PROGRAM") or "").strip()
+    term = (env.get("TERM") or "").strip().lower()
+    if env.get("WT_SESSION"):
+        return True
+    if term_program in {"iTerm.app", "WezTerm", "ghostty", "vscode"}:
+        return True
+    if env.get("KITTY_WINDOW_ID") or "kitty" in term:
+        return True
+    if term == "xterm-ghostty":
+        return True
+    if term.startswith("tmux") or term_program.lower() == "tmux":
+        return True
+    return False
+
+
+def _enable_extended_enter_keys(output=None, env: Optional[Mapping[str, str]] = None) -> bool:
+    """Ask allowlisted terminals to report Shift+Enter distinctly.
+
+    Writes both the Kitty keyboard protocol push (CSI >1u) and xterm
+    modifyOtherKeys level 2 (CSI >4;2m), mirroring the Ink TUI. The exit reset
+    sequence already pops/resets both modes, so this is safe across normal
+    exits, Ctrl+C, and SIGTERM cleanup.
+    """
+    if not _terminal_supports_extended_enter_keys(env):
+        return False
+    try:
+        target = output
+        if target is not None and hasattr(target, "write_raw"):
+            target.write_raw(_EXTENDED_ENTER_KEYS_SEQ)
+            target.flush()
+            return True
+        stream = sys.stdout
+        if stream is not None and stream.isatty():
+            stream.write(_EXTENDED_ENTER_KEYS_SEQ)
+            stream.flush()
+            return True
+    except Exception:
+        return False
+    return False
+
+
+def _cli_multiline_shortcuts_enabled(config: Optional[Dict[str, Any]] = None) -> bool:
+    """Return whether classic CLI harness-standard multiline fallbacks are on.
+
+    Default is on to match the norm in adjacent agent harnesses: Ctrl+J is a
+    documented no-setup newline shortcut in Claude Code, OpenCode defaults
+    ``input_newline`` to include ``ctrl+j``, and Codex exposes Ctrl+J/keymap
+    newline behavior. Users on unusual POSIX PTYs that send bare LF for plain
+    Enter can set ``display.cli_multiline_shortcuts: false`` to restore the
+    legacy c-j submit fallback.
+    """
+    if config is None:
+        config = CLI_CONFIG
+    display = config.get("display") if isinstance(config, dict) else None
+    value = display.get("cli_multiline_shortcuts", True) if isinstance(display, dict) else True
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized in {"1", "true", "yes", "on", "enabled"}:
+            return True
+        if normalized in {"0", "false", "no", "off", "disabled"}:
+            return False
+    return True
+
+
+def _is_backslash_line_continuation(text: str) -> bool:
+    """True when Enter should turn a trailing backslash into a newline."""
+    return bool(_BACKSLASH_LINE_CONTINUATION_RE.search(text or ""))
+
+
+def _apply_backslash_line_continuation(text: str) -> str:
+    """Replace a trailing ``\\`` marker with an actual newline."""
+    return _BACKSLASH_LINE_CONTINUATION_RE.sub("", text or "") + "\n"
 
 
 def _preserve_ctrl_enter_newline() -> bool:
@@ -3787,8 +3878,8 @@ def _preserve_ctrl_enter_newline() -> bool:
     NOT be bound to submit;
     binding it to submit makes Ctrl+Enter (intended as 'newline like Alt+Enter')
     submit instead. Local POSIX TTYs that deliver Enter as LF (docker exec,
-    some thin PTYs without SSH) still need c-j bound to submit, so we keep
-    that binding for those.
+    some thin PTYs without SSH) still need c-j bound to submit when
+    display.cli_multiline_shortcuts is disabled, so we keep that legacy opt-out.
 
     See issue #22379.
     """
@@ -3817,22 +3908,33 @@ def _preserve_ctrl_enter_newline() -> bool:
     return False
 
 
-def _bind_prompt_submit_keys(kb, handler) -> None:
+def _bind_prompt_submit_keys(
+    kb,
+    handler,
+    *,
+    multiline_shortcuts_enabled: Optional[bool] = None,
+) -> None:
     """Bind terminal Enter forms to the submit handler.
 
-    Enter is always submit. On POSIX we also bind c-j (LF) to submit because
-    some thin PTYs (docker exec, certain SSH flavors) deliver Enter as LF
-    instead of CR — without this, Enter appears dead on those terminals.
+    Enter is always submit. By default, c-j (Ctrl+J/LF) is left for the
+    multiline newline handler because that is the common agent-harness UX.
+    Users can set ``display.cli_multiline_shortcuts: false`` to restore the
+    legacy POSIX fallback that binds c-j to submit on local thin PTYs whose
+    plain Enter arrives as LF instead of CR.
 
-    Exception: on Windows, WSL, SSH sessions, Windows Terminal, and Ghostty,
-    c-j is the wire encoding of Ctrl+Enter (a distinct keystroke from
-    plain Enter / c-m). We leave c-j unbound there so the c-j newline
-    handler registered separately can fire — giving the user an
-    Enter-involving newline keystroke without terminal settings changes.
+    Even when the setting is disabled, environments where Ctrl+Enter is known
+    to arrive as c-j (Windows, WSL, SSH, Windows Terminal, Ghostty) keep c-j
+    reserved for newline; otherwise Ctrl+Enter submits instead of composing.
     See _preserve_ctrl_enter_newline() and issue #22379.
     """
+    if multiline_shortcuts_enabled is None:
+        multiline_shortcuts_enabled = _cli_multiline_shortcuts_enabled()
     kb.add("enter")(handler)
-    if sys.platform != "win32" and not _preserve_ctrl_enter_newline():
+    if (
+        sys.platform != "win32"
+        and not multiline_shortcuts_enabled
+        and not _preserve_ctrl_enter_newline()
+    ):
         kb.add("c-j")(handler)
 
 
@@ -8618,7 +8720,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                 )
 
         _cprint(f"\n  {_DIM}Tip: Just type your message to chat with Hermes!{_RST}")
-        _cprint(f"  {_DIM}Multi-line: Alt+Enter for a new line{_RST}")
+        _cprint(f"  {_DIM}Multi-line: Ctrl+J, Alt+Enter, or \\+Enter for a new line{_RST}")
         _cprint(f"  {_DIM}Draft editor: Ctrl+G (Alt+G in VSCode/Cursor){_RST}")
         if _is_termux_environment():
             _cprint(f"  {_DIM}Attach image: /image {_termux_example_image_path()} or start your prompt with a local image path{_RST}\n")
@@ -16352,6 +16454,8 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         # Key bindings for the input area
         kb = KeyBindings()
 
+        _multiline_shortcuts_enabled = _cli_multiline_shortcuts_enabled(self.config or CLI_CONFIG)
+
         from prompt_toolkit.keys import Keys as _IgnoreKeys
 
         @kb.add(_IgnoreKeys.Ignore, eager=True)
@@ -16506,7 +16610,18 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                 return
 
             # --- Normal input routing ---
-            text = event.app.current_buffer.text.strip()
+            raw_text = event.app.current_buffer.text
+            if (
+                _multiline_shortcuts_enabled
+                and event.app.current_buffer.cursor_position == len(raw_text)
+                and _is_backslash_line_continuation(raw_text)
+            ):
+                continued = _apply_backslash_line_continuation(raw_text)
+                event.app.current_buffer.text = continued
+                event.app.current_buffer.cursor_position = len(continued)
+                event.app.invalidate()
+                return
+            text = raw_text.strip()
             has_images = bool(self._attached_images)
             if text or has_images:
                 # Handle /model directly on the UI thread so interactive pickers
@@ -16660,7 +16775,11 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                 self._inline_pastes(event.app.current_buffer)
                 event.app.current_buffer.reset(append_to_history=True)
 
-        _bind_prompt_submit_keys(kb, handle_enter)
+        _bind_prompt_submit_keys(
+            kb,
+            handle_enter,
+            multiline_shortcuts_enabled=_multiline_shortcuts_enabled,
+        )
         
         @kb.add('escape', 'enter')
         def handle_alt_enter(event):
@@ -16673,19 +16792,17 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             """
             event.current_buffer.insert_text('\n')
 
-        if _preserve_ctrl_enter_newline():
+        if _multiline_shortcuts_enabled or _preserve_ctrl_enter_newline():
             @kb.add('c-j')
             def handle_ctrl_enter_newline(event):
-                """Ctrl+Enter inserts a newline on Windows, WSL, SSH, and WT.
+                """Ctrl+J inserts a newline for multi-line input.
 
-                Windows Terminal (incl. WSL/SSH sessions through it) delivers
-                Ctrl+Enter as LF (c-j), distinct from plain Enter (c-m). This
-                binding makes Ctrl+Enter the equivalent of Alt+Enter on those
-                terminals, giving an Enter-involving newline keystroke
-                without requiring terminal settings changes. Ctrl+J (the raw
-                LF keystroke) also triggers this by virtue of being the same
-                key code — a harmless side effect since Ctrl+J has no
-                conflicting Hermes binding. See issue #22379.
+                This is enabled by default to match Claude Code / Codex /
+                OpenCode behavior. On Windows Terminal and similar environments,
+                Ctrl+Enter is delivered as the same c-j key code, so this also
+                covers Ctrl+Enter there. Set display.cli_multiline_shortcuts:
+                false to restore legacy c-j submit behavior on unusual POSIX
+                PTYs where plain Enter arrives as LF.
                 """
                 event.current_buffer.insert_text('\n')
 
@@ -18956,8 +19073,13 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                 except Exception:
                     pass
                 # The app enables focus reporting + mouse tracking; record that
-                # so _run_cleanup resets them on exit (#36823).
+                # so _run_cleanup resets them on exit (#36823). When multiline
+                # shortcuts are on, also ask supported terminals (e.g. iTerm2)
+                # to distinguish Shift+Enter from Enter; the same cleanup reset
+                # pops kitty keyboard mode and resets modifyOtherKeys.
                 _mark_tui_input_modes_active()
+                if _multiline_shortcuts_enabled:
+                    _enable_extended_enter_keys(app.output)
                 # Drive the petdex mascot animation (no-op when no pet enabled).
                 self._pet_start_anim()
                 app.run()

--- a/cli.py
+++ b/cli.py
@@ -17416,6 +17416,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             from hermes_cli.config import load_config
             from hermes_cli.voice import (
                 normalize_voice_record_key_for_prompt_toolkit,
+                pt_key_to_sequence,
                 voice_record_key_from_config,
             )
             _raw_key = voice_record_key_from_config(load_config())
@@ -17441,7 +17442,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         # voice.record_key mid-session (Copilot round-13 on #19835).
         self.set_voice_record_key_cache(_raw_key)
 
-        @kb.add(_voice_key)
+        @kb.add(*pt_key_to_sequence(_voice_key))
         def handle_voice_record(event):
             """Toggle voice recording when voice mode is active.
 

--- a/contributors/emails/moisesvs84@gmail.com
+++ b/contributors/emails/moisesvs84@gmail.com
@@ -1,0 +1,1 @@
+moisesvalero

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1173,6 +1173,13 @@ DEFAULT_CONFIG = {
         # "Steered into current run" confirmation bubble by setting this false.
         # The mid-turn steering itself still happens.
         "busy_steer_ack_enabled": True,
+        # Classic CLI multiline fallbacks beyond Alt+Enter.
+        # Default true matches Claude Code / Codex / OpenCode: Ctrl+J inserts
+        # a newline, a trailing backslash followed by Enter continues the draft,
+        # and supported terminals are asked to report Shift+Enter distinctly.
+        # Set false to restore the legacy c-j submit fallback on unusual POSIX
+        # PTYs whose plain Enter arrives as LF instead of CR.
+        "cli_multiline_shortcuts": True,
         # Which interface bare `hermes` (and `hermes chat`) launches by default:
         #   "cli" — the classic prompt_toolkit REPL (default, preserves prior behavior)
         #   "tui" — the modern Ink TUI (same as passing `--tui`)

--- a/hermes_cli/voice.py
+++ b/hermes_cli/voice.py
@@ -183,6 +183,17 @@ def normalize_voice_record_key_for_prompt_toolkit(raw: Any) -> str:
     return f"{normalized_mod}{named}"
 
 
+def pt_key_to_sequence(pt_key: str) -> tuple[str, ...]:
+    """Convert a prompt_toolkit key specifier (e.g. 'c-b' or 'a-v') to a sequence tuple.
+
+    prompt_toolkit's ``@kb.add`` rejects 'a-x' strings directly (raises ValueError),
+    expecting ('escape', 'x') instead for Alt-modifier shortcuts.
+    """
+    if isinstance(pt_key, str) and pt_key.startswith("a-"):
+        return ("escape", pt_key[2:])
+    return (pt_key,)
+
+
 def format_voice_record_key_for_status(raw: Any) -> str:
     """Render ``voice.record_key`` for ``/voice status`` in CLI-friendly form.
 

--- a/tests/cli/test_cli_init.py
+++ b/tests/cli/test_cli_init.py
@@ -150,14 +150,14 @@ class TestBusyInputMode:
 
 
 class TestPromptToolkitTerminalCompatibility:
-    def test_lf_enter_binds_to_submit_handler_posix(self):
-        """Some thin PTYs deliver Enter as LF/c-j instead of CR/enter.
+    def test_lf_enter_binding_respects_multiline_shortcuts(self):
+        """Ctrl+J is reserved by default, with legacy LF-submit available as an opt-out.
 
-        On a bare local POSIX TTY (no SSH/WSL/WT/Ghostty) we keep c-j → submit so
-        Enter works on thin PTYs (docker exec, certain ssh configurations).
-        In WSL, SSH sessions, Windows Terminal, and Ghostty we leave c-j
-        unbound here so it can be used as the Ctrl+Enter newline keystroke
-        without conflicting with submit. See issue #22379.
+        Some thin POSIX PTYs deliver plain Enter as LF/c-j instead of CR/enter.
+        The default keeps c-j free for multiline input; disabling multiline
+        shortcuts restores c-j → submit on bare local POSIX terminals. Windows,
+        WSL, SSH sessions, Windows Terminal, and Ghostty always reserve c-j for
+        the Ctrl+Enter/Ctrl+J newline binding. See issue #22379.
 
         The native-Windows arm of this behaviour is
         ``test_windows_leaves_ctrl_j_unbound`` below — it has to run on a real
@@ -176,11 +176,24 @@ class TestPromptToolkitTerminalCompatibility:
         def submit_handler(event):
             return None
 
-        # Bare local POSIX (no SSH/WSL markers): both enter and c-j submit.
+        # Default: Enter submits while c-j stays free for the newline binding.
+        # (Runs on the POSIX CI job; the native-Windows arm is the marked test
+        # below, so no sys.platform fake is needed here.)
         with _patch.dict(_os.environ, {}, clear=True), \
              _patch("builtins.open", side_effect=OSError("no /proc")):
             kb = KeyBindings()
             _bind_prompt_submit_keys(kb, submit_handler)
+            bindings = {tuple(key.value for key in binding.keys): binding.handler for binding in kb.bindings}
+            assert bindings[("c-m",)] is submit_handler
+            assert ("c-j",) not in bindings
+
+            # Legacy opt-out: bare POSIX LF/c-j submits for thin PTYs.
+            kb = KeyBindings()
+            _bind_prompt_submit_keys(
+                kb,
+                submit_handler,
+                multiline_shortcuts_enabled=False,
+            )
             bindings = {tuple(key.value for key in binding.keys): binding.handler for binding in kb.bindings}
             assert bindings[("c-m",)] is submit_handler
             assert bindings[("c-j",)] is submit_handler

--- a/tests/cli/test_ctrl_enter_newline.py
+++ b/tests/cli/test_ctrl_enter_newline.py
@@ -24,6 +24,33 @@ from unittest.mock import patch
 
 import pytest
 
+import sys
+
+
+class FakeKeyBindings:
+    def __init__(self):
+        self.bound = []
+
+    def add(self, *keys, **_kwargs):
+        def _decorator(handler):
+            self.bound.append(keys)
+            return handler
+
+        return _decorator
+
+
+def _bind_submit_keys_for_local_linux(cli_mod, *, multiline_shortcuts_enabled):
+    with patch.object(sys, "platform", "linux"):
+        with patch.dict(os.environ, {}, clear=True):
+            with patch("builtins.open", side_effect=OSError("no /proc")):
+                kb = FakeKeyBindings()
+                cli_mod._bind_prompt_submit_keys(
+                    kb,
+                    lambda _event: None,
+                    multiline_shortcuts_enabled=multiline_shortcuts_enabled,
+                )
+                return kb
+
 
 @pytest.mark.windows_only
 def test_native_windows_preserves_newline():
@@ -54,6 +81,76 @@ def test_ghostty_tmux_session_preserves_ctrl_j_newline():
         clear=True,
     ):
         assert cli_mod._preserve_ctrl_enter_newline() is True
+
+
+def test_cli_multiline_shortcuts_default_on():
+    """Hermes should default to the common harness behavior: Ctrl+J newline.
+
+    Claude Code documents Ctrl+J as a no-setup newline shortcut, OpenCode's
+    default input_newline includes ctrl+j, and Codex exposes Ctrl+J/keymap
+    newline behavior. Keep Hermes aligned unless the user opts out.
+    """
+    import cli as cli_mod
+
+    assert cli_mod._cli_multiline_shortcuts_enabled({"display": {}}) is True
+
+
+def test_cli_multiline_shortcuts_can_be_disabled():
+    import cli as cli_mod
+
+    assert cli_mod._cli_multiline_shortcuts_enabled(
+        {"display": {"cli_multiline_shortcuts": False}}
+    ) is False
+
+
+def test_ctrl_j_is_not_submit_when_multiline_shortcuts_enabled():
+    """With the default setting, c-j is reserved for the newline handler.
+
+    This fixes local terminals like iTerm2 where Ctrl+J reaches prompt_toolkit
+    as c-j but the legacy POSIX fallback bound it to submit.
+    """
+    import cli as cli_mod
+
+    kb = _bind_submit_keys_for_local_linux(
+        cli_mod,
+        multiline_shortcuts_enabled=True,
+    )
+
+    assert ("enter",) in kb.bound
+    assert ("c-j",) not in kb.bound
+
+
+def test_ctrl_j_legacy_submit_when_multiline_shortcuts_disabled():
+    """Users can opt out to preserve Enter-as-LF submit fallback on odd PTYs."""
+    import cli as cli_mod
+
+    kb = _bind_submit_keys_for_local_linux(
+        cli_mod,
+        multiline_shortcuts_enabled=False,
+    )
+
+    assert ("enter",) in kb.bound
+    assert ("c-j",) in kb.bound
+
+
+def test_backslash_enter_continuation_replaces_marker_with_newline():
+    import cli as cli_mod
+
+    assert cli_mod._apply_backslash_line_continuation("first line\\") == "first line\n"
+    assert cli_mod._apply_backslash_line_continuation("first line\\   ") == "first line\n"
+
+
+def test_iterm_is_allowlisted_for_extended_enter_keys():
+    """iTerm2 needs the app to request extended keys before Shift+Enter is distinct."""
+    import cli as cli_mod
+
+    assert cli_mod._terminal_supports_extended_enter_keys({"TERM_PROGRAM": "iTerm.app"}) is True
+
+
+def test_unknown_terminal_does_not_enable_extended_enter_keys():
+    import cli as cli_mod
+
+    assert cli_mod._terminal_supports_extended_enter_keys({"TERM_PROGRAM": "unknown"}) is False
 
 
 @pytest.mark.linux_only

--- a/tests/hermes_cli/test_voice_wrapper.py
+++ b/tests/hermes_cli/test_voice_wrapper.py
@@ -73,6 +73,13 @@ class TestNormalizeVoiceRecordKeyForPromptToolkit:
     # configs like ``option+c`` don't bind Alt+C in the CLI while the
     # TUI falls back to Ctrl+B.
 
+    def test_pt_key_to_sequence(self):
+        from hermes_cli.voice import pt_key_to_sequence
+
+        assert pt_key_to_sequence("c-b") == ("c-b",)
+        assert pt_key_to_sequence("a-v") == ("escape", "v")
+        assert pt_key_to_sequence("a-space") == ("escape", "space")
+
 
 class TestVoiceRecordKeyFromConfig:
     """Round-11 Copilot review regression on #19835.

--- a/ui-tui/src/__tests__/inputSelectionClipboard.test.ts
+++ b/ui-tui/src/__tests__/inputSelectionClipboard.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { handleInputSelectionClipboard } from '../app/useInputHandlers.js'
+
+const selection = (start = 1, end = 4) => ({
+  clear: vi.fn(),
+  collapseToEnd: vi.fn(),
+  copy: vi.fn(),
+  cut: vi.fn(),
+  end,
+  start,
+  value: 'hello'
+})
+
+describe('handleInputSelectionClipboard', () => {
+  it('copies an active composer selection', () => {
+    const active = selection()
+
+    expect(handleInputSelectionClipboard(active, 'copy')).toBe(true)
+    expect(active.copy).toHaveBeenCalledOnce()
+    expect(active.cut).not.toHaveBeenCalled()
+  })
+
+  it('cuts an active composer selection', () => {
+    const active = selection()
+
+    expect(handleInputSelectionClipboard(active, 'cut')).toBe(true)
+    expect(active.cut).toHaveBeenCalledOnce()
+    expect(active.copy).not.toHaveBeenCalled()
+  })
+
+  it('leaves shortcuts available when there is no active selection', () => {
+    expect(handleInputSelectionClipboard(null, 'copy')).toBe(false)
+    expect(handleInputSelectionClipboard(selection(2, 2), 'cut')).toBe(false)
+  })
+})

--- a/ui-tui/src/__tests__/textInputCut.test.ts
+++ b/ui-tui/src/__tests__/textInputCut.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { cutSelection } from '../components/textInput.js'
+
+describe('cutSelection (transactional cut)', () => {
+  it('removes the selection only after the clipboard write succeeds', async () => {
+    const write = vi.fn().mockResolvedValue(true)
+    const removeSelection = vi.fn()
+
+    const ok = await cutSelection('hello', write, removeSelection)
+
+    expect(ok).toBe(true)
+    expect(write).toHaveBeenCalledWith('hello')
+    expect(removeSelection).toHaveBeenCalledOnce()
+  })
+
+  it('keeps the text intact when the clipboard write fails (headless/SSH)', async () => {
+    const write = vi.fn().mockResolvedValue(false)
+    const removeSelection = vi.fn()
+
+    const ok = await cutSelection('hello', write, removeSelection)
+
+    expect(ok).toBe(false)
+    expect(write).toHaveBeenCalledWith('hello')
+    // Text must NOT be removed. A failed write would otherwise destroy it with no
+    // clipboard copy to paste back.
+    expect(removeSelection).not.toHaveBeenCalled()
+  })
+
+  it('awaits the write before removing (no fire-and-forget removal)', async () => {
+    let resolveWrite: (value: boolean) => void = () => {}
+
+    const write = vi.fn(
+      () =>
+        new Promise<boolean>(resolve => {
+          resolveWrite = resolve
+        })
+    )
+
+    const removeSelection = vi.fn()
+
+    const pending = cutSelection('hello', write, removeSelection)
+
+    // While the write is still pending the selection must remain untouched.
+    await Promise.resolve()
+    expect(removeSelection).not.toHaveBeenCalled()
+
+    resolveWrite(true)
+    await pending
+
+    expect(removeSelection).toHaveBeenCalledOnce()
+  })
+})

--- a/ui-tui/src/__tests__/textInputWordDelete.test.ts
+++ b/ui-tui/src/__tests__/textInputWordDelete.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest'
+
+import { InputEvent } from '../../packages/hermes-ink/src/ink/events/input-event.js'
+import { INITIAL_STATE, parseMultipleKeypresses } from '../../packages/hermes-ink/src/ink/parse-keypress.js'
+import { deleteWordForward } from '../components/textInput.js'
+
+function parseOne(sequence: string) {
+  const [keys] = parseMultipleKeypresses(INITIAL_STATE, sequence)
+  expect(keys).toHaveLength(1)
+
+  return keys[0]!
+}
+
+// The web dashboard maps Ctrl+Delete to ESC d (see
+// web/src/lib/pty-keyboard-shortcuts.ts). hermes-ink decodes that bare
+// meta-letter form via META_KEY_CODE_RE. If this contract ever changes the
+// `wordMod && inp === 'd'` binding in textInput.tsx stops firing and
+// Ctrl+Delete regresses to typing a literal "d".
+describe('Ctrl+Delete → ESC d decode contract', () => {
+  it('decodes ESC d as meta+"d" so the composer binding is reached', () => {
+    const event = new InputEvent(parseOne('\x1bd'))
+
+    expect(event.key.meta).toBe(true)
+    expect(event.key.ctrl).toBe(false)
+    expect(event.input).toBe('d')
+  })
+})
+
+describe('deleteWordForward', () => {
+  it('deletes the word to the right of the cursor', () => {
+    // cursor before "hello" → removes "hello" and the trailing space.
+    expect(deleteWordForward('foo hello world', 4)).toEqual({ cursor: 4, value: 'foo world' })
+  })
+
+  it('deletes from mid-word to the next word boundary', () => {
+    // cursor inside "hello" (after "he") → removes "llo" + trailing space.
+    expect(deleteWordForward('foo hello world', 6)).toEqual({ cursor: 6, value: 'foo heworld' })
+  })
+
+  it('keeps the cursor fixed while removing text', () => {
+    const result = deleteWordForward('alpha beta', 0)
+
+    expect(result.cursor).toBe(0)
+    expect(result.value).toBe('beta')
+  })
+
+  it('is a no-op when the cursor is already at the end', () => {
+    expect(deleteWordForward('foo bar', 7)).toEqual({ cursor: 7, value: 'foo bar' })
+  })
+
+  it('handles an empty string', () => {
+    expect(deleteWordForward('', 0)).toEqual({ cursor: 0, value: '' })
+  })
+})

--- a/ui-tui/src/app/inputSelectionStore.ts
+++ b/ui-tui/src/app/inputSelectionStore.ts
@@ -3,6 +3,8 @@ import { atom } from 'nanostores'
 export interface InputSelection {
   clear: () => void
   collapseToEnd: () => void
+  copy: () => void
+  cut: () => void
   end: number
   start: number
   value: string

--- a/ui-tui/src/app/useInputHandlers.ts
+++ b/ui-tui/src/app/useInputHandlers.ts
@@ -35,6 +35,19 @@ const DASHBOARD_NEW_SESSION_MESSAGE = 'starting a fresh dashboard chat...'
 
 export const shouldAllowIdleHotkeyExit = (dashboardTuiMode = DASHBOARD_TUI_MODE) => !dashboardTuiMode
 
+export function handleInputSelectionClipboard(
+  selection: ReturnType<typeof getInputSelection>,
+  action: 'copy' | 'cut'
+): boolean {
+  if (!selection || selection.end <= selection.start) {
+    return false
+  }
+
+  selection[action]()
+
+  return true
+}
+
 export function handleIdleHotkeyExit(
   actions: Pick<InputHandlerActions, 'die' | 'sys'>,
   dashboardTuiMode = DASHBOARD_TUI_MODE,
@@ -562,9 +575,7 @@ export function useInputHandlers(ctx: InputHandlerContext): InputHandlerResult {
 
       const inputSel = getInputSelection()
 
-      if (inputSel && inputSel.end > inputSel.start) {
-        inputSel.clear()
-
+      if (handleInputSelectionClipboard(inputSel, 'copy')) {
         return
       }
 
@@ -573,6 +584,10 @@ export function useInputHandlers(ctx: InputHandlerContext): InputHandlerResult {
       if (isMac) {
         return
       }
+    }
+
+    if (isCtrl(key, ch, 'x') && handleInputSelectionClipboard(getInputSelection(), 'cut')) {
+      return
     }
 
     if (isCtrl(key, ch, 'x') && cState.queueEditIdx !== null) {

--- a/ui-tui/src/components/textInput.tsx
+++ b/ui-tui/src/components/textInput.tsx
@@ -810,6 +810,23 @@ export function TextInput({
         setCur(vRef.current.length)
         curRef.current = vRef.current.length
       },
+      copy: () => {
+        const range = selRange()
+
+        if (range) {
+          void writeClipboardText(vRef.current.slice(range.start, range.end))
+        }
+      },
+      cut: () => {
+        const range = selRange()
+
+        if (!range) {
+          return
+        }
+
+        void writeClipboardText(vRef.current.slice(range.start, range.end))
+        commit(vRef.current.slice(0, range.start) + vRef.current.slice(range.end), range.start)
+      },
       end: selected?.end ?? curRef.current,
       start: selected?.start ?? curRef.current,
       value: vRef.current

--- a/ui-tui/src/components/textInput.tsx
+++ b/ui-tui/src/components/textInput.tsx
@@ -184,6 +184,27 @@ export function valueForReturnSubmit(
   return applyPrintableInsert(value, cursor, beforeReturn, range) ?? { cursor, value }
 }
 
+/**
+ * Transactional cut. Writes `text` to the clipboard and only invokes
+ * `removeSelection` once the write actually succeeds. On failure (e.g. a
+ * headless/SSH box with no clipboard backend) the selection is left untouched
+ * so the text is never destroyed without a copy to paste back. Returns whether
+ * the clipboard write succeeded.
+ */
+export async function cutSelection(
+  text: string,
+  write: (text: string) => Promise<boolean>,
+  removeSelection: () => void
+): Promise<boolean> {
+  const ok = await write(text)
+
+  if (ok) {
+    removeSelection()
+  }
+
+  return ok
+}
+
 export function shouldPreserveCtrlJNewline(env: MinimalEnv = process.env): boolean {
   if (env.WT_SESSION) {
     return true
@@ -261,6 +282,16 @@ function wordRight(s: string, p: number) {
   }
 
   return i
+}
+
+/**
+ * Delete the word to the RIGHT of the cursor (readline meta+d / kill-word).
+ * The cursor stays put; the text from the cursor to the next word boundary is
+ * removed. Callers guard against `cursor >= value.length` themselves; when the
+ * cursor is already at the end this is a no-op.
+ */
+export function deleteWordForward(value: string, cursor: number): TextInsertResult {
+  return { cursor, value: value.slice(0, cursor) + value.slice(wordRight(value, cursor)) }
 }
 
 /**
@@ -824,8 +855,24 @@ export function TextInput({
           return
         }
 
-        void writeClipboardText(vRef.current.slice(range.start, range.end))
-        commit(vRef.current.slice(0, range.start) + vRef.current.slice(range.end), range.start)
+        // Transactional cut: only remove the selection once the clipboard
+        // write actually succeeds. A fire-and-forget write on a headless/SSH
+        // box (no clipboard backend) would otherwise destroy the text with no
+        // copy to paste back. On failure the selection is left intact.
+        const text = vRef.current.slice(range.start, range.end)
+
+        void cutSelection(text, writeClipboardText, () => {
+          // Re-read the selection: the awaited clipboard write opens a window
+          // in which the user could have moved/changed the selection. Only
+          // remove when it still matches what we copied.
+          const current = selRange()
+
+          if (!current || current.start !== range.start || current.end !== range.end) {
+            return
+          }
+
+          commit(vRef.current.slice(0, current.start) + vRef.current.slice(current.end), current.start)
+        })
       },
       end: selected?.end ?? curRef.current,
       start: selected?.start ?? curRef.current,
@@ -1319,6 +1366,21 @@ export function TextInput({
       } else if (wordMod && inp === 'f') {
         clearSel()
         c = wordRight(v, c)
+      } else if (wordMod && inp === 'd') {
+        // meta+d (readline kill-word). The web dashboard maps Ctrl+Delete to
+        // ESC d, which hermes-ink decodes as meta+'d'; without this branch it
+        // fell through to the printable path and typed a literal "d".
+        if (range) {
+          v = v.slice(0, range.start) + v.slice(range.end)
+          c = range.start
+        } else if (c < v.length) {
+          clearSel()
+          const next = deleteWordForward(v, c)
+          v = next.value
+          c = next.cursor
+        } else {
+          return
+        }
       } else if (range && (k.backspace || delFwd)) {
         v = v.slice(0, range.start) + v.slice(range.end)
         c = range.start
@@ -1355,8 +1417,7 @@ export function TextInput({
           // Cmd+ForwardDelete — kill to end of line, matching Ctrl+K.
           ;({ cursor: c, value: v } = killToLineEnd(v, c))
         } else if (wordMod) {
-          const t = wordRight(v, c)
-          v = v.slice(0, c) + v.slice(t)
+          v = deleteWordForward(v, c).value
         } else {
           v = v.slice(0, c) + v.slice(nextPos(v, c))
         }

--- a/web/src/lib/pty-keyboard-shortcuts.test.ts
+++ b/web/src/lib/pty-keyboard-shortcuts.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest'
+
+import { resolvePtyKeyboardShortcut } from './pty-keyboard-shortcuts'
+
+const key = (overrides: Partial<KeyboardEvent> = {}) =>
+  ({
+    altKey: false,
+    ctrlKey: false,
+    key: '',
+    metaKey: false,
+    shiftKey: false,
+    ...overrides,
+  }) as KeyboardEvent
+
+describe('resolvePtyKeyboardShortcut', () => {
+  it('copies terminal selection with bare Ctrl+C on non-macOS', () => {
+    expect(
+      resolvePtyKeyboardShortcut(key({ ctrlKey: true, key: 'c' }), false, true),
+    ).toBe('copy')
+  })
+
+  it('preserves Ctrl+C interrupt when nothing is selected', () => {
+    expect(
+      resolvePtyKeyboardShortcut(key({ ctrlKey: true, key: 'c' }), false, false),
+    ).toBe('pass')
+  })
+
+  it('maps Ctrl+Backspace to backward word deletion', () => {
+    expect(
+      resolvePtyKeyboardShortcut(
+        key({ ctrlKey: true, key: 'Backspace' }),
+        false,
+        false,
+      ),
+    ).toBe('delete-word-backward')
+  })
+
+  it('maps Ctrl+Delete to forward word deletion', () => {
+    expect(
+      resolvePtyKeyboardShortcut(key({ ctrlKey: true, key: 'Delete' }), false, false),
+    ).toBe('delete-word-forward')
+  })
+})

--- a/web/src/lib/pty-keyboard-shortcuts.test.ts
+++ b/web/src/lib/pty-keyboard-shortcuts.test.ts
@@ -1,6 +1,10 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
-import { resolvePtyKeyboardShortcut } from './pty-keyboard-shortcuts'
+import {
+  resolvePtyKeyboardShortcut,
+  sendPtyShortcutSequence,
+} from './pty-keyboard-shortcuts'
+import type { PtyConnectionState } from './pty-reconnect'
 
 const key = (overrides: Partial<KeyboardEvent> = {}) =>
   ({
@@ -39,5 +43,38 @@ describe('resolvePtyKeyboardShortcut', () => {
     expect(
       resolvePtyKeyboardShortcut(key({ ctrlKey: true, key: 'Delete' }), false, false),
     ).toBe('delete-word-forward')
+  })
+})
+
+describe('sendPtyShortcutSequence', () => {
+  const socket = (readyState: number = WebSocket.OPEN) => ({
+    readyState,
+    send: vi.fn(),
+  })
+
+  it('sends the sequence when the socket and PTY state are open', () => {
+    const ws = socket()
+
+    expect(sendPtyShortcutSequence(ws, 'open', '\x17')).toBe(true)
+    expect(ws.send).toHaveBeenCalledOnce()
+    expect(ws.send).toHaveBeenCalledWith('\x17')
+  })
+
+  it.each<PtyConnectionState>(['connecting', 'reconnecting', 'closed', 'ended'])(
+    'blocks shortcut bytes while the PTY state is %s',
+    (state) => {
+      const ws = socket()
+
+      expect(sendPtyShortcutSequence(ws, state, '\x1bd')).toBe(false)
+      expect(ws.send).not.toHaveBeenCalled()
+    },
+  )
+
+  it('blocks shortcut bytes when the socket is missing or not open', () => {
+    const ws = socket(WebSocket.CLOSING)
+
+    expect(sendPtyShortcutSequence(null, 'open', '\x17')).toBe(false)
+    expect(sendPtyShortcutSequence(ws, 'open', '\x17')).toBe(false)
+    expect(ws.send).not.toHaveBeenCalled()
   })
 })

--- a/web/src/lib/pty-keyboard-shortcuts.test.ts
+++ b/web/src/lib/pty-keyboard-shortcuts.test.ts
@@ -50,7 +50,7 @@ describe('sendPtyShortcutSequence', () => {
   const socket = (readyState: number = WebSocket.OPEN) => ({
     readyState,
     send: vi.fn(),
-  })
+  }) as unknown as Pick<WebSocket, 'readyState' | 'send'> & { send: ReturnType<typeof vi.fn> }
 
   it('sends the sequence when the socket and PTY state are open', () => {
     const ws = socket()

--- a/web/src/lib/pty-keyboard-shortcuts.ts
+++ b/web/src/lib/pty-keyboard-shortcuts.ts
@@ -1,0 +1,42 @@
+export type PtyKeyboardShortcut =
+  | "copy"
+  | "delete-word-backward"
+  | "delete-word-forward"
+  | "pass";
+
+export function resolvePtyKeyboardShortcut(
+  ev: Pick<KeyboardEvent, "altKey" | "ctrlKey" | "key" | "metaKey" | "shiftKey">,
+  isMac: boolean,
+  hasTerminalSelection: boolean,
+): PtyKeyboardShortcut {
+  const key = ev.key.toLowerCase();
+  const copyPressed = isMac
+    ? ev.metaKey && !ev.ctrlKey
+    : ev.ctrlKey && !ev.altKey && !ev.metaKey;
+
+  if (copyPressed && key === "c" && hasTerminalSelection) {
+    return "copy";
+  }
+
+  if (
+    ev.ctrlKey &&
+    !ev.shiftKey &&
+    !ev.altKey &&
+    !ev.metaKey &&
+    ev.key === "Backspace"
+  ) {
+    return "delete-word-backward";
+  }
+
+  if (
+    ev.ctrlKey &&
+    !ev.shiftKey &&
+    !ev.altKey &&
+    !ev.metaKey &&
+    ev.key === "Delete"
+  ) {
+    return "delete-word-forward";
+  }
+
+  return "pass";
+}

--- a/web/src/lib/pty-keyboard-shortcuts.ts
+++ b/web/src/lib/pty-keyboard-shortcuts.ts
@@ -1,3 +1,7 @@
+import { shouldBlockPtyInput, type PtyConnectionState } from "./pty-reconnect";
+
+const WS_OPEN = 1;
+
 export type PtyKeyboardShortcut =
   | "copy"
   | "delete-word-backward"
@@ -39,4 +43,21 @@ export function resolvePtyKeyboardShortcut(
   }
 
   return "pass";
+}
+
+// Guarded sender for shortcut escape sequences. Applies the same gate as the
+// term.onData path (socket OPEN + shouldBlockPtyInput) so a reconnecting or
+// closed session never receives shortcut bytes.
+export function sendPtyShortcutSequence(
+  ws: Pick<WebSocket, "readyState" | "send"> | null,
+  ptyState: PtyConnectionState,
+  sequence: string,
+): boolean {
+  if (!ws || ws.readyState !== WS_OPEN || shouldBlockPtyInput(ptyState)) {
+    return false;
+  }
+
+  ws.send(sequence);
+
+  return true;
 }

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -60,6 +60,7 @@ import {
   normalizePtyMobileInput,
   shouldTreatInputAsMobileReplacement,
 } from "@/lib/pty-mobile-input";
+import { resolvePtyKeyboardShortcut } from "@/lib/pty-keyboard-shortcuts";
 import {
   isViewportPinnedToBottom,
   shouldFollowPtyOutput,
@@ -663,13 +664,11 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
     term.attachCustomKeyEventHandler((ev) => {
       if (ev.type !== "keydown") return true;
 
-      // Copy: Cmd+C on macOS, Ctrl+Shift+C on other platforms. Bare Ctrl+C
-      // is reserved for SIGINT to the TUI child — matches xterm / gnome-terminal /
-      // konsole / Windows Terminal. Ctrl+Shift+C only copies if a selection exists;
-      // without a selection it passes through to the TUI so agents can still
-      // react to the keypress.
+      // Copy: Cmd+C on macOS, Ctrl+C or Ctrl+Shift+C elsewhere. Copy only
+      // when xterm has a selection; without one Ctrl+C still reaches the TUI
+      // as SIGINT.
       // Paste: Cmd+Shift+V on macOS, Ctrl+Shift+V on others.
-      const copyModifier = isMac ? ev.metaKey : ev.ctrlKey && ev.shiftKey;
+      const copyModifier = isMac ? ev.metaKey : ev.ctrlKey;
       // Paste on BARE Ctrl+V too (not only Ctrl+Shift+V). Bare Ctrl+V otherwise
       // falls through to the TUI, whose server-side clipboard read can't see the
       // browser/OS clipboard → "No image found in clipboard". Routing Ctrl+V
@@ -677,22 +676,28 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
       // image-or-text correctly, like Ctrl+Shift+V.
       const pasteModifier = isMac ? ev.metaKey : ev.ctrlKey;
 
-      if (copyModifier && ev.key.toLowerCase() === "c") {
-        const sel = term.getSelection();
-        if (sel) {
-          // Direct writeText inside the keydown handler preserves the user
-          // gesture — async round-trips through OSC 52 can lose activation
-          // and fail with "Document is not focused".
-          navigator.clipboard.writeText(sel).catch((err) => {
-            console.warn("[dashboard clipboard] direct copy failed:", err.message);
-          });
-          // Clear xterm.js's highlight after copy (matches gnome-terminal).
-          term.clearSelection();
-          ev.preventDefault();
-          return false;
-        }
-        // No selection → fall through so the TUI receives Ctrl+Shift+C
-        // (or the bare ev if the user used a different modifier).
+      const terminalSelection = term.getSelection();
+      const shortcut = resolvePtyKeyboardShortcut(
+        ev,
+        isMac,
+        Boolean(terminalSelection),
+      );
+
+      if (
+        (shortcut === "copy" ||
+          (copyModifier && ev.shiftKey && ev.key.toLowerCase() === "c")) &&
+        terminalSelection
+      ) {
+        // Direct writeText inside the keydown handler preserves the user
+        // gesture — async round-trips through OSC 52 can lose activation
+        // and fail with "Document is not focused".
+        navigator.clipboard.writeText(terminalSelection).catch((err) => {
+          console.warn("[dashboard clipboard] direct copy failed:", err.message);
+        });
+        // Clear xterm.js's highlight after copy (matches gnome-terminal).
+        term.clearSelection();
+        ev.preventDefault();
+        return false;
       }
 
       // Ctrl+Backspace → delete previous word. xterm.js sends bare DEL
@@ -701,13 +706,7 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
       // delete-word-backward. (Ctrl+W can't be used in a browser tab — it's a
       // reserved shortcut that closes the tab and preventDefault has no effect;
       // for Ctrl+W muscle memory use the Electron desktop app.)
-      if (
-        ev.ctrlKey &&
-        !ev.shiftKey &&
-        !ev.altKey &&
-        !ev.metaKey &&
-        ev.key === "Backspace"
-      ) {
+      if (shortcut === "delete-word-backward") {
         ev.preventDefault();
         const ws = wsRef.current;
         if (ws && ws.readyState === WebSocket.OPEN) ws.send("\x17");
@@ -716,13 +715,7 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
 
       // Ctrl+Delete → delete next word. Mirror of Ctrl+Backspace; sends Alt+d
       // (ESC d), the readline / prompt_toolkit kill-word-forward binding.
-      if (
-        ev.ctrlKey &&
-        !ev.shiftKey &&
-        !ev.altKey &&
-        !ev.metaKey &&
-        ev.key === "Delete"
-      ) {
+      if (shortcut === "delete-word-forward") {
         ev.preventDefault();
         const ws = wsRef.current;
         if (ws && ws.readyState === WebSocket.OPEN) ws.send("\x1bd");

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -60,7 +60,10 @@ import {
   normalizePtyMobileInput,
   shouldTreatInputAsMobileReplacement,
 } from "@/lib/pty-mobile-input";
-import { resolvePtyKeyboardShortcut } from "@/lib/pty-keyboard-shortcuts";
+import {
+  resolvePtyKeyboardShortcut,
+  sendPtyShortcutSequence,
+} from "@/lib/pty-keyboard-shortcuts";
 import {
   isViewportPinnedToBottom,
   shouldFollowPtyOutput,
@@ -708,8 +711,7 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
       // for Ctrl+W muscle memory use the Electron desktop app.)
       if (shortcut === "delete-word-backward") {
         ev.preventDefault();
-        const ws = wsRef.current;
-        if (ws && ws.readyState === WebSocket.OPEN) ws.send("\x17");
+        sendPtyShortcutSequence(wsRef.current, ptyStateRef.current, "\x17");
         return false;
       }
 
@@ -717,8 +719,7 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
       // (ESC d), the readline / prompt_toolkit kill-word-forward binding.
       if (shortcut === "delete-word-forward") {
         ev.preventDefault();
-        const ws = wsRef.current;
-        if (ws && ws.readyState === WebSocket.OPEN) ws.send("\x1bd");
+        sendPtyShortcutSequence(wsRef.current, ptyStateRef.current, "\x1bd");
         return false;
       }
 

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -670,7 +670,12 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
       // react to the keypress.
       // Paste: Cmd+Shift+V on macOS, Ctrl+Shift+V on others.
       const copyModifier = isMac ? ev.metaKey : ev.ctrlKey && ev.shiftKey;
-      const pasteModifier = isMac ? ev.metaKey : ev.ctrlKey && ev.shiftKey;
+      // Paste on BARE Ctrl+V too (not only Ctrl+Shift+V). Bare Ctrl+V otherwise
+      // falls through to the TUI, whose server-side clipboard read can't see the
+      // browser/OS clipboard → "No image found in clipboard". Routing Ctrl+V
+      // through the same navigator.clipboard path below makes it paste
+      // image-or-text correctly, like Ctrl+Shift+V.
+      const pasteModifier = isMac ? ev.metaKey : ev.ctrlKey;
 
       if (copyModifier && ev.key.toLowerCase() === "c") {
         const sel = term.getSelection();
@@ -688,6 +693,40 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
         }
         // No selection → fall through so the TUI receives Ctrl+Shift+C
         // (or the bare ev if the user used a different modifier).
+      }
+
+      // Ctrl+Backspace → delete previous word. xterm.js sends bare DEL
+      // regardless of modifier, so word-delete never reaches the TUI on its
+      // own. Send ^W (0x17), which readline / prompt_toolkit treat as
+      // delete-word-backward. (Ctrl+W can't be used in a browser tab — it's a
+      // reserved shortcut that closes the tab and preventDefault has no effect;
+      // for Ctrl+W muscle memory use the Electron desktop app.)
+      if (
+        ev.ctrlKey &&
+        !ev.shiftKey &&
+        !ev.altKey &&
+        !ev.metaKey &&
+        ev.key === "Backspace"
+      ) {
+        ev.preventDefault();
+        const ws = wsRef.current;
+        if (ws && ws.readyState === WebSocket.OPEN) ws.send("\x17");
+        return false;
+      }
+
+      // Ctrl+Delete → delete next word. Mirror of Ctrl+Backspace; sends Alt+d
+      // (ESC d), the readline / prompt_toolkit kill-word-forward binding.
+      if (
+        ev.ctrlKey &&
+        !ev.shiftKey &&
+        !ev.altKey &&
+        !ev.metaKey &&
+        ev.key === "Delete"
+      ) {
+        ev.preventDefault();
+        const ws = wsRef.current;
+        if (ws && ws.readyState === WebSocket.OPEN) ws.send("\x1bd");
+        return false;
       }
 
       if (pasteModifier && ev.key.toLowerCase() === "v") {

--- a/website/docs/user-guide/cli.md
+++ b/website/docs/user-guide/cli.md
@@ -270,6 +270,14 @@ There are two ways to enter multi-line messages:
   2. Returns the sum
 ```
 
+`Ctrl+J` and backslash continuation are enabled by default, matching Claude Code / Codex / OpenCode multiline shortcuts. On supported terminals such as iTerm2, Hermes also requests extended key reporting so `Shift+Enter` arrives as a distinct newline key. If your terminal sends LF for plain `Enter` and you need the legacy `Ctrl+J`-as-submit fallback, opt out:
+
+```yaml
+# ~/.hermes/config.yaml
+display:
+  cli_multiline_shortcuts: false
+```
+
 :::info
 Pasting multi-line text is supported — use any of the newline keys above, or simply paste content directly.
 :::
@@ -285,7 +293,7 @@ Most terminals send the same byte sequence for `Enter` and `Shift+Enter` by defa
 | Windows Terminal Preview 1.25+ | Supported once the Kitty protocol is enabled in settings |
 | macOS Terminal.app, stock Windows Terminal (stable) | Not supported — `Shift+Enter` is indistinguishable from `Enter` |
 
-Where the terminal cannot distinguish them, `Alt+Enter` and `Ctrl+J` continue to work everywhere. **On Windows Terminal specifically, `Alt+Enter` is captured by the terminal (toggles fullscreen) and never reaches Hermes — use `Ctrl+Enter` (delivered as `Ctrl+J`) or `Ctrl+J` directly for a newline.**
+Where the terminal cannot distinguish them, `Alt+Enter` and `Ctrl+J` continue to work by default. **On Windows Terminal specifically, `Alt+Enter` is captured by the terminal (toggles fullscreen) and never reaches Hermes — use `Ctrl+Enter` (delivered as `Ctrl+J`) or `Ctrl+J` directly for a newline.**
 
 ## Redirecting the Agent Mid-Turn
 

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1734,6 +1734,7 @@ display:
   skin: default           # Built-in or custom CLI skin (see user-guide/features/skins)
   personality: ""         # Legacy cosmetic field still surfaced in some summaries
   compact: false          # Compact output mode (less whitespace)
+  cli_multiline_shortcuts: true  # CLI: Ctrl+J, \ + Enter, and supported Shift+Enter insert newlines (false = legacy c-j submit fallback)
   resume_display: full    # full (show previous messages on resume) | minimal (one-liner only)
   bell_on_complete: false # Play terminal bell when agent finishes (great for long tasks)
   show_reasoning: true    # Show model reasoning/thinking above each response (default: true; toggle with /reasoning show|hide)


### PR DESCRIPTION
Salvages three contributor PRs covering TUI/dashboard clipboard-and-editing shortcuts, classic-CLI multiline input, and an Alt-shortcut crash in prompt_toolkit key binding.

## Changes

- **Dashboard/TUI paste, copy/cut, and word-delete** (#63363, @null-runner, 4 commits):
  - Ctrl+V / Ctrl+Shift+V paste browser clipboard text or images into the xterm.js dashboard terminal.
  - Ctrl+C copies an xterm selection; with no selection it still reaches the TUI as interrupt.
  - Ctrl+Backspace → Ctrl+W (backward word delete), Ctrl+Delete → Alt+D (forward word delete), with shortcut sends gated on PTY state.
  - TUI side: meta+d forward word-delete no longer types a literal "d"; copy/cut restored with transactional cut semantics. Rebase note: the forward-delete branch was merged with main's newer Cmd+ForwardDelete line-kill path (`isLineKillModifier` checked first, contributor's `deleteWordForward` for the word case).
- **Classic CLI multiline shortcuts on by default** (#61215, @John-Lussier, 2 commits): Ctrl+J inserts a newline (matching Claude Code / Codex / OpenCode), trailing `\` + Enter continues the draft, and allowlisted terminals (iTerm2, WezTerm, kitty, Ghostty, WT, vscode, tmux) are asked for extended Enter-key reporting so Shift+Enter arrives distinctly. Opt-out via `display.cli_multiline_shortcuts: false` in config.yaml (restores the legacy c-j-submit fallback for thin PTYs). Rebase note: main moved `DEFAULT_CONFIG` to `hermes_cli/config_defaults.py`, so the new key landed there; the conflicting test files were merged to keep both main's `windows_only`/`linux_only` markers and the new coverage.
- **Alt shortcuts no longer crash the CLI** (#74257, @moisesvalero): `voice.record_key: alt+v` normalized to `a-v`, which `prompt_toolkit`'s `@kb.add()` rejects with `ValueError: Invalid key: a-v`. New `pt_key_to_sequence()` converts `a-x` specifiers to the `('escape', 'x')` sequence tuple prompt_toolkit expects. Fixes #74169.

## Not included

- **#81727 (Ctrl+F dead on Pop!_OS)**: desktop-renderer issue, not these prompt_toolkit/TUI keybind tables — noted in the sibling desktop-keybinds salvage PR (root cause tracked by #79870).

## Validation

| Check | Result |
|---|---|
| `pytest tests/cli/test_ctrl_enter_newline.py tests/cli/test_cli_init.py tests/hermes_cli/test_voice_wrapper.py -o addopts="" -q` | ✅ 69 passed, 2 skipped |
| `vitest run` ui-tui textInputCut / textInputWordDelete / inputSelectionClipboard | ✅ 12 passed |
| `vitest run` web pty-keyboard-shortcuts | ✅ 10 passed |
| `tsc --noEmit` (web) | ✅ clean |
| `py_compile` cli.py, hermes_cli/{voice,config,config_defaults}.py | ✅ clean |
| `scripts/audit_pr_attribution.py --fix` | ✅ all emails mapped |

## Credits

Thanks to @null-runner (#63363), @John-Lussier (#61215), and @moisesvalero (#74257) — authorship preserved via cherry-pick.

Fixes #74169.
Covers #63363, #61215, #74257.

## Infographic

![TUI/CLI editing shortcuts](https://files.catbox.moe/qzntnt.png)
