### PR TITLE
feat(feishu): add config-driven application launchers

### DIFF
--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -68,7 +68,7 @@ from pathlib import Path
 from types import SimpleNamespace
 from typing import Any, Dict, List, Literal, Optional, Sequence
 from urllib.error import HTTPError, URLError
-from urllib.parse import urlencode
+from urllib.parse import urlencode, urlsplit
 from urllib.request import Request, urlopen
 
 # aiohttp/websockets are independent optional deps — import outside lark_oapi
@@ -2121,6 +2121,89 @@ class FeishuAdapter(BasePlatformAdapter):
             logger.error("[Feishu] Send error: %s", exc, exc_info=True)
             return SendResult(success=False, error=str(exc))
 
+    @staticmethod
+    def _normalize_quick_launcher_text(value: Any) -> str:
+        """Normalize a short launcher command without broad intent matching."""
+        normalized = re.sub(r"\s+", "", str(value or "")).casefold()
+        if normalized.startswith("/"):
+            normalized = normalized[1:]
+        return normalized.rstrip("。.!！?？")
+
+    def _match_quick_launcher(self, text: str) -> Optional[Dict[str, Any]]:
+        """Return the exact configured quick launcher for *text*, if any."""
+        wanted = self._normalize_quick_launcher_text(text)
+        if not wanted:
+            return None
+        configured = (self.config.extra or {}).get("quick_launchers", [])
+        if not isinstance(configured, list):
+            return None
+        for candidate in configured:
+            if not isinstance(candidate, dict):
+                continue
+            url = str(candidate.get("url") or "").strip()
+            parsed = urlsplit(url)
+            if parsed.scheme != "https" or not parsed.netloc:
+                continue
+            keywords = candidate.get("keywords") or []
+            if isinstance(keywords, str):
+                keywords = [keywords]
+            aliases = [candidate.get("name"), *keywords]
+            if wanted in {
+                self._normalize_quick_launcher_text(alias)
+                for alias in aliases
+                if alias
+            }:
+                return candidate
+        return None
+
+    @staticmethod
+    def _build_quick_launcher_card(launcher: Dict[str, Any]) -> Dict[str, Any]:
+        title = str(launcher.get("title") or launcher.get("name") or "Open app").strip()
+        description = str(launcher.get("description") or "Open the configured application.").strip()
+        button_text = str(launcher.get("button_text") or "Open app").strip()
+        return {
+            "config": {"wide_screen_mode": True},
+            "header": {
+                "title": {"content": title, "tag": "plain_text"},
+                "template": str(launcher.get("template") or "blue"),
+            },
+            "elements": [
+                {"tag": "markdown", "content": description},
+                {
+                    "tag": "action",
+                    "actions": [
+                        {
+                            "tag": "button",
+                            "text": {"tag": "plain_text", "content": button_text},
+                            "type": "primary",
+                            "url": str(launcher["url"]).strip(),
+                        }
+                    ],
+                },
+            ],
+        }
+
+    async def _send_quick_launcher_card(
+        self,
+        chat_id: str,
+        launcher: Dict[str, Any],
+    ) -> SendResult:
+        if not self._client:
+            return SendResult(success=False, error="Not connected")
+        card = self._build_quick_launcher_card(launcher)
+        try:
+            response = await self._feishu_send_with_retry(
+                chat_id=chat_id,
+                msg_type="interactive",
+                payload=json.dumps(card, ensure_ascii=False),
+                reply_to=None,
+                metadata=None,
+            )
+            return self._finalize_send_result(response, "quick launcher send failed")
+        except Exception as exc:
+            logger.error("[Feishu] Quick launcher send error: %s", exc, exc_info=True)
+            return SendResult(success=False, error=str(exc))
+
     async def edit_message(
         self,
         chat_id: str,
@@ -3275,6 +3358,22 @@ class FeishuAdapter(BasePlatformAdapter):
         chat_id = getattr(event.source, "chat_id", "") or "" if event.source else ""
         chat_lock = self._get_chat_lock(chat_id)
         async with chat_lock:
+            if event.message_type in {MessageType.TEXT, MessageType.COMMAND}:
+                launcher = self._match_quick_launcher(event.text)
+                if launcher is not None:
+                    result = await self._send_quick_launcher_card(chat_id, launcher)
+                    if result.success:
+                        logger.info(
+                            "[Feishu] Sent quick launcher %r in chat %s",
+                            launcher.get("name") or launcher.get("title") or "<unnamed>",
+                            chat_id,
+                        )
+                        return
+                    logger.warning(
+                        "[Feishu] Quick launcher failed in chat %s; falling back to agent: %s",
+                        chat_id,
+                        result.error,
+                    )
             await self.handle_message(event)
 
     # =========================================================================

--- a/tests/gateway/test_feishu_quick_launchers.py
+++ b/tests/gateway/test_feishu_quick_launchers.py
@@ -1,0 +1,109 @@
+"""Tests for config-driven Feishu application quick launchers."""
+
+import json
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from gateway.config import Platform, PlatformConfig
+from gateway.platforms.base import MessageEvent, MessageType
+from gateway.session import SessionSource
+from plugins.platforms.feishu.adapter import FeishuAdapter
+
+
+def _launcher_config() -> PlatformConfig:
+    return PlatformConfig(
+        enabled=True,
+        extra={
+            "quick_launchers": [
+                {
+                    "name": "open reports",
+                    "title": "Reports",
+                    "description": "Open the reporting application.",
+                    "button_text": "Open reports",
+                    "template": "green",
+                    "url": "https://example.com/reports",
+                    "keywords": ["reports"],
+                }
+            ]
+        },
+    )
+
+
+def _event(text: str) -> MessageEvent:
+    return MessageEvent(
+        text=text,
+        message_type=MessageType.TEXT,
+        source=SessionSource(
+            platform=Platform.FEISHU,
+            chat_id="oc_test",
+            chat_name="Test chat",
+            chat_type="dm",
+            user_id="ou_user",
+            user_name="User",
+        ),
+        message_id="om_trigger",
+    )
+
+
+def test_quick_launcher_matches_only_exact_configured_commands():
+    adapter = FeishuAdapter(_launcher_config())
+
+    assert adapter._match_quick_launcher("open reports") is not None
+    assert adapter._match_quick_launcher(" /reports. ") is not None
+    assert adapter._match_quick_launcher("please analyze the reports") is None
+
+
+def test_quick_launcher_rejects_non_https_url():
+    config = _launcher_config()
+    config.extra["quick_launchers"][0]["url"] = "javascript:alert(1)"
+    adapter = FeishuAdapter(config)
+
+    assert adapter._match_quick_launcher("reports") is None
+
+
+@pytest.mark.asyncio
+async def test_quick_launcher_sends_native_url_card():
+    adapter = FeishuAdapter(_launcher_config())
+    adapter._client = MagicMock()
+    response = SimpleNamespace(
+        success=lambda: True,
+        data=SimpleNamespace(message_id="om_launcher"),
+    )
+
+    with patch.object(
+        adapter,
+        "_feishu_send_with_retry",
+        new_callable=AsyncMock,
+        return_value=response,
+    ) as send:
+        result = await adapter._send_quick_launcher_card(
+            "oc_test", adapter._match_quick_launcher("reports")
+        )
+
+    assert result.success is True
+    kwargs = send.call_args.kwargs
+    assert kwargs["msg_type"] == "interactive"
+    card = json.loads(kwargs["payload"])
+    button = card["elements"][1]["actions"][0]
+    assert button["url"] == "https://example.com/reports"
+    assert button["text"]["content"] == "Open reports"
+
+
+@pytest.mark.asyncio
+async def test_matching_launcher_bypasses_agent_but_other_text_does_not():
+    adapter = FeishuAdapter(_launcher_config())
+    adapter.handle_message = AsyncMock()
+    adapter._send_quick_launcher_card = AsyncMock(
+        return_value=SimpleNamespace(success=True, error=None)
+    )
+
+    await adapter._handle_message_with_guards(_event("reports"))
+    adapter._send_quick_launcher_card.assert_awaited_once()
+    adapter.handle_message.assert_not_awaited()
+
+    adapter._send_quick_launcher_card.reset_mock()
+    await adapter._handle_message_with_guards(_event("analyze expenses"))
+    adapter._send_quick_launcher_card.assert_not_awaited()
+    adapter.handle_message.assert_awaited_once()


### PR DESCRIPTION
## Summary

- add exact-match, profile-local quick launcher commands under `platforms.feishu.extra.quick_launchers`
- validate launcher URLs as HTTPS
- send a native interactive Feishu card before entering the model pipeline
- fall back to normal agent handling if card delivery fails

## Why

Profiles sometimes need a deterministic chat entry point for an external web application without turning ordinary natural-language mentions into commands.

## Tests

- `scripts/run_tests.sh tests/gateway/test_feishu_quick_launchers.py tests/gateway/test_feishu.py`
- 80 passed
- `ruff check plugins/platforms/feishu/adapter.py tests/gateway/test_feishu_quick_launchers.py`