### PR TITLE
Fix skills install paths under symlinked skills roots

### DIFF
--- a/hermes_cli/skills_hub.py
+++ b/hermes_cli/skills_hub.py
@@ -737,7 +737,8 @@ def do_install(identifier: str, category: str = "", force: bool = False,
                          bundle.trust_level, "invalid_path", str(exc))
         return
     from tools.skills_hub import SKILLS_DIR
-    c.print(f"[bold green]Installed:[/] {install_dir.relative_to(SKILLS_DIR)}")
+    install_rel = install_dir.resolve().relative_to(Path(SKILLS_DIR).resolve())
+    c.print(f"[bold green]Installed:[/] {install_rel}")
     c.print(f"[dim]Files: {', '.join(bundle.files.keys())}[/]\n")
 
     # Blueprint detection: if the installed skill declares a

--- a/tests/hermes_cli/test_skills_hub.py
+++ b/tests/hermes_cli/test_skills_hub.py
@@ -255,6 +255,60 @@ def _install_mocks(monkeypatch, tmp_path, source_factory, category_hint=""):
     return install_calls
 
 
+def test_do_install_prints_installed_path_under_symlinked_skills_dir(monkeypatch, tmp_path):
+    import tools.skills_hub as hub
+    import tools.skills_guard as guard
+
+    real_skills_dir = tmp_path / "real-home" / "skills"
+    real_skills_dir.mkdir(parents=True)
+    linked_skills_dir = tmp_path / "linked-skills"
+    try:
+        linked_skills_dir.symlink_to(real_skills_dir, target_is_directory=True)
+    except (OSError, NotImplementedError):
+        pytest.skip("symlink creation unsupported on this platform")
+
+    q_path = linked_skills_dir / ".hub" / "quarantine" / "pending"
+    q_path.mkdir(parents=True)
+
+    def _install_from_quarantine(q, name, category, bundle, result):
+        install_dir = real_skills_dir / category / name
+        install_dir.mkdir(parents=True)
+        return install_dir
+
+    monkeypatch.setattr(hub, "SKILLS_DIR", linked_skills_dir)
+    monkeypatch.setattr(hub, "ensure_hub_dirs", lambda: None)
+    monkeypatch.setattr(
+        hub,
+        "create_source_router",
+        lambda auth: [_make_url_bundle_fetcher("example-skill", awaiting_name=False)()],
+    )
+    monkeypatch.setattr(hub, "quarantine_bundle", lambda bundle: q_path)
+    monkeypatch.setattr(hub, "install_from_quarantine", _install_from_quarantine)
+    monkeypatch.setattr(
+        hub,
+        "HubLockFile",
+        lambda: type("Lock", (), {"get_installed": lambda self, n: None})(),
+    )
+    monkeypatch.setattr(
+        guard,
+        "scan_skill",
+        lambda skill_path, source="community": guard.ScanResult(
+            skill_name="pending", source=source, trust_level="community", verdict="safe",
+        ),
+    )
+    monkeypatch.setattr(guard, "format_scan_report", lambda result: "scan ok")
+    monkeypatch.setattr(guard, "should_allow_install", lambda result, force=False: (True, "ok"))
+
+    sink = StringIO()
+    console = Console(file=sink, force_terminal=False, color_system=None, width=80)
+
+    do_install("https://example.com/example-skill", category="tools", force=True, console=console)
+
+    out = sink.getvalue()
+    assert "Installed:" in out
+    assert "tools/example-skill" in out
+
+
 
 
 
@@ -312,4 +366,3 @@ def test_do_search_json_flag_emits_full_identifiers(capsys):
     assert payload[0]["source"] == "browse-sh"
     # Table render must be suppressed — sink should be empty (no "Searching for:" header).
     assert "Searching for:" not in sink.getvalue()
-

--- a/tests/tools/test_skills_hub.py
+++ b/tests/tools/test_skills_hub.py
@@ -1655,6 +1655,53 @@ class TestInstallPathSafety:
         assert installed.is_dir()
         record_installed.assert_called_once_with("good-skill")
 
+    def test_install_from_quarantine_records_path_under_symlinked_skills_dir(self, tmp_path):
+        """A symlinked skills root must still record a portable lock path."""
+        import tools.skills_hub as hub
+        from tools.skills_guard import ScanResult
+
+        real_skills_dir = tmp_path / "real-home" / "skills"
+        real_skills_dir.mkdir(parents=True)
+        linked_skills_dir = tmp_path / "linked-skills"
+        try:
+            linked_skills_dir.symlink_to(real_skills_dir, target_is_directory=True)
+        except (OSError, NotImplementedError):
+            pytest.skip("symlink creation unsupported on this platform")
+
+        quarantine_root = linked_skills_dir / ".hub" / "quarantine"
+        q_dir = quarantine_root / "pending"
+        q_dir.mkdir(parents=True)
+        skill_md = "---\nname: good-skill\n---\n\n# Good skill\n"
+        (q_dir / "SKILL.md").write_text(skill_md, encoding="utf-8")
+        bundle = hub.SkillBundle(
+            name="good-skill",
+            files={"SKILL.md": skill_md},
+            source="community",
+            identifier="good/source",
+            trust_level="community",
+        )
+        scan_result = ScanResult(
+            skill_name="good-skill",
+            source="community",
+            trust_level="community",
+            verdict="safe",
+        )
+
+        with patch.object(hub, "SKILLS_DIR", linked_skills_dir), \
+             patch.object(hub, "QUARANTINE_DIR", quarantine_root), \
+             patch("tools.skill_usage.record_installed"):
+            installed = hub.install_from_quarantine(
+                q_dir,
+                "good-skill",
+                "",
+                bundle,
+                scan_result,
+            )
+
+        assert installed == real_skills_dir / "good-skill"
+        lock_data = json.loads((real_skills_dir / ".hub" / "lock.json").read_text())
+        assert lock_data["installed"]["good-skill"]["install_path"] == "good-skill"
+
 
 # ---------------------------------------------------------------------------
 # parallel_search_sources — overall_timeout must be honoured even when a

--- a/tools/skills_hub.py
+++ b/tools/skills_hub.py
@@ -297,6 +297,11 @@ def _resolve_lock_install_path(install_path: str, skill_name: str) -> Path:
     return target
 
 
+def _install_path_relative_to_skills_dir(path: Path) -> str:
+    """Return a lock-file relative path for an installed skill."""
+    return path.resolve().relative_to(_skills_dir().resolve()).as_posix()
+
+
 def _ssrf_safe_http_get(url: str, *, timeout: int = 20) -> httpx.Response:
     """Fetch one URL with connect-time SSRF validation and no automatic redirects."""
     from tools.url_safety import create_ssrf_safe_client
@@ -3999,7 +4004,7 @@ def install_from_quarantine(
         trust_level=bundle.trust_level,
         scan_verdict=scan_result.verdict,
         skill_hash=content_hash(install_dir),
-        install_path=str(install_dir.relative_to(_skills_dir())),
+        install_path=_install_path_relative_to_skills_dir(install_dir),
         files=list(bundle.files.keys()),
         metadata=bundle.metadata,
         scan_provenance=scan_provenance or getattr(scan_result, "scan_provenance", None),


### PR DESCRIPTION
## Summary
- resolve installed skill paths against the resolved skills root before recording lock-file paths
- resolve the CLI display path the same way so symlinked/junctioned skills roots do not crash after install
- add regression coverage for symlinked skills roots in the library and CLI install flow

Fixes #86971

## Tests
- scripts/run_tests.sh tests/tools/test_skills_hub.py -q
- scripts/run_tests.sh tests/hermes_cli/test_skills_hub.py -q
- .venv/bin/python -m ruff check tools/skills_hub.py hermes_cli/skills_hub.py tests/tools/test_skills_hub.py tests/hermes_cli/test_skills_hub.py
- git diff --check