### PR TITLE
fix(feishu): resolve group sender names from chat members

### DIFF
--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -3150,12 +3150,19 @@ class FeishuAdapter(BasePlatformAdapter):
         action = "added" if "created" in event_type else "removed"
         synthetic_text = f"reaction:{action}:{emoji_type}"
 
-        sender_profile = await self._resolve_sender_profile(user_id_obj)
         chat_info = await self.get_chat_info(chat_id)
+        source_chat_type = self._resolve_source_chat_type(
+            chat_info=chat_info,
+            event_chat_type=chat_type_raw,
+        )
+        sender_profile = await self._resolve_sender_profile(
+            user_id_obj,
+            chat_id=chat_id if source_chat_type in {"group", "forum"} else None,
+        )
         source = self.build_source(
             chat_id=chat_id,
             chat_name=chat_info.get("name") or chat_id or "Feishu Chat",
-            chat_type=self._resolve_source_chat_type(chat_info=chat_info, event_chat_type=chat_type_raw),
+            chat_type=source_chat_type,
             user_id=sender_profile["user_id"],
             user_name=sender_profile["user_name"],
             thread_id=None,
@@ -3501,11 +3508,19 @@ class FeishuAdapter(BasePlatformAdapter):
 
         chat_id = getattr(message, "chat_id", "") or ""
         chat_info = await self.get_chat_info(chat_id)
-        sender_profile = await self._resolve_sender_profile(sender_id, is_bot=is_bot)
+        source_chat_type = self._resolve_source_chat_type(
+            chat_info=chat_info,
+            event_chat_type=chat_type,
+        )
+        sender_profile = await self._resolve_sender_profile(
+            sender_id,
+            is_bot=is_bot,
+            chat_id=chat_id if source_chat_type in {"group", "forum"} else None,
+        )
         source = self.build_source(
             chat_id=chat_id,
             chat_name=chat_info.get("name") or chat_id or "Feishu Chat",
-            chat_type=self._resolve_source_chat_type(chat_info=chat_info, event_chat_type=chat_type),
+            chat_type=source_chat_type,
             user_id=sender_profile["user_id"],
             user_name=sender_profile["user_name"],
             thread_id=thread_id,
@@ -4277,6 +4292,7 @@ class FeishuAdapter(BasePlatformAdapter):
         sender_id: Any,
         *,
         is_bot: bool = False,
+        chat_id: Optional[str] = None,
     ) -> Dict[str, Optional[str]]:
         """Map Feishu's three-tier user IDs onto Hermes' SessionSource fields.
 
@@ -4299,11 +4315,39 @@ class FeishuAdapter(BasePlatformAdapter):
         display_name = await self._resolve_sender_name_from_api(
             name_lookup_id, is_bot=is_bot,
         )
+        # External or cross-tenant group members can be visible in the chat
+        # while the Contact API rejects them with ``no user authority``. The
+        # chat-members endpoint still returns an authoritative display name
+        # keyed by this app's open_id, so use it as a group-only fallback.
+        if not display_name and not is_bot and chat_id and open_id:
+            display_name = await self._resolve_sender_name_from_chat_members(
+                chat_id,
+                open_id,
+            )
         return {
             "user_id": primary_id,
             "user_name": display_name,
             "user_id_alt": union_id,
         }
+
+    async def _resolve_sender_name_from_chat_members(
+        self,
+        chat_id: str,
+        open_id: str,
+    ) -> Optional[str]:
+        """Resolve one group sender from the existing chat-member directory."""
+        for name, member_open_id in await self._fetch_chat_mention_members(chat_id):
+            if member_open_id != open_id:
+                continue
+            normalized = str(name or "").strip()
+            if not normalized:
+                return None
+            self._sender_name_cache[open_id] = (
+                normalized,
+                time.time() + _FEISHU_SENDER_NAME_TTL_SECONDS,
+            )
+            return normalized
+        return None
 
     def _get_cached_sender_name(self, sender_id: Optional[str]) -> Optional[str]:
         """Return a cached sender name only while its TTL is still valid."""

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -1723,6 +1723,38 @@ class TestSenderNameResolution(unittest.TestCase):
         self.assertEqual(result, "Bob")
         self.assertIn("ou_bob", adapter._sender_name_cache)
 
+    @patch.dict(os.environ, {}, clear=True)
+    def test_group_sender_falls_back_to_chat_members_when_contact_api_denies_name(self):
+        from gateway.config import PlatformConfig
+        from plugins.platforms.feishu.adapter import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        adapter._resolve_sender_name_from_api = AsyncMock(return_value=None)
+        adapter._fetch_chat_mention_members = AsyncMock(
+            return_value=[
+                ("Bryan Min", "ou_bryan"),
+                ("Ork Sokheng", "ou_sokheng"),
+            ]
+        )
+        sender_id = SimpleNamespace(
+            open_id="ou_sokheng",
+            user_id=None,
+            union_id="on_sokheng",
+        )
+
+        result = asyncio.run(
+            adapter._resolve_sender_profile(sender_id, chat_id="oc_jamii2")
+        )
+
+        self.assertEqual(result["user_id"], "ou_sokheng")
+        self.assertEqual(result["user_name"], "Ork Sokheng")
+        self.assertEqual(result["user_id_alt"], "on_sokheng")
+        adapter._fetch_chat_mention_members.assert_awaited_once_with("oc_jamii2")
+        self.assertEqual(
+            adapter._sender_name_cache["ou_sokheng"][0],
+            "Ork Sokheng",
+        )
+
 
 @unittest.skipUnless(_HAS_LARK_OAPI, "lark-oapi not installed")
 class TestBotNameResolution(unittest.TestCase):
@@ -2465,5 +2497,3 @@ class TestChatLockEviction(unittest.TestCase):
 
         adapter = self._make_adapter()
         self.assertIsInstance(adapter._chat_locks, _collections.OrderedDict)
-
-


### PR DESCRIPTION
## Summary

- pass group chat context into Feishu sender-profile resolution
- when Contact API name lookup is unavailable, resolve the sender from the chat-members directory by exact app-scoped `open_id`
- cache the authoritative group-member display name
- keep the fallback group and forum-only

## Why

External or cross-tenant group participants may be visible in a chat while the Contact API returns no user authority. Without a fallback, their messages can be attributed to the wrong or missing display identity.

## Tests

- `scripts/run_tests.sh tests/gateway/test_feishu.py`
- 77 passed
- `ruff check plugins/platforms/feishu/adapter.py tests/gateway/test_feishu.py`