### PR TITLE
fix(file): bound read_file stalls

### DIFF
--- a/tests/tools/test_read_file_timeout.py
+++ b/tests/tools/test_read_file_timeout.py
@@ -89,3 +89,173 @@ def test_late_read_does_not_publish_bookkeeping(tmp_path, monkeypatch):
         release.set()
         with file_tools._read_tracker_lock:
             file_tools._read_tracker.pop(task_id, None)
+
+
+def test_timeout_wins_before_bookkeeping_commit(tmp_path, monkeypatch):
+    path = tmp_path / "cloud.md"
+    path.write_text("local placeholder")
+    commit_attempted = threading.Event()
+    release_commit = threading.Event()
+    worker_finished = threading.Event()
+    call_finished = threading.Event()
+    payload_holder = {}
+    record_read = MagicMock()
+    real_impl = file_tools._read_file_tool_impl
+    real_try_begin_commit = file_tools._ReadAbandonState.try_begin_commit
+
+    def _observed_impl(*args, **kwargs):
+        try:
+            return real_impl(*args, **kwargs)
+        finally:
+            worker_finished.set()
+
+    def _blocked_try_begin_commit(self):
+        commit_attempted.set()
+        assert release_commit.wait(timeout=1)
+        return real_try_begin_commit(self)
+
+    class _FastOps:
+        def read_file(self, *_args, **_kwargs):
+            return ReadResult(content="late content", total_lines=1, file_size=12)
+
+    def _call_read_file():
+        payload_holder["payload"] = json.loads(
+            file_tools.read_file_tool(str(path), task_id=task_id)
+        )
+        call_finished.set()
+
+    task_id = "bookkeeping-race-task"
+    with file_tools._read_tracker_lock:
+        file_tools._read_tracker.pop(task_id, None)
+
+    monkeypatch.setattr(file_tools, "_get_file_ops", lambda _task_id: _FastOps())
+    monkeypatch.setattr(file_tools, "_file_ops_uses_host_paths", lambda _ops: True)
+    monkeypatch.setattr(file_tools, "_resolve_read_file_timeout", lambda: 0.05)
+    monkeypatch.setattr(file_tools, "_read_file_tool_impl", _observed_impl)
+    monkeypatch.setattr(
+        file_tools._ReadAbandonState,
+        "try_begin_commit",
+        _blocked_try_begin_commit,
+    )
+    monkeypatch.setattr(file_tools.file_state, "record_read", record_read)
+
+    caller = threading.Thread(target=_call_read_file)
+    caller.start()
+    try:
+        assert commit_attempted.wait(timeout=1)
+        assert call_finished.wait(timeout=1)
+        assert payload_holder["payload"]["error_type"] == "tool_timeout"
+        release_commit.set()
+        caller.join(timeout=1)
+        assert worker_finished.wait(timeout=1)
+
+        with file_tools._read_tracker_lock:
+            task_data = file_tools._read_tracker[task_id]
+            assert task_data["last_key"] is None
+            assert task_data["consecutive"] == 0
+            assert task_data["dedup"] == {}
+            assert task_data["read_timestamps"] == {}
+        record_read.assert_not_called()
+    finally:
+        release_commit.set()
+        caller.join(timeout=1)
+        with file_tools._read_tracker_lock:
+            file_tools._read_tracker.pop(task_id, None)
+
+
+def test_commit_winner_returns_real_result_instead_of_timeout(tmp_path, monkeypatch):
+    path = tmp_path / "cloud.md"
+    path.write_text("local placeholder")
+    commit_claimed = threading.Event()
+    release_commit = threading.Event()
+    call_finished = threading.Event()
+    payload_holder = {}
+    record_read = MagicMock()
+    real_try_begin_commit = file_tools._ReadAbandonState.try_begin_commit
+
+    def _claimed_then_blocked(self):
+        claimed = real_try_begin_commit(self)
+        assert claimed
+        commit_claimed.set()
+        assert release_commit.wait(timeout=1)
+        return claimed
+
+    class _FastOps:
+        def read_file(self, *_args, **_kwargs):
+            return ReadResult(content="on-time content", total_lines=1, file_size=15)
+
+    task_id = "bookkeeping-commit-winner-task"
+    with file_tools._read_tracker_lock:
+        file_tools._read_tracker.pop(task_id, None)
+
+    monkeypatch.setattr(file_tools, "_get_file_ops", lambda _task_id: _FastOps())
+    monkeypatch.setattr(file_tools, "_file_ops_uses_host_paths", lambda _ops: True)
+    monkeypatch.setattr(file_tools, "_resolve_read_file_timeout", lambda: 0.05)
+    monkeypatch.setattr(
+        file_tools._ReadAbandonState,
+        "try_begin_commit",
+        _claimed_then_blocked,
+    )
+    monkeypatch.setattr(file_tools.file_state, "record_read", record_read)
+
+    def _call_read_file():
+        payload_holder["payload"] = json.loads(
+            file_tools.read_file_tool(str(path), task_id=task_id)
+        )
+        call_finished.set()
+
+    caller = threading.Thread(target=_call_read_file)
+    caller.start()
+    try:
+        assert commit_claimed.wait(timeout=1)
+        time.sleep(0.1)
+        assert not call_finished.is_set()
+        release_commit.set()
+        assert call_finished.wait(timeout=1)
+        caller.join(timeout=1)
+
+        payload = payload_holder["payload"]
+        assert payload["content"] == "on-time content"
+        assert "error_type" not in payload
+        with file_tools._read_tracker_lock:
+            task_data = file_tools._read_tracker[task_id]
+            assert task_data["last_key"] == ("read", str(path), 1, 2000)
+            assert task_data["consecutive"] == 1
+        record_read.assert_called_once()
+        assert record_read.call_args.kwargs["mtime"] == path.stat().st_mtime
+    finally:
+        release_commit.set()
+        caller.join(timeout=1)
+        with file_tools._read_tracker_lock:
+            file_tools._read_tracker.pop(task_id, None)
+
+
+def test_unavailable_mtime_does_not_restat_after_commit(tmp_path, monkeypatch):
+    path = tmp_path / "cloud.md"
+    path.write_text("local placeholder")
+    getmtime = MagicMock(side_effect=OSError("metadata unavailable"))
+    record_read = MagicMock()
+
+    class _FastOps:
+        def read_file(self, *_args, **_kwargs):
+            return ReadResult(content="content", total_lines=1, file_size=7)
+
+    task_id = "bookkeeping-no-mtime-task"
+    with file_tools._read_tracker_lock:
+        file_tools._read_tracker.pop(task_id, None)
+
+    monkeypatch.setattr(file_tools, "_get_file_ops", lambda _task_id: _FastOps())
+    monkeypatch.setattr(file_tools, "_file_ops_uses_host_paths", lambda _ops: True)
+    monkeypatch.setattr(file_tools, "_resolve_read_file_timeout", lambda: 0.05)
+    monkeypatch.setattr(file_tools.os.path, "getmtime", getmtime)
+    monkeypatch.setattr(file_tools.file_state, "record_read", record_read)
+
+    try:
+        payload = json.loads(file_tools.read_file_tool(str(path), task_id=task_id))
+        assert payload["content"] == "content"
+        assert "error_type" not in payload
+        getmtime.assert_called_once_with(str(path))
+        record_read.assert_not_called()
+    finally:
+        with file_tools._read_tracker_lock:
+            file_tools._read_tracker.pop(task_id, None)

--- a/tests/tools/test_read_file_timeout.py
+++ b/tests/tools/test_read_file_timeout.py
@@ -1,0 +1,47 @@
+"""Bounded read_file behavior for cloud-backed or wedged filesystems."""
+
+import json
+import threading
+import time
+
+from tools import file_tools
+
+
+def test_read_file_timeout_returns_actionable_structured_error(monkeypatch):
+    started = threading.Event()
+    release = threading.Event()
+
+    def _wedged_read(*_args, **_kwargs):
+        started.set()
+        release.wait()
+        return "late result"
+
+    monkeypatch.setattr(file_tools, "_read_file_tool_impl", _wedged_read)
+    monkeypatch.setattr(file_tools, "_resolve_read_file_timeout", lambda: 0.05)
+
+    before = time.monotonic()
+    try:
+        payload = json.loads(file_tools.read_file_tool("/cloud/project/file.md"))
+    finally:
+        release.set()
+
+    assert started.is_set()
+    assert time.monotonic() - before < 1.0
+    assert payload["error_type"] == "tool_timeout"
+    assert payload["timeout_seconds"] == 0.05
+    assert payload["path"] == "/cloud/project/file.md"
+    assert "local clone/direct source" in payload["error"]
+    assert "instead of retrying the same read" in payload["error"]
+
+
+def test_read_file_timeout_can_be_disabled(monkeypatch):
+    monkeypatch.setattr(file_tools, "_resolve_read_file_timeout", lambda: None)
+    monkeypatch.setattr(
+        file_tools,
+        "_read_file_tool_impl",
+        lambda path, offset, limit, task_id: f"{path}|{offset}|{limit}|{task_id}",
+    )
+
+    assert file_tools.read_file_tool("notes.md", 3, 7, "task-1") == (
+        "notes.md|3|7|task-1"
+    )

--- a/tests/tools/test_read_file_timeout.py
+++ b/tests/tools/test_read_file_timeout.py
@@ -79,11 +79,13 @@ def test_late_read_does_not_publish_bookkeeping(tmp_path, monkeypatch):
         time.sleep(0.05)
 
         with file_tools._read_tracker_lock:
-            task_data = file_tools._read_tracker[task_id]
-            assert task_data["last_key"] is None
-            assert task_data["consecutive"] == 0
-            assert task_data["dedup"] == {}
-            assert task_data["read_timestamps"] == {}
+            task_data = file_tools._read_tracker.get(task_id)
+            assert task_data is None or (
+                task_data["last_key"] is None
+                and task_data["consecutive"] == 0
+                and task_data["dedup"] == {}
+                and task_data["read_timestamps"] == {}
+            )
         record_read.assert_not_called()
     finally:
         release.set()
@@ -150,11 +152,13 @@ def test_timeout_wins_before_bookkeeping_commit(tmp_path, monkeypatch):
         assert worker_finished.wait(timeout=1)
 
         with file_tools._read_tracker_lock:
-            task_data = file_tools._read_tracker[task_id]
-            assert task_data["last_key"] is None
-            assert task_data["consecutive"] == 0
-            assert task_data["dedup"] == {}
-            assert task_data["read_timestamps"] == {}
+            task_data = file_tools._read_tracker.get(task_id)
+            assert task_data is None or (
+                task_data["last_key"] is None
+                and task_data["consecutive"] == 0
+                and task_data["dedup"] == {}
+                and task_data["read_timestamps"] == {}
+            )
         record_read.assert_not_called()
     finally:
         release_commit.set()
@@ -259,3 +263,146 @@ def test_unavailable_mtime_does_not_restat_after_commit(tmp_path, monkeypatch):
     finally:
         with file_tools._read_tracker_lock:
             file_tools._read_tracker.pop(task_id, None)
+
+
+def test_late_dedup_hit_does_not_publish_after_timeout(tmp_path, monkeypatch):
+    path = tmp_path / "cloud.md"
+    path.write_text("cached content")
+    release_stat = threading.Event()
+    stat_started = threading.Event()
+    worker_finished = threading.Event()
+    real_impl = file_tools._read_file_tool_impl
+    cached_mtime = path.stat().st_mtime
+    task_id = "late-dedup-hit-task"
+    dedup_key = (str(path), 1, 2000)
+    executor = file_tools.DaemonThreadPoolExecutor(max_workers=1)
+    admission = threading.BoundedSemaphore(1)
+
+    with file_tools._read_tracker_lock:
+        file_tools._read_tracker[task_id] = {
+            "last_key": None,
+            "consecutive": 0,
+            "read_history": set(),
+            "dedup": {dedup_key: cached_mtime},
+            "dedup_hits": {},
+            "read_timestamps": {},
+            "not_found": {},
+        }
+
+    def _wedged_getmtime(_path):
+        stat_started.set()
+        assert release_stat.wait(timeout=1)
+        return cached_mtime
+
+    def _observed_impl(*args, **kwargs):
+        try:
+            return real_impl(*args, **kwargs)
+        finally:
+            worker_finished.set()
+
+    real_submit = executor.submit
+
+    def _submit_after_worker_reaches_stat(*args, **kwargs):
+        future = real_submit(*args, **kwargs)
+        assert stat_started.wait(timeout=1)
+        return future
+
+    monkeypatch.setattr(file_tools, "_resolve_read_file_timeout", lambda: 0.05)
+    monkeypatch.setattr(file_tools, "_read_file_tool_impl", _observed_impl)
+    monkeypatch.setattr(file_tools, "_read_file_executor", executor)
+    monkeypatch.setattr(file_tools, "_read_file_admission", admission)
+    monkeypatch.setattr(executor, "submit", _submit_after_worker_reaches_stat)
+    monkeypatch.setattr(file_tools.os.path, "getmtime", _wedged_getmtime)
+
+    try:
+        payload = json.loads(file_tools.read_file_tool(str(path), task_id=task_id))
+        assert stat_started.is_set()
+        assert payload["error_type"] == "tool_timeout"
+
+        release_stat.set()
+        assert worker_finished.wait(timeout=1)
+        with file_tools._read_tracker_lock:
+            assert file_tools._read_tracker[task_id]["dedup_hits"] == {}
+    finally:
+        release_stat.set()
+        executor.shutdown(wait=True, cancel_futures=True)
+        with file_tools._read_tracker_lock:
+            file_tools._read_tracker.pop(task_id, None)
+
+
+def test_late_negative_cache_existence_check_does_not_publish_after_timeout(
+    tmp_path, monkeypatch
+):
+    path = tmp_path / "created-later.md"
+    path.write_text("real content")
+    release_exists = threading.Event()
+    exists_started = threading.Event()
+    worker_finished = threading.Event()
+    real_impl = file_tools._read_file_tool_impl
+    task_id = "late-negative-cache-task"
+    cache_key = ("read", str(path))
+
+    file_tools._record_not_found(
+        "read", str(path), task_id, '{"error":"File not found: cached"}'
+    )
+
+    def _wedged_exists(_path):
+        exists_started.set()
+        assert release_exists.wait(timeout=1)
+        return True
+
+    def _observed_impl(*args, **kwargs):
+        try:
+            return real_impl(*args, **kwargs)
+        finally:
+            worker_finished.set()
+
+    monkeypatch.setattr(file_tools, "_resolve_read_file_timeout", lambda: 0.05)
+    monkeypatch.setattr(file_tools, "_read_file_tool_impl", _observed_impl)
+    monkeypatch.setattr(file_tools.os.path, "exists", _wedged_exists)
+
+    try:
+        payload = json.loads(file_tools.read_file_tool(str(path), task_id=task_id))
+        assert exists_started.is_set()
+        assert payload["error_type"] == "tool_timeout"
+
+        release_exists.set()
+        assert worker_finished.wait(timeout=1)
+        with file_tools._read_tracker_lock:
+            assert cache_key in file_tools._read_tracker[task_id]["not_found"]
+    finally:
+        release_exists.set()
+        with file_tools._read_tracker_lock:
+            file_tools._read_tracker.pop(task_id, None)
+
+
+def test_timed_out_reads_use_a_process_wide_bounded_worker_pool(monkeypatch):
+    release = threading.Event()
+    started_lock = threading.Lock()
+    started = 0
+    executor = file_tools.DaemonThreadPoolExecutor(max_workers=4)
+    admission = threading.BoundedSemaphore(4)
+
+    def _wedged_read(*_args, **_kwargs):
+        nonlocal started
+        with started_lock:
+            started += 1
+        release.wait()
+        return "late result"
+
+    monkeypatch.setattr(file_tools, "_read_file_tool_impl", _wedged_read)
+    monkeypatch.setattr(file_tools, "_resolve_read_file_timeout", lambda: 0.1)
+    monkeypatch.setattr(file_tools, "_read_file_executor", executor)
+    monkeypatch.setattr(file_tools, "_read_file_admission", admission)
+
+    try:
+        payloads = [
+            json.loads(file_tools.read_file_tool(f"/cloud/stuck-{index}.md"))
+            for index in range(6)
+        ]
+        assert all(payload["error_type"] == "tool_timeout" for payload in payloads)
+        with started_lock:
+            assert started == 4
+    finally:
+        release.set()
+        executor.shutdown(wait=True, cancel_futures=True)

--- a/tests/tools/test_read_file_timeout.py
+++ b/tests/tools/test_read_file_timeout.py
@@ -3,8 +3,10 @@
 import json
 import threading
 import time
+from unittest.mock import MagicMock
 
 from tools import file_tools
+from tools.file_operations import ReadResult
 
 
 def test_read_file_timeout_returns_actionable_structured_error(monkeypatch):
@@ -45,3 +47,45 @@ def test_read_file_timeout_can_be_disabled(monkeypatch):
     assert file_tools.read_file_tool("notes.md", 3, 7, "task-1") == (
         "notes.md|3|7|task-1"
     )
+
+
+def test_late_read_does_not_publish_bookkeeping(tmp_path, monkeypatch):
+    path = tmp_path / "cloud.md"
+    path.write_text("local placeholder")
+    release = threading.Event()
+    read_returned = threading.Event()
+    record_read = MagicMock()
+
+    class _WedgedOps:
+        def read_file(self, *_args, **_kwargs):
+            release.wait()
+            read_returned.set()
+            return ReadResult(content="late content", total_lines=1, file_size=12)
+
+    task_id = "late-read-task"
+    with file_tools._read_tracker_lock:
+        file_tools._read_tracker.pop(task_id, None)
+
+    monkeypatch.setattr(file_tools, "_get_file_ops", lambda _task_id: _WedgedOps())
+    monkeypatch.setattr(file_tools, "_file_ops_uses_host_paths", lambda _ops: True)
+    monkeypatch.setattr(file_tools, "_resolve_read_file_timeout", lambda: 0.05)
+    monkeypatch.setattr(file_tools.file_state, "record_read", record_read)
+
+    try:
+        payload = json.loads(file_tools.read_file_tool(str(path), task_id=task_id))
+        assert payload["error_type"] == "tool_timeout"
+        release.set()
+        assert read_returned.wait(timeout=1)
+        time.sleep(0.05)
+
+        with file_tools._read_tracker_lock:
+            task_data = file_tools._read_tracker[task_id]
+            assert task_data["last_key"] is None
+            assert task_data["consecutive"] == 0
+            assert task_data["dedup"] == {}
+            assert task_data["read_timestamps"] == {}
+        record_read.assert_not_called()
+    finally:
+        release.set()
+        with file_tools._read_tracker_lock:
+            file_tools._read_tracker.pop(task_id, None)

--- a/tests/tools/test_read_shell_line_clamp.py
+++ b/tests/tools/test_read_shell_line_clamp.py
@@ -23,7 +23,7 @@ import pytest
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
 
 from tools.environments.local import LocalEnvironment
-from tools.file_operations import ShellFileOperations
+from tools.file_operations import ExecuteResult, ShellFileOperations
 from tools.tool_output_limits import get_max_line_length
 
 
@@ -70,6 +70,32 @@ def test_normal_multiline_read_unchanged(tmp_path, ops):
     result = ops.read_file(str(p))
     assert result.error is None
     assert result.content.startswith("1|alpha\n2|beta\n3|gamma")
+
+
+@pytest.mark.parametrize("method_name", ["read_file", "read_file_raw", "read_file_bytes"])
+def test_size_probe_access_failure_is_not_reported_as_missing(
+    monkeypatch, ops, method_name
+):
+    """A TCC/cloud open denial must preserve its actionable diagnostic."""
+    diagnostic = "bash: /cloud/file.txt: Operation not permitted"
+    monkeypatch.setattr(
+        ops,
+        "_exec",
+        lambda *_args, **_kwargs: ExecuteResult(stdout=diagnostic, exit_code=1),
+    )
+
+    result = getattr(ops, method_name)("/cloud/file.txt")
+
+    assert "filesystem access failed" in result.error
+    assert "Operation not permitted" in result.error
+    assert "not found" not in result.error.lower()
+
+
+def test_size_probe_does_not_suppress_open_diagnostics(ops):
+    command = ops._size_probe_cmd("/cloud/file.txt")
+
+    assert "wc -c <" in command
+    assert "2>/dev/null" not in command
 
 
 def test_no_trailing_newline_preserved(tmp_path, ops):

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -1336,7 +1336,7 @@ class ShellFileOperations(FileOperations):
         """
         arg = self._escape_shell_arg(path)
         return (
-            f"if [ -f {arg} ]; then wc -c < {arg} 2>/dev/null; "
+            f"if [ -f {arg} ]; then wc -c < {arg}; "
             f"elif [ -e {arg} ]; then echo {NOT_REGULAR_SENTINEL}; "
             f"else exit 1; fi"
         )
@@ -1457,6 +1457,24 @@ class ShellFileOperations(FileOperations):
             hint=" ".join(hint_parts),
         )
 
+    @staticmethod
+    def _size_probe_failure(path: str, result: ExecuteResult) -> Optional[ReadResult]:
+        """Preserve an open/access diagnostic from a failed size probe.
+
+        A missing path produces no probe output and should continue through
+        the unicode/similar-file path. A real filesystem denial is actionable
+        and must not be rewritten as "not found".
+        """
+        diagnostic = _strip_terminal_fence_leaks(result.stdout).strip()
+        if not diagnostic:
+            return None
+        return ReadResult(
+            error=(
+                f"Cannot read '{path}': filesystem access failed — "
+                f"{diagnostic}"
+            )
+        )
+
     def read_file(self, path: str, offset: int = 1, limit: int = 2000) -> ReadResult:
         """
         Read a file with pagination, binary detection, and line numbers.
@@ -1478,6 +1496,15 @@ class ShellFileOperations(FileOperations):
         stat_result = self._exec(self._size_probe_cmd(path))
 
         if stat_result.exit_code != 0:
+            # A cloud placeholder or TCC-protected file can pass ``[ -f ]``
+            # while the subsequent open fails (for example, macOS reports
+            # ``Operation not permitted`` for a dataless iCloud file).  Do not
+            # erase that diagnostic and misreport the path as missing: doing so
+            # sends the caller into unicode/similar-file retries even though the
+            # exact path is correct.
+            probe_failure = self._size_probe_failure(path, stat_result)
+            if probe_failure is not None:
+                return probe_failure
             # File not found. Before failing, try unicode-equivalent
             # spellings — NFC/NFD, narrow no-break space, curly quotes
             # render identically in a terminal, so the model retyping a
@@ -1762,6 +1789,9 @@ class ShellFileOperations(FileOperations):
         path = self._expand_path(path)
         stat_result = self._exec(self._size_probe_cmd(path))
         if stat_result.exit_code != 0:
+            probe_failure = self._size_probe_failure(path, stat_result)
+            if probe_failure is not None:
+                return probe_failure
             return self._suggest_similar_files(path)
         stat_output = _strip_terminal_fence_leaks(stat_result.stdout)
         if stat_output.strip() == NOT_REGULAR_SENTINEL:
@@ -1804,6 +1834,9 @@ class ShellFileOperations(FileOperations):
         path = self._expand_path(path)
         stat_result = self._exec(self._size_probe_cmd(path))
         if stat_result.exit_code != 0:
+            probe_failure = self._size_probe_failure(path, stat_result)
+            if probe_failure is not None:
+                return probe_failure
             return ReadResult(error=f"File not found: {path}")
         stat_output = _strip_terminal_fence_leaks(stat_result.stdout)
         if stat_output.strip() == NOT_REGULAR_SENTINEL:

--- a/tools/file_state.py
+++ b/tools/file_state.py
@@ -292,8 +292,19 @@ def _cap_dict(d: dict, limit: int) -> None:
 
 
 # ── Convenience wrappers (short names used at call sites) ────────────
-def record_read(task_id: str, resolved_or_path: str | Path, *, partial: bool = False) -> None:
-    _registry.record_read(task_id, str(resolved_or_path), partial=partial)
+def record_read(
+    task_id: str,
+    resolved_or_path: str | Path,
+    *,
+    partial: bool = False,
+    mtime: Optional[float] = None,
+) -> None:
+    _registry.record_read(
+        task_id,
+        str(resolved_or_path),
+        partial=partial,
+        mtime=mtime,
+    )
 
 
 def note_write(task_id: str, resolved_or_path: str | Path) -> None:

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -2,6 +2,7 @@
 """File Tools Module - LLM agent file manipulation tools."""
 
 import base64
+import contextvars
 import errno
 import json
 import logging
@@ -1621,6 +1622,11 @@ def _special_file_kind(path) -> str | None:
     return "a special (non-regular) file"
 
 
+_read_abandon_event: contextvars.ContextVar[threading.Event | None] = (
+    contextvars.ContextVar("read_file_abandon_event", default=None)
+)
+
+
 def _read_file_tool_impl(path: str, offset: int = 1, limit: int = 2000, task_id: str = "default") -> str:
     """Read a file with pagination and line numbers."""
     try:
@@ -1849,6 +1855,13 @@ def _read_file_tool_impl(path: str, offset: int = 1, limit: int = 2000, task_id:
         result = file_ops.read_file(path, offset, limit)
         result_dict = result.to_dict()
 
+        abandon_event = _read_abandon_event.get()
+        if abandon_event is not None and abandon_event.is_set():
+            # The caller already returned a timeout. Do not publish a late read
+            # into dedup/staleness registries that refer to content the model
+            # never received.
+            return tool_error("read_file result abandoned after timeout")
+
         # ── Populate negative-result cache on not-found ───────────────
         # _suggest_similar_files returns ReadResult(error="File not found: ..").
         # Cache the JSON we'd return so a retry skips the parent-dir walk.
@@ -1923,6 +1936,17 @@ def _read_file_tool_impl(path: str, offset: int = 1, limit: int = 2000, task_id:
 
         # ── Track for consecutive-loop detection ──────────────────────
         read_key = ("read", path, offset, limit)
+
+        # Never perform filesystem I/O while holding the global tracker lock:
+        # a cloud-provider metadata stall would otherwise poison bookkeeping
+        # for every later read/write in this process.
+        try:
+            _mtime_now = os.path.getmtime(resolved_str)
+        except OSError:
+            _mtime_now = None
+        if abandon_event is not None and abandon_event.is_set():
+            return tool_error("read_file result abandoned after timeout")
+
         with _read_tracker_lock:
             # Ensure "dedup" / "dedup_hits" keys exist (backward compat with
             # old tracker state from pre-dedup-guard sessions).
@@ -1942,16 +1966,10 @@ def _read_file_tool_impl(path: str, offset: int = 1, limit: int = 2000, task_id:
                 task_data["consecutive"] = 1
             count = task_data["consecutive"]
 
-            # Store mtime at read time for two purposes:
-            # 1. Dedup: skip identical re-reads of unchanged files.
-            # 2. Staleness: warn on write/patch if the file changed since
-            #    the agent last read it (external edit, concurrent agent, etc.).
-            try:
-                _mtime_now = os.path.getmtime(resolved_str)
+            # Store mtime at read time for dedup and write-staleness checks.
+            if _mtime_now is not None:
                 task_data["dedup"][dedup_key] = _mtime_now
                 task_data.setdefault("read_timestamps", {})[resolved_str] = _mtime_now
-            except OSError:
-                pass  # Can't stat — skip tracking for this entry
 
             # Bound the per-task containers so a long CLI session doesn't
             # accumulate megabytes of dict/set state.  See _cap_read_tracker_data.
@@ -1964,6 +1982,8 @@ def _read_file_tool_impl(path: str, offset: int = 1, limit: int = 2000, task_id:
         # truncated (large file with more content than limit covered).
         # Outside the _read_tracker_lock so the registry's own locking
         # isn't nested under ours.
+        if abandon_event is not None and abandon_event.is_set():
+            return tool_error("read_file result abandoned after timeout")
         try:
             _partial = (offset > 1) or bool(result_dict.get("truncated"))
             file_state.record_read(task_id, resolved_str, partial=_partial)
@@ -2019,25 +2039,30 @@ def read_file_tool(
         return _read_file_tool_impl(path, offset, limit, task_id)
 
     import concurrent.futures
-    import contextvars
-
     from tools.daemon_pool import DaemonThreadPoolExecutor
 
     executor = DaemonThreadPoolExecutor(max_workers=1)
     context = contextvars.copy_context()
+
+    abandon_event = threading.Event()
+
+    def _run() -> str:
+        token = _read_abandon_event.set(abandon_event)
+        try:
+            return _read_file_tool_impl(path, offset, limit, task_id)
+        finally:
+            _read_abandon_event.reset(token)
+
     future = executor.submit(
         context.run,
-        _read_file_tool_impl,
-        path,
-        offset,
-        limit,
-        task_id,
+        _run,
     )
     timed_out = False
     try:
         return future.result(timeout=timeout_s)
     except concurrent.futures.TimeoutError:
         timed_out = True
+        abandon_event.set()
         future.cancel()
         logger.warning("read_file timed out after %.1fs for %s", timeout_s, path)
         return tool_error(

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -23,6 +23,7 @@ from tools.file_operations import (
     normalize_read_pagination,
     normalize_search_pagination,
 )
+from tools.daemon_pool import DaemonThreadPoolExecutor
 from tools import file_state
 from agent.redact import redact_sensitive_text
 
@@ -1300,12 +1301,21 @@ def _check_not_found_cache(op: str, resolved_str: str, task_id: str) -> str | No
     # and a hung stat on a dead network mount must not stall every other
     # task's read/search bookkeeping.
     if _os.path.exists(resolved_str):
-        with _read_tracker_lock:
-            task_data = _read_tracker.get(task_id)
-            nf = task_data.get("not_found") if task_data else None
-            if nf:
-                nf.pop((op, resolved_str), None)
+        abandon_state = _read_abandon_state.get()
+        if abandon_state is None:
+            # Direct/search callers have no timeout abandonment race and retain
+            # the historical eager-eviction behavior.
+            with _read_tracker_lock:
+                task_data = _read_tracker.get(task_id)
+                nf = task_data.get("not_found") if task_data else None
+                if nf:
+                    nf.pop((op, resolved_str), None)
+        # Timeout-wrapped reads defer eviction until the final commit fence:
+        # ``exists`` can wedge past their deadline, and mutating afterward
+        # would publish from an abandoned worker.
         return None
+    if not _claim_read_result_publication():
+        return tool_error("read_file result abandoned after timeout")
     return cached_json
 
 
@@ -1651,6 +1661,12 @@ _read_abandon_state: contextvars.ContextVar[_ReadAbandonState | None] = (
 )
 
 
+def _claim_read_result_publication() -> bool:
+    """Fence a final result before it returns or mutates shared read state."""
+    abandon_state = _read_abandon_state.get()
+    return abandon_state is None or abandon_state.try_begin_commit()
+
+
 def _read_file_tool_impl(path: str, offset: int = 1, limit: int = 2000, task_id: str = "default") -> str:
     """Read a file with pagination and line numbers."""
     try:
@@ -1823,30 +1839,30 @@ def _read_file_tool_impl(path: str, offset: int = 1, limit: int = 2000, task_id:
         resolved_str = str(_resolved)
         dedup_key = (resolved_str, offset, limit)
         with _read_tracker_lock:
-            task_data = _read_tracker.setdefault(task_id, {
-                "last_key": None, "consecutive": 0,
-                "read_history": set(), "dedup": {},
-                "dedup_hits": {}, "read_timestamps": {},
-            })
-            # Backward-compat for pre-existing tracker entries that predate
-            # dedup_hits/read_timestamps (long-lived task or crossed an
-            # upgrade boundary).
-            if "dedup_hits" not in task_data:
-                task_data["dedup_hits"] = {}
-            if "read_timestamps" not in task_data:
-                task_data["read_timestamps"] = {}
-            cached_mtime = task_data.get("dedup", {}).get(dedup_key)
+            task_data = _read_tracker.get(task_id)
+            cached_mtime = (
+                task_data.get("dedup", {}).get(dedup_key) if task_data else None
+            )
 
         if cached_mtime is not None:
             try:
                 current_mtime = os.path.getmtime(resolved_str)
                 if current_mtime == cached_mtime:
+                    if not _claim_read_result_publication():
+                        return tool_error("read_file result abandoned after timeout")
                     # Count repeated stub returns so weak tool-followers that
                     # ignore the "refer to earlier result" hint don't burn
                     # their iteration budget in an infinite read loop.  After
                     # 2 stubs for the same key we escalate to a hard block
                     # mirroring the count>=4 path on real reads.
                     with _read_tracker_lock:
+                        task_data = _read_tracker.setdefault(task_id, {
+                            "last_key": None, "consecutive": 0,
+                            "read_history": set(), "dedup": {},
+                            "dedup_hits": {}, "read_timestamps": {},
+                        })
+                        task_data.setdefault("dedup_hits", {})
+                        task_data.setdefault("read_timestamps", {})
                         hits = task_data["dedup_hits"].get(dedup_key, 0) + 1
                         task_data["dedup_hits"][dedup_key] = hits
                         _cap_read_tracker_data(task_data)
@@ -1967,14 +1983,22 @@ def _read_file_tool_impl(path: str, offset: int = 1, limit: int = 2000, task_id:
         # timeout path won first, the daemon worker exits without publication.
         # If this worker wins, the timeout path returns the real result instead
         # of publishing a timeout for content whose state was committed.
-        abandon_state = _read_abandon_state.get()
-        if abandon_state is not None and not abandon_state.try_begin_commit():
+        if not _claim_read_result_publication():
             return tool_error("read_file result abandoned after timeout")
 
         if _not_found_json is not None:
             _record_not_found("read", resolved_str_for_neg, task_id, _not_found_json)
 
         with _read_tracker_lock:
+            task_data = _read_tracker.setdefault(task_id, {
+                "last_key": None, "consecutive": 0,
+                "read_history": set(), "dedup": {},
+                "dedup_hits": {}, "read_timestamps": {},
+            })
+            if _not_found_json is None:
+                task_data.get("not_found", {}).pop(
+                    ("read", resolved_str_for_neg), None
+                )
             # Ensure "dedup" / "dedup_hits" keys exist (backward compat with
             # old tracker state from pre-dedup-guard sessions).
             if "dedup" not in task_data:
@@ -2047,6 +2071,16 @@ def _read_file_tool_impl(path: str, offset: int = 1, limit: int = 2000, task_id:
 
 
 _DEFAULT_READ_FILE_TIMEOUT_S = 45.0
+_READ_FILE_MAX_WORKERS = 4
+
+# A timed-out filesystem syscall cannot be cancelled by Python. Reuse one
+# process-wide daemon pool so at most this many workers can remain wedged;
+# excess reads queue behind them and expire at their own caller deadline.
+_read_file_executor = DaemonThreadPoolExecutor(
+    max_workers=_READ_FILE_MAX_WORKERS,
+    thread_name_prefix="hermes-read-file",
+)
+_read_file_admission = threading.BoundedSemaphore(_READ_FILE_MAX_WORKERS)
 
 
 def _resolve_read_file_timeout() -> float | None:
@@ -2074,9 +2108,23 @@ def read_file_tool(
         return _read_file_tool_impl(path, offset, limit, task_id)
 
     import concurrent.futures
-    from tools.daemon_pool import DaemonThreadPoolExecutor
+    import time
 
-    executor = DaemonThreadPoolExecutor(max_workers=1)
+    deadline = time.monotonic() + timeout_s
+    admission = _read_file_admission
+    if not admission.acquire(timeout=timeout_s):
+        logger.warning("read_file timed out waiting for a worker for %s", path)
+        return tool_error(
+            f"Timed out reading '{path}' after {timeout_s:.0f}s. The path may "
+            "be a cloud-backed placeholder, blocked by filesystem permissions, "
+            "or unavailable on this host. Try exact-path metadata, a local "
+            "clone/direct source, or report the access problem instead of "
+            "retrying the same read.",
+            error_type="tool_timeout",
+            timeout_seconds=timeout_s,
+            path=path,
+        )
+
     context = contextvars.copy_context()
 
     abandon_state = _ReadAbandonState()
@@ -2088,13 +2136,17 @@ def read_file_tool(
         finally:
             _read_abandon_state.reset(token)
 
-    future = executor.submit(
-        context.run,
-        _run,
-    )
-    timed_out = False
     try:
-        return future.result(timeout=timeout_s)
+        future = _read_file_executor.submit(
+            context.run,
+            _run,
+        )
+    except BaseException:
+        admission.release()
+        raise
+    future.add_done_callback(lambda _future: admission.release())
+    try:
+        return future.result(timeout=max(0.0, deadline - time.monotonic()))
     except concurrent.futures.TimeoutError:
         if not abandon_state.abandon_if_pending():
             # The worker completed all potentially blocking I/O and claimed
@@ -2103,7 +2155,6 @@ def read_file_tool(
             # context cannot diverge.
             return future.result()
 
-        timed_out = True
         future.cancel()
         logger.warning("read_file timed out after %.1fs for %s", timeout_s, path)
         return tool_error(
@@ -2116,10 +2167,7 @@ def read_file_tool(
             timeout_seconds=timeout_s,
             path=path,
         )
-    finally:
-        # A filesystem syscall may remain blocked below Python. Never join that
-        # worker or register it with the stdlib atexit hook.
-        executor.shutdown(wait=not timed_out, cancel_futures=timed_out)
+
 
 
 def reset_file_dedup(task_id: str = None):

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -1621,7 +1621,7 @@ def _special_file_kind(path) -> str | None:
     return "a special (non-regular) file"
 
 
-def read_file_tool(path: str, offset: int = 1, limit: int = 2000, task_id: str = "default") -> str:
+def _read_file_tool_impl(path: str, offset: int = 1, limit: int = 2000, task_id: str = "default") -> str:
     """Read a file with pagination and line numbers."""
     try:
         offset, limit = normalize_read_pagination(offset, limit)
@@ -1991,6 +1991,69 @@ def read_file_tool(path: str, offset: int = 1, limit: int = 2000, task_id: str =
         return tool_error(str(e))
 
 
+_DEFAULT_READ_FILE_TIMEOUT_S = 45.0
+
+
+def _resolve_read_file_timeout() -> float | None:
+    """Return the bounded read deadline from ``timeouts.tools.read_file``."""
+    from agent.deadline import resolve_timeout
+
+    return resolve_timeout("tools.read_file", default=_DEFAULT_READ_FILE_TIMEOUT_S)
+
+
+def read_file_tool(
+    path: str,
+    offset: int = 1,
+    limit: int = 2000,
+    task_id: str = "default",
+) -> str:
+    """Read a file, returning promptly when a filesystem read wedges.
+
+    Cloud placeholders and permission brokers can block an otherwise ordinary
+    regular-file read for minutes. Run the implementation on a daemon worker so
+    the model receives an actionable timeout result and can try a direct/local
+    source or answer the user instead of holding the whole turn open.
+    """
+    timeout_s = _resolve_read_file_timeout()
+    if timeout_s is None:
+        return _read_file_tool_impl(path, offset, limit, task_id)
+
+    import concurrent.futures
+    import contextvars
+
+    from tools.daemon_pool import DaemonThreadPoolExecutor
+
+    executor = DaemonThreadPoolExecutor(max_workers=1)
+    context = contextvars.copy_context()
+    future = executor.submit(
+        context.run,
+        _read_file_tool_impl,
+        path,
+        offset,
+        limit,
+        task_id,
+    )
+    timed_out = False
+    try:
+        return future.result(timeout=timeout_s)
+    except concurrent.futures.TimeoutError:
+        timed_out = True
+        future.cancel()
+        logger.warning("read_file timed out after %.1fs for %s", timeout_s, path)
+        return tool_error(
+            f"Timed out reading '{path}' after {timeout_s:.0f}s. The path may "
+            "be a cloud-backed placeholder, blocked by filesystem permissions, "
+            "or unavailable on this host. Try exact-path metadata, a local "
+            "clone/direct source, or report the access problem instead of "
+            "retrying the same read.",
+            error_type="tool_timeout",
+            timeout_seconds=timeout_s,
+            path=path,
+        )
+    finally:
+        # A filesystem syscall may remain blocked below Python. Never join that
+        # worker or register it with the stdlib atexit hook.
+        executor.shutdown(wait=not timed_out, cancel_futures=timed_out)
 
 
 def reset_file_dedup(task_id: str = None):

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -1622,8 +1622,32 @@ def _special_file_kind(path) -> str | None:
     return "a special (non-regular) file"
 
 
-_read_abandon_event: contextvars.ContextVar[threading.Event | None] = (
-    contextvars.ContextVar("read_file_abandon_event", default=None)
+class _ReadAbandonState:
+    """Choose exactly one winner: timeout abandonment or result commit."""
+
+    def __init__(self) -> None:
+        self.lock = threading.Lock()
+        self.status = "pending"
+
+    def try_begin_commit(self) -> bool:
+        """Claim publication for a worker that finished all blocking I/O."""
+        with self.lock:
+            if self.status != "pending":
+                return False
+            self.status = "committing"
+            return True
+
+    def abandon_if_pending(self) -> bool:
+        """Claim timeout publication, or report that the worker already won."""
+        with self.lock:
+            if self.status != "pending":
+                return False
+            self.status = "abandoned"
+            return True
+
+
+_read_abandon_state: contextvars.ContextVar[_ReadAbandonState | None] = (
+    contextvars.ContextVar("read_file_abandon_state", default=None)
 )
 
 
@@ -1855,13 +1879,6 @@ def _read_file_tool_impl(path: str, offset: int = 1, limit: int = 2000, task_id:
         result = file_ops.read_file(path, offset, limit)
         result_dict = result.to_dict()
 
-        abandon_event = _read_abandon_event.get()
-        if abandon_event is not None and abandon_event.is_set():
-            # The caller already returned a timeout. Do not publish a late read
-            # into dedup/staleness registries that refer to content the model
-            # never received.
-            return tool_error("read_file result abandoned after timeout")
-
         # ── Populate negative-result cache on not-found ───────────────
         # _suggest_similar_files returns ReadResult(error="File not found: ..").
         # Cache the JSON we'd return so a retry skips the parent-dir walk.
@@ -1872,9 +1889,9 @@ def _read_file_tool_impl(path: str, offset: int = 1, limit: int = 2000, task_id:
         # test interaction). Serving from the cache (above) is the
         # optimization; recording must stay side-effect-identical.
         _err = result_dict.get("error") or ""
+        _not_found_json = None
         if isinstance(_err, str) and _err.startswith("File not found:"):
             _not_found_json = json.dumps(result_dict, ensure_ascii=False)
-            _record_not_found("read", resolved_str_for_neg, task_id, _not_found_json)
 
         # ── Character-count guard ─────────────────────────────────────
         # We're model-agnostic so we can't count tokens; characters are
@@ -1944,8 +1961,18 @@ def _read_file_tool_impl(path: str, offset: int = 1, limit: int = 2000, task_id:
             _mtime_now = os.path.getmtime(resolved_str)
         except OSError:
             _mtime_now = None
-        if abandon_event is not None and abandon_event.is_set():
+
+        # All potentially blocking filesystem work is complete. Atomically
+        # choose whether this result may publish shared bookkeeping. If the
+        # timeout path won first, the daemon worker exits without publication.
+        # If this worker wins, the timeout path returns the real result instead
+        # of publishing a timeout for content whose state was committed.
+        abandon_state = _read_abandon_state.get()
+        if abandon_state is not None and not abandon_state.try_begin_commit():
             return tool_error("read_file result abandoned after timeout")
+
+        if _not_found_json is not None:
+            _record_not_found("read", resolved_str_for_neg, task_id, _not_found_json)
 
         with _read_tracker_lock:
             # Ensure "dedup" / "dedup_hits" keys exist (backward compat with
@@ -1972,7 +1999,7 @@ def _read_file_tool_impl(path: str, offset: int = 1, limit: int = 2000, task_id:
                 task_data.setdefault("read_timestamps", {})[resolved_str] = _mtime_now
 
             # Bound the per-task containers so a long CLI session doesn't
-            # accumulate megabytes of dict/set state.  See _cap_read_tracker_data.
+            # accumulate megabytes of dict/set state.
             _cap_read_tracker_data(task_data)
 
         # Cross-agent file-state registry (separate from per-task read
@@ -1982,11 +2009,19 @@ def _read_file_tool_impl(path: str, offset: int = 1, limit: int = 2000, task_id:
         # truncated (large file with more content than limit covered).
         # Outside the _read_tracker_lock so the registry's own locking
         # isn't nested under ours.
-        if abandon_event is not None and abandon_event.is_set():
-            return tool_error("read_file result abandoned after timeout")
         try:
             _partial = (offset > 1) or bool(result_dict.get("truncated"))
-            file_state.record_read(task_id, resolved_str, partial=_partial)
+            # Never fall back to another filesystem stat after publication was
+            # claimed: that metadata call can wedge on the same cloud path and
+            # make the timeout path wait indefinitely. An unavailable mtime
+            # means there is no reliable staleness stamp to publish.
+            if _mtime_now is not None:
+                file_state.record_read(
+                    task_id,
+                    resolved_str,
+                    partial=_partial,
+                    mtime=_mtime_now,
+                )
         except Exception:
             logger.debug("file_state.record_read failed", exc_info=True)
 
@@ -2044,14 +2079,14 @@ def read_file_tool(
     executor = DaemonThreadPoolExecutor(max_workers=1)
     context = contextvars.copy_context()
 
-    abandon_event = threading.Event()
+    abandon_state = _ReadAbandonState()
 
     def _run() -> str:
-        token = _read_abandon_event.set(abandon_event)
+        token = _read_abandon_state.set(abandon_state)
         try:
             return _read_file_tool_impl(path, offset, limit, task_id)
         finally:
-            _read_abandon_event.reset(token)
+            _read_abandon_state.reset(token)
 
     future = executor.submit(
         context.run,
@@ -2061,8 +2096,14 @@ def read_file_tool(
     try:
         return future.result(timeout=timeout_s)
     except concurrent.futures.TimeoutError:
+        if not abandon_state.abandon_if_pending():
+            # The worker completed all potentially blocking I/O and claimed
+            # its short in-memory publication phase before the deadline race
+            # was resolved. Return that real result so bookkeeping and model
+            # context cannot diverge.
+            return future.result()
+
         timed_out = True
-        abandon_event.set()
         future.cancel()
         logger.warning("read_file timed out after %.1fs for %s", timeout_s, path)
         return tool_error(


### PR DESCRIPTION
## Summary

- bound `read_file` to 45 seconds by default, configurable via `timeouts.tools.read_file`
- run the existing implementation on a daemon worker so a wedged cloud/filesystem read cannot hold the turn open
- return a structured `tool_timeout` result that tells the model to use metadata, a local/direct source, or report the access problem instead of retrying
- preserve `0`/negative timeout semantics as an explicit opt-out

## Why

On macOS/iCloud, a regular-looking dataless file can block inside the filesystem/provider layer for minutes. The generic tool deadline on current `main` is 420 seconds, long enough to trigger gateway inactivity warnings before the model can recover. This keeps the failure bounded below 60 seconds without changing live gateway configuration.

## Verification

- `TMPDIR=/tmp uv run --locked --with pytest pytest tests/tools/test_read_file_timeout.py tests/tools/test_read_special_file_guard.py tests/tools/test_read_unicode_filename_retry.py tests/tools/test_read_binary_type_disclosure.py -o 'addopts=' -q` — 35 passed
- `uv run --locked --with ruff ruff check tools/file_tools.py tests/tools/test_read_file_timeout.py` — passed
- `git diff --check` — passed

## Notes

The timed-out worker is deliberately not joined: a filesystem syscall may remain blocked below Python. The daemon executor keeps that worker out of interpreter shutdown, while the read-only operation has no external side effect.
