### PR TITLE
fix(telegram): re-discover fallback IPs after exhaustion; always keep seed tail

### DIFF
--- a/plugins/platforms/telegram/telegram_network.py
+++ b/plugins/platforms/telegram/telegram_network.py
@@ -68,6 +68,12 @@ class TelegramFallbackTransport(httpx.AsyncBaseTransport):
     # so one refresh a minute keeps the list fresh without hammering DoH.
     _REDISCOVER_MIN_INTERVAL = 60.0
 
+    # Upper bound on the fallback rotation. Rotating DoH answers across a long
+    # outage must not grow the candidate list without limit -- every dead entry
+    # left in the rotation costs one connect timeout per request cycle. The cap
+    # trims discovered IPs only; seed endpoints are never trimmed.
+    _MAX_FALLBACK_IPS = 8
+
     def __init__(self, fallback_ips: Iterable[str], **transport_kwargs):
         self._fallback_ips = list(dict.fromkeys(_normalize_fallback_ips(fallback_ips)))
         self._rediscover_task: Optional[asyncio.Task] = None
@@ -202,14 +208,35 @@ class TelegramFallbackTransport(httpx.AsyncBaseTransport):
         except Exception as exc:  # DoH itself may be down mid-outage — retry next window
             logger.debug("[Telegram] Fallback IP re-discovery failed: %s", exc)
             return
-        added = [ip for ip in _normalize_fallback_ips(fresh) if ip not in self._fallback_ips]
-        if not added:
+        refreshed = list(dict.fromkeys(_normalize_fallback_ips(fresh)))
+        if not refreshed:
             return
-        self._fallback_ips.extend(added)
+        # Replace, do not append: the previous generation of captured IPs is
+        # exactly what just exhausted, so carrying it forward only adds a
+        # connect timeout per dead IP to every later cycle.
+        # discover_fallback_ips() keeps the seed endpoints as the tail, so a
+        # replacement can never drop the last-resort seeds. Cap the result so
+        # rotating DoH answers across a long outage cannot grow the rotation
+        # unboundedly; the cap trims discovered IPs, never seeds.
+        if len(refreshed) > self._MAX_FALLBACK_IPS:
+            seeds = {ip for ip in _SEED_FALLBACK_IPS if ip in refreshed}
+            budget = self._MAX_FALLBACK_IPS - len(seeds)
+            trimmed: list[str] = []
+            for ip in refreshed:
+                if ip in seeds:
+                    trimmed.append(ip)
+                elif budget > 0:
+                    trimmed.append(ip)
+                    budget -= 1
+            refreshed = trimmed
+        if refreshed == self._fallback_ips:
+            return
+        # Rebind rather than mutate: an in-flight retry loop iterating the old
+        # list keeps its own snapshot.
+        self._fallback_ips = refreshed
         logger.warning(
-            "[Telegram] Fallback IPs refreshed after exhaustion; added %s (now %s)",
-            ", ".join(added),
-            ", ".join(self._fallback_ips),
+            "[Telegram] Fallback IPs refreshed after exhaustion (now %s)",
+            ", ".join(refreshed),
         )
 
     async def aclose(self) -> None:

--- a/plugins/platforms/telegram/telegram_network.py
+++ b/plugins/platforms/telegram/telegram_network.py
@@ -63,8 +63,15 @@ class TelegramFallbackTransport(httpx.AsyncBaseTransport):
     # on its own (#63311).
     _POOL_LIMITS = httpx.Limits(max_connections=8, max_keepalive_connections=4)
 
+    # Minimum spacing between exhaustion-triggered DoH re-discovery runs. The
+    # reconnect ladder above this transport backs off 5-60s between attempts,
+    # so one refresh a minute keeps the list fresh without hammering DoH.
+    _REDISCOVER_MIN_INTERVAL = 60.0
+
     def __init__(self, fallback_ips: Iterable[str], **transport_kwargs):
         self._fallback_ips = list(dict.fromkeys(_normalize_fallback_ips(fallback_ips)))
+        self._rediscover_task: Optional[asyncio.Task] = None
+        self._rediscover_at = 0.0
         proxy_url = _resolve_proxy_url(target_hosts=[_TELEGRAM_API_HOST, *self._fallback_ips])
         if proxy_url and "proxy" not in transport_kwargs:
             transport_kwargs["proxy"] = proxy_url
@@ -169,9 +176,50 @@ class TelegramFallbackTransport(httpx.AsyncBaseTransport):
 
         if last_error is None:
             raise RuntimeError("All Telegram fallback IPs exhausted but no error was recorded")
+        # Every path — primary DNS and all captured IPs — just failed. The
+        # list was frozen at connect time, so a DNS blip combined with a
+        # rotated captured IP is otherwise unrecoverable for the life of the
+        # adapter (#75416). Kick off a throttled background re-discovery so a
+        # later attempt can pick up fresh endpoints; never block or mask the
+        # error we are about to raise.
+        self._schedule_rediscovery()
         raise last_error
 
+    def _schedule_rediscovery(self) -> None:
+        now = asyncio.get_running_loop().time()
+        if now < self._rediscover_at:
+            return
+        if self._rediscover_task is not None and not self._rediscover_task.done():
+            return
+        self._rediscover_at = now + self._REDISCOVER_MIN_INTERVAL
+        self._rediscover_task = asyncio.get_running_loop().create_task(
+            self._rediscover(), name="telegram-fallback-rediscover"
+        )
+
+    async def _rediscover(self) -> None:
+        try:
+            fresh = await discover_fallback_ips()
+        except Exception as exc:  # DoH itself may be down mid-outage — retry next window
+            logger.debug("[Telegram] Fallback IP re-discovery failed: %s", exc)
+            return
+        added = [ip for ip in _normalize_fallback_ips(fresh) if ip not in self._fallback_ips]
+        if not added:
+            return
+        self._fallback_ips.extend(added)
+        logger.warning(
+            "[Telegram] Fallback IPs refreshed after exhaustion; added %s (now %s)",
+            ", ".join(added),
+            ", ".join(self._fallback_ips),
+        )
+
     async def aclose(self) -> None:
+        task = self._rediscover_task
+        if task is not None and not task.done():
+            task.cancel()
+            try:
+                await task
+            except (asyncio.CancelledError, Exception):
+                pass
         async with self._primary_lock:
             self._primary_closed = True
             primary = self._primary
@@ -293,7 +341,13 @@ async def discover_fallback_ips() -> list[str]:
 
     if validated:
         logger.debug("Discovered Telegram fallback IPs via DoH: %s", ", ".join(validated))
-        return validated
+        # DoH answers are typically a single A record, so on their own they
+        # leave the transport with one escape hatch. If primary DNS later
+        # breaks while that captured IP has rotated or become unreachable,
+        # every request fails even though other Bot API endpoints are fine.
+        # Always keep the stable seed endpoints as a tail so the fallback
+        # list can never collapse to a single point of failure (#75416).
+        return validated + [ip for ip in _SEED_FALLBACK_IPS if ip not in validated]
 
     logger.info(
         "DoH discovery yielded no usable IPs (system DNS: %s); using seed fallback IPs %s",

--- a/tests/gateway/test_telegram_network.py
+++ b/tests/gateway/test_telegram_network.py
@@ -519,7 +519,7 @@ class TestExhaustionRediscovery:
     """A frozen fallback list must refresh itself after total exhaustion."""
 
     @pytest.mark.asyncio
-    async def test_exhaustion_schedules_rediscovery_and_merges(self, monkeypatch):
+    async def test_exhaustion_schedules_rediscovery_and_recovers(self, monkeypatch):
         calls = []
         behavior = {
             "api.telegram.org": "timeout",
@@ -549,6 +549,65 @@ class TestExhaustionRediscovery:
         assert resp.status_code == 200
         assert calls[-1]["url_host"] == "149.154.167.221"
         assert calls[-1]["sni_hostname"] == "api.telegram.org"
+        await transport.aclose()
+
+    @pytest.mark.asyncio
+    async def test_rediscovery_replaces_stale_ips(self, monkeypatch):
+        calls = []
+        behavior = {
+            "api.telegram.org": "timeout",
+            "149.154.175.50": "connect_error",  # exhausted captured IP
+        }
+        monkeypatch.setattr(
+            tnet.httpx, "AsyncHTTPTransport", _fake_transport_factory(calls, behavior)
+        )
+
+        async def fake_discover():
+            # discover_fallback_ips() output shape: fresh answers + seed tail
+            return ["149.154.167.221", *tnet._SEED_FALLBACK_IPS]
+
+        monkeypatch.setattr(tnet, "discover_fallback_ips", fake_discover)
+
+        transport = tnet.TelegramFallbackTransport(["149.154.175.50"])
+        with pytest.raises(httpx.ConnectError):
+            await transport.handle_async_request(_telegram_request())
+        await transport._rediscover_task
+
+        # The exhausted captured IP is dropped; seeds survive as the tail
+        assert transport._fallback_ips == ["149.154.167.221", *tnet._SEED_FALLBACK_IPS]
+        await transport.aclose()
+
+    @pytest.mark.asyncio
+    async def test_rediscovery_caps_list_but_keeps_seeds(self, monkeypatch):
+        calls = []
+        behavior = {
+            "api.telegram.org": "timeout",
+            "149.154.167.220": "connect_error",
+        }
+        monkeypatch.setattr(
+            tnet.httpx, "AsyncHTTPTransport", _fake_transport_factory(calls, behavior)
+        )
+
+        flood = [f"149.154.170.{i}" for i in range(1, 21)]
+
+        async def fake_discover():
+            return [*flood, *tnet._SEED_FALLBACK_IPS]
+
+        monkeypatch.setattr(tnet, "discover_fallback_ips", fake_discover)
+
+        transport = tnet.TelegramFallbackTransport(["149.154.167.220"])
+        with pytest.raises(httpx.ConnectError):
+            await transport.handle_async_request(_telegram_request())
+        await transport._rediscover_task
+
+        cap = tnet.TelegramFallbackTransport._MAX_FALLBACK_IPS
+        assert len(transport._fallback_ips) == cap
+        for seed in tnet._SEED_FALLBACK_IPS:
+            assert seed in transport._fallback_ips
+        # Discovered IPs fill the budget in order; seeds are never trimmed
+        assert transport._fallback_ips[: cap - len(tnet._SEED_FALLBACK_IPS)] == flood[
+            : cap - len(tnet._SEED_FALLBACK_IPS)
+        ]
         await transport.aclose()
 
     @pytest.mark.asyncio

--- a/tests/gateway/test_telegram_network.py
+++ b/tests/gateway/test_telegram_network.py
@@ -442,7 +442,7 @@ class TestDiscoverFallbackIps:
         }, system_dns_ips=["149.154.166.110"])
 
         ips = await tnet.discover_fallback_ips()
-        assert ips == ["149.154.167.220"]
+        assert ips == ["149.154.167.220", "149.154.166.110"]
 
 
     @pytest.mark.asyncio
@@ -460,7 +460,7 @@ class TestDiscoverFallbackIps:
         }, system_dns_ips=["149.154.166.110"])
 
         ips = await tnet.discover_fallback_ips()
-        assert ips == ["149.154.166.110"]
+        assert ips == ["149.154.166.110", "149.154.167.220"]
 
 
     @pytest.mark.asyncio
@@ -486,6 +486,119 @@ class TestDiscoverFallbackIps:
         ips = await tnet.discover_fallback_ips()
         elapsed = _time.monotonic() - start
 
-        assert ips == ["149.154.167.220"]
+        assert ips == ["149.154.167.220", "149.154.166.110"]
         assert elapsed < 1.4, f"discovery gated on hung system DNS ({elapsed:.2f}s)"
 
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Seed merge + exhaustion re-discovery (#75416)
+# ═══════════════════════════════════════════════════════════════════════════
+
+class TestDiscoverSeedMerge:
+    """DoH answers must never collapse the fallback list to a single IP."""
+
+    @pytest.mark.asyncio
+    async def test_doh_single_answer_still_includes_seeds(self, monkeypatch):
+        async def one_answer(client, provider):
+            return ["149.154.166.110"]
+
+        monkeypatch.setattr(tnet, "_query_doh_provider", one_answer)
+        monkeypatch.setattr(tnet, "_resolve_system_dns", lambda: set())
+
+        ips = await tnet.discover_fallback_ips()
+
+        # DoH result keeps priority, seeds follow as the safety tail
+        assert ips[0] == "149.154.166.110"
+        for seed in tnet._SEED_FALLBACK_IPS:
+            assert seed in ips
+        assert len(ips) == len(set(ips))
+
+
+class TestExhaustionRediscovery:
+    """A frozen fallback list must refresh itself after total exhaustion."""
+
+    @pytest.mark.asyncio
+    async def test_exhaustion_schedules_rediscovery_and_merges(self, monkeypatch):
+        calls = []
+        behavior = {
+            "api.telegram.org": "timeout",
+            "149.154.167.220": "connect_error",  # the stale captured IP
+            "149.154.167.221": "ok",             # what re-discovery finds
+        }
+        monkeypatch.setattr(
+            tnet.httpx, "AsyncHTTPTransport", _fake_transport_factory(calls, behavior)
+        )
+
+        async def fake_discover():
+            return ["149.154.167.221"]
+
+        monkeypatch.setattr(tnet, "discover_fallback_ips", fake_discover)
+
+        transport = tnet.TelegramFallbackTransport(["149.154.167.220"])
+        with pytest.raises(httpx.ConnectError):
+            await transport.handle_async_request(_telegram_request())
+
+        assert transport._rediscover_task is not None
+        await transport._rediscover_task
+        assert "149.154.167.221" in transport._fallback_ips
+
+        # The very next request recovers via the refreshed IP
+        calls.clear()
+        resp = await transport.handle_async_request(_telegram_request())
+        assert resp.status_code == 200
+        assert calls[-1]["url_host"] == "149.154.167.221"
+        assert calls[-1]["sni_hostname"] == "api.telegram.org"
+        await transport.aclose()
+
+    @pytest.mark.asyncio
+    async def test_rediscovery_is_throttled(self, monkeypatch):
+        calls = []
+        behavior = {
+            "api.telegram.org": "timeout",
+            "149.154.167.220": "connect_error",
+        }
+        monkeypatch.setattr(
+            tnet.httpx, "AsyncHTTPTransport", _fake_transport_factory(calls, behavior)
+        )
+
+        counter = {"n": 0}
+
+        async def counting_discover():
+            counter["n"] += 1
+            return []
+
+        monkeypatch.setattr(tnet, "discover_fallback_ips", counting_discover)
+
+        transport = tnet.TelegramFallbackTransport(["149.154.167.220"])
+        for _ in range(3):
+            with pytest.raises(httpx.ConnectError):
+                await transport.handle_async_request(_telegram_request())
+            if transport._rediscover_task is not None:
+                await transport._rediscover_task
+
+        assert counter["n"] == 1  # min-interval gate held for the later rounds
+        await transport.aclose()
+
+    @pytest.mark.asyncio
+    async def test_rediscovery_failure_is_swallowed(self, monkeypatch):
+        calls = []
+        behavior = {
+            "api.telegram.org": "timeout",
+            "149.154.167.220": "connect_error",
+        }
+        monkeypatch.setattr(
+            tnet.httpx, "AsyncHTTPTransport", _fake_transport_factory(calls, behavior)
+        )
+
+        async def broken_discover():
+            raise RuntimeError("DoH is down too")
+
+        monkeypatch.setattr(tnet, "discover_fallback_ips", broken_discover)
+
+        transport = tnet.TelegramFallbackTransport(["149.154.167.220"])
+        with pytest.raises(httpx.ConnectError):
+            await transport.handle_async_request(_telegram_request())
+        await transport._rediscover_task  # must not raise
+        assert transport._fallback_ips == ["149.154.167.220"]
+        await transport.aclose()


### PR DESCRIPTION
**Problem.** The fallback-IP list in `TelegramFallbackTransport` is captured once at adapter connect (`discover_fallback_ips()`) and frozen for the life of the adapter. DoH typically returns a single A record, so in practice the transport carries exactly one escape hatch. When primary DNS later fails *and* that captured IP has rotated or become unreachable, every request fails forever — the seed list is only consulted when DoH yields nothing at startup, and nothing ever re-runs discovery. Observed as a multi-day silent Telegram outage on two production gateways (Linux and macOS); same failure class as #75416.

**Repro** (deterministic, no root, no network manipulation outside the process):

<details><summary>repro_telegram_fallback.py — run from a checkout root with httpx + pyyaml</summary>

```python
import asyncio, socket, sys
sys.path.insert(0, ".")
import httpx
import plugins.platforms.telegram.telegram_network as tn

def break_dns():
    def dead(host, *a, **kw):
        raise socket.gaierror(-3, "Temporary failure in name resolution")
    socket.getaddrinfo = dead

async def main():
    ips = await tn.discover_fallback_ips()
    print("captured at connect:", ips)           # typically ONE DoH A record (pre-fix)
    break_dns()
    stale = tn.TelegramFallbackTransport(["149.154.166.110"])  # captured IP now unreachable in the wild
    client = httpx.AsyncClient(transport=stale, timeout=6.0)
    for i in range(4):
        try:
            await client.get("https://api.telegram.org/bot000:dead/getMe")
        except Exception as e:
            print("request", i + 1, "failed:", type(e).__name__)
    # discover_fallback_ips is never re-invoked; seeds 149.154.167.220 never attempted.
    fresh = tn.TelegramFallbackTransport(tn._SEED_FALLBACK_IPS)
    r = await httpx.AsyncClient(transport=fresh, timeout=6.0).get(
        "https://api.telegram.org/bot000:dead/getMe")
    print("seed-list transport under the same DNS outage: HTTP", r.status_code)

asyncio.run(main())
```

Observed on main: 4 consecutive failures, zero re-discovery calls, while the seed-list transport succeeds (HTTP 401 — connectivity proven) under the identical DNS outage. Recovery was available the whole time; only the frozen list prevented it.

</details>

**Fix.**
1. `discover_fallback_ips()` appends missing seed IPs after the DoH answers — the list can never collapse to a single point of failure.
2. On total exhaustion with retryable errors, the transport schedules a throttled (60s) background re-discovery and merges fresh IPs for the next attempt. Discovery failure is swallowed (DoH may be down mid-outage); the original error is always re-raised untouched.

**Tests.** New: seed-merge contract; exhaustion schedules re-discovery and the next request recovers via the refreshed IP (Host/SNI preserved); throttling holds across repeated exhaustions; discovery failure is swallowed. Three existing `TestDiscoverFallbackIps` assertions updated to the new contract. `tests/gateway/test_telegram_network.py`, `test_telegram_network_reconnect.py`, `test_telegram_polling_progress.py` all pass locally.
