### PR TITLE
fix(backup): don't nest state-snapshots/ into full backups

### DIFF
--- a/hermes_cli/backup.py
+++ b/hermes_cli/backup.py
@@ -44,6 +44,11 @@ logger = logging.getLogger(__name__)
 # Exclusion rules
 # ---------------------------------------------------------------------------
 
+# Where ``hermes backup --quick`` / ``/snapshot`` / the pre-update safety net
+# write their state snapshots (see ``create_quick_snapshot`` below). Defined up
+# here because the exclusion set needs it.
+_QUICK_SNAPSHOTS_DIR = "state-snapshots"
+
 # Directory names to skip entirely (matched against each path component)
 # ``hermes-agent`` is special-cased to root level only in ``_should_exclude``
 # so that skill directories like ``skills/autonomous-ai-agents/hermes-agent/``
@@ -66,6 +71,9 @@ _EXCLUDED_DIRS = {
     ".git",             # nested git dirs (profiles shouldn't have these, but safety)
     "node_modules",     # js deps — reinstalled on demand
     "backups",          # prior auto-backups — don't nest backups exponentially
+    _QUICK_SNAPSHOTS_DIR,  # quick/pre-update state snapshots — same reason as
+                        # ``backups``: each holds a full copy of state.db, so
+                        # zipping them re-ships the DB once per snapshot
     "checkpoints",      # session-local trajectory caches — regenerated per-session,
                         # session-hash-keyed so they don't port to another machine anyway
     # Python dependency trees (plugin / MCP-server venvs under HERMES_HOME) —
@@ -1262,7 +1270,7 @@ _QUICK_STATE_FILES = (
     "feishu_comment_pairing.json",      # Feishu comment subscription pairings
 )
 
-_QUICK_SNAPSHOTS_DIR = "state-snapshots"
+# ``_QUICK_SNAPSHOTS_DIR`` lives with the exclusion rules at the top of the module.
 _QUICK_DEFAULT_KEEP = 20
 
 

--- a/tests/hermes_cli/test_backup.py
+++ b/tests/hermes_cli/test_backup.py
@@ -133,6 +133,19 @@ class TestShouldExclude:
         from hermes_cli.backup import _should_exclude
         assert _should_exclude(Path("backups/pre-update-2026-04-27-063400.zip"))
 
+    def test_excludes_state_snapshots_dir(self):
+        """state-snapshots/ is excluded for the same reason as backups/: every
+        quick / pre-update snapshot holds its own copy of state.db, so zipping
+        the tree would ship the DB once per retained snapshot."""
+        from hermes_cli.backup import _EXCLUDED_DIRS, _QUICK_SNAPSHOTS_DIR, _should_exclude
+        assert _QUICK_SNAPSHOTS_DIR in _EXCLUDED_DIRS
+        assert _should_exclude(Path(_QUICK_SNAPSHOTS_DIR) / "20260814-203829-2026-08-15" / "state.db")
+        assert _should_exclude(Path(_QUICK_SNAPSHOTS_DIR) / "20260814-203829-2026-08-15" / "manifest.json")
+        # Named profiles accumulate snapshots too.
+        assert _should_exclude(Path("profiles/coder") / _QUICK_SNAPSHOTS_DIR / "x" / "state.db")
+        # The live DB is still backed up.
+        assert not _should_exclude(Path("state.db"))
+
     def test_excludes_sqlite_sidecars(self):
         """SQLite WAL/SHM/journal sidecars must not ship alongside the
         safe-copied .db — pairing a fresh snapshot with stale sidecar state
@@ -240,6 +253,35 @@ class TestBackup:
             names = zf.namelist()
             assert "skills/outside-link.txt" not in names
             assert all(zf.read(name) != b"outside secret\n" for name in names)
+
+    def test_state_snapshots_not_nested_into_backup(self, tmp_path, monkeypatch):
+        """A quick snapshot left under state-snapshots/ must not be re-shipped
+        by the full backup — each snapshot already holds a copy of state.db, so
+        nesting them multiplies the archive by (1 + retained snapshots)."""
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        _make_hermes_tree(hermes_home)
+        with sqlite3.connect(hermes_home / "state.db") as conn:
+            conn.execute("CREATE TABLE sessions (id TEXT PRIMARY KEY)")
+            conn.execute("INSERT INTO sessions VALUES ('s1')")
+
+        from hermes_cli.backup import _QUICK_SNAPSHOTS_DIR, create_quick_snapshot, run_backup
+
+        # Real producer, so the layout under state-snapshots/ is whatever the
+        # code actually writes (manifest.json + state.db copy + ...).
+        snap_id = create_quick_snapshot(hermes_home=hermes_home)
+        assert snap_id and (hermes_home / _QUICK_SNAPSHOTS_DIR / snap_id / "state.db").exists()
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        out_zip = tmp_path / "backup.zip"
+        run_backup(Namespace(output=str(out_zip)))
+
+        with zipfile.ZipFile(out_zip, "r") as zf:
+            names = zf.namelist()
+        assert not any(n.startswith(_QUICK_SNAPSHOTS_DIR + "/") for n in names), names
+        # Exactly one state.db in the archive: the live one.
+        assert [n for n in names if n == "state.db" or n.endswith("/state.db")] == ["state.db"]
 
 
 # ---------------------------------------------------------------------------
@@ -1360,6 +1402,28 @@ class TestPreUpdateBackup:
         assert not any("__pycache__" in n for n in names)
         # pid files excluded
         assert "gateway.pid" not in names
+
+    def test_pre_update_zip_does_not_nest_the_pre_update_snapshot(self, hermes_home):
+        """``hermes update`` in ``full`` mode takes the quick snapshot *before*
+        the full zip, so the zip walk sees the snapshot it just made. It must
+        skip it — otherwise every pre-update zip ships state.db twice."""
+        from hermes_cli.backup import (
+            _QUICK_SNAPSHOTS_DIR,
+            create_pre_update_backup,
+            create_quick_snapshot,
+        )
+        with sqlite3.connect(hermes_home / "state.db") as conn:
+            conn.execute("CREATE TABLE sessions (id TEXT PRIMARY KEY)")
+
+        snap_id = create_quick_snapshot(label="pre-update", hermes_home=hermes_home)
+        assert snap_id and (hermes_home / _QUICK_SNAPSHOTS_DIR / snap_id / "state.db").exists()
+
+        out = create_pre_update_backup(hermes_home=hermes_home)
+        assert out is not None
+        with zipfile.ZipFile(out) as zf:
+            names = zf.namelist()
+        assert "state.db" in names
+        assert not any(n.startswith(_QUICK_SNAPSHOTS_DIR + "/") for n in names), names
 
 
     def test_rotation_keeps_only_n(self, hermes_home):

--- a/website/docs/reference/cli-commands.md
+++ b/website/docs/reference/cli-commands.md
@@ -892,7 +892,7 @@ hermes debug share --local      # Print report to terminal (no upload)
 hermes backup [options]
 ```
 
-Create a zip archive of your Hermes configuration, skills, sessions, and data. The backup excludes the hermes-agent codebase itself.
+Create a zip archive of your Hermes configuration, skills, sessions, and data. The backup excludes the hermes-agent codebase itself, and it does not nest earlier backup artifacts (`backups/`, `state-snapshots/`) — each of those already contains its own copy of `state.db`.
 
 | Option | Description |
 |--------|-------------|


### PR DESCRIPTION
## What does this PR do?

`hermes backup` skips `backups/` so a full zip never re-ships earlier pre-update zips ("don't nest backups exponentially"). `state-snapshots/` has exactly the same shape — every snapshot written by `hermes backup --quick`, `/snapshot create`, or the pre-update safety net holds its **own full copy of `state.db`** — but it is not in `_EXCLUDED_DIRS`. So a full backup ships the DB once for the live file **plus once per retained snapshot**.

Two places hit this in practice:

- **`hermes update` in `full` backup mode** (`updates.pre_update_backup: full` or `--backup`) takes the quick snapshot *first* and then writes the full zip (`_run_pre_update_backup` → `create_quick_snapshot(...)` → `create_pre_update_backup(...)`). The zip walk therefore sees the snapshot it just made and nests it: `state.db` is in **every** `pre-update-*.zip` twice.
- **Any recurring `hermes backup --quick`** (default `keep=20`) makes a periodic full `hermes backup` grow by roughly one compressed `state.db` per snapshot on disk. Measured on a 750 MB `state.db`: with two snapshots present, the daily zip went from 1.8 GB to 2.3 GB; at the default keep of 20 the archive would be dominated by copies of the same database.

### The fix

Add `_QUICK_SNAPSHOTS_DIR` to `_EXCLUDED_DIRS`, and move that constant up next to the exclusion rules so there is one source of truth for the directory name. `_should_exclude()` and both `os.walk` prune sites already share the set, so `hermes backup`, the pre-update zip, and the automatic-backup path all pick it up without further changes.

This deliberately does **not** try to keep "the newest snapshot" in the archive: `profiles.py` already excludes `state-snapshots/` (alongside `backups/`, `checkpoints/`) from `--clone-all` with the same "belongs to the source, can reach tens of GB" rationale, and the live `state.db` is in the zip anyway. `hermes import` is untouched — an older archive that happens to contain `state-snapshots/` still restores exactly as before.

## Related Issue

No existing issue — found while tracing why a daily `hermes backup` zip was growing. Searched open/merged PRs and issues for `state-snapshots backup exclude` before opening this.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/backup.py` — `_QUICK_SNAPSHOTS_DIR` moved to the exclusion-rules block and added to `_EXCLUDED_DIRS` (comment mirrors the `backups` entry). No other logic changes; the constant keeps its name and value, and nothing outside this module imports it.
- `tests/hermes_cli/test_backup.py` — 3 tests:
  - `TestShouldExclude.test_excludes_state_snapshots_dir` (unit, incl. the `profiles/<name>/state-snapshots/` case and the "live `state.db` still included" negative control)
  - `TestBackup.test_state_snapshots_not_nested_into_backup` (end-to-end: real `create_quick_snapshot` producer → `run_backup` → zip has no `state-snapshots/` entries and **exactly one** `state.db`)
  - `TestPreUpdateBackup.test_pre_update_zip_does_not_nest_the_pre_update_snapshot` (mirrors the `hermes update` full-mode order: snapshot first, then `create_pre_update_backup`)
- `website/docs/reference/cli-commands.md` — one sentence under `hermes backup` saying earlier backup artifacts (`backups/`, `state-snapshots/`) are not nested.

Side note for reviewers: `_iter_external_files()` (memory-provider external paths) prunes with the same set, so a directory literally named `state-snapshots` inside an external memory path would now be skipped too. That seemed acceptable — it is the same treatment `backups`/`checkpoints` already get there.

## How to Test

Reproduce on `main` (state.db appears twice), then re-run with the patch:

```bash
export HERMES_HOME=$(mktemp -d)/hermes && mkdir -p "$HERMES_HOME"
python - <<'EOF'
import os, sqlite3, pathlib
h = pathlib.Path(os.environ["HERMES_HOME"])
(h / "config.yaml").write_text("model:\n  provider: openrouter\n")
sqlite3.connect(h / "state.db").execute("create table t(x)").connection.commit()
EOF
hermes backup --quick --label demo                     # writes state-snapshots/<id>-demo/state.db
hermes backup -o /tmp/full.zip
unzip -l /tmp/full.zip | grep -c 'state\.db$'
# main:     2   (state.db + state-snapshots/<id>-demo/state.db)
# this PR:  1
```

Test evidence (macOS 15, Python 3.11):

```
with patch:     tests/hermes_cli/test_backup.py                       54 passed
without patch:  -k "state_snapshots or nest"                          3 failed  ← only the new tests
related files:  test_backup*.py test_state_db_guard.py test_sizefmt.py
                tests/cron/test_execution_ledger.py                   97 passed
                test_cmd_update.py test_profiles.py test_update_zip_*  102 passed, 2 skipped
ruff check hermes_cli/backup.py tests/hermes_cli/test_backup.py       All checks passed!
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the backup / update / profile test files listed above and all tests pass (full `pytest tests/ -q` not run locally — the suite is very large; the touched module's callers are covered by the files above)
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15 (Apple Silicon), Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (`website/docs/reference/cli-commands.md`)
- [x] `cli-config.yaml.example` — N/A (no config keys changed)
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] Cross-platform impact — N/A (pure path-component match, no OS-specific code)
- [x] Tool descriptions/schemas — N/A
