### PR TITLE
fix(agent): refresh the system-prompt date line when UTC rolls over

### DIFF
--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -882,6 +882,13 @@ def build_system_prompt(agent: Any, system_message: Optional[str] = None) -> str
     parts = build_system_prompt_parts(agent, system_message=system_message)
     joined = "\n\n".join(p for p in (parts["stable"], parts["context"], parts["volatile"]) if p)
     agent._cached_system_prompt_static = parts["stable"]
+    # Record the date this build stamped so long-lived sessions can refresh
+    # the "Conversation started:" line when UTC rolls over (#86938).
+    try:
+        from hermes_time import now as _hermes_now_for_date
+        agent._system_prompt_date = _hermes_now_for_date().strftime("%Y-%m-%d")
+    except Exception:
+        pass
 
     # Surface context-file truncation warnings through the normal agent status
     # channel so gateway/CLI users see them in chat instead of only in logs.
@@ -889,6 +896,23 @@ def build_system_prompt(agent: Any, system_message: Optional[str] = None) -> str
         agent._emit_status(warning)
 
     return joined
+
+
+def system_prompt_date_stale(agent: Any) -> bool:
+    """True when the cached prompt's date predates the current UTC date.
+
+    Date-only prompts are byte-stable per day by design (prefix-cache KV,
+    #20451) — this lets a long-lived session refresh exactly once when the
+    date rolls over instead of rebuilding per turn (#86938).
+    """
+    cached = getattr(agent, "_system_prompt_date", "")
+    if not cached:
+        return False
+    try:
+        from hermes_time import now as _hermes_now_for_date
+        return _hermes_now_for_date().strftime("%Y-%m-%d") != cached
+    except Exception:
+        return False
 
 
 def invalidate_system_prompt(agent: Any) -> None:

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -734,6 +734,17 @@ def build_turn_context(
     # ── System prompt (cached per session for prefix caching) ──
     if agent._cached_system_prompt is None:
         restore_or_build_system_prompt(agent, system_message, conversation_history)
+    else:
+        try:
+            from agent.system_prompt import system_prompt_date_stale
+            if system_prompt_date_stale(agent):
+                # The UTC date rolled over mid-session: rebuild once so the
+                # "Conversation started:" line stops reporting yesterday.
+                # Date-only granularity keeps the prefix cache intact for the
+                # rest of the day (#86938).
+                agent._cached_system_prompt = agent._build_system_prompt(system_message)
+        except Exception:
+            pass
 
     active_system_prompt = agent._cached_system_prompt
 

--- a/tests/agent/test_system_prompt_date_rollover.py
+++ b/tests/agent/test_system_prompt_date_rollover.py
@@ -1,0 +1,64 @@
+"""System-prompt date rollover refresh (#86938).
+
+Date-only prompts are byte-stable per day by design; a long-lived session
+must refresh the 'Conversation started:' line exactly once when the UTC
+date rolls over.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+
+def test_build_records_prompt_date(monkeypatch):
+    from datetime import datetime
+
+    from agent import system_prompt as sp
+
+    monkeypatch.setattr(
+        sp,
+        "build_system_prompt_parts",
+        lambda agent, system_message=None: {
+            "stable": "",
+            "context": "",
+            "volatile": "Conversation started: Saturday, August 15, 2026",
+        },
+    )
+    monkeypatch.setattr(sp, "drain_truncation_warnings", lambda: [])
+
+    class Agent:
+        def _emit_status(self, *a, **k):
+            pass
+
+    a = Agent()
+    with patch("hermes_time.now") as now_mock:
+        now_mock.return_value = datetime(2026, 8, 15, 12, 0, 0)
+        sp.build_system_prompt(a)
+
+    assert a._system_prompt_date == "2026-08-15"
+
+
+def test_date_stale_detects_rollover():
+    from agent.system_prompt import system_prompt_date_stale
+
+    class Agent:
+        _system_prompt_date = "2026-08-15"
+
+    a = Agent()
+    with patch("hermes_time.now") as now_mock:
+        from datetime import datetime
+
+        now_mock.return_value = datetime(2026, 8, 15, 23, 59, 0)
+        assert system_prompt_date_stale(a) is False
+
+        now_mock.return_value = datetime(2026, 8, 16, 0, 1, 0)
+        assert system_prompt_date_stale(a) is True
+
+
+def test_stale_without_recorded_date_is_false():
+    from agent.system_prompt import system_prompt_date_stale
+
+    class Agent:
+        pass
+
+    assert system_prompt_date_stale(Agent()) is False


### PR DESCRIPTION
## Summary

Fixes #86938: the system prompt's `Conversation started: <date>` line is built date-only and cached per session for prefix-cache stability (#20451, credit @iamfoz) — but a session running past UTC midnight kept yesterday's date forever.

## Changes (implementation + test as separate commits)

- `agent/system_prompt.py`: `build_system_prompt` records the stamped date on the agent (`_system_prompt_date`, `%Y-%m-%d`); new `system_prompt_date_stale(agent)` helper compares it against the current date (guarded, never raises).
- `agent/turn_context.py`: the turn-start hook rebuilds the cached prompt once when the date is stale — same day-granularity as the original design, so the prefix-cache rationale is untouched (one rebuild per rollover, never per turn).

## Validation

- New tests: build records the date · rollover detected across 23:59→00:01 · no recorded date → not stale. Green.
- `scripts/run_tests.sh tests/agent/test_system_prompt.py tests/agent/test_turn_context.py` → **39 passed, 0 failed**

Credit: @iamfoz's #20451 rationale preserved intact; reporter of #86938 for the rollover catch.
