### PR TITLE
fix(api-server): stop retrying unavailable bind addresses

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -7452,9 +7452,18 @@ class APIServerAdapter(BasePlatformAdapter):
                         f"different value, then `/platform resume api_server`.",
                         retryable=False,
                     )
+                elif getattr(exc, "errno", None) == errno.EADDRNOTAVAIL:
+                    self._set_fatal_error(
+                        "api_server_address_unavailable",
+                        f"Address {self._host} is not available on this host. Set "
+                        f"platforms.api_server.host in config.yaml to a local "
+                        f"address, then `/platform resume api_server`.",
+                        retryable=False,
+                    )
                 logger.error(
-                    "[%s] Could not bind %s:%d: %s. Set a different port in "
-                    "config.yaml: platforms.api_server.port",
+                    "[%s] Could not bind %s:%d: %s. Check the bind host and "
+                    "port in config.yaml: platforms.api_server.host and "
+                    "platforms.api_server.port",
                     self.name, self._host, self._port, exc,
                 )
                 return False

--- a/tests/gateway/test_api_server_bind_guard.py
+++ b/tests/gateway/test_api_server_bind_guard.py
@@ -4,6 +4,7 @@ Validates that is_network_accessible() correctly classifies addresses and
 that connect() refuses to start without API_SERVER_KEY.
 """
 
+import errno
 import socket
 from unittest.mock import patch
 
@@ -111,11 +112,11 @@ class TestBindMechanics:
 
     _KEY = "sk-test-strong-key-0123456789"
 
-    def _make_adapter(self, port: int) -> APIServerAdapter:
+    def _make_adapter(self, port: int, host: str = "127.0.0.1") -> APIServerAdapter:
         return APIServerAdapter(
             PlatformConfig(
                 enabled=True,
-                extra={"host": "127.0.0.1", "port": port, "key": self._KEY},
+                extra={"host": host, "port": port, "key": self._KEY},
             )
         )
 
@@ -170,3 +171,23 @@ class TestBindMechanics:
         finally:
             await first.disconnect()
             await second.disconnect()
+
+    @pytest.mark.asyncio
+    async def test_unavailable_bind_address_sets_non_retryable_fatal_error(self):
+        """An unavailable configured address must not retry forever."""
+        adapter = self._make_adapter(self._free_port(), host="192.168.64.1")
+        try:
+            with patch(
+                "gateway.platforms.api_server.web.TCPSite.start",
+                side_effect=OSError(
+                    errno.EADDRNOTAVAIL, "Cannot assign requested address"
+                ),
+            ):
+                result = await adapter.connect()
+            assert result is False
+            assert adapter.has_fatal_error is True
+            assert adapter.fatal_error_retryable is False
+            assert adapter.fatal_error_code == "api_server_address_unavailable"
+            assert "192.168.64.1" in (adapter.fatal_error_message or "")
+        finally:
+            await adapter.disconnect()


### PR DESCRIPTION
## Problem

Production logs showed 881 repeated API bind failures over Aug 12–15 for the configured address `192.168.64.1`. The address is not assigned to the host, so the bind raises `EADDRNOTAVAIL`. `APIServerAdapter.connect()` treated only `EADDRINUSE` as fatal, causing the gateway reconnect watcher to retry the invalid configuration indefinitely.

## Fix

- Mark `EADDRNOTAVAIL` as a non-retryable API-server fatal error.
- Report the unavailable host and point recovery at `platforms.api_server.host`.
- Add a regression test beside the existing port-conflict guard.

The live configuration has already been corrected to loopback and the service is healthy; this PR changes no deployed files and performs no restart.

## Verification

- `scripts/run_tests.sh tests/gateway/test_api_server_bind_guard.py tests/gateway/test_adapter_connect_classification.py -q` — 33 passed
- `ruff check gateway/platforms/api_server.py tests/gateway/test_api_server_bind_guard.py` — passed
- `git diff --check` — passed
