### PR TITLE
fix(memory): honor external prefetch timeout

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -33,7 +33,7 @@ from urllib.parse import parse_qs, urlparse, urlunparse
 
 from agent.context_compressor import ContextCompressor
 from agent.iteration_budget import IterationBudget
-from agent.memory_manager import StreamingContextScrubber
+from agent.memory_manager import MAX_EXTERNAL_PREFETCH_TIMEOUT_S, StreamingContextScrubber
 from agent.session_activity import ActivityProvenance
 from agent.model_metadata import (
     MINIMUM_CONTEXT_LENGTH,
@@ -119,9 +119,13 @@ def _external_prefetch_timeout_from_config(mem_config: Any) -> float | None:
             "Ignoring invalid memory.external_prefetch_timeout=%r; using default", raw
         )
         return None
-    if not math.isfinite(value) or value <= 0:
+    if (
+        not math.isfinite(value)
+        or value <= 0
+        or value > MAX_EXTERNAL_PREFETCH_TIMEOUT_S
+    ):
         logger.warning(
-            "Ignoring non-finite or non-positive memory.external_prefetch_timeout=%r; using default",
+            "Ignoring out-of-range memory.external_prefetch_timeout=%r; using default",
             raw,
         )
         return None

--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -20,6 +20,7 @@ preserved.
 from __future__ import annotations
 
 import logging
+import math
 import os
 import re
 import sys
@@ -106,6 +107,11 @@ def _external_prefetch_timeout_from_config(mem_config: Any) -> float | None:
     raw = mem_config.get("external_prefetch_timeout")
     if raw is None:
         return None
+    if isinstance(raw, bool):
+        logger.warning(
+            "Ignoring boolean memory.external_prefetch_timeout=%r; using default", raw
+        )
+        return None
     try:
         value = float(raw)
     except (TypeError, ValueError):
@@ -113,9 +119,10 @@ def _external_prefetch_timeout_from_config(mem_config: Any) -> float | None:
             "Ignoring invalid memory.external_prefetch_timeout=%r; using default", raw
         )
         return None
-    if value <= 0:
+    if not math.isfinite(value) or value <= 0:
         logger.warning(
-            "Ignoring non-positive memory.external_prefetch_timeout=%r; using default", raw
+            "Ignoring non-finite or non-positive memory.external_prefetch_timeout=%r; using default",
+            raw,
         )
         return None
     return value

--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -95,6 +95,32 @@ def _warn_memory_provider_unavailable(name: str, reason: str = "") -> None:
     )
 
 
+def _external_prefetch_timeout_from_config(mem_config: Any) -> float | None:
+    """Return the optional external-memory recall wait bound from config.
+
+    A malformed profile value must not disable the external-memory provider;
+    returning ``None`` delegates to ``MemoryManager``'s documented default.
+    """
+    if not isinstance(mem_config, dict):
+        return None
+    raw = mem_config.get("external_prefetch_timeout")
+    if raw is None:
+        return None
+    try:
+        value = float(raw)
+    except (TypeError, ValueError):
+        logger.warning(
+            "Ignoring invalid memory.external_prefetch_timeout=%r; using default", raw
+        )
+        return None
+    if value <= 0:
+        logger.warning(
+            "Ignoring non-positive memory.external_prefetch_timeout=%r; using default", raw
+        )
+        return None
+    return value
+
+
 def _ra():
     """Lazy reference to ``run_agent`` so callers can patch
     ``run_agent.OpenAI`` / ``run_agent.cleanup_vm`` / ... and have those
@@ -1751,9 +1777,9 @@ def init_agent(
     # So the built-in store is created unless memory is globally disabled, while
     # the external-provider block below stays gated on skip_memory.
     _memory_toolset_requested = "memory" in (agent.enabled_toolsets or [])
+    mem_config = _agent_cfg.get("memory", {})
     if not skip_memory or _memory_toolset_requested:
         try:
-            mem_config = _agent_cfg.get("memory", {})
             agent._memory_enabled = mem_config.get("memory_enabled", False)
             agent._user_profile_enabled = mem_config.get("user_profile_enabled", False)
             agent._memory_nudge_interval = int(mem_config.get("nudge_interval", 10))
@@ -1779,7 +1805,11 @@ def init_agent(
             if _mem_provider_name and _mem_provider_name.strip():
                 from agent.memory_manager import MemoryManager as _MemoryManager
                 from plugins.memory import load_memory_provider as _load_mem
-                agent._memory_manager = _MemoryManager()
+                agent._memory_manager = _MemoryManager(
+                    external_prefetch_timeout=_external_prefetch_timeout_from_config(
+                        mem_config
+                    )
+                )
                 _mp = _load_mem(_mem_provider_name)
                 if _mp and _mp.is_available():
                     agent._memory_manager.add_provider(_mp)

--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -114,7 +114,7 @@ def _external_prefetch_timeout_from_config(mem_config: Any) -> float | None:
         return None
     try:
         value = float(raw)
-    except (TypeError, ValueError):
+    except (TypeError, ValueError, OverflowError):
         logger.warning(
             "Ignoring invalid memory.external_prefetch_timeout=%r; using default", raw
         )

--- a/agent/memory_manager.py
+++ b/agent/memory_manager.py
@@ -373,12 +373,18 @@ class MemoryManager:
         self._providers: List[MemoryProvider] = []
         self._tool_to_provider: Dict[str, MemoryProvider] = {}
         self._has_external: bool = False  # True once a non-builtin provider is added
-        self._external_prefetch_timeout = (
-            _EXTERNAL_PREFETCH_TIMEOUT_S
-            if external_prefetch_timeout is None
-            else float(external_prefetch_timeout)
-        )
-        if not math.isfinite(self._external_prefetch_timeout) or self._external_prefetch_timeout <= 0:
+        try:
+            self._external_prefetch_timeout = (
+                _EXTERNAL_PREFETCH_TIMEOUT_S
+                if external_prefetch_timeout is None
+                else float(external_prefetch_timeout)
+            )
+        except (TypeError, ValueError, OverflowError) as exc:
+            raise ValueError("external_prefetch_timeout must be finite and positive") from exc
+        if (
+            not math.isfinite(self._external_prefetch_timeout)
+            or self._external_prefetch_timeout <= 0
+        ):
             raise ValueError("external_prefetch_timeout must be finite and positive")
         self._external_prefetch_threads: Dict[str, threading.Thread] = {}
         self._external_prefetch_lock = threading.Lock()

--- a/agent/memory_manager.py
+++ b/agent/memory_manager.py
@@ -46,6 +46,9 @@ logger = logging.getLogger(__name__)
 # running past this window dies with the interpreter.
 _SYNC_DRAIN_TIMEOUT_S = 5.0
 _EXTERNAL_PREFETCH_TIMEOUT_S = 8.0
+# This is an interactive turn-bound, not a background-work deadline. It also
+# avoids platform-specific `thread.join()` timestamp overflow for huge values.
+MAX_EXTERNAL_PREFETCH_TIMEOUT_S = 60.0
 
 
 def normalize_tool_schema(schema: Any) -> Optional[Dict[str, Any]]:
@@ -380,12 +383,19 @@ class MemoryManager:
                 else float(external_prefetch_timeout)
             )
         except (TypeError, ValueError, OverflowError) as exc:
-            raise ValueError("external_prefetch_timeout must be finite and positive") from exc
+            raise ValueError(
+                "external_prefetch_timeout must be finite, positive, and at most "
+                f"{MAX_EXTERNAL_PREFETCH_TIMEOUT_S:g} seconds"
+            ) from exc
         if (
             not math.isfinite(self._external_prefetch_timeout)
             or self._external_prefetch_timeout <= 0
+            or self._external_prefetch_timeout > MAX_EXTERNAL_PREFETCH_TIMEOUT_S
         ):
-            raise ValueError("external_prefetch_timeout must be finite and positive")
+            raise ValueError(
+                "external_prefetch_timeout must be finite, positive, and at most "
+                f"{MAX_EXTERNAL_PREFETCH_TIMEOUT_S:g} seconds"
+            )
         self._external_prefetch_threads: Dict[str, threading.Thread] = {}
         self._external_prefetch_lock = threading.Lock()
         # Background executor for end-of-turn sync/prefetch. Lazily created on

--- a/agent/memory_manager.py
+++ b/agent/memory_manager.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 
 import json
 import logging
+import math
 import re
 import inspect
 import threading
@@ -377,8 +378,8 @@ class MemoryManager:
             if external_prefetch_timeout is None
             else float(external_prefetch_timeout)
         )
-        if self._external_prefetch_timeout <= 0:
-            raise ValueError("external_prefetch_timeout must be positive")
+        if not math.isfinite(self._external_prefetch_timeout) or self._external_prefetch_timeout <= 0:
+            raise ValueError("external_prefetch_timeout must be finite and positive")
         self._external_prefetch_threads: Dict[str, threading.Thread] = {}
         self._external_prefetch_lock = threading.Lock()
         # Background executor for end-of-turn sync/prefetch. Lazily created on

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1774,6 +1774,9 @@ DEFAULT_CONFIG = {
         # "hindsight", "holographic", "retaindb", "byterover".
         # Only ONE external provider is allowed at a time.
         "provider": "",
+        # Interactive wait bound for external-memory recall. The work itself
+        # remains daemonized; this only limits how long the active turn joins.
+        "external_prefetch_timeout": 8.0,
     },
 
     # Subagent delegation — override the provider:model used by delegate_task

--- a/tests/agent/test_agent_init_memory_prefetch_timeout.py
+++ b/tests/agent/test_agent_init_memory_prefetch_timeout.py
@@ -1,12 +1,34 @@
 """Regression coverage for the external-memory prefetch config handoff."""
 
+import time
+
 from agent.agent_init import _external_prefetch_timeout_from_config
+from agent.memory_manager import MemoryManager
+from tests.agent.test_memory_provider import BlockingPrefetchProvider
 
 
 def test_configured_external_prefetch_timeout_is_parsed():
     assert _external_prefetch_timeout_from_config(
         {"external_prefetch_timeout": "0.5"}
     ) == 0.5
+
+
+def test_configured_half_second_timeout_bounds_external_recall():
+    manager = MemoryManager(
+        external_prefetch_timeout=_external_prefetch_timeout_from_config(
+            {"external_prefetch_timeout": 0.5}
+        )
+    )
+    provider = BlockingPrefetchProvider()
+    manager.add_provider(provider)
+
+    started = time.monotonic()
+    assert manager.prefetch_all("relevant query") == ""
+    elapsed = time.monotonic() - started
+
+    assert provider.started.is_set()
+    assert 0.45 <= elapsed < 0.8
+    provider.release.set()
 
 
 def test_missing_or_invalid_external_prefetch_timeout_uses_manager_default():

--- a/tests/agent/test_agent_init_memory_prefetch_timeout.py
+++ b/tests/agent/test_agent_init_memory_prefetch_timeout.py
@@ -17,11 +17,25 @@ def test_configured_external_prefetch_timeout_is_parsed():
         _external_prefetch_timeout_from_config({"external_prefetch_timeout": "0.5"})
         == 0.5
     )
+    assert (
+        _external_prefetch_timeout_from_config({"external_prefetch_timeout": 60}) == 60
+    )
 
 
 @pytest.mark.parametrize(
     "raw",
-    [True, -1, HUGE_INT, math.nan, math.inf, -math.inf, "nan", "inf", "1e999"],
+    [
+        True,
+        -1,
+        HUGE_INT,
+        1e308,
+        math.nan,
+        math.inf,
+        -math.inf,
+        "nan",
+        "inf",
+        "1e999",
+    ],
 )
 def test_malformed_or_nonfinite_timeout_uses_manager_default(raw):
     assert (
@@ -30,9 +44,9 @@ def test_malformed_or_nonfinite_timeout_uses_manager_default(raw):
     )
 
 
-@pytest.mark.parametrize("raw", [HUGE_INT, math.nan, math.inf, -math.inf])
+@pytest.mark.parametrize("raw", [HUGE_INT, 1e308, math.nan, math.inf, -math.inf])
 def test_memory_manager_rejects_direct_invalid_timeouts(raw):
-    with pytest.raises(ValueError, match="finite and positive"):
+    with pytest.raises(ValueError, match="external_prefetch_timeout"):
         MemoryManager(external_prefetch_timeout=raw)
 
 

--- a/tests/agent/test_agent_init_memory_prefetch_timeout.py
+++ b/tests/agent/test_agent_init_memory_prefetch_timeout.py
@@ -1,6 +1,9 @@
 """Regression coverage for the external-memory prefetch config handoff."""
 
+import math
 import time
+
+import pytest
 
 from agent.agent_init import _external_prefetch_timeout_from_config
 from agent.memory_manager import MemoryManager
@@ -8,16 +11,33 @@ from tests.agent.test_memory_provider import BlockingPrefetchProvider
 
 
 def test_configured_external_prefetch_timeout_is_parsed():
-    assert _external_prefetch_timeout_from_config(
-        {"external_prefetch_timeout": "0.5"}
-    ) == 0.5
+    assert (
+        _external_prefetch_timeout_from_config({"external_prefetch_timeout": "0.5"})
+        == 0.5
+    )
+
+
+@pytest.mark.parametrize(
+    "raw", [True, -1, math.nan, math.inf, -math.inf, "nan", "inf", "1e999"]
+)
+def test_malformed_or_nonfinite_timeout_uses_manager_default(raw):
+    assert (
+        _external_prefetch_timeout_from_config({"external_prefetch_timeout": raw})
+        is None
+    )
+
+
+@pytest.mark.parametrize("raw", [math.nan, math.inf, -math.inf])
+def test_memory_manager_rejects_direct_nonfinite_timeouts(raw):
+    with pytest.raises(ValueError, match="finite and positive"):
+        MemoryManager(external_prefetch_timeout=raw)
 
 
 def test_configured_half_second_timeout_bounds_external_recall():
     manager = MemoryManager(
-        external_prefetch_timeout=_external_prefetch_timeout_from_config(
-            {"external_prefetch_timeout": 0.5}
-        )
+        external_prefetch_timeout=_external_prefetch_timeout_from_config({
+            "external_prefetch_timeout": 0.5
+        })
     )
     provider = BlockingPrefetchProvider()
     manager.add_provider(provider)
@@ -33,9 +53,10 @@ def test_configured_half_second_timeout_bounds_external_recall():
 
 def test_missing_or_invalid_external_prefetch_timeout_uses_manager_default():
     assert _external_prefetch_timeout_from_config({}) is None
-    assert _external_prefetch_timeout_from_config(
-        {"external_prefetch_timeout": "invalid"}
-    ) is None
-    assert _external_prefetch_timeout_from_config(
-        {"external_prefetch_timeout": 0}
-    ) is None
+    assert (
+        _external_prefetch_timeout_from_config({"external_prefetch_timeout": "invalid"})
+        is None
+    )
+    assert (
+        _external_prefetch_timeout_from_config({"external_prefetch_timeout": 0}) is None
+    )

--- a/tests/agent/test_agent_init_memory_prefetch_timeout.py
+++ b/tests/agent/test_agent_init_memory_prefetch_timeout.py
@@ -1,0 +1,19 @@
+"""Regression coverage for the external-memory prefetch config handoff."""
+
+from agent.agent_init import _external_prefetch_timeout_from_config
+
+
+def test_configured_external_prefetch_timeout_is_parsed():
+    assert _external_prefetch_timeout_from_config(
+        {"external_prefetch_timeout": "0.5"}
+    ) == 0.5
+
+
+def test_missing_or_invalid_external_prefetch_timeout_uses_manager_default():
+    assert _external_prefetch_timeout_from_config({}) is None
+    assert _external_prefetch_timeout_from_config(
+        {"external_prefetch_timeout": "invalid"}
+    ) is None
+    assert _external_prefetch_timeout_from_config(
+        {"external_prefetch_timeout": 0}
+    ) is None

--- a/tests/agent/test_agent_init_memory_prefetch_timeout.py
+++ b/tests/agent/test_agent_init_memory_prefetch_timeout.py
@@ -9,6 +9,8 @@ from agent.agent_init import _external_prefetch_timeout_from_config
 from agent.memory_manager import MemoryManager
 from tests.agent.test_memory_provider import BlockingPrefetchProvider
 
+HUGE_INT = int("1" + "0" * 309)
+
 
 def test_configured_external_prefetch_timeout_is_parsed():
     assert (
@@ -18,7 +20,8 @@ def test_configured_external_prefetch_timeout_is_parsed():
 
 
 @pytest.mark.parametrize(
-    "raw", [True, -1, math.nan, math.inf, -math.inf, "nan", "inf", "1e999"]
+    "raw",
+    [True, -1, HUGE_INT, math.nan, math.inf, -math.inf, "nan", "inf", "1e999"],
 )
 def test_malformed_or_nonfinite_timeout_uses_manager_default(raw):
     assert (
@@ -27,8 +30,8 @@ def test_malformed_or_nonfinite_timeout_uses_manager_default(raw):
     )
 
 
-@pytest.mark.parametrize("raw", [math.nan, math.inf, -math.inf])
-def test_memory_manager_rejects_direct_nonfinite_timeouts(raw):
+@pytest.mark.parametrize("raw", [HUGE_INT, math.nan, math.inf, -math.inf])
+def test_memory_manager_rejects_direct_invalid_timeouts(raw):
     with pytest.raises(ValueError, match="finite and positive"):
         MemoryManager(external_prefetch_timeout=raw)
 


### PR DESCRIPTION
## Why
`memory.external_prefetch_timeout` existed in profile config but was never passed to the `MemoryManager`, so every external-memory provider used the hard-coded 8s join.

## Change
- Declare the setting in `DEFAULT_CONFIG`.
- Parse a positive numeric value defensively and wire it into the external `MemoryManager` construction.
- Preserve the 8s default for absent, invalid, and non-positive values.

## Verification
- `uv run --extra dev pytest tests/agent/test_agent_init_memory_prefetch_timeout.py tests/agent/test_memory_provider.py -q` — 68 passed
- `uv run ruff check agent/agent_init.py hermes_cli/config_defaults.py tests/agent/test_agent_init_memory_prefetch_timeout.py`
- `HERMES_HOME=... uv run hermes config check` — config recognizes the setting
- Fresh-profile construction proof: configured 0.5s → manager 0.5s; Terra default/high read back.

## Risk
Only external memory prefetch joins are bounded; recall that exceeds the configured bound is skipped for that turn, exactly as the existing timeout path specifies.