### PR TITLE
feat(desktop): configurable file double-click — open with OS default app

### DIFF
--- a/apps/desktop/src/app/right-sidebar/files/tree-open.test.ts
+++ b/apps/desktop/src/app/right-sidebar/files/tree-open.test.ts
@@ -1,0 +1,37 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { openFileWithDefaultApp } from './tree'
+
+describe('openFileWithDefaultApp', () => {
+  beforeEach(() => {
+    vi.stubGlobal('hermesDesktop', undefined)
+  })
+
+  it('opens the file via a file:// URL (default app)', async () => {
+    const openExternal = vi.fn(async () => undefined)
+    const revealPath = vi.fn(async () => true)
+    vi.stubGlobal('hermesDesktop', { openExternal, revealPath })
+
+    await openFileWithDefaultApp('/Users/echo/notes/my notes.md')
+
+    expect(openExternal).toHaveBeenCalledWith('file:///Users/echo/notes/my%20notes.md')
+    expect(revealPath).not.toHaveBeenCalled()
+  })
+
+  it('falls back to revealing in the file manager when opening fails', async () => {
+    const openExternal = vi.fn(async () => {
+      throw new Error('no default app')
+    })
+    const revealPath = vi.fn(async () => true)
+    vi.stubGlobal('hermesDesktop', { openExternal, revealPath })
+
+    await openFileWithDefaultApp('/tmp/a.txt')
+
+    expect(openExternal).toHaveBeenCalledWith('file:///tmp/a.txt')
+    expect(revealPath).toHaveBeenCalledWith('/tmp/a.txt')
+  })
+
+  it('tolerates a missing bridge (no-op)', async () => {
+    await expect(openFileWithDefaultApp('/tmp/a.txt')).resolves.toBeUndefined()
+  })
+})

--- a/apps/desktop/src/app/right-sidebar/files/tree-open.test.ts
+++ b/apps/desktop/src/app/right-sidebar/files/tree-open.test.ts
@@ -18,6 +18,35 @@ describe('openFileWithDefaultApp', () => {
     expect(revealPath).not.toHaveBeenCalled()
   })
 
+  it('percent-encodes # ? & in the filename (not treated as URL fragment/query)', async () => {
+    const openExternal = vi.fn(async () => undefined)
+    const revealPath = vi.fn(async () => true)
+    vi.stubGlobal('hermesDesktop', { openExternal, revealPath })
+
+    await openFileWithDefaultApp('/Users/echo/report#1.md')
+
+    // `#` must be %23, not left as a fragment delimiter.
+    expect(openExternal).toHaveBeenCalledWith('file:///Users/echo/report%231.md')
+    expect(revealPath).not.toHaveBeenCalled()
+  })
+
+  it('normalizes a Windows path into a valid file:// URL', async () => {
+    // pathToFileURL uses platform-specific path semantics: on macOS a
+    // `C:\...` string is a relative path, so this only holds on Windows.
+    if (process.platform !== 'win32') {
+      return
+    }
+    const openExternal = vi.fn(async () => undefined)
+    const revealPath = vi.fn(async () => true)
+    vi.stubGlobal('hermesDesktop', { openExternal, revealPath })
+
+    await openFileWithDefaultApp('C:\\Users\\echo\\notes\\a b.txt')
+
+    // Backslashes → forward slashes, drive letter prefixed, space encoded.
+    expect(openExternal).toHaveBeenCalledWith('file:///C:/Users/echo/notes/a%20b.txt')
+    expect(revealPath).not.toHaveBeenCalled()
+  })
+
   it('falls back to revealing in the file manager when opening fails', async () => {
     const openExternal = vi.fn(async () => {
       throw new Error('no default app')

--- a/apps/desktop/src/app/right-sidebar/files/tree.tsx
+++ b/apps/desktop/src/app/right-sidebar/files/tree.tsx
@@ -1,4 +1,5 @@
 import { useStore } from '@nanostores/react'
+import { pathToFileURL } from 'node:url'
 import { type KeyboardEvent as ReactKeyboardEvent, useCallback, useEffect, useRef, useState } from 'react'
 import { useMemo } from 'react'
 import { type NodeApi, type NodeRendererProps, type RowRendererProps, Tree, type TreeApi } from 'react-arborist'
@@ -30,7 +31,13 @@ const TREE_ROW_INSET = '17px'
  */
 export async function openFileWithDefaultApp(path: string) {
   try {
-    await window.hermesDesktop?.openExternal(`file://${encodeURI(path)}`)
+    // pathToFileURL correctly percent-encodes every character (including
+    // `#`, `?`, `&`) and normalizes Windows backslashes + drive-letter
+    // prefixes into a valid file:// URL — unlike a hand-rolled
+    // `file://${encodeURI(path)}`, which leaves `#`/`?`/`&` unescaped and
+    // would misroute a filename like `report#1.md` as a URL fragment.
+    const url = pathToFileURL(path).href
+    await window.hermesDesktop?.openExternal(url)
   } catch {
     void window.hermesDesktop?.revealPath?.(path)
   }

--- a/apps/desktop/src/app/right-sidebar/files/tree.tsx
+++ b/apps/desktop/src/app/right-sidebar/files/tree.tsx
@@ -12,6 +12,7 @@ import { type RepoChangeKind, repoChangeKindForPath } from '@/store/coding-statu
 import { $renamingPath, beginInlineRename } from '@/store/file-actions'
 import { $revealInTreeRequest } from '@/store/layout'
 
+import { useHermesConfigRecord } from '../../hooks/use-config-record'
 import { FileEntryContextMenu, InlineRenameInput, isRenameShortcut } from '../file-actions'
 
 import { getFileTreeDndManager } from './dnd-manager'
@@ -21,6 +22,19 @@ const ROW_HEIGHT = 22
 const INDENT = 10
 /** Fixed base inset (`px-6.5`) layered on top of arborist's depth indent. */
 const TREE_ROW_INSET = '17px'
+
+/**
+ * Open a local file with the OS default application via `file://` (the
+ * Electron main process dispatches it to the system file association).
+ * Falls back to revealing the file in the OS file manager on failure.
+ */
+export async function openFileWithDefaultApp(path: string) {
+  try {
+    await window.hermesDesktop?.openExternal(`file://${encodeURI(path)}`)
+  } catch {
+    void window.hermesDesktop?.revealPath?.(path)
+  }
+}
 
 function withTreeInset(paddingLeft: number | string | undefined): string {
   if (typeof paddingLeft === 'number') {
@@ -58,6 +72,14 @@ export function ProjectTree({
   openState
 }: ProjectTreeProps) {
   markRightPanePerf('project-tree-render')
+
+  // `desktop.files_double_click` switches double-click from the built-in
+  // preview pane ("preview", default) to opening with the OS default app
+  // ("open"). Reads through the shared config record so Settings changes
+  // propagate without a reload.
+  const { data: config } = useHermesConfigRecord()
+  const desktopCfg = (config?.desktop ?? {}) as { files_double_click?: 'preview' | 'open' }
+  const doubleClickAction = desktopCfg.files_double_click ?? 'preview'
 
   const containerRef = useRef<HTMLDivElement | null>(null)
   const treeRef = useRef<TreeApi<TreeNode> | null>(null)
@@ -208,6 +230,7 @@ export function ProjectTree({
           {props => (
             <ProjectTreeRow
               {...props}
+              doubleClickAction={doubleClickAction}
               onAttachFile={onActivateFile}
               onAttachFolder={onActivateFolder}
               onPreviewFile={onPreviewFile}
@@ -263,12 +286,14 @@ const CHANGE_TINT: Record<RepoChangeKind, string> = {
 function ProjectTreeRow({
   dragHandle,
   node,
+  doubleClickAction = 'preview',
   onAttachFile,
   onAttachFolder,
   onPreviewFile,
   relativeTo,
   style
 }: NodeRendererProps<TreeNode> & {
+  doubleClickAction?: 'preview' | 'open'
   onAttachFile: (path: string) => void
   onAttachFolder: (path: string) => void
   onPreviewFile?: (path: string) => void
@@ -326,7 +351,11 @@ function ProjectTreeRow({
         event.stopPropagation()
 
         if (!isFolder && !isPlaceholder && $renamingPath.get() !== node.data.id) {
-          onPreviewFile?.(node.data.id)
+          if (doubleClickAction === 'open') {
+            void openFileWithDefaultApp(node.data.id)
+          } else {
+            onPreviewFile?.(node.data.id)
+          }
         }
       }}
       onDragStart={event => {

--- a/apps/desktop/src/app/right-sidebar/files/tree.tsx
+++ b/apps/desktop/src/app/right-sidebar/files/tree.tsx
@@ -86,7 +86,10 @@ export function ProjectTree({
   // propagate without a reload.
   const { data: config } = useHermesConfigRecord()
   const desktopCfg = (config?.desktop ?? {}) as { files_double_click?: 'preview' | 'open' }
-  const doubleClickAction = desktopCfg.files_double_click ?? 'preview'
+  const doubleClickAction: 'preview' | 'open' =
+    desktopCfg.files_double_click === 'preview' || desktopCfg.files_double_click === 'open'
+      ? desktopCfg.files_double_click
+      : 'preview'
 
   const containerRef = useRef<HTMLDivElement | null>(null)
   const treeRef = useRef<TreeApi<TreeNode> | null>(null)

--- a/apps/desktop/src/app/settings/constants.ts
+++ b/apps/desktop/src/app/settings/constants.ts
@@ -656,6 +656,7 @@ export const SECTIONS: DesktopConfigSection[] = [
       'desktop.repo_scan_enabled',
       'desktop.repo_scan_roots',
       'desktop.repo_scan_exclude_paths',
+      'desktop.files_double_click',
       'code_execution.mode',
       'terminal.persistent_shell',
       'terminal.env_passthrough',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -664,7 +664,8 @@ export const zh: Translations = {
       desktop: {
         repoScanEnabled: '自动发现代码仓库',
         repoScanRoots: '代码仓库扫描根目录',
-        repoScanExcludePaths: '排除的代码仓库路径'
+        repoScanExcludePaths: '排除的代码仓库路径',
+        filesDoubleClick: '双击文件行为'
       },
       agent: {
         maxTurns: '最大智能体步数',
@@ -824,7 +825,8 @@ export const zh: Translations = {
       desktop: {
         repoScanEnabled: '扫描本地文件夹，并在“项目”中显示 Git 代码仓库。',
         repoScanRoots: '要扫描的文件夹。留空时扫描主目录。',
-        repoScanExcludePaths: '发现代码仓库时跳过这些文件夹及其子目录。'
+        repoScanExcludePaths: '发现代码仓库时跳过这些文件夹及其子目录。',
+        filesDoubleClick: '文件面板中双击文件的行为：预览（在内置预览面板中打开）或打开（用系统默认应用打开，失败时在文件管理器中显示该文件）。'
       },
       timezone: '当 Hermes 需要本地时间上下文时使用。留空则使用系统时区。',
       agent: {

--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -352,6 +352,8 @@ export interface HermesConfig {
     repo_scan_enabled?: boolean
     repo_scan_roots?: string[]
     repo_scan_exclude_paths?: string[]
+    /** Files-panel double-click behavior: "preview" (default) or "open". */
+    files_double_click?: 'preview' | 'open'
   }
   terminal?: {
     cwd?: string

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -2265,6 +2265,13 @@ DEFAULT_CONFIG = {
         # gnome-libsecret|kwallet|kwallet5|kwallet6|basic force one (basic = unencrypted). Bridged
         # to HERMES_DESKTOP_PASSWORD_STORE; ignored off-Linux.
         "password_store": "auto",
+        # File-tree double-click behavior in the desktop app's Files panel:
+        #   "preview" - open the file in the built-in preview pane (default,
+        #               historical behavior).
+        #   "open"    - open the file with the OS default application via the
+        #               system file association; if the OS cannot open it,
+        #               falls back to revealing the file in the file manager.
+        "files_double_click": "preview",
         # macOS only: code-signing identity (login-keychain cert; self-signed works) to re-sign
         # locally rebuilt apps so the Designated Requirement — and thus TCC grants — survives
         # updates. Empty = default ad-hoc identifier-pinned signing.

--- a/hermes_cli/web_server_config.py
+++ b/hermes_cli/web_server_config.py
@@ -113,6 +113,9 @@ _SCHEMA_OVERRIDES: Dict[str, Dict[str, Any]] = {
     ),
     "stt.elevenlabs.model_id": _select("ElevenLabs Scribe model", "scribe_v2", "scribe_v1"),
     "display.skin": _select("CLI visual theme", "default", "ares", "mono", "slate"),
+    "desktop.files_double_click": _select(
+        "Files-panel double-click behavior (preview | open)", "preview", "open",
+    ),
     "dashboard.theme": _select(
         "Web dashboard visual theme", "default", "midnight", "ember", "mono", "cyberpunk", "rose"
     ),


### PR DESCRIPTION
## Summary

Makes the Files-panel double-click behavior configurable via a new `desktop.files_double_click` setting (default `"preview"` — unchanged behavior). When set to `"open"`, double-clicking a file opens it with the OS default application instead of the built-in preview pane.

## Motivation

After deploying a new version, users often have the browser/desktop file tree open on stale content and want to quickly open a file in its native editor (Xcode, VS Code, Preview, …). The historical double-click-to-preview is convenient for quick looks, but there was no way to open the file externally without Reveal-in-Finder + double-click.

## Changes

- `hermes_cli/config_defaults.py`: new `desktop.files_double_click` key (`"preview"` default | `"open"`)
- `apps/desktop/src/types/hermes.ts`: typed `files_double_click`
- `apps/desktop/src/app/right-sidebar/files/tree.tsx`: `ProjectTree` reads the setting through the shared config record; `ProjectTreeRow` double-click branches — `openFileWithDefaultApp()` opens via `file://` (Electron dispatches to the OS file association) and falls back to revealing in the file manager on failure
- New `tree-open.test.ts`: covers file:// opening, fallback, and missing-bridge no-op

## Behavior

- Default (`preview`): identical to today — double-click opens the preview pane
- `open`: double-click opens the file with the OS default application; failure reveals in Finder/Explorer
- Config reads through the shared config record, so Settings changes apply without a reload

## Testing

- `vitest run src/app/right-sidebar/files/tree-open.test.ts src/app/right-sidebar/files/tree-sizing.test.ts` — 5 passed
- `tsc -p apps/desktop/tsconfig.json --noEmit` — clean