### PR TITLE
i18n(zh-CN): 汉化侧栏筛选菜单 + 补 settings stt.echoTranscripts

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/filter-menu.tsx
+++ b/apps/desktop/src/app/chat/sidebar/filter-menu.tsx
@@ -1,3 +1,5 @@
+import { useMemo } from 'react'
+
 import { useStore } from '@nanostores/react'
 
 import { sessionDotClassName } from '@/app/chat/session-status-dot'
@@ -71,47 +73,6 @@ interface Option<T extends string = string> {
   label: string
 }
 
-const GROUPINGS: Option<SidebarGrouping>[] = [
-  { icon: 'clock', id: 'date', label: 'Updated' },
-  { icon: 'root-folder', id: 'project', label: 'Project' },
-  { icon: 'pulse', id: 'status', label: 'Status' },
-  { icon: 'account', id: 'profile', label: 'Profile' }
-]
-
-const ORDERINGS: Option<SidebarOrdering>[] = [
-  { icon: 'clock', id: 'updated', label: 'Updated' },
-  { icon: 'add', id: 'created', label: 'Created' },
-  { icon: 'pulse', id: 'status', label: 'Status' },
-  { icon: 'symbol-numeric', id: 'tokens', label: 'Tokens' },
-  { icon: 'credit-card', id: 'cost', label: 'Cost' },
-  { icon: 'list-ordered', id: 'manual', label: 'Manual' }
-]
-
-const ROW_META: Option<SidebarRowMeta>[] = [
-  { icon: 'clock', id: 'updated', label: 'Updated' },
-  { icon: 'comment', id: 'preview', label: 'Preview' },
-  { icon: 'symbol-numeric', id: 'tokens', label: 'Tokens' },
-  { icon: 'credit-card', id: 'cost', label: 'Cost' },
-  { icon: 'git-pull-request', id: 'pr', label: 'PR' },
-  { icon: 'account', id: 'profile', label: 'Profile' }
-]
-
-const PR_FILTERS: Option<PullRequestBucket>[] = [
-  { icon: 'git-pull-request', id: 'open', label: 'Open' },
-  { icon: 'git-pull-request-draft', id: 'draft', label: 'Draft' },
-  { icon: 'git-merge', id: 'merged', label: 'Merged' },
-  { icon: 'git-pull-request-closed', id: 'closed', label: 'Closed' },
-  { icon: 'circle-slash', id: 'none', label: 'No PR' }
-]
-
-const STATUS_FILTERS: Option<SessionStatusBucket>[] = [
-  { dot: sessionDotClassName('needs-input'), id: 'needs-input', label: 'Needs input' },
-  { dot: sessionDotClassName('working'), id: 'working', label: 'Working' },
-  { dot: sessionDotClassName('unread'), id: 'unread', label: 'Unread' },
-  { dot: sessionDotClassName('draft'), id: 'draft', label: 'Draft' },
-  { dot: cn(sessionDotClassName('idle'), 'bg-(--ui-text-quaternary)'), id: 'idle', label: 'Idle' }
-]
-
 function OptionGlyph({ option }: { option: Option }) {
   if (option.dot) {
     return <span aria-hidden="true" className={cn('shrink-0', option.dot)} />
@@ -150,6 +111,63 @@ function OptionRadio({ option }: { option: Option }) {
 
 export function SidebarFilterMenu({ className }: { className?: string }) {
   const { t } = useI18n()
+  const fm = t.sidebar.filterMenu
+
+  const GROUPINGS: Option<SidebarGrouping>[] = useMemo(
+    () => [
+      { icon: 'clock', id: 'date', label: fm.groupingOptions.updated },
+      { icon: 'root-folder', id: 'project', label: fm.groupingOptions.project },
+      { icon: 'pulse', id: 'status', label: fm.groupingOptions.status },
+      { icon: 'account', id: 'profile', label: fm.groupingOptions.profile }
+    ],
+    [fm.groupingOptions.updated, fm.groupingOptions.project, fm.groupingOptions.status, fm.groupingOptions.profile]
+  )
+
+  const ORDERINGS: Option<SidebarOrdering>[] = useMemo(
+    () => [
+      { icon: 'clock', id: 'updated', label: fm.orderingOptions.updated },
+      { icon: 'add', id: 'created', label: fm.orderingOptions.created },
+      { icon: 'pulse', id: 'status', label: fm.orderingOptions.status },
+      { icon: 'symbol-numeric', id: 'tokens', label: fm.orderingOptions.tokens },
+      { icon: 'credit-card', id: 'cost', label: fm.orderingOptions.cost },
+      { icon: 'list-ordered', id: 'manual', label: fm.orderingOptions.manual }
+    ],
+    [fm.orderingOptions.updated, fm.orderingOptions.created, fm.orderingOptions.status, fm.orderingOptions.tokens, fm.orderingOptions.cost, fm.orderingOptions.manual]
+  )
+
+  const ROW_META: Option<SidebarRowMeta>[] = useMemo(
+    () => [
+      { icon: 'clock', id: 'updated', label: fm.rowMetaOptions.updated },
+      { icon: 'comment', id: 'preview', label: fm.rowMetaOptions.preview },
+      { icon: 'symbol-numeric', id: 'tokens', label: fm.rowMetaOptions.tokens },
+      { icon: 'credit-card', id: 'cost', label: fm.rowMetaOptions.cost },
+      { icon: 'git-pull-request', id: 'pr', label: fm.rowMetaOptions.pr },
+      { icon: 'account', id: 'profile', label: fm.rowMetaOptions.profile }
+    ],
+    [fm.rowMetaOptions.updated, fm.rowMetaOptions.preview, fm.rowMetaOptions.tokens, fm.rowMetaOptions.cost, fm.rowMetaOptions.pr, fm.rowMetaOptions.profile]
+  )
+
+  const PR_FILTERS: Option<PullRequestBucket>[] = useMemo(
+    () => [
+      { icon: 'git-pull-request', id: 'open', label: fm.prFilters.open },
+      { icon: 'git-pull-request-draft', id: 'draft', label: fm.prFilters.draft },
+      { icon: 'git-merge', id: 'merged', label: fm.prFilters.merged },
+      { icon: 'git-pull-request-closed', id: 'closed', label: fm.prFilters.closed },
+      { icon: 'circle-slash', id: 'none', label: fm.prFilters.none }
+    ],
+    [fm.prFilters.open, fm.prFilters.draft, fm.prFilters.merged, fm.prFilters.closed, fm.prFilters.none]
+  )
+
+  const STATUS_FILTERS: Option<SessionStatusBucket>[] = useMemo(
+    () => [
+      { dot: sessionDotClassName('needs-input'), id: 'needs-input', label: fm.statusFilters.needsInput },
+      { dot: sessionDotClassName('working'), id: 'working', label: fm.statusFilters.working },
+      { dot: sessionDotClassName('unread'), id: 'unread', label: fm.statusFilters.unread },
+      { dot: sessionDotClassName('draft'), id: 'draft', label: fm.statusFilters.draft },
+      { dot: cn(sessionDotClassName('idle'), 'bg-(--ui-text-quaternary)'), id: 'idle', label: fm.statusFilters.idle }
+    ],
+    [fm.statusFilters.needsInput, fm.statusFilters.working, fm.statusFilters.unread, fm.statusFilters.draft, fm.statusFilters.idle]
+  )
   const grouping = useStore($sidebarGrouping)
   const ordering = useStore($sidebarOrdering)
   const rowMeta = useStore($sidebarRowMeta)
@@ -206,7 +224,7 @@ export function SidebarFilterMenu({ className }: { className?: string }) {
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
         <Button
-          aria-label="Filters"
+          aria-label={fm.ariaLabel}
           className={cn(
             className,
             'data-[state=open]:bg-(--ui-control-active-background) data-[state=open]:text-foreground data-[state=open]:opacity-100',
@@ -227,7 +245,7 @@ export function SidebarFilterMenu({ className }: { className?: string }) {
         <DropdownMenuGroup>
           <DropdownMenuSub>
             <DropdownMenuSubTrigger hideChevron>
-              Grouping
+              {fm.grouping}
               <span className="ml-auto flex items-center gap-1 pl-4 text-(--ui-text-tertiary)">
                 {groupingLabel}
                 <Codicon name="chevron-right" size="1rem" />
@@ -246,7 +264,7 @@ export function SidebarFilterMenu({ className }: { className?: string }) {
           </DropdownMenuSub>
 
           <DropdownMenuSub>
-            <DropdownMenuSubTrigger>Ordering</DropdownMenuSubTrigger>
+            <DropdownMenuSubTrigger>{fm.ordering}</DropdownMenuSubTrigger>
             <DropdownMenuSubContent>
               <DropdownMenuRadioGroup
                 onValueChange={value => setSidebarOrdering(value as SidebarOrdering)}
@@ -260,7 +278,7 @@ export function SidebarFilterMenu({ className }: { className?: string }) {
           </DropdownMenuSub>
 
           <DropdownMenuSub>
-            <DropdownMenuSubTrigger>Show</DropdownMenuSubTrigger>
+            <DropdownMenuSubTrigger>{fm.show}</DropdownMenuSubTrigger>
             <DropdownMenuSubContent>
               {rowMetaOptions.map(option => (
                 <OptionCheckbox
@@ -278,17 +296,17 @@ export function SidebarFilterMenu({ className }: { className?: string }) {
           <OptionCheckbox
             checked={cardRows}
             onCheck={() => setSidebarCardRows(!cardRows)}
-            option={{ icon: 'inbox', id: 'card-rows', label: 'Inbox style' }}
+            option={{ icon: 'inbox', id: 'card-rows', label: fm.inboxStyle }}
           />
         </DropdownMenuGroup>
 
         <DropdownMenuSeparator />
 
         <DropdownMenuGroup>
-          <DropdownMenuLabel>Filters</DropdownMenuLabel>
+          <DropdownMenuLabel>{fm.filtersLabel}</DropdownMenuLabel>
 
           <DropdownMenuSub>
-            <DropdownMenuSubTrigger>Status</DropdownMenuSubTrigger>
+            <DropdownMenuSubTrigger>{fm.status}</DropdownMenuSubTrigger>
             <DropdownMenuSubContent>
               {STATUS_FILTERS.map(option => (
                 <OptionCheckbox
@@ -305,7 +323,7 @@ export function SidebarFilterMenu({ className }: { className?: string }) {
               this submenu never appears rather than filtering everything out. */}
           {prAvailable && (
             <DropdownMenuSub>
-              <DropdownMenuSubTrigger>Pull request</DropdownMenuSubTrigger>
+              <DropdownMenuSubTrigger>{fm.pullRequest}</DropdownMenuSubTrigger>
               <DropdownMenuSubContent>
                 {PR_FILTERS.map(option => (
                   <OptionCheckbox
@@ -320,7 +338,7 @@ export function SidebarFilterMenu({ className }: { className?: string }) {
           )}
 
           <DropdownMenuSub>
-            <DropdownMenuSubTrigger>Profile</DropdownMenuSubTrigger>
+            <DropdownMenuSubTrigger>{fm.profile}</DropdownMenuSubTrigger>
             <DropdownMenuSubContent className="max-h-80 overflow-y-auto">
               {/* Scoped to one profile the rail is already the filter, so the
                   per-profile boxes only appear where they can narrow something.
@@ -347,7 +365,7 @@ export function SidebarFilterMenu({ className }: { className?: string }) {
 
           {projects.length > 1 && (
             <DropdownMenuSub>
-              <DropdownMenuSubTrigger>Project</DropdownMenuSubTrigger>
+              <DropdownMenuSubTrigger>{fm.project}</DropdownMenuSubTrigger>
               <DropdownMenuSubContent className="max-h-80 overflow-y-auto">
                 {projects.map(project => (
                   <OptionCheckbox
@@ -382,12 +400,12 @@ export function SidebarFilterMenu({ className }: { className?: string }) {
           <OptionCheckbox
             checked={showArchived}
             onCheck={() => setSidebarShowArchived(!showArchived)}
-            option={{ id: 'archived', label: 'Archived' }}
+            option={{ id: 'archived', label: fm.archived }}
           />
 
           {/* One way back rather than two near-identical ones: this drops the
               grouping and sort too, which "clear filters" left behind. */}
-          {viewCustomized && <DropdownMenuItem onSelect={resetSidebarView}>Reset to defaults</DropdownMenuItem>}
+          {viewCustomized && <DropdownMenuItem onSelect={resetSidebarView}>{fm.resetToDefaults}</DropdownMenuItem>}
         </DropdownMenuGroup>
 
         <DropdownMenuSeparator />
@@ -405,11 +423,11 @@ export function SidebarFilterMenu({ className }: { className?: string }) {
               )
             }
           >
-            {projectsCollapsed ? 'Expand all' : 'Collapse all'}
+            {projectsCollapsed ? fm.expandAll : fm.collapseAll}
           </DropdownMenuItem>
         )}
         <DropdownMenuItem disabled={unreadIds.length === 0} onSelect={markAllSessionsRead}>
-          Mark all as read
+          {fm.markAllRead}
         </DropdownMenuItem>
       </DropdownMenuContent>
     </DropdownMenu>

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -1951,6 +1951,59 @@ export const en: Translations = {
     projectEmpty: 'No sessions yet',
     noSessions: 'No sessions yet',
     noFilterMatches: 'No sessions match these filters',
+    filterMenu: {
+      grouping: 'Grouping',
+      ordering: 'Ordering',
+      show: 'Show',
+      inboxStyle: 'Inbox style',
+      filtersLabel: 'Filters',
+      status: 'Status',
+      pullRequest: 'Pull request',
+      profile: 'Profile',
+      project: 'Project',
+      archived: 'Archived',
+      resetToDefaults: 'Reset to defaults',
+      expandAll: 'Expand all',
+      collapseAll: 'Collapse all',
+      markAllRead: 'Mark all as read',
+      ariaLabel: 'Filters',
+      groupingOptions: {
+        updated: 'Updated',
+        project: 'Project',
+        status: 'Status',
+        profile: 'Profile'
+      },
+      orderingOptions: {
+        updated: 'Updated',
+        created: 'Created',
+        status: 'Status',
+        tokens: 'Tokens',
+        cost: 'Cost',
+        manual: 'Manual'
+      },
+      rowMetaOptions: {
+        updated: 'Updated',
+        preview: 'Preview',
+        tokens: 'Tokens',
+        cost: 'Cost',
+        pr: 'PR',
+        profile: 'Profile'
+      },
+      prFilters: {
+        open: 'Open',
+        draft: 'Draft',
+        merged: 'Merged',
+        closed: 'Closed',
+        none: 'No PR'
+      },
+      statusFilters: {
+        needsInput: 'Needs input',
+        working: 'Working',
+        unread: 'Unread',
+        draft: 'Draft',
+        idle: 'Idle'
+      }
+    },
     projects: {
       sectionLabel: 'Projects',
       home: 'Home',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -1636,6 +1636,59 @@ export interface Translations {
     projectEmpty: string
     noSessions: string
     noFilterMatches: string
+    filterMenu: {
+      grouping: string
+      ordering: string
+      show: string
+      inboxStyle: string
+      filtersLabel: string
+      status: string
+      pullRequest: string
+      profile: string
+      project: string
+      archived: string
+      resetToDefaults: string
+      expandAll: string
+      collapseAll: string
+      markAllRead: string
+      ariaLabel: string
+      groupingOptions: {
+        updated: string
+        project: string
+        status: string
+        profile: string
+      }
+      orderingOptions: {
+        updated: string
+        created: string
+        status: string
+        tokens: string
+        cost: string
+        manual: string
+      }
+      rowMetaOptions: {
+        updated: string
+        preview: string
+        tokens: string
+        cost: string
+        pr: string
+        profile: string
+      }
+      prFilters: {
+        open: string
+        draft: string
+        merged: string
+        closed: string
+        none: string
+      }
+      statusFilters: {
+        needsInput: string
+        working: string
+        unread: string
+        draft: string
+        idle: string
+      }
+    }
     projects: {
       sectionLabel: string
       home: string

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -602,6 +602,7 @@ export const zh: Translations = {
       },
       stt: {
         enabled: '语音转文字',
+        echoTranscripts: '回显转写文本',
         provider: '语音转文字提供方',
         local: {
           model: '本地转写模型',
@@ -749,6 +750,7 @@ export const zh: Translations = {
       },
       stt: {
         enabled: '启用本地或提供方支持的语音转写。',
+        echoTranscripts: '把语音消息的原始转写文本回贴到对话中。',
         elevenlabs: {
           languageCode: '可选的 ISO-639-3 语言代码。留空让 ElevenLabs 自动检测。'
         }

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -2139,6 +2139,59 @@ export const zh: Translations = {
     projectEmpty: '暂无会话',
     noSessions: '暂无会话',
     noFilterMatches: '没有会话符合这些筛选条件',
+    filterMenu: {
+      grouping: '分组',
+      ordering: '排序',
+      show: '显示',
+      inboxStyle: '收件箱样式',
+      filtersLabel: '筛选',
+      status: '状态',
+      pullRequest: 'PR 请求',
+      profile: '配置',
+      project: '项目',
+      archived: '已归档',
+      resetToDefaults: '恢复默认',
+      expandAll: '全部展开',
+      collapseAll: '全部折叠',
+      markAllRead: '全部标为已读',
+      ariaLabel: '筛选',
+      groupingOptions: {
+        updated: '更新',
+        project: '项目',
+        status: '状态',
+        profile: '配置'
+      },
+      orderingOptions: {
+        updated: '更新',
+        created: '创建',
+        status: '状态',
+        tokens: 'Token 数',
+        cost: '花费',
+        manual: '手动'
+      },
+      rowMetaOptions: {
+        updated: '更新',
+        preview: '预览',
+        tokens: 'Token 数',
+        cost: '花费',
+        pr: 'PR',
+        profile: '配置'
+      },
+      prFilters: {
+        open: '打开',
+        draft: '草稿',
+        merged: '已合并',
+        closed: '已关闭',
+        none: '无 PR'
+      },
+      statusFilters: {
+        needsInput: '等待输入',
+        working: '处理中',
+        unread: '未读',
+        draft: '草稿',
+        idle: '空闲'
+      }
+    },
     projects: {
       sectionLabel: '项目',
       home: '主页',


### PR DESCRIPTION
两个 commit:

1. `a5160ae9f` 通过 i18n 系统汉化侧栏筛选菜单(filter-menu)。types.ts / en.ts / zh.ts 加 sidebar.filterMenu 子块,filter-menu.tsx 数组用 useMemo 读取 t.sidebar.filterMenu.*。英文界面不受影响。

2. `63aa490b3` 补 zh.ts settings.fields.stt.echoTranscripts 中英文案(UI fallback 修)。

不影响 en/ja/zh-hant/ar。