### PR TITLE
fix(hermes_cli): resume full update after Windows self-lock deferral

### DIFF
--- a/hermes_cli/_early_recovery.py
+++ b/hermes_cli/_early_recovery.py
@@ -120,11 +120,25 @@ def _pid_is_running(pid: int) -> bool:
 
 
 def _marker_owner_is_live(marker: Path) -> bool:
-    """True when a legacy update marker names a process still running."""
+    """True when a legacy update marker names a process still running.
+
+    Accepts either the historical ``pid=<n>`` line body or a JSON object with
+    a ``pid`` field (self-lock enriched markers).
+    """
     try:
         body = marker.read_text(encoding="utf-8", errors="replace")
     except OSError:
         return False
+    stripped = body.strip()
+    if stripped.startswith("{"):
+        try:
+            import json as _json
+
+            payload = _json.loads(stripped)
+            if isinstance(payload, dict) and "pid" in payload:
+                return _pid_is_running(int(payload["pid"]))
+        except (ValueError, TypeError, AttributeError):
+            return False
     for line in body.splitlines():
         key, separator, value = line.partition("=")
         if separator and key.strip() == "pid":
@@ -499,6 +513,83 @@ def _release_recovery_lock(root: Path) -> None:
         pass
 
 
+def _print_self_lock_manual_escape(root: Path, *, branch: str | None = None) -> None:
+    """Print manual git reset + update commands for stuck self-lock users."""
+    branch_name = (branch or "main").strip() or "main"
+    venv_win = root / "venv" / "Scripts" / "python.exe"
+    venv_posix = root / "venv" / "bin" / "python"
+    if venv_win.is_file():
+        python_exe = str(venv_win)
+    elif venv_posix.is_file():
+        python_exe = str(venv_posix)
+    else:
+        python_exe = sys.executable
+    print("  Manual escape if retries stay stuck:", file=sys.stderr)
+    print(f'    git -C "{root}" fetch origin', file=sys.stderr)
+    print(
+        f'    git -C "{root}" reset --hard origin/{branch_name}',
+        file=sys.stderr,
+    )
+    print(
+        f'    "{python_exe}" -m hermes_cli.main update --yes',
+        file=sys.stderr,
+    )
+
+
+def _marker_requests_pipeline_resume(payload: dict) -> bool:
+    """True when an enriched incomplete marker still has post-deps work."""
+    if not isinstance(payload, dict):
+        return False
+    if payload.get("reason") == "self_lock":
+        return True
+    pending = payload.get("pending")
+    if not isinstance(pending, list):
+        return False
+    return any(stage in pending for stage in ("node_web", "desktop", "skills"))
+
+
+def _write_pipeline_resume_from_incomplete_marker(
+    root: Path, core_marker: Path
+) -> None:
+    """Leave ``.update-pipeline-resume`` after core deps finish for self-lock.
+
+    Early recovery only installs Python core deps. Desktop rebuild / skills
+    sync still need a later process (``hermes update`` up-to-date path or a
+    plain launch). Never raises.
+    """
+    try:
+        raw = core_marker.read_text(encoding="utf-8", errors="replace").strip()
+        if not raw:
+            return
+        import json as _json
+
+        try:
+            payload = _json.loads(raw)
+        except ValueError:
+            return
+        if not _marker_requests_pipeline_resume(payload):
+            return
+        pending = payload.get("pending")
+        if not isinstance(pending, list):
+            pending = ["core_deps", "node_web", "desktop", "skills"]
+        remaining = [stage for stage in pending if stage != "core_deps"]
+        if not remaining:
+            remaining = ["node_web", "desktop", "skills"]
+        resume = {
+            "reason": payload.get("reason") or "self_lock",
+            "phase": "post_deps",
+            "pending": remaining,
+            "had_desktop_app": bool(payload.get("had_desktop_app")),
+            "branch": payload.get("branch"),
+            "head": payload.get("head"),
+        }
+        (root / ".update-pipeline-resume").write_text(
+            _json.dumps(resume), encoding="utf-8"
+        )
+    except Exception:
+        pass
+
+
 def _complete_pending_core_install(root: Path, core_marker: Path) -> bool:
     """Run the pending core install BEFORE main.py can import native modules.
 
@@ -515,6 +606,9 @@ def _complete_pending_core_install(root: Path, core_marker: Path) -> bool:
     attempts ceiling caps automatic retries so a persistent installer
     failure does not block every launch (``hermes acp`` included).
 
+    For self-lock markers, success also writes ``.update-pipeline-resume`` so
+    a later process can finish node/web/desktop/skills after core deps.
+
     Never raises: any failure leaves the marker for the post-import path and
     returns ``False``.  Returns ``True`` only after the install succeeds.
     """
@@ -525,14 +619,18 @@ def _complete_pending_core_install(root: Path, core_marker: Path) -> bool:
         # persistently-failing install stops hammering early.  After the
         # increment the counter reflects THIS attempt.
         attempts = 0
+        marker_branch = None
         try:
             raw = core_marker.read_text(encoding="utf-8", errors="replace").strip()
             if raw:
                 import json as _json
 
                 try:
-                    attempts = int(_json.loads(raw).get("attempts", 0))
-                except (ValueError, AttributeError):
+                    parsed = _json.loads(raw)
+                    if isinstance(parsed, dict):
+                        attempts = int(parsed.get("attempts", 0) or 0)
+                        marker_branch = parsed.get("branch")
+                except (ValueError, AttributeError, TypeError):
                     attempts = 0
         except OSError:
             attempts = 0
@@ -544,6 +642,7 @@ def _complete_pending_core_install(root: Path, core_marker: Path) -> bool:
                 "post-import recovery path.",
                 file=sys.stderr,
             )
+            _print_self_lock_manual_escape(root, branch=marker_branch)
             return False
 
         if not _claim_recovery_lock(root):
@@ -569,9 +668,13 @@ def _complete_pending_core_install(root: Path, core_marker: Path) -> bool:
                 "the current venv in the meantime.",
                 file=sys.stderr,
             )
+            if new_attempts >= _EARLY_CORE_INSTALL_MAX_ATTEMPTS:
+                _print_self_lock_manual_escape(root, branch=marker_branch)
             return False
         finally:
             _release_recovery_lock(root)
+
+        _write_pipeline_resume_from_incomplete_marker(root, core_marker)
 
         try:
             core_marker.unlink()

--- a/hermes_cli/_early_recovery.py
+++ b/hermes_cli/_early_recovery.py
@@ -515,9 +515,12 @@ def _release_recovery_lock(root: Path) -> None:
 
 def _print_self_lock_manual_escape(root: Path, *, branch: str | None = None) -> None:
     """Print manual git reset + update commands for stuck self-lock users."""
+    # hermes_constants is first-party + stdlib-only — safe here (no 3rd-party).
+    from hermes_constants import venv_python_path
+
     branch_name = (branch or "main").strip() or "main"
-    venv_win = root / "venv" / "Scripts" / "python.exe"
-    venv_posix = root / "venv" / "bin" / "python"
+    venv_win = venv_python_path(root / "venv", windows=True)
+    venv_posix = venv_python_path(root / "venv", windows=False)
     if venv_win.is_file():
         python_exe = str(venv_win)
     elif venv_posix.is_file():

--- a/hermes_cli/_install_repair.py
+++ b/hermes_cli/_install_repair.py
@@ -289,21 +289,32 @@ def bump_marker_attempts(marker_path: Path) -> int:
     The marker's existence is the signal; opportunistic JSON body carries the
     retry count so a persistently failing install can back off instead of
     reinstall-hammering every launch. Corrupt/missing bodies restart at 1.
+
+    When the marker already holds a JSON object (e.g. self-lock deferral
+    metadata with ``reason`` / ``pending``), merge the bumped counter into
+    that payload instead of wiping sibling fields.
     Returns the new attempt count. Never raises.
     """
     attempts = 0
+    payload: dict = {}
     try:
         raw = marker_path.read_text(encoding="utf-8", errors="replace").strip()
         if raw:
             try:
-                attempts = int(json.loads(raw).get("attempts", 0))
-            except (ValueError, AttributeError):
+                loaded = json.loads(raw)
+                if isinstance(loaded, dict):
+                    payload = dict(loaded)
+                    attempts = int(payload.get("attempts", 0) or 0)
+            except (ValueError, TypeError, AttributeError):
                 attempts = 0
+                payload = {}
     except OSError:
         attempts = 0
+        payload = {}
     attempts += 1
+    payload["attempts"] = attempts
     try:
-        marker_path.write_text(json.dumps({"attempts": attempts}), encoding="utf-8")
+        marker_path.write_text(json.dumps(payload), encoding="utf-8")
     except OSError:
         pass
     return attempts

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -4462,8 +4462,17 @@ _LAZY_COMMAND_EXPORTS = {
         "_web_toolchain_roots",
         "_write_lazy_refresh_incomplete_marker",
         "_write_marker_file",
+        "_write_pipeline_resume",
+        "_write_self_lock_incomplete_marker",
         "_write_update_incomplete_marker",
         "_write_update_planned_stop_marker",
+        "_print_self_lock_manual_escape_commands",
+        "_read_pipeline_resume",
+        "_clear_pipeline_resume",
+        "_resume_deferred_update_pipeline_if_needed",
+        "_run_deferred_post_dependency_stages",
+        "_sync_skills_after_update",
+        "_update_pipeline_resume_path",
         "_UPDATE_RUNTIME_RELOAD_MODULES",
         "_UPDATE_CRITICAL_FILES",
         "_UPDATE_CRITICAL_MODULES",
@@ -8060,6 +8069,10 @@ def _update_marker_path() -> Path:
     return PROJECT_ROOT / ".update-incomplete"
 
 
+def _update_pipeline_resume_path() -> Path:
+    return PROJECT_ROOT / ".update-pipeline-resume"
+
+
 def _lazy_refresh_marker_path() -> Path:
     return PROJECT_ROOT / ".lazy-refresh-incomplete"
 
@@ -8100,6 +8113,49 @@ def _clear_lazy_refresh_incomplete_marker() -> None:
     _clear_marker_file(_lazy_refresh_marker_path(), label="lazy-refresh-incomplete")
 
 
+def _resume_deferred_update_pipeline_from_launch() -> None:
+    """Finish self-lock post-deps stages left in ``.update-pipeline-resume``.
+
+    Invoked on ordinary launches (not ``hermes update``) so Desktop/skills
+    still complete when early recovery already cleared ``.update-incomplete``.
+    Routes prints to stderr like other recovery noise. Never raises.
+    """
+    if _pytest_owns_live_checkout(PROJECT_ROOT):
+        return
+    resume_path = _update_pipeline_resume_path()
+    if not resume_path.exists():
+        return
+    if not (PROJECT_ROOT / "pyproject.toml").is_file():
+        try:
+            resume_path.unlink()
+        except OSError:
+            pass
+        return
+
+    saved_stdout_fd = None
+    saved_sys_stdout = sys.stdout
+    try:
+        try:
+            saved_stdout_fd = os.dup(1)
+            os.dup2(2, 1)
+        except OSError:
+            saved_stdout_fd = None
+        sys.stdout = sys.stderr
+        from hermes_cli import update_cmd as _update_cmd
+
+        _update_cmd._resume_deferred_update_pipeline_if_needed()
+    except Exception as exc:
+        logger.debug("Deferred update pipeline resume from launch failed: %s", exc)
+    finally:
+        sys.stdout = saved_sys_stdout
+        if saved_stdout_fd is not None:
+            try:
+                os.dup2(saved_stdout_fd, 1)
+                os.close(saved_stdout_fd)
+            except OSError:
+                pass
+
+
 def _recover_from_interrupted_install() -> None:
     """Finish update work left half-done by a prior ``hermes update``.
 
@@ -8130,7 +8186,10 @@ def _recover_from_interrupted_install() -> None:
         return
     core_marker = _update_marker_path().exists()
     lazy_marker = _lazy_refresh_marker_path().exists()
+    pipeline_resume = _update_pipeline_resume_path().exists()
     if not core_marker and not lazy_marker:
+        if pipeline_resume:
+            _resume_deferred_update_pipeline_from_launch()
         return
 
     # Skip in managed/Docker installs and on PyPI installs with no git checkout:
@@ -8139,6 +8198,10 @@ def _recover_from_interrupted_install() -> None:
     if not (PROJECT_ROOT / "pyproject.toml").is_file():
         _clear_update_incomplete_marker()
         _clear_lazy_refresh_incomplete_marker()
+        try:
+            _update_pipeline_resume_path().unlink()
+        except OSError:
+            pass
         return
 
     # Single-flight guard: atomically claim the recovery lock. If another
@@ -8180,6 +8243,14 @@ def _recover_from_interrupted_install() -> None:
 
         if _update_marker_path().exists():
             _recover_core_update_marker_locked()
+
+        # Self-lock early recovery may have already cleared .update-incomplete
+        # and left .update-pipeline-resume; finish those stages here too when
+        # this late path just completed core deps.
+        if _update_pipeline_resume_path().exists():
+            from hermes_cli import update_cmd as _update_cmd
+
+            _update_cmd._resume_deferred_update_pipeline_if_needed()
     finally:
         sys.stdout = saved_sys_stdout
         if saved_stdout_fd is not None:
@@ -8268,6 +8339,18 @@ def _recover_core_update_marker_locked() -> None:
         # established by _recover_from_interrupted_install, so
         # run_core_install's own redirect nests harmlessly.
         _ir.run_core_install(PROJECT_ROOT)
+
+        # Self-lock markers still need node/web/desktop/skills after core deps.
+        try:
+            from hermes_cli._early_recovery import (
+                _write_pipeline_resume_from_incomplete_marker,
+            )
+
+            _write_pipeline_resume_from_incomplete_marker(
+                PROJECT_ROOT, _update_marker_path()
+            )
+        except Exception:
+            pass
 
         _clear_update_incomplete_marker()
         print("✓ Dependency installation recovered — your install is healthy again.")

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -3334,10 +3334,284 @@ def _defer_update_for_self_lock(loaded: list[str]) -> None:
         print(f"    {name}")
     print()
     print("  On Windows a mapped extension cannot be replaced by the process")
-    print("  holding it. The code update has been applied; only the dependency")
-    print("  sync has been deferred: the next `hermes` launch will complete it")
-    print("  in a fresh process before anything imports these modules.")
-    _m()._write_update_incomplete_marker()
+    print("  holding it. The code update has been applied; only the remaining")
+    print("  install stages have been deferred.")
+    print()
+    print("  The next fresh `hermes` / Desktop Update retry will finish Python")
+    print("  dependencies AND the remaining post-deps stages (Node/web build,")
+    print("  Desktop rebuild when present, skills sync) before importing the")
+    print("  locked modules.")
+    print()
+    _m()._write_self_lock_incomplete_marker()
+    _m()._print_self_lock_manual_escape_commands()
+
+
+def _update_pipeline_resume_path() -> Path:
+    """Sidecar for post-core stages left after self-lock deferral recovery."""
+    return _m().PROJECT_ROOT / ".update-pipeline-resume"
+
+
+def _best_effort_update_git_identity() -> tuple[str | None, str | None]:
+    """Return ``(head_sha, branch)`` best-effort; never raises."""
+    root = _m().PROJECT_ROOT
+    head = None
+    branch = None
+    try:
+        head_proc = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=root,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            check=False,
+        )
+        if head_proc.returncode == 0:
+            head = (head_proc.stdout or "").strip() or None
+    except OSError:
+        head = None
+    try:
+        branch_proc = subprocess.run(
+            ["git", "rev-parse", "--abbrev-ref", "HEAD"],
+            cwd=root,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            check=False,
+        )
+        if branch_proc.returncode == 0:
+            branch = (branch_proc.stdout or "").strip() or None
+            if branch == "HEAD":
+                branch = None
+    except OSError:
+        branch = None
+    return head, branch
+
+
+def _preferred_update_python_executable() -> str:
+    """Prefer the project venv interpreter for manual escape commands."""
+    root = _m().PROJECT_ROOT
+    candidate = venv_python_path(root / "venv", windows=_m()._is_windows())
+    if candidate.is_file():
+        return str(candidate)
+    # Fall back to the other platform's layout when detection mismatches.
+    for alt in (
+        root / "venv" / "Scripts" / "python.exe",
+        root / "venv" / "bin" / "python",
+    ):
+        if alt.is_file():
+            return str(alt)
+    return sys.executable
+
+
+def _print_self_lock_manual_escape_commands(*, branch: str | None = None) -> None:
+    """Tell stuck pre-fix users how to force a clean checkout + update."""
+    root = _m().PROJECT_ROOT
+    if branch is None:
+        _, branch = _best_effort_update_git_identity()
+    branch_name = (branch or "main").strip() or "main"
+    python_exe = _preferred_update_python_executable()
+    print("  If automatic retries stay stuck in a catch-22, run:")
+    print(f'    git -C "{root}" fetch origin')
+    print(f'    git -C "{root}" reset --hard origin/{branch_name}')
+    print(f'    "{python_exe}" -m hermes_cli.main update --yes')
+
+
+def _write_self_lock_incomplete_marker(
+    *,
+    had_desktop_app: bool | None = None,
+    branch: str | None = None,
+    head: str | None = None,
+) -> None:
+    """Write enriched ``.update-incomplete`` for self-lock post-code-swap deferral.
+
+    Keeps a JSON body with ``pid`` so early recovery's live-owner check and
+    attempts counter still work. Never raises.
+    """
+    marker = _m()._update_marker_path()
+    if _m()._pytest_owns_live_checkout(marker.parent):
+        logger.debug("Skipping self-lock incomplete marker under pytest (live checkout)")
+        return
+    if had_desktop_app is None:
+        try:
+            had_desktop_app = _desktop_app_present(
+                _m().PROJECT_ROOT / "apps" / "desktop"
+            )
+        except Exception:
+            had_desktop_app = False
+    if head is None and branch is None:
+        head, branch = _best_effort_update_git_identity()
+    payload = {
+        "reason": "self_lock",
+        "phase": "post_code_swap",
+        "started": _time.time(),
+        "pid": os.getpid(),
+        "attempts": 0,
+        "head": head,
+        "branch": branch,
+        "had_desktop_app": bool(had_desktop_app),
+        "pending": ["core_deps", "node_web", "desktop", "skills"],
+    }
+    try:
+        marker.write_text(json.dumps(payload), encoding="utf-8")
+    except OSError as exc:
+        logger.debug("Could not write self-lock incomplete marker: %s", exc)
+        # Fall back to the legacy breadcrumb so #86979 Desktop retry still sees
+        # a marker even when the enriched JSON write fails.
+        try:
+            _write_update_incomplete_marker()
+        except Exception:
+            pass
+
+
+def _read_pipeline_resume() -> dict | None:
+    """Load ``.update-pipeline-resume`` if present; None on missing/corrupt."""
+    path = _update_pipeline_resume_path()
+    try:
+        raw = path.read_text(encoding="utf-8", errors="replace").strip()
+    except OSError:
+        return None
+    if not raw:
+        return None
+    try:
+        payload = json.loads(raw)
+    except ValueError:
+        return None
+    return payload if isinstance(payload, dict) else None
+
+
+def _clear_pipeline_resume() -> None:
+    """Remove the post-deps resume sidecar. Never raises."""
+    try:
+        _update_pipeline_resume_path().unlink()
+    except FileNotFoundError:
+        pass
+    except OSError as exc:
+        logger.debug("Could not clear update-pipeline-resume: %s", exc)
+
+
+def _write_pipeline_resume(payload: dict) -> None:
+    """Persist the post-deps resume sidecar. Never raises."""
+    path = _update_pipeline_resume_path()
+    if _m()._pytest_owns_live_checkout(path.parent):
+        return
+    try:
+        path.write_text(json.dumps(payload), encoding="utf-8")
+    except OSError as exc:
+        logger.debug("Could not write update-pipeline-resume: %s", exc)
+
+
+def _sync_skills_after_update() -> None:
+    """Run the same skills (+ profile seed) block used by the full update path."""
+    try:
+        from tools.skills_sync import sync_skills
+
+        print()
+        print("→ Syncing bundled skills...")
+        result = sync_skills(quiet=True)
+        if result["copied"]:
+            print(f"  + {len(result['copied'])} new: {', '.join(result['copied'])}")
+        if result.get("updated"):
+            print(
+                f"  ↑ {len(result['updated'])} updated: {', '.join(result['updated'])}"
+            )
+        if result.get("user_modified"):
+            print(f"  ~ {len(result['user_modified'])} user-modified (kept)")
+            print(
+                "    → see them: hermes skills list-modified  "
+                "(diff/reset to resume updates)"
+            )
+        if result.get("cleaned"):
+            print(f"  − {len(result['cleaned'])} removed from manifest")
+        if result.get("relocated"):
+            print(
+                f"  → {len(result['relocated'])} moved to new upstream paths: "
+                f"{', '.join(result['relocated'])}"
+            )
+        if not result["copied"] and not result.get("updated"):
+            print("  ✓ Skills are up to date")
+    except Exception as e:
+        logger.debug("Skills sync during deferred update resume failed: %s", e)
+
+    try:
+        from hermes_cli.profiles import (
+            list_profiles,
+            seed_profile_skills,
+        )
+
+        all_profiles = list_profiles()
+        if all_profiles:
+            print()
+            print("→ Syncing bundled skills to all profiles...")
+            for p in all_profiles:
+                try:
+                    r = seed_profile_skills(p.path, quiet=True)
+                    if r and r.get("skipped_opt_out"):
+                        status = "opted out (--no-skills)"
+                    elif r:
+                        copied = len(r.get("copied", []))
+                        updated = len(r.get("updated", []))
+                        modified = len(r.get("user_modified", []))
+                        parts = []
+                        if copied:
+                            parts.append(f"+{copied} new")
+                        if updated:
+                            parts.append(f"↑{updated} updated")
+                        if modified:
+                            parts.append(f"~{modified} user-modified")
+                        status = ", ".join(parts) if parts else "up to date"
+                    else:
+                        status = "sync failed"
+                    print(f"  {p.name}: {status}")
+                except Exception as pe:
+                    print(f"  {p.name}: error ({pe})")
+    except Exception:
+        pass
+
+
+def _run_deferred_post_dependency_stages(*, had_desktop_app: bool) -> None:
+    """Finish node/web + desktop + skills left after self-lock core recovery."""
+    print("→ Finishing deferred post-dependency update stages...")
+    node_failures = _update_node_dependencies()
+    if node_failures:
+        print(f"  ⚠ Node.js refresh failed for: {', '.join(node_failures)}")
+        print("    Fix npm and re-run `hermes update`.")
+    _m()._build_web_ui(_m().PROJECT_ROOT / "web")
+    _rebuild_desktop_after_update(
+        _m().PROJECT_ROOT / "apps" / "desktop",
+        had_desktop_app_before_update=bool(had_desktop_app),
+    )
+    _sync_skills_after_update()
+
+
+def _resume_deferred_update_pipeline_if_needed() -> bool:
+    """Run ``.update-pipeline-resume`` stages when present. Never raises.
+
+    Returns True when a sidecar was found and the resume attempt ran (even if
+    individual stages logged non-fatal failures).
+    """
+    try:
+        if _m()._pytest_owns_live_checkout(_m().PROJECT_ROOT):
+            return False
+        payload = _read_pipeline_resume()
+        if not payload:
+            return False
+        pending = payload.get("pending")
+        if not isinstance(pending, list):
+            pending = ["node_web", "desktop", "skills"]
+        # core_deps is owned by early/late marker recovery; ignore if leftover.
+        remaining = [stage for stage in pending if stage != "core_deps"]
+        if not remaining:
+            _clear_pipeline_resume()
+            return False
+        had_desktop_app = bool(payload.get("had_desktop_app"))
+        _run_deferred_post_dependency_stages(had_desktop_app=had_desktop_app)
+        _clear_pipeline_resume()
+        return True
+    except Exception as exc:
+        logger.debug("Deferred update pipeline resume failed: %s", exc)
+        return False
 
 
 def _format_venv_python_holders_message(matches: list[tuple[int, str, str]]) -> str:
@@ -4784,7 +5058,13 @@ def _cmd_update_impl(args, gateway_mode: bool):
                     print(f"⚠ Venv still unhealthy after repair: {detail_after}")
                     print("  Close all Hermes windows/gateways and re-run: hermes update")
             else:
-                _repair_node_deps_on_current_checkout(_print_update_completion)
+                deferred_resume = _resume_deferred_update_pipeline_if_needed()
+                if deferred_resume:
+                    _print_update_completion(
+                        "✓ Already up to date - finished deferred post-update stages."
+                    )
+                else:
+                    _repair_node_deps_on_current_checkout(_print_update_completion)
             if runtime_repaired is not None and not _m()._is_windows():
                 print()
                 print(

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -3397,8 +3397,8 @@ def _preferred_update_python_executable() -> str:
         return str(candidate)
     # Fall back to the other platform's layout when detection mismatches.
     for alt in (
-        root / "venv" / "Scripts" / "python.exe",
-        root / "venv" / "bin" / "python",
+        venv_python_path(root / "venv", windows=True),
+        venv_python_path(root / "venv", windows=False),
     ):
         if alt.is_file():
             return str(alt)

--- a/tests/hermes_cli/test_early_recovery.py
+++ b/tests/hermes_cli/test_early_recovery.py
@@ -11,6 +11,7 @@ Covers:
 
 from __future__ import annotations
 
+import json
 import os
 import subprocess
 import sys
@@ -158,6 +159,21 @@ def test_marker_owner_liveness_uses_recorded_pid(tmp_path, monkeypatch):
 
     assert er._marker_owner_is_live(marker) is True
     assert seen == [4321]
+
+
+def test_marker_owner_liveness_reads_json_pid(tmp_path, monkeypatch):
+    marker = tmp_path / ".update-incomplete"
+    marker.write_text(
+        json.dumps({"reason": "self_lock", "pid": 9876, "attempts": 0}),
+        encoding="utf-8",
+    )
+    seen = []
+    monkeypatch.setattr(
+        er, "_pid_is_running", lambda pid: seen.append(pid) or True
+    )
+
+    assert er._marker_owner_is_live(marker) is True
+    assert seen == [9876]
 
 
 def _project(tmp_path: Path, *, pyproject: bool = True) -> Path:
@@ -537,6 +553,104 @@ def test_bump_marker_attempts_handles_missing_and_corrupt_bodies(tmp_path):
     assert ir.bump_marker_attempts(m) == 3
 
 
+def test_bump_marker_attempts_preserves_self_lock_fields(tmp_path):
+    from hermes_cli import _install_repair as ir
+
+    m = tmp_path / ".update-incomplete"
+    m.write_text(
+        json.dumps(
+            {
+                "reason": "self_lock",
+                "pending": ["core_deps", "desktop", "skills"],
+                "attempts": 1,
+                "pid": 42,
+            }
+        ),
+        encoding="utf-8",
+    )
+    assert ir.bump_marker_attempts(m) == 2
+    body = json.loads(m.read_text(encoding="utf-8"))
+    assert body["reason"] == "self_lock"
+    assert body["pending"] == ["core_deps", "desktop", "skills"]
+    assert body["pid"] == 42
+    assert body["attempts"] == 2
+
+
+def test_successful_self_lock_core_install_writes_pipeline_resume(
+    tmp_path, monkeypatch
+):
+    root = _project(tmp_path)
+    core_marker = root / ".update-incomplete"
+    core_marker.write_text(
+        json.dumps(
+            {
+                "reason": "self_lock",
+                "phase": "post_code_swap",
+                "attempts": 0,
+                "pid": 1,
+                "had_desktop_app": True,
+                "branch": "main",
+                "head": "abc123",
+                "pending": ["core_deps", "node_web", "desktop", "skills"],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    from hermes_cli import _install_repair as ir
+
+    monkeypatch.setattr(ir, "run_core_install", lambda _r: None)
+    monkeypatch.setattr(er, "_marker_owner_is_live", lambda _marker: False, raising=False)
+    import hermes_cli._install_repair  # noqa: F401
+
+    er.recover_if_needed(project_root=root, argv=[])
+
+    assert not core_marker.exists()
+    resume = root / ".update-pipeline-resume"
+    assert resume.exists()
+    body = json.loads(resume.read_text(encoding="utf-8"))
+    assert body["reason"] == "self_lock"
+    assert body["had_desktop_app"] is True
+    assert body["branch"] == "main"
+    assert body["head"] == "abc123"
+    assert "core_deps" not in body["pending"]
+    assert "desktop" in body["pending"]
+    assert "skills" in body["pending"]
+
+
+def test_core_marker_retry_ceiling_prints_manual_escape(
+    tmp_path, monkeypatch, capsys
+):
+    root = _project(tmp_path)
+    core_marker = root / ".update-incomplete"
+    core_marker.write_text(
+        json.dumps(
+            {
+                "reason": "self_lock",
+                "attempts": er._EARLY_CORE_INSTALL_MAX_ATTEMPTS,
+                "branch": "fix/demo",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    from hermes_cli import _install_repair as ir
+
+    monkeypatch.setattr(
+        ir,
+        "run_core_install",
+        lambda _r: (_ for _ in ()).throw(
+            AssertionError("install must NOT run past the attempts ceiling")
+        ),
+    )
+    import hermes_cli._install_repair  # noqa: F401
+
+    er.recover_if_needed(project_root=root, argv=[])
+
+    err = capsys.readouterr().err
+    assert "git -C" in err
+    assert "origin/fix/demo" in err
+    assert "update --yes" in err
 
 
 

--- a/tests/hermes_cli/test_update_self_lock.py
+++ b/tests/hermes_cli/test_update_self_lock.py
@@ -23,6 +23,8 @@ looped forever (#86735 / #86780 / #86781).  The guard is now honest:
 
 from __future__ import annotations
 
+import json
+import os
 import subprocess
 import sys
 import textwrap
@@ -190,41 +192,155 @@ def test_abort_helper_noop_when_nothing_at_risk():
     defer.assert_not_called()
 
 
-def test_abort_helper_defers_and_exits_2(capsys):
-    marker_writes = []
+def test_abort_helper_defers_and_exits_2(tmp_path, capsys):
+    marker = tmp_path / ".update-incomplete"
     with patch.object(
         cli_main,
         "_detect_self_loaded_native_modules",
         return_value=["cryptography (_rust.pyd)"],
+    ), patch.object(cli_main, "PROJECT_ROOT", tmp_path), patch.object(
+        cli_main, "_pytest_owns_live_checkout", return_value=False
     ), patch.object(
-        cli_main,
-        "_write_update_incomplete_marker",
-        side_effect=lambda: marker_writes.append("written"),
+        cli_main, "_desktop_packaged_executable", return_value=None
+    ), patch.object(
+        cli_main, "_desktop_dist_exists", return_value=False
+    ), patch.object(
+        cli_main, "_is_windows", return_value=True
     ), pytest.raises(SystemExit) as exc:
         cli_main._abort_dependency_sync_if_self_locked()
     assert exc.value.code == 2
-    # Deferral contract: marker dropped so the next fresh launch completes
-    # the dependency install (the code swap has already happened by now).
-    assert marker_writes == ["written"]
+    # Deferral contract: enriched marker dropped so the next fresh launch
+    # completes core deps (+ later post-deps resume) after the code swap.
+    assert marker.exists()
+    import json
+
+    body = json.loads(marker.read_text(encoding="utf-8"))
+    assert body["reason"] == "self_lock"
+    assert body["phase"] == "post_code_swap"
+    assert body["pid"] == os.getpid()
+    assert body["attempts"] == 0
+    assert "core_deps" in body["pending"]
+    assert "desktop" in body["pending"]
+    assert "skills" in body["pending"]
     out = capsys.readouterr().out
     assert "cryptography (_rust.pyd)" in out
-    assert "deferred" in out
+    assert "deferred" in out.lower() or "Deferred" in out or "remaining" in out
+    assert "git -C" in out
+    assert "update --yes" in out
 
 
-def test_abort_helper_resumes_paused_gateways_before_exit():
+def test_abort_helper_resumes_paused_gateways_before_exit(tmp_path):
     resume_calls = []
     sentinel = object()
     with patch.object(
         cli_main,
         "_detect_self_loaded_native_modules",
         return_value=["cryptography (_rust.pyd)"],
-    ), patch.object(cli_main, "_write_update_incomplete_marker"), patch.object(
+    ), patch.object(cli_main, "PROJECT_ROOT", tmp_path), patch.object(
+        cli_main, "_pytest_owns_live_checkout", return_value=False
+    ), patch.object(
+        cli_main, "_desktop_packaged_executable", return_value=None
+    ), patch.object(
+        cli_main, "_desktop_dist_exists", return_value=False
+    ), patch.object(
         cli_main,
         "_resume_windows_gateways_after_update",
         side_effect=lambda token: resume_calls.append(token),
     ), pytest.raises(SystemExit):
         cli_main._abort_dependency_sync_if_self_locked(sentinel)
     assert resume_calls == [sentinel]
+    assert (tmp_path / ".update-incomplete").exists()
+
+
+def test_resume_deferred_pipeline_runs_desktop_and_skills(tmp_path, monkeypatch):
+    monkeypatch.setattr(cli_main, "PROJECT_ROOT", tmp_path)
+    monkeypatch.setattr(cli_main, "_pytest_owns_live_checkout", lambda _root: False)
+    sidecar = tmp_path / ".update-pipeline-resume"
+    sidecar.write_text(
+        json.dumps(
+            {
+                "reason": "self_lock",
+                "pending": ["node_web", "desktop", "skills"],
+                "had_desktop_app": True,
+            }
+        ),
+        encoding="utf-8",
+    )
+    calls = []
+    monkeypatch.setattr(
+        update_cmd,
+        "_update_node_dependencies",
+        lambda: calls.append("node") or [],
+    )
+    monkeypatch.setattr(
+        cli_main,
+        "_build_web_ui",
+        lambda *_a, **_k: calls.append("web"),
+    )
+    monkeypatch.setattr(
+        update_cmd,
+        "_rebuild_desktop_after_update",
+        lambda desktop_dir, *, had_desktop_app_before_update: calls.append(
+            ("desktop", had_desktop_app_before_update)
+        ),
+    )
+    monkeypatch.setattr(
+        update_cmd,
+        "_sync_skills_after_update",
+        lambda: calls.append("skills"),
+    )
+
+    assert update_cmd._resume_deferred_update_pipeline_if_needed() is True
+    assert calls == ["node", "web", ("desktop", True), "skills"]
+    assert not sidecar.exists()
+
+
+def test_resume_deferred_pipeline_noop_without_sidecar(tmp_path, monkeypatch):
+    monkeypatch.setattr(cli_main, "PROJECT_ROOT", tmp_path)
+    monkeypatch.setattr(cli_main, "_pytest_owns_live_checkout", lambda _root: False)
+    assert update_cmd._resume_deferred_update_pipeline_if_needed() is False
+
+
+def test_uptodate_path_invokes_resume_when_sidecar_exists(tmp_path, monkeypatch, capsys):
+    """commit_count==0 healthy branch must finish deferred desktop/skills."""
+    monkeypatch.setattr(cli_main, "PROJECT_ROOT", tmp_path)
+    monkeypatch.setattr(cli_main, "_pytest_owns_live_checkout", lambda _root: False)
+
+    resume_calls = []
+    monkeypatch.setattr(
+        update_cmd,
+        "_resume_deferred_update_pipeline_if_needed",
+        lambda: resume_calls.append(True) or True,
+    )
+    repair_calls = []
+    monkeypatch.setattr(
+        update_cmd,
+        "_repair_node_deps_on_current_checkout",
+        lambda print_completion: repair_calls.append(print_completion),
+    )
+    completion_msgs = []
+    monkeypatch.setattr(
+        update_cmd,
+        "_print_update_completion",
+        lambda msg: completion_msgs.append(msg),
+    )
+
+    # Drive just the healthy up-to-date branch body by invoking the resume
+    # decision the same way _cmd_update_impl does.
+    deferred_resume = update_cmd._resume_deferred_update_pipeline_if_needed()
+    if deferred_resume:
+        update_cmd._print_update_completion(
+            "✓ Already up to date - finished deferred post-update stages."
+        )
+    else:
+        update_cmd._repair_node_deps_on_current_checkout(
+            update_cmd._print_update_completion
+        )
+
+    assert resume_calls == [True]
+    assert repair_calls == []
+    assert completion_msgs
+    assert "deferred" in completion_msgs[0].lower()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR do?

After a Windows self-lock deferral (native modules already mapped in the updater process), Hermes now resumes the remaining update stages instead of stopping at Python core dependency repair.

### Symptom

Self-lock deferral writes `.update-incomplete` and exits 2 after the code swap. Early recovery / interrupted-install recovery finishes `.[all]` and clears that marker. Desktop rebuild, skills sync, and related post-deps work never run on plain launch or on an `Already up to date` update retry. Pre-fix checkouts that cannot self-heal also lacked a clear manual escape path.

### Impact

Users can end up on new code with repaired deps but a stale Desktop build and unsynced skills. Catch-22 users on older checkouts keep retrying Update with no honest bootstrap instructions.

### Bug Cause

**Trigger:** `_defer_update_for_self_lock` / early core-marker recovery.

**Causal chain:**
1. Update swaps code, then defers the dependency sync because a mapped `.pyd` cannot be replaced.
2. Recovery completes only the core install and clears `.update-incomplete`.
3. The next `hermes update` hits the up-to-date short-circuit and skips Desktop/skills.

**Why it is wrong:** The deferral contract promised the next fresh process would finish the install, but only the venv half was implemented.

**Working sibling / contrast:** Desktop handoff retry in #86979 gets a second process started; this PR makes that second process (and ordinary launches) finish the remaining stages.

### Fix

1. Write an enriched self-lock `.update-incomplete` marker and, after successful core recovery, leave `.update-pipeline-resume` for remaining stages.
2. Resume node/web, Desktop rebuild, and skills sync from the up-to-date update path and from launch recovery.
3. Print explicit `git fetch` / `reset --hard` + venv python `update --yes` escape commands when deferral fires or early attempts are exhausted.

## Related Issue

Fixes #86995

Related to #86943 and #86979 (handoff exit-2 retry).

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/update_cmd.py` - enriched self-lock marker, pipeline-resume sidecar, shared post-deps resume, up-to-date wiring, manual escape copy
- `hermes_cli/_early_recovery.py` - write sidecar after successful self-lock core install; preserve JSON fields; print escape on attempt ceiling
- `hermes_cli/_install_repair.py` - merge-preserving `bump_marker_attempts`
- `hermes_cli/main.py` - resume deferred stages on launch / late recovery
- `tests/hermes_cli/test_update_self_lock.py` / `tests/hermes_cli/test_early_recovery.py` - cover marker, sidecar, and resume behavior

## How to Test

1. On Windows, force a post-swap self-lock deferral (or plant enriched `.update-incomplete` with `reason=self_lock`); run a fresh `hermes update --yes` and confirm Desktop/skills stages run after core deps.
2. Plant `.update-pipeline-resume` alone and launch `hermes` (non-update); confirm resume runs and clears the sidecar.
3. Automated:

```bash
scripts/run_tests.sh tests/hermes_cli/test_update_self_lock.py tests/hermes_cli/test_early_recovery.py -q
```

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repository test entry on the relevant tests and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - N/A, behavior is covered by code comments and tests
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - N/A, no config changes
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - N/A, no architecture or workflow changes
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide - resume is cross-platform-safe; self-lock deferral remains Windows-oriented
- [x] I've updated tool descriptions/schemas if I changed tool behavior - N/A, no tool schema changes
