### PR TITLE
fix(cli): stop pushing Kitty keyboard protocol that breaks Ctrl+C (regression from 2ae7884ffa)

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -3885,7 +3885,7 @@ _TERMINAL_INPUT_MODE_RESET_SEQ = (
     "\x1b[0m"      # reset text attributes
     "\x1b[?25h"    # ensure cursor visible
 )
-_EXTENDED_ENTER_KEYS_SEQ = "\x1b[>1u\x1b[>4;2m"
+_EXTENDED_ENTER_KEYS_SEQ = "\x1b[>4;2m"
 
 
 _BACKSLASH_LINE_CONTINUATION_RE = re.compile(r"\\[ \t]*$")
@@ -3920,10 +3920,14 @@ def _terminal_supports_extended_enter_keys(env: Optional[Mapping[str, str]] = No
 def _enable_extended_enter_keys(output=None, env: Optional[Mapping[str, str]] = None) -> bool:
     """Ask allowlisted terminals to report Shift+Enter distinctly.
 
-    Writes both the Kitty keyboard protocol push (CSI >1u) and xterm
-    modifyOtherKeys level 2 (CSI >4;2m), mirroring the Ink TUI. The exit reset
-    sequence already pops/resets both modes, so this is safe across normal
-    exits, Ctrl+C, and SIGTERM cleanup.
+    Writes xterm modifyOtherKeys level 2 (CSI >4;2m), mirroring the Ink TUI.
+    We do NOT push the Kitty keyboard protocol (CSI >1u) here because
+    prompt_toolkit 3.x cannot parse Kitty CSI-u sequences for control
+    characters — Ctrl+C arrives as ``\\x1b[99;5u`` instead of ``\\x03``,
+    which neither prompt_toolkit's key bindings nor the kernel's INTR
+    mechanism can match, leaving Ctrl+C completely dead (#56684).
+    The exit reset sequence already pops/resets both modes, so this is
+    safe across normal exits, Ctrl+C, and SIGTERM cleanup.
     """
     if not _terminal_supports_extended_enter_keys(env):
         return False


### PR DESCRIPTION
## Summary
Ctrl+C works again on Ghostty, iTerm2, WezTerm, and kitty terminals. A commit that landed on main today (2ae7884ffa, "fix: make CLI multiline shortcuts work by default") pushed the Kitty keyboard protocol on every supported terminal, which re-encodes Ctrl+C as `\x1b[99;5u` — a sequence prompt_toolkit 3.x cannot parse and the kernel's INTR mechanism cannot match. Ctrl+C was completely dead, printing `[99;5u` as literal text.

## Root cause
Commit 2ae7884ffa added `_EXTENDED_ENTER_KEYS_SEQ = "\x1b[>1u\x1b[>4;2m"` to enable Shift+Enter multiline input. The `\x1b[>1u` part pushes the Kitty keyboard protocol (disambiguate escape codes, flags=1). Under this protocol:

- Ctrl+C is encoded as `\x1b[99;5u` (codepoint 99='c', modifier 5=Ctrl) instead of `\x03` (ETX)
- prompt_toolkit 3.0.52 has NO mapping for `\x1b[99;5u` — its only CSI-u entry is `\x1b[1;5u` → `Keys.Control5`
- The kernel's SIGINT mechanism looks for the raw INTR character (`\x03`), which never arrives
- Result: Ctrl+C is completely dead — no signal, no key binding, literal `[99;5u` leaks to screen

This affects every terminal in `_terminal_supports_extended_enter_keys()` allowlist: Ghostty, iTerm2, WezTerm, kitty, tmux, VS Code, Windows Terminal.

## Changes
- Removed `CSI >1u` (Kitty keyboard protocol push) from `_EXTENDED_ENTER_KEYS_SEQ`, keeping only `CSI >4;2m` (modifyOtherKeys)
- Shift+Enter still works: modifyOtherKeys produces `\x1b[27;2;13~` which prompt_toolkit already maps to `Keys.ControlM` (line 128 of `ansi_escape_sequences.py`)
- Updated docstring explaining why the Kitty push is omitted and referencing #56684
- The exit reset sequence (`_TERMINAL_INPUT_MODE_RESET_SEQ`) still pops Kitty + resets modifyOtherKeys for safety

## Validation
| | Before fix | After fix |
|---|---|---|
| Ctrl+C on Ghostty | `[99;5u` printed, no interrupt | Works (sends `\x03`, fires SIGINT) |
| Shift+Enter | Works via Kitty CSI-u `\x1b[13;2u` | Works via modifyOtherKeys `\x1b[27;2;13~` |
| Exit cleanup | Pops Kitty + resets modifyOtherKeys | Still pops Kitty + resets modifyOtherKeys (safe) |

```python
# Verified: no kitty keyboard protocol push, only modifyOtherKeys
assert '>1u' not in _EXTENDED_ENTER_KEYS_SEQ
assert '>4;2m' in _EXTENDED_ENTER_KEYS_SEQ
```

Refs #56684 (open PR by @oleynikandrey mapping CSI-u control keys in prompt_toolkit — complementary approach).
