### PR TITLE
fix(telegram): recover Windows CLOSE-WAIT getUpdates deadlock

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -306,6 +306,7 @@ from plugins.platforms.telegram.telegram_network import (
     TelegramFallbackTransport,
     discover_fallback_ips,
     parse_fallback_ip_env,
+    tcp_keepalive_socket_options,
 )
 from utils import atomic_replace, env_float, env_int
 
@@ -616,6 +617,12 @@ _POLLING_ERROR_TASK_STUCK_TIMEOUT = 300.0
 # A generation is not healthy until the dedicated getUpdates request returns
 # successfully. This exceeds a normal long-poll cycle for healthy idle bots.
 _POLLING_PROGRESS_TIMEOUT = 60.0
+# Steady-state getUpdates liveness (#87057). A healthy long-poll round-trip
+# finishes within the HTTP read timeout (~20s) plus Telegram's ~10s poll
+# window. If the instrumented getUpdates request records no completion for
+# this long, the consumer is wedged on a stale socket — even when get_me()
+# on the general pool still succeeds and pending_update_count is 0.
+_POLLING_STALE_IO_TIMEOUT = 90.0
 # Telegram transcodes an uploaded video before it answers sendVideo, so the
 # wait for the response is unrelated to how fast the bytes went out and can
 # outlast the 20s read timeout the rest of the Bot API is tuned for. Only
@@ -809,6 +816,12 @@ class TelegramAdapter(BasePlatformAdapter):
         self._polling_teardown_started: bool = False
         self._polling_error_callback_ref = None
         self._polling_heartbeat_task: Optional[asyncio.Task] = None
+        # Monotonic timestamp of the last getUpdates request completion
+        # (success or error) for the current polling generation. None until
+        # the first generation starts. The heartbeat uses this as a
+        # getUpdates-pool liveness probe that does not depend on get_me()
+        # or pending_update_count (#87057).
+        self._polling_last_io_at: Optional[float] = None
         # Live @username, refreshed whenever Telegram tells us what it is.
         # PTB caches getMe() in Bot._bot_user at initialize() and only rewrites
         # it inside get_me(), so a BotFather rename leaves self._bot.username
@@ -2430,17 +2443,32 @@ class TelegramAdapter(BasePlatformAdapter):
             polling_req = self._app.bot._request[0]  # noqa: SLF001
         except Exception:
             return
+        shutdown_ok = False
         try:
             # Bounded: a wedged CLOSE-WAIT socket can make this close hang
-            # forever and freeze the reconnect ladder (#66377).
-            await asyncio.wait_for(polling_req.shutdown(), timeout=_DRAIN_TIMEOUT)
+            # forever and freeze the reconnect ladder (#66377). Use the
+            # thread-deadline helper so a cancellation-shielded aclose()
+            # cannot pin the ladder the way asyncio.wait_for would.
+            await _await_with_thread_deadline(
+                polling_req.shutdown(), timeout=_DRAIN_TIMEOUT
+            )
+            shutdown_ok = True
         except Exception:
             logger.debug(
                 "[%s] Polling request shutdown failed/timed out (non-fatal)",
                 self.name, exc_info=True,
             )
+        if not shutdown_ok:
+            # HTTPXRequest.initialize() rebuilds the client only when
+            # ``client.is_closed``. An abandoned aclose() leaves that flag
+            # false, so initialize() is a no-op and start_polling reuses the
+            # CLOSE-WAIT getUpdates socket — the gateway stays alive but
+            # deaf (#87057). Swap in a fresh client before initialize().
+            self._orphan_and_rebuild_polling_client(polling_req)
         try:
-            await asyncio.wait_for(polling_req.initialize(), timeout=_DRAIN_TIMEOUT)
+            await _await_with_thread_deadline(
+                polling_req.initialize(), timeout=_DRAIN_TIMEOUT
+            )
             logger.debug(
                 "[%s] Polling request pool drained before reconnect", self.name
             )
@@ -2449,6 +2477,74 @@ class TelegramAdapter(BasePlatformAdapter):
                 "[%s] Polling request re-initialize failed/timed out (non-fatal)",
                 self.name, exc_info=True,
             )
+            self._orphan_and_rebuild_polling_client(polling_req)
+
+    def _orphan_and_rebuild_polling_client(self, polling_req) -> None:
+        """Replace a wedged HTTPXRequest client after a hung aclose().
+
+        PTB's ``HTTPXRequest.initialize()`` only calls ``_build_client()``
+        when the current client reports ``is_closed``. If ``shutdown()`` was
+        abandoned on a CLOSE-WAIT socket, that flag stays false and the next
+        ``start_polling()`` reuses the dead getUpdates connection (#87057).
+        Swap in a fresh client and detach the old ``aclose()`` so it cannot
+        block the reconnect ladder.
+        """
+        old = getattr(polling_req, "_client", None)
+        build = getattr(polling_req, "_build_client", None)
+        if old is None or not callable(build):
+            return
+        if getattr(old, "is_closed", True):
+            return
+        try:
+            polling_req._client = build()
+        except Exception:
+            logger.debug(
+                "[%s] Failed to rebuild polling HTTP client after hung drain",
+                self.name, exc_info=True,
+            )
+            return
+        logger.warning(
+            "[%s] Replaced wedged getUpdates HTTP client after drain timeout "
+            "(likely CLOSE-WAIT socket)",
+            self.name,
+        )
+
+        async def _orphan_aclose() -> None:
+            try:
+                aclose = getattr(old, "aclose", None)
+                if not callable(aclose):
+                    return
+                result = aclose()
+                if asyncio.iscoroutine(result) or asyncio.isfuture(result):
+                    await result
+            except Exception:
+                logger.debug(
+                    "[%s] Orphan polling client aclose failed (non-fatal)",
+                    self.name, exc_info=True,
+                )
+
+        try:
+            task = asyncio.ensure_future(_orphan_aclose())
+            task.add_done_callback(_consume_abandoned_task)
+        except Exception:
+            pass
+
+    def _note_polling_io(self, generation: Optional[int] = None) -> None:
+        """Stamp getUpdates request completion for the current generation."""
+        if getattr(self, "_polling_teardown_started", False):
+            return
+        if generation is not None and generation != self._polling_generation:
+            return
+        self._polling_last_io_at = time.monotonic()
+
+    def _get_updates_io_is_stale(self) -> bool:
+        """True when the getUpdates consumer has recorded no I/O recently."""
+        if getattr(self, "_webhook_mode", False):
+            return False
+        last = getattr(self, "_polling_last_io_at", None)
+        if last is None:
+            return False
+        return (time.monotonic() - last) >= _POLLING_STALE_IO_TIMEOUT
 
     def _begin_polling_generation(self) -> tuple[int, asyncio.Event]:
         """Start accepting progress for a new getUpdates polling generation."""
@@ -2469,6 +2565,7 @@ class TelegramAdapter(BasePlatformAdapter):
         self._polling_progress_event = asyncio.Event()
         self._polling_progress_accepting = True
         self._send_path_degraded = True
+        self._polling_last_io_at = time.monotonic()
         return self._polling_generation, self._polling_progress_event
 
     def _record_polling_progress(self, generation: int) -> None:
@@ -2538,8 +2635,13 @@ class TelegramAdapter(BasePlatformAdapter):
 
             async def do_request(self, *args, **kwargs):
                 generation = _POLLING_GENERATION_CONTEXT.get()
-                result = await super().do_request(*args, **kwargs)
+                try:
+                    result = await super().do_request(*args, **kwargs)
+                except BaseException:
+                    adapter._note_polling_io(generation)
+                    raise
                 adapter._observe_polling_request_result(self, generation, result)
+                adapter._note_polling_io(generation)
                 return result
 
         request.__class__ = _InstrumentedPollingRequest
@@ -3072,6 +3174,34 @@ class TelegramAdapter(BasePlatformAdapter):
                         return
                 else:
                     stuck_task_ref = None
+
+                # getUpdates-pool liveness (#87057): get_me() uses the general
+                # request path, so it stays healthy while the long-poll socket
+                # is wedged in CLOSE-WAIT. pending_update_count is also blind
+                # when no DMs are queued. If the instrumented getUpdates
+                # request has not completed a round-trip recently, recover
+                # without waiting on get_me() — that probe can hang the same
+                # way on Windows overlapped I/O.
+                if (
+                    self._get_updates_io_is_stale()
+                    and not (
+                        self._polling_error_task
+                        and not self._polling_error_task.done()
+                    )
+                ):
+                    logger.warning(
+                        "[%s] getUpdates I/O stalled for >= %.0fs; "
+                        "triggering polling restart",
+                        self.name, _POLLING_STALE_IO_TIMEOUT,
+                    )
+                    self._schedule_polling_recovery(
+                        RuntimeError(
+                            "getUpdates I/O stalled: no round-trip within "
+                            "liveness watchdog"
+                        ),
+                        reason="getUpdates liveness watchdog",
+                    )
+                    continue
 
                 bot = self._app.bot if self._app else None
                 if bot is None:
@@ -4396,6 +4526,7 @@ class TelegramAdapter(BasePlatformAdapter):
                 _transport_kwargs: dict = {}
                 if _pool_limits is not None:
                     _transport_kwargs["limits"] = _pool_limits
+                _transport_kwargs["socket_options"] = tcp_keepalive_socket_options()
                 request = HTTPXRequest(
                     **request_kwargs,
                     httpx_kwargs={

--- a/plugins/platforms/telegram/telegram_network.py
+++ b/plugins/platforms/telegram/telegram_network.py
@@ -21,6 +21,37 @@ logger = logging.getLogger(__name__)
 
 _TELEGRAM_API_HOST = "api.telegram.org"
 
+# TCP keepalive so a half-open or CLOSE-WAIT long-poll errors out instead of
+# blocking getUpdates indefinitely. Windows does not enable SO_KEEPALIVE on
+# new sockets by default, so a dead api.telegram.org peer can hang forever
+# (#87057). Idle/interval knobs are best-effort — not every Python/OS combo
+# exposes TCP_KEEPIDLE / TCP_KEEPALIVE.
+_TCP_KEEPALIVE_IDLE_S = 30
+_TCP_KEEPALIVE_INTERVAL_S = 10
+_TCP_KEEPALIVE_COUNT = 3
+
+
+def tcp_keepalive_socket_options() -> list[tuple[int, int, int]]:
+    """Return ``setsockopt`` tuples that enable TCP keepalive on new sockets.
+
+    Pure data for httpx/httpcore ``socket_options``. Safe on every host: the
+    list always includes ``SO_KEEPALIVE`` and adds idle/interval/count only
+    when the running interpreter exposes those option names.
+    """
+    options: list[tuple[int, int, int]] = [
+        (socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1),
+    ]
+    idle = getattr(socket, "TCP_KEEPIDLE", None) or getattr(socket, "TCP_KEEPALIVE", None)
+    if idle is not None:
+        options.append((socket.IPPROTO_TCP, idle, _TCP_KEEPALIVE_IDLE_S))
+    interval = getattr(socket, "TCP_KEEPINTVL", None)
+    if interval is not None:
+        options.append((socket.IPPROTO_TCP, interval, _TCP_KEEPALIVE_INTERVAL_S))
+    count = getattr(socket, "TCP_KEEPCNT", None)
+    if count is not None:
+        options.append((socket.IPPROTO_TCP, count, _TCP_KEEPALIVE_COUNT))
+    return options
+
 # DNS-over-HTTPS providers used to discover Telegram API IPs that may differ
 # from the (potentially unreachable) IP returned by the local system resolver.
 _DOH_TIMEOUT = 4.0  # seconds — bounded so connect() isn't noticeably delayed
@@ -69,6 +100,7 @@ class TelegramFallbackTransport(httpx.AsyncBaseTransport):
         if proxy_url and "proxy" not in transport_kwargs:
             transport_kwargs["proxy"] = proxy_url
         transport_kwargs.setdefault("limits", self._POOL_LIMITS)
+        transport_kwargs.setdefault("socket_options", tcp_keepalive_socket_options())
         self._transport_kwargs = transport_kwargs
         self._primary = httpx.AsyncHTTPTransport(**transport_kwargs)
         self._primary_lock = asyncio.Lock()

--- a/tests/gateway/test_telegram_closewait_limits_31599.py
+++ b/tests/gateway/test_telegram_closewait_limits_31599.py
@@ -26,6 +26,7 @@ client-level limits when a custom transport is supplied.
 """
 
 import asyncio
+import socket
 import sys
 from unittest.mock import MagicMock, patch
 
@@ -182,6 +183,14 @@ def test_fallback_branch_forwards_tuned_limits_to_inner_transports(monkeypatch):
         assert limits.keepalive_expiry is not None
         assert limits.keepalive_expiry < 5.0
         assert limits.max_connections == 512
+        sock_opts = transport._transport_kwargs.get("socket_options")
+        assert sock_opts, "fallback transport must enable TCP keepalive (#87057)"
+        assert any(
+            opt[0] == socket.SOL_SOCKET
+            and opt[1] == socket.SO_KEEPALIVE
+            and opt[2] == 1
+            for opt in sock_opts
+        )
 
     for instance in instances:
         asyncio.run(instance.kwargs["httpx_kwargs"]["transport"].aclose())

--- a/tests/gateway/test_telegram_network.py
+++ b/tests/gateway/test_telegram_network.py
@@ -17,6 +17,7 @@ fallback IPs in order, then "stick" to whichever IP works.
 
 import httpx
 import pytest
+import socket
 
 import plugins.platforms.telegram.telegram_network as tnet
 
@@ -275,6 +276,13 @@ class TestFallbackTransportInit:
             assert "limits" in kw
             # Caller-supplied limits must win over the setdefault default.
             assert kw["limits"] is custom_limits
+            assert "socket_options" in kw
+            assert any(
+                opt[0] == socket.SOL_SOCKET
+                and opt[1] == socket.SO_KEEPALIVE
+                and opt[2] == 1
+                for opt in kw["socket_options"]
+            )
 
 
 class TestFallbackTransportClose:
@@ -488,4 +496,15 @@ class TestDiscoverFallbackIps:
 
         assert ips == ["149.154.167.220"]
         assert elapsed < 1.4, f"discovery gated on hung system DNS ({elapsed:.2f}s)"
+
+
+def test_tcp_keepalive_socket_options_enables_so_keepalive():
+    """Windows long-polls need SO_KEEPALIVE or a dead peer hangs forever (#87057)."""
+    options = tnet.tcp_keepalive_socket_options()
+    assert any(
+        level == socket.SOL_SOCKET
+        and opt == socket.SO_KEEPALIVE
+        and value == 1
+        for level, opt, value in options
+    )
 

--- a/tests/gateway/test_telegram_network_reconnect.py
+++ b/tests/gateway/test_telegram_network_reconnect.py
@@ -686,3 +686,96 @@ async def test_disconnect_advances_past_cancellation_swallowing_lifecycle(monkey
 
     release.set()
     await asyncio.wait({wedged}, timeout=0.2)
+
+
+@pytest.mark.asyncio
+async def test_drain_rebuilds_http_client_when_shutdown_hangs(monkeypatch):
+    """Hung aclose() must not leave initialize() as a no-op (#87057).
+
+    PTB's HTTPXRequest.initialize() only rebuilds when client.is_closed.
+    If shutdown() is abandoned on a CLOSE-WAIT socket, that flag stays
+    false and start_polling would reuse the dead getUpdates connection.
+    Drain must swap in a fresh client so the reconnect ladder is live.
+    """
+    adapter = _make_adapter()
+
+    class _FakeClient:
+        def __init__(self):
+            self.is_closed = False
+
+        async def aclose(self):
+            await asyncio.Event().wait()
+
+    class _FakePollingReq:
+        def __init__(self):
+            self._client = _FakeClient()
+            self.built = []
+
+        def _build_client(self):
+            client = _FakeClient()
+            self.built.append(client)
+            return client
+
+        async def shutdown(self):
+            await asyncio.Event().wait()
+
+        async def initialize(self):
+            if self._client.is_closed:
+                self._client = self._build_client()
+
+    polling_req = _FakePollingReq()
+    original = polling_req._client
+    mock_app = MagicMock()
+    mock_app.bot._request = (polling_req, MagicMock())
+    adapter._app = mock_app
+
+    monkeypatch.setattr(tg_adapter, "_DRAIN_TIMEOUT", 0.05)
+    await asyncio.wait_for(adapter._drain_polling_connections(), timeout=2.0)
+
+    assert polling_req.built, "drain must rebuild the HTTP client after hung aclose"
+    assert polling_req._client is not original
+    assert polling_req._client is polling_req.built[-1]
+
+
+@pytest.mark.asyncio
+async def test_heartbeat_recovers_stale_getupdates_io_without_get_me(monkeypatch):
+    """A wedged getUpdates socket must recover even when get_me() would hang.
+
+    get_me() uses the general request path, so it cannot see CLOSE-WAIT on
+    the getUpdates pool (#87057). The heartbeat must trip on stalled
+    instrumented I/O first and must not wait on get_me().
+    """
+    adapter = _make_adapter()
+    adapter._webhook_mode = False
+    adapter._polling_last_io_at = 1.0
+    adapter._handle_polling_network_error = AsyncMock()
+
+    async def _hanging_get_me():
+        raise AssertionError(
+            "get_me must not run when getUpdates I/O is already stale"
+        )
+
+    mock_app = MagicMock()
+    mock_app.bot.get_me = _hanging_get_me
+    adapter._app = mock_app
+
+    clock = [1000.0]
+    sleep_calls = 0
+
+    async def _fake_sleep(_seconds):
+        nonlocal sleep_calls
+        sleep_calls += 1
+        if sleep_calls >= 2:
+            raise asyncio.CancelledError()
+
+    monkeypatch.setattr(tg_adapter.time, "monotonic", lambda: clock[0])
+    monkeypatch.setattr(tg_adapter, "_POLLING_STALE_IO_TIMEOUT", 90.0)
+
+    with patch("asyncio.sleep", new=AsyncMock(side_effect=_fake_sleep)):
+        await adapter._polling_heartbeat_loop()
+    await asyncio.sleep(0)
+
+    pending = adapter._polling_error_task
+    assert pending is not None, "stale getUpdates I/O must schedule recovery"
+    await asyncio.wait_for(pending, timeout=1.0)
+    adapter._handle_polling_network_error.assert_called()

--- a/tests/gateway/test_telegram_polling_progress.py
+++ b/tests/gateway/test_telegram_polling_progress.py
@@ -357,6 +357,7 @@ async def test_current_polling_generation_success_records_progress():
     assert adapter._polling_network_error_count == 0
     assert adapter._send_path_degraded is False
     assert generation > 0
+    assert adapter._polling_last_io_at is not None
 
 
 @pytest.mark.asyncio
@@ -377,6 +378,9 @@ async def test_unsuccessful_polling_request_does_not_record_progress(error_type)
     assert not progress.is_set()
     assert adapter._polling_network_error_count == 3
     assert adapter._send_path_degraded is True
+    # Errors still count as getUpdates I/O so the liveness watchdog does not
+    # treat a completed TimedOut/CancelledError round-trip as a hung socket.
+    assert adapter._polling_last_io_at is not None
 
 
 @pytest.mark.asyncio
@@ -396,6 +400,7 @@ async def test_http_error_response_does_not_record_polling_progress():
     assert not progress.is_set()
     assert adapter._polling_network_error_count == 3
     assert adapter._send_path_degraded is True
+    assert adapter._polling_last_io_at is not None
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- After a Telegram network error on Windows, `updater.stop()` can time out on a stale long-poll socket. PTB's `HTTPXRequest.initialize()` only rebuilds the httpx client when `is_closed` is true, so a hung `aclose()` left `start_polling()` on the same CLOSE-WAIT connection. The gateway process stayed alive (PID, cron, heartbeat) while inbound `getUpdates` blocked indefinitely ([#87057](https://github.com/NousResearch/hermes-agent/issues/87057)).
- Rebuild the polling HTTP client when drain times out, watch instrumented getUpdates I/O in the heartbeat (independent of `get_me()` / `pending_update_count`), and enable TCP keepalive on the fallback transport used for `api.telegram.org` IPs such as `149.154.166.110`.

## Test plan
- [x] `scripts/run_tests.sh tests/gateway/test_telegram_network_reconnect.py tests/gateway/test_telegram_network.py tests/gateway/test_telegram_polling_progress.py tests/gateway/test_telegram_closewait_limits_31599.py tests/test_telegram_polling_progress_ptb.py tests/gateway/test_telegram_init_deadline.py tests/gateway/test_telegram_pending_update_probe.py tests/gateway/test_telegram_conflict.py tests/gateway/test_telegram_start_polling_timeout.py tests/gateway/test_telegram_connect.py`
- [ ] Reproduce on Windows: force a Telegram `TimedOut` / `Bad Gateway`, confirm logs still show `updater.stop() timed out` then a client rebuild, and that new DMs arrive instead of a silent 48h hang.