### PR TITLE
fix(providers): preserve entry extra_headers across fallback requests

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -5631,6 +5631,7 @@ def _resolve_fallback_entry(entry: Dict[str, Any]) -> Tuple[Optional[Any], Optio
         explicit_base_url=base_url,
         explicit_api_key=api_key,
         api_mode=api_mode,
+        explicit_extra_headers=entry.get("extra_headers"),
     )
     if client is not None:
         try:
@@ -5639,6 +5640,18 @@ def _resolve_fallback_entry(entry: Dict[str, Any]) -> Tuple[Optional[Any], Optio
             )
         except Exception:
             pass
+        # Merge entry-specific extra_headers into the client so they
+        # survive in fallback requests (#87098).
+        entry_headers = entry.get("extra_headers")
+        if entry_headers and isinstance(entry_headers, dict):
+            try:
+                existing = getattr(client, "default_headers", None) or {}
+                if isinstance(existing, dict):
+                    merged = dict(existing)
+                    merged.update(entry_headers)
+                    client.default_headers = merged
+            except Exception:
+                pass
     return client, resolved_model
 
 
@@ -6083,6 +6096,7 @@ def resolve_provider_client(
     main_runtime: Optional[Dict[str, Any]] = None,
     is_vision: bool = False,
     task: Optional[str] = None,
+    explicit_extra_headers: Optional[Dict[str, str]] = None,
 ) -> Tuple[Optional[Any], Optional[str]]:
     """Central router: given a provider name and optional model, return a
     configured client with the correct auth, base URL, and API format.


### PR DESCRIPTION
## Summary

Fallback entries in `fallback_providers` or `custom_providers` with `extra_headers` (e.g. WAF bypass, tenant routing, Cloudflare Access tokens) lost those headers when the fallback request was constructed — `_resolve_fallback_entry()` never forwarded `entry.get("extra_headers")` into the resolved client.

## Change

`agent/auxiliary_client.py::_resolve_fallback_entry()`: after resolving the client, merge entry-specific `extra_headers` into `client.default_headers` if present. Keeps existing default_headers (e.g. model.default_headers from config) and overlays the entry-specific ones.

## Verification

- Python compile clean.

Closes #87098