### PR TITLE
fix(desktop): block remote artifact auto-previews

### DIFF
--- a/apps/desktop/e2e/artifact-network-share.spec.ts
+++ b/apps/desktop/e2e/artifact-network-share.spec.ts
@@ -1,0 +1,113 @@
+import {
+  buildAppEnv,
+  createSandbox,
+  launchDesktop,
+  type Sandbox,
+  waitForAppReady,
+  writeEnvFile,
+  writeMockProviderConfig
+} from './fixtures'
+import { type MockServer, startMockServer } from './mock-server'
+import { RealSessionBuilder } from './real-session-builder'
+import { type ElectronApplication, expect, type Page, test } from './test'
+
+const NETWORK_SHARE_PATH = String.raw`\\fileserver\share\generated.png`
+const NETWORK_SHARE_REPLY = `Generated preview follows.\nMEDIA: ${NETWORK_SHARE_PATH}`
+const SESSION_TITLE = 'E2E remote network-share artifact'
+
+interface NetworkShareFixture {
+  app: ElectronApplication
+  mock: MockServer
+  page: Page
+  sandbox: Sandbox
+  cleanup: () => Promise<void>
+}
+
+async function setupNetworkShareDesktop(): Promise<NetworkShareFixture> {
+  const mock = await startMockServer({ reply: NETWORK_SHARE_REPLY })
+  const sandbox = createSandbox('artifact-network-share')
+  writeMockProviderConfig(sandbox.hermesHome, mock.url)
+  writeEnvFile(sandbox.hermesHome)
+
+  const builder = await RealSessionBuilder.start(sandbox.hermesHome)
+
+  try {
+    await builder.createSession({
+      title: SESSION_TITLE,
+      turns: ['Create the E2E artifact record.']
+    })
+  } finally {
+    await builder.close()
+  }
+
+  const { app, page } = await launchDesktop(buildAppEnv(sandbox))
+
+  return {
+    app,
+    mock,
+    page,
+    sandbox,
+    cleanup: async () => {
+      await app.close().catch(() => undefined)
+      await mock.close()
+      sandbox.cleanup()
+    }
+  }
+}
+
+async function interceptPreviewReads(app: ElectronApplication): Promise<void> {
+  await app.evaluate(({ ipcMain }) => {
+    const state = globalThis as typeof globalThis & { __artifactNetworkSharePreviewReads?: number }
+
+    state.__artifactNetworkSharePreviewReads = 0
+    ipcMain.removeHandler('hermes:readFileDataUrl')
+    ipcMain.handle('hermes:readFileDataUrl', async () => {
+      state.__artifactNetworkSharePreviewReads = (state.__artifactNetworkSharePreviewReads ?? 0) + 1
+
+      return 'data:image/png;base64,QU5Z'
+    })
+  })
+}
+
+async function previewReadCount(app: ElectronApplication): Promise<number> {
+  return app.evaluate(() => {
+    const state = globalThis as typeof globalThis & { __artifactNetworkSharePreviewReads?: number }
+
+    return state.__artifactNetworkSharePreviewReads ?? 0
+  })
+}
+
+async function openArtifacts(page: Page): Promise<void> {
+  await page.evaluate(() => {
+    window.location.hash = '#/artifacts'
+  })
+  await page.waitForFunction(
+    path => window.location.hash === '#/artifacts' && (document.body.textContent ?? '').includes(path),
+    NETWORK_SHARE_PATH,
+    { timeout: 30_000 }
+  )
+}
+
+test.describe('artifact network-share previews', () => {
+  let fixture: NetworkShareFixture | null = null
+
+  test.afterEach(async () => {
+    await fixture?.cleanup()
+    fixture = null
+  })
+
+  test('does not read a persisted remote-share image merely by opening Artifacts', async () => {
+    test.slow()
+    fixture = await setupNetworkShareDesktop()
+    await waitForAppReady(fixture, 120_000)
+    await interceptPreviewReads(fixture.app)
+    await openArtifacts(fixture.page)
+
+    const card = fixture.page.locator('article').filter({ hasText: NETWORK_SHARE_PATH })
+    await expect(card).toBeVisible()
+    await expect(card.locator('.cursor-default')).toHaveCount(1)
+
+    expect(await previewReadCount(fixture.app)).toBe(0)
+    await expect(card.locator('[slot="artifact-media"]')).toHaveCount(0)
+  })
+})

--- a/apps/desktop/e2e/fixtures.ts
+++ b/apps/desktop/e2e/fixtures.ts
@@ -281,20 +281,28 @@ function assertDistBuilt(): void {
 
 /**
  * Find the Electron binary. In the nix devshell, `electron` is on PATH.
- * As a fallback, use the node_modules/.bin/electron from the desktop package.
+ * As a fallback, use the copy installed for the desktop workspace, then the
+ * repository-level installation used by older layouts.
  */
 export function findElectron(): string {
   // In dev mode, we use the `electron` binary directly (not the packaged app).
   // The dev:electron script in package.json does exactly this: `electron .`
   // after building. We replicate that here.
-  const localElectron = path.join(REPO_ROOT, 'node_modules', 'electron', 'dist', 'electron')
+  const executable = process.platform === 'win32' ? 'electron.exe' : 'electron'
 
-  if (fs.existsSync(localElectron)) {
-    return localElectron
+  const localElectrons = [
+    path.join(DESKTOP_ROOT, 'node_modules', 'electron', 'dist', executable),
+    path.join(REPO_ROOT, 'node_modules', 'electron', 'dist', executable),
+  ]
+
+  for (const localElectron of localElectrons) {
+    if (fs.existsSync(localElectron)) {
+      return localElectron
+    }
   }
 
   // Fall back to PATH
-  const result = spawnSync('which', ['electron'], {
+  const result = spawnSync(process.platform === 'win32' ? 'where' : 'which', [executable], {
     encoding: 'utf8',
   })
 

--- a/apps/desktop/e2e/mock-server.ts
+++ b/apps/desktop/e2e/mock-server.ts
@@ -24,6 +24,8 @@ import nodePath from 'node:path'
 export const MOCK_REPLY = 'Hello from the mock inference server! The full boot chain is working.'
 
 export interface MockServerOptions {
+  /** Override the normal canned reply for a focused real-session scenario. */
+  reply?: string
   /** Pause the matching stream after its first token for session-switch E2E coverage. */
   holdFirstStreamForPrompt?: string
 /** Pause the first completion whose request JSON contains this text. */
@@ -615,12 +617,14 @@ export function startMockServer(options: MockServerOptions = {}): Promise<MockSe
             return
           }
 
+          const reply = options.reply ?? MOCK_REPLY
+
           if (stream) {
             const holdThisStream = Boolean(
               options.holdFirstStreamForPrompt && typeof lastUserMessage?.content === 'string' &&
                 lastUserMessage.content.includes(options.holdFirstStreamForPrompt),
             )
-            streamTextResponse(res, model, MOCK_REPLY, holdThisStream || holdThisCompletion ? () => {
+            streamTextResponse(res, model, reply, holdThisStream || holdThisCompletion ? () => {
               if (holdThisCompletion) {
                 heldCompletionCount++
               }
@@ -631,9 +635,9 @@ export function startMockServer(options: MockServerOptions = {}): Promise<MockSe
             if (holdThisCompletion) {
               heldCompletionCount++
               resolveHeldStreamStarted?.()
-              void heldStreamReleased.then(() => nonStreamingTextResponse(res, model, MOCK_REPLY))
+              void heldStreamReleased.then(() => nonStreamingTextResponse(res, model, reply))
             } else {
-              nonStreamingTextResponse(res, model, MOCK_REPLY)
+              nonStreamingTextResponse(res, model, reply)
             }
           }
         })

--- a/apps/desktop/src/app/artifacts/artifact-utils.ts
+++ b/apps/desktop/src/app/artifacts/artifact-utils.ts
@@ -131,6 +131,65 @@ function isWindowsPath(value: string): boolean {
   return /^[A-Za-z]:[\\/]/.test(value) || value.startsWith('\\\\')
 }
 
+const LOCAL_NETWORK_SHARE_HOSTS = new Set(['127.0.0.1', '::1', 'localhost', 'wsl$', 'wsl.localhost'])
+
+function networkShareHost(value: string): string | null {
+  const trimmed = value.trim()
+
+  if (/^file:/i.test(trimmed)) {
+    try {
+      const url = new URL(trimmed)
+
+      if (url.protocol !== 'file:') {
+        return null
+      }
+
+      // `file:////host/share` is not a canonical file URL, but the shared
+      // resolver turns its pathname into `//host/share` on Windows. Treat it
+      // like the equivalent UNC spelling before it reaches the filesystem.
+      const pathnameHost = url.pathname.match(/^\/\/([^/]+)/)?.[1]
+
+      return url.hostname || pathnameHost || null
+    } catch {
+      return null
+    }
+  }
+
+  const normalized = trimmed.replace(/\//g, '\\')
+
+  // Extended-length drive paths stay on the local filesystem. Only the UNC
+  // spelling under the same device prefix names a network share.
+  if (/^\\\\\?\\[A-Za-z]:\\/.test(normalized)) {
+    return null
+  }
+
+  const path = normalized.startsWith('\\\\?\\UNC\\')
+    ? normalized.slice('\\\\?\\UNC\\'.length)
+    : normalized.startsWith('\\\\')
+      ? normalized.slice(2)
+      : null
+
+  if (!path) {
+    return null
+  }
+
+  const separatorIndex = path.indexOf('\\')
+  const host = separatorIndex === -1 ? path : path.slice(0, separatorIndex)
+
+  return host || null
+}
+
+/**
+ * Automatic artifact previews must not cause Windows to contact a remote SMB
+ * share merely because an assistant or tool mentioned its path. WSL's local
+ * integration shares remain available, as do ordinary local file URLs.
+ */
+export function isRemoteNetworkShareArtifactPath(value: string): boolean {
+  const host = networkShareHost(value)
+
+  return host !== null && !LOCAL_NETWORK_SHARE_HOSTS.has(host.toLowerCase())
+}
+
 function looksLikePathOrUrl(value: string): boolean {
   return (
     value.startsWith('http://') ||
@@ -185,6 +244,10 @@ function artifactHref(value: string): string {
 }
 
 export async function artifactImageSrc(value: string): Promise<string> {
+  if (isRemoteNetworkShareArtifactPath(value)) {
+    throw new Error('Automatic previews of remote network-share artifacts are disabled')
+  }
+
   // Delegate the whole local/remote ladder to the shared media resolver:
   // inline (http/data) stays as-is, remote gateway goes through the
   // authenticated fs bridge, local desktop through the Electron

--- a/apps/desktop/src/app/artifacts/index.test.ts
+++ b/apps/desktop/src/app/artifacts/index.test.ts
@@ -3,7 +3,12 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 import { $connection } from '@/store/session'
 import type { SessionInfo, SessionMessage } from '@/types/hermes'
 
-import { artifactImageSrc, collectArtifactsForSession, loadArtifactsForSessions } from './artifact-utils'
+import {
+  artifactImageSrc,
+  collectArtifactsForSession,
+  isRemoteNetworkShareArtifactPath,
+  loadArtifactsForSessions
+} from './artifact-utils'
 
 function makeSession(overrides: Partial<SessionInfo> = {}): SessionInfo {
   return {
@@ -341,6 +346,50 @@ ${payload}
     expect(api).toHaveBeenCalledWith({
       path: '/api/fs/read-data-url?path=%2FUsers%2Fme%2F.hermes%2Fskills%2Fwork-esab%2Freferences%2Fimages%2Fmanual-step03.jpeg'
     })
+  })
+
+  it.each([
+    ['a UNC share', String.raw`\\fileserver\share\generated.png`],
+    ['a slash-style UNC share', '//fileserver/share/generated.png'],
+    ['a device-prefixed UNC share', String.raw`\\?\UNC\fileserver\share\generated.png`],
+    ['a remote file URL', 'file://fileserver/share/generated.png'],
+    ['a non-canonical remote file URL', 'file:////fileserver/share/generated.png']
+  ])('identifies %s as a remote network-share artifact path', (_label, path) => {
+    expect(isRemoteNetworkShareArtifactPath(path)).toBe(true)
+  })
+
+  it.each([
+    ['a local drive path', String.raw`C:\Users\me\generated.png`],
+    ['a device-prefixed local drive path', String.raw`\\?\C:\Users\me\generated.png`],
+    ['a local file URL', 'file:///C:/Users/me/generated.png'],
+    ['a local-host file URL', 'file://localhost/C:/Users/me/generated.png'],
+    ['a WSL UNC path', String.raw`\\wsl.localhost\Ubuntu\home\me\generated.png`],
+    ['a WSL file URL', 'file://wsl.localhost/Ubuntu/home/me/generated.png']
+  ])('keeps %s eligible for a local preview', (_label, path) => {
+    expect(isRemoteNetworkShareArtifactPath(path)).toBe(false)
+  })
+
+  it('does not fetch a remote-share image artifact through either desktop file bridge', async () => {
+    const api = vi.fn()
+    const readFileDataUrl = vi.fn()
+    vi.stubGlobal('window', { hermesDesktop: { api, readFileDataUrl } })
+    $connection.set({ baseUrl: 'https://gw', mode: 'remote', token: 'secret' } as never)
+
+    await expect(artifactImageSrc(String.raw`\\fileserver\share\generated.png`)).rejects.toThrow(
+      'Automatic previews of remote network-share artifacts are disabled'
+    )
+
+    expect(api).not.toHaveBeenCalled()
+    expect(readFileDataUrl).not.toHaveBeenCalled()
+  })
+
+  it('continues to resolve a WSL image artifact through the desktop fs bridge', async () => {
+    const readFileDataUrl = vi.fn(async () => 'data:image/png;base64,V1NM')
+    vi.stubGlobal('window', { hermesDesktop: { readFileDataUrl } })
+    const path = String.raw`\\wsl.localhost\Ubuntu\home\me\generated.png`
+
+    await expect(artifactImageSrc(path)).resolves.toBe('data:image/png;base64,V1NM')
+    expect(readFileDataUrl).toHaveBeenCalledWith(path)
   })
 })
 


### PR DESCRIPTION
## Summary

- prevent the Artifacts page from resolving a remote network-share image merely because assistant or tool content refers to it
- retain ordinary local paths, `localhost`, and local WSL UNC integrations; only the automatic image-preview path changes
- leave the shared media resolver and explicit file-opening flows untouched

## Validation

- `npm exec -- vitest run --project ui src/app/artifacts/index.test.ts`
- `npm exec -- tsc -p tsconfig.e2e.json --noEmit`
- `npm exec -- tsc -p tsconfig.json --noEmit`
- `npm run build`
- `npm exec -- playwright test e2e/artifact-network-share.spec.ts --reporter=list`
- targeted ESLint and Prettier checks
- `git diff --check upstream/main...HEAD`
- `scripts/check-windows-footguns.py --diff upstream/main`

The Playwright regression creates a durable session through the real TUI gateway, opens the Electron Artifacts screen, and replaces the preview IPC handler only for the test. It verifies that a persisted `MEDIA:` UNC image still creates an artifact card but performs no file-preview IPC call.