### PR TITLE
feat: persist plugin chat lines via session.append_message

### DIFF
--- a/apps/desktop/src/sdk/index.ts
+++ b/apps/desktop/src/sdk/index.ts
@@ -26,6 +26,7 @@ import type { ClientSessionState } from '@/app/types'
 import { $narrowViewport } from '@/components/pane-shell/tree/store'
 import { onGatewayEvent } from '@/contrib/events'
 import { deleteProfile, getLogs, getStatus, type HermesGateway } from '@/hermes'
+import { type ChatMessage, textPart } from '@/lib/chat-messages'
 import { $gateway, openGatewayForAgent, openGatewayForProfile } from '@/store/gateway'
 import { notify, notifyError } from '@/store/notifications'
 import {
@@ -43,7 +44,9 @@ import {
   $currentCwd,
   $currentModel,
   $gatewayState,
-  $selectedStoredSessionId
+  $selectedStoredSessionId,
+  setMessages,
+  touchSessionActivity
 } from '@/store/session'
 import {
   $focusedRuntimeId,
@@ -324,6 +327,58 @@ export const host = {
 
   /** One-shot system status snapshot (platforms, versions, …). */
   status: async () => getStatus(),
+
+  /** Persist a user/assistant line via session.append_message and paint
+   *  only the target session (never a different chat that happens to be
+   *  on screen). */
+  appendMessage: (opts: { role?: string; sessionId?: null | string; text?: string } = {}): boolean => {
+    const body = String(opts.text ?? '').trim()
+    if (!body) {
+      return false
+    }
+
+    const role = opts.role === 'user' ? 'user' : 'assistant'
+    const message: ChatMessage = {
+      id: `${role}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+      role,
+      parts: [textPart(body)]
+    }
+
+    const runtimeId = String(opts.sessionId || $activeSessionId.get() || '').trim()
+    const activeId = String($activeSessionId.get() || '').trim()
+
+    if (runtimeId) {
+      const gateway = $gateway.get()
+      if (gateway) {
+        void gateway
+          .request('session.append_message', {
+            session_id: runtimeId,
+            role,
+            content: body,
+            observed: true
+          })
+          .catch(() => undefined)
+      }
+    }
+
+    if (!runtimeId || runtimeId === activeId) {
+      setMessages(current => [...current, message])
+    }
+
+    if (runtimeId) {
+      const states = $sessionStates.get()
+      const prev = states[runtimeId]
+      if (prev) {
+        $sessionStates.set({
+          ...states,
+          [runtimeId]: { ...prev, messages: [...prev.messages, message] }
+        })
+      }
+    }
+
+    touchSessionActivity(runtimeId || $selectedStoredSessionId.get(), { preview: body })
+    return true
+  },
 
   /** Gateway JSON-RPC — sessions, config, skills, cron, kanban, everything
    *  the app itself uses. Lazy: resolves the LIVE socket per call. */

--- a/apps/desktop/src/sdk/index.ts
+++ b/apps/desktop/src/sdk/index.ts
@@ -330,14 +330,20 @@ export const host = {
 
   /** Persist a user/assistant line via session.append_message and paint
    *  only the target session (never a different chat that happens to be
-   *  on screen). */
+   *  on screen). Role must be user or assistant; unknown values are
+   *  rejected. When a gateway is up, paint only after persist succeeds
+   *  so a later session.activate refresh cannot wipe a ghost line. */
   appendMessage: (opts: { role?: string; sessionId?: null | string; text?: string } = {}): boolean => {
     const body = String(opts.text ?? '').trim()
     if (!body) {
       return false
     }
 
-    const role = opts.role === 'user' ? 'user' : 'assistant'
+    const rawRole = String(opts.role ?? 'assistant').trim().toLowerCase()
+    if (rawRole !== 'user' && rawRole !== 'assistant') {
+      return false
+    }
+    const role = rawRole
     const message: ChatMessage = {
       id: `${role}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
       role,
@@ -346,6 +352,25 @@ export const host = {
 
     const runtimeId = String(opts.sessionId || $activeSessionId.get() || '').trim()
     const activeId = String($activeSessionId.get() || '').trim()
+
+    const paint = () => {
+      if (!runtimeId || runtimeId === activeId) {
+        setMessages(current => [...current, message])
+      }
+
+      if (runtimeId) {
+        const states = $sessionStates.get()
+        const prev = states[runtimeId]
+        if (prev) {
+          $sessionStates.set({
+            ...states,
+            [runtimeId]: { ...prev, messages: [...prev.messages, message] }
+          })
+        }
+      }
+
+      touchSessionActivity(runtimeId || $selectedStoredSessionId.get(), { preview: body })
+    }
 
     if (runtimeId) {
       const gateway = $gateway.get()
@@ -357,26 +382,21 @@ export const host = {
             content: body,
             observed: true
           })
-          .catch(() => undefined)
+          .then((res: { ok?: boolean } | null) => {
+            if (res && res.ok === false) {
+              console.warn('session.append_message failed', res)
+              return
+            }
+            paint()
+          })
+          .catch(err => {
+            console.warn('session.append_message failed', err)
+          })
+        return true
       }
     }
 
-    if (!runtimeId || runtimeId === activeId) {
-      setMessages(current => [...current, message])
-    }
-
-    if (runtimeId) {
-      const states = $sessionStates.get()
-      const prev = states[runtimeId]
-      if (prev) {
-        $sessionStates.set({
-          ...states,
-          [runtimeId]: { ...prev, messages: [...prev.messages, message] }
-        })
-      }
-    }
-
-    touchSessionActivity(runtimeId || $selectedStoredSessionId.get(), { preview: body })
+    paint()
     return true
   },
 

--- a/apps/desktop/src/sdk/index.ts
+++ b/apps/desktop/src/sdk/index.ts
@@ -382,8 +382,8 @@ export const host = {
             content: body,
             observed: true
           })
-          .then((res: { ok?: boolean } | null) => {
-            if (res && res.ok === false) {
+          .then((res: unknown) => {
+            if (typeof res === 'object' && res !== null && 'ok' in res && res.ok === false) {
               console.warn('session.append_message failed', res)
               return
             }

--- a/tui_gateway/methods_session.py
+++ b/tui_gateway/methods_session.py
@@ -2595,23 +2595,23 @@ def _(rid, params: dict) -> dict:
 
     Plugins use this to print a teammate ask/answer into the origin chat
     so a later session.activate REST refresh does not wipe it.
+
+    ``role`` must be ``user`` or ``assistant`` — unknown values are a 4000,
+    not silently coerced. A consecutive same-role append is merged into the
+    last live history entry so the next model turn still sees alternation.
+    Persist runs before the in-memory write; a disk failure returns an error
+    and does not paint a line that ``session.activate`` would later wipe.
     """
     session, err = _sess_nowait(params, rid)
     if err:
         return err
-    role = "user" if str(params.get("role") or "").strip().lower() == "user" else "assistant"
+    raw_role = str(params.get("role") or "").strip().lower()
+    if raw_role not in ("user", "assistant"):
+        return _err(rid, 4000, "role must be 'user' or 'assistant'")
+    role = raw_role
     content = str(params.get("content") or params.get("text") or "").strip()
     if not content:
         return _err(rid, 4000, "empty message")
-    entry = {"role": role, "content": content}
-    lock = session.get("history_lock")
-    if lock is not None:
-        with lock:
-            session.setdefault("history", []).append(entry)
-            session["history_version"] = int(session.get("history_version", 0)) + 1
-    else:
-        session.setdefault("history", []).append(entry)
-        session["history_version"] = int(session.get("history_version", 0)) + 1
     try:
         key = session.get("session_key")
         _ensure_session_db_row(session)
@@ -2624,7 +2624,27 @@ def _(rid, params: dict) -> dict:
                     observed=bool(params.get("observed", True)),
                 )
     except Exception:
-        pass
+        logger.warning("session.append_message persist failed", exc_info=True)
+        return _err(rid, 5007, "persist failed")
+
+    entry = {"role": role, "content": content}
+
+    def _apply(history: list) -> None:
+        if history and history[-1].get("role") == role:
+            prev = history[-1]
+            prev_text = str(prev.get("content") or "").rstrip()
+            prev["content"] = f"{prev_text}\n\n{content}" if prev_text else content
+            return
+        history.append(entry)
+
+    lock = session.get("history_lock")
+    if lock is not None:
+        with lock:
+            _apply(session.setdefault("history", []))
+            session["history_version"] = int(session.get("history_version", 0)) + 1
+    else:
+        _apply(session.setdefault("history", []))
+        session["history_version"] = int(session.get("history_version", 0)) + 1
     return _ok(rid, {"ok": True, "role": role})
 
 

--- a/tui_gateway/methods_session.py
+++ b/tui_gateway/methods_session.py
@@ -2589,6 +2589,45 @@ def _(rid, params: dict) -> dict:
     )
 
 
+@method("session.append_message")
+def _(rid, params: dict) -> dict:
+    """Persist a user/assistant line without starting a turn.
+
+    Plugins use this to print a teammate ask/answer into the origin chat
+    so a later session.activate REST refresh does not wipe it.
+    """
+    session, err = _sess_nowait(params, rid)
+    if err:
+        return err
+    role = "user" if str(params.get("role") or "").strip().lower() == "user" else "assistant"
+    content = str(params.get("content") or params.get("text") or "").strip()
+    if not content:
+        return _err(rid, 4000, "empty message")
+    entry = {"role": role, "content": content}
+    lock = session.get("history_lock")
+    if lock is not None:
+        with lock:
+            session.setdefault("history", []).append(entry)
+            session["history_version"] = int(session.get("history_version", 0)) + 1
+    else:
+        session.setdefault("history", []).append(entry)
+        session["history_version"] = int(session.get("history_version", 0)) + 1
+    try:
+        key = session.get("session_key")
+        _ensure_session_db_row(session)
+        with _session_db(session) as db:
+            if db is not None and key:
+                db.append_message(
+                    session_id=key,
+                    role=role,
+                    content=content,
+                    observed=bool(params.get("observed", True)),
+                )
+    except Exception:
+        pass
+    return _ok(rid, {"ok": True, "role": role})
+
+
 @method("session.undo")
 def _(rid, params: dict) -> dict:
     session, err = _sess(params, rid)


### PR DESCRIPTION
## Summary
- Add `session.append_message` so plugins can persist a user/assistant line without starting a turn (survives a later `session.activate` refresh).
- Teach `host.appendMessage` to persist through that RPC and paint only the target session, not whichever chat happens to be on screen.

## Test plan
- [ ] Call `session.append_message` on a live session, then `session.activate` / reload — the line is still in history.
- [ ] From a plugin, `host.appendMessage({ text, sessionId })` while a *different* session is focused — only the target session's transcript updates.
- [ ] Same call while the target session is focused — the line appears immediately and is still there after refresh.