### PR TITLE
feat(feishu): implement delete_message for progress bubble cleanup

### DIFF
--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -95,6 +95,7 @@ CreateImageRequest = None  # type: ignore[assignment]
 CreateImageRequestBody = None  # type: ignore[assignment]
 CreateMessageRequest = None  # type: ignore[assignment]
 CreateMessageRequestBody = None  # type: ignore[assignment]
+DeleteMessageRequest = None  # type: ignore[assignment]
 GetChatRequest = None  # type: ignore[assignment]
 GetMessageRequest = None  # type: ignore[assignment]
 GetMessageResourceRequest = None  # type: ignore[assignment]
@@ -1400,6 +1401,7 @@ def _load_lark_oapi() -> bool:
                 CreateFileRequest, CreateFileRequestBody,
                 CreateImageRequest, CreateImageRequestBody,
                 CreateMessageRequest, CreateMessageRequestBody,
+                DeleteMessageRequest,
                 GetChatRequest, GetMessageRequest, GetMessageResourceRequest,
                 P2ImMessageMessageReadV1,
                 ReplyMessageRequest, ReplyMessageRequestBody,
@@ -1425,6 +1427,7 @@ def _load_lark_oapi() -> bool:
             "CreateImageRequestBody": CreateImageRequestBody,
             "CreateMessageRequest": CreateMessageRequest,
             "CreateMessageRequestBody": CreateMessageRequestBody,
+            "DeleteMessageRequest": DeleteMessageRequest,
             "GetChatRequest": GetChatRequest,
             "GetMessageRequest": GetMessageRequest,
             "GetMessageResourceRequest": GetMessageResourceRequest,
@@ -2046,6 +2049,29 @@ class FeishuAdapter(BasePlatformAdapter):
         except Exception as exc:
             logger.error("[Feishu] Failed to edit message %s: %s", message_id, exc, exc_info=True)
             return SendResult(success=False, error=str(exc))
+
+    async def delete_message(self, chat_id: str, message_id: str) -> bool:
+        """Delete a previously sent Feishu message.
+
+        Feishu message IDs are globally unique, so ``chat_id`` is accepted
+        for interface compatibility but unused.  Used by the stream
+        consumer's fresh-final cleanup path and the ``cleanup_progress``
+        display setting to remove progress/status bubbles after the final
+        response lands.  The bot can only delete its own messages and only
+        within a rolling window; failures are non-fatal — callers leave the
+        bubble in place and log at debug level.
+        """
+        if not self._client:
+            return False
+        try:
+            if DeleteMessageRequest is None:
+                return False
+            request = DeleteMessageRequest.builder().message_id(message_id).build()
+            response = await self._run_blocking(self._client.im.v1.message.delete, request)
+            return self._response_succeeded(response)
+        except Exception as exc:
+            logger.debug("[Feishu] Failed to delete message %s: %s", message_id, exc)
+            return False
 
     # Template attrs for the shared _format_exec_approval core. The card
     # header carries the title, so the text core starts at the code fence.

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -285,6 +285,103 @@ class TestFeishuAdapterMessaging(unittest.TestCase):
             json.dumps({"text": "可以用 粗体 和 斜体。"}, ensure_ascii=False),
         )
 
+    @patch.dict(os.environ, {}, clear=True)
+    def test_delete_message_builds_request_and_returns_success(self):
+        from gateway.config import PlatformConfig
+        from plugins.platforms.feishu.adapter import FeishuAdapter, _load_lark_oapi
+        if not _HAS_LARK_OAPI:
+            self.skipTest("lark_oapi not installed")
+        self.assertTrue(_load_lark_oapi(), "lark_oapi must load for delete_message")
+
+        adapter = FeishuAdapter(PlatformConfig())
+        captured = {}
+
+        class _MessageAPI:
+            def delete(self, request):
+                captured["request"] = request
+                return SimpleNamespace(success=lambda: True)
+
+        adapter._client = SimpleNamespace(
+            im=SimpleNamespace(v1=SimpleNamespace(message=_MessageAPI()))
+        )
+
+        async def _run_blocking_fake(func, *args):
+            return func(*args)
+
+        with patch.object(adapter, "_run_blocking", new=_run_blocking_fake):
+            result = asyncio.run(
+                adapter.delete_message(chat_id="oc_chat", message_id="om_progress")
+            )
+
+        self.assertTrue(result)
+        self.assertEqual(captured["request"].message_id, "om_progress")
+
+    def test_delete_message_returns_false_when_api_reports_failure(self):
+        from gateway.config import PlatformConfig
+        from plugins.platforms.feishu.adapter import FeishuAdapter, _load_lark_oapi
+        if not _HAS_LARK_OAPI:
+            self.skipTest("lark_oapi not installed")
+        self.assertTrue(_load_lark_oapi())
+
+        adapter = FeishuAdapter(PlatformConfig())
+
+        class _MessageAPI:
+            def delete(self, request):
+                return SimpleNamespace(success=lambda: False, code=99999, msg="forbidden")
+
+        adapter._client = SimpleNamespace(
+            im=SimpleNamespace(v1=SimpleNamespace(message=_MessageAPI()))
+        )
+
+        async def _run_blocking_fake(func, *args):
+            return func(*args)
+
+        with patch.object(adapter, "_run_blocking", new=_run_blocking_fake):
+            result = asyncio.run(
+                adapter.delete_message(chat_id="oc_chat", message_id="om_progress")
+            )
+
+        self.assertFalse(result)
+
+    def test_delete_message_returns_false_when_sdk_raises(self):
+        from gateway.config import PlatformConfig
+        from plugins.platforms.feishu.adapter import FeishuAdapter, _load_lark_oapi
+        if not _HAS_LARK_OAPI:
+            self.skipTest("lark_oapi not installed")
+        self.assertTrue(_load_lark_oapi())
+
+        adapter = FeishuAdapter(PlatformConfig())
+
+        class _MessageAPI:
+            def delete(self, request):
+                raise RuntimeError("sdk boom")
+
+        adapter._client = SimpleNamespace(
+            im=SimpleNamespace(v1=SimpleNamespace(message=_MessageAPI()))
+        )
+
+        async def _run_blocking_fake(func, *args):
+            return func(*args)
+
+        with patch.object(adapter, "_run_blocking", new=_run_blocking_fake):
+            result = asyncio.run(
+                adapter.delete_message(chat_id="oc_chat", message_id="om_progress")
+            )
+
+        self.assertFalse(result)
+
+    def test_delete_message_returns_false_when_client_missing(self):
+        from gateway.config import PlatformConfig
+        from plugins.platforms.feishu.adapter import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        adapter._client = None
+
+        result = asyncio.run(
+            adapter.delete_message(chat_id="oc_chat", message_id="om_progress")
+        )
+        self.assertFalse(result)
+
 
 class TestAdapterModule(unittest.TestCase):
     def test_load_settings_uses_sdk_defaults_for_invalid_ws_reconnect_values(self):


### PR DESCRIPTION
## Problem

The gateway's `cleanup_progress` display setting (`display.platforms.feishu.cleanup_progress: true`) deletes tool-progress / "⏳ Working — N min" / status bubbles after the final response lands. It requires the platform adapter to implement `delete_message`, which the Feishu adapter was missing — so the setting silently no-ops on Feishu (`gateway/run.py` cleanup init forces `_cleanup_progress = False` when `delete_message` is the base-class default).

Telegram, Slack, and Google Chat adapters already implement it; this adds the same capability to Feishu.

## Change

- `plugins/platforms/feishu/adapter.py`: add `FeishuAdapter.delete_message()` (builds `DeleteMessageRequest`, calls `im.v1.message.delete`, returns `self._response_succeeded(response)`; non-fatal on failure).
- Register `DeleteMessageRequest` in the lazy `lark_oapi` import.
- `tests/gateway/test_feishu.py`: 4 unit tests (success, API failure, SDK exception, missing client).

## Verification

- Unit tests: `pytest tests/gateway/test_feishu.py -k delete_message` — 4 passed.
- Full Feishu suite: 100 passed.
- Live verification against a real Feishu app: sent a message to a chat, deleted it via `delete_message` (returned `True`), then re-fetched the message and confirmed `deleted` was set.

Feishu message IDs are globally unique, so `chat_id` is accepted for interface compatibility but unused. The bot can only delete its own messages within a rolling window; failures log at debug level, matching the other adapters.