### PR TITLE
fix(gateway): add --external-supervisor to launchd plist ProgramArguments

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -4401,6 +4401,11 @@ def _timestamped_stderr_gateway_command(error_log: Path) -> list[str]:
         str(error_log),
         "--",
         *_gateway_run_command(),
+        # launchd injects XPC_SERVICE_NAME into the outer stderr_timestamp
+        # wrapper but does not propagate it to this inner subprocess.
+        # --external-supervisor tells gateway run it is managed by launchd so
+        # it does not trigger the duplicate-instance guard and exit with code 1.
+        "--external-supervisor",
     ]
 
 

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -1249,6 +1249,7 @@ class TestProfileArg:
             "gateway",
             "run",
             "--replace",
+            "--external-supervisor",
         ]
 
     def test_launchd_plist_path_uses_real_user_home_not_profile_home(self, tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary

`hermes gateway install` generates a launchd plist whose `ProgramArguments` use a two-layer process structure:

- Outer: `python -m hermes_cli.stderr_timestamp --error-log ... --`
- Inner: `python -m hermes_cli.main gateway run --replace`

launchd injects `XPC_SERVICE_NAME` into the outer process but does **not** propagate it to the inner subprocess. Without `--external-supervisor`, the inner `gateway run` cannot detect the launchd context and falsely triggers the duplicate-instance guard, causing:

- Exit code 1 → `LastExitStatus = 256` in launchctl
- Infinite restart loop
- `gateway.log` repeatedly logs: _"A gateway is already running under launchd"_

## Changes

- Append `"--external-supervisor"` in `_timestamped_stderr_gateway_command()` — added at the wrapper level, not inside `_gateway_run_command()`, so the detached-fallback path (`_spawn_detached_gateway`) is unaffected.
- Update the corresponding `test_launchd_plist_wraps_gateway_stderr_with_timestamps` assertion to expect `--external-supervisor` in `ProgramArguments`.

## Testing

Verified on macOS with three profiles. After patching and reloading the launchd service via `launchctl bootout` + `launchctl bootstrap`, all gateways start and remain running without restarting.

## Risks

No compatibility or migration risk. `--external-supervisor` is already defined in `hermes_cli/subcommands/gateway.py` and is designed exactly for this use case — declaring that an external process manager owns the gateway process. The detached fallback path is not affected because the flag is added only in `_timestamped_stderr_gateway_command()` (the launchd wrapper path), not in `_gateway_run_command()` itself.

## Workaround (for existing users before this ships)

Patch an existing plist manually:

```python
import plistlib, pathlib
p = pathlib.Path.home() / "Library/LaunchAgents/ai.hermes.gateway-<profile>.plist"
d = plistlib.loads(p.read_bytes())
a = list(d["ProgramArguments"])
if "--external-supervisor" not in a:
    a.append("--external-supervisor")
    d["ProgramArguments"] = a
    p.write_bytes(plistlib.dumps(d))
```

Then reload:
```bash
launchctl bootout "gui/$(id -u)/ai.hermes.gateway-<profile>"
launchctl bootstrap "gui/$(id -u)" ~/Library/LaunchAgents/ai.hermes.gateway-<profile>.plist
```