### PR TITLE
fix(desktop): position find bar clear of the files pane when open (salvage of #82896)

### DIFF
--- a/apps/desktop/src/components/find-bar.test.tsx
+++ b/apps/desktop/src/components/find-bar.test.tsx
@@ -610,3 +610,60 @@ describe('FindBar', () => {
     expect(bridge.stopFindInPage).not.toHaveBeenCalled()
   })
 })
+
+// ── Files-pane-aware positioning ────────────────────────────────────────────
+
+describe('FindBar files pane positioning', () => {
+  function mountAside(width = 240) {
+    // eslint-disable-next-line no-restricted-globals -- the component queries the live document for the aside
+    const aside = document.createElement('aside')
+    aside.setAttribute('aria-label', 'Right sidebar')
+    // jsdom has no layout — stub the rect the component measures.
+    aside.getBoundingClientRect = () =>
+      ({ left: window.innerWidth - width, width } as DOMRect)
+    // eslint-disable-next-line no-restricted-globals -- must land in the real DOM the component measures
+    document.body.appendChild(aside)
+
+    return aside
+  }
+
+  afterEach(() => {
+    // eslint-disable-next-line no-restricted-globals -- cleanup of the real DOM the component measures
+    for (const aside of document.querySelectorAll('aside[aria-label="Right sidebar"]')) {
+      aside.remove()
+    }
+  })
+
+  it('keeps the default right-4 position when the pane is closed', async () => {
+    openFindBar()
+    renderFindBar()
+
+    const bar = await screen.findByRole('search')
+    expect(bar.style.right).toBe('')
+  })
+
+  it('parks the bar left of the pane when it is open', async () => {
+    mountAside(240)
+    openFindBar()
+    renderFindBar()
+
+    const bar = await screen.findByRole('search')
+    await waitFor(() => expect(bar.style.right).toBe('calc(240px + 0.75rem)'))
+  })
+
+  it('re-measures when the pane opens or closes while the bar is up', async () => {
+    openFindBar()
+    renderFindBar()
+
+    const bar = await screen.findByRole('search')
+    expect(bar.style.right).toBe('')
+
+    // Pane opens mid-session: the MutationObserver path must re-measure.
+    const aside = mountAside(300)
+    await waitFor(() => expect(bar.style.right).toBe('calc(300px + 0.75rem)'))
+
+    // Pane closes again: the bar falls back to the default position.
+    aside.remove()
+    await waitFor(() => expect(bar.style.right).toBe(''))
+  })
+})

--- a/apps/desktop/src/components/find-bar.tsx
+++ b/apps/desktop/src/components/find-bar.tsx
@@ -37,6 +37,7 @@ export function FindBar() {
   const { active, query, matchOrdinal, matchCount } = useStore($findInPage)
   const inputRef = useRef<HTMLInputElement>(null)
   const [localQuery, setLocalQuery] = useState('')
+  const [filesPaneRight, setFilesPaneRight] = useState<number | null>(null)
   const { pathname } = useLocation()
 
   // Navigating away (opening another session, a settings page, …) closes the
@@ -65,6 +66,34 @@ export function FindBar() {
 
     return undefined
   }, [active])
+
+  // The files pane (right sidebar, `aside[aria-label="Right sidebar"]`) is a
+  // floating right rail. The find bar is `fixed right-4` by default, which
+  // would cover the files pane's header + first rows when it is open. Measure
+  // the pane's live rect and park the bar just left of it instead.
+  useEffect(() => {
+    if (!active) {
+      setFilesPaneRight(null)
+
+      return undefined
+    }
+
+    const measure = () => {
+      const aside = document.querySelector('aside[aria-label="Right sidebar"]')
+      const rect = aside?.getBoundingClientRect()
+
+      if (rect && rect.width > 0 && rect.left < window.innerWidth) {
+        setFilesPaneRight(window.innerWidth - rect.left)
+      } else {
+        setFilesPaneRight(null)
+      }
+    }
+
+    measure()
+    window.addEventListener('resize', measure)
+
+    return () => window.removeEventListener('resize', measure)
+  }, [active, pathname])
 
   // Subscribe to found-in-page results from the main process. Refcounted in
   // the store, so a remount (connection re-home) can't stack listeners; the
@@ -156,6 +185,11 @@ export function FindBar() {
 
   const matchLabel = formatMatchLabel(query, matchOrdinal, matchCount)
 
+  const barStyle =
+    filesPaneRight != null
+      ? { right: `calc(${filesPaneRight}px + 0.75rem)` }
+      : undefined
+
   return (
     <div
       className={cn(
@@ -169,6 +203,7 @@ export function FindBar() {
         'flex items-center gap-1 rounded-lg border border-(--ui-stroke-tertiary) bg-(--ui-surface-background) px-2 py-1 shadow-md'
       )}
       role="search"
+      style={barStyle}
     >
       <input
         aria-label={t.keybinds.actions['view.findInPage'] ?? 'Find in page'}

--- a/apps/desktop/src/components/find-bar.tsx
+++ b/apps/desktop/src/components/find-bar.tsx
@@ -71,6 +71,14 @@ export function FindBar() {
   // floating right rail. The find bar is `fixed right-4` by default, which
   // would cover the files pane's header + first rows when it is open. Measure
   // the pane's live rect and park the bar just left of it instead.
+  //
+  // The pane can open, close, or be drag-resized *while the bar is open* (its
+  // visibility lives in the contrib workspace registry, not a store we can
+  // subscribe to from here), so a window `resize` listener alone is not
+  // enough: a ResizeObserver tracks width drags of the current aside, and a
+  // body-scoped MutationObserver catches the aside mounting/unmounting and
+  // re-attaches the ResizeObserver to the new node. All paths coalesce into
+  // one rAF-batched measure; everything tears down when the bar closes.
   useEffect(() => {
     if (!active) {
       setFilesPaneRight(null)
@@ -78,8 +86,30 @@ export function FindBar() {
       return undefined
     }
 
+    let rafId: null | number = null
+    let observedAside: Element | null = null
+
+    const resizeObserver =
+      typeof ResizeObserver === 'undefined' ? null : new ResizeObserver(() => scheduleMeasure())
+
     const measure = () => {
+      rafId = null
       const aside = document.querySelector('aside[aria-label="Right sidebar"]')
+
+      // The aside can be replaced wholesale (pane closed and reopened, panes
+      // flipped) — retarget the ResizeObserver whenever its identity changes.
+      if (aside !== observedAside) {
+        if (observedAside) {
+          resizeObserver?.unobserve(observedAside)
+        }
+
+        if (aside) {
+          resizeObserver?.observe(aside)
+        }
+
+        observedAside = aside
+      }
+
       const rect = aside?.getBoundingClientRect()
 
       if (rect && rect.width > 0 && rect.left < window.innerWidth) {
@@ -89,10 +119,28 @@ export function FindBar() {
       }
     }
 
-    measure()
-    window.addEventListener('resize', measure)
+    const scheduleMeasure = () => {
+      rafId ??= requestAnimationFrame(measure)
+    }
 
-    return () => window.removeEventListener('resize', measure)
+    // Catches the pane opening/closing while the bar is up. Scoped to
+    // childList mutations only (no attributes/characterData), and the bar is
+    // a transient overlay, so the observer lives only for the find session.
+    const mutationObserver = new MutationObserver(scheduleMeasure)
+    mutationObserver.observe(document.body, { childList: true, subtree: true })
+
+    measure()
+    window.addEventListener('resize', scheduleMeasure)
+
+    return () => {
+      window.removeEventListener('resize', scheduleMeasure)
+      mutationObserver.disconnect()
+      resizeObserver?.disconnect()
+
+      if (rafId != null) {
+        cancelAnimationFrame(rafId)
+      }
+    }
   }, [active, pathname])
 
   // Subscribe to found-in-page results from the main process. Refcounted in


### PR DESCRIPTION
## Summary

Salvage of #82896 by @SongotenU — cherry-picked onto current main with authorship preserved, plus a hardening follow-up commit.

The find-in-page bar (⌘F) is `fixed right-4`, so when the Files pane (right sidebar, `aside[aria-label="Right sidebar"]`) is open, the bar covers the pane's header and first rows. The vertical anchoring fix that landed in #86746 (34px titlebar fallback) moved the bar below the titlebar strip but did **not** remove this horizontal overlap — the bar still sits on top of the pane.

## What the contributor's commit does (cherry-picked as-authored)

- On open, measures the live rect of `aside[aria-label="Right sidebar"]`
- If the pane is visible on the right, parks the bar just left of it (`right: calc(<offset>px + 0.75rem)`)
- Falls back to the stock `right-4` position when the pane is closed
- Re-measures on window resize

Conflict resolution during cherry-pick: main's positioning line (comment block + `top-[calc(var(--titlebar-height,34px)+0.5rem)]` from #86746) was kept; only the contributor's pane-measurement additions were taken.

## Follow-up hardening (second commit)

The original effect listened only to window `resize`, so toggling or drag-resizing the pane *while the bar was open* left the bar in a stale position. Added:

- **ResizeObserver** on the aside — tracks drag-resizes of the pane rail
- **Body-scoped childList MutationObserver** — catches the pane mounting/unmounting mid-find-session and retargets the ResizeObserver when the aside's identity changes (the pane's visibility lives in the contrib workspace registry, not a subscribable store)
- All triggers coalesce into a single rAF-batched measure; observers, listener, and any pending frame tear down when the bar closes

## Verification

- `npx vitest run src/components/find-bar.test.tsx` — **51/51 pass** (48 existing + 3 new positioning tests: default position with pane closed, parked left of an open pane, live re-measure when the pane opens/closes while the bar is up)
- `npm run check:lint` (typecheck + eslint) — 0 errors; the two touched files are warning-free
- `python3 scripts/audit_pr_attribution.py --fix` — all contributor emails mapped

Credit to @SongotenU for the original fix (salvaged from #82896).

## Infographic

![PR infographic](https://files.catbox.moe/2ba5dc.png)
