### PR TITLE
fix(cron): fence sweep_stale_inflight's forced-release write with expected_fire_owner

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -880,12 +880,23 @@ def sweep_stale_inflight(due_jobs: Optional[list] = None) -> list:
             )
             continue
         try:
+            # Fence the write the same way every other terminal mark_job_run()
+            # call in this file does: a claim that changed owner between the
+            # sweep's snapshot and this write (a different worker legitimately
+            # claimed and already completed the job) must not be clobbered by
+            # this stale worker's forced-release message.
+            claim = job.get("fire_claim")
+            fire_owner = str(claim.get("by") or "") if isinstance(claim, dict) else None
+            mark_kwargs = {}
+            if fire_owner is not None:
+                mark_kwargs["expected_fire_owner"] = fire_owner
             mark_job_run(
                 job_id,
                 False,
                 f"Stale in-flight claim force-released after {age / 60:.1f}m "
                 f"(allowance {allowance / 60:.1f}m); previous run never released "
                 f"the scheduler in-flight guard",
+                **mark_kwargs,
             )
         except Exception as e:
             logger.warning("Could not record forced release for job %s: %s", job_id, e)

--- a/tests/cron/test_inflight_stale_guard.py
+++ b/tests/cron/test_inflight_stale_guard.py
@@ -274,6 +274,24 @@ class TestStaleInflightSweep:
             assert sched.sweep_stale_inflight([job]) == [job["id"]]
         assert mark.call_count == 1
 
+    def test_forced_release_fences_on_fire_claim_owner(self, tmp_path):
+        """The forced-release write must be fenced with expected_fire_owner,
+        same as every other terminal mark_job_run() call in this file — a
+        stale worker's own sweep must not be able to overwrite a legitimate
+        replacement claim's result just because its message text differs."""
+        job = _job()
+        job["fire_claim"] = {"by": "worker-a"}
+        sched._running_job_ids.add(job["id"])
+        sched._running_since[job["id"]] = time.time() - 5 * 60 * 60
+        sched._running_futures[job["id"]] = sched._FUTURE_PENDING
+
+        with patch.object(sched, "mark_job_run") as mark, \
+             patch.object(sched, "_get_hermes_home", return_value=tmp_path):
+            assert sched.sweep_stale_inflight([job]) == [job["id"]]
+
+        assert mark.call_count == 1
+        assert mark.call_args.kwargs.get("expected_fire_owner") == "worker-a"
+
     def test_pending_sentinel_young_claim_is_not_released(self, tmp_path):
         """A young pending claim (submit still in flight) is safe."""
         job = _job()


### PR DESCRIPTION
## Summary

`sweep_stale_inflight()`'s forced-release call to `mark_job_run()` (`cron/scheduler.py`) skips the `expected_fire_owner` fencing that every other terminal `mark_job_run()` call site in this file uses (shutdown interrupt, side-effect-lost interrupt, normal run completion/error — all derive `fire_owner` from `job.get("fire_claim")` and pass it through so a stale write can't clobber a completion recorded under a different claim).

## Impact

In the multi-machine/external-scheduler deployment mode `claim_job_for_fire` explicitly supports: if a replica's claim wedges (submit hangs before `pool.submit()` returns — the exact class `sweep_stale_inflight` exists to catch) for longer than its fire-claim TTL, a different replica can legitimately claim and complete the job in the meantime. When the wedged replica's own sweep eventually force-releases its stale claim (potentially 30+ minutes later), its unfenced `mark_job_run()` call unconditionally overwrites `last_status`/`last_error` with its own "forced release" message over the other replica's correct terminal result, and spuriously re-advances `next_run_at` a second time.

## Fix

Derive `fire_owner` from the job's own `fire_claim` (already available via `by_id` in this loop) and pass it as `expected_fire_owner`, mirroring the exact pattern used at every other `mark_job_run()` call site in `cron/scheduler.py` — the kwarg is only included when a claim was actually recorded at sweep time (`fire_owner is not None`), matching `_mark_job_run_locked`'s own contract for when fencing applies.

## Testing

- Added `test_forced_release_fences_on_fire_claim_owner` to `tests/cron/test_inflight_stale_guard.py::TestStaleInflightSweep`, asserting `mark_job_run` is called with `expected_fire_owner` matching the job's recorded `fire_claim.by`.
- Mutation-verified: reverting the production fix makes the new test fail (`AssertionError: assert None == 'worker-a'` — the kwarg was empty).
- Full `tests/cron/` suite: 711 passed, 1 pre-existing skip.
- `tests/gateway/test_cron_drain_floor.py`, `tests/gateway/test_cron_interrupt_notification.py`, `tests/hermes_cli/test_cron*.py`: 65 passed.
- `ruff check` clean.

## Competing PRs

Searched multiple keyword combinations (`sweep_stale_inflight`, `forced release fire owner cron`, `cron in-flight expected_fire_owner`) — no open PR targets this call site.