### PR TITLE
feat(models): add glm-5.3 context length (1M, same as glm-5.2)

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -508,6 +508,7 @@ DEFAULT_CONTEXT_LENGTHS = {
     # ensures "glm-5.2" resolves to 1M while older variants still hit the
     # generic 202K fallback.
     "glm-5.2": 1_048_576,
+    "glm-5.3": 1_048_576,
     "glm": 202752,
     # xAI Grok — xAI /v1/models does not return context_length metadata,
     # so these hardcoded fallbacks prevent Hermes from probing-down to


### PR DESCRIPTION
## Summary
- Adds `glm-5.3` to `DEFAULT_CONTEXT_LENGTHS` with 1,048,576 (1M), matching glm-5.2.
- Without this entry, glm-5.3 resolves to the generic 202,752 fallback, silently truncating long-context conversations.

## Context
Follows the existing pattern one line above (`glm-5.2`: 1M). GLM-5.3 is the successor model from Z.ai with the same 1M context window; Hermes users selecting it via `hermes model` currently hit the 202K fallback.

## Testing
- One-line data-table addition; no behavior change for other models.