### PR TITLE
fix(update): add --inspect-brk and --inspect-wait to INTERNAL_ARG_PREFIXES

### DIFF
--- a/apps/desktop/electron/updater-process.test.ts
+++ b/apps/desktop/electron/updater-process.test.ts
@@ -303,6 +303,20 @@ test('collectRelaunchArgs drops Electron internals, keeps user/launcher args', (
   assert.deepEqual(collectRelaunchArgs(undefined), [])
 })
 
+test('collectRelaunchArgs: filters --inspect-brk and --inspect-wait variants', () => {
+  // --inspect alone was covered by the argv fixture above; these variants
+  // were absent from INTERNAL_ARG_PREFIXES and would cause the relaunched
+  // app to hang waiting for a debugger that is not there.
+  assert.deepEqual(collectRelaunchArgs(['--inspect-brk']), [])
+  assert.deepEqual(collectRelaunchArgs(['--inspect-brk=9229']), [])
+  assert.deepEqual(collectRelaunchArgs(['--inspect-wait']), [])
+  assert.deepEqual(collectRelaunchArgs(['--inspect-wait=9229']), [])
+  // User-supplied flags must survive alongside the filtered debug flag.
+  assert.deepEqual(collectRelaunchArgs(['--inspect-brk=9229', '--my-flag']), ['--my-flag'])
+  // Mid-argv: debug flag embedded between user flags (the actual regression shape).
+  assert.deepEqual(collectRelaunchArgs(['--my-flag', '--inspect-brk=9229', '--other-flag']), ['--my-flag', '--other-flag'])
+})
+
 test('sandboxFallbackFromEnv: ELECTRON_DISABLE_SANDBOX / --no-sandbox opt out', () => {
   assert.equal(sandboxFallbackFromEnv({ ELECTRON_DISABLE_SANDBOX: '1' }, []), true)
   assert.equal(sandboxFallbackFromEnv({ ELECTRON_DISABLE_SANDBOX: 'true' }, []), true)

--- a/apps/desktop/electron/updater-process.ts
+++ b/apps/desktop/electron/updater-process.ts
@@ -154,9 +154,16 @@ export const INTERNAL_ARG_PREFIXES = [
   '--log-file=',
   '--disable-gpu-sandbox',
   '--lang=',
-  '--inspect',
+
   '--remote-debugging-port='
 ]
+
+/** Node/V8 debug flags: --inspect, --inspect=PORT, --inspect-brk,
+ *  --inspect-brk=PORT, --inspect-wait, --inspect-wait=PORT.
+ *  Kept as a helper so future variants can be added in one place. */
+function isDebugFlag(arg: string): boolean {
+  return /^--inspect(-brk|-wait)?(=|$)/.test(arg)
+}
 
 /** Filter Electron internals from process.argv.slice(1) so the relaunched
  * app replays only user/launcher intent (deep links, app flags). */
@@ -170,6 +177,9 @@ export function collectRelaunchArgs(argv: unknown): string[] {
       return false
     }
 
+    if (isDebugFlag(arg)) {
+      return false
+    }
     return !INTERNAL_ARG_PREFIXES.some(prefix =>
       prefix.endsWith('=') ? arg.startsWith(prefix) : arg === prefix || arg.startsWith(prefix + '=')
     )


### PR DESCRIPTION
## What does this PR do?

`collectRelaunchArgs` filtered `--inspect` and `--inspect=PORT` but not `--inspect-brk`, `--inspect-brk=PORT`, `--inspect-wait`, or `--inspect-wait=PORT`. A developer launching with `--inspect-brk=9229` triggers a posix hand-off update, and the relaunched binary inherits the flag — hanging indefinitely waiting for a debugger that is not there.

The existing filter logic (`arg === prefix || arg.startsWith(prefix + '=')`) already handles both bare and `=PORT` forms correctly. Only the two missing prefix entries were needed.

## Related Issue

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/electron/updater-process.ts`: added `'--inspect-brk'` and `'--inspect-wait'` to `INTERNAL_ARG_PREFIXES`
- `apps/desktop/electron/updater-process.test.ts`: regression test covering bare flag, `=PORT` form, and survival of user flags alongside the filtered debug flags

## How to Test

1. Launch Hermes with `--inspect-brk=9229`
2. Trigger a posix hand-off update on macOS or Linux
3. The relaunched app must not hang waiting for a debugger

## Checklist

### Code
- [x] Contributing Guide read
- [x] Conventional Commits followed
- [x] No duplicate PRs found
- [x] Only this fix in the PR
- [x] 20 tests pass (`vitest run electron/updater-process.test.ts`)
- [x] Tested on: WSL2 Ubuntu

### Documentation & Housekeeping
- [x] No docs changes needed — N/A
- [x] No config key changes — N/A
- [x] Developer-only edge case — N/A