### PR TITLE
feat(kanban): add opt-in required goal judge policy

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -78,6 +78,9 @@ def _task_to_dict(t: kb.Task) -> dict[str, Any]:
         "max_retries": t.max_retries,
         "model_override": t.model_override,
         "provider_override": t.provider_override,
+        "goal_mode": t.goal_mode,
+        "goal_max_turns": t.goal_max_turns,
+        "goal_judge_policy": t.goal_judge_policy,
         "session_id": t.session_id,
         "workflow_template_id": t.workflow_template_id,
         "current_step_key": t.current_step_key,
@@ -393,6 +396,12 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
                           metavar="N", dest="goal_max_turns",
                           help="Turn budget for --goal workers (default 20). "
                                "Ignored without --goal.")
+    p_create.add_argument(
+        "--goal-judge-policy",
+        choices=sorted(kb.VALID_GOAL_JUDGE_POLICIES),
+        default="best_effort",
+        help="Goal completion judge policy (required needs --goal).",
+    )
     p_create.add_argument("--initial-status",
                           choices=sorted(kb.VALID_INITIAL_STATUSES),
                           default="running",
@@ -1555,6 +1564,12 @@ def _cmd_create(args: argparse.Namespace) -> int:
         print(f"kanban: --max-runtime: {exc}", file=sys.stderr)
         return 2
     max_retries = getattr(args, "max_retries", None)
+    if (
+        getattr(args, "goal_judge_policy", "best_effort") != "best_effort"
+        and not getattr(args, "goal_mode", False)
+    ):
+        print("kanban: --goal-judge-policy required requires --goal", file=sys.stderr)
+        return 2
     if max_retries is not None and max_retries < 1:
         print(
             f"kanban: --max-retries must be >= 1 (got {max_retries}); "
@@ -1585,6 +1600,7 @@ def _cmd_create(args: argparse.Namespace) -> int:
             provider_override=getattr(args, "provider_override", None),
             goal_mode=bool(getattr(args, "goal_mode", False)),
             goal_max_turns=getattr(args, "goal_max_turns", None),
+            goal_judge_policy=getattr(args, "goal_judge_policy", "best_effort"),
             initial_status=getattr(args, "initial_status", "running"),
         )
         task = kb.get_task(conn, task_id)
@@ -2279,18 +2295,68 @@ def _cmd_complete(args: argparse.Namespace) -> int:
             # to every terminal handoff so request-review cannot bypass the
             # acceptance contract that protects complete.
             task = kb.get_task(conn, tid)
-            rejection = _goal_mode_handoff_rejection(
-                task,
-                (summary or args.result or "").strip(),
-            )
-            if rejection is not None:
-                print(
-                    f"kanban: goal completion of {tid} rejected by judge: {rejection}. "
-                    f"Provide evidence matching the task's acceptance criteria.",
-                    file=sys.stderr,
-                )
+            decision = None
+            if task and task.status not in kb.COMPLETABLE_STATUSES:
                 failed.append(tid)
+                print(f"cannot complete {tid} (unknown id or terminal state)", file=sys.stderr)
                 continue
+            if task and task.goal_mode:
+                from hermes_cli.kanban_goal_judge import evaluate_goal_completion
+
+                def _available() -> bool:
+                    try:
+                        from agent.auxiliary_client import get_text_auxiliary_client
+
+                        client, model = get_text_auxiliary_client("goal_judge")
+                    except Exception:
+                        return False
+                    return client is not None and bool(model)
+
+                def _judge_goal(**kwargs):
+                    from hermes_cli.goals import judge_goal
+
+                    return judge_goal(**kwargs)
+
+                decision = evaluate_goal_completion(
+                    task, summary or args.result or "",
+                    judge_available=_available, judge=_judge_goal,
+                )
+                if decision.action == "block":
+                    run_id = _worker_run_id_for(tid)
+                    if run_id is None and task.status == "running":
+                        print(
+                            f"kanban: required goal judge failed closed for {tid}; "
+                            "no matching worker run is present, so task state was not changed",
+                            file=sys.stderr,
+                        )
+                        failed.append(tid)
+                        continue
+                    ok = kb.block_task(
+                        conn, tid, reason=decision.reason, kind="needs_input",
+                        expected_run_id=run_id,
+                    )
+                    resulting_task = kb.get_task(conn, tid) if ok else None
+                    resulting_state = (
+                        resulting_task.status
+                        if resulting_task is not None
+                        else ("missing" if ok else "unchanged")
+                    )
+                    print(
+                        f"kanban: required goal judge failed closed for {tid}: "
+                        f"{decision.reason}; resulting state: "
+                        f"{resulting_state}",
+                        file=sys.stderr,
+                    )
+                    failed.append(tid)
+                    continue
+                if decision.action == "reject":
+                    print(
+                        f"kanban: goal completion of {tid} rejected by judge: "
+                        f"{decision.reason}. Provide evidence matching the task's "
+                        "acceptance criteria.", file=sys.stderr,
+                    )
+                    failed.append(tid)
+                    continue
 
             if not kb.complete_task(
                 conn, tid,
@@ -2298,6 +2364,7 @@ def _cmd_complete(args: argparse.Namespace) -> int:
                 summary=summary,
                 metadata=metadata,
                 expected_run_id=_worker_run_id_for(tid),
+                goal_gate_passed=bool(decision and decision.action == "pass"),
             ):
                 failed.append(tid)
                 print(f"cannot complete {tid} (unknown id or terminal state)", file=sys.stderr)

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -123,6 +123,26 @@ VALID_INITIAL_STATUSES = {"running", "blocked"}
 # unblocking them only to have the worker re-block for the same reason.
 # ``None`` = legacy/un-typed block (treated as a generic human blocker).
 VALID_BLOCK_KINDS = {"dependency", "needs_input", "capability", "transient"}
+VALID_GOAL_JUDGE_POLICIES = {"best_effort", "required"}
+# Statuses that ``complete_task``'s terminal UPDATE accepts. ``review`` is in
+# the set because a human (or reviewer) can approve a task parked in the review
+# lane; the required-policy gate below therefore has to cover it too, otherwise
+# request-review would be a fail-open detour around the completion gate.
+COMPLETABLE_STATUSES = {"running", "ready", "blocked", "review"}
+
+
+class GoalJudgeRequiredError(RuntimeError):
+    """A required-policy task was completed without validated judge proof."""
+
+
+def _requires_goal_judge_proof(task, goal_gate_passed: bool) -> bool:
+    """True when ``task`` may not be completed without a positive judge decision."""
+    return (
+        task is not None
+        and task.status in COMPLETABLE_STATUSES
+        and getattr(task, "goal_judge_policy", "best_effort") == "required"
+        and not goal_gate_passed
+    )
 
 # After a task has been blocked, unblocked, and re-blocked this many times for
 # the same (truly-blocked) reason, the unblock-loop breaker stops trusting the
@@ -1128,6 +1148,7 @@ class Task:
     # Goal-loop turn budget for ``goal_mode`` workers. ``None`` falls
     # through to the goals engine default (``goals.DEFAULT_MAX_TURNS``).
     goal_max_turns: Optional[int] = None
+    goal_judge_policy: str = "best_effort"
     # Originating chat/agent session id, when the task was created from
     # within an agent loop that propagated ``HERMES_SESSION_ID``. NULL for
     # tasks created from the CLI, the dashboard, or any path that doesn't
@@ -1223,6 +1244,11 @@ class Task:
             ),
             goal_max_turns=(
                 row["goal_max_turns"] if "goal_max_turns" in keys and row["goal_max_turns"] else None
+            ),
+            goal_judge_policy=(
+                row["goal_judge_policy"]
+                if "goal_judge_policy" in keys and row["goal_judge_policy"]
+                else "best_effort"
             ),
             session_id=(
                 row["session_id"] if "session_id" in keys else None
@@ -1404,6 +1430,7 @@ CREATE TABLE IF NOT EXISTS tasks (
     -- Goal-loop turn budget for ``goal_mode`` workers. NULL = use the
     -- goals-engine default.
     goal_max_turns       INTEGER,
+    goal_judge_policy    TEXT NOT NULL DEFAULT 'best_effort',
     -- Originating chat/agent session id when the task was created from
     -- inside an agent loop that propagated ``HERMES_SESSION_ID``. NULL
     -- for tasks created from the CLI, dashboard, or any path that doesn't
@@ -2654,6 +2681,12 @@ def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
             conn, "tasks", "goal_max_turns", "goal_max_turns INTEGER"
         )
 
+    if "goal_judge_policy" not in cols:
+        _add_column_if_missing(
+            conn, "tasks", "goal_judge_policy",
+            "goal_judge_policy TEXT NOT NULL DEFAULT 'best_effort'",
+        )
+
     if "session_id" not in cols:
         # Originating agent/chat session id, populated when the task is
         # created from within an agent loop that propagated
@@ -3178,6 +3211,7 @@ def create_task(
     reasoning_effort: Optional[str] = None,
     goal_mode: bool = False,
     goal_max_turns: Optional[int] = None,
+    goal_judge_policy: str = "best_effort",
     initial_status: str = "running",
     session_id: Optional[str] = None,
     board: Optional[str] = None,
@@ -3228,6 +3262,13 @@ def create_task(
     reasoning_effort = normalize_reasoning_effort(reasoning_effort)
     if provider_override and not model_override:
         raise ValueError("provider_override requires a model_override")
+    if goal_judge_policy not in VALID_GOAL_JUDGE_POLICIES:
+        raise ValueError(
+            "goal_judge_policy must be one of "
+            f"{sorted(VALID_GOAL_JUDGE_POLICIES)}, got {goal_judge_policy!r}"
+        )
+    if goal_judge_policy == "required" and not goal_mode:
+        raise ValueError("goal_judge_policy='required' requires goal_mode=True")
     assignee = _canonical_assignee(assignee)
     if not title or not title.strip():
         raise ValueError("title is required")
@@ -3400,12 +3441,18 @@ def create_task(
     # insert, at which point both rows exist but the next lookup stabilises.
     if idempotency_key:
         row = conn.execute(
-            "SELECT id FROM tasks WHERE idempotency_key = ? "
+            "SELECT id, goal_judge_policy FROM tasks WHERE idempotency_key = ? "
             "AND status != 'archived' "
             "ORDER BY created_at DESC LIMIT 1",
             (idempotency_key,),
         ).fetchone()
         if row:
+            existing_policy = row["goal_judge_policy"] or "best_effort"
+            if existing_policy != goal_judge_policy:
+                raise ValueError(
+                    "idempotency_key already exists with goal_judge_policy="
+                    f"{existing_policy!r}; requested {goal_judge_policy!r}"
+                )
             return row["id"]
 
     now = int(time.time())
@@ -3497,8 +3544,8 @@ def create_task(
                         max_runtime_seconds,
                         skills, max_retries, model_override, provider_override,
                         reasoning_effort,
-                        goal_mode, goal_max_turns, session_id
-                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                        goal_mode, goal_max_turns, goal_judge_policy, session_id
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                     """,
                     (
                         task_id,
@@ -3523,6 +3570,7 @@ def create_task(
                         reasoning_effort,
                         1 if goal_mode else 0,
                         int(goal_max_turns) if goal_max_turns is not None else None,
+                        goal_judge_policy,
                         session_id,
                     ),
                 )
@@ -3550,6 +3598,7 @@ def create_task(
                         "project_id": project_id,
                         "skills": list(skills_list) if skills_list else None,
                         "goal_mode": bool(goal_mode) or None,
+                        "goal_judge_policy": goal_judge_policy,
                         "model_override": model_override,
                         "provider_override": provider_override,
                     },
@@ -5359,6 +5408,7 @@ def complete_task(
     created_cards: Optional[Iterable[str]] = None,
     expected_run_id: Optional[int] = None,
     fire_lifecycle_hook: bool = True,
+    goal_gate_passed: bool = False,
 ) -> bool:
     """Transition ``running|ready|blocked|review -> done`` and record ``result``.
 
@@ -5398,6 +5448,12 @@ def complete_task(
     if not _parents_satisfied(conn, task_id):
         return False
 
+    task = get_task(conn, task_id)
+    if _requires_goal_judge_proof(task, goal_gate_passed):
+        raise GoalJudgeRequiredError(
+            f"task {task_id} requires a positive goal judge decision"
+        )
+
     # Gate: verify created_cards BEFORE the main write txn. A rejected
     # completion still needs an auditable event, so we emit it in a
     # tiny dedicated txn, then raise. The caller is responsible for
@@ -5434,6 +5490,16 @@ def complete_task(
         # ``review`` or ``running``.
         if not _parents_satisfied(conn, task_id):
             return False
+        # Authoritative goal-judge gate under the SQLite write lock.  The
+        # earlier check is a fast rejection, but task status can change before
+        # this transaction begins (for example todo/triage -> ready in another
+        # process).  Re-read here so every status accepted by the terminal
+        # UPDATE is judged from the same locked state.
+        locked_task = get_task(conn, task_id)
+        if _requires_goal_judge_proof(locked_task, goal_gate_passed):
+            raise GoalJudgeRequiredError(
+                f"task {task_id} requires a positive goal judge decision"
+            )
         prior = conn.execute(
             "SELECT status FROM tasks WHERE id = ?",
             (task_id,),

--- a/hermes_cli/kanban_goal_judge.py
+++ b/hermes_cli/kanban_goal_judge.py
@@ -1,0 +1,75 @@
+"""Shared completion-gate decisions for Kanban goal-mode tasks."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable
+
+from agent.redact import redact_sensitive_text
+
+
+@dataclass(frozen=True)
+class GateDecision:
+    action: str  # pass | reject | block
+    reason: str = ""
+
+
+def _safe_reason(reason: object, fallback: str) -> str:
+    """Return a persistence/display-safe judge reason."""
+    text = str(reason or "").strip()
+    return redact_sensitive_text(text, force=True) if text else fallback
+
+
+def evaluate_goal_completion(
+    task,
+    response: str,
+    *,
+    judge_available: Callable[[], bool],
+    judge: Callable[..., tuple],
+) -> GateDecision:
+    """Evaluate once while preserving legacy best-effort fail-open behavior."""
+    # ``getattr`` keeps old fixtures/plugins that construct Task-like objects
+    # compatible with the additive column's default.
+    required = getattr(task, "goal_judge_policy", "best_effort") == "required"
+    if not task.goal_mode:
+        return GateDecision("pass")
+    try:
+        available = judge_available()
+    except Exception:
+        return GateDecision("block", "goal judge availability check failed") if required else GateDecision("pass")
+    if not available:
+        return GateDecision("block", "goal judge is unavailable") if required else GateDecision("pass")
+    try:
+        verdict, reason, parse_failed, wait_directive, transport_failed = judge(
+            goal=f"{task.title}\n\n{task.body or ''}".strip(),
+            last_response=(response or "").strip(),
+        )
+    except Exception:
+        return GateDecision("block", "goal judge evaluation failed") if required else GateDecision("pass")
+
+    if required:
+        if transport_failed:
+            return GateDecision("block", _safe_reason(reason, "goal judge transport failed"))
+        if parse_failed:
+            return GateDecision("block", _safe_reason(reason, "goal judge response could not be parsed"))
+        if verdict == "done":
+            return GateDecision("pass", _safe_reason(reason, "accepted"))
+        if verdict == "continue":
+            return GateDecision("reject", _safe_reason(reason, "goal is not complete"))
+        if verdict == "wait":
+            wait_reason = (
+                wait_directive.get("reason")
+                if isinstance(wait_directive, dict)
+                else None
+            )
+            return GateDecision(
+                "reject",
+                _safe_reason(wait_reason or reason, "goal judge requested a wait"),
+            )
+        return GateDecision("block", _safe_reason(reason, "unsupported goal judge verdict"))
+
+    # Exact legacy mapping: once a judge is reachable and returns normally,
+    # only the verdict controls the existing best-effort gate.
+    if verdict == "done":
+        return GateDecision("pass", _safe_reason(reason, "accepted"))
+    return GateDecision("reject", _safe_reason(reason, "goal is not complete"))

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -610,6 +610,7 @@ class CreateTaskBody(BaseModel):
     skills: Optional[list[str]] = None
     goal_mode: bool = False
     goal_max_turns: Optional[int] = None
+    goal_judge_policy: str = "best_effort"
     model_override: Optional[str] = None
     provider_override: Optional[str] = None
     # Per-task thinking depth (none|minimal|…|ultra). None = inherit the
@@ -642,6 +643,7 @@ def create_task(payload: CreateTaskBody, board: Optional[str] = Query(None)):
             skills=payload.skills,
             goal_mode=payload.goal_mode,
             goal_max_turns=payload.goal_max_turns,
+            goal_judge_policy=payload.goal_judge_policy,
             model_override=payload.model_override,
             provider_override=payload.provider_override,
             reasoning_effort=payload.reasoning_effort,
@@ -897,12 +899,15 @@ def update_task(task_id: str, payload: UpdateTaskBody, board: Optional[str] = Qu
             s = payload.status
             ok = True
             if s == "done":
-                ok = kanban_db.complete_task(
-                    conn, task_id,
-                    result=payload.result,
-                    summary=payload.summary,
-                    metadata=payload.metadata,
-                )
+                try:
+                    ok = kanban_db.complete_task(
+                        conn, task_id,
+                        result=payload.result,
+                        summary=payload.summary,
+                        metadata=payload.metadata,
+                    )
+                except kanban_db.GoalJudgeRequiredError as exc:
+                    raise HTTPException(status_code=409, detail=str(exc))
             elif s == "blocked":
                 ok = kanban_db.block_task(conn, task_id, reason=payload.block_reason)
             elif s == "scheduled":
@@ -1130,6 +1135,8 @@ def _set_status_direct(
     orphaned. ``running -> ready`` via drag-drop is the common case
     (user yanking a stuck worker back to the queue).
     """
+    if new_status == "done":
+        raise ValueError("direct status helper cannot set done; use complete_task")
     terminations: list[tuple[Optional[int], Optional[str]]] = []
     effective_status = new_status
     with kanban_db.write_txn(conn):
@@ -1446,6 +1453,12 @@ def bulk_update(payload: BulkTaskBody, board: Optional[str] = Query(None)):
                             entry.update(ok=False, error="reasoning override refused")
                     except (ValueError, RuntimeError) as e:
                         entry.update(ok=False, error=str(e))
+            except kanban_db.GoalJudgeRequiredError as e:
+                entry.update(
+                    ok=False,
+                    error_code="goal_judge_required",
+                    error=str(e),
+                )
             except Exception as e:  # defensive — one bad id shouldn't kill the batch
                 entry.update(ok=False, error=str(e))
             results.append(entry)

--- a/tests/hermes_cli/test_kanban_goal_judge_policy.py
+++ b/tests/hermes_cli/test_kanban_goal_judge_policy.py
@@ -1,0 +1,357 @@
+from __future__ import annotations
+
+import sqlite3
+import argparse
+import sys
+
+import pytest
+from types import SimpleNamespace
+
+from hermes_cli import kanban_db as kb
+
+
+@pytest.fixture
+def board(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    kb._INITIALIZED_PATHS.clear()
+    kb.init_db()
+    with kb.connect() as conn:
+        yield conn
+
+
+def test_policy_validation_and_required_round_trip(board):
+    with pytest.raises(ValueError, match="goal_judge_policy"):
+        kb.create_task(board, title="bad", goal_judge_policy="unknown")
+    with pytest.raises(ValueError, match="goal_mode"):
+        kb.create_task(board, title="bad", goal_judge_policy="required")
+
+    tid = kb.create_task(
+        board, title="guarded", goal_mode=True, goal_judge_policy="required"
+    )
+    assert kb.get_task(board, tid).goal_judge_policy == "required"
+
+
+def test_idempotency_rejects_policy_mismatch_but_preserves_compatible_duplicate(board):
+    tid = kb.create_task(
+        board, title="guarded", goal_mode=True, goal_judge_policy="required",
+        idempotency_key="same-request",
+    )
+    assert kb.create_task(
+        board, title="duplicate", goal_mode=True, goal_judge_policy="required",
+        idempotency_key="same-request",
+    ) == tid
+    with pytest.raises(ValueError, match="goal_judge_policy"):
+        kb.create_task(
+            board, title="unsafe duplicate", goal_mode=True,
+            goal_judge_policy="best_effort", idempotency_key="same-request",
+        )
+
+
+def test_required_completion_needs_central_proof(board):
+    tid = kb.create_task(
+        board, title="guarded", goal_mode=True, goal_judge_policy="required"
+    )
+    with pytest.raises(kb.GoalJudgeRequiredError):
+        kb.complete_task(board, tid, summary="claimed done")
+    assert kb.get_task(board, tid).status != "done"
+    assert kb.complete_task(board, tid, summary="proved", goal_gate_passed=True)
+    assert kb.get_task(board, tid).status == "done"
+    assert kb.complete_task(board, tid, summary="duplicate") is False
+
+
+def test_blocked_required_completion_still_needs_central_proof(board):
+    tid = kb.create_task(
+        board, title="guarded blocked", goal_mode=True,
+        goal_judge_policy="required",
+    )
+    assert kb.block_task(board, tid, reason="waiting", kind="needs_input")
+    with pytest.raises(kb.GoalJudgeRequiredError):
+        kb.complete_task(board, tid, summary="manual bypass")
+    task = kb.get_task(board, tid)
+    assert task is not None and task.status == "blocked"
+    assert kb.complete_task(
+        board, tid, summary="proved", goal_gate_passed=True,
+    )
+    task = kb.get_task(board, tid)
+    assert task is not None and task.status == "done"
+
+
+def test_required_gate_rechecks_status_inside_write_transaction(board, monkeypatch):
+    tid = kb.create_task(
+        board, title="guarded race", goal_mode=True,
+        goal_judge_policy="required", triage=True,
+    )
+    real_merge = kb._merge_completion_prose_artifacts
+
+    def promote_before_write(conn, task_id, metadata, **kwargs):
+        merged = real_merge(conn, task_id, metadata, **kwargs)
+        conn.execute("UPDATE tasks SET status = 'ready' WHERE id = ?", (task_id,))
+        conn.commit()
+        return merged
+
+    monkeypatch.setattr(kb, "_merge_completion_prose_artifacts", promote_before_write)
+
+    with pytest.raises(kb.GoalJudgeRequiredError):
+        kb.complete_task(board, tid, summary="ungated")
+    task = kb.get_task(board, tid)
+    assert task is not None and task.status == "ready"
+
+
+def test_best_effort_completion_is_unchanged(board):
+    tid = kb.create_task(board, title="legacy", goal_mode=True)
+    assert kb.get_task(board, tid).goal_judge_policy == "best_effort"
+    assert kb.complete_task(board, tid, summary="done")
+
+
+def test_from_row_without_policy_defaults_best_effort():
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    conn.execute(
+        "CREATE TABLE old (id TEXT, title TEXT, body TEXT, assignee TEXT, status TEXT, "
+        "priority INTEGER, created_by TEXT, created_at INTEGER, started_at INTEGER, "
+        "completed_at INTEGER, workspace_kind TEXT, workspace_path TEXT, claim_lock TEXT, "
+        "claim_expires INTEGER)"
+    )
+    conn.execute(
+        "INSERT INTO old VALUES ('t1','old',NULL,NULL,'ready',0,NULL,1,NULL,NULL,"
+        "'scratch',NULL,NULL,NULL)"
+    )
+    task = kb.Task.from_row(conn.execute("SELECT * FROM old").fetchone())
+    assert task.goal_judge_policy == "best_effort"
+
+
+def test_direct_status_helper_rejects_done(board):
+    from plugins.kanban.dashboard.plugin_api import _set_status_direct
+
+    tid = kb.create_task(board, title="x")
+    with pytest.raises(ValueError, match="done"):
+        _set_status_direct(board, tid, "done")
+
+
+def test_cli_rejects_required_policy_without_goal(capsys):
+    from hermes_cli.kanban import _cmd_create
+
+    args = argparse.Namespace(
+        workspace="scratch", branch=None, max_runtime=None, max_retries=None,
+        goal_judge_policy="required", goal_mode=False,
+    )
+    assert _cmd_create(args) == 2
+    assert "requires --goal" in capsys.readouterr().err
+
+
+def _complete_args(task_id):
+    return argparse.Namespace(
+        task_ids=[task_id], summary="acceptance evidence", result=None,
+        metadata=None,
+    )
+
+
+@pytest.mark.parametrize(
+    ("verdict", "expected_rc", "expected_status"),
+    [
+        ("continue", 1, "ready"),
+        ("done", 0, "done"),
+    ],
+)
+def test_cli_required_judge_reject_and_pass(
+    board, monkeypatch, verdict, expected_rc, expected_status,
+):
+    from hermes_cli.kanban import _cmd_complete
+
+    tid = kb.create_task(
+        board, title="guarded", goal_mode=True, goal_judge_policy="required",
+    )
+    monkeypatch.setattr(
+        "agent.auxiliary_client.get_text_auxiliary_client",
+        lambda _purpose: (object(), "judge-model"),
+    )
+    monkeypatch.setattr(
+        "hermes_cli.goals.judge_goal",
+        lambda **_: (verdict, "reviewed", False, None, False),
+    )
+    assert _cmd_complete(_complete_args(tid)) == expected_rc
+    assert kb.get_task(board, tid).status == expected_status
+
+
+def test_cli_required_fail_closed_block_is_run_scoped(board, monkeypatch):
+    from hermes_cli.kanban import _cmd_complete
+
+    tid = kb.create_task(
+        board, title="guarded", goal_mode=True, goal_judge_policy="required",
+    )
+    kb.claim_task(board, tid)
+    run_id = kb.get_task(board, tid).current_run_id
+    monkeypatch.setenv("HERMES_KANBAN_TASK", tid)
+    monkeypatch.setenv("HERMES_KANBAN_RUN_ID", str(run_id))
+    monkeypatch.setattr(
+        "agent.auxiliary_client.get_text_auxiliary_client",
+        lambda _purpose: (None, None),
+    )
+    assert _cmd_complete(_complete_args(tid)) == 1
+    task = kb.get_task(board, tid)
+    assert task.status == "blocked"
+    assert task.block_kind == "needs_input"
+
+
+def test_cli_required_live_worker_without_matching_env_refuses_mutation(
+    board, monkeypatch,
+):
+    from hermes_cli.kanban import _cmd_complete
+
+    tid = kb.create_task(
+        board, title="guarded", goal_mode=True, goal_judge_policy="required",
+    )
+    kb.claim_task(board, tid)
+    monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
+    monkeypatch.delenv("HERMES_KANBAN_RUN_ID", raising=False)
+    monkeypatch.setattr(
+        "agent.auxiliary_client.get_text_auxiliary_client",
+        lambda _purpose: (None, None),
+    )
+    assert _cmd_complete(_complete_args(tid)) == 1
+    assert kb.get_task(board, tid).status == "running"
+
+
+def test_cli_required_ready_card_can_fail_closed_without_run_env(
+    board, monkeypatch,
+):
+    from hermes_cli.kanban import _cmd_complete
+
+    tid = kb.create_task(
+        board, title="guarded ready", goal_mode=True,
+        goal_judge_policy="required",
+    )
+    monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
+    monkeypatch.delenv("HERMES_KANBAN_RUN_ID", raising=False)
+    monkeypatch.setattr(
+        "agent.auxiliary_client.get_text_auxiliary_client",
+        lambda _purpose: (None, None),
+    )
+    assert _cmd_complete(_complete_args(tid)) == 1
+    task = kb.get_task(board, tid)
+    assert task is not None and task.status == "blocked"
+    assert task.block_kind == "needs_input"
+
+
+def test_cli_required_block_handles_task_deleted_before_status_read(
+    board, monkeypatch,
+):
+    from hermes_cli.kanban import _cmd_complete
+
+    tid = kb.create_task(
+        board, title="guarded disappearing", goal_mode=True,
+        goal_judge_policy="required",
+    )
+    monkeypatch.setattr(
+        "agent.auxiliary_client.get_text_auxiliary_client",
+        lambda _purpose: (None, None),
+    )
+    real_block = kb.block_task
+
+    def block_then_delete(conn, task_id, **kwargs):
+        ok = real_block(conn, task_id, **kwargs)
+        conn.execute("DELETE FROM tasks WHERE id = ?", (task_id,))
+        conn.commit()
+        return ok
+
+    monkeypatch.setattr("hermes_cli.kanban.kb.block_task", block_then_delete)
+
+    assert _cmd_complete(_complete_args(tid)) == 1
+    assert kb.get_task(board, tid) is None
+
+
+def test_cli_plain_card_does_not_import_auxiliary_judge_dependencies(
+    board, monkeypatch,
+):
+    from hermes_cli.kanban import _cmd_complete
+
+    tid = kb.create_task(board, title="plain card")
+    monkeypatch.setitem(sys.modules, "agent.auxiliary_client", None)
+    monkeypatch.setitem(sys.modules, "hermes_cli.goals", None)
+    assert _cmd_complete(_complete_args(tid)) == 0
+    assert kb.get_task(board, tid).status == "done"
+
+
+def test_cli_best_effort_goal_card_fails_open_when_judge_imports_are_missing(
+    board, monkeypatch,
+):
+    from hermes_cli.kanban import _cmd_complete
+
+    tid = kb.create_task(
+        board, title="legacy goal card", goal_mode=True,
+        goal_judge_policy="best_effort",
+    )
+    monkeypatch.setitem(sys.modules, "agent.auxiliary_client", None)
+    monkeypatch.setitem(sys.modules, "hermes_cli.goals", None)
+
+    assert _cmd_complete(_complete_args(tid)) == 0
+    assert kb.get_task(board, tid).status == "done"
+
+
+@pytest.mark.parametrize(
+    ("available", "judge_result", "raises", "action"),
+    [
+        (False, None, None, "block"),
+        (True, None, RuntimeError("boom"), "block"),
+        (True, ("done", "bad wire", False, None, True), None, "block"),
+        (True, ("done", "bad json", True, None, False), None, "block"),
+        (True, ("skipped", "no verdict", False, None, False), None, "block"),
+        (True, ("mystery", "unknown", False, None, False), None, "block"),
+        (True, ("continue", "more work", False, None, False), None, "reject"),
+        (True, ("wait", "later", False, {"reason": "external input"}, False), None, "reject"),
+        (True, ("done", "accepted", False, None, False), None, "pass"),
+    ],
+)
+def test_required_decision_mapping(available, judge_result, raises, action):
+    from hermes_cli.kanban_goal_judge import evaluate_goal_completion
+
+    task = SimpleNamespace(
+        goal_mode=True, goal_judge_policy="required", title="goal", body="criteria"
+    )
+
+    def judge(**_kwargs):
+        if raises:
+            raise raises
+        return judge_result
+
+    decision = evaluate_goal_completion(
+        task, "evidence", judge_available=lambda: available, judge=judge
+    )
+    assert decision.action == action
+
+
+def test_wait_preserves_directive_reason_and_all_reasons_are_redacted(monkeypatch):
+    from hermes_cli import kanban_goal_judge as gate
+
+    monkeypatch.setattr(
+        gate, "redact_sensitive_text", lambda text, force=False: f"safe:{text}"
+    )
+    task = SimpleNamespace(
+        goal_mode=True, goal_judge_policy="required", title="goal", body="",
+    )
+    decision = gate.evaluate_goal_completion(
+        task, "x", judge_available=lambda: True,
+        judge=lambda **_: (
+            "wait", "fallback secret", False,
+            {"reason": "preferred secret"}, False,
+        ),
+    )
+    assert decision.reason == "safe:preferred secret"
+
+
+def test_best_effort_judge_exception_and_transport_done_fail_open():
+    from hermes_cli.kanban_goal_judge import evaluate_goal_completion
+
+    task = SimpleNamespace(
+        goal_mode=True, goal_judge_policy="best_effort", title="goal", body=""
+    )
+    assert evaluate_goal_completion(
+        task, "x", judge_available=lambda: True,
+        judge=lambda **_: (_ for _ in ()).throw(RuntimeError("boom")),
+    ).action == "pass"
+    assert evaluate_goal_completion(
+        task, "x", judge_available=lambda: True,
+        judge=lambda **_: ("done", "legacy verdict wins", True, None, True),
+    ).action == "pass"

--- a/tests/hermes_cli/test_kanban_goal_mode.py
+++ b/tests/hermes_cli/test_kanban_goal_mode.py
@@ -83,10 +83,12 @@ def test_legacy_db_migrates_goal_columns(tmp_path, monkeypatch):
         cols = {r["name"] for r in conn.execute("PRAGMA table_info(tasks)")}
         assert "goal_mode" in cols
         assert "goal_max_turns" in cols
+        assert "goal_judge_policy" in cols
         task = kb.get_task(conn, "legacy1")
     # Existing row keeps the safe default.
     assert task.goal_mode is False
     assert task.goal_max_turns is None
+    assert task.goal_judge_policy == "best_effort"
 
 
 # ---------------------------------------------------------------------------
@@ -153,6 +155,8 @@ class TestCLIJudgeGate:
 
         fake_task = types.SimpleNamespace(
             goal_mode=goal_mode,
+            goal_judge_policy="best_effort",
+            status="running",
             title="Finish report",
             body="acceptance: criteria",
         )

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -685,6 +685,38 @@ def test_bulk_status_done_forwards_completion_summary(client):
         conn.close()
 
 
+def test_required_goal_completion_single_and_bulk_conflict(client):
+    from hermes_cli import kanban_db as kb
+
+    with kb.connect() as conn:
+        single = kb.create_task(
+            conn, title="single guarded", goal_mode=True,
+            goal_judge_policy="required",
+        )
+        bulk = kb.create_task(
+            conn, title="bulk guarded", goal_mode=True,
+            goal_judge_policy="required",
+        )
+
+    response = client.patch(
+        f"/api/plugins/kanban/tasks/{single}", json={"status": "done"}
+    )
+    assert response.status_code == 409
+
+    response = client.post(
+        "/api/plugins/kanban/tasks/bulk",
+        json={"ids": [bulk], "status": "done"},
+    )
+    assert response.status_code == 200
+    assert response.json()["results"][0]["ok"] is False
+    assert response.json()["results"][0]["error_code"] == "goal_judge_required"
+    assert "goal judge" in response.json()["results"][0]["error"].lower()
+
+    with kb.connect() as conn:
+        assert kb.get_task(conn, single).status != "done"
+        assert kb.get_task(conn, bulk).status != "done"
+
+
 def test_bulk_status_running_rejected(client):
     """Bulk updates must match single-task PATCH: direct 'running' is invalid."""
     t = client.post("/api/plugins/kanban/tasks", json={"title": "x"}).json()["task"]

--- a/tests/tools/test_kanban_required_goal_judge.py
+++ b/tests/tools/test_kanban_required_goal_judge.py
@@ -1,0 +1,147 @@
+from __future__ import annotations
+
+import json
+
+from hermes_cli import kanban_db as kb
+from tools import kanban_tools as kt
+
+
+def _required_worker(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setenv("HERMES_PROFILE", "worker")
+    kb._INITIALIZED_PATHS.clear()
+    kb.init_db()
+    with kb.connect() as conn:
+        tid = kb.create_task(
+            conn, title="prove it", assignee="worker", goal_mode=True,
+            goal_judge_policy="required",
+        )
+        kb.claim_task(conn, tid)
+        run_id = kb.get_task(conn, tid).current_run_id
+    monkeypatch.setenv("HERMES_KANBAN_TASK", tid)
+    monkeypatch.setenv("HERMES_KANBAN_RUN_ID", str(run_id))
+    return tid
+
+
+def test_required_unavailable_judge_blocks_needs_input(tmp_path, monkeypatch):
+    tid = _required_worker(tmp_path, monkeypatch)
+    monkeypatch.setattr(kt, "_goal_judge_available", lambda: False)
+    out = json.loads(kt._handle_complete({"summary": "done"}))
+    assert out.get("ok") is not True
+    with kb.connect() as conn:
+        task = kb.get_task(conn, tid)
+    assert task.status == "blocked"
+    assert task.block_kind == "needs_input"
+
+
+def test_required_unavailable_judge_reports_actual_triage_state(tmp_path, monkeypatch):
+    tid = _required_worker(tmp_path, monkeypatch)
+    with kb.connect() as conn:
+        conn.execute(
+            "UPDATE tasks SET block_kind = 'needs_input', block_recurrences = ? "
+            "WHERE id = ?",
+            (kb.BLOCK_RECURRENCE_LIMIT, tid),
+        )
+        conn.commit()
+    monkeypatch.setattr(kt, "_goal_judge_available", lambda: False)
+
+    out = json.loads(kt._handle_complete({"summary": "done"}))
+
+    assert out.get("ok") is not True
+    assert "triage" in out["error"].lower()
+    assert "blocked/needs_input" not in out["error"].lower()
+    with kb.connect() as conn:
+        assert kb.get_task(conn, tid).status == "triage"
+
+
+def test_required_done_supplies_gate_proof(tmp_path, monkeypatch):
+    tid = _required_worker(tmp_path, monkeypatch)
+    monkeypatch.setattr(kt, "_goal_judge_available", lambda: True)
+    monkeypatch.setattr(
+        "hermes_cli.goals.judge_goal",
+        lambda **_: ("done", "accepted", False, None, False),
+    )
+    out = json.loads(kt._handle_complete({"summary": "evidence"}))
+    assert out["ok"] is True
+    with kb.connect() as conn:
+        assert kb.get_task(conn, tid).status == "done"
+
+
+def test_required_missing_run_id_does_not_mutate(tmp_path, monkeypatch):
+    tid = _required_worker(tmp_path, monkeypatch)
+    monkeypatch.delenv("HERMES_KANBAN_RUN_ID")
+    monkeypatch.setattr(kt, "_goal_judge_available", lambda: False)
+    out = json.loads(kt._handle_complete({"summary": "done"}))
+    assert "run" in out["error"].lower()
+    with kb.connect() as conn:
+        assert kb.get_task(conn, tid).status == "running"
+
+
+def test_required_stale_run_id_cannot_block_newer_run(tmp_path, monkeypatch):
+    tid = _required_worker(tmp_path, monkeypatch)
+    monkeypatch.setenv("HERMES_KANBAN_RUN_ID", "999999")
+    monkeypatch.setattr(kt, "_goal_judge_available", lambda: False)
+    out = json.loads(kt._handle_complete({"summary": "done"}))
+    assert "refused" in out["error"].lower()
+    with kb.connect() as conn:
+        assert kb.get_task(conn, tid).status == "running"
+
+
+def test_kanban_create_persists_required_policy(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    kb._INITIALIZED_PATHS.clear()
+    kb.init_db()
+    out = json.loads(kt._handle_create({
+        "title": "child", "assignee": "worker", "goal_mode": True,
+        "goal_judge_policy": "required",
+    }))
+    with kb.connect() as conn:
+        assert kb.get_task(conn, out["task_id"]).goal_judge_policy == "required"
+
+
+def test_kanban_create_null_policy_uses_best_effort_default(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    kb._INITIALIZED_PATHS.clear()
+    kb.init_db()
+    out = json.loads(kt._handle_create({
+        "title": "child", "assignee": "worker", "goal_mode": True,
+        "goal_judge_policy": None,
+    }))
+    assert out["ok"] is True
+    with kb.connect() as conn:
+        assert kb.get_task(conn, out["task_id"]).goal_judge_policy == "best_effort"
+
+
+def test_required_dependency_block_is_rejected_but_needs_input_allowed(tmp_path, monkeypatch):
+    tid = _required_worker(tmp_path, monkeypatch)
+    dependency = json.loads(kt._handle_block({
+        "reason": "waiting for child", "kind": "dependency",
+    }))
+    assert dependency.get("ok") is not True
+    with kb.connect() as conn:
+        assert kb.get_task(conn, tid).status == "running"
+
+    needs_input = json.loads(kt._handle_block({
+        "reason": "need operator answer", "kind": "needs_input",
+    }))
+    assert needs_input["ok"] is True
+    with kb.connect() as conn:
+        task = kb.get_task(conn, tid)
+        assert task.status == "blocked"
+        assert task.block_kind == "needs_input"
+
+
+def test_required_fail_closed_block_stays_sticky_and_unclaimable(tmp_path, monkeypatch):
+    tid = _required_worker(tmp_path, monkeypatch)
+    monkeypatch.setattr(kt, "_goal_judge_available", lambda: False)
+    json.loads(kt._handle_complete({"summary": "done"}))
+    with kb.connect() as conn:
+        assert kb.recompute_ready(conn) == 0
+        assert kb.get_task(conn, tid).status == "blocked"
+        assert kb.claim_task(conn, tid) is None

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -34,7 +34,6 @@ import os
 from typing import Any, Optional
 
 from agent.redact import redact_sensitive_text
-from hermes_cli.goals import judge_goal
 from tools.registry import registry, tool_error
 from hermes_cli.config import cfg_get, load_config
 
@@ -249,6 +248,17 @@ def _goal_judge_available() -> bool:
     except Exception:
         return False
     return client is not None and bool(model)
+
+
+def judge_goal(*args, **kwargs):
+    """Lazy compatibility wrapper for the goal judge.
+
+    Preserve the established module-level patch point without importing the
+    optional goal stack for plain Kanban calls.
+    """
+    from hermes_cli.goals import judge_goal as _judge_goal
+
+    return _judge_goal(*args, **kwargs)
 
 
 def _goal_mode_handoff_rejection(task, evidence: str) -> Optional[str]:
@@ -749,16 +759,67 @@ def _handle_complete(args: dict, **kw) -> str:
             # Goal-mode pre-completion judge gate (Issue #38367).
             # Prevent workers from bypassing the auxiliary judge by
             # calling kanban_complete before acceptance criteria are met.
-            # Only enforce when a judge is actually reachable — see
-            # _goal_judge_available for why an unavailable judge fails open.
+            # Under the default ``best_effort`` policy this stays fail-open
+            # — see _goal_judge_available for why an unreachable judge must
+            # not wedge every goal_mode worker. Only tasks created with
+            # goal_judge_policy='required' fail closed.
             task = kb.get_task(conn, tid)
-            rejection = _goal_mode_handoff_rejection(
-                task,
-                (summary or result or "").strip(),
-            )
-            if rejection is not None:
+            # The gate runs for every task the DB layer considers
+            # completable — deliberately *not* narrowed by status here.
+            # kanban_db.COMPLETABLE_STATUSES includes ``review``, and a
+            # status filter that disagreed with it would let a required
+            # task reach complete_task without proof and trip
+            # GoalJudgeRequiredError instead of this friendly path.
+            # evaluate_goal_completion short-circuits to ``pass`` for
+            # non-goal_mode tasks, so no judge probe happens for them.
+            decision = None
+            if task is not None:
+                from hermes_cli.kanban_goal_judge import evaluate_goal_completion
+
+                decision = evaluate_goal_completion(
+                    task,
+                    (summary or result or "").strip(),
+                    judge_available=_goal_judge_available,
+                    judge=judge_goal,
+                )
+            if decision is not None and decision.action == "block":
+                # ``required`` policy only: the judge could not be trusted
+                # (unreachable, unparseable, or raised), so fail closed by
+                # ending this run rather than letting the worker retry into
+                # a completion. Run-scoped so a stale run cannot clobber a
+                # newer claim.
+                run_id = _worker_run_id(tid)
+                if run_id is None:
+                    return tool_error(
+                        "Required goal judge failed closed, but the worker run id "
+                        "is missing; refusing an unscoped block or completion."
+                    )
+                if not kb.block_task(
+                    conn, tid, reason=decision.reason, kind="needs_input",
+                    expected_run_id=run_id,
+                ):
+                    return tool_error(
+                        "Required goal judge failed closed, but the run-scoped "
+                        "needs_input block was refused; task state was not claimed changed."
+                    )
+                # Report the state the board actually landed in: the
+                # unblock-loop breaker can escalate needs_input to triage,
+                # and claiming "blocked/needs_input" would be a lie.
+                resulting_task = kb.get_task(conn, tid)
+                resulting_state = (
+                    resulting_task.status if resulting_task is not None else "missing"
+                )
                 return tool_error(
-                    f"Goal completion rejected by judge: {rejection}. "
+                    f"Required goal judge failed closed: {decision.reason}. "
+                    f"The current run ended; resulting task state: {resulting_state}. "
+                    "do not send further heartbeat or completion calls."
+                )
+            if decision is not None and decision.action == "reject":
+                # Unchanged best_effort semantics: a reachable judge that
+                # says "not done" rejects the handoff and leaves the task
+                # in-flight so the worker can keep going.
+                return tool_error(
+                    f"Goal completion rejected by judge: {decision.reason}. "
                     f"To proceed, either: (1) provide explicit acceptance "
                     f"evidence in your summary matching the task's criteria, "
                     f"or (2) create continuation tasks with parents=[{tid}] "
@@ -771,6 +832,7 @@ def _handle_complete(args: dict, **kw) -> str:
                     result=result, summary=summary, metadata=metadata,
                     created_cards=created_cards,
                     expected_run_id=_worker_run_id(tid),
+                    goal_gate_passed=bool(decision and decision.action == "pass"),
                 )
             except kb.ArtifactPreservationError as artifact_err:
                 return tool_error(
@@ -851,6 +913,18 @@ def _handle_block(args: dict, **kw) -> str:
         # and `transient` (or an unset kind) route back through
         # kanban_complete, which the judge now gates.
         task = kb.get_task(conn, tid)
+        if (
+            task
+            and task.goal_mode
+            and task.goal_judge_policy == "required"
+            and kind == "dependency"
+        ):
+            conn.close()
+            return tool_error(
+                "required goal-mode tasks cannot use kind='dependency' because "
+                "it is re-promotable. Use kind='needs_input' only for a genuine "
+                "human decision, or provide completion evidence to kanban_complete."
+            )
         if (
             task
             and task.goal_mode
@@ -1409,6 +1483,10 @@ def _handle_create(args: dict, **kw) -> str:
     if goal_bool_error:
         return tool_error(goal_bool_error)
     goal_max_turns = args.get("goal_max_turns")
+    raw_goal_judge_policy = args.get("goal_judge_policy")
+    goal_judge_policy = (
+        "best_effort" if raw_goal_judge_policy is None else raw_goal_judge_policy
+    )
     model_override = args.get("model")
     provider_override = args.get("provider")
     if provider_override and not model_override:
@@ -1458,6 +1536,7 @@ def _handle_create(args: dict, **kw) -> str:
                 goal_max_turns=(
                     int(goal_max_turns) if goal_max_turns is not None else None
                 ),
+                goal_judge_policy=goal_judge_policy,
                 initial_status=str(initial_status),
                 created_by=os.environ.get("HERMES_PROFILE") or "worker",
                 session_id=session_id,
@@ -2281,6 +2360,14 @@ KANBAN_CREATE_SCHEMA = {
                     "continuation turns the worker may take before the task "
                     "is blocked for review. Ignored unless goal_mode is "
                     "true. Defaults to the goal-engine default (20)."
+                ),
+            },
+            "goal_judge_policy": {
+                "type": "string",
+                "enum": ["best_effort", "required"],
+                "description": (
+                    "Completion judge policy. 'required' is valid only with "
+                    "goal_mode=true and fails closed unless the judge accepts."
                 ),
             },
             "model": {


### PR DESCRIPTION
## What changed

This adds a task-level `goal_judge_policy` for goal-mode Kanban work:

- `best_effort` remains the default and preserves the existing fail-open behavior when the auxiliary judge is unavailable;
- `required` is opt-in and refuses terminal completion unless the goal judge returns a positive completion decision;
- the policy is persisted in SQLite, included in task serialization, and threaded through CLI, worker tools, and dashboard/direct completion paths;
- direct `done` status writes are routed through `complete_task` rather than bypassing the completion gate;
- required proof is rechecked inside the SQLite write transaction to close the status-change/TOCTOU window;
- judge errors and unavailable/unsupported results fail closed only for `required` tasks, with sensitive reasons redacted before display or persistence.

## Why

The existing best-effort policy is appropriate for compatibility: a missing auxiliary judge must not wedge ordinary goal-mode work. Some bounded review tasks, however, require a stronger acceptance contract where an unavailable or failed judge must not be treated as successful completion.

Making this explicit and task-local provides strict behavior where requested without changing the legacy default.

## Compatibility

- Existing databases migrate additively with `goal_judge_policy TEXT NOT NULL DEFAULT 'best_effort'`.
- Existing task-like fixtures and older rows default to `best_effort`.
- `required` is rejected unless goal mode is enabled.
- Idempotent task creation accepts same-policy replay and rejects policy mismatch.
- No provider, model, cost-routing, environment-variable, or workflow changes are included.

## How to test

Canonical hermetic targeted runner:

```bash
HERMES_PYTHON=/path/to/python scripts/run_tests.sh -j 4 -q \
  tests/hermes_cli/test_kanban_goal_judge_policy.py \
  tests/hermes_cli/test_kanban_goal_mode.py \
  tests/tools/test_kanban_required_goal_judge.py \
  tests/tools/test_kanban_tools.py \
  tests/plugins/test_kanban_dashboard_plugin.py \
  tests/hermes_cli/test_kanban_db.py
```

Observed result:

```text
141 passed, 0 failed, 1 skipped
```

Manual smoke on a temporary SQLite board:

```text
legacy/default completion: accepted
required without proof: refused
required with positive proof: accepted
```

Additional verification:

- `py_compile`: pass
- `git diff --check`: pass
- added-line secret/injection scan: pass
- broad isolated Kanban regression run on the combined integration tree: `473 passed, 0 failed, 1 skipped` across 66 files

## Platform tested

- Linux
- Python 3.11

The skipped test is Windows-only and remains covered by the repository's Windows CI lane.

## Risk and rollout

The main risk is inconsistent enforcement between completion entry points. The patch covers DB, CLI, worker tool, dashboard, bulk/direct status, and transaction-level paths. The default remains `best_effort`, so rollout is opt-in and rollback is to stop creating tasks with `goal_judge_policy=required` or revert this single commit.

## Not included

- No Telegram collaboration plugin or private deployment configuration.
- No provider/model routing changes.
- No GitHub Actions changes.
- No schema or cryptographic claim about the native goal judge; this is an availability/verdict policy gate.
