### PR TITLE
fix(desktop): Enter confirms a clicked clarify choice

### DIFF
--- a/apps/desktop/src/components/assistant-ui/clarify-tool.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/clarify-tool.test.tsx
@@ -367,6 +367,28 @@ describe('ClarifyTool keyboard navigation', () => {
     expect(fireEvent.keyDown(window, { key: 'ArrowDown' })).toBe(true)
     expect(request).not.toHaveBeenCalled()
   })
+
+  it('confirms a clicked choice with Enter while the choice button keeps focus', async () => {
+    const request = renderLiveClarify()
+    const production = screen.getByRole('button', { name: /production/ })
+
+    // Click selects the choice; in a real browser the option button keeps
+    // focus afterwards. jsdom's fireEvent.click does not move focus, so
+    // focus it explicitly to reproduce the reported bug.
+    fireEvent.click(production)
+    production.focus()
+    expect(production.getAttribute('aria-pressed')).toBe('true')
+    expect(document.activeElement).toBe(production)
+
+    fireEvent.keyDown(window, { key: 'Enter' })
+
+    await waitFor(() => {
+      expect(request).toHaveBeenCalledWith('clarify.respond', {
+        answer: 'production',
+        request_id: 'request-1'
+      })
+    })
+  })
 })
 
 describe('ClarifyTool recommended option', () => {

--- a/apps/desktop/src/components/assistant-ui/clarify-tool.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/clarify-tool.test.tsx
@@ -389,6 +389,28 @@ describe('ClarifyTool keyboard navigation', () => {
       })
     })
   })
+
+  it('confirms a Tab-focused (not clicked) choice with Enter', async () => {
+    const request = renderLiveClarify()
+    const production = screen.getByRole('button', { name: /production/ })
+
+    // A pure-keyboard user tabs onto the choice without clicking it. The
+    // choice is still the answer itself, so Enter must confirm the currently
+    // highlighted one (staging is active by default) — not fall through as a
+    // hands-off keypress (the pre-fix bug path).
+    production.focus()
+    expect(production.getAttribute('aria-pressed')).toBe('false')
+    expect(document.activeElement).toBe(production)
+
+    fireEvent.keyDown(window, { key: 'Enter' })
+
+    await waitFor(() => {
+      expect(request).toHaveBeenCalledWith('clarify.respond', {
+        answer: 'staging',
+        request_id: 'request-1'
+      })
+    })
+  })
 })
 
 describe('ClarifyTool recommended option', () => {

--- a/apps/desktop/src/components/assistant-ui/clarify-tool.tsx
+++ b/apps/desktop/src/components/assistant-ui/clarify-tool.tsx
@@ -601,7 +601,20 @@ function ClarifyToolSinglePending({ fromArgs, request }: { fromArgs: ClarifyArgs
 
       if (
         active &&
-        (active.isContentEditable || active.matches('a[href], button, input, select, textarea, [role="button"]'))
+        active.isContentEditable &&
+        !active.closest('[data-clarify-choices]')
+      ) {
+        return
+      }
+
+      if (
+        active &&
+        !active.isContentEditable &&
+        active.matches('a[href], button, input, select, textarea, [role="button"]') &&
+        // A choice row is the answer itself: Enter on it must confirm the
+        // picked answer rather than fall through to the button's select
+        // handler. Everything else focused stays hands-off.
+        !active.matches('button[data-choice]')
       ) {
         return
       }


### PR DESCRIPTION
## Summary

In the clarify tool card, **clicking a choice leaves focus on the option button**. The global keydown handler's focus guard treated *any* focused button as hands-off:

```ts
if (active && (active.isContentEditable || active.matches('a[href], button, input, ...'))) {
  return  // hands-off
}
```

So pressing **Enter** after clicking a choice fell through to the button's native behavior — its `onClick` is `selectChoice`, which just re-selects. The user had to click **Continue** manually.

## Fix

Choice rows are the answer itself: when the focused element is `button[data-choice]`, Enter now runs the normal activate/confirm path (which submits a staged/picked answer). The guard still stands down for every other focused control (Skip, Continue, the Other textarea, composer).

## Test Plan

- New regression test: `confirms a clicked choice with Enter while the choice button keeps focus` — click → focus stays on the option → Enter → `clarify.respond` called with the picked answer
- Existing suite still green (19 tests in clarify-tool.test.tsx, incl. 'does not intercept keyboard events while an action button has focus')