### PR TITLE
fix(gateway): allow launchd service outside Aqua sessions

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -4360,12 +4360,7 @@ def generate_launchd_plist() -> str:
         <string>{hermes_home}</string>
     </dict>
 
-    <key>LimitLoadToSessionType</key>
-    <array>
-        <string>Aqua</string>
-        <string>Background</string>
-    </array>
-    
+
     <key>RunAtLoad</key>
     <true/>
     

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -233,6 +233,12 @@ class TestGeneratedSystemdUnits:
         assert str(local_bin) in plist
         assert str(profile_node_bin) not in plist
 
+    def test_launchd_plist_omits_limit_load_to_session_type(self):
+        """The gateway must not be restricted to Aqua login sessions."""
+        plist = gateway_cli.generate_launchd_plist()
+
+        assert "LimitLoadToSessionType" not in plist
+
     def test_launchd_plist_persists_configured_nofile_soft_limit(self, monkeypatch):
         """The generated plist must carry SoftResourceLimits/NumberOfFiles so a
         plist rewrite by `hermes gateway start` cannot strip the FD floor and


### PR DESCRIPTION
## Summary

Remove `LimitLoadToSessionType` from the generated macOS launchd gateway plist. This allows launchd to supervise the gateway outside an interactive Aqua login session.

## Changes

- Remove the session-type restriction from `generate_launchd_plist()`
- Add a regression test ensuring the key remains absent

## Testing

- `80 passed, 1 skipped`
- `git diff origin/main --check`

The skipped test is Linux-only and was skipped on macOS.