### PR TITLE
fix(cron): respect explicit Slack channel targets

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -1998,17 +1998,6 @@ def _resolve_single_delivery_target(job: dict, deliver_value: str) -> Optional[d
             )
             return None
 
-        if (
-            thread_id is None
-            and platform_key == "slack"
-            and origin
-            and str(origin.get("platform") or "").lower() == platform_key
-            and str(origin.get("chat_id")) == str(chat_id)
-            and origin.get("thread_id")
-            and not _origin_thread_is_stale(origin)
-        ):
-            thread_id = origin.get("thread_id")
-
         return {
             "platform": platform_name,
             "chat_id": chat_id,

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -199,6 +199,23 @@ class TestResolveDeliveryTarget:
             "thread_id": None,
         }
 
+    def test_explicit_slack_channel_target_does_not_inherit_origin_thread(self):
+        job = {
+            "deliver": "slack:C0BAC08MFJQ",
+            "origin": {
+                "platform": "slack",
+                "chat_id": "C0BAC08MFJQ",
+                "thread_id": "1784409341.664739",
+            },
+        }
+
+        assert _resolve_delivery_target(job) == {
+            "platform": "slack",
+            "chat_id": "C0BAC08MFJQ",
+            "thread_id": None,
+        }
+
+
     def test_telegram_cron_thread_id_overrides_home_thread_id(self, monkeypatch):
         """TELEGRAM_CRON_THREAD_ID wins over TELEGRAM_HOME_CHANNEL_THREAD_ID for cron (#24409)."""
         monkeypatch.setenv("TELEGRAM_HOME_CHANNEL", "-1001234567890")


### PR DESCRIPTION
## Summary
- stop explicit `slack:CHANNEL_ID` cron destinations from inheriting the creating thread
- preserve thread delivery only when the target explicitly includes `:THREAD_ID` or uses `origin`
- add a regression test for same-channel jobs created inside a thread

## Test plan
- `TMPDIR=$PWD/.tmp python -m pytest tests/cron/test_scheduler.py::TestResolveDeliveryTarget -q`
- `TMPDIR=$PWD/.tmp python -m pytest tests/cron/test_scheduler.py -q`

Triggered by: Mhadi
Source: https://sync-labs-workspace.slack.com/archives/C0BAC08MFJQ/p1784409341664739