### PR TITLE
fix(desktop): surface the model row's options submenu and make it keyboard-reachable

### DIFF
--- a/apps/desktop/src/app/shell/model-catalog-menu.test.tsx
+++ b/apps/desktop/src/app/shell/model-catalog-menu.test.tsx
@@ -1,5 +1,5 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { DropdownMenu, DropdownMenuContent } from '@/components/ui/dropdown-menu'
@@ -104,5 +104,88 @@ describe('the catalog owns model curation', () => {
     fireEvent.click(screen.getByText('Edit Models…'))
 
     expect($modelVisibilityOpen.get()).toBe(true)
+  })
+})
+
+// A row shows its model's effort ("Gemini 3.1 Pro  Max"), which reads as a
+// fixed model+effort combo unless the row also advertises that the effort is
+// editable behind it. The caret is that advertisement, and ArrowRight is the
+// way in for anyone not driving the menu with a mouse.
+describe('the per-row options submenu is discoverable', () => {
+  it('marks each model row as opening a submenu', async () => {
+    renderMenu()
+
+    const row = await screen.findByText(/Gemini 3\.1 Pro/i)
+    const trigger = row.closest('[data-slot="dropdown-menu-sub-trigger"]')
+
+    expect(trigger).not.toBeNull()
+    expect(trigger?.querySelector('.codicon-chevron-right')).not.toBeNull()
+  })
+
+  it('opens the highlighted row with ArrowRight, so effort is reachable without a mouse', async () => {
+    renderMenu()
+    await screen.findByText(/Gemini 3\.1 Pro/i)
+
+    const input = screen.getByRole('textbox', { name: 'Search models' })
+
+    // Nothing is selected yet, so highlight the first row before opening it.
+    fireEvent.keyDown(input, { key: 'ArrowDown' })
+    fireEvent.keyDown(input, { key: 'ArrowRight' })
+
+    expect(await screen.findByText('Effort')).not.toBeNull()
+    expect(screen.getByRole('menuitemradio', { name: 'Extra High' })).not.toBeNull()
+  })
+
+  it('returns focus to the search field when the keyboard closes the sub again', async () => {
+    renderMenu()
+    await screen.findByText(/Gemini 3\.1 Pro/i)
+
+    const input = screen.getByRole('textbox', { name: 'Search models' })
+
+    fireEvent.keyDown(input, { key: 'ArrowDown' })
+    fireEvent.keyDown(input, { key: 'ArrowRight' })
+    await screen.findByText('Effort')
+
+    // ArrowLeft, not Escape: inside a sub, Escape dismisses the whole menu.
+    fireEvent.keyDown(screen.getByText('Effort'), { key: 'ArrowLeft' })
+
+    await waitFor(() => expect(input.ownerDocument.activeElement).toBe(input))
+  })
+
+  // That round trip is owed by the row we opened and by no other. Once the
+  // pointer takes the menu over, Radix closes the keyboard-opened sub without
+  // handing focus back — reclaiming it there would pull focus out from under
+  // an interaction already in progress.
+  it('leaves focus alone when the pointer takes over from a keyboard-opened sub', async () => {
+    renderMenu()
+    await screen.findByText(/Gemini 3\.1 Pro/i)
+
+    const input = screen.getByRole('textbox', { name: 'Search models' })
+
+    fireEvent.keyDown(input, { key: 'ArrowDown' })
+    fireEvent.keyDown(input, { key: 'ArrowRight' })
+    await screen.findByText('Effort')
+
+    const hovered = screen.getByText(/Gemini 2\.5 Flash/i).closest('[data-slot="dropdown-menu-sub-trigger"]')
+
+    fireEvent.pointerMove(hovered as Element, { pointerType: 'mouse' })
+    await waitFor(() => expect(hovered?.getAttribute('data-state')).toBe('open'))
+
+    expect(input.ownerDocument.activeElement).not.toBe(input)
+  })
+
+  it('leaves ArrowRight to the search field while the caret is inside the query', async () => {
+    renderMenu()
+    await screen.findByText(/Gemini 3\.1 Pro/i)
+
+    const input = screen.getByRole('textbox', { name: 'Search models' }) as HTMLInputElement
+
+    fireEvent.change(input, { target: { value: 'gemini' } })
+    input.setSelectionRange(0, 0)
+
+    fireEvent.keyDown(input, { key: 'ArrowDown' })
+    fireEvent.keyDown(input, { key: 'ArrowRight' })
+
+    expect(screen.queryByText('Effort')).toBeNull()
   })
 })

--- a/apps/desktop/src/app/shell/model-catalog-menu.tsx
+++ b/apps/desktop/src/app/shell/model-catalog-menu.tsx
@@ -312,6 +312,86 @@ export function ModelCatalogMenu({
     }
   }
 
+  // ── Keyboard path into a row's edit submenu ───────────────────────────────
+  // Rows are HIGHLIGHTED, not DOM-focused (focus stays in the search input so
+  // typing keeps working), which is why Radix's own ArrowRight-on-the-trigger
+  // never fires. ArrowRight therefore hands focus to the highlighted trigger
+  // and replays the key there: from that point Radix owns everything — opening
+  // the sub, focusing its first item, and returning focus to the trigger when
+  // ArrowLeft closes it. `onOpenChange` below finishes that round trip by
+  // putting focus back in the search field. (Escape is not part of it: inside
+  // a sub, Radix dismisses the WHOLE menu rather than just the sub.)
+  //
+  // ArrowRight is hard-coded rather than direction-aware because Radix's own
+  // binding is: the app installs no `DirectionProvider` and passes no `dir`,
+  // so `useDirection` resolves to `ltr` and Radix opens subs on ArrowRight in
+  // every locale, RTL included. Matching that keeps the two in step; whoever
+  // wires up a `DirectionProvider` has to teach this handler the same
+  // direction Radix reads, or the sub goes unreachable again in Arabic.
+  const searchRef = useRef<HTMLInputElement>(null)
+  // WHICH row we opened from the keyboard, not merely THAT we opened one: a
+  // bare flag is still set when a keyboard-opened sub closes because the mouse
+  // moved on to another row, and refocusing search there pulls focus out from
+  // under a pointer interaction that has already taken the menu over.
+  const keyboardSubRef = useRef<null | { key: string; trigger: HTMLElement }>(null)
+
+  const openActiveSubmenu = (): boolean => {
+    const trigger = listRef.current?.querySelector<HTMLElement>('[data-kb-active]')
+
+    if (!trigger || !kbActiveKey) {
+      return false
+    }
+
+    keyboardSubRef.current = { key: kbActiveKey, trigger }
+    trigger.focus()
+    trigger.dispatchEvent(new KeyboardEvent('keydown', { bubbles: true, key: 'ArrowRight' }))
+
+    // Highlight also lands on rows that are plain items rather than submenu
+    // triggers (the MoA presets), which swallow the key; an open can also be
+    // interrupted. Either way, don't strand focus on a row where typing no
+    // longer reaches the search field.
+    requestAnimationFrame(() => {
+      // Only while the claim is still ours and untouched: a sub that opened
+      // and closed inside this one frame has already been handled below, and
+      // a stale frame reaching in afterwards would move focus twice.
+      if (keyboardSubRef.current?.trigger !== trigger) {
+        return
+      }
+
+      if (trigger.getAttribute('data-state') !== 'open') {
+        keyboardSubRef.current = null
+        searchRef.current?.focus()
+      }
+    })
+
+    return true
+  }
+
+  // Only the sub THIS row opened from the keyboard owes focus back to the
+  // search field; during mouse use focus never left it, and hover open/close
+  // fires constantly.
+  const handleSubOpenChange = (open: boolean, key: string) => {
+    const claim = keyboardSubRef.current
+
+    if (open || claim?.key !== key) {
+      return
+    }
+
+    keyboardSubRef.current = null
+
+    // Deferred one frame because Radix restores focus to the trigger straight
+    // AFTER this callback — and that restore is the signal we need. Radix does
+    // it only for a keyboard close (ArrowLeft); a sub closed because the
+    // pointer moved to another row leaves focus where it fell, and grabbing it
+    // then would fight the mouse. So finish the round trip only if the trigger
+    // really is holding focus.
+    requestAnimationFrame(() => {
+      if (document.activeElement === claim.trigger) {
+        searchRef.current?.focus()
+      }
+    })
+  }
+
   // Rows are hover-selectable, so they go inert with the pointer.
   const quietRows = pointerQuiet && 'pointer-events-none'
 
@@ -330,6 +410,13 @@ export function ModelCatalogMenu({
             event.preventDefault()
             event.stopPropagation()
             commitKbRow()
+          } else if (event.key === 'ArrowRight' && caretAtEnd(event.currentTarget)) {
+            // Claimed only with the caret parked at the end of the query, where
+            // ArrowRight has nothing left to do as a text cursor.
+            if (openActiveSubmenu()) {
+              event.preventDefault()
+              event.stopPropagation()
+            }
           }
         }}
         onValueChange={value => {
@@ -337,6 +424,7 @@ export function ModelCatalogMenu({
           setKbOverride(null)
         }}
         placeholder={copy.search}
+        ref={searchRef}
         value={search}
       />
 
@@ -428,7 +516,10 @@ export function ModelCatalogMenu({
 
                     // Clicking the row commits the model and closes; the edit
                     // submenu (reasoning/fast) is reached by HOVER, so you can
-                    // tweak those without the click dismissing everything.
+                    // tweak those without the click dismissing everything. The
+                    // trailing caret is what advertises that submenu — without
+                    // it the row's effort badge reads as a fixed model+effort
+                    // combo rather than an editable setting.
                     const activate = () => {
                       if (!isCurrent) {
                         void selectFamily(family, group.provider)
@@ -438,9 +529,11 @@ export function ModelCatalogMenu({
                     }
 
                     return (
-                      <DropdownMenuSub key={`${group.provider.slug}:${family.id}`}>
+                      <DropdownMenuSub
+                        key={`${group.provider.slug}:${family.id}`}
+                        onOpenChange={open => handleSubOpenChange(open, `${group.provider.slug}:${family.id}`)}
+                      >
                         <DropdownMenuSubTrigger
-                          hideChevron
                           onClick={activate}
                           onKeyDown={event => {
                             if (event.key === 'Enter' || event.key === ' ') {
@@ -530,6 +623,14 @@ export function ModelCatalogMenu({
 
 /** Re-exported so callers building a footer row match the catalog's rows. */
 export { dropdownMenuRow }
+
+/** True when the text cursor sits at the very end with nothing selected — the
+ *  only state where ArrowRight is free for the menu to claim. */
+function caretAtEnd(input: HTMLInputElement): boolean {
+  const { selectionEnd, selectionStart, value } = input
+
+  return selectionStart === value.length && selectionEnd === value.length
+}
 
 // Collapsed we show the user's chosen models (or the curated default); typing
 // spans every available model so anything is reachable past the cut. A search


### PR DESCRIPTION
## What does this PR do?

Makes the model row's **Thinking / Effort / Fast** submenu visible as a submenu, and reachable from the keyboard.

Today a row renders `<model name> <effort>` ("GPT-5.6 Sol  Max") with `hideChevron` on its `DropdownMenuSubTrigger`, so nothing indicates the effort is editable — the picker reads as a list of fixed model+effort combos, and users conclude a pairing like "Sol × XHigh" is simply not offered. The submenu is also unreachable without a mouse: the catalog keeps DOM focus in its search input and highlights rows via `data-kb-active`, so Radix's `ArrowRight`-on-the-focused-SubTrigger never fires and no key opens the sub.

## Related Issue

Fixes #86966

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

`apps/desktop/src/app/shell/model-catalog-menu.tsx`

- Removed `hideChevron` from the model row's `DropdownMenuSubTrigger`, restoring the shared caret affordance used by every other submenu trigger in the app.
- Claim `ArrowRight` in the catalog's search input to open the highlighted row's submenu. Because rows are highlighted rather than focused, the handler hands focus to the highlighted trigger and replays the key there — from that point Radix owns the interaction (opening the sub, focusing its first item, restoring focus to the trigger on `ArrowLeft`).
  - `ArrowRight` is claimed **only when the caret is at the end of the query**, so it still moves the text cursor while editing a search term.
  - `onOpenChange` on the row's `DropdownMenuSub` returns focus to the search input after a keyboard-opened sub is closed from the keyboard, so filtering continues normally. The guarding ref records **which** row opened the sub, and the refocus runs only if Radix has handed focus back to that trigger — which it does for a `SUB_CLOSE_KEYS` press (`ArrowLeft`) and not when the sub closes because the pointer moved on to another row. Hover during mouse use therefore never moves focus.
  - If the sub does not open — the highlight also lands on the MoA preset rows, which are plain items and swallow the key — focus is restored to the search field instead of being stranded on the row.

`apps/desktop/src/app/shell/model-catalog-menu.test.tsx`

- Row advertises a submenu (caret present on the trigger).
- `ArrowDown` → `ArrowRight` opens the options submenu and the effort radios are reachable.
- `ArrowLeft` closes it again and focus returns to the search field.
- A keyboard-opened sub closing because the pointer moved to another row leaves focus alone.
- `ArrowRight` is left to the search field while the caret is inside the query.

No behavior change for mouse users beyond the newly visible caret; no changes to what a selection writes (presets, session `config.set`) — this is purely the affordance and the keyboard path into the existing submenu.

## How to Test

1. Open Hermes Desktop, click the composer's model pill.
2. Each model row now shows a trailing `›`. Hover one — the Thinking / Fast / Effort submenu opens as before.
3. Without touching the mouse: press `ArrowDown` to highlight a row, then `ArrowRight`. The options submenu opens with focus on its first item; `ArrowUp`/`ArrowDown` move through the effort levels, `Enter` applies one.
4. Press `ArrowLeft` — the sub closes and focus returns to the search field; typing continues to filter the catalog. (`Esc` inside a submenu dismisses the whole menu — Radix's own behaviour, unchanged here.)
5. Type a query (e.g. `gemini`), move the caret into the middle of it with `ArrowLeft`, then press `ArrowRight` — the caret moves as normal, no submenu opens.

Verified on Ubuntu 24.04.4 LTS (Node v22.23.2, Electron/React 19).

```
npx vitest run --project ui src/app/shell   # 9 files, 74 tests passing
npx eslint src/app/shell/                   # both changed files clean
npx tsc -p apps/desktop --noEmit            # no new errors (diffed against the same tree without this patch)
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — N/A, desktop-renderer-only change; ran the desktop `vitest` suite instead (see above)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04.4 LTS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A (in-file comments updated)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — renderer-only; `ArrowRight` submenu opening is the standard LTR menu binding Radix already implements
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

