### PR TITLE
feat(kanban): add versioned signal read model

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -133,6 +133,7 @@ VALID_BLOCK_KINDS = {"dependency", "needs_input", "capability", "transient"}
 # not dispatcher spawn/crash/timeout failures.
 BLOCK_RECURRENCE_LIMIT = 2
 VALID_WORKSPACE_KINDS = {"scratch", "worktree", "dir"}
+EVENT_GENERATION_KEY = "task_events_generation"
 
 
 def normalize_reasoning_effort(effort: Optional[str]) -> Optional[str]:
@@ -1448,6 +1449,14 @@ CREATE TABLE IF NOT EXISTS task_events (
     created_at INTEGER NOT NULL
 );
 
+CREATE TABLE IF NOT EXISTS kanban_metadata (
+    key   TEXT PRIMARY KEY,
+    value TEXT NOT NULL
+);
+
+INSERT OR IGNORE INTO kanban_metadata (key, value)
+VALUES ('task_events_generation', lower(hex(randomblob(16))));
+
 -- Historical attempt record. Each time the dispatcher claims a task, a
 -- new row is created here; claim state, PID, heartbeat, runtime cap,
 -- and structured summary all live on the run, not the task. Multiple
@@ -2461,6 +2470,44 @@ def connect(
             conn.close()
             raise
     return conn
+
+
+def _connect_existing_query_only(*, board: str) -> sqlite3.Connection:
+    """Open an existing board without schema initialization or logical writes.
+
+    This is the backend boundary for sanitized read models. ``mode=rw`` fails
+    instead of creating a database when the board disappears between
+    validation and open. ``query_only`` then makes accidental writes on this
+    connection fail closed while still allowing normal SQLite WAL reads.
+    """
+    path = kanban_db_path(board=board)
+    if not path.is_file():
+        raise FileNotFoundError(f"kanban board database does not exist: {board}")
+
+    from hermes_cli.sqlite_safe_read import connect_tracked
+
+    busy_timeout_ms = _resolve_busy_timeout_ms()
+    uri = f"{path.resolve().as_uri()}?mode=rw"
+    conn = connect_tracked(
+        uri,
+        tracking_path=path,
+        connect_fn=sqlite3.connect,
+        uri=True,
+        isolation_level=None,
+        timeout=busy_timeout_ms / 1000.0,
+    )
+    try:
+        conn.row_factory = sqlite3.Row
+        conn.execute(f"PRAGMA busy_timeout={busy_timeout_ms}")
+        conn.execute("PRAGMA query_only=ON")
+        conn.execute("PRAGMA foreign_keys=ON")
+        conn.execute("PRAGMA cell_size_check=ON")
+        if not _schema_is_present(conn):
+            raise RuntimeError(f"kanban board schema is not materialized: {board}")
+        return conn
+    except Exception:
+        conn.close()
+        raise
 
 
 @contextlib.contextmanager
@@ -4319,6 +4366,28 @@ def _append_event(
         "VALUES (?, ?, ?, ?, ?)",
         (task_id, run_id, kind, pl, now),
     )
+
+
+def event_generation(conn: sqlite3.Connection) -> str:
+    """Return the generation that identifies the current event history."""
+    row = conn.execute(
+        "SELECT value FROM kanban_metadata WHERE key = ?",
+        (EVENT_GENERATION_KEY,),
+    ).fetchone()
+    if row is None or not re.fullmatch(r"[0-9a-f]{32}", str(row["value"])):
+        raise RuntimeError("kanban event generation is not materialized")
+    return str(row["value"])
+
+
+def _rotate_event_generation(conn: sqlite3.Connection) -> str:
+    """Rotate event history identity inside the caller's write transaction."""
+    generation = secrets.token_hex(16)
+    conn.execute(
+        "INSERT INTO kanban_metadata (key, value) VALUES (?, ?) "
+        "ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+        (EVENT_GENERATION_KEY, generation),
+    )
+    return generation
 
 
 def _end_run(
@@ -7478,6 +7547,8 @@ def delete_archived_task(conn: sqlite3.Connection, task_id: str) -> bool:
         conn.execute("DELETE FROM task_runs WHERE task_id = ?", (task_id,))
         conn.execute("DELETE FROM kanban_notify_subs WHERE task_id = ?", (task_id,))
         cur = conn.execute("DELETE FROM tasks WHERE id = ?", (task_id,))
+        if cur.rowcount == 1:
+            _rotate_event_generation(conn)
         return cur.rowcount == 1
 
 
@@ -7500,6 +7571,7 @@ def delete_task(conn: sqlite3.Connection, task_id: str) -> bool:
         conn.execute("DELETE FROM task_events WHERE task_id = ?", (task_id,))
         conn.execute("DELETE FROM task_runs WHERE task_id = ?", (task_id,))
         conn.execute("DELETE FROM kanban_notify_subs WHERE task_id = ?", (task_id,))
+        _rotate_event_generation(conn)
     recompute_ready(conn)
     return True
 
@@ -11493,6 +11565,8 @@ def gc_events(
             "(SELECT id FROM tasks WHERE status IN ('done', 'archived'))",
             (cutoff,),
         )
+        if cur.rowcount:
+            _rotate_event_generation(conn)
     return int(cur.rowcount or 0)
 
 

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -38,14 +38,15 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import re
 import sqlite3
 import time
 from dataclasses import asdict
 from pathlib import Path
 from typing import Any, Optional
 
-from fastapi import APIRouter, File, Form, HTTPException, Query, UploadFile, WebSocket, WebSocketDisconnect, status as http_status
-from fastapi.responses import FileResponse
+from fastapi import APIRouter, File, Form, HTTPException, Query, Request, UploadFile, WebSocket, WebSocketDisconnect, status as http_status
+from fastapi.responses import FileResponse, JSONResponse, Response
 from pydantic import BaseModel, Field
 
 from hermes_cli import kanban_db
@@ -2889,6 +2890,351 @@ def set_orchestration_settings(payload: OrchestrationSettingsBody):
     return get_orchestration_settings()
 
 
+# ---------------------------------------------------------------------------
+# Sanitized, versioned read surface for observability-only dashboard plugins
+# ---------------------------------------------------------------------------
+
+_SIGNAL_CAPABILITIES = (
+    "kanban.read_model.signal.v1",
+    "kanban.events.signal.v1",
+)
+_SIGNAL_SCHEMA = "kanban.read_model.signal.v1"
+_SIGNAL_EVENTS_SCHEMA = "kanban.events.signal.v1"
+_SIGNAL_TASK_LIMIT = 500
+_SIGNAL_LINK_LIMIT = 2000
+_SIGNAL_RUN_LIMIT = 1000
+_SIGNAL_AUTH_QUERY_KEYS = frozenset({"token", "ticket", "internal"})
+
+
+def supports_signal_view() -> bool:
+    """Stable capability probe for external dashboard plugins."""
+    return True
+
+
+def _no_store_headers(*, generation: str | None = None, cursor: int | None = None):
+    headers = {
+        "Cache-Control": "private, no-store",
+        "X-Kanban-Capabilities": ", ".join(_SIGNAL_CAPABILITIES),
+    }
+    if generation is not None:
+        headers["X-Kanban-Event-Generation"] = generation
+    if cursor is not None:
+        headers["X-Kanban-Event-Cursor"] = str(cursor)
+    return headers
+
+
+def _strict_query_values(query_params, *, allowed: set[str], required: set[str]):
+    pairs = list(query_params.multi_items())
+    counts: dict[str, int] = {}
+    for key, _value in pairs:
+        counts[key] = counts.get(key, 0) + 1
+    unknown = sorted(set(counts) - allowed)
+    duplicates = sorted(key for key, count in counts.items() if count != 1)
+    missing = sorted(required - set(counts))
+    if unknown or duplicates or missing:
+        problems = []
+        if unknown:
+            problems.append(f"unknown query parameters: {', '.join(unknown)}")
+        if duplicates:
+            problems.append(f"duplicate query parameters: {', '.join(duplicates)}")
+        if missing:
+            problems.append(f"missing query parameters: {', '.join(missing)}")
+        raise ValueError("; ".join(problems))
+    return {key: query_params.get(key) for key in counts}
+
+
+def _resolve_signal_board(raw: str | None) -> str:
+    if not raw:
+        raise ValueError("board is required")
+    try:
+        board = kanban_db._normalize_board_slug(raw)
+    except ValueError as exc:
+        raise ValueError(str(exc)) from exc
+    if not board or board != raw:
+        raise ValueError("board must be a canonical slug")
+    if not kanban_db.board_exists(board):
+        raise FileNotFoundError(f"board {board!r} does not exist")
+    return board
+
+
+def _signal_int(value: Any) -> int | None:
+    if value is None:
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError, OverflowError):
+        return None
+
+
+def _signal_label(value: Any) -> str | None:
+    if value is None:
+        return None
+    text = str(value).strip()
+    if not text:
+        return None
+    if len(text) > 128 or not re.fullmatch(r"[A-Za-z0-9_.:@-]+", text):
+        return "[REDACTED]"
+    return text
+
+
+def _signal_task(row: sqlite3.Row) -> dict:
+    status = str(row["status"])
+    block_kind = row["block_kind"]
+    return {
+        "id": _signal_label(row["id"]),
+        "status": status if status in kanban_db.VALID_STATUSES else "unknown",
+        "priority": _signal_int(row["priority"]) or 0,
+        "assignee": _signal_label(row["assignee"]),
+        "created_at": _signal_int(row["created_at"]),
+        "started_at": _signal_int(row["started_at"]),
+        "completed_at": _signal_int(row["completed_at"]),
+        "current_run_id": _signal_int(row["current_run_id"]),
+        "block_kind": (
+            str(block_kind) if block_kind in kanban_db.VALID_BLOCK_KINDS else None
+        ),
+    }
+
+
+def _build_signal_read_model(board: str) -> dict:
+    conn = kanban_db._connect_existing_query_only(board=board)
+    try:
+        # Keep generation, cursor, tasks, links, and runs on one WAL snapshot.
+        # A concurrent GC must not rotate generation between SELECT statements.
+        conn.execute("BEGIN")
+        task_rows = conn.execute(
+            "SELECT id, status, priority, assignee, created_at, "
+            "started_at, completed_at, current_run_id, block_kind "
+            "FROM tasks WHERE status != 'archived' "
+            "ORDER BY created_at ASC, id ASC LIMIT ?",
+            (_SIGNAL_TASK_LIMIT + 1,),
+        ).fetchall()
+        visible_tasks = task_rows[:_SIGNAL_TASK_LIMIT]
+        link_rows = conn.execute(
+            "WITH visible AS ("
+            " SELECT id FROM tasks WHERE status != 'archived'"
+            " ORDER BY created_at ASC, id ASC LIMIT ?"
+            ") SELECT l.parent_id, l.child_id FROM task_links l "
+            "JOIN visible p ON p.id = l.parent_id "
+            "JOIN visible c ON c.id = l.child_id "
+            "ORDER BY l.parent_id ASC, l.child_id ASC LIMIT ?",
+            (_SIGNAL_TASK_LIMIT, _SIGNAL_LINK_LIMIT + 1),
+        ).fetchall()
+        run_rows = conn.execute(
+            "WITH visible AS ("
+            " SELECT id FROM tasks WHERE status != 'archived'"
+            " ORDER BY created_at ASC, id ASC LIMIT ?"
+            ") SELECT r.id, r.task_id, r.profile, r.status, r.started_at, "
+            "r.ended_at, r.outcome FROM task_runs r "
+            "JOIN visible v ON v.id = r.task_id "
+            "ORDER BY r.id ASC LIMIT ?",
+            (_SIGNAL_TASK_LIMIT, _SIGNAL_RUN_LIMIT + 1),
+        ).fetchall()
+        cursor_row = conn.execute(
+            "SELECT COALESCE(MAX(id), 0) AS cursor FROM task_events"
+        ).fetchone()
+        generation = kanban_db.event_generation(conn)
+        cursor = int(cursor_row["cursor"])
+        truncated = (
+            len(task_rows) > _SIGNAL_TASK_LIMIT
+            or len(link_rows) > _SIGNAL_LINK_LIMIT
+            or len(run_rows) > _SIGNAL_RUN_LIMIT
+        )
+        return {
+            "schema": _SIGNAL_SCHEMA,
+            "capabilities": list(_SIGNAL_CAPABILITIES),
+            "board": board,
+            "generation": generation,
+            "cursor": cursor,
+            "generated_at": int(time.time()),
+            "truncated": truncated,
+            "tasks": [_signal_task(row) for row in visible_tasks],
+            "links": [
+                {
+                    "source": _signal_label(row["parent_id"]),
+                    "target": _signal_label(row["child_id"]),
+                    "kind": "parent-child",
+                }
+                for row in link_rows[:_SIGNAL_LINK_LIMIT]
+            ],
+            "runs": [
+                {
+                    "id": _signal_int(row["id"]),
+                    "task_id": _signal_label(row["task_id"]),
+                    "profile": _signal_label(row["profile"]),
+                    "status": _signal_label(row["status"]),
+                    "started_at": _signal_int(row["started_at"]),
+                    "ended_at": _signal_int(row["ended_at"]),
+                    "outcome": _signal_label(row["outcome"]),
+                }
+                for row in run_rows[:_SIGNAL_RUN_LIMIT]
+            ],
+        }
+    finally:
+        if conn.in_transaction:
+            conn.rollback()
+        conn.close()
+
+
+def _signal_http_response(request: Request):
+    try:
+        values = _strict_query_values(
+            request.query_params, allowed={"board"}, required={"board"}
+        )
+        board = _resolve_signal_board(values["board"])
+    except FileNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    model = _build_signal_read_model(board)
+    headers = _no_store_headers(
+        generation=model["generation"], cursor=model["cursor"]
+    )
+    if request.method == "HEAD":
+        return Response(status_code=200, headers=headers)
+    return JSONResponse(model, headers=headers)
+
+
+@router.get("/capabilities")
+def get_capabilities():
+    return JSONResponse(
+        {"capabilities": list(_SIGNAL_CAPABILITIES)},
+        headers=_no_store_headers(),
+    )
+
+
+@router.get("/read-model/signal")
+def get_signal_read_model(request: Request):
+    return _signal_http_response(request)
+
+
+@router.head("/read-model/signal")
+def head_signal_read_model(request: Request):
+    return _signal_http_response(request)
+
+
+def _parse_signal_ws_query(ws: WebSocket) -> tuple[str, int, str | None]:
+    allowed = {"view", "board", "since", "generation"} | set(
+        _SIGNAL_AUTH_QUERY_KEYS
+    )
+    values = _strict_query_values(
+        ws.query_params,
+        allowed=allowed,
+        required={"view", "board", "since"},
+    )
+    if values["view"] != "signal":
+        raise ValueError("unsupported event view")
+    auth_keys = set(values) & set(_SIGNAL_AUTH_QUERY_KEYS)
+    if len(auth_keys) != 1:
+        raise ValueError("exactly one WebSocket credential is required")
+    board = _resolve_signal_board(values["board"])
+    since = values["since"] or ""
+    if not re.fullmatch(r"0|[1-9][0-9]*", since):
+        raise ValueError("since must be a canonical non-negative integer")
+    cursor = int(since)
+    if cursor > 9_223_372_036_854_775_807:
+        raise ValueError("since exceeds SQLite integer range")
+    generation = values.get("generation")
+    if generation is not None and not re.fullmatch(r"[0-9a-f]{32}", generation):
+        raise ValueError("generation must be 32 lowercase hexadecimal characters")
+    if cursor > 0 and generation is None:
+        raise ValueError("generation is required when since is greater than zero")
+    return board, cursor, generation
+
+
+def _signal_event_frame(
+    board: str,
+    cursor: int,
+    *,
+    initial: bool,
+    expected_generation: str | None = None,
+) -> dict:
+    conn = kanban_db._connect_existing_query_only(board=board)
+    try:
+        # Generation, bounds, and events must describe one WAL snapshot.
+        conn.execute("BEGIN")
+        generation = kanban_db.event_generation(conn)
+        bounds = conn.execute(
+            "SELECT MIN(id) AS min_id, COALESCE(MAX(id), 0) AS max_id "
+            "FROM task_events"
+        ).fetchone()
+        min_id = _signal_int(bounds["min_id"])
+        max_id = int(bounds["max_id"])
+        reset = (
+            (expected_generation is not None and generation != expected_generation)
+            or cursor > max_id
+            or (min_id is not None and cursor < min_id - 1)
+        )
+        events: list[dict] = []
+        new_cursor = max_id if reset else cursor
+        if not reset:
+            rows = conn.execute(
+                "SELECT id, task_id, run_id, kind, created_at "
+                "FROM task_events WHERE id > ? ORDER BY id ASC LIMIT 200",
+                (cursor,),
+            ).fetchall()
+            for row in rows:
+                events.append(
+                    {
+                        "id": int(row["id"]),
+                        "task_id": _signal_label(row["task_id"]),
+                        "run_id": _signal_int(row["run_id"]),
+                        "kind": _signal_label(row["kind"]),
+                        "created_at": _signal_int(row["created_at"]),
+                    }
+                )
+                new_cursor = int(row["id"])
+        return {
+            "schema": _SIGNAL_EVENTS_SCHEMA,
+            "initial": initial,
+            "generation": generation,
+            "reset": reset,
+            "cursor": new_cursor,
+            "events": events,
+        }
+    finally:
+        if conn.in_transaction:
+            conn.rollback()
+        conn.close()
+
+
+async def _stream_signal_events(
+    ws: WebSocket,
+    board: str,
+    cursor: int,
+    expected_generation: str | None,
+):
+    frame = await asyncio.to_thread(
+        _signal_event_frame,
+        board,
+        cursor,
+        initial=True,
+        expected_generation=expected_generation,
+    )
+    await ws.send_json(frame)
+    cursor = int(frame["cursor"])
+    generation = str(frame["generation"])
+    while True:
+        try:
+            message = await asyncio.wait_for(
+                ws.receive(), timeout=_EVENT_POLL_SECONDS
+            )
+            if message["type"] == "websocket.disconnect":
+                return
+        except asyncio.TimeoutError:
+            pass
+        frame = await asyncio.to_thread(
+            _signal_event_frame,
+            board,
+            cursor,
+            initial=False,
+            expected_generation=generation,
+        )
+        if frame["reset"] or frame["events"]:
+            await ws.send_json(frame)
+            cursor = int(frame["cursor"])
+            generation = str(frame["generation"])
+
+
 @router.websocket("/events")
 async def stream_events(ws: WebSocket):
     # Authorize the upgrade via the dashboard's canonical WS gate so the
@@ -2899,6 +3245,31 @@ async def stream_events(ws: WebSocket):
     if not _ws_upgrade_authorized(ws):
         await ws.close(code=http_status.WS_1008_POLICY_VIOLATION)
         return
+
+    # ``view`` absent is the exact legacy protocol below. Signal mode is
+    # additive and strict: malformed, duplicated, or unknown parameters fail
+    # closed before the WebSocket is accepted.
+    if "view" in ws.query_params:
+        try:
+            signal_board, signal_cursor, signal_generation = _parse_signal_ws_query(ws)
+        except (ValueError, FileNotFoundError):
+            await ws.close(code=http_status.WS_1008_POLICY_VIOLATION)
+            return
+        await ws.accept()
+        try:
+            await _stream_signal_events(
+                ws, signal_board, signal_cursor, signal_generation
+            )
+        except (WebSocketDisconnect, asyncio.CancelledError):
+            return
+        except Exception as exc:
+            log.warning("Kanban signal event stream error: %s", exc)
+            try:
+                await ws.close()
+            except Exception:
+                pass
+        return
+
     await ws.accept()
     try:
         since_raw = ws.query_params.get("since", "0")

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -2944,6 +2944,7 @@ def _strict_query_values(query_params, *, allowed: set[str], required: set[str])
 
 
 def _resolve_signal_board(raw: str | None) -> str:
+    """Require an existing board expressed as its exact canonical slug."""
     if not raw:
         raise ValueError("board is required")
     try:

--- a/tests/plugins/test_kanban_signal_read_model.py
+++ b/tests/plugins/test_kanban_signal_read_model.py
@@ -372,6 +372,31 @@ def test_signal_websocket_rejects_noncanonical_queries(signal_client, query):
     assert exc.value.code == 1008
 
 
+def test_signal_ws_delegates_to_canonical_web_auth(signal_home, monkeypatch):
+    module = _load_plugin_module()
+    observed = []
+
+    from hermes_cli import web_server
+
+    def deny(websocket):
+        observed.append(websocket)
+        return False
+
+    monkeypatch.setattr(web_server, "_ws_auth_ok", deny)
+    app = FastAPI()
+    app.include_router(module.router, prefix="/api/plugins/kanban")
+
+    with TestClient(app) as client:
+        with pytest.raises(WebSocketDisconnect) as exc:
+            with client.websocket_connect(
+                "/api/plugins/kanban/events?view=signal&board=default&since=0&token=denied"
+            ):
+                pass
+
+    assert exc.value.code == 1008
+    assert len(observed) == 1
+
+
 def test_signal_websocket_resets_after_history_rotation(signal_client):
     conn = kb.connect()
     try:

--- a/tests/plugins/test_kanban_signal_read_model.py
+++ b/tests/plugins/test_kanban_signal_read_model.py
@@ -1,0 +1,488 @@
+"""Contract tests for the Kanban sanitized signal read surface."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import re
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from starlette.websockets import WebSocketDisconnect
+
+from hermes_cli import kanban_db as kb
+
+CAPABILITIES = {
+    "kanban.read_model.signal.v1",
+    "kanban.events.signal.v1",
+}
+DENIED_KEYS = {
+    "title",
+    "body",
+    "result",
+    "prompt",
+    "workspace_path",
+    "branch_name",
+    "claim_lock",
+    "error",
+    "summary",
+    "metadata",
+    "payload",
+    "last_failure_error",
+}
+
+
+def _load_plugin_module():
+    repo_root = Path(__file__).resolve().parents[2]
+    plugin_file = repo_root / "plugins" / "kanban" / "dashboard" / "plugin_api.py"
+    spec = importlib.util.spec_from_file_location(
+        "hermes_dashboard_plugin_kanban_signal_test", plugin_file,
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def signal_home(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb.init_db()
+    return home
+
+
+@pytest.fixture
+def signal_client(signal_home, monkeypatch):
+    module = _load_plugin_module()
+    monkeypatch.setattr(module, "_ws_upgrade_authorized", lambda _ws: True)
+    app = FastAPI()
+    app.include_router(module.router, prefix="/api/plugins/kanban")
+    with TestClient(app) as client:
+        yield client
+
+
+def _all_keys(value):
+    if isinstance(value, dict):
+        for key, child in value.items():
+            yield key
+            yield from _all_keys(child)
+    elif isinstance(value, list):
+        for child in value:
+            yield from _all_keys(child)
+
+
+def _seed_sensitive_graph():
+    secret = "ghp_fake-canary-credential"
+    conn = kb.connect()
+    try:
+        parent = kb.create_task(
+            conn,
+            title=f"Deploy {secret}",
+            body=f"password={secret}",
+            assignee="dev",
+            priority=3,
+        )
+        child = kb.create_task(
+            conn,
+            title="Verify release",
+            body=f"/root/private/{secret}",
+            assignee="qa",
+            priority=1,
+        )
+        conn.execute(
+            "UPDATE tasks SET result=?, workspace_path=?, branch_name=?, "
+            "last_failure_error=? WHERE id=?",
+            (secret, f"/tmp/{secret}", secret, secret, parent),
+        )
+        conn.execute(
+            "INSERT INTO task_links (parent_id, child_id) VALUES (?, ?)",
+            (parent, child),
+        )
+        conn.execute(
+            "INSERT INTO task_runs "
+            "(task_id, profile, status, started_at, summary, metadata, error) "
+            "VALUES (?, ?, 'done', 10, ?, ?, ?)",
+            (parent, "dev", secret, json.dumps({"token": secret}), secret),
+        )
+        return secret, parent, child
+    finally:
+        conn.close()
+
+
+def test_signal_connector_is_query_only_and_never_creates_board(signal_home):
+    conn = kb._connect_existing_query_only(board="default")
+    try:
+        assert conn.execute("PRAGMA query_only").fetchone()[0] == 1
+        with pytest.raises(sqlite3.OperationalError):
+            conn.execute("INSERT INTO kanban_metadata (key, value) VALUES ('x', 'y')")
+    finally:
+        conn.close()
+
+    missing_path = kb.kanban_db_path(board="never-created")
+    assert not missing_path.exists()
+    with pytest.raises(FileNotFoundError):
+        kb._connect_existing_query_only(board="never-created")
+    assert not missing_path.exists()
+
+
+def test_signal_capabilities_are_discoverable_and_not_cached(signal_client):
+    response = signal_client.get("/api/plugins/kanban/capabilities")
+    assert response.status_code == 200
+    assert set(response.json()["capabilities"]) == CAPABILITIES
+    assert response.headers["cache-control"] == "private, no-store"
+
+
+def test_signal_read_model_get_head_allowlists_and_redacts(signal_client):
+    secret, parent, child = _seed_sensitive_graph()
+    url = "/api/plugins/kanban/read-model/signal?board=default"
+
+    response = signal_client.get(url)
+    assert response.status_code == 200, response.text
+    data = response.json()
+    assert set(data) == {
+        "schema",
+        "capabilities",
+        "board",
+        "generation",
+        "cursor",
+        "generated_at",
+        "truncated",
+        "tasks",
+        "links",
+        "runs",
+    }
+    assert data["schema"] == "kanban.read_model.signal.v1"
+    assert data["truncated"] is False
+    assert set(data["capabilities"]) == CAPABILITIES
+    assert data["board"] == "default"
+    assert re.fullmatch(r"[0-9a-f]{32}", data["generation"])
+    assert response.headers["cache-control"] == "private, no-store"
+    assert response.headers["x-kanban-event-generation"] == data["generation"]
+    assert int(response.headers["x-kanban-event-cursor"]) == data["cursor"]
+
+    text = response.text
+    assert secret not in text
+    assert DENIED_KEYS.isdisjoint(set(_all_keys(data)))
+    assert {task["id"] for task in data["tasks"]} == {parent, child}
+    assert set(data["tasks"][0]) == {
+        "id",
+        "status",
+        "priority",
+        "assignee",
+        "created_at",
+        "started_at",
+        "completed_at",
+        "current_run_id",
+        "block_kind",
+    }
+    assert data["links"] == [
+        {"source": parent, "target": child, "kind": "parent-child"},
+    ]
+    assert set(data["runs"][0]) == {
+        "id",
+        "task_id",
+        "profile",
+        "status",
+        "started_at",
+        "ended_at",
+        "outcome",
+    }
+
+    head = signal_client.head(url)
+    assert head.status_code == 200
+    assert head.content == b""
+    assert head.headers["cache-control"] == "private, no-store"
+    assert head.headers["x-kanban-event-generation"] == data["generation"]
+    assert int(head.headers["x-kanban-event-cursor"]) == data["cursor"]
+
+
+@pytest.mark.parametrize(
+    "query,status_code",
+    [
+        ("", 400),
+        ("?board=default&board=default", 400),
+        ("?board=default&extra=1", 400),
+        ("?board=../default", 400),
+        ("?board=missing", 404),
+    ],
+)
+def test_signal_read_model_rejects_noncanonical_queries(
+    signal_client, query, status_code,
+):
+    response = signal_client.get(f"/api/plugins/kanban/read-model/signal{query}")
+    assert response.status_code == status_code
+
+
+def test_signal_read_model_bounds_links_and_marks_truncation(
+    signal_client, monkeypatch,
+):
+    module = sys.modules["hermes_dashboard_plugin_kanban_signal_test"]
+    monkeypatch.setattr(module, "_SIGNAL_LINK_LIMIT", 1)
+    conn = kb.connect()
+    try:
+        parent = kb.create_task(conn, title="parent", assignee="pm")
+        first = kb.create_task(conn, title="first", assignee="dev")
+        second = kb.create_task(conn, title="second", assignee="qa")
+        conn.execute(
+            "INSERT INTO task_links (parent_id, child_id) VALUES (?, ?), (?, ?)",
+            (parent, first, parent, second),
+        )
+    finally:
+        conn.close()
+
+    response = signal_client.get(
+        "/api/plugins/kanban/read-model/signal?board=default"
+    )
+    assert response.status_code == 200
+    assert response.json()["truncated"] is True
+    assert len(response.json()["links"]) == 1
+
+
+def test_event_generation_rotates_only_when_gc_deletes_history(signal_home):
+    conn = kb.connect()
+    try:
+        task_id = kb.create_task(conn, title="old", assignee="qa")
+        conn.execute("UPDATE tasks SET status='done' WHERE id=?", (task_id,))
+        conn.execute(
+            "UPDATE task_events SET created_at=0 WHERE task_id=?",
+            (task_id,),
+        )
+        before = kb.event_generation(conn)
+        assert kb.gc_events(conn, older_than_seconds=1) > 0
+        after = kb.event_generation(conn)
+        assert after != before
+        assert kb.gc_events(conn, older_than_seconds=1) == 0
+        assert kb.event_generation(conn) == after
+    finally:
+        conn.close()
+
+
+def test_event_generation_is_stable_for_append_only_history(signal_home):
+    conn = kb.connect()
+    try:
+        before = kb.event_generation(conn)
+        kb.create_task(conn, title="one", assignee="qa")
+        kb.create_task(conn, title="two", assignee="dev")
+        assert kb.event_generation(conn) == before
+    finally:
+        conn.close()
+
+
+def test_event_generation_is_materialized_for_legacy_board(signal_home):
+    conn = kb.connect()
+    try:
+        conn.execute("DROP TABLE kanban_metadata")
+    finally:
+        conn.close()
+
+    kb.init_db()
+    conn = kb.connect()
+    try:
+        assert re.fullmatch(r"[0-9a-f]{32}", kb.event_generation(conn))
+    finally:
+        conn.close()
+
+
+def test_event_generation_rotates_with_hard_delete(signal_home):
+    conn = kb.connect()
+    try:
+        task_id = kb.create_task(conn, title="delete", assignee="qa")
+        conn.execute("DELETE FROM task_events WHERE task_id=?", (task_id,))
+        before = kb.event_generation(conn)
+        assert kb.delete_task(conn, task_id) is True
+        assert kb.event_generation(conn) != before
+    finally:
+        conn.close()
+
+
+def test_event_generation_rotates_with_archived_delete(signal_home):
+    conn = kb.connect()
+    try:
+        task_id = kb.create_task(conn, title="archive", assignee="qa")
+        assert kb.archive_task(conn, task_id) is True
+        before = kb.event_generation(conn)
+        assert kb.delete_archived_task(conn, task_id) is True
+        assert kb.event_generation(conn) != before
+    finally:
+        conn.close()
+
+
+def test_signal_websocket_sends_initial_allowlisted_frame(signal_client):
+    secret, parent, _child = _seed_sensitive_graph()
+    path = (
+        "/api/plugins/kanban/events"
+        "?view=signal&board=default&since=0&token=test"
+    )
+    with signal_client.websocket_connect(path) as websocket:
+        frame = websocket.receive_json()
+
+    assert set(frame) == {
+        "schema",
+        "initial",
+        "generation",
+        "reset",
+        "cursor",
+        "events",
+    }
+    assert frame["schema"] == "kanban.events.signal.v1"
+    assert frame["initial"] is True
+    assert frame["reset"] is False
+    assert re.fullmatch(r"[0-9a-f]{32}", frame["generation"])
+    assert frame["events"]
+    assert {event["task_id"] for event in frame["events"]} >= {parent}
+    assert all(
+        set(event) == {"id", "task_id", "run_id", "kind", "created_at"}
+        for event in frame["events"]
+    )
+    assert secret not in json.dumps(frame)
+    assert "payload" not in set(_all_keys(frame))
+
+
+@pytest.mark.parametrize(
+    "query",
+    [
+        "?view=signal&board=default&token=test",
+        "?view=signal&since=0&token=test",
+        "?view=signal&board=default&since=-1&token=test",
+        "?view=signal&board=default&since=01&token=test",
+        "?view=signal&board=default&since=x&token=test",
+        "?view=signal&board=default&since=1&token=test",
+        "?view=signal&board=default&since=1&generation=bad&token=test",
+        "?view=signal&board=default&since=1&generation=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA&token=test",
+        "?view=signal&board=default&since=1&generation=00000000000000000000000000000000&generation=11111111111111111111111111111111&token=test",
+        "?view=signal&view=signal&board=default&since=0&token=test",
+        "?view=signal&board=default&since=0&token=test&ticket=test",
+        "?view=signal&board=default&since=0&extra=1&token=test",
+    ],
+)
+def test_signal_websocket_rejects_noncanonical_queries(signal_client, query):
+    with pytest.raises(WebSocketDisconnect) as exc:
+        with signal_client.websocket_connect(
+            f"/api/plugins/kanban/events{query}",
+        ):
+            pass
+    assert exc.value.code == 1008
+
+
+def test_signal_websocket_resets_after_history_rotation(signal_client):
+    conn = kb.connect()
+    try:
+        task_id = kb.create_task(conn, title="old", assignee="qa")
+        conn.execute("UPDATE tasks SET status='done' WHERE id=?", (task_id,))
+        cursor = conn.execute(
+            "SELECT MAX(id) FROM task_events WHERE task_id=?", (task_id,),
+        ).fetchone()[0]
+        old_generation = kb.event_generation(conn)
+        conn.execute("UPDATE task_events SET created_at=0 WHERE task_id=?", (task_id,))
+        assert kb.gc_events(conn, older_than_seconds=1) > 0
+        assert kb.event_generation(conn) != old_generation
+    finally:
+        conn.close()
+
+    path = (
+        "/api/plugins/kanban/events"
+        f"?view=signal&board=default&since={cursor}"
+        f"&generation={old_generation}&token=test"
+    )
+    with signal_client.websocket_connect(path) as websocket:
+        frame = websocket.receive_json()
+    assert frame["initial"] is True
+    assert frame["reset"] is True
+    assert frame["events"] == []
+
+
+def test_signal_websocket_pushes_reset_when_generation_changes(signal_client):
+    conn = kb.connect()
+    try:
+        task_id = kb.create_task(conn, title="old", assignee="qa")
+        conn.execute("UPDATE tasks SET status='done' WHERE id=?", (task_id,))
+        cursor = conn.execute(
+            "SELECT MAX(id) FROM task_events WHERE task_id=?", (task_id,),
+        ).fetchone()[0]
+        generation = kb.event_generation(conn)
+    finally:
+        conn.close()
+
+    path = (
+        "/api/plugins/kanban/events"
+        f"?view=signal&board=default&since={cursor}"
+        f"&generation={generation}&token=test"
+    )
+    with signal_client.websocket_connect(path) as websocket:
+        initial = websocket.receive_json()
+        assert initial["reset"] is False
+
+        conn = kb.connect()
+        try:
+            conn.execute(
+                "UPDATE task_events SET created_at=0 WHERE task_id=?", (task_id,),
+            )
+            assert kb.gc_events(conn, older_than_seconds=1) > 0
+        finally:
+            conn.close()
+
+        reset = websocket.receive_json()
+
+    assert reset["initial"] is False
+    assert reset["reset"] is True
+    assert reset["generation"] != initial["generation"]
+    assert reset["events"] == []
+
+
+def test_signal_reconnect_detects_internal_history_gap(signal_client):
+    conn = kb.connect()
+    try:
+        task_ids = [
+            kb.create_task(conn, title=f"task-{index}", assignee="qa")
+            for index in range(3)
+        ]
+        conn.execute(
+            "UPDATE tasks SET status='done' WHERE id IN (?, ?, ?)", task_ids,
+        )
+        cursor = conn.execute("SELECT MAX(id) FROM task_events").fetchone()[0]
+        generation = kb.event_generation(conn)
+        conn.execute(
+            "UPDATE task_events SET created_at=0 WHERE task_id=?", (task_ids[1],),
+        )
+        assert kb.gc_events(conn, older_than_seconds=1) == 1
+    finally:
+        conn.close()
+
+    path = (
+        "/api/plugins/kanban/events"
+        f"?view=signal&board=default&since={cursor}"
+        f"&generation={generation}&token=test"
+    )
+    with signal_client.websocket_connect(path) as websocket:
+        frame = websocket.receive_json()
+
+    assert frame["initial"] is True
+    assert frame["reset"] is True
+    assert frame["events"] == []
+
+
+def test_legacy_websocket_still_emits_raw_event_envelope(signal_client):
+    _secret, parent, _child = _seed_sensitive_graph()
+    path = "/api/plugins/kanban/events?since=0&token=test"
+    with signal_client.websocket_connect(path) as websocket:
+        frame = websocket.receive_json()
+
+    assert set(frame) == {"events", "cursor"}
+    event = next(item for item in frame["events"] if item["task_id"] == parent)
+    assert "payload" in event
+
+
+def test_legacy_websocket_still_coerces_malformed_since_to_zero(signal_client):
+    _secret, parent, _child = _seed_sensitive_graph()
+    path = "/api/plugins/kanban/events?since=bad&token=test"
+    with signal_client.websocket_connect(path) as websocket:
+        frame = websocket.receive_json()
+    assert any(item["task_id"] == parent for item in frame["events"])

--- a/tests/plugins/test_kanban_signal_read_model.py
+++ b/tests/plugins/test_kanban_signal_read_model.py
@@ -298,7 +298,10 @@ def test_event_generation_rotates_with_hard_delete(signal_home):
         conn.execute("DELETE FROM task_events WHERE task_id=?", (task_id,))
         before = kb.event_generation(conn)
         assert kb.delete_task(conn, task_id) is True
-        assert kb.event_generation(conn) != before
+        after = kb.event_generation(conn)
+        assert after != before
+        assert kb.delete_task(conn, task_id) is False
+        assert kb.event_generation(conn) == after
     finally:
         conn.close()
 

--- a/website/docs/user-guide/features/kanban.md
+++ b/website/docs/user-guide/features/kanban.md
@@ -625,7 +625,7 @@ And the two auxiliary LLM slots:
 
 ### Architecture
 
-The GUI is strictly a **read-through-the-DB + write-through-kanban_db** layer with no domain logic of its own:
+The bundled GUI is a **read-through-the-DB + write-through-kanban_db** layer with no domain logic of its own. External observability plugins can use the sanitized signal read surface described below instead of consuming the full board model.
 
 <!-- ascii-guard-ignore -->
 ```
@@ -655,6 +655,8 @@ All routes are mounted under `/api/plugins/kanban/` and protected by the dashboa
 
 | Method | Path | Purpose |
 |---|---|---|
+| `GET` | `/capabilities` | Advertise versioned, additive Kanban API capabilities |
+| `GET` / `HEAD` | `/read-model/signal?board=<slug>` | Bounded, sanitized task/link/run projection for observability-only plugins |
 | `GET` | `/board?tenant=<name>&include_archived=…` | Full board grouped by status column, plus tenants + assignees for filter dropdowns |
 | `GET` | `/tasks/:id` | Task + comments + events + links |
 | `POST` | `/tasks` | Create (wraps `kanban_db.create_task`, accepts `triage: bool` and `parents: [id, …]`) |
@@ -672,9 +674,18 @@ All routes are mounted under `/api/plugins/kanban/` and protected by the dashboa
 | `DELETE` | `/links?parent_id=…&child_id=…` | Remove a dependency |
 | `POST` | `/dispatch?max=…&dry_run=…` | Nudge the dispatcher — skip the 60 s wait |
 | `GET` | `/config` | Read `dashboard.kanban` preferences from `config.yaml` — `default_tenant`, `lane_by_profile`, `include_archived_by_default`, `render_markdown` |
-| `WS` | `/events?since=<event_id>` | Live stream of `task_events` rows |
+| `WS` | `/events?since=<event_id>` | Legacy live stream of `task_events` rows, including payloads |
+| `WS` | `/events?view=signal&board=<slug>&since=<event_id>&generation=<generation>` | Strict, allowlisted event stream with generation/reset recovery |
 
-Every handler is a thin wrapper — the plugin is ~700 lines of Python (router + WebSocket tail + bulk batcher + config reader) and adds no new business logic. A tiny `_conn()` helper auto-initializes `kanban.db` on every read and write, so a fresh install works whether the user opened the dashboard first, hit the REST API directly, or ran `hermes kanban init`.
+Every handler is a thin wrapper and adds no new task-domain logic. Mutation and full-board routes use `_conn()` to initialize the schema. The signal routes only open an existing board through a private `mode=rw` + `query_only` connection and fail closed when signal state is not materialized.
+
+### Sanitized signal contract
+
+`GET /read-model/signal` is intended for status views, graph visualizations, and other observability-only dashboard plugins. It requires one explicit canonical `board` parameter, rejects duplicate or unknown parameters, returns `Cache-Control: private, no-store`, and advertises `kanban.read_model.signal.v1` plus `kanban.events.signal.v1`.
+
+The projection exposes only bounded task identity/status/timing fields, parent-child links, and bounded run identity/status/timing fields. It never returns task titles, bodies, results, prompts, workspace or branch paths, claim locks, raw errors, summaries, metadata, or event payloads.
+
+Signal WebSocket frames carry `generation`, `cursor`, `reset`, and allowlisted event identity fields. Event-history deletion rotates the generation in the same SQLite transaction. Fresh streams may use `since=0` without `generation`; reconnects with `since>0` must send the generation received with their snapshot or prior frame. A mismatch returns an initial `reset: true`, and the client must fetch a fresh signal read model before applying more events. Omitting `view` preserves the legacy WebSocket protocol unchanged.
 
 ### Dashboard config
 
@@ -693,17 +704,19 @@ Each key is optional and falls back to the shown default.
 
 ### Security model
 
-The dashboard's HTTP auth middleware [explicitly skips `/api/plugins/`](./extending-the-dashboard#backend-api-routes) — plugin routes are unauthenticated by design because the dashboard binds to localhost by default. That means the kanban REST surface is reachable from any process on the host.
+The dashboard's HTTP auth middleware protects `/api/plugins/...` routes with the same session gate used by core API routes. Use the Plugin SDK's `fetchJSON` or `authedFetch`; do not read or assemble credentials in plugin code.
 
-The WebSocket takes one additional step: it requires the dashboard's ephemeral session token as a `?token=…` query parameter (browsers can't set `Authorization` on an upgrade request), matching the pattern used by the in-browser PTY bridge.
+WebSocket clients must use the SDK's `buildWsUrl`. The canonical upgrade gate accepts the correct credential for the active mode: loopback session token, gated single-use ticket, or server-internal credential.
 
-If you run `hermes dashboard --host 0.0.0.0`, every plugin route — kanban included — becomes reachable from the network. **Don't do that on a shared host.** The board contains task bodies, comments, and workspace paths; an attacker reaching these routes gets read access to your entire collaboration surface and can also create / reassign / archive tasks.
+Binding the dashboard beyond loopback still increases exposure. Anyone who obtains a valid dashboard session can access the full legacy board surface, including task bodies, comments, and workspace paths. Prefer the signal surface for plugins that need only operational status.
 
 Tasks in `~/.hermes/kanban.db` are profile-agnostic on purpose (that's the coordination primitive). If you open the dashboard with `hermes -p <profile> dashboard`, the board still shows tasks created by any other profile on the host. Same user owns all profiles, but this is worth knowing if multiple personas coexist.
 
 ### Live updates
 
-`task_events` is an append-only SQLite table with a monotonic `id`. The WebSocket endpoint holds each client's last-seen event id and pushes new rows as they land. When a burst of events arrives, the frontend reloads the (very cheap) board endpoint — simpler and more correct than trying to patch local state from every event kind. WAL mode means the read loop never blocks the dispatcher's `BEGIN IMMEDIATE` claim transactions.
+`task_events` normally grows with a monotonic `id`. The legacy WebSocket holds each client's last-seen event id and pushes new rows as they land. When a burst arrives, the frontend reloads the board endpoint instead of patching local state from every event kind.
+
+Retention or hard deletion can create cursor gaps. The signal WebSocket therefore includes a durable event generation and emits `reset: true` after history changes. WAL mode lets both streams read alongside the dispatcher's `BEGIN IMMEDIATE` claim transactions.
 
 ### Extending it
 

--- a/website/docs/user-guide/features/kanban.md
+++ b/website/docs/user-guide/features/kanban.md
@@ -685,6 +685,8 @@ Every handler is a thin wrapper and adds no new task-domain logic. Mutation and 
 
 The projection exposes only bounded task identity/status/timing fields, parent-child links, and bounded run identity/status/timing fields. It never returns task titles, bodies, results, prompts, workspace or branch paths, claim locks, raw errors, summaries, metadata, or event payloads.
 
+When `truncated` is `true`, tasks are partial and links and runs cover only that visible task set. Clients must not infer board-wide completeness or compute integral board metrics from that response; they should render an explicit partial state or fail closed.
+
 Signal WebSocket frames carry `generation`, `cursor`, `reset`, and allowlisted event identity fields. Event-history deletion rotates the generation in the same SQLite transaction. Fresh streams may use `since=0` without `generation`; reconnects with `since>0` must send the generation received with their snapshot or prior frame. A mismatch returns an initial `reset: true`, and the client must fetch a fresh signal read model before applying more events. Omitting `view` preserves the legacy WebSocket protocol unchanged.
 
 ### Dashboard config


### PR DESCRIPTION
1|## Problem
2|
3|The bundled Kanban dashboard currently offers either the full board/task payloads or the legacy event WebSocket, whose frames include raw event `payload`. Observability-only dashboard plugins therefore lack a narrow integration surface that is safe to consume without reading SQLite directly.
4|
5|## Approach
6|
7|- Add versioned capabilities:
8|  - `kanban.read_model.signal.v1`
9|  - `kanban.events.signal.v1`
10|- Add bounded `GET`/`HEAD /api/plugins/kanban/read-model/signal?board=<slug>` responses with `private, no-store` and a strict allowlist.
11|- Exclude all arbitrary task text, raw errors, paths, metadata, and event payloads.
12|- Open existing boards through a private SQLite `mode=rw` + `PRAGMA query_only=ON` connector that never initializes or creates a board.
13|- Add `view=signal` to the existing `/events` WebSocket while preserving the legacy protocol when `view` is absent.
14|- Persist an event-history generation and rotate it transactionally on GC and hard deletes.
15|- Require reconnects with `since>0` to send their last generation, so internal history gaps produce an initial `reset: true`.
16|
17|## Compatibility and safety
18|
19|- No new service, database, external credential, or write API.
20|- No raw SQLite access from dashboard consumers.
21|- No task titles, bodies, results, prompts, workspace/branch paths, claim locks, run errors/summaries/metadata, or raw event payloads.
22|- Legacy `/events` frames remain unchanged when `view` is absent.
23|- Signal mode rejects missing, duplicate, unknown, non-canonical, and ambiguous credential query parameters.
24|- Event generation and deletions commit in the same SQLite transaction.
25|
26|## Relation to existing work
27|
28|PR #61982 proposes a broader external Kanban REST CRUD/control API and dedicated service authentication. Its current code does not implement these versioned read-only signal capabilities, `view=signal`, generation/reset recovery, or the internal query-only connector. This PR stays additive and observability-only; it does not replace that proposal.
29|
30|## Verification
31|
32|- Broad Kanban surface (`66` files across plugin, CLI, tools, gateway, cron, and agent lanes):
33|  - `485 passed`, `0 failed`, `1 skipped` on Linux.
34|- Focused auth and signal gate:
35|  - `123 passed`, `0 failed`, `1 skipped` on Linux.
36|- `uvx ruff check hermes_cli/kanban_db.py plugins/kanban/dashboard/plugin_api.py tests/plugins/test_kanban_signal_read_model.py`
37|  - passed.
38|- Real Uvicorn canary with isolated `HERMES_HOME`:
39|  - HTTP and HEAD `200`;
40|  - two capabilities advertised;
41|  - no secret or payload in signal output;
42|  - matching reconnect returns `reset: false`;
43|  - mismatched generation returns `reset: true`;
44|  - legacy event frame still includes `payload`;
45|  - canary port closed after verification.
46|- Full repository suite:
47|  - exited `1` with `84` failures across `25` files;
48|  - no Kanban file appeared in the failure list;
49|  - first causes were environment-sensitive optional dependencies (`fal_client`, Parallel SDK), disabled lazy installs, and root permission semantics;
50|  - the affected Kanban surface is covered separately by the green `485`-test gate above.
51|
52|Closes #86808
53|
54|## Coordination with concurrent PR #86854
55|
56|PR #86854 is a smaller concurrent implementation and its CI is green. This PR remains the recommended base for #86808 because it also provides these continuity invariants:
57|
58|- the read path opens only an existing board and never calls `init_db` or schema migration;
59|- generation is persisted and rotated transactionally on every event-history deletion path;
60|- nonzero reconnects require the expected generation;
61|- the first WebSocket frame is emitted even when the event batch is empty;
62|- the read model and event batches are bounded.
63|
64|If maintainers prefer #86854, these invariants should be ported before merge. The two PRs should not be merged independently.
65|
66|### Fresh local verification — 2026-08-15
67|
68|- 69 Kanban test files: **495 passed, 0 failed, 1 expected Windows-only skip**.
69|- Focused signal contract: **32 passed**.
70|- The composed Mission Control gate returns ready for this PR and blocked for #86854, current `main`, and the installed runtime.
71|
72|

## Late QA reconciliation

A comparative review still recommends this PR as the stronger technical base over #86854. The first review used an older Mission Control contract that incorrectly required the upstream endpoint itself to return the downstream rich view model. The current contract separates those layers: this PR provides the generic sanitized wire source, while Mission Control must still build its own adapter and Crew view.

Fresh validation against that split contract:

- the actual `GET /read-model/signal` response validates against the closed wire-source allowlist;
- the actual initial `view=signal` frame validates against the closed signal allowlist;
- 64 downstream contract tests pass across 5 schemas and 20 fixtures;
- 33 focused upstream tests pass, including proof that `view=signal` delegates to the canonical web auth boundary;
- this PR is not presented as a complete Mission Control release. The adapter, Crew surface, upstream merge, runtime update, and live gate remain separate blockers.

