### PR TITLE
fix(bedrock): add Claude Opus 5 to the static 1M context fallback (salvage #75824)

### DIFF
--- a/agent/bedrock_adapter.py
+++ b/agent/bedrock_adapter.py
@@ -1782,6 +1782,9 @@ BEDROCK_CONTEXT_LENGTHS: Dict[str, int] = {
     "anthropic.claude-fable-5":      1_000_000,
     "anthropic.claude-fable":        1_000_000,
     "anthropic.claude-sonnet-5":     1_000_000,
+    # Opus 5 is 1M by default on Bedrock per its model card:
+    # https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-anthropic-claude-opus-5.html
+    "anthropic.claude-opus-5":       1_000_000,
     "anthropic.claude-opus-4-8":     1_000_000,
     "anthropic.claude-opus-4-7":     1_000_000,
     "anthropic.claude-opus-4-6":     1_000_000,

--- a/tests/agent/test_bedrock_adapter.py
+++ b/tests/agent/test_bedrock_adapter.py
@@ -1472,9 +1472,17 @@ class TestClaudeOpus5ContextTable:
         mismatched = []
         with patch("agent.bedrock_adapter.probe_bedrock_context_length") as mock_probe:
             for name, expected in DEFAULT_CONTEXT_LENGTHS.items():
-                if not name.startswith("claude-") or expected < 1_000_000 or "." in name:
+                if not name.startswith("claude-") or expected < 1_000_000:
                     continue
-                actual = get_bedrock_context_length(f"anthropic.{name}", probe=False)
+                # DEFAULT_CONTEXT_LENGTHS carries dotted direct-API aliases
+                # (claude-opus-4.8), while Bedrock model IDs spell the same
+                # revision with hyphens (claude-opus-4-8). Normalize instead
+                # of skipping dotted names so a future dotted 1M model cannot
+                # silently escape this cross-table invariant.
+                bedrock_name = name.replace(".", "-")
+                actual = get_bedrock_context_length(
+                    f"anthropic.{bedrock_name}", probe=False
+                )
                 if actual != expected:
                     mismatched.append((name, expected, actual))
             mock_probe.assert_not_called()

--- a/tests/agent/test_bedrock_adapter.py
+++ b/tests/agent/test_bedrock_adapter.py
@@ -1433,3 +1433,53 @@ class TestBearerTokenRoutesToConverse:
         runtime = self._resolve(monkeypatch, bearer=False)
         assert runtime["api_mode"] == "anthropic_messages"
         assert runtime.get("bedrock_anthropic") is True
+
+
+class TestClaudeOpus5ContextTable:
+    """Salvaged from ryrenz's #75824: the static fallback must not lie for Opus 5."""
+
+    @pytest.mark.parametrize(
+        "model_id",
+        (
+            "anthropic.claude-opus-5",
+            "us.anthropic.claude-opus-5",
+            "eu.anthropic.claude-opus-5",
+            "au.anthropic.claude-opus-5",
+            "global.anthropic.claude-opus-5",
+            # Longest-substring match: the bare key must keep winning once a
+            # dated revision ships.
+            "anthropic.claude-opus-5-v1:0",
+            "eu.anthropic.claude-opus-5-20260724-v1:0",
+        ),
+    )
+    def test_claude_opus_5_uses_offline_context_table(self, model_id):
+        """Claude Opus 5 keeps its documented 1M window without a probe."""
+        from agent.bedrock_adapter import get_bedrock_context_length
+
+        with patch("agent.bedrock_adapter.probe_bedrock_context_length") as mock_probe:
+            assert get_bedrock_context_length(model_id, probe=False) == 1_000_000
+            mock_probe.assert_not_called()
+
+    def test_million_token_claude_entries_match_model_metadata(self):
+        """BEDROCK_CONTEXT_LENGTHS must not drift from DEFAULT_CONTEXT_LENGTHS.
+
+        claude-opus-5 reached one table and not the other and silently fell
+        through to BEDROCK_DEFAULT_CONTEXT_LENGTH (#74263). Assert the pairing
+        rather than a snapshot of today's catalog."""
+        from agent.bedrock_adapter import get_bedrock_context_length
+        from agent.model_metadata import DEFAULT_CONTEXT_LENGTHS
+
+        mismatched = []
+        with patch("agent.bedrock_adapter.probe_bedrock_context_length") as mock_probe:
+            for name, expected in DEFAULT_CONTEXT_LENGTHS.items():
+                if not name.startswith("claude-") or expected < 1_000_000 or "." in name:
+                    continue
+                actual = get_bedrock_context_length(f"anthropic.{name}", probe=False)
+                if actual != expected:
+                    mismatched.append((name, expected, actual))
+            mock_probe.assert_not_called()
+
+        assert not mismatched, (
+            "1M Claude entries missing from BEDROCK_CONTEXT_LENGTHS "
+            f"(model, expected, resolved): {mismatched}"
+        )


### PR DESCRIPTION
## Summary

Salvage of #75824 (@ryrenz, sweeper verdict `salvageability=high`, branch idle since Aug 1). Main has since moved to **probe-first** context resolution (`probe_bedrock_context_length`), but the static fallback table (`probe=False`, offline/display paths) still has no Opus 5 entry — so those paths silently resolve the 128K `BEDROCK_DEFAULT_CONTEXT_LENGTH` for a 1M model.

## Changes

- `agent/bedrock_adapter.py`: add `anthropic.claude-opus-5: 1_000_000` to `BEDROCK_CONTEXT_LENGTHS` (with the model-card reference).
- `tests/agent/test_bedrock_adapter.py`: @ryrenz's two tests, adapted for the probe-first world —
  - `test_claude_opus_5_uses_offline_context_table`: parametrized over bare/us/eu/au/global IDs + versioned suffixes, asserts 1M via the static path with probing uninvoked
  - `test_million_token_claude_entries_match_model_metadata`: pins the pairing between `BEDROCK_CONTEXT_LENGTHS` and `DEFAULT_CONTEXT_LENGTHS` so a future 1M Claude generation can't reach one table and not the other (#74263)

## Validation

`scripts/run_tests.sh tests/agent/test_bedrock_adapter.py` → **70 passed, 0 failed**

## Credit

@ryrenz — original diagnosis and both tests. Right-of-way offered on #75824.
