### PR TITLE
fix(tts): prefer xAI API key for speech synthesis

### DIFF
--- a/tests/tools/test_tts_xai_speech_tags.py
+++ b/tests/tools/test_tts_xai_speech_tags.py
@@ -158,6 +158,44 @@ def test_generate_xai_tts_uses_oauth_pinned_base_url(tmp_path, monkeypatch):
     assert captured["headers"]["Authorization"] == "Bearer oauth-bearer-token"
 
 
+def test_generate_xai_tts_prefers_explicit_api_key_over_oauth(tmp_path, monkeypatch):
+    """TTS requires API billing even when chat OAuth is configured (#87045)."""
+    captured = {}
+
+    class FakeResponse:
+        content = b"audio"
+
+        def raise_for_status(self):
+            pass
+
+    def fake_post(url, *, headers, json, timeout, stream):
+        captured["url"] = url
+        captured["headers"] = headers
+        return FakeResponse()
+
+    monkeypatch.setattr(
+        "tools.tts_tool.get_env_value",
+        lambda name, default=None: {
+            "XAI_API_KEY": "paid-api-key",
+            "XAI_BASE_URL": "https://api-key.example/v1/",
+        }.get(name, default),
+    )
+    monkeypatch.setattr(
+        "tools.xai_http.resolve_xai_http_credentials",
+        lambda: {
+            "provider": "xai-oauth",
+            "api_key": "oauth-token",
+            "base_url": "https://oauth.example/v1",
+        },
+    )
+    monkeypatch.setattr("requests.post", fake_post)
+
+    _generate_xai_tts("hello", str(tmp_path / "out.mp3"), {})
+
+    assert captured["headers"]["Authorization"] == "Bearer paid-api-key"
+    assert captured["url"] == "https://api-key.example/v1/tts"
+
+
 def test_auto_speech_tags_calls_auxiliary_rewriter_with_tts_audio_tags_task():
     """When input has no explicit speech tags, the function must call the
     auxiliary rewriter with task='tts_audio_tags' and a system prompt

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -2099,7 +2099,20 @@ def _generate_xai_tts(text: str, output_path: str, tts_config: Dict[str, Any]) -
 
     from tools.xai_http import resolve_xai_http_credentials
 
-    creds = resolve_xai_http_credentials()
+    # TTS is API-billed. Prefer an explicit API key because subscription OAuth
+    # can authorize chat while returning 403 for /v1/tts. Other xAI features
+    # keep the general OAuth-first resolver order.
+    explicit_key = str(get_env_value("XAI_API_KEY") or "").strip()
+    if explicit_key:
+        creds = {
+            "provider": "xai",
+            "api_key": explicit_key,
+            "base_url": str(
+                get_env_value("XAI_BASE_URL") or DEFAULT_XAI_BASE_URL
+            ).strip().rstrip("/"),
+        }
+    else:
+        creds = resolve_xai_http_credentials()
     api_key = str(creds.get("api_key") or "").strip()
     if not api_key:
         raise ValueError("No xAI credentials found. Configure xAI OAuth in `hermes model` or set XAI_API_KEY.")


### PR DESCRIPTION
## Summary

- prefer an explicit `XAI_API_KEY` for the synchronous xAI `/v1/tts` request because subscription OAuth can be rejected by this separately billed endpoint
- keep the existing OAuth resolver as the fallback when no explicit API key is configured
- preserve API-key-specific `XAI_BASE_URL` handling without changing other xAI integrations

Closes #87045

## Root cause

The general xAI credential resolver prefers `xai-oauth`. That is correct for supported OAuth surfaces, but xAI subscription OAuth does not necessarily authorize `/v1/tts`. Hermes therefore ignored a funded `XAI_API_KEY`, sent the OAuth bearer, and received HTTP 403.

## Verification

- `scripts/run_tests.sh tests/tools/test_tts_xai_speech_tags.py tests/tools/test_tts_dotenv_fallback.py -q`
  - 16 passed, 0 failed
- `python -m ruff check tools/tts_tool.py tests/tools/test_tts_xai_speech_tags.py`
- `git diff --check`
- sabotage check: restoring the old OAuth-first call makes the new regression test fail with `Bearer oauth-token != Bearer paid-api-key`; restoring the fix makes it pass

## Scope

This intentionally changes only the synchronous `/v1/tts` path reported in the issue. It does not change xAI chat, image, search, transcription, or WebSocket streaming credential precedence. OAuth remains available for `/v1/tts` when no explicit API key is configured.