### PR TITLE
feat(zai): GLM-5.3 reasoning support — thinking always-on, low/high/max effort

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -363,6 +363,7 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "gemini-3.1-flash-lite-preview",
     ],
     "zai": [
+        "glm-5.3",
         "glm-5.2",
         "glm-5.1",
         "glm-5",

--- a/plugins/model-providers/zai/__init__.py
+++ b/plugins/model-providers/zai/__init__.py
@@ -19,9 +19,10 @@ untouched.
 
 GLM-5.2 additionally exposes a native ``reasoning_effort`` knob with exactly
 two enabled levels — ``high`` and ``max`` — on the OpenAI-compatible endpoint
-(per Z.AI / BigModel docs).  Hermes' richer effort scale is collapsed onto
-those two so the user's effort preference actually reaches the model instead
-of being silently dropped.
+(per Z.AI / BigModel docs).  GLM-5.3 exposes ``low``, ``high``, and ``max``;
+thinking cannot be disabled on GLM-5.3.  Hermes' richer effort scale is
+collapsed onto the levels each model accepts so the user's effort preference
+actually reaches the model instead of being silently dropped or rejected.
 """
 
 from __future__ import annotations
@@ -59,6 +60,14 @@ def _is_glm_5_2(model: str | None) -> bool:
     return any(token in m for token in ("glm-5.2", "glm-5-2", "glm-5p2"))
 
 
+def _is_glm_5_3(model: str | None) -> bool:
+    """Detect GLM-5.3 across the alias spellings providers use."""
+    m = (model or "").strip().lower()
+    if not m:
+        return False
+    return any(token in m for token in ("glm-5.3", "glm-5-3", "glm-5p3"))
+
+
 def _glm_5_2_reasoning_effort(reasoning_config: dict | None) -> str | None:
     """Map Hermes reasoning effort onto GLM-5.2's native ``high``/``max``.
 
@@ -82,8 +91,30 @@ def _glm_5_2_reasoning_effort(reasoning_config: dict | None) -> str | None:
     return "high"
 
 
+def _glm_5_3_reasoning_effort(reasoning_config: dict | None) -> str | None:
+    """Map Hermes reasoning effort onto GLM-5.3's ``low``/``high``/``max``.
+
+    GLM-5.3 rejects ``thinking.type=disabled``. An explicit Hermes disable is
+    therefore kept working at the model's lowest supported effort by the
+    caller below, rather than sending a request the API will reject.
+    """
+    if not isinstance(reasoning_config, dict):
+        return None
+    if reasoning_config.get("enabled") is False:
+        return "low"
+
+    effort = (reasoning_config.get("effort") or "").strip().lower()
+    if not effort or effort == "none":
+        return "low"
+    if effort in {"xhigh", "max", "ultra"}:
+        return "max"
+    if effort in {"medium", "high"}:
+        return "high"
+    return "low"
+
+
 class ZaiProfile(ProviderProfile):
-    """Z.AI / GLM — extra_body.thinking on/off + GLM-5.2 reasoning_effort."""
+    """Z.AI / GLM — thinking markers + native GLM-5.2/5.3 effort."""
 
     def build_api_kwargs_extras(
         self, *, reasoning_config: dict | None = None, model: str | None = None, **context
@@ -91,16 +122,27 @@ class ZaiProfile(ProviderProfile):
         extra_body: dict[str, Any] = {}
         top_level: dict[str, Any] = {}
 
-        if not _model_supports_thinking(model) and not _is_glm_5_2(model):
+        is_glm_5_2 = _is_glm_5_2(model)
+        is_glm_5_3 = _is_glm_5_3(model)
+        if not _model_supports_thinking(model) and not is_glm_5_2 and not is_glm_5_3:
             return extra_body, top_level
 
         # Only emit when the user expressed a preference; omitting the field
         # keeps the server default (enabled) exactly as before.
         if isinstance(reasoning_config, dict):
             enabled = reasoning_config.get("enabled") is not False
-            extra_body["thinking"] = {"type": "enabled" if enabled else "disabled"}
+            # GLM-5.3 no longer accepts ``disabled``. Keep the request valid
+            # and use its lowest supported effort when Hermes asks for none.
+            if is_glm_5_3:
+                extra_body["thinking"] = {"type": "enabled"}
+            else:
+                extra_body["thinking"] = {"type": "enabled" if enabled else "disabled"}
 
-        if _is_glm_5_2(model):
+        if is_glm_5_3:
+            effort = _glm_5_3_reasoning_effort(reasoning_config)
+            if effort is not None:
+                top_level["reasoning_effort"] = effort
+        elif is_glm_5_2:
             effort = _glm_5_2_reasoning_effort(reasoning_config)
             if effort is not None:
                 top_level["reasoning_effort"] = effort
@@ -116,6 +158,7 @@ zai = ZaiProfile(
     description="Z.AI / GLM — Zhipu AI models",
     signup_url="https://z.ai/",
     fallback_models=(
+        "glm-5.3",
         "glm-5.2",
         "glm-5",
         "glm-4-9b",

--- a/tests/plugins/model_providers/test_zai_profile.py
+++ b/tests/plugins/model_providers/test_zai_profile.py
@@ -7,8 +7,9 @@ Z.AI route — users who turned thinking off kept burning thinking tokens on
 every turn (the desktop "thinking reverts to medium" report).
 
 GLM-5.2 additionally exposes a native ``reasoning_effort`` knob with two
-enabled levels (high / max) on the OpenAI-compatible ``/api/paas/v4``
-endpoint; the Hermes effort scale is collapsed onto those.
+enabled levels (high / max), while GLM-5.3 exposes low / high / max and
+rejects disabled thinking.  The Hermes effort scale is collapsed onto the
+levels each model accepts.
 
 These tests pin the profile's wire-shape contract so Z.AI requests stay
 correctly shaped without going live.
@@ -136,6 +137,53 @@ class TestZaiGLM52ReasoningEffort:
         assert top_level == {}
 
 
+class TestZaiGLM53ReasoningEffort:
+    """GLM-5.3's native ``reasoning_effort`` knob (low / high / max)."""
+
+    @pytest.mark.parametrize(
+        ("effort", "expected"),
+        [
+            ("minimal", "low"),
+            ("low", "low"),
+            ("medium", "high"),
+            ("high", "high"),
+            ("xhigh", "max"),
+            ("max", "max"),
+            ("ultra", "max"),
+        ],
+    )
+    def test_efforts_map_to_supported_levels(self, zai_profile, effort, expected):
+        extra_body, top_level = zai_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": True, "effort": effort},
+            model="glm-5.3",
+        )
+        assert extra_body == {"thinking": {"type": "enabled"}}
+        assert top_level == {"reasoning_effort": expected}
+
+    def test_disabled_is_migrated_to_low_enabled(self, zai_profile):
+        """GLM-5.3 rejects disabled thinking; keep the request API-valid."""
+        extra_body, top_level = zai_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": False, "effort": "none"},
+            model="glm-5.3",
+        )
+        assert extra_body == {"thinking": {"type": "enabled"}}
+        assert top_level == {"reasoning_effort": "low"}
+
+    @pytest.mark.parametrize(
+        "model",
+        ["z-ai/glm-5.3", "glm-5-3", "glm-5p3", "zai-org-glm-5-3"],
+    )
+    def test_alias_spellings_recognized(self, zai_profile, model):
+        _, top_level = zai_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": True, "effort": "max"},
+            model=model,
+        )
+        assert top_level == {"reasoning_effort": "max"}
+
+    def test_curated_catalog_includes_glm_5_3(self, zai_profile):
+        assert "glm-5.3" in zai_profile.fallback_models
+
+
 class TestZaiModelGating:
     """GLM 4.5+ get thinking; earlier GLM models are left untouched."""
 
@@ -157,6 +205,13 @@ class TestZaiModelGating:
         )
         assert extra_body == {"thinking": {"type": "disabled"}}
 
+    def test_glm_5_3_never_emits_disabled_thinking(self, zai_profile):
+        extra_body, top_level = zai_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": False}, model="glm-5.3"
+        )
+        assert extra_body == {"thinking": {"type": "enabled"}}
+        assert top_level == {"reasoning_effort": "low"}
+
 
 class TestZaiFullKwargsIntegration:
     """End-to-end: the transport's full kwargs carry the reasoning wiring."""
@@ -172,6 +227,21 @@ class TestZaiFullKwargsIntegration:
             provider_profile=zai_profile,
             reasoning_config={"enabled": True, "effort": "max"},
             base_url="https://api.z.ai/api/paas/v4",
+            provider_name="zai",
+        )
+        assert kwargs["reasoning_effort"] == "max"
+        assert kwargs["extra_body"]["thinking"] == {"type": "enabled"}
+
+    def test_glm_5_3_effort_reaches_top_level(self, zai_profile):
+        from agent.transports.chat_completions import ChatCompletionsTransport
+
+        kwargs = ChatCompletionsTransport().build_kwargs(
+            model="glm-5.3",
+            messages=[{"role": "user", "content": "ping"}],
+            tools=None,
+            provider_profile=zai_profile,
+            reasoning_config={"enabled": True, "effort": "max"},
+            base_url="https://api.z.ai/api/coding/paas/v4",
             provider_name="zai",
         )
         assert kwargs["reasoning_effort"] == "max"


### PR DESCRIPTION
## Summary
- Adds GLM-5.3 support to the bundled `zai` provider plugin, ported from local work that upgrades kept wiping (now salvaged into a PR).
- GLM-5.3 rejects `thinking.type=disabled`; the profile keeps requests API-valid by pinning thinking `enabled` and clamping an explicit Hermes disable to `reasoning_effort: low`.
- Maps Hermes' effort scale onto GLM-5.3's native `low`/`high`/`max` (GLM-5.2 keeps its existing `high`/`max` mapping).
- Adds `glm-5.3` to the zai curated catalog (`_PROVIDER_MODELS`) — without this, the model is unselectable even with plugin `fallback_models`, because the curated list takes precedence and Z.AI's live `/models` listing does not yet include glm-5.3 (verified: chat completions for `glm-5.3` on the coding-plan endpoint return HTTP 200 with served model `glm-5.3`).

## Validation
- `pytest tests/plugins/model_providers/test_zai_profile.py` — 44 passed (both commits cherry-picked cleanly onto current `main`).
- Live smoke test against `https://api.z.ai/api/coding/paas/v4`: `glm-5.3` + `thinking: enabled` + `reasoning_effort: max` → HTTP 200.

## Notes
- Alias spellings (`glm-5-3`, `glm-5p3`, vendor-prefixed forms) recognized, mirroring the GLM-5.2 handling.