### PR TITLE
fix(feishu): report failed attachment downloads to the agent

### DIFF
--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -3992,6 +3992,23 @@ class FeishuAdapter(BasePlatformAdapter):
         inbound_type = self._resolve_normalized_message_type(normalized, media_types)
         text = normalized.text_content
 
+        # Keep attachment-only turns observable when Feishu accepted the
+        # message metadata but the resource could not be downloaded. Without
+        # this, the agent receives only the filename from the UI and can
+        # incorrectly conclude that the file is available for reading.
+        if normalized.media_refs and not media_urls:
+            failed_names = [
+                ref.file_name.strip()
+                for ref in normalized.media_refs
+                if ref.file_name and ref.file_name.strip()
+            ]
+            label = ", ".join(failed_names) if failed_names else "Feishu attachment"
+            failure_note = (
+                f"[Attachment could not be downloaded: {label}. "
+                "The file content and local path are unavailable.]"
+            )
+            text = "\n\n".join(part for part in (failure_note, text) if part).strip()
+
         if (
             inbound_type in {MessageType.DOCUMENT, MessageType.AUDIO, MessageType.VIDEO, MessageType.PHOTO}
             and len(media_urls) == 1

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -1123,6 +1123,33 @@ class TestAdapterBehavior(unittest.TestCase):
         # down, which only works by accident (httpx's eager buffering).
         self.assertLess(events.index("content_read"), events.index("client_exit"))
 
+    def test_failed_file_attachment_is_explicitly_reported_to_agent(self):
+        """An unavailable Feishu file must not look like a readable filename."""
+        from gateway.config import PlatformConfig
+        from plugins.platforms.feishu.adapter import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        message = SimpleNamespace(
+            message_id="om_svg_1",
+            message_type="file",
+            content=json.dumps({"file_key": "file_svg_1", "file_name": "logo.svg"}),
+            mentions=[],
+        )
+
+        with patch.object(
+            adapter,
+            "_download_feishu_message_resource",
+            new=AsyncMock(return_value=("", "")),
+        ):
+            text, _message_type, media_urls, media_types, _mentions = asyncio.run(
+                adapter._extract_message_content(message)
+            )
+
+        self.assertEqual(media_urls, [])
+        self.assertEqual(media_types, [])
+        self.assertIn("logo.svg", text)
+        self.assertIn("could not be downloaded", text)
+
     def test_download_remote_document_blocks_connect_time_rebind(self):
         import httpcore
         from httpcore._backends.auto import AutoBackend
@@ -2465,5 +2492,3 @@ class TestChatLockEviction(unittest.TestCase):
 
         adapter = self._make_adapter()
         self.assertIsInstance(adapter._chat_locks, _collections.OrderedDict)
-
-


### PR DESCRIPTION
## Summary

- preserve an explicit failure note when Feishu attachment metadata is present but resource download returns no local file
- include the attachment filename when available
- prevent the agent from treating an unavailable filename as readable content

## Why

Feishu can deliver valid file metadata while the resource download fails. The previous path forwarded only the normalized filename or text, which can make the agent claim it can read or process bytes that are not available.

## Tests

- `scripts/run_tests.sh tests/gateway/test_feishu.py`
- 77 passed
- `ruff check plugins/platforms/feishu/adapter.py tests/gateway/test_feishu.py`