### PR TITLE
fix(desktop): keep background terminal events in their owning session

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -25136,6 +25136,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         "type": "completion",
                         "session_id": session_id,
                         "session_key": session_key,
+                        "origin_ui_session_id": (
+                            watcher.get("origin_ui_session_id")
+                            or getattr(session, "origin_ui_session_id", "")
+                            or ""
+                        ),
                         "platform": platform_name,
                         "chat_type": watcher.get("chat_type", ""),
                         "chat_id": chat_id,

--- a/tests/gateway/test_completion_delivery.py
+++ b/tests/gateway/test_completion_delivery.py
@@ -319,6 +319,49 @@ def test_autonomous_completion_redacts_real_command_and_output_secrets(monkeypat
     assert "HOME=/home/user" in delivered.text
 
 
+def test_process_watcher_keeps_runtime_ui_owner(monkeypatch):
+    import tools.process_registry as pr_module
+
+    registry = ProcessRegistry()
+    session = ProcessSession(
+        id="proc_runtime_owner",
+        command="printf done",
+        origin_ui_session_id="runtime-session-a",
+        started_at=1234.5,
+        output_buffer="done\n",
+        exited=True,
+        exit_code=0,
+        notify_on_complete=True,
+    )
+    registry._finished[session.id] = session
+    monkeypatch.setattr(pr_module, "process_registry", registry)
+
+    runner = _runner(SimpleNamespace(handle_message=AsyncMock()))
+    runner._enqueue_process_completion_notification = AsyncMock(return_value=True)
+
+    async def _instant_sleep(*_a, **_kw):
+        pass
+
+    monkeypatch.setattr(asyncio, "sleep", _instant_sleep)
+    asyncio.run(
+        runner._run_process_watcher(
+            {
+                "session_id": session.id,
+                "check_interval": 0,
+                "session_key": "pre-compression-key",
+                "origin_ui_session_id": "runtime-session-a",
+                "platform": "telegram",
+                "chat_type": "dm",
+                "chat_id": "123",
+                "notify_on_complete": True,
+            }
+        )
+    )
+
+    completion = runner._enqueue_process_completion_notification.await_args.args[1]
+    assert completion["origin_ui_session_id"] == "runtime-session-a"
+
+
 def test_concurrent_process_watchers_coalesce_one_session_completion_turn(monkeypatch):
     """Concurrent terminal watchers for one session must re-enter the agent once."""
     import tools.process_registry as pr_module

--- a/tests/tools/test_notify_on_complete.py
+++ b/tests/tools/test_notify_on_complete.py
@@ -72,6 +72,20 @@ class TestCompletionQueue:
         assert registry.completion_queue.empty()
 
 
+    def test_completion_keeps_runtime_ui_owner(self, registry):
+        s = _make_session(notify_on_complete=True, output="done")
+        s.origin_ui_session_id = "runtime-session-a"
+        s.exited = True
+        s.exit_code = 0
+        registry._running[s.id] = s
+
+        with patch.object(registry, "_write_checkpoint"):
+            registry._move_to_finished(s)
+
+        completion = registry.completion_queue.get_nowait()
+        assert completion["origin_ui_session_id"] == "runtime-session-a"
+
+
     def test_move_to_finished_idempotent_no_duplicate(self, registry):
         """Calling _move_to_finished twice must NOT enqueue two notifications.
 
@@ -290,7 +304,7 @@ def _silent_bg_base_config(tmp_path):
     }
 
 
-def _silent_bg_harness(monkeypatch, tmp_path):
+def _silent_bg_harness(monkeypatch, tmp_path, spawned_kwargs=None):
     """Common test fixture: patch enough of terminal_tool to spawn a fake
     background process and capture the JSON result the agent sees."""
     import tools.terminal_tool as terminal_tool_module
@@ -301,6 +315,8 @@ def _silent_bg_harness(monkeypatch, tmp_path):
     dummy_env = SimpleNamespace(env={})
 
     def fake_spawn_local(**kwargs):
+        if spawned_kwargs is not None:
+            spawned_kwargs.update(kwargs)
         return SimpleNamespace(
             id="proc_silent_test",
             pid=4242,
@@ -321,6 +337,24 @@ def _silent_bg_harness(monkeypatch, tmp_path):
     monkeypatch.setitem(terminal_tool_module._active_environments, "default", dummy_env)
     monkeypatch.setitem(terminal_tool_module._last_activity, "default", 0.0)
     return terminal_tool_module
+
+
+def test_background_process_captures_runtime_ui_session_before_spawn(
+    monkeypatch, tmp_path
+):
+    from gateway.session_context import clear_session_vars, set_session_vars
+
+    spawned_kwargs = {}
+    tt = _silent_bg_harness(monkeypatch, tmp_path, spawned_kwargs)
+    tokens = set_session_vars(ui_session_id="runtime-session-a")
+    try:
+        tt.terminal_tool(command="python worker.py", background=True)
+    finally:
+        clear_session_vars(tokens)
+        tt._active_environments.pop("default", None)
+        tt._last_activity.pop("default", None)
+
+    assert spawned_kwargs["origin_ui_session_id"] == "runtime-session-a"
 
 
 def test_background_without_notify_emits_silent_process_hint(monkeypatch, tmp_path):

--- a/tests/tools/test_notify_on_complete.py
+++ b/tests/tools/test_notify_on_complete.py
@@ -357,6 +357,33 @@ def test_background_process_captures_runtime_ui_session_before_spawn(
     assert spawned_kwargs["origin_ui_session_id"] == "runtime-session-a"
 
 
+def test_background_process_logs_runtime_ui_owner_lookup_failure(
+    monkeypatch, tmp_path, caplog
+):
+    from gateway import session_context
+
+    spawned_kwargs = {}
+    tt = _silent_bg_harness(monkeypatch, tmp_path, spawned_kwargs)
+
+    original_get_session_env = session_context.get_session_env
+
+    def fail_ui_session_lookup(name, default=""):
+        if name == "HERMES_UI_SESSION_ID":
+            raise RuntimeError("session context unavailable")
+        return original_get_session_env(name, default)
+
+    monkeypatch.setattr(session_context, "get_session_env", fail_ui_session_lookup)
+    try:
+        with caplog.at_level("DEBUG", logger=tt.__name__):
+            tt.terminal_tool(command="python worker.py", background=True)
+    finally:
+        tt._active_environments.pop("default", None)
+        tt._last_activity.pop("default", None)
+
+    assert spawned_kwargs["origin_ui_session_id"] == ""
+    assert "Unable to capture the background process UI session" in caplog.text
+
+
 def test_background_without_notify_emits_silent_process_hint(monkeypatch, tmp_path):
     """The footgun case (May 2026 PR #31231): bg=True alone runs silently
     and the agent has no signal it finished. Tool must nudge."""

--- a/tests/tools/test_terminal_task_cwd.py
+++ b/tests/tools/test_terminal_task_cwd.py
@@ -168,6 +168,7 @@ def test_background_command_prefers_recorded_session_cwd_over_init_time_cwd(monk
         "cwd": "/workspace/live",
         "task_id": task_id,
         "session_key": task_id,
+        "origin_ui_session_id": "",
         "env_vars": {},
         "use_pty": False,
     }]

--- a/tests/tui_gateway/test_agent_terminal_routing.py
+++ b/tests/tui_gateway/test_agent_terminal_routing.py
@@ -1,0 +1,34 @@
+from types import SimpleNamespace
+
+from tui_gateway import server
+
+
+def test_agent_terminal_owner_survives_session_key_rotation(monkeypatch):
+    monkeypatch.setattr(
+        server,
+        "_sessions",
+        {
+            "runtime-a": {"session_key": "rotated-key"},
+            "runtime-b": {"session_key": "other-key"},
+        },
+    )
+    process = SimpleNamespace(
+        origin_ui_session_id="runtime-a",
+        session_key="pre-compression-key",
+    )
+
+    assert server._agent_terminal_owner_sid(process) == "runtime-a"
+
+
+def test_agent_terminal_owner_falls_back_to_session_key(monkeypatch):
+    monkeypatch.setattr(
+        server,
+        "_sessions",
+        {"runtime-a": {"session_key": "durable-key"}},
+    )
+    process = SimpleNamespace(
+        origin_ui_session_id="stale-runtime",
+        session_key="durable-key",
+    )
+
+    assert server._agent_terminal_owner_sid(process) == "runtime-a"

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -370,6 +370,7 @@ class ProcessSession:
     command: str                                 # Original command string
     task_id: str = ""                           # Task/sandbox isolation key
     session_key: str = ""                       # Gateway session key (for reset protection)
+    origin_ui_session_id: str = ""              # Live UI/runtime session that spawned the process
     pid: Optional[int] = None                   # OS process ID
     process: Optional[subprocess.Popen] = None  # Popen handle (local only)
     env_ref: Any = None                         # Reference to the environment object
@@ -976,6 +977,7 @@ class ProcessRegistry:
         cwd: str = None,
         task_id: str = "",
         session_key: str = "",
+        origin_ui_session_id: str = "",
         env_vars: dict = None,
         use_pty: bool = False,
     ) -> ProcessSession:
@@ -1003,6 +1005,7 @@ class ProcessRegistry:
             command=command,
             task_id=task_id,
             session_key=session_key,
+            origin_ui_session_id=origin_ui_session_id,
             cwd=_resolve_safe_cwd(cwd or os.getcwd()),
             started_at=time.time(),
         )
@@ -1215,6 +1218,7 @@ class ProcessRegistry:
         cwd: str = None,
         task_id: str = "",
         session_key: str = "",
+        origin_ui_session_id: str = "",
         timeout: int = 10,
     ) -> ProcessSession:
         """
@@ -1233,6 +1237,7 @@ class ProcessRegistry:
             command=command,
             task_id=task_id,
             session_key=session_key,
+            origin_ui_session_id=origin_ui_session_id,
             cwd=cwd,
             started_at=time.time(),
             env_ref=env,
@@ -1574,6 +1579,7 @@ class ProcessRegistry:
                 "type": "completion",
                 "session_id": session.id,
                 "session_key": session.session_key,
+                "origin_ui_session_id": session.origin_ui_session_id,
                 "command": session.command,
                 "exit_code": session.exit_code,
                 "completion_reason": session.completion_reason,

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -2989,6 +2989,18 @@ def terminal_tool(
             # For non-local backends: runs inside the sandbox via env.execute().
             from tools.process_registry import process_registry
 
+            # Capture the live UI return address before spawning. Local process
+            # readers may emit output immediately, and the durable session key can
+            # rotate later during compression while this process keeps running.
+            try:
+                from gateway.session_context import get_session_env
+
+                origin_ui_session_id = get_session_env(
+                    "HERMES_UI_SESSION_ID", ""
+                ) or ""
+            except Exception:
+                origin_ui_session_id = ""
+
             effective_cwd = _resolve_command_cwd(
                 workdir=workdir,
                 default_cwd=cwd,
@@ -3002,6 +3014,7 @@ def terminal_tool(
                         cwd=effective_cwd,
                         task_id=effective_task_id,
                         session_key=session_key,
+                        origin_ui_session_id=origin_ui_session_id,
                         env_vars=env.env if hasattr(env, 'env') else None,
                         use_pty=effective_pty,
                     )
@@ -3012,6 +3025,7 @@ def terminal_tool(
                         cwd=effective_cwd,
                         task_id=effective_task_id,
                         session_key=session_key,
+                        origin_ui_session_id=origin_ui_session_id,
                     )
 
                 result_data = {
@@ -3219,6 +3233,7 @@ def terminal_tool(
                             "session_id": proc_session.id,
                             "check_interval": 5,
                             "session_key": session_key,
+                            "origin_ui_session_id": origin_ui_session_id,
                             "platform": proc_session.watcher_platform,
                             "chat_id": proc_session.watcher_chat_id,
                             "user_id": proc_session.watcher_user_id,

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -2998,7 +2998,11 @@ def terminal_tool(
                 origin_ui_session_id = get_session_env(
                     "HERMES_UI_SESSION_ID", ""
                 ) or ""
-            except Exception:
+            except Exception as exc:
+                logger.debug(
+                    "Unable to capture the background process UI session: %s",
+                    exc,
+                )
                 origin_ui_session_id = ""
 
             effective_cwd = _resolve_command_cwd(

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -9989,6 +9989,23 @@ def _async_delegation_display_metadata(evt: dict) -> dict:
     return metadata
 
 
+def _agent_terminal_owner_sid(session) -> str:
+    """Resolve a process to its live UI session, surviving key rotation."""
+    ui_session_id = str(
+        getattr(session, "origin_ui_session_id", "") or ""
+    )
+    session_key = str(getattr(session, "session_key", "") or "")
+
+    with _sessions_lock:
+        if ui_session_id and ui_session_id in _sessions:
+            return ui_session_id
+        if session_key:
+            for sid, tui_session in _sessions.items():
+                if str(tui_session.get("session_key") or "") == session_key:
+                    return sid
+    return ""
+
+
 def _wire_agent_terminal_output() -> None:
     """Idempotently route background-process output (and tab-close requests) to
     the desktop, keyed by process id. Read-only agent terminal tabs stream
@@ -10005,27 +10022,17 @@ def _wire_agent_terminal_output() -> None:
     if has_output_sink and has_close_sink:
         return
 
-    def _owner_sid_for_process(session) -> str:
-        session_key = str(getattr(session, "session_key", "") or "")
-        if not session_key:
-            return ""
-        with _sessions_lock:
-            for sid, tui_session in _sessions.items():
-                if str(tui_session.get("session_key") or "") == session_key:
-                    return sid
-        return ""
-
     def _emit_agent_terminal_output(session, chunk):
         _emit(
             "agent.terminal.output",
-            _owner_sid_for_process(session),
+            _agent_terminal_owner_sid(session),
             {"process_id": session.id, "chunk": chunk},
         )
 
     def _emit_agent_terminal_close(session, process_id):
         # session may be None (process already finished/pruned) — the tab can
         # still linger and be closed; route to the owning window when we can.
-        sid = _owner_sid_for_process(session) if session is not None else ""
+        sid = _agent_terminal_owner_sid(session) if session is not None else ""
         _emit("terminal.close", sid, {"process_id": process_id})
 
     if not has_output_sink:


### PR DESCRIPTION
## What does this PR do?

Background terminal output could lose its owning Desktop runtime session after conversation compression rotated the durable session key. This left `agent.terminal.output` and `terminal.close` events with an empty `session_id`, so concurrent Desktop sessions could no longer reliably attribute those events to the window that started the process. This change preserves the stable runtime return address from process spawn through live output, close, and completion delivery while retaining the existing durable-key fallback.

### Symptom

A background terminal process starts in one Desktop session, then later output and close events are emitted with an empty `session_id` after that session's durable key changes. With multiple sessions active on the same profile, consumers lose the protocol-level owner for those events.

### Impact

Concurrent Desktop sessions cannot reliably attribute long-running terminal events after compression. The verified impact is limited to terminal output, close, and completion routing; this PR does not claim that terminal events independently explain every reported transcript-order symptom.

### Bug Cause

**Trigger:** `tools/terminal_tool.py:terminal_tool` starts a background process before `tui_gateway.server._sync_session_key_after_compress` rotates the owning session's durable key.

**Causal chain:**
1. The terminal tool stored only the current durable `session_key` on `ProcessSession`.
2. Compression replaced the live tui_gateway session key while the background process retained the old value.
3. `_wire_agent_terminal_output` could no longer match that old key to a live session and emitted output and close events with an empty `session_id`.

**Why it is wrong:** A mutable durable key was used as the only return address for a long-lived process even though the process can outlive that key.

**Working sibling / contrast:** Other detached completion paths already carry `HERMES_UI_SESSION_ID`, which is the stable runtime/window identity and does not rotate during compression.

**Ruled out:** The Desktop renderer handles terminal chunks by globally unique `process_id` and does not append them to chat messages, so speculative timestamp sorting is not part of this fix.

### Fix

Capture `HERMES_UI_SESSION_ID` before the process reader can emit, store it on local and remote `ProcessSession` instances, and propagate it through terminal watchers and completion events. The tui_gateway now resolves a live runtime owner first and falls back to the durable session key for compatibility.

## Related Issue

Closes #86890

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/terminal_tool.py` - capture and propagate the spawning runtime session for background processes.
- `tools/process_registry.py` - retain the runtime owner on process state and completion notifications.
- `tui_gateway/server.py` - route terminal output and close events by the stable runtime owner before falling back to the durable key.
- `gateway/run.py` - preserve the runtime return address in gateway completion delivery.
- `tests/` - cover ownership across key rotation, completion propagation, and concurrent session isolation.

## How to Test

1. Start a background terminal process in runtime session A and keep runtime session B active.
2. Rotate session A's durable key while the process is running.
3. Verify later output, close, and completion events retain runtime A and no events route to runtime B.
4. Run the targeted Python and Desktop tests:

```bash
scripts/run_tests.sh tests/tui_gateway/test_agent_terminal_routing.py tests/tools/test_notify_on_complete.py tests/tools/test_terminal_task_cwd.py tests/tools/test_terminal_tool_pty_fallback.py tests/gateway/test_completion_delivery.py tests/gateway/test_completion_session_boundary.py
scripts/run_tests.sh tests/test_tui_gateway_server.py -k 'origin_ui_session_id or terminal_output'
cd apps/desktop && npx vitest run src/lib/gateway-events.test.ts
```

The targeted suites passed with 68 Python tests, 1 filtered tui_gateway test, and 8 Desktop tests. REAL_ENV verification on Windows 11 reproduced empty post-rotation ownership on the base revision and confirmed that this branch keeps output, close, and completion events attributed to runtime A while runtime B receives nothing.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this is not a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run the relevant repository test entry points and all targeted tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Relevant documentation updates are N/A because this fixes internal event attribution without changing user-facing configuration or APIs
- [x] `cli-config.yaml.example` updates are N/A because no config keys changed
- [x] `CONTRIBUTING.md` and `AGENTS.md` updates are N/A because no architecture or workflow contract changed
- [x] I've considered cross-platform impact; the routing data is platform-neutral and targeted process tests cover local and environment-backed spawns
- [x] Tool description and schema updates are N/A because the terminal tool contract is unchanged

## Screenshots / Logs

REAL_ENV verification confirmed that the base revision emitted post-rotation output and close events with an empty `session_id`. This branch retained `runtime-a` for output, close, and completion events while a concurrent `runtime-b` session received no events.
