### PR TITLE
fix(feishu): resolve DM admission config per-profile under multiplex (#86905)

### DIFF
--- a/gateway/authz_mixin.py
+++ b/gateway/authz_mixin.py
@@ -33,11 +33,20 @@ def _auth_env(name: str, default: str = "") -> str:
     if not name:
         return default
     try:
-        from agent.secret_scope import get_secret
+        from agent.secret_scope import current_secret_scope, get_secret, is_multiplex_active
 
         val = get_secret(name)
         if val is not None and str(val).strip():
             return str(val).strip()
+        # Multiplex + a scope installed: the scope is authoritative — a
+        # scoped miss must NOT fall through to os.environ, which in a
+        # multiplexer may hold another profile's allowlist (leaking it here
+        # would skip the allow-all check below with a foreign allowlist and
+        # reject every sender on a secondary profile's bot — #86905). Mirror
+        # of _platform_gate_env (#72348). Single-profile deployments (no
+        # scope, or multiplex off) keep the legacy os.environ read.
+        if current_secret_scope() is not None and is_multiplex_active():
+            return default
     except Exception:
         pass
     return (os.getenv(name) or default).strip()

--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -153,9 +153,28 @@ def _get_scoped_secret(name, default=None):
     ``gateway/platforms/whatsapp_common.py::_get_wsecret``.
     """
     try:
+        from agent.secret_scope import (
+            current_secret_scope,
+            get_secret as _scoped_get_secret,
+            is_multiplex_active,
+        )
+
         val = _scoped_get_secret(name, default)
+        if val is not None:
+            return val
+        # get_secret returned None. Under multiplex WITH a scope installed the
+        # scope is authoritative: a miss is a miss — borrowing from os.environ
+        # would leak another profile's value (e.g. the default profile's
+        # allowlist into a secondary adapter, #86905). Only the unscoped
+        # default-profile path (UnscopedSecretError below, or multiplex off)
+        # falls back to the process environment.
+        if current_secret_scope() is not None and is_multiplex_active():
+            return default
     except _UnscopedSecretError:
-        val = os.getenv(name)
+        # Default-profile adapter constructing unscoped under multiplex:
+        # os.environ is this profile's own value.
+        pass
+    val = os.getenv(name)
     return val if val is not None else default
 
 

--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -436,6 +436,9 @@ class FeishuAdapterSettings:
     group_rules: Dict[str, FeishuGroupRule] = field(default_factory=dict)
     allow_bots: str = "none"  # "none" | "mentions" | "all"
     require_mention: bool = True
+    # DM allow-all (FEISHU_ALLOW_ALL_USERS / GATEWAY_ALLOW_ALL_USERS), resolved
+    # per-profile so multiplexed secondary adapters honor their own .env.
+    allow_all_dm: bool = False
 
 
 @dataclass
@@ -1591,13 +1594,25 @@ class FeishuAdapter(BasePlatformAdapter):
 
         # Env-only so adapter and gateway auth bypass share one source; yaml
         # feishu.allow_bots is bridged to this env var at config load.
-        allow_bots = os.getenv("FEISHU_ALLOW_BOTS", "none").strip().lower()
+        # Scope-aware read: in multiplex mode a secondary profile's .env must
+        # govern its own adapter (same pattern as app_secret below) — see #86905.
+        allow_bots = _get_scoped_secret("FEISHU_ALLOW_BOTS", "none").strip().lower()
         if allow_bots not in {"none", "mentions", "all"}:
             logger.warning(
                 "[Feishu] Unknown allow_bots=%r, falling back to 'none'. Valid: none, mentions, all.",
                 allow_bots,
             )
             allow_bots = "none"
+
+        # DM allow-all: also scope-aware (multiplex secondary profiles set
+        # GATEWAY_ALLOW_ALL_USERS / FEISHU_ALLOW_ALL_USERS in their own .env).
+        allow_all_dm = (
+            _get_scoped_secret("FEISHU_ALLOW_ALL_USERS", "").strip().lower()
+            in {"true", "1", "yes"}
+        ) or (
+            _get_scoped_secret("GATEWAY_ALLOW_ALL_USERS", "").strip().lower()
+            in {"true", "1", "yes"}
+        )
 
         return FeishuAdapterSettings(
             app_id=str(extra.get("app_id") or os.getenv("FEISHU_APP_ID", "")).strip(),
@@ -1610,10 +1625,10 @@ class FeishuAdapter(BasePlatformAdapter):
             verification_token=str(
                 extra.get("verification_token") or _get_scoped_secret("FEISHU_VERIFICATION_TOKEN", "")
             ).strip(),
-            group_policy=os.getenv("FEISHU_GROUP_POLICY", "allowlist").strip().lower(),
+            group_policy=_get_scoped_secret("FEISHU_GROUP_POLICY", "allowlist").strip().lower(),
             allowed_group_users=frozenset(
                 item.strip()
-                for item in os.getenv("FEISHU_ALLOWED_USERS", "").split(",")
+                for item in _get_scoped_secret("FEISHU_ALLOWED_USERS", "").split(",")
                 if item.strip()
             ),
             bot_open_id=os.getenv("FEISHU_BOT_OPEN_ID", "").strip(),
@@ -1658,6 +1673,7 @@ class FeishuAdapter(BasePlatformAdapter):
             default_group_policy=default_group_policy,
             group_rules=group_rules,
             allow_bots=allow_bots,
+            allow_all_dm=allow_all_dm,
             require_mention=_to_boolean(
                 extra.get("require_mention", os.getenv("FEISHU_REQUIRE_MENTION", "true"))
             ),
@@ -1692,6 +1708,7 @@ class FeishuAdapter(BasePlatformAdapter):
         self._ws_ping_interval = settings.ws_ping_interval
         self._ws_ping_timeout = settings.ws_ping_timeout
         self._allow_bots = settings.allow_bots
+        self._allow_all_dm = settings.allow_all_dm
         self._require_mention = settings.require_mention
 
     def _build_event_handler(self) -> Any:
@@ -4370,9 +4387,11 @@ class FeishuAdapter(BasePlatformAdapter):
                 return "bot_not_mentioned"
 
         if not is_group:
-            if os.getenv("FEISHU_ALLOW_ALL_USERS", "").strip().lower() in {"true", "1", "yes"}:
-                return None
-            if os.getenv("GATEWAY_ALLOW_ALL_USERS", "").strip().lower() in {"true", "1", "yes"}:
+            # Resolved per-profile in _load_settings: in multiplex mode a
+            # secondary profile's .env (FEISHU_ALLOW_ALL_USERS /
+            # GATEWAY_ALLOW_ALL_USERS) governs its own adapter — a bare
+            # os.getenv here would read the default profile's value (#86905).
+            if self._allow_all_dm:
                 return None
             # Empty FEISHU_ALLOWED_USERS is the pairing-mode default from setup:
             # forward DMs to gateway intake so the pairing handshake can run.

--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -1694,7 +1694,7 @@ class FeishuAdapter(BasePlatformAdapter):
             allow_bots=allow_bots,
             allow_all_dm=allow_all_dm,
             require_mention=_to_boolean(
-                extra.get("require_mention", os.getenv("FEISHU_REQUIRE_MENTION", "true"))
+                extra.get("require_mention", _get_scoped_secret("FEISHU_REQUIRE_MENTION", "true"))
             ),
         )
 
@@ -3192,7 +3192,7 @@ class FeishuAdapter(BasePlatformAdapter):
     # =========================================================================
 
     def _reactions_enabled(self) -> bool:
-        return os.getenv("FEISHU_REACTIONS", "true").strip().lower() not in {"false", "0", "no"}
+        return _get_scoped_secret("FEISHU_REACTIONS", "true").strip().lower() not in {"false", "0", "no"}
 
     async def _add_reaction(self, message_id: str, emoji_type: str) -> Optional[str]:
         """Return the reaction_id on success, else None. The id is needed later for deletion."""

--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -1634,7 +1634,10 @@ class FeishuAdapter(BasePlatformAdapter):
         )
 
         return FeishuAdapterSettings(
-            app_id=str(extra.get("app_id") or os.getenv("FEISHU_APP_ID", "")).strip(),
+            # Credential identity (app_id + bot_*): scope-aware like app_secret,
+            # so a multiplexed secondary adapter never pairs the default
+            # profile's app_id with its own scoped secret (#86905 review).
+            app_id=str(extra.get("app_id") or _get_scoped_secret("FEISHU_APP_ID", "")).strip(),
             app_secret=str(extra.get("app_secret") or _get_scoped_secret("FEISHU_APP_SECRET", "")).strip(),
             domain_name=str(extra.get("domain") or os.getenv("FEISHU_DOMAIN", "feishu")).strip().lower(),
             connection_mode=str(
@@ -1650,9 +1653,9 @@ class FeishuAdapter(BasePlatformAdapter):
                 for item in _get_scoped_secret("FEISHU_ALLOWED_USERS", "").split(",")
                 if item.strip()
             ),
-            bot_open_id=os.getenv("FEISHU_BOT_OPEN_ID", "").strip(),
-            bot_user_id=os.getenv("FEISHU_BOT_USER_ID", "").strip(),
-            bot_name=os.getenv("FEISHU_BOT_NAME", "").strip(),
+            bot_open_id=_get_scoped_secret("FEISHU_BOT_OPEN_ID", "").strip(),
+            bot_user_id=_get_scoped_secret("FEISHU_BOT_USER_ID", "").strip(),
+            bot_name=_get_scoped_secret("FEISHU_BOT_NAME", "").strip(),
             dedup_cache_size=max(
                 32,
                 env_int("HERMES_FEISHU_DEDUP_CACHE_SIZE", _DEFAULT_DEDUP_CACHE_SIZE),

--- a/tests/gateway/feishu_helpers.py
+++ b/tests/gateway/feishu_helpers.py
@@ -34,6 +34,7 @@ def make_adapter_skeleton(
     allow_bots: str = "none",
     require_mention: bool = True,
     group_policy: str = "allowlist",
+    allow_all_dm: bool = False,
 ) -> Any:
     from plugins.platforms.feishu.adapter import FeishuAdapter
 
@@ -48,6 +49,7 @@ def make_adapter_skeleton(
     adapter._default_group_policy = group_policy
     adapter._allowed_group_users = frozenset()
     adapter._allow_bots = allow_bots
+    adapter._allow_all_dm = allow_all_dm
     adapter._require_mention = require_mention
     return adapter
 

--- a/tests/gateway/test_feishu_bot_admission.py
+++ b/tests/gateway/test_feishu_bot_admission.py
@@ -671,3 +671,28 @@ def test_allow_all_dm_falls_back_to_os_environ_when_unscoped(monkeypatch):
     adapter = object.__new__(FeishuAdapter)
     adapter._apply_settings(settings)
     assert adapter._admit(make_sender(open_id="ou_anyone"), make_message(chat_type="p2p")) is None
+
+
+def test_require_mention_resolves_from_profile_scope(tmp_path, monkeypatch):
+    """FEISHU_REQUIRE_MENTION is a per-profile admission gate: a secondary
+    profile's .env value must win over the default profile's os.environ."""
+    import agent.secret_scope as ss
+    from plugins.platforms.feishu.adapter import FeishuAdapter
+
+    monkeypatch.setenv("FEISHU_APP_ID", "cli_test")
+    monkeypatch.setenv("FEISHU_APP_SECRET", "secret_test")
+    monkeypatch.setenv("FEISHU_REQUIRE_MENTION", "true")  # default profile
+    (tmp_path / ".env").write_text(
+        "FEISHU_APP_ID=cli_test\nFEISHU_APP_SECRET=secret_test\n"
+        "FEISHU_REQUIRE_MENTION=false\n",
+        encoding="utf-8",
+    )
+
+    ss.set_multiplex_active(True)
+    tok = ss.set_secret_scope(ss.build_profile_secret_scope(tmp_path))
+    try:
+        settings = FeishuAdapter._load_settings(extra={})
+        assert settings.require_mention is False
+    finally:
+        ss.reset_secret_scope(tok)
+        ss.set_multiplex_active(False)

--- a/tests/gateway/test_feishu_bot_admission.py
+++ b/tests/gateway/test_feishu_bot_admission.py
@@ -566,3 +566,108 @@ def test_handle_message_event_data_forwards_sender_when_admitted():
     assert captured.get("sender_id") is sender.sender_id
     assert captured.get("is_bot") is True
     assert captured.get("message_id") == "om_bot_ok"
+
+
+# --- Profile-scoped admission config (#86905) -------------------------------
+#
+# In multiplex mode the adapter's admission config must come from the
+# profile's own .env (like app_secret), not from bare os.environ — Feishu
+# open_ids are app-scoped, so the default profile's allow-list can never
+# match senders on a secondary profile's bot.
+
+
+def test_allow_all_dm_resolves_from_profile_scope_not_os_environ(
+    tmp_path, monkeypatch
+):
+    """os.environ holds the default profile's view; the role profile's .env
+    sets GATEWAY_ALLOW_ALL_USERS=true — the adapter must admit DMs whose
+    sender carries the role app's open_id (absent from the default allow-list)."""
+    import agent.secret_scope as ss
+    from plugins.platforms.feishu.adapter import FeishuAdapter
+
+    # Default profile's process env: allow-list keyed on the DEFAULT app's
+    # open_id, no allow-all flag anywhere in os.environ.
+    monkeypatch.setenv("FEISHU_APP_ID", "cli_role")
+    monkeypatch.setenv("FEISHU_APP_SECRET", "secret_role")
+    monkeypatch.setenv("FEISHU_ALLOWED_USERS", "ou_default_view")
+    monkeypatch.delenv("GATEWAY_ALLOW_ALL_USERS", raising=False)
+    monkeypatch.delenv("FEISHU_ALLOW_ALL_USERS", raising=False)
+
+    # Role profile's .env
+    (tmp_path / ".env").write_text(
+        "FEISHU_APP_ID=cli_role\nFEISHU_APP_SECRET=secret_role\n"
+        "GATEWAY_ALLOW_ALL_USERS=true\n",
+        encoding="utf-8",
+    )
+
+    ss.set_multiplex_active(True)
+    tok = ss.set_secret_scope(ss.build_profile_secret_scope(tmp_path))
+    try:
+        settings = FeishuAdapter._load_settings(extra={})
+        assert settings.allow_all_dm is True
+        # The scoped allow-list (profile .env has none) must not fall through
+        # to the default profile's os.environ list either.
+        assert settings.allowed_group_users == frozenset()
+
+        adapter = object.__new__(FeishuAdapter)
+        adapter._apply_settings(settings)
+        sender = make_sender(open_id="ou_role_view")  # role app's open_id
+        assert adapter._admit(sender, make_message(chat_type="p2p")) is None
+    finally:
+        ss.reset_secret_scope(tok)
+        ss.set_multiplex_active(False)
+
+
+def test_allowed_users_resolves_from_profile_scope(tmp_path, monkeypatch):
+    """A secondary profile's FEISHU_ALLOWED_USERS (its own app's open_ids)
+    must gate admission — the default profile's os.environ list must not
+    leak in."""
+    import agent.secret_scope as ss
+    from plugins.platforms.feishu.adapter import FeishuAdapter
+
+    monkeypatch.setenv("FEISHU_APP_ID", "cli_role")
+    monkeypatch.setenv("FEISHU_APP_SECRET", "secret_role")
+    monkeypatch.setenv("FEISHU_ALLOWED_USERS", "ou_default_view")
+    monkeypatch.delenv("GATEWAY_ALLOW_ALL_USERS", raising=False)
+    monkeypatch.delenv("FEISHU_ALLOW_ALL_USERS", raising=False)
+
+    (tmp_path / ".env").write_text(
+        "FEISHU_APP_ID=cli_role\nFEISHU_APP_SECRET=secret_role\n"
+        "FEISHU_ALLOWED_USERS=ou_role_view\n",
+        encoding="utf-8",
+    )
+
+    ss.set_multiplex_active(True)
+    tok = ss.set_secret_scope(ss.build_profile_secret_scope(tmp_path))
+    try:
+        settings = FeishuAdapter._load_settings(extra={})
+        assert settings.allowed_group_users == frozenset({"ou_role_view"})
+
+        adapter = object.__new__(FeishuAdapter)
+        adapter._apply_settings(settings)
+        # Role app's view of the owner → admitted.
+        assert adapter._admit(make_sender(open_id="ou_role_view"), make_message(chat_type="p2p")) is None
+        # Default app's view of the owner → not in the scoped allow-list.
+        assert adapter._admit(make_sender(open_id="ou_default_view"), make_message(chat_type="p2p")) == "dm_policy_rejected"
+    finally:
+        ss.reset_secret_scope(tok)
+        ss.set_multiplex_active(False)
+
+
+def test_allow_all_dm_falls_back_to_os_environ_when_unscoped(monkeypatch):
+    """Non-multiplex behavior unchanged: FEISHU_ALLOW_ALL_USERS in the
+    process environment still opens DMs."""
+    from plugins.platforms.feishu.adapter import FeishuAdapter
+
+    monkeypatch.setenv("FEISHU_APP_ID", "cli_test")
+    monkeypatch.setenv("FEISHU_APP_SECRET", "secret_test")
+    monkeypatch.setenv("GATEWAY_ALLOW_ALL_USERS", "true")
+    monkeypatch.setenv("FEISHU_ALLOWED_USERS", "ou_a,ou_b")
+
+    settings = FeishuAdapter._load_settings(extra={})
+    assert settings.allow_all_dm is True
+    assert settings.allowed_group_users == frozenset({"ou_a", "ou_b"})
+
+    adapter = object.__new__(FeishuAdapter)
+    adapter._apply_settings(settings)
+    assert adapter._admit(make_sender(open_id="ou_anyone"), make_message(chat_type="p2p")) is None

--- a/tests/gateway/test_multiplex_profile_authz.py
+++ b/tests/gateway/test_multiplex_profile_authz.py
@@ -132,3 +132,84 @@ def test_secondary_open_policy_fails_startup_guard(monkeypatch):
     assert violation is not None
     assert "wecom" in violation
     assert "open policy" in violation
+
+
+# --- _auth_env scoped-miss fail-closed (#86905) -----------------------------
+#
+# In multiplex mode with a scope installed, a scoped miss must return the
+# default instead of leaking os.environ (which holds the DEFAULT profile's
+# allowlist). A leaked allowlist would skip the allow-all check and reject
+# every sender on a secondary profile's bot (Feishu open_ids are app-scoped).
+
+
+def test_auth_env_scoped_miss_does_not_leak_os_environ(tmp_path, monkeypatch):
+    from gateway.authz_mixin import _auth_env
+
+    import agent.secret_scope as ss
+
+    # Default profile's process env holds an allowlist the scoped profile
+    # does not have.
+    monkeypatch.setenv("FEISHU_ALLOWED_USERS", "ou_default_view")
+    (tmp_path / ".env").write_text(
+        "GATEWAY_ALLOW_ALL_USERS=true\n", encoding="utf-8"
+    )
+
+    ss.set_multiplex_active(True)
+    tok = ss.set_secret_scope(ss.build_profile_secret_scope(tmp_path))
+    try:
+        assert _auth_env("FEISHU_ALLOWED_USERS") == ""
+        assert _auth_env("GATEWAY_ALLOW_ALL_USERS") == "true"
+    finally:
+        ss.reset_secret_scope(tok)
+        ss.set_multiplex_active(False)
+
+
+def test_auth_env_unscoped_still_reads_os_environ(monkeypatch):
+    """Single-profile (multiplex off): legacy os.environ read unchanged."""
+    from gateway.authz_mixin import _auth_env
+
+    monkeypatch.setenv("FEISHU_ALLOWED_USERS", "ou_a,ou_b")
+    assert _auth_env("FEISHU_ALLOWED_USERS") == "ou_a,ou_b"
+
+
+def test_is_user_authorized_allow_all_not_skipped_by_leaked_allowlist(
+    tmp_path, monkeypatch
+):
+    """End-to-end shape of #86905: the secondary profile's scope has only
+    GATEWAY_ALLOW_ALL_USERS=true; the DEFAULT profile's FEISHU_ALLOWED_USERS
+    lives in os.environ. The sender carries the secondary app's open_id
+    (absent from the default allowlist) and must still be admitted via the
+    allow-all flag — a leaked allowlist must not hijack the decision."""
+    import agent.secret_scope as ss
+    from gateway.authz_mixin import _auth_env
+    from gateway.run import GatewayRunner
+
+    _clear_auth_env(monkeypatch)
+    monkeypatch.setenv("FEISHU_ALLOWED_USERS", "ou_default_view")
+    (tmp_path / ".env").write_text(
+        "GATEWAY_ALLOW_ALL_USERS=true\n", encoding="utf-8"
+    )
+
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(multiplex_profiles=True)
+    runner.adapters = {}
+    runner._profile_adapters = {}
+    runner.pairing_store = MagicMock()
+    runner.pairing_store.is_approved.return_value = False
+
+    ss.set_multiplex_active(True)
+    tok = ss.set_secret_scope(ss.build_profile_secret_scope(tmp_path))
+    try:
+        assert _auth_env("FEISHU_ALLOWED_USERS") == ""  # no leak
+        source = SessionSource(
+            platform=Platform.FEISHU,
+            user_id="ou_role_view",
+            chat_id="dm-chat",
+            user_name="owner",
+            chat_type="dm",
+            profile="role-codex",
+        )
+        assert runner._is_user_authorized(source) is True
+    finally:
+        ss.reset_secret_scope(tok)
+        ss.set_multiplex_active(False)


### PR DESCRIPTION
﻿## What does this PR do?

Under `gateway.multiplex_profiles`, DMs sent to a **secondary profile's** Feishu bot were silently rejected even when the profile's own `.env` granted access. Two independent layers were broken, both from the same root cause — Feishu `open_id`s are **app-scoped** (each bot sees the same human under a different `open_id`), and profile-scoped env config was not being read scope-aware:

**Layer 1 — feishu adapter admission (`plugins/platforms/feishu/adapter.py`).** `_load_settings` read `app_secret` through `_get_scoped_secret` (scope-aware) but the DM allow-list (`FEISHU_ALLOWED_USERS`), `group_policy`, `allow_bots`, and the allow-all flags (`FEISHU_ALLOW_ALL_USERS` / `GATEWAY_ALLOW_ALL_USERS`) via bare `os.getenv` — under multiplex that is the DEFAULT profile's values. The role bot admitted against the default app's allow-list while the sender carried the role app's `open_id` → `dm_policy_rejected` at debug level, zero logs. All five reads now go through `_get_scoped_secret`; allow-all is resolved once into a settings field and `_admit` gates on it.

**Layer 2 — gateway authorization (`gateway/authz_mixin.py`).** Field debugging (temporary logs on the live gateway) showed DMs still rejected after layer 1: `_auth_env` read `FEISHU_ALLOWED_USERS` via `get_secret`, and on a **scoped miss** fell through to `os.environ` — leaking the default profile's allowlist, which then **skipped the allow-all check** (`GATEWAY_ALLOW_ALL_USERS=true` in the role profile's scope) and rejected every sender. `_auth_env` now fails closed on a scoped miss under multiplex (scope installed → miss returns default, never borrows from `os.environ`) — the same contract `_platform_gate_env` already implemented (#72348). `_get_scoped_secret` got the same fail-closed fix (its docstring already promised "no cross-profile borrow"; the implementation now honors it).

Non-multiplex behavior is unchanged: unscoped default-profile paths and single-profile deployments keep the `os.environ` read.

## Related Issue

Fixes #86905

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/platforms/feishu/adapter.py`:
  - `_get_scoped_secret`: fail closed on scoped miss under multiplex (docstring now matches implementation)
  - `_load_settings`: `FEISHU_ALLOW_BOTS`, `FEISHU_GROUP_POLICY`, `FEISHU_ALLOWED_USERS`, `FEISHU_ALLOW_ALL_USERS`, `GATEWAY_ALLOW_ALL_USERS` all scope-aware; new `allow_all_dm` settings field
  - `_admit`: DM allow-all gate uses the resolved per-profile flag
- `gateway/authz_mixin.py`: `_auth_env` fails closed on scoped miss (mirror of `_platform_gate_env`, #72348)
- Tests: `test_feishu_bot_admission.py` (3 new multiplex tests), `test_multiplex_profile_authz.py` (3 new tests: scoped-miss no-leak, unscoped regression, end-to-end allow-all-not-skipped)

## How to Test

1. `pytest tests/gateway/test_feishu_bot_admission.py tests/gateway/test_multiplex_profile_authz.py -q` — 42 passed
2. `ruff check` on changed files — clean
3. **Field verification (this reporter)**: 7-profile multiplex gateway on Windows 11; role profiles' `.env` set `GATEWAY_ALLOW_ALL_USERS=true`. Before the fix: DMs to role bots silently dropped (`dm_policy_rejected` at debug; traced to app-scoped open_id mismatch). After the fix: **DMs to role bots are admitted, reach the agent, and get replies** (agent config is the user's own remaining setup).

Note: the same `_get_scoped_secret` wrapper pattern exists in ~14 other platform adapters with the identical scoped-miss fallback; tracked as a follow-up class fix in the issue.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run pytest and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11, Python 3.11 (live 7-profile multiplex gateway)

### Documentation & Housekeeping

- [x] N/A for docs/config example (no new config keys — existing env vars now resolve per-profile)
- [x] N/A for tool descriptions/schemas
