### PR TITLE
fix(timeouts): reasoning-model floor must not override explicit stale_timeout_seconds

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -825,7 +825,12 @@ def _derive_stream_stale_timeout(agent, api_kwargs: dict) -> float:
     _reasoning_floor = get_reasoning_stale_timeout_floor(_model_id)
     if _reasoning_floor is None and api_kwargs.get("modelId"):
         _reasoning_floor = _bedrock_reasoning_stale_floor(api_kwargs["modelId"])
-    if _reasoning_floor is not None:
+    # The floor is an auto-mitigation for users who have NOT tuned this model.
+    # An explicit ``stale_timeout_seconds`` is a deliberate choice and wins
+    # outright — matching the non-stream resolver
+    # (``run_agent.AIAgent._resolved_api_call_stale_timeout_base``), which
+    # early-returns on provider config before ever consulting the floor.
+    if _reasoning_floor is not None and _cfg_stale is None:
         _timeout = max(_timeout, _reasoning_floor)
     return _timeout
 
@@ -5016,11 +5021,15 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
         # xAI Grok reasoning, etc.) routinely exceed the default 180s chat-
         # model threshold during their thinking phase.  The cloud gateway
         # upstream kills the socket first, surfacing as BrokenPipeError.
-        # Raises the floor only — never overrides explicit user config
-        # (handled by get_provider_stale_timeout above).
+        # Raises the floor only — never overrides explicit user config.  The
+        # ``_cfg_stale is None`` guard is what enforces that: the floor is an
+        # auto-mitigation for untuned models, so a deliberate
+        # ``stale_timeout_seconds`` wins outright.  Mirrors the non-stream
+        # resolver (``run_agent.AIAgent._resolved_api_call_stale_timeout_base``),
+        # which early-returns on provider config before consulting the floor.
         from agent.reasoning_timeouts import get_reasoning_stale_timeout_floor
         _reasoning_floor = get_reasoning_stale_timeout_floor(api_kwargs.get("model"))
-        if _reasoning_floor is not None:
+        if _reasoning_floor is not None and _cfg_stale is None:
             _stream_stale_timeout = max(_stream_stale_timeout, _reasoning_floor)
 
     t = threading.Thread(target=_context_thread_target(_call), daemon=True)

--- a/tests/agent/test_reasoning_stale_timeout_floor.py
+++ b/tests/agent/test_reasoning_stale_timeout_floor.py
@@ -204,3 +204,95 @@ def test_stream_stale_timeout_floor_for_nemotron_3_ultra():
         est_tokens=10_000,
     )
     assert timeout == 600.0
+
+
+# ── real-function tests: explicit config must beat the floor ──────────────
+#
+# The mirror above cannot catch a config/floor precedence bug: it stubs config
+# handling out entirely (`if stale_base != 180.0: pass`) and then applies the
+# floor unconditionally.  These call the production resolver instead.
+#
+# The bug these pin: both stream-side sites applied the floor as
+# `max(timeout, floor)` *after* reading provider config, so a user setting
+# `stale_timeout_seconds: 60` on a floored model silently got 600s — while the
+# non-stream resolver early-returns on config and never consults the floor.
+# Same feature, two paths, opposite semantics.
+
+
+class _FakeAgent:
+    """Minimal stand-in — the resolver only reads .provider and .model."""
+
+    def __init__(self, provider: str, model: str) -> None:
+        self.provider = provider
+        self.model = model
+
+
+@pytest.fixture
+def _no_stale_env(monkeypatch):
+    """The resolver falls back to this env var; keep it out of the way."""
+    monkeypatch.delenv("HERMES_STREAM_STALE_TIMEOUT", raising=False)
+
+
+def _derive(monkeypatch, cfg_stale, model, est_tokens=10_000):
+    from agent import chat_completion_helpers as cch
+
+    monkeypatch.setattr(
+        cch, "get_provider_stale_timeout", lambda provider, m: cfg_stale
+    )
+    return cch._derive_stream_stale_timeout(
+        _FakeAgent("nvidia", model),
+        {"model": model, "messages": [{"role": "user", "content": "x" * est_tokens}]},
+    )
+
+
+def test_floor_applies_when_user_has_not_configured_a_stale_timeout(
+    monkeypatch, _no_stale_env
+):
+    """No explicit config -> the 600s auto-mitigation still applies.
+
+    This is the behavior the floor exists for; the fix must not weaken it.
+    """
+    assert _derive(monkeypatch, None, "deepseek-ai/deepseek-v4-flash-0731") == 600.0
+
+
+def test_explicit_config_below_floor_wins(monkeypatch, _no_stale_env):
+    """`stale_timeout_seconds: 60` must stay 60, not be raised to 600.
+
+    Regression: this returned 600.0.  A user who deliberately wants fast
+    failover on a slow reasoning model could not get it — the knob silently
+    did nothing, and the docstring claimed the opposite.
+    """
+    assert _derive(monkeypatch, 60.0, "deepseek-ai/deepseek-v4-flash-0731") == 60.0
+
+
+def test_explicit_config_above_floor_is_also_honored(monkeypatch, _no_stale_env):
+    """Config wins in both directions — it is not a second floor."""
+    assert _derive(monkeypatch, 900.0, "deepseek-ai/deepseek-v4-flash-0731") == 900.0
+
+
+def test_non_reasoning_model_is_unaffected(monkeypatch, _no_stale_env):
+    """No floor matches -> config passes through untouched."""
+    assert _derive(monkeypatch, 60.0, "z-ai/glm-5.2") == 60.0
+
+
+def test_stream_and_non_stream_resolvers_agree_on_precedence(
+    monkeypatch, _no_stale_env
+):
+    """The two paths must not disagree about what explicit config means.
+
+    This is the invariant whose violation was the bug: the non-stream resolver
+    early-returns on provider config, so the stream resolver must not raise
+    that same value to the floor.
+    """
+    import run_agent
+
+    model = "deepseek-ai/deepseek-v4-flash-0731"
+    monkeypatch.setattr(
+        run_agent, "get_provider_stale_timeout", lambda provider, m: 60.0
+    )
+    agent = run_agent.AIAgent.__new__(run_agent.AIAgent)
+    agent.provider, agent.model = "nvidia", model
+    non_stream_base, _ = agent._resolved_api_call_stale_timeout_base()
+
+    assert non_stream_base == 60.0
+    assert _derive(monkeypatch, 60.0, model) == non_stream_base


### PR DESCRIPTION
## Problem

Both stream-side stale-timeout resolvers read `providers.<id>.models.<model>.stale_timeout_seconds` and then apply the reasoning-model floor as `max(timeout, floor)`. An explicit config value **below** the floor is silently discarded — setting `stale_timeout_seconds: 60` on a floored model yields 600s, and the knob appears to do nothing.

This contradicts the documented contract in two places.

`agent/reasoning_timeouts.py`:
> Never overrides explicit user config (``providers.<id>.models.<model>.stale_timeout_seconds`` or ``request_timeout_seconds`` already wins — this code never runs in that branch).

and the inline comment at the stream site:
> Raises the floor only — never overrides explicit user config (handled by `get_provider_stale_timeout` above).

Neither was accurate.

## Why this is a bug and not a design choice

The **non-stream** resolver already implements the documented precedence. `AIAgent._resolved_api_call_stale_timeout_base` early-returns on provider config and never consults the floor:

```python
cfg = get_provider_stale_timeout(self.provider, self.model)
if cfg is not None:
    return cfg, False        # floor never reached
```

So the same feature behaves one way for non-streaming requests and the opposite way for streaming ones. This PR aligns the stream paths with the non-stream one; it does not change the intended contract.

## Fix

A `_cfg_stale is None` guard at both sites — `_derive_stream_stale_timeout` (shared with the Bedrock streaming watchdog) and the main streaming path. The floor still applies in full whenever the user has **not** configured that model, which is the case it was introduced for in #52217.

## Why it went unnoticed

The existing stream-side test mirrors the production logic instead of calling it, and the mirror stubs config handling out before applying the floor unconditionally:

```python
if stale_base != 180.0:
    pass  # In production this is sourced from config; here we parameterize.
```

so it structurally cannot observe a config/floor precedence bug. That mirror has also drifted from production: it cites "lines 2539-2575" (the block is now ~4990-5030) and returns `float("inf")` for local endpoints where production returns a 900s default. I've left it alone to keep this PR focused, but it's worth replacing with real-function tests.

## Tests

Five new tests calling the real resolver rather than a mirror:

| test | before | after |
|---|---|---|
| `test_floor_applies_when_user_has_not_configured_a_stale_timeout` | pass | pass |
| `test_explicit_config_below_floor_wins` | **FAIL** `600.0 != 60.0` | pass |
| `test_explicit_config_above_floor_is_also_honored` | pass | pass |
| `test_non_reasoning_model_is_unaffected` | pass | pass |
| `test_stream_and_non_stream_resolvers_agree_on_precedence` | **FAIL** `600.0 != 60.0` | pass |

The three that pass in both states are deliberate — they pin behavior the fix must **not** change, in particular that an unconfigured reasoning model still gets its floor.

The last test asserts the stream and non-stream resolvers agree on what explicit config means. That invariant's violation *was* the bug, so it seemed worth encoding directly.

Full `tests/agent`, before and after: **188 pre-existing failures in both runs, identical sets** (network-dependent tests in a sandbox), passed count 4389 → 4394 (the five new tests). No regressions.

## How it was found

Routing a Hermes deployment onto `deepseek-ai/deepseek-v4-flash-0731`, which is bimodal on NVIDIA NIM — first-token latency ranges from ~6s to ~294s. A slow *success* never triggers failover, so the turn stalls; the intended mitigation was `stale_timeout_seconds: 60` to fail over to a fast backup. The setting had no effect, because `deepseek-v4-flash` carries a 600s floor. Worked around with `timeout_seconds` (which routes through `get_provider_request_timeout` and escapes the floor), but the documented behavior should hold.

## Open question for maintainers

The context-size scaling immediately above applies the same `max(base, 240/300)` shape to explicitly-configured values. I've deliberately left it unchanged since the documented claim names the reasoning floor specifically, but if "explicit config wins" is meant to hold generally, that block likely needs the same guard. Happy to extend this PR if you'd prefer.