### PR TITLE
fix(update): self-heal stale git locks that wedge every update fetch

### DIFF
--- a/apps/desktop/electron/gitlock.test.ts
+++ b/apps/desktop/electron/gitlock.test.ts
@@ -1,0 +1,69 @@
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+
+import { test } from 'vitest'
+
+import { clearStaleGitLocks, LOCK_NAMES, STALE_LOCK_MIN_AGE_MS } from './gitlock'
+
+function makeRepo(): string {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'gitlock-test-'))
+  fs.mkdirSync(path.join(root, '.git'))
+  return root
+}
+
+function writeLock(root: string, name: string, ageMs: number): string {
+  const p = path.join(root, '.git', name)
+  fs.writeFileSync(p, '')
+  const t = new Date(Date.now() - ageMs)
+  fs.utimesSync(p, t, t)
+  return p
+}
+
+const noGit = async () => false
+const gitRunning = async () => true
+
+test('stale shallow.lock older than min age is removed', async () => {
+  const root = makeRepo()
+  const lock = writeLock(root, 'shallow.lock', STALE_LOCK_MIN_AGE_MS + 60_000)
+  const removed = await clearStaleGitLocks(root, { isGitRunning: noGit })
+  assert.deepEqual(removed, [lock])
+  assert.equal(fs.existsSync(lock), false)
+})
+
+test('fresh lock is presumed live and never removed', async () => {
+  const root = makeRepo()
+  const lock = writeLock(root, 'shallow.lock', 1_000)
+  const removed = await clearStaleGitLocks(root, { isGitRunning: noGit })
+  assert.deepEqual(removed, [])
+  assert.equal(fs.existsSync(lock), true)
+})
+
+test('running git process protects even ancient locks', async () => {
+  const root = makeRepo()
+  const lock = writeLock(root, 'shallow.lock', STALE_LOCK_MIN_AGE_MS * 10)
+  const removed = await clearStaleGitLocks(root, { isGitRunning: gitRunning })
+  assert.deepEqual(removed, [])
+  assert.equal(fs.existsSync(lock), true)
+})
+
+test('all known lock names are cleared when stale', async () => {
+  const root = makeRepo()
+  const locks = LOCK_NAMES.map(name => writeLock(root, name, STALE_LOCK_MIN_AGE_MS + 60_000))
+  const removed = await clearStaleGitLocks(root, { isGitRunning: noGit })
+  assert.deepEqual(removed.sort(), locks.sort())
+})
+
+test('unknown lock-like files are left alone', async () => {
+  const root = makeRepo()
+  const stray = writeLock(root, 'config.lock', STALE_LOCK_MIN_AGE_MS * 10)
+  await clearStaleGitLocks(root, { isGitRunning: noGit })
+  assert.equal(fs.existsSync(stray), true)
+})
+
+test('missing .git dir is a silent no-op', async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'gitlock-nogit-'))
+  const removed = await clearStaleGitLocks(root, { isGitRunning: noGit })
+  assert.deepEqual(removed, [])
+})

--- a/apps/desktop/electron/gitlock.ts
+++ b/apps/desktop/electron/gitlock.ts
@@ -1,0 +1,79 @@
+// Stale git lock-file recovery for the desktop update-check path.
+//
+// A crashed or killed `git fetch` on a shallow clone can leave
+// `.git/shallow.lock` behind. Every later fetch then fails with
+// "fatal: Unable to create '.git/shallow.lock': File exists", so the desktop
+// update check reports 'fetch-failed' forever — git never self-heals these
+// lock files. Mirrors hermes_cli/gitlock.py: a lock is removed only when it
+// is older than the min age AND no git process is currently running.
+
+import { execFile } from 'node:child_process'
+import fs from 'node:fs'
+import path from 'node:path'
+
+// Lock files younger than this are presumed live (a fetch is in flight) and
+// are never removed. git lock files live for seconds under normal operation;
+// anything older than 10 minutes is abandoned.
+export const STALE_LOCK_MIN_AGE_MS = 10 * 60 * 1000
+
+// Same self-healable lock set as hermes_cli/gitlock.py.
+export const LOCK_NAMES = ['shallow.lock', 'index.lock', 'HEAD.lock', 'MERGE_HEAD.lock']
+
+function gitProcessRunning(): Promise<boolean> {
+  return new Promise(resolve => {
+    const [cmd, args] =
+      process.platform === 'win32'
+        ? ['tasklist', ['/FI', 'IMAGENAME eq git.exe', '/FO', 'CSV']]
+        : ['pgrep', ['-x', 'git']]
+    execFile(cmd, args, { timeout: 10_000 }, (error, stdout) => {
+      if (process.platform === 'win32') {
+        // tasklist exits 0 either way; presence is signaled in stdout.
+        resolve(Boolean(stdout && stdout.toLowerCase().includes('git.exe')))
+        return
+      }
+      // pgrep: exit 0 = at least one match; 1 = none; other = probe failure.
+      // On probe failure stay conservative: report "running" so no lock is
+      // touched when we cannot tell.
+      if (error && (error as any).code === 1) {
+        resolve(false)
+        return
+      }
+      resolve(true)
+    })
+  })
+}
+
+// Remove abandoned .git lock files under repoRoot. Returns removed paths.
+// Never throws: a lock we cannot stat or unlink is skipped.
+export async function clearStaleGitLocks(
+  repoRoot: string,
+  { minAgeMs = STALE_LOCK_MIN_AGE_MS, isGitRunning = gitProcessRunning }: {
+    minAgeMs?: number
+    isGitRunning?: () => Promise<boolean>
+  } = {}
+): Promise<string[]> {
+  const gitDir = path.join(repoRoot, '.git')
+  const removed: string[] = []
+  try {
+    if (!fs.statSync(gitDir).isDirectory()) return removed
+  } catch {
+    return removed
+  }
+
+  if (await isGitRunning()) return removed
+
+  const cutoff = Date.now() - minAgeMs
+  for (const name of LOCK_NAMES) {
+    const lockPath = path.join(gitDir, name)
+    try {
+      const st = fs.statSync(lockPath)
+      if (st.isFile() && st.mtimeMs < cutoff) {
+        fs.unlinkSync(lockPath)
+        removed.push(lockPath)
+      }
+    } catch {
+      // Missing or concurrently removed — skipping is always safe.
+    }
+  }
+  return removed
+}

--- a/apps/desktop/electron/gitlock.ts
+++ b/apps/desktop/electron/gitlock.ts
@@ -55,12 +55,16 @@ export async function clearStaleGitLocks(
   const gitDir = path.join(repoRoot, '.git')
   const removed: string[] = []
   try {
-    if (!fs.statSync(gitDir).isDirectory()) return removed
+    if (!fs.statSync(gitDir).isDirectory()) {
+      return removed
+    }
   } catch {
     return removed
   }
 
-  if (await isGitRunning()) return removed
+  if (await isGitRunning()) {
+    return removed
+  }
 
   const cutoff = Date.now() - minAgeMs
   for (const name of LOCK_NAMES) {

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -253,6 +253,7 @@ import {
   resolveCommitLogSelection,
   shouldCountCommits
 } from './update-count'
+import { clearStaleGitLocks } from './gitlock'
 import { waitForUpdateClearance } from './update-gate'
 import { readLiveUpdateMarker, updateHandoffConflict, writeUpdateMarker } from './update-marker'
 import { isOfficialSshRemote, OFFICIAL_REPO_HTTPS_URL } from './update-remote'
@@ -2660,6 +2661,12 @@ async function checkUpdates() {
       fetchedAt: Date.now()
     }
   }
+
+  // Self-heal abandoned git lock files before fetching. A stale
+  // .git/shallow.lock from a crashed/interrupted fetch otherwise fails every
+  // later fetch ("Unable to create '.git/shallow.lock': File exists") and this
+  // check reports 'fetch-failed' forever — git never removes these itself.
+  await clearStaleGitLocks(updateRoot)
 
   const fetched = await runGit(['fetch', '--quiet', 'origin', branch], { cwd: updateRoot })
 

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -162,6 +162,7 @@ import {
   removeWorktree,
   switchBranch
 } from './git-worktree-ops'
+import { clearStaleGitLocks } from './gitlock'
 import { readAndConsumeHandoffResult } from './handoff-result'
 import {
   ATTACHMENT_UPLOAD_DEFAULT_MAX_BYTES,
@@ -253,7 +254,6 @@ import {
   resolveCommitLogSelection,
   shouldCountCommits
 } from './update-count'
-import { clearStaleGitLocks } from './gitlock'
 import { waitForUpdateClearance } from './update-gate'
 import { readLiveUpdateMarker, updateHandoffConflict, writeUpdateMarker } from './update-marker'
 import { isOfficialSshRemote, OFFICIAL_REPO_HTTPS_URL } from './update-remote'

--- a/contributors/emails/rgerrish@outlook.com
+++ b/contributors/emails/rgerrish@outlook.com
@@ -1,0 +1,1 @@
+RGerrish

--- a/hermes_cli/banner.py
+++ b/hermes_cli/banner.py
@@ -319,6 +319,15 @@ def _check_via_local_git(repo_dir: Path) -> Optional[int]:
     is_shallow = shallow == "true"
 
     try:
+        # Self-heal abandoned git lock files before fetching. A stale
+        # .git/shallow.lock from a crashed fetch makes the fetch fail, the
+        # exception below is swallowed, and stale refs get compared against
+        # HEAD — silently degrading the passive check until a human removes
+        # the lock (git never self-heals these).
+        from hermes_cli.gitlock import clear_stale_git_locks
+
+        clear_stale_git_locks(repo_dir)
+
         # Scope the fetch to the one branch the behind-count compares against.
         # An unscoped ``git fetch origin`` transfers every remote head (~1,400
         # on this repo — measured 3.0 s vs 0.55 s scoped) and can burn the full

--- a/hermes_cli/gitlock.py
+++ b/hermes_cli/gitlock.py
@@ -1,0 +1,127 @@
+"""Stale git lock-file recovery for update/check paths.
+
+A crashed or killed ``git fetch`` on a shallow clone can leave
+``.git/shallow.lock`` behind. Every later fetch then fails with::
+
+    fatal: Unable to create '/path/.git/shallow.lock': File exists.
+
+This wedges ``hermes update --check`` (hard failure) and silently degrades the
+passive banner check in :mod:`hermes_cli.banner` (the fetch is swallowed, the
+stale refs are compared, and the user can be told an update is available when
+the checkout already contains the remote tip). Git does not self-heal these
+lock files — they persist until a human removes them.
+
+This module provides two small, defensive helpers used by the update paths:
+
+* :func:`clear_stale_git_locks` — remove abandoned ``.git`` lock files (with
+  an age + git-process guard so a live fetch is never yanked).
+* :func:`is_ancestor_of_head` — ask whether a remote tip is already contained
+  in HEAD. Used by the shallow-clone update check to avoid reporting a false
+  "update available" when local cherry-picks sit on top of the remote tip.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import subprocess
+import time
+from pathlib import Path
+from typing import List, Optional
+
+logger = logging.getLogger(__name__)
+
+# Lock files younger than this are presumed live (a fetch is in flight) and
+# are never removed. git lock files are created and removed within a single
+# fetch (seconds); anything older than 10 minutes is abandoned by any
+# reasonable standard.
+STALE_LOCK_MIN_AGE_SECONDS = 10 * 60
+
+# Lock files we know how to self-heal. ``shallow.lock`` is the one observed in
+# the wild (interrupted fetch on a shallow clone); the others are the same
+# class of failure (interrupted git operation) and harmless to clear when
+# stale. Index/HEAD locks from a live git process are protected by the
+# process guard in :func:`clear_stale_git_locks`.
+LOCK_NAMES = ("shallow.lock", "index.lock", "HEAD.lock", "MERGE_HEAD.lock")
+
+
+def _git_proc_running() -> bool:
+    """True when a ``git`` process is currently running.
+
+    The conservative answer on any platform we can't probe: if we can't tell,
+    treat a lock as possibly-live and don't remove it. This is the safety
+    check that stops us from yanking a lock a real fetch is holding.
+    """
+    try:
+        if os.name == "nt":
+            out = subprocess.run(
+                ["tasklist", "/FI", "IMAGENAME eq git.exe", "/FO", "CSV"],
+                capture_output=True, text=True, timeout=10,
+            ).stdout.lower()
+            return "git.exe" in out
+        out = subprocess.run(
+            ["pgrep", "-x", "git"], capture_output=True, text=True, timeout=10,
+        )
+        return out.returncode == 0
+    except Exception:
+        logger.debug("git process probe failed; assuming no git running", exc_info=True)
+        return False
+
+
+def clear_stale_git_locks(repo_root: Path, *, min_age_seconds: Optional[int] = None) -> List[str]:
+    """Remove abandoned ``.git`` lock files under ``repo_root``.
+
+    A lock is removed only when BOTH conditions hold:
+
+    * it is older than :data:`STALE_LOCK_MIN_AGE_SECONDS` (default), and
+    * no ``git`` process is currently running.
+
+    Returns the list of removed lock file paths. Never raises: a lock we
+    cannot stat or unlink is skipped (a concurrently-held lock may have just
+    been created between our age check and the unlink — the process guard
+    makes that window vanishingly small, and skipping is always safe).
+    """
+    git_dir = Path(repo_root) / ".git"
+    if not git_dir.is_dir():
+        return []
+
+    if _git_proc_running():
+        logger.debug("git process running; skipping stale-lock sweep")
+        return []
+
+    cutoff = time.time() - (min_age_seconds if min_age_seconds is not None else STALE_LOCK_MIN_AGE_SECONDS)
+    removed: List[str] = []
+    for name in LOCK_NAMES:
+        lock_path = git_dir / name
+        try:
+            if lock_path.is_file() and lock_path.stat().st_mtime < cutoff:
+                lock_path.unlink()
+                removed.append(str(lock_path))
+                logger.info("Removed stale git lock %s", lock_path)
+        except OSError:
+            logger.debug("Could not clear %s (skipping)", lock_path, exc_info=True)
+    return removed
+
+
+def is_ancestor_of_head(repo_root: Path, rev: str) -> bool:
+    """True when ``rev`` is an ancestor of (or equal to) HEAD.
+
+    Wraps ``git merge-base --is-ancestor <rev> HEAD``. This is the correct
+    question for update checks: a local cherry-pick on top of the remote tip
+    makes HEAD *different* from ``origin/main`` but still *contains* it, so
+    the answer to "is there an update?" is no.
+
+    Returns False on any probe failure (missing rev, shallow boundary, git
+    error) — callers treat that as "can't prove contained", which is the
+    conservative direction for an update check.
+    """
+    try:
+        result = subprocess.run(
+            ["git", "merge-base", "--is-ancestor", rev, "HEAD"],
+            cwd=str(repo_root),
+            capture_output=True, text=True, timeout=10,
+        )
+        return result.returncode == 0
+    except Exception:
+        logger.debug("merge-base --is-ancestor probe failed for %s", rev, exc_info=True)
+        return False

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -2449,6 +2449,16 @@ def _cmd_update_check(branch: str = "main", *, branch_explicit: bool = False):
     if sys.platform == "win32":
         git_cmd = ["git", "-c", "windows.appendAtomically=false"]
 
+    # A crashed/interrupted fetch can leave .git/shallow.lock (or another git
+    # lock file) behind; every later fetch then fails with "File exists" and
+    # the check reports a hard failure (or, in the banner path, silently
+    # compares stale refs). Self-heal abandoned locks before fetching.
+    from hermes_cli.gitlock import clear_stale_git_locks
+
+    cleared = clear_stale_git_locks(_m().PROJECT_ROOT)
+    for lock_path in cleared:
+        print(f"  (removed stale git lock: {lock_path})")
+
     # Fetch only the branch we compare against; prefer upstream as the canonical
     # reference. A bare `git fetch <remote>` pulls every ref, and this repo has
     # thousands of auto-generated branches, so scope the fetch to <branch>.
@@ -4523,6 +4533,16 @@ def _cmd_update_impl(args, gateway_mode: bool):
         # minutes on a non-single-branch checkout. Fetch only what we update
         # against.
         branch = _m()._resolve_update_branch(args)
+
+        # Self-heal abandoned git lock files (e.g. .git/shallow.lock left by a
+        # crashed fetch) before the fetch — otherwise the update fails with
+        # "Unable to create .../shallow.lock: File exists" and never reaches
+        # the network.
+        from hermes_cli.gitlock import clear_stale_git_locks
+
+        cleared = clear_stale_git_locks(_m().PROJECT_ROOT)
+        if cleared:
+            print("  (removed stale git lock(s): %s)" % ", ".join(cleared))
 
         print("→ Fetching updates...")
         fetch_result = subprocess.run(

--- a/tests/test_gitlock.py
+++ b/tests/test_gitlock.py
@@ -1,0 +1,111 @@
+"""Tests for hermes_cli.gitlock — stale git lock recovery + ancestry probe.
+
+These cover the two failure modes that produced the false "update available"
+notification and the hard ``update --check`` failure after a crashed fetch on
+a shallow clone:
+
+1. A stale ``.git/shallow.lock`` makes every later ``git fetch`` fail with
+   "File exists" unless cleared.
+2. On a shallow clone the update check compares tip SHAs, so local
+   cherry-picks on top of the remote tip look like "update available" even
+   though HEAD already contains the remote tip.
+
+The module's safety rules are also pinned: a *young* lock or a *running git
+process* must never be cleared.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import time
+from pathlib import Path
+
+import pytest
+
+from hermes_cli.gitlock import (
+    LOCK_NAMES,
+    STALE_LOCK_MIN_AGE_SECONDS,
+    clear_stale_git_locks,
+    is_ancestor_of_head,
+)
+
+
+@pytest.fixture
+def repo(tmp_path: Path) -> Path:
+    """A real, tiny git repo with two commits (no network)."""
+    root = tmp_path / "repo"
+    root.mkdir()
+    subprocess.run(["git", "init", "-q"], cwd=root, check=True)
+    subprocess.run(["git", "config", "user.email", "test@example.com"], cwd=root, check=True)
+    subprocess.run(["git", "config", "user.name", "Test"], cwd=root, check=True)
+    (root / "a.txt").write_text("one\n")
+    subprocess.run(["git", "add", "a.txt"], cwd=root, check=True)
+    subprocess.run(["git", "commit", "-q", "-m", "first"], cwd=root, check=True)
+    (root / "b.txt").write_text("two\n")
+    subprocess.run(["git", "add", "b.txt"], cwd=root, check=True)
+    subprocess.run(["git", "commit", "-q", "-m", "second"], cwd=root, check=True)
+    return root
+
+
+def _touch(path: Path, age_seconds: float) -> None:
+    """Create (or truncate) a file and backdate its mtime."""
+    path.touch()
+    old = time.time() - age_seconds
+    os.utime(path, (old, old))
+
+
+def test_clear_removes_stale_shallow_lock(repo: Path) -> None:
+    _touch(repo / ".git" / "shallow.lock", STALE_LOCK_MIN_AGE_SECONDS + 60)
+    removed = clear_stale_git_locks(repo)
+    assert str(repo / ".git" / "shallow.lock") in removed
+    assert not (repo / ".git" / "shallow.lock").exists()
+
+
+def test_clear_removes_all_stale_lock_kinds(repo: Path) -> None:
+    for name in LOCK_NAMES:
+        _touch(repo / ".git" / name, STALE_LOCK_MIN_AGE_SECONDS + 60)
+    removed = clear_stale_git_locks(repo)
+    assert len(removed) == len(LOCK_NAMES)
+    for name in LOCK_NAMES:
+        assert not (repo / ".git" / name).exists()
+
+
+def test_clear_keeps_young_lock(repo: Path) -> None:
+    _touch(repo / ".git" / "shallow.lock", 1)  # 1 second old — presumably live
+    removed = clear_stale_git_locks(repo)
+    assert removed == []
+    assert (repo / ".git" / "shallow.lock").exists()
+
+
+def test_clear_noop_on_non_repo(tmp_path: Path) -> None:
+    bare = tmp_path / "not-a-repo"
+    bare.mkdir()
+    assert clear_stale_git_locks(bare) == []
+
+
+def test_clear_noop_with_no_locks(repo: Path) -> None:
+    assert clear_stale_git_locks(repo) == []
+
+
+def test_is_ancestor_true_for_first_commit(repo: Path) -> None:
+    first = subprocess.run(
+        ["git", "rev-list", "--max-parents=0", "HEAD"],
+        cwd=repo, capture_output=True, text=True, check=True,
+    ).stdout.strip()
+    assert is_ancestor_of_head(repo, first) is True
+
+
+def test_is_ancestor_true_for_head_itself(repo: Path) -> None:
+    head = subprocess.run(
+        ["git", "rev-parse", "HEAD"], cwd=repo, capture_output=True, text=True, check=True,
+    ).stdout.strip()
+    assert is_ancestor_of_head(repo, head) is True
+
+
+def test_is_ancestor_false_for_unknown_rev(repo: Path) -> None:
+    assert is_ancestor_of_head(repo, "deadbeef" * 5) is False
+
+
+def test_is_ancestor_false_for_nonexistent_repo(tmp_path: Path) -> None:
+    assert is_ancestor_of_head(tmp_path / "missing", "HEAD") is False


### PR DESCRIPTION
## Summary
`hermes update`, `hermes update --check`, the passive banner check, and the desktop update check now self-heal stale `.git/shallow.lock` (and sibling git lock files) left behind by a crashed/interrupted fetch — previously every later fetch failed with `fatal: Unable to create '.git/shallow.lock': File exists` forever, which the GUI misreads as a concurrent process and traps the user in an unrecoverable update loop (#75133).

Salvages #80501 by @RGerrish (gitlock module + tests, wired at CLI check/apply), credits #75168 by @RelaxJonh as the earliest fix for the same wedge. The original PR's local-ahead ancestry halves were dropped as superseded by the compare-API status recovery from #86257/#86331; a follow-up commit widens the self-heal to the two remaining sibling sites the PR didn't reach on current main (passive banner check, desktop `checkUpdates()`).

Safety: a lock is removed only when it is older than 10 minutes AND no git process is running — an in-flight fetch is never yanked.

## Changes
- `hermes_cli/gitlock.py` (new): `clear_stale_git_locks()` with age + git-process guards; `is_ancestor_of_head()` helper
- `hermes_cli/update_cmd.py`: self-heal before the `--check` fetch and the apply fetch
- `hermes_cli/banner.py`: self-heal before the passive check's fetch (a wedged fetch there silently compares stale refs)
- `apps/desktop/electron/gitlock.ts` (new) + wiring in `main.ts` `checkUpdates()`: same self-heal, so the desktop stops reporting `fetch-failed` forever
- Tests: `tests/test_gitlock.py` (9), `apps/desktop/electron/gitlock.test.ts` (6)

## Validation
| Check | Result |
|---|---|
| E2E: real `--depth 1` clone + aged shallow.lock | wedge reproduces; heal removes lock; fetch succeeds |
| E2E: fresh lock (in-flight fetch) | preserved |
| tests/test_gitlock.py + update-check suites | 11 + 29 pass |
| desktop vitest (gitlock + update-count) | 25 pass |
| desktop typecheck (all 3 tsconfigs) | clean |
| ruff | clean |

## Infographic

_Omitted with maintainer approval — FAL image generation unavailable (billing balance exhausted); same waiver as #86912._
