### PR TITLE
fix(state): close the #82770 test-fixture escape — ancestry guard + subprocess-surviving isolation marker + never-active prune

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -12683,6 +12683,16 @@ def main():
         action="store_true",
         help="Also delete archived sessions (excluded by default)",
     )
+    sessions_prune.add_argument(
+        "--never-active",
+        action="store_true",
+        help=(
+            "Instead of ended sessions, delete keyed gateway rows that were "
+            "opened and never used (no messages, tokens, tool calls or title) "
+            "and are older than AGE (default 30 days). Ordinary prune can "
+            "never reach these — it only ever selects ended sessions"
+        ),
+    )
 
     sessions_archive = sessions_subparsers.add_parser(
         "archive",

--- a/hermes_cli/sessions_cmd.py
+++ b/hermes_cli/sessions_cmd.py
@@ -55,6 +55,72 @@ def _confirm_prompt(prompt: str) -> bool:
         return False
 
 
+#: Default age floor for `hermes sessions prune --never-active`.  Deliberately
+#: generous: the rows are worthless but harmless, and a young never-active row
+#: may simply be a chat that nobody has replied to yet.
+_NEVER_ACTIVE_DEFAULT_DAYS = 30.0
+
+
+def _prune_never_active_keyed(db, args):
+    """`hermes sessions prune --never-active` — drop leaked/dead keyed rows.
+
+    Targets keyed gateway rows that were opened and never used at all.  The
+    population is dominated by escaped test fixtures (#82770), which the
+    hermetic-isolation guard can only stop from being *created* — rows already
+    written to a developer's state.db need a sweep to leave.
+    """
+    from hermes_cli.session_filters import format_epoch, parse_duration_seconds
+
+    older_than = getattr(args, "older_than", None)
+    if older_than is None:
+        days = _NEVER_ACTIVE_DEFAULT_DAYS
+    else:
+        seconds = parse_duration_seconds(str(older_than))
+        if seconds is None:
+            print(
+                f"Error: --older-than '{older_than}' is not a duration. "
+                "Use a bare number of days or a form like '2d' / '1w'."
+            )
+            return
+        days = seconds / 86400.0
+
+    candidates = db.list_never_active_keyed_sessions(older_than_days=days)
+    if not candidates:
+        print(f"No never-active keyed sessions older than {days:g} day(s).")
+        return
+
+    shown = candidates if args.dry_run else candidates[:15]
+    print(
+        f"{len(candidates)} never-active keyed session(s) older than "
+        f"{days:g} day(s) — no messages, tokens, tool calls or title:"
+    )
+    for s in shown:
+        print(
+            f"  {s['id']}  {format_epoch(s.get('started_at')):<17} "
+            f"{(s.get('source') or '-'):<10} {s.get('session_key') or '-'}"
+        )
+    if len(candidates) > len(shown):
+        print(f"  … {len(candidates) - len(shown)} more")
+
+    if args.dry_run:
+        print("Dry run — nothing deleted.")
+        return
+    if not args.yes and not _confirm_prompt(
+        f"Delete {len(candidates)} session(s)? [y/N] "
+    ):
+        print("Aborted.")
+        return
+
+    sessions_dir = get_hermes_home() / "sessions"
+    deleted, routing_deleted = db.prune_never_active_keyed_sessions(
+        older_than_days=days, sessions_dir=sessions_dir
+    )
+    print(
+        f"Deleted {deleted} never-active session(s) and {routing_deleted} "
+        "stale routing entr(ies)."
+    )
+
+
 def cmd_sessions(args, sessions_parser=None):
     import json as _json
 
@@ -805,6 +871,12 @@ def cmd_sessions(args, sessions_parser=None):
             print(f"Deleted session '{resolved_session_id}'.")
         else:
             print(f"Session '{args.session_id}' not found.")
+
+    elif action == "prune" and getattr(args, "never_active", False):
+        # Separate branch on purpose: the shared prune/archive selector is
+        # pinned to `ended_at IS NOT NULL`, so never-closed rows sit outside
+        # it by construction and cannot be expressed as one more filter.
+        _prune_never_active_keyed(db, args)
 
     elif action in ("prune", "archive"):
         from hermes_cli.session_filters import (

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -495,7 +495,11 @@ def _process_looks_like_pytest(proc: Any) -> bool:
         return False
     for arg in cmdline:
         try:
-            name = os.path.basename(str(arg).strip('"').strip("'")).lower()
+            token = str(arg).strip('"').strip("'")
+            # Split on both separators on every host: os.path.basename is
+            # POSIX-only under Linux and would leave a Windows-style path
+            # intact, making the matcher's answer depend on the platform.
+            name = token.replace("\\", "/").rsplit("/", 1)[-1].lower()
         except Exception:
             continue
         if name in _PYTEST_LAUNCHER_NAMES:

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -423,6 +423,12 @@ def _default_db_path() -> Path:
 #: ``@pytest.mark.live_system_guard_bypass``; scripts may set it explicitly.
 _STATE_DB_GUARD_BYPASS = False
 
+#: Env-carried twin of ``_STATE_DB_GUARD_BYPASS``.  A module global cannot
+#: cross a process boundary, so a test that deliberately points a *child* at
+#: the live DB has no way to opt out once ancestry arms the guard there.
+#: Export this in the child's env instead.
+_STATE_DB_GUARD_BYPASS_ENV = "HERMES_STATE_DB_GUARD_BYPASS"
+
 #: Additional production roots to refuse (beyond the platform default
 #: ``~/.hermes``).  The test conftest injects the pre-sandbox production
 #: root here so custom-``HERMES_HOME`` deployments are covered too.
@@ -463,6 +469,82 @@ def _running_under_pytest() -> bool:
     )
 
 
+#: Names that identify a pytest launcher in a process command line.  Matched
+#: against the *basename* of each argv token so ``/tmp/pytest-of-dev/...``
+#: paths — which do show up in real argv — cannot false-positive.
+_PYTEST_LAUNCHER_NAMES = frozenset(
+    {"pytest", "py.test", "pytest.exe", "py.test.exe"}
+)
+
+#: Memoised ancestry answer.  The process tree above us does not change in a
+#: way that matters here, and the walk must not cost anything on the hot path.
+_PYTEST_ANCESTOR: Optional[bool] = None
+
+
+def _process_looks_like_pytest(proc: Any) -> bool:
+    """True when *proc*'s command line is a pytest invocation.
+
+    Covers both ``pytest ...`` (launcher on argv[0]) and ``python -m pytest``
+    (launcher as a bare ``pytest`` token).  A process whose command line we
+    cannot read is treated as "not pytest": guessing the other way would
+    refuse production opens for unrelated reasons.
+    """
+    try:
+        cmdline = proc.cmdline() or []
+    except Exception:
+        return False
+    for arg in cmdline:
+        try:
+            name = os.path.basename(str(arg).strip('"').strip("'")).lower()
+        except Exception:
+            continue
+        if name in _PYTEST_LAUNCHER_NAMES:
+            return True
+    return False
+
+
+def _has_pytest_ancestor() -> bool:
+    """True when some ancestor process of this one is a pytest run.
+
+    ``_running_under_pytest`` reads ``PYTEST_*`` env vars, which a child
+    spawned with a rebuilt environment loses at the same moment it loses the
+    ``HERMES_HOME`` redirect: that child aims at the production DB *and*
+    disarms the guard in one step (#82770).  Ancestry is the one test-context
+    signal that survives an env rebuild, so it backs the env check up.
+
+    Fails open (``False``) when ``psutil`` is unavailable or the walk errors —
+    that restores the previous env-only behaviour rather than blocking real
+    user runs on a psutil hiccup.
+    """
+    global _PYTEST_ANCESTOR
+    if _PYTEST_ANCESTOR is not None:
+        return _PYTEST_ANCESTOR
+    found = False
+    if psutil is not None:
+        try:
+            for parent in psutil.Process().parents():
+                if _process_looks_like_pytest(parent):
+                    found = True
+                    break
+        except Exception:
+            found = False
+    _PYTEST_ANCESTOR = found
+    return found
+
+
+def _in_test_context() -> bool:
+    """True when this process is a test run, by environment or by ancestry.
+
+    Order matters for cost: the env probe is two dict lookups and covers the
+    common in-process case, so the ancestry walk only runs for processes the
+    environment claims are ordinary user runs — and its answer is memoised,
+    so a real ``hermes`` invocation pays for at most one walk.
+    """
+    if _running_under_pytest():
+        return True
+    return _has_pytest_ancestor()
+
+
 def _production_state_roots() -> List[Path]:
     roots: List[Path] = []
     real_root = _real_platform_state_root()
@@ -501,8 +583,15 @@ def _ensure_test_isolation(db_path: Path) -> None:
     Raises ``RuntimeError`` before any connection, mkdir, journal-mode
     pragma, or byte probe can touch the live database.  No-op outside
     pytest and for hermetic (tmp ``HERMES_HOME``) paths.
+
+    "pytest context" means environment *or* process ancestry — see
+    :func:`_in_test_context`.  Env alone is not enough: a child spawned with
+    a rebuilt environment loses ``PYTEST_*`` and ``HERMES_HOME`` together,
+    which is precisely the state in which it writes to production (#82770).
     """
-    if _STATE_DB_GUARD_BYPASS or not _running_under_pytest():
+    if _STATE_DB_GUARD_BYPASS or os.environ.get(_STATE_DB_GUARD_BYPASS_ENV):
+        return
+    if not _in_test_context():
         return
     try:
         resolved = Path(db_path).expanduser().resolve()
@@ -517,7 +606,9 @@ def _ensure_test_isolation(db_path: Path) -> None:
                 "explicit tmp db_path or let the hermetic conftest redirect "
                 "HERMES_HOME. If this test genuinely needs the live "
                 "database, mark it with "
-                "@pytest.mark.live_system_guard_bypass."
+                "@pytest.mark.live_system_guard_bypass — or, for a spawned "
+                f"child process, export {_STATE_DB_GUARD_BYPASS_ENV}=1 in "
+                "its environment."
             )
 
 # ---------------------------------------------------------------------------
@@ -4538,6 +4629,123 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             )
 
         self._execute_write(_do)
+
+    def list_never_active_keyed_sessions(
+        self, *, older_than_days: float
+    ) -> List[Dict[str, Any]]:
+        """Keyed gateway rows that were opened and then never used at all.
+
+        Selects rows that are keyed (``session_key IS NOT NULL``), still open
+        (``ended_at IS NULL``) and carry no evidence of a single turn: no
+        messages, no tokens, no tool or API calls, no recorded activity, no
+        title.  Such a row is indistinguishable from "never happened".
+
+        That is exactly the shape of a leaked test fixture (#82770) — and
+        also of a chat that was routed but never answered.  Both are safe to
+        drop: there is no transcript to lose, and the gateway mints a fresh
+        session on the next inbound message either way.
+
+        ``bulk prune``/``archive`` cannot reach these rows: their shared
+        selector is pinned to ``ended_at IS NOT NULL`` so that a live session
+        is never picked, which permanently excludes every never-closed row.
+        Hence a separate, narrower selector rather than another filter flag.
+
+        ``pinned`` and ``archived`` rows are excluded — both are explicit
+        user intent to keep the row around.
+        """
+        cutoff = time.time() - (float(older_than_days) * 86400.0)
+        with self._lock:
+            rows = self._conn.execute(
+                """
+                SELECT s.id, s.session_key, s.source, s.chat_id,
+                       s.chat_type, s.user_id, s.started_at
+                  FROM sessions s
+                 WHERE s.session_key IS NOT NULL
+                   AND s.ended_at IS NULL
+                   AND s.title IS NULL
+                   AND s.last_activity_at IS NULL
+                   AND COALESCE(s.message_count, 0) = 0
+                   AND COALESCE(s.tool_call_count, 0) = 0
+                   AND COALESCE(s.api_call_count, 0) = 0
+                   AND COALESCE(s.input_tokens, 0) = 0
+                   AND COALESCE(s.output_tokens, 0) = 0
+                   AND COALESCE(s.pinned, 0) = 0
+                   AND COALESCE(s.archived, 0) = 0
+                   AND s.started_at IS NOT NULL
+                   AND s.started_at < ?
+                   AND NOT EXISTS (
+                           SELECT 1 FROM messages m WHERE m.session_id = s.id
+                       )
+                 ORDER BY s.started_at
+                """,
+                (cutoff,),
+            ).fetchall()
+        return [dict(r) for r in rows]
+
+    def _delete_routing_entries_for_sessions(self, session_ids: Set[str]) -> int:
+        """Drop ``gateway_routing`` rows pointing at any of *session_ids*.
+
+        Routing entries are keyed by ``(scope, session_key)`` and record their
+        target session inside ``entry_json``, so there is no way to reach them
+        by session id in SQL — the match is done in Python over all scopes.
+        """
+        if not session_ids:
+            return 0
+        with self._lock:
+            rows = self._conn.execute(
+                "SELECT scope, session_key, entry_json FROM gateway_routing"
+            ).fetchall()
+        doomed: List[Tuple[str, str]] = []
+        for row in rows:
+            try:
+                entry = json.loads(row["entry_json"] or "{}")
+            except Exception:
+                continue
+            if isinstance(entry, dict) and entry.get("session_id") in session_ids:
+                doomed.append((row["scope"], row["session_key"]))
+        if not doomed:
+            return 0
+
+        def _do(conn):
+            conn.executemany(
+                "DELETE FROM gateway_routing WHERE scope = ? AND session_key = ?",
+                doomed,
+            )
+
+        self._execute_write(_do)
+        return len(doomed)
+
+    def prune_never_active_keyed_sessions(
+        self,
+        *,
+        older_than_days: float,
+        sessions_dir: Optional[Path] = None,
+    ) -> Tuple[int, int]:
+        """Delete never-active keyed rows and the routing entries naming them.
+
+        Returns ``(sessions_deleted, routing_entries_deleted)``.
+
+        The routing entries go first: a stale entry that outlived its target
+        would leave the gateway resuming a session id that no longer exists.
+        Deleting the pair is what leaving them both would have amounted to
+        anyway — the target had no transcript to resume.
+
+        Deletion goes through :meth:`delete_session` rather than a bulk
+        ``DELETE`` so the delegate cascade, FTS bookkeeping and on-disk
+        transcript cleanup stay owned by one implementation.
+        """
+        candidates = self.list_never_active_keyed_sessions(
+            older_than_days=older_than_days
+        )
+        if not candidates:
+            return (0, 0)
+        ids = {str(row["id"]) for row in candidates}
+        routing_deleted = self._delete_routing_entries_for_sessions(ids)
+        deleted = 0
+        for session_id in ids:
+            if self.delete_session(session_id, sessions_dir=sessions_dir):
+                deleted += 1
+        return (deleted, routing_deleted)
 
     def list_gateway_sessions(
         self,

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -461,11 +461,24 @@ def _real_platform_state_root() -> Optional[Path]:
         return None
 
 
+#: Env marker exported by the hermetic test conftest at the same moment it
+#: redirects ``HERMES_HOME`` to the per-session tmp isolation root.  Its
+#: value is that isolation root.  Unlike ``PYTEST_*`` (owned by pytest, and
+#: routinely scrubbed by tests that rebuild a child environment), this marker
+#: is OURS: it declares "this process tree is running under Hermes test
+#: isolation", and it inherits into subprocess children by default — so a
+#: child that received the patched ``HERMES_HOME`` also received the marker,
+#: and a child that resolves a production DB while carrying it is, by
+#: definition, an isolation escape (#82770).
+_TEST_ISOLATION_MARKER_ENV = "HERMES_TEST_ISOLATION"
+
+
 def _running_under_pytest() -> bool:
     """True when this process (or a parent test process) is a pytest run."""
     return bool(
         os.environ.get("PYTEST_CURRENT_TEST")
         or os.environ.get("PYTEST_VERSION")
+        or os.environ.get(_TEST_ISOLATION_MARKER_ENV)
     )
 
 

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -45,7 +45,7 @@ from hermes_constants import get_hermes_home
 from hermes_cli.sqlite_runtime import (
     is_sqlite_wal_reset_vulnerable as _is_sqlite_wal_reset_vulnerable,
 )
-from typing import Any, Callable, Dict, List, Optional, Tuple, TypeVar
+from typing import Any, Callable, Dict, List, Optional, Set, Tuple, TypeVar
 
 from hermes_state_common import (  # noqa: F401  (re-exported for back-compat)
     _BRANCH_CHILD_SQL,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -91,6 +91,20 @@ if _hermes_home_points_at_production(os.environ.get("HERMES_HOME", "")):
     os.environ["HERMES_HOME"] = _SESSION_HERMES_HOME
     atexit.register(shutil.rmtree, _SESSION_HERMES_HOME, True)
 
+# Subprocess-surviving isolation marker (#82770). PYTEST_CURRENT_TEST /
+# PYTEST_VERSION are pytest's own vars, and tests that spawn children
+# routinely rebuild the child env and strip them ("the subprocess must look
+# like a real CLI") — which used to disarm hermes_state's live-DB guard in
+# the child at the same moment the child lost the HERMES_HOME redirect.
+# HERMES_TEST_ISOLATION is OUR marker: exported here (before any test module
+# imports), inherited by every child by default, and honored by
+# hermes_state._running_under_pytest() as a test-context signal. A child
+# that carries it and still resolves the production state.db fails hard.
+# Tests that legitimately need a child to look like a non-test process AND
+# open a real DB must export HERMES_STATE_DB_GUARD_BYPASS=1 in that child's
+# env instead of stripping markers.
+os.environ["HERMES_TEST_ISOLATION"] = os.environ.get("HERMES_HOME", "") or "1"
+
 #: HERMES_HOME as it stood when conftest was imported - i.e. before any test
 #: module could import code that configures logging. Recorded so the guard in
 #: tests/test_log_isolation.py can assert the sandbox existed AT THAT MOMENT.
@@ -467,6 +481,14 @@ def _hermetic_environment(tmp_path, monkeypatch):
     (fake_hermes_home / "memories").mkdir()
     (fake_hermes_home / "skills").mkdir()
     monkeypatch.setenv("HERMES_HOME", str(fake_hermes_home))
+    # Keep the subprocess-surviving isolation marker pointed at THIS test's
+    # home (#82770): children spawned by the test inherit it by default, so
+    # hermes_state's live-DB guard stays armed in them even when the test
+    # strips pytest's own PYTEST_* vars from the child env.
+    monkeypatch.setenv("HERMES_TEST_ISOLATION", str(fake_hermes_home))
+    # And never let a developer-shell (or leaked child) bypass disarm the
+    # guard for in-process code under test.
+    monkeypatch.delenv("HERMES_STATE_DB_GUARD_BYPASS", raising=False)
 
     # 3b. hermes_state computes ``DEFAULT_DB_PATH = get_hermes_home() / "state.db"``
     #     at import time. When the module is first imported at collection (any

--- a/tests/hermes_state/test_isolation_marker_env.py
+++ b/tests/hermes_state/test_isolation_marker_env.py
@@ -1,0 +1,121 @@
+"""Subprocess-surviving isolation marker (#82770).
+
+``PYTEST_CURRENT_TEST`` / ``PYTEST_VERSION`` are pytest's vars: tests that
+spawn children and rebuild the child environment routinely strip them so the
+child "looks like a real CLI" — which used to disarm the live-DB guard in the
+child at the same moment the child lost the ``HERMES_HOME`` redirect. That
+pairing is exactly how fixture rows (dm:123 / chat-1 / wx-chat) landed in a
+developer's production state.db.
+
+``HERMES_TEST_ISOLATION`` is Hermes's own marker: the hermetic conftest
+exports it (value = the isolation root) before any test module imports, it
+inherits into children by default, and ``hermes_state`` honors it as a
+test-context signal. These tests pin all three properties.
+"""
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import hermes_state
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+_CHILD_PROBE = r"""
+import json, os, sys
+sys.path.insert(0, {repo!r})
+import hermes_state as hs
+fired = False
+try:
+    hs._ensure_test_isolation(hs._real_platform_state_root() / "state.db")
+except RuntimeError:
+    fired = True
+print(json.dumps({{
+    "armed": hs._running_under_pytest(),
+    "fired": fired,
+}}))
+"""
+
+
+def _spawn_probe(env: dict) -> dict:
+    """Run the guard probe in a real child process with exactly *env*."""
+    proc = subprocess.run(
+        [sys.executable, "-c", _CHILD_PROBE.format(repo=str(REPO_ROOT))],
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=60,
+    )
+    assert proc.returncode == 0, proc.stderr
+    return json.loads(proc.stdout.strip().splitlines()[-1])
+
+
+def _minimal_env(**extra) -> dict:
+    """A rebuilt-from-scratch child env — the residual-bypass pattern."""
+    env = {
+        "PATH": os.environ.get("PATH", ""),
+        "HOME": os.environ.get("HOME", ""),
+        "SYSTEMROOT": os.environ.get("SYSTEMROOT", ""),  # Windows needs it
+        "LOCALAPPDATA": os.environ.get("LOCALAPPDATA", ""),
+    }
+    env = {k: v for k, v in env.items() if v}
+    env.update(extra)
+    return env
+
+
+def test_conftest_exports_the_marker():
+    """The hermetic conftest must export the marker before tests run."""
+    assert os.environ.get("HERMES_TEST_ISOLATION"), (
+        "HERMES_TEST_ISOLATION must be exported by tests/conftest.py so "
+        "subprocess children inherit a test-context signal that survives "
+        "PYTEST_* scrubbing"
+    )
+
+
+def test_marker_alone_reports_test_context(monkeypatch):
+    monkeypatch.delenv("PYTEST_CURRENT_TEST", raising=False)
+    monkeypatch.delenv("PYTEST_VERSION", raising=False)
+    monkeypatch.setenv("HERMES_TEST_ISOLATION", "/tmp/some-isolation-root")
+    assert hermes_state._running_under_pytest() is True
+
+
+def test_no_signals_reports_production(monkeypatch):
+    """Marker absent + PYTEST_* absent = a real user run; guard must not arm
+    off the env (ancestry may still arm it in a real child — not this seam)."""
+    monkeypatch.delenv("PYTEST_CURRENT_TEST", raising=False)
+    monkeypatch.delenv("PYTEST_VERSION", raising=False)
+    monkeypatch.delenv("HERMES_TEST_ISOLATION", raising=False)
+    assert hermes_state._running_under_pytest() is False
+
+
+def test_child_with_rebuilt_env_keeping_marker_refuses_production_db():
+    """THE regression: a child whose env was rebuilt from scratch (PYTEST_*
+    stripped, HERMES_HOME lost) but which keeps the marker must still refuse
+    to open the production state.db."""
+    env = _minimal_env(HERMES_TEST_ISOLATION="/tmp/pytest-isolation-root")
+    result = _spawn_probe(env)
+    assert result["armed"] is True
+    assert result["fired"] is True, (
+        "guard did not fire in a marker-carrying child aimed at the "
+        "production state.db — the #82770 escape is open again"
+    )
+
+
+def test_child_bypass_env_disarms_guard_even_with_marker():
+    """The sanctioned escape hatch for children that genuinely need a real
+    DB: HERMES_STATE_DB_GUARD_BYPASS=1, not marker-stripping."""
+    env = _minimal_env(
+        HERMES_TEST_ISOLATION="/tmp/pytest-isolation-root",
+        HERMES_STATE_DB_GUARD_BYPASS="1",
+    )
+    result = _spawn_probe(env)
+    assert result["fired"] is False
+
+
+def test_child_inheriting_full_test_env_refuses_production_db():
+    """Default inheritance (env=None equivalent): everything rides along."""
+    result = _spawn_probe(dict(os.environ))
+    assert result["armed"] is True
+    assert result["fired"] is True

--- a/tests/hermes_state/test_live_db_guard_ancestry.py
+++ b/tests/hermes_state/test_live_db_guard_ancestry.py
@@ -1,0 +1,154 @@
+"""The live-DB guard must survive a scrubbed child environment (#82770).
+
+Forensic background: a read-only sweep of production ``state.db`` files found
+hundreds of zero-message "open" gateway session rows carrying test-fixture
+identities (``chat-1`` / ``user-1`` / ``wx-chat``), with matching
+``gateway_routing`` scopes pointing at ``pytest-of-*`` temp directories.
+
+The escape is structural, not a one-off test bug.  Hermetic isolation rides
+entirely on the process environment: ``HERMES_HOME`` says *where* to write and
+``PYTEST_CURRENT_TEST`` / ``PYTEST_VERSION`` say *whether the guard is armed*.
+Both live in the same carrier, so a child spawned with a rebuilt environment
+loses them together — it aims at the developer's real ``state.db`` and
+silences the only check that would have stopped it, in one step.
+
+Process ancestry is the signal that survives an env rebuild, so these tests
+pin that the guard is armed by ancestry when the environment no longer says
+"pytest".
+
+These tests drive ``_ensure_test_isolation`` rather than constructing a real
+``SessionDB``: if the guard regresses, the assertion must fail *without* the
+test itself writing to the developer's live database.
+"""
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+import hermes_state
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+# Probe run in the child: resolve the REAL platform state root (not a
+# hardcoded ~/.hermes — that root is %LOCALAPPDATA%\hermes on Windows) and
+# report whether the guard refuses it.
+_CHILD_PROBE = """
+import sys
+sys.path.insert(0, {repo!r})
+import hermes_state
+
+root = hermes_state._real_platform_state_root()
+if root is None:
+    print("NO-ROOT")
+else:
+    try:
+        hermes_state._ensure_test_isolation(root / "state.db")
+    except RuntimeError:
+        print("REFUSED")
+    else:
+        print("ALLOWED")
+"""
+
+
+def _scrubbed_env(**overrides):
+    """The environment a rebuilt-from-scratch child spawn ends up with."""
+    env = {
+        k: v
+        for k, v in os.environ.items()
+        if not k.startswith("PYTEST_") and k != "HERMES_HOME"
+    }
+    env.update(overrides)
+    return env
+
+
+def _run_probe(env):
+    result = subprocess.run(
+        [sys.executable, "-c", _CHILD_PROBE.format(repo=str(REPO_ROOT))],
+        env=env,
+        capture_output=True,
+        text=True,
+        cwd=str(REPO_ROOT),
+        timeout=120,
+    )
+    verdict = result.stdout.strip().splitlines()[-1] if result.stdout.strip() else ""
+    if verdict == "NO-ROOT":
+        pytest.skip("no real platform state root resolvable on this machine")
+    assert verdict in ("REFUSED", "ALLOWED"), (
+        f"probe produced no verdict.\nstdout={result.stdout!r}\n"
+        f"stderr={result.stderr!r}"
+    )
+    return verdict
+
+
+class TestScrubbedChildEnvironment:
+    def test_child_without_pytest_env_still_refuses_production_db(self):
+        """The #82770 escape: no PYTEST_* and no HERMES_HOME, yet still a test.
+
+        This is the exact shape of the leak — the child resolves the real
+        ``state.db`` because ``HERMES_HOME`` is gone, and the env-only guard
+        sees a "normal user run" because ``PYTEST_*`` is gone with it.
+        """
+        assert _run_probe(_scrubbed_env()) == "REFUSED"
+
+    def test_child_inheriting_pytest_env_still_refuses_production_db(self):
+        """The pre-existing env path must keep working unchanged."""
+        env = dict(os.environ)
+        env.pop("HERMES_HOME", None)
+        env.setdefault("PYTEST_CURRENT_TEST", "tests/x.py::test_x (call)")
+        assert _run_probe(env) == "REFUSED"
+
+    def test_env_bypass_lets_a_deliberate_child_through(self):
+        """A test that genuinely needs the live DB in a child can opt out.
+
+        ``_STATE_DB_GUARD_BYPASS`` is a module global and cannot cross a
+        process boundary, so ancestry-armed children need an env-carried
+        escape hatch or they would have no way to opt out at all.
+        """
+        env = _scrubbed_env(**{hermes_state._STATE_DB_GUARD_BYPASS_ENV: "1"})
+        assert _run_probe(env) == "ALLOWED"
+
+
+class TestPytestProcessRecognition:
+    """Unit-level checks for the ancestry predicate's matching rules."""
+
+    class _FakeProc:
+        def __init__(self, cmdline):
+            self._cmdline = cmdline
+
+        def cmdline(self):
+            return self._cmdline
+
+    @pytest.mark.parametrize(
+        "cmdline",
+        [
+            ["/usr/bin/python", "-m", "pytest", "tests/"],
+            ["/venv/bin/pytest", "-q"],
+            [r"C:\venv\Scripts\pytest.exe", "-q"],
+            ["/usr/bin/py.test", "tests/"],
+        ],
+    )
+    def test_recognises_pytest_invocations(self, cmdline):
+        assert hermes_state._process_looks_like_pytest(self._FakeProc(cmdline))
+
+    @pytest.mark.parametrize(
+        "cmdline",
+        [
+            ["hermes", "gateway", "start"],
+            ["/usr/bin/python", "-m", "hermes_cli.main", "sessions", "list"],
+            # A path that merely *contains* "pytest" is not a pytest process:
+            # tmp paths like /tmp/pytest-of-dev/... show up in real argv.
+            ["hermes", "run", "--file", "/tmp/pytest-of-dev/test0/input.txt"],
+        ],
+    )
+    def test_ignores_non_pytest_invocations(self, cmdline):
+        assert not hermes_state._process_looks_like_pytest(self._FakeProc(cmdline))
+
+    def test_unreadable_process_is_not_pytest(self):
+        class _Denied:
+            def cmdline(self):
+                raise PermissionError("access denied")
+
+        assert not hermes_state._process_looks_like_pytest(_Denied())

--- a/tests/hermes_state/test_live_db_guard_ancestry.py
+++ b/tests/hermes_state/test_live_db_guard_ancestry.py
@@ -54,11 +54,17 @@ else:
 
 
 def _scrubbed_env(**overrides):
-    """The environment a rebuilt-from-scratch child spawn ends up with."""
+    """The environment a rebuilt-from-scratch child spawn ends up with.
+
+    Also strips ``HERMES_TEST_ISOLATION`` — the conftest-exported marker
+    layer would otherwise arm the guard first and these tests would no
+    longer prove anything about the ancestry fallback they exist to pin.
+    """
     env = {
         k: v
         for k, v in os.environ.items()
-        if not k.startswith("PYTEST_") and k != "HERMES_HOME"
+        if not k.startswith("PYTEST_")
+        and k not in ("HERMES_HOME", "HERMES_TEST_ISOLATION")
     }
     env.update(overrides)
     return env

--- a/tests/hermes_state/test_live_db_isolation_guard.py
+++ b/tests/hermes_state/test_live_db_isolation_guard.py
@@ -24,7 +24,16 @@ from gateway.config import GatewayConfig
 from gateway.session import SessionStore
 from hermes_state import SessionDB
 
-REAL_ROOT = (Path.home() / ".hermes").resolve()
+# Must match the root the guard itself computes.  Hardcoding ``~/.hermes``
+# silently disarmed every assertion below on Windows, where the real root is
+# ``%LOCALAPPDATA%\hermes``: the paths under test were then *correctly*
+# classified as non-production, so the guard never raised and the whole
+# TestProductionPathRefused class failed for the wrong reason (#82770).
+REAL_ROOT = hermes_state._real_platform_state_root()
+if REAL_ROOT is None:  # pragma: no cover - no resolvable home on this platform
+    pytest.skip(
+        "no real platform state root to assert against", allow_module_level=True
+    )
 
 
 class TestProductionPathRefused:
@@ -45,7 +54,7 @@ class TestProductionPathRefused:
 
     def test_unnormalized_production_path_raises(self):
         """Symlink-free but unnormalized spellings still resolve and refuse."""
-        sneaky = Path.home() / "subdir" / ".." / ".hermes" / "state.db"
+        sneaky = REAL_ROOT.parent / "subdir" / ".." / REAL_ROOT.name / "state.db"
         with pytest.raises(RuntimeError, match="live-system guard"):
             SessionDB(db_path=sneaky)
 

--- a/tests/hermes_state/test_never_active_keyed_prune.py
+++ b/tests/hermes_state/test_never_active_keyed_prune.py
@@ -1,0 +1,149 @@
+"""Sweeping never-active keyed gateway rows (#82770).
+
+The live-DB guard stops *new* fixture escapes, but it cannot touch rows that
+are already in a developer's ``state.db`` — and bulk prune/archive cannot
+either: their shared selector is pinned to ``ended_at IS NOT NULL`` so a live
+session is never picked, which permanently excludes every never-closed row.
+
+These tests pin the narrow selector that reaches them, and — more importantly
+— pin the rows it must refuse to touch.
+"""
+
+import json
+import time
+
+import pytest
+
+from hermes_state import SessionDB
+
+DAY = 86400.0
+
+
+@pytest.fixture()
+def db(tmp_path):
+    return SessionDB(db_path=tmp_path / "state.db")
+
+
+def _insert(db, session_id, *, age_days, **overrides):
+    """Insert a keyed gateway row directly, defaulting to the junk shape."""
+    row = {
+        "id": session_id,
+        "source": "telegram",
+        "user_id": "user-1",
+        "session_key": f"agent:main:telegram:dm:{session_id}",
+        "chat_id": "chat-1",
+        "chat_type": "dm",
+        "started_at": time.time() - age_days * DAY,
+        "message_count": 0,
+        "tool_call_count": 0,
+        "api_call_count": 0,
+        "input_tokens": 0,
+        "output_tokens": 0,
+        "archived": 0,
+        "pinned": 0,
+    }
+    row.update(overrides)
+    cols = ", ".join(row)
+    placeholders = ", ".join("?" for _ in row)
+    db._conn.execute(
+        f"INSERT INTO sessions ({cols}) VALUES ({placeholders})", list(row.values())
+    )
+    db._conn.commit()
+    return session_id
+
+
+class TestSelector:
+    def test_selects_old_never_active_keyed_row(self, db):
+        _insert(db, "junk-old", age_days=45)
+        found = db.list_never_active_keyed_sessions(older_than_days=30)
+        assert [r["id"] for r in found] == ["junk-old"]
+
+    def test_ignores_row_inside_the_age_floor(self, db):
+        _insert(db, "junk-young", age_days=3)
+        assert db.list_never_active_keyed_sessions(older_than_days=30) == []
+
+    def test_ignores_unkeyed_row(self, db):
+        _insert(db, "cli-row", age_days=45, session_key=None, source="cli")
+        assert db.list_never_active_keyed_sessions(older_than_days=30) == []
+
+    def test_ignores_ended_row(self, db):
+        """Ended rows belong to ordinary prune — this selector must not
+        double-claim them."""
+        _insert(db, "ended", age_days=45, ended_at=time.time() - 40 * DAY)
+        assert db.list_never_active_keyed_sessions(older_than_days=30) == []
+
+    @pytest.mark.parametrize(
+        "field, value",
+        [
+            ("message_count", 1),
+            ("tool_call_count", 1),
+            ("api_call_count", 1),
+            ("input_tokens", 12),
+            ("output_tokens", 12),
+            ("title", "kept by the user"),
+            ("last_activity_at", 1785354069.0),
+            ("pinned", 1),
+            ("archived", 1),
+        ],
+    )
+    def test_any_sign_of_use_or_intent_protects_the_row(self, db, field, value):
+        _insert(db, "used", age_days=45, **{field: value})
+        assert db.list_never_active_keyed_sessions(older_than_days=30) == []
+
+    def test_row_with_messages_is_protected_even_if_counter_says_zero(self, db):
+        """``message_count`` is a denormalised counter — trust the messages."""
+        _insert(db, "stale-counter", age_days=45)
+        db._conn.execute(
+            "INSERT INTO messages (session_id, role, content, timestamp) "
+            "VALUES (?, ?, ?, ?)",
+            ("stale-counter", "user", "hello", time.time() - 44 * DAY),
+        )
+        db._conn.commit()
+        assert db.list_never_active_keyed_sessions(older_than_days=30) == []
+
+
+class TestPrune:
+    def test_deletes_candidates_and_leaves_everything_else(self, db):
+        _insert(db, "junk-a", age_days=45)
+        _insert(db, "junk-b", age_days=60)
+        _insert(db, "keeper-young", age_days=1)
+        _insert(db, "keeper-used", age_days=45, message_count=3)
+
+        deleted, _ = db.prune_never_active_keyed_sessions(older_than_days=30)
+
+        assert deleted == 2
+        surviving = {
+            r[0] for r in db._conn.execute("SELECT id FROM sessions").fetchall()
+        }
+        assert surviving == {"keeper-young", "keeper-used"}
+
+    def test_drops_routing_entries_pointing_at_deleted_rows(self, db):
+        """A routing entry that outlived its target would leave the gateway
+        resuming a session id that no longer exists."""
+        _insert(db, "junk", age_days=45)
+        _insert(db, "keeper", age_days=1)
+        db.save_gateway_routing_entry(
+            "agent:main:telegram:dm:junk",
+            json.dumps({"session_id": "junk"}),
+            scope="/tmp/pytest-of-dev/test0",
+        )
+        db.save_gateway_routing_entry(
+            "agent:main:telegram:dm:keeper",
+            json.dumps({"session_id": "keeper"}),
+            scope="/home/dev/project",
+        )
+
+        deleted, routing_deleted = db.prune_never_active_keyed_sessions(
+            older_than_days=30
+        )
+
+        assert (deleted, routing_deleted) == (1, 1)
+        remaining = db._conn.execute(
+            "SELECT session_key FROM gateway_routing"
+        ).fetchall()
+        assert [r[0] for r in remaining] == ["agent:main:telegram:dm:keeper"]
+
+    def test_no_candidates_is_a_no_op(self, db):
+        _insert(db, "keeper", age_days=1)
+        assert db.prune_never_active_keyed_sessions(older_than_days=30) == (0, 0)
+        assert db._conn.execute("SELECT COUNT(*) FROM sessions").fetchone()[0] == 1


### PR DESCRIPTION
Closes #82770.

Salvages and extends @JoaoMarcos44's PR #82803 (his four commits are cherry-picked with authorship preserved), rebased onto current main, plus one additional commit closing the residual bypass his approach still left open.

## The escape path (#82770)

Teknium's production `~/.hermes/state.db` accumulated **700+ zero-message, `ended_at IS NULL` gateway session rows** with test-fixture identities (`agent:main:telegram:dm:123` ×516 in 8–10 rows/sec bursts, `dm:chat-1` +topic variant ×140, `dm:a`/`dm:b`, `weixin:dm:wx-chat`, `dm:42`, and `dm:1` rows dated **Aug 8 — two days after** `_ensure_test_isolation()` landed (2026-08-06, `19fc9c103e`). @JoaoMarcos44 reproduced the same class independently on a second machine (Windows), where `gateway_routing.scope` values literally named the escaping tests (`pytest-of-Nitro\pytest-1441\test_new_session_records_gatew0`, `test_recovers_missing_sessions0`, …) — session-persistence tests that have since been pruned/renamed on main, but the *class* is any test whose child process loses the isolation env.

**Root cause — the detector and the redirect share one carrier.** Hermetic isolation rides entirely on the process environment: `HERMES_HOME` says *where* to write; `PYTEST_CURRENT_TEST`/`PYTEST_VERSION` say *whether the guard is armed*. A test that spawns a child with a rebuilt env loses both **together** — the child resolves the real `state.db` and silences the only check that would have stopped it, in one step. And rebuilding the child env is an *established, deliberate pattern* in this test suite: `tests/cli/test_exit_watchdog_signal_arm.py:86` (`env.pop("PYTEST_CURRENT_TEST")` — "the subprocess must look like a real CLI") and `tests/hermes_cli/test_config_loader_e2e.py:40` do it on purpose.

**Proven still open on current main** (2026-08-15, `f0c222c73d`), read-only probe — a child of a pytest-context process with a rebuilt env:

```
--- child WITH inherited env ---
{"resolved": "/home/teknium/.hermes/state.db", "guard_armed": true, "guard_fired": true}
--- child with REBUILT env (escape pattern) ---
{"resolved": "/home/teknium/.hermes/state.db", "guard_armed": false, "guard_fired": false}
```

## The fix — three independent layers

**Layer 1 — ancestry guard (JoaoMarcos44, commits 1–4).** `_ensure_test_isolation` now arms on `_in_test_context()` = env probe **or** a memoised psutil walk of parent processes matching a pytest launcher by argv-token basename. Ancestry survives an env rebuild. Fails open on any uncertainty (no psutil, unreadable cmdline) — a real user run can never be blocked by a walk error, and pays for at most one walk per process. Env-carried bypass `HERMES_STATE_DB_GUARD_BYPASS=1` for children that genuinely need a live DB (the module-global bypass can't cross a process boundary). Also fixes the guard test suite on Windows, which hardcoded `~/.hermes` and therefore never exercised the guard there.

**Layer 2 — subprocess-surviving isolation marker (new commit, the residual-bypass close).** Ancestry doesn't cover children built from a completely scrubbed env that also *detach* from the process tree (daemonized/`start_new_session` children reparented to init), and it depends on psutil. So the hermetic conftest now exports **`HERMES_TEST_ISOLATION=<isolation root>`** before any test module imports (re-pinned per test in `_hermetic_environment`), and `hermes_state._running_under_pytest()` honors it as a test-context signal. The marker is **ours**, not pytest's: no test needs to strip it to make a child "look like a real CLI" (no production code branches on it except the guard), it inherits into children by default, and the sanctioned way for a child to open a real DB is the bypass env var — never marker-stripping. Production cost: one extra `os.environ.get` on the already-cold guard path; marker absent ⇒ byte-identical behavior.

**Layer 3 — in-process env probe** (pre-existing, unchanged) still catches the common case first.

`tests/hermes_state/test_isolation_marker_env.py` pins the marker layer end-to-end with a real spawned child; **sabotage-verified** (fix reverted → 3/6 fail, including the rebuilt-env child probe). The ancestry suite's `_scrubbed_env` now strips the marker too, so those tests keep proving ancestry rather than riding the new layer.

## Cleanup — `hermes sessions prune --never-active`

Ordinary prune is pinned to `ended_at IS NOT NULL` (so it can never select a live session) — which *permanently* excludes every leaked never-closed row. The new opt-in mode selects keyed, still-open rows with zero evidence of use on every axis (no messages **and** no `messages` table rows, no tokens, no tool/API calls, no `last_activity_at`, no title; `pinned`/`archived` excluded), older than `--older-than` (default 30 days). Deletion routes through `delete_session()` (FTS + transcript + delegate cascade have one owner; `PRAGMA foreign_keys` is 0 here so there is no FK cascade to lean on), and drops the `gateway_routing` entries naming the doomed ids first — JoaoMarcos44 found 8 such entries in his own DB, correcting the issue's "nothing references them" premise.

### Empirical verification against a copy of the reporter's production DB

Teknium's live DB was **already swept clean** of the fixture rows by the `ghost_session_prune_v1` startup migration + `state.db.malformed` recovery of 2026-08-12 (the copy shows 0 matching rows today). To prove the pruner against the issue's exact populations, the copy was re-seeded with the reported counts and swept:

```
$ hermes sessions prune --never-active --older-than 7d --dry-run
700 never-active keyed session(s) older than 7 day(s) — no messages, tokens, tool calls or title:
  agent:main:telegram:dm:123            516
  agent:main:telegram:dm:chat-1         112
  agent:main:telegram:dm:chat-1:topic-1  28
  agent:main:weixin:dm:wx-chat           15
  agent:main:telegram:dm:a               10
  agent:main:telegram:dm:b               10
  agent:main:telegram:dm:1                6
  agent:main:telegram:dm:42               3
Dry run — nothing deleted.

$ hermes sessions prune --never-active --older-than 7d --yes
Deleted 700 never-active session(s) and 0 stale routing entr(ies).
# sessions 989 → 289; fixture leftovers = 0; all 36,632 real message rows intact
```

## Test plan

- `tests/hermes_state/` (full dir: guard ancestry ×11, isolation marker ×6, never-active prune ×17, pre-existing guard suite): **134 passed**
- Cross-checks on the deliberate PYTEST-stripping tests + guard self-test + config-loader e2e + session listing: **169 passed** total
- Sabotage runs: marker tests fail 3/6 without the marker commit; ancestry tests were verified RED-on-main by the original PR
- `python3 scripts/audit_pr_attribution.py --fix` clean; base gate = 0

## Infographic

<img width="1024" alt="infographic" src="https://files.catbox.moe/yprlb7.png" />
