### PR TITLE
test: derive lost-and-found synthetic width from the live schema

### DIFF
--- a/tests/hermes_cli/test_session_recovery_lost_and_found.py
+++ b/tests/hermes_cli/test_session_recovery_lost_and_found.py
@@ -324,10 +324,14 @@ def _make_synthetic_lost_and_found(
         ]
     finally:
         schema.close()
-    assert len(sessions_columns) == 55
+    # Width is derived from the live schema so ordinary column additions
+    # don't break this test (it pinned 54, then 55, then 56 in one week).
+    # The floor guards against accidentally reading an empty/old schema.
+    current_width = len(sessions_columns)
+    assert current_width >= 55
     assert len(usage_columns) == 18
 
-    max_fields = 55
+    max_fields = current_width
     conn = sqlite3.connect(str(path), isolation_level=None)
     try:
         cells = ", ".join(f"c{i}" for i in range(max_fields))
@@ -354,8 +358,8 @@ def _make_synthetic_lost_and_found(
             }
             return [base.get(column) for column in sessions_columns[:ncols]]
 
-        # Current 55-column layout and historical 52-column layout.
-        insert(55, 1, session_row("20260101_010101_aaa001", 55))
+        # Current layout (dynamic width) and historical 52-column layout.
+        insert(max_fields, 1, session_row("20260101_010101_aaa001", max_fields))
         insert(52, 2, session_row("20260202_020202_bbb002", 52))
         # 14-column legacy layout: identity + a plausible epoch timestamp.
         legacy = ["20250303_030303_ccc003", "cli", 1_741_000_000.0] + [None] * 11
@@ -407,7 +411,7 @@ def _make_synthetic_lost_and_found(
 
         # Junk that must NOT be classified into canonical tables.
         insert(3, 300, ["random", "noise", 42])
-        insert(55, 301, ["not-a-session-id", "cli"] + [None] * 53)
+        insert(max_fields, 301, ["not-a-session-id", "cli"] + [None] * (max_fields - 2))
         insert(23, 302, [None, "sess-x", "not-a-role", "junk"])
     finally:
         conn.close()


### PR DESCRIPTION
## Summary
The lost-and-found mapper test now derives its synthetic-row width from the live schema, so ordinary `sessions` column additions no longer break it.

Root cause: the test pinned the exact column count, which changed three times in one week (54 → 55 with `git_metadata_generation`, → 56 with the `hidden` flag). Each addition turned CI red on unrelated PRs — a change-detector test, exactly what the contribution rubric says not to write.

## Changes
- `tests/hermes_cli/test_session_recovery_lost_and_found.py`: `max_fields` now comes from `PRAGMA table_info(sessions)` at runtime with a `>= 55` floor sanity check; synthetic row builders use the derived width. The rebuild contract (current-layout + historical 52-column rows both classified and recovered) is unchanged.

## Validation
| | Before | After |
|---|---|---|
| Schema grows by one column | test fails (`assert 56 == 55`) | test passes, contract still asserted |
| Local run | red on current main | 6 passed, 1 skipped |

## Infographic

![schema-proof test width](https://files.catbox.moe/vkxxj2.png)
