### PR TITLE
fix(gateway): persist resume recovery notes

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1175,6 +1175,24 @@ def build_resume_recovery_note(
     )
 
 
+def _prepare_resume_pending_message(
+    reason: Optional[str],
+    message: Optional[str],
+    *,
+    interactive: bool = True,
+) -> tuple[str, str]:
+    """Return the recovery message and the identical persisted user text.
+
+    Resume turns replace the empty startup event with a recovery note before
+    entering the agent. Persist that note too, rather than the original empty
+    event, so the durable transcript matches what the model received.
+    """
+    recovery_message = build_resume_recovery_note(
+        reason, message or "", interactive=interactive,
+    )
+    return recovery_message, recovery_message
+
+
 # Assistant-message fields that must survive transcript replay so multi-turn
 # reasoning context, prefix-cache hits, and provider-specific echo
 # requirements all behave the same on the gateway as they do in the CLI.
@@ -5963,7 +5981,6 @@ class TurnRunner:
 
         if _is_resume_pending:
             _reason = getattr(_resume_entry, "resume_reason", None) or "restart_timeout"
-            _persist_user_message_override = ctx.message
             # The empty-message case is the auto-resume startup turn
             # synthesized by _schedule_resume_pending_sessions — there is
             # no NEW user message to address.  Guidance is adapter-aware:
@@ -5976,7 +5993,7 @@ class TurnRunner:
             _interactive_resume = bool(
                 getattr(_resume_adapter, "interactive_resume", True)
             )
-            ctx.message = build_resume_recovery_note(
+            ctx.message, _persist_user_message_override = _prepare_resume_pending_message(
                 _reason, ctx.message, interactive=_interactive_resume,
             )
         elif _has_fresh_tool_tail:

--- a/tests/gateway/test_restart_resume_pending.py
+++ b/tests/gateway/test_restart_resume_pending.py
@@ -40,6 +40,7 @@ from gateway.run import (
     _coerce_gateway_timestamp,
     _is_fresh_gateway_interruption,
     _last_transcript_timestamp,
+    _prepare_resume_pending_message,
     _should_clear_resume_pending_after_turn,
     build_resume_recovery_note,
 )
@@ -312,6 +313,18 @@ class TestResumePendingSystemNote:
         assert "skip any unfinished work" not in note
         # But still guards against re-running already-recorded tool calls.
         assert "already appear in the history" in note
+
+
+    def test_resume_note_is_persisted_instead_of_original_empty_message(self):
+        """The auto-resume note must not leave an empty row in state.db."""
+        message, persisted = _prepare_resume_pending_message(
+            "restart_timeout", "", interactive=False
+        )
+
+        assert message
+        assert "CONTINUE the interrupted task" in message
+        assert persisted == message
+        assert persisted != ""
 
 
     def test_resume_pending_fires_without_tool_tail(self):


### PR DESCRIPTION
Fixes #86580

## What does this PR do?

Persists the recovery system note generated for a `resume_pending` startup turn instead of persisting the original empty inbound message. This keeps the durable transcript aligned with the message sent to the model and prevents the pre-call sanitizer from healing the same empty user row on every subsequent turn.

## Related Issue

Fixes #86580

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/run.py`: build the resume recovery note once and use that same non-empty value for both the model input and `persist_user_message`.
- `tests/gateway/test_restart_resume_pending.py`: add a regression test proving the recovery note is persisted instead of the original empty message.

## How to Test

1. Run `pytest tests/gateway/test_restart_resume_pending.py -q`.
2. Run `ruff check gateway/run.py tests/gateway/test_restart_resume_pending.py`.
3. Confirm the regression test is red against the pre-fix `gateway/run.py` and green with this change.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass (targeted gateway regression suite run; full suite not run)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Validation on macOS:

- `32 passed` — `pytest tests/gateway/test_restart_resume_pending.py -q`
- `All checks passed!` — Ruff on both changed files
- Pre-fix sabotage run failed during collection because `_prepare_resume_pending_message` was absent; restored implementation passed the full targeted suite.
