### PR TITLE
fix(desktop): count all five static titlebar buttons; find-bar overlay guard (salvage #72959)

### DIFF
--- a/apps/desktop/src/app/contrib/controller.tsx
+++ b/apps/desktop/src/app/contrib/controller.tsx
@@ -776,7 +776,10 @@ export function ContribController() {
                 className="pointer-events-auto absolute z-10 flex w-max items-center gap-2 [-webkit-app-region:no-drag]"
                 style={{
                   right:
-                    'max(calc(var(--workspace-right, 0px) + 0.5rem), calc(var(--titlebar-tools-right, 0.75rem) + 4 * var(--titlebar-control-size, 24px) + 0.5rem))'
+                    // Five static cluster buttons: four systemTools plus the
+                    // always-present right-sidebar toggle (titlebar-controls.tsx).
+                    // Keep in sync with wiring.tsx's SYSTEM_TOOL_COUNT.
+                    'max(calc(var(--workspace-right, 0px) + 0.5rem), calc(var(--titlebar-tools-right, 0.75rem) + 5 * var(--titlebar-control-size, 24px) + 0.5rem))'
                 }}
               />
             </div>

--- a/apps/desktop/src/app/contrib/wiring.tsx
+++ b/apps/desktop/src/app/contrib/wiring.tsx
@@ -999,7 +999,12 @@ export function ContribWiring({ children }: { children: ReactNode }) {
   // Pane-registered tools (preview's monitor/devtools cluster) anchor flush
   // against the static system cluster — in the tree layout the titlebar band
   // sits ABOVE the grid, so AppShell's pane-width anchoring doesn't apply.
-  const SYSTEM_TOOL_COUNT = 4
+  // Count every button the static cluster actually renders: four systemTools
+  // (layout, haptics, keybinds, settings) PLUS the always-present
+  // right-sidebar toggle (see titlebar-controls.tsx). A shared width that
+  // under-counts leaves the find bar, the titlebar header padding, and the
+  // pane-cluster anchor overlapping the fifth button.
+  const SYSTEM_TOOL_COUNT = 5
   const paneToolCount = rightTitlebarTools.filter(tool => !tool.hidden).length
   const systemToolsWidth = titlebarToolsWidthCss(SYSTEM_TOOL_COUNT)
 

--- a/apps/desktop/src/app/hooks/use-keybinds.ts
+++ b/apps/desktop/src/app/hooks/use-keybinds.ts
@@ -1,6 +1,7 @@
 import { useEffect, useRef } from 'react'
-import { useNavigate } from 'react-router'
+import { useLocation, useNavigate } from 'react-router'
 
+import { appViewForPath, isOverlayView } from '@/app/routes'
 import { closeActiveTab } from '@/app/chat/close-tab'
 import { hudTargetSessionId } from '@/app/hud/handoff'
 import { setTerminalTakeover } from '@/app/right-sidebar/store'
@@ -98,6 +99,7 @@ type HandlerMap = Record<string, () => void>
 // mode is active (edit overlay / panel rebind) — records the pressed combo.
 export function useKeybinds(deps: KeybindRuntimeDeps): void {
   const navigate = useNavigate()
+  const location = useLocation()
   const { resolvedMode, setMode } = useTheme()
 
   // Keep the latest closures without re-subscribing the listener.
@@ -256,7 +258,13 @@ export function useKeybinds(deps: KeybindRuntimeDeps): void {
     // the Win/Linux path where ⌘W reaches the renderer directly.
     'view.closeTab': () => void closeActiveTab(id => navigate(sessionRoute(id))),
     'view.reopenTab': reopenLastClosedTile,
-    'view.findInPage': openFindBar,
+    'view.findInPage': () => {
+      // Suppress on overlay routes so it doesn't collide with overlay-specific
+      // search surfaces (e.g. Settings search bar).
+      if (!isOverlayView(appViewForPath(location.pathname))) {
+        openFindBar()
+      }
+    },
     // ⌘G / ⌘⇧G are handled by the find bar's own capture-phase listener while
     // it is open (so they don't collide with `view.toggleReview`). These
     // registry handlers cover a user-assigned dedicated chord: stepping is a

--- a/apps/desktop/src/app/hooks/use-keybinds.ts
+++ b/apps/desktop/src/app/hooks/use-keybinds.ts
@@ -1,11 +1,11 @@
 import { useEffect, useRef } from 'react'
 import { useLocation, useNavigate } from 'react-router'
 
-import { appViewForPath, isOverlayView } from '@/app/routes'
 import { closeActiveTab } from '@/app/chat/close-tab'
 import { hudTargetSessionId } from '@/app/hud/handoff'
 import { setTerminalTakeover } from '@/app/right-sidebar/store'
 import { closeActiveTerminal, createTerminal, cycleTerminal } from '@/app/right-sidebar/terminal/terminals'
+import { appViewForPath, isOverlayView } from '@/app/routes'
 import {
   activateTreeTabSlot,
   cycleTreeTabInFocusedZone,

--- a/apps/desktop/src/components/find-bar.test.tsx
+++ b/apps/desktop/src/components/find-bar.test.tsx
@@ -650,7 +650,8 @@ describe('view.findInPage keybind gate', () => {
       toggleCommandCenter: vi.fn(),
       startFreshSession: vi.fn(),
       openNewSessionTab: vi.fn(),
-      toggleSelectedPin: vi.fn()
+      toggleSelectedPin: vi.fn(),
+      archiveSelectedSession: vi.fn()
     }
 
     render(

--- a/apps/desktop/src/components/find-bar.test.tsx
+++ b/apps/desktop/src/components/find-bar.test.tsx
@@ -2,11 +2,11 @@ import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-libra
 import { MemoryRouter, useNavigate } from 'react-router'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { type KeybindRuntimeDeps, useKeybinds } from '@/app/hooks/use-keybinds'
 import { FindBar } from '@/components/find-bar'
 import { I18nProvider } from '@/i18n'
 import { en } from '@/i18n/en'
 import { zh } from '@/i18n/zh'
-import { useKeybinds, type KeybindRuntimeDeps } from '@/app/hooks/use-keybinds'
 import { findBarClaimsCombo, findBarKeyAction, formatMatchLabel } from '@/lib/find-in-page'
 import { KEYBIND_ACTIONS } from '@/lib/keybinds/actions'
 import { actionAllowedInInput } from '@/lib/keybinds/combo'

--- a/apps/desktop/src/components/find-bar.test.tsx
+++ b/apps/desktop/src/components/find-bar.test.tsx
@@ -6,6 +6,7 @@ import { FindBar } from '@/components/find-bar'
 import { I18nProvider } from '@/i18n'
 import { en } from '@/i18n/en'
 import { zh } from '@/i18n/zh'
+import { useKeybinds, type KeybindRuntimeDeps } from '@/app/hooks/use-keybinds'
 import { findBarClaimsCombo, findBarKeyAction, formatMatchLabel } from '@/lib/find-in-page'
 import { KEYBIND_ACTIONS } from '@/lib/keybinds/actions'
 import { actionAllowedInInput } from '@/lib/keybinds/combo'
@@ -21,6 +22,13 @@ import {
   setFindQuery,
   updateFindResults
 } from '@/store/find-in-page'
+
+// useKeybinds only needs the theme context for resolvedMode/setMode; the real
+// provider persists themes and subscribes to backend sync, which is unrelated
+// to the find-in-page gate under test.
+vi.mock('@/themes/context', () => ({
+  useTheme: () => ({ resolvedMode: 'dark', setMode: vi.fn() })
+}))
 
 // ── Bridge double ───────────────────────────────────────────────────────────
 // Stands in for the preload `hermesDesktop` surface. `onFoundInPage` records
@@ -620,6 +628,55 @@ describe('FindBar', () => {
     // The store still has active=true but the component guard suppresses
     // rendering — a harmless state ghost that the next pathname-change
     // cleanup will drain via closeFindBar.
+    expect($findInPage.get().active).toBe(true)
+  })
+})
+
+// ── Keybind gate: view.findInPage on overlay routes ─────────────────────────
+// The component guard above proves hidden RENDERING; this proves the keybind
+// itself never OPENS the bar on an overlay route. Mounted against the real
+// useKeybinds listener + combo index so a regression in either the handler
+// wiring or the route classification fails the test.
+
+function KeybindHarness({ deps }: { deps: KeybindRuntimeDeps }) {
+  useKeybinds(deps)
+
+  return null
+}
+
+describe('view.findInPage keybind gate', () => {
+  function renderKeybinds(pathname: string) {
+    const deps: KeybindRuntimeDeps = {
+      toggleCommandCenter: vi.fn(),
+      startFreshSession: vi.fn(),
+      openNewSessionTab: vi.fn(),
+      toggleSelectedPin: vi.fn()
+    }
+
+    render(
+      <MemoryRouter initialEntries={[pathname]}>
+        <I18nProvider configClient={null} initialLocale="en">
+          <KeybindHarness deps={deps} />
+        </I18nProvider>
+      </MemoryRouter>
+    )
+
+    return deps
+  }
+
+  it('does not open the find bar for mod+f while an overlay route is showing', () => {
+    renderKeybinds('/settings')
+
+    fireEvent.keyDown(window, { key: 'f', metaKey: true })
+
+    expect($findInPage.get().active).toBe(false)
+  })
+
+  it('opens the find bar for mod+f on a normal chat route', () => {
+    renderKeybinds('/session/a')
+
+    fireEvent.keyDown(window, { key: 'f', metaKey: true })
+
     expect($findInPage.get().active).toBe(true)
   })
 })

--- a/apps/desktop/src/components/find-bar.test.tsx
+++ b/apps/desktop/src/components/find-bar.test.tsx
@@ -609,4 +609,17 @@ describe('FindBar', () => {
     await waitFor(() => expect(screen.queryByRole('search')).toBeNull())
     expect(bridge.stopFindInPage).not.toHaveBeenCalled()
   })
+
+  it('does not render on overlay routes (settings, command center, …)', () => {
+    // Match isOverlayView: agents, command-center, cron, profiles, settings,
+    // starmap, webhooks. Test with the most commonly hit one.
+    openFindBar()
+    renderFindBar('/settings')
+
+    expect(screen.queryByRole('search')).toBeNull()
+    // The store still has active=true but the component guard suppresses
+    // rendering — a harmless state ghost that the next pathname-change
+    // cleanup will drain via closeFindBar.
+    expect($findInPage.get().active).toBe(true)
+  })
 })

--- a/apps/desktop/src/components/find-bar.tsx
+++ b/apps/desktop/src/components/find-bar.tsx
@@ -2,6 +2,7 @@ import { useStore } from '@nanostores/react'
 import { useEffect, useRef, useState } from 'react'
 import { useLocation } from 'react-router'
 
+import { appViewForPath, isOverlayView } from '@/app/routes'
 import { Tip } from '@/components/ui/tooltip'
 import { useI18n } from '@/i18n'
 import { findBarKeyAction, formatMatchLabel } from '@/lib/find-in-page'
@@ -121,7 +122,7 @@ export function FindBar() {
     return () => window.removeEventListener('keydown', onKeyDown, { capture: true })
   }, [active])
 
-  if (!active) {
+  if (!active || isOverlayView(appViewForPath(pathname))) {
     return null
   }
 


### PR DESCRIPTION
## What does this PR do?

Salvages the still-valid parts of #72959 by @DavidMetcalfe onto current main (fixes #72961). Credit to @DavidMetcalfe — his commits are cherry-picked with authorship preserved.

Two live fixes:

1. **Titlebar cluster undercount (4 → 5).** The static right titlebar cluster renders **five** buttons — four `systemTools` (layout, haptics/HUD, mute, settings) **plus** the always-present right-sidebar toggle appended unconditionally in `titlebar-controls.tsx` (`<TitlebarToolButton … tool={rightSidebarTool} />`). `SYSTEM_TOOL_COUNT = 4` in `wiring.tsx` undercounted it, so `--titlebar-tools-width` (via `titlebarToolsWidthCss`) left the titlebar header padding and the pane-cluster anchor one control-width (24px) short — overlapping the fifth button. Same undercount fixed in the `titleBar.right` contribution slot formula in `controller.tsx` (`4 *` → `5 *`), re-applied onto main's current formula shape during conflict resolution.

2. **Overlay guard + keybind gate.** The find bar rendered (at z-50, behind the overlay card but still active) on overlay routes (Settings, Command Center, …). Added the `isOverlayView()` guard matching the titlebar-controls pattern, and gated the `view.findInPage` keybind so Ctrl+F is a no-op on overlay routes — avoiding collision with the Settings search surface (#69025). Regression tests included for both the component guard and the keybind gate.

## Dropped as obsolete

- The original PR's find-bar **positioning** change (`right-4` → `calc()` offset from `--titlebar-tools-width`) is **dropped**: #86746 already fixed positioning on main by floating the bar below the titlebar band (`top-[calc(var(--titlebar-height,34px)+0.5rem)]`), so the horizontal offset is moot and main's version (with the correct 34px fallback) is kept.
- The sweeper review's concern that the offset "remains 0.75rem inside the cluster" applied to the dropped positioning change; the count fix itself is unaffected.

## Changes Made

- `apps/desktop/src/app/contrib/wiring.tsx` — `SYSTEM_TOOL_COUNT` 4 → 5 with a comment tying it to the rendered cluster
- `apps/desktop/src/app/contrib/controller.tsx` — matching `4 *` → `5 *` in the `titleBar.right` slot right-offset formula
- `apps/desktop/src/components/find-bar.tsx` — `isOverlayView()` render guard (positioning line untouched, main's #86746 version kept)
- `apps/desktop/src/app/hooks/use-keybinds.ts` — gate `view.findInPage` on overlay routes
- `apps/desktop/src/components/find-bar.test.tsx` — overlay-guard regression test + keybind-gate tests against the real `useKeybinds` listener (adapted to main's `KeybindRuntimeDeps`, which grew `archiveSelectedSession` since the PR was opened)

## How to Test

- `cd apps/desktop && npx vitest run src/components/find-bar.test.tsx src/app/shell/titlebar.test.ts` — 63/63 passing
- `npm run check:lint` — typecheck + lint clean (0 errors)
- Manual: open Settings, press Ctrl+F → no find bar; on a chat route Ctrl+F works; the pane tool cluster and titlebar header padding now clear all five right-cluster buttons.

## Checklist

### Code

- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate (supersedes #72959)
- [x] My PR contains only changes related to this fix
- [x] I've added tests for my changes
- [x] Tested: typecheck, lint, targeted vitest on Linux

### Documentation & Housekeeping

- [x] N/A — no documentation changes needed
- [x] N/A — no config keys changed
- [x] N/A — no architecture changes
- [x] Cross-platform: CSS calc() uses existing vars already exercised on Windows/macOS
- [x] N/A — no tool behavior changes

## Infographic

![PR infographic](https://files.catbox.moe/19550b.png)
