### PR TITLE
fix(web): let Windows users build from URL-reserved install paths

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "tsc -b && vite build",
+    "build": "node scripts/build.mjs",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "fix": "npm run lint:fix",

--- a/web/scripts/build.mjs
+++ b/web/scripts/build.mjs
@@ -8,7 +8,6 @@ import { fileURLToPath } from "node:url";
 const webRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const repoRoot = resolve(webRoot, "..");
 const standalone = existsSync(resolve(webRoot, "package-lock.json"));
-const buildRoot = standalone ? webRoot : repoRoot;
 
 function run(command, args, cwd, capture = false) {
   const result = spawnSync(command, args, {
@@ -21,10 +20,11 @@ function run(command, args, cwd, capture = false) {
 }
 
 function runBuild(root) {
-  const mappedWebRoot = standalone ? root : resolve(root, "web");
+  const mappedWebRoot = resolve(root, "web");
+  const dependencyRoot = standalone ? mappedWebRoot : root;
   const steps = [
-    [resolve(root, "node_modules", "typescript", "bin", "tsc"), "-b"],
-    [resolve(root, "node_modules", "vite", "bin", "vite.js"), "build"],
+    [resolve(dependencyRoot, "node_modules", "typescript", "bin", "tsc"), "-b"],
+    [resolve(dependencyRoot, "node_modules", "vite", "bin", "vite.js"), "build"],
   ];
 
   for (const [entrypoint, ...args] of steps) {
@@ -47,8 +47,8 @@ function createSubstMapping(target) {
 }
 
 let status;
-if (process.platform === "win32" && /[#?]/.test(buildRoot)) {
-  const drive = createSubstMapping(buildRoot);
+if (process.platform === "win32" && /[#?]/.test(repoRoot)) {
+  const drive = createSubstMapping(repoRoot);
   console.log(
     `[web] Vite-incompatible install path detected; building through temporary ${drive} mapping.`,
   );
@@ -64,7 +64,7 @@ if (process.platform === "win32" && /[#?]/.test(buildRoot)) {
     }
   }
 } else {
-  status = runBuild(buildRoot);
+  status = runBuild(repoRoot);
 }
 
 process.exit(status);

--- a/web/scripts/build.mjs
+++ b/web/scripts/build.mjs
@@ -7,6 +7,8 @@ import { fileURLToPath } from "node:url";
 
 const webRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const repoRoot = resolve(webRoot, "..");
+const standalone = existsSync(resolve(webRoot, "package-lock.json"));
+const buildRoot = standalone ? webRoot : repoRoot;
 
 function run(command, args, cwd, capture = false) {
   const result = spawnSync(command, args, {
@@ -19,7 +21,7 @@ function run(command, args, cwd, capture = false) {
 }
 
 function runBuild(root) {
-  const mappedWebRoot = resolve(root, "web");
+  const mappedWebRoot = standalone ? root : resolve(root, "web");
   const steps = [
     [resolve(root, "node_modules", "typescript", "bin", "tsc"), "-b"],
     [resolve(root, "node_modules", "vite", "bin", "vite.js"), "build"],
@@ -45,8 +47,8 @@ function createSubstMapping(target) {
 }
 
 let status;
-if (process.platform === "win32" && /[#?]/.test(repoRoot)) {
-  const drive = createSubstMapping(repoRoot);
+if (process.platform === "win32" && /[#?]/.test(buildRoot)) {
+  const drive = createSubstMapping(buildRoot);
   console.log(
     `[web] Vite-incompatible install path detected; building through temporary ${drive} mapping.`,
   );
@@ -62,7 +64,7 @@ if (process.platform === "win32" && /[#?]/.test(repoRoot)) {
     }
   }
 } else {
-  status = runBuild(repoRoot);
+  status = runBuild(buildRoot);
 }
 
 process.exit(status);

--- a/web/scripts/build.mjs
+++ b/web/scripts/build.mjs
@@ -1,0 +1,68 @@
+#!/usr/bin/env node
+
+import { existsSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+const webRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const repoRoot = resolve(webRoot, "..");
+
+function run(command, args, cwd, capture = false) {
+  const result = spawnSync(command, args, {
+    cwd,
+    encoding: capture ? "utf8" : undefined,
+    stdio: capture ? "pipe" : "inherit",
+  });
+  if (result.error) throw result.error;
+  return result;
+}
+
+function runBuild(root) {
+  const mappedWebRoot = resolve(root, "web");
+  const steps = [
+    [resolve(root, "node_modules", "typescript", "bin", "tsc"), "-b"],
+    [resolve(root, "node_modules", "vite", "bin", "vite.js"), "build"],
+  ];
+
+  for (const [entrypoint, ...args] of steps) {
+    const result = run(process.execPath, [entrypoint, ...args], mappedWebRoot);
+    if (result.status !== 0) return result.status ?? 1;
+  }
+  return 0;
+}
+
+function createSubstMapping(target) {
+  for (let code = "Z".charCodeAt(0); code >= "D".charCodeAt(0); code -= 1) {
+    const drive = `${String.fromCharCode(code)}:`;
+    if (existsSync(`${drive}\\`)) continue;
+    const result = run("subst.exe", [drive, target], repoRoot, true);
+    if (result.status === 0) return drive;
+  }
+  throw new Error(
+    "Unable to allocate a temporary drive for the web build. Free a drive letter and retry.",
+  );
+}
+
+let status;
+if (process.platform === "win32" && /[#?]/.test(repoRoot)) {
+  const drive = createSubstMapping(repoRoot);
+  console.log(
+    `[web] Vite-incompatible install path detected; building through temporary ${drive} mapping.`,
+  );
+  try {
+    status = runBuild(`${drive}\\`);
+  } finally {
+    const cleanup = run("subst.exe", [drive, "/D"], repoRoot, true);
+    if (cleanup.status !== 0) {
+      const detail = cleanup.stderr?.trim();
+      throw new Error(
+        `Failed to remove temporary ${drive} mapping${detail ? `: ${detail}` : "."}`,
+      );
+    }
+  }
+} else {
+  status = runBuild(repoRoot);
+}
+
+process.exit(status);


### PR DESCRIPTION
## What does this PR do?

Hermes dashboard builds now succeed on Windows when the installation path contains `#` or `?`. Vite treats these reserved characters as URL fragment/query delimiters and otherwise truncates filesystem asset paths, leaving users in affected Windows accounts unable to build or update the web UI.

### Symptom

Running `npm run build --workspace web` from a physical path containing `#` makes Vite warn about the character and PostCSS fail with `ENOENT` after truncating the path at `#`.

### Impact

Windows users whose valid account or installation path contains a URL-reserved character cannot build the Hermes web UI, although the CLI remains usable.

### Bug Cause

**Trigger:** `web/package.json:8` / the web build command running Vite from a Windows repository path containing `#` or `?`

**Causal chain:**
1. The web build resolves CSS assets and package entrypoints from the physical installation path.
2. Vite and Rolldown interpret `#` or `?` in that filesystem path as URL delimiters and resolve a truncated path.
3. PostCSS or module resolution fails before the dashboard bundle is produced.

**Why it is wrong:** These characters are legal in Windows directory and account names, so a valid installation path must not change build resolution semantics.

**Working sibling / contrast:** The same exact-lockfile build succeeds from an otherwise equivalent path without reserved URL characters.

**Ruled out:** The failure is not caused by a corrupt dependency install. Independent base and fixed-tip workspaces both used `npm ci`; the base failed at the truncated path while the fixed tip completed.

### Fix

Route affected Windows builds through a temporary `subst` drive whose root has a URL-safe path, run TypeScript and Vite from that mapped workspace, and remove the mapping in a `finally` block. The wrapper preserves both monorepo and standalone `web/` dependency layouts and leaves non-Windows or already-safe paths on the existing direct build path.

## Related Issue

Closes #87092

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `web/package.json` - run the production build through the compatibility wrapper.
- `web/scripts/build.mjs` - detect reserved Windows paths, create and clean up a temporary drive mapping, and preserve monorepo and standalone dependency roots.

## How to Test

1. On Windows, install dependencies with `npm ci` in a repository path containing `#`.
2. Run `npm run build --workspace web` and confirm the temporary drive message appears and the Vite build completes.
3. Compare `subst.exe` output before and after both a successful build and a forced child-build failure; no mapping should remain.
4. Run the focused web checks:

```bash
npm run check --workspace web
```

The focused checks passed 33 test files and 256 tests, plus typecheck and lint. The real Windows build completed after transforming 2216 modules.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the relevant web test, typecheck, lint, and build commands and all pass
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Relevant documentation - N/A; this is an internal build compatibility fix
- [x] `cli-config.yaml.example` - N/A; no config keys changed
- [x] `CONTRIBUTING.md` or `AGENTS.md` - N/A; no architecture or workflow contract changed
- [x] Cross-platform impact considered; non-Windows builds keep the direct path
- [x] Tool descriptions/schemas - N/A; no tool behavior changed
