### PR TITLE
fix(gateway): treat a Running Windows scheduled task as a gateway supervisor (#86098)

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -1705,6 +1705,16 @@ def _reap_unsupervised_gateway_orphans(extra_exclude: set | None = None) -> bool
     except Exception:
         return False
 
+    # Windows Task Scheduler is a supervisor too — and the most reliable
+    # signal is the task's own state, not a parent-chain walk. A Scheduled
+    # Task gateway whose conhost bootstrap has already exited is invisible
+    # to `_reaper_candidate_is_supervisor_owned` (the parent chain breaks
+    # before services.exe, fail-open), yet it is alive and supervised.
+    # Querying the task state catches that case: if HermesGateway is
+    # Running, the reaper must not touch its process tree (#86098).
+    if is_windows() and _windows_scheduled_task_running("HermesGateway"):
+        return False
+
     from gateway.status import _pid_exists, write_planned_stop_marker
 
     own = {os.getpid()}
@@ -1935,6 +1945,51 @@ def is_macos() -> bool:
 
 def is_windows() -> bool:
     return sys.platform == "win32"
+
+
+def _windows_scheduled_task_running(task_name: str) -> bool:
+    """Return True when a Windows scheduled task with ``task_name`` is Running.
+
+    Used to treat Task Scheduler as a gateway supervisor on Windows: the
+    orphan-reap sweep must not kill a gateway that a scheduled task is
+    actively managing (it writes the planned-stop marker, the gateway exits
+    cleanly with code 0, and the scheduler never restarts it — silently
+    killing A2A/messaging on every desktop-app launch).
+
+    Best-effort: any failure (missing task, powershell unavailable, timeout)
+    returns False so the caller falls back to its existing behaviour.
+
+    Implemented with PowerShell (``Get-ScheduledTask``) instead of ``schtasks``
+    because the latter localizes its output (a Chinese Windows prints
+    ``状态: 正在运行``, not ``Status: Running``) and emits the local codepage,
+    which ``subprocess`` with ``encoding="utf-8"`` silently mangles. The
+    ``State`` property of ``Get-ScheduledTask`` is an English enum value
+    (``Running`` / ``Ready`` / ``Disabled``), stable across locales.
+    """
+    if not is_windows():
+        return False
+    try:
+        powershell = shutil.which("powershell") or shutil.which("pwsh")
+        if powershell is None:
+            return False
+        ps_cmd = (
+            f"$t = Get-ScheduledTask -TaskName '{task_name}' "
+            "-ErrorAction SilentlyContinue; if ($t) { $t.State } else { 'MISSING' }"
+        )
+        result = subprocess.run(
+            [powershell, "-NoProfile", "-Command", ps_cmd],
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="ignore",
+            timeout=10,
+        )
+        if result.returncode != 0:
+            return False
+        state = (result.stdout or "").strip()
+        return state == "Running"
+    except (OSError, subprocess.TimeoutExpired):
+        return False
 
 
 def _windows_gateway_should_absorb_console_controls() -> bool:

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -1712,8 +1712,18 @@ def _reap_unsupervised_gateway_orphans(extra_exclude: set | None = None) -> bool
     # before services.exe, fail-open), yet it is alive and supervised.
     # Querying the task state catches that case: if HermesGateway is
     # Running, the reaper must not touch its process tree (#86098).
-    if is_windows() and _windows_scheduled_task_running("HermesGateway"):
-        return False
+    if is_windows():
+        try:
+            # The install-time task name is profile-aware (Hermes_Gateway /
+            # Hermes_Gateway_<profile>) — never hardcode it, or the guard is
+            # dormant on every standard `hermes gateway install` deployment.
+            from hermes_cli.gateway_windows import get_task_name
+
+            _task_name = get_task_name()
+        except Exception:
+            _task_name = "Hermes_Gateway"
+        if _windows_scheduled_task_running(_task_name):
+            return False
 
     from gateway.status import _pid_exists, write_planned_stop_marker
 

--- a/tests/hermes_cli/test_gateway.py
+++ b/tests/hermes_cli/test_gateway.py
@@ -793,7 +793,24 @@ class TestWindowsScheduledTaskSupervisorGuard:
         monkeypatch.setattr(gateway, "is_windows", lambda: True)
         monkeypatch.setattr(gateway, "is_macos", lambda: False)
         monkeypatch.setattr(gateway, "supports_systemd_services", lambda: False)
-        monkeypatch.setattr(gateway, "_windows_scheduled_task_running", lambda name: True)
+        # The guard must query the PROFILE-AWARE install-time task name from
+        # gateway_windows.get_task_name(), never a hardcoded literal — a
+        # hardcoded "HermesGateway" would leave the guard dormant on every
+        # standard install (task name is Hermes_Gateway / Hermes_Gateway_<p>).
+        import hermes_cli.gateway_windows as gateway_windows
+
+        monkeypatch.setattr(
+            gateway_windows, "get_task_name", lambda: "Hermes_Gateway_testprof"
+        )
+        queried = []
+
+        def _fake_task_running(name):
+            queried.append(name)
+            return True
+
+        monkeypatch.setattr(
+            gateway, "_windows_scheduled_task_running", _fake_task_running
+        )
 
         # Guard: if the task check were bypassed, these would be reaped.
         def _boom_find_gateway_pids(exclude_pids=None):
@@ -807,6 +824,7 @@ class TestWindowsScheduledTaskSupervisorGuard:
 
         assert result is False
         assert killed_pids == []
+        assert queried == ["Hermes_Gateway_testprof"]
 
     def test_not_running_task_still_reaps_real_orphan(self, monkeypatch):
         """HermesGateway not Running (or missing) => reaper behaves as before

--- a/tests/hermes_cli/test_gateway.py
+++ b/tests/hermes_cli/test_gateway.py
@@ -771,3 +771,80 @@ def test_module_has_logger():
     """Verify module has a logger instance (regression guard for #27154)."""
     assert hasattr(gateway, "logger")
     assert gateway.logger.name == "hermes_cli.gateway"
+
+
+class TestWindowsScheduledTaskSupervisorGuard:
+    """The reaper must skip entirely when the HermesGateway scheduled task is
+    Running — Task Scheduler is a supervisor, and the task's own state is the
+    authoritative signal.
+
+    Regression guard: ``_reaper_candidate_is_supervisor_owned`` walks the
+    parent chain up to ``services.exe`` and fails open when the Task-launched
+    bootstrap has already exited (Windows does not reparent, so the chain
+    breaks). A gateway whose conhost bootstrap exited is then treated as an
+    orphan: the reaper writes the planned-stop marker, the gateway exits
+    cleanly with code 0, and the scheduler never restarts it — silently
+    killing A2A/messaging on every desktop-app launch. Querying the task
+    state closes that gap without depending on process ancestry.
+    """
+
+    def test_running_task_skips_reap(self, monkeypatch):
+        """HermesGateway is Running => reaper returns False, kills nothing."""
+        monkeypatch.setattr(gateway, "is_windows", lambda: True)
+        monkeypatch.setattr(gateway, "is_macos", lambda: False)
+        monkeypatch.setattr(gateway, "supports_systemd_services", lambda: False)
+        monkeypatch.setattr(gateway, "_windows_scheduled_task_running", lambda name: True)
+
+        # Guard: if the task check were bypassed, these would be reaped.
+        def _boom_find_gateway_pids(exclude_pids=None):
+            raise AssertionError("must not scan when scheduled task is Running")
+
+        monkeypatch.setattr(gateway, "find_gateway_pids", _boom_find_gateway_pids)
+        killed_pids = []
+        monkeypatch.setattr(gateway.os, "kill", lambda pid, sig: killed_pids.append((pid, sig)))
+
+        result = gateway._reap_unsupervised_gateway_orphans()
+
+        assert result is False
+        assert killed_pids == []
+
+    def test_not_running_task_still_reaps_real_orphan(self, monkeypatch):
+        """HermesGateway not Running (or missing) => reaper behaves as before
+        and still reaps a genuine orphan."""
+        orphan_pid = 99998
+
+        monkeypatch.setattr(gateway, "is_windows", lambda: True)
+        monkeypatch.setattr(gateway, "is_macos", lambda: False)
+        monkeypatch.setattr(gateway, "supports_systemd_services", lambda: False)
+        monkeypatch.setattr(gateway, "_windows_scheduled_task_running", lambda name: False)
+        monkeypatch.setattr("gateway.status.get_running_pid", lambda: None)
+        monkeypatch.setattr(gateway, "_get_service_pids", lambda: set())
+
+        monkeypatch.setattr(
+            gateway,
+            "find_gateway_pids",
+            lambda exclude_pids=None: [
+                p for p in [orphan_pid] if p not in (exclude_pids or set())
+            ],
+        )
+        killed_pids = []
+        monkeypatch.setattr(gateway.os, "kill", lambda pid, sig: killed_pids.append((pid, sig)))
+        monkeypatch.setattr("gateway.status._pid_exists", lambda pid: False)
+        monkeypatch.setattr("gateway.status.write_planned_stop_marker", lambda pid: None)
+        monkeypatch.setattr("time.sleep", lambda _: None)
+        monkeypatch.setattr("time.monotonic", lambda: 1.0)
+
+        result = gateway._reap_unsupervised_gateway_orphans()
+
+        assert result is True
+        assert orphan_pid in [pid for pid, _ in killed_pids]
+
+    def test_windows_scheduled_task_running_returns_false_off_windows(self, monkeypatch):
+        """The state helper is inert on POSIX (no subprocess spawned)."""
+        monkeypatch.setattr(gateway, "is_windows", lambda: False)
+
+        def _boom_run(*_a, **_k):
+            raise AssertionError("subprocess must not run off Windows")
+
+        monkeypatch.setattr(gateway.subprocess, "run", _boom_run)
+        assert gateway._windows_scheduled_task_running("HermesGateway") is False


### PR DESCRIPTION
## Summary

The Windows orphan reaper no longer kills a gateway that Task Scheduler is actively supervising: when the profile-aware `Hermes_Gateway` scheduled task reports `Running`, `_reap_unsupervised_gateway_orphans` skips entirely.

Salvages #86823 by @hutao562 (first-time contributor) onto current main, with the task name corrected during salvage.

Root cause: the existing ancestry backstop (`_reaper_candidate_is_supervisor_owned`, #86658) walks the parent chain to `services.exe` and fails open when the Task-launched conhost bootstrap has already exited — Windows does not reparent, the chain breaks, and the supervised gateway is misclassified as an orphan. The reaper then writes the planned-stop marker, the gateway exits cleanly with code 0, and the scheduler never restarts it (restart triggers only fire on non-zero exit) — A2A/messaging silently down on every desktop-app launch (#86098).

## Changes

- `hermes_cli/gateway.py`: `_windows_scheduled_task_running()` helper — queries task state via PowerShell `Get-ScheduledTask` (locale-stable English enum; `schtasks` localizes output and emits the local codepage). Reaper skips when the task is `Running`. Best-effort: any failure returns False and the existing behavior proceeds.
- Follow-up (ours): resolve the task name through `gateway_windows.get_task_name()` — the contributor hardcoded `"HermesGateway"`, but installs register `Hermes_Gateway` / `Hermes_Gateway_<profile>`, which would have left the guard dormant on every standard deployment. Also corrected the cherry-picked commit's placeholder author email to the contributor's noreply address.
- `tests/hermes_cli/test_gateway.py`: 3 tests — Running task skips the sweep (and asserts the profile-aware name reaches the query), not-Running still reaps a genuine orphan, helper is inert on POSIX.

## Validation

| | Result |
|---|---|
| `tests/hermes_cli/test_gateway.py` | 27/27 passed |
| Base gate vs origin/main | 0 behind, diff = 2 files, +160 |

Contributor verified the fix on the affected Windows 11 deployment (task Running → reaper returns False, `:9900` stays LISTENING through a full serve-startup simulation).

## Infographic

![Gateway reaper: Task Scheduler is a supervisor](https://files.catbox.moe/dop29x.png)
