### PR TITLE
feat(feishu): allow profiles to disable reaction routing

### DIFF
--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -2834,7 +2834,8 @@ class FeishuAdapter(BasePlatformAdapter):
         # clicking Typing on a bot message) is still routed through.
         loop = self._loop
         if (
-            operator_type in {"bot", "app"}
+            not self.config.extra.get("route_user_reactions", True)
+            or operator_type in {"bot", "app"}
             or not message_id
             or loop is None
             or bool(getattr(loop, "is_closed", lambda: False)())

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -500,6 +500,30 @@ class TestAdapterBehavior(unittest.TestCase):
             adapter._on_reaction_event("im.message.reaction.created_v1", data)
         run_threadsafe.assert_called_once()
 
+    @patch.dict(os.environ, {}, clear=True)
+    def test_user_reaction_is_not_routed_when_profile_disables_it(self):
+        from gateway.config import PlatformConfig
+        from plugins.platforms.feishu.adapter import FeishuAdapter
+
+        adapter = FeishuAdapter(
+            PlatformConfig(extra={"route_user_reactions": False})
+        )
+        adapter._loop = SimpleNamespace(is_closed=lambda: False)
+        event = SimpleNamespace(
+            message_id="om_msg",
+            operator_type="user",
+            reaction_type=SimpleNamespace(emoji_type="LOL"),
+        )
+
+        with patch(
+            "plugins.platforms.feishu.adapter.asyncio.run_coroutine_threadsafe"
+        ) as run_threadsafe:
+            adapter._on_reaction_event(
+                "im.message.reaction.created_v1",
+                SimpleNamespace(event=event),
+            )
+        run_threadsafe.assert_not_called()
+
     def _build_reaction_adapter(self, *, msg_sender_id: str):
         """Build a FeishuAdapter wired up to return a single GET-message result."""
         from gateway.config import PlatformConfig
@@ -2465,5 +2489,3 @@ class TestChatLockEviction(unittest.TestCase):
 
         adapter = self._make_adapter()
         self.assertIsInstance(adapter._chat_locks, _collections.OrderedDict)
-
-


### PR DESCRIPTION
## Summary

- add profile-local `platforms.feishu.extra.route_user_reactions`
- preserve current behavior by default
- when disabled, user reaction events do not become synthetic agent turns

## Why

Some Feishu profiles use reactions as lightweight acknowledgements and must not trigger delayed model responses.

## Tests

- `scripts/run_tests.sh tests/gateway/test_feishu.py`
- 77 passed
- `ruff check plugins/platforms/feishu/adapter.py tests/gateway/test_feishu.py`