### PR TITLE
fix(desktop): add HUD layout reset

### DIFF
--- a/apps/desktop/electron/hud-geometry.test.ts
+++ b/apps/desktop/electron/hud-geometry.test.ts
@@ -2,7 +2,7 @@ import assert from 'node:assert/strict'
 
 import { test } from 'vitest'
 
-import { defaultHudBounds } from './hud-geometry'
+import { applyHudResetBounds, defaultHudBounds } from './hud-geometry'
 
 test('defaultHudBounds restores the standard centered bottom layout', () => {
   assert.deepEqual(defaultHudBounds({ x: 0, y: 25, width: 1440, height: 875 }), {
@@ -24,4 +24,21 @@ test('defaultHudBounds fits the default layout to a small work area', () => {
 
 test('defaultHudBounds keeps the spawn fallback when no display is available', () => {
   assert.deepEqual(defaultHudBounds(), { x: undefined, y: undefined, width: 620, height: 320 })
+})
+
+test('applyHudResetBounds restores the resize lock and reports native failure', () => {
+  let resizable = false
+  const win = {
+    isDestroyed: () => false,
+    isResizable: () => resizable,
+    setResizable: (value: boolean) => {
+      resizable = value
+    },
+    setBounds: () => {
+      throw new Error('window disappeared')
+    }
+  }
+
+  assert.equal(applyHudResetBounds(win, { x: 0, y: 0, width: 620, height: 320 }), false)
+  assert.equal(resizable, false)
 })

--- a/apps/desktop/electron/hud-geometry.test.ts
+++ b/apps/desktop/electron/hud-geometry.test.ts
@@ -1,0 +1,27 @@
+import assert from 'node:assert/strict'
+
+import { test } from 'vitest'
+
+import { defaultHudBounds } from './hud-geometry'
+
+test('defaultHudBounds restores the standard centered bottom layout', () => {
+  assert.deepEqual(defaultHudBounds({ x: 0, y: 25, width: 1440, height: 875 }), {
+    x: 410,
+    y: 508,
+    width: 620,
+    height: 320
+  })
+})
+
+test('defaultHudBounds fits the default layout to a small work area', () => {
+  assert.deepEqual(defaultHudBounds({ x: -800, y: 0, width: 480, height: 240 }), {
+    x: -800,
+    y: 0,
+    width: 480,
+    height: 240
+  })
+})
+
+test('defaultHudBounds keeps the spawn fallback when no display is available', () => {
+  assert.deepEqual(defaultHudBounds(), { x: undefined, y: undefined, width: 620, height: 320 })
+})

--- a/apps/desktop/electron/hud-geometry.ts
+++ b/apps/desktop/electron/hud-geometry.ts
@@ -1,0 +1,32 @@
+export const HUD_WIDTH = 620
+export const HUD_HEIGHT = 320
+export const HUD_BOTTOM_MARGIN = 72
+
+export interface HudWorkArea {
+  height: number
+  width: number
+  x: number
+  y: number
+}
+
+/** Return the display-aware default bounds used to recover the HUD layout. */
+export function defaultHudBounds(area?: HudWorkArea): {
+  height: number
+  width: number
+  x?: number
+  y?: number
+} {
+  if (!area) {
+    return { width: HUD_WIDTH, height: HUD_HEIGHT, x: undefined, y: undefined }
+  }
+
+  const width = Math.min(HUD_WIDTH, area.width)
+  const height = Math.min(HUD_HEIGHT, area.height)
+
+  return {
+    width,
+    height,
+    x: Math.round(area.x + (area.width - width) / 2),
+    y: Math.round(Math.max(area.y, area.y + area.height - height - HUD_BOTTOM_MARGIN))
+  }
+}

--- a/apps/desktop/electron/hud-geometry.ts
+++ b/apps/desktop/electron/hud-geometry.ts
@@ -30,3 +30,36 @@ export function defaultHudBounds(area?: HudWorkArea): {
     y: Math.round(Math.max(area.y, area.y + area.height - height - HUD_BOTTOM_MARGIN))
   }
 }
+
+export interface HudBoundsWindow {
+  isDestroyed(): boolean
+  isResizable(): boolean
+  setBounds(bounds: { height: number; width: number; x?: number; y?: number }): void
+  setResizable(resizable: boolean): void
+}
+
+/** Apply recovery bounds and convert native-window failures into a result. */
+export function applyHudResetBounds(
+  win: HudBoundsWindow,
+  bounds: { height: number; width: number; x?: number; y?: number }
+): boolean {
+  try {
+    const wasResizable = win.isResizable()
+
+    if (!wasResizable) {
+      win.setResizable(true)
+    }
+
+    try {
+      win.setBounds(bounds)
+    } finally {
+      if (!wasResizable && !win.isDestroyed()) {
+        win.setResizable(false)
+      }
+    }
+
+    return true
+  } catch {
+    return false
+  }
+}

--- a/apps/desktop/electron/hud-ipc.ts
+++ b/apps/desktop/electron/hud-ipc.ts
@@ -15,6 +15,7 @@ export interface HudIpcDeps {
   getHudWindow: () => BrowserWindow | null
   openHudWindow: (sessionId: null | string, profile: null | string) => void
   closeHudWindow: () => void
+  resetHudLayout: () => boolean
   setHudSessionId: (sessionId: null | string) => void
 }
 
@@ -26,6 +27,7 @@ export function registerHudIpc({
   getHudWindow,
   openHudWindow,
   closeHudWindow,
+  resetHudLayout,
   setHudSessionId
 }: HudIpcDeps) {
   // Whether the band currently covers the window below the bar. The renderer
@@ -168,6 +170,16 @@ export function registerHudIpc({
     if (resizing) {
       win.setResizable(false)
     }
+  })
+
+  ipcMain.handle('hermes:hud:reset-layout', event => {
+    const hudWindow = getHudWindow()
+
+    if (!hudWindow || hudWindow.isDestroyed() || event.sender !== hudWindow.webContents) {
+      return { ok: false }
+    }
+
+    return { ok: resetHudLayout() }
   })
 
   // The HUD renderer reporting which session it is on, so the close broadcast

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -181,6 +181,7 @@ import {
   writeSecretFileAtomic
 } from './hardening'
 import { cursorPointInWindow } from './hud-cursor'
+import { defaultHudBounds } from './hud-geometry'
 import { registerHudIpc } from './hud-ipc'
 import { snapHudBounds } from './hud-snap'
 import { createHudSnapShortcut } from './hud-snap-shortcut'
@@ -11432,6 +11433,33 @@ function persistHudState() {
   }
 }
 
+function resetHudWindowLayout(): boolean {
+  if (!hudWindow || hudWindow.isDestroyed()) {
+    return false
+  }
+
+  const win = hudWindow
+  const display = screen.getDisplayNearestPoint(screen.getCursorScreenPoint())
+  const bounds = defaultHudBounds(display?.workArea)
+  const wasResizable = win.isResizable()
+
+  if (!wasResizable) {
+    win.setResizable(true)
+  }
+
+  try {
+    win.setBounds(bounds)
+  } finally {
+    if (!wasResizable && !win.isDestroyed()) {
+      win.setResizable(false)
+    }
+  }
+
+  persistHudState()
+
+  return true
+}
+
 const schedulePersistHudState = debounce(persistHudState, 250)
 
 // How often Linux gets told where the cursor is. Fast enough that the bar is
@@ -12410,6 +12438,7 @@ const hudIpc = registerHudIpc({
   getHudWindow: () => hudWindow,
   openHudWindow,
   closeHudWindow,
+  resetHudLayout: resetHudWindowLayout,
   setHudSessionId: value => {
     hudSessionId = value
   }

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -181,7 +181,7 @@ import {
   writeSecretFileAtomic
 } from './hardening'
 import { cursorPointInWindow } from './hud-cursor'
-import { defaultHudBounds } from './hud-geometry'
+import { applyHudResetBounds, defaultHudBounds } from './hud-geometry'
 import { registerHudIpc } from './hud-ipc'
 import { snapHudBounds } from './hud-snap'
 import { createHudSnapShortcut } from './hud-snap-shortcut'
@@ -11441,18 +11441,11 @@ function resetHudWindowLayout(): boolean {
   const win = hudWindow
   const display = screen.getDisplayNearestPoint(screen.getCursorScreenPoint())
   const bounds = defaultHudBounds(display?.workArea)
-  const wasResizable = win.isResizable()
 
-  if (!wasResizable) {
-    win.setResizable(true)
-  }
+  if (!applyHudResetBounds(win, bounds)) {
+    rememberLog('[hud-state] reset layout failed while applying native bounds')
 
-  try {
-    win.setBounds(bounds)
-  } finally {
-    if (!wasResizable && !win.isDestroyed()) {
-      win.setResizable(false)
-    }
+    return false
   }
 
   persistHudState()

--- a/apps/desktop/electron/preload.ts
+++ b/apps/desktop/electron/preload.ts
@@ -75,6 +75,7 @@ contextBridge.exposeInMainWorld('hermesDesktop', {
     setIgnoreMouse: ignore => ipcRenderer.send('hermes:hud:ignore-mouse', ignore),
     moveBy: delta => ipcRenderer.send('hermes:hud:move-by', delta),
     setBounds: bounds => ipcRenderer.send('hermes:hud:set-bounds', bounds),
+    resetLayout: () => ipcRenderer.invoke('hermes:hud:reset-layout'),
     // Whether the band covers the window below the bar. Main pairs it with the
     // user's translucency setting to decide the native frost (macOS vibrancy /
     // Windows 11 DWM backdrop) — see hudFrostFor.

--- a/apps/desktop/src/app/chat/composer/controls.tsx
+++ b/apps/desktop/src/app/chat/composer/controls.tsx
@@ -7,7 +7,7 @@ import { useI18n } from '@/i18n'
 import { triggerHaptic } from '@/lib/haptics'
 import { AudioLines, Ear, EarOff, iconSize, Layers3, Loader2, Square, Volume2, VolumeX } from '@/lib/icons'
 import { cn } from '@/lib/utils'
-import { $hudMode, closeHud } from '@/store/hud'
+import { $hudMode, closeHud, resetHudLayout } from '@/store/hud'
 import { $wakeWord, toggleWakeWord } from '@/store/wake-word'
 
 import { ACTIVE_ICON_BTN, GHOST_ICON_BTN, PRIMARY_ICON_BTN } from './control-classes'
@@ -173,27 +173,41 @@ export function ComposerControls({
           the surface, paid for in every state, for a control that is invisible
           until hovered. Here it costs no reserved space and sits with the other
           things you can press. */}
-      {hudMode ? <ExitHudButton /> : null}
+      {hudMode ? <HudWindowButtons /> : null}
     </div>
   )
 }
 
-function ExitHudButton() {
+function HudWindowButtons() {
   const { t } = useI18n()
 
   return (
-    <Tip label={t.titlebar.exitHud}>
-      <Button
-        aria-label={t.titlebar.exitHud}
-        className={cn(GHOST_ICON_BTN, 'p-0')}
-        onClick={closeHud}
-        size="icon"
-        type="button"
-        variant="ghost"
-      >
-        <Codicon name="screen-normal" size="0.875rem" />
-      </Button>
-    </Tip>
+    <>
+      <Tip label={t.titlebar.resetHudLayout}>
+        <Button
+          aria-label={t.titlebar.resetHudLayout}
+          className={cn(GHOST_ICON_BTN, 'p-0')}
+          onClick={resetHudLayout}
+          size="icon"
+          type="button"
+          variant="ghost"
+        >
+          <Codicon name="discard" size="0.875rem" />
+        </Button>
+      </Tip>
+      <Tip label={t.titlebar.exitHud}>
+        <Button
+          aria-label={t.titlebar.exitHud}
+          className={cn(GHOST_ICON_BTN, 'p-0')}
+          onClick={closeHud}
+          size="icon"
+          type="button"
+          variant="ghost"
+        >
+          <Codicon name="screen-normal" size="0.875rem" />
+        </Button>
+      </Tip>
+    </>
   )
 }
 

--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -96,6 +96,7 @@ declare global {
         setIgnoreMouse: (ignore: boolean) => void
         moveBy: (delta: { x: number; y: number; width: number; height: number }) => void
         setBounds: (bounds: { x: number; y: number; width: number; height: number }) => void
+        resetLayout: () => Promise<{ ok: boolean }>
         setFrost: (showing: boolean) => Promise<{ ok: boolean }>
         setSession: (sessionId: null | string) => void
         onGoto: (callback: (sessionId: string) => void) => () => void

--- a/apps/desktop/src/i18n/ar.ts
+++ b/apps/desktop/src/i18n/ar.ts
@@ -188,6 +188,7 @@ export const ar = defineLocale({
     openStarmap: 'فتح خريطة الذاكرة',
     enterHud: 'وضع HUD',
     exitHud: 'إنهاء وضع HUD',
+    resetHudLayout: 'إعادة تعيين حجم HUD وموضعه',
     layoutEditor: 'محرر التخطيط',
     layoutEditorTitle: modifier => `محرر التخطيط — انقر مع ${modifier} لإعادة ضبط التخطيط`
   },

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -218,6 +218,7 @@ export const en: Translations = {
     openStarmap: 'Open memory graph',
     enterHud: 'HUD mode',
     exitHud: 'Exit HUD mode',
+    resetHudLayout: 'Reset HUD size and position',
     layoutEditor: 'Layout editor',
     layoutEditorTitle: mod => `Layout editor — ${mod}-click resets the layout`
   },

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -216,7 +216,8 @@ export const ja = defineLocale({
     muteHaptics: '触覚フィードバックをオフ',
     unmuteHaptics: '触覚フィードバックをオン',
     openSettings: '設定を開く',
-    openStarmap: 'メモリグラフを開く'
+    openStarmap: 'メモリグラフを開く',
+    resetHudLayout: 'HUD のサイズと位置をリセット'
   },
 
   language: {

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -260,6 +260,7 @@ export interface Translations {
     openStarmap: string
     enterHud: string
     exitHud: string
+    resetHudLayout: string
     layoutEditor: string
     layoutEditorTitle: (modifier: string) => string
   }

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -210,7 +210,8 @@ export const zhHant = defineLocale({
     muteHaptics: '靜音觸感回饋',
     unmuteHaptics: '開啟觸感回饋',
     openSettings: '開啟設定',
-    openStarmap: '開啟記憶圖譜'
+    openStarmap: '開啟記憶圖譜',
+    resetHudLayout: '重設 HUD 大小和位置'
   },
 
   language: {

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -213,6 +213,7 @@ export const zh: Translations = {
     openStarmap: '打开记忆图谱',
     enterHud: 'HUD 模式',
     exitHud: '退出 HUD 模式',
+    resetHudLayout: '重置 HUD 大小和位置',
     layoutEditor: '布局编辑器',
     layoutEditorTitle: mod => `布局编辑器 — ${mod} 点击重置布局`
   },

--- a/apps/desktop/src/store/hud.test.ts
+++ b/apps/desktop/src/store/hud.test.ts
@@ -4,16 +4,17 @@ import { $activeGatewayProfile } from '@/store/profile'
 import { $sessions } from '@/store/session'
 import type { SessionInfo } from '@/types/hermes'
 
-import { $hudActive, $hudSession, openHud } from './hud'
+import { $hudActive, $hudSession, openHud, resetHudLayout } from './hud'
 
 const desktopWindow = window as unknown as { hermesDesktop?: Window['hermesDesktop'] }
 const initialHermesDesktop = desktopWindow.hermesDesktop
 
 const open = vi.fn().mockResolvedValue({ ok: true })
+const resetLayout = vi.fn().mockResolvedValue({ ok: true })
 
 function installBridge() {
   desktopWindow.hermesDesktop = {
-    hud: { open }
+    hud: { open, resetLayout }
   } as unknown as Window['hermesDesktop']
 }
 
@@ -23,11 +24,20 @@ function session(overrides: Partial<SessionInfo>): SessionInfo {
 
 beforeEach(() => {
   open.mockClear()
+  resetLayout.mockClear()
   installBridge()
   $hudActive.set(false)
   $hudSession.set(null)
   $sessions.set([])
   $activeGatewayProfile.set('default')
+})
+
+describe('resetHudLayout', () => {
+  it('uses the native HUD recovery capability', () => {
+    resetHudLayout()
+
+    expect(resetLayout).toHaveBeenCalledOnce()
+  })
 })
 
 afterEach(() => {

--- a/apps/desktop/src/store/hud.ts
+++ b/apps/desktop/src/store/hud.ts
@@ -85,6 +85,11 @@ export function closeHud(): void {
   void api.close()
 }
 
+/** Restore the HUD's persisted geometry to its display-aware default. */
+export function resetHudLayout(): void {
+  void window.hermesDesktop?.hud?.resetLayout?.()
+}
+
 export const toggleHud = (sessionId?: null | string) => ($hudActive.get() ? closeHud() : openHud(sessionId))
 
 /** Tell main which session this HUD is on. Main holds it (the HUD's renderer


### PR DESCRIPTION
## Summary

- add a discoverable **Reset HUD size and position** control next to the existing HUD exit control
- restore the HUD to its display-aware 620×320 default using the existing temporary-resizable Electron pattern
- persist the restored geometry immediately so a quick close/reopen cannot revive stale malformed bounds
- extract and test the default HUD geometry calculation, including small displays

Closes #87055

## Root cause

The HUD accepts and persists any geometry above its minimum size. Because the transparent frameless window is intentionally non-resizable at the OS level, a malformed tall/narrow layout can survive restarts with no discoverable recovery path. The only resize control was an invisible corner.

## Verification

- `npm run typecheck --workspace=apps/desktop`
- `npm run lint --workspace=apps/desktop -- --quiet`
- `npm run fmt --workspace=apps/desktop -- --check`
- `npm exec --workspace=apps/desktop vitest -- run --project electron electron/hud-geometry.test.ts` — 3 passed
- `npm exec --workspace=apps/desktop vitest -- run --project ui src/store/hud.test.ts` — 6 passed
- `git diff --check`
- mutation check: replacing the default-size clamp with the full work-area dimensions makes the new geometry test fail (`1440×875` instead of `620×320`)

## Scope

This PR adds the explicit recovery path requested by the issue. It does not reject user-selected tall/large layouts or change normal HUD resize persistence.
