### PR TITLE
fix(gateway): propagate supervisor marker through stderr_timestamp wrapper

### DIFF
--- a/hermes_cli/stderr_timestamp.py
+++ b/hermes_cli/stderr_timestamp.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import os
 import re
 import signal
 import subprocess
@@ -80,12 +81,39 @@ def _parse_args(argv: Sequence[str] | None) -> argparse.Namespace:
     return args
 
 
+def _child_env() -> dict:
+    """Env for the wrapped child process.
+
+    macOS launchd sets ``XPC_SERVICE_NAME=<job label>`` only on its direct
+    child. When this wrapper (itself the direct child) spawns the real gateway,
+    libSystem resets ``XPC_SERVICE_NAME`` to ``"0"`` in the grandchild, which
+    strips the supervisor marker that the gateway's supervised-conflict guard
+    relies on (``is_gateway_supervisor_process``). The guard then refuses the
+    service's own startup in an infinite spawn→refuse→respawn loop. Propagate
+    the alternate marker ``HERMES_GATEWAY_EXTERNAL_SUPERVISOR`` so the guard
+    recognizes the supervised context.
+
+    Detection is scoped to the launchd-service case: the wrapper is spawned
+    directly by launchd (PPID 1 on macOS) *and* carries a real job label in
+    XPC_SERVICE_NAME. The detached-fallback path (wrapper spawned by the CLI)
+    and interactive shells (XPC_SERVICE_NAME=0) are deliberately excluded so
+    a manually started gateway is never mislabeled as supervised.
+    """
+    env = dict(os.environ)
+    xpc = env.get("XPC_SERVICE_NAME", "")
+    if os.getppid() == 1 and xpc and xpc != "0":
+        env["HERMES_GATEWAY_EXTERNAL_SUPERVISOR"] = "1"
+    return env
+
+
 def main(argv: Sequence[str] | None = None) -> int:
     args = _parse_args(argv)
     log_path: Path = args.error_log
 
     try:
-        proc = subprocess.Popen(args.command, stderr=subprocess.PIPE)
+        proc = subprocess.Popen(
+            args.command, stderr=subprocess.PIPE, env=_child_env()
+        )
     except OSError as exc:
         log_path.parent.mkdir(parents=True, exist_ok=True)
         with log_path.open("a", encoding="utf-8", buffering=1) as log_file:

--- a/tests/hermes_cli/test_stderr_timestamp.py
+++ b/tests/hermes_cli/test_stderr_timestamp.py
@@ -34,3 +34,37 @@ def test_main_timestamps_each_stderr_line(tmp_path):
     assert re.fullmatch(f"{timestamp} first failure", lines[0])
     assert re.fullmatch(f"{timestamp} second failure without newline", lines[1])
     assert lines[2] == "2026-07-15 12:34:56,789 already timestamped"
+
+
+def test_child_env_propagates_supervisor_marker_for_launchd_child(monkeypatch):
+    # launchd's direct child: PPID 1 and a real job label in XPC_SERVICE_NAME.
+    monkeypatch.setattr(stderr_timestamp.os, "getppid", lambda: 1)
+    monkeypatch.setenv("XPC_SERVICE_NAME", "ai.hermes.gateway")
+
+    env = stderr_timestamp._child_env()
+
+    assert env["HERMES_GATEWAY_EXTERNAL_SUPERVISOR"] == "1"
+    assert env["XPC_SERVICE_NAME"] == "ai.hermes.gateway"
+
+
+def test_child_env_no_marker_when_not_launchd_direct_child(monkeypatch):
+    # Detached-fallback path: wrapper spawned by the CLI, not by launchd.
+    monkeypatch.setattr(stderr_timestamp.os, "getppid", lambda: 4242)
+    monkeypatch.setenv("XPC_SERVICE_NAME", "ai.hermes.gateway")
+
+    assert "HERMES_GATEWAY_EXTERNAL_SUPERVISOR" not in stderr_timestamp._child_env()
+
+
+def test_child_env_no_marker_for_interactive_shell_xpc(monkeypatch):
+    # Interactive shells inherit the sentinel XPC_SERVICE_NAME=0.
+    monkeypatch.setattr(stderr_timestamp.os, "getppid", lambda: 1)
+    monkeypatch.setenv("XPC_SERVICE_NAME", "0")
+
+    assert "HERMES_GATEWAY_EXTERNAL_SUPERVISOR" not in stderr_timestamp._child_env()
+
+
+def test_child_env_no_marker_without_xpc(monkeypatch):
+    monkeypatch.setattr(stderr_timestamp.os, "getppid", lambda: 1)
+    monkeypatch.delenv("XPC_SERVICE_NAME", raising=False)
+
+    assert "HERMES_GATEWAY_EXTERNAL_SUPERVISOR" not in stderr_timestamp._child_env()


### PR DESCRIPTION
## What does this PR do?

Fixes an infinite spawn→refuse→respawn loop that wedges the launchd-supervised gateway on macOS and prevents **all** messaging platforms (QQ bot, WeChat, etc.) from ever connecting.

**Root cause chain:**

1. `generate_launchd_plist()` launches the gateway wrapped in `hermes_cli.stderr_timestamp` (added so raw stderr lines get timestamps before landing in `gateway.error.log`).
2. macOS launchd sets `XPC_SERVICE_NAME=<job label>` **only on its direct child** — the wrapper. When the wrapper spawns the actual gateway, libSystem resets `XPC_SERVICE_NAME` to `"0"` in the grandchild (verified empirically: wrapper env carries `XPC_SERVICE_NAME=ai.hermes.gateway`, the gateway child carries `"0"`).
3. The gateway runs `_guard_supervised_gateway_conflict(force=False)`. `is_gateway_supervisor_process()` reads `XPC_SERVICE_NAME`, sees `"0"` → the gateway is **not** recognized as the supervised service.
4. The guard's snapshot probe (`launchctl list <label>`) finds a PID — the job's *own* PID — so `service_running=True`, and the guard refuses the service's own startup: prints *"A gateway is already running under launchd for this profile."* and `sys.exit(1)`.
5. launchd's `KeepAlive=true` + `ThrottleInterval=30` respawns it every ~30 s, forever. Each spawn writes one refusal line to `gateway.log`; the `runs` counter and refusal count grow 1:1.

This affects every fresh/regenerated launchd install on the current code — the plist format with the wrapper is what all newly configured machines get, which matches the observed report of "old machines work, three newly configured machines all fail".

**Fix:** `stderr_timestamp` now detects the launchd-service case (its own PPID is 1 *and* `XPC_SERVICE_NAME` carries a real job label) and propagates `HERMES_GATEWAY_EXTERNAL_SUPERVISOR=1` to the child — the alternate marker `is_gateway_supervisor_process()` already honors for exactly this "wrapped service whose launcher strips the native marker" case (see `gateway/restart.py`). Detached-fallback wrappers (spawned by the CLI, PPID ≠ 1) and interactive shells (`XPC_SERVICE_NAME=0`) are deliberately excluded, so a manually started gateway is never mislabeled as supervised.

## Related Issue

None found via search — opening this PR directly with the full diagnosis in the description.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/stderr_timestamp.py` — new `_child_env()` helper: copies `os.environ` and, when `os.getppid() == 1` and `XPC_SERVICE_NAME` is set and not `"0"`, adds `HERMES_GATEWAY_EXTERNAL_SUPERVISOR=1`; `main()` passes it to `subprocess.Popen`.
- `tests/hermes_cli/test_stderr_timestamp.py` — 4 new unit tests covering all branches of `_child_env()` (launchd child, non-launchd parent, interactive-shell sentinel, missing var).

## How to Test

1. On macOS with the launchd service installed: `hermes gateway restart`, then watch `~/.hermes/logs/gateway.log`.
2. **Before fix**: the log fills with one *"A gateway is already running under launchd for this profile."* per ~30 s; `launchctl print gui/$(id -u)/ai.hermes.gateway` shows `runs` climbing and `last exit code = 1`; no platform ever connects.
3. **After fix**: the gateway starts normally, enabled platforms connect (`✓ qqbot connected` observed in a real install), and the `runs` counter stops climbing.
4. Unit tests: `scripts/run_tests.sh tests/hermes_cli/test_stderr_timestamp.py -v` → 5 passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the relevant tests and all pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.5.1 (arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — the fix is documented in the `_child_env()` docstring
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A — the change is macOS-only (launchd plist path) and no-ops elsewhere
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Before (refusal loop, one line per ~30 s, 178 accumulated refusals):

```
✗ A gateway is already running under launchd for this profile.
  Starting another one from a shell leaves an orphan dispatcher that
  escapes the service, survives restarts, and writes to the same kanban
  DB concurrently — which can corrupt it. Restart the supervised gateway
  instead:
```

After (real startup, QQ bot connects):

```
2026-08-16 00:06:44,943 INFO gateway.platforms.qqbot.adapter: [QQBot:1905433290] Gateway URL: wss://api.sgroup.qq.com/websocket
2026-08-16 00:06:49,699 INFO gateway.platforms.qqbot.adapter: [QQBot:1905433290] WebSocket connected to wss://api.sgroup.qq.com/websocket
2026-08-16 00:06:49,712 INFO gateway.run: ✓ qqbot connected
2026-08-16 00:06:49,894 INFO gateway.platforms.qqbot.adapter: [QQBot:1905433290] Ready, session_id=7fe10cae-98e2-49a0-b0c6-af60eff325fe
```
