### PR TITLE
feat(ui): collapse & density QoL cluster — session-list density, thinking collapse behavior, chevron fixes, web side-panel toggle

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/session-row-details.test.ts
+++ b/apps/desktop/src/app/chat/sidebar/session-row-details.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from 'vitest'
+
+import type { SessionInfo } from '@/types/hermes'
+
+import { sessionRowDetails, sessionRowEstimate, type SessionRowFormatters } from './session-row-details'
+
+const en: SessionRowFormatters = {
+  messageCount: count => `${count} ${count === 1 ? 'message' : 'messages'}`,
+  toolCallCount: count => `${count} ${count === 1 ? 'tool call' : 'tool calls'}`
+}
+
+const session = (overrides: Partial<SessionInfo> = {}): SessionInfo => ({
+  ended_at: null,
+  id: 's1',
+  input_tokens: 0,
+  is_active: false,
+  last_active: 1,
+  message_count: 26,
+  model: 'google/gemini-3.1-pro',
+  output_tokens: 0,
+  preview: '  Explore\nGmail-like density tiers for session rows.  ',
+  source: 'desktop',
+  started_at: 1,
+  title: 'Session density exploration',
+  tool_call_count: 8,
+  ...overrides
+})
+
+describe('session row details', () => {
+  it('provides density-aware virtual row estimates', () => {
+    expect(sessionRowEstimate('compact')).toBe(28)
+    expect(sessionRowEstimate('comfortable')).toBe(45)
+    expect(sessionRowEstimate('detailed')).toBe(63)
+  })
+
+  it('keeps the detailed estimate even when preview is omitted as a title duplicate', () => {
+    const details = sessionRowDetails(session({ title: null }), en)
+
+    expect(details.preview).toBeNull()
+    expect(sessionRowEstimate('detailed')).toBe(63)
+  })
+
+  it('formats deterministic metadata without ambiguous call wording', () => {
+    expect(sessionRowDetails(session({ git_branch: 'feature/menu' }), en)).toEqual({
+      metadata: 'feature/menu · gemini-3.1-pro · 26 messages · 8 tool calls',
+      preview: 'Explore Gmail-like density tiers for session rows.'
+    })
+  })
+
+  it('uses singular labels and omits unavailable fields', () => {
+    expect(
+      sessionRowDetails(
+        session({
+          git_branch: null,
+          message_count: 1,
+          model: null,
+          preview: null,
+          title: 'Manual title',
+          tool_call_count: 1
+        }),
+        en
+      )
+    ).toEqual({ metadata: '1 message · 1 tool call', preview: null })
+  })
+
+  it('omits zero counts from metadata so the sidebar stays clean', () => {
+    expect(
+      sessionRowDetails(
+        session({ git_branch: null, message_count: 0, model: null, tool_call_count: 0 }),
+        en
+      )
+    ).toEqual({ metadata: '', preview: 'Explore Gmail-like density tiers for session rows.' })
+  })
+
+  it('normalizes whitespace-only title, branch, and preview values', () => {
+    expect(
+      sessionRowDetails(
+        session({
+          git_branch: '   ',
+          preview: '  ',
+          title: '   '
+        }),
+        en
+      )
+    ).toEqual({ metadata: 'gemini-3.1-pro · 26 messages · 8 tool calls', preview: null })
+  })
+
+  it('omits the preview when it already supplies the displayed title', () => {
+    expect(sessionRowDetails(session({ title: null }), en)).toEqual({
+      metadata: 'gemini-3.1-pro · 26 messages · 8 tool calls',
+      preview: null
+    })
+  })
+
+  it('localizes count labels via the formatter interface', () => {
+    const ja: SessionRowFormatters = {
+      messageCount: count => `${count} 件のメッセージ`,
+      toolCallCount: count => `${count} 件のツール呼び出し`
+    }
+
+    expect(
+      sessionRowDetails(
+        session({ git_branch: null, message_count: 3, model: null, tool_call_count: 5 }),
+        ja
+      )
+    ).toEqual({
+      metadata: '3 件のメッセージ · 5 件のツール呼び出し',
+      preview: 'Explore Gmail-like density tiers for session rows.'
+    })
+  })
+})

--- a/apps/desktop/src/app/chat/sidebar/session-row-details.ts
+++ b/apps/desktop/src/app/chat/sidebar/session-row-details.ts
@@ -1,0 +1,37 @@
+import type { SessionListDensity } from '@/store/session-list-density'
+import type { SessionInfo } from '@/types/hermes'
+
+export interface SessionRowDetails {
+  metadata: string
+  preview: null | string
+}
+
+export interface SessionRowFormatters {
+  messageCount: (count: number) => string
+  toolCallCount: (count: number) => string
+}
+
+const modelLabel = (model: null | string) => model?.split('/').pop()?.trim() || null
+const oneLine = (value: null | string) => value?.replace(/\s+/g, ' ').trim() || null
+
+export const sessionRowEstimate = (density: SessionListDensity) =>
+  ({ compact: 28, comfortable: 45, detailed: 63 })[density]
+
+export function sessionRowDetails(session: SessionInfo, fmt: SessionRowFormatters): SessionRowDetails {
+  const preview = oneLine(session.preview)
+  const hasOwnTitle = Boolean(session.title?.trim())
+
+  const metadata = [
+    session.git_branch?.trim() || null,
+    modelLabel(session.model),
+    session.message_count > 0 ? fmt.messageCount(session.message_count) : null,
+    session.tool_call_count > 0 ? fmt.toolCallCount(session.tool_call_count) : null
+  ]
+    .filter(Boolean)
+    .join(' · ')
+
+  return {
+    metadata,
+    preview: hasOwnTitle ? preview : null
+  }
+}

--- a/apps/desktop/src/app/chat/sidebar/session-row.tsx
+++ b/apps/desktop/src/app/chat/sidebar/session-row.tsx
@@ -28,6 +28,7 @@ import { normalizeProfileKey } from '@/store/profile'
 import { $projects } from '@/store/projects'
 import { $pullRequestsByBranch, sessionPrKey } from '@/store/pull-requests'
 import { $sessionDotStateById, hasLiveTurn, showsRunningArc } from '@/store/session-dot-state'
+import { $sessionListDensity } from '@/store/session-list-density'
 import { sessionCostUsd } from '@/store/sidebar-archive'
 import { $todoProgressBySession } from '@/store/todos'
 
@@ -43,6 +44,7 @@ import {
   SidebarRowShell
 } from './chrome'
 import { SessionActionsMenu, SessionContextMenu } from './session-actions-menu'
+import { sessionRowDetails } from './session-row-details'
 import { useProfilePrewarm } from './use-profile-prewarm'
 
 interface SidebarSessionRowProps extends React.ComponentProps<'div'> {
@@ -134,6 +136,12 @@ function SidebarSessionRowImpl({
   const r = t.sidebar.row
   const { cancelPrewarm, startPrewarm } = useProfilePrewarm(session.profile)
   const title = sessionTitle(session)
+  const density = useStore($sessionListDensity)
+  const fmt = t.sidebar
+  const details = sessionRowDetails(session, {
+    messageCount: fmt.messageCount,
+    toolCallCount: fmt.toolCallCount
+  })
   const age = formatAge(session.last_active || session.started_at, r)
   const handleLabel = `Reorder ${title}`
   // Opt-in row metadata from the sidebar's filter menu. Read from the store
@@ -311,6 +319,10 @@ function SidebarSessionRowImpl({
         className={cn(
           'group row-hover relative',
           card && SIDEBAR_ROW_CARD_MIN_H,
+          // Density-aware minimum heights for the inline (non-card) row: the
+          // metadata / preview lines below need the extra rows (#68119).
+          !card && density !== 'compact' && 'min-h-[2.75rem]',
+          !card && density === 'detailed' && 'min-h-[3.875rem]',
           isSelected && 'bg-(--ui-row-active-background)',
           liveTurn && 'text-foreground',
           // Opaque surface while lifted so the dragged row erases what's under
@@ -438,15 +450,30 @@ function SidebarSessionRowImpl({
                 <>
                   {leadNode}
                   {handoffBadge}
-                  <OverflowTip label={title}>
-                    <SidebarRowLabel
-                      className="hover-marquee flex-1 font-normal group-hover:text-foreground group-data-[working=true]:text-foreground/90"
-                      onPointerEnter={armMarquee}
-                      onPointerLeave={disarmMarquee}
-                    >
-                      <span className="hover-marquee-inner">{title}</span>
-                    </SidebarRowLabel>
-                  </OverflowTip>
+                  <span className="min-w-0 flex-1 self-center">
+                    <OverflowTip label={title}>
+                      <SidebarRowLabel
+                        className="hover-marquee block font-normal group-hover:text-foreground group-data-[working=true]:text-foreground/90"
+                        onPointerEnter={armMarquee}
+                        onPointerLeave={disarmMarquee}
+                      >
+                        <span className="hover-marquee-inner">{title}</span>
+                      </SidebarRowLabel>
+                    </OverflowTip>
+                    {/* Session-list density (#68119): comfortable adds one
+                        deterministic metadata line; detailed adds the initial
+                        request preview. Compact keeps today's one-line row. */}
+                    {density !== 'compact' && details.metadata && (
+                      <span className="mt-0.5 block truncate text-[0.625rem] leading-none text-(--ui-text-tertiary)">
+                        {details.metadata}
+                      </span>
+                    )}
+                    {density === 'detailed' && details.preview && (
+                      <span className="mt-1 block truncate text-[0.625rem] leading-none text-(--ui-text-quaternary)">
+                        {details.preview}
+                      </span>
+                    )}
+                  </span>
                 </>
               )
             }

--- a/apps/desktop/src/app/chat/sidebar/session-row.tsx
+++ b/apps/desktop/src/app/chat/sidebar/session-row.tsx
@@ -138,10 +138,12 @@ function SidebarSessionRowImpl({
   const title = sessionTitle(session)
   const density = useStore($sessionListDensity)
   const fmt = t.sidebar
+
   const details = sessionRowDetails(session, {
     messageCount: fmt.messageCount,
     toolCallCount: fmt.toolCallCount
   })
+
   const age = formatAge(session.last_active || session.started_at, r)
   const handleLabel = `Reorder ${title}`
   // Opt-in row metadata from the sidebar's filter menu. Read from the store

--- a/apps/desktop/src/app/chat/sidebar/virtual-session-list.test.tsx
+++ b/apps/desktop/src/app/chat/sidebar/virtual-session-list.test.tsx
@@ -12,6 +12,7 @@ const virtualizer = {
     { end: 26, index: 0, start: 0 },
     { end: 68, index: 1, start: 26 }
   ],
+  measure: vi.fn(),
   measureElement: vi.fn()
 }
 

--- a/apps/desktop/src/app/chat/sidebar/virtual-session-list.tsx
+++ b/apps/desktop/src/app/chat/sidebar/virtual-session-list.tsx
@@ -1,8 +1,9 @@
 import { useSortable } from '@dnd-kit/sortable'
 import { CSS } from '@dnd-kit/utilities'
+import { useStore } from '@nanostores/react'
 import { useVirtualizer } from '@tanstack/react-virtual'
 import type * as React from 'react'
-import { type FC, useRef } from 'react'
+import { type FC, useEffect, useRef } from 'react'
 
 import type { SessionInfo } from '@/hermes'
 import { useI18n } from '@/i18n'
@@ -10,9 +11,11 @@ import { type SidebarListRow } from '@/lib/session-date-groups'
 import { sessionBucketLabel } from '@/lib/time'
 import { cn } from '@/lib/utils'
 import { sessionPinId } from '@/store/session'
+import { $sessionListDensity } from '@/store/session-list-density'
 
 import { SidebarDateDivider } from './chrome'
 import { SidebarSessionRow } from './session-row'
+import { sessionRowEstimate } from './session-row-details'
 
 interface SessionRowCommonProps {
   branchStem?: string
@@ -46,11 +49,11 @@ export interface VirtualSessionListProps {
   sortable: boolean
 }
 
-const ROW_ESTIMATE_PX = 28
 // Matches the card's typical rendered height (four lines when a preview
 // exists) so long card lists don't jump under the scroll thumb before
 // self-measurement catches up.
 const CARD_ROW_ESTIMATE_PX = 66
+const DIVIDER_ESTIMATE_PX = 28
 const OVERSCAN_ROWS = 12
 
 export const VirtualSessionList: FC<VirtualSessionListProps> = ({
@@ -71,10 +74,19 @@ export const VirtualSessionList: FC<VirtualSessionListProps> = ({
   const { t } = useI18n()
   const dividerLabels = t.sidebar.dateDivider
   const scrollerRef = useRef<HTMLDivElement | null>(null)
+  const density = useStore($sessionListDensity)
 
   const virtualizer = useVirtualizer({
     count: listRows.length,
-    estimateSize: () => (card ? CARD_ROW_ESTIMATE_PX : ROW_ESTIMATE_PX),
+    estimateSize: (index: number) => {
+      const row = listRows[index]
+
+      if (row?.kind === 'divider') {
+        return DIVIDER_ESTIMATE_PX
+      }
+
+      return card ? CARD_ROW_ESTIMATE_PX : sessionRowEstimate(density)
+    },
     getItemKey: index => {
       const row = listRows[index]
 
@@ -85,6 +97,10 @@ export const VirtualSessionList: FC<VirtualSessionListProps> = ({
     initialRect: { height: 600, width: 240 },
     overscan: OVERSCAN_ROWS
   })
+
+  // Rows are measured after paint, so changing density must invalidate cached
+  // measurements from the previous mode before off-screen rows re-enter.
+  useEffect(() => virtualizer.measure(), [density, virtualizer])
 
   const virtualItems = virtualizer.getVirtualItems()
   const totalSize = virtualizer.getTotalSize()

--- a/apps/desktop/src/app/chat/sidebar/virtual-session-list.tsx
+++ b/apps/desktop/src/app/chat/sidebar/virtual-session-list.tsx
@@ -177,7 +177,9 @@ export const VirtualSessionList: FC<VirtualSessionListProps> = ({
       )}
       ref={scrollerRef}
     >
-      <div className="relative" style={{ height: `${totalSize}px` }}>{rows}</div>
+      <div className="relative" style={{ height: `${totalSize}px` }}>
+        {rows}
+      </div>
     </div>
   )
 }

--- a/apps/desktop/src/app/settings/appearance-settings.tsx
+++ b/apps/desktop/src/app/settings/appearance-settings.tsx
@@ -17,6 +17,11 @@ import { $embedAllowed, $embedMode, clearEmbedAllowed, type EmbedMode, setEmbedM
 import { $activeGatewayProfile, $profiles, normalizeProfileKey } from '@/store/profile'
 import { $reactionsEnabled, setReactionsEnabled } from '@/store/reactions-enabled'
 import { $reasoningCollapsedByDefault, setReasoningCollapsedByDefault } from '@/store/reasoning-disclosure'
+import {
+  $sessionListDensity,
+  type SessionListDensity,
+  setSessionListDensity
+} from '@/store/session-list-density'
 import { $toolViewMode, setToolViewMode } from '@/store/tool-view'
 import { $translucency, setTranslucency } from '@/store/translucency'
 import { $zoomPercent, setZoomPercent } from '@/store/zoom'
@@ -250,6 +255,7 @@ export function AppearanceSettings() {
   const { themeName, mode, resolvedMode, availableThemes, setTheme, setMode } = useTheme()
   const toolViewMode = useStore($toolViewMode)
   const reasoningCollapsedByDefault = useStore($reasoningCollapsedByDefault)
+  const sessionListDensity = useStore($sessionListDensity)
   const zoomPercent = useStore($zoomPercent)
   const embedMode = useStore($embedMode)
   const embedAllowed = useStore($embedAllowed)
@@ -292,6 +298,12 @@ export function AppearanceSettings() {
     { id: 'product', label: a.product },
     { id: 'technical', label: a.technical }
   ] as const
+
+  const sessionDensityOptions = [
+    { id: 'compact', label: a.sessionDensityCompact },
+    { id: 'comfortable', label: a.sessionDensityComfortable },
+    { id: 'detailed', label: a.sessionDensityDetailed }
+  ] as const satisfies readonly { id: SessionListDensity; label: string }[]
 
   const embedOptions = [
     { id: 'ask', label: a.embedsAsk },
@@ -434,6 +446,21 @@ export function AppearanceSettings() {
           />
 
           <TerminalFontSetting />
+
+          <ListRow
+            action={
+              <SegmentedControl
+                onChange={id => {
+                  triggerHaptic('selection')
+                  setSessionListDensity(id)
+                }}
+                options={sessionDensityOptions}
+                value={sessionListDensity}
+              />
+            }
+            description={a.sessionDensityDesc}
+            title={a.sessionDensityTitle}
+          />
 
           <ListRow
             action={

--- a/apps/desktop/src/app/settings/appearance-settings.tsx
+++ b/apps/desktop/src/app/settings/appearance-settings.tsx
@@ -16,6 +16,7 @@ import { $backdrop, setBackdrop } from '@/store/backdrop'
 import { $embedAllowed, $embedMode, clearEmbedAllowed, type EmbedMode, setEmbedMode } from '@/store/embed-consent'
 import { $activeGatewayProfile, $profiles, normalizeProfileKey } from '@/store/profile'
 import { $reactionsEnabled, setReactionsEnabled } from '@/store/reactions-enabled'
+import { $reasoningCollapsedByDefault, setReasoningCollapsedByDefault } from '@/store/reasoning-disclosure'
 import { $toolViewMode, setToolViewMode } from '@/store/tool-view'
 import { $translucency, setTranslucency } from '@/store/translucency'
 import { $zoomPercent, setZoomPercent } from '@/store/zoom'
@@ -248,6 +249,7 @@ export function AppearanceSettings() {
   const { t, isSavingLocale } = useI18n()
   const { themeName, mode, resolvedMode, availableThemes, setTheme, setMode } = useTheme()
   const toolViewMode = useStore($toolViewMode)
+  const reasoningCollapsedByDefault = useStore($reasoningCollapsedByDefault)
   const zoomPercent = useStore($zoomPercent)
   const embedMode = useStore($embedMode)
   const embedAllowed = useStore($embedAllowed)
@@ -508,6 +510,24 @@ export function AppearanceSettings() {
             }
             description={a.toolViewDesc}
             title={a.toolViewTitle}
+          />
+
+          <ListRow
+            action={
+              <SegmentedControl
+                onChange={id => {
+                  triggerHaptic('selection')
+                  setReasoningCollapsedByDefault(id === 'on')
+                }}
+                options={[
+                  { id: 'off', label: t.common.off },
+                  { id: 'on', label: t.common.on }
+                ]}
+                value={reasoningCollapsedByDefault ? 'on' : 'off'}
+              />
+            }
+            description={a.reasoningCollapsedDesc}
+            title={a.reasoningCollapsedTitle}
           />
 
           <ListRow

--- a/apps/desktop/src/app/settings/appearance-settings.tsx
+++ b/apps/desktop/src/app/settings/appearance-settings.tsx
@@ -17,11 +17,7 @@ import { $embedAllowed, $embedMode, clearEmbedAllowed, type EmbedMode, setEmbedM
 import { $activeGatewayProfile, $profiles, normalizeProfileKey } from '@/store/profile'
 import { $reactionsEnabled, setReactionsEnabled } from '@/store/reactions-enabled'
 import { $reasoningCollapsedByDefault, setReasoningCollapsedByDefault } from '@/store/reasoning-disclosure'
-import {
-  $sessionListDensity,
-  type SessionListDensity,
-  setSessionListDensity
-} from '@/store/session-list-density'
+import { $sessionListDensity, type SessionListDensity, setSessionListDensity } from '@/store/session-list-density'
 import { $toolViewMode, setToolViewMode } from '@/store/tool-view'
 import { $translucency, setTranslucency } from '@/store/translucency'
 import { $zoomPercent, setZoomPercent } from '@/store/zoom'

--- a/apps/desktop/src/components/assistant-ui/thread/message-parts.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/message-parts.tsx
@@ -4,6 +4,7 @@ import {
   useAuiState,
   useMessagePartReasoning
 } from '@assistant-ui/react'
+import { useStore } from '@nanostores/react'
 import { type ComponentProps, type FC, type ReactNode, useEffect, useRef, useState } from 'react'
 
 import { ClarifyTool } from '@/components/assistant-ui/clarify-tool'
@@ -21,6 +22,7 @@ import { generatedImageFromResult } from '@/lib/generated-images'
 import { separateGluedReasoningBlocks } from '@/lib/reasoning-blocks'
 import { useEnterAnimation } from '@/lib/use-enter-animation'
 import { cn } from '@/lib/utils'
+import { $reasoningCollapsedByDefault } from '@/store/reasoning-disclosure'
 
 const ImageGenerateTool: FC<ToolCallMessagePartProps> = props => {
   const { args, result } = props
@@ -103,10 +105,9 @@ const ThinkingDisclosure: FC<{
   timerKey: string
 }> = ({ children, messageRunning = false, pending = false, timerKey }) => {
   const { t } = useI18n()
-  // `null` = no explicit user toggle yet, defer to the streaming default.
-  // The default is "auto-open while streaming, auto-collapse when done" so
-  // reasoning surfaces a live preview without manual interaction. The first
-  // explicit toggle wins from then on.
+  const reasoningCollapsedByDefault = useStore($reasoningCollapsedByDefault)
+  // `null` = no explicit user toggle yet. Live reasoning remains visible by
+  // default, unless the user opts into the low-jitter collapsed presentation.
   const [userOpen, setUserOpen] = useState<boolean | null>(null)
   const elapsed = useElapsedSeconds(pending, timerKey)
   const thoughtFor = useMeasuredDuration(pending, timerKey)
@@ -114,8 +115,8 @@ const ThinkingDisclosure: FC<{
   const contentRef = useRef<HTMLDivElement | null>(null)
   const enterRef = useEnterAnimation(messageRunning, timerKey)
 
-  const open = userOpen ?? pending
-  const isPreview = pending && userOpen === null
+  const open = userOpen ?? (pending && !reasoningCollapsedByDefault)
+  const isPreview = pending && userOpen === null && !reasoningCollapsedByDefault
 
   // Three ways a finished block can report itself. With a measured duration it
   // says so, unless the timer's whole seconds round it to "0s" — accurate and

--- a/apps/desktop/src/components/assistant-ui/thread/streaming.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/streaming.test.tsx
@@ -3,6 +3,8 @@ import { act, fireEvent, render, screen, waitFor, within } from '@testing-librar
 import { useEffect, useState } from 'react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { $reasoningCollapsedByDefault } from '@/store/reasoning-disclosure'
+
 import { Thread } from '.'
 
 const createdAt = new Date('2026-05-01T00:00:00.000Z')
@@ -475,6 +477,7 @@ function DismissibleErrorHarness({ onDismissError }: { onDismissError: (messageI
 describe('assistant-ui streaming renderer', () => {
   beforeEach(() => {
     resizeObservers.clear()
+    $reasoningCollapsedByDefault.set(false)
   })
 
   it('renders assistant text incrementally before completion', async () => {
@@ -600,6 +603,21 @@ describe('assistant-ui streaming renderer', () => {
       expect(container.querySelector('[data-slot="aui_reasoning-text"]')?.textContent).toContain('const answer = 42')
     })
     expect(container.textContent).not.toContain('```ts')
+  })
+
+  it('keeps streaming reasoning collapsed by default when the preference is enabled', () => {
+    $reasoningCollapsedByDefault.set(true)
+
+    const { container } = render(<RunningReasoningHarness />)
+    const thinkingToggle = within(container).getByRole('button', { name: /thinking/i })
+
+    expect(thinkingToggle.getAttribute('aria-expanded')).toBe('false')
+    expect(container.querySelector('[data-slot="aui_reasoning-text"]')).toBeNull()
+
+    fireEvent.click(thinkingToggle)
+
+    expect(thinkingToggle.getAttribute('aria-expanded')).toBe('true')
+    expect(container.querySelector('[data-slot="aui_reasoning-text"]')?.textContent).toContain('const answer = 42')
   })
 
   it('renders reasoning text without a leading token space', () => {

--- a/apps/desktop/src/components/pane-shell/tree/renderer/floating-panes.test.tsx
+++ b/apps/desktop/src/components/pane-shell/tree/renderer/floating-panes.test.tsx
@@ -167,6 +167,10 @@ describe('FloatingPanes (live DOM)', () => {
 
     const before = card()!.style.left
     const toggle = card()!.querySelector('button')!
+    const chevron = () => toggle.querySelector('i')!
+
+    // Expanded: down chevron (fold). Collapsed: up chevron (restore).
+    expect(chevron().className).toContain('codicon-chevron-down')
 
     // The button is inside the drag handle — [data-floating-no-drag] must
     // stop it starting a drag.
@@ -182,6 +186,7 @@ describe('FloatingPanes (live DOM)', () => {
 
     expect(document.querySelector('[data-testid="hud-body"]')).toBeNull()
     expect(card()!.style.height).toBe('')
+    expect(chevron().className).toContain('codicon-chevron-up')
   })
 
   it('renders one card per floating contribution', () => {

--- a/apps/desktop/src/components/pane-shell/tree/renderer/floating-panes.tsx
+++ b/apps/desktop/src/components/pane-shell/tree/renderer/floating-panes.tsx
@@ -172,7 +172,7 @@ function FloatingPane({ pane }: { pane: Contribution }) {
           onClick={toggleCollapsed}
           type="button"
         >
-          <Codicon name={collapsed ? 'chevron-down' : 'chevron-up'} size="0.75rem" />
+          <Codicon name={collapsed ? 'chevron-up' : 'chevron-down'} size="0.75rem" />
         </button>
       </header>
 

--- a/apps/desktop/src/components/pane-shell/tree/renderer/tree-group.test.tsx
+++ b/apps/desktop/src/components/pane-shell/tree/renderer/tree-group.test.tsx
@@ -1,0 +1,76 @@
+import { act, type ReactNode } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { registry } from '@/contrib/registry'
+
+import type { GroupNode } from '../model'
+
+import { TreeGroup } from './tree-group'
+
+let root: null | Root = null
+let container: HTMLDivElement | null = null
+let disposePane: (() => void) | null = null
+
+function render(ui: ReactNode) {
+  if (!container) {
+    container = globalThis.document.createElement('div')
+    globalThis.document.body.append(container)
+    root = createRoot(container)
+  }
+
+  act(() => {
+    root!.render(ui)
+  })
+}
+
+function terminalGroup(minimized: boolean): GroupNode {
+  return {
+    active: 'terminal',
+    headerHidden: false,
+    id: 'terminal-zone',
+    minimized,
+    panes: ['terminal'],
+    type: 'group'
+  }
+}
+
+const toggle = (label: string) =>
+  globalThis.document.querySelector<HTMLButtonElement>(
+    `[data-tree-group="terminal-zone"] button[aria-label="${label}"]`
+  )!
+
+afterEach(() => {
+  if (root) {
+    act(() => root!.unmount())
+  }
+
+  container?.remove()
+  disposePane?.()
+  root = null
+  container = null
+  disposePane = null
+  vi.unstubAllGlobals()
+})
+
+describe('TreeGroup', () => {
+  it('points the docked-zone chevron in the collapse or restore action direction', () => {
+    disposePane = registry.register({
+      area: 'panes',
+      data: { height: '12rem' },
+      id: 'terminal',
+      render: () => <div>Terminal</div>,
+      title: 'Terminal'
+    })
+    // jsdom does not implement CSS.escape, which the real tab-strip effect uses.
+    vi.stubGlobal('CSS', { escape: (value: string) => value })
+
+    render(<TreeGroup node={terminalGroup(false)} parentAxis="column" />)
+
+    expect(toggle('Minimize').querySelector('i')!.className).toContain('codicon-chevron-down')
+
+    render(<TreeGroup node={terminalGroup(true)} parentAxis="column" />)
+
+    expect(toggle('Restore').querySelector('i')!.className).toContain('codicon-chevron-up')
+  })
+})

--- a/apps/desktop/src/components/pane-shell/tree/renderer/tree-group.tsx
+++ b/apps/desktop/src/components/pane-shell/tree/renderer/tree-group.tsx
@@ -138,7 +138,9 @@ function ZoneMenu({
         })}
         {minimizable &&
           renderActionItem(kit, {
-            icon: minimized ? 'chevron-down' : 'chevron-up',
+            // Same action-direction contract as the strip button below: the
+            // icon points where the zone will GO (restore opens upward).
+            icon: minimized ? 'chevron-up' : 'chevron-down',
             label: minimized ? t.zones.restore : t.zones.minimize,
             onSelect: () => setTreeGroupMinimized(nodeId, !minimized)
           })}
@@ -436,7 +438,7 @@ export function TreeGroup({
                     onPointerDown={e => e.stopPropagation()}
                     type="button"
                   >
-                    <Codicon name={node.minimized ? 'chevron-down' : 'chevron-up'} size="0.75rem" />
+                    <Codicon name={node.minimized ? 'chevron-up' : 'chevron-down'} size="0.75rem" />
                   </button>
                 )}
                 <StripDropCaret groupId={node.id} stripRef={stripRef} />

--- a/apps/desktop/src/i18n/ar.ts
+++ b/apps/desktop/src/i18n/ar.ts
@@ -397,6 +397,8 @@ export const ar = defineLocale({
       colorModeDesc: 'اختر الوضع الفاتح أو الداكن أو اتبع النظام.',
       toolViewTitle: 'عرض الأدوات',
       toolViewDesc: 'تحكم في كيفية عرض نشاط الأدوات داخل المحادثة.',
+      reasoningCollapsedTitle: 'طي التفكير افتراضيًا',
+      reasoningCollapsedDesc: 'أبقِ التفكير المتدفق متاحًا دون توسيعه حتى تفتحه.',
       translucencyTitle: 'شفافية النافذة',
       translucencyDesc: 'إظهار سطح المكتب من خلال النافذة بالكامل. متاح على macOS وWindows فقط.',
       backdropTitle: 'خلفية النافذة',

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -462,6 +462,11 @@ export const en: Translations = {
       uiScaleTitle: 'UI Scale',
       uiScaleDesc: (percent: number) =>
         `Scales text and controls across the whole app. Cmd/Ctrl with +, - and 0 also works. Current: ${percent}%.`,
+      sessionDensityTitle: 'Session List Density',
+      sessionDensityDesc: 'Choose how much context appears beneath session titles in the sidebar.',
+      sessionDensityCompact: 'Compact',
+      sessionDensityComfortable: 'Comfortable',
+      sessionDensityDetailed: 'Detailed',
       terminalFontTitle: 'Terminal Font',
       terminalFontDesc:
         'Choose an installed font for Desktop terminals. Nerd Fonts render Powerlevel10k and shell icons; leave blank to use bundled JetBrains Mono.',
@@ -1971,6 +1976,8 @@ export const en: Translations = {
     loading: 'Loading…',
     loadMore: 'Load more',
     loadCount: step => `Load ${step} more`,
+    messageCount: count => `${count} ${count === 1 ? 'message' : 'messages'}`,
+    toolCallCount: count => `${count} ${count === 1 ? 'tool call' : 'tool calls'}`,
     row: {
       pin: 'Pin',
       unpin: 'Unpin',

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -457,6 +457,8 @@ export const en: Translations = {
       colorModeDesc: 'Pick a fixed mode or let Hermes follow your system setting.',
       toolViewTitle: 'Tool Call Display',
       toolViewDesc: 'Product hides raw tool payloads; Technical shows full input/output.',
+      reasoningCollapsedTitle: 'Collapse thinking by default',
+      reasoningCollapsedDesc: 'Keep streamed reasoning available without expanding it until you open it.',
       uiScaleTitle: 'UI Scale',
       uiScaleDesc: (percent: number) =>
         `Scales text and controls across the whole app. Cmd/Ctrl with +, - and 0 also works. Current: ${percent}%.`,

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -317,6 +317,8 @@ export const ja = defineLocale({
       colorModeDesc: '固定モードを選ぶか、Hermes をシステム設定に合わせます。',
       toolViewTitle: 'ツール呼び出しの表示',
       toolViewDesc: 'プロダクト表示は生のツールペイロードを隠し、テクニカル表示は入出力をすべて表示します。',
+      reasoningCollapsedTitle: '思考ブロックをデフォルトで折りたたむ',
+      reasoningCollapsedDesc: 'ストリーミング中の推論を、開くまで折りたたんだまま利用できるようにします。',
       uiScaleTitle: 'UI スケール',
       uiScaleDesc: (percent: number) =>
         `アプリ全体の文字と UI を拡大縮小します。Cmd/Ctrl と +、-、0 でも変更できます。現在: ${percent}%`,

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -322,6 +322,11 @@ export const ja = defineLocale({
       uiScaleTitle: 'UI スケール',
       uiScaleDesc: (percent: number) =>
         `アプリ全体の文字と UI を拡大縮小します。Cmd/Ctrl と +、-、0 でも変更できます。現在: ${percent}%`,
+      sessionDensityTitle: 'セッションリストの密度',
+      sessionDensityDesc: 'サイドバーのセッションタイトルの下に表示する情報量を選びます。',
+      sessionDensityCompact: 'コンパクト',
+      sessionDensityComfortable: '標準',
+      sessionDensityDetailed: '詳細',
       terminalFontTitle: 'ターミナルフォント',
       terminalFontDesc:
         'Desktop のターミナルで使用するインストール済みフォントを選びます。Nerd Font は Powerlevel10k とシェルアイコンを表示できます。空欄では内蔵の JetBrains Mono を使用します。',
@@ -1787,6 +1792,8 @@ export const ja = defineLocale({
     loading: '読み込み中…',
     loadMore: 'さらに読み込む',
     loadCount: step => `さらに ${step} 件を読み込む`,
+    messageCount: count => `${count} 件のメッセージ`,
+    toolCallCount: count => `${count} 件のツール呼び出し`,
     row: {
       pin: 'ピン留め',
       unpin: 'ピン留めを解除',

--- a/apps/desktop/src/i18n/runtime.test.ts
+++ b/apps/desktop/src/i18n/runtime.test.ts
@@ -44,6 +44,12 @@ describe('desktop i18n runtime translator', () => {
     setRuntimeI18nLocale('zh-hant')
     expect(translateNow('settings.appearance.title')).toBe('外觀')
     expect(translateNow('settings.nav.providerApiKeys')).toBe('API 金鑰')
+
+    setRuntimeI18nLocale('ar')
+    expect(translateNow('settings.appearance.reasoningCollapsedTitle')).toBe('طي التفكير افتراضيًا')
+    expect(translateNow('settings.appearance.reasoningCollapsedDesc')).toBe(
+      'أبقِ التفكير المتدفق متاحًا دون توسيعه حتى تفتحه.'
+    )
   })
 
   it('keeps translated settings field copy addressable from schema keys', () => {

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -364,6 +364,11 @@ export interface Translations {
       reasoningCollapsedDesc: string
       uiScaleTitle: string
       uiScaleDesc: (percent: number) => string
+      sessionDensityTitle: string
+      sessionDensityDesc: string
+      sessionDensityCompact: string
+      sessionDensityComfortable: string
+      sessionDensityDetailed: string
       terminalFontTitle: string
       terminalFontDesc: string
       terminalFontPlaceholder: string
@@ -1658,6 +1663,8 @@ export interface Translations {
     loading: string
     loadMore: string
     loadCount: (step: number) => string
+    messageCount: (count: number) => string
+    toolCallCount: (count: number) => string
     row: {
       pin: string
       unpin: string

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -360,6 +360,8 @@ export interface Translations {
       colorModeDesc: string
       toolViewTitle: string
       toolViewDesc: string
+      reasoningCollapsedTitle: string
+      reasoningCollapsedDesc: string
       uiScaleTitle: string
       uiScaleDesc: (percent: number) => string
       terminalFontTitle: string

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -314,6 +314,11 @@ export const zhHant = defineLocale({
       uiScaleTitle: '介面縮放',
       uiScaleDesc: (percent: number) =>
         `縮放整個應用程式的文字與介面。也可使用 Cmd/Ctrl 加 +、- 或 0 調整。目前：${percent}%`,
+      sessionDensityTitle: '工作階段列表密度',
+      sessionDensityDesc: '選擇側邊欄工作階段標題下方顯示的資訊量。',
+      sessionDensityCompact: '緊湊',
+      sessionDensityComfortable: '舒適',
+      sessionDensityDetailed: '詳細',
       terminalFontTitle: '終端機字型',
       terminalFontDesc:
         '選擇已安裝的字型用於桌面端終端機。Nerd Font 可正確顯示 Powerlevel10k 與 Shell 圖示；留空則使用內建的 JetBrains Mono。',
@@ -1729,6 +1734,8 @@ export const zhHant = defineLocale({
     loading: '載入中…',
     loadMore: '載入更多',
     loadCount: step => `再載入 ${step} 個`,
+    messageCount: count => `${count} 條訊息`,
+    toolCallCount: count => `${count} 次工具調用`,
     row: {
       pin: '釘選',
       unpin: '取消釘選',

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -309,6 +309,8 @@ export const zhHant = defineLocale({
       colorModeDesc: '選擇固定模式，或讓 Hermes 跟隨系統設定。',
       toolViewTitle: '工具呼叫顯示',
       toolViewDesc: '產品模式會隱藏原始工具 payload；技術模式會顯示完整輸入/輸出。',
+      reasoningCollapsedTitle: '預設摺疊推理過程',
+      reasoningCollapsedDesc: '保留串流推理內容，但在您開啟前維持摺疊。',
       uiScaleTitle: '介面縮放',
       uiScaleDesc: (percent: number) =>
         `縮放整個應用程式的文字與介面。也可使用 Cmd/Ctrl 加 +、- 或 0 調整。目前：${percent}%`,

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -447,6 +447,8 @@ export const zh: Translations = {
       colorModeDesc: '选择固定模式，或让 Hermes 跟随系统设置。',
       toolViewTitle: '工具调用显示',
       toolViewDesc: '产品模式隐藏原始工具数据；技术模式显示完整输入/输出。',
+      reasoningCollapsedTitle: '默认折叠推理过程',
+      reasoningCollapsedDesc: '保留流式推理内容，但在您打开前保持折叠。',
       uiScaleTitle: '界面缩放',
       uiScaleDesc: (percent: number) =>
         `缩放整个应用的文字和界面。也可使用 Cmd/Ctrl 加 +、- 或 0 调整。当前：${percent}%`,

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -452,6 +452,11 @@ export const zh: Translations = {
       uiScaleTitle: '界面缩放',
       uiScaleDesc: (percent: number) =>
         `缩放整个应用的文字和界面。也可使用 Cmd/Ctrl 加 +、- 或 0 调整。当前：${percent}%`,
+      sessionDensityTitle: '会话列表密度',
+      sessionDensityDesc: '选择侧边栏会话标题下方显示的信息量。',
+      sessionDensityCompact: '紧凑',
+      sessionDensityComfortable: '舒适',
+      sessionDensityDetailed: '详细',
       terminalFontTitle: '终端字体',
       terminalFontDesc:
         '选择已安装的字体用于桌面端终端。Nerd Font 可正确显示 Powerlevel10k 和 Shell 图标；留空则使用内置的 JetBrains Mono。',
@@ -2160,6 +2165,8 @@ export const zh: Translations = {
     loading: '加载中…',
     loadMore: '加载更多',
     loadCount: step => `再加载 ${step} 个`,
+    messageCount: count => `${count} 条消息`,
+    toolCallCount: count => `${count} 次工具调用`,
     row: {
       pin: '置顶',
       unpin: '取消置顶',

--- a/apps/desktop/src/store/reasoning-disclosure.ts
+++ b/apps/desktop/src/store/reasoning-disclosure.ts
@@ -1,0 +1,16 @@
+import { atom } from 'nanostores'
+
+import { persistBoolean, storedBoolean } from '@/lib/storage'
+
+const REASONING_COLLAPSED_BY_DEFAULT_STORAGE_KEY = 'hermes.desktop.reasoning.collapsedByDefault'
+
+/** Desktop-local presentation preference; shared backend config must not be changed by a single window. */
+export const $reasoningCollapsedByDefault = atom(
+  storedBoolean(REASONING_COLLAPSED_BY_DEFAULT_STORAGE_KEY, false)
+)
+
+$reasoningCollapsedByDefault.subscribe(value => persistBoolean(REASONING_COLLAPSED_BY_DEFAULT_STORAGE_KEY, value))
+
+export function setReasoningCollapsedByDefault(value: boolean) {
+  $reasoningCollapsedByDefault.set(value)
+}

--- a/apps/desktop/src/store/session-list-density.test.ts
+++ b/apps/desktop/src/store/session-list-density.test.ts
@@ -1,0 +1,30 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const loadStore = async () => {
+  vi.resetModules()
+
+  return import('./session-list-density')
+}
+
+describe('session list density preference', () => {
+  beforeEach(() => {
+    window.localStorage.clear()
+  })
+
+  it('defaults to comfortable and persists changes', async () => {
+    const first = await loadStore()
+
+    expect(first.$sessionListDensity.get()).toBe('comfortable')
+
+    first.setSessionListDensity('detailed')
+
+    expect(window.localStorage.getItem('hermes.desktop.sessionListDensity')).toBe('detailed')
+    expect((await loadStore()).$sessionListDensity.get()).toBe('detailed')
+  })
+
+  it('falls back to comfortable for an unknown stored value', async () => {
+    window.localStorage.setItem('hermes.desktop.sessionListDensity', 'tiny')
+
+    expect((await loadStore()).$sessionListDensity.get()).toBe('comfortable')
+  })
+})

--- a/apps/desktop/src/store/session-list-density.test.ts
+++ b/apps/desktop/src/store/session-list-density.test.ts
@@ -11,10 +11,10 @@ describe('session list density preference', () => {
     window.localStorage.clear()
   })
 
-  it('defaults to comfortable and persists changes', async () => {
+  it('defaults to compact (pre-density behavior) and persists changes', async () => {
     const first = await loadStore()
 
-    expect(first.$sessionListDensity.get()).toBe('comfortable')
+    expect(first.$sessionListDensity.get()).toBe('compact')
 
     first.setSessionListDensity('detailed')
 
@@ -22,9 +22,9 @@ describe('session list density preference', () => {
     expect((await loadStore()).$sessionListDensity.get()).toBe('detailed')
   })
 
-  it('falls back to comfortable for an unknown stored value', async () => {
+  it('falls back to compact for an unknown stored value', async () => {
     window.localStorage.setItem('hermes.desktop.sessionListDensity', 'tiny')
 
-    expect((await loadStore()).$sessionListDensity.get()).toBe('comfortable')
+    expect((await loadStore()).$sessionListDensity.get()).toBe('compact')
   })
 })

--- a/apps/desktop/src/store/session-list-density.ts
+++ b/apps/desktop/src/store/session-list-density.ts
@@ -1,0 +1,16 @@
+import { type Codec, persistentAtom } from '@/lib/persisted'
+
+export type SessionListDensity = 'compact' | 'comfortable' | 'detailed'
+
+const STORAGE_KEY = 'hermes.desktop.sessionListDensity'
+
+const densityCodec: Codec<SessionListDensity> = {
+  decode: raw => (raw === 'compact' || raw === 'detailed' ? raw : 'comfortable'),
+  encode: value => value
+}
+
+export const $sessionListDensity = persistentAtom<SessionListDensity>(STORAGE_KEY, 'comfortable', densityCodec)
+
+export function setSessionListDensity(density: SessionListDensity) {
+  $sessionListDensity.set(density)
+}

--- a/apps/desktop/src/store/session-list-density.ts
+++ b/apps/desktop/src/store/session-list-density.ts
@@ -4,12 +4,14 @@ export type SessionListDensity = 'compact' | 'comfortable' | 'detailed'
 
 const STORAGE_KEY = 'hermes.desktop.sessionListDensity'
 
+// Compact is the pre-density row exactly as it shipped, so existing users see
+// no change until they opt into a denser-information mode themselves (#68119).
 const densityCodec: Codec<SessionListDensity> = {
-  decode: raw => (raw === 'compact' || raw === 'detailed' ? raw : 'comfortable'),
+  decode: raw => (raw === 'comfortable' || raw === 'detailed' ? raw : 'compact'),
   encode: value => value
 }
 
-export const $sessionListDensity = persistentAtom<SessionListDensity>(STORAGE_KEY, 'comfortable', densityCodec)
+export const $sessionListDensity = persistentAtom<SessionListDensity>(STORAGE_KEY, 'compact', densityCodec)
 
 export function setSessionListDensity(density: SessionListDensity) {
   $sessionListDensity.set(density)

--- a/contributors/emails/gh.chiller@pm.me
+++ b/contributors/emails/gh.chiller@pm.me
@@ -1,0 +1,1 @@
+chillerno1

--- a/contributors/emails/isak@ialogics.com
+++ b/contributors/emails/isak@ialogics.com
@@ -1,0 +1,1 @@
+isak-ialogics

--- a/contributors/emails/jordyelfferich15@gmail.com
+++ b/contributors/emails/jordyelfferich15@gmail.com
@@ -1,0 +1,1 @@
+JElfferich

--- a/ui-tui/src/__tests__/messages.test.ts
+++ b/ui-tui/src/__tests__/messages.test.ts
@@ -128,6 +128,81 @@ describe('MessageLine', () => {
 
     expect(renderedLine).toContain('Ψ > Okay')
   })
+
+  it('keeps historical thinking blocks collapsed by default', () => {
+    const stdout = new PassThrough()
+    const stdin = new PassThrough()
+    const stderr = new PassThrough()
+    let output = ''
+
+    Object.assign(stdout, { columns: 80, isTTY: false, rows: 24 })
+    Object.assign(stdin, { isTTY: false })
+    Object.assign(stderr, { isTTY: false })
+    stdout.on('data', chunk => {
+      output += chunk.toString()
+    })
+
+    const instance = renderSync(
+      React.createElement(MessageLine, {
+        cols: 80,
+        msg: { kind: 'trail', role: 'system', text: '', thinking: 'step one\nstep two' },
+        t: DEFAULT_THEME
+      }),
+      {
+        patchConsole: false,
+        stderr: stderr as NodeJS.WriteStream,
+        stdin: stdin as NodeJS.ReadStream,
+        stdout: stdout as NodeJS.WriteStream
+      }
+    )
+
+    instance.unmount()
+    instance.cleanup()
+
+    const rendered = stripAnsi(output)
+
+    expect(rendered).toContain('Thinking')
+    expect(rendered).not.toContain('step one')
+    expect(rendered).not.toContain('step two')
+  })
+
+  it('keeps live thinking blocks expanded while streaming', () => {
+    const stdout = new PassThrough()
+    const stdin = new PassThrough()
+    const stderr = new PassThrough()
+    let output = ''
+
+    Object.assign(stdout, { columns: 80, isTTY: false, rows: 24 })
+    Object.assign(stdin, { isTTY: false })
+    Object.assign(stderr, { isTTY: false })
+    stdout.on('data', chunk => {
+      output += chunk.toString()
+    })
+
+    const instance = renderSync(
+      React.createElement(MessageLine, {
+        cols: 80,
+        liveDetails: true,
+        msg: { kind: 'trail', role: 'system', text: '', thinking: 'step one\nstep two' },
+        t: DEFAULT_THEME
+      }),
+      {
+        patchConsole: false,
+        stderr: stderr as NodeJS.WriteStream,
+        stdin: stdin as NodeJS.ReadStream,
+        stdout: stdout as NodeJS.WriteStream
+      }
+    )
+
+    instance.unmount()
+    instance.cleanup()
+
+    const rendered = stripAnsi(output)
+
+    expect(rendered).toContain('Thinking')
+    expect(rendered).toContain('step one')
+    expect(rendered).toContain('step two')
+  })
 })
 
 describe('upsert', () => {

--- a/ui-tui/src/__tests__/thinkingLiveCollapse.test.tsx
+++ b/ui-tui/src/__tests__/thinkingLiveCollapse.test.tsx
@@ -1,0 +1,118 @@
+import { PassThrough } from 'stream'
+
+import { renderSync } from '@hermes/ink'
+import React from 'react'
+import { describe, expect, it } from 'vitest'
+
+import { ToolTrail } from '../components/thinking.js'
+import { stripAnsi } from '../lib/text.js'
+import { DEFAULT_THEME } from '../theme.js'
+
+const flushEffects = async () => {
+  // Passive effects + the re-render they trigger need a few macrotask
+  // turns (React's scheduler uses MessageChannel) before the next frame
+  // paints — setTimeout(0)-class waits, not setImmediate (which can land
+  // in the wrong phase and observe the pre-effect frame).
+  for (let i = 0; i < 10; i++) {
+    await new Promise(resolve => setTimeout(resolve, 5))
+  }
+}
+
+const mountTrail = (reasoningActive: boolean, sections?: Record<string, string>) => {
+  const stdout = new PassThrough()
+  const stdin = new PassThrough()
+  const stderr = new PassThrough()
+  let output = ''
+
+  Object.assign(stdout, { columns: 60, isTTY: false, rows: 20 })
+  Object.assign(stdin, { isTTY: false })
+  Object.assign(stderr, { isTTY: false })
+  stdout.on('data', chunk => {
+    output += chunk.toString()
+  })
+
+  const instance = renderSync(
+    <ToolTrail
+      reasoning="Live reasoning text."
+      reasoningActive={reasoningActive}
+      sections={sections ?? { thinking: 'collapsed' }}
+      t={DEFAULT_THEME}
+    />,
+    {
+      patchConsole: false,
+      stderr: stderr as NodeJS.WriteStream,
+      stdin: stdin as NodeJS.ReadStream,
+      stdout: stdout as NodeJS.WriteStream
+    }
+  )
+
+  // The PassThrough accumulates every repaint, and a collapsed panel stops
+  // repainting entirely once settled — so assert on the FINAL chevron state
+  // in the accumulated output rather than the tail after a clear().
+  const finalChevronOpen = () => stripAnsi(output).lastIndexOf('▾ ') > stripAnsi(output).lastIndexOf('▸ ')
+
+  return { finalChevronOpen, instance }
+}
+
+describe('ToolTrail — collapsed mode auto-expands while reasoning is live', () => {
+  it('opens (▾) when reasoningActive is true under sections.thinking: collapsed', async () => {
+    const { finalChevronOpen, instance } = mountTrail(true)
+
+    await flushEffects()
+
+    expect(finalChevronOpen()).toBe(true)
+
+    instance.unmount()
+    instance.cleanup()
+  })
+
+  it('collapses (▸) when reasoningActive is false under sections.thinking: collapsed', async () => {
+    const { finalChevronOpen, instance } = mountTrail(false)
+
+    await flushEffects()
+
+    expect(finalChevronOpen()).toBe(false)
+
+    instance.unmount()
+    instance.cleanup()
+  })
+
+  it('closes the panel when the reasoning phase ends mid-turn (rerender)', async () => {
+    const { finalChevronOpen, instance } = mountTrail(true)
+
+    await flushEffects()
+
+    expect(finalChevronOpen()).toBe(true)
+
+    // Reasoning phase finished (final answer / tool call started) — the
+    // turn's reasoningActive drops and the panel must collapse.
+    instance.rerender(
+      <ToolTrail
+        reasoning="Live reasoning text."
+        reasoningActive={false}
+        sections={{ thinking: 'collapsed' }}
+        t={DEFAULT_THEME}
+      />
+    )
+
+    await flushEffects()
+
+    expect(finalChevronOpen()).toBe(false)
+
+    instance.unmount()
+    instance.cleanup()
+  })
+
+  it('leaves expanded-mode panels fully manual (no forced collapse)', async () => {
+    const { finalChevronOpen, instance } = mountTrail(false, { thinking: 'expanded' })
+
+    await flushEffects()
+
+    // `expanded` is a manual preference: reasoningActive=false must NOT
+    // force it closed (the auto behavior only applies to `collapsed`).
+    expect(finalChevronOpen()).toBe(true)
+
+    instance.unmount()
+    instance.cleanup()
+  })
+})

--- a/ui-tui/src/__tests__/virtualHeights.test.ts
+++ b/ui-tui/src/__tests__/virtualHeights.test.ts
@@ -82,6 +82,28 @@ describe('virtual height estimates', () => {
     ).toBe(estimatedMsgHeight(toolsOnly, 80, { compact: false, details: false }))
   })
 
+  it('treats historical thinking blocks as collapsed unless explicitly expanded', () => {
+    const msg: Msg = { role: 'assistant', text: 'ok', thinking: 'line 1\nline 2\nline 3' }
+
+    expect(
+      estimatedMsgHeight(msg, 80, {
+        compact: false,
+        details: true,
+        thinkingExpanded: false,
+        thinkingVisible: true,
+        toolsVisible: false
+      })
+    ).toBeLessThan(
+      estimatedMsgHeight(msg, 80, {
+        compact: false,
+        details: true,
+        thinkingExpanded: true,
+        thinkingVisible: true,
+        toolsVisible: false
+      })
+    )
+  })
+
   it('reserves two extra rows for the inter-turn separator on non-first user messages', () => {
     const msg: Msg = { role: 'user', text: 'follow-up question' }
     const base = estimatedMsgHeight(msg, 80, { compact: false, details: false })

--- a/ui-tui/src/app/turnController.ts
+++ b/ui-tui/src/app/turnController.ts
@@ -266,6 +266,12 @@ class TurnController {
 
   endReasoningPhase() {
     this.reasoningStreamingTimer = clear(this.reasoningStreamingTimer)
+    // Seal any open reasoning segment so its isLiveReasoning flag drops the
+    // moment the reasoning phase ends — the panel must stop tracking the
+    // turn's global reasoningActive, not stay "live" for the rest of the turn.
+    if (this.reasoningSegmentIndex !== null) {
+      this.syncReasoningSegment(false)
+    }
     patchTurnState({ reasoningActive: false, reasoningStreaming: false })
   }
 
@@ -359,7 +365,7 @@ class TurnController {
     })
   }
 
-  private syncReasoningSegment() {
+  private syncReasoningSegment(live = true) {
     const thinking = this.activeReasoningText.trim()
 
     if (!thinking) {
@@ -372,7 +378,8 @@ class TurnController {
       text: '',
       thinking,
       thinkingTokens: estimateTokensRough(thinking),
-      toolTokens: this.toolTokenAcc || undefined
+      toolTokens: this.toolTokenAcc || undefined,
+      ...(live ? { isLiveReasoning: true } : {})
     }
 
     if (this.reasoningSegmentIndex === null) {
@@ -386,7 +393,7 @@ class TurnController {
   }
 
   private closeReasoningSegment() {
-    this.syncReasoningSegment()
+    this.syncReasoningSegment(false)
     this.activeReasoningText = ''
     this.reasoningSegmentIndex = null
   }

--- a/ui-tui/src/app/useMainApp.ts
+++ b/ui-tui/src/app/useMainApp.ts
@@ -353,6 +353,10 @@ export function useMainApp(gw: GatewayClient) {
   const [thinkingDetailsMode, toolsDetailsMode] = detailsLayoutKey.split(':')
   const thinkingDetailsVisible = thinkingDetailsMode !== 'hidden'
   const toolsDetailsVisible = toolsDetailsMode !== 'hidden'
+
+  const historyThinkingExpanded =
+    thinkingDetailsVisible && (ui.detailsModeCommandOverride || ui.sections.thinking === 'expanded')
+
   const detailsVisible = thinkingDetailsVisible || toolsDetailsVisible
   const userPromptWidth = composerPromptWidth(ui.theme.brand.prompt)
   const heightCacheKey = `${ui.sid ?? 'draft'}:${cols}:${userPromptWidth}:${ui.compact ? '1' : '0'}:${detailsLayoutKey}`
@@ -390,6 +394,7 @@ export function useMainApp(gw: GatewayClient) {
           }),
           virtualRows[index]!.msg
         ),
+        thinkingExpanded: historyThinkingExpanded,
         thinkingVisible: thinkingDetailsVisible,
         toolsVisible: toolsDetailsVisible,
         userPrompt: ui.theme.brand.prompt,
@@ -399,6 +404,7 @@ export function useMainApp(gw: GatewayClient) {
       cols,
       detailsVisible,
       firstUserIdx,
+      historyThinkingExpanded,
       thinkingDetailsVisible,
       toolsDetailsVisible,
       ui.compact,

--- a/ui-tui/src/components/messageLine.tsx
+++ b/ui-tui/src/components/messageLine.tsx
@@ -37,6 +37,7 @@ export const MessageLine = memo(function MessageLine({
   liveDetails = false,
   msg,
   prev,
+  reasoningActive = false,
   sections,
   t,
   tools = []
@@ -84,6 +85,7 @@ export const MessageLine = memo(function MessageLine({
           detailsMode={detailsMode}
           preferExpandedThinking={liveDetails}
           reasoning={thinking}
+          reasoningActive={reasoningActive}
           reasoningAlwaysVisible={msg.isMoaReference}
           reasoningTokens={msg.thinkingTokens}
           sections={sections}
@@ -249,6 +251,7 @@ export const MessageLine = memo(function MessageLine({
             detailsMode={detailsMode}
             preferExpandedThinking={liveDetails}
             reasoning={thinking}
+            reasoningActive={reasoningActive}
             reasoningTokens={msg.thinkingTokens}
             sections={sections}
             t={t}
@@ -309,6 +312,7 @@ interface MessageLineProps {
   // lead gap (see domain/blockLayout.ts::hasLeadGap). Undefined at the top of
   // the transcript or when spacing is irrelevant.
   prev?: Msg
+  reasoningActive?: boolean
   sections?: SectionVisibility
   t: Theme
   tools?: ActiveTool[]

--- a/ui-tui/src/components/messageLine.tsx
+++ b/ui-tui/src/components/messageLine.tsx
@@ -34,6 +34,7 @@ export const MessageLine = memo(function MessageLine({
   detailsMode = 'collapsed',
   detailsModeCommandOverride = false,
   isStreaming = false,
+  liveDetails = false,
   msg,
   prev,
   sections,
@@ -81,6 +82,7 @@ export const MessageLine = memo(function MessageLine({
         <ToolTrail
           commandOverride={detailsModeCommandOverride}
           detailsMode={detailsMode}
+          preferExpandedThinking={liveDetails}
           reasoning={thinking}
           reasoningAlwaysVisible={msg.isMoaReference}
           reasoningTokens={msg.thinkingTokens}
@@ -245,6 +247,7 @@ export const MessageLine = memo(function MessageLine({
           <ToolTrail
             commandOverride={detailsModeCommandOverride}
             detailsMode={detailsMode}
+            preferExpandedThinking={liveDetails}
             reasoning={thinking}
             reasoningTokens={msg.thinkingTokens}
             sections={sections}
@@ -300,6 +303,7 @@ interface MessageLineProps {
   detailsMode?: DetailsMode
   detailsModeCommandOverride?: boolean
   isStreaming?: boolean
+  liveDetails?: boolean
   msg: Msg
   // The block rendered directly above this one. Drives the group-boundary
   // lead gap (see domain/blockLayout.ts::hasLeadGap). Undefined at the top of

--- a/ui-tui/src/components/streamingAssistant.tsx
+++ b/ui-tui/src/components/streamingAssistant.tsx
@@ -76,6 +76,7 @@ export const StreamingAssistant = memo(function StreamingAssistant({
             detailsModeCommandOverride={detailsModeCommandOverride}
             isStreaming={block.isStreaming}
             key={block.key}
+            liveDetails
             msg={block.msg}
             prev={prev}
             sections={sections}

--- a/ui-tui/src/components/streamingAssistant.tsx
+++ b/ui-tui/src/components/streamingAssistant.tsx
@@ -79,6 +79,7 @@ export const StreamingAssistant = memo(function StreamingAssistant({
             liveDetails
             msg={block.msg}
             prev={prev}
+            reasoningActive={block.msg.isLiveReasoning === true}
             sections={sections}
             t={ui.theme}
             {...(block.tools ? { tools: block.tools } : {})}

--- a/ui-tui/src/components/thinking.tsx
+++ b/ui-tui/src/components/thinking.tsx
@@ -678,6 +678,7 @@ export const ToolTrail = memo(function ToolTrail({
   commandOverride = false,
   detailsMode = 'collapsed',
   outcome = '',
+  preferExpandedThinking = false,
   reasoningActive = false,
   reasoning = '',
   reasoningAlwaysVisible = false,
@@ -695,6 +696,7 @@ export const ToolTrail = memo(function ToolTrail({
   commandOverride?: boolean
   detailsMode?: DetailsMode
   outcome?: string
+  preferExpandedThinking?: boolean
   reasoningActive?: boolean
   reasoning?: string
   // MoA reference blocks (see Msg.isMoaReference) stay visible even when
@@ -721,6 +723,9 @@ export const ToolTrail = memo(function ToolTrail({
     [commandOverride, detailsMode, sections]
   )
 
+  const thinkingDefaultExpanded =
+    visible.thinking === 'expanded' && (preferExpandedThinking || commandOverride || sections?.thinking === 'expanded')
+
   const [now, setNow] = useState(() => Date.now())
   // Local toggles own the open state once mounted.  Init from the resolved
   // section visibility so default-expanded sections (thinking/tools) render
@@ -735,7 +740,7 @@ export const ToolTrail = memo(function ToolTrail({
   // label. This only affects the initial mount value; the re-sync effect
   // below deliberately does NOT re-apply it, so a manual collapse still
   // sticks (see the no-OR-at-effect-time warning above, #14968).
-  const [openThinking, setOpenThinking] = useState(visible.thinking === 'expanded' || reasoningAlwaysVisible)
+  const [openThinking, setOpenThinking] = useState(thinkingDefaultExpanded || reasoningAlwaysVisible)
   const [openTools, setOpenTools] = useState(visible.tools === 'expanded')
   const [openSubagents, setOpenSubagents] = useState(visible.subagents === 'expanded')
   const [deepSubagents, setDeepSubagents] = useState(visible.subagents === 'expanded')
@@ -766,11 +771,11 @@ export const ToolTrail = memo(function ToolTrail({
       return
     }
 
-    setOpenThinking(visible.thinking === 'expanded')
+    setOpenThinking(thinkingDefaultExpanded)
     setOpenTools(visible.tools === 'expanded')
     setOpenSubagents(visible.subagents === 'expanded')
     setOpenMeta(visible.activity === 'expanded')
-  }, [visible])
+  }, [thinkingDefaultExpanded, visible])
 
   const cot = useMemo(() => thinkingPreview(reasoning, 'full', THINKING_COT_MAX), [reasoning])
 

--- a/ui-tui/src/components/thinking.tsx
+++ b/ui-tui/src/components/thinking.tsx
@@ -777,6 +777,20 @@ export const ToolTrail = memo(function ToolTrail({
     setOpenMeta(visible.activity === 'expanded')
   }, [thinkingDefaultExpanded, visible])
 
+  // `collapsed` is an auto preference: keep the panel open while reasoning
+  // is live (stream pulses keep `reasoningActive` true) and collapse it the
+  // moment the reasoning phase ends (`endReasoningPhase` flips it false).
+  // `expanded` stays fully manual, `hidden` never renders content, and MoA
+  // reference panels (reasoningAlwaysVisible) are left alone.
+  const thinkingAuto = visible.thinking === 'collapsed' && !reasoningAlwaysVisible
+  useEffect(() => {
+    if (!thinkingAuto) {
+      return
+    }
+
+    setOpenThinking(reasoningActive)
+  }, [thinkingAuto, reasoningActive])
+
   const cot = useMemo(() => thinkingPreview(reasoning, 'full', THINKING_COT_MAX), [reasoning])
 
   // Spawn-tree derivations must live above any early return so React's

--- a/ui-tui/src/lib/virtualHeights.ts
+++ b/ui-tui/src/lib/virtualHeights.ts
@@ -74,6 +74,7 @@ export const estimatedMsgHeight = (
     details,
     leadGap = false,
     thinkingVisible = details,
+    thinkingExpanded = thinkingVisible,
     toolsVisible = details,
     userPrompt = '',
     withSeparator = false
@@ -81,6 +82,7 @@ export const estimatedMsgHeight = (
     compact: boolean
     details: boolean
     leadGap?: boolean
+    thinkingExpanded?: boolean
     thinkingVisible?: boolean
     toolsVisible?: boolean
     userPrompt?: string
@@ -124,7 +126,7 @@ export const estimatedMsgHeight = (
     if (hasVisibleDetails) {
       h +=
         (hasVisibleTools ? (msg.tools?.length ?? 0) : 0) +
-        (hasVisibleThinking ? wrappedLines(msg.thinking ?? '', bodyWidth) : 0)
+        (hasVisibleThinking ? (thinkingExpanded ? wrappedLines(msg.thinking ?? '', bodyWidth) : 1) : 0)
 
       if (msg.role === 'assistant' && /\S/.test(msg.text)) {
         h += 2

--- a/ui-tui/src/types.ts
+++ b/ui-tui/src/types.ts
@@ -125,6 +125,11 @@ export interface Msg {
   // user-facing mixture-of-agents process the user opted into, so it stays
   // visible even when `display.sections.thinking` is hidden.
   isMoaReference?: boolean
+  // True only while this trail segment's reasoning is being streamed live by
+  // the current turn (see turnController's syncReasoningSegment). Sealed
+  // reasoning segments from earlier in the turn carry no flag, so the TUI can
+  // tell "the reasoning happening right now" apart from finished blocks.
+  isLiveReasoning?: boolean
   thinkingTokens?: number
   toolTokens?: number
   tools?: string[]

--- a/web/src/pages/ChatPage.test.tsx
+++ b/web/src/pages/ChatPage.test.tsx
@@ -158,6 +158,25 @@ type CloseEventLike = {
 let container: HTMLDivElement;
 let root: Root;
 
+// jsdom runs without an origin here (per-file @vitest-environment jsdom on a
+// node-default config), so localStorage is undefined. Stub it so components
+// that persist UI state (side panel collapse) can be exercised.
+const localStorageMock = (() => {
+  let store: Record<string, string> = {};
+  return {
+    getItem: (key: string) => store[key] ?? null,
+    setItem: (key: string, value: string) => {
+      store[key] = String(value);
+    },
+    removeItem: (key: string) => {
+      delete store[key];
+    },
+    clear: () => {
+      store = {};
+    },
+  };
+})();
+
 async function render(ui: ReactNode) {
   container = document.createElement("div");
   document.body.append(container);
@@ -220,6 +239,8 @@ beforeEach(() => {
     },
   });
   sessionStorage.clear();
+  vi.stubGlobal("localStorage", localStorageMock);
+  localStorageMock.clear();
 });
 
 afterEach(async () => {
@@ -247,6 +268,54 @@ describe("ChatPage", () => {
     });
 
     expect(maybeReloadForLoopbackWsAuthFailure).toHaveBeenCalledWith(4401);
+  });
+});
+
+describe("ChatPage side panel collapse", () => {
+  async function renderChat() {
+    const { default: ChatPage } = await import("./ChatPage");
+    await render(
+      <MemoryRouter initialEntries={["/chat"]}>
+        <ChatPage isActive />
+      </MemoryRouter>,
+    );
+  }
+
+  it("collapses the desktop side panel and persists the choice", async () => {
+    localStorage.clear();
+    await renderChat();
+    await vi.waitFor(() => expect(FakeWebSocket.instances).toHaveLength(1));
+
+    const collapseButton = container.querySelector(
+      '[aria-label="Collapse chat side panel"]',
+    );
+    expect(collapseButton).not.toBeNull();
+
+    await act(async () => {
+      collapseButton!.dispatchEvent(
+        new MouseEvent("click", { bubbles: true }),
+      );
+    });
+
+    expect(localStorage.getItem("hermes-chat-panel-collapsed")).toBe("1");
+    expect(
+      container.querySelector('[aria-label="Collapse chat side panel"]'),
+    ).toBeNull();
+    expect(
+      container.querySelector('[aria-label="Show chat side panel"]'),
+    ).not.toBeNull();
+
+    // Reopening restores the panel and clears the persisted flag.
+    await act(async () => {
+      container
+        .querySelector('[aria-label="Show chat side panel"]')!
+        .dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    expect(localStorage.getItem("hermes-chat-panel-collapsed")).toBe("0");
+    expect(
+      container.querySelector('[aria-label="Collapse chat side panel"]'),
+    ).not.toBeNull();
   });
 });
 

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -289,6 +289,19 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
   // tabs because the dep wouldn't change on tab switch.
   const [mobilePanelOpenRaw, setMobilePanelOpenRaw] = useState(false);
   const mobilePanelOpen = isActive && mobilePanelOpenRaw;
+
+  // Collapse toggle for the desktop chat side panel (model + sessions),
+  // persisted in localStorage so the choice survives reloads.
+  const [chatPanelCollapsed, setChatPanelCollapsed] = useState(
+    () => localStorage.getItem("hermes-chat-panel-collapsed") === "1",
+  );
+  const toggleChatPanel = useCallback(() => {
+    setChatPanelCollapsed((prev) => {
+      const next = !prev;
+      localStorage.setItem("hermes-chat-panel-collapsed", next ? "1" : "0");
+      return next;
+    });
+  }, []);
   const { setEnd, setTitle } = usePageHeader();
   const [sessionTitleState, setSessionTitleState] = useState<{
     scope: string;
@@ -1673,15 +1686,53 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
               </span>
             </span>
           </Button>
+
+          {chatPanelCollapsed && (
+            <Button
+              ghost
+              onClick={toggleChatPanel}
+              title="Show side panel (model + sessions)"
+              aria-label="Show chat side panel"
+              className={cn(
+                "absolute z-10",
+                "normal-case tracking-normal font-normal",
+                "rounded border border-current/30",
+                "bg-black/20",
+                "opacity-70 hover:opacity-100 hover:border-current/60",
+                "transition-opacity duration-150",
+                "top-2 right-2 px-2 py-1 text-xs sm:top-3 sm:right-3",
+              )}
+              style={{ color: terminalFg }}
+            >
+              <span className="inline-flex items-center gap-1">
+                <PanelRight className="h-3 w-3 shrink-0" />
+                <span className="hidden min-[400px]:inline tracking-wide">
+                  panel
+                </span>
+              </span>
+            </Button>
+          )}
         </div>
 
-        {!narrow && (
+        {!narrow && !chatPanelCollapsed && (
           <div
             id="chat-side-panel"
             role="complementary"
             aria-label={modelToolsLabel}
             className="flex min-h-0 shrink-0 flex-col gap-3 overflow-hidden lg:h-full lg:w-60"
           >
+            <div className="flex h-8 shrink-0 items-center justify-end pr-1">
+              <Button
+                ghost
+                size="icon"
+                onClick={toggleChatPanel}
+                aria-label="Collapse chat side panel"
+                title="Collapse side panel"
+                className="text-text-secondary hover:text-midground"
+              >
+                <X />
+              </Button>
+            </div>
             {/* Model picker — keeps the rail thin. */}
             <div className="shrink-0">
               <ChatSidebar


### PR DESCRIPTION
Salvages the collapse/density QoL cluster — session-list density modes, config-respecting thinking/reasoning collapse behavior in Desktop and TUI, zone-chevron direction, and a web side-panel collapse toggle — into one green branch with contributor authorship preserved.

## Changes

- **Session list density modes** (#68124, @DavidMetcalfe — closes #68119): new `Settings → Appearance → Session list density` preference with `compact` (today's row, still the default), `comfortable` (+ one deterministic metadata line: branch · model · message count · tool calls), and `detailed` (+ one-line initial-request preview, omitted when the title already falls back to it). Density-aware virtualizer estimates + re-measure on mode change. Rebased onto current main's inbox-card / marquee-title / actions-cluster row: density applies to the inline (non-card) row and composes with the existing card mode. Desktop-local persisted state; i18n strings for en/ja/zh/zh-hant.
- **Collapse thinking by default — Desktop** (#69217, @isak-ialogics): opt-in `reasoning.collapsedByDefault` appearance toggle (localStorage-backed nanostore). Default `false` — live-preview streaming behavior is unchanged for existing users; an explicit user toggle still wins.
- **Auto-collapse reasoning at phase end — TUI** (#82037, @JElfferich): under `display.sections.thinking: collapsed`, the panel opens while reasoning streams and collapses the moment the reasoning phase ends (`endReasoningPhase` now seals the live segment) instead of staying open for the rest of the turn. `expanded` stays fully manual; MoA reference panels untouched.
- **Keep historical thinking collapsed while streaming — TUI** (#42052, @LeonSGP43): historical transcript trails no longer re-expand (with full wrapped-height estimates) whenever a new turn streams; virtual heights estimate 1 line for collapsed thinking. Resolved on top of main's MoA `reasoningAlwaysVisible` mount rule and the post-#14968 initial-sync skip.
- **Zone collapse chevron direction** (#74007, @chillerno1 — earliest of the #74007/#74106 dup pair): chevron now points in the *action* direction (minimized → `chevron-up` to restore). Widened to the two sibling sites main grew since: the zone context-menu action icon and the floating-pane header.
- **Web side-panel collapse toggle** (#83141, @Eros-ITA): chat side panel on the web dashboard gets a collapse/expand toggle with persisted state.

## Excluded

- **#74106** — duplicate of #74007 (later submission; also bundles unrelated `tool_executor.py` / himalaya-skill edits).
- **#60733** — targets `pane-shell.tsx`, deleted on main by the layout-tree renderer rewrite (63a9bde77b); the hover-reveal strip it patches no longer exists.
- **#75487** — the `w-[1.375rem]` actions track it removes no longer exists on main; the trailing slot was redesigned (8de786c7a7, "one right-aligned slot") and the row now reserves width for opt-in pinned metadata by design, so the #75331 premise needs a fresh look against current main rather than a mechanical port.
- **#40760** (keep tool accordions expanded) — no candidate PR in this cluster carries an implementation; left open.

Defaults are unchanged for existing users in every surface: session-list density defaults to **compact** (the pre-density row, byte-identical), the Desktop reasoning-collapse toggle defaults **off** (live preview streaming unchanged), and the TUI collapse behavior strictly respects the existing `display.sections.thinking` config — `collapsed` just now honors itself mid-turn instead of staying open.

## Validation

| Check | Result |
| --- | --- |
| `apps/desktop` vitest (density store, row details, session-row, streaming, i18n runtime, tree-group, floating-panes) | ✅ 52/52 |
| `ui-tui` vitest (messages, virtualHeights, thinkingLiveCollapse) | ✅ 28/28 |
| `web` vitest (ChatPage) | ✅ 5/5 |
| `tsc --noEmit` — apps/desktop, ui-tui, web | ✅ clean |
| `scripts/audit_pr_attribution.py --fix` | ✅ all emails mapped |

## Credits

- @DavidMetcalfe — session list density modes (#68124)
- @isak-ialogics — collapse thinking by default (#69217)
- @JElfferich — auto-collapse reasoning at phase end (#82037)
- @LeonSGP43 — historical thinking stays collapsed while streaming (#42052)
- @chillerno1 — zone chevron action direction (#74007)
- @Eros-ITA — web side-panel collapse toggle (#83141)

Closes #68119

## Infographic

![Collapse & Density infographic](https://files.catbox.moe/s27c94.png)
