### PR TITLE
fix(checkpoints): restore paths without overlay

### DIFF
--- a/tests/tools/test_checkpoint_manager.py
+++ b/tests/tools/test_checkpoint_manager.py
@@ -6,6 +6,7 @@ import logging
 import os
 import shutil
 import subprocess
+import sys
 import time
 import pytest
 from pathlib import Path
@@ -16,6 +17,7 @@ from tools.checkpoint_manager import (
     _shadow_repo_path,
     _init_store,
     _run_git,
+    _run_git_z_paths,
     _git_env,
     _project_hash,
     _store_path,
@@ -71,6 +73,35 @@ def mgr(work_dir, checkpoint_base, monkeypatch):
 def disabled_mgr(checkpoint_base, monkeypatch):
     monkeypatch.setattr("tools.checkpoint_manager.CHECKPOINT_BASE", checkpoint_base)
     return CheckpointManager(enabled=False)
+
+
+class TestBinaryGitPathOutput:
+    def test_round_trips_non_utf8_and_carriage_returns(
+        self, checkpoint_base, monkeypatch, tmp_path,
+    ):
+        raw_paths = [b"\xff.txt", b"a\rname", b"b\r\nname"]
+        completed = subprocess.CompletedProcess(
+            args=["git"], returncode=0,
+            stdout=b"\x00".join(raw_paths) + b"\x00", stderr=b"",
+        )
+        captured = {}
+
+        def fake_run(*args, **kwargs):
+            captured.update(kwargs)
+            return completed
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        ok, paths, error = _run_git_z_paths(
+            ["ls-files", "-z"], checkpoint_base, str(tmp_path),
+        )
+
+        assert ok is True
+        assert error == ""
+        assert captured["text"] is False
+        assert [
+            path.encode(sys.getfilesystemencoding(), errors="surrogateescape")
+            for path in paths
+        ] == raw_paths
 
 
 # =========================================================================
@@ -269,6 +300,32 @@ class TestRealPruning:
         assert "small.py" in names
         assert "weights.bin" not in names  # filtered by size cap
 
+    def test_oversize_filter_treats_git_metacharacters_literally(
+        self, tmp_path, checkpoint_base, monkeypatch,
+    ):
+        monkeypatch.setattr("tools.checkpoint_manager.CHECKPOINT_BASE", checkpoint_base)
+        wd = tmp_path / "literal-oversize"
+        wd.mkdir()
+        literal = wd / "file[1].bin"
+        sibling = wd / "file1.bin"
+        literal.write_bytes(b"x" * (2 * 1024 * 1024))
+        sibling.write_bytes(b"small")
+
+        manager = CheckpointManager(
+            enabled=True, max_snapshots=5, max_file_size_mb=1,
+        )
+        assert manager.ensure_checkpoint(str(wd), "initial") is True
+
+        store = _store_path(checkpoint_base)
+        ok, files, _ = _run_git(
+            ["ls-tree", "-r", "--name-only", _ref_name(_project_hash(str(wd)))],
+            store, str(wd),
+        )
+        assert ok is True
+        names = set(files.splitlines())
+        assert literal.name not in names
+        assert sibling.name in names
+
 
 # =========================================================================
 # CheckpointManager — restoring
@@ -280,6 +337,361 @@ class TestRestore:
         mgr.ensure_checkpoint(str(work_dir), "initial")
         assert mgr.restore(str(work_dir), "deadbeef1234")["success"] is False
 
+    @pytest.mark.parametrize("position", [0, -1], ids=["newest", "oldest"])
+    def test_restore_at_retention_cap_preserves_target(
+        self, checkpoint_base, monkeypatch, work_dir, position,
+    ):
+        monkeypatch.setattr("tools.checkpoint_manager.CHECKPOINT_BASE", checkpoint_base)
+        manager = CheckpointManager(enabled=True, max_snapshots=3)
+        for version in range(3):
+            manager.new_turn()
+            (work_dir / "main.py").write_text(f"v{version}\n")
+            assert manager.ensure_checkpoint(str(work_dir), f"v{version}") is True
+
+        target = manager.list_checkpoints(str(work_dir))[position]
+        (work_dir / "main.py").write_text("dirty\n")
+
+        result = manager.restore(str(work_dir), target["hash"])
+        assert result["success"] is True
+        assert result["reason"] == target["reason"]
+        assert (work_dir / "main.py").read_text() == f"{target['reason']}\n"
+        store = _store_path(checkpoint_base)
+        ok, pins, _ = _run_git(
+            ["for-each-ref", "--format=%(refname)", "refs/restore-pins/hermes"],
+            store,
+            str(work_dir),
+        )
+        assert ok is True
+        assert pins == ""
+
+    def test_restore_forces_undo_snapshot_when_worktree_matches_tip(
+        self, mgr, work_dir,
+    ):
+        (work_dir / "main.py").write_text("baseline\n")
+        assert mgr.ensure_checkpoint(str(work_dir), "baseline") is True
+        baseline = mgr.list_checkpoints(str(work_dir))[0]
+        mgr.new_turn()
+        (work_dir / "main.py").write_text("current\n")
+        assert mgr.ensure_checkpoint(str(work_dir), "current") is True
+
+        result = mgr.restore(str(work_dir), baseline["hash"])
+        assert result["success"] is True
+        assert (work_dir / "main.py").read_text() == "baseline\n"
+        undo = mgr.list_checkpoints(str(work_dir))[0]
+        assert undo["reason"].startswith("pre-rollback snapshot")
+
+        result = mgr.restore(str(work_dir), undo["hash"])
+        assert result["success"] is True
+        assert (work_dir / "main.py").read_text() == "current\n"
+
+    def test_restore_aborts_when_pre_rollback_snapshot_fails(
+        self, mgr, monkeypatch, work_dir,
+    ):
+        assert mgr.ensure_checkpoint(str(work_dir), "baseline") is True
+        baseline = mgr.list_checkpoints(str(work_dir))[0]
+        before_hashes = [row["hash"] for row in mgr.list_checkpoints(str(work_dir))]
+        (work_dir / "main.py").write_text("dirty\n")
+        late = work_dir / "late.py"
+        late.write_text("must survive\n")
+        monkeypatch.setattr("tools.checkpoint_manager._MAX_FILES", 0)
+
+        result = mgr.restore(str(work_dir), baseline["hash"])
+        assert result["success"] is False
+        assert "pre-rollback" in result["error"].lower()
+        assert (work_dir / "main.py").read_text() == "dirty\n"
+        assert late.read_text() == "must survive\n"
+        assert [row["hash"] for row in mgr.list_checkpoints(str(work_dir))] == before_hashes
+
+    def test_restore_aborts_when_forced_snapshot_omits_oversize_tracked_file(
+        self, checkpoint_base, monkeypatch, tmp_path,
+    ):
+        monkeypatch.setattr("tools.checkpoint_manager.CHECKPOINT_BASE", checkpoint_base)
+        manager = CheckpointManager(
+            enabled=True, max_snapshots=50, max_file_size_mb=1,
+        )
+        project = tmp_path / "oversize-restore"
+        project.mkdir()
+        tracked = project / "tracked.bin"
+        tracked.write_bytes(b"x")
+        assert manager.ensure_checkpoint(str(project), "baseline") is True
+        baseline = manager.list_checkpoints(str(project))[0]
+        before_hashes = [
+            row["hash"] for row in manager.list_checkpoints(str(project))
+        ]
+        oversized = b"z" * (2 * 1024 * 1024)
+        tracked.write_bytes(oversized)
+
+        result = manager.restore(str(project), baseline["hash"])
+        assert result["success"] is False
+        assert "pre-rollback" in result["error"].lower()
+        assert tracked.read_bytes() == oversized
+        assert [
+            row["hash"] for row in manager.list_checkpoints(str(project))
+        ] == before_hashes
+
+    @pytest.mark.parametrize("file_path", [None, "payload.txt"], ids=["full", "file"])
+    def test_restore_aborts_when_ignored_collision_is_missing_from_undo(
+        self, checkpoint_base, monkeypatch, tmp_path, file_path,
+    ):
+        monkeypatch.setattr("tools.checkpoint_manager.CHECKPOINT_BASE", checkpoint_base)
+        manager = CheckpointManager(enabled=True, max_snapshots=50)
+        project = tmp_path / "ignored-collision"
+        project.mkdir()
+        payload = project / "payload.txt"
+        payload.write_text("baseline\n")
+        assert manager.ensure_checkpoint(str(project), "baseline") is True
+        baseline = manager.list_checkpoints(str(project))[0]
+
+        manager.new_turn()
+        payload.unlink()
+        (project / ".gitignore").write_text("payload.txt\n")
+        assert manager.ensure_checkpoint(str(project), "ignore payload") is True
+        before_hashes = [
+            row["hash"] for row in manager.list_checkpoints(str(project))
+        ]
+        payload.write_text("valuable ignored data\n")
+
+        result = manager.restore(
+            str(project), baseline["hash"], file_path=file_path,
+        )
+        assert result["success"] is False
+        assert "pre-rollback" in result["error"].lower()
+        assert payload.read_text() == "valuable ignored data\n"
+        assert [
+            row["hash"] for row in manager.list_checkpoints(str(project))
+        ] == before_hashes
+
+    def test_restore_aborts_when_ignored_ancestor_is_missing_from_undo(
+        self, checkpoint_base, monkeypatch, tmp_path,
+    ):
+        monkeypatch.setattr("tools.checkpoint_manager.CHECKPOINT_BASE", checkpoint_base)
+        manager = CheckpointManager(enabled=True, max_snapshots=50)
+        project = tmp_path / "ignored-ancestor"
+        nested = project / "nested"
+        nested.mkdir(parents=True)
+        payload = nested / "payload.txt"
+        payload.write_text("baseline\n")
+        assert manager.ensure_checkpoint(str(project), "baseline") is True
+        baseline = manager.list_checkpoints(str(project))[0]
+
+        manager.new_turn()
+        payload.unlink()
+        nested.rmdir()
+        (project / ".gitignore").write_text("nested\n")
+        assert manager.ensure_checkpoint(str(project), "ignore ancestor") is True
+        before_hashes = [
+            row["hash"] for row in manager.list_checkpoints(str(project))
+        ]
+        nested.write_text("valuable ignored ancestor\n")
+
+        result = manager.restore(str(project), baseline["hash"])
+        assert result["success"] is False
+        assert "pre-rollback" in result["error"].lower()
+        assert nested.is_file()
+        assert nested.read_text() == "valuable ignored ancestor\n"
+        assert [
+            row["hash"] for row in manager.list_checkpoints(str(project))
+        ] == before_hashes
+
+    def test_restore_preserves_leading_space_in_nul_delimited_scope(
+        self, checkpoint_base, monkeypatch, tmp_path,
+    ):
+        monkeypatch.setattr("tools.checkpoint_manager.CHECKPOINT_BASE", checkpoint_base)
+        manager = CheckpointManager(enabled=True, max_snapshots=50)
+        project = tmp_path / "leading-space"
+        project.mkdir()
+        payload = project / " payload.txt"
+        payload.write_text("baseline\n")
+        assert manager.ensure_checkpoint(str(project), "baseline") is True
+        baseline = manager.list_checkpoints(str(project))[0]
+
+        manager.new_turn()
+        payload.unlink()
+        (project / ".gitignore").write_text(" payload.txt\n")
+        assert manager.ensure_checkpoint(str(project), "ignore payload") is True
+        before_hashes = [
+            row["hash"] for row in manager.list_checkpoints(str(project))
+        ]
+        payload.write_text("valuable leading-space data\n")
+
+        result = manager.restore(str(project), baseline["hash"])
+        assert result["success"] is False
+        assert "pre-rollback" in result["error"].lower()
+        assert payload.read_text() == "valuable leading-space data\n"
+        assert [
+            row["hash"] for row in manager.list_checkpoints(str(project))
+        ] == before_hashes
+
+    @pytest.mark.skipif(os.name == "nt", reason="POSIX permits raw non-UTF-8 names")
+    def test_restore_preserves_non_utf8_filename_bytes(
+        self, checkpoint_base, monkeypatch, tmp_path,
+    ):
+        monkeypatch.setattr("tools.checkpoint_manager.CHECKPOINT_BASE", checkpoint_base)
+        manager = CheckpointManager(enabled=True, max_snapshots=50)
+        project = tmp_path / "non-utf8"
+        project.mkdir()
+        raw_name = b"\xff.txt"
+        raw_path = os.path.join(os.fsencode(project), raw_name)
+        with open(raw_path, "wb") as stream:
+            stream.write(b"baseline\n")
+        assert manager.ensure_checkpoint(str(project), "baseline") is True
+        baseline = manager.list_checkpoints(str(project))[0]
+
+        manager.new_turn()
+        os.unlink(raw_path)
+        (project / ".gitignore").write_bytes(raw_name + b"\n")
+        assert manager.ensure_checkpoint(str(project), "ignore payload") is True
+        before_hashes = [
+            row["hash"] for row in manager.list_checkpoints(str(project))
+        ]
+        with open(raw_path, "wb") as stream:
+            stream.write(b"valuable non-utf8 data\n")
+
+        result = manager.restore(str(project), baseline["hash"])
+        assert result["success"] is False
+        with open(raw_path, "rb") as stream:
+            assert stream.read() == b"valuable non-utf8 data\n"
+        assert [
+            row["hash"] for row in manager.list_checkpoints(str(project))
+        ] == before_hashes
+
+    @pytest.mark.parametrize("file_path", [None, "b.txt"], ids=["full", "single-file"])
+    def test_restore_rejects_checkpoint_from_another_project(
+        self, checkpoint_base, monkeypatch, tmp_path, file_path,
+    ):
+        monkeypatch.setattr("tools.checkpoint_manager.CHECKPOINT_BASE", checkpoint_base)
+        manager = CheckpointManager(enabled=True, max_snapshots=50)
+        project_a = tmp_path / "project-a"
+        project_b = tmp_path / "project-b"
+        project_a.mkdir()
+        project_b.mkdir()
+        a_file = project_a / "a.txt"
+        a_file.write_text("a baseline\n")
+        (project_b / "b.txt").write_text("b baseline\n")
+        assert manager.ensure_checkpoint(str(project_a), "A") is True
+        a_hashes = [row["hash"] for row in manager.list_checkpoints(str(project_a))]
+        manager.new_turn()
+        assert manager.ensure_checkpoint(str(project_b), "B") is True
+        b_checkpoint = manager.list_checkpoints(str(project_b))[0]
+        a_file.write_text("a dirty\n")
+
+        result = manager.restore(
+            str(project_a), b_checkpoint["hash"], file_path=file_path,
+        )
+        assert result["success"] is False
+        assert "does not belong" in result["error"]
+        assert a_file.read_text() == "a dirty\n"
+        assert not (project_a / "b.txt").exists()
+        assert [row["hash"] for row in manager.list_checkpoints(str(project_a))] == a_hashes
+
+    def test_single_file_restore_rejects_adversarial_pathspec_magic(
+        self, mgr, work_dir,
+    ):
+        assert mgr.ensure_checkpoint(str(work_dir), "baseline") is True
+        baseline = mgr.list_checkpoints(str(work_dir))[0]
+        (work_dir / "main.py").write_text("dirty main\n")
+        (work_dir / "README.md").write_text("dirty readme\n")
+        added = work_dir / "new.py"
+        added.write_text("new\n")
+
+        result = mgr.restore(str(work_dir), baseline["hash"], file_path=":(top)**")
+        assert result["success"] is False
+        assert (work_dir / "main.py").read_text() == "dirty main\n"
+        assert (work_dir / "README.md").read_text() == "dirty readme\n"
+        assert added.read_text() == "new\n"
+
+    def test_full_restore_round_trip_removes_checkpoint_tracked_additions(
+        self, mgr, work_dir,
+    ):
+        baseline_main = (work_dir / "main.py").read_text()
+        baseline_readme = (work_dir / "README.md").read_text()
+        assert mgr.ensure_checkpoint(str(work_dir), "baseline") is True
+        baseline = mgr.list_checkpoints(str(work_dir))[0]["hash"]
+
+        (work_dir / "main.py").write_text("changed\n")
+        (work_dir / "README.md").unlink()
+        added = work_dir / "feature.py"
+        added.write_text("new\n")
+        excluded = work_dir / "diagnostic.log"
+        excluded.write_text("preserve me\n")
+
+        result = mgr.restore(str(work_dir), baseline)
+        assert result["success"] is True
+        assert (work_dir / "main.py").read_text() == baseline_main
+        assert (work_dir / "README.md").read_text() == baseline_readme
+        assert not added.exists()
+        assert excluded.read_text() == "preserve me\n"
+
+        pre_rollback = mgr.list_checkpoints(str(work_dir))[0]
+        assert pre_rollback["reason"].startswith("pre-rollback snapshot")
+        result = mgr.restore(str(work_dir), pre_rollback["hash"])
+        assert result["success"] is True
+        assert (work_dir / "main.py").read_text() == "changed\n"
+        assert not (work_dir / "README.md").exists()
+        assert added.read_text() == "new\n"
+        assert excluded.read_text() == "preserve me\n"
+
+    def test_single_file_restore_does_not_change_sibling_paths(self, mgr, work_dir):
+        baseline_main = (work_dir / "main.py").read_text()
+        assert mgr.ensure_checkpoint(str(work_dir), "baseline") is True
+        baseline = mgr.list_checkpoints(str(work_dir))[0]["hash"]
+
+        (work_dir / "main.py").write_text("changed main\n")
+        (work_dir / "README.md").write_text("changed sibling\n")
+        sibling_addition = work_dir / "feature.py"
+        sibling_addition.write_text("leave me\n")
+
+        result = mgr.restore(str(work_dir), baseline, file_path="main.py")
+        assert result["success"] is True
+        assert (work_dir / "main.py").read_text() == baseline_main
+        assert (work_dir / "README.md").read_text() == "changed sibling\n"
+        assert sibling_addition.read_text() == "leave me\n"
+
+    def test_single_file_restore_removes_path_absent_from_checkpoint(
+        self, mgr, work_dir,
+    ):
+        baseline_readme = (work_dir / "README.md").read_text()
+        assert mgr.ensure_checkpoint(str(work_dir), "baseline") is True
+        baseline = mgr.list_checkpoints(str(work_dir))[0]["hash"]
+
+        added = work_dir / "feature.py"
+        added.write_text("remove me\n")
+        (work_dir / "README.md").write_text("changed sibling\n")
+
+        result = mgr.restore(str(work_dir), baseline, file_path="feature.py")
+        assert result["success"] is True
+        assert not added.exists()
+        assert (work_dir / "README.md").read_text() == "changed sibling\n"
+        assert (work_dir / "README.md").read_text() != baseline_readme
+
+    def test_single_file_restore_treats_git_metacharacters_literally(
+        self, mgr, work_dir,
+    ):
+        literal = work_dir / "file[1].py"
+        wildcard_match = work_dir / "file1.py"
+        literal.write_text("baseline literal\n")
+        wildcard_match.write_text("baseline sibling\n")
+        assert mgr.ensure_checkpoint(str(work_dir), "baseline") is True
+        baseline = mgr.list_checkpoints(str(work_dir))[0]["hash"]
+
+        literal.write_text("changed literal\n")
+        wildcard_match.write_text("changed sibling\n")
+
+        result = mgr.restore(str(work_dir), baseline, file_path=literal.name)
+        assert result["success"] is True
+        assert literal.read_text() == "baseline literal\n"
+        assert wildcard_match.read_text() == "changed sibling\n"
+
+    def test_single_file_restore_normalizes_in_root_dot_segments(self, mgr, work_dir):
+        baseline_main = (work_dir / "main.py").read_text()
+        (work_dir / "sub").mkdir()
+        assert mgr.ensure_checkpoint(str(work_dir), "baseline") is True
+        baseline = mgr.list_checkpoints(str(work_dir))[0]["hash"]
+        (work_dir / "main.py").write_text("changed\n")
+
+        result = mgr.restore(str(work_dir), baseline, file_path="sub/../main.py")
+        assert result["success"] is True
+        assert (work_dir / "main.py").read_text() == baseline_main
 
     def test_tilde_path_supports_diff_and_restore_flow(
         self, checkpoint_base, fake_home, monkeypatch,

--- a/tests/tools/test_checkpoint_manager.py
+++ b/tests/tools/test_checkpoint_manager.py
@@ -402,6 +402,37 @@ class TestRestore:
         assert late.read_text() == "must survive\n"
         assert [row["hash"] for row in mgr.list_checkpoints(str(work_dir))] == before_hashes
 
+    def test_restore_removes_pin_when_worktree_disappears_during_snapshot(
+        self, checkpoint_base, monkeypatch, tmp_path,
+    ):
+        monkeypatch.setattr("tools.checkpoint_manager.CHECKPOINT_BASE", checkpoint_base)
+        manager = CheckpointManager(enabled=True, max_snapshots=5)
+        project = tmp_path / "vanishing-worktree"
+        project.mkdir()
+        (project / "main.py").write_text("baseline\n")
+        assert manager.ensure_checkpoint(str(project), "baseline") is True
+        baseline = manager.list_checkpoints(str(project))[0]
+
+        def remove_worktree_and_fail(*_args, **_kwargs):
+            shutil.rmtree(project)
+            return False
+
+        monkeypatch.setattr(manager, "_take", remove_worktree_and_fail)
+
+        result = manager.restore(str(project), baseline["hash"])
+        assert result["success"] is False
+        assert "pre-rollback" in result["error"].lower()
+        assert project.exists() is False
+
+        store = _store_path(checkpoint_base)
+        ok, pins, err = _run_git(
+            ["for-each-ref", "--format=%(refname)", "refs/restore-pins/hermes"],
+            store,
+            str(checkpoint_base),
+        )
+        assert ok is True, err
+        assert pins == ""
+
     def test_restore_aborts_when_forced_snapshot_omits_oversize_tracked_file(
         self, checkpoint_base, monkeypatch, tmp_path,
     ):

--- a/tools/checkpoint_manager.py
+++ b/tools/checkpoint_manager.py
@@ -1091,8 +1091,12 @@ class CheckpointManager:
                 result["file"] = file_path
             return result
         finally:
+            # Pin deletion only mutates the shared checkpoint store.  Use its
+            # stable parent as the subprocess cwd/work-tree so cleanup still
+            # runs if the restored worktree disappears or becomes inaccessible
+            # after the pin was created.
             cleanup_ok, _, cleanup_err = _run_git(
-                ["update-ref", "-d", pin_ref], store, abs_dir,
+                ["update-ref", "-d", pin_ref], store, str(store.parent),
             )
             if not cleanup_ok:
                 logger.warning(

--- a/tools/checkpoint_manager.py
+++ b/tools/checkpoint_manager.py
@@ -55,6 +55,7 @@ import os
 import re
 import shutil
 import subprocess
+import sys
 import time
 from pathlib import Path
 from hermes_constants import get_hermes_home
@@ -364,6 +365,54 @@ def _run_git(
     except Exception as exc:
         logger.error("Unexpected git error running %s: %s", " ".join(cmd), exc, exc_info=True)
         return False, "", str(exc)
+
+
+def _run_git_z_paths(
+    args: List[str],
+    store: Path,
+    working_dir: str,
+    timeout: int = _GIT_TIMEOUT,
+    index_file: Optional[Path] = None,
+) -> Tuple[bool, List[str], str]:
+    """Run Git in binary mode and losslessly decode NUL-delimited paths."""
+    normalized_working_dir = _normalize_path(working_dir)
+    if not normalized_working_dir.is_dir():
+        return False, [], f"working directory not found: {normalized_working_dir}"
+    env = _git_env(store, str(normalized_working_dir), index_file=index_file)
+    cmd = ["git"] + list(args)
+    try:
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=False,
+            timeout=timeout,
+            env=env,
+            cwd=str(normalized_working_dir),
+            stdin=subprocess.DEVNULL,
+            creationflags=windows_hide_flags(),
+        )
+    except subprocess.TimeoutExpired:
+        msg = f"git timed out after {timeout}s: {' '.join(cmd)}"
+        logger.error(msg, exc_info=True)
+        return False, [], msg
+    except OSError as exc:
+        logger.error("Git path command failed: %s", " ".join(cmd), exc_info=True)
+        return False, [], str(exc)
+
+    stderr = result.stderr.decode("utf-8", errors="replace").strip()
+    if result.returncode != 0:
+        logger.error(
+            "Git command failed: %s (rc=%d) stderr=%s",
+            " ".join(cmd), result.returncode, stderr,
+        )
+        return False, [], stderr
+    encoding = sys.getfilesystemencoding()
+    paths = [
+        raw.decode(encoding, errors="surrogateescape")
+        for raw in result.stdout.split(b"\x00")
+        if raw
+    ]
+    return True, paths, stderr
 
 
 # ---------------------------------------------------------------------------
@@ -934,44 +983,122 @@ class CheckpointManager:
         if not (store / "HEAD").exists():
             return {"success": False, "error": "No checkpoints exist for this directory"}
 
-        ok, _, err = _run_git(
-            ["cat-file", "-t", commit_hash], store, abs_dir,
+        ok, target_commit, err = _run_git(
+            ["rev-parse", "--verify", f"{commit_hash}^{{commit}}"],
+            store, abs_dir,
         )
-        if not ok:
+        if not ok or not target_commit:
             return {"success": False, "error": f"Checkpoint '{commit_hash}' not found",
                     "debug": err or None}
 
-        # Take a pre-rollback snapshot so you can undo the undo.
-        self._take(abs_dir, f"pre-rollback snapshot (restoring to {commit_hash[:8]})")
-
         dir_hash = _project_hash(abs_dir)
         index_file = _index_path(store, dir_hash)
-
-        restore_target = file_path if file_path else "."
-        ok, stdout, err = _run_git(
-            ["checkout", commit_hash, "--", restore_target],
-            store, abs_dir, timeout=_GIT_TIMEOUT * 2,
-            index_file=index_file,
+        project_ref = _ref_name(dir_hash)
+        belongs, _, _ = _run_git(
+            ["merge-base", "--is-ancestor", target_commit, project_ref],
+            store, abs_dir,
         )
+        if not belongs:
+            return {
+                "success": False,
+                "error": f"Checkpoint '{commit_hash}' does not belong to this directory",
+            }
 
-        if not ok:
-            return {"success": False, "error": f"Restore failed: {err}",
-                    "debug": err or None}
-
-        ok2, reason_out, _ = _run_git(
-            ["log", "--format=%s", "-1", commit_hash], store, abs_dir,
-        )
-        reason = reason_out if ok2 else "unknown"
-
-        result = {
-            "success": True,
-            "restored_to": commit_hash[:8],
-            "reason": reason,
-            "directory": abs_dir,
-        }
         if file_path:
-            result["file"] = file_path
-        return result
+            normalized_file_path = Path(os.path.normpath(file_path)).as_posix()
+            restore_target = f":(top,literal){normalized_file_path}"
+        else:
+            restore_target = "."
+        paths_ok, target_paths, paths_err = _run_git_z_paths(
+            [
+                "ls-tree", "-r", "-z", "--name-only", target_commit,
+                "--", restore_target,
+            ],
+            store, abs_dir,
+        )
+        if not paths_ok:
+            return {
+                "success": False,
+                "error": "Could not inspect the checkpoint restore scope",
+                "debug": paths_err or None,
+            }
+        required_undo_paths = set(target_paths)
+
+        # Pin the target for the duration of the restore.  Taking the mandatory
+        # pre-rollback snapshot may prune and garbage-collect the project's
+        # history, but the temporary ref keeps this exact commit and tree alive.
+        pin_ref = (
+            f"refs/restore-pins/hermes/{dir_hash}/"
+            f"{os.getpid()}-{time.time_ns()}"
+        )
+        pinned, _, pin_err = _run_git(
+            ["update-ref", pin_ref, target_commit], store, abs_dir,
+        )
+        if not pinned:
+            return {
+                "success": False,
+                "error": "Could not protect the checkpoint for restore",
+                "debug": pin_err or None,
+            }
+
+        try:
+            snapshot_reason = (
+                f"pre-rollback snapshot (restoring to {target_commit[:8]})"
+            )
+            if not self._take(
+                abs_dir,
+                snapshot_reason,
+                force=True,
+                required_paths=required_undo_paths,
+            ):
+                return {
+                    "success": False,
+                    "error": "Pre-rollback checkpoint failed; restore aborted",
+                }
+
+            # Checkout's default overlay mode leaves paths that are absent from
+            # the target checkpoint in place.  Non-overlay mode makes the
+            # selected pathspec exactly match the checkpoint (including
+            # deletions) while preserving excluded/untracked files outside the
+            # shadow index.  File restores use literal pathspec magic so
+            # metacharacters cannot expand the operation to sibling paths.
+            restore_args = [
+                "checkout", "--no-overlay", target_commit, "--", restore_target,
+            ]
+
+            ok, _, err = _run_git(
+                restore_args,
+                store, abs_dir, timeout=_GIT_TIMEOUT * 2,
+                index_file=index_file,
+            )
+
+            if not ok:
+                return {"success": False, "error": f"Restore failed: {err}",
+                        "debug": err or None}
+
+            ok2, reason_out, _ = _run_git(
+                ["log", "--format=%s", "-1", target_commit], store, abs_dir,
+            )
+            reason = reason_out if ok2 else "unknown"
+
+            result = {
+                "success": True,
+                "restored_to": target_commit[:8],
+                "reason": reason,
+                "directory": abs_dir,
+            }
+            if file_path:
+                result["file"] = file_path
+            return result
+        finally:
+            cleanup_ok, _, cleanup_err = _run_git(
+                ["update-ref", "-d", pin_ref], store, abs_dir,
+            )
+            if not cleanup_ok:
+                logger.warning(
+                    "Could not remove temporary checkpoint pin %s: %s",
+                    pin_ref, cleanup_err,
+                )
 
     def get_working_dir_for_path(self, file_path: str) -> str:
         """Resolve a file path to its working directory for checkpointing."""
@@ -995,7 +1122,14 @@ class CheckpointManager:
     # Internal
     # ------------------------------------------------------------------
 
-    def _take(self, working_dir: str, reason: str) -> bool:
+    def _take(
+        self,
+        working_dir: str,
+        reason: str,
+        *,
+        force: bool = False,
+        required_paths: Optional[Set[str]] = None,
+    ) -> bool:
         """Take a snapshot.  Returns True on success."""
         store = _store_path(CHECKPOINT_BASE)
 
@@ -1054,7 +1188,60 @@ class CheckpointManager:
             return False
 
         if self.max_file_size_mb > 0:
-            self._drop_oversize_from_index(store, working_dir, index_file)
+            omitted, filter_ok = self._drop_oversize_from_index(
+                store, working_dir, index_file,
+            )
+            if not filter_ok:
+                logger.debug("Checkpoint oversize-file filtering failed")
+                return False
+            if force and omitted:
+                logger.warning(
+                    "Pre-rollback checkpoint aborted: %d file(s) exceed the "
+                    "%d MB snapshot limit",
+                    len(omitted), self.max_file_size_mb,
+                )
+                return False
+
+        if force and required_paths:
+            ok_index, index_paths, _ = _run_git_z_paths(
+                ["ls-files", "--cached", "-z"],
+                store, working_dir, index_file=index_file,
+            )
+            if not ok_index:
+                logger.debug("Pre-rollback checkpoint index inspection failed")
+                return False
+            indexed_paths = set(index_paths)
+            collision_paths = set(required_paths)
+            for path in required_paths:
+                parts = path.split("/")
+                collision_paths.update(
+                    "/".join(parts[:index])
+                    for index in range(1, len(parts))
+                )
+            abs_workdir = _normalize_path(working_dir)
+            uncaptured = []
+            for path in collision_paths:
+                current_path = abs_workdir / path
+                if not os.path.lexists(current_path):
+                    continue
+                # Exact target paths can replace any existing filesystem
+                # object.  Ancestors only need capture when they are symlinks
+                # or non-directories that checkout may replace to build the
+                # target hierarchy; ordinary directories carry no Git data.
+                needs_capture = (
+                    path in required_paths
+                    or current_path.is_symlink()
+                    or not current_path.is_dir()
+                )
+                if needs_capture and path not in indexed_paths:
+                    uncaptured.append(path)
+            if uncaptured:
+                logger.warning(
+                    "Pre-rollback checkpoint aborted: %d restore collision "
+                    "path(s) were not captured",
+                    len(uncaptured),
+                )
+                return False
 
         # Compare against the current ref tip (not HEAD — HEAD points to a
         # branch that doesn't exist on a bare store, so ``diff --cached``
@@ -1073,7 +1260,7 @@ class CheckpointManager:
                 allowed_returncodes={1},
                 index_file=index_file,
             )
-            if ok_diff:
+            if ok_diff and not force:
                 logger.debug("Checkpoint skipped: no changes in %s", working_dir)
                 return False
         else:
@@ -1131,24 +1318,26 @@ class CheckpointManager:
 
     def _drop_oversize_from_index(
         self, store: Path, working_dir: str, index_file: Path,
-    ) -> None:
+    ) -> Tuple[List[str], bool]:
         """Remove any staged file larger than ``max_file_size_mb`` from the index.
 
         Lets the agent keep snapshotting source code while refusing to
         swallow generated assets (datasets, model weights, logs, videos).
+
+        Returns ``(omitted_paths, ok)`` so mandatory pre-rollback snapshots can
+        fail closed instead of claiming an undo point that omitted live data.
         """
         cap = self.max_file_size_mb * 1024 * 1024
         if cap <= 0:
-            return
-        ok, stdout, _ = _run_git(
+            return [], True
+        ok, paths, _ = _run_git_z_paths(
             ["ls-files", "--cached", "-z"],
             store, working_dir, index_file=index_file,
         )
-        if not ok or not stdout:
-            return
-        # ls-files -z output is NUL-separated. _run_git strips trailing
-        # whitespace but that leaves NULs alone; rebuild list.
-        paths = [p for p in stdout.split("\x00") if p]
+        if not ok:
+            return [], False
+        if not paths:
+            return [], True
         abs_workdir = _normalize_path(working_dir)
         oversize: List[str] = []
         for rel in paths:
@@ -1159,21 +1348,26 @@ class CheckpointManager:
             if size > cap:
                 oversize.append(rel)
         if not oversize:
-            return
+            return [], True
         logger.debug(
             "Checkpoint: dropping %d oversize file(s) (>%d MB) from index",
             len(oversize), self.max_file_size_mb,
         )
-        # Use --pathspec-from-file for safety with many paths.
-        # Chunk into manageable batches.
+        # Chunk into manageable batches.  Force literal pathspec handling so
+        # metacharacters in an oversized filename cannot remove sibling paths
+        # from the checkpoint index.
         BATCH = 200
+        removed_all = True
         for i in range(0, len(oversize), BATCH):
             chunk = oversize[i:i + BATCH]
-            _run_git(
-                ["rm", "--cached", "--quiet", "--"] + chunk,
+            removed, _, _ = _run_git(
+                ["--literal-pathspecs", "rm", "--cached", "--quiet", "--"]
+                + chunk,
                 store, working_dir, index_file=index_file,
                 allowed_returncodes={128},
             )
+            removed_all = removed_all and removed
+        return oversize, removed_all
 
     def _prune(self, store: Path, working_dir: str, ref: str) -> None:
         """Keep only the last ``max_snapshots`` commits on the per-project ref.


### PR DESCRIPTION
## Summary

- restore managed paths with `git checkout --no-overlay`
- use normalized top-level literal pathspecs for file-scoped restore
- reject checkpoints not reachable from the current project's checkpoint ref
- pin the target commit during rollback so pruning or GC cannot invalidate it
- require a complete pre-rollback undo snapshot before mutating files
- fail closed when size filtering or exact/ancestor collision capture is incomplete
- preserve NUL-delimited Git paths losslessly with filesystem decoding and `surrogateescape`

## Why

Checkpoint rollback could previously leave added paths behind, broaden file-scoped restores through pathspec metacharacters, accept cross-project objects, or mutate files without a complete undo snapshot. This change makes restore exact and data-loss resistant.

## Verification

- exact patch-id matches the previously adversarially accepted candidate
- `57 passed, 1 skipped, 2 deselected` in `tests/tools/test_checkpoint_manager.py`
  - the two deselected Windows portability failures are isolated in a separate follow-up branch
- `5 passed` across related agent, gateway, and checkpoint-prune tests
- targeted reviewer run: `23 passed, 1 skipped`
- Ruff: passed
- `git diff --check`: passed
- added-line security scan: clear
- independent exact-tree review: passed with no security or blocking logic findings

## Risk / rollback

The mutation path is intentionally fail-closed. Temporary restore pins are removed in `finally`; a failed pin cleanup can retain unreachable objects but does not weaken restore correctness. Revert this single commit to roll back.
