### PR TITLE
fix(gateway): keep managed Node service PATH stable

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -3157,8 +3157,9 @@ def _append_node_dir_for_service(
 ) -> None:
     """Add the Node directory a generated service unit should use to *path_entries*.
 
-    The Hermes-managed Node under ``$HERMES_HOME/node`` goes first when it
-    exists. A bare ``shutil.which("node")`` cannot be trusted on its own here:
+    The Hermes-managed Node under ``$HERMES_HOME/node`` goes first when its
+    tree contains a Node/npm/npx shim. A bare ``shutil.which("node")`` cannot
+    be trusted on its own here:
     a service unit is written once and then survives reboots, so resolving a
     system Node that happens to be ahead on the installing shell's PATH bakes
     the wrong interpreter in permanently — the exact failure the desktop
@@ -3172,10 +3173,14 @@ def _append_node_dir_for_service(
     candidate dir (hardened home) means "skip the rung", not "crash the
     generator".
 
-    PATH lookup remains the fallback rung for installs with no managed Node.
+    PATH lookup remains the fallback rung for installs with no managed Node tree.
     """
-    from hermes_constants import iter_hermes_node_dirs
+    from hermes_constants import (
+        hermes_managed_node_tree_present,
+        iter_hermes_node_dirs,
+    )
 
+    managed_node_present = hermes_managed_node_tree_present(hermes_root)
     for directory in iter_hermes_node_dirs(hermes_root):
         entry = str(directory)
         try:
@@ -3184,6 +3189,14 @@ def _append_node_dir_for_service(
             present = False
         if present and entry not in path_entries:
             path_entries.append(entry)
+
+    # A real Hermes-managed Node tree is authoritative. Do not let the shell
+    # that happens to generate the service add a second, machine-dependent
+    # Node directory after it. An empty leftover managed directory does not
+    # suppress the fallback: hermes_managed_node_tree_present() requires an
+    # actual Node/npm/npx shim.
+    if managed_node_present:
+        return
 
     resolved_node = shutil.which("node")
     if not resolved_node:

--- a/tests/hermes_cli/test_gateway_node_service_path.py
+++ b/tests/hermes_cli/test_gateway_node_service_path.py
@@ -1,0 +1,149 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+import hermes_constants
+from hermes_cli import gateway as gateway_cli
+
+
+def _install_managed_node(home: Path) -> list[Path]:
+    """Create the platform-native managed Node shim plus both supported dirs."""
+    directories = hermes_constants.iter_hermes_node_dirs(home)
+    for directory in directories:
+        directory.mkdir(parents=True, exist_ok=True)
+
+    if sys.platform == "win32":
+        node = home / "node" / "node.exe"
+    else:
+        node = home / "node" / "bin" / "node"
+    node.write_text("", encoding="utf-8")
+    if sys.platform != "win32":
+        node.chmod(0o755)
+    return directories
+
+
+def test_managed_node_tree_prevents_ambient_node_fallback(monkeypatch, tmp_path):
+    home = tmp_path / "hermes"
+    directories = _install_managed_node(home)
+
+    def unexpected_which(command):
+        raise AssertionError(f"ambient PATH fallback must not run for {command}")
+
+    monkeypatch.setattr(gateway_cli.shutil, "which", unexpected_which)
+
+    entries = []
+    gateway_cli._append_node_dir_for_service(entries, home)
+
+    assert entries == [str(path) for path in directories if path.is_dir()]
+
+
+def test_empty_managed_directories_keep_ambient_node_fallback(monkeypatch, tmp_path):
+    home = tmp_path / "hermes"
+    directories = hermes_constants.iter_hermes_node_dirs(home)
+    for directory in directories:
+        directory.mkdir(parents=True, exist_ok=True)
+
+    ambient_node = tmp_path / "ambient-node" / "bin" / "node"
+    monkeypatch.setattr(
+        gateway_cli.shutil,
+        "which",
+        lambda command: str(ambient_node) if command == "node" else None,
+    )
+
+    entries = []
+    gateway_cli._append_node_dir_for_service(entries, home)
+
+    expected = [str(path) for path in directories if path.is_dir()]
+    expected.append(str(ambient_node.parent))
+    assert entries == expected
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX executable-bit semantics")
+def test_non_executable_managed_node_keeps_ambient_fallback(monkeypatch, tmp_path):
+    home = tmp_path / "hermes"
+    managed_bin = home / "node" / "bin"
+    managed_bin.mkdir(parents=True)
+    managed_node = managed_bin / "node"
+    managed_node.write_text("", encoding="utf-8")
+    managed_node.chmod(0o644)
+
+    ambient_node = tmp_path / "ambient-node" / "bin" / "node"
+    monkeypatch.setattr(
+        gateway_cli.shutil,
+        "which",
+        lambda command: str(ambient_node) if command == "node" else None,
+    )
+
+    entries = []
+    gateway_cli._append_node_dir_for_service(entries, home)
+
+    assert str(managed_bin) in entries
+    assert str(ambient_node.parent) in entries
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="systemd unit generation is POSIX-only")
+def test_user_systemd_unit_is_independent_of_ambient_node_when_managed_tree_exists(
+    monkeypatch, tmp_path
+):
+    home = tmp_path / "hermes"
+    directories = _install_managed_node(home)
+    ambient_nodes = iter(
+        [
+            tmp_path / "ambient-node-a" / "bin" / "node",
+            tmp_path / "ambient-node-b" / "bin" / "node",
+        ]
+    )
+
+    token = hermes_constants.set_hermes_home_override(home)
+    try:
+        monkeypatch.setattr(
+            gateway_cli.shutil,
+            "which",
+            lambda command: str(next(ambient_nodes)) if command == "node" else None,
+        )
+        unit_a = gateway_cli.generate_systemd_unit(system=False)
+        unit_b = gateway_cli.generate_systemd_unit(system=False)
+    finally:
+        hermes_constants.reset_hermes_home_override(token)
+
+    assert unit_a == unit_b
+    assert "ambient-node-a" not in unit_a
+    assert "ambient-node-b" not in unit_a
+    assert any(str(directory) in unit_a for directory in directories)
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="systemd unit generation is POSIX-only")
+def test_systemd_current_ignores_ambient_node_drift_when_managed_tree_exists(
+    monkeypatch, tmp_path
+):
+    home = tmp_path / "hermes"
+    _install_managed_node(home)
+    unit_path = tmp_path / "hermes-gateway.service"
+    ambient = {"path": tmp_path / "ambient-node-a" / "bin" / "node"}
+
+    monkeypatch.setattr(
+        gateway_cli.shutil,
+        "which",
+        lambda command: str(ambient["path"]) if command == "node" else None,
+    )
+    monkeypatch.setattr(
+        gateway_cli,
+        "get_systemd_unit_path",
+        lambda system=False: unit_path,
+    )
+    monkeypatch.setattr(
+        gateway_cli,
+        "_sync_hermes_home_from_systemd_unit",
+        lambda system=False: None,
+    )
+
+    token = hermes_constants.set_hermes_home_override(home)
+    try:
+        installed = gateway_cli.generate_systemd_unit(system=False)
+        unit_path.write_text(installed, encoding="utf-8")
+        ambient["path"] = tmp_path / "ambient-node-b" / "bin" / "node"
+
+        assert gateway_cli.systemd_unit_is_current(system=False) is True
+    finally:
+        hermes_constants.reset_hermes_home_override(token)

--- a/tests/test_managed_runtime_resolution.py
+++ b/tests/test_managed_runtime_resolution.py
@@ -80,8 +80,8 @@ _ALLOWED: dict[tuple[str, str], str] = {
         "guidance."
     ),
     ("hermes_cli/gateway.py", "node"): (
-        "Fallback rung of _append_node_dir_for_service(), after the managed "
-        "dirs from iter_hermes_node_dirs() are already appended."
+        "Fallback rung of _append_node_dir_for_service(), used only when no "
+        "Hermes-managed Node tree is present."
     ),
     ("hermes_cli/main.py", "node"): (
         "_ensure_tui_node()'s idempotence gate: the question really is 'is "


### PR DESCRIPTION
## Summary

- treat an actual Hermes-managed Node tree as authoritative when generating gateway service PATH entries
- consult ambient `node` on PATH only when no managed Node tree is present
- preserve ambient fallback for empty leftover managed directories and non-executable partial installs
- reuse `hermes_managed_node_tree_present()` so service generation follows Hermes's existing managed-runtime authority policy

## Problem

`_append_node_dir_for_service()` already prepended Hermes-managed Node directories, but then always appended the directory returned by `shutil.which("node")` as well.

On multi-profile installs, the shell-visible `node` can vary between invocations or resolve through a profile-specific shim. That makes the generated systemd unit depend on the installer shell even when Hermes already owns a managed Node tree. A unit generated under one ambient Node path can then compare unequal under another, causing `systemd_unit_is_current()` to report a correct installed unit as stale and trigger unnecessary service-definition refreshes.

## Safety / compatibility

- default behavior is unchanged when no managed Node tree exists
- merely having `$HERMES_HOME/node` directories is not enough to suppress fallback; the existing managed-tree predicate requires a Node/npm/npx shim
- on POSIX, a non-executable managed Node shim does not suppress ambient fallback
- explicit target-user `hermes_root` handling remains unchanged for system units
- the existing symlink-parent behavior of the ambient fallback is unchanged

## Verification

Focused and adjacent local tests on current upstream base:

- gateway CLI family: 267 passed, 5 skipped
- managed Node/update/install surfaces: 82 passed, 5 skipped
- adjacent service/profile/WSL surfaces: 21 passed
- ruff: clean
- `git diff --check`: clean

The new `systemd_unit_is_current()` regression was also run against untouched current `main`: it fails there because ambient Node drift changes the expected unit, and passes with this patch.
