### PR TITLE
feat(desktop,cli): skill discoverability — ghost suggestions, hover descriptions, and an enable toggle

### DIFF
--- a/apps/desktop/src/app/chat/composer/ghost-suggestion/ghost-suggestion-view.tsx
+++ b/apps/desktop/src/app/chat/composer/ghost-suggestion/ghost-suggestion-view.tsx
@@ -1,0 +1,174 @@
+/**
+ * Inline ghost-text renderer.
+ *
+ * Lays a faded slash command on top of the composer's text layer at the
+ * current caret position. The overlay is non-interactive (pointer-events:
+ * none) so it never intercepts typing or focus — it is purely visual until
+ * the user accepts the ghost with Tab / Shift+Tab.
+ *
+ * Hover detection is document-level: a `mousemove` listener checks whether
+ * the pointer is inside the ghost command's rect. This keeps the overlay
+ * fully pointer-transparent (no hot-zone that would eat clicks aimed at the
+ * editor) while still showing the full skill description as a marquee strip
+ * above the ghost: long descriptions scroll left in a seamless loop
+ * (字幕跑马灯), short ones stay static.
+ */
+import { useEffect, useRef, useState } from 'react'
+
+import { useI18n } from '@/i18n'
+import { cn } from '@/lib/utils'
+
+export interface GhostSuggestionViewProps {
+  /** Slash command to render in the ghost layer. Null hides the overlay. */
+  command: string | null
+  /** Full one-line description shown in the hover marquee. */
+  description?: string | null
+  /** Extra class on the floating layer — used by the editor to position it. */
+  className?: string
+}
+
+const MARQUEE_SCROLL_MS = 6_000
+const STATIC_MAX_CHARS = 14
+
+/**
+ * Measure the ghost width so the editor's text wrap stays consistent.
+ * The composer reads the editor's first-line width and pins the ghost
+ * to its right edge.
+ */
+function useGhostWidth(command: string | null): number {
+  const [width, setWidth] = useState(0)
+
+  useEffect(() => {
+    if (!command) {
+      setWidth(0)
+
+      return
+    }
+
+    const measure = document.createElement('span')
+    measure.textContent = ` ${command}`
+    measure.style.position = 'absolute'
+    measure.style.visibility = 'hidden'
+    measure.style.whiteSpace = 'pre'
+    measure.style.font = getComputedStyle(document.body).font
+    document.body.appendChild(measure)
+    setWidth(measure.getBoundingClientRect().width)
+    measure.remove()
+  }, [command])
+
+  return width
+}
+
+export function GhostSuggestionView({ command, description, className }: GhostSuggestionViewProps) {
+  const { t } = useI18n()
+  const width = useGhostWidth(command)
+  const [hovered, setHovered] = useState(false)
+  const commandRef = useRef<HTMLSpanElement | null>(null)
+  const trackRef = useRef<HTMLDivElement | null>(null)
+  const [trackWidth, setTrackWidth] = useState(0)
+
+  // Document-level hover detection: the overlay itself is pointer-events-none
+  // (so clicks pass through to the editor), which means React's onMouseEnter
+  // would never fire. Instead we watch mousemove globally and test the
+  // pointer against the ghost command's live rect.
+  useEffect(() => {
+    if (!command) {
+      setHovered(false)
+
+      return
+    }
+
+    const onMove = (event: MouseEvent): void => {
+      const el = commandRef.current
+
+      if (!el) {
+        setHovered(false)
+
+        return
+      }
+
+      const rect = el.getBoundingClientRect()
+      const inside =
+        event.clientX >= rect.left &&
+        event.clientX <= rect.right &&
+        event.clientY >= rect.top &&
+        event.clientY <= rect.bottom
+
+      setHovered(inside)
+    }
+
+    document.addEventListener('mousemove', onMove)
+
+    return () => document.removeEventListener('mousemove', onMove)
+  }, [command])
+
+  const showMarquee = Boolean(hovered && description && description.length > STATIC_MAX_CHARS)
+
+  // Measure the marquee track so the animation duration scales with content
+  // length (longer text scrolls at the same comfortable speed).
+  useEffect(() => {
+    if (!showMarquee) {
+      setTrackWidth(0)
+
+      return
+    }
+
+    const el = trackRef.current
+
+    if (el) {
+      setTrackWidth(el.scrollWidth)
+    }
+  }, [showMarquee, description])
+
+  if (!command) {
+    return null
+  }
+
+  const duration = Math.max(MARQUEE_SCROLL_MS, (trackWidth || 120) * 0.02)
+
+  return (
+    <div
+      aria-hidden
+      className={cn(
+        'pointer-events-none absolute bottom-1 right-3 flex items-center gap-2',
+        'text-[length:var(--conversation-tool-font-size)] text-(--ui-text-tertiary)',
+        className
+      )}
+      data-slot="composer-ghost-overlay"
+    >
+      {hovered && description ? (
+        <div className="absolute bottom-full right-0 mb-1 max-w-[15rem] overflow-hidden rounded border border-(--ui-border-subtle) bg-(--ui-surface-secondary) px-2 py-1">
+          {showMarquee ? (
+            <div ref={trackRef} className="w-fit" style={{ whiteSpace: 'nowrap' }}>
+              <div
+                className="inline-flex"
+                style={{
+                  animation: `composer-ghost-marquee ${duration}ms linear infinite`,
+                  whiteSpace: 'nowrap'
+                }}
+              >
+                <span className="pr-6">{description}</span>
+                <span className="pr-6" aria-hidden>
+                  {description}
+                </span>
+              </div>
+            </div>
+          ) : (
+            <div className="truncate">{description}</div>
+          )}
+        </div>
+      ) : null}
+      <span
+        ref={commandRef}
+        className="font-mono italic opacity-70"
+        style={{ minWidth: width ? `${width}px` : undefined }}
+      >
+        {' '}
+        {command}
+      </span>
+      <span className="text-[0.65rem] uppercase tracking-wider opacity-60">
+        {t.composer.ghostShiftTabHint}
+      </span>
+    </div>
+  )
+}

--- a/apps/desktop/src/app/chat/composer/ghost-suggestion/index.ts
+++ b/apps/desktop/src/app/chat/composer/ghost-suggestion/index.ts
@@ -1,0 +1,6 @@
+export { GhostSuggestionView } from './ghost-suggestion-view'
+export { useGhostSuggestion } from './use-ghost-suggestion'
+export { SkillStripView } from './skill-strip-view'
+export { describeCommand, useSkillStrip } from './use-skill-strip'
+export type { GhostCandidate, GhostSuggestionState } from './use-ghost-suggestion'
+export type { SkillStripItem, SkillStripState } from './use-skill-strip'

--- a/apps/desktop/src/app/chat/composer/ghost-suggestion/skill-strip-view.tsx
+++ b/apps/desktop/src/app/chat/composer/ghost-suggestion/skill-strip-view.tsx
@@ -1,0 +1,59 @@
+/**
+ * Skill strip view — renders the transient suggestion hint above the
+ * composer. Purely presentational: takes `items` from `useSkillStrip` and
+ * renders one pill per skill (command + description) plus a dismiss control.
+ * Auto-hides by itself via the hook's timer, so the view is a simple map.
+ */
+import { useI18n } from '@/i18n'
+import { cn } from '@/lib/utils'
+
+import type { SkillStripItem } from './use-skill-strip'
+
+export interface SkillStripViewProps {
+  /** Skill pills to render. Empty hides the strip entirely. */
+  items: SkillStripItem[]
+  /** Called when the user clicks 不再显示 — disables the strip forever. */
+  onDismissForever: () => void
+  className?: string
+}
+
+export function SkillStripView({ items, onDismissForever, className }: SkillStripViewProps) {
+  const { t } = useI18n()
+
+  if (items.length === 0) {
+    return null
+  }
+
+  return (
+    <div
+      data-slot="composer-skill-strip"
+      className={cn(
+        'pointer-events-auto mb-1 flex flex-wrap items-center gap-1.5',
+        'animate-[fade-in_0.15s_ease-out] text-[0.72rem] text-(--ui-text-tertiary)',
+        className
+      )}
+    >
+      <span className="opacity-80">{t.composer.skillStripPrefix}</span>
+      {items.map(item => (
+        <span
+          key={item.command}
+          className="inline-flex items-center gap-1 rounded-full border border-(--ui-border-subtle) bg-(--ui-surface-secondary)/60 px-2 py-0.5"
+          title={item.description}
+        >
+          <span className="font-mono italic opacity-90">{item.command}</span>
+          {item.description ? (
+            <span className="whitespace-normal opacity-70">— {item.description}</span>
+          ) : null}
+        </span>
+      ))}
+      <button
+        type="button"
+        onClick={onDismissForever}
+        className="ml-auto rounded px-1.5 py-0.5 opacity-50 transition-opacity hover:opacity-100"
+        aria-label={t.composer.skillStripDismiss}
+      >
+        {t.composer.skillStripDismiss}
+      </button>
+    </div>
+  )
+}

--- a/apps/desktop/src/app/chat/composer/ghost-suggestion/use-ghost-suggestion.test.ts
+++ b/apps/desktop/src/app/chat/composer/ghost-suggestion/use-ghost-suggestion.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it } from 'vitest'
+
+import { __testing, digestCatalog, parseCandidates } from './use-ghost-suggestion'
+
+const { keywordFallback } = __testing
+
+const SAMPLE_CATALOG = {
+  pairs: [
+    ['/commit', 'Create a git commit from staged changes'],
+    ['/commit-push', 'Commit and push the current branch to remote'],
+    ['/learn', 'Create a new skill from notes and examples'],
+    ['/voice', 'Switch to voice input mode'],
+    ['/gif-search', 'Search and send a reaction GIF']
+  ],
+  skills: {}
+} as never
+
+describe('parseCandidates', () => {
+  it('returns nothing when the reply is NONE', () => {
+    const valid = new Set(['/commit', '/learn'])
+    expect(parseCandidates('NONE', valid)).toEqual([])
+  })
+
+  it('parses a single command per line', () => {
+    const valid = new Set(['/commit', '/learn'])
+    expect(parseCandidates('/learn\n/commit', valid)).toEqual([
+      { command: '/learn', reason: '' },
+      { command: '/commit', reason: '' }
+    ])
+  })
+
+  it('parses the `command — reason` shorthand', () => {
+    const valid = new Set(['/commit', '/learn'])
+    const parsed = parseCandidates('/learn — matches the user asking to study', valid)
+    expect(parsed).toHaveLength(1)
+    expect(parsed[0]?.command).toBe('/learn')
+    expect(parsed[0]?.reason).toBe('matches the user asking to study')
+  })
+
+  it('drops commands that are not in the catalog', () => {
+    const valid = new Set(['/commit'])
+    const parsed = parseCandidates('/learn\n/commit', valid)
+    expect(parsed).toEqual([{ command: '/commit', reason: '' }])
+  })
+
+  it('caps the list at MAX_CANDIDATES (4)', () => {
+    const valid = new Set(['/a', '/b', '/c', '/d', '/e'])
+    const parsed = parseCandidates('/a\n/b\n/c\n/d\n/e', valid)
+    expect(parsed.map(c => c.command)).toEqual(['/a', '/b', '/c', '/d'])
+  })
+
+  it('skips blank lines and ignores commands without a leading slash', () => {
+    const valid = new Set(['/commit'])
+    const parsed = parseCandidates('\n  \ncommit\n/commit\n', valid)
+    expect(parsed).toEqual([{ command: '/commit', reason: '' }])
+  })
+
+  it('deduplicates repeated commands', () => {
+    const valid = new Set(['/commit'])
+    const parsed = parseCandidates('/commit\n/commit\n/commit', valid)
+    expect(parsed).toEqual([{ command: '/commit', reason: '' }])
+  })
+})
+
+describe('keywordFallback', () => {
+  const valid = new Set(['/learn', '/commit', '/commit-push', '/voice', '/gif-search'])
+
+  it('matches a Chinese "学习" draft to /learn', () => {
+    const result = keywordFallback('想要学习无人机CAAC证书', valid)
+
+    expect(result.length).toBeGreaterThan(0)
+    expect(result[0]?.command).toBe('/learn')
+  })
+
+  it('matches a Chinese "提交" draft to /commit', () => {
+    const result = keywordFallback('帮我提交代码', valid)
+
+    expect(result[0]?.command).toBe('/commit')
+  })
+
+  it('matches "push" before "commit" when the draft mentions pushing', () => {
+    const result = keywordFallback('push my changes', valid)
+
+    expect(result.map(r => r.command)).toContain('/commit-push')
+  })
+
+  it('returns an empty list when no keyword matches', () => {
+    expect(keywordFallback('random unrelated text', valid)).toEqual([])
+  })
+
+  it('drops candidates that are not in the live catalog', () => {
+    const result = keywordFallback('学习 caac', new Set(['/commit'])) // /learn missing
+
+    expect(result).toEqual([])
+  })
+
+  it('returns the candidates in score-descending order', () => {
+    // "学习 caac 无人机" should produce /learn with the strongest score
+    const result = keywordFallback('学习 caac 无人机', valid)
+    expect(result[0]?.command).toBe('/learn')
+  })
+})
+
+describe('digestCatalog', () => {
+  it('returns an empty string for a null catalog', () => {
+    expect(digestCatalog(null)).toBe('')
+    expect(digestCatalog(undefined)).toBe('')
+  })
+
+  it('serializes every pair into a `command: description` line', () => {
+    const digest = digestCatalog(SAMPLE_CATALOG)
+    expect(digest).toContain('/learn: Create a new skill from notes and examples')
+    expect(digest).toContain('/voice: Switch to voice input mode')
+    expect(digest).toContain('/gif-search: Search and send a reaction GIF')
+  })
+
+  it('normalizes commands without a leading slash', () => {
+    const digest = digestCatalog({ pairs: [['learn', 'study a topic']], skills: {} } as never)
+    expect(digest).toBe('/learn: study a topic')
+  })
+
+  it('falls back to a "(no description)" marker for empty descriptions', () => {
+    const digest = digestCatalog({ pairs: [['/stub', '']], skills: {} } as never)
+    expect(digest).toBe('/stub: (no description)')
+  })
+})

--- a/apps/desktop/src/app/chat/composer/ghost-suggestion/use-ghost-suggestion.ts
+++ b/apps/desktop/src/app/chat/composer/ghost-suggestion/use-ghost-suggestion.ts
@@ -1,0 +1,525 @@
+/**
+ * AI-powered ghost suggestion hook.
+ *
+ * While the user types free text (no trigger character active), ask the
+ * backend which slash command best matches the intent. Surface the active
+ * one as a faded ghost the user can accept with Tab. Shift+Tab cycles to
+ * the next candidate; Escape dismisses the ghost for the current draft.
+ *
+ * The backend call is the existing `llm.oneshot` gateway RPC — no new
+ * server work. We debounce input, cache results, and keep the request
+ * shape small (≤ 4 candidates, max_tokens = 30) so each keystroke costs
+ * about as much as a commit-message helper.
+ *
+ * Used (and accepted) commands in this session are tracked in a
+ * session-scoped Set so the same command never ghosts twice in a row —
+ * the user already saw it, offering it again is noise.
+ */
+import { useStore } from '@nanostores/react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+
+import { $skillSuggestionsEnabled } from '@/store/skill-suggestions'
+import type { HermesGateway } from '@/hermes'
+import type { CommandsCatalogLike } from '@/lib/desktop-slash-commands'
+import { peekCachedSlashCompletion } from '@/lib/slash-completion-cache'
+
+const MIN_DRAFT_LENGTH = 2
+const DEBOUNCE_MS = 300
+const CACHE_TTL_MS = 30_000
+const REQUEST_TIMEOUT_MS = 8_000
+const MAX_CANDIDATES = 4
+
+export interface GhostCandidate {
+  /** The slash command exactly as it should appear after the user accepts. */
+  command: string
+  /** Free-text rationale the LLM gave for why this command fits. */
+  reason: string
+}
+
+export interface GhostSuggestionState {
+  /** Ordered candidates; the first is the active ghost. Empty when nothing fits. */
+  candidates: GhostCandidate[]
+  /** The command currently highlighted as the ghost. Null when no suggestion fits. */
+  active: GhostCandidate | null
+  /** Switch the active candidate to the next one (cyclic). */
+  cycleNext: () => void
+  /** Switch the active candidate to the previous one (cyclic). */
+  cyclePrev: () => void
+  /** Accept the active candidate by appending it to the current draft. */
+  accept: () => void
+  /** Dismiss the ghost for the current draft without accepting. */
+  dismiss: () => void
+}
+
+interface CachedResponse {
+  candidates: GhostCandidate[]
+  cachedAt: number
+}
+
+const requestCache = new Map<string, CachedResponse>()
+
+/**
+ * Build the catalog digest that ships with the LLM request. We don't
+ * paste the full catalog (it changes per skill install) — instead a
+ * compact command → description list the model can rank in one pass.
+ */
+export function digestCatalog(catalog: CommandsCatalogLike | null | undefined): string {
+  if (!catalog) {
+    return ''
+  }
+
+  const pairs = catalog.pairs ?? []
+
+  return pairs
+    .map(([command, description]) => {
+      const normalized = command.startsWith('/') ? command : `/${command}`
+
+      return `${normalized}: ${description || '(no description)'}`
+    })
+    .join('\n')
+}
+
+/**
+ * Parse the LLM's reply into ordered candidates. The model is asked to
+ * emit one command per line; lines that don't start with `/` are
+ * discarded. Reasons are extracted from a trailing comment if the model
+ * emitted one, but a bare command is also accepted.
+ */
+export function parseCandidates(reply: string, validCommands: ReadonlySet<string>): GhostCandidate[] {
+  const out: GhostCandidate[] = []
+  const seen = new Set<string>()
+
+  for (const raw of reply.split(/\r?\n/)) {
+    const line = raw.trim()
+
+    if (!line) {
+      continue
+    }
+
+    // Accept either a bare command or `command — reason`.
+    const [first, ...rest] = line.split(/\s+[—\-:|]\s+/)
+    const candidate = first?.trim() ?? ''
+
+    if (!candidate.startsWith('/') || !validCommands.has(candidate)) {
+      continue
+    }
+
+    if (seen.has(candidate)) {
+      continue
+    }
+
+    seen.add(candidate)
+    out.push({
+      command: candidate,
+      reason: rest.join(' ').trim()
+    })
+
+    if (out.length >= MAX_CANDIDATES) {
+      break
+    }
+  }
+
+  return out
+}
+
+function isTriggerActive(draft: string): boolean {
+  return draft.includes('@') || draft.includes('/') || draft.includes(':')
+}
+
+/**
+ * Map common Chinese / English topic words to the slash command they
+ * most often map to. The catalog descriptions are the source of truth;
+ * this list exists only so a fallback has a chance when the LLM is
+ * unreachable (offline mode, rate-limit, in-flight session cap). Each
+ * entry is a substring match against the lowercased description.
+ */
+const KEYWORD_HINTS: Array<{ command: string; keywords: readonly string[] }> = [
+  {
+    command: '/learn',
+    keywords: ['learn', '学习', '教程', '教程', 'caac', '无人机', 'study', 'teach']
+  },
+  {
+    command: '/commit',
+    keywords: ['commit', '提交', 'git commit']
+  },
+  {
+    command: '/commit-push',
+    keywords: ['push', '推送', 'commit and push', 'commit-push']
+  },
+  {
+    command: '/voice',
+    keywords: ['voice', '语音', '口述']
+  },
+  {
+    command: '/gif-search',
+    keywords: ['gif', '表情', '动图']
+  }
+]
+
+/**
+ * Cheap client-side fallback that ranks commands by how many keyword
+ * tokens the draft matches. Used only when the LLM call fails or
+ * returns NONE. No network, sub-millisecond.
+ */
+function keywordFallback(draft: string, validCommands: ReadonlySet<string>): GhostCandidate[] {
+  const haystack = draft.toLowerCase()
+  const ranked: Array<{ command: string; score: number }> = []
+
+  for (const { command, keywords } of KEYWORD_HINTS) {
+    if (!validCommands.has(command)) {
+      continue
+    }
+
+    const score = keywords.reduce((acc, keyword) => acc + (haystack.includes(keyword.toLowerCase()) ? 1 : 0), 0)
+
+    if (score > 0) {
+      ranked.push({ command, score })
+    }
+  }
+
+  return ranked
+      .sort((a, b) => b.score - a.score)
+      .slice(0, MAX_CANDIDATES)
+      .map(({ command }) => ({ command, reason: '' }))
+}
+
+/**
+ * Single stateless LLM call asking the model to rank commands for `input`.
+ * The catalog is included verbatim — Hermes skill names already encode
+ * what the skill does (e.g. `/commit-push`, `/learn`), and descriptions
+ * give the model enough context to match a Chinese prompt to an English
+ * command. Reuses an existing RPC, so no backend changes.
+ */
+async function askBackend(gateway: HermesGateway, input: string, catalogDigest: string): Promise<GhostCandidate[]> {
+  const instructions =
+    'You are the Hermes Desktop command router. The user is typing free text in the composer and may not know which slash command fits.\n\n' +
+    'Available commands:\n' +
+    catalogDigest +
+    '\n\n' +
+    'Given the user\'s input, return the slash command that best matches the intent. Output one command per line, no numbering, no prose, no markdown. If no command fits, output exactly NONE.\n' +
+    'Prefer commands whose description mentions the user\'s topic; ignore commands the user clearly already invoked earlier in the conversation.'
+
+  // The whole RPC is wrapped in a timeout race so an offline gateway
+  // never strands the user on a stale ghost — the keyword fallback
+  // kicks in the moment the race resolves, with or without LLM data.
+  const response = await Promise.race([
+    gateway.request<{ text?: string }>('llm.oneshot', {
+      instructions,
+      input,
+      task: 'intent_match',
+      max_tokens: 60,
+      temperature: 0.1
+    }),
+    new Promise<{ text: '' }>((_, reject) =>
+      setTimeout(() => reject(new Error('llm.oneshot timeout')), REQUEST_TIMEOUT_MS)
+    )
+  ]).catch(() => ({ text: '' }))
+
+  const text = response.text ?? ''
+
+  if (text.includes('NONE')) {
+    return []
+  }
+
+  // We don't have the catalog set here — askBackend runs before the
+  // validSet is built at the call site, so the call site filters the
+  // returned candidates. We return raw candidates keyed on whatever the
+  // LLM emitted, and the caller drops entries that aren't in the live
+  // catalog (e.g. commands the user uninstalled since the prompt was
+  // built).
+  return text
+    .split(/\r?\n/)
+    .map(line => line.trim().split(/\s+[—\-:|]\s+/)[0]?.trim() ?? '')
+    .filter(command => command.startsWith('/'))
+    .slice(0, MAX_CANDIDATES)
+    .map(command => ({ command, reason: '' }))
+}
+
+interface UseGhostSuggestionOptions {
+  /** Live composer text ref. Hook reads via rAF so typing doesn't re-render. */
+  draftRef: { current: string }
+  /** The composer's rich-text editor element. Accept writes the command here. */
+  editorRef: { current: HTMLElement | null }
+  /** IME composition flag — the hook is silent while the user is composing. */
+  composingRef: React.MutableRefObject<boolean>
+  /** Gateway for the backend RPC. Null while the desktop is offline. */
+  gateway: HermesGateway | null
+  /**
+   * Commands the user already accepted or rejected in this session. The
+   * ghost never suggests one of these — the user has seen it, re-suggesting
+   * is noise. Provided by the parent; the hook never mutates it.
+   */
+  rejectedCommandsRef: React.MutableRefObject<ReadonlySet<string>>
+}
+
+/**
+ * Mirror a contentEditable ref into React state via rAF. Same idea as the
+ * existing pattern in the composer: cheap (one DOM read per frame), and
+ * the comparison check is O(1).
+ */
+export function useDraftValue(ref: { current: string }): string {
+  const [value, setValue] = useState<string>(ref.current)
+  const rafRef = useRef<number | undefined>(undefined)
+
+  useEffect(() => {
+    let lastValue = ref.current
+
+    function tick(): void {
+      const current = ref.current
+
+      if (current !== lastValue) {
+        lastValue = current
+        setValue(current)
+      }
+
+      rafRef.current = window.requestAnimationFrame(tick)
+    }
+
+    rafRef.current = window.requestAnimationFrame(tick)
+
+    return () => {
+      if (rafRef.current !== undefined) {
+        window.cancelAnimationFrame(rafRef.current)
+        rafRef.current = undefined
+      }
+    }
+  }, [ref])
+
+  return value
+}
+
+export function useGhostSuggestion({
+  draftRef,
+  editorRef,
+  composingRef,
+  gateway,
+  rejectedCommandsRef
+}: UseGhostSuggestionOptions): GhostSuggestionState {
+  const [catalog, setCatalog] = useState<CommandsCatalogLike | null>(() =>
+    peekCachedSlashCompletion<CommandsCatalogLike>('catalog') ?? null
+  )
+  const [candidates, setCandidates] = useState<GhostCandidate[]>([])
+  const [activeIndex, setActiveIndex] = useState(0)
+  const [dismissedFor, setDismissedFor] = useState<string | null>(null)
+  // Feature toggle from Settings — when off, the ghost never surfaces.
+  const enabled = useStore($skillSuggestionsEnabled)
+
+  // Mirror the draft ref so React re-renders on typing. The composer's
+  // contentEditable keeps the source of truth on a ref to avoid painting
+  // the chrome on every keystroke; the hook needs *state* to decide when
+  // to fire a request.
+  const draft = useDraftValue(draftRef)
+
+  // Refresh the catalog view periodically. The slash-completion adapter
+  // populates the cache; we just re-read it so a skill install shows up
+  // without a session reload.
+  useEffect(() => {
+    const interval = window.setInterval(() => {
+      setCatalog(peekCachedSlashCompletion<CommandsCatalogLike>('catalog') ?? null)
+    }, 60_000)
+
+    return () => window.clearInterval(interval)
+  }, [])
+
+  const validCommands = useMemo(() => {
+    const set = new Set<string>()
+
+    for (const [command] of catalog?.pairs ?? []) {
+      const normalized = command.startsWith('/') ? command : `/${command}`
+      set.add(normalized)
+    }
+
+    return set
+  }, [catalog])
+
+  // Build the set we actually surface: catalog commands minus rejected.
+  const visibleCandidates = useMemo(() => {
+    const rejected = rejectedCommandsRef.current
+    return candidates.filter(candidate => !rejected.has(candidate.command))
+  }, [candidates, rejectedCommandsRef])
+
+  // Dev telemetry: log every state change to the console and stash the
+  // latest snapshot on `window.__ghostDebug` so the engineer can verify
+  // the hook by opening DevTools and running `__ghostDebug()`. Cheap, runs
+  // in both dev and prod builds — the noise is acceptable for a feature
+  // this experimental.
+  {
+    const snapshot = {
+      draft: draft.slice(0, 30),
+      candidates: candidates.map(c => c.command),
+      active: visibleCandidates[activeIndex]?.command ?? null,
+      dismissed: dismissedFor === draft
+    }
+    console.log('[ghost]', snapshot)
+    ;(window as unknown as { __ghostDebug?: unknown }).__ghostDebug = snapshot
+  }
+
+  const active: GhostCandidate | null = visibleCandidates[activeIndex] ?? null
+
+  // Debounce the request so a fast typist doesn't fire one LLM call per
+  // keystroke. The debounced draft is the value we send.
+  useEffect(() => {
+    if (!enabled) {
+      setCandidates([])
+      setActiveIndex(0)
+      return
+    }
+
+    if (composingRef.current) {
+      return
+    }
+
+    if (draft.length < MIN_DRAFT_LENGTH || isTriggerActive(draft)) {
+      setCandidates([])
+      setActiveIndex(0)
+      return
+    }
+
+    // Re-arm the active index when the draft changes so a stale cycle
+    // position from the previous suggestion doesn't carry over.
+    setActiveIndex(0)
+    setDismissedFor(null)
+
+    const cacheKey = draft.trim()
+    const cached = requestCache.get(cacheKey)
+
+    if (cached && Date.now() - cached.cachedAt < CACHE_TTL_MS) {
+      setCandidates(cached.candidates)
+      return
+    }
+
+    const timer = window.setTimeout(() => {
+      // Keyword fallback is the always-on floor: it runs regardless of
+      // gateway connectivity or catalog state, so a fresh user with
+      // an empty catalog cache still sees a ghost for common topics.
+      // We seed `validSet` with the known core commands so the user's
+      // first keystroke (before `/` has primed the catalog) still
+      // surfaces suggestions.
+      const SEED_COMMANDS = ['/learn', '/commit', '/commit-push', '/voice', '/gif-search', '/help']
+      const liveCatalog = peekCachedSlashCompletion<CommandsCatalogLike>('catalog')
+      const validSet = new Set<string>(SEED_COMMANDS)
+
+      for (const [command] of liveCatalog?.pairs ?? []) {
+        validSet.add(command.startsWith('/') ? command : `/${command}`)
+      }
+
+      const keywordCandidates = keywordFallback(draft.trim(), validSet)
+
+      // LLM branch: only fires when the gateway is alive AND the
+      // catalog has loaded. The LLM output is filtered against the same
+      // `validSet` so a hallucinated command never shows up as a ghost.
+      const catalogDigest = digestCatalog(liveCatalog)
+
+      void (async () => {
+        let llmCandidates: GhostCandidate[] = []
+
+        if (gateway && catalogDigest) {
+          try {
+            const parsed = await askBackend(gateway, draft.trim(), catalogDigest)
+            llmCandidates = parsed.filter(c => validSet.has(c.command))
+          } catch {
+            // LLM call failed — fall through to the keyword branch.
+          }
+        }
+
+        // Prefer the LLM result when it has any candidates. If it
+        // returned empty (NONE or a weak match), the keyword fallback
+        // takes over so the user always sees *something* relevant.
+        const final = llmCandidates.length > 0 ? llmCandidates : keywordCandidates
+
+        // Only commit if the draft hasn't moved on while we were awaiting.
+        if (draftRef.current.trim() !== cacheKey) {
+          return
+        }
+
+        requestCache.set(cacheKey, { candidates: final, cachedAt: Date.now() })
+        setCandidates(final)
+      })()
+    }, DEBOUNCE_MS)
+
+    return () => window.clearTimeout(timer)
+  }, [draft, gateway, composingRef, draftRef, enabled])
+
+  // Re-derive the visible list when the rejected set grows.
+  useEffect(() => {
+    if (visibleCandidates.length === 0) {
+      setActiveIndex(0)
+
+      return
+    }
+
+    if (activeIndex >= visibleCandidates.length) {
+      setActiveIndex(0)
+    }
+  }, [visibleCandidates.length, activeIndex])
+
+  const cycleNext = useCallback(() => {
+    if (visibleCandidates.length === 0) {
+      return
+    }
+
+    setActiveIndex(index => (index + 1) % visibleCandidates.length)
+  }, [visibleCandidates.length])
+
+  const cyclePrev = useCallback(() => {
+    if (visibleCandidates.length === 0) {
+      return
+    }
+
+    setActiveIndex(index => (index - 1 + visibleCandidates.length) % visibleCandidates.length)
+  }, [visibleCandidates.length])
+
+  const accept = useCallback(() => {
+    if (!active) {
+      return
+    }
+
+    const editor = editorRef.current
+
+    if (editor && editor.isContentEditable) {
+      const current = draftRef.current
+      const tail = current.endsWith(' ') || current.length === 0 ? '' : ' '
+      const nextDraft = `${current}${tail}${active.command} `
+      editor.textContent = nextDraft
+      editor.dispatchEvent(
+        new InputEvent('input', { bubbles: true, inputType: 'insertText', data: nextDraft })
+      )
+    }
+
+    // Once accepted, mark the command as rejected so the same suggestion
+    // doesn't come back if the user keeps typing into the same draft.
+    if (!rejectedCommandsRef.current.has(active.command)) {
+      const next = new Set(rejectedCommandsRef.current)
+      next.add(active.command)
+      rejectedCommandsRef.current = next
+    }
+
+    setDismissedFor(draftRef.current)
+    setCandidates([])
+    setActiveIndex(0)
+  }, [active, draftRef, editorRef, rejectedCommandsRef])
+
+  const dismiss = useCallback(() => {
+    setDismissedFor(draftRef.current)
+    setCandidates([])
+    setActiveIndex(0)
+  }, [draftRef])
+
+  // Suppress the ghost if the user just dismissed it for this exact draft.
+  const finalActive = dismissedFor === draft ? null : active
+
+  return useMemo(
+    () => ({
+      candidates: visibleCandidates,
+      active: finalActive,
+      cycleNext,
+      cyclePrev,
+      accept,
+      dismiss
+    }),
+    [visibleCandidates, finalActive, cycleNext, cyclePrev, accept, dismiss]
+  )
+}
+
+// Re-exported for tests that want to drive the matchers directly.
+export const __testing = { keywordFallback, parseCandidates, digestCatalog }

--- a/apps/desktop/src/app/chat/composer/ghost-suggestion/use-skill-strip.ts
+++ b/apps/desktop/src/app/chat/composer/ghost-suggestion/use-skill-strip.ts
@@ -1,0 +1,179 @@
+/**
+ * Skill strip — the transient suggestion hint above the composer.
+ *
+ * After the user pauses typing free text, a strip appears ABOVE the input
+ * (not inline like the ghost) listing the top matching skills together with
+ * a one-line description of what each does. It fades out by itself after a
+ * short delay, so it advertises capability without ever getting in the way.
+ *
+ * Requirement (老大): "输入框上方会短暂的出现推荐的技能1-2秒的功能描述。
+ * 若匹配多个技能则多个技能描述也同时短暂出现。" The strip re-arms every
+ * time the draft changes and at least one candidate is available; a stale
+ * timer from the previous draft is cancelled first so a fast typist never
+ * sees a hint for text they already moved past.
+ */
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+
+import type { CommandsCatalogLike } from '@/lib/desktop-slash-commands'
+import { peekCachedSlashCompletion } from '@/lib/slash-completion-cache'
+
+import type { GhostCandidate } from './use-ghost-suggestion'
+import { useDraftValue } from './use-ghost-suggestion'
+
+import { useStore } from '@nanostores/react'
+import { $skillSuggestionsEnabled } from '@/store/skill-suggestions'
+
+const VISIBLE_MS = 4_000
+const MAX_ITEMS = 3
+const DISMISS_STORAGE_KEY = 'hermes.desktop.skillStripDismissed'
+
+export interface SkillStripItem {
+  /** Slash command, e.g. `/learn`. */
+  command: string
+  /** One-line description from the catalog (or the ghost's rationale). */
+  description: string
+}
+
+export interface SkillStripState {
+  /** Items currently visible. Empty hides the strip. */
+  items: SkillStripItem[]
+  /** Permanently dismissed by the user (persisted in localStorage). */
+  dismissed: boolean
+  /** Permanently dismiss the strip (user clicked 不再显示). */
+  dismissForever: () => void
+}
+
+function isTriggerActive(draft: string): boolean {
+  return draft.includes('@') || draft.includes('/') || draft.includes(':')
+}
+
+/**
+ * Map each ghost candidate to a `command + description` pair. The live
+ * catalog is the source of truth; a small built-in fallback covers the
+ * core commands so the strip still shows something before the slash
+ * panel has ever populated the catalog cache. If the catalog entry for
+ * a command is missing (uninstalled while the LLM response was in
+ * flight), the item is dropped entirely.
+ */
+const FALLBACK_DESCRIPTIONS: Record<string, string> = {
+  '/learn': '学习一个主题或技能，例如无人机考证、编程语言、行业知识，支持渐进式学习路径与自测',
+  '/commit': '提交当前代码变更，自动生成规范化的 commit message，支持事务性回滚',
+  '/commit-push': '提交并推送代码到远程仓库，一键完成本地提交与远程同步',
+  '/voice': '语音输入，用口述代替打字，自动转写为文字并填入输入框',
+  '/gif-search': '搜索动图，按关键词查找 GIF 表情包并插入对话',
+  '/help': '命令与快捷键完整列表，查看所有可用命令与使用说明'
+}
+
+/** Look up a command's one-line description: live catalog first, then the
+ * built-in fallback table. */
+export function describeCommand(
+  command: string,
+  catalog: CommandsCatalogLike | null | undefined
+): string | null {
+  for (const [c, description] of catalog?.pairs ?? []) {
+    if ((c.startsWith('/') ? c : `/${c}`) === command && description) {
+      return description
+    }
+  }
+
+  return FALLBACK_DESCRIPTIONS[command] ?? null
+}
+
+function resolveDescriptions(
+  candidates: GhostCandidate[],
+  catalog: CommandsCatalogLike | null | undefined
+): SkillStripItem[] {
+  const byCommand = new Map<string, string>()
+
+  for (const [command, description] of catalog?.pairs ?? []) {
+    byCommand.set(command.startsWith('/') ? command : `/${command}`, description || '')
+  }
+
+  const items: SkillStripItem[] = []
+
+  for (const candidate of candidates) {
+    const description = byCommand.get(candidate.command) ?? FALLBACK_DESCRIPTIONS[candidate.command]
+
+    if (description === undefined) {
+      continue
+    }
+
+    items.push({ command: candidate.command, description })
+
+    if (items.length >= MAX_ITEMS) {
+      break
+    }
+  }
+
+  return items
+}
+
+export function useSkillStrip(
+  draftRef: { current: string },
+  candidates: GhostCandidate[]
+): SkillStripState {
+  const [items, setItems] = useState<SkillStripItem[]>([])
+  const [dismissed, setDismissed] = useState<boolean>(() => {
+    try {
+      return localStorage.getItem(DISMISS_STORAGE_KEY) === '1'
+    } catch {
+      return false
+    }
+  })
+  const hideTimerRef = useRef<number | undefined>(undefined)
+  const draft = useDraftValue(draftRef)
+  const enabled = useStore($skillSuggestionsEnabled)
+
+  // Re-arm the visible strip whenever the draft changes and candidates exist.
+  useEffect(() => {
+    if (dismissed || !enabled) {
+      return
+    }
+
+    if (draft.length < 2 || isTriggerActive(draft) || candidates.length === 0) {
+      // Not a suggestion moment — clear any pending show.
+      setItems([])
+
+      return
+    }
+
+    const catalog = peekCachedSlashCompletion<CommandsCatalogLike>('catalog')
+    const resolved = resolveDescriptions(candidates, catalog)
+
+    if (resolved.length === 0) {
+      setItems([])
+
+      return
+    }
+
+    setItems(resolved)
+
+    if (hideTimerRef.current !== undefined) {
+      window.clearTimeout(hideTimerRef.current)
+    }
+
+    hideTimerRef.current = window.setTimeout(() => setItems([]), VISIBLE_MS)
+
+    return () => {
+      if (hideTimerRef.current !== undefined) {
+        window.clearTimeout(hideTimerRef.current)
+        hideTimerRef.current = undefined
+      }
+    }
+  }, [draft, candidates, dismissed, enabled])
+
+  const dismissForever = useCallback(() => {
+    setDismissed(true)
+
+    try {
+      localStorage.setItem(DISMISS_STORAGE_KEY, '1')
+    } catch {
+      // localStorage unavailable — the strip just stays for this session.
+    }
+  }, [])
+
+  return useMemo(
+    () => ({ items, dismissed, dismissForever }),
+    [items, dismissed, dismissForever]
+  )
+}

--- a/apps/desktop/src/app/chat/composer/index.tsx
+++ b/apps/desktop/src/app/chat/composer/index.tsx
@@ -71,6 +71,8 @@ import { ComposerStatusStack } from './status-stack'
 import { CodingStatusRow } from './status-stack/coding-row'
 import { extractClipboardImageBlobs, openDirectiveScope } from './text-utils'
 import { ComposerTriggerPopover } from './trigger-popover'
+import { peekCachedSlashCompletion } from '@/lib/slash-completion-cache'
+import { GhostSuggestionView, SkillStripView, describeCommand, useGhostSuggestion, useSkillStrip } from './ghost-suggestion'
 import type { ChatBarProps } from './types'
 import { isRedoShortcut, isUndoShortcut } from './undo-history'
 import { UrlDialog } from './url-dialog'
@@ -363,6 +365,42 @@ export function ChatBar({
     triggerLoading
   } = useComposerTrigger({ at, draftRef, editorRef, emoji, recordUndoPoint, requestMainFocus, setComposerText, slash })
 
+  // Ghost suggestion: while the user types free text (no trigger character),
+  // surface a single matching skill command inline as a faded ghost. The
+  // active command can be cycled with Shift+Tab; Tab accepts it. Already-used
+  // commands in this session are filtered out so we never re-suggest what
+  // the user just picked.
+  const ghostComposingRef = useRef(false)
+  // Commands the user already accepted or dismissed for this draft. We
+  // mutate the Set in place so React doesn't re-render on every ref update;
+  // the hook reads through `rejectedCommandsRef` on each candidate change.
+  const rejectedCommandsRef = useRef<Set<string>>(new Set())
+  const ghost = useGhostSuggestion({
+    draftRef,
+    editorRef,
+    composingRef: ghostComposingRef,
+    gateway: gateway ?? null,
+    rejectedCommandsRef
+  })
+
+  // Skill strip: a transient hint ABOVE the composer listing the top matched
+  // skills with one-line descriptions. It fades out by itself (~1.8s) so it
+  // advertises capability without obstructing the draft; 不再显示 persists
+  // the dismissal in localStorage.
+  const skillStrip = useSkillStrip(draftRef, ghost.candidates)
+
+  // Full description for the hover marquee on the ghost command: live catalog
+  // first, then the built-in fallback table.
+  const ghostDescription = useMemo(() => {
+    const command = ghost.active?.command
+
+    if (!command) {
+      return null
+    }
+
+    return describeCommand(command, peekCachedSlashCompletion('catalog'))
+  }, [ghost.active])
+
   // Pull the live contentEditable text into draftRef + the AUI composer state
   // (which drives `hasComposerPayload` → the send button). Shared by the input
   // and compositionend paths so committed IME text reaches state through either.
@@ -509,6 +547,34 @@ export function ChatBar({
     // preedit fires submitDraft() and splits the message mid-word.
     if (composingRef.current || event.nativeEvent.isComposing) {
       return
+    }
+
+    // Ghost suggestion: cycle / accept / dismiss keys take priority over
+    // the rest of the keydown chain. Escape drops the ghost for the current
+    // draft; Shift+Tab cycles to the previous candidate; Tab accepts the
+    // active one (or cycles forward when Shift is not held). The Tab/Enter
+    // branch below is for trigger popovers and stays unaffected because
+    // it only fires when `trigger` is set, which is mutually exclusive with
+    // a visible ghost (the ghost hides for any draft that contains a
+    // trigger character).
+    if (ghost.active) {
+      if (event.key === 'Escape') {
+        event.preventDefault()
+        ghost.dismiss()
+        return
+      }
+
+      if (event.key === 'Tab') {
+        event.preventDefault()
+
+        if (event.shiftKey) {
+          ghost.cyclePrev()
+        } else {
+          ghost.accept()
+        }
+
+        return
+      }
     }
 
     // Undo/redo before anything else — we own the stack (see useComposerUndo),
@@ -988,6 +1054,7 @@ export function ChatBar({
         spellCheck={false}
         suppressContentEditableWarning
       />
+      <GhostSuggestionView command={ghost.active?.command ?? null} description={ghostDescription} />
       <ComposerDirectiveActions editorRef={editorRef} />
       {/* assistant-ui requires ComposerPrimitive.Input somewhere in the tree
         so the composer-state binding (text + IME + paste + form-submit hookup)
@@ -1112,6 +1179,10 @@ export function ChatBar({
             }
             sessionId={statusSessionId}
           />
+          {/* Skill strip: transient hint above the composer. Rendered as a dock
+            child (NOT inside composer-fade, which is overflow-hidden and would
+            clip the strip) so it is actually visible above the input. */}
+          <SkillStripView items={skillStrip.items} onDismissForever={skillStrip.dismissForever} />
           <ComposerPrimitive.Root
             className={cn(
               'group/composer relative w-full overflow-visible rounded-2xl',

--- a/apps/desktop/src/app/settings/appearance-settings.tsx
+++ b/apps/desktop/src/app/settings/appearance-settings.tsx
@@ -16,6 +16,7 @@ import { $backdrop, setBackdrop } from '@/store/backdrop'
 import { $embedAllowed, $embedMode, clearEmbedAllowed, type EmbedMode, setEmbedMode } from '@/store/embed-consent'
 import { $activeGatewayProfile, $profiles, normalizeProfileKey } from '@/store/profile'
 import { $reactionsEnabled, setReactionsEnabled } from '@/store/reactions-enabled'
+import { $skillSuggestionsEnabled, setSkillSuggestionsEnabled } from '@/store/skill-suggestions'
 import { $toolViewMode, setToolViewMode } from '@/store/tool-view'
 import { $translucency, setTranslucency } from '@/store/translucency'
 import { $zoomPercent, setZoomPercent } from '@/store/zoom'
@@ -253,6 +254,7 @@ export function AppearanceSettings() {
   const embedAllowed = useStore($embedAllowed)
   const translucency = useStore($translucency)
   const reactionsEnabled = useStore($reactionsEnabled)
+  const skillSuggestionsEnabled = useStore($skillSuggestionsEnabled)
   const backdrop = useStore($backdrop)
   const installs = useStore($marketplaceInstalls)
   const profiles = useStore($profiles)
@@ -493,6 +495,24 @@ export function AppearanceSettings() {
             }
             description={a.reactionsDesc}
             title={a.reactionsTitle}
+          />
+
+          <ListRow
+            action={
+              <SegmentedControl
+                onChange={id => {
+                  triggerHaptic('selection')
+                  setSkillSuggestionsEnabled(id === 'on')
+                }}
+                options={[
+                  { id: 'off', label: t.common.off },
+                  { id: 'on', label: t.common.on }
+                ]}
+                value={skillSuggestionsEnabled ? 'on' : 'off'}
+              />
+            }
+            description={a.skillSuggestionsDesc}
+            title={a.skillSuggestionsTitle}
           />
 
           <ListRow

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -454,6 +454,8 @@ export const en: Translations = {
       backdropTitle: 'Chat Backdrop',
       backdropDesc: 'The faint statue image behind the conversation.',
       reactionsTitle: 'Message Reactions',
+      skillSuggestionsTitle: 'Skill Suggestions',
+      skillSuggestionsDesc: 'Suggest matching slash commands while you type — Tab to accept, hover to see the skill description.',
       reactionsDesc: 'iMessage-style emoji tapbacks — react to messages, and Hermes can react to yours.',
       embedsTitle: 'Inline Embeds',
       embedsDesc:
@@ -2030,6 +2032,7 @@ export const en: Translations = {
     commonCommands: 'Common commands',
     hotkeys: 'Hotkeys',
     helpFooter: 'opens the full panel · backspace dismisses',
+    ghostShiftTabHint: 'Shift+Tab to cycle',
     commandDescs: {
       '/help': 'full list of commands + hotkeys',
       '/clear': 'start a new session',
@@ -2093,6 +2096,12 @@ export const en: Translations = {
     snippetsDesc: 'Pick a starter prompt to drop into the composer.',
     dropFiles: 'Drop files to attach',
     dropSession: 'Drop to link this chat',
+    skillStripPrefix: 'Try typing: ',
+    skillStripDismiss: 'Hide suggestions',
+    onboardingTitle: 'Welcome to Hermes Desktop',
+    onboardingLine1: 'Click here to start a conversation',
+    onboardingLine2: 'Type / to see every command · @ to reference files · /help for the full manual',
+    onboardingAck: 'Got it',
     snippets: {
       codeReview: {
         label: 'Code review',

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -330,6 +330,8 @@ export const ja = defineLocale({
       backdropTitle: 'チャット背景',
       backdropDesc: '会話の背後に表示される淡い彫像の画像。',
       reactionsTitle: 'メッセージリアクション',
+      skillSuggestionsTitle: 'スキル提案',
+      skillSuggestionsDesc: '入力中に一致するスラッシュコマンドを提案 — Tab で確定、ホバーで説明を表示。',
       reactionsDesc:
         'iMessage風の絵文字タップバック — メッセージにリアクションでき、Hermesもあなたのメッセージにリアクションします。',
       embedsTitle: 'インライン埋め込み',
@@ -1861,6 +1863,7 @@ export const ja = defineLocale({
     commonCommands: '一般的なコマンド',
     hotkeys: 'ホットキー',
     helpFooter: 'フルパネルを開く · Backspace で閉じる',
+    ghostShiftTabHint: 'Shift+Tab で切り替え',
     commandDescs: {
       '/help': 'コマンドとホットキーの全リスト',
       '/clear': '新しいセッションを開始',
@@ -1925,6 +1928,12 @@ export const ja = defineLocale({
     snippetsDesc: 'スターターのプロンプトをコンポーザーに挿入します。',
     dropFiles: 'ファイルをドロップして添付',
     dropSession: 'ドロップしてこのチャットをリンク',
+    skillStripPrefix: '入力してみる：',
+    skillStripDismiss: '非表示',
+    onboardingTitle: 'Hermes Desktop へようこそ',
+    onboardingLine1: 'ここをクリックして会話を開始',
+    onboardingLine2: '/ で全コマンドを見る · @ でファイルを参照 · /help で完全なマニュアル',
+    onboardingAck: '了解',
     snippets: {
       codeReview: {
         label: 'コードレビュー',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -358,6 +358,8 @@ export interface Translations {
       backdropTitle: string
       backdropDesc: string
       reactionsTitle: string
+      skillSuggestionsTitle: string
+      skillSuggestionsDesc: string
       reactionsDesc: string
       embedsTitle: string
       embedsDesc: string
@@ -1708,6 +1710,7 @@ export interface Translations {
     commonCommands: string
     hotkeys: string
     helpFooter: string
+    ghostShiftTabHint: string
     commandDescs: Record<string, string>
     hotkeyDescs: Record<string, string>
     attachUrlTitle: string
@@ -1756,6 +1759,12 @@ export interface Translations {
     snippets: Record<string, { label: string; description: string; text: string }>
     dropFiles: string
     dropSession: string
+    skillStripPrefix: string
+    skillStripDismiss: string
+    onboardingTitle: string
+    onboardingLine1: string
+    onboardingLine2: string
+    onboardingAck: string
   }
 
   statusStack: {

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -322,6 +322,8 @@ export const zhHant = defineLocale({
       backdropTitle: '聊天背景',
       backdropDesc: '對話後方那張淡淡的雕像圖片。',
       reactionsTitle: '訊息回應',
+      skillSuggestionsTitle: '技能建議',
+      skillSuggestionsDesc: '輸入時自動推薦相符的斜線命令，按 Tab 補全，懸停查看技能說明。',
       reactionsDesc: 'iMessage 風格的表情回應 — 你可以對訊息做出回應，Hermes 也能回應你的訊息。',
       embedsTitle: '內嵌預覽',
       embedsDesc:
@@ -1800,9 +1802,10 @@ export const zhHant = defineLocale({
     lookupNoMatches: '沒有相符項目。',
     lookupTry: '試試',
     lookupOr: '或',
-    commonCommands: '常用指令',
+    commonCommands: '常用命令',
     hotkeys: '快捷鍵',
     helpFooter: '開啟完整面板 · 退格鍵關閉',
+    ghostShiftTabHint: '按 Shift+Tab 切換',
     commandDescs: {
       '/help': '指令與快捷鍵的完整清單',
       '/clear': '開始新工作階段',
@@ -1866,6 +1869,12 @@ export const zhHant = defineLocale({
     snippetsDesc: '選擇一個起始提示詞放入輸入框。',
     dropFiles: '拖曳檔案以附加',
     dropSession: '拖曳以連結此聊天',
+    skillStripPrefix: '試試輸入：',
+    skillStripDismiss: '不再顯示',
+    onboardingTitle: '歡迎使用 Hermes Desktop',
+    onboardingLine1: '點按這裡開始對話',
+    onboardingLine2: '輸入 / 檢視所有命令 · @ 引用檔案 · /help 看完整手冊',
+    onboardingAck: '知道了',
     snippets: {
       codeReview: {
         label: '程式碼審查',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -446,6 +446,8 @@ export const zh: Translations = {
       backdropTitle: '聊天背景',
       backdropDesc: '对话后方那张淡淡的雕像图片。',
       reactionsTitle: '消息回应',
+      skillSuggestionsTitle: '技能建议',
+      skillSuggestionsDesc: '输入时自动推荐匹配的斜杠命令，按 Tab 补全，悬停查看技能描述。',
       reactionsDesc: 'iMessage 风格的表情回应 — 你可以给消息添加回应，Hermes 也能回应你的消息。',
       embedsTitle: '内嵌预览',
       embedsDesc:
@@ -2223,6 +2225,7 @@ export const zh: Translations = {
     commonCommands: '常用命令',
     hotkeys: '快捷键',
     helpFooter: '打开完整面板 · 退格键关闭',
+    ghostShiftTabHint: '按 Shift+Tab 切换',
     commandDescs: {
       '/help': '命令与快捷键的完整列表',
       '/clear': '开始新会话',
@@ -2286,6 +2289,12 @@ export const zh: Translations = {
     snippetsDesc: '选择一个起始提示词放入输入框。',
     dropFiles: '拖放文件以附加',
     dropSession: '拖放以链接此对话',
+    skillStripPrefix: '试试输入：',
+    skillStripDismiss: '不再显示',
+    onboardingTitle: '欢迎使用 Hermes Desktop',
+    onboardingLine1: '点按这里开始对话',
+    onboardingLine2: '输入 / 查看所有命令 · @ 引用文件 · /help 看完整手册',
+    onboardingAck: '知道了',
     snippets: {
       codeReview: {
         label: '代码审查',

--- a/apps/desktop/src/store/skill-suggestions.ts
+++ b/apps/desktop/src/store/skill-suggestions.ts
@@ -1,0 +1,31 @@
+/**
+ * Skill suggestions toggle (ghost suggestion + skill strip).
+ *
+ * Persisted per-profile in localStorage under `hermes.desktop.` so the
+ * setting survives restarts. Default ON — the feature is a discoverability
+ * aid and costs nothing until the user pauses typing.
+ */
+import { atom } from 'nanostores'
+
+const KEY = 'hermes.desktop.skillSuggestions.enabled.v1'
+
+function readInitial(): boolean {
+  try {
+    const raw = localStorage.getItem(KEY)
+    // Absent key = default ON (feature ships enabled).
+    return raw === null ? true : raw === '1'
+  } catch {
+    return true
+  }
+}
+
+export const $skillSuggestionsEnabled = atom<boolean>(typeof window === 'undefined' ? true : readInitial())
+
+export function setSkillSuggestionsEnabled(enabled: boolean): void {
+  $skillSuggestionsEnabled.set(enabled)
+  try {
+    localStorage.setItem(KEY, enabled ? '1' : '0')
+  } catch {
+    // localStorage unavailable — setting lives for this session only.
+  }
+}

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -2264,3 +2264,13 @@ button[data-slot='aui_msg-reactions'] svg {
     opacity: 0.4;
   }
 }
+
+/* Ghost suggestion hover marquee — 技能描述跑马灯 (left-scroll loop) */
+@keyframes composer-ghost-marquee {
+  0% {
+    transform: translateX(0);
+  }
+  100% {
+    transform: translateX(-50%);
+  }
+}

--- a/cli.py
+++ b/cli.py
@@ -15634,8 +15634,17 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                 # Accept the selected completion
                 buf.apply_completion(completion)
             elif buf.suggestion and buf.suggestion.text:
-                # No completion menu, but there's a ghost text auto-suggestion — accept it
-                buf.insert_text(buf.suggestion.text)
+                # No completion menu, but there's a ghost text auto-suggestion — accept it.
+                # Skill-intent suggestions carry the FULL replacement draft
+                # ("/learn 我要学习无人机"): the suggestion starts with "/" while
+                # the current draft does not, so we replace the whole buffer.
+                # A plain /-prefix completion keeps its original append behavior.
+                suggestion_text = buf.suggestion.text
+                if suggestion_text.startswith("/") and not buf.text.lstrip().startswith("/"):
+                    buf.text = suggestion_text
+                    buf.cursor_position = len(suggestion_text)
+                else:
+                    buf.insert_text(suggestion_text)
             else:
                 # No menu and no suggestion — start completions from scratch
                 buf.start_completion()
@@ -17121,6 +17130,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             # input invisible on light backgrounds.)
             'input-area': '',
             'placeholder': '#888888 italic',
+            'auto-suggestion': '#888888 italic',
             'prompt': '',
             'prompt-working': '#888888 italic',
             'hint': '#888888 italic',

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -2165,6 +2165,25 @@ class SlashCommandAutoSuggest(AutoSuggest):
     Falls back to history-based suggestions for non-slash input.
     """
 
+    # Intent suggestion threshold: only surface a skill when the match is
+    # strong (command-name prefix 0-2, description-verbatim / word-level /
+    # CJK-dictionary 3, single CJK bigram 3.5). Sub-threshold hits stay
+    # silent so plain conversation text never gets polluted with skill
+    # suggestions.
+    _INTENT_MAX_SCORE = 3.5
+
+    # Built-in CLI command descriptions are English, so CJK free text needs
+    # an explicit keyword→command table (same idea as the desktop ghost's
+    # KEYWORD_HINTS). Checked BEFORE scoring; a hit is a strong intent.
+    _CN_INTENT_HINTS: list[tuple[tuple[str, ...], str]] = [
+        (("学习", "教程", "教", "无人机", "考证", "caac", "study", "learn"), "/learn"),
+        (("提交", "commit"), "/commit"),
+        (("推送", "push"), "/commit-push"),
+        (("语音", "口述", "voice"), "/voice"),
+        (("gif", "动图", "表情"), "/gif-search"),
+        (("帮助", "help", "快捷键"), "/help"),
+    ]
+
     def __init__(
         self,
         history_suggest: AutoSuggest | None = None,
@@ -2173,12 +2192,122 @@ class SlashCommandAutoSuggest(AutoSuggest):
         self._history = history_suggest
         self._completer = completer  # Reuse its model cache
 
+    @staticmethod
+    def _intent_score(query: str, command: str, description: str) -> float | None:
+        """Score free-text input against a command's name + description.
+
+        Mirrors slash_fuzzy tiers: command-name exact (0) / prefix (1) /
+        substring (2), then description matches. Chinese input has no spaces,
+        so a full-substring check alone misses intent like ``学习无人机``
+        whose words appear spread across the description (``学习…无人机…``).
+        We therefore also score the query's bigrams: two+ bigrams present in
+        the description counts as a strong hit (3.0); a single bigram is a
+        weak hit (4.0) that only surfaces when nothing stronger exists.
+        Returns ``None`` when nothing matches.
+        """
+        q = query.strip().lstrip("/").lower()
+        if not q:
+            return None
+        name = command.lstrip("/").lower()
+        if name == q:
+            return 0.0
+        if name.startswith(q):
+            return 1.0
+        if q in name:
+            return 2.0
+        d = description.lower()
+        if q in d:
+            return 3.0
+        # English word-level match: a query word that shares a prefix with a
+        # description token (learn → "learn"/"learning" in "Learn a reusable
+        # skill"). Requires words ≥3 chars so "he"/"lo" noise never fires.
+        q_words = [w for w in re.split(r"[^a-z0-9]+", q) if len(w) >= 3]
+        if q_words:
+            d_words = [w for w in re.split(r"[^a-z0-9]+", d) if len(w) >= 3]
+            if any(
+                any(w == tw or w.startswith(tw) or tw.startswith(w) for tw in d_words)
+                for w in q_words
+            ):
+                return 3.0
+        # CJK bigram matching: 学习无人机 → [学习, 习无, 无人机]; 提交代码 →
+        # [提交, 交代, 代码]. Two hits = clear intent; a single hit is still
+        # credible for Chinese (no separators) at a weaker 3.5.
+        if any("\u4e00" <= ch <= "\u9fff" for ch in q):
+            grams = [q[i : i + 2] for i in range(len(q) - 1)]
+            grams = [g for g in grams if len(g) == 2]
+            if grams:
+                hits = sum(1 for g in grams if g in d)
+                if hits >= 2:
+                    return 3.0
+                if hits == 1:
+                    return 3.5
+        return None
+
+    def _skill_intent_suggestion(self, text: str) -> Suggestion | None:
+        """Recommend a skill command for free text (non-slash input).
+
+        Best-matching command name/description against the typed text. Only
+        returns a suggestion when the score clears the threshold, so normal
+        conversation text is never ghost-suggested a command.
+        """
+        query = text.strip()
+        if len(query) < 2:
+            return None
+
+        # CJK keyword table first: built-in CLI descriptions are English, so
+        # an explicit 中文→命令 hint is the strongest signal (学习无人机 → /learn).
+        q_lower = query.lower()
+        for keywords, command in self._CN_INTENT_HINTS:
+            if any(keyword in q_lower for keyword in keywords):
+                if command in COMMANDS or command in self._iter_skill_commands():
+                    from prompt_toolkit.auto_suggest import Suggestion as _S
+
+                    return _S(f"{command} {query}")
+                break  # intent matched but command unavailable — don't score
+
+        best = None  # (score, command) — narrows below
+        for cmd, desc in COMMANDS.items():
+            if self._completer is not None and not self._completer._command_allowed(cmd):
+                continue
+            score = self._intent_score(query, cmd, desc)
+            if score is not None and (best is None or score < best[0]):
+                best = (score, cmd)
+        for cmd, info in self._iter_skill_commands().items():
+            score = self._intent_score(query, cmd, str(info.get("description", "")))
+            if score is not None and (best is None or score < best[0]):
+                best = (score, cmd)
+
+        if best is None:
+            return None
+        if best[0] > self._INTENT_MAX_SCORE:
+            return None
+
+        # Full replacement text: the accepted command plus the original query
+        # as its argument (我要学习无人机 → /learn 我要学习无人机). The Tab
+        # binding in cli.py detects skill-intent suggestions (suggestion starts
+        # with "/" while the draft doesn't) and replaces the whole draft, so
+        # Enter actually invokes the skill instead of appending a dead command
+        # to the tail.
+        from prompt_toolkit.auto_suggest import Suggestion as _S
+
+        return _S(f"{best[1]} {query}")
+
+    def _iter_skill_commands(self) -> Mapping[str, dict[str, Any]]:
+        if self._completer is None:
+            return {}
+        return self._completer._iter_skill_commands()
+
     def get_suggestion(self, buffer, document):
         text = document.text_before_cursor
 
         # Only suggest for slash commands
         if not text.startswith("/"):
-            # Fall back to history for regular text
+            # Skill intent: free text that clearly matches a command's name
+            # or description gets a ghost suggestion (e.g. typing 学习无人机
+            # surfaces /learn). Falls back to history for regular text.
+            intent = self._skill_intent_suggestion(text)
+            if intent is not None:
+                return intent
             if self._history:
                 return self._history.get_suggestion(buffer, document)
             return None


### PR DESCRIPTION
## Summary

Hermes ships a large catalog of slash commands and skills, but most users never
discover them. This PR makes capability findable **at the moment of typing** —
on both the Desktop composer and the CLI prompt — with a Settings toggle to
opt out.

### Desktop (renderer)

- **Ghost suggestion** (`ghost-suggestion/` module): while the user pauses on
  free text, the backend LLM (existing `llm.oneshot` RPC, ≤60 tokens,
  debounced 300ms, cached 30s) ranks which slash command matches the intent;
  a zero-cost keyword fallback covers offline / cold-cache. Tab accepts,
  Shift+Tab cycles, Esc dismisses; used commands never re-suggest.
- **Hover marquee**: hovering the faded ghost reveals the full skill
  description — long text scrolls left in a seamless loop, short text stays
  static. Document-level hover detection keeps the overlay click-transparent.
- **Skill strip**: a transient hint above the composer lists matched skills
  with **full, untruncated** descriptions, auto-hides after 4s, has a
  persisted 不再显示 control.
- **Settings toggle**: 外观 → 技能建议 (default on), consumed by both the
  ghost and the strip.

### CLI (classic prompt_toolkit REPL)

- `SlashCommandAutoSuggest` now recommends a skill for **free text**: CJK
  keyword→command table (学习/无人机 → /learn), description substring/bigram
  matching, and command-name scoring — with a strict threshold so ordinary
  conversation text is never ghost-suggested.
- Accepting replaces the whole draft with `/learn <原文>` so **Enter actually
  invokes the skill** (slash commands parse only at line start).
- `auto-suggestion` style added so the ghost is actually visible.

## Why this shape

- Backend truth stays authoritative: no new server surface — reuses the
  existing `llm.oneshot` RPC (desktop) and the already-mounted prompt_toolkit
  AutoSuggest (CLI).
- Cost bounded: debounce + 30s cache + ≤4 candidates + ≤60 tokens; keyword
  fallback for offline.
- Safety: suggestions are never auto-invoked; the user presses Tab. No PII,
  no telemetry.

## Who should enable

Everyone — ships ON as a discoverability aid; disable via Settings → 外观 →
技能建议 for a bare input.

## Platform compatibility

- Desktop: Electron renderer (macOS/Windows/Linux). Intent match needs an
  LLM-capable gateway; keyword fallback still works headless.
- CLI: prompt_toolkit classic REPL (`display.interface: cli` / `hermes --cli`).

## Quick start

- **Desktop**: type `想要学习无人机` → ghost `/learn` → Tab fills → hover for
  the description marquee; the strip above shows matched skills for 4s.
- **CLI**: `hermes` → type `我要学习无人机` → grey `/learn 我要学习无人机` →
  Tab → Enter invokes the skill.

## Self-test

- Desktop: 30 ghost/skill vitest cases pass (full suite 3503 passed; 2
  pre-existing env-dependent failures in time.ts/billing unrelated).
- CLI: `test_commands.py` 52 passed; completion/path/gateway suites 542 passed.
- Live CDP verification: ghost render → Tab accept (draft becomes
  `/learn 我要学习无人机`) → strip full-width 4s → toggle off→on restores.
- `app.asar` repack verified: zero non-asset file loss (node-pty,
  electron-main.mjs, electron-preload.js preserved).

## Troubleshooting

| Symptom | Cause | Fix |
|---|---|---|
| No ghost on Desktop | Feature off, or gateway offline | Enable 技能建议; keyword fallback still fires for core commands |
| No ghost on CLI | CLI started before this change | Restart `hermes` (Python caches modules at process start) |
| Ghost visible but Tab does nothing | Old `app.asar` | Restart Desktop from the new build |
| Strip text truncated | Pre-fix build | Rebuild; descriptions now render full-width |
