### PR TITLE
fix(gateway): keep lifecycle start_time on one clock source (#86469, #86471)

### DIFF
--- a/gateway/lifecycle_ledger.py
+++ b/gateway/lifecycle_ledger.py
@@ -41,7 +41,6 @@ from __future__ import annotations
 import json
 import logging
 import os
-import time
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, Optional
@@ -254,10 +253,21 @@ def record_startup(home: Optional[Path] = None) -> Optional[Dict[str, Any]]:
         logger.debug("Unclean-exit detection failed", exc_info=True)
 
     try:
+        # Same clock source as _pid_alive_with_start_time: get_process_start_time
+        # (Linux: /proc/<pid>/stat field 22, ticks since boot; macOS/Windows:
+        # psutil epoch-centiseconds). The previous time.time() (epoch seconds)
+        # never matched the Linux ticks value (~1.7e9 apart), so every
+        # --replace handoff misreported the previous gateway as an unclean exit.
+        from gateway.status import get_process_start_time
+
+        start_time = get_process_start_time(os.getpid())
+    except Exception:
+        start_time = None  # err on "alive" in _pid_alive_with_start_time
+    try:
         claim: Dict[str, Any] = {
             "phase": "running",
             "pid": os.getpid(),
-            "start_time": time.time(),
+            "start_time": start_time,
             "started_at": datetime.now(timezone.utc).isoformat(),
         }
         # Carry the verdict on the PREVIOUS life forward on the new

--- a/gateway/lifecycle_ledger.py
+++ b/gateway/lifecycle_ledger.py
@@ -262,7 +262,11 @@ def record_startup(home: Optional[Path] = None) -> Optional[Dict[str, Any]]:
 
         start_time = get_process_start_time(os.getpid())
     except Exception:
-        start_time = None  # err on "alive" in _pid_alive_with_start_time
+        # err on "alive" in _pid_alive_with_start_time; debug-log so a real
+        # regression in get_process_start_time is not silently masked
+        # (#86818 review).
+        logger.debug("Failed to read process start time", exc_info=True)
+        start_time = None
     try:
         claim: Dict[str, Any] = {
             "phase": "running",

--- a/gateway/status.py
+++ b/gateway/status.py
@@ -285,6 +285,27 @@ def _get_scope_lock_path(scope: str, identity: str) -> Path:
     return _get_lock_dir() / f"{scope}-{_scope_hash(identity)}.lock"
 
 
+def _parse_proc_stat_start_time(stat_text: str) -> Optional[int]:
+    """Field 22 (start time in clock ticks) from ``/proc/<pid>/stat``.
+
+    ``comm`` (field 2, parenthesized) can contain spaces and right parens,
+    so plain whitespace splitting shifts every later field index — and if
+    the shifted index lands on a volatile field (e.g. the processor number,
+    which changes with CPU migration), two reads of the same live process
+    can yield different values. ``comm`` is the only parenthesized field, so
+    split on the LAST ``)`` and index the tail (the same approach
+    ``gateway/drain_control.py`` documents and uses).
+
+    Returns None on any malformed input.
+    """
+    try:
+        tail = stat_text.rsplit(")", 1)[1].split()
+        # tail starts at field 3, so field 22 == tail index 19.
+        return int(tail[19])
+    except (IndexError, ValueError):
+        return None
+
+
 def _get_process_start_time(pid: int) -> Optional[int]:
     """Return a stable per-process start-time fingerprint, or None.
 
@@ -305,9 +326,12 @@ def _get_process_start_time(pid: int) -> Optional[int]:
     """
     stat_path = Path(f"/proc/{pid}/stat")
     try:
-        # Field 22 in /proc/<pid>/stat is process start time (clock ticks).
-        return int(stat_path.read_text(encoding="utf-8").split()[21])
-    except (FileNotFoundError, IndexError, PermissionError, ValueError, OSError):
+        parsed = _parse_proc_stat_start_time(
+            stat_path.read_text(encoding="utf-8")
+        )
+        if parsed is not None:
+            return parsed
+    except (FileNotFoundError, PermissionError, OSError):
         pass
 
     # No /proc (macOS / Windows): psutil is a hard dependency and exposes a

--- a/tests/gateway/test_lifecycle_ledger.py
+++ b/tests/gateway/test_lifecycle_ledger.py
@@ -214,3 +214,69 @@ def test_prior_exit_label_survives_corrupt_sentinel(tmp_path: Path) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text("garbage", encoding="utf-8")
     assert read_prior_exit_label(tmp_path) == "unknown"
+
+
+# ---------------------------------------------------------------------------
+# start_time clock-source consistency (#86469)
+# ---------------------------------------------------------------------------
+
+
+def test_record_startup_stores_same_clock_source_as_comparison(tmp_path: Path, monkeypatch) -> None:
+    """record_startup must persist get_process_start_time(os.getpid()) — the
+    same source _pid_alive_with_start_time reads back — not time.time()
+    (epoch seconds), which never matches Linux's /proc clock ticks and made
+    every --replace handoff look like an unclean exit."""
+    from gateway.lifecycle_ledger import _pid_alive_with_start_time
+
+    record_startup(home=tmp_path)
+    sentinel = _read_sentinel(tmp_path)
+
+    assert "start_time" in sentinel
+    assert sentinel["start_time"] is not None
+    # The stored value must equal what the comparison side reads for this
+    # same process — that is the invariant that keeps the ≤2s check honest.
+    from gateway.status import get_process_start_time
+
+    assert sentinel["start_time"] == get_process_start_time(os.getpid())
+    assert _pid_alive_with_start_time(os.getpid(), sentinel["start_time"]) is True
+
+
+def test_record_startup_falls_back_to_none_when_fingerprint_unavailable(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """A None start_time is the safe degraded state: _pid_alive_with_start_time
+    errs on 'alive' rather than reporting a live owner as dead."""
+    import gateway.lifecycle_ledger as ledger
+
+    monkeypatch.setattr(
+        "gateway.status.get_process_start_time", lambda pid: None
+    )
+    record_startup(home=tmp_path)
+    sentinel = _read_sentinel(tmp_path)
+    assert sentinel["start_time"] is None
+
+    # A None stored value must not cause a false unclean-exit report for a
+    # live process: the takeover path treats it as "can't disambiguate —
+    # assume alive".
+    from gateway.lifecycle_ledger import _pid_alive_with_start_time
+
+    assert _pid_alive_with_start_time(os.getpid(), None) is True
+
+
+def test_mismatched_clock_sources_fail_the_two_second_check(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """Shape of #86469: time.time() (epoch seconds) and /proc clock ticks are
+    ~1.7e9 apart, so a sentinel written from a different clock source than the
+    comparison reads fails the ≤2s check and a live owner is misreported as
+    an unclean exit. Same-source values must match within tolerance."""
+    from gateway.lifecycle_ledger import _pid_alive_with_start_time
+
+    monkeypatch.setattr("gateway.status._pid_exists", lambda pid: True)
+    # Comparison side reads a ticks-like fingerprint (Linux /proc field 22).
+    monkeypatch.setattr("gateway.status.get_process_start_time", lambda pid: 1755200000)
+
+    # Epoch seconds (the pre-fix record_startup value): far apart → dead.
+    assert _pid_alive_with_start_time(os.getpid(), 1755200000.0 + 1000.0) is False
+    # Same-source value → alive (planned takeover, not an unclean death).
+    assert _pid_alive_with_start_time(os.getpid(), 1755200000) is True

--- a/tests/gateway/test_status.py
+++ b/tests/gateway/test_status.py
@@ -288,6 +288,45 @@ class TestGatewayRuntimeStatus:
         assert payload["platforms"]["discord"]["error_message"] is None
 
 
+class TestParseProcStatStartTime:
+    """Field 22 of /proc/<pid>/stat is start time (clock ticks since boot).
+
+    comm (field 2, parenthesized) can contain spaces and right parens, so a
+    plain whitespace split shifts every later field index — parsing must
+    split on the LAST ')' and index the tail (drain_control.py convention).
+    """
+
+    @staticmethod
+    def _stat_line(comm: str, starttime: int) -> str:
+        # Fields 3..21 (19 values: state … itrealvalue), then field 22.
+        tail = [
+            "S", "1", "2", "3", "4", "5", "6", "7", "8", "9",
+            "10", "11", "12", "13", "14", "15", "16", "17", "18",
+        ]
+        return f"42 ({comm}) " + " ".join(tail) + f" {starttime} 23"
+
+    def test_plain_comm(self):
+        stat = self._stat_line("python", 12345)
+        assert status._parse_proc_stat_start_time(stat) == 12345
+
+    def test_comm_with_spaces(self):
+        # Whitespace-splitting would read field 22 as "77777" shifted to an
+        # earlier index (or worse, land on the volatile processor field).
+        stat = self._stat_line("my agent (worker)", 77777)
+        assert status._parse_proc_stat_start_time(stat) == 77777
+
+    def test_comm_with_parens_and_spaces(self):
+        stat = self._stat_line("cmd (sub) proc) )", 99999)
+        assert status._parse_proc_stat_start_time(stat) == 99999
+
+    def test_malformed_returns_none(self):
+        assert status._parse_proc_stat_start_time("no parens at all") is None
+        assert status._parse_proc_stat_start_time("42 (x) S 1 2") is None  # too short
+        # tail[19] (field 22) is not an int → ValueError path
+        stat = "42 (x) S " + " ".join(["1"] * 18) + " nope 23"
+        assert status._parse_proc_stat_start_time(stat) is None
+
+
 class TestGetProcessStartTime:
     """Start-time fingerprint backing the PID-reuse guard (#43846 / #50468).
 


### PR DESCRIPTION
﻿## What does this PR do?

Two halves of the same Linux `/proc` misread, fixed together because the lifecycle fix stores `get_process_start_time(os.getpid())` — the parser must be correct first:

1. **#86471 — `gateway/status.py` parsed `/proc/<pid>/stat` by whitespace-splitting and reading index 21.** `comm` (field 2, parenthesized) can contain spaces and right parens, shifting every later field index. If the shifted index lands on a volatile field (e.g. the processor number, which changes with CPU migration), two reads of the same live process can differ — `delivery_ledger._owner_alive()` could then misjudge a live owner as dead and let a second gateway claim its rows (duplicate delivery). The repo already documents and handles this correctly in `gateway/drain_control.py` (split on the LAST `)`); this call site was the leftover. Fix: extract `_parse_proc_stat_start_time()`, split on the last `)`, index the tail.

2. **#86469 — `gateway/lifecycle_ledger.py::record_startup` stored `time.time()` (epoch seconds) while `_pid_alive_with_start_time` compares against `get_process_start_time`.** On Linux that returns `/proc` field 22 (clock ticks since boot, ~1.7e9 apart from epoch seconds), so the `<= 2.0` check was always False and every `--replace` handoff misreported the previous gateway as an unclean exit (spurious `gateway.previous_unclean_exit` warnings/exit-diag records). Fix: store `get_process_start_time(os.getpid())` — the same source the comparison reads back. A `None` fingerprint (unavailable) degrades to the existing err-on-alive path, never to a false death report.

## Related Issue

Fixes #86469
Fixes #86471

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/status.py`: new `_parse_proc_stat_start_time()` (pure, tested); `_get_process_start_time` Linux branch uses it
- `gateway/lifecycle_ledger.py`: `record_startup` stores the same-source fingerprint; removed now-unused `import time`
- `tests/gateway/test_status.py`: `TestParseProcStatStartTime` — plain comm, comm with spaces, comm with parens, malformed inputs
- `tests/gateway/test_lifecycle_ledger.py`: same-source storage invariant, `None`-fingerprint fallback, mismatched-clock-sources regression shape

## How to Test

1. `pytest tests/gateway/test_status.py tests/gateway/test_lifecycle_ledger.py -q` — 67 passed, 1 skipped (2 pre-existing env failures on Windows: `sleep` binary and a Linux-only `/usr/libexec` assertion — both pass on Linux CI)
2. `ruff check` on the four changed files — clean
3. Linux manual: `hermes gateway run` + `--replace` handoff no longer logs `previous_unclean_exit`

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run `pytest` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11, Python 3.11 (Linux /proc paths covered by unit tests; live-process test is Linux CI)

### Documentation & Housekeeping

- [x] N/A for docs/config example (no new config keys)
- [x] N/A for tool descriptions/schemas
