### PR TITLE
feat(kanban): expose per-task reasoning on create

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -26,6 +26,7 @@ from typing import Any, Optional
 
 from hermes_cli import kanban_db as kb
 from hermes_cli import kanban_swarm as ks
+from hermes_constants import VALID_REASONING_EFFORTS
 
 
 # ---------------------------------------------------------------------------
@@ -78,6 +79,7 @@ def _task_to_dict(t: kb.Task) -> dict[str, Any]:
         "max_retries": t.max_retries,
         "model_override": t.model_override,
         "provider_override": t.provider_override,
+        "reasoning_effort": t.reasoning_effort,
         "session_id": t.session_id,
         "workflow_template_id": t.workflow_template_id,
         "current_step_key": t.current_step_key,
@@ -380,6 +382,16 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
                           help="Provider the --model belongs to (passed as "
                                "--provider <name> to the worker). Requires "
                                "--model.")
+    p_create.add_argument(
+        "--reasoning",
+        default=None,
+        dest="reasoning_effort",
+        choices=("none", *VALID_REASONING_EFFORTS),
+        help=(
+            "Override the worker's reasoning effort for this task. "
+            "Omit to inherit the assignee profile's configured level."
+        ),
+    )
     p_create.add_argument("--goal", action="store_true", dest="goal_mode",
                           help="Run the worker in a goal loop: after each "
                                "turn a judge checks the response against the "
@@ -1583,6 +1595,7 @@ def _cmd_create(args: argparse.Namespace) -> int:
             max_retries=max_retries,
             model_override=getattr(args, "model_override", None),
             provider_override=getattr(args, "provider_override", None),
+            reasoning_effort=getattr(args, "reasoning_effort", None),
             goal_mode=bool(getattr(args, "goal_mode", False)),
             goal_max_turns=getattr(args, "goal_max_turns", None),
             initial_status=getattr(args, "initial_status", "running"),

--- a/tests/hermes_cli/test_kanban_cli.py
+++ b/tests/hermes_cli/test_kanban_cli.py
@@ -57,6 +57,20 @@ def test_kanban_list_json_includes_session_id(kanban_home):
     )
 
 
+def test_create_accepts_per_task_reasoning_effort(kanban_home):
+    raw = kc.run_slash(
+        "create 'risk-sensitive task' --assignee reviewer "
+        "--reasoning xhigh --json"
+    )
+
+    task = json.loads(raw)
+    assert task["reasoning_effort"] == "xhigh"
+    with kb.connect_closing() as conn:
+        stored = kb.get_task(conn, task["id"])
+    assert stored is not None
+    assert stored.reasoning_effort == "xhigh"
+
+
 def test_kanban_show_text_renders_graph_with_open_connection(kanban_home):
     with kb.connect_closing() as conn:
         parent_id = kb.create_task(conn, title="parent task")

--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -416,6 +416,27 @@ def test_create_happy_path(worker_env):
         conn.close()
 
 
+def test_create_accepts_per_task_reasoning_effort(worker_env):
+    from hermes_constants import VALID_REASONING_EFFORTS
+    from tools import kanban_tools as kt
+
+    prop = kt.KANBAN_CREATE_SCHEMA["parameters"]["properties"]["reasoning_effort"]
+    assert prop["enum"] == ["none", *VALID_REASONING_EFFORTS]
+
+    out = kt._handle_create({
+        "title": "critical review",
+        "assignee": "reviewer",
+        "reasoning_effort": "xhigh",
+    })
+    task_id = json.loads(out)["task_id"]
+
+    from hermes_cli import kanban_db as kb
+    with kb.connect_closing() as conn:
+        task = kb.get_task(conn, task_id)
+    assert task is not None
+    assert task.reasoning_effort == "xhigh"
+
+
 def test_link_happy_path(worker_env):
     from hermes_cli import kanban_db as kb
     conn = kb.connect()

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -35,6 +35,7 @@ from typing import Any, Optional
 
 from agent.redact import redact_sensitive_text
 from hermes_cli.goals import judge_goal
+from hermes_constants import VALID_REASONING_EFFORTS
 from tools.registry import registry, tool_error
 from hermes_cli.config import cfg_get, load_config
 
@@ -1411,6 +1412,7 @@ def _handle_create(args: dict, **kw) -> str:
     goal_max_turns = args.get("goal_max_turns")
     model_override = args.get("model")
     provider_override = args.get("provider")
+    reasoning_effort = args.get("reasoning_effort")
     if provider_override and not model_override:
         return tool_error("'provider' requires 'model' to be set as well")
     if isinstance(parents, str):
@@ -1454,6 +1456,7 @@ def _handle_create(args: dict, **kw) -> str:
                 skills=skills,
                 model_override=model_override,
                 provider_override=provider_override,
+                reasoning_effort=reasoning_effort,
                 goal_mode=goal_mode,
                 goal_max_turns=(
                     int(goal_max_turns) if goal_max_turns is not None else None
@@ -2301,6 +2304,15 @@ KANBAN_CREATE_SCHEMA = {
                     "provider — a model name alone is resolved against "
                     "the profile's provider and will fail if it belongs "
                     "to a different one. Requires 'model'."
+                ),
+            },
+            "reasoning_effort": {
+                "type": "string",
+                "enum": ["none", *VALID_REASONING_EFFORTS],
+                "description": (
+                    "Override the dispatched worker's reasoning effort for "
+                    "this task. Omit to inherit the assignee profile's "
+                    "configured level."
                 ),
             },
             "board": _board_schema_prop(),


### PR DESCRIPTION
## What does this PR do?

Hermes already stores a per-task `reasoning_effort` and forwards it to dispatched workers as `--reasoning`, but the CLI and `kanban_create` creation surfaces could not set that field.

This PR exposes the existing capability at creation time so orchestrators can choose reasoning depth before dispatch without a follow-up dashboard edit.

## Related Issue

None.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/kanban.py`: add `hermes kanban create --reasoning`, validate against the canonical effort values, pass the override to `create_task`, and expose `reasoning_effort` in task JSON.
- `tools/kanban_tools.py`: add `reasoning_effort` to the `kanban_create` schema and forward it through the existing persistence path.
- `tests/hermes_cli/test_kanban_cli.py`: verify CLI parsing, JSON output, and persistence.
- `tests/tools/test_kanban_tools.py`: verify schema alignment and tool-side persistence.

## How to Test

1. Run:

   ```bash
   scripts/run_tests.sh tests/hermes_cli/test_kanban_cli.py tests/tools/test_kanban_tools.py tests/plugins/test_kanban_model_override.py
   ```

2. Create a task:

   ```bash
   hermes kanban create "risk-sensitive task" --assignee reviewer --reasoning xhigh --json
   ```

3. Confirm the JSON contains `"reasoning_effort": "xhigh"` and that dispatch forwards `--reasoning xhigh` to the worker.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains only changes related to this feature
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on Debian GNU/Linux 13 with Python 3.13.5

### Documentation & Housekeeping

- [x] Relevant documentation update is N/A. The CLI help and tool schema descriptions are updated in place.
- [x] `cli-config.yaml.example` update is N/A. No config key changed.
- [x] `CONTRIBUTING.md` or `AGENTS.md` update is N/A. No architecture or workflow changed.
- [x] Cross-platform impact was considered. The change is limited to argparse, JSON serialization, and the existing platform-neutral database path.
- [x] The tool schema and description are updated.

## Test Results

- Affected suites: 56 passed, 0 failed.
- Ruff on all four changed files: passed.
- `git diff --check`: passed.
- Manual CLI smoke test persisted and returned `reasoning_effort: xhigh`.
- Independent read-only review: PASS with no material findings.

The full monolithic suite did not complete in this isolated environment. It reaches provider-specific tests that require optional SDKs not installed by `.[all,dev]`. The first such failure, `tests/agent/test_command_token_source.py::TestCallableKeyGetsBearerAuth::test_callable_takes_the_bearer_hook_path`, fails identically on clean `origin/main` because the optional `anthropic` package is absent. The focused Kanban regression suites above pass completely.
