### PR TITLE
refactor(tui_gateway): remove duplicate content display helper

### DIFF
--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -7484,36 +7484,6 @@ def _coerce_seed_history(value: Any) -> list[dict]:
     return history
 
 
-def _content_display_text(content: Any) -> str:
-    if content is None:
-        return ""
-    if isinstance(content, str):
-        return content
-    if isinstance(content, (int, float)):
-        return str(content)
-    if isinstance(content, list):
-        parts = []
-        for part in content:
-            text = _content_display_text(part).strip()
-            if text:
-                parts.append(text)
-        return "\n".join(parts)
-    if isinstance(content, dict):
-        kind = content.get("type")
-        if kind in {"text", "input_text", "output_text"}:
-            return str(content.get("text") or content.get("content") or "")
-        if kind in {"image_url", "input_image", "image"}:
-            return "[image]"
-        if kind in {"input_audio", "audio"}:
-            return "[audio]"
-        if kind:
-            return f"[{kind}]"
-        if "text" in content:
-            return str(content.get("text") or "")
-        return "[structured content]"
-    return str(content)
-
-
 def _inflight_text(value: Any) -> str:
     return _content_display_text(value).strip()
 


### PR DESCRIPTION
## What does this PR do?

Removes the redundant second module-level definition of `_content_display_text` from `tui_gateway/server.py` and keeps the original definition before all of its callers.

The two implementations were identical. At runtime, Python replaced the earlier module binding with the later definition, so consolidating them does not change behavior. Keeping both definitions would make future maintenance error-prone if only one copy were updated.

## Related Issue

No linked issue.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [x] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Removed the duplicate `_content_display_text` definition from `tui_gateway/server.py`.
- Preserved the original implementation and kept it before its earliest required use.
- Made no unrelated formatting, cleanup, or behavioral changes.

## How to Test

1. Run `rg -n '^def _content_display_text\b|_content_display_text\(' tui_gateway/server.py` and confirm exactly one definition remains before both non-recursive callers.
2. Run `scripts/run_tests.sh tests/test_tui_gateway_server.py` from the project environment.
3. Run the syntax, lint, compatibility, and full-suite checks listed below.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
  - The repository-approved full runner was executed, but it did not pass: 32,961 passed, 7 failed, and 306 skipped. The seven failures are outside this change's code path and reproduced when their six files were rerun separately; details are below.
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
  - No behavior was changed. A source-counting test would be a change-detector test rather than a behavior contract.
- [x] I've tested on my platform: WSL2 Linux 5.15.167.4, x86_64, Python 3.11.16

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — `scripts/check-windows-footguns.py --diff origin/main` passed
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Validation

- `scripts/run_tests.sh tests/test_tui_gateway_server.py`: **573 passed**
- `python -m py_compile tui_gateway/server.py`: **passed**
- `ruff check .`: **passed** (with the existing invalid `# noqa` warning for `run_agent.py:108`)
- `scripts/check-windows-footguns.py --diff origin/main`: **passed**, 1 file scanned
- `git diff --check`: **passed**
- `scripts/run_tests.sh`: **32,961 passed, 7 failed, 306 skipped**; exit 1
- Focused rerun of the six failing files: **419 passed, 7 failed**; exit 1

The remaining full-suite failures were:

- `tests/honcho_plugin/test_pin_peer_name.py`: 1 cache-signature assertion
- `tests/hermes_cli/test_doctor.py`: 1 Vercel diagnostics assertion
- `tests/test_minimax_oauth.py`: 1 local HTTP connection reset
- `tests/tools/test_termux_api_detection.py`: 1 container/WSL audio-environment assertion
- `tests/test_mcp_serve.py`: 2 event-bridge polling assertions
- `tests/test_hermes_state.py`: 1 SQLite trace-count assertion

The full runner also reported two first-attempt flakes that passed its automatic retry: `tests/tools/test_transcription_tools.py` and `tests/test_tui_gateway_server.py`.

## History Note

The canonical helper was introduced in `ec9d0e26d4`. The identical second definition arrived in `51c68d4ab1` while restoring the helper during the desktop-app merge, after the original definition was already present on `main`.

## Screenshots / Logs

N/A — this is a behavior-preserving source cleanup with no UI change.
