### PR TITLE
chore: ignore venv backup dirs left by the updater

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 .DS_Store
 /venv/
 /venv.old/
+/venv_old/
+/venv_backup/
 /venv.stale.runtime-*/
 /.hermes-runtime/
 /_pycache/


### PR DESCRIPTION
## Summary

The updater leaves `venv_backup/` and `venv_old/` (underscore variants) next to the shared venv after updates. `.gitignore` only covered `/venv.old/` (dotted), so these directories showed up as untracked noise in `git status` on every update.

This adds both underscore names to `.gitignore` to keep the worktree clean.

## Motivation

On Windows installs updated via `hermes update`, the update flow leaves a `venv_backup/` and `venv_old/` directory next to the shared venv. Neither is covered by the existing ignore patterns, so `git status` is never clean after an update.