### PR TITLE
fix(desktop): claim Ctrl/Cmd+F via before-input-event so Pop!_OS / GNOME doesn't eat it (salvage #81781)

### DIFF
--- a/apps/desktop/electron/find-in-page.test.ts
+++ b/apps/desktop/electron/find-in-page.test.ts
@@ -7,6 +7,7 @@
 import assert from 'node:assert/strict'
 import { EventEmitter } from 'node:events'
 
+import type { BrowserWindow } from 'electron'
 import { describe, test } from 'vitest'
 
 import { formatFoundInPage, installFindShortcut, installFoundInPageForwarder, performFind, stopFind } from './find-in-page'
@@ -225,7 +226,7 @@ describe('installFoundInPageForwarder', () => {
 describe('installFindShortcut', () => {
   // Minimal BrowserWindow stub: only `webContents` is touched.
   function makeFakeWindow(wc: FakeWebContents) {
-    return { webContents: asWC(wc) } as unknown as import('electron').BrowserWindow
+    return { webContents: asWC(wc) } as unknown as BrowserWindow
   }
 
   test('sends hermes:open-find-bar on Ctrl+F (Linux/Windows) and prevents default', () => {

--- a/apps/desktop/electron/find-in-page.test.ts
+++ b/apps/desktop/electron/find-in-page.test.ts
@@ -253,15 +253,39 @@ describe('installFindShortcut', () => {
     uninstall()
   })
 
-  test('sends hermes:open-find-bar on Cmd+F (macOS primary accelerator)', () => {
+  // macOS branch: inject `isMac: () => true` so we exercise the REAL
+  // `meta` (Cmd) path — previously untested, because `process.platform` is
+  // baked at import time and the old "Cmd+F" case actually sent Ctrl.
+  test('sends hermes:open-find-bar on Cmd+F (meta) on macOS and prevents default', () => {
     const wc = makeFakeWebContents()
     const win = makeFakeWindow(wc)
-    const uninstall = installFindShortcut(win)
+    const uninstall = installFindShortcut(win, () => true)
 
-    // On macOS, Cmd is `meta`. We can't flip IS_MAC at runtime in the
-    // module under test, but the helper also accepts literal Ctrl on macOS
-    // so a non-macOS layout still works — verify the macOS-equivalent
-    // chord via Ctrl here (the macOS-specific Cmd path is a thin alias).
+    // Cmd+F on macOS: meta held, no control/alt/shift.
+    wc.emit('before-input-event', {}, {
+      key: 'f',
+      control: false,
+      meta: true,
+      alt: false,
+      shift: false,
+    })
+
+    assert.deepEqual(wc.calls.send, [
+      { channel: 'hermes:open-find-bar', payload: undefined }
+    ])
+
+    uninstall()
+  })
+
+  // The design intentionally accepts literal Ctrl on macOS too (dual-channel)
+  // so a non-macOS layout still works. Pin that behavior so the width of the
+  // chord doesn't silently drift.
+  test('accepts literal Ctrl+F on macOS (dual-channel with Cmd)', () => {
+    const wc = makeFakeWebContents()
+    const win = makeFakeWindow(wc)
+    const uninstall = installFindShortcut(win, () => true)
+
+    // Ctrl+F with no meta on macOS still opens the FindBar.
     wc.emit('before-input-event', {}, {
       key: 'F',
       control: true,
@@ -270,8 +294,30 @@ describe('installFindShortcut', () => {
       shift: false,
     })
 
-    assert.equal(wc.calls.send.length, 1)
-    assert.equal(wc.calls.send[0].channel, 'hermes:open-find-bar')
+    assert.deepEqual(wc.calls.send, [
+      { channel: 'hermes:open-find-bar', payload: undefined }
+    ])
+
+    uninstall()
+  })
+
+  // Cross-check: a bare Ctrl+F WITHOUT meta must NOT open on Linux/Windows,
+  // where only `control` counts (the macOS `meta || control` widening must not
+  // leak across the platform boundary).
+  test('does NOT fire for Ctrl+F with meta only on Linux/Windows', () => {
+    const wc = makeFakeWebContents()
+    const win = makeFakeWindow(wc)
+    const uninstall = installFindShortcut(win, () => false)
+
+    wc.emit('before-input-event', {}, {
+      key: 'f',
+      control: false,
+      meta: true,
+      alt: false,
+      shift: false,
+    })
+
+    assert.equal(wc.calls.send.length, 0, 'meta (Cmd) is not a valid chord on non-macOS')
 
     uninstall()
   })

--- a/apps/desktop/electron/find-in-page.test.ts
+++ b/apps/desktop/electron/find-in-page.test.ts
@@ -9,7 +9,7 @@ import { EventEmitter } from 'node:events'
 
 import { describe, test } from 'vitest'
 
-import { formatFoundInPage, installFoundInPageForwarder, performFind, stopFind } from './find-in-page'
+import { formatFoundInPage, installFindShortcut, installFoundInPageForwarder, performFind, stopFind } from './find-in-page'
 
 // Minimal webContents stub. The Electron.WebContents type is huge, so we
 // model just the slice the helpers touch (`isDestroyed`, `findInPage`,
@@ -218,5 +218,140 @@ describe('installFoundInPageForwarder', () => {
       { channel: 'hermes:found-in-page', payload: { activeMatchOrdinal: 1, count: 1 } }
     ])
     assert.equal(wcB.calls.send.length, 0, 'wcB must not receive wcA results')
+  })
+})
+
+
+describe('installFindShortcut', () => {
+  // Minimal BrowserWindow stub: only `webContents` is touched.
+  function makeFakeWindow(wc: FakeWebContents) {
+    return { webContents: asWC(wc) } as unknown as import('electron').BrowserWindow
+  }
+
+  test('sends hermes:open-find-bar on Ctrl+F (Linux/Windows) and prevents default', () => {
+    const wc = makeFakeWebContents()
+    const win = makeFakeWindow(wc)
+    const uninstall = installFindShortcut(win)
+
+    // Ctrl+F on Linux/Windows (no meta, no alt, no shift).
+    const result = wc.emit('before-input-event', {}, {
+      key: 'f',
+      control: true,
+      meta: false,
+      alt: false,
+      shift: false,
+    })
+    // The listener calls preventDefault on the event; the fake's emit returns
+    // truthy because the event fired — what matters is the side effects.
+    void result
+
+    assert.deepEqual(wc.calls.send, [
+      { channel: 'hermes:open-find-bar', payload: undefined }
+    ])
+
+    uninstall()
+  })
+
+  test('sends hermes:open-find-bar on Cmd+F (macOS primary accelerator)', () => {
+    const wc = makeFakeWebContents()
+    const win = makeFakeWindow(wc)
+    const uninstall = installFindShortcut(win)
+
+    // On macOS, Cmd is `meta`. We can't flip IS_MAC at runtime in the
+    // module under test, but the helper also accepts literal Ctrl on macOS
+    // so a non-macOS layout still works — verify the macOS-equivalent
+    // chord via Ctrl here (the macOS-specific Cmd path is a thin alias).
+    wc.emit('before-input-event', {}, {
+      key: 'F',
+      control: true,
+      meta: false,
+      alt: false,
+      shift: false,
+    })
+
+    assert.equal(wc.calls.send.length, 1)
+    assert.equal(wc.calls.send[0].channel, 'hermes:open-find-bar')
+
+    uninstall()
+  })
+
+  test('does NOT fire for plain F without Ctrl/Cmd', () => {
+    const wc = makeFakeWebContents()
+    const win = makeFakeWindow(wc)
+    const uninstall = installFindShortcut(win)
+
+    wc.emit('before-input-event', {}, {
+      key: 'f',
+      control: false,
+      meta: false,
+      alt: false,
+      shift: false,
+    })
+
+    assert.equal(wc.calls.send.length, 0, 'plain F must not open the FindBar')
+
+    uninstall()
+  })
+
+  test('does NOT fire for Ctrl+Shift+F (different chord)', () => {
+    const wc = makeFakeWebContents()
+    const win = makeFakeWindow(wc)
+    const uninstall = installFindShortcut(win)
+
+    wc.emit('before-input-event', {}, {
+      key: 'f',
+      control: true,
+      meta: false,
+      alt: false,
+      shift: true,
+    })
+
+    assert.equal(wc.calls.send.length, 0, 'Ctrl+Shift+F is reserved (session.focusSearch)')
+
+    uninstall()
+  })
+
+  test('does NOT fire for Ctrl+F with Alt held (combo change)', () => {
+    const wc = makeFakeWebContents()
+    const win = makeFakeWindow(wc)
+    const uninstall = installFindShortcut(win)
+
+    wc.emit('before-input-event', {}, {
+      key: 'f',
+      control: true,
+      meta: false,
+      alt: true,
+      shift: false,
+    })
+
+    assert.equal(wc.calls.send.length, 0)
+
+    uninstall()
+  })
+
+  test('uninstall detaches the listener', () => {
+    const wc = makeFakeWebContents()
+    const win = makeFakeWindow(wc)
+    const uninstall = installFindShortcut(win)
+    uninstall()
+
+    wc.emit('before-input-event', {}, {
+      key: 'f',
+      control: true,
+      meta: false,
+      alt: false,
+      shift: false,
+    })
+
+    assert.equal(wc.calls.send.length, 0, 'listener must be detached after uninstall()')
+  })
+
+  test('is a no-op on a destroyed webContents', () => {
+    const wc = makeFakeWebContents()
+    wc.destroy()
+    const win = makeFakeWindow(wc)
+    // Should not throw — uninstall is the no-op fn returned in this branch.
+    const uninstall = installFindShortcut(win)
+    assert.doesNotThrow(() => uninstall())
   })
 })

--- a/apps/desktop/electron/find-in-page.ts
+++ b/apps/desktop/electron/find-in-page.ts
@@ -135,11 +135,14 @@ export function installFoundInPageForwarder(webContents: Electron.WebContents | 
  * `webContents.findInPage`). This helper just guarantees that a Ctrl/Cmd+F
  * press reaches that pipeline.
  *
+ * `isMac` is injectable so the macOS-modifier branch can be exercised by
+ * unit tests without rebooting the process under a different platform.
+ *
  * Returns an uninstall fn that detaches the listener.
  */
-const IS_MAC = process.platform === 'darwin'
+const IS_MAC = () => process.platform === 'darwin'
 
-export function installFindShortcut(window: Electron.BrowserWindow): () => void {
+export function installFindShortcut(window: Electron.BrowserWindow, isMac: () => boolean = IS_MAC): () => void {
   const { webContents } = window
   if (!webContents || webContents.isDestroyed()) {
     return () => {}
@@ -155,7 +158,7 @@ export function installFindShortcut(window: Electron.BrowserWindow): () => void 
     // is on a non-macOS layout. On Pop!_OS / GNOME the GTK compositor owns
     // Ctrl+F before the renderer's keydown fires — this main-process handler
     // runs strictly before that (#81727).
-    const hasMod = IS_MAC ? input.meta || input.control : input.control
+    const hasMod = isMac() ? input.meta || input.control : input.control
     const isFindChord =
       key === 'f' &&
       hasMod &&

--- a/apps/desktop/electron/find-in-page.ts
+++ b/apps/desktop/electron/find-in-page.ts
@@ -118,3 +118,63 @@ export function installFoundInPageForwarder(webContents: Electron.WebContents | 
     webContents.off('found-in-page', handler)
   }
 }
+
+/**
+ * Install a main-process before-input-event hook that claims Ctrl/Cmd+F and
+ * forwards an "open the find bar" intent to the renderer.
+ *
+ * On Pop!_OS / GNOME-based Linux distros, the GTK compositor intercepts
+ * Ctrl+F at the windowing layer (GNOME Files owns it) before the renderer
+ * ever sees a keydown — so the renderer's own `view.findInPage` keybind is
+ * silently dead even though the binding is registered (#81727). Claiming
+ * the chord in the main process via `before-input-event` runs strictly
+ * before the GTK shortcut can grab it on these distros.
+ *
+ * The renderer's existing find-in-page pipeline still does the actual work
+ * (it owns the FindBar UI, the store, the `hermes:find-in-page` IPC to drive
+ * `webContents.findInPage`). This helper just guarantees that a Ctrl/Cmd+F
+ * press reaches that pipeline.
+ *
+ * Returns an uninstall fn that detaches the listener.
+ */
+const IS_MAC = process.platform === 'darwin'
+
+export function installFindShortcut(window: Electron.BrowserWindow): () => void {
+  const { webContents } = window
+  if (!webContents || webContents.isDestroyed()) {
+    return () => {}
+  }
+
+  const handler = (event: Electron.Event, input: Electron.Input) => {
+    if (!webContents || webContents.isDestroyed()) {
+      return
+    }
+    const key = String(input.key || '').toLowerCase()
+    // Accept the platform's primary accelerator (Cmd on macOS, Ctrl elsewhere)
+    // AND literal Ctrl on macOS so the chord still reaches us when the user
+    // is on a non-macOS layout. On Pop!_OS / GNOME the GTK compositor owns
+    // Ctrl+F before the renderer's keydown fires — this main-process handler
+    // runs strictly before that (#81727).
+    const hasMod = IS_MAC ? input.meta || input.control : input.control
+    const isFindChord =
+      key === 'f' &&
+      hasMod &&
+      !input.alt &&
+      !input.shift
+    if (!isFindChord) {
+      return
+    }
+    if (typeof event.preventDefault === 'function') {
+      event.preventDefault()
+    }
+    webContents.send('hermes:open-find-bar')
+  }
+
+  webContents.on('before-input-event', handler)
+
+  return () => {
+    if (!webContents.isDestroyed()) {
+      webContents.off('before-input-event', handler)
+    }
+  }
+}

--- a/apps/desktop/electron/find-in-page.ts
+++ b/apps/desktop/electron/find-in-page.ts
@@ -123,17 +123,23 @@ export function installFoundInPageForwarder(webContents: Electron.WebContents | 
  * Install a main-process before-input-event hook that claims Ctrl/Cmd+F and
  * forwards an "open the find bar" intent to the renderer.
  *
- * On Pop!_OS / GNOME-based Linux distros, the GTK compositor intercepts
- * Ctrl+F at the windowing layer (GNOME Files owns it) before the renderer
- * ever sees a keydown — so the renderer's own `view.findInPage` keybind is
- * silently dead even though the binding is registered (#81727). Claiming
- * the chord in the main process via `before-input-event` runs strictly
- * before the GTK shortcut can grab it on these distros.
+ * Linux only (#81727): on Pop!_OS / GNOME-based distros the Ctrl+F keydown
+ * does not reach the renderer's `view.findInPage` binding, so the find bar
+ * stays closed. Routing the chord through `before-input-event` (which Chromium
+ * dispatches before the DOM keydown) lets us forward the intent directly.
+ * The exact interception layer varies by distro/desktop (COSMIC shortcut,
+ * webview focus split, etc.); this sidesteps it regardless of cause by acting
+ * at the earliest point the keystroke is observable.
+ *
+ * On macOS / Windows the renderer's own rebindable `view.findInPage` keybind
+ * (`mod+f`, clearable/rebindable via the keybind registry) owns Ctrl/Cmd+F, so
+ * the main-process hook is NOT installed there — installing it would make the
+ * chord un-rebindable and double-open on a rebound binding.
  *
  * The renderer's existing find-in-page pipeline still does the actual work
  * (it owns the FindBar UI, the store, the `hermes:find-in-page` IPC to drive
  * `webContents.findInPage`). This helper just guarantees that a Ctrl/Cmd+F
- * press reaches that pipeline.
+ * press reaches that pipeline on Linux.
  *
  * `isMac` is injectable so the macOS-modifier branch can be exercised by
  * unit tests without rebooting the process under a different platform.

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -115,7 +115,7 @@ import {
   tuiResumeArgs
 } from './external-terminal'
 import { findGitBash as _findGitBash } from './find-git-bash'
-import { installFoundInPageForwarder, performFind, stopFind } from './find-in-page'
+import { installFindShortcut, installFoundInPageForwarder, performFind, stopFind } from './find-in-page'
 import { createFirstRunSetupGate } from './first-run-setup-gate'
 import { readDirForIpc } from './fs-read-dir'
 import {
@@ -9866,6 +9866,13 @@ async function startHermes() {
 function wireCommonWindowHandlers(win, { zoom = true }: { zoom?: boolean } = {}) {
   installPreviewShortcut(win)
   installDevToolsShortcut(win)
+  // Claim Ctrl/Cmd+F in the main process — on Pop!_OS / GNOME-based Linux
+  // distros the GTK compositor grabs Ctrl+F at the windowing layer before
+  // the renderer's keydown listener fires (#81727). Routing it through
+  // `before-input-event` strictly precedes that compositor shortcut, and
+  // the renderer's find-in-page pipeline still owns the FindBar UI and the
+  // search itself.
+  installFindShortcut(win)
 
   if (zoom) {
     installZoomShortcuts(win)

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -9867,12 +9867,14 @@ function wireCommonWindowHandlers(win, { zoom = true }: { zoom?: boolean } = {})
   installPreviewShortcut(win)
   installDevToolsShortcut(win)
   // Claim Ctrl/Cmd+F in the main process — on Pop!_OS / GNOME-based Linux
-  // distros the GTK compositor grabs Ctrl+F at the windowing layer before
-  // the renderer's keydown listener fires (#81727). Routing it through
-  // `before-input-event` strictly precedes that compositor shortcut, and
-  // the renderer's find-in-page pipeline still owns the FindBar UI and the
-  // search itself.
-  installFindShortcut(win)
+  // distros the Ctrl+F keydown does not reach the renderer's `view.findInPage`
+  // binding (#81727). Routing it through `before-input-event` forwards the
+  // intent at the earliest observable point. macOS / Windows keep the
+  // renderer's own rebindable keybind, so the hook is Linux-only: installing
+  // it elsewhere would make Ctrl/Cmd+F un-rebindable and double-open.
+  if (process.platform === 'linux') {
+    installFindShortcut(win)
+  }
 
   if (zoom) {
     installZoomShortcuts(win)

--- a/apps/desktop/electron/preload.ts
+++ b/apps/desktop/electron/preload.ts
@@ -406,5 +406,14 @@ contextBridge.exposeInMainWorld('hermesDesktop', {
     ipcRenderer.on('hermes:found-in-page', listener)
 
     return () => ipcRenderer.removeListener('hermes:found-in-page', listener)
+  },
+  // Main-process `before-input-event` forwards Ctrl/Cmd+F here so renderer
+  // can open the FindBar even when the GTK compositor has already grabbed
+  // the chord at the windowing layer (#81727).
+  onOpenFindBarRequested: callback => {
+    const listener = () => callback()
+    ipcRenderer.on('hermes:open-find-bar', listener)
+
+    return () => ipcRenderer.removeListener('hermes:open-find-bar', listener)
   }
 })

--- a/apps/desktop/src/components/find-bar.tsx
+++ b/apps/desktop/src/components/find-bar.tsx
@@ -12,6 +12,7 @@ import {
   findNext,
   findPrevious,
   initFindInPageListener,
+  initOpenFindBarListener,
   setFindQuery
 } from '@/store/find-in-page'
 
@@ -71,6 +72,11 @@ export function FindBar() {
   // subscription is deliberately mount-scoped and NOT tied to `active` —
   // results for an in-flight search must still land if the bar just closed.
   useEffect(() => initFindInPageListener(), [])
+
+  // Mirror the find-results listener for the main-process Ctrl/Cmd+F
+  // forward — on Pop!_OS / GNOME the GTK compositor grabs the chord at
+  // the windowing layer (#81727).
+  useEffect(() => initOpenFindBarListener(), [])
 
   // Debounce search — fire findInPage 200ms after the user stops typing.
   useEffect(() => {

--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -378,6 +378,10 @@ declare global {
       findInPage: (query: string, options?: { forward?: boolean; findNext?: boolean }) => Promise<{ count: number }>
       stopFindInPage: () => Promise<void>
       onFoundInPage: (callback: (result: { activeMatchOrdinal: number; count: number }) => void) => () => void
+      // Main-process `before-input-event` forwards Ctrl/Cmd+F here so the
+      // renderer can still open the FindBar when the OS compositor has
+      // already grabbed the chord (#81727, e.g. Pop!_OS / GNOME).
+      onOpenFindBarRequested: (callback: () => void) => () => void
     }
   }
 }

--- a/apps/desktop/src/store/find-in-page.ts
+++ b/apps/desktop/src/store/find-in-page.ts
@@ -128,3 +128,49 @@ export function resetFindInPageListenerForTest(): void {
   detachListener = undefined
   listenerRefs = 0
 }
+
+// Same refcount pattern as `initFindInPageListener`, but for the
+// "main-process Ctrl/Cmd+F forwarded to renderer" channel. On Pop!_OS /
+// GNOME-based Linux distros the GTK compositor grabs Ctrl+F before the
+// renderer's keydown listener can fire — the main process intercepts the
+// chord via `before-input-event` and emits this IPC, so the renderer can
+// still open the FindBar (#81727).
+let openFindBarRefs = 0
+let detachOpenFindBar: (() => void) | undefined
+
+export function initOpenFindBarListener(): () => void {
+  openFindBarRefs += 1
+
+  if (openFindBarRefs === 1) {
+    detachOpenFindBar = window.hermesDesktop?.onOpenFindBarRequested?.(() => {
+      openFindBar()
+    })
+  }
+
+  let released = false
+
+  return () => {
+    if (released) {
+      return
+    }
+    released = true
+    openFindBarRefs -= 1
+
+    if (openFindBarRefs === 0) {
+      detachOpenFindBar?.()
+      detachOpenFindBar = undefined
+    }
+  }
+}
+
+/** Test seam: number of live "open find bar" subscriptions. */
+export function openFindBarListenerCount(): number {
+  return openFindBarRefs
+}
+
+/** Test seam: detach the open-find-bar bridge listener and zero the refcount. */
+export function resetOpenFindBarListenerForTest(): void {
+  detachOpenFindBar?.()
+  detachOpenFindBar = undefined
+  openFindBarRefs = 0
+}

--- a/apps/desktop/src/store/find-in-page.ts
+++ b/apps/desktop/src/store/find-in-page.ts
@@ -153,6 +153,7 @@ export function initOpenFindBarListener(): () => void {
     if (released) {
       return
     }
+
     released = true
     openFindBarRefs -= 1
 


### PR DESCRIPTION
Salvaged from #81781 by @Enough1122 — all four contributor commits cherry-picked onto current main with authorship preserved. Fixes #81727.

## Problem

On Pop!_OS / GNOME-based Linux distros the Ctrl+F keydown never reaches the renderer, so the rebindable `view.findInPage` keybind (`mod+f`, registered in the renderer keybind registry) is silently dead even though find works from the menu (#81727).

## Fix (mechanism: `before-input-event`, NOT `globalShortcut`)

`installFindShortcut(window)` in `apps/desktop/electron/find-in-page.ts` attaches a **window-scoped** `webContents.on('before-input-event')` handler — Chromium dispatches this in the main process before the DOM keydown, i.e. before whatever DE/webview layer starves the renderer listener. On a Ctrl/Cmd+F chord it calls `event.preventDefault()` and sends `hermes:open-find-bar` IPC; the renderer's existing find-in-page pipeline (FindBar UI, store, `webContents.findInPage`) does all the actual work.

- **No `globalShortcut`** — nothing is stolen system-wide; the hook only fires for input delivered to this window's webContents.
- **Linux-only install** (`process.platform === 'linux'` in `wireCommonWindowHandlers`) — macOS/Windows keep the renderer's own rebindable keybind, so the chord stays rebindable/clearable there.
- **No double-fire**: on Linux the handler `preventDefault()`s the input, so the renderer keydown (and thus the `view.findInPage` binding) never sees the chord — exactly one path delivers. On macOS/Windows the hook isn't installed, so only the renderer path exists. `openFindBar()` is also idempotent (resets the store to `{active: true}`).
- IPC listener uses the same refcounted attach pattern as the existing `initFindInPageListener`, with test seams.

## Interaction with #81778

Sibling PR #81778 (scope find-in-page to the active view) also touches `src/store/find-in-page.ts`. This salvage only appends new exports at the end of that file; overlap is trivial to reconcile whichever lands second.

## Salvage delta

One `style:` follow-up commit fixing a `padding-line-between-statements` lint warning introduced in the new store code. No behavioral changes on top of the contributor's work.

## Tests

- `apps/desktop`: `npm run check:lint` (tsc ×3 + eslint) — 0 errors
- `npx vitest run electron/find-in-page.test.ts src/components/find-bar.test.tsx` — 77/77 pass (incl. 9 new `installFindShortcut` tests: chord matching per platform, macOS dual-channel Cmd/Ctrl, negative chords, uninstall, destroyed webContents)
- `npm run test:desktop:platforms` — 1180 passed, 2 skipped
- `python3 scripts/audit_pr_attribution.py --fix` — all contributor emails mapped

## Infographic

![Ctrl+F Reclaimed](https://files.catbox.moe/dw6uvu.png)
