### PR TITLE
feat(delegation): operator-defined personas for per-call model routing

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -1462,6 +1462,14 @@ delegation:
   # inherit_mcp_toolsets: true                # When explicit child toolsets are narrowed, also keep the parent's MCP toolsets (default: true). Set false for strict intersection.
   # model: "google/gemini-3-flash-preview"    # Override model for subagents (empty = inherit parent)
   # provider: "openrouter"                    # Override provider for subagents (empty = inherit parent)
+  # personas:                                 # Named model/provider bundles the agent can select per
+  #   planner:                                # delegate_task call via the optional `persona` parameter.
+  #     model: "claude-fable-5"               # A persona may override: model, provider, base_url,
+  #     provider: "anthropic"                 # api_key, api_mode. Orchestration limits (max_iterations,
+  #   coder:                                  # spawn depth, concurrency) stay global. The agent only
+  #     model: "anthropic/claude-sonnet-5"    # ever names a persona — which model that maps to remains
+  #                                           # operator-controlled here. Unknown names degrade to the
+  #                                           # default delegation config with a logged warning.
   #                                           # Resolves full credentials (base_url, api_key) automatically.
   #                                           # Supported: openrouter, nous, zai, kimi-coding, minimax
   #                                           # Cost tip: keep the parent on a frontier model and pin

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -30,6 +30,7 @@ from tools.delegate_tool import (
     _strip_blocked_tools,
     _resolve_child_credential_pool,
     _resolve_delegation_credentials,
+    _apply_persona_overlay,
 )
 from hermes_state import SessionDB
 
@@ -771,6 +772,88 @@ class TestBlockedTools(unittest.TestCase):
         can batch mechanical work instead of burning reasoning iterations
         (Teknium, Jul 2026)."""
         self.assertNotIn("execute_code", DELEGATE_BLOCKED_TOOLS)
+
+class TestPersonaOverlay(unittest.TestCase):
+    """Tests for operator-defined persona overlays (delegation.personas)."""
+
+    BASE_CFG = {
+        "model": "anthropic/claude-sonnet-5",
+        "provider": "anthropic",
+        "max_iterations": 50,
+        "personas": {
+            "planner": {"model": "claude-fable-5", "provider": "anthropic"},
+            "coder": {"model": "anthropic/claude-haiku-4-5"},
+            "broken": "not-a-dict",
+        },
+    }
+
+    def test_no_persona_returns_cfg_unchanged(self):
+        cfg = dict(self.BASE_CFG)
+        self.assertIs(_apply_persona_overlay(cfg, None), cfg)
+        self.assertIs(_apply_persona_overlay(cfg, ""), cfg)
+
+    def test_persona_overrides_model_and_provider(self):
+        merged = _apply_persona_overlay(self.BASE_CFG, "planner")
+        self.assertEqual(merged["model"], "claude-fable-5")
+        self.assertEqual(merged["provider"], "anthropic")
+        # Base config is not mutated.
+        self.assertEqual(self.BASE_CFG["model"], "anthropic/claude-sonnet-5")
+
+    def test_persona_partial_override_keeps_base_keys(self):
+        merged = _apply_persona_overlay(self.BASE_CFG, "coder")
+        self.assertEqual(merged["model"], "anthropic/claude-haiku-4-5")
+        # Provider not set on the persona — inherited from base config.
+        self.assertEqual(merged["provider"], "anthropic")
+
+    def test_persona_cannot_override_orchestration_limits(self):
+        cfg = dict(self.BASE_CFG)
+        cfg["personas"] = {"greedy": {"model": "x", "max_iterations": 9999}}
+        merged = _apply_persona_overlay(cfg, "greedy")
+        self.assertEqual(merged["max_iterations"], 50)
+
+    def test_unknown_persona_degrades_to_base_cfg(self):
+        with self.assertLogs("tools.delegate_tool", level="WARNING") as logs:
+            merged = _apply_persona_overlay(self.BASE_CFG, "nonexistent")
+        self.assertEqual(merged["model"], "anthropic/claude-sonnet-5")
+        self.assertTrue(any("unknown persona" in m for m in logs.output))
+
+    def test_malformed_persona_entry_degrades_to_base_cfg(self):
+        with self.assertLogs("tools.delegate_tool", level="WARNING"):
+            merged = _apply_persona_overlay(self.BASE_CFG, "broken")
+        self.assertEqual(merged["model"], "anthropic/claude-sonnet-5")
+
+    def test_persona_without_personas_section_degrades(self):
+        cfg = {"model": "m", "provider": "p"}
+        with self.assertLogs("tools.delegate_tool", level="WARNING"):
+            merged = _apply_persona_overlay(cfg, "planner")
+        self.assertEqual(merged, cfg)
+
+    def test_persona_flows_into_credential_resolution(self):
+        """A persona with a direct base_url routes children to that endpoint."""
+        parent = _make_mock_parent(depth=0)
+        cfg = {
+            "model": "",
+            "provider": "",
+            "personas": {
+                "local": {
+                    "model": "qwen2.5-coder",
+                    "base_url": "http://localhost:1234/v1",
+                    "api_key": "local-key",
+                }
+            },
+        }
+        creds = _resolve_delegation_credentials(
+            _apply_persona_overlay(cfg, "local"), parent
+        )
+        self.assertEqual(creds["model"], "qwen2.5-coder")
+        self.assertEqual(creds["base_url"], "http://localhost:1234/v1")
+        self.assertEqual(creds["api_key"], "local-key")
+
+    def test_schema_exposes_persona_param(self):
+        self.assertIn(
+            "persona", DELEGATE_TASK_SCHEMA["parameters"]["properties"]
+        )
+
 
 class TestDelegationCredentialResolution(unittest.TestCase):
     """Tests for provider:model credential resolution in delegation config."""

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -3431,6 +3431,7 @@ def delegate_task(
     tasks: Optional[List[Dict[str, Any]]] = None,
     max_iterations: Optional[int] = None,
     role: Optional[str] = None,
+    persona: Optional[str] = None,
     background: Optional[bool] = None,
     output_schema: Optional[Dict[str, Any]] = None,
     action: Optional[str] = None,
@@ -3456,6 +3457,12 @@ def delegate_task(
     'leaf' (default) cannot; 'orchestrator' retains the delegation
     toolset and can spawn its own workers, bounded by
     delegation.max_spawn_depth.  Per-task role beats the top-level one.
+
+    The 'persona' parameter names an operator-defined entry under
+    delegation.personas in config.yaml whose model/provider overrides
+    apply to every child spawned by this call (see
+    _apply_persona_overlay).  Unknown names degrade to the default
+    delegation config with a logged warning.
 
     Returns JSON with results array, one entry per task.
     """
@@ -3531,7 +3538,9 @@ def delegate_task(
     # used by CLI/gateway startup.  When unconfigured, returns None values so
     # children inherit from the parent.
     try:
-        creds = _resolve_delegation_credentials(cfg, parent_agent)
+        creds = _resolve_delegation_credentials(
+            _apply_persona_overlay(cfg, persona), parent_agent
+        )
     except ValueError as exc:
         return tool_error(str(exc))
 
@@ -4236,6 +4245,64 @@ def _resolve_child_credential_pool(
     return None
 
 
+# Keys a persona may override — deliberately restricted to the
+# credential-bearing subset of the delegation config so a persona can
+# re-route model/provider without touching orchestration limits
+# (max_iterations, spawn depth, and concurrency stay global).
+_PERSONA_OVERRIDE_KEYS = ("model", "provider", "base_url", "api_key", "api_mode")
+
+
+def _apply_persona_overlay(cfg: dict, persona: Optional[str]) -> dict:
+    """Overlay ``delegation.personas.<persona>`` onto the delegation config.
+
+    Personas are operator-defined model/provider bundles in config.yaml:
+
+        delegation:
+          personas:
+            planner:
+              model: "claude-fable-5"
+              provider: "anthropic"
+            coder:
+              model: "anthropic/claude-sonnet-5"
+
+    The agent selects a persona *name* per delegate_task call; what that
+    name resolves to stays under operator control in config.yaml. This is
+    the middle ground between no per-call routing at all and letting the
+    model emit arbitrary model strings (#52077, #78522): cost and provider
+    policy remain with the config owner while skills/prompts can still
+    steer which persona handles which kind of work.
+
+    Unknown or malformed persona names degrade to the base config with a
+    warning (same silent-degrade pattern as ``_normalize_role``) — a
+    failed lookup must never break the delegation itself.
+    """
+    if not persona:
+        return cfg
+    personas = cfg.get("personas")
+    if not isinstance(personas, dict):
+        logger.warning(
+            "delegate_task: persona=%r requested but delegation.personas is "
+            "not configured; using default delegation config",
+            persona,
+        )
+        return cfg
+    entry = personas.get(str(persona).strip())
+    if not isinstance(entry, dict):
+        known = sorted(k for k in personas if isinstance(personas.get(k), dict))
+        logger.warning(
+            "delegate_task: unknown persona=%r (configured: %s); using "
+            "default delegation config",
+            persona,
+            known or "none",
+        )
+        return cfg
+    merged = dict(cfg)
+    for key in _PERSONA_OVERRIDE_KEYS:
+        if key in entry and entry[key] is not None:
+            merged[key] = entry[key]
+    return merged
+
+
 def _resolve_delegation_credentials(cfg: dict, parent_agent) -> dict:
     """Resolve credentials for subagent delegation.
 
@@ -4610,6 +4677,18 @@ DELEGATE_TASK_SCHEMA = {
                 "enum": ["leaf", "orchestrator"],
                 "description": "(rebuilt at get_definitions() time)",
             },
+            "persona": {
+                "type": "string",
+                "description": (
+                    "Optional operator-defined persona for this call's "
+                    "children. Maps to delegation.personas.<name> in "
+                    "config.yaml, which may override the child model/"
+                    "provider (e.g. a 'planner' persona pinned to a "
+                    "frontier model, a 'coder' persona on a fast one). "
+                    "Applies to every child spawned by this call. Unknown "
+                    "names fall back to the default delegation config."
+                ),
+            },
             "output_schema": {
                 "type": "object",
                 "description": (
@@ -4721,6 +4800,7 @@ registry.register(
         tasks=_strip_model_hidden_task_fields(args.get("tasks")),
         max_iterations=args.get("max_iterations"),
         role=args.get("role"),
+        persona=args.get("persona"),
         background=_model_background_value(args, kw.get("parent_agent")),
         output_schema=args.get("output_schema"),
         action=args.get("action"),


### PR DESCRIPTION
## Summary

Adds an optional `persona` parameter to `delegate_task` that selects a named, **operator-defined** entry under `delegation.personas` in config.yaml. A persona may override the credential-bearing delegation keys (`model`, `provider`, `base_url`, `api_key`, `api_mode`) for every child spawned by that call. Orchestration limits (`max_iterations`, spawn depth, concurrency) deliberately stay global and cannot be overridden by a persona.

```yaml
delegation:
  personas:
    planner:
      model: "claude-fable-5"
      provider: "anthropic"
    coder:
      model: "anthropic/claude-sonnet-5"
```

The agent then routes work implicitly — a skill or system prompt can say "delegate implementation with `persona: coder`" — while **which model a persona maps to remains entirely under operator control**.

## Motivation and design

Teams running Hermes as a shared agent want "planner on a frontier model, workers on cheaper ones" steered by skills/prompts. Two prior attempts exist:

- #52077 asked for free-form per-task profiles (model + prompt + tools chosen by the caller)
- #78522 adds a raw per-call `model` string parameter

Both give the model itself authority over arbitrary model/provider strings — a legitimate cost-control and policy concern. This PR takes the middle ground: the model only ever names a persona; the name→model mapping lives in config.yaml with the operator. Unknown or malformed persona names degrade to the base delegation config with a logged warning, following the existing `_normalize_role` silent-degrade pattern, so a bad lookup never breaks the delegation.

Implementation-wise the overlay is applied to the delegation config dict immediately before `_resolve_delegation_credentials`, so persona resolution reuses the existing credential-resolution path end to end (direct base_url endpoints, provider bundles, api_mode detection) with no new resolution logic. Net diff: +172/−1.

## Note on #52077's closure

The sweeper closed #52077 citing a standing `delegation-model-routing` policy and a contract comment at `tools/delegate_tool.py:3296`. As far as we can tell, neither exists: the string `delegation-model-routing` appears nowhere in the repository, `git log -S` finds no commit that ever added or removed it, and the referenced line is unrelated code. If there is such a policy somewhere non-public, happy to adapt this PR to it — but flagging in case the sweeper verdict deserves a second look.

## Testing

- 9 new tests in `TestPersonaOverlay` (tests/tools/test_delegate.py): overlay semantics, partial overrides, orchestration-limit protection, unknown/malformed/unconfigured degrade paths, integration through `_resolve_delegation_credentials`, and schema exposure.
- Full `tests/tools/test_delegate.py`: **75 passed**.

## Docs

- `cli-config.yaml.example`: documented `delegation.personas` in the delegation block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
