### PR TITLE
fix(cron): tree-kill script timeout descendants via agent.deadline.kill_process_tree

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -3845,6 +3845,37 @@ def _terminate_cron_script_process(proc: subprocess.Popen) -> None:
         proc.wait(timeout=1.0)
 
 
+def _terminate_cron_script_tree(proc: subprocess.Popen) -> None:
+    """Terminate a script tree, then fall back to the local process-group path."""
+    pid = getattr(proc, "pid", None)
+    if not isinstance(pid, int) or pid <= 0:
+        logger.warning(
+            "Cron script tree-kill received invalid pid %r; "
+            "falling back to process-group termination",
+            pid,
+        )
+        _terminate_cron_script_process(proc)
+        return
+    try:
+        from agent.deadline import kill_process_tree
+
+        if kill_process_tree(pid):
+            return
+        logger.warning(
+            "Cron script tree-kill reported no signal for pid %s; "
+            "falling back to process-group termination",
+            pid,
+        )
+    except Exception:
+        logger.warning(
+            "Cron script tree-kill failed for pid %s; "
+            "falling back to process-group termination",
+            pid,
+            exc_info=True,
+        )
+    _terminate_cron_script_process(proc)
+
+
 def _drain_script_pipes(proc: subprocess.Popen) -> None:
     """Reap a terminated script process without ever blocking indefinitely.
 
@@ -4078,7 +4109,16 @@ def _run_job_script(
                 return False, "Script cancelled because cron fire ownership was lost"
             remaining = deadline - time.monotonic()
             if remaining <= 0:
-                _terminate_cron_script_process(proc)
+                # Phase 4a (#85125): a script timeout must leave ZERO living
+                # descendants. killpg only reaches the script's own process
+                # group — a grandchild that called setsid (backgrounded
+                # shell jobs, watchdogs) escapes it and keeps running after
+                # the job reports failure (#71148 / #59549).
+                # agent.deadline.kill_process_tree snapshots the descendant
+                # set via psutil BEFORE signalling, so own-session
+                # grandchildren are reached too — the unified deadline
+                # layer's tree-kill (#85147, d6a5cb9725).
+                _terminate_cron_script_tree(proc)
                 _drain_script_pipes(proc)
                 return False, f"Script timed out after {script_timeout}s: {path}"
             try:

--- a/tests/cron/test_cron_script.py
+++ b/tests/cron/test_cron_script.py
@@ -629,3 +629,119 @@ class TestRunJobEnvVarCleanup:
         assert os.environ.get("HERMES_SESSION_PLATFORM") is None
         assert os.environ.get("HERMES_SESSION_CHAT_ID") is None
         assert os.environ.get("HERMES_SESSION_CHAT_NAME") is None
+
+
+class TestScriptTimeoutTreeKill:
+    """Phase 4a (#85125): a script timeout must leave zero living descendants."""
+
+    def test_unified_tree_kill_failure_falls_back(self, monkeypatch, caplog):
+        from agent import deadline
+        from cron import scheduler as sched
+
+        proc = SimpleNamespace(pid=12345)
+        fallback_calls = []
+        monkeypatch.setattr(deadline, "kill_process_tree", lambda _pid: False)
+        monkeypatch.setattr(
+            sched,
+            "_terminate_cron_script_process",
+            lambda candidate: fallback_calls.append(candidate),
+        )
+
+        with caplog.at_level("WARNING", logger=sched.__name__):
+            sched._terminate_cron_script_tree(proc)
+
+        assert fallback_calls == [proc]
+        assert "falling back to process-group termination" in caplog.text
+
+    def test_invalid_pid_never_reaches_unified_tree_kill(self, monkeypatch, caplog):
+        from agent import deadline
+        from cron import scheduler as sched
+
+        proc = SimpleNamespace(pid=0)
+        tree_kill_calls = []
+        fallback_calls = []
+        monkeypatch.setattr(
+            deadline,
+            "kill_process_tree",
+            lambda pid: tree_kill_calls.append(pid),
+        )
+        monkeypatch.setattr(
+            sched,
+            "_terminate_cron_script_process",
+            lambda candidate: fallback_calls.append(candidate),
+        )
+
+        with caplog.at_level("WARNING", logger=sched.__name__):
+            sched._terminate_cron_script_tree(proc)
+
+        assert tree_kill_calls == []
+        assert fallback_calls == [proc]
+        assert "invalid pid 0" in caplog.text
+
+    @pytest.mark.live_system_guard_bypass
+    def test_timeout_leaves_no_setsid_grandchild(self, cron_env, monkeypatch):
+        """The script spawns a grandchild in its OWN session (start_new_session).
+        killpg alone cannot reach it; agent.deadline.kill_process_tree must —
+        after the timeout the grandchild must no longer be running."""
+        import time
+
+        psutil = pytest.importorskip(
+            "psutil",
+            reason="kill_process_tree needs psutil to reach own-session descendants",
+        )
+
+        from cron import scheduler as sched
+
+        def is_live(pid):
+            try:
+                process = psutil.Process(pid)
+                return process.is_running() and process.status() != psutil.STATUS_ZOMBIE
+            except (psutil.NoSuchProcess, psutil.ZombieProcess):
+                return False
+
+        scripts_dir = cron_env / "scripts"
+        pid_file = cron_env / "grandchild.pid"
+        (scripts_dir / "spawner.py").write_text(
+            "import subprocess, sys, time\n"
+            "p = subprocess.Popen(\n"
+            "    [sys.executable, '-c', 'import time; time.sleep(30)'],\n"
+            "    start_new_session=True,\n"
+            "    stdin=subprocess.DEVNULL,\n"
+            "    stdout=subprocess.DEVNULL,\n"
+            "    stderr=subprocess.DEVNULL,\n"
+            ")\n"
+            f"open({str(pid_file)!r}, 'w').write(str(p.pid))\n"
+            "time.sleep(30)\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("HERMES_CRON_SCRIPT_TIMEOUT", "1")
+        monkeypatch.setattr(sched, "_SCRIPT_TIMEOUT", sched._DEFAULT_SCRIPT_TIMEOUT)
+
+        ok, out = sched._run_job_script(
+            str(scripts_dir / "spawner.py"), workdir=str(cron_env)
+        )
+        assert not ok, f"script should have timed out, got {out!r}"
+
+        deadline = time.monotonic() + 5
+        gpid = None
+        while time.monotonic() < deadline and gpid is None:
+            try:
+                gpid = int(pid_file.read_text().strip())
+            except (FileNotFoundError, ValueError):
+                time.sleep(0.05)
+        assert gpid is not None, "spawner never wrote the grandchild pid"
+
+        try:
+            deadline = time.monotonic() + 5
+            while is_live(gpid) and time.monotonic() < deadline:
+                time.sleep(0.05)
+            assert not is_live(gpid), (
+                f"grandchild pid {gpid} survived the script timeout — the "
+                "timeout path orphaned an own-session descendant"
+            )
+        finally:
+            if is_live(gpid):
+                try:
+                    psutil.Process(gpid).kill()
+                except psutil.NoSuchProcess:
+                    pass


### PR DESCRIPTION
## Summary

Phase 4a of #85125 (delegated): a cron script timeout must leave **zero living descendants**. The previous timeout handler used a site-local process-group kill (`_terminate_cron_script_process`), which cannot reach a grandchild that created its **own session** — `start_new_session` background jobs, watchdog chains. Those survived the reported failure and kept running (#71148, #59549 — @supotato-ipj's production trace of the 3600s-timeout mislabeling is the same class).

## Changes

- `cron/scheduler.py::_run_job_script`: the timeout branch now calls `agent.deadline.kill_process_tree(proc.pid)` (landed with #85147) — psutil snapshots the descendant set *before* signalling, so own-session grandchildren are reached, with PID-recycling safety. Falls back to the site-local group kill if the import ever fails, so the path cannot re-wedge.
- The explicit `Script timed out after Ns` message stays the classification anchor (the #85536 contract), keeping script timeouts distinct from provider timeouts.
- End-to-end regression test in `tests/cron/test_cron_script.py`: the script spawns a `start_new_session` grandchild (DEVNULL stdio so it can't hold the runner's pipes), the timeout fires at 1s, and the test asserts the grandchild pid is dead. **Red on main before this change, green with it.**

## Validation

- `scripts/run_tests.sh tests/cron/` → **684 passed, 0 failed, 1 skipped**
- Red proof: with the fix stashed, the new test fails (grandchild survives)

## Credit

- `start_new_session=True` mechanism: @dante32683 (#59379) — Co-authored-by
- Production evidence (#59549): @supotato-ipj — Co-authored-by
- Classification contract: @jbagdonas's #82460 via teknium1's #85536

Closes #71148 and #59549's orphan half. The Phase 4 conformance-harness copy of the acceptance cell stacks behind #83964 per the #85125 ordering condition.
