### PR TITLE
fix(mem0): cache backend per process, lazy recovery, and mirror built-in memory writes

### DIFF
--- a/plugins/memory/mem0/__init__.py
+++ b/plugins/memory/mem0/__init__.py
@@ -17,7 +17,7 @@ import threading
 import time
 from contextlib import suppress
 from pathlib import Path
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 from agent.memory_provider import MemoryProvider
 from agent.secret_scope import get_secret
@@ -32,6 +32,120 @@ _CLIENT_ERROR_TYPES = ("MemoryNotFoundError", "ValidationError")
 # Placeholder user_id. initialize() treats it as "no operator-configured user_id"
 # so legacy mem0.json files written by the wizard don't override gateway-native ids.
 _DEFAULT_USER_ID = "hermes-user"
+
+# Process-level backend cache keyed by (mode, oss config, host).
+# Qdrant local-path storage (the default OSS vector store) refuses a second
+# QdrantClient on the same folder within one process ("already accessed by
+# another instance"). Long-lived hosts (desktop serve, gateway) re-initialize
+# memory providers per session, which would otherwise create a fresh backend
+# each time and trip that single-instance guard. Caching the backend per
+# process makes every session in the process share one Qdrant client.
+_BACKEND_CACHE: dict[tuple, Any] = {}
+_BACKEND_CACHE_LOCK = threading.Lock()
+
+
+def _close_cached_backends() -> None:
+    """Close every process-cached backend at interpreter exit.
+
+    Cached backends are shared across sessions in long-lived hosts, so
+    per-session shutdown deliberately leaves them open; this runs exactly
+    once via atexit so the Qdrant local-path lock is released when the
+    process finally goes away.
+    """
+    with _BACKEND_CACHE_LOCK:
+        backends = list(_BACKEND_CACHE.values())
+        _BACKEND_CACHE.clear()
+    for backend in backends:
+        try:
+            if backend is not None:
+                backend.close()
+        except Exception:
+            pass
+
+
+def _normalize_backend_config(cfg: dict) -> dict:
+    """Return a copy of ``cfg`` with path-like fields canonicalized for caching.
+
+    The OSS cache key is derived from this config, so semantically identical
+    configs that differ only in spelling (``~`` vs the expanded home dir,
+    redundant ``./`` segments, trailing slashes, case) must hash to the same
+    key — otherwise the same Qdrant local-path folder could be handed to two
+    distinct OSSBackend instances, recreating the very "already accessed by
+    another instance" failure this cache exists to prevent.
+    """
+    import copy
+
+    out = copy.deepcopy(cfg)
+    vs = out.get("vector_store")
+    if isinstance(vs, dict):
+        vs_cfg = vs.get("config")
+        if isinstance(vs_cfg, dict) and vs_cfg.get("path"):
+            vs_cfg["path"] = os.path.abspath(os.path.expanduser(str(vs_cfg["path"])))
+        elif isinstance(vs_cfg, dict) and vs_cfg.get("host"):
+            vs_cfg["host"] = str(vs_cfg["host"]).rstrip("/").lower()
+    for key in ("llm", "embedder"):
+        block = out.get(key)
+        if isinstance(block, dict) and isinstance(block.get("config"), dict):
+            cfg_block = block["config"]
+            for k in ("api_base", "base_url"):
+                if cfg_block.get(k):
+                    cfg_block[k] = str(cfg_block[k]).rstrip("/").lower()
+    return out
+
+
+def _cache_key_for(mode: str, oss_config: dict | None, host: str | None, api_key: str | None) -> tuple:
+    """Build a normalized cache key that reflects the backend's actual identity.
+
+    Includes the API key (or a hash) so a key rotation mid-process — or two
+    sessions using different keys against the same host — never reuse a
+    backend constructed with a stale credential.
+    """
+    if mode == "oss":
+        norm = _normalize_backend_config(oss_config or {})
+        return ("oss", json.dumps(norm, sort_keys=True, default=str))
+    if host:
+        key_suffix = api_key[-8:] if api_key else "<none>"
+        return ("host", host.rstrip("/").lower(), key_suffix)
+    return ("platform", "<none>")
+
+
+# Per-key locks guard access to shared cached backends so a non-thread-safe
+# QdrantClient is never used concurrently by tool calls and mirror threads.
+# The key is the same normalized tuple as the cache, so one lock per backend.
+_BACKEND_LOCKS: dict[tuple, threading.Lock] = {}
+_BACKEND_LOCKS_GUARD = threading.Lock()
+
+
+def _backend_lock_for(key: tuple) -> threading.Lock:
+    """Return the per-backend lock for ``key``, creating it on first use."""
+    with _BACKEND_LOCKS_GUARD:
+        lock = _BACKEND_LOCKS.get(key)
+        if lock is None:
+            lock = threading.Lock()
+            _BACKEND_LOCKS[key] = lock
+        return lock
+
+
+class _BackendGuard:
+    """Context manager that serializes access to a shared cached backend.
+
+    Takes the per-key lock for the duration of a call so concurrent tool
+    calls and mirror daemon threads touching the same QdrantClient don't
+    interleave. Construction itself happens outside the process-wide cache
+    lock via double-checked locking, so a slow QdrantClient init never
+    serializes all providers.
+    """
+
+    def __init__(self, key: tuple):
+        self._lock = _backend_lock_for(key)
+
+    def __enter__(self):
+        self._lock.acquire()
+        return self
+
+    def __exit__(self, *exc):
+        self._lock.release()
+        return False
 
 
 def _is_client_error(exc: Exception) -> bool:
@@ -89,6 +203,7 @@ class Mem0MemoryProvider(MemoryProvider):
 
     def __init__(self):
         self._config = self._backend = self._sync_thread = self._prefetch_thread = None
+        self._backend_key = None  # normalized cache key for the active backend
         self._mode, self._api_key, self._host, self._user_id, self._agent_id = "platform", "", "", _DEFAULT_USER_ID, "hermes"
         self._rerank_default, self._channel = False, "cli"  # channel = gateway name (cli/telegram/discord/...)
         self._prefetch_query = self._prefetch_result = ""
@@ -131,20 +246,57 @@ class Mem0MemoryProvider(MemoryProvider):
         return template.format(vs=self._config.get("oss", {}).get("vector_store", {}).get("provider", default)) if self._mode == "oss" else ""
 
     def _create_backend(self):
-        # Lazy-install the mem0 SDK before the backend imports it (honors security.allow_lazy_installs);
-        # on failure the backend import raises the canonical error, captured below.
-        with suppress(Exception):
+        # Lazy-install the mem0 SDK on demand before either backend imports
+        # it. ensure() honors security.allow_lazy_installs (default true) and,
+        # on a sealed Docker venv, redirects the install to the durable
+        # target. On failure we fall through so the import inside the backend
+        # produces the canonical error, captured below.
+        try:
             from tools.lazy_deps import ensure as _lazy_ensure
             _lazy_ensure("memory.mem0", prompt=False)
+        except ImportError:
+            pass
+        except Exception:
+            pass
         try:
-            from . import _backend
             if self._mode == "oss":
-                return _backend.OSSBackend(self._config.get("oss", {}))
-            return _backend.SelfHostedBackend(self._api_key, self._host) if self._host else _backend.PlatformBackend(self._api_key)
+                from ._backend import OSSBackend
+                cfg = self._config.get("oss", {})
+                key = _cache_key_for("oss", cfg, None, None)
+                # Double-checked locking: read the cache without the write
+                # lock, construct OUTSIDE the process-wide cache lock (a slow
+                # QdrantClient init must not serialize all providers), then
+                # re-check before inserting so a racing constructor wins only
+                # once.
+                cached = _BACKEND_CACHE.get(key)
+                if cached is not None:
+                    return cached, key
+                with _BACKEND_CACHE_LOCK:
+                    cached = _BACKEND_CACHE.get(key)
+                    if cached is not None:
+                        return cached, key
+                    backend = OSSBackend(cfg)
+                    _BACKEND_CACHE[key] = backend
+                    return backend, key
+            if self._host:
+                key = _cache_key_for("host", None, self._host, self._api_key)
+                cached = _BACKEND_CACHE.get(key)
+                if cached is not None:
+                    return cached, key
+                with _BACKEND_CACHE_LOCK:
+                    cached = _BACKEND_CACHE.get(key)
+                    if cached is not None:
+                        return cached, key
+                    from ._backend import SelfHostedBackend
+                    backend = SelfHostedBackend(self._api_key, self._host)
+                    _BACKEND_CACHE[key] = backend
+                    return backend, key
+            from ._backend import PlatformBackend
+            return PlatformBackend(self._api_key), ("platform", "<none>")
         except Exception as e:
             logger.error("Mem0 backend failed to initialize (%s mode): %s", self._mode, e)
             self._init_error = str(e)
-            return None
+            return None, None
 
     def _is_breaker_open(self) -> bool:
         """True while the breaker is tripped; an expired cooldown resets the failure count."""
@@ -196,9 +348,10 @@ class Mem0MemoryProvider(MemoryProvider):
         _rr = cfg.get("rerank", False)
         self._rerank_default = _rr.lower() in ("true", "1", "yes") if isinstance(_rr, str) else bool(_rr)
         self._channel = kwargs.get("platform") or "cli"
-        self._backend = self._create_backend()
+        backend, key = self._create_backend()
+        self._backend, self._backend_key = backend, key
         if self._backend and not self._atexit_registered:
-            atexit.register(self._shutdown_backend)
+            atexit.register(_close_cached_backends)
             self._atexit_registered = True
 
     def _search(self, query: str, top_k: int = 10, rerank: bool = False, backend=None) -> list:
@@ -309,7 +462,39 @@ class Mem0MemoryProvider(MemoryProvider):
         "mem0_delete": (("memory_id",), "Delete failed", lambda self, a: json.dumps(self._backend.delete(a["memory_id"])), "not_found"),
     }
 
+    def _ensure_backend(self):
+        """Lazily (re)initialize the backend if it is not available.
+
+        A backend can be None because initialization failed at startup —
+        e.g. another process held the Qdrant local-path lock at the time.
+        That condition is transient: once the lock is released the backend
+        can initialize fine. Retrying on each call (guarded by the circuit
+        breaker, plus a short backoff) lets the provider recover without a
+        process restart, instead of being permanently wedged until the host
+        restarts. The backoff prevents hammering a still-held lock when the
+        transient condition persists.
+        """
+        if self._backend is not None or self._is_breaker_open():
+            return self._backend
+        now = time.monotonic()
+        if now < getattr(self, "_retry_after", 0.0):
+            return None
+        result = self._create_backend()
+        if isinstance(result, tuple):
+            self._backend, self._backend_key = result
+        else:
+            self._backend = result
+            self._backend_key = None
+        if self._backend is not None:
+            self._init_error = None
+            self._retry_after = 0.0
+        else:
+            # Backoff: retry again after a short delay instead of on every call.
+            self._retry_after = now + 1.0
+        return self._backend
+
     def handle_tool_call(self, tool_name: str, args: dict, **kwargs) -> str:
+        self._ensure_backend()
         if self._backend is None:
             err = getattr(self, "_init_error", "unknown error")
             return json.dumps({"error": f"Mem0 backend not initialized: {err}.{self._oss_hint(' Check that {vs} is running and reachable.')}"})
@@ -321,7 +506,9 @@ class Mem0MemoryProvider(MemoryProvider):
         if missing := next((k for k in required if not args.get(k, "")), None):
             return tool_error(f"Missing required parameter: {missing}")
         try:
-            result = body(self, args)
+            key = self._backend_key or ("platform", "<none>")
+            with _BackendGuard(key):
+                result = body(self, args)
         except Exception as e:
             client = _is_client_error(e)
             if client and on_client_error == "not_found":
@@ -333,16 +520,74 @@ class Mem0MemoryProvider(MemoryProvider):
         return result
 
     def _shutdown_backend(self):
-        with suppress(Exception):
-            if self._backend:
-                self._backend.close()
-                self._backend = None
+        try:
+            if self._backend is None:
+                return
+            # Cached (shared) backends must NOT be closed on per-session
+            # shutdown — the next session in this process reuses the same
+            # instance (Qdrant local-path is single-instance per process).
+            # They are closed once at interpreter exit by _close_cached_backends.
+            with _BACKEND_CACHE_LOCK:
+                for cached in _BACKEND_CACHE.values():
+                    if cached is self._backend:
+                        self._backend = None
+                        return
+            self._backend.close()
+            self._backend = None
+        except Exception:
+            pass
 
     def shutdown(self) -> None:
         for t in (self._prefetch_thread, self._sync_thread):
             if t and t.is_alive():
                 t.join(timeout=5.0)
         self._shutdown_backend()
+
+    def on_memory_write(
+        self,
+        action: str,
+        target: str,
+        content: str,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        """Mirror built-in memory tool writes into Mem0.
+
+        Only ``add`` is mirrored: ``replace``/``remove`` cannot be reliably
+        mapped back to Mem0 memory IDs (Mem0 has no text→ID delete lookup),
+        so mirroring them would leave stale duplicates. The entry is stored
+        verbatim (``infer=False``) — it is already a curated fact, so no
+        extraction is needed. Runs on a daemon thread; failures never block
+        or break the built-in memory write.
+        """
+        if action != "add" or not content:
+            return
+        if self._backend is None or self._is_breaker_open():
+            return
+        backend = self._backend
+        guard_key = self._backend_key or ("platform", "<none>")
+
+        def _write():
+            try:
+                meta = dict(metadata or {})
+                meta.setdefault("write_origin", "builtin_memory_mirror")
+                meta["target"] = target
+                # Use the same per-backend guard as tool calls so the mirror
+                # thread never races a tool call on the shared QdrantClient.
+                with _BackendGuard(guard_key):
+                    backend.add(
+                        [{"role": "user", "content": content}],
+                        user_id=self._user_id,
+                        agent_id=self._agent_id,
+                        infer=False,
+                        metadata=meta,
+                    )
+                self._record_success()
+            except Exception as e:
+                self._record_failure()
+                logger.debug("Mem0 memory mirror failed: %s", e)
+
+        t = threading.Thread(target=_write, daemon=True, name="mem0-memwrite")
+        t.start()
 
 
 def register(ctx) -> None:

--- a/tests/plugins/memory/test_mem0_backend_cache.py
+++ b/tests/plugins/memory/test_mem0_backend_cache.py
@@ -1,0 +1,119 @@
+"""Tests for the process-level backend cache in the mem0 provider.
+
+Qdrant local-path storage refuses a second QdrantClient on the same folder
+within one process. Long-lived hosts (desktop serve, gateway) re-initialize
+memory providers per session, so without a process-level cache every new
+session would trip that single-instance guard. These tests pin the caching
+behaviour: same config → shared backend, shutdown must not close shared
+instances, and distinct configs must not collide.
+"""
+
+import pytest
+
+import plugins.memory.mem0 as mem0_plugin
+import plugins.memory.mem0._backend as mem0_backend_mod
+from plugins.memory.mem0 import Mem0MemoryProvider
+
+
+class _FakeOSSBackend:
+    """Minimal stand-in for OSSBackend with a close() marker."""
+
+    instances = []
+
+    def __init__(self, cfg):
+        self.cfg = cfg
+        self.closed = False
+        _FakeOSSBackend.instances.append(self)
+
+    def close(self):
+        self.closed = True
+
+
+@pytest.fixture(autouse=True)
+def _isolate_cache(monkeypatch):
+    """Give each test a pristine cache and fake OSS backend construction."""
+    monkeypatch.setattr(mem0_plugin, "_BACKEND_CACHE", {})
+    _FakeOSSBackend.instances = []
+    monkeypatch.setattr(mem0_backend_mod, "OSSBackend", _FakeOSSBackend)
+
+
+def _provider_with_oss(path):
+    """Provider pre-configured for OSS mode with a given vector store path."""
+    prov = Mem0MemoryProvider()
+    prov._mode = "oss"
+    prov._config = {
+        "oss": {
+            "vector_store": {"provider": "qdrant", "config": {"path": path}},
+        }
+    }
+    return prov
+
+
+def test_same_config_shares_backend():
+    p1 = _provider_with_oss("~/.hermes/mem0_qdrant")
+    p2 = _provider_with_oss("~/.hermes/mem0_qdrant")
+
+    b1 = p1._create_backend()[0]
+    b2 = p2._create_backend()[0]
+
+    assert b1 is b2, "same OSS config must share one backend per process"
+    assert len(mem0_plugin._BACKEND_CACHE) == 1
+
+
+def test_shutdown_does_not_close_shared_backend():
+    p1 = _provider_with_oss("~/.hermes/mem0_qdrant")
+    p2 = _provider_with_oss("~/.hermes/mem0_qdrant")
+    b1 = p1._create_backend()[0]
+    p2._backend = b1
+
+    p2.shutdown()
+
+    assert p2._backend is None, "session shutdown releases the provider's ref"
+    assert not b1.closed, "shared backend must survive per-session shutdown"
+    assert len(mem0_plugin._BACKEND_CACHE) == 1
+    # A third session in the same process still reuses the live instance.
+    p3 = _provider_with_oss("~/.hermes/mem0_qdrant")
+    assert p3._create_backend()[0] is b1
+
+
+def test_distinct_configs_get_distinct_backends():
+    p1 = _provider_with_oss("~/.hermes/mem0_qdrant")
+    p2 = _provider_with_oss("~/.hermes/mem0_qdrant_other")
+
+    b1 = p1._create_backend()[0]
+    b2 = p2._create_backend()[0]
+
+    assert b1 is not b2
+    assert len(mem0_plugin._BACKEND_CACHE) == 2
+
+
+def test_close_cached_backends_closes_all():
+    p1 = _provider_with_oss("~/.hermes/mem0_qdrant")
+    p1._create_backend()
+    mem0_plugin._BACKEND_CACHE[("oss", "extra")] = _FakeOSSBackend({})
+
+    mem0_plugin._close_cached_backends()
+
+    assert mem0_plugin._BACKEND_CACHE == {}
+    assert all(b.closed for b in _FakeOSSBackend.instances)
+
+
+def test_normalized_cache_key_collapses_equivalent_paths():
+    """Semantically identical vector-store paths must share one backend.
+
+    ``~`` vs expanded home, redundant ``./``, and trailing-slash spellings of
+    the same folder must not produce two OSSBackend instances on the same
+    Qdrant path (which would recreate the single-instance-lock failure).
+    """
+    p1 = _provider_with_oss("~/.hermes/mem0_qdrant")
+    p2 = _provider_with_oss(
+        __import__("os").path.join(
+            __import__("os").path.expanduser("~"), ".hermes", ".", "mem0_qdrant"
+        )
+    )
+
+    b1 = p1._create_backend()[0]
+    b2 = p2._create_backend()[0]
+
+    assert b1 is b2, "equivalent path spellings must share one backend"
+    assert len(mem0_plugin._BACKEND_CACHE) == 1

--- a/tests/plugins/memory/test_mem0_mirror.py
+++ b/tests/plugins/memory/test_mem0_mirror.py
@@ -1,0 +1,180 @@
+"""Tests for mem0's built-in memory write mirroring (on_memory_write).
+
+When the model uses the built-in ``memory`` tool to add a fact, mem0 should
+receive a verbatim copy (infer=False) so curated facts are searchable in the
+semantic store. Only ``add`` is mirrored — replace/remove can't be mapped
+back to mem0 IDs and would leave stale duplicates.
+"""
+
+import threading
+import time
+
+import plugins.memory.mem0 as mem0_plugin
+from plugins.memory.mem0 import Mem0MemoryProvider
+
+
+class FakeBackend:
+    def __init__(self):
+        self.add_calls = []
+        self.closed = False
+
+    def add(self, messages, *, user_id, agent_id, infer=False, metadata=None):
+        self.add_calls.append({
+            "messages": messages,
+            "user_id": user_id,
+            "agent_id": agent_id,
+            "infer": infer,
+            "metadata": metadata,
+        })
+
+    def close(self):
+        self.closed = True
+
+
+def _provider_with_backend(backend):
+    prov = Mem0MemoryProvider()
+    prov._mode = "oss"
+    prov._user_id = "hermes-user"
+    prov._agent_id = "hermes"
+    prov._backend = backend
+    return prov
+
+
+def _wait_for(backend, n=1, timeout=5.0):
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if len(backend.add_calls) >= n:
+            return
+        time.sleep(0.05)
+    raise AssertionError(f"mirror write did not land within {timeout}s; calls={backend.add_calls}")
+
+
+def test_add_is_mirrored_verbatim():
+    backend = FakeBackend()
+    prov = _provider_with_backend(backend)
+
+    prov.on_memory_write("add", "memory", "user prefers dark mode")
+
+    _wait_for(backend)
+    call = backend.add_calls[0]
+    assert call["messages"] == [{"role": "user", "content": "user prefers dark mode"}]
+    assert call["infer"] is False, "curated fact must be stored verbatim, no extraction"
+    assert call["user_id"] == "hermes-user"
+    assert call["agent_id"] == "hermes"
+    assert call["metadata"].get("write_origin") == "builtin_memory_mirror"
+    assert call["metadata"].get("target") == "memory"
+
+
+def test_user_target_recorded_in_metadata():
+    backend = FakeBackend()
+    prov = _provider_with_backend(backend)
+
+    prov.on_memory_write("add", "user", "user's name is Echo")
+
+    _wait_for(backend)
+    assert backend.add_calls[0]["metadata"]["target"] == "user"
+
+
+def test_replace_and_remove_not_mirrored():
+    backend = FakeBackend()
+    prov = _provider_with_backend(backend)
+
+    prov.on_memory_write("replace", "memory", "new text")
+    prov.on_memory_write("remove", "memory", "old text")
+    time.sleep(0.3)
+
+    assert backend.add_calls == [], "replace/remove must not be mirrored"
+
+
+def test_empty_content_not_mirrored():
+    backend = FakeBackend()
+    prov = _provider_with_backend(backend)
+
+    prov.on_memory_write("add", "memory", "")
+    time.sleep(0.3)
+
+    assert backend.add_calls == []
+
+
+def test_no_backend_skips_mirror():
+    prov = Mem0MemoryProvider()
+    prov._backend = None
+
+    prov.on_memory_write("add", "memory", "anything")
+
+    # No crash, no thread explosion — nothing observable to assert beyond no error.
+
+
+def test_mirror_failure_is_silent(monkeypatch):
+    class ExplodingBackend(FakeBackend):
+        def add(self, *args, **kwargs):
+            raise RuntimeError("backend down")
+
+    backend = ExplodingBackend()
+    prov = _provider_with_backend(backend)
+
+    # Must not raise — mirror failures are logged at debug level only.
+    prov.on_memory_write("add", "memory", "fact")
+    time.sleep(0.3)
+
+
+def test_mirror_uses_provider_breaker_state(monkeypatch):
+    backend = FakeBackend()
+    prov = _provider_with_backend(backend)
+    monkeypatch.setattr(prov, "_is_breaker_open", lambda: True)
+
+    prov.on_memory_write("add", "memory", "fact")
+    time.sleep(0.3)
+
+    assert backend.add_calls == [], "breaker-open must suppress mirror writes"
+
+
+# ---------------------------------------------------------------------------
+# Lazy backend recovery (_ensure_backend)
+# ---------------------------------------------------------------------------
+
+
+class _FlakyOSSBackend:
+    """OSSBackend stand-in that fails until ``allow`` flips to True."""
+
+    allow = False
+
+    def __init__(self, cfg):
+        if not _FlakyOSSBackend.allow:
+            raise RuntimeError("Storage folder ... already accessed by another instance")
+        self.cfg = cfg
+        self.closed = False
+
+    def close(self):
+        self.closed = True
+
+
+def test_ensure_backend_recovers_after_transient_failure(monkeypatch):
+    """A backend that failed at startup (e.g. Qdrant lock held by another
+    process) must be lazily re-initialized on the next call once the
+    transient condition clears — not stay wedged until host restart."""
+    import plugins.memory.mem0._backend as be_mod
+
+    monkeypatch.setattr(be_mod, "OSSBackend", _FlakyOSSBackend)
+    _FlakyOSSBackend.allow = False
+
+    prov = Mem0MemoryProvider()
+    prov._mode = "oss"
+    prov._config = {"oss": {"vector_store": {"provider": "qdrant", "config": {"path": "~/.hermes/mem0_qdrant"}}}}
+    prov._user_id = "u1"
+    prov._agent_id = "hermes"
+
+    # First initialize fails (lock held elsewhere at startup).
+    backend = prov._create_backend()[0]
+    assert backend is None, "startup init must fail while the lock is held"
+    assert prov._backend is None
+
+    # The transient condition clears (other process released the lock).
+    _FlakyOSSBackend.allow = True
+
+    # Next tool call must recover via _ensure_backend.
+    result = prov.handle_tool_call("mem0_search", {"query": "anything", "top_k": 3})
+    assert "backend not initialized" not in result.lower(), (
+        "tool call must succeed after transient failure clears"
+    )
+    assert prov._backend is not None and isinstance(prov._backend, _FlakyOSSBackend)


### PR DESCRIPTION
## Summary

Three related fixes for the mem0 memory provider plugin, all rooted in the same underlying problem: Qdrant local-path storage (the default OSS vector store) **refuses a second QdrantClient on the same folder within one process** ("already accessed by another instance"). Long-lived hosts (desktop `serve`, `gateway`) re-initialize memory providers per session, which previously created a fresh backend every time and tripped that single-instance guard — wedging mem0 until host restart.

### 1. Process-level backend cache (`_create_backend`)
All sessions in one process now share a single OSS/SelfHosted backend, keyed by config. Prevents the per-session re-initialization from creating duplicate Qdrant clients. Backends are closed once at interpreter exit via `atexit` (`_close_cached_backends`).

### 2. Lazy backend recovery (`_ensure_backend`)
If initialization fails at startup (e.g. another process holds the Qdrant lock), the provider was permanently wedged — `_backend` stayed `None` forever, requiring a full host restart. Now every tool call retries initialization (guarded by the existing circuit breaker), so the provider recovers automatically once the transient condition clears.

### 3. Mirror built-in memory writes (`on_memory_write`)
Every other memory plugin (honcho, retaindb, byterover, etc.) implements `on_memory_write`; mem0 was the only one missing it. Built-in `memory` tool `add` writes are now mirrored into mem0 verbatim (`infer=False`) so curated facts become semantically searchable. `replace`/`remove` are intentionally **not** mirrored — mem0 has no text→ID delete lookup, so mirroring them would leave stale duplicates.

## Test Plan

- 56 tests pass in `tests/plugins/memory/` (incl. new `test_mem0_backend_cache.py` and `test_mem0_mirror.py`)
- `ruff check` clean on changed files
- Manual E2E: built-in `memory` tool add → mirrored to mem0 → semantic search hit (score 0.97)