### PR TITLE
fix(relay): stop importing gateway.run from non-gateway hosts (#87183)

### DIFF
--- a/agent/relay_runtime.py
+++ b/agent/relay_runtime.py
@@ -171,14 +171,21 @@ def _segments_config() -> dict[str, Any]:
                 on_compaction = False
                 max_turns = 0
                 try:
-                    from gateway.run import _load_gateway_config  # late import
+                    # Do NOT import gateway.run from a non-gateway host: its
+                    # module top level sets os.environ["_HERMES_GATEWAY"] /
+                    # HERMES_QUIET / HERMES_EXEC_ASK — gateway-process
+                    # semantics. Dragged into a CLI/TUI/desktop/cron process,
+                    # HERMES_EXEC_ASK=1 flips tools/approval.py onto the
+                    # gateway approval path with no notify_cb, so dangerous
+                    # commands hang forever in pending_approval (#87183).
+                    # read_raw_config() + managed overlay reproduce
+                    # gateway.run._load_gateway_config() for this read without
+                    # the import side effects.
+                    from hermes_cli import managed_scope
+                    from hermes_cli.config import read_raw_config
 
-                    telemetry = (
-                        (_load_gateway_config().get("gateway") or {}).get(
-                            "telemetry"
-                        )
-                        or {}
-                    )
+                    raw = managed_scope.apply_managed_overlay(read_raw_config())
+                    telemetry = ((raw.get("gateway") or {}).get("telemetry")) or {}
                     segments = telemetry.get("session_segments") or {}
                     on_compaction = bool(segments.get("on_compaction", False))
                     try:

--- a/tests/agent/test_relay_session_segments.py
+++ b/tests/agent/test_relay_session_segments.py
@@ -121,8 +121,11 @@ def _default_config(monkeypatch):
 
 
 def _set_segments(monkeypatch, *, on_compaction=False, max_turns=0):
+    # _segments_config() reads via read_raw_config() (+ managed overlay)
+    # instead of importing gateway.run (whose module top-level setenv
+    # pollutes the calling process's environment, see #87183).
     monkeypatch.setattr(
-        "gateway.run._load_gateway_config",
+        "hermes_cli.config.read_raw_config",
         lambda: {
             "gateway": {
                 "telemetry": {

--- a/tests/agent/test_relay_session_segments.py
+++ b/tests/agent/test_relay_session_segments.py
@@ -17,7 +17,11 @@ consumed at the next begin_turn before the turn scope pushes.
 
 from __future__ import annotations
 
+import os
+import subprocess
+import sys
 import threading
+from pathlib import Path
 from typing import Any
 
 import pytest
@@ -27,6 +31,18 @@ from agent.relay_runtime import (
     RelayRuntime,
     RelaySessionCoordinator,
 )
+
+
+def _run_isolated(code: str) -> subprocess.CompletedProcess[str]:
+    """Run a Python snippet in the repo root (not tests/) in a fresh process."""
+    repo_root = Path(__file__).parent.parent.parent
+    return subprocess.run(
+        [sys.executable, "-c", code],
+        capture_output=True,
+        text=True,
+        cwd=str(repo_root),
+        env={**os.environ, "PYTHONDONTWRITEBYTECODE": "1"},
+    )
 
 
 class _ScopeHandle:
@@ -115,7 +131,7 @@ def _fast_scope_timeout(monkeypatch):
 def _default_config(monkeypatch):
     """No config on disk by default; tests override _segments_config directly."""
     monkeypatch.setattr(
-        "hermes_cli.config.read_raw_config", lambda: {}, raising=False
+        "hermes_cli.config.read_raw_config", lambda: {}
     )
     relay_runtime._reset_segments_config_for_tests()
 
@@ -136,7 +152,6 @@ def _set_segments(monkeypatch, *, on_compaction=False, max_turns=0):
                 }
             }
         },
-        raising=False,
     )
     relay_runtime._reset_segments_config_for_tests()
 
@@ -411,3 +426,41 @@ class TestRotationSafety:
         assert child_push["parent"] is new_handle, (
             "post-rotation children must parent to the new segment handle"
         )
+
+
+class TestGatewayRunStaysUnimported:
+    """Guard against re-importing gateway.run from a non-gateway host.
+
+    relay_runtime._segments_config() must NEVER trigger ``gateway.run`` —
+    its module top level sets _HERMES_GATEWAY / HERMES_QUIET / HERMES_EXEC_ASK,
+    which flips a CLI/TUI/desktop/cron process onto the gateway path and hangs
+    dangerous commands in pending_approval (#87183). A plain monkeypatch of
+    read_raw_config wouldn't catch a future refactor that adds the import, so
+    this runs the real path in a fresh subprocess and asserts gateway.run never
+    enters sys.modules.
+    """
+
+    def test_relay_runtime_never_imports_gateway_run(self) -> None:
+        result = _run_isolated(
+            """
+import sys
+
+import agent.relay_runtime as rr
+
+# _segments_config() is the only relay path that used to import gateway.run.
+rr._segments_config()
+rr._segments_config()  # cached path too
+
+if "gateway.run" in sys.modules:
+    print("FAIL: gateway.run was imported by a non-gateway host")
+    sys.exit(1)
+print("PASS: gateway.run stays out of sys.modules")
+sys.exit(0)
+"""
+        )
+        assert result.returncode == 0, (
+            f"relay_runtime imported gateway.run:\\n"
+            f"stdout: {result.stdout}\\n"
+            f"stderr: {result.stderr}"
+        )
+        assert "PASS" in result.stdout

--- a/tests/agent/test_relay_session_segments.py
+++ b/tests/agent/test_relay_session_segments.py
@@ -115,7 +115,7 @@ def _fast_scope_timeout(monkeypatch):
 def _default_config(monkeypatch):
     """No config on disk by default; tests override _segments_config directly."""
     monkeypatch.setattr(
-        "gateway.run._load_gateway_config", lambda: {}, raising=False
+        "hermes_cli.config.read_raw_config", lambda: {}, raising=False
     )
     relay_runtime._reset_segments_config_for_tests()
 


### PR DESCRIPTION
Resolves #87183

## Problem

In CLI sessions, dangerous-command approvals return `{"status": "pending_approval"}` and the approval panel never renders — commands hang forever with no listener. Root cause: `agent/relay_runtime.py::_segments_config()` late-imported `gateway.run`, whose **module top level** sets `HERMES_EXEC_ASK=1` (plus `_HERMES_GATEWAY`, `HERMES_QUIET`) into the **calling process's** `os.environ`. `tools/approval.py:3344` then routes every approval onto the gateway async path, where the CLI has no `notify_cb` — so the request silently queues.

Reproduces on plain `hermes` CLI (macOS, main as of 2026-08-16). Restarting the terminal does not help: every session re-imports `gateway.run` on its first relay turn, and the poisoned env var is then persisted into `hermes-snap-*.sh` terminal snapshots, self-replicating.

## Fix

Read the gateway telemetry config without importing `gateway.run`:

```python
from hermes_cli import managed_scope
from hermes_cli.config import read_raw_config
raw = managed_scope.apply_managed_overlay(read_raw_config())
telemetry = ((raw.get("gateway") or {}).get("telemetry")) or {}
```

`read_raw_config()` + managed overlay reproduce `gateway.run._load_gateway_config()` for this read with no import side effects. The test fixture in `test_relay_session_segments.py` is pointed at the new read path.

## Verification

- `_segments_config()` now leaves `gateway.run` out of `sys.modules` and writes nothing to the environment.
- After the change, CLI dangerous-command approvals route back to the interactive path and the panel renders normally (verified on the reporter's machine).
- `tests/agent/test_relay_session_segments.py`: 12 passed.

## Related

Same env-leak family: #83626, #86878, #63183, #62905.
