### PR TITLE
fix(memory): thread session titles into Hindsight via sync_turn

### DIFF
--- a/agent/memory_manager.py
+++ b/agent/memory_manager.py
@@ -672,6 +672,18 @@ class MemoryManager:
             return True
         return "messages" in signature.parameters
 
+    @staticmethod
+    def _provider_sync_accepts_title(provider: MemoryProvider) -> bool:
+        """Return whether sync_turn accepts a session_title keyword."""
+        try:
+            signature = inspect.signature(provider.sync_turn)
+        except (TypeError, ValueError):
+            return True
+        params = list(signature.parameters.values())
+        if any(p.kind == inspect.Parameter.VAR_KEYWORD for p in params):
+            return True
+        return "session_title" in signature.parameters
+
     def sync_all(
         self,
         user_content: str,
@@ -679,6 +691,7 @@ class MemoryManager:
         *,
         session_id: str = "",
         messages: Optional[List[Dict[str, Any]]] = None,
+        session_title: str = "",
     ) -> None:
         """Sync a completed turn to all providers.
 
@@ -709,12 +722,35 @@ class MemoryManager:
         def _run() -> None:
             for provider in providers:
                 try:
-                    if messages is not None and self._provider_sync_accepts_messages(provider):
+                    accepts_messages = (
+                        messages is not None
+                        and self._provider_sync_accepts_messages(provider)
+                    )
+                    accepts_title = (
+                        session_title
+                        and self._provider_sync_accepts_title(provider)
+                    )
+                    if accepts_messages and accepts_title:
                         provider.sync_turn(
                             user_content,
                             assistant_content,
                             session_id=session_id,
                             messages=messages,
+                            session_title=session_title,
+                        )
+                    elif accepts_messages:
+                        provider.sync_turn(
+                            user_content,
+                            assistant_content,
+                            session_id=session_id,
+                            messages=messages,
+                        )
+                    elif accepts_title:
+                        provider.sync_turn(
+                            user_content,
+                            assistant_content,
+                            session_id=session_id,
+                            session_title=session_title,
                         )
                     else:
                         provider.sync_turn(

--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -811,6 +811,7 @@ class HindsightMemoryProvider(MemoryProvider):
         # Points at _writer_thread once the writer is running.
         self._sync_thread = None
         self._session_id = ""
+        self._session_title = ""
         self._parent_session_id = ""
         self._document_id = ""
 
@@ -2017,6 +2018,20 @@ class HindsightMemoryProvider(MemoryProvider):
             metadata["agent_identity"] = self._agent_identity
         return metadata
 
+    def _lineage_tags(self, session_title: str = "") -> list[str]:
+        """Lineage tags for the next retain, including the human-readable
+        session title when one is known (#86824)."""
+        tags: list[str] = []
+        if self._session_id:
+            tags.append(f"session:{self._session_id}")
+        if self._parent_session_id:
+            tags.append(f"parent:{self._parent_session_id}")
+        if session_title:
+            self._session_title = str(session_title).strip()
+            if self._session_title:
+                tags.append(f"title:{self._session_title}")
+        return tags
+
     def _build_retain_kwargs(
         self,
         content: str,
@@ -2048,7 +2063,14 @@ class HindsightMemoryProvider(MemoryProvider):
             kwargs["observation_scopes"] = self._observation_scopes
         return kwargs
 
-    def sync_turn(self, user_content: str, assistant_content: str, *, session_id: str = "") -> None:
+    def sync_turn(
+        self,
+        user_content: str,
+        assistant_content: str,
+        *,
+        session_id: str = "",
+        session_title: str = "",
+    ) -> None:
         """Enqueue a retain for the current turn. Non-blocking.
 
         The actual aretain_batch runs on a single long-lived writer thread
@@ -2095,11 +2117,7 @@ class HindsightMemoryProvider(MemoryProvider):
                      sum(len(t) for t in turns_to_retain))
         content = "[" + ",".join(turns_to_retain) + "]"
 
-        lineage_tags: list[str] = []
-        if self._session_id:
-            lineage_tags.append(f"session:{self._session_id}")
-        if self._parent_session_id:
-            lineage_tags.append(f"parent:{self._parent_session_id}")
+        lineage_tags = self._lineage_tags(session_title)
 
         # Snapshot the state needed for the retain. The writer may run after
         # _session_turns / _turn_index are mutated by a later sync_turn().

--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -2027,9 +2027,12 @@ class HindsightMemoryProvider(MemoryProvider):
         if self._parent_session_id:
             tags.append(f"parent:{self._parent_session_id}")
         if session_title:
-            self._session_title = str(session_title).strip()
+            # Cap + flatten: a long or multi-line title would bloat every
+            # downstream lineage tag/metadata row.
+            clean_title = " ".join(str(session_title).split())[:100]
+            self._session_title = clean_title
             if self._session_title:
-                tags.append(f"title:{self._session_title}")
+                tags.append(f"title:{clean_title}")
         return tags
 
     def _build_retain_kwargs(

--- a/run_agent.py
+++ b/run_agent.py
@@ -4333,6 +4333,18 @@ class AIAgent:
             return
         try:
             sync_kwargs = {"session_id": self.session_id or ""}
+            # Thread the session title into memory providers that store it
+            # (Hindsight banks otherwise surface every session as its raw id —
+            # #86824). Guarded: the title read must never block or break sync.
+            session_title = ""
+            try:
+                if self.session_id and self._session_db is not None:
+                    row = self._session_db.get_session(self.session_id)
+                    session_title = (row.get("title") or "").strip() if row else ""
+            except Exception:
+                pass
+            if session_title:
+                sync_kwargs["session_title"] = session_title
             if messages is not None:
                 sync_kwargs["messages"] = messages
             self._memory_manager.sync_all(

--- a/run_agent.py
+++ b/run_agent.py
@@ -4342,7 +4342,12 @@ class AIAgent:
                     row = self._session_db.get_session(self.session_id)
                     session_title = (row.get("title") or "").strip() if row else ""
             except Exception:
-                pass
+                # Silent for sync safety, but diagnosable: a DB-lock or schema
+                # issue here would otherwise drop titles with no trace
+                # (Enough1122 review on #86870).
+                logger.debug(
+                    "session-title lookup for memory sync failed", exc_info=True
+                )
             if session_title:
                 sync_kwargs["session_title"] = session_title
             if messages is not None:

--- a/tests/agent/test_memory_manager_title_threading.py
+++ b/tests/agent/test_memory_manager_title_threading.py
@@ -1,0 +1,59 @@
+"""MemoryManager threads session_title only to providers that accept it (#86824)."""
+
+from __future__ import annotations
+
+import pytest
+
+
+class _TitleProvider:
+    name = "title-provider"
+
+    def __init__(self, accepts_title: bool):
+        self._accepts_title = accepts_title
+        self.received: dict = {}
+
+    def sync_turn(self, user_content, assistant_content, **kwargs):
+        self.received = kwargs
+
+    @property
+    def __signature__capture(self):
+        pass
+
+
+def _provider_with_sig(accepts_title: bool):
+    """Provider whose sync_turn signature advertises session_title or not."""
+
+    class P(_TitleProvider):
+        def __init__(self):
+            super().__init__(accepts_title)
+
+        if accepts_title:
+
+            def sync_turn(self, user_content, assistant_content, *, session_id="", session_title=""):
+                self.received = {"session_id": session_id, "session_title": session_title}
+
+        else:
+
+            def sync_turn(self, user_content, assistant_content, *, session_id=""):
+                self.received = {"session_id": session_id}
+
+    return P()
+
+
+def test_title_passed_only_to_accepting_provider():
+    from agent.memory_manager import MemoryManager
+
+    mgr = MemoryManager.__new__(MemoryManager)
+    mgr._providers = [_provider_with_sig(True), _provider_with_sig(False)]
+    mgr._submit_background = lambda fn, **kw: fn()
+    mgr._strip_skill_scaffolding = lambda s: s
+
+    mgr.sync_all(
+        "user",
+        "assistant",
+        session_id="sess-1",
+        session_title="API Key Update Verified",
+    )
+
+    assert mgr._providers[0].received.get("session_title") == "API Key Update Verified"
+    assert "session_title" not in mgr._providers[1].received

--- a/tests/plugins/test_hindsight_session_title.py
+++ b/tests/plugins/test_hindsight_session_title.py
@@ -1,0 +1,43 @@
+"""Hindsight session-title threading (#86824).
+
+sync_turn accepts a `session_title` kwarg and surfaces it as a `title:`
+lineage tag at retain time so banks stop listing sessions under raw ids.
+"""
+
+from __future__ import annotations
+
+from plugins.memory.hindsight import HindsightMemoryProvider
+
+
+def _make_provider() -> HindsightMemoryProvider:
+    p = HindsightMemoryProvider.__new__(HindsightMemoryProvider)
+    p._bank_id = "bank"
+    p._session_id = ""
+    p._parent_session_id = ""
+    p._retain_tags = []
+    p._observation_scopes = None
+    return p
+
+
+def test_lineage_tags_carry_title():
+    """The title lands in the lineage tags the retain path ships (#86824)."""
+    p = _make_provider()
+    p._session_id = "sess-1"
+    p._parent_session_id = ""
+
+    tags = p._lineage_tags("API Key Update Verified")
+
+    assert "title:API Key Update Verified" in tags
+    assert "session:sess-1" in tags
+    assert p._session_title == "API Key Update Verified"
+
+
+def test_lineage_tags_omit_empty_title():
+    p = _make_provider()
+    p._session_id = "sess-1"
+    p._parent_session_id = ""
+
+    tags = p._lineage_tags("")
+
+    assert "title:" not in " ".join(tags)
+    assert "session:sess-1" in tags


### PR DESCRIPTION
## Summary

Fixes #86824: Hindsight banks surface every session under its raw id because the generated session title never reached the plugin. Titles exist and are correct in core (`auxiliary.title_generation`, visible in `hermes sessions list`) — the memory pipeline just dropped them.

## Changes (implementation + tests as separate commits)

- **`run_agent.py`** (turn-sync path): reads the session title from `SessionDB.get_session()` at sync time, guarded so a title read can never block or break the sync; passes it as `session_title` kwarg.
- **`agent/memory_manager.py`**: `sync_all` gains `session_title`; new `_provider_sync_accepts_title` introspection mirroring the existing `messages` gate — the kwarg goes only to providers whose `sync_turn` advertises it (VAR_KEYWORD included).
- **`plugins/memory/hindsight/__init__.py`**: `sync_turn` accepts `session_title`; extracted `_lineage_tags()` (unit-testable) which appends a `title:` tag when the title is non-empty, alongside the existing `session:`/`parent:` tags.

## Validation

- New tests: `tests/agent/test_memory_manager_title_threading.py` (dispatch only to accepting providers) + `tests/plugins/test_hindsight_session_title.py` (title tag present, empty title omitted) — green.
- Hindsight plugin suites (`test_hindsight_root_guard`, `test_hindsight_health_grace_timeout`) — green.
- Full `tests/agent/` run: 4480 passed, 30 failed — the 30 are the known flaky/env-dependent LSP e2e tests (`tests/agent/lsp/*`), untouched by this diff.

## Scope note

The tag appears only once a title exists; pre-title turns keep the old id-only tags. Backfilling existing banks is a separate migration — offered to the reporter.
