### PR TITLE
fix(save): deliver gateway /save documents and redact secrets by default

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -9453,14 +9453,16 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
     def save_conversation(self, cmd: str = "/save"):
         """Handle /save — export the current session to json, md, or html.
 
-        Usage: ``/save [json|md|html] [filename] [redact]``
+        Usage: ``/save [json|md|html] [filename] [noredact]``
 
         The snapshot is a convenience export for sharing or off-line
         inspection; every message is already persisted incrementally to the
         SQLite session DB, so the live session remains resumable via
         ``hermes --resume <id>`` regardless of whether the user ever runs
-        ``/save``. ``redact`` runs the export through the force-mode secret
-        redaction pass before writing.
+        ``/save``. The export runs through the force-mode secret redaction
+        pass by default, same as `hermes sessions export --format trace` —
+        ``noredact`` opts out for a user who has reviewed the session and
+        wants the raw export.
         """
         from hermes_cli.session_export import (
             SAVE_USAGE,
@@ -9472,9 +9474,14 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         if not parts:
             print(SAVE_USAGE)
             return
-        redact = False
-        if parts[-1].lower() in ("redact", "--redact"):
-            redact = True
+        redact = True
+        if parts[-1].lower() in ("noredact", "--no-redact"):
+            redact = False
+            parts = parts[:-1]
+            if not parts:
+                print(SAVE_USAGE)
+                return
+        elif parts[-1].lower() in ("redact", "--redact"):
             parts = parts[:-1]
             if not parts:
                 print(SAVE_USAGE)

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -4534,7 +4534,7 @@ class GatewaySlashCommandsMixin:
     async def _handle_save_command(self, event: MessageEvent) -> str:
         """Handle /save — export the current session and send it as a document.
 
-        Usage: ``/save [json|md|html] [filename] [redact]``
+        Usage: ``/save [json|md|html] [filename] [noredact]``
         """
         from hermes_cli.session_export import (
             SAVE_USAGE,
@@ -4546,9 +4546,22 @@ class GatewaySlashCommandsMixin:
         parts = event.get_command_args().split()
         if not parts:
             return SAVE_USAGE
-        redact = False
-        if parts[-1].lower() in ("redact", "--redact"):
-            redact = True
+        # Redaction is ON by default here — unlike the CLI's local-only
+        # /save, this path always leaves the machine (the export is sent as
+        # a document into the chat that invoked it, which may be a group
+        # chat visible to other participants and retained on the platform's
+        # own servers). Same "leaves the machine -> redact by default"
+        # policy as `hermes sessions export --format trace`. `noredact`
+        # opts out for a user who has reviewed the session and wants the
+        # raw export; the old `redact`/`--redact` opt-in token is still
+        # accepted as a harmless no-op for anyone already typing it.
+        redact = True
+        if parts[-1].lower() in ("noredact", "--no-redact"):
+            redact = False
+            parts = parts[:-1]
+            if not parts:
+                return SAVE_USAGE
+        elif parts[-1].lower() in ("redact", "--redact"):
             parts = parts[:-1]
             if not parts:
                 return SAVE_USAGE
@@ -4589,7 +4602,7 @@ class GatewaySlashCommandsMixin:
             with open(temp_path, "w", encoding="utf-8") as f:
                 f.write(content)
 
-            adapter = self.get_adapter(source.platform)
+            adapter = self.adapters.get(source.platform)
             if adapter:
                 await adapter.send_document(
                     chat_id=source.chat_id,

--- a/hermes_cli/session_export.py
+++ b/hermes_cli/session_export.py
@@ -324,7 +324,7 @@ def _finish_markdown(lines: List[str]) -> str:
 SAVE_FORMATS = ("json", "md", "html")
 
 SAVE_USAGE = """/save — export the current session to a file
-Usage: /save <format> [filename] [redact]
+Usage: /save <format> [filename] [noredact]
 
 Formats:
   json    full session snapshot (canonical export shape)
@@ -334,13 +334,16 @@ Formats:
 Options:
   filename   optional output name/path (default: auto-named;
              CLI saves under ~/.hermes/sessions/saved/)
-  redact     scrub API keys, tokens, and credentials before writing
+  noredact   skip scrubbing API keys, tokens, and credentials
+             (redaction runs by default — the export leaves the machine
+             when saved via a chat platform, and may be shared even when
+             saved locally)
 
 Examples:
   /save json
   /save html
   /save md notes.md
-  /save html session.html redact"""
+  /save html session.html noredact"""
 
 
 

--- a/tests/cli/test_save_conversation_location.py
+++ b/tests/cli/test_save_conversation_location.py
@@ -132,3 +132,48 @@ def test_save_conversation_bad_format_shows_usage(hermes_home, capsys):
     assert not saved_dir.exists() or not list(saved_dir.iterdir())
     out = capsys.readouterr().out
     assert "Usage:" in out
+
+
+_FAKE_GH_TOKEN = "ghp_" + "F" * 36
+
+
+def test_save_conversation_redacts_secrets_by_default(hermes_home, tmp_path, monkeypatch):
+    """Regression: /save must scrub secrets by default — the export can be
+    shared or leave the machine even for a local snapshot, so it must not
+    require the user to remember an opt-in `redact` token."""
+    monkeypatch.chdir(tmp_path)
+    for mod in [m for m in sys.modules if m.startswith("cli") or m == "hermes_constants"]:
+        sys.modules.pop(mod, None)
+    import cli
+
+    stub = _make_stub_cli([
+        {"role": "user", "content": f"export GITHUB_TOKEN={_FAKE_GH_TOKEN}"},
+        {"role": "assistant", "content": "Got it."},
+    ])
+    cli.HermesCLI.save_conversation(stub, "/save json")
+
+    saved_dir = hermes_home / "sessions" / "saved"
+    files = list(saved_dir.glob("hermes_conversation_*.json"))
+    assert len(files) == 1, files
+    content = files[0].read_text()
+    assert _FAKE_GH_TOKEN not in content, "raw secret leaked into the default /save export"
+
+
+def test_save_conversation_noredact_skips_redaction(hermes_home, tmp_path, monkeypatch):
+    """`noredact` opts out of the default scrubbing for a reviewed export."""
+    monkeypatch.chdir(tmp_path)
+    for mod in [m for m in sys.modules if m.startswith("cli") or m == "hermes_constants"]:
+        sys.modules.pop(mod, None)
+    import cli
+
+    stub = _make_stub_cli([
+        {"role": "user", "content": f"export GITHUB_TOKEN={_FAKE_GH_TOKEN}"},
+        {"role": "assistant", "content": "Got it."},
+    ])
+    cli.HermesCLI.save_conversation(stub, "/save json noredact")
+
+    saved_dir = hermes_home / "sessions" / "saved"
+    files = list(saved_dir.glob("hermes_conversation_*.json"))
+    assert len(files) == 1, files
+    content = files[0].read_text()
+    assert _FAKE_GH_TOKEN in content

--- a/tests/gateway/test_save_command.py
+++ b/tests/gateway/test_save_command.py
@@ -1,0 +1,155 @@
+"""Regression tests for gateway /save (``_handle_save_command``).
+
+Two independent bugs found in the same function:
+
+1. ``self.get_adapter(source.platform)`` calls a method that does not exist
+   anywhere on ``GatewayRunner`` (the established pattern used everywhere
+   else in this file is ``self.adapters.get(platform)``) — every invocation
+   raised ``AttributeError``, caught by the broad ``except Exception`` and
+   surfaced as "Error exporting session: ...", so the command never
+   delivered a file.
+2. Redaction of the exported session was opt-in only (a trailing ``redact``
+   token) even though the export is always sent as a document into the
+   invoking chat — which may be a group chat visible to other participants
+   and retained on the platform's own servers. ``hermes sessions export
+   --format trace`` treats "leaves the machine" as reason enough to redact
+   by default; /save did not.
+
+This file drives the REAL ``_handle_save_command`` against a REAL
+SessionStore + SessionDB (SQLite in tmp_path), mirroring the harness in
+``tests/gateway/test_branch_routing_columns.py``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from gateway.config import GatewayConfig, Platform
+from gateway.platforms.base import MessageEvent
+from gateway.session import SessionSource, SessionStore
+from hermes_state import AsyncSessionDB
+
+_FAKE_GH_TOKEN = "ghp_" + "F" * 36
+
+
+@pytest.fixture()
+def store(tmp_path, monkeypatch):
+    """Real SessionStore backed by a real SessionDB (SQLite in tmp_path)."""
+    import hermes_state
+
+    monkeypatch.setattr(hermes_state, "DEFAULT_DB_PATH", tmp_path / "state.db")
+    config = GatewayConfig()
+    return SessionStore(sessions_dir=tmp_path, config=config)
+
+
+def _make_source() -> SessionSource:
+    return SessionSource(
+        platform=Platform.TELEGRAM,
+        user_id="170829464",
+        chat_id="170829464",
+        chat_type="dm",
+        thread_id=None,
+    )
+
+
+def _make_event(text: str) -> MessageEvent:
+    return MessageEvent(text=text, source=_make_source(), message_id="m1")
+
+
+class _RecordingAdapter:
+    """Captures send_document's file content before the caller's finally
+    block deletes the temp file."""
+
+    def __init__(self):
+        self.calls: list[dict] = []
+        self.captured_content: str | None = None
+
+    async def send_document(self, *, chat_id, file_path, caption, file_name):
+        with open(file_path, encoding="utf-8") as f:
+            self.captured_content = f.read()
+        self.calls.append(
+            {"chat_id": chat_id, "file_path": file_path, "caption": caption, "file_name": file_name}
+        )
+
+
+def _make_save_runner(store: SessionStore, adapter):
+    """Minimal GatewayRunner stub wired to a REAL session_store/session_db."""
+    from gateway.run import GatewayRunner
+
+    runner = object.__new__(GatewayRunner)
+    runner.adapters = {Platform.TELEGRAM: adapter}
+    runner.session_store = store
+    runner._session_db = AsyncSessionDB(store._db)
+    return runner
+
+
+class TestSaveCommandDeliversDocument:
+    @pytest.mark.asyncio
+    async def test_save_delivers_document_via_platform_adapter(self, store):
+        """Regression: /save must actually call adapter.send_document, not
+        crash on a nonexistent self.get_adapter() before ever reaching it."""
+        source = _make_source()
+        entry = store.get_or_create_session(source)
+        store._db.append_message(entry.session_id, role="user", content="hello")
+        store._db.append_message(entry.session_id, role="assistant", content="world")
+
+        adapter = _RecordingAdapter()
+        runner = _make_save_runner(store, adapter)
+
+        result = await runner._handle_save_command(_make_event("/save json"))
+
+        assert result == "Export complete."
+        assert len(adapter.calls) == 1
+        assert adapter.captured_content is not None
+
+
+class TestSaveCommandRedaction:
+    @pytest.mark.asyncio
+    async def test_save_redacts_secrets_by_default(self, store):
+        source = _make_source()
+        entry = store.get_or_create_session(source)
+        store._db.append_message(
+            entry.session_id, role="user", content=f"export GITHUB_TOKEN={_FAKE_GH_TOKEN}"
+        )
+
+        adapter = _RecordingAdapter()
+        runner = _make_save_runner(store, adapter)
+
+        result = await runner._handle_save_command(_make_event("/save json"))
+
+        assert result == "Export complete."
+        assert adapter.captured_content is not None
+        assert _FAKE_GH_TOKEN not in adapter.captured_content, (
+            "raw secret leaked into the default gateway /save export"
+        )
+
+    @pytest.mark.asyncio
+    async def test_save_noredact_skips_redaction(self, store):
+        source = _make_source()
+        entry = store.get_or_create_session(source)
+        store._db.append_message(
+            entry.session_id, role="user", content=f"export GITHUB_TOKEN={_FAKE_GH_TOKEN}"
+        )
+
+        adapter = _RecordingAdapter()
+        runner = _make_save_runner(store, adapter)
+
+        result = await runner._handle_save_command(_make_event("/save json noredact"))
+
+        assert result == "Export complete."
+        assert adapter.captured_content is not None
+        assert _FAKE_GH_TOKEN in adapter.captured_content
+
+    @pytest.mark.asyncio
+    async def test_save_no_adapter_reports_error_instead_of_crashing(self, store):
+        """No adapter registered for the platform must return the documented
+        'not found' message, not an unhandled AttributeError."""
+        source = _make_source()
+        store.get_or_create_session(source)
+
+        runner = _make_save_runner(store, adapter=None)
+        runner.adapters = {}
+
+        result = await runner._handle_save_command(_make_event("/save json"))
+
+        assert result == "Platform adapter not found to send the document."


### PR DESCRIPTION
## Summary

Two bugs found in \`/save\`'s shared implementation (\`cli.py::save_conversation\`, \`gateway/slash_commands.py::_handle_save_command\`).

### 1. Gateway \`/save\` never delivers a file — \`self.get_adapter\` does not exist

\`gateway/slash_commands.py::_handle_save_command\` resolves the platform adapter via \`self.get_adapter(source.platform)\`. \`GatewayRunner\` has no \`get_adapter\` method anywhere in the codebase — I verified this with \`hasattr(GatewayRunner, 'get_adapter') == False\`. The established pattern used at every other adapter-resolution site in this same file (10+ call sites) is \`self.adapters.get(platform)\`.

Every \`/save\` invocation on the gateway therefore raises \`AttributeError\`, caught by the surrounding \`except Exception\`, and returns \`"Error exporting session: 'GatewayRunner' object has no attribute 'get_adapter'"\` to the user — the command has never successfully delivered a file since it was introduced. Fixed to match the established \`self.adapters.get(...)\` pattern.

### 2. Redaction was opt-in only, even though the export routinely leaves the machine

Redaction of the exported session required a trailing \`redact\` token, on both the CLI and gateway paths. But:
- The **gateway** path sends the export as a document into whatever chat invoked it — group chats included, and the file is retained on the platform's own servers — every single time, with no exception.
- The **CLI** path writes locally, but the file can still be shared afterward.

This repo already has a precedent for exactly this class of artifact: \`hermes sessions export --format trace\` treats "leaves the machine" as reason enough to redact by default (\`hermes_cli/sessions_cmd.py\`: *"Redaction is ON by default for traces (they leave the machine when --upload is used); --no-redact opts out after review."*). \`/save\` did not follow it.

## Fix

- \`gateway/slash_commands.py::_handle_save_command\`: \`self.get_adapter(source.platform)\` → \`self.adapters.get(source.platform)\`.
- Both \`cli.py::save_conversation\` and \`gateway/slash_commands.py::_handle_save_command\`: default flipped to \`redact = True\`; a trailing \`noredact\`/\`--no-redact\` token opts out. The old \`redact\`/\`--redact\` opt-in token is still accepted as a harmless no-op for anyone already typing it.
- Updated the shared \`SAVE_USAGE\` text (rendered by both surfaces) to document \`noredact\`.

## Testing

- New \`tests/gateway/test_save_command.py\` drives the real \`_handle_save_command\` against a real \`SessionStore\`/\`SessionDB\` (SQLite in tmp_path) with a recording fake adapter — 4 tests: document delivery actually happens, default redaction, \`noredact\` opt-out, and a "no adapter registered" case returns the documented message instead of crashing.
- New tests in \`tests/cli/test_save_conversation_location.py\`: default redaction and \`noredact\` opt-out for the CLI path.
- **Mutation-verified both bugs independently**:
  - Stashing the whole gateway fix: all 4 new gateway tests fail with the exact pre-fix \`AttributeError\` message.
  - Isolating just the redact-default line back to \`False\` (keeping the \`get_adapter\` fix): only the default-redaction test fails (raw \`ghp_...\` token leaks into the export), the delivery and \`noredact\` tests still pass — confirms the two bugs and their tests are independent.
- Full \`tests/cli/\` suite: 1029 passed, 1 failure confirmed pre-existing/order-dependent (\`test_resume_quiet_stderr.py\`, identical failure with my changes fully stashed — a test-order-pollution issue unrelated to this change).
- \`tests/gateway/test_slash_access.py\`, \`test_slash_access_dispatch.py\`, \`test_branch_routing_columns.py\`: 15 passed.
- \`ruff check\` clean on all changed files.

## Competing PRs

Searched several keyword combinations. No open PR touches \`_handle_save_command\`'s adapter resolution or the redact default. \#86858 (docs-only, \`website/docs/reference/slash-commands.md\`) documents the *old* \`[redact]\` usage row and will want a follow-up to say \`[noredact]\` once this lands — flagging for awareness, no code overlap. \#86903 (\`apps/desktop/electron/...\`) is an unrelated desktop "save remote gateway files natively" feature — no file overlap.