### PR TITLE
fix(skills): align cache signature with discovery

### DIFF
--- a/tests/tools/test_skills_tool_discovery_cache.py
+++ b/tests/tools/test_skills_tool_discovery_cache.py
@@ -1,12 +1,10 @@
-"""Regression tests for the _find_all_skills discovery cache (#58985 salvage).
+"""Regression tests for the _find_all_skills discovery cache.
 
-Covers the cache-signature fix layered on the cherry-picked contributor
-commit: the original keyed the cache on the max mtime of only the TOP-LEVEL
-scan dirs, so adding/removing a skill inside a category subdir (which bumps
-the category dir's mtime, not the root's) served a stale list indefinitely.
-The signature now covers roots + immediate children (mirroring
-hermes_cli/profiles.py::_count_skills) plus the disabled-set, with a short
-TTL bounding in-place SKILL.md edit staleness.
+The cache signature must cover the same recursive, exclusion-aware SKILL.md
+path set as discovery. These tests protect immediate and deep additions,
+directory-before-file materialization, followed category symlinks, caller-copy
+isolation, and separate disabled/full cache views. In-place content edits remain
+bounded by the short TTL.
 """
 
 import time
@@ -55,6 +53,81 @@ def test_cache_hit_serves_copies_not_cache_objects(tmp_path):
     assert [s["name"] for s in second] == ["skill-one"]
     assert "enabled" not in second[0], "cache poisoned by caller mutation"
     assert second is not first
+
+
+def test_nested_skill_add_invalidates_even_when_directory_mtimes_are_frozen(tmp_path):
+    """Child-name changes must invalidate independently of filesystem mtimes."""
+    import os
+
+    _write_skill(tmp_path, "cat-a", "skill-one")
+    assert [s["name"] for s in st._find_all_skills()] == ["skill-one"]
+
+    root = tmp_path / "skills"
+    category = root / "cat-a"
+    root_stat = root.stat()
+    category_stat = category.stat()
+    _write_skill(tmp_path, "cat-a", "skill-two")
+    os.utime(root, ns=(root_stat.st_atime_ns, root_stat.st_mtime_ns))
+    os.utime(category, ns=(category_stat.st_atime_ns, category_stat.st_mtime_ns))
+
+    names = sorted(s["name"] for s in st._find_all_skills())
+    assert names == ["skill-one", "skill-two"]
+
+
+def test_deep_nested_skill_add_invalidates_cached_discovery(tmp_path):
+    """Discovery and its signature must cover the same recursive layout."""
+    _write_skill(tmp_path, "mlops/training", "skill-one")
+    assert [s["name"] for s in st._find_all_skills()] == ["skill-one"]
+
+    _write_skill(tmp_path, "mlops/training", "skill-two")
+
+    names = sorted(s["name"] for s in st._find_all_skills())
+    assert names == ["skill-one", "skill-two"]
+
+
+def test_skill_md_materialization_invalidates_cached_missing_directory(tmp_path):
+    """A directory created before its SKILL.md must not poison the cache."""
+    _write_skill(tmp_path, "cat-a", "skill-one")
+    pending = tmp_path / "skills" / "cat-a" / "skill-two"
+    pending.mkdir(parents=True)
+    assert [s["name"] for s in st._find_all_skills()] == ["skill-one"]
+
+    (pending / "SKILL.md").write_text(
+        "---\nname: skill-two\ndescription: second skill\n---\n# skill-two\n",
+        encoding="utf-8",
+    )
+
+    names = sorted(s["name"] for s in st._find_all_skills())
+    assert names == ["skill-one", "skill-two"]
+
+
+def test_symlinked_category_add_invalidates_cached_discovery(tmp_path):
+    """The signature must follow category symlinks just like discovery does."""
+    skills_root = tmp_path / "skills"
+    skills_root.mkdir()
+    target = tmp_path / "shared-category"
+    target.mkdir()
+    linked = skills_root / "linked"
+    try:
+        linked.symlink_to(target, target_is_directory=True)
+    except OSError as exc:
+        pytest.skip(f"directory symlinks unavailable: {exc}")
+
+    def write_linked_skill(name):
+        skill_dir = target / name
+        skill_dir.mkdir()
+        (skill_dir / "SKILL.md").write_text(
+            f"---\nname: {name}\ndescription: linked skill\n---\n# {name}\n",
+            encoding="utf-8",
+        )
+
+    write_linked_skill("skill-one")
+    assert [s["name"] for s in st._find_all_skills()] == ["skill-one"]
+
+    write_linked_skill("skill-two")
+
+    names = sorted(s["name"] for s in st._find_all_skills())
+    assert names == ["skill-one", "skill-two"]
 
 
 def test_disabled_and_full_views_cached_separately(tmp_path, monkeypatch):

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -90,14 +90,11 @@ logger = logging.getLogger(__name__)
 
 # Per-session skill discovery cache.  _find_all_skills() re-reads every
 # SKILL.md on every call; with hundreds of skills this is wasteful.
-# Cache validation (mirrors hermes_cli/profiles.py::_count_skills, d5eee133e):
-#   - signature = per-dir max mtime of the dir AND its immediate children
-#     (one scandir per dir; catches skill add/remove inside categories,
-#     which does NOT bump the root dir's mtime), plus the disabled-set
-#     (config-driven — changes with no filesystem mtime bump at all)
-#   - a short TTL bounds staleness from in-place SKILL.md edits, which
-#     bump only the file's mtime, invisible to any directory signature.
-# skip_disabled True/False are cached separately.
+# Cache validation uses the same recursive, exclusion-aware SKILL.md path set
+# as discovery, plus the disabled-set and active platform. This detects skill
+# additions/removals at every supported depth without reading file contents.
+# A short TTL bounds staleness from in-place SKILL.md edits, whose path is
+# unchanged. skip_disabled True/False are cached separately.
 _SKILLS_CACHE: dict = {}          # {cache_key: (signature, timestamp, skills_list)}
 _SKILLS_CACHE_TTL_SECONDS = 30.0
 _SKILLS_CACHE_KEY_DISABLED = "with_disabled"
@@ -105,35 +102,23 @@ _SKILLS_CACHE_KEY_FILTERED = "filtered"
 
 
 def _skills_scan_signature(dirs_to_scan, disabled) -> tuple:
-    """Cheap change-signature for the skill scan inputs.
+    """Return a cheap signature of the files considered by skill discovery.
 
-    O(#dirs + #categories) stat calls, not a recursive walk. Includes the
-    platform the scan's ``skill_matches_platform`` filter will use (read
-    from ``agent.skill_utils``'s ``sys`` so test patches of that module
-    are honored) — the scan result is platform-dependent.
+    Use the same recursive, exclusion-aware iterator as ``_find_all_skills`` so
+    additions and removals at any supported depth (including followed category
+    symlinks) invalidate the cache.  Only relative ``SKILL.md`` path names are
+    collected; file contents remain covered by the short TTL.
     """
     from agent import skill_utils as _skill_utils
 
     platform = getattr(getattr(_skill_utils, "sys", None), "platform", "")
     sig = []
     for d in dirs_to_scan:
-        try:
-            m = d.stat().st_mtime
-        except OSError:
-            continue
-        try:
-            with os.scandir(d) as it:
-                for entry in it:
-                    try:
-                        if entry.is_dir(follow_symlinks=False):
-                            em = entry.stat(follow_symlinks=False).st_mtime
-                            if em > m:
-                                m = em
-                    except OSError:
-                        continue
-        except OSError:
-            pass
-        sig.append((str(d), m))
+        skill_paths = tuple(
+            os.path.relpath(skill_md, d)
+            for skill_md in _skill_utils.iter_skill_index_files(d, "SKILL.md")
+        )
+        sig.append((str(d), skill_paths))
     return (tuple(sig), frozenset(disabled), platform)
 
 


### PR DESCRIPTION
## Summary
- derive the skill discovery cache signature from the same recursive, exclusion-aware `SKILL.md` path iterator used by discovery
- invalidate cached discovery when a skill appears or disappears at any supported depth, including followed category symlinks
- add regression coverage for same-mtime additions, deep nesting, directory-before-`SKILL.md` materialization, and symlinked categories

## Problem
`_find_all_skills()` recursively discovers `SKILL.md` files and follows category symlinks, but its cache signature only tracked the skills root and immediate child directory mtimes.

That mismatch allows the discovered file set to change without changing the cache key. Examples include:

- a skill added below a category while directory mtimes collide
- a skill added below a deeper category such as `mlops/training/`
- a final `SKILL.md` written after its directory was already observed
- a skill added through a followed category symlink

In those cases the running process can continue serving the stale skill list until the cache TTL expires.

## Root cause
The cache signature and discovery walk cover different filesystem domains. Directory timestamps are also not a reliable identity for the recursively discovered `SKILL.md` path set.

## Fix
Build the signature from relative `SKILL.md` path names returned by `iter_skill_index_files()`, the same recursive and exclusion-aware iterator used by `_find_all_skills()`.

Cache hits still avoid reading or parsing skill contents; in-place content changes remain bounded by the existing short TTL. The tradeoff is a recursive metadata-only directory walk for each cache validation instead of shallow directory stats.

## Tests
- [x] `scripts/run_tests.sh tests/tools/test_skills_tool_discovery_cache.py tests/tools/test_skills_tool.py tests/tools/test_skills_tool_profile_scope.py -q` — 49 passed
- [x] `python -m ruff check tools/skills_tool.py tests/tools/test_skills_tool_discovery_cache.py`
- [x] `python -m py_compile tools/skills_tool.py tests/tools/test_skills_tool_discovery_cache.py`
- [x] `git diff --check origin/main...HEAD`

## Related
- #48877 identifies stale nested skill discovery caching as the leading hypothesis. This change fixes the cache-signature mismatch without claiming to resolve unrelated sync or filtering causes.
