### PR TITLE
fix(bedrock): let aux calls omit the Converse maxTokens cap

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -2213,7 +2213,12 @@ class _BedrockCompletionsAdapter:
             model=model,
             messages=messages,
             tools=kwargs.get("tools"),
-            max_tokens=int(max_tokens) if max_tokens else 4096,
+            # Omitted/None caller cap → None: build_converse_kwargs then omits
+            # inferenceConfig.maxTokens so Bedrock uses the model's maximum
+            # allowed output, matching the no-cap-by-default policy every
+            # other aux wire already follows (#10809: vision descriptions
+            # stayed capped at the shim's old hardcoded 4096 on Bedrock).
+            max_tokens=int(max_tokens) if max_tokens else None,
             temperature=kwargs.get("temperature"),
             top_p=kwargs.get("top_p"),
             stop_sequences=stop,

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -2218,6 +2218,9 @@ class _BedrockCompletionsAdapter:
             # allowed output, matching the no-cap-by-default policy every
             # other aux wire already follows (#10809: vision descriptions
             # stayed capped at the shim's old hardcoded 4096 on Bedrock).
+            # Truthiness (not `is None`) is deliberate — it matches the
+            # sibling Anthropic shim's reading of max_tokens above, so a
+            # nonsense explicit 0 is treated as "no cap" on both wires.
             max_tokens=int(max_tokens) if max_tokens else None,
             temperature=kwargs.get("temperature"),
             top_p=kwargs.get("top_p"),

--- a/agent/bedrock_adapter.py
+++ b/agent/bedrock_adapter.py
@@ -1019,7 +1019,7 @@ def build_converse_kwargs(
     model: str,
     messages: List[Dict],
     tools: Optional[List[Dict]] = None,
-    max_tokens: int = 4096,
+    max_tokens: Optional[int] = 4096,
     temperature: Optional[float] = None,
     top_p: Optional[float] = None,
     stop_sequences: Optional[List[str]] = None,
@@ -1028,16 +1028,24 @@ def build_converse_kwargs(
     """Build kwargs for ``bedrock-runtime.converse()`` or ``converse_stream()``.
 
     Converts OpenAI-format inputs to Converse API parameters.
+
+    ``max_tokens=None`` omits ``inferenceConfig.maxTokens`` entirely, in which
+    case Bedrock defaults to the model's maximum allowed output — the Converse
+    field is optional per the AWS API reference. The default stays 4096 so
+    existing callers are unaffected; callers that want the model's full output
+    budget (e.g. uncapped auxiliary vision calls) pass ``None`` explicitly.
     """
     system_prompt, converse_messages = convert_messages_to_converse(messages)
     cache_enabled = _model_supports_prompt_cache(model)
 
+    inference_config: Dict[str, Any] = {}
+    if max_tokens is not None:
+        inference_config["maxTokens"] = max_tokens
+
     kwargs: Dict[str, Any] = {
         "modelId": model,
         "messages": converse_messages,
-        "inferenceConfig": {
-            "maxTokens": max_tokens,
-        },
+        "inferenceConfig": inference_config,
     }
 
     if system_prompt:
@@ -1086,6 +1094,10 @@ def build_converse_kwargs(
     if guardrail_config:
         kwargs["guardrailConfig"] = guardrail_config
 
+    if not kwargs["inferenceConfig"]:
+        # inferenceConfig is optional on the wire; don't send an empty object.
+        del kwargs["inferenceConfig"]
+
     return kwargs
 
 
@@ -1094,7 +1106,7 @@ def call_converse(
     model: str,
     messages: List[Dict],
     tools: Optional[List[Dict]] = None,
-    max_tokens: int = 4096,
+    max_tokens: Optional[int] = 4096,
     temperature: Optional[float] = None,
     top_p: Optional[float] = None,
     stop_sequences: Optional[List[str]] = None,
@@ -1135,7 +1147,7 @@ def call_converse_stream(
     model: str,
     messages: List[Dict],
     tools: Optional[List[Dict]] = None,
-    max_tokens: int = 4096,
+    max_tokens: Optional[int] = 4096,
     temperature: Optional[float] = None,
     top_p: Optional[float] = None,
     stop_sequences: Optional[List[str]] = None,

--- a/tests/agent/test_bedrock_adapter.py
+++ b/tests/agent/test_bedrock_adapter.py
@@ -423,6 +423,27 @@ class TestBuildConverseKwargs:
         )
         assert "inferenceConfig" not in kwargs
 
+    def test_call_converse_stream_omits_cap_for_none(self):
+        """The streaming entry point funnels through the same builder — pin
+        that max_tokens=None omits the cap there too."""
+        from unittest.mock import MagicMock, patch as mock_patch
+        from agent.bedrock_adapter import call_converse_stream
+        boto3_client = MagicMock()
+        boto3_client.converse_stream.return_value = {"stream": []}
+        with mock_patch(
+            "agent.bedrock_adapter._get_bedrock_runtime_client",
+            return_value=boto3_client,
+        ):
+            call_converse_stream(
+                region="us-east-1",
+                model="test-model",
+                messages=[{"role": "user", "content": "Hi"}],
+                max_tokens=None,
+                temperature=0.2,
+            )
+        wire_kwargs = boto3_client.converse_stream.call_args.kwargs
+        assert "maxTokens" not in wire_kwargs.get("inferenceConfig", {})
+
 
 
 

--- a/tests/agent/test_bedrock_adapter.py
+++ b/tests/agent/test_bedrock_adapter.py
@@ -389,6 +389,40 @@ class TestBuildConverseKwargs:
         assert "toolConfig" in kwargs
         assert len(kwargs["toolConfig"]["tools"]) == 1
 
+    def test_default_max_tokens_stays_4096(self):
+        """Callers that don't pass max_tokens keep the historical 4096 cap —
+        the None-omission behavior is strictly opt-in."""
+        from agent.bedrock_adapter import build_converse_kwargs
+        kwargs = build_converse_kwargs(
+            model="test-model", messages=[{"role": "user", "content": "Hi"}],
+        )
+        assert kwargs["inferenceConfig"]["maxTokens"] == 4096
+
+    def test_max_tokens_none_omits_cap(self):
+        """max_tokens=None omits inferenceConfig.maxTokens so Bedrock uses the
+        model's maximum allowed output (the Converse field is optional)."""
+        from agent.bedrock_adapter import build_converse_kwargs
+        kwargs = build_converse_kwargs(
+            model="test-model",
+            messages=[{"role": "user", "content": "Hi"}],
+            max_tokens=None,
+            temperature=0.1,
+        )
+        assert "maxTokens" not in kwargs["inferenceConfig"]
+        # Other inference params still flow through.
+        assert kwargs["inferenceConfig"]["temperature"] == 0.1
+
+    def test_max_tokens_none_and_no_sampling_drops_empty_inference_config(self):
+        """When every inference param is absent, don't send an empty
+        inferenceConfig object on the wire."""
+        from agent.bedrock_adapter import build_converse_kwargs
+        kwargs = build_converse_kwargs(
+            model="test-model",
+            messages=[{"role": "user", "content": "Hi"}],
+            max_tokens=None,
+        )
+        assert "inferenceConfig" not in kwargs
+
 
 
 

--- a/tests/agent/test_bedrock_integration.py
+++ b/tests/agent/test_bedrock_integration.py
@@ -437,3 +437,39 @@ class TestAuxiliaryClientBedrockResolution:
         # got-final-object downgrade path handles the rest.
         assert resp is sentinel
         assert mock_converse.call_count == 1
+
+    def test_bedrock_shim_uncapped_when_caller_omits_max_tokens(self, monkeypatch):
+        """No caller max_tokens → the shim passes None through and the wire
+        request carries no inferenceConfig.maxTokens, so Bedrock uses the
+        model's maximum allowed output (#10809 on the Bedrock wire).
+
+        Guards against the shim's old hardcoded ``else 4096`` fallback, which
+        kept aux vision descriptions capped after the vision call sites
+        dropped their own caps."""
+        monkeypatch.setenv("AWS_ACCESS_KEY_ID", "AKIAIO...MPLE")
+        monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY")
+
+        from agent.auxiliary_client import BedrockAuxiliaryClient
+
+        client = BedrockAuxiliaryClient("us-east-1", "openai.gpt-oss-20b-1:0")
+        boto3_client = MagicMock()
+        with patch("agent.bedrock_adapter._get_bedrock_runtime_client",
+                   return_value=boto3_client), \
+             patch("agent.bedrock_adapter.normalize_converse_response"):
+            # Aux vision-style call: no max_tokens key at all.
+            client.chat.completions.create(
+                model="openai.gpt-oss-20b-1:0",
+                messages=[{"role": "user", "content": "describe"}],
+                temperature=0.1,
+            )
+            wire_kwargs = boto3_client.converse.call_args.kwargs
+            assert "maxTokens" not in wire_kwargs.get("inferenceConfig", {})
+
+            # An explicit caller cap still lands on the wire unchanged.
+            client.chat.completions.create(
+                model="openai.gpt-oss-20b-1:0",
+                messages=[{"role": "user", "content": "describe"}],
+                max_tokens=1234,
+            )
+            wire_kwargs = boto3_client.converse.call_args.kwargs
+            assert wire_kwargs["inferenceConfig"]["maxTokens"] == 1234


### PR DESCRIPTION
## What does this PR do?

Completes #10809 on the Bedrock wire. #75253 removed the hardcoded `max_tokens` caps from the three auxiliary vision call sites, but the Bedrock Converse shim (`_BedrockCompletionsAdapter.create`) had its own `else 4096` fallback when the caller passed no cap — so vision descriptions on Bedrock stayed capped at 4096 tokens while every other wire (OpenAI-compatible, Anthropic Messages, Gemini native, ZAI) honored the model's full output budget.

Converse's `inferenceConfig.maxTokens` is optional per the AWS API reference: "The default value is the maximum allowed value for the model that you are using." This PR threads `max_tokens=None` through `build_converse_kwargs` / `call_converse` to omit the field, so Bedrock applies the model's own ceiling — the same semantics the other wires already have.

## Real-world impact

WHO: anyone running `auxiliary.vision` (or any aux task) on the Bedrock provider.
WHEN: `vision_analyze` / `video_analyze` / `browser_vision` on a complex image or long video.
WHY IT MATTERS: descriptions cut off mid-sentence at exactly 4096 tokens with no error — the one wire where #75253's fix silently didn't take effect.

## Changes Made

- `agent/bedrock_adapter.py`: `build_converse_kwargs` / `call_converse` / `call_converse_stream` accept `max_tokens: Optional[int] = 4096`; `None` omits `inferenceConfig.maxTokens`, and an all-empty `inferenceConfig` is dropped from the wire request entirely
- `agent/auxiliary_client.py`: the Converse shim's `else 4096` fallback becomes `else None` (pass-through), with a comment explaining the no-cap-by-default policy
- `tests/agent/test_bedrock_adapter.py`: 3 new builder tests — default stays 4096, `None` omits the cap while other params flow, empty `inferenceConfig` dropped
- `tests/agent/test_bedrock_integration.py`: shim-level wire test — no caller cap → no `maxTokens` on the boto3 `converse()` call; explicit caller cap still lands unchanged

### Backward compatibility (why nothing else changes)

The `4096` default on all three adapter signatures is unchanged, and the main-agent transport passes `params.get("max_tokens", 4096)` explicitly (`agent/transports/bedrock.py:58`) — so the main conversation loop, and any caller that passes a cap, behave exactly as before. Only callers that pass **no** cap (the auxiliary no-cap-by-default path) opt into omission.

## Testing

- `python -m pytest tests/agent/test_bedrock_adapter.py tests/agent/test_bedrock_integration.py tests/agent/test_auxiliary_client.py` — 277 passed
- `tests/agent/test_bedrock_1m_context.py tests/agent/test_bedrock_empty_text_blocks.py tests/agent/test_bedrock_interrupt_post_worker.py tests/tools/test_vision_tools.py` — 41 passed
- Mutation checks: reverting the shim to `else 4096` fails the new wire test; reverting the builder to unconditional `maxTokens` fails both new builder tests
- Ruff clean on all four changed files

## Related

- Surfaced during review of #75253 (the review noted "#10809 is only partially fixed on that wire")
- Fixes the Bedrock remainder of #10809

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
