### PR TITLE
fix(delegate): cron synchronous delegate_task fallback no longer wedges after the child completes

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -1819,6 +1819,16 @@ class AIAgent:
         appended to the review prompt — e.g. "save the deploy workflow as a
         skill". The automatic post-turn triggers never set it.
         """
+        # A delegation subagent (``_delegate_depth > 0``) must not run the
+        # automatic post-turn review. Subagents are ephemeral workers already
+        # barred from writing shared MEMORY.md (``DELEGATE_BLOCKED_TOOLS``) and
+        # are spawned with ``skip_memory=True``, so a review here has little to
+        # persist — yet it inherits the subagent's (often premium) delegation
+        # model and replays the whole conversation at premium rates, silently
+        # inflating token cost (#85859). An explicit ``/refine`` (``focus`` set)
+        # is a deliberate user request and still runs.
+        if focus is None and getattr(self, "_delegate_depth", 0) > 0:
+            return
         from agent.background_review import spawn_background_review_thread
         from tools.thread_context import propagate_context_to_thread
         target, _prompt = spawn_background_review_thread(

--- a/tests/run_agent/test_background_review.py
+++ b/tests/run_agent/test_background_review.py
@@ -125,6 +125,114 @@ def test_background_review_fork_opts_out_of_session_finalization(monkeypatch):
     assert seen.get("at_run_time") is False
 
 
+def test_background_review_skipped_in_delegation_subagent(monkeypatch):
+    """The automatic post-turn review must NOT fire inside a delegation
+    subagent (``_delegate_depth > 0``).
+
+    Regression for #85859: the fork inherits the subagent's live model, so in
+    a delegation subagent running a premium model it replayed the whole
+    conversation at premium rates. Subagents are already barred from writing
+    shared MEMORY.md, so there is nothing for the review to persist here.
+    """
+    forks = []
+
+    class FakeReviewAgent:
+        def __init__(self, **kwargs):
+            forks.append(kwargs)
+
+        def run_conversation(self, **kwargs):
+            pass
+
+        def shutdown_memory_provider(self):
+            pass
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr(run_agent_module, "AIAgent", FakeReviewAgent)
+    monkeypatch.setattr(run_agent_module.threading, "Thread", ImmediateThread)
+
+    agent = _bare_agent()
+    agent._delegate_depth = 1  # this agent IS a delegation subagent
+
+    AIAgent._spawn_background_review(
+        agent,
+        messages_snapshot=[{"role": "user", "content": "hello"}],
+        review_memory=True,
+        review_skills=True,
+    )
+
+    assert forks == [], "no review fork should be spawned inside a subagent"
+
+
+def test_background_review_runs_at_top_level(monkeypatch):
+    """Sibling guard for the subagent skip: at ``_delegate_depth == 0`` the
+    review still fires exactly as before (the cost guard is subagent-only)."""
+    forks = []
+
+    class FakeReviewAgent:
+        def __init__(self, **kwargs):
+            forks.append(kwargs)
+
+        def run_conversation(self, **kwargs):
+            pass
+
+        def shutdown_memory_provider(self):
+            pass
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr(run_agent_module, "AIAgent", FakeReviewAgent)
+    monkeypatch.setattr(run_agent_module.threading, "Thread", ImmediateThread)
+
+    agent = _bare_agent()
+    agent._delegate_depth = 0  # top-level agent
+
+    AIAgent._spawn_background_review(
+        agent,
+        messages_snapshot=[{"role": "user", "content": "hello"}],
+        review_memory=True,
+    )
+
+    assert len(forks) == 1, "top-level review must still spawn the fork"
+
+
+def test_background_review_explicit_focus_runs_even_in_subagent(monkeypatch):
+    """An explicit ``/refine`` (``focus`` set) is a deliberate user request and
+    is honored regardless of depth — only the automatic post-turn review is
+    suppressed in subagents."""
+    forks = []
+
+    class FakeReviewAgent:
+        def __init__(self, **kwargs):
+            forks.append(kwargs)
+
+        def run_conversation(self, **kwargs):
+            pass
+
+        def shutdown_memory_provider(self):
+            pass
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr(run_agent_module, "AIAgent", FakeReviewAgent)
+    monkeypatch.setattr(run_agent_module.threading, "Thread", ImmediateThread)
+
+    agent = _bare_agent()
+    agent._delegate_depth = 2
+
+    AIAgent._spawn_background_review(
+        agent,
+        messages_snapshot=[{"role": "user", "content": "hello"}],
+        review_skills=True,
+        focus="save the deploy workflow as a skill",
+    )
+
+    assert len(forks) == 1, "explicit focus review must run even in a subagent"
+
+
 def test_background_review_registers_on_active_children_for_interrupt(monkeypatch):
     """The review fork must be added to the parent's ``_active_children`` so
     ``AIAgent.interrupt()`` (which fans out to that list) can reach it, and

--- a/tests/tools/test_delegate_cron_sync_fallback.py
+++ b/tests/tools/test_delegate_cron_sync_fallback.py
@@ -1,0 +1,179 @@
+"""Regression test for #86632: cron's synchronous delegate_task fallback must
+return after the child completes — the automatic background review must not
+fire inside the delegated child.
+
+Field signature (issue #86632): a cron job's top-level ``delegate_task`` takes
+the #66617 stateless-channel synchronous fallback, the child finishes its turn
+normally (``Turn ended: reason=text_response``), and the delegation never
+returns to the parent — the heartbeat monitor goes stale and the cron
+inactivity watchdog kills the job.  Root cause (traced in the issue thread and
+fixed by the ``_delegate_depth`` guard in ``AIAgent._spawn_background_review``):
+the child's turn finalization spawned the automatic memory/skill background
+review fork.  Delegated children must never spawn that fork — it inherits the
+child's (often premium) model, replays the whole conversation, and its spawn
+inside the child's finalize path is the wedge site the cron watchdog kills.
+
+This exercises the REAL end-to-end #86632 path: a genuine ``AIAgent`` child
+(mocked LLM client) with the skill-review trigger armed, dispatched through
+``delegate_task(background=True)`` under a session runtime where async delivery
+is unsupported (cron), forcing the synchronous fallback.
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import tools.delegate_tool as dt
+
+
+def _mock_response(content="Hello", finish_reason="stop", tool_calls=None):
+    msg = SimpleNamespace(content=content, tool_calls=tool_calls)
+    choice = SimpleNamespace(message=msg, finish_reason=finish_reason)
+    return SimpleNamespace(choices=[choice], model="test/model", usage=None)
+
+
+def _make_real_child():
+    """A real AIAgent child, as the cron sync fallback runs one.
+
+    The LLM client is mocked to complete in one call, and the post-turn
+    skill-review trigger is armed the way a long child run arms it — so turn
+    finalization reaches the background-review gate.
+    """
+    from run_agent import AIAgent
+
+    with (
+        patch("run_agent.get_tool_definitions", return_value=[]),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("hermes_cli.config.load_config", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        child = AIAgent(
+            api_key="test-key-1234567890",
+            base_url="https://openrouter.ai/api/v1",
+            max_iterations=10,
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+            platform="subagent",
+        )
+    child.client = MagicMock()
+    child.client.chat.completions.create.return_value = _mock_response(
+        content="child work done", finish_reason="stop"
+    )
+    child._cached_system_prompt = "You are helpful."
+    child._use_prompt_caching = False
+    child.compression_enabled = False
+    child.save_trajectories = False
+    child._fallback_chain = []
+    # Delegated-child identity, as _build_child_agent stamps it.
+    child._delegate_depth = 1
+    child._delegate_role = "leaf"
+    child._subagent_id = "subagent-86632"
+    child._delegate_saved_tool_names = []
+    # Arm the post-turn skill review trigger (finalize_turn's
+    # _should_review_skills gate) exactly as a long child run would.
+    child._skill_nudge_interval = 1
+    child._iters_since_skill = 5
+    child.valid_tool_names = {"skill_manage"}
+    # Keep the test hermetic: no session persistence.
+    child._persist_disabled = True
+    child._session_db = None
+    child._session_json_enabled = False
+    return child
+
+
+def test_cron_sync_fallback_returns_and_spawns_no_review_fork(monkeypatch):
+    """The #86632 path: sync fallback completes AND no review fork spawns.
+
+    Red on the pre-fix code: the delegated child's finalize path constructed a
+    background-review fork (``fork_constructed`` fires).  With the
+    ``_delegate_depth`` guard the fork is never built, removing the wedge site
+    entirely, and ``delegate_task`` returns the child's result promptly.
+    """
+    fork_spawned = threading.Event()
+    release_fork = threading.Event()
+
+    def _recording_review(agent_obj, messages_snapshot, prompt):
+        # Stands in for the review fork's replay; wedges like the field report.
+        fork_spawned.set()
+        release_fork.wait(timeout=60)
+
+    child = _make_real_child()
+    parent = MagicMock()
+    parent._delegate_depth = 0
+    parent.session_id = "cron_244ee2c8b9da"
+    parent._interrupt_requested = False
+    parent._active_children = []
+    parent._active_children_lock = threading.Lock()
+    parent._session_db = None
+
+    creds = {
+        "model": "m", "provider": None, "base_url": None, "api_key": None,
+        "api_mode": None, "command": None, "args": None,
+    }
+    monkeypatch.setattr(dt, "_build_child_agent", lambda **kw: child)
+    monkeypatch.setattr(dt, "_resolve_delegation_credentials", lambda *a, **k: creds)
+    # spawn_background_review_thread's target resolves _run_review_in_thread
+    # from module globals at call time, so this records (and wedges) the
+    # review replay without touching the child's own code paths.
+    monkeypatch.setattr(
+        "agent.background_review._run_review_in_thread", _recording_review
+    )
+
+    done: dict = {}
+
+    def _call_delegate_task():
+        # Cron declares the channel stateless (#66617): async delivery is
+        # unsupported and there is no bound origin session id to wake, so
+        # delegate_task must run the batch synchronously.
+        with (
+            patch(
+                "gateway.session_context.async_delivery_supported",
+                return_value=False,
+            ),
+            patch(
+                "tools.async_delegation._current_origin_session_id",
+                return_value="",
+            ),
+        ):
+            done["out"] = dt.delegate_task(
+                goal="do trivial work and finish",
+                context="cron regression #86632",
+                background=True,
+                parent_agent=parent,
+            )
+
+    worker = threading.Thread(target=_call_delegate_task, daemon=True)
+    worker.start()
+    worker.join(timeout=90)
+    try:
+        # 1) The synchronous fallback must return to the parent. On the field
+        #    failure this never happened; here a non-return means the child's
+        #    finalize path (or the parent join) wedged.
+        assert not worker.is_alive(), (
+            "delegate_task synchronous fallback did not return after the "
+            "child completed (#86632 wedge)"
+        )
+        parsed = json.loads(done["out"])
+        results = parsed["results"]
+        assert len(results) == 1
+        assert results[0]["status"] == "completed"
+        assert results[0]["summary"] == "child work done"
+
+        # 2) The wedge site must not exist at all: a delegated child
+        #    (_delegate_depth > 0) must never spawn the automatic background
+        #    review fork. Give a straggling daemon spawn a moment to show up
+        #    so a race cannot mask a regression.
+        assert not fork_spawned.wait(timeout=3), (
+            "automatic background review fork was constructed inside a "
+            "delegation subagent — the #86632 wedge site is back"
+        )
+    finally:
+        # Unblock a stray fork thread if the regression reappears, so it
+        # cannot outlive this test and pollute the rest of the session.
+        release_fork.set()


### PR DESCRIPTION
## Summary

Fixes #86632 — a cron job's top-level `delegate_task` enters the #66617 synchronous fallback ("async delivery unsupported on this session runtime; running the batch synchronously instead"), the child completes normally (`Turn ended: reason=text_response(finish_reason=stop)`), and the delegation **never returns to the parent**: the delegation heartbeat goes stale after 15 idle cycles (450s) and the cron inactivity watchdog kills the whole job 600s later.

## Root cause

The synchronous fallback runs `_run_single_child()` inline, which blocks on `_child_future.result(timeout=None)` until `child.run_conversation()` returns. After the child's turn ends, `agent/turn_finalizer.py` reaches the automatic background memory/skill review gate. `skip_background_review=True` is set only on the top-level **cron** agent (`cron/scheduler.py`) — it is never propagated to a delegated child, and `tools/delegate_tool.py` has no equivalent argument. So the delegated child (with the review trigger armed after a long run) still spawned `AIAgent._spawn_background_review(...)` inside its own finalize path. The review fork inherits the child's model and replays the whole conversation; when it wedges (custom/Codex provider, as in the report), the child's finalize thread never unwinds, `result(timeout=None)` never returns, and the parent is parked forever — exactly the field signature (`tool=<none>` stale heartbeat, watchdog kill ~17.5 min after the child had produced its result).

Diagnosis credit: @ygd58 traced the mechanism in the issue thread and @webtecnica confirmed it; the guard commit is @PRATHAMESH75's #85881 (cherry-picked here with authorship preserved — it was written for the cost side of the same defect, #85859, and is the exact fix for this wedge site).

## Changes

- **`run_agent.py`** (cherry-pick of #85881, author PRATHAMESH75): `AIAgent._spawn_background_review` returns early for the *automatic* post-turn review whenever `_delegate_depth > 0` — a delegation subagent must never fork the review. An explicit `/refine` (`focus` set) still runs at any depth.
- **`tests/run_agent/test_background_review.py`** (from #85881): unit guards — skipped in subagent, still runs at top level, explicit focus honored.
- **`tests/tools/test_delegate_cron_sync_fallback.py`** (new, this PR): end-to-end #86632 regression — a **real** `AIAgent` child (mocked LLM) with the post-turn skill-review trigger armed, dispatched through `delegate_task(background=True)` with `async_delivery_supported()` returning `False` and no origin wake session id (the cron stateless-channel condition), forcing the synchronous fallback. Asserts `delegate_task` returns the child's result and that no review fork spawns inside the delegated child (the stand-in review target wedges like the field report, so a regression turns this test into the original hang, caught by a bounded join).

## Verification

- **RED on main**: `test_cron_sync_fallback_returns_and_spawns_no_review_fork` fails on pre-fix `main` — `automatic background review fork was constructed inside a delegation subagent`.
- **GREEN with fix**: same test passes in ~4s.
- **Sabotage check**: reverting `run_agent.py` to `origin/main` (fix removed, tests kept) makes the new test fail again; restoring the fix makes it pass.
- Full local suites: `tests/tools/test_async_delegation.py tests/tools/test_delegate.py tests/tools/test_delegate_cron_sync_fallback.py tests/run_agent/test_background_review.py` → **99 passed**.
- `scripts/audit_pr_attribution.py --fix` clean; `ruff check` clean on touched files.

## Notes

- This supersedes #85881 for the merge (same commit, cherry-picked with attribution) and additionally lands the cron-sync-fallback regression test #86632 asked for. If #85881 merges first, this PR reduces to the regression test and rebases cleanly.
- #70301 (blanket-disable delegation in cron) should stay closed/held: with the wedge site removed, the #66617 inline fallback works as designed and cron keeps a working `delegate_task`.

Fixes #86632

## Infographic

![fix-86632 infographic](https://files.catbox.moe/i4xo7h.png)
