### PR TITLE
fix(desktop): reject control characters in terminal launchers

### DIFF
--- a/apps/desktop/e2e/fixtures.ts
+++ b/apps/desktop/e2e/fixtures.ts
@@ -281,25 +281,38 @@ function assertDistBuilt(): void {
 
 /**
  * Find the Electron binary. In the nix devshell, `electron` is on PATH.
- * As a fallback, use the node_modules/.bin/electron from the desktop package.
+ * As a fallback, use the copy installed for the desktop workspace, then the
+ * repository-level installation used by older layouts.
  */
 export function findElectron(): string {
   // In dev mode, we use the `electron` binary directly (not the packaged app).
   // The dev:electron script in package.json does exactly this: `electron .`
   // after building. We replicate that here.
-  const localElectron = path.join(REPO_ROOT, 'node_modules', 'electron', 'dist', 'electron')
+  const executable = process.platform === 'win32' ? 'electron.exe' : 'electron'
 
-  if (fs.existsSync(localElectron)) {
-    return localElectron
+  const localElectrons = [
+    path.join(DESKTOP_ROOT, 'node_modules', 'electron', 'dist', executable),
+    path.join(REPO_ROOT, 'node_modules', 'electron', 'dist', executable),
+  ]
+
+  for (const localElectron of localElectrons) {
+    if (fs.existsSync(localElectron)) {
+      return localElectron
+    }
   }
 
   // Fall back to PATH
-  const result = spawnSync('which', ['electron'], {
+  const result = spawnSync(process.platform === 'win32' ? 'where' : 'which', [executable], {
     encoding: 'utf8',
   })
 
-  if (result.status === 0 && result.stdout.trim()) {
-    return result.stdout.trim()
+  const resolved = result.stdout
+    .split(/\r?\n/)
+    .map(candidate => candidate.trim())
+    .find(Boolean)
+
+  if (result.status === 0 && resolved) {
+    return resolved
   }
 
   throw new Error(

--- a/apps/desktop/e2e/terminal-input-boundary.spec.ts
+++ b/apps/desktop/e2e/terminal-input-boundary.spec.ts
@@ -1,0 +1,37 @@
+import { type MockBackendFixture, setupMockBackend, waitForAppReady } from './fixtures'
+import { expect, test } from './test'
+
+interface TerminalDesktopBridge {
+  openSessionInTerminal: (
+    sessionId: string,
+    opts?: { cwd?: string; profile?: string }
+  ) => Promise<{
+    ok: boolean
+    error?: string
+  }>
+}
+
+test('the external-terminal IPC rejects control-character inputs before launcher creation', async () => {
+  let fixture: MockBackendFixture | null = null
+
+  try {
+    fixture = await setupMockBackend()
+    await waitForAppReady(fixture)
+
+    const results = await fixture.page.evaluate(() => {
+      const desktop = (window as unknown as { hermesDesktop: TerminalDesktopBridge }).hermesDesktop
+
+      return Promise.all([
+        desktop.openSessionInTerminal('session\r\nstart calc.exe', { profile: 'default' }),
+        desktop.openSessionInTerminal('session', { profile: 'default\r\nstart calc.exe' })
+      ])
+    })
+
+    expect(results).toEqual([
+      { ok: false, error: 'invalid-session-id' },
+      { ok: false, error: 'invalid-profile' }
+    ])
+  } finally {
+    await fixture?.cleanup()
+  }
+})

--- a/apps/desktop/electron/external-terminal.test.ts
+++ b/apps/desktop/electron/external-terminal.test.ts
@@ -4,6 +4,7 @@ import { test } from 'vitest'
 
 import {
   buildTerminalScript,
+  containsTerminalControlCharacters,
   posixQuote,
   resolveTerminalLaunch,
   terminalScriptEnv,
@@ -21,6 +22,13 @@ test('tuiResumeArgs resumes the session in the TUI', () => {
 
 test('tuiResumeArgs pins the profile ahead of the mode flag', () => {
   assert.deepEqual(tuiResumeArgs('sess', 'work'), ['--profile', 'work', '--tui', '--resume', 'sess'])
+})
+
+test('terminal launch arguments reject control characters before they reach a script', () => {
+  assert.equal(containsTerminalControlCharacters('safe-session'), false)
+  assert.equal(containsTerminalControlCharacters('session\r\nstart calc.exe'), true)
+  assert.throws(() => tuiResumeArgs('session\r\nstart calc.exe'), /control characters/)
+  assert.throws(() => tuiResumeArgs('session', 'work\nset HERMES_HOME=C:\\other'), /control characters/)
 })
 
 test('posixQuote survives embedded single quotes', () => {
@@ -81,6 +89,50 @@ test('buildTerminalScript emits a cmd script on Windows', () => {
     '"C:\\hermes\\venv\\Scripts\\hermes.exe" "--tui" "--resume" "sess"',
     ''
   ])
+})
+
+test('buildTerminalScript rejects control characters in every Windows script field', () => {
+  const base = {
+    args: ['--tui', '--resume', 'session'],
+    command: 'C:\\hermes\\venv\\Scripts\\hermes.exe',
+    cwd: 'C:\\Users\\b',
+    env: { PYTHONUTF8: '1' },
+    platform: 'win32' as const
+  }
+
+  const unsafeScripts = [
+    () => buildTerminalScript({ ...base, command: 'C:\\hermes\r\nstart calc.exe' }),
+    () => buildTerminalScript({ ...base, args: ['--resume', 'session\r\nstart calc.exe'] }),
+    () => buildTerminalScript({ ...base, cwd: 'C:\\Users\\b\r\nstart calc.exe' }),
+    () => buildTerminalScript({ ...base, env: { 'PYTHONUTF8\r\nstart': '1' } }),
+    () => buildTerminalScript({ ...base, env: { PYTHONUTF8: '1\r\nstart calc.exe' } })
+  ]
+
+  for (const buildUnsafeScript of unsafeScripts) {
+    assert.throws(buildUnsafeScript, /control characters/)
+  }
+})
+
+test('buildTerminalScript rejects control characters in every POSIX script field', () => {
+  const base = {
+    args: ['--tui', '--resume', 'session'],
+    command: '/home/b/.hermes/venv/bin/hermes',
+    cwd: '/home/b',
+    env: { PYTHONUTF8: '1' },
+    platform: 'darwin' as const
+  }
+
+  const unsafeScripts = [
+    () => buildTerminalScript({ ...base, command: '/home/b/hermes\nopen Calculator' }),
+    () => buildTerminalScript({ ...base, args: ['--resume', 'session\nopen Calculator'] }),
+    () => buildTerminalScript({ ...base, cwd: '/home/b\nopen Calculator' }),
+    () => buildTerminalScript({ ...base, env: { 'PYTHONUTF8\nopen': '1' } }),
+    () => buildTerminalScript({ ...base, env: { PYTHONUTF8: '1\nopen Calculator' } })
+  ]
+
+  for (const buildUnsafeScript of unsafeScripts) {
+    assert.throws(buildUnsafeScript, /control characters/)
+  }
 })
 
 test('terminalScriptExtension matches what the platform binds to a terminal', () => {

--- a/apps/desktop/electron/external-terminal.ts
+++ b/apps/desktop/electron/external-terminal.ts
@@ -25,8 +25,39 @@
 // Everything here is pure so it can be unit-tested without Electron; the side
 // effects (writing the script, spawning) live in main.ts.
 
+/**
+ * A launcher script must never contain an embedded control character.
+ *
+ * In particular, CR or LF can terminate a launcher-script line before the
+ * shell processes the remainder. Keep this as a small, reusable predicate so
+ * both the IPC boundary and every script field can fail closed.
+ */
+export function containsTerminalControlCharacters(value: string): boolean {
+  for (const character of value) {
+    const codePoint = character.codePointAt(0)
+
+    if (codePoint !== undefined && (codePoint <= 0x1f || codePoint === 0x7f)) {
+      return true
+    }
+  }
+
+  return false
+}
+
+function assertSafeTerminalScriptValue(value: string): void {
+  if (containsTerminalControlCharacters(value)) {
+    throw new Error('Terminal launcher values must not contain control characters')
+  }
+}
+
 /** Argv for resuming a session in the TUI, profile-pinned when we know it. */
 export function tuiResumeArgs(sessionId: string, profile?: string): string[] {
+  assertSafeTerminalScriptValue(sessionId)
+
+  if (profile) {
+    assertSafeTerminalScriptValue(profile)
+  }
+
   const head = profile ? ['--profile', profile] : []
 
   return [...head, '--tui', '--resume', sessionId]
@@ -34,12 +65,18 @@ export function tuiResumeArgs(sessionId: string, profile?: string): string[] {
 
 /** Single-quote a value for /bin/sh (the POSIX launcher script). */
 export function posixQuote(value: string): string {
-  return `'${String(value ?? '').replaceAll("'", `'\\''`)}'`
+  const text = String(value ?? '')
+  assertSafeTerminalScriptValue(text)
+
+  return `'${text.replaceAll("'", `'\\''`)}'`
 }
 
 /** Quote a value for a cmd.exe script line. */
 export function windowsQuote(value: string): string {
-  return `"${String(value ?? '').replaceAll('"', '""')}"`
+  const text = String(value ?? '')
+  assertSafeTerminalScriptValue(text)
+
+  return `"${text.replaceAll('"', '""')}"`
 }
 
 /**
@@ -85,6 +122,10 @@ export interface TerminalScriptSpec {
  */
 export function buildTerminalScript({ command, args, cwd, env = {}, platform = process.platform }: TerminalScriptSpec) {
   const entries = Object.entries(env)
+
+  for (const [key] of entries) {
+    assertSafeTerminalScriptValue(key)
+  }
 
   if (platform === 'win32') {
     return [

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -136,6 +136,7 @@ import { installEmbedReferer } from './embed-referer'
 import { createEventDeduper } from './event-dedupe'
 import {
   buildTerminalScript,
+  containsTerminalControlCharacters,
   resolveTerminalLaunch,
   terminalScriptEnv,
   terminalScriptExtension,
@@ -12365,12 +12366,18 @@ ipcMain.handle('hermes:window:openInstance', async () => {
 // never ensureRuntime(), which would kick off a first-run install from a menu
 // click; an unresolved runtime is reported instead.
 ipcMain.handle('hermes:window:openInTerminal', async (_event, sessionId, opts) => {
-  if (typeof sessionId !== 'string' || !sessionId.trim()) {
+  if (typeof sessionId !== 'string' || !sessionId.trim() || containsTerminalControlCharacters(sessionId)) {
     return { ok: false, error: 'invalid-session-id' }
   }
 
+  const rawProfile = typeof opts?.profile === 'string' ? opts.profile : ''
+
+  if (rawProfile && containsTerminalControlCharacters(rawProfile)) {
+    return { ok: false, error: 'invalid-profile' }
+  }
+
   try {
-    const profile = typeof opts?.profile === 'string' ? opts.profile.trim() : ''
+    const profile = rawProfile.trim()
     const backend = resolveHermesBackend(tuiResumeArgs(sessionId.trim(), profile || undefined))
 
     if (!backend.command) {


### PR DESCRIPTION
## Summary

The external-terminal action composes a temporary launcher script. On Windows, a control character embedded in a session ID, profile, runtime command, argument, working directory, or environment entry could terminate a `.cmd` line before the existing quote handling applied.

This change:

- rejects control characters at the renderer-to-main IPC boundary for session IDs and profiles;
- validates every value written to a Windows launcher script, including runtime command, arguments, working directory, and environment key/value pairs; and
- preserves ordinary quoted arguments and the existing terminal-selection behaviour.

The E2E fixture now also locates Electron correctly from the Desktop workspace on Windows, including `electron.exe`, so this boundary is exercised by the real app rather than only by a pure-function test.

## Validation

- `npm exec -- vitest run --project electron electron/external-terminal.test.ts`
  - 16 passed
- `npm exec -- tsc -p tsconfig.electron.json --noEmit`
- `npm exec -- tsc -p tsconfig.e2e.json --noEmit`
- `npm exec -- eslint electron/external-terminal.ts electron/main.ts electron/external-terminal.test.ts e2e/terminal-input-boundary.spec.ts`
- `npm run build`
  - built from commit `fccfbb9ef6`
- `npm exec -- playwright test e2e/terminal-input-boundary.spec.ts --reporter=list`
  - 1 passed
  - launches the Windows Electron app and verifies that unsafe session and profile values are rejected by the real preload-to-main IPC path before launcher creation.
- `git diff --check upstream/main...HEAD`
