### PR TITLE
feat(memory): make provider timeouts configurable

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1779,7 +1779,12 @@ def init_agent(
             if _mem_provider_name and _mem_provider_name.strip():
                 from agent.memory_manager import MemoryManager as _MemoryManager
                 from plugins.memory import load_memory_provider as _load_mem
-                agent._memory_manager = _MemoryManager()
+                _prefetch_timeout = mem_config.get("prefetch_timeout")
+                if _prefetch_timeout is not None:
+                    _prefetch_timeout = float(_prefetch_timeout)
+                agent._memory_manager = _MemoryManager(
+                    external_prefetch_timeout=_prefetch_timeout,
+                )
                 _mp = _load_mem(_mem_provider_name)
                 if _mp and _mp.is_available():
                     agent._memory_manager.add_provider(_mp)

--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1780,8 +1780,6 @@ def init_agent(
                 from agent.memory_manager import MemoryManager as _MemoryManager
                 from plugins.memory import load_memory_provider as _load_mem
                 _prefetch_timeout = mem_config.get("prefetch_timeout")
-                if _prefetch_timeout is not None:
-                    _prefetch_timeout = float(_prefetch_timeout)
                 agent._memory_manager = _MemoryManager(
                     external_prefetch_timeout=_prefetch_timeout,
                 )

--- a/agent/memory_manager.py
+++ b/agent/memory_manager.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 
 import json
 import logging
+import math
 import re
 import inspect
 import threading
@@ -45,6 +46,37 @@ logger = logging.getLogger(__name__)
 # running past this window dies with the interpreter.
 _SYNC_DRAIN_TIMEOUT_S = 5.0
 _EXTERNAL_PREFETCH_TIMEOUT_S = 8.0
+MIN_CONFIGURABLE_TIMEOUT_S = 0.01
+MAX_CONFIGURABLE_TIMEOUT_S = 3600.0
+
+
+def coerce_timeout_seconds(
+    value: Any,
+    *,
+    default: float,
+    setting_name: str,
+    minimum: float = MIN_CONFIGURABLE_TIMEOUT_S,
+    maximum: float = MAX_CONFIGURABLE_TIMEOUT_S,
+) -> float:
+    """Return a finite timeout within bounds, or a safe default with a warning."""
+    try:
+        if isinstance(value, bool):
+            raise ValueError
+        parsed = float(value)
+        if not math.isfinite(parsed) or not minimum <= parsed <= maximum:
+            raise ValueError
+    except (TypeError, ValueError, OverflowError):
+        logger.warning(
+            "Invalid %s value %r; using default %.1f seconds "
+            "(expected a number between %.1f and %.1f seconds)",
+            setting_name,
+            value,
+            default,
+            minimum,
+            maximum,
+        )
+        return float(default)
+    return parsed
 
 
 def normalize_tool_schema(schema: Any) -> Optional[Dict[str, Any]]:
@@ -372,13 +404,13 @@ class MemoryManager:
         self._providers: List[MemoryProvider] = []
         self._tool_to_provider: Dict[str, MemoryProvider] = {}
         self._has_external: bool = False  # True once a non-builtin provider is added
-        self._external_prefetch_timeout = (
+        self._external_prefetch_timeout = coerce_timeout_seconds(
             _EXTERNAL_PREFETCH_TIMEOUT_S
             if external_prefetch_timeout is None
-            else float(external_prefetch_timeout)
+            else external_prefetch_timeout,
+            default=_EXTERNAL_PREFETCH_TIMEOUT_S,
+            setting_name="memory.prefetch_timeout",
         )
-        if self._external_prefetch_timeout <= 0:
-            raise ValueError("external_prefetch_timeout must be positive")
         self._external_prefetch_threads: Dict[str, threading.Thread] = {}
         self._external_prefetch_lock = threading.Lock()
         # Background executor for end-of-turn sync/prefetch. Lazily created on

--- a/contributors/emails/hermes@tarrason.com
+++ b/contributors/emails/hermes@tarrason.com
@@ -1,0 +1,2 @@
+thitar
+# Original commit from #69606; takeover consent by @thitar

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1774,6 +1774,8 @@ DEFAULT_CONFIG = {
         # "hindsight", "holographic", "retaindb", "byterover".
         # Only ONE external provider is allowed at a time.
         "provider": "",
+        # Maximum time to wait for an external provider's turn-start prefetch.
+        "prefetch_timeout": 8.0,
     },
 
     # Subagent delegation — override the provider:model used by delegate_task

--- a/plugins/memory/byterover/README.md
+++ b/plugins/memory/byterover/README.md
@@ -28,14 +28,14 @@ echo "BRV_API_KEY=your-key" >> ~/.hermes/.env
 
 `BRV_API_KEY` is optional and only needed for cloud sync. ByteRover is local-first by default.
 
-ByteRover queries time out after 10 seconds unless configured otherwise:
+Automatic ByteRover prefetch uses an effective deadline of `min(memory.prefetch_timeout, memory.byterover.timeout_query)`. The defaults are 8 seconds for `memory.prefetch_timeout` and 10 seconds for `memory.byterover.timeout_query`, so automatic prefetch waits for at most 8 seconds. Direct `brv_query` calls use `memory.byterover.timeout_query` only, which defaults to 10 seconds.
 
 ```bash
 hermes config set memory.byterover.timeout_query 30
 hermes config set memory.prefetch_timeout 31
 ```
 
-Both values are in seconds and accept numbers from 0.01 to 3600. The outer `memory.prefetch_timeout` must be larger than `memory.byterover.timeout_query`; otherwise Hermes may stop waiting before the ByteRover query finishes.
+Both values are in seconds and accept numbers from 0.01 to 3600.
 
 Working directory: `$HERMES_HOME/byterover/` (profile-scoped).
 

--- a/plugins/memory/byterover/README.md
+++ b/plugins/memory/byterover/README.md
@@ -26,9 +26,16 @@ echo "BRV_API_KEY=your-key" >> ~/.hermes/.env
 
 ## Config
 
-| Env Var | Required | Description |
-|---------|----------|-------------|
-| `BRV_API_KEY` | No | Cloud sync key (optional, local-first by default) |
+`BRV_API_KEY` is optional and only needed for cloud sync. ByteRover is local-first by default.
+
+ByteRover queries time out after 10 seconds unless configured otherwise:
+
+```bash
+hermes config set memory.byterover.timeout_query 30
+hermes config set memory.prefetch_timeout 31
+```
+
+Both values are in seconds and accept numbers from 0.01 to 3600. The outer `memory.prefetch_timeout` must be larger than `memory.byterover.timeout_query`; otherwise Hermes may stop waiting before the ByteRover query finishes.
 
 Working directory: `$HERMES_HOME/byterover/` (profile-scoped).
 

--- a/plugins/memory/byterover/__init__.py
+++ b/plugins/memory/byterover/__init__.py
@@ -223,6 +223,8 @@ class ByteRoverMemoryProvider(MemoryProvider):
     def __init__(self, config: Optional[Dict[str, Any]] = None):
         self._config = dict(config) if config is not None else _load_plugin_config()
         self._auto_extract = _coerce_bool(self._config.get("auto_extract"), True)
+        _tq = self._config.get("timeout_query")
+        self._timeout_query = float(_tq) if _tq is not None else _QUERY_TIMEOUT
         self._cwd = ""
         self._session_id = ""
         self._turn_count = 0
@@ -251,6 +253,12 @@ class ByteRoverMemoryProvider(MemoryProvider):
                 "default": "true",
                 "choices": ["true", "false"],
             },
+            {
+                "key": "timeout_query",
+                "description": "Max seconds for brv query calls (prefetch + tool); increase if model cold-start exceeds default",
+                "default": str(_QUERY_TIMEOUT),
+                "type": "number",
+            },
         ]
 
     def initialize(self, session_id: str, **kwargs) -> None:
@@ -272,14 +280,15 @@ class ByteRoverMemoryProvider(MemoryProvider):
     def prefetch(self, query: str, *, session_id: str = "") -> str:
         """Run brv query synchronously before the agent's first LLM call.
 
-        Blocks until the query completes (up to _QUERY_TIMEOUT seconds), ensuring
-        the result is available as context before the model is called.
-        """
+        Blocks until the query completes (up to the configured timeout_query
+        seconds, default %ds), ensuring the result is available as context
+        before the model is called.
+        """ % _QUERY_TIMEOUT
         if not query or len(query.strip()) < _MIN_QUERY_LEN:
             return ""
         result = _run_brv(
             ["query", "--", query.strip()[:5000]],
-            timeout=_QUERY_TIMEOUT, cwd=self._cwd,
+            timeout=self._timeout_query, cwd=self._cwd,
         )
         if result["success"] and result.get("output"):
             output = result["output"].strip()
@@ -402,7 +411,7 @@ class ByteRoverMemoryProvider(MemoryProvider):
 
         result = _run_brv(
             ["query", "--", query.strip()[:5000]],
-            timeout=_QUERY_TIMEOUT, cwd=self._cwd,
+            timeout=self._timeout_query, cwd=self._cwd,
         )
 
         if not result["success"]:

--- a/plugins/memory/byterover/__init__.py
+++ b/plugins/memory/byterover/__init__.py
@@ -16,6 +16,7 @@ Config via config.yaml:
   memory:
     byterover:
       auto_extract: false  # disable automatic brv curate hooks
+      timeout_query: 10    # seconds for prefetch and brv_query calls
 
 Working directory: $HERMES_HOME/byterover/ (profile-scoped context tree)
 """
@@ -31,6 +32,11 @@ import threading
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
+from agent.memory_manager import (
+    MAX_CONFIGURABLE_TIMEOUT_S,
+    MIN_CONFIGURABLE_TIMEOUT_S,
+    coerce_timeout_seconds,
+)
 from agent.memory_provider import MemoryProvider
 from tools.registry import tool_error
 
@@ -123,7 +129,7 @@ def _resolve_brv_path() -> Optional[str]:
     return found
 
 
-def _run_brv(args: List[str], timeout: int = _QUERY_TIMEOUT,
+def _run_brv(args: List[str], timeout: float = _QUERY_TIMEOUT,
              cwd: str = None) -> dict:
     """Run a brv CLI command. Returns {success, output, error}."""
     brv_path = _resolve_brv_path()
@@ -223,8 +229,11 @@ class ByteRoverMemoryProvider(MemoryProvider):
     def __init__(self, config: Optional[Dict[str, Any]] = None):
         self._config = dict(config) if config is not None else _load_plugin_config()
         self._auto_extract = _coerce_bool(self._config.get("auto_extract"), True)
-        _tq = self._config.get("timeout_query")
-        self._timeout_query = float(_tq) if _tq is not None else _QUERY_TIMEOUT
+        self._timeout_query = coerce_timeout_seconds(
+            self._config.get("timeout_query", _QUERY_TIMEOUT),
+            default=_QUERY_TIMEOUT,
+            setting_name="memory.byterover.timeout_query",
+        )
         self._cwd = ""
         self._session_id = ""
         self._turn_count = 0
@@ -256,8 +265,10 @@ class ByteRoverMemoryProvider(MemoryProvider):
             {
                 "key": "timeout_query",
                 "description": "Max seconds for brv query calls (prefetch + tool); increase if model cold-start exceeds default",
-                "default": str(_QUERY_TIMEOUT),
+                "default": _QUERY_TIMEOUT,
                 "type": "number",
+                "minimum": MIN_CONFIGURABLE_TIMEOUT_S,
+                "maximum": MAX_CONFIGURABLE_TIMEOUT_S,
             },
         ]
 

--- a/plugins/memory/byterover/__init__.py
+++ b/plugins/memory/byterover/__init__.py
@@ -292,9 +292,9 @@ class ByteRoverMemoryProvider(MemoryProvider):
         """Run brv query synchronously before the agent's first LLM call.
 
         Blocks until the query completes (up to the configured timeout_query
-        seconds, default %ds), ensuring the result is available as context
+        seconds, default 10s), ensuring the result is available as context
         before the model is called.
-        """ % _QUERY_TIMEOUT
+        """
         if not query or len(query.strip()) < _MIN_QUERY_LEN:
             return ""
         result = _run_brv(

--- a/tests/agent/test_memory_provider.py
+++ b/tests/agent/test_memory_provider.py
@@ -321,9 +321,9 @@ class TestMemoryManager:
         def release_during_join(thread, timeout=None):
             if thread.name == "memory-prefetch-controlled-slow":
                 observed_timeouts.append(timeout)
-                assert external.started.wait(timeout=1.0)
+                assert external.started.wait(timeout=5.0)
                 external.release.set()
-                return original_join(thread, timeout=1.0)
+                return original_join(thread, timeout=5.0)
             return original_join(thread, timeout=timeout)
 
         monkeypatch.setattr(threading.Thread, "join", release_during_join)

--- a/tests/agent/test_memory_provider.py
+++ b/tests/agent/test_memory_provider.py
@@ -310,6 +310,27 @@ class TestMemoryManager:
         assert external.prefetch_queries == ["query", "query 3"]
         assert external.name not in mgr._external_prefetch_threads
 
+    def test_larger_external_prefetch_budget_allows_controlled_provider(self, monkeypatch):
+        mgr = MemoryManager(external_prefetch_timeout=12.0)
+        external = BlockingPrefetchProvider("controlled-slow")
+        external._prefetch_result = "slow memory"
+        mgr.add_provider(external)
+        observed_timeouts = []
+        original_join = threading.Thread.join
+
+        def release_during_join(thread, timeout=None):
+            if thread.name == "memory-prefetch-controlled-slow":
+                observed_timeouts.append(timeout)
+                assert external.started.wait(timeout=1.0)
+                external.release.set()
+                return original_join(thread, timeout=1.0)
+            return original_join(thread, timeout=timeout)
+
+        monkeypatch.setattr(threading.Thread, "join", release_during_join)
+
+        assert mgr.prefetch_all("query") == "slow memory"
+        assert observed_timeouts == [12.0]
+
 
 
 class TestPluginMemoryDiscovery:

--- a/tests/agent/test_memory_provider.py
+++ b/tests/agent/test_memory_provider.py
@@ -310,26 +310,27 @@ class TestMemoryManager:
         assert external.prefetch_queries == ["query", "query 3"]
         assert external.name not in mgr._external_prefetch_threads
 
-    def test_larger_external_prefetch_budget_allows_controlled_provider(self, monkeypatch):
+    def test_larger_external_prefetch_budget_allows_controlled_provider(self):
         mgr = MemoryManager(external_prefetch_timeout=12.0)
         external = BlockingPrefetchProvider("controlled-slow")
         external._prefetch_result = "slow memory"
         mgr.add_provider(external)
-        observed_timeouts = []
-        original_join = threading.Thread.join
 
-        def release_during_join(thread, timeout=None):
-            if thread.name == "memory-prefetch-controlled-slow":
-                observed_timeouts.append(timeout)
-                assert external.started.wait(timeout=5.0)
-                external.release.set()
-                return original_join(thread, timeout=5.0)
-            return original_join(thread, timeout=timeout)
+        def release_after_prefetch_starts():
+            assert external.started.wait(timeout=5.0)
+            external.release.set()
 
-        monkeypatch.setattr(threading.Thread, "join", release_during_join)
+        releaser = threading.Thread(target=release_after_prefetch_starts, daemon=True)
+        releaser.start()
 
-        assert mgr.prefetch_all("query") == "slow memory"
-        assert observed_timeouts == [12.0]
+        try:
+            assert mgr.prefetch_all("query") == "slow memory"
+        finally:
+            external.release.set()
+            releaser.join(timeout=5.0)
+
+        assert not releaser.is_alive()
+        assert mgr._external_prefetch_timeout == 12.0
 
 
 

--- a/tests/plugins/memory/test_byterover_provider.py
+++ b/tests/plugins/memory/test_byterover_provider.py
@@ -1,7 +1,10 @@
 """Tests for the ByteRover memory provider config gates."""
 
+import threading
+
 import pytest
 
+from agent.memory_manager import MemoryManager
 from plugins.memory.byterover import ByteRoverMemoryProvider
 
 
@@ -60,6 +63,45 @@ def test_timeout_query_reaches_prefetch_and_tool_query(monkeypatch):
     assert provider.prefetch("a sufficiently long query")
     assert provider._tool_query({"query": "a sufficiently long query"})
     assert [kwargs["timeout"] for _, kwargs in calls] == [17.5, 17.5]
+
+
+@pytest.mark.parametrize(
+    ("prefetch_timeout", "timeout_query", "expected_deadline"),
+    [(8.0, 10.0, 8.0), (12.0, 10.0, 10.0)],
+    ids=["prefetch-8-query-10", "prefetch-12-query-10"],
+)
+def test_prefetch_all_returns_context_with_minimum_effective_deadline(
+    prefetch_timeout,
+    timeout_query,
+    expected_deadline,
+    monkeypatch,
+):
+    calls = []
+    join_timeouts = []
+    provider = ByteRoverMemoryProvider({"timeout_query": timeout_query})
+    provider.initialize("session-1")
+    manager = MemoryManager(external_prefetch_timeout=prefetch_timeout)
+    manager.add_provider(provider)
+
+    original_join = threading.Thread.join
+
+    def record_join(thread, timeout=None):
+        join_timeouts.append(timeout)
+        return original_join(thread, timeout)
+
+    def fake_run_brv(*args, **kwargs):
+        calls.append((args, kwargs))
+        return {"success": True, "output": "relevant memory content"}
+
+    monkeypatch.setattr("agent.memory_manager.threading.Thread.join", record_join)
+    monkeypatch.setattr("plugins.memory.byterover._run_brv", fake_run_brv)
+
+    context = manager.prefetch_all("a sufficiently long query")
+
+    assert context == "## ByteRover Context\nrelevant memory content"
+    assert join_timeouts == [prefetch_timeout]
+    assert [kwargs["timeout"] for _, kwargs in calls] == [timeout_query]
+    assert min(manager._external_prefetch_timeout, provider._timeout_query) == expected_deadline
 
 
 def test_prefetch_keeps_runtime_docstring():

--- a/tests/plugins/memory/test_byterover_provider.py
+++ b/tests/plugins/memory/test_byterover_provider.py
@@ -62,6 +62,11 @@ def test_timeout_query_reaches_prefetch_and_tool_query(monkeypatch):
     assert [kwargs["timeout"] for _, kwargs in calls] == [17.5, 17.5]
 
 
+def test_prefetch_keeps_runtime_docstring():
+    assert ByteRoverMemoryProvider.prefetch.__doc__ is not None
+    assert "default 10s" in ByteRoverMemoryProvider.prefetch.__doc__
+
+
 def test_timeout_query_schema_registers_default_and_bounds():
     provider = ByteRoverMemoryProvider({})
 

--- a/tests/plugins/memory/test_byterover_provider.py
+++ b/tests/plugins/memory/test_byterover_provider.py
@@ -1,5 +1,7 @@
 """Tests for the ByteRover memory provider config gates."""
 
+import pytest
+
 from plugins.memory.byterover import ByteRoverMemoryProvider
 
 
@@ -14,5 +16,63 @@ def test_auto_extract_false_skips_sync_turn(monkeypatch):
 
     assert calls == []
     assert provider._sync_thread is None
+
+
+def test_timeout_query_defaults_to_ten_seconds():
+    provider = ByteRoverMemoryProvider({})
+
+    assert provider._timeout_query == 10.0
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [(1, 1.0), (1.5, 1.5), ("2.5", 2.5), (0.01, 0.01), (3600, 3600.0)],
+)
+def test_valid_timeout_query_values_are_propagated(value, expected):
+    provider = ByteRoverMemoryProvider({"timeout_query": value})
+
+    assert provider._timeout_query == expected
+
+
+@pytest.mark.parametrize(
+    "value",
+    [True, False, "invalid", 0, -1, float("nan"), float("inf"), float("-inf"), 3600.1],
+)
+def test_invalid_timeout_query_falls_back_to_ten_seconds(value, caplog):
+    provider = ByteRoverMemoryProvider({"timeout_query": value})
+
+    assert provider._timeout_query == 10.0
+    assert "Invalid memory.byterover.timeout_query" in caplog.text
+    assert "using default 10.0 seconds" in caplog.text
+
+
+def test_timeout_query_reaches_prefetch_and_tool_query(monkeypatch):
+    calls = []
+    provider = ByteRoverMemoryProvider({"timeout_query": "17.5"})
+    provider.initialize("session-1")
+
+    def fake_run_brv(*args, **kwargs):
+        calls.append((args, kwargs))
+        return {"success": True, "output": "relevant memory content"}
+
+    monkeypatch.setattr("plugins.memory.byterover._run_brv", fake_run_brv)
+
+    assert provider.prefetch("a sufficiently long query")
+    assert provider._tool_query({"query": "a sufficiently long query"})
+    assert [kwargs["timeout"] for _, kwargs in calls] == [17.5, 17.5]
+
+
+def test_timeout_query_schema_registers_default_and_bounds():
+    provider = ByteRoverMemoryProvider({})
+
+    schema = next(
+        field for field in provider.get_config_schema()
+        if field["key"] == "timeout_query"
+    )
+
+    assert schema["default"] == 10.0
+    assert schema["type"] == "number"
+    assert schema["minimum"] == 0.01
+    assert schema["maximum"] == 3600.0
 
 

--- a/tests/run_agent/test_memory_provider_init.py
+++ b/tests/run_agent/test_memory_provider_init.py
@@ -229,9 +229,12 @@ def test_missing_memory_prefetch_timeout_preserves_default():
 
 
 def test_memory_prefetch_timeout_is_registered_in_default_config():
+    from typing import cast
+
     from hermes_cli.config_defaults import DEFAULT_CONFIG
 
-    assert DEFAULT_CONFIG["memory"]["prefetch_timeout"] == 8.0
+    memory_config = cast(dict[str, object], DEFAULT_CONFIG["memory"])
+    assert memory_config["prefetch_timeout"] == 8.0
 
 
 def test_real_config_reaches_memory_manager_under_temporary_hermes_home(

--- a/tests/run_agent/test_memory_provider_init.py
+++ b/tests/run_agent/test_memory_provider_init.py
@@ -250,26 +250,34 @@ def test_real_config_reaches_memory_manager_under_temporary_hermes_home(
     )
     from hermes_cli import config as config_module
 
+    previous_load_cache = dict(config_module._LOAD_CONFIG_CACHE)
+    previous_raw_cache = dict(config_module._RAW_CONFIG_CACHE)
     config_module._LOAD_CONFIG_CACHE.clear()
     config_module._RAW_CONFIG_CACHE.clear()
     provider = RecordingMemoryProvider()
 
-    with (
-        patch("plugins.memory.load_memory_provider", return_value=provider),
-        patch("agent.model_metadata.get_model_context_length", return_value=204_800),
-        patch("run_agent.get_tool_definitions", return_value=[]),
-        patch("run_agent.check_toolset_requirements", return_value={}),
-        patch("run_agent.OpenAI"),
-    ):
-        from run_agent import AIAgent
+    try:
+        with (
+            patch("plugins.memory.load_memory_provider", return_value=provider),
+            patch("agent.model_metadata.get_model_context_length", return_value=204_800),
+            patch("run_agent.get_tool_definitions", return_value=[]),
+            patch("run_agent.check_toolset_requirements", return_value={}),
+            patch("run_agent.OpenAI"),
+        ):
+            from run_agent import AIAgent
 
-        agent = AIAgent(
-            api_key="test-key-1234567890",
-            base_url="https://openrouter.ai/api/v1",
-            quiet_mode=True,
-            skip_context_files=True,
-            skip_memory=False,
-        )
+            agent = AIAgent(
+                api_key="test-key-1234567890",
+                base_url="https://openrouter.ai/api/v1",
+                quiet_mode=True,
+                skip_context_files=True,
+                skip_memory=False,
+            )
+    finally:
+        config_module._LOAD_CONFIG_CACHE.clear()
+        config_module._LOAD_CONFIG_CACHE.update(previous_load_cache)
+        config_module._RAW_CONFIG_CACHE.clear()
+        config_module._RAW_CONFIG_CACHE.update(previous_raw_cache)
 
     manager = getattr(agent, "_memory_manager")
     assert manager is not None

--- a/tests/run_agent/test_memory_provider_init.py
+++ b/tests/run_agent/test_memory_provider_init.py
@@ -3,6 +3,8 @@
 from types import SimpleNamespace
 from unittest.mock import patch
 
+import pytest
+
 
 class RecordingMemoryProvider:
     name = "recording"
@@ -41,6 +43,27 @@ def test_shutdown_memory_provider_is_idempotent():
 
     manager.on_session_end.assert_called_once()
     manager.shutdown_all.assert_called_once()
+
+
+def _make_agent_with_memory_config(cfg, provider):
+    with (
+        patch("hermes_cli.config.load_config", return_value=cfg),
+        patch("hermes_cli.config.load_config_readonly", return_value=cfg),
+        patch("plugins.memory.load_memory_provider", return_value=provider),
+        patch("agent.model_metadata.get_model_context_length", return_value=204_800),
+        patch("run_agent.get_tool_definitions", return_value=[]),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        from run_agent import AIAgent
+
+        return AIAgent(
+            api_key="test-key-1234567890",
+            base_url="https://openrouter.ai/api/v1",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=False,
+        )
 
 
 def test_blank_memory_provider_does_not_auto_enable_honcho():
@@ -126,6 +149,130 @@ def test_aiagent_forwards_user_id_alt_to_memory_provider():
     assert provider.init_kwargs["platform"] == "feishu"
     assert "warning_callback" not in provider.init_kwargs
     assert "status_callback" not in provider.init_kwargs
+
+
+def test_aiagent_forwards_memory_prefetch_timeout_to_manager():
+    provider = RecordingMemoryProvider()
+    cfg = {
+        "memory": {
+            "provider": "recording",
+            "prefetch_timeout": "12.5",
+        },
+        "agent": {},
+    }
+
+    agent = _make_agent_with_memory_config(cfg, provider)
+
+    manager = getattr(agent, "_memory_manager")
+    assert manager is not None
+    assert manager._external_prefetch_timeout == 12.5
+    assert provider.init_session_id == getattr(agent, "session_id")
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        (1, 1.0),
+        (1.5, 1.5),
+        ("2.5", 2.5),
+        (0.01, 0.01),
+        (3600, 3600.0),
+    ],
+)
+def test_valid_memory_prefetch_timeout_values_are_propagated(value, expected):
+    provider = RecordingMemoryProvider()
+    cfg = {
+        "memory": {"provider": "recording", "prefetch_timeout": value},
+        "agent": {},
+    }
+
+    agent = _make_agent_with_memory_config(cfg, provider)
+
+    manager = getattr(agent, "_memory_manager")
+    assert manager is not None
+    assert manager._external_prefetch_timeout == expected
+
+
+@pytest.mark.parametrize(
+    "value",
+    [True, False, "invalid", 0, -1, float("nan"), float("inf"), float("-inf"), 3600.1],
+)
+def test_invalid_memory_prefetch_timeout_falls_back_without_disabling_provider(
+    value,
+    caplog,
+):
+    provider = RecordingMemoryProvider()
+    cfg = {
+        "memory": {"provider": "recording", "prefetch_timeout": value},
+        "agent": {},
+    }
+
+    agent = _make_agent_with_memory_config(cfg, provider)
+
+    manager = getattr(agent, "_memory_manager")
+    assert manager is not None
+    assert manager._external_prefetch_timeout == 8.0
+    assert provider.init_session_id == getattr(agent, "session_id")
+    assert "Invalid memory.prefetch_timeout" in caplog.text
+    assert "using default 8.0 seconds" in caplog.text
+
+
+def test_missing_memory_prefetch_timeout_preserves_default():
+    provider = RecordingMemoryProvider()
+    cfg = {"memory": {"provider": "recording"}, "agent": {}}
+
+    agent = _make_agent_with_memory_config(cfg, provider)
+
+    manager = getattr(agent, "_memory_manager")
+    assert manager is not None
+    assert manager._external_prefetch_timeout == 8.0
+
+
+def test_memory_prefetch_timeout_is_registered_in_default_config():
+    from hermes_cli.config_defaults import DEFAULT_CONFIG
+
+    assert DEFAULT_CONFIG["memory"]["prefetch_timeout"] == 8.0
+
+
+def test_real_config_reaches_memory_manager_under_temporary_hermes_home(
+    tmp_path,
+    monkeypatch,
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    (tmp_path / "config.yaml").write_text(
+        "memory:\n"
+        "  provider: recording\n"
+        "  prefetch_timeout: 24.5\n",
+        encoding="utf-8",
+    )
+    from hermes_cli import config as config_module
+
+    config_module._LOAD_CONFIG_CACHE.clear()
+    config_module._RAW_CONFIG_CACHE.clear()
+    provider = RecordingMemoryProvider()
+
+    with (
+        patch("plugins.memory.load_memory_provider", return_value=provider),
+        patch("agent.model_metadata.get_model_context_length", return_value=204_800),
+        patch("run_agent.get_tool_definitions", return_value=[]),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        from run_agent import AIAgent
+
+        agent = AIAgent(
+            api_key="test-key-1234567890",
+            base_url="https://openrouter.ai/api/v1",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=False,
+        )
+
+    manager = getattr(agent, "_memory_manager")
+    assert manager is not None
+    assert manager._external_prefetch_timeout == 24.5
+    assert provider.init_kwargs is not None
+    assert provider.init_kwargs["hermes_home"] == str(tmp_path)
 
 
 class CoreShadowProvider:

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -678,9 +678,12 @@ memory:
   memory_char_limit: 2200   # ~800 tokens
   user_char_limit: 1375     # ~500 tokens
   write_approval: false     # true = require approval before any memory write
+  prefetch_timeout: 8       # seconds; external provider turn-start budget
 ```
 
 With `memory.write_approval: true`, memory writes need your approval before they land: interactive CLI turns prompt inline; messaging sessions and the background self-improvement review stage the write for `/memory pending` → `/memory approve <id>` / `/memory reject <id>` review. Toggle at runtime with `/memory approval on|off`. See [Controlling memory writes](/user-guide/features/memory#controlling-memory-writes-write_approval).
+
+`memory.prefetch_timeout` controls how long Hermes waits for any external memory provider before the first model call. The default is 8 seconds; valid values range from 0.01 to 3600 seconds. If your provider has its own request timeout, set the outer `memory.prefetch_timeout` to a larger value so Hermes does not stop waiting first.
 
 ## Context File Truncation
 

--- a/website/docs/user-guide/features/memory-providers.md
+++ b/website/docs/user-guide/features/memory-providers.md
@@ -541,6 +541,8 @@ hermes memory setup    # select "byterover"
 hermes config set memory.provider byterover
 ```
 
+**Automatic prefetch deadline:** `min(memory.prefetch_timeout, memory.byterover.timeout_query)`. The defaults are 8 seconds for `memory.prefetch_timeout` and 10 seconds for `memory.byterover.timeout_query`, so automatic prefetch waits for at most 8 seconds. Direct `brv_query` calls use `memory.byterover.timeout_query` only, which defaults to 10 seconds.
+
 **Key features:**
 - Automatic pre-compression extraction (saves insights before context compression discards them)
 - Knowledge tree stored at `$HERMES_HOME/byterover/` (profile-scoped)


### PR DESCRIPTION
## Summary

This makes two existing memory timeouts configurable without changing their defaults:

- `memory.prefetch_timeout` controls the outer wait for external memory prefetch. The default remains 8 seconds.
- `memory.byterover.timeout_query` controls ByteRover prefetch and `brv_query` calls. The default remains 10 seconds.
- Values must be finite numbers from 0.01 to 3600 seconds. Invalid values log a warning and fall back to the existing defaults instead of disabling the provider.
- The defaults and ByteRover schema metadata are registered, and the docs explain that the outer prefetch budget should exceed the provider request timeout.
- Tests cover propagation, fallbacks, bounds, schema metadata, the real config-to-agent path, and controlled timeout behavior without wall-clock sleeps.

## Context and credit

This is a credited replacement for [#69606](https://github.com/NousResearch/hermes-agent/pull/69606). Its [review thread](https://github.com/NousResearch/hermes-agent/pull/69606#discussion_r3680743792) identified the missing validation, tests, and docs. After a [coordination comment](https://github.com/NousResearch/hermes-agent/pull/69606#issuecomment-5246587260), @thitar [invited me to take over](https://github.com/NousResearch/hermes-agent/pull/69606#issuecomment-5258611257).

I rebased @thitar's original commit as the first commit in this branch rather than recreating it. The `Hermes Agent <hermes@tarrason.com>` author metadata is preserved, and the repository's contributor mapping associates that email with `thitar`. The follow-up validation, tests, and docs are separate assistant-authored commits.

I have not closed #69606; that remains a maintainer decision.

## Validation

- `scripts/run_tests.sh tests/run_agent/test_memory_provider_init.py tests/agent/test_memory_provider.py tests/plugins/memory/test_byterover_provider.py -q` - 109 passed
- `scripts/run_tests.sh tests/hermes_cli/test_config.py tests/hermes_cli/test_config_loader_e2e.py tests/hermes_cli/test_set_config_value.py -q` - 163 passed
- `uv run ruff check` on all changed Python files - passed
- `python scripts/audit_pr_attribution.py` - passed
- `git diff --check upstream/main...HEAD` - passed
- Added-line and commit-message privacy scan - no secrets, private paths, private hosts, task IDs, or session IDs
- Independent Gemini 3.1 Pro (High) review of exact head `dc32e2d2aedaf0e686b239a90221c2187932311e` against `951ae62ffc51e2c279142905a054d0f696e2a54f` - no blockers

I did not run the full suite locally. GitHub CI is the full-suite check.