### PR TITLE
fix: read deprecated cwd vars from .env file, not os.environ

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2184,15 +2184,21 @@ def warn_deprecated_cwd_env_vars(config: Optional[Dict[str, Any]] = None) -> Non
 
     These env vars are deprecated — the canonical setting is terminal.cwd
     in config.yaml.  Prints a migration hint to stderr.
-    """
-    messaging_cwd = os.environ.get("MESSAGING_CWD")
-    terminal_cwd_env = os.environ.get("TERMINAL_CWD")
 
+    Reads the .env FILE (via ``load_env()``), NOT ``os.environ``: Hermes
+    bridges ``terminal.cwd`` into ``TERMINAL_CWD`` in the process environment
+    at startup, so an ``os.environ`` read would false-positive on Hermes's own
+    bridge output even when the user never wrote the deprecated var to .env.
+    """
     if config is None:
         try:
             config = load_config()
         except Exception:
             return
+
+    env_vars = load_env()
+    messaging_cwd = env_vars.get("MESSAGING_CWD")
+    terminal_cwd_env = env_vars.get("TERMINAL_CWD")
 
     terminal_cfg = config.get("terminal", {})
     config_cwd = terminal_cfg.get("cwd", ".") if isinstance(terminal_cfg, dict) else "."

--- a/tests/hermes_cli/test_deprecated_cwd_warning.py
+++ b/tests/hermes_cli/test_deprecated_cwd_warning.py
@@ -1,12 +1,20 @@
 """Tests for warn_deprecated_cwd_env_vars() migration warning."""
 
+import pytest
+
 
 class TestDeprecatedCwdWarning:
     """Warn when MESSAGING_CWD or TERMINAL_CWD is set in .env."""
 
     def test_messaging_cwd_triggers_warning(self, monkeypatch, capsys):
         monkeypatch.setenv("MESSAGING_CWD", "/some/path")
-        monkeypatch.delenv("TERMINAL_CWD", raising=False)
+        monkeypatch.setenv("TERMINAL_CWD", "/term/path")
+        # Simulate the .env file content (the warning must read the FILE,
+        # not os.environ — the env vars above are ambient bridge noise).
+        monkeypatch.setattr(
+            "hermes_cli.config.load_env",
+            lambda: {"MESSAGING_CWD": "/some/path"},
+        )
 
         from hermes_cli.config import warn_deprecated_cwd_env_vars
         warn_deprecated_cwd_env_vars(config={})
@@ -15,11 +23,14 @@ class TestDeprecatedCwdWarning:
         assert "MESSAGING_CWD" in captured.err
         assert "deprecated" in captured.err.lower()
         assert "config.yaml" in captured.err
-
+        # TERMINAL_CWD is NOT in .env -> must not warn about it
+        assert "TERMINAL_CWD" not in captured.err
 
     def test_both_deprecated_vars_warn(self, monkeypatch, capsys):
-        monkeypatch.setenv("MESSAGING_CWD", "/msg/path")
-        monkeypatch.setenv("TERMINAL_CWD", "/term/path")
+        monkeypatch.setattr(
+            "hermes_cli.config.load_env",
+            lambda: {"MESSAGING_CWD": "/msg/path", "TERMINAL_CWD": "/term/path"},
+        )
 
         from hermes_cli.config import warn_deprecated_cwd_env_vars
         warn_deprecated_cwd_env_vars(config={})
@@ -27,3 +38,30 @@ class TestDeprecatedCwdWarning:
         captured = capsys.readouterr()
         assert "MESSAGING_CWD" in captured.err
         assert "TERMINAL_CWD" in captured.err
+
+    def test_terminal_cwd_ignored_when_config_has_explicit_cwd(self, monkeypatch, capsys):
+        monkeypatch.setattr(
+            "hermes_cli.config.load_env",
+            lambda: {"TERMINAL_CWD": "/term/path"},
+        )
+        config = {"terminal": {"cwd": "/explicit/path"}}
+
+        from hermes_cli.config import warn_deprecated_cwd_env_vars
+        warn_deprecated_cwd_env_vars(config=config)
+
+        captured = capsys.readouterr()
+        assert "TERMINAL_CWD" not in captured.err
+
+    def test_env_var_without_dotenv_entry_does_not_warn(self, monkeypatch, capsys):
+        """Regression: TERMINAL_CWD present in os.environ (e.g. injected by
+        Hermes' own config bridge) but absent from the .env file must NOT
+        trigger the deprecated warning."""
+        monkeypatch.setenv("TERMINAL_CWD", "/Users/wen")
+        monkeypatch.setenv("MESSAGING_CWD", "/msg/path")
+        monkeypatch.setattr("hermes_cli.config.load_env", lambda: {})
+
+        from hermes_cli.config import warn_deprecated_cwd_env_vars
+        warn_deprecated_cwd_env_vars(config={})
+
+        captured = capsys.readouterr()
+        assert captured.err == ""


### PR DESCRIPTION
## Summary

Fixes a false-positive in the startup deprecation warning: `warn_deprecated_cwd_env_vars()` claimed `TERMINAL_CWD` / `MESSAGING_CWD` were "found in .env" by reading **`os.environ`**, not the `.env` file.

Hermes bridges `terminal.cwd` into `TERMINAL_CWD` in the process environment at startup (gateway config bridge), so an `os.environ` read falsely triggers the warning even when:
- the user never wrote the deprecated var to `.env`, and
- the `.env` line is commented out (e.g. `# TERMINAL_CWD=.`).

## Root cause

`hermes_cli/config.py` → `warn_deprecated_cwd_env_vars()`:

```python
terminal_cwd_env = os.environ.get("TERMINAL_CWD")   # reads env, not .env
...
if terminal_cwd_env and not config_has_explicit_cwd:
    # "TERMINAL_CWD=... found in .env — this is deprecated."
```

The comment in the original code even says "likely from .env" — it never checks the file. Since Hermes itself injects `TERMINAL_CWD` into the environment (resolving the `.` placeholder to `Path.home()` and bridging terminal config to `TERMINAL_*` vars), every startup with `terminal.cwd: .` in config.yaml and a Hermes-injected env emits a spurious migration warning.

## Fix

Read the deprecated vars from the **`.env` file** via the existing `load_env()` helper (which skips comment/blank lines), not from `os.environ`:

- `.env` entry present → warning still fires (migration is genuinely needed).
- Only ambient env var / Hermes bridge → no warning.

## Tests

Added/updated in `tests/hermes_cli/test_deprecated_cwd_warning.py`:

- `test_messaging_cwd_triggers_warning` — env vars set but only `.env` content matters; `TERMINAL_CWD` absent from `.env` must not warn.
- `test_both_deprecated_vars_warn` — both vars in `.env` warn.
- `test_terminal_cwd_ignored_when_config_has_explicit_cwd` — explicit `terminal.cwd` in config.yaml suppresses the warning.
- `test_env_var_without_dotenv_entry_does_not_warn` — **regression**: `TERMINAL_CWD` in `os.environ` (Hermes bridge) but absent from `.env` must not warn.

Verification:
- `tests/hermes_cli/test_deprecated_cwd_warning.py`: 4 passed.
- End-to-end with a temp `HERMES_HOME`: env-only var → no warning; `.env` entry → warning emitted with correct hint.
- Broader `tests/hermes_cli -k "config or env or dotenv or cwd"`: 917 passed; 32 failures reproduce independently of this change (browser-install / venv-health tests, pass when run in isolation).
