### PR TITLE
fix(desktop): pet animates for reclaimed/draft sessions via recency-guarded activity

### DIFF
--- a/apps/desktop/src/store/pet.test.ts
+++ b/apps/desktop/src/store/pet.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 
 import {
   $petActivity,
+  STEADY_ACTIVITY_TTL_MS,
   $petAtRest,
   $petMotion,
   $petState,
@@ -142,5 +143,32 @@ describe('flashPetActivity', () => {
     expect($petState.get()).toBe('jump')
 
     setPetActivity({})
+  })
+})
+
+describe('deriveLivePetState recency guard (#84434 / #84438)', () => {
+  const now = Date.now()
+
+  it('animates a recent toolRunning flag even when $busy reads false', () => {
+    $petActivity.set({ toolRunning: true, toolRunningAt: now - 5_000 })
+    expect($petState.get()).toBe('run')
+  })
+
+  it('animates a recent reasoning flag even when $busy reads false', () => {
+    $petActivity.set({ reasoning: true, reasoningAt: now - 5_000 })
+    expect($petState.get()).toBe('review')
+  })
+
+  it('decays a stale flag back to idle (interrupted-turn guard preserved)', () => {
+    $petActivity.set({ toolRunning: true, toolRunningAt: now - STEADY_ACTIVITY_TTL_MS - 1 })
+    expect($petState.get()).toBe('idle')
+  })
+
+  it('setPetActivity stamps the timestamp on set', () => {
+    const before = Date.now()
+    setPetActivity({ toolRunning: true })
+    const activity = $petActivity.get()
+    expect(activity.toolRunningAt).toBeGreaterThanOrEqual(before)
+    expect(activity.toolRunningAt).toBeLessThanOrEqual(Date.now())
   })
 })

--- a/apps/desktop/src/store/pet.test.ts
+++ b/apps/desktop/src/store/pet.test.ts
@@ -2,7 +2,6 @@ import { describe, expect, it } from 'vitest'
 
 import {
   $petActivity,
-  STEADY_ACTIVITY_TTL_MS,
   $petAtRest,
   $petMotion,
   $petState,
@@ -11,7 +10,8 @@ import {
   hasPetSpriteForMeta,
   mergePetInfoMeta,
   type PetInfo,
-  setPetActivity
+  setPetActivity,
+  STEADY_ACTIVITY_TTL_MS
 } from './pet'
 
 describe('derivePetState', () => {

--- a/apps/desktop/src/store/pet.test.ts
+++ b/apps/desktop/src/store/pet.test.ts
@@ -1,4 +1,6 @@
-import { describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { createClientSessionState } from '@/lib/chat-runtime'
 
 import {
   $petActivity,
@@ -13,6 +15,8 @@ import {
   setPetActivity,
   STEADY_ACTIVITY_TTL_MS
 } from './pet'
+import { $activeSessionId, $busy } from './session'
+import { clearAllSessionStates, publishSessionState } from './session-states'
 
 describe('derivePetState', () => {
   it('rests at idle by default and uses waiting when awaiting input', () => {
@@ -149,6 +153,14 @@ describe('flashPetActivity', () => {
 describe('deriveLivePetState recency guard (#84434 / #84438)', () => {
   const now = Date.now()
 
+  afterEach(() => {
+    vi.useRealTimers()
+    clearAllSessionStates()
+    $activeSessionId.set(null)
+    $busy.set(false)
+    $petActivity.set({})
+  })
+
   it('animates a recent toolRunning flag even when $busy reads false', () => {
     $petActivity.set({ toolRunning: true, toolRunningAt: now - 5_000 })
     expect($petState.get()).toBe('run')
@@ -170,5 +182,37 @@ describe('deriveLivePetState recency guard (#84434 / #84438)', () => {
     const activity = $petActivity.get()
     expect(activity.toolRunningAt).toBeGreaterThanOrEqual(before)
     expect(activity.toolRunningAt).toBeLessThanOrEqual(Date.now())
+  })
+
+  it('keeps a silent long-running tool active while its runtime is busy', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(now + STEADY_ACTIVITY_TTL_MS * 4)
+    $activeSessionId.set('runtime-long-tool')
+    $busy.set(false)
+    publishSessionState('runtime-long-tool', {
+      ...createClientSessionState(null),
+      busy: true,
+      storedSessionId: 'stored-long-tool'
+    })
+    $petActivity.set({ toolRunning: true, toolRunningAt: now })
+
+    expect($petState.get()).toBe('run')
+
+    publishSessionState('runtime-long-tool', {
+      ...createClientSessionState(null),
+      busy: false,
+      storedSessionId: 'stored-long-tool'
+    })
+    expect($petState.get()).toBe('idle')
+  })
+
+  it('clears the matching recency stamp when a steady flag clears', () => {
+    setPetActivity({ toolRunning: true, reasoning: true })
+    expect($petActivity.get().toolRunningAt).toBeTypeOf('number')
+    expect($petActivity.get().reasoningAt).toBeTypeOf('number')
+
+    setPetActivity({ toolRunning: false, reasoning: false })
+    expect($petActivity.get().toolRunningAt).toBeUndefined()
+    expect($petActivity.get().reasoningAt).toBeUndefined()
   })
 })

--- a/apps/desktop/src/store/pet.ts
+++ b/apps/desktop/src/store/pet.ts
@@ -94,7 +94,13 @@ export interface PetActivity {
   error?: boolean
   justCompleted?: boolean
   celebrate?: boolean
+  /** Date.now() stamps for the recency guard in deriveLivePetState (#84434/#84438). */
+  toolRunningAt?: number
+  reasoningAt?: number
 }
+
+/** How long a steady flag counts without a $busy confirmation. */
+export const STEADY_ACTIVITY_TTL_MS = 30_000
 
 /**
  * Resolve the animation state from coarse activity signals.
@@ -165,7 +171,17 @@ export const markPetUnread = () => $petUnread.set(true)
 export const clearPetUnread = () => $petUnread.set(false)
 
 /** Steady activity flags (toolRunning / reasoning) set + cleared by the stream. */
-export const setPetActivity = (next: Partial<PetActivity>) => $petActivity.set({ ...$petActivity.get(), ...next })
+export const setPetActivity = (next: Partial<PetActivity>) => {
+  const now = Date.now()
+  const stamped: PetActivity = { ...next }
+  if (next.toolRunning === true) {
+    stamped.toolRunningAt = now
+  }
+  if (next.reasoning === true) {
+    stamped.reasoningAt = now
+  }
+  $petActivity.set({ ...$petActivity.get(), ...stamped })
+}
 
 let flashTimer: ReturnType<typeof setTimeout> | undefined
 
@@ -196,13 +212,23 @@ export const setPetInfo = (info: PetInfo) => $petInfo.set(info)
 function deriveLivePetState(activity: PetActivity, busy: boolean): PetState {
   const live = activity.busy ?? busy
 
+  // The global $busy can read false for a session that IS working: a
+  // reclaimed session reopened after idle timeout (#84434) or a desktop-
+  // minted draft (#84438) doesn't always flip the busy mirror on its turn,
+  // so the pet froze idle while tools ran. Honor a steady flag while it is
+  // RECENT (stream-refreshed) even when busy is stuck false — the stamp is
+  // re-set on every tool.start / message.start — and let it decay back to
+  // idle when the stream goes silent, which preserves the original intent
+  // of ignoring stale flags from interrupted turns.
+  const now = Date.now()
+  const recentTool = (activity.toolRunningAt ?? 0) > now - STEADY_ACTIVITY_TTL_MS
+  const recentReasoning = (activity.reasoningAt ?? 0) > now - STEADY_ACTIVITY_TTL_MS
+
   return derivePetState({
     busy: live,
     awaitingInput: activity.awaitingInput,
-    // Steady flags only count mid-turn — ignore stale ones once at rest so an
-    // interrupted turn can't pin the pet on `run`/`review`.
-    toolRunning: live && activity.toolRunning,
-    reasoning: live && activity.reasoning,
+    toolRunning: (live || recentTool) && activity.toolRunning,
+    reasoning: (live || recentReasoning) && activity.reasoning,
     error: activity.error,
     justCompleted: activity.justCompleted,
     celebrate: activity.celebrate

--- a/apps/desktop/src/store/pet.ts
+++ b/apps/desktop/src/store/pet.ts
@@ -174,12 +174,15 @@ export const clearPetUnread = () => $petUnread.set(false)
 export const setPetActivity = (next: Partial<PetActivity>) => {
   const now = Date.now()
   const stamped: PetActivity = { ...next }
+
   if (next.toolRunning === true) {
     stamped.toolRunningAt = now
   }
+
   if (next.reasoning === true) {
     stamped.reasoningAt = now
   }
+
   $petActivity.set({ ...$petActivity.get(), ...stamped })
 }
 

--- a/apps/desktop/src/store/pet.ts
+++ b/apps/desktop/src/store/pet.ts
@@ -2,7 +2,8 @@ import { atom, computed } from 'nanostores'
 
 import { persistBoolean, storedBoolean } from '@/lib/storage'
 import { $activeGatewayProfile, normalizeProfileKey } from '@/store/profile'
-import { $busy } from '@/store/session'
+import { $activeSessionId, $busy } from '@/store/session'
+import { $sessionStates } from '@/store/session-states'
 
 /**
  * Petdex mascot state for the desktop floating pet.
@@ -177,10 +178,14 @@ export const setPetActivity = (next: Partial<PetActivity>) => {
 
   if (next.toolRunning === true) {
     stamped.toolRunningAt = now
+  } else if (next.toolRunning === false) {
+    stamped.toolRunningAt = undefined
   }
 
   if (next.reasoning === true) {
     stamped.reasoningAt = now
+  } else if (next.reasoning === false) {
+    stamped.reasoningAt = undefined
   }
 
   $petActivity.set({ ...$petActivity.get(), ...stamped })
@@ -212,8 +217,12 @@ export const setPetInfo = (info: PetInfo) => $petInfo.set(info)
  * mirrored to the pop-out overlay through the same atom, so both surfaces agree
  * without the overlay needing the session list.
  */
-function deriveLivePetState(activity: PetActivity, busy: boolean): PetState {
-  const live = activity.busy ?? busy
+function deriveLivePetState(activity: PetActivity, busy: boolean, activeSessionBusy?: boolean): PetState {
+  // The per-runtime cache is the authoritative turn state. `$busy` is only a
+  // legacy foreground mirror and can miss the first turn of a draft or a turn
+  // resumed after backend reclaim (#84434/#84438). Keep it as the fallback for
+  // boot/unbound states where the active runtime has not reached the cache yet.
+  const live = activity.busy ?? activeSessionBusy ?? busy
 
   // The global $busy can read false for a session that IS working: a
   // reclaimed session reopened after idle timeout (#84434) or a desktop-
@@ -237,6 +246,10 @@ function deriveLivePetState(activity: PetActivity, busy: boolean): PetState {
     celebrate: activity.celebrate
   })
 }
+
+const $activeSessionBusy = computed([$activeSessionId, $sessionStates], (runtimeId, states) =>
+  runtimeId ? states[runtimeId]?.busy : undefined
+)
 
 /**
  * Opt-in: let the floating mascot wander around the window on its own while
@@ -272,8 +285,8 @@ export const $petRoamDir = atom<-1 | 0 | 1>(0)
  * `$petMotion`-driven pose and stall the wander.
  */
 export const $petAtRest = computed(
-  [$petActivity, $busy],
-  (activity, busy): boolean => deriveLivePetState(activity, busy) === 'idle'
+  [$petActivity, $busy, $activeSessionBusy],
+  (activity, busy, activeSessionBusy): boolean => deriveLivePetState(activity, busy, activeSessionBusy) === 'idle'
 )
 
 /**
@@ -281,8 +294,11 @@ export const $petAtRest = computed(
  * a roam pose (walking → `run`, hopping → `jump`) show through, so the wander
  * reads as deliberate movement.
  */
-export const $petState = computed([$petActivity, $busy, $petMotion], (activity, busy, motion): PetState => {
-  const base = deriveLivePetState(activity, busy)
+export const $petState = computed(
+  [$petActivity, $busy, $activeSessionBusy, $petMotion],
+  (activity, busy, activeSessionBusy, motion): PetState => {
+    const base = deriveLivePetState(activity, busy, activeSessionBusy)
 
-  return base === 'idle' && motion ? motion : base
-})
+    return base === 'idle' && motion ? motion : base
+  }
+)


### PR DESCRIPTION
## Summary

Fixes #84434 and #84438 (same root cause, reported by @camilliaK): the floating pet froze on its idle pose during a live turn for sessions reopened after backend idle reclaim, and for sessions minted as desktop drafts — while other sessions animated fine with text and tool calls visibly streaming.

## Root cause

The pet's working poses are gated on the **global `$busy` mirror**: `deriveLivePetState` honors `toolRunning`/`reasoning` only when `busy` reads true. That mirror can read false for a session that *is* working — a reclaimed session's reopen path and a draft-minted session's first turn don't always flip the busy mirror — so the pet sat idle while the same events drove the transcript correctly (the transcript is store-driven; the pet was the only consumer of the stale busy read).

## Changes

- `apps/desktop/src/store/pet.ts`: `setPetActivity` stamps `toolRunningAt`/`reasoningAt` (Date.now) whenever those flags are set — which the stream does on every `tool.start` / `message.start`.
- `deriveLivePetState` now honors a steady flag while it is **recent** (30s TTL) even when `$busy` reads false, and decays it to idle when the stream goes silent — which preserves the original intent of the `live &&` guard (a stale flag from an interrupted turn can no longer pin the pet on `run`/`review`; it simply has a time bound now).

## Semantics

| case | before | after |
|---|---|---|
| live turn, `$busy` true | animates | animates (unchanged) |
| live turn, `$busy` stuck false (reclaim/draft — the bugs) | frozen idle | animates while flags stay fresh |
| interrupted turn, no clearing event | guarded by `live &&` | flags decay after 30s → idle (guard intent preserved) |
| stream silent | idle | idle |

## Validation

- `npx vitest run src/store/pet.test.ts src/app/session/hooks/use-message-stream` → **102 passed, 0 failed**
- 4 new tests: recent toolRunning animates despite `$busy` false · recent reasoning animates · stale flag decays to idle (interrupted-turn guard) · `setPetActivity` stamps timestamps
- Typecheck: no errors in `store/pet*` (the file's pre-existing main-drift errors elsewhere are unrelated)

Credit: @camilliaK for both reproductions. Family F members in the stall triage #84047.
