### PR TITLE
fix(cli): combined markdown-strip code preservation from #84379 and #84502 (#84377)

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -3087,8 +3087,79 @@ def _rich_text_from_ansi(text: str) -> _RichText:
 
 
 def _strip_markdown_syntax(text: str) -> str:
-    """Best-effort markdown marker removal for plain-text display."""
+    """Best-effort markdown marker removal for plain-text display.
+
+    Code spans and fenced code blocks — including fenced blocks nested inside
+    blockquotes — are protected while prose markers are removed.  Python
+    identifiers and operators share their characters with Markdown emphasis,
+    so running the prose regexes over code corrupts otherwise verbatim output
+    (``__name__`` renders as ``name``, ``a**2`` is eaten as bold).  Fence
+    markers are still dropped and inline backticks still unwrapped, as
+    before — only the *contents* are protected from being interpreted as
+    markdown.  See issue #84377.
+    """
     plain = _rich_text_from_ansi(text or "").plain
+    # Shelve code spans before marker removal: fence markers are dropped and
+    # inline backticks unwrapped, but the code bodies are restored verbatim
+    # after the prose regexes have run.  The placeholder token contains NO
+    # markdown metacharacters (no `_`, `*`, `~`, `#`, `[`, `]`, `` ` ``), so
+    # no prose regex can touch it — dunder identifiers and ``**`` operators
+    # inside code are never interpreted as markdown emphasis.
+    _shelved: list[str] = []
+    _CODE_PLACEHOLDER = "\x00HERMESCODE{}\x00"
+
+    def _shelve(match: re.Match[str]) -> str:
+        _shelved.append(match.group(1))
+        return _CODE_PLACEHOLDER.format(len(_shelved) - 1)
+
+    # Fenced blocks: drop the fence lines (keeping any info string, matching
+    # the old fence-marker-only removal) and shelve the body verbatim.  The
+    # fence regex also accepts blockquote prefixes (``> ``` ``), since models
+    # commonly wrap code snippets in blockquotes when quoting docs.
+    _out_lines: list[str] = []
+    _in_fence = False
+    _fence_char = ""
+    _fence_len = 0
+    _fence_body: list[str] = []
+    for _line in plain.split("\n"):
+        _fm = re.match(r"^(\s*(?:>\s*)*)(`{3,}|~{3,})", _line)
+        if _fm is None:
+            if _in_fence:
+                _fence_body.append(_line)
+            else:
+                _out_lines.append(_line)
+            continue
+        _prefix = _fm.group(1)
+        _marker = _fm.group(2)
+        _trailing = _line[_fm.end():]
+        if not _in_fence:
+            _in_fence = True
+            _fence_char = _marker[0]
+            _fence_len = len(_marker)
+            _fence_body = []
+            if _trailing.strip():
+                _out_lines.append(_prefix + _trailing.lstrip())
+        elif (
+            _marker[0] == _fence_char
+            and len(_marker) >= _fence_len
+            and not _trailing.strip()
+        ):
+            _in_fence = False
+            _shelved.append("\n".join(_fence_body))
+            _out_lines.append(_CODE_PLACEHOLDER.format(len(_shelved) - 1))
+        else:
+            # Different fence char, shorter marker, or trailing content:
+            # CommonMark treats it as body content, not a closer.
+            _fence_body.append(_line)
+    if _in_fence:
+        # Unterminated block — body stays visible, just protected.
+        _shelved.append("\n".join(_fence_body))
+        _out_lines.append(_CODE_PLACEHOLDER.format(len(_shelved) - 1))
+    plain = "\n".join(_out_lines)
+
+    # Inline code spans: unwrap the backticks but protect the contents.
+    plain = re.sub(r"`([^`]*)`", _shelve, plain)
+
     # Avoid stripping cron-style expressions like "* * * * *" as if they were
     # Markdown horizontal rules. CommonMark treats three or more "*" as an HR,
     # but in Hermes output it's common to display cron schedules verbatim.
@@ -3099,8 +3170,6 @@ def _strip_markdown_syntax(text: str) -> str:
     plain = re.sub(r"^\s{0,3}(?:\*\s*){3}\s*$", "", plain, flags=re.MULTILINE)
     plain = re.sub(r"^\s{0,3}#{1,6}\s+", "", plain, flags=re.MULTILINE)
     # Preserve blockquotes, lists, and checkboxes because they carry structure.
-    plain = re.sub(r"(```+|~~~+)", "", plain)
-    plain = re.sub(r"`([^`]*)`", r"\1", plain)
     plain = re.sub(r"!\[([^\]]*)\]\([^\)]*\)", r"\1", plain)
     plain = re.sub(r"\[([^\]]+)\]\([^\)]*\)", r"\1", plain)
     plain = re.sub(r"\*\*\*([^*]+)\*\*\*", r"\1", plain)
@@ -3113,6 +3182,12 @@ def _strip_markdown_syntax(text: str) -> str:
     plain = re.sub(r"(?<!\w)_([^_]+)_(?!\w)", r"\1", plain)
     plain = re.sub(r"~~([^~]+)~~", r"\1", plain)
     plain = re.sub(r"\n{3,}", "\n\n", plain)
+
+    # Restore shelved code verbatim.
+    def _restore(match: re.Match[str]) -> str:
+        return _shelved[int(match.group(1))]
+
+    plain = re.sub(_CODE_PLACEHOLDER.format(r"(\d+)"), _restore, plain)
     return plain.strip("\n")
 
 
@@ -4769,6 +4844,16 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         # populated only while `_in_stream_table` is True.
         self._stream_table_buf: list[str] = []
         self._in_stream_table = False
+        # Fenced-code buffer.  Streamed lines inside ``` / ~~~ fences are
+        # held here and stripped as ONE block on close, so the emphasis
+        # regexes never see code bodies — per-line stripping ate literal
+        # asterisks in code (see #84377).  Mirrors the table-block
+        # buffering above; `_stream_fence_char`/`_stream_fence_len` record
+        # the opener so a closer must match char and length.
+        self._stream_fence_buf: list[str] = []
+        self._stream_in_fence = False
+        self._stream_fence_char = ""
+        self._stream_fence_len = 0
         self._pending_edit_snapshots = {}
         self._last_input_mode_recovery = 0.0
         self._input_mode_recovery_notice_shown = False
@@ -7533,6 +7618,47 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         while "\n" in self._stream_buf:
             line, self._stream_buf = self._stream_buf.split("\n", 1)
 
+            # Fenced-code blocks: buffer until the closing fence, then
+            # strip the WHOLE block at once.  Per-line stripping lets the
+            # emphasis regexes eat literal asterisks inside code (see
+            # #84377) because a lone body line is not recognised as code.
+            # Blockquote prefixes (``> ``` ``) are accepted too, matching
+            # _strip_markdown_syntax.
+            _fm = re.match(r"^(\s*(?:>\s*)*)(`{3,}|~{3,})", line)
+            if _fm is not None:
+                _marker = _fm.group(2)
+                _trailing = line[_fm.end():]
+                if not getattr(self, "_stream_in_fence", False):
+                    # Opening fence (info string, if any, is kept by the
+                    # block-level stripper on close).
+                    self._stream_in_fence = True
+                    self._stream_fence_char = _marker[0]
+                    self._stream_fence_len = len(_marker)
+                    self._stream_fence_buf = [line]
+                elif (
+                    _marker[0] == getattr(self, "_stream_fence_char", "")
+                    and len(_marker) >= getattr(self, "_stream_fence_len", 3)
+                    and not _trailing.strip()
+                ):
+                    # Closing fence: strip and emit the whole block.
+                    self._stream_fence_buf.append(line)
+                    joined = "\n".join(self._stream_fence_buf)
+                    self._stream_in_fence = False
+                    self._stream_fence_buf = []
+                    if self.final_response_markdown == "strip":
+                        joined = _strip_markdown_syntax(joined)
+                    for ln in joined.split("\n"):
+                        _emit_one(ln)
+                else:
+                    # Different fence char, shorter marker, or trailing
+                    # content on a fence line: CommonMark treats it as
+                    # body content.
+                    self._stream_fence_buf.append(line)
+                continue
+            if getattr(self, "_stream_in_fence", False):
+                self._stream_fence_buf.append(line)
+                continue
+
             # Hold table-shaped lines in a side-buffer so we can re-pad
             # the whole block once it ends.  Streaming line-by-line, we
             # cannot re-align mid-table without reflowing already-printed
@@ -7598,6 +7724,26 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
 
         _tc = getattr(self, "_stream_text_ansi", "")
 
+        # If the stream ended inside a fenced-code block, flush the
+        # buffered block now (body stays protected from the emphasis
+        # regexes — matches the unterminated-fence handling in
+        # _strip_markdown_syntax).
+        if getattr(self, "_stream_in_fence", False):
+            # Fold any trailing partial line into the block so it is
+            # stripped as code, not per-line (which would eat literal
+            # asterisks in an unterminated fence).
+            _fence_buf = getattr(self, "_stream_fence_buf", [])
+            if self._stream_buf:
+                _fence_buf.append(self._stream_buf)
+                self._stream_buf = ""
+            joined = "\n".join(_fence_buf)
+            self._stream_in_fence = False
+            self._stream_fence_buf = []
+            if self.final_response_markdown == "strip":
+                joined = _strip_markdown_syntax(joined)
+            for ln in joined.split("\n"):
+                _cprint(f"{_STREAM_PAD}{_tc}{ln}{_RST}" if _tc else f"{_STREAM_PAD}{ln}")
+
         # If the stream buffer has a trailing partial line that looks like
         # a table row, fold it into the table buffer so the whole block
         # gets re-aligned together.  Otherwise the final row prints raw
@@ -7648,6 +7794,10 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         self._deferred_content = ""
         self._stream_table_buf = []
         self._in_stream_table = False
+        self._stream_fence_buf = []
+        self._stream_in_fence = False
+        self._stream_fence_char = ""
+        self._stream_fence_len = 0
 
     def _slow_command_status(self, command: str) -> str:
         """Return a user-facing status message for slower slash commands."""

--- a/tests/cli/test_cli_markdown_rendering.py
+++ b/tests/cli/test_cli_markdown_rendering.py
@@ -102,3 +102,164 @@ def test_strip_mode_still_strips_boundary_underscore_emphasis():
 
     output = _render_to_text(renderable)
     assert "say hi and bold now" in output
+
+
+def test_strip_mode_preserves_dunder_identifiers_in_fenced_code():
+    # Regression: #84377 — dunder identifiers and ** operators inside
+    # fenced code blocks must render verbatim, not be eaten as emphasis.
+    renderable = _render_final_assistant_content(
+        "```python\n"
+        'if __name__ == "__main__":\n'
+        "    total = a**2 + b**2\n"
+        "```",
+        mode="strip",
+    )
+
+    output = _render_to_text(renderable)
+    assert 'if __name__ == "__main__":' in output
+    assert "total = a**2 + b**2" in output
+
+
+def test_strip_mode_preserves_dunders_in_unterminated_fence():
+    # A fence without a closing marker still marks the intent as code.
+    renderable = _render_final_assistant_content(
+        "```\nvalue = __all__[0]\n",
+        mode="strip",
+    )
+
+    output = _render_to_text(renderable)
+    assert "value = __all__[0]" in output
+
+
+def test_strip_mode_preserves_emphasis_in_inline_code():
+    # Regression: #84377 — inline code spans keep ** and __ verbatim while
+    # prose emphasis around them is still stripped.
+    renderable = _render_final_assistant_content(
+        "Run `a**2` and guard with `if __name__ == '__main__':` now",
+        mode="strip",
+    )
+
+    output = _render_to_text(renderable)
+    assert "a**2" in output
+    assert "__name__" in output
+
+
+def test_strip_mode_still_strips_prose_emphasis_outside_code():
+    renderable = _render_final_assistant_content(
+        "**bold** prose and `**not bold**` code",
+        mode="strip",
+    )
+
+    output = _render_to_text(renderable)
+    assert "bold prose and" in output
+    assert "**not bold**" in output
+
+
+def test_strip_mode_preserves_code_in_blockquote_fenced_block():
+    # Third path beyond #84379/#84502: a fenced block nested inside a
+    # blockquote (models quote docs this way) must keep its code verbatim.
+    renderable = _render_final_assistant_content(
+        "> ```python\n"
+        '> if __name__ == "__main__":\n'
+        ">     value = a**2 + b**2\n"
+        "> ```\n",
+        mode="strip",
+    )
+
+    output = _render_to_text(renderable)
+    assert 'if __name__ == "__main__":' in output
+    assert "value = a**2 + b**2" in output
+
+
+def test_strip_mode_streaming_fence_keeps_asterisks_in_code(monkeypatch):
+    # Regression: the streaming path stripped each line individually, so
+    # `*` / `**` inside fenced code blocks were eaten (e.g. `*.{ts,tsx}`
+    # became `.{ts,tsx}`). Fenced lines must be buffered and stripped as
+    # one block on close.
+    import cli as cli_mod
+    from cli import HermesCLI
+
+    cli = HermesCLI.__new__(HermesCLI)
+    cli.show_reasoning = False
+    cli.show_timestamps = False
+    cli.final_response_markdown = "strip"
+    cli._stream_buf = ""
+    cli._stream_started = False
+    cli._stream_box_opened = False
+    cli._stream_prefilt = ""
+    cli._in_reasoning_block = False
+    cli._reasoning_stream_started = False
+    cli._reasoning_box_opened = False
+    cli._reasoning_buf = ""
+    cli._reasoning_preview_buf = ""
+    cli._deferred_content = ""
+    cli._stream_text_ansi = ""
+    cli._stream_needs_break = False
+    cli._stream_table_buf = []
+    cli._in_stream_table = False
+    cli._stream_fence_buf = []
+    cli._stream_in_fence = False
+    cli._stream_fence_char = ""
+    cli._stream_fence_len = 0
+
+    emitted = []
+    monkeypatch.setattr(cli_mod, "_cprint", lambda s: emitted.append(s))
+    monkeypatch.setattr(cli, "_scrollback_box_width", lambda: 80)
+    monkeypatch.setattr(HermesCLI, "_status_bar_display_width", staticmethod(lambda s: 10))
+
+    fence = "```bash\nrg --pcre2 -g '*.{ts,tsx}' '^import(?:(?!.*@mui\\/material).)*IconButton.*$'\n```"
+    # Feed in 3-char chunks to simulate streaming.
+    for i in range(0, len(fence), 3):
+        cli._emit_stream_text(fence[i : i + 3])
+    cli._flush_stream()  # stream end: flush any buffered partial line
+
+    joined = "".join(emitted)
+    assert "*.{ts,tsx}" in joined
+    assert ".*" in joined
+    assert "IconButton" in joined
+    assert "```" not in joined
+
+
+def test_strip_mode_streaming_unterminated_fence_keeps_code(monkeypatch):
+    # If the stream ends inside a fenced block, the buffered body is still
+    # stripped as one unit instead of line-by-line.
+    import cli as cli_mod
+    from cli import HermesCLI
+
+    cli = HermesCLI.__new__(HermesCLI)
+    cli.show_reasoning = False
+    cli.show_timestamps = False
+    cli.final_response_markdown = "strip"
+    cli._stream_buf = ""
+    cli._stream_started = False
+    cli._stream_box_opened = False
+    cli._stream_prefilt = ""
+    cli._in_reasoning_block = False
+    cli._reasoning_stream_started = False
+    cli._reasoning_box_opened = False
+    cli._reasoning_buf = ""
+    cli._reasoning_preview_buf = ""
+    cli._deferred_content = ""
+    cli._stream_text_ansi = ""
+    cli._stream_needs_break = False
+    cli._stream_table_buf = []
+    cli._in_stream_table = False
+    cli._stream_fence_buf = []
+    cli._stream_in_fence = False
+    cli._stream_fence_char = ""
+    cli._stream_fence_len = 0
+
+    emitted = []
+    monkeypatch.setattr(cli_mod, "_cprint", lambda s: emitted.append(s))
+    monkeypatch.setattr(cli, "_scrollback_box_width", lambda: 80)
+    monkeypatch.setattr(HermesCLI, "_status_bar_display_width", staticmethod(lambda s: 10))
+
+    text = "```\nvalue = __all__[0]\nmore = a**2\n"
+    for i in range(0, len(text), 3):
+        cli._emit_stream_text(text[i : i + 3])
+    cli._flush_stream()
+
+    joined = "".join(emitted)
+    assert "value = __all__[0]" in joined
+    assert "more = a**2" in joined
+    assert "```" not in joined

--- a/tests/cli/test_strip_markdown_syntax.py
+++ b/tests/cli/test_strip_markdown_syntax.py
@@ -1,0 +1,80 @@
+"""Unit tests for _strip_markdown_syntax code preservation.
+
+Regression coverage for #84377: in ``final_response_markdown: strip`` mode,
+code contents share their characters with Markdown emphasis, so dunder
+identifiers (``__name__``) and ``**`` operators inside code were eaten as
+emphasis.  The function must protect fenced blocks and inline code spans
+while still stripping prose markers and unwrapping code delimiters.
+
+Note on the combined fix: #84379 protected code spans verbatim (keeping
+fences/backticks); #84502 unwraps delimiters but protects contents.  This
+suite follows #84502's contract — strip mode is "markdown marker removal",
+so fences and backticks are dropped, only the code *contents* survive
+intact — and additionally covers fenced blocks nested inside blockquotes,
+which neither PR handled.
+"""
+
+from cli import _strip_markdown_syntax
+
+
+def test_strip_markdown_syntax_preserves_inline_code():
+    # Backticks are unwrapped but the contents (dunders, **) survive verbatim.
+    text = "Use `__name__ == \"__main__\"` and `a**2 + b**2` here."
+    assert _strip_markdown_syntax(text) == 'Use __name__ == "__main__" and a**2 + b**2 here.'
+
+
+def test_strip_markdown_syntax_preserves_fenced_code():
+    text = (
+        "Before **bold**\n"
+        "```python\n"
+        'if __name__ == "__main__":\n'
+        "    value = a**2\n"
+        "```\n"
+        "After __prose__."
+    )
+    expected = (
+        "Before bold\n"
+        "python\n"
+        'if __name__ == "__main__":\n'
+        "    value = a**2\n"
+        "After prose."
+    )
+    assert _strip_markdown_syntax(text) == expected
+
+
+def test_strip_markdown_syntax_preserves_unterminated_fence():
+    # A fence without a closing marker still marks the intent as code.
+    text = "```\nvalue = __all__[0]\n"
+    assert _strip_markdown_syntax(text) == "value = __all__[0]"
+
+
+def test_strip_markdown_syntax_preserves_blockquote_fenced_code():
+    # Fenced blocks nested inside blockquotes (models quote docs this way)
+    # must keep their code verbatim too.  Neither #84379 nor #84502 covered
+    # the ``> ``` `` prefix; the fence regex accepts it now.
+    text = (
+        "> ```python\n"
+        '> if __name__ == "__main__":\n'
+        ">     value = a**2\n"
+        "> ```\n"
+        "After __prose__."
+    )
+    expected = (
+        "> python\n"
+        '> if __name__ == "__main__":\n'
+        ">     value = a**2\n"
+        "After prose."
+    )
+    assert _strip_markdown_syntax(text) == expected
+
+
+def test_strip_markdown_syntax_preserves_other_code_symbols():
+    # ~~strikethrough~~, triple-asterisk and underscore runs inside code are
+    # protected by the same shelving.
+    text = "```\nfoo ~~bar~~ baz\ntriple = a***b\n```"
+    assert _strip_markdown_syntax(text) == "foo ~~bar~~ baz\ntriple = a***b"
+
+
+def test_strip_markdown_syntax_still_strips_prose_emphasis_outside_code():
+    text = "**bold** prose and `**not bold**` code"
+    assert _strip_markdown_syntax(text) == "bold prose and **not bold** code"


### PR DESCRIPTION
Fixes #84377

> **综合修复**:本 PR 吸收并综合了两个 open PR 的方案——#84379(@kyssta-exe)与 #84502(Enough1122)——取其精华,合成一个更全面的修复,并补上两家都漏掉的第三条路径。

## 两家方案对比

| 维度 | #84379 | #84502 |
|---|---|---|
| 保什么 | 代码块+inline code **连分隔符** verbatim | 只保代码**内容**;fence/反引号仍按 strip 本义删除 |
| 实现 | 单条 regex 整体替换占位符 | 逐行解析 fence(CommonMark)+ inline shelve |
| streaming 路径 | 没碰 | 修了 _emit_stream_text/_flush_stream |
| 未终止 fence | 覆盖 | 覆盖(含 streaming) |
| 测试 | 2 单元 | 4 渲染级+1 streaming(真实 render 路径) |

**取舍**:以 #84502 为主(strip 模式本义是 marker removal,保留分隔符违背特性初衷;且覆盖 streaming 真实路径、测试走 _render_final_assistant_content 更稳);#84379 的增强 docstring 与其单元测试文件保留(适配获胜方契约)。

## 第三条路径(两家都漏的 bug class)

- **blockquote 内的 fenced code**(`> ```python`):#84502 的 `^\s*` 锚点匹配不到 `> ` 前缀;#84379 的非锚点 regex 遇到 `> ``` ` closing 不匹配而吞到文末。合成版扩展 fence regex 为 `^(\s*(?:\>\s*)*)(\`{3,}|~{3,})`,streaming 同步覆盖
- **硬化占位符**:#84502 的 `__HERMES_CODE_`(靠 `[^_]+` 恰好免疫,脆弱巧合)→ 改为无 markdown 元字符的 `\x00HERMESCODE{n}\x00`;streaming 的 `lstrip()[0]` 在 blockquote 下会取到 `>`,改为显式 `_stream_fence_char`/`_stream_fence_len` 状态

## Tests

- test_strip_markdown_syntax.py + test_cli_markdown_rendering.py:20 passed 零失败(含新 blockquote + 未终止 fence streaming 用例)
- tests/cli/ 全目录 112 个文件全部通过(3 个 test_bang_shell_mode.py 失败经 pristine 树复现确认为预存环境路径 flake,与本改动无关)
- 全程 LF,无 CRLF 变更;未触碰无关文件

建议合并本 PR 时保留对 #84379 的 credit。
