### PR TITLE
fix(compression): stop hygiene timeouts from blocking live compression

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -254,31 +254,38 @@ def _record_hygiene_cooldown(
     cooldown_seconds: float,
     error: Optional[str] = None,
 ) -> None:
-    """Persist a session-hygiene compression-failure cooldown to the state DB.
-
-    Uses the same ``compression_failure_cooldown_until`` column and
-    ``record_compression_failure_cooldown`` method that the in-conversation
-    compression path (``agent/context_compressor.py``) already uses, so the
-    cooldown survives gateway restarts (#74136).
-
-    ``error`` is forwarded because the recorder writes
-    ``compression_failure_error`` UNCONDITIONALLY — omitting it clobbers to NULL
-    any reason the in-conversation path recorded, and readers surface that
-    reason to the user (falling back to "unknown error"). That matters more now
-    that an escalated cooldown can last up to an hour.
-    """
+    """Persist a hygiene-only compression-failure cooldown to the state DB."""
     import time as _time
     session_db = getattr(gateway, "_session_db", None)
     if session_db is None:
         return
     session_db = getattr(session_db, "_db", session_db)
-    recorder = getattr(session_db, "record_compression_failure_cooldown", None)
+    recorder = getattr(
+        session_db, "record_hygiene_compression_failure_cooldown", None
+    )
     if recorder is None:
         return
     try:
         recorder(session_id, _time.time() + cooldown_seconds, error)
     except Exception as exc:
         logger.debug("session hygiene cooldown persist failed: %s", exc)
+
+
+def _clear_hygiene_cooldown(gateway, session_id: str) -> None:
+    """Clear a recovered session's hygiene-only cooldown, best effort."""
+    session_db = getattr(gateway, "_session_db", None)
+    if session_db is None:
+        return
+    session_db = getattr(session_db, "_db", session_db)
+    clearer = getattr(
+        session_db, "clear_hygiene_compression_failure_cooldown", None
+    )
+    if clearer is None:
+        return
+    try:
+        clearer(session_id)
+    except Exception as exc:
+        logger.debug("session hygiene cooldown clear failed: %s", exc)
 
 
 def _status_template_to_regex(template: str) -> str:
@@ -18347,15 +18354,18 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 )
 
                 if _needs_compress:
-                    # Use the persistent DB-backed cooldown (same as the
-                    # in-conversation compression path in context_compressor.py)
-                    # so the cooldown survives gateway restarts. The in-memory
-                    # dict was reset on every restart, re-triggering the same
-                    # failing compression and wedging session storage (#74136).
+                    # Hygiene has its own persistent cooldown. It survives
+                    # gateway restarts without suppressing the live agent's
+                    # independent compressor, whose timeout budget may be
+                    # sufficient for the same long prefill (#86972).
                     _session_db = getattr(self, "_session_db", None)
                     if _session_db is not None:
                         _session_db = getattr(_session_db, "_db", _session_db)
-                        _getter = getattr(_session_db, "get_compression_failure_cooldown", None)
+                        _getter = getattr(
+                            _session_db,
+                            "get_hygiene_compression_failure_cooldown",
+                            None,
+                        )
                         if _getter is not None:
                             try:
                                 _cooldown_state = _getter(session_entry.session_id)
@@ -18790,6 +18800,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                                         ):
                                             _reset_hygiene_failure_streak(
                                                 self, session_key
+                                            )
+                                            _clear_hygiene_cooldown(
+                                                self, session_entry.session_id
                                             )
                                     if _hyg_aborted:
                                         if _hyg_failure_cooldown_seconds >= 0:

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -5332,6 +5332,84 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 session_id, exc,
             )
 
+    def record_hygiene_compression_failure_cooldown(
+        self,
+        session_id: str,
+        cooldown_until: float,
+        error: Optional[str] = None,
+    ) -> None:
+        """Persist a gateway-hygiene-only compression cooldown."""
+        if not session_id:
+            return
+
+        def _do(conn):
+            conn.execute(
+                "UPDATE sessions SET "
+                "hygiene_compression_failure_cooldown_until = ?, "
+                "hygiene_compression_failure_error = ? WHERE id = ?",
+                (cooldown_until, error, session_id),
+            )
+
+        try:
+            self._execute_write(_do)
+        except sqlite3.Error as exc:
+            logger.warning(
+                "record_hygiene_compression_failure_cooldown(%s) failed: %s",
+                session_id, exc,
+            )
+
+    def get_hygiene_compression_failure_cooldown(
+        self,
+        session_id: str,
+    ) -> Optional[Dict[str, Any]]:
+        """Return the active gateway-hygiene cooldown for ``session_id``."""
+        if not session_id:
+            return None
+        now = time.time()
+        with self._lock:
+            row = self._conn.execute(
+                "SELECT hygiene_compression_failure_cooldown_until, "
+                "hygiene_compression_failure_error FROM sessions WHERE id = ?",
+                (session_id,),
+            ).fetchone()
+        if row is None:
+            return None
+        cooldown_until = (
+            row["hygiene_compression_failure_cooldown_until"]
+            if isinstance(row, sqlite3.Row)
+            else row[0]
+        )
+        if cooldown_until is None:
+            return None
+        cooldown_until = float(cooldown_until)
+        if cooldown_until <= now:
+            return None
+        error = (
+            row["hygiene_compression_failure_error"]
+            if isinstance(row, sqlite3.Row)
+            else row[1]
+        )
+        return {
+            "cooldown_until": cooldown_until,
+            "remaining_seconds": cooldown_until - now,
+            "error": error,
+        }
+
+    def clear_hygiene_compression_failure_cooldown(self, session_id: str) -> None:
+        """Clear only the gateway-hygiene compression cooldown."""
+        if not session_id:
+            return
+
+        def _do(conn):
+            conn.execute(
+                "UPDATE sessions SET "
+                "hygiene_compression_failure_cooldown_until = NULL, "
+                "hygiene_compression_failure_error = NULL WHERE id = ?",
+                (session_id,),
+            )
+
+        self._execute_write(_do)
+
     def get_compression_failure_cooldown(
         self,
         session_id: str,

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -5408,7 +5408,13 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 (session_id,),
             )
 
-        self._execute_write(_do)
+        try:
+            self._execute_write(_do)
+        except sqlite3.Error as exc:
+            logger.warning(
+                "clear_hygiene_compression_failure_cooldown(%s) failed: %s",
+                session_id, exc,
+            )
 
     def get_compression_failure_cooldown(
         self,

--- a/hermes_state_common.py
+++ b/hermes_state_common.py
@@ -304,6 +304,8 @@ CREATE TABLE IF NOT EXISTS sessions (
     handoff_error TEXT,
     compression_failure_cooldown_until REAL,
     compression_failure_error TEXT,
+    hygiene_compression_failure_cooldown_until REAL,
+    hygiene_compression_failure_error TEXT,
     compression_fallback_streak INTEGER NOT NULL DEFAULT 0,
     compression_ineffective_count INTEGER NOT NULL DEFAULT 0,
     profile_name TEXT,

--- a/tests/gateway/test_hygiene_failure_cooldown_ladder.py
+++ b/tests/gateway/test_hygiene_failure_cooldown_ladder.py
@@ -215,16 +215,15 @@ class TestDegradedRunners:
 # ---------------------------------------------------------------------------
 
 class TestFailureReasonForwarded:
-    """`record_compression_failure_cooldown` writes compression_failure_error
-    UNCONDITIONALLY, so omitting the reason clobbers to NULL whatever the
-    in-conversation path recorded — and readers then show the user
-    "unknown error". Matters more now that a cooldown can last an hour."""
+    """Hygiene failure details stay in the hygiene-only cooldown state."""
 
     def _capture(self, *args):
         seen = {}
 
         class _DB:
-            def record_compression_failure_cooldown(self, sid, until, error=None):
+            def record_hygiene_compression_failure_cooldown(
+                self, sid, until, error=None
+            ):
                 seen.update(sid=sid, until=until, error=error)
 
         class _GW:
@@ -336,7 +335,9 @@ class TestRecordedCooldownEscalates:
         def __init__(self):
             self.calls = []
 
-        def record_compression_failure_cooldown(self, sid, until, error=None):
+        def record_hygiene_compression_failure_cooldown(
+            self, sid, until, error=None
+        ):
             self.calls.append((sid, until))
 
     class _GW:

--- a/tests/gateway/test_session_hygiene.py
+++ b/tests/gateway/test_session_hygiene.py
@@ -477,7 +477,9 @@ async def test_session_hygiene_preserves_transcript_when_in_place_configured_but
 
 
 @pytest.mark.asyncio
-async def test_session_hygiene_timeout_continues_to_agent_and_sets_cooldown(monkeypatch, tmp_path):
+async def test_session_hygiene_timeout_continues_to_agent_with_isolated_cooldown(
+    monkeypatch, tmp_path
+):
     """A timed-out SessionDB-bound worker cannot compact after the live turn starts.
 
     The worker remains alive long enough to cross the old race window. The
@@ -492,8 +494,9 @@ async def test_session_hygiene_timeout_continues_to_agent_and_sets_cooldown(monk
     release_worker = threading.Event()
     cleanup_done = threading.Event()
     fake_db = MagicMock()
-    # The DB-backed cooldown check calls this before compressing; a bare
-    # MagicMock return would be truthy and skip compression entirely.
+    # The DB-backed hygiene cooldown check calls this before compressing; a
+    # bare MagicMock return would be truthy and skip compression entirely.
+    fake_db.get_hygiene_compression_failure_cooldown.return_value = None
     fake_db.get_compression_failure_cooldown.return_value = None
 
     class SlowCompressAgent:
@@ -516,7 +519,7 @@ async def test_session_hygiene_timeout_continues_to_agent_and_sets_cooldown(monk
             self, messages, *_args, commit_fence=None, **_kwargs
         ):
             worker_started.set()
-            assert release_worker.wait(timeout=2)
+            assert release_worker.wait(timeout=10)
             if commit_fence is not None and not commit_fence.begin_commit():
                 return (messages, None)
             try:
@@ -605,17 +608,17 @@ async def test_session_hygiene_timeout_continues_to_agent_and_sets_cooldown(monk
     elapsed = time.monotonic() - started
 
     assert result == "ok"
-    # Loose wall-clock bound per flake policy: this asserts the handler did
-    # NOT block on the hygiene-compression timeout path (which would take
-    # multiple seconds), not a precise latency. 0.15s missed by ~1-8ms on
-    # busy CI shards twice on 2026-07-23.
-    assert elapsed < 2.0
+    # Loose wall-clock bound per flake policy: the worker waits up to 10s, so
+    # returning in under 5s proves the live turn did not join that worker.
+    assert elapsed < 5.0
     assert worker_started.is_set()
     assert runner._run_agent.await_count == 1
-    # Cooldown must be persisted to the state DB (survives restart, #74136),
-    # not stashed in an in-memory dict.
-    assert fake_db.record_compression_failure_cooldown.called
-    _cd_args = fake_db.record_compression_failure_cooldown.call_args[0]
+    # The timeout must cool down only future pre-agent hygiene attempts. The
+    # live agent has a longer timeout budget and must not inherit this failure.
+    assert fake_db.record_hygiene_compression_failure_cooldown.called
+    fake_db.record_compression_failure_cooldown.assert_not_called()
+    assert fake_db.get_compression_failure_cooldown() is None
+    _cd_args = fake_db.record_hygiene_compression_failure_cooldown.call_args[0]
     assert _cd_args[0] == "sess-timeout"
     assert _cd_args[1] > time.time()
     timeout_warnings = [s for s in adapter.sent if "Context compression timed out" in s["content"]]
@@ -657,6 +660,7 @@ async def test_session_hygiene_forces_in_place_compaction_with_bound_session_db(
         "</memory_provider_context>"
     )
     fake_db = MagicMock()
+    fake_db.get_hygiene_compression_failure_cooldown.return_value = None
     fake_db.get_compression_failure_cooldown.return_value = None
     async_session_db = SimpleNamespace(
         _db=fake_db,
@@ -1126,11 +1130,12 @@ async def test_hygiene_compression_cooldown_survives_gateway_restart(
         assert AbortingCompressAgent.instances == 1
 
         # The abort must have persisted a cooldown to the DB.
-        state = db.get_compression_failure_cooldown(session_id)
+        state = db.get_hygiene_compression_failure_cooldown(session_id)
         assert state is not None and state["remaining_seconds"] > 0, (
             "hygiene compression abort did not persist a cooldown to the "
             f"state DB; got {state!r}"
         )
+        assert db.get_compression_failure_cooldown(session_id) is None
 
         # --- simulate a gateway restart: brand-new runner, same DB ---
         del runner1

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -97,6 +97,36 @@ def _no_fts_rebuild_throttle(monkeypatch):
     monkeypatch.setattr(SessionDB, "_FTS_REBUILD_DUTY_FACTOR", 0.0)
 
 
+class TestHygieneCompressionFailureCooldown:
+    def test_hygiene_and_agent_cooldowns_are_independent(self, db):
+        db.create_session("cooldown-isolation", source="telegram")
+        now = time.time()
+
+        db.record_hygiene_compression_failure_cooldown(
+            "cooldown-isolation", now + 120, "hygiene prefill timeout"
+        )
+
+        hygiene = db.get_hygiene_compression_failure_cooldown(
+            "cooldown-isolation"
+        )
+        assert hygiene is not None
+        assert hygiene["error"] == "hygiene prefill timeout"
+        assert db.get_compression_failure_cooldown("cooldown-isolation") is None
+
+        db.record_compression_failure_cooldown(
+            "cooldown-isolation", now + 60, "agent summary failure"
+        )
+        db.clear_hygiene_compression_failure_cooldown("cooldown-isolation")
+
+        assert (
+            db.get_hygiene_compression_failure_cooldown("cooldown-isolation")
+            is None
+        )
+        agent = db.get_compression_failure_cooldown("cooldown-isolation")
+        assert agent is not None
+        assert agent["error"] == "agent summary failure"
+
+
 # =========================================================================
 # Connection lifecycle
 # =========================================================================

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -126,6 +126,19 @@ class TestHygieneCompressionFailureCooldown:
         assert agent is not None
         assert agent["error"] == "agent summary failure"
 
+    def test_hygiene_clear_is_best_effort_on_sqlite_error(self, db, caplog):
+        with mock.patch.object(
+            db,
+            "_execute_write",
+            side_effect=sqlite3.OperationalError("database is locked"),
+        ):
+            db.clear_hygiene_compression_failure_cooldown("cooldown-isolation")
+
+        assert (
+            "clear_hygiene_compression_failure_cooldown(cooldown-isolation) failed"
+            in caplog.text
+        )
+
 
 # =========================================================================
 # Connection lifecycle


### PR DESCRIPTION
## What does this PR do?

A session-hygiene timeout currently starts the shared compression failure cooldown, so the live agent compressor is skipped even when its longer timeout budget can complete the same long prefill. This change gives hygiene retries their own durable cooldown state, allowing the live compressor to proceed while preserving restart-safe hygiene backoff.

### Symptom

After session hygiene reports that compression made no progress for 30 seconds, the next live turn reports that compression is blocked by a cooldown instead of trying with its independent 120-second budget.

### Impact

Long sessions using providers with slow prompt prefill can continue growing because the pre-agent path that times out suppresses the only compression path with enough time to succeed. REAL_ENV verification reproduced the shared-cooldown block before the fix and confirmed that the live compressor completes after the hygiene timeout with this change.

### Bug Cause

**Trigger:** `gateway/run.py` / `_record_hygiene_cooldown` after the session-hygiene inactivity watchdog expires

**Causal chain:**
1. Session hygiene starts compression for a long prompt whose first token takes longer than the 30-second inactivity window.
2. The watchdog aborts that attempt and persists its failure in `compression_failure_cooldown_until`, the same SessionDB field used by the live agent compressor.
3. The live compressor reads that shared deadline and skips its own attempt, even though its longer timeout budget can complete the prefill.

**Why it is wrong:** The two compression paths have different timeout budgets and recovery behavior. A failure in the short pre-agent attempt is not evidence that the live compressor must be suppressed.

**Working sibling / contrast:** The live compressor already owns an independent failure ladder and can complete the same prompt within its longer budget when no shared hygiene cooldown blocks it.

**Ruled out:** Raising the hygiene total ceiling does not fix the reported path because the inactivity watchdog fires before the model emits its first token. Changing timeout policy is therefore outside this fix.

### Fix

- Add durable hygiene-only cooldown deadline and error fields to SessionDB.
- Read, record, and clear those fields only from the gateway hygiene path.
- Leave the existing agent compression cooldown untouched so a hygiene timeout cannot block the live compressor.
- Preserve hygiene cooldown escalation, restart durability, timeout fencing, failure details, and successful-recovery reset behavior.

## Related Issue

Closes #86972

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/run.py` - route hygiene cooldown reads, writes, and recovery clears through hygiene-only SessionDB state.
- `hermes_state.py` - add persistence APIs for recording, reading, and clearing hygiene compression cooldowns.
- `hermes_state_common.py` - add the hygiene cooldown deadline and error columns to the sessions schema.
- `tests/gateway/test_session_hygiene.py` - verify a hygiene timeout continues to the live agent without arming its cooldown and remains durable across restart.
- `tests/gateway/test_hygiene_failure_cooldown_ladder.py` - preserve hygiene escalation and failure-reason coverage against the isolated state.
- `tests/test_hermes_state.py` - verify hygiene and agent cooldown state remain independent.

## How to Test

1. Start with a long session whose summarization model takes more than the hygiene inactivity window but less than the live compressor timeout to emit its first token.
2. Trigger session hygiene and confirm its timeout records only the hygiene cooldown.
3. Continue the live turn and confirm agent compression is not blocked, then restart the SessionDB process and confirm the isolation remains durable.
4. Run the focused automated coverage:

```bash
scripts/run_tests.sh tests/gateway/test_session_hygiene.py tests/gateway/test_hygiene_failure_cooldown_ladder.py tests/test_hermes_state.py
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repository test entry on the relevant tests and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested the end-to-end compression path in REAL_ENV on Windows 11

### Documentation & Housekeeping

- [x] Documentation update is N/A because this changes internal cooldown isolation without changing user configuration or commands
- [x] `cli-config.yaml.example` update is N/A because no configuration keys changed
- [x] `CONTRIBUTING.md` and `AGENTS.md` updates are N/A because no contributor workflow changed
- [x] I've considered cross-platform impact; the state and gateway behavior are platform-independent
- [x] Tool descriptions and schemas are N/A because no model tool behavior changed

## Screenshots / Logs

REAL_ENV verification reproduced the pre-fix shared cooldown, then confirmed that the committed tip records only the hygiene cooldown, permits the live compressor to complete, and preserves the isolation after reopening the database in a fresh process.
