### PR TITLE
feat(cron): alert operators when local jobs fail

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -4986,6 +4986,12 @@ def run_one_job(
             drift_skip = drift_skip_silent or (
                 bool(error) and DRIFT_SKIP_MARKER in str(error)
             )
+            empty_response_error = None
+            if success and not final_response.strip():
+                empty_response_error = (
+                    "Agent completed but produced empty response "
+                    "(model error, timeout, or misconfiguration)"
+                )
             if blocked_config and not success:
                 # Blocked-config alert: bypass the generic failure summarizer
                 # (whose auth/timeout heuristics would mislabel this as a
@@ -5023,6 +5029,15 @@ def run_one_job(
                 should_deliver = False
             unresolved_origin = False
             delivery_job = job
+            if empty_response_error:
+                # Empty responses keep their established no-delivery behavior
+                # unless this local job has an explicit failure-alert fallback.
+                delivery_job = _job_for_result_delivery(job, success=False)
+                if delivery_job is not job:
+                    deliver_content = _summarize_cron_failure_for_delivery(
+                        job, empty_response_error
+                    )
+                    should_deliver = bool(deliver_content.strip())
             # Cron silence suppression — see _is_cron_silence_response.  Replaces the
             # old `SILENT_MARKER in ...upper()` substring check, which both leaked
             # bracketless near-markers ("SILENT" / "NO_REPLY") and wrongly swallowed
@@ -5034,7 +5049,8 @@ def run_one_job(
                 should_deliver = False
 
             if should_deliver:
-                delivery_job = _job_for_result_delivery(job, success=success)
+                if delivery_job is job:
+                    delivery_job = _job_for_result_delivery(job, success=success)
                 unresolved_origin = (
                     _normalize_deliver_value(delivery_job.get("deliver", "local")) == "origin"
                     and not _resolve_delivery_targets(delivery_job)
@@ -5056,9 +5072,9 @@ def run_one_job(
         # Treat empty final_response as a soft failure so last_status
         # is not "ok" — the agent ran but produced nothing useful.
         # (issue #8585)
-        if success and not final_response.strip():
+        if empty_response_error:
             success = False
-            error = "Agent completed but produced empty response (model error, timeout, or misconfiguration)"
+            error = empty_response_error
 
         if not _consume_interrupted_flag(job["id"]):
             if blocked_config:

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -1637,6 +1637,38 @@ def _normalize_deliver_value(deliver) -> str:
     return str(deliver)
 
 
+def _job_for_result_delivery(job: dict, *, success: bool) -> dict:
+    """Select the delivery route without changing the persisted job.
+
+    Failed local-only jobs may use the operator-level ``cron.delivery.failure``
+    route. Successful jobs and jobs with their own non-local route retain their
+    existing delivery semantics. A missing/null/local failure route is disabled.
+    """
+    if success or _normalize_deliver_value(job.get("deliver", "local")) != "local":
+        return job
+
+    try:
+        cron_cfg = (load_config() or {}).get("cron", {})
+        delivery_cfg = cron_cfg.get("delivery", {}) if isinstance(cron_cfg, dict) else {}
+        failure_target = (
+            delivery_cfg.get("failure") if isinstance(delivery_cfg, dict) else None
+        )
+    except Exception:
+        logger.debug(
+            "Job '%s': could not read cron failure delivery config",
+            job.get("id", "?"),
+            exc_info=True,
+        )
+        return job
+
+    if failure_target is None or failure_target == "":
+        return job
+    normalized_target = _normalize_deliver_value(failure_target).strip()
+    if not normalized_target or normalized_target == "local":
+        return job
+    return {**job, "deliver": normalized_target}
+
+
 # Routing intent tokens — resolved at fire time, not create time, so a
 # job created before Telegram was wired up will pick up Telegram once it
 # comes online.  ``all`` expands into the set of connected platforms
@@ -4990,6 +5022,7 @@ def run_one_job(
             if blocked_config_silent or drift_skip_silent:
                 should_deliver = False
             unresolved_origin = False
+            delivery_job = job
             # Cron silence suppression — see _is_cron_silence_response.  Replaces the
             # old `SILENT_MARKER in ...upper()` substring check, which both leaked
             # bracketless near-markers ("SILENT" / "NO_REPLY") and wrongly swallowed
@@ -5001,12 +5034,15 @@ def run_one_job(
                 should_deliver = False
 
             if should_deliver:
+                delivery_job = _job_for_result_delivery(job, success=success)
                 unresolved_origin = (
-                    _normalize_deliver_value(job.get("deliver", "local")) == "origin"
-                    and not _resolve_delivery_targets(job)
+                    _normalize_deliver_value(delivery_job.get("deliver", "local")) == "origin"
+                    and not _resolve_delivery_targets(delivery_job)
                 )
                 try:
-                    delivery_error = _deliver_result(job, deliver_content, adapters=adapters, loop=loop)
+                    delivery_error = _deliver_result(
+                        delivery_job, deliver_content, adapters=adapters, loop=loop
+                    )
                 except Exception as de:
                     delivery_error = str(de)
                     logger.error("Delivery failed for job %s: %s", job["id"], de)
@@ -5032,7 +5068,9 @@ def run_one_job(
                 )
             else:
                 mark_job_run(job["id"], success, error, delivery_error=delivery_error)
-        normalized_deliver = _normalize_deliver_value(job.get("deliver", "local"))
+        normalized_deliver = _normalize_deliver_value(
+            delivery_job.get("deliver", "local")
+        )
         if delivery_error:
             delivery_outcome = "failed"
         elif should_deliver and unresolved_origin:

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -2322,6 +2322,12 @@ DEFAULT_CONFIG = {
             # Empty → the fire endpoint refuses all tokens (no unsigned decode).
             "nas_jwks_url": "",
         },
+        # Optional alert route for failed jobs whose normal delivery is local
+        # (including jobs with an omitted/null deliver value). Uses the same
+        # target grammar as a job's deliver field. null keeps failures local.
+        "delivery": {
+            "failure": None,
+        },
         # Wrap delivered cron responses with a header (task name) and footer
         # ("The agent cannot see this message").  Set to false for clean output.
         "wrap_response": True,

--- a/tests/cron/test_run_one_job.py
+++ b/tests/cron/test_run_one_job.py
@@ -94,6 +94,20 @@ def test_null_failure_delivery_keeps_failed_job_local(monkeypatch):
     assert ("deliver", "failed-local", None) in calls
 
 
+def test_empty_response_failure_uses_configured_failure_delivery(monkeypatch):
+    calls = _patch_pipeline(monkeypatch, success=True, final="   \n\t  ")
+    monkeypatch.setattr(
+        s,
+        "load_config",
+        lambda: {"cron": {"delivery": {"failure": "telegram:alerts"}}},
+    )
+
+    assert s.run_one_job({"id": "empty-local", "deliver": "local"}) is True
+
+    assert ("deliver", "empty-local", "telegram:alerts") in calls
+    assert calls[-1] == ("mark", "empty-local", False)
+
+
 def test_success_and_nonlocal_failure_keep_their_job_delivery(monkeypatch):
     monkeypatch.setattr(
         s,

--- a/tests/cron/test_run_one_job.py
+++ b/tests/cron/test_run_one_job.py
@@ -28,7 +28,7 @@ def _patch_pipeline(monkeypatch, *, success=True, output="out", final="final res
         return f"/tmp/{jid}.txt"
 
     def fake_deliver(job, content, adapters=None, loop=None):
-        calls.append(("deliver", job["id"]))
+        calls.append(("deliver", job["id"], job.get("deliver")))
         return None
 
     def fake_mark(jid, ok, err=None, delivery_error=None, **_kw):
@@ -64,6 +64,48 @@ def test_run_one_job_success_sequence(monkeypatch):
     assert ok is True
     assert [c[0] for c in calls] == ["run_job", "save", "deliver", "mark"]
     assert calls[-1] == ("mark", "j2", True)
+
+
+def test_failed_local_job_uses_configured_failure_delivery(monkeypatch):
+    calls = _patch_pipeline(
+        monkeypatch, success=False, final="", error="script exited 1"
+    )
+    monkeypatch.setattr(
+        s,
+        "load_config",
+        lambda: {"cron": {"delivery": {"failure": "telegram:alerts"}}},
+    )
+
+    assert s.run_one_job({"id": "failed-local", "deliver": None}) is True
+
+    assert ("deliver", "failed-local", "telegram:alerts") in calls
+
+
+def test_null_failure_delivery_keeps_failed_job_local(monkeypatch):
+    calls = _patch_pipeline(
+        monkeypatch, success=False, final="", error="script exited 1"
+    )
+    monkeypatch.setattr(
+        s, "load_config", lambda: {"cron": {"delivery": {"failure": None}}}
+    )
+
+    assert s.run_one_job({"id": "failed-local", "deliver": None}) is True
+
+    assert ("deliver", "failed-local", None) in calls
+
+
+def test_success_and_nonlocal_failure_keep_their_job_delivery(monkeypatch):
+    monkeypatch.setattr(
+        s,
+        "load_config",
+        lambda: {"cron": {"delivery": {"failure": "telegram:alerts"}}},
+    )
+    assert s._job_for_result_delivery(
+        {"id": "success-local", "deliver": "local"}, success=True
+    )["deliver"] == "local"
+    assert s._job_for_result_delivery(
+        {"id": "failed-origin", "deliver": "origin"}, success=False
+    )["deliver"] == "origin"
 
 
 def test_run_one_job_installs_secret_scope_under_multiplex(monkeypatch, tmp_path):

--- a/website/docs/user-guide/features/cron.md
+++ b/website/docs/user-guide/features/cron.md
@@ -361,6 +361,27 @@ When scheduling jobs, you specify where the output goes:
 
 The agent's final response is automatically delivered to the configured `deliver:` target — the agent does not send messages itself, so there is nothing to call in the cron prompt.
 
+### Failure alerts for local-only jobs
+
+`deliver: local` saves both successful and failed runs without sending a
+message. To keep successful output local while alerting on failures, configure
+one operator-level failure target:
+
+```yaml
+# ~/.hermes/config.yaml
+cron:
+  delivery:
+    failure: "telegram"  # accepts the same targets as a job's deliver field
+```
+
+This fallback is used only when a job fails and its normal delivery resolves to
+`local`. An omitted or null job `deliver` value is local, so it uses the same
+fallback. Successful local runs remain local, and failures from jobs with a
+non-local `deliver` target continue to go only to that job's target.
+
+`cron.delivery.failure` defaults to `null`, which means no failure alert target.
+Set it back to `null` to disable failure alerts without changing any jobs.
+
 ### Routing intent (`all`)
 
 `all` lets you ship one cron job to every messaging channel you have configured, without having to enumerate them by name. It is **resolved at fire time**, so a job created before you wired up Telegram will pick up Telegram on the next tick after you set `TELEGRAM_HOME_CHANNEL`.


### PR DESCRIPTION
## What does this PR do?

Adds an opt-in failure delivery route for cron jobs that intentionally keep normal output local. Operators can now receive actionable alerts when unattended local-only jobs fail, while successful local runs and jobs with explicit non-local delivery keep their existing behavior.

### Motivation

`deliver: local` jobs currently record failures only in local history and output files. That is appropriate for successful output, but it leaves unattended failures invisible unless an operator polls the local state.

### Behavior

Set `cron.delivery.failure` to any existing cron delivery target, such as `telegram` or `slack:#alerts`. Failed jobs whose normal delivery is local, omitted, or null use that fallback. The setting defaults to null, successful local runs stay local, and failures from jobs with non-local delivery continue to use only their job target.

### Implementation

The scheduler selects a delivery-only copy of a failed local job with the configured fallback target, then reuses the existing target resolver and delivery pipeline. The persisted job is not mutated. Empty-response failures are classified before delivery selection so they follow the same fallback contract.

## Related Issue

Closes #86998

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Changes Made

- `hermes_cli/config_defaults.py` - add the opt-in `cron.delivery.failure` setting with a null default.
- `cron/scheduler.py` - route failed local-only and empty-response runs through the configured fallback without changing persisted jobs or successful delivery.
- `tests/cron/test_run_one_job.py` - cover configured and disabled fallbacks, empty responses, successful local jobs, and non-local failures.
- `website/docs/user-guide/features/cron.md` - document configuration, supported target grammar, boundaries, and disable behavior.

## How to Test

1. Configure `cron.delivery.failure` with a reachable existing delivery target.
2. Run failing jobs with local, omitted, null, and explicit non-local delivery and confirm only local-only failures use the fallback.
3. Run the focused cron suite (123 tests passed on the committed tip):

```bash
scripts/run_tests.sh tests/cron/test_run_one_job.py tests/cron/test_scheduler.py tests/cron/test_cron_no_agent.py tests/cron/test_preflight_config.py tests/cron/test_execution_ledger.py -q
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this feature (no unrelated commits)
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation
- [x] `cli-config.yaml.example` is N/A because this setting is declared in the merged default config and documented in the cron guide
- [x] `CONTRIBUTING.md` and `AGENTS.md` are N/A because this does not change contributor architecture or workflows
- [x] I've considered cross-platform impact; delivery selection is platform-independent and uses the existing target resolver
- [x] Tool descriptions and schemas are N/A because no model tool contract changes
