### PR TITLE
fix(gateway): preserve plugin and Telegram command routing

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -6352,6 +6352,26 @@ class TurnRunner:
         }
 
 
+def _discover_plugins_at_startup() -> None:
+    """Load Python plugins once, during gateway startup.
+
+    ``force=True`` because something earlier in the process (a CLI entry
+    point, an import-time side effect) may already have created the global
+    PluginManager and marked it discovered — possibly before HERMES_HOME was
+    readable, leaving an empty registry that plain idempotent discovery would
+    keep. Forcing the rescan here is what makes user plugins' hooks and slash
+    commands available to the gateway.
+
+    Fails open: a broken plugin sweep warns but never blocks boot.
+    """
+    try:
+        from hermes_cli.plugins import discover_plugins
+        discover_plugins(force=True)
+    except Exception:
+        logger.warning(
+            "plugin discovery failed at gateway startup", exc_info=True,
+        )
+
 
 class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, GatewaySlashCommandsMixin):
     """
@@ -12066,13 +12086,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # gateway lazily imports run_agent inside per-request handlers,
         # so the discover_plugins() side-effect in model_tools.py is NOT
         # guaranteed to have run by the time we reach this point.
-        try:
-            from hermes_cli.plugins import discover_plugins
-            discover_plugins()
-        except Exception:
-            logger.warning(
-                "plugin discovery failed at gateway startup", exc_info=True,
-            )
+        _discover_plugins_at_startup()
 
         # Register the generic relay adapter when a connector relay URL is
         # configured (GATEWAY_RELAY_URL / gateway.relay_url). No URL -> no-op, so
@@ -17292,6 +17306,23 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     # built-ins (command may be an alias target set by the
                     # quick-command block above, so _cmd_def can be stale).
                     if command.replace("_", "-") not in GATEWAY_KNOWN_COMMANDS:
+                        try:
+                            from hermes_cli.plugins import get_plugin_manager
+                            manager = get_plugin_manager()
+                            logger.info(
+                                "Unknown command registry state: discovered=%s plugins=%d "
+                                "hooks=%d commands=%d pre_gateway_dispatch=%d",
+                                bool(getattr(manager, "_discovered", False)),
+                                len(getattr(manager, "_plugins", {})),
+                                sum(len(items) for items in getattr(manager, "_hooks", {}).values()),
+                                len(getattr(manager, "_plugin_commands", {})),
+                                len(getattr(manager, "_hooks", {}).get("pre_gateway_dispatch", [])),
+                            )
+                        except Exception:
+                            logger.debug(
+                                "Unable to inspect plugin registry for unknown command",
+                                exc_info=True,
+                            )
                         logger.warning(
                             "Unrecognized slash command /%s from %s — "
                             "replying with unknown-command notice",

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -8981,8 +8981,15 @@ class TelegramAdapter(BasePlatformAdapter):
         if not text or not bot_username:
             return text
         username = re.escape(bot_username)
-        cleaned = re.sub(rf"(?i)@{username}\b[,:\-]*\s*", "", text).strip()
+        cleaned = re.sub(rf"(?i)@{username}\b[,:\-]*", "", text).strip()
         return cleaned or text
+
+    @staticmethod
+    def _promote_text_command_event(event: MessageEvent) -> MessageEvent:
+        """Recover slash commands that Telegram delivered without COMMAND metadata."""
+        if event.message_type == MessageType.TEXT and event.get_command():
+            return dataclasses.replace(event, message_type=MessageType.COMMAND)
+        return event
 
     def _should_observe_unmentioned_group_message(self, message: Message) -> bool:
         """Return True when a group message should be stored but not dispatched."""
@@ -9485,6 +9492,7 @@ class TelegramAdapter(BasePlatformAdapter):
 
         event = self._build_message_event(msg, MessageType.TEXT, update_id=update.update_id)
         event.text = self._clean_bot_trigger_text(event.text)
+        event = self._promote_text_command_event(event)
         await self._cache_replied_media(msg, event)
         event = self._apply_telegram_group_observe_attribution(event)
         self._enqueue_text_event(event)

--- a/tests/gateway/test_gateway_startup_plugin_discovery.py
+++ b/tests/gateway/test_gateway_startup_plugin_discovery.py
@@ -1,0 +1,137 @@
+"""Gateway startup must (re)discover plugins even when a stale manager exists.
+
+The gateway boots in a process where something earlier (a CLI entry point, an
+import-time side effect, a probe that ran before ``HERMES_HOME`` plugins were
+readable) may already have created the global ``PluginManager`` and marked it
+``_discovered=True`` with an empty registry. ``discover_plugins()`` is
+idempotent, so in that state the gateway's startup discovery is a no-op and the
+user's plugins never load: ``pre_gateway_dispatch`` hooks never fire and
+plugin slash commands come back as unknown commands.
+
+Startup discovery therefore has to force a rescan.
+"""
+
+import textwrap
+from pathlib import Path
+
+import yaml
+
+
+def _write_user_plugin(hermes_home: Path, name: str) -> None:
+    """Create an enabled user plugin under ``<hermes_home>/plugins/<name>/``.
+
+    The plugin registers one ``pre_gateway_dispatch`` hook and one ``/collab``
+    slash command — the two registries the gateway reads at dispatch time.
+    """
+    plugin_dir = hermes_home / "plugins" / name
+    plugin_dir.mkdir(parents=True, exist_ok=True)
+
+    (plugin_dir / "plugin.yaml").write_text(
+        yaml.safe_dump(
+            {"name": name, "version": "0.1.0", "description": "startup discovery probe"}
+        )
+    )
+    (plugin_dir / "__init__.py").write_text(
+        textwrap.dedent(
+            """
+            def _pre_gateway_dispatch(**kwargs):
+                return None
+
+
+            def _collab(raw_args=""):
+                return "collab ok"
+
+
+            def register(ctx):
+                ctx.register_hook("pre_gateway_dispatch", _pre_gateway_dispatch)
+                ctx.register_command("collab", _collab, description="probe command")
+            """
+        ).lstrip()
+    )
+
+    # Plugins are opt-in: enable it in <HERMES_HOME>/config.yaml.
+    (hermes_home / "config.yaml").write_text(
+        yaml.safe_dump({"plugins": {"enabled": [name]}})
+    )
+
+
+def test_gateway_startup_discovery_loads_plugins_despite_stale_manager(
+    tmp_path, monkeypatch
+):
+    import hermes_cli.plugins as plugins_mod
+
+    hermes_home = tmp_path / "hermes_home"
+    hermes_home.mkdir(parents=True, exist_ok=True)
+    _write_user_plugin(hermes_home, "startup_probe_plugin")
+
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.delenv("HERMES_SAFE_MODE", raising=False)
+    monkeypatch.delenv("HERMES_ENABLE_PROJECT_PLUGINS", raising=False)
+
+    # Seed the exact pre-boot state that breaks plugin loading: a global
+    # manager that already believes discovery is done, with nothing loaded.
+    stale = plugins_mod.PluginManager()
+    stale._discovered = True
+    monkeypatch.setattr(plugins_mod, "_plugin_manager", stale)
+    assert not stale._hooks.get("pre_gateway_dispatch")
+    assert "collab" not in stale._plugin_commands
+
+    from gateway import run as gateway_run
+
+    helper = getattr(gateway_run, "_discover_plugins_at_startup", None)
+    if helper is None:
+        # Pre-fix startup path: a plain idempotent discover_plugins() call
+        # inlined in GatewayRunner.start(). Exercising it here keeps the
+        # failure behavioral (hook/command missing) rather than a bare
+        # AttributeError, and keeps the test honest if the helper is ever
+        # dropped again.
+        helper = plugins_mod.discover_plugins
+
+    helper()
+
+    manager = plugins_mod.get_plugin_manager()
+    assert manager is stale, "startup discovery must populate the global manager"
+    assert "startup_probe_plugin" in manager._plugins
+    assert manager._hooks.get("pre_gateway_dispatch"), (
+        "gateway startup discovery did not load the plugin's "
+        "pre_gateway_dispatch hook"
+    )
+    assert "collab" in manager._plugin_commands, (
+        "gateway startup discovery did not load the plugin's /collab command"
+    )
+
+
+def test_gateway_start_discovers_plugins_before_registering_adapters():
+    """``GatewayRunner.start()`` must call discovery before any adapter loads.
+
+    The behavioral test above proves the helper works; this one pins where it
+    is wired in. Plugins register ``pre_gateway_dispatch`` hooks and slash
+    commands that adapters consult from their first inbound message, so
+    discovery has to happen before the first adapter is registered. A refactor
+    that keeps the call but moves it below adapter registration reopens the
+    race without failing any behavioral test.
+    """
+    import inspect
+
+    from gateway.run import GatewayRunner
+
+    source = inspect.getsource(GatewayRunner.start)
+
+    discovery_at = source.find("_discover_plugins_at_startup()")
+    assert discovery_at != -1, (
+        "GatewayRunner.start() no longer calls _discover_plugins_at_startup(); "
+        "gateway startup will not force a plugin rescan"
+    )
+
+    marker = "# Register the generic relay adapter"
+    marker_at = source.find(marker)
+    assert marker_at != -1, (
+        f"anchor comment {marker!r} is gone from GatewayRunner.start(); update "
+        "this test to the new first-adapter-registration marker"
+    )
+
+    assert discovery_at < marker_at, (
+        "_discover_plugins_at_startup() must run before the first adapter is "
+        "registered, otherwise adapters can dispatch before plugin hooks and "
+        "slash commands exist"
+    )

--- a/tests/gateway/test_telegram_group_gating.py
+++ b/tests/gateway/test_telegram_group_gating.py
@@ -860,6 +860,66 @@ def test_collectible_username_not_suppressed_by_other_bot_mention():
     assert adapter._should_process_message(message) is True
 
 
+def test_human_handles_still_do_not_act_as_routing_hints():
+    """Widening self-matching must not make human @handles suppress this bot."""
+    adapter = _make_adapter(require_mention=True, exclusive_bot_mentions=True)
+    text = "@alice can you check this"
+    message = _group_message(text, entities=_mention_entities(text, ["@alice"]))
+
+    assert adapter._explicit_bot_mentions_exclude_self(message) is False
+
+
+def test_messages_addressed_to_a_different_bot_are_still_suppressed():
+    """The multi-bot exclusivity contract is preserved."""
+    adapter = _make_adapter(require_mention=True, exclusive_bot_mentions=True)
+    text = "@other_helper_bot do it"
+    message = _group_message(text, entities=_mention_entities(text, ["@other_helper_bot"]))
+
+    assert adapter._explicit_bot_mentions_exclude_self(message) is True
+    assert adapter._should_process_message(message) is False
+
+
+def test_clean_bot_trigger_text_strips_the_current_handle():
+    """Prefix stripping must follow a rename, not the stale cached handle."""
+    adapter = _make_adapter(require_mention=True)
+    adapter._bot = _IdentityBot(cached="old_helper_bot", server="new_helper_bot")
+    adapter._note_bot_username("new_helper_bot")
+
+    assert adapter._clean_bot_trigger_text("@new_helper_bot ship it") == "ship it"
+
+
+def test_clean_bot_trigger_text_preserves_targeted_command_argument_boundary():
+    """Removing /cmd@bot must not concatenate the command and its arguments."""
+    adapter = _make_adapter(require_mention=True, bot_username="KodyaDutyBot")
+
+    cleaned = adapter._clean_bot_trigger_text(
+        "/collab@KodyaDutyBot Проверь правила остановки"
+    )
+
+    assert cleaned == "/collab Проверь правила остановки"
+
+
+def test_text_path_promotes_slash_event_before_group_observe_attribution():
+    """Entity-less slash commands must not receive shared-history attribution."""
+    adapter = _make_adapter(
+        require_mention=True,
+        group_allowed_chats=["-100"],
+        observe_unmentioned_group_messages=True,
+        bot_username="KodyaDutyBot",
+    )
+    msg = _group_message("/collab@KodyaDutyBot check loop rules")
+    event = adapter._build_message_event(msg, MessageType.TEXT, update_id=1005)
+    event.text = adapter._clean_bot_trigger_text(event.text) or ""
+
+    event = adapter._promote_text_command_event(event)
+    event = adapter._apply_telegram_group_observe_attribution(event)
+
+    assert event.message_type == MessageType.COMMAND
+    assert event.get_command() == "collab"
+    assert event.text == "/collab check loop rules"
+    assert event.source.user_id == "111"
+
+
 def test_identity_freshness_does_not_depend_on_host_uptime(monkeypatch):
     """A never-checked identity is stale even when monotonic() is near zero.
 


### PR DESCRIPTION
## What changed

This fixes two gateway command-routing edge cases:

- gateway startup now forces one plugin discovery rescan so an earlier empty/idempotent discovery cannot leave user plugin commands and hooks unavailable for the process lifetime;
- startup discovery remains fail-open: a broken plugin sweep logs a warning but does not block gateway boot;
- targeted Telegram commands preserve the boundary between `/command@bot` and their arguments when the bot handle is removed;
- entity-less slash text is promoted to a command event before group-observe attribution, preventing a valid command from being stored as passive shared history;
- unknown-command diagnostics report privacy-safe registry counts/state to distinguish missing discovery from an actually unknown command.

## Why

Gateway startup can instantiate or mark the global plugin manager discovered before the effective `HERMES_HOME` plugin set is readable. A later idempotent discovery then preserves an empty registry, so valid plugin slash commands are treated as unknown until restart or another rescan.

Telegram may also deliver slash-looking text without `COMMAND` metadata. Combined with targeted bot-handle cleanup and group-observe attribution, this could either concatenate the command and its argument or misclassify the event as passive history.

## How to test

Canonical hermetic targeted runner:

```bash
HERMES_PYTHON=/path/to/python scripts/run_tests.sh -j 2 -q \
  tests/gateway/test_gateway_startup_plugin_discovery.py \
  tests/gateway/test_telegram_group_gating.py
```

Observed result:

```text
30 passed, 0 failed
```

Additional verification:

- `py_compile`: pass
- `git diff --check`: pass
- changed-path allowlist: `4/4`
- workflow changes: none

## Platform tested

- Linux
- Python 3.11

No live Telegram message was sent as part of this PR preparation; the affected event-routing paths are exercised locally without external projection.

## Risk and rollback

The startup rescan is process-local and executes once during gateway startup. Discovery failure remains non-fatal. Telegram promotion is limited to text that already parses as a slash command.

Rollback is a single-commit revert. No database migration, provider configuration, authentication, or GitHub Actions changes are involved.

## Not included

- No private `/collab` plugin or owner-specific routing.
- No bot-to-bot transport, polling daemon, bridge, cron, or control plane.
- No live platform configuration.
