### PR TITLE
fix(checkpoints): clean read-only files on Windows

### DIFF
--- a/tests/tools/test_checkpoint_manager.py
+++ b/tests/tools/test_checkpoint_manager.py
@@ -5,6 +5,7 @@ import json
 import logging
 import os
 import shutil
+import stat
 import subprocess
 import time
 import pytest
@@ -382,7 +383,9 @@ class TestGitEnvIsolation:
         env = _git_env(
             store, str(work), index_file=store / "indexes" / "abc",
         )
-        assert env["GIT_INDEX_FILE"].endswith("indexes/abc")
+        assert Path(env["GIT_INDEX_FILE"]).resolve() == (
+            store / "indexes" / "abc"
+        ).resolve()
 
         # ~ in the work tree is expanded.
         tilde_work = fake_home / "work"
@@ -869,6 +872,36 @@ class TestClearFunctions:
         assert not legacy.exists()
         # Store preserved
         assert (base / "store" / "HEAD").exists()
+
+    @pytest.mark.skipif(os.name != "nt", reason="Windows read-only semantics")
+    def test_clear_all_removes_read_only_windows_file(self, tmp_path):
+        base = tmp_path / "checkpoints"
+        read_only = base / "store" / "objects" / "aa" / "object"
+        read_only.parent.mkdir(parents=True)
+        read_only.write_bytes(b"checkpoint")
+        read_only.chmod(stat.S_IREAD)
+
+        result = clear_all(checkpoint_base=base)
+
+        assert result["deleted"] is True
+        assert not base.exists()
+
+    @pytest.mark.skipif(os.name != "nt", reason="Windows read-only semantics")
+    def test_clear_legacy_removes_read_only_windows_file(self, tmp_path):
+        base = tmp_path / "checkpoints"
+        legacy = base / "legacy-20200101-000000"
+        read_only = legacy / "object"
+        read_only.parent.mkdir(parents=True)
+        read_only.write_bytes(b"checkpoint")
+        read_only.chmod(stat.S_IREAD)
+        store = base / "store"
+        store.mkdir()
+
+        result = clear_legacy(checkpoint_base=base)
+
+        assert result["deleted"] == 1
+        assert not legacy.exists()
+        assert store.exists()
 
 
 # =========================================================================

--- a/tools/checkpoint_manager.py
+++ b/tools/checkpoint_manager.py
@@ -54,6 +54,7 @@ import logging
 import os
 import re
 import shutil
+import stat
 import subprocess
 import time
 from pathlib import Path
@@ -1912,6 +1913,20 @@ def store_status(checkpoint_base: Optional[Path] = None) -> Dict:
     return out
 
 
+def _rmtree_onerror(func, path, exc_info) -> None:
+    """Retry removal after clearing Windows read-only Git object bits."""
+    error = exc_info[1]
+    if not isinstance(error, PermissionError):
+        raise error
+    # Deleting a child also requires its parent directory to be writable.
+    for candidate in (os.path.dirname(path), path):
+        try:
+            os.chmod(candidate, stat.S_IRWXU)
+        except OSError:
+            pass
+    func(path)
+
+
 def clear_all(checkpoint_base: Optional[Path] = None) -> Dict[str, int]:
     """Nuke the entire checkpoint base (store + legacy).  Irreversible.
 
@@ -1923,7 +1938,7 @@ def clear_all(checkpoint_base: Optional[Path] = None) -> Dict[str, int]:
         return out
     size = _dir_size_bytes(base)
     try:
-        shutil.rmtree(base)
+        shutil.rmtree(base, onerror=_rmtree_onerror)
         out["bytes_freed"] = size
         out["deleted"] = True
     except OSError as exc:
@@ -1945,7 +1960,7 @@ def clear_legacy(checkpoint_base: Optional[Path] = None) -> Dict[str, int]:
             continue
         try:
             size = _dir_size_bytes(child)
-            shutil.rmtree(child)
+            shutil.rmtree(child, onerror=_rmtree_onerror)
             out["bytes_freed"] += size
             out["deleted"] += 1
         except OSError as exc:


### PR DESCRIPTION
## Summary

- retry checkpoint cleanup after clearing Windows read-only Git object bits
- apply the same behavior to full-store and legacy-archive cleanup
- make the Git index path assertion separator-independent
- add explicit Windows regression tests for read-only files in both cleanup paths

## Why

Git object files can be read-only on Windows. Plain `shutil.rmtree()` then raises `WinError 5`, causing `hermes checkpoints clear` and legacy cleanup to report failure while leaving data behind.

## TDD evidence

On clean base, both new regression tests failed with `WinError 5`:

- `test_clear_all_removes_read_only_windows_file`
- `test_clear_legacy_removes_read_only_windows_file`

On the candidate, both passed.

## Verification

- checkpoint-manager module: `42 passed`
- focused read-only regressions: `2 passed`
- Ruff: passed
- `git diff --check`: passed
- added-line security scan: clear
- independent review of production behavior: passed
- final exact-tree re-review: passed with no security, logic, or test findings

## Risk / rollback

The retry callback runs only after a `PermissionError`; non-permission failures are re-raised. `clear_legacy()` still preserves the active checkpoint store. Revert this single commit to roll back.
