### PR TITLE
fix(cli): map kitty NumLock arrow keys so they don't leak as text

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -81,13 +81,15 @@ try:
         install_cmd_backspace_alias,
         install_ctrl_enter_alias,
         install_ignored_terminal_sequences,
+        install_numlock_cursor_aliases,
         install_shift_enter_alias,
     )
     install_shift_enter_alias()
     install_ctrl_enter_alias()
     install_cmd_backspace_alias()
     install_ignored_terminal_sequences()
-    del install_shift_enter_alias, install_ctrl_enter_alias, install_cmd_backspace_alias, install_ignored_terminal_sequences
+    install_numlock_cursor_aliases()
+    del install_shift_enter_alias, install_ctrl_enter_alias, install_cmd_backspace_alias, install_ignored_terminal_sequences, install_numlock_cursor_aliases
 except Exception:
     pass
 import threading
@@ -5366,8 +5368,10 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         per ``min_interval`` seconds.
         """
         now = time.monotonic()
-        last = getattr(self, "_last_focus_regain_redraw", 0.0)
-        if now - last < min_interval:
+        # None, not 0.0: monotonic() is uptime, so on a fresh CI/VM it can be
+        # less than min_interval and a 0.0 sentinel would skip the first redraw.
+        last = getattr(self, "_last_focus_regain_redraw", None)
+        if last is not None and now - last < min_interval:
             return
         self._last_focus_regain_redraw = now
         self._force_full_redraw()

--- a/hermes_cli/pt_input_extras.py
+++ b/hermes_cli/pt_input_extras.py
@@ -161,3 +161,69 @@ def install_ignored_terminal_sequences() -> int:
             ANSI_SEQUENCES[seq] = Keys.Ignore
             changed += 1
     return changed
+
+
+# xterm/kitty CSI modifier bit 8. When NumLock is on, cursor keys arrive as
+# ``ESC [ 1 ; (base_mod + 128) A`` instead of the un-modified / low-mod form
+# stock prompt_toolkit tables. See https://sw.kovidgoyal.net/kitty/keyboard-protocol/#modifiers
+_NUMLOCK_MOD_BIT = 128
+
+
+def install_numlock_cursor_aliases() -> int:
+    """Map CSI cursor keys that include the NumLock modifier bit.
+
+    Kitty (and other xterm-style terminals once the keyboard protocol or
+    modifyOtherKeys is active) encode NumLock as bit 8 of the CSI modifier
+    parameter. A plain Up then arrives as ``ESC [ 1 ; 129 A`` instead of
+    ``ESC [ A``. Stock prompt_toolkit only tables modifiers 2–9, so the
+    sequence fails to match: Escape is consumed and ``[1;129A`` is inserted
+    as literal text in the classic CLI prompt.
+
+    Also maps the disambiguated unmodified form ``ESC [ 1 ; 1 A`` (kitty
+    keyboard protocol flag 1) to the same unmodified keys, and copies every
+    already-tabled ``ESC [ 1 ; mod X`` binding to ``mod + 128`` so Shift/Ctrl
+    arrows keep working with NumLock on.
+
+    Returns the number of sequences whose mapping was changed.
+    """
+    try:
+        from prompt_toolkit.input.ansi_escape_sequences import ANSI_SEQUENCES
+        from prompt_toolkit.keys import Keys
+    except Exception:
+        return 0
+
+    unmodified = {
+        "A": Keys.Up,
+        "B": Keys.Down,
+        "C": Keys.Right,
+        "D": Keys.Left,
+        "H": Keys.Home,
+        "F": Keys.End,
+    }
+    changed = 0
+
+    def _set(seq: str, key: object) -> None:
+        nonlocal changed
+        if ANSI_SEQUENCES.get(seq) != key:
+            ANSI_SEQUENCES[seq] = key
+            changed += 1
+
+    for letter, key in unmodified.items():
+        _set(f"\x1b[1;1{letter}", key)
+        _set(f"\x1b[1;{1 + _NUMLOCK_MOD_BIT}{letter}", key)
+
+    for seq, key in list(ANSI_SEQUENCES.items()):
+        if not seq.startswith("\x1b[1;") or len(seq) < 6:
+            continue
+        letter = seq[-1]
+        if letter not in unmodified:
+            continue
+        try:
+            mod = int(seq[4:-1])
+        except ValueError:
+            continue
+        if mod & _NUMLOCK_MOD_BIT:
+            continue
+        _set(f"\x1b[1;{mod + _NUMLOCK_MOD_BIT}{letter}", key)
+
+    return changed

--- a/tests/cli/test_cli_force_redraw.py
+++ b/tests/cli/test_cli_force_redraw.py
@@ -408,9 +408,12 @@ class TestFocusRegainRedraw:
 
         assert calls == ["redraw"]
 
-    def test_focus_regain_redraw_is_rate_limited(self, bare_cli):
+    def test_focus_regain_redraw_is_rate_limited(self, bare_cli, monkeypatch):
         calls = []
         bare_cli._force_full_redraw = lambda: calls.append("redraw")
+        # Uptime can be < min_interval on a fresh CI runner; pin monotonic
+        # so the first call is a genuine first-fire, not a 0.0-sentinel skip.
+        monkeypatch.setattr(cli_mod.time, "monotonic", lambda: 10.0)
 
         bare_cli._schedule_focus_regain_redraw(min_interval=60.0)
         bare_cli._schedule_focus_regain_redraw(min_interval=60.0)

--- a/tests/cli/test_cli_numlock_arrows.py
+++ b/tests/cli/test_cli_numlock_arrows.py
@@ -1,0 +1,88 @@
+"""NumLock-modified CSI cursor keys must parse as arrows, not leak as text.
+
+Kitty (and xterm-style terminals with the keyboard protocol active) encode
+NumLock as bit 8 of the CSI modifier, so a plain Up arrives as
+``ESC [ 1 ; 129 A``. Stock prompt_toolkit only tables modifiers 2–9, so
+the VT100 parser emits Escape plus the remainder as literal characters —
+the classic CLI then inserts ``[1;129A`` into the prompt.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from prompt_toolkit.input.ansi_escape_sequences import ANSI_SEQUENCES
+from prompt_toolkit.input.vt100_parser import Vt100Parser
+from prompt_toolkit.keys import Keys
+
+from hermes_cli.pt_input_extras import install_numlock_cursor_aliases
+
+
+NUMLOCK_UNMODIFIED = (
+    ("\x1b[1;129A", Keys.Up),
+    ("\x1b[1;129B", Keys.Down),
+    ("\x1b[1;129C", Keys.Right),
+    ("\x1b[1;129D", Keys.Left),
+    ("\x1b[1;129H", Keys.Home),
+    ("\x1b[1;129F", Keys.End),
+)
+
+DISAMBIGUATED_UNMODIFIED = (
+    ("\x1b[1;1A", Keys.Up),
+    ("\x1b[1;1B", Keys.Down),
+    ("\x1b[1;1C", Keys.Right),
+    ("\x1b[1;1D", Keys.Left),
+)
+
+
+@pytest.fixture(autouse=True)
+def _ensure_alias_installed():
+    install_numlock_cursor_aliases()
+
+
+def _parse(byte_seq: str):
+    out = []
+    parser = Vt100Parser(out.append)
+    for ch in byte_seq:
+        parser.feed(ch)
+    parser.flush()
+    return [kp.key for kp in out]
+
+
+@pytest.mark.parametrize("seq, key", NUMLOCK_UNMODIFIED)
+def test_numlock_arrows_parse_as_unmodified_cursor_keys(seq, key):
+    assert _parse(seq) == [key]
+
+
+@pytest.mark.parametrize("seq, key", DISAMBIGUATED_UNMODIFIED)
+def test_disambiguated_unmodified_arrows_parse_as_cursor_keys(seq, key):
+    """Kitty keyboard protocol flag 1 sends ESC[1;1A for a plain arrow."""
+    assert _parse(seq) == [key]
+
+
+@pytest.mark.parametrize("seq, _key", NUMLOCK_UNMODIFIED + DISAMBIGUATED_UNMODIFIED)
+def test_sequences_emit_exactly_one_keypress(seq, _key):
+    """The whole sequence is consumed. A partial match would emit Escape
+    plus the remainder as literal text — the bug this alias exists to fix."""
+    assert len(_parse(seq)) == 1
+
+
+def test_numlock_shift_up_keeps_shift_binding():
+    assert _parse("\x1b[1;130A") == _parse("\x1b[1;2A") == [Keys.ShiftUp]
+
+
+def test_numlock_ctrl_right_keeps_ctrl_binding():
+    assert _parse("\x1b[1;133C") == _parse("\x1b[1;5C") == [Keys.ControlRight]
+
+
+def test_plain_arrows_keep_their_own_bindings():
+    assert ANSI_SEQUENCES["\x1b[A"] == Keys.Up
+    assert ANSI_SEQUENCES["\x1b[B"] == Keys.Down
+    assert ANSI_SEQUENCES["\x1b[C"] == Keys.Right
+    assert ANSI_SEQUENCES["\x1b[D"] == Keys.Left
+    assert _parse("\x1b[A") == [Keys.Up]
+
+
+def test_install_is_idempotent():
+    install_numlock_cursor_aliases()
+    assert install_numlock_cursor_aliases() == 0


### PR DESCRIPTION
## Summary
- Classic CLI prints `[1;129A` / `[1;129B` / `[1;129C` / `[1;129D` when arrow keys are pressed in kitty with NumLock on, instead of moving the cursor or browsing history.
- Kitty encodes NumLock as CSI modifier 129 (`ESC[1;129A`). prompt_toolkit only tables modifiers 2–9, so the sequence fails to match, Escape is consumed, and the rest is inserted as literal text.
- Map those sequences (and the disambiguated `ESC[1;1A` form, plus NumLock variants of Shift/Ctrl arrows) through the existing `pt_input_extras` alias path.

## Test plan
- [x] `scripts/run_tests.sh tests/cli/test_cli_numlock_arrows.py -q`
- [ ] In kitty with NumLock on, run classic `hermes` (not `--tui`) and confirm Up/Down/Left/Right navigate instead of inserting `[1;129A`
- [ ] Confirm Shift+arrows and Ctrl+arrows still work with NumLock on
- [ ] Confirm `python scripts/keystroke_diagnostic.py` still reports `Keys.Up/Down/Left/Right`