### PR TITLE
fix(gateway): clear pending clarify on /stop to stop swallowing next message

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -25887,6 +25887,24 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         _generation_at_interrupt = self._invalidate_session_run_generation(
             session_key, reason=invalidation_reason
         )
+        # Clear any pending clarify before the interrupted turn unwinds.
+        # /stop (and /new) must not leave a clarify entry registered: the
+        # turn is already dead, but the entry would keep the NEXT non-command
+        # message in this session intercepted as the clarify answer and
+        # swallowed (nothing is emitted because the turn is interrupted).
+        # clear_session also unblocks the agent thread parked in
+        # wait_for_response via the empty-string sentinel, so it drains
+        # instead of hanging until the clarify timeout.
+        try:
+            from tools.clarify_gateway import clear_session as _clear_clarify_session
+
+            _clear_clarify_session(session_key)
+        except Exception as e:  # pragma: no cover - defensive, mirrors approval cleanup
+            logger.debug(
+                "Failed to clear clarify state for interrupted session %s: %s",
+                session_key,
+                e,
+            )
         if _process_task_id and _process_baseline is not None:
             threading.Thread(
                 target=_reap_gateway_turn_processes,

--- a/tests/gateway/test_stop_clears_pending_clarify.py
+++ b/tests/gateway/test_stop_clears_pending_clarify.py
@@ -1,0 +1,134 @@
+"""Regression test: /stop must clear a pending clarify so the next
+non-command message is not swallowed as the interrupted turn's answer.
+
+When a turn is interrupted with /stop while the agent is blocked in a
+clarify (waiting for the user's reply), ``_interrupt_and_clear_session``
+used to leave the clarify entry registered.  The next non-command message
+in the session was then intercepted as the clarify response and dropped —
+the turn was already interrupted, so nothing was emitted and no new turn
+started (log fingerprint: ``Gateway intercepted clarify text response``
+followed by ``Turn ended: reason=interrupted_by_user ... response_len=0``).
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from gateway.config import Platform, PlatformConfig
+from gateway.platforms.base import BasePlatformAdapter, SendResult
+from gateway.session import SessionSource
+
+SESSION_KEY = "agent:main:slack:dm:D123:1111.2222"
+
+
+class _StubAdapter(BasePlatformAdapter):
+    def __init__(self):
+        super().__init__(PlatformConfig(enabled=True, token="test"), Platform.SLACK)
+
+    async def connect(self, *, is_reconnect: bool = False):
+        return True
+
+    async def disconnect(self):
+        pass
+
+    async def send(self, chat_id, content, reply_to=None, metadata=None):
+        return SendResult(success=True, message_id="m1")
+
+
+def _clear_clarify_state():
+    from tools import clarify_gateway as cm
+
+    with cm._lock:
+        cm._entries.clear()
+        cm._session_index.clear()
+        cm._notify_cbs.clear()
+
+
+def _make_runner():
+    from gateway.run import GatewayRunner
+
+    runner = GatewayRunner.__new__(GatewayRunner)
+    # No adapter — the test only asserts clarify cleanup, not adapter I/O.
+    runner._adapter_for_source = lambda source: None
+    # Mock the state-heavy internals so the test focuses on clarify cleanup.
+    runner._peek_session_state = MagicMock(return_value=None)
+    runner._invalidate_session_run_generation = MagicMock(return_value=2)
+    runner._release_running_agent_state = MagicMock()
+    runner._evict_cached_agent = MagicMock()
+    return runner
+
+
+def _source():
+    return SessionSource(
+        platform=Platform.SLACK,
+        chat_id="D123",
+        chat_type="dm",
+        user_id="U1",
+        thread_id="1111.2222",
+    )
+
+
+@pytest.mark.asyncio
+async def test_stop_interrupt_clears_open_ended_clarify():
+    """/stop must clear a pending open-ended clarify (awaiting_text=True)."""
+    _clear_clarify_state()
+    from tools import clarify_gateway as cm
+
+    runner = _make_runner()
+    entry = cm.register("cl-stop-open", SESSION_KEY, "need a token", None)
+    assert entry.awaiting_text is True
+    assert cm.get_pending_for_session(SESSION_KEY, include_choice_prompts=True) is not None
+
+    await runner._interrupt_and_clear_session(
+        SESSION_KEY,
+        _source(),
+        interrupt_reason="Stop requested",
+        invalidation_reason="stop_command",
+    )
+
+    # The pending clarify must be gone, and the blocked wait must have been
+    # unblocked with the empty-string sentinel (so the agent thread drains).
+    assert cm.get_pending_for_session(SESSION_KEY, include_choice_prompts=True) is None
+    assert entry.event.is_set()
+    assert entry.response == ""
+    _clear_clarify_state()
+
+
+@pytest.mark.asyncio
+async def test_stop_interrupt_clears_choice_clarify():
+    """/stop must clear a pending native multi-choice clarify too."""
+    _clear_clarify_state()
+    from tools import clarify_gateway as cm
+
+    runner = _make_runner()
+    entry = cm.register("cl-stop-choice", SESSION_KEY, "pick one", ["a", "b"])
+    assert entry.awaiting_text is False
+    assert cm.get_pending_for_session(SESSION_KEY, include_choice_prompts=True) is not None
+
+    await runner._interrupt_and_clear_session(
+        SESSION_KEY,
+        _source(),
+        interrupt_reason="Stop requested",
+        invalidation_reason="stop_command",
+    )
+
+    assert cm.get_pending_for_session(SESSION_KEY, include_choice_prompts=True) is None
+    assert entry.event.is_set()
+    assert entry.response == ""
+    _clear_clarify_state()
+
+
+@pytest.mark.asyncio
+async def test_interrupt_with_no_pending_clarify_is_noop():
+    """/stop with no clarify registered must still complete cleanly."""
+    _clear_clarify_state()
+
+    runner = _make_runner()
+    await runner._interrupt_and_clear_session(
+        SESSION_KEY,
+        _source(),
+        interrupt_reason="Stop requested",
+        invalidation_reason="stop_command",
+    )
+    # No exception raised and no clarify left behind.
+    _clear_clarify_state()


### PR DESCRIPTION
## Summary

When `/stop` interrupts a turn while the agent is blocked in a clarify (waiting for the user's reply), `_interrupt_and_clear_session` leaves the clarify entry registered in `tools/clarify_gateway`. The next non-command message in that session is then intercepted as the clarify answer and dropped — the turn was already interrupted, so nothing is emitted and no new turn starts. The user sees the agent go silent after `/stop` + `/model` + a follow-up message.

Log fingerprint:

```
Gateway intercepted clarify text response (session=..., id=...)
tool clarify completed (349.28s, ...)
Turn ended: reason=interrupted_by_user ... response_len=0
```

## Root cause

`/stop` → `_busy_stop_command` → `_interrupt_and_clear_session` hard-interrupts the agent, invalidates the run generation, releases the session lock, and evicts the cached agent — but never calls `tools.clarify_gateway.clear_session(session_key)`.

`/new` does not hit this because it additionally runs `_handle_reset_command`, which clears clarify state. `tools/clarify_gateway.clear_session`'s own docstring lists `/new`, gateway shutdown, and cached-agent eviction — `/stop` was simply missed.

Related but distinct: #62034 (Slack threaded follow-up swallowed by pending clarify) — same symptom family, different root cause.

## Fix

Clear the session's pending clarify in `_interrupt_and_clear_session`, right after invalidating the run generation, mirroring the existing approval cleanup. `clear_session` also unblocks the parked agent thread via the empty-string sentinel, so it drains instead of hanging until the clarify timeout.

## Test plan

- New regression tests in `tests/gateway/test_stop_clears_pending_clarify.py`:
  - open-ended clarify is cleared on /stop
  - native multi-choice clarify is cleared on /stop
  - /stop with no pending clarify is a no-op
- Verified the two core tests FAIL before the fix and PASS after.
- Related suites still pass (40 tests): `test_clarify_gateway.py`, `test_clarify_thread_followup_not_swallowed.py`, `test_clarify_active_session_bypass.py`, `test_clarify_progress_leak.py`.