### PR TITLE
feat(gateway): optional profile param on cron.manage RPC

### DIFF
--- a/tests/test_cron_manage_profile_scope.py
+++ b/tests/test_cron_manage_profile_scope.py
@@ -1,0 +1,75 @@
+"""cron.manage optional ``profile`` param — per-profile store scoping.
+
+Mirrors ``skills.manage`` / ``mcp.catalog``: when a ``profile`` is passed the
+handler resolves ``get_profile_dir(profile)`` and wraps the action dispatch in
+``set_hermes_home_override`` / ``reset_hermes_home_override``. Because
+``cronjob()`` -> ``list_jobs()`` keys off ``get_hermes_home()``, the list action
+must then read THAT profile's ``cron/jobs.json``, not the launch profile's.
+"""
+
+import json
+
+from tui_gateway import server
+
+
+def test_cron_manage_profile_reads_that_profiles_store(tmp_path, monkeypatch):
+    # A temp profile home with one job in its cron store.
+    profile_home = tmp_path / "profiles" / "botA"
+    cron_dir = profile_home / "cron"
+    cron_dir.mkdir(parents=True)
+    (cron_dir / "jobs.json").write_text(
+        json.dumps(
+            {
+                "jobs": [
+                    {
+                        "id": "job-botA",
+                        "name": "botA-only-job",
+                        "prompt": "scoped hello",
+                        "enabled": True,
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    # Route the profile name the handler resolves to our temp home.
+    import hermes_cli.profiles as profiles
+
+    monkeypatch.setattr(profiles, "get_profile_dir", lambda name: profile_home)
+
+    resp = server.handle_request(
+        {
+            "id": "1",
+            "method": "cron.manage",
+            "params": {"action": "list", "profile": "botA"},
+        }
+    )
+
+    assert "result" in resp, resp
+    names = [j.get("name") for j in resp["result"]["jobs"]]
+    assert "botA-only-job" in names
+
+    # The override must not leak: an unscoped call after this one resolves the
+    # launch profile again, which does not contain botA's job.
+    from hermes_constants import get_hermes_home_override
+
+    assert get_hermes_home_override() is None
+
+
+def test_cron_manage_unknown_profile_errors(tmp_path, monkeypatch):
+    import hermes_cli.profiles as profiles
+
+    missing = tmp_path / "profiles" / "ghost"
+    monkeypatch.setattr(profiles, "get_profile_dir", lambda name: missing)
+
+    resp = server.handle_request(
+        {
+            "id": "2",
+            "method": "cron.manage",
+            "params": {"action": "list", "profile": "ghost"},
+        }
+    )
+
+    assert "error" in resp, resp
+    assert resp["error"]["code"] == 4064

--- a/tui_gateway/methods_tools.py
+++ b/tui_gateway/methods_tools.py
@@ -1660,6 +1660,23 @@ def _(rid, params: dict) -> dict:
 @method("cron.manage")
 def _(rid, params: dict) -> dict:
     action, jid = params.get("action", "list"), params.get("name", "")
+    # Optional profile scoping: cronjob() keys off HERMES_HOME, so scoping the
+    # env override lets a per-profile cron store be listed/mutated even when
+    # that profile runs a separate gateway. Omitted/None = the launch profile.
+    # Mirrors ``skills.manage`` / ``mcp.catalog``.
+    profile = str(params.get("profile") or "").strip()
+    token = None
+    if profile:
+        try:
+            from hermes_cli.profiles import get_profile_dir
+            from hermes_constants import set_hermes_home_override
+
+            profile_dir = get_profile_dir(profile)
+            if not profile_dir or not profile_dir.is_dir():
+                return _err(rid, 4064, f"profile '{profile}' not found")
+            token = set_hermes_home_override(str(profile_dir))
+        except Exception as e:
+            return _err(rid, 5023, str(e))
     try:
         from tools.cronjob_tools import cronjob
 
@@ -1700,6 +1717,14 @@ def _(rid, params: dict) -> dict:
         return _err(rid, 4016, f"unknown cron action: {action}")
     except Exception as e:
         return _err(rid, 5023, str(e))
+    finally:
+        if token is not None:
+            try:
+                from hermes_constants import reset_hermes_home_override
+
+                reset_hermes_home_override(token)
+            except Exception:
+                pass
 
 
 @method("learning.frames")


### PR DESCRIPTION
`cron.manage` resolved its jobs store from the process `HERMES_HOME`, so a profile whose cron lives in `~/.hermes/profiles/<name>/cron/` was invisible to the default gateway — any per-profile routines query saw 'no cron jobs'.

Add an optional `profile` param that scopes the whole action via `set_hermes_home_override`, **exactly mirroring the adjacent `skills.manage` handler**: resolve `get_profile_dir(profile)`, return err 4064 if missing, override inside a try/finally that always `reset_hermes_home_override`. Omitted/None keeps launch-profile behavior, so existing callers are unaffected. `cronjob()` is unchanged (already keys off HERMES_HOME).

Enables the Hermes-Bot-Mode plugin to show a bot's real routines (NousResearch/Hermes-Bot-Mode#37). **Needs a SERVE-backend gateway restart** to take effect live.

**Verified:** py_compile clean; new focused test 2/2 (scoped list returns the profile's job; override doesn't leak after; unknown profile -> 4064).