### PR TITLE
feat(delegation): operator-controlled routing tiers

### DIFF
--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1839,6 +1839,15 @@ DEFAULT_CONFIG = {
         # Flip to true only if you trust delegated work to run dangerous cmds
         # without human review (cron pipelines, batch automation, etc.).
         "subagent_auto_approve": False,
+        # Operator-controlled model routing. The model may select only a tier
+        # name exposed by delegate_task's dynamic schema; provider/model and
+        # credentials remain config-owned. Each tier overlays the global route.
+        # ``models`` is accepted for forward-compatible ordered candidates;
+        # this release selects its first non-empty entry deterministically.
+        "routing": {
+            "default_tier": "",
+            "tiers": {},
+        },
     },
 
     # Ephemeral prefill messages file — JSON list of {role, content} dicts

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -532,6 +532,10 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "nemotron-3-ultra-free",
     ],
     "opencode-go": [
+        "gpt-5.6-luna",
+        "grok-4.5",
+        "hy3",
+        "hy3-preview",
         "kimi-k3",
         "kimi-k2.7-code",
         "kimi-k2.6",
@@ -552,6 +556,7 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "qwen3.7-plus",
         "qwen3.6-plus",
         "qwen3.5-plus",
+        "qwen3.8-max",
     ],
     "kilocode": [
         "anthropic/claude-opus-4.6",

--- a/run_agent.py
+++ b/run_agent.py
@@ -8192,6 +8192,7 @@ class AIAgent:
             tasks=_strip_model_hidden_task_fields(function_args.get("tasks")),
             max_iterations=function_args.get("max_iterations"),
             role=function_args.get("role"),
+            tier=function_args.get("tier"),
             background=(not _is_subagent),
             action=function_args.get("action"),
             subagent_id=function_args.get("subagent_id"),

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -30,6 +30,7 @@ from tools.delegate_tool import (
     _strip_blocked_tools,
     _resolve_child_credential_pool,
     _resolve_delegation_credentials,
+    _resolve_task_route,
 )
 from hermes_state import SessionDB
 
@@ -81,6 +82,216 @@ class TestDelegateRequirements(unittest.TestCase):
         self.assertNotIn("acp_command", props["tasks"]["items"]["properties"])
         self.assertNotIn("acp_args", props["tasks"]["items"]["properties"])
         self.assertNotIn("maxItems", props["tasks"])  # removed — limit is now runtime-configurable
+        self.assertIn("tier", props)
+        self.assertIn("tier", props["tasks"]["items"]["properties"])
+
+    def test_dynamic_tier_enum_is_operator_controlled(self):
+        from tools.delegate_tool import _build_dynamic_schema_overrides
+
+        cfg = {
+            "routing": {
+                "default_tier": "simple",
+                "tiers": {"simple": {}, "hard": {}},
+            }
+        }
+        with patch("tools.delegate_tool._load_config", return_value=cfg):
+            params = _build_dynamic_schema_overrides()["parameters"]
+
+        self.assertEqual(params["properties"]["tier"]["enum"], ["simple", "hard"])
+        self.assertEqual(
+            params["properties"]["tasks"]["items"]["properties"]["tier"]["enum"],
+            ["simple", "hard"],
+        )
+
+    def test_dynamic_tier_enum_never_mutates_static_schema(self):
+        from tools.delegate_tool import _build_dynamic_schema_overrides
+
+        cfg = {"routing": {"tiers": {"simple": {}, "hard": {}}}}
+        with patch("tools.delegate_tool._load_config", return_value=cfg):
+            _build_dynamic_schema_overrides()
+        self.assertNotIn(
+            "enum",
+            DELEGATE_TASK_SCHEMA["parameters"]["properties"]["tier"],
+        )
+        self.assertNotIn(
+            "enum",
+            DELEGATE_TASK_SCHEMA["parameters"]["properties"]["tasks"]["items"]["properties"]["tier"],
+        )
+
+
+class TestDelegationTierRouting(unittest.TestCase):
+    @staticmethod
+    def _passthrough(cfg, _parent):
+        return {
+            "model": cfg.get("model"),
+            "provider": cfg.get("provider"),
+            "base_url": cfg.get("base_url"),
+            "api_key": cfg.get("api_key"),
+            "api_mode": cfg.get("api_mode"),
+        }
+
+    def test_no_routing_uses_global_route(self):
+        cfg = {"provider": "deepseek", "model": "flash"}
+        with patch(
+            "tools.delegate_tool._resolve_delegation_credentials",
+            side_effect=self._passthrough,
+        ):
+            route = _resolve_task_route(cfg, None, _make_mock_parent())
+        self.assertEqual((route["provider"], route["model"]), ("deepseek", "flash"))
+
+    def test_default_tier_overlays_global_route_and_accepts_models_list(self):
+        cfg = {
+            "provider": "deepseek",
+            "model": "flash",
+            "routing": {
+                "default_tier": "moderate",
+                "tiers": {
+                    "moderate": {"provider": "opencode-go", "models": ["kimi-k3"]}
+                },
+            },
+        }
+        with patch(
+            "tools.delegate_tool._resolve_delegation_credentials",
+            side_effect=self._passthrough,
+        ):
+            route = _resolve_task_route(cfg, None, _make_mock_parent())
+        self.assertEqual((route["provider"], route["model"]), ("opencode-go", "kimi-k3"))
+
+    def test_explicit_tier_beats_default(self):
+        cfg = {
+            "routing": {
+                "default_tier": "simple",
+                "tiers": {
+                    "simple": {"provider": "deepseek", "model": "flash"},
+                    "hard": {
+                        "provider": "openai-codex",
+                        "model": "gpt-5.6-sol",
+                        "reasoning_effort": "high",
+                    },
+                },
+            }
+        }
+        with patch(
+            "tools.delegate_tool._resolve_delegation_credentials",
+            side_effect=self._passthrough,
+        ):
+            route = _resolve_task_route(cfg, "hard", _make_mock_parent())
+        self.assertEqual(
+            (route["provider"], route["model"]),
+            ("openai-codex", "gpt-5.6-sol"),
+        )
+        self.assertEqual(route["reasoning_effort"], "high")
+
+    def test_unknown_tier_is_rejected(self):
+        cfg = {"routing": {"tiers": {"simple": {}}}}
+        with self.assertRaisesRegex(ValueError, "available tiers: simple"):
+            _resolve_task_route(cfg, "elite", _make_mock_parent())
+
+    def test_non_dict_tier_entries_are_filtered(self):
+        from tools.delegate_tool import _configured_routing_tiers
+
+        cfg = {
+            "routing": {
+                "tiers": {
+                    "simple": {"provider": "deepseek", "model": "flash"},
+                    "broken": "not-a-dict",
+                    "": {},
+                    "blank-name": None,
+                }
+            }
+        }
+        self.assertEqual(_configured_routing_tiers(cfg), {"simple": cfg["routing"]["tiers"]["simple"]})
+
+    def test_reasoning_effort_false_preserved_through_tier(self):
+        cfg = {
+            "provider": "deepseek",
+            "model": "flash",
+            "routing": {
+                "default_tier": "fast",
+                "tiers": {"fast": {"model": "flash", "reasoning_effort": False}},
+            },
+        }
+        with patch(
+            "tools.delegate_tool._resolve_delegation_credentials",
+            side_effect=self._passthrough,
+        ):
+            route = _resolve_task_route(cfg, None, _make_mock_parent())
+        self.assertIs(route["reasoning_effort"], False)
+
+    def test_empty_models_list_falls_back_to_global_model(self):
+        cfg = {
+            "provider": "deepseek",
+            "model": "flash",
+            "routing": {
+                "default_tier": "placeholder",
+                "tiers": {"placeholder": {"provider": "deepseek", "models": []}},
+            },
+        }
+        with patch(
+            "tools.delegate_tool._resolve_delegation_credentials",
+            side_effect=self._passthrough,
+        ):
+            route = _resolve_task_route(cfg, None, _make_mock_parent())
+        self.assertEqual((route["provider"], route["model"]), ("deepseek", "flash"))
+
+    def test_batch_resolves_each_task_tier_independently(self):
+        cfg = {
+            "max_iterations": 5,
+            "routing": {
+                "default_tier": "simple",
+                "tiers": {
+                    "simple": {"provider": "opencode-zen", "model": "big-pickle"},
+                    "hard": {"provider": "openai-codex", "model": "gpt-5.6-sol"},
+                },
+            },
+        }
+        built = []
+
+        def capture_child(**kwargs):
+            child = MagicMock()
+            child._delegate_role = "leaf"
+            child._subagent_id = f"child-{len(built)}"
+            built.append(kwargs)
+            return child
+
+        def completed(task_index, goal, child, parent_agent, **kwargs):
+            return {
+                "task_index": task_index,
+                "status": "completed",
+                "summary": goal,
+                "api_calls": 1,
+                "duration_seconds": 0.01,
+                "model": built[task_index]["model"],
+                "exit_reason": "completed",
+            }
+
+        with (
+            patch("tools.delegate_tool._load_config", return_value=cfg),
+            patch(
+                "tools.delegate_tool._resolve_delegation_credentials",
+                side_effect=self._passthrough,
+            ),
+            patch(
+                "tools.delegate_tool._build_child_preserving_parent_tools",
+                side_effect=capture_child,
+            ),
+            patch("tools.delegate_tool._run_single_child", side_effect=completed),
+            patch("tools.delegate_tool.create_live_transcripts", create=True),
+        ):
+            result = delegate_task(
+                tasks=[
+                    {"goal": "Perform a simple inventory", "tier": "simple"},
+                    {"goal": "Perform a difficult architecture review", "tier": "hard"},
+                ],
+                parent_agent=_make_mock_parent(depth=0),
+            )
+
+        parsed = json.loads(result)
+        self.assertNotIn("error", parsed)
+        self.assertEqual(
+            [(item["override_provider"], item["model"]) for item in built],
+            [("opencode-zen", "big-pickle"), ("openai-codex", "gpt-5.6-sol")],
+        )
 
     def test_top_level_description_compact_and_complete(self):
         """The top-level description must stay compact while keeping every
@@ -1383,6 +1594,37 @@ class TestDispatchDelegateTask(unittest.TestCase):
         self.assertEqual(captured["goal"], "test")
         self.assertNotIn("acp_command", captured["tasks"][0])
         self.assertNotIn("acp_args", captured["tasks"][0])
+
+    def test_tier_is_forwarded_from_live_dispatch_path(self):
+        """The model-facing dispatch must forward the tier parameter.
+
+        Regression: the schema gained 'tier' but run_agent._dispatch_delegate_task
+        did not forward it, so explicit tiers were silently dropped and every
+        child resolved through the default route.
+        """
+        import run_agent
+
+        captured = {}
+
+        def fake_delegate_task(**kwargs):
+            captured.update(kwargs)
+            return "{}"
+
+        parent = _make_mock_parent(depth=0)
+        with patch("tools.delegate_tool.delegate_task", fake_delegate_task):
+            run_agent.AIAgent._dispatch_delegate_task(
+                parent,
+                {
+                    "goal": "test",
+                    "tier": "hard",
+                    "tasks": [
+                        {"goal": "nested", "tier": "simple"},
+                    ],
+                },
+            )
+
+        self.assertEqual(captured["tier"], "hard")
+        self.assertEqual(captured["tasks"][0]["tier"], "simple")
 
 class TestDelegateEventEnum(unittest.TestCase):
     """Tests for DelegateEvent enum and back-compat aliases."""

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -1479,6 +1479,7 @@ def _build_child_agent(
     override_api_mode: Optional[str] = None,
     override_request_overrides: Optional[Dict[str, Any]] = None,
     override_max_tokens: Optional[int] = None,
+    override_reasoning_effort: Any = None,
     # ACP transport overrides from trusted delegation config.
     override_acp_command: Optional[str] = None,
     override_acp_args: Optional[List[str]] = None,
@@ -1713,7 +1714,11 @@ def _build_child_agent(
         # Keep the raw value — ``str(x or "")`` would coerce a YAML boolean
         # False (``reasoning_effort: false``) to "" and inherit the parent
         # instead of disabling thinking for children.
-        delegation_effort = delegation_cfg.get("reasoning_effort")
+        delegation_effort = (
+            override_reasoning_effort
+            if override_reasoning_effort is not None
+            else delegation_cfg.get("reasoning_effort")
+        )
         if delegation_effort or delegation_effort is False:
             from hermes_constants import parse_reasoning_effort
 
@@ -3431,6 +3436,7 @@ def delegate_task(
     tasks: Optional[List[Dict[str, Any]]] = None,
     max_iterations: Optional[int] = None,
     role: Optional[str] = None,
+    tier: Optional[str] = None,
     background: Optional[bool] = None,
     output_schema: Optional[Dict[str, Any]] = None,
     action: Optional[str] = None,
@@ -3525,16 +3531,6 @@ def delegate_task(
         )
     effective_max_iter = default_max_iter
 
-    # Resolve delegation credentials (provider:model pair).
-    # When delegation.provider is configured, this resolves the full credential
-    # bundle (base_url, api_key, api_mode) via the same runtime provider system
-    # used by CLI/gateway startup.  When unconfigured, returns None values so
-    # children inherit from the parent.
-    try:
-        creds = _resolve_delegation_credentials(cfg, parent_agent)
-    except ValueError as exc:
-        return tool_error(str(exc))
-
     # Normalize to task list
     max_children = _get_max_concurrent_children()
     recovered_tasks, tasks_error = _recover_tasks_from_json_string(tasks)
@@ -3561,7 +3557,12 @@ def delegate_task(
             )
         task_list = tasks
     elif goal and isinstance(goal, str) and goal.strip():
-        single_task: Dict[str, Any] = {"goal": goal, "context": context, "role": top_role}
+        single_task: Dict[str, Any] = {
+            "goal": goal,
+            "context": context,
+            "role": top_role,
+            "tier": tier,
+        }
         if output_schema is not None:
             single_task["output_schema"] = output_schema
         task_list = [single_task]
@@ -3589,6 +3590,24 @@ def delegate_task(
         batch_error = _validate_batch_tasks(task_list)
         if batch_error:
             return tool_error(batch_error)
+
+    # Resolve every task independently so a batch can mix operator-defined
+    # routing tiers. The model chooses only a tier NAME; provider, model,
+    # endpoint and credentials remain entirely config-controlled.
+    task_routes: List[Dict[str, Any]] = []
+    for i, task in enumerate(task_list):
+        requested = task.get("tier") or tier
+        try:
+            task_routes.append(
+                _resolve_task_route(cfg, requested, parent_agent)
+            )
+        except ValueError as exc:
+            prefix = (
+                f"Task {i} routing tier {requested!r} invalid"
+                if requested
+                else f"Task {i} delegation route invalid"
+            )
+            return tool_error(f"{prefix}: {exc}")
 
     # T1-24: coerce/validate optional per-task output_schema up front so a
     # malformed schema fails the whole call loudly instead of spawning
@@ -3668,6 +3687,7 @@ def delegate_task(
             from tools.delegation_output_schema import append_output_contract
 
             _child_context = append_output_contract(_child_context, _task_schema)
+        creds = task_routes[i]
         child = _build_child_preserving_parent_tools(
             task_index=i,
             goal=t["goal"],
@@ -3685,6 +3705,7 @@ def delegate_task(
             override_api_mode=creds["api_mode"],
             override_request_overrides=creds.get("request_overrides"),
             override_max_tokens=creds.get("max_output_tokens"),
+            override_reasoning_effort=creds.get("reasoning_effort"),
             override_acp_command=creds.get("command"),
             override_acp_args=creds.get("args"),
             role=effective_role,
@@ -4236,6 +4257,59 @@ def _resolve_child_credential_pool(
     return None
 
 
+def _configured_routing_tiers(cfg: dict) -> Dict[str, Dict[str, Any]]:
+    """Return valid operator-defined delegation tier overlays."""
+    routing = cfg.get("routing") if isinstance(cfg, dict) else None
+    raw_tiers = routing.get("tiers") if isinstance(routing, dict) else None
+    if not isinstance(raw_tiers, dict):
+        return {}
+    return {
+        str(name).strip(): value
+        for name, value in raw_tiers.items()
+        if str(name).strip() and isinstance(value, dict)
+    }
+
+
+def _resolve_task_route(
+    cfg: dict,
+    requested_tier: Optional[str],
+    parent_agent,
+) -> dict:
+    """Resolve one task through an operator-controlled routing tier.
+
+    Precedence is explicit tier, routing.default_tier, then the global
+    delegation route. Tier dictionaries overlay the global route and accept
+    either ``model`` or a ``models`` list; list selection is deterministic.
+    """
+    routing = cfg.get("routing") if isinstance(cfg, dict) else None
+    tiers = _configured_routing_tiers(cfg)
+    tier_name = str(requested_tier or "").strip()
+    if not tier_name and isinstance(routing, dict):
+        tier_name = str(routing.get("default_tier") or "").strip()
+    if not tier_name:
+        return _resolve_delegation_credentials(cfg, parent_agent)
+    if tier_name not in tiers:
+        available = ", ".join(tiers) if tiers else "none configured"
+        raise ValueError(
+            f"unknown tier {tier_name!r}; available tiers: {available}"
+        )
+
+    route_cfg = dict(cfg)
+    route_cfg.pop("routing", None)
+    tier_cfg = dict(tiers[tier_name])
+    models = tier_cfg.pop("models", None)
+    if not str(tier_cfg.get("model") or "").strip() and isinstance(models, list):
+        selected = next(
+            (str(item).strip() for item in models if str(item).strip()), ""
+        )
+        if selected:
+            tier_cfg["model"] = selected
+    route_cfg.update(tier_cfg)
+    resolved = _resolve_delegation_credentials(route_cfg, parent_agent)
+    resolved["reasoning_effort"] = route_cfg.get("reasoning_effort")
+    return resolved
+
+
 def _resolve_delegation_credentials(cfg: dict, parent_agent) -> dict:
     """Resolve credentials for subagent delegation.
 
@@ -4529,6 +4603,33 @@ def _build_dynamic_schema_overrides() -> dict:
     overrides_params["properties"]["tasks"]["description"] = _build_tasks_param_description()
     overrides_params["properties"]["role"]["description"] = _build_role_param_description()
 
+    tiers = list(_configured_routing_tiers(_load_config()))
+    tier_description = (
+        "Operator-controlled routing tier. Available tiers: "
+        + ", ".join(tiers)
+        + ". Omit to use delegation.routing.default_tier."
+        if tiers
+        else "No operator-controlled routing tiers are currently configured."
+    )
+    # The nested static objects need copying before dynamic enum injection.
+    tasks_property = dict(overrides_params["properties"]["tasks"])
+    tasks_items = dict(tasks_property["items"])
+    tasks_item_properties = {
+        key: dict(value) for key, value in tasks_items["properties"].items()
+    }
+    tasks_items["properties"] = tasks_item_properties
+    tasks_property["items"] = tasks_items
+    overrides_params["properties"]["tasks"] = tasks_property
+    for tier_property in (
+        overrides_params["properties"]["tier"],
+        tasks_item_properties["tier"],
+    ):
+        tier_property["description"] = tier_description
+        if tiers:
+            tier_property["enum"] = tiers
+        else:
+            tier_property.pop("enum", None)
+
     return {
         "description": _build_top_level_description(),
         "parameters": overrides_params,
@@ -4584,6 +4685,10 @@ DELEGATE_TASK_SCHEMA = {
                             "enum": ["leaf", "orchestrator"],
                             "description": "Per-task role override. See top-level 'role' for semantics.",
                         },
+                        "tier": {
+                            "type": "string",
+                            "description": "Operator-controlled routing tier for this task.",
+                        },
                         "output_schema": {
                             "type": "object",
                             "description": (
@@ -4609,6 +4714,10 @@ DELEGATE_TASK_SCHEMA = {
                 "type": "string",
                 "enum": ["leaf", "orchestrator"],
                 "description": "(rebuilt at get_definitions() time)",
+            },
+            "tier": {
+                "type": "string",
+                "description": "Operator-controlled routing tier for the single task or batch default.",
             },
             "output_schema": {
                 "type": "object",
@@ -4721,6 +4830,7 @@ registry.register(
         tasks=_strip_model_hidden_task_fields(args.get("tasks")),
         max_iterations=args.get("max_iterations"),
         role=args.get("role"),
+        tier=args.get("tier"),
         background=_model_background_value(args, kw.get("parent_agent")),
         output_schema=args.get("output_schema"),
         action=args.get("action"),

--- a/website/docs/user-guide/features/delegation.md
+++ b/website/docs/user-guide/features/delegation.md
@@ -170,6 +170,52 @@ Resolution order: `delegation.base_url` (direct endpoint) takes precedence, then
 
 Note that the pin is global: `delegate_task` has no per-task model parameter, so every child in a batch runs on the configured delegation model. For quality-sensitive subtasks that need a stronger model, either leave `delegation.model` unset for that session or hand the task to the [kanban board](kanban.md#per-task-model-override), which does support a per-task model override.
 
+### Operator-Controlled Routing Tiers
+
+For mixed-complexity workloads, operators can define named tiers. The model
+may choose only a configured tier name; it cannot supply arbitrary provider,
+model, endpoint, or credential values.
+
+```yaml
+delegation:
+  routing:
+    default_tier: simple
+    tiers:
+      simple:
+        provider: opencode-zen
+        model: big-pickle
+        reasoning_effort: low
+      moderate:
+        provider: opencode-go
+        model: deepseek-v4-flash
+        reasoning_effort: medium
+      substantial:
+        provider: opencode-go
+        model: deepseek-v4-pro
+        reasoning_effort: high
+      hard:
+        provider: openai-codex
+        model: gpt-5.6-sol
+        reasoning_effort: high
+```
+
+The available names are injected dynamically into the `delegate_task` schema:
+
+```python
+delegate_task(goal="Inventory the config", tier="simple", context="...")
+
+delegate_task(tasks=[
+    {"goal": "Inspect the logs", "tier": "moderate", "context": "..."},
+    {"goal": "Review the architecture", "tier": "hard", "context": "..."},
+])
+```
+
+An explicit per-task tier overrides the top-level `tier`; otherwise
+`routing.default_tier` is used. If no tier/default is configured, Hermes falls
+back to the global `delegation.provider` / `delegation.model` route. A tier may
+also specify `models: [...]`; the first non-empty entry is selected
+deterministically in this release.
+
 ## Inherited Tool Access
 
 `delegate_task` does not accept a model-facing `toolsets` parameter. Each subagent inherits the parent's enabled toolsets so the model cannot grant a child capabilities that the parent does not have. Configure the parent's tools before starting the conversation if delegated work needs additional capabilities.
@@ -442,6 +488,9 @@ delegation:
   # worktree_isolation: false               # Give each child its own git worktree (see Worktree Isolation above)
   # max_spawn_depth: 1                      # Tree depth (floor 1, no ceiling, default 1 = flat). Raise to 2 to allow orchestrator children to spawn leaves; 3+ for deeper trees.
   # orchestrator_enabled: true              # Disable to force all children to leaf role.
+  routing:                                # Optional operator-controlled tier routing
+    default_tier: ""
+    tiers: {}
   model: "google/gemini-3-flash-preview"             # Optional provider/model override
   provider: "openrouter"                             # Optional built-in provider
   api_mode: anthropic_messages                       # optional; auto-detected from base_url for anthropic_messages endpoints


### PR DESCRIPTION
## Summary
Adds operator-owned `delegation.routing.tiers` so `delegate_task` accepts only a `tier=` name (`simple|moderate|substantial|hard`). Provider, model, endpoint, and credentials stay in config — the model never invents them.

Also adds a small opencode-go model catalog update used on this install (gpt-5.6-luna, grok-4.5, hy3, hy3-preview, qwen3.8-max). Happy to drop that commit if you want the PR scoped to routing only.

## Why
Without this, every child inherits `delegation.provider`/`model`. Cost/quality routing has to be a hardcoded model name in the prompt (fragile) or a local fork (breaks `hermes update` ff-only).

Precedence: per-task tier > top-level tier > `routing.default_tier` > global delegation route.

## Test plan
- [x] `pytest tests/tools/test_delegate.py tests/tools/test_delegate_control_actions.py tests/tools/test_delegate_batch_validation.py tests/tools/test_delegate_output_schema.py -o addopts=` → 137 passed on this tree
- [ ] CI on this PR

## Notes
Cherry-picked from a production install that has been running these commits on top of `main`. Live gateway verified after reapply.