### PR TITLE
fix(desktop): isolate new sessions in worktrees

### DIFF
--- a/apps/desktop/electron/git-worktree-ops.test.ts
+++ b/apps/desktop/electron/git-worktree-ops.test.ts
@@ -12,6 +12,7 @@ import {
   listBaseBranches,
   listBranches,
   parseWorktrees,
+  removeWorktree,
   sanitizeBranch,
   switchBranch
 } from './git-worktree-ops'
@@ -188,6 +189,47 @@ test('addWorktree: existingBranch checks the branch out without a new branch', a
       execFileSync('git', ['branch', '--show-current'], { cwd: result.path }).toString().trim(),
       'cool/feature'
     )
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test('addWorktree: keeps the main checkout clean by locally excluding .worktrees', async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hermes-clean-worktrees-'))
+  const git = (...args) => execFileSync('git', args, { cwd: dir }).toString().trim()
+
+  try {
+    await ensureGitRepo('git', dir)
+    const result = await addWorktree(dir, { branch: 'hermes/clean', name: 'clean' }, 'git')
+
+    assert.ok(fs.existsSync(result.path))
+    assert.equal(git('status', '--porcelain'), '')
+
+    const excludePath = path.resolve(dir, git('rev-parse', '--git-path', 'info/exclude'))
+
+    assert.match(fs.readFileSync(excludePath, 'utf8'), /^\/\.worktrees\/$/m)
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test('removeWorktree: deletes an owned automatic branch only when it still equals its base', async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hermes-clean-owned-branch-'))
+  const git = (...args) => execFileSync('git', args, { cwd: dir }).toString().trim()
+
+  try {
+    await ensureGitRepo('git', dir)
+    const base = git('branch', '--show-current')
+    const result = await addWorktree(dir, { base, branch: 'hermes/session-owned', name: 'owned' }, 'git')
+
+    await removeWorktree(
+      dir,
+      result.path,
+      { deleteBranch: { base, branch: result.branch }, force: false },
+      'git'
+    )
+
+    assert.equal(git('branch', '--list', result.branch), '')
   } finally {
     fs.rmSync(dir, { recursive: true, force: true })
   }

--- a/apps/desktop/electron/git-worktree-ops.ts
+++ b/apps/desktop/electron/git-worktree-ops.ts
@@ -242,6 +242,28 @@ function uniqueDir(base) {
   return dir
 }
 
+async function ensureWorktreesExcluded(gitBin, root) {
+  const gitPath = (await runGit(gitBin, ['rev-parse', '--git-path', 'info/exclude'], root)).trim()
+  const excludePath = path.isAbsolute(gitPath) ? gitPath : path.resolve(root, gitPath)
+  const marker = '/.worktrees/'
+  let existing = ''
+
+  try {
+    existing = fs.readFileSync(excludePath, 'utf8')
+  } catch (error) {
+    if (error.code !== 'ENOENT') {
+      throw error
+    }
+  }
+
+  if (existing.split(/\r?\n/).some(line => line.trim() === marker)) {
+    return
+  }
+
+  fs.mkdirSync(path.dirname(excludePath), { recursive: true })
+  fs.appendFileSync(excludePath, `${existing && !existing.endsWith('\n') ? '\n' : ''}${marker}\n`)
+}
+
 async function addExistingBranchWorktree(gitBin, root, name) {
   const requested = sanitizeBranch(name)
 
@@ -261,6 +283,8 @@ async function addExistingBranchWorktree(gitBin, root, name) {
 
     return { path: root, branch, repoRoot: root }
   }
+
+  await ensureWorktreesExcluded(gitBin, root)
 
   const dir = uniqueDir(path.join(root, '.worktrees', slugify(branch)))
 
@@ -299,6 +323,9 @@ async function addWorktree(repoPath, options, gitBin) {
 
   const slug = slugify(opts.name || `work-${Date.now().toString(36)}`)
   const branch = sanitizeBranch(opts.branch) || `hermes/${slug}`
+
+  await ensureWorktreesExcluded(gitBin, root)
+
   const dir = uniqueDir(path.join(root, '.worktrees', slug))
 
   const args = ['worktree', 'add', '-b', branch, dir]
@@ -359,6 +386,24 @@ async function removeWorktree(repoPath, worktreePath, options, gitBin) {
 
   args.push(resolvedTree)
   await runGit(gitBin, args, root)
+
+  const owned = options && options.deleteBranch
+
+  if (owned) {
+    const branch = String(owned.branch || '')
+    const base = String(owned.base || '')
+
+    if (!branch.startsWith('hermes/session-') || branch !== sanitizeBranch(branch) || !base || base.startsWith('-')) {
+      throw new Error('Invalid automatic worktree branch cleanup request.')
+    }
+
+    const branchOid = (await runGit(gitBin, ['rev-parse', '--verify', `refs/heads/${branch}^{commit}`], root)).trim()
+    const baseOid = (await runGit(gitBin, ['rev-parse', '--verify', `${base}^{commit}`], root)).trim()
+
+    if (branchOid === baseOid) {
+      await runGit(gitBin, ['update-ref', '-d', `refs/heads/${branch}`, branchOid], root)
+    }
+  }
 
   return { removed: resolvedTree }
 }

--- a/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
@@ -7,12 +7,14 @@ import { $terminalTakeover, setTerminalTakeover } from '@/app/right-sidebar/stor
 import { noteActiveTreeGroup, revealTreePane } from '@/components/pane-shell/tree/store'
 import { getAllSessionMessages, getLatestSessionMessages, getSession, type SessionInfo } from '@/hermes'
 import { createClientSessionState } from '@/lib/chat-runtime'
+import * as desktopGitModule from '@/lib/desktop-git'
 import { clearSessionDraft, stashSessionDraft, takeSessionDraft } from '@/store/composer'
 import { $activeGatewayProfile, $newChatProfile, ensureGatewayProfile } from '@/store/profile'
 import { $projectScope, $projectTree, ALL_PROJECTS } from '@/store/projects'
 import {
   $activeSessionId,
   $activeSessionStoredIdRotation,
+  $connection,
   $currentCwd,
   $currentFastMode,
   $currentModel,
@@ -37,7 +39,7 @@ import {
 } from '@/store/session'
 import { $sessionTiles } from '@/store/session-states'
 
-import { sessionRoute } from '../../routes'
+import { NEW_CHAT_ROUTE, sessionRoute } from '../../routes'
 import type { ClientSessionState } from '../../types'
 
 import { useSessionActions } from './use-session-actions'
@@ -78,7 +80,7 @@ function deferred<T>() {
 
 type HarnessHandle = Pick<
   ReturnType<typeof useSessionActions>,
-  'createBackendSessionForSend' | 'selectSidebarItem' | 'startFreshSessionDraft'
+  'createBackendSessionForSend' | 'openNewSessionTile' | 'selectSidebarItem' | 'startFreshSessionDraft'
 >
 
 function storedSession(overrides: Partial<SessionInfo> = {}): SessionInfo {
@@ -101,10 +103,12 @@ function storedSession(overrides: Partial<SessionInfo> = {}): SessionInfo {
 }
 
 function Harness({
+  getRouteToken = () => 'token',
   navigate = vi.fn(),
   onReady,
   requestGateway
 }: {
+  getRouteToken?: () => string
   navigate?: ReturnType<typeof vi.fn>
   onReady: (handle: HarnessHandle) => void
   requestGateway: <T>(method: string, params?: Record<string, unknown>) => Promise<T>
@@ -117,7 +121,7 @@ function Harness({
     busyRef: ref(false),
     creatingSessionRef: ref(false),
     ensureSessionState: () => ({}) as ClientSessionState,
-    getRouteToken: () => 'token',
+    getRouteToken,
     getRoutedStoredSessionId: () => null,
     navigate: navigate as never,
     requestGateway,
@@ -387,6 +391,10 @@ async function createWith(
   let createParams: Record<string, unknown> | undefined
 
   const requestGateway = vi.fn(async (method: string, params?: Record<string, unknown>) => {
+    if (method === 'config.get') {
+      return { branch: '', cwd: '/not-a-repository' } as never
+    }
+
     if (method === 'session.create') {
       createParams = params
 
@@ -463,6 +471,7 @@ describe('startFreshSessionDraft', () => {
 describe('createBackendSessionForSend profile routing', () => {
   afterEach(() => {
     cleanup()
+    $connection.set(null)
     $newChatProfile.set(null)
     $activeGatewayProfile.set('default')
     $projectScope.set(ALL_PROJECTS)
@@ -521,6 +530,473 @@ describe('createBackendSessionForSend profile routing', () => {
     expect(params).toMatchObject({ cwd: '/remote/worktree' })
   })
 
+  it('isolates a new chat from the main checkout before session.create', async () => {
+    vi.spyOn(desktopGitModule, 'desktopGit').mockReturnValue({
+      baseBranchList: vi.fn(async () => [{ isDefault: true, isRemote: true, name: 'origin/main' }]),
+      repoStatus: vi.fn(async () => ({ branch: 'feature/stale', defaultBranch: 'main', detached: false } as never)),
+      worktreeAdd: vi.fn(async () => ({ branch: 'hermes/session-fixed', path: '/repo/.worktrees/session-fixed' })),
+      worktreeList: vi.fn(async () => [
+        { branch: 'feature/stale', detached: false, isMain: true, locked: false, path: '/repo' }
+      ])
+    } as never)
+
+    const params = await createWith(() => {
+      $currentCwd.set('/repo')
+    })
+
+    expect(params).toMatchObject({ cwd: '/repo/.worktrees/session-fixed' })
+  })
+
+  it('isolates the local backend default cwd for a global new chat before session.create', async () => {
+    vi.spyOn(desktopGitModule, 'desktopGit').mockReturnValue({
+      baseBranchList: vi.fn(async () => [{ isDefault: true, isRemote: true, name: 'origin/main' }]),
+      repoStatus: vi.fn(async () => ({ branch: 'main', defaultBranch: 'main', detached: false } as never)),
+      worktreeAdd: vi.fn(async () => ({ branch: 'hermes/session-fixed', path: '/repo/.worktrees/session-fixed' })),
+      worktreeList: vi.fn(async () => [
+        { branch: 'main', detached: false, isMain: true, locked: false, path: '/repo' }
+      ])
+    } as never)
+
+    let createParams: Record<string, unknown> | undefined
+
+    const requestGateway = vi.fn(async (method: string, params?: Record<string, unknown>) => {
+      if (method === 'config.get') {
+        return { branch: 'main', cwd: '/repo' } as never
+      }
+
+      if (method === 'session.create') {
+        createParams = params
+
+        return { session_id: RUNTIME_SESSION_ID, stored_session_id: null } as never
+      }
+
+      return {} as never
+    })
+
+    let handle: HarnessHandle | null = null
+    $currentCwd.set('')
+    setNewChatWorkspaceTarget(undefined)
+    render(<Harness onReady={next => (handle = next)} requestGateway={requestGateway} />)
+    await waitFor(() => expect(handle).not.toBeNull())
+
+    await act(async () => {
+      await handle!.createBackendSessionForSend()
+    })
+
+    expect(requestGateway).toHaveBeenCalledWith('config.get', { key: 'project' })
+    expect(createParams).toMatchObject({ cwd: '/repo/.worktrees/session-fixed' })
+  })
+
+  it('fails closed before session.create when the local backend default cwd is unavailable', async () => {
+    const desktopGitSpy = vi.spyOn(desktopGitModule, 'desktopGit')
+    const requestGateway = vi.fn(async () => ({} as never))
+    let handle: HarnessHandle | null = null
+
+    $currentCwd.set('')
+    setNewChatWorkspaceTarget(undefined)
+    render(<Harness onReady={next => (handle = next)} requestGateway={requestGateway} />)
+    await waitFor(() => expect(handle).not.toBeNull())
+
+    await expect(handle!.createBackendSessionForSend()).rejects.toThrow('backend default cwd')
+    expect(requestGateway).toHaveBeenCalledTimes(1)
+    expect(requestGateway).toHaveBeenCalledWith('config.get', { key: 'project' })
+    expect(requestGateway).not.toHaveBeenCalledWith('session.create', expect.anything())
+    expect(desktopGitSpy).not.toHaveBeenCalled()
+  })
+
+  it('aborts before Git isolation when the route changes while resolving the local default cwd', async () => {
+    const project = deferred<{ branch: string; cwd: string }>()
+    const desktopGitSpy = vi.spyOn(desktopGitModule, 'desktopGit')
+
+    const requestGateway = vi.fn(async (method: string) => {
+      if (method === 'config.get') {
+        return project.promise as never
+      }
+
+      return { session_id: RUNTIME_SESSION_ID, stored_session_id: null } as never
+    })
+
+    let routeToken = `${NEW_CHAT_ROUTE}::`
+    let handle: HarnessHandle | null = null
+
+    $currentCwd.set('')
+    setNewChatWorkspaceTarget(undefined)
+    render(
+      <Harness getRouteToken={() => routeToken} onReady={next => (handle = next)} requestGateway={requestGateway} />
+    )
+    await waitFor(() => expect(handle).not.toBeNull())
+
+    const createPromise = handle!.createBackendSessionForSend()
+
+    await waitFor(() => expect(requestGateway).toHaveBeenCalledWith('config.get', { key: 'project' }))
+    routeToken = `${sessionRoute('stored-other-chat')}::`
+    $currentCwd.set('/other-session')
+    project.resolve({ branch: 'main', cwd: '/repo' })
+
+    await expect(createPromise).resolves.toBeNull()
+    expect(desktopGitSpy).not.toHaveBeenCalled()
+    expect(requestGateway).not.toHaveBeenCalledWith('session.create', expect.anything())
+    expect($currentCwd.get()).toBe('/other-session')
+  })
+
+  it('keeps a cwd-less global new chat remote and never probes local Git or local default cwd', async () => {
+    const desktopGitSpy = vi.spyOn(desktopGitModule, 'desktopGit')
+
+    const requestGateway = vi.fn(async (method: string) => {
+      if (method === 'session.create') {
+        return { session_id: RUNTIME_SESSION_ID, stored_session_id: null } as never
+      }
+
+      return {} as never
+    })
+
+    let handle: HarnessHandle | null = null
+
+    $connection.set({ mode: 'remote', profile: 'default' } as never)
+    $currentCwd.set('')
+    setNewChatWorkspaceTarget(undefined)
+    render(<Harness onReady={next => (handle = next)} requestGateway={requestGateway} />)
+    await waitFor(() => expect(handle).not.toBeNull())
+
+    await act(async () => {
+      await handle!.createBackendSessionForSend()
+    })
+
+    expect(requestGateway.mock.calls.map(([method]) => method)).toEqual(['session.create'])
+    expect(desktopGitSpy).not.toHaveBeenCalled()
+  })
+
+  it('activates an explicit remote profile before resolving the global cwd or probing local Git', async () => {
+    const profileReady = deferred<void>()
+    const desktopGitSpy = vi.spyOn(desktopGitModule, 'desktopGit')
+
+    vi.mocked(ensureGatewayProfile).mockImplementationOnce(async () => {
+      await profileReady.promise
+      $connection.set({ mode: 'remote', profile: 'remote-profile' } as never)
+    })
+
+    const requestGateway = vi.fn(async (method: string, params?: Record<string, unknown>) => {
+      if (method === 'config.get') {
+        return { branch: 'main', cwd: '/old-local-repo' } as never
+      }
+
+      if (method === 'session.create') {
+        return { session_id: RUNTIME_SESSION_ID, stored_session_id: null } as never
+      }
+
+      return params as never
+    })
+
+    let handle: HarnessHandle | null = null
+
+    $connection.set({ mode: 'local', profile: 'default' } as never)
+    $newChatProfile.set('remote-profile')
+    $currentCwd.set('')
+    setNewChatWorkspaceTarget(undefined)
+    render(<Harness onReady={next => (handle = next)} requestGateway={requestGateway} />)
+    await waitFor(() => expect(handle).not.toBeNull())
+
+    const createPromise = handle!.createBackendSessionForSend()
+
+    await waitFor(() => expect(ensureGatewayProfile).toHaveBeenCalledWith('remote-profile'))
+    profileReady.resolve()
+    await expect(createPromise).resolves.toBe(RUNTIME_SESSION_ID)
+
+    expect(requestGateway.mock.calls.map(([method]) => method)).toEqual(['session.create'])
+    expect(requestGateway).toHaveBeenCalledWith(
+      'session.create',
+      expect.objectContaining({ profile: 'remote-profile' })
+    )
+    expect(desktopGitSpy).not.toHaveBeenCalled()
+  })
+
+  it('does not invoke desktop Git while connected to a remote backend', async () => {
+    const git = {
+      baseBranchList: vi.fn(),
+      repoStatus: vi.fn(),
+      worktreeAdd: vi.fn(),
+      worktreeList: vi.fn()
+    }
+
+    const desktopGitSpy = vi.spyOn(desktopGitModule, 'desktopGit').mockReturnValue(git as never)
+
+    $connection.set({ mode: 'remote', profile: 'default' } as never)
+
+    const params = await createWith(() => {
+      $currentCwd.set('/srv/repo')
+    })
+
+    expect(desktopGitSpy).not.toHaveBeenCalled()
+    expect(params).toMatchObject({ cwd: '/srv/repo' })
+  })
+
+  it('isolates a new split session before its eager session.create', async () => {
+    vi.spyOn(desktopGitModule, 'desktopGit').mockReturnValue({
+      baseBranchList: vi.fn(async () => [{ isDefault: true, isRemote: true, name: 'origin/main' }]),
+      repoStatus: vi.fn(async () => ({ branch: 'feature/stale', detached: false } as never)),
+      worktreeAdd: vi.fn(async () => ({ branch: 'hermes/session-fixed', path: '/repo/.worktrees/session-fixed' })),
+      worktreeList: vi.fn(async () => [
+        { branch: 'feature/stale', detached: false, isMain: true, locked: false, path: '/repo' }
+      ])
+    } as never)
+
+    let createParams: Record<string, unknown> | undefined
+
+    const requestGateway = vi.fn(async (method: string, params?: Record<string, unknown>) => {
+      if (method === 'session.create') {
+        createParams = params
+
+        return { session_id: RUNTIME_SESSION_ID, stored_session_id: 'stored-split' } as never
+      }
+
+      return {} as never
+    })
+
+    let handle: HarnessHandle | null = null
+    render(<Harness onReady={next => (handle = next)} requestGateway={requestGateway} />)
+    await waitFor(() => expect(handle).not.toBeNull())
+
+    await act(async () => {
+      await handle!.openNewSessionTile('right', { cwd: '/repo' })
+    })
+
+    expect(createParams).toMatchObject({ cwd: '/repo/.worktrees/session-fixed' })
+  })
+
+  it('activates an explicit remote profile before resolving split-session isolation', async () => {
+    const profileReady = deferred<void>()
+
+    const desktopGitSpy = vi.spyOn(desktopGitModule, 'desktopGit').mockReturnValue({
+      baseBranchList: vi.fn(async () => [{ isDefault: true, isRemote: true, name: 'origin/main' }]),
+      repoStatus: vi.fn(async () => ({ branch: 'main', defaultBranch: 'main', detached: false } as never)),
+      worktreeAdd: vi.fn(async () => ({ branch: 'hermes/session-stale', path: '/repo/.worktrees/session-stale' })),
+      worktreeList: vi.fn(async () => [{ branch: 'main', detached: false, isMain: true, locked: false, path: '/repo' }])
+    } as never)
+
+    $connection.set({ mode: 'local', profile: 'default' } as never)
+    $newChatProfile.set('remote-profile')
+    vi.mocked(ensureGatewayProfile).mockImplementationOnce(async () => {
+      await profileReady.promise
+      $connection.set({ mode: 'remote', profile: 'remote-profile' } as never)
+    })
+
+    const requestGateway = vi.fn(async (method: string, params?: Record<string, unknown>) => {
+      if (method === 'session.create') {
+        return { session_id: RUNTIME_SESSION_ID, stored_session_id: 'stored-remote-split' } as never
+      }
+
+      return params as never
+    })
+
+    let handle: HarnessHandle | null = null
+
+    render(<Harness onReady={next => (handle = next)} requestGateway={requestGateway} />)
+    await waitFor(() => expect(handle).not.toBeNull())
+
+    const createPromise = handle!.openNewSessionTile('right', { cwd: '/repo' })
+
+    await waitFor(() => expect(ensureGatewayProfile).toHaveBeenCalledWith('remote-profile'))
+    expect(desktopGitSpy).not.toHaveBeenCalled()
+    expect(requestGateway).not.toHaveBeenCalled()
+
+    profileReady.resolve()
+    await act(async () => {
+      await createPromise
+    })
+
+    expect(desktopGitSpy).not.toHaveBeenCalled()
+    expect(requestGateway).toHaveBeenCalledWith(
+      'session.create',
+      expect.objectContaining({ cwd: '/repo', profile: 'remote-profile' })
+    )
+  })
+
+  it.each([
+    ['returns null', null],
+    ['omits the stored session id', { session_id: RUNTIME_SESSION_ID, stored_session_id: null }]
+  ])('removes an automatic split worktree when session.create %s', async (_label, response) => {
+    const worktreeRemove = vi.fn(async () => undefined)
+
+    vi.spyOn(desktopGitModule, 'desktopGit').mockReturnValue({
+      baseBranchList: vi.fn(async () => [{ isDefault: true, isRemote: true, name: 'origin/main' }]),
+      repoStatus: vi.fn(async () => ({ branch: 'feature/stale', defaultBranch: 'main', detached: false } as never)),
+      worktreeAdd: vi.fn(async () => ({ branch: 'hermes/session-fixed', path: '/repo/.worktrees/session-fixed' })),
+      worktreeList: vi.fn(async () => [
+        { branch: 'feature/stale', detached: false, isMain: true, locked: false, path: '/repo' }
+      ]),
+      worktreeRemove
+    } as never)
+
+    const requestGateway = vi.fn(async (method: string) => {
+      if (method === 'session.create') {
+        return response as never
+      }
+
+      return {} as never
+    })
+
+    let handle: HarnessHandle | null = null
+
+    render(<Harness onReady={next => (handle = next)} requestGateway={requestGateway} />)
+    await waitFor(() => expect(handle).not.toBeNull())
+
+    await act(async () => {
+      await handle!.openNewSessionTile('right', { cwd: '/repo' })
+    })
+
+    expect(worktreeRemove).toHaveBeenCalledWith('/repo', '/repo/.worktrees/session-fixed', {
+      deleteBranch: { base: 'origin/main', branch: 'hermes/session-fixed' },
+      force: false
+    })
+
+    if (response) {
+      expect(requestGateway).toHaveBeenCalledWith('session.close', { session_id: RUNTIME_SESSION_ID })
+    }
+  })
+
+  it.each([
+    ['rejects', new Error('backend unavailable')],
+    ['returns null', null]
+  ])('removes an unused automatic worktree without force when session.create %s', async (_label, failure) => {
+    const worktreeRemove = vi.fn(async () => undefined)
+
+    vi.spyOn(desktopGitModule, 'desktopGit').mockReturnValue({
+      baseBranchList: vi.fn(async () => [{ isDefault: true, isRemote: true, name: 'origin/main' }]),
+      repoStatus: vi.fn(async () => ({ branch: 'feature/stale', detached: false } as never)),
+      worktreeAdd: vi.fn(async () => ({ branch: 'hermes/session-fixed', path: '/repo/.worktrees/session-fixed' })),
+      worktreeList: vi.fn(async () => [
+        { branch: 'feature/stale', detached: false, isMain: true, locked: false, path: '/repo' }
+      ]),
+      worktreeRemove
+    } as never)
+
+    const requestGateway = vi.fn(async (method: string) => {
+      if (method === 'session.create') {
+        if (failure instanceof Error) {
+          throw failure
+        }
+
+        return failure as never
+      }
+
+      return {} as never
+    })
+
+    let handle: HarnessHandle | null = null
+
+    $currentCwd.set('/repo')
+    render(<Harness onReady={next => (handle = next)} requestGateway={requestGateway} />)
+    await waitFor(() => expect(handle).not.toBeNull())
+
+    await expect(handle!.createBackendSessionForSend()).rejects.toThrow()
+    expect(worktreeRemove).toHaveBeenCalledWith('/repo', '/repo/.worktrees/session-fixed', {
+      deleteBranch: { base: 'origin/main', branch: 'hermes/session-fixed' },
+      force: false
+    })
+    expect($currentCwd.get()).toBe('/repo')
+  })
+
+  it('does not touch local Git when profile readiness fails before isolation', async () => {
+    const worktreeRemove = vi.fn(async () => undefined)
+
+    const desktopGitSpy = vi.spyOn(desktopGitModule, 'desktopGit').mockReturnValue({
+      baseBranchList: vi.fn(async () => [{ isDefault: true, isRemote: true, name: 'origin/main' }]),
+      repoStatus: vi.fn(async () => ({ branch: 'feature/stale', defaultBranch: 'main', detached: false } as never)),
+      worktreeAdd: vi.fn(async () => ({ branch: 'hermes/session-fixed', path: '/repo/.worktrees/session-fixed' })),
+      worktreeList: vi.fn(async () => [
+        { branch: 'feature/stale', detached: false, isMain: true, locked: false, path: '/repo' }
+      ]),
+      worktreeRemove
+    } as never)
+
+    vi.mocked(ensureGatewayProfile).mockRejectedValueOnce(new Error('profile unavailable'))
+
+    const requestGateway = vi.fn()
+    let handle: HarnessHandle | null = null
+
+    $currentCwd.set('/repo')
+    render(<Harness onReady={next => (handle = next)} requestGateway={requestGateway} />)
+    await waitFor(() => expect(handle).not.toBeNull())
+
+    await expect(handle!.createBackendSessionForSend()).rejects.toThrow('profile unavailable')
+    expect(requestGateway).not.toHaveBeenCalled()
+    expect(desktopGitSpy).not.toHaveBeenCalled()
+    expect(worktreeRemove).not.toHaveBeenCalled()
+    expect($currentCwd.get()).toBe('/repo')
+  })
+
+  it('aborts before session.create when the route changes during worktree creation', async () => {
+    const added = deferred<{ branch: string; path: string }>()
+    const worktreeRemove = vi.fn(async () => undefined)
+
+    vi.spyOn(desktopGitModule, 'desktopGit').mockReturnValue({
+      baseBranchList: vi.fn(async () => [{ isDefault: true, isRemote: true, name: 'origin/main' }]),
+      repoStatus: vi.fn(async () => ({ branch: 'feature/stale', detached: false } as never)),
+      worktreeAdd: vi.fn(() => added.promise),
+      worktreeList: vi.fn(async () => [
+        { branch: 'feature/stale', detached: false, isMain: true, locked: false, path: '/repo' }
+      ]),
+      worktreeRemove
+    } as never)
+
+    const requestGateway = vi.fn(async () => ({ session_id: RUNTIME_SESSION_ID, stored_session_id: null }) as never)
+    let routeToken = `${NEW_CHAT_ROUTE}::`
+    let handle: HarnessHandle | null = null
+
+    $currentCwd.set('/repo')
+    render(
+      <Harness getRouteToken={() => routeToken} onReady={next => (handle = next)} requestGateway={requestGateway} />
+    )
+    await waitFor(() => expect(handle).not.toBeNull())
+
+    const createPromise = handle!.createBackendSessionForSend()
+
+    await waitFor(() => expect(desktopGitModule.desktopGit).toHaveBeenCalled())
+    routeToken = `${sessionRoute('stored-other-chat')}::`
+    $currentCwd.set('/other-session')
+    added.resolve({ branch: 'hermes/session-fixed', path: '/repo/.worktrees/session-fixed' })
+
+    await expect(createPromise).resolves.toBeNull()
+    expect(requestGateway).not.toHaveBeenCalledWith('session.create', expect.anything())
+    expect(worktreeRemove).toHaveBeenCalledWith('/repo', '/repo/.worktrees/session-fixed', {
+      deleteBranch: { base: 'origin/main', branch: 'hermes/session-fixed' },
+      force: false
+    })
+    expect($currentCwd.get()).toBe('/other-session')
+  })
+
+  it('serializes duplicate first submits into one worktree and one session', async () => {
+    const added = deferred<{ branch: string; path: string }>()
+    const worktreeAdd = vi.fn(() => added.promise)
+
+    vi.spyOn(desktopGitModule, 'desktopGit').mockReturnValue({
+      baseBranchList: vi.fn(async () => [{ isDefault: true, isRemote: true, name: 'origin/main' }]),
+      repoStatus: vi.fn(async () => ({ branch: 'feature/stale', detached: false } as never)),
+      worktreeAdd,
+      worktreeList: vi.fn(async () => [
+        { branch: 'feature/stale', detached: false, isMain: true, locked: false, path: '/repo' }
+      ])
+    } as never)
+
+    const requestGateway = vi.fn(async () => ({ session_id: RUNTIME_SESSION_ID, stored_session_id: null }) as never)
+    let handle: HarnessHandle | null = null
+
+    $currentCwd.set('/repo')
+    render(<Harness onReady={next => (handle = next)} requestGateway={requestGateway} />)
+    await waitFor(() => expect(handle).not.toBeNull())
+
+    const first = handle!.createBackendSessionForSend()
+    const second = handle!.createBackendSessionForSend()
+
+    await waitFor(() => expect(worktreeAdd).toHaveBeenCalled())
+    added.resolve({ branch: 'hermes/session-fixed', path: '/repo/.worktrees/session-fixed' })
+
+    await expect(second).resolves.toBeNull()
+    await expect(first).resolves.toBe(RUNTIME_SESSION_ID)
+    expect(worktreeAdd).toHaveBeenCalledTimes(1)
+    expect(requestGateway).toHaveBeenCalledTimes(1)
+  })
+
   it('freezes the visible selector state before profile readiness and sends fast: false explicitly', async () => {
     const profileReady = deferred<void>()
     vi.mocked(ensureGatewayProfile).mockReturnValueOnce(profileReady.promise)
@@ -533,6 +1009,10 @@ describe('createBackendSessionForSend profile routing', () => {
     let createParams: Record<string, unknown> | undefined
 
     const requestGateway = vi.fn(async (method: string, params?: Record<string, unknown>) => {
+      if (method === 'config.get') {
+        return { branch: '', cwd: '/not-a-repository' } as never
+      }
+
       if (method === 'session.create') {
         createParams = params
 
@@ -1209,6 +1689,13 @@ describe('branchStoredSession desktop source tagging', () => {
   it('tags desktop branch sessions as desktop sessions', async () => {
     let createParams: Record<string, unknown> | undefined
 
+    vi.spyOn(desktopGitModule, 'desktopGit').mockReturnValue({
+      baseBranchList: vi.fn(async () => [{ isDefault: true, isRemote: true, name: 'origin/main' }]),
+      repoStatus: vi.fn(async () => ({ branch: 'main', defaultBranch: 'main', detached: false } as never)),
+      worktreeAdd: vi.fn(async () => ({ branch: 'hermes/session-branch', path: '/repo/.worktrees/session-branch' })),
+      worktreeList: vi.fn(async () => [{ branch: 'main', detached: false, isMain: true, locked: false, path: '/repo' }])
+    } as never)
+
     const requestGateway = vi.fn(async (method: string, params?: Record<string, unknown>) => {
       if (method === 'session.create') {
         createParams = params
@@ -1219,7 +1706,7 @@ describe('branchStoredSession desktop source tagging', () => {
       return {} as never
     })
 
-    setSessions([storedSession({ id: 'stored-parent', message_count: 1 })])
+    setSessions([storedSession({ cwd: '/repo', id: 'stored-parent', message_count: 1 })])
     vi.mocked(getAllSessionMessages).mockResolvedValue({
       messages: [{ content: 'branch me', role: 'user', timestamp: 1 }],
       session_id: 'stored-parent'
@@ -1232,8 +1719,42 @@ describe('branchStoredSession desktop source tagging', () => {
     await expect(branchStoredSession!('stored-parent')).resolves.toBe(true)
 
     expect(createParams).toMatchObject({
+      cwd: '/repo/.worktrees/session-branch',
       parent_session_id: 'stored-parent',
       source: 'desktop'
+    })
+  })
+
+  it('removes an automatic branch worktree when session.create returns null', async () => {
+    const worktreeRemove = vi.fn(async () => undefined)
+
+    vi.spyOn(desktopGitModule, 'desktopGit').mockReturnValue({
+      baseBranchList: vi.fn(async () => [{ isDefault: true, isRemote: true, name: 'origin/main' }]),
+      repoStatus: vi.fn(async () => ({ branch: 'main', defaultBranch: 'main', detached: false } as never)),
+      worktreeAdd: vi.fn(async () => ({ branch: 'hermes/session-branch', path: '/repo/.worktrees/session-branch' })),
+      worktreeList: vi.fn(async () => [{ branch: 'main', detached: false, isMain: true, locked: false, path: '/repo' }]),
+      worktreeRemove
+    } as never)
+
+    setSessions([storedSession({ cwd: '/repo', id: 'stored-parent', message_count: 1 })])
+    vi.mocked(getAllSessionMessages).mockResolvedValue({
+      messages: [{ content: 'branch me', role: 'user', timestamp: 1 }],
+      session_id: 'stored-parent'
+    } as never)
+
+    let branchStoredSession: ((storedSessionId: string) => Promise<boolean>) | null = null
+    render(
+      <BranchHarness
+        onReady={branch => (branchStoredSession = branch)}
+        requestGateway={vi.fn(async () => null as never)}
+      />
+    )
+    await waitFor(() => expect(branchStoredSession).not.toBeNull())
+
+    await expect(branchStoredSession!('stored-parent')).resolves.toBe(false)
+    expect(worktreeRemove).toHaveBeenCalledWith('/repo', '/repo/.worktrees/session-branch', {
+      deleteBranch: { base: 'origin/main', branch: 'hermes/session-branch' },
+      force: false
     })
   })
 

--- a/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
@@ -6,6 +6,8 @@ import { revealTreePane } from '@/components/pane-shell/tree/store'
 import { deleteSession, getAllSessionMessages, getLatestSessionMessages, setSessionArchived } from '@/hermes'
 import { useI18n } from '@/i18n'
 import { type ChatMessage, preserveLocalAssistantErrors, toChatMessages } from '@/lib/chat-messages'
+import { isDesktopFsRemoteMode } from '@/lib/desktop-fs'
+import { desktopGit } from '@/lib/desktop-git'
 import { isMissingRpcMethod } from '@/lib/gateway-rpc'
 import { recoverInFlightTurnJournal } from '@/lib/inflight-turn-journal'
 import { setSessionYolo } from '@/lib/yolo-session'
@@ -13,11 +15,13 @@ import { normalizeChoices, setClarifyRequest } from '@/store/clarify'
 import { migrateSessionDraft } from '@/store/composer'
 import { clearQueuedPrompts, migrateQueuedPrompts } from '@/store/composer-queue'
 import { $pinnedSessionIds } from '@/store/layout'
+import { type AutomaticSessionWorktree, isolateNewSessionCwd } from '@/store/new-session-worktree'
 import { clearNotifications, notify, notifyError } from '@/store/notifications'
 import { $activeGatewayProfile, $newChatProfile, ensureGatewayProfile, normalizeProfileKey } from '@/store/profile'
 import {
   beginSessionMutation,
   endSessionMutation,
+  refreshWorktrees,
   resolveNewSessionCwd,
   tombstoneSessions,
   untombstoneSessions
@@ -99,6 +103,70 @@ import {
   upsertOptimisticSession
 } from './utils'
 
+async function isolatedNewSessionCwd(
+  cwd: string
+): Promise<{ cwd: string; worktree: AutomaticSessionWorktree | null }> {
+  if (!cwd || isDesktopFsRemoteMode()) {
+    return { cwd, worktree: null }
+  }
+
+  const git = desktopGit()
+
+  if (!git) {
+    return { cwd, worktree: null }
+  }
+
+  let worktree: AutomaticSessionWorktree | null = null
+
+  const isolatedCwd = await isolateNewSessionCwd(cwd, git, undefined, created => {
+    worktree = created
+  })
+
+  if (isolatedCwd !== cwd) {
+    refreshWorktrees()
+  }
+
+  return { cwd: isolatedCwd, worktree }
+}
+
+async function cleanupAutomaticWorktree(worktree: AutomaticSessionWorktree | null): Promise<void> {
+  if (!worktree) {
+    return
+  }
+
+  const git = desktopGit()
+
+  if (!git) {
+    console.warn('[auto-worktree-cleanup-failed]')
+
+    return
+  }
+
+  await git
+    .worktreeRemove(worktree.repoPath, worktree.path, {
+      deleteBranch: { base: worktree.base, branch: worktree.branch },
+      force: false
+    })
+    .then(() => refreshWorktrees())
+    .catch(() => {
+      console.warn('[auto-worktree-cleanup-failed]')
+    })
+}
+
+function requireSessionCreateResponse(value: unknown): SessionCreateResponse {
+  if (!value || typeof value !== 'object') {
+    throw new Error('The backend returned an invalid session.create response.')
+  }
+
+  const response = value as Partial<SessionCreateResponse>
+
+  if (typeof response.session_id !== 'string' || !response.session_id.trim()) {
+    throw new Error('The backend returned an invalid session.create response.')
+  }
+
+  return response as SessionCreateResponse
+}
+
 interface SessionActionsOptions {
   activeSessionId: string | null
   activeSessionIdRef: MutableRefObject<string | null>
@@ -175,20 +243,38 @@ function reconcileAuthoritativeMessages(
 // A no-op for single-profile/local-pooled users (a backend resolves its own launch
 // profile to None). The sticky UI model/effort/fast ride as per-session overrides,
 // never the profile default (that lives in Settings → Model).
-async function desktopSessionCreateParams(cwd: string): Promise<Record<string, unknown>> {
+interface DesktopSessionSelection {
+  effort: string
+  fast: boolean
+  model: string
+  profile: string
+  provider: string
+}
+
+function desktopSessionSelection(): DesktopSessionSelection {
   // Treat Send as the linearization point for the visible selector state. The
   // profile handshake below can yield long enough for background config/model
   // refreshes to finish; reading atoms afterward would silently create the
   // session with a different selection than the one the user submitted.
-  const selection = {
+  return {
     effort: $currentReasoningEffort.get().trim(),
     fast: $currentFastMode.get(),
     model: $currentModel.get().trim(),
+    profile: $newChatProfile.get() ?? normalizeProfileKey($activeGatewayProfile.get()),
     provider: $currentProvider.get().trim()
   }
+}
 
-  const profile = $newChatProfile.get() ?? normalizeProfileKey($activeGatewayProfile.get())
-  await ensureGatewayProfile(profile)
+async function desktopSessionCreateParams(
+  cwd: string,
+  selection = desktopSessionSelection(),
+  profileReady = false
+): Promise<Record<string, unknown>> {
+  const { profile } = selection
+
+  if (!profileReady) {
+    await ensureGatewayProfile(profile)
+  }
 
   return {
     cols: 96,
@@ -427,8 +513,13 @@ export function useSessionActions({
 
   const createBackendSessionForSend = useCallback(
     async (preview: string | null = null): Promise<string | null> => {
+      if (creatingSessionRef.current) {
+        return null
+      }
+
       const startingStoredSessionId = selectedStoredSessionIdRef.current
       const startingRouteToken = getRouteToken()
+      const selection = desktopSessionSelection()
 
       creatingSessionRef.current = true
 
@@ -438,15 +529,93 @@ export function useSessionActions({
         // (resolveNewSessionCwd — a project's new session keeps its repo cwd).
         const workspaceTarget = $newChatWorkspaceTarget.get()
 
-        const cwd =
+        let cwd =
           workspaceTarget === null
             ? ''
             : typeof workspaceTarget === 'string'
               ? workspaceTarget.trim()
               : $currentCwd.get().trim() || resolveNewSessionCwd()
 
-        const params = await desktopSessionCreateParams(cwd)
-        const created = await requestGateway<SessionCreateResponse>('session.create', params)
+        const sourceCwd = cwd
+
+        await ensureGatewayProfile(selection.profile)
+
+        const profileReadyDrift = sessionContextDrift({
+          startRouteToken: startingRouteToken,
+          nowRouteToken: getRouteToken(),
+          startSelectedStoredId: startingStoredSessionId,
+          nowSelectedStoredId: selectedStoredSessionIdRef.current,
+          submitTargetStoredId: null
+        })
+
+        if (profileReadyDrift) {
+          console.warn('[submit-drift-abort]', profileReadyDrift, { phase: 'profile-ready' })
+
+          return null
+        }
+
+        if (!cwd && workspaceTarget !== null && !isDesktopFsRemoteMode()) {
+          const project = await requestGateway<{ cwd?: unknown }>('config.get', { key: 'project' })
+          cwd = typeof project?.cwd === 'string' ? project.cwd.trim() : ''
+
+          if (!cwd) {
+            throw new Error('Cannot isolate a global local session without the backend default cwd.')
+          }
+        }
+
+        const preIsolationDrift = sessionContextDrift({
+          startRouteToken: startingRouteToken,
+          nowRouteToken: getRouteToken(),
+          startSelectedStoredId: startingStoredSessionId,
+          nowSelectedStoredId: selectedStoredSessionIdRef.current,
+          submitTargetStoredId: null
+        })
+
+        if (preIsolationDrift) {
+          console.warn('[submit-drift-abort]', preIsolationDrift, { phase: 'pre-isolation' })
+
+          return null
+        }
+
+        const isolation = await isolatedNewSessionCwd(cwd)
+        const isolatedCwd = isolation.cwd
+
+        const preCreateDrift = sessionContextDrift({
+          startRouteToken: startingRouteToken,
+          nowRouteToken: getRouteToken(),
+          startSelectedStoredId: startingStoredSessionId,
+          nowSelectedStoredId: selectedStoredSessionIdRef.current,
+          submitTargetStoredId: null
+        })
+
+        if (preCreateDrift) {
+          console.warn('[submit-drift-abort]', preCreateDrift, { phase: 'pre-create' })
+          await cleanupAutomaticWorktree(isolation.worktree)
+
+          return null
+        }
+
+        if (isolatedCwd !== cwd) {
+          cwd = isolatedCwd
+          setCurrentCwd(cwd)
+        }
+
+        let created: SessionCreateResponse
+
+        try {
+          const params = await desktopSessionCreateParams(cwd, selection, true)
+
+          created = requireSessionCreateResponse(await requestGateway<SessionCreateResponse>('session.create', params))
+        } catch (error) {
+          await cleanupAutomaticWorktree(isolation.worktree)
+
+          if ($currentCwd.get() === cwd) {
+            setCurrentCwd(sourceCwd)
+          }
+
+          throw error
+        }
+
         const stored = created.stored_session_id ?? null
 
         // Only a genuine move to a DIFFERENT chat mid-create should orphan the
@@ -468,6 +637,11 @@ export function useSessionActions({
         if (drift) {
           console.warn('[submit-drift-abort]', drift, { phase: 'mid-create' })
           await requestGateway('session.close', { session_id: created.session_id }).catch(() => undefined)
+          await cleanupAutomaticWorktree(isolation.worktree)
+
+          if ($currentCwd.get() === cwd) {
+            setCurrentCwd(sourceCwd)
+          }
 
           return null
         }
@@ -558,15 +732,33 @@ export function useSessionActions({
       const listed = options?.listed ?? true
 
       try {
+        const selection = desktopSessionSelection()
+
+        await ensureGatewayProfile(selection.profile)
+
         // Fresh tile → the caller's workspace when one was named (the sidebar
         // "+" on a project/worktree lane), else the resolved new-session cwd
-        // (project scope → configured default).
-        const params = await desktopSessionCreateParams((options?.cwd || resolveNewSessionCwd()).trim())
-        const created = await requestGateway<SessionCreateResponse>('session.create', params)
+        // (project scope → configured default) — never the primary composer's
+        // live cwd.
+        const sourceCwd = (options?.cwd || resolveNewSessionCwd()).trim()
+        const isolation = await isolatedNewSessionCwd(sourceCwd)
+        const cwd = isolation.cwd
+        let created: SessionCreateResponse
+
+        try {
+          const params = await desktopSessionCreateParams(cwd, selection, true)
+
+          created = requireSessionCreateResponse(await requestGateway<SessionCreateResponse>('session.create', params))
+        } catch (error) {
+          await cleanupAutomaticWorktree(isolation.worktree)
+          throw error
+        }
+
         const stored = created.stored_session_id
 
         if (!stored) {
           await requestGateway('session.close', { session_id: created.session_id }).catch(() => undefined)
+          await cleanupAutomaticWorktree(isolation.worktree)
           notify({ kind: 'error', title: copy.sessionUnavailable, message: copy.createSessionFailed })
 
           return
@@ -658,6 +850,7 @@ export function useSessionActions({
       // now-redundant tile so main owns it. Runs before the async awaits below (and
       // before the selection listener homes focus) so the tile is gone the same tick
       // the route takes over; the warm cache/runtime binding survives for main to reuse.
+
       if ($sessionTiles.get().some(t => t.storedSessionId === storedSessionId)) {
         closeSessionTile(storedSessionId)
       }
@@ -667,6 +860,7 @@ export function useSessionActions({
       // must not keep treating it as stranded. It's re-armed below only if THIS
       // attempt fails terminally (RPC reject + REST fallback failure).
       setResumeFailedSessionId(current => (current === storedSessionId ? null : current))
+
       // Also clear the exhausted-latch: a fresh attempt (manual Retry, reconnect,
       // reselect) gives the bounded auto-retry counter a clean cycle, so the
       // chat view drops the error state and shows the loader again.
@@ -1340,6 +1534,7 @@ export function useSessionActions({
       branchCount?: number
     ): Promise<boolean> => {
       creatingSessionRef.current = true
+      let automaticWorktree: AutomaticSessionWorktree | null = null
 
       try {
         // A branch belongs to its parent's OWNING profile. Swapping the live
@@ -1351,20 +1546,27 @@ export function useSessionActions({
         // upsertOptimisticSession's $activeGatewayProfile stamp correct.
         await ensureGatewayProfile(profile)
 
+        const isolation = !sourceSessionId && cwd ? await isolatedNewSessionCwd(cwd) : { cwd: cwd || '', worktree: null }
+        automaticWorktree = isolation.worktree
+
         // No title: the backend auto-names the branch from its parent's lineage.
         const branched = sourceSessionId
           ? await requestGateway<SessionCreateResponse>('session.branch', {
               session_id: sourceSessionId,
               ...(branchCount !== undefined ? { count: branchCount } : {})
             })
-          : await requestGateway<SessionCreateResponse>('session.create', {
-              cols: 96,
-              source: 'desktop',
-              ...(cwd && { cwd }),
-              ...(profile ? { profile } : {}),
-              messages: branchMessages.map(({ content, role }) => ({ content, role })),
-              ...(parentStoredId && { parent_session_id: parentStoredId })
-            })
+          : requireSessionCreateResponse(
+              await requestGateway<SessionCreateResponse>('session.create', {
+                cols: 96,
+                source: 'desktop',
+                ...(isolation.cwd && { cwd: isolation.cwd }),
+                ...(profile ? { profile } : {}),
+                messages: branchMessages.map(({ content, role }) => ({ content, role })),
+                ...(parentStoredId && { parent_session_id: parentStoredId })
+              })
+            )
+
+        automaticWorktree = null
 
         const responseBranchMessages =
           sourceSessionId && branched.messages?.length ? toBranchMessages(toChatMessages(branched.messages)) : []
@@ -1423,6 +1625,7 @@ export function useSessionActions({
 
         return true
       } catch (err) {
+        await cleanupAutomaticWorktree(automaticWorktree)
         notifyError(err, copy.branchFailed)
 
         return false

--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -258,7 +258,7 @@ declare global {
         worktreeRemove: (
           repoPath: string,
           worktreePath: string,
-          options?: { force?: boolean }
+          options?: { deleteBranch?: { base: string; branch: string }; force?: boolean }
         ) => Promise<{ removed: string }>
         branchSwitch: (repoPath: string, branch: string) => Promise<{ branch: string }>
         // The local branches, plus the remote-tracking refs that have no local

--- a/apps/desktop/src/store/new-session-worktree.test.ts
+++ b/apps/desktop/src/store/new-session-worktree.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import type { HermesGitBaseBranch, HermesGitWorktree, HermesRepoStatus } from '@/global'
+
+import { isolateNewSessionCwd } from './new-session-worktree'
+
+function gitBridge(overrides: Record<string, unknown> = {}) {
+  return {
+    baseBranchList: vi.fn(async (): Promise<HermesGitBaseBranch[]> => [
+      { isDefault: true, isRemote: true, name: 'origin/main' }
+    ]),
+    repoStatus: vi.fn(async (): Promise<HermesRepoStatus | null> =>
+      ({ branch: 'feature/stale', defaultBranch: 'main', detached: false } as HermesRepoStatus)
+    ),
+    worktreeAdd: vi.fn(async () => ({ branch: 'hermes/session-fixed', path: '/repo/.worktrees/session-fixed' })),
+    worktreeList: vi.fn(async (): Promise<HermesGitWorktree[]> => [
+      { branch: 'feature/stale', detached: false, isMain: true, locked: false, path: '/repo' }
+    ]),
+    ...overrides
+  }
+}
+
+describe('isolateNewSessionCwd', () => {
+  it('creates a fresh worktree from the default branch instead of inheriting the main checkout branch', async () => {
+    const git = gitBridge()
+
+    const cwd = await isolateNewSessionCwd('/repo', git, () => 'fixed')
+
+    expect(cwd).toBe('/repo/.worktrees/session-fixed')
+    expect(git.worktreeAdd).toHaveBeenCalledWith('/repo', {
+      base: 'origin/main',
+      branch: 'hermes/session-fixed',
+      name: 'session-fixed'
+    })
+  })
+
+  it('falls back to the default branch detected by repo status', async () => {
+    const git = gitBridge({ baseBranchList: vi.fn(async () => []) })
+
+    await isolateNewSessionCwd('/repo', git, () => 'status-default')
+
+    expect(git.worktreeAdd).toHaveBeenCalledWith('/repo', {
+      base: 'main',
+      branch: 'hermes/session-status-default',
+      name: 'session-status-default'
+    })
+  })
+
+  it('fails closed when Git cannot detect a default branch', async () => {
+    const git = gitBridge({
+      baseBranchList: vi.fn(async () => []),
+      repoStatus: vi.fn(async () => ({ branch: 'feature/stale', defaultBranch: null, detached: false } as HermesRepoStatus))
+    })
+
+    await expect(isolateNewSessionCwd('/repo', git, () => 'no-default')).rejects.toThrow(
+      'Cannot isolate a new session without a default branch'
+    )
+    expect(git.worktreeAdd).not.toHaveBeenCalled()
+  })
+
+  it('keeps an explicitly targeted linked worktree', async () => {
+    const git = gitBridge({
+      worktreeList: vi.fn(async (): Promise<HermesGitWorktree[]> => [
+        { branch: 'main', detached: false, isMain: true, locked: false, path: '/repo' },
+        {
+          branch: 'feature/existing',
+          detached: false,
+          isMain: false,
+          locked: false,
+          path: '/repo/.worktrees/existing'
+        }
+      ])
+    })
+
+    const cwd = await isolateNewSessionCwd('/repo/.worktrees/existing', git, () => 'unused')
+
+    expect(cwd).toBe('/repo/.worktrees/existing')
+    expect(git.worktreeAdd).not.toHaveBeenCalled()
+  })
+
+  it('leaves a non-git directory unchanged', async () => {
+    const git = gitBridge({ repoStatus: vi.fn(async () => null) })
+
+    const cwd = await isolateNewSessionCwd('/notes', git, () => 'unused')
+
+    expect(cwd).toBe('/notes')
+    expect(git.worktreeList).not.toHaveBeenCalled()
+    expect(git.worktreeAdd).not.toHaveBeenCalled()
+  })
+
+  it('recognizes a Windows subdirectory of the main worktree case-insensitively', async () => {
+    const git = gitBridge({
+      worktreeList: vi.fn(async (): Promise<HermesGitWorktree[]> => [
+        { branch: 'feature/stale', detached: false, isMain: true, locked: false, path: 'C:\\Repo' }
+      ])
+    })
+
+    await isolateNewSessionCwd('c:/repo/packages/app', git, () => 'windows')
+
+    expect(git.worktreeAdd).toHaveBeenCalledWith('C:\\Repo', {
+      base: 'origin/main',
+      branch: 'hermes/session-windows',
+      name: 'session-windows'
+    })
+  })
+
+  it('recognizes a slash-form Windows UNC path case-insensitively', async () => {
+    const git = gitBridge({
+      worktreeList: vi.fn(async (): Promise<HermesGitWorktree[]> => [
+        { branch: 'feature/stale', detached: false, isMain: true, locked: false, path: '//Server/Share/Repo' }
+      ])
+    })
+
+    await isolateNewSessionCwd('//server/share/repo/packages/app', git, () => 'unc')
+
+    expect(git.worktreeAdd).toHaveBeenCalledWith('//Server/Share/Repo', {
+      base: 'origin/main',
+      branch: 'hermes/session-unc',
+      name: 'session-unc'
+    })
+  })
+
+  it('reports ownership metadata for an automatically created worktree', async () => {
+    const git = gitBridge()
+    const onCreated = vi.fn()
+
+    await isolateNewSessionCwd('/repo', git, () => 'owned', onCreated)
+
+    expect(onCreated).toHaveBeenCalledWith({
+      base: 'origin/main',
+      branch: 'hermes/session-fixed',
+      path: '/repo/.worktrees/session-fixed',
+      repoPath: '/repo'
+    })
+  })
+
+  it('preserves a case-distinct linked worktree on POSIX', async () => {
+    const git = gitBridge({
+      worktreeList: vi.fn(async (): Promise<HermesGitWorktree[]> => [
+        { branch: 'main', detached: false, isMain: true, locked: false, path: '/Repo' },
+        { branch: 'feature/existing', detached: false, isMain: false, locked: false, path: '/repo' }
+      ])
+    })
+
+    const cwd = await isolateNewSessionCwd('/repo', git, () => 'unused')
+
+    expect(cwd).toBe('/repo')
+    expect(git.worktreeAdd).not.toHaveBeenCalled()
+  })
+
+  it('propagates worktree creation failures instead of falling back to the canonical checkout', async () => {
+    const git = gitBridge({ worktreeAdd: vi.fn(async () => Promise.reject(new Error('git worktree add failed'))) })
+
+    await expect(isolateNewSessionCwd('/repo', git, () => 'failure')).rejects.toThrow('git worktree add failed')
+  })
+})

--- a/apps/desktop/src/store/new-session-worktree.ts
+++ b/apps/desktop/src/store/new-session-worktree.ts
@@ -1,0 +1,100 @@
+import type { HermesGitBaseBranch, HermesGitWorktree, HermesRepoStatus } from '@/global'
+
+interface NewSessionGitBridge {
+  baseBranchList: (repoPath: string) => Promise<HermesGitBaseBranch[]>
+  repoStatus: (repoPath: string) => Promise<HermesRepoStatus | null>
+  worktreeAdd: (
+    repoPath: string,
+    options?: { name?: string; branch?: string; base?: string; existingBranch?: string }
+  ) => Promise<{ path: string; branch: string }>
+  worktreeList: (repoPath: string) => Promise<HermesGitWorktree[]>
+}
+
+export interface AutomaticSessionWorktree {
+  base: string
+  branch: string
+  path: string
+  repoPath: string
+}
+
+const isWindowsPath = (value: string): boolean =>
+  /^[a-z]:[\\/]/i.test(value.trim()) || /^(?:\\\\|\/\/)[^/\\]+[/\\][^/\\]+/.test(value.trim())
+
+const pathKey = (value: string, foldCase: boolean): string => {
+  const normalized = value.trim().replace(/\\/g, '/').replace(/\/+$/, '') || '/'
+
+  return foldCase ? normalized.toLowerCase() : normalized
+}
+
+function containingWorktree(cwd: string, worktrees: HermesGitWorktree[]): HermesGitWorktree | null {
+  const foldCase = isWindowsPath(cwd)
+  const target = pathKey(cwd, foldCase)
+
+  return (
+    [...worktrees]
+      .sort((a, b) => pathKey(b.path, foldCase).length - pathKey(a.path, foldCase).length)
+      .find(worktree => {
+        const root = pathKey(worktree.path, foldCase)
+
+        return target === root || (root === '/' ? target.startsWith('/') : target.startsWith(`${root}/`))
+      }) ?? null
+  )
+}
+
+function sessionSlug(id: string): string {
+  const safe = id
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9-]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 40)
+
+  return `session-${safe || Date.now().toString(36)}`
+}
+
+/**
+ * Give a brand-new chat an isolated checkout when its cwd points at a Git
+ * repository's main worktree. Explicit linked-worktree targets are preserved,
+ * and non-repository folders keep their original cwd.
+ */
+export async function isolateNewSessionCwd(
+  cwd: string,
+  git: NewSessionGitBridge,
+  idFactory: () => string = () => globalThis.crypto.randomUUID(),
+  onCreated?: (worktree: AutomaticSessionWorktree) => void
+): Promise<string> {
+  const target = cwd.trim()
+
+  const status = target ? await git.repoStatus(target) : null
+
+  if (!target || !status) {
+    return target
+  }
+
+  const worktrees = await git.worktreeList(target)
+  const current = containingWorktree(target, worktrees)
+
+  if (!current?.isMain) {
+    return target
+  }
+
+  const bases = await git.baseBranchList(target)
+  const base = bases.find(candidate => candidate.isDefault && candidate.isRemote) ?? bases.find(candidate => candidate.isDefault)
+  const baseName = base?.name ?? status.defaultBranch
+
+  if (!baseName) {
+    throw new Error('Cannot isolate a new session without a default branch.')
+  }
+
+  const name = sessionSlug(idFactory())
+
+  const result = await git.worktreeAdd(current.path, {
+    base: baseName,
+    branch: `hermes/${name}`,
+    name
+  })
+
+  onCreated?.({ base: baseName, branch: result.branch, path: result.path, repoPath: current.path })
+
+  return result.path
+}


### PR DESCRIPTION
## Summary

- isolate every new local Desktop session from a canonical checkout into an owned `hermes/session-*` branch and linked worktree before `session.create`
- cover project/global new chats, split/eager creation, and stored-session branch fallback while preserving explicit linked-worktree, detached, and remote behavior
- fail closed on missing base/default cwd, malformed responses, profile/route drift, and duplicate first submits; clean up only owned unchanged worktrees/branches without `--force`
- keep managed `.worktrees` out of canonical status via a root-only local Git exclude

## Safety invariants

- target profile readiness completes before remote-mode/default-cwd/Git decisions
- remote backends never call local Desktop Git or local default-cwd lookup
- route drift cannot overwrite another session's cwd
- automatic branch deletion requires owned `hermes/session-*` metadata and an unchanged base OID
- split runtime sessions with no durable stored id are closed before worktree cleanup

## Verification

- [x] targeted Desktop gate: 312 passed; one unchanged Windows temp-directory cleanup assertion hit `EPERM` on the final combined run (the same file passed 23/23 earlier)
- [x] explicit split local→remote profile-ordering regression: RED before fix, GREEN after fix
- [x] TypeScript: renderer, Electron, and E2E configurations
- [x] scoped ESLint
- [x] production build and `assert-dist-built`
- [x] `git diff --check`
- [x] independent read-only review of the pre-transplant implementation: APPROVE (194/194 reviewer tests)
- [x] Windows MSI installation and installed-app UI E2E on the source snapshot: global and project creation produced isolated worktrees; remote/detached paths covered by tests

## Notes

- The exact PR branch was transplanted onto current upstream `main`; conflict adaptation retained upstream `getAllSessionMessages` and configured-default-cwd behavior.
- Full Windows suite result on the exact branch: 5271 passed / 39 failed across 14 files. The output includes Windows locale/path expectations and existing React test warnings; this PR does not classify all 39 without a clean upstream baseline.
