### PR TITLE
fix(caching): combined LiteLLM OpenAI-wire prompt caching from #84550 and #84982 (#84506)

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -2171,6 +2171,13 @@ def anthropic_prompt_cache_policy(
     gateway implements the Anthropic cache_control contract
     (MiniMax, Zhipu GLM, LiteLLM's Anthropic proxy mode all do).
 
+    LiteLLM proxies exposing the OpenAI-compatible surface instead
+    (``/v1/chat/completions`` — e.g. ``provider: custom:litellm``)
+    also honour Anthropic-style ``cache_control`` markers when serving
+    a Claude model, and get the envelope layout (native_anthropic=False)
+    like OpenRouter.  Without this grant they serve zero cache hits,
+    re-billing the full prompt on every turn.
+
     Qwen / Alibaba-family models on OpenCode, OpenCode Go, and direct
     Alibaba (DashScope) also honour Anthropic-style ``cache_control``
     markers on OpenAI-wire chat completions. Upstream pi-mono #3392 /
@@ -2346,6 +2353,45 @@ def anthropic_prompt_cache_policy(
     # Docs: https://platform.minimax.io/docs/api-reference/anthropic-api-compatible-cache
     if is_anthropic_wire and is_minimax_route:
         return True, True
+
+    # LiteLLM proxies exposing the OpenAI-compatible surface (e.g.
+    # ``provider: custom:litellm`` with /v1/chat/completions — /v1/messages
+    # returns 404) serve Claude models and honour Anthropic-style
+    # cache_control markers on the OpenAI wire, exactly like OpenRouter.
+    # Without this branch the OpenAI-wire LiteLLM route matches no grant
+    # branch and falls through to (False, False) — zero cache hits, the
+    # full prompt re-billed on every turn (the same silent failure class
+    # the Qwen branch below addresses). LiteLLM's Anthropic-native route
+    # (/v1/messages) is already covered by the third-party-gateway branch
+    # above, which returns the native layout.
+    #
+    # Gated on the Claude family only: a Gemini/GPT/Qwen/DeepSeek route
+    # through the same proxy must not receive markers — some strict
+    # OpenAI-wire relays reject the cache_control block format (cf. the
+    # DeepSeek/OpenCode exclusion, #77217).  The calling format is a
+    # property of the *model*, not the endpoint.
+    #
+    # Envelope layout (native_anthropic=False), not native: this is an
+    # OpenAI-wire chat.completions route — "Envelope layout is an
+    # OpenAI-wire construct" (see the OpenRouter branch above), and the
+    # issue reporter's verified repro used exactly the envelope shape
+    # (system as content list + cache_control → real cache hits).
+    #
+    # Detection mirrors the MiniMax provider-or-host pattern: a
+    # ``litellm`` substring in the provider id (``custom:litellm``,
+    # ``litellm``) or in the base URL host (self-hosted proxies
+    # registered as bare ``custom``).  The host check is host-only via
+    # ``base_url_hostname`` so a ``litellm`` path segment on an
+    # unrelated host (e.g. ``https://api.corp.com/v1/litellm``) does not
+    # grant cache_control to a provider that may reject the marker with
+    # HTTP 400.
+    litellm_host = base_url_hostname(eff_base_url)
+    is_litellm = (
+        "litellm" in provider_lower
+        or "litellm" in litellm_host
+    )
+    if is_litellm and is_claude and not is_anthropic_wire:
+        return True, False
 
     # Qwen/Alibaba on OpenCode (Zen/Go) and native DashScope: OpenAI-wire
     # transport that accepts Anthropic-style cache_control markers and

--- a/tests/agent/test_prompt_cache_ttl_propagation.py
+++ b/tests/agent/test_prompt_cache_ttl_propagation.py
@@ -102,6 +102,65 @@ class TestPlanCacheSectionsThreadsTtlAndPrefix:
             "Qwen's 5-minute-only context cache must clamp a configured 1h"
         )
 
+    def test_litellm_openai_wire_destination_gets_envelope_markers(self):
+        """#84506 sibling path: MoA/auxiliary destinations resolve the same
+        policy, so a LiteLLM OpenAI-wire destination must receive envelope
+        cache_control markers here too — not fall through to (False, False)
+        and re-bill the full prompt every turn."""
+        from agent.agent_runtime_helpers import plan_cache_sections_for_destination
+
+        messages = [
+            {"role": "system", "content": "You are helpful."},
+            {"role": "user", "content": "hello"},
+        ]
+        out_msgs, _ = plan_cache_sections_for_destination(
+            messages,
+            None,
+            provider="custom:litellm",
+            base_url="https://litellm.example.com/v1",
+            api_mode="chat_completions",
+            model="claude-sonnet-4-6",
+            cache_disabled=False,
+            cache_ttl="5m",
+        )
+        markers = _collect_cache_controls(out_msgs)
+        assert markers, (
+            "LiteLLM OpenAI-wire Claude must receive cache_control markers "
+            "on the MoA/auxiliary destination path"
+        )
+        # Envelope layout: markers live on content parts (system content is
+        # split into text blocks), never a top-level tool message marker.
+        system = out_msgs[0]
+        assert isinstance(system.get("content"), list) and any(
+            isinstance(part, dict) and "cache_control" in part
+            for part in system["content"]
+        ), "envelope layout marks the system content part, not the message envelope"
+
+    def test_litellm_non_claude_destination_stays_unmarked(self):
+        """#84506 sibling path: a non-Claude model routed through the same
+        LiteLLM proxy must not receive Anthropic markers on the
+        MoA/auxiliary destination path (strict relays reject the block
+        format, cf. #77217)."""
+        from agent.agent_runtime_helpers import plan_cache_sections_for_destination
+
+        messages = [
+            {"role": "system", "content": "You are helpful."},
+            {"role": "user", "content": "hello"},
+        ]
+        out_msgs, _ = plan_cache_sections_for_destination(
+            messages,
+            None,
+            provider="custom:litellm",
+            base_url="https://litellm.example.com/v1",
+            api_mode="chat_completions",
+            model="openai/gpt-5.4",
+            cache_disabled=False,
+            cache_ttl="5m",
+        )
+        assert not _collect_cache_controls(out_msgs), (
+            "non-Claude on LiteLLM must stay marker-free on the destination path"
+        )
+
 
 class TestMoACacheControlThreadsTtl:
     def test_moa_decoration_uses_threaded_1h(self):

--- a/tests/run_agent/test_anthropic_prompt_cache_policy.py
+++ b/tests/run_agent/test_anthropic_prompt_cache_policy.py
@@ -445,6 +445,151 @@ class TestOpenAIWireFormatOnCustomProvider:
         assert agent._anthropic_prompt_cache_policy() == (False, False)
 
 
+class TestLiteLLMOpenAIWire:
+    """LiteLLM proxies exposing the OpenAI-compatible surface get cache_control.
+
+    A LiteLLM deployment that serves Claude over /v1/chat/completions
+    (``provider: custom:litellm``; /v1/messages returns 404) honours
+    Anthropic-style ``cache_control`` markers on the OpenAI wire. Before
+    this fix the policy matched no grant branch for this route and fell
+    through to (False, False) — zero cache hits, the full prompt re-billed
+    on every turn, with no error or warning (#84506).
+
+    Combined from #84550 and #84982: envelope layout (native=False) because
+    the wire format is OpenAI chat.completions — the issue reporter's
+    verified repro used exactly the envelope shape (system as content list
+    + cache_control → real cache hits). Anthropic-native routes through the
+    same proxy keep the native layout via the third-party-gateway branch.
+    """
+
+    def test_named_litellm_custom_provider_caches_with_envelope_layout(self):
+        agent = _make_agent(
+            provider="custom:litellm",
+            base_url="https://litellm.example.com/v1",
+            api_mode="chat_completions",
+            model="claude-opus-5",
+        )
+        should, native = agent._anthropic_prompt_cache_policy()
+        assert should is True, "LiteLLM OpenAI-wire Claude must cache"
+        assert native is False, "LiteLLM OpenAI wire uses the envelope layout"
+
+    def test_bare_litellm_provider_caches(self):
+        agent = _make_agent(
+            provider="litellm",
+            base_url="https://litellm.example.com/v1",
+            api_mode="chat_completions",
+            model="claude-sonnet-4-6",
+        )
+        assert agent._anthropic_prompt_cache_policy() == (True, False)
+
+    def test_custom_provider_pointed_at_litellm_host_caches(self):
+        # A bare custom provider registered at a LiteLLM host — host match
+        # alone is sufficient, mirroring the MiniMax provider-or-host branch.
+        agent = _make_agent(
+            provider="custom",
+            base_url="https://litellm.example.com/v1",
+            api_mode="chat_completions",
+            model="claude-sonnet-4-6",
+        )
+        assert agent._anthropic_prompt_cache_policy() == (True, False)
+
+    @pytest.mark.parametrize(
+        "provider,base_url",
+        [
+            # Provider-string signal: names vary per install.
+            ("litellm", "https://my-litellm-host.example.com/v1"),
+            ("custom:litellm", "https://my-litellm-host.example.com/v1"),
+            # Host signal: bare `custom` alias pointed at a LiteLLM host.
+            ("custom", "https://litellm.internal.example.com/v1"),
+        ],
+    )
+    @pytest.mark.parametrize(
+        "model",
+        [
+            "claude-opus-4.8",
+            "anthropic/claude-sonnet-4.6",
+            "claude-3-7-sonnet",
+        ],
+    )
+    def test_claude_on_litellm_openai_wire_caches_with_envelope_layout(
+        self, provider, base_url, model
+    ):
+        agent = _make_agent(
+            provider=provider,
+            base_url=base_url,
+            api_mode="chat_completions",
+            model=model,
+        )
+        assert agent._anthropic_prompt_cache_policy() == (True, False)
+
+    @pytest.mark.parametrize(
+        "model",
+        [
+            "openai/gpt-5.4",
+            "gemini-2.5-pro",
+            "qwen3.6-plus",
+            "deepseek-v4-pro",
+        ],
+    )
+    def test_non_claude_on_litellm_openai_wire_does_not_cache(self, model):
+        # No over-reach: a Gemini/GPT/Qwen/DeepSeek route through the same
+        # LiteLLM proxy must not receive Anthropic cache_control markers.
+        agent = _make_agent(
+            provider="litellm",
+            base_url="https://litellm.internal.example.com/v1",
+            api_mode="chat_completions",
+            model=model,
+        )
+        assert agent._anthropic_prompt_cache_policy() == (False, False)
+
+    def test_litellm_claude_operator_disable_still_wins(self):
+        # prompt_caching.cache_ttl: false — the _cache_disabled early return
+        # must survive the new branch.
+        agent = _make_agent(
+            provider="litellm",
+            base_url="https://litellm.internal.example.com/v1",
+            api_mode="chat_completions",
+            model="claude-opus-4.8",
+        )
+        agent._cache_disabled = True
+        assert agent._anthropic_prompt_cache_policy() == (False, False)
+
+    def test_litellm_in_anthropic_proxy_mode_still_uses_native_layout(self):
+        # Adjacent behavior: LiteLLM reached over the native Anthropic wire
+        # keeps hitting the pre-existing is_anthropic_wire branch (True, True).
+        agent = _make_agent(
+            provider="litellm",
+            base_url="https://litellm.internal.example.com",
+            api_mode="anthropic_messages",
+            model="claude-opus-4.8",
+        )
+        assert agent._anthropic_prompt_cache_policy() == (True, True)
+
+    def test_litellm_anthropic_wire_keeps_native_layout(self):
+        # LiteLLM's Anthropic-native route (/v1/messages) is covered by the
+        # third-party-gateway branch: native layout, not envelope.
+        agent = _make_agent(
+            provider="custom:litellm",
+            base_url="https://litellm.example.com/v1",
+            api_mode="anthropic_messages",
+            model="claude-opus-5",
+        )
+        assert agent._anthropic_prompt_cache_policy() == (True, True)
+
+    def test_litellm_path_segment_on_unrelated_host_does_not_cache(self):
+        # Host-only detection: a ``litellm`` substring confined to the URL
+        # path (e.g. a failover path on an unrelated provider) must NOT grant
+        # cache_control. Injecting the marker onto a strict OpenAI-wire host
+        # that rejects unknown keys would fail with HTTP 400 (#84506).
+        agent = _make_agent(
+            provider="custom",
+            base_url="https://api.corp.example.com/v1/litellm-failover",
+            api_mode="chat_completions",
+            model="claude-sonnet-4-6",
+        )
+        assert agent._anthropic_prompt_cache_policy() == (False, False)
+
+
 class TestQwenAlibabaFamily:
     """Qwen on OpenCode/OpenCode-Go/Alibaba — needs cache_control even on OpenAI-wire.
 


### PR DESCRIPTION
Fixes #84506

> **综合修复**:本 PR 吸收并综合了两个 open PR 的方案——#84982(@justinbowes)与 #84550(Enough1122)——取双方精华合成,并对布局分歧做了明确裁决。

## 两家方案对比与裁决

**核心分歧:cache marker 的布局 `(inner_block, envelope)`**

- #84982 偏向 `(True, True)`,理由"native inner-block layout 匹配同一网关 anthropic_messages 的 wire 形状"
- #84550 采用 `(True, False)`(envelope 布局)

**采纳 #84550 的 `(True, False)`,理由:**
1. **代码库明文惯例**:`agent_runtime_helpers.py` 注释 "Envelope layout is an OpenAI-wire construct"——所有 OpenAI-wire 分支(OpenRouter、Kimi、Portal、Qwen)全是 `(True, False)`;`(True, True)` 只保留给 anthropic_messages 路由
2. **issue 实测证据**:报告人验证的生效形状 "system as list + cache_control" 正是 envelope 布局;LiteLLM 的 `anthropic_messages_pt`/`translate_system_message` 两种布局都能转译,envelope 是更保守的 wire 形状
3. **#84982 的论证缺陷**:OpenAI wire 和 anthropic_messages 是**不同传输**,同一网关两种表面;OpenAI-wire 上顶层 marker 有被严格 relay 拒绝的风险(正是 #77217 DeepSeek 被拒的同类问题)

**第三条 sibling 路径检查**:`run_agent.py` forwarder、`agent_init.py`、fallback 重评估、`plan_cache_sections_for_destination`(MoA/auxiliary)全部汇聚到同一个 `anthropic_prompt_cache_policy()` 函数——单点修复天然覆盖所有路径,无需第三处代码改动,但补了 E2E 测试证明 MoA/auxiliary 路径也正确获得 envelope marker。

## 改动文件(3 个,250 行新增)

- `agent/agent_runtime_helpers.py`(+46):docstring 记录 LiteLLM OpenAI-wire 场景;MiniMax 后插入 host-only 检测分支,Claude-only 门控,返回 `(True, False)`
- `tests/run_agent/test_anthropic_prompt_cache_policy.py`(+145):`TestLiteLLMOpenAIWire` 20 个测试 = #84550 的 6 个 + #84982 的参数化矩阵(布局断言统一为 envelope)+ `_cache_disabled` 优先 + proxy mode
- `tests/agent/test_prompt_cache_ttl_propagation.py`(+59):sibling 路径测试 2 个(LiteLLM destination 获得 envelope marker / 非 Claude 不标记)

## Tests

- 三个测试文件:86 passed, 0 failed;`TestLiteLLMOpenAIWire` 专属 20/20 passed
- 全 `tests/run_agent/`(1624 passed):与 baseline 对比失败列表完全一致(31 个失败全部 pre-existing,compression/streaming/switch_model 等无关模块);唯一新增差异 `test_tool_activity_heartbeat` 独立重跑两次均通过(flaky 定时测试)

建议合并本 PR 时保留对 #84982 的 credit。
