### PR TITLE
fix(agent): use hostname-anchored match for Nous detection in iteration-summary path

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -2931,7 +2931,7 @@ def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
         )
         _omit_summary_temperature = _raw_summary_temp is _OMIT_TEMP
         _summary_temperature = None if _omit_summary_temperature else _raw_summary_temp
-        _is_nous = "nousresearch" in agent._base_url_lower
+        _is_nous = base_url_host_matches(agent._base_url_lower, "nousresearch.com")
         # LM Studio uses top-level `reasoning_effort` (not extra_body.reasoning).
         # Mirror ChatCompletionsTransport.build_kwargs() so the summary path
         # — which calls chat.completions.create() directly without going

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -2522,6 +2522,38 @@ class TestHandleMaxIterations:
         complete_logical.assert_called_once()
         assert complete_logical.call_args.kwargs == {"outcome": "failed"}
 
+    def test_summary_omits_nous_tags_for_lookalike_host(self, agent):
+        """Regression: a base_url with 'nousresearch' as a PATH substring
+        (not the actual host) must not be tagged as a Nous Portal call. The
+        summary path used to do a raw ``"nousresearch" in base_url_lower``
+        check instead of the hostname-anchored base_url_host_matches() used
+        everywhere else in this file for the same identity question."""
+        agent.base_url = "https://evil.example.com/nousresearch/v1"
+        resp = _mock_response(content="Summary")
+        agent.client.chat.completions.create.return_value = resp
+        agent._cached_system_prompt = "You are helpful."
+        messages = [{"role": "user", "content": "do stuff"}]
+
+        result = agent._handle_max_iterations(messages, 60)
+
+        assert result == "Summary"
+        kwargs = agent.client.chat.completions.create.call_args.kwargs
+        assert "tags" not in kwargs.get("extra_body", {})
+
+    def test_summary_includes_nous_tags_for_nous_portal_host(self, agent):
+        """A genuine (sub)domain of nousresearch.com must still get tagged."""
+        agent.base_url = "https://portal.nousresearch.com/v1"
+        resp = _mock_response(content="Summary")
+        agent.client.chat.completions.create.return_value = resp
+        agent._cached_system_prompt = "You are helpful."
+        messages = [{"role": "user", "content": "do stuff"}]
+
+        result = agent._handle_max_iterations(messages, 60)
+
+        assert result == "Summary"
+        kwargs = agent.client.chat.completions.create.call_args.kwargs
+        assert "product=hermes-agent" in kwargs.get("extra_body", {}).get("tags", [])
+
     def test_summary_skips_reasoning_for_unsupported_openrouter_model(self, agent):
         agent.base_url = "https://openrouter.ai/api/v1"
         agent.model = "minimax/minimax-m2.5"


### PR DESCRIPTION
## Summary

`handle_max_iterations()`'s iteration-limit summary-call path in `agent/chat_completion_helpers.py` checked `"nousresearch" in agent._base_url_lower` (raw substring) to decide whether to inject Nous Portal tags into the outgoing request body.

This is the exact substring false-positive class that `4b7b2b0049` fixed at the sibling site in the *same file* (`build_api_kwargs`, ~line 1934) by switching to `base_url_host_matches()`. That commit's own message claims to cover "agent/chat_completion_helpers.py: nousresearch / nvidia detection," but it only updated the `build_api_kwargs` occurrence — this second, identically-shaped `_is_nous` computation inside `handle_max_iterations` (used for the max-iterations summary request) was missed.

## Impact

A `base_url` containing `"nousresearch"` as a path/query substring (e.g. a proxy or lookalike host) would incorrectly have Nous Portal tags injected into the iteration-limit summary request body — the same misclassification class `base_url_host_matches()` exists to prevent.

## Fix

Switch to `base_url_host_matches(agent._base_url_lower, "nousresearch.com")`, matching the already-fixed sibling check three lines away in the same file. No new imports needed — `base_url_host_matches` is already imported at module scope.

## Testing

- Added `test_summary_omits_nous_tags_for_lookalike_host` (base_url `https://evil.example.com/nousresearch/v1` — hostname is `evil.example.com`, must NOT get Nous tags) and `test_summary_includes_nous_tags_for_nous_portal_host` (base_url `https://portal.nousresearch.com/v1` — a genuine subdomain, must still get tagged) to `tests/run_agent/test_run_agent.py::TestHandleMaxIterations`.
- Mutation-verified: reverting the one-line fix makes the new lookalike-host test fail (`AssertionError`) — confirmed the test actually catches the bug.
- Full `tests/run_agent/test_run_agent.py` suite: 257 passed, 1 pre-existing unrelated failure (`TestAnthropicInterruptHandler::test_interruptible_anthropic_interrupt_never_closes_shared_client` — fails identically on `main` due to the `anthropic` package not being installed in this environment; confirmed by re-running against unmodified files).
- `ruff check` clean on both changed files.

## Competing PRs

Searched with several keyword combinations (`handle_max_iterations nousresearch`, `iteration summary nous portal tags`, `base_url_host_matches chat_completion_helpers`) — no open PR targets this specific site.