### PR TITLE
fix(updater): stop Windows update retries from looping forever on a deferred install (#86780)

### DIFF
--- a/hermes_cli/_early_recovery.py
+++ b/hermes_cli/_early_recovery.py
@@ -56,6 +56,19 @@ LAZY_REFRESH_REPAIR_PACKAGES: dict[str, str] = {
     "jwt": "PyJWT",
 }
 
+# Set only when this process successfully finishes a deferred core install for
+# an ``update`` invocation.  The normal CLI import that follows must not resolve
+# external secret sources: a configured source can map cryptography._rust and
+# immediately recreate the self-lock marker this fresh process just consumed.
+# Process-local state is intentional so child processes do not inherit the
+# bootstrap exception.
+_UPDATE_RETRY_RECOVERED = False
+
+
+def _should_skip_external_secret_sources() -> bool:
+    """Whether this updater already completed its deferred native install."""
+    return _UPDATE_RETRY_RECOVERED
+
 
 def _project_root() -> Path:
     return Path(__file__).resolve().parent.parent
@@ -352,6 +365,8 @@ def recover_if_needed(
     Never raises: on any failure the import of main.py proceeds and surfaces
     the real error.
     """
+    global _UPDATE_RETRY_RECOVERED
+
     try:
         args = sys.argv[1:] if argv is None else argv
         root = _project_root() if project_root is None else project_root
@@ -384,7 +399,9 @@ def recover_if_needed(
         if core_marker.exists():
             if _marker_owner_is_live(core_marker):
                 return
-            _complete_pending_core_install(root, core_marker)
+            completed = _complete_pending_core_install(root, core_marker)
+            if completed and "update" in args:
+                _UPDATE_RETRY_RECOVERED = True
             return
 
         # Keep the historical update-argv exclusion for the lazy-refresh
@@ -482,7 +499,7 @@ def _release_recovery_lock(root: Path) -> None:
         pass
 
 
-def _complete_pending_core_install(root: Path, core_marker: Path) -> None:
+def _complete_pending_core_install(root: Path, core_marker: Path) -> bool:
     """Run the pending core install BEFORE main.py can import native modules.
 
     ``recover_if_needed`` invokes this when ``.update-incomplete`` exists —
@@ -498,7 +515,8 @@ def _complete_pending_core_install(root: Path, core_marker: Path) -> None:
     attempts ceiling caps automatic retries so a persistent installer
     failure does not block every launch (``hermes acp`` included).
 
-    Never raises: any failure leaves the marker for the post-import path.
+    Never raises: any failure leaves the marker for the post-import path and
+    returns ``False``.  Returns ``True`` only after the install succeeds.
     """
     try:
         from hermes_cli import _install_repair as ir
@@ -526,10 +544,10 @@ def _complete_pending_core_install(root: Path, core_marker: Path) -> None:
                 "post-import recovery path.",
                 file=sys.stderr,
             )
-            return
+            return False
 
         if not _claim_recovery_lock(root):
-            return
+            return False
 
         try:
             print(
@@ -551,7 +569,7 @@ def _complete_pending_core_install(root: Path, core_marker: Path) -> None:
                 "the current venv in the meantime.",
                 file=sys.stderr,
             )
-            return
+            return False
         finally:
             _release_recovery_lock(root)
 
@@ -563,6 +581,7 @@ def _complete_pending_core_install(root: Path, core_marker: Path) -> None:
             "  ✓ Dependency installation completed in the early pass.",
             file=sys.stderr,
         )
+        return True
     except Exception:
         # Never block launch — the marker stays for the post-import path.
-        pass
+        return False

--- a/hermes_cli/_early_recovery.py
+++ b/hermes_cli/_early_recovery.py
@@ -61,6 +61,67 @@ def _project_root() -> Path:
     return Path(__file__).resolve().parent.parent
 
 
+def _pid_is_running(pid: int) -> bool:
+    """Best-effort stdlib-only process liveness probe.
+
+    ``os.kill(pid, 0)`` is not a no-op on Windows, so use the Win32 process
+    handle API there.  An access-denied result is conservatively live: racing
+    an elevated updater is worse than postponing recovery for one launch.
+    """
+    if pid <= 0:
+        return False
+    if sys.platform == "win32":
+        try:
+            import ctypes
+
+            synchronize = 0x00100000
+            kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+            kernel32.OpenProcess.argtypes = [
+                ctypes.c_ulong,
+                ctypes.c_int,
+                ctypes.c_ulong,
+            ]
+            kernel32.OpenProcess.restype = ctypes.c_void_p
+            kernel32.WaitForSingleObject.argtypes = [ctypes.c_void_p, ctypes.c_ulong]
+            kernel32.WaitForSingleObject.restype = ctypes.c_ulong
+            kernel32.CloseHandle.argtypes = [ctypes.c_void_p]
+            kernel32.CloseHandle.restype = ctypes.c_int
+            handle = kernel32.OpenProcess(synchronize, False, pid)
+            if not handle:
+                return ctypes.get_last_error() == 5  # ERROR_ACCESS_DENIED
+            try:
+                return kernel32.WaitForSingleObject(handle, 0) == 258
+            finally:
+                kernel32.CloseHandle(handle)
+        except Exception:
+            return True
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    except OSError:
+        return False
+    return True
+
+
+def _marker_owner_is_live(marker: Path) -> bool:
+    """True when a legacy update marker names a process still running."""
+    try:
+        body = marker.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return False
+    for line in body.splitlines():
+        key, separator, value = line.partition("=")
+        if separator and key.strip() == "pid":
+            try:
+                return _pid_is_running(int(value.strip()))
+            except ValueError:
+                return False
+    return False
+
+
 def _pinned_specs(packages: list[str], project_root: Path) -> list[str]:
     """Map bare package names to their pinned specs from pyproject.toml.
 
@@ -293,10 +354,6 @@ def recover_if_needed(
     """
     try:
         args = sys.argv[1:] if argv is None else argv
-        # Same deliberately-loose match as main(): the real update flow writes
-        # and clears its own markers — a recovery install must not race it.
-        if "update" in args:
-            return
         root = _project_root() if project_root is None else project_root
         if _pytest_owns_live_checkout(root):
             return
@@ -319,8 +376,21 @@ def recover_if_needed(
         # every launch, so attempts past the ceiling are left for main.py's
         # post-import recovery path (which can safely probe-import after this
         # process already holds whatever extensions it needs).
+        # A live marker owner means another updater is currently inside the
+        # marker-to-install window.  Never race it.  A dead owner means this is
+        # a prior deferral/interruption and MUST be recovered even when this
+        # launch is itself `hermes update`: CLI and Desktop retries preserve
+        # that argv, and skipping solely on argv recreates the self-lock loop.
         if core_marker.exists():
+            if _marker_owner_is_live(core_marker):
+                return
             _complete_pending_core_install(root, core_marker)
+            return
+
+        # Keep the historical update-argv exclusion for the lazy-refresh
+        # marker.  Unlike the core marker it is not a deferred native install,
+        # and the active update flow owns its probe/repair lifecycle.
+        if "update" in args:
             return
 
         broken = _probe_broken_packages()

--- a/hermes_cli/_early_recovery.py
+++ b/hermes_cli/_early_recovery.py
@@ -109,7 +109,7 @@ def _pid_is_running(pid: int) -> bool:
         except Exception:
             return True
     try:
-        os.kill(pid, 0)
+        os.kill(pid, 0)  # windows-footgun: ok — Windows returns above
     except ProcessLookupError:
         return False
     except PermissionError:

--- a/hermes_cli/env_loader.py
+++ b/hermes_cli/env_loader.py
@@ -517,7 +517,15 @@ def load_hermes_dotenv(
         _load_dotenv_with_fallback(project_env_path, override=not loaded)
         loaded.append(project_env_path)
 
-    _apply_external_secret_sources(home_path)
+    # A fresh ``hermes update`` retry may have completed a deferred dependency
+    # install before importing this module.  Do not remap native secret-source
+    # dependencies in that same updater process or the self-lock preflight will
+    # recreate the marker and exit 2 again.  Dotenv and managed env still load;
+    # only external source resolution is unnecessary for the updater.
+    from hermes_cli import _early_recovery
+
+    if not _early_recovery._should_skip_external_secret_sources():
+        _apply_external_secret_sources(home_path)
     _apply_managed_env()
 
     # config.yaml is the documented source of truth for terminal.* settings,

--- a/tests/hermes_cli/test_early_recovery.py
+++ b/tests/hermes_cli/test_early_recovery.py
@@ -142,6 +142,24 @@ def test_early_recovery_module_is_stdlib_only(tmp_path):
 # recover_if_needed unit behavior
 # ---------------------------------------------------------------------------
 
+
+def test_pid_liveness_recognizes_current_process():
+    assert er._pid_is_running(os.getpid()) is True
+    assert er._pid_is_running(0) is False
+
+
+def test_marker_owner_liveness_uses_recorded_pid(tmp_path, monkeypatch):
+    marker = tmp_path / ".update-incomplete"
+    marker.write_text("started=1\npid=4321\n", encoding="utf-8")
+    seen = []
+    monkeypatch.setattr(
+        er, "_pid_is_running", lambda pid: seen.append(pid) or True
+    )
+
+    assert er._marker_owner_is_live(marker) is True
+    assert seen == [4321]
+
+
 def _project(tmp_path: Path, *, pyproject: bool = True) -> Path:
     root = tmp_path / "proj"
     root.mkdir(exist_ok=True)
@@ -453,11 +471,38 @@ def test_lazy_marker_alone_does_not_trigger_core_install(tmp_path, monkeypatch):
     er.recover_if_needed(project_root=root, argv=[])
 
 
-def test_core_marker_skipped_when_user_is_running_update(tmp_path, monkeypatch):
-    """A launch of `hermes update` itself must not race its own markers."""
+def test_core_marker_from_dead_updater_is_recovered_on_update_retry(
+    tmp_path, monkeypatch
+):
+    """Retrying ``hermes update`` must consume a prior deferral marker.
+
+    The self-lock preflight exits after writing this marker.  Desktop and CLI
+    retries both keep ``update`` in argv, so an argv-only skip loops forever.
+    """
     root = _project(tmp_path)
     core_marker = root / ".update-incomplete"
-    core_marker.write_text('{"attempts": 0}', encoding="utf-8")
+    core_marker.write_text("started=1\npid=1234\n", encoding="utf-8")
+
+    from hermes_cli import _install_repair as ir
+
+    calls = []
+    monkeypatch.setattr(ir, "run_core_install", lambda project_root: calls.append(project_root))
+    monkeypatch.setattr(er, "_marker_owner_is_live", lambda _marker: False, raising=False)
+    import hermes_cli._install_repair  # noqa: F401
+
+    er.recover_if_needed(project_root=root, argv=["update"])
+
+    assert calls == [root]
+    assert not core_marker.exists()
+
+
+def test_core_marker_owned_by_live_updater_is_not_recovered(
+    tmp_path, monkeypatch
+):
+    """A second launch must not reinstall into an active updater's venv."""
+    root = _project(tmp_path)
+    core_marker = root / ".update-incomplete"
+    core_marker.write_text("started=1\npid=1234\n", encoding="utf-8")
 
     from hermes_cli import _install_repair as ir
 
@@ -465,12 +510,14 @@ def test_core_marker_skipped_when_user_is_running_update(tmp_path, monkeypatch):
         ir,
         "run_core_install",
         lambda _r: (_ for _ in ()).throw(
-            AssertionError("install must not run for `hermes update` argv")
+            AssertionError("must not race a live updater")
         ),
     )
+    monkeypatch.setattr(er, "_marker_owner_is_live", lambda _marker: True, raising=False)
     import hermes_cli._install_repair  # noqa: F401
 
-    er.recover_if_needed(project_root=root, argv=["update"])
+    er.recover_if_needed(project_root=root, argv=[])
+
     assert core_marker.exists()
 
 

--- a/tests/hermes_cli/test_early_recovery.py
+++ b/tests/hermes_cli/test_early_recovery.py
@@ -488,12 +488,14 @@ def test_core_marker_from_dead_updater_is_recovered_on_update_retry(
     calls = []
     monkeypatch.setattr(ir, "run_core_install", lambda project_root: calls.append(project_root))
     monkeypatch.setattr(er, "_marker_owner_is_live", lambda _marker: False, raising=False)
+    monkeypatch.setattr(er, "_UPDATE_RETRY_RECOVERED", False)
     import hermes_cli._install_repair  # noqa: F401
 
     er.recover_if_needed(project_root=root, argv=["update"])
 
     assert calls == [root]
     assert not core_marker.exists()
+    assert er._should_skip_external_secret_sources() is True
 
 
 def test_core_marker_owned_by_live_updater_is_not_recovered(

--- a/tests/hermes_cli/test_env_loader.py
+++ b/tests/hermes_cli/test_env_loader.py
@@ -6,6 +6,31 @@ import sys
 from hermes_cli.env_loader import load_hermes_dotenv
 
 
+def test_recovered_update_retry_skips_external_secret_sources(tmp_path, monkeypatch):
+    """The post-recovery updater must not remap native vault dependencies."""
+    import hermes_cli.env_loader as env_loader
+    from hermes_cli import _early_recovery
+
+    home = tmp_path / "hermes"
+    home.mkdir()
+    env_file = home / ".env"
+    env_file.write_text("UPDATE_RETRY_DOTENV=loaded\n", encoding="utf-8")
+    monkeypatch.delenv("UPDATE_RETRY_DOTENV", raising=False)
+    monkeypatch.setattr(_early_recovery, "_UPDATE_RETRY_RECOVERED", True)
+    external_calls = []
+    monkeypatch.setattr(
+        env_loader,
+        "_apply_external_secret_sources",
+        lambda path: external_calls.append(path),
+    )
+
+    loaded = load_hermes_dotenv(hermes_home=home)
+
+    assert loaded == [env_file]
+    assert os.environ["UPDATE_RETRY_DOTENV"] == "loaded"
+    assert external_calls == []
+
+
 def test_utf8_bom_does_not_mangle_first_key(tmp_path, monkeypatch):
     """A leading UTF-8 BOM must not prefix the first key name in os.environ.
 

--- a/tests/hermes_cli/test_update_self_lock.py
+++ b/tests/hermes_cli/test_update_self_lock.py
@@ -33,6 +33,7 @@ import pytest
 
 import hermes_cli.main as cli_main
 import hermes_cli.update_cmd as update_cmd
+from hermes_cli import _early_recovery
 
 ROOT = Path(__file__).resolve().parents[2]
 
@@ -158,6 +159,22 @@ def test_self_lock_detection_clean_when_rust_not_loaded(_winp):
             "cryptography (_rust.pyd)"
             not in cli_main._detect_self_loaded_native_modules()
         )
+
+
+def test_recovered_update_retry_builds_parser_without_native_secret_modules(
+    monkeypatch,
+):
+    """Parser registration must not re-lock a freshly recovered updater."""
+    called = []
+    monkeypatch.setattr(_early_recovery, "_UPDATE_RETRY_RECOVERED", True)
+    monkeypatch.setattr(cli_main, "cmd_update", lambda args: called.append(args))
+    monkeypatch.setattr(sys, "argv", ["hermes", "update", "--yes"])
+    sys.modules.pop("cryptography.hazmat.bindings._rust", None)
+
+    cli_main.main()
+
+    assert len(called) == 1
+    assert "cryptography.hazmat.bindings._rust" not in sys.modules
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Windows `hermes update` retries no longer loop forever on a deferred native dependency install: `_early_recovery.recover_if_needed()` now distinguishes a `.update-incomplete` marker owned by a live updater (stand down, never race) from one left by a dead updater (finish the deferred install before native modules load) — instead of skipping recovery on any `update` argv, which trapped every retry in the exit-2 / marker-rewrite cycle.

Salvages #86804 by @fangliquanflq (4 commits, authorship preserved). Closes #86780.

Root cause: the argv-only exclusion in `recover_if_needed()` could not tell an active update flow from a retry of one that already died. Both CLI and Desktop retries keep `update` in argv, so the deferred install never ran, secret-source imports mapped `cryptography._rust`, and the self-lock preflight exited 2 and rewrote the same marker every time.

## Changes

- `hermes_cli/_early_recovery.py`: marker-owner PID liveness (`_pid_is_running` — Win32 `OpenProcess`/`WaitForSingleObject` on Windows since `os.kill(pid, 0)` is not a no-op probe there; access-denied treated as live, fail-closed). Dead owner ⇒ complete the pending core install even on `update` argv; live owner ⇒ return. `_complete_pending_core_install` now reports success, recorded as process-local `_UPDATE_RETRY_RECOVERED`. Historical argv exclusion retained for the lazy-refresh marker.
- `hermes_cli/env_loader.py`: a recovered update retry skips external secret-source resolution (would remap the native crypto module and recreate the self-lock); dotenv + managed env still load.
- Conflict resolution vs main: `hermes_cli/main.py` is untouched — main's #86782 wave (5a76c8a97/230e5ff04/3f9150e5c) already made secrets-CLI registration crypto-free at parse time, superseding the PR's conditional-registration hunk. The test asserting a recovered retry builds the parser without loading `cryptography._rust` is kept.
- Tests: dead-owner recovery on update argv, live-owner fail-closed, PID liveness, secret-source suppression with dotenv retained.

## Validation

| | Result |
|---|---|
| `test_early_recovery.py` + `test_env_loader.py` + `test_update_self_lock.py` | 61 passed, 1 failed — `test_early_recovery_module_is_stdlib_only`, fails identically on origin/main in the same env (import-guard/venv quirk, pre-existing, unrelated) |
| Base gate vs origin/main | 0 behind, diff = 5 files, +205/−17 |

Contributor validated on Windows 11 (dead-owner marker consumed, update exits 0; live-PID marker left untouched) — 78/78 on their targeted run at head `96fdb66fd`.

## Infographic

![Windows update retry: break the exit-2 loop](https://files.catbox.moe/xiyci4.png)
