### PR TITLE
Fix: Chat Completions misses duplicate tool calls when JSON argument key order differs

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -4873,7 +4873,11 @@ class AIAgent:
         seen: set = set()
         unique: list = []
         for tc in tool_calls:
-            key = (tc.function.name, tc.function.arguments)
+            try:
+                normalized_args = json.dumps(json.loads(tc.function.arguments), sort_keys=True)
+            except (TypeError, ValueError):
+                normalized_args = tc.function.arguments
+            key = (tc.function.name, normalized_args)
             if key not in seen:
                 seen.add(key)
                 unique.append(tc)


### PR DESCRIPTION
## Summary
Fixes #86871

Hermes deduplicates tool calls within a single assistant turn by comparing `(tool_name, arguments)` pairs. The `arguments` field is a raw JSON string, so two functionally identical calls with different key orderings (e.g. `{"command":"x","timeout":10}` vs `{"timeout":10,"command":"x"}`) were treated as distinct and both executed — even though the native Gemini adapter already avoids this by sorting argument keys before comparison.

## Fix
Normalize `arguments` by parsing it and re-serializing with `sort_keys=True` before building the dedup key, so key-order differences no longer produce false negatives. Falls back to the raw string on malformed JSON so existing error handling is unaffected.

## Testing
Ran `py_compile` on the modified file to confirm no syntax errors were introduced.