### PR TITLE
feat(desktop): remember the Quick Entry target picker choice

### DIFF
--- a/apps/desktop/src/app/quick-entry/quick-entry-app.test.tsx
+++ b/apps/desktop/src/app/quick-entry/quick-entry-app.test.tsx
@@ -1,0 +1,57 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { QUICK_ENTRY_TARGET_STORAGE_KEY, QUICK_TARGET_NEW } from '@/store/quick-entry'
+
+// The bridge API the window calls; the primary-renderer side is irrelevant here.
+const quickEntryApi = {
+  dismiss: vi.fn(),
+  onShown: vi.fn(),
+  onState: vi.fn(),
+  onSubmit: vi.fn(),
+  submit: vi.fn()
+}
+
+beforeAll(() => {
+  ;(window as unknown as { hermesDesktop?: { quickEntry: typeof quickEntryApi } }).hermesDesktop = {
+    quickEntry: quickEntryApi
+  }
+})
+
+beforeEach(() => {
+  localStorage.removeItem(QUICK_ENTRY_TARGET_STORAGE_KEY)
+  vi.clearAllMocks()
+  // Simulate the primary renderer pushing a live gateway so the target picker
+  // is enabled; call the registered onState listener synchronously.
+  quickEntryApi.onState.mockImplementation((cb: (payload: { connected: boolean; sessions: { id: string; title: string }[] }) => void) => {
+    cb({ connected: true, sessions: [{ id: 's1', title: 'Fix the build' }] })
+    return () => {}
+  })
+})
+
+describe('QuickEntryApp target persistence integration', () => {
+  it('writes the picker choice to localStorage when the target select changes', async () => {
+    const { QuickEntryApp } = await import('./quick-entry-app')
+
+    render(<QuickEntryApp />)
+
+    // The target picker is enabled once the reducer is connected; drive the
+    // select's onChange directly like the window does.
+    const select = screen.getByLabelText('Target session')
+    fireEvent.change(select, { target: { value: QUICK_TARGET_NEW } })
+
+    // The event handler persists before dispatching.
+    expect(localStorage.getItem(QUICK_ENTRY_TARGET_STORAGE_KEY)).toBe(QUICK_TARGET_NEW)
+  })
+
+  it('persists a specific session id choice', async () => {
+    const { QuickEntryApp } = await import('./quick-entry-app')
+
+    render(<QuickEntryApp />)
+
+    const select = screen.getByLabelText('Target session')
+    fireEvent.change(select, { target: { value: 's1' } })
+
+    expect(localStorage.getItem(QUICK_ENTRY_TARGET_STORAGE_KEY)).toBe('s1')
+  })
+})

--- a/apps/desktop/src/app/quick-entry/quick-entry-app.tsx
+++ b/apps/desktop/src/app/quick-entry/quick-entry-app.tsx
@@ -34,11 +34,6 @@ export function QuickEntryApp() {
   // (hand the payload to the shell, ask to hide) and stores the next state, so
   // the decision stays pure and testable while the effects stay in one place.
   const [state, dispatch] = useReducer((current: QuickComposerState, event: QuickComposerEvent) => {
-    if (event.type === 'target') {
-      // Remember the picker choice so the next summon opens on the same target.
-      persistQuickEntryTarget(event.target)
-    }
-
     const { send, state: next } = quickComposerReducer(current, event)
     const api = window.hermesDesktop?.quickEntry
 
@@ -172,7 +167,14 @@ export function QuickEntryApp() {
             aria-label="Target session"
             disabled={!state.connected}
             id="quick-entry-target"
-            onChange={event => dispatch({ target: event.target.value, type: 'target' })}
+            onChange={event => {
+              const target = event.target.value
+              // Persist the picker choice in the event handler (not the reducer
+              // body) so the reducer stays pure and replayable; the next summon
+              // opens on the same target.
+              persistQuickEntryTarget(target)
+              dispatch({ target, type: 'target' })
+            }}
             onKeyDown={event => {
               if (event.key === 'Escape') {
                 event.preventDefault()

--- a/apps/desktop/src/app/quick-entry/quick-entry-app.tsx
+++ b/apps/desktop/src/app/quick-entry/quick-entry-app.tsx
@@ -1,7 +1,9 @@
 import { useEffect, useReducer, useRef } from 'react'
 
 import {
-  initialQuickComposerState,
+  createInitialQuickComposerState,
+  loadPersistedQuickEntryTarget,
+  persistQuickEntryTarget,
   QUICK_TARGET_CURRENT,
   QUICK_TARGET_NEW,
   type QuickComposerEvent,
@@ -32,6 +34,11 @@ export function QuickEntryApp() {
   // (hand the payload to the shell, ask to hide) and stores the next state, so
   // the decision stays pure and testable while the effects stay in one place.
   const [state, dispatch] = useReducer((current: QuickComposerState, event: QuickComposerEvent) => {
+    if (event.type === 'target') {
+      // Remember the picker choice so the next summon opens on the same target.
+      persistQuickEntryTarget(event.target)
+    }
+
     const { send, state: next } = quickComposerReducer(current, event)
     const api = window.hermesDesktop?.quickEntry
 
@@ -42,7 +49,7 @@ export function QuickEntryApp() {
     }
 
     return next
-  }, initialQuickComposerState)
+  }, undefined, createInitialQuickComposerState)
 
   // Re-summoned by the chord: the shell reuses the window, so reset the draft
   // and take the keyboard back for a fresh capture. Also adopt gateway-state
@@ -51,7 +58,8 @@ export function QuickEntryApp() {
     const api = window.hermesDesktop?.quickEntry
 
     const offShown = api?.onShown(() => {
-      dispatch({ type: 'shown' })
+      // Reset to the persisted picker choice, not always the current chat.
+      dispatch({ resetTarget: loadPersistedQuickEntryTarget(), type: 'shown' })
       requestAnimationFrame(() => inputRef.current?.focus())
     })
 

--- a/apps/desktop/src/store/quick-entry.test.ts
+++ b/apps/desktop/src/store/quick-entry.test.ts
@@ -1,7 +1,11 @@
-import { describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it } from 'vitest'
 
 import {
+  createInitialQuickComposerState,
   initialQuickComposerState,
+  loadPersistedQuickEntryTarget,
+  persistQuickEntryTarget,
+  QUICK_ENTRY_TARGET_STORAGE_KEY,
   QUICK_TARGET_CURRENT,
   QUICK_TARGET_NEW,
   type QuickComposerEvent,
@@ -212,5 +216,49 @@ describe('quickComposerReducer', () => {
 
     expect(first.sent).toEqual([{ target: QUICK_TARGET_CURRENT, text: 'one' }])
     expect(second.sent).toEqual([{ target: QUICK_TARGET_CURRENT, text: 'two' }])
+  })
+
+  describe('persisted target preference', () => {
+    afterEach(() => {
+      window.localStorage.removeItem(QUICK_ENTRY_TARGET_STORAGE_KEY)
+    })
+
+    it('a fresh composer honors a persisted "new session" choice', () => {
+      window.localStorage.setItem(QUICK_ENTRY_TARGET_STORAGE_KEY, QUICK_TARGET_NEW)
+
+      expect(createInitialQuickComposerState().target).toBe(QUICK_TARGET_NEW)
+    })
+
+    it('a fresh composer stays on the current chat when nothing was persisted', () => {
+      expect(createInitialQuickComposerState().target).toBe(QUICK_TARGET_CURRENT)
+    })
+
+    it('a garbage persisted value falls back to the current chat', () => {
+      window.localStorage.setItem(QUICK_ENTRY_TARGET_STORAGE_KEY, '   ')
+
+      expect(loadPersistedQuickEntryTarget()).toBe(QUICK_TARGET_CURRENT)
+    })
+
+    it('persisting a choice makes it the next summon default', () => {
+      persistQuickEntryTarget(QUICK_TARGET_NEW)
+
+      expect(window.localStorage.getItem(QUICK_ENTRY_TARGET_STORAGE_KEY)).toBe(QUICK_TARGET_NEW)
+      expect(loadPersistedQuickEntryTarget()).toBe(QUICK_TARGET_NEW)
+    })
+
+    it('re-summoning resets to the persisted target, not always the current chat', () => {
+      window.localStorage.setItem(QUICK_ENTRY_TARGET_STORAGE_KEY, QUICK_TARGET_NEW)
+
+      const { state } = run([connect, { draft: 'x', type: 'edit' }, { type: 'shown', resetTarget: loadPersistedQuickEntryTarget() }])
+
+      expect(state.target).toBe(QUICK_TARGET_NEW)
+      expect(state.draft).toBe('')
+    })
+
+    it('a plain summon with no persisted reset keeps the shipped default', () => {
+      const { state } = run([connect, { target: 's1', type: 'target' }, { type: 'shown' }])
+
+      expect(state.target).toBe(QUICK_TARGET_CURRENT)
+    })
   })
 })

--- a/apps/desktop/src/store/quick-entry.ts
+++ b/apps/desktop/src/store/quick-entry.ts
@@ -111,6 +111,37 @@ export const QUICK_TARGET_CURRENT = 'current'
 export const QUICK_TARGET_NEW = 'new'
 
 /**
+ * localStorage key remembering the user's last-chosen quick-entry target
+ * ('current' | 'new' | a stored session id). Device-local, like the shortcut
+ * preference, but renderer-owned because only the renderer knows the picker's
+ * options.
+ */
+export const QUICK_ENTRY_TARGET_STORAGE_KEY = 'hermes.quick-entry.target'
+
+/**
+ * Read the persisted target choice. Falls back to the current chat when the
+ * value is absent, unreadable, or the environment has no storage — the shipped
+ * default must stay "send to the chat in front of you".
+ */
+export function loadPersistedQuickEntryTarget(): string {
+  try {
+    const raw = window.localStorage?.getItem(QUICK_ENTRY_TARGET_STORAGE_KEY)
+    return raw && raw.trim() ? raw : QUICK_TARGET_CURRENT
+  } catch {
+    return QUICK_TARGET_CURRENT
+  }
+}
+
+/** Remember the picker choice across summons. Non-fatal when storage fails. */
+export function persistQuickEntryTarget(target: string): void {
+  try {
+    window.localStorage?.setItem(QUICK_ENTRY_TARGET_STORAGE_KEY, target)
+  } catch {
+    // Storage unavailable — the picker still works for this window.
+  }
+}
+
+/**
  * The primary renderer's push into the quick window: is the gateway usable, and
  * which recent sessions can be targeted. The quick window has NO gateway of its
  * own, so this pushed copy is its only view of backend truth — it starts
@@ -152,9 +183,9 @@ export interface QuickComposerState {
 
 export type QuickComposerEvent =
   | { type: 'blur' }
-  | { type: 'dismiss' }
+  | { type: 'dismiss'; resetTarget?: string }
   | { type: 'edit'; draft: string }
-  | { type: 'shown' }
+  | { type: 'shown'; resetTarget?: string }
   | { type: 'state'; connected: boolean; sessions: QuickEntrySessionOption[] }
   | { type: 'submit' }
   | { type: 'target'; target: string }
@@ -176,6 +207,14 @@ export const initialQuickComposerState: QuickComposerState = {
   visible: true
 }
 
+/**
+ * The initial state for a freshly created quick window, honoring the user's
+ * persisted target choice (current chat when nothing was stored).
+ */
+export function createInitialQuickComposerState(): QuickComposerState {
+  return { ...initialQuickComposerState, target: loadPersistedQuickEntryTarget() }
+}
+
 export function quickComposerReducer(state: QuickComposerState, event: QuickComposerEvent): QuickComposerTransition {
   switch (event.type) {
     case 'blur':
@@ -184,7 +223,13 @@ export function quickComposerReducer(state: QuickComposerState, event: QuickComp
       // hides — the send already left for the main process.
       return {
         send: null,
-        state: { ...state, draft: '', submitting: false, target: QUICK_TARGET_CURRENT, visible: false }
+        state: {
+          ...state,
+          draft: '',
+          submitting: false,
+          target: 'resetTarget' in event ? (event.resetTarget ?? QUICK_TARGET_CURRENT) : QUICK_TARGET_CURRENT,
+          visible: false
+        }
       }
     }
 
@@ -197,7 +242,13 @@ export function quickComposerReducer(state: QuickComposerState, event: QuickComp
       // a leftover target — but the pushed gateway truth carries over.
       return {
         send: null,
-        state: { ...state, draft: '', submitting: false, target: QUICK_TARGET_CURRENT, visible: true }
+        state: {
+          ...state,
+          draft: '',
+          submitting: false,
+          target: event.resetTarget ?? QUICK_TARGET_CURRENT,
+          visible: true
+        }
       }
     }
 


### PR DESCRIPTION
## What

The Quick Entry composer's session-target picker (Current chat / New session / a recent session) reset to **Current chat** on every summon, with no way to change that default. Users whose habit is firing prompts into a new session had to re-pick the target every single time.

This PR persists the user's last picker choice in localStorage, so a summon opens on the same target they chose before — while the shipped default (current chat) stays untouched for everyone who never touches the picker.

## Why this shape

- Default preserved: the initial state and the dismiss/shown reset still fall back to `QUICK_TARGET_CURRENT` when nothing was persisted.
- Reducer stays pure: `dismiss`/`shown` accept an optional `resetTarget`, the window layer injects the persisted preference. Omitted field = exactly the old behavior.
- Storage is renderer-local (like the picker options themselves); the main-process `quick-entry.json` (`enabled`/`shortcut`) is untouched.

## Changes

- `apps/desktop/src/store/quick-entry.ts` — `QUICK_ENTRY_TARGET_STORAGE_KEY`, `loadPersistedQuickEntryTarget`/`persistQuickEntryTarget` (safe fallbacks), `createInitialQuickComposerState()`, optional `resetTarget` on dismiss/shown events.
- `apps/desktop/src/app/quick-entry/quick-entry-app.tsx` — seed the composer with the persisted target, persist on picker change, reset to the preference on summon.
- `apps/desktop/src/store/quick-entry.test.ts` — 6 new tests (persisted load, garbage fallback, persist round-trip, re-summon honoring the preference, default preserved).

## Verification

- `vitest run src/store/quick-entry.test.ts` → 23 passed (17 existing + 6 new).
- Renderer rebuild verified the new key lands in `dist/assets/quick-entry-*.js`.