### PR TITLE
fix(desktop): harden the merged remote-media and gateway save path

### DIFF
--- a/apps/desktop/electron/gateway-file-download-transport.test.ts
+++ b/apps/desktop/electron/gateway-file-download-transport.test.ts
@@ -50,9 +50,26 @@ test('finalizeGatewayDownload prompts a save dialog then streams the response', 
   const fn = extract('async function finalizeGatewayDownload', '\nfunction readGatewayErrorText')
 
   assert.match(fn, /dialog\.showSaveDialog/)
-  assert.match(fn, /pumpStreamToFile\(/)
+  assert.match(fn, /pumpStreamToFileAtomically\(/)
   // HTTP errors carry their status so a 404 can trigger the fallback.
   assert.match(fn, /error\.statusCode = statusCode/)
+})
+
+test('finalizeGatewayDownload never saves a redirect body and bounds the download', () => {
+  const fn = extract('async function finalizeGatewayDownload', '\nfunction readGatewayErrorText')
+
+  // A 3xx (e.g. an auth interstitial) must fail the download, not become the file.
+  assert.match(fn, /statusCode >= 300 && statusCode < 400/)
+  // The announced body is rejected before the dialog; the stream is capped while flowing.
+  assert.match(fn, /contentLengthExceedsLimit\(headers, GATEWAY_DOWNLOAD_MAX_BYTES\)/)
+  assert.match(fn, /GATEWAY_DOWNLOAD_MAX_BYTES/)
+})
+
+test('finalizeGatewayDownload binds the save dialog to the requesting window', () => {
+  const fn = extract('async function finalizeGatewayDownload', '\nfunction readGatewayErrorText')
+
+  // The IPC sender's window wins; the global mainWindow is only the fallback.
+  assert.match(fn, /dialog\.showSaveDialog\(ctx\.window \?\? mainWindow/)
 })
 
 test('saveGatewayFile falls back to the data-url route only on 404', () => {

--- a/apps/desktop/electron/gateway-file-download.test.ts
+++ b/apps/desktop/electron/gateway-file-download.test.ts
@@ -4,11 +4,15 @@ import { EventEmitter } from 'node:events'
 import { test } from 'vitest'
 
 import {
+  contentLengthExceedsLimit,
   filenameFromContentDisposition,
+  GATEWAY_DOWNLOAD_MAX_BYTES,
+  GatewayDownloadTooLargeError,
   gatewayFilePath,
   isNotFoundError,
   parseDataUrlToBuffer,
-  pumpStreamToFile
+  pumpStreamToFile,
+  pumpStreamToFileAtomically
 } from './gateway-file-download'
 
 // A Readable-like response driven manually in tests.
@@ -187,4 +191,155 @@ test('isNotFoundError matches only HTTP 404', () => {
   assert.equal(isNotFoundError(forbidden), false)
   assert.equal(isNotFoundError(new Error('plain')), false)
   assert.equal(isNotFoundError(null), false)
+})
+
+test('contentLengthExceedsLimit flags only announced bodies above the cap', () => {
+  assert.equal(contentLengthExceedsLimit({ 'content-length': String(GATEWAY_DOWNLOAD_MAX_BYTES + 1) }), true)
+  assert.equal(contentLengthExceedsLimit({ 'content-length': String(GATEWAY_DOWNLOAD_MAX_BYTES) }), false)
+  assert.equal(contentLengthExceedsLimit({ 'Content-Length': '1024' }), false)
+  assert.equal(contentLengthExceedsLimit({ 'content-length': [String(GATEWAY_DOWNLOAD_MAX_BYTES + 1)] }), true)
+  // Absent or unparsable headers cannot prove the body is bounded — the
+  // stream-time byte count stays the enforcing boundary for those.
+  assert.equal(contentLengthExceedsLimit({}), false)
+  assert.equal(contentLengthExceedsLimit({ 'content-length': 'not-a-number' }), false)
+})
+
+test('pumpStreamToFile enforces the byte cap while streaming and cleans the partial file', async () => {
+  const res = new FakeResponse()
+  const ws = new FakeWriteStream()
+  const unlinked: string[] = []
+
+  const promise = pumpStreamToFile(
+    res as never,
+    '/tmp/too-big.bin',
+    {
+      createWriteStream: () => ws as never,
+      unlink: async p => {
+        unlinked.push(p)
+      }
+    },
+    4
+  )
+
+  res.emit('data', Buffer.from('abcd'))
+  res.emit('data', Buffer.from('e'))
+
+  await assert.rejects(promise, (error: Error) => error instanceof GatewayDownloadTooLargeError)
+  assert.deepEqual(unlinked, ['/tmp/too-big.bin'])
+  assert.equal(ws.destroyed, true)
+})
+
+// Records the filesystem operations the atomic pump performs so tests can
+// assert ordering and — critically — which paths are never touched.
+function atomicDeps(ws: FakeWriteStream, options: { renameError?: string } = {}) {
+  const calls: string[] = []
+  const destDir = '/downloads'
+
+  return {
+    calls,
+    deps: {
+      createWriteStream: () => ws as never,
+      mkdtemp: async (prefix: string) => {
+        calls.push(`mkdtemp:${prefix}`)
+
+        return `${destDir}/.hermes-download-test`
+      },
+      rename: async (from: string, to: string) => {
+        calls.push(`rename:${from}->${to}`)
+
+        if (options.renameError) {
+          const error: any = new Error(options.renameError)
+
+          error.code = options.renameError
+          throw error
+        }
+      },
+      rm: async (target: string, _options: { force: boolean; recursive: boolean }) => {
+        calls.push(`rm:${target}`)
+      },
+      unlink: async (target: string) => {
+        calls.push(`unlink:${target}`)
+      }
+    }
+  }
+}
+
+test('pumpStreamToFileAtomically publishes only a complete file and always cleans the temp dir', async () => {
+  const res = new FakeResponse()
+  const ws = new FakeWriteStream()
+  const { calls, deps } = atomicDeps(ws)
+
+  const promise = pumpStreamToFileAtomically(res as never, '/downloads/report.pdf', deps as never)
+
+  // The async mkdtemp preamble must settle before listeners are attached.
+  await new Promise(resolve => setImmediate(resolve))
+  res.emit('data', Buffer.from('payload'))
+  res.emit('end')
+  await promise
+
+  assert.deepEqual(calls, [
+    'mkdtemp:/downloads/.hermes-download-',
+    'rename:/downloads/.hermes-download-test/payload->/downloads/report.pdf',
+    'rm:/downloads/.hermes-download-test'
+  ])
+})
+
+test('pumpStreamToFileAtomically leaves a pre-existing destination untouched on stream failure', async () => {
+  const res = new FakeResponse()
+  const ws = new FakeWriteStream()
+  const { calls, deps } = atomicDeps(ws)
+
+  const promise = pumpStreamToFileAtomically(res as never, '/downloads/existing.pdf', deps as never)
+
+  // The async mkdtemp preamble must settle before listeners are attached.
+  await new Promise(resolve => setImmediate(resolve))
+  res.emit('data', Buffer.from('partial'))
+  res.emit('error', new Error('connection reset'))
+
+  await assert.rejects(promise, /connection reset/)
+  // The original file at the destination is never written to or unlinked —
+  // only the temp payload is removed. This is the regression guard against
+  // write-in-place + unlink-by-name finalization.
+  assert.deepEqual(calls, [
+    'mkdtemp:/downloads/.hermes-download-',
+    'unlink:/downloads/.hermes-download-test/payload',
+    'rm:/downloads/.hermes-download-test'
+  ])
+})
+
+test('pumpStreamToFileAtomically replaces an existing destination on Windows-style EEXIST', async () => {
+  const res = new FakeResponse()
+  const ws = new FakeWriteStream()
+  const { calls, deps } = atomicDeps(ws, { renameError: 'EEXIST' })
+  let renameAttempts = 0
+  const countingRename = deps.rename
+
+  deps.rename = async (from: string, to: string) => {
+    renameAttempts += 1
+
+    // Only the first rename fails; the post-unlink retry succeeds.
+    if (renameAttempts > 1) {
+      calls.push(`rename:${from}->${to}`)
+
+      return
+    }
+
+    await countingRename(from, to)
+  }
+
+  const promise = pumpStreamToFileAtomically(res as never, '/downloads/existing.pdf', deps as never)
+
+  // The async mkdtemp preamble must settle before listeners are attached.
+  await new Promise(resolve => setImmediate(resolve))
+  res.emit('data', Buffer.from('complete'))
+  res.emit('end')
+  await promise
+
+  assert.deepEqual(calls, [
+    'mkdtemp:/downloads/.hermes-download-',
+    'rename:/downloads/.hermes-download-test/payload->/downloads/existing.pdf',
+    'unlink:/downloads/existing.pdf',
+    'rename:/downloads/.hermes-download-test/payload->/downloads/existing.pdf',
+    'rm:/downloads/.hermes-download-test'
+  ])
 })

--- a/apps/desktop/electron/gateway-file-download.ts
+++ b/apps/desktop/electron/gateway-file-download.ts
@@ -30,6 +30,35 @@ export interface WriteStreamLike {
   once(event: 'drain', listener: () => void): unknown
 }
 
+// Upper bound for a gateway download body. The managed /api/files routes cap
+// server-side, but saveGatewayFile also talks to the broad /api/fs/download
+// route, and a client must not trust a remote peer to stay bounded: enforce
+// the limit locally, both on the announced Content-Length (before the save
+// dialog opens) and on the actual streamed byte count.
+export const GATEWAY_DOWNLOAD_MAX_BYTES = 5 * 1024 ** 3
+
+// Thrown when a gateway response announces or streams more than
+// GATEWAY_DOWNLOAD_MAX_BYTES bytes. Distinct type so callers can tell an
+// over-limit rejection apart from transport/IO failures.
+export class GatewayDownloadTooLargeError extends Error {
+  constructor() {
+    super(`Gateway download exceeds the ${GATEWAY_DOWNLOAD_MAX_BYTES}-byte client limit`)
+    this.name = 'GatewayDownloadTooLargeError'
+  }
+}
+
+// Pre-flight check against the response headers, run before the save dialog
+// opens so an over-limit download fails fast instead of after the user picks a
+// destination. Absent/invalid Content-Length is NOT a pass to skip the stream
+// count — pumpStreamToFile still enforces the bound while bytes flow.
+export function contentLengthExceedsLimit(headers: Record<string, unknown>, maxBytes = GATEWAY_DOWNLOAD_MAX_BYTES): boolean {
+  const raw = headers['content-length'] ?? headers['Content-Length']
+  const value = Array.isArray(raw) ? raw[0] : raw
+  const length = Number(value)
+
+  return Number.isFinite(length) && length > maxBytes
+}
+
 export interface PumpDeps {
   createWriteStream: (destPath: string) => WriteStreamLike
   unlink: (destPath: string) => Promise<unknown>
@@ -38,11 +67,13 @@ export interface PumpDeps {
 // Stream `res` into `destPath`, honoring backpressure. On any read/write error
 // the write stream is torn down and the (partial) destination file is removed
 // before the returned promise rejects, so a failed download never leaves a
-// truncated file behind.
-export function pumpStreamToFile(res: ReadableLike, destPath: string, deps: PumpDeps): Promise<void> {
+// truncated file behind. When maxBytes is given, the stream fails with
+// GatewayDownloadTooLargeError once more than maxBytes bytes arrive.
+export function pumpStreamToFile(res: ReadableLike, destPath: string, deps: PumpDeps, maxBytes?: number): Promise<void> {
   return new Promise((resolve, reject) => {
     const ws = deps.createWriteStream(destPath)
     let failed = false
+    let received = 0
 
     const fail = (err: Error) => {
       if (failed) {
@@ -77,6 +108,15 @@ export function pumpStreamToFile(res: ReadableLike, destPath: string, deps: Pump
       }
 
       const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk as Uint8Array)
+
+      received += buffer.length
+
+      if (maxBytes !== undefined && received > maxBytes) {
+        fail(new GatewayDownloadTooLargeError())
+
+        return
+      }
+
       const ok = ws.write(buffer)
 
       // Backpressure: pause the source until the file stream drains so we never
@@ -99,6 +139,53 @@ export function pumpStreamToFile(res: ReadableLike, destPath: string, deps: Pump
       ws.end(() => resolve())
     })
   })
+}
+
+export interface AtomicPumpDeps extends PumpDeps {
+  mkdtemp: (prefix: string) => Promise<string>
+  rename: (oldPath: string, newPath: string) => Promise<unknown>
+  rm: (target: string, options: { force: boolean; recursive: boolean }) => Promise<unknown>
+}
+
+// Atomic variant of pumpStreamToFile: the body lands in a temp file inside the
+// destination directory and is renamed onto `destPath` only after the stream
+// completed in full. A failed download therefore leaves a pre-existing
+// destination byte-identical — writing directly into the final pathname and
+// unlinking it by name on error both corrupts the original mid-transfer and
+// races a concurrent replacement at the same path.
+//
+// POSIX rename(2) replaces an existing destination atomically. Windows refuses
+// to rename over an existing file, so there the destination is unlinked first
+// and then renamed into place: still never a partial file at the final path,
+// only a small no-file window after the user explicitly confirmed replacement.
+export async function pumpStreamToFileAtomically(
+  res: ReadableLike,
+  destPath: string,
+  deps: AtomicPumpDeps,
+  maxBytes?: number
+): Promise<void> {
+  const tempDir = await deps.mkdtemp(path.join(path.dirname(destPath), '.hermes-download-'))
+  const tempPath = path.join(tempDir, 'payload')
+
+  try {
+    await pumpStreamToFile(res, tempPath, deps, maxBytes)
+
+    try {
+      await deps.rename(tempPath, destPath)
+    } catch (error) {
+      const code = (error as NodeJS.ErrnoException).code
+
+      if (code !== 'EEXIST' && code !== 'EPERM' && code !== 'ENOTEMPTY') {
+        throw error
+      }
+
+      // Windows fallback documented above: replace after confirmed success.
+      await deps.unlink(destPath)
+      await deps.rename(tempPath, destPath)
+    }
+  } finally {
+    await deps.rm(tempDir, { force: true, recursive: true }).catch(() => undefined)
+  }
 }
 
 // Decode a `data:[<mime>][;base64],<payload>` URL into a Buffer. Used by the

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -126,11 +126,14 @@ import {
 import { createFirstRunSetupGate } from './first-run-setup-gate'
 import { readDirForIpc } from './fs-read-dir'
 import {
+  contentLengthExceedsLimit,
   filenameFromContentDisposition,
+  GATEWAY_DOWNLOAD_MAX_BYTES,
+  GatewayDownloadTooLargeError,
   gatewayFilePath,
   isNotFoundError,
   parseDataUrlToBuffer,
-  pumpStreamToFile
+  pumpStreamToFileAtomically
 } from './gateway-file-download'
 import { probeGatewayWebSocket } from './gateway-ws-probe'
 import { scanGitRepos } from './git-repo-scan'
@@ -5207,7 +5210,7 @@ async function resourceBufferFromUrl(rawUrl) {
   })
 }
 
-async function saveImageFromUrl(rawUrl) {
+async function saveImageFromUrl(rawUrl, ctx: any = {}) {
   const { buffer, mimeType } = (await resourceBufferFromUrl(rawUrl)) as any
   const extension = extensionForMimeType(mimeType) || '.png'
   // Generated-image URLs (fal.media etc.) usually end in an extensionless
@@ -5225,7 +5228,7 @@ async function saveImageFromUrl(rawUrl) {
     // Downloads directory to offer.
   }
 
-  const result = await dialog.showSaveDialog(mainWindow, {
+  const result = await dialog.showSaveDialog(ctx.window ?? mainWindow, {
     title: 'Save Image',
     defaultPath: downloadsDir ? path.join(downloadsDir, fallbackName) : fallbackName,
     filters: [
@@ -6931,6 +6934,17 @@ function downloadViaOauthSessionToFile(url, ctx, options: any = {}) {
 // destination. On an HTTP error the status code is attached so saveGatewayFile
 // can trigger the 404-only compatibility fallback.
 async function finalizeGatewayDownload(res, statusCode, headers, ctx: any = {}) {
+  // Redirects cross the gateway boundary: neither transport follows them
+  // automatically, and a 3xx body (typically an interstitial login page) must
+  // never be saved as the requested file.
+  if (statusCode >= 300 && statusCode < 400) {
+    const location = headers.location || headers.Location || ''
+    const error: any = new Error(`Unexpected gateway redirect (${statusCode}${location ? ` → ${location}` : ''})`)
+    error.statusCode = statusCode
+    ctx.abort?.()
+    throw error
+  }
+
   if (statusCode >= 400) {
     const message = await readGatewayErrorText(res)
     const error: any = new Error(`${statusCode}: ${message}`)
@@ -6938,10 +6952,17 @@ async function finalizeGatewayDownload(res, statusCode, headers, ctx: any = {}) 
     throw error
   }
 
+  // Fail fast on an announced over-limit body, before the user picks a
+  // destination. The streamed byte count is still enforced during the pump.
+  if (contentLengthExceedsLimit(headers, GATEWAY_DOWNLOAD_MAX_BYTES)) {
+    ctx.abort?.()
+    throw new GatewayDownloadTooLargeError()
+  }
+
   const disposition = headers['content-disposition'] || headers['Content-Disposition']
   const filename = filenameFromContentDisposition(disposition) || ctx.suggested || ctx.fallbackName
 
-  const result = await dialog.showSaveDialog(mainWindow, {
+  const result = await dialog.showSaveDialog(ctx.window ?? mainWindow, {
     defaultPath: filename,
     title: 'Save File'
   })
@@ -6953,10 +6974,18 @@ async function finalizeGatewayDownload(res, statusCode, headers, ctx: any = {}) 
   }
 
   try {
-    await pumpStreamToFile(res, result.filePath, {
-      createWriteStream: (destPath: string) => fs.createWriteStream(destPath),
-      unlink: (destPath: string) => fs.promises.unlink(destPath)
-    })
+    await pumpStreamToFileAtomically(
+      res,
+      result.filePath,
+      {
+        createWriteStream: (destPath: string) => fs.createWriteStream(destPath),
+        mkdtemp: (prefix: string) => fs.promises.mkdtemp(prefix),
+        rename: (oldPath: string, newPath: string) => fs.promises.rename(oldPath, newPath),
+        rm: (target: string, options: { force: boolean; recursive: boolean }) => fs.promises.rm(target, options),
+        unlink: (destPath: string) => fs.promises.unlink(destPath)
+      },
+      GATEWAY_DOWNLOAD_MAX_BYTES
+    )
   } catch (error) {
     ctx.abort?.()
     throw error
@@ -6986,7 +7015,7 @@ function readGatewayErrorText(res): Promise<string> {
   })
 }
 
-async function saveGatewayFile(payload: any = {}) {
+async function saveGatewayFile(payload: any = {}, ctx: any = {}) {
   const filePath = gatewayFilePath(payload.path)
 
   if (!filePath) {
@@ -6997,7 +7026,7 @@ async function saveGatewayFile(payload: any = {}) {
   const connection = await ensureBackend(profile)
   const suggested = String(payload.suggestedName || '').trim()
   const fallbackName = path.basename(filePath) || suggested || 'download'
-  const ctx = { suggested, fallbackName }
+  const downloadCtx = { ...ctx, suggested, fallbackName }
 
   const requestPath = pathWithGlobalRemoteProfile(`/api/fs/download?path=${encodeURIComponent(filePath)}`, profile, {
     globalRemote: globalRemoteActive(),
@@ -7008,14 +7037,14 @@ async function saveGatewayFile(payload: any = {}) {
 
   try {
     return await (connection.authMode === 'oauth'
-      ? downloadViaOauthSessionToFile(url, ctx)
-      : downloadViaTokenToFile(url, connection.token, ctx))
+      ? downloadViaOauthSessionToFile(url, downloadCtx)
+      : downloadViaTokenToFile(url, connection.token, downloadCtx))
   } catch (error) {
     // Desktop and the remote gateway update independently. A gateway predating
     // /api/fs/download 404s here; fall back (ONLY on 404) to the older capped
     // data-URL route so downloads keep working against older backends.
     if (isNotFoundError(error)) {
-      return await saveGatewayFileViaDataUrl(connection, profile, filePath, ctx)
+      return await saveGatewayFileViaDataUrl(connection, profile, filePath, downloadCtx)
     }
 
     throw error
@@ -7051,7 +7080,7 @@ async function saveGatewayFileViaDataUrl(connection, profile, filePath, ctx: any
   const buffer = parseDataUrlToBuffer(dataUrl)
   const filename = ctx.suggested || ctx.fallbackName
 
-  const result = await dialog.showSaveDialog(mainWindow, {
+  const result = await dialog.showSaveDialog(ctx.window ?? mainWindow, {
     defaultPath: filename,
     title: 'Save File'
   })
@@ -12621,8 +12650,8 @@ ipcMain.handle('hermes:writeClipboard', (_event, text) => {
 
 // Native save-location picker (profile export etc.) — the write itself happens
 // elsewhere (the backend, for profile archives); this only picks the path.
-ipcMain.handle('hermes:selectSavePath', async (_event, options: any = {}) => {
-  const result = await dialog.showSaveDialog(mainWindow, {
+ipcMain.handle('hermes:selectSavePath', async (event, options: any = {}) => {
+  const result = await dialog.showSaveDialog(BrowserWindow.fromWebContents(event.sender) ?? mainWindow, {
     title: options?.title || 'Save',
     defaultPath: options?.defaultPath ? String(options.defaultPath) : undefined,
     filters: Array.isArray(options?.filters) ? options.filters : undefined
@@ -12641,9 +12670,16 @@ ipcMain.handle('hermes:selectSavePath', async (_event, options: any = {}) => {
 // canvas. The main process has no such gate.
 ipcMain.handle('hermes:readClipboard', () => clipboard.readText())
 
-ipcMain.handle('hermes:saveGatewayFile', (_event, payload) => saveGatewayFile(payload))
+// The save dialog must be modal to the window the download was triggered
+// from — binding to the global mainWindow strands the prompt behind secondary
+// session windows and leaks the interaction across windows.
+ipcMain.handle('hermes:saveGatewayFile', (event, payload) =>
+  saveGatewayFile(payload, { window: BrowserWindow.fromWebContents(event.sender) ?? mainWindow })
+)
 
-ipcMain.handle('hermes:saveImageFromUrl', (_event, url) => saveImageFromUrl(String(url || '')))
+ipcMain.handle('hermes:saveImageFromUrl', (event, url) =>
+  saveImageFromUrl(String(url || ''), { window: BrowserWindow.fromWebContents(event.sender) ?? mainWindow })
+)
 
 ipcMain.handle('hermes:saveImageBuffer', async (_event, payload) => {
   const data = payload?.data

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -1106,7 +1106,8 @@ function registerMediaProtocol() {
         bypassCustomProtocolHandlers: true,
         credentials: 'omit',
         headers,
-        method
+        method,
+        redirect: 'error'
       }),
     fetchRemoteWithCookies: (url, headers, method) => {
       const oauthSession = getOauthSession()
@@ -1119,7 +1120,8 @@ function registerMediaProtocol() {
         bypassCustomProtocolHandlers: true,
         credentials: 'include',
         headers,
-        method
+        method,
+        redirect: 'error'
       })
     },
     resolveLocalFile: async filePath => {

--- a/apps/desktop/electron/media-protocol.test.ts
+++ b/apps/desktop/electron/media-protocol.test.ts
@@ -151,6 +151,45 @@ describe('createMediaProtocolHandler', () => {
     expect(deps.fetchRemote).not.toHaveBeenCalled()
   })
 
+  it('refuses to follow a redirect from the token-auth gateway instead of proxying it', async () => {
+    // The fetch wrappers are wired with redirect: 'error'; a 3xx that still
+    // reaches the handler must surface as unavailable — never as bytes the
+    // renderer trusts under the hermes-media: scheme.
+    const deps = dependencies({
+      fetchRemote: vi.fn(async () =>
+        new Response('<html>login</html>', {
+          headers: { location: 'https://attacker.test/interstitial' },
+          status: 302
+        })
+      )
+    })
+
+    const response = await createMediaProtocolHandler(deps)(request('hermes-media://remote/%2Ftmp%2Fclip.mp4'))
+
+    expect(response.status).toBe(502)
+    expect(await response.text()).not.toContain('login')
+  })
+
+  it('refuses to follow a redirect from the OAuth native-bearer gateway', async () => {
+    const deps = dependencies({
+      ensureRemoteBearer: vi.fn(async () => 'native-access-token'),
+      fetchRemote: vi.fn(async () =>
+        new Response(null, { headers: { location: 'https://attacker.test/clip.mp4' }, status: 307 })
+      ),
+      resolveRemoteConnection: vi.fn(async () => ({
+        authMode: 'oauth' as const,
+        baseUrl: 'https://gateway.test',
+        mode: 'remote' as const,
+        token: null
+      }))
+    })
+
+    const response = await createMediaProtocolHandler(deps)(request('hermes-media://remote/%2Ftmp%2Fclip.mp4'))
+
+    expect(response.status).toBe(502)
+    expect(deps.fetchRemoteWithCookies).not.toHaveBeenCalled()
+  })
+
   it('uses a refreshed native bearer for OAuth remote media when available', async () => {
     const deps = dependencies({
       ensureRemoteBearer: vi.fn(async () => 'native-access-token'),

--- a/apps/desktop/electron/media-protocol.ts
+++ b/apps/desktop/electron/media-protocol.ts
@@ -94,6 +94,21 @@ export function remoteMediaEndpoint(baseUrl: string, filePath: string): string {
   return url.toString()
 }
 
+// The gateway must answer media requests directly. A 3xx here would hand the
+// renderer attacker-chosen content under the trusted hermes-media: scheme (and
+// the fetch wrappers in main.ts already refuse to follow with redirect:
+// 'error', so a visible 3xx only appears if that wiring changes). Treat every
+// redirect as unavailable instead of following it across the gateway boundary.
+function rejectMediaRedirect(response: Response): Response {
+  if (response.status >= 300 && response.status < 400) {
+    response.body?.cancel().catch(() => undefined)
+
+    return new Response('Remote media unavailable', { status: 502 })
+  }
+
+  return response
+}
+
 export function createMediaProtocolHandler(dependencies: MediaProtocolDependencies) {
   return async (request: Pick<Request, 'headers' | 'method' | 'url'>): Promise<Response> => {
     if (request.method !== 'GET' && request.method !== 'HEAD') {
@@ -147,10 +162,10 @@ export function createMediaProtocolHandler(dependencies: MediaProtocolDependenci
         if (bearer) {
           headers.set('authorization', `Bearer ${bearer}`)
 
-          return await dependencies.fetchRemote(endpoint, headers, method)
+          return rejectMediaRedirect(await dependencies.fetchRemote(endpoint, headers, method))
         }
 
-        return await dependencies.fetchRemoteWithCookies(endpoint, headers, method)
+        return rejectMediaRedirect(await dependencies.fetchRemoteWithCookies(endpoint, headers, method))
       }
 
       if (!connection.token) {
@@ -159,7 +174,7 @@ export function createMediaProtocolHandler(dependencies: MediaProtocolDependenci
 
       headers.set('x-hermes-session-token', connection.token)
 
-      return await dependencies.fetchRemote(endpoint, headers, method)
+      return rejectMediaRedirect(await dependencies.fetchRemote(endpoint, headers, method))
     } catch {
       return new Response('Remote media unavailable', { status: 502 })
     }

--- a/apps/desktop/src/components/chat/generated-image-result.test.tsx
+++ b/apps/desktop/src/components/chat/generated-image-result.test.tsx
@@ -1,0 +1,90 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { GeneratedImage } from './generated-image-result'
+
+const { generatedImageFromResult, gatewayMediaDataUrl, isRemoteGateway, mediaExternalUrl, openExternal, saveGatewayFile } =
+  vi.hoisted(() => ({
+    gatewayMediaDataUrl: vi.fn(),
+    generatedImageFromResult: vi.fn(),
+    isRemoteGateway: vi.fn(),
+    mediaExternalUrl: vi.fn(),
+    openExternal: vi.fn(),
+    saveGatewayFile: vi.fn()
+  }))
+
+vi.mock('@/i18n', () => ({
+  useI18n: () => ({
+    t: {
+      assistant: { tool: { renderingImage: 'Rendering image…' } },
+      desktop: { imageDownloadFailed: 'Image download failed', openImage: 'Open image' }
+    }
+  })
+}))
+
+vi.mock('@/lib/generated-images', () => ({ generatedImageFromResult }))
+
+vi.mock('@/lib/media', () => ({
+  filePathFromMediaPath: (path: string) => path,
+  gatewayMediaDataUrl,
+  isRemoteGateway,
+  mediaExternalUrl,
+  mediaName: (path: string) => path.split('/').pop() || path
+}))
+
+vi.mock('@/hooks/use-image-download', () => ({
+  useImageDownload: () => ({ download: vi.fn(), saving: false })
+}))
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  generatedImageFromResult.mockReturnValue('/outputs/render.png')
+  // The inline load failing is what renders the "Open image" fallback link.
+  gatewayMediaDataUrl.mockRejectedValue(new Error('gone'))
+  ;(window as any).hermesDesktop = { openExternal, saveGatewayFile }
+})
+
+describe('GeneratedImage remote open fallback', () => {
+  it('saves through the authenticated bridge instead of exposing a ?token= URL externally', async () => {
+    isRemoteGateway.mockReturnValue(true)
+    saveGatewayFile.mockResolvedValue({ path: '/home/me/Downloads/render.png', saved: true })
+
+    render(<GeneratedImage result={{}} />)
+
+    const link = await screen.findByText('Open image: render.png')
+
+    fireEvent.click(link)
+
+    await waitFor(() => {
+      expect(saveGatewayFile).toHaveBeenCalledWith({ path: '/outputs/render.png', suggestedName: 'render.png' })
+    })
+    expect(openExternal).not.toHaveBeenCalled()
+    // The token-carrying external URL must never even be constructed here.
+    expect(mediaExternalUrl).not.toHaveBeenCalled()
+  })
+
+  it('surfaces a failure notice when the bridged save rejects', async () => {
+    isRemoteGateway.mockReturnValue(true)
+    saveGatewayFile.mockRejectedValue(new Error('gateway offline'))
+
+    render(<GeneratedImage result={{}} />)
+
+    fireEvent.click(await screen.findByText('Open image: render.png'))
+
+    expect(await screen.findByText('Image download failed')).toBeTruthy()
+  })
+
+  it('keeps the external open for local connections', async () => {
+    isRemoteGateway.mockReturnValue(false)
+    mediaExternalUrl.mockReturnValue('file:///outputs/render.png')
+    // Force the inline load to fail so the fallback link renders.
+    ;(window as any).hermesDesktop.readFileDataUrl = vi.fn().mockRejectedValue(new Error('gone'))
+
+    render(<GeneratedImage result={{}} />)
+
+    fireEvent.click(await screen.findByText('Open image: render.png'))
+
+    expect(openExternal).toHaveBeenCalledWith('file:///outputs/render.png')
+    expect(saveGatewayFile).not.toHaveBeenCalled()
+  })
+})

--- a/apps/desktop/src/components/chat/generated-image-result.tsx
+++ b/apps/desktop/src/components/chat/generated-image-result.tsx
@@ -59,6 +59,7 @@ export const GeneratedImage: FC<{ aspectRatio?: string; result?: unknown }> = ({
   const [loaded, setLoaded] = useState(false)
   const [canvasGone, setCanvasGone] = useState(false)
   const [failed, setFailed] = useState(false)
+  const [openFailed, setOpenFailed] = useState(false)
   const [lightboxOpen, setLightboxOpen] = useState(false)
   const { download, saving } = useImageDownload(src)
 
@@ -70,6 +71,7 @@ export const GeneratedImage: FC<{ aspectRatio?: string; result?: unknown }> = ({
   useEffect(() => {
     let cancelled = false
     setFailed(false)
+    setOpenFailed(false)
     setLoaded(false)
     setCanvasGone(false)
     setSrc(image && isInlineSrc(image) ? image : '')
@@ -95,16 +97,36 @@ export const GeneratedImage: FC<{ aspectRatio?: string; result?: unknown }> = ({
 
   if (failed && image) {
     return (
-      <a
-        className="mt-2 ref inline-block wrap-anywhere"
-        href="#"
-        onClick={event => {
-          event.preventDefault()
-          void window.hermesDesktop?.openExternal(mediaExternalUrl(image))
-        }}
-      >
-        {copy.openImage}: {mediaName(image)}
-      </a>
+      <span className="block">
+        <a
+          className="mt-2 ref inline-block wrap-anywhere"
+          href="#"
+          onClick={event => {
+            event.preventDefault()
+            setOpenFailed(false)
+
+            // Remote gateway: mediaExternalUrl would carry the session token
+            // in a ?token= query into the external browser's history and OS
+            // logs. Save through the authenticated native bridge instead;
+            // only inline/local sources keep the external open.
+            if (isRemoteGateway() && !isInlineSrc(image) && window.hermesDesktop?.saveGatewayFile) {
+              void window.hermesDesktop
+                .saveGatewayFile({ path: filePathFromMediaPath(image), suggestedName: mediaName(image) })
+                .then(result => {
+                  if (!result.saved && !result.canceled) {
+                    setOpenFailed(true)
+                  }
+                })
+                .catch(() => setOpenFailed(true))
+            } else {
+              void window.hermesDesktop?.openExternal(mediaExternalUrl(image))
+            }
+          }}
+        >
+          {copy.openImage}: {mediaName(image)}
+        </a>
+        {openFailed && <span className="mt-1 block text-xs text-muted-foreground">{copy.imageDownloadFailed}</span>}
+      </span>
     )
   }
 


### PR DESCRIPTION
## Summary

Follow-up to the review criteria from [#63808 (comment)](https://github.com/NousResearch/hermes-agent/pull/63808#issuecomment-3189702417): with the playback design now landed via #86836 and the generic save half via #86744, this PR applies the hardening criteria discussed there — redirect validation, bounded body after headers, atomic no-overwrite finalization, sender-bound dialogs — to the merged implementation, plus one renderer-side credential fix carried over from the same comparison. It builds on the merged design; nothing here re-opens it.

## What changed

**1. Redirects refused at every gateway boundary**
- The `hermes-media` remote proxy fetch wrappers (native bearer and OAuth cookie session) now pass `redirect: 'error'`; previously a 3xx was followed transparently, which could drag main-process credentials across an origin boundary or hand the renderer attacker-chosen bytes under the trusted `hermes-media:` scheme.
- Defense in depth: the protocol handler treats any 3xx that still reaches it as unavailable (502) and cancels the body, so a wiring regression can't resurrect the silent follow.
- The download tail (`finalizeGatewayDownload`) likewise rejects 3xx — neither transport follows them, so an auth-interstitial body must never be saved as the requested file.

**2. Atomic finalization instead of write-in-place + unlink-by-name**
- Download bodies now stream to a temp file in the destination directory and are renamed onto the final path only after completing in full. A failed transfer leaves a pre-existing destination byte-identical (POSIX-atomic replace; on Windows the confirmed-complete temp replaces the destination after unlink — never a partial file at the final path).

**3. Bounded body after headers**
- `GATEWAY_DOWNLOAD_MAX_BYTES` (5 GiB, internal constant — no new env var) is enforced on the announced `Content-Length` before the save dialog opens, and on the actual streamed byte count during the pump. A distinct `GatewayDownloadTooLargeError` keeps over-limit rejections distinguishable from transport failures.

**4. Save dialogs bound to the IPC sender window**
- Gateway file saves (both transports + data-url fallback), image-from-url saves, and the save-path picker now resolve their modal parent via `BrowserWindow.fromWebContents(event.sender)` with the global `mainWindow` as fallback, instead of always binding globally.

**5. Renderer token-leak fix (carried over from the #63808 comparison)**
- The generated-image "Open image" fallback for remote gateways opened `mediaExternalUrl()`, which embeds `?token=<session-token>` and would leak it into the external browser's history and OS logs. It now saves through the authenticated native bridge (`hermes:saveGatewayFile`), keeping tokens out of renderer-visible URLs; local/inline sources keep the external open. Failure surfaces the existing `imageDownloadFailed` copy.

## Tests

New behavior-contract coverage:
- `media-protocol.test.ts`: 3xx from token-auth and OAuth-bearer gateways is refused (502), never proxied.
- `gateway-file-download.test.ts`: byte cap enforced mid-stream; atomic pump publishes only complete files, leaves pre-existing destinations untouched on failure, handles Windows-style `EEXIST` replace, always cleans the temp dir.
- `gateway-file-download-transport.test.ts`: source-shape wiring assertions updated (atomic pump, redirect guard, sender-bound dialog, bounded body).
- `generated-image-result.test.tsx` (new): remote fallback uses the bridge and never constructs the token URL; failure notice; local connections keep external open.

Verification on this branch:
- `test:desktop:platforms` (`vitest run --project electron`): **1206 passed** (95 files)
- `test:ui`: **4307 passed** (466 files)
- `typecheck` (all three tsconfigs): clean
- `lint`: 0 errors (107 pre-existing warnings, none in touched files)

Not done this round: a packaged Wayland E2E — the changes are scoped hardening on freshly merged code and the repo's CI covers the packaged path; happy to supply packaged evidence if reviewers want it.

## Credit & links

- Review criteria and comparison thread: #63808
- Save path this hardens: #86744 (salvage of #63808, @PaulBlackSwan)
- Playback path this hardens: #86836 (salvage of #83347, @0xWhiteMage)

Prepared by @ruben2000de's agent (Metis) under his review, continuing the comparison work from the thread above.
