### PR TITLE
fix(cron): make the #86721 stale-execution reap reachable for hermes cron run

### DIFF
--- a/tests/cron/test_cron_run_stale_claim_reap_86721.py
+++ b/tests/cron/test_cron_run_stale_claim_reap_86721.py
@@ -141,3 +141,113 @@ def test_try_dispatch_background_run_calls_recovery_before_claiming(monkeypatch)
         "recover_interrupted_executions() must be called before any claim "
         "attempt in the one-shot dispatch path"
     )
+
+
+def test_hermes_cron_run_never_reaches_the_86721_recovery_call(monkeypatch):
+    """Follow-up regression: a real `hermes cron run` invocation declares its
+    session stateless (hermes_cli/cron.py::_job_action), so
+    async_delivery_supported() is False and _try_dispatch_background_run()
+    returns None before ever reaching the #86721 recovery call above --
+    exactly the opposite of what test_try_dispatch_background_run_calls_
+    recovery_before_claiming forces with its async_delivery_supported=True
+    monkeypatch. This pins that the #86721 fix's own reachable-path claim
+    (proven by the previous test) does NOT translate to real `hermes cron
+    run` invocations, which is the gap the follow-up fix in _execute_job_now
+    closes."""
+    import tools.cronjob_tools as cronjob_tools
+
+    calls = []
+    monkeypatch.setattr(
+        "cron.executions.recover_interrupted_executions",
+        lambda: calls.append("recovered") or 0,
+    )
+    monkeypatch.setattr(
+        "gateway.session_context.async_delivery_supported", lambda: False
+    )
+
+    job = {"id": "unit-test-job", "name": "unit test job", "deliver": "local"}
+    result = cronjob_tools._try_dispatch_background_run(job, session_id=None)
+
+    assert result is None, "background dispatch must decline for a stateless session"
+    assert calls == [], (
+        "the #86721 recovery call is unreachable on the real hermes cron run "
+        "path -- confirms the caller must fall back to _execute_job_now(), "
+        "which needs its own recovery call"
+    )
+
+
+def test_execute_job_now_calls_recovery_before_claiming(monkeypatch):
+    """Follow-up fix: _execute_job_now() -- what a one-shot `hermes cron run`
+    actually falls through to once _try_dispatch_background_run() declines
+    (see test_hermes_cron_run_never_reaches_the_86721_recovery_call above)
+    -- must reap stale execution rows itself before attempting its own
+    claim, the same self-heal #86721 gave the background-dispatch path."""
+    import tools.cronjob_tools as cronjob_tools
+
+    calls = []
+    monkeypatch.setattr(
+        "cron.executions.recover_interrupted_executions",
+        lambda: calls.append("recovered") or 0,
+    )
+    # Short-circuit right after the point under test so this stays a unit
+    # check on ordering, not a full job execution.
+    monkeypatch.setattr(
+        cronjob_tools, "claim_job_for_fire", lambda job_id, return_job=True: False
+    )
+    monkeypatch.setattr(cronjob_tools, "get_job", lambda job_id: None)
+
+    job = {"id": "unit-test-job-2", "name": "unit test job 2"}
+    result = cronjob_tools._execute_job_now(job)
+
+    assert calls == ["recovered"], (
+        "recover_interrupted_executions() must be called before any claim "
+        "attempt in _execute_job_now(), the path a stateless `hermes cron "
+        "run` session actually reaches"
+    )
+    assert result["claimed"] is False
+
+
+def test_execute_job_now_reaps_a_real_stale_claim_from_a_dead_process(tmp_path):
+    """End-to-end version of the two unit tests above: a stale 'claimed' row
+    left by a genuinely dead one-shot process is cleared by the time
+    _execute_job_now() attempts its own claim -- the actual fix for #86721's
+    reported symptom on the real `hermes cron run` code path (no gateway,
+    async_delivery_supported() False)."""
+    import os
+    import subprocess
+    import sys
+
+    home = tmp_path / "home"
+    repo = Path(__file__).resolve().parents[2]
+    env = os.environ.copy()
+    env["HERMES_HOME"] = str(home)
+    env["PYTHONPATH"] = str(repo)
+
+    create = subprocess.run(
+        [
+            sys.executable, "-c",
+            "from cron.executions import create_execution; "
+            "r=create_execution('cron-run-job-3', source='direct'); "
+            "print(r['id'])",
+        ],
+        cwd=repo, env=env, text=True, capture_output=True, check=True,
+    )
+    execution_id = create.stdout.strip()
+
+    check = subprocess.run(
+        [
+            sys.executable, "-c",
+            "import json; "
+            "from tools.cronjob_tools import _execute_job_now; "
+            "from cron.executions import list_executions; "
+            "_execute_job_now({'id': 'no-such-job', 'name': 'no-such-job'}); "
+            "print(json.dumps(list_executions(job_id='cron-run-job-3')))",
+        ],
+        cwd=repo, env=env, text=True, capture_output=True, check=True,
+    )
+    records = json.loads(check.stdout.strip())
+    assert records[0]["id"] == execution_id
+    assert records[0]["status"] == "unknown", (
+        "a stale execution row from a dead one-shot process must be reaped "
+        "by _execute_job_now() itself, not just the background-dispatch path"
+    )

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -680,6 +680,32 @@ def _execute_job_now(
     Returns {"claimed": bool, "success": bool, "error": str|None}.
     """
     job_id = job["id"]
+    job_name = str(job.get("name") or job_id)
+
+    # Reap any execution row this job (or any job) left stranded 'claimed'/
+    # 'running' by a dead owner process — same self-heal _try_dispatch_
+    # background_run() applies before its own claim. That function's own
+    # async_delivery_supported() gate returns early for a one-shot `hermes
+    # cron run` invocation (which always declares its session stateless, see
+    # hermes_cli/cron.py's _job_action), so its reap call never runs for the
+    # exact CLI path this one exists to serve — this is the path a one-shot
+    # `hermes cron run` with no gateway present actually falls through to
+    # (#86721). Duplicated rather than hoisted to the shared caller so this
+    # function stays self-contained for any other entry point.
+    try:
+        from cron.executions import recover_interrupted_executions
+
+        _reclaimed = recover_interrupted_executions()
+        if _reclaimed:
+            logger.warning(
+                "Reclaimed %d stale cron execution(s) from dead owner(s) "
+                "before running job '%s'",
+                _reclaimed,
+                job_name,
+            )
+    except Exception as _reap_exc:
+        logger.debug("Stale execution reclaim failed: %s", _reap_exc)
+
     claimed_job = None
     try:
         # At-most-once claim: bail without running if a tick/other fire owns it.


### PR DESCRIPTION
## Summary

\#86721's fix (\`recover_interrupted_executions()\` before claiming, to reap an execution ledger row stranded \`claimed\`/\`running\` by a dead process) landed in \`_try_dispatch_background_run()\`. But that function's own \`async_delivery_supported()\` gate returns \`None\` — falling through to \`_execute_job_now()\` — whenever the calling session is stateless.

A one-shot \`hermes cron run\` invocation *always* declares its session stateless: \`hermes_cli/cron.py::_job_action\` scopes \`_SESSION_ASYNC_DELIVERY\` to \`False\` for the duration of the CLI action, specifically so a background-dispatched daemon thread doesn't get orphaned when the process exits right after the tool call returns. That means the #86721 recovery call is unreachable on exactly the CLI path the issue was filed against.

## Evidence

- Two commits landed within about 3 hours of each other on the same day, apparently unaware of each other: \`0fc2a10d82\` (forces the stateless declaration for \`hermes cron run\`) and \`22e638db7c\` (adds the recovery call, but behind the gate the first commit now always trips).
- \`_execute_job_now()\` — what a stateless \`hermes cron run\` session actually falls through to — never calls \`recover_interrupted_executions()\` itself.
- \#86721's own regression test (\`test_try_dispatch_background_run_calls_recovery_before_claiming\`) has to monkeypatch \`async_delivery_supported()\` to \`True\` to reach the code it's testing at all — the exact opposite of what a real \`hermes cron run\` invocation does.

## Impact

Without a gateway running to periodically self-heal via the ticker's own startup reap (a documented, supported "headless cron via external scheduler" deployment mode with no gateway process), a stale \`claimed\`/\`running\` execution-ledger row left by a crashed one-shot \`hermes cron run\` invocation is never cleared — \`cronjob list\`/\`list_executions\` keeps showing a phantom in-flight run for a job that's actually long dead.

## Fix

Duplicate the same reap call (from \`_try_dispatch_background_run\`) into \`_execute_job_now()\`, before its own claim attempt — mirroring the existing self-heal rather than hoisting it to their shared caller, so \`_execute_job_now\` stays self-contained for any other entry point.

## Testing

Extended \`tests/cron/test_cron_run_stale_claim_reap_86721.py\` with 3 new tests:
- \`test_hermes_cron_run_never_reaches_the_86721_recovery_call\` — pins the reachability gap itself: with \`async_delivery_supported()\` False (the real \`hermes cron run\` condition), \`_try_dispatch_background_run\` returns \`None\` without ever calling \`recover_interrupted_executions()\`.
- \`test_execute_job_now_calls_recovery_before_claiming\` — unit check that \`_execute_job_now\` now calls the recovery function before its own claim attempt.
- \`test_execute_job_now_reaps_a_real_stale_claim_from_a_dead_process\` — end-to-end, mirroring the existing real-subprocess pattern in this file: a genuinely dead-owner \`claimed\` row is reclassified to \`unknown\` by the time \`_execute_job_now\` runs, unblocking the job.

Mutation-verified: reverting the production fix makes the 2 new \`_execute_job_now\`-targeted tests fail with the exact pre-fix symptom (\`'claimed' == 'unknown'\` assertion failure); the reachability-gap test passes either way since it documents \`_try_dispatch_background_run\`'s existing (unchanged) behavior.

Full \`tests/cron/\` suite + \`tests/tools/test_cronjob_tools.py\`/\`test_cronjob_run_background.py\`/\`test_cronjob_run_immediate.py\`: 901 passed. \`ruff check\` clean.

## Competing PRs — textual proximity, not semantic overlap

Two large open PRs rewrite \`_execute_job_now\`'s opening lines for unrelated reasons — flagging for transparency, not because either addresses this gap (checked their diffs directly):
- \#75833 (\`fix(cron): harden runtime ownership, supervision, and recovery\`) replaces \`claim_job_for_fire\` with a token-based \`claim_job_for_fire_token\`/\`release_fire_claim\` fencing mechanism. Does not touch \`_SESSION_ASYNC_DELIVERY\`/\`_job_action\`, and its rewritten \`_execute_job_now\` does not add a pre-claim reap call.
- \#67100 (\`fix(cron): make execution ledger failure-atomic\`) makes ledger-row creation atomic with the claim via a receipt/rollback mechanism. Same story: doesn't touch the stateless-session gate, doesn't add a reap call.

Both would need this fix rebased onto their new shape if they merge first — a normal follow-up, not a reason to withhold a real, independently-verified gap.