### PR TITLE
fix(update): reclaim a recovery lock whose owner PID is gone

### DIFF
--- a/contributors/emails/greqone@greqone.pl
+++ b/contributors/emails/greqone@greqone.pl
@@ -1,0 +1,1 @@
+greqone

--- a/hermes_cli/_early_recovery.py
+++ b/hermes_cli/_early_recovery.py
@@ -418,19 +418,8 @@ def recover_if_needed(
         # Single-flight: share main.py's recovery lock so an early repair
         # never races a concurrent full recovery into the same shared venv.
         lock_path = root / ".update-incomplete.lock"
-        try:
-            fd = os.open(lock_path, os.O_CREAT | os.O_EXCL | os.O_WRONLY)
-            os.write(fd, f"{os.getpid()}\n".encode())
-            os.close(fd)
-        except FileExistsError:
-            try:
-                if time.time() - lock_path.stat().st_mtime > 3600:
-                    lock_path.unlink()
-            except OSError:
-                pass
+        if not _claim_recovery_lock(root):
             return
-        except OSError:
-            pass  # read-only fs / perms — proceed unlocked, install surfaces it
 
         try:
             specs = _pinned_specs(broken, root)
@@ -470,25 +459,72 @@ def recover_if_needed(
 _EARLY_CORE_INSTALL_MAX_ATTEMPTS = 3
 
 
+# Age fallback for a lock whose body this cannot reason about (empty,
+# truncated, or written by an older layout).  PID liveness is the primary
+# staleness test; this only backstops the unparseable cases and a wedged
+# but still-running owner.
+_RECOVERY_LOCK_MAX_AGE_SECONDS = 3600
+
+
+def _lock_owner_is_live(lock_path: Path) -> bool:
+    """True when the recovery lock names a process that is still running.
+
+    The body is a bare PID (see the claim below).  Conservative: anything
+    unreadable or non-numeric counts as live, leaving the age fallback in
+    charge rather than stealing a lock this cannot identify.
+    """
+    try:
+        body = lock_path.read_text(encoding="utf-8", errors="replace").strip()
+    except OSError:
+        return True
+    try:
+        pid = int(body.splitlines()[0].strip())
+    except (IndexError, ValueError):
+        return True
+    return _pid_is_running(pid)
+
+
+def _discard_stale_recovery_lock(lock_path: Path) -> bool:
+    """Remove a recovery lock nobody owns.  True when a retry should follow.
+
+    A crashed or killed owner leaves its lock behind, which is the exact
+    state the marker system exists to recover from.  Waiting out the age
+    fallback there means every launch's recovery silently no-ops for an hour
+    (nothing is printed, the claim just fails), so a pending install stalls
+    long after the process holding it died.  Probe the recorded PID and
+    reclaim immediately when it is gone.
+    """
+    try:
+        if _lock_owner_is_live(lock_path):
+            age = time.time() - lock_path.stat().st_mtime
+            if age <= _RECOVERY_LOCK_MAX_AGE_SECONDS:
+                return False
+        lock_path.unlink()
+        return True
+    except OSError:
+        return False
+
+
 def _claim_recovery_lock(root: Path) -> bool:
     """Single-flight claim on the shared recovery lock.  Never raises."""
     lock_path = root / ".update-incomplete.lock"
-    try:
-        fd = os.open(lock_path, os.O_CREAT | os.O_EXCL | os.O_WRONLY)
-        os.write(fd, f"{os.getpid()}\n".encode())
-        os.close(fd)
-        return True
-    except FileExistsError:
+    for retry in (False, True):
         try:
-            if time.time() - lock_path.stat().st_mtime > 3600:
-                lock_path.unlink()
+            fd = os.open(lock_path, os.O_CREAT | os.O_EXCL | os.O_WRONLY)
+            os.write(fd, f"{os.getpid()}\n".encode())
+            os.close(fd)
+            return True
+        except FileExistsError:
+            # Only the first miss may reclaim.  A lock that reappears
+            # between the discard and the retry belongs to a live racer
+            # that won the same reclaim, so yield to it.
+            if retry or not _discard_stale_recovery_lock(lock_path):
+                return False
         except OSError:
-            pass
-        return False
-    except OSError:
-        # Read-only fs / perms — proceed unlocked; the install itself
-        # surfaces the real problem.  Recoverable.
-        return True
+            # Read-only fs / perms — proceed unlocked; the install itself
+            # surfaces the real problem.  Recoverable.
+            return True
+    return False
 
 
 def _release_recovery_lock(root: Path) -> None:

--- a/tests/hermes_cli/test_early_recovery.py
+++ b/tests/hermes_cli/test_early_recovery.py
@@ -15,6 +15,7 @@ import os
 import subprocess
 import sys
 import textwrap
+import time
 from pathlib import Path
 
 import pytest
@@ -545,3 +546,120 @@ def test_bump_marker_attempts_handles_missing_and_corrupt_bodies(tmp_path):
 
 
 
+
+
+# ---------------------------------------------------------------------------
+# Recovery-lock staleness: a dead owner must not hold recovery hostage
+# ---------------------------------------------------------------------------
+
+LOCK = ".update-incomplete.lock"
+
+
+def _write_lock(root: Path, body: str, *, age_seconds: float = 0.0) -> Path:
+    lock = root / LOCK
+    lock.write_text(body, encoding="utf-8")
+    if age_seconds:
+        stamp = time.time() - age_seconds
+        os.utime(lock, (stamp, stamp))
+    return lock
+
+
+def _dead_pid() -> int:
+    """A PID that is genuinely gone: spawn a no-op child and reap it."""
+    proc = subprocess.Popen([sys.executable, "-c", ""])
+    proc.wait()
+    return proc.pid
+
+
+def test_recovery_lock_reclaimed_when_owner_pid_is_dead(tmp_path, monkeypatch):
+    """The regression: a crashed owner used to block recovery for an hour."""
+    root = _project(tmp_path)
+    lock = _write_lock(root, "4242\n")
+    monkeypatch.setattr(er, "_pid_is_running", lambda _pid: False)
+
+    assert er._claim_recovery_lock(root) is True
+    assert lock.read_text(encoding="utf-8").strip() == str(os.getpid())
+
+
+def test_recovery_lock_reclaimed_from_a_real_dead_pid(tmp_path):
+    """Same path without monkeypatching, proving _pid_is_running integrates."""
+    root = _project(tmp_path)
+    _write_lock(root, f"{_dead_pid()}\n")
+
+    assert er._claim_recovery_lock(root) is True
+
+
+def test_recovery_lock_yields_to_a_live_owner(tmp_path):
+    """A running owner keeps its lock: single-flight must still hold."""
+    root = _project(tmp_path)
+    lock = _write_lock(root, f"{os.getpid()}\n")
+
+    assert er._claim_recovery_lock(root) is False
+    assert lock.read_text(encoding="utf-8").strip() == str(os.getpid())
+
+
+def test_recovery_lock_age_fallback_breaks_a_wedged_live_owner(tmp_path):
+    """The old age escape hatch survives for an owner that is alive but stuck."""
+    root = _project(tmp_path)
+    _write_lock(
+        root,
+        f"{os.getpid()}\n",
+        age_seconds=er._RECOVERY_LOCK_MAX_AGE_SECONDS + 60,
+    )
+
+    assert er._claim_recovery_lock(root) is True
+
+
+@pytest.mark.parametrize("body", ["", "   ", "not-a-pid", "\n\n"])
+def test_recovery_lock_unparseable_body_waits_for_the_age_fallback(
+    tmp_path, body
+):
+    """A body this cannot identify is never stolen on liveness grounds."""
+    root = _project(tmp_path)
+    _write_lock(root, body)
+    assert er._claim_recovery_lock(root) is False
+
+    _write_lock(root, body, age_seconds=er._RECOVERY_LOCK_MAX_AGE_SECONDS + 60)
+    assert er._claim_recovery_lock(root) is True
+
+
+def test_recovery_lock_does_not_loop_when_a_racer_recreates_it(
+    tmp_path, monkeypatch
+):
+    """Losing the retry to a racer returns False instead of spinning."""
+    root = _project(tmp_path)
+    _write_lock(root, "4242\n")
+
+    def _discard_then_lose(lock_path):
+        lock_path.unlink()
+        lock_path.write_text("999999\n", encoding="utf-8")  # racer got there
+        return True
+
+    monkeypatch.setattr(er, "_discard_stale_recovery_lock", _discard_then_lose)
+
+    assert er._claim_recovery_lock(root) is False
+
+
+def test_stale_lock_no_longer_blocks_the_early_repair(tmp_path, monkeypatch):
+    """End to end: the user-visible bug.
+
+    Before this fix a lock left by a dead process made every launch's early
+    recovery a silent no-op until the lock aged out, so a pending repair
+    stalled for an hour with nothing printed.
+    """
+    root = _project(tmp_path)
+    marker = root / ".lazy-refresh-incomplete"
+    marker.write_text("x", encoding="utf-8")
+    _write_lock(root, f"{_dead_pid()}\n")
+
+    probe_results = iter([["PyYAML", "python-dotenv"], []])
+    monkeypatch.setattr(er, "_probe_broken_packages", lambda: next(probe_results))
+    installs = []
+    monkeypatch.setattr(
+        er, "_run_repair_install", lambda specs, r: installs.append(specs) or True
+    )
+
+    er.recover_if_needed(project_root=root, argv=[])
+
+    assert installs == [["PyYAML==6.0.2", "python-dotenv==1.2.2"]]
+    assert not (root / LOCK).exists(), "lock released after the repair"


### PR DESCRIPTION
## What does this PR do?

`_claim_recovery_lock` decides whether a held `.update-incomplete.lock` may be broken **purely by age**: older than one hour, take it; otherwise give up. It never asks whether the process that wrote the lock still exists.

That gets the priority exactly backwards. A crashed or force-killed owner is the precise state the marker system exists to recover from, so its abandoned lock is the one that should be reclaimed *soonest*. Instead it is honoured for a full hour, and honoured **silently**: the claim fails, `recover_if_needed` returns without printing anything, and a pending dependency install sits unfinished long after the process holding it died. From the outside the CLI looks healthy and simply never repairs itself.

On Windows this compounds with the `"update" in argv` exclusion a few lines up. `hermes update` deliberately never runs the recovery path, so the only code that can finish a deferred install is the early pass, which is the code being told to wait. I hit this on a real install: the lock was owned by PID 59912, dead for twenty minutes, and three consecutive `hermes doctor` runs each no-opped without a word while the pending install stayed pending.

The fix reuses this module's own `_pid_is_running` helper, which already exists a few hundred lines above and already handles the Win32 `OpenProcess` case. Read the PID out of the lock body, and if that process is gone, reclaim the lock immediately.

Deliberately preserved:

- **The age fallback.** Still there for bodies this cannot reason about (empty, truncated, written by an older layout) and for an owner that is alive but wedged. `_lock_owner_is_live` is conservative: anything unreadable or non-numeric counts as live, so an unidentifiable lock is never stolen on liveness grounds.
- **Single-flight.** A living owner still keeps its lock.

Two behaviour changes beyond the probe, both small:

- A reclaimed lock is retried on the **same** launch. The old age path unlinked the file but still returned `False`, so even a successful break cost an extra launch.
- **Exactly one** retry. If a racer wins the same reclaim and recreates the lock between the discard and the retry, we yield to it rather than spinning.

`recover_if_needed` carried an inline copy of the claim logic with the identical bug. It now calls the shared helper, so both paths are fixed by construction rather than by remembering to patch two places.

## Related Issue

Related to #86943 — that issue's headline symptom is the pre-#86735 preflight, fixed by #86781. This is the *other* reason a deferral fails to resume, and it survives that fix: once the preflight correctly defers, an orphaned lock can still keep the marker recovery from running for an hour.

Not a duplicate of #86782, #86826 or #86857, none of which touch the lock.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/_early_recovery.py`
  - new `_lock_owner_is_live()` — parses the bare PID from the lock body and defers to the existing `_pid_is_running()`; conservative on anything it cannot parse
  - new `_discard_stale_recovery_lock()` — removes a lock whose owner is gone, or which has aged out
  - `_RECOVERY_LOCK_MAX_AGE_SECONDS` replaces the bare `3600` literal
  - `_claim_recovery_lock()` retries once after a successful discard
  - `recover_if_needed()` drops its inline duplicate of the claim and calls the helper
- `tests/hermes_cli/test_early_recovery.py` — ten new tests (below)

## How to Test

1. Create a project root with a `.lazy-refresh-incomplete` marker and write `.update-incomplete.lock` containing the PID of a process that has already exited.
2. Before this change: `_claim_recovery_lock(root)` returns `False`, and `recover_if_needed` performs no repair, for one hour, printing nothing.
3. After: the lock is reclaimed on the first launch and the repair runs.

Automated:

```
pytest tests/hermes_cli/test_early_recovery.py -q     # 27 passed
```

Nine of the ten new tests fail on `main` without the source change; the tenth (`test_recovery_lock_yields_to_a_live_owner`) passes both before and after by design, as it guards the single-flight behaviour this must not break.

New coverage:

| Test | Asserts |
|---|---|
| `..._reclaimed_when_owner_pid_is_dead` | dead owner is reclaimed, lock rewritten with our PID |
| `..._reclaimed_from_a_real_dead_pid` | same via a genuinely spawned-and-reaped PID, no mocking, so `_pid_is_running` is exercised for real on each OS |
| `..._yields_to_a_live_owner` | single-flight preserved |
| `..._age_fallback_breaks_a_wedged_live_owner` | the old hour-long escape hatch survives |
| `..._unparseable_body_waits_for_the_age_fallback` | parametrised over empty / whitespace / non-numeric / newlines |
| `..._does_not_loop_when_a_racer_recreates_it` | returns `False` instead of spinning |
| `test_stale_lock_no_longer_blocks_the_early_repair` | end to end: the user-visible bug |

Adjacent suites run clean: `test_early_recovery.py`, `test_update_self_lock.py`, `test_update_interrupted_recovery.py`, `test_checkout_mutation_guards.py` — 56 passed.

`ruff check .` passes. `ruff format` is not applied: `main` does not satisfy it on these files either, and CI enforces only `ruff check`, so reformatting would have added unrelated churn.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run the affected suites and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11 Pro 26200, Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — docstrings only, no user-facing doc change
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact — the probe routes through the existing `_pid_is_running`, which already branches Win32 `OpenProcess` vs POSIX `os.kill(pid, 0)`; the real-dead-PID test covers both. Module stays stdlib-only, which is load-bearing here.
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)
