### PR TITLE
feat(desktop): honor per-model reasoning-effort enums in model picker

### DIFF
--- a/apps/desktop/src/app/shell/model-catalog-menu.tsx
+++ b/apps/desktop/src/app/shell/model-catalog-menu.tsx
@@ -461,6 +461,7 @@ export function ModelCatalogMenu({
                           }
                           provider={group.provider.slug}
                           reasoning={caps?.reasoning ?? true}
+                          efforts={caps?.efforts}
                         />
                       </DropdownMenuSub>
                     )

--- a/apps/desktop/src/app/shell/model-edit-submenu.test.tsx
+++ b/apps/desktop/src/app/shell/model-edit-submenu.test.tsx
@@ -26,6 +26,7 @@ afterEach(() => {
 function renderSubmenu(opts: {
   defaultEffort?: string
   effort?: string
+  efforts?: readonly string[]
   fastControl: FastControl
   isActive?: boolean
   onSelectModel?: (model: string) => void
@@ -40,6 +41,7 @@ function renderSubmenu(opts: {
           <ModelEditSubmenu
             defaultEffort={opts.defaultEffort ?? 'medium'}
             effort={opts.effort ?? 'medium'}
+            efforts={opts.efforts}
             fastControl={opts.fastControl}
             isActive={opts.isActive ?? true}
             model="m1"
@@ -127,5 +129,71 @@ describe('ModelEditSubmenu reports edits without performing them', () => {
     fireEvent.click(screen.getByRole('switch'))
 
     expect(onSelectModel).toHaveBeenCalledWith('m1-fast')
+  })
+})
+
+// The backend may narrow the effort ladder per model (capabilities.efforts) —
+// e.g. kimi-k3 officially accepts only low/high/max. Offering levels the API
+// rejects turns a picker choice into a silent 400, so the submenu must honor
+// the enum when one is provided.
+describe('ModelEditSubmenu per-model effort enum', () => {
+  it('offers only the backend-provided levels', () => {
+    renderSubmenu({
+      effort: 'high',
+      efforts: ['low', 'high', 'max'],
+      fastControl: { kind: 'none' },
+      onSetOptions: vi.fn(),
+      reasoning: true
+    })
+
+    expect(screen.getByRole('menuitemradio', { name: 'Low' })).toBeTruthy()
+    expect(screen.getByRole('menuitemradio', { name: 'High' })).toBeTruthy()
+    expect(screen.getByRole('menuitemradio', { name: 'Max' })).toBeTruthy()
+    expect(screen.queryByRole('menuitemradio', { name: 'Medium' })).toBeNull()
+    expect(screen.queryByRole('menuitemradio', { name: 'Ultra' })).toBeNull()
+  })
+
+  it('hides the Thinking toggle when the enum has no off state', () => {
+    renderSubmenu({
+      efforts: ['low', 'high', 'max'],
+      fastControl: { kind: 'none' },
+      onSetOptions: vi.fn(),
+      reasoning: true
+    })
+
+    expect(screen.queryByRole('switch')).toBeNull()
+  })
+
+  it('keeps the Thinking toggle when the enum offers none', () => {
+    renderSubmenu({
+      efforts: ['none', 'low', 'high'],
+      fastControl: { kind: 'none' },
+      onSetOptions: vi.fn(),
+      reasoning: true
+    })
+
+    expect(screen.getByRole('switch')).toBeTruthy()
+    // `none` itself stays out of the radio — the toggle owns it.
+    expect(screen.queryByRole('menuitemradio', { name: 'none' })).toBeNull()
+  })
+
+  it('clamps a configured level the model does not offer to the nearest enum level', () => {
+    // medium configured; kimi-style enum → nearest ladder rung is high.
+    renderSubmenu({
+      effort: 'medium',
+      efforts: ['low', 'high', 'max'],
+      fastControl: { kind: 'none' },
+      onSetOptions: vi.fn(),
+      reasoning: true
+    })
+
+    expect(screen.getByRole('menuitemradio', { name: 'High', checked: true })).toBeTruthy()
+  })
+
+  it('falls back to the full ladder when no enum is provided', () => {
+    renderSubmenu({ fastControl: { kind: 'none' }, onSetOptions: vi.fn(), reasoning: true })
+
+    expect(screen.getByRole('menuitemradio', { name: 'Ultra' })).toBeTruthy()
+    expect(screen.getByRole('switch')).toBeTruthy()
   })
 })

--- a/apps/desktop/src/app/shell/model-edit-submenu.tsx
+++ b/apps/desktop/src/app/shell/model-edit-submenu.tsx
@@ -10,7 +10,7 @@ import {
 } from '@/components/ui/dropdown-menu'
 import { Switch } from '@/components/ui/switch'
 import { useI18n } from '@/i18n'
-import { isThinkingEnabled, REASONING_EFFORTS, resolveReasoningEffort } from '@/lib/reasoning-effort'
+import { isThinkingEnabled, REASONING_EFFORTS, type ReasoningEffort, resolveReasoningEffort } from '@/lib/reasoning-effort'
 
 // Hermes' real reasoning levels live in lib/reasoning-effort; `none` is owned
 // by the Thinking toggle, not the radio.
@@ -82,6 +82,9 @@ interface ModelEditSubmenuProps {
   provider: string
   /** Whether this model supports reasoning effort. */
   reasoning: boolean
+  /** Per-model effort enum from the backend capabilities (provider-specific,
+   *  e.g. kimi-k3 → low/high/max). Absent → full 7-level ladder. */
+  efforts?: readonly string[]
 }
 
 export function ModelEditSubmenu(props: ModelEditSubmenuProps) {
@@ -104,12 +107,42 @@ function ModelEditSubmenuBody({
   isActive,
   onSelectModel,
   onSetOptions,
-  reasoning
+  reasoning,
+  efforts
 }: ModelEditSubmenuProps) {
   const { t } = useI18n()
   const copy = t.shell.modelOptions
 
-  const effortValue = resolveReasoningEffort(effort, defaultEffort)
+  // Per-model enum (backend capabilities) narrows the ladder; `none` stays
+  // owned by the Thinking toggle, never the radio. When the enum says thinking
+  // cannot be turned off (e.g. kimi-k3), the toggle itself is hidden.
+  const effortLevels = (efforts ?? REASONING_EFFORTS).filter(level => level !== 'none') as ReasoningEffort[]
+  const canDisableThinking = efforts === undefined || efforts.includes('none')
+
+  const rawEffortValue = resolveReasoningEffort(effort, defaultEffort)
+  // A configured level the model doesn't offer (e.g. medium on kimi-k3, which
+  // the backend maps to high on the wire) must not render as a phantom
+  // selection — clamp the display to the nearest offered level.
+  const ladderIndex = (value: string) => REASONING_EFFORTS.indexOf(value as ReasoningEffort)
+  const clampToOffered = (value: string, levels: ReasoningEffort[]): string => {
+    if (!value || levels.includes(value as ReasoningEffort)) {
+      return value
+    }
+    const target = ladderIndex(value)
+    let best: string = levels[0] ?? value
+    let bestDist = Infinity
+    for (const level of levels) {
+      const dist = Math.abs(ladderIndex(level) - target)
+      // Ties resolve to the HIGHER rung, matching the backend's round-up
+      // mapping (e.g. kimi-k3 sends medium as high).
+      if (dist <= bestDist) {
+        bestDist = dist
+        best = level
+      }
+    }
+    return best
+  }
+  const effortValue = clampToOffered(rawEffortValue, effortLevels)
   const thinkingOn = isThinkingEnabled(effort, defaultEffort)
 
   const setFast = (enabled: boolean) => {
@@ -139,7 +172,7 @@ function ModelEditSubmenuBody({
   ) : (
     <>
       <DropdownMenuLabel className={dropdownMenuSectionLabel}>{copy.options}</DropdownMenuLabel>
-      {reasoning ? (
+      {reasoning && canDisableThinking ? (
         <DropdownMenuItem className={dropdownMenuRow} onSelect={event => event.preventDefault()}>
           {copy.thinking}
           <Switch
@@ -161,7 +194,7 @@ function ModelEditSubmenuBody({
           <DropdownMenuSeparator className="mx-0" />
           <DropdownMenuLabel className={dropdownMenuSectionLabel}>{copy.effort}</DropdownMenuLabel>
           <DropdownMenuRadioGroup onValueChange={value => onSetOptions({ effort: value })} value={effortValue}>
-            {REASONING_EFFORTS.map(value => (
+            {effortLevels.map(value => (
               <DropdownMenuRadioItem
                 className={dropdownMenuRow}
                 key={value}

--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -424,6 +424,10 @@ export interface ModelOptionProvider {
 export interface ModelCapabilities {
   fast: boolean
   reasoning: boolean
+  /** Per-model reasoning-effort enum from the backend (provider-specific).
+   *  Absent → the full 7-level ladder applies. `none` means thinking-off is
+   *  offered (owned by the Thinking toggle, not the effort radio). */
+  efforts?: string[]
 }
 
 export interface ModelOptionsResponse {

--- a/hermes_cli/inventory.py
+++ b/hermes_cli/inventory.py
@@ -431,10 +431,31 @@ def _apply_capabilities(rows: list[dict]) -> None:
                 except Exception:
                     reasoning = True
 
-            caps[model] = {
+            entry: dict[str, Any] = {
                 "fast": bool(model_supports_fast_mode(model)),
                 "reasoning": reasoning,
             }
+
+            # Providers whose official API documents a narrower
+            # reasoning-effort enum than Hermes' 7-level ladder — advertise
+            # the real scale so pickers can't offer levels the API would
+            # reject with a 400. UIs fold "none" into the Thinking toggle.
+            if slug == "deepseek" and (
+                model.lower().startswith("deepseek-v")
+                and not model.lower().startswith("deepseek-v3")
+            ):
+                entry["efforts"] = ["none", "high", "max"]
+            # Kimi K3: official enum low/high/max (default max); thinking is
+            # always on for K3, so no "none" level is offered.
+            elif slug == "kimi-coding" and model.strip().lower() == "kimi-k3":
+                entry["efforts"] = ["low", "high", "max"]
+            # Xiaomi MiMo v2.5: official reasoning.effort enum is
+            # none/low/medium/high (low/medium/high behave identically for
+            # now — all enable thinking).
+            elif slug == "xiaomi" and model.strip().lower() in ("mimo-v2.5", "mimo-v2.5-pro"):
+                entry["efforts"] = ["none", "low", "medium", "high"]
+
+            caps[model] = entry
 
         row["capabilities"] = caps
 

--- a/tests/hermes_cli/test_inventory.py
+++ b/tests/hermes_cli/test_inventory.py
@@ -513,3 +513,26 @@ def _apply_featured_with_dates(rows, dates: dict[str, str]):
 
 
 
+
+
+# ─── _apply_capabilities (per-provider effort scales) ──────────────────
+
+
+def test_apply_capabilities_advertises_documented_effort_scales():
+    """Providers with an officially documented effort enum expose it; others
+    keep the default full-ladder behavior (no ``efforts`` key)."""
+    from hermes_cli.inventory import _apply_capabilities
+
+    rows = [
+        {"slug": "deepseek", "models": ["deepseek-v4-flash"]},
+        {"slug": "kimi-coding", "models": ["kimi-k3"]},
+        {"slug": "xiaomi", "models": ["mimo-v2.5"]},
+        {"slug": "openai", "models": ["gpt-5.1"]},
+    ]
+
+    _apply_capabilities(rows)
+
+    assert rows[0]["capabilities"]["deepseek-v4-flash"]["efforts"] == ["none", "high", "max"]
+    assert rows[1]["capabilities"]["kimi-k3"]["efforts"] == ["low", "high", "max"]
+    assert rows[2]["capabilities"]["mimo-v2.5"]["efforts"] == ["none", "low", "medium", "high"]
+    assert "efforts" not in rows[3]["capabilities"]["gpt-5.1"]


### PR DESCRIPTION
## Problem

The desktop model edit submenu offers the full 7-level reasoning-effort ladder (`minimal/low/medium/high/xhigh/max/ultra`) for every model. Several providers officially document a narrower enum — picking a level the API doesn't accept either 400s the request or silently remaps it behind the user's back:

- **deepseek v4+**: official enum `none/high/max`
- **kimi-k3**: official enum `low/high/max` (thinking always on, no off state)
- **xiaomi mimo v2.5**: official enum `none/low/medium/high`

## Fix

**Backend** (`hermes_cli/inventory.py`): `_apply_capabilities` now attaches a per-model `efforts` list to the picker payload (`capabilities[model].efforts`) for providers with a documented narrower scale. Providers without one are untouched — no `efforts` key, full ladder as before.

**Desktop** (`model-edit-submenu.tsx`): the effort radio narrows to the advertised enum; `none` stays owned by the Thinking toggle, and when the enum has no off state (kimi-k3) the toggle is hidden. A configured level the model doesn't offer (e.g. `medium` on kimi-k3, which the backend maps to `high` on the wire) now displays as the nearest advertised rung instead of a phantom selection. Ties clamp upward to match the backend's round-up mapping.

Fully backward compatible: rows without `capabilities.efforts` render exactly as before.

## Tests

- `tests/hermes_cli/test_inventory.py`: documented scales are advertised; undocumented providers get no `efforts` key
- `model-edit-submenu.test.tsx`: 6 new cases — enum narrowing, toggle hidden/shown by off-state, `none` excluded from radio, upward clamp, full-ladder fallback
- `npx tsc -p . --noEmit` clean; `vitest` 13/13 in the two touched desktop files; `pytest tests/hermes_cli/test_inventory.py` 15/15