### PR TITLE
fix(mem0): cache backends per process and mirror built-in memory writes

### DIFF
--- a/plugins/memory/mem0/__init__.py
+++ b/plugins/memory/mem0/__init__.py
@@ -38,7 +38,7 @@ import logging
 import os
 import threading
 import time
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 from agent.memory_provider import MemoryProvider
 from agent.secret_scope import get_secret
@@ -60,6 +60,35 @@ _CLIENT_ERROR_TYPES = ("MemoryNotFoundError", "ValidationError")
 # wrote this exact placeholder) still allow gateway-native ids to flow
 # through instead of silently overriding them with the placeholder.
 _DEFAULT_USER_ID = "hermes-user"
+
+# Process-level backend cache keyed by (mode, oss config, host).
+# Qdrant local-path storage (the default OSS vector store) refuses a second
+# QdrantClient on the same folder within one process ("already accessed by
+# another instance"). Long-lived hosts (desktop serve, gateway) re-initialize
+# memory providers per session, which would otherwise create a fresh backend
+# each time and trip that single-instance guard. Caching the backend per
+# process makes every session in the process share one Qdrant client.
+_BACKEND_CACHE: dict[tuple, Any] = {}
+_BACKEND_CACHE_LOCK = threading.Lock()
+
+
+def _close_cached_backends() -> None:
+    """Close every process-cached backend at interpreter exit.
+
+    Cached backends are shared across sessions in long-lived hosts, so
+    per-session shutdown deliberately leaves them open; this runs exactly
+    once via atexit so the Qdrant local-path lock is released when the
+    process finally goes away.
+    """
+    with _BACKEND_CACHE_LOCK:
+        backends = list(_BACKEND_CACHE.values())
+        _BACKEND_CACHE.clear()
+    for backend in backends:
+        try:
+            if backend is not None:
+                backend.close()
+        except Exception:
+            pass
 
 
 def _is_client_error(exc: Exception) -> bool:
@@ -280,10 +309,25 @@ class Mem0MemoryProvider(MemoryProvider):
         try:
             if self._mode == "oss":
                 from ._backend import OSSBackend
-                return OSSBackend(self._config.get("oss", {}))
+                cfg = self._config.get("oss", {})
+                cache_key = ("oss", json.dumps(cfg, sort_keys=True, default=str))
+                with _BACKEND_CACHE_LOCK:
+                    cached = _BACKEND_CACHE.get(cache_key)
+                    if cached is not None:
+                        return cached
+                    backend = OSSBackend(cfg)
+                    _BACKEND_CACHE[cache_key] = backend
+                    return backend
             if self._host:
-                from ._backend import SelfHostedBackend
-                return SelfHostedBackend(self._api_key, self._host)
+                cache_key = ("host", self._host)
+                with _BACKEND_CACHE_LOCK:
+                    cached = _BACKEND_CACHE.get(cache_key)
+                    if cached is not None:
+                        return cached
+                    from ._backend import SelfHostedBackend
+                    backend = SelfHostedBackend(self._api_key, self._host)
+                    _BACKEND_CACHE[cache_key] = backend
+                    return backend
             from ._backend import PlatformBackend
             return PlatformBackend(self._api_key)
         except Exception as e:
@@ -366,7 +410,7 @@ class Mem0MemoryProvider(MemoryProvider):
         self._channel = kwargs.get("platform") or "cli"
         self._backend = self._create_backend()
         if self._backend and not self._atexit_registered:
-            atexit.register(self._shutdown_backend)
+            atexit.register(_close_cached_backends)
             self._atexit_registered = True
 
     def _read_filters(self) -> Dict[str, Any]:
@@ -511,6 +555,48 @@ class Mem0MemoryProvider(MemoryProvider):
             self._sync_thread = threading.Thread(target=_sync, daemon=True, name="mem0-sync")
             self._sync_thread.start()
 
+    def on_memory_write(
+        self,
+        action: str,
+        target: str,
+        content: str,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        """Mirror built-in memory tool writes into Mem0.
+
+        Only ``add`` is mirrored: ``replace``/``remove`` cannot be reliably
+        mapped back to Mem0 memory IDs (Mem0 has no text→ID delete lookup),
+        so mirroring them would leave stale duplicates. The entry is stored
+        verbatim (``infer=False``) — it is already a curated fact, so no
+        extraction is needed. Runs on a daemon thread; failures never block
+        or break the built-in memory write.
+        """
+        if action != "add" or not content:
+            return
+        if self._backend is None or self._is_breaker_open():
+            return
+        backend = self._backend
+
+        def _write():
+            try:
+                meta = dict(metadata or {})
+                meta.setdefault("write_origin", "builtin_memory_mirror")
+                meta["target"] = target
+                backend.add(
+                    [{"role": "user", "content": content}],
+                    user_id=self._user_id,
+                    agent_id=self._agent_id,
+                    infer=False,
+                    metadata=meta,
+                )
+                self._record_success()
+            except Exception as e:
+                self._record_failure()
+                logger.debug("Mem0 memory mirror failed: %s", e)
+
+        t = threading.Thread(target=_write, daemon=True, name="mem0-memwrite")
+        t.start()
+
     def get_tool_schemas(self) -> List[Dict[str, Any]]:
         return [SEARCH_SCHEMA, ADD_SCHEMA, UPDATE_SCHEMA, DELETE_SCHEMA]
 
@@ -610,9 +696,19 @@ class Mem0MemoryProvider(MemoryProvider):
 
     def _shutdown_backend(self):
         try:
-            if self._backend:
-                self._backend.close()
-                self._backend = None
+            if self._backend is None:
+                return
+            # Cached (shared) backends must NOT be closed on per-session
+            # shutdown — the next session in this process reuses the same
+            # instance (Qdrant local-path is single-instance per process).
+            # They are closed once at interpreter exit by _close_cached_backends.
+            with _BACKEND_CACHE_LOCK:
+                for cached in _BACKEND_CACHE.values():
+                    if cached is self._backend:
+                        self._backend = None
+                        return
+            self._backend.close()
+            self._backend = None
         except Exception:
             pass
 

--- a/tests/plugins/memory/test_mem0_backend_cache.py
+++ b/tests/plugins/memory/test_mem0_backend_cache.py
@@ -1,0 +1,98 @@
+"""Tests for the process-level backend cache in the mem0 provider.
+
+Qdrant local-path storage refuses a second QdrantClient on the same folder
+within one process. Long-lived hosts (desktop serve, gateway) re-initialize
+memory providers per session, so without a process-level cache every new
+session would trip that single-instance guard. These tests pin the caching
+behaviour: same config → shared backend, shutdown must not close shared
+instances, and distinct configs must not collide.
+"""
+
+import pytest
+
+import plugins.memory.mem0 as mem0_plugin
+import plugins.memory.mem0._backend as mem0_backend_mod
+from plugins.memory.mem0 import Mem0MemoryProvider
+
+
+class _FakeOSSBackend:
+    """Minimal stand-in for OSSBackend with a close() marker."""
+
+    instances = []
+
+    def __init__(self, cfg):
+        self.cfg = cfg
+        self.closed = False
+        _FakeOSSBackend.instances.append(self)
+
+    def close(self):
+        self.closed = True
+
+
+@pytest.fixture(autouse=True)
+def _isolate_cache(monkeypatch):
+    """Give each test a pristine cache and fake OSS backend construction."""
+    monkeypatch.setattr(mem0_plugin, "_BACKEND_CACHE", {})
+    _FakeOSSBackend.instances = []
+    monkeypatch.setattr(mem0_backend_mod, "OSSBackend", _FakeOSSBackend)
+
+
+def _provider_with_oss(path):
+    """Provider pre-configured for OSS mode with a given vector store path."""
+    prov = Mem0MemoryProvider()
+    prov._mode = "oss"
+    prov._config = {
+        "oss": {
+            "vector_store": {"provider": "qdrant", "config": {"path": path}},
+        }
+    }
+    return prov
+
+
+def test_same_config_shares_backend():
+    p1 = _provider_with_oss("~/.hermes/mem0_qdrant")
+    p2 = _provider_with_oss("~/.hermes/mem0_qdrant")
+
+    b1 = p1._create_backend()
+    b2 = p2._create_backend()
+
+    assert b1 is b2, "same OSS config must share one backend per process"
+    assert len(mem0_plugin._BACKEND_CACHE) == 1
+
+
+def test_shutdown_does_not_close_shared_backend():
+    p1 = _provider_with_oss("~/.hermes/mem0_qdrant")
+    p2 = _provider_with_oss("~/.hermes/mem0_qdrant")
+    b1 = p1._create_backend()
+    p2._backend = b1
+
+    p2.shutdown()
+
+    assert p2._backend is None, "session shutdown releases the provider's ref"
+    assert not b1.closed, "shared backend must survive per-session shutdown"
+    assert len(mem0_plugin._BACKEND_CACHE) == 1
+    # A third session in the same process still reuses the live instance.
+    p3 = _provider_with_oss("~/.hermes/mem0_qdrant")
+    assert p3._create_backend() is b1
+
+
+def test_distinct_configs_get_distinct_backends():
+    p1 = _provider_with_oss("~/.hermes/mem0_qdrant")
+    p2 = _provider_with_oss("~/.hermes/mem0_qdrant_other")
+
+    b1 = p1._create_backend()
+    b2 = p2._create_backend()
+
+    assert b1 is not b2
+    assert len(mem0_plugin._BACKEND_CACHE) == 2
+
+
+def test_close_cached_backends_closes_all():
+    p1 = _provider_with_oss("~/.hermes/mem0_qdrant")
+    p1._create_backend()
+    mem0_plugin._BACKEND_CACHE[("oss", "extra")] = _FakeOSSBackend({})
+
+    mem0_plugin._close_cached_backends()
+
+    assert mem0_plugin._BACKEND_CACHE == {}
+    assert all(b.closed for b in _FakeOSSBackend.instances)

--- a/tests/plugins/memory/test_mem0_mirror.py
+++ b/tests/plugins/memory/test_mem0_mirror.py
@@ -1,0 +1,129 @@
+"""Tests for mem0's built-in memory write mirroring (on_memory_write).
+
+When the model uses the built-in ``memory`` tool to add a fact, mem0 should
+receive a verbatim copy (infer=False) so curated facts are searchable in the
+semantic store. Only ``add`` is mirrored — replace/remove can't be mapped
+back to mem0 IDs and would leave stale duplicates.
+"""
+
+import threading
+import time
+
+import plugins.memory.mem0 as mem0_plugin
+from plugins.memory.mem0 import Mem0MemoryProvider
+
+
+class FakeBackend:
+    def __init__(self):
+        self.add_calls = []
+        self.closed = False
+
+    def add(self, messages, *, user_id, agent_id, infer=False, metadata=None):
+        self.add_calls.append({
+            "messages": messages,
+            "user_id": user_id,
+            "agent_id": agent_id,
+            "infer": infer,
+            "metadata": metadata,
+        })
+
+    def close(self):
+        self.closed = True
+
+
+def _provider_with_backend(backend):
+    prov = Mem0MemoryProvider()
+    prov._mode = "oss"
+    prov._user_id = "hermes-user"
+    prov._agent_id = "hermes"
+    prov._backend = backend
+    return prov
+
+
+def _wait_for(backend, n=1, timeout=5.0):
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if len(backend.add_calls) >= n:
+            return
+        time.sleep(0.05)
+    raise AssertionError(f"mirror write did not land within {timeout}s; calls={backend.add_calls}")
+
+
+def test_add_is_mirrored_verbatim():
+    backend = FakeBackend()
+    prov = _provider_with_backend(backend)
+
+    prov.on_memory_write("add", "memory", "user prefers dark mode")
+
+    _wait_for(backend)
+    call = backend.add_calls[0]
+    assert call["messages"] == [{"role": "user", "content": "user prefers dark mode"}]
+    assert call["infer"] is False, "curated fact must be stored verbatim, no extraction"
+    assert call["user_id"] == "hermes-user"
+    assert call["agent_id"] == "hermes"
+    assert call["metadata"].get("write_origin") == "builtin_memory_mirror"
+    assert call["metadata"].get("target") == "memory"
+
+
+def test_user_target_recorded_in_metadata():
+    backend = FakeBackend()
+    prov = _provider_with_backend(backend)
+
+    prov.on_memory_write("add", "user", "user's name is Echo")
+
+    _wait_for(backend)
+    assert backend.add_calls[0]["metadata"]["target"] == "user"
+
+
+def test_replace_and_remove_not_mirrored():
+    backend = FakeBackend()
+    prov = _provider_with_backend(backend)
+
+    prov.on_memory_write("replace", "memory", "new text")
+    prov.on_memory_write("remove", "memory", "old text")
+    time.sleep(0.3)
+
+    assert backend.add_calls == [], "replace/remove must not be mirrored"
+
+
+def test_empty_content_not_mirrored():
+    backend = FakeBackend()
+    prov = _provider_with_backend(backend)
+
+    prov.on_memory_write("add", "memory", "")
+    time.sleep(0.3)
+
+    assert backend.add_calls == []
+
+
+def test_no_backend_skips_mirror():
+    prov = Mem0MemoryProvider()
+    prov._backend = None
+
+    prov.on_memory_write("add", "memory", "anything")
+
+    # No crash, no thread explosion — nothing observable to assert beyond no error.
+
+
+def test_mirror_failure_is_silent(monkeypatch):
+    class ExplodingBackend(FakeBackend):
+        def add(self, *args, **kwargs):
+            raise RuntimeError("backend down")
+
+    backend = ExplodingBackend()
+    prov = _provider_with_backend(backend)
+
+    # Must not raise — mirror failures are logged at debug level only.
+    prov.on_memory_write("add", "memory", "fact")
+    time.sleep(0.3)
+
+
+def test_mirror_uses_provider_breaker_state(monkeypatch):
+    backend = FakeBackend()
+    prov = _provider_with_backend(backend)
+    monkeypatch.setattr(prov, "_is_breaker_open", lambda: True)
+
+    prov.on_memory_write("add", "memory", "fact")
+    time.sleep(0.3)
+
+    assert backend.add_calls == [], "breaker-open must suppress mirror writes"


### PR DESCRIPTION
## Summary

Two related mem0 provider fixes for long-lived hosts (desktop serve, gateway):

1. **Process-level backend cache** — Qdrant local-path storage refuses a second `QdrantClient` on the same folder within one process. Long-lived hosts re-initialize memory providers per session, which would create a fresh backend each time and trip that single-instance guard. Backends are now cached per `(mode, oss config, host)` and closed exactly once at interpreter exit via `atexit`.

2. **Mirror built-in memory writes into Mem0** — the `memory` tool's `add` action is mirrored into Mem0 (verbatim, `infer=False`, on a daemon thread). `replace`/`remove` are intentionally not mirrored since Mem0 has no text→ID delete lookup.

## Test Plan

- `tests/plugins/memory/test_mem0_backend_cache.py` — same config shares one backend; shutdown must not close shared instances; distinct configs don't collide
- `tests/plugins/memory/test_mem0_mirror.py` — mirror writes only on `add`, stores verbatim, failures never block the built-in write

## Notes

- The local kanban.py task_graph fix was **not** included — the upstream `main` already loads the graph inside the connection block.