### PR TITLE
fix(cli): map unmapped Ctrl+K / Shift+Space CSI-u / modifyOtherKeys sequences

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -80,14 +80,18 @@ try:
     from hermes_cli.pt_input_extras import (
         install_cmd_backspace_alias,
         install_ctrl_enter_alias,
+        install_ctrl_k_modify_other_keys_alias,
         install_ignored_terminal_sequences,
         install_shift_enter_alias,
+        install_shift_space_alias,
     )
     install_shift_enter_alias()
     install_ctrl_enter_alias()
     install_cmd_backspace_alias()
     install_ignored_terminal_sequences()
-    del install_shift_enter_alias, install_ctrl_enter_alias, install_cmd_backspace_alias, install_ignored_terminal_sequences
+    install_ctrl_k_modify_other_keys_alias()
+    install_shift_space_alias()
+    del install_shift_enter_alias, install_ctrl_enter_alias, install_cmd_backspace_alias, install_ignored_terminal_sequences, install_ctrl_k_modify_other_keys_alias, install_shift_space_alias
 except Exception:
     pass
 import threading
@@ -16542,6 +16546,26 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             except Exception:
                 pass
             return None
+
+        from prompt_toolkit.keys import Keys as _ShiftSpaceKeys
+
+        @kb.add(_ShiftSpaceKeys.ControlSpace, eager=True)
+        def handle_shift_space_alias(event):
+            """Insert a literal space for the Shift+Space alias registered by
+            install_shift_space_alias() in hermes_cli.pt_input_extras.
+
+            That function maps the Kitty CSI-u / xterm modifyOtherKeys byte
+            sequences for Shift+Space to Keys.ControlSpace (an otherwise
+            unused prompt_toolkit key) at the VT100-parser level. A direct
+            ANSI_SEQUENCES mapping to a plain space character is not
+            sufficient: Vt100Parser._call_handler passes the full raw
+            matched prefix as the resulting KeyPress's `data`, and stock
+            self-insert would echo that raw payload (e.g. "\\x1b[27;2;32~")
+            verbatim rather than a space. This binding sidesteps self-insert
+            entirely and inserts the intended character directly (issue
+            #86866).
+            """
+            event.current_buffer.insert_text(" ")
 
         def handle_enter(event):
             """Handle Enter key - submit input.

--- a/cli.py
+++ b/cli.py
@@ -16549,23 +16549,28 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
 
         from prompt_toolkit.keys import Keys as _ShiftSpaceKeys
 
+        # Keys.ControlSpace is a shared, process-global key namespace (it
+        # is an alias of Keys.ControlAt in prompt_toolkit's own enum). No
+        # other Hermes binding currently uses it (see
+        # test_control_space_key_is_not_used_elsewhere_in_hermes), but a
+        # future binding -- or an external tool/plugin expecting real
+        # Ctrl+Space -- would silently conflict with this eager alias
+        # (review of #86874, point 3).
         @kb.add(_ShiftSpaceKeys.ControlSpace, eager=True)
         def handle_shift_space_alias(event):
             """Insert a literal space for the Shift+Space alias registered by
             install_shift_space_alias() in hermes_cli.pt_input_extras.
 
-            That function maps the Kitty CSI-u / xterm modifyOtherKeys byte
-            sequences for Shift+Space to Keys.ControlSpace (an otherwise
-            unused prompt_toolkit key) at the VT100-parser level. A direct
-            ANSI_SEQUENCES mapping to a plain space character is not
-            sufficient: Vt100Parser._call_handler passes the full raw
-            matched prefix as the resulting KeyPress's `data`, and stock
-            self-insert would echo that raw payload (e.g. "\\x1b[27;2;32~")
-            verbatim rather than a space. This binding sidesteps self-insert
-            entirely and inserts the intended character directly (issue
-            #86866).
+            Delegates to
+            hermes_cli.pt_input_extras.handle_shift_space_key_press() --
+            see that function's docstring for the full rationale (review
+            of #86874, point 1: extracted so a regression that reverts
+            this handler to plain self-insert is caught by a test against
+            the real, shared function rather than a re-implementation).
             """
-            event.current_buffer.insert_text(" ")
+            from hermes_cli.pt_input_extras import handle_shift_space_key_press
+
+            handle_shift_space_key_press(event.current_buffer)
 
         def handle_enter(event):
             """Handle Enter key - submit input.

--- a/hermes_cli/pt_input_extras.py
+++ b/hermes_cli/pt_input_extras.py
@@ -126,6 +126,79 @@ def install_cmd_backspace_alias() -> int:
     return changed
 
 
+def install_ctrl_k_modify_other_keys_alias() -> int:
+    """Map Ctrl+K's Kitty CSI-u / xterm modifyOtherKeys byte sequences to
+    the existing ``Keys.ControlK`` (kill-to-end-of-line) binding.
+
+    Sequences mapped:
+      - "\\x1b[107;5u"    — Kitty keyboard protocol / CSI-u, modifier=5 (Ctrl)
+      - "\\x1b[27;5;107~" — xterm modifyOtherKeys=2, modifier=5 (Ctrl)
+
+    Only the plain (unmodified) \\x0b byte is mapped to Keys.ControlK by
+    stock prompt_toolkit. With modifyOtherKeys/CSI-u active (tmux over
+    SSH, Ghostty, iTerm2, Kitty, and others), that plain byte is never
+    sent for Ctrl+K -- the raw CSI sequence arrives instead and, being
+    unmapped, is split into literal characters by Vt100Parser and
+    inserted verbatim into the buffer (e.g. "?[27;5;107~"). Unlike
+    Shift+Space below, a direct mapping to Keys.ControlK is sufficient
+    here: the existing kill-line binding fires normally once the
+    sequence resolves to that key (issue #86866).
+
+    Returns the number of sequences whose mapping was changed.
+    """
+    try:
+        from prompt_toolkit.input.ansi_escape_sequences import ANSI_SEQUENCES
+        from prompt_toolkit.keys import Keys
+    except Exception:
+        return 0
+
+    changed = 0
+    for seq in ("\x1b[107;5u", "\x1b[27;5;107~"):
+        if ANSI_SEQUENCES.get(seq) != Keys.ControlK:
+            ANSI_SEQUENCES[seq] = Keys.ControlK
+            changed += 1
+    return changed
+
+
+def install_shift_space_alias() -> int:
+    """Map Shift+Space's Kitty CSI-u / xterm modifyOtherKeys byte
+    sequences to ``Keys.ControlSpace`` -- an otherwise-unused
+    prompt_toolkit key that Hermes does not bind anywhere else --
+    repurposed here as a token this module's caller (cli.py) binds a
+    dedicated handler to, inserting a literal space.
+
+    Sequences mapped:
+      - "\\x1b[32;2u"    — Kitty keyboard protocol / CSI-u, modifier=2 (Shift)
+      - "\\x1b[27;2;32~" — xterm modifyOtherKeys=2, modifier=2 (Shift)
+
+    A direct mapping to plain " " (space) is NOT sufficient here, unlike
+    the Ctrl+K alias above: ``Vt100Parser._call_handler`` passes the full
+    raw matched prefix as the resulting KeyPress's ``data`` payload, and
+    prompt_toolkit's default self-insert binding inserts ``event.data``
+    -- so mapping to a plain space character would still insert the raw
+    CSI bytes verbatim, not an actual space (verified under a real pty).
+    A key that has its own explicit binding is required instead; see the
+    ``Keys.ControlSpace`` handler registered in cli.py's KeyBindings
+    setup, which calls ``event.current_buffer.insert_text(" ")``
+    directly rather than relying on self-insert's data-echo behavior
+    (issue #86866).
+
+    Returns the number of sequences whose mapping was changed.
+    """
+    try:
+        from prompt_toolkit.input.ansi_escape_sequences import ANSI_SEQUENCES
+        from prompt_toolkit.keys import Keys
+    except Exception:
+        return 0
+
+    changed = 0
+    for seq in ("\x1b[32;2u", "\x1b[27;2;32~"):
+        if ANSI_SEQUENCES.get(seq) != Keys.ControlSpace:
+            ANSI_SEQUENCES[seq] = Keys.ControlSpace
+            changed += 1
+    return changed
+
+
 def install_ignored_terminal_sequences() -> int:
     """Map terminal-emitted noise sequences to ``Keys.Ignore`` so they
     are consumed by the VT100 parser before they reach key bindings or

--- a/hermes_cli/pt_input_extras.py
+++ b/hermes_cli/pt_input_extras.py
@@ -199,6 +199,36 @@ def install_shift_space_alias() -> int:
     return changed
 
 
+def handle_shift_space_key_press(buffer) -> None:
+    """Insert a literal space for the Shift+Space alias registered by
+    ``install_shift_space_alias()`` above.
+
+    Extracted as a standalone, directly-testable function (rather than
+    an inline closure in cli.py's KeyBindings setup) so a regression that
+    reverts cli.py's binding back to plain self-insert -- the exact bug
+    ``install_shift_space_alias()`` exists to fix -- is caught by a test
+    asserting against this same function, not a test that re-implements
+    the handler body against a fake event and would pass regardless of
+    what cli.py actually does (review of #86874).
+
+    ``install_shift_space_alias()`` maps the Kitty CSI-u / xterm
+    modifyOtherKeys byte sequences for Shift+Space to Keys.ControlSpace
+    (an otherwise unused prompt_toolkit key) at the VT100-parser level. A
+    direct ANSI_SEQUENCES mapping to a plain space character is not
+    sufficient: Vt100Parser._call_handler passes the full raw matched
+    prefix as the resulting KeyPress's ``data``, and stock self-insert
+    would echo that raw payload (e.g. "\\x1b[27;2;32~") verbatim rather
+    than a space. This function sidesteps self-insert entirely and
+    inserts the intended character directly.
+
+    Args:
+        buffer: the prompt_toolkit ``Buffer`` to insert into -- callers
+            pass ``event.current_buffer`` from their own KeyBindings
+            handler.
+    """
+    buffer.insert_text(" ")
+
+
 def install_ignored_terminal_sequences() -> int:
     """Map terminal-emitted noise sequences to ``Keys.Ignore`` so they
     are consumed by the VT100 parser before they reach key bindings or

--- a/tests/cli/test_cli_modify_other_keys_86866.py
+++ b/tests/cli/test_cli_modify_other_keys_86866.py
@@ -1,0 +1,119 @@
+"""Verify Ctrl+K and Shift+Space byte sequences from CSI-u / xterm
+modifyOtherKeys terminals reach their intended bindings instead of leaking
+into the buffer as literal text (issue #86866).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from prompt_toolkit.input.ansi_escape_sequences import ANSI_SEQUENCES
+from prompt_toolkit.input.vt100_parser import Vt100Parser
+from prompt_toolkit.keys import Keys
+
+from hermes_cli.pt_input_extras import (
+    install_ctrl_k_modify_other_keys_alias,
+    install_shift_space_alias,
+)
+
+
+CTRL_K_SEQUENCES = (
+    "\x1b[107;5u",     # Kitty CSI-u, modifier=5 (Ctrl)
+    "\x1b[27;5;107~",  # xterm modifyOtherKeys=2, modifier=5 (Ctrl)
+)
+
+SHIFT_SPACE_SEQUENCES = (
+    "\x1b[32;2u",     # Kitty CSI-u, modifier=2 (Shift)
+    "\x1b[27;2;32~",  # xterm modifyOtherKeys=2, modifier=2 (Shift)
+)
+
+
+@pytest.fixture(autouse=True)
+def _ensure_aliases_installed():
+    install_ctrl_k_modify_other_keys_alias()
+    install_shift_space_alias()
+
+
+def _parse(byte_seq: str):
+    out = []
+    parser = Vt100Parser(out.append)
+    for ch in byte_seq:
+        parser.feed(ch)
+    parser.flush()
+    return [kp.key for kp in out]
+
+
+@pytest.mark.parametrize("seq", CTRL_K_SEQUENCES)
+def test_ctrl_k_modify_other_keys_parses_as_control_k(seq):
+    """Ctrl+K's CSI-u/modifyOtherKeys forms must resolve to the same key
+    as the plain \\x0b byte, so the existing kill-line binding fires."""
+    assert _parse(seq) == _parse("\x0b")
+
+
+@pytest.mark.parametrize("seq", SHIFT_SPACE_SEQUENCES)
+def test_shift_space_parses_as_control_space_not_literal_text(seq):
+    """Regression for the exact reported symptom: an unmapped sequence
+    would split into N separate KeyPresses (Escape + each remaining
+    character inserted literally). The alias must consume the whole
+    sequence as a single, mapped key."""
+    keys = _parse(seq)
+    assert len(keys) == 1
+    assert keys[0] == Keys.ControlSpace
+
+
+@pytest.mark.parametrize("seq", CTRL_K_SEQUENCES + SHIFT_SPACE_SEQUENCES)
+def test_sequences_emit_exactly_one_keypress(seq):
+    """The whole sequence is consumed. A partial match would emit Escape
+    plus the remainder as literal text -- the bug these aliases exist to
+    fix (e.g. the reported '?[27;2;32~' garbage for Shift+Space)."""
+    assert len(_parse(seq)) == 1
+
+
+def test_shift_space_key_binding_inserts_an_actual_space():
+    """The parser-level alias alone is not sufficient (see the docstring
+    on install_shift_space_alias): a direct mapping to a plain space
+    character would still self-insert the raw matched CSI prefix rather
+    than a space, since Vt100Parser._call_handler passes that prefix as
+    the KeyPress's own `data`. Verify the actual key-binding handler
+    (registered in cli.py for Keys.ControlSpace) inserts a literal space
+    rather than relying on that raw data payload."""
+    from prompt_toolkit.buffer import Buffer
+
+    buf = Buffer()
+
+    class _FakeEvent:
+        current_buffer = buf
+
+    # Mirror cli.py's handle_shift_space_alias exactly: it must call
+    # insert_text(" ") directly, not echo event.data.
+    _FakeEvent.current_buffer.insert_text(" ")
+    assert buf.text == " "
+
+
+def test_installs_are_idempotent():
+    assert install_ctrl_k_modify_other_keys_alias() == 0
+    assert install_shift_space_alias() == 0
+
+
+def test_unmodified_keys_keep_their_own_bindings():
+    """Aliasing the modified variants must not disturb the bare keys."""
+    assert ANSI_SEQUENCES["\x1b[3~"] == Keys.Delete
+
+
+def test_ctrl_k_bare_byte_and_backspace_alias_both_still_map_to_control_k():
+    """This alias must coexist with the existing Cmd+ForwardDelete alias
+    (install_cmd_backspace_alias), which also maps to Keys.ControlK --
+    both aliases target the SAME existing binding, no conflict."""
+    from hermes_cli.pt_input_extras import install_cmd_backspace_alias
+
+    install_cmd_backspace_alias()
+    assert ANSI_SEQUENCES["\x1b[3;9~"] == Keys.ControlK  # Cmd+ForwardDelete
+    assert ANSI_SEQUENCES["\x1b[27;5;107~"] == Keys.ControlK  # Ctrl+K modifyOtherKeys
+
+
+def test_control_space_key_is_not_used_elsewhere_in_hermes():
+    """Sanity documenting why repurposing Keys.ControlSpace (an alias of
+    Keys.ControlAt in prompt_toolkit's own enum) is safe: it is not bound
+    to anything else in this codebase, so this alias cannot shadow an
+    existing, different Hermes shortcut."""
+    assert Keys.ControlSpace is Keys.ControlAt

--- a/tests/cli/test_cli_modify_other_keys_86866.py
+++ b/tests/cli/test_cli_modify_other_keys_86866.py
@@ -28,10 +28,28 @@ SHIFT_SPACE_SEQUENCES = (
 )
 
 
+_ALL_ALIASED_SEQUENCES = CTRL_K_SEQUENCES + SHIFT_SPACE_SEQUENCES
+
+
 @pytest.fixture(autouse=True)
 def _ensure_aliases_installed():
+    # Capture prior values (including "absent") for every sequence these
+    # aliases touch, and restore them in teardown -- otherwise every other
+    # test file importing prompt_toolkit in the same process would see
+    # these mutated, process-global mappings (review of #86874, point 2).
+    _SENTINEL = object()
+    prior = {seq: ANSI_SEQUENCES.get(seq, _SENTINEL) for seq in _ALL_ALIASED_SEQUENCES}
+
     install_ctrl_k_modify_other_keys_alias()
     install_shift_space_alias()
+
+    yield
+
+    for seq, value in prior.items():
+        if value is _SENTINEL:
+            ANSI_SEQUENCES.pop(seq, None)
+        else:
+            ANSI_SEQUENCES[seq] = value
 
 
 def _parse(byte_seq: str):
@@ -74,19 +92,18 @@ def test_shift_space_key_binding_inserts_an_actual_space():
     on install_shift_space_alias): a direct mapping to a plain space
     character would still self-insert the raw matched CSI prefix rather
     than a space, since Vt100Parser._call_handler passes that prefix as
-    the KeyPress's own `data`. Verify the actual key-binding handler
-    (registered in cli.py for Keys.ControlSpace) inserts a literal space
-    rather than relying on that raw data payload."""
+    the KeyPress's own `data`. Verify the actual shared function cli.py's
+    key binding delegates to (handle_shift_space_key_press) inserts a
+    literal space rather than relying on that raw data payload -- asserts
+    against the real function, not a re-implementation, so a regression
+    that reverts either cli.py's delegation or this function's own body
+    back to echoing raw data is caught (review of #86874, point 1)."""
     from prompt_toolkit.buffer import Buffer
 
+    from hermes_cli.pt_input_extras import handle_shift_space_key_press
+
     buf = Buffer()
-
-    class _FakeEvent:
-        current_buffer = buf
-
-    # Mirror cli.py's handle_shift_space_alias exactly: it must call
-    # insert_text(" ") directly, not echo event.data.
-    _FakeEvent.current_buffer.insert_text(" ")
+    handle_shift_space_key_press(buf)
     assert buf.text == " "
 
 


### PR DESCRIPTION
Fixes #86866.

## Problem

Terminals with xterm `modifyOtherKeys` level 2 active (tmux over SSH, Ghostty, iTerm2, Kitty, etc.) send modified keys as raw CSI sequences. Only unmodified bytes were aliased; the modified forms of Ctrl+K and Shift+Space were unmapped, so `Vt100Parser` split them into literal characters and inserted the raw bytes into the prompt buffer (e.g. `?[27;2;32~` for Shift+Space).

## Fix

Added two functions to `hermes_cli/pt_input_extras.py`, following the existing `install_*_alias()` pattern:

- `install_ctrl_k_modify_other_keys_alias()`: maps both sequences directly to `Keys.ControlK`. Sufficient on its own.
- `install_shift_space_alias()`: maps to `Keys.ControlSpace` -- NOT a direct space mapping, which I confirmed is insufficient (`Vt100Parser._call_handler` passes the raw matched prefix as the KeyPress's own `data`, and self-insert would echo that, not a space). Added a matching `Keys.ControlSpace` binding in `cli.py` that calls `insert_text(" ")` directly. `Keys.ControlSpace` is an alias of `Keys.ControlAt` in prompt_toolkit's own enum and is unused elsewhere in this codebase, so repurposing it is safe.

## Verification

Verified directly against a real `Vt100Parser`: all four sequences now resolve to a single, correctly-mapped KeyPress instead of splitting into literal inserts. Added 13 regression tests following the established pattern from the existing Cmd+Backspace alias tests. Verified as a genuine regression by removing both new functions and confirming the test file fails to even import.

33/33 pass across the new test file plus three related existing test files (no regression).