### PR TITLE
fix(desktop): scope the unread-flag write guard and lookups by profile

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/index.tsx
+++ b/apps/desktop/src/app/chat/sidebar/index.tsx
@@ -125,7 +125,7 @@ import {
 import { $sessionDotStateById, sessionStatusBucket } from '@/store/session-dot-state'
 import { $focusedStoredSessionId, $workingSessionIds, type SplitDir } from '@/store/session-states'
 import { ackAllSessionsRead } from '@/store/session-unread'
-import { markSessionUnread } from '@/store/session-unread-remote'
+import { markSessionUnread, rowFor as unreadRowFor } from '@/store/session-unread-remote'
 import { $archivedSessions, loadArchivedSessions } from '@/store/sidebar-archive'
 import { $sidebarSessionRankIds } from '@/store/sidebar-sort'
 
@@ -378,8 +378,12 @@ export function ChatSidebar({
   // Toggle the persisted read-state watermark from a row menu. The row's own
   // `unread` prop mirrors what the dot paints; flip it and let the backend
   // become the truth (optimistic update + rollback in markSessionUnread).
+  // Resolved via the same profile-aware lookup markSessionUnread uses
+  // internally: a bare `$sessions.get().find(...)` here would toggle
+  // whichever profile's same-id row happens to sort first when ALL_PROFILES
+  // mode mixes lists, computing the flip direction off the wrong row.
   const toggleUnread = (storedId: string) => {
-    const row = $sessions.get().find(r => r.id === storedId)
+    const row = unreadRowFor(storedId)
 
     if (!row) {
       return

--- a/apps/desktop/src/store/session-dot-state.test.ts
+++ b/apps/desktop/src/store/session-dot-state.test.ts
@@ -127,8 +127,8 @@ describe('persisted unread (backend watermark)', () => {
   })
 
   it('fences a stale page with the write guard', () => {
-    const guard = new Map<string, { at: number; value: boolean }>()
-    guard.set('s1', { at: Date.now(), value: true })
+    const guard = new Map<string, { at: number; profile: string; value: boolean }>()
+    guard.set('s1', { at: Date.now(), profile: 'default', value: true })
     $unreadWriteGuard.set(guard)
 
     // A page issued before our PATCH still says read — keep OUR value.
@@ -136,9 +136,23 @@ describe('persisted unread (backend watermark)', () => {
     expect($sessionDotStateById.get()['s1']).toBe('unread')
 
     // The guard expires: the page wins and the dot drops.
-    const expired = new Map<string, { at: number; value: boolean }>()
-    expired.set('s1', { at: Date.now() - 60_000, value: true })
+    const expired = new Map<string, { at: number; profile: string; value: boolean }>()
+    expired.set('s1', { at: Date.now() - 60_000, profile: 'default', value: true })
     $unreadWriteGuard.set(expired)
+    expect($sessionDotStateById.get()['s1']).not.toBe('unread')
+  })
+
+  it('does not let a write guard for one profile fence a same-id row in another', () => {
+    // Session ids are caller-supplied and each profile's backend is its own
+    // namespace, so two profiles can hold the same id (a real, documented
+    // scenario elsewhere in this store family) — a guard entry written for
+    // 'work' must never paint or protect 'personal''s identically-id'd row.
+    const guard = new Map<string, { at: number; profile: string; value: boolean }>()
+    guard.set('s1', { at: Date.now(), profile: 'work', value: true })
+    $unreadWriteGuard.set(guard)
+
+    setSessions([storedRow('s1', { profile: 'personal', unread: false })])
+
     expect($sessionDotStateById.get()['s1']).not.toBe('unread')
   })
 

--- a/apps/desktop/src/store/session-dot-state.ts
+++ b/apps/desktop/src/store/session-dot-state.ts
@@ -28,6 +28,7 @@ import { computed } from 'nanostores'
 import { stableArray, stableRecord } from '@/lib/stable-array'
 
 import { $backgroundRunningSessionIds } from './composer-status'
+import { normalizeProfileKey } from './profile'
 import { $sessions, $unreadFinishedSessionIds, lineageAliases } from './session'
 import {
   $attentionSessionIds,
@@ -141,8 +142,12 @@ export const $sessionDotStateById = computed(
 
     for (const s of sessions) {
       const entry = unreadWriteGuard.get(s.id)
+      // Same-id rows across profiles are a real, documented possibility
+      // (session-unread.ts) — a guard entry only fences the ROW it was
+      // written for, never a same-id row from another profile.
+      const entryMatchesRow = entry && entry.profile === normalizeProfileKey(s.profile)
 
-      if (entry && Date.now() - entry.at < UNREAD_WRITE_GUARD_MS) {
+      if (entryMatchesRow && Date.now() - entry.at < UNREAD_WRITE_GUARD_MS) {
         if (entry.value) {
           persistedUnread.push(s.id)
         }

--- a/apps/desktop/src/store/session-unread-remote.test.ts
+++ b/apps/desktop/src/store/session-unread-remote.test.ts
@@ -14,7 +14,8 @@ vi.mock('@/hermes', () => ({
 
 import { $sessions } from '@/store/session'
 
-import { $unreadWriteGuard, clearUnreadOnOpen, markSessionUnread, watchUnreadWriteGuard } from './session-unread-remote'
+import { $activeGatewayProfile } from './profile'
+import { $unreadWriteGuard, clearUnreadOnOpen, markSessionUnread, rowFor, watchUnreadWriteGuard } from './session-unread-remote'
 
 const row = (id: string, extra: Partial<SessionInfo> = {}): SessionInfo =>
   ({ id, message_count: 1, source: 'cli', started_at: 0, title: id, ...extra }) as SessionInfo
@@ -22,12 +23,14 @@ const row = (id: string, extra: Partial<SessionInfo> = {}): SessionInfo =>
 beforeEach(() => {
   $sessions.set([])
   $unreadWriteGuard.set(new Map())
+  $activeGatewayProfile.set('default')
   patch.mockClear()
 })
 
 afterEach(() => {
   $sessions.set([])
   $unreadWriteGuard.set(new Map())
+  $activeGatewayProfile.set('default')
 })
 
 describe('markSessionUnread', () => {
@@ -56,6 +59,86 @@ describe('markSessionUnread', () => {
     // the guard is released (nothing to fence a page about).
     expect($sessions.get().find(s => s.id === 'a')?.unread).toBe(false)
     expect($unreadWriteGuard.get().has('a')).toBe(false)
+  })
+
+  it('PATCHes the active-gateway profile row, not a same-id row from another profile', async () => {
+    // Session ids are caller-supplied and each profile's backend is its own
+    // namespace, so two profiles can hold the same id — a real, documented
+    // scenario (session-unread.ts's resolveLoadedRow), and ALL_PROFILES mode
+    // routinely mixes such lists together.
+    $sessions.set([
+      row('a', { profile: 'personal', unread: false }),
+      row('a', { profile: 'work', unread: false })
+    ])
+    $activeGatewayProfile.set('work')
+
+    await markSessionUnread('a', true)
+
+    expect(patch).toHaveBeenCalledWith('a', true, 'work')
+    expect(patch).toHaveBeenCalledTimes(1)
+  })
+
+  it('only optimistically paints the targeted profile row, leaving the other profile\'s same-id row untouched', async () => {
+    $sessions.set([
+      row('a', { profile: 'personal', unread: false }),
+      row('a', { profile: 'work', unread: false })
+    ])
+    $activeGatewayProfile.set('work')
+
+    await markSessionUnread('a', true)
+
+    const rows = $sessions.get()
+    expect(rows.find(s => s.id === 'a' && s.profile === 'work')?.unread).toBe(true)
+    expect(rows.find(s => s.id === 'a' && s.profile === 'personal')?.unread).toBe(false)
+  })
+
+  it('only rolls back the targeted profile row on a failed PATCH', async () => {
+    // 'personal' starts unread so the mid-flight check below can tell a
+    // scoped optimistic paint apart from an unscoped one that also flips
+    // 'personal' — checking only the POST-rollback state can't: an unscoped
+    // paint-then-rollback of BOTH rows would coincidentally undo itself and
+    // land on the same final values as a correctly-scoped write.
+    $sessions.set([
+      row('a', { profile: 'personal', unread: true }),
+      row('a', { profile: 'work', unread: false })
+    ])
+    $activeGatewayProfile.set('work')
+    let rejectPatch: (err: Error) => void = () => {}
+    patch.mockImplementationOnce(() => new Promise((_resolve, reject) => { rejectPatch = reject }))
+
+    const pending = markSessionUnread('a', true)
+
+    // The optimistic paint runs synchronously before the first await point.
+    let rows = $sessions.get()
+    expect(rows.find(s => s.id === 'a' && s.profile === 'work')?.unread).toBe(true)
+    expect(rows.find(s => s.id === 'a' && s.profile === 'personal')?.unread).toBe(true)
+
+    rejectPatch(new Error('offline'))
+    await expect(pending).rejects.toThrow('offline')
+
+    // The backend kept 'work' at its old value; 'personal' must be
+    // completely untouched by this call's rollback too.
+    rows = $sessions.get()
+    expect(rows.find(s => s.id === 'a' && s.profile === 'work')?.unread).toBe(false)
+    expect(rows.find(s => s.id === 'a' && s.profile === 'personal')?.unread).toBe(true)
+  })
+})
+
+describe('rowFor', () => {
+  it('resolves a unique id unambiguously', () => {
+    $sessions.set([row('a', { profile: 'work' })])
+
+    expect(rowFor('a')?.profile).toBe('work')
+  })
+
+  it('breaks a same-id tie across profiles toward the active gateway profile', () => {
+    $sessions.set([
+      row('a', { profile: 'personal' }),
+      row('a', { profile: 'work' })
+    ])
+    $activeGatewayProfile.set('work')
+
+    expect(rowFor('a')?.profile).toBe('work')
   })
 })
 
@@ -88,8 +171,8 @@ describe('clearUnreadOnOpen', () => {
 describe('watchUnreadWriteGuard', () => {
   it('drops a guard entry once a list page confirms the value we wrote', () => {
     watchUnreadWriteGuard()
-    const guard = new Map<string, { at: number; value: boolean }>()
-    guard.set('a', { at: Date.now(), value: true })
+    const guard = new Map<string, { at: number; profile: string; value: boolean }>()
+    guard.set('a', { at: Date.now(), profile: 'default', value: true })
     $unreadWriteGuard.set(guard)
 
     // The server caught up and echoes our value back.
@@ -100,13 +183,26 @@ describe('watchUnreadWriteGuard', () => {
 
   it('keeps the guard while a page contradicts a write still in flight', () => {
     watchUnreadWriteGuard()
-    const guard = new Map<string, { at: number; value: boolean }>()
-    guard.set('a', { at: Date.now(), value: true })
+    const guard = new Map<string, { at: number; profile: string; value: boolean }>()
+    guard.set('a', { at: Date.now(), profile: 'default', value: true })
     $unreadWriteGuard.set(guard)
 
     // A list request issued before the PATCH still says read. Honouring it
     // would silently undo the mark the user just made.
     $sessions.set([row('a', { unread: false })])
+
+    expect($unreadWriteGuard.get().has('a')).toBe(true)
+  })
+
+  it('ignores a same-id row from a DIFFERENT profile when confirming a guard', () => {
+    watchUnreadWriteGuard()
+    const guard = new Map<string, { at: number; profile: string; value: boolean }>()
+    guard.set('a', { at: Date.now(), profile: 'work', value: true })
+    $unreadWriteGuard.set(guard)
+
+    // Same id, but a DIFFERENT profile's row confirming the SAME value --
+    // must not be mistaken for the guarded write, which targeted 'work'.
+    $sessions.set([row('a', { profile: 'personal', unread: true })])
 
     expect($unreadWriteGuard.get().has('a')).toBe(true)
   })

--- a/apps/desktop/src/store/session-unread-remote.ts
+++ b/apps/desktop/src/store/session-unread-remote.ts
@@ -22,16 +22,33 @@
 import { atom } from 'nanostores'
 
 import { setSessionUnreadRemote } from '@/hermes'
+import { $activeGatewayProfile, normalizeProfileKey } from '@/store/profile'
 
 import { $sessions, setSessions } from './session'
 
 export const UNREAD_WRITE_GUARD_MS = 10_000
 
-/** id -> the value we wrote and when. Guarded rows outrank list pages. */
-export const $unreadWriteGuard = atom<Map<string, { at: number; value: boolean }>>(new Map())
+/** id -> the value we wrote, when, and which profile's row it targeted.
+ *  Guarded rows outrank list pages. Profile is carried so a same-id row in
+ *  ANOTHER profile can never be mistaken for the one this guard is fencing. */
+export const $unreadWriteGuard = atom<Map<string, { at: number; profile: string; value: boolean }>>(new Map())
 
-function rowFor(storedId: string) {
-  return $sessions.get().find(row => row.id === storedId)
+/** The row a bare stored id refers to. Ids are caller-supplied and each
+ *  profile's backend is its own namespace, so two profiles can hold the same
+ *  id (session-unread.ts's resolveLoadedRow documents this same fact for the
+ *  watermark/marker half of the unread feature) — a tie breaks toward the
+ *  live gateway, since both opening a session and toggling its flag from the
+ *  row menu only ever happen against what's currently on screen. */
+export function rowFor(storedId: string) {
+  const matches = $sessions.get().filter(row => row.id === storedId)
+
+  if (matches.length < 2) {
+    return matches[0]
+  }
+
+  const gateway = normalizeProfileKey($activeGatewayProfile.get())
+
+  return matches.find(row => normalizeProfileKey(row.profile) === gateway) ?? matches[0]
 }
 
 /** Toggle the persisted unread flag: optimistic row update, then PATCH, then
@@ -44,11 +61,17 @@ export async function markSessionUnread(storedId: string, unread: boolean): Prom
     return
   }
 
+  // Match on (id, profile), not just id: a same-id row in another profile
+  // must never be optimistically painted (or rolled back) by a toggle that
+  // targeted THIS row.
+  const profile = normalizeProfileKey(row.profile)
+  const matchesRow = (r: (typeof row)) => r.id === storedId && normalizeProfileKey(r.profile) === profile
+
   const guard = new Map($unreadWriteGuard.get())
-  guard.set(storedId, { at: Date.now(), value: unread })
+  guard.set(storedId, { at: Date.now(), profile, value: unread })
   $unreadWriteGuard.set(guard)
 
-  setSessions(rows => rows.map(r => (r.id === storedId ? { ...r, unread } : r)))
+  setSessions(rows => rows.map(r => (matchesRow(r) ? { ...r, unread } : r)))
 
   try {
     await setSessionUnreadRemote(storedId, unread, row.profile)
@@ -57,7 +80,7 @@ export async function markSessionUnread(storedId: string, unread: boolean): Prom
     const guard2 = new Map($unreadWriteGuard.get())
     guard2.delete(storedId)
     $unreadWriteGuard.set(guard2)
-    setSessions(rows => rows.map(r => (r.id === storedId ? { ...r, unread: !unread } : r)))
+    setSessions(rows => rows.map(r => (matchesRow(r) ? { ...r, unread: !unread } : r)))
     throw err
   }
 }
@@ -86,7 +109,7 @@ export function watchUnreadWriteGuard(): void {
     let changed = false
 
     for (const [id, entry] of guard) {
-      const row = rows.find(r => r.id === id)
+      const row = rows.find(r => r.id === id && normalizeProfileKey(r.profile) === entry.profile)
 
       if (row && row.unread === entry.value) {
         guard.delete(id)


### PR DESCRIPTION
## Summary

\`session-unread-remote.ts\` owns the WRITE side of the persisted unread flag (\`markSessionUnread\`/\`clearUnreadOnOpen\`/the write guard). Its sibling \`session-unread.ts\` — the watermark/marker half of the same "unread dot" feature — was explicitly hardened this window (\`26b4315e09\`, *"profile-scope persisted unread and stop cold-boot storage clobber"*): *"Session ids are caller-supplied and each profile backend is its own namespace... two profiles can hold the same id"*. \`session-unread-remote.ts\` never got the same treatment — every lookup in it matched on bare session id only, across three sites.

## The three sites

1. **\`rowFor()\` / \`markSessionUnread()\`** — \`$sessions.get().find(r => r.id === storedId)\` picks whichever profile's same-id row sorts first. The optimistic \`setSessions()\` write (and its rollback on PATCH failure) then matched **every** row sharing that id, so toggling one profile's session could paint — or PATCH the backend for — a same-id row in a completely different profile. \`$sessions\` mixes profiles in ALL\\_PROFILES sidebar mode, and per \`session-unread.ts\`'s own comment cron/messaging sessions are "ALWAYS cross-profile".
2. **\`sidebar/index.tsx\`'s \`toggleUnread()\`** — the same bare \`$sessions.get().find()\` pattern, used to compute the flip *direction* before ever reaching \`markSessionUnread\`.
3. **\`session-dot-state.ts\`'s \`$sessionDotStateById\`** — \`unreadWriteGuard.get(s.id)\` applied a guard entry written for one profile's row to every session sharing that id, for up to \`UNREAD_WRITE_GUARD_MS\` (10s).

## Fix

- Mirror \`session-unread.ts\`'s tie-break: same-id matches resolve toward the active gateway profile.
- Scope the optimistic paint/rollback in \`markSessionUnread\` to \`(id, profile)\`, not bare id.
- Carry the target \`profile\` on each write-guard entry (\`$unreadWriteGuard\`'s value type gained a \`profile\` field) so a same-id row from another profile can never be mistaken for the one a guard is fencing — fixed both the write side (\`markSessionUnread\`) and the two read sides (\`watchUnreadWriteGuard\`, \`session-dot-state.ts\`).
- \`rowFor()\` is now exported so \`sidebar/index.tsx\`'s \`toggleUnread()\` reuses the same resolution instead of duplicating its own bare lookup.

## Testing

- \`session-unread-remote.test.ts\`: 3 new tests on \`markSessionUnread\` (PATCHes the active-gateway-profile row not a same-id sibling; optimistic paint only touches the targeted row; rollback only touches the targeted row — checked **mid-flight**, since a same-id sibling that starts and ends at the same value would coincidentally pass a post-rollback-only check even on the buggy code), 2 new tests on \`rowFor\`, 1 new test on \`watchUnreadWriteGuard\`.
- \`session-dot-state.test.ts\`: 1 new test — a guard entry for one profile must not fence a same-id row in another.
- **Mutation-verified**: stashing the \`session-unread-remote.ts\`/\`sidebar/index.tsx\` fix fails 6/6 new tests in that file with the exact pre-fix symptom (wrong profile PATCHed, wrong row painted); stashing the \`session-dot-state.ts\` fix independently fails its 1 new test.
- \`npx tsc -p tsconfig.json --noEmit\`: clean.
- Full \`session-unread-remote.test.ts\` + \`session-dot-state.test.ts\` + \`session-unread.test.ts\` + \`session.test.ts\`: 108 passed. Full \`src/app/chat/sidebar/\` suite: 160 passed.
- \`eslint\` could not run in this environment (\`Cannot find package 'globals'\` — \`eslint.config.mjs\` needs a root-level install this workspace-scoped setup doesn't have); \`tsc\` passed clean and the diff follows the file's existing patterns closely.

## Competing PRs — textual proximity, not semantic overlap

\#84821 (\`feat(desktop): paint agent-created sessions as live in sidebar\`) also touches \`session-dot-state.ts\`, but only the import block and the \`claim()\` priority sequence (adds a new \`claim(foreign, 'working')\` tier) — checked its diff directly, it never touches the \`unreadWriteGuard\`/persisted-unread loop this PR changes. No other open PR references \`session-unread-remote\`, \`unreadWriteGuard\`, or \`markSessionUnread\`.