### PR TITLE
fix(telegram): rebind TypeHandler after lazy dependency install

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -416,7 +416,7 @@ def check_telegram_requirements() -> bool:
     global TELEGRAM_AVAILABLE, Update, Bot, Message, InlineKeyboardButton
     global InlineKeyboardMarkup, LinkPreviewOptions, Application
     global CommandHandler, CallbackQueryHandler, TelegramMessageHandler
-    global ContextTypes, filters, ParseMode, ChatType, HTTPXRequest
+    global ContextTypes, filters, ParseMode, ChatType, HTTPXRequest, TypeHandler
     if TELEGRAM_AVAILABLE:
         return True
     try:
@@ -434,7 +434,7 @@ def check_telegram_requirements() -> bool:
         from telegram.ext import (
             Application as _App, CommandHandler as _CH,
             CallbackQueryHandler as _CQH,
-            MessageHandler as _MH,
+            MessageHandler as _MH, TypeHandler as _TH,
             ContextTypes as _CT, filters as _filters,
         )
         from telegram.constants import ParseMode as _PM, ChatType as _CtT
@@ -451,6 +451,7 @@ def check_telegram_requirements() -> bool:
     CommandHandler = _CH
     CallbackQueryHandler = _CQH
     TelegramMessageHandler = _MH
+    TypeHandler = _TH
     ContextTypes = _CT
     filters = _filters
     ParseMode = _PM


### PR DESCRIPTION
## Summary

`check_telegram_requirements()` — the lazy dependency-reinstall path — rebinds every module-level PTB alias after installing python-telegram-bot, **except `TypeHandler`**.

If the adapter module is first imported while PTB is unavailable, every alias falls back to `typing.Any` (adapter.py:256-270). After the lazy install completes, the rebind misses `TypeHandler`, so it stays `typing.Any`. `_register_handlers()` then calls `TypeHandler(Update, self._on_platform_update)` (adapter.py:4193), raising `TypeError: Any cannot be instantiated` — and `connect()` fails on every attempt forever, because the poisoned module cache never self-heals.

## Real-world incident

- 2026-08-14: a gateway restart (SIGTERM) raced with a dependency reinstall; the module imported with PTB missing, the lazy install ran, and the rebind missed `TypeHandler`.
- Result: ~600 failed reconnect attempts over ~50 hours, each logging `[Telegram] Failed to connect to Telegram: Any cannot be instantiated`, until the process was restarted (after which Telegram connected immediately).

## Fix

Add `TypeHandler` to the `global` declaration, the re-import block, and the rebind inside `check_telegram_requirements()`.

## Sibling check

Audited the other lazy-dep users (`discord`, `dingtalk`, `feishu`, `matrix`, `wecom`, `teams`, `slack`): no other adapter's rebind omits a fallback symbol (discord's rebind covers `DiscordMessage` and `Intents`).

## Verification

- Simulated the poisoned state (`TELEGRAM_AVAILABLE=False`, `TypeHandler=typing.Any`, `lazy_ensure` stubbed): `check_telegram_requirements()` returns `True` and `TypeHandler` is rebound to `telegram.ext._handlers.typehandler.TypeHandler`.
- Live gateway reconnected in polling mode after a process restart.