### PR TITLE
Add signed API run contexts

### DIFF
--- a/gateway/api_run_context.py
+++ b/gateway/api_run_context.py
@@ -1,0 +1,53 @@
+"""Request-scoped authority for authenticated API-server runs.
+
+The API server validates signed run-context headers before allocating an
+agent.  Only the resulting name and opaque context identifier cross into the
+agent worker thread; signing material never does.  Plugins read the bound
+value through :func:`current_trusted_api_run_context` while handling a tool
+call.
+"""
+
+from __future__ import annotations
+
+from contextvars import ContextVar, Token
+from dataclasses import dataclass, field
+
+
+@dataclass(frozen=True, slots=True)
+class TrustedApiRunContext:
+    """Validated authority for one API-server run.
+
+    ``context_id`` is intentionally omitted from ``repr`` because it is an
+    opaque bearer used only to bind a plugin call to its private adapter.
+    """
+
+    name: str
+    context_id: str = field(repr=False)
+    toolsets: tuple[str, ...]
+
+
+_CURRENT_TRUSTED_API_RUN_CONTEXT: ContextVar[TrustedApiRunContext | None] = ContextVar(
+    "current_trusted_api_run_context", default=None
+)
+
+
+def bind_trusted_api_run_context(
+    context: TrustedApiRunContext,
+) -> Token[TrustedApiRunContext | None]:
+    """Bind *context* to the current execution context."""
+
+    return _CURRENT_TRUSTED_API_RUN_CONTEXT.set(context)
+
+
+def reset_trusted_api_run_context(
+    token: Token[TrustedApiRunContext | None],
+) -> None:
+    """Restore the binding that preceded *token*."""
+
+    _CURRENT_TRUSTED_API_RUN_CONTEXT.reset(token)
+
+
+def current_trusted_api_run_context() -> TrustedApiRunContext | None:
+    """Return the validated run context visible to the current tool call."""
+
+    return _CURRENT_TRUSTED_API_RUN_CONTEXT.get()

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -95,6 +95,7 @@ from gateway.platforms.base import (
 from agent.redact import redact_sensitive_text
 from agent.interrupt_compat import request_hard_interrupt
 from gateway.readiness import collect_runtime_readiness
+from gateway.api_run_context import TrustedApiRunContext
 
 from agent.secret_scope import UnscopedSecretError as _UnscopedSecretError
 from agent.secret_scope import get_secret as _scoped_get_secret
@@ -246,6 +247,23 @@ def _coerce_request_bool(value: Any, default: bool = False) -> bool:
 
 _REQUEST_OPTION_MISSING = object()
 _REASONING_EFFORTS = frozenset({"none", "minimal", "low", "medium", "high", "xhigh"})
+_RUN_CONTEXT_HEADER = "X-Hermes-Run-Context"
+_RUN_CONTEXT_ID_HEADER = "X-Hermes-Run-Context-Id"
+_RUN_CONTEXT_SIGNATURE_HEADER = "X-Hermes-Run-Context-Signature"
+_RUN_CONTEXT_HEADERS = (
+    _RUN_CONTEXT_HEADER,
+    _RUN_CONTEXT_ID_HEADER,
+    _RUN_CONTEXT_SIGNATURE_HEADER,
+)
+_RUN_CONTEXT_NAME_RE = re.compile(r"^[a-z0-9_]{1,96}$")
+_RUN_CONTEXT_ID_RE = re.compile(r"^[A-Za-z0-9_-]{16,512}$")
+_RUN_CONTEXT_SIGNATURE_RE = re.compile(r"^[0-9a-f]{64}$")
+_RUN_CONTEXT_SECRET_ENV_RE = re.compile(
+    r"^[A-Z][A-Z0-9_]{0,111}_SIGNING_SECRET$"
+)
+_RUN_CONTEXT_TOOLSET_RE = re.compile(r"^[A-Za-z0-9_-]{1,96}$")
+_RUN_CONTEXT_REPLAY_TTL_SECONDS = 86_400.0
+_RUN_CONTEXT_REPLAY_MAX_CLAIMS = 10_000
 _RUNTIME_AGENT_OVERRIDE_KEYS = (
     "api_key",
     "base_url",
@@ -1436,6 +1454,10 @@ class APIServerAdapter(BasePlatformAdapter):
         # resolves requests by session key, while API clients address the
         # in-flight run by run_id.
         self._run_approval_sessions: Dict[str, str] = {}
+        # One-shot signed run contexts. Only a digest is retained; the opaque
+        # context id itself must never enter logs or public status payloads.
+        # Domain adapters remain the durable replay fence across restarts.
+        self._trusted_run_context_claims: Dict[str, float] = {}
         self._session_db: Optional[Any] = None  # Lazy-init SessionDB for session continuity
         # Last-known-good resolved model per session (keyed by gateway_session_key
         # ONLY — never session_id, which rotates/is ephemeral for one-off API
@@ -2608,6 +2630,7 @@ class APIServerAdapter(BasePlatformAdapter):
         route: Optional[Dict[str, Any]] = None,
         session_model: Optional[str] = None,
         confirmed_runtime_lock: bool = False,
+        trusted_run_context: Optional[TrustedApiRunContext] = None,
     ) -> Any:
         """
         Create an AIAgent instance using the gateway's runtime config.
@@ -2641,6 +2664,10 @@ class APIServerAdapter(BasePlatformAdapter):
         session ``/model`` override, disables the global fallback model
         chain, and fails closed if the locked provider's credentials cannot
         be resolved.
+
+        ``trusted_run_context`` is validated by ``POST /v1/runs`` before this
+        method is called. Its configured toolsets replace the ordinary API
+        surface for that one run.
         """
         from run_agent import AIAgent
         from gateway.run import (
@@ -2872,7 +2899,11 @@ class APIServerAdapter(BasePlatformAdapter):
             self._last_resolved_model["*"] = model
 
         user_config = _load_gateway_config()
-        enabled_toolsets = sorted(_get_platform_tools(user_config, "api_server"))
+        enabled_toolsets = (
+            list(trusted_run_context.toolsets)
+            if trusted_run_context is not None
+            else sorted(_get_platform_tools(user_config, "api_server"))
+        )
 
         max_iterations = _current_max_iterations()
 
@@ -2907,6 +2938,9 @@ class APIServerAdapter(BasePlatformAdapter):
             "verbose_logging": False,
             "ephemeral_system_prompt": ephemeral_system_prompt or None,
             "enabled_toolsets": enabled_toolsets,
+            "skip_context_files": trusted_run_context is not None,
+            "skip_memory": trusted_run_context is not None,
+            "skip_background_review": trusted_run_context is not None,
             "session_id": session_id,
             "platform": "api_server",
             "stream_delta_callback": stream_delta_callback,
@@ -2922,6 +2956,11 @@ class APIServerAdapter(BasePlatformAdapter):
             agent_kwargs["service_tier"] = request_service_tier
 
         agent = AIAgent(**agent_kwargs)
+        if trusted_run_context is not None:
+            # Signed one-purpose runs must not inherit prompt sections from
+            # unrelated plugins. The selected toolset remains available; only
+            # ambient plugin-authored system-prompt text is suppressed.
+            agent._plugin_system_prompt_sections_snapshot = ()
         agent._hermes_api_runtime = {
             "provider": runtime_kwargs.get("provider") or getattr(agent, "provider", "") or "",
             "model": getattr(agent, "model", None) or model,
@@ -3126,6 +3165,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 "responses_api": True,
                 "responses_streaming": True,
                 "run_submission": True,
+                "signed_run_contexts": True,
                 "run_status": True,
                 "run_events_sse": True,
                 "run_stop": True,
@@ -6451,6 +6491,149 @@ class APIServerAdapter(BasePlatformAdapter):
     _RUN_STREAM_TTL = 300  # seconds before orphaned runs are swept
     _RUN_STATUS_TTL = 3600  # seconds to retain terminal run status for polling
 
+    def _authenticate_trusted_run_context(
+        self,
+        request: "web.Request",
+    ) -> tuple[Optional[TrustedApiRunContext], Optional["web.Response"]]:
+        """Validate and one-shot claim an optional signed run context.
+
+        Unsigned ``/v1/runs`` requests retain the ordinary API-server
+        behavior. If any run-context header is present, all three must be
+        unique, canonical, and authenticated by a profile configuration that
+        replaces the run's toolsets. The opaque id and signature are never
+        logged or returned.
+        """
+
+        present = tuple(name in request.headers for name in _RUN_CONTEXT_HEADERS)
+        if not any(present):
+            return None, None
+
+        def _reject(
+            message: str = "Invalid signed run context",
+            *,
+            status: int = 401,
+            code: str = "invalid_run_context",
+        ) -> tuple[None, "web.Response"]:
+            return None, web.json_response(
+                _openai_error(message, code=code),
+                status=status,
+            )
+
+        if not all(present):
+            return _reject()
+
+        values: list[str] = []
+        for name in _RUN_CONTEXT_HEADERS:
+            all_values = request.headers.getall(name, [])
+            if len(all_values) != 1:
+                return _reject()
+            value = all_values[0]
+            if not isinstance(value, str) or value != value.strip():
+                return _reject()
+            values.append(value)
+        context_name, context_id, signature = values
+
+        if (
+            _RUN_CONTEXT_NAME_RE.fullmatch(context_name) is None
+            or _RUN_CONTEXT_ID_RE.fullmatch(context_id) is None
+            or _RUN_CONTEXT_SIGNATURE_RE.fullmatch(signature) is None
+        ):
+            return _reject()
+
+        from gateway.run import _load_gateway_config
+
+        config = _load_gateway_config()
+        gateway_config = config.get("gateway") if isinstance(config, dict) else None
+        api_config = (
+            gateway_config.get("api_server")
+            if isinstance(gateway_config, dict)
+            else None
+        )
+        trusted_contexts = (
+            api_config.get("trusted_run_contexts")
+            if isinstance(api_config, dict)
+            else None
+        )
+        context_config = (
+            trusted_contexts.get(context_name)
+            if isinstance(trusted_contexts, dict)
+            else None
+        )
+        if not isinstance(context_config, dict):
+            return _reject()
+
+        secret_env = context_config.get("signing_secret_env")
+        toolset_mode = context_config.get("toolset_mode")
+        raw_toolsets = context_config.get("toolsets")
+        if (
+            not isinstance(secret_env, str)
+            or _RUN_CONTEXT_SECRET_ENV_RE.fullmatch(secret_env) is None
+            or toolset_mode != "replace"
+            or not isinstance(raw_toolsets, list)
+            or not 1 <= len(raw_toolsets) <= 16
+            or any(
+                not isinstance(toolset, str)
+                or _RUN_CONTEXT_TOOLSET_RE.fullmatch(toolset) is None
+                for toolset in raw_toolsets
+            )
+            or len(set(raw_toolsets)) != len(raw_toolsets)
+        ):
+            return _reject(
+                "Signed run context is unavailable",
+                status=503,
+                code="run_context_unavailable",
+            )
+
+        secret = _get_scoped_secret(secret_env, "")
+        if not isinstance(secret, str) or len(secret) < 32:
+            return _reject(
+                "Signed run context is unavailable",
+                status=503,
+                code="run_context_unavailable",
+            )
+        expected = hmac.new(
+            secret.encode("utf-8"),
+            f"{context_name}\n{context_id}".encode("utf-8"),
+            hashlib.sha256,
+        ).hexdigest()
+        if not hmac.compare_digest(signature, expected):
+            return _reject()
+
+        # Reject immediate transport replays without retaining the opaque id.
+        # Domain adapters provide the durable operation/expiry fence across a
+        # gateway restart; this cache closes the accepted-run replay window in
+        # the live process.
+        now = time.monotonic()
+        cutoff = now - _RUN_CONTEXT_REPLAY_TTL_SECONDS
+        if self._trusted_run_context_claims:
+            self._trusted_run_context_claims = {
+                digest: accepted_at
+                for digest, accepted_at in self._trusted_run_context_claims.items()
+                if accepted_at >= cutoff
+            }
+        claim_digest = hashlib.sha256(
+            f"{context_name}\0{context_id}\0{expected}".encode("utf-8")
+        ).hexdigest()
+        if claim_digest in self._trusted_run_context_claims:
+            return _reject(
+                "Signed run context was already accepted",
+                status=409,
+                code="run_context_replayed",
+            )
+        while len(self._trusted_run_context_claims) >= _RUN_CONTEXT_REPLAY_MAX_CLAIMS:
+            oldest = next(iter(self._trusted_run_context_claims))
+            del self._trusted_run_context_claims[oldest]
+        self._trusted_run_context_claims[claim_digest] = now
+
+        return (
+            TrustedApiRunContext(
+                name=context_name,
+                context_id=context_id,
+                toolsets=tuple(raw_toolsets),
+            ),
+            None,
+        )
+
     def _set_run_status(self, run_id: str, status: str, **fields: Any) -> Dict[str, Any]:
         """Update pollable run status without exposing private agent objects."""
         now = time.time()
@@ -6562,6 +6745,9 @@ class APIServerAdapter(BasePlatformAdapter):
     @_admit_api_agent_request
     async def _handle_runs(self, request: "web.Request") -> "web.Response":
         """POST /v1/runs — start an agent run, return run_id immediately."""
+        signed_context_requested = any(
+            name in request.headers for name in _RUN_CONTEXT_HEADERS
+        )
         # Long-term memory scope header (see chat_completions for details).
         gateway_session_key, key_err = self._parse_session_key_header(request)
         if key_err is not None:
@@ -6588,6 +6774,24 @@ class APIServerAdapter(BasePlatformAdapter):
 
         instructions = body.get("instructions")
         previous_response_id = body.get("previous_response_id")
+
+        # Signed contexts are deliberately fresh, one-purpose runs. A caller
+        # may provide a display/session hint for compatibility, but it cannot
+        # restore history, a persisted system prompt, or long-term memory
+        # scope. The gateway replaces its session id below after allocating
+        # the private run id.
+        if signed_context_requested and (
+            gateway_session_key
+            or "conversation_history" in body
+            or previous_response_id is not None
+        ):
+            return web.json_response(
+                _openai_error(
+                    "Signed run contexts do not accept session history",
+                    code="run_context_history_forbidden",
+                ),
+                status=400,
+            )
 
         # Accept explicit conversation_history from the request body.
         # Precedence: explicit conversation_history > previous_response_id.
@@ -6633,7 +6837,11 @@ class APIServerAdapter(BasePlatformAdapter):
                         )
                     conversation_history.append({"role": msg["role"], "content": str(content)})
 
-        session_id = body.get("session_id") or stored_session_id
+        session_id = (
+            None
+            if signed_context_requested
+            else body.get("session_id") or stored_session_id
+        )
         route = self._resolve_route(body.get("model"))
         agent_overrides = _request_agent_overrides(body, virtual_model=self._model_name)
         selection_error = self._request_route_conflict_error(
@@ -6645,6 +6853,12 @@ class APIServerAdapter(BasePlatformAdapter):
         )
         if selection_error:
             return web.json_response(_openai_error(selection_error), status=400)
+
+        trusted_run_context, context_error = self._authenticate_trusted_run_context(
+            request
+        )
+        if context_error is not None:
+            return context_error
 
         run_id = f"run_{uuid.uuid4().hex}"
         session_id = session_id or run_id
@@ -6723,6 +6937,7 @@ class APIServerAdapter(BasePlatformAdapter):
                         requested_provider=agent_overrides.get("requested_provider"),
                         model_options=agent_overrides.get("model_options"),
                         route=route,
+                        trusted_run_context=trusted_run_context,
                     )
                 self._active_run_agents[run_id] = agent
 
@@ -6767,6 +6982,7 @@ class APIServerAdapter(BasePlatformAdapter):
                     effective_task_id = session_id or run_id
                     approval_token = None
                     session_tokens = []
+                    run_context_token = None
                     with self._profile_scope(request_profile):
                         try:
                             # Bind approval/session identity for this API run via
@@ -6786,6 +7002,14 @@ class APIServerAdapter(BasePlatformAdapter):
                                 session_key=approval_session_key,
                                 session_id=session_id or "",
                             )
+                            if trusted_run_context is not None:
+                                from gateway.api_run_context import (
+                                    bind_trusted_api_run_context,
+                                )
+
+                                run_context_token = bind_trusted_api_run_context(
+                                    trusted_run_context
+                                )
                             register_gateway_notify(approval_session_key, _approval_notify)
                             # /v1/runs runs its own agent lifecycle (no
                             # TurnRunner, no _run_agent) — record turn process
@@ -6815,6 +7039,17 @@ class APIServerAdapter(BasePlatformAdapter):
                                 if session_tokens:
                                     try:
                                         clear_session_vars(session_tokens)
+                                    except Exception:
+                                        pass
+                                if run_context_token is not None:
+                                    try:
+                                        from gateway.api_run_context import (
+                                            reset_trusted_api_run_context,
+                                        )
+
+                                        reset_trusted_api_run_context(
+                                            run_context_token
+                                        )
                                     except Exception:
                                         pass
                         u = {

--- a/tests/gateway/test_api_run_context.py
+++ b/tests/gateway/test_api_run_context.py
@@ -1,0 +1,45 @@
+"""Behavior contracts for request-scoped signed API-run authority."""
+
+from concurrent.futures import ThreadPoolExecutor
+
+from gateway.api_run_context import (
+    TrustedApiRunContext,
+    bind_trusted_api_run_context,
+    current_trusted_api_run_context,
+    reset_trusted_api_run_context,
+)
+
+
+def test_binding_is_scoped_and_opaque_id_is_not_represented():
+    context = TrustedApiRunContext(
+        name="bounded_context",
+        context_id="opaque_context_identifier_1234",
+        toolsets=("bounded_tools",),
+    )
+
+    assert "opaque_context_identifier_1234" not in repr(context)
+    assert current_trusted_api_run_context() is None
+
+    token = bind_trusted_api_run_context(context)
+    try:
+        assert current_trusted_api_run_context() is context
+    finally:
+        reset_trusted_api_run_context(token)
+
+    assert current_trusted_api_run_context() is None
+
+
+def test_binding_does_not_leak_to_an_unbound_worker_thread():
+    context = TrustedApiRunContext(
+        name="bounded_context",
+        context_id="opaque_context_identifier_1234",
+        toolsets=("bounded_tools",),
+    )
+    token = bind_trusted_api_run_context(context)
+    try:
+        with ThreadPoolExecutor(max_workers=1) as executor:
+            observed = executor.submit(current_trusted_api_run_context).result()
+    finally:
+        reset_trusted_api_run_context(token)
+
+    assert observed is None

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -868,6 +868,7 @@ class TestCapabilitiesEndpoint:
             assert data["runtime"]["split_runtime"] is False
             assert "API-server host" in data["runtime"]["description"]
             assert data["features"]["chat_completions"] is True
+            assert data["features"]["signed_run_contexts"] is True
             assert data["features"]["run_status"] is True
             assert data["features"]["run_events_sse"] is True
             assert data["features"]["model_options"] is True
@@ -2865,4 +2866,3 @@ class TestCreateAgentModelRecovery:
         )
         adapter._create_agent(session_id="another-session", gateway_session_key="stable-chan-1")
         assert captured[1]["model"] == "minimax/minimax-m3"
-

--- a/tests/gateway/test_api_server_runs.py
+++ b/tests/gateway/test_api_server_runs.py
@@ -10,8 +10,11 @@ Covers:
 """
 
 import asyncio
+import hashlib
+import hmac
 import threading
 import time
+from concurrent.futures import ThreadPoolExecutor
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -26,6 +29,46 @@ from gateway.platforms.api_server import (
     security_headers_middleware,
 )
 from tools import approval as approval_mod
+
+
+_RUN_CONTEXT_NAME = "fitness_mobile_plan_generation"
+_RUN_CONTEXT_ID = "dispatch_abcdefghijklmnopqrstuvwxyz012345"
+_RUN_CONTEXT_SECRET_ENV = "TEST_HERMES_RUN_CONTEXT_SIGNING_SECRET"
+_RUN_CONTEXT_SECRET = "s" * 64
+
+
+def _run_context_config() -> dict:
+    return {
+        "gateway": {
+            "api_server": {
+                "trusted_run_contexts": {
+                    _RUN_CONTEXT_NAME: {
+                        "signing_secret_env": _RUN_CONTEXT_SECRET_ENV,
+                        "toolset_mode": "replace",
+                        "toolsets": [_RUN_CONTEXT_NAME],
+                    }
+                }
+            }
+        }
+    }
+
+
+def _run_context_headers(
+    *,
+    context_name: str = _RUN_CONTEXT_NAME,
+    context_id: str = _RUN_CONTEXT_ID,
+    secret: str = _RUN_CONTEXT_SECRET,
+) -> dict[str, str]:
+    signature = hmac.new(
+        secret.encode(),
+        f"{context_name}\n{context_id}".encode(),
+        hashlib.sha256,
+    ).hexdigest()
+    return {
+        "X-Hermes-Run-Context": context_name,
+        "X-Hermes-Run-Context-Id": context_id,
+        "X-Hermes-Run-Context-Signature": signature,
+    }
 
 
 # ---------------------------------------------------------------------------
@@ -146,6 +189,513 @@ class TestStartRun:
                 assert status["run_id"] == data["run_id"]
                 assert status["status"] in {"queued", "running", "completed"}
                 assert status["object"] == "hermes.run"
+
+    @pytest.mark.asyncio
+    async def test_signed_context_replaces_toolsets_and_binds_worker_context(
+        self, adapter, monkeypatch
+    ):
+        app = _create_runs_app(adapter)
+        captured = {}
+        monkeypatch.setenv(_RUN_CONTEXT_SECRET_ENV, _RUN_CONTEXT_SECRET)
+
+        async with TestClient(TestServer(app)) as cli:
+            with patch(
+                "gateway.run._load_gateway_config",
+                return_value=_run_context_config(),
+            ), patch.object(adapter, "_create_agent") as mock_create:
+                mock_agent = MagicMock()
+
+                def _capture_context(**_kwargs):
+                    from gateway.api_run_context import (
+                        current_trusted_api_run_context,
+                    )
+
+                    context = current_trusted_api_run_context()
+                    captured["name"] = context.name if context is not None else None
+                    captured["context_id"] = (
+                        context.context_id if context is not None else None
+                    )
+                    return {"final_response": "done"}
+
+                mock_agent.run_conversation.side_effect = _capture_context
+                mock_agent.session_prompt_tokens = 0
+                mock_agent.session_completion_tokens = 0
+                mock_agent.session_total_tokens = 0
+                mock_create.return_value = mock_agent
+
+                resp = await cli.post(
+                    "/v1/runs",
+                    json={"input": "hello"},
+                    headers=_run_context_headers(),
+                )
+                assert resp.status == 202
+                run_id = (await resp.json())["run_id"]
+
+                for _ in range(40):
+                    status = await (await cli.get(f"/v1/runs/{run_id}")).json()
+                    if status["status"] == "completed":
+                        break
+                    await asyncio.sleep(0.05)
+
+        trusted = mock_create.call_args.kwargs["trusted_run_context"]
+        assert trusted.name == _RUN_CONTEXT_NAME
+        assert trusted.toolsets == (_RUN_CONTEXT_NAME,)
+        assert captured == {
+            "name": _RUN_CONTEXT_NAME,
+            "context_id": _RUN_CONTEXT_ID,
+        }
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "headers",
+        [
+            {"X-Hermes-Run-Context": _RUN_CONTEXT_NAME},
+            {"X-Hermes-Run-Context-Id": _RUN_CONTEXT_ID},
+            {"X-Hermes-Run-Context-Signature": "0" * 64},
+            {
+                "X-Hermes-Run-Context": _RUN_CONTEXT_NAME,
+                "X-Hermes-Run-Context-Id": _RUN_CONTEXT_ID,
+            },
+            {
+                "X-Hermes-Run-Context": _RUN_CONTEXT_NAME,
+                "X-Hermes-Run-Context-Signature": "0" * 64,
+            },
+            {
+                "X-Hermes-Run-Context-Id": _RUN_CONTEXT_ID,
+                "X-Hermes-Run-Context-Signature": "0" * 64,
+            },
+        ],
+    )
+    async def test_partial_signed_context_is_rejected_before_run_allocation(
+        self, adapter, headers
+    ):
+        app = _create_runs_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_create_agent") as mock_create:
+                resp = await cli.post(
+                    "/v1/runs",
+                    json={"input": "hello"},
+                    headers=headers,
+                )
+                body = await resp.json()
+
+        assert resp.status == 401
+        assert body["error"]["code"] == "invalid_run_context"
+        assert adapter._run_statuses == {}
+        mock_create.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_bad_signed_context_signature_is_rejected(self, adapter, monkeypatch):
+        app = _create_runs_app(adapter)
+        monkeypatch.setenv(_RUN_CONTEXT_SECRET_ENV, _RUN_CONTEXT_SECRET)
+        headers = _run_context_headers()
+        headers["X-Hermes-Run-Context-Signature"] = "0" * 64
+
+        async with TestClient(TestServer(app)) as cli:
+            with patch(
+                "gateway.run._load_gateway_config",
+                return_value=_run_context_config(),
+            ), patch.object(adapter, "_create_agent") as mock_create:
+                resp = await cli.post(
+                    "/v1/runs",
+                    json={"input": "hello"},
+                    headers=headers,
+                )
+                body = await resp.json()
+
+        assert resp.status == 401
+        assert body["error"]["code"] == "invalid_run_context"
+        assert adapter._run_statuses == {}
+        mock_create.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_signed_context_with_unavailable_secret_fails_closed(
+        self, adapter, monkeypatch
+    ):
+        app = _create_runs_app(adapter)
+        monkeypatch.delenv(_RUN_CONTEXT_SECRET_ENV, raising=False)
+
+        async with TestClient(TestServer(app)) as cli:
+            with patch(
+                "gateway.run._load_gateway_config",
+                return_value=_run_context_config(),
+            ), patch.object(adapter, "_create_agent") as mock_create:
+                resp = await cli.post(
+                    "/v1/runs",
+                    json={"input": "hello"},
+                    headers=_run_context_headers(),
+                )
+                body = await resp.json()
+
+        assert resp.status == 503
+        assert body["error"]["code"] == "run_context_unavailable"
+        assert adapter._run_statuses == {}
+        mock_create.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_signed_context_replay_is_rejected(self, adapter, monkeypatch):
+        app = _create_runs_app(adapter)
+        monkeypatch.setenv(_RUN_CONTEXT_SECRET_ENV, _RUN_CONTEXT_SECRET)
+
+        async with TestClient(TestServer(app)) as cli:
+            with patch(
+                "gateway.run._load_gateway_config",
+                return_value=_run_context_config(),
+            ), patch.object(adapter, "_create_agent") as mock_create:
+                mock_agent = MagicMock()
+                mock_agent.run_conversation.return_value = {"final_response": "done"}
+                mock_agent.session_prompt_tokens = 0
+                mock_agent.session_completion_tokens = 0
+                mock_agent.session_total_tokens = 0
+                mock_create.return_value = mock_agent
+
+                first = await cli.post(
+                    "/v1/runs",
+                    json={"input": "hello"},
+                    headers=_run_context_headers(),
+                )
+                replay = await cli.post(
+                    "/v1/runs",
+                    json={"input": "hello again"},
+                    headers=_run_context_headers(),
+                )
+                body = await replay.json()
+
+        assert first.status == 202
+        assert replay.status == 409
+        assert body["error"]["code"] == "run_context_replayed"
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("header", "value"),
+        [
+            ("X-Hermes-Run-Context", "Fitness Mobile"),
+            ("X-Hermes-Run-Context", f" {_RUN_CONTEXT_NAME}"),
+            ("X-Hermes-Run-Context-Id", "too-short"),
+            ("X-Hermes-Run-Context-Id", f"{_RUN_CONTEXT_ID}!"),
+            ("X-Hermes-Run-Context-Signature", "A" * 64),
+            ("X-Hermes-Run-Context-Signature", "0" * 63),
+        ],
+    )
+    async def test_malformed_signed_context_is_rejected_before_run_allocation(
+        self, adapter, header, value
+    ):
+        app = _create_runs_app(adapter)
+        headers = _run_context_headers()
+        headers[header] = value
+
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_create_agent") as mock_create:
+                resp = await cli.post(
+                    "/v1/runs",
+                    json={"input": "hello"},
+                    headers=headers,
+                )
+                body = await resp.json()
+
+        assert resp.status == 401
+        assert body["error"]["code"] == "invalid_run_context"
+        assert adapter._run_statuses == {}
+        mock_create.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_unknown_signed_context_is_rejected_before_run_allocation(
+        self, adapter, monkeypatch
+    ):
+        app = _create_runs_app(adapter)
+        monkeypatch.setenv(_RUN_CONTEXT_SECRET_ENV, _RUN_CONTEXT_SECRET)
+        headers = _run_context_headers(context_name="unknown_context")
+
+        async with TestClient(TestServer(app)) as cli:
+            with patch(
+                "gateway.run._load_gateway_config",
+                return_value=_run_context_config(),
+            ), patch.object(adapter, "_create_agent") as mock_create:
+                resp = await cli.post(
+                    "/v1/runs",
+                    json={"input": "hello"},
+                    headers=headers,
+                )
+                body = await resp.json()
+
+        assert resp.status == 401
+        assert body["error"]["code"] == "invalid_run_context"
+        assert adapter._run_statuses == {}
+        mock_create.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_duplicate_signed_context_header_is_rejected_before_run_allocation(
+        self, adapter
+    ):
+        app = _create_runs_app(adapter)
+        headers = list(_run_context_headers().items())
+        headers.append(("X-Hermes-Run-Context", _RUN_CONTEXT_NAME))
+
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_create_agent") as mock_create:
+                resp = await cli.post(
+                    "/v1/runs",
+                    json={"input": "hello"},
+                    headers=headers,
+                )
+                body = await resp.json()
+
+        assert resp.status == 401
+        assert body["error"]["code"] == "invalid_run_context"
+        assert adapter._run_statuses == {}
+        mock_create.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_non_replacing_signed_context_configuration_fails_closed(
+        self, adapter, monkeypatch
+    ):
+        app = _create_runs_app(adapter)
+        monkeypatch.setenv(_RUN_CONTEXT_SECRET_ENV, _RUN_CONTEXT_SECRET)
+        config = _run_context_config()
+        config["gateway"]["api_server"]["trusted_run_contexts"][
+            _RUN_CONTEXT_NAME
+        ]["toolset_mode"] = "append"
+
+        async with TestClient(TestServer(app)) as cli:
+            with patch(
+                "gateway.run._load_gateway_config",
+                return_value=config,
+            ), patch.object(adapter, "_create_agent") as mock_create:
+                resp = await cli.post(
+                    "/v1/runs",
+                    json={"input": "hello"},
+                    headers=_run_context_headers(),
+                )
+                body = await resp.json()
+
+        assert resp.status == 503
+        assert body["error"]["code"] == "run_context_unavailable"
+        assert adapter._run_statuses == {}
+        mock_create.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_signed_context_id_does_not_enter_prompt_or_status(
+        self, adapter, monkeypatch
+    ):
+        app = _create_runs_app(adapter)
+        monkeypatch.setenv(_RUN_CONTEXT_SECRET_ENV, _RUN_CONTEXT_SECRET)
+
+        async with TestClient(TestServer(app)) as cli:
+            with patch(
+                "gateway.run._load_gateway_config",
+                return_value=_run_context_config(),
+            ), patch.object(adapter, "_create_agent") as mock_create:
+                mock_agent = MagicMock()
+                mock_agent.run_conversation.return_value = {"final_response": "done"}
+                mock_agent.session_prompt_tokens = 0
+                mock_agent.session_completion_tokens = 0
+                mock_agent.session_total_tokens = 0
+                mock_create.return_value = mock_agent
+
+                resp = await cli.post(
+                    "/v1/runs",
+                    json={"input": "hello", "instructions": "bounded task"},
+                    headers=_run_context_headers(),
+                )
+                run_id = (await resp.json())["run_id"]
+                for _ in range(40):
+                    status = await (await cli.get(f"/v1/runs/{run_id}")).json()
+                    if status["status"] == "completed":
+                        break
+                    await asyncio.sleep(0.05)
+
+        assert resp.status == 202
+        assert mock_agent.run_conversation.call_args.kwargs["user_message"] == "hello"
+        assert mock_create.call_args.kwargs["ephemeral_system_prompt"] == "bounded task"
+        assert _RUN_CONTEXT_ID not in str(status)
+        assert _RUN_CONTEXT_ID not in str(mock_agent.run_conversation.call_args)
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "history_fields",
+        [
+            {"conversation_history": []},
+            {"conversation_history": [{"role": "user", "content": "old"}]},
+            {"previous_response_id": "resp_old"},
+        ],
+    )
+    async def test_signed_context_rejects_session_history_before_run_allocation(
+        self, adapter, history_fields
+    ):
+        app = _create_runs_app(adapter)
+        payload = {"input": "hello", **history_fields}
+
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_create_agent") as mock_create:
+                resp = await cli.post(
+                    "/v1/runs",
+                    json=payload,
+                    headers=_run_context_headers(),
+                )
+                body = await resp.json()
+
+        assert resp.status == 400
+        assert body["error"]["code"] == "run_context_history_forbidden"
+        assert adapter._run_statuses == {}
+        mock_create.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_signed_context_replaces_caller_session_id(
+        self, adapter, monkeypatch
+    ):
+        app = _create_runs_app(adapter)
+        monkeypatch.setenv(_RUN_CONTEXT_SECRET_ENV, _RUN_CONTEXT_SECRET)
+
+        async with TestClient(TestServer(app)) as cli:
+            with patch(
+                "gateway.run._load_gateway_config",
+                return_value=_run_context_config(),
+            ), patch.object(adapter, "_create_agent") as mock_create:
+                mock_agent = MagicMock()
+                mock_agent.run_conversation.return_value = {"final_response": "done"}
+                mock_agent.session_prompt_tokens = 0
+                mock_agent.session_completion_tokens = 0
+                mock_agent.session_total_tokens = 0
+                mock_create.return_value = mock_agent
+
+                resp = await cli.post(
+                    "/v1/runs",
+                    json={"input": "hello", "session_id": "caller-session"},
+                    headers=_run_context_headers(),
+                )
+                run_id = (await resp.json())["run_id"]
+                for _ in range(40):
+                    status = await (await cli.get(f"/v1/runs/{run_id}")).json()
+                    if status["status"] == "completed":
+                        break
+                    await asyncio.sleep(0.05)
+
+        assert resp.status == 202
+        assert status["session_id"] == run_id
+        assert mock_create.call_args.kwargs["session_id"] == run_id
+        assert mock_agent.run_conversation.call_args.kwargs["task_id"] == run_id
+
+    @pytest.mark.asyncio
+    async def test_parallel_signed_runs_keep_contexts_isolated(
+        self, adapter, monkeypatch
+    ):
+        app = _create_runs_app(adapter)
+        monkeypatch.setenv(_RUN_CONTEXT_SECRET_ENV, _RUN_CONTEXT_SECRET)
+        context_ids = (
+            "dispatch_parallel_aaaaaaaaaaaaaaaaaaaaaaaa",
+            "dispatch_parallel_bbbbbbbbbbbbbbbbbbbbbbbb",
+        )
+        barrier = threading.Barrier(2)
+        observed = {}
+
+        def _create_for_context(**kwargs):
+            expected = kwargs["trusted_run_context"].context_id
+            mock_agent = MagicMock()
+
+            def _run(**_run_kwargs):
+                from gateway.api_run_context import current_trusted_api_run_context
+
+                barrier.wait(timeout=5)
+                current = current_trusted_api_run_context()
+                observed[expected] = current.context_id if current is not None else None
+                return {"final_response": "done"}
+
+            mock_agent.run_conversation.side_effect = _run
+            mock_agent.session_prompt_tokens = 0
+            mock_agent.session_completion_tokens = 0
+            mock_agent.session_total_tokens = 0
+            return mock_agent
+
+        async with TestClient(TestServer(app)) as cli:
+            with patch(
+                "gateway.run._load_gateway_config",
+                return_value=_run_context_config(),
+            ), patch.object(
+                adapter,
+                "_create_agent",
+                side_effect=_create_for_context,
+            ):
+                responses = [
+                    await cli.post(
+                        "/v1/runs",
+                        json={"input": "hello"},
+                        headers=_run_context_headers(context_id=context_id),
+                    )
+                    for context_id in context_ids
+                ]
+                run_ids = [(await response.json())["run_id"] for response in responses]
+                for _ in range(80):
+                    statuses = [
+                        (await cli.get(f"/v1/runs/{run_id}")) for run_id in run_ids
+                    ]
+                    payloads = [await status.json() for status in statuses]
+                    if all(payload["status"] == "completed" for payload in payloads):
+                        break
+                    await asyncio.sleep(0.05)
+
+        assert all(response.status == 202 for response in responses)
+        assert observed == {context_id: context_id for context_id in context_ids}
+
+    @pytest.mark.asyncio
+    async def test_signed_context_is_cleared_after_worker_failure(
+        self, adapter, monkeypatch
+    ):
+        app = _create_runs_app(adapter)
+        monkeypatch.setenv(_RUN_CONTEXT_SECRET_ENV, _RUN_CONTEXT_SECRET)
+        loop = asyncio.get_running_loop()
+        loop.set_default_executor(ThreadPoolExecutor(max_workers=1))
+        observed = []
+
+        def _create_agent(**kwargs):
+            mock_agent = MagicMock()
+
+            def _run(**_run_kwargs):
+                from gateway.api_run_context import current_trusted_api_run_context
+
+                current = current_trusted_api_run_context()
+                observed.append(current.context_id if current is not None else None)
+                if kwargs["trusted_run_context"] is not None:
+                    raise RuntimeError("expected test failure")
+                return {"final_response": "done"}
+
+            mock_agent.run_conversation.side_effect = _run
+            mock_agent.session_prompt_tokens = 0
+            mock_agent.session_completion_tokens = 0
+            mock_agent.session_total_tokens = 0
+            return mock_agent
+
+        async with TestClient(TestServer(app)) as cli:
+            with patch(
+                "gateway.run._load_gateway_config",
+                return_value=_run_context_config(),
+            ), patch.object(adapter, "_create_agent", side_effect=_create_agent):
+                signed = await cli.post(
+                    "/v1/runs",
+                    json={"input": "hello"},
+                    headers=_run_context_headers(),
+                )
+                signed_id = (await signed.json())["run_id"]
+                for _ in range(40):
+                    signed_status = await (
+                        await cli.get(f"/v1/runs/{signed_id}")
+                    ).json()
+                    if signed_status["status"] == "failed":
+                        break
+                    await asyncio.sleep(0.05)
+
+                unsigned = await cli.post("/v1/runs", json={"input": "hello"})
+                unsigned_id = (await unsigned.json())["run_id"]
+                for _ in range(40):
+                    unsigned_status = await (
+                        await cli.get(f"/v1/runs/{unsigned_id}")
+                    ).json()
+                    if unsigned_status["status"] == "completed":
+                        break
+                    await asyncio.sleep(0.05)
+
+        assert signed.status == 202
+        assert unsigned.status == 202
+        assert observed == [_RUN_CONTEXT_ID, None]
 
     @pytest.mark.asyncio
     async def test_start_binds_chat_id_for_delegation_wake_target(self, adapter):

--- a/tests/gateway/test_api_server_toolset.py
+++ b/tests/gateway/test_api_server_toolset.py
@@ -80,3 +80,41 @@ class TestApiServerAdapterToolset:
             assert len(toolsets) > 0
             assert call_kwargs.kwargs.get("platform") == "api_server"
 
+    @patch("gateway.platforms.api_server.AIOHTTP_AVAILABLE", True)
+    def test_trusted_run_context_replaces_default_toolsets(self):
+        """A signed run receives only its configured one-purpose surface."""
+        from gateway.api_run_context import TrustedApiRunContext
+        from gateway.config import PlatformConfig
+        from gateway.platforms.api_server import APIServerAdapter
+
+        adapter = APIServerAdapter(PlatformConfig())
+        context = TrustedApiRunContext(
+            name="bounded_context",
+            context_id="opaque_context_identifier_1234",
+            toolsets=("bounded_context",),
+        )
+
+        with patch("gateway.run._resolve_runtime_agent_kwargs") as mock_kwargs, \
+             patch("gateway.run._resolve_gateway_model") as mock_model, \
+             patch("gateway.run._load_gateway_config", return_value={}), \
+             patch("run_agent.AIAgent") as mock_agent_cls:
+            mock_kwargs.return_value = {
+                "api_key": "test-key",
+                "base_url": None,
+                "provider": None,
+                "api_mode": None,
+                "command": None,
+                "args": [],
+            }
+            mock_model.return_value = "test/model"
+            mock_agent_cls.return_value = MagicMock()
+
+            adapter._create_agent(trusted_run_context=context)
+
+        assert mock_agent_cls.call_args.kwargs["enabled_toolsets"] == [
+            "bounded_context"
+        ]
+        assert mock_agent_cls.call_args.kwargs["skip_context_files"] is True
+        assert mock_agent_cls.call_args.kwargs["skip_memory"] is True
+        assert mock_agent_cls.call_args.kwargs["skip_background_review"] is True
+        assert mock_agent_cls.return_value._plugin_system_prompt_sections_snapshot == ()


### PR DESCRIPTION
## What changed

- authenticate optional signed run-context headers on `POST /v1/runs`
- replace the ordinary API tool surface with a configured one-purpose toolset
- bind the opaque context identifier only inside the run's executor context
- suppress ambient context files, memory, plugin prompt sections, and prior session history
- advertise `signed_run_contexts` through `/v1/capabilities`
- reject malformed, partial, duplicated, replayed, or misconfigured contexts before run allocation

## Why

Fitness Mobile v0.5.0 already emits this signed context contract, but Hermes Agent did not implement it. The gateway accepted the run while the Fitness plugin could not recover its bound context, so workout preparation completed without publishing a plan.

## Validation

- 181 focused gateway, secret-scope, toolset, and API compatibility tests pass
- Ruff passes for the entire repository
- actual Fitness Mobile plan plugin resolves the staged context and registers exactly its three intended tools
- broad repository run completed with 31,254 passing, 330 skipped, and 94 failing tests; all failures are outside the changed gateway surface and are attributable to missing optional ACP/Anthropic/FAL/Modal/Parallel dependencies or host-specific service/path assumptions in this macOS developer environment
