### PR TITLE
feat(agent): let a caller supply a pre-acquired session turn lease holder

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -8048,8 +8048,27 @@ class AIAgent:
         persist_user_display_kind: Optional[str] = None,
         persist_user_display_metadata: Optional[Dict[str, Any]] = None,
         moa_config: Optional[dict[str, Any]] = None,
+        session_turn_lease_holder: Optional[str] = None,
+        session_turn_lease_ttl_seconds: Optional[float] = None,
     ) -> Dict[str, Any]:
-        """Forwarder — see ``agent.conversation_loop.run_conversation``."""
+        """Forwarder — see ``agent.conversation_loop.run_conversation``.
+
+        ``session_turn_lease_holder`` is for a caller that has already acquired
+        this conversation's durable turn lease and made its own admission
+        decision. The turn arms the transcript-write fence with that holder and
+        does not acquire, refresh, or release the lease: admission, refresh,
+        and release stay with the caller for the whole life of the lease,
+        including on every path out of this method. So does re-synchronizing
+        the conversation history: a caller whose acquisition waited on another
+        holder must refresh its own snapshot before calling, because the
+        reload this method runs after a contended acquire of its own does not
+        run on this path.
+        ``session_turn_lease_ttl_seconds`` is the TTL the write fence uses when
+        it renews a lapsed row that is still the caller's own (default 300.0,
+        matching the internally acquired lease). Both are ignored when there is
+        no session id or no session store, in which case the turn behaves
+        exactly as it does without them.
+        """
         from agent.aux_accounting import (
             reset_accounting_context,
             set_accounting_context,
@@ -8084,6 +8103,7 @@ class AIAgent:
         relay_lease = None
         relay_turn = None
         durable_turn_lease = None
+        external_turn_lease = None
         durable_turn_lease_stop = None
         durable_turn_lease_thread = None
         durable_turn_lease_activity_lock = threading.Lock()
@@ -8149,7 +8169,25 @@ class AIAgent:
                         exc_info=True,
                     )
                     _durable_session_exists = True
-            if (
+            _external_holder = str(session_turn_lease_holder or "").strip() or None
+            if _external_holder is not None and _turn_db is not None and session_id:
+                # The caller already holds this conversation's lease and made
+                # its own admission decision. Arm the write fence with its
+                # holder and skip acquisition: acquiring again under a
+                # different holder string would block on the caller's own row
+                # for the full wait, then reclaim it once the TTL lapses and
+                # leave the caller's later release matching nothing. Refresh
+                # and release stay with the caller.
+                if _durable_session_exists:
+                    # Same proof the internal path below relies on: the row is
+                    # there, so suppress the redundant create attempt.
+                    self._session_db_created = True
+                external_turn_lease = _external_holder
+                self._active_session_turn_lease_holder = _external_holder
+                self._active_session_turn_lease_ttl_seconds = float(
+                    session_turn_lease_ttl_seconds or 300.0
+                )
+            elif (
                 _turn_db is not None
                 and session_id
                 and not getattr(self, "_persist_disabled", False)
@@ -8493,6 +8531,15 @@ class AIAgent:
                         ):
                             self._active_session_turn_lease_holder = None
                             self._active_session_turn_lease_ttl_seconds = None
+                    if external_turn_lease is not None and (
+                        getattr(self, "_active_session_turn_lease_holder", None)
+                        == external_turn_lease
+                    ):
+                        # Clear the fence input without releasing: the row is
+                        # the caller's and only the caller may release it. A
+                        # cached agent must not fence its next turn with it.
+                        self._active_session_turn_lease_holder = None
+                        self._active_session_turn_lease_ttl_seconds = None
                     # Always clear mid-turn labels when the turn exits — including
                     # interrupted early returns that skip finalize_turn. Keep ts.
                     try:

--- a/run_agent.py
+++ b/run_agent.py
@@ -8170,6 +8170,16 @@ class AIAgent:
                     )
                     _durable_session_exists = True
             _external_holder = str(session_turn_lease_holder or "").strip() or None
+            if _external_holder is not None and not session_id:
+                # Every fence below is keyed on the session id, so a holder
+                # supplied without one is inert: nothing arms, and the turn
+                # runs unfenced while the caller believes its lease covers it.
+                # Say so rather than dropping it silently.
+                logger.warning(
+                    "session turn lease holder supplied without a session id; "
+                    "ignoring it and running this turn unfenced: %s",
+                    _external_holder,
+                )
             if _external_holder is not None and _turn_db is not None and session_id:
                 # The caller already holds this conversation's lease and made
                 # its own admission decision. Arm the write fence with its

--- a/tests/run_agent/test_external_turn_lease_holder.py
+++ b/tests/run_agent/test_external_turn_lease_holder.py
@@ -1,0 +1,417 @@
+"""A caller that already owns the turn lease can hand its holder to the engine.
+
+``AIAgent.run_conversation`` accepts ``session_turn_lease_holder`` from a front
+end that acquired the conversation's durable turn lease itself. The turn must
+then arm the transcript-write fence with that holder and leave acquisition,
+refresh, and release to the caller. Every test here also pins the other half of
+the contract: with the parameter absent, the internal lease path is unchanged.
+"""
+
+from __future__ import annotations
+
+import os
+import threading
+import time
+
+from hermes_state import SessionDB
+from run_agent import AIAgent
+
+_REFRESHER_THREAD_NAME = "session-turn-lease-refresh"
+
+
+def _external_holder(turn: str = "front-end") -> str:
+    """Build a holder whose PID is alive so no reclaim probe can steal it.
+
+    ``try_acquire_session_turn_lease`` reclaims a row whose structured holder
+    PID is gone, so a synthetic PID would make "the engine did not release it"
+    unfalsifiable.
+    """
+    return f"pid={os.getpid()}:turn={turn}:platform=remote"
+
+
+class _DB:
+    """Session-store double that records every turn-lease call it receives."""
+
+    def __init__(self, session_exists=True, acquire_result=True):
+        self.events = []
+        self.session_exists = session_exists
+        self.acquire_result = acquire_result
+
+    def get_session(self, session_id):
+        return {"id": session_id} if self.session_exists else None
+
+    def acquire_session_turn_lease(self, session_id, holder, **kwargs):
+        self.events.append(("acquire", session_id, holder))
+        on_wait = kwargs.get("on_wait")
+        if on_wait is not None and self.acquire_result is False:
+            on_wait(0.0)
+        return self.acquire_result
+
+    def resolve_resume_session_id(self, session_id):
+        self.events.append(("resolve", session_id))
+        return "compressed-tip"
+
+    def get_messages_as_conversation(self, session_id, **kwargs):
+        self.events.append(("reload", session_id, kwargs))
+        return [{"role": "user", "content": "durable latest"}]
+
+    def refresh_session_turn_lease(self, session_id, holder, **kwargs):
+        self.events.append(("refresh", session_id, holder))
+        return True
+
+    def release_session_turn_lease(self, session_id, holder):
+        self.events.append(("release", session_id, holder))
+
+
+def _agent_with_db(db, *, session_id="shared", platform="desktop"):
+    agent = AIAgent.__new__(AIAgent)
+    agent.session_id = session_id
+    agent.platform = platform
+    agent.model = "test-model"
+    agent._session_db = db
+    agent._session_db_created = True
+    agent._persist_disabled = False
+    agent._parent_session_id = None
+    agent._relay_pending_turn_id = None
+    agent._reset_activity_labels_after_turn = lambda: None
+    agent._conversation_root_id = lambda: session_id
+    agent.log_prefix = ""
+    agent._vprint = lambda *a, **k: None
+    agent.status_callback = None
+    agent._interrupt_requested = False
+    agent._interrupt_message = None
+    agent._pending_redirect = None
+    agent._execution_thread_id = None
+    agent._interrupt_thread_signal_pending = False
+    return agent
+
+
+def _arm_flush(agent):
+    """Add the bookkeeping the real persist path reads, nothing more."""
+    agent._session_persist_lock = None
+    agent._last_flushed_db_idx = 0
+    agent._flushed_db_message_ids = set()
+    agent._flushed_db_message_session_id = None
+    agent._db_flush_scan_prefix = None
+    agent._pending_cli_user_message = None
+    agent._persist_user_message_idx = None
+    agent._persist_user_message_override = None
+    agent._persist_user_message_timestamp = None
+    agent._last_persistence_error_cause = None
+    return agent
+
+
+def test_external_holder_skips_engine_acquire(monkeypatch):
+    """A supplied holder suppresses acquire, resolve, reload, and release."""
+    db = _DB()
+    agent = _agent_with_db(db)
+    holder = _external_holder()
+    observed = {}
+
+    def fake_run(_agent, _message, _system, history, *_args, **_kwargs):
+        observed["history"] = history
+        observed["holder"] = getattr(
+            _agent, "_active_session_turn_lease_holder", None
+        )
+        observed["ttl"] = getattr(
+            _agent, "_active_session_turn_lease_ttl_seconds", None
+        )
+        return {"final_response": "ok", "messages": history, "failed": False}
+
+    monkeypatch.setattr("agent.conversation_loop.run_conversation", fake_run)
+    seed = [{"role": "user", "content": "caller seed"}]
+    result = AIAgent.run_conversation(
+        agent,
+        "new message",
+        conversation_history=seed,
+        session_turn_lease_holder=holder,
+        session_turn_lease_ttl_seconds=45.0,
+    )
+
+    assert result["final_response"] == "ok"
+    # No acquire, so also no contended resolve/reload and no release.
+    assert db.events == []
+    # The engine deliberately performs no reload on this path: the reload
+    # after a contended wait belongs to its own acquire, so a caller whose
+    # acquire waited must refresh its own snapshot before calling. This pins
+    # only that the engine does not replace the caller-provided history.
+    assert observed["history"] is seed
+    # The fence input the persist path reads is the caller's holder.
+    assert observed["holder"] == holder
+    assert observed["ttl"] == 45.0
+    # Cleared on exit so a cached agent cannot fence the next turn with it.
+    assert getattr(agent, "_active_session_turn_lease_holder", None) is None
+    assert getattr(agent, "_active_session_turn_lease_ttl_seconds", None) is None
+
+
+def test_external_holder_defaults_ttl_when_unspecified(monkeypatch):
+    """Omitting the TTL leaves the same 300s default the internal path uses."""
+    db = _DB()
+    agent = _agent_with_db(db)
+    observed = {}
+
+    def fake_run(_agent, _message, _system, history, *_args, **_kwargs):
+        observed["ttl"] = getattr(
+            _agent, "_active_session_turn_lease_ttl_seconds", None
+        )
+        return {"final_response": "ok", "messages": history, "failed": False}
+
+    monkeypatch.setattr("agent.conversation_loop.run_conversation", fake_run)
+    AIAgent.run_conversation(
+        agent,
+        "new message",
+        conversation_history=[{"role": "user", "content": "seed"}],
+        session_turn_lease_holder=_external_holder(),
+    )
+
+    assert observed["ttl"] == 300.0
+    assert db.events == []
+
+
+def test_external_holder_is_not_released_by_engine(tmp_path, monkeypatch):
+    """The caller's lease row survives the turn, still owned by the caller."""
+    path = tmp_path / "state.db"
+    db = SessionDB(path)
+    other = SessionDB(path)
+    try:
+        db.create_session("shared", source="test")
+        holder = _external_holder()
+        assert db.try_acquire_session_turn_lease("shared", holder, ttl_seconds=30)
+
+        agent = _agent_with_db(db)
+
+        def fake_run(_agent, _message, _system, history, *_args, **_kwargs):
+            return {"final_response": "ok", "messages": history, "failed": False}
+
+        monkeypatch.setattr("agent.conversation_loop.run_conversation", fake_run)
+        result = AIAgent.run_conversation(
+            agent,
+            "new message",
+            conversation_history=[{"role": "user", "content": "seed"}],
+            session_turn_lease_holder=holder,
+            session_turn_lease_ttl_seconds=30.0,
+        )
+        assert result["final_response"] == "ok"
+
+        # Still held: a contender cannot take the conversation.
+        assert (
+            other.try_acquire_session_turn_lease(
+                "shared", _external_holder("contender"), ttl_seconds=5
+            )
+            is False
+        )
+        # Still held by the caller specifically: a holder-qualified refresh
+        # matches, which a released or reclaimed row could not do.
+        assert (
+            db.refresh_session_turn_lease("shared", holder, ttl_seconds=30) is True
+        )
+        db.release_session_turn_lease("shared", holder)
+    finally:
+        db.close()
+        other.close()
+
+
+def test_external_holder_arms_write_fence(tmp_path, monkeypatch):
+    """Transcript writes carry the caller's holder into the in-txn fence.
+
+    Four arms in one turn, because the discriminator is which writes are
+    admitted and which are refused. If the engine did not arm the fence, the
+    persist path would pass ``turn_lease_holder=None``, the guard would not run
+    at all, and the fenced arm would be admitted like the rest.
+    """
+    path = tmp_path / "state.db"
+    db = SessionDB(path)
+    thief_db = SessionDB(path)
+    ttl = 0.3
+    try:
+        db.create_session("shared", source="test")
+        holder = _external_holder()
+        assert db.try_acquire_session_turn_lease("shared", holder, ttl_seconds=ttl)
+
+        agent = _arm_flush(_agent_with_db(db))
+        agent._ensure_db_session = lambda: None
+        observed = {}
+
+        def fake_run(_agent, _message, _system, history, *_args, **_kwargs):
+            observed["armed"] = getattr(
+                _agent, "_active_session_turn_lease_holder", None
+            )
+            # Arm 1: live lease, own holder. Admitted.
+            observed["owned"] = _agent._flush_messages_to_session_db(
+                [{"role": "user", "content": "owned"}], []
+            )
+            # Arm 2: lease lapsed but uncontested. The fence revives the row
+            # for its own holder, so a turn running without a refresher is not
+            # locked out of its own transcript.
+            time.sleep(ttl + 0.25)
+            observed["revived"] = _agent._flush_messages_to_session_db(
+                [{"role": "assistant", "content": "expired-but-owned"}], []
+            )
+            # Arm 3: the revival used the caller's TTL, not a hardcoded one,
+            # so the row lapses again on the same short clock and a contender
+            # takes the conversation.
+            time.sleep(ttl + 0.25)
+            observed["stolen"] = thief_db.try_acquire_session_turn_lease(
+                "shared", _external_holder("thief"), ttl_seconds=30
+            )
+            # Arm 4: foreign holder now owns the row. Refused.
+            observed["fenced"] = _agent._flush_messages_to_session_db(
+                [{"role": "assistant", "content": "after-steal"}], []
+            )
+            observed["cause"] = getattr(
+                _agent, "_last_persistence_error_cause", None
+            )
+            return {"final_response": "ok", "messages": history, "failed": False}
+
+        monkeypatch.setattr("agent.conversation_loop.run_conversation", fake_run)
+        AIAgent.run_conversation(
+            agent,
+            "new message",
+            conversation_history=[{"role": "user", "content": "seed"}],
+            session_turn_lease_holder=holder,
+            session_turn_lease_ttl_seconds=ttl,
+        )
+
+        assert observed["armed"] == holder
+        assert observed["owned"] is True
+        assert observed["revived"] is True
+        assert observed["stolen"] is True
+        assert observed["fenced"] is False
+        assert observed["cause"] == "turn_lease"
+        assert [m["content"] for m in thief_db.get_messages("shared")] == [
+            "owned",
+            "expired-but-owned",
+        ]
+    finally:
+        db.close()
+        thief_db.close()
+
+
+def test_external_holder_starts_no_refresher(monkeypatch):
+    """No lease refresher runs on the external path, but one still runs without it."""
+    seen = {}
+
+    def fake_run(_agent, _message, _system, history, *_args, **_kwargs):
+        seen.setdefault("threads", []).append(
+            [t.name for t in threading.enumerate() if t.is_alive()]
+        )
+        return {"final_response": "ok", "messages": history, "failed": False}
+
+    monkeypatch.setattr("agent.conversation_loop.run_conversation", fake_run)
+
+    # Control arm first: the internal path does start the refresher, so the
+    # assertion below is about the external path and not about the literal
+    # having drifted out of the code.
+    control_db = _DB()
+    AIAgent.run_conversation(
+        _agent_with_db(control_db),
+        "new message",
+        conversation_history=[{"role": "user", "content": "seed"}],
+    )
+    assert _REFRESHER_THREAD_NAME in seen["threads"][0]
+
+    external_db = _DB()
+    AIAgent.run_conversation(
+        _agent_with_db(external_db),
+        "new message",
+        conversation_history=[{"role": "user", "content": "seed"}],
+        session_turn_lease_holder=_external_holder(),
+    )
+    assert _REFRESHER_THREAD_NAME not in seen["threads"][1]
+    assert external_db.events == []
+    assert [event[0] for event in control_db.events] == ["acquire", "release"]
+
+
+def test_external_holder_ignored_without_session_id(monkeypatch):
+    """Without a session id there is no conversation to fence, so nothing arms."""
+    db = _DB()
+    agent = _agent_with_db(db, session_id="")
+    observed = {}
+
+    def fake_run(_agent, _message, _system, history, *_args, **_kwargs):
+        observed["holder"] = getattr(
+            _agent, "_active_session_turn_lease_holder", None
+        )
+        observed["threads"] = [
+            t.name for t in threading.enumerate() if t.is_alive()
+        ]
+        return {"final_response": "ok", "messages": history, "failed": False}
+
+    monkeypatch.setattr("agent.conversation_loop.run_conversation", fake_run)
+    result = AIAgent.run_conversation(
+        agent,
+        "new message",
+        conversation_history=[{"role": "user", "content": "seed"}],
+        session_turn_lease_holder=_external_holder(),
+    )
+
+    assert result["final_response"] == "ok"
+    assert observed["holder"] is None
+    assert _REFRESHER_THREAD_NAME not in observed["threads"]
+    assert db.events == []
+
+
+def test_absent_param_is_behavior_neutral(monkeypatch):
+    """The internal lease path is untouched when the new parameters are absent.
+
+    This is the regression guard on converting the existing acquire gate from
+    ``if`` to ``elif``: same call sequence, same minted holder shape, same
+    contended reload, same release.
+    """
+    db = _DB()
+    agent = _agent_with_db(db, session_id="stale-parent")
+    agent._conversation_root_id = lambda: "stale-parent"
+    status_events = []
+    agent.status_callback = lambda kind, text=None: status_events.append(
+        (kind, text)
+    )
+    observed = {}
+
+    def fake_run(_agent, _message, _system, history, *_args, **_kwargs):
+        observed["history"] = history
+        observed["session_id"] = _agent.session_id
+        observed["holder"] = getattr(
+            _agent, "_active_session_turn_lease_holder", None
+        )
+        observed["ttl"] = getattr(
+            _agent, "_active_session_turn_lease_ttl_seconds", None
+        )
+        return {"final_response": "ok", "messages": history, "failed": False}
+
+    # Simulate a contended wait so the resolve+reload path is exercised.
+    def acquire_with_wait(session_id, holder, **kwargs):
+        db.events.append(("acquire", session_id, holder))
+        on_wait = kwargs.get("on_wait")
+        if on_wait is not None:
+            on_wait(0.0)
+        return True
+
+    db.acquire_session_turn_lease = acquire_with_wait
+
+    monkeypatch.setattr("agent.conversation_loop.run_conversation", fake_run)
+    result = AIAgent.run_conversation(
+        agent,
+        "new message",
+        conversation_history=[{"role": "user", "content": "stale"}],
+    )
+
+    assert result["final_response"] == "ok"
+    assert observed["history"] == [{"role": "user", "content": "durable latest"}]
+    assert observed["session_id"] == "compressed-tip"
+    assert observed["holder"].startswith(f"pid={os.getpid()}:turn=")
+    assert observed["ttl"] == 300.0
+    assert [event[0] for event in db.events] == [
+        "acquire",
+        "resolve",
+        "reload",
+        "release",
+    ]
+    # Released under exactly the holder that was acquired and armed.
+    acquired = next(e for e in db.events if e[0] == "acquire")[2]
+    released = next(e for e in db.events if e[0] == "release")[2]
+    assert acquired == released == observed["holder"]
+    assert getattr(agent, "_active_session_turn_lease_holder", None) is None
+    assert any(
+        kind == "lifecycle" and text and "waiting for it to finish" in text
+        for kind, text in status_events
+    )

--- a/tests/run_agent/test_external_turn_lease_holder.py
+++ b/tests/run_agent/test_external_turn_lease_holder.py
@@ -9,9 +9,12 @@ the contract: with the parameter absent, the internal lease path is unchanged.
 
 from __future__ import annotations
 
+import logging
 import os
 import threading
 import time
+
+import pytest
 
 from hermes_state import SessionDB
 from run_agent import AIAgent
@@ -322,10 +325,16 @@ def test_external_holder_starts_no_refresher(monkeypatch):
     assert [event[0] for event in control_db.events] == ["acquire", "release"]
 
 
-def test_external_holder_ignored_without_session_id(monkeypatch):
-    """Without a session id there is no conversation to fence, so nothing arms."""
+def test_external_holder_ignored_without_session_id(caplog, monkeypatch):
+    """Without a session id there is no conversation to fence, so nothing arms.
+
+    Dropping the holder is the contract, but dropping it silently is not: a
+    caller that believes the lease it acquired covers this turn is running
+    unfenced, and only the log can tell it so.
+    """
     db = _DB()
     agent = _agent_with_db(db, session_id="")
+    holder = _external_holder()
     observed = {}
 
     def fake_run(_agent, _message, _system, history, *_args, **_kwargs):
@@ -338,17 +347,104 @@ def test_external_holder_ignored_without_session_id(monkeypatch):
         return {"final_response": "ok", "messages": history, "failed": False}
 
     monkeypatch.setattr("agent.conversation_loop.run_conversation", fake_run)
-    result = AIAgent.run_conversation(
-        agent,
-        "new message",
-        conversation_history=[{"role": "user", "content": "seed"}],
-        session_turn_lease_holder=_external_holder(),
-    )
+    with caplog.at_level(logging.WARNING, logger="run_agent"):
+        result = AIAgent.run_conversation(
+            agent,
+            "new message",
+            conversation_history=[{"role": "user", "content": "seed"}],
+            session_turn_lease_holder=holder,
+        )
 
     assert result["final_response"] == "ok"
     assert observed["holder"] is None
     assert _REFRESHER_THREAD_NAME not in observed["threads"]
     assert db.events == []
+    # Named, not just counted: the operator has to know which holder was
+    # dropped to find the caller that supplied it.
+    assert any(
+        "session turn lease holder supplied without a session id"
+        in record.getMessage()
+        and holder in record.getMessage()
+        for record in caplog.records
+    )
+
+
+def test_external_holder_cleared_on_interrupted_exit(monkeypatch):
+    """The fence input is cleared on the exits that skip a normal completion.
+
+    The clear lives in the outermost ``finally`` chain rather than beside the
+    return, so it has to survive both an exception leaving the turn through
+    ``except BaseException`` and an early return reporting an interrupt. Only
+    the completed-turn exit was pinned before. An agent that kept the holder
+    after either of these would fence its next turn with a lease the caller
+    has since released, and the fence would then admit writes the next
+    conversation's real owner should have refused.
+    """
+    holder = _external_holder()
+    observed = {}
+
+    def _record_armed(_agent):
+        observed.setdefault("armed", []).append(
+            getattr(_agent, "_active_session_turn_lease_holder", None)
+        )
+
+    # Arm 1: the turn leaves by raising. KeyboardInterrupt and not a plain
+    # Exception, because the real interrupt is a BaseException and the clear
+    # must not be sitting behind a handler that never sees one.
+    def raising_run(_agent, _message, _system, _history, *_args, **_kwargs):
+        _record_armed(_agent)
+        raise KeyboardInterrupt("stopped mid-turn")
+
+    monkeypatch.setattr("agent.conversation_loop.run_conversation", raising_run)
+    raised_db = _DB()
+    raised_agent = _agent_with_db(raised_db)
+    with pytest.raises(KeyboardInterrupt):
+        AIAgent.run_conversation(
+            raised_agent,
+            "new message",
+            conversation_history=[{"role": "user", "content": "seed"}],
+            session_turn_lease_holder=holder,
+            session_turn_lease_ttl_seconds=45.0,
+        )
+
+    # Armed while the turn was running, so the clear below is not vacuous.
+    assert observed["armed"] == [holder]
+    assert getattr(raised_agent, "_active_session_turn_lease_holder", None) is None
+    assert (
+        getattr(raised_agent, "_active_session_turn_lease_ttl_seconds", None) is None
+    )
+    # Clearing is not releasing: the row stays the caller's on this exit too.
+    assert raised_db.events == []
+
+    # Arm 2: the turn returns early reporting an interrupt instead of raising,
+    # which is the shape the interrupt and redirect paths actually take.
+    def interrupted_run(_agent, _message, _system, history, *_args, **_kwargs):
+        _record_armed(_agent)
+        return {
+            "final_response": "",
+            "messages": history,
+            "failed": False,
+            "interrupted": True,
+        }
+
+    monkeypatch.setattr("agent.conversation_loop.run_conversation", interrupted_run)
+    returned_db = _DB()
+    returned_agent = _agent_with_db(returned_db)
+    result = AIAgent.run_conversation(
+        returned_agent,
+        "new message",
+        conversation_history=[{"role": "user", "content": "seed"}],
+        session_turn_lease_holder=holder,
+        session_turn_lease_ttl_seconds=45.0,
+    )
+
+    assert result["interrupted"] is True
+    assert observed["armed"] == [holder, holder]
+    assert getattr(returned_agent, "_active_session_turn_lease_holder", None) is None
+    assert (
+        getattr(returned_agent, "_active_session_turn_lease_ttl_seconds", None) is None
+    )
+    assert returned_db.events == []
 
 
 def test_absent_param_is_behavior_neutral(monkeypatch):


### PR DESCRIPTION
## What does this PR do?

`AIAgent.run_conversation` mints its own turn lease holder and acquires the durable session turn lease itself (`run_agent.py:8172-8175`, acquire at `:8193`). There is no way for a caller to say "I already hold this conversation's lease."

That matters for a front end that wants to make its own admission decision before a turn starts, rather than letting every arriving turn queue behind the engine's 1800 second wait. Two cases motivate it. A machine-triggered turn, such as an auto-continue after an interrupted turn, wants claim-or-abstain: take the lease if it is free, otherwise do nothing at all, because a duplicate turn is worse than a skipped one. An interactive turn wants a bounded wait with its own transport-level notice, so the person sending the message learns within seconds that another process holds the session instead of waiting out a timeout in silence.

Both require acquiring the lease before calling into the agent, and today that is worse than not acquiring at all. The engine acquires again under a different holder string and blocks on the caller's own row. Once that row's TTL lapses, `try_acquire_session_turn_lease` deletes it and takes the conversation: the DELETE is qualified on the row's own holder, not on the caller's, so expiry is reclaimable regardless of who owns it (`hermes_state.py:5845-5855`). The caller's later release then matches nothing, and for the window in between two holders each believe they own the turn.

This adds two optional keyword parameters to `run_conversation`:

- `session_turn_lease_holder`: the holder string of a lease the caller already owns.
- `session_turn_lease_ttl_seconds`: the TTL the write fence uses when it renews a lapsed row that is still the caller's own. Defaults to 300.0, the same value the internal path uses.

When a holder is supplied, the turn arms the transcript-write fence with it and skips acquisition, refresh, and release. Admission, refresh, and release stay with the caller for the whole life of the lease. The fence input is `self._active_session_turn_lease_holder`, which the persist path already reads on every transcript write (`run_agent.py:2293-2295`), so writes from a turn running under a caller-supplied lease are fenced exactly as they are today. The `finally` block clears the fence input without releasing the row. The history reload the engine runs after a contended acquire stays with the caller too: it is gated on the engine having waited on its own acquire, so it does not run on this path, and a caller whose acquire waited owns re-reading the transcript before it calls, as the docstring states.

### Behavior when the parameters are absent

Unchanged, by construction. The existing acquire gate becomes the `elif` fallback of the new arm, with its condition and body untouched. Both `finally` arms are inert without their respective locals. Neither parameter is forwarded to `agent.conversation_loop.run_conversation`.

The only observable difference for an existing caller is two extra entries in the signature. The repo already treats this method's signature as an additive extension point: `tui_gateway/server.py:10524-10532` (line numbers at `2f094a264`, this PR's base) probes `inspect.signature(agent.run_conversation).parameters` and passes newer keyword arguments only when the running agent has them, so an older agent and a newer one both work. That is the same path a future caller of these parameters would use.

### Reviewer risk worth naming up front

No lease refresher thread runs on the external path, so a long turn can outlive the caller's TTL if the caller does not refresh. Two things bound that.

The caller owns refresh, which is the point of the parameter, and has the same `refresh_session_turn_lease` available to it.

More importantly, the in-transaction write fence already revives a lapsed row for its own holder (`hermes_state.py:8304-8318`). A turn whose lease lapsed with nobody contending is not locked out of its own transcript: the renewal is serialized with acquisition under `BEGIN IMMEDIATE`, so it cannot race a takeover, and a row that a contender actually took still fails the foreign-holder check at `:8299-8303`. `test_external_holder_arms_write_fence` pins both halves inside one turn: an uncontested lapse is admitted and revives the row on the caller's TTL, and the write after a contender takes the conversation is refused.

## Related Issue

Related to #86190. The holder passthrough is the concrete blocker named there: without it a front end cannot pre-acquire and abstain, because pre-acquiring deadlocks against the engine's own acquire and then loses the row at TTL.

This does not close #86190, which covers more than this change, so there is deliberately no `Fixes` line.

History, for anyone tracing the ask: it was raised on #84287 before that PR was superseded; its work is on main via #86383.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)

## Changes Made

- `run_agent.py`: add `session_turn_lease_holder` and `session_turn_lease_ttl_seconds` keyword parameters to `AIAgent.run_conversation`, and a docstring paragraph stating that the caller owns admission, refresh, release, and re-synchronizing its own conversation history when its acquire waited.
- `run_agent.py`: add an external-holder arm before the existing acquire gate. It arms the transcript-write fence and skips acquisition; the existing gate becomes its `elif` fallback, unchanged. The redundant-create suppression inside the new arm is gated on the same `_durable_session_exists` proof the internal path uses, so a caller holding a lease on a conversation with no session row yet still gets its row created.
- `run_agent.py`: add a clear-without-release arm in the `finally`, guarded on the fence input still matching the supplied holder.
- `tests/run_agent/test_external_turn_lease_holder.py`: new file, seven cases.

## How to Test

1. `python -m pytest tests/run_agent/test_external_turn_lease_holder.py -q` passes 7 tests. Against this branch's parent commit the six that pass the new keyword argument fail with `TypeError: AIAgent.run_conversation() got an unexpected keyword argument 'session_turn_lease_holder'`, and `test_absent_param_is_behavior_neutral` passes there as it must, since it pins existing behavior.
2. `python -m pytest tests/run_agent/test_cross_process_turn_lease.py tests/state/test_session_turn_lease.py -q` passes 31 tests. These are the suites that own the internal lease path and are the regression guard on converting the acquire gate from `if` to `elif`.
3. `python scripts/check-windows-footguns.py --diff <base>` reports no findings across both changed files.
4. `ruff check run_agent.py tests/run_agent/test_external_turn_lease_holder.py` passes.
5. The wider blast radius of a signature and acquire-gate change is the suites that drive `AIAgent.run_conversation` against a session store: `tests/run_agent/test_run_agent.py`, `test_860_dedup.py`, `test_compression_persistence.py`, `test_81641_text_turn_incremental_persistence.py`, `test_tool_call_incremental_persistence.py`, `test_token_persistence_non_cli.py`, `test_exit_cleanup_interrupt.py`, plus `tests/agent/test_rotation_flush_persisted_boundary_68196.py` and `tests/tui_gateway/test_auto_continue.py`. That set gives 299 passed and 7 failed on Windows. All 7 reproduce identically on the parent commit with the production change absent, so they are a local baseline, not a regression: 6 are the Windows tempfile teardown race (`PermissionError: [WinError 32]` on a SQLite file the test leaves open) and 1 is the `anthropic` package being absent from the local venv.

The tests cover: a supplied holder suppresses acquire, resolve, reload and release; the TTL defaults to 300.0 when omitted; against a real `SessionDB` the caller's lease row survives the turn still owned by the caller, so a contender cannot take it and a holder-qualified refresh still matches; transcript writes carry the holder into the in-transaction fence, are revived by it on an uncontested lapse, and are refused once a contender takes the conversation; no lease refresher thread starts, with the internal path run as a control arm in the same test so the assertion cannot pass vacuously if the thread name literal drifts; the parameters are ignored without a session id; and the internal path keeps its call sequence, its minted holder shape and its release-under-the-acquired-holder when the parameters are absent.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`feat(agent):`, `test(agent):`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this feature (2 files, 2 commits)
- [ ] I've run `pytest tests/ -q` and all tests pass. Not claimed: the focused and regression runs reported above were run, the full suite was not. The wider run in step 5 has 7 known local baseline failures that reproduce with this change absent.
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11, CPython 3.11.11, pytest 9.1.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation. The two new parameters are documented in the `run_conversation` docstring, which is where the rest of this method's contract lives.
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys. N/A, no config keys added. The 300.0 default matches the existing internal literal rather than introducing a second source of truth.
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows. N/A, no architecture or workflow changed. The lease design, its storage, and its fence are all as they are on main.
- [x] I've considered cross-platform impact. The change adds no syscall, path, or process operation. The tests use `tmp_path` and `os.getpid()` only, carry no OS marker because the file is host-independent, and force nothing about SQLite journal mode.
- [x] I've updated tool descriptions/schemas if I changed tool behavior. N/A, no model-facing tool changed.

## Screenshots / Logs

```text
$ python -m pytest tests/run_agent/test_external_turn_lease_holder.py -q
.......                                                                  [100%]
7 passed in 3.46s

$ python -m pytest tests/run_agent/test_cross_process_turn_lease.py tests/state/test_session_turn_lease.py -q
...............................                                          [100%]
31 passed in 9.28s

$ python scripts/check-windows-footguns.py --diff <base>
✓ No Windows footguns found (2 file(s) scanned).
```

Known local baseline on the wider run of step 5, reproduced identically on the parent commit with the production change absent:

```text
FAILED tests/run_agent/test_run_agent.py::TestAnthropicInterruptHandler::test_interruptible_anthropic_interrupt_never_closes_shared_client
FAILED tests/run_agent/test_compression_persistence.py::TestFlushAfterCompression::test_flush_after_compression_with_long_history
FAILED tests/run_agent/test_compression_persistence.py::TestFlushAfterCompression::test_flush_with_stale_history_loses_messages
FAILED tests/run_agent/test_compression_persistence.py::TestFlushAfterCompression::test_in_place_compression_rebaseline_prevents_duplicate_compacted_rows
FAILED tests/run_agent/test_compression_persistence.py::TestStoredPromptCwdDrift::test_stored_prompt_fresh_when_cwd_matches
FAILED tests/run_agent/test_compression_persistence.py::TestStoredPromptCwdDrift::test_project_context_cannot_force_a_rebuild
FAILED tests/run_agent/test_compression_persistence.py::TestStoredPromptCwdDrift::test_built_prompt_contains_platform_line
7 failed, 299 passed in 458.51s (0:07:38)
```

Against the parent commit, before the production change, the same test file:

```text
FFFFFF.                                                                  [100%]
E   TypeError: AIAgent.run_conversation() got an unexpected keyword argument 'session_turn_lease_holder'
FAILED tests/run_agent/test_external_turn_lease_holder.py::test_external_holder_skips_engine_acquire
FAILED tests/run_agent/test_external_turn_lease_holder.py::test_external_holder_defaults_ttl_when_unspecified
FAILED tests/run_agent/test_external_turn_lease_holder.py::test_external_holder_is_not_released_by_engine
FAILED tests/run_agent/test_external_turn_lease_holder.py::test_external_holder_arms_write_fence
FAILED tests/run_agent/test_external_turn_lease_holder.py::test_external_holder_starts_no_refresher
FAILED tests/run_agent/test_external_turn_lease_holder.py::test_external_holder_ignored_without_session_id
6 failed, 1 passed in 8.44s
```
