### PR TITLE
fix(tui_gateway): move interrupted-turn markers into state.db with owner-checked writes

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -30,6 +30,7 @@ import sys
 import threading
 import time
 from collections import deque
+from collections.abc import Iterable, Mapping
 from contextlib import contextmanager
 from pathlib import Path
 
@@ -164,6 +165,14 @@ class SessionExportTooLargeError(ValueError):
 
 
 _COMPRESSION_LOCK_HOLDER_PID_RE = re.compile(r"(?:^|:)pid=(\d+)(?::|$)")
+
+# Enough to re-submit any realistic prompt; keeps a pathological multi-megabyte
+# paste out of the interrupted-turn row on every turn.
+_INTERRUPTED_TURN_MAX_PROMPT_CHARS = 64_000
+# A record this old is past every usable auto-continue freshness window, and
+# without a sweep a conversation that is never resumed again keeps its row
+# forever. Same bound the desktop sidecar this table replaces enforced.
+_INTERRUPTED_TURN_MAX_AGE_SECS = 24 * 3600
 
 
 def _system_prompt_hash(system_prompt: str) -> str:
@@ -5977,6 +5986,247 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             )
 
         self._execute_write(_do)
+
+    # ── Interrupted turns ────────────────────────────────────────────────
+    #
+    # A turn that started running and never reached a terminal frame leaves a
+    # row in ``interrupted_turns``; ``session.resume`` reads it to decide
+    # whether to continue the interrupted prompt. Rows use the same
+    # compression-lineage root key as the turn lease, so a rotation mid-turn
+    # cannot orphan the record, and every mutation runs inside
+    # ``_execute_write`` (BEGIN IMMEDIATE) so concurrent processes serialize on
+    # the database instead of on a lock only one of them can see.
+    #
+    # Every method here is best-effort by design — this bookkeeping must never
+    # break a turn — so storage errors degrade to "no record" instead of
+    # raising, matching the file-backed implementation this replaces.
+
+    def record_interrupted_turn(
+        self,
+        session_id: str,
+        prompt: str,
+        *,
+        attempts: int = 0,
+        owner: Optional[str] = None,
+        cause: Optional[str] = None,
+    ) -> bool:
+        """Record the turn that is about to run, stamping ``owner`` on the row.
+
+        ``attempts`` counts how many automatic continuations led to this run: 0
+        for a user-initiated turn, N for the Nth re-run, which is what bounds
+        the crash-loop breaker.
+
+        Last writer wins. The row describes the turn running on this
+        conversation right now, and the row it replaces describes a turn that
+        already ended, so overwriting it is the correct record and is what lets
+        the attempts counter advance across a restart. The owner stamp is not
+        an admission decision; it is what makes the retire in
+        :meth:`clear_interrupted_turn` checkable.
+
+        Returns True when a row was written.
+        """
+        if not session_id:
+            return False
+        text = str(prompt or "")
+        if not text.strip():
+            return False
+        try:
+            attempt_count = max(0, int(attempts))
+        except (TypeError, ValueError):
+            attempt_count = 0
+        now = time.time()
+
+        def _do(conn):
+            conversation_id = self._session_turn_lease_key_on_conn(conn, session_id)
+            conn.execute(
+                "DELETE FROM interrupted_turns WHERE started_at < ?",
+                (now - _INTERRUPTED_TURN_MAX_AGE_SECS,),
+            )
+            conn.execute(
+                "INSERT INTO interrupted_turns "
+                "(conversation_id, prompt, attempts, started_at, owner, cause) "
+                "VALUES (?, ?, ?, ?, ?, ?) "
+                "ON CONFLICT(conversation_id) DO UPDATE SET "
+                "prompt = excluded.prompt, "
+                "attempts = excluded.attempts, "
+                "started_at = excluded.started_at, "
+                "owner = excluded.owner, "
+                "cause = excluded.cause",
+                (
+                    conversation_id,
+                    text[:_INTERRUPTED_TURN_MAX_PROMPT_CHARS],
+                    attempt_count,
+                    now,
+                    owner or None,
+                    cause or None,
+                ),
+            )
+            return True
+
+        try:
+            return bool(self._execute_write(_do))
+        except sqlite3.Error as exc:
+            logger.warning(
+                "record_interrupted_turn(%s) failed: %s", session_id, exc,
+            )
+            return False
+
+    def import_interrupted_turns(
+        self,
+        records: Iterable[Tuple[str, Mapping[str, Any]]],
+        *,
+        cause: str = "migrated",
+    ) -> int:
+        """Import legacy records in one transaction; returns rows written.
+
+        ``records`` yields ``(session_id, entry)`` pairs where ``entry`` holds
+        ``prompt``, ``attempts`` and ``started_at``. ``session_id`` is the key
+        the legacy record was filed under, which is the compression *segment*
+        the turn was running on; the resolver maps it to the lineage root this
+        table is keyed on, so a record written before a rotation lands on the
+        row a post-rotation resume actually reads. Because of that mapping two
+        legacy keys can resolve to a single row, and the first pair imported
+        wins — pass them newest first.
+
+        Imported rows carry no owner: the legacy format never recorded one, so
+        any process may retire them. A row already present also wins; it was
+        written by a live process and is newer than anything being imported.
+        """
+        pending = []
+        for session_id, entry in records:
+            if not session_id or not isinstance(entry, Mapping):
+                continue
+            text = str(entry.get("prompt") or "")
+            if not text.strip():
+                continue
+            try:
+                attempt_count = max(0, int(entry.get("attempts") or 0))
+                started = float(entry.get("started_at") or 0)
+            except (TypeError, ValueError):
+                continue
+            pending.append(
+                (
+                    str(session_id),
+                    text[:_INTERRUPTED_TURN_MAX_PROMPT_CHARS],
+                    attempt_count,
+                    started,
+                )
+            )
+        if not pending:
+            return 0
+
+        def _do(conn):
+            written = 0
+            for session_id, text, attempt_count, started in pending:
+                conversation_id = self._session_turn_lease_key_on_conn(
+                    conn, session_id
+                )
+                cursor = conn.execute(
+                    "INSERT OR IGNORE INTO interrupted_turns "
+                    "(conversation_id, prompt, attempts, started_at, owner, cause) "
+                    "VALUES (?, ?, ?, ?, NULL, ?)",
+                    (
+                        conversation_id,
+                        text,
+                        attempt_count,
+                        started,
+                        cause or None,
+                    ),
+                )
+                written += cursor.rowcount
+            return written
+
+        return int(self._execute_write(_do))
+
+    def read_interrupted_turn(self, session_id: str) -> Optional[dict]:
+        """The record left by a turn that never concluded, or None."""
+        if not session_id:
+            return None
+        try:
+            with self._read_ctx() as conn:
+                conversation_id = self._session_turn_lease_key_on_conn(
+                    conn, session_id
+                )
+                row = conn.execute(
+                    "SELECT prompt, attempts, started_at, owner, cause "
+                    "FROM interrupted_turns WHERE conversation_id = ?",
+                    (conversation_id,),
+                ).fetchone()
+        except sqlite3.Error as exc:
+            logger.warning(
+                "read_interrupted_turn(%s) failed: %s", session_id, exc,
+            )
+            return None
+        if row is None:
+            return None
+        prompt = str(row["prompt"] or "")
+        if not prompt.strip():
+            return None
+        try:
+            started_at = float(row["started_at"] or 0)
+            attempts = max(0, int(row["attempts"] or 0))
+        except (TypeError, ValueError):
+            return None
+        return {
+            "attempts": attempts,
+            "prompt": prompt,
+            "started_at": started_at,
+            "owner": row["owner"],
+            "cause": row["cause"],
+        }
+
+    def clear_interrupted_turn(
+        self,
+        session_id: str,
+        *,
+        owner: Optional[str],
+        force: bool = False,
+    ) -> bool:
+        """Retire the record of a turn that concluded; True when a row went.
+
+        ``owner`` is checked against the stamp
+        :meth:`record_interrupted_turn` wrote. A process may retire its own
+        record, and a legacy record that carries no owner, and nothing else:
+        without that check a process that merely tried to take the conversation
+        and gave up can delete the record of a turn still running elsewhere,
+        and a crash of that turn then recovers nothing.
+
+        ``force`` retires regardless of owner and exists for the scheduler's
+        policy deletions. A record past its freshness window or its attempt
+        ceiling is no longer actionable by any process, and the scheduler that
+        just made that determination is the right one to clear it.
+        """
+        if not session_id:
+            return False
+
+        def _do(conn):
+            conversation_id = self._session_turn_lease_key_on_conn(conn, session_id)
+            if force:
+                cursor = conn.execute(
+                    "DELETE FROM interrupted_turns WHERE conversation_id = ?",
+                    (conversation_id,),
+                )
+            elif owner:
+                cursor = conn.execute(
+                    "DELETE FROM interrupted_turns "
+                    "WHERE conversation_id = ? AND (owner = ? OR owner IS NULL)",
+                    (conversation_id, owner),
+                )
+            else:
+                cursor = conn.execute(
+                    "DELETE FROM interrupted_turns "
+                    "WHERE conversation_id = ? AND owner IS NULL",
+                    (conversation_id,),
+                )
+            return cursor.rowcount > 0
+
+        try:
+            return bool(self._execute_write(_do))
+        except sqlite3.Error as exc:
+            logger.warning(
+                "clear_interrupted_turn(%s) failed: %s", session_id, exc,
+            )
+            return False
 
     def get_compression_lock_holder(self, session_id: str) -> Optional[str]:
         """Return the current (non-expired) holder for ``session_id``, or None.

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -6091,18 +6091,44 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         Imported rows carry no owner: the legacy format never recorded one, so
         any process may retire them. A row already present also wins; it was
         written by a live process and is newer than anything being imported.
+
+        An entry the legacy file left unusable is dropped rather than imported
+        half-formed. Only the total is returned, so each drop is logged at
+        debug with its key and reason: a caller that renames the file aside on
+        success has no second chance to see what did not come across.
         """
         pending = []
         for session_id, entry in records:
             if not session_id or not isinstance(entry, Mapping):
+                logger.debug(
+                    "import_interrupted_turns: skipping %r, unusable entry "
+                    "of type %s",
+                    session_id,
+                    type(entry).__name__,
+                )
                 continue
             text = str(entry.get("prompt") or "")
             if not text.strip():
+                logger.debug(
+                    "import_interrupted_turns: skipping %r, empty prompt",
+                    session_id,
+                )
                 continue
+            raw_attempts = raw_started = None
             try:
-                attempt_count = max(0, int(entry.get("attempts") or 0))
-                started = float(entry.get("started_at") or 0)
-            except (TypeError, ValueError):
+                raw_attempts = entry.get("attempts")
+                raw_started = entry.get("started_at")
+                attempt_count = max(0, int(raw_attempts or 0))
+                started = float(raw_started or 0)
+            except (TypeError, ValueError) as exc:
+                logger.debug(
+                    "import_interrupted_turns: skipping %r, "
+                    "attempts=%r started_at=%r not numeric: %s",
+                    session_id,
+                    raw_attempts,
+                    raw_started,
+                    exc,
+                )
                 continue
             pending.append(
                 (

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -6189,7 +6189,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         record, and a legacy record that carries no owner, and nothing else:
         without that check a process that merely tried to take the conversation
         and gave up can delete the record of a turn still running elsewhere,
-        and a crash of that turn then recovers nothing.
+        and nothing then resumes that turn automatically.
 
         ``force`` retires regardless of owner and exists for the scheduler's
         policy deletions. A record past its freshness window or its attempt

--- a/hermes_state_common.py
+++ b/hermes_state_common.py
@@ -390,6 +390,22 @@ CREATE TABLE IF NOT EXISTS session_turn_leases (
     expires_at REAL NOT NULL
 );
 
+-- Durable record of a turn that started running and never reached a terminal
+-- frame, so session.resume can offer to continue it (see
+-- tui_gateway/server.py _maybe_schedule_auto_continue). Keyed on the same
+-- compression-lineage root as session_turn_leases so a rotation mid-turn does
+-- not orphan the record. ``owner`` is the process that started the turn; only
+-- that process may retire the record, which is what stops a second process
+-- from deleting a turn it never ran.
+CREATE TABLE IF NOT EXISTS interrupted_turns (
+    conversation_id TEXT PRIMARY KEY,
+    prompt TEXT NOT NULL,
+    attempts INTEGER NOT NULL DEFAULT 0,
+    started_at REAL NOT NULL,
+    owner TEXT,
+    cause TEXT
+);
+
 CREATE TABLE IF NOT EXISTS async_delegations (
     delegation_id TEXT PRIMARY KEY,
     origin_session TEXT NOT NULL,
@@ -427,6 +443,7 @@ CREATE INDEX IF NOT EXISTS idx_messages_assistant_calls_by_session
     WHERE role = 'assistant' AND tool_calls IS NOT NULL;
 CREATE INDEX IF NOT EXISTS idx_compression_locks_expires ON compression_locks(expires_at);
 CREATE INDEX IF NOT EXISTS idx_session_turn_leases_expires ON session_turn_leases(expires_at);
+CREATE INDEX IF NOT EXISTS idx_interrupted_turns_started ON interrupted_turns(started_at);
 CREATE INDEX IF NOT EXISTS idx_session_model_usage_session ON session_model_usage(session_id);
 CREATE INDEX IF NOT EXISTS idx_session_model_usage_model ON session_model_usage(model);
 CREATE INDEX IF NOT EXISTS idx_async_delegations_delivery

--- a/tests/state/test_interrupted_turns.py
+++ b/tests/state/test_interrupted_turns.py
@@ -1,0 +1,241 @@
+"""Durable interrupted-turn records in state.db.
+
+A turn that starts running and never reaches a terminal frame leaves a row in
+``interrupted_turns``; ``session.resume`` reads it to decide whether to continue
+the interrupted prompt. These records used to live in a JSON sidecar that every
+process rewrote in full and any process could delete. The properties pinned
+here are the ones the file could not have:
+
+* a write touches one conversation's row and no other's, even from a second
+  process handle;
+* only the process that recorded a turn may retire it, so a process that never
+  ran the turn cannot delete the record of one that is still running;
+* records imported from the legacy file carry no owner and stay retirable by
+  anyone, and their keys are resolved to the compression-lineage root the table
+  is keyed on.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+
+from hermes_state import SessionDB
+
+
+def _owner(tag: str) -> str:
+    return f"pid={os.getpid()}:platform={tag}"
+
+
+def test_interrupted_turn_roundtrip(tmp_path):
+    db = SessionDB(tmp_path / "state.db")
+
+    assert db.record_interrupted_turn(
+        "abc", "fix the bug", attempts=1, owner=_owner("a")
+    )
+
+    record = db.read_interrupted_turn("abc")
+    assert record is not None
+    assert record["prompt"] == "fix the bug"
+    assert record["attempts"] == 1
+    assert record["owner"] == _owner("a")
+    assert abs(record["started_at"] - time.time()) < 5
+
+    assert db.clear_interrupted_turn("abc", owner=_owner("a"))
+    assert db.read_interrupted_turn("abc") is None
+
+
+def test_empty_prompt_records_nothing(tmp_path):
+    db = SessionDB(tmp_path / "state.db")
+
+    assert not db.record_interrupted_turn("abc", "   ", owner=_owner("a"))
+    assert not db.record_interrupted_turn("", "prompt", owner=_owner("a"))
+    assert db.read_interrupted_turn("abc") is None
+
+
+def test_foreign_owner_cannot_retire_a_live_record(tmp_path):
+    """The record of a running turn survives another process retiring it.
+
+    This is the lease-timeout path: a second process submits on a conversation
+    the first is already running, its engine waits for the turn lease, times
+    out, and the gateway retires the record as it emits the terminal error
+    frame. The turn it retired belongs to someone else.
+    """
+    path = tmp_path / "state.db"
+    running = SessionDB(path)
+    timing_out = SessionDB(path)
+
+    running.record_interrupted_turn(
+        "conv", "the turn that is actually running", owner=_owner("running")
+    )
+
+    assert not timing_out.clear_interrupted_turn("conv", owner=_owner("timing-out"))
+
+    survivor = running.read_interrupted_turn("conv")
+    assert survivor is not None
+    assert survivor["prompt"] == "the turn that is actually running"
+    assert running.clear_interrupted_turn("conv", owner=_owner("running"))
+
+
+def test_write_does_not_clobber_another_conversation(tmp_path):
+    """Two handles recording different conversations both keep their record.
+
+    The sidecar loaded the whole map, changed one key and stored the map back,
+    so a write for one conversation could drop a record for another. A row is
+    a row.
+    """
+    path = tmp_path / "state.db"
+    first = SessionDB(path)
+    second = SessionDB(path)
+
+    first.record_interrupted_turn("conv-a", "prompt for A", owner=_owner("first"))
+    second.record_interrupted_turn("conv-b", "prompt for B", owner=_owner("second"))
+
+    assert first.read_interrupted_turn("conv-a")["prompt"] == "prompt for A"
+    assert first.read_interrupted_turn("conv-b")["prompt"] == "prompt for B"
+
+
+def test_recording_takes_ownership_of_the_row(tmp_path):
+    """A new turn's record replaces the spent one and carries the new owner.
+
+    A turn only starts after the previous one ended, so the row it replaces
+    describes a turn that is over — usually one whose process died, which is
+    exactly the case whose attempts counter has to keep advancing for the
+    crash-loop breaker to work.
+    """
+    path = tmp_path / "state.db"
+    crashed = SessionDB(path)
+    restarted = SessionDB(path)
+
+    crashed.record_interrupted_turn(
+        "conv", "the interrupted prompt", attempts=0, owner=_owner("crashed")
+    )
+    assert restarted.record_interrupted_turn(
+        "conv", "the interrupted prompt", attempts=1, owner=_owner("restarted")
+    )
+
+    record = restarted.read_interrupted_turn("conv")
+    assert record["attempts"] == 1
+    assert record["owner"] == _owner("restarted")
+    # The dead process's owner string no longer retires it; the live one does.
+    assert not restarted.clear_interrupted_turn("conv", owner=_owner("crashed"))
+    assert restarted.clear_interrupted_turn("conv", owner=_owner("restarted"))
+
+
+def test_force_retires_regardless_of_owner(tmp_path):
+    """The scheduler's policy deletion: past every window, actionable by none."""
+    db = SessionDB(tmp_path / "state.db")
+    db.record_interrupted_turn("conv", "stale prompt", owner=_owner("someone-else"))
+
+    assert db.clear_interrupted_turn("conv", owner=_owner("scheduler"), force=True)
+    assert db.read_interrupted_turn("conv") is None
+
+
+def test_imported_record_has_no_owner_and_stays_retirable(tmp_path):
+    """Legacy records never recorded an owner, so nobody is locked out of them."""
+    db = SessionDB(tmp_path / "state.db")
+
+    assert db.import_interrupted_turns(
+        [("conv", {"prompt": "legacy prompt", "attempts": 1, "started_at": time.time()})]
+    ) == 1
+
+    record = db.read_interrupted_turn("conv")
+    assert record["prompt"] == "legacy prompt"
+    assert record["attempts"] == 1
+    assert record["owner"] is None
+    assert record["cause"] == "migrated"
+
+    assert db.clear_interrupted_turn("conv", owner=_owner("any-process"))
+    assert db.read_interrupted_turn("conv") is None
+
+
+def test_import_does_not_overwrite_a_live_record(tmp_path):
+    """A row written by a running process is newer than anything being imported."""
+    db = SessionDB(tmp_path / "state.db")
+    db.record_interrupted_turn("conv", "live prompt", owner=_owner("live"))
+
+    assert db.import_interrupted_turns(
+        [("conv", {"prompt": "legacy prompt", "started_at": time.time() - 60})]
+    ) == 0
+
+    record = db.read_interrupted_turn("conv")
+    assert record["prompt"] == "live prompt"
+    assert record["owner"] == _owner("live")
+
+
+def test_records_are_keyed_on_the_conversation_root(tmp_path):
+    """Compression segments share one record, as they share one turn lease."""
+    db = SessionDB(tmp_path / "state.db")
+    db.create_session("root", source="test")
+    db.end_session("root", "compression")
+    db.create_session("child", source="test", parent_session_id="root")
+
+    db.record_interrupted_turn("root", "prompt before rotation", owner=_owner("a"))
+
+    # The resume after the rotation looks the record up under the child id.
+    record = db.read_interrupted_turn("child")
+    assert record is not None
+    assert record["prompt"] == "prompt before rotation"
+
+
+def test_import_translates_a_segment_key_to_the_root(tmp_path):
+    """Legacy records were filed under the segment, not the lineage root.
+
+    Without the translation a record written before a rotation would import to
+    a row no post-rotation resume ever reads.
+    """
+    db = SessionDB(tmp_path / "state.db")
+    db.create_session("root", source="test")
+    db.end_session("root", "compression")
+    db.create_session("child", source="test", parent_session_id="root")
+
+    assert db.import_interrupted_turns(
+        [(
+            "root",
+            {"prompt": "prompt from before the rotation", "started_at": time.time()},
+        )]
+    ) == 1
+
+    record = db.read_interrupted_turn("child")
+    assert record is not None
+    assert record["prompt"] == "prompt from before the rotation"
+    assert record["owner"] is None
+
+
+def test_two_legacy_segments_collapse_to_one_row_newest_first(tmp_path):
+    """Both segments of a rotated conversation resolve to the same row."""
+    db = SessionDB(tmp_path / "state.db")
+    db.create_session("root", source="test")
+    db.end_session("root", "compression")
+    db.create_session("child", source="test", parent_session_id="root")
+    now = time.time()
+
+    written = db.import_interrupted_turns([
+        ("child", {"prompt": "after the rotation", "started_at": now}),
+        ("root", {"prompt": "before the rotation", "started_at": now - 600}),
+    ])
+
+    assert written == 1
+    assert db.read_interrupted_turn("child")["prompt"] == "after the rotation"
+
+
+def test_records_older_than_a_day_are_swept_on_write(tmp_path):
+    """Same bound the sidecar enforced on every write."""
+    db = SessionDB(tmp_path / "state.db")
+    db.import_interrupted_turns([
+        ("ancient", {"prompt": "two days ago", "started_at": time.time() - 48 * 3600}),
+        ("recent", {"prompt": "an hour ago", "started_at": time.time() - 3600}),
+    ])
+    assert db.read_interrupted_turn("ancient") is not None
+
+    db.record_interrupted_turn("fresh", "now", owner=_owner("a"))
+
+    assert db.read_interrupted_turn("ancient") is None
+    assert db.read_interrupted_turn("recent") is not None
+    assert db.read_interrupted_turn("fresh") is not None
+
+
+def test_missing_record_reads_as_none(tmp_path):
+    db = SessionDB(tmp_path / "state.db")
+    assert db.read_interrupted_turn("nobody") is None
+    assert not db.clear_interrupted_turn("nobody", owner=_owner("a"))

--- a/tests/tui_gateway/test_auto_continue.py
+++ b/tests/tui_gateway/test_auto_continue.py
@@ -1,35 +1,36 @@
 """Crash-interrupted turns auto-continue on the next session.resume.
 
-A turn's durable marker (tui_gateway/turn_marker.py) is written when the turn
-starts running and cleared when it concludes — success, handled error, or
-interrupt. Only a process death leaves it behind, so a marker found at resume
+A turn's durable record (``interrupted_turns`` in state.db) is written when the
+turn starts running and cleared when it concludes — success, handled error, or
+interrupt. Only a process death leaves it behind, so a record found at resume
 time is positive proof the turn never finished. Contract pinned here:
 
-* the marker module round-trips, prunes stale entries, and tolerates a
-  corrupt sidecar;
-* ``_run_prompt_submit`` writes the marker before the turn and clears it in
+* ``_run_prompt_submit`` writes the record before the turn and clears it in
   the ``finally`` on both the success and exception paths (a handled failure
   is a concluded turn — its terminal frame + retained snapshot own recovery);
+* the retire is owner-checked: a process that never ran the turn cannot delete
+  the record of one still running elsewhere;
 * ``_maybe_schedule_auto_continue`` re-submits a fresh interrupted prompt as
   a continuation note (display_kind ``auto_continue``), refuses stale /
   disabled / crash-looping / already-running cases, and bounds attempts via
-  the marker's attempt counter.
+  the record's attempt counter;
+* the legacy JSON sidecar is imported once per HERMES_HOME and renamed aside,
+  with its keys resolved to the compression-lineage root the table uses.
 """
 
 from __future__ import annotations
 
+import json
 import threading
 import time
 import types
 
 import pytest
 
-from tui_gateway import server
-from tui_gateway.turn_marker import (
-    clear_turn_marker,
-    read_turn_marker,
-    record_turn_start,
-)
+from hermes_state import SessionDB
+from tui_gateway import server, turn_marker
+
+_FOREIGN_OWNER = "pid=999999:platform=other"
 
 
 class _InlineThread:
@@ -70,6 +71,24 @@ def _session(agent=None, **extra):
     }
 
 
+def _record(db, session_key, prompt, *, attempts=0, owner=_FOREIGN_OWNER):
+    """A record left by some other process's interrupted turn."""
+    assert db.record_interrupted_turn(
+        session_key, prompt, attempts=attempts, owner=owner
+    )
+
+
+def _read(db, session_key):
+    return db.read_interrupted_turn(session_key)
+
+
+def _write_sidecar(home, entries):
+    path = home / "desktop" / "interrupted_turns.json"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(entries), encoding="utf-8")
+    return path
+
+
 @pytest.fixture()
 def emits(monkeypatch):
     captured: list = []
@@ -83,13 +102,21 @@ def emits(monkeypatch):
 
 @pytest.fixture()
 def marker_home(monkeypatch, tmp_path):
-    """Point the server's marker storage at a temp HERMES_HOME."""
+    """Point the server's session home at a temp HERMES_HOME."""
     monkeypatch.setattr(server, "_hermes_home", tmp_path)
     return tmp_path
 
 
 @pytest.fixture()
-def turn_env(monkeypatch, tmp_path, marker_home):
+def turn_db(monkeypatch, marker_home):
+    """Point the server's state.db handle at a temp database."""
+    db = SessionDB(marker_home / "state.db")
+    monkeypatch.setattr(server, "_get_db", lambda: db)
+    return db
+
+
+@pytest.fixture()
+def turn_env(monkeypatch, tmp_path, turn_db):
     """Neutralize the turn pipeline's environment-heavy side paths."""
     monkeypatch.setattr(server.threading, "Thread", _InlineThread)
     monkeypatch.setattr(server, "_wire_callbacks", lambda sid: None)
@@ -101,40 +128,67 @@ def turn_env(monkeypatch, tmp_path, marker_home):
     monkeypatch.setattr(server, "_get_usage", lambda agent: {})
 
 
-# ── Marker module ──────────────────────────────────────────────────────
+# ── Record storage ─────────────────────────────────────────────────────
 
 
-def test_marker_roundtrip(tmp_path):
-    record_turn_start(tmp_path, "abc", "fix the bug", attempts=1)
+def test_record_roundtrip(turn_db):
+    _record(turn_db, "abc", "fix the bug", attempts=1)
 
-    marker = read_turn_marker(tmp_path, "abc")
+    marker = _read(turn_db, "abc")
     assert marker is not None
     assert marker["prompt"] == "fix the bug"
     assert marker["attempts"] == 1
     assert marker["started_at"] == pytest.approx(time.time(), abs=5)
 
-    clear_turn_marker(tmp_path, "abc")
-    assert read_turn_marker(tmp_path, "abc") is None
+    assert turn_db.clear_interrupted_turn("abc", owner=_FOREIGN_OWNER)
+    assert _read(turn_db, "abc") is None
 
 
-def test_marker_survives_corrupt_sidecar(tmp_path):
-    path = tmp_path / "desktop" / "interrupted_turns.json"
-    path.parent.mkdir(parents=True)
-    path.write_text("{not json")
+def test_a_foreign_process_cannot_retire_a_live_record(turn_db, marker_home):
+    """The record of a turn running elsewhere survives this process's retire.
 
-    assert read_turn_marker(tmp_path, "abc") is None
-    record_turn_start(tmp_path, "abc", "prompt")
-    assert read_turn_marker(tmp_path, "abc")["prompt"] == "prompt"
+    A second process that submits on a busy conversation waits for the turn
+    lease, times out, and emits a terminal error frame — and the frame path
+    retires the record as it goes. Before the owner check that deleted the
+    running turn's only durable trace.
+    """
+    _record(turn_db, "session-key", "the turn that is actually running")
+
+    server._retire_turn_marker(_session())
+
+    survivor = _read(turn_db, "session-key")
+    assert survivor is not None
+    assert survivor["prompt"] == "the turn that is actually running"
 
 
-# ── Turn lifecycle owns the marker ─────────────────────────────────────
+def test_retire_tolerates_the_keyless_call(turn_env, turn_db):
+    """``_emit_terminal_turn_error`` retires with no explicit keys."""
+    session = _session()
+    server._record_interrupted_turn(session, "session-key", "own turn")
+    assert _read(turn_db, "session-key") is not None
+
+    server._retire_turn_marker(session)
+
+    assert _read(turn_db, "session-key") is None
 
 
-def test_concluded_turn_clears_marker(emits, turn_env, marker_home):
+def test_retire_covers_a_key_compression_rotated_mid_turn(turn_env, turn_db):
+    session = _session(session_key="rotated-key")
+    server._record_interrupted_turn(session, "pre-rotation-key", "own turn")
+
+    server._retire_turn_marker(session, "pre-rotation-key")
+
+    assert _read(turn_db, "pre-rotation-key") is None
+
+
+# ── Turn lifecycle owns the record ─────────────────────────────────────
+
+
+def test_concluded_turn_clears_marker(emits, turn_env, turn_db):
     seen_mid_turn: list = []
 
     def _run(message, **kwargs):
-        seen_mid_turn.append(read_turn_marker(marker_home, "session-key"))
+        seen_mid_turn.append(_read(turn_db, "session-key"))
         return {"final_response": "done"}
 
     agent = types.SimpleNamespace(
@@ -149,12 +203,12 @@ def test_concluded_turn_clears_marker(emits, turn_env, marker_home):
     assert seen_mid_turn[0]["prompt"] == "do the thing"
     assert seen_mid_turn[0]["attempts"] == 0
     # … and cleared once the turn concluded.
-    assert read_turn_marker(marker_home, "session-key") is None
+    assert _read(turn_db, "session-key") is None
 
 
-def test_handled_failure_still_clears_marker(emits, turn_env, marker_home):
+def test_handled_failure_still_clears_marker(emits, turn_env, turn_db):
     """An exception is a CONCLUDED turn (terminal frame + retained snapshot own
-    recovery) — only a process death may leave the marker behind."""
+    recovery) — only a process death may leave the record behind."""
 
     def _boom(message, **kwargs):
         raise RuntimeError("provider exploded")
@@ -166,19 +220,19 @@ def test_handled_failure_still_clears_marker(emits, turn_env, marker_home):
 
     server._run_prompt_submit("rid", "sid", session, "do the thing")
 
-    assert read_turn_marker(marker_home, "session-key") is None
+    assert _read(turn_db, "session-key") is None
 
 
 def test_continuation_turn_records_attempt_and_original_prompt(
-    emits, turn_env, marker_home
+    emits, turn_env, turn_db
 ):
-    """A continuation's marker must carry the attempt count (crash-loop
+    """A continuation's record must carry the attempt count (crash-loop
     breaker) and the ORIGINAL prompt — recording its own recovery note would
     nest note inside note on a second crash."""
     seen: list = []
 
     def _run(message, **kwargs):
-        seen.append(read_turn_marker(marker_home, "session-key"))
+        seen.append(_read(turn_db, "session-key"))
         return {"final_response": "done"}
 
     agent = types.SimpleNamespace(
@@ -199,7 +253,39 @@ def test_continuation_turn_records_attempt_and_original_prompt(
     assert "_auto_continue_prompt" not in session
 
 
-def test_older_agent_still_gets_the_post_turn_stamp(emits, turn_env, marker_home):
+def test_continuation_takes_over_a_dead_process_record(emits, turn_env, turn_db):
+    """The attempts counter has to advance across a restart.
+
+    The record being continued was written by the process that died. Refusing
+    to overwrite another owner's row would freeze the counter and defeat the
+    crash-loop breaker, so a turn start takes the row over and stamps itself.
+    """
+    _record(turn_db, "session-key", "the original prompt", attempts=1)
+    seen: list = []
+
+    def _run(message, **kwargs):
+        seen.append(_read(turn_db, "session-key"))
+        return {"final_response": "done"}
+
+    agent = types.SimpleNamespace(
+        session_id="session-key", run_conversation=_run, clear_interrupt=lambda: None
+    )
+    session = _session(
+        agent=agent,
+        running=True,
+        _auto_continue_attempt=2,
+        _auto_continue_prompt="the original prompt",
+    )
+
+    server._run_prompt_submit("rid", "sid", session, "note")
+
+    assert seen[0]["attempts"] == 2
+    assert seen[0]["owner"] == server._turn_record_owner()
+    # This process owns it now, so its own retire lands.
+    assert _read(turn_db, "session-key") is None
+
+
+def test_older_agent_still_gets_the_post_turn_stamp(emits, turn_env, turn_db):
     """An agent whose run_conversation predates turn-start typing keeps the
     original behavior — the row is typed once the turn concludes."""
     stamped: list = []
@@ -232,7 +318,7 @@ def test_older_agent_still_gets_the_post_turn_stamp(emits, turn_env, marker_home
 
 
 @pytest.fixture()
-def schedule_env(monkeypatch, marker_home):
+def schedule_env(monkeypatch, turn_db):
     monkeypatch.setattr(server.threading, "Thread", _InlineThread)
     monkeypatch.setattr(server, "_start_agent_build", lambda sid, session: None)
     monkeypatch.setattr(server, "_wait_agent", lambda session, rid, timeout=30.0: None)
@@ -246,8 +332,8 @@ def schedule_env(monkeypatch, marker_home):
     return submitted
 
 
-def test_fresh_marker_schedules_continuation(emits, schedule_env, marker_home):
-    record_turn_start(marker_home, "session-key", "fix the flaky test")
+def test_fresh_marker_schedules_continuation(emits, schedule_env, turn_db):
+    _record(turn_db, "session-key", "fix the flaky test")
     session = _session()
 
     result = server._maybe_schedule_auto_continue("sid", session, "session-key")
@@ -263,8 +349,8 @@ def test_fresh_marker_schedules_continuation(emits, schedule_env, marker_home):
     assert ("message.start", "sid", None) in [(e, s, p) for e, s, p in emits]
 
 
-def test_stale_marker_is_cleared_not_continued(schedule_env, marker_home, monkeypatch):
-    record_turn_start(marker_home, "session-key", "old prompt")
+def test_stale_marker_is_cleared_not_continued(schedule_env, turn_db, monkeypatch):
+    _record(turn_db, "session-key", "old prompt")
     monkeypatch.setattr(
         server, "time", types.SimpleNamespace(time=lambda: time.time() + 3600)
     )
@@ -273,11 +359,11 @@ def test_stale_marker_is_cleared_not_continued(schedule_env, marker_home, monkey
 
     assert result is None
     assert not schedule_env
-    assert read_turn_marker(marker_home, "session-key") is None
+    assert _read(turn_db, "session-key") is None
 
 
-def test_config_widens_freshness_window(emits, schedule_env, marker_home, monkeypatch):
-    record_turn_start(marker_home, "session-key", "old prompt")
+def test_config_widens_freshness_window(emits, schedule_env, turn_db, monkeypatch):
+    _record(turn_db, "session-key", "old prompt")
     monkeypatch.setattr(
         server,
         "_load_cfg",
@@ -293,18 +379,18 @@ def test_config_widens_freshness_window(emits, schedule_env, marker_home, monkey
     assert len(schedule_env) == 1
 
 
-def test_exhausted_attempts_break_the_loop(schedule_env, marker_home):
-    record_turn_start(marker_home, "session-key", "crashy prompt", attempts=2)
+def test_exhausted_attempts_break_the_loop(schedule_env, turn_db):
+    _record(turn_db, "session-key", "crashy prompt", attempts=2)
 
     result = server._maybe_schedule_auto_continue("sid", _session(), "session-key")
 
     assert result is None
     assert not schedule_env
-    assert read_turn_marker(marker_home, "session-key") is None
+    assert _read(turn_db, "session-key") is None
 
 
-def test_disabled_by_config(schedule_env, marker_home, monkeypatch):
-    record_turn_start(marker_home, "session-key", "prompt")
+def test_disabled_by_config(schedule_env, turn_db, monkeypatch):
+    _record(turn_db, "session-key", "prompt")
     monkeypatch.setattr(
         server,
         "_load_cfg",
@@ -317,15 +403,15 @@ def test_disabled_by_config(schedule_env, marker_home, monkeypatch):
     assert not schedule_env
 
 
-def test_no_marker_means_no_continuation(schedule_env, marker_home):
+def test_no_marker_means_no_continuation(schedule_env, turn_db):
     assert server._maybe_schedule_auto_continue("sid", _session(), "session-key") is None
     assert not schedule_env
 
 
-def test_running_session_wins_over_continuation(emits, schedule_env, marker_home):
-    """A real user prompt that raced the kickoff keeps its turn; the marker is
+def test_running_session_wins_over_continuation(emits, schedule_env, turn_db):
+    """A real user prompt that raced the kickoff keeps its turn; the record is
     left for that turn's own conclusion to clear."""
-    record_turn_start(marker_home, "session-key", "prompt")
+    _record(turn_db, "session-key", "prompt")
     session = _session(running=True)
 
     result = server._maybe_schedule_auto_continue("sid", session, "session-key")
@@ -334,14 +420,14 @@ def test_running_session_wins_over_continuation(emits, schedule_env, marker_home
     assert result is not None
     assert not schedule_env
     assert session["_auto_continue_scheduled"] is False
-    assert read_turn_marker(marker_home, "session-key") is not None
+    assert _read(turn_db, "session-key") is not None
     # Nothing left behind for the racing user turn to inherit.
     assert "_auto_continue_attempt" not in session
     assert "_auto_continue_prompt" not in session
 
 
-def test_double_schedule_is_guarded(emits, schedule_env, marker_home):
-    record_turn_start(marker_home, "session-key", "prompt")
+def test_double_schedule_is_guarded(emits, schedule_env, turn_db):
+    _record(turn_db, "session-key", "prompt")
     session = _session()
 
     first = server._maybe_schedule_auto_continue("sid", session, "session-key")
@@ -353,9 +439,9 @@ def test_double_schedule_is_guarded(emits, schedule_env, marker_home):
 
 
 def test_failed_agent_build_leaves_marker_for_retry(
-    emits, schedule_env, marker_home, monkeypatch
+    emits, schedule_env, turn_db, monkeypatch
 ):
-    record_turn_start(marker_home, "session-key", "prompt")
+    _record(turn_db, "session-key", "prompt")
     monkeypatch.setattr(
         server,
         "_wait_agent",
@@ -368,9 +454,149 @@ def test_failed_agent_build_leaves_marker_for_retry(
     assert result is not None
     assert not schedule_env
     assert session["_auto_continue_scheduled"] is False
-    assert read_turn_marker(marker_home, "session-key") is not None
+    assert _read(turn_db, "session-key") is not None
 
 
-# ── End to end: continuation runs a real turn and clears the marker ────
+# ── Legacy sidecar import ──────────────────────────────────────────────
 
 
+def test_legacy_sidecar_imports_and_is_renamed_aside(schedule_env, turn_db, marker_home):
+    path = _write_sidecar(
+        marker_home,
+        {
+            "session-key": {
+                "attempts": 1,
+                "prompt": "the prompt the old build recorded",
+                "started_at": time.time(),
+            }
+        },
+    )
+
+    result = server._maybe_schedule_auto_continue("sid", _session(), "session-key")
+
+    assert result is not None
+    assert result["attempt"] == 2
+    (text, _kwargs), = schedule_env
+    assert "the prompt the old build recorded" in text
+    assert not path.exists()
+    assert (marker_home / "desktop" / "interrupted_turns.json.migrated").is_file()
+
+
+def test_legacy_sidecar_key_is_resolved_to_the_conversation_root(
+    schedule_env, turn_db, marker_home
+):
+    """The sidecar filed records under the compression SEGMENT.
+
+    A record written before a rotation has to land on the row the resume after
+    the rotation reads, which is the lineage root.
+    """
+    turn_db.create_session("root", source="test")
+    turn_db.end_session("root", "compression")
+    turn_db.create_session("child", source="test", parent_session_id="root")
+    _write_sidecar(
+        marker_home,
+        {
+            "root": {
+                "attempts": 0,
+                "prompt": "recorded before the rotation",
+                "started_at": time.time(),
+            }
+        },
+    )
+
+    result = server._maybe_schedule_auto_continue(
+        "sid", _session(session_key="child"), "child"
+    )
+
+    assert result is not None
+    (text, _kwargs), = schedule_env
+    assert "recorded before the rotation" in text
+
+
+def test_imported_record_carries_no_owner_and_stays_retirable(turn_db, marker_home):
+    _write_sidecar(
+        marker_home,
+        {
+            "session-key": {
+                "attempts": 0,
+                "prompt": "legacy prompt",
+                "started_at": time.time(),
+            }
+        },
+    )
+    session = _session()
+
+    server._migrate_turn_markers(session)
+
+    record = _read(turn_db, "session-key")
+    assert record["owner"] is None
+    assert record["cause"] == "migrated"
+    server._retire_turn_marker(session)
+    assert _read(turn_db, "session-key") is None
+
+
+def test_import_does_not_overwrite_a_live_record(turn_db, marker_home):
+    _record(turn_db, "session-key", "the live record", attempts=1)
+    _write_sidecar(
+        marker_home,
+        {
+            "session-key": {
+                "attempts": 0,
+                "prompt": "the legacy record",
+                "started_at": time.time() - 60,
+            }
+        },
+    )
+
+    server._migrate_turn_markers(_session())
+
+    record = _read(turn_db, "session-key")
+    assert record["prompt"] == "the live record"
+    assert record["attempts"] == 1
+
+
+def test_corrupt_legacy_sidecar_is_retired_without_breaking_resume(
+    schedule_env, turn_db, marker_home
+):
+    """The unreadable-file case the sidecar had to tolerate, now at import."""
+    path = marker_home / "desktop" / "interrupted_turns.json"
+    path.parent.mkdir(parents=True)
+    path.write_text("{not json", encoding="utf-8")
+    session = _session()
+
+    assert server._maybe_schedule_auto_continue("sid", session, "session-key") is None
+    assert not path.exists()
+
+    # Recording still works afterwards.
+    server._record_interrupted_turn(session, "session-key", "prompt")
+    assert _read(turn_db, "session-key")["prompt"] == "prompt"
+
+
+def test_failed_import_leaves_the_sidecar_for_the_next_resume(
+    turn_db, marker_home, monkeypatch
+):
+    path = _write_sidecar(
+        marker_home,
+        {
+            "session-key": {
+                "attempts": 0,
+                "prompt": "legacy prompt",
+                "started_at": time.time(),
+            }
+        },
+    )
+
+    def _boom(home):
+        raise OSError("rename denied")
+
+    monkeypatch.setattr(server, "retire_sidecar", _boom)
+    server._migrate_turn_markers(_session())
+    assert path.is_file()
+
+    monkeypatch.setattr(server, "retire_sidecar", turn_marker.retire_sidecar)
+    server._migrate_turn_markers(_session())
+    assert not path.exists()
+    assert _read(turn_db, "session-key")["prompt"] == "legacy prompt"
+
+
+# ── End to end: continuation runs a real turn and clears the record ────

--- a/tests/tui_gateway/test_auto_continue.py
+++ b/tests/tui_gateway/test_auto_continue.py
@@ -150,7 +150,9 @@ def test_a_foreign_process_cannot_retire_a_live_record(turn_db, marker_home):
     A second process that submits on a busy conversation waits for the turn
     lease, times out, and emits a terminal error frame — and the frame path
     retires the record as it goes. Before the owner check that deleted the
-    running turn's only durable trace.
+    scheduler's only durable pointer to the running turn: the prompt row
+    itself survives in the session DB, so what it cost was the automatic
+    resume, not the data.
     """
     _record(turn_db, "session-key", "the turn that is actually running")
 
@@ -390,7 +392,13 @@ def test_exhausted_attempts_break_the_loop(schedule_env, turn_db):
 
 
 def test_disabled_by_config(schedule_env, turn_db, monkeypatch):
-    _record(turn_db, "session-key", "prompt")
+    """Disabled here says nothing about a record another process owns.
+
+    ``enabled`` is this process's config, and the process that wrote the
+    record may be running with auto-continue on — so declining to continue is
+    not licence to retire someone else's live record.
+    """
+    _record(turn_db, "session-key", "the turn that is actually running")
     monkeypatch.setattr(
         server,
         "_load_cfg",
@@ -401,6 +409,27 @@ def test_disabled_by_config(schedule_env, turn_db, monkeypatch):
 
     assert result is None
     assert not schedule_env
+    survivor = _read(turn_db, "session-key")
+    assert survivor is not None
+    assert survivor["prompt"] == "the turn that is actually running"
+
+
+def test_disabled_by_config_still_clears_own_record(schedule_env, turn_db, monkeypatch):
+    """Its own record is retired: this process will never continue that turn."""
+    session = _session()
+    server._record_interrupted_turn(session, "session-key", "own turn")
+    assert _read(turn_db, "session-key") is not None
+    monkeypatch.setattr(
+        server,
+        "_load_cfg",
+        lambda: {"desktop": {"auto_continue": {"enabled": False}}},
+    )
+
+    result = server._maybe_schedule_auto_continue("sid", session, "session-key")
+
+    assert result is None
+    assert not schedule_env
+    assert _read(turn_db, "session-key") is None
 
 
 def test_no_marker_means_no_continuation(schedule_env, turn_db):

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -39,9 +39,9 @@ from agent.skill_commands import describe_skill_invocation
 from agent.conversation_loop import INTERRUPT_WAITING_FOR_MODEL_PREFIX
 from tui_gateway import git_probe
 from tui_gateway.turn_marker import (
-    clear_turn_marker,
-    read_turn_marker,
-    record_turn_start,
+    read_turn_markers,
+    retire_sidecar,
+    sidecar_exists,
 )
 from tui_gateway.transport import (
     StdioTransport,
@@ -7602,20 +7602,138 @@ def _session_home(session: dict) -> Path:
     return Path(profile_home) if profile_home else Path(_hermes_home)
 
 
+def _turn_record_owner() -> str:
+    """This process's stamp on interrupted-turn records.
+
+    Same shape as the durable turn lease's holder (``run_agent.py`` mints
+    ``pid=<pid>:turn=<id>:platform=<platform>``) without the per-turn nonce: a
+    record outlives the turn that wrote it, and every turn in this process is
+    equally entitled to retire it. Computed per call rather than cached so a
+    forked child stamps its own pid.
+    """
+    return f"pid={os.getpid()}:platform=tui"
+
+
+def _record_interrupted_turn(
+    session: dict, key: str, prompt: str, *, attempts: int = 0
+) -> None:
+    """Record a turn that is about to run, stamped with this process."""
+    if not key or not isinstance(prompt, str) or not prompt.strip():
+        return
+    try:
+        with _session_db(session) as db:
+            if db is None:
+                return
+            db.record_interrupted_turn(
+                key, prompt, attempts=attempts, owner=_turn_record_owner()
+            )
+    except Exception:
+        logger.debug("failed to record interrupted turn for %s", key, exc_info=True)
+
+
+def _read_interrupted_turn(session: dict, key: str) -> dict | None:
+    """The record left by a turn on ``key`` that never concluded, or None."""
+    if not key:
+        return None
+    try:
+        with _session_db(session) as db:
+            if db is None:
+                return None
+            return db.read_interrupted_turn(key)
+    except Exception:
+        logger.debug("failed to read interrupted turn for %s", key, exc_info=True)
+        return None
+
+
+def _clear_interrupted_turn(session: dict, *keys: str, force: bool = False) -> None:
+    """Retire records this process owns; ``force`` retires regardless of owner."""
+    wanted = list(dict.fromkeys(key for key in keys if key))
+    if not wanted:
+        return
+    owner = _turn_record_owner()
+    try:
+        with _session_db(session) as db:
+            if db is None:
+                return
+            for key in wanted:
+                db.clear_interrupted_turn(key, owner=owner, force=force)
+    except Exception:
+        logger.debug("failed to clear interrupted turn", exc_info=True)
+
+
+_TURN_MARKER_MIGRATION_LOCK = threading.Lock()
+_TURN_MARKER_MIGRATION_WARNED: set[str] = set()
+
+
+def _migrate_turn_markers(session: dict) -> None:
+    """Import this home's legacy interrupted-turn sidecar, once, then rename it.
+
+    Lazy and per-HERMES_HOME rather than per-process: ``_session_home`` is
+    profile-aware, so one gateway can be serving two homes with a sidecar
+    each. The rename is the one-shot flag — a failure leaves the file in place
+    and the next resume retries; only the warning is deduplicated. Once a home
+    has no sidecar this costs one stat and takes no lock.
+
+    Legacy entries carry no owner, so they import as ``owner IS NULL`` and any
+    process may retire them, which is the same freedom the file gave.
+    """
+    home = _session_home(session)
+    if not sidecar_exists(home):
+        return
+    with _TURN_MARKER_MIGRATION_LOCK:
+        # Re-check: a concurrent resume on this home may have just finished.
+        if not sidecar_exists(home):
+            return
+        home_key = os.path.normcase(os.path.abspath(str(home)))
+        entries = read_turn_markers(home)
+        try:
+            with _session_db(session) as db:
+                if db is None:
+                    return
+                # Newest first: two sidecar keys can be segments of one
+                # compression lineage and therefore resolve to a single row,
+                # and the newest record is the one a resume should see.
+                imported = db.import_interrupted_turns(
+                    sorted(
+                        entries.items(),
+                        key=lambda item: item[1]["started_at"],
+                        reverse=True,
+                    )
+                )
+            retire_sidecar(home)
+        except Exception:
+            if home_key not in _TURN_MARKER_MIGRATION_WARNED:
+                _TURN_MARKER_MIGRATION_WARNED.add(home_key)
+                logger.warning(
+                    "could not import the legacy interrupted-turn sidecar; "
+                    "leaving it in place to retry on the next resume",
+                    exc_info=True,
+                )
+            return
+        _TURN_MARKER_MIGRATION_WARNED.discard(home_key)
+        if imported:
+            logger.info(
+                "imported %d legacy interrupted-turn record(s) into state.db",
+                imported,
+            )
+
+
 def _retire_turn_marker(session: dict, *keys: str) -> None:
-    """Drop the crash marker for a turn whose outcome is about to reach the client.
+    """Drop the crash record for a turn whose outcome is about to reach the client.
 
     Called immediately before the terminal frame rather than at the end of the
     turn thread: post-turn work (titles, memory sync, goal hooks) runs for a
     second or more after the client has its answer, and quitting inside that
-    window would leave a marker that looks like a crash — re-running a finished
+    window would leave a record that looks like a crash — re-running a finished
     turn on the next launch. Extra ``keys`` cover a session_key that
     compression rotated mid-turn.
+
+    Owner-checked: this retires the records this process wrote (and legacy
+    records that carry no owner). A turn running in another process keeps its
+    record even when this one decides the turn is over, because only the
+    process that ran the turn can know that it ended.
     """
-    home = _session_home(session)
-    for key in dict.fromkeys((*keys, str(session.get("session_key") or ""))):
-        if key:
-            clear_turn_marker(home, key)
+    _clear_interrupted_turn(session, *keys, str(session.get("session_key") or ""))
 
 
 def _auto_continue_note(prompt: str) -> str:
@@ -7642,8 +7760,8 @@ def _maybe_schedule_auto_continue(sid: str, session: dict, session_key: str) -> 
     same _run_prompt_submit machinery as every other synthesized turn — so
     the client that just resumed streams it live.
     """
-    home = _session_home(session)
-    marker = read_turn_marker(home, session_key)
+    _migrate_turn_markers(session)
+    marker = _read_interrupted_turn(session, session_key)
     if marker is None:
         return None
     enabled, freshness_secs, max_attempts = _auto_continue_config()
@@ -7651,7 +7769,9 @@ def _maybe_schedule_auto_continue(sid: str, session: dict, session_key: str) -> 
     if not enabled or age > freshness_secs or marker["attempts"] >= max_attempts:
         # Stale, disabled, or crash-looping: stop trying. The journal/partial
         # transcript still shows what happened; a manual message continues it.
-        clear_turn_marker(home, session_key)
+        # Retired regardless of owner — the record is past a window every
+        # process reads the same way, so it is actionable by none of them.
+        _clear_interrupted_turn(session, session_key, force=True)
         return None
     if session.get("_auto_continue_scheduled"):
         return None
@@ -10276,18 +10396,19 @@ def _run_prompt_submit(
         # True once a failed turn's snapshot was retained for resume replay —
         # tells the finally below to skip the normal inflight clear.
         turn_error_retained = False
-        # Durable crash marker: written before the turn runs, retired the
+        # Durable crash record: written before the turn runs, retired the
         # moment its outcome reaches the client (see _retire_turn_marker).
         # Any concluded turn — success, handled error, interrupt — retires
-        # it, so a marker that survives means the process died mid-turn;
+        # it, so a record that survives means the process died mid-turn;
         # session.resume auto-continues from it. Compression can rotate
         # session_key mid-turn, so remember the key we wrote under.
-        marker_home = _session_home(session)
         marker_key = str(session.get("session_key") or "")
         marker_attempt = int(session.pop("_auto_continue_attempt", 0) or 0)
         marker_text = session.pop("_auto_continue_prompt", None) or text
         if isinstance(marker_text, str) and marker_text.strip():
-            record_turn_start(marker_home, marker_key, marker_text, attempts=marker_attempt)
+            _record_interrupted_turn(
+                session, marker_key, marker_text, attempts=marker_attempt
+            )
         try:
             from tools.approval import (
                 reset_current_session_key,

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -7766,12 +7766,18 @@ def _maybe_schedule_auto_continue(sid: str, session: dict, session_key: str) -> 
         return None
     enabled, freshness_secs, max_attempts = _auto_continue_config()
     age = time.time() - marker["started_at"]
-    if not enabled or age > freshness_secs or marker["attempts"] >= max_attempts:
-        # Stale, disabled, or crash-looping: stop trying. The journal/partial
-        # transcript still shows what happened; a manual message continues it.
-        # Retired regardless of owner — the record is past a window every
-        # process reads the same way, so it is actionable by none of them.
+    if age > freshness_secs or marker["attempts"] >= max_attempts:
+        # Stale or crash-looping: a policy retirement, so it is taken
+        # regardless of owner. The journal/partial transcript still shows what
+        # happened; a manual message continues it.
         _clear_interrupted_turn(session, session_key, force=True)
+        return None
+    if not enabled:
+        # Disabled is a local policy state, not a fact about the record:
+        # another process may run with auto-continue on, and this one may be
+        # re-enabled later. Retire only what this process owns (plus ownerless
+        # legacy imports) and leave a foreign owner's live record alone.
+        _clear_interrupted_turn(session, session_key)
         return None
     if session.get("_auto_continue_scheduled"):
         return None

--- a/tui_gateway/turn_marker.py
+++ b/tui_gateway/turn_marker.py
@@ -1,21 +1,22 @@
-"""Durable interrupted-turn markers for the desktop/TUI auto-continue path.
+"""Reader for the legacy interrupted-turn sidecar (migration only).
 
-A running turn's progress lives only in process memory (the agent flushes to
-SQLite at turn end, not mid-turn), so an app/backend/machine death mid-turn
-leaves no durable trace of the interrupted prompt. This sidecar is that
-trace: a marker is written when a turn starts running and cleared when the
-turn concludes — success, handled error, or interrupt all clear it, so only
-a process death leaves one behind. ``session.resume`` reads the marker to
-decide whether to auto-continue the interrupted turn (see
-``_maybe_schedule_auto_continue`` in ``tui_gateway/server.py``).
+Interrupted-turn records live in ``state.db``'s ``interrupted_turns`` table
+(see ``SessionDB.record_interrupted_turn``). Before that they lived in this
+JSON sidecar, one file per ``HERMES_HOME``, rewritten in full on every turn
+start. This module is what remains of it: a reader the gateway calls once per
+home to import surviving entries into the table, after which the file is
+renamed and never read again.
 
-Markers are stored per ``HERMES_HOME`` (callers pass the session's home so
-profile sessions keep their state in their own profile directory) and the
-file is bounded: writes prune entries older than ``_MAX_AGE_SECS`` and cap
-the total count, so an unlucky streak of crashes can't grow it unboundedly.
+Nothing writes the sidecar any more. The whole-file rewrite it used was
+synchronized only by a lock local to the writing process, so two processes
+sharing a home could each load the map, change one key, and store the result,
+silently dropping the other's record; and any process could delete any entry,
+including one belonging to a turn still running elsewhere. Both are structural
+properties of the file format, which is why the record moved to a table with
+per-row writes and an owner stamp.
 
-Every function is best-effort by design — marker bookkeeping must never
-break a turn — so I/O errors degrade to "no marker" instead of raising.
+Reads are best-effort: an unreadable or corrupt file degrades to "no entries"
+instead of raising, so a bad sidecar cannot block a resume.
 """
 
 from __future__ import annotations
@@ -23,9 +24,6 @@ from __future__ import annotations
 import json
 import logging
 import os
-import tempfile
-import threading
-import time
 from pathlib import Path
 from typing import Any
 
@@ -33,13 +31,7 @@ logger = logging.getLogger(__name__)
 
 _MARKER_DIR = "desktop"
 _MARKER_FILE = "interrupted_turns.json"
-_MAX_AGE_SECS = 24 * 3600
-_MAX_ENTRIES = 32
-# Enough to re-submit any realistic prompt; guards the sidecar against a
-# pathological multi-megabyte paste being journaled on every turn.
-_MAX_PROMPT_CHARS = 64_000
-
-_lock = threading.Lock()
+_MIGRATED_SUFFIX = ".migrated"
 
 
 def _marker_path(home: Path | str) -> Path:
@@ -53,99 +45,14 @@ def _load(path: Path) -> dict[str, dict]:
     except FileNotFoundError:
         return {}
     except Exception:
-        logger.debug("unreadable turn-marker file %s; starting fresh", path, exc_info=True)
+        logger.debug("unreadable turn-marker file %s; ignoring", path, exc_info=True)
         return {}
     if not isinstance(data, dict):
         return {}
     return {k: v for k, v in data.items() if isinstance(v, dict)}
 
 
-def _prune(entries: dict[str, dict], now: float) -> dict[str, dict]:
-    fresh = {
-        key: entry
-        for key, entry in entries.items()
-        if now - float(entry.get("started_at") or 0) <= _MAX_AGE_SECS
-    }
-    if len(fresh) <= _MAX_ENTRIES:
-        return fresh
-    newest = sorted(
-        fresh.items(),
-        key=lambda item: float(item[1].get("started_at") or 0),
-        reverse=True,
-    )[:_MAX_ENTRIES]
-    return dict(newest)
-
-
-def _store(path: Path, entries: dict[str, dict]) -> None:
-    if not entries:
-        path.unlink(missing_ok=True)
-        return
-    path.parent.mkdir(parents=True, exist_ok=True)
-    fd, tmp = tempfile.mkstemp(dir=path.parent, prefix=".turn-marker-")
-    try:
-        with os.fdopen(fd, "w", encoding="utf-8") as f:
-            json.dump(entries, f)
-        os.replace(tmp, path)
-    except Exception:
-        try:
-            os.unlink(tmp)
-        except OSError:
-            pass
-        raise
-
-
-def record_turn_start(
-    home: Path | str, session_key: str, prompt: str, *, attempts: int = 0
-) -> None:
-    """Persist the marker for a turn that is about to run.
-
-    ``attempts`` counts how many auto-continues led to this run: 0 for a
-    user-initiated turn, N for the Nth automatic re-run — the crash-loop
-    breaker reads it back on the next resume.
-    """
-    if not session_key or not prompt:
-        return
-    now = time.time()
-    entry = {
-        "attempts": max(0, int(attempts)),
-        "prompt": prompt[:_MAX_PROMPT_CHARS],
-        "started_at": now,
-    }
-    try:
-        with _lock:
-            path = _marker_path(home)
-            entries = _prune(_load(path), now)
-            entries[session_key] = entry
-            _store(path, entries)
-    except Exception:
-        logger.debug("failed to record turn marker for %s", session_key, exc_info=True)
-
-
-def clear_turn_marker(home: Path | str, session_key: str) -> None:
-    """Remove the marker once its turn concluded (any outcome the client saw)."""
-    if not session_key:
-        return
-    try:
-        with _lock:
-            path = _marker_path(home)
-            entries = _load(path)
-            if session_key not in entries:
-                return
-            del entries[session_key]
-            _store(path, entries)
-    except Exception:
-        logger.debug("failed to clear turn marker for %s", session_key, exc_info=True)
-
-
-def read_turn_marker(home: Path | str, session_key: str) -> dict[str, Any] | None:
-    """The marker left by a turn that never concluded, or None."""
-    if not session_key:
-        return None
-    try:
-        with _lock:
-            entry = _load(_marker_path(home)).get(session_key)
-    except Exception:
-        return None
+def _coerce_entry(entry: Any) -> dict[str, Any] | None:
     if not isinstance(entry, dict):
         return None
     prompt = str(entry.get("prompt") or "")
@@ -157,3 +64,40 @@ def read_turn_marker(home: Path | str, session_key: str) -> dict[str, Any] | Non
     except (TypeError, ValueError):
         return None
     return {"attempts": attempts, "prompt": prompt, "started_at": started_at}
+
+
+def sidecar_exists(home: Path | str) -> bool:
+    """Whether this home still has a sidecar left to import."""
+    try:
+        return _marker_path(home).is_file()
+    except Exception:
+        return False
+
+
+def retire_sidecar(home: Path | str) -> None:
+    """Rename the sidecar aside once its entries are in the table.
+
+    Raises on failure so the caller can leave the file where it is and retry
+    on the next resume; the rename is what makes the import one-shot.
+    """
+    path = _marker_path(home)
+    os.replace(path, path.with_name(path.name + _MIGRATED_SUFFIX))
+
+
+def read_turn_markers(home: Path | str) -> dict[str, dict[str, Any]]:
+    """Every usable entry in the legacy sidecar, keyed as the file keyed them.
+
+    Keys are the session key the turn was running under when it was recorded,
+    which is the compression segment rather than the lineage root the table is
+    keyed on — the importer resolves that.
+    """
+    try:
+        raw = _load(_marker_path(home))
+    except Exception:
+        return {}
+    entries = {}
+    for session_key, entry in raw.items():
+        coerced = _coerce_entry(entry)
+        if session_key and coerced is not None:
+            entries[str(session_key)] = coerced
+    return entries


### PR DESCRIPTION
## What does this PR do?

A turn that starts running and never reaches a terminal frame leaves a durable marker, and `session.resume` reads it to decide whether to continue the interrupted prompt. That marker lives in `<HERMES_HOME>/desktop/interrupted_turns.json`: one JSON map per home, rewritten in full on every turn start, with no owner recorded. Two `hermes serve` processes sharing one `HERMES_HOME` lose markers two ways.

**Marker loss on write.** `record_turn_start` loads the whole map, sets one key, and stores the whole map back (`tui_gateway/turn_marker.py:114-119`, with `_store` writing the entire map at `:79-94`). The only synchronization is a module-level `threading.Lock` at `:42`, which is local to the writing process and gates nothing across processes. Two processes starting turns on two different conversations each store a map that predates the other's write, so one conversation's marker is gone. The write site is `tui_gateway/server.py:10290`.

**Marker loss on retire.** The retire takes no owner (`tui_gateway/server.py:7605-7618`, calling `clear_turn_marker` at `tui_gateway/turn_marker.py:124-137`), and the terminal-frame path always calls it. A process that submits on a conversation another process is already running waits for that conversation's turn lease (`run_agent.py:8197`, up to 1800s), times out, and returns `error: session_turn_lease_timeout:<id>` with `failed: True` (`run_agent.py:8253-8261`). The gateway renders any `result["error"]` as a terminal error frame (`tui_gateway/server.py:10694-10698`) and retires the marker on its way out (`:10762`), with the `finally` backstop repeating it (`:11015`). The marker it deleted belongs to the process still running the turn, whose interrupted turn nothing then resumes automatically if it dies. One of the three retire call sites passes no keys at all, inside `_emit_terminal_turn_error` (`:8150`).

Both are properties of the file format rather than of any one call site, so the marker moves into `state.db` as an `interrupted_turns` table:

```sql
CREATE TABLE IF NOT EXISTS interrupted_turns (
    conversation_id TEXT PRIMARY KEY,
    prompt TEXT NOT NULL,
    attempts INTEGER NOT NULL DEFAULT 0,
    started_at REAL NOT NULL,
    owner TEXT,
    cause TEXT
);
```

One row per conversation, so a write touches nothing else. Every mutation runs inside `_execute_write` (BEGIN IMMEDIATE), so concurrent processes serialize on the database instead of on a lock only one of them can see. Rows are keyed on the compression-lineage root through the shipped resolver `_session_turn_lease_key_on_conn` (`hermes_state.py:5775-5811`), the same key `session_turn_leases` already uses, so the marker and the lease for one conversation can never disagree and a rotation mid-turn cannot orphan the record.

`owner` is stamped by the process that started the turn, as `pid=<pid>:platform=tui`. That is the shape `run_agent.py:8172-8175` already mints for the lease holder, without the per-turn nonce: a marker outlives the turn that wrote it, and the `finally` backstop has to be able to retire a marker written by a different turn in the same process. `clear_interrupted_turn` deletes only where `owner = ? OR owner IS NULL`, which is what makes the second defect above match nothing.

Auto-continue's scheduling decision is unchanged, and its record retirement changes in one arm. `_maybe_schedule_auto_continue` reads the record from the table and applies the same `desktop.auto_continue` enabled / freshness / max-attempts gates and the same in-memory dedupe to the same fields, in the same order. The stale and exhausted arms still retire the record through an explicit `force=True`, because those are this scheduler's policy deletions rather than ownership claims. The disabled arm does not force. It clears through the owner check, so it retires this process's own record and imported records that carry no owner, and leaves another process's live record alone. Disabled is a per-process config state that can be reverted, so it is not a reason to delete a record another process may still be acting on.

## Related Issue

Related to #86190. This is the "retire the sidecar" half of what that issue leaves open; the admission-polarity half is a separate follow-up, described under "What I did not do".

Related to #81319. Both auto-continue legs funnel through this scheduler, so the record it reads has to be trustworthy before anything else about that path can be reasoned about.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

`hermes_state_common.py`: appends the `interrupted_turns` table to `SCHEMA_SQL` after `session_turn_leases`, plus `idx_interrupted_turns_started` alongside the other expiry indexes. It is a pure `CREATE TABLE IF NOT EXISTS` append, and `SCHEMA_SQL` is applied by `executescript` on every open, so `IF NOT EXISTS` handles mixed-order creation. `SCHEMA_VERSION` is deliberately not bumped: the version table is retained for data migrations that transform existing rows and cannot be expressed declaratively, and a new empty table needs none.

`hermes_state.py`: adds `record_interrupted_turn`, `import_interrupted_turns`, `read_interrupted_turn`, and `clear_interrupted_turn` after `release_session_turn_lease`. Every one resolves the lineage root on its own connection through the existing resolver, and every one is best-effort in the same sense the file-backed code was, degrading to "no record" on a storage error rather than breaking a turn.

`tui_gateway/server.py`: `_turn_record_owner()` mints this process's stamp; three thin helpers wrap the `SessionDB` calls in the existing profile-aware `_session_db` contextmanager; `_migrate_turn_markers` performs the one-shot import; `_retire_turn_marker` keeps its signature and becomes an owner-checked clear; `_maybe_schedule_auto_continue` reads the table; `_run_prompt_submit` records to the table.

`tui_gateway/turn_marker.py`: reduced to a reader for the import. `_lock`, `_prune`, `_store`, `record_turn_start` and `clear_turn_marker` are gone; `_marker_path` and `_load` stay; `read_turn_markers`, `sidecar_exists` and `retire_sidecar` are the public surface, so `server.py` never needs to know the file layout.

`tests/state/test_interrupted_turns.py`: new, 13 tests covering the storage contract.

`tests/tui_gateway/test_auto_continue.py`: 15 tests to 25. Details under "How to Test".

### Migration

Existing markers are imported lazily, once per `HERMES_HOME`, at the first `_maybe_schedule_auto_continue` evaluation that finds a sidecar. The whole set goes in as one transaction with `INSERT OR IGNORE`, so a row a live process already wrote wins, and then the file is renamed to `interrupted_turns.json.migrated`. The rename is the one-shot flag: an import that fails leaves the file in place, warns once for that home, and retries on the next resume. The flag has to be per home rather than per process because `_session_home` and `_session_db` are both profile-aware, so one process can be serving two homes with a sidecar each. Once a home has no sidecar the cost is one `is_file()` and no lock.

Imported rows carry `owner = NULL` and `cause = 'migrated'`. The legacy format recorded exactly `{"attempts", "prompt", "started_at"}` and no owner, so `NULL` is exact rather than a guess, and it keeps those rows retirable by any process, which is the freedom the file gave them.

Keys are translated on the way in. The file keyed on `session["session_key"]`, which is the compression segment the turn was running on (`tui_gateway/server.py:10286`); the table keys on the lineage root. Without the translation a marker written before a rotation would import to a row that no post-rotation resume ever reads, which would silently turn "we migrated your interrupted turns" into "we lost them". Because two legacy keys can be segments of one lineage and collapse to a single row, the import is documented as first-pair-wins and the caller passes them newest first.

## How to Test

1. `pytest tests/state/test_interrupted_turns.py tests/tui_gateway/test_auto_continue.py`
2. `pytest tests/tui_gateway/ tests/state/`
3. For the storage defects specifically, the two regression tests are `tests/state/test_interrupted_turns.py::test_write_does_not_clobber_another_conversation` (two handles on one database, two conversations, both records survive) and `::test_foreign_owner_cannot_retire_a_live_record` (the lease-timeout shape: a handle that never recorded the turn cannot delete it). `tests/tui_gateway/test_auto_continue.py::test_a_foreign_process_cannot_retire_a_live_record` runs the second one through the gateway's own `_retire_turn_marker`.

Both defects were also demonstrated against the unmodified pre-change tree using only the public sidecar functions, to confirm the regression tests describe a real defect rather than the current implementation. The clobber reproduces with two threads and the module lock replaced by a distinct no-op object, which is what a second process's own `threading.Lock` amounts to, plus a gate on `_store` that lets the second thread complete its whole load-mutate-store cycle first; that is the interleaving two processes hit whenever their turn starts overlap. The foreign delete reproduces with a single `clear_turn_marker` call.

### Behavior neutrality

The claim that auto-continue schedules identically is carried by the existing test file rather than asserted. `tests/tui_gateway/test_auto_continue.py` had 15 tests; 13 keep their names, their assertion predicates, and their control flow, with only the storage read helper swapped. Comparing every `assert` line in those 13 before and after: seven are byte-identical, and the other six changed exactly one line each, always the read helper and never the predicate (`read_turn_marker(home, key) is None` becomes a table read of the same key with the same `is None`). One of the 13 grew after that comparison: `test_disabled_by_config` gained a row assertion when the disabled arm stopped forcing, and its original two assertions are untouched. Their setup lines swap `record_turn_start(...)` for a table write under a deliberately foreign owner, so the retire paths are exercised against a row this process does not own, and the fixture that pointed at a temp `HERMES_HOME` now also points `_get_db` at a temp `state.db`.

Two tests were genuinely rewritten. `test_marker_roundtrip` became `test_record_roundtrip` against the table API with the same four assertions. `test_marker_survives_corrupt_sidecar` became `test_corrupt_legacy_sidecar_is_retired_without_breaking_resume`, since the corrupt-file case now belongs to the import: an unparseable sidecar is renamed aside rather than re-parsed on every resume, and recording still works afterwards.

Ten tests are new: the foreign-retire regression at gateway level (the clobber regression is a storage-layer test in `tests/state/`), the keyless retire, a rotated-key retire, ownership transfer across a restart, the disabled arm still clearing this process's own record, and five migration tests (import and rename, segment-key to lineage-root translation, an imported row carrying no owner and staying retirable, no overwrite of a live row, and a failed import leaving the file for the next resume).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass: what was actually run on Windows is `tests/tui_gateway/`, `tests/state/` and `tests/hermes_state/`, where every remaining failure is name-identical to the unmodified base (pre-existing environment flakes) and no new failure appears; full-suite green expected on Linux CI.
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11, Python 3.11. Linux via CI, macOS untested.

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A (no config keys added; the existing `desktop.auto_continue.*` knobs keep their exact meanings)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Uncertainty

The write is last-writer-wins, and that is a decision rather than an oversight. Refusing a foreign owner's write is the obvious symmetric choice and it is wrong here: after a process dies mid-turn its record carries the dead owner, so the process that restarts and re-runs that turn has a different pid and its write would be refused. `attempts` would never advance past the dead process's value and the crash-loop ceiling would never trip. The same refusal would hit a user who restarts and simply types on that conversation, leaving the live turn with no record at all. A liveness-gated variant (refuse only a provably live foreign owner) is implementable, but the liveness probe declines to prove death on every doubtful path including a `psutil`-less host, so it degrades to unconditional refusal exactly where it hurts, and deciding whether a foreign owner may proceed is admission policy rather than storage. The stamp therefore guards the delete, which is the half with a receipt.

The sweep of records older than 24 hours on every write deletes rows this process does not own. It is the sidecar's own `_MAX_AGE_SECS` bound carried over verbatim, and a record that old is past every usable freshness window, but it is an unowned delete and worth naming. The sidecar's 32-entry cap is deliberately not carried over: it trimmed other conversations' live records to bound the cost of rewriting one file, and a table has no such cost.

A profile-scoped session opens a fresh `SessionDB` handle per marker operation through the existing `_session_db` contextmanager, up to twice per turn. That matches how the rest of the gateway persists per-turn state, but it is heavier than the file write it replaces.

The migration has been exercised for a single compression rotation with a well-formed session row. A lineage whose parent row is missing falls back to the segment key, which is the key the file used, so that case behaves as it does today rather than losing anything.

## What I did not do

**Admission polarity is not in this PR.** Auto-continue still reaches the engine without consulting the turn lease, so two processes can still both decide to continue the same conversation and the second still overwrites the first's record. That is the change worth arguing about on its own terms, it needs a decision about what a second process should do rather than only about where the record lives, and bundling it here would mean a reviewer cannot check the behavior-neutrality claim above. It is the follow-up.

**No claim-and-bump CAS.** `claim_interrupted_turn`, the atomic "read the record, check the lease, take both, increment attempts" operation that polarity needs, is not here. Neither is `get_session_turn_lease_holder` or the in-transaction lease-acquire primitive it would need. All three belong with the polarity change.

**No holder threading into the engine.** `_run_prompt_submit` does not pass a lease holder to `run_conversation`, so the engine still acquires its own lease and the transcript-write fence is still off for this stack.

**No change to the recovery note.** `_auto_continue_note` still says the app or its backend process stopped, which is not the only way a marker survives. Correcting it needs the claim to prove what it asserts, so it goes with the polarity change.

**No config keys.** The lease TTL and wait remain literals in `run_agent.py`.

**`turn_marker.py` is not deleted.** It is reduced to the reader the import needs and can be removed once the migration window closes.

