### PR TITLE
fix: bound memory retention and child-process resources

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -3249,6 +3249,22 @@ _MSG_TOKENS_CACHE: Dict[Any, Tuple[list, int]] = {}
 _MSG_TOKENS_CACHE_MAX = 4096
 
 
+def message_token_cache_stats() -> Dict[str, int]:
+    """Return redacted cache-retention counters for local memory telemetry."""
+    pinned_strings = 0
+    pinned_chars = 0
+    for pins, _tokens in list(_MSG_TOKENS_CACHE.values()):
+        for value in pins:
+            if isinstance(value, str):
+                pinned_strings += 1
+                pinned_chars += len(value)
+    return {
+        "entries": len(_MSG_TOKENS_CACHE),
+        "pinned_strings": pinned_strings,
+        "pinned_string_chars": pinned_chars,
+    }
+
+
 def _msg_fingerprint(value: Any, pins: list) -> Any:
     if value is None or value is True or value is False:
         return value
@@ -3271,6 +3287,18 @@ def _msg_fingerprint(value: Any, pins: list) -> Any:
 
 
 def _estimate_message_tokens_cached(msg: Any, image_cost: int) -> int:
+    # Never memoize multimodal messages.  The fingerprint cache deliberately
+    # pins every string leaf so object ids cannot be recycled while an entry is
+    # live.  For an image_url that would pin the *raw base64 payload* even
+    # though the estimator's wire shadow replaces it with ``[stripped]``.
+    # Long-lived desktop/gateway processes can see hundreds of unique images;
+    # keeping up to _MSG_TOKENS_CACHE_MAX full payloads turns this small CPU
+    # memo into a multi-GB retention cache.  Image-bearing messages are rare
+    # enough that computing their small stripped shadow directly is cheaper
+    # and, importantly, releases the payload with the request/session.
+    image_tokens = _count_image_tokens(msg, image_cost)
+    if image_tokens:
+        return _estimate_message_tokens_without_images(msg) + image_tokens
     try:
         pins: list = []
         key = _msg_fingerprint(msg, pins)
@@ -3278,14 +3306,14 @@ def _estimate_message_tokens_cached(msg: Any, image_cost: int) -> int:
     except Exception:
         return (
             _estimate_message_tokens_without_images(msg)
-            + _count_image_tokens(msg, image_cost)
+            + image_tokens
         )
     cached = _MSG_TOKENS_CACHE.get(key)
     if cached is not None:
         return cached[1]
     tokens = (
         _estimate_message_tokens_without_images(msg)
-        + _count_image_tokens(msg, image_cost)
+        + image_tokens
     )
     _MSG_TOKENS_CACHE[key] = (pins, tokens)
     while len(_MSG_TOKENS_CACHE) > _MSG_TOKENS_CACHE_MAX:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -6518,6 +6518,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
     _loop_heartbeat_task: Optional["asyncio.Task"] = None
     _loop_floor_timer_handle: Optional[Any] = None
     _loop_liveness_watchdog: Optional[Any] = None
+    _resource_guard: Optional[Any] = None
     _gateway_started_at: float = 0.0
     _shutdown_watchdog_done: Optional["threading.Event"] = None
     _platform_lock_takeover_on_start: bool = False
@@ -6530,6 +6531,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # secondary profiles do (#64674). Explicit config= injection (tests)
         # is left untouched.
         self.config = config if config is not None else load_gateway_config_for_runner()
+        self._resource_guard = None
         # Mark the process as a profile multiplexer when configured. This flips
         # agent.secret_scope.get_secret() to fail-closed on any unscoped
         # credential read, so a missed migration crashes loudly instead of
@@ -11925,6 +11927,66 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             logger.warning("Legacy session recovery on startup failed: %s", exc)
         return exact, fallback
 
+    def _start_resource_guard(self, loop: asyncio.AbstractEventLoop) -> None:
+        if self._resource_guard is not None:
+            return
+
+        def _metrics() -> dict:
+            cache = getattr(self, "_agent_cache", {})
+            cache_lock = getattr(self, "_agent_cache_lock", None)
+            if cache_lock is not None:
+                with cache_lock:
+                    cache_size = len(cache)
+            else:
+                cache_size = len(cache)
+            result: dict = {
+                "agent_cache_entries": cache_size,
+                "running_agents": self._running_agent_count(),
+                "active_work": self._active_work_count(),
+            }
+            try:
+                from agent.model_metadata import message_token_cache_stats
+
+                result["message_token_cache"] = message_token_cache_stats()
+            except Exception:
+                pass
+            try:
+                from tools.process_registry import process_registry
+
+                result["tracked_background_processes"] = process_registry.count_running()
+            except Exception:
+                pass
+            return result
+
+        def _hard_limit(_snapshot: dict) -> None:
+            def _request() -> None:
+                # request_restart refuses new turns immediately, waits for
+                # active work to settle, then runs the normal checkpointing
+                # and service-restart path.
+                self.request_restart(via_service=True)
+
+            loop.call_soon_threadsafe(_request)
+
+        try:
+            from hermes_cli.resource_guard import ProcessMemoryGuard
+
+            self._resource_guard = ProcessMemoryGuard(
+                component="messaging-gateway",
+                metrics_fn=_metrics,
+                on_hard_limit=_hard_limit,
+            ).start()
+        except Exception:
+            logger.exception("Failed to start gateway resource guard")
+
+    def _stop_resource_guard(self) -> None:
+        guard = self._resource_guard
+        self._resource_guard = None
+        if guard is not None:
+            try:
+                guard.stop()
+            except Exception:
+                logger.debug("Failed to stop gateway resource guard", exc_info=True)
+
     async def start(self) -> bool:
         """
         Start the gateway and all configured platform adapters.
@@ -11981,6 +12043,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             self._gateway_loop = None
         if self._gateway_loop is not None:
             self._start_loop_liveness_guards(self._gateway_loop)
+            self._start_resource_guard(self._gateway_loop)
         logger.info("Session storage: %s", self.config.sessions_dir)
 
         # Sanity-check that systemd's TimeoutStopSec covers our drain
@@ -14069,6 +14132,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         _stop_guards = getattr(self, "_stop_loop_liveness_guards", None)
         if callable(_stop_guards):
             _stop_guards()
+        self._stop_resource_guard()
         if restart:
             self._restart_requested = True
             self._restart_detached = detached_restart

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -47,12 +47,14 @@ DEFAULT_CONFIG = {
     "resource_guard": {
         "enabled": True,
         "poll_seconds": 15,
+        "telemetry_enabled": False,
         "telemetry_seconds": 60,
         "warn_rss_mb": 2048,
         "snapshot_rss_mb": 4096,
         "hard_rss_mb": 8192,
         "descendant_warn_rss_mb": 8192,
         "descendant_hard_rss_mb": 24576,
+        "hard_limit_confirmations": 2,
         "snapshot_cooldown_seconds": 300,
     },
     "agent": {
@@ -352,11 +354,11 @@ DEFAULT_CONFIG = {
         # Resource policy for local tracked background processes. Large model
         # downloads are serialized; every host process tree is warned/capped
         # by aggregate RSS so child workers cannot silently exhaust unified
-        # memory outside the Hermes process's own guard.
+        # memory outside the Hermes process's own guard. Descendant-tree
+        # thresholds are owned by the resource_guard block (single source of
+        # truth) and shared rather than redefined here.
         "background_resource_limits": {
             "large_download_max_concurrent": 1,
-            "descendant_warn_rss_mb": 8192,
-            "descendant_hard_rss_mb": 24576,
             "poll_seconds": 15,
         },
         # Environment variables to pass through to sandboxed execution

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -42,6 +42,19 @@ DEFAULT_CONFIG = {
         # behavior everywhere.
         "terminal_continue": True,
     },
+    # Local-only memory telemetry and restart guard for long-lived Hermes
+    # Python processes. Parent RSS and descendant RSS are tracked separately.
+    "resource_guard": {
+        "enabled": True,
+        "poll_seconds": 15,
+        "telemetry_seconds": 60,
+        "warn_rss_mb": 2048,
+        "snapshot_rss_mb": 4096,
+        "hard_rss_mb": 8192,
+        "descendant_warn_rss_mb": 8192,
+        "descendant_hard_rss_mb": 24576,
+        "snapshot_cooldown_seconds": 300,
+    },
     "agent": {
         "max_turns": 500,
         # Inactivity timeout for gateway agent execution (seconds).
@@ -336,6 +349,16 @@ DEFAULT_CONFIG = {
         # window so it can't leak indefinitely. 0 disables escalation (SIGTERM
         # only — the historical behavior). Floored internally at 0.
         "daemon_term_grace_seconds": 2.0,
+        # Resource policy for local tracked background processes. Large model
+        # downloads are serialized; every host process tree is warned/capped
+        # by aggregate RSS so child workers cannot silently exhaust unified
+        # memory outside the Hermes process's own guard.
+        "background_resource_limits": {
+            "large_download_max_concurrent": 1,
+            "descendant_warn_rss_mb": 8192,
+            "descendant_hard_rss_mb": 24576,
+            "poll_seconds": 15,
+        },
         # Environment variables to pass through to sandboxed execution
         # (terminal and execute_code).  Skill-declared required_environment_variables
         # are passed through automatically; this list is for non-skill use cases.

--- a/hermes_cli/resource_guard.py
+++ b/hermes_cli/resource_guard.py
@@ -1,0 +1,320 @@
+"""Bounded process-memory telemetry and fail-closed restart guard.
+
+The guard is deliberately local-only: it writes redacted counters beneath the
+active HERMES_HOME and never exports telemetry.  It monitors the Hermes Python
+process separately from descendant tool processes so a healthy 300 MB backend
+is not confused with a multi-GB model download.
+"""
+
+from __future__ import annotations
+
+import faulthandler
+import json
+import logging
+import os
+import threading
+import time
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable
+
+from hermes_constants import get_hermes_home
+
+logger = logging.getLogger(__name__)
+_MIB = 1024 * 1024
+
+
+@dataclass(frozen=True)
+class ResourceGuardSettings:
+    enabled: bool = True
+    poll_seconds: float = 15.0
+    telemetry_seconds: float = 60.0
+    warn_rss_mb: int = 2048
+    snapshot_rss_mb: int = 4096
+    hard_rss_mb: int = 8192
+    descendant_warn_rss_mb: int = 8192
+    descendant_hard_rss_mb: int = 24576
+    snapshot_cooldown_seconds: float = 300.0
+
+
+def _positive_float(value: Any, default: float, *, floor: float = 1.0) -> float:
+    if isinstance(value, bool):
+        return default
+    try:
+        return max(floor, float(value))
+    except (TypeError, ValueError):
+        return default
+
+
+def _positive_int(value: Any, default: int) -> int:
+    if isinstance(value, bool):
+        return default
+    try:
+        return max(1, int(value))
+    except (TypeError, ValueError):
+        return default
+
+
+def load_resource_guard_settings() -> ResourceGuardSettings:
+    """Read resource_guard config with safe defaults and ordered thresholds."""
+    raw: dict[str, Any] = {}
+    try:
+        from hermes_cli.config import load_config_readonly
+
+        config = load_config_readonly() or {}
+        candidate = config.get("resource_guard") if isinstance(config, dict) else None
+        if isinstance(candidate, dict):
+            raw = candidate
+    except Exception:
+        pass
+
+    defaults = ResourceGuardSettings()
+    warn = _positive_int(raw.get("warn_rss_mb"), defaults.warn_rss_mb)
+    snapshot = max(
+        warn,
+        _positive_int(raw.get("snapshot_rss_mb"), defaults.snapshot_rss_mb),
+    )
+    hard = max(
+        snapshot,
+        _positive_int(raw.get("hard_rss_mb"), defaults.hard_rss_mb),
+    )
+    descendant_warn = _positive_int(
+        raw.get("descendant_warn_rss_mb"), defaults.descendant_warn_rss_mb
+    )
+    descendant_hard = max(
+        descendant_warn,
+        _positive_int(
+            raw.get("descendant_hard_rss_mb"), defaults.descendant_hard_rss_mb
+        ),
+    )
+    return ResourceGuardSettings(
+        enabled=raw.get("enabled", defaults.enabled) is not False,
+        poll_seconds=_positive_float(
+            raw.get("poll_seconds"), defaults.poll_seconds, floor=2.0
+        ),
+        telemetry_seconds=_positive_float(
+            raw.get("telemetry_seconds"), defaults.telemetry_seconds, floor=5.0
+        ),
+        warn_rss_mb=warn,
+        snapshot_rss_mb=snapshot,
+        hard_rss_mb=hard,
+        descendant_warn_rss_mb=descendant_warn,
+        descendant_hard_rss_mb=descendant_hard,
+        snapshot_cooldown_seconds=_positive_float(
+            raw.get("snapshot_cooldown_seconds"),
+            defaults.snapshot_cooldown_seconds,
+            floor=10.0,
+        ),
+    )
+
+
+def collect_process_memory_snapshot(
+    metrics_fn: Callable[[], dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    """Collect redacted process and descendant counters using psutil."""
+    import psutil
+
+    proc = psutil.Process(os.getpid())
+    parent_rss = int(proc.memory_info().rss)
+    children = []
+    descendant_rss = 0
+    try:
+        descendants = proc.children(recursive=True)
+    except (psutil.NoSuchProcess, psutil.AccessDenied, OSError):
+        descendants = []
+    for child in descendants:
+        try:
+            rss = int(child.memory_info().rss)
+            descendant_rss += rss
+            children.append({"pid": child.pid, "rss_bytes": rss, "name": child.name()})
+        except (psutil.NoSuchProcess, psutil.AccessDenied, OSError):
+            continue
+    children.sort(key=lambda row: row["rss_bytes"], reverse=True)
+
+    snapshot: dict[str, Any] = {
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "pid": os.getpid(),
+        "rss_bytes": parent_rss,
+        "descendant_rss_bytes": descendant_rss,
+        "descendant_count": len(children),
+        "largest_descendants": children[:10],
+        "thread_count": threading.active_count(),
+    }
+    try:
+        vm = psutil.virtual_memory()
+        snapshot["host_available_bytes"] = int(vm.available)
+        snapshot["host_memory_percent"] = float(vm.percent)
+    except Exception:
+        pass
+    if metrics_fn is not None:
+        try:
+            extra = metrics_fn()
+            if isinstance(extra, dict):
+                snapshot["hermes"] = extra
+        except Exception as exc:
+            snapshot["metrics_error"] = type(exc).__name__
+    return snapshot
+
+
+def _append_telemetry(snapshot: dict[str, Any]) -> None:
+    log_dir = get_hermes_home() / "logs"
+    log_dir.mkdir(parents=True, exist_ok=True)
+    path = log_dir / "memory-telemetry.jsonl"
+    try:
+        if path.exists() and path.stat().st_size > 10 * 1024 * 1024:
+            rotated = path.with_suffix(".jsonl.1")
+            try:
+                rotated.unlink(missing_ok=True)
+            except OSError:
+                pass
+            path.replace(rotated)
+        with path.open("a", encoding="utf-8") as handle:
+            handle.write(json.dumps(snapshot, sort_keys=True, separators=(",", ":")))
+            handle.write("\n")
+    except OSError:
+        logger.debug("Could not append memory telemetry", exc_info=True)
+
+
+def _write_evidence_snapshot(snapshot: dict[str, Any], reason: str) -> Path | None:
+    evidence_dir = get_hermes_home() / "logs" / "memory-snapshots"
+    try:
+        evidence_dir.mkdir(parents=True, exist_ok=True)
+        stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+        stem = f"{stamp}-pid{os.getpid()}-{reason}"
+        json_path = evidence_dir / f"{stem}.json"
+        tmp_path = evidence_dir / f".{stem}.tmp"
+        tmp_path.write_text(
+            json.dumps(snapshot, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        os.replace(tmp_path, json_path)
+        stack_path = evidence_dir / f"{stem}-threads.log"
+        with stack_path.open("w", encoding="utf-8") as handle:
+            faulthandler.dump_traceback(file=handle, all_threads=True)
+        return json_path
+    except OSError:
+        logger.exception("Could not write memory evidence snapshot")
+        return None
+
+
+class ProcessMemoryGuard:
+    """Daemon monitor that captures evidence and requests a graceful restart."""
+
+    def __init__(
+        self,
+        *,
+        component: str,
+        metrics_fn: Callable[[], dict[str, Any]] | None = None,
+        on_hard_limit: Callable[[dict[str, Any]], None] | None = None,
+        settings: ResourceGuardSettings | None = None,
+    ) -> None:
+        self.component = component
+        self.metrics_fn = metrics_fn
+        self.on_hard_limit = on_hard_limit
+        self.settings = settings or load_resource_guard_settings()
+        self._stop = threading.Event()
+        self._thread: threading.Thread | None = None
+        self._warned = False
+        self._descendant_warned = False
+        self._hard_fired = False
+        self._last_snapshot_at = 0.0
+        self._last_telemetry_at = 0.0
+
+    def start(self) -> "ProcessMemoryGuard":
+        if not self.settings.enabled or self._thread is not None:
+            return self
+        self._thread = threading.Thread(
+            target=self._run,
+            daemon=True,
+            name=f"hermes-memory-guard-{self.component}",
+        )
+        self._thread.start()
+        return self
+
+    def stop(self) -> None:
+        self._stop.set()
+        thread = self._thread
+        if thread is not None and thread is not threading.current_thread():
+            thread.join(timeout=min(2.0, self.settings.poll_seconds))
+
+    def _run(self) -> None:
+        while not self._stop.wait(self.settings.poll_seconds):
+            try:
+                self._sample()
+            except Exception:
+                logger.exception("Resource guard sample failed for %s", self.component)
+
+    def _sample(self) -> dict[str, Any]:
+        snapshot = collect_process_memory_snapshot(self.metrics_fn)
+        snapshot["component"] = self.component
+        now = time.monotonic()
+        rss_mb = snapshot["rss_bytes"] / _MIB
+        descendant_mb = snapshot["descendant_rss_bytes"] / _MIB
+
+        if now - self._last_telemetry_at >= self.settings.telemetry_seconds:
+            _append_telemetry(snapshot)
+            self._last_telemetry_at = now
+
+        if rss_mb >= self.settings.warn_rss_mb and not self._warned:
+            logger.warning(
+                "Hermes memory guard: component=%s rss_mb=%.1f warn_mb=%d "
+                "descendant_rss_mb=%.1f",
+                self.component,
+                rss_mb,
+                self.settings.warn_rss_mb,
+                descendant_mb,
+            )
+            self._warned = True
+        elif rss_mb < self.settings.warn_rss_mb * 0.8:
+            self._warned = False
+
+        if (
+            descendant_mb >= self.settings.descendant_warn_rss_mb
+            and not self._descendant_warned
+        ):
+            logger.warning(
+                "Hermes descendant memory warning: component=%s rss_mb=%.1f "
+                "warn_mb=%d count=%d",
+                self.component,
+                descendant_mb,
+                self.settings.descendant_warn_rss_mb,
+                snapshot["descendant_count"],
+            )
+            self._descendant_warned = True
+        elif descendant_mb < self.settings.descendant_warn_rss_mb * 0.8:
+            self._descendant_warned = False
+
+        snapshot_due = rss_mb >= self.settings.snapshot_rss_mb and (
+            now - self._last_snapshot_at >= self.settings.snapshot_cooldown_seconds
+        )
+        if snapshot_due:
+            _write_evidence_snapshot(snapshot, "snapshot")
+            self._last_snapshot_at = now
+
+        hard_parent = rss_mb >= self.settings.hard_rss_mb
+        hard_descendants = descendant_mb >= self.settings.descendant_hard_rss_mb
+        if (hard_parent or hard_descendants) and not self._hard_fired:
+            reason = "hard-parent" if hard_parent else "hard-descendants"
+            evidence = _write_evidence_snapshot(snapshot, reason)
+            logger.error(
+                "Hermes memory guard hard limit: component=%s rss_mb=%.1f "
+                "descendant_rss_mb=%.1f evidence=%s; refusing new work and "
+                "requesting graceful restart",
+                self.component,
+                rss_mb,
+                descendant_mb,
+                evidence,
+            )
+            self._hard_fired = True
+            if self.on_hard_limit is not None:
+                self.on_hard_limit(snapshot)
+        return snapshot
+
+
+__all__ = [
+    "ProcessMemoryGuard",
+    "ResourceGuardSettings",
+    "collect_process_memory_snapshot",
+    "load_resource_guard_settings",
+]

--- a/hermes_cli/resource_guard.py
+++ b/hermes_cli/resource_guard.py
@@ -24,17 +24,26 @@ from hermes_constants import get_hermes_home
 logger = logging.getLogger(__name__)
 _MIB = 1024 * 1024
 
+# Canonical descendant-tree memory thresholds and hard-limit confirmation
+# count, shared with tools.process_registry so per-process caps cannot drift
+# from the gateway guard (single source of truth).
+DESCENDANT_WARN_RSS_MB = 8192
+DESCENDANT_HARD_RSS_MB = 24576
+HARD_LIMIT_CONFIRMATIONS = 2
+
 
 @dataclass(frozen=True)
 class ResourceGuardSettings:
     enabled: bool = True
     poll_seconds: float = 15.0
+    telemetry_enabled: bool = False
     telemetry_seconds: float = 60.0
     warn_rss_mb: int = 2048
     snapshot_rss_mb: int = 4096
     hard_rss_mb: int = 8192
-    descendant_warn_rss_mb: int = 8192
-    descendant_hard_rss_mb: int = 24576
+    descendant_warn_rss_mb: int = DESCENDANT_WARN_RSS_MB
+    descendant_hard_rss_mb: int = DESCENDANT_HARD_RSS_MB
+    hard_limit_confirmations: int = HARD_LIMIT_CONFIRMATIONS
     snapshot_cooldown_seconds: float = 300.0
 
 
@@ -90,6 +99,9 @@ def load_resource_guard_settings() -> ResourceGuardSettings:
     )
     return ResourceGuardSettings(
         enabled=raw.get("enabled", defaults.enabled) is not False,
+        telemetry_enabled=(
+            raw.get("telemetry_enabled", defaults.telemetry_enabled) is True
+        ),
         poll_seconds=_positive_float(
             raw.get("poll_seconds"), defaults.poll_seconds, floor=2.0
         ),
@@ -101,6 +113,10 @@ def load_resource_guard_settings() -> ResourceGuardSettings:
         hard_rss_mb=hard,
         descendant_warn_rss_mb=descendant_warn,
         descendant_hard_rss_mb=descendant_hard,
+        hard_limit_confirmations=_positive_int(
+            raw.get("hard_limit_confirmations"),
+            defaults.hard_limit_confirmations,
+        ),
         snapshot_cooldown_seconds=_positive_float(
             raw.get("snapshot_cooldown_seconds"),
             defaults.snapshot_cooldown_seconds,
@@ -218,6 +234,7 @@ class ProcessMemoryGuard:
         self._warned = False
         self._descendant_warned = False
         self._hard_fired = False
+        self._hard_violations = 0
         self._last_snapshot_at = 0.0
         self._last_telemetry_at = 0.0
 
@@ -252,7 +269,10 @@ class ProcessMemoryGuard:
         rss_mb = snapshot["rss_bytes"] / _MIB
         descendant_mb = snapshot["descendant_rss_bytes"] / _MIB
 
-        if now - self._last_telemetry_at >= self.settings.telemetry_seconds:
+        if (
+            self.settings.telemetry_enabled
+            and now - self._last_telemetry_at >= self.settings.telemetry_seconds
+        ):
             _append_telemetry(snapshot)
             self._last_telemetry_at = now
 
@@ -294,7 +314,14 @@ class ProcessMemoryGuard:
 
         hard_parent = rss_mb >= self.settings.hard_rss_mb
         hard_descendants = descendant_mb >= self.settings.descendant_hard_rss_mb
-        if (hard_parent or hard_descendants) and not self._hard_fired:
+        if hard_parent or hard_descendants:
+            self._hard_violations += 1
+        else:
+            self._hard_violations = 0
+        if (
+            self._hard_violations >= self.settings.hard_limit_confirmations
+            and not self._hard_fired
+        ):
             reason = "hard-parent" if hard_parent else "hard-descendants"
             evidence = _write_evidence_snapshot(snapshot, reason)
             logger.error(
@@ -313,6 +340,9 @@ class ProcessMemoryGuard:
 
 
 __all__ = [
+    "DESCENDANT_WARN_RSS_MB",
+    "DESCENDANT_HARD_RSS_MB",
+    "HARD_LIMIT_CONFIRMATIONS",
     "ProcessMemoryGuard",
     "ResourceGuardSettings",
     "collect_process_memory_snapshot",

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -18568,6 +18568,33 @@ def start_server(
     )
     server = uvicorn.Server(config)
 
+    def _desktop_memory_metrics() -> dict[str, Any]:
+        metrics: dict[str, Any] = {}
+        try:
+            from tui_gateway import server as tui_server
+
+            with tui_server._sessions_lock:
+                sessions = list(tui_server._sessions.values())
+            metrics["live_sessions"] = len(sessions)
+            metrics["running_sessions"] = sum(
+                1 for session in sessions if session.get("running")
+            )
+        except Exception:
+            pass
+        try:
+            from agent.model_metadata import message_token_cache_stats
+
+            metrics["message_token_cache"] = message_token_cache_stats()
+        except Exception:
+            pass
+        try:
+            from tools.process_registry import process_registry
+
+            metrics["tracked_background_processes"] = process_registry.count_running()
+        except Exception:
+            pass
+        return metrics
+
     async def _serve():
         # Split startup from main_loop so we can read the bound port
         # after the socket is live (ephemeral port discovery).
@@ -18619,6 +18646,21 @@ def start_server(
                 print(f"  Hermes Web UI → http://{host}:{actual_port}")
             _maybe_open_browser(host, actual_port, open_browser, initial_profile)
 
+            # Local-only telemetry plus a fail-closed restart threshold.  The
+            # normal uvicorn shutdown path lets tui_gateway's atexit/session
+            # finalizers persist active conversation state before Desktop
+            # relaunches the managed backend.
+            from hermes_cli.resource_guard import ProcessMemoryGuard
+
+            _server_loop = asyncio.get_running_loop()
+            _memory_guard = ProcessMemoryGuard(
+                component="desktop-serve" if headless else "dashboard",
+                metrics_fn=_desktop_memory_metrics,
+                on_hard_limit=lambda _snapshot: _server_loop.call_soon_threadsafe(
+                    setattr, server, "should_exit", True
+                ),
+            ).start()
+
             # Collapse the peer-hangup teardown flood (#50005). When the Desktop
             # forcibly closes its WebSocket mid-write, asyncio logs a full
             # traceback per pending connection-lost callback — 50+ identical
@@ -18661,9 +18703,12 @@ def start_server(
                 _hb_interval, _loop_heartbeat, _hb_loop.time() + _hb_interval
             )
 
-            await server.main_loop()
-            if server.started:
-                await server.shutdown()
+            try:
+                await server.main_loop()
+                if server.started:
+                    await server.shutdown()
+            finally:
+                _memory_guard.stop()
 
     # On POSIX, keep the long-standing ``asyncio.run(_serve())`` runner —
     # Python's default loop there is already a SelectorEventLoop (or uvloop when

--- a/tests/agent/test_model_metadata.py
+++ b/tests/agent/test_model_metadata.py
@@ -162,6 +162,22 @@ class TestEstimateMessagesTokensRough:
         # Raw base64 would be ~100K tokens; the flat per-image model is ~1.5K.
         assert estimate_messages_tokens_rough([msg]) < 5_000
 
+    def test_image_payload_is_not_pinned_by_message_token_cache(self):
+        """Image estimates must not retain raw base64 after the call returns."""
+        import agent.model_metadata as mm
+
+        mm._MSG_TOKENS_CACHE.clear()
+        payload = "data:image/png;base64," + ("A" * 1_000_000)
+        msg = {
+            "role": "user",
+            "content": [
+                {"type": "image_url", "image_url": {"url": payload}},
+            ],
+        }
+
+        assert estimate_messages_tokens_rough([msg]) >= 1_500
+        assert mm._MSG_TOKENS_CACHE == {}
+
 
 
 class TestEstimateRequestTokensRough:

--- a/tests/hermes_cli/test_resource_guard.py
+++ b/tests/hermes_cli/test_resource_guard.py
@@ -72,5 +72,140 @@ def test_descendant_hard_limit_is_independent_of_parent_rss(monkeypatch):
     )
 
     guard._sample()
+    guard._sample()
 
     assert len(callbacks) == 1
+    assert callbacks[0]["descendant_rss_bytes"] == 25 * 1024 * 1024
+
+
+def test_single_transient_spike_does_not_fire_hard_limit(monkeypatch):
+    """A lone over-cap sample must not fire; the guard requires consecutive
+    confirmations so a transient allocation spike cannot trigger a restart."""
+    snapshot = {
+        "rss_bytes": 9 * 1024 * 1024,
+        "descendant_rss_bytes": 0,
+        "descendant_count": 0,
+    }
+    callbacks = []
+    monkeypatch.setattr(
+        "hermes_cli.resource_guard.collect_process_memory_snapshot",
+        lambda _metrics: dict(snapshot),
+    )
+    monkeypatch.setattr(
+        "hermes_cli.resource_guard._append_telemetry", lambda row: None
+    )
+    monkeypatch.setattr(
+        "hermes_cli.resource_guard._write_evidence_snapshot", lambda row, reason: None
+    )
+    guard = ProcessMemoryGuard(
+        component="test",
+        settings=ResourceGuardSettings(
+            warn_rss_mb=2,
+            snapshot_rss_mb=4,
+            hard_rss_mb=8,
+            descendant_warn_rss_mb=8,
+            descendant_hard_rss_mb=24,
+            hard_limit_confirmations=3,
+        ),
+        on_hard_limit=lambda row: callbacks.append(row),
+    )
+
+    guard._sample()
+    guard._sample()
+    assert callbacks == []
+
+    guard._sample()
+    assert len(callbacks) == 1
+
+
+def test_recovery_resets_hard_limit_debounce(monkeypatch):
+    """A sample back under the cap resets the confirmation counter."""
+    state = {
+        "rss_bytes": 9 * 1024 * 1024,
+        "descendant_rss_bytes": 0,
+        "descendant_count": 0,
+    }
+    callbacks = []
+    monkeypatch.setattr(
+        "hermes_cli.resource_guard.collect_process_memory_snapshot",
+        lambda _metrics: dict(state),
+    )
+    monkeypatch.setattr(
+        "hermes_cli.resource_guard._append_telemetry", lambda row: None
+    )
+    monkeypatch.setattr(
+        "hermes_cli.resource_guard._write_evidence_snapshot", lambda row, reason: None
+    )
+    guard = ProcessMemoryGuard(
+        component="test",
+        settings=ResourceGuardSettings(
+            warn_rss_mb=2,
+            snapshot_rss_mb=4,
+            hard_rss_mb=8,
+            descendant_warn_rss_mb=8,
+            descendant_hard_rss_mb=24,
+            hard_limit_confirmations=2,
+        ),
+        on_hard_limit=lambda row: callbacks.append(row),
+    )
+
+    guard._sample()  # over cap -> violations = 1
+    state["rss_bytes"] = 1 * 1024 * 1024  # recover
+    guard._sample()  # under cap -> violations = 0
+    state["rss_bytes"] = 9 * 1024 * 1024  # over cap again
+    guard._sample()  # violations = 1
+    assert callbacks == []
+    guard._sample()  # violations = 2 -> fires
+    assert len(callbacks) == 1
+
+
+def test_telemetry_is_opt_in(monkeypatch):
+    """Telemetry rows are written only when telemetry_enabled is set."""
+    snapshot = {
+        "rss_bytes": 1 * 1024 * 1024,
+        "descendant_rss_bytes": 0,
+        "descendant_count": 0,
+    }
+    rows = []
+    monkeypatch.setattr(
+        "hermes_cli.resource_guard.collect_process_memory_snapshot",
+        lambda _metrics: dict(snapshot),
+    )
+    monkeypatch.setattr(
+        "hermes_cli.resource_guard._append_telemetry", lambda row: rows.append(row)
+    )
+    monkeypatch.setattr(
+        "hermes_cli.resource_guard._write_evidence_snapshot", lambda row, reason: None
+    )
+
+    off = ProcessMemoryGuard(
+        component="test",
+        settings=ResourceGuardSettings(
+            warn_rss_mb=2,
+            snapshot_rss_mb=4,
+            hard_rss_mb=8,
+            descendant_warn_rss_mb=8,
+            descendant_hard_rss_mb=24,
+            telemetry_enabled=False,
+            telemetry_seconds=0,
+        ),
+        on_hard_limit=lambda row: None,
+    )
+    off._sample()
+    assert rows == []
+
+    on = ProcessMemoryGuard(
+        component="test",
+        settings=ResourceGuardSettings(
+            warn_rss_mb=2,
+            snapshot_rss_mb=4,
+            hard_rss_mb=8,
+            descendant_warn_rss_mb=8,
+            descendant_hard_rss_mb=24,
+            telemetry_enabled=True,
+            telemetry_seconds=0,
+        ),
+        on_hard_limit=lambda row: None,
+    )
+    on._sample()
+    assert len(rows) == 1

--- a/tests/hermes_cli/test_resource_guard.py
+++ b/tests/hermes_cli/test_resource_guard.py
@@ -1,0 +1,76 @@
+from hermes_cli.resource_guard import ProcessMemoryGuard, ResourceGuardSettings
+
+
+def test_hard_limit_captures_evidence_and_calls_restart_once(monkeypatch):
+    snapshot = {
+        "rss_bytes": 9 * 1024 * 1024,
+        "descendant_rss_bytes": 0,
+        "descendant_count": 0,
+    }
+    callbacks = []
+    evidence = []
+    monkeypatch.setattr(
+        "hermes_cli.resource_guard.collect_process_memory_snapshot",
+        lambda _metrics: dict(snapshot),
+    )
+    monkeypatch.setattr(
+        "hermes_cli.resource_guard._append_telemetry", lambda row: None
+    )
+    monkeypatch.setattr(
+        "hermes_cli.resource_guard._write_evidence_snapshot",
+        lambda row, reason: evidence.append(reason) or None,
+    )
+    guard = ProcessMemoryGuard(
+        component="test",
+        settings=ResourceGuardSettings(
+            poll_seconds=15,
+            telemetry_seconds=60,
+            warn_rss_mb=2,
+            snapshot_rss_mb=4,
+            hard_rss_mb=8,
+            descendant_warn_rss_mb=8,
+            descendant_hard_rss_mb=24,
+            snapshot_cooldown_seconds=300,
+        ),
+        on_hard_limit=lambda row: callbacks.append(row),
+    )
+
+    guard._sample()
+    guard._sample()
+
+    assert callbacks == [callbacks[0]]
+    assert "hard-parent" in evidence
+
+
+def test_descendant_hard_limit_is_independent_of_parent_rss(monkeypatch):
+    snapshot = {
+        "rss_bytes": 1 * 1024 * 1024,
+        "descendant_rss_bytes": 25 * 1024 * 1024,
+        "descendant_count": 2,
+    }
+    callbacks = []
+    monkeypatch.setattr(
+        "hermes_cli.resource_guard.collect_process_memory_snapshot",
+        lambda _metrics: dict(snapshot),
+    )
+    monkeypatch.setattr(
+        "hermes_cli.resource_guard._append_telemetry", lambda row: None
+    )
+    monkeypatch.setattr(
+        "hermes_cli.resource_guard._write_evidence_snapshot", lambda row, reason: None
+    )
+    guard = ProcessMemoryGuard(
+        component="test",
+        settings=ResourceGuardSettings(
+            warn_rss_mb=2,
+            snapshot_rss_mb=4,
+            hard_rss_mb=8,
+            descendant_warn_rss_mb=8,
+            descendant_hard_rss_mb=24,
+        ),
+        on_hard_limit=lambda row: callbacks.append(row),
+    )
+
+    guard._sample()
+
+    assert len(callbacks) == 1

--- a/tests/tools/test_process_registry.py
+++ b/tests/tools/test_process_registry.py
@@ -144,6 +144,30 @@ def _wait_until(predicate, timeout: float = 5.0, interval: float = 0.05) -> bool
     return False
 
 
+def test_large_model_downloads_are_classified_and_serialized(registry, monkeypatch):
+    monkeypatch.setattr(
+        registry,
+        "_background_resource_policy",
+        lambda: {
+            "large_download_max_concurrent": 1,
+            "descendant_warn_rss_mb": 8192,
+            "descendant_hard_rss_mb": 24576,
+            "poll_seconds": 15.0,
+        },
+    )
+    command = "python -c \"from huggingface_hub import hf_hub_download\""
+    assert registry._resource_class_for_command(command) == "large_download"
+    active = _make_session(sid="proc_download", command=command)
+    active.resource_class = "large_download"
+    registry._running[active.id] = active
+
+    with pytest.raises(RuntimeError, match="concurrency limit reached"):
+        registry._assert_resource_spawn_allowed("large_download")
+
+    # Ordinary servers and builds are unaffected by the download-specific cap.
+    registry._assert_resource_spawn_allowed("background")
+
+
 @pytest.mark.windows_only
 def test_write_stdin_uses_str_for_windows_pty(registry):
     """pywinpty expects str input; bytes raises a PyString conversion error.

--- a/tests/tools/test_process_registry.py
+++ b/tests/tools/test_process_registry.py
@@ -168,6 +168,34 @@ def test_large_model_downloads_are_classified_and_serialized(registry, monkeypat
     registry._assert_resource_spawn_allowed("background")
 
 
+def test_background_resource_policy_reads_descendant_thresholds_from_guard(monkeypatch):
+    """Descendant thresholds and the confirmation count come from the
+    resource_guard block (single source of truth), not a duplicated
+    terminal-level knob."""
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config_readonly",
+        lambda: {
+            "resource_guard": {
+                "descendant_warn_rss_mb": 4096,
+                "descendant_hard_rss_mb": 16384,
+                "hard_limit_confirmations": 3,
+            },
+            "terminal": {
+                "background_resource_limits": {
+                    "large_download_max_concurrent": 2,
+                    "poll_seconds": 10,
+                }
+            },
+        },
+    )
+    policy = ProcessRegistry._background_resource_policy()
+    assert policy["descendant_warn_rss_mb"] == 4096
+    assert policy["descendant_hard_rss_mb"] == 16384
+    assert policy["hard_limit_confirmations"] == 3
+    assert policy["large_download_max_concurrent"] == 2
+    assert policy["poll_seconds"] == 10.0
+
+
 @pytest.mark.windows_only
 def test_write_stdin_uses_str_for_windows_pty(registry):
     """pywinpty expects str input; bytes raises a PyString conversion error.

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -507,10 +507,21 @@ class ProcessRegistry:
 
     @staticmethod
     def _background_resource_policy() -> dict[str, float | int]:
+        # Descendant-tree memory thresholds and the hard-limit confirmation
+        # count are owned by the resource_guard config block (single source of
+        # truth), so per-process caps cannot drift from the gateway guard.
+        # Only terminal-specific knobs live under terminal.background_resource_limits.
+        from hermes_cli.resource_guard import (
+            DESCENDANT_WARN_RSS_MB,
+            DESCENDANT_HARD_RSS_MB,
+            HARD_LIMIT_CONFIRMATIONS,
+        )
+
         defaults = {
             "large_download_max_concurrent": 1,
-            "descendant_warn_rss_mb": 8192,
-            "descendant_hard_rss_mb": 24576,
+            "descendant_warn_rss_mb": DESCENDANT_WARN_RSS_MB,
+            "descendant_hard_rss_mb": DESCENDANT_HARD_RSS_MB,
+            "hard_limit_confirmations": HARD_LIMIT_CONFIRMATIONS,
             "poll_seconds": 15.0,
         }
         try:
@@ -523,20 +534,28 @@ class ProcessRegistry:
                 if isinstance(terminal, dict)
                 else None
             )
-            if not isinstance(raw, dict):
-                return defaults
+            guard = cfg.get("resource_guard") if isinstance(cfg, dict) else None
             policy = dict(defaults)
-            policy["large_download_max_concurrent"] = max(
-                1, int(raw.get("large_download_max_concurrent", 1))
-            )
-            policy["descendant_warn_rss_mb"] = max(
-                1, int(raw.get("descendant_warn_rss_mb", 8192))
-            )
-            policy["descendant_hard_rss_mb"] = max(
-                int(policy["descendant_warn_rss_mb"]),
-                int(raw.get("descendant_hard_rss_mb", 24576)),
-            )
-            policy["poll_seconds"] = max(2.0, float(raw.get("poll_seconds", 15)))
+            if isinstance(raw, dict):
+                policy["large_download_max_concurrent"] = max(
+                    1, int(raw.get("large_download_max_concurrent", 1))
+                )
+                policy["poll_seconds"] = max(
+                    2.0, float(raw.get("poll_seconds", 15))
+                )
+            if isinstance(guard, dict):
+                policy["descendant_warn_rss_mb"] = max(
+                    1,
+                    int(guard.get("descendant_warn_rss_mb", DESCENDANT_WARN_RSS_MB)),
+                )
+                policy["descendant_hard_rss_mb"] = max(
+                    int(policy["descendant_warn_rss_mb"]),
+                    int(guard.get("descendant_hard_rss_mb", DESCENDANT_HARD_RSS_MB)),
+                )
+                policy["hard_limit_confirmations"] = max(
+                    1,
+                    int(guard.get("hard_limit_confirmations", HARD_LIMIT_CONFIRMATIONS)),
+                )
             return policy
         except (TypeError, ValueError, OSError):
             return defaults
@@ -605,7 +624,9 @@ class ProcessRegistry:
             policy = self._background_resource_policy()
             warn_bytes = int(policy["descendant_warn_rss_mb"]) * 1024 * 1024
             hard_bytes = int(policy["descendant_hard_rss_mb"]) * 1024 * 1024
+            confirmations = int(policy["hard_limit_confirmations"])
             poll_seconds = float(policy["poll_seconds"])
+            hard_violations = 0
             while not session._completion_event.wait(poll_seconds):
                 if session.exited or not session.pid:
                     return
@@ -625,15 +646,24 @@ class ProcessRegistry:
                     session._resource_warned = True
                 elif rss < warn_bytes * 0.8:
                     session._resource_warned = False
+                # Debounce the hard limit: a single transient spike above the
+                # cap must not terminate the tree; require consecutive
+                # over-cap samples before acting.
                 if rss >= hard_bytes:
+                    hard_violations += 1
+                else:
+                    hard_violations = 0
+                if hard_violations >= confirmations:
                     logger.error(
                         "Background process memory hard limit: session=%s pid=%s "
-                        "class=%s tree_rss_mb=%.1f hard_mb=%d; terminating tree",
+                        "class=%s tree_rss_mb=%.1f hard_mb=%d confirmations=%d; "
+                        "terminating tree",
                         session.id,
                         session.pid,
                         session.resource_class,
                         rss / (1024 * 1024),
                         int(policy["descendant_hard_rss_mb"]),
+                        hard_violations,
                     )
                     self.kill_process(session.id, source="resource_guard")
                     return

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -384,6 +384,8 @@ class ProcessSession:
     max_output_chars: int = MAX_OUTPUT_CHARS
     detached: bool = False                      # True if recovered from crash (no pipe)
     pid_scope: str = "host"                     # "host" for local/PTY PIDs, "sandbox" for env-local PIDs
+    resource_class: str = "background"
+    _resource_warned: bool = field(default=False, repr=False)
     systemd_unit: str = ""                      # transient scope unit name when spawned under systemd-run (#70716)
     # Watcher/notification metadata (persisted for crash recovery)
     watcher_platform: str = ""
@@ -502,6 +504,145 @@ class ProcessRegistry:
         while lines and any(noise in lines[0] for noise in ProcessRegistry._SHELL_NOISE_SUBSTRINGS):
             lines.pop(0)
         return "\n".join(lines)
+
+    @staticmethod
+    def _background_resource_policy() -> dict[str, float | int]:
+        defaults = {
+            "large_download_max_concurrent": 1,
+            "descendant_warn_rss_mb": 8192,
+            "descendant_hard_rss_mb": 24576,
+            "poll_seconds": 15.0,
+        }
+        try:
+            from hermes_cli.config import load_config_readonly
+
+            cfg = load_config_readonly() or {}
+            terminal = cfg.get("terminal") if isinstance(cfg, dict) else None
+            raw = (
+                terminal.get("background_resource_limits")
+                if isinstance(terminal, dict)
+                else None
+            )
+            if not isinstance(raw, dict):
+                return defaults
+            policy = dict(defaults)
+            policy["large_download_max_concurrent"] = max(
+                1, int(raw.get("large_download_max_concurrent", 1))
+            )
+            policy["descendant_warn_rss_mb"] = max(
+                1, int(raw.get("descendant_warn_rss_mb", 8192))
+            )
+            policy["descendant_hard_rss_mb"] = max(
+                int(policy["descendant_warn_rss_mb"]),
+                int(raw.get("descendant_hard_rss_mb", 24576)),
+            )
+            policy["poll_seconds"] = max(2.0, float(raw.get("poll_seconds", 15)))
+            return policy
+        except (TypeError, ValueError, OSError):
+            return defaults
+
+    @staticmethod
+    def _resource_class_for_command(command: str) -> str:
+        normalized = " ".join(str(command or "").lower().split())
+        hugging_face = any(
+            marker in normalized
+            for marker in (
+                "hf_hub_download",
+                "snapshot_download",
+                "huggingface-cli download",
+                "hf download",
+            )
+        )
+        direct_model_download = (
+            any(tool in normalized for tool in ("curl ", "wget ", "aria2c "))
+            and any(
+                suffix in normalized
+                for suffix in (".gguf", ".safetensors", ".ckpt", ".pth")
+            )
+        )
+        return "large_download" if hugging_face or direct_model_download else "background"
+
+    def _assert_resource_spawn_allowed(self, resource_class: str) -> None:
+        if resource_class != "large_download":
+            return
+        policy = self._background_resource_policy()
+        cap = int(policy["large_download_max_concurrent"])
+        with self._lock:
+            active = [
+                session
+                for session in self._running.values()
+                if not session.exited and session.resource_class == "large_download"
+            ]
+        if len(active) >= cap:
+            ids = ", ".join(session.id for session in active[:4])
+            raise RuntimeError(
+                "Large-download concurrency limit reached "
+                f"({len(active)}/{cap}); wait for or stop {ids} before starting another."
+            )
+
+    @staticmethod
+    def _process_tree_rss_bytes(pid: int) -> int:
+        import psutil
+
+        try:
+            parent = psutil.Process(pid)
+            processes = [parent, *parent.children(recursive=True)]
+        except (psutil.NoSuchProcess, psutil.AccessDenied, OSError):
+            return 0
+        total = 0
+        for process in processes:
+            try:
+                total += int(process.memory_info().rss)
+            except (psutil.NoSuchProcess, psutil.AccessDenied, OSError):
+                continue
+        return total
+
+    def _start_resource_monitor(self, session: ProcessSession) -> None:
+        if session.pid_scope != "host" or not session.pid:
+            return
+
+        def _monitor() -> None:
+            policy = self._background_resource_policy()
+            warn_bytes = int(policy["descendant_warn_rss_mb"]) * 1024 * 1024
+            hard_bytes = int(policy["descendant_hard_rss_mb"]) * 1024 * 1024
+            poll_seconds = float(policy["poll_seconds"])
+            while not session._completion_event.wait(poll_seconds):
+                if session.exited or not session.pid:
+                    return
+                rss = self._process_tree_rss_bytes(session.pid)
+                if rss <= 0:
+                    return
+                if rss >= warn_bytes and not session._resource_warned:
+                    logger.warning(
+                        "Background process memory warning: session=%s pid=%s "
+                        "class=%s tree_rss_mb=%.1f warn_mb=%d",
+                        session.id,
+                        session.pid,
+                        session.resource_class,
+                        rss / (1024 * 1024),
+                        int(policy["descendant_warn_rss_mb"]),
+                    )
+                    session._resource_warned = True
+                elif rss < warn_bytes * 0.8:
+                    session._resource_warned = False
+                if rss >= hard_bytes:
+                    logger.error(
+                        "Background process memory hard limit: session=%s pid=%s "
+                        "class=%s tree_rss_mb=%.1f hard_mb=%d; terminating tree",
+                        session.id,
+                        session.pid,
+                        session.resource_class,
+                        rss / (1024 * 1024),
+                        int(policy["descendant_hard_rss_mb"]),
+                    )
+                    self.kill_process(session.id, source="resource_guard")
+                    return
+
+        threading.Thread(
+            target=_monitor,
+            daemon=True,
+            name=f"proc-resource-{session.id}",
+        ).start()
 
     def _emit_output(self, session: ProcessSession, chunk: str) -> None:
         """Forward a freshly-read chunk to the live-output sink, if one is set.
@@ -997,6 +1138,8 @@ class ProcessRegistry:
         from tools.terminal_tool import _rewrite_compound_background as _rewrite_bg
 
         safe_command = _rewrite_bg(command)
+        resource_class = self._resource_class_for_command(command)
+        self._assert_resource_spawn_allowed(resource_class)
 
         session = ProcessSession(
             id=f"proc_{uuid.uuid4().hex[:12]}",
@@ -1005,6 +1148,7 @@ class ProcessRegistry:
             session_key=session_key,
             cwd=_resolve_safe_cwd(cwd or os.getcwd()),
             started_at=time.time(),
+            resource_class=resource_class,
         )
 
         pty_scope_attempted = False
@@ -1070,6 +1214,7 @@ class ProcessRegistry:
                     self._running[session.id] = session
 
                 self._write_checkpoint()
+                self._start_resource_monitor(session)
                 return session
 
             except ImportError:
@@ -1176,6 +1321,7 @@ class ProcessRegistry:
                 self._running[session.id] = session
 
             self._write_checkpoint()
+            self._start_resource_monitor(session)
         except Exception:
             # Post-Popen setup failed — kill the orphaned subprocess (and any
             # descendants spawned via setsid) before re-raising so they do not
@@ -2519,6 +2665,7 @@ class ProcessRegistry:
                             "started_at": s.started_at,
                             "task_id": s.task_id,
                             "session_key": s.session_key,
+                            "resource_class": s.resource_class,
                             "watcher_platform": s.watcher_platform,
                             "watcher_chat_id": s.watcher_chat_id,
                             "watcher_user_id": s.watcher_user_id,
@@ -2626,11 +2773,14 @@ class ProcessRegistry:
                 parent_session_id=entry.get("parent_session_id", ""),
                 notify_on_complete=entry.get("notify_on_complete", False),
                 watch_patterns=entry.get("watch_patterns", []),
+                resource_class=entry.get("resource_class")
+                or self._resource_class_for_command(entry.get("command", "")),
             )
             with self._lock:
                 self._running[session.id] = session
             recovered += 1
             logger.info("Recovered detached process: %s (pid=%d)", session.command[:60], pid)
+            self._start_resource_monitor(session)
 
             # Re-enqueue watcher so gateway can resume notifications
             if session.watcher_interval > 0:


### PR DESCRIPTION
## Summary

Bounds Hermes memory retention at layers that currently grow without a ceiling, and fixes a base64 image-pin leak in the message token cache.

### 1. Process-level memory guard (`hermes_cli/resource_guard.py`, new)

A `ProcessMemoryGuard` that:
- samples parent **and** descendant RSS on a configurable interval,
- writes a redacted evidence snapshot (JSON counters + `faulthandler` thread dump) before a hard limit,
- triggers fail-closed restart on the hard limit,
- emits **local-only** telemetry — nothing is ever exported.

Wired into the messaging gateway (`_start_resource_guard` / `_stop_resource_guard`) and the desktop/dashboard serve loop.

**Relationship to the existing `_sweep_agent_cache_under_pressure` (#80764):** that valve gracefully sheds LRU transcripts when the gateway's *own* anonymous RSS exceeds its budget. This guard is the complementary last-resort layer — it watches the whole process tree (including child workers the gateway valve cannot see) and captures forensic evidence before a hard restart. It is not a replacement or a duplicate.

### 2. Background-process resource limits (`tools/process_registry.py`)

- Classifies model downloads (`hf_hub_download`, `snapshot_download`, `huggingface-cli download`, `curl`/`wget`/`aria2c` of `.gguf`/`.safetensors`/`.ckpt`/`.pth`) as `large_download`.
- Caps concurrent `large_download` spawns (default 1).
- Monitors each host process tree's RSS against warn/hard thresholds and terminates the tree on the hard limit.

### 3. Message-token-cache image-pin fix (`agent/model_metadata.py`)

`_estimate_message_tokens_cached` memoized every message, including multimodal messages with base64 image payloads — so a single large image could stay pinned in `_MSG_TOKENS_CACHE` indefinitely. Multimodal messages now bypass the fingerprint memo, and `message_token_cache_stats()` is added for observability.

### 4. Desktop memory metrics (`hermes_cli/web_server.py`)

Adds `_desktop_memory_metrics` (live sessions, token-cache stats, tracked background processes) consumed by the guard's telemetry.

### Config

- `resource_guard` — enabled flag, poll/telemetry intervals, warn/snapshot/hard RSS thresholds.
- `terminal.background_resource_limits` — download concurrency cap + descendant RSS thresholds.

## Tests

- `tests/hermes_cli/test_resource_guard.py` (new) — hard-limit evidence capture + single restart, and descendant-RSS independence.
- `tests/tools/test_process_registry.py` — download classification + concurrency cap.
- `tests/agent/test_model_metadata.py` — image payload is not pinned by the token cache.

All pass locally (Python 3.11).

## Notes

Rebased from a local hardening fork. The original change also carried gateway agent-cache bound tweaks (128→16 cap / TTL), which I dropped because `AgentCacheBounds` + `_sweep_agent_cache_under_pressure` already cover that on main.
