### PR TITLE
fix(gateway): bind loop wakeups to their originating session

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -18829,6 +18829,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         expected_session_key = str(
             event_metadata.get("gateway_session_key") or ""
         ).strip()
+        pinned_session_id = str(event_metadata.get("gateway_session_id") or "").strip()
         if expected_session_key:
             derived_session_key = self._session_key_for_source(source)
             if derived_session_key != expected_session_key:
@@ -18838,10 +18839,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     expected_session_key,
                     derived_session_key,
                 )
+                self._clear_rejected_loop_wakeup(
+                    event_metadata,
+                    pinned_session_id,
+                )
                 return
 
         strict_session = bool(event_metadata.get("gateway_session_strict"))
-        pinned_session_id = str(event_metadata.get("gateway_session_id") or "").strip()
         if strict_session:
             session_entry = await self.async_session_store.lookup_by_session_key(
                 expected_session_key
@@ -18856,6 +18860,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     "longer current for key=%s",
                     pinned_session_id or "missing",
                     expected_session_key or "missing",
+                )
+                self._clear_rejected_loop_wakeup(
+                    event_metadata,
+                    pinned_session_id,
                 )
                 return
         else:
@@ -21628,6 +21636,32 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             return streamed
         return text
 
+    @staticmethod
+    def _clear_rejected_loop_wakeup(event_metadata: Any, session_id: str) -> None:
+        """Clear a loop whose strict internal wakeup was rejected.
+
+        The watcher claims a tick before handing it to an adapter.  If the
+        downstream strict-session gate rejects the event after a reset, the
+        old loop has no turn that could complete it; clear that stale state
+        instead of leaving it indefinitely ``awaiting_response``.
+        """
+        if (
+            not isinstance(event_metadata, dict)
+            or event_metadata.get("hermes_loop_wakeup") is not True
+            or not session_id
+        ):
+            return
+        try:
+            from hermes_cli.loops import LoopManager
+
+            LoopManager(session_id=session_id).clear()
+        except Exception:
+            logger.warning(
+                "Failed to clear rejected loop wakeup for session %s",
+                session_id,
+                exc_info=True,
+            )
+
     async def _post_turn_loop_completion(
         self,
         *,
@@ -21741,8 +21775,42 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     try:
                         session_key = self._session_key_for_source(source)
                     except Exception:
-                        session_key = None
-                    if session_key and session_key in self._running_agents:
+                        logger.warning(
+                            "loop wakeup: failed to resolve a session key for %s; "
+                            "retaining the loop for retry",
+                            sid,
+                            exc_info=True,
+                        )
+                        continue
+                    if not session_key:
+                        logger.warning(
+                            "loop wakeup: unable to resolve a session key for %s; "
+                            "retaining the loop for retry",
+                            sid,
+                        )
+                        continue
+                    try:
+                        current_entry = await self.async_session_store.lookup_by_session_key(
+                            session_key
+                        )
+                    except Exception:
+                        logger.warning(
+                            "loop wakeup: failed to verify the current session for %s; "
+                            "retaining the loop for retry",
+                            sid,
+                            exc_info=True,
+                        )
+                        continue
+                    if current_entry is None or current_entry.session_id != sid:
+                        logger.info(
+                            "loop wakeup: session %s is no longer current for key %s; "
+                            "clearing the old loop",
+                            sid,
+                            session_key,
+                        )
+                        LoopManager(session_id=sid).clear()
+                        continue
+                    if session_key in self._running_agents:
                         continue  # busy — stays due, next scan retries
                     if goal_blocks_loop_tick(sid):
                         continue
@@ -21759,6 +21827,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                             message_type=MessageType.TEXT,
                             source=source,
                             internal=True,
+                            metadata={
+                                "gateway_session_key": session_key,
+                                "gateway_session_id": sid,
+                                "gateway_session_strict": True,
+                                "hermes_loop_wakeup": True,
+                            },
                         )
                         logger.info(
                             "loop wakeup #%s — injecting for %s chat=%s thread=%s",

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -159,6 +159,24 @@ class GatewaySlashCommandsMixin:
         # expiring session id before reset_session() rotates it.
         old_entry = self.session_store._entries.get(session_key)
 
+        # A /loop belongs to the durable session id, rather than its stable
+        # route key.  Clear it before the reset's first await: a concurrent
+        # wakeup must not inherit the freshly-created /new conversation.
+        # Compression deliberately remains separate because its explicit
+        # migration path carries a loop to its child session.
+        old_session_id = getattr(old_entry, "session_id", None)
+        if isinstance(old_session_id, str) and old_session_id:
+            try:
+                from hermes_cli.loops import LoopManager
+
+                LoopManager(session_id=old_session_id).clear()
+            except Exception:
+                logger.warning(
+                    "Failed to clear /loop state for session reset %s",
+                    session_key,
+                    exc_info=True,
+                )
+
         # Close tool resources on the old agent (terminal sandboxes, browser
         # daemons, background processes) before evicting from cache.
         # Guard with getattr because test fixtures may skip __init__.

--- a/hermes_cli/loops.py
+++ b/hermes_cli/loops.py
@@ -657,6 +657,7 @@ class LoopManager:
         if self._state is None or self._state.status == "cleared":
             return False
         self._state.status = "cleared"
+        self._state.awaiting_response = False
         save_loop(self.session_id, self._state)
         self._state = None
         return True

--- a/tests/gateway/test_35994_reset_button_deadlock.py
+++ b/tests/gateway/test_35994_reset_button_deadlock.py
@@ -198,3 +198,28 @@ async def test_reset_completes_when_cleanup_times_out(caplog):
     ), "expected the timeout warning to be logged"
     runner.session_store.reset_session.assert_called_once()
     assert result is not None
+
+
+@pytest.mark.asyncio
+async def test_reset_clears_the_outgoing_loop(tmp_path, monkeypatch):
+    """A user /new ends the old conversation's persistent /loop state."""
+    from hermes_cli import goals, loops
+
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    goals._DB_CACHE.clear()
+    try:
+        runner = _make_runner_with_cached_agent(lambda: None)
+        loops.LoopManager(session_id="sess-old").set(
+            "check the deployment", interval_seconds=60
+        )
+
+        result = await runner._handle_reset_command(_make_event("/new"))
+
+        state = loops.load_loop("sess-old")
+        assert result is not None
+        assert state is not None
+        assert state.status == "cleared"
+    finally:
+        goals._DB_CACHE.clear()

--- a/tests/gateway/test_loop_session_boundary.py
+++ b/tests/gateway/test_loop_session_boundary.py
@@ -1,0 +1,199 @@
+"""Session-boundary regression and in-process E2E coverage for gateway /loop.
+
+The end-to-end test uses the real SessionStore, persistent LoopManager state,
+and GatewayRunner wakeup watcher against a temporary HERMES_HOME.  The adapter
+is deliberately a local spy: the invariant under test is that a stale loop
+never reaches an outbound platform adapter after the route rotates.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from gateway.config import GatewayConfig, Platform, PlatformConfig
+from gateway.run import GatewayRunner
+from gateway.session import AsyncSessionStore, SessionSource, SessionStore
+from hermes_cli import goals, loops
+
+
+def _source() -> SessionSource:
+    return SessionSource(
+        platform=Platform.DISCORD,
+        chat_id="loop-channel",
+        chat_type="channel",
+        thread_id="loop-thread",
+        user_id="loop-user",
+        user_name="Loop owner",
+    )
+
+
+def _route() -> dict[str, str]:
+    return {
+        "platform": "discord",
+        "chat_id": "loop-channel",
+        "chat_type": "channel",
+        "thread_id": "loop-thread",
+        "user_id": "loop-user",
+        "user_name": "Loop owner",
+    }
+
+
+@pytest.fixture
+def loop_home(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    goals._DB_CACHE.clear()
+    yield home
+    goals._DB_CACHE.clear()
+
+
+def _make_store(tmp_path) -> SessionStore:
+    config = GatewayConfig(
+        platforms={Platform.DISCORD: PlatformConfig(enabled=True, token="test-token")}
+    )
+    return SessionStore(sessions_dir=tmp_path / "sessions", config=config)
+
+
+def _make_runner(store: SessionStore, adapter) -> GatewayRunner:
+    runner = object.__new__(GatewayRunner)
+    runner.config = store.config
+    runner.session_store = store
+    runner._async_session_store = AsyncSessionStore(store)
+    runner.adapters = {Platform.DISCORD: adapter}
+    runner._running = True
+    runner._running_agents = {}
+    return runner
+
+
+def _set_due_loop(session_id: str) -> None:
+    manager = loops.LoopManager(session_id=session_id)
+    state = manager.set("check the deployment", interval_seconds=60, route=_route())
+    state.next_due_at = time.time() - 1
+    loops.save_loop(session_id, state)
+
+
+async def _run_one_watcher_scan(monkeypatch, runner: GatewayRunner) -> None:
+    """Run the watcher's post-startup scan exactly once without wall-clock wait."""
+    sleep_calls = 0
+
+    async def _sleep_once(_delay: float) -> None:
+        nonlocal sleep_calls
+        sleep_calls += 1
+        if sleep_calls >= 2:
+            runner._running = False
+
+    monkeypatch.setattr("gateway.run.asyncio.sleep", _sleep_once)
+    await runner._loop_wakeup_watcher(interval=0)
+
+
+@pytest.mark.asyncio
+async def test_end_to_end_stale_loop_is_not_injected_after_reset(loop_home, monkeypatch):
+    """A due S1 loop must not become a turn in the replacement S2 session."""
+    store = _make_store(loop_home)
+    first_entry = store.get_or_create_session(_source())
+    _set_due_loop(first_entry.session_id)
+
+    replacement = store.reset_session(first_entry.session_key)
+    assert replacement is not None
+    assert replacement.session_id != first_entry.session_id
+
+    adapter = SimpleNamespace(handle_message=AsyncMock())
+    runner = _make_runner(store, adapter)
+    await _run_one_watcher_scan(monkeypatch, runner)
+
+    adapter.handle_message.assert_not_awaited()
+    stale = loops.load_loop(first_entry.session_id)
+    assert stale is not None
+    assert stale.status == "cleared"
+    assert stale.awaiting_response is False
+
+
+@pytest.mark.asyncio
+async def test_watcher_retains_due_loop_when_session_lookup_fails(loop_home, monkeypatch):
+    """A transient SessionStore failure must not destroy a healthy loop."""
+    store = _make_store(loop_home)
+    entry = store.get_or_create_session(_source())
+    _set_due_loop(entry.session_id)
+
+    adapter = SimpleNamespace(handle_message=AsyncMock())
+    runner = _make_runner(store, adapter)
+    runner._async_session_store.lookup_by_session_key = AsyncMock(
+        side_effect=RuntimeError("temporary database failure")
+    )
+    await _run_one_watcher_scan(monkeypatch, runner)
+
+    adapter.handle_message.assert_not_awaited()
+    retained = loops.load_loop(entry.session_id)
+    assert retained is not None
+    assert retained.status == "active"
+    assert retained.awaiting_response is False
+
+
+@pytest.mark.asyncio
+async def test_watcher_retains_due_loop_when_route_resolution_raises(loop_home, monkeypatch):
+    """An unverified route failure stays due for a later retry."""
+    store = _make_store(loop_home)
+    entry = store.get_or_create_session(_source())
+    _set_due_loop(entry.session_id)
+
+    adapter = SimpleNamespace(handle_message=AsyncMock())
+    runner = _make_runner(store, adapter)
+
+    def _raise_route_error(_source):
+        raise ValueError("temporary route failure")
+
+    monkeypatch.setattr(runner, "_session_key_for_source", _raise_route_error)
+    await _run_one_watcher_scan(monkeypatch, runner)
+
+    adapter.handle_message.assert_not_awaited()
+    retained = loops.load_loop(entry.session_id)
+    assert retained is not None
+    assert retained.status == "active"
+    assert retained.awaiting_response is False
+
+
+@pytest.mark.asyncio
+async def test_watcher_stamps_each_wakeup_with_its_exact_session(loop_home, monkeypatch):
+    """The adapter receives an event that the downstream strict gate can bind."""
+    store = _make_store(loop_home)
+    entry = store.get_or_create_session(_source())
+    _set_due_loop(entry.session_id)
+
+    adapter = SimpleNamespace(handle_message=AsyncMock())
+    runner = _make_runner(store, adapter)
+    await _run_one_watcher_scan(monkeypatch, runner)
+
+    adapter.handle_message.assert_awaited_once()
+    event = adapter.handle_message.await_args.args[0]
+    assert event.internal is True
+    assert event.metadata == {
+        "gateway_session_key": entry.session_key,
+        "gateway_session_id": entry.session_id,
+        "gateway_session_strict": True,
+        "hermes_loop_wakeup": True,
+    }
+
+
+def test_rejected_strict_wakeup_clears_claimed_loop(loop_home):
+    """A reset racing after watcher verification cannot leave an inert loop."""
+    session_id = "loop-race-session"
+    _set_due_loop(session_id)
+    manager = loops.LoopManager(session_id=session_id)
+    assert manager.fire_tick() is not None
+    assert manager.state is not None and manager.state.awaiting_response is True
+
+    GatewayRunner._clear_rejected_loop_wakeup(
+        {"hermes_loop_wakeup": True},
+        session_id,
+    )
+
+    cleared = loops.load_loop(session_id)
+    assert cleared is not None
+    assert cleared.status == "cleared"
+    assert cleared.awaiting_response is False


### PR DESCRIPTION
## Summary

A persisted `/loop` is owned by a durable session ID, while its captured route remains stable across `/new`. The gateway watcher previously rebuilt only the route, which could permit a due wakeup from the previous conversation to enter its replacement.

This change:

- verifies that the route still resolves to the loop's recorded session before claiming a wakeup;
- attaches existing strict-session metadata to every accepted wakeup, so a reset that races after verification is rejected before a new turn begins;
- clears the outgoing loop at `/new`, and clears a claimed wakeup if the strict gate rejects it; and
- preserves the explicit compression migration path.

## Validation

- `scripts/run_tests.sh tests/gateway/test_loop_session_boundary.py tests/gateway/test_35994_reset_button_deadlock.py tests/hermes_cli/test_loops.py -q`
  - 70 passed
  - includes an in-process end-to-end path through `SessionStore`, persisted `LoopManager` state, and the gateway wakeup watcher;
  - verifies that a stale loop is not submitted to an adapter after a reset;
  - verifies metadata binding and the concurrent-reset cleanup path.
- `python -m ruff check gateway/run.py gateway/slash_commands.py hermes_cli/loops.py tests/gateway/test_loop_session_boundary.py tests/gateway/test_35994_reset_button_deadlock.py`
- `python scripts/check-windows-footguns.py --diff upstream/main`

The end-to-end test uses a local adapter spy solely to prevent external messaging; the session store, persistent loop state, and watcher are real.