### PR TITLE
feat(cron): broker specialist delivery through default profile

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -44,7 +44,12 @@ from typing import Any, List, Optional, Protocol
 # the module) fail with ModuleNotFoundError for hermes_time et al.
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
-from hermes_constants import get_hermes_home
+from hermes_constants import (
+    get_default_hermes_root,
+    get_hermes_home,
+    reset_hermes_home_override,
+    set_hermes_home_override,
+)
 from hermes_cli._subprocess_compat import windows_hide_flags
 from hermes_cli.config import (
     _expand_env_vars,
@@ -2212,6 +2217,198 @@ def _relay_fronted_delivery_platforms(connected: set) -> set:
         return set()
 
 
+def _default_cron_broker_policy() -> tuple[bool, set[str], Path]:
+    """Return the explicit default-profile outbound broker policy.
+
+    Multiplexed profiles deliberately keep messaging credentials isolated.  A
+    specialist cron may still need to *deliver* through a single default
+    gateway identity, however.  The broker is therefore opt-in, fail-closed,
+    and limited to an explicit platform allowlist stored on the default
+    profile.  Only routing metadata leaves this helper; credentials stay behind
+    the default profile's normal ``hermes send`` transport.
+    """
+    current_home = get_hermes_home().expanduser().resolve(strict=False)
+    default_home = get_default_hermes_root().expanduser().resolve(strict=False)
+    if current_home == default_home:
+        return False, set(), default_home
+
+    token = set_hermes_home_override(default_home)
+    try:
+        cfg = load_config() or {}
+    except Exception:
+        logger.debug("cron default delivery broker: default config unavailable", exc_info=True)
+        return False, set(), default_home
+    finally:
+        reset_hermes_home_override(token)
+
+    gateway_cfg = cfg.get("gateway") if isinstance(cfg.get("gateway"), dict) else {}
+    cron_cfg = cfg.get("cron") if isinstance(cfg.get("cron"), dict) else {}
+    if gateway_cfg.get("multiplex_profiles") is not True:
+        return False, set(), default_home
+    if cron_cfg.get("broker_outbound_via_default") is not True:
+        return False, set(), default_home
+
+    raw_allowed = cron_cfg.get("broker_outbound_platforms", [])
+    if isinstance(raw_allowed, str):
+        raw_text = raw_allowed.strip()
+        if raw_text.startswith("["):
+            try:
+                raw_allowed = json.loads(raw_text)
+            except (TypeError, ValueError, json.JSONDecodeError):
+                raw_allowed = raw_text.split(",")
+        else:
+            raw_allowed = raw_text.split(",")
+    if not isinstance(raw_allowed, (list, tuple, set)):
+        return False, set(), default_home
+    allowed = {
+        str(name).strip().lower()
+        for name in raw_allowed
+        if str(name).strip()
+    }
+    return bool(allowed), allowed, default_home
+
+
+def _default_cron_broker_connected_platforms() -> set[str]:
+    """Return broker-allowed platforms configured on the default profile."""
+    enabled, allowed, default_home = _default_cron_broker_policy()
+    if not enabled:
+        return set()
+    token = set_hermes_home_override(default_home)
+    try:
+        from gateway.config import load_gateway_config
+
+        gateway_config = load_gateway_config()
+        connected = {p.value for p in gateway_config.get_connected_platforms()}
+        # Do not expand relay-fronted logical platforms here. The broker sends
+        # through a separate `hermes send` process, which has no live gateway
+        # adapter/relay connection to borrow. Filter through the send layer's
+        # standalone-capability predicate so live-adapter-only platforms are
+        # never advertised as brokerable.
+        from tools.send_message_tool import supports_standalone_send
+
+        return {
+            name
+            for name in connected & allowed
+            if supports_standalone_send(name)
+        }
+    except Exception:
+        logger.debug("cron default delivery broker: platform probe failed", exc_info=True)
+        return set()
+    finally:
+        reset_hermes_home_override(token)
+
+
+def _default_cron_broker_home_target(platform_name: str) -> tuple[str, Optional[str]]:
+    """Return the default profile's canonical home target for one broker platform."""
+    enabled, allowed, default_home = _default_cron_broker_policy()
+    platform_key = str(platform_name).strip().lower()
+    if not enabled or platform_key not in allowed:
+        return "", None
+    token = set_hermes_home_override(default_home)
+    try:
+        home = _get_config_home_channel(platform_key)
+        if home is None or not getattr(home, "chat_id", None):
+            return "", None
+        thread_id = getattr(home, "thread_id", None)
+        return str(home.chat_id), str(thread_id) if thread_id else None
+    finally:
+        reset_hermes_home_override(token)
+
+
+def _send_via_default_cron_broker(
+    platform_name: str,
+    chat_id: str,
+    content: str,
+    *,
+    thread_id: Optional[str] = None,
+    media_files: Optional[list] = None,
+) -> Optional[str]:
+    """Deliver through the default profile without exposing its credential.
+
+    The specialist scheduler invokes the supported ``hermes send`` CLI in a
+    child process whose HERMES_HOME is the default profile.  This is a narrow
+    outbound capability broker: the specialist agent never receives, reads, or
+    inherits the default profile's messaging secret.
+    """
+    enabled, allowed, default_home = _default_cron_broker_policy()
+    platform_key = str(platform_name).strip().lower()
+    if not enabled or platform_key not in allowed:
+        return f"default delivery broker is not enabled for '{platform_key}'"
+
+    target = f"{platform_key}:{chat_id}"
+    if thread_id is not None and str(thread_id).strip():
+        target = f"{target}:{str(thread_id).strip()}"
+
+    payload = content or ""
+    for media_path in media_files or []:
+        payload += f"\nMEDIA:{media_path}"
+
+    exe_name = "hermes.exe" if os.name == "nt" else "hermes"
+    hermes_exe = Path(sys.executable).with_name(exe_name)
+    if not hermes_exe.exists():
+        resolved = shutil.which("hermes")
+        if not resolved:
+            return "default delivery broker could not locate the Hermes CLI"
+        hermes_exe = Path(resolved)
+
+    # Start from Hermes's normal sanitized child environment so provider keys,
+    # profile-local messaging credentials, and other managed secrets are not
+    # copied from the specialist process into the broker child. The child then
+    # loads Default's own messaging configuration from HERMES_HOME.
+    try:
+        from tools.environments.local import build_subprocess_env
+
+        env = build_subprocess_env()
+    except Exception as exc:
+        # This broker crosses a profile authority boundary. Never fall back to
+        # inheriting the specialist process environment if the centralized
+        # scrubber is unavailable: failing closed is safer than risking a
+        # specialist credential crossing into the Default-scoped child.
+        logger.debug(
+            "cron default delivery broker: sanitized child env unavailable",
+            exc_info=True,
+        )
+        return (
+            "default delivery broker could not build a sanitized child "
+            f"environment: {type(exc).__name__}"
+        )
+    env["HERMES_HOME"] = str(default_home)
+    try:
+        proc = subprocess.run(
+            [
+                str(hermes_exe),
+                "-p",
+                "default",
+                "send",
+                "--to",
+                target,
+                "--file",
+                "-",
+                "--quiet",
+            ],
+            input=payload,
+            text=True,
+            capture_output=True,
+            env=env,
+            timeout=120,
+            check=False,
+            creationflags=windows_hide_flags(),
+        )
+    except Exception as exc:
+        return f"default delivery broker failed to launch: {type(exc).__name__}: {exc}"
+    if proc.returncode == 0:
+        return None
+
+    detail = (proc.stderr or proc.stdout or "delivery command failed").strip()
+    try:
+        from agent.redact import redact_sensitive_text
+
+        detail = redact_sensitive_text(detail, force=True)
+    except Exception:
+        detail = "delivery command failed"
+    return f"default delivery broker failed with exit code {proc.returncode}: {detail[:500]}"
+
+
 def cron_delivery_targets() -> list[dict]:
     """Return the platforms a cron job can auto-deliver to.
 
@@ -2236,18 +2433,23 @@ def cron_delivery_targets() -> list[dict]:
     except Exception:
         logger.debug("cron_delivery_targets: gateway config unavailable", exc_info=True)
         connected = set()
+    broker_connected = _default_cron_broker_connected_platforms()
+    available = connected | broker_connected
 
     for name in _iter_home_target_platforms():
-        if name not in connected:
+        if name not in available:
             continue
         if not _is_known_delivery_platform(name):
             continue
         env_var = _resolve_home_env_var(name)
+        home_target = _get_home_target_chat_id(name)
+        if not home_target and name in broker_connected:
+            home_target, _thread_id = _default_cron_broker_home_target(name)
         targets.append(
             {
                 "id": name,
                 "name": name.replace("_", " ").title(),
-                "home_target_set": bool(_get_home_target_chat_id(name)),
+                "home_target_set": bool(home_target),
                 "home_env_var": env_var or None,
             }
         )
@@ -2329,6 +2531,9 @@ def _resolve_single_delivery_target(job: dict, deliver_value: str) -> Optional[d
         # platform's home channel as a fallback instead of silently dropping.
         for platform_name in _iter_home_target_platforms():
             chat_id = _get_home_target_chat_id(platform_name)
+            thread_id = _get_home_target_thread_id(platform_name)
+            if not chat_id:
+                chat_id, thread_id = _default_cron_broker_home_target(platform_name)
             if chat_id:
                 logger.info(
                     "Job '%s' has deliver=origin but no origin; falling back to %s home channel",
@@ -2338,7 +2543,7 @@ def _resolve_single_delivery_target(job: dict, deliver_value: str) -> Optional[d
                 return {
                     "platform": platform_name,
                     "chat_id": chat_id,
-                    "thread_id": _get_home_target_thread_id(platform_name),
+                    "thread_id": thread_id,
                 }
         return None
 
@@ -2403,13 +2608,16 @@ def _resolve_single_delivery_target(job: dict, deliver_value: str) -> Optional[d
     if not _is_known_delivery_platform(platform_name):
         return None
     chat_id = _get_home_target_chat_id(platform_name)
+    thread_id = _get_home_target_thread_id(platform_name)
+    if not chat_id:
+        chat_id, thread_id = _default_cron_broker_home_target(platform_name)
     if not chat_id:
         return None
 
     return {
         "platform": platform_name,
         "chat_id": chat_id,
-        "thread_id": _get_home_target_thread_id(platform_name),
+        "thread_id": thread_id,
     }
 
 
@@ -2969,6 +3177,16 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
         return msg
 
     delivery_errors = []
+    try:
+        local_connected_platforms = {
+            p.value for p in config.get_connected_platforms()
+        }
+        local_connected_platforms |= _relay_fronted_delivery_platforms(
+            local_connected_platforms
+        )
+    except Exception:
+        local_connected_platforms = set()
+    broker_connected_platforms = _default_cron_broker_connected_platforms()
 
     for target in targets:
         platform_name = target["platform"]
@@ -3025,10 +3243,24 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
 
         from gateway.delivery import resolve_delivery_transport
 
-        transport = resolve_delivery_transport(platform, config, adapters)
+        platform_key = platform_name.lower()
+        brokered = (
+            platform_key not in local_connected_platforms
+            and platform_key in broker_connected_platforms
+        )
+        transport = None if brokered else resolve_delivery_transport(platform, config, adapters)
         if transport is not None:
             pconfig = transport.config
             runtime_adapter = transport.adapter
+        elif brokered:
+            # Outbound-only broker: the specialist profile owns the cron run,
+            # while Default owns the messaging identity.  Keep a credential-free
+            # placeholder config in this process; actual send happens through a
+            # child ``hermes send`` scoped to the default profile below.
+            from gateway.config import PlatformConfig
+
+            pconfig = PlatformConfig(enabled=True)
+            runtime_adapter = None
         else:
             # No live transport: preserve the existing standalone delivery path,
             # which uses the logical platform's configured credential.
@@ -3063,7 +3295,8 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
         # case the live-send block is skipped and delivery falls through to the
         # standalone path — which cannot seed the flat session (r3609147550).
         live_adapter_ready = (
-            runtime_adapter is not None
+            not brokered
+            and runtime_adapter is not None
             and loop is not None
             and getattr(loop, "is_running", lambda: False)()
         )
@@ -3543,6 +3776,31 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                     )
 
         if not delivered:
+            if brokered:
+                broker_error = _send_via_default_cron_broker(
+                    platform_name,
+                    str(chat_id),
+                    cleaned_delivery_content,
+                    thread_id=thread_id,
+                    media_files=media_files,
+                )
+                if broker_error:
+                    msg = (
+                        f"brokered delivery to {platform_name}:{chat_id} failed: "
+                        f"{broker_error}"
+                    )
+                    logger.error("Job '%s': %s", job["id"], msg)
+                    target_errors.append(msg)
+                    delivery_errors.extend(target_errors)
+                else:
+                    logger.info(
+                        "Job '%s': delivered to %s:%s via default-profile outbound broker",
+                        job["id"], platform_name, chat_id,
+                    )
+                # Brokered notifications are intentionally one-way.  Do not
+                # seed/mirror a specialist session into Default's chat history;
+                # replies continue with the Default/Orchestrator bot identity.
+                continue
             if transport is not None and transport.is_relay:
                 # Relay owns the logical destination and its connector owns the
                 # platform credential. A native retry could duplicate delivery
@@ -4816,6 +5074,7 @@ def _preflight_check_delivery(job: dict) -> Optional[str]:
         return None
 
     connected: Optional[set] = None
+    broker_connected: Optional[set] = None
     for platform_name in platform_parts:
         if not _is_known_delivery_platform(platform_name):
             return (
@@ -4839,10 +5098,16 @@ def _preflight_check_delivery(job: dict) -> Optional[str]:
                 )
                 return None  # fail-open
         if platform_name.lower() not in connected:
+            if broker_connected is None:
+                broker_connected = _default_cron_broker_connected_platforms()
+            if platform_name.lower() in broker_connected:
+                continue
             return (
                 f"delivery platform '{platform_name}' has no gateway "
-                "credentials configured (not connected). Configure it via "
-                "`hermes setup` or change the job's `deliver` target."
+                "credentials configured (not connected), and no authorized "
+                "default-profile outbound broker is available. Configure it via "
+                "`hermes setup`, enable the default delivery broker, or change "
+                "the job's `deliver` target."
             )
     return None
 

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -2563,6 +2563,16 @@ DEFAULT_CONFIG = {
         # with ONE alert (no re-alert every tick) and NO LLM call is made.
         # Set to false to restore the old behavior (fail during the run).
         "preflight": True,
+        # Optional outbound-only delivery broker for multiplexed profiles.
+        # Named profiles keep their messaging credentials isolated, but when
+        # this is explicitly enabled on Default they may hand a finished cron
+        # payload to Default's normal `hermes send` transport. Credentials are
+        # never copied into the specialist process. Fail closed unless both the
+        # switch and an explicit platform allowlist are present. The grant is
+        # platform-wide outbound authority: an allowed specialist cron may send
+        # to any valid target on that platform, so keep this allowlist narrow.
+        "broker_outbound_via_default": False,
+        "broker_outbound_platforms": [],
         # Fail closed when an unpinned job's current global model/provider
         # differs from its creation-time snapshot. This prevents unattended
         # jobs from silently inheriting a paid default. Set to false only when

--- a/tests/cron/test_default_delivery_broker.py
+++ b/tests/cron/test_default_delivery_broker.py
@@ -1,0 +1,432 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+import cron.scheduler as sched
+
+
+def _gateway_config(connected_values):
+    config = MagicMock()
+    config.get_connected_platforms.return_value = [
+        MagicMock(value=value) for value in connected_values
+    ]
+    return config
+
+
+def test_preflight_accepts_authorized_default_broker(monkeypatch):
+    monkeypatch.setattr(
+        sched, "_default_cron_broker_connected_platforms", lambda: {"telegram"}
+    )
+    with patch("gateway.config.load_gateway_config", return_value=_gateway_config(set())):
+        assert sched._preflight_check_delivery({"deliver": "telegram"}) is None
+
+
+def test_preflight_rejects_platform_outside_broker(monkeypatch):
+    monkeypatch.setattr(
+        sched, "_default_cron_broker_connected_platforms", lambda: {"telegram"}
+    )
+    with patch("gateway.config.load_gateway_config", return_value=_gateway_config(set())):
+        reason = sched._preflight_check_delivery({"deliver": "discord:123"})
+    assert reason is not None
+    assert "no authorized default-profile outbound broker" in reason
+
+
+def test_bare_platform_can_resolve_default_broker_home(monkeypatch):
+    monkeypatch.setattr(sched, "_get_home_target_chat_id", lambda _name: "")
+    monkeypatch.setattr(sched, "_get_home_target_thread_id", lambda _name: None)
+    monkeypatch.setattr(
+        sched,
+        "_default_cron_broker_home_target",
+        lambda name: ("1234567890", None) if name == "telegram" else ("", None),
+    )
+    target = sched._resolve_single_delivery_target({}, "telegram")
+    assert target == {
+        "platform": "telegram",
+        "chat_id": "1234567890",
+        "thread_id": None,
+    }
+
+
+def test_broker_send_scopes_child_to_default_home(monkeypatch, tmp_path):
+    default_home = tmp_path / ".hermes"
+    default_home.mkdir()
+    monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "specialist-must-not-leak")
+    monkeypatch.setenv("DISCORD_BOT_TOKEN", "specialist-must-not-leak")
+    monkeypatch.setattr(
+        sched,
+        "_default_cron_broker_policy",
+        lambda: (True, {"telegram", "discord"}, default_home),
+    )
+    completed = MagicMock(returncode=0, stdout="", stderr="")
+    monkeypatch.setattr(sched.subprocess, "run", MagicMock(return_value=completed))
+
+    error = sched._send_via_default_cron_broker(
+        "telegram",
+        "1234567890",
+        "hello",
+        media_files=["/tmp/chart.png"],
+    )
+
+    assert error is None
+    call = sched.subprocess.run.call_args
+    assert call.kwargs["env"]["HERMES_HOME"] == str(default_home)
+    assert call.kwargs["creationflags"] == sched.windows_hide_flags()
+    assert "TELEGRAM_BOT_TOKEN" not in call.kwargs["env"]
+    assert "DISCORD_BOT_TOKEN" not in call.kwargs["env"]
+    assert call.kwargs["input"] == "hello\nMEDIA:/tmp/chart.png"
+    assert call.args[0][1:4] == ["-p", "default", "send"]
+    assert call.args[0][-6:] == [
+        "send",
+        "--to",
+        "telegram:1234567890",
+        "--file",
+        "-",
+        "--quiet",
+    ]
+
+
+def _set_profile_homes(monkeypatch, tmp_path, profile="growth"):
+    default_home = tmp_path / "fleet-root"
+    specialist_home = default_home / "profiles" / profile
+    specialist_home.mkdir(parents=True)
+    monkeypatch.setattr(sched, "get_hermes_home", lambda: specialist_home)
+    monkeypatch.setattr(sched, "get_default_hermes_root", lambda: default_home)
+    return default_home, specialist_home
+
+
+def test_policy_reads_authority_from_default_profile(monkeypatch, tmp_path):
+    default_home, _specialist_home = _set_profile_homes(monkeypatch, tmp_path)
+    observed = {}
+
+    def fake_load_config():
+        from hermes_constants import get_hermes_home
+
+        observed["home"] = get_hermes_home()
+        return {
+            "gateway": {"multiplex_profiles": True},
+            "cron": {
+                "broker_outbound_via_default": True,
+                "broker_outbound_platforms": '["telegram", "discord"]',
+            },
+        }
+
+    monkeypatch.setattr(sched, "load_config", fake_load_config)
+    enabled, allowed, resolved_default = sched._default_cron_broker_policy()
+
+    assert enabled is True
+    assert allowed == {"telegram", "discord"}
+    assert resolved_default == default_home
+    assert observed["home"] == default_home
+
+
+def test_default_profile_never_brokers_through_itself(monkeypatch, tmp_path):
+    default_home = tmp_path / "fleet-root"
+    default_home.mkdir()
+    monkeypatch.setattr(sched, "get_hermes_home", lambda: default_home)
+    monkeypatch.setattr(sched, "get_default_hermes_root", lambda: default_home)
+    load = MagicMock()
+    monkeypatch.setattr(sched, "load_config", load)
+
+    assert sched._default_cron_broker_policy() == (False, set(), default_home)
+    load.assert_not_called()
+
+
+def test_policy_real_config_load_from_named_profile_context(monkeypatch, tmp_path):
+    from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+
+    default_home = tmp_path / "fleet-root"
+    specialist_home = default_home / "profiles" / "growth"
+    specialist_home.mkdir(parents=True)
+    (default_home / "config.yaml").write_text(
+        "gateway:\n"
+        "  multiplex_profiles: true\n"
+        "cron:\n"
+        "  broker_outbound_via_default: true\n"
+        "  broker_outbound_platforms:\n"
+        "    - telegram\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(default_home))
+
+    token = set_hermes_home_override(specialist_home)
+    try:
+        enabled, allowed, resolved_default = sched._default_cron_broker_policy()
+    finally:
+        reset_hermes_home_override(token)
+
+    assert enabled is True
+    assert allowed == {"telegram"}
+    assert resolved_default == default_home
+
+
+@pytest.mark.parametrize(
+    "gateway_cfg,cron_cfg",
+    [
+        ({"multiplex_profiles": False}, {"broker_outbound_via_default": True, "broker_outbound_platforms": ["telegram"]}),
+        ({"multiplex_profiles": True}, {"broker_outbound_via_default": False, "broker_outbound_platforms": ["telegram"]}),
+        ({"multiplex_profiles": True}, {"broker_outbound_via_default": True, "broker_outbound_platforms": []}),
+        ({"multiplex_profiles": True}, {"broker_outbound_via_default": True, "broker_outbound_platforms": {"telegram": True}}),
+    ],
+)
+def test_policy_fails_closed_without_all_required_authority(
+    monkeypatch, tmp_path, gateway_cfg, cron_cfg
+):
+    default_home, _specialist_home = _set_profile_homes(monkeypatch, tmp_path)
+    monkeypatch.setattr(
+        sched,
+        "load_config",
+        lambda: {"gateway": gateway_cfg, "cron": cron_cfg},
+    )
+
+    enabled, allowed, resolved_default = sched._default_cron_broker_policy()
+    assert enabled is False
+    assert allowed == set()
+    assert resolved_default == default_home
+
+
+def test_policy_normalizes_comma_separated_allowlist(monkeypatch, tmp_path):
+    _default_home, _specialist_home = _set_profile_homes(monkeypatch, tmp_path)
+    monkeypatch.setattr(
+        sched,
+        "load_config",
+        lambda: {
+            "gateway": {"multiplex_profiles": True},
+            "cron": {
+                "broker_outbound_via_default": True,
+                "broker_outbound_platforms": " Telegram, DISCORD , ",
+            },
+        },
+    )
+
+    enabled, allowed, _ = sched._default_cron_broker_policy()
+    assert enabled is True
+    assert allowed == {"telegram", "discord"}
+
+
+def test_connected_platforms_are_intersection_of_default_and_allowlist(monkeypatch, tmp_path):
+    default_home = tmp_path / "fleet-root"
+    default_home.mkdir()
+    monkeypatch.setattr(
+        sched,
+        "_default_cron_broker_policy",
+        lambda: (True, {"telegram", "discord"}, default_home),
+    )
+    with patch(
+        "gateway.config.load_gateway_config",
+        return_value=_gateway_config({"telegram", "slack"}),
+    ), patch(
+        "tools.send_message_tool.supports_standalone_send",
+        side_effect=lambda name: name == "telegram",
+    ):
+        assert sched._default_cron_broker_connected_platforms() == {"telegram"}
+
+
+def test_connected_live_only_platform_is_not_broker_authorized(monkeypatch, tmp_path):
+    default_home = tmp_path / "fleet-root"
+    default_home.mkdir()
+    monkeypatch.setattr(
+        sched,
+        "_default_cron_broker_policy",
+        lambda: (True, {"yuanbao"}, default_home),
+    )
+    with patch(
+        "gateway.config.load_gateway_config",
+        return_value=_gateway_config({"yuanbao"}),
+    ), patch(
+        "tools.send_message_tool.supports_standalone_send",
+        return_value=False,
+    ):
+        assert sched._default_cron_broker_connected_platforms() == set()
+
+
+def test_home_target_is_read_under_default_profile(monkeypatch, tmp_path):
+    default_home = tmp_path / "fleet-root"
+    default_home.mkdir()
+    observed = {}
+    monkeypatch.setattr(
+        sched,
+        "_default_cron_broker_policy",
+        lambda: (True, {"telegram"}, default_home),
+    )
+
+    def fake_home(_platform):
+        from hermes_constants import get_hermes_home
+
+        observed["home"] = get_hermes_home()
+        return SimpleNamespace(chat_id="123", thread_id="17")
+
+    monkeypatch.setattr(sched, "_get_config_home_channel", fake_home)
+    assert sched._default_cron_broker_home_target("telegram") == ("123", "17")
+    assert observed["home"] == default_home
+
+
+def test_broker_refuses_platform_not_in_allowlist(monkeypatch, tmp_path):
+    default_home = tmp_path / "fleet-root"
+    default_home.mkdir()
+    monkeypatch.setattr(
+        sched,
+        "_default_cron_broker_policy",
+        lambda: (True, {"telegram"}, default_home),
+    )
+    run = MagicMock()
+    monkeypatch.setattr(sched.subprocess, "run", run)
+
+    error = sched._send_via_default_cron_broker("discord", "123", "hello")
+
+    assert "not enabled" in error
+    run.assert_not_called()
+
+
+def test_broker_fails_closed_if_sanitized_env_builder_fails(monkeypatch, tmp_path):
+    default_home = tmp_path / "fleet-root"
+    default_home.mkdir()
+    monkeypatch.setattr(
+        sched,
+        "_default_cron_broker_policy",
+        lambda: (True, {"telegram"}, default_home),
+    )
+    run = MagicMock()
+    monkeypatch.setattr(sched.subprocess, "run", run)
+
+    with patch(
+        "tools.environments.local.build_subprocess_env",
+        side_effect=RuntimeError("sanitizer unavailable"),
+    ):
+        error = sched._send_via_default_cron_broker("telegram", "123", "hello")
+
+    assert "sanitized child environment" in error
+    assert "RuntimeError" in error
+    run.assert_not_called()
+
+
+def test_preflight_accepts_explicit_target_on_authorized_broker(monkeypatch):
+    monkeypatch.setattr(
+        sched, "_default_cron_broker_connected_platforms", lambda: {"telegram"}
+    )
+    with patch("gateway.config.load_gateway_config", return_value=_gateway_config(set())):
+        assert sched._preflight_check_delivery({"deliver": "telegram:123"}) is None
+
+
+def test_delivery_targets_include_brokered_platform_and_default_home(monkeypatch):
+    monkeypatch.setattr(sched, "_iter_home_target_platforms", lambda: ["telegram", "discord"])
+    monkeypatch.setattr(sched, "_is_known_delivery_platform", lambda name: True)
+    monkeypatch.setattr(sched, "_resolve_home_env_var", lambda name: f"{name.upper()}_HOME")
+    monkeypatch.setattr(sched, "_get_home_target_chat_id", lambda _name: "")
+    monkeypatch.setattr(
+        sched, "_default_cron_broker_connected_platforms", lambda: {"telegram"}
+    )
+    monkeypatch.setattr(
+        sched,
+        "_default_cron_broker_home_target",
+        lambda name: ("123", None) if name == "telegram" else ("", None),
+    )
+
+    with patch("gateway.config.load_gateway_config", return_value=_gateway_config(set())):
+        platform_targets = [
+            target
+            for target in sched.cron_delivery_targets()
+            if not target["id"].startswith("bot-chat:")
+        ]
+        assert platform_targets == [
+            {
+                "id": "telegram",
+                "name": "Telegram",
+                "home_target_set": True,
+                "home_env_var": "TELEGRAM_HOME",
+            }
+        ]
+
+
+def _delivery_config(local_platforms):
+    from gateway.config import Platform, PlatformConfig
+
+    config = MagicMock()
+    config.get_connected_platforms.return_value = [
+        MagicMock(value=name) for name in local_platforms
+    ]
+    config.platforms = {
+        Platform(name): PlatformConfig(enabled=True)
+        for name in local_platforms
+    }
+    return config
+
+
+def test_local_specialist_transport_wins_over_broker(monkeypatch):
+    config = _delivery_config({"telegram"})
+    broker_send = MagicMock(return_value=None)
+    standalone_send = AsyncMock(return_value={"success": True})
+    monkeypatch.setattr(
+        sched,
+        "_resolve_delivery_targets",
+        lambda _job: [{"platform": "telegram", "chat_id": "123", "thread_id": None}],
+    )
+    monkeypatch.setattr(
+        sched, "_default_cron_broker_connected_platforms", lambda: {"telegram"}
+    )
+    monkeypatch.setattr(sched, "_send_via_default_cron_broker", broker_send)
+
+    with patch("gateway.config.load_gateway_config", return_value=config), patch(
+        "cron.scheduler.load_config", return_value={"cron": {"wrap_response": False}}
+    ), patch("tools.send_message_tool._send_to_platform", new=standalone_send):
+        error = sched._deliver_result({"id": "job", "deliver": "telegram"}, "hello")
+
+    assert error is None
+    standalone_send.assert_awaited_once()
+    broker_send.assert_not_called()
+
+
+def test_broker_failure_propagates_as_delivery_error(monkeypatch):
+    config = _delivery_config(set())
+    monkeypatch.setattr(
+        sched,
+        "_resolve_delivery_targets",
+        lambda _job: [{"platform": "telegram", "chat_id": "123", "thread_id": None}],
+    )
+    monkeypatch.setattr(
+        sched, "_default_cron_broker_connected_platforms", lambda: {"telegram"}
+    )
+    monkeypatch.setattr(
+        sched,
+        "_send_via_default_cron_broker",
+        lambda *_args, **_kwargs: "simulated broker outage",
+    )
+
+    with patch("gateway.config.load_gateway_config", return_value=config), patch(
+        "cron.scheduler.load_config", return_value={"cron": {"wrap_response": False}}
+    ):
+        error = sched._deliver_result({"id": "job", "deliver": "telegram"}, "hello")
+
+    assert error is not None
+    assert "brokered delivery to telegram:123 failed" in error
+    assert "simulated broker outage" in error
+
+
+def test_mixed_local_and_brokered_targets_each_send_once(monkeypatch):
+    config = _delivery_config({"discord"})
+    broker_send = MagicMock(return_value=None)
+    standalone_send = AsyncMock(return_value={"success": True})
+    monkeypatch.setattr(
+        sched,
+        "_resolve_delivery_targets",
+        lambda _job: [
+            {"platform": "telegram", "chat_id": "111", "thread_id": None},
+            {"platform": "discord", "chat_id": "222", "thread_id": None},
+        ],
+    )
+    monkeypatch.setattr(
+        sched, "_default_cron_broker_connected_platforms", lambda: {"telegram"}
+    )
+    monkeypatch.setattr(sched, "_send_via_default_cron_broker", broker_send)
+
+    with patch("gateway.config.load_gateway_config", return_value=config), patch(
+        "cron.scheduler.load_config", return_value={"cron": {"wrap_response": False}}
+    ), patch("tools.send_message_tool._send_to_platform", new=standalone_send):
+        error = sched._deliver_result(
+            {"id": "job", "deliver": "telegram:111,discord:222"}, "hello"
+        )
+
+    assert error is None
+    broker_send.assert_called_once()
+    assert broker_send.call_args.args[:2] == ("telegram", "111")
+    standalone_send.assert_awaited_once()

--- a/tests/tools/test_send_message_standalone_capability.py
+++ b/tests/tools/test_send_message_standalone_capability.py
@@ -1,0 +1,45 @@
+from unittest.mock import MagicMock, patch
+
+from tools.send_message_tool import supports_standalone_send
+
+
+def test_native_direct_platforms_are_standalone_capable():
+    for platform_name in ("signal", "weixin", "bluebubbles", "qqbot"):
+        assert supports_standalone_send(platform_name) is True
+
+
+def test_registered_standalone_sender_is_capable():
+    entry = MagicMock()
+    entry.standalone_sender_fn = object()
+    with patch("tools.send_message_tool.prepare_send_message_platforms"), patch(
+        "gateway.platform_registry.platform_registry.get", return_value=entry
+    ):
+        assert supports_standalone_send("custom-platform") is True
+
+
+def test_registered_live_only_platform_is_not_standalone_capable():
+    entry = MagicMock()
+    entry.standalone_sender_fn = None
+    with patch("tools.send_message_tool.prepare_send_message_platforms"), patch(
+        "gateway.platform_registry.platform_registry.get", return_value=entry
+    ):
+        assert supports_standalone_send("live-only") is False
+
+
+def test_unregistered_platform_is_not_standalone_capable():
+    with patch("tools.send_message_tool.prepare_send_message_platforms"), patch(
+        "gateway.platform_registry.platform_registry.get", return_value=None
+    ):
+        assert supports_standalone_send("missing-platform") is False
+
+
+def test_live_adapter_only_native_platform_is_not_whitelisted():
+    with patch("tools.send_message_tool.prepare_send_message_platforms"), patch(
+        "gateway.platform_registry.platform_registry.get", return_value=None
+    ):
+        assert supports_standalone_send("yuanbao") is False
+        assert supports_standalone_send("relay") is False
+
+
+def test_blank_platform_is_not_standalone_capable():
+    assert supports_standalone_send("") is False

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -93,6 +93,42 @@ def prepare_send_message_platforms() -> None:
     discover_plugins()
 
 
+# Native send paths that are genuinely usable from an out-of-process
+# ``hermes send`` invocation even though they do not register a plugin
+# ``standalone_sender_fn``. Keep this intentionally narrow: transports that
+# require a live adapter/persistent gateway connection (for example Yuanbao)
+# must not be advertised as standalone-capable.
+_NATIVE_STANDALONE_SEND_PLATFORMS = frozenset(
+    {"signal", "weixin", "bluebubbles", "qqbot"}
+)
+
+
+def supports_standalone_send(platform_name: str) -> bool:
+    """Return whether ``hermes send`` can deliver without a live gateway.
+
+    This is the capability boundary for out-of-process callers such as cron
+    delivery brokers. Plugin platforms opt in with ``standalone_sender_fn``;
+    a small number of native direct transports are listed above because their
+    send path is implemented in this module rather than the platform registry.
+    """
+    name = str(platform_name or "").strip().lower()
+    if not name:
+        return False
+    if name in _NATIVE_STANDALONE_SEND_PLATFORMS:
+        return True
+    try:
+        prepare_send_message_platforms()
+        from gateway.platform_registry import platform_registry
+
+        entry = platform_registry.get(name)
+        return bool(entry is not None and entry.standalone_sender_fn is not None)
+    except Exception:
+        logger.debug(
+            "standalone send capability lookup failed for %s", name, exc_info=True
+        )
+        return False
+
+
 def _media_caption_split(text, media_files, *, max_caption_len):
     """Decide whether the accompanying text should ride on the media bubble.
 


### PR DESCRIPTION
## Summary

Adds an opt-in outbound delivery broker for cron jobs owned by named profiles in a multiplexed Hermes deployment.

A specialist profile keeps ownership of the cron job and its execution context, while Default can provide the messaging identity for the final outbound notification. Messaging credentials are never copied into the specialist profile.

- adds `cron.broker_outbound_via_default`, disabled by default
- adds an explicit `cron.broker_outbound_platforms` allowlist on Default
- requires `gateway.multiplex_profiles: true`
- lets specialist cron preflight use an authorized Default transport when no local specialist transport exists
- resolves bare brokered platforms against Default's configured home target
- exposes broker-authorized targets through the existing cron delivery-target discovery surface
- keeps a healthy specialist-local transport authoritative; the broker is fallback-only
- propagates broker delivery failures into normal cron delivery error handling
- supports mixed local + brokered fan-out without duplicate sends

## Rebase

Rebased as a single commit onto current `main` at `f43eabee5f36e11448086ee8ee17c499958e81bf`.

The branch had diverged by more than a thousand upstream commits, so this recovery used GitHub's conflict-free three-way merge tree from the old feature head and then layered it onto the exact current-main tree. The only two upstream commits after that synthetic merge touched Desktop preview files and did not overlap any of this PR's five files.

Current head: `cf4285df5be399dc86b847a789c0c23e7348dbe9`.

## Authority and security model

The broker is deliberately narrow and fail-closed.

- policy is read from Default, not from the specialist profile
- the platform allowlist is a platform-wide outbound authority grant, so it should be kept narrow
- Default root resolution uses `get_default_hermes_root()` so standard, custom-root, Docker, and profile layouts follow Hermes's existing path semantics
- profile scoping uses Hermes's context-local `HERMES_HOME` override (`ContextVar`); it does not mutate process-global `os.environ`
- the child process is built through Hermes's centralized sanitized subprocess environment; if that sanitizer is unavailable, broker delivery is refused rather than falling back to inherited variables
- the broker child receives an explicit Default `HERMES_HOME` and is invoked with `-p default`, so sticky profile state cannot redirect delivery into a specialist
- broker availability is filtered through the send layer's actual standalone-send capability
- relay-fronted logical platforms and live-adapter-only platforms are not advertised as subprocess-brokerable
- brokered notifications are intentionally one-way: the specialist does not seed or mirror a continuation session into Default's chat history

## Review follow-up

The earlier automated review raised two points that are now explicitly covered:

1. **Failure propagation:** broker failures are appended to the same `delivery_errors` path used by normal cron delivery and are returned by `_deliver_result`; the focused regression test asserts the exact broker outage appears in the returned delivery error.
2. **HERMES_HOME switching:** on current Hermes, `set_hermes_home_override()` is context-local via `ContextVar`, not a process-global environment flip. Repeated Default-policy loads may still be a micro-optimization opportunity, but they no longer create the concurrency window described in the earlier review.

## Compatibility

Existing behavior is unchanged unless both the broker switch and a non-empty platform allowlist are configured on Default. Single-profile installs and Default-owned cron jobs do not broker through themselves.

## Regression coverage

The rebased branch carries focused coverage for:

- Default-policy loading from a named-profile context
- explicit Default child selection
- sanitized-child failure behavior
- allowlist refusal
- local-transport precedence over broker fallback
- broker failure propagation through normal delivery errors
- mixed local + brokered fan-out with no duplicate sends
- broker-aware preflight
- UI delivery-target discovery using Default home targets
- standalone-send capability detection and rejection of live-only transports

## CI

Fresh exact-head CI is being triggered for `cf4285df5be399dc86b847a789c0c23e7348dbe9`. This PR should not be treated as green until those runs complete successfully.