### PR TITLE
fix(tools): release per-task file registry state (#86514)

### DIFF
--- a/tests/tools/test_file_state_registry.py
+++ b/tests/tools/test_file_state_registry.py
@@ -25,6 +25,7 @@ import unittest
 
 from tools import file_state
 from tools.file_tools import (
+    clear_file_ops_cache,
     read_file_tool,
     write_file_tool,
     patch_tool,
@@ -122,6 +123,54 @@ class FileStateRegistryUnitTests(unittest.TestCase):
         self.assertTrue(b_entered.wait(timeout=3.0))
         ta.join(timeout=3.0)
         tb.join(timeout=3.0)
+
+    def test_lock_path_state_is_released_after_last_waiter(self):
+        p = self._mk()
+        first_entered = threading.Event()
+        release_first = threading.Event()
+        second_entered = threading.Event()
+
+        def first() -> None:
+            with file_state.lock_path(p):
+                first_entered.set()
+                release_first.wait(timeout=2.0)
+
+        def second() -> None:
+            first_entered.wait(timeout=2.0)
+            with file_state.lock_path(p):
+                second_entered.set()
+
+        ta = threading.Thread(target=first)
+        tb = threading.Thread(target=second)
+        ta.start()
+        tb.start()
+        self.assertTrue(first_entered.wait(timeout=2.0))
+        time.sleep(0.02)
+        self.assertFalse(second_entered.is_set())
+        release_first.set()
+        ta.join(timeout=3.0)
+        tb.join(timeout=3.0)
+
+        registry = file_state.get_registry()
+        self.assertTrue(second_entered.is_set())
+        self.assertNotIn(p, registry._path_locks)
+        self.assertNotIn(p, registry._path_lock_users)
+
+    def test_clear_file_ops_cache_releases_task_state(self):
+        p = self._mk()
+        task_id = "finished-task"
+        file_state.record_read(task_id, p)
+
+        from tools import file_tools
+
+        file_tools._read_tracker[task_id] = {"dedup": {}}
+        file_tools._patch_failure_tracker[task_id] = {p: 2}
+
+        clear_file_ops_cache(task_id)
+
+        self.assertEqual(file_state.known_reads(task_id), [])
+        self.assertNotIn(task_id, file_tools._read_tracker)
+        self.assertNotIn(task_id, file_tools._patch_failure_tracker)
 
 
     def test_kill_switch_env_var(self):

--- a/tools/file_state.py
+++ b/tools/file_state.py
@@ -63,6 +63,7 @@ class FileStateRegistry:
         self._reads: Dict[str, Dict[str, ReadStamp]] = defaultdict(dict)
         self._last_writer: Dict[str, Tuple[str, float]] = {}
         self._path_locks: Dict[str, threading.Lock] = {}
+        self._path_lock_users: Dict[str, int] = {}
         self._meta_lock = threading.Lock()  # guards _path_locks
         self._state_lock = threading.Lock()  # guards _reads + _last_writer
 
@@ -73,6 +74,7 @@ class FileStateRegistry:
             if lock is None:
                 lock = threading.Lock()
                 self._path_locks[resolved] = lock
+            self._path_lock_users[resolved] = self._path_lock_users.get(resolved, 0) + 1
             return lock
 
     @contextmanager
@@ -88,6 +90,13 @@ class FileStateRegistry:
             yield
         finally:
             lock.release()
+            with self._meta_lock:
+                users = self._path_lock_users[resolved] - 1
+                if users:
+                    self._path_lock_users[resolved] = users
+                else:
+                    self._path_lock_users.pop(resolved, None)
+                    self._path_locks.pop(resolved, None)
 
     # ── Read/write accounting ───────────────────────────────────────
     def record_read(
@@ -248,6 +257,11 @@ class FileStateRegistry:
         with self._state_lock:
             return list(self._reads.get(task_id, {}).keys())
 
+    def forget_task(self, task_id: str) -> None:
+        """Release read stamps owned by a task after its lifecycle ends."""
+        with self._state_lock:
+            self._reads.pop(task_id, None)
+
     # ── Testing hooks ───────────────────────────────────────────────
     def clear(self) -> None:
         """Reset all state.  Intended for tests only."""
@@ -256,6 +270,7 @@ class FileStateRegistry:
             self._last_writer.clear()
         with self._meta_lock:
             self._path_locks.clear()
+            self._path_lock_users.clear()
 
 
 # ── Module-level singleton + helpers ─────────────────────────────────

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -1581,12 +1581,29 @@ def _get_file_ops(task_id: str = "default") -> ShellFileOperations:
 
 
 def clear_file_ops_cache(task_id: str = None):
-    """Clear the file operations cache."""
+    """Clear file-operation state for a finished task, or all tasks."""
     with _file_ops_lock:
         if task_id:
             _file_ops_cache.pop(task_id, None)
         else:
             _file_ops_cache.clear()
+
+    with _read_tracker_lock:
+        if task_id:
+            _read_tracker.pop(task_id, None)
+        else:
+            _read_tracker.clear()
+
+    with _patch_failure_lock:
+        if task_id:
+            _patch_failure_tracker.pop(task_id, None)
+        else:
+            _patch_failure_tracker.clear()
+
+    if task_id:
+        file_state.get_registry().forget_task(task_id)
+    else:
+        file_state.get_registry().clear()
 
 
 def _special_file_kind(path) -> str | None:


### PR DESCRIPTION
## Summary

- release `_read_tracker`, `_patch_failure_tracker`, and cross-agent read stamps when a terminal task lifecycle ends
- remove per-path lock entries after the last holder or waiter exits
- preserve bounded `_last_writer` history so parent agents still detect writes made by completed subagents

## Root cause

The file-tool registries capped entries inside each task, but retained every top-level task key for the lifetime of the gateway process. Per-path locks were also never removed. Long-lived gateways therefore accumulated state monotonically as sessions touched new tasks and paths.

The lock cleanup uses a waiter/holder reference count under the registry metadata lock. This avoids deleting an unlocked-looking entry while another thread is already waiting for it, which would allow two independent locks for the same path.

## Validation

- `PYTHONPATH=. python3 -m pytest tests/tools/test_file_state_registry.py -q` (`9 passed`)
- `PYTHONPATH=. python3 -m pytest tests/tools/test_patch_failure_tracking.py tests/tools/test_line_ending_preservation.py -q` (`8 passed`)
- `PYTHONPATH=. python3 -m pytest tests/tools/test_file_tools.py -q` (`45 passed, 2 skipped`)
- `ruff check tools/file_state.py tools/file_tools.py tests/tools/test_file_state_registry.py`
- `git diff --check`

Fixes #86514
