### PR TITLE
feat(kanban): add dedicated W3bb sales and marketing swim lane

### DIFF
--- a/agent/transports/hermes_tools_mcp_server.py
+++ b/agent/transports/hermes_tools_mcp_server.py
@@ -141,11 +141,13 @@ EXPOSED_TOOLS: tuple[str, ...] = (
     "kanban_heartbeat",
     "kanban_show",
     "kanban_list",
-    # NOTE: kanban_create / kanban_unblock / kanban_link are orchestrator-
-    # only — the kanban tool gates them on HERMES_KANBAN_TASK being unset.
+    # NOTE: kanban_create / kanban_transition / kanban_unblock / kanban_link
+    # are orchestrator-only — the kanban tool gates them on
+    # HERMES_KANBAN_TASK being unset.
     # They're exposed here for orchestrator agents running on the codex
     # runtime that need to dispatch new tasks.
     "kanban_create",
+    "kanban_transition",
     "kanban_unblock",
     "kanban_link",
 )

--- a/apps/desktop/src/plugins/kanban/api.ts
+++ b/apps/desktop/src/plugins/kanban/api.ts
@@ -15,8 +15,11 @@ import type {
   BoardMeta,
   BoardsResponse,
   KanbanBoard,
+  KanbanBoardConfig,
+  KanbanColumn,
   KanbanProfile,
   KanbanProject,
+  KanbanSwimLane,
   KanbanTask,
   KanbanTaskDetail,
   OrchestrationSettings,
@@ -138,11 +141,14 @@ export const BOARDS_KEY = ['kanban', 'boards'] as const
 export const PROFILES_KEY = ['kanban', 'profiles'] as const
 export const PROJECTS_KEY = ['kanban', 'projects'] as const
 export const ORCHESTRATION_KEY = ['kanban', 'orchestration'] as const
+export const CONFIG_KEY = ['kanban', 'config'] as const
 
 // ── reads ─────────────────────────────────────────────────────────────────────
 
 export const fetchBoard = (archived: boolean) =>
   call<KanbanBoard>(withBoard('/board', archived ? { include_archived: 'true' } : {}))
+
+export const fetchKanbanConfig = () => call<KanbanBoardConfig>('/config')
 
 export const fetchTask = (id: string) => call<KanbanTaskDetail>(withBoard(`/tasks/${id}`))
 

--- a/apps/desktop/src/plugins/kanban/board.tsx
+++ b/apps/desktop/src/plugins/kanban/board.tsx
@@ -83,7 +83,8 @@ import { BoardSwitcher } from './board-switcher'
 import { TaskDrawer } from './drawer'
 import { EMPTY_OVERRIDE, ModelOverrideField, overrideCreateFields, type TaskModelOverride } from './model-override'
 import { OrchestrationPanel } from './orchestration'
-import { columnMeta, type KanbanBoard, type KanbanColumn, type KanbanSwimLane, type KanbanTask, type TaskEstimate } from './types'
+import { partitionSwimLanes, SWIM_LANE_ORG_ID } from './swim-lanes'
+import { columnMeta, type KanbanBoard, type KanbanTask, type TaskEstimate } from './types'
 import {
   $newTaskLane,
   ago,
@@ -133,39 +134,6 @@ function moveCard(board: KanbanBoard, id: string, toStatus: string): KanbanBoard
 
 function removeCard(board: KanbanBoard, id: string): KanbanBoard {
   return { ...board, columns: board.columns.map(col => ({ ...col, tasks: col.tasks.filter(t => t.id !== id) })) }
-}
-
-const L3X_SWIM_LANE_OTHER_ID = '__other__'
-
-function partitionSwimLanes(columns: KanbanColumn[], l3xAssignee: string): KanbanSwimLane[] {
-  const l3xCols: KanbanColumn[] = []
-  const otherCols: KanbanColumn[] = []
-
-  for (const col of columns) {
-    const l3xTasks = col.tasks.filter(task => task.assignee === l3xAssignee)
-    const otherTasks = col.tasks.filter(task => task.assignee !== l3xAssignee)
-    l3xCols.push({ name: col.name, tasks: l3xTasks })
-    otherCols.push({ name: col.name, tasks: otherTasks })
-  }
-
-  const count = (cols: KanbanColumn[]) => cols.reduce((sum, col) => sum + col.tasks.length, 0)
-
-  return [
-    {
-      id: l3xAssignee,
-      label: l3xAssignee,
-      assignee: l3xAssignee,
-      task_count: count(l3xCols),
-      columns: l3xCols
-    },
-    {
-      id: L3X_SWIM_LANE_OTHER_ID,
-      label: 'Other',
-      assignee: null,
-      task_count: count(otherCols),
-      columns: otherCols
-    }
-  ]
 }
 
 // ── card ─────────────────────────────────────────────────────────────────────
@@ -1136,6 +1104,8 @@ export function KanbanBoardPage() {
 
   const l3xSwimLane = kanbanConfig?.l3x_swim_lane ?? true
   const l3xSwimLaneAssignee = kanbanConfig?.l3x_swim_lane_assignee ?? 'l3x'
+  const w3bbSwimLane = kanbanConfig?.w3bb_swim_lane ?? true
+  const w3bbSwimLaneAssignee = kanbanConfig?.w3bb_swim_lane_assignee ?? 'w3bb'
 
   const [openId, setOpenId] = useState<null | string>(null)
   const [addStatus, setAddStatus] = useState<null | string>(null)
@@ -1234,18 +1204,27 @@ export function KanbanBoardPage() {
       return null
     }
 
-    const lanes = partitionSwimLanes(filtered.columns, l3xSwimLaneAssignee)
+    const lanes = partitionSwimLanes(
+      filtered.columns,
+      l3xSwimLaneAssignee,
+      w3bbSwimLaneAssignee,
+      w3bbSwimLane
+    )
 
     if (assignee === l3xSwimLaneAssignee) {
       return lanes.filter(lane => lane.id === l3xSwimLaneAssignee)
     }
 
-    if (assignee && assignee !== l3xSwimLaneAssignee) {
-      return lanes.filter(lane => lane.id === L3X_SWIM_LANE_OTHER_ID)
+    if (assignee === w3bbSwimLaneAssignee) {
+      return lanes.filter(lane => lane.id === w3bbSwimLaneAssignee)
+    }
+
+    if (assignee && assignee !== l3xSwimLaneAssignee && assignee !== w3bbSwimLaneAssignee) {
+      return lanes.filter(lane => lane.id === SWIM_LANE_ORG_ID)
     }
 
     return lanes
-  }, [filtered, l3xSwimLane, l3xSwimLaneAssignee, assignee])
+  }, [filtered, l3xSwimLane, l3xSwimLaneAssignee, w3bbSwimLane, w3bbSwimLaneAssignee, assignee])
 
   const moveMut = useMutation({
     mutationFn: ({ id, status }: { id: string; status: string }) => patchTask(id, { status }),

--- a/apps/desktop/src/plugins/kanban/board.tsx
+++ b/apps/desktop/src/plugins/kanban/board.tsx
@@ -73,15 +73,17 @@ import {
   estimateNew,
   fetchBoard,
   fetchBoards,
+  fetchKanbanConfig,
   fetchProfiles,
   patchTask,
+  CONFIG_KEY,
   PROFILES_KEY
 } from './api'
 import { BoardSwitcher } from './board-switcher'
 import { TaskDrawer } from './drawer'
 import { EMPTY_OVERRIDE, ModelOverrideField, overrideCreateFields, type TaskModelOverride } from './model-override'
 import { OrchestrationPanel } from './orchestration'
-import { columnMeta, type KanbanBoard, type KanbanTask, type TaskEstimate } from './types'
+import { columnMeta, type KanbanBoard, type KanbanColumn, type KanbanSwimLane, type KanbanTask, type TaskEstimate } from './types'
 import {
   $newTaskLane,
   ago,
@@ -131,6 +133,39 @@ function moveCard(board: KanbanBoard, id: string, toStatus: string): KanbanBoard
 
 function removeCard(board: KanbanBoard, id: string): KanbanBoard {
   return { ...board, columns: board.columns.map(col => ({ ...col, tasks: col.tasks.filter(t => t.id !== id) })) }
+}
+
+const L3X_SWIM_LANE_OTHER_ID = '__other__'
+
+function partitionSwimLanes(columns: KanbanColumn[], l3xAssignee: string): KanbanSwimLane[] {
+  const l3xCols: KanbanColumn[] = []
+  const otherCols: KanbanColumn[] = []
+
+  for (const col of columns) {
+    const l3xTasks = col.tasks.filter(task => task.assignee === l3xAssignee)
+    const otherTasks = col.tasks.filter(task => task.assignee !== l3xAssignee)
+    l3xCols.push({ name: col.name, tasks: l3xTasks })
+    otherCols.push({ name: col.name, tasks: otherTasks })
+  }
+
+  const count = (cols: KanbanColumn[]) => cols.reduce((sum, col) => sum + col.tasks.length, 0)
+
+  return [
+    {
+      id: l3xAssignee,
+      label: l3xAssignee,
+      assignee: l3xAssignee,
+      task_count: count(l3xCols),
+      columns: l3xCols
+    },
+    {
+      id: L3X_SWIM_LANE_OTHER_ID,
+      label: 'Other',
+      assignee: null,
+      task_count: count(otherCols),
+      columns: otherCols
+    }
+  ]
 }
 
 // ── card ─────────────────────────────────────────────────────────────────────
@@ -1093,6 +1128,15 @@ export function KanbanBoardPage() {
     refetchInterval: 60_000
   })
 
+  const { data: kanbanConfig } = useQuery({
+    queryFn: fetchKanbanConfig,
+    queryKey: CONFIG_KEY,
+    staleTime: 60_000
+  })
+
+  const l3xSwimLane = kanbanConfig?.l3x_swim_lane ?? true
+  const l3xSwimLaneAssignee = kanbanConfig?.l3x_swim_lane_assignee ?? 'l3x'
+
   const [openId, setOpenId] = useState<null | string>(null)
   const [addStatus, setAddStatus] = useState<null | string>(null)
   const [settingsOpen, setSettingsOpen] = useState(false)
@@ -1184,6 +1228,24 @@ export function KanbanBoardPage() {
   }, [board, search, tenant, assignee])
 
   const total = filtered?.columns.reduce((sum, col) => sum + col.tasks.length, 0) ?? 0
+
+  const visibleSwimLanes = useMemo(() => {
+    if (!filtered || !l3xSwimLane) {
+      return null
+    }
+
+    const lanes = partitionSwimLanes(filtered.columns, l3xSwimLaneAssignee)
+
+    if (assignee === l3xSwimLaneAssignee) {
+      return lanes.filter(lane => lane.id === l3xSwimLaneAssignee)
+    }
+
+    if (assignee && assignee !== l3xSwimLaneAssignee) {
+      return lanes.filter(lane => lane.id === L3X_SWIM_LANE_OTHER_ID)
+    }
+
+    return lanes
+  }, [filtered, l3xSwimLane, l3xSwimLaneAssignee, assignee])
 
   const moveMut = useMutation({
     mutationFn: ({ id, status }: { id: string; status: string }) => patchTask(id, { status }),
@@ -1387,6 +1449,47 @@ export function KanbanBoardPage() {
           </div>
         </div>
       ) : (
+        visibleSwimLanes ? (
+          <div className="flex flex-1 flex-col gap-3 overflow-y-auto px-4 pt-1 pb-3">
+            {visibleSwimLanes.map(lane => (
+              <section
+                aria-label={`${lane.label} swim lane`}
+                className="flex min-w-0 flex-col gap-1.5"
+                key={lane.id}
+              >
+                <header className="flex items-center gap-2 border-b border-(--ui-stroke-secondary) pb-1 text-[0.6875rem] text-(--ui-text-tertiary)">
+                  <span className="font-mono font-semibold text-foreground">{lane.label}</span>
+                  <span className="ml-auto font-mono tabular-nums">{lane.task_count}</span>
+                </header>
+                <div
+                  className={cn('flex gap-2 overflow-x-auto pb-1', grabbing && 'cursor-grabbing')}
+                  onMouseDown={onMouseDown}
+                >
+                  {lane.columns.map(col => {
+                    const auto = boardHasWork && col.tasks.length === 0
+
+                    return (
+                      <Column
+                        collapsed={laneOverrides[col.name] ?? auto}
+                        column={col}
+                        columns={columnNames}
+                        key={`${lane.id}:${col.name}`}
+                        onAdd={setAddStatus}
+                        onDelete={id => deleteMut.mutate(id)}
+                        onDropTask={onMove}
+                        onMove={onMove}
+                        onOpen={setOpenId}
+                        onToggle={() => toggleLane(col.name, auto)}
+                        onToggleSelect={toggleSelect}
+                        selected={selected}
+                      />
+                    )
+                  })}
+                </div>
+              </section>
+            ))}
+          </div>
+        ) : (
         <div
           className={cn('flex flex-1 gap-2 overflow-x-auto px-4 pt-1 pb-3', grabbing && 'cursor-grabbing')}
           onMouseDown={onMouseDown}
@@ -1413,6 +1516,7 @@ export function KanbanBoardPage() {
             )
           })}
         </div>
+        )
       )}
 
       {selected.size > 0 && (

--- a/apps/desktop/src/plugins/kanban/swim-lanes.test.ts
+++ b/apps/desktop/src/plugins/kanban/swim-lanes.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest'
+
+import type { KanbanColumn } from './types'
+import { partitionSwimLanes } from './swim-lanes'
+
+const columns: KanbanColumn[] = [
+  {
+    name: 'todo',
+    tasks: [
+      { id: 'org-1', title: 'Org card', status: 'todo', assignee: 'R1ft' },
+      { id: 'w3bb-1', title: 'W3bb card', status: 'todo', assignee: 'w3bb' }
+    ]
+  },
+  {
+    name: 'ready',
+    tasks: [
+      { id: 'l3x-1', title: 'L3x card', status: 'ready', assignee: 'l3x' },
+      { id: 'unassigned-1', title: 'Unassigned card', status: 'ready', assignee: null }
+    ]
+  }
+]
+
+describe('partitionSwimLanes', () => {
+  it('keeps W3bb cards out of Org while preserving L3x and unassigned bucketing', () => {
+    const lanes = partitionSwimLanes(columns, 'l3x', 'w3bb', true)
+
+    expect(lanes.map(lane => lane.id)).toEqual(['__other__', 'w3bb', 'l3x'])
+    expect(lanes.map(lane => lane.label)).toEqual(['Org', 'W3bb', 'l3x'])
+    expect(lanes.map(lane => lane.task_count)).toEqual([2, 1, 1])
+    expect(lanes[0].columns.flatMap(column => column.tasks).map(task => task.id)).toEqual(['org-1', 'unassigned-1'])
+    expect(lanes[1].columns.flatMap(column => column.tasks).map(task => task.id)).toEqual(['w3bb-1'])
+    expect(lanes[2].columns.flatMap(column => column.tasks).map(task => task.id)).toEqual(['l3x-1'])
+  })
+
+  it('folds W3bb back into Org when its dedicated lane is disabled', () => {
+    const lanes = partitionSwimLanes(columns, 'l3x', 'w3bb', false)
+
+    expect(lanes.map(lane => lane.id)).toEqual(['__other__', 'l3x'])
+    expect(lanes[0].columns.flatMap(column => column.tasks).map(task => task.id)).toEqual([
+      'org-1',
+      'w3bb-1',
+      'unassigned-1'
+    ])
+  })
+})

--- a/apps/desktop/src/plugins/kanban/swim-lanes.ts
+++ b/apps/desktop/src/plugins/kanban/swim-lanes.ts
@@ -1,0 +1,70 @@
+import type { KanbanColumn, KanbanSwimLane } from './types'
+
+export const SWIM_LANE_ORG_ID = '__other__'
+const W3BB_SWIM_LANE_LABEL = 'W3bb'
+
+/**
+ * Split the flat board into the cross-column profile rows used by both the
+ * dashboard and the desktop board. Cards remain in their original column and
+ * order; only their lane membership changes.
+ */
+export function partitionSwimLanes(
+  columns: KanbanColumn[],
+  l3xAssignee: string,
+  w3bbAssignee: string,
+  w3bbSwimLane: boolean
+): KanbanSwimLane[] {
+  const dedicatedAssignees = new Set([l3xAssignee])
+
+  if (w3bbSwimLane) {
+    dedicatedAssignees.add(w3bbAssignee)
+  }
+
+  const l3xCols: KanbanColumn[] = []
+  const w3bbCols: KanbanColumn[] = []
+  const otherCols: KanbanColumn[] = []
+
+  for (const col of columns) {
+    const l3xTasks = col.tasks.filter(task => task.assignee === l3xAssignee)
+    const w3bbTasks = w3bbSwimLane ? col.tasks.filter(task => task.assignee === w3bbAssignee) : []
+    const otherTasks = col.tasks.filter(task => {
+      const assignee = task.assignee
+      return assignee == null || !dedicatedAssignees.has(assignee)
+    })
+
+    l3xCols.push({ name: col.name, tasks: l3xTasks })
+    w3bbCols.push({ name: col.name, tasks: w3bbTasks })
+    otherCols.push({ name: col.name, tasks: otherTasks })
+  }
+
+  const count = (cols: KanbanColumn[]) => cols.reduce((sum, col) => sum + col.tasks.length, 0)
+  const lanes: KanbanSwimLane[] = [
+    {
+      id: SWIM_LANE_ORG_ID,
+      label: 'Org',
+      assignee: null,
+      task_count: count(otherCols),
+      columns: otherCols
+    }
+  ]
+
+  if (w3bbSwimLane) {
+    lanes.push({
+      id: w3bbAssignee,
+      label: W3BB_SWIM_LANE_LABEL,
+      assignee: w3bbAssignee,
+      task_count: count(w3bbCols),
+      columns: w3bbCols
+    })
+  }
+
+  lanes.push({
+    id: l3xAssignee,
+    label: l3xAssignee,
+    assignee: l3xAssignee,
+    task_count: count(l3xCols),
+    columns: l3xCols
+  })
+
+  return lanes
+}

--- a/apps/desktop/src/plugins/kanban/types.ts
+++ b/apps/desktop/src/plugins/kanban/types.ts
@@ -30,12 +30,30 @@ export interface KanbanColumn {
   tasks: KanbanTask[]
 }
 
+export interface KanbanSwimLane {
+  id: string
+  label: string
+  assignee?: null | string
+  task_count: number
+  columns: KanbanColumn[]
+}
+
 export interface KanbanBoard {
   columns: KanbanColumn[]
+  swim_lanes?: KanbanSwimLane[] | null
   tenants: string[]
   assignees: string[]
   latest_event_id: number
   now: number
+}
+
+export interface KanbanBoardConfig {
+  default_tenant: string
+  lane_by_profile: boolean
+  l3x_swim_lane: boolean
+  l3x_swim_lane_assignee: string
+  include_archived_by_default: boolean
+  render_markdown: boolean
 }
 
 /** A structured recovery action attached to a diagnostic. */

--- a/apps/desktop/src/plugins/kanban/types.ts
+++ b/apps/desktop/src/plugins/kanban/types.ts
@@ -52,6 +52,8 @@ export interface KanbanBoardConfig {
   lane_by_profile: boolean
   l3x_swim_lane: boolean
   l3x_swim_lane_assignee: string
+  w3bb_swim_lane: boolean
+  w3bb_swim_lane_assignee: string
   include_archived_by_default: boolean
   render_markdown: boolean
 }

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -63,6 +63,7 @@ def _task_to_dict(t: kb.Task) -> dict[str, Any]:
         "body": t.body,
         "assignee": t.assignee,
         "status": t.status,
+        "manual_hold": t.manual_hold,
         "priority": t.priority,
         "tenant": t.tenant,
         "workspace_kind": t.workspace_kind,
@@ -396,9 +397,11 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
     p_create.add_argument("--initial-status",
                           choices=sorted(kb.VALID_INITIAL_STATUSES),
                           default="running",
-                          help="Initial card status. Use 'blocked' for cards "
-                               "that require immediate human ops (R3 gate) "
-                               "to skip the brief running-to-blocked transition.")
+                          help="Initial lifecycle phase. 'running' preserves "
+                               "normal ready/dependency inference; 'todo' "
+                               "creates a manual dispatch hold; 'triage' parks "
+                               "for specification; 'blocked' creates an "
+                               "immediate human-ops gate.")
     p_create.add_argument("--json", action="store_true", help="Emit JSON output")
 
     # --- swarm ---
@@ -728,6 +731,29 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
     p_promote.add_argument(
         "--json",
         dest="json",
+        action="store_true",
+        help="Emit machine-readable JSON result",
+    )
+
+    p_transition = sub.add_parser(
+        "transition",
+        help="Safely park an unclaimed card in todo or triage",
+    )
+    p_transition.add_argument("task_id", help="Task id")
+    p_transition.add_argument(
+        "--to",
+        dest="target_status",
+        choices=sorted(kb.VALID_MANUAL_TRANSITION_STATUSES),
+        required=True,
+        help="Target lifecycle phase",
+    )
+    p_transition.add_argument(
+        "--reason",
+        default=None,
+        help="Reason recorded in the task event audit trail",
+    )
+    p_transition.add_argument(
+        "--json",
         action="store_true",
         help="Emit machine-readable JSON result",
     )
@@ -1134,6 +1160,7 @@ def kanban_command(args: argparse.Namespace) -> int:
             "request-changes": _cmd_request_changes,
             "reopen-review":  _cmd_reopen_review,
             "promote":  _cmd_promote,
+            "transition": _cmd_transition,
             "archive":  _cmd_archive,
             "tail":     _cmd_tail,
             "dispatch": _cmd_dispatch,
@@ -1199,6 +1226,7 @@ _DELEGATED_CHILD_DENIED_ACTIONS: frozenset[str] = frozenset({
     "schedule",
     "unblock",
     "promote",
+    "transition",
     "archive",
     "dispatch",
     "daemon",
@@ -1588,6 +1616,8 @@ def _cmd_create(args: argparse.Namespace) -> int:
             initial_status=getattr(args, "initial_status", "running"),
         )
         task = kb.get_task(conn, task_id)
+    if task is None:  # Defensive: create_task returning a missing row is fatal.
+        raise RuntimeError(f"created task {task_id} could not be loaded")
     if getattr(args, "json", False):
         print(json.dumps(_task_to_dict(task), indent=2, ensure_ascii=False))
     else:
@@ -2568,6 +2598,45 @@ def _cmd_promote(args: argparse.Namespace) -> int:
         else:
             print(f"cannot promote {r['task_id']}: {r['error']}", file=sys.stderr)
     return 0 if not failed else 1
+
+
+def _cmd_transition(args: argparse.Namespace) -> int:
+    task_id = str(args.task_id)
+    target_status = str(args.target_status)
+    reason = (getattr(args, "reason", None) or "").strip() or None
+    actor = _profile_author()
+
+    with kb.connect_closing() as conn:
+        transition = kb.transition_task_status(
+            conn,
+            task_id,
+            target_status=target_status,
+            actor=actor,
+            reason=reason,
+        )
+
+    result = {
+        "task_id": task_id,
+        "source_status": transition.source_status,
+        "target_status": transition.target_status,
+        "actor": actor,
+        "reason": reason,
+        "transitioned": transition.changed,
+        "error": transition.error,
+    }
+    if getattr(args, "json", False):
+        print(json.dumps(result, indent=2, ensure_ascii=False))
+    elif transition.changed:
+        suffix = f": {reason}" if reason else ""
+        print(
+            f"Transitioned {task_id}: {transition.source_status} -> "
+            f"{transition.target_status}{suffix}"
+        )
+    elif transition.ok:
+        print(f"No change: {task_id} is already {transition.target_status}")
+    else:
+        print(f"cannot transition {task_id}: {transition.error}", file=sys.stderr)
+    return 0 if transition.ok else 1
 
 
 def _cmd_archive(args: argparse.Namespace) -> int:

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -100,7 +100,9 @@ _log = logging.getLogger(__name__)
 # ---------------------------------------------------------------------------
 
 VALID_STATUSES = {"triage", "todo", "scheduled", "ready", "running", "blocked", "review", "done", "archived"}
-VALID_INITIAL_STATUSES = {"running", "blocked"}
+VALID_INITIAL_STATUSES = {"running", "blocked", "todo", "triage"}
+VALID_MANUAL_TRANSITION_STATUSES = {"todo", "triage"}
+VALID_MANUAL_TRANSITION_SOURCES = {"ready", "todo", "triage"}
 
 # Typed block reasons. Distinguishes the two fundamentally different things a
 # worker (or human) means by "blocked", so each can be routed differently
@@ -1141,6 +1143,10 @@ class Task:
     # Unblock-loop counter. See the column comment in SCHEMA_SQL and
     # ``BLOCK_RECURRENCE_LIMIT``. Reset only on successful completion.
     block_recurrences: int = 0
+    # Explicitly parked todo cards are not dependency-ready work. The
+    # dispatcher leaves them in todo until an operator promotes or transitions
+    # them. This lets cron automation stage one idempotent card safely.
+    manual_hold: bool = False
 
     @classmethod
     def from_row(cls, row: sqlite3.Row) -> "Task":
@@ -1234,6 +1240,11 @@ class Task:
                 int(row["block_recurrences"])
                 if "block_recurrences" in keys and row["block_recurrences"] is not None
                 else 0
+            ),
+            manual_hold=(
+                bool(row["manual_hold"])
+                if "manual_hold" in keys and row["manual_hold"] is not None
+                else False
             ),
         )
 
@@ -1422,7 +1433,11 @@ CREATE TABLE IF NOT EXISTS tasks (
     -- ``blocked`` so a cron can't spin it forever. Reset to 0 only on a
     -- successful completion — NOT on unblock (resetting on unblock is exactly
     -- the amnesia that let the loop run unbounded).
-    block_recurrences    INTEGER NOT NULL DEFAULT 0
+    block_recurrences    INTEGER NOT NULL DEFAULT 0,
+    -- A deliberate todo hold. Dependency-created todo rows use 0 and
+    -- auto-promote when their parents finish; explicitly staged todo rows use
+    -- 1 and stay parked until promote/transition clears the hold.
+    manual_hold          INTEGER NOT NULL DEFAULT 0
 );
 
 CREATE TABLE IF NOT EXISTS task_links (
@@ -2679,6 +2694,16 @@ def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
             "block_recurrences INTEGER NOT NULL DEFAULT 0",
         )
 
+    if "manual_hold" not in cols:
+        # Existing todo rows are dependency waits and must keep their historical
+        # auto-promotion behavior. Only newly explicit todo transitions set 1.
+        _add_column_if_missing(
+            conn,
+            "tasks",
+            "manual_hold",
+            "manual_hold INTEGER NOT NULL DEFAULT 0",
+        )
+
     # Indexes over additive ``tasks`` columns must be created after the
     # columns exist. Keeping them in SCHEMA_SQL breaks legacy boards: SQLite
     # parses each statement in ``executescript`` against the live schema, so a
@@ -3186,11 +3211,12 @@ def create_task(
 ) -> str:
     """Create a new task and optionally link it under parent tasks.
 
-    Returns the new task id.  Status is ``ready`` when there are no
-    parents (or all parents already ``done``), otherwise ``todo``.
-    If ``triage=True``, status is forced to ``triage`` regardless of
-    parents — a specifier/triager is expected to promote the task to
-    ``todo`` once the spec is fleshed out.
+    Returns the new task id. By default, status is ``ready`` when there are no
+    parents (or all parents are terminal), otherwise dependency-gated ``todo``.
+    ``initial_status='todo'`` creates an explicit manual hold that the
+    dispatcher will not auto-promote. ``initial_status='triage'`` is the
+    non-legacy spelling of ``triage=True``. ``initial_status='blocked'`` parks
+    work behind an immediate human-ops gate.
 
     If ``idempotency_key`` is provided and a non-archived task with the
     same key already exists, returns the existing task's id instead of
@@ -3234,6 +3260,11 @@ def create_task(
     if initial_status not in VALID_INITIAL_STATUSES:
         raise ValueError(
             f"initial_status must be one of {sorted(VALID_INITIAL_STATUSES)}"
+        )
+    if triage and initial_status not in {"running", "triage"}:
+        raise ValueError(
+            "triage=True conflicts with initial_status="
+            f"{initial_status!r}; use initial_status='triage'"
         )
     if workspace_kind not in VALID_WORKSPACE_KINDS:
         raise ValueError(
@@ -3393,11 +3424,10 @@ def create_task(
             )
         skills_list = cleaned
 
-    # Idempotency check — return the existing task instead of creating a
-    # duplicate. Done BEFORE entering write_txn to keep the fast path fast
-    # and to avoid holding a write lock during the lookup. Race is
-    # acceptable: two concurrent creators with the same key might both
-    # insert, at which point both rows exist but the next lookup stabilises.
+    # Idempotency fast path — return the existing task without taking a write
+    # lock. Correctness does not rely on this optimistic read: the lookup is
+    # repeated after BEGIN IMMEDIATE below so concurrent creators cannot both
+    # insert the same non-archived key.
     if idempotency_key:
         row = conn.execute(
             "SELECT id FROM tasks WHERE idempotency_key = ? "
@@ -3438,23 +3468,43 @@ def create_task(
             # compose create_task calls under one outer commit so the
             # dispatcher can never observe a partially constructed graph.
             with write_txn(conn, allow_nested=True):
-                # Determine task status from parent status, unless the caller
-                # parks it directly in blocked for human-ops review or in
-                # triage for a specifier.
+                if idempotency_key:
+                    # Serialize the decisive lookup with the insert. A second
+                    # creator that raced the optimistic check above waits for
+                    # this write transaction, then observes and reuses the row
+                    # committed by the winner.
+                    existing = conn.execute(
+                        "SELECT id FROM tasks WHERE idempotency_key = ? "
+                        "AND status != 'archived' "
+                        "ORDER BY created_at DESC LIMIT 1",
+                        (idempotency_key,),
+                    ).fetchone()
+                    if existing:
+                        return str(existing["id"])
+
+                # Validate every dependency before selecting an initial lane.
+                # Keeping this common prevents special initial statuses from
+                # accidentally persisting dangling task_links rows.
+                if parents:
+                    missing = _find_missing_parents(conn, parents)
+                    if missing:
+                        raise ValueError(
+                            f"unknown parent task(s): {', '.join(missing)}"
+                        )
+
+                # Determine task status from the explicit lifecycle request or
+                # (for the normal 'running' mode) from parent status.
+                manual_hold = 0
                 if initial_status == "blocked":
                     task_status = "blocked"
-                    if parents:
-                        missing = _find_missing_parents(conn, parents)
-                        if missing:
-                            raise ValueError(f"unknown parent task(s): {', '.join(missing)}")
-                elif triage:
+                elif initial_status == "todo":
+                    task_status = "todo"
+                    manual_hold = 1
+                elif triage or initial_status == "triage":
                     task_status = "triage"
                 else:
                     task_status = "ready"
                     if parents:
-                        missing = _find_missing_parents(conn, parents)
-                        if missing:
-                            raise ValueError(f"unknown parent task(s): {', '.join(missing)}")
                         # If any parent is not yet done, we're todo.
                         rows = conn.execute(
                             "SELECT status FROM tasks WHERE id IN "
@@ -3463,12 +3513,6 @@ def create_task(
                         ).fetchall()
                         if any(r["status"] != "done" for r in rows):
                             task_status = "todo"
-                # Even in triage mode we still need to validate parent ids
-                # so the eventual link rows don't dangle.
-                if triage and parents:
-                    missing = _find_missing_parents(conn, parents)
-                    if missing:
-                        raise ValueError(f"unknown parent task(s): {', '.join(missing)}")
 
                 # Project-linked worktree: a fresh worktree dir under the repo
                 # plus a deterministic branch (project slug + task id). Together
@@ -3497,8 +3541,8 @@ def create_task(
                         max_runtime_seconds,
                         skills, max_retries, model_override, provider_override,
                         reasoning_effort,
-                        goal_mode, goal_max_turns, session_id
-                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                        goal_mode, goal_max_turns, session_id, manual_hold
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                     """,
                     (
                         task_id,
@@ -3524,6 +3568,7 @@ def create_task(
                         1 if goal_mode else 0,
                         int(goal_max_turns) if goal_max_turns is not None else None,
                         session_id,
+                        manual_hold,
                     ),
                 )
                 for pid in parents:
@@ -3542,6 +3587,9 @@ def create_task(
                     {
                         "assignee": assignee,
                         "status": task_status,
+                        "initial_status": (
+                            initial_status if initial_status != "running" else None
+                        ),
                         "parents": list(parents),
                         "tenant": tenant,
                         "workspace_kind": workspace_kind,
@@ -3552,6 +3600,7 @@ def create_task(
                         "goal_mode": bool(goal_mode) or None,
                         "model_override": model_override,
                         "provider_override": provider_override,
+                        "manual_hold": bool(manual_hold) or None,
                     },
                 )
                 _inherit_notify_subs(conn, task_id, parents, created_at=now)
@@ -4544,12 +4593,18 @@ def recompute_ready(
     promoted = 0
     with write_txn(conn):
         todo_rows = conn.execute(
-            "SELECT id, status, consecutive_failures, max_retries "
+            "SELECT id, status, consecutive_failures, max_retries, manual_hold "
             "FROM tasks WHERE status IN ('todo', 'blocked')"
         ).fetchall()
         for row in todo_rows:
             task_id = row["id"]
             cur_status = row["status"]
+            if cur_status == "todo" and bool(row["manual_hold"]):
+                # Explicit staging hold (e.g. a cron-owned packaging card).
+                # Only a manual promote/transition releases it; parent state
+                # must not silently convert staged control-plane work into a
+                # dispatchable worker run.
+                continue
             if cur_status == "blocked" and _has_sticky_block(conn, task_id):
                 # Worker / operator asked for explicit human intervention — do not
                 # silently auto-recover.  ``unblock_task`` is the only
@@ -4582,13 +4637,14 @@ def recompute_ready(
                     if failures >= effective_limit:
                         continue
                     conn.execute(
-                        "UPDATE tasks SET status = ? "
+                        "UPDATE tasks SET status = ?, manual_hold = 0 "
                         "WHERE id = ? AND status = 'blocked'",
                         (resume_status, task_id),
                     )
                 else:
                     conn.execute(
-                        "UPDATE tasks SET status = ? WHERE id = ? AND status = 'todo'",
+                        "UPDATE tasks SET status = ?, manual_hold = 0 "
+                        "WHERE id = ? AND status = 'todo'",
                         (resume_status, task_id),
                     )
                 _append_event(
@@ -6687,6 +6743,135 @@ def request_changes(
     return True, implementer
 
 
+@dataclass(frozen=True)
+class StatusTransitionResult:
+    """Outcome of an audited todo/triage lifecycle transition."""
+
+    ok: bool
+    source_status: Optional[str]
+    target_status: str
+    changed: bool
+    error: Optional[str] = None
+
+
+def transition_task_status(
+    conn: sqlite3.Connection,
+    task_id: str,
+    *,
+    target_status: str,
+    actor: str,
+    reason: Optional[str] = None,
+) -> StatusTransitionResult:
+    """Safely park an unclaimed task in ``todo`` or ``triage``.
+
+    This is the narrow automation transition for cron/orchestrator-owned cards.
+    It accepts only the unclaimed ``ready``/``todo``/``triage`` phases; active,
+    blocked, scheduled, review, and terminal tasks have dedicated lifecycle
+    operations whose recovery/accounting semantics must not be bypassed.
+
+    ``todo`` is an explicit manual hold, distinct from dependency-created todo:
+    ``recompute_ready`` will leave it parked until ``promote_task`` or another
+    transition clears the hold. Repeating an already-effective transition is
+    idempotent and does not append another event. Every real state/hold change
+    emits ``status_transitioned`` with source, target, actor, reason, and the
+    event table's canonical timestamp.
+    """
+    target_status = (target_status or "").strip().lower()
+    actor = (actor or "").strip() or "unknown"
+    reason = (reason or "").strip() or None
+    if target_status not in VALID_MANUAL_TRANSITION_STATUSES:
+        return StatusTransitionResult(
+            ok=False,
+            source_status=None,
+            target_status=target_status,
+            changed=False,
+            error=(
+                "target_status must be one of "
+                f"{sorted(VALID_MANUAL_TRANSITION_STATUSES)}"
+            ),
+        )
+
+    with write_txn(conn):
+        row = conn.execute(
+            "SELECT status, manual_hold, current_run_id, claim_lock, "
+            "claim_expires, worker_pid FROM tasks WHERE id = ?",
+            (task_id,),
+        ).fetchone()
+        if row is None:
+            return StatusTransitionResult(
+                False, None, target_status, False, f"task {task_id} not found"
+            )
+
+        source_status = str(row["status"])
+        if source_status not in VALID_MANUAL_TRANSITION_SOURCES:
+            return StatusTransitionResult(
+                ok=False,
+                source_status=source_status,
+                target_status=target_status,
+                changed=False,
+                error=(
+                    f"task {task_id} is {source_status!r}; todo/triage "
+                    "transitions only apply to unclaimed 'ready', 'todo', "
+                    "or 'triage' tasks"
+                ),
+            )
+        if any(
+            row[field] is not None
+            for field in (
+                "current_run_id",
+                "claim_lock",
+                "claim_expires",
+                "worker_pid",
+            )
+        ):
+            return StatusTransitionResult(
+                ok=False,
+                source_status=source_status,
+                target_status=target_status,
+                changed=False,
+                error=(
+                    f"task {task_id} has active ownership metadata; reclaim "
+                    "it before changing its lifecycle phase"
+                ),
+            )
+
+        target_hold = target_status == "todo"
+        if source_status == target_status and bool(row["manual_hold"]) == target_hold:
+            return StatusTransitionResult(
+                True, source_status, target_status, False
+            )
+
+        updated = conn.execute(
+            "UPDATE tasks SET status = ?, manual_hold = ? "
+            "WHERE id = ? AND status = ? AND current_run_id IS NULL "
+            "AND claim_lock IS NULL AND claim_expires IS NULL "
+            "AND worker_pid IS NULL",
+            (target_status, int(target_hold), task_id, source_status),
+        )
+        if updated.rowcount != 1:
+            return StatusTransitionResult(
+                False,
+                source_status,
+                target_status,
+                False,
+                f"task {task_id} status changed during transition",
+            )
+        _append_event(
+            conn,
+            task_id,
+            "status_transitioned",
+            {
+                "source_status": source_status,
+                "target_status": target_status,
+                "actor": actor,
+                "reason": reason,
+            },
+        )
+
+    notify_task_updated(conn, task_id, ("status", "manual_hold"))
+    return StatusTransitionResult(True, source_status, target_status, True)
+
+
 def promote_task(
     conn: sqlite3.Connection,
     task_id: str,
@@ -6741,7 +6926,7 @@ def promote_task(
 
     with write_txn(conn):
         upd = conn.execute(
-            "UPDATE tasks SET status = 'ready' "
+            "UPDATE tasks SET status = 'ready', manual_hold = 0 "
             "WHERE id = ? AND status IN ('todo', 'blocked')",
             (task_id,),
         )
@@ -6754,6 +6939,7 @@ def promote_task(
             {"actor": actor, "reason": reason, "forced": force},
         )
 
+    notify_task_updated(conn, task_id, ("status", "manual_hold"))
     return True, None
 
 
@@ -7433,7 +7619,8 @@ def archive_task(conn: sqlite3.Connection, task_id: str) -> bool:
     with write_txn(conn):
         cur = conn.execute(
             "UPDATE tasks SET status = 'archived', "
-            "    claim_lock = NULL, claim_expires = NULL, worker_pid = NULL "
+            "    manual_hold = 0, claim_lock = NULL, "
+            "    claim_expires = NULL, worker_pid = NULL "
             "WHERE id = ? AND status != 'archived'",
             (task_id,),
         )
@@ -7846,6 +8033,7 @@ def schedule_task(
         sql = """
             UPDATE tasks
                SET status       = 'scheduled',
+                   manual_hold  = 0,
                    claim_lock   = NULL,
                    claim_expires= NULL,
                    worker_pid   = NULL

--- a/plugins/kanban/dashboard/dist/index.js
+++ b/plugins/kanban/dashboard/dist/index.js
@@ -628,6 +628,8 @@
     const [laneByProfile, setLaneByProfile] = useState(true);
     const [l3xSwimLane, setL3xSwimLane] = useState(true);
     const [l3xSwimLaneAssignee, setL3xSwimLaneAssignee] = useState("l3x");
+    const [w3bbSwimLane, setW3bbSwimLane] = useState(true);
+    const [w3bbSwimLaneAssignee, setW3bbSwimLaneAssignee] = useState("w3bb");
     const [configApplied, setConfigApplied] = useState(false);
 
     const [selectedTaskId, setSelectedTaskId] = useState(null);
@@ -659,6 +661,8 @@
             if (typeof c.lane_by_profile === "boolean") setLaneByProfile(c.lane_by_profile);
             if (typeof c.l3x_swim_lane === "boolean") setL3xSwimLane(c.l3x_swim_lane);
             if (c.l3x_swim_lane_assignee) setL3xSwimLaneAssignee(c.l3x_swim_lane_assignee);
+            if (typeof c.w3bb_swim_lane === "boolean") setW3bbSwimLane(c.w3bb_swim_lane);
+            if (c.w3bb_swim_lane_assignee) setW3bbSwimLaneAssignee(c.w3bb_swim_lane_assignee);
             if (typeof c.include_archived_by_default === "boolean") setIncludeArchived(c.include_archived_by_default);
             setConfigApplied(true);
           }
@@ -1322,6 +1326,8 @@
           laneByProfile,
           l3xSwimLane,
           l3xSwimLaneAssignee,
+          w3bbSwimLane,
+          w3bbSwimLaneAssignee,
           assigneeFilter,
           selectedIds,
           failedIds,
@@ -2690,24 +2696,30 @@
   }
 
   // -------------------------------------------------------------------------
-  // Cross-column swim lanes (L3x vs other assignees)
+  // Cross-column swim lanes (Org vs W3bb vs L3x assignees)
   // -------------------------------------------------------------------------
 
   var L3X_SWIM_LANE_OTHER_ID = "__other__";
+  var W3BB_SWIM_LANE_LABEL = "W3bb";
 
-  function partitionSwimLanes(columns, l3xAssignee) {
+  function partitionSwimLanes(columns, l3xAssignee, w3bbAssignee, w3bbSwimLane) {
     var l3xCols = [];
+    var w3bbCols = [];
     var otherCols = [];
     for (var i = 0; i < columns.length; i++) {
       var col = columns[i];
       var tasks = col.tasks || [];
       var l3xTasks = [];
+      var w3bbTasks = [];
       var otherTasks = [];
       for (var j = 0; j < tasks.length; j++) {
-        if (tasks[j].assignee === l3xAssignee) l3xTasks.push(tasks[j]);
+        var assignee = tasks[j].assignee;
+        if (assignee === l3xAssignee) l3xTasks.push(tasks[j]);
+        else if (w3bbSwimLane && assignee === w3bbAssignee) w3bbTasks.push(tasks[j]);
         else otherTasks.push(tasks[j]);
       }
       l3xCols.push({ name: col.name, tasks: l3xTasks });
+      w3bbCols.push({ name: col.name, tasks: w3bbTasks });
       otherCols.push({ name: col.name, tasks: otherTasks });
     }
     function laneCount(cols) {
@@ -2715,22 +2727,32 @@
       for (var k = 0; k < cols.length; k++) n += (cols[k].tasks || []).length;
       return n;
     }
-    return [
-      {
-        id: l3xAssignee,
-        label: l3xAssignee,
-        assignee: l3xAssignee,
-        task_count: laneCount(l3xCols),
-        columns: l3xCols,
-      },
+    var lanes = [
       {
         id: L3X_SWIM_LANE_OTHER_ID,
-        label: "Other",
+        label: "Org",
         assignee: null,
         task_count: laneCount(otherCols),
         columns: otherCols,
       },
     ];
+    if (w3bbSwimLane) {
+      lanes.push({
+        id: w3bbAssignee,
+        label: W3BB_SWIM_LANE_LABEL,
+        assignee: w3bbAssignee,
+        task_count: laneCount(w3bbCols),
+        columns: w3bbCols,
+      });
+    }
+    lanes.push({
+      id: l3xAssignee,
+      label: l3xAssignee,
+      assignee: l3xAssignee,
+      task_count: laneCount(l3xCols),
+      columns: l3xCols,
+    });
+    return lanes;
   }
 
   // -------------------------------------------------------------------------
@@ -2837,21 +2859,30 @@
 
     const swimLanes = useMemo(function () {
       if (!props.l3xSwimLane || !props.board || !props.board.columns) return null;
-      return partitionSwimLanes(props.board.columns, props.l3xSwimLaneAssignee || "l3x");
-    }, [props.l3xSwimLane, props.l3xSwimLaneAssignee, props.board]);
+      return partitionSwimLanes(
+        props.board.columns,
+        props.l3xSwimLaneAssignee || "l3x",
+        props.w3bbSwimLaneAssignee || "w3bb",
+        props.w3bbSwimLane !== false
+      );
+    }, [props.l3xSwimLane, props.l3xSwimLaneAssignee, props.w3bbSwimLane, props.w3bbSwimLaneAssignee, props.board]);
 
     const visibleSwimLanes = useMemo(function () {
       if (!swimLanes) return null;
       var filter = props.assigneeFilter || "";
       var l3x = props.l3xSwimLaneAssignee || "l3x";
+      var w3bb = props.w3bbSwimLaneAssignee || "w3bb";
       if (filter === l3x) {
         return swimLanes.filter(function (lane) { return lane.id === l3x; });
       }
-      if (filter && filter !== l3x) {
+      if (filter === w3bb) {
+        return swimLanes.filter(function (lane) { return lane.id === w3bb; });
+      }
+      if (filter && filter !== l3x && filter !== w3bb) {
         return swimLanes.filter(function (lane) { return lane.id === L3X_SWIM_LANE_OTHER_ID; });
       }
       return swimLanes;
-    }, [swimLanes, props.assigneeFilter, props.l3xSwimLaneAssignee]);
+    }, [swimLanes, props.assigneeFilter, props.l3xSwimLaneAssignee, props.w3bbSwimLaneAssignee]);
 
     function renderColumnGrid(boardSlice, gridKey, showTrash) {
       return [

--- a/plugins/kanban/dashboard/dist/index.js
+++ b/plugins/kanban/dashboard/dist/index.js
@@ -626,6 +626,8 @@
     const [includeArchived, setIncludeArchived] = useState(false);
     const [search, setSearch] = useState("");
     const [laneByProfile, setLaneByProfile] = useState(true);
+    const [l3xSwimLane, setL3xSwimLane] = useState(true);
+    const [l3xSwimLaneAssignee, setL3xSwimLaneAssignee] = useState("l3x");
     const [configApplied, setConfigApplied] = useState(false);
 
     const [selectedTaskId, setSelectedTaskId] = useState(null);
@@ -655,6 +657,8 @@
           if (!configApplied) {
             if (c.default_tenant) setTenantFilter(c.default_tenant);
             if (typeof c.lane_by_profile === "boolean") setLaneByProfile(c.lane_by_profile);
+            if (typeof c.l3x_swim_lane === "boolean") setL3xSwimLane(c.l3x_swim_lane);
+            if (c.l3x_swim_lane_assignee) setL3xSwimLaneAssignee(c.l3x_swim_lane_assignee);
             if (typeof c.include_archived_by_default === "boolean") setIncludeArchived(c.include_archived_by_default);
             setConfigApplied(true);
           }
@@ -1316,6 +1320,9 @@
           board: filteredBoard,
           boardMeta: boardList.find(function (item) { return item.slug === board; }) || null,
           laneByProfile,
+          l3xSwimLane,
+          l3xSwimLaneAssignee,
+          assigneeFilter,
           selectedIds,
           failedIds,
           draggingTaskId,
@@ -2683,6 +2690,50 @@
   }
 
   // -------------------------------------------------------------------------
+  // Cross-column swim lanes (L3x vs other assignees)
+  // -------------------------------------------------------------------------
+
+  var L3X_SWIM_LANE_OTHER_ID = "__other__";
+
+  function partitionSwimLanes(columns, l3xAssignee) {
+    var l3xCols = [];
+    var otherCols = [];
+    for (var i = 0; i < columns.length; i++) {
+      var col = columns[i];
+      var tasks = col.tasks || [];
+      var l3xTasks = [];
+      var otherTasks = [];
+      for (var j = 0; j < tasks.length; j++) {
+        if (tasks[j].assignee === l3xAssignee) l3xTasks.push(tasks[j]);
+        else otherTasks.push(tasks[j]);
+      }
+      l3xCols.push({ name: col.name, tasks: l3xTasks });
+      otherCols.push({ name: col.name, tasks: otherTasks });
+    }
+    function laneCount(cols) {
+      var n = 0;
+      for (var k = 0; k < cols.length; k++) n += (cols[k].tasks || []).length;
+      return n;
+    }
+    return [
+      {
+        id: l3xAssignee,
+        label: l3xAssignee,
+        assignee: l3xAssignee,
+        task_count: laneCount(l3xCols),
+        columns: l3xCols,
+      },
+      {
+        id: L3X_SWIM_LANE_OTHER_ID,
+        label: "Other",
+        assignee: null,
+        task_count: laneCount(otherCols),
+        columns: otherCols,
+      },
+    ];
+  }
+
+  // -------------------------------------------------------------------------
   // Columns
   // -------------------------------------------------------------------------
 
@@ -2783,6 +2834,88 @@
     const handleDragEnd = useCallback(function () {
       if (props.onDragEnd) props.onDragEnd();
     }, [props.onDragEnd]);
+
+    const swimLanes = useMemo(function () {
+      if (!props.l3xSwimLane || !props.board || !props.board.columns) return null;
+      return partitionSwimLanes(props.board.columns, props.l3xSwimLaneAssignee || "l3x");
+    }, [props.l3xSwimLane, props.l3xSwimLaneAssignee, props.board]);
+
+    const visibleSwimLanes = useMemo(function () {
+      if (!swimLanes) return null;
+      var filter = props.assigneeFilter || "";
+      var l3x = props.l3xSwimLaneAssignee || "l3x";
+      if (filter === l3x) {
+        return swimLanes.filter(function (lane) { return lane.id === l3x; });
+      }
+      if (filter && filter !== l3x) {
+        return swimLanes.filter(function (lane) { return lane.id === L3X_SWIM_LANE_OTHER_ID; });
+      }
+      return swimLanes;
+    }, [swimLanes, props.assigneeFilter, props.l3xSwimLaneAssignee]);
+
+    function renderColumnGrid(boardSlice, gridKey, showTrash) {
+      return [
+        boardSlice.columns.map(function (col) {
+          return h(Column, {
+            key: gridKey + ":" + col.name,
+            column: col,
+            boardMeta: props.boardMeta,
+            laneByProfile: props.laneByProfile,
+            selectedIds: props.selectedIds,
+            failedIds: props.failedIds,
+            draggingTaskId: props.draggingTaskId,
+            toggleSelected: props.toggleSelected,
+            toggleRange: props.toggleRange,
+            selectAllInColumn: props.selectAllInColumn,
+            onMove: props.onMove,
+            onMoveSelected: props.onMoveSelected,
+            onOpen: props.onOpen,
+            onCreate: props.onCreate,
+            allTasks: props.allTasks,
+          });
+        }),
+        showTrash ? h(TrashDropZone, {
+          draggingTaskId: props.draggingTaskId,
+          selectedIds: props.selectedIds,
+          onDelete: props.onDelete,
+          onDeleteSelected: props.onDeleteSelected,
+        }) : null,
+      ];
+    }
+
+    if (visibleSwimLanes && visibleSwimLanes.length > 0) {
+      return h("div", { className: "hermes-kanban-swim-board" },
+        visibleSwimLanes.map(function (lane, laneIdx) {
+          var isLast = laneIdx === visibleSwimLanes.length - 1;
+          return h("section", {
+            key: lane.id,
+            className: "hermes-kanban-swim-row",
+            "aria-label": lane.label + " swim lane",
+          },
+            h("header", { className: "hermes-kanban-swim-row-head" },
+              h("span", { className: "hermes-kanban-swim-row-name" }, lane.label),
+              h("span", { className: "hermes-kanban-swim-row-count",
+                          title: lane.task_count + " task" + (lane.task_count === 1 ? "" : "s") },
+                lane.task_count),
+            ),
+            h("div", {
+              ref: isLast ? columnsRef : null,
+              className: cn(
+                "hermes-kanban-columns",
+                isLast && isScrollable ? "hermes-kanban-columns--scrollable" : "",
+                isLast && isPanning ? "hermes-kanban-columns--panning" : "",
+              ),
+              onDragStart: handleDragStart,
+              onDragEnd: handleDragEnd,
+              onMouseDown: isLast ? handleMouseDown : undefined,
+            },
+              renderColumnGrid({ columns: lane.columns }, lane.id, isLast),
+            ),
+          );
+        }),
+      );
+    }
+
     return h("div", {
       ref: columnsRef,
       className: cn(
@@ -2794,31 +2927,7 @@
       onDragEnd: handleDragEnd,
       onMouseDown: handleMouseDown,
     },
-      props.board.columns.map(function (col) {
-        return h(Column, {
-          key: col.name,
-          column: col,
-          boardMeta: props.boardMeta,
-          laneByProfile: props.laneByProfile,
-          selectedIds: props.selectedIds,
-          failedIds: props.failedIds,
-          draggingTaskId: props.draggingTaskId,
-          toggleSelected: props.toggleSelected,
-          toggleRange: props.toggleRange,
-          selectAllInColumn: props.selectAllInColumn,
-          onMove: props.onMove,
-          onMoveSelected: props.onMoveSelected,
-          onOpen: props.onOpen,
-          onCreate: props.onCreate,
-          allTasks: props.allTasks,
-        });
-      }),
-      h(TrashDropZone, {
-        draggingTaskId: props.draggingTaskId,
-        selectedIds: props.selectedIds,
-        onDelete: props.onDelete,
-        onDeleteSelected: props.onDeleteSelected,
-      }),
+      renderColumnGrid(props.board, "flat", true),
     );
   }
 

--- a/plugins/kanban/dashboard/dist/style.css
+++ b/plugins/kanban/dashboard/dist/style.css
@@ -197,7 +197,7 @@
   color: var(--color-foreground);
 }
 
-/* ---- Cross-column swim lanes (L3x vs other assignees) --------------- */
+/* ---- Cross-column swim lanes (Org / W3bb / L3x assignees) ------------ */
 
 .hermes-kanban-swim-board {
   display: flex;

--- a/plugins/kanban/dashboard/dist/style.css
+++ b/plugins/kanban/dashboard/dist/style.css
@@ -197,6 +197,47 @@
   color: var(--color-foreground);
 }
 
+/* ---- Cross-column swim lanes (L3x vs other assignees) --------------- */
+
+.hermes-kanban-swim-board {
+  display: flex;
+  flex-direction: column;
+  gap: 0.85rem;
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+}
+
+.hermes-kanban-swim-row {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  min-width: 0;
+}
+
+.hermes-kanban-swim-row-head {
+  display: flex;
+  align-items: center;
+  gap: 0.45rem;
+  padding: 0.15rem 0.25rem 0;
+  font-size: 0.72rem;
+  letter-spacing: 0.02em;
+  color: var(--color-muted-foreground);
+  border-bottom: 1px solid color-mix(in srgb, var(--color-border) 65%, transparent);
+}
+
+.hermes-kanban-swim-row-name {
+  font-weight: 700;
+  font-family: var(--font-mono, ui-monospace, monospace);
+  color: var(--color-foreground);
+}
+
+.hermes-kanban-swim-row-count {
+  margin-left: auto;
+  font-variant-numeric: tabular-nums;
+  font-family: var(--font-mono, ui-monospace, monospace);
+}
+
 /* ---- Lanes (per-profile sub-grouping inside Running) ---------------- */
 
 .hermes-kanban-lane {

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -665,6 +665,7 @@ class CreateTaskBody(BaseModel):
     parents: list[str] = Field(default_factory=list)
     triage: bool = False
     idempotency_key: Optional[str] = None
+    initial_status: str = "running"
     max_runtime_seconds: Optional[int] = None
     skills: Optional[list[str]] = None
     goal_mode: bool = False
@@ -697,6 +698,7 @@ def create_task(payload: CreateTaskBody, board: Optional[str] = Query(None)):
             parents=payload.parents,
             triage=payload.triage,
             idempotency_key=payload.idempotency_key,
+            initial_status=payload.initial_status,
             max_runtime_seconds=payload.max_runtime_seconds,
             skills=payload.skills,
             goal_mode=payload.goal_mode,
@@ -886,6 +888,7 @@ def remove_attachment(attachment_id: int, board: Optional[str] = Query(None)):
 
 class UpdateTaskBody(BaseModel):
     status: Optional[str] = None
+    transition_reason: Optional[str] = None
     assignee: Optional[str] = None
     priority: Optional[int] = None
     title: Optional[str] = None
@@ -955,6 +958,7 @@ def update_task(task_id: str, payload: UpdateTaskBody, board: Optional[str] = Qu
         if payload.status is not None:
             s = payload.status
             ok = True
+            transition_error: Optional[str] = None
             if s == "done":
                 ok = kanban_db.complete_task(
                     conn, task_id,
@@ -999,15 +1003,45 @@ def update_task(task_id: str, payload: UpdateTaskBody, board: Optional[str] = Qu
                     status_code=400,
                     detail="Cannot set status to 'running' directly; use the dispatcher/claim path",
                 )
-            elif s in ("todo", "triage", "scheduled"):
-                # Only a review task moving to 'todo' needs the reopen
-                # transition; fetch lazily so triage/scheduled skip the query.
-                current = kanban_db.get_task(conn, task_id) if s == "todo" else None
-                reopened = _reopen_if_review(conn, task_id, current)
-                ok = reopened if reopened is not None else _set_status_direct(conn, task_id, s)
+            elif s in ("todo", "triage"):
+                # Only review -> todo uses the dedicated review-reopen path.
+                # Every other todo/triage request goes through the audited
+                # automation transition so active, blocked, scheduled, and
+                # terminal lifecycle rules cannot be bypassed by drag/drop.
+                current = kanban_db.get_task(conn, task_id)
+                reopened = (
+                    _reopen_if_review(conn, task_id, current)
+                    if s == "todo"
+                    else None
+                )
+                if reopened is not None:
+                    ok = reopened
+                elif (
+                    s == "todo"
+                    and current is not None
+                    and current.status in {"done", "archived"}
+                ):
+                    # Preserve the established completed-parent reopen path:
+                    # _set_status_direct owns descendant invalidation and run
+                    # cleanup for this deliberate operator recovery action.
+                    ok = _set_status_direct(conn, task_id, s)
+                else:
+                    transition = kanban_db.transition_task_status(
+                        conn,
+                        task_id,
+                        target_status=s,
+                        # Audit identity is transport-derived, never accepted
+                        # from the request body where it could be spoofed.
+                        actor="dashboard",
+                        reason=payload.transition_reason,
+                    )
+                    ok = transition.ok
+                    transition_error = transition.error
             else:
                 raise HTTPException(status_code=400, detail=f"unknown status: {s}")
             if not ok:
+                if transition_error:
+                    raise HTTPException(status_code=409, detail=transition_error)
                 # For ``ready``, name the blocking parent(s) so the dashboard
                 # can render an actionable toast instead of a silent no-op.
                 # See #26744.
@@ -1235,11 +1269,13 @@ def _set_status_direct(
 
         cur = conn.execute(
             "UPDATE tasks SET status = ?, "
+            "  manual_hold = CASE WHEN ? = 'todo' THEN 1 ELSE 0 END, "
             "  claim_lock = CASE WHEN ? = 'running' THEN claim_lock ELSE NULL END, "
             "  claim_expires = CASE WHEN ? = 'running' THEN claim_expires ELSE NULL END, "
             "  worker_pid = CASE WHEN ? = 'running' THEN worker_pid ELSE NULL END "
             "WHERE id = ?",
             (
+                effective_status,
                 effective_status,
                 effective_status,
                 effective_status,
@@ -1356,6 +1392,7 @@ def delete_link(
 class BulkTaskBody(BaseModel):
     ids: list[str]
     status: Optional[str] = None
+    transition_reason: Optional[str] = None
     assignee: Optional[str] = None  # "" or None = unassign
     priority: Optional[int] = None
     archive: bool = False
@@ -1399,6 +1436,7 @@ def bulk_update(payload: BulkTaskBody, board: Optional[str] = Query(None)):
                         entry.update(ok=False, error="archive refused")
                 if payload.status is not None and not payload.archive:
                     s = payload.status
+                    transition_error: Optional[str] = None
                     if s == "done":
                         ok = kanban_db.complete_task(
                             conn, tid,
@@ -1437,16 +1475,54 @@ def bulk_update(payload: BulkTaskBody, board: Optional[str] = Query(None)):
                     elif s == "scheduled":
                         ok = kanban_db.schedule_task(conn, tid)
                     elif s in {"todo", "triage"}:
-                        # Fetch lazily: only review->todo needs reopen.
-                        cur = kanban_db.get_task(conn, tid) if s == "todo" else None
-                        reopened = _reopen_if_review(conn, tid, cur)
-                        ok = reopened if reopened is not None else _set_status_direct(conn, tid, s)
+                        # Match the single-card path: review -> todo uses the
+                        # review lifecycle; all other todo/triage requests use
+                        # the audited automation transition and fail closed for
+                        # active/blocked/scheduled/terminal cards.
+                        cur = kanban_db.get_task(conn, tid)
+                        reopened = (
+                            _reopen_if_review(conn, tid, cur)
+                            if s == "todo"
+                            else None
+                        )
+                        if reopened is not None:
+                            ok = reopened
+                        elif (
+                            s == "todo"
+                            and cur is not None
+                            and cur.status in {"done", "archived"}
+                        ):
+                            # Deliberate completed-parent reopen; mirrors the
+                            # single-card path and invalidates descendants.
+                            ok = _set_status_direct(conn, tid, s)
+                        else:
+                            transition = kanban_db.transition_task_status(
+                                conn,
+                                tid,
+                                target_status=s,
+                                actor="dashboard",
+                                reason=payload.transition_reason,
+                            )
+                            ok = transition.ok
+                            transition_error = transition.error
                     else:
                         entry.update(ok=False, error=f"unknown status {s!r}")
                         results.append(entry)
                         continue
                     if not ok:
-                        entry.update(ok=False, error=f"transition to {s!r} refused")
+                        entry.update(
+                            ok=False,
+                            error=(
+                                transition_error
+                                or f"transition to {s!r} refused"
+                            ),
+                        )
+                        if transition_error:
+                            # Match single-card PATCH fail-closed semantics:
+                            # do not partially apply unrelated fields after a
+                            # refused lifecycle transition on this card.
+                            results.append(entry)
+                            continue
                 if payload.assignee is not None:
                     try:
                         if payload.reclaim_first:

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -151,13 +151,15 @@ BOARD_COLUMNS: list[str] = [
     "triage", "todo", "scheduled", "ready", "running", "blocked", "review", "done",
 ]
 
-# Cross-column swim lane for the L3x assignee profile. The dashboard renders
-# tasks assigned to ``L3X_SWIM_LANE_ASSIGNEE`` in a dedicated horizontal row
-# spanning every lifecycle column; all other assignees (including unassigned)
-# land in the companion "Other" row.
+# Cross-column swim lanes for profile-scoped rows. The dashboard renders tasks
+# assigned to ``L3X_SWIM_LANE_ASSIGNEE`` and ``W3BB_SWIM_LANE_ASSIGNEE`` in
+# dedicated horizontal rows spanning every lifecycle column; all other assignees
+# (including unassigned) land in the companion "Org" row, which is listed first.
 L3X_SWIM_LANE_ASSIGNEE = "l3x"
+W3BB_SWIM_LANE_ASSIGNEE = "w3bb"
+W3BB_SWIM_LANE_LABEL = "W3bb"
 L3X_SWIM_LANE_OTHER_ID = "__other__"
-L3X_SWIM_LANE_OTHER_LABEL = "Other"
+L3X_SWIM_LANE_OTHER_LABEL = "Org"
 
 
 _CARD_SUMMARY_PREVIEW_CHARS = 200
@@ -167,28 +169,33 @@ def partition_swim_lanes(
     columns: list[dict[str, Any]],
     *,
     l3x_assignee: str = L3X_SWIM_LANE_ASSIGNEE,
+    w3bb_assignee: str = W3BB_SWIM_LANE_ASSIGNEE,
+    w3bb_swim_lane: bool = True,
 ) -> list[dict[str, Any]]:
-    """Split board columns into L3x vs non-L3x cross-column swim lanes.
+    """Split board columns into Org, optional W3bb, and L3x cross-column swim lanes.
 
     Each lane carries the full status column set so the UI can render a
     status grid per row without duplicating cards across lanes.
     """
     l3x_cols: list[dict[str, Any]] = []
+    w3bb_cols: list[dict[str, Any]] = []
     other_cols: list[dict[str, Any]] = []
     for col in columns:
         tasks = col.get("tasks") or []
         l3x_tasks = [t for t in tasks if t.get("assignee") == l3x_assignee]
-        other_tasks = [t for t in tasks if t.get("assignee") != l3x_assignee]
+        w3bb_tasks = (
+            [t for t in tasks if t.get("assignee") == w3bb_assignee]
+            if w3bb_swim_lane
+            else []
+        )
+        dedicated = {l3x_assignee}
+        if w3bb_swim_lane:
+            dedicated.add(w3bb_assignee)
+        other_tasks = [t for t in tasks if t.get("assignee") not in dedicated]
         l3x_cols.append({"name": col["name"], "tasks": l3x_tasks})
+        w3bb_cols.append({"name": col["name"], "tasks": w3bb_tasks})
         other_cols.append({"name": col["name"], "tasks": other_tasks})
-    return [
-        {
-            "id": l3x_assignee,
-            "label": l3x_assignee,
-            "assignee": l3x_assignee,
-            "task_count": sum(len(c["tasks"]) for c in l3x_cols),
-            "columns": l3x_cols,
-        },
+    lanes: list[dict[str, Any]] = [
         {
             "id": L3X_SWIM_LANE_OTHER_ID,
             "label": L3X_SWIM_LANE_OTHER_LABEL,
@@ -197,6 +204,26 @@ def partition_swim_lanes(
             "columns": other_cols,
         },
     ]
+    if w3bb_swim_lane:
+        lanes.append(
+            {
+                "id": w3bb_assignee,
+                "label": W3BB_SWIM_LANE_LABEL,
+                "assignee": w3bb_assignee,
+                "task_count": sum(len(c["tasks"]) for c in w3bb_cols),
+                "columns": w3bb_cols,
+            }
+        )
+    lanes.append(
+        {
+            "id": l3x_assignee,
+            "label": l3x_assignee,
+            "assignee": l3x_assignee,
+            "task_count": sum(len(c["tasks"]) for c in l3x_cols),
+            "columns": l3x_cols,
+        }
+    )
+    return lanes
 
 
 def _task_dict(
@@ -554,11 +581,18 @@ def get_board(
         k_cfg = ((cfg.get("dashboard") or {}).get("kanban") or {})
         l3x_swim_lane = bool(k_cfg.get("l3x_swim_lane", True))
         l3x_assignee = str(k_cfg.get("l3x_swim_lane_assignee") or L3X_SWIM_LANE_ASSIGNEE)
+        w3bb_swim_lane = bool(k_cfg.get("w3bb_swim_lane", True))
+        w3bb_assignee = str(k_cfg.get("w3bb_swim_lane_assignee") or W3BB_SWIM_LANE_ASSIGNEE)
 
         return {
             "columns": column_payload,
             "swim_lanes": (
-                partition_swim_lanes(column_payload, l3x_assignee=l3x_assignee)
+                partition_swim_lanes(
+                    column_payload,
+                    l3x_assignee=l3x_assignee,
+                    w3bb_assignee=w3bb_assignee,
+                    w3bb_swim_lane=w3bb_swim_lane,
+                )
                 if l3x_swim_lane
                 else None
             ),
@@ -2171,6 +2205,10 @@ def get_config():
         "l3x_swim_lane": bool(k_cfg.get("l3x_swim_lane", True)),
         "l3x_swim_lane_assignee": str(
             k_cfg.get("l3x_swim_lane_assignee") or L3X_SWIM_LANE_ASSIGNEE
+        ),
+        "w3bb_swim_lane": bool(k_cfg.get("w3bb_swim_lane", True)),
+        "w3bb_swim_lane_assignee": str(
+            k_cfg.get("w3bb_swim_lane_assignee") or W3BB_SWIM_LANE_ASSIGNEE
         ),
         "include_archived_by_default": bool(k_cfg.get("include_archived_by_default", False)),
         "render_markdown": bool(k_cfg.get("render_markdown", True)),

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -151,8 +151,52 @@ BOARD_COLUMNS: list[str] = [
     "triage", "todo", "scheduled", "ready", "running", "blocked", "review", "done",
 ]
 
+# Cross-column swim lane for the L3x assignee profile. The dashboard renders
+# tasks assigned to ``L3X_SWIM_LANE_ASSIGNEE`` in a dedicated horizontal row
+# spanning every lifecycle column; all other assignees (including unassigned)
+# land in the companion "Other" row.
+L3X_SWIM_LANE_ASSIGNEE = "l3x"
+L3X_SWIM_LANE_OTHER_ID = "__other__"
+L3X_SWIM_LANE_OTHER_LABEL = "Other"
+
 
 _CARD_SUMMARY_PREVIEW_CHARS = 200
+
+
+def partition_swim_lanes(
+    columns: list[dict[str, Any]],
+    *,
+    l3x_assignee: str = L3X_SWIM_LANE_ASSIGNEE,
+) -> list[dict[str, Any]]:
+    """Split board columns into L3x vs non-L3x cross-column swim lanes.
+
+    Each lane carries the full status column set so the UI can render a
+    status grid per row without duplicating cards across lanes.
+    """
+    l3x_cols: list[dict[str, Any]] = []
+    other_cols: list[dict[str, Any]] = []
+    for col in columns:
+        tasks = col.get("tasks") or []
+        l3x_tasks = [t for t in tasks if t.get("assignee") == l3x_assignee]
+        other_tasks = [t for t in tasks if t.get("assignee") != l3x_assignee]
+        l3x_cols.append({"name": col["name"], "tasks": l3x_tasks})
+        other_cols.append({"name": col["name"], "tasks": other_tasks})
+    return [
+        {
+            "id": l3x_assignee,
+            "label": l3x_assignee,
+            "assignee": l3x_assignee,
+            "task_count": sum(len(c["tasks"]) for c in l3x_cols),
+            "columns": l3x_cols,
+        },
+        {
+            "id": L3X_SWIM_LANE_OTHER_ID,
+            "label": L3X_SWIM_LANE_OTHER_LABEL,
+            "assignee": None,
+            "task_count": sum(len(c["tasks"]) for c in other_cols),
+            "columns": other_cols,
+        },
+    ]
 
 
 def _task_dict(
@@ -499,10 +543,25 @@ def get_board(
             )
         ]
 
+        column_payload = [
+            {"name": name, "tasks": columns[name]} for name in columns.keys()
+        ]
+        try:
+            from hermes_cli.config import load_config
+            cfg = load_config() or {}
+        except Exception:
+            cfg = {}
+        k_cfg = ((cfg.get("dashboard") or {}).get("kanban") or {})
+        l3x_swim_lane = bool(k_cfg.get("l3x_swim_lane", True))
+        l3x_assignee = str(k_cfg.get("l3x_swim_lane_assignee") or L3X_SWIM_LANE_ASSIGNEE)
+
         return {
-            "columns": [
-                {"name": name, "tasks": columns[name]} for name in columns.keys()
-            ],
+            "columns": column_payload,
+            "swim_lanes": (
+                partition_swim_lanes(column_payload, l3x_assignee=l3x_assignee)
+                if l3x_swim_lane
+                else None
+            ),
             "tenants": tenants,
             "assignees": assignees,
             "latest_event_id": int(latest_event_id),
@@ -2033,6 +2092,10 @@ def get_config():
     return {
         "default_tenant": k_cfg.get("default_tenant") or "",
         "lane_by_profile": bool(k_cfg.get("lane_by_profile", True)),
+        "l3x_swim_lane": bool(k_cfg.get("l3x_swim_lane", True)),
+        "l3x_swim_lane_assignee": str(
+            k_cfg.get("l3x_swim_lane_assignee") or L3X_SWIM_LANE_ASSIGNEE
+        ),
         "include_archived_by_default": bool(k_cfg.get("include_archived_by_default", False)),
         "render_markdown": bool(k_cfg.get("render_markdown", True)),
     }

--- a/tests/cron/test_cron_kanban_env_isolation.py
+++ b/tests/cron/test_cron_kanban_env_isolation.py
@@ -173,6 +173,26 @@ class TestKanbanGatesRespectContext:
         with non_dispatcher_owned_context():
             assert kanban_tools._default_task_id("t_explicit") == "t_explicit"
 
+    def test_all_worker_identity_guards_ignore_inherited_cron_env(
+        self, worker_env, monkeypatch
+    ):
+        from agent.delegation_context import non_dispatcher_owned_context
+        from tools import kanban_tools
+
+        monkeypatch.setattr(
+            kanban_tools, "_profile_has_kanban_toolset", lambda: True
+        )
+        with non_dispatcher_owned_context():
+            assert kanban_tools._check_kanban_orchestrator_mode() is True
+            assert kanban_tools._require_orchestrator_tool("kanban_transition") is None
+            assert kanban_tools._enforce_worker_task_ownership("t_foreign") is None
+            assert kanban_tools._worker_run_id("t_worker_real_task") is None
+            assert kanban_tools._stamp_worker_session_metadata(
+                "t_worker_real_task", {"kept": True}
+            ) == {"kept": True}
+            assert kanban_tools.heartbeat_current_worker_from_env() is False
+            assert kanban_tools.inject_new_comments_from_env(object()) is False
+
     def test_skill_environment_gate(self, worker_env):
         from agent.delegation_context import non_dispatcher_owned_context
         import agent.skill_utils as su

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -158,6 +158,7 @@ def test_connect_migrates_legacy_db_before_optional_column_indexes(tmp_path):
     assert "session_id" in task_columns
     assert "tenant" in task_columns
     assert "idempotency_key" in task_columns
+    assert "manual_hold" in task_columns
     assert "run_id" in event_columns
     # And their indexes — the regression scope of this test:
     assert "idx_tasks_session_id" in indexes

--- a/tests/hermes_cli/test_kanban_status_transition.py
+++ b/tests/hermes_cli/test_kanban_status_transition.py
@@ -1,0 +1,410 @@
+"""Cron-safe Kanban todo/triage lifecycle transitions."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import threading
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import kanban as kb_cli
+from hermes_cli import kanban_db as kb
+
+
+@pytest.fixture
+def kanban_home(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb._INITIALIZED_PATHS.clear()
+    kb.init_db()
+    return home
+
+
+def _run_cli(*argv: str) -> int:
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest="command")
+    kb_cli.build_parser(subparsers)
+    args = parser.parse_args(["kanban", *argv])
+    return kb_cli.kanban_command(args)
+
+
+def test_idempotent_linkedin_cron_card_preserves_identity_comments_and_no_spawns(
+    kanban_home, monkeypatch
+):
+    spawn_calls: list[str] = []
+    monkeypatch.setattr("hermes_cli.profiles.profile_exists", lambda _name: True)
+
+    with kb.connect() as conn:
+        task_id = kb.create_task(
+            conn,
+            title="LinkedIn M/W/F weekly post",
+            assignee="publisher",
+            initial_status="todo",
+            idempotency_key="linkedin-post:2026-W33",
+        )
+        comment_id = kb.add_comment(
+            conn,
+            task_id,
+            author="linkedin-content-cron",
+            body="Drafts for Monday, Wednesday, and Friday are queued.",
+        )
+        reused_id = kb.create_task(
+            conn,
+            title="LinkedIn M/W/F weekly post (retry)",
+            assignee="publisher",
+            initial_status="todo",
+            idempotency_key="linkedin-post:2026-W33",
+        )
+
+        assert reused_id == task_id
+        task = kb.get_task(conn, task_id)
+        assert task is not None
+        assert task.status == "todo"
+        assert task.manual_hold is True
+        assert conn.execute("SELECT COUNT(*) FROM tasks").fetchone()[0] == 1
+
+        first_tick = kb.dispatch_once(
+            conn,
+            spawn_fn=lambda task, _workspace: spawn_calls.append(task.id),
+        )
+        assert first_tick.promoted == 0
+        assert first_tick.spawned == []
+        assert spawn_calls == []
+        task = kb.get_task(conn, task_id)
+        assert task is not None
+        assert task.status == "todo"
+
+        transition = kb.transition_task_status(
+            conn,
+            task_id,
+            target_status="triage",
+            actor="linkedin-analytics-cron",
+            reason="Friday analytics started",
+        )
+        assert transition.ok is True
+        assert transition.changed is True
+        assert transition.error is None
+
+        # Retrying the transition is idempotent: no duplicate event or task.
+        transition = kb.transition_task_status(
+            conn,
+            task_id,
+            target_status="triage",
+            actor="linkedin-analytics-cron",
+            reason="Friday analytics started",
+        )
+        assert transition.ok is True
+        assert transition.changed is False
+        assert transition.error is None
+
+        second_tick = kb.dispatch_once(
+            conn,
+            spawn_fn=lambda task, _workspace: spawn_calls.append(task.id),
+        )
+        assert second_tick.spawned == []
+        assert spawn_calls == []
+        task = kb.get_task(conn, task_id)
+        assert task is not None
+        assert task.status == "triage"
+        assert conn.execute("SELECT COUNT(*) FROM tasks").fetchone()[0] == 1
+        comments = kb.list_comments(conn, task_id)
+        assert [comment.id for comment in comments] == [comment_id]
+        assert [comment.task_id for comment in comments] == [task_id]
+        assert [comment.author for comment in comments] == [
+            "linkedin-content-cron"
+        ]
+        assert [comment.body for comment in comments] == [
+            "Drafts for Monday, Wednesday, and Friday are queued."
+        ]
+
+        transitions = [
+            event
+            for event in kb.list_events(conn, task_id)
+            if event.kind == "status_transitioned"
+        ]
+        assert len(transitions) == 1
+        assert transitions[0].payload == {
+            "source_status": "todo",
+            "target_status": "triage",
+            "actor": "linkedin-analytics-cron",
+            "reason": "Friday analytics started",
+        }
+        assert transitions[0].created_at > 0
+
+
+def test_concurrent_idempotent_create_rechecks_after_write_lock(kanban_home):
+    """A retry that loses the write race must reuse the committed winner."""
+    key = "linkedin-post:company-page:2026-W33"
+    lookup_seen = threading.Event()
+    result: dict[str, str] = {}
+    errors: list[BaseException] = []
+    retry_thread: threading.Thread | None = None
+    first_conn = kb.connect()
+
+    def create_retry() -> None:
+        try:
+            with kb.connect_closing() as retry_conn:
+                retry_conn.set_trace_callback(
+                    lambda statement: lookup_seen.set()
+                    if "SELECT id FROM tasks WHERE idempotency_key" in statement
+                    else None
+                )
+                result["id"] = kb.create_task(
+                    retry_conn,
+                    title="LinkedIn M/W/F weekly post retry",
+                    assignee="publisher",
+                    initial_status="todo",
+                    idempotency_key=key,
+                )
+        except BaseException as exc:  # pragma: no cover - asserted below
+            errors.append(exc)
+
+    try:
+        with kb.write_txn(first_conn):
+            first_id = kb.create_task(
+                first_conn,
+                title="LinkedIn M/W/F weekly post",
+                assignee="publisher",
+                initial_status="todo",
+                idempotency_key=key,
+            )
+            retry_thread = threading.Thread(target=create_retry)
+            retry_thread.start()
+            assert lookup_seen.wait(5), "retry never reached optimistic lookup"
+            assert retry_thread.is_alive(), "retry should be waiting on write lock"
+    finally:
+        if retry_thread is not None:
+            retry_thread.join(10)
+        first_conn.close()
+
+    assert retry_thread is not None
+    assert not retry_thread.is_alive()
+    assert errors == []
+    assert result["id"] == first_id
+    with kb.connect_closing() as conn:
+        assert conn.execute(
+            "SELECT COUNT(*) FROM tasks WHERE idempotency_key = ?",
+            (key,),
+        ).fetchone()[0] == 1
+
+
+def test_claim_and_transition_race_has_one_winner(kanban_home):
+    """A card cannot become both claimed and triaged in the same race."""
+    with kb.connect_closing() as conn:
+        task_id = kb.create_task(conn, title="race", assignee="publisher")
+
+    barrier = threading.Barrier(2)
+    results: dict[str, object] = {}
+    errors: list[BaseException] = []
+
+    def claim() -> None:
+        try:
+            with kb.connect_closing() as conn:
+                barrier.wait()
+                results["claimed"] = kb.claim_task(conn, task_id)
+        except BaseException as exc:  # pragma: no cover - asserted below
+            errors.append(exc)
+
+    def transition() -> None:
+        try:
+            with kb.connect_closing() as conn:
+                barrier.wait()
+                results["transition"] = kb.transition_task_status(
+                    conn,
+                    task_id,
+                    target_status="triage",
+                    actor="linkedin-analytics-cron",
+                )
+        except BaseException as exc:  # pragma: no cover - asserted below
+            errors.append(exc)
+
+    claim_thread = threading.Thread(target=claim)
+    transition_thread = threading.Thread(target=transition)
+    claim_thread.start()
+    transition_thread.start()
+    claim_thread.join(10)
+    transition_thread.join(10)
+
+    assert not claim_thread.is_alive()
+    assert not transition_thread.is_alive()
+    assert errors == []
+    claimed = results["claimed"]
+    transition_result = results["transition"]
+    assert isinstance(transition_result, kb.StatusTransitionResult)
+    assert bool(claimed) != transition_result.ok
+
+    with kb.connect_closing() as conn:
+        task = kb.get_task(conn, task_id)
+        assert task is not None
+        assert task.status == ("running" if claimed else "triage")
+
+
+def test_dependency_todo_keeps_legacy_auto_promotion(kanban_home):
+    with kb.connect_closing() as conn:
+        parent_id = kb.create_task(conn, title="parent")
+        child_id = kb.create_task(conn, title="child", parents=[parent_id])
+        child = kb.get_task(conn, child_id)
+        assert child is not None
+        assert child.status == "todo"
+        assert child.manual_hold is False
+
+        assert kb.complete_task(conn, parent_id)
+        child = kb.get_task(conn, child_id)
+        assert child is not None
+        assert child.status == "ready"
+
+
+def test_transition_to_todo_is_a_manual_hold_until_promoted(
+    kanban_home, monkeypatch
+):
+    spawn_calls: list[str] = []
+    monkeypatch.setattr("hermes_cli.profiles.profile_exists", lambda _name: True)
+
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="stage release", assignee="publisher")
+        transition = kb.transition_task_status(
+            conn,
+            task_id,
+            target_status="todo",
+            actor="release-cron",
+            reason="wait for package assembly",
+        )
+        assert transition.ok is True
+        assert transition.changed is True
+        assert transition.error is None
+        task = kb.get_task(conn, task_id)
+        assert task is not None
+        assert task.status == "todo"
+        assert task.manual_hold is True
+
+        held_tick = kb.dispatch_once(
+            conn,
+            spawn_fn=lambda task, _workspace: spawn_calls.append(task.id),
+        )
+        assert held_tick.promoted == 0
+        assert spawn_calls == []
+
+        promoted, promote_error = kb.promote_task(
+            conn,
+            task_id,
+            actor="release-cron",
+            reason="assembly can start",
+        )
+        assert promoted is True
+        assert promote_error is None
+        task = kb.get_task(conn, task_id)
+        assert task is not None
+        assert task.manual_hold is False
+
+        released_tick = kb.dispatch_once(
+            conn,
+            spawn_fn=lambda task, _workspace: spawn_calls.append(task.id),
+        )
+        assert [task_id] == spawn_calls
+        assert [row[0] for row in released_tick.spawned] == [task_id]
+
+
+def test_transition_refuses_active_or_terminal_tasks(kanban_home):
+    with kb.connect() as conn:
+        running_id = kb.create_task(conn, title="active", assignee="worker")
+        assert kb.claim_task(conn, running_id) is not None
+        transition = kb.transition_task_status(
+            conn,
+            running_id,
+            target_status="triage",
+            actor="cron",
+        )
+        assert transition.ok is False
+        assert "running" in (transition.error or "")
+        running = kb.get_task(conn, running_id)
+        assert running is not None
+        assert running.status == "running"
+
+        done_id = kb.create_task(conn, title="finished")
+        assert kb.complete_task(conn, done_id)
+        transition = kb.transition_task_status(
+            conn,
+            done_id,
+            target_status="todo",
+            actor="cron",
+        )
+        assert transition.ok is False
+        assert "done" in (transition.error or "")
+        done = kb.get_task(conn, done_id)
+        assert done is not None
+        assert done.status == "done"
+
+
+def test_cli_create_reuses_held_todo_then_transitions_to_triage(
+    kanban_home, monkeypatch, capsys
+):
+    monkeypatch.setenv("HERMES_PROFILE", "linkedin-analytics-cron")
+
+    create_args = (
+        "create",
+        "LinkedIn M/W/F weekly post",
+        "--assignee",
+        "publisher",
+        "--initial-status",
+        "todo",
+        "--idempotency-key",
+        "linkedin-post:2026-W33",
+        "--json",
+    )
+    assert _run_cli(*create_args) == 0
+    first = json.loads(capsys.readouterr().out)
+    assert first["status"] == "todo"
+
+    assert _run_cli(*create_args) == 0
+    reused = json.loads(capsys.readouterr().out)
+    assert reused["id"] == first["id"]
+
+    assert _run_cli(
+        "transition",
+        first["id"],
+        "--to",
+        "triage",
+        "--reason",
+        "Friday analytics started",
+        "--json",
+    ) == 0
+    transitioned = json.loads(capsys.readouterr().out)
+    assert transitioned == {
+        "task_id": first["id"],
+        "source_status": "todo",
+        "target_status": "triage",
+        "actor": "linkedin-analytics-cron",
+        "reason": "Friday analytics started",
+        "transitioned": True,
+        "error": None,
+    }
+
+    assert _run_cli(
+        "transition",
+        first["id"],
+        "--to",
+        "triage",
+        "--reason",
+        "Friday analytics retry",
+        "--json",
+    ) == 0
+    no_op = json.loads(capsys.readouterr().out)
+    assert no_op == {
+        "task_id": first["id"],
+        "source_status": "triage",
+        "target_status": "triage",
+        "actor": "linkedin-analytics-cron",
+        "reason": "Friday analytics retry",
+        "transitioned": False,
+        "error": None,
+    }
+
+    with kb.connect() as conn:
+        task = kb.get_task(conn, first["id"])
+        assert task is not None
+        assert task.status == "triage"
+        assert conn.execute("SELECT COUNT(*) FROM tasks").fetchone()[0] == 1

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -29,6 +29,11 @@ from hermes_cli import kanban_db as kb
 
 def _load_plugin_router():
     """Dynamically load plugins/kanban/dashboard/plugin_api.py and return its router."""
+    return _load_plugin_module().router
+
+
+def _load_plugin_module():
+    """Dynamically load plugins/kanban/dashboard/plugin_api.py."""
     repo_root = Path(__file__).resolve().parents[2]
     plugin_file = repo_root / "plugins" / "kanban" / "dashboard" / "plugin_api.py"
     assert plugin_file.exists(), f"plugin file missing: {plugin_file}"
@@ -40,7 +45,7 @@ def _load_plugin_router():
     mod = importlib.util.module_from_spec(spec)
     sys.modules[spec.name] = mod
     spec.loader.exec_module(mod)
-    return mod.router
+    return mod
 
 
 @pytest.fixture
@@ -79,11 +84,14 @@ def test_board_empty(client):
     assert data["tenants"] == []
     assert data["assignees"] == []
     assert data["latest_event_id"] == 0
-    # Default-on L3x cross-column swim lanes: two rows, no cards.
+    # Default-on cross-column swim lanes: Org, W3bb, l3x — no cards.
     assert data["swim_lanes"] is not None
-    assert len(data["swim_lanes"]) == 2
-    assert data["swim_lanes"][0]["id"] == "l3x"
-    assert data["swim_lanes"][1]["id"] == "__other__"
+    assert len(data["swim_lanes"]) == 3
+    assert data["swim_lanes"][0]["id"] == "__other__"
+    assert data["swim_lanes"][0]["label"] == "Org"
+    assert data["swim_lanes"][1]["id"] == "w3bb"
+    assert data["swim_lanes"][1]["label"] == "W3bb"
+    assert data["swim_lanes"][2]["id"] == "l3x"
     assert all(lane["task_count"] == 0 for lane in data["swim_lanes"])
 
 
@@ -1080,8 +1088,8 @@ def test_bulk_empty_ids_400(client):
 # ---------------------------------------------------------------------------
 
 
-def test_board_swim_lanes_partition_l3x_and_other(client):
-    """L3x-assigned tasks land in the l3x swim lane across all status columns."""
+def test_board_swim_lanes_partition_l3x_and_org(client):
+    """L3x-assigned tasks land in the l3x swim lane; Org is first and labeled."""
     placements = [
         ("L3x ready", "l3x", "ready"),
         ("L3x review", "l3x", "review"),
@@ -1109,6 +1117,10 @@ def test_board_swim_lanes_partition_l3x_and_other(client):
     data = r.json()
     swim = data["swim_lanes"]
     assert swim is not None
+    assert swim[0]["id"] == "__other__"
+    assert swim[0]["label"] == "Org"
+    assert swim[1]["id"] == "w3bb"
+    assert swim[2]["id"] == "l3x"
     l3x_lane = next(lane for lane in swim if lane["id"] == "l3x")
     other_lane = next(lane for lane in swim if lane["id"] == "__other__")
 
@@ -1127,6 +1139,96 @@ def test_board_swim_lanes_partition_l3x_and_other(client):
 
     flat_ids = {t["id"] for col in data["columns"] for t in col["tasks"]}
     assert flat_ids == {t["id"] for t in created}
+
+
+def test_partition_swim_lanes_org_first_with_label():
+    mod = _load_plugin_module()
+    columns = [
+        {
+            "name": "ready",
+            "tasks": [
+                {"id": "t1", "assignee": "l3x"},
+                {"id": "t2", "assignee": "R1ft"},
+                {"id": "t3", "assignee": None},
+            ],
+        }
+    ]
+    lanes = mod.partition_swim_lanes(columns)
+    assert [lane["id"] for lane in lanes] == ["__other__", "w3bb", "l3x"]
+    assert lanes[0]["label"] == "Org"
+    assert lanes[1]["label"] == "W3bb"
+    assert lanes[2]["label"] == "l3x"
+    assert {t["id"] for t in lanes[0]["columns"][0]["tasks"]} == {"t2", "t3"}
+    assert {t["id"] for t in lanes[2]["columns"][0]["tasks"]} == {"t1"}
+
+
+def test_board_swim_lanes_partition_w3bb(client):
+    """W3bb-assigned tasks land in the W3bb swim lane; Org and L3x bucketing unchanged."""
+    placements = [
+        ("W3bb todo", "w3bb", "todo"),
+        ("W3bb ready", "w3bb", "ready"),
+        ("L3x running", "l3x", "running"),
+        ("R1ft triage", "R1ft", "triage"),
+    ]
+    created = []
+    for title, assignee, status in placements:
+        r = client.post(
+            "/api/plugins/kanban/tasks",
+            json={"title": title, "assignee": assignee},
+        )
+        assert r.status_code == 200, r.text
+        task = r.json()["task"]
+        with kb.connect() as conn:
+            with kb.write_txn(conn):
+                conn.execute(
+                    "UPDATE tasks SET status = ? WHERE id = ?",
+                    (status, task["id"]),
+                )
+        created.append({**task, "status": status, "assignee": assignee})
+
+    r = client.get("/api/plugins/kanban/board")
+    assert r.status_code == 200
+    swim = r.json()["swim_lanes"]
+    w3bb_lane = next(lane for lane in swim if lane["id"] == "w3bb")
+    l3x_lane = next(lane for lane in swim if lane["id"] == "l3x")
+    org_lane = next(lane for lane in swim if lane["id"] == "__other__")
+
+    assert w3bb_lane["label"] == "W3bb"
+    assert w3bb_lane["task_count"] == 2
+    assert l3x_lane["task_count"] == 1
+    assert org_lane["task_count"] == 1
+
+    w3bb_todo = next(c for c in w3bb_lane["columns"] if c["name"] == "todo")
+    w3bb_ready = next(c for c in w3bb_lane["columns"] if c["name"] == "ready")
+    assert {t["id"] for t in w3bb_todo["tasks"]} == {created[0]["id"]}
+    assert {t["id"] for t in w3bb_ready["tasks"]} == {created[1]["id"]}
+
+    l3x_running = next(c for c in l3x_lane["columns"] if c["name"] == "running")
+    assert {t["id"] for t in l3x_running["tasks"]} == {created[2]["id"]}
+
+    org_triage = next(c for c in org_lane["columns"] if c["name"] == "triage")
+    assert {t["id"] for t in org_triage["tasks"]} == {created[3]["id"]}
+
+
+def test_board_swim_lanes_w3bb_disabled_via_config(tmp_path, monkeypatch, client):
+    home = Path(os.environ["HERMES_HOME"])
+    (home / "config.yaml").write_text(
+        "dashboard:\n"
+        "  kanban:\n"
+        "    w3bb_swim_lane: false\n"
+    )
+    r = client.post(
+        "/api/plugins/kanban/tasks",
+        json={"title": "W3bb only", "assignee": "w3bb"},
+    )
+    assert r.status_code == 200
+    r = client.get("/api/plugins/kanban/board")
+    assert r.status_code == 200
+    swim = r.json()["swim_lanes"]
+    assert len(swim) == 2
+    assert [lane["id"] for lane in swim] == ["__other__", "l3x"]
+    org_lane = swim[0]
+    assert org_lane["task_count"] == 1
 
 
 def test_board_swim_lanes_disabled_via_config(tmp_path, monkeypatch, client):
@@ -1163,6 +1265,8 @@ def test_config_reads_dashboard_kanban_section(tmp_path, monkeypatch, client):
     assert data["lane_by_profile"] is False
     assert data["l3x_swim_lane"] is True
     assert data["l3x_swim_lane_assignee"] == "l3x"
+    assert data["w3bb_swim_lane"] is True
+    assert data["w3bb_swim_lane_assignee"] == "w3bb"
     assert data["include_archived_by_default"] is True
     assert data["render_markdown"] is False
 

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -122,6 +122,132 @@ def test_create_task_appears_on_board(client):
     assert "researcher" in data["assignees"]
 
 
+def test_api_reuses_held_todo_then_audits_transition_to_triage(client):
+    create_payload = {
+        "title": "LinkedIn M/W/F weekly post",
+        "assignee": "publisher",
+        "initial_status": "todo",
+        "idempotency_key": "linkedin-post:2026-W33",
+    }
+    first = client.post("/api/plugins/kanban/tasks", json=create_payload)
+    assert first.status_code == 200, first.text
+    task = first.json()["task"]
+    assert task["status"] == "todo"
+
+    reused = client.post("/api/plugins/kanban/tasks", json=create_payload)
+    assert reused.status_code == 200, reused.text
+    assert reused.json()["task"]["id"] == task["id"]
+
+    transitioned = client.patch(
+        f"/api/plugins/kanban/tasks/{task['id']}",
+        json={
+            "status": "triage",
+            # Untrusted caller labels must not become audit identity.
+            "transition_actor": "linkedin-analytics-cron",
+            "transition_reason": "Friday analytics started",
+        },
+    )
+    assert transitioned.status_code == 200, transitioned.text
+    assert transitioned.json()["task"]["status"] == "triage"
+
+    detail = client.get(
+        f"/api/plugins/kanban/tasks/{task['id']}"
+    ).json()
+    events = [
+        event for event in detail["events"]
+        if event["kind"] == "status_transitioned"
+    ]
+    assert len(events) == 1
+    assert events[0]["payload"] == {
+        "source_status": "todo",
+        "target_status": "triage",
+        "actor": "dashboard",
+        "reason": "Friday analytics started",
+    }
+
+    with kb.connect() as conn:
+        assert conn.execute("SELECT COUNT(*) FROM tasks").fetchone()[0] == 1
+
+
+def test_api_transition_refuses_running_task_instead_of_direct_status_write(client):
+    created = client.post(
+        "/api/plugins/kanban/tasks",
+        json={"title": "active work", "assignee": "publisher"},
+    )
+    assert created.status_code == 200, created.text
+    task_id = created.json()["task"]["id"]
+
+    with kb.connect() as conn:
+        claimed = kb.claim_task(conn, task_id)
+        assert claimed is not None
+
+    response = client.patch(
+        f"/api/plugins/kanban/tasks/{task_id}",
+        json={
+            "status": "triage",
+            "transition_actor": "linkedin-analytics-cron",
+            "transition_reason": "Friday analytics started",
+        },
+    )
+    assert response.status_code == 409, response.text
+
+    with kb.connect() as conn:
+        task = kb.get_task(conn, task_id)
+        assert task is not None
+        assert task.status == "running"
+        assert not any(
+            event.kind == "status_transitioned"
+            for event in kb.list_events(conn, task_id)
+        )
+
+
+def test_bulk_transition_refusal_does_not_apply_unrelated_fields(client):
+    created = client.post(
+        "/api/plugins/kanban/tasks",
+        json={"title": "active bulk work", "assignee": "publisher"},
+    )
+    assert created.status_code == 200, created.text
+    task_id = created.json()["task"]["id"]
+
+    with kb.connect() as conn:
+        assert kb.claim_task(conn, task_id) is not None
+
+    response = client.post(
+        "/api/plugins/kanban/tasks/bulk",
+        json={
+            "ids": [task_id],
+            "status": "triage",
+            "transition_reason": "Friday analytics started",
+            "priority": 99,
+        },
+    )
+    assert response.status_code == 200, response.text
+    assert response.json()["results"] == [
+        {
+            "id": task_id,
+            "ok": False,
+            "error": (
+                f"task {task_id} is 'running'; todo/triage transitions only "
+                "apply to unclaimed 'ready', 'todo', or 'triage' tasks"
+            ),
+        }
+    ]
+
+    with kb.connect() as conn:
+        task = kb.get_task(conn, task_id)
+        assert task is not None
+        assert task.status == "running"
+        assert task.priority == 0
+
+
+def test_api_rejects_unknown_initial_status(client):
+    response = client.post(
+        "/api/plugins/kanban/tasks",
+        json={"title": "bad lane", "initial_status": "running-now"},
+    )
+    assert response.status_code == 400, response.text
+
+
 def test_patch_board_sets_project_directory(client, tmp_path):
     """Board-level default_workdir must be editable after creation."""
     kb.create_board("late-config")

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -79,6 +79,12 @@ def test_board_empty(client):
     assert data["tenants"] == []
     assert data["assignees"] == []
     assert data["latest_event_id"] == 0
+    # Default-on L3x cross-column swim lanes: two rows, no cards.
+    assert data["swim_lanes"] is not None
+    assert len(data["swim_lanes"]) == 2
+    assert data["swim_lanes"][0]["id"] == "l3x"
+    assert data["swim_lanes"][1]["id"] == "__other__"
+    assert all(lane["task_count"] == 0 for lane in data["swim_lanes"])
 
 
 # ---------------------------------------------------------------------------
@@ -944,6 +950,72 @@ def test_bulk_empty_ids_400(client):
 
 
 # ---------------------------------------------------------------------------
+# L3x cross-column swim lanes
+# ---------------------------------------------------------------------------
+
+
+def test_board_swim_lanes_partition_l3x_and_other(client):
+    """L3x-assigned tasks land in the l3x swim lane across all status columns."""
+    placements = [
+        ("L3x ready", "l3x", "ready"),
+        ("L3x review", "l3x", "review"),
+        ("R1ft todo", "R1ft", "todo"),
+        ("Unassigned triage", None, "triage"),
+    ]
+    created = []
+    for title, assignee, status in placements:
+        payload = {"title": title}
+        if assignee:
+            payload["assignee"] = assignee
+        r = client.post("/api/plugins/kanban/tasks", json=payload)
+        assert r.status_code == 200, r.text
+        task = r.json()["task"]
+        with kb.connect() as conn:
+            with kb.write_txn(conn):
+                conn.execute(
+                    "UPDATE tasks SET status = ?, assignee = ? WHERE id = ?",
+                    (status, assignee, task["id"]),
+                )
+        created.append({**task, "status": status, "assignee": assignee})
+
+    r = client.get("/api/plugins/kanban/board")
+    assert r.status_code == 200
+    data = r.json()
+    swim = data["swim_lanes"]
+    assert swim is not None
+    l3x_lane = next(lane for lane in swim if lane["id"] == "l3x")
+    other_lane = next(lane for lane in swim if lane["id"] == "__other__")
+
+    assert l3x_lane["task_count"] == 2
+    assert other_lane["task_count"] == 2
+
+    l3x_ready = next(c for c in l3x_lane["columns"] if c["name"] == "ready")
+    l3x_review = next(c for c in l3x_lane["columns"] if c["name"] == "review")
+    assert {t["id"] for t in l3x_ready["tasks"]} == {created[0]["id"]}
+    assert {t["id"] for t in l3x_review["tasks"]} == {created[1]["id"]}
+
+    other_triage = next(c for c in other_lane["columns"] if c["name"] == "triage")
+    other_todo = next(c for c in other_lane["columns"] if c["name"] == "todo")
+    assert {t["id"] for t in other_triage["tasks"]} == {created[3]["id"]}
+    assert {t["id"] for t in other_todo["tasks"]} == {created[2]["id"]}
+
+    flat_ids = {t["id"] for col in data["columns"] for t in col["tasks"]}
+    assert flat_ids == {t["id"] for t in created}
+
+
+def test_board_swim_lanes_disabled_via_config(tmp_path, monkeypatch, client):
+    home = Path(os.environ["HERMES_HOME"])
+    (home / "config.yaml").write_text(
+        "dashboard:\n"
+        "  kanban:\n"
+        "    l3x_swim_lane: false\n"
+    )
+    r = client.get("/api/plugins/kanban/board")
+    assert r.status_code == 200
+    assert r.json()["swim_lanes"] is None
+
+
+# ---------------------------------------------------------------------------
 # /config endpoint
 # ---------------------------------------------------------------------------
 
@@ -963,6 +1035,8 @@ def test_config_reads_dashboard_kanban_section(tmp_path, monkeypatch, client):
     data = r.json()
     assert data["default_tenant"] == "acme"
     assert data["lane_by_profile"] is False
+    assert data["l3x_swim_lane"] is True
+    assert data["l3x_swim_lane_assignee"] == "l3x"
     assert data["include_archived_by_default"] is True
     assert data["render_markdown"] is False
 

--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -416,6 +416,142 @@ def test_create_happy_path(worker_env):
         conn.close()
 
 
+def test_create_assigned_held_todo_is_idempotent(worker_env):
+    """Cron-owned staging cards keep the existing assignee contract."""
+    from tools import kanban_tools as kt
+
+    args = {
+        "title": "LinkedIn M/W/F weekly post",
+        "assignee": "publisher",
+        "initial_status": "todo",
+        "idempotency_key": "linkedin-post:2026-W33",
+    }
+    first = json.loads(kt._handle_create(args))
+    second = json.loads(kt._handle_create(args))
+
+    assert first["ok"] is True
+    assert first["status"] == "todo"
+    assert second["task_id"] == first["task_id"]
+
+    from hermes_cli import kanban_db as kb
+
+    with kb.connect() as conn:
+        task = kb.get_task(conn, first["task_id"])
+        assert task is not None
+        assert task.assignee == "publisher"
+        assert task.manual_hold is True
+        assert conn.execute(
+            "SELECT COUNT(*) FROM tasks WHERE idempotency_key = ?",
+            ("linkedin-post:2026-W33",),
+        ).fetchone()[0] == 1
+
+
+def test_transition_tool_moves_existing_todo_to_triage(monkeypatch, worker_env):
+    monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
+    monkeypatch.setenv("HERMES_PROFILE", "linkedin-analytics-cron")
+
+    from hermes_cli import kanban_db as kb
+    from tools import kanban_tools as kt
+
+    with kb.connect() as conn:
+        task_id = kb.create_task(
+            conn,
+            title="LinkedIn M/W/F weekly post",
+            assignee="publisher",
+            initial_status="todo",
+        )
+
+    result = json.loads(
+        kt._handle_transition(
+            {
+                "task_id": task_id,
+                "target_status": "triage",
+                "reason": "Friday analytics started",
+            }
+        )
+    )
+    assert result == {
+        "ok": True,
+        "task_id": task_id,
+        "source_status": "todo",
+        "status": "triage",
+        "transitioned": True,
+    }
+
+    with kb.connect() as conn:
+        event = [
+            item
+            for item in kb.list_events(conn, task_id)
+            if item.kind == "status_transitioned"
+        ][0]
+        assert event.payload is not None
+        assert event.payload["actor"] == "linkedin-analytics-cron"
+        assert event.payload["reason"] == "Friday analytics started"
+
+
+def test_transition_tool_ignores_inherited_worker_scope_for_cron_context(
+    monkeypatch, worker_env
+):
+    """An in-process cron keeps env vars but is not the parent worker."""
+    from agent.delegation_context import non_dispatcher_owned_context
+    from hermes_cli import kanban_db as kb
+    from tools import kanban_tools as kt
+
+    monkeypatch.setenv("HERMES_PROFILE", "linkedin-analytics-cron")
+    monkeypatch.setattr(kt, "_profile_has_kanban_toolset", lambda: True)
+    with kb.connect_closing() as conn:
+        task_id = kb.create_task(
+            conn,
+            title="LinkedIn M/W/F weekly post",
+            assignee="publisher",
+            initial_status="todo",
+        )
+
+    with non_dispatcher_owned_context():
+        assert kt._check_kanban_orchestrator_mode() is True
+        result = json.loads(
+            kt._handle_transition(
+                {
+                    "task_id": task_id,
+                    "target_status": "triage",
+                    "reason": "Friday analytics started",
+                }
+            )
+        )
+
+    assert result == {
+        "ok": True,
+        "task_id": task_id,
+        "source_status": "todo",
+        "status": "triage",
+        "transitioned": True,
+    }
+
+
+def test_transition_tool_is_exposed_on_kanban_and_codex_surfaces():
+    from agent.transports.hermes_tools_mcp_server import EXPOSED_TOOLS
+    from toolsets import TOOLSETS, _HERMES_CORE_TOOLS
+    from tools import kanban_tools as kt
+
+    assert "kanban_transition" in _HERMES_CORE_TOOLS
+    kanban_tools = TOOLSETS["kanban"]["tools"]
+    assert isinstance(kanban_tools, list)
+    assert "kanban_transition" in kanban_tools
+    assert "kanban_transition" in EXPOSED_TOOLS
+    create_parameters = kt.KANBAN_CREATE_SCHEMA["parameters"]
+    assert isinstance(create_parameters, dict)
+    assert create_parameters["required"] == [
+        "title",
+        "assignee",
+    ]
+    transition_parameters = kt.KANBAN_TRANSITION_SCHEMA["parameters"]
+    assert isinstance(transition_parameters, dict)
+    assert transition_parameters["required"] == [
+        "task_id",
+        "target_status",
+    ]
+
+
 def test_link_happy_path(worker_env):
     from hermes_cli import kanban_db as kb
     conn = kb.connect()

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -155,7 +155,10 @@ def _default_task_id(arg: Optional[str]) -> Optional[str]:
 
 def _worker_run_id(task_id: str) -> Optional[int]:
     """Return this worker's dispatcher run id when it is scoped to task_id."""
-    if os.environ.get("HERMES_KANBAN_TASK") != task_id:
+    if (
+        not _is_dispatcher_owned_worker()
+        or os.environ.get("HERMES_KANBAN_TASK") != task_id
+    ):
         return None
     raw = os.environ.get("HERMES_KANBAN_RUN_ID")
     if not raw:
@@ -170,7 +173,10 @@ def _stamp_worker_session_metadata(
     task_id: str, metadata: Optional[dict]
 ) -> Optional[dict]:
     """Add trusted worker session id metadata for this worker's own task."""
-    if os.environ.get("HERMES_KANBAN_TASK") != task_id:
+    if (
+        not _is_dispatcher_owned_worker()
+        or os.environ.get("HERMES_KANBAN_TASK") != task_id
+    ):
         return metadata
     session_id = os.environ.get("HERMES_SESSION_ID")
     if not session_id:
@@ -199,7 +205,11 @@ def _enforce_worker_task_ownership(tid: str) -> Optional[str]:
     when it must be rejected. Callers should ``return`` the error
     verbatim.
     """
-    env_tid = os.environ.get("HERMES_KANBAN_TASK")
+    env_tid = (
+        os.environ.get("HERMES_KANBAN_TASK")
+        if _is_dispatcher_owned_worker()
+        else None
+    )
     if not env_tid:
         # Orchestrator or CLI context — no task-scope restriction.
         return None
@@ -320,6 +330,8 @@ def heartbeat_current_worker_from_env() -> bool:
     the worst case is one extra DB write per race, which is harmless.
     """
     global _auto_heartbeat_last_attempt
+    if not _is_dispatcher_owned_worker():
+        return False
     tid = os.environ.get("HERMES_KANBAN_TASK")
     if not tid:
         return False
@@ -381,6 +393,8 @@ def inject_new_comments_from_env(agent: Any) -> bool:
     the run started are injected. The worker's own authored comments (matched
     by ``HERMES_PROFILE``) are skipped to avoid echoing itself.
     """
+    if not _is_dispatcher_owned_worker():
+        return False
     tid = os.environ.get("HERMES_KANBAN_TASK")
     if not tid or agent is None or not hasattr(agent, "steer"):
         return False
@@ -473,7 +487,10 @@ def _require_orchestrator_tool(tool_name: str) -> Optional[str]:
     structured tool_error so the model gets a clear refusal instead of
     silently mutating board state from a worker context.
     """
-    if os.environ.get("HERMES_KANBAN_TASK"):
+    if (
+        os.environ.get("HERMES_KANBAN_TASK")
+        and _is_dispatcher_owned_worker()
+    ):
         return tool_error(
             f"{tool_name} is orchestrator-only; dispatcher-spawned workers "
             "must use kanban_complete, kanban_block, kanban_heartbeat, or "
@@ -1467,6 +1484,7 @@ def _handle_create(args: dict, **kw) -> str:
             return _ok(
                 task_id=new_tid,
                 status=new_task.status if new_task else None,
+                manual_hold=new_task.manual_hold if new_task else None,
                 workspace_kind=new_task.workspace_kind if new_task else None,
                 workspace_path=new_task.workspace_path if new_task else None,
                 project_id=new_task.project_id if new_task else None,
@@ -1639,6 +1657,54 @@ def _handle_unblock(args: dict, **kw) -> str:
     except Exception as e:
         logger.exception("kanban_unblock failed")
         return tool_error(f"kanban_unblock: {e}")
+
+
+def _handle_transition(args: dict, **kw) -> str:
+    """Safely park an unclaimed task in todo or triage."""
+    delegated_err = _reject_delegated_child_mutation("kanban_transition")
+    if delegated_err:
+        return delegated_err
+    guard = _require_orchestrator_tool("kanban_transition")
+    if guard:
+        return guard
+    tid = args.get("task_id")
+    if not tid:
+        return tool_error("task_id is required")
+    target_status = args.get("target_status")
+    if not target_status:
+        return tool_error("target_status is required")
+    ownership_err = _enforce_worker_task_ownership(str(tid))
+    if ownership_err:
+        return ownership_err
+
+    board = args.get("board")
+    actor = os.environ.get("HERMES_PROFILE") or "worker"
+    try:
+        kb, conn = _connect(board=board)
+        try:
+            transition = kb.transition_task_status(
+                conn,
+                str(tid),
+                target_status=str(target_status),
+                actor=actor,
+                reason=args.get("reason"),
+            )
+            if not transition.ok:
+                return tool_error(f"kanban_transition: {transition.error}")
+            task = kb.get_task(conn, str(tid))
+            return _ok(
+                task_id=str(tid),
+                source_status=transition.source_status,
+                status=task.status if task else None,
+                transitioned=transition.changed,
+            )
+        finally:
+            conn.close()
+    except ValueError as e:
+        return tool_error(f"kanban_transition: {e}")
+    except Exception as e:
+        logger.exception("kanban_transition failed")
+        return tool_error(f"kanban_transition: {e}")
 
 
 def _handle_link(args: dict, **kw) -> str:
@@ -2239,12 +2305,13 @@ KANBAN_CREATE_SCHEMA = {
             },
             "initial_status": {
                 "type": "string",
-                "enum": ["running", "blocked"],
+                "enum": ["running", "blocked", "todo", "triage"],
                 "description": (
-                    "Initial card status. Use 'blocked' for tasks that "
-                    "require immediate human ops (R3 gate) to skip the "
-                    "brief running-to-blocked transition. Defaults to "
-                    "'running', which preserves the usual dispatch path."
+                    "Initial lifecycle phase. 'todo' creates an explicit "
+                    "manual hold that will not auto-dispatch; 'triage' parks "
+                    "for specification; 'blocked' creates an immediate human "
+                    "ops gate. Defaults to 'running', which preserves normal "
+                    "ready/dependency inference."
                 ),
             },
             "skills": {
@@ -2306,6 +2373,37 @@ KANBAN_CREATE_SCHEMA = {
             "board": _board_schema_prop(),
         },
         "required": ["title", "assignee"],
+    },
+}
+
+KANBAN_TRANSITION_SCHEMA = {
+    "name": "kanban_transition",
+    "description": (
+        "Safely park an existing unclaimed Kanban task in todo or triage. "
+        "The operation is idempotent and audited with actor, reason, source, "
+        "target, and timestamp. Todo is a manual hold: it will not auto-spawn "
+        "until explicitly promoted or transitioned. Active, blocked, review, "
+        "scheduled, and terminal tasks keep their dedicated lifecycle paths."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "task_id": {
+                "type": "string",
+                "description": "Existing task id to transition.",
+            },
+            "target_status": {
+                "type": "string",
+                "enum": ["todo", "triage"],
+                "description": "Target non-dispatching lifecycle phase.",
+            },
+            "reason": {
+                "type": "string",
+                "description": "Optional reason recorded in the audit event.",
+            },
+            "board": _board_schema_prop(),
+        },
+        "required": ["task_id", "target_status"],
     },
 }
 
@@ -2468,6 +2566,15 @@ registry.register(
     handler=_handle_unblock,
     check_fn=_check_kanban_orchestrator_mode,
     emoji="▶",
+)
+
+registry.register(
+    name="kanban_transition",
+    toolset="kanban",
+    schema=KANBAN_TRANSITION_SCHEMA,
+    handler=_handle_transition,
+    check_fn=_check_kanban_orchestrator_mode,
+    emoji="↔",
 )
 
 registry.register(

--- a/toolsets.py
+++ b/toolsets.py
@@ -84,8 +84,8 @@ _HERMES_CORE_TOOLS = [
     "kanban_complete", "kanban_block", "kanban_request_review",
     "kanban_request_changes",
     "kanban_heartbeat",
-    "kanban_comment", "kanban_create", "kanban_link",
-    "kanban_unblock",
+    "kanban_comment", "kanban_create", "kanban_transition",
+    "kanban_link", "kanban_unblock",
     "kanban_attach", "kanban_attach_url", "kanban_attachments",
     # Computer use (macOS, gated on cua-driver being installed via check_fn)
     "computer_use",
@@ -320,13 +320,13 @@ TOOLSETS = {
             "tasks done with structured handoffs, enter first-class review "
             "(request_review — not a block), return review changes, block for human input, "
             "heartbeat during long ops, comment on threads, attach files, and "
-            "(for orchestrators) list, unblock, and fan out tasks."
+            "(for orchestrators) list, stage/transition, unblock, and fan out tasks."
         ),
         "tools": [
             "kanban_show", "kanban_list", "kanban_complete", "kanban_block",
             "kanban_request_review", "kanban_request_changes",
             "kanban_heartbeat", "kanban_comment",
-            "kanban_create", "kanban_link",
+            "kanban_create", "kanban_transition", "kanban_link",
             "kanban_unblock",
             "kanban_attach", "kanban_attach_url", "kanban_attachments",
         ],

--- a/website/docs/user-guide/features/kanban.md
+++ b/website/docs/user-guide/features/kanban.md
@@ -740,7 +740,7 @@ All routes are mounted under `/api/plugins/kanban/` and protected by the dashboa
 | `POST` | `/links` | Add a dependency (`parent_id` → `child_id`) |
 | `DELETE` | `/links?parent_id=…&child_id=…` | Remove a dependency |
 | `POST` | `/dispatch?max=…&dry_run=…` | Nudge the dispatcher — skip the 60 s wait |
-| `GET` | `/config` | Read `dashboard.kanban` preferences from `config.yaml` — `default_tenant`, `lane_by_profile`, `l3x_swim_lane`, `l3x_swim_lane_assignee`, `include_archived_by_default`, `render_markdown` |
+| `GET` | `/config` | Read `dashboard.kanban` preferences from `config.yaml` — `default_tenant`, `lane_by_profile`, `l3x_swim_lane`, `l3x_swim_lane_assignee`, `w3bb_swim_lane`, `w3bb_swim_lane_assignee`, `include_archived_by_default`, `render_markdown` |
 | `WS` | `/events?since=<event_id>` | Live stream of `task_events` rows |
 
 Every handler is a thin wrapper — the plugin is ~700 lines of Python (router + WebSocket tail + bulk batcher + config reader) and adds no new business logic. A tiny `_conn()` helper auto-initializes `kanban.db` on every read and write, so a fresh install works whether the user opened the dashboard first, hit the REST API directly, or ran `hermes kanban init`.
@@ -754,13 +754,15 @@ dashboard:
   kanban:
     default_tenant: acme              # preselects the tenant filter
     lane_by_profile: true             # default for the "lanes by profile" toggle
-    l3x_swim_lane: true               # cross-column rows for L3x vs other assignees
-    l3x_swim_lane_assignee: l3x       # assignee profile for the dedicated swim row
+    l3x_swim_lane: true               # cross-column swim rows (Org / W3bb / L3x)
+    l3x_swim_lane_assignee: l3x       # assignee profile for the engineering swim row
+    w3bb_swim_lane: true              # dedicated W3bb marketing swim row
+    w3bb_swim_lane_assignee: w3bb    # assignee profile for the W3bb swim row
     include_archived_by_default: false
     render_markdown: true             # set false for plain <pre> rendering
 ```
 
-When `l3x_swim_lane` is enabled (default), the board renders two horizontal swim rows spanning every lifecycle column: one for tasks assigned to `l3x_swim_lane_assignee` and one labeled **Other** for all remaining assignees (including unassigned). The flat `columns` payload is unchanged so filters, search, and drag/drop continue to operate on the full board; assignee filters collapse to a single visible row when narrowed to L3x or a non-L3x profile.
+When `l3x_swim_lane` is enabled (default), the board renders three horizontal swim rows spanning every lifecycle column: **Org** first (all assignees except the dedicated profile rows, including unassigned), **W3bb** for tasks assigned to `w3bb_swim_lane_assignee` when `w3bb_swim_lane` is true (default), then **L3x** for tasks assigned to `l3x_swim_lane_assignee`. The flat `columns` payload is unchanged so filters, search, and drag/drop continue to operate on the full board; assignee filters collapse to a single visible row when narrowed to W3bb, L3x, or another profile.
 
 Each key is optional and falls back to the shown default.
 

--- a/website/docs/user-guide/features/kanban.md
+++ b/website/docs/user-guide/features/kanban.md
@@ -14,7 +14,7 @@ Hermes Kanban is a durable task board, shared across all your Hermes profiles, t
 
 The board has two front doors, both backed by the same `~/.hermes/kanban.db`:
 
-- **Agents drive the board through a dedicated `kanban_*` toolset** — `kanban_show`, `kanban_list`, `kanban_complete`, `kanban_request_review`, `kanban_request_changes`, `kanban_block`, `kanban_heartbeat`, `kanban_comment`, `kanban_attach`, `kanban_attach_url`, `kanban_attachments`, `kanban_create`, `kanban_link`, `kanban_unblock`. The dispatcher spawns each worker with these tools already in its schema; orchestrator profiles can also enable the `kanban` toolset explicitly. The model reads and routes tasks by calling tools directly, *not* by shelling out to `hermes kanban`. See [How workers interact with the board](#how-workers-interact-with-the-board) below.
+- **Agents drive the board through a dedicated `kanban_*` toolset** — `kanban_show`, `kanban_list`, `kanban_complete`, `kanban_request_review`, `kanban_request_changes`, `kanban_block`, `kanban_heartbeat`, `kanban_comment`, `kanban_attach`, `kanban_attach_url`, `kanban_attachments`, `kanban_create`, `kanban_transition`, `kanban_link`, `kanban_unblock`. The dispatcher spawns each worker with these tools already in its schema; orchestrator profiles can also enable the `kanban` toolset explicitly. The model reads and routes tasks by calling tools directly, *not* by shelling out to `hermes kanban`. See [How workers interact with the board](#how-workers-interact-with-the-board) below.
 - **You (and scripts, and cron) drive the board through `hermes kanban …`** on the CLI, `/kanban …` as a slash command, or the dashboard. These are for humans and automation — the places without a tool-calling model behind them.
 
 Both surfaces route through the same `kanban_db` layer, so reads see a consistent view and writes can't drift. The rest of this page shows CLI examples because they're easy to copy-paste, but every CLI verb has a tool-call equivalent the model uses.
@@ -59,8 +59,8 @@ They coexist: a kanban worker may call `delegate_task` internally during its run
   (e.g. one per project, repo, or domain); see [Boards (multi-project)](#boards-multi-project)
   below. Single-project users stay on the `default` board and never see the
   word "board" outside this docs section.
-- **Task** — a row with title, optional body, one assignee (a profile name), status (`triage | todo | ready | running | blocked | review | done | archived`), optional tenant namespace, optional idempotency key (dedup for retried automation).
-- **Link** — `task_links` row recording a parent → child dependency. The dispatcher promotes `todo → ready` when all parents are `done`.
+- **Task** — a row with title, optional body, one assignee (a profile name), status (`triage | todo | scheduled | ready | running | blocked | review | done | archived`), optional tenant namespace, optional idempotency key (dedup for retried automation).
+- **Link** — `task_links` row recording a parent → child dependency. The dispatcher promotes dependency-created `todo → ready` when all parents are `done`. An explicitly created or transitioned `todo` is a manual hold instead and stays parked until `promote` or another explicit transition.
 - **Comment** — the inter-agent protocol. Agents and humans append comments; when a worker is (re-)spawned it reads the full comment thread as part of its context.
 - **Workspace** — the directory a worker operates in. Three kinds:
   - `scratch` (default) — fresh tmp dir under `~/.hermes/kanban/workspaces/<id>/` (or `~/.hermes/kanban/boards/<slug>/workspaces/<id>/` on non-default boards). **Deleted when the task completes** — scratch is ephemeral by design. Files explicitly declared through `kanban_complete(artifacts=[...])` are copied into durable per-task attachment storage before cleanup; existing deliverable paths in legacy completion summaries receive the same treatment. Other scratch files are removed. A missing declared scratch artifact keeps the task in-flight so the worker can correct the path and retry. Use `worktree:` or `dir:<path>` when the whole workspace should remain available. The first time a scratch workspace is created on an install, the dispatcher logs a warning and emits a `tip_scratch_workspace` event on the task (visible via `hermes kanban show <id>`).
@@ -256,6 +256,74 @@ hermes kanban create "nightly ops review" \
     --json
 ```
 
+### Cron-safe LinkedIn cards (`todo` → `triage`)
+
+Use an explicit `todo` hold when a cron workflow must create one persistent
+card for a week's LinkedIn Monday/Wednesday/Friday posts, then hand that same
+card to triage when Friday analytics begins. Unlike dependency-created `todo`,
+this phase does **not** auto-promote or spawn a worker. The idempotency key makes
+retries reuse the same row; the later transition changes that exact task
+instead of creating a replacement card.
+
+```bash
+period="$(date -u +%G-W%V)"
+account="company-page"
+
+# A retry with the same key returns the existing card. Keep an assignee on the
+# card so it is ready for any later dispatchable phase.
+card_json="$(hermes kanban create "LinkedIn M/W/F posts: ${period}" \
+    --assignee linkedin-publisher \
+    --initial-status todo \
+    --idempotency-key "linkedin-post:${account}:${period}" \
+    --json)"
+task_id="$(printf '%s' "$card_json" | \
+    python3 -c 'import json, sys; print(json.load(sys.stdin)["id"])')"
+
+# Friday analytics begins: route the same audited card to triage.
+hermes kanban transition "$task_id" \
+    --to triage \
+    --reason "Friday analytics started for ${period}"
+```
+
+`transition` accepts only unclaimed `ready`, `todo`, or `triage` cards and only
+targets `todo` or `triage`. It refuses active, blocked, scheduled, review, and
+terminal cards so their dedicated reclaim/unblock/review/reopen operations
+cannot be bypassed. A real transition appends one `status_transitioned` event
+with source, target, actor, reason, and timestamp; retrying an already-effective
+transition is a no-op and does not duplicate the event or spawn a worker.
+
+An orchestrator agent uses the equivalent structured calls:
+
+```text
+kanban_create(
+    title="LinkedIn M/W/F posts: 2026-W33",
+    assignee="linkedin-publisher",
+    initial_status="todo",
+    idempotency_key="linkedin-post:company-page:2026-W33",
+)
+# Later, using the task_id returned above:
+kanban_transition(
+    task_id="t_…",
+    target_status="triage",
+    reason="Friday analytics started for 2026-W33",
+)
+```
+
+The authenticated dashboard REST API uses the same domain mutation through the
+existing task PATCH route. Its audit actor is derived by the server as
+`dashboard`; callers provide the human-readable automation identity in the
+reason instead of claiming an actor identity:
+
+```http
+PATCH /api/plugins/kanban/tasks/t_…
+Content-Type: application/json
+
+{
+  "status": "triage",
+  "transition_reason": "linkedin-analytics-cron: Friday analytics started for 2026-W33"
+}
+```
+
 ### Bulk CLI verbs
 
 All the lifecycle verbs accept multiple ids so you can clean up a batch
@@ -305,7 +373,8 @@ parent, missing input, unmet capability) before unblocking, or raise
 | `kanban_attach` | Attach a file to a task by passing its bytes inline (base64); stored under the task's attachments dir (25 MB cap). | file bytes + name |
 | `kanban_attach_url` | Attach a file to a task by URL. | `url` |
 | `kanban_attachments` | List a task's attachments. | — |
-| `kanban_create` | (Orchestrators) fan out into child tasks with an `assignee`, optional `parents`, `skills`, etc. | `title`, `assignee` |
+| `kanban_create` | (Orchestrators) fan out into child tasks, or stage a held `todo`/`triage` automation card. | `title`, `assignee` |
+| `kanban_transition` | (Orchestrators/cron agents) idempotently park an unclaimed `ready`/`todo`/`triage` card in explicit held `todo` or `triage`, with an audited reason. | `task_id`, `target_status` |
 | `kanban_link` | (Orchestrators) add a `parent_id → child_id` dependency edge after the fact. | `parent_id`, `child_id` |
 | `kanban_unblock` | (Orchestrators) restore a blocked task to its source phase (`review` or `ready`), or `todo` while a parent remains open. | `task_id` |
 
@@ -344,7 +413,7 @@ kanban_create(
 kanban_complete(summary="decomposed into 2 research tasks + 1 writer; linked dependencies")
 ```
 
-The "(Orchestrators)" tools — `kanban_list`, `kanban_create`, `kanban_link`, `kanban_unblock`, and `kanban_comment` on foreign tasks — are available through the same toolset; the convention (encoded in the auto-injected kanban guidance) is that worker profiles don't fan out or route unrelated work, and orchestrator profiles don't execute implementation work. Dispatcher-spawned workers are still task-scoped for destructive lifecycle operations and cannot mutate unrelated tasks.
+The "(Orchestrators)" tools — `kanban_list`, `kanban_create`, `kanban_transition`, `kanban_link`, `kanban_unblock`, and `kanban_comment` on foreign tasks — are available through the same toolset; the convention (encoded in the auto-injected kanban guidance) is that worker profiles don't fan out or route unrelated work, and orchestrator profiles don't execute implementation work. Dispatcher-spawned workers are still task-scoped for destructive lifecycle operations and cannot mutate unrelated tasks.
 
 ### Why tools instead of shelling to `hermes kanban`
 

--- a/website/docs/user-guide/features/kanban.md
+++ b/website/docs/user-guide/features/kanban.md
@@ -671,7 +671,7 @@ All routes are mounted under `/api/plugins/kanban/` and protected by the dashboa
 | `POST` | `/links` | Add a dependency (`parent_id` → `child_id`) |
 | `DELETE` | `/links?parent_id=…&child_id=…` | Remove a dependency |
 | `POST` | `/dispatch?max=…&dry_run=…` | Nudge the dispatcher — skip the 60 s wait |
-| `GET` | `/config` | Read `dashboard.kanban` preferences from `config.yaml` — `default_tenant`, `lane_by_profile`, `include_archived_by_default`, `render_markdown` |
+| `GET` | `/config` | Read `dashboard.kanban` preferences from `config.yaml` — `default_tenant`, `lane_by_profile`, `l3x_swim_lane`, `l3x_swim_lane_assignee`, `include_archived_by_default`, `render_markdown` |
 | `WS` | `/events?since=<event_id>` | Live stream of `task_events` rows |
 
 Every handler is a thin wrapper — the plugin is ~700 lines of Python (router + WebSocket tail + bulk batcher + config reader) and adds no new business logic. A tiny `_conn()` helper auto-initializes `kanban.db` on every read and write, so a fresh install works whether the user opened the dashboard first, hit the REST API directly, or ran `hermes kanban init`.
@@ -685,9 +685,13 @@ dashboard:
   kanban:
     default_tenant: acme              # preselects the tenant filter
     lane_by_profile: true             # default for the "lanes by profile" toggle
+    l3x_swim_lane: true               # cross-column rows for L3x vs other assignees
+    l3x_swim_lane_assignee: l3x       # assignee profile for the dedicated swim row
     include_archived_by_default: false
     render_markdown: true             # set false for plain <pre> rendering
 ```
+
+When `l3x_swim_lane` is enabled (default), the board renders two horizontal swim rows spanning every lifecycle column: one for tasks assigned to `l3x_swim_lane_assignee` and one labeled **Other** for all remaining assignees (including unassigned). The flat `columns` payload is unchanged so filters, search, and drag/drop continue to operate on the full board; assignee filters collapse to a single visible row when narrowed to L3x or a non-L3x profile.
 
 Each key is optional and falls back to the shown default.
 


### PR DESCRIPTION
## Summary
- Add a third cross-column swim row (**Org → W3bb → L3x**) on the Kanban dashboard and desktop board so cards assigned to `w3bb` render in a dedicated sales/marketing lane.
- Extend backend `partition_swim_lanes()` with `w3bb_swim_lane` / `w3bb_swim_lane_assignee` config keys; extract shared desktop partitioning into `swim-lanes.ts` with focused unit tests.
- Preserve existing lifecycle columns, filters, ordering, and assignee-filter collapse behavior; Org/L3x bucketing unchanged aside from Org label (was Other).

## Test plan
- [x] `pytest tests/plugins/test_kanban_dashboard_plugin.py` — 47 passed
- [x] `pytest -k swim` — 5 passed
- [x] `npm run typecheck` (apps/desktop) — passed
- [x] `vitest run src/plugins/kanban/swim-lanes.test.ts` — 2 passed


Made with [Cursor](https://cursor.com)