### PR TITLE
build(desktop): migrate Vite 8 config — import.meta.dirname, codeSplitting

### DIFF
--- a/apps/desktop/vite.config.ts
+++ b/apps/desktop/vite.config.ts
@@ -5,6 +5,10 @@ import path from 'path'
 import fs from 'fs'
 import { createRequire } from 'module'
 
+// Vite 8 uses native ESM config loader; __dirname is not available.
+// import.meta.dirname returns the same directory as the CJS __dirname.
+const __dirname = import.meta.dirname!
+
 // `hgui` symlinks a worktree's node_modules to the main checkout. Vite realpaths
 // those before enforcing server.fs.allow, so codicon/font assets resolve outside
 // the worktree root and 404. Whitelist the real node_modules locations.
@@ -120,7 +124,7 @@ export default defineConfig(({ command }) => ({
     chunkSizeWarningLimit: 25000,
     rolldownOptions: {
       output: {
-        advancedChunks: {
+        codeSplitting: {
           groups: [
             // Shared foundations FIRST (first match wins): an unmatched
             // module shared by the entry and a heavy chunk gets merged INTO


### PR DESCRIPTION
## Summary

Migrates the Vite 8 build config to use the new native ESM and Rolldown APIs.

## Changes

- `__dirname` → `import.meta.dirname` (Vite 8 native ESM config loader)
- `advancedChunks` → `codeSplitting` (Rolldown API rename)

## Validation

- [x] `npm run pack` — full build with Vite 8
- [x] `npx playwright test e2e/` — 15 passed, 0 failed

## Breaking changes

None — these are API renames, no behavior change.