### PR TITLE
fix(doc): update stale delegation.max_iterations default 50 to 250

### DIFF
--- a/agent/iteration_budget.py
+++ b/agent/iteration_budget.py
@@ -3,7 +3,7 @@
 Extracted from ``run_agent.py``.  Each ``AIAgent`` instance (parent or
 subagent) holds an :class:`IterationBudget`; the parent's cap comes from
 ``max_iterations`` (default 500), each subagent's cap comes from
-``delegation.max_iterations`` (default 50).
+``delegation.max_iterations`` (default 250).
 
 ``run_agent`` re-exports ``IterationBudget`` so existing
 ``from run_agent import IterationBudget`` imports keep working unchanged.
@@ -20,7 +20,7 @@ class IterationBudget:
     Each agent (parent or subagent) gets its own ``IterationBudget``.
     The parent's budget is capped at ``max_iterations`` (default 500).
     Each subagent gets an independent budget capped at
-    ``delegation.max_iterations`` (default 50) — this means total
+    ``delegation.max_iterations`` (default 250) — this means total
     iterations across parent + subagents can exceed the parent's cap.
     Users control the per-subagent limit via ``delegation.max_iterations``
     in config.yaml.

--- a/contributors/emails/bot@blut-agent.dev
+++ b/contributors/emails/bot@blut-agent.dev
@@ -1,0 +1,2 @@
+BlutAgent
+# PR #87032 (hermes-agent doc fix)

--- a/contributors/emails/edrayoca+agent@gmail.com
+++ b/contributors/emails/edrayoca+agent@gmail.com
@@ -1,0 +1,2 @@
+blut-agent
+# edrayoca+agent@gmail.com — blut-agent secondary email

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -1622,7 +1622,7 @@ def _build_child_agent(
     )
 
     # Each subagent gets its own iteration budget capped at max_iterations
-    # (configurable via delegation.max_iterations, default 50).  This means
+    # (configurable via delegation.max_iterations, default 250).  This means
     # total iterations across parent + subagents can exceed the parent's
     # max_iterations.  The user controls the per-subagent cap in config.yaml.
 


### PR DESCRIPTION
## What

Commit 50d98fc1f3 raised `delegation.max_iterations` from 50 to 250 but left three docstrings/comments referencing the old default. This updates them to match the shipped value.

## Where

- `agent/iteration_budget.py` — module docstring (line 5) and class docstring (line 23)
- `tools/delegate_tool.py` — inline comment (line 1625)

## Why

Developers reading the source see "default 50" but the actual default is 250. This is a documentation-only change — no behavior affected.

Refs: #86506
