### PR TITLE
feat(cli): non-interactive 'hermes fallback add <provider>/<model>'

### DIFF
--- a/hermes_cli/fallback_cmd.py
+++ b/hermes_cli/fallback_cmd.py
@@ -144,10 +144,65 @@ def _describe_primary(config: Dict[str, Any]) -> Optional[str]:
     return None
 
 
+def _parse_spec(spec: str) -> Optional[Dict[str, Any]]:
+    """Parse a non-interactive fallback spec into a ``{provider, model, base_url?}`` entry.
+
+    Accepted forms::
+
+        <provider>/<model>
+        <provider>/<model>@https://base.url/v1
+
+    Returns ``None`` when no spec was provided.  Raises ``ValueError`` when a
+    spec IS provided but malformed (missing provider or model separator).
+    """
+    spec = (spec or "").strip()
+    if not spec:
+        return None
+
+    base_url = ""
+    if "@" in spec:
+        spec, base_url = spec.rsplit("@", 1)
+        base_url = base_url.strip()
+
+    provider, sep, model = spec.partition("/")
+    provider = provider.strip()
+    model = model.strip()
+    if not sep or not provider or not model:
+        raise ValueError(
+            f"Invalid fallback spec: {spec!r}. Expected <provider>/<model> "
+            "e.g. openrouter/anthropic/claude-sonnet-4.6, optionally with @base_url."
+        )
+
+    entry: Dict[str, Any] = {"provider": provider, "model": model}
+    if base_url:
+        entry["base_url"] = base_url
+    return entry
+
+
 def cmd_fallback_add(args) -> None:
-    """Launch the same picker as `hermes model`, then append the selection to the chain."""
-    from hermes_cli.main import _require_tty, select_provider_and_model
+    """Add a fallback entry.
+
+    Non-interactive when ``args.spec`` is a ``<provider>/<model>`` spec;
+    otherwise launches the same picker as `hermes model` and appends the
+    selection to the chain.
+    """
     from hermes_cli.config import load_config, save_config
+
+    spec = getattr(args, "spec", None)
+    spec_entry = None
+    if spec:
+        try:
+            spec_entry = _parse_spec(spec)
+        except ValueError as exc:
+            print()
+            print(f"  ✗ {exc}")
+            print()
+            raise SystemExit(2)
+    if spec_entry:
+        _append_fallback(spec_entry)
+        return
+
+    from hermes_cli.main import _require_tty, select_provider_and_model
 
     _require_tty("fallback add")
 
@@ -218,8 +273,22 @@ def cmd_fallback_add(args) -> None:
     _restore_model_cfg(model_before)
     _restore_auth_active_provider(active_provider_before)
 
+    _append_fallback(new_entry)
+
+
+def _append_fallback(new_entry: Dict[str, Any]) -> None:
+    """Validate and append a fallback entry (shared by picker and spec paths)."""
+    from agent.backend_identity import BackendIdentity, same_deployment
+    from hermes_cli.config import load_config, save_config
+
     final_cfg = load_config()
     chain = _read_chain(final_cfg)
+
+    new_ident = BackendIdentity.build(
+        provider=new_entry.get("provider"),
+        model=new_entry.get("model"),
+        base_url=new_entry.get("base_url"),
+    )
 
     # Reject exact-duplicate fallback entries (same deployment; a different
     # explicit base_url is a different endpoint and NOT a duplicate).

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -11775,7 +11775,18 @@ def main():
     )
     fallback_subparsers.add_parser(
         "add",
-        help="Pick a provider + model (same picker as `hermes model`) and append to the chain",
+        help=(
+            "Append a fallback. Without args, opens the provider/model picker. "
+            "Or pass a spec directly: <provider>/<model> (e.g. openrouter/anthropic/claude-sonnet-4.6), "
+            "optionally with @base_url."
+        ),
+    ).add_argument(
+        "spec",
+        nargs="?",
+        help=(
+            "Non-interactive fallback spec as <provider>/<model>, e.g. "
+            "openrouter/anthropic/claude-sonnet-4.6.  Optional @base_url suffix for custom endpoints."
+        ),
     )
     fallback_subparsers.add_parser(
         "remove",

--- a/tests/hermes_cli/test_fallback_cmd.py
+++ b/tests/hermes_cli/test_fallback_cmd.py
@@ -33,8 +33,64 @@ def _read_config(home: Path) -> dict:
 
 
 # ---------------------------------------------------------------------------
-# _read_chain / _write_chain
+# _parse_spec
 # ---------------------------------------------------------------------------
+
+class TestParseSpec:
+    """Tests for _parse_spec — non-interactive fallback spec parsing."""
+
+    def test_returns_none_for_empty(self):
+        from hermes_cli.fallback_cmd import _parse_spec
+        assert _parse_spec("") is None
+        assert _parse_spec(None) is None
+        assert _parse_spec("  ") is None
+
+    def test_parses_provider_and_model(self):
+        from hermes_cli.fallback_cmd import _parse_spec
+        result = _parse_spec("openrouter/anthropic/claude-sonnet-4.6")
+        assert result == {"provider": "openrouter", "model": "anthropic/claude-sonnet-4.6"}
+
+    def test_parses_with_base_url(self):
+        from hermes_cli.fallback_cmd import _parse_spec
+        result = _parse_spec("nous/Hermes-4@https://api.nousresearch.com/v1")
+        assert result == {
+            "provider": "nous",
+            "model": "Hermes-4",
+            "base_url": "https://api.nousresearch.com/v1",
+        }
+
+    def test_parses_simple_provider_model(self):
+        from hermes_cli.fallback_cmd import _parse_spec
+        result = _parse_spec("openai/gpt-5.4")
+        assert result == {"provider": "openai", "model": "gpt-5.4"}
+
+    def test_raises_on_missing_separator(self):
+        from hermes_cli.fallback_cmd import _parse_spec
+        with pytest.raises(ValueError, match="Invalid fallback spec"):
+            _parse_spec("noslash")
+
+    def test_raises_on_empty_provider(self):
+        from hermes_cli.fallback_cmd import _parse_spec
+        with pytest.raises(ValueError, match="Invalid fallback spec"):
+            _parse_spec("/model-only")
+
+    def test_raises_on_empty_model(self):
+        from hermes_cli.fallback_cmd import _parse_spec
+        with pytest.raises(ValueError, match="Invalid fallback spec"):
+            _parse_spec("provider/")
+
+    def test_strips_whitespace(self):
+        from hermes_cli.fallback_cmd import _parse_spec
+        result = _parse_spec("  openai / gpt-5.4  @  https://api.openai.com/v1  ")
+        assert result == {
+            "provider": "openai",
+            "model": "gpt-5.4",
+            "base_url": "https://api.openai.com/v1",
+        }
+
+
+# ---------------------------------------------------------------------------
+# _read_chain / _write_chain
 
 class TestReadChain:
     def test_returns_empty_list_when_unset(self):
@@ -215,6 +271,81 @@ class TestAddCommand:
         # Fallback added
         assert len(cfg["fallback_providers"]) == 1
         assert cfg["fallback_providers"][0]["provider"] == "openrouter"
+    def test_add_via_spec(self, isolated_home, capsys):
+        _write_config(isolated_home, {
+            "model": {"provider": "anthropic", "default": "claude-sonnet-4-6"},
+        })
+        from hermes_cli.fallback_cmd import cmd_fallback_add
+        cmd_fallback_add(types.SimpleNamespace(spec="openrouter/anthropic/claude-sonnet-4.6"))
+
+        cfg = _read_config(isolated_home)
+        assert cfg["fallback_providers"] == [
+            {"provider": "openrouter", "model": "anthropic/claude-sonnet-4.6"},
+        ]
+        out = capsys.readouterr().out
+        assert "Added fallback" in out
+
+    def test_add_via_spec_with_base_url(self, isolated_home, capsys):
+        _write_config(isolated_home, {
+            "model": {"provider": "anthropic", "default": "claude-sonnet-4-6"},
+        })
+        from hermes_cli.fallback_cmd import cmd_fallback_add
+        cmd_fallback_add(types.SimpleNamespace(
+            spec="nous/Hermes-4@https://api.nousresearch.com/v1"
+        ))
+
+        cfg = _read_config(isolated_home)
+        assert cfg["fallback_providers"] == [
+            {
+                "provider": "nous",
+                "model": "Hermes-4",
+                "base_url": "https://api.nousresearch.com/v1",
+            },
+        ]
+        out = capsys.readouterr().out
+        assert "Added fallback" in out
+
+    def test_add_via_spec_duplicate_skipped(self, isolated_home, capsys):
+        _write_config(isolated_home, {
+            "model": {"provider": "anthropic", "default": "claude-sonnet-4-6"},
+            "fallback_providers": [
+                {"provider": "openrouter", "model": "anthropic/claude-sonnet-4.6"},
+            ],
+        })
+        from hermes_cli.fallback_cmd import cmd_fallback_add
+        cmd_fallback_add(types.SimpleNamespace(spec="openrouter/anthropic/claude-sonnet-4.6"))
+
+        cfg = _read_config(isolated_home)
+        assert len(cfg["fallback_providers"]) == 1
+        out = capsys.readouterr().out
+        assert "already in the fallback chain" in out
+
+    def test_add_via_spec_malformed_exits(self, isolated_home, capsys):
+        _write_config(isolated_home, {
+            "model": {"provider": "anthropic", "default": "claude-sonnet-4-6"},
+        })
+        from hermes_cli.fallback_cmd import cmd_fallback_add
+        with pytest.raises(SystemExit):
+            cmd_fallback_add(types.SimpleNamespace(spec="badspec"))
+
+        out = capsys.readouterr().out
+        assert "Invalid fallback spec" in out
+
+    def test_add_via_spec_skips_tty(self, isolated_home, capsys):
+        """When spec is given, _require_tty must NOT be called."""
+        _write_config(isolated_home, {
+            "model": {"provider": "anthropic", "default": "claude-sonnet-4-6"},
+        })
+        # The spec path never imports _require_tty, so we verify by ensuring
+        # the command succeeds without a TTY (which would fail in picker path).
+        from hermes_cli.fallback_cmd import cmd_fallback_add
+        cmd_fallback_add(types.SimpleNamespace(spec="openai/gpt-5.4"))
+
+        cfg = _read_config(isolated_home)
+        assert cfg["fallback_providers"] == [
+            {"provider": "openai", "model": "gpt-5.4"},
+        ]
+
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

`hermes fallback add` currently only works via an interactive provider/model picker, which requires a TTY and cannot be scripted. This PR adds a non-interactive spec form so the command can be used headlessly (cron, automation, CI, agent scripts).

**New syntax:**
```
hermes fallback add <provider>/<model>
hermes fallback add <provider>/<model>@https://base.url/v1   # custom endpoint
```

With no argument, the existing interactive picker behaviour is unchanged (backwards compatible).

## What changed

- **`hermes_cli/fallback_cmd.py`**
  - `_parse_spec()` — parses a `<provider>/<model>` (optionally `@base_url`) spec; raises a clear `ValueError` on malformed input.
  - `_append_fallback()` — extracted the duplicate-check + append + save logic, shared by both picker and spec paths.
  - `cmd_fallback_add()` — branches to the spec path when `args.spec` is provided, otherwise falls through to the existing picker.
- **`hermes_cli/main.py`** — adds the optional `spec` positional argument to the `fallback add` subparser.
- **`tests/hermes_cli/test_fallback_cmd.py`** — 13 new tests: `_parse_spec()` edge cases (empty, whitespace, provider/model, base_url, malformed), spec-based add, duplicate skip, malformed spec error exit, TTY-skip verification.

## Relationship to existing PR #87117

An alternative implementation exists in PR #87117 (@rafarq) with the same approach and file changes. This version additionally includes:
- 13 unit tests covering `_parse_spec()` and `_append_fallback()`
- Whitespace-stripping in spec parsing
- Cleaner error message example (shows 3-segment provider slash like `openrouter/anthropic/claude-sonnet-4.6`)

Both PRs implement the same feature. This PR adds test coverage.

## Tests

27 tests pass in `tests/hermes_cli/test_fallback_cmd.py` (14 original + 13 new).

Closes #87119