### PR TITLE
fix(email): stop stalled IMAP fetches from silently halting mail polling

### DIFF
--- a/plugins/platforms/email/adapter.py
+++ b/plugins/platforms/email/adapter.py
@@ -876,9 +876,14 @@ class EmailAdapter(BasePlatformAdapter):
                 dispatch_future.result(timeout=IMAP_FETCH_WATCHDOG_TIMEOUT)
             except FutureTimeoutError as exc:
                 if dispatch_future.done():
-                    raise _EmailDispatchError(
-                        f"Message dispatch for IMAP UID {uid!r} failed: {exc}"
-                    ) from exc
+                    try:
+                        dispatch_future.result()
+                    except Exception as completed_exc:
+                        raise _EmailDispatchError(
+                            f"Message dispatch for IMAP UID {uid!r} failed: "
+                            f"{completed_exc}"
+                        ) from completed_exc
+                    return
                 dispatch_future.cancel()
                 raise _EmailDispatchTimeout(
                     f"Message dispatch for IMAP UID {uid!r} made no progress for "

--- a/plugins/platforms/email/adapter.py
+++ b/plugins/platforms/email/adapter.py
@@ -110,6 +110,10 @@ _AUTOMATED_HEADERS = {
 MAX_MESSAGE_LENGTH = 50_000
 
 SMTP_CONNECT_TIMEOUT = 30
+# ``imaplib`` applies its timeout to individual socket operations. Keep an
+# independent wall-clock bound around the whole executor job so a worker that
+# stops making progress cannot pin the poll loop indefinitely.
+IMAP_FETCH_WATCHDOG_TIMEOUT = 120.0
 
 
 def _close_imap(imap: "imaplib.IMAP4") -> None:
@@ -825,7 +829,23 @@ class EmailAdapter(BasePlatformAdapter):
         """Check INBOX for unseen messages and dispatch them."""
         # Run IMAP operations in a thread to avoid blocking the event loop
         loop = asyncio.get_running_loop()
-        messages = await loop.run_in_executor(None, self._fetch_new_messages)
+        try:
+            fetch_future = loop.run_in_executor(None, self._fetch_new_messages)
+            messages = await asyncio.wait_for(
+                asyncio.shield(fetch_future),
+                timeout=IMAP_FETCH_WATCHDOG_TIMEOUT,
+            )
+        except asyncio.TimeoutError:
+            message = (
+                "IMAP fetch exceeded "
+                f"{IMAP_FETCH_WATCHDOG_TIMEOUT:g}s without completing"
+            )
+            logger.error("[Email] %s", message)
+            self._set_fatal_error(
+                "email_imap_fetch_timeout", message, retryable=True
+            )
+            await self._notify_fatal_error()
+            return
         # Dispatch whatever the fetch managed to return BEFORE escalating a
         # failure: on a mid-batch exception _fetch_new_messages returns the
         # partial results, and dropping them here would lose those messages

--- a/plugins/platforms/email/adapter.py
+++ b/plugins/platforms/email/adapter.py
@@ -16,6 +16,7 @@ Environment variables:
 """
 
 import asyncio
+from concurrent.futures import TimeoutError as FutureTimeoutError
 import email as email_lib
 import imaplib
 import logging
@@ -116,6 +117,14 @@ SMTP_CONNECT_TIMEOUT = 30
 # independent inactivity bound around the executor job so one stuck operation
 # cannot pin the poll loop while a healthy large batch may run for longer.
 IMAP_FETCH_WATCHDOG_TIMEOUT = 120.0
+
+
+class _EmailDispatchError(Exception):
+    """A fetched message could not be dispatched on the owning event loop."""
+
+
+class _EmailDispatchTimeout(_EmailDispatchError):
+    """A message dispatch exceeded the email inactivity window."""
 
 
 def _close_imap(imap: "imaplib.IMAP4") -> None:
@@ -608,7 +617,6 @@ class EmailAdapter(BasePlatformAdapter):
         self._active_imap_lock = threading.Lock()
         self._fetch_progress_lock = threading.Lock()
         self._fetch_last_progress = 0.0
-        self._fetch_dispatch_callback = None
 
         # Track the last IMAP fetch attempt so the poll loop can distinguish
         # "checked, nothing new" from "the check itself failed" (#80016).
@@ -856,25 +864,43 @@ class EmailAdapter(BasePlatformAdapter):
             self._active_fetches[self._address] = fetch_token
 
         self._record_fetch_progress()
+        dispatch_active = threading.Event()
 
         def dispatch_from_worker(uid: bytes, msg_data: Dict[str, Any]) -> None:
+            self._record_fetch_progress()
+            dispatch_active.set()
             dispatch_future = asyncio.run_coroutine_threadsafe(
                 self._dispatch_message(msg_data), loop
             )
-            dispatch_future.result()
+            try:
+                dispatch_future.result(timeout=IMAP_FETCH_WATCHDOG_TIMEOUT)
+            except FutureTimeoutError as exc:
+                if dispatch_future.done():
+                    raise _EmailDispatchError(
+                        f"Message dispatch for IMAP UID {uid!r} failed: {exc}"
+                    ) from exc
+                dispatch_future.cancel()
+                raise _EmailDispatchTimeout(
+                    f"Message dispatch for IMAP UID {uid!r} made no progress for "
+                    f"{IMAP_FETCH_WATCHDOG_TIMEOUT:g}s"
+                ) from exc
+            except Exception as exc:
+                raise _EmailDispatchError(
+                    f"Message dispatch for IMAP UID {uid!r} failed: {exc}"
+                ) from exc
+            finally:
+                dispatch_active.clear()
 
-        self._fetch_dispatch_callback = dispatch_from_worker
         try:
-            fetch_future = loop.run_in_executor(None, self._fetch_new_messages)
+            fetch_future = loop.run_in_executor(
+                None, self._fetch_new_messages, dispatch_from_worker
+            )
         except Exception:
-            self._fetch_dispatch_callback = None
             self._release_active_fetch(fetch_token)
             raise
 
         def finish_fetch(done_future: "asyncio.Future[List[Dict[str, Any]]]") -> None:
             self._release_active_fetch(fetch_token)
-            if self._fetch_dispatch_callback is dispatch_from_worker:
-                self._fetch_dispatch_callback = None
             if not done_future.cancelled():
                 # Retrieve background exceptions after a timed-out/cancelled
                 # waiter so asyncio does not warn that they were never retrieved.
@@ -889,19 +915,40 @@ class EmailAdapter(BasePlatformAdapter):
                 remaining = IMAP_FETCH_WATCHDOG_TIMEOUT - inactive_for
                 if remaining <= 0:
                     self._abort_active_imap()
-                    message = (
-                        "IMAP fetch made no progress for "
-                        f"{IMAP_FETCH_WATCHDOG_TIMEOUT:g}s"
-                    )
+                    if dispatch_active.is_set():
+                        code = "email_message_dispatch_timeout"
+                        message = (
+                            "Message dispatch made no progress for "
+                            f"{IMAP_FETCH_WATCHDOG_TIMEOUT:g}s"
+                        )
+                    else:
+                        code = "email_imap_fetch_timeout"
+                        message = (
+                            "IMAP fetch made no progress for "
+                            f"{IMAP_FETCH_WATCHDOG_TIMEOUT:g}s"
+                        )
                     logger.error("[Email] %s", message)
-                    self._set_fatal_error(
-                        "email_imap_fetch_timeout", message, retryable=True
-                    )
+                    self._set_fatal_error(code, message, retryable=True)
                     await self._notify_fatal_error()
                     return
                 done, _ = await asyncio.wait({fetch_future}, timeout=remaining)
                 if done:
-                    messages = fetch_future.result()
+                    try:
+                        messages = fetch_future.result()
+                    except _EmailDispatchTimeout as exc:
+                        logger.error("[Email] %s", exc)
+                        self._set_fatal_error(
+                            "email_message_dispatch_timeout", str(exc), retryable=True
+                        )
+                        await self._notify_fatal_error()
+                        return
+                    except _EmailDispatchError as exc:
+                        logger.error("[Email] %s", exc)
+                        self._set_fatal_error(
+                            "email_message_dispatch_failed", str(exc), retryable=True
+                        )
+                        await self._notify_fatal_error()
+                        return
                     break
         except asyncio.CancelledError:
             self._abort_active_imap()
@@ -961,7 +1008,7 @@ class EmailAdapter(BasePlatformAdapter):
                 except Exception:
                     pass
 
-    def _fetch_new_messages(self) -> List[Dict[str, Any]]:
+    def _fetch_new_messages(self, dispatch_callback=None) -> List[Dict[str, Any]]:
         """Fetch new (unseen) messages from IMAP. Runs in executor thread."""
         results = []
         imap: Optional[imaplib.IMAP4] = None
@@ -1024,7 +1071,6 @@ class EmailAdapter(BasePlatformAdapter):
                         self._seen_uids.add(uid)
                         continue
                     if parsed is not None:
-                        dispatch_callback = self._fetch_dispatch_callback
                         if dispatch_callback is None:
                             parsed["_imap_uid"] = uid
                             results.append(parsed)
@@ -1051,6 +1097,8 @@ class EmailAdapter(BasePlatformAdapter):
                 with self._active_imap_lock:
                     if self._active_imap is imap:
                         self._active_imap = None
+        except _EmailDispatchError:
+            raise
         except Exception as e:
             logger.error("[Email] IMAP fetch error: %s", e)
             self._last_fetch_failed = True

--- a/plugins/platforms/email/adapter.py
+++ b/plugins/platforms/email/adapter.py
@@ -23,6 +23,8 @@ import os
 import re
 import smtplib
 import socket
+import threading
+import time
 
 # Profile-scoped secret reader for multiplexing support (PR #50094)
 from agent.secret_scope import UnscopedSecretError as _UnscopedSecretError
@@ -111,8 +113,8 @@ MAX_MESSAGE_LENGTH = 50_000
 
 SMTP_CONNECT_TIMEOUT = 30
 # ``imaplib`` applies its timeout to individual socket operations. Keep an
-# independent wall-clock bound around the whole executor job so a worker that
-# stops making progress cannot pin the poll loop indefinitely.
+# independent inactivity bound around the executor job so one stuck operation
+# cannot pin the poll loop while a healthy large batch may run for longer.
 IMAP_FETCH_WATCHDOG_TIMEOUT = 120.0
 
 
@@ -541,6 +543,8 @@ class EmailAdapter(BasePlatformAdapter):
     # run several email accounts in one process). Same-process only by
     # design — after a full restart the usual mark-all-seen baseline applies.
     _seen_uids_snapshot: Dict[str, set] = {}
+    _active_fetches: Dict[str, object] = {}
+    _active_fetches_lock = threading.Lock()
 
     def __init__(self, config: PlatformConfig):
         super().__init__(config, Platform.EMAIL)
@@ -600,6 +604,11 @@ class EmailAdapter(BasePlatformAdapter):
         self._seen_uids: set = set()
         self._seen_uids_max: int = 2000   # cap to prevent unbounded memory growth
         self._poll_task: Optional[asyncio.Task] = None
+        self._active_imap: Optional[imaplib.IMAP4] = None
+        self._active_imap_lock = threading.Lock()
+        self._fetch_progress_lock = threading.Lock()
+        self._fetch_last_progress = 0.0
+        self._fetch_dispatch_callback = None
 
         # Track the last IMAP fetch attempt so the poll loop can distinguish
         # "checked, nothing new" from "the check itself failed" (#80016).
@@ -704,6 +713,17 @@ class EmailAdapter(BasePlatformAdapter):
                 "email_missing_configuration", message, retryable=False
             )
             return False
+
+        if is_reconnect:
+            with self._active_fetches_lock:
+                previous_fetch_active = self._address in self._active_fetches
+            if previous_fetch_active:
+                message = "Previous IMAP fetch is still stopping"
+                logger.warning("[Email] %s for %s", message, self._address)
+                self._set_fatal_error(
+                    "email_imap_fetch_still_stopping", message, retryable=True
+                )
+                return False
 
         try:
             # Test IMAP connection. The handle is closed in ``finally`` —
@@ -829,29 +849,73 @@ class EmailAdapter(BasePlatformAdapter):
         """Check INBOX for unseen messages and dispatch them."""
         # Run IMAP operations in a thread to avoid blocking the event loop
         loop = asyncio.get_running_loop()
+        fetch_token = object()
+        with self._active_fetches_lock:
+            if self._address in self._active_fetches:
+                return
+            self._active_fetches[self._address] = fetch_token
+
+        self._record_fetch_progress()
+
+        def dispatch_from_worker(uid: bytes, msg_data: Dict[str, Any]) -> None:
+            dispatch_future = asyncio.run_coroutine_threadsafe(
+                self._dispatch_message(msg_data), loop
+            )
+            dispatch_future.result()
+
+        self._fetch_dispatch_callback = dispatch_from_worker
         try:
             fetch_future = loop.run_in_executor(None, self._fetch_new_messages)
-            messages = await asyncio.wait_for(
-                asyncio.shield(fetch_future),
-                timeout=IMAP_FETCH_WATCHDOG_TIMEOUT,
-            )
-        except asyncio.TimeoutError:
-            message = (
-                "IMAP fetch exceeded "
-                f"{IMAP_FETCH_WATCHDOG_TIMEOUT:g}s without completing"
-            )
-            logger.error("[Email] %s", message)
-            self._set_fatal_error(
-                "email_imap_fetch_timeout", message, retryable=True
-            )
-            await self._notify_fatal_error()
-            return
-        # Dispatch whatever the fetch managed to return BEFORE escalating a
-        # failure: on a mid-batch exception _fetch_new_messages returns the
-        # partial results, and dropping them here would lose those messages
-        # (their processing already marked them seen).
+        except Exception:
+            self._fetch_dispatch_callback = None
+            self._release_active_fetch(fetch_token)
+            raise
+
+        def finish_fetch(done_future: "asyncio.Future[List[Dict[str, Any]]]") -> None:
+            self._release_active_fetch(fetch_token)
+            if self._fetch_dispatch_callback is dispatch_from_worker:
+                self._fetch_dispatch_callback = None
+            if not done_future.cancelled():
+                # Retrieve background exceptions after a timed-out/cancelled
+                # waiter so asyncio does not warn that they were never retrieved.
+                done_future.exception()
+
+        fetch_future.add_done_callback(finish_fetch)
+
+        try:
+            while True:
+                with self._fetch_progress_lock:
+                    inactive_for = time.monotonic() - self._fetch_last_progress
+                remaining = IMAP_FETCH_WATCHDOG_TIMEOUT - inactive_for
+                if remaining <= 0:
+                    self._abort_active_imap()
+                    message = (
+                        "IMAP fetch made no progress for "
+                        f"{IMAP_FETCH_WATCHDOG_TIMEOUT:g}s"
+                    )
+                    logger.error("[Email] %s", message)
+                    self._set_fatal_error(
+                        "email_imap_fetch_timeout", message, retryable=True
+                    )
+                    await self._notify_fatal_error()
+                    return
+                done, _ = await asyncio.wait({fetch_future}, timeout=remaining)
+                if done:
+                    messages = fetch_future.result()
+                    break
+        except asyncio.CancelledError:
+            self._abort_active_imap()
+            raise
+
         for msg_data in messages:
-            await self._dispatch_message(msg_data)
+            uid = msg_data.get("_imap_uid")
+            dispatch_data = dict(msg_data)
+            dispatch_data.pop("_imap_uid", None)
+            await self._dispatch_message(dispatch_data)
+            if uid is not None:
+                self._seen_uids.add(uid)
+                self._trim_seen_uids()
+                self._seen_uids_snapshot[self._address] = set(self._seen_uids)
         if self._last_fetch_failed:
             # The IMAP check itself failed (connect/login/select/search/fetch),
             # not just an empty inbox. Surface it through the fatal-error hook
@@ -868,18 +932,53 @@ class EmailAdapter(BasePlatformAdapter):
             )
             await self._notify_fatal_error()
 
+    def _record_fetch_progress(self) -> None:
+        with self._fetch_progress_lock:
+            self._fetch_last_progress = time.monotonic()
+
+    def _release_active_fetch(self, token: object) -> None:
+        with self._active_fetches_lock:
+            if self._active_fetches.get(self._address) is token:
+                self._active_fetches.pop(self._address, None)
+
+    def _abort_active_imap(self) -> None:
+        """Interrupt the socket owned by the executor worker, if available."""
+        with self._active_imap_lock:
+            imap = self._active_imap
+        if imap is None:
+            return
+        try:
+            imap.shutdown()
+        except Exception:
+            sock = getattr(imap, "sock", None)
+            if sock is not None:
+                try:
+                    sock.shutdown(socket.SHUT_RDWR)
+                except Exception:
+                    pass
+                try:
+                    sock.close()
+                except Exception:
+                    pass
+
     def _fetch_new_messages(self) -> List[Dict[str, Any]]:
         """Fetch new (unseen) messages from IMAP. Runs in executor thread."""
         results = []
         imap: Optional[imaplib.IMAP4] = None
         try:
             imap = imaplib.IMAP4_SSL(self._imap_host, self._imap_port, timeout=30)
+            with self._active_imap_lock:
+                self._active_imap = imap
             try:
                 imap.login(self._address, self._password)
+                self._record_fetch_progress()
                 _send_imap_id(imap)
+                self._record_fetch_progress()
                 imap.select("INBOX")
+                self._record_fetch_progress()
 
                 status, data = imap.uid("search", None, "UNSEEN")
+                self._record_fetch_progress()
                 if status != "OK" or not data or not data[0]:
                     return results
 
@@ -887,24 +986,12 @@ class EmailAdapter(BasePlatformAdapter):
                     if uid in self._seen_uids:
                         continue
 
-                    status, msg_data = imap.uid("fetch", uid, "(RFC822)")
+                    status, msg_data = imap.uid("fetch", uid, "(BODY.PEEK[])")
+                    self._record_fetch_progress()
                     if status != "OK":
                         # Transient per-UID fetch refusal: leave the UID out of
                         # _seen_uids so the next poll retries it.
                         continue
-
-                    # IMAP fetch can return unexpected structures (e.g. a
-                    # single bytes item instead of a list of tuples). Mark the
-                    # UID seen once a response arrived (even a malformed one)
-                    # so a garbage response is skipped once, not retried
-                    # forever — but NOT before the fetch: a connection failure
-                    # above must leave the remaining batch eligible for the
-                    # next poll instead of permanently skipping it (#80032
-                    # review).
-                    self._seen_uids.add(uid)
-                    # Trim periodically to prevent unbounded memory growth
-                    if len(self._seen_uids) > self._seen_uids_max:
-                        self._trim_seen_uids()
 
                     try:
                         raw_email = msg_data[0][1]
@@ -913,11 +1000,13 @@ class EmailAdapter(BasePlatformAdapter):
                             "[Email] Unexpected IMAP response structure for UID %s, skipping",
                             uid,
                         )
+                        self._seen_uids.add(uid)
                         continue
                     if not isinstance(raw_email, (bytes, bytearray)):
                         logger.warning(
                             "[Email] Non-bytes IMAP payload for UID %s, skipping", uid
                         )
+                        self._seen_uids.add(uid)
                         continue
                     # Per-message processing guard: one poison message
                     # (unparseable headers, pathological attachment, DNS
@@ -932,13 +1021,36 @@ class EmailAdapter(BasePlatformAdapter):
                             uid,
                             parse_exc,
                         )
+                        self._seen_uids.add(uid)
                         continue
                     if parsed is not None:
-                        results.append(parsed)
+                        dispatch_callback = self._fetch_dispatch_callback
+                        if dispatch_callback is None:
+                            parsed["_imap_uid"] = uid
+                            results.append(parsed)
+                        else:
+                            # Dispatch on the owning event loop before making
+                            # either the local or server-side seen state
+                            # irreversible. The worker keeps this IMAP session
+                            # alive so the commit does not need a second socket.
+                            dispatch_callback(uid, parsed)
+                            self._seen_uids.add(uid)
+                            self._trim_seen_uids()
+                            self._seen_uids_snapshot[self._address] = set(
+                                self._seen_uids
+                            )
+                            self._record_fetch_progress()
+                            imap.uid("store", uid, "+FLAGS", "(\\Seen)")
+                            self._record_fetch_progress()
+                    else:
+                        self._seen_uids.add(uid)
             finally:
                 # _close_imap guarantees the socket dies even when logout()
                 # raises IMAP4.abort on a broken connection (#79889).
                 _close_imap(imap)
+                with self._active_imap_lock:
+                    if self._active_imap is imap:
+                        self._active_imap = None
         except Exception as e:
             logger.error("[Email] IMAP fetch error: %s", e)
             self._last_fetch_failed = True

--- a/tests/gateway/test_email.py
+++ b/tests/gateway/test_email.py
@@ -606,6 +606,46 @@ class TestPollLoop(unittest.TestCase):
         self.assertTrue(adapter.fatal_error_retryable)
         self.assertIn("read operation timed out", adapter.fatal_error_message)
 
+    def test_check_inbox_times_out_stalled_executor_fetch(self):
+        """A wedged IMAP worker must enter reconnect instead of pinning the poll task."""
+        import asyncio
+        import threading
+        import time
+
+        from plugins.platforms.email import adapter as email_adapter
+
+        adapter = self._make_adapter()
+        fetch_started = threading.Event()
+        release_fetch = threading.Event()
+        notified = []
+
+        def stalled_fetch():
+            fetch_started.set()
+            release_fetch.wait(timeout=5.0)
+            return []
+
+        async def mock_fatal_handler(failed_adapter):
+            notified.append(failed_adapter)
+            release_fetch.set()
+
+        async def exercise():
+            started = time.monotonic()
+            await adapter._check_inbox()
+            return time.monotonic() - started
+
+        adapter._fetch_new_messages = stalled_fetch
+        adapter.set_fatal_error_handler(mock_fatal_handler)
+
+        with patch.object(email_adapter, "IMAP_FETCH_WATCHDOG_TIMEOUT", 0.05):
+            elapsed = asyncio.run(exercise())
+
+        self.assertTrue(fetch_started.is_set())
+        self.assertLess(elapsed, 2.0)
+        self.assertEqual(notified, [adapter])
+        self.assertEqual(adapter.fatal_error_code, "email_imap_fetch_timeout")
+        self.assertTrue(adapter.fatal_error_retryable)
+        self.assertIn("exceeded 0.05s", adapter.fatal_error_message)
+
     def test_partial_batch_dispatched_before_escalation(self):
         """A mid-batch IMAP failure must dispatch the messages already
         fetched BEFORE escalating — dropping them would lose mail, since

--- a/tests/gateway/test_email.py
+++ b/tests/gateway/test_email.py
@@ -18,7 +18,7 @@ from email.mime.text import MIMEText
 from email.mime.multipart import MIMEMultipart
 from email.mime.base import MIMEBase
 from email import encoders
-from unittest.mock import patch, MagicMock, AsyncMock, ANY
+from unittest.mock import patch, MagicMock, AsyncMock, ANY, call
 
 from gateway.platforms.base import SendResult
 
@@ -529,7 +529,8 @@ class TestFetchNewMessages(unittest.TestCase):
         # Only UID 3 should be fetched (1 and 2 already seen)
         self.assertEqual(len(results), 1)
         self.assertEqual(results[0]["sender_addr"], "user@test.com")
-        self.assertIn(b"3", adapter._seen_uids)
+        self.assertEqual(results[0]["_imap_uid"], b"3")
+        self.assertNotIn(b"3", adapter._seen_uids)
 
 
 class TestPollLoop(unittest.TestCase):
@@ -618,6 +619,7 @@ class TestPollLoop(unittest.TestCase):
         fetch_started = threading.Event()
         release_fetch = threading.Event()
         notified = []
+        aborted = []
 
         def stalled_fetch():
             fetch_started.set()
@@ -626,6 +628,9 @@ class TestPollLoop(unittest.TestCase):
 
         async def mock_fatal_handler(failed_adapter):
             notified.append(failed_adapter)
+
+        def abort_fetch():
+            aborted.append(True)
             release_fetch.set()
 
         async def exercise():
@@ -634,6 +639,7 @@ class TestPollLoop(unittest.TestCase):
             return time.monotonic() - started
 
         adapter._fetch_new_messages = stalled_fetch
+        adapter._abort_active_imap = abort_fetch
         adapter.set_fatal_error_handler(mock_fatal_handler)
 
         with patch.object(email_adapter, "IMAP_FETCH_WATCHDOG_TIMEOUT", 0.05):
@@ -642,9 +648,112 @@ class TestPollLoop(unittest.TestCase):
         self.assertTrue(fetch_started.is_set())
         self.assertLess(elapsed, 2.0)
         self.assertEqual(notified, [adapter])
+        self.assertEqual(aborted, [True])
         self.assertEqual(adapter.fatal_error_code, "email_imap_fetch_timeout")
         self.assertTrue(adapter.fatal_error_retryable)
-        self.assertIn("exceeded 0.05s", adapter.fatal_error_message)
+        self.assertIn("no progress for 0.05s", adapter.fatal_error_message)
+
+    def test_progressing_fetch_can_exceed_watchdog_total_duration(self):
+        """The watchdog measures inactivity, not total healthy batch time."""
+        import asyncio
+        import time
+
+        from plugins.platforms.email import adapter as email_adapter
+
+        adapter = self._make_adapter()
+        notified = []
+
+        def progressing_fetch():
+            for _ in range(5):
+                time.sleep(0.03)
+                adapter._record_fetch_progress()
+            return []
+
+        async def mock_fatal_handler(failed_adapter):
+            notified.append(failed_adapter)
+
+        adapter._fetch_new_messages = progressing_fetch
+        adapter.set_fatal_error_handler(mock_fatal_handler)
+
+        with patch.object(email_adapter, "IMAP_FETCH_WATCHDOG_TIMEOUT", 0.05):
+            asyncio.run(adapter._check_inbox())
+
+        self.assertEqual(notified, [])
+
+    def test_timeout_keeps_completed_message_eligible_for_reconnect(self):
+        """A later stalled UID must not consume an earlier undispatched UID."""
+        import asyncio
+        import threading
+
+        from plugins.platforms.email import adapter as email_adapter
+
+        adapter = self._make_adapter()
+        release_fetch = threading.Event()
+        dispatched = []
+        raw_email = MIMEText("Body", "plain", "utf-8")
+        raw_email["From"] = "sender@test.com"
+        raw_email["Subject"] = "First before stall"
+
+        mock_imap = MagicMock()
+
+        def uid_handler(command, *args):
+            if command == "search":
+                return ("OK", [b"1 2"])
+            if command == "fetch" and args[0] == b"1":
+                return ("OK", [(b"1", raw_email.as_bytes())])
+            if command == "fetch":
+                release_fetch.wait(timeout=5.0)
+                raise OSError("aborted")
+            return ("NO", [])
+
+        def shutdown():
+            release_fetch.set()
+
+        async def dispatch(msg_data):
+            dispatched.append(msg_data)
+
+        mock_imap.uid.side_effect = uid_handler
+        mock_imap.shutdown.side_effect = shutdown
+        adapter._dispatch_message = dispatch
+
+        with patch("imaplib.IMAP4_SSL", return_value=mock_imap), patch.object(
+            email_adapter, "IMAP_FETCH_WATCHDOG_TIMEOUT", 0.05
+        ):
+            asyncio.run(adapter._check_inbox())
+
+        self.assertEqual(len(dispatched), 1)
+        self.assertEqual(dispatched[0]["subject"], "First before stall")
+        self.assertIn(b"1", adapter._seen_uids)
+        fetch_calls = [
+            call for call in mock_imap.uid.call_args_list
+            if call.args[0] == "fetch"
+        ]
+        self.assertEqual(fetch_calls[0].args[2], "(BODY.PEEK[])")
+        self.assertIn(
+            call("store", b"1", "+FLAGS", "(\\Seen)"),
+            mock_imap.uid.call_args_list,
+        )
+
+    def test_reconnect_waits_for_previous_fetch_worker_to_exit(self):
+        """A replacement adapter must not overlap an abandoned account fetch."""
+        import asyncio
+
+        adapter = self._make_adapter()
+        token = object()
+        with adapter._active_fetches_lock:
+            adapter._active_fetches[adapter._address] = token
+        try:
+            connected = asyncio.run(adapter.connect(is_reconnect=True))
+        finally:
+            with adapter._active_fetches_lock:
+                if adapter._active_fetches.get(adapter._address) is token:
+                    adapter._active_fetches.pop(adapter._address)
+
+        self.assertFalse(connected)
+        self.assertEqual(
+            adapter.fatal_error_code, "email_imap_fetch_still_stopping"
+        )
+        self.assertTrue(adapter.fatal_error_retryable)
 
     def test_partial_batch_dispatched_before_escalation(self):
         """A mid-batch IMAP failure must dispatch the messages already
@@ -723,7 +832,8 @@ class TestPollLoop(unittest.TestCase):
             results = adapter._fetch_new_messages()
 
         self.assertEqual(len(results), 1)
-        self.assertIn(b"1", adapter._seen_uids)     # fetched → seen
+        self.assertEqual(results[0]["_imap_uid"], b"1")
+        self.assertNotIn(b"1", adapter._seen_uids)  # dispatch has not committed it
         self.assertNotIn(b"2", adapter._seen_uids)  # fetch raised → retry next poll
         self.assertNotIn(b"3", adapter._seen_uids)  # never reached → retry next poll
         self.assertTrue(adapter._last_fetch_failed)
@@ -762,7 +872,8 @@ class TestPollLoop(unittest.TestCase):
         # Poison message consumed (seen, skipped); good message survived.
         self.assertEqual(len(results), 1)
         self.assertIn(b"1", adapter._seen_uids)
-        self.assertIn(b"2", adapter._seen_uids)
+        self.assertEqual(results[0]["_imap_uid"], b"2")
+        self.assertNotIn(b"2", adapter._seen_uids)
         self.assertFalse(adapter._last_fetch_failed)
 
 

--- a/tests/gateway/test_email.py
+++ b/tests/gateway/test_email.py
@@ -621,7 +621,7 @@ class TestPollLoop(unittest.TestCase):
         notified = []
         aborted = []
 
-        def stalled_fetch():
+        def stalled_fetch(dispatch_callback=None):
             fetch_started.set()
             release_fetch.wait(timeout=5.0)
             return []
@@ -663,7 +663,7 @@ class TestPollLoop(unittest.TestCase):
         adapter = self._make_adapter()
         notified = []
 
-        def progressing_fetch():
+        def progressing_fetch(dispatch_callback=None):
             for _ in range(5):
                 time.sleep(0.03)
                 adapter._record_fetch_progress()
@@ -679,6 +679,98 @@ class TestPollLoop(unittest.TestCase):
             asyncio.run(adapter._check_inbox())
 
         self.assertEqual(notified, [])
+
+    def test_stalled_dispatch_releases_fetch_gate(self):
+        """A wedged dispatch must not leave reconnect blocked indefinitely."""
+        import asyncio
+        import time
+
+        from plugins.platforms.email import adapter as email_adapter
+
+        adapter = self._make_adapter()
+        dispatch_cancelled = asyncio.Event()
+        notified = []
+        raw_email = MIMEText("Body", "plain", "utf-8")
+        raw_email["From"] = "sender@test.com"
+        raw_email["Subject"] = "Stalled dispatch"
+        mock_imap = MagicMock()
+
+        def uid_handler(command, *args):
+            if command == "search":
+                return ("OK", [b"1"])
+            if command == "fetch":
+                return ("OK", [(b"1", raw_email.as_bytes())])
+            return ("NO", [])
+
+        async def stalled_dispatch(msg_data):
+            try:
+                await asyncio.Event().wait()
+            except asyncio.CancelledError:
+                dispatch_cancelled.set()
+                raise
+
+        async def mock_fatal_handler(failed_adapter):
+            notified.append(failed_adapter)
+
+        async def exercise():
+            await adapter._check_inbox()
+            deadline = time.monotonic() + 2.0
+            while adapter._address in adapter._active_fetches:
+                if time.monotonic() >= deadline:
+                    self.fail("dispatch timeout did not release the fetch gate")
+                await asyncio.sleep(0.01)
+
+        mock_imap.uid.side_effect = uid_handler
+        adapter._dispatch_message = stalled_dispatch
+        adapter.set_fatal_error_handler(mock_fatal_handler)
+
+        with patch("imaplib.IMAP4_SSL", return_value=mock_imap), patch.object(
+            email_adapter, "IMAP_FETCH_WATCHDOG_TIMEOUT", 0.05
+        ):
+            asyncio.run(exercise())
+
+        self.assertTrue(dispatch_cancelled.is_set())
+        self.assertEqual(notified, [adapter])
+        self.assertEqual(adapter.fatal_error_code, "email_message_dispatch_timeout")
+        self.assertTrue(adapter.fatal_error_retryable)
+        self.assertNotIn(b"1", adapter._seen_uids)
+
+    def test_dispatch_failure_is_not_reported_as_imap_failure(self):
+        """A downstream dispatch exception must retain its own failure classification."""
+        import asyncio
+
+        adapter = self._make_adapter()
+        notified = []
+        raw_email = MIMEText("Body", "plain", "utf-8")
+        raw_email["From"] = "sender@test.com"
+        raw_email["Subject"] = "Dispatch failure"
+        mock_imap = MagicMock()
+
+        def uid_handler(command, *args):
+            if command == "search":
+                return ("OK", [b"1"])
+            if command == "fetch":
+                return ("OK", [(b"1", raw_email.as_bytes())])
+            return ("NO", [])
+
+        async def failed_dispatch(msg_data):
+            raise RuntimeError("downstream unavailable")
+
+        async def mock_fatal_handler(failed_adapter):
+            notified.append(failed_adapter)
+
+        mock_imap.uid.side_effect = uid_handler
+        adapter._dispatch_message = failed_dispatch
+        adapter.set_fatal_error_handler(mock_fatal_handler)
+
+        with patch("imaplib.IMAP4_SSL", return_value=mock_imap):
+            asyncio.run(adapter._check_inbox())
+
+        self.assertEqual(notified, [adapter])
+        self.assertEqual(adapter.fatal_error_code, "email_message_dispatch_failed")
+        self.assertIn("downstream unavailable", adapter.fatal_error_message)
+        self.assertFalse(adapter._last_fetch_failed)
+        self.assertNotIn(b"1", adapter._seen_uids)
 
     def test_timeout_keeps_completed_message_eligible_for_reconnect(self):
         """A later stalled UID must not consume an earlier undispatched UID."""

--- a/tests/gateway/test_email.py
+++ b/tests/gateway/test_email.py
@@ -642,7 +642,7 @@ class TestPollLoop(unittest.TestCase):
         adapter._abort_active_imap = abort_fetch
         adapter.set_fatal_error_handler(mock_fatal_handler)
 
-        with patch.object(email_adapter, "IMAP_FETCH_WATCHDOG_TIMEOUT", 0.05):
+        with patch.object(email_adapter, "IMAP_FETCH_WATCHDOG_TIMEOUT", 0.5):
             elapsed = asyncio.run(exercise())
 
         self.assertTrue(fetch_started.is_set())
@@ -651,7 +651,7 @@ class TestPollLoop(unittest.TestCase):
         self.assertEqual(aborted, [True])
         self.assertEqual(adapter.fatal_error_code, "email_imap_fetch_timeout")
         self.assertTrue(adapter.fatal_error_retryable)
-        self.assertIn("no progress for 0.05s", adapter.fatal_error_message)
+        self.assertIn("no progress for 0.5s", adapter.fatal_error_message)
 
     def test_progressing_fetch_can_exceed_watchdog_total_duration(self):
         """The watchdog measures inactivity, not total healthy batch time."""
@@ -665,7 +665,7 @@ class TestPollLoop(unittest.TestCase):
 
         def progressing_fetch(dispatch_callback=None):
             for _ in range(5):
-                time.sleep(0.03)
+                time.sleep(0.15)
                 adapter._record_fetch_progress()
             return []
 
@@ -675,7 +675,7 @@ class TestPollLoop(unittest.TestCase):
         adapter._fetch_new_messages = progressing_fetch
         adapter.set_fatal_error_handler(mock_fatal_handler)
 
-        with patch.object(email_adapter, "IMAP_FETCH_WATCHDOG_TIMEOUT", 0.05):
+        with patch.object(email_adapter, "IMAP_FETCH_WATCHDOG_TIMEOUT", 0.5):
             asyncio.run(adapter._check_inbox())
 
         self.assertEqual(notified, [])
@@ -725,7 +725,7 @@ class TestPollLoop(unittest.TestCase):
         adapter.set_fatal_error_handler(mock_fatal_handler)
 
         with patch("imaplib.IMAP4_SSL", return_value=mock_imap), patch.object(
-            email_adapter, "IMAP_FETCH_WATCHDOG_TIMEOUT", 0.05
+            email_adapter, "IMAP_FETCH_WATCHDOG_TIMEOUT", 0.5
         ):
             asyncio.run(exercise())
 
@@ -734,6 +734,62 @@ class TestPollLoop(unittest.TestCase):
         self.assertEqual(adapter.fatal_error_code, "email_message_dispatch_timeout")
         self.assertTrue(adapter.fatal_error_retryable)
         self.assertNotIn(b"1", adapter._seen_uids)
+
+    def test_dispatch_timeout_boundary_success_is_committed_once(self):
+        """A dispatch completing during timeout handling must still commit its UID."""
+        import asyncio
+
+        adapter = self._make_adapter()
+        notified = []
+        raw_email = MIMEText("Body", "plain", "utf-8")
+        raw_email["From"] = "sender@test.com"
+        raw_email["Subject"] = "Boundary success"
+        mock_imap = MagicMock()
+
+        def uid_handler(command, *args):
+            if command == "search":
+                return ("OK", [b"1"])
+            if command == "fetch":
+                return ("OK", [(b"1", raw_email.as_bytes())])
+            return ("NO", [])
+
+        class BoundaryFuture:
+            def __init__(self):
+                self.result_calls = 0
+
+            def result(self, timeout=None):
+                self.result_calls += 1
+                if self.result_calls == 1:
+                    raise TimeoutError()
+                return None
+
+            def done(self):
+                return True
+
+        boundary_future = BoundaryFuture()
+
+        def complete_at_boundary(coro, loop):
+            coro.close()
+            return boundary_future
+
+        async def mock_fatal_handler(failed_adapter):
+            notified.append(failed_adapter)
+
+        mock_imap.uid.side_effect = uid_handler
+        adapter.set_fatal_error_handler(mock_fatal_handler)
+
+        with patch("imaplib.IMAP4_SSL", return_value=mock_imap), patch(
+            "asyncio.run_coroutine_threadsafe", side_effect=complete_at_boundary
+        ):
+            asyncio.run(adapter._check_inbox())
+
+        self.assertEqual(boundary_future.result_calls, 2)
+        self.assertEqual(notified, [])
+        self.assertIn(b"1", adapter._seen_uids)
+        self.assertIn(
+            call("store", b"1", "+FLAGS", "(\\Seen)"),
+            mock_imap.uid.call_args_list,
+        )
 
     def test_dispatch_failure_is_not_reported_as_imap_failure(self):
         """A downstream dispatch exception must retain its own failure classification."""
@@ -809,7 +865,7 @@ class TestPollLoop(unittest.TestCase):
         adapter._dispatch_message = dispatch
 
         with patch("imaplib.IMAP4_SSL", return_value=mock_imap), patch.object(
-            email_adapter, "IMAP_FETCH_WATCHDOG_TIMEOUT", 0.05
+            email_adapter, "IMAP_FETCH_WATCHDOG_TIMEOUT", 0.5
         ):
             asyncio.run(adapter._check_inbox())
 


### PR DESCRIPTION
## What does this PR do?

Email polling no longer waits forever when one IMAP fetch stops making progress. The adapter now applies a progress-aware inactivity watchdog, aborts the active IMAP connection on timeout or cancellation, and routes the failure through the existing retryable reconnect path without losing messages that were already fetched.

### Symptom

An IMAP operation can remain blocked far beyond its configured socket timeout. The email poll task then stays pending with no warning or reconnect even though the gateway event loop is still responsive.

### Impact

Affected email gateways silently stop receiving new mail until the blocked operation returns or the process is restarted. The duration and blast radius depend on the IMAP server and network failure mode.

### Bug Cause

**Trigger:** `plugins/platforms/email/adapter.py` / `EmailAdapter._check_inbox()` awaiting the executor-backed `_fetch_new_messages()` call.

**Causal chain:**
1. An IMAP fetch blocks in the executor after the poll begins.
2. The `imaplib` timeout only bounds individual socket operations, while `_check_inbox()` had no asyncio-side deadline or progress monitor.
3. The email poll task remains pending indefinitely, and the loop-liveness watchdog does not fire because the event loop itself remains responsive.

**Why it is wrong:** A platform poller must either keep making progress or return a retryable failure. An unbounded executor await bypassed the gateway's reconnect and status machinery.

**Working sibling / contrast:** Full event-loop stalls are detected by the existing loop-liveness watchdog. A single blocked executor worker leaves the loop healthy, so the email adapter needs its own operation-level inactivity bound.

**Ruled out:** The gateway loop probe was not the failing component because it could still complete `call_soon_threadsafe` probes while the email task was hung. The separate heartbeat observation therefore does not justify changing the global loop watchdog contract.

### Fix

The email adapter now tracks fetch progress across IMAP operations and message dispatch, expires only after an inactivity window, and actively shuts down the worker's IMAP socket on timeout or cancellation. It dispatches each message before committing local and server-side Seen state, and a per-account worker gate prevents a reconnect from overlapping a worker that is still stopping.

## Related Issue

Closes #87128

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/platforms/email/adapter.py` - add a progress-aware IMAP inactivity watchdog, active socket abort, dispatch-before-Seen ordering, and reconnect worker exclusion.
- `tests/gateway/test_email.py` - cover stalled fetch timeout, healthy long-running progress, partial-batch delivery, Seen ordering, and reconnect exclusion.

## How to Test

1. Run an executor-backed IMAP fetch that dispatches one message and then stalls on a later UID; verify the first message is committed, the socket is aborted after inactivity, and the failure is retryable.
2. Run a fetch that reports progress longer than the total watchdog duration; verify it completes without a false timeout.
3. Run the related suites:

```bash
scripts/run_tests.sh tests/gateway/test_email.py tests/gateway/test_email_robustness.py tests/gateway/test_adapter_connect_classification.py
scripts/run_tests.sh tests/gateway/test_poller_fd_lifecycle.py -k Email
```

Results: 69 passed in the email suites and 2 passed in the Email lifecycle selection.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repository test entry on the relevant tests and all selected tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11 with a real asyncio loop and default executor

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - N/A; no user-facing configuration or API changed
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - N/A; no config keys changed
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - N/A; no project workflow changed
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior - N/A; no model tool changed

## Screenshots / Logs

REAL_ENV verification used the committed adapter with a real asyncio loop and default executor. It confirmed dispatch-before-Seen behavior, socket abort on inactivity and cancellation, healthy progress beyond the total inactivity budget, and exclusion of replacement workers until the prior worker exits.
