### PR TITLE
browser_exec: pin the browser-use CLI pipes to UTF-8

### DIFF
--- a/tests/tools/test_browser_use_cli.py
+++ b/tests/tools/test_browser_use_cli.py
@@ -835,6 +835,31 @@ class TestBrowserExec:
         result = json.loads(bu_cli.browser_exec("print(1)", timeout_s=1))
         assert "timed out" in result["error"]
 
+    def test_pipes_are_pinned_to_utf8(self, tmp_path, monkeypatch):
+        """text=True alone decodes with the locale codec — on Windows the ANSI
+        code page, which mangles or rejects the CLI's UTF-8 output."""
+        cli = _fake_cli(tmp_path, "cat > /dev/null\n")
+        monkeypatch.setattr(bu_cli, "_find_cli", lambda: [cli])
+        seen = {}
+        real_run = bu_cli.subprocess.run
+
+        def _capture(*args, **kwargs):
+            seen.update(kwargs)
+            return real_run(*args, **kwargs)
+
+        monkeypatch.setattr(bu_cli.subprocess, "run", _capture)
+        bu_cli.browser_exec("print(1)")
+        assert seen.get("encoding") == "utf-8"
+        assert seen.get("errors") == "replace"
+
+    def test_non_ascii_output_round_trips(self, tmp_path, monkeypatch):
+        """A page title with non-ASCII characters must survive the pipe."""
+        cli = _fake_cli(tmp_path, "cat > /dev/null\nprintf 'P\\303\\241gina \\342\\206\\222 caf\\303\\251\\n'\n")
+        monkeypatch.setattr(bu_cli, "_find_cli", lambda: [cli])
+        result = json.loads(bu_cli.browser_exec("print(1)"))
+        assert result["success"] is True
+        assert "Página → café" in result["output"]
+
 
 class TestFindCliManagedBin:
     """MANAGED-FIRST: _find_cli probes $HERMES_HOME/bin before PATH and

--- a/tools/browser_use_cli.py
+++ b/tools/browser_use_cli.py
@@ -634,6 +634,15 @@ def browser_exec(
             input=code,
             capture_output=True,
             text=True,
+            # text=True alone decodes with locale.getencoding(), which on
+            # Windows is the ANSI code page (cp1252/cp932/…), never UTF-8.
+            # The CLI inherits PYTHONIOENCODING/PYTHONUTF8 from
+            # hermes_bootstrap and emits UTF-8, so the pair must be pinned
+            # here too — otherwise a page title or log line with a non-ASCII
+            # character comes back as mojibake, or raises UnicodeDecodeError,
+            # which is a ValueError and so escapes the OSError handler below.
+            encoding="utf-8",
+            errors="replace",
             timeout=timeout,
             env=env,
             **popen_extra,


### PR DESCRIPTION
Fixes #87152

## Problem

`browser_exec` in `tools/browser_use_cli.py` runs the CLI with `text=True` and no `encoding`:

```python
proc = subprocess.run(
    cmd,
    input=code,
    capture_output=True,
    text=True,
    timeout=timeout,
    env=env,
    **popen_extra,
)
```

`text=True` on its own decodes the child's stdout/stderr with `locale.getencoding()`. On Windows that is the ANSI code page — cp1252 on US/Western installs, cp932/cp936/cp949 on CJK ones — never UTF-8.

The child, meanwhile, **is** emitting UTF-8: `hermes_bootstrap.py` sets `PYTHONUTF8=1` and `PYTHONIOENCODING=utf-8` in `os.environ` on Windows, and the browser-use CLI inherits them. So the two ends of the pipe disagree by construction.

What that produces, verified locally:

```
sample = "Página — Ferramenta ✓".encode("utf-8")
  cp1252   -> decoded (mojibake, no crash)
  cp932    -> UnicodeDecodeError: illegal multibyte sequence at byte 10
  cp949    -> UnicodeDecodeError: illegal multibyte sequence at byte 8
  cp936    -> UnicodeDecodeError: illegal multibyte sequence at byte 10
  cp1252 b'\x81' -> UnicodeDecodeError (character maps to <undefined>)
  cp1252 b'\x8d' -> UnicodeDecodeError (character maps to <undefined>)
  cp1252 b'\x8f' -> UnicodeDecodeError (character maps to <undefined>)
  cp1252 b'\x90' -> UnicodeDecodeError (character maps to <undefined>)
  cp1252 b'\x9d' -> UnicodeDecodeError (character maps to <undefined>)
```

So a page title, URL, or log line with a non-ASCII character either comes back to the model as mojibake, or blows up. And the blow-up is not contained — the call site only handles `subprocess.TimeoutExpired` and `OSError`:

```
UnicodeDecodeError is a ValueError: True
UnicodeDecodeError is an OSError  : False
```

`UnicodeDecodeError` is a `ValueError`, so it escapes `browser_exec` entirely rather than being turned into a `tool_error(...)` the agent can recover from.

## Fix

Pin both ends to UTF-8:

```python
encoding="utf-8",
errors="replace",
```

This is exactly what the `uv tool install browser-use` call at the top of this same file already does (line ~353), so it brings the two `subprocess.run` calls in the module into agreement.

`errors="replace"` also means the decode can no longer raise at all, so the surrounding exception handling does not need widening.

It fixes the input direction too: `input=code` is encoded with the same codec, so a script containing a non-ASCII selector or string no longer risks `UnicodeEncodeError` on cp1252.

## Tests

Two tests added to `tests/tools/test_browser_use_cli.py::TestBrowserExec`:

- `test_pipes_are_pinned_to_utf8` — asserts the kwargs actually handed to `subprocess.run`. Deterministic on every platform. On `main` it fails with `assert None == 'utf-8'`.
- `test_non_ascii_output_round_trips` — a fake CLI emitting `Página → café` must survive the pipe. This one only bites on Windows CI, since POSIX locales are already UTF-8.

I could only install a subset of the project deps locally, so 8 tests in this file fail in my environment. That set is **identical before and after the change** (baseline `8 failed, 84 passed` → with this PR `8 failed, 86 passed`, the two extra passes being the new tests), so full CI is the real check.

## Not addressed here

The same `text=True`-without-`encoding` pattern appears at 7 other call sites, which I left alone to keep this focused on the filed issue:

```
tools/code_execution_tool.py:1894
tools/computer_use/cua_backend.py:453
tools/computer_use/cua_backend.py:477
tools/self_repo_guard.py:569
tools/transcription_tools.py:1610
tools/transcription_tools.py:2030
tools/transcription_tools.py:2040
```

Happy to fold them in here or open a follow-up, whichever you prefer.