### PR TITLE
fix(tui): show session source in the Ink switcher rows

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -13797,6 +13797,7 @@ def test_session_active_list_reports_live_sessions(monkeypatch):
         session_key="key-a",
         created_at=10.0,
         last_active=20.0,
+        source="telegram",
     )
     server._sessions["sid-b"] = _session(
         agent=types.SimpleNamespace(model="model-b"),
@@ -13805,6 +13806,7 @@ def test_session_active_list_reports_live_sessions(monkeypatch):
         session_key="key-b",
         created_at=11.0,
         last_active=30.0,
+        source="cli",
     )
     try:
         resp = server.handle_request(
@@ -13830,6 +13832,7 @@ def test_session_active_list_reports_live_sessions(monkeypatch):
         "model": "model-a",
         "preview": "find docs",
         "session_key": "key-a",
+        "source": "telegram",
         "started_at": 10.0,
         "status": "idle",
         "title": "Research",
@@ -13838,6 +13841,7 @@ def test_session_active_list_reports_live_sessions(monkeypatch):
     assert rows["sid-b"]["status"] == "working"
     assert rows["sid-b"]["title"] == "Implement"
     assert rows["sid-b"]["preview"] == "writing code"
+    assert rows["sid-b"]["source"] == "cli"
 
 
 def test_session_active_list_excludes_finalized_sessions(monkeypatch):

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -8407,6 +8407,7 @@ def _session_live_item(sid: str, session: dict, current_sid: str = "") -> dict:
         "model": str(getattr(agent, "model", "") or _resolve_model()),
         "preview": preview,
         "session_key": key,
+        "source": _session_source(session),
         "started_at": float(session.get("created_at") or now),
         "status": status,
         "title": _session_live_title(session, key),

--- a/ui-tui/src/__tests__/activeSessionSwitcher.test.ts
+++ b/ui-tui/src/__tests__/activeSessionSwitcher.test.ts
@@ -24,7 +24,8 @@ import {
   resumableHistory,
   selectedSessionRowStyle,
   sessionRowKindAt,
-  sessionsCountLabel
+  sessionsCountLabel,
+  sessionSourceLabel
 } from '../components/activeSessionSwitcher.js'
 import { listRowStyle } from '../components/overlayPrimitives.js'
 import type { SessionActiveItem } from '../gatewayTypes.js'
@@ -213,5 +214,13 @@ describe('unified Sessions overlay helpers', () => {
     expect(relativeSessionAge(nowSec - 3 * 86400)).toBe('3d ago')
     expect(relativeSessionAge(undefined)).toBe('')
     expect(relativeSessionAge(0)).toBe('')
+  })
+
+  it('labels the session source column, truncated and defaulted like the CLI picker', () => {
+    expect(sessionSourceLabel('telegram')).toBe('telegr')
+    expect(sessionSourceLabel('cli')).toBe('cli')
+    expect(sessionSourceLabel('  wecom  ')).toBe('wecom')
+    expect(sessionSourceLabel('')).toBe('—')
+    expect(sessionSourceLabel(undefined)).toBe('—')
   })
 })

--- a/ui-tui/src/components/activeSessionSwitcher.tsx
+++ b/ui-tui/src/components/activeSessionSwitcher.tsx
@@ -40,8 +40,18 @@ const STATUS_LABEL: Record<string, string> = {
 
 const CTRL_OFFSET = 96
 
+const SOURCE_LABEL_WIDTH = 6
+
 const shortModel = (model = '') => model.replace(/^.*\//, '') || 'model?'
 const ctrlChar = (letter: string) => String.fromCharCode(letter.charCodeAt(0) - CTRL_OFFSET)
+
+// Mirrors the CLI curses picker's `source[:6]` column (`_format_row` in
+// hermes_cli/main.py) so the two session pickers stay consistent.
+export const sessionSourceLabel = (source?: string) => {
+  const trimmed = (source ?? '').trim()
+
+  return trimmed ? trimmed.slice(0, SOURCE_LABEL_WIDTH) : '—'
+}
 
 export const fixedSessionColumnStyle = () => ({ flexShrink: 0 })
 
@@ -787,6 +797,12 @@ export function ActiveSessionSwitcher({
                 </Text>
               </Box>
 
+              <Box {...fixedSessionColumnStyle()} width={8}>
+                <Text color={rowTextColor ?? t.color.muted} wrap="truncate-end">
+                  {sessionSourceLabel(h.source)}
+                </Text>
+              </Box>
+
               <Box flexGrow={1} flexShrink={1} minWidth={0}>
                 <Text
                   bold={selected}
@@ -848,6 +864,12 @@ export function ActiveSessionSwitcher({
             <Box {...fixedSessionColumnStyle()} width={18}>
               <Text color={rowTextColor ?? t.color.muted} wrap="truncate-end">
                 {shortModel(s.model)}
+              </Text>
+            </Box>
+
+            <Box {...fixedSessionColumnStyle()} width={8}>
+              <Text color={rowTextColor ?? t.color.muted} wrap="truncate-end">
+                {sessionSourceLabel(s.source)}
               </Text>
             </Box>
 

--- a/ui-tui/src/components/activeSessionSwitcher.tsx
+++ b/ui-tui/src/components/activeSessionSwitcher.tsx
@@ -41,6 +41,9 @@ const STATUS_LABEL: Record<string, string> = {
 const CTRL_OFFSET = 96
 
 const SOURCE_LABEL_WIDTH = 6
+// Rendered in an 8-wide Box below — the extra 2 chars are the same
+// inter-column gap the other fixed-width columns in this table use, not a
+// truncation mismatch.
 
 const shortModel = (model = '') => model.replace(/^.*\//, '') || 'model?'
 const ctrlChar = (letter: string) => String.fromCharCode(letter.charCodeAt(0) - CTRL_OFFSET)

--- a/ui-tui/src/gatewayTypes.ts
+++ b/ui-tui/src/gatewayTypes.ts
@@ -203,6 +203,7 @@ export interface SessionActiveItem {
   model?: string
   preview?: string
   session_key?: string
+  source?: string
   started_at?: number
   status: LiveSessionStatus
   title?: string


### PR DESCRIPTION
Fixes #86810

## Summary

The Ink TUI session switcher (`activeSessionSwitcher.tsx`, opened via Ctrl+K or `/sessions`) rendered every row without the session's **source** (Telegram / Feishu / WeCom / CLI / etc.), so a multi-platform user's history looked like a flat, indistinguishable list. The CLI curses picker (`hermes sessions browse`) already shows a `source[:6]` column (`_format_row` in `hermes_cli/main.py`); the Ink switcher was the one surface missing it.

## Root cause / fix

- `session.list` already returned `source` per row (used by history rows) — no change needed there.
- `session.active_list` (live rows) did **not** — `_session_live_item()` in `tui_gateway/server.py` built its dict without a `source` key, even though every session in `_sessions` already carries one (set at `_init_session` time) and the repo already has a `_session_source(session)` helper (used elsewhere) that resolves it with the correct fallback. Added `"source": _session_source(session)` to `_session_live_item`.
- `ui-tui/src/gatewayTypes.ts`: added `source?: string` to `SessionActiveItem` (it already existed on `SessionListItem`).
- `ui-tui/src/components/activeSessionSwitcher.tsx`: added a new exported `sessionSourceLabel()` helper (truncates to 6 chars, mirroring the CLI picker's `source[:6]`, with an em-dash fallback) and a fixed-width source column in both the history-row and live-row renderers, placed just before the title column.

## Tests

- New Vitest case for `sessionSourceLabel` (truncation, trimming, empty/undefined fallback). Confirmed it fails without the fix: reverting `activeSessionSwitcher.tsx` to its pre-fix state and running the suite gives `TypeError: sessionSourceLabel is not a function`; reapplying the fix passes.
- Extended `test_session_active_list_reports_live_sessions` in `tests/test_tui_gateway_server.py` to set `source` on the fixture sessions and assert it round-trips through `session.active_list`. Confirmed it fails without the backend fix (`AssertionError` — `source` key missing from the row); passes with `_session_live_item` fix applied.

```
# ui-tui
$ npx vitest run src/__tests__/activeSessionSwitcher.test.ts
 Test Files  1 passed (1)
      Tests  17 passed (17)

$ npx vitest run
 Test Files  154 passed (154)
      Tests  1630 passed | 4 skipped (1634)

$ npm run typecheck   # clean
$ npm run lint        # clean (2 pre-existing unrelated warnings only)
$ npx prettier --check src/components/activeSessionSwitcher.tsx src/__tests__/activeSessionSwitcher.test.ts src/gatewayTypes.ts
All matched files use Prettier code style!

# python
$ python -m pytest tests/test_tui_gateway_server.py -q
573 passed

$ python -m pytest tests/hermes_cli/test_session_filters.py -q
12 passed

$ ruff check tui_gateway/server.py tests/test_tui_gateway_server.py
All checks passed!

$ git diff --check   # clean
```

## AI assistance disclosure

This PR was written with AI assistance (Claude Code / Anthropic).
