### PR TITLE
fix(cron): don't fail a job on one undecodable byte of script output

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -3212,7 +3212,16 @@ def _run_job_script(
     try:
         from tools.environments.local import build_subprocess_env
 
-        popen_kwargs: dict[str, Any] = {"start_new_session": True}
+        # errors="replace" without an explicit encoding: the POSIX decoding
+        # default (locale-derived, see 7498eae3f) is preserved, only the error
+        # handler changes.  The pipes are read in text mode, so one undecodable
+        # byte — a chunked multibyte write, iconv output, binary noise on
+        # stderr — makes communicate() raise UnicodeDecodeError and fails the
+        # whole job even though the script itself exited 0.
+        popen_kwargs: dict[str, Any] = {
+            "start_new_session": True,
+            "errors": "replace",
+        }
         if sys.platform == "win32":
             popen_kwargs = {
                 "creationflags": windows_hide_flags()

--- a/tests/cron/test_cron_script.py
+++ b/tests/cron/test_cron_script.py
@@ -104,6 +104,46 @@ class TestRunJobScript:
         assert success is True
         assert output == "relative works"
 
+    def test_script_undecodable_byte_does_not_fail_job(self, cron_env):
+        """One undecodable byte must not fail an otherwise successful job.
+
+        The output pipes are read in text mode; with the strict default error
+        handler, communicate() raises UnicodeDecodeError and the job is
+        reported as failed even though the script exited 0.
+        """
+        from cron.scheduler import _run_job_script
+
+        script = cron_env / "scripts" / "invalid_utf8.py"
+        script.write_text(
+            "import sys\n"
+            "sys.stdout.buffer.write(b'before-\\xff-after\\n')\n"
+            "sys.stdout.buffer.flush()\n"
+        )
+
+        success, output = _run_job_script(str(script))
+        assert success is True
+        # Only the offending byte degrades; the surrounding output survives.
+        # Asserted by prefix/suffix so the test does not depend on which
+        # replacement character the active locale codec produces.
+        assert output.startswith("before-")
+        assert output.endswith("-after")
+
+    def test_script_undecodable_byte_on_stderr_does_not_fail_job(self, cron_env):
+        """stderr is decoded with the same kwargs — cover it too."""
+        from cron.scheduler import _run_job_script
+
+        script = cron_env / "scripts" / "invalid_utf8_stderr.py"
+        script.write_text(
+            "import sys\n"
+            "sys.stderr.buffer.write(b'warn-\\xff\\n')\n"
+            "sys.stderr.buffer.flush()\n"
+            "print('done')\n"
+        )
+
+        success, output = _run_job_script(str(script))
+        assert success is True
+        assert output == "done"
+
 
     def test_script_subprocess_env_sanitized(self, cron_env, monkeypatch):
         """Cron scripts must not inherit Hermes provider env (SECURITY.md §2.3)."""
@@ -231,8 +271,11 @@ class TestRunJobScript:
         assert captured["argv"] == [sys.executable, str(script.resolve())]
         assert captured["kwargs"]["text"] is True
         assert "creationflags" not in captured["kwargs"]
+        # The POSIX encoding default stays untouched (locale-derived).  Only the
+        # error handler is pinned, so an undecodable byte degrades that one
+        # character instead of failing the job.
         assert "encoding" not in captured["kwargs"]
-        assert "errors" not in captured["kwargs"]
+        assert captured["kwargs"]["errors"] == "replace"
 
     def test_emoji_stdout_round_trips_through_script_capture(self, cron_env):
         """Emoji in script stdout must reach the caller intact (#42384).


### PR DESCRIPTION
## What does this PR do?

A cron job script that writes a single undecodable byte to stdout or stderr fails the whole job, even when the script itself exits 0.

`_run_job_script()` reads the child's pipes in text mode (`text=True`). On Windows, `popen_kwargs` pins `encoding="utf-8", errors="replace"`; on POSIX no error handler is set, so the strict default applies and `communicate()` raises `UnicodeDecodeError` straight out of the `try` block. The job is then reported as failed and its output is lost — including the output produced before the bad byte.

This is easy to hit in practice without the script doing anything wrong: a chunked multibyte write split across two `write()` calls, output piped through `iconv`, or a third-party tool emitting a stray byte on stderr.

The fix sets `errors="replace"` for every platform, **without** setting `encoding`. That deliberately keeps the POSIX decoding default (locale-derived) introduced in 7498eae3f — only the error handler changes, so an undecodable byte degrades that one character instead of failing the run. Windows behavior is unchanged.

I updated `test_non_windows_script_preserves_default_text_decoding` accordingly: it still asserts `encoding` is not passed (the invariant that commit was protecting), and now asserts the error handler is pinned.

## Related Issue

No existing issue — happy to open one if you'd prefer that first.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `cron/scheduler.py` — `_run_job_script()`: add `errors="replace"` to the base `popen_kwargs` (no `encoding`, so the POSIX default is preserved); the Windows branch is untouched.
- `tests/cron/test_cron_script.py` — two new tests covering an undecodable byte on stdout and on stderr; updated the `errors` assertion in `test_non_windows_script_preserves_default_text_decoding`.

## How to Test

1. Reproduce on `main` (POSIX). Save as `$HERMES_HOME/scripts/badbyte.py`:

   ```python
   import sys
   sys.stdout.buffer.write(b'before-\xff-after\n')
   ```

   Then run it through the scheduler:

   ```python
   from cron.scheduler import _run_job_script
   print(_run_job_script("badbyte.py"))
   ```

   On `main` this raises `UnicodeDecodeError: 'utf-8' codec can't decode byte 0xff in position 7` and the job is marked failed. With this PR it returns `(True, 'before-�-after')`.

2. Negative control — the new tests fail without the fix:

   ```
   git stash push cron/scheduler.py
   pytest tests/cron/test_cron_script.py -q
   # 3 failed, 22 passed   (2 new tests + the updated guard test)
   git stash pop
   ```

3. Full suite for the touched area:

   ```
   pytest tests/cron/ -q
   # 712 passed, 1 skipped
   ```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/cron/ -q` and all tests pass (712 passed, 1 skipped)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)

### Documentation & Housekeeping

- [x] Documentation — N/A (internal behavior fix, no user-facing surface change)
- [x] `cli-config.yaml.example` — N/A (no config keys changed)
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] Cross-platform impact — Windows path unchanged; POSIX keeps its locale-derived encoding default, only the error handler is pinned
- [x] Tool descriptions/schemas — N/A
