### PR TITLE
feat(dashboard): touch scrolling for chat terminal on mobile/tablet

### DIFF
--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -786,6 +786,82 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
       return false;
     });
 
+    // Touch scrolling (mobile / tablet).  xterm.js has no native touch
+    // support: a finger drag neither scrolls the viewport nor reaches the
+    // wheel handler above, so on touch devices the only way to scroll is
+    // the thin scrollbar.  Translate touch drags into scrollLines() using
+    // the live cell height (host height / visible rows), so the transcript
+    // tracks the finger 1:1.  passive:false + preventDefault stops the
+    // page itself from scrolling / pull-to-refresh instead.
+    const touchStart: { x: number; y: number; time: number } | null = {
+      x: 0,
+      y: 0,
+      time: 0,
+    };
+    let lastTouchY = 0;
+    let lastTouchTime = 0;
+    let touchVelocity = 0;
+    const cellHeightPx = () => {
+      const rows = term.rows > 0 ? term.rows : 1;
+      const h = host.clientHeight > 0 ? host.clientHeight : rows * 18;
+      return Math.max(1, h / rows);
+    };
+    const onTouchStart = (ev: TouchEvent) => {
+      if (ev.touches.length !== 1) return;
+      const t = ev.touches[0];
+      touchStart.x = t.clientX;
+      touchStart.y = t.clientY;
+      touchStart.time = ev.timeStamp;
+      lastTouchY = t.clientY;
+      lastTouchTime = ev.timeStamp;
+      touchVelocity = 0;
+    };
+    const onTouchMove = (ev: TouchEvent) => {
+      if (ev.touches.length !== 1 || touchStart.time === 0) return;
+      const t = ev.touches[0];
+      const dy = lastTouchY - t.clientY; // + = finger up = scroll down
+      const dt = ev.timeStamp - lastTouchTime;
+      if (dt > 0) {
+        touchVelocity = dy / dt; // px per ms, for momentum
+      }
+      lastTouchY = t.clientY;
+      lastTouchTime = ev.timeStamp;
+      const lines = dy / cellHeightPx();
+      if (lines !== 0) {
+        term.scrollLines(Math.round(lines));
+      }
+      ev.preventDefault();
+      ev.stopPropagation();
+    };
+    const onTouchEnd = () => {
+      // Momentum: short fast flicks keep scrolling after release, like a
+      // native mobile list.  ~120ms of decaying distance, reprojected into
+      // terminal lines via the same cell height.
+      const speed = touchVelocity; // px/ms at release
+      if (Math.abs(speed) < 0.15 || touchStart.time === 0) {
+        touchStart.time = 0;
+        return;
+      }
+      const cell = cellHeightPx();
+      const dir = speed > 0 ? 1 : -1;
+      let remaining = Math.abs(speed) * 120; // total px of momentum
+      const step = () => {
+        if (remaining <= 0) return;
+        const chunk = Math.max(1, remaining * 0.1);
+        term.scrollLines(dir * Math.round(chunk / cell));
+        remaining -= chunk;
+        if (remaining > 0) {
+          requestAnimationFrame(step);
+        }
+      };
+      requestAnimationFrame(step);
+      touchStart.time = 0;
+    };
+    host.addEventListener("touchstart", onTouchStart, { passive: true });
+    host.addEventListener("touchmove", onTouchMove, { passive: false });
+    host.addEventListener("touchend", onTouchEnd, { passive: true });
+    host.addEventListener("touchcancel", onTouchEnd, { passive: true });
+
     const unicode11 = new Unicode11Addon();
     term.loadAddon(unicode11);
     term.unicode.activeVersion = "11";
@@ -1405,6 +1481,10 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
         scheduleSyncTerminalMetrics,
       );
       ro.disconnect();
+      host.removeEventListener("touchstart", onTouchStart);
+      host.removeEventListener("touchmove", onTouchMove);
+      host.removeEventListener("touchend", onTouchEnd);
+      host.removeEventListener("touchcancel", onTouchEnd);
       if (hostSyncRaf) cancelAnimationFrame(hostSyncRaf);
       if (settleRaf1) cancelAnimationFrame(settleRaf1);
       if (settleRaf2) cancelAnimationFrame(settleRaf2);

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -793,14 +793,11 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
     // the live cell height (host height / visible rows), so the transcript
     // tracks the finger 1:1.  passive:false + preventDefault stops the
     // page itself from scrolling / pull-to-refresh instead.
-    const touchStart: { x: number; y: number; time: number } | null = {
-      x: 0,
-      y: 0,
-      time: 0,
-    };
+    let touchStart: { x: number; y: number; time: number } | null = null;
     let lastTouchY = 0;
     let lastTouchTime = 0;
     let touchVelocity = 0;
+    let momentumRaf = 0;
     const cellHeightPx = () => {
       const rows = term.rows > 0 ? term.rows : 1;
       const h = host.clientHeight > 0 ? host.clientHeight : rows * 18;
@@ -808,16 +805,19 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
     };
     const onTouchStart = (ev: TouchEvent) => {
       if (ev.touches.length !== 1) return;
+      // A new gesture supersedes any in-flight momentum animation.
+      if (momentumRaf) {
+        cancelAnimationFrame(momentumRaf);
+        momentumRaf = 0;
+      }
       const t = ev.touches[0];
-      touchStart.x = t.clientX;
-      touchStart.y = t.clientY;
-      touchStart.time = ev.timeStamp;
+      touchStart = { x: t.clientX, y: t.clientY, time: ev.timeStamp };
       lastTouchY = t.clientY;
       lastTouchTime = ev.timeStamp;
       touchVelocity = 0;
     };
     const onTouchMove = (ev: TouchEvent) => {
-      if (ev.touches.length !== 1 || touchStart.time === 0) return;
+      if (ev.touches.length !== 1 || touchStart === null) return;
       const t = ev.touches[0];
       const dy = lastTouchY - t.clientY; // + = finger up = scroll down
       const dt = ev.timeStamp - lastTouchTime;
@@ -830,32 +830,45 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
       if (lines !== 0) {
         term.scrollLines(Math.round(lines));
       }
-      ev.preventDefault();
-      ev.stopPropagation();
+      // Only capture the gesture when the transcript can actually scroll
+      // (buffer longer than the viewport, or viewport not at the bottom);
+      // with no scrollback the drag is a no-op, so let the page scroll
+      // natively instead of freezing it.
+      const buf = term.buffer.active;
+      const canScroll = buf.length > term.rows || buf.baseY > 0;
+      if (canScroll) {
+        ev.preventDefault();
+        ev.stopPropagation();
+      }
     };
     const onTouchEnd = () => {
       // Momentum: short fast flicks keep scrolling after release, like a
       // native mobile list.  ~120ms of decaying distance, reprojected into
       // terminal lines via the same cell height.
       const speed = touchVelocity; // px/ms at release
-      if (Math.abs(speed) < 0.15 || touchStart.time === 0) {
-        touchStart.time = 0;
+      if (Math.abs(speed) < 0.15 || touchStart === null) {
+        touchStart = null;
         return;
       }
       const cell = cellHeightPx();
       const dir = speed > 0 ? 1 : -1;
       let remaining = Math.abs(speed) * 120; // total px of momentum
       const step = () => {
-        if (remaining <= 0) return;
+        if (remaining <= 0) {
+          momentumRaf = 0;
+          return;
+        }
         const chunk = Math.max(1, remaining * 0.1);
         term.scrollLines(dir * Math.round(chunk / cell));
         remaining -= chunk;
         if (remaining > 0) {
-          requestAnimationFrame(step);
+          momentumRaf = requestAnimationFrame(step);
+        } else {
+          momentumRaf = 0;
         }
       };
-      requestAnimationFrame(step);
-      touchStart.time = 0;
+      momentumRaf = requestAnimationFrame(step);
+      touchStart = null;
     };
     host.addEventListener("touchstart", onTouchStart, { passive: true });
     host.addEventListener("touchmove", onTouchMove, { passive: false });
@@ -1488,6 +1501,7 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
       if (hostSyncRaf) cancelAnimationFrame(hostSyncRaf);
       if (settleRaf1) cancelAnimationFrame(settleRaf1);
       if (settleRaf2) cancelAnimationFrame(settleRaf2);
+      if (momentumRaf) cancelAnimationFrame(momentumRaf);
       clearReconnectTimer();
       clearConnectingTimer();
       clearTicketTimer();


### PR DESCRIPTION
## Summary

The dashboard's chat tab embeds the full `hermes --tui` in xterm.js. xterm.js has **no native touch support**, and the custom wheel handler in `ChatPage.tsx` only listens for mouse `wheel` events - so on phones and tablets a finger drag did nothing. The only way to scroll the transcript was the thin scrollbar, which is very hard to hit on a touchscreen.

This PR adds single-finger touch scrolling to the chat terminal:

- **1:1 tracking** - touch drags are translated into `term.scrollLines()` using the live cell height (host `clientHeight / term.rows`), so the transcript follows the finger like a native app.
- **Momentum** - release velocity (px/ms) drives a short decaying `requestAnimationFrame` flick animation, matching native mobile list feel.
- **No page hijack** - `touchmove` uses `passive: false` + `preventDefault()` so the surrounding page / pull-to-refresh never steals the drag.
- **Cleanup** - all four listeners are removed in the effect's cleanup alongside the existing resize/observer teardown.

Desktop behaviour is unchanged: the existing `attachCustomWheelEventHandler` path is untouched, and the touch listeners are inert for mouse input.

## Test plan

- [x] `tsc -b` clean, `vite build` succeeds
- [x] Verified on a tablet against the deployed dashboard: finger drag scrolls the chat transcript smoothly; flicks carry momentum; page does not scroll or trigger pull-to-refresh behind the terminal
- [x] Desktop mouse wheel scrolling unchanged
- [x] Long touch for text selection / link taps (WebLinksAddon) still work - `touchstart`/`touchend` remain passive and only `touchmove` is intercepted