### PR TITLE
fix(cronjob): warn when builtin scheduler has no gateway

### DIFF
--- a/tests/tools/test_cronjob_tools.py
+++ b/tests/tools/test_cronjob_tools.py
@@ -490,6 +490,50 @@ class TestLocalDeliveryNotice:
         assert created["deliver"] == "origin"
         assert "local-only cron job" not in created["message"]
 
+    @staticmethod
+    def _fake_scheduler(name: str):
+        class _S:
+            def __init__(self, n):
+                self.name = n
+
+        return _S(name)
+
+    def test_builtin_scheduler_without_gateway_emits_warning(self, monkeypatch):
+        from tools import cronjob_tools
+
+        monkeypatch.setattr(
+            cronjob_tools, "resolve_cron_scheduler", lambda: self._fake_scheduler("builtin")
+        )
+        monkeypatch.setattr("hermes_cli.gateway.find_gateway_pids", lambda: [])
+
+        created = json.loads(cronjob(action="create", prompt="x", schedule="every 2m"))
+        assert created["success"] is True
+        assert "Gateway is not running" in created["message"]
+
+    def test_non_builtin_scheduler_omits_gateway_warning(self, monkeypatch):
+        from tools import cronjob_tools
+
+        monkeypatch.setattr(
+            cronjob_tools, "resolve_cron_scheduler", lambda: self._fake_scheduler("chronos")
+        )
+        monkeypatch.setattr("hermes_cli.gateway.find_gateway_pids", lambda: [])
+
+        created = json.loads(cronjob(action="create", prompt="x", schedule="every 2m"))
+        assert created["success"] is True
+        assert "Gateway is not running" not in created["message"]
+
+    def test_running_gateway_omits_warning(self, monkeypatch):
+        from tools import cronjob_tools
+
+        monkeypatch.setattr(
+            cronjob_tools, "resolve_cron_scheduler", lambda: self._fake_scheduler("builtin")
+        )
+        monkeypatch.setattr("hermes_cli.gateway.find_gateway_pids", lambda: [1234])
+
+        created = json.loads(cronjob(action="create", prompt="x", schedule="every 2m"))
+        assert created["success"] is True
+        assert "Gateway is not running" not in created["message"]
+
 
 class TestValidateCronBaseUrl:
     """The cron base_url guard must not let a NAMED custom provider's stored

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -15,6 +15,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional, Union
 
 from hermes_constants import display_hermes_home
+from cron.scheduler_provider import resolve_cron_scheduler
 
 logger = logging.getLogger(__name__)
 
@@ -391,6 +392,31 @@ def _local_delivery_notice(job: Dict[str, Any], user_deliver: Optional[str]) -> 
         "notified when it runs, recreate or update the job with deliver set to "
         "a gateway-connected platform, e.g. deliver='telegram' or deliver='all'."
     )
+
+
+def _gateway_not_running_warning() -> Optional[str]:
+    """Return a creation warning when jobs are configured but won't fire.
+
+    The tool currently succeeds even when the built-in scheduler is active and no
+    gateway process is running; that means jobs are persisted but inert.
+    """
+    try:
+        if resolve_cron_scheduler().name != "builtin":
+            return None
+    except Exception as e:
+        logger.debug("Unable to resolve cron scheduler for gateway warning check: %s", e)
+        return None
+
+    try:
+        from hermes_cli.gateway import find_gateway_pids
+
+        if find_gateway_pids():
+            return None
+    except Exception as e:
+        logger.debug("Unable to inspect gateway process state for cron warning: %s", e)
+        return None
+
+    return "⚠  Gateway is not running — cron jobs won't fire automatically."
 
 
 def _repeat_display(job: Dict[str, Any]) -> str:
@@ -1260,8 +1286,14 @@ def cronjob(
                 return tool_error(_partial.pop("error"), success=False, **_partial)
             _create_message = f"Cron job '{job['name']}' created."
             _local_notice = _local_delivery_notice(job, _normalize_deliver_param(deliver))
+            _gateway_warning = _gateway_not_running_warning()
+            notices = []
             if _local_notice:
-                _create_message = f"{_create_message} {_local_notice}"
+                notices.append(_local_notice)
+            if _gateway_warning:
+                notices.append(_gateway_warning)
+            if notices:
+                _create_message = f"{_create_message} {' '.join(notices)}"
             return json.dumps(
                 {
                     "success": True,


### PR DESCRIPTION
## Summary
- Add a creation-time warning when `cronjob` jobs are created with the builtin scheduler but no gateway process is running.
- Preserve existing local-delivery warning behavior and keep the warning optional/non-blocking.

## Changes
- `tools/cronjob_tools.py`
  - Added `_gateway_not_running_warning()` to detect `resolve_cron_scheduler().name == "builtin"` and no running gateway PID.
  - Appended this warning (when applicable) to the `cronjob` create response message alongside existing local-delivery notice.
  - Added debug logging on scheduler/pid resolution failures instead of swallowing silently.
- `tests/tools/test_cronjob_tools.py`
  - Added regression tests covering:
    - builtin scheduler with no gateway emits warning,
    - non-builtin scheduler omits warning,
    - running gateway omits warning.

## Test Plan
- `python3 -m py_compile tools/cronjob_tools.py tests/tools/test_cronjob_tools.py`
- `python3 -m pytest tests/tools/test_cronjob_tools.py::TestLocalDeliveryNotice::test_builtin_scheduler_without_gateway_emits_warning tests/tools/test_cronjob_tools.py::TestLocalDeliveryNotice::test_non_builtin_scheduler_omits_gateway_warning tests/tools/test_cronjob_tools.py::TestLocalDeliveryNotice::test_running_gateway_omits_warning tests/tools/test_cronjob_tools.py::TestUnifiedCronjobTool::test_create_and_list -q`

Closes #87033
