### PR TITLE
feat(feishu): add fail-closed plugin card actions

### DIFF
--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -1207,6 +1207,7 @@ class PluginRegistration:
 _PLUGIN_SETTING_SEGMENT_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_-]{0,127}$")
 _PLUGIN_SETTING_RESERVED_ROOTS = frozenset({"model", "plugins", "security", "settings"})
 _PLUGIN_STATE_KEY_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.:-]{0,127}$")
+_FEISHU_PLUGIN_ACTION_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.:-]{0,127}$")
 _PLUGIN_STATE_QUOTA_BYTES = 10 * 1024 * 1024
 _PLUGIN_STATE_LOCKS: Dict[str, threading.RLock] = {}
 _PLUGIN_STATE_LOCKS_GUARD = threading.Lock()
@@ -2927,6 +2928,62 @@ class PluginContext:
         )
         return handle
 
+    def register_feishu_card_action_handler(
+        self,
+        action_id: str,
+        callback: Callable,
+    ) -> PluginRegistration:
+        """Register one synchronous exact-match Feishu card-action handler.
+
+        A card opts into this path by setting ``value.hermes_plugin_action``
+        to *action_id*. The Feishu adapter invokes the callback with a
+        canonical envelope, its exact JSON bytes, and a gateway-owned HMAC
+        attestation. Matched actions never enter the synthetic message / LLM
+        path.
+
+        The callback must finish within Feishu's callback window and return
+        ``{"ok": True}`` only after its downstream consumer durably accepts
+        the event. Exceptions and missing acknowledgements fail closed.
+        """
+        if not callable(callback):
+            raise ValueError(
+                f"Plugin '{self.manifest.name}' tried to register a Feishu "
+                "card action handler with a non-callable callback."
+            )
+        if inspect.iscoroutinefunction(callback):
+            raise ValueError("Feishu card action callback must be synchronous")
+        if not isinstance(action_id, str):
+            raise ValueError("Feishu card action_id must be a non-empty string")
+        normalized = action_id.strip()
+        if not _FEISHU_PLUGIN_ACTION_ID_RE.fullmatch(normalized):
+            raise ValueError(
+                "Feishu card action_id must match "
+                "[A-Za-z0-9][A-Za-z0-9_.:-]{0,127}"
+            )
+        if any(
+            existing[0] == normalized
+            for existing in self._manager._feishu_card_action_handlers
+        ):
+            raise ValueError(
+                f"Feishu card action_id {normalized!r} is already registered"
+            )
+
+        entry = (normalized, callback, self.plugin_id)
+        self._manager._feishu_card_action_handlers.append(entry)
+        handle = self._track(
+            "feishu_card_action_handler",
+            normalized,
+            lambda: self._manager._remove_identity(
+                self._manager._feishu_card_action_handlers, entry
+            ),
+        )
+        logger.debug(
+            "Plugin %s registered Feishu card action handler: %s",
+            self.plugin_id,
+            normalized,
+        )
+        return handle
+
     # -- hook registration --------------------------------------------------
 
     # -- auxiliary task registration ---------------------------------------
@@ -3437,6 +3494,10 @@ class PluginManager:
         # ``re.Pattern``, or a constraint dict); ``callback`` is an async
         # function with the slack_bolt signature ``(ack, body, action)``.
         self._slack_action_handlers: List[tuple] = []
+        # Exact-match Feishu interactive-card handlers. Each entry is
+        # (action_id, synchronous callback, plugin_id). The Feishu adapter
+        # invokes these before any synthetic MessageEvent can reach the model.
+        self._feishu_card_action_handlers: List[tuple] = []
         # Registration handles are kept both per plugin (ownership lookup) and
         # globally (reverse-order teardown for overrides spanning plugins).
         #
@@ -3725,6 +3786,7 @@ class PluginManager:
             self._system_prompt_sections.clear()
             self._approval_transports.clear()
             self._slack_action_handlers.clear()
+            self._feishu_card_action_handlers.clear()
             self._predeclared_modules.clear()
             self._predeclared_tools.clear()
             self._context_engine = None
@@ -5450,6 +5512,10 @@ class PluginManager:
         :meth:`PluginContext.register_slack_action_handler`.
         """
         return list(self._slack_action_handlers)
+
+    def get_feishu_card_action_handlers(self) -> List[tuple]:
+        """Return plugin-registered exact-match Feishu action handlers."""
+        return list(self._feishu_card_action_handlers)
 
     # -----------------------------------------------------------------------
     # Introspection

--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -55,6 +55,7 @@ import hmac
 import itertools
 import json
 import logging
+import math
 import mimetypes
 import os
 import re
@@ -109,6 +110,7 @@ FEISHU_DOMAIN = None  # type: ignore[assignment]
 LARK_DOMAIN = None  # type: ignore[assignment]
 BaseRequest = None  # type: ignore[assignment]
 CallBackCard = None  # type: ignore[assignment]
+CallBackToast = None  # type: ignore[assignment]
 P2CardActionTriggerResponse = None  # type: ignore[assignment]
 EventDispatcherHandler = None  # type: ignore[assignment]
 FeishuWSClient = None  # type: ignore[assignment]
@@ -132,7 +134,11 @@ from gateway.platforms.base import (
     cache_image_from_bytes,
 )
 from gateway.status import acquire_scoped_lock, release_scoped_lock
-from hermes_constants import get_hermes_home
+from hermes_constants import (
+    get_hermes_home,
+    reset_hermes_home_override,
+    set_hermes_home_override,
+)
 from utils import atomic_json_write, env_float, env_int
 
 from agent.secret_scope import UnscopedSecretError as _UnscopedSecretError
@@ -239,9 +245,17 @@ _FEISHU_WEBHOOK_RATE_WINDOW_SECONDS = 60            # sliding window for rate li
 _FEISHU_WEBHOOK_RATE_LIMIT_MAX = 120               # max requests per window per IP — matches openclaw
 _FEISHU_WEBHOOK_RATE_MAX_KEYS = 4096               # max tracked keys (prevents unbounded growth)
 _FEISHU_WEBHOOK_BODY_TIMEOUT_SECONDS = 30          # max seconds to read request body
+_FEISHU_WEBHOOK_CARD_ACTION_TIMEOUT_SECONDS = 3.0  # bound sync plugin/builtin callbacks
+_FEISHU_WEBHOOK_CARD_ACTION_MAX_WORKERS = 4         # bound callbacks that outlive HTTP wait
+_FEISHU_WEBHOOK_CARD_ACTION_SLOTS = threading.BoundedSemaphore(
+    _FEISHU_WEBHOOK_CARD_ACTION_MAX_WORKERS
+)
 _FEISHU_WEBHOOK_ANOMALY_THRESHOLD = 25             # consecutive error responses before WARNING log
 _FEISHU_WEBHOOK_ANOMALY_TTL_SECONDS = 6 * 60 * 60  # anomaly tracker TTL (6 hours) — matches openclaw
 _FEISHU_CARD_ACTION_DEDUP_TTL_SECONDS = 15 * 60    # card action token dedup window (15 min)
+_FEISHU_PLUGIN_ACTION_KEY = "hermes_plugin_action"
+_FEISHU_CARD_ACTION_ATTESTATION_VERSION = "hermes-feishu-card-action-v1"
+_FEISHU_PLUGIN_ACTION_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.:-]{0,127}$")
 
 _APPROVAL_CHOICE_MAP: Dict[str, str] = {
     "approve_once": "once",
@@ -1409,7 +1423,7 @@ def _load_lark_oapi() -> bool:
             from lark_oapi.core.const import FEISHU_DOMAIN, LARK_DOMAIN
             from lark_oapi.core.model import BaseRequest
             from lark_oapi.event.callback.model.p2_card_action_trigger import (
-                CallBackCard, P2CardActionTriggerResponse,
+                CallBackCard, CallBackToast, P2CardActionTriggerResponse,
             )
             from lark_oapi.event.dispatcher_handler import EventDispatcherHandler
             from lark_oapi.ws import Client as FeishuWSClient
@@ -1439,6 +1453,7 @@ def _load_lark_oapi() -> bool:
             "LARK_DOMAIN": LARK_DOMAIN,
             "BaseRequest": BaseRequest,
             "CallBackCard": CallBackCard,
+            "CallBackToast": CallBackToast,
             "P2CardActionTriggerResponse": P2CardActionTriggerResponse,
             "EventDispatcherHandler": EventDispatcherHandler,
             "FeishuWSClient": FeishuWSClient,
@@ -1502,6 +1517,7 @@ class FeishuAdapter(BasePlatformAdapter):
     def __init__(self, config: PlatformConfig):
         super().__init__(config, Platform.FEISHU)
 
+        self._hermes_home = get_hermes_home().expanduser().resolve(strict=False)
         self._settings = self._load_settings(config.extra or {})
         self._apply_settings(self._settings)
         self._client: Optional[Any] = None
@@ -1524,12 +1540,13 @@ class FeishuAdapter(BasePlatformAdapter):
         self._event_handler: Optional[Any] = None
         self._seen_message_ids: Dict[str, float] = {}  # message_id → seen_at (time.time())
         self._seen_message_order: List[str] = []
-        self._dedup_state_path = get_hermes_home() / "feishu_seen_message_ids.json"
+        self._dedup_state_path = self._hermes_home / "feishu_seen_message_ids.json"
         self._dedup_lock = threading.Lock()
         self._sender_name_cache: Dict[str, tuple[str, float]] = {}  # sender_id → (name, expire_at)
         self._webhook_rate_counts: Dict[str, tuple[int, float]] = {}  # rate_key → (count, window_start)
         self._webhook_anomaly_counts: Dict[str, tuple[int, str, float]] = {}  # ip → (count, last_status, first_seen)
         self._card_action_tokens: Dict[str, float] = {}  # token → first_seen_time
+        self._card_action_token_lock = threading.Lock()
         # Inbound events that arrived before the adapter loop was ready
         # (e.g. during startup/restart or network-flap reconnect). A single
         # drainer thread replays them as soon as the loop becomes available.
@@ -2721,19 +2738,19 @@ class FeishuAdapter(BasePlatformAdapter):
 
         For other card actions: delegates to ``_handle_card_action_event``.
         """
+        event = getattr(data, "event", None)
+        action = getattr(event, "action", None)
+        action_value = self._card_action_value(getattr(action, "value", None)) or {}
+        if _FEISHU_PLUGIN_ACTION_KEY in action_value:
+            return self._handle_plugin_card_action(data=data, action_value=action_value)
+
         loop = self._loop
         if not self._loop_accepts_callbacks(loop):
             logger.warning("[Feishu] Dropping card action before adapter loop is ready")
             return P2CardActionTriggerResponse() if P2CardActionTriggerResponse else None
 
-        event = getattr(data, "event", None)
-        action = getattr(event, "action", None)
-        action_value = getattr(action, "value", {}) or {}
-        hermes_action = action_value.get("hermes_action") if isinstance(action_value, dict) else None
-        update_prompt_action = (
-            action_value.get("hermes_update_prompt_action")
-            if isinstance(action_value, dict) else None
-        )
+        hermes_action = action_value.get("hermes_action")
+        update_prompt_action = action_value.get("hermes_update_prompt_action")
 
         if hermes_action:
             return self._handle_approval_card_action(event=event, action_value=action_value, loop=loop)
@@ -2748,6 +2765,362 @@ class FeishuAdapter(BasePlatformAdapter):
         if P2CardActionTriggerResponse is None:
             return None
         return P2CardActionTriggerResponse()
+
+    def _on_webhook_card_action_trigger(self, data: Any) -> tuple[Any, bool]:
+        """Return the callback response and whether downstream durably accepted it."""
+        event = getattr(data, "event", None)
+        action = getattr(event, "action", None)
+        action_value = self._card_action_value(getattr(action, "value", None)) or {}
+        if _FEISHU_PLUGIN_ACTION_KEY in action_value:
+            return self._handle_plugin_card_action_result(
+                data=data,
+                action_value=action_value,
+            )
+        logger.warning(
+            "[Feishu] Non-plugin card actions are not durably supported in webhook mode"
+        )
+        return (
+            self._plugin_card_action_response(
+                "error",
+                "Webhook 模式暂不支持此卡片操作",
+            ),
+            False,
+        )
+
+    @staticmethod
+    def _plugin_card_action_response(toast_type: str, content: str) -> Any:
+        """Build a bounded callback response without exposing event details."""
+        if P2CardActionTriggerResponse is None:
+            return None
+        response = P2CardActionTriggerResponse()
+        if CallBackToast is not None:
+            toast = CallBackToast()
+            toast.type = toast_type
+            toast.content = content[:120]
+            response.toast = toast
+        return response
+
+    @classmethod
+    def _normalize_card_action_json(cls, value: Any, *, depth: int = 0) -> Any:
+        """Recursively copy SDK callback data without invoking properties."""
+        if depth > 8:
+            raise ValueError("card action nesting is too deep")
+        if value is None or isinstance(value, (str, bool, int)):
+            return value
+        if isinstance(value, float):
+            if not math.isfinite(value):
+                raise ValueError("card action number is not finite")
+            return value
+        if isinstance(value, SimpleNamespace):
+            value = vars(value)
+        elif not isinstance(value, (dict, list, tuple)):
+            try:
+                value = vars(value)
+            except TypeError as exc:
+                raise TypeError("unsupported card action value") from exc
+        if isinstance(value, dict):
+            if len(value) > 256:
+                raise ValueError("card action object is too large")
+            normalized: dict[str, Any] = {}
+            for key, item in value.items():
+                if not isinstance(key, str) or key.startswith("_"):
+                    raise ValueError("card action object key is invalid")
+                normalized[key] = cls._normalize_card_action_json(
+                    item,
+                    depth=depth + 1,
+                )
+            return normalized
+        if len(value) > 256:
+            raise ValueError("card action array is too large")
+        return [
+            cls._normalize_card_action_json(item, depth=depth + 1)
+            for item in value
+        ]
+
+    @classmethod
+    def _card_action_value(cls, value: Any) -> dict[str, Any] | None:
+        """Normalize supported SDK shapes into a JSON-safe action object."""
+        try:
+            normalized = cls._normalize_card_action_json(value)
+        except (TypeError, ValueError):
+            return None
+        return normalized if isinstance(normalized, dict) else None
+
+    @classmethod
+    def _webhook_card_action_payload(cls, response: Any) -> dict[str, Any]:
+        """Serialize the SDK callback response for webhook transport."""
+        if response is None:
+            return {}
+        try:
+            normalized = cls._normalize_card_action_json(response)
+        except (TypeError, ValueError):
+            logger.error("[Feishu] Card action response was not serializable")
+            return {"toast": {"type": "error", "content": "请求处理失败，请重试"}}
+        if not isinstance(normalized, dict):
+            return {}
+
+        def _without_null_fields(value: Any) -> Any:
+            if isinstance(value, dict):
+                return {
+                    key: _without_null_fields(item)
+                    for key, item in value.items()
+                    if item is not None
+                }
+            if isinstance(value, list):
+                return [_without_null_fields(item) for item in value]
+            return value
+
+        return _without_null_fields(normalized)
+
+    async def _run_bounded_webhook_card_action(
+        self,
+        data: Any,
+    ) -> tuple[str, Any, bool]:
+        """Run one sync callback on a bounded daemon worker.
+
+        ``asyncio.to_thread`` only cancels the awaiter on timeout; its worker
+        keeps running and another click can start an unbounded duplicate.  A
+        plugin callback still cannot be force-killed safely in-process, so the
+        gateway bounds late workers globally and returns a retryable non-2xx
+        until downstream durable acceptance is known. PopaSkin's network
+        transport has its own killable child-process deadline and durable
+        idempotency inside this outer boundary.
+        """
+        slots = _FEISHU_WEBHOOK_CARD_ACTION_SLOTS
+        if not slots.acquire(blocking=False):
+            return "busy", None, False
+
+        loop = asyncio.get_running_loop()
+        future: asyncio.Future = loop.create_future()
+
+        def _settle(ok: bool, value: Any) -> None:
+            if not future.done():
+                future.set_result((ok, value))
+
+        def _worker() -> None:
+            try:
+                outcome = (True, self._on_webhook_card_action_trigger(data))
+            except BaseException as exc:  # daemon boundary; return type only
+                outcome = (False, type(exc).__name__)
+            finally:
+                slots.release()
+            try:
+                loop.call_soon_threadsafe(_settle, *outcome)
+            except RuntimeError:
+                # The request loop may already have shut down after timeout.
+                pass
+
+        try:
+            thread = threading.Thread(
+                target=_worker,
+                name="feishu-webhook-card-action",
+                daemon=True,
+            )
+            thread.start()
+        except BaseException:
+            slots.release()
+            raise
+
+        try:
+            ok, value = await asyncio.wait_for(
+                asyncio.shield(future),
+                timeout=_FEISHU_WEBHOOK_CARD_ACTION_TIMEOUT_SECONDS,
+            )
+        except asyncio.TimeoutError:
+            return "timeout", None, False
+        if not ok:
+            raise RuntimeError(f"card action worker failed ({value})")
+        response, acknowledged = value
+        return "completed", response, acknowledged
+
+    def _plugin_card_action_handler(self, action_id: str) -> tuple[Any, str] | None:
+        """Resolve one exact plugin handler; ambiguity fails closed."""
+        home_token = set_hermes_home_override(self._hermes_home)
+        try:
+            from hermes_cli.plugins import get_plugin_manager
+
+            handlers = get_plugin_manager().get_feishu_card_action_handlers()
+        except Exception as exc:  # pragma: no cover - defensive import/runtime guard
+            logger.warning(
+                "[Feishu] Could not load plugin card action handlers (%s)",
+                type(exc).__name__,
+            )
+            return None
+        finally:
+            reset_hermes_home_override(home_token)
+        matches = [
+            (callback, plugin_id)
+            for registered_id, callback, plugin_id in handlers
+            if registered_id == action_id
+        ]
+        if len(matches) != 1:
+            return None
+        return matches[0]
+
+    def _build_plugin_card_action_attestation(
+        self,
+        data: Any,
+    ) -> tuple[dict[str, Any], bytes, str]:
+        """Return a canonical HMAC-attested representation of one callback."""
+        app_secret = str(self._app_secret or "")
+        if not app_secret:
+            raise ValueError("Feishu app secret unavailable")
+
+        header = getattr(data, "header", None)
+        event = getattr(data, "event", None)
+        operator = getattr(event, "operator", None)
+        context = getattr(event, "context", None)
+        action = getattr(event, "action", None)
+        action_value = self._card_action_value(getattr(action, "value", None))
+
+        event_id = str(getattr(header, "event_id", "") or "").strip()
+        create_time = str(getattr(header, "create_time", "") or "").strip()
+        event_type = str(getattr(header, "event_type", "") or "").strip()
+        app_id = str(getattr(header, "app_id", "") or "").strip()
+        tenant_key = str(getattr(header, "tenant_key", "") or "").strip()
+        operator_tenant_key = str(
+            getattr(operator, "tenant_key", "") or ""
+        ).strip()
+        open_id = str(getattr(operator, "open_id", "") or "").strip()
+        open_message_id = str(
+            getattr(context, "open_message_id", "") or ""
+        ).strip()
+        open_chat_id = str(getattr(context, "open_chat_id", "") or "").strip()
+        action_tag = str(getattr(action, "tag", "") or "").strip()
+        host = str(getattr(event, "host", "") or "").strip()
+
+        if not all(
+            (
+                event_id,
+                create_time,
+                event_type,
+                app_id,
+                tenant_key,
+                operator_tenant_key,
+                open_id,
+                open_message_id,
+                open_chat_id,
+                action_tag,
+                host,
+            )
+        ):
+            raise ValueError("incomplete Feishu card callback")
+        if event_type != "card.action.trigger" or host != "im_message":
+            raise ValueError("unexpected Feishu card callback type")
+        expected_app_id = str(self._app_id or "").strip()
+        if not expected_app_id or not hmac.compare_digest(app_id, expected_app_id):
+            raise ValueError("Feishu callback app mismatch")
+        if not hmac.compare_digest(operator_tenant_key, tenant_key):
+            raise ValueError("Feishu callback tenant mismatch")
+        if action_value is None:
+            raise ValueError("Feishu callback action value must be an object")
+
+        envelope: dict[str, Any] = {
+            "version": _FEISHU_CARD_ACTION_ATTESTATION_VERSION,
+            "header": {
+                "event_id": event_id,
+                "create_time": create_time,
+                "event_type": event_type,
+                "tenant_key": tenant_key,
+                "app_id": app_id,
+            },
+            "operator": {
+                "tenant_key": operator_tenant_key,
+                "user_id": str(getattr(operator, "user_id", "") or ""),
+                "open_id": open_id,
+                "union_id": str(getattr(operator, "union_id", "") or ""),
+            },
+            "context": {
+                "open_message_id": open_message_id,
+                "open_chat_id": open_chat_id,
+            },
+            "host": host,
+            "action": {
+                "tag": action_tag,
+                "value": action_value,
+            },
+        }
+        body = json.dumps(
+            envelope,
+            ensure_ascii=False,
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode("utf-8")
+        signed = (_FEISHU_CARD_ACTION_ATTESTATION_VERSION + "\n").encode("ascii") + body
+        signature = "v1=" + hmac.new(
+            app_secret.encode("utf-8"),
+            signed,
+            hashlib.sha256,
+        ).hexdigest()
+        return envelope, body, signature
+
+    def _handle_plugin_card_action(
+        self,
+        *,
+        data: Any,
+        action_value: dict[str, Any],
+    ) -> Any:
+        response, _acknowledged = self._handle_plugin_card_action_result(
+            data=data,
+            action_value=action_value,
+        )
+        return response
+
+    def _handle_plugin_card_action_result(
+        self,
+        *,
+        data: Any,
+        action_value: dict[str, Any],
+    ) -> tuple[Any, bool]:
+        """Invoke one trusted plugin handler without entering the model path."""
+        raw_action_id = action_value.get(_FEISHU_PLUGIN_ACTION_KEY)
+        if not isinstance(raw_action_id, str):
+            logger.warning("[Feishu] Rejected malformed plugin card action id")
+            return self._plugin_card_action_response("error", "卡片操作无效"), False
+        action_id = raw_action_id.strip()
+        if not _FEISHU_PLUGIN_ACTION_ID_RE.fullmatch(action_id):
+            logger.warning("[Feishu] Rejected malformed plugin card action id")
+            return self._plugin_card_action_response("error", "卡片操作无效"), False
+
+        resolved = self._plugin_card_action_handler(action_id)
+        if resolved is None:
+            logger.warning("[Feishu] Plugin card action handler unavailable")
+            return self._plugin_card_action_response("error", "卡片处理器不可用"), False
+        callback, plugin_id = resolved
+
+        try:
+            envelope, body, signature = self._build_plugin_card_action_attestation(data)
+        except Exception as exc:
+            logger.warning(
+                "[Feishu] Rejected unattestable plugin card action (%s)",
+                type(exc).__name__,
+            )
+            return self._plugin_card_action_response("error", "卡片验证失败"), False
+
+        try:
+            result = callback(envelope=envelope, body=body, signature=signature)
+        except Exception as exc:
+            logger.error(
+                "[Feishu] Plugin %s card action handler failed (%s)",
+                plugin_id,
+                type(exc).__name__,
+            )
+            return self._plugin_card_action_response("error", "请求处理失败，请重试"), False
+        if not isinstance(result, dict) or result.get("ok") is not True:
+            logger.warning(
+                "[Feishu] Plugin %s did not acknowledge card action",
+                plugin_id,
+            )
+            return self._plugin_card_action_response("error", "请求未确认，请重试"), False
+
+        toast_data = result.get("toast")
+        if not isinstance(toast_data, dict):
+            toast_data = {}
+        toast_type = str(toast_data.get("type") or "success").strip().lower()
+        if toast_type not in {"success", "info", "warning", "error"}:
+            toast_type = "success"
+        content = str(toast_data.get("content") or "请求已接收")
+        return self._plugin_card_action_response(toast_type, content), True
 
     @staticmethod
     def _loop_accepts_callbacks(loop: Any) -> bool:
@@ -3049,15 +3422,20 @@ class FeishuAdapter(BasePlatformAdapter):
 
     def _is_card_action_duplicate(self, token: str) -> bool:
         """Return True if this card action token was already processed within the dedup window."""
-        now = time.time()
-        # Prune expired tokens lazily each call.
-        expired = [t for t, ts in self._card_action_tokens.items() if now - ts > _FEISHU_CARD_ACTION_DEDUP_TTL_SECONDS]
-        for t in expired:
-            del self._card_action_tokens[t]
-        if token in self._card_action_tokens:
-            return True
-        self._card_action_tokens[token] = now
-        return False
+        with self._card_action_token_lock:
+            now = time.time()
+            # Prune expired tokens lazily each call.
+            expired = [
+                value
+                for value, seen_at in self._card_action_tokens.items()
+                if now - seen_at > _FEISHU_CARD_ACTION_DEDUP_TTL_SECONDS
+            ]
+            for value in expired:
+                del self._card_action_tokens[value]
+            if token in self._card_action_tokens:
+                return True
+            self._card_action_tokens[token] = now
+            return False
 
     async def _handle_card_action_event(self, data: Any) -> None:
         """Route Feishu interactive card button clicks as synthetic COMMAND events."""
@@ -3605,6 +3983,11 @@ class FeishuAdapter(BasePlatformAdapter):
             self._record_webhook_anomaly(remote_ip, "400")
             return web.json_response({"code": 400, "msg": "invalid json"}, status=400)
 
+        if not (self._verification_token or self._encrypt_key):
+            logger.error("[Feishu] Webhook rejected: authentication is not configured")
+            self._record_webhook_anomaly(remote_ip, "503-auth")
+            return web.Response(status=503, text="Webhook authentication unavailable")
+
         # Verification token check — second layer of defence beyond signature (matches openclaw).
         if self._verification_token:
             header = payload.get("header") or {}
@@ -3618,18 +4001,18 @@ class FeishuAdapter(BasePlatformAdapter):
                 self._record_webhook_anomaly(remote_ip, "401-token")
                 return web.Response(status=401, text="Invalid verification token")
 
-        # URL verification challenge — Feishu includes the verification token in
-        # challenge requests. Validate the token (above) before reflecting the
-        # challenge so an unauthenticated remote request cannot prove endpoint
-        # control by getting attacker-supplied challenge data echoed back.
-        if payload.get("type") == "url_verification":
-            return web.json_response({"challenge": payload.get("challenge", "")})
-
         # Timing-safe signature verification (only enforced when encrypt_key is set).
+        # Run it before reflecting URL-verification challenges so every configured
+        # authentication factor is enforced for every webhook request.
         if self._encrypt_key and not self._is_webhook_signature_valid(request.headers, body_bytes):
             logger.warning("[Feishu] Webhook rejected: invalid signature from %s", remote_ip)
             self._record_webhook_anomaly(remote_ip, "401-sig")
             return web.Response(status=401, text="Invalid signature")
+
+        # URL verification challenge — authenticate the request above before
+        # reflecting attacker-controlled challenge data.
+        if payload.get("type") == "url_verification":
+            return web.json_response({"challenge": payload.get("challenge", "")})
 
         if payload.get("encrypt"):
             logger.error("[Feishu] Encrypted webhook payloads are not supported by Hermes webhook mode")
@@ -3651,7 +4034,45 @@ class FeishuAdapter(BasePlatformAdapter):
         elif event_type in {"im.message.reaction.created_v1", "im.message.reaction.deleted_v1"}:
             self._on_reaction_event(event_type, data)
         elif event_type == "card.action.trigger":
-            self._on_card_action_trigger(data)
+            try:
+                callback_state, callback_response, callback_acknowledged = (
+                    await self._run_bounded_webhook_card_action(data)
+                )
+                if callback_state == "busy":
+                    logger.error("[Feishu] Webhook card action worker capacity exhausted")
+                    return web.json_response(
+                        {
+                            "toast": {
+                                "type": "warning",
+                                "content": "处理器繁忙，状态未知，系统将自动重试，请勿重复点击",
+                            }
+                        },
+                        status=503,
+                    )
+                if callback_state == "timeout":
+                    logger.error("[Feishu] Webhook card action handler timed out")
+                    return web.json_response(
+                        {
+                            "toast": {
+                                "type": "warning",
+                                "content": "请求状态未知，系统将自动重试，请勿重复点击",
+                            }
+                        },
+                        status=503,
+                    )
+            except Exception as exc:
+                logger.error(
+                    "[Feishu] Webhook card action handler failed (%s)",
+                    type(exc).__name__,
+                )
+                return web.json_response(
+                    {"toast": {"type": "error", "content": "请求处理失败，请重试"}},
+                    status=503,
+                )
+            return web.json_response(
+                self._webhook_card_action_payload(callback_response),
+                status=200 if callback_acknowledged else 503,
+            )
         elif event_type == "drive.notice.comment_add_v1":
             self._on_drive_comment_event(data)
         elif event_type == "vc.bot.meeting_invited_v1":

--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -4019,9 +4019,22 @@ class FeishuAdapter(BasePlatformAdapter):
             self._record_webhook_anomaly(remote_ip, "400-encrypted")
             return web.json_response({"code": 400, "msg": "encrypted webhook payloads are not supported"}, status=400)
 
+        event_type = str((payload.get("header") or {}).get("event_type") or "")
+        if event_type == "card.action.trigger" and not (
+            self._verification_token and self._encrypt_key
+        ):
+            logger.error(
+                "[Feishu] Card-action webhook rejected: strong authentication "
+                "requires verification token and encrypt key"
+            )
+            self._record_webhook_anomaly(remote_ip, "503-card-auth")
+            return web.Response(
+                status=503,
+                text="Card-action webhook authentication unavailable",
+            )
+
         self._clear_webhook_anomaly(remote_ip)
 
-        event_type = str((payload.get("header") or {}).get("event_type") or "")
         data = self._namespace_from_mapping(payload)
         if event_type == "im.message.receive_v1":
             self._on_message_event(data)

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -852,7 +852,7 @@ class TestAdapterBehavior(unittest.TestCase):
 
         self.assertTrue(submit.called)
 
-    @patch.dict(os.environ, {}, clear=True)
+    @patch.dict(os.environ, {"FEISHU_VERIFICATION_TOKEN": "expected-token"}, clear=True)
     def test_webhook_request_uses_same_message_dispatch_path(self):
         from gateway.config import PlatformConfig
         from plugins.platforms.feishu.adapter import FeishuAdapter
@@ -861,7 +861,10 @@ class TestAdapterBehavior(unittest.TestCase):
         adapter._on_message_event = Mock()
 
         body = json.dumps({
-            "header": {"event_type": "im.message.receive_v1"},
+            "header": {
+                "event_type": "im.message.receive_v1",
+                "token": "expected-token",
+            },
             "event": {"message": {"message_id": "om_test"}},
         }).encode("utf-8")
         request = SimpleNamespace(
@@ -892,6 +895,56 @@ class TestAdapterBehavior(unittest.TestCase):
             "type": "url_verification",
             "token": "wrong-token",
             "challenge": "attacker-controlled-challenge",
+        }).encode("utf-8")
+        request = SimpleNamespace(
+            remote="203.0.113.10",
+            content_length=None,
+            headers={},
+            content=_FakeRequestContent(body),
+        )
+
+        response = asyncio.run(adapter._handle_webhook_request(request))
+
+        self.assertEqual(response.status, 401)
+
+    @patch.dict(os.environ, {"FEISHU_ENCRYPT_KEY": "encrypt-key"}, clear=True)
+    def test_url_verification_requires_configured_signature(self):
+        from gateway.config import PlatformConfig
+        from plugins.platforms.feishu.adapter import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        body = json.dumps({
+            "type": "url_verification",
+            "challenge": "unsigned-challenge",
+        }).encode("utf-8")
+        request = SimpleNamespace(
+            remote="203.0.113.10",
+            content_length=None,
+            headers={},
+            content=_FakeRequestContent(body),
+        )
+
+        response = asyncio.run(adapter._handle_webhook_request(request))
+
+        self.assertEqual(response.status, 401)
+
+    @patch.dict(
+        os.environ,
+        {
+            "FEISHU_ENCRYPT_KEY": "encrypt-key",
+            "FEISHU_VERIFICATION_TOKEN": "expected-token",
+        },
+        clear=True,
+    )
+    def test_url_verification_requires_every_configured_auth_factor(self):
+        from gateway.config import PlatformConfig
+        from plugins.platforms.feishu.adapter import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        body = json.dumps({
+            "type": "url_verification",
+            "token": "expected-token",
+            "challenge": "unsigned-challenge",
         }).encode("utf-8")
         request = SimpleNamespace(
             remote="203.0.113.10",
@@ -2465,5 +2518,4 @@ class TestChatLockEviction(unittest.TestCase):
 
         adapter = self._make_adapter()
         self.assertIsInstance(adapter._chat_locks, _collections.OrderedDict)
-
 

--- a/tests/gateway/test_feishu_plugin_action_handlers.py
+++ b/tests/gateway/test_feishu_plugin_action_handlers.py
@@ -1,0 +1,698 @@
+"""Contracts for plugin-owned Feishu card actions and callback attestation.
+
+Plugin-owned actions are a trusted transport edge. They must be dispatched to
+one exact plugin handler, attested by the Feishu adapter, and never converted
+into an LLM-visible synthetic message.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import asyncio
+import json
+import sys
+import threading
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+_repo = str(Path(__file__).resolve().parents[2])
+if _repo not in sys.path:
+    sys.path.insert(0, _repo)
+
+
+def _ensure_feishu_mocks() -> None:
+    if "lark_oapi" not in sys.modules and importlib.util.find_spec("lark_oapi") is None:
+        mod = MagicMock()
+        for name in (
+            "lark_oapi",
+            "lark_oapi.api.im.v1",
+            "lark_oapi.event",
+            "lark_oapi.event.callback_type",
+        ):
+            sys.modules.setdefault(name, mod)
+    if "aiohttp" not in sys.modules and importlib.util.find_spec("aiohttp") is None:
+        aio = MagicMock()
+        sys.modules.setdefault("aiohttp", aio)
+        sys.modules.setdefault("aiohttp.web", aio.web)
+
+
+_ensure_feishu_mocks()
+
+from gateway.config import PlatformConfig  # noqa: E402
+from hermes_constants import (  # noqa: E402
+    get_hermes_home,
+    reset_hermes_home_override,
+    set_hermes_home_override,
+)
+from hermes_cli.plugins import PluginContext, PluginManager, PluginManifest  # noqa: E402
+import plugins.platforms.feishu.adapter as feishu_module  # noqa: E402
+from plugins.platforms.feishu.adapter import FeishuAdapter  # noqa: E402
+
+
+PLUGIN_ACTION = "popaskin_ads.pending_write"
+
+
+class _FakeToast:
+    def __init__(self):
+        self.type = None
+        self.content = None
+
+
+class _FakeResponse:
+    def __init__(self):
+        self.card = None
+        self.toast = None
+
+
+class _FakeRequestContent:
+    def __init__(self, body: bytes):
+        self.body = body
+
+    async def readexactly(self, size: int) -> bytes:
+        if len(self.body) < size:
+            raise asyncio.IncompleteReadError(self.body, size)
+        return self.body[:size]
+
+
+@pytest.fixture(autouse=True)
+def _callback_types(monkeypatch):
+    monkeypatch.setattr(feishu_module, "CallBackToast", _FakeToast, raising=False)
+    monkeypatch.setattr(feishu_module, "P2CardActionTriggerResponse", _FakeResponse)
+
+
+def _make_ctx(name: str = "test_plugin") -> tuple[PluginManager, PluginContext]:
+    manager = PluginManager()
+    manifest = PluginManifest(name=name, version="0.1.0", description="test")
+    return manager, PluginContext(manifest=manifest, manager=manager)
+
+
+def _make_adapter(*, loop_ready: bool = False) -> FeishuAdapter:
+    adapter = FeishuAdapter(PlatformConfig(enabled=True))
+    adapter._app_id = "cli_test"
+    adapter._app_secret = "app-secret-test"
+    adapter._verification_token = "verify-token-test"
+    if loop_ready:
+        adapter._loop = MagicMock()
+        adapter._loop.is_closed.return_value = False
+    else:
+        adapter._loop = None
+    return adapter
+
+
+def _make_card_action_data(
+    *,
+    route: str = PLUGIN_ACTION,
+    event_id: str = "evt_1",
+    event_token: str = "card-token-1",
+    message_id: str = "om_card",
+    app_id: str = "cli_test",
+    extra_value: dict | None = None,
+) -> SimpleNamespace:
+    action_value = {
+        "hermes_plugin_action": route,
+        "action_id": "pa_public_123",
+        "decision": "approve",
+    }
+    if extra_value:
+        action_value.update(extra_value)
+    return SimpleNamespace(
+        header=SimpleNamespace(
+            event_id=event_id,
+            create_time="1720000000000000",
+            event_type="card.action.trigger",
+            tenant_key="tenant_1",
+            app_id=app_id,
+        ),
+        event=SimpleNamespace(
+            token=event_token,
+            host="im_message",
+            operator=SimpleNamespace(
+                open_id="ou_owner",
+                user_id="u_owner",
+                union_id="on_owner",
+                tenant_key="tenant_1",
+            ),
+            context=SimpleNamespace(
+                open_message_id=message_id,
+                open_chat_id="oc_dm",
+            ),
+            action=SimpleNamespace(tag="button", value=action_value),
+        ),
+    )
+
+
+def _make_webhook_request(
+    *,
+    event_id: str,
+    route: str | None = PLUGIN_ACTION,
+) -> SimpleNamespace:
+    action_value = {
+        "action_id": "pa_public_123",
+        "decision": "approve",
+    }
+    if route is not None:
+        action_value["hermes_plugin_action"] = route
+    payload = {
+        "header": {
+            "event_id": event_id,
+            "create_time": "1720000000000000",
+            "event_type": "card.action.trigger",
+            "tenant_key": "tenant_1",
+            "app_id": "cli_test",
+            "token": "verify-token-test",
+        },
+        "event": {
+            "token": f"card-token-{event_id}",
+            "host": "im_message",
+            "operator": {
+                "open_id": "ou_owner",
+                "user_id": "u_owner",
+                "union_id": "on_owner",
+                "tenant_key": "tenant_1",
+            },
+            "context": {
+                "open_message_id": f"om_{event_id}",
+                "open_chat_id": "oc_dm",
+            },
+            "action": {
+                "tag": "button",
+                "value": action_value,
+            },
+        },
+    }
+    body = json.dumps(payload).encode("utf-8")
+    return SimpleNamespace(
+        remote="127.0.0.1",
+        content_length=None,
+        headers={"Content-Type": "application/json"},
+        content=_FakeRequestContent(body),
+    )
+
+
+class TestRegisterFeishuCardActionHandlerAPI:
+    def test_exact_action_id_is_registered_and_disposable(self):
+        manager, ctx = _make_ctx()
+        callback = MagicMock()
+
+        registration = ctx.register_feishu_card_action_handler(PLUGIN_ACTION, callback)
+
+        assert manager.get_feishu_card_action_handlers() == [
+            (PLUGIN_ACTION, callback, "test_plugin")
+        ]
+        assert registration.active is True
+
+        registration.dispose()
+
+        assert manager.get_feishu_card_action_handlers() == []
+        assert registration.active is False
+
+    def test_accessor_returns_a_copy(self):
+        manager, ctx = _make_ctx()
+        ctx.register_feishu_card_action_handler(PLUGIN_ACTION, MagicMock())
+
+        handlers = manager.get_feishu_card_action_handlers()
+        handlers.clear()
+
+        assert len(manager.get_feishu_card_action_handlers()) == 1
+
+    @pytest.mark.parametrize(
+        "action_id",
+        [None, "", "   ", 123, "../escape", "a" * 129],
+    )
+    def test_invalid_action_id_is_rejected(self, action_id):
+        _manager, ctx = _make_ctx()
+        with pytest.raises(ValueError, match="action_id"):
+            ctx.register_feishu_card_action_handler(action_id, MagicMock())
+
+    def test_non_callable_callback_is_rejected(self):
+        _manager, ctx = _make_ctx()
+        with pytest.raises(ValueError, match="non-callable"):
+            ctx.register_feishu_card_action_handler(PLUGIN_ACTION, "not callable")
+
+    def test_async_callback_is_rejected(self):
+        _manager, ctx = _make_ctx()
+
+        async def callback(**_kwargs):
+            return {"ok": True}
+
+        with pytest.raises(ValueError, match="synchronous"):
+            ctx.register_feishu_card_action_handler(PLUGIN_ACTION, callback)
+
+    def test_duplicate_action_id_is_rejected(self):
+        manager, first = _make_ctx("first")
+        second = PluginContext(
+            PluginManifest(name="second", version="0.1.0", description="test"),
+            manager,
+        )
+        first.register_feishu_card_action_handler(PLUGIN_ACTION, MagicMock())
+
+        with pytest.raises(ValueError, match="already registered"):
+            second.register_feishu_card_action_handler(PLUGIN_ACTION, MagicMock())
+
+
+class TestFeishuPluginCardActionDispatch:
+    def test_webhook_card_action_rejects_missing_auth_configuration(self):
+        adapter = _make_adapter(loop_ready=False)
+        adapter._verification_token = ""
+        adapter._encrypt_key = ""
+
+        response = asyncio.run(
+            adapter._handle_webhook_request(_make_webhook_request(event_id="evt_no_auth"))
+        )
+
+        assert response.status == 503
+        assert response.text == "Webhook authentication unavailable"
+
+    @staticmethod
+    def _manager_with(callback=None, route: str = PLUGIN_ACTION):
+        manager = MagicMock()
+        handlers = [] if callback is None else [(route, callback, "popaskin_ads")]
+        manager.get_feishu_card_action_handlers.return_value = handlers
+        return manager
+
+    def test_matching_action_is_attested_without_adapter_loop_or_llm_dispatch(self):
+        adapter = _make_adapter(loop_ready=False)
+        callback = MagicMock(
+            return_value={"ok": True, "toast": {"type": "success", "content": "已接收"}}
+        )
+        data = _make_card_action_data()
+
+        with (
+            patch(
+                "hermes_cli.plugins.get_plugin_manager",
+                return_value=self._manager_with(callback),
+            ),
+            patch.object(adapter, "_submit_on_loop") as submit,
+        ):
+            response = adapter._on_card_action_trigger(data)
+
+        submit.assert_not_called()
+        callback.assert_called_once()
+        kwargs = callback.call_args.kwargs
+        expected_body = (
+            b'{"action":{"tag":"button","value":{"action_id":"pa_public_123",'
+            b'"decision":"approve","hermes_plugin_action":"popaskin_ads.pending_write"}},'
+            b'"context":{"open_chat_id":"oc_dm","open_message_id":"om_card"},'
+            b'"header":{"app_id":"cli_test","create_time":"1720000000000000",'
+            b'"event_id":"evt_1","event_type":"card.action.trigger",'
+            b'"tenant_key":"tenant_1"},"host":"im_message",'
+            b'"operator":{"open_id":"ou_owner","tenant_key":"tenant_1",'
+            b'"union_id":"on_owner","user_id":"u_owner"},'
+            b'"version":"hermes-feishu-card-action-v1"}'
+        )
+        assert kwargs["body"] == expected_body
+        assert kwargs["signature"] == (
+            "v1=5ddca6c9b5265a716642c4fbb0a7a0dd2761ba70c715d5c1fc390e59767751eb"
+        )
+        assert kwargs["envelope"] == json.loads(expected_body)
+        assert response.toast.type == "success"
+        assert response.toast.content == "已接收"
+
+    def test_webhook_namespace_action_value_uses_trusted_plugin_path(self):
+        adapter = _make_adapter(loop_ready=False)
+        callback = MagicMock(return_value={"ok": True})
+        data = _make_card_action_data()
+        data.event.action.value["metadata"] = SimpleNamespace(
+            source="feishu",
+            nested=SimpleNamespace(attempt=1),
+        )
+        data.event.action.value = SimpleNamespace(**data.event.action.value)
+
+        with (
+            patch(
+                "hermes_cli.plugins.get_plugin_manager",
+                return_value=self._manager_with(callback),
+            ),
+            patch.object(adapter, "_submit_on_loop") as submit,
+        ):
+            response = adapter._on_card_action_trigger(data)
+
+        callback.assert_called_once()
+        submit.assert_not_called()
+        assert callback.call_args.kwargs["envelope"]["action"]["value"]["metadata"] == {
+            "source": "feishu",
+            "nested": {"attempt": 1},
+        }
+        assert response.toast.type == "success"
+
+    def test_webhook_returns_plugin_error_toast_instead_of_generic_ack(self):
+        adapter = _make_adapter(loop_ready=False)
+        callback_threads = []
+
+        def _reject_callback(**_kwargs):
+            callback_threads.append(threading.get_ident())
+            return {"ok": False}
+
+        callback = MagicMock(side_effect=_reject_callback)
+        payload = {
+            "header": {
+                "event_id": "evt_webhook",
+                "create_time": "1720000000000000",
+                "event_type": "card.action.trigger",
+                "tenant_key": "tenant_1",
+                "app_id": "cli_test",
+                "token": "verify-token-test",
+            },
+            "event": {
+                "token": "card-token-webhook",
+                "host": "im_message",
+                "operator": {
+                    "open_id": "ou_owner",
+                    "user_id": "u_owner",
+                    "union_id": "on_owner",
+                    "tenant_key": "tenant_1",
+                },
+                "context": {
+                    "open_message_id": "om_card",
+                    "open_chat_id": "oc_dm",
+                },
+                "action": {
+                    "tag": "button",
+                    "value": {
+                        "hermes_plugin_action": PLUGIN_ACTION,
+                        "action_id": "pa_public_123",
+                        "decision": "approve",
+                    },
+                },
+            },
+        }
+        body = json.dumps(payload).encode("utf-8")
+        request = SimpleNamespace(
+            remote="127.0.0.1",
+            content_length=None,
+            headers={"Content-Type": "application/json"},
+            content=_FakeRequestContent(body),
+        )
+
+        with patch(
+            "hermes_cli.plugins.get_plugin_manager",
+            return_value=self._manager_with(callback),
+        ):
+            response = asyncio.run(adapter._handle_webhook_request(request))
+
+        assert response.status == 503
+        assert json.loads(response.text) == {
+            "toast": {"type": "error", "content": "请求未确认，请重试"}
+        }
+        assert callback_threads and callback_threads != [threading.get_ident()]
+
+    def test_webhook_success_is_acknowledged_only_after_plugin_acceptance(self):
+        adapter = _make_adapter(loop_ready=False)
+        callback = MagicMock(return_value={"ok": True})
+
+        with patch(
+            "hermes_cli.plugins.get_plugin_manager",
+            return_value=self._manager_with(callback),
+        ):
+            response = asyncio.run(
+                adapter._handle_webhook_request(
+                    _make_webhook_request(event_id="evt_durable_accept")
+                )
+            )
+
+        assert response.status == 200
+        assert json.loads(response.text)["toast"]["type"] == "success"
+
+    def test_webhook_non_plugin_action_fails_closed_before_memory_dispatch(self):
+        adapter = _make_adapter(loop_ready=False)
+
+        with patch.object(adapter, "_on_card_action_trigger") as legacy_dispatch:
+            response = asyncio.run(
+                adapter._handle_webhook_request(
+                    _make_webhook_request(
+                        event_id="evt_legacy_action",
+                        route=None,
+                    )
+                )
+            )
+
+        legacy_dispatch.assert_not_called()
+        assert response.status == 503
+        assert json.loads(response.text) == {
+            "toast": {
+                "type": "error",
+                "content": "Webhook 模式暂不支持此卡片操作",
+            }
+        }
+
+    def test_webhook_timeout_and_busy_are_bounded_and_retryable(
+        self,
+        monkeypatch,
+    ):
+        adapter = _make_adapter(loop_ready=False)
+        started = threading.Event()
+        release = threading.Event()
+        callback_calls = []
+
+        def _blocking_callback(**_kwargs):
+            callback_calls.append(threading.get_ident())
+            started.set()
+            release.wait(1.0)
+            return {"ok": True}
+
+        manager = self._manager_with(_blocking_callback)
+        monkeypatch.setattr(
+            feishu_module,
+            "_FEISHU_WEBHOOK_CARD_ACTION_TIMEOUT_SECONDS",
+            0.01,
+        )
+        monkeypatch.setattr(
+            feishu_module,
+            "_FEISHU_WEBHOOK_CARD_ACTION_SLOTS",
+            threading.BoundedSemaphore(1),
+            raising=False,
+        )
+
+        timer = threading.Timer(0.15, release.set)
+        timer.daemon = True
+        timer.start()
+
+        async def _run_two_requests():
+            first = await adapter._handle_webhook_request(
+                _make_webhook_request(event_id="evt_timeout_1")
+            )
+            assert started.is_set()
+            second = await adapter._handle_webhook_request(
+                _make_webhook_request(event_id="evt_timeout_2")
+            )
+            return first, second
+
+        try:
+            with patch("hermes_cli.plugins.get_plugin_manager", return_value=manager):
+                first, second = asyncio.run(_run_two_requests())
+        finally:
+            release.set()
+            timer.cancel()
+
+        assert len(callback_calls) == 1
+        for response in (first, second):
+            assert response.status == 503
+            payload = json.loads(response.text)
+            assert payload["toast"]["type"] == "warning"
+            assert "未知" in payload["toast"]["content"]
+
+    def test_webhook_serializer_preserves_resolved_card_and_drops_null_sdk_fields(self):
+        response = _FakeResponse()
+        response.toast = _FakeToast()
+        response.toast.type = "success"
+        response.toast.content = "已处理"
+        response.card = SimpleNamespace(
+            type="raw",
+            data={"elements": [{"tag": "div", "text": "done"}]},
+            optional=None,
+        )
+
+        assert FeishuAdapter._webhook_card_action_payload(response) == {
+            "toast": {"type": "success", "content": "已处理"},
+            "card": {
+                "type": "raw",
+                "data": {"elements": [{"tag": "div", "text": "done"}]},
+            },
+        }
+
+    def test_handler_resolution_uses_adapter_profile_home(self, tmp_path):
+        adapter_home = tmp_path / "profile-a"
+        ambient_home = tmp_path / "profile-b"
+        adapter_token = set_hermes_home_override(str(adapter_home))
+        try:
+            adapter = _make_adapter(loop_ready=False)
+        finally:
+            reset_hermes_home_override(adapter_token)
+
+        callback = MagicMock(return_value={"ok": True})
+        manager = self._manager_with(callback)
+        observed_homes = []
+
+        def _manager_for_current_home():
+            observed_homes.append(get_hermes_home().resolve())
+            return manager
+
+        ambient_token = set_hermes_home_override(str(ambient_home))
+        try:
+            with patch(
+                "hermes_cli.plugins.get_plugin_manager",
+                side_effect=_manager_for_current_home,
+            ):
+                response = adapter._on_card_action_trigger(_make_card_action_data())
+        finally:
+            reset_hermes_home_override(ambient_token)
+
+        callback.assert_called_once()
+        assert response.toast.type == "success"
+        assert observed_homes == [adapter_home.resolve()]
+
+    def test_reserved_plugin_key_takes_precedence_over_builtin_action(self):
+        adapter = _make_adapter(loop_ready=True)
+        callback = MagicMock(return_value={"ok": True})
+        data = _make_card_action_data(extra_value={"hermes_action": "approve_once"})
+
+        with (
+            patch(
+                "hermes_cli.plugins.get_plugin_manager",
+                return_value=self._manager_with(callback),
+            ),
+            patch.object(adapter, "_handle_approval_card_action") as builtin,
+            patch.object(adapter, "_submit_on_loop") as submit,
+        ):
+            adapter._on_card_action_trigger(data)
+
+        callback.assert_called_once()
+        builtin.assert_not_called()
+        submit.assert_not_called()
+
+    def test_unknown_plugin_action_fails_closed_without_synthetic_dispatch(self):
+        adapter = _make_adapter()
+
+        with (
+            patch(
+                "hermes_cli.plugins.get_plugin_manager",
+                return_value=self._manager_with(),
+            ),
+            patch.object(adapter, "_submit_on_loop") as submit,
+        ):
+            response = adapter._on_card_action_trigger(_make_card_action_data())
+
+        submit.assert_not_called()
+        assert response.toast.type == "error"
+
+    @pytest.mark.parametrize(
+        "mutation",
+        [
+            {"message_id": ""},
+            {"app_id": "cli_other"},
+        ],
+    )
+    def test_unattestable_callback_fails_closed(self, mutation):
+        adapter = _make_adapter()
+        callback = MagicMock()
+        data = _make_card_action_data(**mutation)
+
+        with (
+            patch(
+                "hermes_cli.plugins.get_plugin_manager",
+                return_value=self._manager_with(callback),
+            ),
+            patch.object(adapter, "_submit_on_loop") as submit,
+        ):
+            response = adapter._on_card_action_trigger(data)
+
+        submit.assert_not_called()
+        callback.assert_not_called()
+        assert response.toast.type == "error"
+
+    def test_missing_app_secret_fails_closed(self):
+        adapter = _make_adapter()
+        adapter._app_secret = ""
+        callback = MagicMock()
+
+        with patch(
+            "hermes_cli.plugins.get_plugin_manager",
+            return_value=self._manager_with(callback),
+        ):
+            response = adapter._on_card_action_trigger(_make_card_action_data())
+
+        callback.assert_not_called()
+        assert response.toast.type == "error"
+
+    def test_duplicate_callback_is_forwarded_for_durable_downstream_idempotency(self):
+        adapter = _make_adapter()
+        callback = MagicMock(return_value={"ok": True})
+        manager = self._manager_with(callback)
+        data = _make_card_action_data()
+
+        with patch("hermes_cli.plugins.get_plugin_manager", return_value=manager):
+            first = adapter._on_card_action_trigger(data)
+            second = adapter._on_card_action_trigger(data)
+
+        assert callback.call_count == 2
+        assert first.toast.type == "success"
+        assert second.toast.type == "success"
+
+    def test_failed_forward_does_not_poison_same_event_retry(self):
+        adapter = _make_adapter()
+        callback = MagicMock(side_effect=[{"ok": False}, {"ok": True}])
+        manager = self._manager_with(callback)
+        data = _make_card_action_data()
+
+        with patch("hermes_cli.plugins.get_plugin_manager", return_value=manager):
+            first = adapter._on_card_action_trigger(data)
+            second = adapter._on_card_action_trigger(data)
+
+        assert callback.call_count == 2
+        assert first.toast.type == "error"
+        assert second.toast.type == "success"
+
+    def test_plugin_exception_fails_closed_without_logging_exception_text(self, caplog):
+        adapter = _make_adapter()
+        callback = MagicMock(side_effect=RuntimeError("SENSITIVE_CALLBACK_TEXT"))
+
+        with patch(
+            "hermes_cli.plugins.get_plugin_manager",
+            return_value=self._manager_with(callback),
+        ):
+            response = adapter._on_card_action_trigger(_make_card_action_data())
+
+        assert response.toast.type == "error"
+        assert "RuntimeError" in caplog.text
+        assert "SENSITIVE_CALLBACK_TEXT" not in caplog.text
+
+    def test_non_acknowledging_plugin_result_fails_closed(self):
+        adapter = _make_adapter()
+        callback = MagicMock(return_value=None)
+
+        with patch(
+            "hermes_cli.plugins.get_plugin_manager",
+            return_value=self._manager_with(callback),
+        ):
+            response = adapter._on_card_action_trigger(_make_card_action_data())
+
+        callback.assert_called_once()
+        assert response.toast.type == "error"
+
+    def test_non_plugin_card_action_keeps_existing_synthetic_path(self):
+        adapter = _make_adapter(loop_ready=True)
+        data = _make_card_action_data()
+        data.event.action.value = {"ordinary": "value"}
+
+        def close_coro(_loop, coro):
+            coro.close()
+            return True
+
+        with patch.object(adapter, "_submit_on_loop", side_effect=close_coro) as submit:
+            adapter._on_card_action_trigger(data)
+
+        submit.assert_called_once()
+
+    def test_ordinary_card_dedup_uses_adapter_lock(self):
+        adapter = _make_adapter()
+        guard = MagicMock()
+        adapter._card_action_token_lock = guard
+
+        assert adapter._is_card_action_duplicate("token") is False
+
+        guard.__enter__.assert_called_once_with()
+        guard.__exit__.assert_called_once()

--- a/tests/gateway/test_feishu_plugin_action_handlers.py
+++ b/tests/gateway/test_feishu_plugin_action_handlers.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import importlib.util
 import asyncio
+import hashlib
 import json
 import sys
 import threading
@@ -54,6 +55,19 @@ from plugins.platforms.feishu.adapter import FeishuAdapter  # noqa: E402
 
 
 PLUGIN_ACTION = "popaskin_ads.pending_write"
+TEST_ENCRYPT_KEY = "encrypt-key-test"
+
+
+def _signed_webhook_headers(body: bytes) -> dict[str, str]:
+    timestamp = "1720000000"
+    nonce = "nonce-test"
+    content = f"{timestamp}{nonce}{TEST_ENCRYPT_KEY}{body.decode('utf-8')}"
+    return {
+        "Content-Type": "application/json",
+        "x-lark-request-timestamp": timestamp,
+        "x-lark-request-nonce": nonce,
+        "x-lark-signature": hashlib.sha256(content.encode("utf-8")).hexdigest(),
+    }
 
 
 class _FakeToast:
@@ -95,6 +109,7 @@ def _make_adapter(*, loop_ready: bool = False) -> FeishuAdapter:
     adapter._app_id = "cli_test"
     adapter._app_secret = "app-secret-test"
     adapter._verification_token = "verify-token-test"
+    adapter._encrypt_key = TEST_ENCRYPT_KEY
     if loop_ready:
         adapter._loop = MagicMock()
         adapter._loop.is_closed.return_value = False
@@ -188,7 +203,7 @@ def _make_webhook_request(
     return SimpleNamespace(
         remote="127.0.0.1",
         content_length=None,
-        headers={"Content-Type": "application/json"},
+        headers=_signed_webhook_headers(body),
         content=_FakeRequestContent(body),
     )
 
@@ -266,6 +281,19 @@ class TestFeishuPluginCardActionDispatch:
 
         assert response.status == 503
         assert response.text == "Webhook authentication unavailable"
+
+    def test_webhook_card_action_rejects_verification_token_only(self):
+        adapter = _make_adapter(loop_ready=False)
+        adapter._encrypt_key = ""
+
+        response = asyncio.run(
+            adapter._handle_webhook_request(
+                _make_webhook_request(event_id="evt_token_only")
+            )
+        )
+
+        assert response.status == 503
+        assert response.text == "Card-action webhook authentication unavailable"
 
     @staticmethod
     def _manager_with(callback=None, route: str = PLUGIN_ACTION):
@@ -384,7 +412,7 @@ class TestFeishuPluginCardActionDispatch:
         request = SimpleNamespace(
             remote="127.0.0.1",
             content_length=None,
-            headers={"Content-Type": "application/json"},
+            headers=_signed_webhook_headers(body),
             content=_FakeRequestContent(body),
         )
 

--- a/tests/hermes_cli/test_plugins.py
+++ b/tests/hermes_cli/test_plugins.py
@@ -381,6 +381,7 @@ class TestPluginDiscovery:
         mgr._plugin_skills["p:skill"] = {}
         mgr._aux_tasks["task"] = {"plugin": "p"}
         mgr._slack_action_handlers.append(("aid", lambda **_: None, "p"))
+        mgr._feishu_card_action_handlers.append(("aid", lambda **_: None, "p"))
         mgr._discovered = True
 
         monkeypatch.setattr(PluginManager, "_discover_and_load_inner", lambda self_inner: None)
@@ -398,6 +399,7 @@ class TestPluginDiscovery:
         assert mgr._plugin_skills == {}
         assert mgr._aux_tasks == {}
         assert mgr._slack_action_handlers == []
+        assert mgr._feishu_card_action_handlers == []
 
 
 # ── TestPluginLoading ──────────────────────────────────────────────────────

--- a/tests/tools/test_hermes_subprocess_env.py
+++ b/tests/tools/test_hermes_subprocess_env.py
@@ -18,6 +18,8 @@ from tools.environments.local import (
     hermes_subprocess_env,
     _ALWAYS_STRIP_KEYS,
     _HERMES_PROVIDER_ENV_FORCE_PREFIX,
+    _make_run_env,
+    _sanitize_subprocess_env,
 )
 
 
@@ -25,6 +27,7 @@ _TIER1_SAMPLE = {
     "GH_TOKEN": "ghp_secret",
     "TELEGRAM_BOT_TOKEN": "bot-token",
     "SLACK_APP_TOKEN": "xapp-secret",
+    "FEISHU_APP_SECRET": "feishu-secret",
     "MODAL_TOKEN_SECRET": "modal-secret",
     "HERMES_DASHBOARD_SESSION_TOKEN": "dash-secret",
 }
@@ -107,11 +110,38 @@ class TestTierInvariants:
     def test_tier1_covers_gateway_bot_token(self):
         assert "TELEGRAM_BOT_TOKEN" in _ALWAYS_STRIP_KEYS
 
+    def test_tier1_covers_feishu_callback_attestation_key(self):
+        assert "FEISHU_APP_SECRET" in _ALWAYS_STRIP_KEYS
+
     def test_tier1_covers_github_auth(self):
         assert {"GH_TOKEN", "GITHUB_TOKEN"} <= _ALWAYS_STRIP_KEYS
 
     def test_tier1_covers_infra_secrets(self):
         assert {"MODAL_TOKEN_ID", "MODAL_TOKEN_SECRET", "DAYTONA_API_KEY"} <= _ALWAYS_STRIP_KEYS
+
+    def test_tier1_always_stripped_from_terminal_spawn_paths(self):
+        """Terminal, PTY, and execute-code paths share the Tier-1 boundary."""
+        sample = {key: f"secret-{key}" for key in _ALWAYS_STRIP_KEYS}
+        safe = {**_SAFE_SAMPLE, **sample}
+        with patch.dict(os.environ, safe, clear=True):
+            background = _sanitize_subprocess_env(safe, sample)
+            foreground = _make_run_env(sample)
+
+        for name, result in (
+            ("background", background),
+            ("foreground", foreground),
+        ):
+            leaked = set(_ALWAYS_STRIP_KEYS) & set(result)
+            assert not leaked, f"Tier-1 keys leaked through {name}: {sorted(leaked)}"
+
+    def test_force_prefix_cannot_reintroduce_tier1_secret(self):
+        forced_key = _HERMES_PROVIDER_ENV_FORCE_PREFIX + "FEISHU_APP_SECRET"
+        with patch.dict(os.environ, {**_SAFE_SAMPLE, forced_key: "secret"}, clear=True):
+            background = _sanitize_subprocess_env({}, {forced_key: "secret"})
+            foreground = _make_run_env({forced_key: "secret"})
+
+        assert "FEISHU_APP_SECRET" not in background
+        assert "FEISHU_APP_SECRET" not in foreground
 
 
 class TestBrowserPassthroughPattern:

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -469,6 +469,8 @@ def _sanitize_subprocess_env(base_env: dict | None, extra_env: dict | None = Non
     for key, value in (base_env or {}).items():
         if key.startswith(_HERMES_PROVIDER_ENV_FORCE_PREFIX):
             continue
+        if key in _ALWAYS_STRIP_KEYS:
+            continue
         if _is_hermes_internal_secret(key):
             continue
         passthrough = _is_passthrough(key)
@@ -481,9 +483,13 @@ def _sanitize_subprocess_env(base_env: dict | None, extra_env: dict | None = Non
     for key, value in (extra_env or {}).items():
         if key.startswith(_HERMES_PROVIDER_ENV_FORCE_PREFIX):
             real_key = key[len(_HERMES_PROVIDER_ENV_FORCE_PREFIX):]
+            if real_key in _ALWAYS_STRIP_KEYS:
+                continue
             if _is_hermes_internal_secret(real_key):
                 continue
             sanitized[real_key] = value
+        elif key in _ALWAYS_STRIP_KEYS:
+            continue
         elif _is_hermes_internal_secret(key):
             continue
         else:
@@ -549,6 +555,7 @@ _ALWAYS_STRIP_KEYS: frozenset[str] = frozenset({
     "SLACK_BOT_TOKEN",
     "SLACK_APP_TOKEN",
     "SLACK_SIGNING_SECRET",
+    "FEISHU_APP_SECRET",
     "GATEWAY_ALLOWED_USERS",
     "GATEWAY_ALLOW_ALL_USERS",
     # Gateway relay auth — the ID/secret/delivery-key triplet the gateway
@@ -1281,9 +1288,13 @@ def _make_run_env(env: dict) -> dict:
     for k, v in merged.items():
         if k.startswith(_HERMES_PROVIDER_ENV_FORCE_PREFIX):
             real_key = k[len(_HERMES_PROVIDER_ENV_FORCE_PREFIX):]
+            if real_key in _ALWAYS_STRIP_KEYS:
+                continue
             if _is_hermes_internal_secret(real_key):
                 continue
             run_env[real_key] = v
+        elif k in _ALWAYS_STRIP_KEYS:
+            continue
         elif _is_hermes_internal_secret(k):
             continue
         else:

--- a/website/docs/developer-guide/plugins/index.md
+++ b/website/docs/developer-guide/plugins/index.md
@@ -1256,6 +1256,53 @@ def register(ctx):
 
 This is the public way for plugins to participate in Slack interactivity. Older plugins may patch `SlackAdapter.connect`; prefer this API instead.
 
+### Handle trusted Feishu card actions
+
+Plugins that post Feishu interactive cards can reserve one exact action route
+without turning the click into an agent message. Put the route in
+`value.hermes_plugin_action`; the Feishu adapter binds the event, operator,
+message, chat, action value, app, and tenant into canonical JSON and signs the
+exact bytes with a domain-separated HMAC owned by the gateway.
+
+```python
+def register(ctx):
+    dashboard_base = ctx.get_config("dashboard_base", default="")
+
+    def _on_action(*, envelope, body, signature):
+        accepted = forward_to_service(
+            dashboard_base,
+            body=body,
+            signature=signature,
+        )
+        # Return true only after the downstream service durably accepts it.
+        return {"ok": accepted}
+
+    ctx.register_feishu_card_action_handler("acme.review", _on_action)
+```
+
+**Signature:** `ctx.register_feishu_card_action_handler(action_id, callback) -> PluginRegistration`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `action_id` | `str` | Exact route matching `[A-Za-z0-9][A-Za-z0-9_.:-]{0,127}` |
+| `callback` | synchronous callable | Receives keyword arguments `envelope` (dict), `body` (the canonical bytes), and `signature` (`v1=<sha256 hex>`) |
+
+**Runtime behavior:**
+
+- A card containing `hermes_plugin_action` never enters the synthetic message
+  or LLM path, including when its route is malformed or unregistered.
+- The gateway keeps the Feishu app secret; plugins receive only the canonical
+  body and its attestation.
+- The callback is synchronous and must complete within Feishu's callback
+  window. Use a bounded downstream timeout.
+- Exceptions and any result other than `{"ok": True}` fail closed. Retries are
+  forwarded again so durable downstream idempotency remains authoritative.
+- In webhook mode, only registered plugin actions have a durable acceptance
+  contract. Other card-action families fail closed; use WebSocket mode for
+  those actions until they provide their own durable webhook acknowledgement.
+- Use `ctx.get_config()` for non-secret endpoints. Do not put behavioral
+  settings in `.env`.
+
 :::tip
 This guide covers **general plugins** (tools, hooks, slash commands, CLI commands). The sections below sketch the authoring pattern for each specialized plugin type; each links to its full guide for field reference and examples.
 :::


### PR DESCRIPTION
## What does this PR do?

Adds a generic, exact-match Feishu card-action route for external plugins that need to hand an authenticated click to a downstream durable consumer without converting the click into an agent message.

The Feishu adapter validates configured webhook credentials, builds canonical callback bytes, signs them with a domain-separated HMAC, and invokes only the plugin registered for the exact hermes_plugin_action value. The app secret remains gateway-owned. In webhook mode, Hermes returns HTTP 200 only when the handler returns exactly {"ok": true}; missing configuration, unknown/non-plugin actions, busy workers, timeouts, exceptions, and negative acknowledgements fail closed.

This also strips FEISHU_APP_SECRET from child environments and documents the plugin API.

## Related work

No issue is linked.

Related open PRs were reviewed before submission:

- #78425 adds a platform-neutral API for plugins to create and host their own interactive cards with a Hermes SQLite ledger. This PR instead handles inbound actions from an already-rendered Feishu card and delegates durable acceptance to the registered downstream consumer.
- #72137 adds authenticated authority for protected model tools and commands. This PR never routes the action through the model or command path.

The concepts are adjacent and touch some of the same integration files, but the dispatch contracts are different.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [x] 🔒 Security fix
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Add PluginContext.register_feishu_card_action_handler with exact registration, ownership, and teardown.
- Add authenticated canonical Feishu action envelopes and plugin-only dispatch.
- Separate WebSocket response handling from webhook durable acknowledgement semantics.
- Bound plugin execution by concurrency, time, response shape, and fail-closed error handling.
- Strip FEISHU_APP_SECRET from local child-process environments.
- Add Feishu, plugin lifecycle, and subprocess secret-isolation regressions.
- Document the public plugin contract and its acknowledgement requirements.

## How to Test

1. Run:
   python -m pytest -q tests/gateway/test_feishu*.py tests/hermes_cli/test_plugins.py tests/tools/test_hermes_subprocess_env.py
2. Run Ruff against the seven changed Python files.
3. Run scripts/check-windows-footguns.py --diff origin/main.

Observed on macOS:

- 254 passed
- Ruff: all checks passed
- py_compile: passed
- Windows footgun scan reported nine pre-existing bare Path read/write calls in tests/hermes_cli/test_plugins.py; this PR adds only two list assertions in that file and introduces no new scanner match.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched existing open and merged PRs for overlapping Feishu/plugin-action work
- [x] My PR contains only changes related to this feature
- [ ] I've run pytest tests/ -q and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on macOS

The full suite is not claimed: the local baseline cannot collect it because the optional acp dependency is absent. A prior broader candidate run produced 654 passed with one warning; the current-main focused run above produced 254 passed.

### Documentation & Housekeeping

- [x] I've updated relevant plugin documentation
- [x] cli-config.yaml.example: N/A; no config keys added
- [x] CONTRIBUTING.md or AGENTS.md: N/A; public developer docs cover the new API
- [x] I've considered cross-platform impact; no POSIX-only process primitive was added
- [x] Tool descriptions/schemas: N/A; no model tool was added

## Screenshots / Logs

No UI change. No real Feishu callback, plugin activation, or external downstream service was invoked during validation.