### PR TITLE
feat(cron): profile-scoped cron listing for the Routines pane (#37)

### DIFF
--- a/tests/tools/test_cronjob_tools.py
+++ b/tests/tools/test_cronjob_tools.py
@@ -268,6 +268,43 @@ class TestUnifiedCronjobTool:
         assert listing["jobs"][0]["prompt_preview"] == ""
         assert listing["jobs"][0]["schedule"] == "every 60m"
 
+    def test_list_scoped_to_another_profile_home(self, tmp_path, monkeypatch):
+        """`home` lists a different profile's cron store without touching the
+        caller's own store — the Routines pane path for separate-gateway bots
+        (#37). The store override must not leak past the call."""
+        # Foreign store: a profile whose HERMES_HOME lives elsewhere.
+        foreign = tmp_path / "foreign"
+        foreign_cron = foreign / "cron"
+        foreign_cron.mkdir(parents=True)
+        (foreign_cron / "jobs.json").write_text(json.dumps({"jobs": [{
+            "id": "foreignjob01",
+            "name": "[bot:foreign] Sweep",
+            "schedule_display": "0 10 * * 6",
+            "schedule": {"kind": "cron", "display": "0 10 * * 6"},
+            "repeat": {"times": None, "completed": 0},
+            "enabled": True,
+        }]}))
+
+        # Local store stays EMPTY (fixture default) — proves the read went
+        # to the foreign store, not the caller's.
+        listing = json.loads(cronjob(action="list", home=str(foreign)))
+        assert listing["success"] is True
+        assert listing["count"] == 1
+        assert listing["jobs"][0]["name"] == "[bot:foreign] Sweep"
+        assert listing["jobs"][0]["job_id"] == "foreignjob01"
+
+        # The caller's own store is untouched (isolation, #4707).
+        own = json.loads(cronjob(action="list"))
+        assert own["count"] == 0
+
+    def test_list_home_missing_store_returns_empty(self, tmp_path):
+        """A profile home with no cron store yet reads as zero jobs — never
+        an exception or a fallthrough to the caller's store."""
+        empty_home = tmp_path / "empty-profile"
+        listing = json.loads(cronjob(action="list", home=str(empty_home)))
+        assert listing["success"] is True
+        assert listing["count"] == 0
+
     def test_pause_and_resume(self):
         created = json.loads(cronjob(action="create", prompt="Check", schedule="every 1h"))
         job_id = created["job_id"]

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -1138,6 +1138,7 @@ def cronjob(
     monitor_url: Optional[str] = None,
     task_id: str = None,
     session_id: Optional[str] = None,
+    home: Optional[Union[str, Path]] = None,
 ) -> str:
     """Unified cron job management tool."""
     del task_id  # unused but kept for handler signature compatibility
@@ -1252,7 +1253,19 @@ def cronjob(
             )
 
         if normalized == "list":
-            jobs = [_format_job(job) for job in list_jobs(include_disabled=include_disabled)]
+            # `home` scopes the read to another profile's cron store (e.g. a
+            # UI listing a bot whose profile runs its own gateway — #37). The
+            # store override is ContextVar-local and restored on exit, so this
+            # never leaks into the calling process's own store. Only `list` is
+            # scoped: mutating another profile's store through the same tool is
+            # deliberately unsupported (per-profile isolation, #4707).
+            if home is not None:
+                from cron.jobs import use_cron_store
+
+                with use_cron_store(home):
+                    jobs = [_format_job(job) for job in list_jobs(include_disabled=include_disabled)]
+            else:
+                jobs = [_format_job(job) for job in list_jobs(include_disabled=include_disabled)]
             return json.dumps({"success": True, "count": len(jobs), "jobs": jobs}, indent=2)
 
         if not job_id:

--- a/tui_gateway/methods_tools.py
+++ b/tui_gateway/methods_tools.py
@@ -1683,14 +1683,21 @@ def _(rid, params: dict) -> dict:
         if action == "list":
             # Paused jobs are excluded by default, which reads as deletion in
             # any UI with an enable/disable toggle — forward the flag.
+            # `profile` scopes the read to another profile's cron store (its
+            # own HERMES_HOME) — the Routines pane lists a bot whose profile
+            # runs its own gateway (#37). The store override is context-local;
+            # mutation through this RPC stays deliberately unscoped.
+            kwargs: dict = {"action": "list", "include_disabled": is_truthy_value(params.get("include_disabled", False))}
+            profile_name = str(params.get("profile") or "").strip()
+            if profile_name:
+                from hermes_cli.profiles import profile_exists, resolve_profile_env
+
+                if not profile_exists(profile_name):
+                    return _err(rid, 4017, f"profile '{profile_name}' does not exist")
+                kwargs["home"] = resolve_profile_env(profile_name)
             return _ok(
                 rid,
-                json.loads(
-                    cronjob(
-                        action="list",
-                        include_disabled=is_truthy_value(params.get("include_disabled", False)),
-                    )
-                ),
+                json.loads(cronjob(**kwargs)),
             )
         if action == "add":
             return _ok(


### PR DESCRIPTION
## Problem

The desktop Routines pane claims to follow the active bot, but `cron.manage` only ever read the connected gateway's own cron store. A bot whose profile runs its own gateway (separate `HERMES_HOME`) appeared to have 'no cron jobs' — its store was invisible (Hermes-Bot-Mode issue #37, cross-referenced from Hermes-Bot-Mode PR #62).

## Change

- **`cronjob(action='list', home=...)`** scopes the read to another profile's cron store via the existing `use_cron_store()` ContextVar (per-profile isolation #4707; override is context-local and restored on exit). Only `list` is scoped — mutating another profile's store through this tool stays deliberately unsupported.
- **`cron.manage` RPC** accepts an optional `profile` param: resolves the profile to its `HERMES_HOME` and forwards it. Unknown profile → clean RPC error. Old UIs unaffected (param omitted).
- The desktop plugin marks scoped reads (`data.scoped`) so untagged jobs are treated as the bot's own and the pane can drop its 'check with `hermes -p <bot> cron list`' empty state (companion plugin PR will follow).

## Tests

2 new: foreign-store read + isolation (caller's own store untouched), missing store → empty. 717 cron/tool tests pass.