### PR TITLE
feat(reasoning): soft replay family for loopback endpoints — preserve reasoning_content for local llama.cpp/vLLM, no pads

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -3788,13 +3788,32 @@ def copy_reasoning_content_for_api(agent, source_msg: dict, api_msg: dict) -> No
 
     Forwarder — the strip-vs-repad POLICY is owned by
     ``agent.message_sanitization.apply_reasoning_content_policy`` (audit F4);
-    this only supplies the agent's cached provider-direction flag.
+    this only supplies the agent's cached provider-direction flags.
     """
     from agent.message_sanitization import apply_reasoning_content_policy
 
     apply_reasoning_content_policy(
-        source_msg, api_msg, agent._needs_thinking_reasoning_pad()
+        source_msg, api_msg, agent._needs_thinking_reasoning_pad(),
+        soft_replay=agent._replays_reasoning_content(),
     )
+
+
+def replays_reasoning_content_for_agent(agent) -> bool:
+    """Cached soft-replay classification for the active provider.
+
+    Companion to the require-side pad cache: ``_replays_reasoning_content``
+    on AIAgent, resolved via ``agent.message_sanitization.
+    replays_reasoning_content`` (loopback-host table).
+    """
+    cached = getattr(agent, "_soft_replay_cache", None)
+    key = (agent.provider, getattr(agent, "_base_url_lower", agent.base_url))
+    if cached is not None and cached[0] == key:
+        return cached[1]
+    from agent.message_sanitization import replays_reasoning_content
+
+    result = replays_reasoning_content(agent.provider, agent.model, agent.base_url)
+    agent._soft_replay_cache = (key, result)
+    return result
 
 
 def reapply_reasoning_echo_for_provider(agent, api_messages: list) -> int:
@@ -3829,7 +3848,8 @@ def reapply_reasoning_echo_for_provider(agent, api_messages: list) -> int:
     from agent.message_sanitization import reapply_reasoning_echo
 
     return reapply_reasoning_echo(
-        api_messages, agent._needs_thinking_reasoning_pad()
+        api_messages, agent._needs_thinking_reasoning_pad(),
+        soft_replay=agent._replays_reasoning_content(),
     )
 
 

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -3806,7 +3806,7 @@ def replays_reasoning_content_for_agent(agent) -> bool:
     replays_reasoning_content`` (loopback-host table).
     """
     cached = getattr(agent, "_soft_replay_cache", None)
-    key = (agent.provider, getattr(agent, "_base_url_lower", agent.base_url))
+    key = (agent.provider, agent.model, getattr(agent, "_base_url_lower", agent.base_url))
     if cached is not None and cached[0] == key:
         return cached[1]
     from agent.message_sanitization import replays_reasoning_content

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -2480,7 +2480,10 @@ class ContextCompressor(ContextEngine):
         correction now covers the soft-replay family).
         """
         cached = getattr(self, "_replay_all_cache", None)
-        key = (self.provider, self.model, self.base_url)
+        try:
+            key = (self.provider, self.model, self.base_url)
+        except AttributeError:
+            key = None
         if cached is not None and cached[0] == key:
             return cached[1]
         result = False

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -1054,8 +1054,21 @@ def _estimate_msg_budget_tokens(msg: dict, charge_stale_thinking: bool = True) -
         tokens += _serialized_length_for_budget(msg.get(key)) // _CHARS_PER_TOKEN
     if not charge_stale_thinking:
         return tokens
-    for key in _NEWEST_TURN_ONLY_BUDGET_KEYS:
-        tokens += _serialized_length_for_budget(msg.get(key)) // _CHARS_PER_TOKEN
+    # Persisted assistant messages carry the same thinking text under BOTH
+    # 'reasoning' (internal trajectory key) and 'reasoning_content'
+    # (write-time promotion in chat_completion_helpers).  Only one of the
+    # two ships on any transport — summing both double-charges the turn,
+    # which for replay-all providers (require-side echo families and
+    # soft-replay loopback endpoints, where every turn's thinking is now
+    # charged) would recreate the #73624 overcharge this walk fixed.
+    # Charge the larger payload once.
+    tokens += max(
+        (
+            _serialized_length_for_budget(msg.get(key))
+            for key in _NEWEST_TURN_ONLY_BUDGET_KEYS
+        ),
+        default=0,
+    ) // _CHARS_PER_TOKEN
     # reasoning_details: charge only the thinking TEXT, never the signed /
     # base64 envelope (#73298 second site; mirrors the preflight estimator's
     # exclusion in model_metadata).  When the same thinking text already rides

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -2453,6 +2453,39 @@ class ContextCompressor(ContextEngine):
             if _effective_cap < self.threshold_tokens:
                 self.threshold_tokens = _effective_cap
 
+    def _replays_all_turn_thinking(self) -> bool:
+        """True when the active provider replays EVERY turn's thinking text.
+
+        The tail-budget walks (#73624) exempt stale ``reasoning`` /
+        ``reasoning_content`` from the charge on the assumption those bytes
+        are stripped at send time.  That assumption is per-transport: for
+        require-side echo families (DeepSeek/Kimi/MiMo) and soft-replay
+        loopback endpoints (local llama.cpp et al.), every assistant turn's
+        thinking ships on every request.  Exempting bytes that DO reach the
+        wire makes compression ineffective — the compacted context stays
+        larger than the budget walk believed (K3 incident #83247; the same
+        correction now covers the soft-replay family).
+        """
+        cached = getattr(self, "_replay_all_cache", None)
+        key = (self.provider, self.model, self.base_url)
+        if cached is not None and cached[0] == key:
+            return cached[1]
+        result = False
+        try:
+            from agent.message_sanitization import (
+                needs_reasoning_echo,
+                replays_reasoning_content,
+            )
+            result = bool(
+                needs_reasoning_echo(self.provider, self.model, self.base_url)
+                or replays_reasoning_content(
+                    self.provider, self.model, self.base_url)
+            )
+        except Exception:
+            result = False
+        self._replay_all_cache = (key, result)
+        return result
+
     @staticmethod
     def _effective_threshold_percent(
         context_length: int, threshold_percent: float,
@@ -3167,10 +3200,12 @@ class ContextCompressor(ContextEngine):
             # (#73624) — this boundary decides which tool results stay
             # prunable, and overcharging stale thinking shrinks that window.
             _newest_asst_idx = _last_assistant_index(result)
+            _replay_all_thinking = self._replays_all_turn_thinking()
             for i in range(len(result) - 1, -1, -1):
                 msg = result[i]
                 msg_tokens = _estimate_msg_budget_tokens(
-                    msg, charge_stale_thinking=(i == _newest_asst_idx)
+                    msg, charge_stale_thinking=(
+                        _replay_all_thinking or i == _newest_asst_idx)
                 )
                 if accumulated + msg_tokens > protect_tail_tokens and (len(result) - i) >= min_protect:
                     boundary = i
@@ -5551,12 +5586,17 @@ This compaction should PRIORITISE preserving all information related to the focu
         # fields any transport still replays (#73624) — every older turn's
         # reasoning/reasoning_content is stripped or padded at send time,
         # so charging it here spends tail budget on bytes that never ship.
+        # Exception: replay-all providers (require-side echo families and
+        # soft-replay loopback endpoints) ship every turn's thinking, so
+        # those bytes DO reach the wire and must stay charged (K3 #83247).
         _newest_asst_idx = _last_assistant_index(messages)
+        _replay_all_thinking = self._replays_all_turn_thinking()
 
         for i in range(n - 1, head_end - 1, -1):
             msg = messages[i]
             msg_tokens = _estimate_msg_budget_tokens(
-                msg, charge_stale_thinking=(i == _newest_asst_idx)
+                msg, charge_stale_thinking=(
+                    _replay_all_thinking or i == _newest_asst_idx)
             )
             # Stop once we exceed the soft ceiling (unless we haven't hit min_tail yet)
             if accumulated + msg_tokens > soft_ceiling and (n - i) >= min_tail:
@@ -5584,7 +5624,8 @@ This compaction should PRIORITISE preserving all information related to the focu
             for j in range(n - 1, head_end - 1, -1):
                 raw_msg = messages[j]
                 raw_tok = _estimate_msg_budget_tokens(
-                    raw_msg, charge_stale_thinking=(j == _newest_asst_idx)
+                    raw_msg, charge_stale_thinking=(
+                        _replay_all_thinking or j == _newest_asst_idx)
                 )
                 if raw_accumulated + raw_tok > raw_budget and (n - j) >= min_tail:
                     cut_idx = j

--- a/agent/message_sanitization.py
+++ b/agent/message_sanitization.py
@@ -663,6 +663,43 @@ _REASONING_ECHO_RULES: tuple = (
      ("api.xiaomimimo.com", "xiaomimimo.com")),
 )
 
+# Soft replay side: endpoints that ACCEPT ``reasoning_content`` on assistant
+# replay messages and ATTEND to it, but do not REQUIRE the field (no HTTP 400
+# when absent).  Replying back the model's own prior thinking measurably
+# improves multi-turn reasoning recall on these endpoints (llama.cpp
+# ``--reasoning-preserve`` serving Qwen3.8: paired A/B, see PR body), but the
+# replay contract is "preserve verbatim or omit" — NEVER fabricate a
+# placeholder, because fabricated pads pollute the preserved sequence these
+# backends serialize back into the context.
+#
+# Host-driven and loopback-only on purpose.  llama-server is a local binary
+# with no canonical public hostname; a model-substring match (e.g. "qwen")
+# would false-positive on every aggregator that re-exports qwen models over
+# an OpenAI-compat wire that drops the field.  Any user pointing Hermes at
+# their own llama.cpp/llama-swap/vLLM-style loopback endpoint gets replay;
+# nothing public changes behavior.
+_SOFT_REASONING_REPLAY_HOSTS = (
+    "localhost",
+    "127.0.0.1",
+    "::1",
+)
+
+
+def replays_reasoning_content(provider: Any, model: Any, base_url: Any) -> bool:
+    """True when the endpoint accepts-and-attends replayed reasoning_content.
+
+    Soft families differ from the require-side table above in both
+    directions: omitting the field is fine (no pad synthesis), and sending
+    the model's OWN prior reasoning is beneficial (cross-turn reasoning
+    continuity).  This classification is disjoint from
+    ``reasoning_echo_family`` by construction: require-side hosts are public
+    API domains, soft-replay hosts are loopback only.
+    """
+    from utils import base_url_hostname
+
+    host = base_url_hostname(base_url)
+    return host in _SOFT_REASONING_REPLAY_HOSTS
+
 
 def _family_rule(family: str) -> tuple:
     for rule in _REASONING_ECHO_RULES:
@@ -712,13 +749,21 @@ def needs_reasoning_echo(provider: Any, model: Any, base_url: Any) -> bool:
 
 
 def apply_reasoning_content_policy(
-    source_msg: dict, api_msg: dict, needs_thinking_pad: bool
+    source_msg: dict, api_msg: dict, needs_thinking_pad: bool,
+    soft_replay: bool = False,
 ) -> None:
     """Copy provider-facing reasoning fields onto an API replay message.
 
     ``needs_thinking_pad`` is the require-side flag (see
     ``needs_reasoning_echo`` / the agent's cached
-    ``_needs_thinking_reasoning_pad``). Mutates ``api_msg`` in place.
+    ``_needs_thinking_reasoning_pad``).  ``soft_replay`` is the
+    accepts-and-attends flag (see ``replays_reasoning_content``) for
+    endpoints like a local llama.cpp server: preserve the model's own prior
+    reasoning verbatim, but never fabricate pads — omitting the field is
+    valid there.  When both flags could apply, require-side wins (a
+    require-side host never matches the loopback-only soft table, so the
+    combination is unreachable in practice; the guard keeps the policy
+    total).  Mutates ``api_msg`` in place.
     """
     if source_msg.get("role") != "assistant":
         return
@@ -743,10 +788,16 @@ def apply_reasoning_content_policy(
     # already-built api_messages path. Refs #45655.
     existing = source_msg.get("reasoning_content")
     if isinstance(existing, str):
-        if not needs_thinking_pad:
+        if not needs_thinking_pad and not soft_replay:
             api_msg.pop("reasoning_content", None)
         elif existing == "":
-            api_msg["reasoning_content"] = " "
+            # Require-side upgrades "" → " " (#17341).  Soft-replay side
+            # omits instead: an empty preserved block is noise the server
+            # would serialize back into context.
+            if needs_thinking_pad:
+                api_msg["reasoning_content"] = " "
+            else:
+                api_msg.pop("reasoning_content", None)
         else:
             api_msg["reasoning_content"] = existing
         return
@@ -762,24 +813,34 @@ def apply_reasoning_content_policy(
     # provider's chain of thought to DeepSeek/Kimi. Space (not "")
     # because DeepSeek V4 Pro rejects empty-string reasoning_content
     # in thinking mode (refs #17341).
+    #
+    # Soft-replay side strips the same shape instead: the foreign
+    # chain-of-thought is not this model's own output, and the soft
+    # contract is preserve-verbatim-or-omit (no fabrication, no foreign
+    # CoT laundering). Same-provider local history always carries
+    # reasoning_content pinned at write time, so this shape is foreign
+    # there too.
     normalized_reasoning = source_msg.get("reasoning")
     if (
-        needs_thinking_pad
-        and source_msg.get("tool_calls")
+        source_msg.get("tool_calls")
         and isinstance(normalized_reasoning, str)
         and normalized_reasoning
+        and (needs_thinking_pad or soft_replay)
     ):
-        api_msg["reasoning_content"] = " "
+        if needs_thinking_pad:
+            api_msg["reasoning_content"] = " "
+        else:
+            api_msg.pop("reasoning_content", None)
         return
 
     # 3. Healthy session: promote 'reasoning' field to 'reasoning_content'
     # for providers that use the internal 'reasoning' key.
     # This must happen before the unconditional empty-string fallback so
     # genuine reasoning content is not overwritten (#15812 regression in
-    # PR #15478). Only promote for providers that enforce echo-back —
-    # strict providers reject the field (refs #45655).
+    # PR #15478). Only promote for providers that enforce echo-back or
+    # soft-replay it — strict providers reject the field (refs #45655).
     if isinstance(normalized_reasoning, str) and normalized_reasoning:
-        if needs_thinking_pad:
+        if needs_thinking_pad or soft_replay:
             api_msg["reasoning_content"] = normalized_reasoning
         else:
             api_msg.pop("reasoning_content", None)
@@ -802,7 +863,9 @@ def apply_reasoning_content_policy(
     api_msg.pop("reasoning_content", None)
 
 
-def reapply_reasoning_echo(api_messages: list, needs_thinking_pad: bool) -> int:
+def reapply_reasoning_echo(
+    api_messages: list, needs_thinking_pad: bool, soft_replay: bool = False
+) -> int:
     """Re-pad (or strip) assistant turns' reasoning_content for the active provider.
 
     ``api_messages`` is built once, before the retry loop, while the *primary*
@@ -840,6 +903,17 @@ def reapply_reasoning_echo(api_messages: list, needs_thinking_pad: bool) -> int:
                 continue
             apply_reasoning_content_policy(api_msg, api_msg, needs_thinking_pad)
             if api_msg.get("reasoning_content"):
+                changed += 1
+        elif soft_replay:
+            # Soft replay: keep genuine preserved reasoning (non-empty,
+            # non-whitespace — a lone " " is a require-side pad, not model
+            # output), drop fabricated pads.  Never add anything: omitting
+            # the field is valid on these endpoints.
+            existing = api_msg.get("reasoning_content")
+            if isinstance(existing, str) and existing.strip():
+                continue
+            if "reasoning_content" in api_msg:
+                api_msg.pop("reasoning_content", None)
                 changed += 1
         else:
             # Strict provider — strip any stale reasoning_content pad left

--- a/agent/message_sanitization.py
+++ b/agent/message_sanitization.py
@@ -709,6 +709,14 @@ def replays_reasoning_content(provider: Any, model: Any, base_url: Any) -> bool:
     continuity).  This classification is disjoint from
     ``reasoning_echo_family`` by construction: require-side hosts are public
     API domains, soft-replay hosts are loopback only.
+
+    Boundary: a REMOTE self-hosted endpoint (e.g. a vLLM box on the LAN or
+    a rented GPU box over Tailscale) that accepts-and-attends the field is
+    deliberately classified strict here and gets the strip path — loopback
+    is the only host shape we can auto-detect without false positives on
+    aggregators that silently drop the field.  A config override for
+    non-loopback endpoints can layer on the tri-state introduced by this
+    family (see PR #87123 discussion).
     """
     from utils import base_url_hostname
 

--- a/agent/message_sanitization.py
+++ b/agent/message_sanitization.py
@@ -680,9 +680,24 @@ _REASONING_ECHO_RULES: tuple = (
 # nothing public changes behavior.
 _SOFT_REASONING_REPLAY_HOSTS = (
     "localhost",
-    "127.0.0.1",
     "::1",
 )
+
+
+def _is_loopback_host(host: str) -> bool:
+    """True for loopback host forms: localhost, any 127.0.0.0/8 address,
+    IPv4-mapped loopback (::ffff:127.x.x.x), and unspecified 0.0.0.0 / ::
+    (llama-server binds 0.0.0.0 and clients sometimes address it that way)."""
+    import ipaddress
+
+    if not host:
+        return False
+    if host == "localhost" or host.endswith(".localhost"):
+        return True
+    try:
+        return ipaddress.ip_address(host).is_loopback or host == "0.0.0.0"
+    except ValueError:
+        return False
 
 
 def replays_reasoning_content(provider: Any, model: Any, base_url: Any) -> bool:
@@ -697,8 +712,7 @@ def replays_reasoning_content(provider: Any, model: Any, base_url: Any) -> bool:
     """
     from utils import base_url_hostname
 
-    host = base_url_hostname(base_url)
-    return host in _SOFT_REASONING_REPLAY_HOSTS
+    return _is_loopback_host(base_url_hostname(base_url))
 
 
 def _family_rule(family: str) -> tuple:

--- a/run_agent.py
+++ b/run_agent.py
@@ -7770,6 +7770,18 @@ class AIAgent:
         from agent.agent_runtime_helpers import copy_reasoning_content_for_api
         return copy_reasoning_content_for_api(self, source_msg, api_msg)
 
+    def _replays_reasoning_content(self) -> bool:
+        """Forwarder — see ``agent.agent_runtime_helpers.replays_reasoning_content_for_agent``.
+
+        Soft-replay classification (accepts-and-attends ``reasoning_content``
+        on replay, no requirement, no pads): loopback-host endpoints such as
+        a local llama.cpp server.  Independent of the require-side
+        ``_needs_thinking_reasoning_pad`` flag so a soft endpoint never
+        triggers pad fabrication and a strict-provider fallback still strips.
+        """
+        from agent.agent_runtime_helpers import replays_reasoning_content_for_agent
+        return replays_reasoning_content_for_agent(self)
+
     def _reapply_reasoning_echo_for_provider(self, api_messages: list) -> int:
         """Forwarder — see ``agent.agent_runtime_helpers.reapply_reasoning_echo_for_provider``."""
         from agent.agent_runtime_helpers import reapply_reasoning_echo_for_provider

--- a/tests/agent/test_compressor_replay_awareness.py
+++ b/tests/agent/test_compressor_replay_awareness.py
@@ -28,3 +28,32 @@ class TestCompressorReplayAllAwareness:
         # a different stub for a strict provider evaluates independently
         assert _stub("mistral", "m", "https://api.mistral.ai/v1") \
             ._replays_all_turn_thinking() is False
+
+
+class TestAgentSoftReplayCacheKey:
+    """The agent-side cache key must match the classifier signature
+    (provider, model, base_url) — same triplet as the require-side pad
+    cache and _replays_all_turn_thinking.  A model change alone must
+    invalidate a warm entry, so a future model-dependent rule cannot
+    serve a stale answer (review point on PR #87123)."""
+
+    class _Agent:
+        _soft_replay_cache = None  # warmed dynamically by the helper
+
+        def __init__(self, provider, model, base_url):
+            self.provider, self.model, self.base_url = provider, model, base_url
+
+    def test_model_change_invalidates_warm_cache(self):
+        from agent.agent_runtime_helpers import replays_reasoning_content_for_agent
+
+        agent = self._Agent("local", "qwen-a", "http://localhost:8081/v1")
+        assert replays_reasoning_content_for_agent(agent) is True
+        warm = getattr(agent, "_soft_replay_cache")
+        assert warm is not None and warm[0] == ("local", "qwen-a", "http://localhost:8081/v1")
+        # swap model only — classification is host-based so the answer is
+        # still True, but the warm entry must NOT be served: it must be
+        # re-evaluated under the new triplet
+        agent.model = "qwen-b"
+        assert replays_reasoning_content_for_agent(agent) is True
+        warm = getattr(agent, "_soft_replay_cache")
+        assert warm is not None and warm[0] == ("local", "qwen-b", "http://localhost:8081/v1")

--- a/tests/agent/test_compressor_replay_awareness.py
+++ b/tests/agent/test_compressor_replay_awareness.py
@@ -1,0 +1,30 @@
+"""Compressor replay-awareness tests for _replays_all_turn_thinking."""
+from agent.context_compressor import ContextCompressor
+
+
+def _stub(provider, model, base_url):
+    cc = object.__new__(ContextCompressor)
+    cc.provider, cc.model, cc.base_url = provider, model, base_url
+    return cc
+
+
+class TestCompressorReplayAllAwareness:
+    def test_soft_replay_loopback(self):
+        cc = _stub("local", "qwen", "http://localhost:8081/v1")
+        assert cc._replays_all_turn_thinking() is True
+
+    def test_require_side_echo_family(self):
+        cc = _stub("deepseek", "d", "https://api.deepseek.com")
+        assert cc._replays_all_turn_thinking() is True
+
+    def test_strict_indifferent(self):
+        cc = _stub("openai", "gpt-5", "https://api.openai.com/v1")
+        assert cc._replays_all_turn_thinking() is False
+
+    def test_result_cached_per_provider_triplet(self):
+        cc = _stub("local", "qwen", "http://localhost:8081/v1")
+        assert cc._replays_all_turn_thinking() is True
+        assert cc._replay_all_cache is not None  # warm
+        # a different stub for a strict provider evaluates independently
+        assert _stub("mistral", "m", "https://api.mistral.ai/v1") \
+            ._replays_all_turn_thinking() is False

--- a/tests/agent/test_compressor_replay_awareness.py
+++ b/tests/agent/test_compressor_replay_awareness.py
@@ -1,5 +1,10 @@
-"""Compressor replay-awareness tests for _replays_all_turn_thinking."""
-from agent.context_compressor import ContextCompressor
+"""Compressor replay-awareness tests: _replays_all_turn_thinking and the
+duplicate-alias charge in the tail-protection budget walks."""
+from agent.context_compressor import (
+    ContextCompressor,
+    _CHARS_PER_TOKEN,
+    _estimate_msg_budget_tokens,
+)
 
 
 def _stub(provider, model, base_url):
@@ -57,3 +62,60 @@ class TestAgentSoftReplayCacheKey:
         assert replays_reasoning_content_for_agent(agent) is True
         warm = getattr(agent, "_soft_replay_cache")
         assert warm is not None and warm[0] == ("local", "qwen-b", "http://localhost:8081/v1")
+
+
+class TestDuplicateAliasCharge:
+    """Persisted assistant messages carry the same thinking text under BOTH
+    'reasoning' and 'reasoning_content' (write-time promotion).  Only one
+    ships on any transport, so the tail budget must charge it once —
+    summing both recreates the #73624 overcharge the walks fixed.  Pinned
+    per the estimator/provenance case raised in the PR #87123 discussion."""
+
+    def test_identical_aliases_charged_once(self):
+        cot = "t" * (_CHARS_PER_TOKEN * 40)  # 40 tokens of thinking
+        msg = {"role": "assistant", "content": "hi",
+               "reasoning": cot, "reasoning_content": cot}
+        charged = _estimate_msg_budget_tokens(msg, charge_stale_thinking=True)
+        # content ("hi" -> ~10) + exactly one 40-token thinking charge
+        assert charged < 10 + 40 + 5  # strictly less than a doubled charge
+        assert charged >= 10 + 40  # and never undercharged
+
+    def test_larger_alias_wins_not_sum(self):
+        # Asymmetric aliases: the max() must pick the larger payload once,
+        # never sum (a sum would land between double-small and double-large).
+        small = "s" * (_CHARS_PER_TOKEN * 10)
+        large = "l" * (_CHARS_PER_TOKEN * 100)
+        msg = {"role": "assistant", "content": "",
+               "reasoning": small, "reasoning_content": large}
+        charged = _estimate_msg_budget_tokens(msg, charge_stale_thinking=True)
+        assert 100 + 10 <= charged < 10 + 100 + 90  # < small+large
+
+    def test_single_alias_unchanged(self):
+        # No duplication: one reasoning field charges exactly once.
+        cot = "x" * (_CHARS_PER_TOKEN * 50)
+        one = _estimate_msg_budget_tokens(
+            {"role": "assistant", "content": "", "reasoning": cot},
+            charge_stale_thinking=True)
+        both = _estimate_msg_budget_tokens(
+            {"role": "assistant", "content": "",
+             "reasoning": cot, "reasoning_content": cot},
+            charge_stale_thinking=True)
+        assert one == both
+
+    def test_scaled_history_no_double_charge(self):
+        # Scaled version of the discussion fixture: a few hundred assistant
+        # rows with byte-identical reasoning/reasoning_content, as persisted
+        # by a soft-replay local session.  The per-message dedupe must hold
+        # at volume: per-message charge identical to the single-alias shape.
+        cot = "c" * (_CHARS_PER_TOKEN * 20)
+        dup = {"role": "assistant", "content": "a",
+               "reasoning": cot, "reasoning_content": cot}
+        single = {"role": "assistant", "content": "a", "reasoning": cot}
+        per_dup = _estimate_msg_budget_tokens(dup, charge_stale_thinking=True)
+        per_single = _estimate_msg_budget_tokens(single, charge_stale_thinking=True)
+        assert per_dup == per_single
+        # 300 rows: no accumulation drift from the alias duplication
+        total = sum(
+            _estimate_msg_budget_tokens(
+                {**dup}, charge_stale_thinking=True) for _ in range(300))
+        assert total == 300 * per_dup

--- a/tests/agent/test_message_sanitization_policy.py
+++ b/tests/agent/test_message_sanitization_policy.py
@@ -410,3 +410,45 @@ class TestReapplyReasoningEchoSoft:
         msgs = copy.deepcopy(self.MSGS)
         reapply_reasoning_echo(msgs, False, soft_replay=True)
         assert reapply_reasoning_echo(msgs, False, soft_replay=True) == 0
+
+
+class TestSoftToStrictFallbackNoLeak:
+    """The local→strict provider fallback boundary (PR #87123 discussion):
+    history persisted under a soft-replay loopback primary carries
+    reasoning_content on every assistant turn.  When the request falls
+    back to a strict provider (Mistral/Cerebras/Groq reject the field
+    with 400/422), reapply_reasoning_echo must strip every trace —
+    genuine preserved reasoning included — so nothing leaks to the wire."""
+
+    # A soft-replay session's history: genuine CoT preserved verbatim.
+    SOFT_MSGS = [
+        {"role": "assistant", "content": "a1",
+         "reasoning_content": "genuine chain of thought"},
+        {"role": "assistant", "content": "a2", "reasoning_content": " "},
+        {"role": "assistant", "content": "a3"},  # bare turn, nothing to strip
+        {"role": "user", "content": "u"},
+    ]
+
+    def test_fallback_strips_genuine_reasoning_too(self):
+        import copy
+        msgs = copy.deepcopy(self.SOFT_MSGS)
+        changed = reapply_reasoning_echo(msgs, needs_thinking_pad=False)
+        assert changed == 2
+        assert all("reasoning_content" not in m for m in msgs)
+
+    def test_fallback_idempotent(self):
+        import copy
+        msgs = copy.deepcopy(self.SOFT_MSGS)
+        reapply_reasoning_echo(msgs, False)
+        assert reapply_reasoning_echo(msgs, False) == 0
+
+    def test_apply_policy_strict_strips_soft_shaped_history(self):
+        # The rebuild path (apply_reasoning_content_policy) on a message
+        # shaped by a soft primary: strict target must not carry the field.
+        api = {"role": "assistant", "content": "x",
+               "reasoning_content": "genuine CoT"}
+        apply_reasoning_content_policy(
+            {"role": "assistant", "content": "x",
+             "reasoning_content": "genuine CoT"},
+            api, needs_thinking_pad=False, soft_replay=False)
+        assert "reasoning_content" not in api

--- a/tests/agent/test_message_sanitization_policy.py
+++ b/tests/agent/test_message_sanitization_policy.py
@@ -19,6 +19,7 @@ from agent.message_sanitization import (
     needs_reasoning_echo,
     reapply_reasoning_echo,
     reasoning_echo_family,
+    replays_reasoning_content,
     uniquify_tool_call_ids,
 )
 
@@ -294,3 +295,114 @@ class TestReapplyReasoningEcho:
         assert reapply_reasoning_echo(msgs, True) == 0
         reapply_reasoning_echo(msgs, False)
         assert reapply_reasoning_echo(msgs, False) == 0
+
+
+# ---------------------------------------------------------------------------
+# soft replay family — loopback endpoints that accept-and-attend
+# reasoning_content without requiring it (local llama.cpp et al.)
+# ---------------------------------------------------------------------------
+
+class TestSoftReplayClassification:
+    @pytest.mark.parametrize("base_url", [
+        "http://localhost:8081/v1",
+        "http://127.0.0.1:8080/v1",
+        "http://[::1]:8080/v1",
+        "localhost:8081",
+    ])
+    def test_loopback_hosts_match(self, base_url):
+        assert replays_reasoning_content("local", "some-model", base_url) is True
+
+    @pytest.mark.parametrize("base_url", [
+        "https://api.openai.com/v1",
+        "https://api.mistral.ai/v1",
+        "https://qwen.example.com/v1",        # model-name-ish host: no match
+        "http://localhost.evil.example/v1",   # loopback as subdomain: no match
+        "https://my-localhost.demo/v1",
+        None,
+    ])
+    def test_non_loopback_no_match(self, base_url):
+        assert replays_reasoning_content("openai", "qwen3.8-27b", base_url) is False
+
+    def test_disjoint_from_require_side(self):
+        # A require-side host never matches the soft table and vice versa.
+        assert replays_reasoning_content(
+            "custom", None, "https://api.deepseek.com") is False
+        assert reasoning_echo_family(
+            "local", "qwen3.8", "http://localhost:8081/v1") is None
+
+
+class TestApplyPolicySoftReplay:
+    def test_soft_preserves_existing_reasoning(self):
+        api = {"role": "assistant", "content": "x"}
+        apply_reasoning_content_policy(
+            {"role": "assistant", "content": "x", "reasoning_content": "thoughts"},
+            api, needs_thinking_pad=False, soft_replay=True)
+        assert api["reasoning_content"] == "thoughts"
+
+    def test_soft_never_fabricates_pad_on_bare_turn(self):
+        # THE soft-family contract: no field -> no field.  A lone assistant
+        # turn with no reasoning must NOT gain a " " pad (branch 4 stays
+        # require-side-only).
+        api = {"role": "assistant", "content": "x"}
+        apply_reasoning_content_policy(
+            {"role": "assistant", "content": "x"}, api,
+            needs_thinking_pad=False, soft_replay=True)
+        assert "reasoning_content" not in api
+
+    def test_soft_drops_empty_string(self):
+        # "" is upgraded to " " only on require-side; soft omits.
+        api = {"role": "assistant", "content": "x", "reasoning_content": ""}
+        apply_reasoning_content_policy(
+            {"role": "assistant", "content": "x", "reasoning_content": ""}, api,
+            needs_thinking_pad=False, soft_replay=True)
+        assert "reasoning_content" not in api
+
+    def test_soft_does_not_pad_foreign_cot(self):
+        # Branch 2 (foreign CoT -> " " pad) is require-side-only.
+        src = {"role": "assistant", "content": "x", "reasoning": "other CoT",
+               "tool_calls": [{"id": "c", "function": {"name": "t",
+                                                       "arguments": "{}"}}]}
+        api = {"role": "assistant", "content": "x"}
+        apply_reasoning_content_policy(
+            src, api, needs_thinking_pad=False, soft_replay=True)
+        assert "reasoning_content" not in api
+
+    def test_soft_promotes_internal_reasoning_field(self):
+        # Same-provider history where thinking lives under 'reasoning'
+        # (write-time promotion missed it): promote, don't pad.
+        src = {"role": "assistant", "content": "x", "reasoning": "my thoughts"}
+        api = {"role": "assistant", "content": "x"}
+        apply_reasoning_content_policy(
+            src, api, needs_thinking_pad=False, soft_replay=True)
+        assert api["reasoning_content"] == "my thoughts"
+
+    def test_strict_default_unchanged(self):
+        # needs_thinking_pad=False, soft_replay=False -> historical strip.
+        api = {"role": "assistant", "content": "x", "reasoning_content": "t"}
+        apply_reasoning_content_policy(
+            {"role": "assistant", "content": "x", "reasoning_content": "t"},
+            api, needs_thinking_pad=False)
+        assert "reasoning_content" not in api
+
+
+class TestReapplyReasoningEchoSoft:
+    MSGS = [
+        {"role": "assistant", "content": "a1", "reasoning_content": "genuine CoT"},
+        {"role": "assistant", "content": "a2", "reasoning_content": " "},
+        {"role": "assistant", "content": "a3"},
+        {"role": "user", "content": "u"},
+    ]
+
+    def test_soft_keeps_genuine_drops_pads(self):
+        import copy
+        msgs = copy.deepcopy(self.MSGS)
+        assert reapply_reasoning_echo(msgs, False, soft_replay=True) == 1
+        assert msgs[0]["reasoning_content"] == "genuine CoT"
+        assert "reasoning_content" not in msgs[1]  # pad dropped
+        assert "reasoning_content" not in msgs[2]  # nothing added
+
+    def test_soft_idempotent(self):
+        import copy
+        msgs = copy.deepcopy(self.MSGS)
+        reapply_reasoning_echo(msgs, False, soft_replay=True)
+        assert reapply_reasoning_echo(msgs, False, soft_replay=True) == 0

--- a/tests/agent/test_message_sanitization_policy.py
+++ b/tests/agent/test_message_sanitization_policy.py
@@ -306,7 +306,10 @@ class TestSoftReplayClassification:
     @pytest.mark.parametrize("base_url", [
         "http://localhost:8081/v1",
         "http://127.0.0.1:8080/v1",
+        "http://127.8.9.10:8080/v1",           # any 127.0.0.0/8
         "http://[::1]:8080/v1",
+        "http://[::ffff:127.0.0.1]:8080/v1",   # IPv4-mapped loopback
+        "http://0.0.0.0:8080/v1",              # unspecified bind form
         "localhost:8081",
     ])
     def test_loopback_hosts_match(self, base_url):
@@ -318,6 +321,7 @@ class TestSoftReplayClassification:
         "https://qwen.example.com/v1",        # model-name-ish host: no match
         "http://localhost.evil.example/v1",   # loopback as subdomain: no match
         "https://my-localhost.demo/v1",
+        "http://192.168.1.5:8080/v1",         # LAN address: not loopback
         None,
     ])
     def test_non_loopback_no_match(self, base_url):


### PR DESCRIPTION
## Problem

Hermes strips `reasoning_content` from every replayed assistant message for providers outside the DeepSeek/Kimi/MiMo require-side table (`apply_reasoning_content_policy`, branch 1). That is correct for strict OpenAI-compatible providers (Mistral/Cerebras/Groq 422 on the field, #45655), but it throws away the model's own prior thinking on **local servers that accept AND attend to the field**: llama.cpp `--reasoning-preserve` (upstream llama.cpp #22615), vLLM, LM Studio.

Effect on agent loops: anything that only ever existed in thinking — multi-step plans, constraint tracking, decisions under ambiguity — is gone by the next turn. Server-side support alone doesn't help; the client must replay the field.

## What this PR does

**1. Soft replay classification** (`agent/message_sanitization.py`): `_SOFT_REASONING_REPLAY_HOSTS` loopback table (`localhost`, `127.0.0.1`, `::1`) + `replays_reasoning_content()`. Host-driven, no model substrings — a "qwen" substring would false-positive on every aggregator re-exporting qwen over a wire that drops the field. Disjoint from the require-side table by construction (public API hosts vs loopback only). Zero config: auto-detected from `base_url`, nothing public changes behavior.

**2. Tri-state policy** (`apply_reasoning_content_policy` + `reapply_reasoning_echo`): preserve-verbatim / promote-internal-`reasoning`, but **never fabricate pads**. Branches 2 (foreign-CoT `" "` pad) and 4 (bare-turn `" "` pad) stay require-side-only; on the soft side branch 2 *strips* the foreign chain-of-thought instead of padding it. The soft contract is preserve-or-omit: a missing field is valid, so a bare assistant turn stays bare.

**3. Fallback safety** (the concern raised in review of #76019): detection is per-provider via a cached `AIAgent._replays_reasoning_content()` (keyed like the existing pad cache), and `reapply_reasoning_echo_for_provider` re-evaluates it — so a mid-conversation fallback from a local endpoint to a strict provider still strips every field. No HTTP 400/422 leak.

**4. Compression interaction** (decided per K3 incident #83247): soft-replay providers ship every turn's thinking on every request, so the tail-budget walks' stale-thinking exemption (#73624) must not apply to them. `ContextCompressor._replays_all_turn_thinking()` now charges stale thinking for require-side echo families AND soft-replay loopback hosts, at all three `charge_stale_thinking` call sites. This also closes the pre-existing require-side gap: deepseek/kimi/mimo were equally exempt despite replaying all thinking.

## Evidence

**Paired A/B against a live llama-server** (Qwen3.8-27B UD-Q4_K_XL + mmproj + MTP draft, `--reasoning-preserve`, build 10441, Strix Halo). 4-turn agent-loop protocol where a code word is invented by the model **in turn-1 thinking only** (never in visible content), a tool-call turn and a pure-thinking planning turn intervene, and turn 4 requests the code:

| Arm | Recall success | t4 completion tokens |
|---|---|---|
| REPLAY (reasoning_content sent) | **10/10** | 187 |
| STRIP (field omitted = current Hermes behavior) | **0/9** | 512 |

All 9 valid pairs discordant in replay's favor; exact sign-test **p = 0.0039**. Scoring: turn-4 answer must appear verbatim in turn-1 *thinking* (identical rule for both arms, taint-guarded against visible-content leaks; 1 STRIP trial invalid — empty answer). STRIP also generated 2.7× more turn-4 thinking, re-planning from scratch what REPLAY could read, and its transcripts literally contain *"Since I can't actually see my previous private reasoning…"*.

Server-side serialization+attention was separately verified by secret-codeword probes (replayed field produces a +27-token structural delta and the model quotes a thinking-only word back verbatim). Hermes-side replay path verified live through `copy_reasoning_content_for_api`: genuine reasoning preserved for `provider=local`, stripped for `openai`, no pad fabricated on bare turns.

## Relation to prior art

- **#76019** (open): same goal via a config toggle. Two deltas here: (a) auto-detection means no config surface, and (b) the toggle ORs into `needs_thinking_pad`, which routes bare assistant turns into the branch-4 `" "` pad and foreign-CoT history into the branch-2 pad — the soft contract forbids fabrication; this PR's tri-state keeps those branches require-side-only. A toggle for non-loopback endpoints could layer cleanly on the tri-state introduced here.
- **#66640** (open): opposite direction (strip generic scratchpads harder, preserve `reasoning_details` envelopes) — compatible; touches the same policy function but no conflicting semantics.
- Upstream llama.cpp #22615 measured 58% vs 17% multi-turn recall on the qwen35 arch with replay serialized-and-attended, consistent with the A/B above.

## Tests

- `tests/agent/test_message_sanitization_policy.py`: +23 assertions — soft classification (loopback match incl. `[::1]` and bare-host forms, subdomain non-match, disjointness from require-side), tri-state policy (preserve, no-pad-on-bare-turn, empty-drops, foreign-CoT-strip, promote, strict default unchanged), soft `reapply_reasoning_echo` (keeps genuine, drops `" "` pads, idempotent).
- `tests/agent/test_compressor_replay_awareness.py`: new — classification triptych + per-provider cache behavior.
- Full touched surface green: 314 passed across sanitization policy, compressor replay-awareness, budget accounting, tail-cut suites, deepseek echo, provider parity, context compressor, compression fallback budget.
