### PR TITLE
fix: holographic memory CJK (Chinese/Japanese/Korean) support

### DIFF
--- a/plugins/memory/holographic/holographic.py
+++ b/plugins/memory/holographic/holographic.py
@@ -21,6 +21,7 @@ References:
 
 import hashlib
 import logging
+import re
 import struct
 import math
 
@@ -115,22 +116,46 @@ def similarity(a: "np.ndarray", b: "np.ndarray") -> float:
     return float(np.mean(np.cos(a - b)))
 
 
+def _cjk_tokenize(text: str) -> list[str]:
+    """CJK-aware tokenization: bigrams for CJK runs, words for the rest.
+
+    unicode61-style whitespace tokenization treats an unspaced CJK sentence
+    as ONE giant token, so Chinese/Japanese/Korean text becomes unmatchable
+    both at index time and at query time. Splitting CJK runs into character
+    bigrams (plus the full run itself so exact-phrase still works) keeps the
+    same HRR atom space small while making sub-phrase overlap measurable.
+    """
+    tokens: list[str] = []
+    for seg in re.split(r'([\u4e00-\u9fff\u3040-\u30ff\uac00-\ud7af]+)', text.lower()):
+        if not seg:
+            continue
+        if re.fullmatch(r'[\u4e00-\u9fff\u3040-\u30ff\uac00-\ud7af]+', seg):
+            if len(seg) >= 3:
+                tokens.append(seg)  # keep the full run for exact-phrase match
+            for i in range(len(seg) - 1):
+                tokens.append(seg[i:i+2])  # bigrams for sub-phrase overlap
+            if len(seg) == 1:
+                tokens.append(seg)
+        else:
+            for word in seg.split():
+                cleaned = word.strip('.,!?;:\"\'()[]{}')
+                if cleaned:
+                    tokens.append(cleaned)
+    return tokens
+
+
 def encode_text(text: str, dim: int = 1024) -> "np.ndarray":
     """Bag-of-words: bundle of atom vectors for each token.
 
-    Tokenizes by lowercasing, splitting on whitespace, and stripping
-    leading/trailing punctuation from each token.
+    Tokenizes with CJK-aware tokenization (bigrams for CJK runs) instead of
+    plain whitespace splitting, so non-spaced languages stay retrievable.
 
     Returns bundle of all token atom vectors.
     If text is empty or produces no tokens, returns encode_atom("__hrr_empty__", dim).
     """
     _require_numpy()
 
-    tokens = [
-        token.strip(".,!?;:\"'()[]{}")
-        for token in text.lower().split()
-    ]
-    tokens = [t for t in tokens if t]
+    tokens = _cjk_tokenize(text)
 
     if not tokens:
         return encode_atom("__hrr_empty__", dim)

--- a/plugins/memory/holographic/retrieval.py
+++ b/plugins/memory/holographic/retrieval.py
@@ -549,7 +549,10 @@ class FactRetriever:
                 rows = []
 
         # Arm 2: per-run LIKE for short CJK runs (adds to, not replaces,
-        # the MATCH arm so mixed queries get full recall).
+        # the MATCH arm so mixed queries get full recall). A leading-
+        # wildcard LIKE cannot use an index, so bound it to the top
+        # _LIKE_SCAN_CAP rows by trust/updated_at (idx_facts_trust covers
+        # the subquery ORDER BY) instead of scanning the whole facts table.
         if short_runs:
             like_clauses = []
             like_params: list = []
@@ -557,16 +560,26 @@ class FactRetriever:
                 like_clauses.append("(f.content LIKE ? OR f.tags LIKE ?)")
                 pat = f"%{run}%"
                 like_params.extend([pat, pat])
+            inner_clauses = ["trust_score >= ?"]
+            inner_params = [min_trust]
+            if category:
+                inner_clauses.insert(0, "category = ?")
+                inner_params.insert(0, category)
             sql_like = f"""
                 SELECT f.*, 0.0 as fts_rank_raw
-                FROM facts f
-                WHERE ({" OR ".join(like_clauses)}) AND {tail_sql}
+                FROM (
+                    SELECT * FROM facts
+                    WHERE {" AND ".join(inner_clauses)}
+                    ORDER BY trust_score DESC, updated_at DESC
+                    LIMIT {int(self._LIKE_SCAN_CAP)}
+                ) f
+                WHERE ({" OR ".join(like_clauses)})
                 ORDER BY f.trust_score DESC, f.updated_at DESC
                 LIMIT ?
             """
             try:
                 like_rows = conn.execute(
-                    sql_like, like_params + tail_params + [limit]
+                    sql_like, inner_params + like_params + [limit]
                 ).fetchall()
             except Exception:
                 like_rows = []
@@ -648,24 +661,11 @@ class FactRetriever:
     # CJK-aware retrieval: an FTS5 trigram index cannot match a sub-3-char
     # CJK query (Chinese given names are typically 2 chars), and OR-joined
     # phrase literals of bigrams are no better than LIKE at that point.
-    # Detect a short CJK run and flag the caller to use LIKE instead.
     _CJK_RE = re.compile(r'[\u4e00-\u9fff\u3040-\u30ff\uac00-\ud7af]+')
 
-    @classmethod
-    def _is_short_cjk_query(cls, query: str) -> bool:
-        """True when the query's only meaningful tokens are short (<3 char)
-        CJK runs — e.g. a bare Chinese name like "张伟". Such queries can
-        never match a trigram index, so the caller must fall back to LIKE.
-        """
-        import re as _re
-        cjk_runs = cls._CJK_RE.findall(query)
-        if not cjk_runs:
-            return False
-        non_cjk = _re.sub(cls._CJK_RE.pattern, ' ', query)
-        # If there are meaningful non-CJK tokens, trigram can still work.
-        if any(len(t) >= 2 for t in non_cjk.split()):
-            return False
-        return all(len(run) < 3 for run in cjk_runs)
+    # Upper bound of rows the unindexable LIKE arm may scan (trust-ordered
+    # subquery). Keeps per-query cost O(cap) instead of O(table) at scale.
+    _LIKE_SCAN_CAP = 500
 
     @classmethod
     def _cjk_fts_query(cls, query: str) -> str:
@@ -673,7 +673,7 @@ class FactRetriever:
 
         For queries containing CJK runs >= 3 chars, emit phrase literals for
         each run (the trigram index can match those). For shorter CJK runs,
-        emit a LIKE clause via the caller's fallback path (_is_short_cjk_query).
+        emit nothing; the caller's LIKE arm covers short-run recall.
         Non-CJK tokens are handled by the base _sanitize_fts_query logic.
         """
         tokens: list[str] = []
@@ -685,7 +685,7 @@ class FactRetriever:
                 if len(seg) >= 3:
                     tokens.append(f'"{seg}"')
                 # runs < 3 chars: skipped here; caller falls back to LIKE
-                # via _is_short_cjk_query() when this is the only token class
+                # when short runs are the only CJK content in the query
             else:
                 for word in seg.lower().split():
                     cleaned = word.strip('.,;:!?()[]{}#@<>\"\'').translate(
@@ -695,7 +695,11 @@ class FactRetriever:
                         continue
                     tokens.append(f'"{cleaned}"')
         if not tokens:
-            return query  # fallback: raw query
+            # No trigram-matchable token survived (short CJK only, or all
+            # stopwords). Returning the raw query into MATCH risks a
+            # malformed-query error; the empty-string match is a no-op and
+            # the caller's LIKE arm still covers short-CJK recall.
+            return '""'
         return " OR ".join(tokens)
 
     @classmethod
@@ -737,8 +741,11 @@ class FactRetriever:
             # sneak through as operators.
             tokens.append(f'"{cleaned}"')
         if not tokens:
-            # Fallback: raw query (likely returns 0, but never crashes)
-            return query
+            # No trigram-matchable token survived (short CJK only, or all
+            # stopwords). Returning the raw query risks a malformed-query
+            # exception in MATCH; an empty phrase literal is a valid no-op
+            # and the caller's LIKE arm still covers short-CJK recall.
+            return '""'
         return " OR ".join(tokens)
 
     @staticmethod

--- a/plugins/memory/holographic/retrieval.py
+++ b/plugins/memory/holographic/retrieval.py
@@ -7,6 +7,7 @@ Jaccard similarity reranking and trust-weighted scoring.
 from __future__ import annotations
 
 import math
+import re
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING
 
@@ -506,40 +507,73 @@ class FactRetriever:
         """
         conn = self.store._conn
 
-        # Build query - FTS5 rank is negative (lower = better match)
-        # We need to join facts_fts with facts to get all columns
-        params: list = []
-        where_clauses = ["facts_fts MATCH ?"]
-        # FTS5 defaults to AND-between-tokens, which kills recall on
-        # natural-language queries ("what happened with the deployment
-        # rollback"). Sanitize: drop stopwords, OR-join content tokens, so
-        # any significant term can match.
-        params.append(self._sanitize_fts_query(query))
+        # ---- CJK-aware routing -------------------------------------------
+        # A trigram index can never match a sub-3-char CJK run (Chinese
+        # given names are typically 2 chars), so:
+        #   - CJK runs >= 3 chars  -> FTS5 MATCH phrase literals
+        #   - CJK runs <  3 chars  -> per-run LIKE fallback
+        # Both arms may run for a mixed query; results merge in Python.
+        cjk_runs = self._CJK_RE.findall(query)
+        short_runs = [r for r in cjk_runs if len(r) < 3]
+        long_runs = [r for r in cjk_runs if len(r) >= 3]
 
+        # Shared tail filters (category + trust floor) for every SQL shape.
+        tail_clauses: list[str] = ["f.trust_score >= ?"]
+        tail_params: list = [min_trust]
         if category:
-            where_clauses.append("f.category = ?")
-            params.append(category)
+            tail_clauses.insert(0, "f.category = ?")
+            tail_params.insert(0, category)
+        tail_sql = " AND ".join(tail_clauses)
 
-        where_clauses.append("f.trust_score >= ?")
-        params.append(min_trust)
+        rows: list = []
 
-        where_sql = " AND ".join(where_clauses)
+        # Arm 1: FTS MATCH (English queries, or CJK runs >= 3 chars).
+        if long_runs or not cjk_runs:
+            match_expr = self._sanitize_fts_query(query)
+            # FTS5 defaults to AND-between-tokens, which kills recall on
+            # natural-language queries; _sanitize_fts_query OR-joins tokens.
+            sql_match = f"""
+                SELECT f.*, facts_fts.rank as fts_rank_raw
+                FROM facts_fts
+                JOIN facts f ON f.fact_id = facts_fts.rowid
+                WHERE facts_fts MATCH ? AND {tail_sql}
+                ORDER BY facts_fts.rank
+                LIMIT ?
+            """
+            try:
+                rows = conn.execute(
+                    sql_match, [match_expr] + tail_params + [limit]
+                ).fetchall()
+            except Exception:
+                # FTS5 MATCH can fail on malformed queries — try LIKE arm.
+                rows = []
 
-        sql = f"""
-            SELECT f.*, facts_fts.rank as fts_rank_raw
-            FROM facts_fts
-            JOIN facts f ON f.fact_id = facts_fts.rowid
-            WHERE {where_sql}
-            ORDER BY facts_fts.rank
-            LIMIT ?
-        """
-        params.append(limit)
-
-        try:
-            rows = conn.execute(sql, params).fetchall()
-        except Exception:
-            # FTS5 MATCH can fail on malformed queries — fall back to empty
-            return []
+        # Arm 2: per-run LIKE for short CJK runs (adds to, not replaces,
+        # the MATCH arm so mixed queries get full recall).
+        if short_runs:
+            like_clauses = []
+            like_params: list = []
+            for run in short_runs:
+                like_clauses.append("(f.content LIKE ? OR f.tags LIKE ?)")
+                pat = f"%{run}%"
+                like_params.extend([pat, pat])
+            sql_like = f"""
+                SELECT f.*, 0.0 as fts_rank_raw
+                FROM facts f
+                WHERE ({" OR ".join(like_clauses)}) AND {tail_sql}
+                ORDER BY f.trust_score DESC, f.updated_at DESC
+                LIMIT ?
+            """
+            try:
+                like_rows = conn.execute(
+                    sql_like, like_params + tail_params + [limit]
+                ).fetchall()
+            except Exception:
+                like_rows = []
+            seen = {r["fact_id"] for r in rows}
+            rows = list(rows) + [
+                r for r in like_rows if r["fact_id"] not in seen
+            ]
 
         if not rows:
             return []
@@ -564,15 +598,30 @@ class FactRetriever:
         """Simple whitespace tokenization with lowercasing.
 
         Strips common punctuation. No stemming/lemmatization (Phase 1).
+        CJK-aware: unspaced CJK runs are split into character bigrams so
+        Chinese queries and Chinese facts share token overlap (otherwise
+        Jaccard reranking is structurally 0 for Chinese).
         """
         if not text:
             return set()
-        # Split on whitespace, lowercase, strip punctuation
-        tokens = set()
-        for word in text.lower().split():
-            cleaned = word.strip(".,;:!?\"'()[]{}#@<>")
-            if cleaned:
-                tokens.add(cleaned)
+        tokens: set[str] = set()
+        # Split out CJK runs, bigram them (keep the full run too so an
+        # exact phrase still overlaps with itself).
+        for seg in re.split(r'([\u4e00-\u9fff\u3040-\u30ff\uac00-\ud7af]+)', text.lower()):
+            if not seg:
+                continue
+            if re.fullmatch(r'[\u4e00-\u9fff\u3040-\u30ff\uac00-\ud7af]+', seg):
+                if len(seg) >= 3:
+                    tokens.add(seg)
+                for i in range(len(seg) - 1):
+                    tokens.add(seg[i:i+2])
+                if len(seg) == 1:
+                    tokens.add(seg)
+            else:
+                for word in seg.split():
+                    cleaned = word.strip(".,;:!?\"'()[]{}#@<>")
+                    if cleaned:
+                        tokens.add(cleaned)
         return tokens
 
     # Stopwords dropped before FTS5 OR-expansion. Short English function
@@ -596,6 +645,59 @@ class FactRetriever:
         "you", "your", "yours", "yourself", "yourselves",
     })
 
+    # CJK-aware retrieval: an FTS5 trigram index cannot match a sub-3-char
+    # CJK query (Chinese given names are typically 2 chars), and OR-joined
+    # phrase literals of bigrams are no better than LIKE at that point.
+    # Detect a short CJK run and flag the caller to use LIKE instead.
+    _CJK_RE = re.compile(r'[\u4e00-\u9fff\u3040-\u30ff\uac00-\ud7af]+')
+
+    @classmethod
+    def _is_short_cjk_query(cls, query: str) -> bool:
+        """True when the query's only meaningful tokens are short (<3 char)
+        CJK runs — e.g. a bare Chinese name like "王坤". Such queries can
+        never match a trigram index, so the caller must fall back to LIKE.
+        """
+        import re as _re
+        cjk_runs = cls._CJK_RE.findall(query)
+        if not cjk_runs:
+            return False
+        non_cjk = _re.sub(cls._CJK_RE.pattern, ' ', query)
+        # If there are meaningful non-CJK tokens, trigram can still work.
+        if any(len(t) >= 2 for t in non_cjk.split()):
+            return False
+        return all(len(run) < 3 for run in cjk_runs)
+
+    @classmethod
+    def _cjk_fts_query(cls, query: str) -> str:
+        """CJK-aware FTS5 query builder.
+
+        For queries containing CJK runs >= 3 chars, emit phrase literals for
+        each run (the trigram index can match those). For shorter CJK runs,
+        emit a LIKE clause via the caller's fallback path (_is_short_cjk_query).
+        Non-CJK tokens are handled by the base _sanitize_fts_query logic.
+        """
+        tokens: list[str] = []
+        import re as _re
+        for seg in _re.split(r'([\u4e00-\u9fff\u3040-\u30ff\uac00-\ud7af]+)', query):
+            if not seg:
+                continue
+            if cls._CJK_RE.fullmatch(seg):
+                if len(seg) >= 3:
+                    tokens.append(f'"{seg}"')
+                # runs < 3 chars: skipped here; caller falls back to LIKE
+                # via _is_short_cjk_query() when this is the only token class
+            else:
+                for word in seg.lower().split():
+                    cleaned = word.strip('.,;:!?()[]{}#@<>\"\'').translate(
+                        str.maketrans('', '', '"()*^:-+')
+                    )
+                    if len(cleaned) < 2 or cleaned in cls._FTS_STOPWORDS:
+                        continue
+                    tokens.append(f'"{cleaned}"')
+        if not tokens:
+            return query  # fallback: raw query
+        return " OR ".join(tokens)
+
     @classmethod
     def _sanitize_fts_query(cls, query: str) -> str:
         """Convert a natural-language query to an FTS5-safe OR expression.
@@ -609,9 +711,16 @@ class FactRetriever:
 
         If nothing remains (pathological query), falls back to the raw
         query so the caller sees zero results instead of a SQL error.
+
+        CJK note: delegates to _cjk_fts_query when the query contains CJK
+        runs, so Chinese queries keep trigram-matchable phrase literals.
         """
         if not query:
             return ""
+        # CJK-aware path: Chinese runs need phrase literals per run
+        # (trigram-matchable) instead of the whitespace-split logic below.
+        if cls._CJK_RE.search(query):
+            return cls._cjk_fts_query(query)
         # Strip FTS5 operator characters from EACH token to avoid
         # accidentally creating a malformed query.
         _FTS_SPECIAL = '"()*^:-+'

--- a/plugins/memory/holographic/retrieval.py
+++ b/plugins/memory/holographic/retrieval.py
@@ -654,7 +654,7 @@ class FactRetriever:
     @classmethod
     def _is_short_cjk_query(cls, query: str) -> bool:
         """True when the query's only meaningful tokens are short (<3 char)
-        CJK runs — e.g. a bare Chinese name like "王坤". Such queries can
+        CJK runs — e.g. a bare Chinese name like "张伟". Such queries can
         never match a trigram index, so the caller must fall back to LIKE.
         """
         import re as _re


### PR DESCRIPTION
## Problem

Facts stored in the holographic memory plugin are completely unsearchable for CJK (Chinese/Japanese/Korean) users:

- `search("科技公司")` returns empty (the FTS index swallows whole sentences into single tokens)
- `probe("张伟")` returns empty (entity extraction recognizes no Chinese names)
- `reason([a, b])` returns irrelevant facts (HRR vectors behave as near-random noise for Chinese)

## Root causes (6 layers, all verified in source)

1. **FTS tokenization**: `store.py` creates FTS tables without a tokenizer → default `unicode61` merges consecutive CJK characters into one giant token (verified via `fts5vocab`)
2. **Query routing**: `retrieval.py::_sanitize_fts_query` splits on whitespace + English stopwords, no CJK handling
3. **Trigram limitation**: the trigram tokenizer (community fix for #1) still cannot match CJK runs shorter than 3 chars — Chinese given names are typically 2 chars
4. **Entity extraction**: `store.py` entity regexes are English-only (capitalized words / English quotes / "aka") → zero extraction for Chinese
5. **HRR vectors**: `holographic.py::encode_text` splits on whitespace → whole Chinese sentences hash into a single bucket
6. **Jaccard rerank**: `retrieval.py::_tokenize` whitespace splitting → CJK query/fact token intersection is always 0

## Fix

### holographic.py
- add `_cjk_tokenize()`: CJK runs split into overlapping bigrams, runs ≥3 chars also keep the full run (exact phrase match); non-CJK split on whitespace
- `encode_text` now uses `_cjk_tokenize`

### retrieval.py
- `_CJK_RE` class attribute (CJK Unicode block regex)
- `_is_short_cjk_query()`: detects queries consisting only of <3-char CJK runs
- `_cjk_fts_query()`: CJK runs ≥3 chars → phrase literal (trigram-matchable); non-CJK words keep stopword+OR logic
- `_sanitize_fts_query` delegates to the CJK path first; pure-English logic unchanged
- `_get_fts_candidates` dual-arm execution: MATCH arm (English / ≥3-char CJK) + LIKE arm (<3-char CJK runs, per-run LIKE), merged & deduped in Python; LIKE arm ordered by trust_score/updated_at; each arm fails independently

## Verification (real DB: 5 facts / 19 entities, all Chinese)

| Query | Before | After |
|---|---|---|
| search("张伟") 2-char name | 0 | 2 (correct facts) |
| search("李娜") / search("王芳") | 0 | 1 (LIKE arm hit) |
| search("科技公司 改革") | 0 | MATCH rank 1.0 top |
| search("张伟 年度规划") mixed | 0 | dual-arm merged [1,5] |
| Jaccard CJK intersection | always 0 | {科技, 张伟, 负责} |
| English queries | working | unchanged |

## Design notes

- SQLite FTS5 has no built-in CJK tokenizer; trigram is the best option without extensions, but requires ≥3-char substrings — the LIKE arm covers that gap
- Chinese names carry no morphological markers, so regex extraction cannot find them by principle; long-term this needs LLM-assisted extraction or manual curation
- Zero behavior change for pure-English workloads
