### PR TITLE
fix(browser): pin shared CDP sessions to tabs

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -2330,29 +2330,44 @@ def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
 
 
 def cleanup_task_resources(agent, task_id: str) -> None:
-    """Per-turn VM + browser cleanup for a task. Skips ``cleanup_vm`` for persistent
-    terminal envs (``_cleanup_inactive_envs`` reaps them after ``terminal.lifetime_seconds``)
-    and ``cleanup_browser`` in headed mode (the inactivity reaper handles idle sessions)."""
-    def _headed() -> bool:
-        try:
-            from tools.browser_tool_cloud import _is_headed_mode
-            return _is_headed_mode()
-        except Exception:
-            return bool(os.environ.get("AGENT_BROWSER_HEADED"))
+    """Per-turn VM cleanup plus ownership-aware browser finalization.
 
-    for label, skip, skip_what, cleanup in (
-        ("VM", is_persistent_env, "cleanup_vm for persistent env", lambda: _ra().cleanup_vm(task_id)),
-        ("browser", lambda _tid: _headed(), "cleanup_browser for headed session", lambda: _ra().cleanup_browser(task_id)),
-    ):
-        try:
-            if skip(task_id):
-                if agent.verbose_logging:
-                    logging.debug(f"Skipping per-turn {skip_what} {task_id}; idle reaper will handle it.")
-            else:
-                cleanup()
-        except Exception as e:
+    Persistent terminal backends retain their VM. Browser finalization keeps
+    only Hermes-owned local headed state; provider/shared-CDP ownership always
+    crosses the terminal boundary.
+    """
+    try:
+        if is_persistent_env(task_id):
             if agent.verbose_logging:
-                logger.warning("Failed to cleanup %s for task %s: %s", label, task_id, e)
+                logging.debug(
+                    "Skipping per-turn cleanup_vm for persistent env %s; "
+                    "idle reaper will handle it.",
+                    task_id,
+                )
+        else:
+            _ra().cleanup_vm(task_id)
+    except Exception as e:
+        if agent.verbose_logging:
+            logger.warning("Failed to cleanup VM for task %s: %s", task_id, e)
+
+    browser_boundary_completed = False
+    try:
+        cleanup_for_turn = getattr(_ra(), "cleanup_browser_for_turn", None)
+        if callable(cleanup_for_turn):
+            cleanup_result = cleanup_for_turn(task_id)
+        else:
+            cleanup_result = _ra().cleanup_browser(task_id)
+        # False means exact ownership is still pending; keep the outer turn
+        # boundary armed for one immediate retry. None is legacy success.
+        browser_boundary_completed = cleanup_result is not False
+    except Exception as e:
+        if agent.verbose_logging:
+            logger.warning("Failed to cleanup browser for task %s: %s", task_id, e)
+    finally:
+        if browser_boundary_completed:
+            mark_complete = getattr(_ra(), "_mark_browser_turn_cleanup_complete", None)
+            if callable(mark_complete):
+                mark_complete()
 
 
 def _build_partial_stream_stub(role, full_content, full_reasoning, model_name, usage_obj, *,

--- a/agent/turn_facade.py
+++ b/agent/turn_facade.py
@@ -7,13 +7,46 @@ MRO unchanged.
 """
 import logging
 import uuid
-from contextlib import suppress
+from contextlib import contextmanager, suppress
+from contextvars import ContextVar
 from typing import Any, Dict, List, Optional
 
 from agent.lazy_forward import forward as _forward
 
 # Same logger name as the origin module so log records / caplog filters are unchanged.
 logger = logging.getLogger("run_agent")
+
+
+_browser_turn_cleanup_completed: ContextVar[bool] = ContextVar(
+    "browser_turn_cleanup_completed", default=False
+)
+
+
+def _mark_browser_turn_cleanup_complete() -> None:
+    """Record that this synchronous turn already ran its browser boundary."""
+    _browser_turn_cleanup_completed.set(True)
+
+
+@contextmanager
+def _browser_turn_cleanup_boundary(task_id: str):
+    """Guarantee browser finalization for every conversation-loop exit."""
+    token = _browser_turn_cleanup_completed.set(False)
+    try:
+        yield
+    finally:
+        try:
+            if not _browser_turn_cleanup_completed.get():
+                # Resolve through the public facade at call time so embedders
+                # and tests that replace the cleanup binding remain supported.
+                import run_agent
+
+                run_agent.cleanup_browser_for_turn(task_id)
+        except Exception as exc:
+            # Cleanup must not replace the response/original exception. The
+            # RETIRING state remains the fail-closed boundary for later retry.
+            logger.warning("Browser turn cleanup failed for task %s: %s", task_id, exc)
+        finally:
+            _browser_turn_cleanup_completed.reset(token)
 
 
 class TurnFacadeMixin:
@@ -70,6 +103,8 @@ class TurnFacadeMixin:
         token = affinity_token = acct_token = None
         task_started = task_finished = False
         relay_outcome = "failed"
+        browser_cleanup_scope = _browser_turn_cleanup_boundary(effective_task_id)
+        browser_cleanup_scope.__enter__()
 
         try:
             # First statement of the try so the finally's note_turn_finished balances every exit.
@@ -167,6 +202,7 @@ class TurnFacadeMixin:
                     if relay_lease is not None:
                         relay_runtime.SESSION_COORDINATOR.release_conversation(relay_lease)
                 finally:
+                    browser_cleanup_scope.__exit__(None, None, None)
                     if lease is not None:
                         lease.stop_refresher()
                         lease.join_threads()

--- a/run_agent.py
+++ b/run_agent.py
@@ -102,7 +102,7 @@ if not _loaded_env_paths:
 from model_tools import get_toolset_for_tool
 from tools.terminal_tool_lifecycle import cleanup_vm, get_active_env
 from tools.interrupt import set_interrupt as _set_interrupt
-from tools.browser_tool_lifecycle import cleanup_browser
+from tools.browser_tool_lifecycle import cleanup_browser, cleanup_browser_for_turn
 
 from agent.memory_provider import is_trivial_prompt
 from agent.client_lifecycle import ClientLifecycleMixin
@@ -116,7 +116,11 @@ from agent.activity_tracking import ActivityTrackingMixin
 from agent.rate_limit_credits import RateLimitCreditsMixin
 from agent.session_persistence import SessionPersistenceMixin
 from agent.compression_facade import CompressionFacadeMixin
-from agent.turn_facade import TurnFacadeMixin
+from agent.turn_facade import (
+    TurnFacadeMixin,
+    _browser_turn_cleanup_boundary,
+    _mark_browser_turn_cleanup_complete,
+)
 from agent.vision_message_prep import VisionMessagePrepMixin
 from agent.reasoning_params import ReasoningParamsMixin
 from agent.lazy_forward import forward as _forward, forward_static as _forward_static

--- a/tests/test_managed_runtime_resolution.py
+++ b/tests/test_managed_runtime_resolution.py
@@ -81,6 +81,11 @@ _ALLOWED: dict[tuple[str, str], str] = {
         "uv on PATH is a legitimate last rung before giving up with install "
         "guidance."
     ),
+    ("tools/browser_tool.py", "node"): (
+        "Capability preflight must inspect the Node that a concrete agent-browser "
+        "candidate will execute from its own directory plus the exact subprocess "
+        "PATH; using the global managed resolver could certify a different runtime."
+    ),
     ("hermes_cli/gateway.py", "node"): (
         "Fallback rung of _append_node_dir_for_service(), after the managed "
         "dirs from iter_hermes_node_dirs() are already appended."

--- a/tests/test_managed_runtime_resolution.py
+++ b/tests/test_managed_runtime_resolution.py
@@ -81,7 +81,7 @@ _ALLOWED: dict[tuple[str, str], str] = {
         "uv on PATH is a legitimate last rung before giving up with install "
         "guidance."
     ),
-    ("tools/browser_tool.py", "node"): (
+    ("tools/browser_tool_install.py", "node"): (
         "Capability preflight must inspect the Node that a concrete agent-browser "
         "candidate will execute from its own directory plus the exact subprocess "
         "PATH; using the global managed resolver could certify a different runtime."

--- a/tests/tools/test_browser_agent_version.py
+++ b/tests/tools/test_browser_agent_version.py
@@ -23,17 +23,20 @@ def _reset_agent_browser_caches():
         bt._agent_browser_resolved,
         bt._cached_pin_tab_agent_browser,
         bt._pin_tab_agent_browser_resolved,
+        bt._pin_tab_failure_cache,
     )
     bt._cached_agent_browser = None
     bt._agent_browser_resolved = False
     bt._cached_pin_tab_agent_browser = None
     bt._pin_tab_agent_browser_resolved = False
+    bt._pin_tab_failure_cache = None
     yield
     (
         bt._cached_agent_browser,
         bt._agent_browser_resolved,
         bt._cached_pin_tab_agent_browser,
         bt._pin_tab_agent_browser_resolved,
+        bt._pin_tab_failure_cache,
     ) = original
 
 
@@ -119,6 +122,8 @@ def _configure_resolution(
 def test_runnable_033_remains_generic_but_is_rejected_for_pin(monkeypatch, tmp_path):
     old_cli = _fake_agent_browser(tmp_path / "old", "0.33.1", 24)
     _configure_resolution(monkeypatch, current_agent_browser=old_cli)
+    clock = [100.0]
+    monkeypatch.setattr(bt.time, "monotonic", lambda: clock[0])
 
     assert bt._find_agent_browser() == old_cli
     with pytest.raises(bt.AgentBrowserCapabilityError) as exc_info:
@@ -130,9 +135,19 @@ def test_runnable_033_remains_generic_but_is_rejected_for_pin(monkeypatch, tmp_p
     assert "ordinary non-CDP browser commands remain supported" in message
     assert bt._find_agent_browser() == old_cli
 
-    # Capability failures are not cached: upgrading the same executable makes
-    # the next explicit user command succeed without restarting Hermes.
+    # The negative cache suppresses repeated subprocess probes, but expires
+    # quickly enough that an in-place upgrade works without restarting Hermes.
     _fake_agent_browser(tmp_path / "old", "0.34.0", 24)
+    real_probe = bt._probe_agent_browser_version
+    monkeypatch.setattr(
+        bt,
+        "_probe_agent_browser_version",
+        lambda _path: pytest.fail("negative cache should suppress a second probe"),
+    )
+    with pytest.raises(bt.AgentBrowserCapabilityError, match="agent-browser >=0.34.0"):
+        bt._find_agent_browser(require_pin_tab=True)
+    clock[0] += bt.AGENT_BROWSER_PIN_TAB_FAILURE_TTL_SECONDS + 0.01
+    monkeypatch.setattr(bt, "_probe_agent_browser_version", real_probe)
     assert bt._find_agent_browser(require_pin_tab=True) == old_cli
 
 

--- a/tests/tools/test_browser_agent_version.py
+++ b/tests/tools/test_browser_agent_version.py
@@ -1,0 +1,237 @@
+"""Executable-level capability tests for agent-browser CDP tab pinning."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from tools import browser_tool as bt
+
+
+pytestmark = pytest.mark.skipif(
+    os.name == "nt",
+    reason="fake POSIX executables use /bin/sh",
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_agent_browser_caches():
+    original = (
+        bt._cached_agent_browser,
+        bt._agent_browser_resolved,
+        bt._cached_pin_tab_agent_browser,
+        bt._pin_tab_agent_browser_resolved,
+    )
+    bt._cached_agent_browser = None
+    bt._agent_browser_resolved = False
+    bt._cached_pin_tab_agent_browser = None
+    bt._pin_tab_agent_browser_resolved = False
+    yield
+    (
+        bt._cached_agent_browser,
+        bt._agent_browser_resolved,
+        bt._cached_pin_tab_agent_browser,
+        bt._pin_tab_agent_browser_resolved,
+    ) = original
+
+
+def _write_executable(path: Path, body: str) -> str:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(f"#!/bin/sh\n{body}\n", encoding="utf-8")
+    path.chmod(0o755)
+    return str(path)
+
+
+def _fake_agent_browser(root: Path, version: str, node_major: int) -> str:
+    cli = _write_executable(
+        root / "agent-browser",
+        (
+            'if [ "$1" = "--version" ]; then\n'
+            f"  printf '%s\\n' 'agent-browser {version}'\n"
+            "  exit 0\n"
+            "fi\n"
+            "exit 91"
+        ),
+    )
+    _write_executable(
+        root / "node",
+        f"printf '%s\\n' 'v{node_major}.0.0'",
+    )
+    return cli
+
+
+def _fake_npx(root: Path, node_major: int) -> str:
+    npx = _write_executable(root / "npx", "printf '%s\\n' '11.19.0'")
+    _write_executable(
+        root / "node",
+        f"printf '%s\\n' 'v{node_major}.0.0'",
+    )
+    return npx
+
+
+def _configure_resolution(
+    monkeypatch,
+    *,
+    current_agent_browser: str | None = None,
+    extended_agent_browser: str | None = None,
+    npx: str | None = None,
+) -> None:
+    extra_dirs = []
+    for executable in (extended_agent_browser, npx):
+        if executable:
+            parent = str(Path(executable).parent)
+            if parent not in extra_dirs:
+                extra_dirs.append(parent)
+
+    def merge_path(_existing: str) -> str:
+        return os.pathsep.join(extra_dirs)
+
+    def which(command: str, path: str | None = None) -> str | None:
+        search_dirs = [] if path is None else path.split(os.pathsep)
+        if command == "agent-browser":
+            if path is None:
+                return current_agent_browser
+            if (
+                extended_agent_browser
+                and str(Path(extended_agent_browser).parent) in search_dirs
+            ):
+                return extended_agent_browser
+            return None
+        if command == "npx":
+            if npx and (path is None or str(Path(npx).parent) in search_dirs):
+                return npx
+            return None
+        if command == "node":
+            for directory in search_dirs:
+                candidate = Path(directory) / "node"
+                if candidate.is_file():
+                    return str(candidate)
+            return None
+        return None
+
+    monkeypatch.setattr(bt, "_build_browser_env", lambda: {"PATH": ""})
+    monkeypatch.setattr(bt, "_merge_browser_path", merge_path)
+    monkeypatch.setattr(bt.shutil, "which", which)
+
+
+def test_runnable_033_remains_generic_but_is_rejected_for_pin(monkeypatch, tmp_path):
+    old_cli = _fake_agent_browser(tmp_path / "old", "0.33.1", 24)
+    _configure_resolution(monkeypatch, current_agent_browser=old_cli)
+
+    assert bt._find_agent_browser() == old_cli
+    with pytest.raises(bt.AgentBrowserCapabilityError) as exc_info:
+        bt._find_agent_browser(require_pin_tab=True)
+
+    message = str(exc_info.value)
+    assert "agent-browser >=0.34.0" in message
+    assert "Node.js >=24" in message
+    assert "ordinary non-CDP browser commands remain supported" in message
+    assert bt._find_agent_browser() == old_cli
+
+    # Capability failures are not cached: upgrading the same executable makes
+    # the next explicit user command succeed without restarting Hermes.
+    _fake_agent_browser(tmp_path / "old", "0.34.0", 24)
+    assert bt._find_agent_browser(require_pin_tab=True) == old_cli
+
+
+def test_generic_install_guidance_keeps_node22_package_line(monkeypatch):
+    monkeypatch.setattr(bt, "_is_termux_environment", lambda: False)
+
+    assert bt._browser_install_hint() == (
+        "npm install -g 'agent-browser@0.26.0' && "
+        "agent-browser install --with-deps"
+    )
+
+
+def test_pin_lookup_falls_through_033_to_034_and_caches(monkeypatch, tmp_path):
+    old_cli = _fake_agent_browser(tmp_path / "old", "0.33.1", 24)
+    new_cli = _fake_agent_browser(tmp_path / "new", "0.34.0", 24)
+    _configure_resolution(
+        monkeypatch,
+        current_agent_browser=old_cli,
+        extended_agent_browser=new_cli,
+    )
+
+    assert bt._find_agent_browser() == old_cli
+    assert bt._find_agent_browser(require_pin_tab=True) == new_cli
+
+    monkeypatch.setattr(
+        bt,
+        "_probe_agent_browser_version",
+        lambda _path: pytest.fail("pin-capability cache should avoid a second probe"),
+    )
+    assert bt._find_agent_browser(require_pin_tab=True) == new_cli
+    assert bt._find_agent_browser() == old_cli
+
+
+def test_agent_browser_034_on_node22_is_not_pin_capable(monkeypatch, tmp_path):
+    cli = _fake_agent_browser(tmp_path / "node22", "0.34.0", 22)
+    _configure_resolution(monkeypatch, current_agent_browser=cli)
+
+    with pytest.raises(bt.AgentBrowserCapabilityError, match=r"Detected Node\.js 22"):
+        bt._find_agent_browser(require_pin_tab=True)
+
+
+@pytest.mark.parametrize(
+    ("node_major", "pin_available"),
+    [(22, False), (24, True)],
+)
+def test_npx_pin_capability_respects_node_floor(
+    monkeypatch, tmp_path, node_major, pin_available
+):
+    npx = _fake_npx(tmp_path / f"node-{node_major}", node_major)
+    _configure_resolution(monkeypatch, npx=npx)
+
+    if pin_available:
+        assert (
+            bt._find_agent_browser(require_pin_tab=True)
+            == bt.NPX_AGENT_BROWSER_SENTINEL
+        )
+    else:
+        with pytest.raises(
+            bt.AgentBrowserCapabilityError, match=r"Detected Node\.js 22"
+        ):
+            bt._find_agent_browser(require_pin_tab=True)
+        # The capability failure is scoped to shared CDP. The same runnable
+        # npx remains available for the Node-22-compatible ordinary package.
+        assert bt._find_agent_browser() == bt.NPX_AGENT_BROWSER_SENTINEL
+
+
+def test_cdp_command_does_not_spawn_runnable_old_cli(monkeypatch, tmp_path):
+    old_cli = _fake_agent_browser(tmp_path / "old", "0.33.1", 24)
+    _configure_resolution(monkeypatch, current_agent_browser=old_cli)
+    real_popen = bt.subprocess.Popen
+    command_spawns = []
+
+    def guarded_popen(command, *args, **kwargs):
+        if command == [old_cli, "--version"]:
+            return real_popen(command, *args, **kwargs)
+        command_spawns.append(command)
+        raise AssertionError("old CLI must not be invoked for the CDP command")
+
+    monkeypatch.setattr(bt, "_requires_real_termux_browser_install", lambda _cmd: False)
+    monkeypatch.setattr(bt, "_is_local_mode", lambda: False)
+    monkeypatch.setattr(
+        bt,
+        "_get_session_info",
+        lambda _task: {
+            "session_name": "cdp_task",
+            "cdp_url": "ws://shared",
+        },
+    )
+    monkeypatch.setattr("tools.interrupt.is_interrupted", lambda: False)
+    monkeypatch.setattr(bt.subprocess, "Popen", guarded_popen)
+
+    result = bt._run_browser_command("task", "snapshot", ["-c"])
+
+    assert result["success"] is False
+    assert result["code"] == "pin_tab_unavailable"
+    assert result["data"] == {
+        "required_agent_browser": ">=0.34.0",
+        "required_node": ">=24",
+        "non_cdp_available": True,
+    }
+    assert "agent-browser >=0.34.0" in result["error"]
+    assert command_spawns == []

--- a/tests/tools/test_browser_agent_version.py
+++ b/tests/tools/test_browser_agent_version.py
@@ -233,7 +233,9 @@ def test_cdp_command_does_not_spawn_runnable_old_cli(monkeypatch, tmp_path):
         "_get_session_info",
         lambda _task: {
             "session_name": "cdp_task",
+            "bb_session_id": None,
             "cdp_url": "ws://shared",
+            "features": {"cdp_override": True},
         },
     )
     monkeypatch.setattr("tools.interrupt.is_interrupted", lambda: False)

--- a/tests/tools/test_browser_agent_version.py
+++ b/tests/tools/test_browser_agent_version.py
@@ -8,6 +8,9 @@ from pathlib import Path
 import pytest
 
 from tools import browser_tool as bt
+from tools import browser_tool_cloud as browser_cloud
+from tools import browser_tool_install as browser_install
+from tools import browser_tool_session as browser_session
 
 
 pytestmark = pytest.mark.skipif(
@@ -115,46 +118,46 @@ def _configure_resolution(
         return None
 
     monkeypatch.setattr(bt, "_build_browser_env", lambda: {"PATH": ""})
-    monkeypatch.setattr(bt, "_merge_browser_path", merge_path)
-    monkeypatch.setattr(bt.shutil, "which", which)
+    monkeypatch.setattr(browser_install, "_merge_browser_path", merge_path)
+    monkeypatch.setattr(browser_install.shutil, "which", which)
 
 
 def test_runnable_033_remains_generic_but_is_rejected_for_pin(monkeypatch, tmp_path):
     old_cli = _fake_agent_browser(tmp_path / "old", "0.33.1", 24)
     _configure_resolution(monkeypatch, current_agent_browser=old_cli)
     clock = [100.0]
-    monkeypatch.setattr(bt.time, "monotonic", lambda: clock[0])
+    monkeypatch.setattr(browser_install.time, "monotonic", lambda: clock[0])
 
-    assert bt._find_agent_browser() == old_cli
-    with pytest.raises(bt.AgentBrowserCapabilityError) as exc_info:
-        bt._find_agent_browser(require_pin_tab=True)
+    assert browser_install._find_agent_browser() == old_cli
+    with pytest.raises(browser_install.AgentBrowserCapabilityError) as exc_info:
+        browser_install._find_agent_browser(require_pin_tab=True)
 
     message = str(exc_info.value)
     assert "agent-browser >=0.34.0" in message
     assert "Node.js >=24" in message
     assert "ordinary non-CDP browser commands remain supported" in message
-    assert bt._find_agent_browser() == old_cli
+    assert browser_install._find_agent_browser() == old_cli
 
     # The negative cache suppresses repeated subprocess probes, but expires
     # quickly enough that an in-place upgrade works without restarting Hermes.
     _fake_agent_browser(tmp_path / "old", "0.34.0", 24)
-    real_probe = bt._probe_agent_browser_version
+    real_probe = browser_install._probe_agent_browser_version
     monkeypatch.setattr(
-        bt,
+        browser_install,
         "_probe_agent_browser_version",
         lambda _path: pytest.fail("negative cache should suppress a second probe"),
     )
-    with pytest.raises(bt.AgentBrowserCapabilityError, match="agent-browser >=0.34.0"):
-        bt._find_agent_browser(require_pin_tab=True)
+    with pytest.raises(browser_install.AgentBrowserCapabilityError, match="agent-browser >=0.34.0"):
+        browser_install._find_agent_browser(require_pin_tab=True)
     clock[0] += bt.AGENT_BROWSER_PIN_TAB_FAILURE_TTL_SECONDS + 0.01
-    monkeypatch.setattr(bt, "_probe_agent_browser_version", real_probe)
-    assert bt._find_agent_browser(require_pin_tab=True) == old_cli
+    monkeypatch.setattr(browser_install, "_probe_agent_browser_version", real_probe)
+    assert browser_install._find_agent_browser(require_pin_tab=True) == old_cli
 
 
 def test_generic_install_guidance_keeps_node22_package_line(monkeypatch):
-    monkeypatch.setattr(bt, "_is_termux_environment", lambda: False)
+    monkeypatch.setattr(browser_install, "_is_termux_environment", lambda: False)
 
-    assert bt._browser_install_hint() == (
+    assert browser_install._browser_install_hint() == (
         "npm install -g 'agent-browser@0.26.0' && "
         "agent-browser install --with-deps"
     )
@@ -169,24 +172,24 @@ def test_pin_lookup_falls_through_033_to_034_and_caches(monkeypatch, tmp_path):
         extended_agent_browser=new_cli,
     )
 
-    assert bt._find_agent_browser() == old_cli
-    assert bt._find_agent_browser(require_pin_tab=True) == new_cli
+    assert browser_install._find_agent_browser() == old_cli
+    assert browser_install._find_agent_browser(require_pin_tab=True) == new_cli
 
     monkeypatch.setattr(
-        bt,
+        browser_install,
         "_probe_agent_browser_version",
         lambda _path: pytest.fail("pin-capability cache should avoid a second probe"),
     )
-    assert bt._find_agent_browser(require_pin_tab=True) == new_cli
-    assert bt._find_agent_browser() == old_cli
+    assert browser_install._find_agent_browser(require_pin_tab=True) == new_cli
+    assert browser_install._find_agent_browser() == old_cli
 
 
 def test_agent_browser_034_on_node22_is_not_pin_capable(monkeypatch, tmp_path):
     cli = _fake_agent_browser(tmp_path / "node22", "0.34.0", 22)
     _configure_resolution(monkeypatch, current_agent_browser=cli)
 
-    with pytest.raises(bt.AgentBrowserCapabilityError, match=r"Detected Node\.js 22"):
-        bt._find_agent_browser(require_pin_tab=True)
+    with pytest.raises(browser_install.AgentBrowserCapabilityError, match=r"Detected Node\.js 22"):
+        browser_install._find_agent_browser(require_pin_tab=True)
 
 
 @pytest.mark.parametrize(
@@ -201,23 +204,23 @@ def test_npx_pin_capability_respects_node_floor(
 
     if pin_available:
         assert (
-            bt._find_agent_browser(require_pin_tab=True)
+            browser_install._find_agent_browser(require_pin_tab=True)
             == bt.NPX_AGENT_BROWSER_SENTINEL
         )
     else:
         with pytest.raises(
-            bt.AgentBrowserCapabilityError, match=r"Detected Node\.js 22"
+            browser_install.AgentBrowserCapabilityError, match=r"Detected Node\.js 22"
         ):
-            bt._find_agent_browser(require_pin_tab=True)
+            browser_install._find_agent_browser(require_pin_tab=True)
         # The capability failure is scoped to shared CDP. The same runnable
         # npx remains available for the Node-22-compatible ordinary package.
-        assert bt._find_agent_browser() == bt.NPX_AGENT_BROWSER_SENTINEL
+        assert browser_install._find_agent_browser() == bt.NPX_AGENT_BROWSER_SENTINEL
 
 
 def test_cdp_command_does_not_spawn_runnable_old_cli(monkeypatch, tmp_path):
     old_cli = _fake_agent_browser(tmp_path / "old", "0.33.1", 24)
     _configure_resolution(monkeypatch, current_agent_browser=old_cli)
-    real_popen = bt.subprocess.Popen
+    real_popen = browser_install.subprocess.Popen
     command_spawns = []
 
     def guarded_popen(command, *args, **kwargs):
@@ -226,10 +229,10 @@ def test_cdp_command_does_not_spawn_runnable_old_cli(monkeypatch, tmp_path):
         command_spawns.append(command)
         raise AssertionError("old CLI must not be invoked for the CDP command")
 
-    monkeypatch.setattr(bt, "_requires_real_termux_browser_install", lambda _cmd: False)
-    monkeypatch.setattr(bt, "_is_local_mode", lambda: False)
+    monkeypatch.setattr(browser_install, "_requires_real_termux_browser_install", lambda _cmd: False)
+    monkeypatch.setattr(browser_cloud, "_is_local_mode", lambda: False)
     monkeypatch.setattr(
-        bt,
+        browser_session,
         "_get_session_info",
         lambda _task: {
             "session_name": "cdp_task",
@@ -239,9 +242,9 @@ def test_cdp_command_does_not_spawn_runnable_old_cli(monkeypatch, tmp_path):
         },
     )
     monkeypatch.setattr("tools.interrupt.is_interrupted", lambda: False)
-    monkeypatch.setattr(bt.subprocess, "Popen", guarded_popen)
+    monkeypatch.setattr(browser_session.subprocess, "Popen", guarded_popen)
 
-    result = bt._run_browser_command("task", "snapshot", ["-c"])
+    result = browser_session._run_browser_command("task", "snapshot", ["-c"])
 
     assert result["success"] is False
     assert result["code"] == "pin_tab_unavailable"

--- a/tests/tools/test_browser_cdp_pinning.py
+++ b/tests/tools/test_browser_cdp_pinning.py
@@ -188,3 +188,52 @@ def test_high_level_console_does_not_mask_structured_tab_gone(monkeypatch):
     result = json.loads(browser_tool.browser_console(task_id="task-a"))
 
     assert result == TAB_GONE_RESULT
+
+
+def test_fixed_cdp_supervisor_waits_for_pinned_target(monkeypatch):
+    from tools.browser_supervisor import SUPERVISOR_REGISTRY
+
+    start = MagicMock()
+    monkeypatch.setattr(browser_tool, "_get_cdp_override", lambda: "ws://shared")
+    monkeypatch.setattr(SUPERVISOR_REGISTRY, "get_or_start", start)
+
+    browser_tool._ensure_cdp_supervisor("task-a")
+
+    start.assert_not_called()
+
+
+def test_fixed_cdp_supervisor_receives_pinned_target(monkeypatch):
+    from tools.browser_supervisor import SUPERVISOR_REGISTRY
+
+    start = MagicMock()
+    monkeypatch.setattr(browser_tool, "_get_cdp_override", lambda: "ws://shared")
+    monkeypatch.setattr(browser_tool, "_get_dialog_policy_config", lambda: ("must_respond", 300.0))
+    monkeypatch.setattr(SUPERVISOR_REGISTRY, "get_or_start", start)
+
+    browser_tool._ensure_cdp_supervisor("task-a", target_id="TARGET-A")
+
+    start.assert_called_once_with(
+        task_id="task-a",
+        cdp_url="ws://shared",
+        target_id="TARGET-A",
+        dialog_policy="must_respond",
+        dialog_timeout_s=300.0,
+    )
+
+
+def test_pinned_cdp_target_id_uses_agent_browser_active_page(monkeypatch):
+    monkeypatch.setattr(
+        browser_tool,
+        "_run_browser_command",
+        lambda *_args, **_kwargs: {
+            "success": True,
+            "data": {
+                "tabs": [
+                    {"active": False, "type": "page", "targetId": "OTHER"},
+                    {"active": True, "type": "page", "targetId": "TARGET-A"},
+                ]
+            },
+        },
+    )
+
+    assert browser_tool._pinned_cdp_target_id("task-a") == "TARGET-A"

--- a/tests/tools/test_browser_cdp_pinning.py
+++ b/tests/tools/test_browser_cdp_pinning.py
@@ -1,0 +1,190 @@
+"""Command-construction tests for agent-browser CDP tab pinning."""
+
+from __future__ import annotations
+
+import json
+import os
+from typing import Any
+from unittest.mock import MagicMock
+
+from tools import browser_tool
+
+
+TAB_GONE_RESULT = {
+    "success": False,
+    "error": "Pinned tab is no longer available",
+    "code": "tab_gone",
+    "data": {
+        "targetId": "ABC123",
+        "lastUrl": "https://example.com/path",
+    },
+}
+
+
+def _run_commands(
+    monkeypatch,
+    tmp_path,
+    sessions: dict[str, dict[str, Any]],
+    calls: list[tuple[str, str, list[str]]],
+) -> tuple[list[list[str]], list[dict[str, Any]]]:
+    commands: list[list[str]] = []
+    results: list[dict[str, Any]] = []
+
+    proc = MagicMock()
+    proc.returncode = 0
+    proc.wait.return_value = 0
+
+    def capture_popen(command, **kwargs):
+        commands.append(command)
+        os.write(kwargs["stdout"], json.dumps({"success": True}).encode())
+        return proc
+
+    monkeypatch.setattr(browser_tool, "_find_agent_browser", lambda: "/usr/bin/agent-browser")
+    monkeypatch.setattr(browser_tool, "_requires_real_termux_browser_install", lambda _cmd: False)
+    monkeypatch.setattr(browser_tool, "_is_local_mode", lambda: False)
+    monkeypatch.setattr(browser_tool, "_get_session_info", sessions.__getitem__)
+    monkeypatch.setattr(browser_tool, "_get_browser_engine", lambda: "auto")
+    monkeypatch.setattr(browser_tool, "_is_headed_mode", lambda: False)
+    monkeypatch.setattr(browser_tool, "_socket_safe_tmpdir", lambda: str(tmp_path))
+    monkeypatch.setattr(browser_tool, "_write_owner_pid", lambda *_args: None)
+    monkeypatch.setattr(browser_tool, "_build_browser_env", lambda: {"PATH": "/usr/bin"})
+    monkeypatch.setattr(browser_tool, "_merge_browser_path", lambda path: path)
+    monkeypatch.setattr(browser_tool, "_needs_chromium_sandbox_bypass", lambda: False)
+    monkeypatch.setattr(browser_tool.subprocess, "Popen", capture_popen)
+    monkeypatch.setattr("tools.interrupt.is_interrupted", lambda: False)
+
+    for task_id, command, args in calls:
+        results.append(browser_tool._run_browser_command(task_id, command, args))
+
+    return commands, results
+
+
+def test_managed_npx_spec_includes_first_tab_pinning_release():
+    assert browser_tool.AGENT_BROWSER_NPX_SPEC == "agent-browser@^0.34.0"
+
+
+def test_cdp_command_uses_named_session_and_pins_tab(monkeypatch, tmp_path):
+    cdp_url = "ws://127.0.0.1:9222/devtools/browser/shared"
+    sessions = {
+        "task-a": {
+            "session_name": "cdp_task_a",
+            "cdp_url": cdp_url,
+        }
+    }
+
+    commands, results = _run_commands(
+        monkeypatch,
+        tmp_path,
+        sessions,
+        [("task-a", "snapshot", ["-c"])],
+    )
+
+    assert results == [{"success": True}]
+    assert commands == [[
+        "/usr/bin/agent-browser",
+        "--session",
+        "cdp_task_a",
+        "--cdp",
+        cdp_url,
+        "--pin-tab",
+        "--json",
+        "snapshot",
+        "-c",
+    ]]
+
+
+def test_non_cdp_command_keeps_existing_session_shape(monkeypatch, tmp_path):
+    sessions = {
+        "task-local": {
+            "session_name": "local_task",
+            "cdp_url": None,
+        }
+    }
+
+    commands, results = _run_commands(
+        monkeypatch,
+        tmp_path,
+        sessions,
+        [("task-local", "snapshot", ["-c"])],
+    )
+
+    assert results == [{"success": True}]
+    assert commands == [[
+        "/usr/bin/agent-browser",
+        "--session",
+        "local_task",
+        "--json",
+        "snapshot",
+        "-c",
+    ]]
+
+
+def test_two_tasks_pin_distinct_sessions_on_same_cdp_endpoint(monkeypatch, tmp_path):
+    cdp_url = "ws://127.0.0.1:9222/devtools/browser/shared"
+    sessions = {
+        "task-a": {"session_name": "cdp_task_a", "cdp_url": cdp_url},
+        "task-b": {"session_name": "cdp_task_b", "cdp_url": cdp_url},
+    }
+
+    commands, results = _run_commands(
+        monkeypatch,
+        tmp_path,
+        sessions,
+        [
+            ("task-a", "snapshot", []),
+            ("task-b", "snapshot", []),
+        ],
+    )
+
+    assert results == [{"success": True}, {"success": True}]
+    assert commands == [
+        [
+            "/usr/bin/agent-browser",
+            "--session",
+            "cdp_task_a",
+            "--cdp",
+            cdp_url,
+            "--pin-tab",
+            "--json",
+            "snapshot",
+        ],
+        [
+            "/usr/bin/agent-browser",
+            "--session",
+            "cdp_task_b",
+            "--cdp",
+            cdp_url,
+            "--pin-tab",
+            "--json",
+            "snapshot",
+        ],
+    ]
+
+
+def test_high_level_snapshot_preserves_structured_tab_gone(monkeypatch):
+    monkeypatch.setattr(browser_tool, "_is_camofox_mode", lambda: False)
+    monkeypatch.setattr(browser_tool, "_last_session_key", lambda task_id: task_id)
+    monkeypatch.setattr(
+        browser_tool,
+        "_run_browser_command",
+        lambda *_args, **_kwargs: dict(TAB_GONE_RESULT),
+    )
+
+    result = json.loads(browser_tool.browser_snapshot(task_id="task-a"))
+
+    assert result == TAB_GONE_RESULT
+
+
+def test_high_level_console_does_not_mask_structured_tab_gone(monkeypatch):
+    monkeypatch.setattr(browser_tool, "_is_camofox_mode", lambda: False)
+    monkeypatch.setattr(browser_tool, "_last_session_key", lambda task_id: task_id)
+    monkeypatch.setattr(browser_tool, "_eval_ssrf_guard_active", lambda _task_id: False)
+    monkeypatch.setattr(
+        browser_tool,
+        "_run_browser_command",
+        lambda *_args, **_kwargs: dict(TAB_GONE_RESULT),
+    )
+
+    result = json.loads(browser_tool.browser_console(task_id="task-a"))
+
+    assert result == TAB_GONE_RESULT

--- a/tests/tools/test_browser_cdp_pinning.py
+++ b/tests/tools/test_browser_cdp_pinning.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 import os
 from typing import Any
-from unittest.mock import MagicMock
+from unittest.mock import ANY, MagicMock
 
 from tools import browser_tool
 
@@ -318,7 +318,9 @@ def test_fixed_cdp_supervisor_receives_pinned_target(monkeypatch):
         target_id="TARGET-A",
         dialog_policy="must_respond",
         dialog_timeout_s=300.0,
+        publish_guard=ANY,
     )
+    assert callable(start.call_args.kwargs["publish_guard"])
 
 
 def test_pinned_cdp_target_id_uses_agent_browser_active_page(monkeypatch):

--- a/tests/tools/test_browser_cdp_pinning.py
+++ b/tests/tools/test_browser_cdp_pinning.py
@@ -345,6 +345,7 @@ def test_navigate_fails_if_auto_snapshot_reports_tab_gone(monkeypatch):
     session = {
         "session_name": "cdp_task_a",
         "cdp_url": "ws://shared",
+        "target_id": "TARGET-OWNED",
         "_first_nav": False,
     }
     command_results = iter(
@@ -393,10 +394,16 @@ def test_navigate_fails_if_auto_snapshot_reports_tab_gone(monkeypatch):
 
 def test_explicit_navigation_after_cleanup_creates_fresh_owned_session(monkeypatch):
     task_id = "task-retired"
+    monkeypatch.setattr(
+        browser_tool,
+        "_close_shared_cdp_target_confirmed",
+        lambda _cdp_url, _target_id: True,
+    )
     old_session = {
         "session_name": "cdp_old",
         "bb_session_id": None,
         "cdp_url": "ws://shared",
+        "target_id": "TARGET-OWNED",
         "features": {"cdp_override": True},
         "session_key": task_id,
         "owner_task_id": task_id,
@@ -458,12 +465,28 @@ def test_explicit_navigation_after_cleanup_creates_fresh_owned_session(monkeypat
 
 def test_failed_explicit_restart_restores_retired_boundary(monkeypatch):
     task_id = "task-retired-failed-restart"
+    monkeypatch.setattr(
+        browser_tool,
+        "_close_shared_cdp_target_confirmed",
+        lambda _cdp_url, _target_id: True,
+    )
     monkeypatch.setattr(browser_tool, "_active_sessions", {})
     monkeypatch.setattr(browser_tool, "_session_last_activity", {})
     monkeypatch.setattr(browser_tool, "_last_active_session_key", {})
     monkeypatch.setattr(browser_tool, "_retired_browser_tasks", {task_id}, raising=False)
     monkeypatch.setattr(browser_tool, "_start_browser_cleanup_thread", lambda: None)
     monkeypatch.setattr(browser_tool, "_get_cdp_override", lambda: "ws://shared")
+    monkeypatch.setattr(
+        browser_tool,
+        "_create_cdp_session",
+        lambda task, cdp_url: {
+            "session_name": f"cdp_{task}",
+            "bb_session_id": None,
+            "cdp_url": cdp_url,
+            "target_id": "TARGET-RESTART",
+            "features": {"cdp_override": True},
+        },
+    )
     monkeypatch.setattr(browser_tool, "_is_always_blocked_url", lambda _url: False)
     monkeypatch.setattr(browser_tool, "_is_local_backend", lambda: True)
     monkeypatch.setattr(browser_tool, "check_website_access", lambda _url: None)
@@ -492,6 +515,5 @@ def test_failed_explicit_restart_restores_retired_boundary(monkeypatch):
     assert task_id not in browser_tool._last_active_session_key
     assert command_calls == [
         (task_id, "open", ["https://example.com"]),
-        (task_id, "tab", ["close"]),
         (task_id, "close", []),
     ]

--- a/tests/tools/test_browser_cdp_pinning.py
+++ b/tests/tools/test_browser_cdp_pinning.py
@@ -26,6 +26,9 @@ def _run_commands(
     tmp_path,
     sessions: dict[str, dict[str, Any]],
     calls: list[tuple[str, str, list[str]]],
+    *,
+    browser_cmd: str = "/usr/bin/agent-browser",
+    environments: list[dict[str, str]] | None = None,
 ) -> tuple[list[list[str]], list[dict[str, Any]]]:
     commands: list[list[str]] = []
     results: list[dict[str, Any]] = []
@@ -36,10 +39,16 @@ def _run_commands(
 
     def capture_popen(command, **kwargs):
         commands.append(command)
+        if environments is not None:
+            environments.append(dict(kwargs["env"]))
         os.write(kwargs["stdout"], json.dumps({"success": True}).encode())
         return proc
 
-    monkeypatch.setattr(browser_tool, "_find_agent_browser", lambda: "/usr/bin/agent-browser")
+    monkeypatch.setattr(
+        browser_tool,
+        "_find_agent_browser",
+        lambda **_kwargs: browser_cmd,
+    )
     monkeypatch.setattr(browser_tool, "_requires_real_termux_browser_install", lambda _cmd: False)
     monkeypatch.setattr(browser_tool, "_is_local_mode", lambda: False)
     monkeypatch.setattr(browser_tool, "_get_session_info", sessions.__getitem__)
@@ -59,8 +68,9 @@ def _run_commands(
     return commands, results
 
 
-def test_managed_npx_spec_includes_first_tab_pinning_release():
-    assert browser_tool.AGENT_BROWSER_NPX_SPEC == "agent-browser@^0.34.0"
+def test_npx_specs_keep_generic_and_pin_tab_capabilities_separate():
+    assert browser_tool.AGENT_BROWSER_NPX_SPEC == "agent-browser@0.26.0"
+    assert browser_tool.AGENT_BROWSER_PIN_TAB_NPX_SPEC == "agent-browser@0.34.0"
 
 
 def test_cdp_command_uses_named_session_and_pins_tab(monkeypatch, tmp_path):
@@ -117,6 +127,48 @@ def test_non_cdp_command_keeps_existing_session_shape(monkeypatch, tmp_path):
         "snapshot",
         "-c",
     ]]
+
+
+def test_cdp_npx_command_uses_pin_spec_and_npm_policy(monkeypatch, tmp_path):
+    cdp_url = "ws://127.0.0.1:9222/devtools/browser/shared"
+    sessions = {
+        "task-npx": {
+            "session_name": "cdp_task_npx",
+            "cdp_url": cdp_url,
+        }
+    }
+    environments: list[dict[str, str]] = []
+    monkeypatch.setattr(browser_tool, "_resolve_npx_bin", lambda: "/managed/bin/npx")
+
+    commands, results = _run_commands(
+        monkeypatch,
+        tmp_path,
+        sessions,
+        [("task-npx", "snapshot", ["-c"])],
+        browser_cmd=browser_tool.NPX_AGENT_BROWSER_SENTINEL,
+        environments=environments,
+    )
+
+    assert results == [{"success": True}]
+    assert commands == [[
+        "/managed/bin/npx",
+        "--ignore-scripts",
+        "--prefer-offline",
+        "-y",
+        "agent-browser@0.34.0",
+        "--session",
+        "cdp_task_npx",
+        "--cdp",
+        cdp_url,
+        "--pin-tab",
+        "--json",
+        "snapshot",
+        "-c",
+    ]]
+    assert len(environments) == 1
+    assert environments[0]["PATH"] == "/usr/bin"
+    assert environments[0]["npm_config_engine_strict"] == "true"
+    assert environments[0]["npm_config_min_release_age"] == "0"
 
 
 def test_two_tasks_pin_distinct_sessions_on_same_cdp_endpoint(monkeypatch, tmp_path):
@@ -237,3 +289,53 @@ def test_pinned_cdp_target_id_uses_agent_browser_active_page(monkeypatch):
     )
 
     assert browser_tool._pinned_cdp_target_id("task-a") == "TARGET-A"
+
+
+def test_navigate_fails_if_auto_snapshot_reports_tab_gone(monkeypatch):
+    session = {
+        "session_name": "cdp_task_a",
+        "cdp_url": "ws://shared",
+        "_first_nav": False,
+    }
+    command_results = iter(
+        [
+            {
+                "success": True,
+                "data": {
+                    "url": "https://example.com/final",
+                    "title": "Example final",
+                },
+            },
+            dict(TAB_GONE_RESULT),
+        ]
+    )
+    monkeypatch.setattr(
+        browser_tool,
+        "_navigation_session_key",
+        lambda task_id, _url: task_id,
+    )
+    monkeypatch.setattr(browser_tool, "_is_local_backend", lambda: True)
+    monkeypatch.setattr(browser_tool, "_is_always_blocked_url", lambda _url: False)
+    monkeypatch.setattr(browser_tool, "check_website_access", lambda _url: None)
+    monkeypatch.setattr(browser_tool, "_is_camofox_mode", lambda: False)
+    monkeypatch.setattr(browser_tool, "_get_session_info", lambda _task: session)
+    monkeypatch.setattr(browser_tool, "_pinned_cdp_target_id", lambda _task: "TARGET-A")
+    monkeypatch.setattr(browser_tool, "_ensure_cdp_supervisor", lambda *_a, **_kw: None)
+    monkeypatch.setattr(
+        browser_tool,
+        "_run_browser_command",
+        lambda *_args, **_kwargs: next(command_results),
+    )
+
+    result = json.loads(
+        browser_tool.browser_navigate("https://example.com", task_id="task-a")
+    )
+
+    assert result == {
+        "success": False,
+        "error": TAB_GONE_RESULT["error"],
+        "url": "https://example.com/final",
+        "title": "Example final",
+        "code": "tab_gone",
+        "data": TAB_GONE_RESULT["data"],
+    }

--- a/tests/tools/test_browser_cdp_pinning.py
+++ b/tests/tools/test_browser_cdp_pinning.py
@@ -78,7 +78,9 @@ def test_cdp_command_uses_named_session_and_pins_tab(monkeypatch, tmp_path):
     sessions = {
         "task-a": {
             "session_name": "cdp_task_a",
+            "bb_session_id": None,
             "cdp_url": cdp_url,
+            "features": {"cdp_override": True},
         }
     }
 
@@ -182,7 +184,9 @@ def test_cdp_npx_command_uses_pin_spec_and_npm_policy(monkeypatch, tmp_path):
     sessions = {
         "task-npx": {
             "session_name": "cdp_task_npx",
+            "bb_session_id": None,
             "cdp_url": cdp_url,
+            "features": {"cdp_override": True},
         }
     }
     environments: list[dict[str, str]] = []
@@ -222,8 +226,18 @@ def test_cdp_npx_command_uses_pin_spec_and_npm_policy(monkeypatch, tmp_path):
 def test_two_tasks_pin_distinct_sessions_on_same_cdp_endpoint(monkeypatch, tmp_path):
     cdp_url = "ws://127.0.0.1:9222/devtools/browser/shared"
     sessions = {
-        "task-a": {"session_name": "cdp_task_a", "cdp_url": cdp_url},
-        "task-b": {"session_name": "cdp_task_b", "cdp_url": cdp_url},
+        "task-a": {
+            "session_name": "cdp_task_a",
+            "bb_session_id": None,
+            "cdp_url": cdp_url,
+            "features": {"cdp_override": True},
+        },
+        "task-b": {
+            "session_name": "cdp_task_b",
+            "bb_session_id": None,
+            "cdp_url": cdp_url,
+            "features": {"cdp_override": True},
+        },
     }
 
     commands, results = _run_commands(
@@ -344,8 +358,10 @@ def test_pinned_cdp_target_id_uses_agent_browser_active_page(monkeypatch):
 def test_navigate_fails_if_auto_snapshot_reports_tab_gone(monkeypatch):
     session = {
         "session_name": "cdp_task_a",
+        "bb_session_id": None,
         "cdp_url": "ws://shared",
         "target_id": "TARGET-OWNED",
+        "features": {"cdp_override": True},
         "_first_nav": False,
     }
     command_results = iter(

--- a/tests/tools/test_browser_cdp_pinning.py
+++ b/tests/tools/test_browser_cdp_pinning.py
@@ -103,6 +103,54 @@ def test_cdp_command_uses_named_session_and_pins_tab(monkeypatch, tmp_path):
     ]]
 
 
+def test_shared_cdp_command_disables_daemon_idle_timeout(monkeypatch, tmp_path):
+    sessions = {
+        "task-a": {
+            "session_name": "cdp_task_a",
+            "bb_session_id": None,
+            "cdp_url": "ws://127.0.0.1:9222/devtools/browser/shared",
+            "features": {"cdp_override": True},
+        }
+    }
+    environments: list[dict[str, str]] = []
+
+    _commands, results = _run_commands(
+        monkeypatch,
+        tmp_path,
+        sessions,
+        [("task-a", "snapshot", ["-c"])],
+        environments=environments,
+    )
+
+    assert results == [{"success": True}]
+    assert environments[0]["AGENT_BROWSER_IDLE_TIMEOUT_MS"] == "0"
+
+
+def test_local_command_keeps_configured_daemon_idle_timeout(monkeypatch, tmp_path):
+    sessions = {
+        "task-local": {
+            "session_name": "local_task",
+            "bb_session_id": None,
+            "cdp_url": None,
+            "features": {"local": True},
+        }
+    }
+    environments: list[dict[str, str]] = []
+
+    _commands, results = _run_commands(
+        monkeypatch,
+        tmp_path,
+        sessions,
+        [("task-local", "snapshot", ["-c"])],
+        environments=environments,
+    )
+
+    assert results == [{"success": True}]
+    assert environments[0]["AGENT_BROWSER_IDLE_TIMEOUT_MS"] == str(
+        browser_tool.BROWSER_SESSION_INACTIVITY_TIMEOUT * 1000
+    )
+
+
 def test_non_cdp_command_keeps_existing_session_shape(monkeypatch, tmp_path):
     sessions = {
         "task-local": {
@@ -339,3 +387,109 @@ def test_navigate_fails_if_auto_snapshot_reports_tab_gone(monkeypatch):
         "code": "tab_gone",
         "data": TAB_GONE_RESULT["data"],
     }
+
+
+def test_explicit_navigation_after_cleanup_creates_fresh_owned_session(monkeypatch):
+    task_id = "task-retired"
+    old_session = {
+        "session_name": "cdp_old",
+        "bb_session_id": None,
+        "cdp_url": "ws://shared",
+        "features": {"cdp_override": True},
+        "session_key": task_id,
+        "owner_task_id": task_id,
+    }
+    monkeypatch.setattr(browser_tool, "_active_sessions", {task_id: old_session})
+    monkeypatch.setattr(browser_tool, "_session_last_activity", {task_id: 1.0})
+    monkeypatch.setattr(browser_tool, "_last_active_session_key", {task_id: task_id})
+    monkeypatch.setattr(browser_tool, "_retired_browser_tasks", set(), raising=False)
+    monkeypatch.setattr(browser_tool, "_maybe_stop_recording", lambda _task: None)
+    monkeypatch.setattr(browser_tool.os.path, "exists", lambda _path: False)
+    monkeypatch.setattr(
+        browser_tool,
+        "_run_browser_command",
+        lambda *_args, **_kwargs: {"success": True},
+    )
+
+    assert browser_tool.cleanup_browser(task_id) is True
+    assert task_id in browser_tool._retired_browser_tasks
+
+    monkeypatch.setattr(browser_tool, "_start_browser_cleanup_thread", lambda: None)
+    monkeypatch.setattr(browser_tool, "_get_cdp_override", lambda: "ws://shared")
+    monkeypatch.setattr(browser_tool, "_is_always_blocked_url", lambda _url: False)
+    monkeypatch.setattr(browser_tool, "_is_local_backend", lambda: True)
+    monkeypatch.setattr(browser_tool, "check_website_access", lambda _url: None)
+    monkeypatch.setattr(browser_tool, "_is_camofox_mode", lambda: False)
+    monkeypatch.setattr(browser_tool, "_maybe_start_recording", lambda _task: None)
+    monkeypatch.setattr(browser_tool, "_pinned_cdp_target_id", lambda _task: None)
+    monkeypatch.setattr(browser_tool, "_ensure_cdp_supervisor", lambda *_a, **_kw: None)
+    command_calls: list[tuple[str, str, list[str]]] = []
+
+    def run_command(session_key, command, args, **_kwargs):
+        command_calls.append((session_key, command, args))
+        if command == "open":
+            return {
+                "success": True,
+                "data": {"url": "https://example.com", "title": "Example"},
+            }
+        return {"success": True, "data": {"snapshot": "fresh", "refs": {}}}
+
+    monkeypatch.setattr(browser_tool, "_run_browser_command", run_command)
+
+    result = json.loads(
+        browser_tool.browser_navigate("https://example.com", task_id=task_id)
+    )
+
+    assert result["success"] is True
+    assert task_id not in browser_tool._retired_browser_tasks
+    fresh_session = browser_tool._active_sessions[task_id]
+    assert fresh_session is not old_session
+    assert fresh_session["session_name"] != old_session["session_name"]
+    assert fresh_session["owner_task_id"] == task_id
+    assert fresh_session["session_key"] == task_id
+    assert browser_tool._last_active_session_key[task_id] == task_id
+    assert command_calls == [
+        (task_id, "open", ["https://example.com"]),
+        (task_id, "snapshot", ["-c"]),
+    ]
+
+
+def test_failed_explicit_restart_restores_retired_boundary(monkeypatch):
+    task_id = "task-retired-failed-restart"
+    monkeypatch.setattr(browser_tool, "_active_sessions", {})
+    monkeypatch.setattr(browser_tool, "_session_last_activity", {})
+    monkeypatch.setattr(browser_tool, "_last_active_session_key", {})
+    monkeypatch.setattr(browser_tool, "_retired_browser_tasks", {task_id}, raising=False)
+    monkeypatch.setattr(browser_tool, "_start_browser_cleanup_thread", lambda: None)
+    monkeypatch.setattr(browser_tool, "_get_cdp_override", lambda: "ws://shared")
+    monkeypatch.setattr(browser_tool, "_is_always_blocked_url", lambda _url: False)
+    monkeypatch.setattr(browser_tool, "_is_local_backend", lambda: True)
+    monkeypatch.setattr(browser_tool, "check_website_access", lambda _url: None)
+    monkeypatch.setattr(browser_tool, "_is_camofox_mode", lambda: False)
+    monkeypatch.setattr(browser_tool, "_maybe_start_recording", lambda _task: None)
+    monkeypatch.setattr(browser_tool, "_maybe_stop_recording", lambda _task: None)
+    monkeypatch.setattr(browser_tool.os.path, "exists", lambda _path: False)
+    command_calls: list[tuple[str, str, list[str]]] = []
+
+    def run_command(session_key, command, args, **_kwargs):
+        command_calls.append((session_key, command, args))
+        if command == "open":
+            return {"success": False, "error": "navigation failed"}
+        return {"success": True}
+
+    monkeypatch.setattr(browser_tool, "_run_browser_command", run_command)
+
+    result = json.loads(
+        browser_tool.browser_navigate("https://example.com", task_id=task_id)
+    )
+
+    assert result == {"success": False, "error": "navigation failed"}
+    assert task_id in browser_tool._retired_browser_tasks
+    assert task_id not in browser_tool._active_sessions
+    assert task_id not in browser_tool._session_last_activity
+    assert task_id not in browser_tool._last_active_session_key
+    assert command_calls == [
+        (task_id, "open", ["https://example.com"]),
+        (task_id, "tab", ["close"]),
+        (task_id, "close", []),
+    ]

--- a/tests/tools/test_browser_cdp_pinning.py
+++ b/tests/tools/test_browser_cdp_pinning.py
@@ -8,6 +8,12 @@ from typing import Any
 from unittest.mock import ANY, MagicMock
 
 from tools import browser_tool
+from tools import browser_tool_cdp as browser_cdp
+from tools import browser_tool_cloud as browser_cloud
+from tools import browser_tool_eval_policy as browser_eval_policy
+from tools import browser_tool_install as browser_install
+from tools import browser_tool_lifecycle as browser_lifecycle
+from tools import browser_tool_session as browser_session
 
 
 TAB_GONE_RESULT = {
@@ -45,25 +51,25 @@ def _run_commands(
         return proc
 
     monkeypatch.setattr(
-        browser_tool,
+        browser_install,
         "_find_agent_browser",
         lambda **_kwargs: browser_cmd,
     )
-    monkeypatch.setattr(browser_tool, "_requires_real_termux_browser_install", lambda _cmd: False)
-    monkeypatch.setattr(browser_tool, "_is_local_mode", lambda: False)
-    monkeypatch.setattr(browser_tool, "_get_session_info", sessions.__getitem__)
-    monkeypatch.setattr(browser_tool, "_get_browser_engine", lambda: "auto")
-    monkeypatch.setattr(browser_tool, "_is_headed_mode", lambda: False)
+    monkeypatch.setattr(browser_install, "_requires_real_termux_browser_install", lambda _cmd: False)
+    monkeypatch.setattr(browser_cloud, "_is_local_mode", lambda: False)
+    monkeypatch.setattr(browser_session, "_get_session_info", sessions.__getitem__)
+    monkeypatch.setattr(browser_cloud, "_get_browser_engine", lambda: "auto")
+    monkeypatch.setattr(browser_cloud, "_is_headed_mode", lambda: False)
     monkeypatch.setattr(browser_tool, "_socket_safe_tmpdir", lambda: str(tmp_path))
-    monkeypatch.setattr(browser_tool, "_write_owner_pid", lambda *_args: None)
+    monkeypatch.setattr(browser_lifecycle, "_write_owner_pid", lambda *_args: None)
     monkeypatch.setattr(browser_tool, "_build_browser_env", lambda: {"PATH": "/usr/bin"})
-    monkeypatch.setattr(browser_tool, "_merge_browser_path", lambda path: path)
-    monkeypatch.setattr(browser_tool, "_needs_chromium_sandbox_bypass", lambda: False)
-    monkeypatch.setattr(browser_tool.subprocess, "Popen", capture_popen)
+    monkeypatch.setattr(browser_install, "_merge_browser_path", lambda path: path)
+    monkeypatch.setattr(browser_session, "_needs_chromium_sandbox_bypass", lambda: False)
+    monkeypatch.setattr(browser_session.subprocess, "Popen", capture_popen)
     monkeypatch.setattr("tools.interrupt.is_interrupted", lambda: False)
 
     for task_id, command, args in calls:
-        results.append(browser_tool._run_browser_command(task_id, command, args))
+        results.append(browser_session._run_browser_command(task_id, command, args))
 
     return commands, results
 
@@ -190,7 +196,7 @@ def test_cdp_npx_command_uses_pin_spec_and_npm_policy(monkeypatch, tmp_path):
         }
     }
     environments: list[dict[str, str]] = []
-    monkeypatch.setattr(browser_tool, "_resolve_npx_bin", lambda: "/managed/bin/npx")
+    monkeypatch.setattr(browser_install, "_resolve_npx_bin", lambda: "/managed/bin/npx")
 
     commands, results = _run_commands(
         monkeypatch,
@@ -279,7 +285,7 @@ def test_high_level_snapshot_preserves_structured_tab_gone(monkeypatch):
     monkeypatch.setattr(browser_tool, "_is_camofox_mode", lambda: False)
     monkeypatch.setattr(browser_tool, "_last_session_key", lambda task_id: task_id)
     monkeypatch.setattr(
-        browser_tool,
+        browser_session,
         "_run_browser_command",
         lambda *_args, **_kwargs: dict(TAB_GONE_RESULT),
     )
@@ -292,9 +298,9 @@ def test_high_level_snapshot_preserves_structured_tab_gone(monkeypatch):
 def test_high_level_console_does_not_mask_structured_tab_gone(monkeypatch):
     monkeypatch.setattr(browser_tool, "_is_camofox_mode", lambda: False)
     monkeypatch.setattr(browser_tool, "_last_session_key", lambda task_id: task_id)
-    monkeypatch.setattr(browser_tool, "_eval_ssrf_guard_active", lambda _task_id: False)
+    monkeypatch.setattr(browser_eval_policy, "_eval_ssrf_guard_active", lambda _task_id: False)
     monkeypatch.setattr(
-        browser_tool,
+        browser_session,
         "_run_browser_command",
         lambda *_args, **_kwargs: dict(TAB_GONE_RESULT),
     )
@@ -308,10 +314,10 @@ def test_fixed_cdp_supervisor_waits_for_pinned_target(monkeypatch):
     from tools.browser_supervisor import SUPERVISOR_REGISTRY
 
     start = MagicMock()
-    monkeypatch.setattr(browser_tool, "_get_cdp_override", lambda: "ws://shared")
+    monkeypatch.setattr(browser_cdp, "_get_cdp_override", lambda: "ws://shared")
     monkeypatch.setattr(SUPERVISOR_REGISTRY, "get_or_start", start)
 
-    browser_tool._ensure_cdp_supervisor("task-a")
+    browser_cdp._ensure_cdp_supervisor("task-a")
 
     start.assert_not_called()
 
@@ -320,11 +326,11 @@ def test_fixed_cdp_supervisor_receives_pinned_target(monkeypatch):
     from tools.browser_supervisor import SUPERVISOR_REGISTRY
 
     start = MagicMock()
-    monkeypatch.setattr(browser_tool, "_get_cdp_override", lambda: "ws://shared")
-    monkeypatch.setattr(browser_tool, "_get_dialog_policy_config", lambda: ("must_respond", 300.0))
+    monkeypatch.setattr(browser_cdp, "_get_cdp_override", lambda: "ws://shared")
+    monkeypatch.setattr(browser_cdp, "_get_dialog_policy_config", lambda: ("must_respond", 300.0))
     monkeypatch.setattr(SUPERVISOR_REGISTRY, "get_or_start", start)
 
-    browser_tool._ensure_cdp_supervisor("task-a", target_id="TARGET-A")
+    browser_cdp._ensure_cdp_supervisor("task-a", target_id="TARGET-A")
 
     start.assert_called_once_with(
         task_id="task-a",
@@ -339,7 +345,7 @@ def test_fixed_cdp_supervisor_receives_pinned_target(monkeypatch):
 
 def test_pinned_cdp_target_id_uses_agent_browser_active_page(monkeypatch):
     monkeypatch.setattr(
-        browser_tool,
+        browser_session,
         "_run_browser_command",
         lambda *_args, **_kwargs: {
             "success": True,
@@ -352,7 +358,7 @@ def test_pinned_cdp_target_id_uses_agent_browser_active_page(monkeypatch):
         },
     )
 
-    assert browser_tool._pinned_cdp_target_id("task-a") == "TARGET-A"
+    assert browser_cdp._pinned_cdp_target_id("task-a") == "TARGET-A"
 
 
 def test_navigate_fails_if_auto_snapshot_reports_tab_gone(monkeypatch):
@@ -381,15 +387,15 @@ def test_navigate_fails_if_auto_snapshot_reports_tab_gone(monkeypatch):
         "_navigation_session_key",
         lambda task_id, _url: task_id,
     )
-    monkeypatch.setattr(browser_tool, "_is_local_backend", lambda: True)
+    monkeypatch.setattr(browser_cloud, "_is_local_backend", lambda: True)
     monkeypatch.setattr(browser_tool, "_is_always_blocked_url", lambda _url: False)
     monkeypatch.setattr(browser_tool, "check_website_access", lambda _url: None)
     monkeypatch.setattr(browser_tool, "_is_camofox_mode", lambda: False)
-    monkeypatch.setattr(browser_tool, "_get_session_info", lambda _task: session)
-    monkeypatch.setattr(browser_tool, "_pinned_cdp_target_id", lambda _task: "TARGET-A")
-    monkeypatch.setattr(browser_tool, "_ensure_cdp_supervisor", lambda *_a, **_kw: None)
+    monkeypatch.setattr(browser_session, "_get_session_info", lambda _task: session)
+    monkeypatch.setattr(browser_cdp, "_pinned_cdp_target_id", lambda _task: "TARGET-A")
+    monkeypatch.setattr(browser_cdp, "_ensure_cdp_supervisor", lambda *_a, **_kw: None)
     monkeypatch.setattr(
-        browser_tool,
+        browser_session,
         "_run_browser_command",
         lambda *_args, **_kwargs: next(command_results),
     )
@@ -411,7 +417,7 @@ def test_navigate_fails_if_auto_snapshot_reports_tab_gone(monkeypatch):
 def test_explicit_navigation_after_cleanup_creates_fresh_owned_session(monkeypatch):
     task_id = "task-retired"
     monkeypatch.setattr(
-        browser_tool,
+        browser_cdp,
         "_close_shared_cdp_target_confirmed",
         lambda _cdp_url, _target_id: True,
     )
@@ -429,25 +435,25 @@ def test_explicit_navigation_after_cleanup_creates_fresh_owned_session(monkeypat
     monkeypatch.setattr(browser_tool, "_last_active_session_key", {task_id: task_id})
     monkeypatch.setattr(browser_tool, "_retired_browser_tasks", set(), raising=False)
     monkeypatch.setattr(browser_tool, "_maybe_stop_recording", lambda _task: None)
-    monkeypatch.setattr(browser_tool.os.path, "exists", lambda _path: False)
+    monkeypatch.setattr(browser_lifecycle.os.path, "exists", lambda _path: False)
     monkeypatch.setattr(
-        browser_tool,
+        browser_session,
         "_run_browser_command",
         lambda *_args, **_kwargs: {"success": True},
     )
 
-    assert browser_tool.cleanup_browser(task_id) is True
+    assert browser_lifecycle.cleanup_browser(task_id) is True
     assert task_id in browser_tool._retired_browser_tasks
 
-    monkeypatch.setattr(browser_tool, "_start_browser_cleanup_thread", lambda: None)
-    monkeypatch.setattr(browser_tool, "_get_cdp_override", lambda: "ws://shared")
+    monkeypatch.setattr(browser_lifecycle, "_start_browser_cleanup_thread", lambda: None)
+    monkeypatch.setattr(browser_cdp, "_get_cdp_override", lambda: "ws://shared")
     monkeypatch.setattr(browser_tool, "_is_always_blocked_url", lambda _url: False)
-    monkeypatch.setattr(browser_tool, "_is_local_backend", lambda: True)
+    monkeypatch.setattr(browser_cloud, "_is_local_backend", lambda: True)
     monkeypatch.setattr(browser_tool, "check_website_access", lambda _url: None)
     monkeypatch.setattr(browser_tool, "_is_camofox_mode", lambda: False)
     monkeypatch.setattr(browser_tool, "_maybe_start_recording", lambda _task: None)
-    monkeypatch.setattr(browser_tool, "_pinned_cdp_target_id", lambda _task: None)
-    monkeypatch.setattr(browser_tool, "_ensure_cdp_supervisor", lambda *_a, **_kw: None)
+    monkeypatch.setattr(browser_cdp, "_pinned_cdp_target_id", lambda _task: None)
+    monkeypatch.setattr(browser_cdp, "_ensure_cdp_supervisor", lambda *_a, **_kw: None)
     command_calls: list[tuple[str, str, list[str]]] = []
 
     def run_command(session_key, command, args, **_kwargs):
@@ -459,7 +465,7 @@ def test_explicit_navigation_after_cleanup_creates_fresh_owned_session(monkeypat
             }
         return {"success": True, "data": {"snapshot": "fresh", "refs": {}}}
 
-    monkeypatch.setattr(browser_tool, "_run_browser_command", run_command)
+    monkeypatch.setattr(browser_session, "_run_browser_command", run_command)
 
     result = json.loads(
         browser_tool.browser_navigate("https://example.com", task_id=task_id)
@@ -482,7 +488,7 @@ def test_explicit_navigation_after_cleanup_creates_fresh_owned_session(monkeypat
 def test_failed_explicit_restart_restores_retired_boundary(monkeypatch):
     task_id = "task-retired-failed-restart"
     monkeypatch.setattr(
-        browser_tool,
+        browser_cdp,
         "_close_shared_cdp_target_confirmed",
         lambda _cdp_url, _target_id: True,
     )
@@ -490,10 +496,10 @@ def test_failed_explicit_restart_restores_retired_boundary(monkeypatch):
     monkeypatch.setattr(browser_tool, "_session_last_activity", {})
     monkeypatch.setattr(browser_tool, "_last_active_session_key", {})
     monkeypatch.setattr(browser_tool, "_retired_browser_tasks", {task_id}, raising=False)
-    monkeypatch.setattr(browser_tool, "_start_browser_cleanup_thread", lambda: None)
-    monkeypatch.setattr(browser_tool, "_get_cdp_override", lambda: "ws://shared")
+    monkeypatch.setattr(browser_lifecycle, "_start_browser_cleanup_thread", lambda: None)
+    monkeypatch.setattr(browser_cdp, "_get_cdp_override", lambda: "ws://shared")
     monkeypatch.setattr(
-        browser_tool,
+        browser_session,
         "_create_cdp_session",
         lambda task, cdp_url: {
             "session_name": f"cdp_{task}",
@@ -504,12 +510,12 @@ def test_failed_explicit_restart_restores_retired_boundary(monkeypatch):
         },
     )
     monkeypatch.setattr(browser_tool, "_is_always_blocked_url", lambda _url: False)
-    monkeypatch.setattr(browser_tool, "_is_local_backend", lambda: True)
+    monkeypatch.setattr(browser_cloud, "_is_local_backend", lambda: True)
     monkeypatch.setattr(browser_tool, "check_website_access", lambda _url: None)
     monkeypatch.setattr(browser_tool, "_is_camofox_mode", lambda: False)
     monkeypatch.setattr(browser_tool, "_maybe_start_recording", lambda _task: None)
     monkeypatch.setattr(browser_tool, "_maybe_stop_recording", lambda _task: None)
-    monkeypatch.setattr(browser_tool.os.path, "exists", lambda _path: False)
+    monkeypatch.setattr(browser_lifecycle.os.path, "exists", lambda _path: False)
     command_calls: list[tuple[str, str, list[str]]] = []
 
     def run_command(session_key, command, args, **_kwargs):
@@ -518,7 +524,7 @@ def test_failed_explicit_restart_restores_retired_boundary(monkeypatch):
             return {"success": False, "error": "navigation failed"}
         return {"success": True}
 
-    monkeypatch.setattr(browser_tool, "_run_browser_command", run_command)
+    monkeypatch.setattr(browser_session, "_run_browser_command", run_command)
 
     result = json.loads(
         browser_tool.browser_navigate("https://example.com", task_id=task_id)

--- a/tests/tools/test_browser_cleanup.py
+++ b/tests/tools/test_browser_cleanup.py
@@ -114,6 +114,7 @@ class TestBrowserCleanup:
             "bb_session_id": None,
             "cdp_url": "ws://127.0.0.1:9222/devtools/browser/shared",
             "target_id": "TARGET-OWNED",
+            "features": {"cdp_override": True},
         }
 
         with (
@@ -139,6 +140,7 @@ class TestBrowserCleanup:
             "bb_session_id": None,
             "cdp_url": "ws://shared",
             "target_id": "TARGET-OWNED",
+            "features": {"cdp_override": True},
         }
         browser_tool._session_last_activity["task-gone"] = 123.0
 
@@ -166,6 +168,7 @@ class TestBrowserCleanup:
             "bb_session_id": None,
             "cdp_url": "ws://shared",
             "target_id": "TARGET-OWNED",
+            "features": {"cdp_override": True},
         }
         browser_tool._active_sessions["task-retry"] = session
         browser_tool._session_last_activity["task-retry"] = 123.0
@@ -189,6 +192,7 @@ class TestBrowserCleanup:
             "bb_session_id": None,
             "cdp_url": "ws://shared",
             "target_id": "TARGET-OWNED",
+            "features": {"cdp_override": True},
         }
         browser_tool._session_last_activity["task-repeat"] = 123.0
 
@@ -309,7 +313,7 @@ class TestInactivityJanitorMultiplex:
 
         seen = {}
 
-        def fake_close(task_id, cmd, args, timeout=None):
+        def fake_close(task_id, cmd, args, timeout=None, **_kwargs):
             seen["home"] = str(get_hermes_home())
             seen["url"] = secret_scope.get_secret("CAMOFOX_URL")
             return {"success": True}
@@ -477,6 +481,7 @@ def test_successful_cleanup_tombstones_non_navigation_without_recreation(
             "bb_session_id": None,
             "cdp_url": "ws://shared",
             "target_id": "TARGET-OWNED",
+            "features": {"cdp_override": True},
         }
     )
     find_browser = MagicMock(return_value="/usr/bin/agent-browser")

--- a/tests/tools/test_browser_cleanup.py
+++ b/tests/tools/test_browser_cleanup.py
@@ -66,6 +66,29 @@ class TestBrowserCleanup:
         mock_stop.assert_called_once_with("task-1")
         mock_run.assert_called_once_with("task-1", "close", [], timeout=10)
 
+    def test_cleanup_shared_cdp_closes_only_pinned_tab_before_session(self):
+        browser_tool = self.browser_tool
+        browser_tool._active_sessions["task-cdp"] = {
+            "session_name": "sess-cdp",
+            "bb_session_id": None,
+            "cdp_url": "ws://127.0.0.1:9222/devtools/browser/shared",
+        }
+
+        with (
+            patch("tools.browser_tool._maybe_stop_recording"),
+            patch(
+                "tools.browser_tool._run_browser_command",
+                return_value={"success": True},
+            ) as mock_run,
+            patch("tools.browser_tool.os.path.exists", return_value=False),
+        ):
+            browser_tool.cleanup_browser("task-cdp")
+
+        assert mock_run.call_args_list == [
+            (("task-cdp", "tab", ["close"]), {"timeout": 10}),
+            (("task-cdp", "close", []), {"timeout": 10}),
+        ]
+
 
     def test_emergency_cleanup_clears_all_tracking_state(self):
         browser_tool = self.browser_tool

--- a/tests/tools/test_browser_cleanup.py
+++ b/tests/tools/test_browser_cleanup.py
@@ -31,6 +31,7 @@ class TestBrowserCleanup:
         self.browser_tool = browser_tool
         self.orig_active_sessions = browser_tool._active_sessions.copy()
         self.orig_session_last_activity = browser_tool._session_last_activity.copy()
+        self.orig_last_active_session_key = browser_tool._last_active_session_key.copy()
         self.orig_recording_sessions = browser_tool._recording_sessions.copy()
         self.orig_cleanup_done = browser_tool._cleanup_done
 
@@ -39,6 +40,10 @@ class TestBrowserCleanup:
         self.browser_tool._active_sessions.update(self.orig_active_sessions)
         self.browser_tool._session_last_activity.clear()
         self.browser_tool._session_last_activity.update(self.orig_session_last_activity)
+        self.browser_tool._last_active_session_key.clear()
+        self.browser_tool._last_active_session_key.update(
+            self.orig_last_active_session_key
+        )
         self.browser_tool._recording_sessions.clear()
         self.browser_tool._recording_sessions.update(self.orig_recording_sessions)
         self.browser_tool._cleanup_done = self.orig_cleanup_done
@@ -59,14 +64,15 @@ class TestBrowserCleanup:
             ) as mock_run,
             patch("tools.browser_tool.os.path.exists", return_value=False),
         ):
-            bt_lifecycle.cleanup_browser("task-1")
+            cleaned = bt_lifecycle.cleanup_browser("task-1")
 
+        assert cleaned is True
         assert "task-1" not in browser_tool._active_sessions
         assert "task-1" not in browser_tool._session_last_activity
         mock_stop.assert_called_once_with("task-1")
         mock_run.assert_called_once_with("task-1", "close", [], timeout=10)
 
-    def test_cleanup_shared_cdp_closes_only_pinned_tab_before_session(self):
+    def test_cleanup_shared_cdp_closes_pinned_tab_before_session(self):
         browser_tool = self.browser_tool
         browser_tool._active_sessions["task-cdp"] = {
             "session_name": "sess-cdp",
@@ -82,12 +88,130 @@ class TestBrowserCleanup:
             ) as mock_run,
             patch("tools.browser_tool.os.path.exists", return_value=False),
         ):
-            browser_tool.cleanup_browser("task-cdp")
+            cleaned = browser_tool.cleanup_browser("task-cdp")
 
+        assert cleaned is True
+        assert "task-cdp" not in browser_tool._active_sessions
         assert mock_run.call_args_list == [
             (("task-cdp", "tab", ["close"]), {"timeout": 10}),
             (("task-cdp", "close", []), {"timeout": 10}),
         ]
+
+    def test_cleanup_shared_cdp_accepts_already_gone_tab(self):
+        browser_tool = self.browser_tool
+        browser_tool._active_sessions["task-gone"] = {
+            "session_name": "sess-gone",
+            "bb_session_id": None,
+            "cdp_url": "ws://shared",
+        }
+        browser_tool._session_last_activity["task-gone"] = 123.0
+
+        with (
+            patch("tools.browser_tool._maybe_stop_recording"),
+            patch(
+                "tools.browser_tool._run_browser_command",
+                side_effect=[
+                    {
+                        "success": False,
+                        "code": "tab_gone",
+                        "error": "Pinned tab is no longer available",
+                    },
+                    {"success": True},
+                ],
+            ) as mock_run,
+            patch("tools.browser_tool.os.path.exists", return_value=False),
+        ):
+            cleaned = browser_tool.cleanup_browser("task-gone")
+
+        assert cleaned is True
+        assert "task-gone" not in browser_tool._active_sessions
+        assert "task-gone" not in browser_tool._session_last_activity
+        assert mock_run.call_args_list == [
+            (("task-gone", "tab", ["close"]), {"timeout": 10}),
+            (("task-gone", "close", []), {"timeout": 10}),
+        ]
+
+    def test_cleanup_shared_cdp_transient_failure_retains_ownership(self):
+        browser_tool = self.browser_tool
+        session = {
+            "session_name": "sess-retry",
+            "bb_session_id": None,
+            "cdp_url": "ws://shared",
+        }
+        browser_tool._active_sessions["task-retry"] = session
+        browser_tool._session_last_activity["task-retry"] = 123.0
+        browser_tool._last_active_session_key["task-retry"] = "task-retry"
+
+        with (
+            patch("tools.browser_tool._maybe_stop_recording"),
+            patch(
+                "tools.browser_tool._run_browser_command",
+                return_value={"success": False, "error": "temporary disconnect"},
+            ) as mock_run,
+        ):
+            cleaned = browser_tool.cleanup_browser("task-retry")
+
+        assert cleaned is False
+        assert browser_tool._active_sessions["task-retry"] is session
+        assert browser_tool._session_last_activity["task-retry"] == 123.0
+        assert browser_tool._last_active_session_key["task-retry"] == "task-retry"
+        mock_run.assert_called_once_with(
+            "task-retry", "tab", ["close"], timeout=10
+        )
+
+    def test_cleanup_shared_cdp_retries_then_becomes_idempotent(self):
+        browser_tool = self.browser_tool
+        browser_tool._active_sessions["task-repeat"] = {
+            "session_name": "sess-repeat",
+            "bb_session_id": None,
+            "cdp_url": "ws://shared",
+        }
+        browser_tool._session_last_activity["task-repeat"] = 123.0
+
+        with (
+            patch("tools.browser_tool._maybe_stop_recording"),
+            patch(
+                "tools.browser_tool._run_browser_command",
+                side_effect=[
+                    {"success": False, "error": "temporary disconnect"},
+                    {"success": True},
+                    {"success": True},
+                ],
+            ) as mock_run,
+            patch("tools.browser_tool.os.path.exists", return_value=False),
+        ):
+            assert browser_tool.cleanup_browser("task-repeat") is False
+            assert "task-repeat" in browser_tool._active_sessions
+            assert browser_tool.cleanup_browser("task-repeat") is True
+            assert browser_tool.cleanup_browser("task-repeat") is True
+
+        assert "task-repeat" not in browser_tool._active_sessions
+        assert mock_run.call_args_list == [
+            (("task-repeat", "tab", ["close"]), {"timeout": 10}),
+            (("task-repeat", "tab", ["close"]), {"timeout": 10}),
+            (("task-repeat", "close", []), {"timeout": 10}),
+        ]
+
+    def test_successful_sidecar_cleanup_preserves_primary_binding(self):
+        browser_tool = self.browser_tool
+        sidecar = "task-sidecar::local"
+        browser_tool._active_sessions[sidecar] = {
+            "session_name": "sess-sidecar",
+            "bb_session_id": None,
+        }
+        browser_tool._last_active_session_key["task-sidecar"] = "task-sidecar"
+
+        with (
+            patch("tools.browser_tool._maybe_stop_recording"),
+            patch(
+                "tools.browser_tool._run_browser_command",
+                return_value={"success": True},
+            ),
+            patch("tools.browser_tool.os.path.exists", return_value=False),
+        ):
+            assert browser_tool.cleanup_browser(sidecar) is True
+
+        assert browser_tool._last_active_session_key["task-sidecar"] == "task-sidecar"
 
 
     def test_emergency_cleanup_clears_all_tracking_state(self):

--- a/tests/tools/test_browser_cleanup.py
+++ b/tests/tools/test_browser_cleanup.py
@@ -44,6 +44,11 @@ class TestBrowserCleanup:
         self.orig_provider_cleanups = browser_tool._pending_provider_cleanups.copy()
         self.orig_recording_sessions = browser_tool._recording_sessions.copy()
         self.orig_cleanup_done = browser_tool._cleanup_done
+        self.close_target_patch = patch(
+            "tools.browser_tool._close_shared_cdp_target_confirmed",
+            return_value=True,
+        )
+        self.close_target_mock = self.close_target_patch.start()
 
     def teardown_method(self):
         self.browser_tool._active_sessions.clear()
@@ -74,6 +79,7 @@ class TestBrowserCleanup:
         self.browser_tool._recording_sessions.clear()
         self.browser_tool._recording_sessions.update(self.orig_recording_sessions)
         self.browser_tool._cleanup_done = self.orig_cleanup_done
+        self.close_target_patch.stop()
 
     def test_cleanup_browser_clears_tracking_state(self):
         browser_tool = self.browser_tool
@@ -107,6 +113,7 @@ class TestBrowserCleanup:
             "session_name": "sess-cdp",
             "bb_session_id": None,
             "cdp_url": "ws://127.0.0.1:9222/devtools/browser/shared",
+            "target_id": "TARGET-OWNED",
         }
 
         with (
@@ -122,7 +129,6 @@ class TestBrowserCleanup:
         assert cleaned is True
         assert "task-cdp" not in browser_tool._active_sessions
         assert mock_run.call_args_list == [
-            (("task-cdp", "tab", ["close"]), {"timeout": 10, "_allow_cleanup": True}),
             (("task-cdp", "close", []), {"timeout": 10, "_allow_cleanup": True}),
         ]
 
@@ -132,6 +138,7 @@ class TestBrowserCleanup:
             "session_name": "sess-gone",
             "bb_session_id": None,
             "cdp_url": "ws://shared",
+            "target_id": "TARGET-OWNED",
         }
         browser_tool._session_last_activity["task-gone"] = 123.0
 
@@ -139,14 +146,7 @@ class TestBrowserCleanup:
             patch("tools.browser_tool._maybe_stop_recording"),
             patch(
                 "tools.browser_tool._run_browser_command",
-                side_effect=[
-                    {
-                        "success": False,
-                        "code": "tab_gone",
-                        "error": "Pinned tab is no longer available",
-                    },
-                    {"success": True},
-                ],
+                return_value={"success": True},
             ) as mock_run,
             patch("tools.browser_tool.os.path.exists", return_value=False),
         ):
@@ -156,7 +156,6 @@ class TestBrowserCleanup:
         assert "task-gone" not in browser_tool._active_sessions
         assert "task-gone" not in browser_tool._session_last_activity
         assert mock_run.call_args_list == [
-            (("task-gone", "tab", ["close"]), {"timeout": 10, "_allow_cleanup": True}),
             (("task-gone", "close", []), {"timeout": 10, "_allow_cleanup": True}),
         ]
 
@@ -166,19 +165,14 @@ class TestBrowserCleanup:
             "session_name": "sess-retry",
             "bb_session_id": None,
             "cdp_url": "ws://shared",
+            "target_id": "TARGET-OWNED",
         }
         browser_tool._active_sessions["task-retry"] = session
         browser_tool._session_last_activity["task-retry"] = 123.0
         browser_tool._last_active_session_key["task-retry"] = "task-retry"
 
-        with (
-            patch("tools.browser_tool._maybe_stop_recording"),
-            patch(
-                "tools.browser_tool._run_browser_command",
-                return_value={"success": False, "error": "temporary disconnect"},
-            ) as mock_run,
-        ):
-            cleaned = browser_tool.cleanup_browser("task-retry")
+        self.close_target_mock.return_value = False
+        cleaned = browser_tool.cleanup_browser("task-retry")
 
         assert cleaned is False
         assert browser_tool._active_sessions["task-retry"] is session
@@ -186,9 +180,7 @@ class TestBrowserCleanup:
         assert browser_tool._last_active_session_key["task-retry"] == "task-retry"
         assert "task-retry" not in browser_tool._retired_browser_tasks
         assert session["_cleanup_retry_pending"] is True
-        mock_run.assert_called_once_with(
-            "task-retry", "tab", ["close"], timeout=10, _allow_cleanup=True
-        )
+        self.close_target_mock.return_value = True
 
     def test_cleanup_shared_cdp_retries_then_becomes_idempotent(self):
         browser_tool = self.browser_tool
@@ -196,18 +188,16 @@ class TestBrowserCleanup:
             "session_name": "sess-repeat",
             "bb_session_id": None,
             "cdp_url": "ws://shared",
+            "target_id": "TARGET-OWNED",
         }
         browser_tool._session_last_activity["task-repeat"] = 123.0
 
+        self.close_target_mock.side_effect = [False, True]
         with (
             patch("tools.browser_tool._maybe_stop_recording"),
             patch(
                 "tools.browser_tool._run_browser_command",
-                side_effect=[
-                    {"success": False, "error": "temporary disconnect"},
-                    {"success": True},
-                    {"success": True},
-                ],
+                return_value={"success": True},
             ) as mock_run,
             patch("tools.browser_tool.os.path.exists", return_value=False),
         ):
@@ -218,8 +208,6 @@ class TestBrowserCleanup:
 
         assert "task-repeat" not in browser_tool._active_sessions
         assert mock_run.call_args_list == [
-            (("task-repeat", "tab", ["close"]), {"timeout": 10, "_allow_cleanup": True}),
-            (("task-repeat", "tab", ["close"]), {"timeout": 10, "_allow_cleanup": True}),
             (("task-repeat", "close", []), {"timeout": 10, "_allow_cleanup": True}),
         ]
 
@@ -379,6 +367,7 @@ def test_inactivity_reaper_spares_task_owned_shared_cdp(monkeypatch):
                 "session_name": "cdp_owned",
                 "bb_session_id": None,
                 "cdp_url": "ws://127.0.0.1:9222/devtools/browser/shared",
+                "target_id": "TARGET-OWNED",
                 "features": {"cdp_override": True},
             }
         },
@@ -454,12 +443,18 @@ def test_successful_cleanup_tombstones_non_navigation_without_recreation(
     task_id = "task-terminal"
     monkeypatch.setattr(
         browser_tool,
+        "_close_shared_cdp_target_confirmed",
+        lambda _cdp_url, _target_id: True,
+    )
+    monkeypatch.setattr(
+        browser_tool,
         "_active_sessions",
         {
             task_id: {
                 "session_name": "cdp_terminal",
                 "bb_session_id": None,
                 "cdp_url": "ws://shared",
+                "target_id": "TARGET-OWNED",
                 "features": {"cdp_override": True},
             }
         },
@@ -481,6 +476,7 @@ def test_successful_cleanup_tombstones_non_navigation_without_recreation(
             "session_name": "replacement",
             "bb_session_id": None,
             "cdp_url": "ws://shared",
+            "target_id": "TARGET-OWNED",
         }
     )
     find_browser = MagicMock(return_value="/usr/bin/agent-browser")

--- a/tests/tools/test_browser_cleanup.py
+++ b/tests/tools/test_browser_cleanup.py
@@ -1,6 +1,9 @@
 """Regression tests for browser session cleanup and screenshot recovery."""
 
-from unittest.mock import patch
+import json
+import time
+
+from unittest.mock import MagicMock, patch
 from tools import browser_tool_lifecycle as bt_lifecycle
 
 
@@ -32,6 +35,9 @@ class TestBrowserCleanup:
         self.orig_active_sessions = browser_tool._active_sessions.copy()
         self.orig_session_last_activity = browser_tool._session_last_activity.copy()
         self.orig_last_active_session_key = browser_tool._last_active_session_key.copy()
+        self.orig_retired_browser_tasks = getattr(
+            browser_tool, "_retired_browser_tasks", set()
+        ).copy()
         self.orig_recording_sessions = browser_tool._recording_sessions.copy()
         self.orig_cleanup_done = browser_tool._cleanup_done
 
@@ -44,6 +50,11 @@ class TestBrowserCleanup:
         self.browser_tool._last_active_session_key.update(
             self.orig_last_active_session_key
         )
+        if hasattr(self.browser_tool, "_retired_browser_tasks"):
+            self.browser_tool._retired_browser_tasks.clear()
+            self.browser_tool._retired_browser_tasks.update(
+                self.orig_retired_browser_tasks
+            )
         self.browser_tool._recording_sessions.clear()
         self.browser_tool._recording_sessions.update(self.orig_recording_sessions)
         self.browser_tool._cleanup_done = self.orig_cleanup_done
@@ -155,6 +166,8 @@ class TestBrowserCleanup:
         assert browser_tool._active_sessions["task-retry"] is session
         assert browser_tool._session_last_activity["task-retry"] == 123.0
         assert browser_tool._last_active_session_key["task-retry"] == "task-retry"
+        assert "task-retry" not in browser_tool._retired_browser_tasks
+        assert session["_cleanup_retry_pending"] is True
         mock_run.assert_called_once_with(
             "task-retry", "tab", ["close"], timeout=10
         )
@@ -334,3 +347,153 @@ class TestInactivityJanitorMultiplex:
         assert "t1" not in self.bt._active_sessions
         assert "t1" not in self.bt._session_last_activity
         assert "t1" not in self.bt._cleanup_failures
+
+def test_inactivity_reaper_spares_task_owned_shared_cdp(monkeypatch):
+    from tools import browser_tool
+
+    now = time.time()
+    task_id = "task-shared-cdp"
+    monkeypatch.setattr(
+        browser_tool,
+        "_active_sessions",
+        {
+            task_id: {
+                "session_name": "cdp_owned",
+                "bb_session_id": None,
+                "cdp_url": "ws://127.0.0.1:9222/devtools/browser/shared",
+                "features": {"cdp_override": True},
+            }
+        },
+    )
+    monkeypatch.setattr(
+        browser_tool,
+        "_session_last_activity",
+        {task_id: now - browser_tool.BROWSER_SESSION_INACTIVITY_TIMEOUT - 1},
+    )
+    cleanup = MagicMock(return_value=True)
+    monkeypatch.setattr(browser_tool, "cleanup_browser", cleanup)
+    monkeypatch.setattr(browser_tool.time, "time", lambda: now)
+
+    browser_tool._cleanup_inactive_browser_sessions()
+
+    cleanup.assert_not_called()
+    assert task_id in browser_tool._active_sessions
+    assert task_id in browser_tool._session_last_activity
+
+    # Once terminal cleanup has been requested and failed, the retained owner
+    # must remain eligible for a later background retry.
+    browser_tool._active_sessions[task_id]["_cleanup_retry_pending"] = True
+    cleanup.reset_mock()
+
+    browser_tool._cleanup_inactive_browser_sessions()
+
+    cleanup.assert_called_once_with(task_id)
+
+
+def test_inactivity_reaper_still_cleans_local_session(monkeypatch):
+    from tools import browser_tool
+
+    now = time.time()
+    task_id = "task-local"
+    monkeypatch.setattr(
+        browser_tool,
+        "_active_sessions",
+        {
+            task_id: {
+                "session_name": "local_owned",
+                "bb_session_id": None,
+                "cdp_url": None,
+                "features": {"local": True},
+            }
+        },
+    )
+    monkeypatch.setattr(
+        browser_tool,
+        "_session_last_activity",
+        {task_id: now - browser_tool.BROWSER_SESSION_INACTIVITY_TIMEOUT - 1},
+    )
+    cleanup = MagicMock(return_value=True)
+    monkeypatch.setattr(browser_tool, "cleanup_browser", cleanup)
+    monkeypatch.setattr(browser_tool.time, "time", lambda: now)
+
+    browser_tool._cleanup_inactive_browser_sessions()
+
+    cleanup.assert_called_once_with(task_id)
+    assert task_id not in browser_tool._session_last_activity
+
+
+def test_successful_cleanup_tombstones_non_navigation_without_recreation(
+    monkeypatch,
+):
+    from tools import browser_tool
+
+    task_id = "task-terminal"
+    monkeypatch.setattr(
+        browser_tool,
+        "_active_sessions",
+        {
+            task_id: {
+                "session_name": "cdp_terminal",
+                "bb_session_id": None,
+                "cdp_url": "ws://shared",
+                "features": {"cdp_override": True},
+            }
+        },
+    )
+    monkeypatch.setattr(browser_tool, "_session_last_activity", {task_id: 1.0})
+    monkeypatch.setattr(browser_tool, "_last_active_session_key", {task_id: task_id})
+    monkeypatch.setattr(browser_tool, "_retired_browser_tasks", set(), raising=False)
+    monkeypatch.setattr(browser_tool, "_maybe_stop_recording", lambda _task: None)
+    monkeypatch.setattr(browser_tool.os.path, "exists", lambda _path: False)
+    with patch(
+        "tools.browser_tool._run_browser_command",
+        return_value={"success": True},
+    ):
+        assert browser_tool.cleanup_browser(task_id) is True
+    assert task_id in browser_tool._retired_browser_tasks
+
+    get_session = MagicMock(
+        return_value={
+            "session_name": "replacement",
+            "bb_session_id": None,
+            "cdp_url": "ws://shared",
+        }
+    )
+    find_browser = MagicMock(return_value="/usr/bin/agent-browser")
+    popen = MagicMock()
+    monkeypatch.setattr(browser_tool, "_is_camofox_mode", lambda: False)
+    monkeypatch.setattr(browser_tool, "_is_local_mode", lambda: False)
+    monkeypatch.setattr(browser_tool, "_get_session_info", get_session)
+    monkeypatch.setattr(browser_tool, "_find_agent_browser", find_browser)
+    monkeypatch.setattr(browser_tool.subprocess, "Popen", popen)
+
+    result = json.loads(browser_tool.browser_snapshot(task_id=task_id))
+
+    assert result["success"] is False
+    assert result["code"] == "browser_session_retired"
+    assert result["data"]["terminal"] is True
+    get_session.assert_not_called()
+    find_browser.assert_not_called()
+    popen.assert_not_called()
+
+
+def test_retired_eval_does_not_use_stale_supervisor_or_subprocess(monkeypatch):
+    from tools import browser_tool
+    from tools.browser_supervisor import SUPERVISOR_REGISTRY
+
+    task_id = "task-retired-eval"
+    monkeypatch.setattr(browser_tool, "_retired_browser_tasks", {task_id})
+    monkeypatch.setattr(browser_tool, "_last_active_session_key", {})
+    supervisor_get = MagicMock()
+    run_command = MagicMock()
+    monkeypatch.setattr(SUPERVISOR_REGISTRY, "get", supervisor_get)
+    monkeypatch.setattr(browser_tool, "_run_browser_command", run_command)
+
+    result = json.loads(
+        browser_tool.browser_console(expression="1 + 1", task_id=task_id)
+    )
+
+    assert result["code"] == "browser_session_retired"
+    assert result["data"]["terminal"] is True
+    supervisor_get.assert_not_called()
+    run_command.assert_not_called()

--- a/tests/tools/test_browser_cleanup.py
+++ b/tests/tools/test_browser_cleanup.py
@@ -38,6 +38,10 @@ class TestBrowserCleanup:
         self.orig_retired_browser_tasks = getattr(
             browser_tool, "_retired_browser_tasks", set()
         ).copy()
+        self.orig_task_states = browser_tool._browser_task_states.copy()
+        self.orig_task_generations = browser_tool._browser_task_generations.copy()
+        self.orig_cleanup_reasons = browser_tool._browser_task_cleanup_reasons.copy()
+        self.orig_provider_cleanups = browser_tool._pending_provider_cleanups.copy()
         self.orig_recording_sessions = browser_tool._recording_sessions.copy()
         self.orig_cleanup_done = browser_tool._cleanup_done
 
@@ -55,6 +59,18 @@ class TestBrowserCleanup:
             self.browser_tool._retired_browser_tasks.update(
                 self.orig_retired_browser_tasks
             )
+        self.browser_tool._browser_task_states.clear()
+        self.browser_tool._browser_task_states.update(self.orig_task_states)
+        self.browser_tool._browser_task_generations.clear()
+        self.browser_tool._browser_task_generations.update(self.orig_task_generations)
+        self.browser_tool._browser_task_cleanup_reasons.clear()
+        self.browser_tool._browser_task_cleanup_reasons.update(
+            self.orig_cleanup_reasons
+        )
+        self.browser_tool._pending_provider_cleanups.clear()
+        self.browser_tool._pending_provider_cleanups.update(
+            self.orig_provider_cleanups
+        )
         self.browser_tool._recording_sessions.clear()
         self.browser_tool._recording_sessions.update(self.orig_recording_sessions)
         self.browser_tool._cleanup_done = self.orig_cleanup_done
@@ -81,7 +97,9 @@ class TestBrowserCleanup:
         assert "task-1" not in browser_tool._active_sessions
         assert "task-1" not in browser_tool._session_last_activity
         mock_stop.assert_called_once_with("task-1")
-        mock_run.assert_called_once_with("task-1", "close", [], timeout=10)
+        mock_run.assert_called_once_with(
+            "task-1", "close", [], timeout=10, _allow_cleanup=True
+        )
 
     def test_cleanup_shared_cdp_closes_pinned_tab_before_session(self):
         browser_tool = self.browser_tool
@@ -104,8 +122,8 @@ class TestBrowserCleanup:
         assert cleaned is True
         assert "task-cdp" not in browser_tool._active_sessions
         assert mock_run.call_args_list == [
-            (("task-cdp", "tab", ["close"]), {"timeout": 10}),
-            (("task-cdp", "close", []), {"timeout": 10}),
+            (("task-cdp", "tab", ["close"]), {"timeout": 10, "_allow_cleanup": True}),
+            (("task-cdp", "close", []), {"timeout": 10, "_allow_cleanup": True}),
         ]
 
     def test_cleanup_shared_cdp_accepts_already_gone_tab(self):
@@ -138,8 +156,8 @@ class TestBrowserCleanup:
         assert "task-gone" not in browser_tool._active_sessions
         assert "task-gone" not in browser_tool._session_last_activity
         assert mock_run.call_args_list == [
-            (("task-gone", "tab", ["close"]), {"timeout": 10}),
-            (("task-gone", "close", []), {"timeout": 10}),
+            (("task-gone", "tab", ["close"]), {"timeout": 10, "_allow_cleanup": True}),
+            (("task-gone", "close", []), {"timeout": 10, "_allow_cleanup": True}),
         ]
 
     def test_cleanup_shared_cdp_transient_failure_retains_ownership(self):
@@ -169,7 +187,7 @@ class TestBrowserCleanup:
         assert "task-retry" not in browser_tool._retired_browser_tasks
         assert session["_cleanup_retry_pending"] is True
         mock_run.assert_called_once_with(
-            "task-retry", "tab", ["close"], timeout=10
+            "task-retry", "tab", ["close"], timeout=10, _allow_cleanup=True
         )
 
     def test_cleanup_shared_cdp_retries_then_becomes_idempotent(self):
@@ -200,9 +218,9 @@ class TestBrowserCleanup:
 
         assert "task-repeat" not in browser_tool._active_sessions
         assert mock_run.call_args_list == [
-            (("task-repeat", "tab", ["close"]), {"timeout": 10}),
-            (("task-repeat", "tab", ["close"]), {"timeout": 10}),
-            (("task-repeat", "close", []), {"timeout": 10}),
+            (("task-repeat", "tab", ["close"]), {"timeout": 10, "_allow_cleanup": True}),
+            (("task-repeat", "tab", ["close"]), {"timeout": 10, "_allow_cleanup": True}),
+            (("task-repeat", "close", []), {"timeout": 10, "_allow_cleanup": True}),
         ]
 
     def test_successful_sidecar_cleanup_preserves_primary_binding(self):
@@ -387,7 +405,10 @@ def test_inactivity_reaper_spares_task_owned_shared_cdp(monkeypatch):
 
     browser_tool._cleanup_inactive_browser_sessions()
 
-    cleanup.assert_called_once_with(task_id)
+    cleanup.assert_called_once_with(
+        task_id,
+        reason=browser_tool.BrowserCleanupReason.INACTIVITY,
+    )
 
 
 def test_inactivity_reaper_still_cleans_local_session(monkeypatch):
@@ -418,7 +439,10 @@ def test_inactivity_reaper_still_cleans_local_session(monkeypatch):
 
     browser_tool._cleanup_inactive_browser_sessions()
 
-    cleanup.assert_called_once_with(task_id)
+    cleanup.assert_called_once_with(
+        task_id,
+        reason=browser_tool.BrowserCleanupReason.INACTIVITY,
+    )
     assert task_id not in browser_tool._session_last_activity
 
 

--- a/tests/tools/test_browser_cleanup.py
+++ b/tests/tools/test_browser_cleanup.py
@@ -4,7 +4,11 @@ import json
 import time
 
 from unittest.mock import MagicMock, patch
+from tools import browser_tool_cdp as bt_cdp
+from tools import browser_tool_cloud as bt_cloud
+from tools import browser_tool_install as bt_install
 from tools import browser_tool_lifecycle as bt_lifecycle
+from tools import browser_tool_session as bt_session
 
 
 class TestScreenshotPathRecovery:
@@ -45,7 +49,7 @@ class TestBrowserCleanup:
         self.orig_recording_sessions = browser_tool._recording_sessions.copy()
         self.orig_cleanup_done = browser_tool._cleanup_done
         self.close_target_patch = patch(
-            "tools.browser_tool._close_shared_cdp_target_confirmed",
+            "tools.browser_tool_cdp._close_shared_cdp_target_confirmed",
             return_value=True,
         )
         self.close_target_mock = self.close_target_patch.start()
@@ -95,7 +99,7 @@ class TestBrowserCleanup:
                 "tools.browser_tool_session._run_browser_command",
                 return_value={"success": True},
             ) as mock_run,
-            patch("tools.browser_tool.os.path.exists", return_value=False),
+            patch("tools.browser_tool_lifecycle.os.path.exists", return_value=False),
         ):
             cleaned = bt_lifecycle.cleanup_browser("task-1")
 
@@ -120,12 +124,12 @@ class TestBrowserCleanup:
         with (
             patch("tools.browser_tool._maybe_stop_recording"),
             patch(
-                "tools.browser_tool._run_browser_command",
+                "tools.browser_tool_session._run_browser_command",
                 return_value={"success": True},
             ) as mock_run,
-            patch("tools.browser_tool.os.path.exists", return_value=False),
+            patch("tools.browser_tool_lifecycle.os.path.exists", return_value=False),
         ):
-            cleaned = browser_tool.cleanup_browser("task-cdp")
+            cleaned = bt_lifecycle.cleanup_browser("task-cdp")
 
         assert cleaned is True
         assert "task-cdp" not in browser_tool._active_sessions
@@ -147,12 +151,12 @@ class TestBrowserCleanup:
         with (
             patch("tools.browser_tool._maybe_stop_recording"),
             patch(
-                "tools.browser_tool._run_browser_command",
+                "tools.browser_tool_session._run_browser_command",
                 return_value={"success": True},
             ) as mock_run,
-            patch("tools.browser_tool.os.path.exists", return_value=False),
+            patch("tools.browser_tool_lifecycle.os.path.exists", return_value=False),
         ):
-            cleaned = browser_tool.cleanup_browser("task-gone")
+            cleaned = bt_lifecycle.cleanup_browser("task-gone")
 
         assert cleaned is True
         assert "task-gone" not in browser_tool._active_sessions
@@ -175,7 +179,7 @@ class TestBrowserCleanup:
         browser_tool._last_active_session_key["task-retry"] = "task-retry"
 
         self.close_target_mock.return_value = False
-        cleaned = browser_tool.cleanup_browser("task-retry")
+        cleaned = bt_lifecycle.cleanup_browser("task-retry")
 
         assert cleaned is False
         assert browser_tool._active_sessions["task-retry"] is session
@@ -200,15 +204,15 @@ class TestBrowserCleanup:
         with (
             patch("tools.browser_tool._maybe_stop_recording"),
             patch(
-                "tools.browser_tool._run_browser_command",
+                "tools.browser_tool_session._run_browser_command",
                 return_value={"success": True},
             ) as mock_run,
-            patch("tools.browser_tool.os.path.exists", return_value=False),
+            patch("tools.browser_tool_lifecycle.os.path.exists", return_value=False),
         ):
-            assert browser_tool.cleanup_browser("task-repeat") is False
+            assert bt_lifecycle.cleanup_browser("task-repeat") is False
             assert "task-repeat" in browser_tool._active_sessions
-            assert browser_tool.cleanup_browser("task-repeat") is True
-            assert browser_tool.cleanup_browser("task-repeat") is True
+            assert bt_lifecycle.cleanup_browser("task-repeat") is True
+            assert bt_lifecycle.cleanup_browser("task-repeat") is True
 
         assert "task-repeat" not in browser_tool._active_sessions
         assert mock_run.call_args_list == [
@@ -227,12 +231,12 @@ class TestBrowserCleanup:
         with (
             patch("tools.browser_tool._maybe_stop_recording"),
             patch(
-                "tools.browser_tool._run_browser_command",
+                "tools.browser_tool_session._run_browser_command",
                 return_value={"success": True},
             ),
-            patch("tools.browser_tool.os.path.exists", return_value=False),
+            patch("tools.browser_tool_lifecycle.os.path.exists", return_value=False),
         ):
-            assert browser_tool.cleanup_browser(sidecar) is True
+            assert bt_lifecycle.cleanup_browser(sidecar) is True
 
         assert browser_tool._last_active_session_key["task-sidecar"] == "task-sidecar"
 
@@ -298,7 +302,7 @@ class TestInactivityJanitorMultiplex:
         monkeypatch.delenv("BROWSER_CDP_URL", raising=False)
         p1 = tmp_path / "profiles" / "p1"
         p1.mkdir(parents=True)
-        (p1 / ".env").write_text("CAMOFOX_URL=http://127.0.0.1:1\n")
+        (p1 / ".env").write_text("CAMOFOX_URL=http://127.0.0.1:1\n", encoding="utf-8")
 
         # Profile p1's turn opens the session; the janitor later runs unscoped.
         home_tok = set_hermes_home_override(str(p1))
@@ -321,7 +325,7 @@ class TestInactivityJanitorMultiplex:
         with (
             patch("tools.browser_tool_session._run_browser_command", side_effect=fake_close),
             patch("tools.browser_camofox._delete", return_value={}),
-            patch("tools.browser_tool.os.path.exists", return_value=False),
+            patch("tools.browser_tool_lifecycle.os.path.exists", return_value=False),
         ):
             bt_lifecycle._cleanup_inactive_browser_sessions()
 
@@ -340,7 +344,7 @@ class TestInactivityJanitorMultiplex:
         with (
             patch("tools.browser_tool_lifecycle.cleanup_browser", side_effect=RuntimeError("boom")),
             patch("tools.browser_tool_cloud._get_cloud_provider", return_value=provider),
-            patch("tools.browser_tool.os.path.exists", return_value=False),
+            patch("tools.browser_tool_lifecycle.os.path.exists", return_value=False),
         ):
             for _ in range(self.bt.MAX_INACTIVITY_CLEANUP_FAILURES - 1):
                 bt_lifecycle._cleanup_inactive_browser_sessions()
@@ -382,10 +386,10 @@ def test_inactivity_reaper_spares_task_owned_shared_cdp(monkeypatch):
         {task_id: now - browser_tool.BROWSER_SESSION_INACTIVITY_TIMEOUT - 1},
     )
     cleanup = MagicMock(return_value=True)
-    monkeypatch.setattr(browser_tool, "cleanup_browser", cleanup)
-    monkeypatch.setattr(browser_tool.time, "time", lambda: now)
+    monkeypatch.setattr(bt_lifecycle, "cleanup_browser", cleanup)
+    monkeypatch.setattr(bt_lifecycle.time, "time", lambda: now)
 
-    browser_tool._cleanup_inactive_browser_sessions()
+    bt_lifecycle._cleanup_inactive_browser_sessions()
 
     cleanup.assert_not_called()
     assert task_id in browser_tool._active_sessions
@@ -396,11 +400,11 @@ def test_inactivity_reaper_spares_task_owned_shared_cdp(monkeypatch):
     browser_tool._active_sessions[task_id]["_cleanup_retry_pending"] = True
     cleanup.reset_mock()
 
-    browser_tool._cleanup_inactive_browser_sessions()
+    bt_lifecycle._cleanup_inactive_browser_sessions()
 
     cleanup.assert_called_once_with(
         task_id,
-        reason=browser_tool.BrowserCleanupReason.INACTIVITY,
+        reason=bt_lifecycle.BrowserCleanupReason.INACTIVITY,
     )
 
 
@@ -427,14 +431,14 @@ def test_inactivity_reaper_still_cleans_local_session(monkeypatch):
         {task_id: now - browser_tool.BROWSER_SESSION_INACTIVITY_TIMEOUT - 1},
     )
     cleanup = MagicMock(return_value=True)
-    monkeypatch.setattr(browser_tool, "cleanup_browser", cleanup)
-    monkeypatch.setattr(browser_tool.time, "time", lambda: now)
+    monkeypatch.setattr(bt_lifecycle, "cleanup_browser", cleanup)
+    monkeypatch.setattr(bt_lifecycle.time, "time", lambda: now)
 
-    browser_tool._cleanup_inactive_browser_sessions()
+    bt_lifecycle._cleanup_inactive_browser_sessions()
 
     cleanup.assert_called_once_with(
         task_id,
-        reason=browser_tool.BrowserCleanupReason.INACTIVITY,
+        reason=bt_lifecycle.BrowserCleanupReason.INACTIVITY,
     )
     assert task_id not in browser_tool._session_last_activity
 
@@ -446,7 +450,7 @@ def test_successful_cleanup_tombstones_non_navigation_without_recreation(
 
     task_id = "task-terminal"
     monkeypatch.setattr(
-        browser_tool,
+        bt_cdp,
         "_close_shared_cdp_target_confirmed",
         lambda _cdp_url, _target_id: True,
     )
@@ -467,12 +471,12 @@ def test_successful_cleanup_tombstones_non_navigation_without_recreation(
     monkeypatch.setattr(browser_tool, "_last_active_session_key", {task_id: task_id})
     monkeypatch.setattr(browser_tool, "_retired_browser_tasks", set(), raising=False)
     monkeypatch.setattr(browser_tool, "_maybe_stop_recording", lambda _task: None)
-    monkeypatch.setattr(browser_tool.os.path, "exists", lambda _path: False)
+    monkeypatch.setattr(bt_lifecycle.os.path, "exists", lambda _path: False)
     with patch(
-        "tools.browser_tool._run_browser_command",
+        "tools.browser_tool_session._run_browser_command",
         return_value={"success": True},
     ):
-        assert browser_tool.cleanup_browser(task_id) is True
+        assert bt_lifecycle.cleanup_browser(task_id) is True
     assert task_id in browser_tool._retired_browser_tasks
 
     get_session = MagicMock(
@@ -487,10 +491,10 @@ def test_successful_cleanup_tombstones_non_navigation_without_recreation(
     find_browser = MagicMock(return_value="/usr/bin/agent-browser")
     popen = MagicMock()
     monkeypatch.setattr(browser_tool, "_is_camofox_mode", lambda: False)
-    monkeypatch.setattr(browser_tool, "_is_local_mode", lambda: False)
-    monkeypatch.setattr(browser_tool, "_get_session_info", get_session)
-    monkeypatch.setattr(browser_tool, "_find_agent_browser", find_browser)
-    monkeypatch.setattr(browser_tool.subprocess, "Popen", popen)
+    monkeypatch.setattr(bt_cloud, "_is_local_mode", lambda: False)
+    monkeypatch.setattr(bt_session, "_get_session_info", get_session)
+    monkeypatch.setattr(bt_install, "_find_agent_browser", find_browser)
+    monkeypatch.setattr(bt_session.subprocess, "Popen", popen)
 
     result = json.loads(browser_tool.browser_snapshot(task_id=task_id))
 
@@ -512,7 +516,7 @@ def test_retired_eval_does_not_use_stale_supervisor_or_subprocess(monkeypatch):
     supervisor_get = MagicMock()
     run_command = MagicMock()
     monkeypatch.setattr(SUPERVISOR_REGISTRY, "get", supervisor_get)
-    monkeypatch.setattr(browser_tool, "_run_browser_command", run_command)
+    monkeypatch.setattr(bt_session, "_run_browser_command", run_command)
 
     result = json.loads(
         browser_tool.browser_console(expression="1 + 1", task_id=task_id)

--- a/tests/tools/test_browser_eval_supervisor_path.py
+++ b/tests/tools/test_browser_eval_supervisor_path.py
@@ -85,6 +85,38 @@ class TestBrowserEvalSupervisorPath:
         # result_type reflects the parsed Python type, not the raw JS type.
         assert out["result_type"] == "dict"
 
+    def test_closed_supervisor_session_falls_back_to_structured_tab_gone(self, monkeypatch):
+        import tools.browser_tool as bt
+
+        sup = MagicMock()
+        sup.evaluate_runtime.return_value = {
+            "ok": False,
+            "error": (
+                "RuntimeError: CDP error on id=10: "
+                "{'code': -32001, 'message': 'Session with given id not found.'}"
+            ),
+        }
+        _patch_supervisor(monkeypatch, sup)
+        stop = MagicMock()
+        monkeypatch.setattr(bt, "_stop_cdp_supervisor", stop)
+        monkeypatch.setattr(
+            bt,
+            "_run_browser_command",
+            lambda *a, **kw: {
+                "success": False,
+                "error": "Pinned tab is no longer available",
+                "code": "tab_gone",
+                "data": {"targetId": "TARGET-A"},
+            },
+        )
+
+        out = json.loads(bt._browser_eval("location.href"))
+
+        assert out["success"] is False
+        assert out["code"] == "tab_gone"
+        assert out["data"] == {"targetId": "TARGET-A"}
+        stop.assert_called_once_with("test-task")
+
 
     def test_subprocess_reference_chain_error_becomes_guidance(self, monkeypatch):
         """The CLI subprocess can't retry with returnByValue=False, so the

--- a/tests/tools/test_browser_eval_supervisor_path.py
+++ b/tests/tools/test_browser_eval_supervisor_path.py
@@ -367,13 +367,13 @@ def _make_supervisor_with_cdp_fn(cdp_fn):
     return sup
 
 
-class TestEvaluateRuntimeDomNodeCrashRetry:
+class TestEvaluateRuntimeSerializationFailure:
     """returnByValue=True on a DOM node fails CDP serialization with 'Object
-    reference chain is too long'.  evaluate_runtime must retry with
-    returnByValue=False and return the node's description instead of crashing.
+    reference chain is too long'. The expression has already run and must not
+    be dispatched a second time.
     """
 
-    def test_reference_chain_crash_retries_without_by_value(self):
+    def test_reference_chain_crash_returns_actionable_failure_without_replay(self):
         from tools.browser_supervisor import CDPProtocolError
 
         calls = []
@@ -389,26 +389,40 @@ class TestEvaluateRuntimeDomNodeCrashRetry:
                         "message": "Object reference chain is too long",
                     },
                 )
-            # returnByValue=False: Chrome returns the node's description, no value.
-            return {
-                "id": 8,
-                "result": {
-                    "result": {
-                        "type": "object",
-                        "subtype": "node",
-                        "description": "body",
-                    }
-                },
-            }
+            raise AssertionError("expression must not be replayed")
 
         sup = _make_supervisor_with_cdp_fn(_fake_cdp)
         try:
             out = sup.evaluate_runtime("document.body")
-            assert out["ok"] is True
-            assert out["result"] == "body"
-            assert out["result_type"] == "object"
-            # First call by_value=True (crashed), retried with by_value=False.
-            assert calls == [True, False]
+            assert out["ok"] is False
+            assert out["kind"] == "result_serialization_failed"
+            assert out["data"]["expression_executed"] is True
+            assert out["data"]["replayed"] is False
+            assert calls == [True]
+        finally:
+            _stop_supervisor(sup)
+
+    def test_side_effecting_serialization_failure_executes_once(self):
+        from tools.browser_supervisor import CDPProtocolError
+
+        side_effect_count = 0
+
+        async def _fake_cdp(method, params=None, *, session_id=None, timeout=10.0):
+            nonlocal side_effect_count
+            side_effect_count += 1
+            raise CDPProtocolError(
+                9,
+                {
+                    "code": -32000,
+                    "message": "Object reference chain is too long",
+                },
+            )
+
+        sup = _make_supervisor_with_cdp_fn(_fake_cdp)
+        try:
+            out = sup.evaluate_runtime("window.counter++; returnDeepCycle()")
+            assert out["kind"] == "result_serialization_failed"
+            assert side_effect_count == 1
         finally:
             _stop_supervisor(sup)
 

--- a/tests/tools/test_browser_eval_supervisor_path.py
+++ b/tests/tools/test_browser_eval_supervisor_path.py
@@ -7,7 +7,10 @@ real browser, no real WebSocket.  Real-CDP coverage lives in
 """
 from __future__ import annotations
 
+import asyncio
+from concurrent.futures import Future
 import json
+import threading
 from unittest.mock import MagicMock
 
 import pytest
@@ -26,6 +29,26 @@ def _disable_camofox(monkeypatch):
 
     monkeypatch.setattr(bt, "_is_camofox_mode", lambda: False)
     monkeypatch.setattr(bt, "_last_session_key", lambda task_id: "test-task")
+
+
+@pytest.fixture(autouse=True)
+def _run_scheduled_coroutines_inline(monkeypatch):
+    """Run mocked CDP coroutines deterministically without a background loop."""
+
+    def schedule(coro, _loop):
+        future = Future()
+        try:
+            future.set_result(asyncio.run(coro))
+        except BaseException as exc:
+            future.set_exception(exc)
+        return future
+
+    monkeypatch.setattr("agent.async_utils.safe_schedule_threadsafe", schedule)
+
+
+class _RunningLoop:
+    def is_running(self):
+        return True
 
 
 def _patch_supervisor(monkeypatch, supervisor):
@@ -91,10 +114,18 @@ class TestBrowserEvalSupervisorPath:
         sup = MagicMock()
         sup.evaluate_runtime.return_value = {
             "ok": False,
+            "kind": "cdp_protocol",
             "error": (
-                "RuntimeError: CDP error on id=10: "
+                "CDPProtocolError: CDP error on id=10: "
                 "{'code': -32001, 'message': 'Session with given id not found.'}"
             ),
+            "data": {
+                "protocol_error": {
+                    "code": -32001,
+                    "message": "Session with given id not found.",
+                },
+                "session_lost": True,
+            },
         }
         _patch_supervisor(monkeypatch, sup)
         stop = MagicMock()
@@ -117,6 +148,52 @@ class TestBrowserEvalSupervisorPath:
         assert out["data"] == {"targetId": "TARGET-A"}
         stop.assert_called_once_with("test-task")
 
+    @pytest.mark.parametrize(
+        "message",
+        [
+            "target closed",
+            "session with given id not found",
+        ],
+    )
+    def test_js_exception_text_never_replays_expression(self, monkeypatch, message):
+        import tools.browser_tool as bt
+
+        sup = MagicMock()
+        sup.evaluate_runtime.return_value = {
+            "ok": False,
+            "kind": "js_exception",
+            "error": f"Uncaught Error: {message}",
+            "data": {"exception_details": {"text": message}},
+        }
+        _patch_supervisor(monkeypatch, sup)
+        stop = MagicMock()
+        subprocess_run = MagicMock(side_effect=AssertionError("must not replay"))
+        monkeypatch.setattr(bt, "_stop_cdp_supervisor", stop)
+        monkeypatch.setattr(bt, "_run_browser_command", subprocess_run)
+
+        out = json.loads(bt._browser_eval("window.sideEffectCount++"))
+
+        assert out["success"] is False
+        assert out["code"] == "javascript_exception"
+        assert message in out["error"]
+        subprocess_run.assert_not_called()
+        stop.assert_not_called()
+
+    def test_ambiguous_supervisor_exception_is_not_replayed(self, monkeypatch):
+        import tools.browser_tool as bt
+
+        sup = MagicMock()
+        sup.evaluate_runtime.side_effect = TimeoutError("response lost")
+        _patch_supervisor(monkeypatch, sup)
+        subprocess_run = MagicMock(side_effect=AssertionError("must not replay"))
+        monkeypatch.setattr(bt, "_run_browser_command", subprocess_run)
+
+        out = json.loads(bt._browser_eval("window.sideEffectCount++"))
+
+        assert out["success"] is False
+        assert out["code"] == "cdp_evaluate_failed"
+        assert out["data"] == {"exception_type": "TimeoutError"}
+        subprocess_run.assert_not_called()
 
     def test_subprocess_reference_chain_error_becomes_guidance(self, monkeypatch):
         """The CLI subprocess can't retry with returnByValue=False, so the
@@ -156,9 +233,6 @@ def _make_supervisor_with_cdp(cdp_response):
     Bypasses ``__init__`` entirely so we don't need a real WS connection.  We
     set just the state ``evaluate_runtime`` reads.
     """
-    import asyncio
-    import threading
-
     from tools.browser_supervisor import CDPSupervisor
 
     sup = object.__new__(CDPSupervisor)
@@ -166,29 +240,16 @@ def _make_supervisor_with_cdp(cdp_response):
     sup._active = True
     sup._page_session_id = "test-session-id"
 
-    # Build a real running event loop on a background thread so
-    # asyncio.run_coroutine_threadsafe has somewhere to dispatch.
-    loop = asyncio.new_event_loop()
-
-    def _runner():
-        asyncio.set_event_loop(loop)
-        loop.run_forever()
-
-    thread = threading.Thread(target=_runner, daemon=True)
-    thread.start()
-
     async def _fake_cdp(method, params=None, *, session_id=None, timeout=10.0):
         return cdp_response
 
     sup._cdp = _fake_cdp  # type: ignore[method-assign]
-    sup._loop = loop
-    sup._thread = thread
+    sup._loop = _RunningLoop()
     return sup
 
 
 def _stop_supervisor(sup):
-    sup._loop.call_soon_threadsafe(sup._loop.stop)
-    sup._thread.join(timeout=2)
+    del sup
 
 
 class TestEvaluateRuntimeResponseShaping:
@@ -225,8 +286,6 @@ class TestEvaluateRuntimeResponseShaping:
 
 
     def test_no_session_attached_returns_error(self):
-        import asyncio
-        import threading
         from tools.browser_supervisor import CDPSupervisor
 
         sup = object.__new__(CDPSupervisor)
@@ -234,29 +293,68 @@ class TestEvaluateRuntimeResponseShaping:
         sup._active = True
         sup._page_session_id = None  # ← attach hasn't happened yet
 
-        loop = asyncio.new_event_loop()
-        thread = threading.Thread(
-            target=lambda: (asyncio.set_event_loop(loop), loop.run_forever()),
-            daemon=True,
+        sup._loop = _RunningLoop()
+        out = sup.evaluate_runtime("1+1")
+        assert out == {
+            "ok": False,
+            "kind": "supervisor_unavailable",
+            "error": "supervisor has no attached page session",
+            "data": {"reason": "no_page_session"},
+        }
+
+    def test_js_exception_details_are_structured(self):
+        details = {
+            "text": "Uncaught",
+            "exception": {
+                "description": "Error: session with given id not found"
+            },
+        }
+        sup = _make_supervisor_with_cdp(
+            {
+                "id": 2,
+                "result": {
+                    "result": {"type": "object", "subtype": "error"},
+                    "exceptionDetails": details,
+                },
+            }
         )
-        thread.start()
-        sup._loop = loop
-        try:
-            out = sup.evaluate_runtime("1+1")
-            assert out["ok"] is False
-            assert "session" in out["error"].lower()
-        finally:
-            loop.call_soon_threadsafe(loop.stop)
-            thread.join(timeout=2)
+
+        out = sup.evaluate_runtime("throw new Error('session with given id not found')")
+
+        assert out == {
+            "ok": False,
+            "kind": "js_exception",
+            "error": "Uncaught: Error: session with given id not found",
+            "data": {"exception_details": details},
+        }
+
+    def test_stale_protocol_error_is_structured(self):
+        from tools.browser_supervisor import CDPProtocolError
+
+        async def _stale_cdp(method, params=None, *, session_id=None, timeout=10.0):
+            raise CDPProtocolError(
+                9,
+                {"code": -32001, "message": "Session with given id not found."},
+            )
+
+        sup = _make_supervisor_with_cdp_fn(_stale_cdp)
+        out = sup.evaluate_runtime("location.href")
+
+        assert out["ok"] is False
+        assert out["kind"] == "cdp_protocol"
+        assert out["data"] == {
+            "protocol_error": {
+                "code": -32001,
+                "message": "Session with given id not found.",
+            },
+            "session_lost": True,
+        }
 
 
 def _make_supervisor_with_cdp_fn(cdp_fn):
     """Like ``_make_supervisor_with_cdp`` but lets the test supply a coroutine
     function as ``_cdp`` so behaviour can vary by params (e.g. returnByValue).
     """
-    import asyncio
-    import threading
-
     from tools.browser_supervisor import CDPSupervisor
 
     sup = object.__new__(CDPSupervisor)
@@ -264,18 +362,8 @@ def _make_supervisor_with_cdp_fn(cdp_fn):
     sup._active = True
     sup._page_session_id = "test-session-id"
 
-    loop = asyncio.new_event_loop()
-
-    def _runner():
-        asyncio.set_event_loop(loop)
-        loop.run_forever()
-
-    thread = threading.Thread(target=_runner, daemon=True)
-    thread.start()
-
     sup._cdp = cdp_fn  # type: ignore[method-assign]
-    sup._loop = loop
-    sup._thread = thread
+    sup._loop = _RunningLoop()
     return sup
 
 
@@ -286,16 +374,20 @@ class TestEvaluateRuntimeDomNodeCrashRetry:
     """
 
     def test_reference_chain_crash_retries_without_by_value(self):
+        from tools.browser_supervisor import CDPProtocolError
+
         calls = []
 
         async def _fake_cdp(method, params=None, *, session_id=None, timeout=10.0):
             by_value = (params or {}).get("returnByValue")
             calls.append(by_value)
             if by_value:
-                # Mirror _read_loop turning a top-level CDP error into a RuntimeError.
-                raise RuntimeError(
-                    "CDP error on id=7: {'code': -32000, "
-                    "'message': 'Object reference chain is too long'}"
+                raise CDPProtocolError(
+                    7,
+                    {
+                        "code": -32000,
+                        "message": "Object reference chain is too long",
+                    },
                 )
             # returnByValue=False: Chrome returns the node's description, no value.
             return {
@@ -331,6 +423,7 @@ class TestEvaluateRuntimeDomNodeCrashRetry:
         try:
             out = sup.evaluate_runtime("document.body")
             assert out["ok"] is False
+            assert out["kind"] == "cdp_transport"
             assert "Target closed" in out["error"]
             # No retry for unrelated failures — exactly one call.
             assert calls == [True]

--- a/tests/tools/test_browser_eval_supervisor_path.py
+++ b/tests/tools/test_browser_eval_supervisor_path.py
@@ -15,6 +15,7 @@ from unittest.mock import MagicMock
 
 import pytest
 from tools import browser_tool_session as bt_session
+from tools import browser_tool_cdp as bt_cdp
 
 
 # ---------------------------------------------------------------------------
@@ -129,9 +130,9 @@ class TestBrowserEvalSupervisorPath:
         }
         _patch_supervisor(monkeypatch, sup)
         stop = MagicMock()
-        monkeypatch.setattr(bt, "_stop_cdp_supervisor", stop)
+        monkeypatch.setattr(bt_cdp, "_stop_cdp_supervisor", stop)
         monkeypatch.setattr(
-            bt,
+            bt_session,
             "_run_browser_command",
             lambda *a, **kw: {
                 "success": False,
@@ -168,8 +169,8 @@ class TestBrowserEvalSupervisorPath:
         _patch_supervisor(monkeypatch, sup)
         stop = MagicMock()
         subprocess_run = MagicMock(side_effect=AssertionError("must not replay"))
-        monkeypatch.setattr(bt, "_stop_cdp_supervisor", stop)
-        monkeypatch.setattr(bt, "_run_browser_command", subprocess_run)
+        monkeypatch.setattr(bt_cdp, "_stop_cdp_supervisor", stop)
+        monkeypatch.setattr(bt_session, "_run_browser_command", subprocess_run)
 
         out = json.loads(bt._browser_eval("window.sideEffectCount++"))
 
@@ -186,7 +187,7 @@ class TestBrowserEvalSupervisorPath:
         sup.evaluate_runtime.side_effect = TimeoutError("response lost")
         _patch_supervisor(monkeypatch, sup)
         subprocess_run = MagicMock(side_effect=AssertionError("must not replay"))
-        monkeypatch.setattr(bt, "_run_browser_command", subprocess_run)
+        monkeypatch.setattr(bt_session, "_run_browser_command", subprocess_run)
 
         out = json.loads(bt._browser_eval("window.sideEffectCount++"))
 

--- a/tests/tools/test_browser_exact_target_close.py
+++ b/tests/tools/test_browser_exact_target_close.py
@@ -1,0 +1,88 @@
+"""Exact shared-CDP target close regression tests."""
+
+from tools import browser_cdp_tool, browser_tool
+
+
+def _install_fake_cdp(monkeypatch, responses):
+    calls = []
+    queued = iter(responses)
+
+    def fake_cdp_call(_url, method, params, target_id, timeout):
+        calls.append((method, params, target_id, timeout))
+        return method
+
+    def fake_run_async(method):
+        response = next(queued)
+        if isinstance(response, BaseException):
+            raise response
+        return response
+
+    monkeypatch.setattr(browser_cdp_tool, "_cdp_call", fake_cdp_call)
+    monkeypatch.setattr(browser_cdp_tool, "_run_async", fake_run_async)
+    return calls
+
+
+def test_exact_close_succeeds_only_after_target_disappears(monkeypatch):
+    calls = _install_fake_cdp(
+        monkeypatch,
+        [
+            {"success": True},
+            {"targetInfos": [{"targetId": "OTHER"}]},
+        ],
+    )
+
+    assert browser_tool._close_shared_cdp_target_confirmed(
+        "ws://shared", "TARGET-OWNED"
+    ) is True
+    assert [call[0] for call in calls] == ["Target.closeTarget", "Target.getTargets"]
+    assert calls[0][1] == {"targetId": "TARGET-OWNED"}
+    assert all(call[2] is None for call in calls)
+
+
+def test_exact_close_rejects_surface_success_while_target_remains(monkeypatch):
+    calls = _install_fake_cdp(
+        monkeypatch,
+        [
+            {"success": True},
+            {"targetInfos": [{"targetId": "TARGET-OWNED"}]},
+        ],
+    )
+    ticks = iter([10.0, 13.0])
+    monkeypatch.setattr(browser_tool.time, "monotonic", lambda: next(ticks))
+
+    assert browser_tool._close_shared_cdp_target_confirmed(
+        "ws://shared", "TARGET-OWNED"
+    ) is False
+    assert [call[0] for call in calls] == ["Target.closeTarget", "Target.getTargets"]
+
+
+def test_exact_close_accepts_lost_response_only_after_absence_proof(monkeypatch):
+    calls = _install_fake_cdp(
+        monkeypatch,
+        [
+            TimeoutError("close response lost"),
+            {"targetInfos": []},
+        ],
+    )
+
+    assert browser_tool._close_shared_cdp_target_confirmed(
+        "ws://shared", "TARGET-OWNED"
+    ) is True
+    assert [call[0] for call in calls] == ["Target.closeTarget", "Target.getTargets"]
+
+
+def test_exact_close_fails_when_target_list_cannot_be_verified(monkeypatch):
+    calls = _install_fake_cdp(
+        monkeypatch,
+        [
+            {"success": True},
+            TimeoutError("target list unavailable"),
+        ],
+    )
+    ticks = iter([20.0, 23.0])
+    monkeypatch.setattr(browser_tool.time, "monotonic", lambda: next(ticks))
+
+    assert browser_tool._close_shared_cdp_target_confirmed(
+        "ws://shared", "TARGET-OWNED"
+    ) is False
+    assert [call[0] for call in calls] == ["Target.closeTarget", "Target.getTargets"]

--- a/tests/tools/test_browser_exact_target_close.py
+++ b/tests/tools/test_browser_exact_target_close.py
@@ -86,3 +86,43 @@ def test_exact_close_fails_when_target_list_cannot_be_verified(monkeypatch):
         "ws://shared", "TARGET-OWNED"
     ) is False
     assert [call[0] for call in calls] == ["Target.closeTarget", "Target.getTargets"]
+
+
+def test_cleanup_recovers_exact_target_from_daemon_metadata(monkeypatch, tmp_path):
+    task_id = "timeout-target-recovery"
+    session_name = "cdp_timeout_recovery"
+    socket_dir = tmp_path / f"agent-browser-{session_name}"
+    socket_dir.mkdir()
+    (socket_dir / f"{session_name}.target").write_text(
+        '{"pinned":true,"targetId":"TARGET-FROM-DISK"}',
+        encoding="utf-8",
+    )
+    session = {
+        "session_name": session_name,
+        "bb_session_id": None,
+        "cdp_url": "ws://shared",
+        "features": {"cdp_override": True},
+    }
+    monkeypatch.setattr(browser_tool, "_active_sessions", {task_id: session})
+    monkeypatch.setattr(browser_tool, "_session_last_activity", {task_id: 1.0})
+    monkeypatch.setattr(browser_tool, "_socket_safe_tmpdir", lambda: str(tmp_path))
+    monkeypatch.setattr(browser_tool, "_stop_cdp_supervisor", lambda _task: None)
+    monkeypatch.setattr(browser_tool, "_is_camofox_mode", lambda: False)
+    monkeypatch.setattr(browser_tool, "_maybe_stop_recording", lambda _task: None)
+    monkeypatch.setattr(
+        browser_tool,
+        "_run_browser_command",
+        lambda *_args, **_kwargs: {"success": True},
+    )
+    close_calls = []
+    monkeypatch.setattr(
+        browser_tool,
+        "_close_shared_cdp_target_confirmed",
+        lambda cdp_url, target_id: close_calls.append((cdp_url, target_id)) or True,
+    )
+
+    assert browser_tool._cleanup_single_browser_session(task_id) is True
+
+    assert close_calls == [("ws://shared", "TARGET-FROM-DISK")]
+    assert session["target_id"] == "TARGET-FROM-DISK"
+    assert task_id not in browser_tool._active_sessions

--- a/tests/tools/test_browser_exact_target_close.py
+++ b/tests/tools/test_browser_exact_target_close.py
@@ -1,6 +1,9 @@
 """Exact shared-CDP target close regression tests."""
 
 from tools import browser_cdp_tool, browser_tool
+from tools import browser_tool_cdp as browser_cdp
+from tools import browser_tool_lifecycle as browser_lifecycle
+from tools import browser_tool_session as browser_session
 
 
 def _install_fake_cdp(monkeypatch, responses):
@@ -31,7 +34,7 @@ def test_exact_close_succeeds_only_after_target_disappears(monkeypatch):
         ],
     )
 
-    assert browser_tool._close_shared_cdp_target_confirmed(
+    assert browser_cdp._close_shared_cdp_target_confirmed(
         "ws://shared", "TARGET-OWNED"
     ) is True
     assert [call[0] for call in calls] == ["Target.closeTarget", "Target.getTargets"]
@@ -48,9 +51,9 @@ def test_exact_close_rejects_surface_success_while_target_remains(monkeypatch):
         ],
     )
     ticks = iter([10.0, 13.0])
-    monkeypatch.setattr(browser_tool.time, "monotonic", lambda: next(ticks))
+    monkeypatch.setattr(browser_cdp.time, "monotonic", lambda: next(ticks))
 
-    assert browser_tool._close_shared_cdp_target_confirmed(
+    assert browser_cdp._close_shared_cdp_target_confirmed(
         "ws://shared", "TARGET-OWNED"
     ) is False
     assert [call[0] for call in calls] == ["Target.closeTarget", "Target.getTargets"]
@@ -65,7 +68,7 @@ def test_exact_close_accepts_lost_response_only_after_absence_proof(monkeypatch)
         ],
     )
 
-    assert browser_tool._close_shared_cdp_target_confirmed(
+    assert browser_cdp._close_shared_cdp_target_confirmed(
         "ws://shared", "TARGET-OWNED"
     ) is True
     assert [call[0] for call in calls] == ["Target.closeTarget", "Target.getTargets"]
@@ -80,9 +83,9 @@ def test_exact_close_fails_when_target_list_cannot_be_verified(monkeypatch):
         ],
     )
     ticks = iter([20.0, 23.0])
-    monkeypatch.setattr(browser_tool.time, "monotonic", lambda: next(ticks))
+    monkeypatch.setattr(browser_cdp.time, "monotonic", lambda: next(ticks))
 
-    assert browser_tool._close_shared_cdp_target_confirmed(
+    assert browser_cdp._close_shared_cdp_target_confirmed(
         "ws://shared", "TARGET-OWNED"
     ) is False
     assert [call[0] for call in calls] == ["Target.closeTarget", "Target.getTargets"]
@@ -106,22 +109,22 @@ def test_cleanup_recovers_exact_target_from_daemon_metadata(monkeypatch, tmp_pat
     monkeypatch.setattr(browser_tool, "_active_sessions", {task_id: session})
     monkeypatch.setattr(browser_tool, "_session_last_activity", {task_id: 1.0})
     monkeypatch.setattr(browser_tool, "_socket_safe_tmpdir", lambda: str(tmp_path))
-    monkeypatch.setattr(browser_tool, "_stop_cdp_supervisor", lambda _task: None)
+    monkeypatch.setattr(browser_cdp, "_stop_cdp_supervisor", lambda _task: None)
     monkeypatch.setattr(browser_tool, "_is_camofox_mode", lambda: False)
     monkeypatch.setattr(browser_tool, "_maybe_stop_recording", lambda _task: None)
     monkeypatch.setattr(
-        browser_tool,
+        browser_session,
         "_run_browser_command",
         lambda *_args, **_kwargs: {"success": True},
     )
     close_calls = []
     monkeypatch.setattr(
-        browser_tool,
+        browser_cdp,
         "_close_shared_cdp_target_confirmed",
         lambda cdp_url, target_id: close_calls.append((cdp_url, target_id)) or True,
     )
 
-    assert browser_tool._cleanup_single_browser_session(task_id) is True
+    assert browser_lifecycle._cleanup_single_browser_session(task_id) is True
 
     assert close_calls == [("ws://shared", "TARGET-FROM-DISK")]
     assert session["target_id"] == "TARGET-FROM-DISK"

--- a/tests/tools/test_browser_headed_mode.py
+++ b/tests/tools/test_browser_headed_mode.py
@@ -68,7 +68,7 @@ class TestCleanupTaskResourcesHeadedSkip:
         with (
             patch("tools.browser_tool_cloud._is_headed_mode", return_value=False),
             patch("run_agent.cleanup_vm"),
-            patch("run_agent.cleanup_browser") as mock_cb,
+            patch("run_agent.cleanup_browser_for_turn") as mock_cb,
             patch(
                 "agent.chat_completion_helpers.is_persistent_env",
                 return_value=False,
@@ -84,7 +84,7 @@ class TestCleanupTaskResourcesHeadedSkip:
         with (
             patch("tools.browser_tool_cloud._is_headed_mode", return_value=True),
             patch("run_agent.cleanup_vm") as mock_vm,
-            patch("run_agent.cleanup_browser"),
+            patch("run_agent.cleanup_browser_for_turn") as mock_browser,
             patch(
                 "agent.chat_completion_helpers.is_persistent_env",
                 return_value=False,
@@ -92,6 +92,7 @@ class TestCleanupTaskResourcesHeadedSkip:
         ):
             cleanup_task_resources(_make_agent(), "task-x")
             mock_vm.assert_called_once_with("task-x")
+            mock_browser.assert_called_once_with("task-x")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/tools/test_browser_homebrew_paths.py
+++ b/tests/tools/test_browser_homebrew_paths.py
@@ -139,7 +139,7 @@ class TestFindAgentBrowser:
         without calling agent_browser_runnable — that keeps the probe a cheap
         existence check with no subprocess spawn."""
         fake_binary = tmp_path / "agent-browser"
-        fake_binary.write_text("#!/bin/sh\n")
+        fake_binary.write_text("#!/bin/sh\n", encoding="utf-8")
         fake_binary.chmod(0o755)
 
         def mock_which(cmd, path=None):
@@ -171,7 +171,7 @@ class TestFindAgentBrowser:
         local_bin_dir = repo_root / "node_modules" / ".bin"
 
         fake_binary = tmp_path / "agent-browser"
-        fake_binary.write_text("#!/bin/sh\n")
+        fake_binary.write_text("#!/bin/sh\n", encoding="utf-8")
         fake_binary.chmod(0o755)
 
         def mock_which(cmd, path=None):
@@ -248,7 +248,7 @@ class TestAgentBrowserCandidatePresent:
 
     def test_executable_file_is_true(self, tmp_path):
         binary = tmp_path / "agent-browser"
-        binary.write_text("#!/bin/sh\n")
+        binary.write_text("#!/bin/sh\n", encoding="utf-8")
         binary.chmod(0o755)
         assert _agent_browser_candidate_present(str(binary)) is True
 
@@ -258,7 +258,7 @@ class TestAgentBrowserCandidatePresent:
     )
     def test_nonexecutable_file_is_false(self, tmp_path):
         binary = tmp_path / "agent-browser"
-        binary.write_text("#!/bin/sh\n")
+        binary.write_text("#!/bin/sh\n", encoding="utf-8")
         binary.chmod(0o644)
         assert _agent_browser_candidate_present(str(binary)) is False
 

--- a/tests/tools/test_browser_homebrew_paths.py
+++ b/tests/tools/test_browser_homebrew_paths.py
@@ -24,10 +24,14 @@ def _clear_browser_caches():
     _discover_homebrew_node_dirs.cache_clear()
     _bt._cached_agent_browser = None
     _bt._agent_browser_resolved = False
+    _bt._cached_pin_tab_agent_browser = None
+    _bt._pin_tab_agent_browser_resolved = False
     yield
     _discover_homebrew_node_dirs.cache_clear()
     _bt._cached_agent_browser = None
     _bt._agent_browser_resolved = False
+    _bt._cached_pin_tab_agent_browser = None
+    _bt._pin_tab_agent_browser_resolved = False
 
 
 class TestSanePath:

--- a/tests/tools/test_browser_homebrew_paths.py
+++ b/tests/tools/test_browser_homebrew_paths.py
@@ -26,12 +26,14 @@ def _clear_browser_caches():
     _bt._agent_browser_resolved = False
     _bt._cached_pin_tab_agent_browser = None
     _bt._pin_tab_agent_browser_resolved = False
+    _bt._pin_tab_failure_cache = None
     yield
     _discover_homebrew_node_dirs.cache_clear()
     _bt._cached_agent_browser = None
     _bt._agent_browser_resolved = False
     _bt._cached_pin_tab_agent_browser = None
     _bt._pin_tab_agent_browser_resolved = False
+    _bt._pin_tab_failure_cache = None
 
 
 class TestSanePath:

--- a/tests/tools/test_browser_hybrid_routing.py
+++ b/tests/tools/test_browser_hybrid_routing.py
@@ -24,7 +24,13 @@ from tools import browser_tool_cloud as bt_cloud
 def _reset_routing_state(monkeypatch):
     """Clear module-level caches so each test starts clean."""
     monkeypatch.setattr(browser_tool, "_active_sessions", {})
+    monkeypatch.setattr(browser_tool, "_session_last_activity", {})
     monkeypatch.setattr(browser_tool, "_last_active_session_key", {})
+    monkeypatch.setattr(browser_tool, "_retired_browser_tasks", set())
+    monkeypatch.setattr(browser_tool, "_browser_task_states", {})
+    monkeypatch.setattr(browser_tool, "_browser_task_generations", {})
+    monkeypatch.setattr(browser_tool, "_browser_task_cleanup_reasons", {})
+    monkeypatch.setattr(browser_tool, "_pending_provider_cleanups", {})
     monkeypatch.setattr(browser_tool, "_cached_cloud_provider", None)
     monkeypatch.setattr(browser_tool, "_cloud_provider_resolved", False)
     monkeypatch.setattr(browser_tool, "_auto_local_for_private_urls_resolved", False)
@@ -105,7 +111,7 @@ class TestHybridRoutingSessionCreation:
             "cdp_url": "wss://fake.browserbase.com/ws",
         }
         monkeypatch.setattr(bt_cloud, "_get_cloud_provider", lambda: provider)
-        monkeypatch.setattr("tools.browser_tool_cdp._ensure_cdp_supervisor", lambda t: None)
+        monkeypatch.setattr("tools.browser_tool_cdp._ensure_cdp_supervisor", lambda *_a, **_kw: None)
 
         session = bt_session._get_session_info("default::local")
 
@@ -125,7 +131,7 @@ class TestHybridRoutingSessionCreation:
             "cdp_url": "wss://real.browserbase.com/ws",
         }
         monkeypatch.setattr(bt_cloud, "_get_cloud_provider", lambda: provider)
-        monkeypatch.setattr("tools.browser_tool_cdp._ensure_cdp_supervisor", lambda t: None)
+        monkeypatch.setattr("tools.browser_tool_cdp._ensure_cdp_supervisor", lambda *_a, **_kw: None)
         monkeypatch.setattr("tools.browser_tool_cdp._resolve_cdp_override", lambda u: u)
 
         session = bt_session._get_session_info("default")

--- a/tests/tools/test_browser_lifecycle_fail_closed.py
+++ b/tests/tools/test_browser_lifecycle_fail_closed.py
@@ -359,6 +359,11 @@ def test_failed_restart_blanking_and_exact_close_stays_fail_closed(monkeypatch):
     monkeypatch.setattr(bt, "check_website_access", lambda _url: None)
     monkeypatch.setattr(bt, "_pinned_cdp_target_id", lambda _task: "TARGET")
     monkeypatch.setattr(bt, "_ensure_cdp_supervisor", lambda *_a, **_kw: None)
+    monkeypatch.setattr(
+        bt,
+        "_close_shared_cdp_target_confirmed",
+        lambda _cdp_url, _target_id: False,
+    )
 
     command_calls: list[tuple[str, list[str]]] = []
 
@@ -374,8 +379,6 @@ def test_failed_restart_blanking_and_exact_close_stays_fail_closed(monkeypatch):
             }
         if command == "open" and args == ["about:blank"]:
             return {"success": False, "error": "blanking failed"}
-        if command == "tab":
-            return {"success": False, "error": "exact close failed"}
         raise AssertionError((command, args))
 
     monkeypatch.setattr(bt, "_run_browser_command", _command)
@@ -388,7 +391,6 @@ def test_failed_restart_blanking_and_exact_close_stays_fail_closed(monkeypatch):
     assert command_calls == [
         ("open", ["https://example.com"]),
         ("open", ["about:blank"]),
-        ("tab", ["close"]),
     ]
 
     # A new explicit navigation is also rejected until exact rollback cleanup
@@ -575,20 +577,28 @@ def test_headed_turn_retains_local_but_cleans_shared_external_cdp(monkeypatch):
         "session_name": "shared-headed",
         "bb_session_id": None,
         "cdp_url": "ws://shared",
+        "target_id": "TARGET-SHARED",
         "features": {"cdp_override": True},
     }
     bt._active_sessions.update({local_task: local, shared_task: shared})
 
-    with patch.object(
-        bt, "_run_browser_command", return_value={"success": True}
-    ) as command:
+    with (
+        patch.object(
+            bt,
+            "_close_shared_cdp_target_confirmed",
+            return_value=True,
+        ),
+        patch.object(
+            bt, "_run_browser_command", return_value={"success": True}
+        ) as command,
+    ):
         assert bt.cleanup_browser_for_turn(local_task) is True
         assert bt.cleanup_browser_for_turn(shared_task) is True
 
     assert bt._active_sessions[local_task] is local
     assert shared_task not in bt._active_sessions
     assert shared_task in bt._retired_browser_tasks
-    assert command.call_count == 2
+    assert command.call_count == 1
 
 
 def test_hard_cleanup_still_closes_untracked_camofox_task(monkeypatch):

--- a/tests/tools/test_browser_lifecycle_fail_closed.py
+++ b/tests/tools/test_browser_lifecycle_fail_closed.py
@@ -32,6 +32,19 @@ def _isolated_browser_lifecycle(monkeypatch):
     monkeypatch.setattr(bt, "_is_camofox_mode", lambda: False)
 
 
+def _observe_cleanup_lock_request(monkeypatch, requested: threading.Event) -> None:
+    """Signal when the named cleanup thread requests the task operation lock."""
+    original = bt._task_cleanup_operation_lock
+
+    def _wrapped(bare_task_id):
+        lock = original(bare_task_id)
+        if threading.current_thread().name == "browser-cleanup-test":
+            requested.set()
+        return lock
+
+    monkeypatch.setattr(bt, "_task_cleanup_operation_lock", _wrapped)
+
+
 @pytest.mark.parametrize("backend", ["local", "provider"])
 def test_real_inactivity_cleanup_is_nonterminal_and_normal_command_recreates(
     monkeypatch,
@@ -169,6 +182,63 @@ def test_provider_cdp_uses_generic_node22_path_and_provider_cleanup(
     provider.close_session.assert_called_once_with("paid-provider-id")
 
 
+def test_real_profile_cdp_keeps_generic_node22_and_local_headed_semantics(
+    monkeypatch,
+    tmp_path,
+):
+    task_id = "real-profile-node22"
+    session = {
+        "session_name": "rp_task_owned_copy",
+        "bb_session_id": None,
+        "cdp_url": "ws://127.0.0.1:9333/devtools/browser/profile-copy",
+        "features": {"local": True, "real_profile": True},
+    }
+    bt._active_sessions[task_id] = session
+
+    resolver_calls: list[bool] = []
+    commands: list[list[str]] = []
+
+    def _resolver(*, require_pin_tab: bool = False):
+        resolver_calls.append(require_pin_tab)
+        if require_pin_tab:
+            raise bt.AgentBrowserCapabilityError("Node >=24 required")
+        return "/tmp/agent-browser-node22"
+
+    class _Proc:
+        returncode = 0
+
+        def __init__(self, argv, *, stdout, stderr, **_kwargs):
+            commands.append(list(argv))
+            os.write(stdout, b'{"success":true,"data":{"snapshot":"ok"}}')
+
+        def wait(self, timeout=None):
+            return self.returncode
+
+        def kill(self):
+            self.returncode = -9
+
+    monkeypatch.setattr(bt, "_find_agent_browser", _resolver)
+    monkeypatch.setattr(bt, "_requires_real_termux_browser_install", lambda _cmd: False)
+    monkeypatch.setattr(bt, "_is_local_mode", lambda: False)
+    monkeypatch.setattr(bt, "_ensure_cdp_supervisor", lambda *_a, **_kw: None)
+    monkeypatch.setattr(bt, "_socket_safe_tmpdir", lambda: str(tmp_path))
+    monkeypatch.setattr(bt, "_write_owner_pid", lambda *_a: None)
+    monkeypatch.setattr(bt, "_build_browser_env", lambda: {"PATH": "/usr/bin"})
+    monkeypatch.setattr(bt, "_merge_browser_path", lambda value: value)
+    monkeypatch.setattr(bt, "_needs_chromium_sandbox_bypass", lambda: False)
+    monkeypatch.setattr(bt.subprocess, "Popen", _Proc)
+    monkeypatch.setattr("tools.interrupt.is_interrupted", lambda: False)
+
+    assert bt._is_task_owned_shared_cdp_session(session) is False
+    assert bt._is_hermes_owned_local_browser_session(session) is True
+    result = bt._run_browser_command(task_id, "snapshot", ["-c"])
+
+    assert result["success"] is True
+    assert resolver_calls == [False]
+    assert commands[0][1:3] == ["--cdp", session["cdp_url"]]
+    assert "--pin-tab" not in commands[0]
+
+
 def test_provider_api_close_is_not_blocked_by_local_tab_capability(monkeypatch):
     task_id = "provider-close-authoritative"
     provider = MagicMock()
@@ -201,6 +271,49 @@ def test_provider_api_close_is_not_blocked_by_local_tab_capability(monkeypatch):
         _allow_cleanup=True,
     )
     provider.close_session.assert_called_once_with("provider-close-id")
+
+
+def test_shared_cdp_timeout_enters_exact_nonterminal_cleanup(monkeypatch):
+    task_id = "shared-timeout-exact-cleanup"
+    session = {
+        "session_name": "cdp_timeout",
+        "bb_session_id": None,
+        "cdp_url": "ws://shared",
+        "target_id": "TARGET-TIMEOUT",
+        "features": {"cdp_override": True},
+    }
+    bt._active_sessions[task_id] = session
+    cleanup = MagicMock(return_value=True)
+    discard = MagicMock()
+    monkeypatch.setattr(bt, "_cleanup_browser_session_keys", cleanup)
+    monkeypatch.setattr(bt, "_discard_timed_out_browser_session", discard)
+
+    bt._handle_browser_command_timeout(task_id, session, "/tmp/not-used")
+
+    cleanup.assert_called_once_with(
+        task_id,
+        [task_id],
+        reason=bt.BrowserCleanupReason.INACTIVITY,
+    )
+    discard.assert_not_called()
+
+
+def test_shared_cdp_timeout_without_exact_target_stays_fail_closed():
+    task_id = "shared-timeout-missing-target"
+    session = {
+        "session_name": "cdp_timeout_missing",
+        "bb_session_id": None,
+        "cdp_url": "ws://shared",
+        "features": {"cdp_override": True},
+    }
+    bt._active_sessions[task_id] = session
+
+    bt._handle_browser_command_timeout(task_id, session, "/tmp/not-used")
+
+    assert bt._active_sessions[task_id] is session
+    assert session["_cleanup_retry_pending"] is True
+    assert bt._browser_task_states[task_id] is bt.BrowserTaskState.RETIRING
+    assert bt._is_browser_task_unavailable(task_id) is True
 
 
 def test_cleanup_command_ignores_turn_interrupt(monkeypatch, tmp_path):
@@ -566,6 +679,7 @@ def test_headed_turn_retains_local_but_cleans_shared_external_cdp(monkeypatch):
     monkeypatch.setattr(bt.os.path, "exists", lambda _path: False)
 
     local_task = "headed-local"
+    real_profile_task = "headed-real-profile"
     shared_task = "headed-shared"
     local = {
         "session_name": "local-headed",
@@ -580,7 +694,19 @@ def test_headed_turn_retains_local_but_cleans_shared_external_cdp(monkeypatch):
         "target_id": "TARGET-SHARED",
         "features": {"cdp_override": True},
     }
-    bt._active_sessions.update({local_task: local, shared_task: shared})
+    real_profile = {
+        "session_name": "rp-headed",
+        "bb_session_id": None,
+        "cdp_url": "ws://real-profile-copy",
+        "features": {"local": True, "real_profile": True},
+    }
+    bt._active_sessions.update(
+        {
+            local_task: local,
+            real_profile_task: real_profile,
+            shared_task: shared,
+        }
+    )
 
     with (
         patch.object(
@@ -593,9 +719,11 @@ def test_headed_turn_retains_local_but_cleans_shared_external_cdp(monkeypatch):
         ) as command,
     ):
         assert bt.cleanup_browser_for_turn(local_task) is True
+        assert bt.cleanup_browser_for_turn(real_profile_task) is True
         assert bt.cleanup_browser_for_turn(shared_task) is True
 
     assert bt._active_sessions[local_task] is local
+    assert bt._active_sessions[real_profile_task] is real_profile
     assert shared_task not in bt._active_sessions
     assert shared_task in bt._retired_browser_tasks
     assert command.call_count == 1
@@ -634,6 +762,235 @@ def test_headed_turn_preserves_untracked_camofox_task(monkeypatch):
     soft_cleanup.assert_not_called()
     assert task_id not in bt._browser_task_states
     assert task_id not in bt._retired_browser_tasks
+
+
+def test_browser_free_camofox_turn_does_not_allocate_lifecycle_rows(monkeypatch):
+    task_id = "camofox-browser-free"
+    monkeypatch.setattr(bt, "_is_headed_mode", lambda: False)
+    monkeypatch.setattr(bt, "_is_camofox_mode", lambda: True)
+    monkeypatch.setattr(
+        "tools.browser_camofox.camofox_has_session",
+        lambda _task: False,
+    )
+    soft_cleanup = MagicMock()
+    monkeypatch.setattr("tools.browser_camofox.camofox_soft_cleanup", soft_cleanup)
+
+    assert bt.cleanup_browser_for_turn(task_id) is True
+
+    soft_cleanup.assert_not_called()
+    assert task_id not in bt._browser_task_states
+    assert task_id not in bt._browser_task_generations
+    assert task_id not in bt._browser_task_cleanup_locks
+
+
+def test_browser_free_camofox_fast_path_waits_for_inflight_navigation(monkeypatch):
+    task_id = "camofox-navigation-transaction"
+    nav_entered = threading.Event()
+    release_nav = threading.Event()
+    cleanup_lock_requested = threading.Event()
+    cleanup_done = threading.Event()
+    events: list[str] = []
+
+    monkeypatch.setattr(bt, "_is_headed_mode", lambda: False)
+    monkeypatch.setattr(bt, "_is_camofox_mode", lambda: True)
+    monkeypatch.setattr(bt, "_is_always_blocked_url", lambda _url: False)
+    monkeypatch.setattr(bt, "_is_local_backend", lambda: True)
+    monkeypatch.setattr(bt, "check_website_access", lambda _url: None)
+    monkeypatch.setattr(
+        "tools.browser_camofox.camofox_has_session",
+        lambda _task: False,
+    )
+
+    def _navigate(_url, _task):
+        events.append("navigation-start")
+        nav_entered.set()
+        assert release_nav.wait(timeout=3)
+        events.append("navigation-end")
+        return json.dumps({"success": True})
+
+    def _soft_cleanup(_task):
+        events.append("cleanup")
+        return True
+
+    monkeypatch.setattr("tools.browser_camofox.camofox_navigate", _navigate)
+    monkeypatch.setattr("tools.browser_camofox.camofox_soft_cleanup", _soft_cleanup)
+    _observe_cleanup_lock_request(monkeypatch, cleanup_lock_requested)
+
+    nav_result: list[str] = []
+    nav_thread = threading.Thread(
+        target=lambda: nav_result.append(
+            bt.browser_navigate("https://example.com", task_id)
+        )
+    )
+    cleanup_thread = threading.Thread(
+        target=lambda: (bt.cleanup_browser_for_turn(task_id), cleanup_done.set()),
+        name="browser-cleanup-test",
+    )
+
+    nav_thread.start()
+    assert nav_entered.wait(timeout=3)
+    cleanup_thread.start()
+    assert cleanup_lock_requested.wait(timeout=3)
+    assert not cleanup_done.is_set()
+
+    release_nav.set()
+    nav_thread.join(timeout=4)
+    cleanup_thread.join(timeout=4)
+
+    assert not nav_thread.is_alive()
+    assert not cleanup_thread.is_alive()
+    assert json.loads(nav_result[0])["success"] is True
+    assert events == ["navigation-start", "navigation-end", "cleanup"]
+
+
+def test_browser_free_turn_cleanup_does_not_allocate_lifecycle_rows():
+    """Per-turn finalization is a no-op when the task never used a browser."""
+    for index in range(100):
+        assert bt.cleanup_browser_for_turn(f"browser-free-{index}") is True
+
+    assert bt._browser_task_states == {}
+    assert bt._browser_task_generations == {}
+    assert bt._browser_task_cleanup_reasons == {}
+    assert bt._browser_task_cleanup_locks == {}
+    assert bt._retired_browser_tasks == set()
+
+
+def test_navigation_holds_task_lifecycle_lock_through_snapshot(monkeypatch):
+    task_id = "navigation-transaction"
+    session = {
+        "session_name": "navigation-transaction",
+        "bb_session_id": None,
+        "cdp_url": None,
+        "features": {"local": True},
+        "_first_nav": False,
+    }
+    nav_entered = threading.Event()
+    release_nav = threading.Event()
+    cleanup_lock_requested = threading.Event()
+    cleanup_done = threading.Event()
+    events: list[str] = []
+
+    monkeypatch.setattr(bt, "_navigation_session_key", lambda _task, _url: task_id)
+    monkeypatch.setattr(bt, "_is_always_blocked_url", lambda _url: False)
+    monkeypatch.setattr(bt, "_is_local_backend", lambda: True)
+    monkeypatch.setattr(bt, "check_website_access", lambda _url: None)
+    monkeypatch.setattr(bt, "_is_camofox_mode", lambda: False)
+    monkeypatch.setattr(bt, "_clear_retired_browser_task_for_navigation", lambda _task: False)
+    monkeypatch.setattr(bt, "_get_open_command_timeout", lambda **_kwargs: 10)
+    monkeypatch.setattr(bt, "_maybe_start_recording", lambda _task: None)
+
+    def _get_session_info(_task):
+        events.append("session-start")
+        nav_entered.set()
+        assert release_nav.wait(timeout=3)
+        bt._active_sessions[task_id] = session
+        events.append("session-end")
+        return session
+
+    monkeypatch.setattr(bt, "_get_session_info", _get_session_info)
+
+    def _run(_session_key, command, _args, **_kwargs):
+        if command == "open":
+            events.append("open")
+            return {"success": True, "data": {"url": "https://example.com", "title": "Example"}}
+        events.append(command)
+        return {"success": True, "data": {"snapshot": "ok", "refs": {}}}
+
+    monkeypatch.setattr(bt, "_run_browser_command", _run)
+    _observe_cleanup_lock_request(monkeypatch, cleanup_lock_requested)
+    nav_result: list[str] = []
+    nav_thread = threading.Thread(
+        target=lambda: nav_result.append(bt.browser_navigate("https://example.com", task_id))
+    )
+    cleanup_thread = threading.Thread(
+        target=lambda: (bt.cleanup_browser(task_id), cleanup_done.set()),
+        name="browser-cleanup-test",
+    )
+
+    nav_thread.start()
+    assert nav_entered.wait(timeout=3)
+    cleanup_thread.start()
+    assert cleanup_lock_requested.wait(timeout=3)
+    assert not cleanup_done.is_set()
+
+    release_nav.set()
+    nav_thread.join(timeout=4)
+    cleanup_thread.join(timeout=4)
+
+    assert not nav_thread.is_alive()
+    assert not cleanup_thread.is_alive()
+    assert json.loads(nav_result[0])["success"] is True
+    assert events == ["session-start", "session-end", "open", "snapshot", "close"]
+
+
+def test_browser_dialog_is_blocked_by_retired_task(monkeypatch):
+    from tools import browser_dialog_tool
+
+    task_id = "dialog-retired"
+    bt._retired_browser_tasks.add(task_id)
+    supervisor = MagicMock()
+    monkeypatch.setattr(
+        browser_dialog_tool.SUPERVISOR_REGISTRY,
+        "get",
+        lambda _task: supervisor,
+    )
+
+    result = json.loads(browser_dialog_tool.browser_dialog(action="dismiss", task_id=task_id))
+
+    assert result["code"] == "browser_session_retired"
+    supervisor.respond_to_dialog.assert_not_called()
+
+
+def test_browser_dialog_waits_for_terminal_cleanup(monkeypatch):
+    from tools import browser_dialog_tool
+
+    task_id = "dialog-cleanup-race"
+    bt._active_sessions[task_id] = {
+        "session_name": "dialog-cleanup-race",
+        "bb_session_id": None,
+        "cdp_url": None,
+        "features": {"local": True},
+    }
+    dialog_entered = threading.Event()
+    release_dialog = threading.Event()
+    cleanup_lock_requested = threading.Event()
+    cleanup_done = threading.Event()
+    supervisor = MagicMock()
+
+    def _respond(**_kwargs):
+        dialog_entered.set()
+        assert release_dialog.wait(timeout=3)
+        return {"ok": True, "dialog": {"id": "d-1"}}
+
+    supervisor.respond_to_dialog.side_effect = _respond
+    monkeypatch.setattr(browser_dialog_tool.SUPERVISOR_REGISTRY, "get", lambda _task: supervisor)
+    monkeypatch.setattr(bt, "_run_browser_command", lambda *_args, **_kwargs: {"success": True})
+    monkeypatch.setattr(bt.os.path, "exists", lambda _path: False)
+    _observe_cleanup_lock_request(monkeypatch, cleanup_lock_requested)
+
+    dialog_result: list[str] = []
+    dialog_thread = threading.Thread(
+        target=lambda: dialog_result.append(
+            browser_dialog_tool.browser_dialog(action="dismiss", task_id=task_id)
+        )
+    )
+    cleanup_thread = threading.Thread(
+        target=lambda: (bt.cleanup_browser(task_id), cleanup_done.set()),
+        name="browser-cleanup-test",
+    )
+    dialog_thread.start()
+    assert dialog_entered.wait(timeout=3)
+    cleanup_thread.start()
+    assert cleanup_lock_requested.wait(timeout=3)
+    assert not cleanup_done.is_set()
+
+    release_dialog.set()
+    dialog_thread.join(timeout=4)
+    cleanup_thread.join(timeout=4)
+
+    assert not dialog_thread.is_alive()
+    assert not cleanup_thread.is_alive()
+    assert json.loads(dialog_result[0])["success"] is True
 
 
 @pytest.mark.parametrize("exit_kind", ["direct_return", "exception", "cancellation"])
@@ -729,6 +1086,7 @@ def test_terminal_cleanup_waits_for_inflight_subprocess_command(monkeypatch):
     }
     command_entered = threading.Event()
     release_command = threading.Event()
+    cleanup_lock_requested = threading.Event()
     cleanup_done = threading.Event()
     events: list[str] = []
 
@@ -753,6 +1111,10 @@ def test_terminal_cleanup_waits_for_inflight_subprocess_command(monkeypatch):
 
     monkeypatch.setattr(bt, "_find_agent_browser", lambda **_kwargs: "/tmp/fake-agent-browser")
     monkeypatch.setattr(bt.subprocess, "Popen", _Popen)
+    # The local-Chromium fast-fail gate must not short-circuit this test's
+    # fake Popen path: this host may have no real Chromium installed.
+    monkeypatch.setattr(bt, "_is_local_mode", lambda: False)
+    _observe_cleanup_lock_request(monkeypatch, cleanup_lock_requested)
     command_result: list[dict] = []
     cleanup_result: list[bool] = []
     command_thread = threading.Thread(
@@ -765,11 +1127,12 @@ def test_terminal_cleanup_waits_for_inflight_subprocess_command(monkeypatch):
         cleanup_result.append(bt.cleanup_browser(task_id))
         cleanup_done.set()
 
-    cleanup_thread = threading.Thread(target=_cleanup)
+    cleanup_thread = threading.Thread(target=_cleanup, name="browser-cleanup-test")
     command_thread.start()
     assert command_entered.wait(timeout=3)
     cleanup_thread.start()
-    assert not cleanup_done.wait(timeout=0.1)
+    assert cleanup_lock_requested.wait(timeout=3)
+    assert not cleanup_done.is_set()
 
     release_command.set()
     command_thread.join(timeout=4)
@@ -795,6 +1158,7 @@ def test_terminal_cleanup_waits_for_inflight_supervisor_eval(monkeypatch):
     }
     eval_entered = threading.Event()
     release_eval = threading.Event()
+    cleanup_lock_requested = threading.Event()
     cleanup_done = threading.Event()
     events: list[str] = []
 
@@ -821,6 +1185,10 @@ def test_terminal_cleanup_waits_for_inflight_supervisor_eval(monkeypatch):
 
     monkeypatch.setattr(bt, "_find_agent_browser", lambda **_kwargs: "/tmp/fake-agent-browser")
     monkeypatch.setattr(bt.subprocess, "Popen", _Popen)
+    # The local-Chromium fast-fail gate must not short-circuit this test's
+    # fake close Popen: this host may have no real Chromium installed.
+    monkeypatch.setattr(bt, "_is_local_mode", lambda: False)
+    _observe_cleanup_lock_request(monkeypatch, cleanup_lock_requested)
     eval_result: list[dict] = []
     cleanup_result: list[bool] = []
     eval_thread = threading.Thread(
@@ -833,11 +1201,12 @@ def test_terminal_cleanup_waits_for_inflight_supervisor_eval(monkeypatch):
         cleanup_result.append(bt.cleanup_browser(task_id))
         cleanup_done.set()
 
-    cleanup_thread = threading.Thread(target=_cleanup)
+    cleanup_thread = threading.Thread(target=_cleanup, name="browser-cleanup-test")
     eval_thread.start()
     assert eval_entered.wait(timeout=3)
     cleanup_thread.start()
-    assert not cleanup_done.wait(timeout=0.1)
+    assert cleanup_lock_requested.wait(timeout=3)
+    assert not cleanup_done.is_set()
 
     release_eval.set()
     eval_thread.join(timeout=4)

--- a/tests/tools/test_browser_lifecycle_fail_closed.py
+++ b/tests/tools/test_browser_lifecycle_fail_closed.py
@@ -1,0 +1,841 @@
+"""Focused regressions for task-owned shared-CDP lifecycle fencing."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import threading
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from tools import browser_tool as bt
+
+
+@pytest.fixture(autouse=True)
+def _isolated_browser_lifecycle(monkeypatch):
+    monkeypatch.setattr(bt, "_active_sessions", {})
+    monkeypatch.setattr(bt, "_session_last_activity", {})
+    monkeypatch.setattr(bt, "_last_active_session_key", {})
+    monkeypatch.setattr(bt, "_retired_browser_tasks", set())
+    monkeypatch.setattr(bt, "_browser_task_states", {})
+    monkeypatch.setattr(bt, "_browser_task_generations", {})
+    monkeypatch.setattr(bt, "_browser_task_cleanup_reasons", {})
+    monkeypatch.setattr(bt, "_browser_task_cleanup_locks", {})
+    monkeypatch.setattr(bt, "_pending_provider_cleanups", {})
+    monkeypatch.setattr(bt, "_start_browser_cleanup_thread", lambda: None)
+    monkeypatch.setattr(bt, "_stop_cdp_supervisor", lambda _task: None)
+    monkeypatch.setattr(bt, "_maybe_stop_recording", lambda _task: None)
+    monkeypatch.setattr(bt, "_maybe_start_recording", lambda _task: None)
+    monkeypatch.setattr(bt, "_is_camofox_mode", lambda: False)
+
+
+@pytest.mark.parametrize("backend", ["local", "provider"])
+def test_real_inactivity_cleanup_is_nonterminal_and_normal_command_recreates(
+    monkeypatch,
+    backend,
+):
+    task_id = f"idle-{backend}"
+    now = 10_000.0
+
+    provider = MagicMock()
+    provider.close_session.return_value = True
+    provider.create_session.return_value = {
+        "session_name": "provider-new",
+        "bb_session_id": "provider-new-id",
+        "cdp_url": "wss://provider.example/new",
+        "features": {},
+    }
+    if backend == "provider":
+        old_session = {
+            "session_name": "provider-old",
+            "bb_session_id": "provider-old-id",
+            "cdp_url": "wss://provider.example/old",
+            "features": {},
+            "_provider_cleanup_owner": provider,
+        }
+    else:
+        old_session = {
+            "session_name": "local-old",
+            "bb_session_id": None,
+            "cdp_url": None,
+            "features": {"local": True},
+        }
+
+    bt._active_sessions[task_id] = old_session
+    bt._session_last_activity[task_id] = now - 100
+    monkeypatch.setattr(bt, "BROWSER_SESSION_INACTIVITY_TIMEOUT", 10)
+    monkeypatch.setattr(bt.time, "time", lambda: now)
+    monkeypatch.setattr(bt.os.path, "exists", lambda _path: False)
+    monkeypatch.setattr(bt, "_get_cdp_override", lambda: "")
+    monkeypatch.setattr(
+        bt,
+        "_get_cloud_provider",
+        (lambda: provider) if backend == "provider" else (lambda: None),
+    )
+    monkeypatch.setattr(bt, "_resolve_cdp_override", lambda value: value)
+    monkeypatch.setattr(bt, "_ensure_cdp_supervisor", lambda *_a, **_kw: None)
+
+    with patch.object(bt, "_run_browser_command", return_value={"success": True}):
+        bt._cleanup_inactive_browser_sessions()
+
+    assert task_id not in bt._active_sessions
+    assert task_id not in bt._retired_browser_tasks
+    assert bt._browser_task_states[task_id] is bt.BrowserTaskState.ACTIVE
+
+    # Drive the same implicit session lookup used by a normal snapshot command.
+    monkeypatch.setattr(bt, "_is_local_backend", lambda: True)
+
+    def _normal_snapshot(session_key, command, args, **_kwargs):
+        assert command == "snapshot"
+        session = bt._get_session_info(session_key)
+        return {
+            "success": True,
+            "data": {"snapshot": session["session_name"], "refs": {}},
+        }
+
+    monkeypatch.setattr(bt, "_run_browser_command", _normal_snapshot)
+    result = json.loads(bt.browser_snapshot(task_id=task_id))
+
+    assert result["success"] is True
+    assert bt._active_sessions[task_id] is not old_session
+    if backend == "provider":
+        provider.close_session.assert_called_once_with("provider-old-id")
+        provider.create_session.assert_called_once_with(task_id)
+    else:
+        assert bt._active_sessions[task_id]["features"]["local"] is True
+
+
+def test_provider_cdp_uses_generic_node22_path_and_provider_cleanup(
+    monkeypatch, tmp_path
+):
+    task_id = "provider-node22"
+    provider = MagicMock()
+    provider.close_session.return_value = True
+    session = {
+        "session_name": "provider-session",
+        "bb_session_id": "paid-provider-id",
+        "cdp_url": "wss://provider.example/devtools/browser/paid",
+        "features": {},
+        "_provider_cleanup_owner": provider,
+    }
+    bt._active_sessions[task_id] = session
+    bt._session_last_activity[task_id] = 1.0
+
+    resolver_calls: list[bool] = []
+    commands: list[list[str]] = []
+
+    def _resolver(*, require_pin_tab: bool = False):
+        resolver_calls.append(require_pin_tab)
+        if require_pin_tab:
+            raise bt.AgentBrowserCapabilityError("Node >=24 required")
+        return "/tmp/agent-browser-node22"
+
+    class _Proc:
+        returncode = 0
+
+        def __init__(self, argv, *, stdout, stderr, **_kwargs):
+            commands.append(list(argv))
+            os.write(stdout, b'{"success":true,"data":{"snapshot":"ok"}}')
+
+        def wait(self, timeout=None):
+            return self.returncode
+
+        def kill(self):
+            self.returncode = -9
+
+    monkeypatch.setattr(bt, "_find_agent_browser", _resolver)
+    monkeypatch.setattr(bt, "_requires_real_termux_browser_install", lambda _cmd: False)
+    monkeypatch.setattr(bt, "_is_local_mode", lambda: False)
+    monkeypatch.setattr(bt, "_socket_safe_tmpdir", lambda: str(tmp_path))
+    monkeypatch.setattr(bt, "_write_owner_pid", lambda *_a: None)
+    monkeypatch.setattr(bt, "_build_browser_env", lambda: {"PATH": "/usr/bin"})
+    monkeypatch.setattr(bt, "_merge_browser_path", lambda value: value)
+    monkeypatch.setattr(bt, "_needs_chromium_sandbox_bypass", lambda: False)
+    monkeypatch.setattr(bt.subprocess, "Popen", _Proc)
+    monkeypatch.setattr("tools.interrupt.is_interrupted", lambda: False)
+
+    command_result = bt._run_browser_command(task_id, "snapshot", ["-c"])
+    cleanup_result = bt.cleanup_browser(task_id)
+
+    assert command_result["success"] is True
+    assert cleanup_result is True
+    assert resolver_calls == [False, False]
+    assert all("--pin-tab" not in argv for argv in commands)
+    assert all("agent-browser@0.34.0" not in argv for argv in commands)
+    assert commands[0][1:3] == ["--cdp", session["cdp_url"]]
+    provider.close_session.assert_called_once_with("paid-provider-id")
+
+
+def test_provider_api_close_is_not_blocked_by_local_tab_capability(monkeypatch):
+    task_id = "provider-close-authoritative"
+    provider = MagicMock()
+    provider.close_session.return_value = True
+    bt._active_sessions[task_id] = {
+        "session_name": "provider-close",
+        "bb_session_id": "provider-close-id",
+        "cdp_url": "wss://provider.example/close",
+        "features": {},
+        "_provider_cleanup_owner": provider,
+    }
+    monkeypatch.setattr(bt.os.path, "exists", lambda _path: False)
+
+    with patch.object(
+        bt,
+        "_run_browser_command",
+        return_value={
+            "success": False,
+            "code": "pin_tab_unavailable",
+            "error": "Node >=24 required",
+        },
+    ) as command:
+        assert bt.cleanup_browser(task_id) is True
+
+    command.assert_called_once_with(
+        task_id,
+        "close",
+        [],
+        timeout=10,
+        _allow_cleanup=True,
+    )
+    provider.close_session.assert_called_once_with("provider-close-id")
+
+
+def test_cleanup_command_ignores_turn_interrupt(monkeypatch, tmp_path):
+    task_id = "cleanup-during-cancellation"
+    bt._active_sessions[task_id] = {
+        "session_name": "cleanup-during-cancellation",
+        "bb_session_id": None,
+        "cdp_url": None,
+        "features": {"local": True},
+    }
+    commands: list[list[str]] = []
+
+    class _Proc:
+        returncode = 0
+
+        def __init__(self, argv, *, stdout, stderr, **_kwargs):
+            commands.append(list(argv))
+            os.write(stdout, b'{"success":true,"data":{}}')
+
+        def wait(self, timeout=None):
+            return self.returncode
+
+        def kill(self):
+            self.returncode = -9
+
+    monkeypatch.setattr(
+        bt, "_find_agent_browser", lambda **_kwargs: "/tmp/agent-browser"
+    )
+    monkeypatch.setattr(bt, "_requires_real_termux_browser_install", lambda _cmd: False)
+    monkeypatch.setattr(bt, "_is_local_mode", lambda: False)
+    monkeypatch.setattr(bt, "_socket_safe_tmpdir", lambda: str(tmp_path))
+    monkeypatch.setattr(bt, "_write_owner_pid", lambda *_a: None)
+    monkeypatch.setattr(bt, "_build_browser_env", lambda: {"PATH": "/usr/bin"})
+    monkeypatch.setattr(bt, "_merge_browser_path", lambda value: value)
+    monkeypatch.setattr(bt, "_needs_chromium_sandbox_bypass", lambda: False)
+    monkeypatch.setattr(bt.subprocess, "Popen", _Proc)
+    monkeypatch.setattr("tools.interrupt.is_interrupted", lambda: True)
+
+    result = bt._run_browser_command(
+        task_id,
+        "close",
+        [],
+        _allow_cleanup=True,
+    )
+
+    assert result["success"] is True
+    assert len(commands) == 1
+
+
+@pytest.mark.parametrize("failure", ["false", "exception"])
+def test_provider_close_failure_retains_retry_identity_until_success(
+    monkeypatch,
+    failure,
+):
+    task_id = f"provider-retry-{failure}"
+    calls: list[str] = []
+
+    class _Provider:
+        def close_session(self, session_id):
+            calls.append(session_id)
+            if len(calls) == 1:
+                if failure == "exception":
+                    raise RuntimeError("provider unavailable")
+                return False
+            return True
+
+    provider = _Provider()
+    bt._active_sessions[task_id] = {
+        "session_name": "provider-retry",
+        "bb_session_id": "provider-retry-id",
+        "cdp_url": "wss://provider.example/retry",
+        "features": {},
+        "_provider_cleanup_owner": provider,
+    }
+    monkeypatch.setattr(bt.os.path, "exists", lambda _path: False)
+
+    with patch.object(bt, "_run_browser_command", return_value={"success": True}):
+        assert bt.cleanup_browser(task_id) is False
+
+    assert task_id not in bt._active_sessions
+    pending = list(bt._pending_provider_cleanups.values())
+    assert [(item.provider, item.session_id) for item in pending] == [
+        (provider, "provider-retry-id")
+    ]
+    assert bt._browser_task_states[task_id] is bt.BrowserTaskState.RETIRING
+
+    find_browser = MagicMock()
+    monkeypatch.setattr(bt, "_find_agent_browser", find_browser)
+    blocked = json.loads(bt.browser_snapshot(task_id=task_id))
+    assert blocked["code"] == "browser_session_retired"
+    assert blocked["data"]["cleanup_pending"] is True
+    find_browser.assert_not_called()
+
+    # Retry only the retained provider identity. No page lookup/adoption occurs.
+    get_session = MagicMock()
+    monkeypatch.setattr(bt, "_get_session_info", get_session)
+    assert bt.cleanup_browser(task_id) is True
+    assert calls == ["provider-retry-id", "provider-retry-id"]
+    assert bt._pending_provider_cleanups == {}
+    assert task_id in bt._retired_browser_tasks
+    get_session.assert_not_called()
+
+
+def test_cleanup_pending_blocks_all_business_commands_and_supervisor_eval(monkeypatch):
+    from tools.browser_supervisor import SUPERVISOR_REGISTRY
+
+    task_id = "cleanup-pending-all-commands"
+    session = {
+        "session_name": "cdp-pending",
+        "bb_session_id": None,
+        "cdp_url": "ws://shared",
+        "features": {"cdp_override": True},
+    }
+    bt._active_sessions[task_id] = session
+    bt._last_active_session_key[task_id] = task_id
+
+    with patch.object(
+        bt,
+        "_run_browser_command",
+        return_value={"success": False, "error": "exact close unavailable"},
+    ):
+        assert bt.cleanup_browser(task_id) is False
+
+    monkeypatch.setattr(bt, "_eval_ssrf_guard_active", lambda _task: False)
+    find_browser = MagicMock()
+    supervisor_get = MagicMock()
+    monkeypatch.setattr(bt, "_find_agent_browser", find_browser)
+    monkeypatch.setattr(SUPERVISOR_REGISTRY, "get", supervisor_get)
+
+    results = [
+        json.loads(bt.browser_snapshot(task_id=task_id)),
+        json.loads(bt.browser_click("@e1", task_id=task_id)),
+        json.loads(bt.browser_type("@e1", "value", task_id=task_id)),
+        json.loads(
+            bt.browser_console(expression="window.sideEffect++", task_id=task_id)
+        ),
+    ]
+
+    assert all(result["code"] == "browser_session_retired" for result in results)
+    assert all(result["data"]["cleanup_pending"] is True for result in results)
+    find_browser.assert_not_called()
+    supervisor_get.assert_not_called()
+
+
+def test_failed_restart_blanking_and_exact_close_stays_fail_closed(monkeypatch):
+    task_id = "failed-restart-three-stage"
+    bt._retired_browser_tasks.add(task_id)
+    monkeypatch.setattr(bt, "_navigation_session_key", lambda task, _url: task)
+    monkeypatch.setattr(bt, "_get_cdp_override", lambda: "ws://shared")
+    monkeypatch.setattr(bt, "_is_local_backend", lambda: True)
+    monkeypatch.setattr(
+        bt,
+        "_is_always_blocked_url",
+        lambda url: url == "http://blocked.internal/",
+    )
+    monkeypatch.setattr(bt, "check_website_access", lambda _url: None)
+    monkeypatch.setattr(bt, "_pinned_cdp_target_id", lambda _task: "TARGET")
+    monkeypatch.setattr(bt, "_ensure_cdp_supervisor", lambda *_a, **_kw: None)
+
+    command_calls: list[tuple[str, list[str]]] = []
+
+    def _command(_task, command, args, **_kwargs):
+        command_calls.append((command, list(args)))
+        if command == "open" and args == ["https://example.com"]:
+            return {
+                "success": True,
+                "data": {
+                    "url": "http://blocked.internal/",
+                    "title": "blocked",
+                },
+            }
+        if command == "open" and args == ["about:blank"]:
+            return {"success": False, "error": "blanking failed"}
+        if command == "tab":
+            return {"success": False, "error": "exact close failed"}
+        raise AssertionError((command, args))
+
+    monkeypatch.setattr(bt, "_run_browser_command", _command)
+
+    result = json.loads(bt.browser_navigate("https://example.com", task_id=task_id))
+
+    assert result["success"] is False
+    assert bt._browser_task_states[task_id] is bt.BrowserTaskState.RETIRING
+    assert bt._active_sessions[task_id]["_cleanup_retry_pending"] is True
+    assert command_calls == [
+        ("open", ["https://example.com"]),
+        ("open", ["about:blank"]),
+        ("tab", ["close"]),
+    ]
+
+    # A new explicit navigation is also rejected until exact rollback cleanup
+    # completes; it cannot silently start another generation.
+    blocked = json.loads(bt.browser_navigate("https://example.org", task_id=task_id))
+    assert blocked["code"] == "browser_session_retired"
+    assert blocked["data"]["cleanup_pending"] is True
+
+
+def test_two_provider_creators_close_the_loser(monkeypatch):
+    task_id = "provider-creator-race"
+    barrier = threading.Barrier(2)
+    created: list[str] = []
+    closed: list[str] = []
+    list_lock = threading.Lock()
+
+    class _Provider:
+        def create_session(self, _task_id):
+            with list_lock:
+                index = len(created) + 1
+                session_id = f"provider-{index}"
+                created.append(session_id)
+            barrier.wait(timeout=3)
+            return {
+                "session_name": f"provider-session-{index}",
+                "bb_session_id": session_id,
+                "cdp_url": f"wss://provider.example/{index}",
+                "features": {},
+            }
+
+        def close_session(self, session_id):
+            closed.append(session_id)
+            return True
+
+    provider = _Provider()
+    monkeypatch.setattr(bt, "_get_cdp_override", lambda: "")
+    monkeypatch.setattr(bt, "_get_cloud_provider", lambda: provider)
+    monkeypatch.setattr(bt, "_resolve_cdp_override", lambda value: value)
+    monkeypatch.setattr(bt, "_ensure_cdp_supervisor", lambda *_a, **_kw: None)
+
+    results: list[dict] = []
+    threads = [
+        threading.Thread(target=lambda: results.append(bt._get_session_info(task_id)))
+        for _ in range(2)
+    ]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=4)
+
+    assert all(not thread.is_alive() for thread in threads)
+    assert len(created) == 2
+    assert len(closed) == 1
+    assert closed[0] != bt._active_sessions[task_id]["bb_session_id"]
+    assert {result["bb_session_id"] for result in results} == {
+        bt._active_sessions[task_id]["bb_session_id"]
+    }
+
+
+def test_terminal_cleanup_fences_inflight_provider_creator(monkeypatch):
+    task_id = "provider-create-vs-terminal"
+    entered = threading.Event()
+    release = threading.Event()
+    closed: list[str] = []
+
+    class _Provider:
+        def create_session(self, _task_id):
+            entered.set()
+            assert release.wait(timeout=3)
+            return {
+                "session_name": "late-provider",
+                "bb_session_id": "late-provider-id",
+                "cdp_url": "wss://provider.example/late",
+                "features": {},
+            }
+
+        def close_session(self, session_id):
+            closed.append(session_id)
+            return True
+
+    provider = _Provider()
+    monkeypatch.setattr(bt, "_get_cdp_override", lambda: "")
+    monkeypatch.setattr(bt, "_get_cloud_provider", lambda: provider)
+    monkeypatch.setattr(bt, "_resolve_cdp_override", lambda value: value)
+    monkeypatch.setattr(bt, "_ensure_cdp_supervisor", lambda *_a, **_kw: None)
+
+    errors: list[BaseException] = []
+
+    def _create():
+        try:
+            bt._get_session_info(task_id)
+        except BaseException as exc:
+            errors.append(exc)
+
+    thread = threading.Thread(target=_create)
+    thread.start()
+    assert entered.wait(timeout=3)
+
+    assert bt.cleanup_browser(task_id) is True
+    assert bt._browser_task_states[task_id] is bt.BrowserTaskState.RETIRED
+    release.set()
+    thread.join(timeout=4)
+
+    assert not thread.is_alive()
+    assert task_id not in bt._active_sessions
+    assert closed == ["late-provider-id"]
+    assert len(errors) == 1
+    assert isinstance(errors[0], bt._BrowserSessionRetiredError)
+
+
+def test_late_stale_creator_close_failure_reopens_only_cleanup_state(monkeypatch):
+    task_id = "provider-create-late-close-retry"
+    entered = threading.Event()
+    release = threading.Event()
+    close_calls: list[str] = []
+
+    class _Provider:
+        def create_session(self, _task_id):
+            entered.set()
+            assert release.wait(timeout=3)
+            return {
+                "session_name": "late-provider-retry",
+                "bb_session_id": "late-provider-retry-id",
+                "cdp_url": "wss://provider.example/late-retry",
+                "features": {},
+            }
+
+        def close_session(self, session_id):
+            close_calls.append(session_id)
+            return len(close_calls) > 1
+
+    provider = _Provider()
+    monkeypatch.setattr(bt, "_get_cdp_override", lambda: "")
+    monkeypatch.setattr(bt, "_get_cloud_provider", lambda: provider)
+    monkeypatch.setattr(bt, "_resolve_cdp_override", lambda value: value)
+    monkeypatch.setattr(bt, "_ensure_cdp_supervisor", lambda *_a, **_kw: None)
+
+    errors: list[BaseException] = []
+
+    def _create():
+        try:
+            bt._get_session_info(task_id)
+        except BaseException as exc:
+            errors.append(exc)
+
+    thread = threading.Thread(target=_create)
+    thread.start()
+    assert entered.wait(timeout=3)
+
+    assert bt.cleanup_browser(task_id) is True
+    release.set()
+    thread.join(timeout=4)
+
+    assert not thread.is_alive()
+    assert len(errors) == 1
+    assert isinstance(errors[0], bt._BrowserSessionRetiredError)
+    assert task_id not in bt._active_sessions
+    assert len(bt._pending_provider_cleanups) == 1
+    assert bt._browser_task_states[task_id] is bt.BrowserTaskState.RETIRING
+
+    blocked = json.loads(bt.browser_snapshot(task_id=task_id))
+    assert blocked["code"] == "browser_session_retired"
+    assert blocked["data"]["cleanup_pending"] is True
+
+    assert bt.cleanup_browser(task_id) is True
+    assert close_calls == ["late-provider-retry-id", "late-provider-retry-id"]
+    assert bt._pending_provider_cleanups == {}
+    assert task_id in bt._retired_browser_tasks
+
+
+def test_headed_turn_retains_local_but_cleans_shared_external_cdp(monkeypatch):
+    monkeypatch.setattr(bt, "_is_headed_mode", lambda: True)
+    monkeypatch.setattr(bt.os.path, "exists", lambda _path: False)
+
+    local_task = "headed-local"
+    shared_task = "headed-shared"
+    local = {
+        "session_name": "local-headed",
+        "bb_session_id": None,
+        "cdp_url": None,
+        "features": {"local": True},
+    }
+    shared = {
+        "session_name": "shared-headed",
+        "bb_session_id": None,
+        "cdp_url": "ws://shared",
+        "features": {"cdp_override": True},
+    }
+    bt._active_sessions.update({local_task: local, shared_task: shared})
+
+    with patch.object(
+        bt, "_run_browser_command", return_value={"success": True}
+    ) as command:
+        assert bt.cleanup_browser_for_turn(local_task) is True
+        assert bt.cleanup_browser_for_turn(shared_task) is True
+
+    assert bt._active_sessions[local_task] is local
+    assert shared_task not in bt._active_sessions
+    assert shared_task in bt._retired_browser_tasks
+    assert command.call_count == 2
+
+
+def test_hard_cleanup_still_closes_untracked_camofox_task(monkeypatch):
+    task_id = "camofox-hard-boundary"
+    soft_cleanup = MagicMock(return_value=False)
+    close = MagicMock()
+    monkeypatch.setattr(bt, "_is_camofox_mode", lambda: True)
+    monkeypatch.setattr(
+        "tools.browser_camofox.camofox_soft_cleanup",
+        soft_cleanup,
+    )
+    monkeypatch.setattr("tools.browser_camofox.camofox_close", close)
+
+    assert bt.cleanup_browser(task_id) is True
+
+    soft_cleanup.assert_called_once_with(task_id)
+    close.assert_called_once_with(task_id)
+    assert task_id in bt._retired_browser_tasks
+
+
+def test_headed_turn_preserves_untracked_camofox_task(monkeypatch):
+    task_id = "camofox-headed-boundary"
+    monkeypatch.setattr(bt, "_is_headed_mode", lambda: True)
+    monkeypatch.setattr(bt, "_is_camofox_mode", lambda: True)
+    soft_cleanup = MagicMock()
+    monkeypatch.setattr(
+        "tools.browser_camofox.camofox_soft_cleanup",
+        soft_cleanup,
+    )
+
+    assert bt.cleanup_browser_for_turn(task_id) is True
+
+    soft_cleanup.assert_not_called()
+    assert task_id not in bt._browser_task_states
+    assert task_id not in bt._retired_browser_tasks
+
+
+@pytest.mark.parametrize("exit_kind", ["direct_return", "exception", "cancellation"])
+def test_outer_turn_boundary_cleans_browser_on_every_exit(monkeypatch, exit_kind):
+    import run_agent
+
+    cleanup = MagicMock()
+    monkeypatch.setattr(run_agent, "cleanup_browser_for_turn", cleanup)
+
+    def _run():
+        with run_agent._browser_turn_cleanup_boundary("turn-exit-task"):
+            if exit_kind == "exception":
+                raise RuntimeError("ordinary failure")
+            if exit_kind == "cancellation":
+                raise asyncio.CancelledError("cancelled")
+            return {"completed": False, "partial": True}
+
+    if exit_kind == "exception":
+        with pytest.raises(RuntimeError):
+            _run()
+    elif exit_kind == "cancellation":
+        with pytest.raises(asyncio.CancelledError):
+            _run()
+    else:
+        assert _run()["partial"] is True
+
+    cleanup.assert_called_once_with("turn-exit-task")
+
+
+def test_outer_turn_boundary_does_not_repeat_normal_finalizer_cleanup(monkeypatch):
+    import run_agent
+
+    cleanup = MagicMock()
+    monkeypatch.setattr(run_agent, "cleanup_browser_for_turn", cleanup)
+
+    with run_agent._browser_turn_cleanup_boundary("already-finalized"):
+        run_agent._mark_browser_turn_cleanup_complete()
+
+    cleanup.assert_not_called()
+
+
+def test_outer_turn_boundary_retries_when_normal_finalizer_cleanup_raises(monkeypatch):
+    import run_agent
+    from agent.chat_completion_helpers import cleanup_task_resources
+
+    cleanup = MagicMock(side_effect=[RuntimeError("cleanup failed"), True])
+    monkeypatch.setattr(run_agent, "cleanup_browser_for_turn", cleanup)
+    monkeypatch.setattr(run_agent, "cleanup_vm", lambda _task: None)
+    monkeypatch.setattr(
+        "agent.chat_completion_helpers.is_persistent_env",
+        lambda _task: False,
+    )
+    agent = SimpleNamespace(verbose_logging=False)
+
+    with run_agent._browser_turn_cleanup_boundary("retry-turn-boundary"):
+        cleanup_task_resources(agent, "retry-turn-boundary")
+
+    assert [item.args for item in cleanup.call_args_list] == [
+        ("retry-turn-boundary",),
+        ("retry-turn-boundary",),
+    ]
+
+
+def test_outer_turn_boundary_retries_when_normal_finalizer_cleanup_returns_false(monkeypatch):
+    import run_agent
+    from agent.chat_completion_helpers import cleanup_task_resources
+
+    cleanup = MagicMock(side_effect=[False, True])
+    monkeypatch.setattr(run_agent, "cleanup_browser_for_turn", cleanup)
+    monkeypatch.setattr(run_agent, "cleanup_vm", lambda _task: None)
+    monkeypatch.setattr(
+        "agent.chat_completion_helpers.is_persistent_env",
+        lambda _task: False,
+    )
+    agent = SimpleNamespace(verbose_logging=False)
+
+    with run_agent._browser_turn_cleanup_boundary("retry-false-boundary"):
+        cleanup_task_resources(agent, "retry-false-boundary")
+
+    assert [item.args for item in cleanup.call_args_list] == [
+        ("retry-false-boundary",),
+        ("retry-false-boundary",),
+    ]
+
+
+def test_terminal_cleanup_waits_for_inflight_subprocess_command(monkeypatch):
+    task_id = "command-vs-terminal-cleanup"
+    bt._active_sessions[task_id] = {
+        "session_name": "local-command-race",
+        "bb_session_id": None,
+        "cdp_url": None,
+        "features": {"local": True},
+    }
+    command_entered = threading.Event()
+    release_command = threading.Event()
+    cleanup_done = threading.Event()
+    events: list[str] = []
+
+    class _Popen:
+        def __init__(self, cmd, *, stdout, **_kwargs):
+            if "snapshot" in cmd:
+                events.append("snapshot-start")
+                command_entered.set()
+                assert release_command.wait(timeout=3)
+                events.append("snapshot-end")
+                payload = b'{"success":true,"data":{"snapshot":"ok"}}'
+            elif "close" in cmd:
+                events.append("close")
+                payload = b'{"success":true}'
+            else:
+                raise AssertionError(cmd)
+            os.write(stdout, payload)
+            self.returncode = 0
+
+        def wait(self, timeout=None):
+            return self.returncode
+
+    monkeypatch.setattr(bt, "_find_agent_browser", lambda **_kwargs: "/tmp/fake-agent-browser")
+    monkeypatch.setattr(bt.subprocess, "Popen", _Popen)
+    command_result: list[dict] = []
+    cleanup_result: list[bool] = []
+    command_thread = threading.Thread(
+        target=lambda: command_result.append(
+            bt._run_browser_command(task_id, "snapshot", ["-c"])
+        )
+    )
+
+    def _cleanup():
+        cleanup_result.append(bt.cleanup_browser(task_id))
+        cleanup_done.set()
+
+    cleanup_thread = threading.Thread(target=_cleanup)
+    command_thread.start()
+    assert command_entered.wait(timeout=3)
+    cleanup_thread.start()
+    assert not cleanup_done.wait(timeout=0.1)
+
+    release_command.set()
+    command_thread.join(timeout=4)
+    cleanup_thread.join(timeout=4)
+
+    assert not command_thread.is_alive()
+    assert not cleanup_thread.is_alive()
+    assert command_result[0]["success"] is True
+    assert cleanup_result == [True]
+    assert events == ["snapshot-start", "snapshot-end", "close"]
+    assert task_id in bt._retired_browser_tasks
+
+
+def test_terminal_cleanup_waits_for_inflight_supervisor_eval(monkeypatch):
+    from tools.browser_supervisor import SUPERVISOR_REGISTRY
+
+    task_id = "supervisor-eval-vs-terminal-cleanup"
+    bt._active_sessions[task_id] = {
+        "session_name": "local-supervisor-race",
+        "bb_session_id": None,
+        "cdp_url": None,
+        "features": {"local": True},
+    }
+    eval_entered = threading.Event()
+    release_eval = threading.Event()
+    cleanup_done = threading.Event()
+    events: list[str] = []
+
+    class _Supervisor:
+        def evaluate_runtime(self, _expression):
+            events.append("eval-start")
+            eval_entered.set()
+            assert release_eval.wait(timeout=3)
+            events.append("eval-end")
+            return {"ok": True, "result": 1}
+
+    monkeypatch.setattr(SUPERVISOR_REGISTRY, "get", lambda _task: _Supervisor())
+    monkeypatch.setattr(bt, "_eval_ssrf_guard_active", lambda _task: False)
+
+    class _Popen:
+        def __init__(self, cmd, *, stdout, **_kwargs):
+            assert "close" in cmd
+            events.append("close")
+            os.write(stdout, b'{"success":true}')
+            self.returncode = 0
+
+        def wait(self, timeout=None):
+            return self.returncode
+
+    monkeypatch.setattr(bt, "_find_agent_browser", lambda **_kwargs: "/tmp/fake-agent-browser")
+    monkeypatch.setattr(bt.subprocess, "Popen", _Popen)
+    eval_result: list[dict] = []
+    cleanup_result: list[bool] = []
+    eval_thread = threading.Thread(
+        target=lambda: eval_result.append(
+            json.loads(bt._browser_eval("window.value", task_id=task_id))
+        )
+    )
+
+    def _cleanup():
+        cleanup_result.append(bt.cleanup_browser(task_id))
+        cleanup_done.set()
+
+    cleanup_thread = threading.Thread(target=_cleanup)
+    eval_thread.start()
+    assert eval_entered.wait(timeout=3)
+    cleanup_thread.start()
+    assert not cleanup_done.wait(timeout=0.1)
+
+    release_eval.set()
+    eval_thread.join(timeout=4)
+    cleanup_thread.join(timeout=4)
+
+    assert not eval_thread.is_alive()
+    assert not cleanup_thread.is_alive()
+    assert eval_result[0]["success"] is True
+    assert cleanup_result == [True]
+    assert events == ["eval-start", "eval-end", "close"]
+    assert task_id in bt._retired_browser_tasks

--- a/tests/tools/test_browser_lifecycle_fail_closed.py
+++ b/tests/tools/test_browser_lifecycle_fail_closed.py
@@ -12,6 +12,12 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from tools import browser_tool as bt
+from tools import browser_tool_cdp as bt_cdp
+from tools import browser_tool_cloud as bt_cloud
+from tools import browser_tool_eval_policy as bt_eval_policy
+from tools import browser_tool_install as bt_install
+from tools import browser_tool_lifecycle as bt_lifecycle
+from tools import browser_tool_session as bt_session
 
 
 @pytest.fixture(autouse=True)
@@ -25,8 +31,8 @@ def _isolated_browser_lifecycle(monkeypatch):
     monkeypatch.setattr(bt, "_browser_task_cleanup_reasons", {})
     monkeypatch.setattr(bt, "_browser_task_cleanup_locks", {})
     monkeypatch.setattr(bt, "_pending_provider_cleanups", {})
-    monkeypatch.setattr(bt, "_start_browser_cleanup_thread", lambda: None)
-    monkeypatch.setattr(bt, "_stop_cdp_supervisor", lambda _task: None)
+    monkeypatch.setattr(bt_lifecycle, "_start_browser_cleanup_thread", lambda: None)
+    monkeypatch.setattr(bt_cdp, "_stop_cdp_supervisor", lambda _task: None)
     monkeypatch.setattr(bt, "_maybe_stop_recording", lambda _task: None)
     monkeypatch.setattr(bt, "_maybe_start_recording", lambda _task: None)
     monkeypatch.setattr(bt, "_is_camofox_mode", lambda: False)
@@ -34,7 +40,7 @@ def _isolated_browser_lifecycle(monkeypatch):
 
 def _observe_cleanup_lock_request(monkeypatch, requested: threading.Event) -> None:
     """Signal when the named cleanup thread requests the task operation lock."""
-    original = bt._task_cleanup_operation_lock
+    original = bt_lifecycle._task_cleanup_operation_lock
 
     def _wrapped(bare_task_id):
         lock = original(bare_task_id)
@@ -42,7 +48,7 @@ def _observe_cleanup_lock_request(monkeypatch, requested: threading.Event) -> No
             requested.set()
         return lock
 
-    monkeypatch.setattr(bt, "_task_cleanup_operation_lock", _wrapped)
+    monkeypatch.setattr(bt_lifecycle, "_task_cleanup_operation_lock", _wrapped)
 
 
 @pytest.mark.parametrize("backend", ["local", "provider"])
@@ -80,36 +86,36 @@ def test_real_inactivity_cleanup_is_nonterminal_and_normal_command_recreates(
     bt._active_sessions[task_id] = old_session
     bt._session_last_activity[task_id] = now - 100
     monkeypatch.setattr(bt, "BROWSER_SESSION_INACTIVITY_TIMEOUT", 10)
-    monkeypatch.setattr(bt.time, "time", lambda: now)
-    monkeypatch.setattr(bt.os.path, "exists", lambda _path: False)
-    monkeypatch.setattr(bt, "_get_cdp_override", lambda: "")
+    monkeypatch.setattr(bt_lifecycle.time, "time", lambda: now)
+    monkeypatch.setattr(bt_lifecycle.os.path, "exists", lambda _path: False)
+    monkeypatch.setattr(bt_cdp, "_get_cdp_override", lambda: "")
     monkeypatch.setattr(
-        bt,
+        bt_cloud,
         "_get_cloud_provider",
         (lambda: provider) if backend == "provider" else (lambda: None),
     )
-    monkeypatch.setattr(bt, "_resolve_cdp_override", lambda value: value)
-    monkeypatch.setattr(bt, "_ensure_cdp_supervisor", lambda *_a, **_kw: None)
+    monkeypatch.setattr(bt_cdp, "_resolve_cdp_override", lambda value: value)
+    monkeypatch.setattr(bt_cdp, "_ensure_cdp_supervisor", lambda *_a, **_kw: None)
 
-    with patch.object(bt, "_run_browser_command", return_value={"success": True}):
-        bt._cleanup_inactive_browser_sessions()
+    with patch.object(bt_session, "_run_browser_command", return_value={"success": True}):
+        bt_lifecycle._cleanup_inactive_browser_sessions()
 
     assert task_id not in bt._active_sessions
     assert task_id not in bt._retired_browser_tasks
-    assert bt._browser_task_states[task_id] is bt.BrowserTaskState.ACTIVE
+    assert bt._browser_task_states[task_id] is bt_lifecycle.BrowserTaskState.ACTIVE
 
     # Drive the same implicit session lookup used by a normal snapshot command.
-    monkeypatch.setattr(bt, "_is_local_backend", lambda: True)
+    monkeypatch.setattr(bt_cloud, "_is_local_backend", lambda: True)
 
     def _normal_snapshot(session_key, command, args, **_kwargs):
         assert command == "snapshot"
-        session = bt._get_session_info(session_key)
+        session = bt_session._get_session_info(session_key)
         return {
             "success": True,
             "data": {"snapshot": session["session_name"], "refs": {}},
         }
 
-    monkeypatch.setattr(bt, "_run_browser_command", _normal_snapshot)
+    monkeypatch.setattr(bt_session, "_run_browser_command", _normal_snapshot)
     result = json.loads(bt.browser_snapshot(task_id=task_id))
 
     assert result["success"] is True
@@ -143,7 +149,7 @@ def test_provider_cdp_uses_generic_node22_path_and_provider_cleanup(
     def _resolver(*, require_pin_tab: bool = False):
         resolver_calls.append(require_pin_tab)
         if require_pin_tab:
-            raise bt.AgentBrowserCapabilityError("Node >=24 required")
+            raise bt_install.AgentBrowserCapabilityError("Node >=24 required")
         return "/tmp/agent-browser-node22"
 
     class _Proc:
@@ -159,19 +165,19 @@ def test_provider_cdp_uses_generic_node22_path_and_provider_cleanup(
         def kill(self):
             self.returncode = -9
 
-    monkeypatch.setattr(bt, "_find_agent_browser", _resolver)
-    monkeypatch.setattr(bt, "_requires_real_termux_browser_install", lambda _cmd: False)
-    monkeypatch.setattr(bt, "_is_local_mode", lambda: False)
+    monkeypatch.setattr(bt_install, "_find_agent_browser", _resolver)
+    monkeypatch.setattr(bt_install, "_requires_real_termux_browser_install", lambda _cmd: False)
+    monkeypatch.setattr(bt_cloud, "_is_local_mode", lambda: False)
     monkeypatch.setattr(bt, "_socket_safe_tmpdir", lambda: str(tmp_path))
-    monkeypatch.setattr(bt, "_write_owner_pid", lambda *_a: None)
+    monkeypatch.setattr(bt_lifecycle, "_write_owner_pid", lambda *_a: None)
     monkeypatch.setattr(bt, "_build_browser_env", lambda: {"PATH": "/usr/bin"})
-    monkeypatch.setattr(bt, "_merge_browser_path", lambda value: value)
-    monkeypatch.setattr(bt, "_needs_chromium_sandbox_bypass", lambda: False)
-    monkeypatch.setattr(bt.subprocess, "Popen", _Proc)
+    monkeypatch.setattr(bt_install, "_merge_browser_path", lambda value: value)
+    monkeypatch.setattr(bt_session, "_needs_chromium_sandbox_bypass", lambda: False)
+    monkeypatch.setattr(bt_session.subprocess, "Popen", _Proc)
     monkeypatch.setattr("tools.interrupt.is_interrupted", lambda: False)
 
-    command_result = bt._run_browser_command(task_id, "snapshot", ["-c"])
-    cleanup_result = bt.cleanup_browser(task_id)
+    command_result = bt_session._run_browser_command(task_id, "snapshot", ["-c"])
+    cleanup_result = bt_lifecycle.cleanup_browser(task_id)
 
     assert command_result["success"] is True
     assert cleanup_result is True
@@ -201,7 +207,7 @@ def test_real_profile_cdp_keeps_generic_node22_and_local_headed_semantics(
     def _resolver(*, require_pin_tab: bool = False):
         resolver_calls.append(require_pin_tab)
         if require_pin_tab:
-            raise bt.AgentBrowserCapabilityError("Node >=24 required")
+            raise bt_install.AgentBrowserCapabilityError("Node >=24 required")
         return "/tmp/agent-browser-node22"
 
     class _Proc:
@@ -217,21 +223,21 @@ def test_real_profile_cdp_keeps_generic_node22_and_local_headed_semantics(
         def kill(self):
             self.returncode = -9
 
-    monkeypatch.setattr(bt, "_find_agent_browser", _resolver)
-    monkeypatch.setattr(bt, "_requires_real_termux_browser_install", lambda _cmd: False)
-    monkeypatch.setattr(bt, "_is_local_mode", lambda: False)
-    monkeypatch.setattr(bt, "_ensure_cdp_supervisor", lambda *_a, **_kw: None)
+    monkeypatch.setattr(bt_install, "_find_agent_browser", _resolver)
+    monkeypatch.setattr(bt_install, "_requires_real_termux_browser_install", lambda _cmd: False)
+    monkeypatch.setattr(bt_cloud, "_is_local_mode", lambda: False)
+    monkeypatch.setattr(bt_cdp, "_ensure_cdp_supervisor", lambda *_a, **_kw: None)
     monkeypatch.setattr(bt, "_socket_safe_tmpdir", lambda: str(tmp_path))
-    monkeypatch.setattr(bt, "_write_owner_pid", lambda *_a: None)
+    monkeypatch.setattr(bt_lifecycle, "_write_owner_pid", lambda *_a: None)
     monkeypatch.setattr(bt, "_build_browser_env", lambda: {"PATH": "/usr/bin"})
-    monkeypatch.setattr(bt, "_merge_browser_path", lambda value: value)
-    monkeypatch.setattr(bt, "_needs_chromium_sandbox_bypass", lambda: False)
-    monkeypatch.setattr(bt.subprocess, "Popen", _Proc)
+    monkeypatch.setattr(bt_install, "_merge_browser_path", lambda value: value)
+    monkeypatch.setattr(bt_session, "_needs_chromium_sandbox_bypass", lambda: False)
+    monkeypatch.setattr(bt_session.subprocess, "Popen", _Proc)
     monkeypatch.setattr("tools.interrupt.is_interrupted", lambda: False)
 
-    assert bt._is_task_owned_shared_cdp_session(session) is False
-    assert bt._is_hermes_owned_local_browser_session(session) is True
-    result = bt._run_browser_command(task_id, "snapshot", ["-c"])
+    assert bt_lifecycle._is_task_owned_shared_cdp_session(session) is False
+    assert bt_lifecycle._is_hermes_owned_local_browser_session(session) is True
+    result = bt_session._run_browser_command(task_id, "snapshot", ["-c"])
 
     assert result["success"] is True
     assert resolver_calls == [False]
@@ -250,10 +256,10 @@ def test_provider_api_close_is_not_blocked_by_local_tab_capability(monkeypatch):
         "features": {},
         "_provider_cleanup_owner": provider,
     }
-    monkeypatch.setattr(bt.os.path, "exists", lambda _path: False)
+    monkeypatch.setattr(bt_lifecycle.os.path, "exists", lambda _path: False)
 
     with patch.object(
-        bt,
+        bt_session,
         "_run_browser_command",
         return_value={
             "success": False,
@@ -261,7 +267,7 @@ def test_provider_api_close_is_not_blocked_by_local_tab_capability(monkeypatch):
             "error": "Node >=24 required",
         },
     ) as command:
-        assert bt.cleanup_browser(task_id) is True
+        assert bt_lifecycle.cleanup_browser(task_id) is True
 
     command.assert_called_once_with(
         task_id,
@@ -285,15 +291,15 @@ def test_shared_cdp_timeout_enters_exact_nonterminal_cleanup(monkeypatch):
     bt._active_sessions[task_id] = session
     cleanup = MagicMock(return_value=True)
     discard = MagicMock()
-    monkeypatch.setattr(bt, "_cleanup_browser_session_keys", cleanup)
-    monkeypatch.setattr(bt, "_discard_timed_out_browser_session", discard)
+    monkeypatch.setattr(bt_lifecycle, "_cleanup_browser_session_keys", cleanup)
+    monkeypatch.setattr(bt_session, "_discard_timed_out_browser_session", discard)
 
-    bt._handle_browser_command_timeout(task_id, session, "/tmp/not-used")
+    bt_session._handle_browser_command_timeout(task_id, session, "/tmp/not-used")
 
     cleanup.assert_called_once_with(
         task_id,
         [task_id],
-        reason=bt.BrowserCleanupReason.INACTIVITY,
+        reason=bt_lifecycle.BrowserCleanupReason.INACTIVITY,
     )
     discard.assert_not_called()
 
@@ -308,12 +314,12 @@ def test_shared_cdp_timeout_without_exact_target_stays_fail_closed():
     }
     bt._active_sessions[task_id] = session
 
-    bt._handle_browser_command_timeout(task_id, session, "/tmp/not-used")
+    bt_session._handle_browser_command_timeout(task_id, session, "/tmp/not-used")
 
     assert bt._active_sessions[task_id] is session
     assert session["_cleanup_retry_pending"] is True
-    assert bt._browser_task_states[task_id] is bt.BrowserTaskState.RETIRING
-    assert bt._is_browser_task_unavailable(task_id) is True
+    assert bt._browser_task_states[task_id] is bt_lifecycle.BrowserTaskState.RETIRING
+    assert bt_lifecycle._is_browser_task_unavailable(task_id) is True
 
 
 def test_cleanup_command_ignores_turn_interrupt(monkeypatch, tmp_path):
@@ -340,19 +346,19 @@ def test_cleanup_command_ignores_turn_interrupt(monkeypatch, tmp_path):
             self.returncode = -9
 
     monkeypatch.setattr(
-        bt, "_find_agent_browser", lambda **_kwargs: "/tmp/agent-browser"
+        bt_install, "_find_agent_browser", lambda **_kwargs: "/tmp/agent-browser"
     )
-    monkeypatch.setattr(bt, "_requires_real_termux_browser_install", lambda _cmd: False)
-    monkeypatch.setattr(bt, "_is_local_mode", lambda: False)
+    monkeypatch.setattr(bt_install, "_requires_real_termux_browser_install", lambda _cmd: False)
+    monkeypatch.setattr(bt_cloud, "_is_local_mode", lambda: False)
     monkeypatch.setattr(bt, "_socket_safe_tmpdir", lambda: str(tmp_path))
-    monkeypatch.setattr(bt, "_write_owner_pid", lambda *_a: None)
+    monkeypatch.setattr(bt_lifecycle, "_write_owner_pid", lambda *_a: None)
     monkeypatch.setattr(bt, "_build_browser_env", lambda: {"PATH": "/usr/bin"})
-    monkeypatch.setattr(bt, "_merge_browser_path", lambda value: value)
-    monkeypatch.setattr(bt, "_needs_chromium_sandbox_bypass", lambda: False)
-    monkeypatch.setattr(bt.subprocess, "Popen", _Proc)
+    monkeypatch.setattr(bt_install, "_merge_browser_path", lambda value: value)
+    monkeypatch.setattr(bt_session, "_needs_chromium_sandbox_bypass", lambda: False)
+    monkeypatch.setattr(bt_session.subprocess, "Popen", _Proc)
     monkeypatch.setattr("tools.interrupt.is_interrupted", lambda: True)
 
-    result = bt._run_browser_command(
+    result = bt_session._run_browser_command(
         task_id,
         "close",
         [],
@@ -388,20 +394,20 @@ def test_provider_close_failure_retains_retry_identity_until_success(
         "features": {},
         "_provider_cleanup_owner": provider,
     }
-    monkeypatch.setattr(bt.os.path, "exists", lambda _path: False)
+    monkeypatch.setattr(bt_lifecycle.os.path, "exists", lambda _path: False)
 
-    with patch.object(bt, "_run_browser_command", return_value={"success": True}):
-        assert bt.cleanup_browser(task_id) is False
+    with patch.object(bt_session, "_run_browser_command", return_value={"success": True}):
+        assert bt_lifecycle.cleanup_browser(task_id) is False
 
     assert task_id not in bt._active_sessions
     pending = list(bt._pending_provider_cleanups.values())
     assert [(item.provider, item.session_id) for item in pending] == [
         (provider, "provider-retry-id")
     ]
-    assert bt._browser_task_states[task_id] is bt.BrowserTaskState.RETIRING
+    assert bt._browser_task_states[task_id] is bt_lifecycle.BrowserTaskState.RETIRING
 
     find_browser = MagicMock()
-    monkeypatch.setattr(bt, "_find_agent_browser", find_browser)
+    monkeypatch.setattr(bt_install, "_find_agent_browser", find_browser)
     blocked = json.loads(bt.browser_snapshot(task_id=task_id))
     assert blocked["code"] == "browser_session_retired"
     assert blocked["data"]["cleanup_pending"] is True
@@ -409,8 +415,8 @@ def test_provider_close_failure_retains_retry_identity_until_success(
 
     # Retry only the retained provider identity. No page lookup/adoption occurs.
     get_session = MagicMock()
-    monkeypatch.setattr(bt, "_get_session_info", get_session)
-    assert bt.cleanup_browser(task_id) is True
+    monkeypatch.setattr(bt_session, "_get_session_info", get_session)
+    assert bt_lifecycle.cleanup_browser(task_id) is True
     assert calls == ["provider-retry-id", "provider-retry-id"]
     assert bt._pending_provider_cleanups == {}
     assert task_id in bt._retired_browser_tasks
@@ -431,16 +437,16 @@ def test_cleanup_pending_blocks_all_business_commands_and_supervisor_eval(monkey
     bt._last_active_session_key[task_id] = task_id
 
     with patch.object(
-        bt,
+        bt_session,
         "_run_browser_command",
         return_value={"success": False, "error": "exact close unavailable"},
     ):
-        assert bt.cleanup_browser(task_id) is False
+        assert bt_lifecycle.cleanup_browser(task_id) is False
 
-    monkeypatch.setattr(bt, "_eval_ssrf_guard_active", lambda _task: False)
+    monkeypatch.setattr(bt_eval_policy, "_eval_ssrf_guard_active", lambda _task: False)
     find_browser = MagicMock()
     supervisor_get = MagicMock()
-    monkeypatch.setattr(bt, "_find_agent_browser", find_browser)
+    monkeypatch.setattr(bt_install, "_find_agent_browser", find_browser)
     monkeypatch.setattr(SUPERVISOR_REGISTRY, "get", supervisor_get)
 
     results = [
@@ -462,18 +468,18 @@ def test_failed_restart_blanking_and_exact_close_stays_fail_closed(monkeypatch):
     task_id = "failed-restart-three-stage"
     bt._retired_browser_tasks.add(task_id)
     monkeypatch.setattr(bt, "_navigation_session_key", lambda task, _url: task)
-    monkeypatch.setattr(bt, "_get_cdp_override", lambda: "ws://shared")
-    monkeypatch.setattr(bt, "_is_local_backend", lambda: True)
+    monkeypatch.setattr(bt_cdp, "_get_cdp_override", lambda: "ws://shared")
+    monkeypatch.setattr(bt_cloud, "_is_local_backend", lambda: True)
     monkeypatch.setattr(
         bt,
         "_is_always_blocked_url",
         lambda url: url == "http://blocked.internal/",
     )
     monkeypatch.setattr(bt, "check_website_access", lambda _url: None)
-    monkeypatch.setattr(bt, "_pinned_cdp_target_id", lambda _task: "TARGET")
-    monkeypatch.setattr(bt, "_ensure_cdp_supervisor", lambda *_a, **_kw: None)
+    monkeypatch.setattr(bt_cdp, "_pinned_cdp_target_id", lambda _task: "TARGET")
+    monkeypatch.setattr(bt_cdp, "_ensure_cdp_supervisor", lambda *_a, **_kw: None)
     monkeypatch.setattr(
-        bt,
+        bt_cdp,
         "_close_shared_cdp_target_confirmed",
         lambda _cdp_url, _target_id: False,
     )
@@ -494,12 +500,12 @@ def test_failed_restart_blanking_and_exact_close_stays_fail_closed(monkeypatch):
             return {"success": False, "error": "blanking failed"}
         raise AssertionError((command, args))
 
-    monkeypatch.setattr(bt, "_run_browser_command", _command)
+    monkeypatch.setattr(bt_session, "_run_browser_command", _command)
 
     result = json.loads(bt.browser_navigate("https://example.com", task_id=task_id))
 
     assert result["success"] is False
-    assert bt._browser_task_states[task_id] is bt.BrowserTaskState.RETIRING
+    assert bt._browser_task_states[task_id] is bt_lifecycle.BrowserTaskState.RETIRING
     assert bt._active_sessions[task_id]["_cleanup_retry_pending"] is True
     assert command_calls == [
         ("open", ["https://example.com"]),
@@ -539,14 +545,14 @@ def test_two_provider_creators_close_the_loser(monkeypatch):
             return True
 
     provider = _Provider()
-    monkeypatch.setattr(bt, "_get_cdp_override", lambda: "")
-    monkeypatch.setattr(bt, "_get_cloud_provider", lambda: provider)
-    monkeypatch.setattr(bt, "_resolve_cdp_override", lambda value: value)
-    monkeypatch.setattr(bt, "_ensure_cdp_supervisor", lambda *_a, **_kw: None)
+    monkeypatch.setattr(bt_cdp, "_get_cdp_override", lambda: "")
+    monkeypatch.setattr(bt_cloud, "_get_cloud_provider", lambda: provider)
+    monkeypatch.setattr(bt_cdp, "_resolve_cdp_override", lambda value: value)
+    monkeypatch.setattr(bt_cdp, "_ensure_cdp_supervisor", lambda *_a, **_kw: None)
 
     results: list[dict] = []
     threads = [
-        threading.Thread(target=lambda: results.append(bt._get_session_info(task_id)))
+        threading.Thread(target=lambda: results.append(bt_session._get_session_info(task_id)))
         for _ in range(2)
     ]
     for thread in threads:
@@ -585,16 +591,16 @@ def test_terminal_cleanup_fences_inflight_provider_creator(monkeypatch):
             return True
 
     provider = _Provider()
-    monkeypatch.setattr(bt, "_get_cdp_override", lambda: "")
-    monkeypatch.setattr(bt, "_get_cloud_provider", lambda: provider)
-    monkeypatch.setattr(bt, "_resolve_cdp_override", lambda value: value)
-    monkeypatch.setattr(bt, "_ensure_cdp_supervisor", lambda *_a, **_kw: None)
+    monkeypatch.setattr(bt_cdp, "_get_cdp_override", lambda: "")
+    monkeypatch.setattr(bt_cloud, "_get_cloud_provider", lambda: provider)
+    monkeypatch.setattr(bt_cdp, "_resolve_cdp_override", lambda value: value)
+    monkeypatch.setattr(bt_cdp, "_ensure_cdp_supervisor", lambda *_a, **_kw: None)
 
     errors: list[BaseException] = []
 
     def _create():
         try:
-            bt._get_session_info(task_id)
+            bt_session._get_session_info(task_id)
         except BaseException as exc:
             errors.append(exc)
 
@@ -602,8 +608,8 @@ def test_terminal_cleanup_fences_inflight_provider_creator(monkeypatch):
     thread.start()
     assert entered.wait(timeout=3)
 
-    assert bt.cleanup_browser(task_id) is True
-    assert bt._browser_task_states[task_id] is bt.BrowserTaskState.RETIRED
+    assert bt_lifecycle.cleanup_browser(task_id) is True
+    assert bt._browser_task_states[task_id] is bt_lifecycle.BrowserTaskState.RETIRED
     release.set()
     thread.join(timeout=4)
 
@@ -611,7 +617,7 @@ def test_terminal_cleanup_fences_inflight_provider_creator(monkeypatch):
     assert task_id not in bt._active_sessions
     assert closed == ["late-provider-id"]
     assert len(errors) == 1
-    assert isinstance(errors[0], bt._BrowserSessionRetiredError)
+    assert isinstance(errors[0], bt_lifecycle._BrowserSessionRetiredError)
 
 
 def test_late_stale_creator_close_failure_reopens_only_cleanup_state(monkeypatch):
@@ -636,16 +642,16 @@ def test_late_stale_creator_close_failure_reopens_only_cleanup_state(monkeypatch
             return len(close_calls) > 1
 
     provider = _Provider()
-    monkeypatch.setattr(bt, "_get_cdp_override", lambda: "")
-    monkeypatch.setattr(bt, "_get_cloud_provider", lambda: provider)
-    monkeypatch.setattr(bt, "_resolve_cdp_override", lambda value: value)
-    monkeypatch.setattr(bt, "_ensure_cdp_supervisor", lambda *_a, **_kw: None)
+    monkeypatch.setattr(bt_cdp, "_get_cdp_override", lambda: "")
+    monkeypatch.setattr(bt_cloud, "_get_cloud_provider", lambda: provider)
+    monkeypatch.setattr(bt_cdp, "_resolve_cdp_override", lambda value: value)
+    monkeypatch.setattr(bt_cdp, "_ensure_cdp_supervisor", lambda *_a, **_kw: None)
 
     errors: list[BaseException] = []
 
     def _create():
         try:
-            bt._get_session_info(task_id)
+            bt_session._get_session_info(task_id)
         except BaseException as exc:
             errors.append(exc)
 
@@ -653,30 +659,30 @@ def test_late_stale_creator_close_failure_reopens_only_cleanup_state(monkeypatch
     thread.start()
     assert entered.wait(timeout=3)
 
-    assert bt.cleanup_browser(task_id) is True
+    assert bt_lifecycle.cleanup_browser(task_id) is True
     release.set()
     thread.join(timeout=4)
 
     assert not thread.is_alive()
     assert len(errors) == 1
-    assert isinstance(errors[0], bt._BrowserSessionRetiredError)
+    assert isinstance(errors[0], bt_lifecycle._BrowserSessionRetiredError)
     assert task_id not in bt._active_sessions
     assert len(bt._pending_provider_cleanups) == 1
-    assert bt._browser_task_states[task_id] is bt.BrowserTaskState.RETIRING
+    assert bt._browser_task_states[task_id] is bt_lifecycle.BrowserTaskState.RETIRING
 
     blocked = json.loads(bt.browser_snapshot(task_id=task_id))
     assert blocked["code"] == "browser_session_retired"
     assert blocked["data"]["cleanup_pending"] is True
 
-    assert bt.cleanup_browser(task_id) is True
+    assert bt_lifecycle.cleanup_browser(task_id) is True
     assert close_calls == ["late-provider-retry-id", "late-provider-retry-id"]
     assert bt._pending_provider_cleanups == {}
     assert task_id in bt._retired_browser_tasks
 
 
 def test_headed_turn_retains_local_but_cleans_shared_external_cdp(monkeypatch):
-    monkeypatch.setattr(bt, "_is_headed_mode", lambda: True)
-    monkeypatch.setattr(bt.os.path, "exists", lambda _path: False)
+    monkeypatch.setattr(bt_cloud, "_is_headed_mode", lambda: True)
+    monkeypatch.setattr(bt_lifecycle.os.path, "exists", lambda _path: False)
 
     local_task = "headed-local"
     real_profile_task = "headed-real-profile"
@@ -710,17 +716,17 @@ def test_headed_turn_retains_local_but_cleans_shared_external_cdp(monkeypatch):
 
     with (
         patch.object(
-            bt,
+            bt_cdp,
             "_close_shared_cdp_target_confirmed",
             return_value=True,
         ),
         patch.object(
-            bt, "_run_browser_command", return_value={"success": True}
+            bt_session, "_run_browser_command", return_value={"success": True}
         ) as command,
     ):
-        assert bt.cleanup_browser_for_turn(local_task) is True
-        assert bt.cleanup_browser_for_turn(real_profile_task) is True
-        assert bt.cleanup_browser_for_turn(shared_task) is True
+        assert bt_lifecycle.cleanup_browser_for_turn(local_task) is True
+        assert bt_lifecycle.cleanup_browser_for_turn(real_profile_task) is True
+        assert bt_lifecycle.cleanup_browser_for_turn(shared_task) is True
 
     assert bt._active_sessions[local_task] is local
     assert bt._active_sessions[real_profile_task] is real_profile
@@ -740,7 +746,7 @@ def test_hard_cleanup_still_closes_untracked_camofox_task(monkeypatch):
     )
     monkeypatch.setattr("tools.browser_camofox.camofox_close", close)
 
-    assert bt.cleanup_browser(task_id) is True
+    assert bt_lifecycle.cleanup_browser(task_id) is True
 
     soft_cleanup.assert_called_once_with(task_id)
     close.assert_called_once_with(task_id)
@@ -749,7 +755,7 @@ def test_hard_cleanup_still_closes_untracked_camofox_task(monkeypatch):
 
 def test_headed_turn_preserves_untracked_camofox_task(monkeypatch):
     task_id = "camofox-headed-boundary"
-    monkeypatch.setattr(bt, "_is_headed_mode", lambda: True)
+    monkeypatch.setattr(bt_cloud, "_is_headed_mode", lambda: True)
     monkeypatch.setattr(bt, "_is_camofox_mode", lambda: True)
     soft_cleanup = MagicMock()
     monkeypatch.setattr(
@@ -757,7 +763,7 @@ def test_headed_turn_preserves_untracked_camofox_task(monkeypatch):
         soft_cleanup,
     )
 
-    assert bt.cleanup_browser_for_turn(task_id) is True
+    assert bt_lifecycle.cleanup_browser_for_turn(task_id) is True
 
     soft_cleanup.assert_not_called()
     assert task_id not in bt._browser_task_states
@@ -766,7 +772,7 @@ def test_headed_turn_preserves_untracked_camofox_task(monkeypatch):
 
 def test_browser_free_camofox_turn_does_not_allocate_lifecycle_rows(monkeypatch):
     task_id = "camofox-browser-free"
-    monkeypatch.setattr(bt, "_is_headed_mode", lambda: False)
+    monkeypatch.setattr(bt_cloud, "_is_headed_mode", lambda: False)
     monkeypatch.setattr(bt, "_is_camofox_mode", lambda: True)
     monkeypatch.setattr(
         "tools.browser_camofox.camofox_has_session",
@@ -775,7 +781,7 @@ def test_browser_free_camofox_turn_does_not_allocate_lifecycle_rows(monkeypatch)
     soft_cleanup = MagicMock()
     monkeypatch.setattr("tools.browser_camofox.camofox_soft_cleanup", soft_cleanup)
 
-    assert bt.cleanup_browser_for_turn(task_id) is True
+    assert bt_lifecycle.cleanup_browser_for_turn(task_id) is True
 
     soft_cleanup.assert_not_called()
     assert task_id not in bt._browser_task_states
@@ -791,10 +797,10 @@ def test_browser_free_camofox_fast_path_waits_for_inflight_navigation(monkeypatc
     cleanup_done = threading.Event()
     events: list[str] = []
 
-    monkeypatch.setattr(bt, "_is_headed_mode", lambda: False)
+    monkeypatch.setattr(bt_cloud, "_is_headed_mode", lambda: False)
     monkeypatch.setattr(bt, "_is_camofox_mode", lambda: True)
     monkeypatch.setattr(bt, "_is_always_blocked_url", lambda _url: False)
-    monkeypatch.setattr(bt, "_is_local_backend", lambda: True)
+    monkeypatch.setattr(bt_cloud, "_is_local_backend", lambda: True)
     monkeypatch.setattr(bt, "check_website_access", lambda _url: None)
     monkeypatch.setattr(
         "tools.browser_camofox.camofox_has_session",
@@ -823,7 +829,7 @@ def test_browser_free_camofox_fast_path_waits_for_inflight_navigation(monkeypatc
         )
     )
     cleanup_thread = threading.Thread(
-        target=lambda: (bt.cleanup_browser_for_turn(task_id), cleanup_done.set()),
+        target=lambda: (bt_lifecycle.cleanup_browser_for_turn(task_id), cleanup_done.set()),
         name="browser-cleanup-test",
     )
 
@@ -846,7 +852,7 @@ def test_browser_free_camofox_fast_path_waits_for_inflight_navigation(monkeypatc
 def test_browser_free_turn_cleanup_does_not_allocate_lifecycle_rows():
     """Per-turn finalization is a no-op when the task never used a browser."""
     for index in range(100):
-        assert bt.cleanup_browser_for_turn(f"browser-free-{index}") is True
+        assert bt_lifecycle.cleanup_browser_for_turn(f"browser-free-{index}") is True
 
     assert bt._browser_task_states == {}
     assert bt._browser_task_generations == {}
@@ -872,10 +878,10 @@ def test_navigation_holds_task_lifecycle_lock_through_snapshot(monkeypatch):
 
     monkeypatch.setattr(bt, "_navigation_session_key", lambda _task, _url: task_id)
     monkeypatch.setattr(bt, "_is_always_blocked_url", lambda _url: False)
-    monkeypatch.setattr(bt, "_is_local_backend", lambda: True)
+    monkeypatch.setattr(bt_cloud, "_is_local_backend", lambda: True)
     monkeypatch.setattr(bt, "check_website_access", lambda _url: None)
     monkeypatch.setattr(bt, "_is_camofox_mode", lambda: False)
-    monkeypatch.setattr(bt, "_clear_retired_browser_task_for_navigation", lambda _task: False)
+    monkeypatch.setattr(bt_lifecycle, "_clear_retired_browser_task_for_navigation", lambda _task: False)
     monkeypatch.setattr(bt, "_get_open_command_timeout", lambda **_kwargs: 10)
     monkeypatch.setattr(bt, "_maybe_start_recording", lambda _task: None)
 
@@ -887,7 +893,7 @@ def test_navigation_holds_task_lifecycle_lock_through_snapshot(monkeypatch):
         events.append("session-end")
         return session
 
-    monkeypatch.setattr(bt, "_get_session_info", _get_session_info)
+    monkeypatch.setattr(bt_session, "_get_session_info", _get_session_info)
 
     def _run(_session_key, command, _args, **_kwargs):
         if command == "open":
@@ -896,14 +902,14 @@ def test_navigation_holds_task_lifecycle_lock_through_snapshot(monkeypatch):
         events.append(command)
         return {"success": True, "data": {"snapshot": "ok", "refs": {}}}
 
-    monkeypatch.setattr(bt, "_run_browser_command", _run)
+    monkeypatch.setattr(bt_session, "_run_browser_command", _run)
     _observe_cleanup_lock_request(monkeypatch, cleanup_lock_requested)
     nav_result: list[str] = []
     nav_thread = threading.Thread(
         target=lambda: nav_result.append(bt.browser_navigate("https://example.com", task_id))
     )
     cleanup_thread = threading.Thread(
-        target=lambda: (bt.cleanup_browser(task_id), cleanup_done.set()),
+        target=lambda: (bt_lifecycle.cleanup_browser(task_id), cleanup_done.set()),
         name="browser-cleanup-test",
     )
 
@@ -964,8 +970,8 @@ def test_browser_dialog_waits_for_terminal_cleanup(monkeypatch):
 
     supervisor.respond_to_dialog.side_effect = _respond
     monkeypatch.setattr(browser_dialog_tool.SUPERVISOR_REGISTRY, "get", lambda _task: supervisor)
-    monkeypatch.setattr(bt, "_run_browser_command", lambda *_args, **_kwargs: {"success": True})
-    monkeypatch.setattr(bt.os.path, "exists", lambda _path: False)
+    monkeypatch.setattr(bt_session, "_run_browser_command", lambda *_args, **_kwargs: {"success": True})
+    monkeypatch.setattr(bt_lifecycle.os.path, "exists", lambda _path: False)
     _observe_cleanup_lock_request(monkeypatch, cleanup_lock_requested)
 
     dialog_result: list[str] = []
@@ -975,7 +981,7 @@ def test_browser_dialog_waits_for_terminal_cleanup(monkeypatch):
         )
     )
     cleanup_thread = threading.Thread(
-        target=lambda: (bt.cleanup_browser(task_id), cleanup_done.set()),
+        target=lambda: (bt_lifecycle.cleanup_browser(task_id), cleanup_done.set()),
         name="browser-cleanup-test",
     )
     dialog_thread.start()
@@ -1109,22 +1115,22 @@ def test_terminal_cleanup_waits_for_inflight_subprocess_command(monkeypatch):
         def wait(self, timeout=None):
             return self.returncode
 
-    monkeypatch.setattr(bt, "_find_agent_browser", lambda **_kwargs: "/tmp/fake-agent-browser")
-    monkeypatch.setattr(bt.subprocess, "Popen", _Popen)
+    monkeypatch.setattr(bt_install, "_find_agent_browser", lambda **_kwargs: "/tmp/fake-agent-browser")
+    monkeypatch.setattr(bt_session.subprocess, "Popen", _Popen)
     # The local-Chromium fast-fail gate must not short-circuit this test's
     # fake Popen path: this host may have no real Chromium installed.
-    monkeypatch.setattr(bt, "_is_local_mode", lambda: False)
+    monkeypatch.setattr(bt_cloud, "_is_local_mode", lambda: False)
     _observe_cleanup_lock_request(monkeypatch, cleanup_lock_requested)
     command_result: list[dict] = []
     cleanup_result: list[bool] = []
     command_thread = threading.Thread(
         target=lambda: command_result.append(
-            bt._run_browser_command(task_id, "snapshot", ["-c"])
+            bt_session._run_browser_command(task_id, "snapshot", ["-c"])
         )
     )
 
     def _cleanup():
-        cleanup_result.append(bt.cleanup_browser(task_id))
+        cleanup_result.append(bt_lifecycle.cleanup_browser(task_id))
         cleanup_done.set()
 
     cleanup_thread = threading.Thread(target=_cleanup, name="browser-cleanup-test")
@@ -1171,7 +1177,7 @@ def test_terminal_cleanup_waits_for_inflight_supervisor_eval(monkeypatch):
             return {"ok": True, "result": 1}
 
     monkeypatch.setattr(SUPERVISOR_REGISTRY, "get", lambda _task: _Supervisor())
-    monkeypatch.setattr(bt, "_eval_ssrf_guard_active", lambda _task: False)
+    monkeypatch.setattr(bt_eval_policy, "_eval_ssrf_guard_active", lambda _task: False)
 
     class _Popen:
         def __init__(self, cmd, *, stdout, **_kwargs):
@@ -1183,11 +1189,11 @@ def test_terminal_cleanup_waits_for_inflight_supervisor_eval(monkeypatch):
         def wait(self, timeout=None):
             return self.returncode
 
-    monkeypatch.setattr(bt, "_find_agent_browser", lambda **_kwargs: "/tmp/fake-agent-browser")
-    monkeypatch.setattr(bt.subprocess, "Popen", _Popen)
+    monkeypatch.setattr(bt_install, "_find_agent_browser", lambda **_kwargs: "/tmp/fake-agent-browser")
+    monkeypatch.setattr(bt_session.subprocess, "Popen", _Popen)
     # The local-Chromium fast-fail gate must not short-circuit this test's
     # fake close Popen: this host may have no real Chromium installed.
-    monkeypatch.setattr(bt, "_is_local_mode", lambda: False)
+    monkeypatch.setattr(bt_cloud, "_is_local_mode", lambda: False)
     _observe_cleanup_lock_request(monkeypatch, cleanup_lock_requested)
     eval_result: list[dict] = []
     cleanup_result: list[bool] = []
@@ -1198,7 +1204,7 @@ def test_terminal_cleanup_waits_for_inflight_supervisor_eval(monkeypatch):
     )
 
     def _cleanup():
-        cleanup_result.append(bt.cleanup_browser(task_id))
+        cleanup_result.append(bt_lifecycle.cleanup_browser(task_id))
         cleanup_done.set()
 
     cleanup_thread = threading.Thread(target=_cleanup, name="browser-cleanup-test")

--- a/tests/tools/test_browser_npx_warmup.py
+++ b/tests/tools/test_browser_npx_warmup.py
@@ -8,7 +8,7 @@ It must never raise, must accurately report success/failure via its return
 value, must use a credential-scrubbed and PATH-propagated environment (it
 runs registry-fetched, potentially install-scripted npm code on every
 `hermes update` — not only when a browser tool is actually used), must pass
---ignore-scripts (AGENT_BROWSER_NPX_SPEC is a floating ^0.26.0 range, not an
+--ignore-scripts (AGENT_BROWSER_NPX_SPEC is a floating ^0.34.0 range, not an
 exact pin), and must kill the whole process tree — not just the top-level
 npx PID — on timeout.
 """

--- a/tests/tools/test_browser_npx_warmup.py
+++ b/tests/tools/test_browser_npx_warmup.py
@@ -8,8 +8,8 @@ It must never raise, must accurately report success/failure via its return
 value, must use a credential-scrubbed and PATH-propagated environment (it
 runs registry-fetched, potentially install-scripted npm code on every
 `hermes update` — not only when a browser tool is actually used), must pass
---ignore-scripts (AGENT_BROWSER_NPX_SPEC is a floating ^0.34.0 range, not an
-exact pin), and must kill the whole process tree — not just the top-level
+--ignore-scripts (AGENT_BROWSER_NPX_SPEC is an exact 0.26.0 pin), and must
+kill the whole process tree — not just the top-level
 npx PID — on timeout.
 """
 
@@ -99,6 +99,8 @@ def test_uses_credential_scrubbed_environment():
 
     _args, kwargs = mock_popen.call_args
     assert kwargs["env"]["SCRUBBED"] == "1"
+    assert kwargs["env"]["npm_config_engine_strict"] == "true"
+    assert kwargs["env"]["npm_config_min_release_age"] == "14"
     assert "OPENAI_API_KEY" not in kwargs["env"]
 
 

--- a/tests/tools/test_browser_npx_warmup.py
+++ b/tests/tools/test_browser_npx_warmup.py
@@ -230,12 +230,12 @@ class TestLegacyKillProcessTree:
         monkeypatch.setattr("os.getpgid", lambda pid: 999)
         killpg_calls = []
         monkeypatch.setattr(
-            "os.killpg", lambda pgid, sig: killpg_calls.append((pgid, sig))
+            "os.killpg", lambda pgid, sig: killpg_calls.append((pgid, sig))  # windows-footgun: ok
         )
 
         _legacy_kill_process_tree(proc)
 
-        assert killpg_calls == [(999, signal.SIGTERM), (999, signal.SIGKILL)]
+        assert killpg_calls == [(999, signal.SIGTERM), (999, signal.SIGKILL)]  # windows-footgun: ok
 
     def test_posix_missing_process_returns_silently(self, monkeypatch):
         proc = MagicMock()
@@ -295,7 +295,7 @@ class TestLegacyKillProcessTree:
             killpg_calls.append((pgid, sig))
             raise PermissionError()
 
-        monkeypatch.setattr("os.killpg", fake_killpg)
+        monkeypatch.setattr("os.killpg", fake_killpg)  # windows-footgun: ok
 
         _legacy_kill_process_tree(proc)  # must not raise
 

--- a/tests/tools/test_browser_open_timeout.py
+++ b/tests/tools/test_browser_open_timeout.py
@@ -112,6 +112,9 @@ class TestCommandTimeoutRecovery:
 
         monkeypatch.setattr(bt_install, "_find_agent_browser", lambda: "agent-browser")
         monkeypatch.setattr("tools.browser_tool_install._requires_real_termux_browser_install", lambda _cmd: False)
+        # This fixture drives timeout recovery with a fake subprocess; avoid
+        # the local-Chromium availability gate in the decomposed install owner.
+        monkeypatch.setattr(bt_cloud, "_is_local_mode", lambda: False)
         monkeypatch.setattr("tools.browser_tool_lifecycle._start_browser_cleanup_thread", lambda: None)
         monkeypatch.setattr("tools.browser_tool_cdp._ensure_cdp_supervisor", lambda _: supervisor_events.append("ensure"))
         monkeypatch.setattr("tools.browser_tool_cdp._stop_cdp_supervisor", lambda _: supervisor_events.append("stop"))

--- a/tests/tools/test_browser_orphan_reaper.py
+++ b/tests/tools/test_browser_orphan_reaper.py
@@ -31,7 +31,12 @@ def _isolate_sessions():
 
 
 def _make_socket_dir(
-    tmpdir, session_name, pid=None, owner_pid=None, pinned_target_id=None
+    tmpdir,
+    session_name,
+    pid=None,
+    owner_pid=None,
+    pinned_target_id=None,
+    cdp_endpoint=None,
 ):
     """Create a fake agent-browser socket directory with optional ownership files.
 
@@ -42,6 +47,7 @@ def _make_socket_dir(
         owner_pid: owning hermes PID to write to <session>.owner_pid
                    (None = no file; tests the legacy path)
         pinned_target_id: exact owned target recorded by agent-browser
+        cdp_endpoint: browser-level endpoint persisted by Hermes
     """
     d = tmpdir / f"agent-browser-{session_name}"
     d.mkdir()
@@ -53,6 +59,8 @@ def _make_socket_dir(
         (d / f"{session_name}.target").write_text(
             '{"targetId":"' + pinned_target_id + '","url":"about:blank","pinned":true}'
         )
+    if cdp_endpoint is not None:
+        (d / f"{session_name}.cdp_endpoint").write_text(cdp_endpoint)
     return d
 
 
@@ -214,6 +222,34 @@ class TestReapOrphanedBrowserSessions:
         assert d.exists()
         assert (d / "cdp_dead12345.target").exists()
 
+    def test_dead_daemon_with_endpoint_closes_target_and_removes_directory(
+        self, fake_tmpdir
+    ):
+        from tools.browser_tool import _reap_orphaned_browser_sessions
+
+        d = _make_socket_dir(
+            fake_tmpdir,
+            "cdp_dead_recoverable",
+            pid=12345,
+            owner_pid=54321,
+            pinned_target_id="TARGET-DEAD-RECOVERABLE",
+            cdp_endpoint="ws://shared/devtools/browser/opaque",
+        )
+        with (
+            patch("gateway.status._pid_exists", side_effect=[False, False]),
+            patch(
+                "tools.browser_tool._close_shared_cdp_target_confirmed",
+                return_value=True,
+            ) as close_target,
+        ):
+            _reap_orphaned_browser_sessions()
+
+        close_target.assert_called_once_with(
+            "ws://shared/devtools/browser/opaque",
+            "TARGET-DEAD-RECOVERABLE",
+        )
+        assert not d.exists()
+
     @pytest.mark.parametrize(
         "metadata",
         [
@@ -309,42 +345,41 @@ class TestReapOrphanedBrowserSessions:
 
         _reap_orphaned_browser_sessions()
 
-    def test_orphan_close_uses_exact_named_session_without_discovery(
+    def test_orphan_close_uses_persisted_endpoint_and_exact_target_without_discovery(
         self, fake_tmpdir, monkeypatch
     ):
         import tools.browser_tool as bt
 
-        monkeypatch.setattr(bt, "_find_agent_browser", lambda **_kwargs: "/bin/agent-browser")
-        monkeypatch.setattr(bt, "_build_browser_env", lambda: {"PATH": "/usr/bin"})
-        monkeypatch.setattr(bt, "_merge_browser_path", lambda value: value)
-
-        class _Result:
-            stdout = '{"success":true,"data":{"targetId":"TARGET-OWNED"}}\n'
-
+        session_name = "cdp_exact123"
+        socket_dir = _make_socket_dir(
+            fake_tmpdir,
+            session_name,
+            pinned_target_id="TARGET-OWNED",
+            cdp_endpoint="ws://shared/devtools/browser/opaque",
+        )
         calls = []
-
-        def fake_run(argv, **kwargs):
-            calls.append((argv, kwargs))
-            return _Result()
-
-        monkeypatch.setattr(bt.subprocess, "run", fake_run)
+        monkeypatch.setattr(
+            bt,
+            "_close_shared_cdp_target_confirmed",
+            lambda cdp_url, target_id: calls.append((cdp_url, target_id)) or True,
+        )
         assert bt._close_orphaned_pinned_target(
-            str(fake_tmpdir / "agent-browser-cdp_exact123"), "cdp_exact123"
+            str(socket_dir), session_name
         )
-        argv, kwargs = calls[0]
-        assert argv == [
-            "/bin/agent-browser",
-            "--session",
-            "cdp_exact123",
-            "--pin-tab",
-            "--json",
-            "tab",
-            "close",
-        ]
-        assert "--cdp" not in argv
-        assert kwargs["env"]["AGENT_BROWSER_SOCKET_DIR"].endswith(
-            "agent-browser-cdp_exact123"
+        assert calls == [("ws://shared/devtools/browser/opaque", "TARGET-OWNED")]
+
+    def test_orphan_close_without_persisted_endpoint_fails_closed(self, fake_tmpdir):
+        import tools.browser_tool as bt
+
+        session_name = "cdp_legacy_no_endpoint"
+        socket_dir = _make_socket_dir(
+            fake_tmpdir,
+            session_name,
+            pinned_target_id="TARGET-LEGACY",
         )
+
+        assert bt._close_orphaned_pinned_target(str(socket_dir), session_name) is False
+        assert socket_dir.exists()
 
 
 class TestOwnerPidCrossProcess:
@@ -423,6 +458,65 @@ class TestOwnerPidCrossProcess:
 
         # Must not raise
         bt_lifecycle._write_owner_pid(str(fake_tmpdir), "h_readonly123")
+
+    def test_write_shared_cdp_endpoint_is_private(self, fake_tmpdir):
+        import tools.browser_tool as bt
+
+        session_name = "cdp_private_endpoint"
+        bt._write_shared_cdp_endpoint(
+            str(fake_tmpdir),
+            session_name,
+            "ws://user:secret@shared/devtools/browser/opaque",
+        )
+
+        endpoint_file = fake_tmpdir / f"{session_name}.cdp_endpoint"
+        assert endpoint_file.read_text() == (
+            "ws://user:secret@shared/devtools/browser/opaque"
+        )
+        assert endpoint_file.stat().st_mode & 0o777 == 0o600
+
+    def test_run_browser_command_persists_shared_cdp_endpoint(
+        self, fake_tmpdir, monkeypatch
+    ):
+        import tools.browser_tool as bt
+
+        session_name = "cdp_endpoint_wiring"
+
+        class _FakePopen:
+            def __init__(self, *args, **kwargs):
+                raise RuntimeError("short-circuit after endpoint write")
+
+        monkeypatch.setattr(bt.subprocess, "Popen", _FakePopen)
+        monkeypatch.setattr(bt, "_find_agent_browser", lambda **_kwargs: "/bin/true")
+        monkeypatch.setattr(
+            bt, "_requires_real_termux_browser_install", lambda *args: False
+        )
+        monkeypatch.setattr(bt, "_chromium_installed", lambda: True)
+        monkeypatch.setattr(
+            bt,
+            "_get_session_info",
+            lambda _task_id: {
+                "session_name": session_name,
+                "bb_session_id": None,
+                "cdp_url": "ws://shared/devtools/browser/opaque",
+            },
+        )
+
+        with patch("tools.browser_tool._socket_safe_tmpdir", return_value=str(fake_tmpdir)):
+            result = bt._run_browser_command(
+                task_id="test_task", command="goto", args=[]
+            )
+
+        assert result["success"] is False
+        assert "short-circuit" in result["error"]
+
+        endpoint_file = (
+            fake_tmpdir
+            / f"agent-browser-{session_name}"
+            / f"{session_name}.cdp_endpoint"
+        )
+        assert endpoint_file.read_text() == "ws://shared/devtools/browser/opaque"
+        assert endpoint_file.stat().st_mode & 0o777 == 0o600
 
     def test_run_browser_command_calls_write_owner_pid(
         self, fake_tmpdir, monkeypatch

--- a/tests/tools/test_browser_orphan_reaper.py
+++ b/tests/tools/test_browser_orphan_reaper.py
@@ -3,6 +3,7 @@ daemons whose Python parent exited without cleaning up."""
 
 import os
 import time
+from pathlib import Path
 from unittest.mock import patch
 
 import pytest
@@ -212,6 +213,101 @@ class TestReapOrphanedBrowserSessions:
 
         assert d.exists()
         assert (d / "cdp_dead12345.target").exists()
+
+    @pytest.mark.parametrize(
+        "metadata",
+        [
+            None,
+            "{truncated",
+            "[]",
+            '{"pinned":true}',
+        ],
+        ids=["missing", "truncated", "non_object", "wrong_schema"],
+    )
+    def test_unknown_shared_target_metadata_preserves_daemon_and_directory(
+        self,
+        fake_tmpdir,
+        metadata,
+    ):
+        session_name = f"cdp_unknown_{abs(hash(str(metadata)))}"
+        d = _make_socket_dir(
+            fake_tmpdir,
+            session_name,
+            pid=12345,
+            owner_pid=54321,
+        )
+        if metadata is not None:
+            (d / f"{session_name}.target").write_text(metadata)
+
+        with (
+            patch("gateway.status._pid_exists", return_value=False),
+            patch(
+                "tools.process_registry.ProcessRegistry._terminate_host_pid"
+            ) as terminate,
+        ):
+            self._run_reaper()
+
+        terminate.assert_not_called()
+        assert d.exists()
+
+    def test_unreadable_shared_target_metadata_is_unknown(
+        self,
+        fake_tmpdir,
+        monkeypatch,
+    ):
+        session_name = "cdp_unreadable"
+        d = _make_socket_dir(
+            fake_tmpdir,
+            session_name,
+            pid=12345,
+            owner_pid=54321,
+        )
+        target_file = d / f"{session_name}.target"
+        target_file.write_text('{"pinned":true,"targetId":"TARGET"}')
+        original_read_text = Path.read_text
+
+        def _read_text(path, *args, **kwargs):
+            if path == target_file:
+                raise PermissionError("unreadable")
+            return original_read_text(path, *args, **kwargs)
+
+        monkeypatch.setattr(Path, "read_text", _read_text)
+        with (
+            patch("gateway.status._pid_exists", return_value=False),
+            patch(
+                "tools.process_registry.ProcessRegistry._terminate_host_pid"
+            ) as terminate,
+        ):
+            self._run_reaper()
+
+        terminate.assert_not_called()
+        assert d.exists()
+
+    def test_non_object_metadata_does_not_abort_remaining_orphan_sweep(
+        self,
+        fake_tmpdir,
+    ):
+        cdp_name = "cdp_nonobject_continue"
+        cdp_dir = _make_socket_dir(
+            fake_tmpdir,
+            cdp_name,
+            pid=12345,
+            owner_pid=54321,
+        )
+        (cdp_dir / f"{cdp_name}.target").write_text("[]")
+        legacy_dir = _make_socket_dir(fake_tmpdir, "h_stale_after_unknown")
+
+        with patch("gateway.status._pid_exists", return_value=False):
+            self._run_reaper()
+
+        assert cdp_dir.exists()
+        assert not legacy_dir.exists()
+
+    @staticmethod
+    def _run_reaper():
+        from tools.browser_tool import _reap_orphaned_browser_sessions
+
+        _reap_orphaned_browser_sessions()
 
     def test_orphan_close_uses_exact_named_session_without_discovery(
         self, fake_tmpdir, monkeypatch

--- a/tests/tools/test_browser_orphan_reaper.py
+++ b/tests/tools/test_browser_orphan_reaper.py
@@ -174,9 +174,11 @@ class TestReapOrphanedBrowserSessions:
         )
         terminated = []
         with patch("gateway.status._pid_exists", side_effect=[False, True]), \
+             patch("gateway.status.get_process_start_time", return_value=777), \
              patch("tools.browser_tool._verify_reapable_browser_daemon", return_value=True), \
              patch("tools.browser_tool._close_orphaned_pinned_target", return_value=True) as close_target, \
-             patch("tools.process_registry.ProcessRegistry._terminate_host_pid", side_effect=terminated.append):
+             patch("tools.process_registry.ProcessRegistry._terminate_host_pid",
+                   side_effect=lambda pid, expected_start=None: terminated.append(pid)):
             _reap_orphaned_browser_sessions()
 
         close_target.assert_called_once_with(str(d), "cdp_owned1234")
@@ -332,6 +334,9 @@ class TestReapOrphanedBrowserSessions:
         )
         (cdp_dir / f"{cdp_name}.target").write_text("[]")
         legacy_dir = _make_socket_dir(fake_tmpdir, "h_stale_after_unknown")
+        from tools.browser_tool import BROWSER_ORPHAN_GRACE_SECONDS
+
+        _age_socket_dir(legacy_dir, BROWSER_ORPHAN_GRACE_SECONDS + 600)
 
         with patch("gateway.status._pid_exists", return_value=False):
             self._run_reaper()
@@ -499,6 +504,7 @@ class TestOwnerPidCrossProcess:
                 "session_name": session_name,
                 "bb_session_id": None,
                 "cdp_url": "ws://shared/devtools/browser/opaque",
+                "features": {"cdp_override": True},
             },
         )
 

--- a/tests/tools/test_browser_orphan_reaper.py
+++ b/tests/tools/test_browser_orphan_reaper.py
@@ -29,8 +29,10 @@ def _isolate_sessions():
     bt._active_sessions.update(orig)
 
 
-def _make_socket_dir(tmpdir, session_name, pid=None, owner_pid=None):
-    """Create a fake agent-browser socket directory with optional PID files.
+def _make_socket_dir(
+    tmpdir, session_name, pid=None, owner_pid=None, pinned_target_id=None
+):
+    """Create a fake agent-browser socket directory with optional ownership files.
 
     Args:
         tmpdir: base temp directory
@@ -38,6 +40,7 @@ def _make_socket_dir(tmpdir, session_name, pid=None, owner_pid=None):
         pid: daemon PID to write to <session>.pid (None = no file)
         owner_pid: owning hermes PID to write to <session>.owner_pid
                    (None = no file; tests the legacy path)
+        pinned_target_id: exact owned target recorded by agent-browser
     """
     d = tmpdir / f"agent-browser-{session_name}"
     d.mkdir()
@@ -45,6 +48,10 @@ def _make_socket_dir(tmpdir, session_name, pid=None, owner_pid=None):
         (d / f"{session_name}.pid").write_text(str(pid))
     if owner_pid is not None:
         (d / f"{session_name}.owner_pid").write_text(str(owner_pid))
+    if pinned_target_id is not None:
+        (d / f"{session_name}.target").write_text(
+            '{"targetId":"' + pinned_target_id + '","url":"about:blank","pinned":true}'
+        )
     return d
 
 
@@ -143,6 +150,105 @@ class TestReapOrphanedBrowserSessions:
 
         _reap_orphaned_browser_sessions()
         assert not d.exists()
+
+    def test_live_orphan_closes_exact_pinned_target_before_reaping(
+        self, fake_tmpdir
+    ):
+        from tools.browser_tool import _reap_orphaned_browser_sessions
+
+        d = _make_socket_dir(
+            fake_tmpdir,
+            "cdp_owned1234",
+            pid=12345,
+            owner_pid=54321,
+            pinned_target_id="TARGET-OWNED",
+        )
+        terminated = []
+        with patch("gateway.status._pid_exists", side_effect=[False, True]), \
+             patch("tools.browser_tool._verify_reapable_browser_daemon", return_value=True), \
+             patch("tools.browser_tool._close_orphaned_pinned_target", return_value=True) as close_target, \
+             patch("tools.process_registry.ProcessRegistry._terminate_host_pid", side_effect=terminated.append):
+            _reap_orphaned_browser_sessions()
+
+        close_target.assert_called_once_with(str(d), "cdp_owned1234")
+        assert terminated == [12345]
+        assert not d.exists()
+
+    def test_transient_pinned_close_failure_retains_daemon_and_ownership(
+        self, fake_tmpdir
+    ):
+        from tools.browser_tool import _reap_orphaned_browser_sessions
+
+        d = _make_socket_dir(
+            fake_tmpdir,
+            "cdp_retry1234",
+            pid=12345,
+            owner_pid=54321,
+            pinned_target_id="TARGET-RETRY",
+        )
+        terminated = []
+        with patch("gateway.status._pid_exists", side_effect=[False, True]), \
+             patch("tools.browser_tool._verify_reapable_browser_daemon", return_value=True), \
+             patch("tools.browser_tool._close_orphaned_pinned_target", return_value=False), \
+             patch("tools.process_registry.ProcessRegistry._terminate_host_pid", side_effect=terminated.append):
+            _reap_orphaned_browser_sessions()
+
+        assert terminated == []
+        assert d.exists()
+        assert (d / "cdp_retry1234.target").exists()
+
+    def test_dead_pinned_daemon_retains_exact_ownership_record(self, fake_tmpdir):
+        from tools.browser_tool import _reap_orphaned_browser_sessions
+
+        d = _make_socket_dir(
+            fake_tmpdir,
+            "cdp_dead12345",
+            pid=12345,
+            owner_pid=54321,
+            pinned_target_id="TARGET-DEAD",
+        )
+        with patch("gateway.status._pid_exists", side_effect=[False, False]):
+            _reap_orphaned_browser_sessions()
+
+        assert d.exists()
+        assert (d / "cdp_dead12345.target").exists()
+
+    def test_orphan_close_uses_exact_named_session_without_discovery(
+        self, fake_tmpdir, monkeypatch
+    ):
+        import tools.browser_tool as bt
+
+        monkeypatch.setattr(bt, "_find_agent_browser", lambda **_kwargs: "/bin/agent-browser")
+        monkeypatch.setattr(bt, "_build_browser_env", lambda: {"PATH": "/usr/bin"})
+        monkeypatch.setattr(bt, "_merge_browser_path", lambda value: value)
+
+        class _Result:
+            stdout = '{"success":true,"data":{"targetId":"TARGET-OWNED"}}\n'
+
+        calls = []
+
+        def fake_run(argv, **kwargs):
+            calls.append((argv, kwargs))
+            return _Result()
+
+        monkeypatch.setattr(bt.subprocess, "run", fake_run)
+        assert bt._close_orphaned_pinned_target(
+            str(fake_tmpdir / "agent-browser-cdp_exact123"), "cdp_exact123"
+        )
+        argv, kwargs = calls[0]
+        assert argv == [
+            "/bin/agent-browser",
+            "--session",
+            "cdp_exact123",
+            "--pin-tab",
+            "--json",
+            "tab",
+            "close",
+        ]
+        assert "--cdp" not in argv
+        assert kwargs["env"]["AGENT_BROWSER_SOCKET_DIR"].endswith(
+            "agent-browser-cdp_exact123"
+        )
 
 
 class TestOwnerPidCrossProcess:

--- a/tests/tools/test_browser_orphan_reaper.py
+++ b/tests/tools/test_browser_orphan_reaper.py
@@ -10,6 +10,7 @@ import pytest
 from tools import browser_tool_lifecycle as bt_lifecycle
 from tools import browser_tool_session as bt_session
 from tools import browser_tool_install as bt_install
+from tools import browser_tool_cdp as bt_cdp
 
 
 @pytest.fixture
@@ -52,15 +53,16 @@ def _make_socket_dir(
     d = tmpdir / f"agent-browser-{session_name}"
     d.mkdir()
     if pid is not None:
-        (d / f"{session_name}.pid").write_text(str(pid))
+        (d / f"{session_name}.pid").write_text(str(pid), encoding="utf-8")
     if owner_pid is not None:
-        (d / f"{session_name}.owner_pid").write_text(str(owner_pid))
+        (d / f"{session_name}.owner_pid").write_text(str(owner_pid), encoding="utf-8")
     if pinned_target_id is not None:
         (d / f"{session_name}.target").write_text(
-            '{"targetId":"' + pinned_target_id + '","url":"about:blank","pinned":true}'
+            '{"targetId":"' + pinned_target_id + '","url":"about:blank","pinned":true}',
+            encoding="utf-8",
         )
     if cdp_endpoint is not None:
-        (d / f"{session_name}.cdp_endpoint").write_text(cdp_endpoint)
+        (d / f"{session_name}.cdp_endpoint").write_text(cdp_endpoint, encoding="utf-8")
     return d
 
 
@@ -155,7 +157,7 @@ class TestReapOrphanedBrowserSessions:
         from tools.browser_tool_lifecycle import _reap_orphaned_browser_sessions
 
         d = _make_socket_dir(fake_tmpdir, "h_corrupt1234")
-        (d / "h_corrupt1234.pid").write_text("not-a-number")
+        (d / "h_corrupt1234.pid").write_text("not-a-number", encoding="utf-8")
 
         _reap_orphaned_browser_sessions()
         assert not d.exists()
@@ -163,7 +165,7 @@ class TestReapOrphanedBrowserSessions:
     def test_live_orphan_closes_exact_pinned_target_before_reaping(
         self, fake_tmpdir
     ):
-        from tools.browser_tool import _reap_orphaned_browser_sessions
+        from tools.browser_tool_lifecycle import _reap_orphaned_browser_sessions
 
         d = _make_socket_dir(
             fake_tmpdir,
@@ -175,8 +177,8 @@ class TestReapOrphanedBrowserSessions:
         terminated = []
         with patch("gateway.status._pid_exists", side_effect=[False, True]), \
              patch("gateway.status.get_process_start_time", return_value=777), \
-             patch("tools.browser_tool._verify_reapable_browser_daemon", return_value=True), \
-             patch("tools.browser_tool._close_orphaned_pinned_target", return_value=True) as close_target, \
+             patch("tools.browser_tool_lifecycle._verify_reapable_browser_daemon", return_value=True), \
+             patch("tools.browser_tool_lifecycle._close_orphaned_pinned_target", return_value=True) as close_target, \
              patch("tools.process_registry.ProcessRegistry._terminate_host_pid",
                    side_effect=lambda pid, expected_start=None: terminated.append(pid)):
             _reap_orphaned_browser_sessions()
@@ -188,7 +190,7 @@ class TestReapOrphanedBrowserSessions:
     def test_transient_pinned_close_failure_retains_daemon_and_ownership(
         self, fake_tmpdir
     ):
-        from tools.browser_tool import _reap_orphaned_browser_sessions
+        from tools.browser_tool_lifecycle import _reap_orphaned_browser_sessions
 
         d = _make_socket_dir(
             fake_tmpdir,
@@ -199,8 +201,8 @@ class TestReapOrphanedBrowserSessions:
         )
         terminated = []
         with patch("gateway.status._pid_exists", side_effect=[False, True]), \
-             patch("tools.browser_tool._verify_reapable_browser_daemon", return_value=True), \
-             patch("tools.browser_tool._close_orphaned_pinned_target", return_value=False), \
+             patch("tools.browser_tool_lifecycle._verify_reapable_browser_daemon", return_value=True), \
+             patch("tools.browser_tool_lifecycle._close_orphaned_pinned_target", return_value=False), \
              patch("tools.process_registry.ProcessRegistry._terminate_host_pid", side_effect=terminated.append):
             _reap_orphaned_browser_sessions()
 
@@ -209,7 +211,7 @@ class TestReapOrphanedBrowserSessions:
         assert (d / "cdp_retry1234.target").exists()
 
     def test_dead_pinned_daemon_retains_exact_ownership_record(self, fake_tmpdir):
-        from tools.browser_tool import _reap_orphaned_browser_sessions
+        from tools.browser_tool_lifecycle import _reap_orphaned_browser_sessions
 
         d = _make_socket_dir(
             fake_tmpdir,
@@ -227,7 +229,7 @@ class TestReapOrphanedBrowserSessions:
     def test_dead_daemon_with_endpoint_closes_target_and_removes_directory(
         self, fake_tmpdir
     ):
-        from tools.browser_tool import _reap_orphaned_browser_sessions
+        from tools.browser_tool_lifecycle import _reap_orphaned_browser_sessions
 
         d = _make_socket_dir(
             fake_tmpdir,
@@ -240,7 +242,7 @@ class TestReapOrphanedBrowserSessions:
         with (
             patch("gateway.status._pid_exists", side_effect=[False, False]),
             patch(
-                "tools.browser_tool._close_shared_cdp_target_confirmed",
+                "tools.browser_tool_cdp._close_shared_cdp_target_confirmed",
                 return_value=True,
             ) as close_target,
         ):
@@ -275,7 +277,7 @@ class TestReapOrphanedBrowserSessions:
             owner_pid=54321,
         )
         if metadata is not None:
-            (d / f"{session_name}.target").write_text(metadata)
+            (d / f"{session_name}.target").write_text(metadata, encoding="utf-8")
 
         with (
             patch("gateway.status._pid_exists", return_value=False),
@@ -301,7 +303,7 @@ class TestReapOrphanedBrowserSessions:
             owner_pid=54321,
         )
         target_file = d / f"{session_name}.target"
-        target_file.write_text('{"pinned":true,"targetId":"TARGET"}')
+        target_file.write_text('{"pinned":true,"targetId":"TARGET"}', encoding="utf-8")
         original_read_text = Path.read_text
 
         def _read_text(path, *args, **kwargs):
@@ -332,7 +334,7 @@ class TestReapOrphanedBrowserSessions:
             pid=12345,
             owner_pid=54321,
         )
-        (cdp_dir / f"{cdp_name}.target").write_text("[]")
+        (cdp_dir / f"{cdp_name}.target").write_text("[]", encoding="utf-8")
         legacy_dir = _make_socket_dir(fake_tmpdir, "h_stale_after_unknown")
         from tools.browser_tool import BROWSER_ORPHAN_GRACE_SECONDS
 
@@ -346,15 +348,13 @@ class TestReapOrphanedBrowserSessions:
 
     @staticmethod
     def _run_reaper():
-        from tools.browser_tool import _reap_orphaned_browser_sessions
+        from tools.browser_tool_lifecycle import _reap_orphaned_browser_sessions
 
         _reap_orphaned_browser_sessions()
 
     def test_orphan_close_uses_persisted_endpoint_and_exact_target_without_discovery(
         self, fake_tmpdir, monkeypatch
     ):
-        import tools.browser_tool as bt
-
         session_name = "cdp_exact123"
         socket_dir = _make_socket_dir(
             fake_tmpdir,
@@ -364,18 +364,16 @@ class TestReapOrphanedBrowserSessions:
         )
         calls = []
         monkeypatch.setattr(
-            bt,
+            bt_cdp,
             "_close_shared_cdp_target_confirmed",
             lambda cdp_url, target_id: calls.append((cdp_url, target_id)) or True,
         )
-        assert bt._close_orphaned_pinned_target(
+        assert bt_lifecycle._close_orphaned_pinned_target(
             str(socket_dir), session_name
         )
         assert calls == [("ws://shared/devtools/browser/opaque", "TARGET-OWNED")]
 
     def test_orphan_close_without_persisted_endpoint_fails_closed(self, fake_tmpdir):
-        import tools.browser_tool as bt
-
         session_name = "cdp_legacy_no_endpoint"
         socket_dir = _make_socket_dir(
             fake_tmpdir,
@@ -383,7 +381,7 @@ class TestReapOrphanedBrowserSessions:
             pinned_target_id="TARGET-LEGACY",
         )
 
-        assert bt._close_orphaned_pinned_target(str(socket_dir), session_name) is False
+        assert bt_lifecycle._close_orphaned_pinned_target(str(socket_dir), session_name) is False
         assert socket_dir.exists()
 
 
@@ -465,17 +463,15 @@ class TestOwnerPidCrossProcess:
         bt_lifecycle._write_owner_pid(str(fake_tmpdir), "h_readonly123")
 
     def test_write_shared_cdp_endpoint_is_private(self, fake_tmpdir):
-        import tools.browser_tool as bt
-
         session_name = "cdp_private_endpoint"
-        bt._write_shared_cdp_endpoint(
+        bt_lifecycle._write_shared_cdp_endpoint(
             str(fake_tmpdir),
             session_name,
             "ws://user:secret@shared/devtools/browser/opaque",
         )
 
         endpoint_file = fake_tmpdir / f"{session_name}.cdp_endpoint"
-        assert endpoint_file.read_text() == (
+        assert endpoint_file.read_text(encoding="utf-8") == (
             "ws://user:secret@shared/devtools/browser/opaque"
         )
         assert endpoint_file.stat().st_mode & 0o777 == 0o600
@@ -491,14 +487,14 @@ class TestOwnerPidCrossProcess:
             def __init__(self, *args, **kwargs):
                 raise RuntimeError("short-circuit after endpoint write")
 
-        monkeypatch.setattr(bt.subprocess, "Popen", _FakePopen)
-        monkeypatch.setattr(bt, "_find_agent_browser", lambda **_kwargs: "/bin/true")
+        monkeypatch.setattr(bt_session.subprocess, "Popen", _FakePopen)
+        monkeypatch.setattr(bt_install, "_find_agent_browser", lambda **_kwargs: "/bin/true")
         monkeypatch.setattr(
-            bt, "_requires_real_termux_browser_install", lambda *args: False
+            bt_install, "_requires_real_termux_browser_install", lambda *args: False
         )
-        monkeypatch.setattr(bt, "_chromium_installed", lambda: True)
+        monkeypatch.setattr(bt_install, "_chromium_installed", lambda: True)
         monkeypatch.setattr(
-            bt,
+            bt_session,
             "_get_session_info",
             lambda _task_id: {
                 "session_name": session_name,
@@ -509,7 +505,7 @@ class TestOwnerPidCrossProcess:
         )
 
         with patch("tools.browser_tool._socket_safe_tmpdir", return_value=str(fake_tmpdir)):
-            result = bt._run_browser_command(
+            result = bt_session._run_browser_command(
                 task_id="test_task", command="goto", args=[]
             )
 
@@ -521,7 +517,7 @@ class TestOwnerPidCrossProcess:
             / f"agent-browser-{session_name}"
             / f"{session_name}.cdp_endpoint"
         )
-        assert endpoint_file.read_text() == "ws://shared/devtools/browser/opaque"
+        assert endpoint_file.read_text(encoding="utf-8") == "ws://shared/devtools/browser/opaque"
         assert endpoint_file.stat().st_mode & 0o777 == 0o600
 
     def test_run_browser_command_calls_write_owner_pid(
@@ -537,7 +533,7 @@ class TestOwnerPidCrossProcess:
             def __init__(self, *a, **kw):
                 raise RuntimeError("short-circuit after owner_pid")
 
-        monkeypatch.setattr(bt.subprocess, "Popen", _FakePopen)
+        monkeypatch.setattr(bt_session.subprocess, "Popen", _FakePopen)
         monkeypatch.setattr(bt_install, "_find_agent_browser", lambda: "/bin/true")
         monkeypatch.setattr(
             "tools.browser_tool_install._requires_real_termux_browser_install", lambda *a: False
@@ -735,11 +731,11 @@ class TestSocketDirIdleSeconds:
         d = tmp_path / "agent-browser-h_reuse"
         d.mkdir()
         f = d / "_stdout_click"
-        f.write_text("x")
+        f.write_text("x", encoding="utf-8")
         _age_socket_dir(d, 7200)
         assert _socket_dir_idle_seconds(str(d)) > 7000
 
-        f.write_text("y")  # rewrite in place — dir mtime stays stale
+        f.write_text("y", encoding="utf-8")  # rewrite in place — dir mtime stays stale
         assert time.time() - os.path.getmtime(d) > 7000, "precondition"
         assert _socket_dir_idle_seconds(str(d)) < 5
 
@@ -894,7 +890,7 @@ class TestPeriodicOrphanReap:
                        side_effect=lambda: reap_calls.append(1)), \
                  patch("tools.browser_tool_lifecycle._cleanup_inactive_browser_sessions",
                        side_effect=fake_cleanup), \
-                 patch("tools.browser_tool.time.sleep"):
+                 patch("tools.browser_tool_lifecycle.time.sleep"):
                 bt_lifecycle._browser_cleanup_thread_worker()
         finally:
             bt._cleanup_running = orig_running

--- a/tests/tools/test_browser_supervisor.py
+++ b/tests/tools/test_browser_supervisor.py
@@ -200,6 +200,66 @@ def _fire_on_page(cdp_url: str, expression: str) -> None:
     asyncio.run(run())
 
 
+def _browser_level_call(cdp_url: str, method: str, params=None):
+    """Call one browser-level CDP method without listing or adopting targets."""
+    import websockets as _ws_mod
+
+    async def run():
+        async with _ws_mod.connect(cdp_url, max_size=50 * 1024 * 1024) as ws:
+            await ws.send(json.dumps({"id": 1, "method": method, "params": params or {}}))
+            async for raw in ws:
+                message = json.loads(raw)
+                if message.get("id") != 1:
+                    continue
+                if "error" in message:
+                    raise RuntimeError(f"CDP {method} failed: {message['error']}")
+                return message.get("result", {})
+        raise RuntimeError(f"CDP {method} connection closed without a response")
+
+    return asyncio.run(run())
+
+
+def _evaluate_exact_target(cdp_url: str, target_id: str, expression: str):
+    """Attach to exactly ``target_id`` and evaluate without target discovery."""
+    import websockets as _ws_mod
+
+    async def run():
+        async with _ws_mod.connect(cdp_url, max_size=50 * 1024 * 1024) as ws:
+            next_id = 1
+
+            async def call(method, params=None, session_id=None):
+                nonlocal next_id
+                call_id = next_id
+                next_id += 1
+                payload = {"id": call_id, "method": method}
+                if params:
+                    payload["params"] = params
+                if session_id:
+                    payload["sessionId"] = session_id
+                await ws.send(json.dumps(payload))
+                async for raw in ws:
+                    message = json.loads(raw)
+                    if message.get("id") != call_id:
+                        continue
+                    if "error" in message:
+                        raise RuntimeError(f"CDP {method} failed: {message['error']}")
+                    return message
+
+            attached = await call(
+                "Target.attachToTarget",
+                {"targetId": target_id, "flatten": True},
+            )
+            session_id = attached["result"]["sessionId"]
+            evaluated = await call(
+                "Runtime.evaluate",
+                {"expression": expression, "returnByValue": True},
+                session_id=session_id,
+            )
+            return evaluated["result"]["result"].get("value")
+
+    return asyncio.run(run())
+
+
 @pytest.fixture
 def supervisor_registry():
     """Yield the global registry and tear down any supervisors after the test."""
@@ -351,3 +411,59 @@ def test_evaluate_runtime_unserializable_value(chrome_cdp, supervisor_registry):
     out = supervisor.evaluate_runtime("Infinity")
     assert out["ok"] is True
     assert out["result"] == "Infinity"
+
+
+def test_supervisor_real_cdp_contract_pins_only_owned_target(
+    chrome_cdp, supervisor_registry
+):
+    """Opt-in contract: explicit pinning never adopts or closes another page."""
+    cdp_url, _port = chrome_cdp
+    owned_target_ids = []
+    task_id = "pytest-owned-target-contract"
+
+    try:
+        for title in ("HERMES-OWNED-A", "HERMES-OWNED-B"):
+            page_url = "data:text/html;base64," + base64.b64encode(
+                f"<!doctype html><title>{title}</title><body>{title}</body>".encode()
+            ).decode()
+            created = _browser_level_call(
+                cdp_url,
+                "Target.createTarget",
+                {"url": page_url},
+            )
+            owned_target_ids.append(created["targetId"])
+
+        supervisor = supervisor_registry.get_or_start(
+            task_id=task_id,
+            cdp_url=cdp_url,
+            target_id=owned_target_ids[0],
+        )
+
+        deadline = time.monotonic() + 5
+        evaluated = None
+        while time.monotonic() < deadline:
+            evaluated = supervisor.evaluate_runtime("document.title")
+            if evaluated.get("ok") and evaluated.get("result") == "HERMES-OWNED-A":
+                break
+            time.sleep(0.05)
+
+        assert evaluated == {
+            "ok": True,
+            "result": "HERMES-OWNED-A",
+            "result_type": "string",
+        }
+        assert (
+            _evaluate_exact_target(cdp_url, owned_target_ids[1], "document.title")
+            == "HERMES-OWNED-B"
+        )
+    finally:
+        supervisor_registry.stop(task_id)
+        for target_id in owned_target_ids:
+            try:
+                _browser_level_call(
+                    cdp_url,
+                    "Target.closeTarget",
+                    {"targetId": target_id},
+                )
+            except Exception:
+                pass

--- a/tests/tools/test_browser_supervisor_healthcheck.py
+++ b/tests/tools/test_browser_supervisor_healthcheck.py
@@ -219,3 +219,129 @@ def test_concurrent_different_targets_leave_one_live_supervisor(
     assert sum(supervisor.live for supervisor in created) == 1
     assert sum(supervisor.stop_calls for supervisor in created) == 1
     isolated_registry.stop("race-task")
+
+
+def test_stop_fences_inflight_starter_publication(isolated_registry, monkeypatch):
+    """A starter that completes after stop must be stopped, never published."""
+    started = threading.Event()
+    release = threading.Event()
+    stopped: list[str] = []
+
+    class _BlockingSupervisor:
+        def __init__(
+            self,
+            *,
+            task_id,
+            cdp_url,
+            target_id,
+            dialog_policy,
+            dialog_timeout_s,
+        ):
+            self.task_id = task_id
+            self.cdp_url = cdp_url
+            self.target_id = target_id
+
+        def start(self, timeout=15.0):
+            started.set()
+            assert release.wait(timeout=3)
+
+        def stop(self):
+            stopped.append(self.task_id)
+
+    monkeypatch.setattr(bs, "CDPSupervisor", _BlockingSupervisor)
+    results = []
+    thread = threading.Thread(
+        target=lambda: results.append(
+            isolated_registry.get_or_start(
+                "stop-race",
+                "ws://shared",
+                target_id="TARGET",
+            )
+        )
+    )
+    thread.start()
+    assert started.wait(timeout=3)
+
+    isolated_registry.stop("stop-race")
+    release.set()
+    thread.join(timeout=4)
+
+    assert not thread.is_alive()
+    assert len(results) == 1
+    assert isolated_registry.get("stop-race") is None
+    assert stopped
+
+
+def test_stop_cannot_pass_between_displacement_and_starter_registration(
+    isolated_registry,
+    monkeypatch,
+):
+    """Replacing an old supervisor must register before stopping the old one."""
+    old_stop_entered = threading.Event()
+    release_old_stop = threading.Event()
+
+    def _stop_old():
+        old_stop_entered.set()
+        assert release_old_stop.wait(timeout=3)
+
+    old = SimpleNamespace(
+        cdp_url="ws://old",
+        target_id="OLD",
+        _thread=None,
+        _loop=None,
+        stop=_stop_old,
+    )
+    isolated_registry._by_task["replacement-race"] = old
+
+    created = []
+
+    class _ReplacementSupervisor:
+        def __init__(
+            self,
+            *,
+            task_id,
+            cdp_url,
+            target_id,
+            dialog_policy,
+            dialog_timeout_s,
+        ):
+            self.task_id = task_id
+            self.cdp_url = cdp_url
+            self.target_id = target_id
+            self.live = False
+            self.stop_calls = 0
+            created.append(self)
+
+        def start(self, timeout=15.0):
+            self.live = True
+
+        def stop(self):
+            self.stop_calls += 1
+            self.live = False
+
+    monkeypatch.setattr(bs, "CDPSupervisor", _ReplacementSupervisor)
+    results = []
+    thread = threading.Thread(
+        target=lambda: results.append(
+            isolated_registry.get_or_start(
+                "replacement-race",
+                "ws://new",
+                target_id="NEW",
+            )
+        )
+    )
+    thread.start()
+    assert old_stop_entered.wait(timeout=3)
+
+    # stop() must see the already-registered replacement starter even though
+    # the creator is still blocked while disposing the displaced instance.
+    isolated_registry.stop("replacement-race")
+    release_old_stop.set()
+    thread.join(timeout=4)
+
+    assert not thread.is_alive()
+    assert len(results) == 1
+    assert len(created) == 1
+    assert isolated_registry.get("replacement-race") is None
+    assert created[0].live is False
+    assert created[0].stop_calls >= 1

--- a/tests/tools/test_browser_supervisor_healthcheck.py
+++ b/tests/tools/test_browser_supervisor_healthcheck.py
@@ -221,6 +221,49 @@ def test_concurrent_different_targets_leave_one_live_supervisor(
     isolated_registry.stop("race-task")
 
 
+def test_start_failure_is_stopped_and_never_published(
+    isolated_registry, monkeypatch
+):
+    """A missing pinned target must fail visibly without leaking a starter."""
+    created = []
+
+    class _FailingSupervisor:
+        def __init__(
+            self,
+            *,
+            task_id,
+            cdp_url,
+            target_id,
+            dialog_policy,
+            dialog_timeout_s,
+        ):
+            self.task_id = task_id
+            self.cdp_url = cdp_url
+            self.target_id = target_id
+            self.stop_calls = 0
+            created.append(self)
+
+        def start(self, timeout=15.0):
+            raise RuntimeError("requested pinned target is absent")
+
+        def stop(self):
+            self.stop_calls += 1
+
+    monkeypatch.setattr(bs, "CDPSupervisor", _FailingSupervisor)
+
+    with pytest.raises(RuntimeError, match="requested pinned target is absent"):
+        isolated_registry.get_or_start(
+            "missing-target",
+            "ws://shared",
+            target_id="GONE",
+        )
+
+    assert isolated_registry.get("missing-target") is None
+    assert "missing-target" not in isolated_registry._starting
+    assert len(created) == 1
+    assert created[0].stop_calls == 1
+
+
 def test_stop_fences_inflight_starter_publication(isolated_registry, monkeypatch):
     """A starter that completes after stop must be stopped, never published."""
     started = threading.Event()

--- a/tests/tools/test_browser_supervisor_healthcheck.py
+++ b/tests/tools/test_browser_supervisor_healthcheck.py
@@ -150,6 +150,26 @@ def test_missing_thread_and_loop_attrs_trigger_recreate(
     fresh.stop()
 
 
+def test_inactive_cached_supervisor_triggers_recreate(
+    isolated_registry, stub_cdp_supervisor
+):
+    cdp_url = "http://h/inactive"
+    broken = _make_fake_supervisor(
+        cdp_url,
+        thread_alive=True,
+        loop_running=True,
+    )
+    broken._active = False
+    isolated_registry._by_task["inactive"] = broken
+
+    fresh = isolated_registry.get_or_start(task_id="inactive", cdp_url=cdp_url)
+
+    assert fresh is not broken
+    assert isolated_registry._by_task["inactive"] is fresh
+    broken._thread._release()  # type: ignore[attr-defined]
+    fresh.stop()
+
+
 def test_concurrent_different_targets_leave_one_live_supervisor(
     isolated_registry, monkeypatch
 ):
@@ -388,3 +408,69 @@ def test_stop_cannot_pass_between_displacement_and_starter_registration(
     assert isolated_registry.get("replacement-race") is None
     assert created[0].live is False
     assert created[0].stop_calls >= 1
+
+
+def test_top_level_target_detach_marks_supervisor_inactive_and_clears_state():
+    supervisor = bs.CDPSupervisor(
+        task_id="top-level-detach",
+        cdp_url="ws://shared",
+        target_id="TARGET-TOP",
+    )
+    supervisor._active = True
+    supervisor._page_session_id = "PAGE-SESSION"
+    supervisor._attached_target_id = "TARGET-TOP"
+    supervisor._child_sessions["CHILD-SESSION"] = {"type": "iframe"}
+    supervisor._frames["top"] = bs.FrameInfo(
+        frame_id="top",
+        url="https://example.com",
+        origin="https://example.com",
+        parent_frame_id=None,
+        is_oopif=False,
+        cdp_session_id="PAGE-SESSION",
+    )
+    supervisor._pending_dialogs["d-1"] = bs.PendingDialog(
+        id="d-1",
+        type="alert",
+        message="hello",
+        default_prompt="",
+        opened_at=0.0,
+        cdp_session_id="PAGE-SESSION",
+    )
+
+    supervisor._on_target_detached(
+        {"sessionId": "PAGE-SESSION", "targetId": "TARGET-TOP"}
+    )
+
+    snapshot = supervisor.snapshot()
+    assert snapshot.active is False
+    assert supervisor._page_session_id is None
+    assert supervisor._attached_target_id is None
+    assert supervisor._child_sessions == {}
+    assert snapshot.frame_tree == {"top": None, "children": [], "truncated": False}
+    assert snapshot.pending_dialogs == ()
+
+
+def test_child_target_detach_keeps_frame_but_clears_child_session():
+    supervisor = bs.CDPSupervisor(
+        task_id="child-detach",
+        cdp_url="ws://shared",
+        target_id="TARGET-TOP",
+    )
+    supervisor._active = True
+    supervisor._page_session_id = "PAGE-SESSION"
+    supervisor._attached_target_id = "TARGET-TOP"
+    supervisor._child_sessions["CHILD-SESSION"] = {"type": "iframe"}
+    supervisor._frames["child"] = bs.FrameInfo(
+        frame_id="child",
+        url="https://child.example",
+        origin="https://child.example",
+        parent_frame_id="top",
+        is_oopif=True,
+        cdp_session_id="CHILD-SESSION",
+    )
+
+    supervisor._on_target_detached({"sessionId": "CHILD-SESSION", "targetId": "TARGET-CHILD"})
+
+    assert supervisor.snapshot().active is True
+    assert supervisor._frames["child"].cdp_session_id is None
+    assert supervisor._child_sessions == {}

--- a/tests/tools/test_browser_supervisor_healthcheck.py
+++ b/tests/tools/test_browser_supervisor_healthcheck.py
@@ -23,7 +23,13 @@ class _FakeLoop:
         return self._running
 
 
-def _make_fake_supervisor(cdp_url: str, *, thread_alive: bool, loop_running: bool):
+def _make_fake_supervisor(
+    cdp_url: str,
+    *,
+    target_id: str | None = None,
+    thread_alive: bool,
+    loop_running: bool,
+):
     """Build a minimal stand-in for a CDPSupervisor entry in the registry.
 
     Only the attributes touched by the healthcheck (_thread, _loop, cdp_url)
@@ -45,6 +51,7 @@ def _make_fake_supervisor(cdp_url: str, *, thread_alive: bool, loop_running: boo
 
     fake = SimpleNamespace(
         cdp_url=cdp_url,
+        target_id=target_id,
         _thread=t,
         _loop=_FakeLoop(loop_running),
         stop=lambda: stop_calls.append(True),
@@ -68,9 +75,18 @@ def stub_cdp_supervisor(monkeypatch):
     created: list[SimpleNamespace] = []
 
     class _StubSupervisor:
-        def __init__(self, *, task_id, cdp_url, dialog_policy, dialog_timeout_s):
+        def __init__(
+            self,
+            *,
+            task_id,
+            cdp_url,
+            target_id,
+            dialog_policy,
+            dialog_timeout_s,
+        ):
             self.task_id = task_id
             self.cdp_url = cdp_url
+            self.target_id = target_id
             self.dialog_policy = dialog_policy
             self.dialog_timeout_s = dialog_timeout_s
             # Healthy by default — real thread, running "loop".
@@ -121,6 +137,7 @@ def test_missing_thread_and_loop_attrs_trigger_recreate(
     cdp_url = "http://h/4"
     broken = SimpleNamespace(
         cdp_url=cdp_url,
+        target_id=None,
         _thread=None,
         _loop=None,
         stop=lambda: None,
@@ -131,3 +148,74 @@ def test_missing_thread_and_loop_attrs_trigger_recreate(
     assert fresh is not broken
     assert isolated_registry._by_task["t4"] is fresh
     fresh.stop()
+
+
+def test_concurrent_different_targets_leave_one_live_supervisor(
+    isolated_registry, monkeypatch
+):
+    """A publication race must stop the displaced target supervisor."""
+    start_barrier = threading.Barrier(2)
+    created = []
+
+    class _RacingSupervisor:
+        def __init__(
+            self,
+            *,
+            task_id,
+            cdp_url,
+            target_id,
+            dialog_policy,
+            dialog_timeout_s,
+        ):
+            self.task_id = task_id
+            self.cdp_url = cdp_url
+            self.target_id = target_id
+            self.dialog_policy = dialog_policy
+            self.dialog_timeout_s = dialog_timeout_s
+            self.live = False
+            self.stop_calls = 0
+            created.append(self)
+
+        def start(self, timeout=15.0):
+            self.live = True
+            start_barrier.wait(timeout=2)
+
+        def stop(self):
+            self.stop_calls += 1
+            self.live = False
+
+    monkeypatch.setattr(bs, "CDPSupervisor", _RacingSupervisor)
+    results = []
+    errors = []
+
+    def run(target_id):
+        try:
+            results.append(
+                isolated_registry.get_or_start(
+                    task_id="race-task",
+                    cdp_url="ws://shared",
+                    target_id=target_id,
+                )
+            )
+        except BaseException as exc:  # pragma: no cover - assertion aid
+            errors.append(exc)
+
+    threads = [
+        threading.Thread(target=run, args=("TARGET-A",)),
+        threading.Thread(target=run, args=("TARGET-B",)),
+    ]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=3)
+
+    assert not errors
+    assert all(not thread.is_alive() for thread in threads)
+    assert len(results) == 2
+    assert len(created) == 2
+    managed = isolated_registry.get("race-task")
+    assert managed in created
+    assert managed.live is True
+    assert sum(supervisor.live for supervisor in created) == 1
+    assert sum(supervisor.stop_calls for supervisor in created) == 1
+    isolated_registry.stop("race-task")

--- a/tests/tools/test_browser_use_session_expiry.py
+++ b/tests/tools/test_browser_use_session_expiry.py
@@ -11,8 +11,13 @@ from tools import browser_tool_cloud as bt_cloud
 def _isolate_browser_state(monkeypatch):
     monkeypatch.setattr(browser_tool, "_active_sessions", {})
     monkeypatch.setattr(browser_tool, "_session_last_activity", {})
+    monkeypatch.setattr(browser_tool, "_retired_browser_tasks", set())
+    monkeypatch.setattr(browser_tool, "_browser_task_states", {})
+    monkeypatch.setattr(browser_tool, "_browser_task_generations", {})
+    monkeypatch.setattr(browser_tool, "_browser_task_cleanup_reasons", {})
+    monkeypatch.setattr(browser_tool, "_pending_provider_cleanups", {})
     monkeypatch.setattr("tools.browser_tool_lifecycle._start_browser_cleanup_thread", lambda: None)
-    monkeypatch.setattr("tools.browser_tool_cdp._ensure_cdp_supervisor", lambda task_id: None)
+    monkeypatch.setattr("tools.browser_tool_cdp._ensure_cdp_supervisor", lambda *_a, **_kw: None)
 
 
 def test_browser_use_preserves_provider_timeout(monkeypatch):
@@ -53,6 +58,7 @@ def test_live_cloud_session_is_reused(monkeypatch):
     }
     browser_tool._active_sessions["task-1"] = existing
     provider = Mock()
+    provider.close_session.return_value = True
     monkeypatch.setattr(bt_cloud, "_get_cloud_provider", lambda: provider)
 
     session = bt_session._get_session_info("task-1")
@@ -72,6 +78,7 @@ def test_expired_cloud_session_is_replaced_without_reusing_dead_cdp(monkeypatch)
     browser_tool._session_last_activity["task-1"] = 1.0
 
     provider = Mock()
+    provider.close_session.return_value = True
     provider.create_session.return_value = {
         "session_name": "replacement",
         "bb_session_id": "browser-session-new",

--- a/tools/browser_camofox.py
+++ b/tools/browser_camofox.py
@@ -215,6 +215,13 @@ _sessions: Dict[str, Dict[str, Any]] = {}  # task_id -> {"user_id": str, "tab_id
 _sessions_lock = threading.Lock()
 
 
+def camofox_has_session(task_id: Optional[str] = None) -> bool:
+    """Return whether this process currently tracks a Camofox task session."""
+    task_id = task_id or "default"
+    with _sessions_lock:
+        return task_id in _sessions
+
+
 def _adopt_existing_tab(session: Dict[str, Any]) -> Dict[str, Any]:
     """Rehydrate tab_id from an already-open managed tab: gateway restarts empty the
     in-memory cache while Camofox still holds the integration-owned tab."""

--- a/tools/browser_dialog_tool.py
+++ b/tools/browser_dialog_tool.py
@@ -8,10 +8,13 @@ appears together with ``browser_cdp``. Design: ``website/docs/developer-guide/br
 from __future__ import annotations
 
 import json
+import logging
 from typing import Any, Dict, Optional
 
 from tools.browser_supervisor import SUPERVISOR_REGISTRY
 from tools.registry import registry
+
+logger = logging.getLogger(__name__)
 
 BROWSER_DIALOG_SCHEMA: Dict[str, Any] = {
     "name": "browser_dialog",
@@ -74,18 +77,36 @@ def browser_dialog(
     task_id: Optional[str] = None,
 ) -> str:
     """Respond to a pending dialog on the active task's CDP supervisor."""
-    supervisor = SUPERVISOR_REGISTRY.get(task_id or "default")
-    if supervisor is None:
-        return json.dumps({
-            "success": False,
-            "error": (
-                "No CDP supervisor is attached to this task. Either the "
-                "browser backend doesn't expose CDP (Camofox, default "
-                "Playwright) or no browser session has been started yet. "
-                "Call browser_navigate or /browser connect first."
-            ),
-        })
-    result = supervisor.respond_to_dialog(action=action, prompt_text=prompt_text, dialog_id=dialog_id)
+    effective_task_id = task_id or "default"
+    try:
+        from tools import browser_tool
+        from tools import browser_tool_lifecycle as lifecycle
+
+        bare_task_id = browser_tool._bare_task_id_for_session_key(effective_task_id)
+        with lifecycle._task_cleanup_operation_lock(bare_task_id):
+            if lifecycle._is_browser_task_unavailable(effective_task_id):
+                return json.dumps(
+                    lifecycle._browser_session_retired_result(effective_task_id),
+                    ensure_ascii=False,
+                )
+            session_key = browser_tool._last_session_key(effective_task_id)
+            supervisor = SUPERVISOR_REGISTRY.get(session_key)
+            if supervisor is None:
+                return json.dumps({
+                    "success": False,
+                    "error": (
+                        "No CDP supervisor is attached to this task. Either the "
+                        "browser backend doesn't expose CDP (Camofox, default "
+                        "Playwright) or no browser session has been started yet. "
+                        "Call browser_navigate or /browser connect first."
+                    ),
+                })
+            result = supervisor.respond_to_dialog(
+                action=action, prompt_text=prompt_text, dialog_id=dialog_id
+            )
+    except Exception as exc:
+        logger.debug("browser_dialog lifecycle guard failed: %s", exc)
+        return json.dumps({"success": False, "error": str(exc)})
     if result.get("ok"):
         return json.dumps({"success": True, "action": action, "dialog": result.get("dialog", {})})
     return json.dumps({"success": False, "error": result.get("error", "unknown error")})
@@ -113,9 +134,6 @@ registry.register(
 # Names external plugins imported from this module before the Sep 2026 decomposition.
 # Internal code MUST NOT use these (scripts/check_compat_pointers.py fails CI if it does).
 # The whole block is removed by reverting the commit that added it.
-import logging  # noqa: F401,E402
-
-
 _PLUGIN_COMPAT_LAZY = {
     'logger': ('tools.approval', 'logger'),
 }

--- a/tools/browser_supervisor.py
+++ b/tools/browser_supervisor.py
@@ -50,6 +50,62 @@ class _LoopUnavailable(RuntimeError):
     """The supervisor loop refused new work (closed / shutting down)."""
 
 
+class CDPProtocolError(RuntimeError):
+    """A structured error response returned by the CDP endpoint."""
+
+    def __init__(self, call_id: int, error: Dict[str, Any]) -> None:
+        self.call_id = call_id
+        self.data = dict(error)
+        super().__init__(f"CDP error on id={call_id}: {self.data}")
+
+
+_STALE_SESSION_ERROR_MARKERS = (
+    "session with given id not found",
+    "no session with given id",
+    "target closed",
+    "target is closing",
+)
+
+
+def _is_stale_session_protocol_error(error: Dict[str, Any]) -> bool:
+    message = str(error.get("message") or "").lower()
+    return any(marker in message for marker in _STALE_SESSION_ERROR_MARKERS)
+
+
+def _is_reference_chain_protocol_error(exc: BaseException) -> bool:
+    return isinstance(exc, CDPProtocolError) and (
+        "reference chain is too long" in str(exc.data.get("message") or "").lower()
+    )
+
+
+def _runtime_failure(exc: BaseException) -> Dict[str, Any]:
+    """Shape Runtime.evaluate failures without guessing from page-controlled text."""
+    if isinstance(exc, _LoopUnavailable):
+        return {
+            "ok": False,
+            "kind": "supervisor_unavailable",
+            "error": str(exc),
+            "data": {"reason": "scheduler_unavailable"},
+        }
+    if isinstance(exc, CDPProtocolError):
+        protocol_error = dict(exc.data)
+        return {
+            "ok": False,
+            "kind": "cdp_protocol",
+            "error": str(exc),
+            "data": {
+                "protocol_error": protocol_error,
+                "session_lost": _is_stale_session_protocol_error(protocol_error),
+            },
+        }
+    return {
+        "ok": False,
+        "kind": "cdp_transport",
+        "error": f"{type(exc).__name__}: {exc}",
+        "data": {"exception_type": type(exc).__name__},
+    }
+
+
 def _schedule(coro, loop, *, timeout: float):
     """Run ``coro`` on the supervisor loop from a sync caller and wait for its result."""
     from agent.async_utils import safe_schedule_threadsafe
@@ -88,17 +144,19 @@ class SupervisorSnapshot:
 
 
 class CDPSupervisor(DialogSupervisionMixin, FrameTrackingMixin):
-    """One supervisor per (task_id, cdp_url) pair. ``start()`` spawns a daemon thread
-    running its own asyncio loop, connects, attaches to the first page target, enables
+    """One supervisor per (task_id, cdp_url, target_id) binding. ``start()`` spawns a daemon thread
+    running its own asyncio loop, connects, attaches to the selected page target, enables
     domains and auto-attach. ``snapshot()`` / ``respond_to_dialog()`` / ``evaluate_runtime()``
     are sync, thread-safe bridges onto that loop; all CDP I/O lives on the loop."""
 
-    def __init__(self, task_id: str, cdp_url: str, *, dialog_policy: str = DEFAULT_DIALOG_POLICY,
+    def __init__(self, task_id: str, cdp_url: str, *, target_id: Optional[str] = None,
+                 dialog_policy: str = DEFAULT_DIALOG_POLICY,
                  dialog_timeout_s: float = DEFAULT_DIALOG_TIMEOUT_S) -> None:
         if dialog_policy not in _VALID_POLICIES:
             raise ValueError(f"Invalid dialog_policy {dialog_policy!r}; must be one of {sorted(_VALID_POLICIES)}")
         self.task_id = task_id
         self.cdp_url = cdp_url
+        self.target_id = target_id
         self.dialog_policy = dialog_policy
         self.dialog_timeout_s = float(dialog_timeout_s)
 
@@ -119,6 +177,8 @@ class CDPSupervisor(DialogSupervisionMixin, FrameTrackingMixin):
         self._pending_calls: Dict[int, asyncio.Future] = {}
         self._ws: Optional[ClientConnection] = None
         self._page_session_id: Optional[str] = None
+        self._attached_target_id: Optional[str] = None
+        self._child_sessions: Dict[str, Dict[str, Any]] = {}
         # Dialog auto-dismiss watchdog handles (per dialog id) + id generator.
         self._dialog_watchdogs: Dict[str, asyncio.TimerHandle] = {}
         self._dialog_seq = 0
@@ -210,13 +270,28 @@ class CDPSupervisor(DialogSupervisionMixin, FrameTrackingMixin):
         semantics); non-serializable objects come back as a description string."""
         loop = self._loop
         if loop is None or not loop.is_running():
-            return _fail("supervisor loop is not running")
+            return {
+                "ok": False,
+                "kind": "supervisor_unavailable",
+                "error": "supervisor loop is not running",
+                "data": {"reason": "loop_not_running"},
+            }
         with self._state_lock:
             active, session_id = self._active, self._page_session_id
         if not active:
-            return _fail("supervisor is not active")
+            return {
+                "ok": False,
+                "kind": "supervisor_unavailable",
+                "error": "supervisor is not active",
+                "data": {"reason": "inactive"},
+            }
         if not session_id:
-            return _fail("supervisor has no attached page session")
+            return {
+                "ok": False,
+                "kind": "supervisor_unavailable",
+                "error": "supervisor has no attached page session",
+                "data": {"reason": "no_page_session"},
+            }
 
         def _run_eval(by_value: bool) -> Dict[str, Any]:
             # userGesture: clipboard / fullscreen APIs need user activation.
@@ -228,15 +303,25 @@ class CDPSupervisor(DialogSupervisionMixin, FrameTrackingMixin):
         try:
             response = _run_eval(return_by_value)
         except Exception as exc:
-            # Deep-serializing live DOM nodes / NodeLists / Window can blow past
-            # CDP's recursion guard (``Object reference chain is too long``).
-            # Retry once with returnByValue=False so Chrome returns the description.
-            if not (return_by_value and "reference chain is too long" in str(exc).lower()):
-                return _err(exc)
-            try:
-                response = _run_eval(False)
-            except Exception as exc2:
-                return _err(exc2)
+            # Serialization can fail after the expression already ran. Never
+            # replay it with different parameters: JS side effects are exactly-once.
+            if return_by_value and _is_reference_chain_protocol_error(exc):
+                failure = _runtime_failure(exc)
+                return {
+                    "ok": False,
+                    "kind": "result_serialization_failed",
+                    "error": (
+                        "JavaScript executed once, but its result could not be "
+                        "serialized. Return a primitive value, use JSON.stringify(), "
+                        "or inspect the page with a snapshot."
+                    ),
+                    "data": {
+                        **(failure.get("data") or {}),
+                        "expression_executed": True,
+                        "replayed": False,
+                    },
+                }
+            return _runtime_failure(exc)
 
         # Response: {"result": {"result": {"type", "value", ...}, "exceptionDetails"?}}
         result_payload = response.get("result", {}) if isinstance(response, dict) else {}
@@ -244,7 +329,12 @@ class CDPSupervisor(DialogSupervisionMixin, FrameTrackingMixin):
         if exception_details:
             exc_text = exception_details.get("text") or "JavaScript exception"
             description = (exception_details.get("exception") or {}).get("description")
-            return _fail(f"{exc_text}: {description}" if description else exc_text)
+            return {
+                "ok": False,
+                "kind": "js_exception",
+                "error": f"{exc_text}: {description}" if description else exc_text,
+                "data": {"exception_details": exception_details},
+            }
 
         result_obj = result_payload.get("result", {})
         result_type = result_obj.get("type", "undefined")
@@ -323,6 +413,7 @@ class CDPSupervisor(DialogSupervisionMixin, FrameTrackingMixin):
                 # are deliberately kept — they reconcile as fresh events arrive (worst case a
                 # stale dialog entry is rejected with "no dialog is showing", logged only).
                 self._page_session_id = None
+                self._attached_target_id = None
                 await self._attach_initial_page()
                 self._set_active(True)
                 last_success_at = time.time()
@@ -352,11 +443,27 @@ class CDPSupervisor(DialogSupervisionMixin, FrameTrackingMixin):
             backoff = min(backoff * 2, 10.0)
 
     async def _attach_initial_page(self) -> None:
-        """Find (or create) a page target, attach flattened, enable domains, install dialog bridge."""
+        """Attach the requested page (or first page), then enable its domains."""
         targets = (await self._cdp("Target.getTargets")).get("result", {}).get("targetInfos", [])
-        page_target = next((t for t in targets if t.get("type") == "page"), None)
+        page_target = next(
+            (
+                target
+                for target in targets
+                if target.get("type") == "page"
+                and (
+                    self.target_id is None
+                    or target.get("targetId") == self.target_id
+                )
+            ),
+            None,
+        )
+        if self.target_id is not None and page_target is None:
+            raise RuntimeError(
+                f"Requested CDP page target is unavailable: {self.target_id}"
+            )
         if page_target is None:
             page_target = (await self._cdp("Target.createTarget", {"url": "about:blank"}))["result"]
+        self._attached_target_id = page_target["targetId"]
         attach = await self._cdp("Target.attachToTarget", {"targetId": page_target["targetId"], "flatten": True})
         self._page_session_id = sid = attach["result"]["sessionId"]
         await self._enable_page_domains(sid, timeout=10.0)
@@ -395,7 +502,7 @@ class CDPSupervisor(DialogSupervisionMixin, FrameTrackingMixin):
                     if fut is None or fut.done():
                         continue
                     if "error" in msg:
-                        fut.set_exception(RuntimeError(f"CDP error on id={msg['id']}: {msg['error']}"))
+                        fut.set_exception(CDPProtocolError(msg["id"], msg["error"]))
                     else:
                         fut.set_result(msg)
                 elif handler := self._EVENT_HANDLERS.get(msg.get("method")):
@@ -418,60 +525,153 @@ class _SupervisorRegistry:
     def __init__(self) -> None:
         self._lock = threading.Lock()
         self._by_task: Dict[str, CDPSupervisor] = {}
+        self._generation: Dict[str, int] = {}
+        self._starting: Dict[str, List[CDPSupervisor]] = {}
 
     def get(self, task_id: str) -> Optional[CDPSupervisor]:
         with self._lock:
             return self._by_task.get(task_id)
 
-    def _pop(self, task_id: str) -> Optional[CDPSupervisor]:
-        with self._lock:
-            return self._by_task.pop(task_id, None)
-
-    def get_or_start(self, task_id: str, cdp_url: str, *, dialog_policy: str = DEFAULT_DIALOG_POLICY,
-                     dialog_timeout_s: float = DEFAULT_DIALOG_TIMEOUT_S, start_timeout: float = 15.0) -> CDPSupervisor:
-        """Idempotently ensure a supervisor runs for ``(task_id, cdp_url)``; one bound to a
-        different ``cdp_url`` or unhealthy (dead thread / stopped loop) is stopped and replaced."""
+    def get_or_start(
+        self,
+        task_id: str,
+        cdp_url: str,
+        *,
+        target_id: Optional[str] = None,
+        dialog_policy: str = DEFAULT_DIALOG_POLICY,
+        dialog_timeout_s: float = DEFAULT_DIALOG_TIMEOUT_S,
+        start_timeout: float = 15.0,
+        publish_guard: Optional[Callable[[], bool]] = None,
+    ) -> CDPSupervisor:
+        """Ensure one healthy supervisor for an exact task/url/target binding."""
         with self._lock:
             existing = self._by_task.get(task_id)
             if existing is not None:
                 thread, loop = existing._thread, existing._loop
-                healthy = thread is not None and thread.is_alive() and loop is not None and loop.is_running()
-                if existing.cdp_url == cdp_url and healthy:
+                healthy = (
+                    thread is not None
+                    and thread.is_alive()
+                    and loop is not None
+                    and loop.is_running()
+                    and bool(getattr(existing, "_active", True))
+                )
+                guard_ok = publish_guard is None or publish_guard()
+                if (
+                    existing.cdp_url == cdp_url
+                    and existing.target_id == target_id
+                    and healthy
+                    and guard_ok
+                ):
                     return existing
-                self._by_task.pop(task_id, None)
-        if existing is not None:
-            existing.stop()
+            # Register the starter under the same lock that displaced the old
+            # binding. stop() can now fence it even before start() returns.
+            supervisor = CDPSupervisor(
+                task_id=task_id,
+                cdp_url=cdp_url,
+                target_id=target_id,
+                dialog_policy=dialog_policy,
+                dialog_timeout_s=dialog_timeout_s,
+            )
+            self._by_task.pop(task_id, None)
+            start_generation = self._generation.get(task_id, 0)
+            self._starting.setdefault(task_id, []).append(supervisor)
 
-        supervisor = CDPSupervisor(task_id=task_id, cdp_url=cdp_url,
-                                   dialog_policy=dialog_policy, dialog_timeout_s=dialog_timeout_s)
-        supervisor.start(timeout=start_timeout)
+        try:
+            if existing is not None:
+                existing.stop()
+            supervisor.start(timeout=start_timeout)
+        except BaseException:
+            with self._lock:
+                starters = self._starting.get(task_id, [])
+                if supervisor in starters:
+                    starters.remove(supervisor)
+                if not starters:
+                    self._starting.pop(task_id, None)
+            supervisor.stop()
+            raise
+
+        duplicate: Optional[CDPSupervisor] = None
+        displaced: Optional[CDPSupervisor] = None
         with self._lock:
-            # Guard against a concurrent get_or_start from another thread.
+            starters = self._starting.get(task_id, [])
+            if supervisor in starters:
+                starters.remove(supervisor)
+            if not starters:
+                self._starting.pop(task_id, None)
+
+            stale_start = self._generation.get(task_id, 0) != start_generation
+            if not stale_start and publish_guard is not None:
+                stale_start = not publish_guard()
             already = self._by_task.get(task_id)
-            if already is not None and already.cdp_url == cdp_url:
-                supervisor.stop()
-                return already
-            self._by_task[task_id] = supervisor
+            if stale_start:
+                pass
+            elif (
+                already is not None
+                and already.cdp_url == cdp_url
+                and already.target_id == target_id
+            ):
+                duplicate = already
+            else:
+                displaced = already
+                self._by_task[task_id] = supervisor
+
+        # stop() may block; never call it while holding the registry lock.
+        if stale_start:
+            supervisor.stop()
+            return supervisor
+        if duplicate is not None:
+            supervisor.stop()
+            return duplicate
+        if displaced is not None:
+            displaced.stop()
         return supervisor
 
     def stop(self, task_id: str) -> None:
-        supervisor = self._pop(task_id)
-        if supervisor is not None:
-            supervisor.stop()
+        """Fence, stop, and discard published or in-flight supervisors."""
+        with self._lock:
+            self._generation[task_id] = self._generation.get(task_id, 0) + 1
+            supervisor = self._by_task.pop(task_id, None)
+            starters = list(self._starting.get(task_id, ()))
+        seen: set[int] = set()
+        for item in ([supervisor] if supervisor is not None else []) + starters:
+            if id(item) in seen:
+                continue
+            seen.add(id(item))
+            item.stop()
 
     def stop_all(self) -> None:
         """Stop every running supervisor. For shutdown / test teardown."""
         with self._lock:
-            items = list(self._by_task.values())
+            items = list(self._by_task.items())
             self._by_task.clear()
-        for supervisor in items:
+            starters = [
+                (task_id, supervisor)
+                for task_id, supervisors in self._starting.items()
+                for supervisor in supervisors
+            ]
+            self._starting.clear()
+            for task_id in set(self._generation) | set(self._starting) | {
+                task_id for task_id, _ in items
+            }:
+                self._generation[task_id] = self._generation.get(task_id, 0) + 1
+        seen: set[int] = set()
+        for _, supervisor in items + starters:
+            if id(supervisor) in seen:
+                continue
+            seen.add(id(supervisor))
             supervisor.stop()
 
 
 SUPERVISOR_REGISTRY = _SupervisorRegistry()
 
 
-__all__ = ["CDPSupervisor", "SUPERVISOR_REGISTRY", "SupervisorSnapshot", "_SupervisorRegistry"]
+__all__ = [
+    "CDPProtocolError",
+    "CDPSupervisor",
+    "SUPERVISOR_REGISTRY",
+    "SupervisorSnapshot",
+    "_SupervisorRegistry",
+]
 
 
 # ---- BEGIN PLUGIN-COMPAT (revert-scheduled; see COMPAT_MANIFEST.md) ----

--- a/tools/browser_supervisor_frames.py
+++ b/tools/browser_supervisor_frames.py
@@ -96,6 +96,7 @@ class FrameTrackingMixin:
         target_type = info.get("type")
         if not sid or target_type not in {"iframe", "worker"}:
             return
+        self._child_sessions[sid] = dict(info)
         if target_type == "iframe":
             # Record the frame with its OOPIF session id for interaction routing;
             # origin is filled by frameNavigated on the child session.
@@ -119,12 +120,33 @@ class FrameTrackingMixin:
         await self._install_dialog_bridge(sid)
 
     def _on_target_detached(self, params: Dict[str, Any], session_id: Optional[str] = None) -> None:
-        """Clear the session binding of frames on a detached child session. Frames are
-        deliberately NOT dropped: Browserbase fires transient detaches during page transitions
-        while the iframe is still visible; ``Page.frameDetached`` cleans up if it truly goes away."""
+        """Clear a top-level binding or a detached child-session binding.
+
+        Top-level detach is terminal for this exact target: retaining active
+        state would let eval/dialog calls target a vanished page. Child OOPIF
+        records remain until ``Page.frameDetached`` proves the iframe is gone.
+        """
         sid = params.get("sessionId")
+        target_id = params.get("targetId")
+        top_level = bool(
+            (sid and sid == self._page_session_id)
+            or (target_id and target_id == self._attached_target_id)
+        )
+        if top_level:
+            with self._state_lock:
+                self._page_session_id = None
+                self._attached_target_id = None
+                self._active = False
+                self._pending_dialogs.clear()
+                self._frames.clear()
+            for handle in list(self._dialog_watchdogs.values()):
+                handle.cancel()
+            self._dialog_watchdogs.clear()
+            self._child_sessions.clear()
+            return
         if not sid:
             return
+        self._child_sessions.pop(sid, None)
         with self._state_lock:
             self._frames.update({fid: replace(f, cdp_session_id=None) for fid, f in self._frames.items()
                                  if f.cdp_session_id == sid})

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -9,6 +9,7 @@ Sibling ``browser_tool_*`` modules hold extracted clusters.
 """
 
 import atexit
+import functools
 import json
 import logging
 import os
@@ -123,7 +124,16 @@ _EMPTY_OK_COMMANDS: frozenset = frozenset({"close", "record"})  # legitimately e
 NPX_AGENT_BROWSER_SENTINEL = "npx agent-browser"
 # Pinned to match scripts/install.sh / install.ps1's managed install so a bare-npx
 # resolution gets the same version instead of floating latest. Update together.
-AGENT_BROWSER_NPX_SPEC = "agent-browser@^0.26.0"
+AGENT_BROWSER_NPX_SPEC = "agent-browser@0.26.0"
+
+# ``--pin-tab`` first shipped in agent-browser 0.34.0 and requires Node 24.
+# Keep this capability separate from the generic Node-22-compatible browser
+# path: only user-supplied shared-CDP sessions need the stricter runtime.
+AGENT_BROWSER_PIN_TAB_NPX_SPEC = "agent-browser@0.34.0"
+AGENT_BROWSER_PIN_TAB_MIN_VERSION = (0, 34, 0)
+AGENT_BROWSER_PIN_TAB_MIN_NODE_MAJOR = 24
+AGENT_BROWSER_NPX_MIN_RELEASE_AGE_DAYS = 14
+AGENT_BROWSER_PIN_TAB_FAILURE_TTL_SECONDS = 5.0
 
 # Process caches (``_cached_X`` + ``_X_resolved`` pairs) for config-derived lookups;
 # reset by ``cleanup_all_browsers``. Written/read by the sibling modules via ``browser_tool_origin``.
@@ -142,6 +152,9 @@ _allow_private_urls_resolved = False
 _cached_allow_private_urls: Optional[bool] = None
 _cached_agent_browser: Optional[str] = None
 _agent_browser_resolved = False
+_cached_pin_tab_agent_browser: Optional[str] = None
+_pin_tab_agent_browser_resolved = False
+_pin_tab_failure_cache: Optional[tuple[float, str]] = None
 _cached_browser_engine: Optional[str] = None  # agent-browser v0.25.3+ ``--engine lightpanda``
 _browser_engine_resolved = False
 _auto_local_for_private_urls_resolved = False
@@ -418,6 +431,19 @@ _cleanup_thread = None
 _cleanup_running = False
 _cleanup_lock = threading.Lock()  # protects _session_last_activity AND _active_sessions
 
+# Bare-task lifecycle/generation fencing. Algorithms and enum definitions live
+# in ``browser_tool_lifecycle``; the facade owns the process-global tables so a
+# reload/test namespace still presents one coherent browser state surface.
+_retired_browser_tasks: set[str] = set()
+_browser_task_states: Dict[str, Any] = {}
+_browser_task_generations: Dict[str, int] = {}
+_browser_task_cleanup_reasons: Dict[str, Any] = {}
+_browser_task_cleanup_locks: Dict[str, Any] = {}
+
+# Provider account ownership survives page/daemon cleanup failures. Values are
+# ``browser_tool_lifecycle._PendingProviderCleanup`` records.
+_pending_provider_cleanups: Dict[tuple[str, int, str], Any] = {}
+
 from tools import browser_tool_lifecycle as _lifecycle
 
 # atexit only — NO SIGINT/SIGTERM handlers calling sys.exit(): a SystemExit raised
@@ -689,17 +715,35 @@ def _merge_fallback_warning(response: Dict[str, Any], result: Dict[str, Any]) ->
         _lp._copy_fallback_warning(response, result)
 
 
-def _attach_auto_snapshot(response: Dict[str, Any], nav_session_key: str) -> None:
-    """Add a compact snapshot to a navigate response so the model can act without browser_snapshot."""
+def _attach_auto_snapshot(
+    response: Dict[str, Any], nav_session_key: str
+) -> Optional[Dict[str, Any]]:
+    """Add a compact snapshot; return a structured terminal failure if any."""
     try:
         snap_result = _session._run_browser_command(nav_session_key, "snapshot", ["-c"])
+        if snap_result.get("code") == "tab_gone":
+            return snap_result
         if snap_result.get("success"):
             response.update(_snapshot_fields(snap_result))
             _merge_fallback_warning(response, snap_result)
     except Exception as e:
         logger.debug("Auto-snapshot after navigate failed: %s", e)
+    return None
 
 
+def _serialize_browser_navigation(func):
+    """Keep navigation, target binding, publication, and snapshot atomic."""
+
+    @functools.wraps(func)
+    def _wrapped(url: str, task_id: Optional[str] = None) -> str:
+        bare_task_id = _bare_task_id_for_session_key(task_id or "default")
+        with _lifecycle._task_cleanup_operation_lock(bare_task_id):
+            return func(url, task_id)
+
+    return _wrapped
+
+
+@_serialize_browser_navigation
 def browser_navigate(url: str, task_id: Optional[str] = None) -> str:
     """Navigate to ``url``; JSON with title, compact snapshot and, on first nav, stealth features.
     Hybrid routing decides BEFORE the safety checks whether this URL goes to a local sidecar
@@ -716,6 +760,13 @@ def browser_navigate(url: str, task_id: Optional[str] = None) -> str:
     if safety_error is not None:
         return json.dumps(safety_error)
 
+    try:
+        restarting_retired_task = (
+            _lifecycle._clear_retired_browser_task_for_navigation(effective_task_id)
+        )
+    except _lifecycle._BrowserSessionRetiredError:
+        return _dumps(_lifecycle._browser_session_retired_result(effective_task_id))
+
     if _is_camofox_mode():
         return _camofox("camofox_navigate", url, task_id)
 
@@ -724,7 +775,14 @@ def browser_navigate(url: str, task_id: Optional[str] = None) -> str:
                     "cloud for public URLs; set browser.auto_local_for_private_urls: false to disable)",
                     url, type(_cloud._get_cloud_provider()).__name__ if _cloud._get_cloud_provider() else "none")
 
-    session_info = _session._get_session_info(nav_session_key)
+    try:
+        session_info = _session._get_session_info(nav_session_key)
+    except Exception:
+        if restarting_retired_task:
+            _lifecycle._restore_retired_browser_task_after_failed_navigation(
+                effective_task_id, nav_session_key
+            )
+        raise
     is_first_nav = session_info.get("_first_nav", True)
     if is_first_nav:
         session_info["_first_nav"] = False
@@ -733,13 +791,39 @@ def browser_navigate(url: str, task_id: Optional[str] = None) -> str:
     result = _session._run_browser_command(nav_session_key, "open", [url],
                                   timeout=_get_open_command_timeout(first_open=is_first_nav))
     if not result.get("success"):
-        return _dumps(_err(result.get("error", "Navigation failed")))
+        if restarting_retired_task:
+            _lifecycle._restore_retired_browser_task_after_failed_navigation(
+                effective_task_id, nav_session_key
+            )
+        return _dumps(
+            _lp._copy_fallback_warning(
+                _err(result.get("error", "Navigation failed")), result
+            )
+        )
 
     data = result.get("data", {})
     title = data.get("title", "")
     final_url = data.get("url", url)
+
+    if _lifecycle._is_task_owned_shared_cdp_session(session_info):
+        pinned_target_id = _cdp._pinned_cdp_target_id(nav_session_key)
+        if pinned_target_id:
+            with _cleanup_lock:
+                current_session = _active_sessions.get(nav_session_key)
+                if current_session is session_info:
+                    current_session["target_id"] = pinned_target_id
+            _cdp._ensure_cdp_supervisor(
+                nav_session_key,
+                target_id=pinned_target_id,
+                expected_generation=session_info.get("_lifecycle_generation"),
+            )
+
     blocked = _post_redirect_block(nav_session_key, url, final_url, auto_local_this_nav)
     if blocked is not None:
+        if restarting_retired_task:
+            _lifecycle._restore_retired_browser_task_after_failed_navigation(
+                effective_task_id, nav_session_key
+            )
         return blocked
 
     response = {"success": True, "url": final_url, "title": title}
@@ -751,7 +835,25 @@ def browser_navigate(url: str, task_id: Optional[str] = None) -> str:
     _last_active_session_key[effective_task_id] = nav_session_key
     _lp._copy_fallback_warning(response, result)
     _add_navigate_warnings(response, title, session_info if is_first_nav else None)
-    _attach_auto_snapshot(response, nav_session_key)
+    snapshot_failure = _attach_auto_snapshot(response, nav_session_key)
+    if snapshot_failure is not None:
+        if restarting_retired_task:
+            _lifecycle._restore_retired_browser_task_after_failed_navigation(
+                effective_task_id, nav_session_key
+            )
+        return _dumps(
+            _lp._copy_fallback_warning(
+                {
+                    "success": False,
+                    "error": snapshot_failure.get(
+                        "error", "Pinned browser tab disappeared after navigation"
+                    ),
+                    "url": final_url,
+                    "title": title,
+                },
+                snapshot_failure,
+            )
+        )
     return _dumps(response)
 
 
@@ -954,7 +1056,11 @@ def browser_console(clear: bool = False, expression: Optional[str] = None, task_
 
     clear_args = ["--clear"] if clear else []
     console_result = _session._run_browser_command(effective_task_id, "console", clear_args)
+    if console_result.get("code") == "tab_gone":
+        return _dumps(console_result)
     errors_result = _session._run_browser_command(effective_task_id, "errors", clear_args)
+    if errors_result.get("code") == "tab_gone":
+        return _dumps(errors_result)
 
     messages = [
         {"type": msg.get("type", "log"), "text": _snapshot._redact_browser_output(msg.get("text", "")), "source": "console"}
@@ -1007,21 +1113,78 @@ def _eval_supervisor_fast_path(effective_task_id: str, expression: str) -> Optio
     try:
         from tools.browser_supervisor import SUPERVISOR_REGISTRY  # type: ignore[import-not-found]
         supervisor = SUPERVISOR_REGISTRY.get(effective_task_id)
-        if supervisor is None:
-            return None
-        sup_result = supervisor.evaluate_runtime(expression)
-        if sup_result.get("ok"):
-            return _eval_result_or_blocked(
-                effective_task_id, _parse_eval_value(sup_result.get("result")), {}, method="cdp_supervisor")
-        err = sup_result.get("error") or "evaluate_runtime failed"
-        if "supervisor" not in err.lower():
-            return _dumps(_err(err))
-        logger.debug("browser_eval: supervisor path unavailable (%s), falling back to subprocess", err)
     except ImportError:
-        pass
-    except Exception as exc:  # pragma: no cover — defensive
-        logger.debug("browser_eval: supervisor path errored (%s), falling back", exc)
-    return None
+        return None
+    except Exception as exc:
+        # Lookup failed before any JavaScript dispatch, so fallback is safe.
+        logger.debug("browser_eval: supervisor lookup failed (%s), falling back", exc)
+        return None
+    if supervisor is None:
+        return None
+
+    bare_task_id = _bare_task_id_for_session_key(effective_task_id)
+    with _lifecycle._task_cleanup_operation_lock(bare_task_id):
+        if _lifecycle._is_browser_task_unavailable(effective_task_id):
+            return _dumps(
+                _lifecycle._browser_session_retired_result(effective_task_id)
+            )
+        try:
+            sup_result = supervisor.evaluate_runtime(expression)
+        except Exception as exc:
+            # A live supervisor may have dispatched before raising. Never turn
+            # an ambiguous failure into a second execution through the CLI.
+            return _dumps(
+                {
+                    "success": False,
+                    "error": f"{type(exc).__name__}: {exc}",
+                    "code": "cdp_evaluate_failed",
+                    "data": {"exception_type": type(exc).__name__},
+                }
+            )
+
+    if sup_result.get("ok"):
+        return _eval_result_or_blocked(
+            effective_task_id,
+            _parse_eval_value(sup_result.get("result")),
+            {},
+            method="cdp_supervisor",
+        )
+
+    err = sup_result.get("error") or "evaluate_runtime failed"
+    failure_kind = sup_result.get("kind")
+    failure_data = sup_result.get("data")
+    if failure_kind == "js_exception":
+        return _dumps(
+            {
+                "success": False,
+                "error": err,
+                "code": "javascript_exception",
+                "data": failure_data or {},
+            }
+        )
+    if (
+        failure_kind == "cdp_protocol"
+        and isinstance(failure_data, dict)
+        and failure_data.get("session_lost") is True
+    ):
+        # The stale WS binding did not have a live page session. Let the
+        # named pin owner report structured tab_gone without adopting a tab.
+        _cdp._stop_cdp_supervisor(effective_task_id)
+        return None
+    if failure_kind == "supervisor_unavailable":
+        logger.debug(
+            "browser_eval: supervisor path unavailable (%s), falling back", err
+        )
+        return None
+    # Transport/protocol/serialization failures can happen after JS ran.
+    return _dumps(
+        {
+            "success": False,
+            "error": err,
+            "code": failure_kind or "cdp_evaluate_failed",
+            "data": failure_data or {},
+        }
+    )
 
 
 def _eval_failure_response(result: Dict[str, Any]) -> str:
@@ -1046,6 +1209,11 @@ def _browser_eval(expression: str, task_id: Optional[str] = None) -> str:
     pre-scan closes direct fetches (they never update ``location.href``); the post-eval
     page-URL recheck closes navigate-then-read."""
     effective_task_id = _last_session_key(task_id or "default")
+
+    if _lifecycle._is_browser_task_unavailable(effective_task_id):
+        return _dumps(
+            _lifecycle._browser_session_retired_result(effective_task_id)
+        )
 
     if _eval_policy._eval_ssrf_guard_active(effective_task_id):
         blocked_literal = _eval_policy._expression_targets_private_url(expression)

--- a/tools/browser_tool_cdp.py
+++ b/tools/browser_tool_cdp.py
@@ -2,9 +2,9 @@
 
 Split out of ``tools/browser_tool.py``. Facade-owned state is read through ``_bt`` (``tools.browser_tool``, resolved per call) — no import cycle."""
 
-import contextlib
 import os
-from typing import Tuple
+import time
+from typing import Any, Optional, Tuple
 
 from tools.browser_tool_origin import origin_module as _origin
 
@@ -98,7 +98,12 @@ def _get_dialog_policy_config() -> Tuple[str, float]:
         return DEFAULT_DIALOG_POLICY, DEFAULT_DIALOG_TIMEOUT_S
 
 
-def _ensure_cdp_supervisor(task_id: str) -> None:
+def _ensure_cdp_supervisor(
+    task_id: str,
+    target_id: Optional[str] = None,
+    *,
+    expected_generation: Optional[int] = None,
+) -> None:
     """Start a CDP supervisor for ``task_id`` if an endpoint is reachable.
 
     Idempotent (``get_or_start`` skips an existing ``(task_id, cdp_url)`` and restarts on URL change), so safe on
@@ -107,10 +112,19 @@ def _ensure_cdp_supervisor(task_id: str) -> None:
     snapshots just lack ``pending_dialogs`` / ``frame_tree``.
     """
     _bt = _origin()
+    with _bt._cleanup_lock:
+        session_info = _bt._active_sessions.get(task_id, {})
+        if expected_generation is None:
+            raw_generation = session_info.get("_lifecycle_generation")
+            if isinstance(raw_generation, int) and not isinstance(raw_generation, bool):
+                expected_generation = raw_generation
+
     cdp_url = _get_cdp_override()
+    # A shared endpoint may already contain unrelated pages. Do not attach to
+    # its first page before agent-browser publishes this task's exact pin.
+    if cdp_url and target_id is None:
+        return
     if not cdp_url:
-        with _bt._cleanup_lock:
-            session_info = _bt._active_sessions.get(task_id, {})
         maybe = str(session_info.get("cdp_url") or "")
         if maybe:
             cdp_url = _resolve_cdp_override(maybe)
@@ -118,8 +132,37 @@ def _ensure_cdp_supervisor(task_id: str) -> None:
         return
     try:
         from tools.browser_supervisor import SUPERVISOR_REGISTRY  # type: ignore[import-not-found]
+        from tools import browser_tool_lifecycle as _lifecycle
+
         policy, timeout_s = _get_dialog_policy_config()
-        SUPERVISOR_REGISTRY.get_or_start(task_id=task_id, cdp_url=cdp_url, dialog_policy=policy, dialog_timeout_s=timeout_s)
+
+        def _publication_allowed() -> bool:
+            bare_task_id = _bt._bare_task_id_for_session_key(task_id)
+            with _bt._cleanup_lock:
+                current = _bt._active_sessions.get(task_id)
+                if current is None:
+                    return False
+                if _lifecycle._task_state_locked(bare_task_id) in {
+                    _lifecycle.BrowserTaskState.RETIRING,
+                    _lifecycle.BrowserTaskState.RETIRED,
+                }:
+                    return False
+                if expected_generation is None:
+                    return True
+                return (
+                    _lifecycle._task_generation_locked(bare_task_id)
+                    == expected_generation
+                    and current.get("_lifecycle_generation") == expected_generation
+                )
+
+        SUPERVISOR_REGISTRY.get_or_start(
+            task_id=task_id,
+            cdp_url=cdp_url,
+            target_id=target_id,
+            dialog_policy=policy,
+            dialog_timeout_s=timeout_s,
+            publish_guard=_publication_allowed,
+        )
     except Exception as exc:
         _bt.logger.debug("CDP supervisor attach for task=%s failed (non-fatal): %s", task_id, exc)
 
@@ -131,3 +174,73 @@ def _stop_cdp_supervisor(task_id: str) -> None:
         SUPERVISOR_REGISTRY.stop(task_id)
     except Exception as exc:
         _origin().logger.debug("CDP supervisor stop for task=%s failed (non-fatal): %s", task_id, exc)
+
+
+def _pinned_cdp_target_id(task_id: str) -> Optional[str]:
+    """Return agent-browser's active pinned page target for ``task_id``."""
+    from tools import browser_tool_session as _session
+
+    result = _session._run_browser_command(task_id, "tab", ["list"], timeout=10)
+    if not result.get("success"):
+        return None
+    tabs = result.get("data", {}).get("tabs", [])
+    for tab in tabs if isinstance(tabs, list) else []:
+        if isinstance(tab, dict) and tab.get("active") and tab.get("type") == "page":
+            target_id = str(tab.get("targetId") or "").strip()
+            if target_id:
+                return target_id
+    return None
+
+
+def _close_shared_cdp_target_confirmed(cdp_url: str, target_id: str) -> bool:
+    """Close one shared-CDP target and verify that exact ID disappeared."""
+    _bt = _origin()
+    target_id = str(target_id or "").strip()
+    cdp_url = str(cdp_url or "").strip()
+    if not target_id or not cdp_url:
+        return False
+    try:
+        from tools.browser_cdp_tool import _cdp_call, _run_async
+    except Exception:
+        return False
+
+    def _targets() -> Optional[list[dict[str, Any]]]:
+        try:
+            result = _run_async(
+                _cdp_call(cdp_url, "Target.getTargets", {}, None, 10.0)
+            )
+            raw = result.get("targetInfos", [])
+            return raw if isinstance(raw, list) else None
+        except Exception as exc:
+            _bt.logger.debug("Could not verify shared-CDP target %s: %s", target_id, exc)
+            return None
+
+    try:
+        _run_async(
+            _cdp_call(
+                cdp_url,
+                "Target.closeTarget",
+                {"targetId": target_id},
+                None,
+                10.0,
+            )
+        )
+    except Exception as exc:
+        # The response can be lost after Chrome performed the close. Exact
+        # absence is authoritative; any other outcome remains retryable.
+        _bt.logger.debug("Shared-CDP close for target %s was uncertain: %s", target_id, exc)
+
+    deadline = time.monotonic() + 2.0
+    while True:
+        targets = _targets()
+        if targets is not None:
+            if not any(
+                isinstance(target, dict) and target.get("targetId") == target_id
+                for target in targets
+            ):
+                return True
+            if time.monotonic() >= deadline:
+                return False
+        elif time.monotonic() >= deadline:
+            return False
+        time.sleep(0.05)

--- a/tools/browser_tool_install.py
+++ b/tools/browser_tool_install.py
@@ -5,11 +5,13 @@ Split out of ``tools/browser_tool.py``. Facade-owned state is read through ``_bt
 import contextlib
 import functools
 import os
+import re
 import shutil
 import subprocess
 import sys
+import time
 from pathlib import Path
-from typing import List, Optional
+from typing import Dict, List, Optional
 
 from hermes_cli._subprocess_compat import windows_hide_flags
 from hermes_constants import agent_browser_runnable, get_hermes_home, is_termux as _is_termux_environment, node_tool_runnable
@@ -55,7 +57,31 @@ def _merge_browser_path(existing_path: str = "") -> str:
 
 
 def _browser_install_hint() -> str:
-    return "npm install -g agent-browser && agent-browser install" + ("" if _is_termux_environment() else " --with-deps")
+    package = f"'{_origin().AGENT_BROWSER_NPX_SPEC}'"
+    if _is_termux_environment():
+        return f"npm install -g {package} && agent-browser install"
+    return f"npm install -g {package} && agent-browser install --with-deps"
+
+
+class AgentBrowserCapabilityError(RuntimeError):
+    """The discovered CLI/runtime cannot provide strict shared-CDP pinning."""
+
+
+def _apply_agent_browser_npm_policy(
+    env: Dict[str, str], *, pin_tab_acquisition: bool = False
+) -> Dict[str, str]:
+    """Apply the release-age/engine policy to one agent-browser npx process.
+
+    Ordinary acquisition keeps the 14-day quarantine. The exact reviewed
+    pin-tab package gets a scoped zero-day exception so an empty cache can
+    acquire the security capability immediately.
+    """
+    _bt = _origin()
+    env["npm_config_engine_strict"] = "true"
+    env["npm_config_min_release_age"] = str(
+        0 if pin_tab_acquisition else _bt.AGENT_BROWSER_NPX_MIN_RELEASE_AGE_DAYS
+    )
+    return env
 
 
 def _is_npx_agent_browser_sentinel(browser_cmd: str) -> bool:
@@ -106,7 +132,100 @@ def _agent_browser_candidates(extended_path: str):
         yield shutil.which("agent-browser", path=str(local_bin_dir))
 
 
-def _find_agent_browser(*, validate: bool = True) -> str:
+_SEMVER_TRIPLE_RE = re.compile(r"(?<!\d)(\d+)\.(\d+)\.(\d+)(?![\d-])")
+_NODE_MAJOR_RE = re.compile(r"(?m)^\s*v?(\d+)(?:\.\d+){1,2}\s*$")
+
+
+def _version_probe_env() -> Dict[str, str]:
+    _bt = _origin()
+    env = _bt._build_browser_env()
+    _apply_agent_browser_npm_policy(env)
+    env["PATH"] = _merge_browser_path(env.get("PATH", ""))
+    return env
+
+
+def _probe_agent_browser_version(path: str) -> Optional[tuple[int, int, int]]:
+    """Run a concrete CLI's real ``--version`` entrypoint and parse semver."""
+    if not os.path.exists(path) or (os.name != "nt" and not os.access(path, os.X_OK)):
+        return None
+    try:
+        result = subprocess.run(
+            [path, "--version"],
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=10,
+            env=_version_probe_env(),
+            creationflags=windows_hide_flags(),
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError, ValueError):
+        return None
+    if result.returncode != 0:
+        return None
+    match = _SEMVER_TRIPLE_RE.search(f"{result.stdout}\n{result.stderr}")
+    return tuple(int(part) for part in match.groups()) if match is not None else None
+
+
+def _effective_node_major(executable: str) -> Optional[int]:
+    """Return the Node major the browser subprocess PATH would resolve."""
+    env = _version_probe_env()
+    search_parts = [str(Path(executable).parent)]
+    search_parts.extend(part for part in env.get("PATH", "").split(os.pathsep) if part)
+    node_bin = shutil.which("node", path=os.pathsep.join(dict.fromkeys(search_parts)))
+    if not node_bin:
+        return None
+    try:
+        result = subprocess.run(
+            [node_bin, "--version"],
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=10,
+            env=env,
+            creationflags=windows_hide_flags(),
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError, ValueError):
+        return None
+    if result.returncode != 0:
+        return None
+    match = _NODE_MAJOR_RE.search(f"{result.stdout}\n{result.stderr}")
+    return int(match.group(1)) if match is not None else None
+
+
+def _pin_tab_candidate_status(
+    path: str,
+) -> tuple[bool, Optional[tuple[int, int, int]], Optional[int]]:
+    """Compatibility plus observed CLI/Node versions for one candidate."""
+    _bt = _origin()
+    version = _probe_agent_browser_version(path)
+    if version is None or version < _bt.AGENT_BROWSER_PIN_TAB_MIN_VERSION:
+        return False, version, None
+    node_major = _effective_node_major(path)
+    return (
+        node_major is not None
+        and node_major >= _bt.AGENT_BROWSER_PIN_TAB_MIN_NODE_MAJOR,
+        version,
+        node_major,
+    )
+
+
+def _pin_tab_capability_error(node_major: Optional[int] = None) -> str:
+    _bt = _origin()
+    detected = f" Detected Node.js {node_major}." if node_major is not None else ""
+    return (
+        "Shared-CDP page isolation requires agent-browser >=0.34.0 and "
+        f"Node.js >={_bt.AGENT_BROWSER_PIN_TAB_MIN_NODE_MAJOR}.{detected} "
+        "Hermes and ordinary non-CDP browser commands remain supported on "
+        "Node.js >=22.22. Use Node.js 24+ (Node.js 26 also qualifies) and "
+        "install agent-browser >=0.34.0, then retry."
+    )
+
+
+def _find_agent_browser(*, validate: bool = True, require_pin_tab: bool = False) -> str:
     """Find the agent-browser CLI: PATH, Homebrew/managed dirs, local node_modules/.bin, npx fallback, lazy install.
 
     A bare ``shutil.which`` hit is NOT trusted: agent-browser's npm postinstall re-points a global symlink at our
@@ -124,23 +243,67 @@ def _find_agent_browser(*, validate: bool = True) -> str:
     def _accept(candidate: str) -> str:
         # Set resolved at each accept site (not before the search) so a concurrent reader never sees
         # resolved=True with a None cache.
-        if validate:
+        if validate and require_pin_tab:
+            _bt._cached_pin_tab_agent_browser = candidate
+            _bt._pin_tab_agent_browser_resolved = True
+            _bt._pin_tab_failure_cache = None
+            if not _bt._agent_browser_resolved:
+                _bt._cached_agent_browser = candidate
+                _bt._agent_browser_resolved = True
+        elif validate:
             _bt._cached_agent_browser = candidate
             _bt._agent_browser_resolved = True
         return candidate
 
-    if _bt._agent_browser_resolved:
+    if (
+        require_pin_tab
+        and _bt._pin_tab_agent_browser_resolved
+        and _bt._cached_pin_tab_agent_browser is not None
+    ):
+        return _bt._cached_pin_tab_agent_browser
+    if require_pin_tab and _bt._pin_tab_failure_cache is not None:
+        retry_at, message = _bt._pin_tab_failure_cache
+        if time.monotonic() < retry_at:
+            raise AgentBrowserCapabilityError(message)
+        _bt._pin_tab_failure_cache = None
+    if _bt._agent_browser_resolved and not require_pin_tab:
         if _bt._cached_agent_browser is None:
             raise _not_found(cached=True)
         return _bt._cached_agent_browser
-    ok = agent_browser_runnable if validate else _agent_browser_candidate_present
+
+    detected_node_major: Optional[int] = None
+
+    def candidate_usable(path: str) -> bool:
+        nonlocal detected_node_major
+        if require_pin_tab:
+            usable, _version, node_major = _pin_tab_candidate_status(path)
+            if node_major is not None:
+                detected_node_major = node_major
+            return usable
+        return agent_browser_runnable(path) if validate else _agent_browser_candidate_present(path)
+
     extended_path = _merge_browser_path("")
     for candidate in _agent_browser_candidates(extended_path):
-        if candidate and ok(candidate):
+        if candidate and candidate_usable(candidate):
             return _accept(candidate)
     # npx fallback (also searches the extended PATH)
-    if _resolve_npx_bin():
-        return _accept(_bt.NPX_AGENT_BROWSER_SENTINEL)
+    if npx_path := _resolve_npx_bin():
+        if require_pin_tab:
+            detected_node_major = _effective_node_major(npx_path)
+            if (
+                detected_node_major is not None
+                and detected_node_major >= _bt.AGENT_BROWSER_PIN_TAB_MIN_NODE_MAJOR
+            ):
+                return _accept(_bt.NPX_AGENT_BROWSER_SENTINEL)
+        else:
+            return _accept(_bt.NPX_AGENT_BROWSER_SENTINEL)
+    if require_pin_tab:
+        message = _pin_tab_capability_error(detected_node_major)
+        _bt._pin_tab_failure_cache = (
+            time.monotonic() + _bt.AGENT_BROWSER_PIN_TAB_FAILURE_TTL_SECONDS,
+            message,
+        )
+        raise AgentBrowserCapabilityError(message)
     if not validate:
         raise FileNotFoundError("agent-browser CLI not found")
     try:  # Nothing found — try lazy installation before giving up.
@@ -178,6 +341,7 @@ def warm_agent_browser_npx_cache(timeout: float = 60.0) -> bool:
     if not npx_bin:
         return False
     env = _bt._build_browser_env()
+    _apply_agent_browser_npm_policy(env)
     env["PATH"] = _merge_browser_path(env.get("PATH", ""))
     popen_kwargs: dict = {"stdout": subprocess.PIPE, "stderr": subprocess.PIPE, "text": True, "env": env}
     if os.name == "posix":

--- a/tools/browser_tool_lifecycle.py
+++ b/tools/browser_tool_lifecycle.py
@@ -4,13 +4,16 @@ Split out of ``tools/browser_tool.py``. Facade-owned state is read through ``_bt
 """
 
 import contextlib
+import json
 import os
 import shutil
 import signal
 import subprocess
 import threading
 import time
+from dataclasses import dataclass
 from datetime import datetime, timezone
+from enum import Enum
 from pathlib import Path
 from typing import Any, Dict, Optional, Tuple
 
@@ -21,6 +24,190 @@ from tools import browser_tool_cloud as _cloud
 from tools import browser_tool_session as _session
 from tools import browser_tool_install as _install
 from tools import browser_tool_real_profile as _real_profile
+
+
+class BrowserCleanupReason(str, Enum):
+    """Why browser ownership is being torn down."""
+
+    TERMINAL = "terminal"
+    INACTIVITY = "inactivity"
+    PROVIDER_EXPIRY = "provider_expiry"
+    RESTART_ROLLBACK = "restart_rollback"
+
+
+class BrowserTaskState(str, Enum):
+    """Process-local lifecycle for one bare browser task."""
+
+    STARTING = "starting"
+    ACTIVE = "active"
+    RETIRING = "retiring"
+    RETIRED = "retired"
+
+
+class OrphanTargetOwnership(str, Enum):
+    """Confidence in exact target ownership recovered from daemon metadata."""
+
+    PINNED = "pinned"
+    CONFIRMED_UNPINNED = "confirmed_unpinned"
+    UNKNOWN = "unknown"
+
+
+@dataclass(frozen=True)
+class _PendingProviderCleanup:
+    """Provider session identity retained until close is confirmed."""
+
+    task_id: str
+    provider: Any
+    session_id: str
+
+
+class _BrowserSessionRetiredError(RuntimeError):
+    """Implicit lookup targeted a retired or still-retiring browser task."""
+
+
+def _task_state_locked(bare_task_id: str) -> BrowserTaskState:
+    """Read lifecycle state while ``_cleanup_lock`` is held."""
+    if bare_task_id in _bt._retired_browser_tasks:
+        return BrowserTaskState.RETIRED
+    state = _bt._browser_task_states.get(bare_task_id, BrowserTaskState.ACTIVE)
+    # The compatibility tombstone stays authoritative. A stale RETIRED map
+    # entry cannot survive a test/hot-reload caller clearing the set.
+    return BrowserTaskState.ACTIVE if state is BrowserTaskState.RETIRED else state
+
+
+def _set_task_state_locked(
+    bare_task_id: str,
+    state: BrowserTaskState,
+    *,
+    cleanup_reason: Optional[BrowserCleanupReason] = None,
+) -> None:
+    """Write lifecycle state and keep the compatibility tombstone in sync."""
+    _bt._browser_task_states[bare_task_id] = state
+    if state is BrowserTaskState.RETIRED:
+        _bt._retired_browser_tasks.add(bare_task_id)
+    else:
+        _bt._retired_browser_tasks.discard(bare_task_id)
+    if cleanup_reason is None:
+        if state is not BrowserTaskState.RETIRING:
+            _bt._browser_task_cleanup_reasons.pop(bare_task_id, None)
+    else:
+        _bt._browser_task_cleanup_reasons[bare_task_id] = cleanup_reason
+
+
+def _task_generation_locked(bare_task_id: str) -> int:
+    return _bt._browser_task_generations.get(bare_task_id, 0)
+
+
+def _advance_task_generation_locked(bare_task_id: str) -> int:
+    generation = _task_generation_locked(bare_task_id) + 1
+    _bt._browser_task_generations[bare_task_id] = generation
+    return generation
+
+
+def _task_has_active_sessions_locked(bare_task_id: str) -> bool:
+    return any(
+        _bt._bare_task_id_for_session_key(session_key) == bare_task_id
+        for session_key in _bt._active_sessions
+    )
+
+
+def _task_cleanup_operation_lock(bare_task_id: str) -> Any:
+    """Per-task re-entrant lock shared by commands, dialogs, and cleanup."""
+    with _bt._cleanup_lock:
+        return _bt._browser_task_cleanup_locks.setdefault(
+            bare_task_id, threading.RLock()
+        )
+
+
+def _cleanup_reason_retires_task(reason: BrowserCleanupReason) -> bool:
+    return reason in {
+        BrowserCleanupReason.TERMINAL,
+        BrowserCleanupReason.RESTART_ROLLBACK,
+    }
+
+
+def _coerce_cleanup_reason(reason: BrowserCleanupReason | str) -> BrowserCleanupReason:
+    return reason if isinstance(reason, BrowserCleanupReason) else BrowserCleanupReason(str(reason))
+
+
+def _is_browser_task_unavailable(task_id: str) -> bool:
+    bare_task_id = _bt._bare_task_id_for_session_key(task_id or "default")
+    with _bt._cleanup_lock:
+        return _task_state_locked(bare_task_id) in {
+            BrowserTaskState.RETIRING,
+            BrowserTaskState.RETIRED,
+        }
+
+
+def _is_task_owned_shared_cdp_session(session_info: Dict[str, Any]) -> bool:
+    """True only for a task-owned tab on a user-supplied shared CDP."""
+    features = session_info.get("features")
+    return bool(session_info.get("cdp_url")) and bool(
+        isinstance(features, dict) and features.get("cdp_override") is True
+    )
+
+
+def _is_browser_task_retired(task_id: str) -> bool:
+    bare_task_id = _bt._bare_task_id_for_session_key(task_id or "default")
+    with _bt._cleanup_lock:
+        return _task_state_locked(bare_task_id) is BrowserTaskState.RETIRED
+
+
+def _browser_session_retired_result(task_id: str) -> Dict[str, Any]:
+    bare_task_id = _bt._bare_task_id_for_session_key(task_id or "default")
+    with _bt._cleanup_lock:
+        state = _task_state_locked(bare_task_id)
+        reason = _bt._browser_task_cleanup_reasons.get(bare_task_id)
+    cleanup_pending = state is BrowserTaskState.RETIRING
+    terminal = state is BrowserTaskState.RETIRED or (
+        cleanup_pending
+        and reason is not None
+        and _cleanup_reason_retires_task(reason)
+    )
+    return {
+        "success": False,
+        "error": (
+            "Browser session cleanup is still pending; normal browser commands "
+            "are blocked until exact ownership is released."
+            if cleanup_pending
+            else (
+                "Browser session ownership for this task has been retired. "
+                "Call browser_navigate to start a fresh owned session."
+            )
+        ),
+        "code": "browser_session_retired",
+        "data": {
+            "task_id": bare_task_id,
+            "state": state.value,
+            "terminal": terminal,
+            "cleanup_pending": cleanup_pending,
+            "cleanup_reason": reason.value if reason is not None else None,
+            "recovery": "retry_cleanup" if cleanup_pending else "browser_navigate",
+        },
+    }
+
+
+def _clear_retired_browser_task_for_navigation(task_id: str) -> bool:
+    """Let explicit navigation restart a retired task; return whether it did."""
+    bare_task_id = _bt._bare_task_id_for_session_key(task_id or "default")
+    with _bt._cleanup_lock:
+        state = _task_state_locked(bare_task_id)
+        if state is BrowserTaskState.RETIRING:
+            raise _BrowserSessionRetiredError(bare_task_id)
+        was_retired = state is BrowserTaskState.RETIRED
+        if was_retired:
+            _advance_task_generation_locked(bare_task_id)
+            _set_task_state_locked(bare_task_id, BrowserTaskState.STARTING)
+    if was_retired:
+        _bt.logger.info("Explicit navigation is restarting retired browser task: %s", bare_task_id)
+    return was_retired
+
+
+def _restore_retired_browser_task_after_failed_navigation(
+    task_id: str, session_key: str
+) -> None:
+    """Rollback a failed explicit restart through the exact cleanup path."""
+    cleanup_browser(session_key, reason=BrowserCleanupReason.RESTART_ROLLBACK)
 
 
 def _session_expiry_timestamp(session_info: Dict[str, Any]) -> Optional[float]:
@@ -55,6 +242,94 @@ def _session_has_expired(
     return (time.time() if now is None else now) >= expires_at
 
 
+def _provider_cleanup_key(
+    task_id: str, provider: Any, session_id: str
+) -> Tuple[str, int, str]:
+    return (task_id, id(provider) if provider is not None else 0, session_id)
+
+
+def _remember_pending_provider_cleanup(
+    task_id: str, provider: Any, session_id: str
+) -> None:
+    """Retain provider identity until an authoritative close succeeds."""
+    bare_task_id = _bt._bare_task_id_for_session_key(task_id)
+    record = _PendingProviderCleanup(bare_task_id, provider, session_id)
+    with _bt._cleanup_lock:
+        stale_keys = [
+            key
+            for key, pending in _bt._pending_provider_cleanups.items()
+            if pending.task_id == bare_task_id and pending.session_id == session_id
+        ]
+        for key in stale_keys:
+            _bt._pending_provider_cleanups.pop(key, None)
+        _bt._pending_provider_cleanups[
+            _provider_cleanup_key(bare_task_id, provider, session_id)
+        ] = record
+        # A stale creator may finish after terminal cleanup reached RETIRED.
+        # Reopen cleanup only; normal browser commands remain fenced out.
+        if _task_state_locked(bare_task_id) is BrowserTaskState.RETIRED:
+            _set_task_state_locked(
+                bare_task_id,
+                BrowserTaskState.RETIRING,
+                cleanup_reason=BrowserCleanupReason.TERMINAL,
+            )
+        _bt._session_last_activity.setdefault(bare_task_id, time.time())
+
+
+def _clear_pending_provider_cleanup(task_id: str, session_id: str) -> None:
+    bare_task_id = _bt._bare_task_id_for_session_key(task_id)
+    with _bt._cleanup_lock:
+        stale_keys = [
+            key
+            for key, record in _bt._pending_provider_cleanups.items()
+            if record.task_id == bare_task_id and record.session_id == session_id
+        ]
+        for key in stale_keys:
+            _bt._pending_provider_cleanups.pop(key, None)
+
+
+def _attempt_provider_session_close(
+    task_id: str, provider: Any, session_id: str
+) -> bool:
+    """Close a provider session once and retain exact retry identity on failure."""
+    bare_task_id = _bt._bare_task_id_for_session_key(task_id)
+    owner = provider
+    if owner is None:
+        try:
+            owner = _cloud._get_cloud_provider()
+        except Exception as exc:
+            _bt.logger.warning("Could not resolve cloud browser provider for cleanup: %s", exc)
+    if owner is None:
+        _remember_pending_provider_cleanup(bare_task_id, provider, session_id)
+        return False
+    try:
+        closed = owner.close_session(session_id)
+    except Exception as exc:
+        _bt.logger.warning("Could not close cloud browser session: %s", exc)
+        _remember_pending_provider_cleanup(bare_task_id, owner, session_id)
+        return False
+    if closed is not True:
+        _bt.logger.warning("Cloud browser provider did not confirm session close")
+        _remember_pending_provider_cleanup(bare_task_id, owner, session_id)
+        return False
+    _clear_pending_provider_cleanup(bare_task_id, session_id)
+    return True
+
+
+def _dispose_unpublished_session(
+    task_id: str, session_info: Any, provider: Any = None
+) -> bool:
+    """Dispose provider resources created by a stale or losing creator."""
+    if not isinstance(session_info, dict):
+        return True
+    session_id = session_info.get("bb_session_id")
+    if not session_id:
+        # Local/shared-CDP candidates are metadata-only until first command.
+        return True
+    owner = session_info.get("_provider_cleanup_owner", provider)
+    return _attempt_provider_session_close(task_id, owner, str(session_id))
+
+
 def _best_effort(label: str, fn) -> None:
     """Run ``fn()``; log (debug) and swallow any exception — teardown must never abort."""
     try:
@@ -80,8 +355,9 @@ def _emergency_cleanup_all_sessions():
     # Real-profile Chrome is launched directly (not by agent-browser), so the
     # session cleanup never reaps it.
     _best_effort("Real-profile chrome cleanup on exit", _real_profile._terminate_real_profile_chrome)
-    if _bt._active_sessions:
-        _bt.logger.info("Emergency cleanup: closing %s active session(s)...", len(_bt._active_sessions))
+    if _bt._active_sessions or _bt._pending_provider_cleanups:
+        ownership_count = len(_bt._active_sessions) + len(_bt._pending_provider_cleanups)
+        _bt.logger.info("Emergency cleanup: closing %s active/pending browser ownership(s)...", ownership_count)
         try:
             cleanup_all_browsers()
         except Exception as e:
@@ -151,16 +427,36 @@ def _cleanup_inactive_browser_sessions():
     current_time = time.time()
 
     with _bt._cleanup_lock:
-        sessions_to_cleanup = [task_id for task_id, last_time in list(_bt._session_last_activity.items())
-                               if current_time - last_time > _bt.BROWSER_SESSION_INACTIVITY_TIMEOUT]
+        sessions_to_cleanup = []
+        for task_id, last_time in list(_bt._session_last_activity.items()):
+            session_info = _bt._active_sessions.get(task_id)
+            # Shared-CDP silence is not turn inactivity: the model may be
+            # waiting on the page. Only an already-pending cleanup retry may be
+            # driven by the janitor; normal ownership ends at the turn boundary.
+            if (
+                session_info
+                and _is_task_owned_shared_cdp_session(session_info)
+                and not session_info.get("_cleanup_retry_pending")
+            ):
+                continue
+            if current_time - last_time > _bt.BROWSER_SESSION_INACTIVITY_TIMEOUT:
+                sessions_to_cleanup.append(task_id)
 
     for task_id in sessions_to_cleanup:
         elapsed = int(current_time - _bt._session_last_activity.get(task_id, current_time))
         _bt.logger.info("Cleaning up inactive session for task: %s (inactive for %ss)", task_id, elapsed)
         try:
             with _session_owner_scope(task_id):
-                cleanup_browser(task_id)
-            _forget_session_tracking(task_id)
+                cleanup_succeeded = cleanup_browser(
+                    task_id, reason=BrowserCleanupReason.INACTIVITY
+                )
+            if cleanup_succeeded:
+                _forget_session_tracking(task_id)
+            else:
+                # Keep ownership retryable without hammering it every tick.
+                with _bt._cleanup_lock:
+                    if task_id in _bt._session_last_activity:
+                        _bt._session_last_activity[task_id] = current_time
         except Exception as e:
             with _bt._cleanup_lock:
                 failures = _bt._cleanup_failures[task_id] = _bt._cleanup_failures.get(task_id, 0) + 1
@@ -189,6 +485,28 @@ def _write_owner_pid(socket_dir: str, session_name: str) -> None:
             f.write(str(os.getpid()))
     except OSError as exc:
         _bt.logger.debug("Could not write owner_pid file for %s: %s", session_name, exc)
+
+
+def _write_shared_cdp_endpoint(
+    socket_dir: str, session_name: str, cdp_url: str
+) -> None:
+    """Persist the browser endpoint needed for exact orphan target cleanup.
+
+    It may contain authentication material, so the file is private. Failure is
+    fail-closed: the orphan reaper retains the ownership directory instead of
+    discovering or guessing a replacement target.
+    """
+    cdp_url = str(cdp_url or "").strip()
+    if not cdp_url:
+        return
+    path = os.path.join(socket_dir, f"{session_name}.cdp_endpoint")
+    try:
+        fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            handle.write(cdp_url)
+        os.chmod(path, 0o600)
+    except OSError as exc:
+        _bt.logger.debug("Could not persist shared-CDP endpoint for %s: %s", session_name, exc)
 
 
 def _verify_reapable_browser_daemon(daemon_pid: int, socket_dir: str,
@@ -291,6 +609,73 @@ def _terminate_verified_daemon(daemon_pid: int, session_name: str, log) -> bool:
     return True
 
 
+def _orphan_target_ownership(
+    socket_dir: str, session_name: str
+) -> OrphanTargetOwnership:
+    """Classify exact target ownership without guessing from bad metadata."""
+    target_file = Path(socket_dir) / f"{session_name}.target"
+    if not target_file.exists():
+        return (
+            OrphanTargetOwnership.UNKNOWN
+            if session_name.startswith("cdp_")
+            else OrphanTargetOwnership.CONFIRMED_UNPINNED
+        )
+    try:
+        payload = json.loads(target_file.read_text(encoding="utf-8"))
+    except (OSError, ValueError, TypeError):
+        return OrphanTargetOwnership.UNKNOWN
+    if not isinstance(payload, dict):
+        return OrphanTargetOwnership.UNKNOWN
+    target_id = payload.get("targetId")
+    if payload.get("pinned") is True and isinstance(target_id, str) and target_id:
+        return OrphanTargetOwnership.PINNED
+    if payload.get("pinned") is False:
+        return OrphanTargetOwnership.CONFIRMED_UNPINNED
+    return OrphanTargetOwnership.UNKNOWN
+
+
+def _read_recorded_pinned_target_id(
+    socket_dir: str, session_name: str
+) -> Optional[str]:
+    """Read only an explicitly pinned target id from daemon metadata."""
+    try:
+        payload = json.loads(
+            (Path(socket_dir) / f"{session_name}.target").read_text(
+                encoding="utf-8"
+            )
+        )
+    except (OSError, ValueError, TypeError):
+        return None
+    if not isinstance(payload, dict) or payload.get("pinned") is not True:
+        return None
+    target_id = payload.get("targetId")
+    if not isinstance(target_id, str) or not target_id.strip():
+        return None
+    return target_id.strip()
+
+
+def _orphan_has_pinned_target(socket_dir: str, session_name: str) -> bool:
+    """Compatibility predicate; the reaper itself uses tri-state ownership."""
+    return (
+        _orphan_target_ownership(socket_dir, session_name)
+        is OrphanTargetOwnership.PINNED
+    )
+
+
+def _close_orphaned_pinned_target(socket_dir: str, session_name: str) -> bool:
+    """Close only the persisted exact target through its persisted endpoint."""
+    try:
+        target_id = _read_recorded_pinned_target_id(socket_dir, session_name)
+        cdp_url = (
+            Path(socket_dir) / f"{session_name}.cdp_endpoint"
+        ).read_text(encoding="utf-8").strip()
+    except (OSError, ValueError, TypeError):
+        return False
+    if not target_id or not cdp_url:
+        return False
+    return _cdp._close_shared_cdp_target_confirmed(cdp_url, target_id)
+
+
 def _reap_socket_dir(socket_dir: str, session_name: str, tracked_names: set) -> bool:
     """Reap one ``agent-browser-<session>`` dir if orphaned; True when a daemon was killed.
 
@@ -315,10 +700,36 @@ def _reap_socket_dir(socket_dir: str, session_name: str, tracked_names: set) -> 
     elif owner_alive is None and session_name in tracked_names:
         return False
 
+    target_ownership = _orphan_target_ownership(socket_dir, session_name)
+    if target_ownership is OrphanTargetOwnership.UNKNOWN:
+        _bt.logger.warning(
+            "Orphaned shared-CDP target metadata for session %s is missing "
+            "or unreadable; retaining daemon and ownership directory",
+            session_name,
+        )
+        return False
+    pinned_target_owned = target_ownership is OrphanTargetOwnership.PINNED
+    if pinned_target_owned and not _close_orphaned_pinned_target(
+        socket_dir, session_name
+    ):
+        _bt.logger.warning(
+            "Could not confirm exact pinned target close for orphaned session %s; "
+            "retaining daemon and ownership metadata for retry",
+            session_name,
+        )
+        return False
+
     pid_file = os.path.join(socket_dir, f"{session_name}.pid")
     if not os.path.isfile(pid_file):
         idle_s = _socket_dir_idle_seconds(socket_dir)
         if idle_s is None or idle_s < _bt.BROWSER_ORPHAN_GRACE_SECONDS:
+            return False
+        if pinned_target_owned:
+            _bt.logger.warning(
+                "Orphaned pinned target metadata for session %s has no daemon PID; "
+                "retaining ownership record for manual recovery",
+                session_name,
+            )
             return False
         shutil.rmtree(socket_dir, ignore_errors=True)
         return False
@@ -532,29 +943,243 @@ def _cleanup_old_recordings(max_age_hours=72):
         _unlink_older_than(recordings_dir, "session_*.webm", max_age_hours, "recording")
 
 
-def _drop_last_active_binding(task_id: str) -> None:
-    """Drop stale last-active ownership after cleaning ``task_id``: a bare task always, a
-    sidecar only if it was still the recorded owner (a later click must not resurrect a
-    cleaned sidecar while a primary-session binding is preserved)."""
-    bare_task_id = _bt._bare_task_id_for_session_key(task_id)
-    if bare_task_id == task_id or _bt._last_active_session_key.get(bare_task_id) == task_id:
-        _bt._last_active_session_key.pop(bare_task_id, None)
+def _retry_provider_cleanup_records(
+    records: list[_PendingProviderCleanup],
+) -> bool:
+    all_closed = True
+    for record in records:
+        if not _attempt_provider_session_close(
+            record.task_id, record.provider, record.session_id
+        ):
+            all_closed = False
+    return all_closed
 
 
-def cleanup_browser(task_id: Optional[str] = None) -> None:
-    """Clean up browser session(s) for a task: a bare task id reaps BOTH the primary
-    session and any hybrid local sidecar; a ``::local`` key reaps only that one."""
-    if task_id is None:
-        task_id = "default"
+def _begin_task_cleanup_locked(
+    bare_task_id: str, reason: BrowserCleanupReason
+) -> BrowserCleanupReason:
+    """Enter RETIRING and advance generation before inspecting ownership."""
+    state = _task_state_locked(bare_task_id)
+    previous_reason = _bt._browser_task_cleanup_reasons.get(bare_task_id)
+    if state is BrowserTaskState.RETIRED:
+        effective_reason = BrowserCleanupReason.TERMINAL
+    elif (
+        state is BrowserTaskState.RETIRING
+        and previous_reason is not None
+        and _cleanup_reason_retires_task(previous_reason)
+        and not _cleanup_reason_retires_task(reason)
+    ):
+        effective_reason = previous_reason
+    else:
+        effective_reason = reason
+    _advance_task_generation_locked(bare_task_id)
+    _set_task_state_locked(
+        bare_task_id,
+        BrowserTaskState.RETIRING,
+        cleanup_reason=effective_reason,
+    )
+    return effective_reason
 
-    session_keys = [task_id]
-    sidecar_key = f"{task_id}{_bt._LOCAL_SUFFIX}"
+
+def _is_hermes_owned_local_browser_session(session_info: Dict[str, Any]) -> bool:
+    """Whether headed cross-turn persistence may retain this session."""
+    features = session_info.get("features")
+    if isinstance(features, dict) and features.get("local") is True:
+        return not session_info.get("bb_session_id") and not bool(
+            features.get("cdp_override")
+        )
+    # Hot-reload compatibility for throwaway-local rows predating features.
+    return not session_info.get("cdp_url") and not session_info.get("bb_session_id")
+
+
+def _cleanup_browser_session_keys(
+    task_id: str,
+    session_keys: Optional[list[str]] = None,
+    *,
+    reason: BrowserCleanupReason | str,
+    preserve_local_headed: bool = False,
+) -> bool:
+    """Cleanup selected ownership under one bare-task lifecycle transition."""
+    reason = _coerce_cleanup_reason(reason)
+    bare_task_id = _bt._bare_task_id_for_session_key(task_id or "default")
+    include_camofox = session_keys is None and _bt._is_camofox_mode()
+
+    # Browser-free turns are a true no-op: do not leak lifecycle rows/locks.
     with _bt._cleanup_lock:
-        if not _bt._is_local_sidecar_key(task_id) and sidecar_key in _bt._active_sessions:
-            session_keys.append(sidecar_key)
-    for session_key in session_keys:
-        _cleanup_single_browser_session(session_key)
-    _drop_last_active_binding(task_id)
+        state = _task_state_locked(bare_task_id)
+        if session_keys is None:
+            has_selected_session = any(
+                _bt._bare_task_id_for_session_key(key) == bare_task_id
+                for key in _bt._active_sessions
+            )
+        else:
+            has_selected_session = any(
+                key in _bt._active_sessions for key in dict.fromkeys(session_keys)
+            )
+        has_pending_provider = any(
+            record.task_id == bare_task_id
+            for record in _bt._pending_provider_cleanups.values()
+        )
+        if (
+            not include_camofox
+            and not has_selected_session
+            and not has_pending_provider
+            and bare_task_id not in _bt._browser_task_cleanup_locks
+            and state in {BrowserTaskState.ACTIVE, BrowserTaskState.RETIRED}
+        ):
+            return True
+
+    with _task_cleanup_operation_lock(bare_task_id):
+        with _bt._cleanup_lock:
+            effective_reason = _begin_task_cleanup_locked(bare_task_id, reason)
+            if session_keys is None:
+                if _bt._is_local_sidecar_key(task_id):
+                    selected_keys = [task_id] if task_id in _bt._active_sessions else []
+                else:
+                    selected_keys = [
+                        key
+                        for key, info in _bt._active_sessions.items()
+                        if _bt._bare_task_id_for_session_key(key) == bare_task_id
+                        and not (
+                            preserve_local_headed
+                            and _is_hermes_owned_local_browser_session(info)
+                        )
+                    ]
+            else:
+                selected_keys = list(dict.fromkeys(session_keys))
+            if include_camofox and task_id not in selected_keys:
+                selected_keys.append(task_id)
+            pending_before = [
+                record
+                for record in _bt._pending_provider_cleanups.values()
+                if record.task_id == bare_task_id
+            ]
+
+        # Fence in-flight supervisor starters for task keys without a selected
+        # published session. Selected sessions stop only after exact target close.
+        for supervisor_key in {task_id} - set(selected_keys):
+            _cdp._stop_cdp_supervisor(supervisor_key)
+
+        pending_retries_closed = _retry_provider_cleanup_records(pending_before)
+        cleanup_results = {
+            session_key: _cleanup_single_browser_session(session_key)
+            for session_key in selected_keys
+        }
+        failed_keys = [
+            key for key, cleaned in cleanup_results.items() if cleaned is False
+        ]
+
+        with _bt._cleanup_lock:
+            retained_failed_keys = []
+            for failed_key in failed_keys:
+                retained = _bt._active_sessions.get(failed_key)
+                if retained is not None:
+                    retained["_cleanup_retry_pending"] = True
+                    retained_failed_keys.append(failed_key)
+
+            recorded_key = _bt._last_active_session_key.get(bare_task_id)
+            if retained_failed_keys:
+                if recorded_key not in retained_failed_keys:
+                    _bt._last_active_session_key[bare_task_id] = retained_failed_keys[0]
+            elif recorded_key in selected_keys:
+                sidecar_key = f"{bare_task_id}{_bt._LOCAL_SUFFIX}"
+                if (
+                    task_id == bare_task_id
+                    and sidecar_key not in selected_keys
+                    and sidecar_key in _bt._active_sessions
+                ):
+                    _bt._last_active_session_key[bare_task_id] = sidecar_key
+                else:
+                    _bt._last_active_session_key.pop(bare_task_id, None)
+            elif (
+                not failed_keys
+                and not _bt._is_local_sidecar_key(task_id)
+                and not _task_has_active_sessions_locked(bare_task_id)
+            ):
+                _bt._last_active_session_key.pop(bare_task_id, None)
+
+            has_active_sessions = _task_has_active_sessions_locked(bare_task_id)
+            has_pending_provider = any(
+                record.task_id == bare_task_id
+                for record in _bt._pending_provider_cleanups.values()
+            )
+            cleanup_confirmed = (
+                not failed_keys
+                and pending_retries_closed
+                and not has_pending_provider
+            )
+            if cleanup_confirmed:
+                if has_active_sessions:
+                    _set_task_state_locked(bare_task_id, BrowserTaskState.ACTIVE)
+                elif _cleanup_reason_retires_task(effective_reason):
+                    _set_task_state_locked(bare_task_id, BrowserTaskState.RETIRED)
+                else:
+                    _set_task_state_locked(bare_task_id, BrowserTaskState.ACTIVE)
+                if not has_active_sessions:
+                    for activity_key in list(_bt._session_last_activity):
+                        if _bt._bare_task_id_for_session_key(activity_key) == bare_task_id:
+                            _bt._session_last_activity.pop(activity_key, None)
+            else:
+                _set_task_state_locked(
+                    bare_task_id,
+                    BrowserTaskState.RETIRING,
+                    cleanup_reason=effective_reason,
+                )
+                _bt._session_last_activity.setdefault(bare_task_id, time.time())
+        return cleanup_confirmed
+
+
+def cleanup_browser(
+    task_id: Optional[str] = None,
+    *,
+    reason: BrowserCleanupReason | str = BrowserCleanupReason.TERMINAL,
+) -> bool:
+    """Clean all ownership for a task (primary + sidecar for bare ids)."""
+    return _cleanup_browser_session_keys(task_id or "default", reason=reason)
+
+
+def cleanup_browser_for_turn(task_id: Optional[str] = None) -> bool:
+    """Finalize a turn while retaining only Hermes-owned local headed state."""
+    task_id = task_id or "default"
+    preserve_local = _cloud._is_headed_mode()
+    if _bt._is_camofox_mode():
+        if preserve_local:
+            return True
+        try:
+            from tools.browser_camofox import camofox_has_session
+
+            if not camofox_has_session(task_id):
+                bare_task_id = _bt._bare_task_id_for_session_key(task_id)
+                with _bt._cleanup_lock:
+                    if bare_task_id not in _bt._browser_task_cleanup_locks:
+                        return True
+        except Exception:
+            pass
+    if preserve_local:
+        bare_task_id = _bt._bare_task_id_for_session_key(task_id)
+        with _bt._cleanup_lock:
+            task_state = _task_state_locked(bare_task_id)
+            owned_sessions = [
+                info
+                for key, info in _bt._active_sessions.items()
+                if _bt._bare_task_id_for_session_key(key) == bare_task_id
+            ]
+            has_pending_provider = any(
+                record.task_id == bare_task_id
+                for record in _bt._pending_provider_cleanups.values()
+            )
+        if (
+            task_state is BrowserTaskState.ACTIVE
+            and owned_sessions
+            and not has_pending_provider
+            and all(_is_hermes_owned_local_browser_session(info) for info in owned_sessions)
+        ):
+            return True
+    return _cleanup_browser_session_keys(
+        task_id,
+        reason=BrowserCleanupReason.TERMINAL,
+        preserve_local_headed=preserve_local,
+    )
 
 
 def _kill_verified_daemon(socket_dir: str, session_name: str) -> bool:
@@ -578,7 +1203,12 @@ def _kill_verified_daemon(socket_dir: str, session_name: str) -> bool:
         return False
 
 
-def _release_session_resources(task_id: str, session_info: Dict[str, Any]) -> None:
+def _release_session_resources(
+    task_id: str,
+    session_info: Dict[str, Any],
+    *,
+    retain_provider_failure: bool = True,
+) -> bool:
     """Untrack ``task_id``, close its cloud provider session, kill its daemon — the
     unconditional tail of a teardown, and the whole of the janitor's force-reap path.
 
@@ -586,16 +1216,28 @@ def _release_session_resources(task_id: str, session_info: Dict[str, Any]) -> No
     force-reap path (#100738), which skips the polite agent-browser/Camofox ``close`` that kept failing but
     must still release the cloud session and the local Chromium.
     """
-    bb_session_id = session_info.get("bb_session_id", "unknown")
+    bb_session_id = session_info.get("bb_session_id")
     _forget_session_tracking(task_id, session=True)
 
-    if bb_session_id:  # cloud only — local sidecars have bb_session_id=None
-        provider = _cloud._get_cloud_provider()
-        if provider is not None:
-            try:
-                provider.close_session(bb_session_id)
-            except Exception as e:
-                _bt.logger.warning("Could not close cloud browser session: %s", e)
+    provider_closed = True
+    if bb_session_id:
+        if retain_provider_failure:
+            provider_closed = _attempt_provider_session_close(
+                task_id,
+                session_info.get("_provider_cleanup_owner"),
+                str(bb_session_id),
+            )
+        else:
+            # Janitor last resort: after repeated cleanup exceptions, issue one
+            # provider close but do not keep retry state forever.
+            provider = session_info.get("_provider_cleanup_owner")
+            if provider is None:
+                provider = _cloud._get_cloud_provider()
+            if provider is not None:
+                try:
+                    provider.close_session(bb_session_id)
+                except Exception as exc:
+                    _bt.logger.warning("Could not close cloud browser session: %s", exc)
 
     session_name = session_info.get("session_name", "")
     if session_name:
@@ -603,6 +1245,7 @@ def _release_session_resources(task_id: str, session_info: Dict[str, Any]) -> No
         if os.path.exists(socket_dir):
             _kill_verified_daemon(socket_dir, session_name)
             shutil.rmtree(socket_dir, ignore_errors=True)
+    return provider_closed
 
 
 def _force_reap_browser_session(task_id: str) -> None:
@@ -610,19 +1253,57 @@ def _force_reap_browser_session(task_id: str) -> None:
 
     Janitor last resort after repeated cleanup failures (#100738).
     """
-    _cdp._stop_cdp_supervisor(task_id)
     with _bt._cleanup_lock:
         session_info = _bt._active_sessions.get(task_id)
-        _bt._session_last_activity.pop(task_id, None)
         _bt._recording_sessions.discard(task_id)
+    if session_info and _is_task_owned_shared_cdp_session(session_info):
+        # Never destroy the only exact-close path for an external shared tab.
+        if _cleanup_single_browser_session(task_id):
+            with _bt._cleanup_lock:
+                _bt._session_last_activity.pop(task_id, None)
+        return
+    _cdp._stop_cdp_supervisor(task_id)
     if session_info:
-        _release_session_resources(task_id, session_info)
-    _drop_last_active_binding(task_id)
+        _release_session_resources(
+            task_id, session_info, retain_provider_failure=False
+        )
+    with _bt._cleanup_lock:
+        _bt._session_last_activity.pop(task_id, None)
+    bare_task_id = _bt._bare_task_id_for_session_key(task_id)
+    if bare_task_id == task_id or _bt._last_active_session_key.get(bare_task_id) == task_id:
+        _bt._last_active_session_key.pop(bare_task_id, None)
 
 
-def _cleanup_single_browser_session(task_id: str) -> None:
-    """Reap a single browser session by its exact session key."""
-    _cdp._stop_cdp_supervisor(task_id)  # close our WebSocket BEFORE the backend tears down the endpoint
+def _cleanup_single_browser_session(task_id: str) -> bool:
+    """Reap one exact session key; False retains retryable ownership."""
+    with _bt._cleanup_lock:
+        session_info = _bt._active_sessions.get(task_id)
+
+    # Close a task-owned shared-CDP page by exact ID before stopping the only
+    # reliable supervisor/daemon connection or removing its metadata.
+    if session_info and _is_task_owned_shared_cdp_session(session_info):
+        session_name = str(session_info.get("session_name") or "")
+        socket_dir = os.path.join(
+            _bt._socket_safe_tmpdir(), f"agent-browser-{session_name}"
+        )
+        target_id = str(session_info.get("target_id") or "").strip()
+        if not target_id and session_name:
+            target_id = _read_recorded_pinned_target_id(socket_dir, session_name) or ""
+            if target_id:
+                with _bt._cleanup_lock:
+                    current = _bt._active_sessions.get(task_id)
+                    if current is session_info:
+                        current["target_id"] = target_id
+        cdp_url = str(session_info.get("cdp_url") or _cdp._get_cdp_override()).strip()
+        if not target_id or not _cdp._close_shared_cdp_target_confirmed(cdp_url, target_id):
+            _bt.logger.warning(
+                "Exact shared-CDP target close could not be confirmed for task %s; "
+                "retaining session ownership for retry",
+                task_id,
+            )
+            return False
+
+    _cdp._stop_cdp_supervisor(task_id)
 
     # Camofox: managed persistence keeps the profile (cookies) across tasks; skip the full
     # close then — the inactivity reaper still frees idle resources.
@@ -636,13 +1317,13 @@ def _cleanup_single_browser_session(task_id: str) -> None:
     _bt.logger.debug("cleanup_browser called for task_id: %s", task_id)
     _bt.logger.debug("Active sessions: %s", list(_bt._active_sessions.keys()))
 
-    # Look up but don't remove yet — _run_browser_command needs the entry for ``close``.
+    # Look up but don't remove yet — cleanup's close command needs the entry.
     with _bt._cleanup_lock:
         session_info = _bt._active_sessions.get(task_id)
 
     if not session_info:
         _bt.logger.debug("No active session found for task_id: %s", task_id)
-        return
+        return True
 
     _bt.logger.debug("Found session for task %s: bb_session_id=%s", task_id, session_info.get("bb_session_id", "unknown"))
     _bt._maybe_stop_recording(task_id)  # saves the file before close
@@ -659,19 +1340,34 @@ def _cleanup_single_browser_session(task_id: str) -> None:
         _bt.logger.debug("Skipping agent-browser close for expired session %s", task_id)
     else:
         try:
-            _session._run_browser_command(task_id, "close", [], timeout=10)
+            close_result = _session._run_browser_command(
+                task_id, "close", [], timeout=10, _allow_cleanup=True
+            )
+            if not close_result.get("success"):
+                _bt.logger.warning(
+                    "agent-browser session close failed for task %s: %s",
+                    task_id,
+                    close_result.get("error", close_result),
+                )
             _bt.logger.debug("agent-browser close command completed for task %s", task_id)
         except Exception as e:
             _bt.logger.warning("agent-browser close failed for task %s: %s", task_id, e)
 
-    _release_session_resources(task_id, session_info)
+    provider_closed = _release_session_resources(task_id, session_info)
     _bt.logger.debug("Removed task %s from active sessions", task_id)
+    return provider_closed
 
 
 def cleanup_all_browsers() -> None:
     """Clean up all active browser sessions (shutdown) and reset cached lookups."""
     with _bt._cleanup_lock:
-        task_ids = list(_bt._active_sessions.keys())
+        task_ids = {
+            _bt._bare_task_id_for_session_key(task_id)
+            for task_id in _bt._active_sessions
+        }
+        task_ids.update(
+            record.task_id for record in _bt._pending_provider_cleanups.values()
+        )
     for task_id in task_ids:
         cleanup_browser(task_id)
 
@@ -686,6 +1382,7 @@ def cleanup_all_browsers() -> None:
     # sees ``resolved=True`` with ``cache=None``.
     for flag, cache in (
         ("_agent_browser_resolved", "_cached_agent_browser"),
+        ("_pin_tab_agent_browser_resolved", "_cached_pin_tab_agent_browser"),
         ("_command_timeout_resolved", "_cached_command_timeout"),
         ("_snapshot_threshold_resolved", "_cached_snapshot_threshold"),
         ("_chromium_autoinstall_attempted", "_cached_chromium_installed"),
@@ -693,3 +1390,4 @@ def cleanup_all_browsers() -> None:
     ):
         setattr(_bt, flag, False)
         setattr(_bt, cache, None)
+    _bt._pin_tab_failure_cache = None

--- a/tools/browser_tool_lightpanda_fallback.py
+++ b/tools/browser_tool_lightpanda_fallback.py
@@ -108,6 +108,12 @@ def _annotate_lightpanda_fallback(result: Dict[str, Any], reason: str) -> Dict[s
 
 def _copy_fallback_warning(target: Dict[str, Any], result: Dict[str, Any]) -> Dict[str, Any]:
     """Copy browser fallback metadata from an internal result into a tool response."""
+    # Preserve exact terminal ownership failures through high-level response
+    # shaping; never replace them by opening/adopting another tab.
+    if result.get("code") in {"tab_gone", "browser_session_retired"}:
+        target["code"] = result["code"]
+        if "data" in result:
+            target["data"] = result["data"]
     if result.get("fallback_warning"):
         target["fallback_warning"] = result["fallback_warning"]
         target["browser_engine"] = result.get("browser_engine")

--- a/tools/browser_tool_session.py
+++ b/tools/browser_tool_session.py
@@ -5,15 +5,18 @@ Split out of ``tools/browser_tool.py``. Facade-owned state is read through ``_bt
 """
 
 import json
+import functools
 import logging
 import os
 import shutil
 import subprocess
+import time
 import uuid
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 from hermes_cli._subprocess_compat import windows_hide_flags
+from hermes_constants import get_hermes_home
 from tools.browser_tool_origin import origin as _bt
 from tools import browser_tool_cdp as _cdp
 from tools import browser_tool_cloud as _cloud
@@ -94,7 +97,7 @@ def _format_browser_timeout_error(
     return "\n".join(parts)
 
 
-def _agent_browser_argv(browser_cmd: str) -> list:
+def _agent_browser_argv(browser_cmd: str, *, require_pin_tab: bool = False) -> list:
     """Command prefix to invoke agent-browser (concrete binary, or the npx sentinel expanded).
 
     npx is resolved through the same PATH cascade as ``_find_agent_browser`` (a bare
@@ -104,7 +107,12 @@ def _agent_browser_argv(browser_cmd: str) -> list:
     """
     if _install._is_npx_agent_browser_sentinel(browser_cmd):
         _npx_bin = _install._resolve_npx_bin() or "npx"
-        return [_npx_bin, "--ignore-scripts", "--prefer-offline", "-y", _bt.AGENT_BROWSER_NPX_SPEC]
+        spec = (
+            _bt.AGENT_BROWSER_PIN_TAB_NPX_SPEC
+            if require_pin_tab
+            else _bt.AGENT_BROWSER_NPX_SPEC
+        )
+        return [_npx_bin, "--ignore-scripts", "--prefer-offline", "-y", spec]
     return [browser_cmd]
 
 
@@ -118,14 +126,27 @@ def _prepare_session_socket_dir(session_name: str) -> str:
     return socket_dir
 
 
-def _agent_browser_command_env(socket_dir: str) -> Dict[str, str]:
+def _agent_browser_command_env(
+    socket_dir: str,
+    *,
+    npx_acquisition: bool = False,
+    shared_cdp: bool = False,
+) -> Dict[str, str]:
     """Credential-scrubbed env for one command: PATH fallbacks, the session socket dir, and
     daemon-side idle self-termination (agent-browser 0.24+) mirroring the Python janitor
     unless the user set ``AGENT_BROWSER_IDLE_TIMEOUT_MS`` explicitly."""
     env = _bt._build_browser_env()
+    if npx_acquisition:
+        _install._apply_agent_browser_npm_policy(
+            env, pin_tab_acquisition=shared_cdp
+        )
     env["PATH"] = _install._merge_browser_path(env.get("PATH", ""))
     env["AGENT_BROWSER_SOCKET_DIR"] = socket_dir
-    if "AGENT_BROWSER_IDLE_TIMEOUT_MS" not in env:
+    if shared_cdp:
+        # The tab binding belongs to the whole turn, including time spent
+        # waiting on the page; agent-browser documents 0 as disabled.
+        env["AGENT_BROWSER_IDLE_TIMEOUT_MS"] = "0"
+    elif "AGENT_BROWSER_IDLE_TIMEOUT_MS" not in env:
         env["AGENT_BROWSER_IDLE_TIMEOUT_MS"] = str(_bt.BROWSER_SESSION_INACTIVITY_TIMEOUT * 1000)
     return env
 
@@ -219,15 +240,18 @@ def _create_cdp_session(task_id: str, cdp_url: str) -> Dict[str, str]:
 def _create_cloud_session_or_fallback(task_id: str, provider) -> Dict[str, Any]:
     """Cloud session; fall back to local Chromium (marked degraded) on failure. ``cdp_url``
     is resolved here because some providers return an HTTP discovery URL, not a websocket."""
+    provider_candidate: Any = None
     try:
-        session_info = provider.create_session(task_id)
-        if not session_info or not isinstance(session_info, dict):
-            raise ValueError(f"Cloud provider returned invalid session: {session_info!r}")
+        provider_candidate = provider.create_session(task_id)
+        if not provider_candidate or not isinstance(provider_candidate, dict):
+            raise ValueError(f"Cloud provider returned invalid session: {provider_candidate!r}")
+        session_info = dict(provider_candidate)
+        session_info["_provider_cleanup_owner"] = provider
         if session_info.get("cdp_url"):
-            session_info = dict(session_info)
             session_info["cdp_url"] = _cdp._resolve_cdp_override(str(session_info["cdp_url"]))
         return session_info
     except Exception as e:
+        _lifecycle._dispose_unpublished_session(task_id, provider_candidate, provider)
         provider_name = type(provider).__name__
         _bt.logger.warning("Cloud provider %s failed (%s); attempting fallback to local Chromium for task %s",
                            provider_name, e, task_id, exc_info=True)
@@ -256,60 +280,139 @@ def _create_session_for_key(task_id: str, force_local: bool) -> Dict[str, Any]:
     return _create_cloud_session_or_fallback(task_id, provider)
 
 
-def _get_session_info(task_id: Optional[str] = None) -> Dict[str, Any]:
-    """Get or create session info for a session key (thread-safe); also starts the
-    inactivity thread and touches activity. A ``::local`` key forces local Chromium
-    even with a cloud provider configured."""
+def _abandon_session_creation(bare_task_id: str, generation: int) -> None:
+    """Return a failed current creator's STARTING state to ACTIVE."""
+    with _bt._cleanup_lock:
+        if (
+            _lifecycle._task_generation_locked(bare_task_id) == generation
+            and _lifecycle._task_state_locked(bare_task_id)
+            is _lifecycle.BrowserTaskState.STARTING
+            and not _lifecycle._task_has_active_sessions_locked(bare_task_id)
+        ):
+            _lifecycle._set_task_state_locked(
+                bare_task_id, _lifecycle.BrowserTaskState.ACTIVE
+            )
+
+
+def _get_session_info(
+    task_id: Optional[str] = None,
+    *,
+    _for_cleanup: bool = False,
+) -> Dict[str, Any]:
+    """Get/create one session key with generation-fenced publication."""
     if task_id is None:
         task_id = "default"
+    bare_task_id = _bt._bare_task_id_for_session_key(task_id)
 
     _lifecycle._start_browser_cleanup_thread()
-    _lifecycle._update_session_activity(task_id)
-
     with _bt._cleanup_lock:
+        state = _lifecycle._task_state_locked(bare_task_id)
         existing_session = _bt._active_sessions.get(task_id)
-
-    def _replacement_after_teardown() -> Optional[Dict[str, Any]]:
-        # Teardown removes the activity entry; re-touch so the reaper tracks the
-        # replacement. Another thread may already have re-created it — reuse that.
-        _lifecycle._update_session_activity(task_id)
-        with _bt._cleanup_lock:
-            replacement = _bt._active_sessions.get(task_id)
-        return replacement if replacement is not None and replacement is not existing_session else None
+        cleanup_lookup = (
+            _for_cleanup
+            and state is _lifecycle.BrowserTaskState.RETIRING
+            and existing_session is not None
+        )
+        if (
+            state
+            in {
+                _lifecycle.BrowserTaskState.RETIRING,
+                _lifecycle.BrowserTaskState.RETIRED,
+            }
+            and not cleanup_lookup
+        ):
+            raise _lifecycle._BrowserSessionRetiredError(task_id)
+        if not _for_cleanup:
+            _bt._session_last_activity[task_id] = time.time()
+            _bt._session_owner_homes.setdefault(task_id, str(get_hermes_home()))
 
     if existing_session is not None:
-        # Suspect recycle: a command timeout marked this session; the expensive recycle
-        # lives here at next use, not on the timeout path (mark must stay cheap).
         if not _bt._browser_session_backend(task_id).ensure_healthy():
-            replacement = _replacement_after_teardown()
-            if replacement is not None:
+            _lifecycle._update_session_activity(task_id)
+            with _bt._cleanup_lock:
+                replacement = _bt._active_sessions.get(task_id)
+            if replacement is not None and replacement is not existing_session:
                 return replacement
             existing_session = None
-        elif not _lifecycle._session_has_expired(existing_session) and not _local_backend_process_dead(existing_session):
+        elif _for_cleanup or (
+            not _lifecycle._session_has_expired(existing_session)
+            and not _local_backend_process_dead(existing_session)
+        ):
             return existing_session
         else:
             _bt.logger.info("Replacing expired or dead browser session for task %s", task_id)
-            _lifecycle._cleanup_single_browser_session(task_id)
-            replacement = _replacement_after_teardown()
-            if replacement is not None:
-                return replacement
+            if not _lifecycle._cleanup_browser_session_keys(
+                task_id,
+                [task_id],
+                reason=_lifecycle.BrowserCleanupReason.PROVIDER_EXPIRY,
+            ):
+                raise _lifecycle._BrowserSessionRetiredError(task_id)
+            return _get_session_info(task_id)
 
-    force_local = _bt._is_local_sidecar_key(task_id)
-    session_info = _create_session_for_key(task_id, force_local)
+    if _for_cleanup:
+        raise _lifecycle._BrowserSessionRetiredError(task_id)
 
     with _bt._cleanup_lock:
-        if task_id in _bt._active_sessions:  # created concurrently during the network call — don't leak ours
-            return _bt._active_sessions[task_id]
-        session_info = dict(session_info)
-        session_info.setdefault("session_key", task_id)
-        session_info.setdefault("owner_task_id", _bt._bare_task_id_for_session_key(task_id))
-        _bt._active_sessions[task_id] = session_info
-        _bt._suspect_browser_sessions.pop(task_id, None)  # brand-new session is healthy by definition
+        state = _lifecycle._task_state_locked(bare_task_id)
+        if state in {
+            _lifecycle.BrowserTaskState.RETIRING,
+            _lifecycle.BrowserTaskState.RETIRED,
+        }:
+            raise _lifecycle._BrowserSessionRetiredError(task_id)
+        winner = _bt._active_sessions.get(task_id)
+        if winner is not None:
+            return winner
+        creation_generation = _lifecycle._task_generation_locked(bare_task_id)
+        if not _lifecycle._task_has_active_sessions_locked(bare_task_id):
+            _lifecycle._set_task_state_locked(
+                bare_task_id, _lifecycle.BrowserTaskState.STARTING
+            )
 
-    # Lazy-start the CDP supervisor (idempotent). Skip local sidecars (no CDP URL) and
-    # Lightpanda sessions (Browser Use mode hides the tools that consume supervisor state).
+    force_local = _bt._is_local_sidecar_key(task_id)
+    try:
+        session_info = _create_session_for_key(task_id, force_local)
+    except BaseException:
+        _abandon_session_creation(bare_task_id, creation_generation)
+        raise
+
+    with _bt._cleanup_lock:
+        current_state = _lifecycle._task_state_locked(bare_task_id)
+        stale_creator = (
+            _lifecycle._task_generation_locked(bare_task_id) != creation_generation
+            or current_state
+            in {
+                _lifecycle.BrowserTaskState.RETIRING,
+                _lifecycle.BrowserTaskState.RETIRED,
+            }
+        )
+        winner = _bt._active_sessions.get(task_id)
+        if not stale_creator and winner is None:
+            session_info = dict(session_info)
+            session_info.setdefault("session_key", task_id)
+            session_info.setdefault("owner_task_id", bare_task_id)
+            session_info["_lifecycle_generation"] = creation_generation
+            _bt._active_sessions[task_id] = session_info
+            _bt._suspect_browser_sessions.pop(task_id, None)
+            _lifecycle._set_task_state_locked(
+                bare_task_id, _lifecycle.BrowserTaskState.ACTIVE
+            )
+            published = True
+        else:
+            published = False
+
+    if not published:
+        _lifecycle._dispose_unpublished_session(task_id, session_info)
+        if stale_creator:
+            raise _lifecycle._BrowserSessionRetiredError(task_id)
+        return winner
+
     if not force_local and not (session_info.get("features") or {}).get("lightpanda"):
-        _cdp._ensure_cdp_supervisor(task_id)
+        if session_info.get("cdp_url"):
+            _cdp._ensure_cdp_supervisor(
+                task_id, expected_generation=creation_generation
+            )
+        else:
+            _cdp._ensure_cdp_supervisor(task_id)
 
     return session_info
 
@@ -319,7 +422,6 @@ def _discard_timed_out_browser_session(task_id: str, session_info: Dict[str, Any
     with _bt._cleanup_lock:
         if _bt._active_sessions.get(task_id) is not session_info:
             return
-        _cdp._stop_cdp_supervisor(task_id)
         if session_info.get("bb_session_id") or session_info.get("cdp_url"):
             replacement = dict(session_info)
             replacement["session_name"] = f"h_{uuid.uuid4().hex[:10]}"
@@ -332,6 +434,10 @@ def _discard_timed_out_browser_session(task_id: str, session_info: Dict[str, Any
         bare_task_id = _bt._bare_task_id_for_session_key(task_id)
         if _bt._last_active_session_key.get(bare_task_id) == task_id:
             _bt._last_active_session_key.pop(bare_task_id, None)
+
+    # Stopping can join a starter whose publication guard needs the lifecycle
+    # lock. Never wait for it while holding ``_cleanup_lock``.
+    _cdp._stop_cdp_supervisor(task_id)
 
     session_name = str(session_info.get("session_name") or "")
     if session_name and os.path.isfile(os.path.join(task_socket_dir, f"{session_name}.pid")):
@@ -405,6 +511,19 @@ def _handle_browser_command_timeout(task_id: str, session_info: Dict[str, Any], 
     via ``agent.deadline.kill_process_tree`` and evict the cache entry now; the next browser call respawns
     from scratch. See #72206.
     """
+    if _lifecycle._is_task_owned_shared_cdp_session(session_info):
+        if not _lifecycle._cleanup_browser_session_keys(
+            task_id,
+            [task_id],
+            reason=_lifecycle.BrowserCleanupReason.INACTIVITY,
+        ):
+            _bt.logger.warning(
+                "Timed-out shared-CDP session %s remains fail-closed until "
+                "its exact target cleanup can be confirmed",
+                task_id,
+            )
+        return
+
     if session_info.get("bb_session_id") or session_info.get("cdp_url"):
         _discard_timed_out_browser_session(task_id, session_info, task_socket_dir)
         return
@@ -473,7 +592,7 @@ def _interpret_browser_command_output(command: str, stdout: str, stderr: str, re
     return parsed
 
 
-def _browser_command_preflight() -> Dict[str, Any]:
+def _browser_command_preflight(*, _allow_cleanup: bool = False) -> Dict[str, Any]:
     """Fail fast before spawning (missing CLI, Termux gap, interrupt, no Chromium in local
     mode — else every call hangs for command_timeout). Error result, or ``{"browser_cmd": path}``."""
     try:
@@ -499,7 +618,7 @@ def _browser_command_preflight() -> Dict[str, Any]:
         return {"success": False, "error": hint}
 
     from tools.interrupt import is_interrupted
-    if is_interrupted():
+    if not _allow_cleanup and is_interrupted():
         return {"success": False, "error": "Interrupted"}
     return {"browser_cmd": browser_cmd}
 
@@ -507,12 +626,25 @@ def _browser_command_preflight() -> Dict[str, Any]:
 def _spawn_and_collect(
     task_id: str, session_info: Dict[str, Any], cmd_parts: List[str],
     command: str, engine: str, timeout: int,
+    *,
+    browser_cmd: str,
+    task_owned_shared_cdp: bool,
 ) -> Dict[str, Any]:
     """Run the prepared agent-browser argv once and interpret its output (handles timeout)."""
     task_socket_dir = _prepare_session_socket_dir(session_info["session_name"])
+    if task_owned_shared_cdp:
+        _lifecycle._write_shared_cdp_endpoint(
+            task_socket_dir,
+            session_info["session_name"],
+            str(session_info.get("cdp_url") or ""),
+        )
     _bt.logger.debug("browser cmd=%s task=%s socket_dir=%s (%d chars)",
                  command, task_id, task_socket_dir, len(task_socket_dir))
-    browser_env = _agent_browser_command_env(task_socket_dir)
+    browser_env = _agent_browser_command_env(
+        task_socket_dir,
+        npx_acquisition=_install._is_npx_agent_browser_sentinel(browser_cmd),
+        shared_cdp=task_owned_shared_cdp,
+    )
 
     # Lightpanda rejects Chromium-only launch flags: strip current and legacy vars;
     # Chrome commands and fallback use the shared Chromium policy.
@@ -550,40 +682,111 @@ def _spawn_and_collect(
     return _interpret_browser_command_output(command, stdout, stderr, proc.returncode)
 
 
+def _serialize_browser_task_command(func):
+    """Fence browser subprocess dispatch against task cleanup."""
+
+    @functools.wraps(func)
+    def _wrapped(
+        task_id: str,
+        command: str,
+        args: List[str] = None,
+        timeout: Optional[int] = None,
+        _engine_override: Optional[str] = None,
+        _allow_cleanup: bool = False,
+    ) -> Dict[str, Any]:
+        if _allow_cleanup:
+            # Cleanup already owns the same per-task operation lock.
+            return func(
+                task_id,
+                command,
+                args,
+                timeout,
+                _engine_override,
+                _allow_cleanup=True,
+            )
+        bare_task_id = _bt._bare_task_id_for_session_key(task_id or "default")
+        with _lifecycle._task_cleanup_operation_lock(bare_task_id):
+            if _lifecycle._is_browser_task_unavailable(task_id):
+                return _lifecycle._browser_session_retired_result(task_id)
+            return func(task_id, command, args, timeout, _engine_override)
+
+    return _wrapped
+
+
+@_serialize_browser_task_command
 def _run_browser_command(
     task_id: str,
     command: str,
     args: List[str] = None,
     timeout: Optional[int] = None,
     _engine_override: Optional[str] = None,
+    _allow_cleanup: bool = False,
 ) -> Dict[str, Any]:
     """Run one agent-browser CLI command against the task's session; returns its parsed JSON.
     ``timeout=None`` reads ``browser.command_timeout``; ``_engine_override`` forces an engine
     for this call only (Lightpanda fallback retries with Chrome without touching global state)."""
+    if not _allow_cleanup and _lifecycle._is_browser_task_unavailable(task_id):
+        return _lifecycle._browser_session_retired_result(task_id)
+
     if timeout is None:
         timeout = _bt._safe_command_timeout()
     args = args or []
 
-    preflight = _browser_command_preflight()
+    preflight = _browser_command_preflight(_allow_cleanup=_allow_cleanup)
     if "browser_cmd" not in preflight:
         return preflight
     browser_cmd = preflight["browser_cmd"]
 
     try:
-        session_info = _get_session_info(task_id)
+        session_info = (
+            _get_session_info(task_id, _for_cleanup=True)
+            if _allow_cleanup
+            else _get_session_info(task_id)
+        )
+    except _lifecycle._BrowserSessionRetiredError:
+        return _lifecycle._browser_session_retired_result(task_id)
     except Exception as e:
         _bt.logger.warning("Failed to create browser session for task=%s: %s", task_id, e)
         return {"success": False, "error": f"Failed to create browser session: {str(e)}"}
-    # Cleanup stops the supervisor before closing the backend; keep it stopped.
     if command != "close" and session_info.get("cdp_url"):
         _cdp._ensure_cdp_supervisor(task_id)
+
+    if not _allow_cleanup and _lifecycle._is_browser_task_unavailable(task_id):
+        return _lifecycle._browser_session_retired_result(task_id)
+
+    task_owned_shared_cdp = _lifecycle._is_task_owned_shared_cdp_session(
+        session_info
+    )
+    if task_owned_shared_cdp:
+        try:
+            browser_cmd = _install._find_agent_browser(require_pin_tab=True)
+        except _install.AgentBrowserCapabilityError as exc:
+            _bt.logger.warning("browser CDP command blocked: %s", exc)
+            return {
+                "success": False,
+                "error": str(exc),
+                "code": "pin_tab_unavailable",
+                "data": {
+                    "required_agent_browser": ">=0.34.0",
+                    "required_node": ">=24",
+                    "non_cdp_available": True,
+                },
+            }
 
     # Cloud/CDP: ``--cdp <ws_url>`` (NEVER with --session: agent-browser >=0.13
     # would create a local browser and silently ignore --cdp). Local: ``--session <name>``.
     # Engine injection keys off the resolved session backend, not global provider
     # state: hybrid routing can create a local sidecar while a cloud provider stays configured.
     engine = _engine_override or _cloud._get_browser_engine()
-    if session_info.get("cdp_url"):
+    if task_owned_shared_cdp:
+        backend_args = [
+            "--session",
+            session_info["session_name"],
+            "--cdp",
+            session_info["cdp_url"],
+            "--pin-tab",
+        ]
+    elif session_info.get("cdp_url"):
         backend_args = ["--cdp", session_info["cdp_url"]]
     else:
         backend_args = ["--session", session_info["session_name"]]
@@ -592,10 +795,21 @@ def _run_browser_command(
         if engine != "auto" and not _bt._is_camofox_mode():
             backend_args += ["--engine", engine]
 
-    cmd_parts = _agent_browser_argv(browser_cmd) + backend_args + ["--json", command] + args
+    cmd_parts = _agent_browser_argv(
+        browser_cmd, require_pin_tab=task_owned_shared_cdp
+    ) + backend_args + ["--json", command] + args
 
     try:
-        result = _spawn_and_collect(task_id, session_info, cmd_parts, command, engine, timeout)
+        result = _spawn_and_collect(
+            task_id,
+            session_info,
+            cmd_parts,
+            command,
+            engine,
+            timeout,
+            browser_cmd=browser_cmd,
+            task_owned_shared_cdp=task_owned_shared_cdp,
+        )
     except Exception as e:
         _bt.logger.warning("browser '%s' exception: %s", command, e, exc_info=True)
         result = {"success": False, "error": str(e)}

--- a/website/docs/user-guide/features/browser.md
+++ b/website/docs/user-guide/features/browser.md
@@ -481,6 +481,23 @@ In the CLI, use:
 
 If a browser isn't already running with remote debugging, Hermes will attempt to auto-launch a supported Chromium-family browser with `--remote-debugging-port=9222`. Detection includes Brave, Brave Origin/Nightly, Google Chrome, Chromium, and Microsoft Edge, with common Linux install paths and binary names such as `brave-origin`, `brave-origin-nightly`, `/opt/brave.com/brave-origin/brave-origin`, `/opt/brave.com/brave-origin-nightly/brave-origin`, `/opt/brave-bin/brave`, and `/snap/bin/brave`.
 
+:::caution Shared-CDP runtime requirement
+Page-isolated `/browser connect` sessions require **Node.js 24 or newer** and
+**agent-browser 0.34.0 or newer**, because `--pin-tab` first shipped in
+agent-browser 0.34 and that package declares Node.js 24 as its minimum. The
+same capability also works on newer supported releases such as Node.js 26.
+
+Hermes itself and ordinary non-CDP browser sessions remain supported on
+Node.js 22.22 or newer; those sessions use the Node-22-compatible
+`agent-browser@0.26.0` acquisition path. On Node.js 22, a shared-CDP command
+fails after the read-only version preflight but before any `--pin-tab` command
+or daemon starts, and reports the two prerequisites instead of running an
+unsupported package. The capability-scoped npx path uses the exact audited
+`agent-browser@0.34.0` package, enforces npm's engine check, and overrides the
+normal 14-day release-age gate only for that one exact acquisition. Future
+0.34.x releases do not inherit that exception automatically.
+:::
+
 :::tip
 To start a Chromium-family browser manually with CDP enabled, use a dedicated user-data-dir so the debug port actually comes up even if the browser is already running with your normal profile:
 
@@ -521,7 +538,7 @@ Then launch the Hermes CLI and run `/browser connect`.
 **Chrome 136+ makes the dedicated profile mandatory.** As a security hardening change, Chrome 136 and later silently refuse to open the remote debugging port when `--remote-debugging-port` is combined with the *default* user-data-dir — even from a cold start with no other Chrome running. The browser launches normally but nothing ever listens on 9222, so `/browser connect` (and any manual `curl http://127.0.0.1:9222/json/version`) fails with connection refused. There is no error message. The fix is exactly the commands above: always pass a `--user-data-dir` pointing somewhere other than your default profile directory (e.g. `$HOME/.hermes/chrome-debug`). This applies to Chrome, Chromium, Edge, and Brave builds that have picked up the change.
 :::
 
-When connected via CDP, all browser tools (`browser_navigate`, `browser_click`, etc.) operate on your live browser instance instead of spinning up a cloud session.
+When connected via CDP, all browser tools (`browser_navigate`, `browser_click`, etc.) operate on your live browser instance instead of spinning up a cloud session. Each Hermes task pins the page target it creates and does not adopt another task's existing tab. Cookies, storage, and signed-in account state still belong to the shared browser profile and are intentionally shared.
 
 ### WSL2 + Windows Chrome: prefer MCP over `/browser connect`
 
@@ -581,11 +598,15 @@ AGENT_BROWSER_ARGS=--no-sandbox
 ### Install agent-browser CLI
 
 You don't need to install anything — `agent-browser` resolves automatically via
-`npx agent-browser` on first browser-tool use. To avoid the one-time npx fetch,
-you can install it globally ahead of time (optional):
+npx on first browser-tool use. To avoid the one-time fetch, install the package
+line for the browser mode you use (optional):
 
 ```bash
-npm install -g agent-browser
+# Ordinary local/non-CDP browser sessions (Node.js >=22.22)
+npm install -g 'agent-browser@0.26.0'
+
+# Shared-CDP /browser connect sessions (Node.js >=24)
+npm install -g 'agent-browser@0.34.0'
 ```
 
 :::info

--- a/website/docs/user-guide/features/browser.md
+++ b/website/docs/user-guide/features/browser.md
@@ -540,6 +540,15 @@ Then launch the Hermes CLI and run `/browser connect`.
 
 When connected via CDP, all browser tools (`browser_navigate`, `browser_click`, etc.) operate on your live browser instance instead of spinning up a cloud session. Each Hermes task pins the page target it creates and does not adopt another task's existing tab. Cookies, storage, and signed-in account state still belong to the shared browser profile and are intentionally shared.
 
+A shared external-CDP target is not closed merely because no browser command was
+issued during `browser.inactivity_timeout`; model reasoning or another long tool
+call can legitimately exceed that interval. Hermes closes its owned target at
+terminal task cleanup instead. After that cleanup, non-navigation tools fail
+with `browser_session_retired` rather than creating or adopting a replacement
+page. A new lifecycle begins only with an explicit, policy-checked
+`browser_navigate`; if that navigation fails, Hermes cleans the partial
+replacement and keeps the task retired.
+
 ### WSL2 + Windows Chrome: prefer MCP over `/browser connect`
 
 If Hermes runs inside WSL2 but the Chrome window you want to control runs on the Windows host, `/browser connect` is often not the best path.


### PR DESCRIPTION
## What does this PR do?

Prevents high-level browser tasks from hijacking each other when multiple Hermes tasks share one Chrome/CDP endpoint and profile.

- gives each high-level shared-CDP task a unique named `agent-browser` session with `--cdp --pin-tab`
- binds Hermes' CDP supervisor to that exact pinned target
- returns structured `tab_gone` instead of adopting another task's or user's page
- separates page JavaScript exceptions from CDP transport/session loss; dispatched JavaScript is never replayed after an ambiguous or serialization failure
- keeps shared external-CDP sessions alive during long model waits, then fails non-navigation calls closed after terminal cleanup instead of creating a replacement `about:blank` session
- uses explicit lifecycle state, cleanup reasons, per-task operation locks, and generation fencing so commands, cleanup, session creation, and supervisor publication cannot reopen or leak a retired task
- keeps provider-backed browser sessions separate from task-owned external CDP; provider cleanup does not depend on local pin-tab capability and failed provider closes retain retry ownership
- reaps dead-owner targets only from persisted exact target metadata; malformed or unknown metadata fails closed instead of deleting the last ownership evidence

## Why this approach?

`agent-browser` 0.34 provides the missing low-level primitive: persistent named-session-to-target binding plus strict `--pin-tab`. Hermes owns the lifecycle, publication fencing, supervisor routing, and cleanup guarantees around that primitive rather than adding a second target broker or an endpoint-wide lock.

The shared browser profile is still intentionally shared: cookies, storage, accounts, and rate limits are not isolated. The isolation boundary is page-target ownership.

Addresses the high-level browser path in #62338 and overlaps with the shared-CDP isolation work discussed in #83274, #75597, and #86924. This PR additionally covers Hermes high-level tool lifecycle, provider ownership, supervisor routing, exact-once eval behavior, cleanup/orphan handling, and idle continuity.

## Runtime compatibility

- ordinary non-CDP sessions: exact `agent-browser@0.26.0`, compatible with Hermes' Node.js 22.22+ baseline
- shared-CDP pinning: Node.js 24+ and `agent-browser >=0.34.0`
- capability-scoped lazy install: exact audited `agent-browser@0.34.0`; npm's release-age override applies only to that exact acquisition, not future `0.34.x` releases
- Node 22 fails before starting a pin-tab daemon or mutating the shared browser

## Testing

Final local verification on commit `f9de232401`:

- `538 passed, 8 skipped` across `tests/tools/test_browser_*.py`
- `44 passed` across lifecycle, turn-finalizer, interrupt, and run-agent regression tests
- `7 passed` in managed runtime resolution tests (plus two pre-existing `DeprecationWarning`s)
- Ruff, `py_compile`, and `git diff --check` pass
- focused regressions cover JavaScript exception markers and exact-once dispatch, stale-session fallback, version/candidate selection, task lifecycle transitions, cleanup retry, provider ownership, concurrent creator disposal, supervisor start/stop fencing, SIGKILL orphan recovery, malformed target metadata, long idle waits, terminal cleanup, and failed restart navigation

Real isolated Chromium + `agent-browser 0.34.0` acceptance covered:

- two tasks received distinct pinned targets and each read only its own token
- cleaning task A closed only A; task B remained attached and usable
- task A then failed closed with `browser_session_retired`
- a pre-existing user target was neither read nor closed
- final cleanup removed every task-owned target while the persistent browser and pre-existing target survived

Node/runtime acquisition was also exercised with empty npm caches on the supported paths.

## Scope

This intentionally does not add per-task ACLs to raw `browser_cdp`. Raw CDP remains a privileged browser-wide escape hatch and can address a caller-supplied target directly. The page-ownership guarantees above apply to the high-level `browser_*` task flow.