### PR TITLE
feat(kanban): add secure body file input to create

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -329,7 +329,12 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
     # --- create ---
     p_create = sub.add_parser("create", help="Create a new task")
     p_create.add_argument("title", help="Task title")
-    p_create.add_argument("--body", default=None, help="Optional opening post")
+    _body_group = p_create.add_mutually_exclusive_group()
+    _body_group.add_argument("--body", default=None, help="Optional opening post")
+    _body_group.add_argument(
+        "--body-file", default=None,
+        help="Read body from PATH (or '-' for stdin). Max 1 MiB, UTF-8.",
+    )
     p_create.add_argument("--assignee", default=None, help="Profile name to assign")
     p_create.add_argument("--parent", action="append", default=[],
                           help="Parent task id (repeatable)")
@@ -1539,6 +1544,51 @@ def _cmd_assignees(args: argparse.Namespace) -> int:
     return 0
 
 
+_BODY_FILE_MAX_BYTES = 1_048_576  # 1 MiB
+_BODY_FILE_PATH_DISPLAY_MAX = 200
+
+
+def _body_file_source_label(path: str) -> str:
+    escaped = ascii(path)
+    if len(escaped) <= _BODY_FILE_PATH_DISPLAY_MAX:
+        return escaped
+    return escaped[:_BODY_FILE_PATH_DISPLAY_MAX - 3] + "..."
+
+
+def _resolve_body_file(path: str) -> str | None:
+    """Read and validate a ``--body-file`` argument.
+
+    Returns the decoded UTF-8 string on success, or *None* on failure
+    (after printing a bounded error to stderr).
+    """
+    source = _body_file_source_label(path)
+    try:
+        if path == "-":
+            raw = sys.stdin.buffer.read(_BODY_FILE_MAX_BYTES + 1)
+        else:
+            with open(path, "rb") as fh:
+                raw = fh.read(_BODY_FILE_MAX_BYTES + 1)
+    except FileNotFoundError:
+        print(f"kanban: --body-file: not found: {source}", file=sys.stderr)
+        return None
+    except (OSError, ValueError, AttributeError):
+        print(f"kanban: --body-file: cannot read: {source}", file=sys.stderr)
+        return None
+
+    if len(raw) > _BODY_FILE_MAX_BYTES:
+        print(
+            f"kanban: --body-file: exceeds 1 MiB ({_BODY_FILE_MAX_BYTES} bytes)",
+            file=sys.stderr,
+        )
+        return None
+
+    try:
+        return raw.decode("utf-8")
+    except UnicodeDecodeError:
+        print("kanban: --body-file: not valid utf-8", file=sys.stderr)
+        return None
+
+
 def _cmd_create(args: argparse.Namespace) -> int:
     try:
         ws_kind, ws_path = _parse_workspace_flag(args.workspace)
@@ -1562,11 +1612,19 @@ def _cmd_create(args: argparse.Namespace) -> int:
             file=sys.stderr,
         )
         return 2
+    # Resolve --body-file after cheap flag validation but before DB access.
+    body_file = getattr(args, "body_file", None)
+    if body_file is not None:
+        body = _resolve_body_file(body_file)
+        if body is None:
+            return 2
+    else:
+        body = args.body
     with kb.connect_closing() as conn:
         task_id = kb.create_task(
             conn,
             title=args.title,
-            body=args.body,
+            body=body,
             assignee=args.assignee,
             created_by=args.created_by or _profile_author(),
             workspace_kind=ws_kind,

--- a/tests/hermes_cli/test_kanban_body_file.py
+++ b/tests/hermes_cli/test_kanban_body_file.py
@@ -1,0 +1,323 @@
+"""Tests for ``hermes kanban create --body-file`` secure body input."""
+
+from __future__ import annotations
+
+import argparse
+import io
+from pathlib import Path
+import pytest
+
+from hermes_cli import kanban as kc
+from hermes_cli import kanban_db as kb
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def kanban_home(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb.init_db()
+    return home
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="hermes", add_help=False)
+    sub = parser.add_subparsers(dest="command")
+    kc.build_parser(sub)
+    return parser
+
+
+# ---------------------------------------------------------------------------
+# Happy-path: --body-file with a real file
+# ---------------------------------------------------------------------------
+
+class TestBodyFile:
+    def test_body_from_file(self, kanban_home, tmp_path):
+        """--body-file PATH reads and persists the file content as task body."""
+        body_file = tmp_path / "body.md"
+        body_file.write_text("detailed task description", encoding="utf-8")
+        parser = _build_parser()
+        args = parser.parse_args(
+            ["kanban", "create", "file-task", "--body-file", str(body_file)]
+        )
+        rc = kc.kanban_command(args)
+        assert rc == 0
+        with kb.connect_closing() as conn:
+            tasks = kb.list_tasks(conn)
+            assert len(tasks) == 1
+            assert tasks[0].body == "detailed task description"
+
+    def test_body_from_stdin(self, kanban_home, monkeypatch):
+        """--body-file - reads body from stdin."""
+        parser = _build_parser()
+        monkeypatch.setattr(
+            "sys.stdin",
+            io.TextIOWrapper(io.BytesIO(b"stdin body content")),
+        )
+        args = parser.parse_args(
+            ["kanban", "create", "stdin-task", "--body-file", "-"]
+        )
+        rc = kc.kanban_command(args)
+        assert rc == 0
+        with kb.connect_closing() as conn:
+            tasks = kb.list_tasks(conn)
+            assert len(tasks) == 1
+            assert tasks[0].body == "stdin body content"
+
+    def test_empty_body_file(self, kanban_home, tmp_path):
+        """An empty file results in an empty-string body (preserving semantics)."""
+        body_file = tmp_path / "empty.md"
+        body_file.write_text("", encoding="utf-8")
+        parser = _build_parser()
+        args = parser.parse_args(
+            ["kanban", "create", "empty-task", "--body-file", str(body_file)]
+        )
+        rc = kc.kanban_command(args)
+        assert rc == 0
+        with kb.connect_closing() as conn:
+            tasks = kb.list_tasks(conn)
+            assert len(tasks) == 1
+            assert tasks[0].body == ""
+
+    def test_exactly_1mib(self, kanban_home, tmp_path):
+        """Exactly 1 MiB body is accepted."""
+        body_file = tmp_path / "big.md"
+        content = "A" * 1_048_576
+        body_file.write_text(content, encoding="utf-8")
+        parser = _build_parser()
+        args = parser.parse_args(
+            ["kanban", "create", "big-task", "--body-file", str(body_file)]
+        )
+        rc = kc.kanban_command(args)
+        assert rc == 0
+        with kb.connect_closing() as conn:
+            tasks = kb.list_tasks(conn)
+            assert len(tasks) == 1
+            assert len(tasks[0].body) == 1_048_576
+
+
+# ---------------------------------------------------------------------------
+# Mutual exclusion
+# ---------------------------------------------------------------------------
+
+class TestMutualExclusion:
+    def test_body_and_body_file_are_mutually_exclusive(self, kanban_home, tmp_path):
+        """--body and --body-file cannot be used together (argparse-level)."""
+        body_file = tmp_path / "body.md"
+        body_file.write_text("content", encoding="utf-8")
+        parser = _build_parser()
+        with pytest.raises(SystemExit) as exc_info:
+            parser.parse_args(
+                ["kanban", "create", "task", "--body", "inline",
+                 "--body-file", str(body_file)]
+            )
+        assert exc_info.value.code == 2
+
+
+# ---------------------------------------------------------------------------
+# Error handling: fail closed, exit 2, no task creation
+# ---------------------------------------------------------------------------
+
+class TestErrorHandling:
+    def test_file_not_found(self, kanban_home, tmp_path, capsys):
+        """Non-existent file -> exit 2, no task created."""
+        parser = _build_parser()
+        args = parser.parse_args(
+            ["kanban", "create", "task", "--body-file", str(tmp_path / "nope.md")]
+        )
+        rc = kc.kanban_command(args)
+        assert rc == 2
+        with kb.connect_closing() as conn:
+            assert len(kb.list_tasks(conn)) == 0
+        captured = capsys.readouterr()
+        assert "nope.md" in captured.err
+
+    def test_error_message_bounds_long_path(self, kanban_home, capsys):
+        """A hostile path cannot make the error output unbounded."""
+        parser = _build_parser()
+        args = parser.parse_args(
+            ["kanban", "create", "task", "--body-file", "x" * 10_000]
+        )
+        assert kc.kanban_command(args) == 2
+        with kb.connect_closing() as conn:
+            assert len(kb.list_tasks(conn)) == 0
+        assert len(capsys.readouterr().err) <= 300
+
+    def test_error_message_escapes_path_control_characters(
+        self, kanban_home, capsys
+    ):
+        """A hostile path cannot inject terminal controls or extra lines."""
+        parser = _build_parser()
+        args = parser.parse_args(
+            ["kanban", "create", "task", "--body-file", "bad\n\x1b[31m.md"]
+        )
+        assert kc.kanban_command(args) == 2
+        error = capsys.readouterr().err
+        assert error.count("\n") == 1
+        assert "\x1b" not in error
+
+    def test_oversized_input(self, kanban_home, tmp_path, capsys):
+        """Input exceeding 1 MiB -> exit 2, no task created."""
+        body_file = tmp_path / "huge.md"
+        body_file.write_bytes(b"X" * (1_048_576 + 1))
+        parser = _build_parser()
+        args = parser.parse_args(
+            ["kanban", "create", "task", "--body-file", str(body_file)]
+        )
+        rc = kc.kanban_command(args)
+        assert rc == 2
+        with kb.connect_closing() as conn:
+            assert len(kb.list_tasks(conn)) == 0
+        captured = capsys.readouterr()
+        assert "1 MiB" in captured.err or "1048576" in captured.err
+
+    def test_invalid_utf8(self, kanban_home, tmp_path, capsys):
+        """Non-UTF-8 content -> exit 2, no task created."""
+        body_file = tmp_path / "bad.bin"
+        body_file.write_bytes(b"\x80\x81\x82\xff")
+        parser = _build_parser()
+        args = parser.parse_args(
+            ["kanban", "create", "task", "--body-file", str(body_file)]
+        )
+        rc = kc.kanban_command(args)
+        assert rc == 2
+        with kb.connect_closing() as conn:
+            assert len(kb.list_tasks(conn)) == 0
+        captured = capsys.readouterr()
+        assert "utf" in captured.err.lower() or "decode" in captured.err.lower()
+
+    def test_oversized_stdin(self, kanban_home, monkeypatch, capsys):
+        """Oversized stdin is bounded and rejected before task creation."""
+        monkeypatch.setattr(
+            "sys.stdin",
+            io.TextIOWrapper(io.BytesIO(b"X" * (1_048_576 + 1))),
+        )
+        parser = _build_parser()
+        args = parser.parse_args(
+            ["kanban", "create", "task", "--body-file", "-"]
+        )
+        assert kc.kanban_command(args) == 2
+        with kb.connect_closing() as conn:
+            assert len(kb.list_tasks(conn)) == 0
+        assert "1 MiB" in capsys.readouterr().err
+
+    def test_invalid_utf8_stdin(self, kanban_home, monkeypatch, capsys):
+        """Invalid UTF-8 on stdin is rejected before task creation."""
+        monkeypatch.setattr(
+            "sys.stdin",
+            io.TextIOWrapper(io.BytesIO(b"SENTINEL_SECRET_DATA\x80\xff")),
+        )
+        parser = _build_parser()
+        args = parser.parse_args(
+            ["kanban", "create", "task", "--body-file", "-"]
+        )
+        assert kc.kanban_command(args) == 2
+        with kb.connect_closing() as conn:
+            assert len(kb.list_tasks(conn)) == 0
+        captured = capsys.readouterr()
+        assert "utf" in captured.err.lower()
+        assert "SENTINEL_SECRET_DATA" not in captured.err
+
+    def test_text_only_stdin_fails_closed(self, kanban_home, monkeypatch, capsys):
+        """An embedded stdin without a binary buffer does not traceback."""
+        monkeypatch.setattr("sys.stdin", io.StringIO("SENTINEL_SECRET_DATA"))
+        parser = _build_parser()
+        args = parser.parse_args(
+            ["kanban", "create", "task", "--body-file", "-"]
+        )
+        assert kc.kanban_command(args) == 2
+        with kb.connect_closing() as conn:
+            assert len(kb.list_tasks(conn)) == 0
+        captured = capsys.readouterr()
+        assert "cannot read" in captured.err
+        assert "SENTINEL_SECRET_DATA" not in captured.err
+
+    def test_invalid_workspace_does_not_consume_stdin(
+        self, kanban_home, monkeypatch, capsys
+    ):
+        """Cheap flag validation happens before potentially blocking stdin reads."""
+        class StdinMustNotBeRead:
+            @property
+            def buffer(self):
+                raise AssertionError("stdin was consumed")
+
+        monkeypatch.setattr("sys.stdin", StdinMustNotBeRead())
+        parser = _build_parser()
+        args = parser.parse_args(
+            [
+                "kanban", "create", "task", "--body-file", "-",
+                "--workspace", "invalid",
+            ]
+        )
+        assert kc.kanban_command(args) == 2
+        assert "unknown" in capsys.readouterr().err
+
+    def test_permission_error(self, kanban_home, tmp_path, capsys, monkeypatch):
+        """Unreadable file -> exit 2, no task created."""
+        body_file = tmp_path / "secret.md"
+        body_file.write_text("secret", encoding="utf-8")
+        def deny_open(*_args, **_kwargs):
+            raise PermissionError("SENTINEL_SECRET_DATA")
+
+        monkeypatch.setattr("builtins.open", deny_open)
+        parser = _build_parser()
+        args = parser.parse_args(
+            ["kanban", "create", "task", "--body-file", str(body_file)]
+        )
+        rc = kc.kanban_command(args)
+        assert rc == 2
+        with kb.connect_closing() as conn:
+            assert len(kb.list_tasks(conn)) == 0
+        captured = capsys.readouterr()
+        assert "cannot read" in captured.err
+        assert "SENTINEL_SECRET_DATA" not in captured.err
+
+    def test_no_body_content_in_stderr(self, kanban_home, tmp_path, capsys):
+        """Error messages must not leak body file content."""
+        body_file = tmp_path / "bad.bin"
+        # Use recognizable sentinel bytes that would stand out if leaked
+        body_file.write_bytes(b"SENTINEL_SECRET_DATA\x80\xff")
+        parser = _build_parser()
+        args = parser.parse_args(
+            ["kanban", "create", "task", "--body-file", str(body_file)]
+        )
+        rc = kc.kanban_command(args)
+        assert rc == 2
+        captured = capsys.readouterr()
+        assert "SENTINEL_SECRET_DATA" not in captured.err
+        assert "SENTINEL_SECRET_DATA" not in captured.out
+
+
+# ---------------------------------------------------------------------------
+# Backward compatibility
+# ---------------------------------------------------------------------------
+
+class TestBackwardCompat:
+    def test_body_inline_still_works(self, kanban_home):
+        """Existing --body flag continues to work."""
+        parser = _build_parser()
+        args = parser.parse_args(
+            ["kanban", "create", "inline-task", "--body", "inline body"]
+        )
+        rc = kc.kanban_command(args)
+        assert rc == 0
+        with kb.connect_closing() as conn:
+            tasks = kb.list_tasks(conn)
+            assert len(tasks) == 1
+            assert tasks[0].body == "inline body"
+
+    def test_no_body_flag_gives_none(self, kanban_home):
+        """No --body or --body-file -> body is None."""
+        parser = _build_parser()
+        args = parser.parse_args(["kanban", "create", "bare-task"])
+        rc = kc.kanban_command(args)
+        assert rc == 0
+        with kb.connect_closing() as conn:
+            tasks = kb.list_tasks(conn)
+            assert len(tasks) == 1
+            assert tasks[0].body is None


### PR DESCRIPTION
## What does this PR do?

Adds secure, exact body transport to `hermes kanban create`:

- `--body-file PATH` reads a UTF-8 task body from a file.
- `--body-file -` reads the body from standard input, keeping private or large bodies out of process argv.
- `--body` and `--body-file` are mutually exclusive.
- Reads are bounded to 1 MiB and fail closed before database access on missing/unreadable input, oversized input, or invalid UTF-8.
- Diagnostics are bounded, escaped, and never include body contents.

This unblocks public-CLI-only automation that must transport exact task requirements without exposing them through process listings or command wrappers.

## Related Issue

Related downstream integration: quickwhips/hermes-github-kanban-sync#36

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [x] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/kanban.py`: add mutually exclusive body-source flags plus bounded strict-UTF-8 file/stdin resolution before DB access.
- `tests/hermes_cli/test_kanban_body_file.py`: cover file/stdin success, exact-size and oversized input, invalid UTF-8, unreadable/missing files, bounded escaped errors, failure atomicity, validation ordering, and backward compatibility.

## How to Test

1. `uv run --extra dev pytest -q tests/hermes_cli/test_kanban_body_file.py tests/hermes_cli/test_kanban_cli.py tests/hermes_cli/test_kanban_core_functionality.py -o 'addopts='`
2. `uv run --extra dev ruff check hermes_cli/kanban.py tests/hermes_cli/test_kanban_body_file.py`
3. `printf 'private body\n' | uv run python -m hermes_cli.main kanban create stdin-task --body-file - --triage --json`

Focused result on Ubuntu/Linux: **46 passed**. The public CLI file and stdin smoke tests both passed from isolated `HERMES_HOME` directories.

The repository-wide local test runner is not clean on this checkout. A controlled `tests/hermes_cli/test_kanban*.py` comparison produced the same 15 unrelated failures on this candidate and an untouched archive of base `a90d5369f76c87c98547d2e283aa26d5cfabf322`; the changed and directly adjacent suites above are green.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04 / Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A; argparse help and implementation docstrings define the new interface
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — stdlib binary reads, strict UTF-8 decoding, no POSIX-specific APIs
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A; this is a CLI-only option

## Screenshots / Logs

```text
46 passed in 3.36s
All checks passed!
public_cli_body_file_and_stdin_ok
exact_head_public_cli_stdin_ok
```

Independent exact-commit review of `06a219e714e449daa2db559de7b7da44fb844a2b` reported no P0/P1/P2 findings.
