### PR TITLE
feat(mcp): add Aidress to the MCP catalog

### DIFF
--- a/optional-mcps/aidress/manifest.yaml
+++ b/optional-mcps/aidress/manifest.yaml
@@ -1,0 +1,52 @@
+# Nous-approved MCP catalog entry.
+# Presence in this directory = approval. Merged via PR review.
+manifest_version: 1
+
+name: aidress
+description: Discover third-party agents by capability, and check their trust before delegating work to them.
+source: https://github.com/Aidress-ai/Aidress
+
+# Aidress is a hosted registry of third-party agents. Hermes connects straight
+# to the remote endpoint over Streamable HTTP — nothing is cloned, installed,
+# or executed locally, so there is no `install:` block and no bootstrap.
+transport:
+  type: http
+  url: https://api.aidress.ai/mcp-http/mcp
+
+auth:
+  type: none
+
+# The registry exposes 16 tools. The five below are the read-only ones —
+# discovery plus due diligence on what discovery returns — and they are public,
+# which is why this entry needs no credentials.
+#
+# The other eleven mutate registry state: registering an agent, rotating and
+# claiming keys, updating a profile, proxying a paid call to another agent,
+# and submitting a transaction review. They are left unchecked so an install
+# cannot write to a live registry by default, and they need an Aidress key to
+# work at all (see post_install).
+tools:
+  default_enabled:
+    - match_agents
+    - list_registry
+    - verify_agent
+    - get_agent
+    - protocol_reference
+
+post_install: |
+  No credentials needed. The five tools enabled by default are public reads.
+
+  Typical use is discovery first: ask for an agent that can do something
+  ("find me an agent that does web research") and Hermes searches the registry
+  by capability rather than starting from a list of services you already know.
+  Because the agents it turns up are ones you have not worked with before,
+  every result also carries trust data — a trust score, whether the agent is
+  verified, how many transactions it has completed, and any flags — so it can
+  vet a candidate before recommending it.
+
+  The remaining eleven tools write to the registry (register an agent, rotate
+  or claim a key, update a profile, proxy a paid call, submit a review). They
+  need an Aidress key, which this entry does not configure: add it as an
+  Authorization header on mcp_servers.aidress in your Hermes config, then
+  enable the tools you want with:
+    hermes mcp configure aidress

--- a/optional-mcps/aidress/manifest.yaml
+++ b/optional-mcps/aidress/manifest.yaml
@@ -16,6 +16,13 @@ transport:
 auth:
   type: none
 
+# What leaves the machine when these tools are enabled: this is a remote
+# service, so each tool call sends its arguments to api.aidress.ai over TLS.
+# That is the capability string you are searching for ("web research"), an
+# agent_id, a protocol_reference topic, or list_registry's limit/offset —
+# and nothing else. No conversation content, no file contents, and no
+# credentials, since these five tools take none. See post_install.
+
 # The registry exposes 16 tools. The five below are the read-only ones —
 # discovery plus due diligence on what discovery returns — and they are public,
 # which is why this entry needs no credentials.
@@ -35,6 +42,13 @@ tools:
 
 post_install: |
   No credentials needed. The five tools enabled by default are public reads.
+
+  Data flow: this is a remote service. Enabling these tools means each call
+  sends its arguments to https://api.aidress.ai over TLS — the capability you
+  are searching for, an agent_id, a protocol topic, or a limit/offset. Your
+  conversation, files, and environment are not sent, and these five tools take
+  no credentials. If you would rather nothing leave the machine, do not install
+  this entry: the registry it queries is remote by nature.
 
   Typical use is discovery first: ask for an agent that can do something
   ("find me an agent that does web research") and Hermes searches the registry


### PR DESCRIPTION
## What does this PR do?

Adds Aidress to the MCP catalog as `optional-mcps/aidress/manifest.yaml`.

Aidress is a hosted registry of third-party agents. It gives Hermes a **discovery** step it doesn't have today: instead of starting from services the user already knows about, Hermes can search the registry by capability — "find me an agent that does web research" — and learn at runtime who exists. Because the agents it turns up are ones the user has never worked with, every result also carries trust data (trust score, verified status, completed transaction count, flags), so a candidate can be vetted before anything is delegated to it.

That is a different shape from the current five entries, which each connect Hermes to one known service. This one is a lookup layer for finding services.

**On the security-review lane this triggers** (`optional-mcps/` per `scripts/ci/classify_changes.py`), the entry is deliberately the lowest-risk shape the schema allows:

- **No `install:` block, no bootstrap, no `transport.command:`.** Nothing is cloned, pip-installed, or executed locally — it's a remote Streamable HTTP endpoint, the same shape as `figma` and `comfy-cloud`. The trust-model warning in `website/docs/user-guide/features/mcp.md` about reading `install.bootstrap:` before installing has nothing to read here.
- **`auth: none`, and it genuinely needs none.** The five tools enabled by default are public reads.
- **11 of 16 tools are left unchecked by default.** The registry exposes tools that mutate registry state — registering an agent, rotating and claiming keys, updating a profile, proxying a paid call, submitting a review. `tools.default_enabled` lists only the five read-only ones, so an install cannot write to a live registry out of the box. This follows the curated-subset precedent from `comfy-cloud`.

## Related Issue

No issue — new catalog entry.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `optional-mcps/aidress/manifest.yaml` — new catalog entry. One file; nothing else touched.

## How to Test

1. Confirm the entry parses and joins the catalog:
   ```
   python3 -c "from hermes_cli.mcp_catalog import list_catalog, catalog_diagnostics; \
   print(sorted(e.name for e in list_catalog())); print(catalog_diagnostics())"
   ```
   ```
   ['aidress', 'comfy-cloud', 'figma', 'linear', 'n8n', 'unreal-engine']
   []
   ```

2. Confirm the endpoint the manifest points at is live and needs no credentials, and that every tool in `default_enabled` actually exists on it:
   ```
   manifest url : https://api.aidress.ai/mcp-http/mcp
   manifest auth: none
   live tools   : 16
   default_enabled (5): ['match_agents', 'list_registry', 'verify_agent', 'get_agent', 'protocol_reference']
   missing from live server: NONE
   left unchecked (11): ['call_agent', 'claim_bearer_key', 'import_agent', 'list_org_agents',
                         'preview_sandbox_match', 'promote_sandbox_agent', 'register_agent',
                         'review_transaction', 'rotate_agent_key', 'set_agent_key', 'update_agent']
   ```
   (Connected with the raw `mcp` SDK over `streamable_http_client`, no credentials supplied.)

3. `hermes mcp install aidress`, then ask for something you don't have a service for — e.g. "find me an agent that can do web research and tell me which one you'd trust." Discovery returns live candidates with their trust data.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass — I ran the tests that cover this change rather than the full suite: `tests/hermes_cli/test_mcp_catalog.py` and `tests/ci/test_classify_changes.py`, **62 passed**. Happy to run the whole suite if you'd like it on the record.
- [ ] I've added tests for my changes — the catalog is data-driven, and `test_mcp_catalog.py` validates every manifest in `optional-mcps/` including this one. No new test seemed warranted; glad to add one if you disagree.
- [x] I've tested on my platform: macOS 15 (Darwin 24.5.0), Python 3.12

### Documentation & Housekeeping

- [x] I've updated relevant documentation — or N/A. N/A: `website/docs/user-guide/features/mcp.md` documents the catalog generically and links the directory, so it needs no per-entry edit.
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A. N/A: no new config keys.
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A. N/A.
- [x] I've considered cross-platform impact — or N/A. N/A: remote HTTP endpoint, no local process, no platform-specific paths or commands.
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A. N/A: no Hermes tool behavior changed.

---

Two disclosures, since neither is obvious from the diff. I'm one of the authors of the registry this entry points at — the manifest describes what the service does and enables only its public read tools, and I've tried to write it the way I'd want to read a third-party entry during security review. And this PR was prepared with AI assistance; every claim in it was verified against the live endpoint and your own parser rather than asserted, including the tool-name check in step 2, which is the sort of thing that goes stale silently.

Entirely your call whether a discovery-and-trust layer belongs in a curated catalog. No hard feelings either way.
