### PR TITLE
fix(telegram): route proxy through TelegramFallbackTransport to avoid httpx crash

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -4413,12 +4413,29 @@ class TelegramAdapter(BasePlatformAdapter):
                     },
                 )
             elif proxy_url:
-                logger.info("[%s] Proxy detected; passing explicitly to HTTPXRequest: %s", self.name, proxy_url)
+                logger.info("[%s] Proxy detected; passing to TelegramFallbackTransport: %s", self.name, proxy_url)
+                # PTB 22.8 + httpx 0.28.1: passing proxy= to HTTPXRequest
+                # crashes with "Any cannot be instantiated". Route the proxy
+                # through TelegramFallbackTransport instead.
+                _transport_kwargs: dict = {}
+                if _pool_limits is not None:
+                    _transport_kwargs["limits"] = _pool_limits
+                _transport_kwargs["proxy"] = proxy_url
                 request = HTTPXRequest(
-                    **request_kwargs, proxy=proxy_url, httpx_kwargs=_with_limits()
+                    **request_kwargs,
+                    httpx_kwargs={
+                        "transport": TelegramFallbackTransport(
+                            fallback_ips, **_transport_kwargs
+                        )
+                    },
                 )
                 get_updates_request = HTTPXRequest(
-                    **request_kwargs, proxy=proxy_url, httpx_kwargs=_with_limits()
+                    **request_kwargs,
+                    httpx_kwargs={
+                        "transport": TelegramFallbackTransport(
+                            fallback_ips, **_transport_kwargs
+                        )
+                    },
                 )
             else:
                 if disable_fallback:


### PR DESCRIPTION
## Summary
- PTB 22.8 + httpx 0.28.1 crashes with "Any cannot be instantiated" when proxy= is passed directly to HTTPXRequest
- Routes proxy URL through TelegramFallbackTransport instead, which handles proxy correctly via httpx.AsyncHTTPTransport

## Problem
When using Hiddify (or any HTTP proxy) on macOS, the Telegram adapter crashes because python-telegram-bot 22.8 cannot properly handle the proxy parameter with httpx 0.28.1.

## Solution
Pass the proxy URL to `TelegramFallbackTransport` (which internally uses `httpx.AsyncHTTPTransport(proxy=...)`) instead of passing it directly to `HTTPXRequest`.

## Tested
- [x] Verified proxy connection works with Hiddify on macOS
- [x] Telegram bot connects successfully through proxy
