### PR TITLE
docs(execute-code): require helper imports

### DIFF
--- a/tests/tools/test_code_execution.py
+++ b/tests/tools/test_code_execution.py
@@ -323,6 +323,25 @@ raise RuntimeError("deliberate crash")
         self.assertIn("RuntimeError", result.get("error", "") + result.get("output", ""))
 
 
+    def test_helper_import_guidance_matches_runtime_contract(self):
+        """Helpers live in hermes_tools and must be imported by user scripts."""
+        from tools.code_execution_tool import build_execute_code_schema
+
+        description = build_execute_code_schema()["description"]
+        self.assertIn(
+            "from hermes_tools import json_parse, shell_quote, retry",
+            description,
+        )
+        self.assertNotIn("Built-in helpers (no import)", description)
+
+    def test_sandbox_failure_hint_recommends_helper_import(self):
+        """The recovery hint must not prescribe the known-broken direct-call form."""
+        from tools.code_execution_tool import _sandbox_failure_hint
+
+        hint = _sandbox_failure_hint("NameError: name 'json_parse' is not defined") or ""
+        self.assertIn("from hermes_tools import json_parse", hint)
+        self.assertNotIn("call it directly", hint)
+
     def test_shell_quote_helper(self):
         """shell_quote properly escapes dangerous characters."""
         code = """

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -396,8 +396,9 @@ def _sandbox_failure_hint(stderr_text: str, enabled_tools=None) -> Optional[str]
             builtin = {"json_parse", "shell_quote", "retry"}
             if missing in builtin:
                 return (
-                    f"{missing} is a BUILT-IN helper in the sandbox — no import "
-                    f"needed. Remove it from the import line and call {missing}(...) directly."
+                    f"{missing} is exported by the generated hermes_tools module. "
+                    "The module is stale or incomplete; retry in a fresh execute_code call "
+                    f"and use `from hermes_tools import {missing}`."
                 )
             return (
                 f"'{missing}' is not available inside the execute_code sandbox. "
@@ -407,8 +408,8 @@ def _sandbox_failure_hint(stderr_text: str, enabled_tools=None) -> Optional[str]
         m = re.search(r"NameError: name '(json_parse|shell_quote|retry)' is not defined", window)
         if m:
             return (
-                f"{m.group(1)} is built into the generated sandbox module — "
-                "call it directly at module scope without importing it."
+                f"Import it in the script with `from hermes_tools import {m.group(1)}` "
+                "before calling it."
             )
         m = re.search(r"ModuleNotFoundError: No module named '([\w.]+)'", window)
         if m:
@@ -2125,8 +2126,9 @@ def build_execute_code_schema(enabled_sandbox_tools: set = None,
         f"{cwd_note}\n\n"
         "Print your final result to stdout; stdlib (json, re, csv, datetime, ...) "
         "is available for processing.\n\n"
-        "Built-in helpers (no import): json_parse(text) — tolerant json.loads for "
-        "terminal() output; shell_quote(s) — shlex.quote for dynamic shell args; "
+        "Import helpers with `from hermes_tools import json_parse, shell_quote, retry`: "
+        "json_parse(text) — tolerant json.loads for terminal() output; "
+        "shell_quote(s) — shlex.quote for dynamic shell args; "
         "retry(fn, max_attempts=3, delay=2) — exponential backoff for transient failures."
     )
 


### PR DESCRIPTION
## Summary
- document that `json_parse`, `shell_quote`, and `retry` must be imported from `hermes_tools`
- update recovery hints to match the runtime helper contract
- add focused tests for the documented import and hint paths

## Why
The helpers are exposed through the injected `hermes_tools` module, not as implicit globals. Existing examples could lead generated code to call undefined names.

## Test plan
- `uv run --with pytest python -m pytest -q tests/tools/test_code_execution.py` — 44 passed, 5 subtests passed
- `uvx ruff check tools/code_execution_tool.py tests/tools/test_code_execution.py`
- `python3 -m compileall -q tools/code_execution_tool.py`
- `git diff --check`

## Platforms
- Linux, Python 3.11