### PR TITLE
fix(gateway): coerce numeric profile-route IDs to str so routes match (#86470)

### DIFF
--- a/gateway/profile_routing.py
+++ b/gateway/profile_routing.py
@@ -106,6 +106,25 @@ class ProfileRoute:
         return True
 
 
+def _coerce_route_id(key: str, value: Any, name: str) -> Optional[str]:
+    """Coerce a route discriminator to ``str``, warning on non-string input.
+
+    YAML parses unquoted numeric IDs (e.g. Discord snowflakes) as ``int``,
+    but the ``SessionSource`` fields they are matched against are always
+    ``str`` — an ``int`` route would silently never match and messages
+    would fall through to the default profile. Normalize here so the
+    comparison is type-consistent, and surface the misconfiguration.
+    """
+    if value is None or isinstance(value, str):
+        return value
+    logger.warning(
+        "Profile route %r: %s=%r is not a string — coercing to %r. "
+        "Quote the value in config.yaml (e.g. `%s: \"%s\"`) to be explicit.",
+        name, key, value, str(value), key, value,
+    )
+    return str(value)
+
+
 def parse_profile_routes(raw: Optional[List[Dict[str, Any]]]) -> List[ProfileRoute]:
     """Parse profile_routes from config.yaml into ProfileRoute objects.
 
@@ -143,9 +162,9 @@ def parse_profile_routes(raw: Optional[List[Dict[str, Any]]]) -> List[ProfileRou
                 name=name,
                 platform=platform,
                 profile=profile,
-                guild_id=entry.get("guild_id"),
-                chat_id=entry.get("chat_id"),
-                thread_id=entry.get("thread_id"),
+                guild_id=_coerce_route_id("guild_id", entry.get("guild_id"), name),
+                chat_id=_coerce_route_id("chat_id", entry.get("chat_id"), name),
+                thread_id=_coerce_route_id("thread_id", entry.get("thread_id"), name),
                 enabled=entry.get("enabled", True),
             )
         )

--- a/gateway/profile_routing.py
+++ b/gateway/profile_routing.py
@@ -114,13 +114,36 @@ def _coerce_route_id(key: str, value: Any, name: str) -> Optional[str]:
     ``str`` — an ``int`` route would silently never match and messages
     would fall through to the default profile. Normalize here so the
     comparison is type-consistent, and surface the misconfiguration.
+
+    Only ``int`` is coerced (the legitimate YAML-numeric-ID case). Other
+    non-string types (float, bool, ...) are almost always mis-parsed YAML:
+    stringifying them would produce a value that can never match a string
+    discriminator (``123.0`` vs ``"123"``) — recreating the silent-no-match
+    this helper exists to fix. They are still returned as strings (never
+    None: a None discriminator makes the route unconstrained and would
+    match everything), but the warning says outright that the value can
+    never match.
     """
     if value is None or isinstance(value, str):
         return value
+    if isinstance(value, bool):  # bool is an int subclass — check first
+        logger.warning(
+            "Profile route %r: %s=%r is a boolean and can never match — "
+            "quote the value in config.yaml (e.g. `%s: \"%s\"`).",
+            name, key, value, key, value,
+        )
+        return str(value)
+    if isinstance(value, int):
+        logger.warning(
+            "Profile route %r: %s=%r is not a string — coercing to %r. "
+            "Quote the value in config.yaml (e.g. `%s: \"%s\"`) to be explicit.",
+            name, key, value, str(value), key, value,
+        )
+        return str(value)
     logger.warning(
-        "Profile route %r: %s=%r is not a string — coercing to %r. "
-        "Quote the value in config.yaml (e.g. `%s: \"%s\"`) to be explicit.",
-        name, key, value, str(value), key, value,
+        "Profile route %r: %s=%r (type %s) can never match a string route "
+        "discriminator — quote it in config.yaml (e.g. `%s: \"%s\"`).",
+        name, key, value, type(value).__name__, key, value,
     )
     return str(value)
 

--- a/tests/gateway/test_profile_routing.py
+++ b/tests/gateway/test_profile_routing.py
@@ -1,5 +1,7 @@
 """Tests for gateway/profile_routing.py — profile-based routing."""
 
+import logging
+
 import pytest
 from gateway.profile_routing import (
     ProfileRoute,
@@ -49,6 +51,74 @@ class TestParseProfileRoutes:
     def test_empty(self):
         assert parse_profile_routes(None) == []
         assert parse_profile_routes([]) == []
+
+
+class TestNumericRouteIds:
+    """Unquoted numeric IDs in YAML parse as int; SessionSource fields are str.
+
+    parse_profile_routes must coerce them so the route can actually match
+    (previously an int discriminator compared int != str and silently never
+    matched, falling through to the default profile).
+    """
+
+    def test_numeric_ids_are_coerced_to_str(self):
+        # Simulates `guild_id: 123456789012345678` in config.yaml
+        routes = parse_profile_routes([
+            {
+                "name": "numeric",
+                "platform": "discord",
+                "profile": "server-profile",
+                "guild_id": 123456789012345678,
+                "chat_id": 111222333,
+                "thread_id": 444555666,
+            },
+        ])
+        assert len(routes) == 1
+        r = routes[0]
+        assert r.guild_id == "123456789012345678"
+        assert r.chat_id == "111222333"
+        assert r.thread_id == "444555666"
+
+    def test_numeric_route_matches_str_source(self):
+        routes = parse_profile_routes([
+            {
+                "name": "numeric",
+                "platform": "discord",
+                "profile": "server-profile",
+                "guild_id": 123456789012345678,
+            },
+        ])
+        assert match_profile_route(
+            routes, "discord", guild_id="123456789012345678"
+        ) is not None
+
+    def test_non_string_id_logs_warning(self, caplog):
+        with caplog.at_level(logging.WARNING, logger="gateway.profile_routing"):
+            parse_profile_routes([
+                {
+                    "name": "numeric",
+                    "platform": "discord",
+                    "profile": "server-profile",
+                    "guild_id": 123456789012345678,
+                },
+            ])
+        assert any(
+            "not a string" in rec.message and "guild_id" in rec.message
+            for rec in caplog.records
+        )
+
+    def test_string_ids_unchanged(self):
+        routes = parse_profile_routes([
+            {
+                "name": "quoted",
+                "platform": "discord",
+                "profile": "server-profile",
+                "guild_id": "123",
+                "chat_id": "456",
+            },
+        ])
+        assert routes[0].guild_id == "123"
+        assert routes[0].chat_id == "456"
 
 
 class TestMatchProfileRoute:

--- a/tests/gateway/test_profile_routing.py
+++ b/tests/gateway/test_profile_routing.py
@@ -120,6 +120,70 @@ class TestNumericRouteIds:
         assert routes[0].guild_id == "123"
         assert routes[0].chat_id == "456"
 
+    def test_float_id_warns_and_never_matches(self, caplog):
+        """A YAML float (e.g. `guild_id: 123.0`) must not be silently
+        stringified: str(123.0) == "123.0" never equals the str source
+        "123", recreating the silent-no-match this coercion exists to fix.
+        The value stays a string (so the route is never unconstrained) but
+        the warning says outright it can never match."""
+        with caplog.at_level(logging.WARNING, logger="gateway.profile_routing"):
+            routes = parse_profile_routes([
+                {
+                    "name": "floaty",
+                    "platform": "discord",
+                    "profile": "server-profile",
+                    "guild_id": 123.0,
+                },
+            ])
+        r = routes[0]
+        assert r.guild_id == "123.0"  # kept as str, never None
+        # The float stringification does NOT match the int-coerced str form.
+        assert match_profile_route(routes, "discord", guild_id="123") is None
+        assert any(
+            "can never match" in rec.message and "guild_id" in rec.message
+            for rec in caplog.records
+        )
+
+    def test_bool_id_warns_and_never_matches(self, caplog):
+        """bool is an int subclass in Python, so the bool branch must be
+        checked BEFORE int — `guild_id: true` would otherwise be coerced
+        like a numeric ID. A boolean can never name a route; warn loudly
+        and keep it a string (never None/unconstrained)."""
+        with caplog.at_level(logging.WARNING, logger="gateway.profile_routing"):
+            routes = parse_profile_routes([
+                {
+                    "name": "booly",
+                    "platform": "discord",
+                    "profile": "server-profile",
+                    "guild_id": True,
+                },
+            ])
+        r = routes[0]
+        assert r.guild_id == "True"  # kept as str, never None
+        assert match_profile_route(routes, "discord", guild_id="true") is None
+        assert any(
+            "boolean" in rec.message and "guild_id" in rec.message
+            for rec in caplog.records
+        )
+
+    def test_non_string_ids_never_become_none(self):
+        """None would make the discriminator unconstrained (matches() uses
+        truthiness) and turn the route into an accidental wildcard — the
+        coercion contract is: every non-None input yields a str."""
+        routes = parse_profile_routes([
+            {
+                "name": "mixed",
+                "platform": "discord",
+                "profile": "server-profile",
+                "guild_id": 123.0,
+                "chat_id": True,
+                "thread_id": 456,
+            },
+        ])
+        r = routes[0]
+        assert isinstance(r.guild_id, str)
+        assert isinstance(r.chat_id, str)
+        assert isinstance(r.thread_id, str)
 
 class TestMatchProfileRoute:
 


### PR DESCRIPTION
## What does this PR do?

Unquoted numeric IDs in `config.yaml` profile routes (e.g. Discord snowflakes) parse as `int`, but the `SessionSource` fields they are matched against are always `str` — `ProfileRoute.matches()` compared `int != str`, so the route silently never matched and messages fell through to the default profile with only a DEBUG log.

`parse_profile_routes` now coerces `guild_id`/`chat_id`/`thread_id` with `str()` (idempotent for existing string configs) and logs a WARNING when a route ID is not a string, turning a silent misrouting into a visible misconfiguration.

## Related Issue

Fixes #86470

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/profile_routing.py`: new `_coerce_route_id()` helper; `parse_profile_routes` normalizes the three discriminators and warns on non-string input
- `tests/gateway/test_profile_routing.py`: `TestNumericRouteIds` — coercion, end-to-end match against a str source, warning emission, string-config regression

## How to Test

1. `pytest tests/gateway/test_profile_routing.py -q` — 14 passed
2. `ruff check gateway/profile_routing.py tests/gateway/test_profile_routing.py` — clean
3. Manual: set `guild_id: 123456789012345678` (unquoted) in a profile route; gateway now logs a WARNING and the route matches messages from that guild

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run `pytest` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11, Python 3.11
- [x] Cross-platform impact considered (pure config parsing; no platform-specific code)

### Documentation & Housekeeping

- [x] N/A for docs/config example (no new config keys)
- [x] N/A for tool descriptions/schemas