### PR TITLE
fix(web): scope Parallel async clients to extraction loops

### DIFF
--- a/plugins/web/parallel/provider.py
+++ b/plugins/web/parallel/provider.py
@@ -3,8 +3,8 @@
 Subclasses :class:`agent.web_search_provider.WebSearchProvider`. Uses two
 distinct Parallel SDK clients:
 
-- ``Parallel`` (sync)        — for :meth:`search`
-- ``AsyncParallel`` (async)  — for :meth:`extract`
+- ``Parallel`` (sync, cached)                — for :meth:`search`
+- ``AsyncParallel`` (async, request-scoped)  — for :meth:`extract`
 
 This is the first plugin to exercise the **async-extract** code path in
 the ABC: :meth:`extract` is declared ``async def``, and the dispatcher
@@ -36,11 +36,11 @@ from agent.web_search_provider import WebSearchProvider
 
 logger = logging.getLogger(__name__)
 
-# Module-level note: the canonical cache slots ``_parallel_client`` and
-# ``_async_parallel_client`` live on :mod:`tools.web_tools` so tests that do
-# ``tools.web_tools._parallel_client = None`` between cases see fresh state.
-# The plugin reads/writes through that public module (see
-# :func:`_get_sync_client` / :func:`_get_async_client`).
+# Module-level note: the canonical sync cache slot ``_parallel_client`` lives
+# on :mod:`tools.web_tools` so tests that reset it between cases see fresh
+# state. Async clients are deliberately request-scoped: httpx transports are
+# bound to the event loop that first uses them and cannot be shared safely by
+# the per-thread loops used for concurrent tool execution.
 
 
 def _ensure_parallel_sdk_installed() -> None:
@@ -91,16 +91,13 @@ def _get_sync_client() -> Any:
 
 
 def _get_async_client() -> Any:
-    """Lazy-load + cache the async Parallel client.
+    """Create an async Parallel client owned by the current extraction.
 
-    Cache lives on :mod:`tools.web_tools` (as ``_async_parallel_client``).
+    The caller must close the client on the same event loop that uses it.
+    Caching this process-wide lets concurrent tool workers race to publish
+    loop-affine clients; losing clients can then be finalized from
+    prompt_toolkit's loop after their worker loops have died.
     """
-    import tools.web_tools as _wt
-
-    cached = getattr(_wt, "_async_parallel_client", None)
-    if cached is not None:
-        return cached
-
     from agent.web_search_provider import get_provider_env
 
     api_key = get_provider_env("PARALLEL_API_KEY")
@@ -113,21 +110,17 @@ def _get_async_client() -> Any:
     _ensure_parallel_sdk_installed()
     from parallel import AsyncParallel  # noqa: WPS433 — deliberately lazy
 
-    client = AsyncParallel(api_key=api_key)
-    _wt._async_parallel_client = client
-    return client
+    return AsyncParallel(api_key=api_key)
 
 
 def _reset_clients_for_tests() -> None:
-    """Drop both cached clients so tests can re-instantiate cleanly.
+    """Drop the cached sync client so tests can re-instantiate cleanly.
 
-    Clears the canonical slots on :mod:`tools.web_tools` (where
-    :func:`_get_sync_client` / :func:`_get_async_client` read/write them).
+    The async client is request-scoped and therefore has no cache to reset.
     """
     import tools.web_tools as _wt
 
     _wt._parallel_client = None
-    _wt._async_parallel_client = None
 
 
 # Backward-compatible aliases for the names that lived in tools.web_tools
@@ -234,10 +227,41 @@ class ParallelWebSearchProvider(WebSearchProvider):
                 ]
 
             logger.info("Parallel extract: %d URL(s)", len(urls))
-            response = await _get_async_client().beta.extract(
-                urls=urls,
-                full_content=True,
-            )
+            client = _get_async_client()
+            try:
+                response = await client.beta.extract(
+                    urls=urls,
+                    full_content=True,
+                )
+            finally:
+                # AsyncParallel owns an httpx connection pool whose transports
+                # are tied to this running loop. Drain it here, before the
+                # concurrent-tool worker and its loop go out of scope.
+                #
+                # Never let a teardown failure destroy an otherwise successful
+                # extraction: ``close()`` funnels into ``httpx.aclose()`` ->
+                # ``transport.aclose()``, which can raise (a mid-shutdown TLS
+                # error, or the very RuntimeError this cleanup exists to
+                # prevent). Without this guard that exception propagates out
+                # of ``finally``, past the response handling below, and the
+                # outer ``except Exception`` rewrites every URL into an error
+                # result even though the content was already fetched.
+                #
+                # Masked from the caller, but NOT from operators: a failed
+                # close can leave partial resources behind, and an "Event loop
+                # is closed" here would mean this ownership fix regressed, so
+                # it must stay visible. ``except Exception`` deliberately lets
+                # ``CancelledError`` (BaseException since 3.8) propagate so
+                # cancellation semantics are preserved.
+                try:
+                    await client.close()
+                except Exception as close_exc:  # noqa: BLE001 — cleanup is best-effort
+                    logger.warning(
+                        "Parallel async client close failed; preserving "
+                        "extraction result: %s: %s",
+                        type(close_exc).__name__,
+                        close_exc,
+                    )
 
             results: List[Dict[str, Any]] = []
             for result in response.results or []:

--- a/tests/tools/test_parallel_async_client_lifecycle.py
+++ b/tests/tools/test_parallel_async_client_lifecycle.py
@@ -1,0 +1,189 @@
+"""Regression coverage for Parallel's loop-affine async client lifecycle."""
+
+import asyncio
+import logging
+import sys
+import threading
+import types
+from types import SimpleNamespace
+
+from tools.daemon_pool import DaemonThreadPoolExecutor
+
+
+def test_concurrent_extract_closes_each_client_on_its_owner_loop(monkeypatch):
+    """Concurrent workers must never publish an async client process-wide.
+
+    A constructor barrier forces the old cache implementation's three workers
+    to observe an empty slot before any client can be published. Two clients
+    then lose the publication race and become cyclic garbage after their
+    worker threads exit, reproducing the lifecycle that surfaced as
+    ``RuntimeError('Event loop is closed')`` in prompt_toolkit.
+    """
+    from model_tools import _run_async
+    from plugins.web.parallel import provider as parallel_provider
+    import tools.web_tools as web_tools
+
+    constructor_barrier = threading.Barrier(3, timeout=15)
+    instances = []
+
+    class FakeBeta:
+        def __init__(self, client):
+            self.client = client
+
+        async def extract(self, *, urls, full_content):
+            assert full_content is True
+            self.client.use_loop_id = id(asyncio.get_running_loop())
+            return SimpleNamespace(
+                results=[
+                    SimpleNamespace(
+                        url=urls[0],
+                        title="Example",
+                        full_content="content",
+                        excerpts=[],
+                    )
+                ],
+                errors=[],
+            )
+
+    class FakeAsyncParallel:
+        def __init__(self, *, api_key):
+            assert api_key == "parallel-test-key"
+            self.beta = FakeBeta(self)
+            self.closed = False
+            self.use_loop_id = None
+            self.close_loop_id = None
+            instances.append(self)
+            constructor_barrier.wait()
+
+        async def close(self):
+            self.close_loop_id = id(asyncio.get_running_loop())
+            self.closed = True
+
+    fake_parallel = types.ModuleType("parallel")
+    fake_parallel.AsyncParallel = FakeAsyncParallel
+    monkeypatch.setitem(sys.modules, "parallel", fake_parallel)
+    monkeypatch.setenv("PARALLEL_API_KEY", "parallel-test-key")
+    monkeypatch.setattr(
+        parallel_provider,
+        "_ensure_parallel_sdk_installed",
+        lambda: None,
+    )
+    # Preserve compatibility with callers/tests that still create this legacy
+    # attribute dynamically. The provider must neither read nor populate it.
+    monkeypatch.setattr(web_tools, "_async_parallel_client", None, raising=False)
+
+    provider = parallel_provider.ParallelWebSearchProvider()
+
+    def extract(index):
+        return _run_async(provider.extract([f"https://example.test/{index}"]))
+
+    with DaemonThreadPoolExecutor(max_workers=3) as executor:
+        results = list(executor.map(extract, range(3)))
+
+    assert len(instances) == 3
+    assert all(client.closed for client in instances)
+    assert all(client.close_loop_id == client.use_loop_id for client in instances)
+    assert web_tools._async_parallel_client is None
+    assert [result[0]["content"] for result in results] == ["content"] * 3
+
+
+def test_close_failure_does_not_discard_a_successful_extraction(monkeypatch, caplog):
+    """A teardown error must not rewrite fetched content into an error result.
+
+    ``AsyncParallel.close()`` funnels into ``httpx.aclose()`` ->
+    ``transport.aclose()``, which can raise while the pool is being drained.
+    That happens *after* the content is already in hand, so the extraction
+    must still succeed; the cleanup failure is masked from the caller but
+    logged at warning level so a regressed ownership fix stays visible.
+    """
+    from plugins.web.parallel import provider as parallel_provider
+
+    class FakeBeta:
+        def __init__(self, client):
+            self.client = client
+
+        async def extract(self, *, urls, full_content):
+            assert full_content is True
+            return SimpleNamespace(
+                results=[
+                    SimpleNamespace(
+                        url=urls[0],
+                        title="Example",
+                        full_content="content",
+                        excerpts=[],
+                    )
+                ],
+                errors=[],
+            )
+
+    class ExplodingOnCloseParallel:
+        def __init__(self, *, api_key):
+            self.beta = FakeBeta(self)
+            self.close_calls = 0
+            instances.append(self)
+
+        async def close(self):
+            self.close_calls += 1
+            raise RuntimeError("Event loop is closed")
+
+    instances = []
+    fake_parallel = types.ModuleType("parallel")
+    fake_parallel.AsyncParallel = ExplodingOnCloseParallel
+    monkeypatch.setitem(sys.modules, "parallel", fake_parallel)
+    monkeypatch.setenv("PARALLEL_API_KEY", "parallel-test-key")
+    monkeypatch.setattr(
+        parallel_provider,
+        "_ensure_parallel_sdk_installed",
+        lambda: None,
+    )
+
+    provider = parallel_provider.ParallelWebSearchProvider()
+    with caplog.at_level(logging.WARNING, logger=parallel_provider.__name__):
+        results = asyncio.run(provider.extract(["https://example.test/1"]))
+
+    assert results[0]["content"] == "content"
+    assert "error" not in results[0]
+    # Pin this test's own trigger: deleting the close entirely must not pass.
+    assert [client.close_calls for client in instances] == [1]
+    close_warnings = [
+        record
+        for record in caplog.records
+        if record.levelno == logging.WARNING and "close failed" in record.message
+    ]
+    assert len(close_warnings) == 1
+
+
+def test_extraction_failure_outranks_a_close_failure(monkeypatch):
+    """When both the request and the cleanup fail, report the request error.
+
+    The primary exception must win: a secondary cleanup failure must not
+    overwrite the reason the extraction actually failed.
+    """
+    from plugins.web.parallel import provider as parallel_provider
+
+    class FakeBeta:
+        async def extract(self, *, urls, full_content):
+            raise RuntimeError("extract failed")
+
+    class ExplodingBothWaysParallel:
+        def __init__(self, *, api_key):
+            self.beta = FakeBeta()
+
+        async def close(self):
+            raise RuntimeError("close failed")
+
+    fake_parallel = types.ModuleType("parallel")
+    fake_parallel.AsyncParallel = ExplodingBothWaysParallel
+    monkeypatch.setitem(sys.modules, "parallel", fake_parallel)
+    monkeypatch.setenv("PARALLEL_API_KEY", "parallel-test-key")
+    monkeypatch.setattr(
+        parallel_provider,
+        "_ensure_parallel_sdk_installed",
+        lambda: None,
+    )
+
+    provider = parallel_provider.ParallelWebSearchProvider()
+    results = asyncio.run(provider.extract(["https://example.test/1"]))
+
+    assert "extract failed" in results[0]["error"]
+    assert "close failed" not in results[0]["error"]

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -65,22 +65,22 @@ from plugins.web.tavily.provider import (  # noqa: F401 — backward-compat name
     _normalize_tavily_search_results,
     _tavily_request,
 )
-# Parallel + Exa clients re-exported for backward-compat with existing
+# Parallel + Exa client helpers re-exported for backward-compat with existing
 # unit tests (tests/tools/test_web_tools_config.py imports _get_parallel_client
-# / _get_async_parallel_client / _get_exa_client directly).
+# / _get_async_parallel_client / _get_exa_client directly). The async Parallel
+# helper is a factory; its caller owns and closes each returned client.
 from plugins.web.parallel.provider import (  # noqa: F401 — backward-compat names
     _get_async_parallel_client,
     _get_parallel_client,
 )
 from plugins.web.exa.provider import _get_exa_client  # noqa: F401
 
-# Module-level cache slots for the per-vendor clients. The plugins read/write
-# these via tools.web_tools so unit tests that reset
+# Module-level cache slots for reusable synchronous vendor clients. The
+# plugins read/write these via tools.web_tools so unit tests that reset
 # ``tools.web_tools._<vendor>_client = None`` between cases keep working.
 _firecrawl_client: Optional[Any] = None
 _firecrawl_client_config: Optional[Any] = None
 _parallel_client: Optional[Any] = None
-_async_parallel_client: Optional[Any] = None
 _exa_client: Optional[Any] = None
 
 from tools.debug_helpers import DebugSession


### PR DESCRIPTION
## What does this PR do?

Prevents Parallel web-extraction clients from crossing event-loop ownership boundaries during concurrent tool execution.

`AsyncParallel` owns an HTTPX async transport whose connections are event-loop-affine, but it was cached process-wide in `tools.web_tools._async_parallel_client`. Concurrent tool workers each run on their own thread-local event loop (`model_tools._get_worker_loop`), so a single cached client ends up with sockets bound to a loop other workers don't own.

`AsyncParallel` is now created per extraction and closed in `finally` on the same loop that performed the request. The synchronous `Parallel` client keeps its cache — it has no loop affinity.

## Related Issue

Addresses the async Parallel portion of #24736.

This corrects **only** the async Parallel portion of #83786; that PR's sync `Parallel` and `Exa` singleton-lock changes remain valid and are not touched here.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Root Cause

On first concurrent use, every worker observes an empty cache, constructs its own client, and races to publish one. The clients that lose the race are dropped while still holding live keep-alive connections bound to their worker loops. When they are finalized later, the SDK's `AsyncHttpxClientWrapper.__del__` schedules `aclose()` on whatever loop happens to be running — prompt_toolkit's — while the transports belong to loops that are gone:

```
RuntimeError: Event loop is closed
  httpx/_client.py aclose -> _transports/default.py aclose
  -> httpcore connection_pool/connection/http11 -> anyio tls
  -> asyncio selector_events.close -> base_events.call_soon -> _check_closed
```

Three concurrent first-use extractions reproduce it deterministically: three clients constructed, two unpublished, two closed-loop errors. The fetches themselves succeed — the crash lands afterwards, at finalization, and prompt_toolkit surfaces it as `Unhandled exception in event loop` followed by `Press ENTER to continue...`.

Note on the alternative: serializing construction with a lock removes the orphaned clients but forces one loop-affine client to be shared across worker loops, which is the condition that makes the transports unusable in the first place.

## Changes Made

- `plugins/web/parallel/provider.py` — `_get_async_client()` is now a factory rather than a cache; `extract()` owns its client and closes it in `finally` on the owning loop.
- `plugins/web/parallel/provider.py` — a cleanup failure can no longer discard a completed extraction. `close()` funnels into `httpx.aclose()` -> `transport.aclose()`, which can raise after the response is fully materialized; that failure is masked from the caller but logged at **warning** level so a regression of this ownership fix stays visible. `except Exception` is deliberate: `CancelledError` is a `BaseException` and must keep propagating so cancellation semantics are preserved.
- `plugins/web/parallel/provider.py` — `_reset_clients_for_tests()` no longer clears an async slot.
- `tools/web_tools.py` — removed the obsolete `_async_parallel_client` cache slot.
- `tests/tools/test_parallel_async_client_lifecycle.py` — new regression coverage.

## How to Test

1. On clean `165c889`, run three first-use Parallel extractions concurrently (a constructor barrier makes the publication race deterministic). The old implementation constructs three clients, leaves two unpublished and unclosed, and produces two `RuntimeError: Event loop is closed` failures at finalization.
2. Apply this change and repeat: three clients, each closed on its owner loop, zero closed-loop errors. Verified against live network with the three URLs from the original report.
3. Run the tests:

```
python -m pytest -q tests/tools/test_parallel_async_client_lifecycle.py
python -m pytest -q tests/tools/test_web_tools_config.py tests/plugins/web/
```

All three new tests fail on `165c889` and pass with this change:

- `test_concurrent_extract_closes_each_client_on_its_owner_loop` — one client per extraction, closed on the same loop that used it, no process-wide publication.
- `test_close_failure_does_not_discard_a_successful_extraction` — asserts the close was actually attempted and exactly one warning emitted, so deleting the cleanup cannot make it pass.
- `test_extraction_failure_outranks_a_close_failure` — a secondary cleanup failure must not overwrite the primary error.

Local results: 69 passed for the provider/config suites, 25/25 repeated runs of the new file with no flakes, `ruff check` and `git diff --check` clean.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.6, Python 3.11.15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — module and function docstrings in the provider now state the ownership rule
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) — no platform-specific APIs; the change is pure asyncio/HTTPX lifecycle
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A (no user-visible tool surface change)
