### PR TITLE
fix(agent): remove dangling references to non-existent 'hermes-agent' skill

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -163,9 +163,8 @@ HERMES_AGENT_HELP_GUIDANCE = (
     "it — or when you need to understand your own features, tools, or capabilities, "
     "the documentation at https://hermes-agent.nousresearch.com/docs is your "
     "authoritative reference and always holds the latest, most up-to-date "
-    "information. Load the `hermes-agent` skill with skill_view(name='hermes-agent') "
-    "for additional guidance and proven workflows, but treat the docs as the source "
-    "of truth when the two differ."
+    "information. Treat the docs as the source of truth rather than guessing or "
+    "inventing workarounds."
 )
 
 MEMORY_GUIDANCE = (
@@ -2032,11 +2031,6 @@ def _build_skills_system_prompt_inner(
             "Skills also encode the user's preferred approach, conventions, and quality standards "
             "for tasks like code review, planning, and testing — load them even for tasks you "
             "already know how to do, because the skill defines how it should be done here.\n"
-            "Whenever the user asks you to configure, set up, install, enable, disable, modify, "
-            "or troubleshoot Hermes Agent itself — its CLI, config, models, providers, tools, "
-            "skills, voice, gateway, plugins, or any feature — load the `hermes-agent` skill "
-            "first. It has the actual commands (e.g. `hermes config set …`, `hermes tools`, "
-            "`hermes setup`) so you don't have to guess or invent workarounds.\n"
             "If a skill has issues, fix it with skill_manage(action='patch').\n"
             "After difficult/iterative tasks, offer to save as a skill. "
             "If a skill you loaded was missing steps, had wrong commands, or needed "

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -30,6 +30,7 @@ from agent.prompt_builder import (
     OPENAI_MODEL_EXECUTION_GUIDANCE,
     PARALLEL_TOOL_CALL_GUIDANCE,
     GOOGLE_MODEL_OPERATIONAL_GUIDANCE,
+    HERMES_AGENT_HELP_GUIDANCE,
     MEMORY_GUIDANCE,
     SESSION_SEARCH_GUIDANCE,
     PLATFORM_HINTS,
@@ -54,6 +55,17 @@ class TestGuidanceConstants:
     def test_session_search_guidance_is_simple_cross_session_recall(self):
         assert "relevant cross-session context exists" in SESSION_SEARCH_GUIDANCE
         assert "recent turns of the current session" not in SESSION_SEARCH_GUIDANCE
+
+    def test_hermes_agent_help_guidance_does_not_reference_missing_skill(self):
+        assert "`hermes-agent` skill" not in HERMES_AGENT_HELP_GUIDANCE
+        assert "skill_view" not in HERMES_AGENT_HELP_GUIDANCE
+        assert "https://hermes-agent.nousresearch.com/docs" in HERMES_AGENT_HELP_GUIDANCE
+        assert "source of truth" in HERMES_AGENT_HELP_GUIDANCE
+
+    def test_skills_system_prompt_does_not_reference_hermes_agent_skill(self):
+        prompt = build_skills_system_prompt()
+        assert "load the `hermes-agent` skill" not in prompt
+        assert "skill_view(name='hermes-agent')" not in prompt
 
 
 # =========================================================================


### PR DESCRIPTION
## What does this PR do?

`HERMES_AGENT_HELP_GUIDANCE` and the skills system prompt both instructed the model to load a `hermes-agent` skill that does not exist in the repository, installer, or `hermes skills list`. This caused a wasted `skill_view` tool call and a "Skill 'hermes-agent' not found" error on every self-help question before the model fell back to the docs URL. This PR removes those dangling references and keeps the docs URL as the authoritative source of truth.

## Related Issue

Fixes #86478

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/prompt_builder.py`:
  - Reworded `HERMES_AGENT_HELP_GUIDANCE` to remove the `Load the \`hermes-agent\` skill with skill_view(name='hermes-agent') ...` sentence. The docs URL is now explicitly recommended as the source of truth.
  - Removed the `Whenever the user asks you to configure ... load the \`hermes-agent\` skill first.` paragraph from `_build_skills_system_prompt_inner()`. The `<available_skills>` index already routes to real skills.
- `tests/agent/test_prompt_builder.py`:
  - Added `test_hermes_agent_help_guidance_does_not_reference_missing_skill`.
  - Added `test_skills_system_prompt_does_not_reference_hermes_agent_skill`.

## How to Test

1. Focused regression tests:
   ```bash
   PYTHONPATH=. python -m pytest tests/agent/test_prompt_builder.py::TestGuidanceConstants -x -q
   ```
   Expected: 4 passed.
2. Broader prompt coverage:
   ```bash
   PYTHONPATH=. python -m pytest tests/agent/test_prompt_builder.py tests/agent/test_system_prompt.py -q
   ```
   Expected: 82 passed, 1 skipped.
3. On the exact base, the new `TestGuidanceConstants` assertions fail because the missing skill is still referenced; on the branch they pass.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 24.6.0

### Documentation & Housekeeping

- [x] N/A — the change only removes references to a non-existent skill from prompt constants.

## Screenshots / Logs

N/A
