### PR TITLE
fix(tui): register configured hooks in gateway child

### DIFF
--- a/tests/tui_gateway/test_entry_shell_hooks.py
+++ b/tests/tui_gateway/test_entry_shell_hooks.py
@@ -1,0 +1,76 @@
+"""Regression coverage for declarative shell hooks in the stdio TUI."""
+
+from __future__ import annotations
+
+import io
+from pathlib import Path
+
+from agent import outbound_webhooks, shell_hooks
+from hermes_cli import plugins
+from hermes_cli import config as hermes_config
+from tui_gateway import entry
+
+
+def _run_main_to_eof(monkeypatch) -> None:
+    monkeypatch.setattr(entry, "_install_sidecar_publisher", lambda: None)
+    monkeypatch.setattr(entry, "ensure_mcp_discovery_started", lambda: None)
+    monkeypatch.setattr(entry, "resolve_skin", lambda: "default")
+    monkeypatch.setattr(entry.server, "_ensure_skin_watcher", lambda: None)
+    monkeypatch.setattr(entry, "write_json", lambda payload: True)
+    monkeypatch.setattr(entry, "handle_spurious_eof", lambda *args: False)
+    monkeypatch.setattr(entry.sys, "stdin", io.StringIO(""))
+    entry.main()
+
+
+def test_main_registers_terminal_policy_before_accepting_requests(
+    monkeypatch, tmp_path: Path,
+):
+    """The TUI must enforce the same configured pre-tool hook as CLI runs."""
+    policy = tmp_path / "terminal-policy.py"
+    policy.write_text(
+        "#!/usr/bin/env python3\n"
+        "import json, sys\n"
+        "payload = json.load(sys.stdin)\n"
+        "command = payload.get('tool_input', {}).get('command', '')\n"
+        "allowed = command.startswith('agent-browser ') and not any(\n"
+        "    token in command for token in ('&&', ';', '|')\n"
+        ")\n"
+        "if not allowed:\n"
+        "    print(json.dumps({'decision': 'block', 'reason': 'terminal policy'}))\n",
+        encoding="utf-8",
+    )
+    policy.chmod(0o755)
+
+    cfg = {
+        "hooks_auto_accept": True,
+        "hooks": {
+            "pre_tool_call": [
+                {"matcher": "terminal", "command": str(policy)},
+            ],
+        },
+    }
+    monkeypatch.setattr(hermes_config, "load_config", lambda: cfg)
+    monkeypatch.setattr(
+        "hermes_cli.model_switch.prewarm_picker_cache_async", lambda: None,
+    )
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "home"))
+    plugins._plugin_manager = plugins.PluginManager()
+    shell_hooks.reset_for_tests()
+    outbound_webhooks.reset_for_tests()
+
+    try:
+        _run_main_to_eof(monkeypatch)
+
+        for command in ("python3 check.py", "sleep 15", "agent-browser open x && sleep 1"):
+            assert plugins.get_pre_tool_call_block_message(
+                tool_name="terminal", args={"command": command},
+            ) == "terminal policy"
+
+        assert plugins.get_pre_tool_call_block_message(
+            tool_name="terminal",
+            args={"command": "agent-browser open https://www.ainclave.com/"},
+        ) is None
+    finally:
+        shell_hooks.reset_for_tests()
+        outbound_webhooks.reset_for_tests()
+        plugins._plugin_manager = None

--- a/tui_gateway/entry.py
+++ b/tui_gateway/entry.py
@@ -45,6 +45,31 @@ _mcp_discovery_thread = None
 _mcp_discovery_enabled = False
 
 
+def _register_configured_hooks() -> None:
+    """Register declarative hooks in the TUI gateway process.
+
+    ``hermes --tui`` launches this module in a child process.  Hook
+    registration performed by the parent CLI therefore does not carry into
+    the process that actually invokes tools.  Mirror the CLI and messaging
+    gateway startup paths here, before the first RPC request is accepted.
+    """
+    try:
+        from agent.outbound_webhooks import (
+            register_from_config as register_outbound_webhooks,
+        )
+        from agent.shell_hooks import register_from_config
+        from hermes_cli.config import load_config
+
+        hooks_cfg = load_config()
+        register_from_config(hooks_cfg, accept_hooks=False)
+        register_outbound_webhooks(hooks_cfg)
+    except Exception:
+        logger.debug(
+            "hook registration failed at TUI gateway startup",
+            exc_info=True,
+        )
+
+
 def _install_sidecar_publisher() -> None:
     """Mirror every dispatcher emit to the dashboard sidebar via WS.
 
@@ -419,6 +444,7 @@ def ensure_mcp_discovery_started() -> None:
 
 
 def main():
+    _register_configured_hooks()
     _install_sidecar_publisher()
 
     # MCP tool discovery — backgrounded so a slow or unreachable MCP server


### PR DESCRIPTION
## Summary
- register configured shell hooks and outbound webhooks inside the stdio TUI gateway child process
- run registration before the gateway accepts its first RPC request
- add end-to-end regression coverage for blocked terminal commands and an allowed direct browser command

## Root cause
`hermes --tui` runs tool calls in a separate `tui_gateway.entry` child process. Hook registration in the parent CLI is process-local, and the child never repeated it, so configured `pre_tool_call` hooks were absent from the process enforcing tool calls.

## Verification
- `HERMES_TEST_FILE_RETRIES=0 scripts/run_tests.sh tests/tui_gateway/test_entry_shell_hooks.py tests/tui_gateway/test_entry_picker_prewarm.py tests/tui_gateway/test_entry_import_off_main_thread.py tests/agent/test_shell_hooks.py tests/agent/test_shell_hooks_consent.py` (57 passed)
- `.venv/bin/ruff check tui_gateway/entry.py tests/tui_gateway/test_entry_shell_hooks.py`
- `git diff --check`