### PR TITLE
fix(discord): keep full model IDs in Discord picker labels

### DIFF
--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -8838,7 +8838,14 @@ def _define_discord_view_classes() -> None:
             models = provider.get("models", [])
             options = []
             for model_id in models[:25]:
-                short = model_id.split("/")[-1] if "/" in model_id else model_id
+                # Label with the FULL model ID, not the stripped short name.
+                # Custom aggregator endpoints (e.g. a local CI proxy) serve
+                # models from many upstream providers; several upstreams can
+                # use the same bare name (deepseek-v4-pro vs nim/deepseek-v4-pro).
+                # Stripping the namespace made those duplicates indistinguishable
+                # in the picker. The value already carries the full ID, so only
+                # the visible label changes — selection is unaffected.
+                short = model_id
                 options.append(
                     discord.SelectOption(
                         label=_truncate_discord_component_text(

--- a/tests/gateway/test_discord_model_picker.py
+++ b/tests/gateway/test_discord_model_picker.py
@@ -83,3 +83,47 @@ async def test_model_picker_clears_controls_before_running_switch_callback():
     interaction.edit_original_response.assert_awaited_once()
 
 
+@pytest.mark.asyncio
+async def test_model_picker_labels_keep_full_model_id_namespace():
+    """Aggregator providers can serve the same bare name from multiple
+    upstreams (deepseek-v4-pro vs nim/deepseek-v4-pro). The dropdown must
+    label each option with its FULL model ID so those duplicates stay
+    distinguishable instead of collapsing to the stripped short name.
+    """
+    view = ModelPickerView(
+        providers=[
+            {
+                "slug": "cliproxy",
+                "name": "cliproxy",
+                "models": [
+                    "deepseek-v4-pro",
+                    "nim/deepseek-v4-pro",
+                    "claude-sonnet-5",
+                ],
+                "total_models": 3,
+                "is_current": True,
+            }
+        ],
+        current_model="deepseek-v4-pro",
+        current_provider="cliproxy",
+        session_key="session-1",
+        on_model_selected=AsyncMock(),
+        allowed_user_ids={"123"},
+    )
+
+    view._build_model_select("cliproxy")
+
+    model_select = next(
+        c for c in view.children if getattr(c, "custom_id", "") == "model_model_select"
+    )
+    labels = [o.label for o in model_select.options]
+    assert labels == ["deepseek-v4-pro", "nim/deepseek-v4-pro", "claude-sonnet-5"]
+    # The namespaced entry must NOT have been stripped to the bare name.
+    assert labels.count("deepseek-v4-pro") == 1
+    assert "nim/deepseek-v4-pro" in labels
+    # Values carry the full ID so selection still routes correctly.
+    values = [o.value for o in model_select.options]
+    assert values == ["deepseek-v4-pro", "nim/deepseek-v4-pro", "claude-sonnet-5"]
+
+
+


### PR DESCRIPTION
## What does this PR do?

Fixes a display bug in the Discord `/model` picker. For custom/aggregator endpoints (e.g. a local proxy) that serve models from multiple upstream providers, several upstreams can expose the **same bare model name** (`deepseek-v4-pro` vs `nim/deepseek-v4-pro`). The model dropdown stripped the provider namespace with `split('/')[-1]`, so those distinct entries collapsed into identical, indistinguishable options — the user can't tell which provider a model belongs to.

This change labels each dropdown option with its **full model ID** so namespaced entries stay distinct. The option `value` already carried the full ID, so model-selection routing is unaffected — this is display-only.

## Related Issue

No existing issue filed; reported directly in a user session.

Fixes # (none)

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/platforms/discord/adapter.py` — `ModelPickerView._build_model_select`: label options with the full model ID instead of the `split('/')[-1]` short name.
- `tests/gateway/test_discord_model_picker.py` — adds a regression test asserting namespaced model IDs (`nim/deepseek-v4-pro`) are not stripped to collide with the bare ID.

## How to Test

1. Configure a custom provider whose `/v1/models` returns both a bare and a namespaced model (e.g. `deepseek-v4-pro` and `nim/deepseek-v4-pro`).
2. In Discord, open `/model`, pick that provider.
3. Confirm the dropdown shows both `deepseek-v4-pro` and `nim/deepseek-v4-pro` as distinct options.
4. Run `pytest tests/gateway/test_discord_model_picker.py -q` — both tests pass.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, ...)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/gateway/test_discord_model_picker.py -q` and all tests pass (2 passed)
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 27.0

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A (docstring added in code)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — N/A (display-only change in the Discord adapter; no platform-specific code)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

N/A — verified via unit test (`2 passed` on the picker test file) and the fix is live on the author's gateway.
