### PR TITLE
fix: parse JSON-array strings in disabled skills/toolsets config (#86661)

### DIFF
--- a/agent/skill_utils.py
+++ b/agent/skill_utils.py
@@ -475,7 +475,17 @@ def _normalize_string_set(values) -> Set[str]:
     if values is None:
         return set()
     if isinstance(values, str):
-        values = [values]
+        # A JSON-array string like '["a","b"]' should be parsed,
+        # not wrapped as a single opaque name (#86661).
+        import json
+        try:
+            parsed = json.loads(values)
+            if isinstance(parsed, list):
+                values = parsed
+            else:
+                values = [values]
+        except (json.JSONDecodeError, ValueError):
+            values = [values]
     return {str(v).strip() for v in values if str(v).strip()}
 
 

--- a/hermes_cli/skills_config.py
+++ b/hermes_cli/skills_config.py
@@ -34,7 +34,17 @@ def _normalize_skill_names(values) -> Set[str]:
     if values is None:
         return set()
     if isinstance(values, str):
-        values = [values]
+        # A JSON-array string like '["a","b"]' should be parsed,
+        # not wrapped as a single opaque name (#86661).
+        import json
+        try:
+            parsed = json.loads(values)
+            if isinstance(parsed, list):
+                values = parsed
+            else:
+                values = [values]
+        except (json.JSONDecodeError, ValueError):
+            values = [values]
     try:
         return {str(v).strip() for v in values if str(v).strip()}
     except TypeError:

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -2554,6 +2554,15 @@ def _get_platform_tools(
     agent_cfg = config.get("agent") or {}
     disabled_toolsets = agent_cfg.get("disabled_toolsets") or []
     if disabled_toolsets:
+        # A JSON-array string like '["a"]' should be parsed (#86661)
+        if isinstance(disabled_toolsets, str):
+            import json
+            try:
+                parsed = json.loads(disabled_toolsets)
+                if isinstance(parsed, list):
+                    disabled_toolsets = parsed
+            except (json.JSONDecodeError, ValueError):
+                pass
         disabled_set = {str(ts) for ts in disabled_toolsets}
         enabled_toolsets -= disabled_set
 


### PR DESCRIPTION
## Fix: Parse JSON-array strings in disabled skills/toolsets config

Fixes #86661

### Problem

When `skills.disabled` or `agent.disabled_toolsets` is set to a JSON-array string in config.yaml (e.g. `disabled: '["skill-a","skill-b"]'` due to YAML quoting), the normalize functions wrap the entire string as a single opaque name. No skill/toolset is actually disabled, and there is zero diagnostic output.

### Root Cause

Three normalize paths treat any `str` as a scalar and wrap it in `[str]`:

1. `agent/skill_utils.py::_normalize_string_set` — used by `skills.disabled` and `skills.platform_disabled`
2. `hermes_cli/skills_config.py::_normalize_skill_names` — mirror of the above for CLI-side config reads
3. `hermes_cli/tools_config.py` — `agent.disabled_toolsets` uses `{str(ts) for ts in disabled_toolsets}` directly

### Fix

Detect JSON-array strings (`'["a","b"]'`) and parse them to lists before normalizing. Plain strings like `"my-skill"` still work as single-item entries (backward compatible with #13026). Invalid JSON falls through to the existing scalar wrapping behavior.

### Changes

- `agent/skill_utils.py` — `_normalize_string_set`: try `json.loads` for str inputs, use parsed list if it's a list
- `hermes_cli/skills_config.py` — `_normalize_skill_names`: same pattern
- `hermes_cli/tools_config.py` — `disabled_toolsets` block: parse JSON str before set comprehension
