### PR TITLE
fix(desktop): recover model catalog via REST + keep optimistic cache complete (salvage #84832)

### DIFF
--- a/apps/desktop/src/app/contrib/types.ts
+++ b/apps/desktop/src/app/contrib/types.ts
@@ -59,8 +59,8 @@ export type ChatActions = Pick<
  * the latest closure.
  */
 export interface WiringActions extends SidebarActions, ChatActions {
-  /** The live gateway instance (held in a controller ref). Surfaces recapture
-   *  it by subscribing to `$gatewayState`, so no gateway prop needs threading. */
+  /** Imperative access to the live gateway for controller-owned callbacks.
+   *  Rendered surfaces subscribe to the active `$gateway` atom directly. */
   getGateway: () => ComponentProps<typeof ChatView>['gateway']
   openAgents: () => void
   openCommandCenterSection: (section: CommandCenterSection) => void

--- a/apps/desktop/src/app/session/hooks/use-model-controls.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-model-controls.test.tsx
@@ -213,9 +213,42 @@ describe('useModelControls', () => {
     expect($currentModel.get()).toBe('poolside/laguna-xs-2.1:free')
     expect($currentProvider.get()).toBe('nous')
     expect(getCurrentModelSource()).toBe('default')
-    expect(queryClient.getQueryData(modelOptionsQueryKey('default'))).toMatchObject({
+    expect(queryClient.getQueryData(modelOptionsQueryKey('default'))).toEqual({
       model: 'poolside/laguna-xs-2.1:free',
-      provider: 'nous'
+      provider: 'nous',
+      providers: [
+        {
+          models: ['poolside/laguna-xs-2.1:free'],
+          name: 'nous',
+          slug: 'nous'
+        }
+      ]
+    })
+  })
+
+  it('preserves a populated model catalog when painting a saved profile default', () => {
+    const queryClient = new QueryClient()
+    const providers = [{ models: ['tencent/hy3:free'], name: 'Nous', slug: 'nous' }]
+
+    queryClient.setQueryData(modelOptionsQueryKey('default'), {
+      model: 'tencent/hy3:free',
+      provider: 'nous',
+      providers
+    })
+
+    const { result } = renderHook(() =>
+      useModelControls({
+        queryClient,
+        requestGateway: vi.fn()
+      })
+    )
+
+    result.current.applySavedMainModel('nous', 'poolside/laguna-xs-2.1:free')
+
+    expect(queryClient.getQueryData(modelOptionsQueryKey('default'))).toEqual({
+      model: 'poolside/laguna-xs-2.1:free',
+      provider: 'nous',
+      providers
     })
   })
 

--- a/apps/desktop/src/app/session/hooks/use-model-controls.ts
+++ b/apps/desktop/src/app/session/hooks/use-model-controls.ts
@@ -45,7 +45,18 @@ export function useModelControls({ queryClient, requestGateway }: ModelControlsO
       includeGlobal: boolean,
       profile = $activeGatewayProfile.get()
     ) => {
-      const patch = (prev: ModelOptionsResponse | undefined) => ({ ...(prev ?? {}), provider, model })
+      const patch = (prev: ModelOptionsResponse | undefined) => {
+        // Selection state can update before the catalog query has resolved.
+        // Keep that optimistic cache structurally complete; the composer
+        // interprets a response without `providers` as an empty catalog.
+        const providers = prev?.providers?.length
+          ? prev.providers
+          : provider && model
+            ? [{ models: [model], name: provider, slug: provider }]
+            : []
+
+        return { ...prev, provider, model, providers }
+      }
 
       queryClient.setQueryData<ModelOptionsResponse>(modelOptionsQueryKey(profile, sessionId), patch)
 

--- a/apps/desktop/src/lib/model-options.test.ts
+++ b/apps/desktop/src/lib/model-options.test.ts
@@ -16,7 +16,11 @@ describe('requestModelOptions', () => {
   })
 
   it('uses the connected gateway even before a session exists', async () => {
-    const gatewayPayload = { model: 'BeastMode', provider: 'moa', providers: [] }
+    const gatewayPayload = {
+      model: 'BeastMode',
+      provider: 'moa',
+      providers: [{ models: ['BeastMode'], name: 'Mixture of Agents', slug: 'moa' }]
+    }
 
     const gateway = {
       request: vi.fn(() => Promise.resolve(gatewayPayload))
@@ -26,6 +30,40 @@ describe('requestModelOptions', () => {
 
     expect(gateway.request).toHaveBeenCalledWith('model.options', { explicit_only: true })
     expect(getGlobalModelOptions).not.toHaveBeenCalled()
+  })
+
+  it('recovers an empty gateway catalog through profile-scoped REST without replacing the session selection', async () => {
+    const gatewayPayload = { model: 'hermes-local', provider: 'hermes-local' }
+
+    const restPayload = {
+      model: 'profile-default',
+      provider: 'openai-codex',
+      providers: [{ models: ['hermes-local'], name: 'Hermes Local vLLM', slug: 'hermes-local' }]
+    }
+
+    const gateway = {
+      request: vi.fn(() => Promise.resolve(gatewayPayload))
+    }
+
+    vi.mocked(getGlobalModelOptions).mockResolvedValueOnce(restPayload)
+
+    await expect(requestModelOptions({ gateway: gateway as never, sessionId: 'session-1' })).resolves.toEqual({
+      ...restPayload,
+      model: 'hermes-local',
+      provider: 'hermes-local'
+    })
+
+    expect(getGlobalModelOptions).toHaveBeenCalledWith({ explicitOnly: true })
+  })
+
+  it('keeps the gateway result when both catalog paths have no selectable models', async () => {
+    const gatewayPayload = { model: 'hermes-local', provider: 'hermes-local', providers: [] }
+
+    const gateway = {
+      request: vi.fn(() => Promise.resolve(gatewayPayload))
+    }
+
+    await expect(requestModelOptions({ gateway: gateway as never })).resolves.toBe(gatewayPayload)
   })
 
   it('passes the active session id and refresh flag through the gateway', async () => {
@@ -40,6 +78,7 @@ describe('requestModelOptions', () => {
       refresh: true,
       session_id: 'session-1'
     })
+    expect(getGlobalModelOptions).toHaveBeenCalledWith({ explicitOnly: true, refresh: true })
   })
 
   it('falls back to REST when no gateway is connected', async () => {

--- a/apps/desktop/src/lib/model-options.test.ts
+++ b/apps/desktop/src/lib/model-options.test.ts
@@ -56,6 +56,35 @@ describe('requestModelOptions', () => {
     expect(getGlobalModelOptions).toHaveBeenCalledWith({ explicitOnly: true })
   })
 
+  it('recovers through profile-scoped REST when the gateway catalog request fails', async () => {
+    const restPayload = {
+      model: 'hermes-local',
+      provider: 'hermes-local',
+      providers: [{ models: ['hermes-local'], name: 'Hermes Local vLLM', slug: 'hermes-local' }]
+    }
+
+    const gateway = {
+      request: vi.fn(() => Promise.reject(new Error('gateway request unavailable')))
+    }
+
+    vi.mocked(getGlobalModelOptions).mockResolvedValueOnce(restPayload)
+
+    await expect(requestModelOptions({ gateway: gateway as never, sessionId: 'session-1' })).resolves.toEqual(restPayload)
+    expect(getGlobalModelOptions).toHaveBeenCalledWith({ explicitOnly: true })
+  })
+
+  it('preserves the gateway error when its REST recovery path also fails', async () => {
+    const gatewayError = new Error('gateway request unavailable')
+
+    const gateway = {
+      request: vi.fn(() => Promise.reject(gatewayError))
+    }
+
+    vi.mocked(getGlobalModelOptions).mockRejectedValueOnce(new Error('REST request unavailable'))
+
+    await expect(requestModelOptions({ gateway: gateway as never })).rejects.toBe(gatewayError)
+  })
+
   it('keeps the gateway result when both catalog paths have no selectable models', async () => {
     const gatewayPayload = { model: 'hermes-local', provider: 'hermes-local', providers: [] }
 

--- a/apps/desktop/src/lib/model-options.ts
+++ b/apps/desktop/src/lib/model-options.ts
@@ -50,7 +50,11 @@ export function modelOptionsQueryKey(profile: null | string | undefined, session
   return ['model-options', profileKey, sessionId || 'global'] as const
 }
 
-export function requestModelOptions({
+function hasSelectableModels(options: ModelOptionsResponse | null | undefined): boolean {
+  return options?.providers?.some(provider => (provider.models?.length ?? 0) > 0) ?? false
+}
+
+export async function requestModelOptions({
   explicitOnly = true,
   gateway,
   refresh = false,
@@ -71,7 +75,31 @@ export function requestModelOptions({
       params.explicit_only = true
     }
 
-    return gateway.request<ModelOptionsResponse>('model.options', params)
+    const gatewayOptions = await gateway.request<ModelOptionsResponse>('model.options', params)
+
+    if (hasSelectableModels(gatewayOptions)) {
+      return gatewayOptions
+    }
+
+    // A connected Desktop gateway can occasionally return only the current
+    // provider/model (or an empty provider list) while its authenticated REST
+    // catalog is already populated. Recover through the same profile-scoped
+    // endpoint Settings uses, but keep the live session selection authoritative.
+    try {
+      const restOptions = await getGlobalModelOptions({ explicitOnly, ...(refresh ? { refresh: true } : {}) })
+
+      if (hasSelectableModels(restOptions)) {
+        return {
+          ...restOptions,
+          ...(gatewayOptions?.provider ? { provider: gatewayOptions.provider } : {}),
+          ...(gatewayOptions?.model ? { model: gatewayOptions.model } : {})
+        }
+      }
+    } catch {
+      // Preserve the gateway result when the recovery path is unavailable.
+    }
+
+    return gatewayOptions
   }
 
   return getGlobalModelOptions({ explicitOnly, ...(refresh ? { refresh: true } : {}) })

--- a/apps/desktop/src/lib/model-options.ts
+++ b/apps/desktop/src/lib/model-options.ts
@@ -75,9 +75,16 @@ export async function requestModelOptions({
       params.explicit_only = true
     }
 
-    const gatewayOptions = await gateway.request<ModelOptionsResponse>('model.options', params)
+    let gatewayError: unknown
+    let gatewayOptions: ModelOptionsResponse | undefined
 
-    if (hasSelectableModels(gatewayOptions)) {
+    try {
+      gatewayOptions = await gateway.request<ModelOptionsResponse>('model.options', params)
+    } catch (error) {
+      gatewayError = error
+    }
+
+    if (gatewayOptions && hasSelectableModels(gatewayOptions)) {
       return gatewayOptions
     }
 
@@ -96,10 +103,15 @@ export async function requestModelOptions({
         }
       }
     } catch {
-      // Preserve the gateway result when the recovery path is unavailable.
+      // Preserve the gateway result (or its original error) when the recovery
+      // path is unavailable.
     }
 
-    return gatewayOptions
+    if (gatewayOptions) {
+      return gatewayOptions
+    }
+
+    throw gatewayError
   }
 
   return getGlobalModelOptions({ explicitOnly, ...(refresh ? { refresh: true } : {}) })

--- a/contributors/emails/mjolley9@gmail.com
+++ b/contributors/emails/mjolley9@gmail.com
@@ -1,0 +1,1 @@
+mjolley9


### PR DESCRIPTION
Salvages the remaining half of PR #84832 (@mjolley9): Desktop model-catalog recovery through the authenticated REST endpoint plus optimistic-cache completeness — the `surfaces.tsx` picker-rebind hunk already landed on main via #86250 (see #86591's exclusion notes) and is not re-shipped here.

## Changes (cherry-picked, authorship preserved)

- `apps/desktop/src/lib/model-options.ts` (`72a06b9e0b` + `ef1d2cc5e5`): when a connected gateway's `model.options` returns no selectable models (empty/partial catalog after a profile switch) **or throws**, recover through the same profile-scoped REST catalog Settings uses (`getGlobalModelOptions`), while keeping the live session's `provider`/`model` selection authoritative. Fail-open: if the recovery path is also unavailable, the original gateway result (or its original error) is preserved.
- `apps/desktop/src/app/session/hooks/use-model-controls.ts`: the optimistic `setQueryData` patch on model selection now keeps the cached response structurally complete (synthesizes a one-provider `providers` list when the catalog query hasn't resolved), so the composer no longer interprets the optimistic cache as an empty catalog.
- Tests for both (`model-options.test.ts`, `use-model-controls.test.tsx`).
- Residual docstring hunk from the PR's third commit (`990936d6f6`): `WiringActions.getGateway` doc updated to describe today's `$gateway`-atom subscription; the functional change it documented is already on main via #86250.

## Verified vs main

- `990936d6f6`'s `surfaces.tsx` hunk is byte-identical to what #86250 landed (confirmed: `git diff origin/main pr84832 -- surfaces.tsx` shows only the comment/doc deltas). Its test file conflicts with the main-side test #86250 brought; not carried.

## Validation

| Check | Result |
|---|---|
| `vitest run model-options.test.ts use-model-controls.test.tsx` | 36 passed |
| `npx tsc --noEmit` (apps/desktop) | clean |
| `scripts/audit_pr_attribution.py` | all contributor emails mapped |

Credit: @mjolley9 (#84832) — both functional commits cherry-picked with authorship preserved.

## Infographic

![model catalog recovery](https://files.catbox.moe/wmfczw.png)

<sub>Nous Research</sub>
