### PR TITLE
fix(desktop): point WhatsApp setup guide at Hermes docs

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -8061,7 +8061,7 @@ _PLATFORM_OVERRIDES: dict[str, dict[str, Any]] = {
     "whatsapp": {
         "name": "WhatsApp",
         "description": "Use Hermes through the bundled WhatsApp bridge with QR-based auth.",
-        "docs_url": "https://github.com/tulir/whatsmeow",
+        "docs_url": "https://hermes-agent.nousresearch.com/docs/user-guide/messaging/whatsapp",
         "env_vars": (
             "WHATSAPP_ENABLED",
             "WHATSAPP_MODE",

--- a/tests/hermes_cli/test_setup_hidden_env.py
+++ b/tests/hermes_cli/test_setup_hidden_env.py
@@ -56,6 +56,14 @@ class TestChannelCards:
             for key in entry["env_vars"]:
                 assert not is_setup_hidden_env(key), f"{entry['id']}: {key}"
 
+    def test_whatsapp_card_links_to_hermes_baileys_setup_docs(self):
+        from hermes_cli.web_server import _messaging_platform_catalog
+
+        whatsapp = next(entry for entry in _messaging_platform_catalog() if entry["id"] == "whatsapp")
+
+        assert whatsapp["docs_url"] == "https://hermes-agent.nousresearch.com/docs/user-guide/messaging/whatsapp"
+        assert "whatsmeow" not in whatsapp["docs_url"]
+
 
     def test_hidden_knobs_move_to_the_keys_page_not_into_a_void(self):
         """Keys hides what a Channels card owns. Dropping these from the card


### PR DESCRIPTION
## Summary
- replace the desktop Messaging WhatsApp setup-guide link with the Hermes WhatsApp setup docs
- add a channel-card regression test so the WhatsApp card does not point back at whatsmeow

Fixes #87041

## Tests
- scripts/run_tests.sh tests/hermes_cli/test_setup_hidden_env.py -q
- .venv/bin/python -m ruff check hermes_cli/web_server.py tests/hermes_cli/test_setup_hidden_env.py
- git diff --check