### PR TITLE
fix(desktop): focus clarify panel so keyboard shortcuts work hands-free

### DIFF
--- a/apps/desktop/src/components/assistant-ui/clarify-tool.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/clarify-tool.test.tsx
@@ -176,6 +176,16 @@ describe('ClarifyTool live card stays mounted across settle', () => {
 })
 
 describe('ClarifyTool choice selection', () => {
+  it('moves focus onto the panel so keyboard shortcuts work without a mouse', async () => {
+    renderLiveClarify()
+
+    await waitFor(() => {
+      const panel = document.querySelector('[data-clarify-choices]')
+      expect(panel).not.toBeNull()
+      expect(document.activeElement).toBe(panel)
+    })
+  })
+
   it('selects independently, deselects and submits multi-select choices as a JSON array', async () => {
     const { request } = renderLiveClarify({ multiSelect: true })
     const staging = screen.getByRole('button', { name: /staging/ })

--- a/apps/desktop/src/components/assistant-ui/clarify-tool.tsx
+++ b/apps/desktop/src/components/assistant-ui/clarify-tool.tsx
@@ -536,6 +536,24 @@ function ClarifyToolSinglePending({
     setActiveIndex(index => Math.min(index, choices.length))
   }, [choices.length])
 
+  // Claim keyboard ownership when the card becomes interactive: move focus
+  // onto the panel container (tabIndex=-1) so the global handler below sees a
+  // neutral focus target instead of the composer's contenteditable/input —
+  // otherwise Arrow keys and letter shortcuts are swallowed by the composer
+  // and a pure-keyboard user can't drive the choices at all. Only when the
+  // card actually owns choices; a free-text-only clarify keeps composer focus.
+  const panelRef = useRef<HTMLFormElement | null>(null)
+  const claimedFocus = useRef(false)
+
+  useEffect(() => {
+    if (!ready || !hasChoices || submitting || claimedFocus.current) {
+      return
+    }
+
+    claimedFocus.current = true
+    panelRef.current?.focus()
+  }, [hasChoices, ready, submitting])
+
   const moveActive = useCallback(
     (delta: number) => {
       const itemCount = choices.length + 1
@@ -733,7 +751,11 @@ function ClarifyToolSinglePending({
       className="my-1.5 grid gap-4"
       data-clarify-choices={hasChoices ? choices.length : undefined}
       onSubmit={handleSubmit}
-      ref={formRef}
+      ref={(el) => {
+        formRef.current = el
+        panelRef.current = el
+      }}
+      tabIndex={-1}
     >
       <ClarifyShell className="grid gap-2">
         <div className="flex items-start gap-2">

--- a/apps/desktop/src/components/assistant-ui/clarify-tool.tsx
+++ b/apps/desktop/src/components/assistant-ui/clarify-tool.tsx
@@ -550,6 +550,23 @@ function ClarifyToolSinglePending({
       return
     }
 
+    // Don't yank focus from an input the user is actively typing in (the
+    // composer contenteditable, the Other free-text box, a terminal input,
+    // etc.). If the user is mid-draft they'd lose keystrokes to the choices.
+    // Only claim when focus is neutral or on a non-editable element, so a
+    // pure-keyboard user still gets a usable target but a typist isn't
+    // interrupted. `hasChoices` in the deps re-runs this when choices resolve
+    // after an initial no-choice render, so the late-arriving case is covered.
+    const el = document.activeElement
+    const editing =
+      el instanceof HTMLInputElement ||
+      el instanceof HTMLTextAreaElement ||
+      (el instanceof HTMLElement && el.isContentEditable)
+
+    if (editing) {
+      return
+    }
+
     claimedFocus.current = true
     panelRef.current?.focus()
   }, [hasChoices, ready, submitting])


### PR DESCRIPTION
## Summary

When a clarify card appears mid-conversation, keyboard focus stays in the composer. The card's global keydown handler has a focus guard that stands down when focus is on a contenteditable/input — so **Arrow keys and letter shortcuts (1-9 / A-Z) were swallowed by the composer** and a pure-keyboard user couldn't drive the choices without first clicking the card.

## Fix

As soon as the card is interactive (`ready` && has choices && not submitting), it **claims focus on its panel container** (`tabIndex={-1}` on the `form[data-clarify-choices]`). The global handler now sees a neutral focus target and Arrow/letter/Enter all work immediately, no mouse needed. Focus is claimed once (ref guard) and only when the card owns choices — a free-text-only clarify leaves composer focus alone.

## Test Plan

- New test: `moves focus onto the panel so keyboard shortcuts work without a mouse` — after render, `document.activeElement` is the `[data-clarify-choices]` panel
- Existing suite green (20 tests in clarify-tool.test.tsx, incl. the clicked-choice-Enter regression)