### PR TITLE
fix(doctor): recognize Mem0 OSS configs without API key + bump nanoid

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -2884,9 +2884,30 @@ def run_doctor(args):
             from plugins.memory.mem0 import _load_config as _load_mem0_config
             mem0_cfg = _load_mem0_config()
             mem0_key = mem0_cfg.get("api_key", "")
+            mem0_mode = mem0_cfg.get("mode", "platform")
             if mem0_key:
                 check_ok("Mem0 API key configured")
                 check_info(f"user_id={mem0_cfg.get('user_id', '?')}  agent_id={mem0_cfg.get('agent_id', '?')}")
+            elif mem0_mode == "oss":
+                _oss_cfg = mem0_cfg.get("oss") or {}
+                _oss_llm = (_oss_cfg.get("llm") or {}).get("provider", "?")
+                _oss_embedder = (_oss_cfg.get("embedder") or {}).get("provider", "?")
+                _oss_vector_store = (_oss_cfg.get("vector_store") or {}).get("provider", "?")
+                if _oss_cfg.get("vector_store"):
+                    check_ok(
+                        "Mem0 OSS (self-hosted) configured",
+                        f"llm={_oss_llm} embedder={_oss_embedder} "
+                        f"vector_store={_oss_vector_store} (no API key needed)",
+                    )
+                else:
+                    _fail_and_issue(
+                        "Mem0 OSS mode set but vector store not configured",
+                        "run: hermes memory setup",
+                        "Mem0 is in OSS mode but the OSS vector store is not configured",
+                        issues,
+                    )
+            elif mem0_cfg.get("host"):
+                check_ok("Mem0 self-hosted (HTTP) configured", f"host={mem0_cfg.get('host')}")
             else:
                 _fail_and_issue(
                     "Mem0 API key not set",

--- a/package-lock.json
+++ b/package-lock.json
@@ -15204,6 +15204,34 @@
         "points-on-curve": "0.2.0"
       }
     },
+    "node_modules/postcss": {
+      "version": "8.5.23",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
+      "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.16",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
     "node_modules/postcss-selector-parser": {
       "version": "6.0.10",
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.10.tgz",
@@ -15215,6 +15243,24 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/postcss/node_modules/nanoid": {
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
     "node_modules/postject": {
@@ -16467,9 +16513,9 @@
       }
     },
     "node_modules/sanitize-html": {
-      "version": "2.17.6",
-      "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-2.17.6.tgz",
-      "integrity": "sha512-M4bo9tfv1yfhQZZKkc6dL07ALrGJtfvNOuhX3hU9AVPR/uPQ+nKOJBqTYc7LfMQblTW04mtSWDJWEyLvygJsLA==",
+      "version": "2.17.7",
+      "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-2.17.7.tgz",
+      "integrity": "sha512-PGtEkc9cbnedU3s9TmzDbpsZ8w086g/0Q8k8/oIO1NLNU3i5k9yn835CrjJSajp1KMmkisbO1qPXxNKO3welAg==",
       "license": "MIT",
       "dependencies": {
         "deepmerge": "^4.2.2",
@@ -16482,52 +16528,6 @@
       },
       "engines": {
         "node": ">=22.12.0"
-      }
-    },
-    "node_modules/sanitize-html/node_modules/nanoid": {
-      "version": "3.3.17",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
-      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "bin": {
-        "nanoid": "bin/nanoid.cjs"
-      },
-      "engines": {
-        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
-      }
-    },
-    "node_modules/sanitize-html/node_modules/postcss": {
-      "version": "8.5.23",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
-      "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/postcss"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "nanoid": "^3.3.16",
-        "picocolors": "^1.1.1",
-        "source-map-js": "^1.2.1"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14"
       }
     },
     "node_modules/sax": {
@@ -18322,52 +18322,6 @@
         "lightningcss-linux-x64-musl": "1.33.0",
         "lightningcss-win32-arm64-msvc": "1.33.0",
         "lightningcss-win32-x64-msvc": "1.33.0"
-      }
-    },
-    "node_modules/vite/node_modules/nanoid": {
-      "version": "3.3.17",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
-      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "bin": {
-        "nanoid": "bin/nanoid.cjs"
-      },
-      "engines": {
-        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
-      }
-    },
-    "node_modules/vite/node_modules/postcss": {
-      "version": "8.5.23",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
-      "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/postcss"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "nanoid": "^3.3.16",
-        "picocolors": "^1.1.1",
-        "source-map-js": "^1.2.1"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14"
       }
     },
     "node_modules/vitest": {

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -233,9 +233,9 @@ class TestDoctorMemoryProviderSection:
         (home / "config.yaml").write_text(yaml.dump(config))
         return home
 
-    def _run_doctor_and_capture(self, monkeypatch, tmp_path, provider=""):
+    def _run_doctor_and_capture(self, monkeypatch, tmp_path, provider="", home=None):
         """Run doctor and capture stdout."""
-        home = self._make_hermes_home(tmp_path, provider)
+        home = home or self._make_hermes_home(tmp_path, provider)
         monkeypatch.setattr(doctor_mod, "HERMES_HOME", home)
         monkeypatch.setattr(doctor_mod, "PROJECT_ROOT", tmp_path / "project")
         monkeypatch.setattr(doctor_mod, "_DHH", str(home))
@@ -278,6 +278,41 @@ class TestDoctorMemoryProviderSection:
         out = self._run_doctor_and_capture(monkeypatch, tmp_path, provider="mem0")
         assert "Memory Provider" in out
         assert "Built-in memory active" not in out
+
+    def test_mem0_oss_mode_without_api_key_shows_ok(self, monkeypatch, tmp_path):
+        # OSS (self-hosted) mode needs no API key — doctor must not flag it.
+        home = self._make_hermes_home(tmp_path, provider="mem0")
+        import json
+        (home / "mem0.json").write_text(json.dumps({
+            "mode": "oss",
+            "oss": {
+                "llm": {"provider": "ollama", "config": {"model": "qwen3:4b"}},
+                "embedder": {"provider": "ollama", "config": {"model": "nomic-embed-text"}},
+                "vector_store": {"provider": "qdrant", "config": {"path": str(tmp_path / "qdrant")}},
+            },
+        }))
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        out = self._run_doctor_and_capture(monkeypatch, tmp_path, provider="mem0", home=home)
+        assert "Memory Provider" in out
+        assert "Mem0 OSS (self-hosted) configured" in out
+        assert "API key is missing" not in out
+
+    def test_mem0_oss_mode_without_vector_store_fails(self, monkeypatch, tmp_path):
+        # OSS mode with an incomplete config is still a real issue.
+        home = self._make_hermes_home(tmp_path, provider="mem0")
+        import json
+        (home / "mem0.json").write_text(json.dumps({"mode": "oss", "oss": {}}))
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        out = self._run_doctor_and_capture(monkeypatch, tmp_path, provider="mem0", home=home)
+        assert "vector store not configured" in out
+
+    def test_mem0_platform_mode_without_api_key_still_fails(self, monkeypatch, tmp_path):
+        # Platform (cloud) mode without an API key must still be flagged.
+        home = self._make_hermes_home(tmp_path, provider="mem0")
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        out = self._run_doctor_and_capture(monkeypatch, tmp_path, provider="mem0", home=home)
+        assert "Mem0 API key not set" in out
+        assert "API key is missing" in out
 
 
 def test_run_doctor_termux_treats_docker_and_browser_warnings_as_expected(monkeypatch, tmp_path):


### PR DESCRIPTION
## What

Two fixes to clear `hermes doctor` issues:

### 1. Doctor falsely flags Mem0 OSS setups as missing an API key

Mem0 in OSS (self-hosted) mode (e.g. Ollama LLM/embedder + Qdrant vector store) needs no MEM0_API_KEY, but the doctor only checked for a key and reported "Mem0 API key not set".

The Mem0 provider check now:
- reports OK for OSS mode with a configured vector store (shows llm/embedder/vector_store providers)
- reports OK for self-hosted HTTP setups (`host`)
- reports a real issue for OSS mode with no vector store configured
- still fails for platform (cloud) mode without an API key

Tests: 3 new cases in `tests/hermes_cli/test_doctor.py` (OSS ok, OSS incomplete, platform missing key) plus an optional `home` param on the capture helper.

### 2. nanoid 3.3.17 -> 3.3.18 in package-lock.json

Clears the remaining `npm audit` highs (GHSA-2v37-7h3g-55p8) in the web/ and ui-tui/ workspaces, via postcss nested nanoid dep.

## Test plan

- `scripts/run_tests.sh tests/hermes_cli/test_doctor.py` - 55 passed
- `npm audit` in web/ and ui-tui/ - 0 vulnerabilities