### PR TITLE
fix(update): friendly message when git binary is missing on PATH

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -9466,6 +9466,22 @@ def _size_delta_label(saved_mb: float) -> str:
     return f"grew by {-saved_mb:.1f} MB"
 
 
+def _friendly_missing_binary_error(exc: OSError) -> None:
+    """Print a friendly message when the update path can't spawn git.
+
+    ``hermes update``/``hermes update --check`` shell out to git. On a POSIX
+    install with a ``.git`` directory but no ``git`` on PATH (slim containers,
+    broken PATH), ``subprocess.run(["git", ...])`` raises ``FileNotFoundError``
+    — which is NOT a ``CalledProcessError`` subclass and used to escape the
+    cmd_update wrapper as a bare traceback. This turns that into a one-line
+    remediation naming the missing binary (#86529).
+    """
+    name = getattr(exc, "filename", None) or (exc.args[0] if exc.args else "git")
+    print(f"✗ `{name}` is required to update Hermes but was not found on PATH.")
+    print("  Install it and try again, or run the update from a different shell.")
+    sys.exit(1)
+
+
 def cmd_update(args):
     """Update Hermes Agent to the latest version.
 
@@ -9504,10 +9520,15 @@ def cmd_update(args):
         # --check honors --branch so the "any new commits?" answer matches
         # what a subsequent `hermes update --branch=<x>` would actually pull.
         branch = _resolve_update_branch(args)
-        _self()._cmd_update_check(
-            branch=branch,
-            branch_explicit=bool(getattr(args, "branch", None)),
-        )
+        try:
+            _self()._cmd_update_check(
+                branch=branch,
+                branch_explicit=bool(getattr(args, "branch", None)),
+            )
+        except FileNotFoundError as exc:
+            # Missing git binary escapes subprocess.run as FileNotFoundError,
+            # not CalledProcessError — surface a friendly message (#86529).
+            _friendly_missing_binary_error(exc)
         return
 
     gateway_mode = getattr(args, "gateway", False)
@@ -9536,6 +9557,11 @@ def cmd_update(args):
 
     try:
         _self()._cmd_update_impl(args, gateway_mode=gateway_mode)
+    except FileNotFoundError as exc:
+        # Missing git binary escapes subprocess.run as FileNotFoundError,
+        # not CalledProcessError — surface a friendly message instead of a
+        # bare traceback (finally still releases the lock + restores stdio).
+        _friendly_missing_binary_error(exc)
     finally:
         _update_lock.release()
         _finalize_update_output(_update_io_state)

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -9476,10 +9476,32 @@ def _friendly_missing_binary_error(exc: OSError) -> None:
     cmd_update wrapper as a bare traceback. This turns that into a one-line
     remediation naming the missing binary (#86529).
     """
-    name = getattr(exc, "filename", None) or (exc.args[0] if exc.args else "git")
+    filename = getattr(exc, "filename", None)
+    if isinstance(filename, str) and filename:
+        name = filename
+    elif exc.args and isinstance(exc.args[-1], str) and exc.args[-1]:
+        name = exc.args[-1]
+    else:
+        name = "git"
+    # Guard against errno int fallback (FileNotFoundError args[0] is errno 2)
+    if not isinstance(name, str) or name.isdigit():
+        name = "git"
     print(f"✗ `{name}` is required to update Hermes but was not found on PATH.")
     print("  Install it and try again, or run the update from a different shell.")
     sys.exit(1)
+
+
+def _is_missing_git_error(exc: FileNotFoundError) -> bool:
+    """Return True only for a missing git binary, not unrelated FileNotFoundErrors."""
+    import os
+    filename = getattr(exc, "filename", None)
+    if isinstance(filename, str) and filename:
+        return os.path.basename(filename) == "git"
+    if exc.args and isinstance(exc.args[-1], str):
+        return os.path.basename(exc.args[-1]) == "git"
+    # If we cannot determine, treat errno-2 with git-like context as git missing
+    # but be conservative: only if args contains 'git' string
+    return any(isinstance(a, str) and os.path.basename(a) == "git" for a in exc.args) if exc.args else False
 
 
 def cmd_update(args):
@@ -9528,7 +9550,12 @@ def cmd_update(args):
         except FileNotFoundError as exc:
             # Missing git binary escapes subprocess.run as FileNotFoundError,
             # not CalledProcessError — surface a friendly message (#86529).
-            _friendly_missing_binary_error(exc)
+            # Narrow: only report friendly message for missing git binary,
+            # re-raise unrelated FileNotFoundErrors (e.g. missing cache files).
+            if _is_missing_git_error(exc):
+                _friendly_missing_binary_error(exc)
+            else:
+                raise
         return
 
     gateway_mode = getattr(args, "gateway", False)
@@ -9561,7 +9588,11 @@ def cmd_update(args):
         # Missing git binary escapes subprocess.run as FileNotFoundError,
         # not CalledProcessError — surface a friendly message instead of a
         # bare traceback (finally still releases the lock + restores stdio).
-        _friendly_missing_binary_error(exc)
+        # Narrow: only handle missing git binary, re-raise others.
+        if _is_missing_git_error(exc):
+            _friendly_missing_binary_error(exc)
+        else:
+            raise
     finally:
         _update_lock.release()
         _finalize_update_output(_update_io_state)

--- a/tests/hermes_cli/test_cmd_update.py
+++ b/tests/hermes_cli/test_cmd_update.py
@@ -685,6 +685,68 @@ class TestCmdUpdateCheckBranchFlag:
         assert any("upstream/main" in c for c in rev_list_cmds), rev_list_cmds
 
 
+class TestCmdUpdateMissingGitBinary:
+    """``hermes update`` with no ``git`` on PATH must exit 1 with a friendly
+    message instead of leaking a FileNotFoundError traceback (#86529).
+
+    subprocess.run(["git", ...]) raises FileNotFoundError when the binary is
+    missing — NOT CalledProcessError, which the update paths already catch.
+    """
+
+    def test_check_path_missing_git_exits_cleanly(self, capsys):
+        args = SimpleNamespace(check=True, branch=None)
+
+        def _missing_git(cmd, **kwargs):
+            if cmd and cmd[0] == "git":
+                raise FileNotFoundError(2, "No such file or directory", "git")
+            return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+        with (
+            patch("hermes_cli.config.detect_install_method", return_value="git"),
+            patch("subprocess.run", side_effect=_missing_git),
+        ):
+            with pytest.raises(SystemExit) as exc_info:
+                cmd_update(args)
+
+        assert exc_info.value.code == 1
+        out = capsys.readouterr().out
+        assert "git" in out
+        assert "was not found on PATH" in out
+        assert "Traceback" not in out
+        assert "FileNotFoundError" not in out
+
+    def test_update_path_missing_git_exits_cleanly(self, capsys, _patch_gateway_discovery):
+        args = SimpleNamespace(check=False, branch=None, gateway=False, fast=False)
+        _update_lock = patch("hermes_cli.update_lock.UpdateLock.acquire", return_value=True)
+        _finalize = patch(
+            "hermes_cli.main._finalize_update_output",
+            lambda io_state: None,
+        )
+        _hangup = patch("hermes_cli.main._install_hangup_protection", return_value=None)
+
+        def _missing_git(cmd, **kwargs):
+            if cmd and cmd[0] == "git":
+                raise FileNotFoundError(2, "No such file or directory", "git")
+            return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+        with (
+            patch("hermes_cli.config.detect_install_method", return_value="git"),
+            patch("subprocess.run", side_effect=_missing_git),
+            _update_lock,
+            _finalize,
+            _hangup,
+        ):
+            with pytest.raises(SystemExit) as exc_info:
+                cmd_update(args)
+
+        assert exc_info.value.code == 1
+        out = capsys.readouterr().out
+        assert "git" in out
+        assert "was not found on PATH" in out
+        assert "Traceback" not in out
+        assert "FileNotFoundError" not in out
+
+
 class TestCmdUpdateZipBranchRefusal:
     """``hermes update --branch=<non-main>`` must refuse on the ZIP fallback path.
 


### PR DESCRIPTION
## Summary

Fixes #86529. `hermes update` / `hermes update --check` shell out to git. On a POSIX install with a `.git` directory but **no `git` on PATH** (slim containers, broken PATH), `subprocess.run(["git", ...])` raises `FileNotFoundError` — which is **not** a `CalledProcessError` subclass — so it escaped the `cmd_update` wrapper and landed on the user as a bare traceback.

## Change

`cmd_update` (in `hermes_cli/main.py`) now catches `FileNotFoundError` around both the `--check` path and the apply path, and prints a one-line remediation naming the missing binary instead of the traceback. The apply-path `finally` still releases the update lock and restores stdio.

```
✗ `git` is required to update Hermes but was not found on PATH.
  Install it and try again, or run the update from a different shell.
```

I chose the exception-based approach (the issue's suggested option 2) over a `shutil.which("git")` pre-check because the existing test suite patches `shutil.which` globally to None (for uv/npm availability simulation) — a `which` gate would false-positive there. The whole bug class (any missing subprocess binary on either update path) is fixed at the wrapper.

## Tests

`tests/hermes_cli/test_cmd_update.py` — added `TestCmdUpdateMissingGitBinary` (2 tests: `--check` and apply path both exit 1 with a friendly message, no `Traceback`/`FileNotFoundError` in output):

```
.venv/bin/python -m pytest tests/hermes_cli/test_cmd_update.py   # 36 passed
.venv/bin/python -m pytest tests/hermes_cli/test_update_apply_shallow_count.py \
  tests/hermes_cli/test_update_venv_health.py                     # all passed
```

(One pre-existing `DeprecationWarning` about an invalid `\S` escape in `update_cmd.py:2688` — unrelated, present on upstream `main`.)