### PR TITLE
fix(tools): report search_files truncation only when an extra hit exists

### DIFF
--- a/tests/tools/test_file_operations.py
+++ b/tests/tools/test_file_operations.py
@@ -1,6 +1,7 @@
 """Tests for tools/file_operations.py — deny list, result dataclasses, helpers."""
 
 import os
+import re
 import pytest
 import subprocess
 from pathlib import Path
@@ -928,23 +929,27 @@ class TestEscapeNativeToolArg:
 # =========================================================================
 
 class TestSearchTruncatedFlag:
-    """Regression for #86480: truncated flag is unreachable in content search.
+    """Regression for #86480: truncated is true only when an extra hit exists.
 
-    When the search backend is capped at `fetch_limit = limit + offset` lines
-    by `head -n`, a result that exactly fills the cap must be reported as
-    truncated.  The bug used `total > offset + limit`, which is always False
-    because `total` can never exceed the cap.  The fix uses `>=` for content
-    matches and adds the same check to `files_only` branches.
+    Fetching ``head -n (limit + offset)`` and then testing
+    ``total >= offset + limit`` cannot tell a complete result of exactly
+    that size from a capped page.  The backends fetch one extra row and
+    set ``truncated`` only when that extra hit is present.
     """
 
     def _make_ops(self, payload: str, exit_code: int = 0):
-        """Return a ShellFileOperations whose _exec always returns `payload`."""
+        """Return a ShellFileOperations whose _exec honors `head -n`."""
         env = MagicMock()
         env.cwd = "/tmp/test"
         ops = ShellFileOperations(env)
 
-        def _mock_exec(*args, **kwargs):
-            return ExecuteResult(stdout=payload, exit_code=exit_code)
+        def _mock_exec(cmd, *args, **kwargs):
+            stdout = payload
+            head = re.search(r"head\s+-n\s+(\d+)", cmd)
+            if head:
+                lines = [ln for ln in payload.split("\n") if ln]
+                stdout = "\n".join(lines[: int(head.group(1))])
+            return ExecuteResult(stdout=stdout, exit_code=exit_code)
 
         object.__setattr__(ops, "_exec", _mock_exec)
         return ops
@@ -955,35 +960,38 @@ class TestSearchTruncatedFlag:
     def _file_lines(self, n: int) -> str:
         return "\n".join(f"src/file_{i:02d}.py" for i in range(n))
 
-    @pytest.mark.parametrize("backend", ["rg", "grep"])
-    def test_content_exactly_at_cap_is_truncated(self, backend):
-        """A full page at the head cap means there may be more matches."""
-        limit, offset = 10, 0
-        fetch_limit = limit + offset
-        payload = self._content_lines(fetch_limit)
+    def _search(self, backend, payload, limit, offset, mode):
         ops = self._make_ops(payload)
-
         if backend == "rg":
-            result = ops._search_with_rg("match", ".", None, limit, offset, "content", 0)
-        else:
-            result = ops._search_with_grep("match", ".", None, limit, offset, "content", 0)
+            return ops._search_with_rg("match", ".", None, limit, offset, mode, 0)
+        return ops._search_with_grep("match", ".", None, limit, offset, mode, 0)
+
+    @pytest.mark.parametrize("backend", ["rg", "grep"])
+    def test_content_exactly_at_cap_is_not_truncated(self, backend):
+        """Exactly limit matches is a complete result, not a truncated page."""
+        limit, offset = 10, 0
+        result = self._search(backend, self._content_lines(limit + offset), limit, offset, "content")
 
         assert result.error is None
         assert len(result.matches) == limit
-        assert result.total_count == fetch_limit
+        assert result.total_count == limit + offset
+        assert result.truncated is False
+
+    @pytest.mark.parametrize("backend", ["rg", "grep"])
+    def test_content_extra_hit_is_truncated(self, backend):
+        """One extra fetched hit is the only reliable truncation signal."""
+        limit, offset = 10, 0
+        result = self._search(backend, self._content_lines(limit + offset + 1), limit, offset, "content")
+
+        assert result.error is None
+        assert len(result.matches) == limit
+        assert result.total_count == limit + offset + 1
         assert result.truncated is True
 
     @pytest.mark.parametrize("backend", ["rg", "grep"])
     def test_content_below_cap_is_not_truncated(self, backend):
         """Fewer matches than the cap means the result is complete."""
-        limit, offset = 10, 0
-        payload = self._content_lines(9)
-        ops = self._make_ops(payload)
-
-        if backend == "rg":
-            result = ops._search_with_rg("match", ".", None, limit, offset, "content", 0)
-        else:
-            result = ops._search_with_grep("match", ".", None, limit, offset, "content", 0)
+        result = self._search(backend, self._content_lines(9), 10, 0, "content")
 
         assert result.error is None
         assert len(result.matches) == 9
@@ -991,37 +999,67 @@ class TestSearchTruncatedFlag:
         assert result.truncated is False
 
     @pytest.mark.parametrize("backend", ["rg", "grep"])
-    def test_content_with_offset_is_truncated(self, backend):
-        """A page starting at offset can still hit the cap."""
+    def test_content_with_offset_extra_hit_is_truncated(self, backend):
+        """A page starting at offset is truncated only when a later hit exists."""
         limit, offset = 10, 5
-        fetch_limit = limit + offset
-        payload = self._content_lines(fetch_limit)
-        ops = self._make_ops(payload)
-
-        if backend == "rg":
-            result = ops._search_with_rg("match", ".", None, limit, offset, "content", 0)
-        else:
-            result = ops._search_with_grep("match", ".", None, limit, offset, "content", 0)
+        result = self._search(backend, self._content_lines(limit + offset + 1), limit, offset, "content")
 
         assert result.error is None
         assert len(result.matches) == limit
-        assert result.total_count == fetch_limit
+        assert result.total_count == limit + offset + 1
         assert result.truncated is True
 
     @pytest.mark.parametrize("backend", ["rg", "grep"])
-    def test_files_only_at_cap_is_truncated(self, backend):
-        """Files-only search also reports truncation when the cap is hit."""
-        limit, offset = 10, 0
-        fetch_limit = limit + offset
-        payload = self._file_lines(fetch_limit)
-        ops = self._make_ops(payload)
+    def test_content_with_offset_exact_window_is_not_truncated(self, backend):
+        """offset+limit matches with no extra hit is a complete tail page."""
+        limit, offset = 10, 5
+        result = self._search(backend, self._content_lines(limit + offset), limit, offset, "content")
 
-        if backend == "rg":
-            result = ops._search_with_rg("match", ".", None, limit, offset, "files_only", 0)
-        else:
-            result = ops._search_with_grep("match", ".", None, limit, offset, "files_only", 0)
+        assert result.error is None
+        assert len(result.matches) == limit
+        assert result.total_count == limit + offset
+        assert result.truncated is False
+
+    @pytest.mark.parametrize("backend", ["rg", "grep"])
+    def test_files_only_extra_hit_is_truncated(self, backend):
+        """Files-only search reports truncation only when an extra file exists."""
+        limit, offset = 10, 0
+        result = self._search(backend, self._file_lines(limit + offset + 1), limit, offset, "files_only")
 
         assert result.error is None
         assert len(result.files) == limit
-        assert result.total_count == fetch_limit
+        assert result.total_count == limit + offset + 1
         assert result.truncated is True
+
+    @pytest.mark.parametrize("backend", ["rg", "grep"])
+    def test_files_only_exactly_at_cap_is_not_truncated(self, backend):
+        """Exactly limit files is a complete listing."""
+        limit, offset = 10, 0
+        result = self._search(backend, self._file_lines(limit + offset), limit, offset, "files_only")
+
+        assert result.error is None
+        assert len(result.files) == limit
+        assert result.total_count == limit + offset
+        assert result.truncated is False
+
+    @pytest.mark.parametrize("backend", ["rg", "grep"])
+    def test_files_only_with_offset_extra_hit_is_truncated(self, backend):
+        """Files-only pagination is truncated only when a later file exists."""
+        limit, offset = 10, 5
+        result = self._search(backend, self._file_lines(limit + offset + 1), limit, offset, "files_only")
+
+        assert result.error is None
+        assert len(result.files) == limit
+        assert result.total_count == limit + offset + 1
+        assert result.truncated is True
+
+    @pytest.mark.parametrize("backend", ["rg", "grep"])
+    def test_files_only_with_offset_exact_window_is_not_truncated(self, backend):
+        """offset+limit files with no extra hit is a complete tail page."""
+        limit, offset = 10, 5
+        result = self._search(backend, self._file_lines(limit + offset), limit, offset, "files_only")
+
+        assert result.error is None
+        assert len(result.files) == limit
+        assert result.total_count == limit + offset
+        assert result.truncated is False

--- a/tests/tools/test_file_operations.py
+++ b/tests/tools/test_file_operations.py
@@ -15,6 +15,7 @@ from tools.file_operations import (
     WriteResult,
     PatchResult,
     SearchResult,
+    ExecuteResult,
     ShellFileOperations,
     normalize_read_pagination,
     normalize_search_pagination,
@@ -920,3 +921,107 @@ class TestEscapeNativeToolArg:
         assert node_cmds, f"no node command captured in: {commands}"
         assert "'C:/Users/alice/app/main.js'" in node_cmds[0]
         assert "/c/Users" not in node_cmds[0]
+
+
+# =========================================================================
+# search_files truncated flag
+# =========================================================================
+
+class TestSearchTruncatedFlag:
+    """Regression for #86480: truncated flag is unreachable in content search.
+
+    When the search backend is capped at `fetch_limit = limit + offset` lines
+    by `head -n`, a result that exactly fills the cap must be reported as
+    truncated.  The bug used `total > offset + limit`, which is always False
+    because `total` can never exceed the cap.  The fix uses `>=` for content
+    matches and adds the same check to `files_only` branches.
+    """
+
+    def _make_ops(self, payload: str, exit_code: int = 0):
+        """Return a ShellFileOperations whose _exec always returns `payload`."""
+        env = MagicMock()
+        env.cwd = "/tmp/test"
+        ops = ShellFileOperations(env)
+
+        def _mock_exec(*args, **kwargs):
+            return ExecuteResult(stdout=payload, exit_code=exit_code)
+
+        object.__setattr__(ops, "_exec", _mock_exec)
+        return ops
+
+    def _content_lines(self, n: int) -> str:
+        return "\n".join(f"src/file_{i:02d}.py:{i + 1}:match line {i}" for i in range(n))
+
+    def _file_lines(self, n: int) -> str:
+        return "\n".join(f"src/file_{i:02d}.py" for i in range(n))
+
+    @pytest.mark.parametrize("backend", ["rg", "grep"])
+    def test_content_exactly_at_cap_is_truncated(self, backend):
+        """A full page at the head cap means there may be more matches."""
+        limit, offset = 10, 0
+        fetch_limit = limit + offset
+        payload = self._content_lines(fetch_limit)
+        ops = self._make_ops(payload)
+
+        if backend == "rg":
+            result = ops._search_with_rg("match", ".", None, limit, offset, "content", 0)
+        else:
+            result = ops._search_with_grep("match", ".", None, limit, offset, "content", 0)
+
+        assert result.error is None
+        assert len(result.matches) == limit
+        assert result.total_count == fetch_limit
+        assert result.truncated is True
+
+    @pytest.mark.parametrize("backend", ["rg", "grep"])
+    def test_content_below_cap_is_not_truncated(self, backend):
+        """Fewer matches than the cap means the result is complete."""
+        limit, offset = 10, 0
+        payload = self._content_lines(9)
+        ops = self._make_ops(payload)
+
+        if backend == "rg":
+            result = ops._search_with_rg("match", ".", None, limit, offset, "content", 0)
+        else:
+            result = ops._search_with_grep("match", ".", None, limit, offset, "content", 0)
+
+        assert result.error is None
+        assert len(result.matches) == 9
+        assert result.total_count == 9
+        assert result.truncated is False
+
+    @pytest.mark.parametrize("backend", ["rg", "grep"])
+    def test_content_with_offset_is_truncated(self, backend):
+        """A page starting at offset can still hit the cap."""
+        limit, offset = 10, 5
+        fetch_limit = limit + offset
+        payload = self._content_lines(fetch_limit)
+        ops = self._make_ops(payload)
+
+        if backend == "rg":
+            result = ops._search_with_rg("match", ".", None, limit, offset, "content", 0)
+        else:
+            result = ops._search_with_grep("match", ".", None, limit, offset, "content", 0)
+
+        assert result.error is None
+        assert len(result.matches) == limit
+        assert result.total_count == fetch_limit
+        assert result.truncated is True
+
+    @pytest.mark.parametrize("backend", ["rg", "grep"])
+    def test_files_only_at_cap_is_truncated(self, backend):
+        """Files-only search also reports truncation when the cap is hit."""
+        limit, offset = 10, 0
+        fetch_limit = limit + offset
+        payload = self._file_lines(fetch_limit)
+        ops = self._make_ops(payload)
+
+        if backend == "rg":
+            result = ops._search_with_rg("match", ".", None, limit, offset, "files_only", 0)
+        else:
+            result = ops._search_with_grep("match", ".", None, limit, offset, "files_only", 0)
+
+        assert result.error is None
+        assert len(result.files) == limit
+        assert result.total_count == fetch_limit
+        assert result.truncated is True

--- a/tools/file_operations_search.py
+++ b/tools/file_operations_search.py
@@ -211,7 +211,7 @@ def _parse_search_output(result, output_mode: str, limit: int, offset: int,
     if output_mode == "files_only":
         return SearchResult(
             files=lines[offset:offset + limit], total_count=len(lines),
-            truncated=len(lines) >= offset + limit or bool(limit_reason), limit_reason=limit_reason, warning=warning)
+            truncated=len(lines) > offset + limit or bool(limit_reason), limit_reason=limit_reason, warning=warning)
     if output_mode == "count":
         counts = {}
         for line in lines:
@@ -242,7 +242,7 @@ def _parse_search_output(result, output_mode: str, limit: int, offset: int,
     total = len(matches)
     return SearchResult(
         matches=matches[offset:offset + limit], total_count=total,
-        truncated=total >= offset + limit or bool(limit_reason), limit_reason=limit_reason, warning=warning,
+        truncated=total > offset + limit or bool(limit_reason), limit_reason=limit_reason, warning=warning,
     )
 
 
@@ -833,7 +833,7 @@ class SearchMixin:
         ``line_cap`` appends ``| cut -c1-2000`` for engines without --max-columns
         (grep): bounds giant single-line matches at the pipe layer; skipped for
         files_only/count where lines are paths/counts."""
-        fetch_limit = limit + offset + (200 if context > 0 else 0)
+        fetch_limit = limit + offset + (200 if context > 0 else 1)
         if line_cap:  # grep/find pipelines: shell only, with the column cap
             parts = cmd_parts + ["|", "head", "-n", str(fetch_limit)]
             if output_mode not in ("files_only", "count"):

--- a/tools/file_operations_search.py
+++ b/tools/file_operations_search.py
@@ -211,7 +211,7 @@ def _parse_search_output(result, output_mode: str, limit: int, offset: int,
     if output_mode == "files_only":
         return SearchResult(
             files=lines[offset:offset + limit], total_count=len(lines),
-            truncated=bool(limit_reason), limit_reason=limit_reason, warning=warning)
+            truncated=len(lines) >= offset + limit or bool(limit_reason), limit_reason=limit_reason, warning=warning)
     if output_mode == "count":
         counts = {}
         for line in lines:
@@ -242,7 +242,7 @@ def _parse_search_output(result, output_mode: str, limit: int, offset: int,
     total = len(matches)
     return SearchResult(
         matches=matches[offset:offset + limit], total_count=total,
-        truncated=total > offset + limit or bool(limit_reason), limit_reason=limit_reason, warning=warning,
+        truncated=total >= offset + limit or bool(limit_reason), limit_reason=limit_reason, warning=warning,
     )
 
 


### PR DESCRIPTION
## What does this PR do?

Fixes `search_files` so `truncated=True` only when a later match actually exists. The previous `total >= offset + limit` check was a false positive whenever the tree had *exactly* that many hits, because `head -n` caps `total` at the fetch size.

The backends now fetch one extra row (`limit + offset + 1`) and set `truncated` only when that extra hit is present. The returned page is still sliced to `limit`. That is what makes the `Use offset=N to see more` hint in `tools/file_tools.py` appear only when paging will return more results.

## Related Issue

Fixes #86480

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/file_operations.py` (`_search_with_rg` / `_search_with_grep`, content and `files_only`):
  - fetch `limit + offset + 1` (context mode still over-fetches for `--` separators)
  - `truncated = total > offset + limit or bool(limit_reason)`
- `tests/tools/test_file_operations.py`: `TestSearchTruncatedFlag` now honors `head -n` and covers extra-hit vs exact-window vs below-cap, content and `files_only`, with and without offset.

## How to Test

1. Run the regression tests:
   ```bash
   PYTHONPATH=. .venv/bin/python -m pytest tests/tools/test_file_operations.py::TestSearchTruncatedFlag -q
   ```
   Expected: 18 tests pass.
2. Confirm the extra-hit cases fail if `head -n` is capped at `limit + offset` (no probe row), and the exact-window cases fail if `truncated` uses `>=` again.
3. Run the affected-area suite:
   ```bash
   bash scripts/check.sh --project hermes-agent --worktree worktrees/hermes-agent/86480
   ```
   Expected: `ruff`, `uv lock --check`, and the changed-area `pytest` pass.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/` on the affected area and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.0

### Documentation & Housekeeping

- [x] N/A — no documentation or config changes
- [x] N/A — no `cli-config.yaml.example` changes
- [x] N/A — no `CONTRIBUTING.md` or `AGENTS.md` changes
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] N/A — no tool descriptions or schemas changed

## Screenshots / Logs

N/A