### PR TITLE
fix(file_state): sibling stale-warning now guides worktree isolation

### DIFF
--- a/tools/file_state.py
+++ b/tools/file_state.py
@@ -178,7 +178,10 @@ class FileStateRegistry:
                         f"{resolved} was modified by sibling subagent "
                         f"{writer_tid!r} but this agent never read it. "
                         "Read the file before writing to avoid overwriting "
-                        "the sibling's changes."
+                        "the sibling's changes. If concurrent agents will "
+                        "keep editing this repo, isolate in a git worktree "
+                        "(`hermes -w` / `git worktree add`) or coordinate "
+                        "to avoid further clobbers."
                     )
                 read_ts = stamp[1]
                 if writer_ts > read_ts:
@@ -186,7 +189,10 @@ class FileStateRegistry:
                         f"{resolved} was modified by sibling subagent "
                         f"{writer_tid!r} at {_fmt_ts(writer_ts)} — after "
                         f"this agent's last read at {_fmt_ts(read_ts)}. "
-                        "Re-read the file before writing."
+                        "Re-read the file before writing. If concurrent "
+                        "agents will keep editing this repo, isolate in a "
+                        "git worktree (`hermes -w` / `git worktree add`) "
+                        "or coordinate to avoid further clobbers."
                     )
 
         # Case 2: external / unknown modification (mtime drifted).


### PR DESCRIPTION
## Context

When concurrent Hermes sessions edit the same git repository, `FileStateRegistry.check_stale()` warns the model that a sibling subagent modified a file it had read. A real incident (two sessions clobbering each other on the same file) showed the warning alone is not enough: it only says "Re-read the file" — it never tells the model there is an active sibling session, that parallel edits carry clobber risk, or what to do about it.

## Change

Both sibling-warning branches in `tools/file_state.py::check_stale` (Case 1a "sibling wrote, agent never read" and Case 1b "sibling wrote after agent's last read") now append a short collaboration-guidance line:

- names the risk: concurrent agents may keep editing this repo;
- gives the escape hatch: isolate in a git worktree (`hermes -w` / `git worktree add`) or coordinate with the sibling session.

The added text is intentionally short, generic (no project-specific skill names), and stays warning-only — consistent with the existing "warn, don't block" contract of `check_stale`.

## Relationship to #65605

#65605 (`fix: block stale write_file overwrites`) is the complementary direction: it makes `write_file` fail closed on stale baselines by changing `tools/file_tools.py` and the staleness plumbing. This PR touches only warning text in `tools/file_state.py` and does not conflict with it — both can land independently; if #65605 lands first, this guidance still improves the surviving warning path.

## Tests

- `tests/tools/test_file_state_registry.py`: 7 passed (existing sibling assertions still hold, warning text retains `sibling` + writer id)
- `tests/tools/test_file_staleness.py`: 6 passed
