### PR TITLE
feat(kanban): add sanitized read-model and signal event view

### DIFF
--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -44,8 +44,8 @@ from dataclasses import asdict
 from pathlib import Path
 from typing import Any, Optional
 
-from fastapi import APIRouter, File, Form, HTTPException, Query, UploadFile, WebSocket, WebSocketDisconnect, status as http_status
-from fastapi.responses import FileResponse
+from fastapi import APIRouter, File, Form, HTTPException, Query, Request, UploadFile, WebSocket, WebSocketDisconnect, status as http_status
+from fastapi.responses import FileResponse, JSONResponse
 from pydantic import BaseModel, Field
 
 from hermes_cli import kanban_db
@@ -94,6 +94,61 @@ def _ws_upgrade_authorized(ws: "WebSocket") -> bool:
     return bool(_ws._ws_auth_ok(ws))
 
 
+# Query params the WS upgrade may legitimately carry in ``view=signal``
+# mode: the signal contract's own params plus whichever credential
+# ``_ws_upgrade_authorized`` accepts for the active auth mode.
+_SIGNAL_WS_ALLOWED_PARAMS = {"view", "board", "since", "token", "ticket", "internal"}
+
+
+def _signal_ws_query_items(ws: "WebSocket") -> list[tuple[str, str]]:
+    """Query items as ``(key, value)`` pairs, preserving duplicates.
+
+    Real Starlette ``QueryParams`` exposes ``multi_items()``; falls back
+    to plain ``.items()`` for the simple dict-based fakes used in tests.
+    """
+    qp = ws.query_params
+    multi = getattr(qp, "multi_items", None)
+    if callable(multi):
+        return list(multi())
+    return list(qp.items())
+
+
+def _signal_ws_validation_error(ws: "WebSocket") -> Optional[str]:
+    """Strict canonical query validation for ``view=signal`` connections.
+
+    Returns a short reason string when the query is malformed (unknown
+    or duplicated parameter, missing/invalid ``board``, non-canonical
+    ``since``), else ``None``. The legacy view-absent path never calls
+    this — it keeps coercing a malformed ``since`` to 0, unchanged, for
+    byte-compatibility with existing callers.
+    """
+    seen: set[str] = set()
+    for key, _ in _signal_ws_query_items(ws):
+        if key not in _SIGNAL_WS_ALLOWED_PARAMS:
+            return f"unknown parameter: {key}"
+        if key in seen:
+            return f"duplicate parameter: {key}"
+        seen.add(key)
+
+    board_raw = ws.query_params.get("board")
+    if not board_raw:
+        return "board is required"
+    try:
+        if not kanban_db._normalize_board_slug(board_raw):
+            return "board is required"
+    except ValueError as exc:
+        return str(exc)
+
+    since_raw = ws.query_params.get("since")
+    if since_raw is not None:
+        try:
+            if int(since_raw) < 0:
+                return "since must be a non-negative integer"
+        except ValueError:
+            return "since must be a non-negative integer"
+    return None
+
+
 def _resolve_board(board: Optional[str]) -> Optional[str]:
     """Validate and normalise a board slug from a query param.
 
@@ -114,6 +169,46 @@ def _resolve_board(board: Optional[str]) -> Optional[str]:
             detail=f"board {normed!r} does not exist",
         )
     return normed
+
+
+def _resolve_board_strict(board: Optional[str]) -> str:
+    """Like :func:`_resolve_board`, but ``board`` is mandatory.
+
+    Used by the generic read-model surface (issue-scoped read-only
+    consumers), which must name the board explicitly rather than
+    inheriting the ambient "current board" pointer other endpoints fall
+    back to.
+    """
+    if not board or not board.strip():
+        raise HTTPException(status_code=400, detail="board is required")
+    try:
+        normed = kanban_db._normalize_board_slug(board)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+    if not normed:
+        raise HTTPException(status_code=400, detail="board is required")
+    if normed != kanban_db.DEFAULT_BOARD and not kanban_db.board_exists(normed):
+        raise HTTPException(status_code=404, detail=f"board {normed!r} does not exist")
+    return normed
+
+
+def _reject_unknown_query_params(request: "Request", allowed: set[str]) -> None:
+    """Enforce strict canonical query params: every key must be in
+    ``allowed`` and appear at most once. Raises 400 otherwise.
+
+    Generic FastAPI ``Query(...)`` declarations silently ignore extra or
+    repeated params, which is fine for the dashboard's own UI but wrong
+    for a versioned external read-model contract where a typo'd or
+    duplicated param should fail loudly instead of being silently
+    dropped.
+    """
+    seen: set[str] = set()
+    for key, _ in request.query_params.multi_items():
+        if key not in allowed:
+            raise HTTPException(status_code=400, detail=f"unknown parameter: {key}")
+        if key in seen:
+            raise HTTPException(status_code=400, detail=f"duplicate parameter: {key}")
+        seen.add(key)
 
 
 def _conn(board: Optional[str] = None):
@@ -232,6 +327,40 @@ def _run_dict(r: kanban_db.Run) -> dict[str, Any]:
         "metadata": r.metadata,
         "error": r.error,
     }
+
+
+# ---------------------------------------------------------------------------
+# Signal read-model — allowlisted, redacted views for external consumers
+# (issue: generic Kanban read-model surface). Never emit body, result,
+# prompt, path, token, raw error, summary, metadata, or event payload —
+# those are exposed only through the authenticated dashboard REST/WS
+# surfaces above, whose consumers already need the full task record.
+# ---------------------------------------------------------------------------
+
+_SIGNAL_TASK_FIELDS = (
+    "id", "title", "status", "priority", "assignee", "tenant", "project_id",
+    "created_at", "started_at", "completed_at", "workflow_template_id",
+    "current_step_key", "current_run_id", "consecutive_failures",
+    "block_kind", "goal_mode",
+)
+
+_SIGNAL_RUN_FIELDS = ("id", "task_id", "profile", "step_key", "status", "started_at", "ended_at", "outcome")
+
+_SIGNAL_EVENT_FIELDS = ("id", "task_id", "run_id", "kind", "created_at")
+
+
+def _signal_task_dict(task: kanban_db.Task) -> dict[str, Any]:
+    d = asdict(task)
+    return {k: d.get(k) for k in _SIGNAL_TASK_FIELDS}
+
+
+def _signal_run_dict(r: kanban_db.Run) -> dict[str, Any]:
+    d = asdict(r)
+    return {k: d.get(k) for k in _SIGNAL_RUN_FIELDS}
+
+
+def _signal_event_dict(event: dict[str, Any]) -> dict[str, Any]:
+    return {k: event.get(k) for k in _SIGNAL_EVENT_FIELDS}
 
 
 # Hallucination-warning event kinds — see complete_task() in kanban_db.py.
@@ -2604,6 +2733,73 @@ def switch_board(slug: str):
 
 
 # ---------------------------------------------------------------------------
+# GET/HEAD /read-model/signal?board=<slug> — generic sanitized read model
+# ---------------------------------------------------------------------------
+
+_SIGNAL_CAPABILITIES = ("kanban.read_model.signal.v1", "kanban.events.signal.v1")
+
+
+@router.get("/capabilities")
+def get_capabilities():
+    """Discoverable capability strings for external plugin consumers."""
+    return {"capabilities": list(_SIGNAL_CAPABILITIES)}
+
+
+@router.api_route("/read-model/signal", methods=["GET", "HEAD"])
+def get_signal_read_model(request: Request, board: Optional[str] = Query(None)):
+    """Authenticated, redacted operational-graph view of a board.
+
+    Strict surface for external dashboard plugins that only need
+    status/graph signals: allowlisted task/run fields and parent/child
+    links, never the sensitive fields the full REST/WS surfaces carry
+    (body, result, prompt, workspace path, claim tokens, run error/
+    summary/metadata). ``board`` is mandatory and no other query
+    parameter is accepted.
+    """
+    _reject_unknown_query_params(request, {"board"})
+    normed = _resolve_board_strict(board)
+    conn = _conn(board=normed)
+    try:
+        tasks = kanban_db.list_tasks(conn, include_archived=True)
+        task_ids = [t.id for t in tasks]
+        links = [
+            {"parent_id": row["parent_id"], "child_id": row["child_id"]}
+            for row in conn.execute("SELECT parent_id, child_id FROM task_links").fetchall()
+        ]
+        runs: list[dict[str, Any]] = []
+        if task_ids:
+            placeholders = ",".join(["?"] * len(task_ids))
+            for row in conn.execute(
+                f"SELECT * FROM task_runs WHERE task_id IN ({placeholders}) ORDER BY id",
+                tuple(task_ids),
+            ).fetchall():
+                runs.append(_signal_run_dict(kanban_db.Run.from_row(row)))
+        floor_row = conn.execute(
+            "SELECT COALESCE(MIN(id), 0) AS floor, COALESCE(MAX(id), 0) AS latest "
+            "FROM task_events"
+        ).fetchone()
+        payload = {
+            "board": normed,
+            "tasks": [_signal_task_dict(t) for t in tasks],
+            "links": links,
+            "runs": runs,
+            # The lowest surviving task_events.id: since ids are
+            # monotonic and retention (kanban_db.gc_events) only ever
+            # deletes the oldest rows, this floor only moves forward.
+            # A WS ``since`` cursor below it means history in that gap
+            # was reclaimed — the signal envelope surfaces the same
+            # value as ``generation`` so callers can detect the gap.
+            "generation": int(floor_row["floor"]),
+            "cursor": int(floor_row["latest"]),
+        }
+    finally:
+        conn.close()
+    response = JSONResponse(content=payload)
+    response.headers["Cache-Control"] = "private, no-store"
+    return response
+
+
+# ---------------------------------------------------------------------------
 # WebSocket: /events?since=<event_id>
 # ---------------------------------------------------------------------------
 
@@ -2899,6 +3095,18 @@ async def stream_events(ws: WebSocket):
     if not _ws_upgrade_authorized(ws):
         await ws.close(code=http_status.WS_1008_POLICY_VIOLATION)
         return
+
+    # ``view=signal`` opts into the strict, redacted read-model contract.
+    # Absent/empty ``view`` is the legacy path below, kept byte-compatible.
+    view_raw = (ws.query_params.get("view") or "").strip()
+    signal_mode = view_raw == "signal"
+    if view_raw and not signal_mode:
+        await ws.close(code=http_status.WS_1008_POLICY_VIOLATION)
+        return
+    if signal_mode and _signal_ws_validation_error(ws) is not None:
+        await ws.close(code=http_status.WS_1008_POLICY_VIOLATION)
+        return
+
     await ws.accept()
     try:
         since_raw = ws.query_params.get("since", "0")
@@ -2906,6 +3114,8 @@ async def stream_events(ws: WebSocket):
             cursor = int(since_raw)
         except ValueError:
             cursor = 0
+        starting_cursor = cursor
+        reset_notified = False
 
         # Board selection — pinned at the WS handshake; re-subscribe to
         # switch boards. Changing boards mid-stream would require
@@ -2917,7 +3127,7 @@ async def stream_events(ws: WebSocket):
         except ValueError:
             ws_board = None
 
-        def _fetch_new(cursor_val: int) -> tuple[int, list[dict]]:
+        def _fetch_new(cursor_val: int) -> tuple[int, list[dict], int]:
             conn = kanban_db.connect(board=ws_board)
             try:
                 rows = conn.execute(
@@ -2941,7 +3151,17 @@ async def stream_events(ws: WebSocket):
                         "created_at": r["created_at"],
                     })
                     new_cursor = r["id"]
-                return new_cursor, out
+                floor = 0
+                if signal_mode:
+                    # Lowest surviving event id — see
+                    # get_signal_read_model's ``generation`` for why this
+                    # doubles as the retention-gap marker.
+                    floor = int(
+                        conn.execute(
+                            "SELECT COALESCE(MIN(id), 0) AS floor FROM task_events"
+                        ).fetchone()["floor"]
+                    )
+                return new_cursor, out, floor
             finally:
                 conn.close()
 
@@ -2961,8 +3181,22 @@ async def stream_events(ws: WebSocket):
             except asyncio.TimeoutError:
                 pass  # no client message — poll the DB
 
-            cursor, events = await asyncio.to_thread(_fetch_new, cursor)
-            if events:
+            cursor, events, floor = await asyncio.to_thread(_fetch_new, cursor)
+            if signal_mode:
+                if not reset_notified and starting_cursor > 0 and floor > starting_cursor:
+                    # Some history between the requested cursor and the
+                    # current floor was reclaimed by retention — the
+                    # client must not treat this as "nothing happened"
+                    # and should refetch /read-model/signal to resync.
+                    await ws.send_json({"reset": True, "generation": floor, "cursor": floor})
+                    reset_notified = True
+                if events:
+                    await ws.send_json({
+                        "generation": floor,
+                        "cursor": cursor,
+                        "events": [_signal_event_dict(e) for e in events],
+                    })
+            elif events:
                 await ws.send_json({"events": events, "cursor": cursor})
     except WebSocketDisconnect:
         return

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -134,10 +134,13 @@ def _signal_ws_validation_error(ws: "WebSocket") -> Optional[str]:
     if not board_raw:
         return "board is required"
     try:
-        if not kanban_db._normalize_board_slug(board_raw):
+        normed_board = kanban_db._normalize_board_slug(board_raw)
+        if not normed_board:
             return "board is required"
     except ValueError as exc:
         return str(exc)
+    if normed_board != kanban_db.DEFAULT_BOARD and not kanban_db.board_exists(normed_board):
+        return f"board {normed_board!r} does not exist"
 
     since_raw = ws.query_params.get("since")
     if since_raw is not None:

--- a/tests/plugins/test_kanban_events_signal_ws.py
+++ b/tests/plugins/test_kanban_events_signal_ws.py
@@ -1,0 +1,228 @@
+"""Kanban dashboard plugin: ``/events`` WS ``view=signal`` mode (#86808).
+
+Covers the strict, redacted read-model contract layered onto the
+existing live-events WebSocket:
+
+* legacy (``view`` absent) behaviour is untouched — a malformed
+  ``since`` still silently coerces to 0
+* ``view=signal`` rejects unknown/duplicate query params and a
+  malformed/negative ``since`` by closing the upgrade instead of
+  coercing
+* signal-mode event frames carry only the allowlisted fields (no
+  ``payload``) plus a ``generation`` marker
+* a cursor below the current retention floor gets an explicit
+  ``reset`` frame instead of being treated as "nothing happened"
+"""
+
+from __future__ import annotations
+
+import asyncio
+import importlib.util
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+
+
+def _load_plugin_module():
+    repo_root = Path(__file__).resolve().parents[2]
+    plugin_file = repo_root / "plugins" / "kanban" / "dashboard" / "plugin_api.py"
+    spec = importlib.util.spec_from_file_location(
+        "hermes_dashboard_plugin_kanban_signal_ws_test", plugin_file,
+    )
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+class _QueryParams:
+    """Minimal stand-in for Starlette's multidict ``QueryParams``."""
+
+    def __init__(self, items):
+        self._items = list(items)
+
+    def get(self, key, default=None):
+        for k, v in self._items:
+            if k == key:
+                return v
+        return default
+
+    def multi_items(self):
+        return list(self._items)
+
+
+class _FakeWebSocket:
+    """Accepts (unless rejected), replays canned client messages, then
+    reports disconnect; records everything sent/closed."""
+
+    def __init__(self, query_items, messages=()):
+        self.query_params = _QueryParams(query_items)
+        self.accepted = False
+        self.closed_with = None
+        self.sent: list[dict] = []
+        self._messages = list(messages) + [{"type": "websocket.disconnect"}]
+
+    async def accept(self):
+        self.accepted = True
+
+    async def receive(self):
+        return self._messages.pop(0)
+
+    async def send_json(self, payload):
+        self.sent.append(payload)
+
+    async def close(self, code=None):
+        self.closed_with = code
+
+
+@pytest.fixture
+def kanban_home(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb.init_db()
+    return home
+
+
+def _insert_event(conn, task_id, kind="task_created", payload='{"secret": "nope"}'):
+    conn.execute(
+        "INSERT INTO task_events (task_id, run_id, kind, payload, created_at) "
+        "VALUES (?, NULL, ?, ?, ?)",
+        (task_id, kind, payload, int(time.time())),
+    )
+    conn.commit()
+    return conn.execute("SELECT last_insert_rowid() AS id").fetchone()["id"]
+
+
+@pytest.mark.asyncio
+async def test_legacy_mode_still_coerces_malformed_since(kanban_home, monkeypatch):
+    mod = _load_plugin_module()
+    monkeypatch.setattr(mod, "_ws_upgrade_authorized", lambda ws: True)
+    ws = _FakeWebSocket([("since", "not-a-number")])
+
+    await asyncio.wait_for(mod.stream_events(ws), timeout=5)
+
+    assert ws.accepted
+    assert ws.closed_with is None
+    assert ws.sent == []  # no events on a fresh board; legacy path never rejects
+
+
+@pytest.mark.asyncio
+async def test_signal_mode_rejects_unknown_param(kanban_home, monkeypatch):
+    mod = _load_plugin_module()
+    monkeypatch.setattr(mod, "_ws_upgrade_authorized", lambda ws: True)
+    ws = _FakeWebSocket([("view", "signal"), ("board", "default"), ("color", "blue")])
+
+    await asyncio.wait_for(mod.stream_events(ws), timeout=5)
+
+    assert not ws.accepted
+    assert ws.closed_with == mod.http_status.WS_1008_POLICY_VIOLATION
+
+
+@pytest.mark.asyncio
+async def test_signal_mode_rejects_duplicate_param(kanban_home, monkeypatch):
+    mod = _load_plugin_module()
+    monkeypatch.setattr(mod, "_ws_upgrade_authorized", lambda ws: True)
+    ws = _FakeWebSocket([("view", "signal"), ("board", "default"), ("board", "default")])
+
+    await asyncio.wait_for(mod.stream_events(ws), timeout=5)
+
+    assert not ws.accepted
+    assert ws.closed_with == mod.http_status.WS_1008_POLICY_VIOLATION
+
+
+@pytest.mark.asyncio
+async def test_signal_mode_requires_board(kanban_home, monkeypatch):
+    mod = _load_plugin_module()
+    monkeypatch.setattr(mod, "_ws_upgrade_authorized", lambda ws: True)
+    ws = _FakeWebSocket([("view", "signal")])
+
+    await asyncio.wait_for(mod.stream_events(ws), timeout=5)
+
+    assert not ws.accepted
+    assert ws.closed_with == mod.http_status.WS_1008_POLICY_VIOLATION
+
+
+@pytest.mark.asyncio
+async def test_signal_mode_rejects_malformed_since_instead_of_coercing(kanban_home, monkeypatch):
+    mod = _load_plugin_module()
+    monkeypatch.setattr(mod, "_ws_upgrade_authorized", lambda ws: True)
+    ws = _FakeWebSocket([("view", "signal"), ("board", "default"), ("since", "-1")])
+
+    await asyncio.wait_for(mod.stream_events(ws), timeout=5)
+
+    assert not ws.accepted
+    assert ws.closed_with == mod.http_status.WS_1008_POLICY_VIOLATION
+
+
+@pytest.mark.asyncio
+async def test_signal_mode_frame_is_redacted_and_versioned(kanban_home, monkeypatch):
+    mod = _load_plugin_module()
+    monkeypatch.setattr(mod, "_ws_upgrade_authorized", lambda ws: True)
+
+    conn = kb.connect(board="default")
+    try:
+        task_id = kb.create_task(conn, title="do it", board="default")
+        # create_task already logs its own "created" event; clear it so
+        # the only surviving event is the one this test controls.
+        conn.execute("DELETE FROM task_events")
+        conn.commit()
+        _insert_event(conn, task_id, payload='{"leak": "should-not-appear"}')
+    finally:
+        conn.close()
+
+    ws = _FakeWebSocket(
+        [("view", "signal"), ("board", "default")],
+        messages=[{"type": "websocket.receive", "text": ""}],
+    )
+    await asyncio.wait_for(mod.stream_events(ws), timeout=5)
+
+    assert ws.accepted
+    assert len(ws.sent) == 1
+    frame = ws.sent[0]
+    assert "generation" in frame and "cursor" in frame
+    assert len(frame["events"]) == 1
+    event = frame["events"][0]
+    assert set(event.keys()) == {"id", "task_id", "run_id", "kind", "created_at"}
+    assert "payload" not in event
+
+
+@pytest.mark.asyncio
+async def test_signal_mode_gap_below_retention_floor_sends_reset(kanban_home, monkeypatch):
+    mod = _load_plugin_module()
+    monkeypatch.setattr(mod, "_ws_upgrade_authorized", lambda ws: True)
+
+    conn = kb.connect(board="default")
+    try:
+        task_id = kb.create_task(conn, title="do it", board="default")
+        # create_task already logs its own "created" event; clear it so
+        # the ids below are fully under this test's control.
+        conn.execute("DELETE FROM task_events")
+        conn.commit()
+        stale_id = _insert_event(conn, task_id, kind="stale")
+        # Simulate retention (kanban_db.gc_events) reclaiming the old
+        # event: the client's stored cursor (stale_id - 1) now points
+        # below the surviving history's floor.
+        conn.execute("DELETE FROM task_events WHERE id = ?", (stale_id,))
+        conn.commit()
+        fresh_id = _insert_event(conn, task_id, kind="fresh")
+    finally:
+        conn.close()
+
+    ws = _FakeWebSocket(
+        [("view", "signal"), ("board", "default"), ("since", str(stale_id - 1))],
+        messages=[{"type": "websocket.receive", "text": ""}],
+    )
+    await asyncio.wait_for(mod.stream_events(ws), timeout=5)
+
+    assert ws.accepted
+    assert ws.sent[0].get("reset") is True
+    assert ws.sent[0]["generation"] == fresh_id
+    # The surviving event still arrives — nothing is silently dropped,
+    # the client is just told a gap happened.
+    assert any(f.get("events") for f in ws.sent[1:])

--- a/tests/plugins/test_kanban_events_signal_ws.py
+++ b/tests/plugins/test_kanban_events_signal_ws.py
@@ -149,6 +149,18 @@ async def test_signal_mode_requires_board(kanban_home, monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_signal_mode_rejects_nonexistent_board(kanban_home, monkeypatch):
+    mod = _load_plugin_module()
+    monkeypatch.setattr(mod, "_ws_upgrade_authorized", lambda ws: True)
+    ws = _FakeWebSocket([("view", "signal"), ("board", "no-such-board")])
+
+    await asyncio.wait_for(mod.stream_events(ws), timeout=5)
+
+    assert not ws.accepted
+    assert ws.closed_with == mod.http_status.WS_1008_POLICY_VIOLATION
+
+
+@pytest.mark.asyncio
 async def test_signal_mode_rejects_malformed_since_instead_of_coercing(kanban_home, monkeypatch):
     mod = _load_plugin_module()
     monkeypatch.setattr(mod, "_ws_upgrade_authorized", lambda ws: True)

--- a/tests/plugins/test_kanban_read_model_signal.py
+++ b/tests/plugins/test_kanban_read_model_signal.py
@@ -1,0 +1,118 @@
+"""Kanban dashboard plugin: GET/HEAD /read-model/signal (issue #86808).
+
+The generic Kanban read-model surface exists so external dashboard
+plugins can read operational graph/status signals without over-fetching
+sensitive fields (task body/result/workspace path, run error/summary/
+metadata) or coupling to the raw SQLite schema. This covers the REST
+half of the contract: strict query validation, the allowlisted
+redaction, and the no-store cache header.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from hermes_cli import kanban_db as kb
+
+
+def _load_plugin_router():
+    repo_root = Path(__file__).resolve().parents[2]
+    plugin_file = repo_root / "plugins" / "kanban" / "dashboard" / "plugin_api.py"
+    spec = importlib.util.spec_from_file_location("hermes_kanban_plugin_signal_test", plugin_file)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = mod
+    spec.loader.exec_module(mod)
+    return mod.router
+
+
+@pytest.fixture
+def kanban_home(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb.init_db()
+    return home
+
+
+@pytest.fixture
+def client(kanban_home):
+    app = FastAPI()
+    app.include_router(_load_plugin_router(), prefix="/api/plugins/kanban")
+    return TestClient(app)
+
+
+@pytest.fixture
+def sensitive_task(kanban_home):
+    """A task carrying every field the signal surface must never expose."""
+    conn = kb.connect(board="default")
+    try:
+        task_id = kb.create_task(
+            conn,
+            title="fix the thing",
+            body="SECRET-PROMPT-BODY",
+            workspace_path="/home/alice/.ssh/id_rsa",
+            board="default",
+        )
+        conn.execute(
+            "UPDATE tasks SET result = ?, claim_lock = ?, last_failure_error = ? WHERE id = ?",
+            ("SECRET-RESULT", "SECRET-CLAIM-TOKEN", "SECRET-RAW-ERROR", task_id),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+    return task_id
+
+
+def test_signal_read_model_requires_board(client):
+    r = client.get("/api/plugins/kanban/read-model/signal")
+    assert r.status_code == 400
+
+
+def test_signal_read_model_rejects_unknown_param(client):
+    r = client.get("/api/plugins/kanban/read-model/signal?board=default&color=blue")
+    assert r.status_code == 400
+
+
+def test_signal_read_model_rejects_duplicate_param(client):
+    r = client.get("/api/plugins/kanban/read-model/signal?board=default&board=default")
+    assert r.status_code == 400
+
+
+def test_signal_read_model_redacts_sensitive_fields(client, sensitive_task):
+    r = client.get("/api/plugins/kanban/read-model/signal?board=default")
+    assert r.status_code == 200, r.text
+    assert r.headers["cache-control"] == "private, no-store"
+
+    body = r.json()
+    task = next(t for t in body["tasks"] if t["id"] == sensitive_task)
+    assert task["title"] == "fix the thing"
+    assert task["status"]
+
+    blob = str(body)
+    for secret in ("SECRET-PROMPT-BODY", "SECRET-RESULT", "SECRET-CLAIM-TOKEN", "SECRET-RAW-ERROR", "/home/alice/.ssh/id_rsa"):
+        assert secret not in blob
+
+    for forbidden_key in ("body", "result", "workspace_path", "claim_lock", "last_failure_error"):
+        assert forbidden_key not in task
+
+
+def test_signal_read_model_head(client, sensitive_task):
+    r = client.head("/api/plugins/kanban/read-model/signal?board=default")
+    assert r.status_code == 200
+    assert r.headers["cache-control"] == "private, no-store"
+    assert r.content == b""
+
+
+def test_capabilities_lists_signal_capabilities(client):
+    r = client.get("/api/plugins/kanban/capabilities")
+    assert r.status_code == 200
+    caps = r.json()["capabilities"]
+    assert "kanban.read_model.signal.v1" in caps
+    assert "kanban.events.signal.v1" in caps


### PR DESCRIPTION
## What does this PR do?

The bundled Kanban dashboard exposes its full board/task payloads and a legacy `/events` WebSocket whose frames include raw event `payload`. External dashboard plugins that only need operational graph/status signals must either over-fetch sensitive fields or couple directly to the Kanban SQLite schema. The legacy `/events` compatibility path also coerces a malformed `since` value to `0`, which is fine for legacy callers but unsuitable for a strict, versioned consumer.

This adds a backward-compatible, authenticated Kanban read surface:

- `GET`/`HEAD /api/plugins/kanban/read-model/signal?board=<slug>` — strict explicit `board` param, no unknown/duplicate query params, `Cache-Control: private, no-store`, allowlisted task/link/run fields only (never `body`, `result`, `prompt`, `path`/`workspace_path`, `claim_lock`, raw `error`, `summary`, `metadata`, or event payload).
- `view=signal` mode on the existing `WS /api/plugins/kanban/events` — strict canonical query validation (unknown/duplicate params, malformed/negative `since` all reject the upgrade instead of coercing), allowlisted event fields (no `payload`), and a `generation`/`cursor`/`reset` envelope: the lowest surviving `task_events.id` doubles as a generation marker, and a client whose cursor predates it (because retention — `kanban_db.gc_events` — reclaimed that history) gets an explicit `reset` frame instead of silently seeing "nothing happened".
- `view` absent keeps the legacy WebSocket byte-compatible — same message shape, same silent `since` coercion.
- `GET /api/plugins/kanban/capabilities` — discoverable capability strings: `kanban.read_model.signal.v1` and `kanban.events.signal.v1`.

## Related Issue

Fixes #86808

## Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `plugins/kanban/dashboard/plugin_api.py`:
  - `_resolve_board_strict` / `_reject_unknown_query_params` — strict, mandatory-board query validation for the REST surface.
  - `_signal_task_dict` / `_signal_run_dict` / `_signal_event_dict` — allowlisted redaction helpers.
  - `GET /capabilities` and `GET`/`HEAD /read-model/signal` endpoints.
  - `_signal_ws_validation_error` and `view=signal` handling inside `stream_events` (the `/events` WebSocket): strict query validation before `ws.accept()`, redacted+versioned event frames, and the reset-on-retention-gap frame. The legacy (`view` absent) branch is untouched.

## How to Test

1. `pytest tests/plugins/test_kanban_read_model_signal.py tests/plugins/test_kanban_events_signal_ws.py -q` — new tests covering: mandatory/strict `board`, unknown/duplicate query rejection, field redaction, `Cache-Control`, HEAD support, capability discovery, WS strict validation (unknown/duplicate param, missing board, malformed/negative `since` all reject the upgrade), redacted+versioned event frames, and the reset frame when a cursor predates the retention floor.
2. `pytest tests/plugins/ -k kanban -q` — full existing Kanban plugin suite (97 tests), confirming the legacy `/events` WebSocket and REST surfaces are unaffected.

```
$ pytest tests/plugins/test_kanban_read_model_signal.py tests/plugins/test_kanban_events_signal_ws.py -q
.............
13 passed in ~1s

$ pytest tests/plugins/ -k kanban -q
97 passed, 2 skipped in ~15s
```

Verified the new tests fail without the fix: checked out `plugins/kanban/dashboard/plugin_api.py` from the pre-fix commit while keeping the new test files, re-ran — 12 of the 13 new tests failed (404s on the new REST routes, WS upgrades accepted instead of rejected, unversioned/unredacted legacy frames); the one that passed (`test_legacy_mode_still_coerces_malformed_since`) is the byte-compatibility control, which is expected to hold either way. Restored the fix and confirmed all 13 pass again.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`feat(kanban):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate (see issue comment re: #61982, which proposes a broader CRUD surface without the versioned read-only signal contract)
- [x] My PR contains only changes related to this feature
- [x] I've run `pytest tests/plugins/ -k kanban -q` and all tests pass
- [x] I've added tests for my changes
- [ ] I've tested on my platform — CI/sandbox only, not manually verified on a specific OS

### Documentation & Housekeeping

- [x] N/A — no config keys, no architecture/workflow change beyond the plugin route surface documented in the module docstring
- [x] Cross-platform impact — pure Python/SQLite, no platform-specific code paths

## Disclosure

This change was developed with AI assistance (an autonomous Claude Code agent), with the diff reviewed before submission.
