### PR TITLE
fix(batch_runner): count-based resume so duplicate prompts are not dropped

### DIFF
--- a/batch_runner.py
+++ b/batch_runner.py
@@ -32,6 +32,7 @@ except ModuleNotFoundError:
     pass
 
 import json
+from collections import Counter
 import logging
 import os
 import time
@@ -731,17 +732,22 @@ class BatchRunner:
         else:
             atomic_json_write(self.checkpoint_file, checkpoint_data)
     
-    def _scan_completed_prompts_by_content(self) -> set:
+    def _scan_completed_prompts_by_content(self) -> Counter:
         """
         Scan all batch files and extract completed prompts by their actual content.
-        
+
         This provides a more robust resume mechanism that matches on prompt text
         rather than indices, allowing recovery even if indices don't match.
-        
+
+        A Counter (not a set) is used so each distinct prompt text is tracked by
+        the number of times it was actually completed. When the dataset contains
+        duplicate prompt texts, resume must skip only as many copies as were
+        finished — the remaining duplicates still need to run.
+
         Returns:
-            set: Set of prompt texts that have been successfully processed
+            Counter: Mapping of prompt text -> completed occurrence count
         """
-        completed_prompts = set()
+        completed_prompts = Counter()
         batch_files = sorted(self.output_dir.glob("batch_*.jsonl"))
         
         if not batch_files:
@@ -766,7 +772,7 @@ class BatchRunner:
                                 if msg.get("from") == "human":
                                     prompt_text = msg.get("value", "").strip()
                                     if prompt_text:
-                                        completed_prompts.add(prompt_text)
+                                        completed_prompts[prompt_text] += 1
                                     break  # Only need the first human message
                         except json.JSONDecodeError:
                             continue
@@ -775,23 +781,29 @@ class BatchRunner:
         
         return completed_prompts
     
-    def _filter_dataset_by_completed(self, completed_prompts: set) -> Tuple[List[Dict], List[int]]:
+    def _filter_dataset_by_completed(self, completed_prompts: Counter) -> Tuple[List[Dict], List[int]]:
         """
         Filter the dataset to exclude prompts that have already been completed.
-        
+
+        Matching is count-based: a prompt text that was completed N times is
+        skipped for the first N occurrences in the dataset, but any further
+        occurrences are kept so duplicate prompts still run to completion.
+        A mutable copy of the counter is decremented as each match is consumed.
+
         Args:
-            completed_prompts: Set of prompt texts that have been completed
-            
+            completed_prompts: Counter of prompt text -> completed occurrence count
+
         Returns:
             Tuple of (filtered_dataset, skipped_indices)
         """
         filtered_dataset = []
         skipped_indices = []
-        
+        remaining = Counter(completed_prompts)
+
         for idx, entry in enumerate(self.dataset):
             # Extract prompt from the dataset entry
             prompt_text = entry.get("prompt", "").strip()
-            
+
             # Also check conversations format
             if not prompt_text:
                 conversations = entry.get("conversations", [])
@@ -800,13 +812,14 @@ class BatchRunner:
                     if role in {"user", "human"}:
                         prompt_text = (msg.get("content") or msg.get("value", "")).strip()
                         break
-            
-            if prompt_text in completed_prompts:
+
+            if remaining[prompt_text] > 0:
+                remaining[prompt_text] -= 1
                 skipped_indices.append(idx)
             else:
                 # Keep original index for tracking
                 filtered_dataset.append((idx, entry))
-        
+
         return filtered_dataset, skipped_indices
     
     def run(self, resume: bool = False):
@@ -821,11 +834,11 @@ class BatchRunner:
         print("=" * 70)
         
         # Smart resume: scan batch files by content to find completed prompts
-        completed_prompt_texts = set()
+        completed_prompt_texts = Counter()
         if resume:
             completed_prompt_texts = self._scan_completed_prompts_by_content()
             if completed_prompt_texts:
-                print(f"   Found {len(completed_prompt_texts)} already-completed prompts by content matching")
+                print(f"   Found {sum(completed_prompt_texts.values())} already-completed prompts by content matching")
         
         # Filter dataset to only include unprocessed prompts
         if resume and completed_prompt_texts:

--- a/batch_runner.py
+++ b/batch_runner.py
@@ -32,10 +32,10 @@ except ModuleNotFoundError:
     pass
 
 import json
-from collections import Counter
 import logging
 import os
 import time
+from collections import Counter
 from pathlib import Path
 from typing import List, Dict, Any, Optional, Tuple
 from datetime import datetime
@@ -733,19 +733,11 @@ class BatchRunner:
             atomic_json_write(self.checkpoint_file, checkpoint_data)
     
     def _scan_completed_prompts_by_content(self) -> Counter:
-        """
-        Scan all batch files and extract completed prompts by their actual content.
+        """Count finished prompt texts from batch_*.jsonl files.
 
-        This provides a more robust resume mechanism that matches on prompt text
-        rather than indices, allowing recovery even if indices don't match.
-
-        A Counter (not a set) is used so each distinct prompt text is tracked by
-        the number of times it was actually completed. When the dataset contains
-        duplicate prompt texts, resume must skip only as many copies as were
-        finished — the remaining duplicates still need to run.
-
-        Returns:
-            Counter: Mapping of prompt text -> completed occurrence count
+        Returns a Counter, not a set. A set would collapse duplicates, so
+        --resume would treat every copy of a prompt as done after the first
+        one finished. The count is how many copies we are allowed to skip.
         """
         completed_prompts = Counter()
         batch_files = sorted(self.output_dir.glob("batch_*.jsonl"))
@@ -782,19 +774,10 @@ class BatchRunner:
         return completed_prompts
     
     def _filter_dataset_by_completed(self, completed_prompts: Counter) -> Tuple[List[Dict], List[int]]:
-        """
-        Filter the dataset to exclude prompts that have already been completed.
+        """Drop already-finished rows using counts, not set membership.
 
-        Matching is count-based: a prompt text that was completed N times is
-        skipped for the first N occurrences in the dataset, but any further
-        occurrences are kept so duplicate prompts still run to completion.
-        A mutable copy of the counter is decremented as each match is consumed.
-
-        Args:
-            completed_prompts: Counter of prompt text -> completed occurrence count
-
-        Returns:
-            Tuple of (filtered_dataset, skipped_indices)
+        If "hello" finished twice, skip the first two "hello" rows and keep
+        any later copies. Copy the Counter so the caller is not mutated.
         """
         filtered_dataset = []
         skipped_indices = []

--- a/tests/test_batch_runner_checkpoint.py
+++ b/tests/test_batch_runner_checkpoint.py
@@ -1,6 +1,7 @@
 """Tests for batch_runner checkpoint behavior — incremental writes, resume, atomicity."""
 
 import json
+from collections import Counter
 from pathlib import Path
 from threading import Lock
 
@@ -239,3 +240,56 @@ class TestFinalCheckpointNoDuplicates:
             buggy.extend(br.get("completed_prompts", []))
         # Every index appears twice
         assert len(buggy) == 2 * len(set(buggy))
+
+
+class TestResumeCountBasedDedup:
+    """Regression: --resume used a set for completed prompts, so duplicate
+    prompts in the dataset were all marked "completed" after the first one
+    finished — the rest were silently skipped on resume.
+
+    Fix: _scan_completed_prompts_by_content returns a Counter (count per
+    text), and _filter_dataset_by_completed skips only that many rows per
+    text, not every row with a matching text.
+    """
+
+    def _make_runner(self, tmp_path, dataset):
+        """Build a BatchRunner with output_dir and dataset set up."""
+        r = BatchRunner.__new__(BatchRunner)
+        r.run_name = "test_run"
+        r.output_dir = tmp_path
+        r.checkpoint_file = tmp_path / "checkpoint.json"
+        r.output_file = tmp_path / "output.jsonl"
+        r.prompts_file = tmp_path / "prompts.jsonl"
+        r.dataset = dataset
+        return r
+
+    def test_duplicate_prompts_survive_resume(self, tmp_path):
+        """Dataset has 3 copies of the same prompt. One completes. On
+        resume, the remaining 2 must NOT be skipped."""
+        prompt = "What is 2+2?"
+        dataset = [
+            {"prompt": prompt},
+            {"prompt": prompt},
+            {"prompt": prompt},
+        ]
+        runner = self._make_runner(tmp_path, dataset)
+
+        # Simulate: one trajectory already written to a batch file
+        batch_file = tmp_path / "batch_0.jsonl"
+        entry = {
+            "failed": False,
+            "conversations": [{"from": "human", "value": prompt}],
+        }
+        batch_file.write_text(json.dumps(entry) + "\n")
+
+        # Scan completed prompts
+        completed = runner._scan_completed_prompts_by_content()
+
+        # Counter should report 1 completion for this prompt
+        assert isinstance(completed, Counter)
+        assert completed[prompt] == 1
+
+        # Filter should skip only 1 of the 3 duplicates
+        filtered, skipped = runner._filter_dataset_by_completed(completed)
+        assert len(skipped) == 1
+        assert len(filtered) == 2

--- a/tests/test_batch_runner_checkpoint.py
+++ b/tests/test_batch_runner_checkpoint.py
@@ -243,17 +243,15 @@ class TestFinalCheckpointNoDuplicates:
 
 
 class TestResumeCountBasedDedup:
-    """Regression: --resume used a set for completed prompts, so duplicate
-    prompts in the dataset were all marked "completed" after the first one
-    finished — the rest were silently skipped on resume.
+    """--resume used to store completed prompt texts in a set.
 
-    Fix: _scan_completed_prompts_by_content returns a Counter (count per
-    text), and _filter_dataset_by_completed skips only that many rows per
-    text, not every row with a matching text.
+    After one copy of a duplicated prompt finished, every remaining copy
+    was treated as done and silently dropped. These tests pin the
+    count-based behavior: skip N rows only if N copies actually finished.
     """
 
     def _make_runner(self, tmp_path, dataset):
-        """Build a BatchRunner with output_dir and dataset set up."""
+        """Minimal BatchRunner: only the fields scan/filter need."""
         r = BatchRunner.__new__(BatchRunner)
         r.run_name = "test_run"
         r.output_dir = tmp_path
@@ -263,33 +261,80 @@ class TestResumeCountBasedDedup:
         r.dataset = dataset
         return r
 
+    def _write_completed(self, tmp_path, prompt, n=1, failed=False):
+        """Write n trajectory lines in the format scan() actually reads."""
+        lines = []
+        for _ in range(n):
+            lines.append(json.dumps({
+                "failed": failed,
+                "conversations": [{"from": "human", "value": prompt}],
+            }))
+        (tmp_path / "batch_0.jsonl").write_text("\n".join(lines) + "\n")
+
     def test_duplicate_prompts_survive_resume(self, tmp_path):
-        """Dataset has 3 copies of the same prompt. One completes. On
-        resume, the remaining 2 must NOT be skipped."""
+        """3 identical rows, 1 finished → skip 1, keep 2."""
         prompt = "What is 2+2?"
-        dataset = [
-            {"prompt": prompt},
-            {"prompt": prompt},
-            {"prompt": prompt},
-        ]
-        runner = self._make_runner(tmp_path, dataset)
+        runner = self._make_runner(tmp_path, [{"prompt": prompt}] * 3)
+        self._write_completed(tmp_path, prompt, n=1)
 
-        # Simulate: one trajectory already written to a batch file
-        batch_file = tmp_path / "batch_0.jsonl"
-        entry = {
-            "failed": False,
-            "conversations": [{"from": "human", "value": prompt}],
-        }
-        batch_file.write_text(json.dumps(entry) + "\n")
-
-        # Scan completed prompts
         completed = runner._scan_completed_prompts_by_content()
-
-        # Counter should report 1 completion for this prompt
         assert isinstance(completed, Counter)
         assert completed[prompt] == 1
 
-        # Filter should skip only 1 of the 3 duplicates
         filtered, skipped = runner._filter_dataset_by_completed(completed)
-        assert len(skipped) == 1
+        assert skipped == [0]
+        assert len(filtered) == 2
+        # Remaining rows still carry their original dataset indices.
+        assert [idx for idx, _ in filtered] == [1, 2]
+
+    def test_two_of_three_completed_keeps_the_last(self, tmp_path):
+        """2 finished copies → only the last duplicate is still due."""
+        prompt = "repeat me"
+        runner = self._make_runner(tmp_path, [{"prompt": prompt}] * 3)
+        self._write_completed(tmp_path, prompt, n=2)
+
+        completed = runner._scan_completed_prompts_by_content()
+        filtered, skipped = runner._filter_dataset_by_completed(completed)
+        assert completed[prompt] == 2
+        assert skipped == [0, 1]
+        assert [idx for idx, _ in filtered] == [2]
+
+    def test_unique_prompts_still_skip_as_before(self, tmp_path):
+        """Unrelated texts must not leak skip-budget onto each other."""
+        runner = self._make_runner(tmp_path, [
+            {"prompt": "alpha"},
+            {"prompt": "beta"},
+            {"prompt": "gamma"},
+        ])
+        self._write_completed(tmp_path, "beta", n=1)
+
+        filtered, skipped = runner._filter_dataset_by_completed(
+            runner._scan_completed_prompts_by_content()
+        )
+        assert skipped == [1]
+        assert [idx for idx, _ in filtered] == [0, 2]
+
+    def test_failed_trajectory_is_not_counted(self, tmp_path):
+        """Failed rows are retried, so they must not consume skip-budget."""
+        prompt = "flaky"
+        runner = self._make_runner(tmp_path, [{"prompt": prompt}] * 2)
+        self._write_completed(tmp_path, prompt, n=1, failed=True)
+
+        completed = runner._scan_completed_prompts_by_content()
+        assert completed[prompt] == 0
+        filtered, skipped = runner._filter_dataset_by_completed(completed)
+        assert skipped == []
+        assert len(filtered) == 2
+
+    def test_filter_does_not_mutate_the_counter(self, tmp_path):
+        """Filter decrements a copy so a second call sees the same counts."""
+        prompt = "stable"
+        runner = self._make_runner(tmp_path, [{"prompt": prompt}] * 3)
+        self._write_completed(tmp_path, prompt, n=1)
+        completed = runner._scan_completed_prompts_by_content()
+
+        runner._filter_dataset_by_completed(completed)
+        filtered, skipped = runner._filter_dataset_by_completed(completed)
+        assert completed[prompt] == 1
+        assert skipped == [0]
         assert len(filtered) == 2


### PR DESCRIPTION
## What does this PR do?

**TL;DR:** If a batch dataset repeats the same prompt on purpose (3 copies, say), `--resume` used to skip *all 3* after the first one finished. Those extra runs never happened, and the summary claimed they were already done. This PR only skips the copies that actually finished. The rest still run.

`--resume` scanned finished trajectories into a **set** of prompt texts. Duplicate prompts are legal (repeat sampling, paraphrase controls). After the first copy finished, every remaining copy of that text was treated as done and silently dropped. The resume summary then reported those lost rows as "Already completed."

This switches the scan to a `Counter` and skips only as many matching dataset rows as actually finished. Remaining copies still run.

## Related Issue

Fixes #86523

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `batch_runner.py`: `_scan_completed_prompts_by_content` now returns a `Counter` (count per prompt text) instead of a `set`
- `batch_runner.py`: `_filter_dataset_by_completed` decrements that count per match, so only N rows are skipped when N copies finished
- `batch_runner.py`: resume summary uses `sum(counter.values())` so the printed total is completed rows, not unique texts
- `tests/test_batch_runner_checkpoint.py`: regression tests for 1-of-3 / 2-of-3 duplicates, unique texts, failed rows, and Counter immutability

## How to Test

1. Dataset with three identical prompts; write one successful `batch_*.jsonl` trajectory for that text (the format scan() reads: `conversations[].from == "human"`).
2. Call `_scan_completed_prompts_by_content()` then `_filter_dataset_by_completed()`.
3. Expect: skip the first row only; the other two keep their original indices.

```bash
pytest tests/test_batch_runner_checkpoint.py::TestResumeCountBasedDedup tests/test_batch_runner_durability.py -v
```

On this change: 22 passed (macOS, Python 3.11). RED→GREEN: reverting the Counter change makes `test_duplicate_prompts_survive_resume` fail (`set` is not a `Counter`).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the batch_runner suites (`test_batch_runner_checkpoint.py` + `test_batch_runner_durability.py`) — 22 passed; not the full `tests/` tree
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.3, Python 3.11 (batch_runner unit tests)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
