### PR TITLE
fix(tui_gateway): attach resuming clients instead of stealing the live event stream

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -5294,27 +5294,60 @@ def test_finalize_session_closes_slash_worker(monkeypatch):
 
 
 def test_close_transport_rebinds_session_to_remaining_viewer(monkeypatch):
-    """Closing a pop-out window's transport must re-bind the session to a
-    still-open window instead of stranding it on the drop sentinel (#83716)."""
+    """Closing a pop-out window's transport must leave the session with the
+    still-open window instead of stranding it on the drop sentinel (#83716).
+
+    The rebind #83716 added is gone; multi-client fan-out subsumes it. Both
+    windows are attached to the slot at once, so the pop-out is a fan-out peer
+    rather than a viewer waiting to be promoted, and closing it detaches that
+    peer and collapses the slot back onto the main window. This pins the same
+    guarantee through the mechanism that replaced the rebind: the session is
+    not parked, not reaped, not handed to the orphan reaper, and the surviving
+    window keeps receiving frames.
+    """
     reap_calls = []
     monkeypatch.setattr(server, "_schedule_ws_orphan_reap", lambda sid: reap_calls.append(sid))
 
     class _LiveTransport:
-        def write(self, *a, **k):
+        def __init__(self):
+            self.frames = []
+
+        def write(self, obj=None, *a, **k):
+            self.frames.append(obj)
             return True
 
     main = _LiveTransport()
     popout = _LiveTransport()
-    session = _session(transport=popout, running=False)
+    session = _session(transport=None, running=False)
+    # Build the state the way production does: every window that resumes goes
+    # through _live_session_payload, which attaches it into the slot and then
+    # stamps it into the viewers registry.
+    server._attach_session_transport(session, main)
+    server._attach_session_transport(session, popout)
     session["viewers"] = {main: 100.0, popout: 200.0}
     server._sessions["multi-sid"] = session
+    assert isinstance(session["transport"], server.FanoutTransport)
 
-    reaped, detached = server._close_sessions_for_transport(popout)
+    try:
+        reaped, detached = server._close_sessions_for_transport(popout)
 
-    assert reaped == 0 and detached == 0
-    assert session["transport"] is main
-    assert "multi-sid" not in reap_calls
-    assert server._ws_session_is_orphaned(session) is False
+        assert reaped == 0 and detached == 0
+        # One peer left, so the fan-out collapses back to the bare transport —
+        # the slot is indistinguishable from a session that never fanned out.
+        assert session["transport"] is main
+        assert "multi-sid" not in reap_calls
+        assert server._ws_session_is_orphaned(session) is False
+
+        # And it is still a working stream, not just a surviving reference.
+        server._emit("message.delta", "multi-sid", {"text": "still here"})
+        assert [(f.get("params") or {}).get("type") for f in main.frames] == [
+            "message.delta"
+        ]
+        assert popout.frames == []
+    finally:
+        # The fake slot must not outlive the test: _sessions is module state and
+        # later sweeps would walk it.
+        server._sessions.pop("multi-sid", None)
 
 
 def test_close_transport_detaches_when_no_viewers_remain(monkeypatch):
@@ -5340,7 +5373,15 @@ def test_close_transport_detaches_when_no_viewers_remain(monkeypatch):
 
 
 def test_close_transport_skips_dead_remaining_viewers(monkeypatch):
-    """A viewer whose socket is already dead must not win the re-bind."""
+    """A viewer whose socket is already dead must not hold the session open.
+
+    #83716's rebind refused to hand the session to a dead viewer; fan-out
+    membership keeps that filter through _transport_is_live_peer, which is what
+    decides whether anything survives the departing client. Both windows are
+    ATTACHED here, which is the state production builds — a viewer that was
+    never attached leaves the slot single-client and exercises the ordinary park
+    path instead of this one.
+    """
     reap_calls = []
     monkeypatch.setattr(server, "_schedule_ws_orphan_reap", lambda sid: reap_calls.append(sid))
 
@@ -5349,17 +5390,25 @@ def test_close_transport_skips_dead_remaining_viewers(monkeypatch):
             return True
 
     dead = _LiveTransport()
+    popout = _LiveTransport()
+    session = _session(transport=None, running=False)
+    server._attach_session_transport(session, dead)
+    server._attach_session_transport(session, popout)
+    session["viewers"] = {dead: 100.0, popout: 200.0}
+    assert isinstance(session["transport"], server.FanoutTransport)
+    # The socket goes away without a disconnect reaching the gateway; the latch
+    # _transport_is_dead reads is the only trace it leaves behind.
     dead._closed = True
-    owner = _LiveTransport()
-    session = _session(transport=owner, running=False)
-    session["viewers"] = {dead: 100.0, owner: 200.0}
     server._sessions["dead-viewer-sid"] = session
 
-    reaped, detached = server._close_sessions_for_transport(owner)
+    try:
+        reaped, detached = server._close_sessions_for_transport(popout)
 
-    assert detached == 1
-    assert session["transport"] is server._detached_ws_transport
-    assert reap_calls == ["dead-viewer-sid"]
+        assert reaped == 0 and detached == 1
+        assert session["transport"] is server._detached_ws_transport
+        assert reap_calls == ["dead-viewer-sid"]
+    finally:
+        server._sessions.pop("dead-viewer-sid", None)
 
 
 def test_live_session_payload_registers_transport_as_viewer():

--- a/tests/tui_gateway/test_multi_client_fanout.py
+++ b/tests/tui_gateway/test_multi_client_fanout.py
@@ -656,6 +656,38 @@ def test_queued_prompt_drain_keeps_both_clients_attached(monkeypatch):
     assert b.types() == ["message.delta"]
 
 
+def test_queued_prompt_drain_skips_a_queuer_that_disconnected(monkeypatch):
+    """B goes away while its prompt waits: the prompt runs, the dead pin does not.
+
+    Attaching a transport whose client already left would pin a dead peer into
+    the slot until the first failed write prunes it. A keeps its stream and
+    stays the only attached client.
+    """
+    dispatched = []
+    monkeypatch.setattr(
+        server,
+        "_run_prompt_submit",
+        lambda rid, sid, _session, text, **kw: dispatched.append((rid, text)),
+    )
+
+    a, b = _FakeClient("a"), _FakeClient("b")
+    session = _session(transport=a)
+    server._enqueue_prompt(session, "from B", b)
+    b._closed = True  # what _transport_is_dead reads: B's socket went away
+    server._sessions["sid"] = session
+    try:
+        assert server._drain_queued_prompt("drain", "sid", session) is True
+        server._emit("message.delta", "sid", {"text": "drained answer"})
+    finally:
+        server._sessions.pop("sid", None)
+
+    assert dispatched == [("drain", "from B")]  # drain semantics unchanged
+    assert session["transport"] is a
+    assert server._session_transport_contains(session, b) is False
+    assert a.types() == ["message.delta"]
+    assert b.types() == []
+
+
 def test_queued_prompt_drain_still_rebinds_a_single_client_session(monkeypatch):
     """(j) Control: with one client the drain lands on the queuer's transport."""
     monkeypatch.setattr(server, "_run_prompt_submit", lambda *a, **k: None)

--- a/tests/tui_gateway/test_multi_client_fanout.py
+++ b/tests/tui_gateway/test_multi_client_fanout.py
@@ -327,6 +327,197 @@ def test_a_fanout_with_no_live_peer_is_dead():
     assert server._transport_is_dead(FanoutTransport()) is True
 
 
+def test_steer_authority_recognizes_the_exact_client_inside_a_fanout():
+    """Wrapping attached peers must not revoke the commissioning peer's authority."""
+    owner, watcher, stranger = (
+        _FakeClient("owner"),
+        _FakeClient("watcher"),
+        _FakeClient("stranger"),
+    )
+    session = _session(transport=FanoutTransport(owner, watcher))
+    server._sessions["sid"] = session
+    try:
+        token = server.bind_transport(owner)
+        try:
+            assert server._current_session_steer_authority("sid") == (owner, session)
+        finally:
+            server.reset_transport(token)
+
+        token = server.bind_transport(stranger)
+        try:
+            assert server._current_session_steer_authority("sid") == (None, None)
+        finally:
+            server.reset_transport(token)
+    finally:
+        server._sessions.pop("sid", None)
+
+
+def test_steer_authority_is_granted_to_an_attached_watcher():
+    """A client that attached to watch a session may also steer its subagents.
+
+    This is INTENTIONAL and wider than the pre-fan-out rule, which admitted only
+    whichever client happened to hold the transport slot. A mirrored session has
+    no single owner in that slot, so authority is membership in it. Narrowing
+    this back to the commissioning peer would need a per-subagent record of who
+    commissioned it, which this change does not add; the widening is stated in
+    the pull request description, and this test pins it so it cannot be changed
+    silently in either direction.
+    """
+    owner, watcher, stranger = (
+        _FakeClient("owner"),
+        _FakeClient("watcher"),
+        _FakeClient("stranger"),
+    )
+    session = _session(transport=owner)
+    server._attach_session_transport(session, watcher)
+    solo = _session(transport=owner)
+    server._sessions["sid"] = session
+    server._sessions["solo"] = solo
+    try:
+        token = server.bind_transport(watcher)
+        try:
+            assert server._current_session_steer_authority("sid") == (watcher, session)
+            # Control: on a single-client session the same watcher is a stranger,
+            # so the widening reaches attached clients and nobody else.
+            assert server._current_session_steer_authority("solo") == (None, None)
+        finally:
+            server.reset_transport(token)
+
+        token = server.bind_transport(stranger)
+        try:
+            assert server._current_session_steer_authority("sid") == (None, None)
+        finally:
+            server.reset_transport(token)
+    finally:
+        server._sessions.pop("sid", None)
+        server._sessions.pop("solo", None)
+
+
+# ── browser-control session ownership ──────────────────────────────────────
+#
+# The four browser.controller.* handlers gate on the session slot exactly as
+# subagent.steer did, so fan-out breaks them the same way and the fix is the
+# same predicate. These tests pin the gate itself: they assert on the ownership
+# error message and stop at the NEXT gate ("no controller registered for this
+# session"), so a later broker change cannot make them pass vacuously.
+
+_CONTROLLER_IDENTITY = {"user_id": "user-fixture", "provider": "provider-fixture"}
+_NOT_OWNED = "session is not owned by this transport"
+_NO_CONTROLLER = "no controller registered for this session"
+
+
+def _controller_client(name: str) -> _FakeClient:
+    """A fan-out client that also carries a server-authenticated identity."""
+    client = _FakeClient(name)
+    client.auth_identity = dict(_CONTROLLER_IDENTITY)
+    return client
+
+
+def _controller_rpc(transport, method_name: str, **params) -> dict:
+    return server.dispatch(
+        {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": method_name,
+            "params": params,
+        },
+        transport,
+    )
+
+
+def _error_message(response: dict) -> str | None:
+    return (response.get("error") or {}).get("message")
+
+
+def test_browser_control_ownership_gate_admits_a_peer_inside_a_fanout():
+    """Wrapping attached peers must not revoke browser control for all of them."""
+    owner, watcher, stranger = (
+        _controller_client("owner"),
+        _controller_client("watcher"),
+        _controller_client("stranger"),
+    )
+    session = _session(transport=FanoutTransport(owner, watcher), profile="default")
+    server._sessions["sid"] = session
+    try:
+        # The peer that would have registered the controller clears the
+        # ownership gate and stops at the next one.
+        assert _error_message(_controller_rpc(owner, "browser.controller.heartbeat", session_id="sid")) == _NO_CONTROLLER
+        # Widened, exactly as the steer conversion widened steer: any attached
+        # peer clears the session gate. The broker's is_owner check below it is
+        # what still refuses a peer that did not register the controller.
+        assert _error_message(_controller_rpc(watcher, "browser.controller.heartbeat", session_id="sid")) == _NO_CONTROLLER
+        # An unattached client is still refused at the ownership gate.
+        assert _error_message(_controller_rpc(stranger, "browser.controller.heartbeat", session_id="sid")) == _NOT_OWNED
+    finally:
+        server._sessions.pop("sid", None)
+
+
+def test_browser_control_ownership_gate_is_unchanged_for_a_single_client():
+    """Control: a bare slot still compares by identity on all four handlers."""
+    owner, stranger = _controller_client("owner"), _controller_client("stranger")
+    session = _session(transport=owner, profile="default")
+    server._sessions["solo"] = session
+    try:
+        for method_name in (
+            "browser.controller.heartbeat",
+            "browser.controller.result",
+            "browser.controller.detach",
+        ):
+            assert _error_message(_controller_rpc(stranger, method_name, session_id="solo")) == _NOT_OWNED
+        assert _error_message(_controller_rpc(owner, "browser.controller.heartbeat", session_id="solo")) == _NO_CONTROLLER
+    finally:
+        server._sessions.pop("solo", None)
+
+
+def test_browser_controller_registers_and_detaches_inside_a_fanout(monkeypatch):
+    """End to end: registration on a mirrored session, then a clean detach."""
+    from gateway import browser_control_broker
+
+    monkeypatch.setattr(
+        "gateway.browser_control_broker.browser_control_enabled", lambda: True
+    )
+    owner, watcher, stranger = (
+        _controller_client("owner"),
+        _controller_client("watcher"),
+        _controller_client("stranger"),
+    )
+    session = _session(transport=FanoutTransport(owner, watcher), profile="default")
+    server._sessions["sid"] = session
+    registration = {}
+    try:
+        registration = _controller_rpc(
+            owner,
+            "browser.controller.register",
+            session_id="sid",
+            controller_id="controller-fixture",
+            browser_profile_id="browser-profile-fixture",
+            capabilities=["controller.noop"],
+            protocol_version=browser_control_broker.BROWSER_CONTROL_PROTOCOL_VERSION,
+        )
+        assert registration.get("error") is None, registration
+        assert registration["result"]["scope"]["session_id"] == "sid"
+
+        # The registering peer owns the controller; the fan-out peer that did
+        # not register clears the session gate and is refused by the broker.
+        assert _controller_rpc(owner, "browser.controller.heartbeat", session_id="sid")["result"] == {"ok": True}
+        assert _error_message(_controller_rpc(watcher, "browser.controller.heartbeat", session_id="sid")) == "controller is not owned by this transport"
+        assert _error_message(_controller_rpc(stranger, "browser.controller.heartbeat", session_id="sid")) == _NOT_OWNED
+
+        detached = _controller_rpc(owner, "browser.controller.detach", session_id="sid")
+        assert detached.get("error") is None, detached
+    finally:
+        if registration.get("result"):
+            broker = browser_control_broker.get_browser_control_broker()
+            scope = broker.scope_for_session(
+                session_id="sid",
+                principal_id=registration["result"]["scope"]["principal_id"],
+                transport_family=registration["result"]["scope"]["transport_family"],
+            )
+            if scope is not None:
+                broker.detach(scope, notify_controller=False)
+        server._sessions.pop("sid", None)
+
+
 # ── event delivery ─────────────────────────────────────────────────────────
 
 

--- a/tests/tui_gateway/test_multi_client_fanout.py
+++ b/tests/tui_gateway/test_multi_client_fanout.py
@@ -1,0 +1,813 @@
+"""A session streams to EVERY attached client, not just the newest one.
+
+Before this, ``session["transport"]`` held exactly one client and every
+``prompt.submit`` / ``session.resume`` / ``session.activate`` / queued-prompt
+drain rebound it — so a second client either saw nothing, stole the stream from
+the first, or silenced the turn the first was reading. The slot now holds a
+``FanoutTransport`` as soon as a second client attaches, and the disconnect path
+detaches instead of parking whenever another client is still there.
+
+Single-client behaviour is the control condition throughout: with one client
+attached the slot holds the bare transport and every path behaves exactly as it
+did before fan-out existed.
+"""
+
+import threading
+import types
+
+from tui_gateway import server
+from tui_gateway.transport import FanoutTransport
+
+
+class _FakeClient:
+    """A connected client: records the frames it receives.
+
+    ``ok`` False models a peer that has gone away (``write`` returns False, the
+    gateway's peer-gone signal); ``boom`` models a wedged peer whose write
+    raises. Both must be pruned without disturbing the healthy clients.
+    """
+
+    def __init__(self, name: str, *, ok: bool = True, boom: bool = False) -> None:
+        self.name = name
+        self.frames: list[dict] = []
+        self.closed = False
+        self._ok = ok
+        self._boom = boom
+
+    def write(self, obj: dict) -> bool:
+        if self._boom:
+            raise RuntimeError(f"{self.name} is wedged")
+        self.frames.append(obj)
+        return self._ok
+
+    def close(self) -> None:
+        self.closed = True
+
+    def types(self) -> list[str]:
+        return [(f.get("params") or {}).get("type") for f in self.frames]
+
+
+def _session(**extra) -> dict:
+    return {
+        "agent": None,
+        "session_key": "session-key",
+        "history": [],
+        "history_lock": threading.Lock(),
+        "history_version": 0,
+        "running": False,
+        "attached_images": [],
+        "transport": None,
+        **extra,
+    }
+
+
+# ── FanoutTransport ────────────────────────────────────────────────────────
+
+
+def test_fanout_delivers_to_every_attached_transport():
+    a, b = _FakeClient("a"), _FakeClient("b")
+    fan = FanoutTransport(a, b)
+
+    assert fan.write({"frame": 1}) is True
+    assert a.frames == b.frames == [{"frame": 1}]
+    assert fan.transports() == [a, b]
+
+
+def test_fanout_attach_is_idempotent_and_detach_is_by_identity():
+    a, b = _FakeClient("a"), _FakeClient("b")
+    fan = FanoutTransport(a)
+
+    assert fan.attach(a) is False  # already attached
+    assert fan.attach(b) is True
+    assert fan.contains(a) and fan.contains(b)
+    assert fan.has_transports(excluding=a) is True
+
+    assert fan.detach(a) is True
+    assert fan.detach(a) is False
+    assert fan.transports() == [b]
+    assert fan.has_transports(excluding=b) is False
+
+
+def test_fanout_prunes_a_wedged_peer_without_disturbing_the_rest():
+    """(g) A raising peer is dropped; the healthy client keeps its stream."""
+    healthy, wedged = _FakeClient("healthy"), _FakeClient("wedged", boom=True)
+    fan = FanoutTransport(wedged, healthy)
+
+    assert fan.write({"frame": 1}) is True
+    assert healthy.frames == [{"frame": 1}]
+    assert fan.transports() == [healthy]
+
+    # And the pruning is permanent — no retry storm against the wedged peer.
+    assert fan.write({"frame": 2}) is True
+    assert len(healthy.frames) == 2
+
+
+def test_fanout_prunes_a_peer_that_reports_gone_and_reports_all_dead():
+    gone = _FakeClient("gone", ok=False)
+    fan = FanoutTransport(gone)
+
+    # write() returned False -> peer gone -> pruned, and an empty fan-out
+    # reports peer-gone exactly like a single dead transport would.
+    assert fan.write({"frame": 1}) is False
+    assert fan.transports() == []
+    assert fan.write({"frame": 2}) is False
+
+
+def test_fanout_close_releases_peers_without_closing_their_sockets():
+    a = _FakeClient("a")
+    fan = FanoutTransport(a)
+
+    fan.close()
+
+    assert fan.transports() == []
+    # Each client owns its own socket; the WS handler closes it on disconnect.
+    assert a.closed is False
+
+
+# ── attach ladder ──────────────────────────────────────────────────────────
+
+
+def test_attach_replaces_an_empty_or_stdio_slot_without_wrapping():
+    """The single-client shape is unchanged: no FanoutTransport in sight."""
+    a = _FakeClient("a")
+
+    empty = _session(transport=None)
+    assert server._attach_session_transport(empty, a) is True
+    assert empty["transport"] is a
+
+    stdio = _session(transport=server._stdio_transport)
+    assert server._attach_session_transport(stdio, a) is True
+    assert stdio["transport"] is a
+
+    parked = _session(transport=server._detached_ws_transport)
+    assert server._attach_session_transport(parked, a) is True
+    assert parked["transport"] is a
+
+
+def test_attach_of_the_same_transport_is_a_noop():
+    a = _FakeClient("a")
+    session = _session(transport=a)
+
+    assert server._attach_session_transport(session, a) is True
+    assert session["transport"] is a
+
+
+def test_attach_of_a_second_client_wraps_both_and_a_third_joins_the_fanout():
+    a, b, c = _FakeClient("a"), _FakeClient("b"), _FakeClient("c")
+    session = _session(transport=a)
+
+    server._attach_session_transport(session, b)
+    assert isinstance(session["transport"], FanoutTransport)
+    assert session["transport"].transports() == [a, b]
+
+    server._attach_session_transport(session, c)
+    assert session["transport"].transports() == [a, b, c]
+
+
+def test_attach_never_lets_stdio_displace_a_live_client():
+    """An unbound-context activate must not silence the websocket that owns it."""
+    a = _FakeClient("a")
+    session = _session(transport=a)
+
+    assert server._attach_session_transport(session, server._stdio_transport) is False
+    assert session["transport"] is a
+
+
+def test_attach_flattens_a_fanout_argument_instead_of_nesting_it():
+    a, b, c = _FakeClient("a"), _FakeClient("b"), _FakeClient("c")
+    session = _session(transport=a)
+    server._attach_session_transport(session, b)
+
+    server._attach_session_transport(session, FanoutTransport(b, c))
+
+    assert session["transport"].transports() == [a, b, c]
+
+
+def test_attach_flattens_a_fanout_argument_onto_a_single_client_slot(monkeypatch):
+    """The nesting the queued-prompt paths can actually reach.
+
+    A busy submit pins ``t or session["transport"]`` to the queued prompt, so
+    the envelope can hold the FAN-OUT that was in the slot, and the drain hands
+    that straight back to attach. Flattening only when the slot ALREADY fans out
+    leaves the leaf-slot case nesting one fan-out inside another, and every
+    reader of the slot scans a single level — ``FanoutTransport.contains``, the
+    steer-authority check, detach — so a peer in the inner fan-out is invisible
+    to all of them, and a peer in BOTH levels is written to twice per frame.
+    """
+    a, b = _FakeClient("a"), _FakeClient("b")
+
+    # (1) A fan-out arriving at a leaf slot is flattened into it, not wrapped.
+    session = _session(transport=a)
+    assert server._attach_session_transport(session, FanoutTransport(a, b)) is True
+    slot = session["transport"]
+    assert isinstance(slot, FanoutTransport)
+    assert slot.transports() == [a, b]
+    assert not any(isinstance(t, FanoutTransport) for t in slot.transports())
+    assert server._session_transport_contains(session, b) is True
+
+    # (2) The sequence that produces it. Two clients attach, so the slot holds a
+    # fan-out; a busy submit captures that slot in the queued envelope; the
+    # second client disconnects and the slot collapses back to the first; the
+    # drain then attaches the captured fan-out to a leaf slot.
+    monkeypatch.setattr(server, "_run_prompt_submit", lambda *a_, **k: None)
+
+    drained = _session(transport=a)
+    server._attach_session_transport(drained, b)
+    captured = drained["transport"]
+    assert isinstance(captured, FanoutTransport)
+    server._enqueue_prompt(drained, "queued while busy", captured)
+
+    assert server._detach_session_transport(drained, b) is True
+    assert drained["transport"] is a
+
+    server._sessions["flatten-sid"] = drained
+    try:
+        assert server._drain_queued_prompt("drain", "flatten-sid", drained) is True
+        # Flat: the captured fan-out lost b to the same detach that collapsed
+        # the slot, so flattening it re-attaches only a, which is already there.
+        assert drained["transport"] is a
+        server._emit("message.delta", "flatten-sid", {"text": "once"})
+    finally:
+        server._sessions.pop("flatten-sid", None)
+
+    # Nesting would have put a inside the slot AND under it: one frame, two
+    # writes to the same client.
+    assert a.types() == ["message.delta"]
+
+
+def test_detach_collapses_back_to_the_single_remaining_client():
+    a, b = _FakeClient("a"), _FakeClient("b")
+    session = _session(transport=a)
+    server._attach_session_transport(session, b)
+
+    assert server._detach_session_transport(session, a) is True
+    assert session["transport"] is b
+    assert server._detach_session_transport(session, b) is False
+
+
+def test_detach_of_a_single_client_leaves_the_slot_for_the_caller_to_park():
+    a = _FakeClient("a")
+    session = _session(transport=a)
+
+    # False == "no live client remains" — the disconnect path parks the sentinel.
+    assert server._detach_session_transport(session, a) is False
+    assert session["transport"] is a
+
+
+def test_live_transport_predicates_ignore_stdio_and_the_drop_sentinel():
+    a = _FakeClient("a")
+
+    assert server._session_has_live_transport(_session(transport=a)) is True
+    assert server._session_has_live_transport(_session(transport=a), excluding=a) is False
+    assert server._session_has_live_transport(_session(transport=None)) is False
+    assert (
+        server._session_has_live_transport(_session(transport=server._stdio_transport))
+        is False
+    )
+    assert (
+        server._session_has_live_transport(
+            _session(transport=server._detached_ws_transport)
+        )
+        is False
+    )
+
+
+def test_a_closed_socket_is_not_a_live_peer():
+    """A transport that already latched ``_closed`` is a departed client.
+
+    ``_transport_is_live_peer`` ended on a bare ``return True``, so a WSTransport
+    whose socket had gone away still counted as a live peer: a session whose only
+    remaining peer was that dead socket answered "another client is still here"
+    and escaped both the park and the reap. ``_transport_is_dead`` is the
+    module's deadness predicate; the ladder now defers to it.
+    """
+    dead = _FakeClient("dead")
+    dead._closed = True  # the flag WSTransport latches when its socket goes away
+
+    assert server._transport_is_live_peer(dead) is False
+    assert server._session_has_live_transport(_session(transport=dead)) is False
+
+    # And a fan-out that collapses onto a dead peer is parked, not skipped: the
+    # live client leaving was the last real client.
+    live_client = _FakeClient("live")
+    session = _session(transport=FanoutTransport(live_client, dead))
+    server._sessions["dead-peer-sid"] = session
+    try:
+        assert server._close_sessions_for_transport(live_client) == (0, 1)
+        assert session["transport"] is server._detached_ws_transport
+    finally:
+        server._sessions.pop("dead-peer-sid", None)
+
+
+def test_a_fanout_with_no_live_peer_is_dead():
+    """``_transport_is_dead`` is the reapers' gate, and a fan-out could not fail it.
+
+    A ``FanoutTransport`` is never the drop sentinel and its ``__slots__`` give
+    it no ``_closed``, so a session that fanned out once read as alive forever:
+    the TTL reaper, the LRU cap and the disconnect revalidation all ask this one
+    predicate. A fan-out reaches the no-live-peer state without any disconnect
+    passing through ``_close_sessions_for_transport`` — a write that returns
+    False or raises prunes that peer — so the empty case is reachable, and it is
+    dead.
+    """
+    a, b = _FakeClient("a"), _FakeClient("b")
+    session = _session(transport=a)
+    server._attach_session_transport(session, b)
+    assert isinstance(session["transport"], FanoutTransport)
+    assert server._transport_is_dead(session["transport"]) is False
+
+    # One peer gone, one still reading: the session keeps its client.
+    a._closed = True  # the flag WSTransport latches when its socket goes away
+    assert server._transport_is_dead(session["transport"]) is False
+
+    b._closed = True
+    assert server._transport_is_dead(session["transport"]) is True
+
+    # Pruning every peer leaves the fan-out empty, which is nobody attached.
+    assert server._transport_is_dead(FanoutTransport()) is True
+
+
+# ── event delivery ─────────────────────────────────────────────────────────
+
+
+def test_two_attached_clients_both_receive_a_session_event(monkeypatch):
+    """(a) The headline behaviour: one emit, two clients."""
+    a, b = _FakeClient("a"), _FakeClient("b")
+    session = _session(transport=a)
+    server._attach_session_transport(session, b)
+    server._sessions["sid"] = session
+    try:
+        server._emit("message.delta", "sid", {"text": "hi"})
+    finally:
+        server._sessions.pop("sid", None)
+
+    assert a.types() == ["message.delta"]
+    assert b.types() == ["message.delta"]
+    assert a.frames[0] == b.frames[0]
+
+
+def test_a_single_client_session_writes_through_the_bare_transport(monkeypatch):
+    """(j) Control: nothing about the one-client path changed."""
+    a = _FakeClient("a")
+    server._sessions["sid"] = _session(transport=a)
+    try:
+        assert server._sessions["sid"]["transport"] is a
+        server._emit("message.delta", "sid", {"text": "hi"})
+    finally:
+        server._sessions.pop("sid", None)
+
+    # The replay contract stamps a monotonic ``seq`` on every WS event frame.
+    # Strip it: this control test is about ROUTING, not numbering.
+    frames = [
+        {**f, "params": {k: v for k, v in f["params"].items() if k != "seq"}}
+        for f in a.frames
+    ]
+    assert frames == [
+        {
+            "jsonrpc": "2.0",
+            "method": "event",
+            "params": {
+                "type": "message.delta",
+                "session_id": "sid",
+                "payload": {"text": "hi"},
+            },
+        }
+    ]
+
+
+def test_both_attached_clients_receive_the_terminal_message_complete():
+    """The frame that ENDS a turn fans out too, not just the streaming deltas.
+
+    ``message.complete`` is how a client knows the turn is over. A mirrored
+    session that delivered deltas but dropped the terminal frame would leave the
+    second client rendering a turn that never finishes.
+    """
+    a, b = _FakeClient("a"), _FakeClient("b")
+    session = _session(transport=a)
+    server._attach_session_transport(session, b)
+    server._sessions["sid"] = session
+    try:
+        server._emit("message.delta", "sid", {"text": "par"})
+        server._emit("message.complete", "sid", {"text": "part", "status": "ok"})
+    finally:
+        server._sessions.pop("sid", None)
+
+    assert a.types() == ["message.delta", "message.complete"]
+    assert b.types() == ["message.delta", "message.complete"]
+    assert a.frames[-1] == b.frames[-1]
+    assert a.frames[-1]["params"]["payload"] == {"text": "part", "status": "ok"}
+
+    # Control: the one-client path delivers the same terminal frame through the
+    # bare transport, with no fan-out in the slot.
+    solo = _FakeClient("solo")
+    server._sessions["solo-sid"] = _session(transport=solo)
+    try:
+        assert server._sessions["solo-sid"]["transport"] is solo
+        server._emit("message.complete", "solo-sid", {"text": "part", "status": "ok"})
+    finally:
+        server._sessions.pop("solo-sid", None)
+
+    assert solo.types() == ["message.complete"]
+    assert solo.frames[-1]["params"]["payload"] == {"text": "part", "status": "ok"}
+
+
+# ── prompt.submit / queued drain ───────────────────────────────────────────
+
+
+def test_second_clients_submit_attaches_and_the_first_keeps_streaming(monkeypatch):
+    """(c) A second client's prompt.submit must not cut the first one out."""
+    monkeypatch.setattr(server, "_run_prompt_submit", lambda *a, **k: None)
+    monkeypatch.setattr(server, "_ensure_active_session_slot", lambda *a, **k: None)
+
+    watcher, submitter = _FakeClient("watcher"), _FakeClient("submitter")
+    session = _session(transport=watcher, agent=types.SimpleNamespace())
+    server._sessions["sid"] = session
+    token = server.bind_transport(submitter)
+    try:
+        server._methods["prompt.submit"]("r1", {"session_id": "sid", "text": "hello"})
+        server._emit("message.delta", "sid", {"text": "answer"})
+    finally:
+        server.reset_transport(token)
+        server._sessions.pop("sid", None)
+
+    assert isinstance(session["transport"], FanoutTransport)
+    assert watcher.types() == ["message.delta"]
+    assert submitter.types() == ["message.delta"]
+
+
+def test_queued_prompt_drain_keeps_both_clients_attached(monkeypatch):
+    """(d) The hole every competing patch missed: the drain used to rebind.
+
+    Client A is streaming; client B submits mid-turn, so B's prompt is queued
+    with B's transport pinned to it. When the drain fires it must ATTACH B —
+    rebinding pinned the whole drained turn to B and silenced A.
+    """
+    dispatched = []
+    monkeypatch.setattr(
+        server,
+        "_run_prompt_submit",
+        lambda rid, sid, _session, text, **kw: dispatched.append((rid, text)),
+    )
+
+    a, b = _FakeClient("a"), _FakeClient("b")
+    session = _session(transport=a)
+    server._enqueue_prompt(session, "from B", b)
+    server._sessions["sid"] = session
+    try:
+        assert server._drain_queued_prompt("drain", "sid", session) is True
+        server._emit("message.delta", "sid", {"text": "drained answer"})
+    finally:
+        server._sessions.pop("sid", None)
+
+    assert dispatched == [("drain", "from B")]
+    assert isinstance(session["transport"], FanoutTransport)
+    assert a.types() == ["message.delta"]
+    assert b.types() == ["message.delta"]
+
+
+def test_queued_prompt_drain_still_rebinds_a_single_client_session(monkeypatch):
+    """(j) Control: with one client the drain lands on the queuer's transport."""
+    monkeypatch.setattr(server, "_run_prompt_submit", lambda *a, **k: None)
+
+    b = _FakeClient("b")
+    session = _session(transport=server._detached_ws_transport)
+    server._enqueue_prompt(session, "from B", b)
+
+    assert server._drain_queued_prompt("drain", "sid", session) is True
+    assert session["transport"] is b
+
+
+# ── disconnect ─────────────────────────────────────────────────────────────
+
+
+def test_watcher_disconnect_leaves_the_other_client_streaming():
+    """(e) One client leaving must not park or reap a session someone is reading."""
+    a, watcher = _FakeClient("a"), _FakeClient("watcher")
+    session = _session(transport=a)
+    server._attach_session_transport(session, watcher)
+    server._sessions["sid"] = session
+    try:
+        assert server._close_sessions_for_transport(watcher) == (0, 0)
+        assert session["transport"] is a
+        assert server._ws_session_is_orphaned(session) is False
+        server._emit("message.delta", "sid", {"text": "still here"})
+    finally:
+        server._sessions.pop("sid", None)
+
+    assert a.types() == ["message.delta"]
+    assert watcher.types() == []
+
+
+def test_last_client_disconnect_parks_exactly_as_before(monkeypatch):
+    """(f) Once the last client goes, today's park + grace-reap path runs."""
+    monkeypatch.setattr(server, "_WS_ORPHAN_REAP_GRACE_S", 0)
+
+    a, watcher = _FakeClient("a"), _FakeClient("watcher")
+    session = _session(transport=a)
+    server._attach_session_transport(session, watcher)
+    server._sessions["sid"] = session
+    try:
+        assert server._close_sessions_for_transport(watcher) == (0, 0)
+        assert server._close_sessions_for_transport(a) == (0, 1)
+        assert session["transport"] is server._detached_ws_transport
+        assert server._ws_session_is_orphaned(session) is True
+    finally:
+        server._sessions.pop("sid", None)
+
+
+def test_last_client_disconnect_reaps_a_close_on_disconnect_session(monkeypatch):
+    """(f) close_on_disconnect still fires — but only for the LAST client."""
+    # The disconnect path claims the session with _pop_session_by_id and finishes
+    # the close through _teardown_popped_session, so that is what this stubs; the
+    # sid is asserted through the pop rather than through the call arguments.
+    closed = []
+
+    def _fake_teardown(session, *, end_reason: str = "tui_close") -> bool:
+        closed.append((session, end_reason))
+        return True
+
+    monkeypatch.setattr(server, "_teardown_popped_session", _fake_teardown)
+
+    a, watcher = _FakeClient("a"), _FakeClient("watcher")
+    session = _session(transport=a, close_on_disconnect=True)
+    server._attach_session_transport(session, watcher)
+    server._sessions["sid"] = session
+    try:
+        assert server._close_sessions_for_transport(watcher) == (0, 0)
+        assert closed == []
+        assert server._close_sessions_for_transport(
+            a, end_reason="ws_disconnect"
+        ) == (1, 0)
+        assert "sid" not in server._sessions
+    finally:
+        server._sessions.pop("sid", None)
+
+    assert closed == [(session, "ws_disconnect")]
+
+
+def test_orphan_check_spares_a_session_that_still_has_a_fanout_peer():
+    # _ws_session_is_orphaned stayed slot-identity based on main: a fan-out is
+    # never the drop sentinel, and the disconnect path only parks the sentinel
+    # once the last peer is gone, so these hold without a liveness rewrite.
+    a, watcher = _FakeClient("a"), _FakeClient("watcher")
+    session = _session(transport=a)
+    server._attach_session_transport(session, watcher)
+
+    assert server._ws_session_is_orphaned(session) is False
+
+    # Losing one of two clients collapses the slot but keeps the session live.
+    assert server._detach_session_transport(session, a) is True
+    assert server._ws_session_is_orphaned(session) is False
+
+    # Losing the last one reports "no client left"; the caller then parks the
+    # drop sentinel, which is what makes the session orphaned.
+    assert server._detach_session_transport(session, watcher) is False
+    session["transport"] = server._detached_ws_transport
+    assert server._ws_session_is_orphaned(session) is True
+
+
+# ---------------------------------------------------------------------------
+# Concurrent fan-out delivery
+#
+# A SERIAL ``FanoutTransport.write`` — each peer written in turn — would let a
+# client whose write parks for the full ``tui_gateway.ws._WS_WRITE_TIMEOUT_S``
+# (10s, the non-streaming path's ``fut.result`` wait for a stalled event loop)
+# hold the same frame back from every healthy client behind it in the list.
+# That is the property these tests pin, so the writes run concurrently, with two
+# cases deliberately kept inline: a lone peer (single-client sessions must not
+# change at all) and a caller that is already on an event loop (handing that
+# write to a pool thread would make the pool thread block on the loop it just
+# left, freezing both).
+#
+# Extra imports for this block: ``asyncio`` below, plus a function-local
+# ``tui_gateway.transport`` in the deadline test (it monkeypatches a module
+# constant). Everything else — ``threading``, ``FanoutTransport``,
+# ``_FakeClient`` — comes from the top of this file.
+# ---------------------------------------------------------------------------
+
+import asyncio
+
+
+class _SlowPeer:
+    """A peer whose write parks until the test releases it.
+
+    Models the real stall: a non-streaming ``WSTransport.write`` blocks on
+    ``fut.result(timeout=_WS_WRITE_TIMEOUT_S)`` while the owning event loop is
+    busy, so the emitting thread sits inside that one peer's write for seconds.
+    """
+
+    def __init__(self, name: str = "slow") -> None:
+        self.name = name
+        self.frames: list[dict] = []
+        self.entered = threading.Event()
+        self.release = threading.Event()
+        self.closed = False
+
+    def write(self, obj: dict) -> bool:
+        self.entered.set()
+        # Bounded: a regression must fail the assertion below, never hang the
+        # suite waiting for a release that the failing path never reaches.
+        self.release.wait(timeout=5.0)
+        self.frames.append(obj)
+        return True
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class _SignallingPeer:
+    """A healthy peer that announces each frame the moment it lands."""
+
+    def __init__(self, name: str = "healthy") -> None:
+        self.name = name
+        self.frames: list[dict] = []
+        self.got_frame = threading.Event()
+        self.closed = False
+
+    def write(self, obj: dict) -> bool:
+        self.frames.append(obj)
+        self.got_frame.set()
+        return True
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class _ThreadRecordingPeer:
+    """A healthy peer that records which thread each of its writes ran on."""
+
+    def __init__(self, name: str = "peer") -> None:
+        self.name = name
+        self.frames: list[dict] = []
+        self.threads: list[threading.Thread] = []
+        self.closed = False
+
+    def write(self, obj: dict) -> bool:
+        self.threads.append(threading.current_thread())
+        self.frames.append(obj)
+        return True
+
+    def close(self) -> None:
+        self.closed = True
+
+
+def _healthy_peer_is_not_held_behind(slow_first: bool) -> None:
+    """One wedged peer, one healthy peer, one ``write`` from a worker thread.
+
+    The healthy peer must hold the frame while the wedged peer is still parked
+    inside its own write. Asserted for both list orders so the fix cannot be a
+    special case that only ever hurries the first (or the last) peer along.
+    """
+    slow = _SlowPeer()
+    healthy = _SignallingPeer()
+    peers = (slow, healthy) if slow_first else (healthy, slow)
+    fanout = FanoutTransport(*peers)
+    frame = {"jsonrpc": "2.0", "method": "event", "params": {"type": "message.complete"}}
+
+    returned = threading.Event()
+    result: dict = {}
+
+    def emit() -> None:
+        try:
+            result["ok"] = fanout.write(frame)
+        finally:
+            returned.set()
+
+    # Emit from a worker thread, which is where the gateway's event writes come
+    # from: ``handle_ws`` runs ``server.dispatch`` on ``asyncio.to_thread``.
+    worker = threading.Thread(target=emit, name="fanout-emitter", daemon=True)
+    worker.start()
+    try:
+        assert slow.entered.wait(timeout=2.0), "the wedged peer never got the frame"
+        assert healthy.got_frame.wait(timeout=2.0), (
+            "the healthy peer did not get the frame while a wedged peer held its "
+            "write open — the fan-out is still serial"
+        )
+        assert healthy.frames == [frame]
+        assert slow.frames == []
+    finally:
+        slow.release.set()
+        assert returned.wait(timeout=5.0), "the fan-out write never returned"
+        worker.join(timeout=5.0)
+
+    # The fan-out still collects: the wedged peer's frame landed before the
+    # call returned, and both peers stay attached.
+    assert slow.frames == [frame]
+    assert result["ok"] is True
+    assert fanout.transports() == [*peers]
+
+
+def test_a_wedged_peer_does_not_hold_the_frame_from_a_healthy_peer_behind_it():
+    _healthy_peer_is_not_held_behind(slow_first=True)
+
+
+def test_a_wedged_peer_does_not_hold_the_frame_from_a_healthy_peer_ahead_of_it():
+    _healthy_peer_is_not_held_behind(slow_first=False)
+
+
+def test_a_write_from_inside_an_event_loop_stays_on_the_loop_thread():
+    """The deadlock the concurrent path must never introduce.
+
+    ``WSTransport.write`` fires and forgets when it can see it is running on
+    its own loop, and BLOCKS on ``fut.result`` when it cannot. Hand a
+    loop-thread write to a pool thread and that pool thread takes the blocking
+    path, waiting on a loop that is itself waiting on the pool — the whole
+    gateway stalls for the write timeout. So an on-loop caller stays inline.
+    """
+    a, b = _ThreadRecordingPeer("a"), _ThreadRecordingPeer("b")
+    fanout = FanoutTransport(a, b)
+    frame = {"params": {"type": "message.complete"}}
+    outcome: dict = {}
+
+    async def emit() -> None:
+        outcome["loop_thread"] = threading.current_thread()
+        outcome["ok"] = fanout.write(frame)
+
+    # Driven from a side thread with a bounded join so a real deadlock fails
+    # this test instead of hanging the run.
+    runner = threading.Thread(target=lambda: asyncio.run(emit()), daemon=True)
+    runner.start()
+    runner.join(timeout=5.0)
+    assert not runner.is_alive(), "fan-out write from the event loop did not return"
+
+    assert outcome["ok"] is True
+    assert a.frames == [frame] and b.frames == [frame]
+    assert a.threads == [outcome["loop_thread"]]
+    assert b.threads == [outcome["loop_thread"]]
+
+
+def test_a_lone_peer_is_written_on_the_calling_thread():
+    """Single-client sessions keep the exact behaviour they had before."""
+    only = _ThreadRecordingPeer("only")
+    fanout = FanoutTransport(only)
+
+    frame = {"params": {"type": "message.complete"}}
+    assert fanout.write(frame) is True
+
+    assert only.frames == [frame]
+    assert only.threads == [threading.current_thread()]
+
+
+def test_the_concurrent_path_prunes_dead_peers_and_still_delivers():
+    """Pruning is unchanged: ``False`` and a raise both detach the peer."""
+    gone = _FakeClient("gone", ok=False)
+    wedged = _FakeClient("wedged", boom=True)
+    healthy = _FakeClient("healthy")
+    fanout = FanoutTransport(gone, wedged, healthy)
+
+    frame = {"params": {"type": "message.complete"}}
+    assert fanout.write(frame) is True
+
+    assert healthy.frames == [frame]
+    assert fanout.transports() == [healthy]
+
+
+def test_the_concurrent_path_reports_peer_gone_when_every_peer_is_dead():
+    gone = _FakeClient("gone", ok=False)
+    wedged = _FakeClient("wedged", boom=True)
+    fanout = FanoutTransport(gone, wedged)
+
+    assert fanout.write({"params": {"type": "message.complete"}}) is False
+    assert fanout.transports() == []
+
+
+def test_consecutive_frames_reach_every_peer_in_order():
+    """The fan-out collects before returning, so frame A is on every peer
+    before frame B is dispatched to any of them."""
+    a, b = _ThreadRecordingPeer("a"), _ThreadRecordingPeer("b")
+    fanout = FanoutTransport(a, b)
+    first = {"params": {"type": "message.delta", "text": "1"}}
+    second = {"params": {"type": "message.complete"}}
+
+    assert fanout.write(first) is True
+    # Collect-before-return: nothing is still in flight when write() answers.
+    assert a.frames == [first] and b.frames == [first]
+
+    assert fanout.write(second) is True
+    assert a.frames == [first, second]
+    assert b.frames == [first, second]
+
+
+def test_a_peer_that_misses_the_deadline_is_kept_and_counts_as_delivered(monkeypatch):
+    """Slow is not dead.
+
+    A peer still writing when the fan-out deadline expires stays attached and
+    the frame counts as in flight — which is what ``WSTransport.write`` itself
+    reports when its own write times out. Here it is the ONLY live peer, so the
+    ``True`` return rests entirely on it.
+    """
+    from tui_gateway import transport as transport_module
+
+    monkeypatch.setattr(transport_module, "_FANOUT_WRITE_DEADLINE_S", 0.05)
+
+    slow = _SlowPeer()
+    gone = _FakeClient("gone", ok=False)
+    fanout = FanoutTransport(slow, gone)
+    frame = {"params": {"type": "message.complete"}}
+
+    assert fanout.write(frame) is True
+    # The dead peer is pruned; the slow one is not.
+    assert fanout.transports() == [slow]
+    assert slow.frames == []
+
+    slow.release.set()

--- a/tui_gateway/methods_browser_control.py
+++ b/tui_gateway/methods_browser_control.py
@@ -3,10 +3,12 @@
 The controller extension registers over the authenticated ``/api/ws`` gateway. Everything
 binds to the SERVER-MINTED identity (``WSTransport.auth_identity``, stamped from the single-use
 ticket); a client-supplied ``principal_id`` is ignored and replaced by a digest of it. Broker
-frames are re-enveloped as Gateway ``event`` frames; ``result`` resolves a command only on the
-owning transport for the exact attached scope (the broker's exact-scope ``complete`` is the
-backstop). Capabilities come from the broker's explicit allowlist (no raw CDP/eval/uploads).
-Bodies are rebound onto server.py's globals (bind_module publishes this module's helpers too).
+frames are re-enveloped as Gateway ``event`` frames; ``result`` resolves a command only when the
+request arrives on a transport ATTACHED to the session and that transport is the broker-recorded
+owner of the exact attached scope (the broker's exact-scope ``complete`` is the backstop).
+Capabilities come from the broker's explicit allowlist (no raw CDP/eval/uploads). Bodies are
+rebound onto server.py's globals (bind_module publishes this module's helpers too), which is how
+the session gate reaches ``_session_transport_contains`` with no import of its own.
 """
 
 from __future__ import annotations
@@ -81,9 +83,10 @@ def _controller_method(
     """Register a handler behind the shared fail-closed (4403) controller gates.
 
     Order: ``precheck(rid, params)`` (may return an error envelope) → caller holds a
-    server-authenticated, non-internal identity → the named session exists and its
-    ``transport`` is exactly the caller → when ``lookup_scope``, a scope is attached for
-    this session/principal/family and the caller owns it. Then
+    server-authenticated, non-internal identity → the named session exists and the caller is
+    ATTACHED to it, directly or through the ``FanoutTransport`` a mirrored session holds in its
+    slot → when ``lookup_scope``, a scope is attached for this session/principal/family and the
+    caller owns it. Then
     ``fn(rid, params, transport, identity, session_id, broker, scope, session)`` runs.
     """
 
@@ -102,7 +105,11 @@ def _controller_method(
             session_id = str(params.get("session_id") or "")
             with _sessions_lock:
                 session = _sessions.get(session_id)
-                if session is None or session.get("transport") is not transport:
+                # Membership, not slot identity: a mirrored session holds a FanoutTransport, which is
+                # identical to no peer's transport, so slot identity would refuse every client here — the
+                # peer that registered the controller included. The broker's is_owner check below still
+                # keys on the transport that attached the scope.
+                if not _session_transport_contains(session, transport):
                     return _err(rid, _ERR_FORBIDDEN, "session is not owned by this transport")
             broker = browser_control_broker.get_browser_control_broker()
             scope = None
@@ -190,7 +197,11 @@ def _(rid, params: dict, _transport, _identity, _session_id, broker, scope, _ses
 
 @_controller_method("browser.controller.heartbeat")
 def _(rid, params: dict, *_gate) -> dict:
-    """Acknowledge a heartbeat only for this transport's attached controller."""
+    """Acknowledge a heartbeat only for this transport's own attached controller.
+
+    The session gate admits any client attached to the session, including a fan-out peer; the
+    broker's ``is_owner`` check then narrows the answer to the transport that actually registered
+    the controller."""
     return _ok(rid, {"ok": True})
 
 

--- a/tui_gateway/methods_prompt.py
+++ b/tui_gateway/methods_prompt.py
@@ -572,10 +572,12 @@ def _(rid, params: dict) -> dict:
     turn_isolation = _session_uses_compute_host(session, _load_dashboard_process_isolation_config())
     if internal_hosted_submit and turn_isolation:
         return _err(rid, 4121, "hosted room turns do not support isolated compute workers yet")
-    # Re-bind to the current transport: streaming must stay on the active websocket even
-    # if a disconnect/fallback moved the session to stdio.
+    # Attach the current transport: streaming must stay on the active websocket even if a
+    # disconnect/fallback moved the session to stdio — and, since it attaches rather than rebinds,
+    # a second client submitting a prompt no longer cuts the first client out of the session it is
+    # watching.
     if (t := current_transport()) is not None:
-        session["transport"] = t
+        _attach_session_transport(session, t)
     # Claim the turn against a possibly-running session (busy/queued reply, else fall
     # through once ``running`` is observed False).  The provider interrupt happens after
     # history_lock is released (a non-interruptible tool may hold it); if the old turn

--- a/tui_gateway/methods_session.py
+++ b/tui_gateway/methods_session.py
@@ -519,18 +519,21 @@ def _find_live_unpersisted(needle: str, home) -> str:
 
 def _resume_live_unpersisted(ctx: _Resume, live_sid: str, live: dict) -> dict:
     """Reattach a LIVE lazy session with no state.db row yet (every fresh Bot Chat; a 404 here killed messaging
-    for never-spoken bots). Rebind the transport and cancel the armed orphan-reap Timer (a WS drop may have
+    for never-spoken bots). Attach the transport and cancel the armed orphan-reap Timer (a WS drop may have
     sentinel-parked the record) or it fires against this client."""
     if ctx.owns_db:
         _release_db(ctx.db)
     live["last_active"] = time.time()
     if (transport := current_transport()) is not None:
         # This resume reattaches the live record. A lazy session (no state.db row yet — every fresh Bot
-        # Chat) that was sentinel-parked by a WS drop MUST be rebound here, or it keeps the drop sentinel
+        # Chat) that was sentinel-parked by a WS drop MUST be reattached here, or it keeps the drop sentinel
         # and the armed orphan-reap Timer fires against a client that is attached right now — the
         # unpersisted sibling of the storm-killer paths (#91276).
         with live.setdefault("history_lock", threading.Lock()):
-            live["transport"] = transport
+            # Attach additively so a second client resuming this live record does not steal the stream
+            # from the one already attached; attaching a live transport also un-parks a sentinel slot,
+            # which is what #91276 needed here.
+            _attach_session_transport(live, transport)
             live.setdefault("viewers", {})[transport] = time.time()
     _cancel_ws_orphan_reap(live_sid)
     history = live.get("history") or []
@@ -629,7 +632,8 @@ def _resume_guard(ctx: _Resume) -> dict | None:
 
 def _resume_reuse_live(ctx: _Resume, sid: str, session: dict) -> dict:
     """Reattach an already-live session under the resume lock (held across the client-gone check,
-    transport rebind and reap cancel so grace expiry is atomic)."""
+    transport attach and reap cancel so grace expiry is atomic). _live_session_payload ATTACHES this
+    caller alongside the client(s) already streaming instead of taking the slot from them."""
     with _session_resume_lock:
         if _sessions.get(sid) is not session:
             return _err(ctx.rid, 4007, "session no longer live; retry resume")
@@ -889,7 +893,10 @@ def _(rid, params: dict) -> dict:
 
 @_session_method("session.activate")
 def _(rid, params: dict, session: dict) -> dict:
-    """Attach the frontend to a live TUI session without closing the previously focused one."""
+    """Attach the frontend to a live TUI session without closing the previously focused one.
+
+    _live_session_payload ATTACHES this caller to the session rather than rebinding it, so activating a
+    session someone else is already streaming mirrors it instead of stealing it."""
     return _ok(rid, _live_session_payload(
         str(params.get("session_id") or ""), session, touch=True, transport=current_transport() or _stdio_transport,
         omit_messages=is_truthy_value(params.get("omit_messages", False))))

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -914,16 +914,20 @@ def handle_request(req: dict) -> dict | None:
 
 def _current_session_steer_authority(session_id: str) -> tuple[Transport | None, dict | None]:
     """Unforgeable steering authority for this RPC context: the public session id is only a lookup
-    hint; authority is the identity of BOTH the ContextVar-bound transport and the live in-memory
-    record under that id, so transport rebinding, removal or id reuse invalidates an earlier generation."""
+    hint; authority requires the ContextVar-bound transport to be ATTACHED to the live in-memory record
+    under that id, so transport detachment, session removal or id reuse invalidates an earlier generation."""
     transport = current_transport()
     if transport is None or not session_id:
         return None, None
     expected_session = _current_runtime_session_record.get()
     with _sessions_lock:
         session = _sessions.get(session_id)
+        # Membership, not slot identity: a mirrored session stores a FanoutTransport in the slot, so slot
+        # identity alone would reject every client, the peer that commissioned the subagent included.
+        # Authority is membership in the slot, which also grants it to any client attached to mirror the
+        # session (see tests/tui_gateway/test_multi_client_fanout.py).
         if (session is None or (expected_session is not None and session is not expected_session)
-                or session.get("transport") is not transport):
+                or not _session_transport_contains(session, transport)):
             return None, None
         return transport, session
 

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -34,7 +34,8 @@ from agent.conversation_loop import INTERRUPT_WAITING_FOR_MODEL_PREFIX  # noqa: 
 from tui_gateway import git_probe
 from tui_gateway._env import env_float, env_int
 from tui_gateway.turn_marker import clear_turn_marker, read_turn_marker, record_turn_start  # noqa: F401
-from tui_gateway.transport import (StdioTransport, Transport, bind_transport, current_transport, reset_transport)
+from tui_gateway.transport import (FanoutTransport, StdioTransport, Transport, bind_transport,
+                                   current_transport, reset_transport)
 
 logger = logging.getLogger(__name__)
 
@@ -207,6 +208,180 @@ _stdio_transport = StdioTransport(lambda: _real_stdout, _stdout_lock)
 # Detached websocket sessions use a drop sink instead of stdio: Desktop embeds the gateway in-process
 # and captures stdout into logs, so stale frames must not fall through while a session awaits resume/reap.
 _detached_ws_transport = _DropTransport()
+
+
+# ── multi-client fan-out ─────────────────────────────────────────────────────
+#
+# A session's ``transport`` slot holds either ONE transport — the historical,
+# single-client shape, byte-identical to pre-fan-out behaviour — or a
+# ``FanoutTransport`` wrapping several. Because the fan-out satisfies the same
+# Transport protocol, ``write_json`` and every other reader of the slot are
+# untouched; only the attach/detach ladder below knows the difference.
+#
+# ``_session_transport_lock`` serializes the read-modify-write of that one slot.
+# It is a LEAF lock: nothing under it acquires ``_sessions_lock`` or a session's
+# ``history_lock`` (the fan-out's own lock is likewise a leaf), so it is safe to
+# take while holding either of those.
+_session_transport_lock = threading.Lock()
+
+
+def _transport_is_live_peer(transport) -> bool:
+    """True when *transport* is a real, currently attached client.
+
+    Excluded: the parked drop sentinel (by definition clientless) and stdio,
+    which is the process-wide fallback sink — a standalone ``hermes --tui``
+    writes there, but nothing "attaches" to it and a second client can never
+    share it.
+    """
+    if transport is None:
+        return False
+    if transport is _detached_ws_transport or transport is _stdio_transport:
+        return False
+    if isinstance(transport, (_DropTransport, StdioTransport)):
+        return False
+    # A socket that already latched ``_closed`` is a departed client, not a live
+    # peer: without this, a stale WSTransport keeps a session out of the park /
+    # reap path and keeps answering "another client is still here".
+    # ``_transport_is_dead`` is the deadness predicate this module shares with
+    # the reaper (defined in ``session_reaper``, published onto this namespace
+    # by ``method_ctx.bind_module``; module globals resolve at call time).
+    return not _transport_is_dead(transport)
+
+
+def _session_transport_contains(session: dict | None, transport) -> bool:
+    """True when *transport* is attached to *session*, directly or via fan-out."""
+    if not session or transport is None:
+        return False
+    existing = session.get("transport")
+    if existing is transport:
+        return True
+    if isinstance(existing, FanoutTransport):
+        return existing.contains(transport)
+    return False
+
+
+def _session_live_transports(session: dict | None) -> list:
+    """Every live client attached to *session* (empty for a parked/stdio slot)."""
+    existing = (session or {}).get("transport")
+    if isinstance(existing, FanoutTransport):
+        return [t for t in existing.transports() if _transport_is_live_peer(t)]
+    return [existing] if _transport_is_live_peer(existing) else []
+
+
+def _session_has_live_transport(session: dict | None, *, excluding=None) -> bool:
+    """True when *session* still has a live client attached, ignoring *excluding*.
+
+    ``excluding`` answers whether another live client remains once one peer is
+    ignored, which is what the detach and orphan paths need: whether anything
+    survives the departing transport.
+    """
+    return any(t is not excluding for t in _session_live_transports(session))
+
+
+def _attach_session_transport(session: dict | None, transport) -> bool:
+    """Attach *transport* to *session* ADDITIVELY — never steal the slot.
+
+    A ``FanoutTransport`` argument is FLATTENED before the ladder runs, whatever
+    the slot holds: each of its peers is attached as a leaf, so the slot never
+    nests one fan-out inside another. The queued-prompt paths make that
+    reachable — a busy submit records ``session["transport"]`` as the prompt's
+    transport, which is the fan-out itself when two clients are attached, and
+    the drain hands it back here after a disconnect has collapsed the slot to a
+    single client. Nesting would blind every single-level reader of the slot
+    (``FanoutTransport.contains``, the steer-authority scan, detach) to the
+    inner peers, so a client inside the inner fan-out could never be found,
+    parked, reaped, or granted authority over its own turn.
+
+    The ladder, for the leaf newcomer that always reaches it:
+
+    * same object already in the slot → no-op;
+    * the slot already fans out → attach into it;
+    * the slot is empty / stdio / the parked drop sentinel → take the slot,
+      which is exactly what the old rebind did;
+    * otherwise → wrap the incumbent and the newcomer in a ``FanoutTransport``
+      so both clients keep streaming.
+
+    A non-peer newcomer (stdio, drop sentinel) never displaces a live client:
+    an activate/resume dispatched without a bound websocket must not silence the
+    socket that owns the session.
+
+    Returns ``True`` when *transport* is attached afterwards.
+    """
+    if not session or transport is None:
+        return False
+    if isinstance(transport, FanoutTransport):
+        # Flatten OUTSIDE the lock — _session_transport_lock is not reentrant.
+        # Each peer then walks the ladder on its own, so a peer whose socket
+        # died while the prompt sat in the queue is dropped by the liveness rung
+        # instead of being pinned back into the slot.
+        attached = False
+        for peer in transport.transports():
+            if _attach_session_transport(session, peer):
+                attached = True
+        return attached
+    with _session_transport_lock:
+        existing = session.get("transport")
+        if existing is transport:
+            return True
+        if isinstance(existing, FanoutTransport):
+            if isinstance(transport, FanoutTransport):
+                for member in transport.transports():
+                    existing.attach(member)
+            else:
+                existing.attach(transport)
+            return True
+        if not _transport_is_live_peer(transport):
+            if _transport_is_live_peer(existing):
+                return False
+            session["transport"] = transport
+            return True
+        if not _transport_is_live_peer(existing):
+            session["transport"] = transport
+            return True
+        session["transport"] = FanoutTransport(existing, transport)
+        return True
+
+
+def _detach_session_transport(session: dict | None, transport) -> bool:
+    """Detach *transport* from *session*'s slot.
+
+    Returns ``True`` when a live client OTHER than *transport* remains — i.e.
+    the session must keep streaming and must NOT be parked or reaped. A
+    single-client session leaves the departing transport in the slot, exactly as
+    before fan-out existed; its caller parks the drop sentinel over it.
+    """
+    if not session:
+        return False
+    with _session_transport_lock:
+        existing = session.get("transport")
+        if isinstance(existing, FanoutTransport):
+            existing.detach(transport)
+            remaining = existing.transports()
+            if len(remaining) == 1:
+                # Collapse: a session back down to one client is indistinguishable
+                # from one that never fanned out.
+                session["transport"] = remaining[0]
+    return _session_has_live_transport(session, excluding=transport)
+
+
+def _detach_transport_from_sessions(transport) -> list[tuple[str, dict]]:
+    """Detach *transport* from every session holding it.
+
+    Returns the ``(sid, session)`` pairs left with NO live client — the ones the
+    disconnect path must park or reap. Sessions that retain another attached
+    client keep streaming and are not returned.
+    """
+    with _sessions_lock:
+        attached = [
+            (sid, s)
+            for sid, s in _sessions.items()
+            if _session_transport_contains(s, transport)
+        ]
+    return [
+        (sid, session)
+        for sid, session in attached
+        if not _detach_session_transport(session, transport)
+    ]
 
 
 def _prepend_tool_paths(env: dict[str, str]) -> dict[str, str]:
@@ -2693,9 +2868,12 @@ def _live_session_payload(
         if cols is not None:
             session["cols"] = cols
         if transport is not None:
-            session["transport"] = transport
-            # Every transport that showed this session (pop-outs resume the same sid); on disconnect the last
-            # viewer becomes the transport instead of the drop sentinel.
+            # Resume/activate of a LIVE session ATTACHES the caller alongside whoever is already streaming
+            # instead of rebinding the slot — the old rebind is what made a second client steal the stream.
+            _attach_session_transport(session, transport)
+            # Every transport that showed this session (pop-outs resume the same sid). Fan-out membership now
+            # carries the surviving-window case the disconnect path used this for; the registry is still
+            # written and still pruned on disconnect.
             session.setdefault("viewers", {})[transport] = time.time()
             # See #83716.
             if transport is not _detached_ws_transport:

--- a/tui_gateway/session_auto_continue.py
+++ b/tui_gateway/session_auto_continue.py
@@ -285,11 +285,13 @@ def _drain_queued_prompt(rid, sid: str, session: dict) -> bool:
         queue_generation = int(session.get("_queued_prompt_generation", 0))
         _ac_set_queue(session, session.get("queued_prompts") or [])
         session["running"] = True
-        if queued.get("transport") is not None:
-            # The queuer's transport is pinned so the drained turn reaches the client that sent it — but
-            # ATTACHED, not rebound: a mid-turn prompt from a second client used to silence the first for the
-            # whole drained turn.
-            _attach_session_transport(session, queued["transport"])
+        queued_transport = queued.get("transport")
+        # The queuer's transport is pinned so the drained turn reaches the client that sent it — but
+        # ATTACHED, not rebound: a mid-turn prompt from a second client used to silence the first for the
+        # whole drained turn. A peer that disconnected while its prompt sat in the queue is skipped: the
+        # prompt still runs, only the dead pin is dropped.
+        if queued_transport is not None and not _transport_is_dead(queued_transport):
+            _attach_session_transport(session, queued_transport)
     use_compute_host = _session_uses_compute_host(session)
     with session["history_lock"]:
         if int(session.get("_queued_prompt_generation", 0)) != queue_generation:

--- a/tui_gateway/session_auto_continue.py
+++ b/tui_gateway/session_auto_continue.py
@@ -286,7 +286,10 @@ def _drain_queued_prompt(rid, sid: str, session: dict) -> bool:
         _ac_set_queue(session, session.get("queued_prompts") or [])
         session["running"] = True
         if queued.get("transport") is not None:
-            session["transport"] = queued["transport"]
+            # The queuer's transport is pinned so the drained turn reaches the client that sent it — but
+            # ATTACHED, not rebound: a mid-turn prompt from a second client used to silence the first for the
+            # whole drained turn.
+            _attach_session_transport(session, queued["transport"])
     use_compute_host = _session_uses_compute_host(session)
     with session["history_lock"]:
         if int(session.get("_queued_prompt_generation", 0)) != queue_generation:

--- a/tui_gateway/session_lifecycle.py
+++ b/tui_gateway/session_lifecycle.py
@@ -536,39 +536,45 @@ def _schedule_ws_orphan_reap(sid: str, *, delay_s: float | None = None) -> None:
 def _close_sessions_for_transport(transport, *, end_reason: str = "ws_disconnect") -> tuple[int, int]:
     """Single WS-disconnect teardown entry point: reap close_on_disconnect sessions (sidecar/dashboard) immediately;
     re-point the rest at the detached transport (later emits miss the dead socket) for the grace-windowed WS-orphan
-    reaper. Returns ``(reaped, detached)`` counts."""
-    with _sessions_lock:
-        owned = [(sid, s) for sid, s in _sessions.items() if s.get("transport") is transport]
+    reaper. Returns ``(reaped, detached)`` counts.
+
+    Multi-client fan-out: the departing transport is DETACHED from every session first. A session that still has
+    another client attached keeps streaming and is neither parked nor reaped — a watcher leaving must not end the
+    turn the remaining client is reading. Only the sessions left clientless take the historical
+    close_on_disconnect / park-sentinel path, so a single-client disconnect behaves exactly as it always has."""
+    clientless = _detach_transport_from_sessions(transport)
     reaped = detached = 0
-    for sid, session in owned:
+    for sid, session in clientless:
         claimed_for_teardown = None
         should_schedule_reap = False
-        # session.resume fast-path rebinds under _session_resume_lock: take it so a reconnect can't move the transport
-        # between check and claim.
+        # session.resume fast-path attaches under _session_resume_lock: take it so a reconnect can't attach
+        # between the detach above and the claim.
         with _session_resume_lock, _sessions_lock:
             current = _sessions.get(sid)
             if current is not session:
                 continue
-            if current.get("transport") is not transport:
-                # The reconnect owns this session now; drop only the old viewer registration.
-                (current.get("viewers") or {}).pop(transport, None)
-                continue
+            # Prune the departing viewer registration in every branch; it must not affect the new owner.
+            (current.get("viewers") or {}).pop(transport, None)
+            # Revalidate before claiming (#77129, kept under fan-out): between _detach_transport_from_sessions
+            # returning this session as clientless and this claim, a concurrent session.resume can attach a NEW
+            # live transport. Tearing the session down, or parking the sentinel over it, would knock an attached
+            # client into detached state and arm an orphan reap against a session that has a live owner. Attach
+            # and detach both serialize on _session_transport_lock, so this check is race-free against them; that
+            # lock is a leaf, so taking it under _sessions_lock is safe and _session_has_live_transport does not
+            # re-acquire it.
+            with _session_transport_lock:
+                if _session_has_live_transport(current, excluding=transport):
+                    continue
             if current.get("close_on_disconnect"):
                 claimed_for_teardown = _pop_session_by_id(sid)
             else:
                 # Point at the drop sentinel (NOT real stdio) so _ws_session_is_orphaned recognizes it; standalone
-                # `hermes --tui` keeps real _stdio. UNLESS another window (pop-out viewer) still shows the session:
-                # re-bind to the most recent surviving viewer instead.
-                viewers = current.get("viewers") or {}
-                # See #83716.
-                viewers.pop(transport, None)
-                live = [vt for vt, ts in sorted(viewers.items(), key=lambda kv: kv[1]) if not _transport_is_dead(vt)]
-                if live:
-                    current["transport"] = live[-1]
-                else:
-                    current["transport"] = _detached_ws_transport
-                    current.pop("_client_gone_interrupt_requested", None)
-                    should_schedule_reap = True
+                # `hermes --tui` keeps real _stdio. The #83716 rebind-to-surviving-viewer is subsumed by fan-out
+                # membership: a pop-out window is a fan-out peer, so a session that still shows in another window
+                # is never returned here as clientless.
+                current["transport"] = _detached_ws_transport
+                current.pop("_client_gone_interrupt_requested", None)
+                should_schedule_reap = True
         if claimed_for_teardown is not None:
             reaped += _teardown_popped_session(claimed_for_teardown, end_reason=end_reason)
         elif should_schedule_reap:

--- a/tui_gateway/session_reaper.py
+++ b/tui_gateway/session_reaper.py
@@ -133,7 +133,18 @@ def install_exit_flush_signal_handlers() -> bool:
 def _transport_is_dead(transport) -> bool:
     # _detached_ws_transport is the post-disconnect drop sentinel. _stdio_transport is the REAL transport for
     # standalone `hermes --tui` and must NOT count as dead.
-    return transport is _detached_ws_transport or getattr(transport, "_closed", None) is True
+    if transport is _detached_ws_transport:
+        return True
+    if isinstance(transport, FanoutTransport):
+        # A fan-out is never the sentinel and has no ``_closed`` of its own, so without this arm every
+        # multi-client session reads as alive forever — the TTL reaper, the LRU cap and the #77129 disconnect
+        # revalidation all gate on this predicate. A fan-out can legitimately end up empty, or holding nothing
+        # but closed sockets, with no disconnect passing through _close_sessions_for_transport: a failed write
+        # prunes the peer that failed. It is dead exactly when no peer of its own is alive, and an empty one is
+        # dead. Peers are always leaf transports (attach flattens a fan-out argument instead of nesting it), so
+        # this recurses one level at most.
+        return all(_transport_is_dead(peer) for peer in transport.transports())
+    return getattr(transport, "_closed", None) is True
 
 
 def _session_is_lru_evictable(sid: str, session: dict) -> bool:

--- a/tui_gateway/transport.py
+++ b/tui_gateway/transport.py
@@ -9,6 +9,8 @@ A :class:`Transport` forwards a JSON-serialisable dict to its peer, so one dispa
 
 from __future__ import annotations
 
+import asyncio
+import concurrent.futures
 import contextlib
 import contextvars
 import errno
@@ -16,6 +18,7 @@ import json
 import logging
 import os
 import threading
+import time
 from typing import Any, Callable, Optional, Protocol, runtime_checkable
 
 # Errno values that mean "the peer is gone" rather than "the host has a real I/O problem". Anything
@@ -31,6 +34,64 @@ logger = logging.getLogger(__name__)
 # while the gateway still emits) flush can block long enough to starve the worker pool. Python text stdout is
 # fully buffered on a pipe, so this ONLY makes sense with ``-u``/``PYTHONUNBUFFERED=1``; otherwise the TUI hangs.
 _DISABLE_FLUSH = (os.environ.get("HERMES_TUI_GATEWAY_NO_FLUSH", "") or "").strip().lower() in {"1", "true", "yes", "on"}
+
+# Worker pool behind FanoutTransport.write.  A non-streaming WebSocket write
+# blocks the calling thread while the owning event loop flushes the frame — up
+# to ``tui_gateway.ws._WS_WRITE_TIMEOUT_S`` (10s) when that loop is stalled —
+# so walking a session's peers one at a time lets one wedged client hold the
+# frame back from every healthy client behind it.  The pool is created lazily
+# and only ever used when a session has more than one peer, so the ordinary
+# single-client gateway never starts a thread.
+#
+# Sizing: these workers are idle except while a peer is actually wedged, so the
+# cap only has to cover the wedged peers of all sessions at once.  If it were
+# ever saturated the excess writes queue and run in submission order, which is
+# the pre-pool behaviour — degraded, not broken.
+_FANOUT_POOL_MAX_WORKERS = 32
+
+# Wall-clock bound on ONE fan-out write, measured from before the first peer is
+# dispatched.  Deliberately larger than ``tui_gateway.ws._WS_WRITE_TIMEOUT_S``
+# (10.0) so a merely-slow peer reaches its own timeout and reports for itself;
+# this deadline only exists so a peer that never returns at all cannot pin the
+# emitting thread forever.  Not imported from ``tui_gateway.ws``: that module
+# imports ``tui_gateway.server``, which imports this one, so the import would
+# be circular.  Drift is harmless — a peer that misses this deadline is treated
+# as in-flight, not as dead (see ``FanoutTransport.write``).
+_FANOUT_WRITE_DEADLINE_S = 12.0
+
+_fanout_pool: "concurrent.futures.ThreadPoolExecutor | None" = None
+_fanout_pool_lock = threading.Lock()
+
+
+def _fanout_write_pool() -> "concurrent.futures.ThreadPoolExecutor":
+    """The shared fan-out pool, created on first multi-peer write."""
+    global _fanout_pool
+    pool = _fanout_pool
+    if pool is not None:
+        return pool
+    with _fanout_pool_lock:
+        if _fanout_pool is None:
+            _fanout_pool = concurrent.futures.ThreadPoolExecutor(
+                max_workers=_FANOUT_POOL_MAX_WORKERS,
+                thread_name_prefix="tui-fanout",
+            )
+        return _fanout_pool
+
+
+def _caller_is_on_event_loop() -> bool:
+    """True when the CALLING thread is running an asyncio event loop.
+
+    Mirrors the probe in ``tui_gateway.ws.WSTransport.write``, which takes a
+    fire-and-forget path when it can see it is on its own loop and a BLOCKING
+    ``fut.result`` path when it cannot.  ``FanoutTransport`` owns no loop and
+    its peers may sit on different ones, so the test here is the conservative
+    one: if this thread is running any loop at all, keep the peer writes on it.
+    """
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        return False
+    return True
 
 
 @runtime_checkable
@@ -113,6 +174,208 @@ class StdioTransport:
 
     def close(self) -> None:
         return None
+
+
+class FanoutTransport:
+    """Delivers one JSON frame to every client attached to a session.
+
+    A session's ``transport`` slot used to hold exactly one client, so every
+    ``prompt.submit`` / ``session.resume`` / ``session.activate`` / queued-prompt
+    drain REBOUND it and whichever client was there before went silent.  This
+    object goes in the same slot and satisfies the same :class:`Transport`
+    protocol, so ``server.write_json`` — and every other reader of that slot —
+    is unchanged; the only difference is that N clients receive the frame
+    instead of the most recent one.
+
+    Scope: this carries a session's ASYNC EVENT stream only.  Request/response
+    RPCs still answer on the request's context-bound transport
+    (``dispatch`` → ``current_transport()``), so a client only ever sees replies
+    to its own calls.
+
+    Peers are pruned on failure: a transport that returns ``False`` (peer gone)
+    or raises is dropped from the fan-out instead of being written to forever.
+    Pruning is about dead peers, not slow ones — a client that is merely wedged
+    is kept, and :meth:`write` runs the peer writes concurrently so its stall
+    stays its own.
+    """
+
+    __slots__ = ("_lock", "_transports")
+
+    def __init__(self, *transports: "Transport") -> None:
+        self._lock = threading.Lock()
+        self._transports: list["Transport"] = []
+        for transport in transports:
+            self.attach(transport)
+
+    def attach(self, transport: "Transport") -> bool:
+        """Add *transport*. Returns ``True`` when it was not already attached."""
+        if transport is None or transport is self:
+            return False
+        with self._lock:
+            for existing in self._transports:
+                if existing is transport:
+                    return False
+            self._transports.append(transport)
+            return True
+
+    def detach(self, transport: "Transport") -> bool:
+        """Remove *transport*. Returns ``True`` when it was attached."""
+        with self._lock:
+            for idx, existing in enumerate(self._transports):
+                if existing is transport:
+                    del self._transports[idx]
+                    return True
+        return False
+
+    def contains(self, transport: "Transport") -> bool:
+        with self._lock:
+            return any(existing is transport for existing in self._transports)
+
+    def transports(self) -> list["Transport"]:
+        """A snapshot of the attached transports (safe to iterate)."""
+        with self._lock:
+            return list(self._transports)
+
+    def has_transports(self, *, excluding: "Transport | None" = None) -> bool:
+        """True when any transport other than *excluding* is still attached."""
+        with self._lock:
+            return any(existing is not excluding for existing in self._transports)
+
+    @staticmethod
+    def _deliver(transport: "Transport", obj: dict, dead: list) -> bool:
+        """Write *obj* to one peer inline.  Records a dead peer in *dead*.
+
+        Returns ``True`` when the peer took the frame.
+        """
+        try:
+            ok = transport.write(obj)
+        except Exception:
+            logger.debug("fanout write failed; pruning peer", exc_info=True)
+            dead.append(transport)
+            return False
+        if ok:
+            return True
+        dead.append(transport)
+        return False
+
+    def write(self, obj: dict) -> bool:
+        """Deliver *obj* to every attached transport.
+
+        Iterates a SNAPSHOT and never holds the lock across a peer write, so a
+        peer write can never block an attach or a detach.
+
+        With more than one peer the writes run CONCURRENTLY: every peer but one
+        is handed to a shared worker pool and the last runs on the calling
+        thread, which is going to block here anyway.  Serial delivery would let
+        a client wedged for the full WS write timeout hold the frame back from
+        every healthy client behind it in the list; this way each peer's stall
+        is its own.  Two cases stay inline:
+
+        * exactly one peer, so a single-client session is untouched;
+        * a caller already running on an event loop.  ``WSTransport.write``
+          fires and forgets when it sees its own loop and BLOCKS on
+          ``fut.result`` when it does not, so moving a loop-thread write onto a
+          pool thread would make that thread wait on the loop it just left
+          while the loop waits on it — a full write-timeout freeze.
+
+        Pruning is unchanged: a peer that returns ``False`` or raises is
+        detached, whichever path it took.  A peer that has not answered by
+        ``_FANOUT_WRITE_DEADLINE_S`` is NOT pruned — slow is not dead — and
+        counts as delivered, which is what ``WSTransport.write`` itself reports
+        when its own write times out: the frame is queued on that peer's loop
+        and flushes when the loop breathes.  If that peer really is gone, its
+        next write returns ``False`` promptly and prunes it then.
+
+        The collect happens before the return, so frame A is on every peer that
+        answered within the deadline before frame B is dispatched to any of
+        them.  A peer whose write was still queued on the pool when the deadline
+        passed is the exception: the next frame can reach that peer's own
+        ``_token_lock`` while the previous one is still waiting for it, and the
+        lock — not this method — decides the order they land in.  Within a peer,
+        ordering is that peer's own business (``WSTransport`` queues under its
+        token lock, ``StdioTransport`` writes under its stream lock);
+        ``server.write_json`` takes no lock, so concurrent emitters interleave
+        here exactly as they already did.
+
+        Returns ``True`` when at least one client accepted the frame or still
+        has it in flight — an all-dead fan-out reports peer-gone exactly like a
+        single dead transport would.
+        """
+        targets = self.transports()
+        if not targets:
+            return False
+
+        dead: list["Transport"] = []
+        delivered = False
+
+        if len(targets) == 1 or _caller_is_on_event_loop():
+            for transport in targets:
+                if self._deliver(transport, obj, dead):
+                    delivered = True
+            for transport in dead:
+                self.detach(transport)
+            return delivered
+
+        deadline = time.monotonic() + _FANOUT_WRITE_DEADLINE_S
+        pool = _fanout_write_pool()
+        dispatched: list[tuple["Transport", "concurrent.futures.Future | None"]] = []
+        for transport in targets[:-1]:
+            try:
+                dispatched.append((transport, pool.submit(transport.write, obj)))
+            except RuntimeError:
+                # Pool refused the work (interpreter shutting down).  Deliver
+                # inline below rather than dropping the frame.
+                dispatched.append((transport, None))
+
+        # The last peer runs here: one fewer worker per write, and a two-client
+        # session costs a single pool thread.
+        if self._deliver(targets[-1], obj, dead):
+            delivered = True
+
+        # One deadline for the whole batch, then read only the futures that
+        # finished.  Waiting first and calling ``result()`` on a settled future
+        # keeps our deadline distinguishable from a peer that raised: on 3.11+
+        # ``concurrent.futures.TimeoutError`` IS the builtin ``TimeoutError``,
+        # so a ``result(timeout=...)`` cannot tell the two apart.
+        futures = [fut for _, fut in dispatched if fut is not None]
+        if futures:
+            concurrent.futures.wait(
+                futures, timeout=max(0.0, deadline - time.monotonic())
+            )
+
+        for transport, fut in dispatched:
+            if fut is None:
+                if self._deliver(transport, obj, dead):
+                    delivered = True
+                continue
+            if not fut.done():
+                # Slow, not dead: leave it attached and count the frame as in
+                # flight.  Cancelling would not stop a write already running.
+                logger.warning(
+                    "fanout write still pending after %ss; peer left attached",
+                    _FANOUT_WRITE_DEADLINE_S,
+                )
+                delivered = True
+                continue
+            try:
+                ok = fut.result()
+            except Exception:
+                logger.debug("fanout write failed; pruning peer", exc_info=True)
+                dead.append(transport)
+                continue
+            if ok:
+                delivered = True
+            else:
+                dead.append(transport)
+
+        for transport in dead:
+            self.detach(transport)
+        return delivered
+
+    def close(self) -> None:
+        """Detach every peer. Does NOT close them — each owns its own socket."""
+        with self._lock:
+            self._transports = []
 
 
 class TeeTransport:


### PR DESCRIPTION
## What does this PR do?

0.21.0 made per-session submit exclusivity unconditional (`PER_SESSION_EXCLUSIVE_SUBMIT = True`, `hermes_cli/active_sessions.py:116` at `79445a496c`). This does not argue with that. Exclusivity decides which surface may run a turn and is enforced across processes through the lease registry; the transport slot this PR changes decides which connections a running turn's frames are written to, inside one gateway process. The refusal message gives the reason for exclusivity as "Only one surface at a time may run a session, because a second one would reason from a transcript that does not include the first one's work" (`hermes_cli/active_sessions.py:150-152`). Nothing here weakens that. What changes is that a surface which is not running the turn can watch it, instead of receiving nothing at all until it reloads history.

The transport fan-out here is a port of @OmarB97's #40822: `FanoutTransport`, the attach/detach ladder, and the invariant that RPC replies stay on the request-bound transport are all from that PR. This one extracts the backend half so it can land without the session-presence substrate #40822 is stacked on (#40814, still open, and carried whole inside #40822's own first commit). On top of that half it adds the queued-prompt drain rebind, the `subagent.steer` and browser-control authority checks that fan-out otherwise breaks, identity-based rather than equality-based membership, the lazy-resume rebind that #91276 added after this PR was first cut, and the disconnect-path reconciliation that goes with all of it: the #83716 rebind removed, the #77129 revalidation re-expressed under fan-out.

A session's `transport` slot holds exactly one client, and four paths rebind it to whoever called last: `_live_session_payload` (`tui_gateway/server.py:2696` at `79445a496c`), which is what `session.resume` and `session.activate` go through for a session that is already live; `prompt.submit` (`tui_gateway/methods_prompt.py:578`); the queued-prompt drain (`tui_gateway/session_auto_continue.py:289`); and the lazy resume of an unpersisted session (`tui_gateway/methods_session.py:533`), which is the site #91276 added. Opening a live session from a second client therefore takes the event stream away from the first. The first client stops receiving the turn it is already rendering, with no error and no signal that anything happened, and it stays silent through `message.complete`, so it never learns the turn ended. Either client disconnecting then parks the whole session on the drop sentinel, because the disconnect path matched sessions by slot identity.

`FanoutTransport` goes in that same slot and satisfies the same `Transport` protocol, so `write_json` and every other reader of the slot are unchanged. It delivers each frame to a snapshot of its peers. With more than one peer, and a caller that is not already running an event loop, the peer writes are dispatched to a small shared thread pool and collected under one deadline before `write` returns. The deadline is 12s, the 10s `WSTransport` write timeout plus a margin, so a peer that is merely slow reaches its own timeout and reports for itself. Two cases take a plain inline write: a fan-out with one peer, so a single-client session is untouched, and a caller already on a running event loop. On-loop has to stay inline because `WSTransport.write` skips its blocking `fut.result` only when it can see it is on its own loop, so a pool thread taking that write would sit waiting on the loop that dispatched it while the loop waits on the write. A peer is pruned only when it returns `False` or raises. Missing the deadline is not evidence of death: the peer stays attached and the frame counts as delivered, which is what `WSTransport.write` itself reports when its own write times out. Ordering holds for every peer that answers inside the deadline, because the collect happens before `write` returns, so frame A is on such a peer before frame B is dispatched to it; within a peer, `WSTransport` schedules inside its own `_token_lock`, and `write_json` takes no lock, so concurrent emitters interleave here exactly as they already did. The exception is a peer whose write was still queued on the pool when the deadline passed: the next frame can race it into that peer's `_token_lock`. That needs a stall longer than the deadline and a saturated pool, and the `write` docstring says so. This is not a fix for slowness. A dead client is dropped; a slow one now costs the emitting thread at most one write timeout per frame rather than one per peer. On the inline on-loop path, a peer bound to a different loop than the caller's would still block, which does not arise in a single-loop `hermes serve`. Request/response RPCs answered on the dispatcher thread are unaffected: they still answer on the request's context-bound transport, so a client only ever sees replies to its own calls. The turn thread is different, and unchanged by this diff in text but not in effect: `_run_prompt_submit` binds `session.get("transport")` as the turn's context transport, so once the slot holds a `FanoutTransport`, anything the turn thread writes through `current_transport()` rather than through `_emit` reaches every attached client, and a subagent commissioned from that turn captures the fan-out as its authority. That is the mirroring behaviour for turn output; it is stated here because the sentence before it would otherwise read as covering the turn thread too.

The four rebind sites become attach sites through `_attach_session_transport`, whose ladder leaves a single-client session behaving exactly as it did. The same object already in the slot is a no-op; an empty, stdio, or parked slot is taken outright, which is exactly what the old rebind did; only the arrival of a second live client wraps both. A non-peer newcomer such as stdio or the drop sentinel never displaces a live client, so an activate dispatched without a bound websocket cannot silence the socket that owns the session. On disconnect the departing transport is detached from every session holding it first: a session that retains another peer keeps streaming and is neither parked nor reaped, and only the clientless ones follow the existing `close_on_disconnect` and park-sentinel path. The #77129 revalidation before that claim is kept, re-expressed as a liveness check under `_session_transport_lock`, so a session that a concurrent resume has re-attached is spared both teardown and parking, as it is on `main`.

The #83716 rebind-to-the-most-recent-surviving-viewer is deleted rather than reconciled (`tui_gateway/session_lifecycle.py:562-567` at `79445a496c`). A surviving window is a fan-out peer, so the session is never returned as clientless and there is nothing left to rebind it to. The `viewers` registry itself stays: it is still written at both write sites and still pruned on disconnect, but after this change nothing reads it except its own prune, so removing it is offered as a follow-up rather than done here. One loose end that comes with keeping it: `_detach_session_transport` does not pop `viewers`, so a stale entry can survive for a session that keeps another peer. The one thing the rebind carried that membership does not is its dead-viewer filter, and that is preserved by `_transport_is_live_peer` ending in `not _transport_is_dead(transport)`, so a session whose only surviving peer is a `_closed` socket is parked and reaped as before. `_transport_is_dead` now also understands a `FanoutTransport`, reporting it dead when no peer of its own is alive, so an all-pruned fan-out cannot keep a session alive past the reapers.

The behavior of `session.resume` and `session.activate` changes by default, deliberately. There is no opt-in flag and no capability negotiation. The rebind is itself the reported data-loss bug, so a fix that has to be requested would not fix the reporter, whose client sends no new parameters. Clients that never had a second peer see no difference at all: with one client attached the slot holds the bare transport and every path behaves as it did before.

No entitlement check is performed on attach. Any peer that authenticated to this gateway may attach to, and therefore mirror, any live session. That is not a new exposure, since before this change the same peer could take the stream outright, but it should be stated rather than left implicit. If per-connection identity is wanted at attach time, the place for it is the four call sites named above, each of which has the request's transport in hand immediately before `_attach_session_transport`. Since this PR was first cut the ticket path has begun stamping a server-minted `{user_id, provider}` onto the connection (`hermes_cli/web_server_chat.py:247-254` at `79445a496c`), and it reaches the transport as `WSTransport.auth_identity` (`tui_gateway/ws.py:90`), so the identity half of such a check now exists. The other half does not: a session records no owner, so there is nothing on it to compare the connection against. Adding that is a larger change than this one and is not attempted here.

Known limitation, not fixed here: `tui_gateway/compute_host.py:262` and `:339` at `79445a496c` still assign the session's transport slot directly. A process-isolated session therefore has any fan-out in its slot overwritten by the host transport, and mirroring is defeated for that session. Converting those two sites reaches into the compute-host lifecycle, where the slot is being handed to a child process rather than shared between clients, so it is left for a follow-up rather than smuggled into this diff.

The second commit is a repair, not an addition. `subagent.steer` resolves authority by comparing the request's context-bound transport with the session's transport slot (`tui_gateway/server.py:751` at `79445a496c`). Once the slot holds a `FanoutTransport`, that comparison fails for every client, the peer that commissioned the subagent included, and every steer is rejected. The first commit alone would ship that regression, and no existing test catches it, because the steer suite exercises only single-client sessions. Commit 2 makes authority membership in the slot instead of identity of the slot.

That widens authority, and the widening is intentional: any client attached to a mirrored session can steer that session's subagents, not only the client that commissioned them. A mirrored session has no single owner in the slot to compare against, so membership is the available rule. Narrowing it back to the commissioning peer means recording that peer per subagent, which is a separate change; if a maintainer prefers that, it is a reasonable follow-up and this PR is a fine place to say so. The widened case is pinned by a test with a comment saying it is deliberate, so it cannot be quietly narrowed or quietly widened further.

The same commit converts the browser-control gate, which broke the same way. Since the decomposition, all four `browser.controller.*` handlers share one gate in the `_controller_method` decorator (`tui_gateway/methods_browser_control.py:105` at `79445a496c`), which compares the request's transport against the session's slot. Once the slot holds a `FanoutTransport` the gate refuses every client, the peer that registered the controller included, so `.register`, `.result`, `.heartbeat` and `.detach` all answer `session is not owned by this transport` on any mirrored session and browser control is unusable there. The gate now asks `_session_transport_contains`, the predicate the steer repair already introduced, which compares by identity first and only consults the fan-out when the slot actually holds one, so a single-client session is unchanged.

Only registration widens. `.result`, `.heartbeat` and `.detach` reach the broker's own owner check below the gate (`tui_gateway/methods_browser_control.py:117`, also at `79445a496c`), which compares `controller.owner is owner` against the transport recorded when the controller attached (`gateway/browser_control_broker.py:297-300`), so a mirrored peer that did not register is refused there instead, with `controller is not owned by this transport` rather than the session message. `browser.controller.register` runs the gate with `lookup_scope=False` and reaches no such check, so any client attached to a mirrored session may register a controller for that session. Two bounds remain. The scope's `principal_id` is a server-derived digest of the WS-authenticated identity and never an RPC parameter, so a peer authenticated as a different user lands in a different broker lane and is not cross-matched; and within one lane a different `controller_id` or `browser_profile_id` is a hard replacement (`gateway/browser_control_broker.py:240-261`), so a second registration terminalizes the first rather than producing two live controllers for one session.

## Related Issue

Addresses root cause 1 of #79064. That report has three root causes and this fixes one, so no closing keyword: root cause 2 is a client-side resubmission in `apps/desktop`, and root cause 3 asked for a server guard on non-empty truncation, which has substantially landed since the report.

Also reports this defect: #55564, which quotes the `prompt.submit` rebind directly.

Same area, in flight: #40822, the fan-out PR this is a port of, and #40814, the presence substrate it is stacked on and carries inside its own diff. If #40822 lands first, this PR should be closed or rebased down to the delta, which is the drain conversion, the steer and browser-control repairs, the membership semantics, the lazy-resume site, and the disconnect-path reconciliation.

Opposite remedy, and the two read well side by side: #79309 proposes refusing a second client on the same session. This PR takes the other position, that the second client should be harmless rather than rejected, and it is offered as a demonstration that mirroring is cheap rather than as an argument against that issue.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)

## Changes Made

This branch was first written against a `tui_gateway/server.py` that has since been decomposed (#102117), so most of what it touches now lives elsewhere. For anyone reading it against the older diff:

| symbol | where it lives now |
| --- | --- |
| `_live_session_payload`, `_current_session_steer_authority`, `_event_frame`, `_set_session_context` | still `tui_gateway/server.py` |
| `_claim_parked_runtimes`, `_find_live_session_by_key` | still `tui_gateway/server.py`, both with a new `profile_home` parameter |
| `_drain_queued_prompt`, `_enqueue_prompt`, `_maybe_schedule_auto_continue` | `tui_gateway/session_auto_continue.py` |
| `_run_prompt_submit` | `tui_gateway/prompt_turn.py` |
| `_close_sessions_for_transport`, `_schedule_ws_orphan_reap`, `_ws_session_is_orphaned` | `tui_gateway/session_lifecycle.py` |
| `_transport_is_dead` | `tui_gateway/session_reaper.py` |
| the `session.resume` payload | built once in `tui_gateway/methods_session.py` `_resume_response`; the live-reuse path is `_resume_reuse_live` |
| the four `browser.controller.*` ownership gates | one gate in `_controller_method`, `tui_gateway/methods_browser_control.py` |

`FanoutTransport` and `_detach_transport_from_sessions` are this branch's own and exist nowhere upstream.

- `tui_gateway/transport.py`: add `FanoutTransport`, which delivers one frame to every attached peer, uses identity for membership, prunes a peer that returns `False` or raises, and on `close()` detaches its peers without closing their sockets, since each client owns its own socket. With more than one peer, and a caller not already on an event loop, the peer writes are dispatched to a shared worker pool and collected under a 12s deadline; a lone peer and an on-loop caller stay inline. A peer that misses the deadline is left attached and its frame counts as in flight.
- `tui_gateway/server.py`: add the attach/detach ladder and its leaf lock (`_session_transport_lock`, `_transport_is_live_peer`, `_session_transport_contains`, `_session_live_transports`, `_session_has_live_transport`, `_attach_session_transport`, `_detach_session_transport`, `_detach_transport_from_sessions`). A `FanoutTransport` handed to `_attach_session_transport` as the newcomer is flattened into its peers rather than nested, since the queued-prompt path captures the slot itself as the queuer's transport. `_transport_is_live_peer` defers to `_transport_is_dead` for the final answer, and `_transport_is_dead` (`tui_gateway/session_reaper.py`) gains a `FanoutTransport` arm so an empty or all-closed fan-out reads as dead to the TTL and LRU reapers.
- `tui_gateway/server.py`: `_live_session_payload` attaches instead of rebinding, which covers `session.resume` for a live session and `session.activate`.
- `tui_gateway/session_auto_continue.py`: `_drain_queued_prompt` attaches instead of rebinding, and skips the pin when the queuer's transport is already dead (third commit).
- `tui_gateway/session_lifecycle.py`: `_close_sessions_for_transport` detaches the departing transport from every session first and takes the historical park or reap path only for the sessions left with no client. The #77129 revalidation before that claim is kept, as a liveness check under the slot lock; the #83716 rebind to the most recent surviving viewer is removed, since a surviving window is now a fan-out peer and such a session is never reported clientless.
- `tui_gateway/server.py`: `_current_session_steer_authority` checks membership rather than slot identity (second commit).
- `tui_gateway/methods_browser_control.py`: the shared `browser.controller.*` gate in `_controller_method` checks membership rather than slot identity, so browser control works on a mirrored session; the broker's own owner check below it is untouched (second commit).
- `tui_gateway/methods_prompt.py`: `prompt.submit` attaches the caller's transport instead of rebinding.
- `tui_gateway/methods_session.py`: the lazy resume path attaches instead of rebinding, plus comments at the resume and activate payload sites.
- `tests/tui_gateway/test_multi_client_fanout.py`: new, covering the fan-out unit behavior, the attach and detach ladder, dead-peer liveness, steer authority, browser-control ownership, event delivery including the terminal frame, `prompt.submit` and the queued drain, disconnect, and the orphan check, with single-client control cases throughout. The concurrent write has its own block: a wedged peer does not hold a frame from a healthy peer either side of it, the on-loop and single-peer paths stay inline, pruning still works on the concurrent path, consecutive frames reach every peer in order, and a peer that misses the deadline is kept and counted as delivered. The browser-control block pins the registering peer's access inside a fan-out, the widened registration and the broker's refusal of a non-registering peer, and a single-client control in which an unattached client is still refused.
- `tests/test_tui_gateway_server.py`: `test_close_transport_rebinds_session_to_remaining_viewer` re-expressed in fan-out terms. It builds the two windows the way production does, by attaching both, then asserts the same guarantee the rebind gave it: closing the pop-out leaves the session with the main window, unparked and unreaped, and still receiving frames. `test_close_transport_skips_dead_remaining_viewers` is re-expressed the same way, a fan-out whose surviving peer is a `_closed` socket, and asserts the session is parked and the reap armed, which is the dead-viewer filter the rebind had. `test_close_transport_detaches_when_no_viewers_remain` is untouched.

## How to Test

1. Reproduce the data loss on `main`. Save this at the repository root and run `python repro_stream_steal.py`:

```python
import threading

from tui_gateway import server


class Client:
    def __init__(self, name):
        self.name = name
        self.frames = []

    def write(self, obj):
        self.frames.append(obj)
        return True

    def close(self):
        pass


session = {
    "agent": None,
    "session_key": "session-key",
    "history": [],
    "history_lock": threading.Lock(),
    "history_version": 0,
    "running": False,
    "attached_images": [],
    "transport": None,
}

a, b = Client("A"), Client("B")
session["transport"] = a
server._sessions["sid"] = session

# what session.resume does for a session that is already live
server._live_session_payload("sid", session, touch=True, transport=b)
server._emit("message.delta", "sid", {"text": "hello"})
server._emit("message.complete", "sid", {"text": "hello", "status": "ok"})

print("slot:", type(session["transport"]).__name__)
print("A:", [(f.get("params") or {}).get("type") for f in a.frames])
print("B:", [(f.get("params") or {}).get("type") for f in b.frames])
```

On `main`, client A receives nothing at all, including the frame that ends the turn:

```text
slot: Client
A: []
B: ['message.delta', 'message.complete']
```

On this branch both clients receive both frames:

```text
slot: FanoutTransport
A: ['message.delta', 'message.complete']
B: ['message.delta', 'message.complete']
```

2. The same thing with real clients: start a turn in one client, then open that session from a second client while the turn is streaming. On `main` the first client goes quiet and stays quiet through the end of the turn. On this branch both render it.

3. `pytest tests/tui_gateway/test_multi_client_fanout.py -q` gives `40 passed`. The file cannot be run at the base at all, because it imports `FanoutTransport`; copying `tui_gateway/transport.py` across as well, since its change is purely additive, gives `24 failed, 16 passed` there. The 16 that pass are the 13 `FanoutTransport` unit tests plus the three single-client controls, and the 24 that fail are the server-side behaviours these commits add, including both browser-control fan-out cases.

4. `pytest tests/tools/test_subagent_steer.py -q` gives `30 passed`. Note that it gives the same result with the first commit alone and the steer regression present, which is why the steer cases live in the new file.

5. The browser-control suites, which are the other half of the second commit: `pytest tests/gateway/test_browser_control_api.py tests/gateway/test_browser_control_artifacts.py tests/gateway/test_browser_control_broker.py tests/gateway/test_browser_control_broker_hardening.py tests/gateway/test_browser_control_cloud.py tests/tools/test_browser_extension_router.py -q` gives `102 passed` on the branch, against `102 passed` on the unmodified base commit. The three browser-control regression tests live in the fan-out file, so this selection is a control rather than a count of new tests.

6. `pytest tests/tui_gateway/ -q` on Windows 11, deselecting `tests/tui_gateway/test_serve_exit_flush.py::test_sigterm_flushes_populated_session_into_state_db` (it sends `SIGTERM` to its own process, which kills the pytest run on Windows before any summary is written, at the tip and at the base alike) and ignoring `tests/tui_gateway/test_compute_host_phase1.py`, gives `4 failed, 1008 passed, 1 deselected` on the branch against `4 failed, 968 passed, 1 deselected` on the unmodified base commit. Details below.

7. `pytest tests/test_tui_gateway_server.py -q` gives `1 failed, 636 passed` on the branch and `1 failed, 636 passed` on the unmodified base commit; the one failure in both is `test_model_options_preserves_canonical_custom_row_after_agent_init`, which depends on the provider inventory of the machine running it. That file is listed here because this PR rewrites one test in it.

8. Linux, under WSL on Python 3.11.15: the fan-out file gives `40 passed`, identical to Windows, and `tests/tui_gateway/` gives `1 failed, 1009 passed, 1 skipped, 1 deselected`. The one failure is a missing `snowballstemmer` import that reproduces identically at the base, and one further file was ignored there for a missing optional `aiohttp`. None of the Windows failures below reproduces on Linux.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate. #40822 covers the same architecture and is credited above; it is stacked on #40814 and cannot land alone.
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits). Three commits, ten files, +1,639 / -67.
- [ ] I've run `pytest tests/ -q` and all tests pass. Not claimed. `tests/tui_gateway/`, `tests/test_tui_gateway_server.py`, `tests/tools/test_subagent_steer.py` and the browser-control files were run, with a stock control run of the same paths on the base commit for comparison; the remaining failures are pre-existing on this platform and are listed below.
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A. The changed behavior is documented in docstrings at the ladder, at `FanoutTransport.write`, and in the module comment above them; `methods_browser_control.py`'s module docstring and its handler docstrings are updated where they asserted the old exactly-this-transport rule.
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A. No config keys.
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A.
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A. No platform surface is touched; `ruff check` passes on all ten changed files, and `scripts/check-windows-footguns.py --diff 79445a496c` reports 16 findings, every one the `bare Path.read_text()/write_text() without encoding=` rule on a pre-existing line of `tests/test_tui_gateway_server.py`, none of them inside a hunk this branch has in that file. `--diff` scans whole changed files rather than changed hunks, which is why an untouched region reports at all; the same scanner on that one file at the base returns the same 16.
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A.

## Screenshots / Logs

Focused file on the branch:

```text
........................................                                 [100%]
40 passed in 3.55s
```

Full directory on the branch:

```text
=========================== short test summary info ===========================
FAILED tests/tui_gateway/test_bot_relay_methods.py::test_deliver_write_failure_still_removes_tempfile
FAILED tests/tui_gateway/test_compute_host.py::test_compute_host_line_json_hello_and_shutdown
FAILED tests/tui_gateway/test_entry_import_off_main_thread.py::test_entry_imports_cleanly_from_worker_thread
FAILED tests/tui_gateway/test_slash_worker_mcp_discovery.py::test_profile_local_mcp_tool_is_visible_in_slash_worker
4 failed, 1008 passed, 1 deselected in 316.94s (0:05:17)
```

The same directory on the unmodified base commit, same machine and runner:

```text
=========================== short test summary info ===========================
FAILED tests/tui_gateway/test_bot_relay_methods.py::test_deliver_write_failure_still_removes_tempfile
FAILED tests/tui_gateway/test_compute_host.py::test_compute_host_line_json_hello_and_shutdown
FAILED tests/tui_gateway/test_compute_host_late_compress_ack.py::test_late_ack_handlers_are_bounded_by_ttl_and_cap
FAILED tests/tui_gateway/test_entry_import_off_main_thread.py::test_entry_imports_cleanly_from_worker_thread
4 failed, 968 passed, 1 deselected in 317.44s (0:05:17)
```

Three of those names are the same on both trees and none is in a file this PR changes: `test_deliver_write_failure_still_removes_tempfile` writes a tempfile, `test_compute_host_line_json_hello_and_shutdown` drives the compute-host supervisor, and `test_entry_imports_cleanly_from_worker_thread` is `signal.SIGPIPE` not existing on Windows. The fourth entry differs by run, so the whole directory was run twice on each tree: the branch gave `4 failed, 1008 passed` and then `3 failed, 1009 passed`, the base gave `4 failed, 968 passed` and then `5 failed, 967 passed`. Every name beyond the stable three fired on one round of one tree and not the other, both of the round-one divergences pass in isolation on both trees, and one of them, `test_late_ack_handlers_are_bounded_by_ttl_and_cap`, failed on the base in both rounds and on the branch in neither. Collected is 1012 on the branch and 972 on the base in every round, a difference of exactly the 40 tests this PR adds, and that count is the stable signal on this platform. The Linux lane reproduces none of them.

```text
$ ruff check tests/test_tui_gateway_server.py tests/tui_gateway/test_multi_client_fanout.py tui_gateway/methods_browser_control.py tui_gateway/methods_prompt.py tui_gateway/methods_session.py tui_gateway/server.py tui_gateway/session_auto_continue.py tui_gateway/session_lifecycle.py tui_gateway/session_reaper.py tui_gateway/transport.py
All checks passed!

$ python scripts/check-windows-footguns.py --diff 79445a496c
✗ 16 Windows footgun(s) found across 10 file(s) scanned.
```

## Uncertainty

Run on Windows 11 and on Linux under WSL, not on macOS. Nothing in the change is platform-specific and the new tests touch no platform surface. Neither lane demonstrates a fully green directory: Windows carries three pre-existing failures plus the flake set above, and the Linux venv is missing two optional imports. All of it reproduces at the base.

The tests drive fake client objects rather than real websockets, following the convention of this directory. The end-to-end path was checked with the script above rather than in the suite, and there is no test that exercises a real `WSTransport` through `handle_ws` under fan-out.

The fan-out's concurrent write is exercised, with fake peers: a wedged peer does not hold the frame from a healthy peer ahead of or behind it, the on-loop and single-peer paths stay inline, a dead peer is still pruned on the concurrent path, consecutive frames arrive in order, and a peer that misses the deadline is kept. What is not exercised is the rest of the concurrency. No test races attach against write, and, as above, none drives a real `WSTransport` through `handle_ws`. `_detach_session_transport` releases the slot lock before asking whether a live client remains, so a detach racing an attach can observe the post-attach answer; that is the safe direction, since it reports a client remaining rather than parking a session someone is reading, but it is not pinned by a test.

The browser-control tests drive the handlers through `server.dispatch(req, transport)` with fake clients carrying an `auth_identity`, the way `tests/gateway/test_browser_control_cloud.py` drives them. No real browser extension is involved, and the widened registration is pinned as behavior rather than argued for.

## What I did not do

A peer sees the assistant's output, not the other client's input. The gateway emits four `message.*` events, `message.start`, `message.delta`, `message.interim` and `message.complete`, and all four carry the assistant's reply; nothing on the wire announces that a client submitted a prompt. A mirrored client therefore renders the turn live and learns what its peer typed only when it reconciles history at the end of it. Fan-out delivers the frames that exist, and there is no user-message frame to deliver; adding one is a protocol change and does not belong in a bug fix.

`tui_gateway/compute_host.py` is untouched, so process-isolated sessions still rebind the slot and defeat fan-out.

`_set_session_context` still reads `auth_identity` off the session's transport slot (`tui_gateway/server.py:1199` at `79445a496c`), and a `FanoutTransport` carries none, so a mirrored session derives an empty browser-control principal wherever the session context is the source rather than the request's transport. The `browser.controller.*` handlers read the identity off the calling transport (`tui_gateway/methods_browser_control.py:99`) and are unaffected, which is why the gate conversion above is enough for them.

The `viewers` registry is not removed. After the #83716 deletion its only remaining consumer is its own prune, but deleting it is a second behavior change this PR did not propose, and the prune still depends on the entries existing.

`_ws_session_is_orphaned` is not changed. It still asks whether the drop sentinel is in the slot, and a fan-out is never the sentinel, so a session that still has a peer is never reported orphaned.

An all-pruned fan-out does not take the park path. `FanoutTransport.write` prunes a peer that fails a write, and `WSTransport.close()` latches `_closed` before `_close_sessions_for_transport` runs, so if every peer of a session is pruned inside that window the slot holds an empty fan-out that no disconnect sweep matches. `_transport_is_dead` reports it dead, so the TTL and LRU reapers collect it; the WS-orphan grace reap does not, because the session is never given the sentinel. Closing that means a second `_sessions` scan on every disconnect, and it is not done here.

A queued prompt whose queuer has disconnected still runs, and if the session's slot is the drop sentinel at drain time the drained turn streams into the sentinel with `running` set; the output is recoverable from history. On `main` the same drain rebinds the slot to the dead socket, so this is not a regression, but it is not improved either.

One race on the disconnect path is documented but not closed: if a resume attaches a new peer between the detach and the revalidation, the revalidation sees that peer, the session is spared, and the departing socket stays inside the fan-out until its first failed write prunes it.

No entitlement or identity check was added at any attach point, and the ticket auth path was not changed.

Nothing was added to the wire: no new event fields, no new RPC parameters, no capability flag in `gateway.ready`. A client cannot yet tell that a session is mirrored or which client started a given turn. That is a separate change and belongs in its own PR, since it is a protocol question rather than a bug fix.

Steer authority was not narrowed to the commissioning peer, and no per-subagent record of the commissioning client was added.

Root causes 2 and 3 of #79064 are not addressed here.

