### PR TITLE
test: isolate platform-specific suite gates

### DIFF
--- a/tests/hermes_cli/test_dashboard_unified_launch.py
+++ b/tests/hermes_cli/test_dashboard_unified_launch.py
@@ -31,17 +31,25 @@ class TestUnifiedDashboardRouting:
 
     def test_profile_launch_reexecs_machine_dashboard(self, main_mod, monkeypatch):
         monkeypatch.delenv("HERMES_HOME", raising=False)
+        monkeypatch.delenv("HERMES_DESKTOP", raising=False)
         monkeypatch.setattr(
             "hermes_cli.profiles.get_active_profile_name", lambda: "worker_x"
         )
         monkeypatch.setattr(main_mod, "_dashboard_listening", lambda host, port: False)
         execs = []
 
-        def fake_exec(exe, argv, env):
-            execs.append((exe, argv, env))
-            raise SystemExit(0)  # execvpe never returns
+        if sys.platform == "win32":
+            def fake_popen(argv, env):
+                execs.append((sys.executable, argv, env))
+                return types.SimpleNamespace(wait=lambda: 0)
 
-        monkeypatch.setattr(main_mod.os, "execvpe", fake_exec)
+            monkeypatch.setattr(main_mod.subprocess, "Popen", fake_popen)
+        else:
+            def fake_exec(exe, argv, env):
+                execs.append((exe, argv, env))
+                raise SystemExit(0)  # execvpe never returns
+
+            monkeypatch.setattr(main_mod.os, "execvpe", fake_exec)
 
         with pytest.raises(SystemExit):
             main_mod.cmd_dashboard(_args())

--- a/tests/hermes_cli/test_gateway.py
+++ b/tests/hermes_cli/test_gateway.py
@@ -477,6 +477,7 @@ class TestReapUnsupervisedGatewayOrphansMacOS:
         # Pretend we're on macOS — supports_systemd_services() returns False
         # so the function does NOT short-circuit and proceeds to the scan.
         monkeypatch.setattr(gateway, "is_macos", lambda: True)
+        monkeypatch.setattr(gateway, "is_windows", lambda: False)
         monkeypatch.setattr(gateway, "supports_systemd_services", lambda: False)
 
         # _get_service_pids returns the launchd-managed gateway PID.
@@ -494,11 +495,21 @@ class TestReapUnsupervisedGatewayOrphansMacOS:
         )
 
         killed_pids = []
-        monkeypatch.setattr(gateway.os, "kill", lambda pid, sig: killed_pids.append((pid, sig)))
+        monkeypatch.setattr(
+            gateway,
+            "os",
+            SimpleNamespace(
+                getpid=os.getpid,
+                kill=lambda pid, sig: killed_pids.append((pid, sig)),
+            ),
+        )
         monkeypatch.setattr("gateway.status._pid_exists", lambda pid: False)
         monkeypatch.setattr("gateway.status.write_planned_stop_marker", lambda pid: None)
-        monkeypatch.setattr("time.sleep", lambda _: None)
-        monkeypatch.setattr("time.monotonic", lambda: 1.0)
+        monkeypatch.setattr(
+            gateway,
+            "time",
+            SimpleNamespace(sleep=lambda _: None, monotonic=lambda: 1.0),
+        )
 
         result = gateway._reap_unsupervised_gateway_orphans()
 
@@ -512,6 +523,7 @@ class TestReapUnsupervisedGatewayOrphansMacOS:
         launchd_pid = 52615
 
         monkeypatch.setattr(gateway, "is_macos", lambda: True)
+        monkeypatch.setattr(gateway, "is_windows", lambda: False)
         monkeypatch.setattr(gateway, "supports_systemd_services", lambda: False)
         monkeypatch.setattr(gateway, "_get_service_pids", lambda: {launchd_pid})
         monkeypatch.setattr("gateway.status.get_running_pid", lambda: None)
@@ -524,7 +536,14 @@ class TestReapUnsupervisedGatewayOrphansMacOS:
         )
 
         killed_pids = []
-        monkeypatch.setattr(gateway.os, "kill", lambda pid, sig: killed_pids.append((pid, sig)))
+        monkeypatch.setattr(
+            gateway,
+            "os",
+            SimpleNamespace(
+                getpid=os.getpid,
+                kill=lambda pid, sig: killed_pids.append((pid, sig)),
+            ),
+        )
 
         result = gateway._reap_unsupervised_gateway_orphans()
 

--- a/tests/hermes_cli/test_gateway.py
+++ b/tests/hermes_cli/test_gateway.py
@@ -13,6 +13,20 @@ import pytest
 import hermes_cli.gateway as gateway
 
 
+def _isolate_reaper_runtime(monkeypatch, kill, *, monotonic=lambda: 1.0):
+    """Patch gateway process primitives without mutating shared stdlib modules."""
+    monkeypatch.setattr(
+        gateway,
+        "os",
+        SimpleNamespace(getpid=os.getpid, kill=kill),
+    )
+    monkeypatch.setattr(
+        gateway,
+        "time",
+        SimpleNamespace(sleep=lambda _: None, monotonic=monotonic),
+    )
+
+
 def _install_fake_gateway_run(monkeypatch, start_gateway):
     module = ModuleType("gateway.run")
     module.start_gateway = start_gateway
@@ -606,11 +620,11 @@ class TestReapUnsupervisedGatewayOrphansWindows:
         )
 
         killed_pids = []
-        monkeypatch.setattr(gateway.os, "kill", lambda pid, sig: killed_pids.append((pid, sig)))
+        _isolate_reaper_runtime(
+            monkeypatch, lambda pid, sig: killed_pids.append((pid, sig))
+        )
         monkeypatch.setattr("gateway.status._pid_exists", lambda pid: False)
         monkeypatch.setattr("gateway.status.write_planned_stop_marker", lambda pid: None)
-        monkeypatch.setattr("time.sleep", lambda _: None)
-        monkeypatch.setattr("time.monotonic", lambda: 1.0)
 
         result = gateway._reap_unsupervised_gateway_orphans()
 
@@ -649,7 +663,9 @@ class TestReapUnsupervisedGatewayOrphansWindows:
         )
 
         killed_pids = []
-        monkeypatch.setattr(gateway.os, "kill", lambda pid, sig: killed_pids.append((pid, sig)))
+        _isolate_reaper_runtime(
+            monkeypatch, lambda pid, sig: killed_pids.append((pid, sig))
+        )
 
         result = gateway._reap_unsupervised_gateway_orphans()
 
@@ -714,11 +730,11 @@ class TestReaperCandidateIsSupervisorOwned:
         )
 
         killed_pids = []
-        monkeypatch.setattr(gateway.os, "kill", lambda pid, sig: killed_pids.append((pid, sig)))
+        _isolate_reaper_runtime(
+            monkeypatch, lambda pid, sig: killed_pids.append((pid, sig))
+        )
         monkeypatch.setattr("gateway.status._pid_exists", lambda pid: False)
         monkeypatch.setattr("gateway.status.write_planned_stop_marker", lambda pid: None)
-        monkeypatch.setattr("time.sleep", lambda _: None)
-        monkeypatch.setattr("time.monotonic", lambda: 1.0)
 
         result = gateway._reap_unsupervised_gateway_orphans()
 
@@ -754,11 +770,11 @@ class TestReaperCandidateIsSupervisorOwned:
         )
 
         killed_pids = []
-        monkeypatch.setattr(gateway.os, "kill", lambda pid, sig: killed_pids.append((pid, sig)))
+        _isolate_reaper_runtime(
+            monkeypatch, lambda pid, sig: killed_pids.append((pid, sig))
+        )
         monkeypatch.setattr("gateway.status._pid_exists", lambda pid: False)
         monkeypatch.setattr("gateway.status.write_planned_stop_marker", lambda pid: None)
-        monkeypatch.setattr("time.sleep", lambda _: None)
-        monkeypatch.setattr("time.monotonic", lambda: 1.0)
 
         result = gateway._reap_unsupervised_gateway_orphans()
 
@@ -837,7 +853,9 @@ class TestWindowsScheduledTaskSupervisorGuard:
 
         monkeypatch.setattr(gateway, "find_gateway_pids", _boom_find_gateway_pids)
         killed_pids = []
-        monkeypatch.setattr(gateway.os, "kill", lambda pid, sig: killed_pids.append((pid, sig)))
+        _isolate_reaper_runtime(
+            monkeypatch, lambda pid, sig: killed_pids.append((pid, sig))
+        )
 
         result = gateway._reap_unsupervised_gateway_orphans()
 
@@ -865,11 +883,11 @@ class TestWindowsScheduledTaskSupervisorGuard:
             ],
         )
         killed_pids = []
-        monkeypatch.setattr(gateway.os, "kill", lambda pid, sig: killed_pids.append((pid, sig)))
+        _isolate_reaper_runtime(
+            monkeypatch, lambda pid, sig: killed_pids.append((pid, sig))
+        )
         monkeypatch.setattr("gateway.status._pid_exists", lambda pid: False)
         monkeypatch.setattr("gateway.status.write_planned_stop_marker", lambda pid: None)
-        monkeypatch.setattr("time.sleep", lambda _: None)
-        monkeypatch.setattr("time.monotonic", lambda: 1.0)
 
         result = gateway._reap_unsupervised_gateway_orphans()
 

--- a/tests/tools/test_browser_npx_warmup.py
+++ b/tests/tools/test_browser_npx_warmup.py
@@ -15,6 +15,7 @@ npx PID — on timeout.
 
 from __future__ import annotations
 
+import os
 import subprocess
 from unittest.mock import MagicMock, patch
 
@@ -124,7 +125,7 @@ def test_merges_extended_path_so_managed_only_npx_can_find_sibling_node():
 
 
 def test_runs_in_its_own_process_group_on_posix(monkeypatch):
-    monkeypatch.setattr("os.name", "posix")
+    monkeypatch.setattr("tools.browser_tool._runtime_os_name", lambda: "posix")
     with patch("tools.browser_tool._resolve_npx_bin", return_value="/usr/bin/npx"), \
          patch("subprocess.Popen", return_value=_mock_proc()) as mock_popen:
         warm_agent_browser_npx_cache()
@@ -137,7 +138,7 @@ def test_uses_new_process_group_creationflag_on_windows_instead_of_start_new_ses
     """start_new_session is a POSIX-only Popen kwarg (raises on Windows).
     The Windows equivalent for _kill_process_tree's taskkill /T to have a
     coherent tree to kill is CREATE_NEW_PROCESS_GROUP via creationflags."""
-    with patch("os.name", "nt"), \
+    with patch("tools.browser_tool._runtime_os_name", return_value="nt"), \
          patch("tools.browser_tool._resolve_npx_bin", return_value="C:\\npx.cmd"), \
          patch("tools.browser_tool._build_browser_env", return_value={"PATH": "C:\\Windows"}), \
          patch("tools.browser_tool._merge_browser_path", side_effect=lambda p: p), \
@@ -222,26 +223,28 @@ class TestKillProcessTree:
 
         proc = MagicMock()
         proc.pid = 999
-        monkeypatch.setattr("os.name", "posix")
-        monkeypatch.setattr("os.getpgid", lambda pid: 999)
+        monkeypatch.setattr("tools.browser_tool._runtime_os_name", lambda: "posix")
+        monkeypatch.setattr(os, "getpgid", lambda pid: 999, raising=False)
         killpg_calls = []
         monkeypatch.setattr(
-            "os.killpg", lambda pgid, sig: killpg_calls.append((pgid, sig))
+            os, "killpg", lambda pgid, sig: killpg_calls.append((pgid, sig)),
+            raising=False,
         )
 
         _kill_process_tree(proc)
 
-        assert killpg_calls == [(999, signal.SIGTERM), (999, signal.SIGKILL)]
+        sigkill = getattr(signal, "SIGKILL", signal.SIGTERM)
+        assert killpg_calls == [(999, signal.SIGTERM), (999, sigkill)]
 
     def test_posix_missing_process_returns_silently(self, monkeypatch):
         proc = MagicMock()
         proc.pid = 999
-        monkeypatch.setattr("os.name", "posix")
+        monkeypatch.setattr("tools.browser_tool._runtime_os_name", lambda: "posix")
 
         def _raise(pid):
             raise ProcessLookupError()
 
-        monkeypatch.setattr("os.getpgid", _raise)
+        monkeypatch.setattr(os, "getpgid", _raise, raising=False)
 
         _kill_process_tree(proc)  # must not raise
 
@@ -257,7 +260,7 @@ class TestKillProcessTree:
 
         proc = MagicMock()
         proc.pid = 999
-        monkeypatch.setattr("os.name", "posix")
+        monkeypatch.setattr("tools.browser_tool._runtime_os_name", lambda: "posix")
         monkeypatch.delattr(os_module, "killpg", raising=False)
 
         _kill_process_tree(proc)
@@ -270,7 +273,7 @@ class TestKillProcessTree:
         proc = MagicMock()
         proc.pid = 999
         proc.kill.side_effect = OSError("already reaped")
-        monkeypatch.setattr("os.name", "posix")
+        monkeypatch.setattr("tools.browser_tool._runtime_os_name", lambda: "posix")
         monkeypatch.delattr(os_module, "killpg", raising=False)
 
         _kill_process_tree(proc)  # must not raise
@@ -283,15 +286,15 @@ class TestKillProcessTree:
 
         proc = MagicMock()
         proc.pid = 999
-        monkeypatch.setattr("os.name", "posix")
-        monkeypatch.setattr("os.getpgid", lambda pid: 999)
+        monkeypatch.setattr("tools.browser_tool._runtime_os_name", lambda: "posix")
+        monkeypatch.setattr(os, "getpgid", lambda pid: 999, raising=False)
         killpg_calls = []
 
         def fake_killpg(pgid, sig):
             killpg_calls.append((pgid, sig))
             raise PermissionError()
 
-        monkeypatch.setattr("os.killpg", fake_killpg)
+        monkeypatch.setattr(os, "killpg", fake_killpg, raising=False)
 
         _kill_process_tree(proc)  # must not raise
 
@@ -300,7 +303,7 @@ class TestKillProcessTree:
     def test_windows_uses_taskkill_with_tree_and_force_flags(self, monkeypatch):
         proc = MagicMock()
         proc.pid = 4321
-        monkeypatch.setattr("os.name", "nt")
+        monkeypatch.setattr("tools.browser_tool._runtime_os_name", lambda: "nt")
         with patch("subprocess.run") as mock_run:
             _kill_process_tree(proc)
 
@@ -311,6 +314,6 @@ class TestKillProcessTree:
     def test_windows_taskkill_failure_does_not_raise(self, monkeypatch):
         proc = MagicMock()
         proc.pid = 4321
-        monkeypatch.setattr("os.name", "nt")
+        monkeypatch.setattr("tools.browser_tool._runtime_os_name", lambda: "nt")
         with patch("subprocess.run", side_effect=OSError("taskkill missing")):
             _kill_process_tree(proc)  # must not raise

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -2602,6 +2602,11 @@ def _find_agent_browser(*, validate: bool = True) -> str:
     )
 
 
+def _runtime_os_name() -> str:
+    """Return the host OS family through a narrow, testable boundary."""
+    return os.name
+
+
 def _kill_process_tree(proc: "subprocess.Popen") -> None:
     """Best-effort kill of *proc* and any descendants it spawned.
 
@@ -2628,7 +2633,7 @@ def _kill_process_tree(proc: "subprocess.Popen") -> None:
     full timeout budget waiting for a graceful exit — there's nothing to gain
     from waiting again here, only more delay on an already-timed-out call.
     """
-    if os.name == "nt":
+    if _runtime_os_name() == "nt":
         try:
             subprocess.run(
                 ["taskkill", "/PID", str(proc.pid), "/T", "/F"],
@@ -2705,7 +2710,7 @@ def warm_agent_browser_npx_cache(timeout: float = 60.0) -> bool:
         "env": env,
         "creationflags": windows_hide_flags(),
     }
-    if os.name == "posix":
+    if _runtime_os_name() == "posix":
         popen_kwargs["start_new_session"] = True
     else:
         popen_kwargs["creationflags"] |= getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0)


### PR DESCRIPTION
## Summary

- isolate browser npx platform simulation behind a narrow runtime helper instead of mutating global `os.name`
- patch the actual Windows dashboard re-exec boundary so tests cannot launch a real dashboard server
- isolate macOS and Windows gateway orphan-reaper tests from shared `os` / `time` stdlib modules
- explicitly model the simulated platform in gateway reaper tests

## Why

Several platform tests mutate shared stdlib module state or patch a stale process boundary. On Windows, a failing test could leave pytest seeing `os.name == "posix"`, causing a `pathlib.PosixPath` INTERNALERROR. Dashboard tests could also reach the real Windows `subprocess.Popen(...).wait()` path and start a dashboard process. Gateway orphan-reaper tests similarly replaced shared `os.kill` and `time` functions, allowing test state to affect pytest and background threads.

The changes keep platform simulation local to the module under test and patch the implementation boundary used on the current host.

## Verification

Run on Windows 10 against current `origin/main` (`45af7a71f`):

```text
22 passed in 2.57s
```

for:

```text
tests/tools/test_browser_npx_warmup.py
tests/hermes_cli/test_dashboard_unified_launch.py
```

Gateway reaper subset:

```text
8 passed, 19 deselected in 3.09s
```

Complete gateway test file:

```text
22 passed, 5 skipped in 3.26s
```

Also verified:

- `py_compile` for all four touched Python files
- `git diff --check`

## Scope

This PR intentionally does not port the separate POSIX script/FIFO assumptions in `test_gateway_restart_loop.py` to Windows. That file currently completes normally on Windows with `115 passed, 10 failed`; those failures are a separate test-contract change and are not required for these suite-isolation fixes.
