### PR TITLE
fix(tools-config): stop clobbering image_gen.use_gateway on Nous-managed FAL picks

### DIFF
--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -3671,9 +3671,17 @@ def _is_provider_active(
 ) -> bool:
     """Check if a provider entry matches the currently active config."""
     plugin_name = provider.get("image_gen_plugin_name")
-    if plugin_name:
+    if plugin_name and not provider.get("managed_nous_feature"):
+        # Managed (Nous-subscription) entries fall through to the
+        # managed_feature branch below, which also checks use_gateway —
+        # otherwise a managed FAL pick and a direct-key FAL pick would both
+        # report active for the same provider name (video already guards).
         image_cfg = config.get("image_gen", {})
-        return isinstance(image_cfg, dict) and image_cfg.get("provider") == plugin_name
+        if not (isinstance(image_cfg, dict) and image_cfg.get("provider") == plugin_name):
+            return False
+        # A direct-key entry is only active when the managed route is OFF —
+        # mirror of the managed branch's use_gateway check.
+        return not is_truthy_value(image_cfg.get("use_gateway"), default=False)
 
     video_plugin_name = provider.get("video_gen_plugin_name")
     if video_plugin_name and not provider.get("managed_nous_feature"):
@@ -4026,14 +4034,22 @@ def _configure_xai_imagine_storage(section_name: str, config: dict) -> None:
         _print_success("  xAI stored public URLs enabled without automatic expiry")
 
 
-def _select_plugin_image_gen_provider(plugin_name: str, config: dict) -> None:
-    """Persist a plugin-backed image generation provider selection."""
+def _select_plugin_image_gen_provider(plugin_name: str, config: dict, *, use_gateway: bool = False) -> None:
+    """Persist a plugin-backed image generation provider selection.
+
+    ``use_gateway`` mirrors :func:`_select_plugin_video_gen_provider`: a
+    provider picked through the Nous-managed flow must keep routing through
+    the gateway. Hardcoding ``False`` here silently flipped Nous-managed FAL
+    picks onto the user's personal FAL_KEY — _write_provider_config sets
+    ``image_gen.use_gateway = True`` for a managed pick, and this function
+    runs AFTER it, so the hardcoded value clobbered the managed flag.
+    """
     img_cfg = config.setdefault("image_gen", {})
     if not isinstance(img_cfg, dict):
         img_cfg = {}
         config["image_gen"] = img_cfg
     img_cfg["provider"] = plugin_name
-    img_cfg["use_gateway"] = False
+    img_cfg["use_gateway"] = use_gateway
     _print_success(f"  image_gen.provider set to: {plugin_name}")
     _configure_imagegen_model_for_plugin(plugin_name, config)
     if plugin_name == "xai":
@@ -4386,7 +4402,7 @@ def _configure_provider(
         # and route model selection to the plugin's own catalog.
         plugin_name = provider.get("image_gen_plugin_name")
         if plugin_name:
-            _select_plugin_image_gen_provider(plugin_name, config)
+            _select_plugin_image_gen_provider(plugin_name, config, use_gateway=bool(managed_feature))
             return
         # Plugin-registered video_gen provider — same flow, different
         # registry.
@@ -4471,7 +4487,7 @@ def _configure_provider(
         _print_success(f"  {provider['name']} configured!")
         plugin_name = provider.get("image_gen_plugin_name")
         if plugin_name:
-            _select_plugin_image_gen_provider(plugin_name, config)
+            _select_plugin_image_gen_provider(plugin_name, config, use_gateway=bool(managed_feature))
             return
         video_plugin = provider.get("video_gen_plugin_name")
         if video_plugin:
@@ -4917,7 +4933,7 @@ def _reconfigure_provider(
             _print_info("  Requests for this tool will be billed to your Nous subscription.")
         plugin_name = provider.get("image_gen_plugin_name")
         if plugin_name:
-            _select_plugin_image_gen_provider(plugin_name, config)
+            _select_plugin_image_gen_provider(plugin_name, config, use_gateway=bool(managed_feature))
             return
         # Plugin-registered video_gen provider — same flow, different registry.
         video_plugin = provider.get("video_gen_plugin_name")
@@ -4959,7 +4975,7 @@ def _reconfigure_provider(
     # Imagegen backends prompt for model selection on reconfig too.
     plugin_name = provider.get("image_gen_plugin_name")
     if plugin_name:
-        _select_plugin_image_gen_provider(plugin_name, config)
+        _select_plugin_image_gen_provider(plugin_name, config, use_gateway=bool(managed_feature))
         return
 
     # Plugin-registered video_gen provider — same flow, different registry.

--- a/tests/hermes_cli/test_imagegen_managed_gateway.py
+++ b/tests/hermes_cli/test_imagegen_managed_gateway.py
@@ -1,0 +1,67 @@
+"""Regression tests for image_gen use_gateway persistence (managed FAL clobber).
+
+Bug: ``_select_plugin_image_gen_provider`` hardcoded
+``image_gen.use_gateway = False``. When a user picked FAL through the
+Nous-subscription managed flow, ``_write_provider_config`` first set
+``use_gateway = True`` — then the image selector ran and clobbered it back
+to False, silently routing every generation through the user's personal
+FAL_KEY instead of the Nous Tool Gateway (real incident: personal key
+drained to zero while the subscription sat unused).
+
+The video twin (``_select_plugin_video_gen_provider``) already accepted a
+``use_gateway`` kwarg; these tests pin the image path to the same contract.
+"""
+
+from hermes_cli.tools_config import (
+    _select_plugin_image_gen_provider,
+    _select_plugin_video_gen_provider,
+    _write_provider_config,
+)
+
+
+def _quiet(monkeypatch):
+    import hermes_cli.tools_config as tc
+
+    monkeypatch.setattr(tc, "_print_success", lambda *a, **k: None)
+    monkeypatch.setattr(tc, "_print_info", lambda *a, **k: None, raising=False)
+    monkeypatch.setattr(tc, "_configure_imagegen_model_for_plugin", lambda *a, **k: None)
+    monkeypatch.setattr(tc, "_configure_videogen_model_for_plugin", lambda *a, **k: None)
+
+
+def test_image_gen_selector_preserves_managed_gateway_flag(monkeypatch):
+    """Managed pick: use_gateway=True must survive the selector."""
+    _quiet(monkeypatch)
+    config = {}
+
+    # The managed flow first writes the managed flag...
+    _write_provider_config(
+        {"image_gen_plugin_name": "fal"}, config, managed_feature="image_gen"
+    )
+    assert config["image_gen"]["use_gateway"] is True
+
+    # ...then the selector runs; passing the managed flag must NOT clobber it.
+    _select_plugin_image_gen_provider("fal", config, use_gateway=True)
+    assert config["image_gen"]["provider"] == "fal"
+    assert config["image_gen"]["use_gateway"] is True
+
+
+def test_image_gen_selector_direct_key_pick_clears_gateway(monkeypatch):
+    """Non-managed pick keeps the historical default: direct key, no gateway."""
+    _quiet(monkeypatch)
+    config = {"image_gen": {"use_gateway": True}}
+
+    _select_plugin_image_gen_provider("fal", config)
+    assert config["image_gen"]["provider"] == "fal"
+    assert config["image_gen"]["use_gateway"] is False
+
+
+def test_image_and_video_selectors_share_the_gateway_contract(monkeypatch):
+    """The two selectors are twins: same kwarg, same persistence behavior."""
+    _quiet(monkeypatch)
+
+    for use_gateway in (True, False):
+        config = {}
+        _select_plugin_image_gen_provider("fal", config, use_gateway=use_gateway)
+        _select_plugin_video_gen_provider("fal", config, use_gateway=use_gateway)
+        assert config["image_gen"]["use_gateway"] is use_gateway
+        assert config["video_gen"]["use_gateway"] is use_gateway

--- a/website/docs/user-guide/desktop.md
+++ b/website/docs/user-guide/desktop.md
@@ -230,7 +230,7 @@ Connection modes are configured **per profile** — a per-profile override can p
 
 ### Settings → Connections: the multi-connection registry
 
-Alongside the per-profile connection mode above, **Settings → Connections** manages a named registry of every agent source the app knows about — the local runtime, any number of remote gateways (LAN, Tailscale, internet), Hermes Cloud instances, and SSH hosts — all persisted together in one place.
+Alongside the per-profile connection mode above, **Settings → Connections** manages a named registry of every agent source the app knows about — the local runtime, any number of remote gateways (LAN, Tailscale, internet), Hermes Cloud instances, and SSH hosts — all persisted together in one place. The full guide, including the union agent roster, `@name-device` handles, fleet-wide updates, and the plugin SDK surface, is at [Connecting Desktop to Many Hermes Instances](./multi-connection-desktop.md).
 
 - **Every connection needs a unique name** (a device name such as "Homelab" or "Work laptop"). When the same profile name exists on several registered sources, surfaces disambiguate it as `@profile-device` (e.g. `@research-homelab`).
 - **Add / edit / remove / test** connections from the panel. The local entry is managed by the app and cannot be removed. **Test** probes the connection's own HTTP and WebSocket legs directly.

--- a/website/docs/user-guide/multi-connection-desktop.md
+++ b/website/docs/user-guide/multi-connection-desktop.md
@@ -1,0 +1,119 @@
+---
+sidebar_position: 5
+---
+
+# Connecting Desktop to Many Hermes Instances
+
+Register every Hermes backend you own — the local runtime, remote gateways on
+your LAN or VPS, SSH hosts, and Hermes Cloud instances — in one desktop app,
+and use the agents on all of them side by side.
+
+This is the desktop-side complement to
+[Running Many Gateways at Once](./multi-profile-gateways.md): that page is
+about hosting several gateways on one machine; this one is about one desktop
+app talking to several machines.
+
+## The connection registry
+
+**Settings → Connections** manages a named registry of agent sources. Each
+entry is a *connection*:
+
+| Kind | What it is | Auth |
+|---|---|---|
+| **Local** | The runtime this app manages on your machine | automatic |
+| **Remote gateway** | A `hermes serve` backend reachable over HTTP(S) — LAN, Tailscale, VPS | session token or OAuth |
+| **SSH** | A Hermes install reached over SSH; the app opens the tunnel and starts the dashboard for you | SSH key + adopted token |
+| **Hermes Cloud** | A hosted instance discovered through your Nous account | portal sign-in |
+
+Rules worth knowing:
+
+- **Every connection needs a unique device name** ("Homelab", "Work laptop").
+  The name shows up everywhere the instance appears — roster badges, handles,
+  update results.
+- The **local** entry is managed by the app and cannot be removed. Removing
+  any other connection tears down its live backends and tunnels; the instance
+  itself is untouched.
+- **Test** probes the connection's own HTTP *and* WebSocket legs, so a pass
+  means chat will actually work — not just that the host pinged.
+- Cloud entries come from the Hermes Cloud sign-in/discovery flow, not a
+  hand-typed URL.
+- Tokens are encrypted with the OS keyring (same plain-text opt-in as
+  Settings → Gateway on keyring-less Linux), and never leave the Electron
+  main process.
+
+### Migrating from the single-connection settings
+
+The first launch of a registry-capable build imports your existing settings
+automatically: the global connection mode and any per-profile overrides from
+Settings → Gateway become named registry entries (deduplicated by URL/host).
+The legacy settings file is left untouched, so older builds on the same
+machine keep working.
+
+## Agents across sources
+
+Every profile on every registered connection is an *agent*. The union roster
+is what multi-source surfaces (and plugins like
+[Bot Mode](https://github.com/NousResearch/Hermes-Bot-Mode)) render:
+
+- When the same profile name exists on several sources, handles disambiguate
+  as **`@name-device`** — `research` on your Homelab renders as
+  `@research-homelab`, while a profile unique across all sources keeps its
+  bare name.
+- Enumeration is eager but sockets are lazy: the app lists agents over REST
+  without dialing every source's WebSocket. An unreachable source reports
+  per-row instead of breaking the roster; SSH sources stay connect-on-demand
+  until you first open an agent on them (no surprise tunnels).
+- Opening an agent dials **its own source** — chats, sessions, and memory
+  live on the machine that owns the profile, exactly as if you were using
+  that instance directly.
+
+Each `(connection, profile)` pair gets its own backend and socket, pooled
+with the same idle-reaping as local per-profile backends — background agents
+keep streaming while you look at another source.
+
+## Updating every instance at once
+
+**Settings → Connections → Update all instances** dispatches `hermes update`
+to every eligible connection in parallel:
+
+- **Local** updates through the app's own update pipeline (the same flow as
+  Settings → Updates).
+- **Remote and SSH** connections are told to update themselves via their own
+  backend — the update runs on *that* machine.
+- **Hermes Cloud** instances are skipped: the platform manages their
+  versions.
+
+Each instance reports independently, so one unreachable box never wedges the
+batch. Backends that manage updates externally (Docker, Nix) refuse politely
+with their own message, per row.
+
+## For plugin authors
+
+The Desktop [plugin SDK](../developer-guide/desktop-plugin-sdk.md) exposes the
+multi-source surface directly:
+
+- `host.connections()` — the registered connection list (labels, kinds,
+  primary; never token bytes).
+- `host.agents()` — the union roster: one row per `(source, profile)` with
+  the precomputed `@name-device` handle.
+- `host.ensureAgent(connectionId, profile)` — activate an agent's gateway so
+  subsequent `host.request` calls hit its backend.
+- `host.warmAgent(connectionId, profile)` — fire-and-forget socket pre-warm
+  (hover-intent).
+
+All four are feature-detected: on an older Desktop build they're absent and a
+plugin should fall back to the single-source `profiles.list` flow. Bot Mode's
+multi-source roster is the reference consumer.
+
+## Troubleshooting
+
+- **An agent shows but won't open** — run **Test** on its connection. The
+  WebSocket leg failing while HTTP passes usually means a proxy, firewall, or
+  gateway auth/origin guard is blocking `/api/ws`.
+- **A remote source is missing from the roster** — its backend is down or
+  unreachable; the roster lists it under sources with the error. SSH sources
+  show *connect-on-demand* until first use — that's by design, not a failure.
+- **"Update Hermes Desktop to chat with agents on other connections"** — the
+  app predates the multi-connection stack; update the desktop app itself.
+- **Duplicate device names** — not possible; names are enforced unique at
+  save time. If a migrated name collided, it was suffixed (`Homelab 2`).

--- a/website/docs/user-guide/multi-profile-gateways.md
+++ b/website/docs/user-guide/multi-profile-gateways.md
@@ -11,7 +11,9 @@ across profiles, preventing the host from sleeping, and recovering from common
 launchd/systemd quirks.
 
 If you only run one Hermes agent, you don't need this page — see
-[Profiles](./profiles.md) for the basics.
+[Profiles](./profiles.md) for the basics. And if your instances live on
+*different* machines that one desktop app should reach simultaneously, see
+[Connecting Desktop to Many Hermes Instances](./multi-connection-desktop.md).
 
 ## When to use this
 

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -53,6 +53,7 @@ const sidebars: SidebarsConfig = {
         'user-guide/profiles',
         'user-guide/profile-distributions',
         'user-guide/multi-profile-gateways',
+        'user-guide/multi-connection-desktop',
         'user-guide/git-worktrees',
         'user-guide/docker',
         'user-guide/security',


### PR DESCRIPTION
## Summary
Picking FAL through the Nous-subscription managed flow now persists `image_gen.use_gateway: true` — previously the image selector hardcoded it back to `false` AFTER the managed flow set it, so every generation silently billed the user's personal `FAL_KEY` instead of the subscription (real incident: personal key drained to a zero-balance lock while managed FAL sat unused).

## Changes
- `_select_plugin_image_gen_provider` gains the `use_gateway` kwarg its video twin already had; all 4 call sites pass `use_gateway=bool(managed_feature)` — same contract as video/tts/stt/browser/web. Class fix, not a site patch.
- Active-provider detection (`hermes tools` checkmark): the `image_gen_plugin_name` branch now defers managed entries to the `managed_feature` branch and requires `use_gateway` OFF for direct-key entries — mirroring the guard the video branch already had, so managed-FAL and direct-key-FAL no longer both show active.
- Runtime (`prefers_gateway("image_gen")`) was already correct; the bug was setup-time only.

## Validation
| Check | Result |
|---|---|
| New `test_imagegen_managed_gateway.py` (managed survives / direct clears / image-video parity) | 3/3 |
| Sabotage run (hardcoded `False` restored) | 2/3 fail — tests pin the bug |
| Neighboring provider/managed/tools_config suites | 180 passed |
| ruff | clean |

## Infographic

![Managed FAL fix](https://v3b.fal.media/files/b/0aa66d84/7VxEMvEZCnNdyug-_feH2_l0JjkHk0.png)
