### PR TITLE
feat(managed-files): signed short-lived download tickets for external viewers

### DIFF
--- a/hermes_cli/dashboard_auth/download_ticket.py
+++ b/hermes_cli/dashboard_auth/download_ticket.py
@@ -1,0 +1,84 @@
+"""Short-lived signed download tickets for external viewers (WPS Office etc.).
+
+The gated dashboard authenticates with session cookies. An external viewer
+like WPS Office opens a plain GET URL and can attach neither cookies nor
+headers, so the cookie gate would 401 every direct link. These tickets let a
+first-party caller (agent, App, or the /api/files/download-ticket endpoint)
+mint a time-limited, path-scoped signed URL for ``/api/files/download`` that
+bypasses the cookie gate for exactly one file for a few minutes.
+
+Security model:
+
+* HMAC-SHA256 over ``f"{path}|{expiry}"`` with an in-process random secret,
+  so the signature cannot be forged without process access and dies with the
+  dashboard process.
+* Tickets are short-lived (default 300s) and single-file: even a leaked URL
+  is bounded in both time and scope.
+* Bypassing the gate only skips *authentication* — every file-level guard in
+  ``download_managed_file`` (managed-root resolution, sensitive-path
+  denylist, size cap) still runs unchanged.
+
+Mobile/gateway host is unchanged; this is a dashboard-side capability.
+"""
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import secrets
+import time
+import urllib.parse
+
+from fastapi import Request
+
+_TICKET_TTL_SECONDS = 300  # 5 minutes
+_SECRET = secrets.token_bytes(32)
+
+
+def _sign(payload: str) -> str:
+    return (
+        base64.urlsafe_b64encode(
+            hmac.new(_SECRET, payload.encode(), hashlib.sha256).digest()
+        )
+        .decode()
+        .rstrip("=")
+    )
+
+
+def build_download_url(
+    base_url: str,
+    path: str,
+    ttl_seconds: int = _TICKET_TTL_SECONDS,
+) -> str:
+    """Mint a signed download URL for ``path`` valid for ``ttl_seconds``.
+
+    ``path`` is the absolute host path (or ``~``-expanded); the signed
+    payload uses the raw path so verification is exact.
+    """
+    exp = int(time.time()) + ttl_seconds
+    sig = _sign(f"{path}|{exp}")
+    enc_path = urllib.parse.quote(path)
+    return f"{base_url.rstrip('/')}/api/files/download?path={enc_path}&exp={exp}&sig={sig}"
+
+
+def verify_download_ticket(request: Request) -> bool:
+    """True iff the request carries a valid, unexpired ticket for its path.
+
+    Only acts on ``/api/files/download``; every other path returns False so
+    this helper can never widen the auth surface of a different route.
+    """
+    if request.url.path != "/api/files/download":
+        return False
+    path = request.query_params.get("path", "")
+    exp_raw = request.query_params.get("exp", "")
+    sig = request.query_params.get("sig", "")
+    if not path or not exp_raw or not sig:
+        return False
+    try:
+        exp = int(exp_raw)
+    except ValueError:
+        return False
+    if exp < time.time():
+        return False
+    expected = _sign(f"{path}|{exp}")
+    return hmac.compare_digest(sig, expected)

--- a/hermes_cli/dashboard_auth/download_ticket.py
+++ b/hermes_cli/dashboard_auth/download_ticket.py
@@ -9,11 +9,18 @@ bypasses the cookie gate for exactly one file for a few minutes.
 
 Security model:
 
-* HMAC-SHA256 over ``f"{path}|{expiry}"`` with an in-process random secret,
-  so the signature cannot be forged without process access and dies with the
-  dashboard process.
+* HMAC-SHA256 over ``f"{path}|{expiry}|{mtime_ns}|{size}"`` with an
+  in-process random secret, so the signature cannot be forged without
+  process access and dies with the dashboard process. A dashboard restart
+  rotates the secret and therefore invalidates every outstanding ticket —
+  a viewer mid-download gets a 401 and the caller must mint a fresh URL.
+  This restart-invalidation is deliberate: the secret is never persisted
+  to disk.
 * Tickets are short-lived (default 300s) and single-file: even a leaked URL
   is bounded in both time and scope.
+* A ticket is bound to the file's identity (``st_mtime_ns`` + ``st_size``
+  at mint time), so a file replaced at the same path between mint and
+  download does not ride the old ticket; a deleted file invalidates it too.
 * Bypassing the gate only skips *authentication* — every file-level guard in
   ``download_managed_file`` (managed-root resolution, sensitive-path
   denylist, size cap) still runs unchanged.
@@ -25,6 +32,7 @@ from __future__ import annotations
 import base64
 import hashlib
 import hmac
+import os
 import secrets
 import time
 import urllib.parse
@@ -45,6 +53,21 @@ def _sign(payload: str) -> str:
     )
 
 
+def _file_identity(path: str) -> tuple[int, int] | None:
+    """Return ``(st_mtime_ns, st_size)`` for ``path``, or None if unstat-able.
+
+    The identity is what a ticket is bound to: a file replaced at the same
+    path (new mtime/size) or deleted no longer satisfies the ticket.
+    ``~`` is expanded so relative-to-home paths behave like the managed-file
+    resolver's.
+    """
+    try:
+        st = os.stat(os.path.expanduser(path))
+    except OSError:
+        return None
+    return st.st_mtime_ns, st.st_size
+
+
 def build_download_url(
     base_url: str,
     path: str,
@@ -53,10 +76,20 @@ def build_download_url(
     """Mint a signed download URL for ``path`` valid for ``ttl_seconds``.
 
     ``path`` is the absolute host path (or ``~``-expanded); the signed
-    payload uses the raw path so verification is exact.
+    payload uses the raw path so verification is exact. The ticket is bound
+    to the file's current identity (mtime + size), so a file swapped at the
+    same path after minting no longer satisfies the ticket. Raises
+    :class:`FileNotFoundError` when ``path`` cannot be stat'ed (e.g. deleted
+    between the caller's existence check and the mint).
     """
     exp = int(time.time()) + ttl_seconds
-    sig = _sign(f"{path}|{exp}")
+    identity = _file_identity(path)
+    if identity is None:
+        raise FileNotFoundError(
+            f"cannot mint download ticket for missing/unreadable file: {path}"
+        )
+    mtime_ns, size = identity
+    sig = _sign(f"{path}|{exp}|{mtime_ns}|{size}")
     enc_path = urllib.parse.quote(path)
     return f"{base_url.rstrip('/')}/api/files/download?path={enc_path}&exp={exp}&sig={sig}"
 
@@ -66,6 +99,10 @@ def verify_download_ticket(request: Request) -> bool:
 
     Only acts on ``/api/files/download``; every other path returns False so
     this helper can never widen the auth surface of a different route.
+
+    The signed payload binds path, expiry, and the file's mtime/size at
+    mint time, so verification also stats the file: a ticket whose file was
+    deleted (or replaced at the same path) since minting is rejected.
     """
     if request.url.path != "/api/files/download":
         return False
@@ -80,5 +117,9 @@ def verify_download_ticket(request: Request) -> bool:
         return False
     if exp < time.time():
         return False
-    expected = _sign(f"{path}|{exp}")
+    identity = _file_identity(path)
+    if identity is None:
+        return False
+    mtime_ns, size = identity
+    expected = _sign(f"{path}|{exp}|{mtime_ns}|{size}")
     return hmac.compare_digest(sig, expected)

--- a/hermes_cli/dashboard_auth/middleware.py
+++ b/hermes_cli/dashboard_auth/middleware.py
@@ -38,6 +38,7 @@ from hermes_cli.dashboard_auth.cookies import (
     set_sso_attempt_cookie,
 )
 from hermes_cli.dashboard_auth.public_paths import PUBLIC_API_PATHS
+from hermes_cli.dashboard_auth.download_ticket import verify_download_ticket
 
 _log = logging.getLogger(__name__)
 
@@ -341,6 +342,14 @@ async def gated_auth_middleware(
 
     path = request.url.path
     if _path_is_public(path):
+        return await call_next(request)
+
+    # Short-lived signed download tickets (external viewers like WPS open a
+    # plain GET URL and can attach neither cookie nor header): a valid
+    # ticket for this exact file bypasses the cookie gate but still hits
+    # every file-level guard inside the route handler (managed-root
+    # resolution, sensitive-path denylist, size cap).
+    if path == "/api/files/download" and verify_download_ticket(request):
         return await call_next(request)
 
     # RFC 8252 native-app bearer path (goal: no session cookies). The desktop

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -2674,6 +2674,35 @@ async def stream_managed_file(request: Request, path: str):
     )
 
 
+@app.get("/api/files/download-ticket")
+async def download_ticket(request: Request, path: str):
+    """Mint a short-lived signed URL for an external viewer (WPS etc.).
+
+    Same auth as every other sensitive route (session cookie through the
+    gate, or ``_require_token`` in loopback mode); the returned URL carries
+    an HMAC-signed ``exp``/``sig`` pair that lets a cookie-less external
+    viewer stream exactly this one file for a few minutes. The file-level
+    guards below run *now* so a ticket is never minted for a missing,
+    non-file, or sensitive path.
+    """
+    _require_token(request)
+    policy, target, _display_path = _resolve_managed_path(path, request)
+    if not target.exists():
+        raise HTTPException(status_code=404, detail="File not found")
+    if not target.is_file():
+        raise HTTPException(status_code=400, detail="Path is not a file")
+    if _is_sensitive_path(target):
+        raise HTTPException(status_code=403, detail="Access to sensitive files is not allowed")
+
+    from hermes_cli.dashboard_auth.download_ticket import build_download_url
+
+    return {
+        "ok": True,
+        "url": build_download_url(str(request.base_url).rstrip("/"), str(target)),
+        "path": str(target),
+    }
+
+
 @app.post("/api/files/upload")
 async def upload_managed_file(payload: ManagedFileUpload, request: Request):
     policy, target, display_path = _resolve_managed_path(payload.path, request, for_write=True)

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -2695,10 +2695,17 @@ async def download_ticket(request: Request, path: str):
         raise HTTPException(status_code=403, detail="Access to sensitive files is not allowed")
 
     from hermes_cli.dashboard_auth.download_ticket import build_download_url
+    from hermes_cli.dashboard_auth.prefix import resolve_public_url
 
+    # Behind a reverse proxy, ``request.base_url`` can expose the internal
+    # scheme/host, which the external viewer cannot reach. When the operator
+    # declared a public URL (HERMES_DASHBOARD_PUBLIC_URL / dashboard.public_url)
+    # prefer it so the minted link points at the externally reachable base;
+    # otherwise fall back to the request-derived base.
+    base = resolve_public_url() or str(request.base_url).rstrip("/")
     return {
         "ok": True,
-        "url": build_download_url(str(request.base_url).rstrip("/"), str(target)),
+        "url": build_download_url(base, str(target)),
         "path": str(target),
     }
 

--- a/tests/hermes_cli/test_dashboard_auth_download_ticket.py
+++ b/tests/hermes_cli/test_dashboard_auth_download_ticket.py
@@ -1,0 +1,333 @@
+"""Regression tests for signed short-lived download tickets.
+
+Covers the mint/verify round trip, expiry rejection, tampered signature and
+tampered path rejection, missing-param rejection, non-``/api/files/download``
+path scoping, the middleware bypass (a valid ticket passes the cookie gate,
+an invalid one is 401), the file-identity binding (a file replaced at the
+same path after minting no longer satisfies the ticket), and the mint
+endpoint's public-URL handling behind a reverse proxy.
+"""
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
+
+import pytest
+from fastapi import Request
+from fastapi.responses import JSONResponse
+
+from hermes_cli.dashboard_auth.download_ticket import (
+    build_download_url,
+    verify_download_ticket,
+)
+
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+
+
+def _request_for(url: str, *, app=None) -> Request:
+    """Build a starlette Request whose URL matches ``url``."""
+    parts = urlsplit(url)
+    scope = {
+        "type": "http",
+        "http_version": "1.1",
+        "method": "GET",
+        "scheme": parts.scheme or "http",
+        "path": parts.path,
+        "raw_path": parts.path.encode(),
+        "query_string": parts.query.encode(),
+        "headers": [],
+        "server": (parts.hostname or "127.0.0.1", parts.port or 80),
+        "client": ("127.0.0.1", 12345),
+    }
+    if app is not None:
+        scope["app"] = app
+    return Request(scope)
+
+
+def _swap_query(url: str, **changes) -> str:
+    """Return ``url`` with the given query params replaced."""
+    parts = urlsplit(url)
+    q = dict(parse_qsl(parts.query, keep_blank_values=True))
+    q.update(changes)
+    return urlunsplit(
+        (parts.scheme, parts.netloc, parts.path, urlencode(q), parts.fragment)
+    )
+
+
+def _drop_query(url: str, key: str) -> str:
+    """Return ``url`` with the given query param removed."""
+    parts = urlsplit(url)
+    q = dict(parse_qsl(parts.query, keep_blank_values=True))
+    q.pop(key, None)
+    return urlunsplit(
+        (parts.scheme, parts.netloc, parts.path, urlencode(q), parts.fragment)
+    )
+
+
+@pytest.fixture
+def ticket_file(tmp_path):
+    f = tmp_path / "doc.docx"
+    f.write_bytes(b"x" * 100)
+    return f
+
+
+# ---------------------------------------------------------------------------
+# mint / verify round trip
+# ---------------------------------------------------------------------------
+
+
+def test_mint_verify_round_trip(ticket_file):
+    url = build_download_url("http://127.0.0.1:9119", str(ticket_file))
+    assert url.startswith("http://127.0.0.1:9119/api/files/download?")
+    assert verify_download_ticket(_request_for(url)) is True
+
+
+def test_base_url_trailing_slash_normalised(ticket_file):
+    url = build_download_url("http://127.0.0.1:9119/", str(ticket_file))
+    assert url.startswith("http://127.0.0.1:9119/api/files/download?")
+
+
+def test_url_carries_path_exp_sig_params(ticket_file):
+    url = build_download_url("http://h", str(ticket_file))
+    q = dict(parse_qsl(urlsplit(url).query))
+    assert q["path"] == str(ticket_file)
+    assert int(q["exp"]) > 0
+    assert q["sig"]
+
+
+def test_expired_ticket_rejected(ticket_file):
+    url = build_download_url("http://h", str(ticket_file), ttl_seconds=-10)
+    assert verify_download_ticket(_request_for(url)) is False
+
+
+def test_tampered_signature_rejected(ticket_file):
+    url = build_download_url("http://h", str(ticket_file))
+    tampered = _swap_query(url, sig="A" * 40)
+    assert verify_download_ticket(_request_for(tampered)) is False
+
+
+def test_tampered_path_rejected(ticket_file):
+    url = build_download_url("http://h", str(ticket_file))
+    tampered = _swap_query(url, path="/etc/passwd")
+    assert verify_download_ticket(_request_for(tampered)) is False
+
+
+@pytest.mark.parametrize("dropped", ["path", "exp", "sig"])
+def test_missing_param_rejected(ticket_file, dropped):
+    url = build_download_url("http://h", str(ticket_file))
+    assert verify_download_ticket(_request_for(_drop_query(url, dropped))) is False
+
+
+def test_bad_exp_value_rejected(ticket_file):
+    url = build_download_url("http://h", str(ticket_file))
+    assert verify_download_ticket(_request_for(_swap_query(url, exp="soon"))) is False
+
+
+def test_non_download_path_never_verifies(ticket_file):
+    """The same ticket query on a different route must not authenticate."""
+    url = build_download_url("http://h", str(ticket_file))
+    parts = urlsplit(url)
+    req = Request(
+        {
+            "type": "http",
+            "http_version": "1.1",
+            "method": "GET",
+            "scheme": "http",
+            "path": "/api/files/read",
+            "raw_path": b"/api/files/read",
+            "query_string": parts.query.encode(),
+            "headers": [],
+            "server": ("127.0.0.1", 80),
+            "client": ("127.0.0.1", 1),
+        }
+    )
+    assert verify_download_ticket(req) is False
+
+
+def test_mint_requires_existing_file(tmp_path):
+    with pytest.raises(FileNotFoundError):
+        build_download_url("http://h", str(tmp_path / "nope.docx"))
+
+
+# ---------------------------------------------------------------------------
+# file-identity binding (TOCTOU)
+# ---------------------------------------------------------------------------
+
+
+def test_file_replaced_at_same_path_invalidates_ticket(ticket_file):
+    url = build_download_url("http://h", str(ticket_file))
+    assert verify_download_ticket(_request_for(url)) is True
+    # Same path, different content/size → different identity → ticket dead.
+    ticket_file.write_bytes(b"y" * 999)
+    assert verify_download_ticket(_request_for(url)) is False
+
+
+def test_deleted_file_invalidates_ticket(ticket_file):
+    url = build_download_url("http://h", str(ticket_file))
+    ticket_file.unlink()
+    assert verify_download_ticket(_request_for(url)) is False
+
+
+# ---------------------------------------------------------------------------
+# middleware integration: the gate bypass is exactly as narrow as designed
+# ---------------------------------------------------------------------------
+
+
+class _FakeApp:
+    def __init__(self, auth_required: bool = True):
+        self.state = SimpleNamespace(auth_required=auth_required)
+
+
+async def _passthrough(request: Request) -> JSONResponse:
+    return JSONResponse({"ok": True}, status_code=200)
+
+
+def test_middleware_bypasses_gate_with_valid_ticket(ticket_file):
+    from hermes_cli.dashboard_auth.middleware import gated_auth_middleware
+
+    url = build_download_url("http://127.0.0.1:9119", str(ticket_file))
+    req = _request_for(url, app=_FakeApp())
+    resp = asyncio.run(gated_auth_middleware(req, _passthrough))
+    assert resp.status_code == 200
+
+
+def test_middleware_401s_with_invalid_ticket(ticket_file):
+    from hermes_cli.dashboard_auth.middleware import gated_auth_middleware
+
+    url = build_download_url("http://127.0.0.1:9119", str(ticket_file))
+    tampered = _swap_query(url, sig="A" * 40)
+    req = _request_for(tampered, app=_FakeApp())
+    resp = asyncio.run(gated_auth_middleware(req, _passthrough))
+    assert resp.status_code == 401
+
+
+def test_middleware_ignores_ticket_on_other_routes(ticket_file):
+    from hermes_cli.dashboard_auth.middleware import gated_auth_middleware
+
+    url = build_download_url("http://127.0.0.1:9119", str(ticket_file))
+    parts = urlsplit(url)
+    req = Request(
+        {
+            "type": "http",
+            "http_version": "1.1",
+            "method": "GET",
+            "scheme": "http",
+            "path": "/api/files/read",
+            "raw_path": b"/api/files/read",
+            "query_string": parts.query.encode(),
+            "headers": [],
+            "server": ("127.0.0.1", 9119),
+            "client": ("127.0.0.1", 1),
+            "app": _FakeApp(),
+        }
+    )
+    resp = asyncio.run(gated_auth_middleware(req, _passthrough))
+    # Ticket params on a non-download route must NOT authenticate: 401.
+    assert resp.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# endpoint-level: mint honours the declared public URL (reverse proxy)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def loopback_client():
+    from fastapi.testclient import TestClient
+
+    from hermes_cli import web_server
+
+    prev_host = getattr(web_server.app.state, "bound_host", None)
+    prev_port = getattr(web_server.app.state, "bound_port", None)
+    prev_required = getattr(web_server.app.state, "auth_required", None)
+    web_server.app.state.bound_host = "127.0.0.1"
+    web_server.app.state.bound_port = 9119
+    web_server.app.state.auth_required = False
+    client = TestClient(web_server.app, base_url="http://127.0.0.1:9119")
+    yield client, web_server
+    web_server.app.state.bound_host = prev_host
+    web_server.app.state.bound_port = prev_port
+    web_server.app.state.auth_required = prev_required
+
+
+def _mint(client, web_server, path):
+    return client.get(
+        "/api/files/download-ticket",
+        params={"path": str(path)},
+        headers={
+            web_server._SESSION_HEADER_NAME: web_server._SESSION_TOKEN,
+        },
+    )
+
+
+def test_mint_endpoint_uses_public_url_when_declared(
+    loopback_client, ticket_file, monkeypatch, tmp_path
+):
+    client, web_server = loopback_client
+    monkeypatch.setenv("HERMES_DASHBOARD_PUBLIC_URL", "https://media.example.com/hermes")
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "home"))
+    r = _mint(client, web_server, ticket_file)
+    assert r.status_code == 200, r.text
+    assert r.json()["url"].startswith(
+        "https://media.example.com/hermes/api/files/download?"
+    )
+
+
+def test_mint_endpoint_falls_back_to_request_base(
+    loopback_client, ticket_file, monkeypatch, tmp_path
+):
+    client, web_server = loopback_client
+    monkeypatch.delenv("HERMES_DASHBOARD_PUBLIC_URL", raising=False)
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "home"))
+    r = _mint(client, web_server, ticket_file)
+    assert r.status_code == 200, r.text
+    assert r.json()["url"].startswith("http://127.0.0.1:9119/api/files/download?")
+
+
+# ---------------------------------------------------------------------------
+# end-to-end: full gate + route with a real ticket (no cookie, no token)
+# ---------------------------------------------------------------------------
+
+
+def test_gated_download_serves_file_with_valid_ticket_only(
+    ticket_file, monkeypatch, tmp_path
+):
+    from fastapi.testclient import TestClient
+
+    from hermes_cli import web_server
+
+    prev_host = getattr(web_server.app.state, "bound_host", None)
+    prev_port = getattr(web_server.app.state, "bound_port", None)
+    prev_required = getattr(web_server.app.state, "auth_required", None)
+    web_server.app.state.bound_host = "127.0.0.1"
+    web_server.app.state.bound_port = 9119
+    web_server.app.state.auth_required = True
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "home"))
+    try:
+        client = TestClient(web_server.app, base_url="http://127.0.0.1:9119")
+        url = build_download_url("http://127.0.0.1:9119", str(ticket_file))
+        parts = urlsplit(url)
+
+        # No cookie, no token, no ticket → the gate 401s.
+        r = client.get("/api/files/download", params={"path": str(ticket_file)})
+        assert r.status_code == 401, r.text
+
+        # Valid ticket → bypasses the gate and the file is streamed.
+        r = client.get("/api/files/download", params=dict(parse_qsl(parts.query)))
+        assert r.status_code == 200, r.text
+        assert r.content == b"x" * 100
+
+        # Tampered ticket → back to 401.
+        r = client.get(
+            "/api/files/download",
+            params=dict(parse_qsl(urlsplit(_swap_query(url, sig="B" * 40)).query)),
+        )
+        assert r.status_code == 401, r.text
+    finally:
+        web_server.app.state.bound_host = prev_host
+        web_server.app.state.bound_port = prev_port
+        web_server.app.state.auth_required = prev_required


### PR DESCRIPTION
## What

Gated (basic-auth) dashboards authenticate `/api/files/download` with a session cookie. An external viewer like **WPS Office** opens a plain GET URL and can attach neither cookies nor headers — so direct links 401 behind the gate. This PR adds a **signed, short-lived download ticket** endpoint so a first-party caller (the mobile app) can mint a cookie-free URL for exactly one file.

## Changes (3 files, +122)

1. **`hermes_cli/dashboard_auth/download_ticket.py`** (new) — HMAC-SHA256 over `path|expiry` with an in-process random secret; 5-minute TTL; one file per ticket; `verify_download_ticket()` only ever acts on `/api/files/download`, so it can't widen the auth surface of another route.
2. **`hermes_cli/dashboard_auth/middleware.py`** — the cookie gate passes a request carrying a valid ticket. All file-level guards in the route handler (managed-root resolution, sensitive-path denylist, size cap) still run — the ticket only bypasses *authentication*, not *authorization*.
3. **`hermes_cli/web_server.py`** — `GET /api/files/download-ticket?path=<enc>` (same auth as every sensitive route) mints and returns `{ok, url, path}`.

## Security model

- Ticket = HMAC(path|expiry), in-process random secret → unforgeable, dies with the dashboard process.
- 5-minute TTL + single-file scope → even a leaked URL is tightly bounded.
- No state needed (stateless verification), no new config, no new env vars.

## Context

Mobile counterpart: [hermes-mobile PR #912](https://github.com/Hy4ri/hermes-mobile/pull/912) streams `MEDIA:` document attachments into WPS via its `wps://open?url=` deep link using these tickets. Without this endpoint the app degrades to the existing cookie download path unchanged.

## Testing

- `python -m py_compile` on all three files ✅
- E2E on the user's dashboard (gated basic-auth): login → mint ticket → cookie-free `GET /api/files/download` returns 200 with md5 matching the local file; tampered signature / missing sig / expired ticket / path-swapped ticket all rejected (401); original cookie flow unaffected ✅
- WiFi (LAN) and Tailscale paths both verified on device ✅
