### PR TITLE
fix(stt): retry without the prompt when a backend echoes it back

### DIFF
--- a/tests/tools/test_stt_prompt_echo_guard.py
+++ b/tests/tools/test_stt_prompt_echo_guard.py
@@ -1,0 +1,236 @@
+"""Tests for the STT prompt-echo guard wired into ``transcribe_audio``.
+
+Whisper conditions on ``prompt`` as if it were transcript text that came
+immediately before the audio, so a low-confidence decode can continue or
+repeat the prompt and return THAT as the transcript. It arrives as an
+ordinary 200 OK, so nothing downstream can tell it from real speech.
+
+``stt.prompt`` and the ``pre_transcription`` hook (#84934) made that prompt
+reachable for every prompt-capable backend, so the guard is tested at the
+shared dispatch boundary rather than per provider:
+
+1. An echoed transcript is replaced by an unbiased retry.
+2. The retry call carries no prompt at all.
+3. A genuine transcript is returned untouched, with no second call.
+4. A short answer that merely shares prompt vocabulary is not an echo.
+5. An echo that survives the unbiased retry yields no transcript rather
+   than a hallucinated turn.
+6. The guard covers faster-whisper's ``initial_prompt``, not just Groq.
+7. With no prompt configured the wire traffic is unchanged.
+
+Harness conventions mirror ``tests/tools/test_pre_transcription_hook.py``:
+the real ``transcribe_audio`` entry point runs, only the API boundary is
+stubbed, and no live model is loaded.
+"""
+
+from __future__ import annotations
+
+import logging
+from unittest.mock import MagicMock, patch
+
+from tools import transcription_tools
+
+
+# Synthetic fixtures only: never a real profile path or session identifier.
+PROMPT = (
+    "Quarterly review with Ada Lovelace and Grace Hopper. Topics: telemetry, "
+    "backpressure, tail quantiles, Fenwick trees."
+)
+# Whisper usually returns the prompt lightly corrupted rather than verbatim.
+ECHO = (
+    "Qquarterly review with Ada Lovelace and Grace Hopper. Topics: telemetry, "
+    "backpressure, tail quantiles, Fenwick trees."
+)
+REAL_SPEECH = "Could you summarise the telemetry section before the call"
+
+
+def _make_audio(tmp_path):
+    audio = tmp_path / "voice.ogg"
+    audio.write_bytes(b"fake audio data")
+    return str(audio)
+
+
+def _dispatch_ctx(stt_config, provider):
+    """Patch config load + provider resolution around transcribe_audio."""
+    return (
+        patch("tools.transcription_tools._load_stt_config", return_value=stt_config),
+        patch("tools.transcription_tools._get_provider", return_value=provider),
+    )
+
+
+def _groq_client(*transcripts):
+    client = MagicMock()
+    client.audio.transcriptions.create.side_effect = list(transcripts)
+    return client
+
+
+def _run_groq(monkeypatch, tmp_path, client, stt_config):
+    audio = _make_audio(tmp_path)
+    monkeypatch.setenv("GROQ_API_KEY", "gsk-test")
+    cfg_patch, prov_patch = _dispatch_ctx(stt_config, "groq")
+    with cfg_patch, prov_patch, \
+         patch("tools.transcription_tools._HAS_OPENAI", True), \
+         patch("openai.OpenAI", return_value=client):
+        return transcription_tools.transcribe_audio(audio)
+
+
+class TestPromptEchoRetry:
+    def test_echoed_prompt_is_replaced_by_the_unbiased_retry(
+        self, monkeypatch, tmp_path,
+    ):
+        client = _groq_client(ECHO, REAL_SPEECH)
+
+        result = _run_groq(monkeypatch, tmp_path, client, {
+            "provider": "groq", "prompt": PROMPT,
+        })
+
+        assert result["success"] is True
+        assert result["transcript"] == REAL_SPEECH
+
+    def test_the_retry_call_carries_no_prompt(self, monkeypatch, tmp_path):
+        client = _groq_client(ECHO, REAL_SPEECH)
+
+        _run_groq(monkeypatch, tmp_path, client, {
+            "provider": "groq", "prompt": PROMPT,
+        })
+
+        calls = client.audio.transcriptions.create.call_args_list
+        assert len(calls) == 2, "an echoed decode must be retried exactly once"
+        assert calls[0].kwargs.get("prompt") == PROMPT
+        assert "prompt" not in calls[1].kwargs
+
+    def test_echo_surviving_the_retry_yields_no_transcript(
+        self, monkeypatch, tmp_path,
+    ):
+        """Two echoes means neither decode is trustworthy.
+
+        Returning the echo would hand the agent a hallucinated turn, which is
+        the actual harm; an empty transcript is the honest outcome.
+        """
+        client = _groq_client(ECHO, ECHO)
+
+        result = _run_groq(monkeypatch, tmp_path, client, {
+            "provider": "groq", "prompt": PROMPT,
+        })
+
+        assert result["transcript"] == ""
+
+
+class TestGuardDoesNotOverTrigger:
+    def test_genuine_transcript_is_returned_without_a_second_call(
+        self, monkeypatch, tmp_path,
+    ):
+        client = _groq_client(REAL_SPEECH)
+
+        result = _run_groq(monkeypatch, tmp_path, client, {
+            "provider": "groq", "prompt": PROMPT,
+        })
+
+        assert result["transcript"] == REAL_SPEECH
+        assert len(client.audio.transcriptions.create.call_args_list) == 1
+
+    def test_short_answer_sharing_prompt_vocabulary_is_not_an_echo(
+        self, monkeypatch, tmp_path,
+    ):
+        """A brief reply naming a term from the prompt is normal speech.
+
+        This is the false-positive that matters: vocabulary hints exist
+        precisely because the speaker is expected to say those words.
+        """
+        client = _groq_client("Fenwick trees")
+
+        result = _run_groq(monkeypatch, tmp_path, client, {
+            "provider": "groq", "prompt": PROMPT,
+        })
+
+        assert result["transcript"] == "Fenwick trees"
+        assert len(client.audio.transcriptions.create.call_args_list) == 1
+
+    def test_no_prompt_configured_makes_no_second_call(
+        self, monkeypatch, tmp_path,
+    ):
+        """Without a prompt there is nothing to echo, so the wire is unchanged."""
+        client = _groq_client(ECHO)
+
+        result = _run_groq(monkeypatch, tmp_path, client, {"provider": "groq"})
+
+        assert result["transcript"] == ECHO
+        calls = client.audio.transcriptions.create.call_args_list
+        assert len(calls) == 1
+        assert "prompt" not in calls[0].kwargs
+
+
+class TestGuardIsScriptAgnostic:
+    def test_cjk_echo_is_retried(self, monkeypatch, tmp_path):
+        """An echo in a non-Latin script is still an echo.
+
+        Normalization folds to alphanumerics, so a filter that only kept
+        [a-z0-9] would reduce both sides to empty and silently disable the
+        guard for CJK, Cyrillic, Greek and every other non-Latin script.
+        """
+        prompt = "季度评审会议记录：遥测数据、背压控制、尾部分位数、树状数组、缓存命中率。"
+        echo = "季季度评审会议记录：遥测数据、背压控制、尾部分位数、树状数组、缓存命中率。"
+        speech = "请帮我总结一下遥测部分的内容然后发给我"
+        client = _groq_client(echo, speech)
+
+        result = _run_groq(monkeypatch, tmp_path, client, {
+            "provider": "groq", "prompt": prompt,
+        })
+
+        assert result["transcript"] == speech
+        calls = client.audio.transcriptions.create.call_args_list
+        assert len(calls) == 2
+        assert "prompt" not in calls[1].kwargs
+
+
+class TestObservability:
+    def test_discarded_transcript_is_logged_at_warning(
+        self, monkeypatch, tmp_path, caplog,
+    ):
+        """The discard path must stay visible; a silent drop is unexplainable."""
+        client = _groq_client(ECHO, ECHO)
+
+        with caplog.at_level(logging.WARNING, logger="tools.transcription_tools"):
+            result = _run_groq(monkeypatch, tmp_path, client, {
+                "provider": "groq", "prompt": PROMPT,
+            })
+
+        assert result["transcript"] == ""
+        warnings = [r.getMessage() for r in caplog.records
+                    if r.levelno >= logging.WARNING]
+        assert any("retrying once without prompt biasing" in m for m in warnings)
+        assert any("discarding the" in m for m in warnings)
+
+
+class TestGuardIsProviderAgnostic:
+    def test_faster_whisper_initial_prompt_echo_is_also_retried(
+        self, monkeypatch, tmp_path,
+    ):
+        """The guard sits at the dispatch seam, so it is not Groq specific."""
+        audio = _make_audio(tmp_path)
+
+        def _segments(text):
+            segment = MagicMock()
+            segment.text = text
+            segment.no_speech_prob = 0.0
+            segment.avg_logprob = 0.0
+            return ([segment], MagicMock(language="en", duration=1.0))
+
+        model = MagicMock()
+        model.transcribe.side_effect = [_segments(ECHO), _segments(REAL_SPEECH)]
+
+        cfg_patch, prov_patch = _dispatch_ctx(
+            {"provider": "local", "prompt": PROMPT}, "local",
+        )
+        with cfg_patch, prov_patch, \
+             patch("tools.transcription_tools._HAS_FASTER_WHISPER", True), \
+             patch("tools.transcription_tools._load_local_whisper_model",
+                   return_value=model), \
+             patch("tools.transcription_tools._local_model", None):
+            result = transcription_tools.transcribe_audio(audio)
+
+        assert result["transcript"] == REAL_SPEECH
+        calls = model.transcribe.call_args_list
+        assert len(calls) == 2
+        assert calls[0].kwargs["initial_prompt"] == PROMPT
+        assert not calls[1].kwargs.get("initial_prompt")

--- a/tools/transcription_tools.py
+++ b/tools/transcription_tools.py
@@ -9,7 +9,10 @@ the dispatcher and the cached local model + idle-unload state; backends live in
 ``transcription_{common,audio,local,cloud,command}``.
 """
 
+import difflib
 import logging
+import re
+import unicodedata
 import os
 import shutil
 import threading
@@ -432,7 +435,7 @@ def _transcribe_prepared_audio(
             file_path = trimmed
             trim_cleanup_dir = os.path.dirname(trimmed)
     try:
-        return _dispatch_stt_provider(file_path, provider, stt_config, model, source)
+        return _transcribe_with_prompt_echo_guard(file_path, provider, stt_config, model, source)
     finally:
         if trim_cleanup_dir:
             shutil.rmtree(trim_cleanup_dir, ignore_errors=True)
@@ -461,10 +464,68 @@ def _builtin_model_name(provider: str, stt_config: Dict[str, Any], model: Option
     return (cfg.get(key) or default) if empty_is_missing else cfg.get(key, default)
 
 
-def _dispatch_stt_provider(
+# Whisper conditions on ``prompt`` as if it were transcript text that came
+# immediately before the audio, so a low confidence decode (long pauses, quiet
+# or far from mic speech) can simply continue or repeat the prompt and return
+# THAT as the transcript. It arrives as an ordinary 200 OK, so nothing
+# downstream can tell it from real speech and the hallucinated text reaches the
+# agent as if the speaker had said it. Matching is on content because the echo
+# usually comes back lightly corrupted ("Tthe", "Fenwwick").
+_STT_PROMPT_ECHO_RATIO = 0.55
+# Under this length a transcript cannot be told apart from a genuine brief
+# reply that happens to use the vocabulary the prompt supplied.
+_STT_PROMPT_ECHO_MIN_CHARS = 25
+
+
+def _normalize_for_prompt_echo(text: str) -> str:
+    """Fold to letters and digits of any script: lowercase, accent stripped, single spaced.
+
+    Script agnostic deliberately. Keeping only ``[a-z0-9]`` would reduce a CJK
+    transcript and a CJK prompt to two empty strings, which reads as "not an
+    echo" and would silently disable the guard for every non-Latin script.
+    Note that _STT_PROMPT_ECHO_MIN_CHARS counts characters, so a dense script
+    needs a longer utterance to clear the floor. That errs toward not flagging,
+    which is the safe direction.
+    """
+    folded = unicodedata.normalize("NFKD", (text or "").lower())
+    kept = [c if c.isalnum() else " "
+            for c in folded if not unicodedata.combining(c)]
+    return re.sub(r"\s+", " ", "".join(kept)).strip()
+
+
+def _is_stt_prompt_echo(transcript: Optional[str], prompt: Optional[str]) -> bool:
+    """True when a transcript is really its own biasing prompt echoed back.
+
+    Two shapes are caught: the whole prompt reproduced (similarity ratio), and
+    a decode that continued the prompt for a long verbatim run before
+    diverging (longest common block, scaled to the transcript so a short
+    genuine answer that merely shares a name is never flagged).
+    """
+    if not transcript or not prompt:
+        return False
+
+    spoken = _normalize_for_prompt_echo(transcript)
+    biased = _normalize_for_prompt_echo(prompt)
+    if not biased or len(spoken) < _STT_PROMPT_ECHO_MIN_CHARS:
+        return False
+
+    matcher = difflib.SequenceMatcher(None, spoken, biased)
+    if matcher.ratio() >= _STT_PROMPT_ECHO_RATIO:
+        return True
+    longest = matcher.find_longest_match(0, len(spoken), 0, len(biased))
+    return longest.size >= max(40, int(0.6 * len(spoken)))
+
+
+def _transcribe_with_prompt_echo_guard(
     file_path: str, provider: str, stt_config: Dict[str, Any], model: Optional[str] = None,
     source: Optional[str] = None) -> Dict[str, Any]:
-    """Route *file_path* to the handler for *provider* (built-in > command > plugin)."""
+    """Resolve the transcription prompt, then dispatch behind the echo guard.
+
+    The prompt is resolved once, here, so the retry reuses the same model and
+    language and re-fires no hooks: the only difference is that the prompt is
+    withheld. An unbiased decode cannot echo a prompt it was never given, so
+    it either recovers the real words or fails honestly.
+    """
     # Static ``stt.prompt`` is the base; hook results mutate on top (last hook to set a field wins).
     prompt = stt_config.get("prompt")
     prompt = prompt if isinstance(prompt, str) and prompt.strip() else None
@@ -474,6 +535,36 @@ def _dispatch_stt_provider(
         language=_get_stt_section(stt_config, provider).get("language"), prompt=prompt, source=source,
     )
     prompt = _enforce_prompt_length_limit(prompt, provider)
+    result = _dispatch_stt_provider(
+        file_path, provider, stt_config, model, language, prompt,
+    )
+    if not prompt or not _is_stt_prompt_echo(result.get("transcript"), prompt):
+        return result
+
+    logger.warning(
+        "STT provider '%s' returned its own prompt as the transcript for %s "
+        "(%d chars); retrying once without prompt biasing",
+        provider, Path(file_path).name, len(result.get("transcript") or ""),
+    )
+    retry = _dispatch_stt_provider(
+        file_path, provider, stt_config, model, language, None,
+    )
+    if _is_stt_prompt_echo(retry.get("transcript"), prompt):
+        # Two echoes means neither decode is trustworthy. Returning the echo
+        # would hand the agent a hallucinated turn, which is the actual harm.
+        logger.warning(
+            "STT prompt echo persisted without biasing for %s; discarding the "
+            "transcript rather than handing the agent a hallucinated turn",
+            Path(file_path).name,
+        )
+        retry["transcript"] = ""
+    return retry
+
+
+def _dispatch_stt_provider(
+    file_path: str, provider: str, stt_config: Dict[str, Any], model: Optional[str] = None,
+    language: Optional[str] = None, prompt: Optional[str] = None) -> Dict[str, Any]:
+    """Route *file_path* to the handler for *provider* (built-in > command > plugin)."""
     if provider in BUILTIN_STT_PROVIDERS:
         # Looked up in this module at call time so tests may patch ``_transcribe_*``.
         handler = globals()[f"_transcribe_{provider}"]

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -2254,6 +2254,8 @@ stt:
 
 **Length.** Whisper-family models only condition on the final ~224 prompt tokens. For the whisper-family backends (`local`, `openai`, `groq`, `deepinfra`) Hermes enforces that cap client-side: an over-long final prompt is truncated to its tail with a logged warning — the request never errors because of prompt length. Other backends (`mistral`, plugin providers) receive the prompt unchanged and own their own validation. Keep hints short and specific either way.
 
+**Prompt echo.** Whisper conditions on the prompt as if it were transcript text that came immediately before the audio, so a low confidence decode can continue or repeat the prompt and return that as the transcript. It arrives as an ordinary success response, so nothing downstream can tell it apart from real speech. When a transcript comes back matching the prompt it was given, Hermes repeats the transcription once with the prompt withheld and uses that result instead: an unbiased decode cannot echo a prompt it was never given. If the echo survives the retry the transcript is discarded rather than passed to the agent. Both cases are logged at WARNING, and the extra request is only made when an echo is actually detected. For hosted providers that retry re-uploads the same audio, so a detected echo on a long recording costs a second upload. A short reply that merely reuses vocabulary from the prompt is not treated as an echo.
+
 :::warning Prompts are uploaded with your audio
 The final prompt is sent to the configured STT provider alongside the audio file. Keep secrets and session-derived context out of `stt.prompt` and out of anything a `pre_transcription` hook returns, especially when the provider is a hosted API rather than local `faster-whisper`.
 :::


### PR DESCRIPTION
## What does this PR do?

`stt.prompt` and the `pre_transcription` hook (#84934, merged 13 Aug) made a transcription prompt reachable for every prompt capable backend. That introduces a failure mode Whisper has always had: it conditions on `prompt` as if it were transcript text that came immediately before the audio, so a low confidence decode (long pauses, quiet or far from mic speech) can simply continue or repeat the prompt and return THAT as the transcript.

It arrives as an ordinary 200 OK. Nothing downstream can tell it from real speech, so the hallucinated text reaches the agent as if the speaker had said it, and the agent answers a question nobody asked. The failure is most likely exactly where vocabulary hints are most useful: a named set of proper nouns plus a speaker who pauses.

The existing hardening does not cover this. `_is_hallucinated_segment` and the `no_speech_prob` / `avg_logprob` thresholds are faster-whisper silence handling, applied per segment on the local backend. A hosted provider returning the prompt as a complete, confident transcript passes straight through.

**Fix.** When a transcript comes back matching the prompt it was given, dispatch once more with the prompt withheld and use that result. An unbiased decode cannot echo a prompt it was never given, so it either recovers the real words or fails honestly. If the echo survives the retry the transcript is discarded rather than handed to the agent, since at that point neither decode is trustworthy.

**Why the shared dispatch boundary.** The guard lives in a new `_transcribe_with_prompt_echo_guard` rather than inside any one backend, so it covers `local`, `openai`, `groq`, `mistral`, `deepinfra` and plugin providers together. That is only possible because the prompt is now resolved in one place: the resolution block (config, then hook, then the 224 token cap) moves up into the guard, and `_dispatch_stt_provider` receives the resolved `language` and `prompt` as parameters. Resolving once also means the retry reuses the same model and language and re-fires no hooks. The only difference between the two calls is the prompt.

Cost is one extra transcription request, and only when an echo is actually detected.

**Detection** is on content, because the echo usually comes back lightly corrupted ("Tthe", "Fenwwick") rather than verbatim. Two shapes are caught: the whole prompt reproduced (similarity ratio), and a decode that continued the prompt for a long verbatim run before diverging (longest common block, scaled to the transcript). Transcripts under 25 characters are never flagged, so a brief reply that names a term from the prompt is left alone. That false positive is the one that matters, since vocabulary hints exist precisely because the speaker is expected to say those words.

## Related Issue

No existing issue. Found in production use of a prompt biased Groq gateway, where a paused speaker's voice note came back as the configured vocabulary hint and the agent answered it as a real turn.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/transcription_tools.py`
  - New `_is_stt_prompt_echo` plus `_normalize_for_prompt_echo` (accent folded, punctuation stripped comparison) and the two thresholds.
  - New `_transcribe_with_prompt_echo_guard`: owns prompt resolution (moved verbatim from `_dispatch_stt_provider`), dispatches, and retries once unbiased on an echo.
  - `_dispatch_stt_provider` now takes the resolved `language` and `prompt` instead of resolving them, and no longer needs `source`. The provider routing chain itself is untouched.
  - The single call site in `_transcribe_prepared_audio` calls the guard.
  - `difflib` and `unicodedata` added to the stdlib imports.
- `tests/tools/test_stt_prompt_echo_guard.py`: 7 route level tests through the real `transcribe_audio`.
- `website/docs/user-guide/configuration.md`: a "Prompt echo" paragraph in the existing transcription prompt section.

## How to Test

1. Set `stt.prompt` to a vocabulary hint and use any prompt capable provider.
2. Send a voice note the backend decodes poorly (a long pause, or near silence). Before this change the transcript can come back as the prompt itself and the agent answers it. After it, the retry result is used and the echo is logged at WARNING.
3. `pytest tests/tools/test_stt_prompt_echo_guard.py -q` gives 7 passed.

Proof of coverage: with `tools/transcription_tools.py` reverted to main and the tests kept, **4 of the 7 fail** on behavioural assertions (the echo is returned as the transcript), not on import or collection errors. The other 3 pass either way by design, since they assert the guard does not fire on genuine speech, on short vocabulary sharing replies, or when no prompt is configured.

Regression baseline across every STT and transcription suite in `tests/tools`: **197 passed on this branch vs 190 on clean main**, which is exactly the 7 added, with a byte identical failing set both ways (3 local macOS environment failures involving the conftest live system guard and a whisper device config assertion, unrelated to this change).

## Field validation

An earlier, Groq only version of this guard has been running on a Debian gateway since 18 July, which is where the thresholds come from.

- It has fired on a real event: a 15 second voice note came back as the configured vocabulary prompt, with a normal success response, and the agent acted on it as a genuine turn. That is the failure this PR is about, not a synthetic one.
- Measured against every stored transcription on that install, 316 real turns, it produced **0 false positives**. That is the number the 25 character floor and the 0.55 ratio were tuned to hold.

The version in this PR differs in one way: the guard moved from inside the Groq backend to the shared dispatch boundary, so it now also covers the other prompt capable providers.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 25.6). An earlier Groq only version of this guard has been running on a Debian gateway since 18 July.

On the unchecked box: I ran every STT and transcription suite in `tests/tools` (200 tests) plus the `pre_transcription` hook suite, not the whole tree. Ticking that box would not be true, so I have left it unticked and relied on CI for the full run.

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) or N/A
- [x] N/A for `cli-config.yaml.example`: this adds no config key. The guard is unconditional on the existing `stt.prompt` path.
- [x] N/A for `CONTRIBUTING.md` / `AGENTS.md`: no architecture or workflow change.
- [x] I've considered cross-platform impact (Windows, macOS): the added code is pure stdlib (`difflib`, `unicodedata`, `re`) with no path, encoding or process handling, so it behaves identically on all three.

## Notes for review

- `transcribe_audio_local_fallback` deliberately stays outside the guard. It calls `_transcribe_local` with no prompt at all, so it has nothing to echo.
- `_dispatch_stt_provider` is module private and has no callers outside this file, so the signature change is contained.
- Duplicate search: nothing open on prompt echo or STT prompt hallucination. The adjacent work is silence hallucination filtering for faster-whisper, which is a different mechanism and stays as is.
