### PR TITLE
fix(gateway): treat a Running HermesGateway scheduled task as a supervisor

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -1598,6 +1598,16 @@ def _reap_unsupervised_gateway_orphans(extra_exclude: set | None = None) -> bool
     except Exception:
         return False
 
+    # Windows Task Scheduler is a supervisor too — and the most reliable
+    # signal is the task's own state, not a parent-chain walk. A Scheduled
+    # Task gateway whose conhost bootstrap has already exited is invisible
+    # to `_reaper_candidate_is_supervisor_owned` (the parent chain breaks
+    # before services.exe, fail-open), yet it is alive and supervised.
+    # Querying the task state catches that case: if HermesGateway is
+    # Running, the reaper must not touch its process tree (#86098).
+    if is_windows() and _windows_scheduled_task_running("HermesGateway"):
+        return False
+
     from gateway.status import _pid_exists, write_planned_stop_marker
 
     own = {os.getpid()}
@@ -1828,6 +1838,51 @@ def is_macos() -> bool:
 
 def is_windows() -> bool:
     return sys.platform == "win32"
+
+
+def _windows_scheduled_task_running(task_name: str) -> bool:
+    """Return True when a Windows scheduled task with ``task_name`` is Running.
+
+    Used to treat Task Scheduler as a gateway supervisor on Windows: the
+    orphan-reap sweep must not kill a gateway that a scheduled task is
+    actively managing (it writes the planned-stop marker, the gateway exits
+    cleanly with code 0, and the scheduler never restarts it — silently
+    killing A2A/messaging on every desktop-app launch).
+
+    Best-effort: any failure (missing task, powershell unavailable, timeout)
+    returns False so the caller falls back to its existing behaviour.
+
+    Implemented with PowerShell (``Get-ScheduledTask``) instead of ``schtasks``
+    because the latter localizes its output (a Chinese Windows prints
+    ``状态: 正在运行``, not ``Status: Running``) and emits the local codepage,
+    which ``subprocess`` with ``encoding="utf-8"`` silently mangles. The
+    ``State`` property of ``Get-ScheduledTask`` is an English enum value
+    (``Running`` / ``Ready`` / ``Disabled``), stable across locales.
+    """
+    if not is_windows():
+        return False
+    try:
+        powershell = shutil.which("powershell") or shutil.which("pwsh")
+        if powershell is None:
+            return False
+        ps_cmd = (
+            f"$t = Get-ScheduledTask -TaskName '{task_name}' "
+            "-ErrorAction SilentlyContinue; if ($t) { $t.State } else { 'MISSING' }"
+        )
+        result = subprocess.run(
+            [powershell, "-NoProfile", "-Command", ps_cmd],
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="ignore",
+            timeout=10,
+        )
+        if result.returncode != 0:
+            return False
+        state = (result.stdout or "").strip()
+        return state == "Running"
+    except (OSError, subprocess.TimeoutExpired):
+        return False
 
 
 def _windows_gateway_should_absorb_console_controls() -> bool:

--- a/tests/hermes_cli/test_gateway.py
+++ b/tests/hermes_cli/test_gateway.py
@@ -771,3 +771,80 @@ def test_module_has_logger():
     """Verify module has a logger instance (regression guard for #27154)."""
     assert hasattr(gateway, "logger")
     assert gateway.logger.name == "hermes_cli.gateway"
+
+
+class TestWindowsScheduledTaskSupervisorGuard:
+    """The reaper must skip entirely when the HermesGateway scheduled task is
+    Running — Task Scheduler is a supervisor, and the task's own state is the
+    authoritative signal.
+
+    Regression guard: ``_reaper_candidate_is_supervisor_owned`` walks the
+    parent chain up to ``services.exe`` and fails open when the Task-launched
+    bootstrap has already exited (Windows does not reparent, so the chain
+    breaks). A gateway whose conhost bootstrap exited is then treated as an
+    orphan: the reaper writes the planned-stop marker, the gateway exits
+    cleanly with code 0, and the scheduler never restarts it — silently
+    killing A2A/messaging on every desktop-app launch. Querying the task
+    state closes that gap without depending on process ancestry.
+    """
+
+    def test_running_task_skips_reap(self, monkeypatch):
+        """HermesGateway is Running => reaper returns False, kills nothing."""
+        monkeypatch.setattr(gateway, "is_windows", lambda: True)
+        monkeypatch.setattr(gateway, "is_macos", lambda: False)
+        monkeypatch.setattr(gateway, "supports_systemd_services", lambda: False)
+        monkeypatch.setattr(gateway, "_windows_scheduled_task_running", lambda name: True)
+
+        # Guard: if the task check were bypassed, these would be reaped.
+        def _boom_find_gateway_pids(exclude_pids=None):
+            raise AssertionError("must not scan when scheduled task is Running")
+
+        monkeypatch.setattr(gateway, "find_gateway_pids", _boom_find_gateway_pids)
+        killed_pids = []
+        monkeypatch.setattr(gateway.os, "kill", lambda pid, sig: killed_pids.append((pid, sig)))
+
+        result = gateway._reap_unsupervised_gateway_orphans()
+
+        assert result is False
+        assert killed_pids == []
+
+    def test_not_running_task_still_reaps_real_orphan(self, monkeypatch):
+        """HermesGateway not Running (or missing) => reaper behaves as before
+        and still reaps a genuine orphan."""
+        orphan_pid = 99998
+
+        monkeypatch.setattr(gateway, "is_windows", lambda: True)
+        monkeypatch.setattr(gateway, "is_macos", lambda: False)
+        monkeypatch.setattr(gateway, "supports_systemd_services", lambda: False)
+        monkeypatch.setattr(gateway, "_windows_scheduled_task_running", lambda name: False)
+        monkeypatch.setattr("gateway.status.get_running_pid", lambda: None)
+        monkeypatch.setattr(gateway, "_get_service_pids", lambda: set())
+
+        monkeypatch.setattr(
+            gateway,
+            "find_gateway_pids",
+            lambda exclude_pids=None: [
+                p for p in [orphan_pid] if p not in (exclude_pids or set())
+            ],
+        )
+        killed_pids = []
+        monkeypatch.setattr(gateway.os, "kill", lambda pid, sig: killed_pids.append((pid, sig)))
+        monkeypatch.setattr("gateway.status._pid_exists", lambda pid: False)
+        monkeypatch.setattr("gateway.status.write_planned_stop_marker", lambda pid: None)
+        monkeypatch.setattr("time.sleep", lambda _: None)
+        monkeypatch.setattr("time.monotonic", lambda: 1.0)
+
+        result = gateway._reap_unsupervised_gateway_orphans()
+
+        assert result is True
+        assert orphan_pid in [pid for pid, _ in killed_pids]
+
+    def test_windows_scheduled_task_running_returns_false_off_windows(self, monkeypatch):
+        """The state helper is inert on POSIX (no subprocess spawned)."""
+        monkeypatch.setattr(gateway, "is_windows", lambda: False)
+
+        def _boom_run(*_a, **_k):
+            raise AssertionError("subprocess must not run off Windows")
+
+        monkeypatch.setattr(gateway.subprocess, "run", _boom_run)
+        assert gateway._windows_scheduled_task_running("HermesGateway") is False


### PR DESCRIPTION
## Summary

`_reap_unsupervised_gateway_orphans` must not kill a gateway that Windows Task Scheduler is actively supervising. When it does, the failure mode is silent and total: the reaper writes the planned-stop marker (which the gateway's watcher honours), the gateway exits **cleanly with code 0**, the scheduler's `RestartCount` never fires (it only triggers on non-zero exit), and every gateway-mediated channel — A2A, messaging — stays down until an operator manually restarts the task.

## The gap this closes

The existing Windows backstop (`_reaper_candidate_is_supervisor_owned`) walks the candidate's parent chain looking for `services.exe`. It **fails open** when the Task-launched conhost bootstrap has already exited: Windows does not reparent the gateway, the chain breaks before `services.exe`, and the supervised gateway is misclassified as an orphan. That is exactly the common deployment shape — the scheduled task's `conhost --headless hermes.exe gateway run` bootstrap exits early, leaving the gateway alive under a broken ancestry.

Querying the task's **own state** (`Get-ScheduledTask ... .State == "Running"`) is the authoritative signal and does not depend on process ancestry at all. If `HermesGateway` is Running, the reaper skips entirely.

## Reproduction (real deployment, Windows 11)

- Gateway supervised by a `HermesGateway` scheduled task (conhost bootstrap, InteractiveToken).
- Desktop app launches → `hermes serve` (HERMES_DESKTOP=1) → `_reap_unsupervised_gateway_orphans()` runs during lifespan.
- `desktop.log` shows: `⚠ Permission denied to kill orphaned gateway PID <gw>` (SIGTERM denied — different security context), but the planned-stop marker was already written first.
- `gateway.log` shows: `Received UNKNOWN as a planned gateway stop — exiting cleanly` ~2s after startup.
- Scheduled task state: `Ready` (never `Running` again) — `RestartCount=3, RestartInterval=1min` do nothing because exit code is 0.

Verified fix on the same machine: with the task `Running`, `_reap_unsupervised_gateway_orphans()` now returns `False`, the gateway PID is untouched, and `:9900` stays LISTENING through a full serve-startup simulation.

## Notes

- Uses PowerShell `Get-ScheduledTask` rather than `schtasks`: the latter localizes its output (`状态: 正在运行` on zh-CN) and emits the local codepage, which `subprocess(encoding="utf-8")` mangles. `Get-ScheduledTask.State` is an English enum (`Running`/`Ready`/`Disabled`), locale-stable.
- The task name is `HermesGateway` — the name produced by `hermes gateway install` on Windows. Other supervisor names (Startup VBS, etc.) remain covered by the existing ancestry backstop.
- POSIX unaffected: helper returns `False` off-Windows without spawning anything.

## Tests

- `tests/hermes_cli/test_gateway.py`: 27 passed (3 new tests cover task-Running skip, not-Running still reaps real orphans, and POSIX inertness).
