### PR TITLE
fix(desktop): don't reap the healthy standalone gateway on Windows desktop startup

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -1751,10 +1751,19 @@ def _reap_unsupervised_gateway_orphans(extra_exclude: set | None = None) -> bool
     # the Scheduled-Task bootstrap's argv (``gateway run``) matches the
     # gateway scan — killing that bootstrap takes the detached gateway it
     # spawned down with it.
+    #
+    # Probe the record with cleanup_stale=False so the sweep never deletes
+    # the registration it is about to use as exclusion evidence.  With the
+    # default cleanup, a record that fails liveness validation is unlinked
+    # mid-sweep; the recorded PID then never joins the exclusion set, and a
+    # healthy standalone gateway (no service supervisor — e.g. `hermes
+    # gateway run` on Windows) is hard-killed by the sweep.  On Windows
+    # SIGTERM is TerminateProcess, so the gateway's own planned-stop watcher
+    # never gets a chance to shut down gracefully.
     try:
         from gateway.status import get_running_pid
 
-        recorded = get_running_pid()
+        recorded = get_running_pid(cleanup_stale=False)
         if recorded and recorded > 0:
             own.add(recorded)
             try:

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -373,10 +373,23 @@ async def _lifespan(app: "FastAPI"):
         # the old gateway to launchd (PPID=1). It keeps holding the QQ
         # WebSocket, and a newly forked gateway then races the same credential,
         # splitting messages across parallel session trees (#77276).
+        #
+        # Only reap when no live, registered gateway is in the record: a
+        # healthy standalone gateway (launched via `hermes gateway run`, no
+        # service supervisor) is not an orphan, and the sweep would kill it.
+        # On Windows every layer of the launcher chain (stub -> venv python ->
+        # runtime python) carries "gateway run" in its command line, so
+        # find_gateway_pids() matches processes the pidfile exclusion cannot
+        # see, and os.kill(SIGTERM) is a hard TerminateProcess — the
+        # gateway's planned-stop watcher (0.5s poll) has no time to drain.
+        # cleanup_stale=False keeps the probe from deleting the registration
+        # record it is checking.
         try:
+            from gateway.status import get_running_pid
             from hermes_cli.gateway import _reap_unsupervised_gateway_orphans
 
-            _reap_unsupervised_gateway_orphans()
+            if get_running_pid(cleanup_stale=False) is None:
+                _reap_unsupervised_gateway_orphans()
         except Exception:
             _log.exception("Desktop startup: orphan gateway reap failed")
 

--- a/tests/hermes_cli/test_gateway.py
+++ b/tests/hermes_cli/test_gateway.py
@@ -572,7 +572,9 @@ class TestReapUnsupervisedGatewayOrphansWindows:
         self._install_fake_psutil(monkeypatch, [recorded, bootstrap])
 
         # get_running_pid() returns the recorded healthy gateway PID.
-        monkeypatch.setattr("gateway.status.get_running_pid", lambda: recorded_pid)
+        monkeypatch.setattr(
+            "gateway.status.get_running_pid", lambda cleanup_stale=True: recorded_pid
+        )
 
         # find_gateway_pids returns the recorded PID, its bootstrap parent
         # and a real orphan. The reaper should only kill the orphan.
@@ -615,7 +617,9 @@ class TestReapUnsupervisedGatewayOrphansWindows:
         recorded = SimpleNamespace(pid=recorded_pid, parent=lambda: bootstrap)
         self._install_fake_psutil(monkeypatch, [recorded, bootstrap])
 
-        monkeypatch.setattr("gateway.status.get_running_pid", lambda: recorded_pid)
+        monkeypatch.setattr(
+            "gateway.status.get_running_pid", lambda cleanup_stale=True: recorded_pid
+        )
 
         # find_gateway_pids would return the recorded PID and its bootstrap
         # parent, but both are excluded.


### PR DESCRIPTION
## Symptom

On Windows, every launch of the desktop app (the `HERMES_DESKTOP=1` serve backend) hard-kills a healthy standalone gateway that is already running (`hermes gateway run`, e.g. a standalone WeChat gateway). Messaging goes down on every desktop start and does not recover automatically until the gateway is restarted manually.

## Root cause

`hermes_cli/web_server.py` `_lifespan` runs the #77276 orphan sweep on every desktop startup. On Windows this sweep kills the healthy, registered gateway:

- There is no systemd/launchd gate: `supports_systemd_services()` is `False` on Windows, so the sweep always proceeds.
- `find_gateway_pids()` matches every process whose command line contains `gateway run` — including the registered, healthy gateway. The whole Windows launcher chain (stub → venv python → runtime python) carries `gateway run` in its command line, so excluding just the pidfile-recorded PID is not enough: unregistered intermediate layers are matched too, and killing the middle layer takes the gateway runtime down with it.
- `os.kill(pid, SIGTERM)` on Windows is a hard `TerminateProcess`. The gateway's own planned-stop watcher polls every 0.5s, so it never gets a chance to see the stop marker and shut down gracefully.
- The exclusion probe used `get_running_pid()` with the default `cleanup_stale=True`: a record that fails liveness validation is unlinked mid-sweep, so the recorded PID never joins the exclusion set and the sweep proceeds against a gateway that was healthy all along.

## Fix

- `hermes_cli/gateway.py` — `_reap_unsupervised_gateway_orphans()`: probe the registration with `get_running_pid(cleanup_stale=False)` so the sweep never deletes the record it is about to use as exclusion evidence. A healthy, registered gateway is not an orphan per the function's own contract ("orphans the pidfile/runtime record can't see").
- `hermes_cli/web_server.py` — `_lifespan` (`HERMES_DESKTOP=1` branch): run the sweep only when `get_running_pid(cleanup_stale=False) is None`. When a live, registered gateway is in the record, skip the sweep entirely.

## Verification

- Test suite (5 files, this branch): **77 passed, 5 skipped** — `tests/hermes_cli/test_gateway.py`, `tests/hermes_cli/test_spawn_gateway_restart_reap.py`, `tests/hermes_cli/test_dashboard_admin_endpoints.py`, `tests/gateway/test_planned_stop_watcher.py`, `tests/gateway/test_gateway_shutdown.py`.
- Live reproduction on Windows 11: with the standalone gateway registered, the desktop-startup guard now short-circuits (**SKIP reap**) and the gateway survives repeated desktop launches; before the fix it was hard-killed on every launch with no auto-recovery.
- `py_compile` clean on both modified modules.

## Known risks / follow-up

`_spawn_gateway_restart`'s pre-restart sweep (same #77276 lineage) can still hard-kill unregistered intermediate launcher layers when a healthy gateway is registered. That path runs only during an explicit gateway restart, where the extra kill is tolerable (the fresh gateway takes over), so it is left as a candidate for the same guard in a follow-up.
