### PR TITLE
fix(updater): stop Windows update retries from looping forever

### DIFF
--- a/hermes_cli/_early_recovery.py
+++ b/hermes_cli/_early_recovery.py
@@ -56,6 +56,19 @@ LAZY_REFRESH_REPAIR_PACKAGES: dict[str, str] = {
     "jwt": "PyJWT",
 }
 
+# Set only when this process successfully finishes a deferred core install for
+# an ``update`` invocation.  The normal CLI import that follows must not resolve
+# external secret sources: a configured source can map cryptography._rust and
+# immediately recreate the self-lock marker this fresh process just consumed.
+# Process-local state is intentional so child processes do not inherit the
+# bootstrap exception.
+_UPDATE_RETRY_RECOVERED = False
+
+
+def _should_skip_external_secret_sources() -> bool:
+    """Whether this updater already completed its deferred native install."""
+    return _UPDATE_RETRY_RECOVERED
+
 
 def _project_root() -> Path:
     return Path(__file__).resolve().parent.parent
@@ -352,6 +365,8 @@ def recover_if_needed(
     Never raises: on any failure the import of main.py proceeds and surfaces
     the real error.
     """
+    global _UPDATE_RETRY_RECOVERED
+
     try:
         args = sys.argv[1:] if argv is None else argv
         root = _project_root() if project_root is None else project_root
@@ -384,7 +399,9 @@ def recover_if_needed(
         if core_marker.exists():
             if _marker_owner_is_live(core_marker):
                 return
-            _complete_pending_core_install(root, core_marker)
+            completed = _complete_pending_core_install(root, core_marker)
+            if completed and "update" in args:
+                _UPDATE_RETRY_RECOVERED = True
             return
 
         # Keep the historical update-argv exclusion for the lazy-refresh
@@ -482,7 +499,7 @@ def _release_recovery_lock(root: Path) -> None:
         pass
 
 
-def _complete_pending_core_install(root: Path, core_marker: Path) -> None:
+def _complete_pending_core_install(root: Path, core_marker: Path) -> bool:
     """Run the pending core install BEFORE main.py can import native modules.
 
     ``recover_if_needed`` invokes this when ``.update-incomplete`` exists —
@@ -498,7 +515,8 @@ def _complete_pending_core_install(root: Path, core_marker: Path) -> None:
     attempts ceiling caps automatic retries so a persistent installer
     failure does not block every launch (``hermes acp`` included).
 
-    Never raises: any failure leaves the marker for the post-import path.
+    Never raises: any failure leaves the marker for the post-import path and
+    returns ``False``.  Returns ``True`` only after the install succeeds.
     """
     try:
         from hermes_cli import _install_repair as ir
@@ -526,10 +544,10 @@ def _complete_pending_core_install(root: Path, core_marker: Path) -> None:
                 "post-import recovery path.",
                 file=sys.stderr,
             )
-            return
+            return False
 
         if not _claim_recovery_lock(root):
-            return
+            return False
 
         try:
             print(
@@ -551,7 +569,7 @@ def _complete_pending_core_install(root: Path, core_marker: Path) -> None:
                 "the current venv in the meantime.",
                 file=sys.stderr,
             )
-            return
+            return False
         finally:
             _release_recovery_lock(root)
 
@@ -563,6 +581,7 @@ def _complete_pending_core_install(root: Path, core_marker: Path) -> None:
             "  ✓ Dependency installation completed in the early pass.",
             file=sys.stderr,
         )
+        return True
     except Exception:
         # Never block launch — the marker stays for the post-import path.
-        pass
+        return False

--- a/hermes_cli/_early_recovery.py
+++ b/hermes_cli/_early_recovery.py
@@ -61,6 +61,67 @@ def _project_root() -> Path:
     return Path(__file__).resolve().parent.parent
 
 
+def _pid_is_running(pid: int) -> bool:
+    """Best-effort stdlib-only process liveness probe.
+
+    ``os.kill(pid, 0)`` is not a no-op on Windows, so use the Win32 process
+    handle API there.  An access-denied result is conservatively live: racing
+    an elevated updater is worse than postponing recovery for one launch.
+    """
+    if pid <= 0:
+        return False
+    if sys.platform == "win32":
+        try:
+            import ctypes
+
+            synchronize = 0x00100000
+            kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+            kernel32.OpenProcess.argtypes = [
+                ctypes.c_ulong,
+                ctypes.c_int,
+                ctypes.c_ulong,
+            ]
+            kernel32.OpenProcess.restype = ctypes.c_void_p
+            kernel32.WaitForSingleObject.argtypes = [ctypes.c_void_p, ctypes.c_ulong]
+            kernel32.WaitForSingleObject.restype = ctypes.c_ulong
+            kernel32.CloseHandle.argtypes = [ctypes.c_void_p]
+            kernel32.CloseHandle.restype = ctypes.c_int
+            handle = kernel32.OpenProcess(synchronize, False, pid)
+            if not handle:
+                return ctypes.get_last_error() == 5  # ERROR_ACCESS_DENIED
+            try:
+                return kernel32.WaitForSingleObject(handle, 0) == 258
+            finally:
+                kernel32.CloseHandle(handle)
+        except Exception:
+            return True
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    except OSError:
+        return False
+    return True
+
+
+def _marker_owner_is_live(marker: Path) -> bool:
+    """True when a legacy update marker names a process still running."""
+    try:
+        body = marker.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return False
+    for line in body.splitlines():
+        key, separator, value = line.partition("=")
+        if separator and key.strip() == "pid":
+            try:
+                return _pid_is_running(int(value.strip()))
+            except ValueError:
+                return False
+    return False
+
+
 def _pinned_specs(packages: list[str], project_root: Path) -> list[str]:
     """Map bare package names to their pinned specs from pyproject.toml.
 
@@ -293,10 +354,6 @@ def recover_if_needed(
     """
     try:
         args = sys.argv[1:] if argv is None else argv
-        # Same deliberately-loose match as main(): the real update flow writes
-        # and clears its own markers — a recovery install must not race it.
-        if "update" in args:
-            return
         root = _project_root() if project_root is None else project_root
         if _pytest_owns_live_checkout(root):
             return
@@ -319,8 +376,21 @@ def recover_if_needed(
         # every launch, so attempts past the ceiling are left for main.py's
         # post-import recovery path (which can safely probe-import after this
         # process already holds whatever extensions it needs).
+        # A live marker owner means another updater is currently inside the
+        # marker-to-install window.  Never race it.  A dead owner means this is
+        # a prior deferral/interruption and MUST be recovered even when this
+        # launch is itself `hermes update`: CLI and Desktop retries preserve
+        # that argv, and skipping solely on argv recreates the self-lock loop.
         if core_marker.exists():
+            if _marker_owner_is_live(core_marker):
+                return
             _complete_pending_core_install(root, core_marker)
+            return
+
+        # Keep the historical update-argv exclusion for the lazy-refresh
+        # marker.  Unlike the core marker it is not a deferred native install,
+        # and the active update flow owns its probe/repair lifecycle.
+        if "update" in args:
             return
 
         broken = _probe_broken_packages()

--- a/hermes_cli/_early_recovery.py
+++ b/hermes_cli/_early_recovery.py
@@ -109,7 +109,7 @@ def _pid_is_running(pid: int) -> bool:
         except Exception:
             return True
     try:
-        os.kill(pid, 0)
+        os.kill(pid, 0)  # windows-footgun: ok — Windows returns above
     except ProcessLookupError:
         return False
     except PermissionError:

--- a/hermes_cli/env_loader.py
+++ b/hermes_cli/env_loader.py
@@ -517,7 +517,15 @@ def load_hermes_dotenv(
         _load_dotenv_with_fallback(project_env_path, override=not loaded)
         loaded.append(project_env_path)
 
-    _apply_external_secret_sources(home_path)
+    # A fresh ``hermes update`` retry may have completed a deferred dependency
+    # install before importing this module.  Do not remap native secret-source
+    # dependencies in that same updater process or the self-lock preflight will
+    # recreate the marker and exit 2 again.  Dotenv and managed env still load;
+    # only external source resolution is unnecessary for the updater.
+    from hermes_cli import _early_recovery
+
+    if not _early_recovery._should_skip_external_secret_sources():
+        _apply_external_secret_sources(home_path)
     _apply_managed_env()
 
     # config.yaml is the documented source of truth for terminal.* settings,

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -11750,12 +11750,16 @@ def main():
         help="1Password (op:// references) integration",
     )
 
-    # Lazy import — only pays for itself when this subcommand is actually used.
-    from hermes_cli import secrets_cli as _secrets_cli
-    from hermes_cli import onepassword_secrets_cli as _op_secrets_cli
+    # Registering the secret-manager commands imports their native crypto
+    # dependencies while the top-level parser is being assembled.  A recovered
+    # update retry must stay native-module-free until its dependency mutation
+    # finishes; this process cannot be dispatching ``secrets`` at the same time.
+    if not _early_recovery_mod._should_skip_external_secret_sources():
+        from hermes_cli import secrets_cli as _secrets_cli
+        from hermes_cli import onepassword_secrets_cli as _op_secrets_cli
 
-    _secrets_cli.register_cli(secrets_bw)
-    _op_secrets_cli.register_cli(secrets_op)
+        _secrets_cli.register_cli(secrets_bw)
+        _op_secrets_cli.register_cli(secrets_op)
 
     def _dispatch_secrets(args):  # noqa: ANN001
         sub = getattr(args, "secrets_command", None)

--- a/tests/hermes_cli/test_early_recovery.py
+++ b/tests/hermes_cli/test_early_recovery.py
@@ -142,6 +142,24 @@ def test_early_recovery_module_is_stdlib_only(tmp_path):
 # recover_if_needed unit behavior
 # ---------------------------------------------------------------------------
 
+
+def test_pid_liveness_recognizes_current_process():
+    assert er._pid_is_running(os.getpid()) is True
+    assert er._pid_is_running(0) is False
+
+
+def test_marker_owner_liveness_uses_recorded_pid(tmp_path, monkeypatch):
+    marker = tmp_path / ".update-incomplete"
+    marker.write_text("started=1\npid=4321\n", encoding="utf-8")
+    seen = []
+    monkeypatch.setattr(
+        er, "_pid_is_running", lambda pid: seen.append(pid) or True
+    )
+
+    assert er._marker_owner_is_live(marker) is True
+    assert seen == [4321]
+
+
 def _project(tmp_path: Path, *, pyproject: bool = True) -> Path:
     root = tmp_path / "proj"
     root.mkdir(exist_ok=True)
@@ -453,11 +471,38 @@ def test_lazy_marker_alone_does_not_trigger_core_install(tmp_path, monkeypatch):
     er.recover_if_needed(project_root=root, argv=[])
 
 
-def test_core_marker_skipped_when_user_is_running_update(tmp_path, monkeypatch):
-    """A launch of `hermes update` itself must not race its own markers."""
+def test_core_marker_from_dead_updater_is_recovered_on_update_retry(
+    tmp_path, monkeypatch
+):
+    """Retrying ``hermes update`` must consume a prior deferral marker.
+
+    The self-lock preflight exits after writing this marker.  Desktop and CLI
+    retries both keep ``update`` in argv, so an argv-only skip loops forever.
+    """
     root = _project(tmp_path)
     core_marker = root / ".update-incomplete"
-    core_marker.write_text('{"attempts": 0}', encoding="utf-8")
+    core_marker.write_text("started=1\npid=1234\n", encoding="utf-8")
+
+    from hermes_cli import _install_repair as ir
+
+    calls = []
+    monkeypatch.setattr(ir, "run_core_install", lambda project_root: calls.append(project_root))
+    monkeypatch.setattr(er, "_marker_owner_is_live", lambda _marker: False, raising=False)
+    import hermes_cli._install_repair  # noqa: F401
+
+    er.recover_if_needed(project_root=root, argv=["update"])
+
+    assert calls == [root]
+    assert not core_marker.exists()
+
+
+def test_core_marker_owned_by_live_updater_is_not_recovered(
+    tmp_path, monkeypatch
+):
+    """A second launch must not reinstall into an active updater's venv."""
+    root = _project(tmp_path)
+    core_marker = root / ".update-incomplete"
+    core_marker.write_text("started=1\npid=1234\n", encoding="utf-8")
 
     from hermes_cli import _install_repair as ir
 
@@ -465,12 +510,14 @@ def test_core_marker_skipped_when_user_is_running_update(tmp_path, monkeypatch):
         ir,
         "run_core_install",
         lambda _r: (_ for _ in ()).throw(
-            AssertionError("install must not run for `hermes update` argv")
+            AssertionError("must not race a live updater")
         ),
     )
+    monkeypatch.setattr(er, "_marker_owner_is_live", lambda _marker: True, raising=False)
     import hermes_cli._install_repair  # noqa: F401
 
-    er.recover_if_needed(project_root=root, argv=["update"])
+    er.recover_if_needed(project_root=root, argv=[])
+
     assert core_marker.exists()
 
 

--- a/tests/hermes_cli/test_early_recovery.py
+++ b/tests/hermes_cli/test_early_recovery.py
@@ -488,12 +488,14 @@ def test_core_marker_from_dead_updater_is_recovered_on_update_retry(
     calls = []
     monkeypatch.setattr(ir, "run_core_install", lambda project_root: calls.append(project_root))
     monkeypatch.setattr(er, "_marker_owner_is_live", lambda _marker: False, raising=False)
+    monkeypatch.setattr(er, "_UPDATE_RETRY_RECOVERED", False)
     import hermes_cli._install_repair  # noqa: F401
 
     er.recover_if_needed(project_root=root, argv=["update"])
 
     assert calls == [root]
     assert not core_marker.exists()
+    assert er._should_skip_external_secret_sources() is True
 
 
 def test_core_marker_owned_by_live_updater_is_not_recovered(

--- a/tests/hermes_cli/test_env_loader.py
+++ b/tests/hermes_cli/test_env_loader.py
@@ -6,6 +6,31 @@ import sys
 from hermes_cli.env_loader import load_hermes_dotenv
 
 
+def test_recovered_update_retry_skips_external_secret_sources(tmp_path, monkeypatch):
+    """The post-recovery updater must not remap native vault dependencies."""
+    import hermes_cli.env_loader as env_loader
+    from hermes_cli import _early_recovery
+
+    home = tmp_path / "hermes"
+    home.mkdir()
+    env_file = home / ".env"
+    env_file.write_text("UPDATE_RETRY_DOTENV=loaded\n", encoding="utf-8")
+    monkeypatch.delenv("UPDATE_RETRY_DOTENV", raising=False)
+    monkeypatch.setattr(_early_recovery, "_UPDATE_RETRY_RECOVERED", True)
+    external_calls = []
+    monkeypatch.setattr(
+        env_loader,
+        "_apply_external_secret_sources",
+        lambda path: external_calls.append(path),
+    )
+
+    loaded = load_hermes_dotenv(hermes_home=home)
+
+    assert loaded == [env_file]
+    assert os.environ["UPDATE_RETRY_DOTENV"] == "loaded"
+    assert external_calls == []
+
+
 def test_utf8_bom_does_not_mangle_first_key(tmp_path, monkeypatch):
     """A leading UTF-8 BOM must not prefix the first key name in os.environ.
 

--- a/tests/hermes_cli/test_update_self_lock.py
+++ b/tests/hermes_cli/test_update_self_lock.py
@@ -27,6 +27,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 import hermes_cli.main as cli_main
+from hermes_cli import _early_recovery
 
 
 # ---------------------------------------------------------------------------
@@ -54,6 +55,22 @@ def test_self_lock_detection_clean_when_rust_not_loaded(_winp):
     # no cryptography module in sys.modules → no lock → update proceeds.
     sys.modules.pop("cryptography.hazmat.bindings._rust", None)
     assert cli_main._detect_self_loaded_native_modules() == []
+
+
+def test_recovered_update_retry_builds_parser_without_native_secret_modules(
+    monkeypatch,
+):
+    """Parser registration must not re-lock a freshly recovered updater."""
+    called = []
+    monkeypatch.setattr(_early_recovery, "_UPDATE_RETRY_RECOVERED", True)
+    monkeypatch.setattr(cli_main, "cmd_update", lambda args: called.append(args))
+    monkeypatch.setattr(sys, "argv", ["hermes", "update", "--yes"])
+    sys.modules.pop("cryptography.hazmat.bindings._rust", None)
+
+    cli_main.main()
+
+    assert len(called) == 1
+    assert "cryptography.hazmat.bindings._rust" not in sys.modules
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR do?

Windows CLI and Desktop update retries can loop forever after the updater defers a native dependency replacement. This change recovers a dead updater's pending install before native modules load, keeps active updater markers fail-closed, and prevents the recovered retry from remapping native secret-source dependencies before the self-lock preflight.

### Symptom

After `hermes update` or the Desktop update handoff writes `.update-incomplete`, the retry exits with code 2 because `cryptography.hazmat.bindings._rust` is already mapped. The retry rewrites the same marker, so subsequent retries repeat the failure.

### Impact

Affected Windows users cannot complete CLI or Desktop in-app updates. The retry path remains trapped in the same exit-2 cycle until the pending dependency mutation is completed outside that path.

### Bug Cause

**Trigger:** `hermes_cli/_early_recovery.py` / `recover_if_needed()` / an `update` argv with a dead-owner `.update-incomplete` marker

**Causal chain:**
1. A Windows update defers native dependency replacement and records `.update-incomplete`.
2. The retry preserves the `update` argv, so early recovery skips the pending install and imports the normal CLI graph.
3. Secret-source and parser imports map `cryptography.hazmat.bindings._rust`; the updater self-lock preflight exits 2 and rewrites the marker.

**Why it is wrong:** The argv-only exclusion cannot distinguish a marker owned by an active updater from a marker left by a finished updater. It therefore treats every retry as an in-flight update and never allows the deferred install to complete.

**Working sibling / contrast:** A normal non-update launch consumes the pending marker before native imports. The fix gives an update retry the same early-recovery behavior only when the recorded owner is no longer running.

**Ruled out:** Removing the update exclusion unconditionally is unsafe because a second launch could race dependency mutation owned by a live updater. The implementation checks marker-owner liveness and retains the exclusion for lazy-refresh markers.

### Fix

- Recover dead-owner core update markers before the normal CLI import graph, including when the retry argv contains `update`.
- Treat live or inaccessible marker owners as active so concurrent launches remain fail-closed.
- Record successful retry recovery as process-local state and skip external secret-source resolution and secret-manager parser registration in that updater process.
- Preserve normal dotenv and managed-environment loading, and preserve the existing lazy-refresh update exclusion.

## Related Issue

Closes #86780

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/_early_recovery.py` - distinguish live and dead marker owners, recover dead-owner update retries, and expose process-local recovery state.
- `hermes_cli/env_loader.py` - avoid remapping external secret-source native dependencies after retry recovery.
- `hermes_cli/main.py` - defer secret-manager parser imports in the recovered updater process.
- `tests/hermes_cli/test_early_recovery.py` - cover dead-owner recovery, live-owner preservation, and PID liveness.
- `tests/hermes_cli/test_env_loader.py` - cover secret-source suppression while retaining dotenv loading.
- `tests/hermes_cli/test_update_self_lock.py` - cover parser construction without remapping the native cryptography module.

## How to Test

1. On Windows 11, create a dead-owner `.update-incomplete` marker and run `hermes_cli.main update --yes --no-backup` from a disposable install with a native secret source configured.
2. Verify the pending dependency install completes before native imports, the update exits 0, and the marker is removed.
3. Write a live process PID into the marker and verify a second launch leaves the marker unchanged and does not claim the recovery lock.
4. Run the targeted automated suite:

```bash
scripts/run_tests.sh tests/hermes_cli/test_early_recovery.py tests/hermes_cli/test_env_loader.py tests/hermes_cli/test_update_self_lock.py tests/hermes_cli/test_update_interrupted_recovery.py tests/hermes_cli/test_update_lock.py -v
```

Result: 77 passed, 0 failed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run the repository test entry on the relevant test files and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Relevant documentation update: N/A - behavior is covered by code comments and regression tests
- [x] `cli-config.yaml.example` update: N/A - no configuration keys changed
- [x] `CONTRIBUTING.md` or `AGENTS.md` update: N/A - no architecture or workflow changed
- [x] Cross-platform impact considered - POSIX uses `os.kill(pid, 0)` while Windows uses a non-signaling process-handle probe
- [x] Tool descriptions/schemas update: N/A - no model tool behavior changed

## Screenshots / Logs

Windows REAL_ENV verification reproduced the baseline exit-2 marker rewrite. On the final commit, the same update retry printed `Already up to date!`, exited 0, removed `.update-incomplete`, and preserved a separate live-owner marker byte-for-byte.
