### PR TITLE
feat(kanban): task-scoped watch terminal status and delegated-child K0 read-only dispatch

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -19,6 +19,7 @@ import contextlib
 import json
 import os
 import shlex
+import sqlite3
 import sys
 import time
 from pathlib import Path
@@ -798,6 +799,20 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
                               "(e.g. 'completed,blocked,gave_up,crashed,timed_out')")
     p_watch.add_argument("--interval", type=float, default=0.5,
                          help="Poll interval in seconds (default: 0.5)")
+    p_watch.add_argument("--task", dest="task_id", default=None,
+                         help="Only show events for this task id")
+    p_watch.add_argument(
+        "--until-status",
+        default=None,
+        help="With --task, exit successfully when the task reaches any "
+             "comma-separated status",
+    )
+    p_watch.add_argument(
+        "--timeout",
+        type=float,
+        default=None,
+        help="Stop waiting after this many seconds",
+    )
 
     # --- stats ---
     p_stats = sub.add_parser(
@@ -1050,11 +1065,37 @@ def kanban_command(args: argparse.Namespace) -> int:
         )
         return 1
 
-    # Board-management commands operate on board metadata and the persisted
-    # current-board pointer itself. They must ignore the shared `--board`
-    # task-routing override; otherwise `/kanban --board beta boards show`
-    # reports beta as the current board even when the on-disk pointer is
-    # alpha.
+    # Delegated-child contexts are a strict trust boundary, split by verb
+    # (policy §3): K0 read-only verbs (show/list/runs/log/watch/tail) are
+    # allowed and dispatched below over a genuine mode=ro connection; every
+    # other verb is denied here, BEFORE init_db, so delegated children get a
+    # clean CLI-level denial rather than a misleading "could not initialize
+    # database" error from the in-flight backfill's write_txn. The durable
+    # DB-layer mutation guard in kanban_db stays untouched as the backstop.
+    try:
+        from agent.delegation_context import is_delegated_child_process_context
+        delegated = is_delegated_child_process_context()
+    except Exception:
+        delegated = bool(os.environ.get("HERMES_DELEGATED_CHILD_CONTEXT"))
+    if delegated:
+        if action == "boards":
+            # Mutating boards subcommands were already rejected above; the
+            # remaining ones are read-only filesystem operations.
+            return _dispatch_boards(args)
+        if action not in _DELEGATED_CHILD_K0_ACTIONS:
+            print(
+                "kanban: delegate_task child contexts cannot use the Kanban CLI",
+                file=sys.stderr,
+            )
+            return 1
+
+    # `repair` must dispatch BEFORE the auto-init below: on a corrupt DB
+    # init_db() itself raises KanbanDbCorruptError, which would turn
+    # every `hermes kanban repair` into "could not initialize database"
+    # without ever reaching the repair path. The check above also has to run
+    # before the auto-init so delegated-child contexts see a clean CLI-level
+    # denial for mutation verbs instead of a misleading "could not
+    # initialize database" error.
     if action == "boards":
         return _dispatch_boards(args)
 
@@ -1099,6 +1140,42 @@ def kanban_command(args: argparse.Namespace) -> int:
         # without ever reaching the repair path.
         if action == "repair":
             return _cmd_repair(args)
+        if delegated and action in _DELEGATED_CHILD_K0_ACTIONS:
+            # K0 read-only dispatch (policy §3.2): bypass init_db entirely and
+            # serve the verb over a genuine mode=ro connection. init_db would
+            # run the in-flight backfill inside a write_txn, which the DB-layer
+            # delegated-child guard correctly refuses — read-only verbs simply
+            # never need it.
+            k0_handlers = {
+                "show": _cmd_show,
+                "list": _cmd_list,
+                "ls": _cmd_list,
+                "runs": _cmd_runs,
+                "log": _cmd_log,
+                "watch": _cmd_watch,
+                "tail": _cmd_tail,
+            }
+            orig_connect, orig_closing = kb.connect, kb.connect_closing
+            orig_recompute = kb.recompute_ready
+            kb.connect = _k0_readonly_connect
+            kb.connect_closing = _k0_readonly_connect_closing
+            # _cmd_list runs a "mini-dispatch" recompute_ready (a write) to
+            # freshen its output. A K0 observer must not mutate board state,
+            # so neutralise it on this path only — the child sees the board
+            # as-is, the dispatcher remains the sole promoter.
+            kb.recompute_ready = lambda conn, failure_limit=None: 0
+            try:
+                return int(k0_handlers[action](args) or 0)
+            except (ValueError, RuntimeError, sqlite3.Error) as exc:
+                # sqlite3.Error covers a missing DB file (mode=ro cannot
+                # create one) and read-only-write attempts — both should be
+                # clean CLI errors, not bare tracebacks.
+                print(f"kanban: {exc}", file=sys.stderr)
+                return 1
+            finally:
+                kb.connect = orig_connect
+                kb.connect_closing = orig_closing
+                kb.recompute_ready = orig_recompute
         try:
             kb.init_db()
         except Exception as exc:
@@ -1222,6 +1299,53 @@ _DELEGATED_CHILD_DENIED_BOARD_ACTIONS: frozenset[str] = frozenset({
     "rename",
     "set-default-workdir",
 })
+
+
+_DELEGATED_CHILD_K0_ACTIONS: frozenset[str] = frozenset({
+    # Policy §3.1: delegated children may use these read-only verbs. They are
+    # dispatched through a genuine read-only SQLite connection (mode=ro +
+    # PRAGMA query_only) and never touch init_db / write_txn, so the durable
+    # DB-layer mutation guard is preserved while the child can still pull the
+    # board, read its own runs and write its report.
+    "show",
+    "list",
+    "ls",
+    "runs",
+    "log",
+    "watch",
+    "tail",
+})
+
+
+def _k0_readonly_connect(
+    db_path: Optional[Path] = None,
+    *,
+    board: Optional[str] = None,
+) -> sqlite3.Connection:
+    """Genuine read-only connection for delegated-child K0 verbs (policy §3.2).
+
+    Bypasses :func:`kb.connect` entirely: no init_db, no schema writes, no
+    in-flight backfill write_txn. Any attempted write fails at the SQLite
+    layer with "attempt to write a readonly database".
+    """
+    path = Path(db_path) if db_path is not None else kb.kanban_db_path(board=board)
+    conn = sqlite3.connect(f"file:{path}?mode=ro", uri=True)
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA query_only = 1")
+    return conn
+
+
+@contextlib.contextmanager
+def _k0_readonly_connect_closing(
+    db_path: Optional[Path] = None,
+    *,
+    board: Optional[str] = None,
+):
+    conn = _k0_readonly_connect(db_path, board=board)
+    try:
+        yield conn
+    finally:
+        conn.close()
 
 
 def _is_delegated_child_cli_mutation(args: argparse.Namespace) -> bool:
@@ -2870,6 +2994,36 @@ def _cmd_watch(args: argparse.Namespace) -> int:
         {k.strip() for k in args.kinds.split(",") if k.strip()}
         if args.kinds else None
     )
+    task_id = getattr(args, "task_id", None)
+    until_statuses = (
+        {s.strip() for s in args.until_status.split(",") if s.strip()}
+        if getattr(args, "until_status", None) else None
+    )
+    if until_statuses and not task_id:
+        print("kanban watch: --until-status requires --task", file=sys.stderr)
+        return 2
+    invalid_statuses = (until_statuses or set()) - kb.VALID_STATUSES
+    if invalid_statuses:
+        print(
+            "kanban watch: unknown status(es): "
+            + ", ".join(sorted(invalid_statuses)),
+            file=sys.stderr,
+        )
+        return 2
+    if task_id:
+        with kb.connect_closing() as conn:
+            task = kb.get_task(conn, task_id)
+        if task is None:
+            print(f"kanban watch: no such task: {task_id}", file=sys.stderr)
+            return 1
+        if until_statuses and task.status in until_statuses:
+            print(f"{task_id} reached status {task.status}")
+            return 0
+    timeout = getattr(args, "timeout", None)
+    if timeout is not None and timeout < 0:
+        print("kanban watch: --timeout must be >= 0", file=sys.stderr)
+        return 2
+    deadline = time.monotonic() + timeout if timeout is not None else None
     cursor = 0
     print("Watching kanban events. Ctrl-C to stop.", flush=True)
     # Seed cursor at the latest id so we don't replay history.
@@ -2891,6 +3045,8 @@ def _cmd_watch(args: argparse.Namespace) -> int:
                 ).fetchall()
             for r in rows:
                 cursor = max(cursor, int(r["id"]))
+                if task_id and r["task_id"] != task_id:
+                    continue
                 if kinds and r["kind"] not in kinds:
                     continue
                 if args.assignee and r["assignee"] != args.assignee:
@@ -2907,7 +3063,24 @@ def _cmd_watch(args: argparse.Namespace) -> int:
                     f"{r['kind']:18s} (@{r['assignee'] or '-'}){pl}",
                     flush=True,
                 )
-            time.sleep(max(0.1, args.interval))
+            if task_id and until_statuses:
+                with kb.connect_closing() as conn:
+                    task = kb.get_task(conn, task_id)
+                if task is None:
+                    print(f"kanban watch: task disappeared: {task_id}", file=sys.stderr)
+                    return 1
+                if task.status in until_statuses:
+                    print(f"{task_id} reached status {task.status}")
+                    return 0
+            sleep_for = max(0.1, args.interval)
+            if deadline is not None:
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    target = task_id or "kanban events"
+                    print(f"kanban watch: timed out waiting for {target}", file=sys.stderr)
+                    return 124
+                sleep_for = min(sleep_for, remaining)
+            time.sleep(sleep_for)
     except KeyboardInterrupt:
         print("\n(stopped)")
         return 0

--- a/tests/hermes_cli/test_kanban_watch_cli.py
+++ b/tests/hermes_cli/test_kanban_watch_cli.py
@@ -1,0 +1,285 @@
+"""Behavior tests for task-scoped, bounded Kanban watch mode."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import kanban as kc
+from hermes_cli import kanban_db as kb
+
+
+@pytest.fixture()
+def kanban_home(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.delenv("HERMES_KANBAN_BOARD", raising=False)
+    monkeypatch.delenv("HERMES_DELEGATED_CHILD_CONTEXT", raising=False)
+    kb.init_db()
+    return home
+
+
+def _run(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest="command")
+    kc.build_parser(subparsers)
+    args = parser.parse_args(["kanban", *argv])
+    return kc.kanban_command(args)
+
+
+def test_watch_until_status_returns_immediately_for_done_task(
+    kanban_home, capsys
+) -> None:
+    with kb.connect_closing() as conn:
+        task_id = kb.create_task(
+            conn,
+            title="already done",
+            initial_status="running",
+        )
+        kb.complete_task(conn, task_id, result="ok")
+
+    rc = _run(
+        [
+            "watch",
+            "--task",
+            task_id,
+            "--until-status",
+            "done,blocked,archived",
+            "--timeout",
+            "1",
+        ]
+    )
+
+    assert rc == 0
+    assert f"{task_id} reached status done" in capsys.readouterr().out
+
+
+def test_watch_until_status_exits_after_task_transitions_to_done(
+    kanban_home, capsys, monkeypatch
+) -> None:
+    with kb.connect_closing() as conn:
+        task_id = kb.create_task(
+            conn,
+            title="finishes later",
+            initial_status="running",
+        )
+
+    sleep_calls = 0
+
+    def complete_on_first_sleep(_seconds: float) -> None:
+        nonlocal sleep_calls
+        sleep_calls += 1
+        if sleep_calls == 1:
+            with kb.connect_closing() as conn:
+                kb.complete_task(conn, task_id, result="ok")
+            return
+        raise AssertionError("watch did not exit after the task reached done")
+
+    monkeypatch.setattr(kc.time, "sleep", complete_on_first_sleep)
+    rc = _run(
+        [
+            "watch",
+            "--task",
+            task_id,
+            "--until-status",
+            "done,blocked,archived",
+            "--timeout",
+            "2",
+            "--interval",
+            "0.05",
+        ]
+    )
+
+    assert rc == 0
+    assert sleep_calls == 1
+    assert f"{task_id} reached status done" in capsys.readouterr().out
+
+
+def test_watch_timeout_is_bounded_and_does_not_mutate_task(
+    kanban_home, capsys, monkeypatch
+) -> None:
+    with kb.connect_closing() as conn:
+        task_id = kb.create_task(
+            conn,
+            title="keeps running",
+            initial_status="running",
+        )
+        status_before_watch = kb.get_task(conn, task_id).status
+
+    def unexpected_sleep(_seconds: float) -> None:
+        raise AssertionError("watch slept after its deadline")
+
+    monkeypatch.setattr(kc.time, "sleep", unexpected_sleep)
+    rc = _run(
+        [
+            "watch",
+            "--task",
+            task_id,
+            "--until-status",
+            "done,blocked,archived",
+            "--timeout",
+            "0",
+        ]
+    )
+
+    assert rc == 124
+    assert f"timed out waiting for {task_id}" in capsys.readouterr().err
+    with kb.connect_closing() as conn:
+        assert kb.get_task(conn, task_id).status == status_before_watch
+
+
+def test_watch_unknown_until_status_is_rejected(kanban_home, capsys) -> None:
+    with kb.connect_closing() as conn:
+        task_id = kb.create_task(
+            conn,
+            title="never finishes",
+            initial_status="running",
+        )
+
+    rc = _run(
+        [
+            "watch",
+            "--task",
+            task_id,
+            "--until-status",
+            "nope,also_nope",
+            "--timeout",
+            "0",
+        ]
+    )
+
+    assert rc == 2
+    err = capsys.readouterr().err
+    assert "unknown status" in err
+    assert "nope" in err
+
+
+def test_watch_negative_timeout_is_rejected(kanban_home, capsys) -> None:
+    with kb.connect_closing() as conn:
+        task_id = kb.create_task(
+            conn,
+            title="never finishes",
+            initial_status="running",
+        )
+
+    rc = _run(
+        [
+            "watch",
+            "--task",
+            task_id,
+            "--until-status",
+            "done",
+            "--timeout",
+            "-5",
+        ]
+    )
+
+    assert rc == 2
+    assert "--timeout must be >= 0" in capsys.readouterr().err
+
+
+def test_watch_missing_task_is_rejected(kanban_home, capsys) -> None:
+    rc = _run(
+        [
+            "watch",
+            "--task",
+            "t_does_not_exist",
+            "--until-status",
+            "done",
+            "--timeout",
+            "0",
+        ]
+    )
+
+    assert rc == 1
+    assert "no such task" in capsys.readouterr().err
+
+
+def test_watch_is_allowed_in_delegated_child_context(
+    kanban_home, capsys, monkeypatch
+) -> None:
+    with kb.connect_closing() as conn:
+        task_id = kb.create_task(
+            conn,
+            title="observer only",
+            initial_status="running",
+        )
+    monkeypatch.setenv("HERMES_DELEGATED_CHILD_CONTEXT", "1")
+
+    rc = _run(
+        [
+            "watch",
+            "--task",
+            task_id,
+            "--until-status",
+            "done,blocked,archived",
+            "--timeout",
+            "0",
+        ]
+    )
+
+    # Policy §3.1: delegated children MAY use read-only K0 verbs (watch is one
+    # of them). The verb is served over a genuine mode=ro connection, bypassing
+    # init_db entirely so the in-flight backfill's write_txn never runs.
+    assert rc == 124
+    assert "timed out" in capsys.readouterr().err
+
+
+def test_delegated_child_k0_list_is_allowed(
+    kanban_home, capsys, monkeypatch
+) -> None:
+    with kb.connect_closing() as conn:
+        kb.create_task(conn, title="visible to child", initial_status="running")
+    monkeypatch.setenv("HERMES_DELEGATED_CHILD_CONTEXT", "1")
+
+    rc = _run(["list"])
+
+    assert rc == 0
+    assert "visible to child" in capsys.readouterr().out
+
+
+def test_delegated_child_k0_show_is_allowed(
+    kanban_home, capsys, monkeypatch
+) -> None:
+    with kb.connect_closing() as conn:
+        task_id = kb.create_task(
+            conn,
+            title="readable task",
+            initial_status="running",
+        )
+    monkeypatch.setenv("HERMES_DELEGATED_CHILD_CONTEXT", "1")
+
+    rc = _run(["show", task_id])
+
+    assert rc == 0
+    assert "readable task" in capsys.readouterr().out
+
+
+def test_delegated_child_k0_connection_is_genuinely_readonly(kanban_home) -> None:
+    conn = kc._k0_readonly_connect()
+    try:
+        with pytest.raises(Exception):
+            conn.execute("INSERT INTO tasks (id, title) VALUES ('t_x', 'nope')")
+    finally:
+        conn.close()
+
+
+def test_delegated_child_cannot_complete_a_task(
+    kanban_home, capsys, monkeypatch
+) -> None:
+    with kb.connect_closing() as conn:
+        task_id = kb.create_task(
+            conn,
+            title="must not be mutated",
+            initial_status="running",
+        )
+    monkeypatch.setenv("HERMES_DELEGATED_CHILD_CONTEXT", "1")
+
+    rc = _run(["complete", task_id, "--result", "forbidden"])
+
+    assert rc == 1
+    assert "delegate_task" in capsys.readouterr().err


### PR DESCRIPTION
## Summary

Two coupled enhancements to the kanban CLI, extracted from a local Windows deployment that relies on a deterministic, bounded observer/worker split:

1. **Task-scoped watch terminal status** — `kanban watch --task/--until-status/--timeout`:
   - bound a watch to one task and exit successfully once it reaches a terminal status
   - `--timeout` bounds the wait (0 = no wait, timeout exit 124)
   - rejects unknown/negative/missing args with clear messages

2. **Delegated-child K0 read-only dispatch** — delegated children (subagents with `HERMES_DELEGATED_CHILD_CONTEXT`) may only observe the board:
   - `show/list/runs/log/watch/tail` are served over a genuine `mode=ro` connection that bypasses `init_db` entirely, so an in-flight backfill `write_txn` never runs from an observer child
   - mutating verbs remain denied for delegated children
   - `watch` is a member of the K0 whitelist; the delegated-child watch test spans both features, which is why they ship in one PR

## Tests

`tests/hermes_cli/test_kanban_watch_cli.py` (new, 285 lines) — 11 tests covering terminal-status transitions, bounded waits, rejection of unknown/negative/missing args, K0 allowlist membership, and a genuine read-only connection check.

Run: `pytest tests/hermes_cli/test_kanban_watch_cli.py` → 11 passed.

performed_by: arnei
