### PR TITLE
fix(state): discard pooled read connections after DatabaseError

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -3625,28 +3625,41 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         """
         conn = self._checkout_read_conn()
         if conn is not None:
+            broken = False
             try:
                 yield conn
+            except sqlite3.DatabaseError:
+                # A query failure (file is not a database, disk I/O, schema
+                # change after an external replace/repair) means this pooled
+                # connection is no longer safe to reuse. The write path
+                # self-heals via _reconnect_after_notadb; returning a dead
+                # reader to the LIFO pool would serve stale or failing
+                # results until process restart (#86518).
+                broken = True
+                raise
             finally:
-                returned = False
-                with self._read_conns_lock:
-                    if not self._read_conns_closed:
-                        try:
-                            self._read_pool.put_nowait(conn)
-                            returned = True
-                        except queue.Full:
-                            pass
-                if not returned:
-                    # close() has already drained the pool, so this connection
-                    # is surplus. Close it here — dropping it on the floor is
-                    # what leaked the fd.
-                    #
-                    # queue.Full is now unreachable in practice (permits and
-                    # maxsize are both _READ_POOL_MAX, so there can never be a
-                    # ninth connection to return), but the branch stays: it is
-                    # load-bearing if those two ever drift apart, and a leak is
-                    # the failure mode it prevents.
+                if broken:
                     self._close_read_conn(conn)
+                else:
+                    returned = False
+                    with self._read_conns_lock:
+                        if not self._read_conns_closed:
+                            try:
+                                self._read_pool.put_nowait(conn)
+                                returned = True
+                            except queue.Full:
+                                pass
+                    if not returned:
+                        # close() has already drained the pool, so this connection
+                        # is surplus. Close it here — dropping it on the floor is
+                        # what leaked the fd.
+                        #
+                        # queue.Full is now unreachable in practice (permits and
+                        # maxsize are both _READ_POOL_MAX, so there can never be a
+                        # ninth connection to return), but the branch stays: it is
+                        # load-bearing if those two ever drift apart, and a leak is
+                        # the failure mode it prevents.
+                        self._close_read_conn(conn)
             return
         with self._lock:
             yield self._conn

--- a/tests/test_session_db_read_conn_pool.py
+++ b/tests/test_session_db_read_conn_pool.py
@@ -231,6 +231,49 @@ def test_checkout_seam_is_the_single_acquisition_point(db):
     assert calls, "_read_ctx must route acquisition through _checkout_read_conn"
 
 
+def test_database_error_discards_pooled_read_conn(db, monkeypatch):
+    """A query DatabaseError must close the reader, not return it to the pool."""
+    import sqlite3
+
+    class _Broken:
+        def execute(self, *_args, **_kwargs):
+            raise sqlite3.DatabaseError("file is not a database")
+
+    fake = _Broken()
+    closed = []
+    returned = []
+    monkeypatch.setattr(db, "_checkout_read_conn", lambda: fake)
+    monkeypatch.setattr(db, "_close_read_conn", lambda conn: closed.append(conn))
+    monkeypatch.setattr(db._read_pool, "put_nowait", lambda conn: returned.append(conn))
+
+    with pytest.raises(sqlite3.DatabaseError, match="file is not a database"):
+        with db._read_ctx() as conn:
+            conn.execute("SELECT 1")
+
+    assert closed == [fake]
+    assert returned == []
+
+
+def test_successful_read_still_returns_conn_to_pool(db, monkeypatch):
+    """Healthy readers must still be recycled."""
+    class _Ok:
+        def execute(self, *_args, **_kwargs):
+            return None
+
+    fake = _Ok()
+    closed = []
+    returned = []
+    monkeypatch.setattr(db, "_checkout_read_conn", lambda: fake)
+    monkeypatch.setattr(db, "_close_read_conn", lambda conn: closed.append(conn))
+    monkeypatch.setattr(db._read_pool, "put_nowait", lambda conn: returned.append(conn))
+
+    with db._read_ctx() as conn:
+        conn.execute("SELECT 1")
+
+    assert returned == [fake]
+    assert closed == []
+
+
 def test_fallback_to_locked_writer_when_read_conn_unavailable(db, monkeypatch):
     """With no read connection available, reads still work under self._lock.
 


### PR DESCRIPTION
## What does this PR do?

`_read_ctx` always returned a pooled read connection to the LIFO pool, even after `sqlite3.DatabaseError`. After an external replace/repair of `state.db` (forked curator closing the write fd, offline heal), that reader then either fails forever (`file is not a database`) or silently serves the old inode. The write path already self-heals via `_reconnect_after_notadb`; the read pool did not.

On `DatabaseError`, the connection is now closed and discarded. Successful reads still return to the pool.

## Related Issue

Fixes #86518

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_state.py` (`_read_ctx`): close the borrowed reader on `sqlite3.DatabaseError` instead of `put_nowait`.
- `tests/test_session_db_read_conn_pool.py`: a simulated `file is not a database` error is discarded; a successful checkout is still recycled.

## How to Test

1. Inject a pooled reader that raises `sqlite3.DatabaseError` inside `_read_ctx`.
2. On current `main` the connection is returned to the pool (`put_nowait` called).
3. On this branch `_close_read_conn` is called and `put_nowait` is not.
4. A successful `_read_ctx` still returns the connection to the pool.
5. `scripts/run_tests.sh tests/test_session_db_read_conn_pool.py` for the two new tests plus existing fallback coverage.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin aarch64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Fail-on-base: `test_database_error_discards_pooled_read_conn` fails on `origin/main` because the broken reader is recycled. Branch: discard + recycle tests pass. `ruff` / `uv lock --check` clean.
