### PR TITLE
fix(vision): allow configured timeout fast-fail

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -11401,6 +11401,23 @@ async def _async_call_llm_impl(
         except Exception as transient_err:
             if not _is_transient_transport_error(transient_err):
                 raise
+            # Vision calls often fan out across several rendered PDF pages.
+            # Retrying a full-budget timeout on the same provider multiplies
+            # latency without improving the result; allow profile config to
+            # skip that duplicate attempt and go straight to fallback.
+            if task == "vision" and _is_timeout_error(transient_err):
+                try:
+                    from hermes_cli.config import cfg_get, load_config
+                    _vision_cfg = cfg_get(load_config(), "auxiliary", "vision", default={})
+                    if isinstance(_vision_cfg, dict) and _vision_cfg.get("retry_on_timeout") is False:
+                        logger.info(
+                            "Auxiliary vision: timeout on configured fast-fail path; "
+                            "skipping same-provider retry: %s",
+                            transient_err,
+                        )
+                        raise
+                except ImportError:
+                    pass
             # See call_llm(): compression is on the critical preflight path,
             # so skip the same-provider retry on a full-budget timeout and
             # fall straight through to fallback (issue #54465).

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -2118,6 +2118,57 @@ class TestTransientTransportRetry:
         assert primary.chat.completions.create.call_count == 1
         assert fb_client.chat.completions.create.call_count == 1
 
+    @pytest.mark.asyncio
+    async def test_vision_can_skip_same_provider_retry_on_timeout(self):
+        """Profile config can fast-fail a timed-out vision request to fallback."""
+        class _Timeout(Exception):
+            pass
+        _Timeout.__name__ = "APITimeoutError"
+
+        primary = MagicMock()
+        primary.base_url = "https://openrouter.ai/api/v1"
+        primary.chat.completions.create = AsyncMock(
+            side_effect=_Timeout("Request timed out.")
+        )
+        fallback = MagicMock()
+        async_fallback = MagicMock()
+        expected = {"fallback": True}
+        config = {
+            "auxiliary": {
+                "vision": {"retry_on_timeout": False},
+            }
+        }
+
+        p1, p2, p3 = self._patches(primary)
+        with (
+            p1, p2, p3,
+            patch("hermes_cli.config.load_config", return_value=config),
+            patch("hermes_cli.config.load_config_readonly", return_value=config),
+            patch(
+                "agent.auxiliary_client.resolve_vision_provider_client",
+                return_value=("openrouter", primary, "some-model"),
+            ),
+            patch(
+                "agent.auxiliary_client._try_configured_fallback_chain",
+                return_value=(fallback, "fb-model", "configured-fallback"),
+            ),
+            patch(
+                "agent.auxiliary_client._to_async_client",
+                return_value=(async_fallback, "fb-model"),
+            ),
+            patch(
+                "agent.auxiliary_client._call_fallback_candidate_async",
+                new=AsyncMock(return_value=expected),
+            ),
+        ):
+            result = await async_call_llm(
+                task="vision",
+                messages=[{"role": "user", "content": "inspect image"}],
+            )
+
+        assert result == expected
+        assert primary.chat.completions.create.call_count == 1
+
     def test_timeout_forwards_failed_model_to_configured_chain(self):
         """A timeout is model-specific, so call_llm must forward the failed
         model to the configured chain (failed_model=<model>, not None). This


### PR DESCRIPTION
## Summary

- add `auxiliary.vision.retry_on_timeout` with backward-compatible default
  behavior
- when set to `false`, skip the second same-provider attempt after a vision
  timeout
- continue into the configured fallback chain without changing non-timeout
  retry behavior

## Why

Document and image-heavy workloads can spend a second full timeout budget
retrying the same provider before a healthy fallback is attempted.

## Current-main verification

- rebased onto `73f68362b` (2026-09-02)
- focused fast-fail regression: passed
- full auxiliary-client module: 188 passed; one unrelated Anthropic OAuth
  refresh test also fails on unmodified current main
- Ruff and `git diff --check`: passed
