### PR TITLE
fix(skills): make Windows skill Python examples runnable

### DIFF
--- a/optional-skills/web-development/har-derived-api-client/SKILL.md
+++ b/optional-skills/web-development/har-derived-api-client/SKILL.md
@@ -76,17 +76,17 @@ Resolve paths against this skill's directory. Canonical loop:
 
 ```bash
 # 1a. Capture, LOCAL browser (Hermes launched it)
-python3 scripts/har_capture.py "https://SITE/" out.har \
+python scripts/har_capture.py "https://SITE/" out.har \
   --action "fill:input[name=search]:my query" --action "sleep:3" --wait 2
 
 # 1b. Capture, CDP browser (cloud backend or /browser connect)
 #     get the endpoint from /browser connect or BROWSER_CDP_URL
-python3 scripts/har_capture_cdp.py "ws://HOST/devtools/browser/..." out.har \
+python scripts/har_capture_cdp.py "ws://HOST/devtools/browser/..." out.har \
   --goto "https://SITE/" --action "fill:input[name=search]:my query" \
   --action "sleep:3" --wait 2
 
 # 2. Derive — read the endpoints out of the HAR
-python3 scripts/har_to_client.py out.har --host SITE --max-body 400
+python scripts/har_to_client.py out.har --host SITE --max-body 400
 
 # 3. Replay — write a tiny client from the printed endpoint (see Procedure)
 ```
@@ -153,9 +153,9 @@ for p in r.json()["pages"]:
 End-to-end proof against a live site with no API key:
 
 ```bash
-python3 scripts/har_capture.py "https://en.wikipedia.org/wiki/Main_Page" /tmp/wiki.har \
+python scripts/har_capture.py "https://en.wikipedia.org/wiki/Main_Page" /tmp/wiki.har \
   --action "fill:input[name=search]:dune messiah" --action "sleep:3" --wait 2
-python3 scripts/har_to_client.py /tmp/wiki.har --host wikipedia.org --max-body 200
+python scripts/har_to_client.py /tmp/wiki.har --host wikipedia.org --max-body 200
 ```
 
 Expect the derivation to print `GET https://en.wikipedia.org/w/rest.php/v1/search/title`

--- a/optional-skills/web-development/har-derived-api-client/SKILL.md
+++ b/optional-skills/web-development/har-derived-api-client/SKILL.md
@@ -76,17 +76,17 @@ Resolve paths against this skill's directory. Canonical loop:
 
 ```bash
 # 1a. Capture, LOCAL browser (Hermes launched it)
-python scripts/har_capture.py "https://SITE/" out.har \
+uv run python scripts/har_capture.py "https://SITE/" out.har \
   --action "fill:input[name=search]:my query" --action "sleep:3" --wait 2
 
 # 1b. Capture, CDP browser (cloud backend or /browser connect)
 #     get the endpoint from /browser connect or BROWSER_CDP_URL
-python scripts/har_capture_cdp.py "ws://HOST/devtools/browser/..." out.har \
+uv run python scripts/har_capture_cdp.py "ws://HOST/devtools/browser/..." out.har \
   --goto "https://SITE/" --action "fill:input[name=search]:my query" \
   --action "sleep:3" --wait 2
 
 # 2. Derive — read the endpoints out of the HAR
-python scripts/har_to_client.py out.har --host SITE --max-body 400
+uv run python scripts/har_to_client.py out.har --host SITE --max-body 400
 
 # 3. Replay — write a tiny client from the printed endpoint (see Procedure)
 ```
@@ -153,9 +153,9 @@ for p in r.json()["pages"]:
 End-to-end proof against a live site with no API key:
 
 ```bash
-python scripts/har_capture.py "https://en.wikipedia.org/wiki/Main_Page" /tmp/wiki.har \
+uv run python scripts/har_capture.py "https://en.wikipedia.org/wiki/Main_Page" /tmp/wiki.har \
   --action "fill:input[name=search]:dune messiah" --action "sleep:3" --wait 2
-python scripts/har_to_client.py /tmp/wiki.har --host wikipedia.org --max-body 200
+uv run python scripts/har_to_client.py /tmp/wiki.har --host wikipedia.org --max-body 200
 ```
 
 Expect the derivation to print `GET https://en.wikipedia.org/w/rest.php/v1/search/title`

--- a/optional-skills/web-development/har-derived-api-client/scripts/har_capture.py
+++ b/optional-skills/web-development/har-derived-api-client/scripts/har_capture.py
@@ -2,7 +2,7 @@
 """Record a HAR file while driving a website with Playwright.
 
 Usage:
-  python har_capture.py <url> <output.har> [--wait SECONDS] \
+  uv run python har_capture.py <url> <output.har> [--wait SECONDS] \
       [--action "fill:SELECTOR:TEXT"] [--action "press:SELECTOR:KEY"] \
       [--action "click:SELECTOR"] [--action "goto:URL"] [--action "sleep:SECONDS"]
 

--- a/optional-skills/web-development/har-derived-api-client/scripts/har_capture.py
+++ b/optional-skills/web-development/har-derived-api-client/scripts/har_capture.py
@@ -2,7 +2,7 @@
 """Record a HAR file while driving a website with Playwright.
 
 Usage:
-  python3 har_capture.py <url> <output.har> [--wait SECONDS] \
+  python har_capture.py <url> <output.har> [--wait SECONDS] \
       [--action "fill:SELECTOR:TEXT"] [--action "press:SELECTOR:KEY"] \
       [--action "click:SELECTOR"] [--action "goto:URL"] [--action "sleep:SECONDS"]
 

--- a/optional-skills/web-development/har-derived-api-client/scripts/har_capture_cdp.py
+++ b/optional-skills/web-development/har-derived-api-client/scripts/har_capture_cdp.py
@@ -12,7 +12,7 @@ record_har is unavailable — we assemble the HAR from CDP Network.* events
 ourselves via page.on("request"/"response").
 
 Usage:
-  python3 har_capture_cdp.py <cdp_url> <output.har> [--wait S] \
+  python har_capture_cdp.py <cdp_url> <output.har> [--wait S] \
       [--goto URL] [--action "fill:SEL:TEXT"] [--action "click:SEL"] ...
 
 <cdp_url> is the ws:// or http:// CDP endpoint. For Hermes: run

--- a/optional-skills/web-development/har-derived-api-client/scripts/har_capture_cdp.py
+++ b/optional-skills/web-development/har-derived-api-client/scripts/har_capture_cdp.py
@@ -12,7 +12,7 @@ record_har is unavailable — we assemble the HAR from CDP Network.* events
 ourselves via page.on("request"/"response").
 
 Usage:
-  python har_capture_cdp.py <cdp_url> <output.har> [--wait S] \
+  uv run python har_capture_cdp.py <cdp_url> <output.har> [--wait S] \
       [--goto URL] [--action "fill:SEL:TEXT"] [--action "click:SEL"] ...
 
 <cdp_url> is the ws:// or http:// CDP endpoint. For Hermes: run

--- a/optional-skills/web-development/har-derived-api-client/scripts/har_to_client.py
+++ b/optional-skills/web-development/har-derived-api-client/scripts/har_to_client.py
@@ -2,7 +2,7 @@
 """Distill a HAR file into an API summary an agent can turn into a client.
 
 Usage:
-  python har_to_client.py <input.har> [--include-static] [--host SUBSTRING] [--max-body 600]
+  uv run python har_to_client.py <input.har> [--include-static] [--host SUBSTRING] [--max-body 600]
 
 Filters to XHR/fetch/JSON traffic by default, groups by (method, host, path
 template), and prints per-endpoint: query params, interesting request headers,

--- a/optional-skills/web-development/har-derived-api-client/scripts/har_to_client.py
+++ b/optional-skills/web-development/har-derived-api-client/scripts/har_to_client.py
@@ -2,7 +2,7 @@
 """Distill a HAR file into an API summary an agent can turn into a client.
 
 Usage:
-  python3 har_to_client.py <input.har> [--include-static] [--host SUBSTRING] [--max-body 600]
+  python har_to_client.py <input.har> [--include-static] [--host SUBSTRING] [--max-body 600]
 
 Filters to XHR/fetch/JSON traffic by default, groups by (method, host, path
 template), and prints per-endpoint: query params, interesting request headers,

--- a/skills/research/blocked-page-recovery/SKILL.md
+++ b/skills/research/blocked-page-recovery/SKILL.md
@@ -31,7 +31,7 @@ ladder, cheapest first.
 Run it in one shot with the bundled script:
 
 ```bash
-python3 scripts/recover_page.py "https://example.com/blocked-article" --json
+python scripts/recover_page.py "https://example.com/blocked-article" --json
 ```
 
 The script tries each route in order, validates every body (see "Fake

--- a/skills/research/blocked-page-recovery/SKILL.md
+++ b/skills/research/blocked-page-recovery/SKILL.md
@@ -31,7 +31,7 @@ ladder, cheapest first.
 Run it in one shot with the bundled script:
 
 ```bash
-python scripts/recover_page.py "https://example.com/blocked-article" --json
+uv run python scripts/recover_page.py "https://example.com/blocked-article" --json
 ```
 
 The script tries each route in order, validates every body (see "Fake

--- a/skills/research/blocked-page-recovery/scripts/recover_page.py
+++ b/skills/research/blocked-page-recovery/scripts/recover_page.py
@@ -11,7 +11,7 @@ redirect-stub detection (meta-refresh/JS pointing back at the original host),
 and interstitial-title rejection. Fake 200s are the norm in this space.
 
 Stdlib only. Usage:
-    python recover_page.py URL [--json] [--out FILE] [--timeout N]
+    uv run python recover_page.py URL [--json] [--out FILE] [--timeout N]
 
 Exit codes: 0 recovered, 1 nothing worked, 2 bad invocation.
 """

--- a/skills/research/blocked-page-recovery/scripts/recover_page.py
+++ b/skills/research/blocked-page-recovery/scripts/recover_page.py
@@ -11,7 +11,7 @@ redirect-stub detection (meta-refresh/JS pointing back at the original host),
 and interstitial-title rejection. Fake 200s are the norm in this space.
 
 Stdlib only. Usage:
-    python3 recover_page.py URL [--json] [--out FILE] [--timeout N]
+    python recover_page.py URL [--json] [--out FILE] [--timeout N]
 
 Exit codes: 0 recovered, 1 nothing worked, 2 bad invocation.
 """


### PR DESCRIPTION
## What does this PR do?

Windows users following the bundled blocked-page recovery and HAR-derived API client skills can fail before the scripts start because the documented `python3` command is not available on native Windows, while an unqualified `python` may resolve to Python 2. This change routes the affected runnable examples through `uv run python`, which consistently selects the supported Python 3 environment across platforms.

### Symptom

On the verified Windows environment, `python3 --version` exits with code 127. Replacing it with bare `python` is also insufficient because that command resolves to Python 2.7.17 and the bundled Python 3 scripts fail with `SyntaxError`.

### Impact

Windows users cannot run the primary blocked-page recovery example or the related HAR capture and derivation examples as documented.

### Bug Cause

**Trigger:** `skills/research/blocked-page-recovery/SKILL.md:34` and the runnable commands in `optional-skills/web-development/har-derived-api-client/SKILL.md`

**Causal chain:**
1. A Windows user copies a documented skill command that starts with `python3`.
2. Native Windows command resolution cannot find that executable; using bare `python` can select an incompatible Python 2 installation.
3. The command fails before the bundled Python 3 script can run.

**Why it is wrong:** The skills declare Windows support, but their main executable examples depend on a POSIX-style interpreter name or an ambiguous system interpreter.

**Working sibling / contrast:** Other cross-platform bundled skills already use `uv run python` to resolve the project-supported Python interpreter consistently.

**Ruled out:** The scripts themselves are not the source of the failure. Their help and syntax-check paths succeed when launched through the Python 3 interpreter resolved by uv.

### Fix

Use `uv run python` for all standalone Python command examples in the two Windows-declared skills and in their bundled scripts' usage text. Preserve POSIX shebangs and versioned interpreter references because they are not Windows copy-paste command words.

## Related Issue

Closes #87048

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `skills/research/blocked-page-recovery/` - launch the recovery example through uv and align its script usage text.
- `optional-skills/web-development/har-derived-api-client/` - launch capture and derivation examples through uv and align all bundled script usage text.

## How to Test

1. On Windows, confirm `uv run python skills/research/blocked-page-recovery/scripts/recover_page.py --help` exits successfully.
2. Confirm `uv run python optional-skills/web-development/har-derived-api-client/scripts/har_to_client.py --help` exits successfully and syntax-check both capture scripts with the same interpreter.
3. Run the focused skill validation:

```bash
scripts/run_tests.sh tests/skills/test_har_derived_api_client_skill.py
```

Verified locally: 9 tests passed. A repository audit of 161 Windows-declared skills found no remaining standalone `python3` command words.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run the repository's focused test entry and all relevant tests pass
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant skill documentation
- [x] Config example updates are not applicable because no config keys changed
- [x] Architecture and workflow documentation updates are not applicable
- [x] I've considered cross-platform impact per the compatibility guide
- [x] Tool description and schema updates are not applicable
