### PR TITLE
fix(desktop): no-op branch switch on non-Git project so New session works

### DIFF
--- a/apps/desktop/electron/git-worktree-ops.test.ts
+++ b/apps/desktop/electron/git-worktree-ops.test.ts
@@ -94,6 +94,20 @@ test('switchBranch: switches a normal checkout branch', async () => {
   }
 })
 
+test('switchBranch: no-ops on a non-repo path so non-Git projects are not blocked', async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hermes-switch-nonrepo-'))
+
+  try {
+    const result = await switchBranch(dir, 'main', 'git')
+
+    // Resolves (does not throw) with a skipped marker, mirroring how the
+    // sidebar's fallback `main` lane must not block "New session".
+    assert.deepEqual(result, { branch: 'main', skipped: true })
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true })
+  }
+})
+
 test('listBranches: lists locals and flags the checked-out branch', async () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hermes-branches-'))
 

--- a/apps/desktop/electron/git-worktree-ops.ts
+++ b/apps/desktop/electron/git-worktree-ops.ts
@@ -462,6 +462,23 @@ async function switchBranch(repoPath, branch, gitBin) {
     throw new Error('Branch name is required.')
   }
 
+  // Plain document workspaces are not Git repositories, but the sidebar renders
+  // them with a fallback `main` lane (a display label, not a real branch).
+  // `git switch` has nothing to run there, so it would fail and block "New
+  // session" from that project. Preflight git-repo status and no-op instead,
+  // so non-repo projects stay first-class. (Same probe as ensureGitRepo.)
+  let insideWorkTree = false
+
+  try {
+    insideWorkTree = (await runGit(gitBin, ['rev-parse', '--is-inside-work-tree'], resolved)).trim() === 'true'
+  } catch {
+    insideWorkTree = false
+  }
+
+  if (!insideWorkTree) {
+    return { branch: target, skipped: true }
+  }
+
   await runGit(gitBin, ['switch', target], resolved)
 
   return { branch: target }


### PR DESCRIPTION
## Summary

The Desktop cannot create a new session in a project whose workspace folder is **not a Git repository**. Clicking **New session** from such a project fails with **"Could not switch to main"**, and no session is created. This is a Desktop repository-lane defect: non-repo document workspaces are rendered with a fallback `main` lane, and the branch-switch action runs `git switch main`, which has nothing to switch in a non-repository.

Fixes #86939

## Change

In `apps/desktop/electron/git-worktree-ops.ts`, `switchBranch` now preflights Git-repository status (`git rev-parse --is-inside-work-tree`, the same probe `ensureGitRepo` already uses). When the target path is not inside a Git work tree, it resolves as a benign no-op (`{ branch, skipped: true }`) instead of throwing — so the sidebar's fallback `main` lane no longer blocks "New session" for non-repo projects. Real repositories are unaffected: the preflight passes and `git switch` runs exactly as before.

## Why this layer

The fix lives at the Electron git op where the failure actually happens, so it covers every caller (the new-session lane, the composer branch-off, and the worktree dialog) rather than patching a single renderer site. It also matches the documented intended behavior for non-repos: make the branch-switch a no-op / unavailable affordance when Git isn't present, and never coerce the folder into a repository to silence the error.

## Tests

Added `switchBranch: no-ops on a non-repo path so non-Git projects are not blocked` asserting that `switchBranch` resolves (does not throw) with a `skipped` marker on a non-repo directory. All existing `git-worktree-ops` tests still pass, including real-branch switching.

Run:

```sh
cd apps/desktop && npx vitest run electron/git-worktree-ops.test.ts
```