### PR TITLE
feat(api): add durable profile-scoped execution read contract v1

### DIFF
--- a/docs/ADR.md
+++ b/docs/ADR.md
@@ -25,8 +25,9 @@ Decision:
   public GET.
 - Treat the ordered event table as a transactional outbox. Terminal state,
   evidence-backed receipt, and publication events commit in one transaction.
-- Assert profile, authority, and executor identity in responses. Embed a
-  profile fingerprint in public IDs so a cross-profile identifier fails with
+- Derive profile-instance, authority, and executor identity from the active
+  scoped Hermes home, never a URL label or literal default. Embed that home
+  fingerprint in public IDs so a cross-profile identifier fails with
   `403` instead of becoming an ambiguous `404`. Bind store metadata and every
   persisted public row to that same authority so a misplaced database cannot
   be projected under a different profile.
@@ -37,6 +38,18 @@ Decision:
 - Add an optional profile-scoped `API_SERVER_READ_KEY` with only
   `execution:read`. Keep run submission, decision resolution, steering,
   stopping, and all other API authority behind the full `API_SERVER_KEY`.
+  Refuse startup if the read and full keys are equal in any served profile.
+- Enforce the execution transition graph for decision creation and closure;
+  cancellation and restart recovery close pending decisions transactionally.
+  Bind effect evidence to the latest resolved decision so an older resolution
+  cannot authorize work after a newer decision exists.
+- Pin an explicit snapshot high-water in the same read transaction as every
+  collection query and require clients to carry it across pages.
+- Allow late evidence only through a dedicated atomic reconciliation hook
+  that can publish an authoritative ambiguous receipt without upgrading the
+  execution to success.
+- Deep-validate persisted identifiers, references, digests, bindings, states,
+  revisions, and timestamp ordering before projecting any stored object.
 - Retain ordered events for 30 days by default. Prune only a contiguous global
   prefix and return `410` with an explicit minimum cursor when replay history
   is gone.

--- a/docs/ADR.md
+++ b/docs/ADR.md
@@ -25,12 +25,13 @@ Decision:
   public GET.
 - Treat the ordered event table as a transactional outbox. Terminal state,
   evidence-backed receipt, and publication events commit in one transaction.
-- Derive profile-instance, authority, and executor identity from the active
-  scoped Hermes home, never a URL label or literal default. Embed that home
-  fingerprint in public IDs so a cross-profile identifier fails with
+- Derive profile-instance, authority, and executor identity from an atomically
+  created, owner-only, versioned random anchor inside the active scoped Hermes
+  home, never from the home path, a URL label, or a literal default. Embed an
+  anchor-derived key in public IDs so a cross-profile identifier fails with
   `403` instead of becoming an ambiguous `404`. Bind store metadata and every
-  persisted public row to that same authority so a misplaced database cannot
-  be projected under a different profile.
+  persisted public row to that same authority so a database copied without
+  its complete profile home cannot be projected under a different profile.
 - Require an explicit executor evidence hook before publishing an external
   effect receipt. Generic chat, session, Kanban, tool-progress, or process-run
   completion terminates an effect-bearing execution as ambiguous and
@@ -42,17 +43,24 @@ Decision:
 - Enforce the execution transition graph for decision creation and closure;
   cancellation and restart recovery close pending decisions transactionally.
   Bind effect evidence to the latest resolved decision so an older resolution
-  cannot authorize work after a newer decision exists.
+  cannot authorize work after a newer decision exists. Serialize decision and
+  evidence creation under the same immediate transaction, and reject every new
+  decision after evidence or a receipt exists.
 - Pin an explicit snapshot high-water in the same read transaction as every
-  collection query and require clients to carry it across pages.
+  collection query and require clients to carry it across pages. Prove the
+  unfiltered global event interval is contiguous before declaring any event
+  page complete, including filtered feeds.
 - Allow late evidence only through a dedicated atomic reconciliation hook
   that can publish an authoritative ambiguous receipt without upgrading the
-  execution to success.
+  execution to success. Include the effective recovery reference in immutable
+  retry comparison.
 - Deep-validate persisted identifiers, references, digests, bindings, states,
   revisions, and timestamp ordering before projecting any stored object.
 - Retain ordered events for 30 days by default. Prune only a contiguous global
   prefix and return `410` with an explicit minimum cursor when replay history
   is gone.
+- Normalize authenticated router-level `404` and `405` failures in the default
+  and multiplex contract namespaces into the same closed error envelope.
 
 Consequences:
 - External controllers can read durable state across restart without using

--- a/docs/ADR.md
+++ b/docs/ADR.md
@@ -1,5 +1,59 @@
 # Architecture Decision Records
 
+## 2026-08-15: Durable, profile-scoped public execution read contract
+
+Status: Accepted for the Release 1 source candidate. This status records the
+architecture decision; it does not claim merge, package release, deployment,
+or runtime enablement.
+
+Context:
+Hermes exposes useful process-local run, approval, session, Kanban, and UI
+state, but none of those surfaces is a stable durable authority contract for
+an external controller. Process dictionaries disappear on restart, chat and
+session history do not prove an external effect, and operator projections may
+lag or omit lifecycle transitions. A downstream reader needs versioned,
+profile-scoped objects, detectable replay gaps, and terminal receipts that
+cannot diverge from terminal state across a crash.
+
+Decision:
+- Add the provider-neutral `hermes.execution.read.v1` contract and closed
+  packaged JSON Schema for executions, decisions, ordered events, receipts,
+  capability negotiation, and errors.
+- Store each profile's ledger at
+  `{get_hermes_home()}/execution_contract.sqlite3`. Use explicit schema
+  migration and startup recovery; use read-only SQLite connections for every
+  public GET.
+- Treat the ordered event table as a transactional outbox. Terminal state,
+  evidence-backed receipt, and publication events commit in one transaction.
+- Assert profile, authority, and executor identity in responses. Embed a
+  profile fingerprint in public IDs so a cross-profile identifier fails with
+  `403` instead of becoming an ambiguous `404`. Bind store metadata and every
+  persisted public row to that same authority so a misplaced database cannot
+  be projected under a different profile.
+- Require an explicit executor evidence hook before publishing an external
+  effect receipt. Generic chat, session, Kanban, tool-progress, or process-run
+  completion terminates an effect-bearing execution as ambiguous and
+  unproven.
+- Add an optional profile-scoped `API_SERVER_READ_KEY` with only
+  `execution:read`. Keep run submission, decision resolution, steering,
+  stopping, and all other API authority behind the full `API_SERVER_KEY`.
+- Retain ordered events for 30 days by default. Prune only a contiguous global
+  prefix and return `410` with an explicit minimum cursor when replay history
+  is gone.
+
+Consequences:
+- External controllers can read durable state across restart without using
+  Hermes internals or mutation credentials.
+- Existing `/v1/runs` remains a convenience projection and may carry a durable
+  `execution_id`, but it is not the authority store.
+- The API server refuses startup when the ledger cannot migrate or recover;
+  a failed durable write degrades the profile's read contract instead of
+  serving a healthy projection.
+- Release 2 proposal/action dispatch, WebAuthn step-up, and public decision
+  mutation remain separately gated. This decision does not authorize them.
+
+Detailed contract: [execution-read-contract-v1.md](execution-read-contract-v1.md)
+
 ## 2026-07-13: Scope plugin manager state by Hermes home/profile (keyed cache)
 
 Status: Accepted

--- a/docs/execution-read-contract-v1.md
+++ b/docs/execution-read-contract-v1.md
@@ -98,6 +98,11 @@ Before returning `completeness=complete`, every event request proves the
 unfiltered global sequence interval from `pruned_through + 1` through its
 pinned snapshot. Start, interior, and trailing gaps fail closed, including
 when the requested feed is filtered to one execution.
+Before retention deletes events or advances `pruned_through`, the same write
+transaction proves the complete global sequence from the previous watermark
+through the exact prune boundary against SQLite's independent allocation
+high-water. A start, interior, or tail gap aborts the transaction without
+deleting rows or changing the watermark.
 
 ## Execution lifecycle
 
@@ -134,7 +139,9 @@ decision; a newer pending or closed decision invalidates older authorization.
 No new decision may be created after effect evidence or a receipt exists.
 Decision requests and evidence publication share the same immediate write
 transaction boundary, so either ordering is deterministic; an exact retry of
-an already-created decision remains idempotent.
+an already-created decision remains idempotent even after its expiry or after
+effect evidence and a receipt exist. Expiry-in-the-future validation applies
+only when a genuinely new decision is created.
 
 ## Terminal receipts
 
@@ -148,6 +155,9 @@ Receipt insertion, terminal execution state, and their ordered events commit
 in one `BEGIN IMMEDIATE` transaction. Duplicate identical evidence is
 idempotent. A changed digest, effect, decision, profile, or outcome conflicts
 and fails closed.
+An ordinary receipt's `terminal_at` exactly equals the execution terminal
+timestamp. A late ambiguous reconciliation instead binds `terminal_at` to the
+authoritative effect-evidence `recorded_at` timestamp.
 
 An execution already recorded as `terminal_ambiguous`/`unproven` uses a
 separate late-reconciliation hook. It accepts only explicit authoritative

--- a/docs/execution-read-contract-v1.md
+++ b/docs/execution-read-contract-v1.md
@@ -1,0 +1,167 @@
+# Hermes execution read contract v1
+
+Status: Release 1 source contract. This document does not claim that the
+contract is merged, packaged, deployed, or enabled in any running Hermes
+installation.
+
+Contract identity: `hermes.execution.read.v1`
+
+HTTP API namespace: `/v1/execution-contract`
+
+Store schema: SQLite `PRAGMA user_version=1`
+
+## Purpose and authority
+
+This contract is Hermes's provider-neutral public read surface for execution
+lifecycle, pending decisions, ordered events, and authoritative terminal
+effect receipts. It is profile scoped. The server returns the profile,
+execution authority, and executor identities in every response; clients do
+not infer authority from a URL, model name, provider, process, or config file.
+
+The following are projections, not authoritative effect evidence:
+
+- `/v1/runs` process-local state;
+- chat output or session history;
+- Kanban rows or summaries;
+- tool progress events without an executor evidence record.
+
+An execution that references an external effect can publish a receipt only
+after an executor calls the closed internal evidence hook with the exact
+execution, effect, decision when applicable, outcome, and SHA-256 subject,
+evidence, and result digests. Generic completion without that evidence is
+stored as `terminal_ambiguous` with `receipt_state=unproven`.
+
+## Discovery and version negotiation
+
+| Method | Route | Result |
+| --- | --- | --- |
+| `GET` | `/v1/execution-contract/capabilities` | Version, asserted authority, scopes, retention, limits, and features |
+| `GET` | `/v1/execution-contract/schema` | Packaged closed JSON Schema |
+
+Clients may send `Hermes-Execution-Contract-Version` or the
+`contract_version` query parameter. Omitting both selects the only supported
+version. Supplying two different values is `400`; an unsupported version is
+`409`. Successful responses include
+`Hermes-Execution-Contract-Version: hermes.execution.read.v1` and
+`Cache-Control: no-store`.
+
+## Read routes
+
+All routes are also available under the existing multiplex prefix
+`/p/<profile>/...`. The prefix enters that profile's home and credential
+scope before the store or key is resolved.
+
+| Method | Route | Filters |
+| --- | --- | --- |
+| `GET` | `/v1/execution-contract/executions` | `after`, `limit`, `lifecycle` |
+| `GET` | `/v1/execution-contract/executions/{execution_id}` | none |
+| `GET` | `/v1/execution-contract/decisions` | `after`, `limit`, `state` |
+| `GET` | `/v1/execution-contract/decisions/{decision_id}` | none |
+| `GET` | `/v1/execution-contract/events` | `after`, `limit`, `execution_id` |
+| `GET` | `/v1/execution-contract/receipts` | `after`, `limit`, `outcome` |
+| `GET` | `/v1/execution-contract/receipts/{receipt_id}` | none |
+
+`limit` is 1 through 200. Collection order is immutable creation order. Event
+order is the store-assigned monotonic `sequence`, not client or wall-clock
+order.
+
+Every collection returns:
+
+- `cursor`: the last sequence/ordinal covered by the response;
+- `high_water`: the newest durable sequence/ordinal at read time;
+- `minimum_available`: the earliest retained position;
+- `has_more`: whether another page exists within this snapshot;
+- `completeness=complete`: returned only when the ledger is trustworthy.
+
+The event page also returns `pruned_through` and
+`retention_seconds=2592000`. Events form a transactional outbox and are kept
+for 30 days by default. Pruning advances only across a contiguous global
+prefix, so no retained event can be hidden behind the watermark. A cursor
+older than retained history returns `410` with the new minimum and high-water;
+a cursor ahead of high-water returns `409`.
+
+## Execution lifecycle
+
+Initial states are `accepted`, `queued`, or `running`. The closed lifecycle
+set is:
+
+`accepted`, `queued`, `running`, `awaiting_decision`,
+`cancellation_requested`, `terminal_succeeded`, `terminal_failed`,
+`terminal_cancelled`, `terminal_partial`, and `terminal_ambiguous`.
+
+`execution_id` and its work, proposal, and effect references are immutable.
+An `effect_id` requires both `work_ref` and `proposal_ref`. `revision` is the
+optimistic concurrency token. `created_at`, `started_at`, `updated_at`, and
+`terminal_at` are RFC 3339 UTC timestamps. Nonterminal data from a prior
+runtime is reported `stale` until startup recovery closes it as
+`terminal_ambiguous`; it is never projected as healthy or successful.
+
+## Decisions
+
+A decision has an immutable `decision_id` and exact execution, effect, and
+proposal binding. It includes allowed choices, request digest, optional
+candidate and policy digests, expiry, state, resolution evidence, timestamps,
+and revision. States are `pending`, `resolved`, `expired`, and `superseded`.
+
+One execution may have only one pending decision at a time. Resolution is
+idempotent only for the exact same choice and evidence. Expiry terminates the
+waiting execution as ambiguous. Any other terminal transition supersedes its
+pending decision transactionally.
+
+## Terminal receipts
+
+Receipt outcomes are `succeeded`, `failed`, `cancelled`, `partial`, and
+`ambiguous`. A receipt contains immutable receipt, execution, and effect IDs;
+asserted profile, authority, and executor IDs; subject, evidence, and result
+digests; terminal time; exact decision binding when applicable; optional
+recovery/reconciliation references; and immutable `revision=1`.
+
+Receipt insertion, terminal execution state, and their ordered events commit
+in one `BEGIN IMMEDIATE` transaction. Duplicate identical evidence is
+idempotent. A changed digest, effect, decision, profile, or outcome conflicts
+and fails closed.
+
+## Authentication and errors
+
+`API_SERVER_KEY` retains full API authority. A distinct optional
+`API_SERVER_READ_KEY` grants only `execution:read` for `/v1/capabilities` and
+`GET /v1/execution-contract/*`. The read key receives `403` for run submission,
+decision resolution, steering, stopping, chat/responses, unrelated reads, and
+all other mutation paths. Both keys are profile scoped and must pass the same
+minimum-strength guard. Reads never create or migrate the database.
+
+Contract errors use a closed JSON shape and these statuses:
+
+| Status | Meaning |
+| --- | --- |
+| `400` | malformed input or unknown closed value |
+| `401` | missing or invalid bearer token |
+| `403` | scope denial or cross-profile identifier |
+| `404` | scoped object does not exist |
+| `409` | version, revision, binding, lifecycle, or cursor conflict |
+| `410` | cursor points into pruned history |
+| `429` | ledger is busy; response includes `Retry-After` |
+| `500` | persisted contract data is corrupt or an internal invariant failed |
+| `503` | ledger is unavailable or the profile is degraded after a failed write |
+
+Server error details are not returned to clients.
+
+## Persistence and migration
+
+Each profile owns `{get_hermes_home()}/execution_contract.sqlite3`. Schema
+creation is an explicit, atomic migration performed before the HTTP listener
+starts. Store metadata and every public row are bound to the exact asserted
+profile, authority, and executor where applicable; a misplaced ledger fails
+closed. Public reads open the existing file with SQLite `mode=ro` and
+`query_only=ON`; a missing ledger returns an empty complete collection without
+creating a file. Startup rejects an unknown store or contract version, recovers
+orphaned nonterminal executions, expires decisions, and applies event
+retention before accepting reads.
+
+## Release 2 hold
+
+Release 1 does not add proposal submission, general action dispatch,
+WebAuthn/step-up authorization, public decision mutation, executor delegation,
+or recovery mutation routes. The capability document advertises
+`webauthn_decisions=false` and `action_dispatch=false`. Those features require
+a separate accepted decision and action-contract release.

--- a/docs/execution-read-contract-v1.md
+++ b/docs/execution-read-contract-v1.md
@@ -18,6 +18,11 @@ effect receipts. It is profile scoped. The server returns the profile,
 execution authority, and executor identities in every response; clients do
 not infer authority from a URL, model name, provider, process, or config file.
 
+Authority IDs are derived from a fingerprint of the active scoped
+`get_hermes_home()` profile instance and bound into ledger metadata. A URL
+profile label is routing context only; it cannot assert authority. Moving a
+ledger to another profile home fails closed.
+
 The following are projections, not authoritative effect evidence:
 
 - `/v1/runs` process-local state;
@@ -53,12 +58,12 @@ scope before the store or key is resolved.
 
 | Method | Route | Filters |
 | --- | --- | --- |
-| `GET` | `/v1/execution-contract/executions` | `after`, `limit`, `lifecycle` |
+| `GET` | `/v1/execution-contract/executions` | `after`, `limit`, `lifecycle`, `snapshot_high_water` |
 | `GET` | `/v1/execution-contract/executions/{execution_id}` | none |
-| `GET` | `/v1/execution-contract/decisions` | `after`, `limit`, `state` |
+| `GET` | `/v1/execution-contract/decisions` | `after`, `limit`, `state`, `snapshot_high_water` |
 | `GET` | `/v1/execution-contract/decisions/{decision_id}` | none |
-| `GET` | `/v1/execution-contract/events` | `after`, `limit`, `execution_id` |
-| `GET` | `/v1/execution-contract/receipts` | `after`, `limit`, `outcome` |
+| `GET` | `/v1/execution-contract/events` | `after`, `limit`, `execution_id`, `snapshot_high_water` |
+| `GET` | `/v1/execution-contract/receipts` | `after`, `limit`, `outcome`, `snapshot_high_water` |
 | `GET` | `/v1/execution-contract/receipts/{receipt_id}` | none |
 
 `limit` is 1 through 200. Collection order is immutable creation order. Event
@@ -69,9 +74,15 @@ Every collection returns:
 
 - `cursor`: the last sequence/ordinal covered by the response;
 - `high_water`: the newest durable sequence/ordinal at read time;
+- `snapshot_high_water`: the immutable upper bound for this page sequence;
 - `minimum_available`: the earliest retained position;
 - `has_more`: whether another page exists within this snapshot;
 - `completeness=complete`: returned only when the ledger is trustworthy.
+
+The first page pins `snapshot_high_water` in the same SQLite read transaction
+as row selection. Clients carry it unchanged to later pages. Every query is
+bounded by that snapshot, so concurrent inserts cannot skip or duplicate
+items. A snapshot ahead of durable state or behind its cursor is `409`.
 
 The event page also returns `pruned_through` and
 `retention_seconds=2592000`. Events form a transactional outbox and are kept
@@ -107,6 +118,11 @@ One execution may have only one pending decision at a time. Resolution is
 idempotent only for the exact same choice and evidence. Expiry terminates the
 waiting execution as ambiguous. Any other terminal transition supersedes its
 pending decision transactionally.
+Cancellation and restart recovery also supersede pending decisions in the
+same transaction. Create, resolve, and supersede operations enforce the
+execution transition graph and cannot revive a cancelling or terminal
+execution. Effect evidence is accepted only against the latest resolved
+decision; a newer pending or closed decision invalidates older authorization.
 
 ## Terminal receipts
 
@@ -121,6 +137,12 @@ in one `BEGIN IMMEDIATE` transaction. Duplicate identical evidence is
 idempotent. A changed digest, effect, decision, profile, or outcome conflicts
 and fails closed.
 
+An execution already recorded as `terminal_ambiguous`/`unproven` uses a
+separate late-reconciliation hook. It accepts only explicit authoritative
+`ambiguous` evidence with a reconciliation reference and atomically records
+evidence, publishes the receipt, updates the execution, and appends both
+events. It cannot upgrade ambiguity to success.
+
 ## Authentication and errors
 
 `API_SERVER_KEY` retains full API authority. A distinct optional
@@ -128,7 +150,9 @@ and fails closed.
 `GET /v1/execution-contract/*`. The read key receives `403` for run submission,
 decision resolution, steering, stopping, chat/responses, unrelated reads, and
 all other mutation paths. Both keys are profile scoped and must pass the same
-minimum-strength guard. Reads never create or migrate the database.
+minimum-strength guard. Startup fails if the two keys are equal for the
+default or any served named/multiplex profile. Reads never create or migrate
+the database.
 
 Contract errors use a closed JSON shape and these statuses:
 
@@ -156,7 +180,10 @@ closed. Public reads open the existing file with SQLite `mode=ro` and
 `query_only=ON`; a missing ledger returns an empty complete collection without
 creating a file. Startup rejects an unknown store or contract version, recovers
 orphaned nonterminal executions, expires decisions, and applies event
-retention before accepting reads.
+retention before accepting reads. Each returned persisted object is deeply
+validated for scoped IDs, references, digests, bindings, lifecycle/receipt
+combinations, revisions, and timestamp ordering before HTTP `200`; corruption
+returns the closed `500 execution_contract_corrupt` envelope.
 
 ## Release 2 hold
 

--- a/docs/execution-read-contract-v1.md
+++ b/docs/execution-read-contract-v1.md
@@ -100,9 +100,10 @@ pinned snapshot. Start, interior, and trailing gaps fail closed, including
 when the requested feed is filtered to one execution.
 Before retention deletes events or advances `pruned_through`, the same write
 transaction proves the complete global sequence from the previous watermark
-through the exact prune boundary against SQLite's independent allocation
-high-water. A start, interior, or tail gap aborts the transaction without
-deleting rows or changing the watermark.
+through SQLite's independent allocation high-water. Only after the complete
+retained suffix passes that check does the transaction select a prunable
+prefix. A start, interior, or tail gap anywhere in the allocated interval
+aborts without deleting rows or changing the watermark.
 
 ## Execution lifecycle
 

--- a/docs/execution-read-contract-v1.md
+++ b/docs/execution-read-contract-v1.md
@@ -18,10 +18,14 @@ effect receipts. It is profile scoped. The server returns the profile,
 execution authority, and executor identities in every response; clients do
 not infer authority from a URL, model name, provider, process, or config file.
 
-Authority IDs are derived from a fingerprint of the active scoped
-`get_hermes_home()` profile instance and bound into ledger metadata. A URL
-profile label is routing context only; it cannot assert authority. Moving a
-ledger to another profile home fails closed.
+Authority IDs are derived from a versioned random profile-instance anchor,
+created atomically with owner-only permissions inside the active scoped
+`get_hermes_home()`, and bound into ledger metadata. They never encode or hash
+the filesystem path. A URL profile label is routing context only; it cannot
+assert authority. Moving or restoring the complete profile home preserves the
+anchor and authority; copying only the ledger into another home fails closed
+against that home's different anchor. An existing ledger with a missing,
+corrupt, mismatched, or permission-unsafe anchor is unavailable.
 
 The following are projections, not authoritative effect evidence:
 
@@ -90,6 +94,10 @@ for 30 days by default. Pruning advances only across a contiguous global
 prefix, so no retained event can be hidden behind the watermark. A cursor
 older than retained history returns `410` with the new minimum and high-water;
 a cursor ahead of high-water returns `409`.
+Before returning `completeness=complete`, every event request proves the
+unfiltered global sequence interval from `pruned_through + 1` through its
+pinned snapshot. Start, interior, and trailing gaps fail closed, including
+when the requested feed is filtered to one execution.
 
 ## Execution lifecycle
 
@@ -123,6 +131,10 @@ same transaction. Create, resolve, and supersede operations enforce the
 execution transition graph and cannot revive a cancelling or terminal
 execution. Effect evidence is accepted only against the latest resolved
 decision; a newer pending or closed decision invalidates older authorization.
+No new decision may be created after effect evidence or a receipt exists.
+Decision requests and evidence publication share the same immediate write
+transaction boundary, so either ordering is deterministic; an exact retry of
+an already-created decision remains idempotent.
 
 ## Terminal receipts
 
@@ -142,6 +154,9 @@ separate late-reconciliation hook. It accepts only explicit authoritative
 `ambiguous` evidence with a reconciliation reference and atomically records
 evidence, publishes the receipt, updates the execution, and appends both
 events. It cannot upgrade ambiguity to success.
+The effective recovery reference is part of the immutable retry identity:
+identical reconciliation retries return the existing receipt and a changed
+recovery reference conflicts.
 
 ## Authentication and errors
 
@@ -162,21 +177,26 @@ Contract errors use a closed JSON shape and these statuses:
 | `401` | missing or invalid bearer token |
 | `403` | scope denial or cross-profile identifier |
 | `404` | scoped object does not exist |
+| `405` | authenticated contract route does not support the method |
 | `409` | version, revision, binding, lifecycle, or cursor conflict |
 | `410` | cursor points into pruned history |
 | `429` | ledger is busy; response includes `Retry-After` |
 | `500` | persisted contract data is corrupt or an internal invariant failed |
 | `503` | ledger is unavailable or the profile is degraded after a failed write |
 
-Server error details are not returned to clients.
+Server error details are not returned to clients. Router-level `404` and `405`
+responses inside both the default and `/p/<profile>/` contract namespaces use
+this same closed envelope after authentication. Non-contract aiohttp routing
+behavior is unchanged.
 
 ## Persistence and migration
 
 Each profile owns `{get_hermes_home()}/execution_contract.sqlite3`. Schema
 creation is an explicit, atomic migration performed before the HTTP listener
-starts. Store metadata and every public row are bound to the exact asserted
-profile, authority, and executor where applicable; a misplaced ledger fails
-closed. Public reads open the existing file with SQLite `mode=ro` and
+starts. Profile-anchor initialization is separate from the ledger and is also
+completed before reads are accepted. Store metadata and every public row are
+bound to the exact asserted profile, authority, and executor where applicable;
+a misplaced ledger fails closed. Public reads open the existing file with SQLite `mode=ro` and
 `query_only=ON`; a missing ledger returns an empty complete collection without
 creating a file. Startup rejects an unknown store or contract version, recovers
 orphaned nonterminal executions, expires decisions, and applies event

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -1540,8 +1540,8 @@ def load_gateway_config() -> GatewayConfig:
                 if _nested_platforms:
                     _merge_platform_map(_nested_platforms)
 
-            # Bridge api_server-specific keys (port, key, host, cors_origins,
-            # model_name) into extra so PlatformConfig.from_dict preserves
+            # Bridge api_server-specific keys (port, key, read_key, host,
+            # cors_origins, model_name) into extra so PlatformConfig.from_dict preserves
             # them — adapting what _apply_env_overrides does for env vars to
             # the YAML path.  Users writing ``gateway.api_server.port: 8642``
             # expect these to end up in the platform's extra dict.
@@ -1551,7 +1551,14 @@ def load_gateway_config() -> GatewayConfig:
                 if not isinstance(_api_extra, dict):
                     _api_extra = {}
                     _api_plat["extra"] = _api_extra
-                for _bridge_key in ("port", "key", "host", "cors_origins", "model_name"):
+                for _bridge_key in (
+                    "port",
+                    "key",
+                    "read_key",
+                    "host",
+                    "cors_origins",
+                    "model_name",
+                ):
                     if _bridge_key in _api_plat and _bridge_key not in _api_extra:
                         _api_extra[_bridge_key] = _api_plat.pop(_bridge_key)
 
@@ -2201,6 +2208,7 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
 
     # API Server
     api_server_key = getenv("API_SERVER_KEY", "")
+    api_server_read_key = getenv("API_SERVER_READ_KEY", "")
     api_server_cors_origins = getenv("API_SERVER_CORS_ORIGINS", "")
     api_server_port = getenv("API_SERVER_PORT")
     api_server_host = getenv("API_SERVER_HOST")
@@ -2227,6 +2235,8 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
             config.platforms[Platform.API_SERVER].enabled = True
         if api_server_key:
             config.platforms[Platform.API_SERVER].extra["key"] = api_server_key
+        if api_server_read_key:
+            config.platforms[Platform.API_SERVER].extra["read_key"] = api_server_read_key
         if api_server_cors_origins:
             origins = [origin.strip() for origin in api_server_cors_origins.split(",") if origin.strip()]
             if origins:

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -1834,20 +1834,26 @@ class APIServerAdapter(BasePlatformAdapter):
         return path
 
     @staticmethod
+    def _is_execution_contract_namespace_path(path: str) -> bool:
+        return path == "/v1/execution-contract" or path.startswith(
+            "/v1/execution-contract/"
+        )
+
+    @staticmethod
     def _read_key_path_allowed(request: "web.Request") -> bool:
         """True only for Release 1 contract reads and capability negotiation."""
         if request.method != "GET":
             return False
         path = APIServerAdapter._request_path(request)
-        return path == "/v1/capabilities" or path.startswith(
-            "/v1/execution-contract/"
+        return path == "/v1/capabilities" or (
+            APIServerAdapter._is_execution_contract_namespace_path(path)
         )
 
     @staticmethod
     def _is_execution_contract_public_request(request: "web.Request") -> bool:
         path = APIServerAdapter._request_path(request)
-        return path == "/v1/capabilities" or path.startswith(
-            "/v1/execution-contract/"
+        return path == "/v1/capabilities" or (
+            APIServerAdapter._is_execution_contract_namespace_path(path)
         )
 
     def _execution_contract_auth_response(
@@ -2125,6 +2131,14 @@ class APIServerAdapter(BasePlatformAdapter):
         """
         profile = (request.match_info.get("profile") or "").strip()
         if not profile:
+            raw_path = getattr(request, "path", "")
+            if isinstance(raw_path, str) and raw_path.startswith("/p/"):
+                parts = raw_path.split("/", 3)
+                if len(parts) == 4:
+                    profile = parts[2].strip()
+                if not profile and self._is_execution_contract_public_request(request):
+                    return _PROFILE_REJECTED
+        if not profile:
             return None
         runner = getattr(self, "gateway_runner", None)
         cfg = getattr(runner, "config", None)
@@ -2189,6 +2203,9 @@ class APIServerAdapter(BasePlatformAdapter):
                 if self._is_execution_contract_public_request(request):
                     from hermes_cli.execution_contract import ContractNotFoundError
 
+                    auth_err = self._check_auth(request)
+                    if auth_err:
+                        return auth_err
                     return self._execution_contract_error_response(
                         ContractNotFoundError("profile is unknown or unconfigured")
                     )
@@ -2204,6 +2221,42 @@ class APIServerAdapter(BasePlatformAdapter):
                 _api_request_profile.reset(token)
 
         return profile_prefix_middleware
+
+    def _make_execution_contract_router_error_middleware(self):
+        """Close authenticated 404/405 responses inside the contract namespace."""
+
+        @web.middleware
+        async def execution_contract_router_error_middleware(
+            request: "web.Request",
+            handler,
+        ):
+            try:
+                return await handler(request)
+            except (web.HTTPNotFound, web.HTTPMethodNotAllowed) as exc:
+                if not self._is_execution_contract_namespace_path(
+                    self._request_path(request)
+                ):
+                    raise
+                auth_err = self._check_auth(request)
+                if auth_err:
+                    return auth_err
+                if isinstance(exc, web.HTTPMethodNotAllowed):
+                    from hermes_cli.execution_contract import (
+                        ContractMethodNotAllowedError,
+                    )
+
+                    return self._execution_contract_error_response(
+                        ContractMethodNotAllowedError(
+                            "method is not allowed in the execution contract namespace"
+                        )
+                    )
+                from hermes_cli.execution_contract import ContractNotFoundError
+
+                return self._execution_contract_error_response(
+                    ContractNotFoundError("execution contract route not found")
+                )
+
+        return execution_contract_router_error_middleware
 
     def _http_route_table(self) -> List[tuple]:
         """Return (method, path, handler) rows registered by ``connect()``.
@@ -3356,6 +3409,7 @@ class APIServerAdapter(BasePlatformAdapter):
             ContractCursorGoneError,
             ContractDataError,
             ContractForbiddenError,
+            ContractMethodNotAllowedError,
             ContractNotFoundError,
             ContractRateLimitedError,
             ContractUnauthorizedError,
@@ -3377,6 +3431,8 @@ class APIServerAdapter(BasePlatformAdapter):
             status, code = 403, "execution_contract_profile_forbidden"
         elif isinstance(exc, ContractNotFoundError):
             status, code = 404, "execution_contract_not_found"
+        elif isinstance(exc, ContractMethodNotAllowedError):
+            status, code = 405, "execution_contract_method_not_allowed"
         elif isinstance(exc, (ContractConflictError, UnsupportedContractVersionError)):
             status, code = 409, "execution_contract_conflict"
         elif isinstance(exc, ContractCursorGoneError):
@@ -8511,6 +8567,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 mw
                 for mw in (
                     self._make_profile_prefix_middleware(),
+                    self._make_execution_contract_router_error_middleware(),
                     cors_middleware,
                     body_limit_middleware,
                     security_headers_middleware,

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -1822,17 +1822,51 @@ class APIServerAdapter(BasePlatformAdapter):
             return ""
 
     @staticmethod
+    def _request_path(request: "web.Request") -> str:
+        """Return the request path for aiohttp and narrow auth-test doubles."""
+        path = getattr(request, "path", None)
+        if not isinstance(path, str):
+            path_qs = getattr(request, "path_qs", "")
+            path = path_qs.split("?", 1)[0] if isinstance(path_qs, str) else ""
+        if path.startswith("/p/"):
+            parts = path.split("/", 3)
+            path = f"/{parts[3]}" if len(parts) == 4 else "/"
+        return path
+
+    @staticmethod
     def _read_key_path_allowed(request: "web.Request") -> bool:
         """True only for Release 1 contract reads and capability negotiation."""
         if request.method != "GET":
             return False
-        path = request.path
-        if path.startswith("/p/"):
-            parts = path.split("/", 3)
-            path = f"/{parts[3]}" if len(parts) == 4 else "/"
+        path = APIServerAdapter._request_path(request)
         return path == "/v1/capabilities" or path.startswith(
             "/v1/execution-contract/"
         )
+
+    @staticmethod
+    def _is_execution_contract_public_request(request: "web.Request") -> bool:
+        path = APIServerAdapter._request_path(request)
+        return path == "/v1/capabilities" or path.startswith(
+            "/v1/execution-contract/"
+        )
+
+    def _execution_contract_auth_response(
+        self,
+        *,
+        status: int,
+        message: str,
+    ) -> "web.Response":
+        from hermes_cli.execution_contract import (
+            ContractForbiddenError,
+            ContractUnauthorizedError,
+        )
+
+        error = (
+            ContractUnauthorizedError(message)
+            if status == 401
+            else ContractForbiddenError(message)
+        )
+        return self._execution_contract_error_response(error)
 
     def _check_auth(self, request: "web.Request") -> Optional["web.Response"]:
         """
@@ -1846,6 +1880,29 @@ class APIServerAdapter(BasePlatformAdapter):
         is_named_profile = bool(profile and profile != "default")
         expected_key = self._expected_api_key()
         expected_read_key = self._expected_read_api_key()
+        contract_request = self._is_execution_contract_public_request(request)
+        if expected_key and expected_read_key and hmac.compare_digest(
+            expected_key.encode(),
+            expected_read_key.encode(),
+        ):
+            if contract_request:
+                from hermes_cli.execution_contract import ContractUnavailableError
+
+                return self._execution_contract_error_response(
+                    ContractUnavailableError(
+                        "execution contract credentials are misconfigured"
+                    )
+                )
+            return web.json_response(
+                {
+                    "error": {
+                        "message": "Gateway API credentials are misconfigured",
+                        "type": "gateway_auth_error",
+                        "code": "gateway_auth_misconfigured",
+                    }
+                },
+                status=503,
+            )
         if not expected_key and not expected_read_key:
             # Preserve the historical no-key test/manual-wiring behavior only
             # for the default listener. Named profiles must fail closed rather
@@ -1858,6 +1915,11 @@ class APIServerAdapter(BasePlatformAdapter):
                 profile,
                 self._request_audit_log_suffix(request),
             )
+            if contract_request:
+                return self._execution_contract_auth_response(
+                    status=401,
+                    message="Execution contract bearer token is invalid",
+                )
             return web.json_response(
                 {
                     "error": {
@@ -1889,6 +1951,11 @@ class APIServerAdapter(BasePlatformAdapter):
             ):
                 if self._read_key_path_allowed(request):
                     return None
+                if contract_request:
+                    return self._execution_contract_auth_response(
+                        status=403,
+                        message="Bearer token lacks the required contract scope",
+                    )
                 return web.json_response(
                     {
                         "error": {
@@ -1906,6 +1973,11 @@ class APIServerAdapter(BasePlatformAdapter):
             "API server rejected invalid API key: %s",
             self._request_audit_log_suffix(request),
         )
+        if contract_request:
+            return self._execution_contract_auth_response(
+                status=401,
+                message="Execution contract bearer token is invalid",
+            )
         return web.json_response(
             {"error": {"message": "Invalid gateway API key (API_SERVER_KEY)", "type": "gateway_auth_error", "code": "gateway_auth_failed"}},
             status=401,
@@ -2114,6 +2186,12 @@ class APIServerAdapter(BasePlatformAdapter):
         async def profile_prefix_middleware(request: "web.Request", handler):
             profile = self._resolve_request_profile(request)
             if profile is _PROFILE_REJECTED:
+                if self._is_execution_contract_public_request(request):
+                    from hermes_cli.execution_contract import ContractNotFoundError
+
+                    return self._execution_contract_error_response(
+                        ContractNotFoundError("profile is unknown or unconfigured")
+                    )
                 return web.json_response(
                     {"error": "Unknown or unconfigured profile"},
                     status=404,
@@ -3241,9 +3319,10 @@ class APIServerAdapter(BasePlatformAdapter):
 
     def _execution_contract_store(self):
         from hermes_cli.execution_contract import ExecutionContractStore
+        from hermes_constants import get_hermes_home
 
         return ExecutionContractStore(
-            profile_name=self._execution_contract_profile_name(),
+            profile_home=get_hermes_home(),
             runtime_instance_id=self._execution_contract_runtime_id,
         )
 
@@ -3279,6 +3358,7 @@ class APIServerAdapter(BasePlatformAdapter):
             ContractForbiddenError,
             ContractNotFoundError,
             ContractRateLimitedError,
+            ContractUnauthorizedError,
             ContractUnavailableError,
             ContractValidationError,
             UnsupportedContractVersionError,
@@ -3288,7 +3368,10 @@ class APIServerAdapter(BasePlatformAdapter):
         code = "execution_contract_internal_error"
         details: dict[str, Any] = {}
         headers = {"Hermes-Execution-Contract-Version": CONTRACT_VERSION}
-        if isinstance(exc, ContractValidationError):
+        headers["Cache-Control"] = "no-store"
+        if isinstance(exc, ContractUnauthorizedError):
+            status, code = 401, "execution_contract_unauthorized"
+        elif isinstance(exc, ContractValidationError):
             status, code = 400, "execution_contract_invalid_request"
         elif isinstance(exc, ContractForbiddenError):
             status, code = 403, "execution_contract_profile_forbidden"
@@ -3366,8 +3449,13 @@ class APIServerAdapter(BasePlatformAdapter):
             return guard
         from hermes_cli.execution_contract import contract_capabilities
 
+        store = self._execution_contract_store()
+
         return web.json_response(
-            contract_capabilities(self._execution_contract_profile_name()),
+            contract_capabilities(
+                store.profile_home,
+                store.authority.profile_name,
+            ),
             headers=self._execution_contract_headers(),
         )
 
@@ -3418,6 +3506,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 after=request.query.get("after", 0),
                 limit=request.query.get("limit", 50),
                 lifecycle=request.query.get("lifecycle"),
+                snapshot_high_water=request.query.get("snapshot_high_water"),
             )
             return web.json_response(
                 self._execution_contract_envelope(
@@ -3460,6 +3549,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 after=request.query.get("after", 0),
                 limit=request.query.get("limit", 50),
                 state=request.query.get("state"),
+                snapshot_high_water=request.query.get("snapshot_high_water"),
             )
             return web.json_response(
                 self._execution_contract_envelope(
@@ -3502,6 +3592,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 after=request.query.get("after", 0),
                 limit=request.query.get("limit", 50),
                 execution_id=request.query.get("execution_id"),
+                snapshot_high_water=request.query.get("snapshot_high_water"),
             )
             return web.json_response(
                 self._execution_contract_envelope(
@@ -3526,6 +3617,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 after=request.query.get("after", 0),
                 limit=request.query.get("limit", 50),
                 outcome=request.query.get("outcome"),
+                snapshot_high_water=request.query.get("snapshot_high_water"),
             )
             return web.json_response(
                 self._execution_contract_envelope(
@@ -7323,7 +7415,20 @@ class APIServerAdapter(BasePlatformAdapter):
                 run_id
             )
             execution_id = execution["execution_id"]
-        return self._execution_contract_store().record_effect_evidence(
+        store = self._execution_contract_store()
+        if reconciliation_ref is not None:
+            return store.reconcile_ambiguous_evidence(
+                execution_id=execution_id,
+                effect_id=effect_id,
+                outcome=outcome,
+                subject_digest=subject_digest,
+                evidence_digest=evidence_digest,
+                result_digest=result_digest,
+                decision_id=decision_id,
+                recovery_ref=recovery_ref,
+                reconciliation_ref=reconciliation_ref,
+            )
+        return store.record_effect_evidence(
             execution_id=execution_id,
             effect_id=effect_id,
             outcome=outcome,
@@ -8240,9 +8345,7 @@ class APIServerAdapter(BasePlatformAdapter):
         return True
 
     def _read_api_key_passes_startup_guard(self) -> bool:
-        """Reject a configured read-only key that is weak or placeholder-like."""
-        if not self._read_api_key:
-            return True
+        """Validate read keys and reject equality for every served profile."""
         try:
             from hermes_cli.auth import has_usable_secret
         except Exception as exc:
@@ -8253,13 +8356,50 @@ class APIServerAdapter(BasePlatformAdapter):
                 type(exc).__name__,
             )
             return False
-        if not has_usable_secret(self._read_api_key, min_length=16):
-            logger.error(
-                "[%s] Refusing to start: API_SERVER_READ_KEY is a placeholder "
-                "or too short (<16 chars)",
-                self.name,
-            )
-            return False
+        for profile in self._execution_contract_profiles():
+            token = _api_request_profile.set(profile)
+            try:
+                with self._profile_scope(profile):
+                    if not profile or profile == "default":
+                        full_key = self._api_key or ""
+                        read_key = self._read_api_key or ""
+                    else:
+                        from agent.secret_scope import get_secret
+
+                        full_key = get_secret("API_SERVER_KEY", "") or ""
+                        read_key = get_secret("API_SERVER_READ_KEY", "") or ""
+            except Exception as exc:
+                logger.error(
+                    "[%s] Refusing to start: profile-scoped API keys could not "
+                    "be resolved for %r (%s)",
+                    self.name,
+                    profile or "default",
+                    type(exc).__name__,
+                )
+                return False
+            finally:
+                _api_request_profile.reset(token)
+            if not read_key:
+                continue
+            if not has_usable_secret(read_key, min_length=16):
+                logger.error(
+                    "[%s] Refusing to start: API_SERVER_READ_KEY is a placeholder "
+                    "or too short (<16 chars) for profile %r",
+                    self.name,
+                    profile or "default",
+                )
+                return False
+            if full_key and hmac.compare_digest(
+                full_key.encode(),
+                read_key.encode(),
+            ):
+                logger.error(
+                    "[%s] Refusing to start: API_SERVER_READ_KEY must differ "
+                    "from API_SERVER_KEY for profile %r",
+                    self.name,
+                    profile or "default",
+                )
+                return False
         return True
 
     def _execution_contract_profiles(self) -> list[Optional[str]]:

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -20,13 +20,21 @@ Exposes an HTTP server with endpoints:
 - POST /v1/runs/{run_id}/approval — resolve a pending run approval
 - POST /v1/runs/{run_id}/steer      — inject guidance into a running agent
 - POST /v1/runs/{run_id}/stop       — interrupt a running agent
+- GET  /v1/execution-contract/capabilities — version and authority negotiation
+- GET  /v1/execution-contract/schema — closed Release 1 JSON Schema
+- GET  /v1/execution-contract/executions[/<id>] — durable execution reads
+- GET  /v1/execution-contract/decisions[/<id>] — durable decision reads
+- GET  /v1/execution-contract/events — ordered restart-safe event feed
+- GET  /v1/execution-contract/receipts[/<id>] — authoritative receipt reads
 - GET  /health                     — health check
 - GET  /health/detailed            — rich status for cross-container dashboard probing
 
 Any OpenAI-compatible frontend (Open WebUI, LobeChat, LibreChat,
 AnythingLLM, NextChat, ChatBox, etc.) can connect to hermes-agent
 through this adapter by pointing at http://localhost:8642/v1 and
-authenticating with API_SERVER_KEY.
+authenticating with API_SERVER_KEY. Read-only execution consumers may instead
+use API_SERVER_READ_KEY, which is accepted only for capability discovery and
+the versioned execution-contract GET routes.
 
 When ``gateway.multiplex_profiles`` is on, the default profile owns this
 listener and secondary profiles are reached via a URL prefix — same contract
@@ -57,6 +65,7 @@ import sys
 import threading
 import time
 import uuid
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
@@ -1381,6 +1390,10 @@ class APIServerAdapter(BasePlatformAdapter):
             raw_port = os.getenv("API_SERVER_PORT", str(DEFAULT_PORT))
         self._port: int = _coerce_port(raw_port, DEFAULT_PORT)
         self._api_key: str = extra.get("key", _get_scoped_secret("API_SERVER_KEY", ""))
+        self._read_api_key: str = extra.get(
+            "read_key",
+            _get_scoped_secret("API_SERVER_READ_KEY", ""),
+        )
         self._cors_origins: tuple[str, ...] = self._parse_cors_origins(
             extra.get("cors_origins", os.getenv("API_SERVER_CORS_ORIGINS", "")),
         )
@@ -1436,6 +1449,13 @@ class APIServerAdapter(BasePlatformAdapter):
         # resolves requests by session key, while API clients address the
         # in-flight run by run_id.
         self._run_approval_sessions: Dict[str, str] = {}
+        # Release 1 durable execution contract.  Runtime maps only correlate
+        # legacy /v1/runs handles with durable IDs; the SQLite ledger remains
+        # authoritative and survives restart.
+        self._execution_contract_runtime_id = uuid.uuid4().hex
+        self._run_execution_ids: Dict[str, str] = {}
+        self._run_decision_ids: Dict[str, Dict[str, str]] = {}
+        self._execution_contract_degraded_profiles: set[str] = set()
         self._session_db: Optional[Any] = None  # Lazy-init SessionDB for session continuity
         self._session_dbs: Dict[str, Any] = {}
         self._session_db_cache_lock = threading.Lock()
@@ -1779,6 +1799,41 @@ class APIServerAdapter(BasePlatformAdapter):
             )
             return ""
 
+    def _expected_read_api_key(self) -> str:
+        """Return the profile-scoped execution:read bearer key, if configured."""
+        profile = _api_request_profile.get()
+        try:
+            from hermes_cli.auth import has_usable_secret
+
+            if not profile or profile == "default":
+                key = self._read_api_key or ""
+            else:
+                from agent.secret_scope import get_secret
+
+                key = get_secret("API_SERVER_READ_KEY", "") or ""
+            return key if has_usable_secret(key, min_length=16) else ""
+        except Exception as exc:
+            logger.warning(
+                "Failed to resolve a usable profile-scoped API_SERVER_READ_KEY "
+                "for %r: %s",
+                profile,
+                type(exc).__name__,
+            )
+            return ""
+
+    @staticmethod
+    def _read_key_path_allowed(request: "web.Request") -> bool:
+        """True only for Release 1 contract reads and capability negotiation."""
+        if request.method != "GET":
+            return False
+        path = request.path
+        if path.startswith("/p/"):
+            parts = path.split("/", 3)
+            path = f"/{parts[3]}" if len(parts) == 4 else "/"
+        return path == "/v1/capabilities" or path.startswith(
+            "/v1/execution-contract/"
+        )
+
     def _check_auth(self, request: "web.Request") -> Optional["web.Response"]:
         """
         Validate Bearer token from Authorization header.
@@ -1790,7 +1845,8 @@ class APIServerAdapter(BasePlatformAdapter):
         profile = _api_request_profile.get()
         is_named_profile = bool(profile and profile != "default")
         expected_key = self._expected_api_key()
-        if not expected_key:
+        expected_read_key = self._expected_read_api_key()
+        if not expected_key and not expected_read_key:
             # Preserve the historical no-key test/manual-wiring behavior only
             # for the default listener. Named profiles must fail closed rather
             # than inherit the listener owner's key.
@@ -1822,8 +1878,29 @@ class APIServerAdapter(BasePlatformAdapter):
             # otherwise crash this handler (500) instead of returning a clean
             # 401. Encoding both sides keeps the timing-safe comparison and
             # matches web_server.py's dashboard-token check.
-            if hmac.compare_digest(token.encode(), expected_key.encode()):
+            if expected_key and hmac.compare_digest(
+                token.encode(),
+                expected_key.encode(),
+            ):
                 return None  # Auth OK
+            if expected_read_key and hmac.compare_digest(
+                token.encode(),
+                expected_read_key.encode(),
+            ):
+                if self._read_key_path_allowed(request):
+                    return None
+                return web.json_response(
+                    {
+                        "error": {
+                            "message": "Bearer token lacks the required mutation scope",
+                            "type": "gateway_authorization_error",
+                            "code": "gateway_scope_forbidden",
+                            "required_scope": "mutation",
+                            "granted_scope": "execution:read",
+                        }
+                    },
+                    status=403,
+                )
 
         logger.warning(
             "API server rejected invalid API key: %s",
@@ -2097,6 +2174,51 @@ class APIServerAdapter(BasePlatformAdapter):
             ("POST", "/v1/runs/{run_id}/approval", self._handle_run_approval),
             ("POST", "/v1/runs/{run_id}/steer", self._handle_steer_run),
             ("POST", "/v1/runs/{run_id}/stop", self._handle_stop_run),
+            (
+                "GET",
+                "/v1/execution-contract/capabilities",
+                self._handle_execution_contract_capabilities,
+            ),
+            (
+                "GET",
+                "/v1/execution-contract/schema",
+                self._handle_execution_contract_schema,
+            ),
+            (
+                "GET",
+                "/v1/execution-contract/executions",
+                self._handle_execution_contract_executions,
+            ),
+            (
+                "GET",
+                "/v1/execution-contract/executions/{execution_id}",
+                self._handle_execution_contract_execution,
+            ),
+            (
+                "GET",
+                "/v1/execution-contract/decisions",
+                self._handle_execution_contract_decisions,
+            ),
+            (
+                "GET",
+                "/v1/execution-contract/decisions/{decision_id}",
+                self._handle_execution_contract_decision,
+            ),
+            (
+                "GET",
+                "/v1/execution-contract/events",
+                self._handle_execution_contract_events,
+            ),
+            (
+                "GET",
+                "/v1/execution-contract/receipts",
+                self._handle_execution_contract_receipts,
+            ),
+            (
+                "GET",
+                "/v1/execution-contract/receipts/{receipt_id}",
+                self._handle_execution_contract_receipt,
+            ),
         ]
         if _CRON_AVAILABLE:
             # Chronos managed-cron fire webhook (NAS → agent). Authenticated
@@ -3110,6 +3232,330 @@ class APIServerAdapter(BasePlatformAdapter):
                 status=500,
             )
 
+    # ------------------------------------------------------------------
+    # Durable execution read contract (Release 1)
+    # ------------------------------------------------------------------
+
+    def _execution_contract_profile_name(self) -> str:
+        return _api_request_profile.get() or "default"
+
+    def _execution_contract_store(self):
+        from hermes_cli.execution_contract import ExecutionContractStore
+
+        return ExecutionContractStore(
+            profile_name=self._execution_contract_profile_name(),
+            runtime_instance_id=self._execution_contract_runtime_id,
+        )
+
+    def _execution_contract_is_degraded(self) -> bool:
+        return (
+            self._execution_contract_profile_name()
+            in self._execution_contract_degraded_profiles
+        )
+
+    def _mark_execution_contract_degraded(self) -> None:
+        self._execution_contract_degraded_profiles.add(
+            self._execution_contract_profile_name()
+        )
+
+    @staticmethod
+    def _requested_execution_contract_version(request: "web.Request") -> Optional[str]:
+        header_version = request.headers.get("Hermes-Execution-Contract-Version")
+        query_version = request.query.get("contract_version")
+        if header_version and query_version and header_version != query_version:
+            from hermes_cli.execution_contract import ContractValidationError
+
+            raise ContractValidationError(
+                "header and query contract versions disagree"
+            )
+        return header_version or query_version
+
+    def _execution_contract_error_response(self, exc: Exception) -> "web.Response":
+        from hermes_cli.execution_contract import (
+            CONTRACT_VERSION,
+            ContractConflictError,
+            ContractCursorGoneError,
+            ContractDataError,
+            ContractForbiddenError,
+            ContractNotFoundError,
+            ContractRateLimitedError,
+            ContractUnavailableError,
+            ContractValidationError,
+            UnsupportedContractVersionError,
+        )
+
+        status = 500
+        code = "execution_contract_internal_error"
+        details: dict[str, Any] = {}
+        headers = {"Hermes-Execution-Contract-Version": CONTRACT_VERSION}
+        if isinstance(exc, ContractValidationError):
+            status, code = 400, "execution_contract_invalid_request"
+        elif isinstance(exc, ContractForbiddenError):
+            status, code = 403, "execution_contract_profile_forbidden"
+        elif isinstance(exc, ContractNotFoundError):
+            status, code = 404, "execution_contract_not_found"
+        elif isinstance(exc, (ContractConflictError, UnsupportedContractVersionError)):
+            status, code = 409, "execution_contract_conflict"
+        elif isinstance(exc, ContractCursorGoneError):
+            status, code = 410, "execution_contract_cursor_gone"
+            details = {
+                "minimum_available": exc.minimum_available,
+                "high_water": exc.high_water,
+            }
+        elif isinstance(exc, ContractRateLimitedError):
+            status, code = 429, "execution_contract_rate_limited"
+            headers["Retry-After"] = "1"
+        elif isinstance(exc, ContractUnavailableError):
+            status, code = 503, "execution_contract_unavailable"
+        elif isinstance(exc, ContractDataError):
+            status, code = 500, "execution_contract_corrupt"
+        message = str(exc) if status < 500 else "Execution contract unavailable"
+        return web.json_response(
+            {
+                "error": {
+                    "message": message,
+                    "type": "execution_contract_error",
+                    "code": code,
+                    **details,
+                }
+            },
+            status=status,
+            headers=headers,
+        )
+
+    def _execution_contract_read_guard(
+        self,
+        request: "web.Request",
+    ) -> Optional["web.Response"]:
+        auth_err = self._check_auth(request)
+        if auth_err:
+            return auth_err
+        if self._execution_contract_is_degraded():
+            from hermes_cli.execution_contract import ContractUnavailableError
+
+            return self._execution_contract_error_response(
+                ContractUnavailableError(
+                    "execution contract is degraded after a failed durable write"
+                )
+            )
+        try:
+            from hermes_cli.execution_contract import validate_contract_version
+
+            validate_contract_version(
+                self._requested_execution_contract_version(request)
+            )
+        except Exception as exc:
+            return self._execution_contract_error_response(exc)
+        return None
+
+    @staticmethod
+    def _execution_contract_headers() -> dict[str, str]:
+        from hermes_cli.execution_contract import CONTRACT_VERSION
+
+        return {
+            "Hermes-Execution-Contract-Version": CONTRACT_VERSION,
+            "Cache-Control": "no-store",
+        }
+
+    async def _handle_execution_contract_capabilities(
+        self,
+        request: "web.Request",
+    ) -> "web.Response":
+        guard = self._execution_contract_read_guard(request)
+        if guard:
+            return guard
+        from hermes_cli.execution_contract import contract_capabilities
+
+        return web.json_response(
+            contract_capabilities(self._execution_contract_profile_name()),
+            headers=self._execution_contract_headers(),
+        )
+
+    async def _handle_execution_contract_schema(
+        self,
+        request: "web.Request",
+    ) -> "web.Response":
+        guard = self._execution_contract_read_guard(request)
+        if guard:
+            return guard
+        try:
+            from hermes_cli.execution_contract import contract_schema
+
+            return web.json_response(
+                contract_schema(),
+                headers=self._execution_contract_headers(),
+            )
+        except Exception as exc:
+            return self._execution_contract_error_response(exc)
+
+    def _execution_contract_envelope(
+        self,
+        key: str,
+        value: Any,
+        *,
+        page: Optional[dict[str, Any]] = None,
+    ) -> dict[str, Any]:
+        from hermes_cli.execution_contract import CONTRACT_VERSION
+
+        payload = {
+            "contract_version": CONTRACT_VERSION,
+            "authority": self._execution_contract_store().authority.public(),
+            key: value,
+        }
+        if page is not None:
+            payload["page"] = page
+        return payload
+
+    async def _handle_execution_contract_executions(
+        self,
+        request: "web.Request",
+    ) -> "web.Response":
+        guard = self._execution_contract_read_guard(request)
+        if guard:
+            return guard
+        try:
+            page = self._execution_contract_store().list_executions(
+                after=request.query.get("after", 0),
+                limit=request.query.get("limit", 50),
+                lifecycle=request.query.get("lifecycle"),
+            )
+            return web.json_response(
+                self._execution_contract_envelope(
+                    "executions",
+                    page["items"],
+                    page=page["page"],
+                ),
+                headers=self._execution_contract_headers(),
+            )
+        except Exception as exc:
+            return self._execution_contract_error_response(exc)
+
+    async def _handle_execution_contract_execution(
+        self,
+        request: "web.Request",
+    ) -> "web.Response":
+        guard = self._execution_contract_read_guard(request)
+        if guard:
+            return guard
+        try:
+            execution = self._execution_contract_store().get_execution(
+                request.match_info["execution_id"]
+            )
+            return web.json_response(
+                self._execution_contract_envelope("execution", execution),
+                headers=self._execution_contract_headers(),
+            )
+        except Exception as exc:
+            return self._execution_contract_error_response(exc)
+
+    async def _handle_execution_contract_decisions(
+        self,
+        request: "web.Request",
+    ) -> "web.Response":
+        guard = self._execution_contract_read_guard(request)
+        if guard:
+            return guard
+        try:
+            page = self._execution_contract_store().list_decisions(
+                after=request.query.get("after", 0),
+                limit=request.query.get("limit", 50),
+                state=request.query.get("state"),
+            )
+            return web.json_response(
+                self._execution_contract_envelope(
+                    "decisions",
+                    page["items"],
+                    page=page["page"],
+                ),
+                headers=self._execution_contract_headers(),
+            )
+        except Exception as exc:
+            return self._execution_contract_error_response(exc)
+
+    async def _handle_execution_contract_decision(
+        self,
+        request: "web.Request",
+    ) -> "web.Response":
+        guard = self._execution_contract_read_guard(request)
+        if guard:
+            return guard
+        try:
+            decision = self._execution_contract_store().get_decision(
+                request.match_info["decision_id"]
+            )
+            return web.json_response(
+                self._execution_contract_envelope("decision", decision),
+                headers=self._execution_contract_headers(),
+            )
+        except Exception as exc:
+            return self._execution_contract_error_response(exc)
+
+    async def _handle_execution_contract_events(
+        self,
+        request: "web.Request",
+    ) -> "web.Response":
+        guard = self._execution_contract_read_guard(request)
+        if guard:
+            return guard
+        try:
+            page = self._execution_contract_store().list_events(
+                after=request.query.get("after", 0),
+                limit=request.query.get("limit", 50),
+                execution_id=request.query.get("execution_id"),
+            )
+            return web.json_response(
+                self._execution_contract_envelope(
+                    "events",
+                    page["items"],
+                    page=page["page"],
+                ),
+                headers=self._execution_contract_headers(),
+            )
+        except Exception as exc:
+            return self._execution_contract_error_response(exc)
+
+    async def _handle_execution_contract_receipts(
+        self,
+        request: "web.Request",
+    ) -> "web.Response":
+        guard = self._execution_contract_read_guard(request)
+        if guard:
+            return guard
+        try:
+            page = self._execution_contract_store().list_receipts(
+                after=request.query.get("after", 0),
+                limit=request.query.get("limit", 50),
+                outcome=request.query.get("outcome"),
+            )
+            return web.json_response(
+                self._execution_contract_envelope(
+                    "receipts",
+                    page["items"],
+                    page=page["page"],
+                ),
+                headers=self._execution_contract_headers(),
+            )
+        except Exception as exc:
+            return self._execution_contract_error_response(exc)
+
+    async def _handle_execution_contract_receipt(
+        self,
+        request: "web.Request",
+    ) -> "web.Response":
+        guard = self._execution_contract_read_guard(request)
+        if guard:
+            return guard
+        try:
+            receipt = self._execution_contract_store().get_receipt(
+                request.match_info["receipt_id"]
+            )
+            return web.json_response(
+                self._execution_contract_envelope("receipt", receipt),
+                headers=self._execution_contract_headers(),
+            )
+        except Exception as exc:
+            return self._execution_contract_error_response(exc)
+
     async def _handle_capabilities(self, request: "web.Request") -> "web.Response":
         """GET /v1/capabilities — advertise the stable API surface.
 
@@ -3128,6 +3574,8 @@ class APIServerAdapter(BasePlatformAdapter):
             "auth": {
                 "type": "bearer",
                 "required": bool(self._api_key),
+                "read_only_key_configured": bool(self._expected_read_api_key()),
+                "read_only_scope": "execution:read",
             },
             "runtime": {
                 "mode": "server_agent",
@@ -3152,6 +3600,9 @@ class APIServerAdapter(BasePlatformAdapter):
                 "run_approval_response": True,
                 "tool_progress_events": True,
                 "approval_events": True,
+                "execution_read_contract": True,
+                "execution_read_contract_version": "hermes.execution.read.v1",
+                "authoritative_effect_receipts_require_evidence": True,
                 "session_resources": True,
                 "model_options": True,
                 "session_chat": True,
@@ -3181,6 +3632,42 @@ class APIServerAdapter(BasePlatformAdapter):
                 "run_approval": {"method": "POST", "path": "/v1/runs/{run_id}/approval"},
                 "run_steer": {"method": "POST", "path": "/v1/runs/{run_id}/steer"},
                 "run_stop": {"method": "POST", "path": "/v1/runs/{run_id}/stop"},
+                "execution_contract_capabilities": {
+                    "method": "GET",
+                    "path": "/v1/execution-contract/capabilities",
+                },
+                "execution_contract_schema": {
+                    "method": "GET",
+                    "path": "/v1/execution-contract/schema",
+                },
+                "executions": {
+                    "method": "GET",
+                    "path": "/v1/execution-contract/executions",
+                },
+                "execution": {
+                    "method": "GET",
+                    "path": "/v1/execution-contract/executions/{execution_id}",
+                },
+                "decisions": {
+                    "method": "GET",
+                    "path": "/v1/execution-contract/decisions",
+                },
+                "decision": {
+                    "method": "GET",
+                    "path": "/v1/execution-contract/decisions/{decision_id}",
+                },
+                "execution_events": {
+                    "method": "GET",
+                    "path": "/v1/execution-contract/events",
+                },
+                "receipts": {
+                    "method": "GET",
+                    "path": "/v1/execution-contract/receipts",
+                },
+                "receipt": {
+                    "method": "GET",
+                    "path": "/v1/execution-contract/receipts/{receipt_id}",
+                },
                 "skills": {"method": "GET", "path": "/v1/skills"},
                 "toolsets": {"method": "GET", "path": "/v1/toolsets"},
                 "sessions": {"method": "GET", "path": "/api/sessions"},
@@ -6633,6 +7120,221 @@ class APIServerAdapter(BasePlatformAdapter):
 
         return _callback
 
+    @staticmethod
+    def _parse_execution_contract_context(body: dict[str, Any]) -> dict[str, Optional[str]]:
+        """Validate the optional immutable bindings accepted by legacy /v1/runs."""
+        raw = body.get("execution_context")
+        if raw is None:
+            return {"work_ref": None, "proposal_ref": None, "effect_id": None}
+        if not isinstance(raw, dict):
+            raise ValueError("execution_context must be an object")
+        allowed = {"work_ref", "proposal_ref", "effect_id"}
+        extras = sorted(set(raw) - allowed)
+        if extras:
+            raise ValueError(
+                f"execution_context contains unsupported fields: {', '.join(extras)}"
+            )
+        values = {
+            key: (str(raw[key]).strip() if raw.get(key) is not None else None)
+            for key in allowed
+        }
+        if values["effect_id"] and not (
+            values["work_ref"] and values["proposal_ref"]
+        ):
+            raise ValueError(
+                "effect_id requires exact work_ref and proposal_ref bindings"
+            )
+        return values
+
+    def _create_execution_contract_run(
+        self,
+        run_id: str,
+        context: dict[str, Optional[str]],
+    ) -> dict[str, Any]:
+        execution = self._execution_contract_store().create_execution(
+            lifecycle="queued",
+            source_run_id=run_id,
+            work_ref=context.get("work_ref"),
+            proposal_ref=context.get("proposal_ref"),
+            effect_id=context.get("effect_id"),
+        )
+        self._run_execution_ids[run_id] = execution["execution_id"]
+        return execution
+
+    def _transition_execution_contract_run(
+        self,
+        run_id: str,
+        lifecycle: str,
+        *,
+        reason_code: Optional[str] = None,
+        recovery_ref: Optional[str] = None,
+    ) -> Optional[dict[str, Any]]:
+        execution_id = self._run_execution_ids.get(run_id)
+        if not execution_id:
+            return None
+        try:
+            return self._execution_contract_store().transition_execution(
+                execution_id,
+                lifecycle,
+                reason_code=reason_code,
+                recovery_ref=recovery_ref,
+            )
+        except Exception:
+            self._mark_execution_contract_degraded()
+            logger.exception(
+                "Durable execution contract transition failed for run=%s",
+                run_id,
+            )
+            return None
+
+    def _terminalize_execution_contract_run(
+        self,
+        run_id: str,
+        terminal_status: str,
+        *,
+        reason_code: Optional[str] = None,
+    ) -> Optional[dict[str, Any]]:
+        lifecycle = {
+            "completed": "terminal_succeeded",
+            "failed": "terminal_failed",
+            "cancelled": "terminal_cancelled",
+            "partial": "terminal_partial",
+            "ambiguous": "terminal_ambiguous",
+        }.get(terminal_status)
+        if lifecycle is None:
+            raise ValueError(f"unknown terminal execution status: {terminal_status}")
+        return self._transition_execution_contract_run(
+            run_id,
+            lifecycle,
+            reason_code=reason_code,
+        )
+
+    def _create_execution_contract_decision(
+        self,
+        run_id: str,
+        approval_data: dict[str, Any],
+        allowed_choices: list[str],
+    ) -> Optional[dict[str, Any]]:
+        execution_id = self._run_execution_ids.get(run_id)
+        if not execution_id:
+            return None
+        store = self._execution_contract_store()
+        execution = store.get_execution(execution_id)
+        if not execution["effect_id"] or not execution["proposal_ref"]:
+            return None
+        from hermes_cli.execution_contract import canonical_digest
+        from tools.approval import _get_approval_timeout
+
+        request_payload = {
+            "request_id": approval_data.get("request_id"),
+            "execution_id": execution_id,
+            "effect_id": execution["effect_id"],
+            "proposal_ref": execution["proposal_ref"],
+            "command": approval_data.get("command"),
+            "description": approval_data.get("description"),
+            "pattern_keys": approval_data.get("pattern_keys") or [],
+            "allowed_choices": allowed_choices,
+        }
+        decision = store.create_decision(
+            execution_id=execution_id,
+            effect_id=execution["effect_id"],
+            proposal_ref=execution["proposal_ref"],
+            request_digest=canonical_digest(request_payload),
+            candidate_digest=canonical_digest(
+                {
+                    "command": approval_data.get("command"),
+                    "pattern_keys": approval_data.get("pattern_keys") or [],
+                }
+            ),
+            allowed_choices=allowed_choices,
+            expires_at=datetime.now(timezone.utc)
+            + timedelta(seconds=max(float(_get_approval_timeout()), 0.0)),
+        )
+        request_id = str(approval_data.get("request_id") or "")
+        if not request_id:
+            raise RuntimeError("approval request is missing its host request_id")
+        self._run_decision_ids.setdefault(run_id, {})[request_id] = decision[
+            "decision_id"
+        ]
+        return decision
+
+    def _resolve_execution_contract_decision(
+        self,
+        run_id: str,
+        choice: str,
+        *,
+        request_id: Optional[str] = None,
+        decision_id: Optional[str] = None,
+    ) -> tuple[Optional[dict[str, Any]], Optional[str]]:
+        mappings = self._run_decision_ids.get(run_id, {})
+        if not mappings:
+            return None, None
+        if request_id is None:
+            from tools.approval import list_gateway_approvals
+
+            pending = list_gateway_approvals(run_id)
+            request_id = str(pending[0].get("request_id")) if pending else None
+        expected_decision_id = mappings.get(str(request_id or ""))
+        if expected_decision_id is None:
+            raise RuntimeError("durable decision binding is unavailable")
+        if decision_id and decision_id != expected_decision_id:
+            from hermes_cli.execution_contract import ContractConflictError
+
+            raise ContractConflictError("decision_id does not match the pending request")
+        from hermes_cli.execution_contract import canonical_digest
+
+        resolved = self._execution_contract_store().resolve_decision(
+            expected_decision_id,
+            choice=choice,
+            resolution_evidence_digest=canonical_digest(
+                {
+                    "decision_id": expected_decision_id,
+                    "request_id": request_id,
+                    "run_id": run_id,
+                    "choice": choice,
+                    "transport": "api_server_bearer",
+                }
+            ),
+        )
+        return resolved, request_id
+
+    def record_execution_effect_evidence(
+        self,
+        *,
+        run_id: str,
+        effect_id: str,
+        outcome: str,
+        subject_digest: str,
+        evidence_digest: str,
+        result_digest: str,
+        decision_id: Optional[str] = None,
+        recovery_ref: Optional[str] = None,
+        reconciliation_ref: Optional[str] = None,
+    ) -> dict[str, Any]:
+        """Closed executor hook required before an authoritative receipt exists.
+
+        Tool/executor integrations call this with their own exact effect
+        evidence. Generic chat output, session history, Kanban summaries, and
+        the process-local run status are intentionally not accepted here.
+        """
+        execution_id = self._run_execution_ids.get(run_id)
+        if not execution_id:
+            execution = self._execution_contract_store().get_execution_by_source_run_id(
+                run_id
+            )
+            execution_id = execution["execution_id"]
+        return self._execution_contract_store().record_effect_evidence(
+            execution_id=execution_id,
+            effect_id=effect_id,
+            outcome=outcome,
+            subject_digest=subject_digest,
+            evidence_digest=evidence_digest,
+            result_digest=result_digest,
+            decision_id=decision_id,
+            recovery_ref=recovery_ref,
+            reconciliation_ref=reconciliation_ref,
+        )
+
     @_admit_api_agent_request
     async def _handle_runs(self, request: "web.Request") -> "web.Response":
         """POST /v1/runs — start an agent run, return run_id immediately."""
@@ -6651,6 +7353,14 @@ class APIServerAdapter(BasePlatformAdapter):
             body = await request.json()
         except Exception:
             return web.json_response(_openai_error("Invalid JSON"), status=400)
+
+        try:
+            execution_context = self._parse_execution_contract_context(body)
+        except ValueError as exc:
+            return web.json_response(
+                _openai_error(str(exc), code="invalid_execution_context"),
+                status=400,
+            )
 
         raw_input = body.get("input")
         if not raw_input:
@@ -6722,6 +7432,13 @@ class APIServerAdapter(BasePlatformAdapter):
 
         run_id = f"run_{uuid.uuid4().hex}"
         session_id = session_id or run_id
+        try:
+            durable_execution = self._create_execution_contract_run(
+                run_id,
+                execution_context,
+            )
+        except Exception as exc:
+            return self._execution_contract_error_response(exc)
         # Approval queues gate host-side tool execution and must be isolated
         # per API run.  Client-provided session IDs and memory session keys are
         # conversation/memory scopes, not authorization namespaces: multiple
@@ -6765,6 +7482,7 @@ class APIServerAdapter(BasePlatformAdapter):
             created_at=created_at,
             session_id=session_id,
             model=body.get("model", self._model_name),
+            execution_id=durable_execution["execution_id"],
         )
 
         # Background task outlives the HTTP response (and thus the middleware
@@ -6774,6 +7492,8 @@ class APIServerAdapter(BasePlatformAdapter):
         async def _run_and_close():
             try:
                 self._set_run_status(run_id, "running")
+                with self._profile_scope(request_profile):
+                    self._transition_execution_contract_run(run_id, "running")
                 if run_id in self._stopping_run_ids:
                     _put_event_if_active({
                         "event": "run.cancelled",
@@ -6785,6 +7505,12 @@ class APIServerAdapter(BasePlatformAdapter):
                         "cancelled",
                         last_event="run.cancelled",
                     )
+                    with self._profile_scope(request_profile):
+                        self._terminalize_execution_contract_run(
+                            run_id,
+                            "cancelled",
+                            reason_code="stopped_before_agent_start",
+                        )
                     return
                 with self._profile_scope(request_profile):
                     agent = self._create_agent(
@@ -6810,14 +7536,44 @@ class APIServerAdapter(BasePlatformAdapter):
                         from gateway.run import _redact_approval_command
 
                         event["command"] = _redact_approval_command(event.get("command"))
+                    choices = _approval_event_choices(
+                        smart_denied=bool(event.get("smart_denied")),
+                        allow_permanent=event.get("allow_permanent") is not False,
+                    )
+                    try:
+                        decision = self._create_execution_contract_decision(
+                            run_id,
+                            event,
+                            choices,
+                        )
+                        if decision is None:
+                            self._transition_execution_contract_run(
+                                run_id,
+                                "awaiting_decision",
+                            )
+                        else:
+                            event.update(
+                                {
+                                    "decision_id": decision["decision_id"],
+                                    "request_digest": decision["request_digest"],
+                                    "candidate_digest": decision["candidate_digest"],
+                                    "expires_at": decision["expires_at"],
+                                }
+                            )
+                    except Exception as exc:
+                        self._mark_execution_contract_degraded()
+                        logger.exception(
+                            "Durable approval publication failed for run=%s",
+                            run_id,
+                        )
+                        raise RuntimeError(
+                            "durable approval publication failed closed"
+                        ) from exc
                     event.update({
                         "event": "approval.request",
                         "run_id": run_id,
                         "timestamp": time.time(),
-                        "choices": _approval_event_choices(
-                            smart_denied=bool(event.get("smart_denied")),
-                            allow_permanent=event.get("allow_permanent") is not False,
-                        ),
+                        "choices": choices,
                     })
                     self._set_run_status(
                         run_id,
@@ -6910,6 +7666,12 @@ class APIServerAdapter(BasePlatformAdapter):
                         "cancelled",
                         last_event="run.cancelled",
                     )
+                    with self._profile_scope(request_profile):
+                        self._terminalize_execution_contract_run(
+                            run_id,
+                            "cancelled",
+                            reason_code="stop_requested",
+                        )
                 # Check for structured failure (non-retryable client errors like
                 # 401/400 return failed=True instead of raising, so the except
                 # block below never fires — issue #15561).
@@ -6927,6 +7689,12 @@ class APIServerAdapter(BasePlatformAdapter):
                         error=error_msg,
                         last_event="run.failed",
                     )
+                    with self._profile_scope(request_profile):
+                        self._terminalize_execution_contract_run(
+                            run_id,
+                            "failed",
+                            reason_code="agent_reported_failure",
+                        )
                 else:
                     final_response = result.get("final_response", "") if isinstance(result, dict) else ""
                     # Undelivered steer text (accepted after the final response;
@@ -6951,6 +7719,8 @@ class APIServerAdapter(BasePlatformAdapter):
                         last_event="run.completed",
                         **({"pending_steer": pending_steer} if pending_steer else {}),
                     )
+                    with self._profile_scope(request_profile):
+                        self._terminalize_execution_contract_run(run_id, "completed")
             except asyncio.CancelledError:
                 self._set_run_status(
                     run_id,
@@ -6965,6 +7735,12 @@ class APIServerAdapter(BasePlatformAdapter):
                     })
                 except Exception:
                     pass
+                with self._profile_scope(request_profile):
+                    self._terminalize_execution_contract_run(
+                        run_id,
+                        "cancelled",
+                        reason_code="task_cancelled",
+                    )
                 raise
             except _ProviderAuthResolutionError as exc:
                 # /v1/runs builds its own agent via _create_agent() and does
@@ -6991,6 +7767,12 @@ class APIServerAdapter(BasePlatformAdapter):
                     })
                 except Exception:
                     pass
+                with self._profile_scope(request_profile):
+                    self._terminalize_execution_contract_run(
+                        run_id,
+                        "failed",
+                        reason_code="provider_authentication_failed",
+                    )
             except Exception as exc:
                 logger.exception("[api_server] run %s failed", run_id)
                 self._set_run_status(
@@ -7008,6 +7790,12 @@ class APIServerAdapter(BasePlatformAdapter):
                     })
                 except Exception:
                     pass
+                with self._profile_scope(request_profile):
+                    self._terminalize_execution_contract_run(
+                        run_id,
+                        "failed",
+                        reason_code="agent_exception",
+                    )
             finally:
                 # If the asyncio wrapper is cancelled (for example via
                 # /stop), the executor thread can still be blocked waiting
@@ -7044,7 +7832,11 @@ class APIServerAdapter(BasePlatformAdapter):
             {"X-Hermes-Session-Key": gateway_session_key} if gateway_session_key else {}
         )
         return web.json_response(
-            {"run_id": run_id, "status": "started"},
+            {
+                "run_id": run_id,
+                "execution_id": durable_execution["execution_id"],
+                "status": "started",
+            },
             status=202,
             headers=response_headers,
         )
@@ -7162,6 +7954,28 @@ class APIServerAdapter(BasePlatformAdapter):
             _coerce_request_bool(body.get("all"), default=False)
             or _coerce_request_bool(body.get("resolve_all"), default=False)
         )
+        durable_decision = None
+        durable_request_id = str(body.get("request_id") or "").strip() or None
+        requested_decision_id = str(body.get("decision_id") or "").strip() or None
+        if self._run_decision_ids.get(run_id) and resolve_all:
+            return web.json_response(
+                _openai_error(
+                    "resolve_all is not supported for durable decisions; resolve one exact decision_id",
+                    code="durable_decision_requires_exact_binding",
+                ),
+                status=409,
+            )
+        try:
+            durable_decision, durable_request_id = (
+                self._resolve_execution_contract_decision(
+                    run_id,
+                    choice,
+                    request_id=durable_request_id,
+                    decision_id=requested_decision_id,
+                )
+            )
+        except Exception as exc:
+            return self._execution_contract_error_response(exc)
         try:
             from tools.approval import resolve_gateway_approval
 
@@ -7169,12 +7983,25 @@ class APIServerAdapter(BasePlatformAdapter):
                 approval_session_key,
                 choice,
                 resolve_all=resolve_all,
+                request_id=durable_request_id,
             )
         except Exception as exc:
             logger.exception("[api_server] approval resolution failed for run %s", run_id)
+            if durable_decision is not None:
+                self._terminalize_execution_contract_run(
+                    run_id,
+                    "ambiguous",
+                    reason_code="approval_delivery_failed",
+                )
             return web.json_response(_openai_error(str(exc)), status=500)
 
         if resolved <= 0:
+            if durable_decision is not None:
+                self._terminalize_execution_contract_run(
+                    run_id,
+                    "ambiguous",
+                    reason_code="approval_target_missing",
+                )
             return web.json_response(
                 _openai_error(
                     f"Run has no pending approval: {run_id}",
@@ -7193,6 +8020,11 @@ class APIServerAdapter(BasePlatformAdapter):
                     "timestamp": time.time(),
                     "choice": choice,
                     "resolved": resolved,
+                    **(
+                        {"decision_id": durable_decision["decision_id"]}
+                        if durable_decision is not None
+                        else {}
+                    ),
                 })
             except Exception:
                 pass
@@ -7202,6 +8034,14 @@ class APIServerAdapter(BasePlatformAdapter):
             "run_id": run_id,
             "choice": choice,
             "resolved": resolved,
+            **(
+                {
+                    "decision_id": durable_decision["decision_id"],
+                    "request_id": durable_request_id,
+                }
+                if durable_decision is not None
+                else {}
+            ),
         })
 
     async def _handle_steer_run(self, request: "web.Request") -> "web.Response":
@@ -7278,6 +8118,11 @@ class APIServerAdapter(BasePlatformAdapter):
             return web.json_response(_openai_error(f"Run not found: {run_id}", code="run_not_found"), status=404)
 
         self._set_run_status(run_id, "stopping", last_event="run.stopping")
+        self._transition_execution_contract_run(
+            run_id,
+            "cancellation_requested",
+            reason_code="stop_requested",
+        )
         self._stopping_run_ids.add(run_id)
 
         if agent is not None:
@@ -7301,6 +8146,10 @@ class APIServerAdapter(BasePlatformAdapter):
         while True:
             await asyncio.sleep(60)
             self._sweep_orphaned_runs_once(time.time())
+            try:
+                self._maintain_execution_contract_state(recover=False)
+            except Exception:
+                logger.exception("Execution contract maintenance failed")
 
     def _sweep_orphaned_runs_once(self, now: Optional[float] = None) -> None:
         """Expire old SSE buffers without treating transport age as run age."""
@@ -7343,6 +8192,8 @@ class APIServerAdapter(BasePlatformAdapter):
         ]
         for run_id in stale_statuses:
             self._run_statuses.pop(run_id, None)
+            self._run_execution_ids.pop(run_id, None)
+            self._run_decision_ids.pop(run_id, None)
 
     # ------------------------------------------------------------------
     # BasePlatformAdapter interface
@@ -7388,6 +8239,77 @@ class APIServerAdapter(BasePlatformAdapter):
             return False
         return True
 
+    def _read_api_key_passes_startup_guard(self) -> bool:
+        """Reject a configured read-only key that is weak or placeholder-like."""
+        if not self._read_api_key:
+            return True
+        try:
+            from hermes_cli.auth import has_usable_secret
+        except Exception as exc:
+            logger.error(
+                "[%s] Refusing to start: API_SERVER_READ_KEY strength could not "
+                "be verified (%s)",
+                self.name,
+                type(exc).__name__,
+            )
+            return False
+        if not has_usable_secret(self._read_api_key, min_length=16):
+            logger.error(
+                "[%s] Refusing to start: API_SERVER_READ_KEY is a placeholder "
+                "or too short (<16 chars)",
+                self.name,
+            )
+            return False
+        return True
+
+    def _execution_contract_profiles(self) -> list[Optional[str]]:
+        profiles: list[Optional[str]] = [None]
+        runner = getattr(self, "gateway_runner", None)
+        cfg = getattr(runner, "config", None)
+        if getattr(cfg, "multiplex_profiles", False):
+            from hermes_cli.profiles import profiles_to_serve
+
+            profiles = []
+            for name, _home in profiles_to_serve(
+                multiplex=True,
+                profile_allowlist=getattr(
+                    cfg,
+                    "multiplex_profile_allowlist",
+                    None,
+                ),
+            ):
+                profiles.append(None if name == "default" else name)
+        return profiles
+
+    def _maintain_execution_contract_state(self, *, recover: bool) -> None:
+        """Migrate, expire, prune, and optionally recover every served profile."""
+        profiles = self._execution_contract_profiles()
+        for profile in profiles:
+            token = _api_request_profile.set(profile)
+            try:
+                with self._profile_scope(profile):
+                    store = self._execution_contract_store()
+                    store.initialize()
+                    if recover:
+                        store.recover_orphaned_executions(
+                            recovery_ref=(
+                                f"api-server-restart:{self._execution_contract_runtime_id}"
+                            )
+                        )
+                    store.expire_decisions()
+                    store.prune_events()
+            except Exception:
+                self._execution_contract_degraded_profiles.add(
+                    profile or "default"
+                )
+                raise
+            finally:
+                _api_request_profile.reset(token)
+
+    def _initialize_execution_contract_state(self) -> None:
+        """Migrate and recover every profile before the listener accepts reads."""
+        self._maintain_execution_contract_state(recover=True)
+
     async def connect(self, *, is_reconnect: bool = False) -> bool:
         """Start the aiohttp web server."""
         if not AIOHTTP_AVAILABLE:
@@ -7416,6 +8338,30 @@ class APIServerAdapter(BasePlatformAdapter):
                 "error logged above). Generate a strong secret (e.g. "
                 "`openssl rand -hex 32`), set API_SERVER_KEY, then "
                 "`/platform resume api_server`.",
+                retryable=False,
+            )
+            return False
+
+        if not self._read_api_key_passes_startup_guard():
+            self._set_fatal_error(
+                "api_server_read_key_invalid",
+                "API_SERVER_READ_KEY was rejected by the startup guard. Generate "
+                "a strong secret or remove it to disable read-only access.",
+                retryable=False,
+            )
+            return False
+
+        try:
+            self._initialize_execution_contract_state()
+        except Exception as exc:
+            logger.error(
+                "[%s] Refusing to start: execution contract initialization failed (%s)",
+                self.name,
+                type(exc).__name__,
+            )
+            self._set_fatal_error(
+                "execution_contract_unavailable",
+                "The durable execution contract could not be initialized or recovered.",
                 retryable=False,
             )
             return False

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -4502,6 +4502,14 @@ OPTIONAL_ENV_VARS = {
         "category": "messaging",
         "advanced": True,
     },
+    "API_SERVER_READ_KEY": {
+        "description": "Optional bearer token limited to the versioned execution read contract and capability discovery. It cannot submit, approve, steer, stop, or access other API resources.",
+        "prompt": "API server execution read-only key",
+        "url": None,
+        "password": True,
+        "category": "messaging",
+        "advanced": True,
+    },
     "API_SERVER_PORT": {
         "description": "Port for the API server (default: 8642).",
         "prompt": "API server port",

--- a/hermes_cli/execution_contract.py
+++ b/hermes_cli/execution_contract.py
@@ -2138,6 +2138,11 @@ class ExecutionContractStore:
                     or current_high_water > allocated_high_water
                 ):
                     raise ContractDataError("event high-water metadata is corrupt")
+                self._validate_global_event_continuity(
+                    connection,
+                    pruned_through=prior,
+                    snapshot_high_water=allocated_high_water,
+                )
                 rows = connection.execute(
                     """
                     SELECT ev.sequence, ev.occurred_at, ex.lifecycle
@@ -2158,11 +2163,6 @@ class ExecutionContractStore:
                         break
                 if through <= prior:
                     return 0
-                self._validate_global_event_continuity(
-                    connection,
-                    pruned_through=prior,
-                    snapshot_high_water=through,
-                )
                 deleted = connection.execute(
                     "DELETE FROM execution_events WHERE sequence <= ?",
                     (through,),

--- a/hermes_cli/execution_contract.py
+++ b/hermes_cli/execution_contract.py
@@ -17,8 +17,12 @@ from __future__ import annotations
 import hashlib
 import importlib.resources
 import json
+import os
 import re
+import secrets
 import sqlite3
+import stat
+import time
 import uuid
 from contextlib import contextmanager, suppress
 from dataclasses import dataclass
@@ -36,6 +40,12 @@ STORE_SCHEMA_VERSION = 1
 EVENT_RETENTION_SECONDS = 30 * 24 * 60 * 60
 DEFAULT_PAGE_SIZE = 50
 MAX_PAGE_SIZE = 200
+PROFILE_ANCHOR_VERSION = 1
+PROFILE_ANCHOR_FILENAME = ".execution-contract-profile-instance.json"
+_PROFILE_ANCHOR_LOCK_FILENAME = ".execution-contract-profile-instance.lock"
+_PROFILE_ANCHOR_MAX_BYTES = 4096
+_PROFILE_ANCHOR_WAIT_ATTEMPTS = 200
+_PROFILE_ANCHOR_WAIT_SECONDS = 0.01
 
 EXECUTION_STATES = frozenset(
     {
@@ -123,6 +133,7 @@ _ALLOWED_TRANSITIONS: dict[str, frozenset[str]] = {
 _ID_RE = re.compile(r"^(exe|dec|rcp|evt)_([0-9a-f]{12})_([0-9a-f]{32})$")
 _EVIDENCE_ID_RE = re.compile(r"^evd_([0-9a-f]{12})_([0-9a-f]{32})$")
 _SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
+_PROFILE_INSTANCE_RE = re.compile(r"^[0-9a-f]{64}$")
 _CONTROL_RE = re.compile(r"[\x00-\x1f\x7f]")
 
 
@@ -144,6 +155,10 @@ class ContractForbiddenError(ExecutionContractError):
 
 class ContractUnauthorizedError(ExecutionContractError):
     """The request did not present valid credentials for this contract."""
+
+
+class ContractMethodNotAllowedError(ExecutionContractError):
+    """The contract namespace does not support the requested HTTP method."""
 
 
 class ContractConflictError(ExecutionContractError):
@@ -224,26 +239,206 @@ def _normalize_profile_name(profile_name: str) -> str:
     return clean
 
 
+def _profile_anchor_path(profile_home: Path) -> Path:
+    return Path(profile_home) / PROFILE_ANCHOR_FILENAME
+
+
+def _profile_anchor_exists(profile_home: Path) -> bool:
+    return os.path.lexists(_profile_anchor_path(profile_home))
+
+
+def _read_profile_anchor(profile_home: Path) -> str:
+    """Read and validate the durable profile-instance anchor without mutation."""
+
+    path = _profile_anchor_path(profile_home)
+    descriptor: Optional[int] = None
+    try:
+        path_metadata = path.lstat()
+    except FileNotFoundError as exc:
+        raise ContractDataError("profile instance anchor is missing") from exc
+    except OSError as exc:
+        raise ContractDataError("profile instance anchor is unavailable") from exc
+    if not stat.S_ISREG(path_metadata.st_mode) or stat.S_ISLNK(path_metadata.st_mode):
+        raise ContractDataError("profile instance anchor is not a regular file")
+    try:
+        descriptor = os.open(
+            path,
+            os.O_RDONLY
+            | getattr(os, "O_CLOEXEC", 0)
+            | getattr(os, "O_NOFOLLOW", 0),
+        )
+        metadata = os.fstat(descriptor)
+    except OSError as exc:
+        if descriptor is not None:
+            os.close(descriptor)
+        raise ContractDataError("profile instance anchor is unavailable") from exc
+    if (
+        not stat.S_ISREG(metadata.st_mode)
+        or (path_metadata.st_dev, path_metadata.st_ino)
+        != (metadata.st_dev, metadata.st_ino)
+    ):
+        os.close(descriptor)
+        raise ContractDataError("profile instance anchor changed while opening")
+    if stat.S_IMODE(metadata.st_mode) != 0o600:
+        os.close(descriptor)
+        raise ContractDataError("profile instance anchor permissions are unsafe")
+    if hasattr(os, "geteuid") and metadata.st_uid != os.geteuid():
+        os.close(descriptor)
+        raise ContractDataError("profile instance anchor owner is unsafe")
+    if metadata.st_size <= 0 or metadata.st_size > _PROFILE_ANCHOR_MAX_BYTES:
+        os.close(descriptor)
+        raise ContractDataError("profile instance anchor is corrupt")
+    try:
+        raw = os.read(descriptor, _PROFILE_ANCHOR_MAX_BYTES + 1)
+        os.close(descriptor)
+        descriptor = None
+        payload = json.loads(raw)
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        if descriptor is not None:
+            os.close(descriptor)
+        raise ContractDataError("profile instance anchor is corrupt") from exc
+    if not isinstance(payload, dict) or set(payload) != {"version", "instance_id"}:
+        raise ContractDataError("profile instance anchor is corrupt")
+    version = payload.get("version")
+    instance_id = payload.get("instance_id")
+    if (
+        isinstance(version, bool)
+        or version != PROFILE_ANCHOR_VERSION
+        or not isinstance(instance_id, str)
+        or _PROFILE_INSTANCE_RE.fullmatch(instance_id) is None
+    ):
+        raise ContractDataError("profile instance anchor is corrupt")
+    return instance_id
+
+
+def _fsync_profile_home(profile_home: Path) -> None:
+    """Durably publish profile metadata on platforms supporting directory fsync."""
+
+    flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0)
+    try:
+        descriptor = os.open(profile_home, flags)
+    except OSError:
+        if os.name == "nt":
+            return
+        raise
+    try:
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
+
+
+def _write_all(descriptor: int, payload: bytes) -> None:
+    offset = 0
+    while offset < len(payload):
+        written = os.write(descriptor, payload[offset:])
+        if written <= 0:
+            raise OSError("profile instance anchor write made no progress")
+        offset += written
+
+
+def _restrict_open_file(descriptor: int, path: Path) -> None:
+    if hasattr(os, "fchmod"):
+        os.fchmod(descriptor, 0o600)
+    else:
+        os.chmod(path, 0o600)
+
+
+def _create_profile_anchor(profile_home: Path) -> str:
+    """Create the anchor once through an owner-only lock and atomic rename."""
+
+    anchor_path = _profile_anchor_path(profile_home)
+    if _profile_anchor_exists(profile_home):
+        return _read_profile_anchor(profile_home)
+    lock_path = Path(profile_home) / _PROFILE_ANCHOR_LOCK_FILENAME
+    open_flags = (
+        os.O_WRONLY
+        | os.O_CREAT
+        | os.O_EXCL
+        | getattr(os, "O_CLOEXEC", 0)
+        | getattr(os, "O_NOFOLLOW", 0)
+    )
+    lock_descriptor: Optional[int] = None
+    try:
+        lock_descriptor = os.open(lock_path, open_flags, 0o600)
+        _restrict_open_file(lock_descriptor, lock_path)
+        os.fsync(lock_descriptor)
+    except FileExistsError:
+        for _attempt in range(_PROFILE_ANCHOR_WAIT_ATTEMPTS):
+            if _profile_anchor_exists(profile_home):
+                return _read_profile_anchor(profile_home)
+            if not os.path.lexists(lock_path):
+                return _create_profile_anchor(profile_home)
+            time.sleep(_PROFILE_ANCHOR_WAIT_SECONDS)
+        raise ContractUnavailableError("profile instance anchor initialization is busy")
+    except OSError as exc:
+        if lock_descriptor is not None:
+            os.close(lock_descriptor)
+        with suppress(OSError):
+            lock_path.unlink()
+        raise ContractUnavailableError(
+            "profile instance anchor cannot be initialized"
+        ) from exc
+
+    temp_path = Path(profile_home) / (
+        f".{PROFILE_ANCHOR_FILENAME}.{os.getpid()}.{uuid.uuid4().hex}.tmp"
+    )
+    temp_descriptor: Optional[int] = None
+    try:
+        if _profile_anchor_exists(profile_home):
+            return _read_profile_anchor(profile_home)
+        instance_id = secrets.token_hex(32)
+        encoded = (
+            json.dumps(
+                {"version": PROFILE_ANCHOR_VERSION, "instance_id": instance_id},
+                sort_keys=True,
+                separators=(",", ":"),
+            )
+            + "\n"
+        ).encode("utf-8")
+        temp_descriptor = os.open(temp_path, open_flags, 0o600)
+        _restrict_open_file(temp_descriptor, temp_path)
+        _write_all(temp_descriptor, encoded)
+        os.fsync(temp_descriptor)
+        os.close(temp_descriptor)
+        temp_descriptor = None
+        if _profile_anchor_exists(profile_home):
+            return _read_profile_anchor(profile_home)
+        os.replace(temp_path, anchor_path)
+        _fsync_profile_home(profile_home)
+        return _read_profile_anchor(profile_home)
+    except ExecutionContractError:
+        raise
+    except OSError as exc:
+        raise ContractUnavailableError(
+            "profile instance anchor cannot be initialized"
+        ) from exc
+    finally:
+        if temp_descriptor is not None:
+            os.close(temp_descriptor)
+        with suppress(OSError):
+            temp_path.unlink()
+        if lock_descriptor is not None:
+            os.close(lock_descriptor)
+        with suppress(OSError):
+            lock_path.unlink()
+        with suppress(OSError):
+            _fsync_profile_home(profile_home)
+
+
 def authority_identity(
     profile_home: Path,
     profile_name: Optional[str] = None,
 ) -> AuthorityIdentity:
-    """Derive authority from the active profile home, never request routing.
-
-    The canonical home path is hashed rather than exposed. The resulting
-    profile-instance identity is deterministic for that durable home and is
-    persisted in ledger metadata, so moving a database to another profile
-    home fails closed.
-    """
+    """Derive authority from the durable anchor, never routing or a home path."""
 
     canonical_home = Path(profile_home).expanduser().resolve(strict=False)
-    home_fingerprint = hashlib.sha256(
-        b"hermes-execution-profile-home-v1\x00"
-        + str(canonical_home).encode("utf-8")
+    anchor_id = _read_profile_anchor(canonical_home)
+    fingerprint = hashlib.sha256(
+        b"hermes-execution-profile-anchor-v1\x00" + bytes.fromhex(anchor_id)
     ).hexdigest()
-    profile_key = home_fingerprint[:12]
+    profile_key = fingerprint[:12]
     clean = _normalize_profile_name(profile_name or canonical_home.name or "profile")
-    instance = home_fingerprint[:24]
+    instance = fingerprint[:24]
     return AuthorityIdentity(
         profile_id=f"hermes-profile-instance:{instance}",
         profile_name=clean,
@@ -356,19 +551,48 @@ class ExecutionContractStore:
         ).expanduser().resolve(strict=False)
         self.profile_home = active_home
         self.database_path = database_path or (active_home / "execution_contract.sqlite3")
-        self.authority = authority_identity(active_home, profile_name)
+        self.profile_name = _normalize_profile_name(
+            profile_name or active_home.name or "profile"
+        )
+        self._authority: Optional[AuthorityIdentity] = None
         self.runtime_instance_id = runtime_instance_id or uuid.uuid4().hex
+
+    @property
+    def authority(self) -> AuthorityIdentity:
+        if self._authority is None:
+            self._authority = authority_identity(
+                self.profile_home,
+                self.profile_name,
+            )
+        return self._authority
+
+    @property
+    def profile_anchor_path(self) -> Path:
+        return _profile_anchor_path(self.profile_home)
 
     # ------------------------------------------------------------------
     # Connection and schema lifecycle
     # ------------------------------------------------------------------
 
     def initialize(self) -> None:
+        self.profile_home.mkdir(parents=True, exist_ok=True, mode=0o700)
+        try:
+            self.profile_home.chmod(0o700)
+        except OSError:
+            pass
         self.database_path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
         try:
             self.database_path.parent.chmod(0o700)
         except OSError:
             pass
+        ledger_exists = self.database_path.exists()
+        if ledger_exists and not _profile_anchor_exists(self.profile_home):
+            raise ContractDataError(
+                "existing execution ledger is missing its profile instance anchor"
+            )
+        if not _profile_anchor_exists(self.profile_home):
+            _create_profile_anchor(self.profile_home)
+        self._authority = authority_identity(self.profile_home, self.profile_name)
         connection = self._connect_write()
         try:
             version = int(connection.execute("PRAGMA user_version").fetchone()[0])
@@ -1069,26 +1293,11 @@ class ExecutionContractStore:
         connection = self._connect_write()
         try:
             with write_txn(connection):
+                self._after_write_lock_acquired("decision", execution_id)
                 execution = self._execution_row(connection, execution_id)
                 if execution is None:
                     raise ContractNotFoundError("execution not found")
                 current_lifecycle = str(execution["lifecycle"])
-                pending = connection.execute(
-                    "SELECT decision_id FROM decisions "
-                    "WHERE execution_id=? AND state='pending' LIMIT 1",
-                    (execution_id,),
-                ).fetchone()
-                if pending is not None:
-                    raise ContractConflictError(
-                        "execution already has a pending decision"
-                    )
-                if "awaiting_decision" not in _ALLOWED_TRANSITIONS.get(
-                    current_lifecycle,
-                    frozenset(),
-                ):
-                    raise ContractConflictError(
-                        f"execution cannot request a decision from {current_lifecycle}"
-                    )
                 if execution["effect_id"] != effect_id:
                     raise ContractConflictError("decision effect binding mismatch")
                 if execution["proposal_ref"] != proposal_ref:
@@ -1119,6 +1328,31 @@ class ExecutionContractStore:
                             "decision request digest has conflicting bindings"
                         )
                     return self._decision_from_row(existing)
+                published_effect = connection.execute(
+                    "SELECT 1 FROM effect_evidence WHERE execution_id=? "
+                    "UNION ALL SELECT 1 FROM receipts WHERE execution_id=? LIMIT 1",
+                    (execution_id, execution_id),
+                ).fetchone()
+                if published_effect is not None:
+                    raise ContractConflictError(
+                        "execution effect evidence already exists; no new decision is allowed"
+                    )
+                pending = connection.execute(
+                    "SELECT decision_id FROM decisions "
+                    "WHERE execution_id=? AND state='pending' LIMIT 1",
+                    (execution_id,),
+                ).fetchone()
+                if pending is not None:
+                    raise ContractConflictError(
+                        "execution already has a pending decision"
+                    )
+                if "awaiting_decision" not in _ALLOWED_TRANSITIONS.get(
+                    current_lifecycle,
+                    frozenset(),
+                ):
+                    raise ContractConflictError(
+                        f"execution cannot request a decision from {current_lifecycle}"
+                    )
                 connection.execute(
                     """
                     INSERT INTO decisions(
@@ -1502,6 +1736,7 @@ class ExecutionContractStore:
         connection = self._connect_write()
         try:
             with write_txn(connection):
+                self._after_write_lock_acquired("evidence", execution_id)
                 execution = self._execution_row(connection, execution_id)
                 if execution is None:
                     raise ContractNotFoundError("execution not found")
@@ -1691,6 +1926,7 @@ class ExecutionContractStore:
                     raise ContractNotFoundError("execution not found")
                 if execution["effect_id"] != effect_id:
                     raise ContractConflictError("effect evidence binding mismatch")
+                actual_recovery_ref = recovery_ref or execution["recovery_ref"]
                 if (
                     execution["lifecycle"] != "terminal_ambiguous"
                     or execution["receipt_state"] != "unproven"
@@ -1708,6 +1944,7 @@ class ExecutionContractStore:
                             evidence_digest,
                             result_digest,
                             decision_id,
+                            actual_recovery_ref,
                             reconciliation_ref,
                         )
                         actual = (
@@ -1717,6 +1954,7 @@ class ExecutionContractStore:
                             existing_receipt["evidence_digest"],
                             existing_receipt["result_digest"],
                             existing_receipt["decision_id"],
+                            existing_receipt["recovery_ref"],
                             existing_receipt["reconciliation_ref"],
                         )
                         if immutable == actual:
@@ -1762,7 +2000,6 @@ class ExecutionContractStore:
                         "late effect evidence exists without its transactional receipt"
                     )
 
-                actual_recovery_ref = recovery_ref or execution["recovery_ref"]
                 connection.execute(
                     """
                     INSERT INTO effect_evidence(
@@ -2115,18 +2352,33 @@ class ExecutionContractStore:
                         "event cursor is ahead of high-water"
                     )
                 return self._event_page([], after, 0, 1, False, 0, 0)
+            sequence_row = connection.execute(
+                "SELECT seq FROM sqlite_sequence WHERE name='execution_events'"
+            ).fetchone()
+            allocated_high_water = int(sequence_row[0]) if sequence_row else 0
             current_high_water = int(
                 connection.execute(
                     "SELECT COALESCE(MAX(sequence), 0) FROM execution_events"
                 ).fetchone()[0]
             )
-            pruned_through = int(
-                connection.execute(
-                    "SELECT value FROM execution_contract_metadata "
-                    "WHERE key='events_pruned_through'"
-                ).fetchone()[0]
-            )
-            available_high_water = max(current_high_water, pruned_through)
+            try:
+                pruned_through = int(
+                    connection.execute(
+                        "SELECT value FROM execution_contract_metadata "
+                        "WHERE key='events_pruned_through'"
+                    ).fetchone()[0]
+                )
+            except (TypeError, ValueError, sqlite3.Error) as exc:
+                raise ContractDataError("event retention watermark is corrupt") from exc
+            if (
+                allocated_high_water < 0
+                or current_high_water < 0
+                or current_high_water > allocated_high_water
+                or pruned_through < 0
+                or pruned_through > allocated_high_water
+            ):
+                raise ContractDataError("event high-water metadata is corrupt")
+            available_high_water = allocated_high_water
             high_water = (
                 available_high_water
                 if snapshot_high_water is None
@@ -2147,6 +2399,11 @@ class ExecutionContractStore:
             if after < pruned_through:
                 raise ContractCursorGoneError(minimum_available, high_water)
             self._after_snapshot_pinned("events", high_water)
+            self._validate_global_event_continuity(
+                connection,
+                pruned_through=pruned_through,
+                snapshot_high_water=high_water,
+            )
             params: list[Any] = [after, high_water]
             where = "sequence > ? AND sequence <= ?"
             if execution_id:
@@ -2263,6 +2520,8 @@ class ExecutionContractStore:
                 evidence["evidence_digest"],
                 evidence["result_digest"],
                 evidence["decision_id"],
+                evidence["recovery_ref"],
+                evidence["reconciliation_ref"],
             )
             actual = tuple(
                 existing[key]
@@ -2273,6 +2532,8 @@ class ExecutionContractStore:
                     "evidence_digest",
                     "result_digest",
                     "decision_id",
+                    "recovery_ref",
+                    "reconciliation_ref",
                 )
             )
             if immutable != actual:
@@ -2712,6 +2973,8 @@ class ExecutionContractStore:
                 ("evidence_digest", evidence_digest),
                 ("result_digest", result_digest),
                 ("decision_id", decision_id),
+                ("recovery_ref", recovery_ref),
+                ("reconciliation_ref", reconciliation_ref),
             ):
                 if evidence[field] != expected:
                     raise ContractDataError("receipt evidence binding is invalid")
@@ -2945,6 +3208,40 @@ class ExecutionContractStore:
 
     def _after_snapshot_pinned(self, _collection: str, _high_water: int) -> None:
         """Test seam called inside the pinned SQLite read transaction."""
+
+    def _after_write_lock_acquired(self, _operation: str, _execution_id: str) -> None:
+        """Test seam called only after BEGIN IMMEDIATE owns the writer lock."""
+
+    @staticmethod
+    def _validate_global_event_continuity(
+        connection: sqlite3.Connection,
+        *,
+        pruned_through: int,
+        snapshot_high_water: int,
+    ) -> None:
+        """Prove the complete unfiltered global interval for this snapshot."""
+
+        if snapshot_high_water < pruned_through:
+            raise ContractDataError("event snapshot predates the retention watermark")
+        expected_count = snapshot_high_water - pruned_through
+        row = connection.execute(
+            "SELECT COUNT(*), MIN(sequence), MAX(sequence) "
+            "FROM execution_events WHERE sequence > ? AND sequence <= ?",
+            (pruned_through, snapshot_high_water),
+        ).fetchone()
+        count = int(row[0])
+        minimum = int(row[1]) if row[1] is not None else None
+        maximum = int(row[2]) if row[2] is not None else None
+        if expected_count == 0:
+            if count != 0 or minimum is not None or maximum is not None:
+                raise ContractDataError("global event sequence continuity failed")
+            return
+        if (
+            count != expected_count
+            or minimum != pruned_through + 1
+            or maximum != snapshot_high_water
+        ):
+            raise ContractDataError("global event sequence gap detected")
 
     @staticmethod
     def _collection_page(

--- a/hermes_cli/execution_contract.py
+++ b/hermes_cli/execution_contract.py
@@ -1285,8 +1285,6 @@ class ExecutionContractStore:
             raise ContractValidationError("expires_at must be timezone-aware")
         if instant_dt.tzinfo is None or instant_dt.utcoffset() is None:
             raise ContractValidationError("now must be timezone-aware")
-        if expires_at.astimezone(timezone.utc) <= instant_dt.astimezone(timezone.utc):
-            raise ContractValidationError("expires_at must be in the future")
         instant = _timestamp(instant_dt)
         expiry = _timestamp(expires_at)
         decision_id = self._new_id("dec")
@@ -1328,6 +1326,10 @@ class ExecutionContractStore:
                             "decision request digest has conflicting bindings"
                         )
                     return self._decision_from_row(existing)
+                if expires_at.astimezone(timezone.utc) <= instant_dt.astimezone(
+                    timezone.utc
+                ):
+                    raise ContractValidationError("expires_at must be in the future")
                 published_effect = connection.execute(
                     "SELECT 1 FROM effect_evidence WHERE execution_id=? "
                     "UNION ALL SELECT 1 FROM receipts WHERE execution_id=? LIMIT 1",
@@ -2106,38 +2108,72 @@ class ExecutionContractStore:
         connection = self._connect_write()
         try:
             with write_txn(connection):
+                self._after_write_lock_acquired("prune", "")
+                try:
+                    prior = int(
+                        connection.execute(
+                            "SELECT value FROM execution_contract_metadata "
+                            "WHERE key='events_pruned_through'"
+                        ).fetchone()[0]
+                    )
+                except (TypeError, ValueError, sqlite3.Error) as exc:
+                    raise ContractDataError(
+                        "event retention watermark is corrupt"
+                    ) from exc
+                sequence_row = connection.execute(
+                    "SELECT seq FROM sqlite_sequence "
+                    "WHERE name='execution_events'"
+                ).fetchone()
+                allocated_high_water = int(sequence_row[0]) if sequence_row else 0
+                current_high_water = int(
+                    connection.execute(
+                        "SELECT COALESCE(MAX(sequence), 0) FROM execution_events"
+                    ).fetchone()[0]
+                )
+                if (
+                    prior < 0
+                    or allocated_high_water < 0
+                    or current_high_water < 0
+                    or prior > allocated_high_water
+                    or current_high_water > allocated_high_water
+                ):
+                    raise ContractDataError("event high-water metadata is corrupt")
                 rows = connection.execute(
                     """
                     SELECT ev.sequence, ev.occurred_at, ex.lifecycle
                     FROM execution_events ev
                     JOIN executions ex ON ex.execution_id = ev.execution_id
+                    WHERE ev.sequence > ?
                     ORDER BY ev.sequence ASC
-                    """
+                    """,
+                    (prior,),
                 ).fetchall()
-                through = 0
+                through = allocated_high_water
                 for row in rows:
                     if not (
                         str(row["occurred_at"]) < cutoff_text
                         and str(row["lifecycle"]).startswith("terminal_")
                     ):
+                        through = int(row["sequence"]) - 1
                         break
-                    through = int(row["sequence"])
-                if through <= 0:
+                if through <= prior:
                     return 0
+                self._validate_global_event_continuity(
+                    connection,
+                    pruned_through=prior,
+                    snapshot_high_water=through,
+                )
                 deleted = connection.execute(
                     "DELETE FROM execution_events WHERE sequence <= ?",
                     (through,),
                 ).rowcount
-                prior = int(
-                    connection.execute(
-                        "SELECT value FROM execution_contract_metadata "
-                        "WHERE key='events_pruned_through'"
-                    ).fetchone()[0]
-                )
+                expected_deleted = through - prior
+                if int(deleted or 0) != expected_deleted:
+                    raise ContractDataError("event pruning row count is inconsistent")
                 connection.execute(
                     "UPDATE execution_contract_metadata SET value=? "
                     "WHERE key='events_pruned_through'",
-                    (str(max(prior, through)),),
+                    (str(through),),
                 )
                 return int(deleted or 0)
         finally:
@@ -2957,8 +2993,6 @@ class ExecutionContractStore:
                 execution["terminal_at"],
                 field="execution_terminal_at",
             )
-            if terminal < execution_terminal:
-                raise ContractDataError("receipt terminal timestamp precedes execution")
             evidence = connection.execute(
                 "SELECT * FROM effect_evidence WHERE execution_id=?",
                 (execution_id,),
@@ -2966,6 +3000,24 @@ class ExecutionContractStore:
             if evidence is None:
                 raise ContractDataError("receipt effect evidence is missing")
             self._evidence_from_row(evidence, connection=connection)
+            evidence_recorded = _parse_timestamp(
+                evidence["recorded_at"],
+                field="evidence_recorded_at",
+            )
+            if evidence_recorded > execution_terminal:
+                if (
+                    reconciliation_ref is None
+                    or outcome != "ambiguous"
+                    or execution["lifecycle"] != "terminal_ambiguous"
+                    or terminal != evidence_recorded
+                ):
+                    raise ContractDataError(
+                        "reconciled receipt terminal timestamp must equal evidence recorded timestamp"
+                    )
+            elif terminal != execution_terminal:
+                raise ContractDataError(
+                    "receipt terminal timestamp must equal execution terminal timestamp"
+                )
             for field, expected in (
                 ("effect_id", effect_id),
                 ("outcome", outcome),

--- a/hermes_cli/execution_contract.py
+++ b/hermes_cli/execution_contract.py
@@ -20,7 +20,7 @@ import json
 import re
 import sqlite3
 import uuid
-from contextlib import contextmanager
+from contextlib import contextmanager, suppress
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
@@ -121,6 +121,7 @@ _ALLOWED_TRANSITIONS: dict[str, frozenset[str]] = {
 }
 
 _ID_RE = re.compile(r"^(exe|dec|rcp|evt)_([0-9a-f]{12})_([0-9a-f]{32})$")
+_EVIDENCE_ID_RE = re.compile(r"^evd_([0-9a-f]{12})_([0-9a-f]{32})$")
 _SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
 _CONTROL_RE = re.compile(r"[\x00-\x1f\x7f]")
 
@@ -139,6 +140,10 @@ class ContractNotFoundError(ExecutionContractError):
 
 class ContractForbiddenError(ExecutionContractError):
     """An identifier belongs to a different profile authority."""
+
+
+class ContractUnauthorizedError(ExecutionContractError):
+    """The request did not present valid credentials for this contract."""
 
 
 class ContractConflictError(ExecutionContractError):
@@ -219,17 +224,31 @@ def _normalize_profile_name(profile_name: str) -> str:
     return clean
 
 
-def authority_identity(profile_name: str) -> AuthorityIdentity:
-    """Return the server-asserted authority identity for one Hermes profile."""
+def authority_identity(
+    profile_home: Path,
+    profile_name: Optional[str] = None,
+) -> AuthorityIdentity:
+    """Derive authority from the active profile home, never request routing.
 
-    clean = _normalize_profile_name(profile_name)
-    profile_id = f"hermes-profile:{clean}"
-    profile_key = hashlib.sha256(profile_id.encode("utf-8")).hexdigest()[:12]
+    The canonical home path is hashed rather than exposed. The resulting
+    profile-instance identity is deterministic for that durable home and is
+    persisted in ledger metadata, so moving a database to another profile
+    home fails closed.
+    """
+
+    canonical_home = Path(profile_home).expanduser().resolve(strict=False)
+    home_fingerprint = hashlib.sha256(
+        b"hermes-execution-profile-home-v1\x00"
+        + str(canonical_home).encode("utf-8")
+    ).hexdigest()
+    profile_key = home_fingerprint[:12]
+    clean = _normalize_profile_name(profile_name or canonical_home.name or "profile")
+    instance = home_fingerprint[:24]
     return AuthorityIdentity(
-        profile_id=profile_id,
+        profile_id=f"hermes-profile-instance:{instance}",
         profile_name=clean,
-        authority_id=f"hermes-execution-authority:{clean}",
-        executor_id=f"hermes-agent:{clean}",
+        authority_id=f"hermes-execution-authority:{instance}",
+        executor_id=f"hermes-agent-executor:{instance}",
         profile_key=profile_key,
     )
 
@@ -314,6 +333,12 @@ def _validated_cursor(after: int) -> int:
     return value
 
 
+def _validated_snapshot(value: Optional[int]) -> Optional[int]:
+    if value in (None, ""):
+        return None
+    return _validated_cursor(cast(int, value))
+
+
 class ExecutionContractStore:
     """Profile-local durable authority store and read projection."""
 
@@ -321,13 +346,17 @@ class ExecutionContractStore:
         self,
         *,
         database_path: Optional[Path] = None,
-        profile_name: str = "default",
+        profile_home: Optional[Path] = None,
+        profile_name: Optional[str] = None,
         runtime_instance_id: Optional[str] = None,
     ) -> None:
-        self.database_path = database_path or (
-            get_hermes_home() / "execution_contract.sqlite3"
-        )
-        self.authority = authority_identity(profile_name)
+        active_home = Path(
+            profile_home
+            or (database_path.parent if database_path is not None else get_hermes_home())
+        ).expanduser().resolve(strict=False)
+        self.profile_home = active_home
+        self.database_path = database_path or (active_home / "execution_contract.sqlite3")
+        self.authority = authority_identity(active_home, profile_name)
         self.runtime_instance_id = runtime_instance_id or uuid.uuid4().hex
 
     # ------------------------------------------------------------------
@@ -394,6 +423,7 @@ class ExecutionContractStore:
             connection.execute("PRAGMA query_only=ON")
             connection.execute("PRAGMA foreign_keys=ON")
             connection.execute("PRAGMA busy_timeout=1000")
+            connection.execute("BEGIN")
             version = int(connection.execute("PRAGMA user_version").fetchone()[0])
             if version != STORE_SCHEMA_VERSION:
                 raise UnsupportedContractVersionError(
@@ -417,6 +447,8 @@ class ExecutionContractStore:
         try:
             yield connection
         finally:
+            with suppress(sqlite3.Error):
+                connection.rollback()
             connection.close()
 
     def _tighten_permissions(self) -> None:
@@ -770,6 +802,7 @@ class ExecutionContractStore:
                         receipt_state = "unproven"
                         event_reason = event_reason or "effect_evidence_missing"
                     else:
+                        self._evidence_from_row(evidence, connection=connection)
                         actual_lifecycle = f"terminal_{evidence['outcome']}"
                         receipt_id = self._publish_receipt_in_txn(
                             connection,
@@ -790,7 +823,11 @@ class ExecutionContractStore:
                     "ORDER BY ordinal ASC",
                     (execution_id,),
                 ).fetchall()
-                if actual_lifecycle in TERMINAL_EXECUTION_STATES:
+                closes_decisions = (
+                    actual_lifecycle in TERMINAL_EXECUTION_STATES
+                    or actual_lifecycle == "cancellation_requested"
+                )
+                if closes_decisions:
                     for decision in pending_decisions:
                         connection.execute(
                             """
@@ -846,7 +883,7 @@ class ExecutionContractStore:
                     revision=new_revision,
                 )
                 for decision in pending_decisions:
-                    if actual_lifecycle in TERMINAL_EXECUTION_STATES:
+                    if closes_decisions:
                         self._append_event_in_txn(
                             connection,
                             execution_id=execution_id,
@@ -854,7 +891,11 @@ class ExecutionContractStore:
                             from_lifecycle=actual_lifecycle,
                             to_lifecycle=actual_lifecycle,
                             decision_id=decision["decision_id"],
-                            reason_code="execution_terminal",
+                            reason_code=(
+                                "execution_terminal"
+                                if actual_lifecycle in TERMINAL_EXECUTION_STATES
+                                else "execution_cancellation_requested"
+                            ),
                             occurred_at=instant,
                             revision=new_revision,
                         )
@@ -910,6 +951,20 @@ class ExecutionContractStore:
                     receipt_state = (
                         "unproven" if row["effect_id"] else "not_applicable"
                     )
+                    pending_decisions = connection.execute(
+                        "SELECT * FROM decisions WHERE execution_id=? AND state='pending' "
+                        "ORDER BY ordinal ASC",
+                        (row["execution_id"],),
+                    ).fetchall()
+                    for decision in pending_decisions:
+                        connection.execute(
+                            """
+                            UPDATE decisions
+                            SET state='superseded', updated_at=?, revision=revision+1
+                            WHERE decision_id=? AND state='pending'
+                            """,
+                            (instant, decision["decision_id"]),
+                        )
                     connection.execute(
                         """
                         UPDATE executions
@@ -938,6 +993,18 @@ class ExecutionContractStore:
                         occurred_at=instant,
                         revision=revision,
                     )
+                    for decision in pending_decisions:
+                        self._append_event_in_txn(
+                            connection,
+                            execution_id=row["execution_id"],
+                            event_type="decision.superseded",
+                            from_lifecycle="terminal_ambiguous",
+                            to_lifecycle="terminal_ambiguous",
+                            decision_id=decision["decision_id"],
+                            reason_code="runtime_restarted",
+                            occurred_at=instant,
+                            revision=revision,
+                        )
                     recovered.append(str(row["execution_id"]))
             return recovered
         finally:
@@ -1005,8 +1072,23 @@ class ExecutionContractStore:
                 execution = self._execution_row(connection, execution_id)
                 if execution is None:
                     raise ContractNotFoundError("execution not found")
-                if execution["lifecycle"] in TERMINAL_EXECUTION_STATES:
-                    raise ContractConflictError("terminal execution cannot request a decision")
+                current_lifecycle = str(execution["lifecycle"])
+                pending = connection.execute(
+                    "SELECT decision_id FROM decisions "
+                    "WHERE execution_id=? AND state='pending' LIMIT 1",
+                    (execution_id,),
+                ).fetchone()
+                if pending is not None:
+                    raise ContractConflictError(
+                        "execution already has a pending decision"
+                    )
+                if "awaiting_decision" not in _ALLOWED_TRANSITIONS.get(
+                    current_lifecycle,
+                    frozenset(),
+                ):
+                    raise ContractConflictError(
+                        f"execution cannot request a decision from {current_lifecycle}"
+                    )
                 if execution["effect_id"] != effect_id:
                     raise ContractConflictError("decision effect binding mismatch")
                 if execution["proposal_ref"] != proposal_ref:
@@ -1037,15 +1119,6 @@ class ExecutionContractStore:
                             "decision request digest has conflicting bindings"
                         )
                     return self._decision_from_row(existing)
-                pending = connection.execute(
-                    "SELECT decision_id FROM decisions "
-                    "WHERE execution_id=? AND state='pending' LIMIT 1",
-                    (execution_id,),
-                ).fetchone()
-                if pending is not None:
-                    raise ContractConflictError(
-                        "execution already has a pending decision"
-                    )
                 connection.execute(
                     """
                     INSERT INTO decisions(
@@ -1076,15 +1149,23 @@ class ExecutionContractStore:
                     """
                     UPDATE executions
                     SET lifecycle='awaiting_decision', updated_at=?, revision=?
-                    WHERE execution_id=?
+                    WHERE execution_id=? AND revision=? AND lifecycle=?
                     """,
-                    (instant, revision, execution_id),
+                    (
+                        instant,
+                        revision,
+                        execution_id,
+                        execution["revision"],
+                        current_lifecycle,
+                    ),
                 )
+                if connection.execute("SELECT changes()").fetchone()[0] != 1:
+                    raise ContractConflictError("execution decision transition conflict")
                 self._append_event_in_txn(
                     connection,
                     execution_id=execution_id,
                     event_type="decision.requested",
-                    from_lifecycle=execution["lifecycle"],
+                    from_lifecycle=current_lifecycle,
                     to_lifecycle="awaiting_decision",
                     decision_id=decision_id,
                     occurred_at=instant,
@@ -1155,6 +1236,17 @@ class ExecutionContractStore:
                 choices = json.loads(row["allowed_choices_json"])
                 if choice not in choices:
                     raise ContractValidationError("choice is not allowed")
+                execution = self._execution_row(connection, row["execution_id"])
+                if execution is None:
+                    raise ContractDataError("decision execution is missing")
+                current_lifecycle = str(execution["lifecycle"])
+                if "running" not in _ALLOWED_TRANSITIONS.get(
+                    current_lifecycle,
+                    frozenset(),
+                ):
+                    raise ContractConflictError(
+                        f"decision cannot resolve execution from {current_lifecycle}"
+                    )
                 connection.execute(
                     """
                     UPDATE decisions
@@ -1164,21 +1256,29 @@ class ExecutionContractStore:
                     """,
                     (choice, evidence_digest, instant, instant, decision_id, expected_revision),
                 )
-                execution = self._execution_row(connection, row["execution_id"])
-                assert execution is not None
+                if connection.execute("SELECT changes()").fetchone()[0] != 1:
+                    raise ContractConflictError("decision revision conflict")
                 execution_revision = int(execution["revision"]) + 1
                 connection.execute(
                     """
                     UPDATE executions SET lifecycle='running', updated_at=?, revision=?
-                    WHERE execution_id=?
+                    WHERE execution_id=? AND revision=? AND lifecycle=?
                     """,
-                    (instant, execution_revision, row["execution_id"]),
+                    (
+                        instant,
+                        execution_revision,
+                        row["execution_id"],
+                        execution["revision"],
+                        current_lifecycle,
+                    ),
                 )
+                if connection.execute("SELECT changes()").fetchone()[0] != 1:
+                    raise ContractConflictError("execution decision transition conflict")
                 self._append_event_in_txn(
                     connection,
                     execution_id=row["execution_id"],
                     event_type="decision.resolved",
-                    from_lifecycle=execution["lifecycle"],
+                    from_lifecycle=current_lifecycle,
                     to_lifecycle="running",
                     decision_id=decision_id,
                     occurred_at=instant,
@@ -1286,6 +1386,17 @@ class ExecutionContractStore:
                     raise ContractNotFoundError("decision not found")
                 if row["state"] != "pending":
                     raise ContractConflictError("decision is not pending")
+                execution = self._execution_row(connection, row["execution_id"])
+                if execution is None:
+                    raise ContractDataError("decision execution is missing")
+                current_lifecycle = str(execution["lifecycle"])
+                if "running" not in _ALLOWED_TRANSITIONS.get(
+                    current_lifecycle,
+                    frozenset(),
+                ):
+                    raise ContractConflictError(
+                        f"decision cannot be superseded from {current_lifecycle}"
+                    )
                 connection.execute(
                     """
                     UPDATE decisions SET state='superseded', updated_at=?,
@@ -1293,21 +1404,29 @@ class ExecutionContractStore:
                     """,
                     (instant, decision_id),
                 )
-                execution = self._execution_row(connection, row["execution_id"])
-                assert execution is not None
+                if connection.execute("SELECT changes()").fetchone()[0] != 1:
+                    raise ContractConflictError("decision supersession conflict")
                 revision = int(execution["revision"]) + 1
                 connection.execute(
                     """
                     UPDATE executions SET lifecycle='running', updated_at=?, revision=?
-                    WHERE execution_id=?
+                    WHERE execution_id=? AND revision=? AND lifecycle=?
                     """,
-                    (instant, revision, row["execution_id"]),
+                    (
+                        instant,
+                        revision,
+                        row["execution_id"],
+                        execution["revision"],
+                        current_lifecycle,
+                    ),
                 )
+                if connection.execute("SELECT changes()").fetchone()[0] != 1:
+                    raise ContractConflictError("execution decision transition conflict")
                 self._append_event_in_txn(
                     connection,
                     execution_id=row["execution_id"],
                     event_type="decision.superseded",
-                    from_lifecycle=execution["lifecycle"],
+                    from_lifecycle=current_lifecycle,
                     to_lifecycle="running",
                     decision_id=decision_id,
                     reason_code=reason_code,
@@ -1388,41 +1507,47 @@ class ExecutionContractStore:
                     raise ContractNotFoundError("execution not found")
                 if execution["effect_id"] != effect_id:
                     raise ContractConflictError("effect evidence binding mismatch")
-                bound_decisions = connection.execute(
-                    "SELECT * FROM decisions WHERE execution_id=? ORDER BY ordinal DESC",
+                if (
+                    execution["lifecycle"] == "terminal_ambiguous"
+                    and execution["receipt_state"] == "unproven"
+                ):
+                    raise ContractConflictError(
+                        "late ambiguous evidence requires the reconciliation path"
+                    )
+                latest_decision = connection.execute(
+                    "SELECT * FROM decisions WHERE execution_id=? "
+                    "ORDER BY ordinal DESC LIMIT 1",
                     (execution_id,),
-                ).fetchall()
-                if bound_decisions:
+                ).fetchone()
+                if latest_decision is not None:
+                    if latest_decision["state"] == "pending":
+                        raise ContractConflictError(
+                            "newer pending decision blocks effect evidence"
+                        )
+                    if latest_decision["state"] != "resolved":
+                        raise ContractConflictError(
+                            "latest decision does not authorize effect evidence"
+                        )
                     if not decision_id:
                         raise ContractConflictError(
-                            "effect evidence requires its exact decision binding"
+                            "effect evidence requires its exact decision binding to the "
+                            "latest resolved decision"
                         )
-                    matching = next(
-                        (
-                            row
-                            for row in bound_decisions
-                            if row["decision_id"] == decision_id
-                        ),
-                        None,
-                    )
-                    if matching is None:
+                    if latest_decision["decision_id"] != decision_id:
                         raise ContractConflictError(
-                            "effect evidence decision is not bound to the execution"
+                            "effect evidence is not bound to the latest decision"
                         )
-                    if matching["state"] != "resolved":
-                        raise ContractConflictError("decision is not resolved")
-                if decision_id:
-                    decision = connection.execute(
-                        "SELECT * FROM decisions WHERE decision_id=?",
-                        (decision_id,),
-                    ).fetchone()
-                    if decision is None:
-                        raise ContractNotFoundError("decision not found")
                     if (
-                        decision["execution_id"] != execution_id
-                        or decision["effect_id"] != effect_id
+                        latest_decision["execution_id"] != execution_id
+                        or latest_decision["effect_id"] != effect_id
+                        or latest_decision["proposal_ref"]
+                        != execution["proposal_ref"]
                     ):
                         raise ContractConflictError("decision evidence binding mismatch")
+                elif decision_id:
+                    raise ContractConflictError(
+                        "effect evidence decision is not bound to the execution"
+                    )
                 existing = connection.execute(
                     "SELECT * FROM effect_evidence WHERE execution_id=?",
                     (execution_id,),
@@ -1497,6 +1622,236 @@ class ExecutionContractStore:
         finally:
             connection.close()
 
+    def reconcile_ambiguous_evidence(
+        self,
+        *,
+        execution_id: str,
+        effect_id: str,
+        outcome: str,
+        subject_digest: str,
+        evidence_digest: str,
+        result_digest: str,
+        reconciliation_ref: str,
+        decision_id: Optional[str] = None,
+        recovery_ref: Optional[str] = None,
+        now: Optional[datetime] = None,
+    ) -> dict[str, Any]:
+        """Publish late authoritative ambiguous evidence in one transaction.
+
+        This path never upgrades an ambiguous execution to success. It exists
+        only for an executor that can later prove that the terminal outcome
+        itself was ambiguous; generic process, chat, session, or Kanban state
+        is not accepted as evidence.
+        """
+
+        self.initialize()
+        self._assert_identifier_scope(execution_id, "exe")
+        if outcome != "ambiguous":
+            raise ContractValidationError(
+                "late reconciliation only accepts authoritative ambiguous evidence"
+            )
+        effect_id = cast(
+            str,
+            _validated_ref(effect_id, field="effect_id", required=True),
+        )
+        subject_digest = cast(
+            str,
+            _validated_digest(subject_digest, field="subject_digest", required=True),
+        )
+        evidence_digest = cast(
+            str,
+            _validated_digest(
+                evidence_digest,
+                field="evidence_digest",
+                required=True,
+            ),
+        )
+        result_digest = cast(
+            str,
+            _validated_digest(result_digest, field="result_digest", required=True),
+        )
+        if decision_id:
+            self._assert_identifier_scope(decision_id, "dec")
+        recovery_ref = _validated_ref(recovery_ref, field="recovery_ref")
+        reconciliation_ref = cast(
+            str,
+            _validated_ref(
+                reconciliation_ref,
+                field="reconciliation_ref",
+                required=True,
+            ),
+        )
+        instant = _timestamp(now)
+        evidence_id = f"evd_{self.authority.profile_key}_{uuid.uuid4().hex}"
+        connection = self._connect_write()
+        try:
+            with write_txn(connection):
+                execution = self._execution_row(connection, execution_id)
+                if execution is None:
+                    raise ContractNotFoundError("execution not found")
+                if execution["effect_id"] != effect_id:
+                    raise ContractConflictError("effect evidence binding mismatch")
+                if (
+                    execution["lifecycle"] != "terminal_ambiguous"
+                    or execution["receipt_state"] != "unproven"
+                    or execution["receipt_id"] is not None
+                ):
+                    existing_receipt = connection.execute(
+                        "SELECT * FROM receipts WHERE execution_id=?",
+                        (execution_id,),
+                    ).fetchone()
+                    if existing_receipt is not None:
+                        immutable = (
+                            effect_id,
+                            outcome,
+                            subject_digest,
+                            evidence_digest,
+                            result_digest,
+                            decision_id,
+                            reconciliation_ref,
+                        )
+                        actual = (
+                            existing_receipt["effect_id"],
+                            existing_receipt["outcome"],
+                            existing_receipt["subject_digest"],
+                            existing_receipt["evidence_digest"],
+                            existing_receipt["result_digest"],
+                            existing_receipt["decision_id"],
+                            existing_receipt["reconciliation_ref"],
+                        )
+                        if immutable == actual:
+                            return self._receipt_from_row(
+                                existing_receipt,
+                                connection=connection,
+                            )
+                    raise ContractConflictError(
+                        "execution is not eligible for late ambiguous reconciliation"
+                    )
+
+                latest_decision = connection.execute(
+                    "SELECT * FROM decisions WHERE execution_id=? "
+                    "ORDER BY ordinal DESC LIMIT 1",
+                    (execution_id,),
+                ).fetchone()
+                if latest_decision is not None:
+                    if latest_decision["state"] == "pending":
+                        raise ContractConflictError(
+                            "newer pending decision blocks effect evidence"
+                        )
+                    if (
+                        latest_decision["state"] != "resolved"
+                        or latest_decision["decision_id"] != decision_id
+                        or latest_decision["effect_id"] != effect_id
+                        or latest_decision["proposal_ref"]
+                        != execution["proposal_ref"]
+                    ):
+                        raise ContractConflictError(
+                            "late evidence requires the latest resolved decision"
+                        )
+                elif decision_id:
+                    raise ContractConflictError(
+                        "effect evidence decision is not bound to the execution"
+                    )
+
+                existing_evidence = connection.execute(
+                    "SELECT * FROM effect_evidence WHERE execution_id=?",
+                    (execution_id,),
+                ).fetchone()
+                if existing_evidence is not None:
+                    raise ContractDataError(
+                        "late effect evidence exists without its transactional receipt"
+                    )
+
+                actual_recovery_ref = recovery_ref or execution["recovery_ref"]
+                connection.execute(
+                    """
+                    INSERT INTO effect_evidence(
+                        evidence_id, execution_id, profile_id, authority_id,
+                        executor_id, effect_id, outcome, subject_digest,
+                        evidence_digest, result_digest, decision_id, recovery_ref,
+                        reconciliation_ref, recorded_at
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    (
+                        evidence_id,
+                        execution_id,
+                        self.authority.profile_id,
+                        self.authority.authority_id,
+                        self.authority.executor_id,
+                        effect_id,
+                        outcome,
+                        subject_digest,
+                        evidence_digest,
+                        result_digest,
+                        decision_id,
+                        actual_recovery_ref,
+                        reconciliation_ref,
+                        instant,
+                    ),
+                )
+                evidence = connection.execute(
+                    "SELECT * FROM effect_evidence WHERE evidence_id=?",
+                    (evidence_id,),
+                ).fetchone()
+                assert evidence is not None
+                receipt_id = self._publish_receipt_in_txn(
+                    connection,
+                    row=execution,
+                    evidence=evidence,
+                    terminal_at=instant,
+                )
+                revision = int(execution["revision"]) + 1
+                connection.execute(
+                    """
+                    UPDATE executions
+                    SET receipt_state='published', receipt_id=?, updated_at=?,
+                        recovery_ref=?, revision=?, runtime_instance_id=?
+                    WHERE execution_id=? AND revision=?
+                    """,
+                    (
+                        receipt_id,
+                        instant,
+                        actual_recovery_ref,
+                        revision,
+                        self.runtime_instance_id,
+                        execution_id,
+                        execution["revision"],
+                    ),
+                )
+                if connection.execute("SELECT changes()").fetchone()[0] != 1:
+                    raise ContractConflictError("execution reconciliation conflict")
+                self._append_event_in_txn(
+                    connection,
+                    execution_id=execution_id,
+                    event_type="effect.evidence_recorded",
+                    from_lifecycle="terminal_ambiguous",
+                    to_lifecycle="terminal_ambiguous",
+                    decision_id=decision_id,
+                    reason_code="late_ambiguous_evidence",
+                    occurred_at=instant,
+                    revision=revision,
+                )
+                self._append_event_in_txn(
+                    connection,
+                    execution_id=execution_id,
+                    event_type="receipt.published",
+                    from_lifecycle="terminal_ambiguous",
+                    to_lifecycle="terminal_ambiguous",
+                    decision_id=decision_id,
+                    receipt_id=receipt_id,
+                    reason_code="late_ambiguous_reconciliation",
+                    occurred_at=instant,
+                    revision=revision,
+                )
+                receipt = connection.execute(
+                    "SELECT * FROM receipts WHERE receipt_id=?",
+                    (receipt_id,),
+                ).fetchone()
+                assert receipt is not None
+                return self._receipt_from_row(receipt, connection=connection)
+        finally:
+            connection.close()
+
     def prune_events(
         self,
         *,
@@ -1561,18 +1916,26 @@ class ExecutionContractStore:
         after: int = 0,
         limit: int = DEFAULT_PAGE_SIZE,
         lifecycle: Optional[str] = None,
+        snapshot_high_water: Optional[int] = None,
     ) -> dict[str, Any]:
         after = _validated_cursor(after)
         limit = _validated_limit(limit)
+        snapshot_high_water = _validated_snapshot(snapshot_high_water)
         if lifecycle is not None and lifecycle not in EXECUTION_STATES:
             raise ContractValidationError("unknown execution lifecycle")
         with self._read_connection() as connection:
             if connection is None:
-                if after > 0:
+                if after > 0 or snapshot_high_water not in (None, 0):
                     raise ContractConflictError("execution cursor is ahead of high-water")
-                return self._collection_page([], after, 0, 0, False)
-            params: list[Any] = [after]
-            where = "ordinal > ?"
+                return self._collection_page([], after, 0, 0, False, 0)
+            pinned = self._pin_collection_snapshot(
+                connection,
+                table="executions",
+                after=after,
+                requested=snapshot_high_water,
+            )
+            params: list[Any] = [after, pinned]
+            where = "ordinal > ? AND ordinal <= ?"
             if lifecycle:
                 where += " AND lifecycle = ?"
                 params.append(lifecycle)
@@ -1585,9 +1948,9 @@ class ExecutionContractStore:
                 rows,
                 after=after,
                 limit=limit,
-                table="executions",
                 decoder=self._execution_from_row,
                 connection=connection,
+                snapshot_high_water=pinned,
             )
 
     def get_execution(self, execution_id: str) -> dict[str, Any]:
@@ -1598,7 +1961,7 @@ class ExecutionContractStore:
             row = self._execution_row(connection, execution_id)
             if row is None:
                 raise ContractNotFoundError("execution not found")
-            return self._execution_from_row(row)
+            return self._execution_from_row(row, connection=connection)
 
     def get_execution_by_source_run_id(self, source_run_id: str) -> dict[str, Any]:
         source_run_id = cast(
@@ -1618,7 +1981,7 @@ class ExecutionContractStore:
             ).fetchone()
             if row is None:
                 raise ContractNotFoundError("execution not found")
-            return self._execution_from_row(row)
+            return self._execution_from_row(row, connection=connection)
 
     def list_decisions(
         self,
@@ -1626,18 +1989,26 @@ class ExecutionContractStore:
         after: int = 0,
         limit: int = DEFAULT_PAGE_SIZE,
         state: Optional[str] = None,
+        snapshot_high_water: Optional[int] = None,
     ) -> dict[str, Any]:
         after = _validated_cursor(after)
         limit = _validated_limit(limit)
+        snapshot_high_water = _validated_snapshot(snapshot_high_water)
         if state is not None and state not in DECISION_STATES:
             raise ContractValidationError("unknown decision state")
         with self._read_connection() as connection:
             if connection is None:
-                if after > 0:
+                if after > 0 or snapshot_high_water not in (None, 0):
                     raise ContractConflictError("decision cursor is ahead of high-water")
-                return self._collection_page([], after, 0, 0, False)
-            params: list[Any] = [after]
-            where = "ordinal > ?"
+                return self._collection_page([], after, 0, 0, False, 0)
+            pinned = self._pin_collection_snapshot(
+                connection,
+                table="decisions",
+                after=after,
+                requested=snapshot_high_water,
+            )
+            params: list[Any] = [after, pinned]
+            where = "ordinal > ? AND ordinal <= ?"
             if state:
                 where += " AND state = ?"
                 params.append(state)
@@ -1650,9 +2021,9 @@ class ExecutionContractStore:
                 rows,
                 after=after,
                 limit=limit,
-                table="decisions",
                 decoder=self._decision_from_row,
                 connection=connection,
+                snapshot_high_water=pinned,
             )
 
     def get_decision(self, decision_id: str) -> dict[str, Any]:
@@ -1666,7 +2037,7 @@ class ExecutionContractStore:
             ).fetchone()
             if row is None:
                 raise ContractNotFoundError("decision not found")
-            return self._decision_from_row(row)
+            return self._decision_from_row(row, connection=connection)
 
     def list_receipts(
         self,
@@ -1674,18 +2045,26 @@ class ExecutionContractStore:
         after: int = 0,
         limit: int = DEFAULT_PAGE_SIZE,
         outcome: Optional[str] = None,
+        snapshot_high_water: Optional[int] = None,
     ) -> dict[str, Any]:
         after = _validated_cursor(after)
         limit = _validated_limit(limit)
+        snapshot_high_water = _validated_snapshot(snapshot_high_water)
         if outcome is not None and outcome not in RECEIPT_OUTCOMES:
             raise ContractValidationError("unknown receipt outcome")
         with self._read_connection() as connection:
             if connection is None:
-                if after > 0:
+                if after > 0 or snapshot_high_water not in (None, 0):
                     raise ContractConflictError("receipt cursor is ahead of high-water")
-                return self._collection_page([], after, 0, 0, False)
-            params: list[Any] = [after]
-            where = "ordinal > ?"
+                return self._collection_page([], after, 0, 0, False, 0)
+            pinned = self._pin_collection_snapshot(
+                connection,
+                table="receipts",
+                after=after,
+                requested=snapshot_high_water,
+            )
+            params: list[Any] = [after, pinned]
+            where = "ordinal > ? AND ordinal <= ?"
             if outcome:
                 where += " AND outcome = ?"
                 params.append(outcome)
@@ -1698,9 +2077,9 @@ class ExecutionContractStore:
                 rows,
                 after=after,
                 limit=limit,
-                table="receipts",
                 decoder=self._receipt_from_row,
                 connection=connection,
+                snapshot_high_water=pinned,
             )
 
     def get_receipt(self, receipt_id: str) -> dict[str, Any]:
@@ -1714,7 +2093,7 @@ class ExecutionContractStore:
             ).fetchone()
             if row is None:
                 raise ContractNotFoundError("receipt not found")
-            return self._receipt_from_row(row)
+            return self._receipt_from_row(row, connection=connection)
 
     def list_events(
         self,
@@ -1722,18 +2101,20 @@ class ExecutionContractStore:
         after: int = 0,
         limit: int = DEFAULT_PAGE_SIZE,
         execution_id: Optional[str] = None,
+        snapshot_high_water: Optional[int] = None,
     ) -> dict[str, Any]:
         after = _validated_cursor(after)
         limit = _validated_limit(limit)
+        snapshot_high_water = _validated_snapshot(snapshot_high_water)
         if execution_id:
             self._assert_identifier_scope(execution_id, "exe")
         with self._read_connection() as connection:
             if connection is None:
-                if after > 0:
+                if after > 0 or snapshot_high_water not in (None, 0):
                     raise ContractConflictError(
                         "event cursor is ahead of high-water"
                     )
-                return self._event_page([], after, 0, 1, False, 0)
+                return self._event_page([], after, 0, 1, False, 0, 0)
             current_high_water = int(
                 connection.execute(
                     "SELECT COALESCE(MAX(sequence), 0) FROM execution_events"
@@ -1745,7 +2126,16 @@ class ExecutionContractStore:
                     "WHERE key='events_pruned_through'"
                 ).fetchone()[0]
             )
-            high_water = max(current_high_water, pruned_through)
+            available_high_water = max(current_high_water, pruned_through)
+            high_water = (
+                available_high_water
+                if snapshot_high_water is None
+                else snapshot_high_water
+            )
+            if high_water > available_high_water:
+                raise ContractConflictError("event snapshot is ahead of high-water")
+            if after > high_water:
+                raise ContractConflictError("event cursor is ahead of snapshot")
             minimum_available_row = connection.execute(
                 "SELECT MIN(sequence) FROM execution_events"
             ).fetchone()
@@ -1756,10 +2146,9 @@ class ExecutionContractStore:
             )
             if after < pruned_through:
                 raise ContractCursorGoneError(minimum_available, high_water)
-            if after > high_water:
-                raise ContractConflictError("event cursor is ahead of high-water")
-            params: list[Any] = [after]
-            where = "sequence > ?"
+            self._after_snapshot_pinned("events", high_water)
+            params: list[Any] = [after, high_water]
+            where = "sequence > ? AND sequence <= ?"
             if execution_id:
                 where += " AND execution_id = ?"
                 params.append(execution_id)
@@ -1777,12 +2166,13 @@ class ExecutionContractStore:
                 else high_water
             )
             return self._event_page(
-                [self._event_from_row(row) for row in visible],
+                [self._event_from_row(row, connection=connection) for row in visible],
                 cursor,
                 high_water,
                 minimum_available,
                 has_more,
                 pruned_through,
+                high_water,
             )
 
     # ------------------------------------------------------------------
@@ -1935,17 +2325,165 @@ class ExecutionContractStore:
                 "persisted row authority does not match the active profile"
             )
 
-    def _execution_from_row(self, row: sqlite3.Row) -> dict[str, Any]:
+    def _persisted_identifier(
+        self,
+        value: Any,
+        kind: str,
+        *,
+        nullable: bool = False,
+    ) -> Optional[str]:
+        if value is None and nullable:
+            return None
+        try:
+            self._assert_identifier_scope(str(value or ""), kind)
+        except (ContractValidationError, ContractForbiddenError) as exc:
+            raise ContractDataError(f"persisted {kind} identifier is invalid") from exc
+        return str(value)
+
+    @staticmethod
+    def _persisted_ref(
+        value: Any,
+        *,
+        field: str,
+        required: bool = False,
+        max_length: int = 512,
+    ) -> Optional[str]:
+        try:
+            return _validated_ref(
+                value,
+                field=field,
+                required=required,
+                max_length=max_length,
+            )
+        except ContractValidationError as exc:
+            raise ContractDataError(f"persisted {field} is invalid") from exc
+
+    @staticmethod
+    def _persisted_digest(
+        value: Any,
+        *,
+        field: str,
+        required: bool,
+    ) -> Optional[str]:
+        try:
+            return _validated_digest(value, field=field, required=required)
+        except ContractValidationError as exc:
+            raise ContractDataError(f"persisted {field} is invalid") from exc
+
+    @staticmethod
+    def _persisted_revision(value: Any, *, field: str = "revision") -> int:
+        if isinstance(value, bool):
+            raise ContractDataError(f"persisted {field} is invalid")
+        try:
+            revision = int(value)
+        except (TypeError, ValueError) as exc:
+            raise ContractDataError(f"persisted {field} is invalid") from exc
+        if revision < 1:
+            raise ContractDataError(f"persisted {field} is invalid")
+        return revision
+
+    @staticmethod
+    def _ordered_timestamps(
+        *,
+        created: datetime,
+        updated: datetime,
+        started: Optional[datetime] = None,
+        terminal: Optional[datetime] = None,
+    ) -> None:
+        if updated < created:
+            raise ContractDataError("persisted timestamp ordering is invalid")
+        if started is not None and (started < created or started > updated):
+            raise ContractDataError("persisted timestamp ordering is invalid")
+        if terminal is not None and (terminal < created or terminal > updated):
+            raise ContractDataError("persisted timestamp ordering is invalid")
+
+    def _execution_from_row(
+        self,
+        row: sqlite3.Row,
+        *,
+        connection: Optional[sqlite3.Connection] = None,
+    ) -> dict[str, Any]:
         self._assert_row_authority(row, require_executor=True)
+        execution_id = cast(str, self._persisted_identifier(row["execution_id"], "exe"))
         lifecycle = str(row["lifecycle"])
         receipt_state = str(row["receipt_state"])
         if lifecycle not in EXECUTION_STATES or receipt_state not in RECEIPT_STATES:
             raise ContractDataError("execution row contains an unknown state")
-        for field in ("created_at", "updated_at"):
-            _parse_timestamp(row[field], field=field)
-        for field in ("started_at", "terminal_at"):
-            if row[field] is not None:
-                _parse_timestamp(row[field], field=field)
+        source_run_id = self._persisted_ref(row["source_run_id"], field="source_run_id")
+        work_ref = self._persisted_ref(row["work_ref"], field="work_ref")
+        proposal_ref = self._persisted_ref(row["proposal_ref"], field="proposal_ref")
+        effect_id = self._persisted_ref(row["effect_id"], field="effect_id")
+        recovery_ref = self._persisted_ref(row["recovery_ref"], field="recovery_ref")
+        self._persisted_ref(
+            row["runtime_instance_id"],
+            field="runtime_instance_id",
+            required=True,
+        )
+        revision = self._persisted_revision(row["revision"])
+        created = _parse_timestamp(row["created_at"], field="created_at")
+        updated = _parse_timestamp(row["updated_at"], field="updated_at")
+        started = (
+            _parse_timestamp(row["started_at"], field="started_at")
+            if row["started_at"] is not None
+            else None
+        )
+        terminal = (
+            _parse_timestamp(row["terminal_at"], field="terminal_at")
+            if row["terminal_at"] is not None
+            else None
+        )
+        self._ordered_timestamps(
+            created=created,
+            updated=updated,
+            started=started,
+            terminal=terminal,
+        )
+        is_terminal = lifecycle in TERMINAL_EXECUTION_STATES
+        if is_terminal != (terminal is not None):
+            raise ContractDataError("execution terminal timestamp invariant failed")
+        if effect_id and not (work_ref and proposal_ref):
+            raise ContractDataError("execution effect binding is incomplete")
+        receipt_id = self._persisted_identifier(
+            row["receipt_id"],
+            "rcp",
+            nullable=True,
+        )
+        if effect_id is None:
+            if receipt_state != "not_applicable" or receipt_id is not None:
+                raise ContractDataError("effect-free execution has receipt state")
+        elif receipt_state == "not_applicable":
+            raise ContractDataError("effect execution has non-applicable receipt state")
+        elif receipt_state == "pending_evidence":
+            if is_terminal or receipt_id is not None:
+                raise ContractDataError("pending evidence execution is terminal")
+        elif receipt_state == "unproven":
+            if lifecycle != "terminal_ambiguous" or receipt_id is not None:
+                raise ContractDataError("unproven execution is not terminal ambiguous")
+        elif receipt_state == "published":
+            if not is_terminal or receipt_id is None:
+                raise ContractDataError("published execution is missing its receipt")
+        if effect_id and is_terminal and lifecycle != "terminal_ambiguous" and (
+            receipt_state != "published"
+        ):
+            raise ContractDataError("proven terminal execution is missing its receipt")
+        if connection is not None and receipt_id is not None:
+            receipt = connection.execute(
+                "SELECT * FROM receipts WHERE receipt_id=?",
+                (receipt_id,),
+            ).fetchone()
+            if receipt is None or (
+                receipt["execution_id"] != execution_id
+                or receipt["effect_id"] != effect_id
+            ):
+                raise ContractDataError("execution receipt binding is invalid")
+            self._receipt_from_row(receipt, connection=connection)
+        if connection is not None and effect_id is not None:
+            evidence = connection.execute(
+                "SELECT * FROM effect_evidence WHERE execution_id=?",
+                (execution_id,),
+            ).fetchone()
+            if evidence is not None:
+                self._evidence_from_row(evidence, connection=connection)
         freshness = "terminal" if lifecycle in TERMINAL_EXECUTION_STATES else (
             "live"
             if row["runtime_instance_id"] == self.runtime_instance_id
@@ -1953,28 +2491,35 @@ class ExecutionContractStore:
         )
         return {
             "contract_version": CONTRACT_VERSION,
-            "execution_id": row["execution_id"],
+            "execution_id": execution_id,
             "profile_id": row["profile_id"],
             "authority_id": row["authority_id"],
             "executor_id": row["executor_id"],
-            "source_run_id": row["source_run_id"],
-            "work_ref": row["work_ref"],
-            "proposal_ref": row["proposal_ref"],
-            "effect_id": row["effect_id"],
+            "source_run_id": source_run_id,
+            "work_ref": work_ref,
+            "proposal_ref": proposal_ref,
+            "effect_id": effect_id,
             "lifecycle": lifecycle,
             "freshness": freshness,
             "receipt_state": receipt_state,
-            "receipt_id": row["receipt_id"],
+            "receipt_id": receipt_id,
             "created_at": row["created_at"],
             "started_at": row["started_at"],
             "updated_at": row["updated_at"],
             "terminal_at": row["terminal_at"],
-            "recovery_ref": row["recovery_ref"],
-            "revision": int(row["revision"]),
+            "recovery_ref": recovery_ref,
+            "revision": revision,
         }
 
-    def _decision_from_row(self, row: sqlite3.Row) -> dict[str, Any]:
+    def _decision_from_row(
+        self,
+        row: sqlite3.Row,
+        *,
+        connection: Optional[sqlite3.Connection] = None,
+    ) -> dict[str, Any]:
         self._assert_row_authority(row, require_executor=False)
+        decision_id = cast(str, self._persisted_identifier(row["decision_id"], "dec"))
+        execution_id = cast(str, self._persisted_identifier(row["execution_id"], "exe"))
         state = str(row["state"])
         if state not in DECISION_STATES:
             raise ContractDataError("decision row contains an unknown state")
@@ -1982,97 +2527,372 @@ class ExecutionContractStore:
             choices = json.loads(row["allowed_choices_json"])
         except (TypeError, json.JSONDecodeError) as exc:
             raise ContractDataError("decision choices are malformed") from exc
-        if not isinstance(choices, list) or not choices or not all(
-            isinstance(choice, str) for choice in choices
-        ):
-            raise ContractDataError("decision choices are malformed")
-        for field in ("created_at", "updated_at", "expires_at"):
-            _parse_timestamp(row[field], field=field)
-        if row["resolved_at"] is not None:
+        try:
+            choices = _validated_choices(choices)
+        except ContractValidationError as exc:
+            raise ContractDataError("decision choices are malformed") from exc
+        effect_id = cast(
+            str,
+            self._persisted_ref(row["effect_id"], field="effect_id", required=True),
+        )
+        proposal_ref = cast(
+            str,
+            self._persisted_ref(
+                row["proposal_ref"],
+                field="proposal_ref",
+                required=True,
+            ),
+        )
+        request_digest = cast(
+            str,
+            self._persisted_digest(
+                row["request_digest"],
+                field="request_digest",
+                required=True,
+            ),
+        )
+        candidate_digest = self._persisted_digest(
+            row["candidate_digest"],
+            field="candidate_digest",
+            required=False,
+        )
+        policy_digest = self._persisted_digest(
+            row["policy_digest"],
+            field="policy_digest",
+            required=False,
+        )
+        resolution_digest = self._persisted_digest(
+            row["resolution_evidence_digest"],
+            field="resolution_evidence_digest",
+            required=state == "resolved",
+        )
+        revision = self._persisted_revision(row["revision"])
+        created = _parse_timestamp(row["created_at"], field="created_at")
+        updated = _parse_timestamp(row["updated_at"], field="updated_at")
+        expires = _parse_timestamp(row["expires_at"], field="expires_at")
+        resolved = (
             _parse_timestamp(row["resolved_at"], field="resolved_at")
+            if row["resolved_at"] is not None
+            else None
+        )
+        if updated < created or expires <= created:
+            raise ContractDataError("decision timestamp ordering is invalid")
+        if resolved is not None and (resolved < created or resolved > updated):
+            raise ContractDataError("decision timestamp ordering is invalid")
+        choice = row["choice"]
+        if state == "resolved":
+            if choice not in choices or resolution_digest is None or resolved is None:
+                raise ContractDataError("resolved decision evidence is incomplete")
+            if revision < 2:
+                raise ContractDataError("resolved decision revision is invalid")
+        elif choice is not None or resolution_digest is not None or resolved is not None:
+            raise ContractDataError("unresolved decision contains resolution evidence")
+        elif state != "pending" and revision < 2:
+            raise ContractDataError("closed decision revision is invalid")
+        if connection is not None:
+            execution = self._execution_row(connection, execution_id)
+            if execution is None:
+                raise ContractDataError("decision execution is missing")
+            self._assert_row_authority(execution, require_executor=True)
+            self._execution_from_row(execution)
+            if (
+                execution["effect_id"] != effect_id
+                or execution["proposal_ref"] != proposal_ref
+            ):
+                raise ContractDataError("decision execution binding is invalid")
+            if state == "pending" and execution["lifecycle"] != "awaiting_decision":
+                raise ContractDataError("pending decision execution state is invalid")
         return {
             "contract_version": CONTRACT_VERSION,
-            "decision_id": row["decision_id"],
-            "execution_id": row["execution_id"],
+            "decision_id": decision_id,
+            "execution_id": execution_id,
             "profile_id": row["profile_id"],
             "authority_id": row["authority_id"],
-            "effect_id": row["effect_id"],
-            "proposal_ref": row["proposal_ref"],
-            "request_digest": row["request_digest"],
-            "candidate_digest": row["candidate_digest"],
-            "policy_digest": row["policy_digest"],
+            "effect_id": effect_id,
+            "proposal_ref": proposal_ref,
+            "request_digest": request_digest,
+            "candidate_digest": candidate_digest,
+            "policy_digest": policy_digest,
             "allowed_choices": choices,
             "expires_at": row["expires_at"],
             "state": state,
-            "choice": row["choice"],
-            "resolution_evidence_digest": row["resolution_evidence_digest"],
+            "choice": choice,
+            "resolution_evidence_digest": resolution_digest,
             "created_at": row["created_at"],
             "updated_at": row["updated_at"],
             "resolved_at": row["resolved_at"],
-            "revision": int(row["revision"]),
+            "revision": revision,
         }
 
-    def _receipt_from_row(self, row: sqlite3.Row) -> dict[str, Any]:
+    def _receipt_from_row(
+        self,
+        row: sqlite3.Row,
+        *,
+        connection: Optional[sqlite3.Connection] = None,
+    ) -> dict[str, Any]:
         self._assert_row_authority(row, require_executor=True)
+        receipt_id = cast(str, self._persisted_identifier(row["receipt_id"], "rcp"))
+        execution_id = cast(str, self._persisted_identifier(row["execution_id"], "exe"))
         outcome = str(row["outcome"])
         if outcome not in RECEIPT_OUTCOMES:
             raise ContractDataError("receipt row contains an unknown outcome")
-        _parse_timestamp(row["terminal_at"], field="terminal_at")
+        effect_id = cast(
+            str,
+            self._persisted_ref(row["effect_id"], field="effect_id", required=True),
+        )
+        subject_digest = cast(
+            str,
+            self._persisted_digest(
+                row["subject_digest"],
+                field="subject_digest",
+                required=True,
+            ),
+        )
+        evidence_digest = cast(
+            str,
+            self._persisted_digest(
+                row["evidence_digest"],
+                field="evidence_digest",
+                required=True,
+            ),
+        )
+        result_digest = cast(
+            str,
+            self._persisted_digest(
+                row["result_digest"],
+                field="result_digest",
+                required=True,
+            ),
+        )
+        decision_id = self._persisted_identifier(
+            row["decision_id"],
+            "dec",
+            nullable=True,
+        )
+        recovery_ref = self._persisted_ref(row["recovery_ref"], field="recovery_ref")
+        reconciliation_ref = self._persisted_ref(
+            row["reconciliation_ref"],
+            field="reconciliation_ref",
+        )
+        terminal = _parse_timestamp(row["terminal_at"], field="terminal_at")
+        revision = self._persisted_revision(row["revision"])
+        if revision != 1:
+            raise ContractDataError("receipt revision must be immutable at one")
+        if connection is not None:
+            execution = self._execution_row(connection, execution_id)
+            if execution is None:
+                raise ContractDataError("receipt execution is missing")
+            self._assert_row_authority(execution, require_executor=True)
+            self._execution_from_row(execution)
+            expected_lifecycle = f"terminal_{outcome}"
+            if (
+                execution["effect_id"] != effect_id
+                or execution["receipt_id"] != receipt_id
+                or execution["receipt_state"] != "published"
+                or execution["lifecycle"] != expected_lifecycle
+            ):
+                raise ContractDataError("receipt execution invariant failed")
+            execution_terminal = _parse_timestamp(
+                execution["terminal_at"],
+                field="execution_terminal_at",
+            )
+            if terminal < execution_terminal:
+                raise ContractDataError("receipt terminal timestamp precedes execution")
+            evidence = connection.execute(
+                "SELECT * FROM effect_evidence WHERE execution_id=?",
+                (execution_id,),
+            ).fetchone()
+            if evidence is None:
+                raise ContractDataError("receipt effect evidence is missing")
+            self._evidence_from_row(evidence, connection=connection)
+            for field, expected in (
+                ("effect_id", effect_id),
+                ("outcome", outcome),
+                ("subject_digest", subject_digest),
+                ("evidence_digest", evidence_digest),
+                ("result_digest", result_digest),
+                ("decision_id", decision_id),
+            ):
+                if evidence[field] != expected:
+                    raise ContractDataError("receipt evidence binding is invalid")
+            if decision_id is not None:
+                decision = connection.execute(
+                    "SELECT * FROM decisions WHERE decision_id=?",
+                    (decision_id,),
+                ).fetchone()
+                if decision is None or (
+                    decision["execution_id"] != execution_id
+                    or decision["effect_id"] != effect_id
+                    or decision["state"] != "resolved"
+                ):
+                    raise ContractDataError("receipt decision binding is invalid")
         return {
             "contract_version": CONTRACT_VERSION,
-            "receipt_id": row["receipt_id"],
-            "execution_id": row["execution_id"],
-            "effect_id": row["effect_id"],
+            "receipt_id": receipt_id,
+            "execution_id": execution_id,
+            "effect_id": effect_id,
             "profile_id": row["profile_id"],
             "authority_id": row["authority_id"],
             "executor_id": row["executor_id"],
             "outcome": outcome,
-            "subject_digest": row["subject_digest"],
-            "evidence_digest": row["evidence_digest"],
-            "result_digest": row["result_digest"],
+            "subject_digest": subject_digest,
+            "evidence_digest": evidence_digest,
+            "result_digest": result_digest,
             "terminal_at": row["terminal_at"],
-            "decision_id": row["decision_id"],
-            "recovery_ref": row["recovery_ref"],
-            "reconciliation_ref": row["reconciliation_ref"],
-            "revision": int(row["revision"]),
+            "decision_id": decision_id,
+            "recovery_ref": recovery_ref,
+            "reconciliation_ref": reconciliation_ref,
+            "revision": revision,
         }
 
-    def _event_from_row(self, row: sqlite3.Row) -> dict[str, Any]:
+    def _event_from_row(
+        self,
+        row: sqlite3.Row,
+        *,
+        connection: Optional[sqlite3.Connection] = None,
+    ) -> dict[str, Any]:
         self._assert_row_authority(row, require_executor=False)
+        event_id = cast(str, self._persisted_identifier(row["event_id"], "evt"))
+        execution_id = cast(str, self._persisted_identifier(row["execution_id"], "exe"))
         event_type = str(row["event_type"])
         if event_type not in EVENT_TYPES:
             raise ContractDataError("event row contains an unknown type")
+        try:
+            sequence = int(row["sequence"])
+        except (TypeError, ValueError) as exc:
+            raise ContractDataError("event sequence is invalid") from exc
+        if sequence < 1:
+            raise ContractDataError("event sequence is invalid")
+        from_lifecycle = row["from_lifecycle"]
+        to_lifecycle = row["to_lifecycle"]
+        if from_lifecycle is not None and from_lifecycle not in EXECUTION_STATES:
+            raise ContractDataError("event from lifecycle is invalid")
+        if to_lifecycle is not None and to_lifecycle not in EXECUTION_STATES:
+            raise ContractDataError("event to lifecycle is invalid")
+        decision_id = self._persisted_identifier(
+            row["decision_id"],
+            "dec",
+            nullable=True,
+        )
+        receipt_id = self._persisted_identifier(
+            row["receipt_id"],
+            "rcp",
+            nullable=True,
+        )
+        reason_code = self._persisted_ref(
+            row["reason_code"],
+            field="reason_code",
+            max_length=128,
+        )
         _parse_timestamp(row["occurred_at"], field="occurred_at")
+        revision = self._persisted_revision(row["revision"])
+        if connection is not None:
+            execution = self._execution_row(connection, execution_id)
+            if execution is None:
+                raise ContractDataError("event execution is missing")
+            self._assert_row_authority(execution, require_executor=True)
+            self._execution_from_row(execution)
+            if decision_id is not None:
+                decision = connection.execute(
+                    "SELECT * FROM decisions WHERE decision_id=?",
+                    (decision_id,),
+                ).fetchone()
+                if decision is None or decision["execution_id"] != execution_id:
+                    raise ContractDataError("event decision binding is invalid")
+                self._decision_from_row(decision)
+            if receipt_id is not None:
+                receipt = connection.execute(
+                    "SELECT * FROM receipts WHERE receipt_id=?",
+                    (receipt_id,),
+                ).fetchone()
+                if receipt is None or receipt["execution_id"] != execution_id:
+                    raise ContractDataError("event receipt binding is invalid")
+                self._receipt_from_row(receipt, connection=connection)
         return {
             "contract_version": CONTRACT_VERSION,
-            "sequence": int(row["sequence"]),
-            "event_id": row["event_id"],
-            "execution_id": row["execution_id"],
+            "sequence": sequence,
+            "event_id": event_id,
+            "execution_id": execution_id,
             "profile_id": row["profile_id"],
             "authority_id": row["authority_id"],
             "event_type": event_type,
-            "from_lifecycle": row["from_lifecycle"],
-            "to_lifecycle": row["to_lifecycle"],
-            "decision_id": row["decision_id"],
-            "receipt_id": row["receipt_id"],
-            "reason_code": row["reason_code"],
+            "from_lifecycle": from_lifecycle,
+            "to_lifecycle": to_lifecycle,
+            "decision_id": decision_id,
+            "receipt_id": receipt_id,
+            "reason_code": reason_code,
             "occurred_at": row["occurred_at"],
-            "revision": int(row["revision"]),
+            "revision": revision,
         }
 
-    def _evidence_from_row(self, row: sqlite3.Row) -> dict[str, Any]:
+    def _evidence_from_row(
+        self,
+        row: sqlite3.Row,
+        *,
+        connection: Optional[sqlite3.Connection] = None,
+    ) -> dict[str, Any]:
         self._assert_row_authority(row, require_executor=True)
+        evidence_match = _EVIDENCE_ID_RE.fullmatch(str(row["evidence_id"] or ""))
+        if (
+            evidence_match is None
+            or evidence_match.group(1) != self.authority.profile_key
+        ):
+            raise ContractDataError("persisted evidence identifier is invalid")
+        execution_id = cast(str, self._persisted_identifier(row["execution_id"], "exe"))
+        effect_id = cast(
+            str,
+            self._persisted_ref(row["effect_id"], field="effect_id", required=True),
+        )
+        outcome = str(row["outcome"])
+        if outcome not in RECEIPT_OUTCOMES:
+            raise ContractDataError("effect evidence outcome is invalid")
+        digests = {
+            field: cast(
+                str,
+                self._persisted_digest(row[field], field=field, required=True),
+            )
+            for field in ("subject_digest", "evidence_digest", "result_digest")
+        }
+        decision_id = self._persisted_identifier(
+            row["decision_id"],
+            "dec",
+            nullable=True,
+        )
+        recovery_ref = self._persisted_ref(row["recovery_ref"], field="recovery_ref")
+        reconciliation_ref = self._persisted_ref(
+            row["reconciliation_ref"],
+            field="reconciliation_ref",
+        )
+        _parse_timestamp(row["recorded_at"], field="recorded_at")
+        if connection is not None:
+            execution = self._execution_row(connection, execution_id)
+            if execution is None or execution["effect_id"] != effect_id:
+                raise ContractDataError("effect evidence execution binding is invalid")
+            latest_decision = connection.execute(
+                "SELECT * FROM decisions WHERE execution_id=? "
+                "ORDER BY ordinal DESC LIMIT 1",
+                (execution_id,),
+            ).fetchone()
+            if latest_decision is None:
+                if decision_id is not None:
+                    raise ContractDataError("effect evidence decision is unbound")
+            elif (
+                latest_decision["decision_id"] != decision_id
+                or latest_decision["state"] != "resolved"
+                or latest_decision["effect_id"] != effect_id
+            ):
+                raise ContractDataError("effect evidence decision binding is invalid")
         return {
             "evidence_id": row["evidence_id"],
-            "execution_id": row["execution_id"],
-            "effect_id": row["effect_id"],
-            "outcome": row["outcome"],
-            "subject_digest": row["subject_digest"],
-            "evidence_digest": row["evidence_digest"],
-            "result_digest": row["result_digest"],
-            "decision_id": row["decision_id"],
-            "recovery_ref": row["recovery_ref"],
-            "reconciliation_ref": row["reconciliation_ref"],
+            "execution_id": execution_id,
+            "effect_id": effect_id,
+            "outcome": outcome,
+            "subject_digest": digests["subject_digest"],
+            "evidence_digest": digests["evidence_digest"],
+            "result_digest": digests["result_digest"],
+            "decision_id": decision_id,
+            "recovery_ref": recovery_ref,
+            "reconciliation_ref": reconciliation_ref,
             "recorded_at": row["recorded_at"],
         }
 
@@ -2082,29 +2902,49 @@ class ExecutionContractStore:
         *,
         after: int,
         limit: int,
-        table: str,
         decoder,
         connection: sqlite3.Connection,
+        snapshot_high_water: int,
     ) -> dict[str, Any]:
         visible = rows[:limit]
-        high_water = int(
-            connection.execute(f"SELECT COALESCE(MAX(ordinal), 0) FROM {table}").fetchone()[0]
-        )
-        if after > high_water:
-            raise ContractConflictError(f"{table} cursor is ahead of high-water")
         has_more = len(rows) > limit
         cursor = (
             int(visible[-1]["ordinal"])
             if has_more and visible
-            else high_water
+            else snapshot_high_water
         )
         return self._collection_page(
-            [decoder(row) for row in visible],
+            [decoder(row, connection=connection) for row in visible],
             cursor,
-            high_water,
-            1 if high_water else 0,
+            snapshot_high_water,
+            1 if snapshot_high_water else 0,
             has_more,
+            snapshot_high_water,
         )
+
+    def _pin_collection_snapshot(
+        self,
+        connection: sqlite3.Connection,
+        *,
+        table: str,
+        after: int,
+        requested: Optional[int],
+    ) -> int:
+        available = int(
+            connection.execute(
+                f"SELECT COALESCE(MAX(ordinal), 0) FROM {table}"
+            ).fetchone()[0]
+        )
+        pinned = available if requested is None else requested
+        if pinned > available:
+            raise ContractConflictError(f"{table} snapshot is ahead of high-water")
+        if after > pinned:
+            raise ContractConflictError(f"{table} cursor is ahead of snapshot")
+        self._after_snapshot_pinned(table, pinned)
+        return pinned
+
+    def _after_snapshot_pinned(self, _collection: str, _high_water: int) -> None:
+        """Test seam called inside the pinned SQLite read transaction."""
 
     @staticmethod
     def _collection_page(
@@ -2113,12 +2953,14 @@ class ExecutionContractStore:
         high_water: int,
         minimum_available: int,
         has_more: bool,
+        snapshot_high_water: int,
     ) -> dict[str, Any]:
         return {
             "items": items,
             "page": {
                 "cursor": cursor,
                 "high_water": high_water,
+                "snapshot_high_water": snapshot_high_water,
                 "minimum_available": minimum_available,
                 "has_more": has_more,
                 "completeness": "complete",
@@ -2133,12 +2975,14 @@ class ExecutionContractStore:
         minimum_available: int,
         has_more: bool,
         pruned_through: int,
+        snapshot_high_water: int,
     ) -> dict[str, Any]:
         return {
             "items": events,
             "page": {
                 "cursor": cursor,
                 "high_water": high_water,
+                "snapshot_high_water": snapshot_high_water,
                 "minimum_available": minimum_available,
                 "has_more": has_more,
                 "completeness": "complete",
@@ -2148,8 +2992,11 @@ class ExecutionContractStore:
         }
 
 
-def contract_capabilities(profile_name: str) -> dict[str, Any]:
-    authority = authority_identity(profile_name)
+def contract_capabilities(
+    profile_home: Path,
+    profile_name: Optional[str] = None,
+) -> dict[str, Any]:
+    authority = authority_identity(profile_home, profile_name)
     return {
         "contract_version": CONTRACT_VERSION,
         "api_version": API_VERSION,

--- a/hermes_cli/execution_contract.py
+++ b/hermes_cli/execution_contract.py
@@ -1,0 +1,2189 @@
+"""Durable, profile-scoped Hermes execution read contract.
+
+The execution ledger is the authoritative local record for externally
+observable execution lifecycle, decisions, ordered events, and terminal
+effect receipts.  It deliberately does not infer effect success from chat
+text, session history, process-local run state, or Kanban summaries.
+
+All public reads use SQLite ``mode=ro`` and ``PRAGMA query_only``.  Schema
+creation, migration, recovery, and publication are explicit write operations.
+Terminal state, its ordered event, and any evidence-backed receipt are written
+in one ``BEGIN IMMEDIATE`` transaction; the events table is therefore the
+transactional publication outbox for the read API.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import importlib.resources
+import json
+import re
+import sqlite3
+import uuid
+from contextlib import contextmanager
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any, Iterator, Mapping, Optional, cast
+
+from hermes_cli.sqlite_safe_read import connect_tracked
+from hermes_cli.sqlite_util import write_txn
+from hermes_constants import get_hermes_home
+
+CONTRACT_VERSION = "hermes.execution.read.v1"
+API_VERSION = "v1"
+STORE_SCHEMA_VERSION = 1
+EVENT_RETENTION_SECONDS = 30 * 24 * 60 * 60
+DEFAULT_PAGE_SIZE = 50
+MAX_PAGE_SIZE = 200
+
+EXECUTION_STATES = frozenset(
+    {
+        "accepted",
+        "queued",
+        "running",
+        "awaiting_decision",
+        "cancellation_requested",
+        "terminal_succeeded",
+        "terminal_failed",
+        "terminal_cancelled",
+        "terminal_partial",
+        "terminal_ambiguous",
+    }
+)
+TERMINAL_EXECUTION_STATES = frozenset(
+    {
+        "terminal_succeeded",
+        "terminal_failed",
+        "terminal_cancelled",
+        "terminal_partial",
+        "terminal_ambiguous",
+    }
+)
+DECISION_STATES = frozenset({"pending", "resolved", "expired", "superseded"})
+RECEIPT_OUTCOMES = frozenset(
+    {"succeeded", "failed", "cancelled", "partial", "ambiguous"}
+)
+EVENT_TYPES = frozenset(
+    {
+        "execution.created",
+        "execution.transitioned",
+        "execution.recovered",
+        "decision.requested",
+        "decision.resolved",
+        "decision.expired",
+        "decision.superseded",
+        "effect.evidence_recorded",
+        "receipt.published",
+    }
+)
+RECEIPT_STATES = frozenset(
+    {"not_applicable", "pending_evidence", "unproven", "published"}
+)
+
+_ALLOWED_TRANSITIONS: dict[str, frozenset[str]] = {
+    "accepted": frozenset(
+        EXECUTION_STATES - {"accepted"}
+    ),
+    "queued": frozenset(
+        EXECUTION_STATES - {"accepted", "queued"}
+    ),
+    "running": frozenset(
+        {
+            "awaiting_decision",
+            "cancellation_requested",
+            *TERMINAL_EXECUTION_STATES,
+        }
+    ),
+    "awaiting_decision": frozenset(
+        {"running", "cancellation_requested", *TERMINAL_EXECUTION_STATES}
+    ),
+    "cancellation_requested": frozenset(
+        {
+            "terminal_cancelled",
+            "terminal_failed",
+            "terminal_partial",
+            "terminal_ambiguous",
+        }
+    ),
+    "terminal_ambiguous": frozenset(
+        {
+            "terminal_succeeded",
+            "terminal_failed",
+            "terminal_cancelled",
+            "terminal_partial",
+        }
+    ),
+    "terminal_succeeded": frozenset(),
+    "terminal_failed": frozenset(),
+    "terminal_cancelled": frozenset(),
+    "terminal_partial": frozenset(),
+}
+
+_ID_RE = re.compile(r"^(exe|dec|rcp|evt)_([0-9a-f]{12})_([0-9a-f]{32})$")
+_SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
+_CONTROL_RE = re.compile(r"[\x00-\x1f\x7f]")
+
+
+class ExecutionContractError(RuntimeError):
+    """Base class for closed-contract failures."""
+
+
+class ContractValidationError(ExecutionContractError):
+    """Caller input does not satisfy the public contract."""
+
+
+class ContractNotFoundError(ExecutionContractError):
+    """A correctly scoped contract object does not exist."""
+
+
+class ContractForbiddenError(ExecutionContractError):
+    """An identifier belongs to a different profile authority."""
+
+
+class ContractConflictError(ExecutionContractError):
+    """A revision, lifecycle, or immutable binding conflicts."""
+
+
+class ContractCursorGoneError(ExecutionContractError):
+    """The requested event cursor predates retained history."""
+
+    def __init__(self, minimum_available: int, high_water: int) -> None:
+        self.minimum_available = minimum_available
+        self.high_water = high_water
+        super().__init__(
+            f"event cursor was pruned; minimum_available={minimum_available}"
+        )
+
+
+class ContractRateLimitedError(ExecutionContractError):
+    """The durable ledger is temporarily busy."""
+
+
+class ContractUnavailableError(ExecutionContractError):
+    """The durable ledger cannot currently provide trustworthy data."""
+
+
+class UnsupportedContractVersionError(ExecutionContractError):
+    """The caller or store requested an unsupported contract version."""
+
+
+class ContractDataError(ExecutionContractError):
+    """Persisted data violates a closed contract invariant."""
+
+
+@dataclass(frozen=True)
+class AuthorityIdentity:
+    profile_id: str
+    profile_name: str
+    authority_id: str
+    executor_id: str
+    profile_key: str
+
+    def public(self) -> dict[str, str]:
+        return {
+            "profile_id": self.profile_id,
+            "profile_name": self.profile_name,
+            "authority_id": self.authority_id,
+            "executor_id": self.executor_id,
+        }
+
+
+def _utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _timestamp(value: Optional[datetime] = None) -> str:
+    current = value or _utc_now()
+    if current.tzinfo is None or current.utcoffset() is None:
+        raise ContractValidationError("timestamps must be timezone-aware")
+    return current.astimezone(timezone.utc).isoformat(timespec="microseconds").replace(
+        "+00:00", "Z"
+    )
+
+
+def _parse_timestamp(value: str, *, field: str) -> datetime:
+    if not isinstance(value, str) or not value.endswith("Z"):
+        raise ContractDataError(f"{field} must be an RFC3339 UTC timestamp")
+    try:
+        parsed = datetime.fromisoformat(value[:-1] + "+00:00")
+    except ValueError as exc:
+        raise ContractDataError(f"{field} is malformed") from exc
+    return parsed.astimezone(timezone.utc)
+
+
+def _normalize_profile_name(profile_name: str) -> str:
+    clean = str(profile_name or "default").strip()
+    if not clean or len(clean) > 128 or _CONTROL_RE.search(clean):
+        raise ContractValidationError("profile_name is invalid")
+    return clean
+
+
+def authority_identity(profile_name: str) -> AuthorityIdentity:
+    """Return the server-asserted authority identity for one Hermes profile."""
+
+    clean = _normalize_profile_name(profile_name)
+    profile_id = f"hermes-profile:{clean}"
+    profile_key = hashlib.sha256(profile_id.encode("utf-8")).hexdigest()[:12]
+    return AuthorityIdentity(
+        profile_id=profile_id,
+        profile_name=clean,
+        authority_id=f"hermes-execution-authority:{clean}",
+        executor_id=f"hermes-agent:{clean}",
+        profile_key=profile_key,
+    )
+
+
+def validate_contract_version(value: Optional[str]) -> None:
+    if value in (None, "", CONTRACT_VERSION):
+        return
+    raise UnsupportedContractVersionError(
+        f"unsupported execution contract version: {value}"
+    )
+
+
+def canonical_digest(value: Mapping[str, Any] | list[Any] | str) -> str:
+    if isinstance(value, str):
+        encoded = value.encode("utf-8")
+    else:
+        encoded = json.dumps(
+            value,
+            sort_keys=True,
+            separators=(",", ":"),
+            ensure_ascii=False,
+        ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _validated_digest(value: Optional[str], *, field: str, required: bool) -> Optional[str]:
+    if value in (None, "") and not required:
+        return None
+    clean = str(value or "").strip().lower()
+    if not _SHA256_RE.fullmatch(clean):
+        raise ContractValidationError(f"{field} must be a lowercase SHA-256 digest")
+    return clean
+
+
+def _validated_ref(
+    value: Optional[str],
+    *,
+    field: str,
+    required: bool = False,
+    max_length: int = 512,
+) -> Optional[str]:
+    if value in (None, "") and not required:
+        return None
+    clean = str(value or "").strip()
+    if not clean or len(clean) > max_length or _CONTROL_RE.search(clean):
+        raise ContractValidationError(f"{field} is invalid")
+    return clean
+
+
+def _validated_choices(choices: list[str] | tuple[str, ...]) -> list[str]:
+    if not isinstance(choices, (list, tuple)) or not choices:
+        raise ContractValidationError("allowed_choices must be a non-empty array")
+    if len(choices) > 32:
+        raise ContractValidationError("allowed_choices cannot exceed 32 items")
+    out: list[str] = []
+    for raw in choices:
+        choice = _validated_ref(raw, field="allowed_choice", required=True, max_length=64)
+        assert choice is not None
+        if choice in out:
+            raise ContractValidationError("allowed_choices must be unique")
+        out.append(choice)
+    return out
+
+
+def _validated_limit(limit: int) -> int:
+    try:
+        value = int(limit)
+    except (TypeError, ValueError) as exc:
+        raise ContractValidationError("limit must be an integer") from exc
+    if value < 1 or value > MAX_PAGE_SIZE:
+        raise ContractValidationError(f"limit must be between 1 and {MAX_PAGE_SIZE}")
+    return value
+
+
+def _validated_cursor(after: int) -> int:
+    try:
+        value = int(after)
+    except (TypeError, ValueError) as exc:
+        raise ContractValidationError("after must be an integer") from exc
+    if value < 0:
+        raise ContractValidationError("after must be non-negative")
+    return value
+
+
+class ExecutionContractStore:
+    """Profile-local durable authority store and read projection."""
+
+    def __init__(
+        self,
+        *,
+        database_path: Optional[Path] = None,
+        profile_name: str = "default",
+        runtime_instance_id: Optional[str] = None,
+    ) -> None:
+        self.database_path = database_path or (
+            get_hermes_home() / "execution_contract.sqlite3"
+        )
+        self.authority = authority_identity(profile_name)
+        self.runtime_instance_id = runtime_instance_id or uuid.uuid4().hex
+
+    # ------------------------------------------------------------------
+    # Connection and schema lifecycle
+    # ------------------------------------------------------------------
+
+    def initialize(self) -> None:
+        self.database_path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+        try:
+            self.database_path.parent.chmod(0o700)
+        except OSError:
+            pass
+        connection = self._connect_write()
+        try:
+            version = int(connection.execute("PRAGMA user_version").fetchone()[0])
+            if version == 0:
+                self._create_schema_v1(connection)
+            elif version != STORE_SCHEMA_VERSION:
+                raise UnsupportedContractVersionError(
+                    f"unsupported execution store schema version: {version}"
+                )
+            self._validate_schema_metadata(connection)
+        finally:
+            connection.close()
+        self._tighten_permissions()
+
+    def _connect_write(self) -> sqlite3.Connection:
+        try:
+            connection = connect_tracked(self.database_path, timeout=5.0)
+            connection.row_factory = sqlite3.Row
+            connection.execute("PRAGMA foreign_keys=ON")
+            connection.execute("PRAGMA busy_timeout=5000")
+            from hermes_state import apply_wal_with_fallback
+
+            apply_wal_with_fallback(
+                connection,
+                db_label="execution_contract.sqlite3",
+            )
+            return connection
+        except sqlite3.OperationalError as exc:
+            if "locked" in str(exc).lower() or "busy" in str(exc).lower():
+                raise ContractRateLimitedError("execution ledger is busy") from exc
+            raise ContractUnavailableError("execution ledger is unavailable") from exc
+        except ExecutionContractError:
+            raise
+        except Exception as exc:
+            raise ContractUnavailableError("execution ledger is unavailable") from exc
+
+    @contextmanager
+    def _read_connection(self) -> Iterator[Optional[sqlite3.Connection]]:
+        if not self.database_path.exists():
+            yield None
+            return
+        uri = self.database_path.resolve().as_uri() + "?mode=ro"
+        connection: Optional[sqlite3.Connection] = None
+        try:
+            connection = connect_tracked(
+                uri,
+                tracking_path=self.database_path,
+                uri=True,
+                timeout=1.0,
+            )
+            connection.row_factory = sqlite3.Row
+            connection.execute("PRAGMA query_only=ON")
+            connection.execute("PRAGMA foreign_keys=ON")
+            connection.execute("PRAGMA busy_timeout=1000")
+            version = int(connection.execute("PRAGMA user_version").fetchone()[0])
+            if version != STORE_SCHEMA_VERSION:
+                raise UnsupportedContractVersionError(
+                    f"unsupported execution store schema version: {version}"
+                )
+            self._validate_schema_metadata(connection)
+        except sqlite3.OperationalError as exc:
+            if connection is not None:
+                connection.close()
+            if "locked" in str(exc).lower() or "busy" in str(exc).lower():
+                raise ContractRateLimitedError("execution ledger is busy") from exc
+            raise ContractUnavailableError("execution ledger is unavailable") from exc
+        except ExecutionContractError:
+            if connection is not None:
+                connection.close()
+            raise
+        except Exception as exc:
+            if connection is not None:
+                connection.close()
+            raise ContractUnavailableError("execution ledger is unavailable") from exc
+        try:
+            yield connection
+        finally:
+            connection.close()
+
+    def _tighten_permissions(self) -> None:
+        for candidate in (
+            self.database_path,
+            Path(f"{self.database_path}-wal"),
+            Path(f"{self.database_path}-shm"),
+        ):
+            try:
+                if candidate.exists():
+                    candidate.chmod(0o600)
+            except OSError:
+                pass
+
+    def _create_schema_v1(self, connection: sqlite3.Connection) -> None:
+        quoted_profile_id = connection.execute(
+            "SELECT quote(?)",
+            (self.authority.profile_id,),
+        ).fetchone()[0]
+        quoted_authority_id = connection.execute(
+            "SELECT quote(?)",
+            (self.authority.authority_id,),
+        ).fetchone()[0]
+        quoted_executor_id = connection.execute(
+            "SELECT quote(?)",
+            (self.authority.executor_id,),
+        ).fetchone()[0]
+        connection.executescript(
+            f"""
+            BEGIN IMMEDIATE;
+
+            CREATE TABLE IF NOT EXISTS execution_contract_metadata (
+                key TEXT PRIMARY KEY,
+                value TEXT NOT NULL
+            );
+
+            CREATE TABLE IF NOT EXISTS executions (
+                ordinal INTEGER PRIMARY KEY AUTOINCREMENT,
+                execution_id TEXT NOT NULL UNIQUE,
+                profile_id TEXT NOT NULL,
+                authority_id TEXT NOT NULL,
+                executor_id TEXT NOT NULL,
+                source_run_id TEXT UNIQUE,
+                work_ref TEXT,
+                proposal_ref TEXT,
+                effect_id TEXT,
+                lifecycle TEXT NOT NULL,
+                receipt_state TEXT NOT NULL,
+                receipt_id TEXT,
+                created_at TEXT NOT NULL,
+                started_at TEXT,
+                updated_at TEXT NOT NULL,
+                terminal_at TEXT,
+                recovery_ref TEXT,
+                revision INTEGER NOT NULL,
+                runtime_instance_id TEXT NOT NULL,
+                CHECK (lifecycle IN (
+                    'accepted', 'queued', 'running', 'awaiting_decision',
+                    'cancellation_requested', 'terminal_succeeded',
+                    'terminal_failed', 'terminal_cancelled', 'terminal_partial',
+                    'terminal_ambiguous'
+                )),
+                CHECK (receipt_state IN (
+                    'not_applicable', 'pending_evidence', 'unproven', 'published'
+                )),
+                CHECK (revision >= 1)
+            );
+
+            CREATE TABLE IF NOT EXISTS decisions (
+                ordinal INTEGER PRIMARY KEY AUTOINCREMENT,
+                decision_id TEXT NOT NULL UNIQUE,
+                execution_id TEXT NOT NULL,
+                profile_id TEXT NOT NULL,
+                authority_id TEXT NOT NULL,
+                effect_id TEXT NOT NULL,
+                proposal_ref TEXT NOT NULL,
+                request_digest TEXT NOT NULL,
+                candidate_digest TEXT,
+                policy_digest TEXT,
+                allowed_choices_json TEXT NOT NULL,
+                expires_at TEXT NOT NULL,
+                state TEXT NOT NULL,
+                choice TEXT,
+                resolution_evidence_digest TEXT,
+                created_at TEXT NOT NULL,
+                updated_at TEXT NOT NULL,
+                resolved_at TEXT,
+                revision INTEGER NOT NULL,
+                FOREIGN KEY (execution_id) REFERENCES executions(execution_id),
+                UNIQUE (execution_id, request_digest),
+                CHECK (state IN ('pending', 'resolved', 'expired', 'superseded')),
+                CHECK (revision >= 1)
+            );
+
+            CREATE TABLE IF NOT EXISTS effect_evidence (
+                evidence_id TEXT PRIMARY KEY,
+                execution_id TEXT NOT NULL UNIQUE,
+                profile_id TEXT NOT NULL,
+                authority_id TEXT NOT NULL,
+                executor_id TEXT NOT NULL,
+                effect_id TEXT NOT NULL,
+                outcome TEXT NOT NULL,
+                subject_digest TEXT NOT NULL,
+                evidence_digest TEXT NOT NULL,
+                result_digest TEXT NOT NULL,
+                decision_id TEXT,
+                recovery_ref TEXT,
+                reconciliation_ref TEXT,
+                recorded_at TEXT NOT NULL,
+                FOREIGN KEY (execution_id) REFERENCES executions(execution_id),
+                FOREIGN KEY (decision_id) REFERENCES decisions(decision_id),
+                CHECK (outcome IN ('succeeded', 'failed', 'cancelled', 'partial', 'ambiguous'))
+            );
+
+            CREATE TABLE IF NOT EXISTS receipts (
+                ordinal INTEGER PRIMARY KEY AUTOINCREMENT,
+                receipt_id TEXT NOT NULL UNIQUE,
+                execution_id TEXT NOT NULL UNIQUE,
+                effect_id TEXT NOT NULL,
+                profile_id TEXT NOT NULL,
+                authority_id TEXT NOT NULL,
+                executor_id TEXT NOT NULL,
+                outcome TEXT NOT NULL,
+                subject_digest TEXT NOT NULL,
+                evidence_digest TEXT NOT NULL,
+                result_digest TEXT NOT NULL,
+                terminal_at TEXT NOT NULL,
+                decision_id TEXT,
+                recovery_ref TEXT,
+                reconciliation_ref TEXT,
+                revision INTEGER NOT NULL,
+                FOREIGN KEY (execution_id) REFERENCES executions(execution_id),
+                FOREIGN KEY (decision_id) REFERENCES decisions(decision_id),
+                CHECK (outcome IN ('succeeded', 'failed', 'cancelled', 'partial', 'ambiguous')),
+                CHECK (revision = 1)
+            );
+
+            CREATE TABLE IF NOT EXISTS execution_events (
+                sequence INTEGER PRIMARY KEY AUTOINCREMENT,
+                event_id TEXT NOT NULL UNIQUE,
+                execution_id TEXT NOT NULL,
+                profile_id TEXT NOT NULL,
+                authority_id TEXT NOT NULL,
+                event_type TEXT NOT NULL,
+                from_lifecycle TEXT,
+                to_lifecycle TEXT,
+                decision_id TEXT,
+                receipt_id TEXT,
+                reason_code TEXT,
+                occurred_at TEXT NOT NULL,
+                revision INTEGER NOT NULL,
+                FOREIGN KEY (execution_id) REFERENCES executions(execution_id),
+                FOREIGN KEY (decision_id) REFERENCES decisions(decision_id),
+                FOREIGN KEY (receipt_id) REFERENCES receipts(receipt_id),
+                CHECK (event_type IN (
+                    'execution.created', 'execution.transitioned',
+                    'execution.recovered', 'decision.requested',
+                    'decision.resolved', 'decision.expired',
+                    'decision.superseded', 'effect.evidence_recorded',
+                    'receipt.published'
+                )),
+                CHECK (revision >= 1)
+            );
+
+            CREATE INDEX IF NOT EXISTS execution_events_execution_sequence
+                ON execution_events(execution_id, sequence);
+            CREATE INDEX IF NOT EXISTS decisions_state_ordinal
+                ON decisions(state, ordinal);
+            CREATE INDEX IF NOT EXISTS executions_lifecycle_ordinal
+                ON executions(lifecycle, ordinal);
+
+            INSERT OR IGNORE INTO execution_contract_metadata(key, value)
+                VALUES ('contract_version', 'hermes.execution.read.v1');
+            INSERT OR IGNORE INTO execution_contract_metadata(key, value)
+                VALUES ('events_pruned_through', '0');
+            INSERT OR IGNORE INTO execution_contract_metadata(key, value)
+                VALUES ('event_retention_seconds', '2592000');
+            INSERT OR IGNORE INTO execution_contract_metadata(key, value)
+                VALUES ('profile_id', {quoted_profile_id});
+            INSERT OR IGNORE INTO execution_contract_metadata(key, value)
+                VALUES ('authority_id', {quoted_authority_id});
+            INSERT OR IGNORE INTO execution_contract_metadata(key, value)
+                VALUES ('executor_id', {quoted_executor_id});
+
+            PRAGMA user_version=1;
+            COMMIT;
+            """
+        )
+
+    def _validate_schema_metadata(self, connection: sqlite3.Connection) -> None:
+        try:
+            rows = connection.execute(
+                "SELECT key, value FROM execution_contract_metadata WHERE key IN "
+                "('contract_version', 'profile_id', 'authority_id', 'executor_id')"
+            ).fetchall()
+        except sqlite3.DatabaseError as exc:
+            raise ContractDataError("execution ledger schema is incomplete") from exc
+        metadata = {str(row[0]): str(row[1]) for row in rows}
+        actual = metadata.get("contract_version")
+        if actual != CONTRACT_VERSION:
+            raise UnsupportedContractVersionError(
+                f"unsupported stored execution contract version: {actual}"
+            )
+        expected_authority = {
+            "profile_id": self.authority.profile_id,
+            "authority_id": self.authority.authority_id,
+            "executor_id": self.authority.executor_id,
+        }
+        if any(metadata.get(key) != value for key, value in expected_authority.items()):
+            raise ContractDataError(
+                "execution ledger authority metadata does not match the active profile"
+            )
+
+    # ------------------------------------------------------------------
+    # Durable mutation hooks (not public HTTP mutation routes)
+    # ------------------------------------------------------------------
+
+    def create_execution(
+        self,
+        *,
+        lifecycle: str = "accepted",
+        source_run_id: Optional[str] = None,
+        work_ref: Optional[str] = None,
+        proposal_ref: Optional[str] = None,
+        effect_id: Optional[str] = None,
+        now: Optional[datetime] = None,
+    ) -> dict[str, Any]:
+        self.initialize()
+        if lifecycle not in {"accepted", "queued", "running"}:
+            raise ContractValidationError("initial lifecycle is invalid")
+        source_run_id = _validated_ref(source_run_id, field="source_run_id")
+        work_ref = _validated_ref(work_ref, field="work_ref")
+        proposal_ref = _validated_ref(proposal_ref, field="proposal_ref")
+        effect_id = _validated_ref(effect_id, field="effect_id")
+        if effect_id and not (work_ref and proposal_ref):
+            raise ContractValidationError(
+                "effect_id requires exact work_ref and proposal_ref bindings"
+            )
+        instant = _timestamp(now)
+        execution_id = self._new_id("exe")
+        receipt_state = "pending_evidence" if effect_id else "not_applicable"
+        connection = self._connect_write()
+        try:
+            with write_txn(connection):
+                if source_run_id:
+                    existing = connection.execute(
+                        "SELECT * FROM executions WHERE source_run_id=?",
+                        (source_run_id,),
+                    ).fetchone()
+                    if existing is not None:
+                        expected = (work_ref, proposal_ref, effect_id)
+                        actual = (
+                            existing["work_ref"],
+                            existing["proposal_ref"],
+                            existing["effect_id"],
+                        )
+                        if expected != actual:
+                            raise ContractConflictError(
+                                "source_run_id already has different immutable bindings"
+                            )
+                        return self._execution_from_row(existing)
+                connection.execute(
+                    """
+                    INSERT INTO executions(
+                        execution_id, profile_id, authority_id, executor_id,
+                        source_run_id, work_ref, proposal_ref, effect_id,
+                        lifecycle, receipt_state, created_at, started_at,
+                        updated_at, revision, runtime_instance_id
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 1, ?)
+                    """,
+                    (
+                        execution_id,
+                        self.authority.profile_id,
+                        self.authority.authority_id,
+                        self.authority.executor_id,
+                        source_run_id,
+                        work_ref,
+                        proposal_ref,
+                        effect_id,
+                        lifecycle,
+                        receipt_state,
+                        instant,
+                        instant if lifecycle == "running" else None,
+                        instant,
+                        self.runtime_instance_id,
+                    ),
+                )
+                self._append_event_in_txn(
+                    connection,
+                    execution_id=execution_id,
+                    event_type="execution.created",
+                    to_lifecycle=lifecycle,
+                    occurred_at=instant,
+                    revision=1,
+                )
+                row = self._execution_row(connection, execution_id)
+                assert row is not None
+                return self._execution_from_row(row)
+        except sqlite3.IntegrityError as exc:
+            raise ContractConflictError("execution identity conflicts") from exc
+        finally:
+            connection.close()
+
+    def transition_execution(
+        self,
+        execution_id: str,
+        lifecycle: str,
+        *,
+        expected_revision: Optional[int] = None,
+        reason_code: Optional[str] = None,
+        recovery_ref: Optional[str] = None,
+        now: Optional[datetime] = None,
+    ) -> dict[str, Any]:
+        self.initialize()
+        self._assert_identifier_scope(execution_id, "exe")
+        if lifecycle not in EXECUTION_STATES:
+            raise ContractValidationError("unknown execution lifecycle")
+        reason_code = _validated_ref(reason_code, field="reason_code", max_length=128)
+        recovery_ref = _validated_ref(recovery_ref, field="recovery_ref")
+        instant = _timestamp(now)
+        connection = self._connect_write()
+        try:
+            with write_txn(connection):
+                row = self._execution_row(connection, execution_id)
+                if row is None:
+                    raise ContractNotFoundError("execution not found")
+                current = str(row["lifecycle"])
+                revision = int(row["revision"])
+                if expected_revision is not None and int(expected_revision) != revision:
+                    raise ContractConflictError("execution revision conflict")
+                if lifecycle == current:
+                    return self._execution_from_row(row)
+                if lifecycle not in _ALLOWED_TRANSITIONS.get(current, frozenset()):
+                    raise ContractConflictError(
+                        f"invalid execution transition: {current} -> {lifecycle}"
+                    )
+
+                evidence = connection.execute(
+                    "SELECT * FROM effect_evidence WHERE execution_id=?",
+                    (execution_id,),
+                ).fetchone()
+                requested_terminal = lifecycle in TERMINAL_EXECUTION_STATES
+                actual_lifecycle = lifecycle
+                receipt_state = str(row["receipt_state"])
+                receipt_id: Optional[str] = row["receipt_id"]
+                event_reason = reason_code
+
+                if requested_terminal and row["effect_id"]:
+                    if evidence is None:
+                        actual_lifecycle = "terminal_ambiguous"
+                        receipt_state = "unproven"
+                        event_reason = event_reason or "effect_evidence_missing"
+                    else:
+                        actual_lifecycle = f"terminal_{evidence['outcome']}"
+                        receipt_id = self._publish_receipt_in_txn(
+                            connection,
+                            row=row,
+                            evidence=evidence,
+                            terminal_at=instant,
+                        )
+                        receipt_state = "published"
+
+                if current == "terminal_ambiguous" and actual_lifecycle != current:
+                    if evidence is None or not recovery_ref:
+                        raise ContractConflictError(
+                            "terminal ambiguity requires evidence and recovery_ref to reconcile"
+                        )
+
+                pending_decisions = connection.execute(
+                    "SELECT * FROM decisions WHERE execution_id=? AND state='pending' "
+                    "ORDER BY ordinal ASC",
+                    (execution_id,),
+                ).fetchall()
+                if actual_lifecycle in TERMINAL_EXECUTION_STATES:
+                    for decision in pending_decisions:
+                        connection.execute(
+                            """
+                            UPDATE decisions
+                            SET state='superseded', updated_at=?, revision=revision+1
+                            WHERE decision_id=? AND state='pending'
+                            """,
+                            (instant, decision["decision_id"]),
+                        )
+
+                new_revision = revision + 1
+                started_at = row["started_at"]
+                if started_at is None and actual_lifecycle == "running":
+                    started_at = instant
+                terminal_at = (
+                    instant if actual_lifecycle in TERMINAL_EXECUTION_STATES else None
+                )
+                connection.execute(
+                    """
+                    UPDATE executions
+                    SET lifecycle=?, receipt_state=?, receipt_id=?, started_at=?,
+                        updated_at=?, terminal_at=?, recovery_ref=?, revision=?,
+                        runtime_instance_id=?
+                    WHERE execution_id=? AND revision=?
+                    """,
+                    (
+                        actual_lifecycle,
+                        receipt_state,
+                        receipt_id,
+                        started_at,
+                        instant,
+                        terminal_at,
+                        recovery_ref or row["recovery_ref"],
+                        new_revision,
+                        self.runtime_instance_id,
+                        execution_id,
+                        revision,
+                    ),
+                )
+                if connection.execute("SELECT changes()").fetchone()[0] != 1:
+                    raise ContractConflictError("execution revision conflict")
+                self._append_event_in_txn(
+                    connection,
+                    execution_id=execution_id,
+                    event_type=(
+                        "execution.recovered" if recovery_ref else "execution.transitioned"
+                    ),
+                    from_lifecycle=current,
+                    to_lifecycle=actual_lifecycle,
+                    receipt_id=receipt_id,
+                    reason_code=event_reason,
+                    occurred_at=instant,
+                    revision=new_revision,
+                )
+                for decision in pending_decisions:
+                    if actual_lifecycle in TERMINAL_EXECUTION_STATES:
+                        self._append_event_in_txn(
+                            connection,
+                            execution_id=execution_id,
+                            event_type="decision.superseded",
+                            from_lifecycle=actual_lifecycle,
+                            to_lifecycle=actual_lifecycle,
+                            decision_id=decision["decision_id"],
+                            reason_code="execution_terminal",
+                            occurred_at=instant,
+                            revision=new_revision,
+                        )
+                if receipt_id:
+                    self._append_event_in_txn(
+                        connection,
+                        execution_id=execution_id,
+                        event_type="receipt.published",
+                        to_lifecycle=actual_lifecycle,
+                        receipt_id=receipt_id,
+                        occurred_at=instant,
+                        revision=new_revision,
+                    )
+                updated = self._execution_row(connection, execution_id)
+                assert updated is not None
+                return self._execution_from_row(updated)
+        finally:
+            connection.close()
+
+    def recover_orphaned_executions(
+        self,
+        *,
+        recovery_ref: str,
+        now: Optional[datetime] = None,
+    ) -> list[str]:
+        """Mark prior-runtime nonterminal rows ambiguous after restart."""
+
+        self.initialize()
+        recovery_ref = cast(
+            str,
+            _validated_ref(
+                recovery_ref,
+                field="recovery_ref",
+                required=True,
+            ),
+        )
+        instant = _timestamp(now)
+        recovered: list[str] = []
+        connection = self._connect_write()
+        try:
+            with write_txn(connection):
+                rows = connection.execute(
+                    """
+                    SELECT * FROM executions
+                    WHERE lifecycle NOT LIKE 'terminal_%'
+                      AND runtime_instance_id != ?
+                    ORDER BY ordinal ASC
+                    """,
+                    (self.runtime_instance_id,),
+                ).fetchall()
+                for row in rows:
+                    revision = int(row["revision"]) + 1
+                    receipt_state = (
+                        "unproven" if row["effect_id"] else "not_applicable"
+                    )
+                    connection.execute(
+                        """
+                        UPDATE executions
+                        SET lifecycle='terminal_ambiguous', receipt_state=?,
+                            updated_at=?, terminal_at=?, recovery_ref=?, revision=?,
+                            runtime_instance_id=?
+                        WHERE execution_id=?
+                        """,
+                        (
+                            receipt_state,
+                            instant,
+                            instant,
+                            recovery_ref,
+                            revision,
+                            self.runtime_instance_id,
+                            row["execution_id"],
+                        ),
+                    )
+                    self._append_event_in_txn(
+                        connection,
+                        execution_id=row["execution_id"],
+                        event_type="execution.recovered",
+                        from_lifecycle=row["lifecycle"],
+                        to_lifecycle="terminal_ambiguous",
+                        reason_code="runtime_restarted",
+                        occurred_at=instant,
+                        revision=revision,
+                    )
+                    recovered.append(str(row["execution_id"]))
+            return recovered
+        finally:
+            connection.close()
+
+    def create_decision(
+        self,
+        *,
+        execution_id: str,
+        effect_id: str,
+        proposal_ref: str,
+        request_digest: str,
+        allowed_choices: list[str] | tuple[str, ...],
+        expires_at: datetime,
+        candidate_digest: Optional[str] = None,
+        policy_digest: Optional[str] = None,
+        now: Optional[datetime] = None,
+    ) -> dict[str, Any]:
+        self.initialize()
+        self._assert_identifier_scope(execution_id, "exe")
+        effect_id = cast(
+            str,
+            _validated_ref(effect_id, field="effect_id", required=True),
+        )
+        proposal_ref = cast(
+            str,
+            _validated_ref(
+                proposal_ref,
+                field="proposal_ref",
+                required=True,
+            ),
+        )
+        request_digest = cast(
+            str,
+            _validated_digest(
+                request_digest,
+                field="request_digest",
+                required=True,
+            ),
+        )
+        candidate_digest = _validated_digest(
+            candidate_digest,
+            field="candidate_digest",
+            required=False,
+        )
+        policy_digest = _validated_digest(
+            policy_digest,
+            field="policy_digest",
+            required=False,
+        )
+        choices = _validated_choices(allowed_choices)
+        instant_dt = now or _utc_now()
+        if expires_at.tzinfo is None or expires_at.utcoffset() is None:
+            raise ContractValidationError("expires_at must be timezone-aware")
+        if instant_dt.tzinfo is None or instant_dt.utcoffset() is None:
+            raise ContractValidationError("now must be timezone-aware")
+        if expires_at.astimezone(timezone.utc) <= instant_dt.astimezone(timezone.utc):
+            raise ContractValidationError("expires_at must be in the future")
+        instant = _timestamp(instant_dt)
+        expiry = _timestamp(expires_at)
+        decision_id = self._new_id("dec")
+        connection = self._connect_write()
+        try:
+            with write_txn(connection):
+                execution = self._execution_row(connection, execution_id)
+                if execution is None:
+                    raise ContractNotFoundError("execution not found")
+                if execution["lifecycle"] in TERMINAL_EXECUTION_STATES:
+                    raise ContractConflictError("terminal execution cannot request a decision")
+                if execution["effect_id"] != effect_id:
+                    raise ContractConflictError("decision effect binding mismatch")
+                if execution["proposal_ref"] != proposal_ref:
+                    raise ContractConflictError("decision proposal binding mismatch")
+                existing = connection.execute(
+                    "SELECT * FROM decisions WHERE execution_id=? AND request_digest=?",
+                    (execution_id, request_digest),
+                ).fetchone()
+                if existing is not None:
+                    immutable = (
+                        effect_id,
+                        proposal_ref,
+                        candidate_digest,
+                        policy_digest,
+                        json.dumps(choices, separators=(",", ":")),
+                        expiry,
+                    )
+                    actual = (
+                        existing["effect_id"],
+                        existing["proposal_ref"],
+                        existing["candidate_digest"],
+                        existing["policy_digest"],
+                        existing["allowed_choices_json"],
+                        existing["expires_at"],
+                    )
+                    if immutable != actual:
+                        raise ContractConflictError(
+                            "decision request digest has conflicting bindings"
+                        )
+                    return self._decision_from_row(existing)
+                pending = connection.execute(
+                    "SELECT decision_id FROM decisions "
+                    "WHERE execution_id=? AND state='pending' LIMIT 1",
+                    (execution_id,),
+                ).fetchone()
+                if pending is not None:
+                    raise ContractConflictError(
+                        "execution already has a pending decision"
+                    )
+                connection.execute(
+                    """
+                    INSERT INTO decisions(
+                        decision_id, execution_id, profile_id, authority_id,
+                        effect_id, proposal_ref, request_digest, candidate_digest,
+                        policy_digest, allowed_choices_json, expires_at, state,
+                        created_at, updated_at, revision
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'pending', ?, ?, 1)
+                    """,
+                    (
+                        decision_id,
+                        execution_id,
+                        self.authority.profile_id,
+                        self.authority.authority_id,
+                        effect_id,
+                        proposal_ref,
+                        request_digest,
+                        candidate_digest,
+                        policy_digest,
+                        json.dumps(choices, separators=(",", ":")),
+                        expiry,
+                        instant,
+                        instant,
+                    ),
+                )
+                revision = int(execution["revision"]) + 1
+                connection.execute(
+                    """
+                    UPDATE executions
+                    SET lifecycle='awaiting_decision', updated_at=?, revision=?
+                    WHERE execution_id=?
+                    """,
+                    (instant, revision, execution_id),
+                )
+                self._append_event_in_txn(
+                    connection,
+                    execution_id=execution_id,
+                    event_type="decision.requested",
+                    from_lifecycle=execution["lifecycle"],
+                    to_lifecycle="awaiting_decision",
+                    decision_id=decision_id,
+                    occurred_at=instant,
+                    revision=revision,
+                )
+                row = connection.execute(
+                    "SELECT * FROM decisions WHERE decision_id=?",
+                    (decision_id,),
+                ).fetchone()
+                assert row is not None
+                return self._decision_from_row(row)
+        finally:
+            connection.close()
+
+    def resolve_decision(
+        self,
+        decision_id: str,
+        *,
+        choice: str,
+        resolution_evidence_digest: str,
+        expected_revision: int = 1,
+        now: Optional[datetime] = None,
+    ) -> dict[str, Any]:
+        self.initialize()
+        self._assert_identifier_scope(decision_id, "dec")
+        choice = cast(
+            str,
+            _validated_ref(
+                choice,
+                field="choice",
+                required=True,
+                max_length=64,
+            ),
+        )
+        evidence_digest = cast(
+            str,
+            _validated_digest(
+                resolution_evidence_digest,
+                field="resolution_evidence_digest",
+                required=True,
+            ),
+        )
+        instant = _timestamp(now)
+        connection = self._connect_write()
+        try:
+            with write_txn(connection):
+                row = connection.execute(
+                    "SELECT * FROM decisions WHERE decision_id=?",
+                    (decision_id,),
+                ).fetchone()
+                if row is None:
+                    raise ContractNotFoundError("decision not found")
+                if int(row["revision"]) != int(expected_revision):
+                    if (
+                        row["state"] == "resolved"
+                        and row["choice"] == choice
+                        and row["resolution_evidence_digest"] == evidence_digest
+                    ):
+                        return self._decision_from_row(row)
+                    raise ContractConflictError("decision revision conflict")
+                if row["state"] != "pending":
+                    raise ContractConflictError("decision is not pending")
+                if _parse_timestamp(row["expires_at"], field="expires_at") <= _parse_timestamp(
+                    instant,
+                    field="now",
+                ):
+                    raise ContractConflictError("decision expired")
+                choices = json.loads(row["allowed_choices_json"])
+                if choice not in choices:
+                    raise ContractValidationError("choice is not allowed")
+                connection.execute(
+                    """
+                    UPDATE decisions
+                    SET state='resolved', choice=?, resolution_evidence_digest=?,
+                        updated_at=?, resolved_at=?, revision=revision+1
+                    WHERE decision_id=? AND revision=?
+                    """,
+                    (choice, evidence_digest, instant, instant, decision_id, expected_revision),
+                )
+                execution = self._execution_row(connection, row["execution_id"])
+                assert execution is not None
+                execution_revision = int(execution["revision"]) + 1
+                connection.execute(
+                    """
+                    UPDATE executions SET lifecycle='running', updated_at=?, revision=?
+                    WHERE execution_id=?
+                    """,
+                    (instant, execution_revision, row["execution_id"]),
+                )
+                self._append_event_in_txn(
+                    connection,
+                    execution_id=row["execution_id"],
+                    event_type="decision.resolved",
+                    from_lifecycle=execution["lifecycle"],
+                    to_lifecycle="running",
+                    decision_id=decision_id,
+                    occurred_at=instant,
+                    revision=execution_revision,
+                )
+                updated = connection.execute(
+                    "SELECT * FROM decisions WHERE decision_id=?",
+                    (decision_id,),
+                ).fetchone()
+                assert updated is not None
+                return self._decision_from_row(updated)
+        finally:
+            connection.close()
+
+    def expire_decisions(self, *, now: Optional[datetime] = None) -> list[str]:
+        self.initialize()
+        instant = _timestamp(now)
+        expired: list[str] = []
+        connection = self._connect_write()
+        try:
+            with write_txn(connection):
+                rows = connection.execute(
+                    "SELECT * FROM decisions WHERE state='pending' AND expires_at <= ? "
+                    "ORDER BY ordinal ASC",
+                    (instant,),
+                ).fetchall()
+                for row in rows:
+                    connection.execute(
+                        """
+                        UPDATE decisions SET state='expired', updated_at=?,
+                            revision=revision+1 WHERE decision_id=?
+                        """,
+                        (instant, row["decision_id"]),
+                    )
+                    execution = self._execution_row(connection, row["execution_id"])
+                    assert execution is not None
+                    if execution["lifecycle"] in TERMINAL_EXECUTION_STATES:
+                        revision = int(execution["revision"])
+                        self._append_event_in_txn(
+                            connection,
+                            execution_id=row["execution_id"],
+                            event_type="decision.expired",
+                            from_lifecycle=execution["lifecycle"],
+                            to_lifecycle=execution["lifecycle"],
+                            decision_id=row["decision_id"],
+                            reason_code="decision_expired_after_terminal",
+                            occurred_at=instant,
+                            revision=revision,
+                        )
+                        expired.append(str(row["decision_id"]))
+                        continue
+                    revision = int(execution["revision"]) + 1
+                    connection.execute(
+                        """
+                        UPDATE executions
+                        SET lifecycle='terminal_ambiguous', receipt_state='unproven',
+                            updated_at=?, terminal_at=?, revision=?
+                        WHERE execution_id=?
+                        """,
+                        (instant, instant, revision, row["execution_id"]),
+                    )
+                    self._append_event_in_txn(
+                        connection,
+                        execution_id=row["execution_id"],
+                        event_type="decision.expired",
+                        from_lifecycle=execution["lifecycle"],
+                        to_lifecycle="terminal_ambiguous",
+                        decision_id=row["decision_id"],
+                        reason_code="decision_expired",
+                        occurred_at=instant,
+                        revision=revision,
+                    )
+                    expired.append(str(row["decision_id"]))
+            return expired
+        finally:
+            connection.close()
+
+    def supersede_decision(
+        self,
+        decision_id: str,
+        *,
+        reason_code: str,
+        now: Optional[datetime] = None,
+    ) -> dict[str, Any]:
+        self.initialize()
+        self._assert_identifier_scope(decision_id, "dec")
+        reason_code = cast(
+            str,
+            _validated_ref(
+                reason_code,
+                field="reason_code",
+                required=True,
+                max_length=128,
+            ),
+        )
+        instant = _timestamp(now)
+        connection = self._connect_write()
+        try:
+            with write_txn(connection):
+                row = connection.execute(
+                    "SELECT * FROM decisions WHERE decision_id=?",
+                    (decision_id,),
+                ).fetchone()
+                if row is None:
+                    raise ContractNotFoundError("decision not found")
+                if row["state"] != "pending":
+                    raise ContractConflictError("decision is not pending")
+                connection.execute(
+                    """
+                    UPDATE decisions SET state='superseded', updated_at=?,
+                        revision=revision+1 WHERE decision_id=?
+                    """,
+                    (instant, decision_id),
+                )
+                execution = self._execution_row(connection, row["execution_id"])
+                assert execution is not None
+                revision = int(execution["revision"]) + 1
+                connection.execute(
+                    """
+                    UPDATE executions SET lifecycle='running', updated_at=?, revision=?
+                    WHERE execution_id=?
+                    """,
+                    (instant, revision, row["execution_id"]),
+                )
+                self._append_event_in_txn(
+                    connection,
+                    execution_id=row["execution_id"],
+                    event_type="decision.superseded",
+                    from_lifecycle=execution["lifecycle"],
+                    to_lifecycle="running",
+                    decision_id=decision_id,
+                    reason_code=reason_code,
+                    occurred_at=instant,
+                    revision=revision,
+                )
+                updated = connection.execute(
+                    "SELECT * FROM decisions WHERE decision_id=?",
+                    (decision_id,),
+                ).fetchone()
+                assert updated is not None
+                return self._decision_from_row(updated)
+        finally:
+            connection.close()
+
+    def record_effect_evidence(
+        self,
+        *,
+        execution_id: str,
+        effect_id: str,
+        outcome: str,
+        subject_digest: str,
+        evidence_digest: str,
+        result_digest: str,
+        decision_id: Optional[str] = None,
+        recovery_ref: Optional[str] = None,
+        reconciliation_ref: Optional[str] = None,
+        now: Optional[datetime] = None,
+    ) -> dict[str, Any]:
+        """Record closed executor evidence; never infer it from generic output."""
+
+        self.initialize()
+        self._assert_identifier_scope(execution_id, "exe")
+        if outcome not in RECEIPT_OUTCOMES:
+            raise ContractValidationError("unknown effect outcome")
+        effect_id = cast(
+            str,
+            _validated_ref(effect_id, field="effect_id", required=True),
+        )
+        subject_digest = cast(
+            str,
+            _validated_digest(
+                subject_digest,
+                field="subject_digest",
+                required=True,
+            ),
+        )
+        evidence_digest = cast(
+            str,
+            _validated_digest(
+                evidence_digest,
+                field="evidence_digest",
+                required=True,
+            ),
+        )
+        result_digest = cast(
+            str,
+            _validated_digest(
+                result_digest,
+                field="result_digest",
+                required=True,
+            ),
+        )
+        if decision_id:
+            self._assert_identifier_scope(decision_id, "dec")
+        recovery_ref = _validated_ref(recovery_ref, field="recovery_ref")
+        reconciliation_ref = _validated_ref(
+            reconciliation_ref,
+            field="reconciliation_ref",
+        )
+        instant = _timestamp(now)
+        evidence_id = f"evd_{self.authority.profile_key}_{uuid.uuid4().hex}"
+        connection = self._connect_write()
+        try:
+            with write_txn(connection):
+                execution = self._execution_row(connection, execution_id)
+                if execution is None:
+                    raise ContractNotFoundError("execution not found")
+                if execution["effect_id"] != effect_id:
+                    raise ContractConflictError("effect evidence binding mismatch")
+                bound_decisions = connection.execute(
+                    "SELECT * FROM decisions WHERE execution_id=? ORDER BY ordinal DESC",
+                    (execution_id,),
+                ).fetchall()
+                if bound_decisions:
+                    if not decision_id:
+                        raise ContractConflictError(
+                            "effect evidence requires its exact decision binding"
+                        )
+                    matching = next(
+                        (
+                            row
+                            for row in bound_decisions
+                            if row["decision_id"] == decision_id
+                        ),
+                        None,
+                    )
+                    if matching is None:
+                        raise ContractConflictError(
+                            "effect evidence decision is not bound to the execution"
+                        )
+                    if matching["state"] != "resolved":
+                        raise ContractConflictError("decision is not resolved")
+                if decision_id:
+                    decision = connection.execute(
+                        "SELECT * FROM decisions WHERE decision_id=?",
+                        (decision_id,),
+                    ).fetchone()
+                    if decision is None:
+                        raise ContractNotFoundError("decision not found")
+                    if (
+                        decision["execution_id"] != execution_id
+                        or decision["effect_id"] != effect_id
+                    ):
+                        raise ContractConflictError("decision evidence binding mismatch")
+                existing = connection.execute(
+                    "SELECT * FROM effect_evidence WHERE execution_id=?",
+                    (execution_id,),
+                ).fetchone()
+                immutable = (
+                    effect_id,
+                    outcome,
+                    subject_digest,
+                    evidence_digest,
+                    result_digest,
+                    decision_id,
+                    recovery_ref,
+                    reconciliation_ref,
+                )
+                if existing is not None:
+                    actual = tuple(
+                        existing[key]
+                        for key in (
+                            "effect_id",
+                            "outcome",
+                            "subject_digest",
+                            "evidence_digest",
+                            "result_digest",
+                            "decision_id",
+                            "recovery_ref",
+                            "reconciliation_ref",
+                        )
+                    )
+                    if immutable != actual:
+                        raise ContractConflictError("conflicting effect evidence")
+                    return self._evidence_from_row(existing)
+                connection.execute(
+                    """
+                    INSERT INTO effect_evidence(
+                        evidence_id, execution_id, profile_id, authority_id,
+                        executor_id, effect_id, outcome, subject_digest,
+                        evidence_digest, result_digest, decision_id, recovery_ref,
+                        reconciliation_ref, recorded_at
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    (
+                        evidence_id,
+                        execution_id,
+                        self.authority.profile_id,
+                        self.authority.authority_id,
+                        self.authority.executor_id,
+                        effect_id,
+                        outcome,
+                        subject_digest,
+                        evidence_digest,
+                        result_digest,
+                        decision_id,
+                        recovery_ref,
+                        reconciliation_ref,
+                        instant,
+                    ),
+                )
+                self._append_event_in_txn(
+                    connection,
+                    execution_id=execution_id,
+                    event_type="effect.evidence_recorded",
+                    decision_id=decision_id,
+                    occurred_at=instant,
+                    revision=int(execution["revision"]),
+                )
+                inserted = connection.execute(
+                    "SELECT * FROM effect_evidence WHERE evidence_id=?",
+                    (evidence_id,),
+                ).fetchone()
+                assert inserted is not None
+                return self._evidence_from_row(inserted)
+        finally:
+            connection.close()
+
+    def prune_events(
+        self,
+        *,
+        older_than: Optional[datetime] = None,
+        now: Optional[datetime] = None,
+    ) -> int:
+        """Prune terminal history while persisting an explicit cursor watermark."""
+
+        self.initialize()
+        current = now or _utc_now()
+        cutoff = older_than or (
+            current - timedelta(seconds=EVENT_RETENTION_SECONDS)
+        )
+        cutoff_text = _timestamp(cutoff)
+        connection = self._connect_write()
+        try:
+            with write_txn(connection):
+                rows = connection.execute(
+                    """
+                    SELECT ev.sequence, ev.occurred_at, ex.lifecycle
+                    FROM execution_events ev
+                    JOIN executions ex ON ex.execution_id = ev.execution_id
+                    ORDER BY ev.sequence ASC
+                    """
+                ).fetchall()
+                through = 0
+                for row in rows:
+                    if not (
+                        str(row["occurred_at"]) < cutoff_text
+                        and str(row["lifecycle"]).startswith("terminal_")
+                    ):
+                        break
+                    through = int(row["sequence"])
+                if through <= 0:
+                    return 0
+                deleted = connection.execute(
+                    "DELETE FROM execution_events WHERE sequence <= ?",
+                    (through,),
+                ).rowcount
+                prior = int(
+                    connection.execute(
+                        "SELECT value FROM execution_contract_metadata "
+                        "WHERE key='events_pruned_through'"
+                    ).fetchone()[0]
+                )
+                connection.execute(
+                    "UPDATE execution_contract_metadata SET value=? "
+                    "WHERE key='events_pruned_through'",
+                    (str(max(prior, through)),),
+                )
+                return int(deleted or 0)
+        finally:
+            connection.close()
+
+    # ------------------------------------------------------------------
+    # Side-effect-free public reads
+    # ------------------------------------------------------------------
+
+    def list_executions(
+        self,
+        *,
+        after: int = 0,
+        limit: int = DEFAULT_PAGE_SIZE,
+        lifecycle: Optional[str] = None,
+    ) -> dict[str, Any]:
+        after = _validated_cursor(after)
+        limit = _validated_limit(limit)
+        if lifecycle is not None and lifecycle not in EXECUTION_STATES:
+            raise ContractValidationError("unknown execution lifecycle")
+        with self._read_connection() as connection:
+            if connection is None:
+                if after > 0:
+                    raise ContractConflictError("execution cursor is ahead of high-water")
+                return self._collection_page([], after, 0, 0, False)
+            params: list[Any] = [after]
+            where = "ordinal > ?"
+            if lifecycle:
+                where += " AND lifecycle = ?"
+                params.append(lifecycle)
+            params.append(limit + 1)
+            rows = connection.execute(
+                f"SELECT * FROM executions WHERE {where} ORDER BY ordinal ASC LIMIT ?",
+                params,
+            ).fetchall()
+            return self._rows_page(
+                rows,
+                after=after,
+                limit=limit,
+                table="executions",
+                decoder=self._execution_from_row,
+                connection=connection,
+            )
+
+    def get_execution(self, execution_id: str) -> dict[str, Any]:
+        self._assert_identifier_scope(execution_id, "exe")
+        with self._read_connection() as connection:
+            if connection is None:
+                raise ContractNotFoundError("execution not found")
+            row = self._execution_row(connection, execution_id)
+            if row is None:
+                raise ContractNotFoundError("execution not found")
+            return self._execution_from_row(row)
+
+    def get_execution_by_source_run_id(self, source_run_id: str) -> dict[str, Any]:
+        source_run_id = cast(
+            str,
+            _validated_ref(
+                source_run_id,
+                field="source_run_id",
+                required=True,
+            ),
+        )
+        with self._read_connection() as connection:
+            if connection is None:
+                raise ContractNotFoundError("execution not found")
+            row = connection.execute(
+                "SELECT * FROM executions WHERE source_run_id=?",
+                (source_run_id,),
+            ).fetchone()
+            if row is None:
+                raise ContractNotFoundError("execution not found")
+            return self._execution_from_row(row)
+
+    def list_decisions(
+        self,
+        *,
+        after: int = 0,
+        limit: int = DEFAULT_PAGE_SIZE,
+        state: Optional[str] = None,
+    ) -> dict[str, Any]:
+        after = _validated_cursor(after)
+        limit = _validated_limit(limit)
+        if state is not None and state not in DECISION_STATES:
+            raise ContractValidationError("unknown decision state")
+        with self._read_connection() as connection:
+            if connection is None:
+                if after > 0:
+                    raise ContractConflictError("decision cursor is ahead of high-water")
+                return self._collection_page([], after, 0, 0, False)
+            params: list[Any] = [after]
+            where = "ordinal > ?"
+            if state:
+                where += " AND state = ?"
+                params.append(state)
+            params.append(limit + 1)
+            rows = connection.execute(
+                f"SELECT * FROM decisions WHERE {where} ORDER BY ordinal ASC LIMIT ?",
+                params,
+            ).fetchall()
+            return self._rows_page(
+                rows,
+                after=after,
+                limit=limit,
+                table="decisions",
+                decoder=self._decision_from_row,
+                connection=connection,
+            )
+
+    def get_decision(self, decision_id: str) -> dict[str, Any]:
+        self._assert_identifier_scope(decision_id, "dec")
+        with self._read_connection() as connection:
+            if connection is None:
+                raise ContractNotFoundError("decision not found")
+            row = connection.execute(
+                "SELECT * FROM decisions WHERE decision_id=?",
+                (decision_id,),
+            ).fetchone()
+            if row is None:
+                raise ContractNotFoundError("decision not found")
+            return self._decision_from_row(row)
+
+    def list_receipts(
+        self,
+        *,
+        after: int = 0,
+        limit: int = DEFAULT_PAGE_SIZE,
+        outcome: Optional[str] = None,
+    ) -> dict[str, Any]:
+        after = _validated_cursor(after)
+        limit = _validated_limit(limit)
+        if outcome is not None and outcome not in RECEIPT_OUTCOMES:
+            raise ContractValidationError("unknown receipt outcome")
+        with self._read_connection() as connection:
+            if connection is None:
+                if after > 0:
+                    raise ContractConflictError("receipt cursor is ahead of high-water")
+                return self._collection_page([], after, 0, 0, False)
+            params: list[Any] = [after]
+            where = "ordinal > ?"
+            if outcome:
+                where += " AND outcome = ?"
+                params.append(outcome)
+            params.append(limit + 1)
+            rows = connection.execute(
+                f"SELECT * FROM receipts WHERE {where} ORDER BY ordinal ASC LIMIT ?",
+                params,
+            ).fetchall()
+            return self._rows_page(
+                rows,
+                after=after,
+                limit=limit,
+                table="receipts",
+                decoder=self._receipt_from_row,
+                connection=connection,
+            )
+
+    def get_receipt(self, receipt_id: str) -> dict[str, Any]:
+        self._assert_identifier_scope(receipt_id, "rcp")
+        with self._read_connection() as connection:
+            if connection is None:
+                raise ContractNotFoundError("receipt not found")
+            row = connection.execute(
+                "SELECT * FROM receipts WHERE receipt_id=?",
+                (receipt_id,),
+            ).fetchone()
+            if row is None:
+                raise ContractNotFoundError("receipt not found")
+            return self._receipt_from_row(row)
+
+    def list_events(
+        self,
+        *,
+        after: int = 0,
+        limit: int = DEFAULT_PAGE_SIZE,
+        execution_id: Optional[str] = None,
+    ) -> dict[str, Any]:
+        after = _validated_cursor(after)
+        limit = _validated_limit(limit)
+        if execution_id:
+            self._assert_identifier_scope(execution_id, "exe")
+        with self._read_connection() as connection:
+            if connection is None:
+                if after > 0:
+                    raise ContractConflictError(
+                        "event cursor is ahead of high-water"
+                    )
+                return self._event_page([], after, 0, 1, False, 0)
+            current_high_water = int(
+                connection.execute(
+                    "SELECT COALESCE(MAX(sequence), 0) FROM execution_events"
+                ).fetchone()[0]
+            )
+            pruned_through = int(
+                connection.execute(
+                    "SELECT value FROM execution_contract_metadata "
+                    "WHERE key='events_pruned_through'"
+                ).fetchone()[0]
+            )
+            high_water = max(current_high_water, pruned_through)
+            minimum_available_row = connection.execute(
+                "SELECT MIN(sequence) FROM execution_events"
+            ).fetchone()
+            minimum_available = (
+                int(minimum_available_row[0])
+                if minimum_available_row and minimum_available_row[0] is not None
+                else pruned_through + 1
+            )
+            if after < pruned_through:
+                raise ContractCursorGoneError(minimum_available, high_water)
+            if after > high_water:
+                raise ContractConflictError("event cursor is ahead of high-water")
+            params: list[Any] = [after]
+            where = "sequence > ?"
+            if execution_id:
+                where += " AND execution_id = ?"
+                params.append(execution_id)
+            params.append(limit + 1)
+            rows = connection.execute(
+                f"SELECT * FROM execution_events WHERE {where} "
+                "ORDER BY sequence ASC LIMIT ?",
+                params,
+            ).fetchall()
+            visible = rows[:limit]
+            has_more = len(rows) > limit
+            cursor = (
+                int(visible[-1]["sequence"])
+                if has_more and visible
+                else high_water
+            )
+            return self._event_page(
+                [self._event_from_row(row) for row in visible],
+                cursor,
+                high_water,
+                minimum_available,
+                has_more,
+                pruned_through,
+            )
+
+    # ------------------------------------------------------------------
+    # Internal serialization and invariants
+    # ------------------------------------------------------------------
+
+    def _new_id(self, kind: str) -> str:
+        return f"{kind}_{self.authority.profile_key}_{uuid.uuid4().hex}"
+
+    def _assert_identifier_scope(self, identifier: str, expected_kind: str) -> None:
+        match = _ID_RE.fullmatch(str(identifier or ""))
+        if match is None or match.group(1) != expected_kind:
+            raise ContractValidationError(f"invalid {expected_kind} identifier")
+        if match.group(2) != self.authority.profile_key:
+            raise ContractForbiddenError("identifier belongs to another profile")
+
+    @staticmethod
+    def _execution_row(
+        connection: sqlite3.Connection,
+        execution_id: str,
+    ) -> Optional[sqlite3.Row]:
+        return connection.execute(
+            "SELECT * FROM executions WHERE execution_id=?",
+            (execution_id,),
+        ).fetchone()
+
+    def _append_event_in_txn(
+        self,
+        connection: sqlite3.Connection,
+        *,
+        execution_id: str,
+        event_type: str,
+        occurred_at: str,
+        revision: int,
+        from_lifecycle: Optional[str] = None,
+        to_lifecycle: Optional[str] = None,
+        decision_id: Optional[str] = None,
+        receipt_id: Optional[str] = None,
+        reason_code: Optional[str] = None,
+    ) -> int:
+        if event_type not in EVENT_TYPES:
+            raise ContractValidationError("unknown event type")
+        event_id = self._new_id("evt")
+        cursor = connection.execute(
+            """
+            INSERT INTO execution_events(
+                event_id, execution_id, profile_id, authority_id, event_type,
+                from_lifecycle, to_lifecycle, decision_id, receipt_id,
+                reason_code, occurred_at, revision
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                event_id,
+                execution_id,
+                self.authority.profile_id,
+                self.authority.authority_id,
+                event_type,
+                from_lifecycle,
+                to_lifecycle,
+                decision_id,
+                receipt_id,
+                reason_code,
+                occurred_at,
+                revision,
+            ),
+        )
+        if cursor.lastrowid is None:
+            raise ContractDataError("event append did not allocate a sequence")
+        return int(cursor.lastrowid)
+
+    def _publish_receipt_in_txn(
+        self,
+        connection: sqlite3.Connection,
+        *,
+        row: sqlite3.Row,
+        evidence: sqlite3.Row,
+        terminal_at: str,
+    ) -> str:
+        existing = connection.execute(
+            "SELECT * FROM receipts WHERE execution_id=?",
+            (row["execution_id"],),
+        ).fetchone()
+        if existing is not None:
+            immutable = (
+                evidence["effect_id"],
+                evidence["outcome"],
+                evidence["subject_digest"],
+                evidence["evidence_digest"],
+                evidence["result_digest"],
+                evidence["decision_id"],
+            )
+            actual = tuple(
+                existing[key]
+                for key in (
+                    "effect_id",
+                    "outcome",
+                    "subject_digest",
+                    "evidence_digest",
+                    "result_digest",
+                    "decision_id",
+                )
+            )
+            if immutable != actual:
+                raise ContractConflictError("conflicting terminal receipt")
+            return str(existing["receipt_id"])
+        receipt_id = self._new_id("rcp")
+        connection.execute(
+            """
+            INSERT INTO receipts(
+                receipt_id, execution_id, effect_id, profile_id, authority_id,
+                executor_id, outcome, subject_digest, evidence_digest,
+                result_digest, terminal_at, decision_id, recovery_ref,
+                reconciliation_ref, revision
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 1)
+            """,
+            (
+                receipt_id,
+                row["execution_id"],
+                evidence["effect_id"],
+                self.authority.profile_id,
+                self.authority.authority_id,
+                self.authority.executor_id,
+                evidence["outcome"],
+                evidence["subject_digest"],
+                evidence["evidence_digest"],
+                evidence["result_digest"],
+                terminal_at,
+                evidence["decision_id"],
+                evidence["recovery_ref"],
+                evidence["reconciliation_ref"],
+            ),
+        )
+        return receipt_id
+
+    def _assert_row_authority(
+        self,
+        row: sqlite3.Row,
+        *,
+        require_executor: bool,
+    ) -> None:
+        if (
+            row["profile_id"] != self.authority.profile_id
+            or row["authority_id"] != self.authority.authority_id
+            or (
+                require_executor
+                and row["executor_id"] != self.authority.executor_id
+            )
+        ):
+            raise ContractDataError(
+                "persisted row authority does not match the active profile"
+            )
+
+    def _execution_from_row(self, row: sqlite3.Row) -> dict[str, Any]:
+        self._assert_row_authority(row, require_executor=True)
+        lifecycle = str(row["lifecycle"])
+        receipt_state = str(row["receipt_state"])
+        if lifecycle not in EXECUTION_STATES or receipt_state not in RECEIPT_STATES:
+            raise ContractDataError("execution row contains an unknown state")
+        for field in ("created_at", "updated_at"):
+            _parse_timestamp(row[field], field=field)
+        for field in ("started_at", "terminal_at"):
+            if row[field] is not None:
+                _parse_timestamp(row[field], field=field)
+        freshness = "terminal" if lifecycle in TERMINAL_EXECUTION_STATES else (
+            "live"
+            if row["runtime_instance_id"] == self.runtime_instance_id
+            else "stale"
+        )
+        return {
+            "contract_version": CONTRACT_VERSION,
+            "execution_id": row["execution_id"],
+            "profile_id": row["profile_id"],
+            "authority_id": row["authority_id"],
+            "executor_id": row["executor_id"],
+            "source_run_id": row["source_run_id"],
+            "work_ref": row["work_ref"],
+            "proposal_ref": row["proposal_ref"],
+            "effect_id": row["effect_id"],
+            "lifecycle": lifecycle,
+            "freshness": freshness,
+            "receipt_state": receipt_state,
+            "receipt_id": row["receipt_id"],
+            "created_at": row["created_at"],
+            "started_at": row["started_at"],
+            "updated_at": row["updated_at"],
+            "terminal_at": row["terminal_at"],
+            "recovery_ref": row["recovery_ref"],
+            "revision": int(row["revision"]),
+        }
+
+    def _decision_from_row(self, row: sqlite3.Row) -> dict[str, Any]:
+        self._assert_row_authority(row, require_executor=False)
+        state = str(row["state"])
+        if state not in DECISION_STATES:
+            raise ContractDataError("decision row contains an unknown state")
+        try:
+            choices = json.loads(row["allowed_choices_json"])
+        except (TypeError, json.JSONDecodeError) as exc:
+            raise ContractDataError("decision choices are malformed") from exc
+        if not isinstance(choices, list) or not choices or not all(
+            isinstance(choice, str) for choice in choices
+        ):
+            raise ContractDataError("decision choices are malformed")
+        for field in ("created_at", "updated_at", "expires_at"):
+            _parse_timestamp(row[field], field=field)
+        if row["resolved_at"] is not None:
+            _parse_timestamp(row["resolved_at"], field="resolved_at")
+        return {
+            "contract_version": CONTRACT_VERSION,
+            "decision_id": row["decision_id"],
+            "execution_id": row["execution_id"],
+            "profile_id": row["profile_id"],
+            "authority_id": row["authority_id"],
+            "effect_id": row["effect_id"],
+            "proposal_ref": row["proposal_ref"],
+            "request_digest": row["request_digest"],
+            "candidate_digest": row["candidate_digest"],
+            "policy_digest": row["policy_digest"],
+            "allowed_choices": choices,
+            "expires_at": row["expires_at"],
+            "state": state,
+            "choice": row["choice"],
+            "resolution_evidence_digest": row["resolution_evidence_digest"],
+            "created_at": row["created_at"],
+            "updated_at": row["updated_at"],
+            "resolved_at": row["resolved_at"],
+            "revision": int(row["revision"]),
+        }
+
+    def _receipt_from_row(self, row: sqlite3.Row) -> dict[str, Any]:
+        self._assert_row_authority(row, require_executor=True)
+        outcome = str(row["outcome"])
+        if outcome not in RECEIPT_OUTCOMES:
+            raise ContractDataError("receipt row contains an unknown outcome")
+        _parse_timestamp(row["terminal_at"], field="terminal_at")
+        return {
+            "contract_version": CONTRACT_VERSION,
+            "receipt_id": row["receipt_id"],
+            "execution_id": row["execution_id"],
+            "effect_id": row["effect_id"],
+            "profile_id": row["profile_id"],
+            "authority_id": row["authority_id"],
+            "executor_id": row["executor_id"],
+            "outcome": outcome,
+            "subject_digest": row["subject_digest"],
+            "evidence_digest": row["evidence_digest"],
+            "result_digest": row["result_digest"],
+            "terminal_at": row["terminal_at"],
+            "decision_id": row["decision_id"],
+            "recovery_ref": row["recovery_ref"],
+            "reconciliation_ref": row["reconciliation_ref"],
+            "revision": int(row["revision"]),
+        }
+
+    def _event_from_row(self, row: sqlite3.Row) -> dict[str, Any]:
+        self._assert_row_authority(row, require_executor=False)
+        event_type = str(row["event_type"])
+        if event_type not in EVENT_TYPES:
+            raise ContractDataError("event row contains an unknown type")
+        _parse_timestamp(row["occurred_at"], field="occurred_at")
+        return {
+            "contract_version": CONTRACT_VERSION,
+            "sequence": int(row["sequence"]),
+            "event_id": row["event_id"],
+            "execution_id": row["execution_id"],
+            "profile_id": row["profile_id"],
+            "authority_id": row["authority_id"],
+            "event_type": event_type,
+            "from_lifecycle": row["from_lifecycle"],
+            "to_lifecycle": row["to_lifecycle"],
+            "decision_id": row["decision_id"],
+            "receipt_id": row["receipt_id"],
+            "reason_code": row["reason_code"],
+            "occurred_at": row["occurred_at"],
+            "revision": int(row["revision"]),
+        }
+
+    def _evidence_from_row(self, row: sqlite3.Row) -> dict[str, Any]:
+        self._assert_row_authority(row, require_executor=True)
+        return {
+            "evidence_id": row["evidence_id"],
+            "execution_id": row["execution_id"],
+            "effect_id": row["effect_id"],
+            "outcome": row["outcome"],
+            "subject_digest": row["subject_digest"],
+            "evidence_digest": row["evidence_digest"],
+            "result_digest": row["result_digest"],
+            "decision_id": row["decision_id"],
+            "recovery_ref": row["recovery_ref"],
+            "reconciliation_ref": row["reconciliation_ref"],
+            "recorded_at": row["recorded_at"],
+        }
+
+    def _rows_page(
+        self,
+        rows: list[sqlite3.Row],
+        *,
+        after: int,
+        limit: int,
+        table: str,
+        decoder,
+        connection: sqlite3.Connection,
+    ) -> dict[str, Any]:
+        visible = rows[:limit]
+        high_water = int(
+            connection.execute(f"SELECT COALESCE(MAX(ordinal), 0) FROM {table}").fetchone()[0]
+        )
+        if after > high_water:
+            raise ContractConflictError(f"{table} cursor is ahead of high-water")
+        has_more = len(rows) > limit
+        cursor = (
+            int(visible[-1]["ordinal"])
+            if has_more and visible
+            else high_water
+        )
+        return self._collection_page(
+            [decoder(row) for row in visible],
+            cursor,
+            high_water,
+            1 if high_water else 0,
+            has_more,
+        )
+
+    @staticmethod
+    def _collection_page(
+        items: list[dict[str, Any]],
+        cursor: int,
+        high_water: int,
+        minimum_available: int,
+        has_more: bool,
+    ) -> dict[str, Any]:
+        return {
+            "items": items,
+            "page": {
+                "cursor": cursor,
+                "high_water": high_water,
+                "minimum_available": minimum_available,
+                "has_more": has_more,
+                "completeness": "complete",
+            },
+        }
+
+    @staticmethod
+    def _event_page(
+        events: list[dict[str, Any]],
+        cursor: int,
+        high_water: int,
+        minimum_available: int,
+        has_more: bool,
+        pruned_through: int,
+    ) -> dict[str, Any]:
+        return {
+            "items": events,
+            "page": {
+                "cursor": cursor,
+                "high_water": high_water,
+                "minimum_available": minimum_available,
+                "has_more": has_more,
+                "completeness": "complete",
+                "pruned_through": pruned_through,
+                "retention_seconds": EVENT_RETENTION_SECONDS,
+            },
+        }
+
+
+def contract_capabilities(profile_name: str) -> dict[str, Any]:
+    authority = authority_identity(profile_name)
+    return {
+        "contract_version": CONTRACT_VERSION,
+        "api_version": API_VERSION,
+        "authority": authority.public(),
+        "read_scope": "execution:read",
+        "mutation_scopes": [
+            "execution:start",
+            "decision:resolve",
+            "execution:steer",
+            "execution:stop",
+        ],
+        "event_retention_seconds": EVENT_RETENTION_SECONDS,
+        "max_page_size": MAX_PAGE_SIZE,
+        "features": {
+            "durable_executions": True,
+            "durable_pending_decisions": True,
+            "ordered_restart_safe_events": True,
+            "evidence_gated_terminal_receipts": True,
+            "transactional_event_outbox": True,
+            "profile_scoped_authority": True,
+            "webauthn_decisions": False,
+            "action_dispatch": False,
+        },
+    }
+
+
+def contract_schema() -> dict[str, Any]:
+    """Load the packaged closed JSON Schema for capability negotiation."""
+
+    resource = importlib.resources.files("hermes_cli.execution_contract_schemas").joinpath(
+        "hermes.execution.read.v1.schema.json"
+    )
+    with resource.open("r", encoding="utf-8") as handle:
+        value = json.load(handle)
+    if not isinstance(value, dict):
+        raise ContractDataError("packaged execution contract schema is malformed")
+    return value

--- a/hermes_cli/execution_contract_schemas/__init__.py
+++ b/hermes_cli/execution_contract_schemas/__init__.py
@@ -1,0 +1,1 @@
+"""Packaged JSON Schemas for the Hermes execution read contract."""

--- a/hermes_cli/execution_contract_schemas/hermes.execution.read.v1.schema.json
+++ b/hermes_cli/execution_contract_schemas/hermes.execution.read.v1.schema.json
@@ -1,0 +1,378 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://hermes-agent.nousresearch.com/contracts/hermes.execution.read.v1.schema.json",
+  "title": "Hermes Execution Read Contract v1",
+  "description": "Closed public schemas for profile-scoped executions, decisions, ordered events, and evidence-backed terminal receipts.",
+  "$defs": {
+    "nullableString": {
+      "type": ["string", "null"]
+    },
+    "digest": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "nullableDigest": {
+      "type": ["string", "null"],
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "timestamp": {
+      "type": "string",
+      "format": "date-time",
+      "pattern": "Z$"
+    },
+    "nullableTimestamp": {
+      "type": ["string", "null"],
+      "format": "date-time",
+      "pattern": "Z$"
+    },
+    "nullableDecisionId": {
+      "anyOf": [
+        {"type": "null"},
+        {"type": "string", "pattern": "^dec_[0-9a-f]{12}_[0-9a-f]{32}$"}
+      ]
+    },
+    "nullableReceiptId": {
+      "anyOf": [
+        {"type": "null"},
+        {"type": "string", "pattern": "^rcp_[0-9a-f]{12}_[0-9a-f]{32}$"}
+      ]
+    },
+    "authority": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["profile_id", "profile_name", "authority_id", "executor_id"],
+      "properties": {
+        "profile_id": {"type": "string", "minLength": 1},
+        "profile_name": {"type": "string", "minLength": 1},
+        "authority_id": {"type": "string", "minLength": 1},
+        "executor_id": {"type": "string", "minLength": 1}
+      }
+    },
+    "page": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["cursor", "high_water", "minimum_available", "has_more", "completeness"],
+      "properties": {
+        "cursor": {"type": "integer", "minimum": 0},
+        "high_water": {"type": "integer", "minimum": 0},
+        "minimum_available": {"type": "integer", "minimum": 0},
+        "has_more": {"type": "boolean"},
+        "completeness": {"const": "complete"}
+      }
+    },
+    "eventPage": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["cursor", "high_water", "minimum_available", "has_more", "completeness", "pruned_through", "retention_seconds"],
+      "properties": {
+        "cursor": {"type": "integer", "minimum": 0},
+        "high_water": {"type": "integer", "minimum": 0},
+        "minimum_available": {"type": "integer", "minimum": 0},
+        "has_more": {"type": "boolean"},
+        "completeness": {"const": "complete"},
+        "pruned_through": {"type": "integer", "minimum": 0},
+        "retention_seconds": {"type": "integer", "minimum": 1}
+      }
+    },
+    "execution": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "contract_version", "execution_id", "profile_id", "authority_id",
+        "executor_id", "source_run_id", "work_ref", "proposal_ref", "effect_id",
+        "lifecycle", "freshness", "receipt_state", "receipt_id", "created_at",
+        "started_at", "updated_at", "terminal_at", "recovery_ref", "revision"
+      ],
+      "properties": {
+        "contract_version": {"const": "hermes.execution.read.v1"},
+        "execution_id": {"type": "string", "pattern": "^exe_[0-9a-f]{12}_[0-9a-f]{32}$"},
+        "profile_id": {"type": "string", "minLength": 1},
+        "authority_id": {"type": "string", "minLength": 1},
+        "executor_id": {"type": "string", "minLength": 1},
+        "source_run_id": {"$ref": "#/$defs/nullableString"},
+        "work_ref": {"$ref": "#/$defs/nullableString"},
+        "proposal_ref": {"$ref": "#/$defs/nullableString"},
+        "effect_id": {"$ref": "#/$defs/nullableString"},
+        "lifecycle": {
+          "enum": [
+            "accepted", "queued", "running", "awaiting_decision",
+            "cancellation_requested", "terminal_succeeded", "terminal_failed",
+            "terminal_cancelled", "terminal_partial", "terminal_ambiguous"
+          ]
+        },
+        "freshness": {"enum": ["live", "stale", "terminal"]},
+        "receipt_state": {"enum": ["not_applicable", "pending_evidence", "unproven", "published"]},
+        "receipt_id": {"$ref": "#/$defs/nullableReceiptId"},
+        "created_at": {"$ref": "#/$defs/timestamp"},
+        "started_at": {"$ref": "#/$defs/nullableTimestamp"},
+        "updated_at": {"$ref": "#/$defs/timestamp"},
+        "terminal_at": {"$ref": "#/$defs/nullableTimestamp"},
+        "recovery_ref": {"$ref": "#/$defs/nullableString"},
+        "revision": {"type": "integer", "minimum": 1}
+      }
+    },
+    "decision": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "contract_version", "decision_id", "execution_id", "profile_id",
+        "authority_id", "effect_id", "proposal_ref", "request_digest",
+        "candidate_digest", "policy_digest", "allowed_choices", "expires_at",
+        "state", "choice", "resolution_evidence_digest", "created_at", "updated_at",
+        "resolved_at", "revision"
+      ],
+      "properties": {
+        "contract_version": {"const": "hermes.execution.read.v1"},
+        "decision_id": {"type": "string", "pattern": "^dec_[0-9a-f]{12}_[0-9a-f]{32}$"},
+        "execution_id": {"type": "string", "pattern": "^exe_[0-9a-f]{12}_[0-9a-f]{32}$"},
+        "profile_id": {"type": "string", "minLength": 1},
+        "authority_id": {"type": "string", "minLength": 1},
+        "effect_id": {"type": "string", "minLength": 1},
+        "proposal_ref": {"type": "string", "minLength": 1},
+        "request_digest": {"$ref": "#/$defs/digest"},
+        "candidate_digest": {"$ref": "#/$defs/nullableDigest"},
+        "policy_digest": {"$ref": "#/$defs/nullableDigest"},
+        "allowed_choices": {
+          "type": "array",
+          "minItems": 1,
+          "maxItems": 32,
+          "uniqueItems": true,
+          "items": {"type": "string", "minLength": 1, "maxLength": 64}
+        },
+        "expires_at": {"$ref": "#/$defs/timestamp"},
+        "state": {"enum": ["pending", "resolved", "expired", "superseded"]},
+        "choice": {"$ref": "#/$defs/nullableString"},
+        "resolution_evidence_digest": {"$ref": "#/$defs/nullableDigest"},
+        "created_at": {"$ref": "#/$defs/timestamp"},
+        "updated_at": {"$ref": "#/$defs/timestamp"},
+        "resolved_at": {"$ref": "#/$defs/nullableTimestamp"},
+        "revision": {"type": "integer", "minimum": 1}
+      }
+    },
+    "receipt": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "contract_version", "receipt_id", "execution_id", "effect_id", "profile_id",
+        "authority_id", "executor_id", "outcome", "subject_digest", "evidence_digest",
+        "result_digest", "terminal_at", "decision_id", "recovery_ref",
+        "reconciliation_ref", "revision"
+      ],
+      "properties": {
+        "contract_version": {"const": "hermes.execution.read.v1"},
+        "receipt_id": {"type": "string", "pattern": "^rcp_[0-9a-f]{12}_[0-9a-f]{32}$"},
+        "execution_id": {"type": "string", "pattern": "^exe_[0-9a-f]{12}_[0-9a-f]{32}$"},
+        "effect_id": {"type": "string", "minLength": 1},
+        "profile_id": {"type": "string", "minLength": 1},
+        "authority_id": {"type": "string", "minLength": 1},
+        "executor_id": {"type": "string", "minLength": 1},
+        "outcome": {"enum": ["succeeded", "failed", "cancelled", "partial", "ambiguous"]},
+        "subject_digest": {"$ref": "#/$defs/digest"},
+        "evidence_digest": {"$ref": "#/$defs/digest"},
+        "result_digest": {"$ref": "#/$defs/digest"},
+        "terminal_at": {"$ref": "#/$defs/timestamp"},
+        "decision_id": {"$ref": "#/$defs/nullableDecisionId"},
+        "recovery_ref": {"$ref": "#/$defs/nullableString"},
+        "reconciliation_ref": {"$ref": "#/$defs/nullableString"},
+        "revision": {"const": 1}
+      }
+    },
+    "event": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "contract_version", "sequence", "event_id", "execution_id", "profile_id",
+        "authority_id", "event_type", "from_lifecycle", "to_lifecycle", "decision_id",
+        "receipt_id", "reason_code", "occurred_at", "revision"
+      ],
+      "properties": {
+        "contract_version": {"const": "hermes.execution.read.v1"},
+        "sequence": {"type": "integer", "minimum": 1},
+        "event_id": {"type": "string", "pattern": "^evt_[0-9a-f]{12}_[0-9a-f]{32}$"},
+        "execution_id": {"type": "string", "pattern": "^exe_[0-9a-f]{12}_[0-9a-f]{32}$"},
+        "profile_id": {"type": "string", "minLength": 1},
+        "authority_id": {"type": "string", "minLength": 1},
+        "event_type": {
+          "enum": [
+            "execution.created", "execution.transitioned", "execution.recovered",
+            "decision.requested", "decision.resolved", "decision.expired",
+            "decision.superseded", "effect.evidence_recorded", "receipt.published"
+          ]
+        },
+        "from_lifecycle": {"$ref": "#/$defs/nullableString"},
+        "to_lifecycle": {"$ref": "#/$defs/nullableString"},
+        "decision_id": {"$ref": "#/$defs/nullableDecisionId"},
+        "receipt_id": {"$ref": "#/$defs/nullableReceiptId"},
+        "reason_code": {"$ref": "#/$defs/nullableString"},
+        "occurred_at": {"$ref": "#/$defs/timestamp"},
+        "revision": {"type": "integer", "minimum": 1}
+      }
+    },
+    "capabilities": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "contract_version", "api_version", "authority", "read_scope",
+        "mutation_scopes", "event_retention_seconds", "max_page_size", "features"
+      ],
+      "properties": {
+        "contract_version": {"const": "hermes.execution.read.v1"},
+        "api_version": {"const": "v1"},
+        "authority": {"$ref": "#/$defs/authority"},
+        "read_scope": {"const": "execution:read"},
+        "mutation_scopes": {
+          "type": "array",
+          "minItems": 4,
+          "maxItems": 4,
+          "items": {
+            "enum": [
+              "execution:start",
+              "decision:resolve",
+              "execution:steer",
+              "execution:stop"
+            ]
+          },
+          "uniqueItems": true
+        },
+        "event_retention_seconds": {"type": "integer", "minimum": 1},
+        "max_page_size": {"type": "integer", "minimum": 1},
+        "features": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "durable_executions", "durable_pending_decisions",
+            "ordered_restart_safe_events", "evidence_gated_terminal_receipts",
+            "transactional_event_outbox", "profile_scoped_authority",
+            "webauthn_decisions", "action_dispatch"
+          ],
+          "properties": {
+            "durable_executions": {"const": true},
+            "durable_pending_decisions": {"const": true},
+            "ordered_restart_safe_events": {"const": true},
+            "evidence_gated_terminal_receipts": {"const": true},
+            "transactional_event_outbox": {"const": true},
+            "profile_scoped_authority": {"const": true},
+            "webauthn_decisions": {"const": false},
+            "action_dispatch": {"const": false}
+          }
+        }
+      }
+    },
+    "executionList": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["contract_version", "authority", "executions", "page"],
+      "properties": {
+        "contract_version": {"const": "hermes.execution.read.v1"},
+        "authority": {"$ref": "#/$defs/authority"},
+        "executions": {"type": "array", "items": {"$ref": "#/$defs/execution"}},
+        "page": {"$ref": "#/$defs/page"}
+      }
+    },
+    "decisionList": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["contract_version", "authority", "decisions", "page"],
+      "properties": {
+        "contract_version": {"const": "hermes.execution.read.v1"},
+        "authority": {"$ref": "#/$defs/authority"},
+        "decisions": {"type": "array", "items": {"$ref": "#/$defs/decision"}},
+        "page": {"$ref": "#/$defs/page"}
+      }
+    },
+    "receiptList": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["contract_version", "authority", "receipts", "page"],
+      "properties": {
+        "contract_version": {"const": "hermes.execution.read.v1"},
+        "authority": {"$ref": "#/$defs/authority"},
+        "receipts": {"type": "array", "items": {"$ref": "#/$defs/receipt"}},
+        "page": {"$ref": "#/$defs/page"}
+      }
+    },
+    "eventList": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["contract_version", "authority", "events", "page"],
+      "properties": {
+        "contract_version": {"const": "hermes.execution.read.v1"},
+        "authority": {"$ref": "#/$defs/authority"},
+        "events": {"type": "array", "items": {"$ref": "#/$defs/event"}},
+        "page": {"$ref": "#/$defs/eventPage"}
+      }
+    },
+    "executionDetail": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["contract_version", "authority", "execution"],
+      "properties": {
+        "contract_version": {"const": "hermes.execution.read.v1"},
+        "authority": {"$ref": "#/$defs/authority"},
+        "execution": {"$ref": "#/$defs/execution"}
+      }
+    },
+    "decisionDetail": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["contract_version", "authority", "decision"],
+      "properties": {
+        "contract_version": {"const": "hermes.execution.read.v1"},
+        "authority": {"$ref": "#/$defs/authority"},
+        "decision": {"$ref": "#/$defs/decision"}
+      }
+    },
+    "receiptDetail": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["contract_version", "authority", "receipt"],
+      "properties": {
+        "contract_version": {"const": "hermes.execution.read.v1"},
+        "authority": {"$ref": "#/$defs/authority"},
+        "receipt": {"$ref": "#/$defs/receipt"}
+      }
+    },
+    "errorDetail": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["error"],
+      "properties": {
+        "error": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["message", "type", "code"],
+          "properties": {
+            "message": {"type": "string", "minLength": 1},
+            "type": {"const": "execution_contract_error"},
+            "code": {
+              "enum": [
+                "execution_contract_invalid_request",
+                "execution_contract_profile_forbidden",
+                "execution_contract_not_found",
+                "execution_contract_conflict",
+                "execution_contract_cursor_gone",
+                "execution_contract_rate_limited",
+                "execution_contract_unavailable",
+                "execution_contract_corrupt",
+                "execution_contract_internal_error"
+              ]
+            },
+            "minimum_available": {"type": "integer", "minimum": 1},
+            "high_water": {"type": "integer", "minimum": 0}
+          }
+        }
+      }
+    }
+  },
+  "oneOf": [
+    {"$ref": "#/$defs/capabilities"},
+    {"$ref": "#/$defs/executionList"},
+    {"$ref": "#/$defs/decisionList"},
+    {"$ref": "#/$defs/receiptList"},
+    {"$ref": "#/$defs/eventList"},
+    {"$ref": "#/$defs/executionDetail"},
+    {"$ref": "#/$defs/decisionDetail"},
+    {"$ref": "#/$defs/receiptDetail"},
+    {"$ref": "#/$defs/errorDetail"}
+  ]
+}

--- a/hermes_cli/execution_contract_schemas/hermes.execution.read.v1.schema.json
+++ b/hermes_cli/execution_contract_schemas/hermes.execution.read.v1.schema.json
@@ -364,6 +364,7 @@
                 "execution_contract_invalid_request",
                 "execution_contract_profile_forbidden",
                 "execution_contract_not_found",
+                "execution_contract_method_not_allowed",
                 "execution_contract_conflict",
                 "execution_contract_cursor_gone",
                 "execution_contract_rate_limited",

--- a/hermes_cli/execution_contract_schemas/hermes.execution.read.v1.schema.json
+++ b/hermes_cli/execution_contract_schemas/hermes.execution.read.v1.schema.json
@@ -37,24 +37,37 @@
         {"type": "string", "pattern": "^rcp_[0-9a-f]{12}_[0-9a-f]{32}$"}
       ]
     },
+    "profileId": {
+      "type": "string",
+      "pattern": "^hermes-profile-instance:[0-9a-f]{24}$"
+    },
+    "authorityId": {
+      "type": "string",
+      "pattern": "^hermes-execution-authority:[0-9a-f]{24}$"
+    },
+    "executorId": {
+      "type": "string",
+      "pattern": "^hermes-agent-executor:[0-9a-f]{24}$"
+    },
     "authority": {
       "type": "object",
       "additionalProperties": false,
       "required": ["profile_id", "profile_name", "authority_id", "executor_id"],
       "properties": {
-        "profile_id": {"type": "string", "minLength": 1},
+        "profile_id": {"$ref": "#/$defs/profileId"},
         "profile_name": {"type": "string", "minLength": 1},
-        "authority_id": {"type": "string", "minLength": 1},
-        "executor_id": {"type": "string", "minLength": 1}
+        "authority_id": {"$ref": "#/$defs/authorityId"},
+        "executor_id": {"$ref": "#/$defs/executorId"}
       }
     },
     "page": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["cursor", "high_water", "minimum_available", "has_more", "completeness"],
+      "required": ["cursor", "high_water", "snapshot_high_water", "minimum_available", "has_more", "completeness"],
       "properties": {
         "cursor": {"type": "integer", "minimum": 0},
         "high_water": {"type": "integer", "minimum": 0},
+        "snapshot_high_water": {"type": "integer", "minimum": 0},
         "minimum_available": {"type": "integer", "minimum": 0},
         "has_more": {"type": "boolean"},
         "completeness": {"const": "complete"}
@@ -63,10 +76,11 @@
     "eventPage": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["cursor", "high_water", "minimum_available", "has_more", "completeness", "pruned_through", "retention_seconds"],
+      "required": ["cursor", "high_water", "snapshot_high_water", "minimum_available", "has_more", "completeness", "pruned_through", "retention_seconds"],
       "properties": {
         "cursor": {"type": "integer", "minimum": 0},
         "high_water": {"type": "integer", "minimum": 0},
+        "snapshot_high_water": {"type": "integer", "minimum": 0},
         "minimum_available": {"type": "integer", "minimum": 0},
         "has_more": {"type": "boolean"},
         "completeness": {"const": "complete"},
@@ -86,9 +100,9 @@
       "properties": {
         "contract_version": {"const": "hermes.execution.read.v1"},
         "execution_id": {"type": "string", "pattern": "^exe_[0-9a-f]{12}_[0-9a-f]{32}$"},
-        "profile_id": {"type": "string", "minLength": 1},
-        "authority_id": {"type": "string", "minLength": 1},
-        "executor_id": {"type": "string", "minLength": 1},
+        "profile_id": {"$ref": "#/$defs/profileId"},
+        "authority_id": {"$ref": "#/$defs/authorityId"},
+        "executor_id": {"$ref": "#/$defs/executorId"},
         "source_run_id": {"$ref": "#/$defs/nullableString"},
         "work_ref": {"$ref": "#/$defs/nullableString"},
         "proposal_ref": {"$ref": "#/$defs/nullableString"},
@@ -125,8 +139,8 @@
         "contract_version": {"const": "hermes.execution.read.v1"},
         "decision_id": {"type": "string", "pattern": "^dec_[0-9a-f]{12}_[0-9a-f]{32}$"},
         "execution_id": {"type": "string", "pattern": "^exe_[0-9a-f]{12}_[0-9a-f]{32}$"},
-        "profile_id": {"type": "string", "minLength": 1},
-        "authority_id": {"type": "string", "minLength": 1},
+        "profile_id": {"$ref": "#/$defs/profileId"},
+        "authority_id": {"$ref": "#/$defs/authorityId"},
         "effect_id": {"type": "string", "minLength": 1},
         "proposal_ref": {"type": "string", "minLength": 1},
         "request_digest": {"$ref": "#/$defs/digest"},
@@ -163,9 +177,9 @@
         "receipt_id": {"type": "string", "pattern": "^rcp_[0-9a-f]{12}_[0-9a-f]{32}$"},
         "execution_id": {"type": "string", "pattern": "^exe_[0-9a-f]{12}_[0-9a-f]{32}$"},
         "effect_id": {"type": "string", "minLength": 1},
-        "profile_id": {"type": "string", "minLength": 1},
-        "authority_id": {"type": "string", "minLength": 1},
-        "executor_id": {"type": "string", "minLength": 1},
+        "profile_id": {"$ref": "#/$defs/profileId"},
+        "authority_id": {"$ref": "#/$defs/authorityId"},
+        "executor_id": {"$ref": "#/$defs/executorId"},
         "outcome": {"enum": ["succeeded", "failed", "cancelled", "partial", "ambiguous"]},
         "subject_digest": {"$ref": "#/$defs/digest"},
         "evidence_digest": {"$ref": "#/$defs/digest"},
@@ -190,8 +204,8 @@
         "sequence": {"type": "integer", "minimum": 1},
         "event_id": {"type": "string", "pattern": "^evt_[0-9a-f]{12}_[0-9a-f]{32}$"},
         "execution_id": {"type": "string", "pattern": "^exe_[0-9a-f]{12}_[0-9a-f]{32}$"},
-        "profile_id": {"type": "string", "minLength": 1},
-        "authority_id": {"type": "string", "minLength": 1},
+        "profile_id": {"$ref": "#/$defs/profileId"},
+        "authority_id": {"$ref": "#/$defs/authorityId"},
         "event_type": {
           "enum": [
             "execution.created", "execution.transitioned", "execution.recovered",
@@ -346,6 +360,7 @@
             "type": {"const": "execution_contract_error"},
             "code": {
               "enum": [
+                "execution_contract_unauthorized",
                 "execution_contract_invalid_request",
                 "execution_contract_profile_forbidden",
                 "execution_contract_not_found",

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -8221,6 +8221,7 @@ _PLATFORM_OVERRIDES: dict[str, dict[str, Any]] = {
         "env_vars": (
             "API_SERVER_ENABLED",
             "API_SERVER_KEY",
+            "API_SERVER_READ_KEY",
             "API_SERVER_PORT",
             "API_SERVER_HOST",
             "API_SERVER_MODEL_NAME",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -437,7 +437,11 @@ py-modules = [
 include = ["agent", "agent.*", "tools", "tools.*", "hermes_cli", "hermes_cli.*", "gateway", "gateway.*", "tui_gateway", "tui_gateway.*", "cron", "cron.*", "acp_adapter", "plugins", "plugins.*", "providers", "providers.*"]
 
 [tool.setuptools.package-data]
-hermes_cli = ["observability/schemas/*.json", "data/*.json"]
+hermes_cli = [
+  "observability/schemas/*.json",
+  "execution_contract_schemas/*.json",
+  "data/*.json",
+]
 # gateway/assets/ ships status_phrases.yaml and the Telegram BotFather
 # screenshot. Without this, sealed venvs (uv2nix) silently lose both —
 # status phrases fall back to the tiny hardcoded set and the Telegram

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -224,6 +224,7 @@ _CREDENTIAL_NAMES = frozenset({
     "SUDO_PASSWORD",
     "GATEWAY_PROXY_KEY",
     "API_SERVER_KEY",
+    "API_SERVER_READ_KEY",
     "TOOL_GATEWAY_USER_TOKEN",
     "TELEGRAM_WEBHOOK_SECRET",
     "WEBHOOK_SECRET",
@@ -414,6 +415,7 @@ _HERMES_BEHAVIORAL_VARS = frozenset({
     "API_SERVER_HOST",
     "API_SERVER_PORT",
     "API_SERVER_KEY",
+    "API_SERVER_READ_KEY",
     "API_SERVER_CORS_ORIGINS",
     "API_SERVER_MODEL_NAME",
     # Platform gating — set by load_gateway_config() as a side effect when

--- a/tests/fixtures/execution_contract/capabilities.json
+++ b/tests/fixtures/execution_contract/capabilities.json
@@ -2,10 +2,10 @@
   "contract_version": "hermes.execution.read.v1",
   "api_version": "v1",
   "authority": {
-    "profile_id": "hermes-profile:synthetic",
+    "profile_id": "hermes-profile-instance:0123456789ab0123456789ab",
     "profile_name": "synthetic",
-    "authority_id": "hermes-execution-authority:synthetic",
-    "executor_id": "hermes-agent:synthetic"
+    "authority_id": "hermes-execution-authority:0123456789ab0123456789ab",
+    "executor_id": "hermes-agent-executor:0123456789ab0123456789ab"
   },
   "read_scope": "execution:read",
   "mutation_scopes": [

--- a/tests/fixtures/execution_contract/capabilities.json
+++ b/tests/fixtures/execution_contract/capabilities.json
@@ -1,0 +1,29 @@
+{
+  "contract_version": "hermes.execution.read.v1",
+  "api_version": "v1",
+  "authority": {
+    "profile_id": "hermes-profile:synthetic",
+    "profile_name": "synthetic",
+    "authority_id": "hermes-execution-authority:synthetic",
+    "executor_id": "hermes-agent:synthetic"
+  },
+  "read_scope": "execution:read",
+  "mutation_scopes": [
+    "execution:start",
+    "decision:resolve",
+    "execution:steer",
+    "execution:stop"
+  ],
+  "event_retention_seconds": 2592000,
+  "max_page_size": 200,
+  "features": {
+    "durable_executions": true,
+    "durable_pending_decisions": true,
+    "ordered_restart_safe_events": true,
+    "evidence_gated_terminal_receipts": true,
+    "transactional_event_outbox": true,
+    "profile_scoped_authority": true,
+    "webauthn_decisions": false,
+    "action_dispatch": false
+  }
+}

--- a/tests/fixtures/execution_contract/decision-list.json
+++ b/tests/fixtures/execution_contract/decision-list.json
@@ -1,18 +1,18 @@
 {
   "contract_version": "hermes.execution.read.v1",
   "authority": {
-    "profile_id": "hermes-profile:synthetic",
+    "profile_id": "hermes-profile-instance:0123456789ab0123456789ab",
     "profile_name": "synthetic",
-    "authority_id": "hermes-execution-authority:synthetic",
-    "executor_id": "hermes-agent:synthetic"
+    "authority_id": "hermes-execution-authority:0123456789ab0123456789ab",
+    "executor_id": "hermes-agent-executor:0123456789ab0123456789ab"
   },
   "decisions": [
     {
       "contract_version": "hermes.execution.read.v1",
       "decision_id": "dec_0123456789ab_00000000000000000000000000000002",
       "execution_id": "exe_0123456789ab_00000000000000000000000000000001",
-      "profile_id": "hermes-profile:synthetic",
-      "authority_id": "hermes-execution-authority:synthetic",
+      "profile_id": "hermes-profile-instance:0123456789ab0123456789ab",
+      "authority_id": "hermes-execution-authority:0123456789ab0123456789ab",
       "effect_id": "effect:synthetic-1",
       "proposal_ref": "proposal:synthetic-1",
       "request_digest": "1111111111111111111111111111111111111111111111111111111111111111",
@@ -32,6 +32,7 @@
   "page": {
     "cursor": 1,
     "high_water": 1,
+    "snapshot_high_water": 1,
     "minimum_available": 1,
     "has_more": false,
     "completeness": "complete"

--- a/tests/fixtures/execution_contract/decision-list.json
+++ b/tests/fixtures/execution_contract/decision-list.json
@@ -1,0 +1,39 @@
+{
+  "contract_version": "hermes.execution.read.v1",
+  "authority": {
+    "profile_id": "hermes-profile:synthetic",
+    "profile_name": "synthetic",
+    "authority_id": "hermes-execution-authority:synthetic",
+    "executor_id": "hermes-agent:synthetic"
+  },
+  "decisions": [
+    {
+      "contract_version": "hermes.execution.read.v1",
+      "decision_id": "dec_0123456789ab_00000000000000000000000000000002",
+      "execution_id": "exe_0123456789ab_00000000000000000000000000000001",
+      "profile_id": "hermes-profile:synthetic",
+      "authority_id": "hermes-execution-authority:synthetic",
+      "effect_id": "effect:synthetic-1",
+      "proposal_ref": "proposal:synthetic-1",
+      "request_digest": "1111111111111111111111111111111111111111111111111111111111111111",
+      "candidate_digest": "2222222222222222222222222222222222222222222222222222222222222222",
+      "policy_digest": null,
+      "allowed_choices": ["once", "deny"],
+      "expires_at": "2026-08-15T12:05:00.000000Z",
+      "state": "pending",
+      "choice": null,
+      "resolution_evidence_digest": null,
+      "created_at": "2026-08-15T12:01:00.000000Z",
+      "updated_at": "2026-08-15T12:01:00.000000Z",
+      "resolved_at": null,
+      "revision": 1
+    }
+  ],
+  "page": {
+    "cursor": 1,
+    "high_water": 1,
+    "minimum_available": 1,
+    "has_more": false,
+    "completeness": "complete"
+  }
+}

--- a/tests/fixtures/execution_contract/event-list.json
+++ b/tests/fixtures/execution_contract/event-list.json
@@ -1,0 +1,36 @@
+{
+  "contract_version": "hermes.execution.read.v1",
+  "authority": {
+    "profile_id": "hermes-profile:synthetic",
+    "profile_name": "synthetic",
+    "authority_id": "hermes-execution-authority:synthetic",
+    "executor_id": "hermes-agent:synthetic"
+  },
+  "events": [
+    {
+      "contract_version": "hermes.execution.read.v1",
+      "sequence": 2,
+      "event_id": "evt_0123456789ab_00000000000000000000000000000003",
+      "execution_id": "exe_0123456789ab_00000000000000000000000000000001",
+      "profile_id": "hermes-profile:synthetic",
+      "authority_id": "hermes-execution-authority:synthetic",
+      "event_type": "decision.requested",
+      "from_lifecycle": "running",
+      "to_lifecycle": "awaiting_decision",
+      "decision_id": "dec_0123456789ab_00000000000000000000000000000002",
+      "receipt_id": null,
+      "reason_code": null,
+      "occurred_at": "2026-08-15T12:01:00.000000Z",
+      "revision": 3
+    }
+  ],
+  "page": {
+    "cursor": 2,
+    "high_water": 2,
+    "minimum_available": 1,
+    "has_more": false,
+    "completeness": "complete",
+    "pruned_through": 0,
+    "retention_seconds": 2592000
+  }
+}

--- a/tests/fixtures/execution_contract/event-list.json
+++ b/tests/fixtures/execution_contract/event-list.json
@@ -1,10 +1,10 @@
 {
   "contract_version": "hermes.execution.read.v1",
   "authority": {
-    "profile_id": "hermes-profile:synthetic",
+    "profile_id": "hermes-profile-instance:0123456789ab0123456789ab",
     "profile_name": "synthetic",
-    "authority_id": "hermes-execution-authority:synthetic",
-    "executor_id": "hermes-agent:synthetic"
+    "authority_id": "hermes-execution-authority:0123456789ab0123456789ab",
+    "executor_id": "hermes-agent-executor:0123456789ab0123456789ab"
   },
   "events": [
     {
@@ -12,8 +12,8 @@
       "sequence": 2,
       "event_id": "evt_0123456789ab_00000000000000000000000000000003",
       "execution_id": "exe_0123456789ab_00000000000000000000000000000001",
-      "profile_id": "hermes-profile:synthetic",
-      "authority_id": "hermes-execution-authority:synthetic",
+      "profile_id": "hermes-profile-instance:0123456789ab0123456789ab",
+      "authority_id": "hermes-execution-authority:0123456789ab0123456789ab",
       "event_type": "decision.requested",
       "from_lifecycle": "running",
       "to_lifecycle": "awaiting_decision",
@@ -27,6 +27,7 @@
   "page": {
     "cursor": 2,
     "high_water": 2,
+    "snapshot_high_water": 2,
     "minimum_available": 1,
     "has_more": false,
     "completeness": "complete",

--- a/tests/fixtures/execution_contract/execution-list.json
+++ b/tests/fixtures/execution_contract/execution-list.json
@@ -1,0 +1,39 @@
+{
+  "contract_version": "hermes.execution.read.v1",
+  "authority": {
+    "profile_id": "hermes-profile:synthetic",
+    "profile_name": "synthetic",
+    "authority_id": "hermes-execution-authority:synthetic",
+    "executor_id": "hermes-agent:synthetic"
+  },
+  "executions": [
+    {
+      "contract_version": "hermes.execution.read.v1",
+      "execution_id": "exe_0123456789ab_00000000000000000000000000000001",
+      "profile_id": "hermes-profile:synthetic",
+      "authority_id": "hermes-execution-authority:synthetic",
+      "executor_id": "hermes-agent:synthetic",
+      "source_run_id": "run-synthetic-1",
+      "work_ref": "work:synthetic-1",
+      "proposal_ref": "proposal:synthetic-1",
+      "effect_id": "effect:synthetic-1",
+      "lifecycle": "running",
+      "freshness": "live",
+      "receipt_state": "pending_evidence",
+      "receipt_id": null,
+      "created_at": "2026-08-15T12:00:00.000000Z",
+      "started_at": "2026-08-15T12:00:01.000000Z",
+      "updated_at": "2026-08-15T12:00:01.000000Z",
+      "terminal_at": null,
+      "recovery_ref": null,
+      "revision": 2
+    }
+  ],
+  "page": {
+    "cursor": 1,
+    "high_water": 1,
+    "minimum_available": 1,
+    "has_more": false,
+    "completeness": "complete"
+  }
+}

--- a/tests/fixtures/execution_contract/execution-list.json
+++ b/tests/fixtures/execution_contract/execution-list.json
@@ -1,18 +1,18 @@
 {
   "contract_version": "hermes.execution.read.v1",
   "authority": {
-    "profile_id": "hermes-profile:synthetic",
+    "profile_id": "hermes-profile-instance:0123456789ab0123456789ab",
     "profile_name": "synthetic",
-    "authority_id": "hermes-execution-authority:synthetic",
-    "executor_id": "hermes-agent:synthetic"
+    "authority_id": "hermes-execution-authority:0123456789ab0123456789ab",
+    "executor_id": "hermes-agent-executor:0123456789ab0123456789ab"
   },
   "executions": [
     {
       "contract_version": "hermes.execution.read.v1",
       "execution_id": "exe_0123456789ab_00000000000000000000000000000001",
-      "profile_id": "hermes-profile:synthetic",
-      "authority_id": "hermes-execution-authority:synthetic",
-      "executor_id": "hermes-agent:synthetic",
+      "profile_id": "hermes-profile-instance:0123456789ab0123456789ab",
+      "authority_id": "hermes-execution-authority:0123456789ab0123456789ab",
+      "executor_id": "hermes-agent-executor:0123456789ab0123456789ab",
       "source_run_id": "run-synthetic-1",
       "work_ref": "work:synthetic-1",
       "proposal_ref": "proposal:synthetic-1",
@@ -32,6 +32,7 @@
   "page": {
     "cursor": 1,
     "high_water": 1,
+    "snapshot_high_water": 1,
     "minimum_available": 1,
     "has_more": false,
     "completeness": "complete"

--- a/tests/fixtures/execution_contract/receipt-list.json
+++ b/tests/fixtures/execution_contract/receipt-list.json
@@ -1,10 +1,10 @@
 {
   "contract_version": "hermes.execution.read.v1",
   "authority": {
-    "profile_id": "hermes-profile:synthetic",
+    "profile_id": "hermes-profile-instance:0123456789ab0123456789ab",
     "profile_name": "synthetic",
-    "authority_id": "hermes-execution-authority:synthetic",
-    "executor_id": "hermes-agent:synthetic"
+    "authority_id": "hermes-execution-authority:0123456789ab0123456789ab",
+    "executor_id": "hermes-agent-executor:0123456789ab0123456789ab"
   },
   "receipts": [
     {
@@ -12,9 +12,9 @@
       "receipt_id": "rcp_0123456789ab_00000000000000000000000000000004",
       "execution_id": "exe_0123456789ab_00000000000000000000000000000001",
       "effect_id": "effect:synthetic-1",
-      "profile_id": "hermes-profile:synthetic",
-      "authority_id": "hermes-execution-authority:synthetic",
-      "executor_id": "hermes-agent:synthetic",
+      "profile_id": "hermes-profile-instance:0123456789ab0123456789ab",
+      "authority_id": "hermes-execution-authority:0123456789ab0123456789ab",
+      "executor_id": "hermes-agent-executor:0123456789ab0123456789ab",
       "outcome": "partial",
       "subject_digest": "3333333333333333333333333333333333333333333333333333333333333333",
       "evidence_digest": "4444444444444444444444444444444444444444444444444444444444444444",
@@ -29,6 +29,7 @@
   "page": {
     "cursor": 1,
     "high_water": 1,
+    "snapshot_high_water": 1,
     "minimum_available": 1,
     "has_more": false,
     "completeness": "complete"

--- a/tests/fixtures/execution_contract/receipt-list.json
+++ b/tests/fixtures/execution_contract/receipt-list.json
@@ -1,0 +1,36 @@
+{
+  "contract_version": "hermes.execution.read.v1",
+  "authority": {
+    "profile_id": "hermes-profile:synthetic",
+    "profile_name": "synthetic",
+    "authority_id": "hermes-execution-authority:synthetic",
+    "executor_id": "hermes-agent:synthetic"
+  },
+  "receipts": [
+    {
+      "contract_version": "hermes.execution.read.v1",
+      "receipt_id": "rcp_0123456789ab_00000000000000000000000000000004",
+      "execution_id": "exe_0123456789ab_00000000000000000000000000000001",
+      "effect_id": "effect:synthetic-1",
+      "profile_id": "hermes-profile:synthetic",
+      "authority_id": "hermes-execution-authority:synthetic",
+      "executor_id": "hermes-agent:synthetic",
+      "outcome": "partial",
+      "subject_digest": "3333333333333333333333333333333333333333333333333333333333333333",
+      "evidence_digest": "4444444444444444444444444444444444444444444444444444444444444444",
+      "result_digest": "5555555555555555555555555555555555555555555555555555555555555555",
+      "terminal_at": "2026-08-15T12:02:00.000000Z",
+      "decision_id": "dec_0123456789ab_00000000000000000000000000000002",
+      "recovery_ref": null,
+      "reconciliation_ref": "reconcile:synthetic-1",
+      "revision": 1
+    }
+  ],
+  "page": {
+    "cursor": 1,
+    "high_water": 1,
+    "minimum_available": 1,
+    "has_more": false,
+    "completeness": "complete"
+  }
+}

--- a/tests/gateway/test_api_server_execution_contract.py
+++ b/tests/gateway/test_api_server_execution_contract.py
@@ -1,0 +1,378 @@
+"""HTTP and authorization conformance for the execution read contract."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+
+from gateway.config import (
+    GatewayConfig,
+    Platform,
+    PlatformConfig,
+    _apply_env_overrides,
+)
+from gateway.platforms.api_server import APIServerAdapter, _api_request_profile
+from hermes_cli.execution_contract import (
+    CONTRACT_VERSION,
+    ContractDataError,
+    ContractRateLimitedError,
+    ContractUnavailableError,
+    canonical_digest,
+)
+
+
+FULL_KEY = "full-mutation-key-0123456789abcdef"
+READ_KEY = "execution-read-key-0123456789abcdef"
+NOW = datetime(2026, 8, 15, 12, 0, tzinfo=timezone.utc)
+
+
+def _auth(key: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {key}"}
+
+
+@pytest.fixture
+def contract_adapter(monkeypatch):
+    monkeypatch.delenv("API_SERVER_KEY", raising=False)
+    monkeypatch.delenv("API_SERVER_READ_KEY", raising=False)
+    adapter = APIServerAdapter(
+        PlatformConfig(
+            enabled=True,
+            extra={"key": FULL_KEY, "read_key": READ_KEY},
+        )
+    )
+    try:
+        yield adapter
+    finally:
+        adapter._response_store.close()
+
+
+def _contract_app(adapter: APIServerAdapter) -> web.Application:
+    app = web.Application()
+    wanted = {
+        ("GET", "/v1/capabilities"),
+        ("GET", "/v1/models"),
+        ("GET", "/v1/execution-contract/capabilities"),
+        ("GET", "/v1/execution-contract/schema"),
+        ("GET", "/v1/execution-contract/executions"),
+        ("GET", "/v1/execution-contract/executions/{execution_id}"),
+        ("GET", "/v1/execution-contract/decisions"),
+        ("GET", "/v1/execution-contract/decisions/{decision_id}"),
+        ("GET", "/v1/execution-contract/events"),
+        ("GET", "/v1/execution-contract/receipts"),
+        ("GET", "/v1/execution-contract/receipts/{receipt_id}"),
+        ("POST", "/v1/runs"),
+        ("POST", "/v1/runs/{run_id}/approval"),
+        ("POST", "/v1/runs/{run_id}/steer"),
+        ("POST", "/v1/runs/{run_id}/stop"),
+        ("POST", "/v1/responses"),
+    }
+    for method, path, handler in adapter._http_route_table():
+        if (method, path) in wanted:
+            app.router.add_route(method, path, handler)
+    return app
+
+
+@pytest.mark.asyncio
+async def test_read_key_is_side_effect_free_and_returns_asserted_authority(
+    contract_adapter,
+):
+    store = contract_adapter._execution_contract_store()
+    assert not store.database_path.exists()
+    app = _contract_app(contract_adapter)
+
+    async with TestClient(TestServer(app)) as client:
+        capabilities_response = await client.get(
+            "/v1/execution-contract/capabilities",
+            headers=_auth(READ_KEY),
+        )
+        assert capabilities_response.status == 200
+        capabilities = await capabilities_response.json()
+        assert capabilities["contract_version"] == CONTRACT_VERSION
+        assert capabilities["authority"] == {
+            "profile_id": "hermes-profile:default",
+            "profile_name": "default",
+            "authority_id": "hermes-execution-authority:default",
+            "executor_id": "hermes-agent:default",
+        }
+        assert capabilities["features"]["action_dispatch"] is False
+
+        list_response = await client.get(
+            "/v1/execution-contract/executions",
+            headers=_auth(READ_KEY),
+        )
+        assert list_response.status == 200
+        payload = await list_response.json()
+        assert payload["executions"] == []
+        assert payload["page"]["completeness"] == "complete"
+        assert list_response.headers["Hermes-Execution-Contract-Version"] == (
+            CONTRACT_VERSION
+        )
+        assert list_response.headers["Cache-Control"] == "no-store"
+
+        schema_response = await client.get(
+            "/v1/execution-contract/schema",
+            headers=_auth(FULL_KEY),
+        )
+        assert schema_response.status == 200
+        schema = await schema_response.json()
+        assert schema["$defs"]["receipt"]["additionalProperties"] is False
+
+    assert not store.database_path.exists()
+
+
+@pytest.mark.asyncio
+async def test_read_scope_is_accepted_only_for_contract_gets(contract_adapter):
+    app = _contract_app(contract_adapter)
+    async with TestClient(TestServer(app)) as client:
+        allowed = await client.get(
+            "/v1/capabilities",
+            headers=_auth(READ_KEY),
+        )
+        assert allowed.status == 200
+
+        forbidden_get = await client.get("/v1/models", headers=_auth(READ_KEY))
+        assert forbidden_get.status == 403
+
+        writes = [
+            ("/v1/runs", {"input": "synthetic"}),
+            ("/v1/runs/run-synthetic/approval", {"choice": "deny"}),
+            ("/v1/runs/run-synthetic/steer", {"message": "synthetic"}),
+            ("/v1/runs/run-synthetic/stop", {}),
+            ("/v1/responses", {"input": "synthetic"}),
+        ]
+        for path, body in writes:
+            response = await client.post(path, json=body, headers=_auth(READ_KEY))
+            assert response.status == 403, path
+            payload = await response.json()
+            assert payload["error"]["granted_scope"] == "execution:read"
+
+        missing = await client.get("/v1/execution-contract/executions")
+        invalid = await client.get(
+            "/v1/execution-contract/executions",
+            headers=_auth("wrong-token-0123456789abcdef"),
+        )
+        assert missing.status == invalid.status == 401
+
+
+@pytest.mark.asyncio
+async def test_http_contract_validation_not_found_conflict_and_profile_denial(
+    contract_adapter,
+):
+    store = contract_adapter._execution_contract_store()
+    execution = store.create_execution(
+        lifecycle="queued",
+        source_run_id="run-http",
+        work_ref="work:http",
+        proposal_ref="proposal:http",
+        now=NOW,
+    )
+    app = _contract_app(contract_adapter)
+    async with TestClient(TestServer(app)) as client:
+        detail = await client.get(
+            f"/v1/execution-contract/executions/{execution['execution_id']}",
+            headers=_auth(READ_KEY),
+        )
+        assert detail.status == 200
+        assert (await detail.json())["execution"]["source_run_id"] == "run-http"
+
+        malformed = await client.get(
+            "/v1/execution-contract/executions?lifecycle=future_state",
+            headers=_auth(READ_KEY),
+        )
+        assert malformed.status == 400
+
+        unknown_version = await client.get(
+            "/v1/execution-contract/executions",
+            headers={
+                **_auth(READ_KEY),
+                "Hermes-Execution-Contract-Version": "hermes.execution.read.v999",
+            },
+        )
+        assert unknown_version.status == 409
+
+        unknown_id = (
+            f"exe_{store.authority.profile_key}_" + "f" * 32
+        )
+        missing = await client.get(
+            f"/v1/execution-contract/executions/{unknown_id}",
+            headers=_auth(READ_KEY),
+        )
+        assert missing.status == 404
+
+        foreign_id = "exe_abcdefabcdef_" + "0" * 32
+        forbidden = await client.get(
+            f"/v1/execution-contract/executions/{foreign_id}",
+            headers=_auth(READ_KEY),
+        )
+        assert forbidden.status == 403
+
+
+@pytest.mark.asyncio
+async def test_cursor_gone_rate_limit_corruption_and_unavailable_statuses(
+    contract_adapter,
+    monkeypatch,
+):
+    store = contract_adapter._execution_contract_store()
+    old = NOW - timedelta(days=40)
+    execution = store.create_execution(lifecycle="running", now=old)
+    store.transition_execution(
+        execution["execution_id"],
+        "terminal_failed",
+        now=old + timedelta(seconds=1),
+    )
+    assert store.prune_events(now=NOW) == 2
+    app = _contract_app(contract_adapter)
+
+    async with TestClient(TestServer(app)) as client:
+        gone = await client.get(
+            "/v1/execution-contract/events?after=0",
+            headers=_auth(READ_KEY),
+        )
+        assert gone.status == 410
+        gone_payload = await gone.json()
+        assert gone_payload["error"]["minimum_available"] == 3
+
+        class FailingStore:
+            authority = store.authority
+
+            def __init__(self, error):
+                self.error = error
+
+            def list_executions(self, **_kwargs):
+                raise self.error
+
+        for error, status in (
+            (ContractRateLimitedError("synthetic busy"), 429),
+            (ContractDataError("synthetic corrupt secret detail"), 500),
+            (ContractUnavailableError("synthetic unavailable"), 503),
+        ):
+            monkeypatch.setattr(
+                contract_adapter,
+                "_execution_contract_store",
+                lambda error=error: FailingStore(error),
+            )
+            response = await client.get(
+                "/v1/execution-contract/executions",
+                headers=_auth(READ_KEY),
+            )
+            assert response.status == status
+            payload = await response.json()
+            if status >= 500:
+                assert payload["error"]["message"] == "Execution contract unavailable"
+            if status == 429:
+                assert response.headers["Retry-After"] == "1"
+
+
+def test_process_local_and_projection_state_cannot_publish_receipts(contract_adapter):
+    context = {
+        "work_ref": "work:synthetic",
+        "proposal_ref": "proposal:synthetic",
+        "effect_id": "effect:synthetic",
+    }
+    execution = contract_adapter._create_execution_contract_run(
+        "run-unproven",
+        context,
+    )
+    contract_adapter._run_statuses["run-unproven"] = {
+        "status": "completed",
+        "final_response": "chat output is not executor evidence",
+        "session_history": ["synthetic transcript"],
+        "kanban_summary": "synthetic operator projection",
+    }
+    terminal = contract_adapter._terminalize_execution_contract_run(
+        "run-unproven",
+        "completed",
+        reason_code="process_local_completed",
+    )
+    assert terminal is not None
+    assert terminal["execution_id"] == execution["execution_id"]
+    assert terminal["lifecycle"] == "terminal_ambiguous"
+    assert terminal["receipt_state"] == "unproven"
+    assert contract_adapter._execution_contract_store().list_receipts()["items"] == []
+
+    proven = contract_adapter._create_execution_contract_run("run-proven", context)
+    contract_adapter._transition_execution_contract_run("run-proven", "running")
+    evidence = contract_adapter.record_execution_effect_evidence(
+        run_id="run-proven",
+        effect_id="effect:synthetic",
+        outcome="succeeded",
+        subject_digest=canonical_digest({"subject": "synthetic"}),
+        evidence_digest=canonical_digest({"executor_evidence": "synthetic"}),
+        result_digest=canonical_digest({"result": "synthetic"}),
+    )
+    assert evidence["execution_id"] == proven["execution_id"]
+    published = contract_adapter._terminalize_execution_contract_run(
+        "run-proven",
+        "completed",
+    )
+    assert published is not None
+    assert published["receipt_state"] == "published"
+    receipt = contract_adapter._execution_contract_store().get_receipt(
+        published["receipt_id"]
+    )
+    assert receipt["effect_id"] == "effect:synthetic"
+
+
+def test_execution_context_is_closed_and_requires_exact_effect_bindings():
+    assert APIServerAdapter._parse_execution_contract_context({}) == {
+        "work_ref": None,
+        "proposal_ref": None,
+        "effect_id": None,
+    }
+    with pytest.raises(ValueError, match="unsupported fields"):
+        APIServerAdapter._parse_execution_contract_context(
+            {"execution_context": {"provider": "synthetic"}}
+        )
+    with pytest.raises(ValueError, match="exact work_ref"):
+        APIServerAdapter._parse_execution_contract_context(
+            {"execution_context": {"effect_id": "effect:synthetic"}}
+        )
+
+
+def test_read_key_configuration_and_profile_scope_are_explicit(monkeypatch):
+    monkeypatch.setenv("API_SERVER_KEY", FULL_KEY)
+    monkeypatch.setenv("API_SERVER_READ_KEY", READ_KEY)
+    config = GatewayConfig()
+    _apply_env_overrides(config)
+    api_config = config.platforms[Platform.API_SERVER]
+    assert api_config.enabled is True
+    assert api_config.extra["key"] == FULL_KEY
+    assert api_config.extra["read_key"] == READ_KEY
+
+    adapter = APIServerAdapter(api_config)
+    try:
+        assert adapter._read_api_key_passes_startup_guard() is True
+        adapter._read_api_key = "weak"
+        assert adapter._read_api_key_passes_startup_guard() is False
+
+        profile_key = "worker-read-key-0123456789abcdef"
+        monkeypatch.setattr(
+            "agent.secret_scope.get_secret",
+            lambda name, default="": profile_key
+            if name == "API_SERVER_READ_KEY"
+            else default,
+        )
+        token = _api_request_profile.set("worker")
+        try:
+            assert adapter._expected_read_api_key() == profile_key
+        finally:
+            _api_request_profile.reset(token)
+    finally:
+        adapter._response_store.close()
+
+
+def test_fixture_payloads_contain_no_runtime_or_secret_material():
+    root = (
+        __import__("pathlib").Path(__file__).parents[1]
+        / "fixtures"
+        / "execution_contract"
+    )
+    forbidden = ("api_key", "bearer", "credential", "session_history", "home/")
+    for path in sorted(root.glob("*.json")):
+        text = path.read_text(encoding="utf-8").lower()
+        json.loads(text)
+        assert not any(token in text for token in forbidden), path

--- a/tests/gateway/test_api_server_execution_contract.py
+++ b/tests/gateway/test_api_server_execution_contract.py
@@ -3,11 +3,13 @@
 from __future__ import annotations
 
 import json
+from contextlib import nullcontext
 from datetime import datetime, timedelta, timezone
 
 import pytest
 from aiohttp import web
 from aiohttp.test_utils import TestClient, TestServer
+from jsonschema import Draft202012Validator
 
 from gateway.config import (
     GatewayConfig,
@@ -22,6 +24,7 @@ from hermes_cli.execution_contract import (
     ContractRateLimitedError,
     ContractUnavailableError,
     canonical_digest,
+    contract_schema,
 )
 
 
@@ -32,6 +35,10 @@ NOW = datetime(2026, 8, 15, 12, 0, tzinfo=timezone.utc)
 
 def _auth(key: str) -> dict[str, str]:
     return {"Authorization": f"Bearer {key}"}
+
+
+def _assert_closed_error(payload: dict) -> None:
+    Draft202012Validator(contract_schema()["$defs"]["errorDetail"]).validate(payload)
 
 
 @pytest.fixture
@@ -92,12 +99,11 @@ async def test_read_key_is_side_effect_free_and_returns_asserted_authority(
         assert capabilities_response.status == 200
         capabilities = await capabilities_response.json()
         assert capabilities["contract_version"] == CONTRACT_VERSION
-        assert capabilities["authority"] == {
-            "profile_id": "hermes-profile:default",
-            "profile_name": "default",
-            "authority_id": "hermes-execution-authority:default",
-            "executor_id": "hermes-agent:default",
-        }
+        assert capabilities["authority"] == store.authority.public()
+        assert capabilities["authority"]["profile_id"].startswith(
+            "hermes-profile-instance:"
+        )
+        assert not capabilities["authority"]["profile_id"].endswith(":default")
         assert capabilities["features"]["action_dispatch"] is False
 
         list_response = await client.get(
@@ -156,6 +162,8 @@ async def test_read_scope_is_accepted_only_for_contract_gets(contract_adapter):
             headers=_auth("wrong-token-0123456789abcdef"),
         )
         assert missing.status == invalid.status == 401
+        _assert_closed_error(await missing.json())
+        _assert_closed_error(await invalid.json())
 
 
 @pytest.mark.asyncio
@@ -184,6 +192,7 @@ async def test_http_contract_validation_not_found_conflict_and_profile_denial(
             headers=_auth(READ_KEY),
         )
         assert malformed.status == 400
+        _assert_closed_error(await malformed.json())
 
         unknown_version = await client.get(
             "/v1/execution-contract/executions",
@@ -193,6 +202,7 @@ async def test_http_contract_validation_not_found_conflict_and_profile_denial(
             },
         )
         assert unknown_version.status == 409
+        _assert_closed_error(await unknown_version.json())
 
         unknown_id = (
             f"exe_{store.authority.profile_key}_" + "f" * 32
@@ -202,6 +212,7 @@ async def test_http_contract_validation_not_found_conflict_and_profile_denial(
             headers=_auth(READ_KEY),
         )
         assert missing.status == 404
+        _assert_closed_error(await missing.json())
 
         foreign_id = "exe_abcdefabcdef_" + "0" * 32
         forbidden = await client.get(
@@ -209,6 +220,7 @@ async def test_http_contract_validation_not_found_conflict_and_profile_denial(
             headers=_auth(READ_KEY),
         )
         assert forbidden.status == 403
+        _assert_closed_error(await forbidden.json())
 
 
 @pytest.mark.asyncio
@@ -234,6 +246,7 @@ async def test_cursor_gone_rate_limit_corruption_and_unavailable_statuses(
         )
         assert gone.status == 410
         gone_payload = await gone.json()
+        _assert_closed_error(gone_payload)
         assert gone_payload["error"]["minimum_available"] == 3
 
         class FailingStore:
@@ -261,6 +274,7 @@ async def test_cursor_gone_rate_limit_corruption_and_unavailable_statuses(
             )
             assert response.status == status
             payload = await response.json()
+            _assert_closed_error(payload)
             if status >= 500:
                 assert payload["error"]["message"] == "Execution contract unavailable"
             if status == 429:
@@ -363,6 +377,92 @@ def test_read_key_configuration_and_profile_scope_are_explicit(monkeypatch):
             _api_request_profile.reset(token)
     finally:
         adapter._response_store.close()
+
+
+def test_equal_full_and_read_keys_fail_startup_default_and_named(monkeypatch):
+    adapter = APIServerAdapter(
+        PlatformConfig(
+            enabled=True,
+            extra={"key": FULL_KEY, "read_key": FULL_KEY},
+        )
+    )
+    try:
+        assert adapter._read_api_key_passes_startup_guard() is False
+
+        adapter._read_api_key = READ_KEY
+        monkeypatch.setattr(
+            adapter,
+            "_execution_contract_profiles",
+            lambda: [None, "worker"],
+        )
+        monkeypatch.setattr(adapter, "_profile_scope", lambda _profile: nullcontext())
+        monkeypatch.setattr(
+            "agent.secret_scope.get_secret",
+            lambda name, default="": FULL_KEY
+            if name in {"API_SERVER_KEY", "API_SERVER_READ_KEY"}
+            else default,
+        )
+        assert adapter._read_api_key_passes_startup_guard() is False
+    finally:
+        adapter._response_store.close()
+
+
+def test_profile_authority_comes_from_active_home_not_request_name(
+    contract_adapter,
+    tmp_path,
+):
+    from gateway.run import _profile_runtime_scope
+
+    named_home = tmp_path / "named-single-profile"
+    alpha_home = tmp_path / "multiplex-alpha"
+    beta_home = tmp_path / "multiplex-beta"
+    for home in (named_home, alpha_home, beta_home):
+        home.mkdir()
+
+    with _profile_runtime_scope(named_home):
+        first = contract_adapter._execution_contract_store()
+        token = _api_request_profile.set("url-name-must-not-control-authority")
+        try:
+            same_home = contract_adapter._execution_contract_store()
+        finally:
+            _api_request_profile.reset(token)
+    assert first.authority == same_home.authority
+    assert first.authority.profile_name == named_home.name
+
+    with _profile_runtime_scope(alpha_home):
+        alpha = contract_adapter._execution_contract_store()
+    with _profile_runtime_scope(beta_home):
+        beta = contract_adapter._execution_contract_store()
+    assert alpha.authority.profile_id != beta.authority.profile_id
+    assert alpha.authority.profile_key != beta.authority.profile_key
+
+
+@pytest.mark.asyncio
+async def test_unknown_profile_route_uses_closed_contract_error(
+    contract_adapter,
+    monkeypatch,
+):
+    from gateway.platforms.api_server import _PROFILE_REJECTED
+
+    monkeypatch.setattr(
+        contract_adapter,
+        "_resolve_request_profile",
+        lambda _request: _PROFILE_REJECTED,
+    )
+    app = web.Application(
+        middlewares=[contract_adapter._make_profile_prefix_middleware()]
+    )
+    app.router.add_get(
+        "/p/{profile}/v1/execution-contract/executions",
+        contract_adapter._handle_execution_contract_executions,
+    )
+    async with TestClient(TestServer(app)) as client:
+        response = await client.get(
+            "/p/unknown/v1/execution-contract/executions",
+            headers=_auth(READ_KEY),
+        )
+        assert response.status == 404
+        _assert_closed_error(await response.json())
 
 
 def test_fixture_payloads_contain_no_runtime_or_secret_material():

--- a/tests/gateway/test_api_server_execution_contract.py
+++ b/tests/gateway/test_api_server_execution_contract.py
@@ -58,7 +58,12 @@ def contract_adapter(monkeypatch):
 
 
 def _contract_app(adapter: APIServerAdapter) -> web.Application:
-    app = web.Application()
+    app = web.Application(
+        middlewares=[
+            adapter._make_profile_prefix_middleware(),
+            adapter._make_execution_contract_router_error_middleware(),
+        ]
+    )
     wanted = {
         ("GET", "/v1/capabilities"),
         ("GET", "/v1/models"),
@@ -80,6 +85,7 @@ def _contract_app(adapter: APIServerAdapter) -> web.Application:
     for method, path, handler in adapter._http_route_table():
         if (method, path) in wanted:
             app.router.add_route(method, path, handler)
+            app.router.add_route(method, f"/p/{{profile}}{path}", handler)
     return app
 
 
@@ -89,6 +95,8 @@ async def test_read_key_is_side_effect_free_and_returns_asserted_authority(
 ):
     store = contract_adapter._execution_contract_store()
     assert not store.database_path.exists()
+    store.initialize()
+    ledger_mtime = store.database_path.stat().st_mtime_ns
     app = _contract_app(contract_adapter)
 
     async with TestClient(TestServer(app)) as client:
@@ -127,7 +135,7 @@ async def test_read_key_is_side_effect_free_and_returns_asserted_authority(
         schema = await schema_response.json()
         assert schema["$defs"]["receipt"]["additionalProperties"] is False
 
-    assert not store.database_path.exists()
+    assert store.database_path.stat().st_mtime_ns == ledger_mtime
 
 
 @pytest.mark.asyncio
@@ -421,6 +429,7 @@ def test_profile_authority_comes_from_active_home_not_request_name(
 
     with _profile_runtime_scope(named_home):
         first = contract_adapter._execution_contract_store()
+        first.initialize()
         token = _api_request_profile.set("url-name-must-not-control-authority")
         try:
             same_home = contract_adapter._execution_contract_store()
@@ -431,10 +440,15 @@ def test_profile_authority_comes_from_active_home_not_request_name(
 
     with _profile_runtime_scope(alpha_home):
         alpha = contract_adapter._execution_contract_store()
+        alpha.initialize()
     with _profile_runtime_scope(beta_home):
         beta = contract_adapter._execution_contract_store()
+        beta.initialize()
     assert alpha.authority.profile_id != beta.authority.profile_id
     assert alpha.authority.profile_key != beta.authority.profile_key
+    assert alpha.profile_anchor_path.exists()
+    assert beta.profile_anchor_path.exists()
+    assert alpha.profile_anchor_path.read_bytes() != beta.profile_anchor_path.read_bytes()
 
 
 @pytest.mark.asyncio
@@ -450,19 +464,163 @@ async def test_unknown_profile_route_uses_closed_contract_error(
         lambda _request: _PROFILE_REJECTED,
     )
     app = web.Application(
-        middlewares=[contract_adapter._make_profile_prefix_middleware()]
+        middlewares=[
+            contract_adapter._make_profile_prefix_middleware(),
+            contract_adapter._make_execution_contract_router_error_middleware(),
+        ]
     )
     app.router.add_get(
         "/p/{profile}/v1/execution-contract/executions",
         contract_adapter._handle_execution_contract_executions,
     )
     async with TestClient(TestServer(app)) as client:
+        unauthenticated = await client.get(
+            "/p/unknown/v1/execution-contract/executions"
+        )
+        assert unauthenticated.status == 401
+        _assert_closed_error(await unauthenticated.json())
         response = await client.get(
             "/p/unknown/v1/execution-contract/executions",
             headers=_auth(READ_KEY),
         )
         assert response.status == 404
         _assert_closed_error(await response.json())
+
+
+@pytest.mark.asyncio
+async def test_router_404_and_405_use_closed_contract_errors_with_auth_precedence(
+    contract_adapter,
+):
+    contract_adapter._execution_contract_store().initialize()
+    app = _contract_app(contract_adapter)
+    async with TestClient(TestServer(app)) as client:
+        unknown_without_auth = await client.get(
+            "/v1/execution-contract/not-a-route"
+        )
+        assert unknown_without_auth.status == 401
+        _assert_closed_error(await unknown_without_auth.json())
+
+        unknown = await client.get(
+            "/v1/execution-contract/not-a-route",
+            headers=_auth(READ_KEY),
+        )
+        assert unknown.status == 404
+        unknown_payload = await unknown.json()
+        _assert_closed_error(unknown_payload)
+        assert unknown_payload["error"]["code"] == "execution_contract_not_found"
+
+        wrong_method_without_auth = await client.post(
+            "/v1/execution-contract/executions"
+        )
+        assert wrong_method_without_auth.status == 401
+        _assert_closed_error(await wrong_method_without_auth.json())
+
+        read_scope_denial = await client.post(
+            "/v1/execution-contract/executions",
+            headers=_auth(READ_KEY),
+        )
+        assert read_scope_denial.status == 403
+        _assert_closed_error(await read_scope_denial.json())
+
+        wrong_method = await client.post(
+            "/v1/execution-contract/executions",
+            headers=_auth(FULL_KEY),
+        )
+        assert wrong_method.status == 405
+        wrong_method_payload = await wrong_method.json()
+        _assert_closed_error(wrong_method_payload)
+        assert wrong_method_payload["error"]["code"] == (
+            "execution_contract_method_not_allowed"
+        )
+
+        prefixed_wrong_method = await client.post(
+            "/p/default/v1/execution-contract/executions",
+            headers=_auth(FULL_KEY),
+        )
+        assert prefixed_wrong_method.status == 405
+        _assert_closed_error(await prefixed_wrong_method.json())
+
+        malformed_without_auth = await client.get(
+            "/p//v1/execution-contract/executions"
+        )
+        assert malformed_without_auth.status == 401
+        _assert_closed_error(await malformed_without_auth.json())
+        malformed = await client.get(
+            "/p//v1/execution-contract/executions",
+            headers=_auth(READ_KEY),
+        )
+        assert malformed.status == 404
+        _assert_closed_error(await malformed.json())
+
+        non_contract = await client.get(
+            "/not-an-api-route",
+            headers=_auth(FULL_KEY),
+        )
+        assert non_contract.status == 404
+        assert non_contract.content_type != "application/json"
+
+
+@pytest.mark.asyncio
+async def test_named_multiplex_router_errors_use_named_profile_auth(
+    contract_adapter,
+    monkeypatch,
+    tmp_path,
+):
+    from agent import secret_scope
+    from gateway.run import _profile_runtime_scope
+
+    worker_home = tmp_path / "profiles" / "worker"
+    worker_home.mkdir(parents=True)
+    worker_full_key = "worker-full-key-0123456789abcdef"
+    worker_read_key = "worker-read-key-0123456789abcdef"
+    (worker_home / ".env").write_text(
+        f"API_SERVER_KEY={worker_full_key}\nAPI_SERVER_READ_KEY={worker_read_key}\n",
+        encoding="utf-8",
+    )
+    contract_adapter.gateway_runner = type(
+        "_Runner",
+        (),
+        {"config": GatewayConfig(multiplex_profiles=True)},
+    )()
+    monkeypatch.setattr(
+        "hermes_cli.profiles.profiles_to_serve",
+        lambda multiplex, profile_allowlist=None: [
+            ("default", tmp_path),
+            ("worker", worker_home),
+        ],
+    )
+    monkeypatch.setattr(
+        "hermes_cli.profiles.get_profile_dir",
+        lambda name: tmp_path if name == "default" else worker_home,
+    )
+    with _profile_runtime_scope(worker_home):
+        contract_adapter._execution_contract_store().initialize()
+    secret_scope.set_multiplex_active(True)
+    try:
+        app = _contract_app(contract_adapter)
+        async with TestClient(TestServer(app)) as client:
+            rejected = await client.get(
+                "/p/worker/v1/execution-contract/not-a-route",
+                headers=_auth(READ_KEY),
+            )
+            assert rejected.status == 401
+            _assert_closed_error(await rejected.json())
+
+            unknown = await client.get(
+                "/p/worker/v1/execution-contract/not-a-route",
+                headers=_auth(worker_read_key),
+            )
+            assert unknown.status == 404
+            _assert_closed_error(await unknown.json())
+
+            wrong_method = await client.post(
+                "/p/worker/v1/execution-contract/executions",
+                headers=_auth(worker_full_key),
+            )
+            assert wrong_method.status == 405
+            _assert_closed_error(await wrong_method.json())
+    finally:
+        secret_scope.set_multiplex_active(False)
 
 
 def test_fixture_payloads_contain_no_runtime_or_secret_material():

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -497,6 +497,7 @@ class TestLoadGatewayConfig:
         for key in (
             "API_SERVER_ENABLED",
             "API_SERVER_KEY",
+            "API_SERVER_READ_KEY",
             "API_SERVER_PORT",
             "API_SERVER_HOST",
             "API_SERVER_CORS_ORIGINS",
@@ -529,7 +530,7 @@ class TestLoadGatewayConfig:
 
     def test_api_server_port_bridged_into_extra(self, tmp_path, monkeypatch):
         """``gateway.api_server.port`` must land in PlatformConfig.extra —
-        the adapter reads port/key/host/cors_origins/model_name from extra
+        the adapter reads port/key/read_key/host/cors_origins/model_name from extra
         (gateway/platforms/api_server.py), and from_dict discards unknown
         top-level keys, so without the bridge the port is silently lost."""
         self._clear_api_server_env(monkeypatch)
@@ -542,6 +543,7 @@ class TestLoadGatewayConfig:
             "    port: 8642\n"
             "    host: 0.0.0.0\n"
             "    key: sekrit\n"
+            "    read_key: read-sekrit\n"
             "    model_name: my-hermes\n",
             encoding="utf-8",
         )
@@ -553,6 +555,7 @@ class TestLoadGatewayConfig:
         assert extra["port"] == 8642
         assert extra["host"] == "0.0.0.0"
         assert extra["key"] == "sekrit"
+        assert extra["read_key"] == "read-sekrit"
         assert extra["model_name"] == "my-hermes"
 
 

--- a/tests/hermes_cli/test_execution_contract.py
+++ b/tests/hermes_cli/test_execution_contract.py
@@ -663,6 +663,82 @@ def test_prune_rejects_global_gap_without_mutating_rows_or_watermark(
         store.list_events(execution_id=executions[0]["execution_id"])
 
 
+@pytest.mark.parametrize("missing_sequence", [4, 5, 6])
+def test_prune_rejects_gap_in_retained_suffix_before_deleting_terminal_prefix(
+    tmp_path,
+    missing_sequence,
+):
+    store = _store(tmp_path)
+    old = NOW - timedelta(days=40)
+    terminal = store.create_execution(
+        lifecycle="running",
+        source_run_id="prunable-terminal-prefix",
+        now=old,
+    )
+    store.transition_execution(
+        terminal["execution_id"],
+        "terminal_failed",
+        now=old + timedelta(seconds=1),
+    )
+    live = store.create_execution(
+        lifecycle="running",
+        source_run_id="live-prune-boundary",
+        now=old + timedelta(seconds=2),
+    )
+    retained = store.create_execution(
+        lifecycle="accepted",
+        source_run_id="retained-terminal-suffix",
+        now=NOW,
+    )
+    store.transition_execution(
+        retained["execution_id"],
+        "running",
+        now=NOW + timedelta(seconds=1),
+    )
+    store.transition_execution(
+        retained["execution_id"],
+        "terminal_failed",
+        now=NOW + timedelta(seconds=2),
+    )
+
+    with sqlite3.connect(store.database_path) as connection:
+        assert connection.execute(
+            "SELECT sequence FROM execution_events ORDER BY sequence"
+        ).fetchall() == [(1,), (2,), (3,), (4,), (5,), (6,)]
+        connection.execute(
+            "DELETE FROM execution_events WHERE sequence=?",
+            (missing_sequence,),
+        )
+        connection.commit()
+        before_rows = connection.execute(
+            "SELECT sequence, event_id, execution_id FROM execution_events "
+            "ORDER BY sequence"
+        ).fetchall()
+        before_watermark = connection.execute(
+            "SELECT value FROM execution_contract_metadata "
+            "WHERE key='events_pruned_through'"
+        ).fetchone()[0]
+
+    with pytest.raises(ContractDataError, match="event sequence gap"):
+        store.prune_events(now=NOW)
+
+    with sqlite3.connect(store.database_path) as connection:
+        assert connection.execute(
+            "SELECT sequence, event_id, execution_id FROM execution_events "
+            "ORDER BY sequence"
+        ).fetchall() == before_rows
+        assert connection.execute(
+            "SELECT value FROM execution_contract_metadata "
+            "WHERE key='events_pruned_through'"
+        ).fetchone()[0] == before_watermark == "0"
+
+    with pytest.raises(ContractDataError, match="event sequence gap"):
+        store.list_events()
+    with pytest.raises(ContractDataError, match="event sequence gap"):
+        store.list_events(execution_id=terminal["execution_id"])
+    assert live["lifecycle"] == "running"
+
+
 def test_prune_boundary_excludes_append_waiting_on_same_write_lock(tmp_path):
     seed = _store(tmp_path, runtime="prune-race")
     old = NOW - timedelta(days=40)

--- a/tests/hermes_cli/test_execution_contract.py
+++ b/tests/hermes_cli/test_execution_contract.py
@@ -1,0 +1,656 @@
+"""Behavioral conformance tests for the durable execution read contract."""
+
+from __future__ import annotations
+
+import concurrent.futures
+import json
+import os
+import sqlite3
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+from hermes_cli.execution_contract import (
+    CONTRACT_VERSION,
+    ContractConflictError,
+    ContractCursorGoneError,
+    ContractDataError,
+    ContractForbiddenError,
+    ContractValidationError,
+    ExecutionContractStore,
+    UnsupportedContractVersionError,
+    canonical_digest,
+    contract_capabilities,
+    contract_schema,
+)
+
+
+NOW = datetime(2026, 8, 15, 12, 0, tzinfo=timezone.utc)
+FIXTURES = Path(__file__).parents[1] / "fixtures" / "execution_contract"
+
+
+def _digest(label: str) -> str:
+    return canonical_digest({"fixture": label})
+
+
+def _store(tmp_path, *, profile="default", runtime="runtime-a"):
+    return ExecutionContractStore(
+        database_path=tmp_path / profile / "execution_contract.sqlite3",
+        profile_name=profile,
+        runtime_instance_id=runtime,
+    )
+
+
+def _bound_execution(store: ExecutionContractStore, *, suffix="one"):
+    return store.create_execution(
+        lifecycle="queued",
+        source_run_id=f"run-{suffix}",
+        work_ref=f"work:{suffix}",
+        proposal_ref=f"proposal:{suffix}",
+        effect_id=f"effect:{suffix}",
+        now=NOW,
+    )
+
+
+def _resolved_decision(store: ExecutionContractStore, execution: dict, *, suffix="one"):
+    decision = store.create_decision(
+        execution_id=execution["execution_id"],
+        effect_id=execution["effect_id"],
+        proposal_ref=execution["proposal_ref"],
+        request_digest=_digest(f"request-{suffix}"),
+        candidate_digest=_digest(f"candidate-{suffix}"),
+        policy_digest=_digest(f"policy-{suffix}"),
+        allowed_choices=["once", "deny"],
+        expires_at=NOW + timedelta(minutes=5),
+        now=NOW,
+    )
+    return store.resolve_decision(
+        decision["decision_id"],
+        choice="once",
+        resolution_evidence_digest=_digest(f"resolution-{suffix}"),
+        now=NOW + timedelta(seconds=1),
+    )
+
+
+def _record_evidence(
+    store: ExecutionContractStore,
+    execution: dict,
+    *,
+    outcome="succeeded",
+    decision_id=None,
+    suffix="one",
+    reconciliation_ref=None,
+):
+    return store.record_effect_evidence(
+        execution_id=execution["execution_id"],
+        effect_id=execution["effect_id"],
+        outcome=outcome,
+        subject_digest=_digest(f"subject-{suffix}"),
+        evidence_digest=_digest(f"evidence-{suffix}"),
+        result_digest=_digest(f"result-{suffix}"),
+        decision_id=decision_id,
+        reconciliation_ref=reconciliation_ref,
+        now=NOW + timedelta(seconds=2),
+    )
+
+
+def test_absent_read_is_side_effect_free_then_create_reopen_and_migrate(tmp_path):
+    store = _store(tmp_path)
+    assert not store.database_path.exists()
+
+    empty = store.list_executions()
+
+    assert empty["items"] == []
+    assert empty["page"] == {
+        "cursor": 0,
+        "high_water": 0,
+        "minimum_available": 0,
+        "has_more": False,
+        "completeness": "complete",
+    }
+    assert not store.database_path.exists()
+
+    execution = store.create_execution(
+        lifecycle="accepted",
+        source_run_id="run-create",
+        work_ref="work:create",
+        proposal_ref="proposal:create",
+        now=NOW,
+    )
+
+    assert store.database_path.exists()
+    assert os.stat(store.database_path).st_mode & 0o077 == 0
+    with sqlite3.connect(store.database_path) as connection:
+        assert connection.execute("PRAGMA user_version").fetchone()[0] == 1
+    reopened = _store(tmp_path)
+    assert reopened.get_execution(execution["execution_id"])["revision"] == 1
+    assert reopened.get_execution(execution["execution_id"])["freshness"] == "live"
+
+
+def test_packaged_schema_and_synthetic_fixtures_are_closed():
+    schema = contract_schema()
+    assert schema["$schema"] == "https://json-schema.org/draft/2020-12/schema"
+    fixture_defs = {
+        "capabilities.json": ("capabilities", None),
+        "execution-list.json": ("executionList", "execution"),
+        "decision-list.json": ("decisionList", "decision"),
+        "event-list.json": ("eventList", "event"),
+        "receipt-list.json": ("receiptList", "receipt"),
+    }
+    for filename, (definition_name, item_definition_name) in fixture_defs.items():
+        payload = json.loads((FIXTURES / filename).read_text(encoding="utf-8"))
+        definition = schema["$defs"][definition_name]
+        assert definition["additionalProperties"] is False
+        assert set(payload) == set(definition["required"])
+        if item_definition_name:
+            collection = definition_name.removesuffix("List").lower() + "s"
+            item_definition = schema["$defs"][item_definition_name]
+            assert item_definition["additionalProperties"] is False
+            assert set(payload[collection][0]) == set(item_definition["required"])
+
+    capabilities = contract_capabilities("synthetic")
+    assert capabilities == json.loads(
+        (FIXTURES / "capabilities.json").read_text(encoding="utf-8")
+    )
+    assert schema["$defs"]["errorDetail"]["additionalProperties"] is False
+
+
+def test_unknown_store_version_fails_closed(tmp_path):
+    store = _store(tmp_path)
+    store.database_path.parent.mkdir(parents=True)
+    with sqlite3.connect(store.database_path) as connection:
+        connection.execute("PRAGMA user_version=99")
+
+    with pytest.raises(UnsupportedContractVersionError):
+        store.initialize()
+    with pytest.raises(UnsupportedContractVersionError):
+        store.list_executions()
+
+
+@pytest.mark.parametrize(
+    ("outcome", "lifecycle"),
+    [
+        ("succeeded", "terminal_succeeded"),
+        ("failed", "terminal_failed"),
+        ("cancelled", "terminal_cancelled"),
+        ("partial", "terminal_partial"),
+        ("ambiguous", "terminal_ambiguous"),
+    ],
+)
+def test_all_evidence_backed_receipt_outcomes_publish_atomically(
+    tmp_path,
+    outcome,
+    lifecycle,
+):
+    store = _store(tmp_path)
+    execution = _bound_execution(store, suffix=outcome)
+    store.transition_execution(execution["execution_id"], "running", now=NOW)
+    evidence = _record_evidence(store, execution, outcome=outcome, suffix=outcome)
+
+    terminal = store.transition_execution(
+        execution["execution_id"],
+        lifecycle,
+        now=NOW + timedelta(seconds=3),
+    )
+
+    assert evidence["outcome"] == outcome
+    assert terminal["lifecycle"] == lifecycle
+    assert terminal["receipt_state"] == "published"
+    receipt = store.get_receipt(terminal["receipt_id"])
+    assert receipt["execution_id"] == execution["execution_id"]
+    assert receipt["effect_id"] == execution["effect_id"]
+    assert receipt["outcome"] == outcome
+    assert receipt["revision"] == 1
+    events = store.list_events(execution_id=execution["execution_id"])["items"]
+    assert events[-2]["event_type"] == "execution.transitioned"
+    assert events[-1]["event_type"] == "receipt.published"
+    assert events[-1]["receipt_id"] == receipt["receipt_id"]
+
+
+def test_nonterminal_lifecycle_progression_and_initial_state_are_closed(tmp_path):
+    store = _store(tmp_path)
+    execution = store.create_execution(lifecycle="accepted", now=NOW)
+    queued = store.transition_execution(
+        execution["execution_id"],
+        "queued",
+        now=NOW + timedelta(seconds=1),
+    )
+    running = store.transition_execution(
+        execution["execution_id"],
+        "running",
+        now=NOW + timedelta(seconds=2),
+    )
+    cancelling = store.transition_execution(
+        execution["execution_id"],
+        "cancellation_requested",
+        now=NOW + timedelta(seconds=3),
+    )
+    terminal = store.transition_execution(
+        execution["execution_id"],
+        "terminal_cancelled",
+        now=NOW + timedelta(seconds=4),
+    )
+    assert [
+        queued["lifecycle"],
+        running["lifecycle"],
+        cancelling["lifecycle"],
+        terminal["lifecycle"],
+    ] == ["queued", "running", "cancellation_requested", "terminal_cancelled"]
+    with pytest.raises(ContractValidationError, match="initial lifecycle"):
+        store.create_execution(lifecycle="awaiting_decision", now=NOW)
+
+
+def test_unproven_effect_is_terminal_ambiguous_without_receipt(tmp_path):
+    store = _store(tmp_path)
+    execution = _bound_execution(store)
+    store.transition_execution(execution["execution_id"], "running", now=NOW)
+
+    terminal = store.transition_execution(
+        execution["execution_id"],
+        "terminal_succeeded",
+        reason_code="generic_chat_completed",
+        now=NOW + timedelta(seconds=1),
+    )
+
+    assert terminal["lifecycle"] == "terminal_ambiguous"
+    assert terminal["receipt_state"] == "unproven"
+    assert terminal["receipt_id"] is None
+    assert store.list_receipts()["items"] == []
+
+
+def test_execution_without_external_effect_can_terminate_without_receipt(tmp_path):
+    store = _store(tmp_path)
+    execution = store.create_execution(
+        lifecycle="running",
+        source_run_id="run-chat-only",
+        work_ref="work:chat",
+        proposal_ref="proposal:chat",
+        now=NOW,
+    )
+
+    terminal = store.transition_execution(
+        execution["execution_id"],
+        "terminal_succeeded",
+        now=NOW + timedelta(seconds=1),
+    )
+
+    assert terminal["lifecycle"] == "terminal_succeeded"
+    assert terminal["receipt_state"] == "not_applicable"
+    assert terminal["receipt_id"] is None
+
+
+def test_pending_resolved_expired_and_superseded_decisions(tmp_path):
+    store = _store(tmp_path)
+
+    resolved_execution = _bound_execution(store, suffix="resolved")
+    resolved = _resolved_decision(store, resolved_execution, suffix="resolved")
+    assert resolved["state"] == "resolved"
+    assert resolved["choice"] == "once"
+    assert resolved["resolution_evidence_digest"] == _digest("resolution-resolved")
+
+    expiring_execution = _bound_execution(store, suffix="expired")
+    expiring = store.create_decision(
+        execution_id=expiring_execution["execution_id"],
+        effect_id=expiring_execution["effect_id"],
+        proposal_ref=expiring_execution["proposal_ref"],
+        request_digest=_digest("request-expired"),
+        allowed_choices=["once", "deny"],
+        expires_at=NOW + timedelta(seconds=1),
+        now=NOW,
+    )
+    assert store.expire_decisions(now=NOW + timedelta(seconds=2)) == [
+        expiring["decision_id"]
+    ]
+    assert store.get_decision(expiring["decision_id"])["state"] == "expired"
+    assert store.get_execution(expiring_execution["execution_id"])["lifecycle"] == (
+        "terminal_ambiguous"
+    )
+
+    superseded_execution = _bound_execution(store, suffix="superseded")
+    superseded = store.create_decision(
+        execution_id=superseded_execution["execution_id"],
+        effect_id=superseded_execution["effect_id"],
+        proposal_ref=superseded_execution["proposal_ref"],
+        request_digest=_digest("request-superseded"),
+        allowed_choices=["once", "deny"],
+        expires_at=NOW + timedelta(minutes=5),
+        now=NOW,
+    )
+    superseded = store.supersede_decision(
+        superseded["decision_id"],
+        reason_code="proposal_replaced",
+        now=NOW + timedelta(seconds=1),
+    )
+    assert superseded["state"] == "superseded"
+    assert store.list_decisions(state="pending")["items"] == []
+
+
+def test_one_pending_decision_and_terminalization_closes_it(tmp_path):
+    store = _store(tmp_path)
+    execution = _bound_execution(store)
+    decision = store.create_decision(
+        execution_id=execution["execution_id"],
+        effect_id=execution["effect_id"],
+        proposal_ref=execution["proposal_ref"],
+        request_digest=_digest("request-first"),
+        allowed_choices=["once", "deny"],
+        expires_at=NOW + timedelta(minutes=5),
+        now=NOW,
+    )
+    with pytest.raises(ContractConflictError, match="already has a pending"):
+        store.create_decision(
+            execution_id=execution["execution_id"],
+            effect_id=execution["effect_id"],
+            proposal_ref=execution["proposal_ref"],
+            request_digest=_digest("request-second"),
+            allowed_choices=["once", "deny"],
+            expires_at=NOW + timedelta(minutes=5),
+            now=NOW,
+        )
+
+    terminal = store.transition_execution(
+        execution["execution_id"],
+        "terminal_failed",
+        now=NOW + timedelta(seconds=1),
+    )
+    assert terminal["lifecycle"] == "terminal_ambiguous"
+    assert store.get_decision(decision["decision_id"])["state"] == "superseded"
+    assert store.expire_decisions(now=NOW + timedelta(minutes=10)) == []
+
+
+def test_decision_and_effect_bindings_fail_closed(tmp_path):
+    store = _store(tmp_path)
+    first = _bound_execution(store, suffix="first")
+    second = _bound_execution(store, suffix="second")
+
+    with pytest.raises(ContractConflictError, match="effect binding"):
+        store.create_decision(
+            execution_id=first["execution_id"],
+            effect_id=second["effect_id"],
+            proposal_ref=first["proposal_ref"],
+            request_digest=_digest("wrong-effect"),
+            allowed_choices=["once", "deny"],
+            expires_at=NOW + timedelta(minutes=5),
+            now=NOW,
+        )
+
+    decision = _resolved_decision(store, first, suffix="first")
+    with pytest.raises(ContractConflictError, match="exact decision"):
+        _record_evidence(store, first, decision_id=None)
+    with pytest.raises(ContractConflictError, match="not bound"):
+        _record_evidence(
+            store,
+            first,
+            decision_id="dec_"
+            + store.authority.profile_key
+            + "_"
+            + "f" * 32,
+        )
+    with pytest.raises(ContractConflictError, match="effect evidence binding"):
+        store.record_effect_evidence(
+            execution_id=first["execution_id"],
+            effect_id="effect:wrong",
+            outcome="succeeded",
+            subject_digest=_digest("subject"),
+            evidence_digest=_digest("evidence"),
+            result_digest=_digest("result"),
+            decision_id=decision["decision_id"],
+            now=NOW,
+        )
+
+
+def test_duplicate_evidence_is_idempotent_and_conflict_is_rejected(tmp_path):
+    store = _store(tmp_path)
+    execution = _bound_execution(store)
+    first = _record_evidence(store, execution)
+    duplicate = _record_evidence(store, execution)
+    assert duplicate == first
+
+    with pytest.raises(ContractConflictError, match="conflicting effect evidence"):
+        _record_evidence(store, execution, outcome="partial")
+
+
+def test_optimistic_revision_and_out_of_order_lifecycle_fail_closed(tmp_path):
+    store = _store(tmp_path)
+    execution = store.create_execution(lifecycle="queued", now=NOW)
+
+    running = store.transition_execution(
+        execution["execution_id"],
+        "running",
+        expected_revision=1,
+        now=NOW + timedelta(seconds=1),
+    )
+    with pytest.raises(ContractConflictError, match="revision"):
+        store.transition_execution(
+            execution["execution_id"],
+            "cancellation_requested",
+            expected_revision=1,
+            now=NOW + timedelta(seconds=2),
+        )
+    terminal = store.transition_execution(
+        execution["execution_id"],
+        "terminal_failed",
+        expected_revision=running["revision"],
+        now=NOW + timedelta(seconds=2),
+    )
+    with pytest.raises(ContractConflictError, match="invalid execution transition"):
+        store.transition_execution(
+            terminal["execution_id"],
+            "running",
+            now=NOW + timedelta(seconds=3),
+        )
+
+
+def test_transaction_rolls_back_state_when_event_append_fails(tmp_path, monkeypatch):
+    store = _store(tmp_path)
+    execution = store.create_execution(lifecycle="queued", now=NOW)
+
+    def fail_event(*_args, **_kwargs):
+        raise RuntimeError("synthetic crash boundary")
+
+    monkeypatch.setattr(store, "_append_event_in_txn", fail_event)
+    with pytest.raises(RuntimeError, match="synthetic crash"):
+        store.transition_execution(
+            execution["execution_id"],
+            "running",
+            now=NOW + timedelta(seconds=1),
+        )
+
+    reopened = _store(tmp_path)
+    current = reopened.get_execution(execution["execution_id"])
+    assert current["lifecycle"] == "queued"
+    assert current["revision"] == 1
+    assert len(reopened.list_events()["items"]) == 1
+
+
+def test_terminal_receipt_and_event_roll_back_together(tmp_path, monkeypatch):
+    store = _store(tmp_path)
+    execution = _bound_execution(store)
+    store.transition_execution(execution["execution_id"], "running", now=NOW)
+    _record_evidence(store, execution)
+    original_append = store._append_event_in_txn
+
+    def fail_terminal_event(*args, **kwargs):
+        if kwargs.get("event_type") == "execution.transitioned":
+            raise RuntimeError("synthetic crash after receipt insert")
+        return original_append(*args, **kwargs)
+
+    monkeypatch.setattr(store, "_append_event_in_txn", fail_terminal_event)
+    with pytest.raises(RuntimeError, match="after receipt insert"):
+        store.transition_execution(
+            execution["execution_id"],
+            "terminal_succeeded",
+            now=NOW + timedelta(seconds=3),
+        )
+
+    reopened = _store(tmp_path)
+    current = reopened.get_execution(execution["execution_id"])
+    assert current["lifecycle"] == "running"
+    assert current["receipt_state"] == "pending_evidence"
+    assert reopened.list_receipts()["items"] == []
+
+
+def test_restart_marks_orphaned_nonterminal_execution_ambiguous(tmp_path):
+    first_runtime = _store(tmp_path, runtime="runtime-a")
+    execution = first_runtime.create_execution(lifecycle="running", now=NOW)
+
+    second_runtime = _store(tmp_path, runtime="runtime-b")
+    before = second_runtime.get_execution(execution["execution_id"])
+    assert before["freshness"] == "stale"
+
+    recovered = second_runtime.recover_orphaned_executions(
+        recovery_ref="restart:test",
+        now=NOW + timedelta(seconds=1),
+    )
+
+    assert recovered == [execution["execution_id"]]
+    after = second_runtime.get_execution(execution["execution_id"])
+    assert after["lifecycle"] == "terminal_ambiguous"
+    assert after["freshness"] == "terminal"
+    assert after["recovery_ref"] == "restart:test"
+
+
+def test_concurrent_append_has_monotonic_unique_sequences_and_pagination(tmp_path):
+    path = tmp_path / "shared" / "execution_contract.sqlite3"
+
+    def create(index: int) -> str:
+        store = ExecutionContractStore(
+            database_path=path,
+            profile_name="default",
+            runtime_instance_id="runtime-a",
+        )
+        return store.create_execution(
+            lifecycle="queued",
+            source_run_id=f"run-{index}",
+            now=NOW + timedelta(microseconds=index),
+        )["execution_id"]
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=6) as pool:
+        ids = list(pool.map(create, range(24)))
+
+    assert len(set(ids)) == 24
+    store = ExecutionContractStore(
+        database_path=path,
+        profile_name="default",
+        runtime_instance_id="runtime-a",
+    )
+    first = store.list_events(limit=7)
+    second = store.list_events(after=first["page"]["cursor"], limit=200)
+    sequences = [event["sequence"] for event in first["items"] + second["items"]]
+    assert sequences == sorted(sequences)
+    assert len(sequences) == len(set(sequences)) == 24
+    assert first["page"]["has_more"] is True
+    assert second["page"]["high_water"] == sequences[-1]
+    assert second["page"]["has_more"] is False
+
+
+def test_pruned_cursor_returns_explicit_gap(tmp_path):
+    store = _store(tmp_path)
+    old = NOW - timedelta(days=40)
+    execution = store.create_execution(lifecycle="running", now=old)
+    store.transition_execution(
+        execution["execution_id"],
+        "terminal_failed",
+        now=old + timedelta(seconds=1),
+    )
+    assert store.prune_events(now=NOW) == 2
+
+    with pytest.raises(ContractCursorGoneError) as exc:
+        store.list_events(after=0)
+    assert exc.value.minimum_available == 3
+    assert exc.value.high_water == 2
+
+
+def test_retention_does_not_prune_across_a_live_execution_gap(tmp_path):
+    store = _store(tmp_path)
+    old = NOW - timedelta(days=40)
+    live = store.create_execution(lifecycle="running", now=old)
+    terminal = store.create_execution(lifecycle="running", now=old)
+    store.transition_execution(
+        terminal["execution_id"],
+        "terminal_failed",
+        now=old + timedelta(seconds=1),
+    )
+
+    assert store.prune_events(now=NOW) == 0
+    events = store.list_events(after=0)["items"]
+    assert events[0]["execution_id"] == live["execution_id"]
+    assert len(events) == 3
+
+
+def test_profile_crossing_and_malformed_identifiers_are_distinct(tmp_path):
+    first = _store(tmp_path, profile="first")
+    second = _store(tmp_path, profile="second")
+    execution = first.create_execution(lifecycle="queued", now=NOW)
+
+    with pytest.raises(ContractForbiddenError):
+        second.get_execution(execution["execution_id"])
+    with pytest.raises(ContractValidationError):
+        first.get_execution("run_not-an-execution-id")
+
+
+def test_store_file_is_bound_to_exact_profile_authority(tmp_path):
+    path = tmp_path / "shared" / "execution_contract.sqlite3"
+    first = ExecutionContractStore(
+        database_path=path,
+        profile_name="first",
+        runtime_instance_id="runtime-a",
+    )
+    first.create_execution(lifecycle="queued", now=NOW)
+    misplaced = ExecutionContractStore(
+        database_path=path,
+        profile_name="second",
+        runtime_instance_id="runtime-a",
+    )
+
+    with pytest.raises(ContractDataError, match="authority metadata"):
+        misplaced.list_executions()
+    with pytest.raises(ContractDataError, match="authority metadata"):
+        misplaced.initialize()
+
+
+def test_malformed_persisted_state_and_cursor_ahead_fail_closed(tmp_path):
+    store = _store(tmp_path)
+    execution = store.create_execution(lifecycle="queued", now=NOW)
+    with sqlite3.connect(store.database_path) as connection:
+        connection.execute("PRAGMA ignore_check_constraints=ON")
+        connection.execute(
+            "UPDATE executions SET lifecycle='future_state' WHERE execution_id=?",
+            (execution["execution_id"],),
+        )
+        connection.commit()
+
+    with pytest.raises(ContractDataError, match="unknown state"):
+        store.get_execution(execution["execution_id"])
+    with pytest.raises(ContractConflictError, match="cursor"):
+        store.list_events(after=999)
+
+
+def test_closed_reference_and_digest_validation(tmp_path):
+    store = _store(tmp_path)
+    with pytest.raises(ContractValidationError):
+        store.create_execution(lifecycle="queued", work_ref="bad\nref", now=NOW)
+    with pytest.raises(ContractValidationError, match="exact work_ref"):
+        store.create_execution(
+            lifecycle="queued",
+            effect_id="effect:unbound",
+            now=NOW,
+        )
+    with pytest.raises(ContractValidationError, match="timezone-aware"):
+        store.create_execution(
+            lifecycle="queued",
+            now=datetime(2026, 8, 15, 12, 0),
+        )
+    execution = _bound_execution(store)
+    with pytest.raises(ContractValidationError, match="SHA-256"):
+        store.record_effect_evidence(
+            execution_id=execution["execution_id"],
+            effect_id=execution["effect_id"],
+            outcome="succeeded",
+            subject_digest="not-a-digest",
+            evidence_digest=_digest("evidence"),
+            result_digest=_digest("result"),
+            now=NOW,
+        )
+    assert CONTRACT_VERSION == execution["contract_version"]

--- a/tests/hermes_cli/test_execution_contract.py
+++ b/tests/hermes_cli/test_execution_contract.py
@@ -610,6 +610,108 @@ def test_retention_does_not_prune_across_a_live_execution_gap(tmp_path):
     assert len(events) == 3
 
 
+@pytest.mark.parametrize("missing_sequence", [1, 2, 4])
+def test_prune_rejects_global_gap_without_mutating_rows_or_watermark(
+    tmp_path,
+    missing_sequence,
+):
+    store = _store(tmp_path)
+    old = NOW - timedelta(days=40)
+    executions = []
+    for index in range(2):
+        execution = store.create_execution(
+            lifecycle="running",
+            source_run_id=f"prune-gap-{index}",
+            now=old + timedelta(microseconds=index),
+        )
+        executions.append(execution)
+        store.transition_execution(
+            execution["execution_id"],
+            "terminal_failed",
+            now=old + timedelta(seconds=1, microseconds=index),
+        )
+
+    with sqlite3.connect(store.database_path) as connection:
+        connection.execute(
+            "DELETE FROM execution_events WHERE sequence=?",
+            (missing_sequence,),
+        )
+        connection.commit()
+        before_rows = connection.execute(
+            "SELECT sequence, event_id FROM execution_events ORDER BY sequence"
+        ).fetchall()
+        before_watermark = connection.execute(
+            "SELECT value FROM execution_contract_metadata "
+            "WHERE key='events_pruned_through'"
+        ).fetchone()[0]
+
+    with pytest.raises(ContractDataError, match="event sequence gap"):
+        store.prune_events(now=NOW)
+
+    with sqlite3.connect(store.database_path) as connection:
+        assert connection.execute(
+            "SELECT sequence, event_id FROM execution_events ORDER BY sequence"
+        ).fetchall() == before_rows
+        assert connection.execute(
+            "SELECT value FROM execution_contract_metadata "
+            "WHERE key='events_pruned_through'"
+        ).fetchone()[0] == before_watermark == "0"
+
+    with pytest.raises(ContractDataError, match="event sequence gap"):
+        store.list_events()
+    with pytest.raises(ContractDataError, match="event sequence gap"):
+        store.list_events(execution_id=executions[0]["execution_id"])
+
+
+def test_prune_boundary_excludes_append_waiting_on_same_write_lock(tmp_path):
+    seed = _store(tmp_path, runtime="prune-race")
+    old = NOW - timedelta(days=40)
+    execution = seed.create_execution(lifecycle="running", now=old)
+    seed.transition_execution(
+        execution["execution_id"],
+        "terminal_failed",
+        now=old + timedelta(seconds=1),
+    )
+    pruner = _store(tmp_path, runtime="prune-race")
+    writer = _store(tmp_path, runtime="prune-race")
+    prune_locked = threading.Event()
+    release_prune = threading.Event()
+    writer_attempted = threading.Event()
+
+    def hold_prune(operation, _execution_id):
+        if operation == "prune":
+            prune_locked.set()
+            assert release_prune.wait(timeout=5)
+
+    pruner._after_write_lock_acquired = hold_prune
+
+    def append_event():
+        writer_attempted.set()
+        return writer.create_execution(
+            lifecycle="queued",
+            source_run_id="after-prune-boundary",
+            now=NOW,
+        )
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=2) as pool:
+        prune_future = pool.submit(pruner.prune_events, now=NOW)
+        assert prune_locked.wait(timeout=5)
+        append_future = pool.submit(append_event)
+        assert writer_attempted.wait(timeout=5)
+        assert not append_future.done()
+        release_prune.set()
+        assert prune_future.result(timeout=10) == 2
+        appended = append_future.result(timeout=10)
+
+    page = seed.list_events(after=2)
+    assert [event["execution_id"] for event in page["items"]] == [
+        appended["execution_id"]
+    ]
+    assert page["page"]["pruned_through"] == 2
+    assert page["page"]["snapshot_high_water"] == 3
+    assert page["page"]["completeness"] == "complete"
+
+
 def test_profile_crossing_and_malformed_identifiers_are_distinct(tmp_path):
     first = _store(tmp_path, profile="first")
     second = _store(tmp_path, profile="second")
@@ -986,6 +1088,79 @@ def test_evidence_blocks_new_decisions_but_preserves_idempotent_resolved_retry(
         )
 
 
+@pytest.mark.parametrize(
+    ("case", "expected_state"),
+    [
+        ("pending", "pending"),
+        ("expired", "expired"),
+        ("resolved", "resolved"),
+        ("superseded", "superseded"),
+        ("evidence", "resolved"),
+        ("receipt", "resolved"),
+    ],
+)
+def test_exact_decision_retry_remains_idempotent_after_expiry_and_effects(
+    tmp_path,
+    case,
+    expected_state,
+):
+    store = _store(tmp_path)
+    execution = _bound_execution(store, suffix=f"retry-{case}")
+    expires_at = NOW + timedelta(seconds=1)
+    request_digest = _digest(f"retry-{case}")
+    create = {
+        "execution_id": execution["execution_id"],
+        "effect_id": execution["effect_id"],
+        "proposal_ref": execution["proposal_ref"],
+        "request_digest": request_digest,
+        "candidate_digest": _digest(f"candidate-retry-{case}"),
+        "policy_digest": _digest(f"policy-retry-{case}"),
+        "allowed_choices": ["once", "deny"],
+        "expires_at": expires_at,
+    }
+    decision = store.create_decision(**create, now=NOW)
+
+    if case == "expired":
+        assert store.expire_decisions(now=NOW + timedelta(seconds=2)) == [
+            decision["decision_id"]
+        ]
+    elif case in {"resolved", "evidence", "receipt"}:
+        decision = store.resolve_decision(
+            decision["decision_id"],
+            choice="once",
+            resolution_evidence_digest=_digest(f"resolution-retry-{case}"),
+            now=NOW + timedelta(microseconds=500_000),
+        )
+        if case in {"evidence", "receipt"}:
+            _record_evidence(
+                store,
+                execution,
+                decision_id=decision["decision_id"],
+                suffix=f"retry-{case}",
+            )
+        if case == "receipt":
+            store.transition_execution(
+                execution["execution_id"],
+                "terminal_succeeded",
+                now=NOW + timedelta(seconds=3),
+            )
+    elif case == "superseded":
+        decision = store.supersede_decision(
+            decision["decision_id"],
+            reason_code="retry-test",
+            now=NOW + timedelta(microseconds=500_000),
+        )
+
+    exact = store.create_decision(**create, now=NOW + timedelta(days=1))
+    assert exact["decision_id"] == decision["decision_id"]
+    assert exact["state"] == expected_state
+
+    conflicting = dict(create)
+    conflicting["allowed_choices"] = ["once", "deny", "always"]
+    with pytest.raises(ContractConflictError, match="conflicting bindings"):
+        store.create_decision(**conflicting, now=NOW + timedelta(days=1))
+
+
 @pytest.mark.parametrize("first_operation", ["decision", "evidence"])
 def test_decision_and_evidence_race_is_serialized_by_write_transaction(
     tmp_path,
@@ -1311,6 +1486,92 @@ def test_late_ambiguous_evidence_publishes_receipt_transactionally(tmp_path):
             recovery_ref="recovery:conflicting-retry",
             reconciliation_ref="reconcile:late-ambiguous",
             now=NOW + timedelta(seconds=4),
+        )
+
+
+@pytest.mark.parametrize("offset_seconds", [-86400, 0, 86400])
+def test_normal_receipt_terminal_timestamp_must_equal_execution_terminal(
+    tmp_path,
+    offset_seconds,
+):
+    store = _store(tmp_path)
+    execution = _bound_execution(store, suffix=f"receipt-time-{offset_seconds}")
+    _record_evidence(
+        store,
+        execution,
+        suffix=f"receipt-time-{offset_seconds}",
+        reconciliation_ref=(
+            "reconcile:ordinary-terminal" if offset_seconds == 0 else None
+        ),
+    )
+    terminal_time = NOW + timedelta(seconds=3)
+    terminal = store.transition_execution(
+        execution["execution_id"],
+        "terminal_succeeded",
+        now=terminal_time,
+    )
+    receipt_id = terminal["receipt_id"]
+    if offset_seconds:
+        changed = (terminal_time + timedelta(seconds=offset_seconds)).isoformat(
+            timespec="microseconds"
+        ).replace("+00:00", "Z")
+        with sqlite3.connect(store.database_path) as connection:
+            connection.execute(
+                "UPDATE receipts SET terminal_at=? WHERE receipt_id=?",
+                (changed, receipt_id),
+            )
+            connection.commit()
+        with pytest.raises(
+            ContractDataError,
+            match="must equal execution terminal timestamp",
+        ):
+            store.get_receipt(receipt_id)
+    else:
+        assert store.get_receipt(receipt_id)["terminal_at"] == terminal["terminal_at"]
+
+
+@pytest.mark.parametrize("offset_seconds", [-1, 0, 1])
+def test_reconciled_receipt_terminal_timestamp_must_equal_evidence_recorded_at(
+    tmp_path,
+    offset_seconds,
+):
+    store = _store(tmp_path)
+    execution = _bound_execution(store, suffix=f"reconcile-time-{offset_seconds}")
+    store.transition_execution(
+        execution["execution_id"],
+        "terminal_failed",
+        recovery_ref=f"recovery:reconcile-time-{offset_seconds}",
+        now=NOW + timedelta(seconds=1),
+    )
+    evidence_time = NOW + timedelta(seconds=2)
+    receipt = store.reconcile_ambiguous_evidence(
+        execution_id=execution["execution_id"],
+        effect_id=execution["effect_id"],
+        outcome="ambiguous",
+        subject_digest=_digest(f"reconcile-subject-{offset_seconds}"),
+        evidence_digest=_digest(f"reconcile-evidence-{offset_seconds}"),
+        result_digest=_digest(f"reconcile-result-{offset_seconds}"),
+        reconciliation_ref=f"reconcile:timestamp-{offset_seconds}",
+        now=evidence_time,
+    )
+    if offset_seconds:
+        changed = (evidence_time + timedelta(seconds=offset_seconds)).isoformat(
+            timespec="microseconds"
+        ).replace("+00:00", "Z")
+        with sqlite3.connect(store.database_path) as connection:
+            connection.execute(
+                "UPDATE receipts SET terminal_at=? WHERE receipt_id=?",
+                (changed, receipt["receipt_id"]),
+            )
+            connection.commit()
+        with pytest.raises(
+            ContractDataError,
+            match="must equal evidence recorded timestamp",
+        ):
+            store.get_receipt(receipt["receipt_id"])
+    else:
+        assert store.get_receipt(receipt["receipt_id"])["terminal_at"] == (
+            evidence_time.isoformat(timespec="microseconds").replace("+00:00", "Z")
         )
 
 

--- a/tests/hermes_cli/test_execution_contract.py
+++ b/tests/hermes_cli/test_execution_contract.py
@@ -6,6 +6,7 @@ import concurrent.futures
 import json
 import os
 import sqlite3
+import threading
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
@@ -105,6 +106,7 @@ def test_absent_read_is_side_effect_free_then_create_reopen_and_migrate(tmp_path
     assert empty["page"] == {
         "cursor": 0,
         "high_water": 0,
+        "snapshot_high_water": 0,
         "minimum_available": 0,
         "has_more": False,
         "completeness": "complete",
@@ -149,10 +151,19 @@ def test_packaged_schema_and_synthetic_fixtures_are_closed():
             assert item_definition["additionalProperties"] is False
             assert set(payload[collection][0]) == set(item_definition["required"])
 
-    capabilities = contract_capabilities("synthetic")
-    assert capabilities == json.loads(
+    capabilities = contract_capabilities(Path("/synthetic/profile"), "synthetic")
+    fixture_capabilities = json.loads(
         (FIXTURES / "capabilities.json").read_text(encoding="utf-8")
     )
+    assert capabilities["authority"]["profile_name"] == "synthetic"
+    assert capabilities["authority"]["profile_id"].startswith(
+        "hermes-profile-instance:"
+    )
+    assert {
+        key: value for key, value in capabilities.items() if key != "authority"
+    } == {
+        key: value for key, value in fixture_capabilities.items() if key != "authority"
+    }
     assert schema["$defs"]["errorDetail"]["additionalProperties"] is False
 
 
@@ -594,13 +605,13 @@ def test_store_file_is_bound_to_exact_profile_authority(tmp_path):
     path = tmp_path / "shared" / "execution_contract.sqlite3"
     first = ExecutionContractStore(
         database_path=path,
-        profile_name="first",
+        profile_home=tmp_path / "first-home",
         runtime_instance_id="runtime-a",
     )
     first.create_execution(lifecycle="queued", now=NOW)
     misplaced = ExecutionContractStore(
         database_path=path,
-        profile_name="second",
+        profile_home=tmp_path / "second-home",
         runtime_instance_id="runtime-a",
     )
 
@@ -654,3 +665,344 @@ def test_closed_reference_and_digest_validation(tmp_path):
             now=NOW,
         )
     assert CONTRACT_VERSION == execution["contract_version"]
+
+
+def test_restart_recovery_transactionally_supersedes_pending_decision(tmp_path):
+    first_runtime = _store(tmp_path, runtime="runtime-a")
+    execution = _bound_execution(first_runtime, suffix="restart-pending")
+    decision = first_runtime.create_decision(
+        execution_id=execution["execution_id"],
+        effect_id=execution["effect_id"],
+        proposal_ref=execution["proposal_ref"],
+        request_digest=_digest("restart-pending"),
+        allowed_choices=["once", "deny"],
+        expires_at=NOW + timedelta(minutes=5),
+        now=NOW,
+    )
+
+    second_runtime = _store(tmp_path, runtime="runtime-b")
+    assert second_runtime.recover_orphaned_executions(
+        recovery_ref="restart:pending",
+        now=NOW + timedelta(seconds=1),
+    ) == [execution["execution_id"]]
+
+    assert second_runtime.get_execution(execution["execution_id"])["lifecycle"] == (
+        "terminal_ambiguous"
+    )
+    assert second_runtime.get_decision(decision["decision_id"])["state"] == (
+        "superseded"
+    )
+    assert second_runtime.list_decisions(state="pending")["items"] == []
+
+
+def test_decision_request_racing_cancellation_never_leaves_pending(tmp_path):
+    seed = _store(tmp_path, runtime="runtime-race")
+    execution = _bound_execution(seed, suffix="cancel-race")
+    seed.transition_execution(execution["execution_id"], "running", now=NOW)
+    decision_store = _store(tmp_path, runtime="runtime-race")
+    cancel_store = _store(tmp_path, runtime="runtime-race")
+    barrier = threading.Barrier(2)
+
+    def request_decision():
+        barrier.wait()
+        try:
+            return decision_store.create_decision(
+                execution_id=execution["execution_id"],
+                effect_id=execution["effect_id"],
+                proposal_ref=execution["proposal_ref"],
+                request_digest=_digest("cancel-race"),
+                allowed_choices=["once", "deny"],
+                expires_at=NOW + timedelta(minutes=5),
+                now=NOW,
+            )
+        except ContractConflictError:
+            return None
+
+    def request_cancel():
+        barrier.wait()
+        return cancel_store.transition_execution(
+            execution["execution_id"],
+            "cancellation_requested",
+            now=NOW + timedelta(seconds=1),
+        )
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=2) as pool:
+        decision_future = pool.submit(request_decision)
+        cancel_future = pool.submit(request_cancel)
+        decision_result = decision_future.result()
+        cancel_future.result()
+
+    current = seed.get_execution(execution["execution_id"])
+    assert current["lifecycle"] == "cancellation_requested"
+    assert seed.list_decisions(state="pending")["items"] == []
+    if decision_result is not None:
+        assert seed.get_decision(decision_result["decision_id"])["state"] == (
+            "superseded"
+        )
+
+
+@pytest.mark.parametrize("operation", ["resolve", "supersede"])
+def test_decision_close_cannot_revive_terminal_execution(tmp_path, operation):
+    store = _store(tmp_path)
+    execution = _bound_execution(store, suffix=f"terminal-{operation}")
+    decision = store.create_decision(
+        execution_id=execution["execution_id"],
+        effect_id=execution["effect_id"],
+        proposal_ref=execution["proposal_ref"],
+        request_digest=_digest(f"terminal-{operation}"),
+        allowed_choices=["once", "deny"],
+        expires_at=NOW + timedelta(minutes=5),
+        now=NOW,
+    )
+    terminal = "2026-08-15T12:00:01.000000Z"
+    with sqlite3.connect(store.database_path) as connection:
+        connection.execute(
+            "UPDATE executions SET lifecycle='terminal_ambiguous', "
+            "receipt_state='unproven', terminal_at=?, updated_at=? "
+            "WHERE execution_id=?",
+            (terminal, terminal, execution["execution_id"]),
+        )
+        connection.commit()
+
+    with pytest.raises(ContractConflictError, match="terminal_ambiguous"):
+        if operation == "resolve":
+            store.resolve_decision(
+                decision["decision_id"],
+                choice="once",
+                resolution_evidence_digest=_digest("terminal-resolution"),
+                now=NOW + timedelta(seconds=2),
+            )
+        else:
+            store.supersede_decision(
+                decision["decision_id"],
+                reason_code="terminal",
+                now=NOW + timedelta(seconds=2),
+            )
+    with sqlite3.connect(store.database_path) as connection:
+        assert connection.execute(
+            "SELECT lifecycle FROM executions WHERE execution_id=?",
+            (execution["execution_id"],),
+        ).fetchone()[0] == "terminal_ambiguous"
+        assert connection.execute(
+            "SELECT state FROM decisions WHERE decision_id=?",
+            (decision["decision_id"],),
+        ).fetchone()[0] == "pending"
+
+
+def test_old_resolution_cannot_authorize_newer_pending_decision(tmp_path):
+    store = _store(tmp_path)
+    execution = _bound_execution(store, suffix="decision-generation")
+    old = _resolved_decision(store, execution, suffix="old")
+    newer = store.create_decision(
+        execution_id=execution["execution_id"],
+        effect_id=execution["effect_id"],
+        proposal_ref=execution["proposal_ref"],
+        request_digest=_digest("request-newer"),
+        allowed_choices=["once", "deny"],
+        expires_at=NOW + timedelta(minutes=5),
+        now=NOW + timedelta(seconds=2),
+    )
+
+    with pytest.raises(ContractConflictError, match="newer pending"):
+        _record_evidence(
+            store,
+            execution,
+            decision_id=old["decision_id"],
+            suffix="old-resolution",
+        )
+    assert store.get_decision(newer["decision_id"])["state"] == "pending"
+
+
+def test_collection_snapshot_excludes_concurrent_insert(monkeypatch, tmp_path):
+    import hermes_state
+
+    monkeypatch.setattr(
+        hermes_state,
+        "apply_wal_with_fallback",
+        lambda connection, **_kwargs: connection.execute("PRAGMA journal_mode=WAL"),
+    )
+    store = _store(tmp_path)
+    writer = _store(tmp_path)
+    store.create_execution(lifecycle="queued", source_run_id="snapshot-1", now=NOW)
+    store.create_execution(lifecycle="queued", source_run_id="snapshot-2", now=NOW)
+    writer.initialize()
+    inserted = []
+
+    def append_after_pin(collection, _high_water):
+        if collection == "executions" and not inserted:
+            inserted.append(
+                writer.create_execution(
+                    lifecycle="queued",
+                    source_run_id="snapshot-concurrent",
+                    now=NOW,
+                )
+            )
+
+    store._after_snapshot_pinned = append_after_pin
+    first = store.list_executions(limit=1)
+    assert first["page"]["snapshot_high_water"] == 2
+    assert inserted
+    store._after_snapshot_pinned = lambda *_args: None
+    second = store.list_executions(
+        after=first["page"]["cursor"],
+        snapshot_high_water=first["page"]["snapshot_high_water"],
+    )
+    source_ids = [item["source_run_id"] for item in first["items"] + second["items"]]
+    assert source_ids == ["snapshot-1", "snapshot-2"]
+    assert "snapshot-concurrent" not in source_ids
+
+
+def test_event_snapshot_excludes_append_after_high_water(monkeypatch, tmp_path):
+    import hermes_state
+
+    monkeypatch.setattr(
+        hermes_state,
+        "apply_wal_with_fallback",
+        lambda connection, **_kwargs: connection.execute("PRAGMA journal_mode=WAL"),
+    )
+    store = _store(tmp_path)
+    writer = _store(tmp_path)
+    first_execution = store.create_execution(lifecycle="queued", now=NOW)
+    second_execution = store.create_execution(lifecycle="queued", now=NOW)
+    writer.initialize()
+    appended = []
+
+    def append_after_pin(collection, _high_water):
+        if collection == "events" and not appended:
+            appended.append(
+                writer.transition_execution(
+                    second_execution["execution_id"],
+                    "running",
+                    now=NOW + timedelta(seconds=1),
+                )
+            )
+
+    store._after_snapshot_pinned = append_after_pin
+    page = store.list_events(limit=200)
+    assert page["page"]["snapshot_high_water"] == 2
+    assert appended
+    assert [event["execution_id"] for event in page["items"]] == [
+        first_execution["execution_id"],
+        second_execution["execution_id"],
+    ]
+
+
+def test_late_ambiguous_evidence_publishes_receipt_transactionally(tmp_path):
+    store = _store(tmp_path)
+    execution = _bound_execution(store, suffix="late-ambiguous")
+    terminal = store.transition_execution(
+        execution["execution_id"],
+        "terminal_failed",
+        now=NOW + timedelta(seconds=1),
+    )
+    assert terminal["lifecycle"] == "terminal_ambiguous"
+    assert terminal["receipt_state"] == "unproven"
+
+    with pytest.raises(ContractConflictError, match="reconciliation path"):
+        _record_evidence(store, execution, outcome="ambiguous", suffix="late")
+
+    receipt = store.reconcile_ambiguous_evidence(
+        execution_id=execution["execution_id"],
+        effect_id=execution["effect_id"],
+        outcome="ambiguous",
+        subject_digest=_digest("late-subject"),
+        evidence_digest=_digest("late-evidence"),
+        result_digest=_digest("late-result"),
+        reconciliation_ref="reconcile:late-ambiguous",
+        now=NOW + timedelta(seconds=2),
+    )
+    current = store.get_execution(execution["execution_id"])
+    assert receipt["outcome"] == "ambiguous"
+    assert current["lifecycle"] == "terminal_ambiguous"
+    assert current["receipt_state"] == "published"
+    assert current["receipt_id"] == receipt["receipt_id"]
+    assert store.get_receipt(receipt["receipt_id"])["reconciliation_ref"] == (
+        "reconcile:late-ambiguous"
+    )
+
+
+@pytest.mark.parametrize(
+    ("case", "message"),
+    [
+        ("execution_id", "identifier"),
+        ("execution_timestamp", "timestamp ordering"),
+        ("execution_receipt_state", "receipt"),
+        ("decision_digest", "request_digest"),
+        ("decision_binding", "binding"),
+        ("receipt_digest", "evidence_digest"),
+    ],
+)
+def test_deep_persisted_corruption_fails_before_projection(tmp_path, case, message):
+    store = _store(tmp_path)
+    execution = _bound_execution(store, suffix=case)
+    target = "execution"
+    target_id = execution["execution_id"]
+
+    if case.startswith("decision_"):
+        decision = store.create_decision(
+            execution_id=execution["execution_id"],
+            effect_id=execution["effect_id"],
+            proposal_ref=execution["proposal_ref"],
+            request_digest=_digest(f"request-{case}"),
+            allowed_choices=["once", "deny"],
+            expires_at=NOW + timedelta(minutes=5),
+            now=NOW,
+        )
+        target = "decision"
+        target_id = decision["decision_id"]
+    elif case == "receipt_digest":
+        evidence = _record_evidence(store, execution, suffix=case)
+        assert evidence["outcome"] == "succeeded"
+        terminal = store.transition_execution(
+            execution["execution_id"],
+            "terminal_succeeded",
+            now=NOW + timedelta(seconds=3),
+        )
+        target = "receipt"
+        target_id = terminal["receipt_id"]
+
+    with sqlite3.connect(store.database_path) as connection:
+        if case == "execution_id":
+            connection.execute(
+                "UPDATE executions SET execution_id='bad-id' WHERE execution_id=?",
+                (execution["execution_id"],),
+            )
+        elif case == "execution_timestamp":
+            connection.execute(
+                "UPDATE executions SET updated_at='2026-08-14T00:00:00.000000Z' "
+                "WHERE execution_id=?",
+                (execution["execution_id"],),
+            )
+        elif case == "execution_receipt_state":
+            connection.execute(
+                "UPDATE executions SET receipt_state='published', "
+                "receipt_id=? WHERE execution_id=?",
+                (
+                    f"rcp_{store.authority.profile_key}_{'f' * 32}",
+                    execution["execution_id"],
+                ),
+            )
+        elif case == "decision_digest":
+            connection.execute(
+                "UPDATE decisions SET request_digest='bad' WHERE decision_id=?",
+                (target_id,),
+            )
+        elif case == "decision_binding":
+            connection.execute(
+                "UPDATE decisions SET effect_id='effect:other' WHERE decision_id=?",
+                (target_id,),
+            )
+        elif case == "receipt_digest":
+            connection.execute(
+                "UPDATE receipts SET evidence_digest='bad' WHERE receipt_id=?",
+                (target_id,),
+            )
+        connection.commit()
+
+    with pytest.raises(ContractDataError, match=message):
+        if target == "execution":
+            store.list_executions()
+        elif target == "decision":
+            store.get_decision(target_id)
+        else:
+            store.get_receipt(target_id)

--- a/tests/hermes_cli/test_execution_contract.py
+++ b/tests/hermes_cli/test_execution_contract.py
@@ -3,9 +3,12 @@
 from __future__ import annotations
 
 import concurrent.futures
+import hashlib
 import json
 import os
+import shutil
 import sqlite3
+import stat
 import threading
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
@@ -99,6 +102,7 @@ def _record_evidence(
 def test_absent_read_is_side_effect_free_then_create_reopen_and_migrate(tmp_path):
     store = _store(tmp_path)
     assert not store.database_path.exists()
+    assert not store.profile_anchor_path.exists()
 
     empty = store.list_executions()
 
@@ -112,6 +116,7 @@ def test_absent_read_is_side_effect_free_then_create_reopen_and_migrate(tmp_path
         "completeness": "complete",
     }
     assert not store.database_path.exists()
+    assert not store.profile_anchor_path.exists()
 
     execution = store.create_execution(
         lifecycle="accepted",
@@ -122,7 +127,16 @@ def test_absent_read_is_side_effect_free_then_create_reopen_and_migrate(tmp_path
     )
 
     assert store.database_path.exists()
+    assert store.profile_anchor_path.exists()
     assert os.stat(store.database_path).st_mode & 0o077 == 0
+    assert os.stat(store.profile_anchor_path).st_mode & 0o777 == 0o600
+    anchor_payload = json.loads(store.profile_anchor_path.read_text(encoding="utf-8"))
+    assert anchor_payload["version"] == 1
+    assert len(anchor_payload["instance_id"]) == 64
+    assert str(store.profile_home) not in json.dumps(store.authority.public())
+    assert hashlib.sha256(str(store.profile_home).encode()).hexdigest() not in json.dumps(
+        store.authority.public()
+    )
     with sqlite3.connect(store.database_path) as connection:
         assert connection.execute("PRAGMA user_version").fetchone()[0] == 1
     reopened = _store(tmp_path)
@@ -130,7 +144,7 @@ def test_absent_read_is_side_effect_free_then_create_reopen_and_migrate(tmp_path
     assert reopened.get_execution(execution["execution_id"])["freshness"] == "live"
 
 
-def test_packaged_schema_and_synthetic_fixtures_are_closed():
+def test_packaged_schema_and_synthetic_fixtures_are_closed(tmp_path):
     schema = contract_schema()
     assert schema["$schema"] == "https://json-schema.org/draft/2020-12/schema"
     fixture_defs = {
@@ -151,7 +165,13 @@ def test_packaged_schema_and_synthetic_fixtures_are_closed():
             assert item_definition["additionalProperties"] is False
             assert set(payload[collection][0]) == set(item_definition["required"])
 
-    capabilities = contract_capabilities(Path("/synthetic/profile"), "synthetic")
+    synthetic_home = tmp_path / "synthetic-profile"
+    synthetic_store = ExecutionContractStore(
+        profile_home=synthetic_home,
+        profile_name="synthetic",
+    )
+    synthetic_store.initialize()
+    capabilities = contract_capabilities(synthetic_home, "synthetic")
     fixture_capabilities = json.loads(
         (FIXTURES / "capabilities.json").read_text(encoding="utf-8")
     )
@@ -169,7 +189,7 @@ def test_packaged_schema_and_synthetic_fixtures_are_closed():
 
 def test_unknown_store_version_fails_closed(tmp_path):
     store = _store(tmp_path)
-    store.database_path.parent.mkdir(parents=True)
+    store.initialize()
     with sqlite3.connect(store.database_path) as connection:
         connection.execute("PRAGMA user_version=99")
 
@@ -594,6 +614,7 @@ def test_profile_crossing_and_malformed_identifiers_are_distinct(tmp_path):
     first = _store(tmp_path, profile="first")
     second = _store(tmp_path, profile="second")
     execution = first.create_execution(lifecycle="queued", now=NOW)
+    second.initialize()
 
     with pytest.raises(ContractForbiddenError):
         second.get_execution(execution["execution_id"])
@@ -601,24 +622,116 @@ def test_profile_crossing_and_malformed_identifiers_are_distinct(tmp_path):
         first.get_execution("run_not-an-execution-id")
 
 
-def test_store_file_is_bound_to_exact_profile_authority(tmp_path):
-    path = tmp_path / "shared" / "execution_contract.sqlite3"
-    first = ExecutionContractStore(
-        database_path=path,
-        profile_home=tmp_path / "first-home",
+def test_concurrent_profile_initialization_creates_one_stable_anchor(tmp_path):
+    profile_home = tmp_path / "concurrent-profile"
+
+    def initialize(_index: int):
+        store = ExecutionContractStore(
+            profile_home=profile_home,
+            runtime_instance_id="runtime-a",
+        )
+        store.initialize()
+        return store.authority
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=8) as pool:
+        authorities = list(pool.map(initialize, range(16)))
+
+    assert len(set(authorities)) == 1
+    anchor = profile_home / ".execution-contract-profile-instance.json"
+    assert anchor.exists()
+    assert stat.S_IMODE(anchor.stat().st_mode) == 0o600
+    payload = json.loads(anchor.read_text(encoding="utf-8"))
+    assert set(payload) == {"version", "instance_id"}
+
+
+def test_full_profile_home_move_and_restore_preserve_authority(tmp_path):
+    original_home = tmp_path / "profile-original"
+    moved_home = tmp_path / "profile-moved"
+    restored_home = tmp_path / "profile-restored"
+    backup_home = tmp_path / "profile-backup"
+    original = ExecutionContractStore(
+        profile_home=original_home,
         runtime_instance_id="runtime-a",
     )
-    first.create_execution(lifecycle="queued", now=NOW)
-    misplaced = ExecutionContractStore(
-        database_path=path,
-        profile_home=tmp_path / "second-home",
+    execution = original.create_execution(lifecycle="queued", now=NOW)
+    original_authority = original.authority
+
+    original_home.rename(moved_home)
+    moved = ExecutionContractStore(
+        profile_home=moved_home,
         runtime_instance_id="runtime-a",
+    )
+    assert moved.get_execution(execution["execution_id"])["execution_id"] == (
+        execution["execution_id"]
+    )
+    assert moved.authority.profile_id == original_authority.profile_id
+    assert moved.authority.authority_id == original_authority.authority_id
+
+    moved_home.rename(restored_home)
+    restored = ExecutionContractStore(
+        profile_home=restored_home,
+        runtime_instance_id="runtime-a",
+    )
+    assert restored.authority.profile_id == original_authority.profile_id
+    assert restored.get_execution(execution["execution_id"])["execution_id"] == (
+        execution["execution_id"]
+    )
+    with sqlite3.connect(restored.database_path) as connection:
+        connection.execute("PRAGMA wal_checkpoint(TRUNCATE)")
+    shutil.copytree(restored_home, backup_home)
+    backup = ExecutionContractStore(
+        profile_home=backup_home,
+        runtime_instance_id="runtime-a",
+    )
+    assert backup.authority.profile_id == original_authority.profile_id
+    assert backup.get_execution(execution["execution_id"])["execution_id"] == (
+        execution["execution_id"]
     )
 
+
+def test_database_only_copy_fails_against_destination_anchor(tmp_path):
+    source_home = tmp_path / "source-profile"
+    destination_home = tmp_path / "destination-profile"
+    source = ExecutionContractStore(profile_home=source_home)
+    source.create_execution(lifecycle="queued", now=NOW)
+    with sqlite3.connect(source.database_path) as connection:
+        connection.execute("PRAGMA wal_checkpoint(TRUNCATE)")
+
+    destination_identity = ExecutionContractStore(
+        profile_home=destination_home,
+        database_path=destination_home / "identity-seed.sqlite3",
+    )
+    destination_identity.initialize()
+    shutil.copy2(source.database_path, destination_home / "execution_contract.sqlite3")
+    copied = ExecutionContractStore(profile_home=destination_home)
+
     with pytest.raises(ContractDataError, match="authority metadata"):
-        misplaced.list_executions()
+        copied.list_executions()
     with pytest.raises(ContractDataError, match="authority metadata"):
-        misplaced.initialize()
+        copied.initialize()
+
+
+@pytest.mark.parametrize("damage", ["missing", "corrupt", "unsafe-mode", "symlink"])
+def test_missing_corrupt_or_unsafe_profile_anchor_fails_closed(tmp_path, damage):
+    store = _store(tmp_path)
+    store.create_execution(lifecycle="queued", now=NOW)
+    anchor = store.profile_anchor_path
+    if damage == "missing":
+        anchor.unlink()
+    elif damage == "corrupt":
+        anchor.write_text('{"version":1,"instance_id":"bad"}\n', encoding="utf-8")
+        anchor.chmod(0o600)
+    elif damage == "unsafe-mode":
+        anchor.chmod(0o644)
+    else:
+        anchor.unlink()
+        anchor.symlink_to(store.database_path)
+
+    reopened = _store(tmp_path)
+    with pytest.raises(ContractDataError, match="profile instance anchor"):
+        reopened.list_executions()
+    with pytest.raises(ContractDataError, match="profile instance anchor"):
+        reopened.initialize()
 
 
 def test_malformed_persisted_state_and_cursor_ahead_fail_closed(tmp_path):
@@ -813,6 +926,159 @@ def test_old_resolution_cannot_authorize_newer_pending_decision(tmp_path):
     assert store.get_decision(newer["decision_id"])["state"] == "pending"
 
 
+def test_evidence_blocks_new_decisions_but_preserves_idempotent_resolved_retry(
+    tmp_path,
+):
+    store = _store(tmp_path)
+    execution = _bound_execution(store, suffix="evidence-decision-gate")
+    resolved = _resolved_decision(store, execution, suffix="evidence-decision-gate")
+    evidence = _record_evidence(
+        store,
+        execution,
+        decision_id=resolved["decision_id"],
+        suffix="evidence-decision-gate",
+    )
+    duplicate = store.create_decision(
+        execution_id=execution["execution_id"],
+        effect_id=execution["effect_id"],
+        proposal_ref=execution["proposal_ref"],
+        request_digest=_digest("request-evidence-decision-gate"),
+        candidate_digest=_digest("candidate-evidence-decision-gate"),
+        policy_digest=_digest("policy-evidence-decision-gate"),
+        allowed_choices=["once", "deny"],
+        expires_at=NOW + timedelta(minutes=5),
+        now=NOW + timedelta(seconds=3),
+    )
+    assert duplicate["decision_id"] == resolved["decision_id"]
+    assert duplicate["state"] == "resolved"
+    assert store.record_effect_evidence(
+        execution_id=execution["execution_id"],
+        effect_id=execution["effect_id"],
+        outcome="succeeded",
+        subject_digest=_digest("subject-evidence-decision-gate"),
+        evidence_digest=_digest("evidence-evidence-decision-gate"),
+        result_digest=_digest("result-evidence-decision-gate"),
+        decision_id=resolved["decision_id"],
+        now=NOW + timedelta(seconds=4),
+    )["evidence_id"] == evidence["evidence_id"]
+
+    with pytest.raises(ContractConflictError, match="no new decision"):
+        store.create_decision(
+            execution_id=execution["execution_id"],
+            effect_id=execution["effect_id"],
+            proposal_ref=execution["proposal_ref"],
+            request_digest=_digest("request-after-evidence"),
+            allowed_choices=["once", "deny"],
+            expires_at=NOW + timedelta(minutes=6),
+            now=NOW + timedelta(seconds=3),
+        )
+    with pytest.raises(ContractConflictError, match="conflicting bindings"):
+        store.create_decision(
+            execution_id=execution["execution_id"],
+            effect_id=execution["effect_id"],
+            proposal_ref=execution["proposal_ref"],
+            request_digest=_digest("request-evidence-decision-gate"),
+            candidate_digest=_digest("candidate-conflict"),
+            policy_digest=_digest("policy-evidence-decision-gate"),
+            allowed_choices=["once", "deny"],
+            expires_at=NOW + timedelta(minutes=5),
+            now=NOW + timedelta(seconds=3),
+        )
+
+
+@pytest.mark.parametrize("first_operation", ["decision", "evidence"])
+def test_decision_and_evidence_race_is_serialized_by_write_transaction(
+    tmp_path,
+    first_operation,
+):
+    seed = _store(tmp_path, runtime="race-runtime")
+    execution = _bound_execution(seed, suffix=f"race-{first_operation}")
+    decision_store = _store(tmp_path, runtime="race-runtime")
+    evidence_store = _store(tmp_path, runtime="race-runtime")
+    first_locked = threading.Event()
+    release_first = threading.Event()
+    second_attempted = threading.Event()
+
+    def hold_first(operation, _execution_id):
+        if operation == first_operation:
+            first_locked.set()
+            assert release_first.wait(timeout=5)
+
+    if first_operation == "decision":
+        decision_store._after_write_lock_acquired = hold_first
+    else:
+        evidence_store._after_write_lock_acquired = hold_first
+
+    def request_decision():
+        if first_operation != "decision":
+            second_attempted.set()
+        return decision_store.create_decision(
+            execution_id=execution["execution_id"],
+            effect_id=execution["effect_id"],
+            proposal_ref=execution["proposal_ref"],
+            request_digest=_digest(f"race-request-{first_operation}"),
+            allowed_choices=["once", "deny"],
+            expires_at=NOW + timedelta(minutes=5),
+            now=NOW,
+        )
+
+    def record_evidence():
+        if first_operation != "evidence":
+            second_attempted.set()
+        return _record_evidence(
+            evidence_store,
+            execution,
+            suffix=f"race-{first_operation}",
+        )
+
+    first_call = request_decision if first_operation == "decision" else record_evidence
+    second_call = record_evidence if first_operation == "decision" else request_decision
+    with concurrent.futures.ThreadPoolExecutor(max_workers=2) as pool:
+        first_future = pool.submit(first_call)
+        assert first_locked.wait(timeout=5)
+        second_future = pool.submit(second_call)
+        assert second_attempted.wait(timeout=5)
+        release_first.set()
+        first_result = first_future.result(timeout=10)
+        with pytest.raises(ContractConflictError):
+            second_future.result(timeout=10)
+
+    if first_operation == "decision":
+        assert first_result["state"] == "pending"
+        assert seed.list_decisions(state="pending")["items"] == [first_result]
+        assert seed.list_events(execution_id=execution["execution_id"])["page"][
+            "completeness"
+        ] == "complete"
+    else:
+        assert first_result["outcome"] == "succeeded"
+        assert seed.list_decisions()["items"] == []
+        assert seed.get_execution(execution["execution_id"])["receipt_state"] == (
+            "pending_evidence"
+        )
+
+
+def test_receipt_also_blocks_new_decisions(tmp_path):
+    store = _store(tmp_path)
+    execution = _bound_execution(store, suffix="receipt-decision-gate")
+    store.transition_execution(execution["execution_id"], "running", now=NOW)
+    _record_evidence(store, execution, suffix="receipt-decision-gate")
+    store.transition_execution(
+        execution["execution_id"],
+        "terminal_succeeded",
+        now=NOW + timedelta(seconds=3),
+    )
+    with pytest.raises(ContractConflictError, match="no new decision"):
+        store.create_decision(
+            execution_id=execution["execution_id"],
+            effect_id=execution["effect_id"],
+            proposal_ref=execution["proposal_ref"],
+            request_digest=_digest("receipt-new-decision"),
+            allowed_choices=["once", "deny"],
+            expires_at=NOW + timedelta(minutes=5),
+            now=NOW + timedelta(seconds=4),
+        )
+
+
 def test_collection_snapshot_excludes_concurrent_insert(monkeypatch, tmp_path):
     import hermes_state
 
@@ -887,12 +1153,115 @@ def test_event_snapshot_excludes_append_after_high_water(monkeypatch, tmp_path):
     ]
 
 
+@pytest.mark.parametrize("gap", ["start", "interior", "end"])
+def test_global_event_sequence_gaps_fail_closed_before_complete(tmp_path, gap):
+    store = _store(tmp_path)
+    for index in range(4):
+        store.create_execution(
+            lifecycle="queued",
+            source_run_id=f"gap-{gap}-{index}",
+            now=NOW + timedelta(microseconds=index),
+        )
+    sequence = {"start": 1, "interior": 2, "end": 4}[gap]
+    with sqlite3.connect(store.database_path) as connection:
+        connection.execute(
+            "DELETE FROM execution_events WHERE sequence=?",
+            (sequence,),
+        )
+        connection.commit()
+
+    with pytest.raises(ContractDataError, match="event sequence gap"):
+        store.list_events()
+
+
+def test_filtered_event_feed_still_validates_unfiltered_global_continuity(tmp_path):
+    store = _store(tmp_path)
+    first = store.create_execution(lifecycle="queued", now=NOW)
+    store.create_execution(
+        lifecycle="queued",
+        now=NOW + timedelta(microseconds=1),
+    )
+    with sqlite3.connect(store.database_path) as connection:
+        connection.execute("DELETE FROM execution_events WHERE sequence=2")
+        connection.commit()
+
+    with pytest.raises(ContractDataError, match="event sequence gap"):
+        store.list_events(execution_id=first["execution_id"])
+
+
+def test_empty_and_fully_pruned_event_windows_are_legitimately_complete(tmp_path):
+    empty = _store(tmp_path, profile="empty")
+    assert empty.list_events()["page"] == {
+        "cursor": 0,
+        "high_water": 0,
+        "snapshot_high_water": 0,
+        "minimum_available": 1,
+        "has_more": False,
+        "completeness": "complete",
+        "pruned_through": 0,
+        "retention_seconds": 2592000,
+    }
+
+    store = _store(tmp_path, profile="pruned")
+    old = NOW - timedelta(days=40)
+    execution = store.create_execution(lifecycle="running", now=old)
+    store.transition_execution(
+        execution["execution_id"],
+        "terminal_failed",
+        now=old + timedelta(seconds=1),
+    )
+    assert store.prune_events(now=NOW) == 2
+    page = store.list_events(after=2, snapshot_high_water=2)
+    assert page["items"] == []
+    assert page["page"]["completeness"] == "complete"
+    assert page["page"]["pruned_through"] == 2
+    assert page["page"]["snapshot_high_water"] == 2
+
+
+def test_pruning_after_snapshot_pin_does_not_create_false_gap(
+    monkeypatch,
+    tmp_path,
+):
+    import hermes_state
+
+    monkeypatch.setattr(
+        hermes_state,
+        "apply_wal_with_fallback",
+        lambda connection, **_kwargs: connection.execute("PRAGMA journal_mode=WAL"),
+    )
+    reader = _store(tmp_path)
+    writer = _store(tmp_path)
+    old = NOW - timedelta(days=40)
+    execution = reader.create_execution(lifecycle="running", now=old)
+    reader.transition_execution(
+        execution["execution_id"],
+        "terminal_failed",
+        now=old + timedelta(seconds=1),
+    )
+    writer.initialize()
+    pruned = []
+
+    def prune_after_pin(collection, _high_water):
+        if collection == "events" and not pruned:
+            pruned.append(writer.prune_events(now=NOW))
+
+    reader._after_snapshot_pinned = prune_after_pin
+    page = reader.list_events(after=0)
+    assert pruned == [2]
+    assert len(page["items"]) == 2
+    assert page["page"]["completeness"] == "complete"
+    reader._after_snapshot_pinned = lambda *_args: None
+    with pytest.raises(ContractCursorGoneError):
+        reader.list_events(after=0)
+
+
 def test_late_ambiguous_evidence_publishes_receipt_transactionally(tmp_path):
     store = _store(tmp_path)
     execution = _bound_execution(store, suffix="late-ambiguous")
     terminal = store.transition_execution(
         execution["execution_id"],
         "terminal_failed",
+        recovery_ref="recovery:late-ambiguous",
         now=NOW + timedelta(seconds=1),
     )
     assert terminal["lifecycle"] == "terminal_ambiguous"
@@ -919,6 +1288,30 @@ def test_late_ambiguous_evidence_publishes_receipt_transactionally(tmp_path):
     assert store.get_receipt(receipt["receipt_id"])["reconciliation_ref"] == (
         "reconcile:late-ambiguous"
     )
+    assert receipt["recovery_ref"] == "recovery:late-ambiguous"
+    identical = store.reconcile_ambiguous_evidence(
+        execution_id=execution["execution_id"],
+        effect_id=execution["effect_id"],
+        outcome="ambiguous",
+        subject_digest=_digest("late-subject"),
+        evidence_digest=_digest("late-evidence"),
+        result_digest=_digest("late-result"),
+        reconciliation_ref="reconcile:late-ambiguous",
+        now=NOW + timedelta(seconds=3),
+    )
+    assert identical["receipt_id"] == receipt["receipt_id"]
+    with pytest.raises(ContractConflictError, match="not eligible"):
+        store.reconcile_ambiguous_evidence(
+            execution_id=execution["execution_id"],
+            effect_id=execution["effect_id"],
+            outcome="ambiguous",
+            subject_digest=_digest("late-subject"),
+            evidence_digest=_digest("late-evidence"),
+            result_digest=_digest("late-result"),
+            recovery_ref="recovery:conflicting-retry",
+            reconciliation_ref="reconcile:late-ambiguous",
+            now=NOW + timedelta(seconds=4),
+        )
 
 
 @pytest.mark.parametrize(

--- a/tests/test_packaging_build_guard.py
+++ b/tests/test_packaging_build_guard.py
@@ -1,5 +1,6 @@
 """Behavioral regression coverage for the wheel/sdist distribution guard."""
 
+import json
 import os
 import subprocess
 import sys
@@ -79,18 +80,33 @@ def test_artifact_build_allows_explicit_nix_package_build_marker(kind, artifact_
         for pattern in ("plugin.yaml", "plugin.yml")
         for path in (PROJECT_ROOT / "plugins").rglob(pattern)
     }
+    contract_schema_path = (
+        "hermes_cli/execution_contract_schemas/"
+        "hermes.execution.read.v1.schema.json"
+    )
+    expected.add(contract_schema_path)
     assert expected, "expected bundled plugin manifests under plugins/"
 
     if kind == "wheel":
         with zipfile.ZipFile(artifacts[0]) as wheel:
             shipped = set(wheel.namelist())
+            packaged_contract = json.loads(wheel.read(contract_schema_path))
     else:
         with tarfile.open(artifacts[0]) as sdist:
+            root = sdist.getnames()[0].split("/", 1)[0]
             shipped = {
                 name.split("/", 1)[1]
                 for name in sdist.getnames()
                 if "/" in name
             }
+            member = sdist.extractfile(f"{root}/{contract_schema_path}")
+            assert member is not None
+            packaged_contract = json.loads(member.read())
 
     missing = sorted(expected - shipped)
-    assert not missing, f"{kind} omits bundled plugin manifests: {missing}"
+    assert not missing, f"{kind} omits required packaged data: {missing}"
+    assert packaged_contract["$id"] == (
+        "https://hermes-agent.nousresearch.com/contracts/"
+        "hermes.execution.read.v1.schema.json"
+    )
+    assert packaged_contract["$defs"]["errorDetail"]["additionalProperties"] is False

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -525,6 +525,7 @@ These are set automatically by the Docker terminal backend when `proxy.enabled: 
 | `WEBHOOK_SECRET` | Global HMAC secret for webhook signature validation (used as fallback when routes don't specify their own) |
 | `API_SERVER_ENABLED` | Enable the OpenAI-compatible API server (`true`/`false`). Runs alongside other platforms. |
 | `API_SERVER_KEY` | Bearer token for API server authentication. Required whenever the API server is enabled. |
+| `API_SERVER_READ_KEY` | Optional profile-scoped bearer token limited to capability discovery and the versioned execution read contract. It cannot submit, approve, steer, stop, or access unrelated API resources. |
 | `API_SERVER_CORS_ORIGINS` | Comma-separated browser origins allowed to call the API server directly (for example `http://localhost:3000,http://127.0.0.1:3000`). Default: disabled. |
 | `API_SERVER_PORT` | Port for the API server (default: `8642`) |
 | `API_SERVER_HOST` | Host/bind address for the API server (default: `127.0.0.1`). `API_SERVER_KEY` is still required on loopback; use a narrow `API_SERVER_CORS_ORIGINS` allowlist for browser access. |

--- a/website/docs/user-guide/features/api-server.md
+++ b/website/docs/user-guide/features/api-server.md
@@ -430,10 +430,13 @@ Contract version: `hermes.execution.read.v1`
 | `GET` | `/v1/execution-contract/receipts` | Read authoritative terminal effect receipts |
 | `GET` | `/v1/execution-contract/receipts/{receipt_id}` | Read one receipt |
 
-Collections accept `after` and `limit` (maximum 200). Events include a
-monotonic sequence, high-water mark, minimum available cursor, completeness,
-and explicit retention watermark. A pruned cursor returns `410`, so consumers
-can detect a replay gap instead of silently treating missing history as empty.
+Collections accept `after`, `limit` (maximum 200), and
+`snapshot_high_water`. The first page pins a high-water mark in the same read
+transaction as row selection; carry that value to subsequent pages so
+concurrent inserts cannot skip or duplicate data. Events also include a
+monotonic sequence, minimum available cursor, completeness, and explicit
+retention watermark. A pruned cursor returns `410`, so consumers can detect a
+replay gap instead of silently treating missing history as empty.
 
 Use `API_SERVER_READ_KEY` when a service needs these GETs without run, approval,
 steer, stop, chat, or other mutation authority:
@@ -444,9 +447,13 @@ curl http://localhost:8642/v1/execution-contract/capabilities \
   -H "Hermes-Execution-Contract-Version: hermes.execution.read.v1"
 ```
 
-The server asserts the profile, authority, and executor identity in every
-response. Under multiplexing, `/p/<profile>/v1/execution-contract/...` uses
-that profile's home, ledger, and keys. Release 1 does not expose proposal/action
+The server derives and asserts the profile-instance, authority, and executor
+identity from the active scoped Hermes home in every response; URL labels do
+not create authority. Under multiplexing,
+`/p/<profile>/v1/execution-contract/...` uses that profile's home, ledger, and
+keys. Late authoritative ambiguous evidence has a dedicated atomic
+reconciliation path, while generic chat/process state remains non-authoritative.
+Release 1 does not expose proposal/action
 dispatch, public decision mutation, or WebAuthn step-up; capability discovery
 reports those features as disabled.
 
@@ -570,7 +577,8 @@ Configure the key via `API_SERVER_KEY` env var. If you need a browser to call He
 For read-only execution consumers, configure a distinct
 `API_SERVER_READ_KEY`. It is accepted only by `/v1/capabilities` and
 `GET /v1/execution-contract/*`; presenting it to any other route returns
-`403`.
+`403`. Hermes refuses to start if it equals `API_SERVER_KEY` for the default
+or any served named profile.
 
 ### Multi-profile routing (`/p/<profile>/…`)
 

--- a/website/docs/user-guide/features/api-server.md
+++ b/website/docs/user-guide/features/api-server.md
@@ -23,6 +23,8 @@ Add to `~/.hermes/.env`:
 ```bash
 API_SERVER_ENABLED=true
 API_SERVER_KEY=change-me-local-dev
+# Optional: a separate key for execution/capability GETs only
+# API_SERVER_READ_KEY=change-me-read-only
 # Optional: only if a browser must call Hermes directly
 # API_SERVER_CORS_ORIGINS=http://localhost:3000
 ```
@@ -405,6 +407,52 @@ running.
 
 Resolve a pending approval for a run that is waiting on a human decision (for example, a tool call gated behind an approval policy). The body carries the approval decision; the run resumes once the decision is recorded. This endpoint is advertised in `/v1/capabilities` as the `run_approval` feature so external UIs can detect support before surfacing an approval prompt.
 
+## Execution read contract (Release 1)
+
+Hermes exposes a durable, provider-neutral execution read contract at
+`/v1/execution-contract`. It is separate from the process-local Runs API:
+chat output, session history, a Kanban row, or `status=completed` does not prove
+an external effect. An effect-bearing execution publishes a terminal receipt
+only after its executor supplies exact evidence digests; otherwise it closes
+as `terminal_ambiguous` with no receipt.
+
+Contract version: `hermes.execution.read.v1`
+
+| Method | Path | Purpose |
+|---|---|---|
+| `GET` | `/v1/execution-contract/capabilities` | Negotiate version, authority, scopes, retention, and features |
+| `GET` | `/v1/execution-contract/schema` | Fetch the closed packaged JSON Schema |
+| `GET` | `/v1/execution-contract/executions` | Read durable execution lifecycle |
+| `GET` | `/v1/execution-contract/executions/{execution_id}` | Read one execution |
+| `GET` | `/v1/execution-contract/decisions` | Read pending or historical decisions |
+| `GET` | `/v1/execution-contract/decisions/{decision_id}` | Read one decision |
+| `GET` | `/v1/execution-contract/events` | Replay ordered, restart-safe events |
+| `GET` | `/v1/execution-contract/receipts` | Read authoritative terminal effect receipts |
+| `GET` | `/v1/execution-contract/receipts/{receipt_id}` | Read one receipt |
+
+Collections accept `after` and `limit` (maximum 200). Events include a
+monotonic sequence, high-water mark, minimum available cursor, completeness,
+and explicit retention watermark. A pruned cursor returns `410`, so consumers
+can detect a replay gap instead of silently treating missing history as empty.
+
+Use `API_SERVER_READ_KEY` when a service needs these GETs without run, approval,
+steer, stop, chat, or other mutation authority:
+
+```bash
+curl http://localhost:8642/v1/execution-contract/capabilities \
+  -H "Authorization: Bearer $API_SERVER_READ_KEY" \
+  -H "Hermes-Execution-Contract-Version: hermes.execution.read.v1"
+```
+
+The server asserts the profile, authority, and executor identity in every
+response. Under multiplexing, `/p/<profile>/v1/execution-contract/...` uses
+that profile's home, ledger, and keys. Release 1 does not expose proposal/action
+dispatch, public decision mutation, or WebAuthn step-up; capability discovery
+reports those features as disabled.
+
+See `docs/execution-read-contract-v1.md` in the source repository for complete
+lifecycle, receipt, pagination, and error semantics.
+
 ## Jobs API (background scheduled work)
 
 The server exposes a lightweight jobs CRUD surface for managing scheduled / background agent runs from a remote client. All endpoints are gated behind the same bearer auth.
@@ -519,6 +567,11 @@ Authorization: Bearer ***
 
 Configure the key via `API_SERVER_KEY` env var. If you need a browser to call Hermes directly, also set `API_SERVER_CORS_ORIGINS` to an explicit allowlist.
 
+For read-only execution consumers, configure a distinct
+`API_SERVER_READ_KEY`. It is accepted only by `/v1/capabilities` and
+`GET /v1/execution-contract/*`; presenting it to any other route returns
+`403`.
+
 ### Multi-profile routing (`/p/<profile>/…`)
 
 When [multi-profile gateway routing](/user-guide/multi-profile-gateways) is
@@ -554,6 +607,7 @@ The API server gives full access to hermes-agent's toolset, **including terminal
 | `API_SERVER_PORT` | `8642` | HTTP server port |
 | `API_SERVER_HOST` | `127.0.0.1` | Bind address (localhost only by default) |
 | `API_SERVER_KEY` | _(required)_ | Bearer token for auth |
+| `API_SERVER_READ_KEY` | _(none)_ | Optional profile-scoped bearer token limited to execution/capability GETs |
 | `API_SERVER_CORS_ORIGINS` | _(none)_ | Comma-separated allowed browser origins |
 | `API_SERVER_MODEL_NAME` | _(profile name)_ | Model name on `/v1/models`. Defaults to profile name, or `hermes-agent` for default profile. |
 
@@ -568,6 +622,7 @@ gateway:
     port: 8642
     host: 127.0.0.1
     key: your-secret-key
+    read_key: your-read-only-secret
     cors_origins: http://localhost:3000
     model_name: my-hermes
     max_concurrent_runs: 10   # concurrent-run cap; 0 disables the limit


### PR DESCRIPTION
## What does this PR do?

Hermes has process-local run, session, approval, and Kanban state. Those surfaces do not provide a durable authority contract for external execution readers. Process completion or chat output also cannot prove that an external effect occurred.

This PR adds `hermes.execution.read.v1`. It is a provider-neutral, profile-scoped public read contract for execution lifecycle, decisions, ordered events, and authoritative terminal receipts.

Public GET routes live under `/v1/execution-contract`:

- `/capabilities`
- `/schema`
- `/executions` and `/executions/{execution_id}`
- `/decisions` and `/decisions/{decision_id}`
- `/events`
- `/receipts` and `/receipts/{receipt_id}`

The same routes work through `/p/<profile>/...`.

Each profile owns a protected random authority anchor and a durable SQLite ledger. Authority derives from that anchor. It does not derive from a URL label, provider, model, process, or local path. A full profile-home move preserves authority. A database-only copy into another profile fails closed.

The ledger commits lifecycle, evidence, receipt, and event publication atomically. Generic chat, session, Kanban, tool-progress, and process-run completion are not authoritative effect evidence. Effects without executor evidence become `ambiguous`. Late reconciliation cannot upgrade ambiguity to success.

Collection reads use immutable ordering and snapshot-safe pagination. Event reads prove global sequence continuity. Pruning validates the complete allocated interval before it deletes any prefix or advances a watermark.

An optional `API_SERVER_READ_KEY` grants only `execution:read`. It cannot submit, approve, steer, stop, chat, access unrelated resources, or mutate state. Hermes refuses startup when the read key equals `API_SERVER_KEY`, including named and multiplex profiles.

The contract uses a closed error envelope for 400, 401, 403, 404, 405, 409, 410, 429, 500, and 503 outcomes.

The package includes a closed Draft 2020-12 JSON Schema and five synthetic fixtures. Wheel and sdist guards prove that the schema ships once with the expected identity and closed error shape.

This Release 1 PR does not add action dispatch, WebAuthn, step-up authorization, public decision mutation, executor delegation, recovery mutation, deployment configuration, or runtime activation.

## Related Issue

No matching open issue or pull request was found on 2026-08-15. This PR includes the complete problem statement and validation evidence.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [x] 🔒 Security fix
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added the durable execution ledger in `hermes_cli/execution_contract.py`.
- Added the versioned contract schema and synthetic fixtures.
- Added profile-scoped authority-anchor validation and fail-closed recovery.
- Added GET-only routes and read-key scope enforcement in `gateway/platforms/api_server.py`.
- Added named and multiplex profile credential isolation.
- Added decision, evidence, event, receipt, retry, retention, and pruning invariants.
- Added package-data configuration and real wheel/sdist content guards.
- Added operator, API, environment, and architecture documentation.
- Added no dependency. `uv.lock` is unchanged.

Rebased source identity:

- Base: `45af7a71fcd420b4422d2c074b1ce58b9ce0d048`
- Head: `0987053af97de785fa974498e2829eb408019cbc`
- Five commits; all five stable patch IDs match the independently accepted series.

The refreshed base changed `hermes_cli/web_server.py` and `tests/conftest.py`. The changes were in managed-media streaming and test isolation. The rebase had no conflicts. The candidate patches remained identical. The new overlap tests passed.

## How to Test

1. Install the project test environment with `uv sync --extra all --extra dev --locked` using a current uv release.
2. Run the bounded contract and gateway gate:

   ```bash
   scripts/run_tests.sh \
     tests/hermes_cli/test_execution_contract.py \
     tests/gateway/test_api_server_execution_contract.py \
     tests/gateway/test_config.py \
     tests/gateway/test_api_server.py \
     tests/gateway/test_api_server_runs.py \
     tests/gateway/test_multiplex_api_server_routing.py \
     tests/gateway/test_api_server_multiplex_secret_scope.py \
     tests/test_packaging_build_guard.py
   ```

3. Run the refreshed-base overlap gate:

   ```bash
   scripts/run_tests.sh \
     tests/hermes_cli/test_web_server_files.py \
     tests/hermes_state/test_isolation_marker_env.py \
     tests/hermes_state/test_live_db_guard_ancestry.py
   ```

4. Run `ruff check .`, `ty check hermes_cli/execution_contract.py`, JSON validation, package guards, and the PR CI matrix.

Current-head evidence:

- Contract/gateway/auth/config/package gate: 277 passed.
- Refreshed-base overlap gate: 25 passed.
- Execution ledger subset: 75 passed.
- Wheel and sdist package guards: 4 passed.
- Ruff and targeted ty: passed.
- Compile, JSON, diff, and five-commit Gitleaks scans: passed.
- Platform tested: macOS 26.4, Apple Silicon, Python 3.11.15.

A full repository wrapper was not repeated locally. A precursor full run recorded 32,415 passed, 116 unrelated environment or optional-dependency failures, and 330 skipped. Required PR CI remains blocking.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.4, Apple Silicon, Python 3.11.15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A (`API_SERVER_READ_KEY` is documented in the environment reference)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A (N/A; the public architecture is documented in `docs/ADR.md`)
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A (N/A; no model tool changed)

## Screenshots / Logs

No UI changed. The test counts and exact source identities are recorded above.
