### PR TITLE
fix(mcp): use Hugging Face OAuth login URL for suggestion pills

### DIFF
--- a/apps/desktop/src/lib/mcp-directory.ts
+++ b/apps/desktop/src/lib/mcp-directory.ts
@@ -129,8 +129,10 @@ export const MCP_DIRECTORY: McpDirectoryEntry[] = [
     hosts: ['huggingface.co', 'hf.co'],
     keywords: ['hugging face', 'huggingface'],
     // Underscored so prettyName renders "Hugging Face", not "Huggingface".
+    // `?login` is required for OAuth discovery; the anonymous `/mcp` URL never
+    // challenges, so the suggestion pill's forced-OAuth flow cannot start.
     name: 'hugging_face',
-    url: 'https://huggingface.co/mcp'
+    url: 'https://huggingface.co/mcp?login'
   },
   {
     description: 'Tasks, projects, and goals from your Asana workspace.',

--- a/apps/desktop/src/store/suggestion-providers/mcp.test.ts
+++ b/apps/desktop/src/store/suggestion-providers/mcp.test.ts
@@ -100,4 +100,16 @@ describe('matchSuggestions', () => {
 
     expect(matchSuggestions('connect github', index)).toEqual([])
   })
+
+  it('points Hugging Face at the OAuth login URL so the suggestion pill can connect', () => {
+    const huggingFace = MCP_DIRECTORY.find(entry => entry.name === 'hugging_face')
+
+    expect(huggingFace?.url).toBe('https://huggingface.co/mcp?login')
+
+    const index = MCP_DIRECTORY.map(entry => ({ hosts: entry.hosts, keywords: entry.keywords, server: entry.name }))
+
+    expect(matchSuggestions('add hugging face mcp ', index)).toEqual([
+      { keyword: 'hugging face', server: 'hugging_face' }
+    ])
+  })
 })

--- a/optional-mcps/hugging_face/manifest.yaml
+++ b/optional-mcps/hugging_face/manifest.yaml
@@ -12,9 +12,13 @@ source: https://huggingface.co/docs/hub/agents-mcp
 # Hermes's MCP client + mcp_oauth_manager handle discovery, PKCE, token
 # exchange, and refresh.
 # Underscored name so UIs render "Hugging Face", not "Huggingface".
+# The `?login` suffix is what makes the server return 401 + WWW-Authenticate
+# (RFC 8414 resource_metadata). The anonymous URL (`/mcp` with no query)
+# serves tools without a challenge, so a forced-OAuth connect never obtains
+# an authorization URL and the desktop suggestion pill rolls the config back.
 transport:
   type: http
-  url: https://huggingface.co/mcp
+  url: https://huggingface.co/mcp?login
 
 auth:
   type: oauth

--- a/tests/hermes_cli/test_mcp_catalog.py
+++ b/tests/hermes_cli/test_mcp_catalog.py
@@ -679,3 +679,18 @@ class TestShippedCatalog:
                     )
 
         assert not problems, "unpinned catalog entries:\n" + "\n".join(problems)
+
+    def test_hugging_face_url_uses_oauth_login_query(self, monkeypatch):
+        """HF only advertises OAuth at ``/mcp?login``. The anonymous ``/mcp``
+        URL serves tools without a WWW-Authenticate challenge, so the desktop
+        suggestion pill's forced-OAuth flow never gets an authorization URL
+        and rolls the config write back.
+        """
+        monkeypatch.delenv("HERMES_OPTIONAL_MCPS", raising=False)
+        from hermes_cli.mcp_catalog import get_entry
+
+        entry = get_entry("hugging_face")
+        assert entry is not None, "hugging_face catalog entry missing"
+        assert entry.transport.url == "https://huggingface.co/mcp?login"
+        assert entry.auth is not None
+        assert entry.auth.type == "oauth"


### PR DESCRIPTION
## What does this PR do?

The desktop MCP suggestion pill (and the catalog entry it reads) pointed Hugging Face at `https://huggingface.co/mcp`. That URL serves an anonymous tool set and never returns a `WWW-Authenticate` challenge, so the pill's forced-OAuth flow cannot obtain an authorization URL, reports a connect failure, and rolls the config write back.

Hugging Face only negotiates OAuth at `https://huggingface.co/mcp?login`. This PR updates the catalog manifest and the desktop directory fallback to that URL so the existing OAuth path can start.

## Related Issue

Fixes #87062

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `optional-mcps/hugging_face/manifest.yaml` — catalog / suggestion-pill URL is now `https://huggingface.co/mcp?login`
- `apps/desktop/src/lib/mcp-directory.ts` — same URL on the compatibility fallback used when the backend catalog has no `suggest` metadata
- `tests/hermes_cli/test_mcp_catalog.py` — shipped-catalog contract that `hugging_face` stays on the OAuth login URL
- `apps/desktop/src/store/suggestion-providers/mcp.test.ts` — directory URL + keyword match for "add hugging face mcp"

## How to Test

1. On current main, `hermes mcp login hugging_face` against `https://huggingface.co/mcp` prints `Server responded, but no OAuth token was obtained`. The Desktop "Add Hugging Face" pill uses that same anonymous URL, then rolls the config write back.
2. After this change, `get_entry("hugging_face")` / `hermes mcp catalog` shows `https://huggingface.co/mcp?login`. `hermes mcp login hugging_face` against that URL opens the Hugging Face authorize page (OAuth discovery succeeds).
3. In Desktop, type `add hugging face mcp ` in the composer so the pill appears, click it, and complete the browser consent. `hermes mcp list` should show `hugging_face` afterwards.
4. Regression tests: `pytest tests/hermes_cli/test_mcp_catalog.py::TestShippedCatalog::test_hugging_face_url_uses_oauth_login_query -q` and `cd apps/desktop && npx vitest run src/store/suggestion-providers/mcp.test.ts --project ui`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS (darwin 25.5.0)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Before (anonymous URL + forced OAuth):

```
Starting OAuth flow for 'hugging_face'...
⚠ Server responded, but no OAuth token was obtained — authentication did not complete.
```

After (`?login` URL):

```
MCP OAuth: authorization required.
Open this URL in your browser:
  https://huggingface.co/oauth/authorize?...
(Browser opened automatically.)
✓ Authenticated — 6 tool(s) available
```