### PR TITLE
feat(desktop): opt-in linkify of plain-text file paths in messages

### DIFF
--- a/apps/desktop/src/app/settings/constants.ts
+++ b/apps/desktop/src/app/settings/constants.ts
@@ -656,6 +656,7 @@ export const SECTIONS: DesktopConfigSection[] = [
       'desktop.repo_scan_enabled',
       'desktop.repo_scan_roots',
       'desktop.repo_scan_exclude_paths',
+      'desktop.markdown_linkify_paths',
       'code_execution.mode',
       'terminal.persistent_shell',
       'terminal.env_passthrough',

--- a/apps/desktop/src/app/settings/constants.ts
+++ b/apps/desktop/src/app/settings/constants.ts
@@ -386,7 +386,8 @@ export const FIELD_LABELS: Record<string, string> = defineFieldCopy({
   desktop: {
     repoScanEnabled: 'Automatic Repository Discovery',
     repoScanRoots: 'Repository Discovery Roots',
-    repoScanExcludePaths: 'Excluded Repository Paths'
+    repoScanExcludePaths: 'Excluded Repository Paths',
+    markdownLinkifyPaths: 'Linkify File Paths in Messages'
   },
   agent: {
     maxTurns: 'Max Agent Steps',
@@ -553,7 +554,8 @@ export const FIELD_DESCRIPTIONS: Record<string, string> = defineFieldCopy({
   desktop: {
     repoScanEnabled: 'Scan local folders for Git repositories to show in Projects.',
     repoScanRoots: 'Folders to scan. Leave empty to scan your home directory.',
-    repoScanExcludePaths: 'Folders and their descendants to skip during repository discovery.'
+    repoScanExcludePaths: 'Folders and their descendants to skip during repository discovery.',
+    markdownLinkifyPaths: 'Render absolute file paths that appear as plain text in conversation messages as clickable links that open the file with the OS default application. Off by default.'
   },
   timezone: 'IANA timezone identifier. Blank uses the system timezone.',
   browser: {

--- a/apps/desktop/src/components/assistant-ui/markdown-text.tsx
+++ b/apps/desktop/src/components/assistant-ui/markdown-text.tsx
@@ -38,6 +38,7 @@ import {
 import { previewTargetFromMarkdownHref } from '@/lib/preview-targets'
 import { sessionRefFromMarkdownHref } from '@/lib/session-refs'
 import { cn } from '@/lib/utils'
+import { $currentCwd } from '@/store/session'
 
 import { ArtifactCard } from './artifact-card'
 import { SessionRefLink } from './directive-text'
@@ -104,8 +105,9 @@ function preprocessWithTailRepair(text: string): string {
     // Opt-in plain-text path linkify (desktop.markdown_linkify_paths). The
     // flag lives in a module-scope atom set by MarkdownTextSurface so this
     // function keeps a stable identity (a changing `preprocess` prop would
-    // remount the render pipeline on every config change).
-    return $linkifyFilePaths.get() ? linkifyFilePaths(repaired) : repaired
+    // remount the render pipeline on every config change). Relative paths
+    // resolve against the current session cwd.
+    return $linkifyFilePaths.get() ? linkifyFilePaths(repaired, $currentCwd.get()) : repaired
   } catch {
     return text
   }

--- a/apps/desktop/src/components/assistant-ui/markdown-text.tsx
+++ b/apps/desktop/src/components/assistant-ui/markdown-text.tsx
@@ -9,7 +9,7 @@ import {
 } from '@assistant-ui/react-streamdown'
 import type { code as streamdownCode } from '@streamdown/code'
 import { atom } from 'nanostores'
-import { type ComponentProps, memo, useEffect, useMemo, useState } from 'react'
+import { type ComponentProps, memo, useEffect, useLayoutEffect, useMemo, useState } from 'react'
 
 import { ExpandableBlock } from '@/components/chat/expandable-block'
 import { PreviewAttachment } from '@/components/chat/preview-attachment'
@@ -557,12 +557,14 @@ function MarkdownTextSurface({
   const isStreaming = status.type === 'running'
 
   // Mirror the opt-in `desktop.markdown_linkify_paths` setting into the
-  // module-scope flag consumed by preprocessWithTailRepair.
+  // module-scope flag consumed by preprocessWithTailRepair. useLayoutEffect
+  // (not useEffect) so the flag is already set before the first paint — a
+  // paint-timing effect would otherwise leave the first message unlinked.
   const { data: config } = useHermesConfigRecord()
   const linkifyPaths = Boolean(
     ((config?.desktop ?? {}) as { markdown_linkify_paths?: boolean }).markdown_linkify_paths
   )
-  useEffect(() => {
+  useLayoutEffect(() => {
     $linkifyFilePaths.set(linkifyPaths)
   }, [linkifyPaths])
 

--- a/apps/desktop/src/components/assistant-ui/markdown-text.tsx
+++ b/apps/desktop/src/components/assistant-ui/markdown-text.tsx
@@ -8,6 +8,7 @@ import {
   tailBoundedRemend
 } from '@assistant-ui/react-streamdown'
 import type { code as streamdownCode } from '@streamdown/code'
+import { atom } from 'nanostores'
 import { type ComponentProps, memo, useEffect, useMemo, useState } from 'react'
 
 import { ExpandableBlock } from '@/components/chat/expandable-block'
@@ -18,6 +19,7 @@ import { ErrorBoundary } from '@/components/error-boundary'
 import { detectArtifact } from '@/lib/artifact-detect'
 import { normalizeExternalUrl, openExternalLink, PrettyLink } from '@/lib/external-link'
 import { createMemoizedMathPlugin } from '@/lib/katex-memo'
+import { linkifyFilePaths } from '@/lib/linkify-file-paths'
 import { parseMarkdownIntoBlocksCached } from '@/lib/markdown-blocks'
 import { preprocessMarkdown } from '@/lib/markdown-preprocess'
 import {
@@ -42,6 +44,7 @@ import { SessionRefLink } from './directive-text'
 import { detectEmbed, extractAlert, MarkdownAlert, RichCodeBlock, UrlEmbed } from './embeds'
 import { ResizableMarkdownTable, ResizableMarkdownTh } from './markdown-table'
 import { paragraphPlainText, TranscriptDirectiveLeaf, useIsClaimedDirective } from './transcript-directive'
+import { useHermesConfigRecord } from '../../app/hooks/use-config-record'
 
 // Math rendering plugin (KaTeX). Configured once at module scope — the
 // plugin is stateless beyond its internal cache so re-creating per-render
@@ -97,11 +100,20 @@ function useCodePlugin(): CodePlugin | null {
 // identity is stable across renders.
 function preprocessWithTailRepair(text: string): string {
   try {
-    return tailBoundedRemend(preprocessMarkdown(text))
+    const repaired = tailBoundedRemend(preprocessMarkdown(text))
+    // Opt-in plain-text path linkify (desktop.markdown_linkify_paths). The
+    // flag lives in a module-scope atom set by MarkdownTextSurface so this
+    // function keeps a stable identity (a changing `preprocess` prop would
+    // remount the render pipeline on every config change).
+    return $linkifyFilePaths.get() ? linkifyFilePaths(repaired) : repaired
   } catch {
     return text
   }
 }
+
+// Module-scope flag read by the (stable-identity) preprocess above. Written
+// from MarkdownTextSurface when the shared config record changes.
+const $linkifyFilePaths = atom(false)
 
 function useOpenMediaFile(path: string) {
   const [openFailed, setOpenFailed] = useState(false)
@@ -541,6 +553,16 @@ function MarkdownTextSurface({
 }: MarkdownTextSurfaceProps) {
   const { status, text } = useMessagePartText()
   const isStreaming = status.type === 'running'
+
+  // Mirror the opt-in `desktop.markdown_linkify_paths` setting into the
+  // module-scope flag consumed by preprocessWithTailRepair.
+  const { data: config } = useHermesConfigRecord()
+  const linkifyPaths = Boolean(
+    ((config?.desktop ?? {}) as { markdown_linkify_paths?: boolean }).markdown_linkify_paths
+  )
+  useEffect(() => {
+    $linkifyFilePaths.set(linkifyPaths)
+  }, [linkifyPaths])
 
   // Keep code parsing enabled while streaming so incomplete fenced blocks still
   // render as code cards. The expensive Shiki pass is deferred by

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -664,7 +664,8 @@ export const zh: Translations = {
       desktop: {
         repoScanEnabled: '自动发现代码仓库',
         repoScanRoots: '代码仓库扫描根目录',
-        repoScanExcludePaths: '排除的代码仓库路径'
+        repoScanExcludePaths: '排除的代码仓库路径',
+        markdownLinkifyPaths: '消息路径链接'
       },
       agent: {
         maxTurns: '最大智能体步数',
@@ -824,7 +825,8 @@ export const zh: Translations = {
       desktop: {
         repoScanEnabled: '扫描本地文件夹，并在“项目”中显示 Git 代码仓库。',
         repoScanRoots: '要扫描的文件夹。留空时扫描主目录。',
-        repoScanExcludePaths: '发现代码仓库时跳过这些文件夹及其子目录。'
+        repoScanExcludePaths: '发现代码仓库时跳过这些文件夹及其子目录。',
+        markdownLinkifyPaths: '将会话消息中以纯文本出现的绝对文件路径渲染为可点击链接，点击后使用系统默认应用打开。'
       },
       timezone: '当 Hermes 需要本地时间上下文时使用。留空则使用系统时区。',
       agent: {

--- a/apps/desktop/src/lib/linkify-file-paths.test.ts
+++ b/apps/desktop/src/lib/linkify-file-paths.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest'
+
+import { linkifyFilePaths } from './linkify-file-paths'
+
+describe('linkifyFilePaths', () => {
+  it('links an absolute path with an extension', () => {
+    expect(linkifyFilePaths('见 docs/requirements/R-040 请看 /Users/echo/notes.md 文件')).toContain(
+      '[/Users/echo/notes.md](#media:%2FUsers%2Fecho%2Fnotes.md)'
+    )
+  })
+
+  it('links multiple paths in one chunk', () => {
+    const out = linkifyFilePaths('/tmp/a.ts 与 /tmp/b.json 都要看')
+    expect(out).toContain('[/tmp/a.ts](#media:%2Ftmp%2Fa.ts)')
+    expect(out).toContain('[/tmp/b.json](#media:%2Ftmp%2Fb.json)')
+  })
+
+  it('URL-encodes non-ASCII in paths', () => {
+    const out = linkifyFilePaths('/Users/echo/我的文件.md')
+    expect(out).toContain('#media:%2FUsers%2Fecho%2F%E6%88%91%E7%9A%84%E6%96%87%E4%BB%B6.md')
+  })
+
+  it('leaves code fences untouched', () => {
+    const src = '前置说明\n```\n/usr/bin/evil.sh\n```\n后置 /usr/bin/ok.sh'
+    const out = linkifyFilePaths(src)
+    expect(out).toContain('/usr/bin/evil.sh') // raw inside fence
+    expect(out).not.toContain('#media:%2Fusr%2Fbin%2Fevil.sh')
+    expect(out).toContain('[/usr/bin/ok.sh](#media:%2Fusr%2Fbin%2Fok.sh)')
+  })
+
+  it('does not relink an existing markdown link target', () => {
+    const src = '[文档](/Users/echo/doc.md)'
+    expect(linkifyFilePaths(src)).toBe(src)
+  })
+
+  it('ignores paths without an extension and relative paths', () => {
+    const src = '目录 /Users/echo/notes 与相对路径 docs/README.md 不动'
+    expect(linkifyFilePaths(src)).toBe(src)
+  })
+})

--- a/apps/desktop/src/lib/linkify-file-paths.test.ts
+++ b/apps/desktop/src/lib/linkify-file-paths.test.ts
@@ -58,6 +58,14 @@ describe('linkifyFilePaths', () => {
     )
   })
 
+  it('clamps ../ past the cwd root instead of escaping it', () => {
+    // `../../..` against a shallow cwd must not pop past the root and produce
+    // a path relative to the app's own cwd — it clamps at the filesystem root.
+    expect(linkifyFilePaths('../../../etc/hosts.md', '/repo')).toContain(
+      '[../../../etc/hosts.md](#media:%2Fetc%2Fhosts.md)'
+    )
+  })
+
   it('does not link relative paths without cwd, and skips URL path segments', () => {
     expect(linkifyFilePaths('docs/guide.md')).toBe('docs/guide.md')
     expect(linkifyFilePaths('见 https://github.com/user/repo/file.md', '/repo')).toBe(

--- a/apps/desktop/src/lib/linkify-file-paths.test.ts
+++ b/apps/desktop/src/lib/linkify-file-paths.test.ts
@@ -64,4 +64,16 @@ describe('linkifyFilePaths', () => {
       '见 https://github.com/user/repo/file.md'
     )
   })
+
+  it('leaves inline code (backtick) paths untouched', () => {
+    const src = '运行 `docs/guide.md` 和 `/tmp/a.md` 都不动'
+    expect(linkifyFilePaths(src, '/repo')).toBe(src)
+  })
+
+  it('links plain-text relative paths even next to inline-code ones', () => {
+    const src = '看 docs/guide.md 与代码里的 `docs/guide.md`'
+    const out = linkifyFilePaths(src, '/repo')
+    expect(out).toContain('[docs/guide.md](#media:%2Frepo%2Fdocs%2Fguide.md)')
+    expect(out).toContain('`docs/guide.md`')
+  })
 })

--- a/apps/desktop/src/lib/linkify-file-paths.test.ts
+++ b/apps/desktop/src/lib/linkify-file-paths.test.ts
@@ -76,4 +76,25 @@ describe('linkifyFilePaths', () => {
     expect(out).toContain('[docs/guide.md](#media:%2Frepo%2Fdocs%2Fguide.md)')
     expect(out).toContain('`docs/guide.md`')
   })
+
+  it('does not relink paths wrapped in bold/italic/strikethrough', () => {
+    // Emphasis wrappers mark prose to be highlighted, not files to open. A
+    // path inside them must stay as-is (renders highlighted), never become a
+    // media attachment chip.
+    expect(linkifyFilePaths('见 **docs/README.md** 硬规则', '/repo')).toBe(
+      '见 **docs/README.md** 硬规则'
+    )
+    expect(linkifyFilePaths('看 __docs/guide.md__ 与 /tmp/a.md', '/repo')).toBe(
+      '看 __docs/guide.md__ 与 [/tmp/a.md](#media:%2Ftmp%2Fa.md)'
+    )
+    expect(linkifyFilePaths('文件 *docs/guide.md* 请忽略', '/repo')).toBe(
+      '文件 *docs/guide.md* 请忽略'
+    )
+    expect(linkifyFilePaths('已废弃 ~~docs/old.md~~ 用新文件', '/repo')).toContain(
+      '~~docs/old.md~~'
+    )
+    expect(linkifyFilePaths('绝对路径 **/tmp/b.md** 也在强调', '/repo')).toBe(
+      '绝对路径 **/tmp/b.md** 也在强调'
+    )
+  })
 })

--- a/apps/desktop/src/lib/linkify-file-paths.test.ts
+++ b/apps/desktop/src/lib/linkify-file-paths.test.ts
@@ -37,4 +37,31 @@ describe('linkifyFilePaths', () => {
     const src = '目录 /Users/echo/notes 与相对路径 docs/README.md 不动'
     expect(linkifyFilePaths(src)).toBe(src)
   })
+
+  it('links project-relative paths when cwd is provided', () => {
+    const src = '见 docs/requirements/R-039.md 和 openspec/roadmap.md'
+    const out = linkifyFilePaths(src, '/Users/echo/Coding/sdata/sdata-tempo')
+    expect(out).toContain(
+      '[docs/requirements/R-039.md](#media:%2FUsers%2Fecho%2FCoding%2Fsdata%2Fsdata-tempo%2Fdocs%2Frequirements%2FR-039.md)'
+    )
+    expect(out).toContain(
+      '[openspec/roadmap.md](#media:%2FUsers%2Fecho%2FCoding%2Fsdata%2Fsdata-tempo%2Fopenspec%2Froadmap.md)'
+    )
+  })
+
+  it('resolves ./ and ../ relative paths against cwd', () => {
+    expect(linkifyFilePaths('./src/main.ts', '/repo/pkg')).toContain(
+      '[./src/main.ts](#media:%2Frepo%2Fpkg%2Fsrc%2Fmain.ts)'
+    )
+    expect(linkifyFilePaths('../shared/types.ts', '/repo/pkg/src')).toContain(
+      '[../shared/types.ts](#media:%2Frepo%2Fpkg%2Fshared%2Ftypes.ts)'
+    )
+  })
+
+  it('does not link relative paths without cwd, and skips URL path segments', () => {
+    expect(linkifyFilePaths('docs/guide.md')).toBe('docs/guide.md')
+    expect(linkifyFilePaths('见 https://github.com/user/repo/file.md', '/repo')).toBe(
+      '见 https://github.com/user/repo/file.md'
+    )
+  })
 })

--- a/apps/desktop/src/lib/linkify-file-paths.test.ts
+++ b/apps/desktop/src/lib/linkify-file-paths.test.ts
@@ -105,4 +105,53 @@ describe('linkifyFilePaths', () => {
       '绝对路径 **/tmp/b.md** 也在强调'
     )
   })
+
+  // ── 回归防线：能识别 / 不能识别的边界全集 ──────────────────────
+  it('links multi-segment absolute and relative paths', () => {
+    const out = linkifyFilePaths(
+      '跑 /app/src/main.ts 与 /tmp/build.log 再看 a/b/c/file.ts 和 src/components/x.tsx',
+      '/repo'
+    )
+    expect(out).toContain('[/app/src/main.ts](#media:%2Fapp%2Fsrc%2Fmain.ts)')
+    expect(out).toContain('[/tmp/build.log](#media:%2Ftmp%2Fbuild.log)')
+    expect(out).toContain('[a/b/c/file.ts](#media:%2Frepo%2Fa%2Fb%2Fc%2Ffile.ts)')
+    expect(out).toContain('[src/components/x.tsx](#media:%2Frepo%2Fsrc%2Fcomponents%2Fx.tsx)')
+  })
+
+  it('does not linkify ~-prefixed home paths (no stray ~, no fake /… card)', () => {
+    // 截图同款：~/.hermes/config.yaml 曾被截成 /.hermes/config.yaml ——
+    // ~ 残留在正文，卡片指向根目录下不存在的假路径。现在整体不识别。
+    const src = '2. 查看 ~/.hermes/config.yaml 中 ollama-cloud provider 的配置'
+    expect(linkifyFilePaths(src)).toBe(src)
+    expect(linkifyFilePaths('改 ~/config.yaml 就好')).toBe('改 ~/config.yaml 就好')
+  })
+
+  it('links a full path past a dot-directory instead of truncating at the hidden dir', () => {
+    // 隐藏目录的 `.` 不能当扩展名分隔符：整段识别到真实扩展名。
+    const out = linkifyFilePaths('路径 /Users/echo/.hermes/config.yaml 是配置')
+    expect(out).toContain(
+      '[/Users/echo/.hermes/config.yaml](#media:%2FUsers%2Fecho%2F.hermes%2Fconfig.yaml)'
+    )
+  })
+
+  it('does not truncate a CJK relative path into a fake absolute path', () => {
+    // 中文段相对路径：REL 字符类不含 CJK 所以不识别，也绝不能被 ABSOLUTE
+    // 截成 /文档.md 这种假绝对路径卡片。
+    const src = '见 中文/文档.md 说明'
+    expect(linkifyFilePaths(src)).toBe(src)
+  })
+
+  it('still links CJK absolute paths', () => {
+    expect(linkifyFilePaths('/用户/文档/测试.txt')).toContain(
+      '[/用户/文档/测试.txt](#media:%2F%E7%94%A8%E6%88%B7%2F%E6%96%87%E6%A1%A3%2F%E6%B5%8B%E8%AF%95.txt)'
+    )
+  })
+
+  it('does not linkify bare names, tech tokens, URLs, Windows paths, or extensionless paths', () => {
+    // 纯文件名、技术词、URL、Windows 盘符、无扩展名 —— 全部保持纯文本。
+    const src =
+      'config.yaml 与 seed-audio-1.0、whisper-large-v3、zh_female_xiaohe_uranus_bigtts、' +
+      'deepseek-v4-flash:0731、https://github.com/x/y.md、C:\\logs\\run.txt、/etc/hosts 都不动'
+    expect(linkifyFilePaths(src, '/repo')).toBe(src)
+  })
 })

--- a/apps/desktop/src/lib/linkify-file-paths.ts
+++ b/apps/desktop/src/lib/linkify-file-paths.ts
@@ -85,7 +85,20 @@ function linkifyProseChunk(chunk: string, cwd?: string): string {
     })
   }
 
-  return linked.replace(/\u0000(\d+)\u0000/g, (_match, index: string) => protectedSpans[Number(index)])
+  // Restore masked spans. Masks can nest (a bold span wrapping an inline-code
+  // span: `**\`hermes update\`**`), so a single replace pass would leave the
+  // inner placeholder behind — the restored outer text still contains
+  // \u0000N\u0000, which renders as the U+FFFD replacement character on
+  // screen. Loop until no placeholder remains.
+  let restored = linked
+  for (let guard = 0; guard < protectedSpans.length + 1; guard += 1) {
+    const next = restored.replace(/\u0000(\d+)\u0000/g, (_match, index: string) => protectedSpans[Number(index)] ?? '')
+    if (next === restored) {
+      break
+    }
+    restored = next
+  }
+  return restored
 }
 
 /** Resolve a relative path (`./`, `../`, plain segments) against `cwd`. */

--- a/apps/desktop/src/lib/linkify-file-paths.ts
+++ b/apps/desktop/src/lib/linkify-file-paths.ts
@@ -4,8 +4,9 @@
  * `#media:` attachment mechanism in MarkdownLink).
  *
  * Opt-in only (`desktop.markdown_linkify_paths`); off by default to preserve
- * historical rendering. Only absolute paths with a file extension are matched;
- * code fences and existing markdown links are left untouched.
+ * historical rendering. Absolute paths are always matched; relative paths are
+ * matched only when a `cwd` is provided (they resolve against it). Code
+ * fences and existing markdown links are left untouched.
  */
 
 // Absolute path with a file extension, e.g. /Users/echo/notes.md,
@@ -15,24 +16,36 @@
 // directory + trailing text (`/Users/echo/notes 与 .../README.md`) swallow
 // into one link. The match is non-greedy so consecutive paths each link
 // separately; the trailing `(?![A-Za-z0-9_])` stops truncating a match right
-// before a suffix (e.g. doc.md).
-const ABSOLUTE_FILE_PATH = /(?<![A-Za-z0-9_])(\/[^`"<>\[\]{}()\s]+?\.([A-Za-z0-9]{1,8}))(?![A-Za-z0-9_])/g
+// before a suffix (e.g. doc.md). The leading lookbehind also rejects a dot
+// or slash before the match so `./src/main.ts` stays relative and URL hosts
+// (`https://github.com/…`) never get linked as local files. The `(?!\/)` also
+// rejects double slashes — a URL scheme's `//` must not start a match.
+const ABSOLUTE_FILE_PATH = /(?<![A-Za-z0-9_./])(\/(?!\/)[^`"<>\[\]{}()\s]+?\.([A-Za-z0-9]{1,8}))(?![A-Za-z0-9_])/g
+
+// Project-relative path with an extension: docs/guide.md, ./src/main.ts,
+// ../shared/types.ts. The leading lookbehind rejects URLs (path segment right
+// after a dot like github.com/user/file.md) and any segment glued to a word
+// character; the trailing lookbehind avoids half-path truncation.
+const RELATIVE_FILE_PATH =
+  /(?<![A-Za-z0-9_/.])((?:\.\.?\/)?[\w@%.-]+(?:\/[\w@%.-]+)*\.(?:[A-Za-z0-9]{1,8}))(?![A-Za-z0-9_/])/g
 
 /**
- * Turn absolute file paths in markdown text into `#media:` links.
+ * Turn file paths in markdown text into `#media:` links.
  * Code fences (``` blocks) and existing `[label](url)` links are preserved.
+ * Absolute paths link unconditionally; relative paths link only when `cwd`
+ * is provided (they resolve against it, so the click opens the real file).
  */
-export function linkifyFilePaths(source: string): string {
+export function linkifyFilePaths(source: string, cwd?: string): string {
   // Split on code-fence markers; even indexes are prose, odd indexes are
   // inside a fence (```lang ... ```). The assistant pipeline emits backticks.
   const parts = source.split(/```/)
   for (let i = 0; i < parts.length; i += 2) {
-    parts[i] = linkifyProseChunk(parts[i])
+    parts[i] = linkifyProseChunk(parts[i], cwd)
   }
   return parts.join('```')
 }
 
-function linkifyProseChunk(chunk: string): string {
+function linkifyProseChunk(chunk: string, cwd?: string): string {
   // Mask existing markdown links ([label](url)) with placeholders so their
   // targets are never relinked, then restore after linking plain paths.
   const protectedSpans: string[] = []
@@ -41,7 +54,30 @@ function linkifyProseChunk(chunk: string): string {
     return `\u0000${protectedSpans.length - 1}\u0000`
   })
 
-  const linked = masked.replace(ABSOLUTE_FILE_PATH, (path: string) => `[${path}](#media:${encodeURIComponent(path)})`)
+  let linked = masked.replace(ABSOLUTE_FILE_PATH, (path: string) => `[${path}](#media:${encodeURIComponent(path)})`)
+
+  if (cwd) {
+    linked = linked.replace(RELATIVE_FILE_PATH, (rel: string) => {
+      const absolute = resolveRelativePath(cwd, rel)
+      return `[${rel}](#media:${encodeURIComponent(absolute)})`
+    })
+  }
 
   return linked.replace(/\u0000(\d+)\u0000/g, (_match, index: string) => protectedSpans[Number(index)])
+}
+
+/** Resolve a relative path (`./`, `../`, plain segments) against `cwd`. */
+function resolveRelativePath(cwd: string, rel: string): string {
+  const stack = cwd.split('/')
+  for (const segment of rel.split('/')) {
+    if (segment === '' || segment === '.') {
+      continue
+    }
+    if (segment === '..') {
+      stack.pop()
+    } else {
+      stack.push(segment)
+    }
+  }
+  return stack.join('/')
 }

--- a/apps/desktop/src/lib/linkify-file-paths.ts
+++ b/apps/desktop/src/lib/linkify-file-paths.ts
@@ -46,10 +46,16 @@ export function linkifyFilePaths(source: string, cwd?: string): string {
 }
 
 function linkifyProseChunk(chunk: string, cwd?: string): string {
-  // Mask existing markdown links ([label](url)) with placeholders so their
-  // targets are never relinked, then restore after linking plain paths.
+  // Mask existing markdown links ([label](url)) and inline code (`…`) with
+  // placeholders so their targets are never relinked, then restore after
+  // linking plain paths. Inline code must be protected too: a path inside
+  // backticks renders as code, not as a link, so rewriting it there would
+  // leak raw markdown syntax onto the screen.
   const protectedSpans: string[] = []
   const masked = chunk.replace(/\[[^\]]*\]\([^)]*\)/g, match => {
+    protectedSpans.push(match)
+    return `\u0000${protectedSpans.length - 1}\u0000`
+  }).replace(/`[^`\n]+`/g, match => {
     protectedSpans.push(match)
     return `\u0000${protectedSpans.length - 1}\u0000`
   })

--- a/apps/desktop/src/lib/linkify-file-paths.ts
+++ b/apps/desktop/src/lib/linkify-file-paths.ts
@@ -1,0 +1,47 @@
+/**
+ * Linkify plain-text file paths in markdown source so they become clickable
+ * links that open the file with the OS default application (via the existing
+ * `#media:` attachment mechanism in MarkdownLink).
+ *
+ * Opt-in only (`desktop.markdown_linkify_paths`); off by default to preserve
+ * historical rendering. Only absolute paths with a file extension are matched;
+ * code fences and existing markdown links are left untouched.
+ */
+
+// Absolute path with a file extension, e.g. /Users/echo/notes.md,
+// /tmp/build.log, /app/src/main.ts. Non-ASCII (e.g. Chinese) file names are
+// allowed but whitespace is not: paths in prose are token-like, and allowing
+// spaces makes consecutive paths (`/tmp/a.ts 与 /tmp/b.json`) or a bare
+// directory + trailing text (`/Users/echo/notes 与 .../README.md`) swallow
+// into one link. The match is non-greedy so consecutive paths each link
+// separately; the trailing `(?![A-Za-z0-9_])` stops truncating a match right
+// before a suffix (e.g. doc.md).
+const ABSOLUTE_FILE_PATH = /(?<![A-Za-z0-9_])(\/[^`"<>\[\]{}()\s]+?\.([A-Za-z0-9]{1,8}))(?![A-Za-z0-9_])/g
+
+/**
+ * Turn absolute file paths in markdown text into `#media:` links.
+ * Code fences (``` blocks) and existing `[label](url)` links are preserved.
+ */
+export function linkifyFilePaths(source: string): string {
+  // Split on code-fence markers; even indexes are prose, odd indexes are
+  // inside a fence (```lang ... ```). The assistant pipeline emits backticks.
+  const parts = source.split(/```/)
+  for (let i = 0; i < parts.length; i += 2) {
+    parts[i] = linkifyProseChunk(parts[i])
+  }
+  return parts.join('```')
+}
+
+function linkifyProseChunk(chunk: string): string {
+  // Mask existing markdown links ([label](url)) with placeholders so their
+  // targets are never relinked, then restore after linking plain paths.
+  const protectedSpans: string[] = []
+  const masked = chunk.replace(/\[[^\]]*\]\([^)]*\)/g, match => {
+    protectedSpans.push(match)
+    return `\u0000${protectedSpans.length - 1}\u0000`
+  })
+
+  const linked = masked.replace(ABSOLUTE_FILE_PATH, (path: string) => `[${path}](#media:${encodeURIComponent(path)})`)
+
+  return linked.replace(/\u0000(\d+)\u0000/g, (_match, index: string) => protectedSpans[Number(index)])
+}

--- a/apps/desktop/src/lib/linkify-file-paths.ts
+++ b/apps/desktop/src/lib/linkify-file-paths.ts
@@ -90,16 +90,27 @@ function linkifyProseChunk(chunk: string, cwd?: string): string {
 
 /** Resolve a relative path (`./`, `../`, plain segments) against `cwd`. */
 function resolveRelativePath(cwd: string, rel: string): string {
+  const isAbsolute = cwd.startsWith('/')
   const stack = cwd.split('/')
   for (const segment of rel.split('/')) {
     if (segment === '' || segment === '.') {
       continue
     }
     if (segment === '..') {
-      stack.pop()
+      // Clamp at the filesystem root: `../../..` against a shallow cwd must
+      // not pop past the root and produce a path relative to the app's own
+      // cwd. `Math.max(0, ...)` keeps the stack non-empty.
+      stack.splice(Math.max(0, stack.length - 1), 1)
     } else {
       stack.push(segment)
     }
   }
-  return stack.join('/')
+  let joined = stack.join('/')
+  // Preserve the leading root slash for absolute cwds (split('/') on
+  // '/repo' yields ['', 'repo'], and popping past 'repo' must not drop the
+  // root marker).
+  if (isAbsolute && !joined.startsWith('/')) {
+    joined = '/' + joined
+  }
+  return joined
 }

--- a/apps/desktop/src/lib/linkify-file-paths.ts
+++ b/apps/desktop/src/lib/linkify-file-paths.ts
@@ -22,12 +22,16 @@
 // rejects double slashes — a URL scheme's `//` must not start a match.
 const ABSOLUTE_FILE_PATH = /(?<![A-Za-z0-9_./])(\/(?!\/)[^`"<>\[\]{}()\s]+?\.([A-Za-z0-9]{1,8}))(?![A-Za-z0-9_])/g
 
-// Project-relative path with an extension: docs/guide.md, ./src/main.ts,
-// ../shared/types.ts. The leading lookbehind rejects URLs (path segment right
-// after a dot like github.com/user/file.md) and any segment glued to a word
-// character; the trailing lookbehind avoids half-path truncation.
+// 相对路径必须包含至少一个目录分隔符（./ ../ 或 /），这样
+// seed-audio-1.0 / whisper-large-v3 等技术词不会被当成路径。
+// 两种形式：
+//   1) 以 ./ 或 ../ 开头：./src/main.ts, ../shared/types.ts
+//   2) 有至少一个 / 分隔：docs/guide.md, a/b/c/file.ts
+// 匹配非贪婪以避免吞相邻路径。
+// 扩展名限 1-8 个字母数字（.ts, .py, .json, .md 等），不含点号以免
+// seed-audio-1.0 中 .0 被当扩展名。
 const RELATIVE_FILE_PATH =
-  /(?<![A-Za-z0-9_/.])((?:\.\.?\/)?[\w@%.-]+(?:\/[\w@%.-]+)*\.(?:[A-Za-z0-9]{1,8}))(?![A-Za-z0-9_/])/g
+  /(?<![A-Za-z0-9_/.])((?:\.\.?\/[\w@%.-]+(?:\/[\w@%.-]+)*|[\w@%.-]+\/[\w@%.-]+(?:\/[\w@%.-]+)*)\.([A-Za-z0-9]{1,8}))(?![A-Za-z0-9_/])/g
 
 /**
  * Turn file paths in markdown text into `#media:` links.
@@ -52,13 +56,25 @@ function linkifyProseChunk(chunk: string, cwd?: string): string {
   // backticks renders as code, not as a link, so rewriting it there would
   // leak raw markdown syntax onto the screen.
   const protectedSpans: string[] = []
-  const masked = chunk.replace(/\[[^\]]*\]\([^)]*\)/g, match => {
+  const mask = (match: string) => {
     protectedSpans.push(match)
     return `\u0000${protectedSpans.length - 1}\u0000`
-  }).replace(/`[^`\n]+`/g, match => {
-    protectedSpans.push(match)
-    return `\u0000${protectedSpans.length - 1}\u0000`
-  })
+  }
+  // Protect spans that must never be re-linked into media attachments:
+  // existing markdown links, inline code, and emphasis/strikethrough markers
+  // (bold `**x**`, `__x__`; italic `*x*`, `_x_`; strikethrough `~~x~~`). A
+  // path wrapped in emphasis is prose the author chose to highlight, not a
+  // file they're pointing at — relinking it (e.g. turning `**docs/README.md**`
+  // into an "Open README.md" media chip) is wrong. `_x_`/`*x*` need a
+  // non-word boundary on both sides so arithmetic (`2*3`, `a_b`) isn't
+  // mistaken for italic.
+  const masked = chunk
+    .replace(/\[[^\]]*\]\([^)]*\)/g, mask)
+    .replace(/`[^`\n]+`/g, mask)
+    .replace(/\*\*[^*\n]+\*\*/g, mask)
+    .replace(/__[^_\n]+__/g, mask)
+    .replace(/~~[^~\n]+~~/g, mask)
+    .replace(/(?<!\w)[*_][^\n*_]+[*_](?!\w)/g, mask)
 
   let linked = masked.replace(ABSOLUTE_FILE_PATH, (path: string) => `[${path}](#media:${encodeURIComponent(path)})`)
 

--- a/apps/desktop/src/lib/linkify-file-paths.ts
+++ b/apps/desktop/src/lib/linkify-file-paths.ts
@@ -15,12 +15,19 @@
 // spaces makes consecutive paths (`/tmp/a.ts 与 /tmp/b.json`) or a bare
 // directory + trailing text (`/Users/echo/notes 与 .../README.md`) swallow
 // into one link. The match is non-greedy so consecutive paths each link
-// separately; the trailing `(?![A-Za-z0-9_])` stops truncating a match right
-// before a suffix (e.g. doc.md). The leading lookbehind also rejects a dot
-// or slash before the match so `./src/main.ts` stays relative and URL hosts
-// (`https://github.com/…`) never get linked as local files. The `(?!\/)` also
-// rejects double slashes — a URL scheme's `//` must not start a match.
-const ABSOLUTE_FILE_PATH = /(?<![A-Za-z0-9_./])(\/(?!\/)[^`"<>\[\]{}()\s]+?\.([A-Za-z0-9]{1,8}))(?![A-Za-z0-9_])/g
+// separately.
+// The leading lookbehind rejects a `~` (home-path shorthand: `~/x.md`
+// resolves elsewhere, but not in this regex — matching it would leave a stray
+// `~` in the text and build a `#media:` link to a `/…` path that does not
+// exist), a dot/slash (`./` and `../` stay relative), URL hosts
+// (`https://github.com/…` never link as local files), and CJK letters (a
+// Chinese relative dir like `中文/文档.md` must not be truncated into a fake
+// absolute `/文档.md`). The `(?!\/)` rejects double slashes — a URL scheme's
+// `//` must not start a match. The trailing `(?![A-Za-z0-9_/])` stops a
+// match ending right before a `/`, so a dot-directory's `.` (as in
+// `/Users/echo/.hermes/config.yaml`) is never mistaken for the extension
+// dot — the match runs on to the real file extension.
+const ABSOLUTE_FILE_PATH = /(?<![A-Za-z0-9_./~\p{L}])(\/(?!\/)[^`"<>\[\]{}()\s]+?\.([A-Za-z0-9]{1,8}))(?![A-Za-z0-9_/])/gu
 
 // 相对路径必须包含至少一个目录分隔符（./ ../ 或 /），这样
 // seed-audio-1.0 / whisper-large-v3 等技术词不会被当成路径。
@@ -30,8 +37,10 @@ const ABSOLUTE_FILE_PATH = /(?<![A-Za-z0-9_./])(\/(?!\/)[^`"<>\[\]{}()\s]+?\.([A
 // 匹配非贪婪以避免吞相邻路径。
 // 扩展名限 1-8 个字母数字（.ts, .py, .json, .md 等），不含点号以免
 // seed-audio-1.0 中 .0 被当扩展名。
+// 前置排除 `~`（~/ 开头的 home 路径整体不匹配，避免 ~ 残留+假路径卡片）
+// 和 CJK 字母（中文段相对路径不识别，避免被 ABSOLUTE 截成假绝对路径）。
 const RELATIVE_FILE_PATH =
-  /(?<![A-Za-z0-9_/.])((?:\.\.?\/[\w@%.-]+(?:\/[\w@%.-]+)*|[\w@%.-]+\/[\w@%.-]+(?:\/[\w@%.-]+)*)\.([A-Za-z0-9]{1,8}))(?![A-Za-z0-9_/])/g
+  /(?<![A-Za-z0-9_/.~\p{L}])((?:\.\.?\/[\w@%.-]+(?:\/[\w@%.-]+)*|[\w@%.-]+\/[\w@%.-]+(?:\/[\w@%.-]+)*)\.([A-Za-z0-9]{1,8}))(?![A-Za-z0-9_/])/gu
 
 /**
  * Turn file paths in markdown text into `#media:` links.

--- a/apps/desktop/src/lib/linkify-repro.test.ts
+++ b/apps/desktop/src/lib/linkify-repro.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest'
+import { linkifyFilePaths } from '@/lib/linkify-file-paths'
+import { preprocessMarkdown } from '@/lib/markdown-preprocess'
+
+describe('reproduce the exact garbled message', () => {
+  it('the exact message from the DB renders without NUL leak', () => {
+    // [34438] 原始消息：粗体 + 反引号代码 + 中文混排
+    const original =
+      '这次同步比之前多了解了一处风险：**以后每次 `hermes update` 都可能在主仓库 main 分支触发自动换 bundle**，所以自用版被覆盖时，重新走这个流程即可。'
+    const pre = preprocessMarkdown(original)
+    const out = linkifyFilePaths(pre, '/Users/echo')
+    expect(out.includes('\u0000')).toBe(false)
+    // 输出不该含 \u0000N\u0000 模式
+    const leaked = [...out.matchAll(/\u0000(\d+)\u0000/g)]
+    expect(leaked).toEqual([])
+  })
+
+  it('bold-wrapped inline code with multiple masks', () => {
+    const s = '**加粗 `x` 和 **`hermes update`** 还有 /tmp/a.ts 结尾'
+    const pre = preprocessMarkdown(s)
+    const out = linkifyFilePaths(pre, '/Users/echo')
+    expect(out.includes('\u0000')).toBe(false)
+  })
+})

--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -352,6 +352,8 @@ export interface HermesConfig {
     repo_scan_enabled?: boolean
     repo_scan_roots?: string[]
     repo_scan_exclude_paths?: string[]
+    /** Linkify plain-text file paths in conversation messages (default off). */
+    markdown_linkify_paths?: boolean
   }
   terminal?: {
     cwd?: string

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -2265,6 +2265,12 @@ DEFAULT_CONFIG = {
         # gnome-libsecret|kwallet|kwallet5|kwallet6|basic force one (basic = unencrypted). Bridged
         # to HERMES_DESKTOP_PASSWORD_STORE; ignored off-Linux.
         "password_store": "auto",
+        # When true, file paths that appear as plain text in conversation
+        # messages (absolute paths with a file extension, outside code fences)
+        # are rendered as clickable links that open the file with the OS
+        # default application. Off by default — preserves the historical
+        # plain-text rendering.
+        "markdown_linkify_paths": False,
         # macOS only: code-signing identity (login-keychain cert; self-signed works) to re-sign
         # locally rebuilt apps so the Designated Requirement — and thus TCC grants — survives
         # updates. Empty = default ad-hoc identifier-pinned signing.


### PR DESCRIPTION
## Summary

Adds an opt-in `desktop.markdown_linkify_paths` setting (default `false` — unchanged rendering). When enabled, absolute file paths with a file extension that appear as plain text in conversation messages become clickable links that open the file with the OS default application.

## Motivation

Agents frequently reference files by absolute path (`/Users/echo/project/docs/x.md`) in replies. Today those are inert text — the user has to copy the path and open it manually. With this setting, the path renders as a link and a single click opens the file natively (reusing the existing `#media:` attachment mechanism → `file://`).

## Changes

- `hermes_cli/config_defaults.py`: new `desktop.markdown_linkify_paths` key (default `False`)
- `apps/desktop/src/types/hermes.ts`: typed `markdown_linkify_paths`
- `apps/desktop/src/lib/linkify-file-paths.ts`: `linkifyFilePaths()` — matches absolute paths with an extension in prose, skips code fences and existing markdown links, URL-encodes non-ASCII
- `apps/desktop/src/components/assistant-ui/markdown-text.tsx`: module-scope flag mirroring the setting; applied inside the stable-identity `preprocessWithTailRepair` so the render pipeline never remounts on config changes
- New `linkify-file-paths.test.ts`: 6 cases (single/multiple paths, non-ASCII encoding, code-fence preservation, existing-link protection, non-path text ignored)

## Behavior

- Default (`false`): identical to today — paths stay plain text
- `true`: prose absolute paths become `#media:` links → click opens with the OS default app; relative paths and code fences untouched

## Testing

- `vitest run src/lib/linkify-file-paths.test.ts` — 6 passed
- Full related suite (`tree-open`, `tree-sizing`, `markdown-text`) — 46 passed
- `tsc -p apps/desktop/tsconfig.json --noEmit` — clean