### PR TITLE
test: fix five native-Windows test-environment failures (#86830)

### DIFF
--- a/tests/cron/test_cron_no_agent.py
+++ b/tests/cron/test_cron_no_agent.py
@@ -12,10 +12,49 @@ Covers:
 from __future__ import annotations
 
 import json
+import os
+import pathlib
+import shutil
 import subprocess
 from unittest.mock import patch
 
 import pytest
+
+
+def _has_working_bash() -> bool:
+    """True when bash can actually execute a script given a Windows path.
+
+    ``shutil.which("bash")`` alone is not enough on Windows:
+    - the WindowsApps shim hands off to WSL, which mangles Windows paths
+      (``C:\\...`` loses its backslashes) and exits 127 — see #62514;
+    - Git Bash handles Windows paths fine.
+
+    Probe by running a real script file through bash and requiring its
+    stdout to come back (see #86830).
+    """
+    import os
+    import tempfile
+
+    bash = shutil.which("bash")
+    if not bash:
+        return False
+    probe = pathlib.Path(tempfile.gettempdir()) / f"hermes_bash_probe_{os.getpid()}.sh"
+    try:
+        probe.write_text("echo PROBE_123\n", encoding="utf-8")
+        result = subprocess.run(
+            [bash, str(probe)], capture_output=True, text=True, timeout=10
+        )
+        return result.returncode == 0 and "PROBE_123" in result.stdout
+    except (OSError, subprocess.TimeoutExpired):
+        return False
+    finally:
+        try:
+            probe.unlink()
+        except OSError:
+            pass
+
+
+_HAS_WORKING_BASH = _has_working_bash()
 
 
 @pytest.fixture
@@ -88,6 +127,10 @@ def test_cronjob_tool_create_no_agent_without_script_errors(hermes_env):
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.skipif(
+    not _HAS_WORKING_BASH,
+    reason="no working bash (WindowsApps shim does not count)",
+)
 def test_run_job_no_agent_success_returns_script_stdout(hermes_env):
     """Happy path: script exits 0 with output, delivered verbatim."""
     from cron.jobs import create_job
@@ -106,6 +149,10 @@ def test_run_job_no_agent_success_returns_script_stdout(hermes_env):
     assert "RAM 92% on host" in doc
 
 
+@pytest.mark.skipif(
+    not _HAS_WORKING_BASH,
+    reason="no working bash (WindowsApps shim does not count)",
+)
 def test_run_job_no_agent_reloads_dotenv_before_script(hermes_env, monkeypatch):
     """Regression: a standalone cron tick process starts without home-channel
     vars in its environment, and the agent path's per-run dotenv reload never

--- a/tests/cron/test_cron_no_agent.py
+++ b/tests/cron/test_cron_no_agent.py
@@ -21,6 +21,10 @@ from unittest.mock import patch
 import pytest
 
 
+import functools
+
+
+@functools.lru_cache(maxsize=1)
 def _has_working_bash() -> bool:
     """True when bash can actually execute a script given a Windows path.
 
@@ -30,7 +34,8 @@ def _has_working_bash() -> bool:
     - Git Bash handles Windows paths fine.
 
     Probe by running a real script file through bash and requiring its
-    stdout to come back (see #86830).
+    stdout to come back (see #86830). Cached so the subprocess probe runs
+    once per process even if the module is imported multiple times.
     """
     import os
     import tempfile

--- a/tests/gateway/test_status.py
+++ b/tests/gateway/test_status.py
@@ -299,7 +299,11 @@ class TestGetProcessStartTime:
     def test_live_process_is_stable_int(self):
         import subprocess
         import time
-        p = subprocess.Popen(["sleep", "20"])
+        # `sleep` does not exist on Windows; use the interpreter itself so
+        # the test stays cross-platform (see #86830).
+        p = subprocess.Popen(
+            [sys.executable, "-c", "import time; time.sleep(20)"]
+        )
         try:
             a = status._get_process_start_time(p.pid)
             time.sleep(0.2)
@@ -869,6 +873,10 @@ class TestPlannedStopMarker:
 class TestReadProcessCmdlinePsFallback:
     """Tests for _read_process_cmdline falling back to ps on non-Linux."""
 
+    @pytest.mark.skipif(
+        sys.platform == "win32",
+        reason="ps fallback is POSIX-only; Windows uses the psutil path",
+    )
     def test_ps_fallback_when_proc_unavailable(self, monkeypatch):
         monkeypatch.setattr(status.Path, "read_bytes", lambda self: (_ for _ in ()).throw(FileNotFoundError))
         monkeypatch.setattr(

--- a/tests/secret_sources/test_secret_source_registry.py
+++ b/tests/secret_sources/test_secret_source_registry.py
@@ -97,12 +97,17 @@ class TestRegistration:
 
     def test_same_name_is_isolated_by_profile(self, tmp_path):
         from hermes_constants import (
+            hermes_home_key,
             reset_hermes_home_override,
             set_hermes_home_override,
         )
 
-        home_a = str((tmp_path / "secrets-a").resolve())
-        home_b = str((tmp_path / "secrets-b").resolve())
+        # Scope keys are the normalized hermes_home_key() form (the plugin
+        # path and apply_all both use it). A raw path string would differ
+        # from the normalized form on Windows (normcase lowercases), making
+        # get_source() miss the scoped registration — see #86830.
+        home_a = hermes_home_key(tmp_path / "secrets-a")
+        home_b = hermes_home_key(tmp_path / "secrets-b")
         source_a = _make_source(name="profile_secret", secrets={"A": "a"})
         source_b = _make_source(name="profile_secret", secrets={"B": "b"})
         assert reg.register_source(source_a, scope=home_a)

--- a/tests/test_bitwarden_secrets.py
+++ b/tests/test_bitwarden_secrets.py
@@ -94,7 +94,9 @@ def test_platform_asset_name(system, machine, libc_text, expected):
 def _make_fake_zip(binary_bytes: bytes) -> bytes:
     buf = io.BytesIO()
     with zipfile.ZipFile(buf, "w") as zf:
-        zf.writestr("bws", binary_bytes)
+        # Member name must match what install_bws looks up on this platform
+        # (_platform_binary_name() is "bws.exe" on Windows) — see #86830.
+        zf.writestr(bw._platform_binary_name(), binary_bytes)
     return buf.getvalue()
 
 
@@ -157,8 +159,10 @@ def test_install_bws_happy_path(hermes_home, monkeypatch):
     path = bw.install_bws()
     assert path.exists()
     assert path.read_bytes() == fake_binary
-    # Executable bit set
-    assert path.stat().st_mode & stat.S_IXUSR
+    # Executable bit set. NTFS does not reflect POSIX modes, so the assertion
+    # only holds on POSIX hosts (CONTRIBUTING: mode assertions skip on win32).
+    if sys.platform != "win32":
+        assert path.stat().st_mode & stat.S_IXUSR
 
 
 
@@ -370,8 +374,11 @@ def test_encrypted_cache_writes_without_plaintext(monkeypatch, tmp_path):
     assert not bw._disk_cache_path(home).exists()
     cache_path = bw._encrypted_disk_cache_path(home)
     assert cache_path.exists()
-    mode = stat.S_IMODE(os.stat(cache_path).st_mode)
-    assert mode == 0o600, f"expected 0o600, got 0o{mode:o}"
+    # NTFS does not enforce POSIX modes (files land at 0o666), so the 0o600
+    # assertion only holds on POSIX hosts (CONTRIBUTING) — see #86830.
+    if sys.platform != "win32":
+        mode = stat.S_IMODE(os.stat(cache_path).st_mode)
+        assert mode == 0o600, f"expected 0o600, got 0o{mode:o}"
     text = cache_path.read_text()
     assert "secret-value" not in text
     assert "0.t" not in text


### PR DESCRIPTION
﻿## What does this PR do?

Fixes five tests that fail on native Windows for environmental reasons (all pass on Linux CI; verified identical on baseline main with the fixes stashed — none mask a product bug):

1. **`test_secret_source_registry.py::test_same_name_is_isolated_by_profile`** — passed raw path strings as registration scopes, but the registry contract is the normalized `hermes_home_key()` form (`os.path.normcase` is the identity on Linux, so this only broke on Windows where `C:\Users\...` != `c:\users\...`). The test now normalizes with `hermes_home_key()`.
2. **`test_bitwarden_secrets.py::test_encrypted_cache_writes_without_plaintext`** — the `0o600` assertion cannot hold on NTFS (files land at 0o666). Gated on `sys.platform != "win32"` per CONTRIBUTING.
3. **`test_bitwarden_secrets.py::test_install_bws_happy_path`** — `_make_fake_zip` hardcoded the member name `bws`, but `install_bws` looks up `_platform_binary_name()` (`bws.exe` on Windows), so install failed. Also gated the `S_IXUSR` assertion (NTFS).
4. **`test_cron_no_agent.py`** — the two `.sh`-script tests need a bash that can execute a Windows-path script; the WindowsApps/WSL shim resolves on PATH and even echoes, but exits 127 on Windows paths (see #62514). Added a `_has_working_bash()` probe that runs a real script file and requires its stdout; both tests skip when it fails.
5. **`test_status.py`** — `test_live_process_is_stable_int` spawned `["sleep", "20"]` (no `sleep` on Windows); now uses the interpreter itself, keeping the test cross-platform. `test_ps_fallback_when_proc_unavailable` exercises the POSIX-only `ps` fallback (Windows uses the psutil path); marked `skipif win32`.

## Related Issue

Fixes #86830

## Type of Change

- [x] ✅ Tests (fixing platform-gating so the suite is green for native Windows contributors, per #84437's goal)

## Changes Made

- `tests/secret_sources/test_secret_source_registry.py`
- `tests/test_bitwarden_secrets.py`
- `tests/cron/test_cron_no_agent.py`
- `tests/gateway/test_status.py`

## How to Test

On native Windows: `pytest tests/secret_sources/test_secret_source_registry.py tests/test_bitwarden_secrets.py tests/cron/test_cron_no_agent.py tests/gateway/test_status.py -q` → 116 passed, 3 skipped. The one remaining failure in this file set (`test_run_job_script_nul_path_fails_cleanly`) is a product bug fixed by #86832 (separate PR), not a test-environment issue.

On Linux CI: the previously-passing tests still pass (gates only relax on win32 / no-bash).

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run pytest and all tests pass
- [x] I've added tests for my changes (platform gating)
- [x] I've tested on my platform: Windows 11, Python 3.11

### Documentation & Housekeeping

- [x] N/A for docs/config example
- [x] N/A for tool descriptions/schemas
