### PR TITLE
feat(sdk): export route-decoupled McpTab + ToolsetConfigPanel for plugins

### DIFF
--- a/apps/desktop/src/app/settings/toolset-config-panel.tsx
+++ b/apps/desktop/src/app/settings/toolset-config-panel.tsx
@@ -50,6 +50,23 @@ interface ToolsetConfigPanelProps {
  *  backend's _MODEL_CATALOG_TOOLSETS map). */
 const MODEL_CATALOG_TOOLSETS = new Set(['image_gen', 'video_gen'])
 
+/**
+ * `useNavigate` throws when there is no react-router context. Inside Settings
+ * (the panel's original home) there always is one, so behavior is unchanged;
+ * embedded in a plugin dialog OUTSIDE the router there is none, and this
+ * degrades to `null` instead of crashing the whole panel. Router presence is
+ * stable for a mounted instance's lifetime, so the try/catch never changes the
+ * hook count between renders (rules-of-hooks safe).
+ */
+function useOptionalNavigate(): null | ReturnType<typeof useNavigate> {
+  try {
+    // eslint-disable-next-line react-hooks/rules-of-hooks -- stable per instance: router presence never changes for a mounted component's lifetime
+    return useNavigate()
+  } catch {
+    return null
+  }
+}
+
 function providerConfigured(provider: ToolProvider, envState: Record<string, boolean>): boolean {
   if (provider.env_vars.length === 0) {
     return true
@@ -91,7 +108,7 @@ interface EnvVarFieldProps {
 function EnvVarField({ envVar, isSet, onSaved, onCleared, profile }: EnvVarFieldProps) {
   const { t } = useI18n()
   const copy = t.settings.toolsets
-  const navigate = useNavigate()
+  const navigate = useOptionalNavigate()
   const [editing, setEditing] = useState(false)
   const [value, setValue] = useState('')
   const [revealed, setRevealed] = useState<string | null>(null)
@@ -99,7 +116,9 @@ function EnvVarField({ envVar, isSet, onSaved, onCleared, profile }: EnvVarField
 
   // Internal route change to Settings → API Keys (tools sub-view) with the
   // deep-link param keys-settings consumes to scroll + flash this key's card.
-  const openInKeys = () => navigate(`${SETTINGS_ROUTE}?tab=keys&key=${encodeURIComponent(envVar.key)}`)
+  // No-op when there is no router (embedded outside Settings, e.g. a plugin
+  // dialog): the "Manage keys" affordance simply doesn't navigate there.
+  const openInKeys = () => navigate?.(`${SETTINGS_ROUTE}?tab=keys&key=${encodeURIComponent(envVar.key)}`)
 
   async function handleSave() {
     if (!value) {

--- a/apps/desktop/src/app/settings/use-deep-link-highlight.ts
+++ b/apps/desktop/src/app/settings/use-deep-link-highlight.ts
@@ -9,6 +9,21 @@ interface DeepLinkHighlightOptions {
   block?: ScrollLogicalPosition
 }
 
+// react-router's useSearchParams throws with no router context. Inside Settings
+// (every original caller) there always is one, so behavior is unchanged; when a
+// consumer is embedded OUTSIDE the router (e.g. McpTab in a plugin dialog) there
+// is none, and this degrades to an inert [empty params, no-op setter] instead of
+// crashing. Router presence is stable for a mounted instance's lifetime, so the
+// try/catch never changes the hook count between renders (rules-of-hooks safe).
+function useOptionalSearchParams(): ReturnType<typeof useSearchParams> {
+  try {
+    // eslint-disable-next-line react-hooks/rules-of-hooks -- stable per instance: router presence never changes for a mounted component's lifetime
+    return useSearchParams()
+  } catch {
+    return [new URLSearchParams(), () => undefined]
+  }
+}
+
 // Deep-link from the command palette (?<param>=<id>): once the target row is
 // renderable, scroll it into view and flash it, then drop the param so it
 // doesn't re-fire. Returns the pending target (null once consumed) so callers
@@ -20,7 +35,7 @@ export function useDeepLinkHighlight({
   onResolve,
   block = 'center'
 }: DeepLinkHighlightOptions): null | string {
-  const [searchParams, setSearchParams] = useSearchParams()
+  const [searchParams, setSearchParams] = useOptionalSearchParams()
   const target = searchParams.get(param)
 
   useEffect(() => {

--- a/apps/desktop/src/sdk/index.ts
+++ b/apps/desktop/src/sdk/index.ts
@@ -23,7 +23,7 @@ import { atom, type ReadableAtom } from 'nanostores'
 import { openSession, type OpenSessionIntent } from '@/app/open-session'
 import { $narrowViewport } from '@/components/pane-shell/tree/store'
 import { onGatewayEvent } from '@/contrib/events'
-import { getLogs, getStatus } from '@/hermes'
+import { getLogs, getStatus, type HermesGateway } from '@/hermes'
 import { $gateway, ensureGatewayForAgent, openGatewayForAgent, openGatewayForProfile } from '@/store/gateway'
 import { notify, notifyError } from '@/store/notifications'
 import { $activeGatewayProfile, ensureGatewayProfile, newSessionInProfile, setShowAllProfiles } from '@/store/profile'
@@ -212,7 +212,14 @@ export const host = {
     }
 
     return gateway.request<T>(method, params)
-  }
+  },
+
+  /** The LIVE gateway instance for the active profile (null before the first
+   *  socket opens). Most plugins want `host.request`; this exists for SDK
+   *  components that take a `HermesGateway` prop directly (e.g. `McpTab`),
+   *  which need the instance, not just a JSON-RPC door. Re-read per use — the
+   *  active instance changes on a profile swap. */
+  getGateway: (): HermesGateway | null => $gateway.get()
 }
 
 // -- react bridge -------------------------------------------------------------
@@ -221,6 +228,22 @@ export const host = {
 // commands, routes, themes, panes, composer extensions, and bar items with
 // the same area ids + payload types core uses.
 export { COMPOSER_AREAS, type ComposerAttachmentProvider, type ComposerMiddleware } from '@/app/chat/composer/contrib'
+
+// -- capabilities: the real Settings → Capabilities components ----------------
+
+/** THE full MCP tab core Settings renders — per-server enable + OAuth sign-in
+ *  + API-key setup + live probes, not a checkbox list. Route-decoupled so it
+ *  renders anywhere (a plugin dialog); pass a live `gateway` (see
+ *  `host.getGateway()`) and an optional `profile` to scope it to one bot. */
+export { McpTab } from '@/app/skills/mcp-tab'
+/** THE full per-toolset config panel core Settings renders — provider picker,
+ *  env vars / API keys, model catalog picker, and post-setup runners. Route-
+ *  decoupled (the "manage keys" deep link is a no-op outside the router); pass
+ *  `toolset`, optional `onConfiguredChange`, and an optional `profile`. */
+export { ToolsetConfigPanel } from '@/app/settings/toolset-config-panel'
+/** The live gateway instance type — for typing the `gateway` prop `McpTab`
+ *  takes; obtain the instance from `host.getGateway()`. */
+export type { HermesGateway } from '@/hermes'
 
 // -- ui: the design language --------------------------------------------------
 

--- a/apps/desktop/src/sdk/index.ts
+++ b/apps/desktop/src/sdk/index.ts
@@ -229,26 +229,15 @@ export const host = {
 // the same area ids + payload types core uses.
 export { COMPOSER_AREAS, type ComposerAttachmentProvider, type ComposerMiddleware } from '@/app/chat/composer/contrib'
 
-// -- capabilities: the real Settings → Capabilities components ----------------
+// -- ui: the design language --------------------------------------------------
 
-/** THE full MCP tab core Settings renders — per-server enable + OAuth sign-in
- *  + API-key setup + live probes, not a checkbox list. Route-decoupled so it
- *  renders anywhere (a plugin dialog); pass a live `gateway` (see
- *  `host.getGateway()`) and an optional `profile` to scope it to one bot. */
-export { McpTab } from '@/app/skills/mcp-tab'
+export { PALETTE_AREA, type PaletteContribution } from '@/app/command-palette/contrib'
+export { type RouteContribution, ROUTES_AREA, SIDEBAR_NAV_AREA, type SidebarNavContribution } from '@/app/routes'
 /** THE full per-toolset config panel core Settings renders — provider picker,
  *  env vars / API keys, model catalog picker, and post-setup runners. Route-
  *  decoupled (the "manage keys" deep link is a no-op outside the router); pass
  *  `toolset`, optional `onConfiguredChange`, and an optional `profile`. */
 export { ToolsetConfigPanel } from '@/app/settings/toolset-config-panel'
-/** The live gateway instance type — for typing the `gateway` prop `McpTab`
- *  takes; obtain the instance from `host.getGateway()`. */
-export type { HermesGateway } from '@/hermes'
-
-// -- ui: the design language --------------------------------------------------
-
-export { PALETTE_AREA, type PaletteContribution } from '@/app/command-palette/contrib'
-export { type RouteContribution, ROUTES_AREA, SIDEBAR_NAV_AREA, type SidebarNavContribution } from '@/app/routes'
 /** THE model catalog menu — the same searchable, provider-grouped, family-
  *  collapsing picker the chat composer uses, including the per-row
  *  thinking/effort/fast submenu. Drive it with a `ModelMenuController`: the
@@ -264,6 +253,11 @@ export {
 export type { StatusbarItem } from '@/app/shell/statusbar-controls'
 
 export type { TitlebarTool } from '@/app/shell/titlebar-controls'
+/** THE full MCP tab core Settings renders — per-server enable + OAuth sign-in
+ *  + API-key setup + live probes, not a checkbox list. Route-decoupled so it
+ *  renders anywhere (a plugin dialog); pass a live `gateway` (see
+ *  `host.getGateway()`) and an optional `profile` to scope it to one bot. */
+export { McpTab } from '@/app/skills/mcp-tab'
 /** Pane placement roles. `'floating'` is the one NON-tiling value: the pane is
  *  excluded from the layout tree and rendered as a fixed, draggable card above
  *  it — it takes no width from any zone, has no tab, and can't be docked.
@@ -342,6 +336,9 @@ export type {
  *  id with your plugin slug (`kanban:board-switcher`). */
 export { Contribute, type ContributeProps } from '@/contrib/react/contribute'
 export type { Contribution } from '@/contrib/types'
+/** The live gateway instance type — for typing the `gateway` prop `McpTab`
+ *  takes; obtain the instance from `host.getGateway()`. */
+export type { HermesGateway } from '@/hermes'
 /** Grab-to-pan for overflow containers (boards, timelines, wide tables) —
  *  the shared scrub primitive; don't hand-roll drag-to-scroll. */
 export { type GrabScroll, useGrabScroll } from '@/hooks/use-grab-scroll'


### PR DESCRIPTION
## Why
Runtime desktop plugins can only import from `@hermes/plugin-sdk`. The **real** Capabilities components — the full per-toolset config panel (provider picker, env vars / API keys, model-catalog picker, post-setup runners) and the full MCP tab (per-server enable + **OAuth sign-in** + API-key setup + live probes) — were never exported there. So a plugin (e.g. Hermes-Bot-Mode's bot creator/editor) could only reimplement bare on/off checkbox lists, with no way to configure credentials or OAuth. This exposes the genuine components so plugins render the same experience as Settings → Capabilities, scoped to a chosen profile.

## Changes (renderer/SDK only, +67/-5 across 3 files)
- **`sdk/index.ts`**: `export { McpTab }`, `export { ToolsetConfigPanel }`, `export type HermesGateway`, and `host.getGateway()` returning the live `$gateway` instance (McpTab takes a `HermesGateway` prop; plugins previously had no way to obtain the instance).
- **`toolset-config-panel.tsx`**: `useOptionalNavigate()` wraps `useNavigate` in try/catch (returns `null` with no router); the 'manage keys' deep-link becomes a no-op when embedded outside Settings. **In-Settings behavior unchanged.**
- **`use-deep-link-highlight.ts`**: `useOptionalSearchParams()` degrades to inert params with no router. Shared by 4 in-Settings callers incl. `McpTab` — identical behavior there (Settings always has a router).

Both components are already profile-aware (`profile?: null|string`, #86548), so a plugin can scope them to a specific bot profile.

## Compatibility / invariants
Route-decoupling is a pure widening: the try/catch `return useNavigate()` succeeds inside the router (unchanged), only the no-router case is new. Router presence is stable for a mounted instance's lifetime, so the hook count never varies between renders (rules-of-hooks safe). No visual change; no change to component logic.

## Verification
- `tsc --noEmit`: **0 errors**, identical to baseline (stash-compared).
- Exports + `host.getGateway()` grep-confirmed in the barrel.
- ⚠️ Unit test (`toolset-config-panel.test.tsx`) not run locally — the isolated worktree has production-only deps; **relying on CI** for the full desktop suite. The change wraps two hooks in try/catch + adds exports; the existing test exercises the in-router path, which is byte-identical.

Paired with a Hermes-Bot-Mode plugin PR that embeds these in the bot editor's Tools/MCP tabs. **Reaches plugins only after a desktop rebuild** (SDK exports are baked into the plugin shim at build time).