### PR TITLE
fix(agent): import cryptography lazily in the Bitwarden secret source (#86735)

### DIFF
--- a/agent/secret_sources/bitwarden.py
+++ b/agent/secret_sources/bitwarden.py
@@ -47,9 +47,12 @@ import zipfile
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple
 
-from cryptography.hazmat.primitives import hashes
-from cryptography.hazmat.primitives.ciphers.aead import AESGCM
-from cryptography.hazmat.primitives.kdf.hkdf import HKDF
+# NOTE: cryptography is intentionally NOT imported at module level.  It pulls
+# in native bindings (cryptography._rust on Windows) that a mapped extension
+# cannot replace once loaded — and this module is imported unconditionally by
+# the secret-source registry for every CLI/gateway process, so an eager import
+# trips `hermes update`'s self-lock preflight on Windows before it can even
+# pull new commits (#86735).  Import lazily inside the functions that use it.
 
 from agent.secret_sources._cache import (
     CachedFetch as _CachedFetch,
@@ -375,6 +378,11 @@ def _b64d(text: str) -> bytes:
 
 def _derive_encrypted_cache_key(access_token: str, salt: bytes) -> bytes:
     """Derive the local cache encryption key from the bootstrap BWS token."""
+    # Lazy: cryptography must not load unless an encrypted cache is actually
+    # in use (see the module-level NOTE — #86735).
+    from cryptography.hazmat.primitives import hashes
+    from cryptography.hazmat.primitives.kdf.hkdf import HKDF
+
     return HKDF(
         algorithm=hashes.SHA256(),
         length=32,
@@ -407,6 +415,10 @@ def _write_encrypted_disk_cache(
         nonce = os.urandom(12)
         serialized_key = _cache_key_str(cache_key)
         key = _derive_encrypted_cache_key(access_token, salt)
+        # Lazy: cryptography must not load unless an encrypted cache is
+        # actually in use (see the module-level NOTE — #86735).
+        from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+
         plaintext = json.dumps(
             {"secrets": entry.secrets, "fetched_at": entry.fetched_at},
             separators=(",", ":"),
@@ -471,6 +483,10 @@ def _read_encrypted_disk_cache(
         nonce = _b64d(str(payload.get("nonce", "")))
         ciphertext = _b64d(str(payload.get("ciphertext", "")))
         key = _derive_encrypted_cache_key(access_token, salt)
+        # Lazy: cryptography must not load unless an encrypted cache is
+        # actually in use (see the module-level NOTE — #86735).
+        from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+
         raw = AESGCM(key).decrypt(
             nonce, ciphertext, serialized_key.encode("utf-8")
         )

--- a/tests/secret_sources/test_secret_source_registry.py
+++ b/tests/secret_sources/test_secret_source_registry.py
@@ -9,7 +9,9 @@ against the bundled Bitwarden source.
 
 from __future__ import annotations
 
+import subprocess
 import sys
+import textwrap
 import time
 from pathlib import Path
 
@@ -361,3 +363,39 @@ class TestOnePasswordConformance(SecretSourceConformance):
         monkeypatch.setattr(op, "find_op", lambda *_a, **_kw: None)
         monkeypatch.delenv("OP_SERVICE_ACCOUNT_TOKEN", raising=False)
         return op.OnePasswordSource()
+
+
+class TestNoEagerCryptographyImport:
+    """#86735 regression: registering the bundled sources must not load
+    ``cryptography``.
+
+    Every CLI/gateway process imports the secret-source registry, and
+    Bitwarden's module used to import ``cryptography.hazmat...`` at module
+    level. On Windows a mapped native extension (``cryptography._rust``)
+    cannot be replaced once loaded, so ``hermes update``'s self-lock
+    preflight deferred every update before it could even pull commits.
+    The imports are now lazy; this test proves it in a clean interpreter
+    (a subprocess, so the test runner's own imports cannot mask a
+    regression).
+    """
+
+    def test_builtin_registration_does_not_import_cryptography(self):
+        code = textwrap.dedent(
+            """
+            import sys
+            from agent.secret_sources import registry
+            registry._ensure_builtin_sources()
+            print("cryptography" in sys.modules)
+            print("cryptography.hazmat.bindings._rust" in sys.modules)
+            """
+        )
+        result = subprocess.run(
+            [sys.executable, "-c", code],
+            capture_output=True,
+            text=True,
+            cwd=str(ROOT),
+        )
+        assert result.returncode == 0, result.stderr
+        lines = result.stdout.strip().splitlines()
+        assert lines[0] == "False"
+        assert lines[1] == "False"


### PR DESCRIPTION
﻿## What does this PR do?

`hermes update` fails with exit 2 on Windows on every run:

```
✗ This updater process has already loaded native venv modules that
  the dependency sync must replace:
    cryptography (_rust.pyd)
```

Root cause (as located in the issue): every CLI/gateway process imports the secret-source registry, which unconditionally registers the bundled Bitwarden source — and `agent/secret_sources/bitwarden.py` imported `cryptography.hazmat` at **module level**. On Windows a mapped native extension (`cryptography._rust`) cannot be replaced once loaded, so the updater's self-lock preflight (`_detect_self_loaded_native_modules` in `update_cmd.py`) deferred every update before it could even pull commits.

The `cryptography` imports are now lazy — inside the three functions that actually use them (HKDF key derivation, AESGCM encrypt/decrypt). A process that never reads an encrypted BWS cache never loads `cryptography`, so the self-lock preflight stays quiet on cold updates. The registry's "lazy, cheap, broken-source-safe" design (documented in `_ensure_builtin_sources`) is preserved.

## Related Issue

Fixes #86735

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/secret_sources/bitwarden.py`: removed module-level `from cryptography...` imports (with a NOTE explaining why); lazy imports in `_derive_encrypted_cache_key`, `_write_encrypted_disk_cache`, `_read_encrypted_disk_cache`
- `tests/secret_sources/test_secret_source_registry.py`: `TestNoEagerCryptographyImport` — in a clean subprocess interpreter, `_ensure_builtin_sources()` must not leave `cryptography` or `cryptography.hazmat.bindings._rust` in `sys.modules` (subprocess so the test runner's own imports cannot mask a regression)

## How to Test

1. `pytest tests/secret_sources/test_secret_source_registry.py tests/test_bitwarden_secrets.py -q` — new regression test passes; encrypted-cache behavior unchanged (pre-existing Windows env failures unrelated: NTFS 0o600, bws.exe naming)
2. `ruff check` + `check-windows-footguns.py --diff` — clean
3. Windows manual: `hermes update` no longer trips the self-lock preflight on a cold process; Bitwarden encrypted cache still works when configured

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run `pytest` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11, Python 3.11

### Documentation & Housekeeping

- [x] N/A for docs/config example (no new config keys)
- [x] N/A for tool descriptions/schemas
