### PR TITLE
fix(terminal): preserve lifecycle guard paths on Windows

### DIFF
--- a/cron/lifecycle_guard.py
+++ b/cron/lifecycle_guard.py
@@ -427,6 +427,14 @@ def _resolve_script_directory(script_path: str) -> Optional[str]:
 
 def _read_referenced_script(path: Path) -> tuple[Optional[str], bool]:
     """Return ``(text, unsafe)`` using bounded, regular-file-only reads."""
+    # Windows refuses to open directories with ``os.open`` before ``fstat``
+    # can classify them. Preserve the fail-closed non-regular-file contract
+    # across platforms while keeping missing paths as "nothing to scan".
+    try:
+        if path.exists() and not path.is_file():
+            return None, True
+    except (OSError, ValueError):
+        pass
     flags = os.O_RDONLY | getattr(os, "O_NONBLOCK", 0)
     try:
         descriptor = os.open(path, flags)

--- a/tests/hermes_cli/test_gateway_restart_loop.py
+++ b/tests/hermes_cli/test_gateway_restart_loop.py
@@ -305,7 +305,7 @@ class TestTerminalToolGatewayLifecycleGuard:
         script.write_text("#!/bin/bash\nsleep 45\nhermes gateway restart\n", encoding="utf-8")
         self._patch_env(monkeypatch, self._make_fake_env(), inside_gateway=True)
 
-        result = json.loads(tt.terminal_tool(command=f"/bin/bash {script}"))
+        result = json.loads(tt.terminal_tool(command=f"/bin/bash {script.as_posix()}"))
 
         assert result["exit_code"] == 1
         assert "referenced script" in result["error"]
@@ -383,7 +383,7 @@ class TestTerminalToolGatewayLifecycleGuard:
         )
         self._patch_env(monkeypatch, self._make_fake_env(), inside_gateway=True)
 
-        result = json.loads(tt.terminal_tool(command=f"/bin/bash {script}"))
+        result = json.loads(tt.terminal_tool(command=f"/bin/bash {script.as_posix()}"))
 
         assert result["exit_code"] == 1
         assert "referenced script" in result["error"]
@@ -415,7 +415,7 @@ class TestTerminalToolGatewayLifecycleGuard:
         script.chmod(0o700)
         self._patch_env(monkeypatch, self._make_fake_env(), inside_gateway=True)
 
-        result = json.loads(tt.terminal_tool(command=str(script)))
+        result = json.loads(tt.terminal_tool(command=script.as_posix()))
 
         assert result["exit_code"] == 1
 
@@ -438,7 +438,7 @@ class TestTerminalToolGatewayLifecycleGuard:
         self._patch_env(monkeypatch, self._make_fake_env(), inside_gateway=True)
 
         result = json.loads(tt.terminal_tool(
-            command=f"/bin/bash -O extglob {script}"
+            command=f"/bin/bash -O extglob {script.as_posix()}"
         ))
 
         assert result["exit_code"] == 1
@@ -479,13 +479,15 @@ class TestTerminalToolGatewayLifecycleGuard:
 
         self._patch_env(monkeypatch, _FakeEnv(), inside_gateway=True)
 
-        result = json.loads(tt.terminal_tool(command=f"/bin/bash {outer}"))
+        result = json.loads(tt.terminal_tool(command=f"/bin/bash {outer.as_posix()}"))
 
         assert result["exit_code"] == 1
 
     def test_non_regular_referenced_script_fails_closed(self, monkeypatch, tmp_path):
         import tools.terminal_tool as tt
 
+        if not hasattr(os, "mkfifo"):
+            pytest.skip("FIFO creation is unavailable on this platform")
         fifo = tmp_path / "script.fifo"
         os.mkfifo(fifo)
         self._patch_env(monkeypatch, self._make_fake_env(), inside_gateway=True)
@@ -533,7 +535,7 @@ class TestTerminalToolGatewayLifecycleGuard:
         monkeypatch.setattr(
             tt, "_check_all_guards", lambda cmd, env, **kwargs: {"approved": True}
         )
-        command = f"/bin/bash {script}"
+        command = f"/bin/bash {script.as_posix()}"
 
         result = json.loads(tt.terminal_tool(command=command))
 
@@ -1033,7 +1035,7 @@ class TestTerminalToolGatewayLifecycleGuardRemote:
         monkeypatch.setattr(tt, "_active_environments", {eid: fake_env})
         monkeypatch.setattr(tt, "_last_activity", {eid: 0.0})
         monkeypatch.setattr(tt, "_task_env_overrides", {})
-        monkeypatch.setattr(tt, "_get_env_config", lambda: {"env_type": "local", "cwd": "/tmp", "timeout": 60, "lifetime_seconds": 3600})
+        monkeypatch.setattr(tt, "_get_env_config", lambda: {"env_type": "ssh", "cwd": "/tmp", "timeout": 60, "lifetime_seconds": 3600})
         if inside_gateway:
             monkeypatch.setenv("_HERMES_GATEWAY", "1")
         else:
@@ -1053,7 +1055,7 @@ class TestTerminalToolGatewayLifecycleGuardRemote:
             def execute(self, command, **kwargs):
                 calls.append(command)
                 if "head -c" in command and "/remote/workspace/remote.sh" in command:
-                    return {"output": "#!/bin/bash\\nhermes gateway restart\\n", "returncode": 0}
+                    return {"output": "#!/bin/bash\nhermes gateway restart\n", "returncode": 0}
                 return {"output": "", "returncode": 0}
 
         fake_env = _RemoteEnv()
@@ -1207,8 +1209,9 @@ class TestLifecycleGuardNeverRaises:
     def test_directory_and_dev_null_fail_closed_not_crash(self, tmp_path):
         # Non-regular files are suspicious (fail closed = blocked), but the
         # important contract is: verdict, not exception.
-        assert self._scan(f"bash {tmp_path}") is True
-        assert self._scan("bash /dev/null") is True
+        assert self._scan(f"bash {tmp_path.as_posix()}") is True
+        if os.name != "nt":
+            assert self._scan("bash /dev/null") is True
 
     def test_magic_prefix_binaries_skipped_without_full_read(self, tmp_path):
         """Executable magic (ELF/PE/Mach-O) short-circuits the read: the
@@ -1238,6 +1241,9 @@ class TestLifecycleGuardNeverRaises:
         binary.write_bytes(b"\x7fELF" + bytes(128))
         for value in ("nul\x00byte.sh", str(binary), "/nonexistent/x.sh"):
             check_gateway_lifecycle("clean prompt", value)  # must not raise
-        for value in ("/dev/null", str(tmp_path)):
+        non_regular_values = [str(tmp_path)]
+        if os.name != "nt":
+            non_regular_values.append("/dev/null")
+        for value in non_regular_values:
             with pytest.raises(GatewayLifecycleBlocked):
                 check_gateway_lifecycle("clean prompt", value)

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -2850,9 +2850,15 @@ def terminal_tool(
                 # redirect keeps leading-dash paths out of argv (same form as
                 # tools/image_source.py).
                 try:
+                    remote_script_path = script_path
+                    if os.name == "nt" and env_type != "local":
+                        # ``lifecycle_guard`` renders candidates using the
+                        # host Path flavor. Restore POSIX remote spelling on
+                        # Windows before passing the path to a remote shell.
+                        remote_script_path = script_path.replace("\\", "/")
                     result = env.execute(
                         f"head -c {_MAX_REFERENCED_SCRIPT_BYTES + 1} "
-                        f"< {shlex.quote(script_path)}"
+                        f"< {shlex.quote(remote_script_path)}"
                     )
                     if result.get("returncode", -1) == 0:
                         output = result.get("output", "")


### PR DESCRIPTION
## Summary

- preserve fail-closed handling for existing non-regular referenced paths on Windows, where `os.open()` rejects directories before `fstat()` can classify them
- restore POSIX remote path spelling when a Windows host reads a referenced script through a non-local terminal backend
- make gateway lifecycle-guard tests use shell-valid forward-slash paths on Windows
- gate POSIX-only FIFO and `/dev/null` assertions by platform
- correct the remote-backend fixture to use an SSH environment and return actual newline-delimited script content

## Why

The gateway lifecycle guard recursively scans referenced shell scripts before allowing lifecycle commands to execute. Windows exposes two cross-platform gaps:

1. opening a directory with `os.open()` fails before the existing `fstat()` non-regular-file check, so an existing directory is treated like a missing path instead of failing closed;
2. `pathlib` renders a POSIX remote path with backslashes on a Windows host, so the bounded remote `head -c` read targets the wrong path.

Several tests also built unquoted Git Bash commands with native `C:\\...` paths. Those commands are not shell-valid because POSIX parsing consumes the backslashes; the tests now use forward-slash paths while retaining the same behavior contracts.

## Red / green proof

With the corrected portable fixtures but without the two production changes:

```text
3 failed in 0.95s
```

The failures cover:

- Windows host → POSIX remote referenced-script read
- directory/non-regular referenced-path fail-closed verdict
- `check_gateway_lifecycle()` non-regular script-path rejection

With the production changes restored:

```text
3 passed in 0.50s
```

## Verification

Windows 10, current `origin/main` (`45af7a71f`):

```text
124 passed, 1 skipped in 3.03s
```

for `tests/hermes_cli/test_gateway_restart_loop.py`.

Combined order gate:

```text
134 passed, 1 skipped in 3.82s
```

for:

```text
tests/hermes_cli/test_gateway_restart_loop.py
tests/tools/test_terminal_tool.py
```

Also passed:

- Python `py_compile` for all three touched files
- `ruff check` for all three touched files
- `git diff --check`

## Scope

This is independent of #87038. It does not modify that PR's commits, branch, or test-isolation changes.
