### PR TITLE
feat(skills): route learned skills by owner profile

### DIFF
--- a/hermes_cli/write_approval_commands.py
+++ b/hermes_cli/write_approval_commands.py
@@ -148,7 +148,7 @@ def _apply_one(subsystem: str, rec, memory_store):
             result = apply_memory_pending(payload, memory_store)
             return bool(result.get("success")), result.get("error", "")
         else:
-            from tools.skill_manager_tool import apply_skill_pending
+            from tools.skill_owner_routing_tool import apply_skill_pending
             result = json.loads(apply_skill_pending(payload))
             return bool(result.get("success")), result.get("error", "")
     except Exception as e:

--- a/tests/tools/test_skill_owner_routing.py
+++ b/tests/tools/test_skill_owner_routing.py
@@ -1,0 +1,369 @@
+"""Focused tests for profile-owned skill creation routing."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from hermes_constants import get_hermes_home, reset_hermes_home_override, set_hermes_home_override
+from tools.skill_owner_routing import (
+    active_profile_from_home,
+    create_skill_with_owner_routing,
+    declared_skill_owner,
+    owner_routing_policy,
+    reset_owner_routing_scope,
+)
+
+
+ROUTED_SKILL = """\
+---
+name: routed-skill
+description: A routed test skill.
+metadata:
+  hermes:
+    owner_profile: trt
+---
+
+# Routed Skill
+
+Verify ownership routing.
+"""
+
+PLAIN_SKILL = """\
+---
+name: routed-skill
+description: A plain test skill.
+---
+
+# Routed Skill
+"""
+
+
+def _enabled_policy(**overrides):
+    value = {
+        "enabled": True,
+        "require_owner_metadata": True,
+        "route_from_default": True,
+    }
+    value.update(overrides)
+    return value
+
+
+def _creator(observed, *, success=True):
+    def create(name, content, category=None):
+        observed["home"] = get_hermes_home().resolve(strict=False)
+        observed["args"] = (name, content, category)
+        return {"success": success, "message": "created" if success else "failed"}
+
+    return create
+
+
+def test_policy_uses_canonical_default_root_for_custom_profile_home(tmp_path, monkeypatch):
+    root = tmp_path / "fleet-data"
+    active = root / "profiles" / "growth"
+    active.mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(active))
+    observed = {}
+
+    def fake_load_config():
+        observed["home"] = get_hermes_home().resolve(strict=False)
+        return {
+            "skills": {
+                "owner_routing": {
+                    "enabled": True,
+                    "require_owner_metadata": False,
+                    "route_from_default": False,
+                }
+            }
+        }
+
+    with patch("hermes_cli.config.load_config", side_effect=fake_load_config):
+        policy = owner_routing_policy()
+
+    assert observed["home"] == root.resolve(strict=False)
+    assert policy == {
+        "enabled": True,
+        "require_owner_metadata": False,
+        "route_from_default": False,
+    }
+
+
+def test_policy_failure_disables_cross_profile_routing(monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", "/definitely/not/used")
+    with patch("hermes_cli.config.load_config", side_effect=RuntimeError("boom")):
+        assert owner_routing_policy()["enabled"] is False
+
+
+def test_declared_owner_reads_nested_hermes_metadata():
+    assert declared_skill_owner(ROUTED_SKILL) == "trt"
+    assert declared_skill_owner(PLAIN_SKILL) is None
+
+
+def test_active_profile_comes_from_live_context_home_not_sticky_file(tmp_path, monkeypatch):
+    root = tmp_path / "fleet"
+    profile = root / "profiles" / "growth"
+    profile.mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(root))
+
+    token = set_hermes_home_override(profile)
+    try:
+        assert active_profile_from_home() == "growth"
+    finally:
+        reset_hermes_home_override(token)
+
+
+def test_default_routes_create_and_holds_owner_scope_for_post_write_hooks(tmp_path, monkeypatch):
+    root = tmp_path / "fleet"
+    target = root / "profiles" / "trt"
+    target.mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(root))
+    observed = {}
+
+    with patch(
+        "tools.skill_owner_routing.owner_routing_policy",
+        return_value=_enabled_policy(),
+    ):
+        result, token = create_skill_with_owner_routing(
+            name="routed-skill",
+            content=ROUTED_SKILL,
+            category=None,
+            create_fn=_creator(observed),
+        )
+
+    assert result["success"] is True
+    assert result["owner_profile"] == "trt"
+    assert result["routed_from_profile"] == "default"
+    assert "hand those mutations" in result["hint"]
+    assert observed["home"] == target.resolve(strict=False)
+    assert token is not None
+    assert get_hermes_home().resolve(strict=False) == target.resolve(strict=False)
+
+    reset_owner_routing_scope(token)
+    assert get_hermes_home().resolve(strict=False) == root.resolve(strict=False)
+
+
+def test_failed_routed_create_restores_default_scope(tmp_path, monkeypatch):
+    root = tmp_path / "fleet"
+    (root / "profiles" / "trt").mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(root))
+    observed = {}
+
+    with patch(
+        "tools.skill_owner_routing.owner_routing_policy",
+        return_value=_enabled_policy(),
+    ):
+        result, token = create_skill_with_owner_routing(
+            name="routed-skill",
+            content=ROUTED_SKILL,
+            category=None,
+            create_fn=_creator(observed, success=False),
+        )
+
+    assert result["success"] is False
+    assert token is None
+    assert get_hermes_home().resolve(strict=False) == root.resolve(strict=False)
+
+
+def test_named_profile_cannot_write_sideways(tmp_path, monkeypatch):
+    root = tmp_path / "fleet"
+    active = root / "profiles" / "growth"
+    target = root / "profiles" / "trt"
+    active.mkdir(parents=True)
+    target.mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(active))
+    observed = {}
+
+    with patch(
+        "tools.skill_owner_routing.owner_routing_policy",
+        return_value=_enabled_policy(),
+    ):
+        result, token = create_skill_with_owner_routing(
+            name="routed-skill",
+            content=ROUTED_SKILL,
+            category=None,
+            create_fn=_creator(observed),
+        )
+
+    assert result["success"] is False
+    assert result["owner_profile"] == "trt"
+    assert result["active_profile"] == "growth"
+    assert "may not write skills sideways" in result["error"]
+    assert token is None
+    assert "home" not in observed
+
+
+def test_owner_matching_named_profile_creates_locally(tmp_path, monkeypatch):
+    root = tmp_path / "fleet"
+    active = root / "profiles" / "trt"
+    active.mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(active))
+    observed = {}
+
+    with patch(
+        "tools.skill_owner_routing.owner_routing_policy",
+        return_value=_enabled_policy(),
+    ):
+        result, token = create_skill_with_owner_routing(
+            name="routed-skill",
+            content=ROUTED_SKILL,
+            category="ops",
+            create_fn=_creator(observed),
+        )
+
+    assert result["success"] is True
+    assert result["owner_profile"] == "trt"
+    assert "routed_from_profile" not in result
+    assert token is None
+    assert observed["home"] == active.resolve(strict=False)
+    assert observed["args"][2] == "ops"
+
+
+def test_default_owned_skill_stays_on_default(tmp_path, monkeypatch):
+    root = tmp_path / "fleet"
+    root.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(root))
+    content = ROUTED_SKILL.replace("owner_profile: trt", "owner_profile: default")
+    observed = {}
+
+    with patch(
+        "tools.skill_owner_routing.owner_routing_policy",
+        return_value=_enabled_policy(),
+    ):
+        result, token = create_skill_with_owner_routing(
+            name="routed-skill",
+            content=content,
+            category=None,
+            create_fn=_creator(observed),
+        )
+
+    assert result["success"] is True
+    assert result["owner_profile"] == "default"
+    assert token is None
+    assert observed["home"] == root.resolve(strict=False)
+
+
+def test_unknown_owner_is_rejected(tmp_path, monkeypatch):
+    root = tmp_path / "fleet"
+    root.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(root))
+    content = ROUTED_SKILL.replace("owner_profile: trt", "owner_profile: missing-profile")
+
+    with patch(
+        "tools.skill_owner_routing.owner_routing_policy",
+        return_value=_enabled_policy(),
+    ):
+        result, token = create_skill_with_owner_routing(
+            name="routed-skill",
+            content=content,
+            category=None,
+            create_fn=lambda *args, **kwargs: pytest.fail("create must not run"),
+        )
+
+    assert result["success"] is False
+    assert "not registered" in result["error"]
+    assert token is None
+
+
+@pytest.mark.parametrize("bad_owner", ["../../tmp", "root", "bad/profile"])
+def test_invalid_owner_is_rejected_before_profile_lookup(tmp_path, monkeypatch, bad_owner):
+    root = tmp_path / "fleet"
+    root.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(root))
+    content = ROUTED_SKILL.replace("owner_profile: trt", f"owner_profile: {bad_owner}")
+
+    with patch(
+        "tools.skill_owner_routing.owner_routing_policy",
+        return_value=_enabled_policy(),
+    ), patch(
+        "hermes_cli.profiles.profile_exists",
+        side_effect=AssertionError("invalid owner reached profile lookup"),
+    ):
+        result, token = create_skill_with_owner_routing(
+            name="routed-skill",
+            content=content,
+            category=None,
+            create_fn=lambda *args, **kwargs: pytest.fail("create must not run"),
+        )
+
+    assert result["success"] is False
+    assert "Could not resolve skill owner profile" in result["error"]
+    assert token is None
+
+
+def test_default_can_refuse_cross_profile_routing(tmp_path, monkeypatch):
+    root = tmp_path / "fleet"
+    (root / "profiles" / "trt").mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(root))
+
+    with patch(
+        "tools.skill_owner_routing.owner_routing_policy",
+        return_value=_enabled_policy(route_from_default=False),
+    ):
+        result, token = create_skill_with_owner_routing(
+            name="routed-skill",
+            content=ROUTED_SKILL,
+            category=None,
+            create_fn=lambda *args, **kwargs: pytest.fail("create must not run"),
+        )
+
+    assert result["success"] is False
+    assert "configured to refuse cross-profile creation" in result["error"]
+    assert token is None
+
+
+def test_required_owner_metadata_and_optional_compatibility(tmp_path, monkeypatch):
+    root = tmp_path / "fleet"
+    root.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(root))
+
+    with patch(
+        "tools.skill_owner_routing.owner_routing_policy",
+        return_value=_enabled_policy(),
+    ):
+        result, token = create_skill_with_owner_routing(
+            name="routed-skill",
+            content=PLAIN_SKILL,
+            category=None,
+            create_fn=lambda *args, **kwargs: pytest.fail("create must not run"),
+        )
+    assert result["success"] is False
+    assert "owner_profile" in result["error"]
+    assert token is None
+
+    observed = {}
+    with patch(
+        "tools.skill_owner_routing.owner_routing_policy",
+        return_value=_enabled_policy(require_owner_metadata=False),
+    ):
+        result, token = create_skill_with_owner_routing(
+            name="routed-skill",
+            content=PLAIN_SKILL,
+            category=None,
+            create_fn=_creator(observed),
+        )
+    assert result["success"] is True
+    assert token is None
+    assert observed["home"] == root.resolve(strict=False)
+
+
+def test_disabled_policy_preserves_existing_create_behavior(tmp_path, monkeypatch):
+    root = tmp_path / "fleet"
+    root.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(root))
+    observed = {}
+
+    with patch(
+        "tools.skill_owner_routing.owner_routing_policy",
+        return_value={"enabled": False},
+    ):
+        result, token = create_skill_with_owner_routing(
+            name="routed-skill",
+            content=PLAIN_SKILL,
+            category=None,
+            create_fn=_creator(observed),
+        )
+
+    assert result["success"] is True
+    assert token is None
+    assert observed["home"] == root.resolve(strict=False)

--- a/tests/tools/test_skill_owner_routing_tool.py
+++ b/tests/tools/test_skill_owner_routing_tool.py
@@ -1,0 +1,225 @@
+"""Integration tests for the owner-aware skill_manage registration adapter."""
+
+from __future__ import annotations
+
+import json
+
+from hermes_constants import get_hermes_home
+from tools import skill_manager_tool as manager
+from tools import skill_owner_routing_tool as routed
+from tools.registry import registry
+
+
+SKILL = """\
+---
+name: routed-skill
+description: Use when routing a learned skill.
+metadata:
+  hermes:
+    owner_profile: trt
+---
+
+# Routed Skill
+
+Do the routed thing.
+"""
+
+
+def _enabled_policy():
+    return {
+        "enabled": True,
+        "require_owner_metadata": True,
+        "route_from_default": True,
+    }
+
+
+def test_registered_skill_manage_exposes_owner_contract():
+    entry = registry.get_entry("skill_manage")
+    assert entry is not None
+    assert entry.handler is not None
+    assert "metadata.hermes.owner_profile" in entry.schema["description"]
+    assert "may not write sideways" in entry.schema["description"]
+
+
+def test_gate_runs_in_caller_scope_and_full_create_runs_in_owner_scope(
+    tmp_path, monkeypatch
+):
+    root = tmp_path / "fleet"
+    owner = root / "profiles" / "trt"
+    owner.mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(root))
+
+    observed = {}
+
+    def fake_gate(*args, **kwargs):
+        observed["gate_home"] = get_hermes_home().resolve(strict=False)
+        return None
+
+    def fake_base(**kwargs):
+        observed["base_home"] = get_hermes_home().resolve(strict=False)
+        observed["base_bypass"] = manager._skill_gate_bypass.get()
+        observed["base_kwargs"] = kwargs
+        return json.dumps({"success": True, "message": "created", "path": "routed-skill"})
+
+    monkeypatch.setattr(routed, "owner_routing_policy", _enabled_policy)
+    monkeypatch.setattr(manager, "_apply_skill_write_gate", fake_gate)
+    monkeypatch.setattr(manager, "skill_manage", fake_base)
+
+    result = json.loads(
+        routed.skill_manage(
+            action="create",
+            name="routed-skill",
+            content=SKILL,
+            task_id="task-1",
+            session_id="session-1",
+        )
+    )
+
+    assert observed["gate_home"] == root.resolve(strict=False)
+    assert observed["base_home"] == owner.resolve(strict=False)
+    assert observed["base_bypass"] is True
+    assert observed["base_kwargs"]["task_id"] == "task-1"
+    assert observed["base_kwargs"]["session_id"] == "session-1"
+    assert result["success"] is True
+    assert result["owner_profile"] == "trt"
+    assert result["routed_from_profile"] == "default"
+    assert get_hermes_home().resolve(strict=False) == root.resolve(strict=False)
+
+
+def test_staged_create_never_switches_to_owner_or_invokes_base(tmp_path, monkeypatch):
+    root = tmp_path / "fleet"
+    (root / "profiles" / "trt").mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(root))
+    staged = json.dumps({"success": True, "staged": True, "pending_id": "abc123"})
+    observed = {}
+
+    def fake_gate(*args, **kwargs):
+        observed["gate_home"] = get_hermes_home().resolve(strict=False)
+        return staged
+
+    def fail_base(**kwargs):
+        raise AssertionError("staged create must not invoke the base manager")
+
+    monkeypatch.setattr(routed, "owner_routing_policy", _enabled_policy)
+    monkeypatch.setattr(manager, "_apply_skill_write_gate", fake_gate)
+    monkeypatch.setattr(manager, "skill_manage", fail_base)
+
+    assert routed.skill_manage(action="create", name="routed-skill", content=SKILL) == staged
+    assert observed["gate_home"] == root.resolve(strict=False)
+    assert get_hermes_home().resolve(strict=False) == root.resolve(strict=False)
+
+
+def test_approved_pending_create_uses_same_owner_route(tmp_path, monkeypatch):
+    root = tmp_path / "fleet"
+    owner = root / "profiles" / "trt"
+    owner.mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(root))
+    observed = {}
+
+    def fake_gate(*args, **kwargs):
+        observed["gate_bypass"] = manager._skill_gate_bypass.get()
+        observed["gate_home"] = get_hermes_home().resolve(strict=False)
+        return None
+
+    def fake_base(**kwargs):
+        observed["base_home"] = get_hermes_home().resolve(strict=False)
+        observed["base_bypass"] = manager._skill_gate_bypass.get()
+        return json.dumps({"success": True, "message": "created", "path": "routed-skill"})
+
+    monkeypatch.setattr(routed, "owner_routing_policy", _enabled_policy)
+    monkeypatch.setattr(manager, "_apply_skill_write_gate", fake_gate)
+    monkeypatch.setattr(manager, "skill_manage", fake_base)
+
+    result = json.loads(
+        routed.apply_skill_pending(
+            {
+                "action": "create",
+                "name": "routed-skill",
+                "content": SKILL,
+            }
+        )
+    )
+
+    assert observed["gate_bypass"] is True
+    assert observed["gate_home"] == root.resolve(strict=False)
+    assert observed["base_bypass"] is True
+    assert observed["base_home"] == owner.resolve(strict=False)
+    assert result["owner_profile"] == "trt"
+    assert get_hermes_home().resolve(strict=False) == root.resolve(strict=False)
+
+
+def test_missing_content_preserves_base_manager_error_path(tmp_path, monkeypatch):
+    root = tmp_path / "fleet"
+    root.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(root))
+    observed = {}
+
+    def fake_gate(*args, **kwargs):
+        return None
+
+    def fake_base(**kwargs):
+        observed["bypass"] = manager._skill_gate_bypass.get()
+        return json.dumps({"success": False, "error": "content is required for 'create'."})
+
+    monkeypatch.setattr(routed, "owner_routing_policy", _enabled_policy)
+    monkeypatch.setattr(manager, "_apply_skill_write_gate", fake_gate)
+    monkeypatch.setattr(manager, "skill_manage", fake_base)
+
+    result = json.loads(routed.skill_manage(action="create", name="routed-skill"))
+    assert result["error"] == "content is required for 'create'."
+    assert observed["bypass"] is True
+
+
+def test_disabled_policy_delegates_without_pre_gating(tmp_path, monkeypatch):
+    root = tmp_path / "fleet"
+    root.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(root))
+    observed = {"gate": 0, "base": 0}
+
+    def fake_gate(*args, **kwargs):
+        observed["gate"] += 1
+        return None
+
+    def fake_base(**kwargs):
+        observed["base"] += 1
+        observed["home"] = get_hermes_home().resolve(strict=False)
+        return json.dumps({"success": True})
+
+    monkeypatch.setattr(routed, "owner_routing_policy", lambda: {"enabled": False})
+    monkeypatch.setattr(manager, "_apply_skill_write_gate", fake_gate)
+    monkeypatch.setattr(manager, "skill_manage", fake_base)
+
+    assert json.loads(routed.skill_manage(action="create", name="plain", content=SKILL))["success"] is True
+    # The adapter does not run its own gate when routing is disabled; the real
+    # base manager owns that path exactly as before.
+    assert observed["gate"] == 0
+    assert observed["base"] == 1
+    assert observed["home"] == root.resolve(strict=False)
+
+
+def test_non_create_actions_are_identical_pass_through(tmp_path, monkeypatch):
+    root = tmp_path / "fleet"
+    root.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(root))
+    observed = {}
+
+    def fake_base(**kwargs):
+        observed.update(kwargs)
+        return json.dumps({"success": True, "message": "patched"})
+
+    monkeypatch.setattr(manager, "skill_manage", fake_base)
+    result = json.loads(
+        routed.skill_manage(
+            action="patch",
+            name="existing",
+            old_string="old",
+            new_string="new",
+            replace_all=True,
+        )
+    )
+
+    assert result["message"] == "patched"
+    assert observed["action"] == "patch"
+    assert observed["old_string"] == "old"
+    assert observed["new_string"] == "new"
+    assert observed["replace_all"] is True

--- a/tools/skill_owner_routing.py
+++ b/tools/skill_owner_routing.py
@@ -1,0 +1,264 @@
+"""Profile ownership routing for agent-created skills.
+
+This module keeps cross-profile admission policy out of ``skill_manager_tool``
+so the manager stays below Hermes' 2k production-file boundary. The policy is
+owned by the fleet Default profile and is opt-in. When enabled, a new skill can
+declare ``metadata.hermes.owner_profile``; Default may route the create into
+that registered profile, while named profiles may only create for themselves.
+"""
+
+from __future__ import annotations
+
+import logging
+from contextvars import Token
+from pathlib import Path
+from typing import Any, Callable
+
+from agent.skill_utils import parse_frontmatter
+from hermes_constants import (
+    get_default_hermes_root,
+    get_hermes_home,
+    reset_hermes_home_override,
+    set_hermes_home_override,
+)
+from hermes_cli.config import cfg_get
+from utils import is_truthy_value
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_POLICY: dict[str, bool] = {
+    "enabled": False,
+    "require_owner_metadata": True,
+    "route_from_default": True,
+}
+
+
+def owner_routing_policy() -> dict[str, bool]:
+    """Read owner-routing policy from the fleet Default profile.
+
+    ``get_default_hermes_root()`` is the canonical root resolver for standard,
+    custom-root, Docker, and profile-scoped deployments. Reading policy under
+    a context-local override prevents a specialist's local config from
+    weakening the fleet-level cross-profile admission rule.
+    """
+    try:
+        from hermes_cli.config import load_config
+
+        token = set_hermes_home_override(get_default_hermes_root())
+        try:
+            cfg = load_config() or {}
+        finally:
+            reset_hermes_home_override(token)
+
+        raw = cfg_get(cfg, "skills", "owner_routing", default={})
+        if isinstance(raw, bool):
+            return {**_DEFAULT_POLICY, "enabled": raw}
+        if not isinstance(raw, dict):
+            return dict(_DEFAULT_POLICY)
+        return {
+            "enabled": is_truthy_value(raw.get("enabled"), default=False),
+            "require_owner_metadata": is_truthy_value(
+                raw.get("require_owner_metadata"), default=True
+            ),
+            "route_from_default": is_truthy_value(
+                raw.get("route_from_default"), default=True
+            ),
+        }
+    except Exception:
+        # Cross-profile authority must fail closed. An unreadable or malformed
+        # Default config means routing is disabled, never delegated to the
+        # specialist's own config.
+        logger.debug("Could not resolve skill owner-routing policy", exc_info=True)
+        return dict(_DEFAULT_POLICY)
+
+
+def declared_skill_owner(content: str) -> str | None:
+    """Return ``metadata.hermes.owner_profile`` from SKILL.md frontmatter."""
+    try:
+        frontmatter, _body = parse_frontmatter(content)
+    except Exception:
+        return None
+    metadata = frontmatter.get("metadata")
+    if not isinstance(metadata, dict):
+        return None
+    hermes_meta = metadata.get("hermes")
+    if not isinstance(hermes_meta, dict):
+        return None
+    raw = hermes_meta.get("owner_profile")
+    if raw is None:
+        return None
+    owner = str(raw).strip()
+    return owner or None
+
+
+def _resolved(path: Path) -> Path:
+    return path.expanduser().resolve(strict=False)
+
+
+def active_profile_from_home() -> str:
+    """Derive the active profile from the live context-scoped HERMES_HOME.
+
+    This intentionally does not consult the sticky ``active_profile`` file.
+    Long-lived Dashboard/TUI/Desktop processes bind a profile per request via
+    ``set_hermes_home_override``; the live home is therefore the authority for
+    which profile is performing this mutation.
+    """
+    from hermes_cli.profiles import normalize_profile_name, validate_profile_name
+
+    current = _resolved(get_hermes_home())
+    root = _resolved(get_default_hermes_root())
+    if current == root:
+        return "default"
+
+    profiles_root = root / "profiles"
+    try:
+        relative = current.relative_to(profiles_root)
+    except ValueError as exc:
+        raise ValueError(
+            f"active HERMES_HOME {current} is outside the fleet profile root {profiles_root}"
+        ) from exc
+    if len(relative.parts) != 1:
+        raise ValueError(
+            f"active HERMES_HOME {current} is not a direct named-profile home"
+        )
+
+    active = normalize_profile_name(relative.parts[0])
+    validate_profile_name(active)
+    return active
+
+
+def _validated_owner(raw_owner: str) -> str:
+    from hermes_cli.profiles import normalize_profile_name, validate_profile_name
+
+    owner = normalize_profile_name(raw_owner)
+    # Validation happens before any profile filesystem lookup. It rejects path
+    # separators, traversal-like values, and reserved identifiers while keeping
+    # the special ``default`` root profile valid.
+    validate_profile_name(owner)
+    return owner
+
+
+def create_skill_with_owner_routing(
+    *,
+    name: str,
+    content: str,
+    category: str | None,
+    create_fn: Callable[[str, str, str | None], dict[str, Any]],
+    policy: dict[str, bool] | None = None,
+) -> tuple[dict[str, Any], Token | None]:
+    """Create a skill under the declared owner and return a held scope token.
+
+    ``create_fn`` owns the actual skill-management transaction. For a successful
+    cross-profile route the returned token deliberately remains active until the
+    adapter has finished that transaction, so the write, audit ledger, prompt
+    cache, usage/provenance telemetry, and sync hook all observe the same owner
+    profile. Failed and local creates return ``None`` and leave the caller scope
+    unchanged.
+    """
+    resolved_policy = dict(policy) if policy is not None else owner_routing_policy()
+    if not resolved_policy.get("enabled"):
+        return create_fn(name, content, category), None
+
+    raw_owner = declared_skill_owner(content)
+    if not raw_owner:
+        if resolved_policy.get("require_owner_metadata", True):
+            return (
+                {
+                    "success": False,
+                    "error": (
+                        "Skill owner routing is enabled. New skills must declare "
+                        "metadata.hermes.owner_profile in SKILL.md frontmatter. "
+                        "Choose the profile that owns the capability's primary "
+                        "output, not the profile that happened to discover it."
+                    ),
+                },
+                None,
+            )
+        return create_fn(name, content, category), None
+
+    try:
+        owner = _validated_owner(raw_owner)
+        active = active_profile_from_home()
+    except Exception as exc:
+        return (
+            {
+                "success": False,
+                "error": f"Could not resolve skill owner profile {raw_owner!r}: {exc}",
+            },
+            None,
+        )
+
+    from hermes_cli.profiles import get_profile_dir, profile_exists
+
+    if owner != "default" and not profile_exists(owner):
+        return (
+            {
+                "success": False,
+                "error": f"Declared skill owner profile {owner!r} is not registered.",
+            },
+            None,
+        )
+
+    if active == owner:
+        result = create_fn(name, content, category)
+        if result.get("success"):
+            result["owner_profile"] = owner
+        return result, None
+
+    if active != "default":
+        return (
+            {
+                "success": False,
+                "error": (
+                    f"Skill {name!r} declares owner_profile={owner!r}, but the active "
+                    f"profile is {active!r}. Named specialists may not write skills "
+                    "sideways into another specialist. Hand the skill creation to "
+                    f"the {owner!r} profile."
+                ),
+                "owner_profile": owner,
+                "active_profile": active,
+            },
+            None,
+        )
+
+    if not resolved_policy.get("route_from_default", True):
+        return (
+            {
+                "success": False,
+                "error": (
+                    f"Skill {name!r} belongs to {owner!r}. Default owner-routing is "
+                    "configured to refuse cross-profile creation; delegate the create."
+                ),
+                "owner_profile": owner,
+            },
+            None,
+        )
+
+    target_home = get_profile_dir(owner)
+    token = set_hermes_home_override(target_home)
+    try:
+        result = create_fn(name, content, category)
+    except BaseException:
+        reset_hermes_home_override(token)
+        raise
+
+    if not result.get("success"):
+        reset_hermes_home_override(token)
+        return result, None
+
+    result["owner_profile"] = owner
+    result["routed_from_profile"] = "default"
+    result["message"] = (
+        f"Skill {name!r} created in owner profile {owner!r} (routed from default)."
+    )
+    result["hint"] = (
+        f"Further edits, patches, or supporting-file writes for {name!r} belong "
+        f"to profile {owner!r}; hand those mutations to that profile."
+    )
+    return result, token
+
+
+def reset_owner_routing_scope(token: Token | None) -> None:
+    """Restore the caller's HERMES_HOME after the routed transaction finishes."""
+    if token is not None:
+        reset_hermes_home_override(token)

--- a/tools/skill_owner_routing_tool.py
+++ b/tools/skill_owner_routing_tool.py
@@ -1,0 +1,270 @@
+"""Owner-aware registration adapter for ``skill_manage``.
+
+The core skill manager is intentionally kept below Hermes' 2k production-file
+limit. This module owns only the cross-profile create admission seam: it runs the
+existing write-approval gate in the caller's profile, then (when explicitly
+enabled by Default policy) executes the complete existing ``skill_manage``
+transaction under the declared owner profile. Non-create actions are delegated
+unchanged.
+
+The adapter re-registers the same ``skill_manage`` tool after
+``skill_manager_tool`` in built-in discovery order, so there is no second user-
+visible tool and no duplicate action implementation.
+"""
+
+from __future__ import annotations
+
+import copy
+import json
+from typing import Any
+
+from tools import skill_manager_tool as _manager
+from tools.registry import registry
+from tools.skill_owner_routing import (
+    create_skill_with_owner_routing,
+    owner_routing_policy,
+    reset_owner_routing_scope,
+)
+
+
+def _call_base(
+    *,
+    action: str,
+    name: str,
+    content: str | None,
+    category: str | None,
+    file_path: str | None,
+    file_content: str | None,
+    old_string: str | None,
+    new_string: str | None,
+    replace_all: bool,
+    absorbed_into: str | None,
+    task_id: str | None,
+    session_id: str | None,
+) -> str:
+    """Delegate to the existing manager without changing its semantics."""
+    return _manager.skill_manage(
+        action=action,
+        name=name,
+        content=content,
+        category=category,
+        file_path=file_path,
+        file_content=file_content,
+        old_string=old_string,
+        new_string=new_string,
+        replace_all=replace_all,
+        absorbed_into=absorbed_into,
+        task_id=task_id,
+        session_id=session_id,
+    )
+
+
+def _call_base_after_gate(
+    *,
+    name: str,
+    content: str,
+    category: str | None,
+    task_id: str | None,
+    session_id: str | None,
+) -> dict[str, Any]:
+    """Run the full base create transaction after caller-scope admission.
+
+    The adapter has already run ``_apply_skill_write_gate`` in the caller's
+    profile. Set the manager's existing replay bypass while delegating so the
+    same create is not staged a second time after HERMES_HOME switches to the
+    owner. The base function still owns validation, filesystem mutation, audit
+    ledger, cache invalidation, usage/provenance telemetry, and sync.
+    """
+    bypass = _manager._skill_gate_bypass.set(True)
+    try:
+        raw = _call_base(
+            action="create",
+            name=name,
+            content=content,
+            category=category,
+            file_path=None,
+            file_content=None,
+            old_string=None,
+            new_string=None,
+            replace_all=False,
+            absorbed_into=None,
+            task_id=task_id,
+            session_id=session_id,
+        )
+    finally:
+        _manager._skill_gate_bypass.reset(bypass)
+
+    try:
+        result = json.loads(raw)
+    except (TypeError, ValueError):
+        return {
+            "success": False,
+            "error": "skill_manage returned a malformed result during owner-routed create",
+        }
+    if not isinstance(result, dict):
+        return {
+            "success": False,
+            "error": "skill_manage returned a non-object result during owner-routed create",
+        }
+    return result
+
+
+def skill_manage(
+    action: str,
+    name: str,
+    content: str = None,
+    category: str = None,
+    file_path: str = None,
+    file_content: str = None,
+    old_string: str = None,
+    new_string: str = None,
+    replace_all: bool = False,
+    absorbed_into: str = None,
+    task_id: str = None,
+    session_id: str = None,
+) -> str:
+    """Route only newly-created skills; preserve every other manager action."""
+    if action != "create":
+        return _call_base(
+            action=action,
+            name=name,
+            content=content,
+            category=category,
+            file_path=file_path,
+            file_content=file_content,
+            old_string=old_string,
+            new_string=new_string,
+            replace_all=replace_all,
+            absorbed_into=absorbed_into,
+            task_id=task_id,
+            session_id=session_id,
+        )
+
+    policy = owner_routing_policy()
+    if not policy.get("enabled"):
+        return _call_base(
+            action=action,
+            name=name,
+            content=content,
+            category=category,
+            file_path=file_path,
+            file_content=file_content,
+            old_string=old_string,
+            new_string=new_string,
+            replace_all=replace_all,
+            absorbed_into=absorbed_into,
+            task_id=task_id,
+            session_id=session_id,
+        )
+
+    # Keep write approval in the CALLER's scope. Switching to the owner before
+    # this check could let a Default-routed write inherit a specialist's weaker
+    # approval policy. Approved staged writes already have the manager bypass
+    # set, so this becomes a no-op during replay.
+    gate_result = _manager._apply_skill_write_gate(
+        action,
+        name,
+        content=content,
+        category=category,
+        file_path=file_path,
+        file_content=file_content,
+        old_string=old_string,
+        new_string=new_string,
+        replace_all=replace_all,
+        absorbed_into=absorbed_into,
+    )
+    if gate_result is not None:
+        return gate_result
+
+    # Preserve the base manager's exact required-content error instead of
+    # turning a malformed create into an owner-metadata error.
+    if not content:
+        bypass = _manager._skill_gate_bypass.set(True)
+        try:
+            return _call_base(
+                action=action,
+                name=name,
+                content=content,
+                category=category,
+                file_path=file_path,
+                file_content=file_content,
+                old_string=old_string,
+                new_string=new_string,
+                replace_all=replace_all,
+                absorbed_into=absorbed_into,
+                task_id=task_id,
+                session_id=session_id,
+            )
+        finally:
+            _manager._skill_gate_bypass.reset(bypass)
+
+    result: dict[str, Any]
+    owner_scope = None
+    try:
+        result, owner_scope = create_skill_with_owner_routing(
+            name=name,
+            content=content,
+            category=category,
+            policy=policy,
+            create_fn=lambda create_name, create_content, create_category: _call_base_after_gate(
+                name=create_name,
+                content=create_content,
+                category=create_category,
+                task_id=task_id,
+                session_id=session_id,
+            ),
+        )
+        return json.dumps(result, ensure_ascii=False)
+    finally:
+        reset_owner_routing_scope(owner_scope)
+
+
+def apply_skill_pending(payload: dict[str, Any]) -> str:
+    """Replay an approved staged skill write through the owner-aware adapter."""
+    token = _manager._skill_gate_bypass.set(True)
+    try:
+        return skill_manage(
+            action=payload.get("action", ""),
+            name=payload.get("name", ""),
+            content=payload.get("content"),
+            category=payload.get("category"),
+            file_path=payload.get("file_path"),
+            file_content=payload.get("file_content"),
+            old_string=payload.get("old_string"),
+            new_string=payload.get("new_string"),
+            replace_all=payload.get("replace_all", False),
+            absorbed_into=payload.get("absorbed_into"),
+        )
+    finally:
+        _manager._skill_gate_bypass.reset(token)
+
+
+SKILL_MANAGE_SCHEMA = copy.deepcopy(_manager.SKILL_MANAGE_SCHEMA)
+SKILL_MANAGE_SCHEMA["description"] += (
+    "\n\nProfile ownership: when `skills.owner_routing.enabled` is true in the "
+    "Default profile, new skills declare `metadata.hermes.owner_profile`. "
+    "Default may route creation to that registered owner; a named profile may "
+    "create for itself but may not write sideways into another named profile."
+)
+
+
+registry.register(
+    name="skill_manage",
+    toolset="skills",
+    schema=SKILL_MANAGE_SCHEMA,
+    handler=lambda args, **kw: skill_manage(
+        action=args.get("action", ""),
+        name=args.get("name", ""),
+        content=args.get("content"),
+        category=args.get("category"),
+        file_path=args.get("file_path"),
+        file_content=args.get("file_content"),
+        old_string=args.get("old_string"),
+        new_string=args.get("new_string"),
+        replace_all=args.get("replace_all", False),
+        absorbed_into=args.get("absorbed_into"),
+        task_id=kw.get("task_id"),
+        session_id=kw.get("session_id"),
+    ),
+    emoji="📝",
+)


### PR DESCRIPTION
## Summary

Adds an opt-in ownership contract for agent-created skills in multi-profile Hermes installs.

- reads `metadata.hermes.owner_profile` from new skill frontmatter
- lets Default route a newly learned specialist skill directly into the declared owner profile
- refuses cross-profile writes from named specialists instead of silently putting the skill in the wrong profile
- can require owner metadata when routing is enabled
- validates declared owner IDs with the existing profile-name validator before any profile filesystem lookup
- keeps the entire routed create transaction scoped to the owner profile, including the skill audit ledger, prompt-cache invalidation, usage/provenance bookkeeping, and sync hook
- routes approved staged creates through the same owner-aware path
- returns an owner handoff hint for subsequent edits/supporting-file writes
- keeps existing `skill_manage` behavior unchanged when the feature is disabled

The goal is to let procedural memory follow the profile that owns the capability rather than whichever profile happened to discover it.

## Rebase / architecture update

Rebased onto current `main` at `f43eabee5f36e11448086ee8ee17c499958e81bf`.

The original implementation placed owner-routing logic directly in `tools/skill_manager_tool.py`. Current Hermes has a hard 2k production-file boundary and that manager is already close to it, so this rebase keeps the godfile untouched:

- `tools/skill_owner_routing.py` owns Default policy, owner parsing/validation, canonical fleet-root resolution, and profile scope switching
- `tools/skill_owner_routing_tool.py` is a thin `skill_manage` registration adapter; non-create actions delegate unchanged
- `hermes_cli/write_approval_commands.py` replays approved staged skill writes through the same owner-aware adapter

The adapter intentionally runs the existing skill write-approval gate **before** switching profiles. A Default-routed create therefore cannot inherit a specialist profile's weaker approval policy. Only after admission does the complete existing `skill_manage(create)` transaction run in the owner profile.

## Authority / safety model

- opt-in; absent or unreadable `skills.owner_routing` policy means routing is disabled
- policy is always read from fleet Default, not from the active specialist
- Default resolution uses `get_default_hermes_root()` rather than assuming a literal `.../profiles/<name>` layout, so custom roots / Docker / profile-scoped installs follow Hermes' canonical path semantics
- `default` remains a valid owner for global/control-plane skills
- a named profile may create for itself but may not mutate another profile's skill namespace
- malformed, traversal-like, reserved, and unregistered owner profile IDs are rejected before profile filesystem lookup
- the live context-scoped `HERMES_HOME`, not the sticky `active_profile` file, determines which profile is performing the mutation
- manual web/API skill creation remains unchanged; this policy applies to the agent-managed `skill_manage(create)` path
- successful routed creates restore the caller's profile scope after the full transaction finishes; failures restore immediately

## Regression coverage added

Focused tests cover:

- Default-policy loading from a named profile under a nonstandard custom fleet root
- fail-closed policy resolution
- nested owner metadata parsing
- live context-scoped active-profile resolution
- Default → owner routing and scope restoration
- failed routed-create restoration
- specialist cross-profile refusal
- matching-owner local creation
- Default-owned skills
- unknown / traversal / reserved owner rejection before filesystem lookup
- `route_from_default=false`
- required vs optional owner metadata
- disabled-policy compatibility
- caller-scope write approval vs owner-scope create transaction
- staged writes never switching profile before approval
- approved staged creates taking the same owner route
- existing required-content error behavior
- non-create pass-through
- registered tool-schema discoverability

## CI

Fresh CI was triggered on rebased head `29dc92a4665d260a561743b1e81cc62135407bce`.

At the time of this update, CI / Docker / Nix runs are queued. This PR should not be treated as green until those exact-head runs complete successfully.