### PR TITLE
fix(cli): parse colon-delimited log levels

### DIFF
--- a/hermes_cli/logs.py
+++ b/hermes_cli/logs.py
@@ -45,15 +45,19 @@ LOG_FILES = {
 _TS_RE = re.compile(r"^(\d{4}-\d{2}-\d{2}\s+\d{2}:\d{2}:\d{2})")
 
 # Level extraction — matches " INFO ", " WARNING ", " ERROR ", " DEBUG ", " CRITICAL "
-_LEVEL_RE = re.compile(r"\s(DEBUG|INFO|WARNING|ERROR|CRITICAL)\s")
+_LEVEL_RE = re.compile(
+    r"^\d{4}-\d{2}-\d{2}[ \t]+\d{2}:\d{2}:\d{2}(?:,\d+)?[ \t]+"
+    r"(DEBUG|INFO|WARNING|ERROR|CRITICAL)(?=[: \t])"
+)
 
 # Logger name extraction — after level and optional session tag, the next
 # non-space token before ":" is the logger name.
 # Matches: "INFO gateway.run:" or "INFO [sess_abc] tools.terminal_tool:"
 _LOGGER_NAME_RE = re.compile(
-    r"\s(?:DEBUG|INFO|WARNING|ERROR|CRITICAL)"  # level
-    r"(?:\s+\[.*?\])?"                           # optional session tag
-    r"\s+(\S+):"                                 # logger name
+    r"^\d{4}-\d{2}-\d{2}[ \t]+\d{2}:\d{2}:\d{2}(?:,\d+)?[ \t]+"
+    r"(?:DEBUG|INFO|WARNING|ERROR|CRITICAL):?"  # level
+    r"(?:[ \t]+\[[^\]\r\n]*\])?"             # optional session tag
+    r"[ \t]+([^ \t\r\n]+):"                   # logger name
 )
 
 # Level ordering for >= filtering

--- a/tests/hermes_cli/test_logs.py
+++ b/tests/hermes_cli/test_logs.py
@@ -47,6 +47,31 @@ class TestExtractLevel:
     def test_info(self):
         assert _extract_level("2026-01-01 00:00:00 INFO gateway.run: msg") == "INFO"
 
+    def test_colon_delimited_level(self):
+        assert (
+            _extract_level("2026-08-15 01:02:03 ERROR: connection failed"),
+            _extract_logger_name(
+                "2026-08-15 01:02:03 ERROR: gateway.run: connection failed"
+            ),
+        ) == ("ERROR", "gateway.run")
+
+    def test_structured_session_tag_forms(self):
+        spaced = "2026-08-15 01:02:03,123 WARNING [sess_abc] gateway.run: failed"
+        colon = "2026-08-15 01:02:03 ERROR: [sess_abc] gateway.run: failed"
+
+        assert (_extract_level(spaced), _extract_logger_name(spaced)) == (
+            "WARNING",
+            "gateway.run",
+        )
+        assert (_extract_level(colon), _extract_logger_name(colon)) == (
+            "ERROR",
+            "gateway.run",
+        )
+
+    def test_ignores_level_like_message_text(self):
+        line = "2026-08-15 01:02:03 connection failed at ERROR gateway.run: details"
+        assert (_extract_level(line), _extract_logger_name(line)) == (None, None)
+
 
 # ---------------------------------------------------------------------------
 # Logger name extraction (new for component filtering)


### PR DESCRIPTION
## Bug Description

`hermes logs` did not recognize a structured log level when the formatter placed a colon immediately after it, for example:

```text
2026-08-15 01:02:03 ERROR: connection failed
2026-08-15 01:02:03 ERROR: gateway.run: connection failed
```

The same parser could also treat a level-looking word later in message text as the record's level/logger.

## Root Cause

The level and logger regexes searched for whitespace-delimited level words anywhere in the line. A colon after the level therefore failed the delimiter check, while an unrelated `ERROR` later in the message could match.

## Fix

- Anchor level and logger extraction to the timestamp at the start of a physical log line.
- Accept both spaced and colon-delimited levels while preserving optional session tags.
- Keep horizontal whitespace explicit so matches cannot cross physical lines.
- Add positive, compatibility, and negative regression coverage.

## How to Verify

1. Run `HERMES_TEST_FILE_RETRIES=0 scripts/run_tests.sh tests/hermes_cli/test_logs.py -q`.
2. Confirm colon-delimited level/logger examples return `ERROR` and `gateway.run`.
3. Confirm level-looking message text without a structured level prefix returns no extracted level/logger.

## Test Plan

- [x] Strict RED observed before implementation: the targeted colon case returned `(None, None)` instead of `("ERROR", "gateway.run")`.
- [x] Focused suite: `17 passed`.
- [x] Ruff and ty checks pass for both changed files.
- [x] Independent read-only Codex review passed with no security or logic findings.
- [x] Repository-wide suite attempted; unrelated local baseline failures from missing optional SDKs/lazy-install-disabled paths were reproduced on the unchanged base. The focused parser suite remained green before and after rebasing onto current `main`.

## Risk Assessment

Low — the production change is limited to two pure regex constants in `hermes_cli/logs.py`, with compatibility and false-positive regressions covering both extraction paths.
