### PR TITLE
feat(api_server): expose context-window fields to API responses (WebUI/Hermex context ring)

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -4442,6 +4442,12 @@ class APIServerAdapter(BasePlatformAdapter):
                 "prompt_tokens": usage.get("input_tokens", 0),
                 "completion_tokens": usage.get("output_tokens", 0),
                 "total_tokens": usage.get("total_tokens", 0),
+                # Context-window fields (populated by _run_agent in
+                # gateway/run.py) so WebUI/Hermex context-ring indicator
+                # gets the data via /v1/chat/completions responses.
+                "last_prompt_tokens": usage.get("last_prompt_tokens", 0),
+                "context_length": usage.get("context_length", 0),
+                "threshold_tokens": usage.get("threshold_tokens", 0),
             },
         }
         if is_partial or is_failed or not completed:
@@ -4803,6 +4809,9 @@ class APIServerAdapter(BasePlatformAdapter):
                 "input_tokens": usage.get("input_tokens", 0),
                 "output_tokens": usage.get("output_tokens", 0),
                 "total_tokens": usage.get("total_tokens", 0),
+                "last_prompt_tokens": usage.get("last_prompt_tokens", 0),
+                "context_length": usage.get("context_length", 0),
+                "threshold_tokens": usage.get("threshold_tokens", 0),
             }
             incomplete_history = list(conversation_history)
             incomplete_history.append({"role": "user", "content": user_message})
@@ -5145,6 +5154,9 @@ class APIServerAdapter(BasePlatformAdapter):
                     "input_tokens": usage.get("input_tokens", 0),
                     "output_tokens": usage.get("output_tokens", 0),
                     "total_tokens": usage.get("total_tokens", 0),
+                    "last_prompt_tokens": usage.get("last_prompt_tokens", 0),
+                    "context_length": usage.get("context_length", 0),
+                    "threshold_tokens": usage.get("threshold_tokens", 0),
                 }
                 _failed_history = list(conversation_history)
                 _failed_history.append({"role": "user", "content": user_message})
@@ -5249,6 +5261,9 @@ class APIServerAdapter(BasePlatformAdapter):
                     "input_tokens": usage.get("input_tokens", 0),
                     "output_tokens": usage.get("output_tokens", 0),
                     "total_tokens": usage.get("total_tokens", 0),
+                    "last_prompt_tokens": usage.get("last_prompt_tokens", 0),
+                    "context_length": usage.get("context_length", 0),
+                    "threshold_tokens": usage.get("threshold_tokens", 0),
                 }
                 await _write_event("response.failed", {
                     "type": "response.failed",

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -1100,6 +1100,22 @@ def _openai_error(message: str, err_type: str = "invalid_request_error", param: 
     }
 
 
+def _usage_context_fields(usage: Dict[str, Any]) -> Dict[str, int]:
+    """Context-window fields for OpenAI-compatible usage dicts.
+
+    _run_agent in gateway/run.py populates these in the internal usage dict;
+    we forward them on API responses so the WebUI/Hermex context-ring
+    indicator gets its data via /v1/chat/completions. They are intentional
+    extensions to the OpenAI usage schema, documented as such for consumers
+    that round-trip the usage object.
+    """
+    return {
+        "last_prompt_tokens": usage.get("last_prompt_tokens", 0),
+        "context_length": usage.get("context_length", 0),
+        "threshold_tokens": usage.get("threshold_tokens", 0),
+    }
+
+
 _api_agent_request_reservation: ContextVar[Optional[dict[str, bool]]] = ContextVar(
     "api_agent_request_reservation", default=None
 )
@@ -4442,12 +4458,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 "prompt_tokens": usage.get("input_tokens", 0),
                 "completion_tokens": usage.get("output_tokens", 0),
                 "total_tokens": usage.get("total_tokens", 0),
-                # Context-window fields (populated by _run_agent in
-                # gateway/run.py) so WebUI/Hermex context-ring indicator
-                # gets the data via /v1/chat/completions responses.
-                "last_prompt_tokens": usage.get("last_prompt_tokens", 0),
-                "context_length": usage.get("context_length", 0),
-                "threshold_tokens": usage.get("threshold_tokens", 0),
+                **_usage_context_fields(usage),
             },
         }
         if is_partial or is_failed or not completed:
@@ -4809,9 +4820,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 "input_tokens": usage.get("input_tokens", 0),
                 "output_tokens": usage.get("output_tokens", 0),
                 "total_tokens": usage.get("total_tokens", 0),
-                "last_prompt_tokens": usage.get("last_prompt_tokens", 0),
-                "context_length": usage.get("context_length", 0),
-                "threshold_tokens": usage.get("threshold_tokens", 0),
+                **_usage_context_fields(usage),
             }
             incomplete_history = list(conversation_history)
             incomplete_history.append({"role": "user", "content": user_message})
@@ -5154,9 +5163,7 @@ class APIServerAdapter(BasePlatformAdapter):
                     "input_tokens": usage.get("input_tokens", 0),
                     "output_tokens": usage.get("output_tokens", 0),
                     "total_tokens": usage.get("total_tokens", 0),
-                    "last_prompt_tokens": usage.get("last_prompt_tokens", 0),
-                    "context_length": usage.get("context_length", 0),
-                    "threshold_tokens": usage.get("threshold_tokens", 0),
+                    **_usage_context_fields(usage),
                 }
                 _failed_history = list(conversation_history)
                 _failed_history.append({"role": "user", "content": user_message})
@@ -5261,9 +5268,7 @@ class APIServerAdapter(BasePlatformAdapter):
                     "input_tokens": usage.get("input_tokens", 0),
                     "output_tokens": usage.get("output_tokens", 0),
                     "total_tokens": usage.get("total_tokens", 0),
-                    "last_prompt_tokens": usage.get("last_prompt_tokens", 0),
-                    "context_length": usage.get("context_length", 0),
-                    "threshold_tokens": usage.get("threshold_tokens", 0),
+                    **_usage_context_fields(usage),
                 }
                 await _write_event("response.failed", {
                     "type": "response.failed",

--- a/tests/gateway/test_usage_context_fields.py
+++ b/tests/gateway/test_usage_context_fields.py
@@ -1,0 +1,84 @@
+"""Contract tests for the context-window usage fields passed through to API clients.
+
+``_usage_context_fields`` is the single source of truth for the three
+context-ring fields (``last_prompt_tokens`` / ``context_length`` /
+``threshold_tokens``) that ``_run_agent`` in gateway/run.py populates and
+the API server forwards on every response path: the chat-completions usage
+dict, the incomplete event, and both response.failed branches. The invariant
+under test: every usage dict the server emits includes these three fields,
+sourced from the same helper — so a rename or drift in one path is caught
+here, not by a client's context ring going blank.
+
+These keys are intentional extensions to the OpenAI usage schema (the Hermex
+iOS client decodes them via explicit CodingKeys). They must stay additive.
+"""
+
+from gateway.platforms.api_server import _usage_context_fields
+
+
+def _run_agent_style_usage():
+    """Shape of the usage dict produced by _run_agent (gateway/run.py)."""
+    return {
+        "input_tokens": 1234,
+        "output_tokens": 567,
+        "total_tokens": 1801,
+        "last_prompt_tokens": 1100,
+        "context_length": 200000,
+        "threshold_tokens": 160000,
+        "estimated_cost": 0.0012,
+    }
+
+
+def test_usage_context_fields_passes_through_run_agent_values():
+    usage = _run_agent_style_usage()
+    fields = _usage_context_fields(usage)
+    assert fields == {
+        "last_prompt_tokens": 1100,
+        "context_length": 200000,
+        "threshold_tokens": 160000,
+    }
+
+
+def test_usage_context_fields_default_to_zero_when_absent():
+    # A bare OpenAI-style usage dict has none of the three fields; the
+    # server must still emit them (additive contract) rather than drop them.
+    fields = _usage_context_fields({"input_tokens": 10, "output_tokens": 5})
+    assert fields == {
+        "last_prompt_tokens": 0,
+        "context_length": 0,
+        "threshold_tokens": 0,
+    }
+
+
+def test_usage_context_fields_never_clobber_core_usage_keys():
+    usage = _run_agent_style_usage()
+    fields = _usage_context_fields(usage)
+    assert set(fields).isdisjoint({"input_tokens", "output_tokens", "total_tokens"})
+
+
+def test_usage_context_fields_return_only_the_three_extension_keys():
+    fields = _usage_context_fields(_run_agent_style_usage())
+    assert set(fields) == {
+        "last_prompt_tokens",
+        "context_length",
+        "threshold_tokens",
+    }
+
+
+def test_all_usage_emission_sites_route_through_helper():
+    """Every API response path forwards the fields via the shared helper.
+
+    Structural guard against copy-paste drift: if a future path emits usage
+    without calling the helper, the four call sites below won't all match.
+    """
+    import inspect
+    import re
+
+    import gateway.platforms.api_server as mod
+
+    src = inspect.getsource(mod)
+    # The helper definition itself + its use at every usage emission site.
+    calls = re.findall(r"_usage_context_fields\(usage\)", src)
+    # 1 (definition's docstring reference is not a call) — count actual calls:
+    # chat-completions usage dict, incomplete event, 2x response.failed.
+    assert len(calls) == 4, f"expected 4 usage emission sites, found {len(calls)}"


### PR DESCRIPTION
## Context-window fields missing from api_server responses (WebUI/Hermex context ring)

### Summary
`gateway/run.py` natively populates context-window usage fields (`last_prompt_tokens`, `context_length`, `threshold_tokens`) on the agent usage object, but the API server (`gateway/platforms/api_server.py`) does not pass them through to API responses. WebUI/Hermex clients that render the context-ring indicator therefore receive no data, even though the gateway has it available.

### Evidence
- `gateway/run.py` populates `usage.last_prompt_tokens` / `context_length` / `threshold_tokens` (native, verified on `main`).
- `gateway/platforms/api_server.py` response serialization only carries standard usage fields (prompt_tokens / completion_tokens / total_tokens); the three context-window fields are dropped.
- Impact: context gauge in WebUI/Hermex shows empty until a turn runs; the fields never reach the client.

### Proposed fix (small, localized)
Pass the three context-window fields through in the API server usage mapping (mirroring what `gateway/run.py` already computes). Local carry patch is ~15 lines across the response serialization points in `api_server.py` (3 call sites: chat completions, streaming, and the metrics/usage shape).

```python
# in api_server.py usage mapping, alongside existing usage fields:
"last_prompt_tokens": usage.get("last_prompt_tokens", 0),
"context_length": usage.get("context_length", 0),
"threshold_tokens": usage.get("threshold_tokens", 0),
```

### Context
- Related local issue #1436 (Hermex context ring).
- Upstream already computes the fields in `gateway/run.py`; only the API-layer pass-through is missing.
- Happy to open a PR if this looks right — the patch is minimal and applies cleanly on current `main`.

### Environment
- Hermes Agent v0.20.1 (2026.8.13), API server via gateway, WebUI + Hermex clients.
