### PR TITLE
fix(update): restart launchd dashboards through supervisor

### DIFF
--- a/hermes_cli/dashboard_procs.py
+++ b/hermes_cli/dashboard_procs.py
@@ -313,11 +313,12 @@ def _kill_stale_dashboard_processes(
     Manually-started dashboards are not auto-restarted because we don't know
     the original launch args (--host, --port, --insecure, --tui, --no-open).
     When ``restart_managed`` is true (the ``hermes update`` path), a detected
-    ``hermes-dashboard.service`` is restarted through systemd; any OTHER
-    killed PID that was supervised by a systemd unit (custom unit names —
-    e.g. a remote backend's ``hermes-serve.service``) has its owning unit
-    restarted after the kill, because systemd treats our SIGTERM as a clean
-    stop and ``Restart=on-failure`` would never fire (#68934).
+    ``hermes-dashboard.service`` or macOS Dashboard LaunchAgent is restarted
+    through its supervisor.  Any OTHER killed PID that was supervised by a
+    systemd unit (custom unit names — e.g. a remote backend's
+    ``hermes-serve.service``) has its owning unit restarted after the kill,
+    because systemd treats our SIGTERM as a clean stop and
+    ``Restart=on-failure`` would never fire (#68934).
     """
     if restart_managed and _m()._restart_managed_dashboard_service(reason):
         return {"matched": [], "killed": [], "failed": []}

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -7698,21 +7698,215 @@ def _dashboard_probe_host(host: str | None) -> str:
 
 
 _DASHBOARD_SYSTEMD_UNIT = "hermes-dashboard.service"
+_DASHBOARD_LAUNCHD_LABEL = "ai.hermes.dashboard"
+
+
+def _dashboard_launchd_label() -> str:
+    """Return the conventional dashboard LaunchAgent label for this profile."""
+    from hermes_cli.gateway import _profile_suffix
+
+    suffix = _profile_suffix()
+    if suffix:
+        return f"{_DASHBOARD_LAUNCHD_LABEL}-{suffix}"
+    return _DASHBOARD_LAUNCHD_LABEL
+
+
+def _dashboard_launchd_plist_path(label: str) -> Path:
+    """Return the canonical per-user LaunchAgent plist path for *label*."""
+    from hermes_cli.gateway import _launchd_user_home
+
+    return _launchd_user_home() / "Library" / "LaunchAgents" / f"{label}.plist"
+
+
+def _dashboard_launchd_label_from_plist_name(name: str) -> str | None:
+    """Return a conventional Dashboard label encoded by a plist filename."""
+    suffix = ".plist"
+    if not name.endswith(suffix):
+        return None
+    label = name[: -len(suffix)]
+    if label == _DASHBOARD_LAUNCHD_LABEL:
+        return label
+    prefix = f"{_DASHBOARD_LAUNCHD_LABEL}-"
+    if not label.startswith(prefix):
+        return None
+    profile = label[len(prefix):]
+    if not profile or any(
+        char not in "abcdefghijklmnopqrstuvwxyz0123456789_-" for char in profile
+    ):
+        return None
+    return label
+
+
+def _dashboard_launchd_candidates() -> tuple[
+    list[str], dict[str, tuple[Path, int]]
+]:
+    """Discover conventional Dashboard labels and installed plist identities.
+
+    ``hermes update`` refreshes one shared source checkout, so a Dashboard
+    launched under another profile is just as stale as the current profile's
+    process.  Always probe the default and current labels, plus every
+    conventional profile plist in the user's LaunchAgents directory.
+    """
+    current_label = _dashboard_launchd_label()
+    paths = {
+        _DASHBOARD_LAUNCHD_LABEL: _dashboard_launchd_plist_path(
+            _DASHBOARD_LAUNCHD_LABEL
+        ),
+        current_label: _dashboard_launchd_plist_path(current_label),
+    }
+    launch_agents = paths[_DASHBOARD_LAUNCHD_LABEL].parent
+    try:
+        entries = list(launch_agents.iterdir())
+    except FileNotFoundError:
+        entries = []
+
+    for path in entries:
+        label = _dashboard_launchd_label_from_plist_name(path.name)
+        if label is not None:
+            paths.setdefault(label, path)
+
+    configurations: dict[str, tuple[Path, int]] = {}
+    for label, path in paths.items():
+        try:
+            mode = path.lstat().st_mode
+        except FileNotFoundError:
+            continue
+        configurations[label] = (path, mode)
+
+    labels = [_DASHBOARD_LAUNCHD_LABEL]
+    labels.extend(sorted(label for label in paths if label != _DASHBOARD_LAUNCHD_LABEL))
+    return labels, configurations
+
+
+def _launchctl_dashboard_job_missing(
+    result: subprocess.CompletedProcess,
+    label: str,
+) -> bool:
+    """Return True only for launchctl's explicit job-not-found response."""
+    detail = f"{result.stderr or ''}\n{result.stdout or ''}".casefold()
+    quoted_label = re.escape(label.casefold())
+    return (
+        result.returncode in {3, 113}
+        and re.search(
+            rf"could not find service\s+[\"']{quoted_label}[\"'](?:\s|$)",
+            detail,
+        )
+        is not None
+    )
 
 
 def _restart_managed_dashboard_service(
     reason: str,
     unit: str = _DASHBOARD_SYSTEMD_UNIT,
 ) -> bool:
-    """Restart a systemd-managed dashboard instead of raw-killing its PID.
+    """Restart a supervisor-managed dashboard instead of raw-killing its PID.
 
-    Returns True when a dashboard unit was found and handled (successfully or
-    with a printed actionable failure).  Returning True deliberately prevents
-    the caller from falling back to ``os.kill``: systemd treats a direct
-    SIGTERM of the service's main PID as a clean stop, so ``Restart=on-failure``
-    will not bring the dashboard back.
+    Returns True when a systemd unit or macOS LaunchAgent was found and handled
+    (successfully or with a printed actionable failure).  Ambiguous launchd
+    ownership is also treated as handled so an update cannot create a detached
+    duplicate beside a supervisor.  Returning True deliberately prevents the
+    caller from falling back to ``os.kill``.
     """
     if sys.platform == "win32":
+        return False
+
+    if sys.platform == "darwin":
+        try:
+            labels, configurations = _dashboard_launchd_candidates()
+        except (ImportError, KeyError, OSError, ValueError) as exc:
+            print()
+            print(f"    ⚠ could not discover dashboard LaunchAgents: {exc}")
+            print("  launchd ownership is unknown; refusing detached fallback.")
+            return True
+
+        # A non-regular conventional plist makes ownership ambiguous.  Check
+        # every configuration before restarting anything so discovery remains
+        # a fail-closed, all-or-nothing phase.
+        for label, (plist_path, plist_mode) in configurations.items():
+            if not stat.S_ISREG(plist_mode):
+                print()
+                print(f"    ⚠ {plist_path} is not a regular LaunchAgent plist")
+                print("  launchd ownership is unknown; refusing detached fallback.")
+                return True
+
+        uid = os.getuid()
+        loaded_targets: list[tuple[str, str]] = []
+        for label in labels:
+            for domain in (f"gui/{uid}", f"user/{uid}"):
+                target = f"{domain}/{label}"
+                try:
+                    probe = subprocess.run(
+                        ["launchctl", "print", target],
+                        capture_output=True,
+                        text=True, encoding="utf-8", errors="replace",
+                        timeout=10,
+                    )
+                except (FileNotFoundError, subprocess.TimeoutExpired, OSError) as exc:
+                    print()
+                    print(f"    ⚠ could not inspect {target}: {exc}")
+                    print("  launchd ownership is unknown; refusing detached fallback.")
+                    return True
+
+                if probe.returncode == 0:
+                    loaded_targets.append((label, target))
+                    break
+                if _launchctl_dashboard_job_missing(probe, label):
+                    continue
+                detail = (probe.stderr or probe.stdout or "").strip()
+                print()
+                print(
+                    f"    ⚠ could not inspect {target}: "
+                    f"{detail or f'exit {probe.returncode}'}"
+                )
+                print("  launchd ownership is unknown; refusing detached fallback.")
+                return True
+
+        if loaded_targets:
+            print()
+            print(f"⟲ Restarting managed dashboard service(s) ({reason})")
+            failures: list[tuple[str, list[str], str]] = []
+            for label, target in loaded_targets:
+                command = ["launchctl", "kickstart", "-k", target]
+                try:
+                    restarted = subprocess.run(
+                        command,
+                        capture_output=True,
+                        text=True, encoding="utf-8", errors="replace",
+                        timeout=60,
+                    )
+                except (FileNotFoundError, subprocess.TimeoutExpired, OSError) as exc:
+                    failures.append((label, command, str(exc)))
+                    continue
+                if restarted.returncode == 0:
+                    print(f"    ✓ restarted {label}")
+                    continue
+                detail = (restarted.stderr or restarted.stdout or "").strip()
+                failures.append(
+                    (label, command, detail or f"exit {restarted.returncode}")
+                )
+
+            for label, _command, detail in failures:
+                print(f"    ✗ failed to restart {label}: {detail}")
+            if failures:
+                print("  Dashboard is managed by launchd; refusing detached fallback.")
+                for _label, command, _detail in failures:
+                    print(f"  Restart manually: {' '.join(command)}")
+            return True
+
+        # Every conventional launchd job was explicitly absent.  Any canonical
+        # plist still means at least one Dashboard is supervisor-configured;
+        # do not create a detached duplicate while jobs are merely unloaded.
+        if configurations:
+            print()
+            for label in labels:
+                configured = configurations.get(label)
+                if configured is None:
+                    continue
+                plist_path, _plist_mode = configured
+                print(f"    ⚠ {label} is configured but not loaded")
+                print(f"      Inspect or reload manually: {plist_path}")
+            print("  Refusing detached fallback while a LaunchAgent plist exists.")
+            return True
         return False
 
     def _systemctl(*args: str, timeout: int = 10) -> subprocess.CompletedProcess:

--- a/tests/hermes_cli/test_update_stale_dashboard.py
+++ b/tests/hermes_cli/test_update_stale_dashboard.py
@@ -15,6 +15,8 @@ from __future__ import annotations
 
 import importlib
 import os
+from pathlib import Path
+import subprocess
 import sys
 from unittest.mock import patch, MagicMock
 
@@ -159,6 +161,7 @@ class TestKillStaleDashboardPosix:
 
 
 
+    @pytest.mark.linux_only
     def test_user_scope_restart_never_falls_back_to_system_or_sudo(self, capsys):
         """A user unit is discovered and restarted through ``systemctl --user``."""
         calls: list[list[str]] = []
@@ -190,6 +193,429 @@ class TestKillStaleDashboardPosix:
         find_pids.assert_not_called()
         kill.assert_not_called()
         assert "✓ restarted hermes-dashboard.service" in capsys.readouterr().out
+
+    @pytest.mark.macos_only
+    def test_launchctl_missing_response_requires_exact_label(self):
+        """A named-profile error must not prove the default job is absent."""
+        live = sys.modules["hermes_cli.main"]
+        label = "ai.hermes.dashboard"
+        other_profile = subprocess.CompletedProcess(
+            ["launchctl", "print", f"gui/501/{label}"],
+            113,
+            "",
+            (
+                'Could not find service "ai.hermes.dashboard-work" '
+                "in domain for user gui: 501"
+            ),
+        )
+
+        assert not live._launchctl_dashboard_job_missing(other_profile, label)
+
+    @pytest.mark.macos_only
+    def test_launchd_managed_dashboard_restarts_without_detached_respawn(
+        self, tmp_path, capsys
+    ):
+        """A loaded LaunchAgent is restarted through launchctl, never raw-killed."""
+        live = sys.modules["hermes_cli.main"]
+        launch_agents = tmp_path / "Library" / "LaunchAgents"
+        calls: list[list[str]] = []
+
+        def fake_run(args, *a, **kw):
+            calls.append(list(args))
+            if args == ["launchctl", "print", "gui/501/ai.hermes.dashboard"]:
+                return MagicMock(returncode=0, stdout="state = running\n", stderr="")
+            if args == [
+                "launchctl", "kickstart", "-k", "gui/501/ai.hermes.dashboard"
+            ]:
+                return MagicMock(returncode=0, stdout="", stderr="")
+            raise AssertionError(f"unexpected subprocess.run call: {args}")
+
+        with patch.object(live.os, "getuid", return_value=501), \
+             patch.object(
+                 live,
+                 "_dashboard_launchd_label",
+                 return_value="ai.hermes.dashboard",
+                 create=True,
+             ), \
+             patch.object(
+                 live,
+                 "_dashboard_launchd_plist_path",
+                 side_effect=lambda label: launch_agents / f"{label}.plist",
+             ), \
+             patch.object(live.subprocess, "run", side_effect=fake_run), \
+             patch.object(live, "_find_stale_dashboard_pids") as find_pids, \
+             patch.object(live, "_respawn_dashboard_processes") as respawn, \
+             patch.object(live.os, "kill") as kill:
+            result = _kill_stale_dashboard_processes(restart_managed=True)
+
+        assert result == {"matched": [], "killed": [], "failed": []}
+        assert calls == [
+            ["launchctl", "print", "gui/501/ai.hermes.dashboard"],
+            ["launchctl", "kickstart", "-k", "gui/501/ai.hermes.dashboard"],
+        ]
+        find_pids.assert_not_called()
+        respawn.assert_not_called()
+        kill.assert_not_called()
+        assert "✓ restarted ai.hermes.dashboard" in capsys.readouterr().out
+
+    @pytest.mark.macos_only
+    def test_launchd_update_finds_default_job_from_named_profile(
+        self, tmp_path, capsys
+    ):
+        """A source update must not raw-kill a default job from another profile."""
+        live = sys.modules["hermes_cli.main"]
+        launch_agents = tmp_path / "Library" / "LaunchAgents"
+        launch_agents.mkdir(parents=True)
+        default_plist = launch_agents / "ai.hermes.dashboard.plist"
+        default_plist.write_text("<plist/>", encoding="utf-8")
+        calls: list[list[str]] = []
+
+        def plist_path(label: str) -> Path:
+            return launch_agents / f"{label}.plist"
+
+        def fake_run(args, *a, **kw):
+            calls.append(list(args))
+            target = args[-1]
+            if args[:2] == ["launchctl", "print"]:
+                if target == "gui/501/ai.hermes.dashboard":
+                    return MagicMock(returncode=0, stdout="state = running\n", stderr="")
+                label = target.rsplit("/", 1)[-1]
+                return MagicMock(
+                    returncode=113,
+                    stdout="",
+                    stderr=(
+                        f'Could not find service "{label}" '
+                        "in domain for user gui: 501"
+                    ),
+                )
+            if args == [
+                "launchctl", "kickstart", "-k", "gui/501/ai.hermes.dashboard"
+            ]:
+                return MagicMock(returncode=0, stdout="", stderr="")
+            raise AssertionError(f"unexpected subprocess.run call: {args}")
+
+        with patch.object(live.os, "getuid", return_value=501), \
+             patch.object(
+                 live,
+                 "_dashboard_launchd_label",
+                 return_value="ai.hermes.dashboard-work",
+             ), \
+             patch.object(
+                 live,
+                 "_dashboard_launchd_plist_path",
+                 side_effect=plist_path,
+             ), \
+             patch.object(live.subprocess, "run", side_effect=fake_run), \
+             patch.object(live, "_find_stale_dashboard_pids") as find_pids, \
+             patch.object(live, "_respawn_dashboard_processes") as respawn, \
+             patch.object(live.os, "kill") as kill:
+            result = _kill_stale_dashboard_processes(restart_managed=True)
+
+        assert not result["matched"]
+        assert [
+            "launchctl", "kickstart", "-k", "gui/501/ai.hermes.dashboard"
+        ] in calls
+        find_pids.assert_not_called()
+        respawn.assert_not_called()
+        kill.assert_not_called()
+        assert "✓ restarted ai.hermes.dashboard" in capsys.readouterr().out
+
+    @pytest.mark.macos_only
+    def test_launchd_update_restarts_all_loaded_profile_jobs(self, tmp_path, capsys):
+        """Every conventional loaded Dashboard job sharing the source is restarted."""
+        live = sys.modules["hermes_cli.main"]
+        launch_agents = tmp_path / "Library" / "LaunchAgents"
+        launch_agents.mkdir(parents=True)
+        labels = ("ai.hermes.dashboard", "ai.hermes.dashboard-work")
+        for label in labels:
+            (launch_agents / f"{label}.plist").write_text(
+                "<plist/>", encoding="utf-8"
+            )
+        calls: list[list[str]] = []
+
+        def plist_path(label: str) -> Path:
+            return launch_agents / f"{label}.plist"
+
+        def fake_run(args, *a, **kw):
+            calls.append(list(args))
+            target = args[-1]
+            if args[:2] == ["launchctl", "print"] and target in {
+                f"gui/501/{label}" for label in labels
+            }:
+                return MagicMock(returncode=0, stdout="state = running\n", stderr="")
+            if args[:3] == ["launchctl", "kickstart", "-k"] and target in {
+                f"gui/501/{label}" for label in labels
+            }:
+                return MagicMock(returncode=0, stdout="", stderr="")
+            raise AssertionError(f"unexpected subprocess.run call: {args}")
+
+        with patch.object(live.os, "getuid", return_value=501), \
+             patch.object(
+                 live,
+                 "_dashboard_launchd_label",
+                 return_value="ai.hermes.dashboard-work",
+             ), \
+             patch.object(
+                 live,
+                 "_dashboard_launchd_plist_path",
+                 side_effect=plist_path,
+             ), \
+             patch.object(live.subprocess, "run", side_effect=fake_run), \
+             patch.object(live, "_find_stale_dashboard_pids") as find_pids, \
+             patch.object(live, "_respawn_dashboard_processes") as respawn, \
+             patch.object(live.os, "kill") as kill:
+            result = _kill_stale_dashboard_processes(restart_managed=True)
+
+        assert result == {"matched": [], "killed": [], "failed": []}
+        assert {
+            tuple(["launchctl", "kickstart", "-k", f"gui/501/{label}"])
+            for label in labels
+        } <= {tuple(call) for call in calls}
+        find_pids.assert_not_called()
+        respawn.assert_not_called()
+        kill.assert_not_called()
+        output = capsys.readouterr().out
+        assert "✓ restarted ai.hermes.dashboard" in output
+        assert "✓ restarted ai.hermes.dashboard-work" in output
+
+    @pytest.mark.macos_only
+    def test_launchd_profile_probe_is_all_or_nothing(self, tmp_path, capsys):
+        """A later ambiguous profile probe prevents every supervisor mutation."""
+        live = sys.modules["hermes_cli.main"]
+        launch_agents = tmp_path / "Library" / "LaunchAgents"
+        launch_agents.mkdir(parents=True)
+        labels = ("ai.hermes.dashboard", "ai.hermes.dashboard-work")
+        for label in labels:
+            (launch_agents / f"{label}.plist").write_text(
+                "<plist/>", encoding="utf-8"
+            )
+        calls: list[list[str]] = []
+
+        def plist_path(label: str) -> Path:
+            return launch_agents / f"{label}.plist"
+
+        def fake_run(args, *a, **kw):
+            calls.append(list(args))
+            target = args[-1]
+            if args == ["launchctl", "print", "gui/501/ai.hermes.dashboard"]:
+                return MagicMock(returncode=0, stdout="state = running\n", stderr="")
+            if args == ["launchctl", "print", "gui/501/ai.hermes.dashboard-work"]:
+                raise subprocess.TimeoutExpired(args, 10)
+            raise AssertionError(f"unexpected subprocess.run call: {args}")
+
+        with patch.object(live.os, "getuid", return_value=501), \
+             patch.object(
+                 live,
+                 "_dashboard_launchd_label",
+                 return_value="ai.hermes.dashboard-work",
+             ), \
+             patch.object(
+                 live,
+                 "_dashboard_launchd_plist_path",
+                 side_effect=plist_path,
+             ), \
+             patch.object(live.subprocess, "run", side_effect=fake_run), \
+             patch.object(live, "_find_stale_dashboard_pids") as find_pids, \
+             patch.object(live, "_respawn_dashboard_processes") as respawn, \
+             patch.object(live.os, "kill") as kill:
+            result = _kill_stale_dashboard_processes(restart_managed=True)
+
+        assert result == {"matched": [], "killed": [], "failed": []}
+        assert not any(call[:3] == ["launchctl", "kickstart", "-k"] for call in calls)
+        find_pids.assert_not_called()
+        respawn.assert_not_called()
+        kill.assert_not_called()
+        assert "ownership is unknown" in capsys.readouterr().out
+
+    @pytest.mark.macos_only
+    def test_launchd_profile_restart_failure_never_uses_detached_fallback(
+        self, tmp_path, capsys
+    ):
+        """One failed profile restart is reported while other loaded jobs continue."""
+        live = sys.modules["hermes_cli.main"]
+        launch_agents = tmp_path / "Library" / "LaunchAgents"
+        launch_agents.mkdir(parents=True)
+        labels = ("ai.hermes.dashboard", "ai.hermes.dashboard-work")
+        for label in labels:
+            (launch_agents / f"{label}.plist").write_text(
+                "<plist/>", encoding="utf-8"
+            )
+        calls: list[list[str]] = []
+
+        def plist_path(label: str) -> Path:
+            return launch_agents / f"{label}.plist"
+
+        def fake_run(args, *a, **kw):
+            calls.append(list(args))
+            target = args[-1]
+            if args[:2] == ["launchctl", "print"] and target in {
+                f"gui/501/{label}" for label in labels
+            }:
+                return MagicMock(returncode=0, stdout="state = running\n", stderr="")
+            if args == [
+                "launchctl", "kickstart", "-k", "gui/501/ai.hermes.dashboard"
+            ]:
+                return MagicMock(returncode=5, stdout="", stderr="not permitted")
+            if args == [
+                "launchctl", "kickstart", "-k", "gui/501/ai.hermes.dashboard-work"
+            ]:
+                return MagicMock(returncode=0, stdout="", stderr="")
+            raise AssertionError(f"unexpected subprocess.run call: {args}")
+
+        with patch.object(live.os, "getuid", return_value=501), \
+             patch.object(
+                 live,
+                 "_dashboard_launchd_label",
+                 return_value="ai.hermes.dashboard-work",
+             ), \
+             patch.object(
+                 live,
+                 "_dashboard_launchd_plist_path",
+                 side_effect=plist_path,
+             ), \
+             patch.object(live.subprocess, "run", side_effect=fake_run), \
+             patch.object(live, "_find_stale_dashboard_pids") as find_pids, \
+             patch.object(live, "_respawn_dashboard_processes") as respawn, \
+             patch.object(live.os, "kill") as kill:
+            result = _kill_stale_dashboard_processes(restart_managed=True)
+
+        assert result == {"matched": [], "killed": [], "failed": []}
+        for label in labels:
+            assert [
+                "launchctl", "kickstart", "-k", f"gui/501/{label}"
+            ] in calls
+        find_pids.assert_not_called()
+        respawn.assert_not_called()
+        kill.assert_not_called()
+        output = capsys.readouterr().out
+        assert "failed to restart ai.hermes.dashboard: not permitted" in output
+        assert "✓ restarted ai.hermes.dashboard-work" in output
+        assert "refusing detached fallback" in output
+
+    @pytest.mark.macos_only
+    def test_launchd_ambiguous_probe_failure_refuses_detached_fallback(
+        self, tmp_path, capsys
+    ):
+        """Unknown launchd ownership must not degrade to PID kill and respawn."""
+        live = sys.modules["hermes_cli.main"]
+        launch_agents = tmp_path / "Library" / "LaunchAgents"
+
+        with patch.object(live.os, "getuid", return_value=501), \
+             patch.object(
+                 live,
+                 "_dashboard_launchd_label",
+                 return_value="ai.hermes.dashboard",
+                 create=True,
+             ), \
+             patch.object(
+                 live,
+                 "_dashboard_launchd_plist_path",
+                 side_effect=lambda label: launch_agents / f"{label}.plist",
+             ), \
+             patch.object(
+                 live.subprocess,
+                 "run",
+                 side_effect=subprocess.TimeoutExpired(["launchctl", "print"], 10),
+             ), \
+             patch.object(live, "_find_stale_dashboard_pids") as find_pids, \
+             patch.object(live, "_respawn_dashboard_processes") as respawn, \
+             patch.object(live.os, "kill") as kill:
+            result = _kill_stale_dashboard_processes(restart_managed=True)
+
+        assert result == {"matched": [], "killed": [], "failed": []}
+        find_pids.assert_not_called()
+        respawn.assert_not_called()
+        kill.assert_not_called()
+        assert "refusing detached fallback" in capsys.readouterr().out
+
+    @pytest.mark.macos_only
+    def test_launchd_missing_job_with_plist_refuses_detached_fallback(
+        self, tmp_path, capsys
+    ):
+        """An installed but unloaded LaunchAgent stays supervisor-owned."""
+        live = sys.modules["hermes_cli.main"]
+        plist = tmp_path / "Library" / "LaunchAgents" / "ai.hermes.dashboard.plist"
+        plist.parent.mkdir(parents=True)
+        plist.write_text("<plist/>", encoding="utf-8")
+        missing = MagicMock(
+            returncode=113,
+            stdout="",
+            stderr=(
+                'Could not find service "ai.hermes.dashboard" '
+                "in domain for user gui: 501"
+            ),
+        )
+
+        with patch.object(live.os, "getuid", return_value=501), \
+             patch.object(
+                 live,
+                 "_dashboard_launchd_label",
+                 return_value="ai.hermes.dashboard",
+                 create=True,
+             ), \
+             patch.object(
+                 live,
+                 "_dashboard_launchd_plist_path",
+                 return_value=plist,
+                 create=True,
+             ), \
+             patch.object(live.subprocess, "run", return_value=missing), \
+             patch.object(live, "_find_stale_dashboard_pids") as find_pids, \
+             patch.object(live, "_respawn_dashboard_processes") as respawn, \
+             patch.object(live.os, "kill") as kill:
+            result = _kill_stale_dashboard_processes(restart_managed=True)
+
+        assert result == {"matched": [], "killed": [], "failed": []}
+        find_pids.assert_not_called()
+        respawn.assert_not_called()
+        kill.assert_not_called()
+        assert "configured but not loaded" in capsys.readouterr().out
+
+    @pytest.mark.macos_only
+    def test_launchd_missing_job_without_plist_keeps_manual_respawn(
+        self, tmp_path, capsys
+    ):
+        """Definitively unmanaged macOS dashboards retain the existing update path."""
+        live = sys.modules["hermes_cli.main"]
+        argv = ["hermes", "dashboard", "--port", "8300"]
+        missing = MagicMock(
+            returncode=113,
+            stdout="",
+            stderr=(
+                'Could not find service "ai.hermes.dashboard" '
+                "in domain for user gui: 501"
+            ),
+        )
+        plist = tmp_path / "Library" / "LaunchAgents" / "ai.hermes.dashboard.plist"
+
+        with patch.object(live.os, "getuid", return_value=501), \
+             patch.object(
+                 live,
+                 "_dashboard_launchd_label",
+                 return_value="ai.hermes.dashboard",
+                 create=True,
+             ), \
+             patch.object(
+                 live,
+                 "_dashboard_launchd_plist_path",
+                 return_value=plist,
+                 create=True,
+             ), \
+             patch.object(live.subprocess, "run", return_value=missing), \
+             patch.object(live, "_find_stale_dashboard_pids", return_value=[6001]), \
+             patch.object(live, "_get_pid_cgroup_path", return_value=None), \
+             patch.object(live, "_get_systemd_service_for_pid", return_value=None), \
+             patch.object(live, "_dashboard_cmdline_for_pid", return_value=argv), \
+             patch("hermes_cli.dashboard_procs._hermes_home_for_pid", return_value=None), \
+             patch.object(live, "_respawn_dashboard_processes", return_value=[]) as respawn, \
+             patch.object(live.os, "kill"), \
+             patch("gateway.status._pid_exists", return_value=False), \
+             patch("time.sleep"):
+            result = _kill_stale_dashboard_processes(restart_managed=True)
+
+        assert result["killed"] == [6001]
+        respawn.assert_called_once_with([argv])
+        assert "refusing detached fallback" not in capsys.readouterr().out
 
 
 


### PR DESCRIPTION
## What does this PR do?

Prevents `hermes update` from raw-killing and detached-respawning a macOS Dashboard that is already owned by launchd.

A launchd-managed Dashboard currently falls through the Linux-only managed-service check. Update cleanup then treats its PID as manual: launchd `KeepAlive` starts one replacement while the updater detached-respawns another, so the processes race for the same port and can leave an `EADDRINUSE` loop or a listener no longer owned by launchd.

The fix discovers the conventional default, current-profile, and installed profile-scoped Dashboard LaunchAgents, completes ownership discovery for all of them before any mutation, and delegates loaded-job restarts to `launchctl kickstart -k`. Ambiguous ownership fails closed instead of creating a competing detached process. Definitively unmanaged Dashboards retain the existing kill/respawn path.

## Related Issue

Related to #44106. This PR addresses only the update/restart race; it does not add Dashboard service installation, status, or removal commands.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/main.py`
  - derive `ai.hermes.dashboard[-<profile>]` with the existing gateway profile helper;
  - discover the default/current labels and conventional profile plists in the user's LaunchAgents directory;
  - probe both `gui/<uid>` and `user/<uid>` launchd domains for every candidate before restarting any job;
  - restart every loaded candidate with `launchctl kickstart -k`;
  - refuse raw-kill/detached fallback on ambiguous discovery, probe, configuration, or restart errors;
  - treat existing conventional LaunchAgent plists as configured ownership when jobs are unloaded;
  - retain manual Dashboard respawn only when every candidate is explicitly absent and no conventional plist exists.
- `hermes_cli/dashboard_procs.py`
  - document launchd as a managed Dashboard supervisor.
- `tests/hermes_cli/test_update_stale_dashboard.py`
  - add macOS regressions for exact-label absence classification, loaded, multi-profile, all-or-nothing discovery, restart-failure, configured-unloaded, and definitively unmanaged states;
  - make the existing systemd test explicitly Linux-only.

Linux systemd handling, Windows handling, and explicit `hermes dashboard --stop` behavior are unchanged.

## How to Test

1. Run `scripts/run_tests.sh tests/hermes_cli/test_update_stale_dashboard.py -q`.
   - On macOS: 35 passed, 4 skipped.
   - Linux- and Windows-only cases run in their CI lanes.
2. Run `python -m ruff check hermes_cli/main.py hermes_cli/dashboard_procs.py tests/hermes_cli/test_update_stale_dashboard.py`.
3. With one or more Dashboard LaunchAgents loaded, verify `hermes update` invokes `launchctl kickstart -k <domain>/ai.hermes.dashboard[-profile]` for each loaded candidate and does not enter the raw PID kill/detached respawn path.
4. Verify a missing job plus no conventional Dashboard plist still takes the existing manual Dashboard respawn path.

Additional local checks:

- in-memory Python AST compile of all three changed Python files
- `git diff --check`
- read-only real-macOS probes: default/named profile labels and plist paths resolved correctly; loaded job returned 0; intentionally missing label returned 113 and was classified as explicitly absent.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
  - The focused CI-parity wrapper passed locally. The full local suite was not completed because unrelated process-lifecycle tests on this live macOS host can touch its running Dashboard; the isolated GitHub CI matrix is the full-suite gate.
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 27.0

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — docstrings updated
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A, no config changes
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Not applicable. The regression tests assert that launchd-owned or ambiguously owned Dashboards never reach PID kill or detached respawn, while definitively unmanaged Dashboards keep the existing behavior.
