### PR TITLE
fix(desktop): route prompt replies to their source

### DIFF
--- a/apps/desktop/src/api/mcp.test.ts
+++ b/apps/desktop/src/api/mcp.test.ts
@@ -1,0 +1,43 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { addMcpServer, cancelMcpOAuthFlow, setMcpServerEnabled } from './mcp'
+
+const originalDesktop = window.hermesDesktop
+
+afterEach(() => {
+  window.hermesDesktop = originalDesktop
+  vi.restoreAllMocks()
+})
+
+describe('source-scoped MCP mutations', () => {
+  it('routes setup writes to the backend that raised the request', async () => {
+    const api = vi.fn().mockResolvedValue({ ok: true })
+    window.hermesDesktop = { api } as unknown as Window['hermesDesktop']
+    const scope = { connectionId: 'homelab', profile: 'research' }
+
+    await addMcpServer({ name: 'docs', url: 'https://docs.invalid/mcp' }, scope)
+    await setMcpServerEnabled('docs', true, scope)
+    await cancelMcpOAuthFlow('flow-1', scope)
+
+    expect(api).toHaveBeenNthCalledWith(1, {
+      body: { name: 'docs', url: 'https://docs.invalid/mcp' },
+      connectionId: 'homelab',
+      method: 'POST',
+      path: '/api/mcp/servers',
+      profile: 'research'
+    })
+    expect(api).toHaveBeenNthCalledWith(2, {
+      body: { enabled: true },
+      connectionId: 'homelab',
+      method: 'PUT',
+      path: '/api/mcp/servers/docs/enabled',
+      profile: 'research'
+    })
+    expect(api).toHaveBeenNthCalledWith(3, {
+      connectionId: 'homelab',
+      method: 'DELETE',
+      path: '/api/mcp/oauth/flows/flow-1',
+      profile: 'research'
+    })
+  })
+})

--- a/apps/desktop/src/api/mcp.ts
+++ b/apps/desktop/src/api/mcp.ts
@@ -67,9 +67,9 @@ export function getMcpOAuthFlow(flowId: string, profile?: ProfileScope): Promise
 
 /** Cancel an in-flight MCP OAuth flow server-side, freeing the per-server
  *  "already in progress" slot so a retry doesn't 409. */
-export function cancelMcpOAuthFlow(flowId: string, profile?: null | string): Promise<{ ok: boolean; status: string }> {
-  return hermesApi<{ ok: boolean; status: string }>({
-    ...profileScoped(profile),
+export function cancelMcpOAuthFlow(flowId: string, profile?: ProfileScope): Promise<{ ok: boolean; status: string }> {
+  return window.hermesDesktop.api<{ ok: boolean; status: string }>({
+    ...capabilityScoped(profile),
     path: `/api/mcp/oauth/flows/${encodeURIComponent(flowId)}`,
     method: 'DELETE'
   })
@@ -90,16 +90,19 @@ export function listMcpServers(): Promise<{ servers: McpServerSummary[] }> {
 
 /** Add one server to `mcp_servers` (validated + name-collision-checked
  *  server-side — the same endpoint the dashboard's add form uses). */
-export function addMcpServer(body: {
-  name: string
-  url?: string
-  command?: string
-  args?: string[]
-  env?: Record<string, string>
-  auth?: string
-}): Promise<McpServerSummary> {
-  return hermesApi<McpServerSummary>({
-    ...profileScoped(),
+export function addMcpServer(
+  body: {
+    name: string
+    url?: string
+    command?: string
+    args?: string[]
+    env?: Record<string, string>
+    auth?: string
+  },
+  profile?: ProfileScope
+): Promise<McpServerSummary> {
+  return window.hermesDesktop.api<McpServerSummary>({
+    ...capabilityScoped(profile),
     path: '/api/mcp/servers',
     method: 'POST',
     body
@@ -108,17 +111,17 @@ export function addMcpServer(body: {
 
 /** Remove one server from `mcp_servers` (the inline setup card's rollback
  *  when a directory install is cancelled after the config write). */
-export function removeMcpServer(name: string): Promise<{ ok: boolean }> {
-  return hermesApi<{ ok: boolean }>({
-    ...profileScoped(),
+export function removeMcpServer(name: string, profile?: ProfileScope): Promise<{ ok: boolean }> {
+  return window.hermesDesktop.api<{ ok: boolean }>({
+    ...capabilityScoped(profile),
     path: `/api/mcp/servers/${encodeURIComponent(name)}`,
     method: 'DELETE'
   })
 }
 
-export function setMcpServerEnabled(name: string, enabled: boolean): Promise<{ ok: boolean }> {
-  return hermesApi<{ ok: boolean }>({
-    ...profileScoped(),
+export function setMcpServerEnabled(name: string, enabled: boolean, profile?: ProfileScope): Promise<{ ok: boolean }> {
+  return window.hermesDesktop.api<{ ok: boolean }>({
+    ...capabilityScoped(profile),
     path: `/api/mcp/servers/${encodeURIComponent(name)}/enabled`,
     method: 'PUT',
     body: { enabled }

--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-submit.test.tsx
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-submit.test.tsx
@@ -5,7 +5,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 import { PaneVisibleContext } from '@/components/pane-shell/pane-visibility'
 import { $clarifyRequests } from '@/store/clarify'
 import type { ComposerAttachment } from '@/store/composer'
-import { $gateway } from '@/store/gateway'
+import { setPrimaryGateway } from '@/store/gateway'
 import {
   clearAllPrompts,
   hasBlockingPromptRequest,
@@ -395,17 +395,18 @@ describe('useComposerSubmit with a clarify parked on the session', () => {
         question: 'which one?',
         choices: ['a', 'b'],
         multiSelect: false,
-        sessionId
+        sessionId,
+        scope: { connectionId: null, profile: 'default' }
       }
     })
-    $gateway.set({ request: gatewayRequest } as unknown as ReturnType<typeof $gateway.get>)
+    setPrimaryGateway({ request: gatewayRequest } as never, 'default')
   }
 
   afterEach(() => {
     cleanup()
     gatewayRequest.mockClear()
     $clarifyRequests.set({})
-    $gateway.set(null)
+    setPrimaryGateway(null)
     vi.restoreAllMocks()
   })
 

--- a/apps/desktop/src/app/session/hooks/use-message-stream/clarify-hydration.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/clarify-hydration.test.tsx
@@ -63,6 +63,22 @@ describe('clarify.request stream hydration', () => {
     })
   })
 
+  it('parks the exact gateway source that raised the request', () => {
+    mountStream()
+
+    act(() =>
+      stream.handleEvent({
+        connectionId: 'homelab',
+        payload: { choices: ['yes', 'no'], question: 'Ship it?', request_id: 'req-scoped' },
+        profile: 'research',
+        session_id: SID,
+        type: 'clarify.request'
+      })
+    )
+
+    expect($clarifyRequests.get()[SID]?.scope).toEqual({ connectionId: 'homelab', profile: 'research' })
+  })
+
   it('reveals a clarify prompt raised by the active session', () => {
     mountStream()
 

--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/desktop-bridge.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/desktop-bridge.ts
@@ -4,7 +4,6 @@ import { readActiveTerminal } from '@/app/right-sidebar/terminal/buffer'
 import { closeAgentTerminalByProc } from '@/app/right-sidebar/terminal/terminals'
 import type { PreviewActAction } from '@/lib/preview-act/act-in-page'
 import type { TourAction, TourStep } from '@/lib/tour'
-import { $gateway } from '@/store/gateway'
 import { applyDesktopLayoutPreset, revealDesktopPane } from '@/store/pane-focus'
 import { recordAgentReaction } from '@/store/reactions-local'
 import { setMessages } from '@/store/session'
@@ -43,7 +42,7 @@ const loadPreviewEngine = () => {
  *  (terminal/preview/window), agent terminal streaming, pane reveal, and
  *  message reactions. */
 export function handleDesktopBridgeEvent(ctx: GatewayEventContext): boolean {
-  const { event, payload, isActiveEvent } = ctx
+  const { event, payload, isActiveEvent, sourceGateway } = ctx
 
   if (event.type === 'terminal.read.request') {
     // read_terminal tool: serialize the renderer's xterm buffer and answer
@@ -55,7 +54,7 @@ export function handleDesktopBridgeEvent(ctx: GatewayEventContext): boolean {
       const count = typeof payload?.count === 'number' ? payload.count : undefined
       const result = readActiveTerminal({ start, count })
 
-      void $gateway.get()?.request('terminal.read.respond', {
+      void sourceGateway?.request('terminal.read.respond', {
         request_id: requestId,
         text: result ? JSON.stringify(result) : ''
       })
@@ -74,7 +73,7 @@ export function handleDesktopBridgeEvent(ctx: GatewayEventContext): boolean {
       const count = typeof payload?.count === 'number' ? payload.count : undefined
 
       void readActivePreview({ count, start }).then(result => {
-        void $gateway.get()?.request('preview.read.respond', {
+        void sourceGateway?.request('preview.read.respond', {
           request_id: requestId,
           text: result ? JSON.stringify(result) : ''
         })
@@ -94,7 +93,7 @@ export function handleDesktopBridgeEvent(ctx: GatewayEventContext): boolean {
 
     if (requestId) {
       const answer = (result: unknown) =>
-        $gateway.get()?.request('preview.act.respond', {
+        sourceGateway?.request('preview.act.respond', {
           request_id: requestId,
           text: result ? JSON.stringify(result) : ''
         })
@@ -138,7 +137,7 @@ export function handleDesktopBridgeEvent(ctx: GatewayEventContext): boolean {
       const read = window.hermesDesktop?.readWindowBelow
 
       const answer = (result: unknown) =>
-        $gateway.get()?.request('window.read.respond', {
+        sourceGateway?.request('window.read.respond', {
           request_id: requestId,
           text: result ? JSON.stringify(result) : ''
         })
@@ -178,7 +177,7 @@ export function handleDesktopBridgeEvent(ctx: GatewayEventContext): boolean {
 
     if (requestId) {
       const answer = (result: unknown) =>
-        $gateway.get()?.request('tour.respond', {
+        sourceGateway?.request('tour.respond', {
           request_id: requestId,
           text: result ? JSON.stringify(result) : ''
         })

--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/index.ts
@@ -8,7 +8,7 @@ import {
   UNSCOPED_STREAM_EVENT_TYPES
 } from '@/lib/gateway-events'
 import { setSessionCompacting } from '@/store/compaction'
-import { $gateway, activeGatewayConnectionId } from '@/store/gateway'
+import { activeGatewayConnectionId, gatewayForScope, gatewaySourceScopeFromEvent } from '@/store/gateway'
 import { $activeGatewayProfile, normalizeProfileKey } from '@/store/profile'
 import { replayPendingApproval } from '@/store/prompts'
 import { setSessionProviderWait } from '@/store/provider-wait'
@@ -167,6 +167,8 @@ export function useGatewayEventHandler(deps: GatewayEventDeps) {
       }
 
       const sessionId = route.sessionId
+      const sourceScope = gatewaySourceScopeFromEvent(event)
+      const sourceGateway = gatewayForScope(sourceScope)
 
       // Late stragglers: an unscoped stream event attributed via the
       // active-session fallback (no pin) to a session that has no live turn
@@ -198,7 +200,7 @@ export function useGatewayEventHandler(deps: GatewayEventDeps) {
       const replaySessionId = approvalReplaySessionId(event.type, activeSessionIdRef.current, sessionId)
 
       if (replaySessionId) {
-        void replayPendingApproval($gateway.get(), replaySessionId).catch(() => undefined)
+        void replayPendingApproval(sourceGateway, replaySessionId, sourceScope).catch(() => undefined)
       }
 
       // Mid-turn compaction does not emit another message.start. The first
@@ -225,6 +227,8 @@ export function useGatewayEventHandler(deps: GatewayEventDeps) {
         explicitSid,
         isActiveEvent,
         occurredAt,
+        sourceGateway,
+        sourceScope,
         fromActiveSource,
         scheduleConfigRefresh
       }

--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/input-requests.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/input-requests.ts
@@ -1,6 +1,5 @@
 import { translateNow } from '@/i18n'
 import { normalizeChoices, normalizeQuestions, setClarifyRequest, warnDroppedChoices } from '@/store/clarify'
-import { $gateway } from '@/store/gateway'
 import { setMcpSetupRequest } from '@/store/mcp-setup'
 import { dispatchNativeNotification } from '@/store/native-notifications'
 import { receiveApprovalRequest, setSecretRequest, setSudoRequest } from '@/store/prompts'
@@ -12,7 +11,7 @@ import type { GatewayEventContext } from './types'
  *  secret requests. The Python side is blocked on the matching *.respond, so
  *  each of these must be parked per-session and surfaced. */
 export function handleInputRequestEvent(ctx: GatewayEventContext): boolean {
-  const { deps, event, payload, sessionId, occurredAt } = ctx
+  const { deps, event, payload, sessionId, occurredAt, sourceGateway, sourceScope } = ctx
   const { activeSessionIdRef, updateSessionState, upsertToolCall } = deps
 
   if (event.type === 'clarify.request') {
@@ -53,7 +52,8 @@ export function handleInputRequestEvent(ctx: GatewayEventContext): boolean {
         question: '',
         questions,
         requestId,
-        sessionId: sessionId ?? null
+        sessionId: sessionId ?? null,
+        scope: sourceScope
       })
 
       if (sessionId) {
@@ -100,7 +100,8 @@ export function handleInputRequestEvent(ctx: GatewayEventContext): boolean {
         question,
         choices: choices.length > 0 ? choices : null,
         multiSelect,
-        sessionId: sessionId ?? null
+        sessionId: sessionId ?? null,
+        scope: sourceScope
       })
 
       if (sessionId) {
@@ -159,7 +160,7 @@ export function handleInputRequestEvent(ctx: GatewayEventContext): boolean {
     const reason = typeof payload?.reason === 'string' ? payload.reason : ''
 
     if (requestId && server) {
-      setMcpSetupRequest({ action, reason, requestId, server, sessionId: sessionId ?? null })
+      setMcpSetupRequest({ action, reason, requestId, server, sessionId: sessionId ?? null, scope: sourceScope })
 
       if (sessionId) {
         upsertToolCall(
@@ -191,7 +192,7 @@ export function handleInputRequestEvent(ctx: GatewayEventContext): boolean {
     const command = typeof payload?.command === 'string' ? payload.command : ''
     const description = typeof payload?.description === 'string' ? payload.description : 'dangerous command'
 
-    void receiveApprovalRequest($gateway.get(), {
+    void receiveApprovalRequest(sourceGateway, {
       // false only when a tirith warning forbids it; backend omits the field otherwise.
       allowPermanent: payload?.allow_permanent !== false,
       choices: Array.isArray(payload?.choices)
@@ -201,6 +202,7 @@ export function handleInputRequestEvent(ctx: GatewayEventContext): boolean {
       description,
       requestId: typeof payload?.request_id === 'string' ? payload.request_id : undefined,
       sessionId: sessionId ?? null,
+      scope: sourceScope,
       smartDenied: payload?.smart_denied === true
     }).catch(() => undefined)
 
@@ -228,7 +230,7 @@ export function handleInputRequestEvent(ctx: GatewayEventContext): boolean {
     const requestId = typeof payload?.request_id === 'string' ? payload.request_id : ''
 
     if (requestId) {
-      setSudoRequest({ requestId, sessionId: sessionId ?? null })
+      setSudoRequest({ requestId, sessionId: sessionId ?? null, scope: sourceScope })
 
       if (sessionId) {
         updateSessionState(sessionId, state => ({ ...state, needsInput: true }))
@@ -258,7 +260,8 @@ export function handleInputRequestEvent(ctx: GatewayEventContext): boolean {
         requestId,
         envVar,
         prompt: promptText,
-        sessionId: sessionId ?? null
+        sessionId: sessionId ?? null,
+        scope: sourceScope
       })
 
       if (sessionId) {

--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/types.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/types.ts
@@ -1,6 +1,8 @@
+import type { GatewaySourceScope } from '@hermes/shared'
 import type { QueryClient } from '@tanstack/react-query'
 import type { MutableRefObject } from 'react'
 
+import type { HermesGateway } from '@/hermes'
 import type { GatewayEventPayload } from '@/lib/chat-messages'
 import type { RpcEvent } from '@/types/hermes'
 
@@ -62,6 +64,10 @@ export interface GatewayEventContext {
   isActiveEvent: boolean
   /** Event timestamp in epoch seconds (payload timestamp or receipt time). */
   occurredAt: number
+  /** Exact backend that emitted the event, or null when the source tag is invalid. */
+  sourceScope: GatewaySourceScope | null
+  /** Already-registered gateway for sourceScope; never falls back to the active socket. */
+  sourceGateway: HermesGateway | null
   /** The event came from the active (connection, profile) source. */
   fromActiveSource: () => boolean
   /** Coalesced trailing refreshHermesConfig (one per session.info burst). */

--- a/apps/desktop/src/components/assistant-ui/clarify-tool.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/clarify-tool.test.tsx
@@ -6,7 +6,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 import { onComposerInsertRequest } from '@/app/chat/composer/focus'
 import { I18nProvider } from '@/i18n'
 import { clearClarifyRequest, setClarifyRequest } from '@/store/clarify'
-import { $gateway } from '@/store/gateway'
+import { setPrimaryGateway } from '@/store/gateway'
 import { $activeSessionId } from '@/store/session'
 
 import { ClarifyTool, readClarifyBatchResult, readClarifyResult } from './clarify-tool'
@@ -21,7 +21,7 @@ afterEach(() => {
   cleanup()
   clearClarifyRequest()
   $activeSessionId.set(null)
-  $gateway.set(null)
+  setPrimaryGateway(null)
   vi.clearAllMocks()
 })
 
@@ -75,13 +75,14 @@ function renderLiveClarify({ multiSelect = false }: { multiSelect?: boolean } = 
   const request = vi.fn().mockResolvedValue({ ok: true })
 
   $activeSessionId.set('session-1')
-  $gateway.set({ request } as never)
+  setPrimaryGateway({ request } as never, 'default')
   setClarifyRequest({
     choices: ['staging', 'production'],
     multiSelect,
     question: 'Which deployment target?',
     requestId: 'request-1',
-    sessionId: 'session-1'
+    sessionId: 'session-1',
+    scope: { connectionId: null, profile: 'default' }
   })
   renderClarify(<ClarifyTool {...liveClarifyProps()} />)
 
@@ -374,13 +375,14 @@ describe('ClarifyTool recommended option', () => {
     const request = vi.fn().mockResolvedValue({ ok: true })
 
     $activeSessionId.set('session-1')
-    $gateway.set({ request } as never)
+    setPrimaryGateway({ request } as never, 'default')
     setClarifyRequest({
       choices: ['staging (Recommended)', 'production'],
       multiSelect: false,
       question: 'Which deployment target?',
       requestId: 'request-1',
-      sessionId: 'session-1'
+      sessionId: 'session-1',
+      scope: { connectionId: null, profile: 'default' }
     })
     renderClarify(<ClarifyTool {...liveClarifyProps(['staging (Recommended)', 'production'])} />)
 
@@ -418,13 +420,14 @@ describe('ClarifyTool pending marker', () => {
 
   it('does not mark a free-text (no-choice) pending card', () => {
     $activeSessionId.set('session-1')
-    $gateway.set({ request: vi.fn().mockResolvedValue({ ok: true }) } as never)
+    setPrimaryGateway({ request: vi.fn().mockResolvedValue({ ok: true }) } as never, 'default')
     setClarifyRequest({
       choices: null,
       multiSelect: false,
       question: 'Anything else?',
       requestId: 'request-1',
-      sessionId: 'session-1'
+      sessionId: 'session-1',
+      scope: { connectionId: null, profile: 'default' }
     })
 
     const args = { question: 'Anything else?' }
@@ -479,7 +482,7 @@ function renderLiveBatch(lockedAnswers?: Record<string, string>) {
   const request = vi.fn().mockResolvedValue({ ok: true, remaining: [] })
 
   $activeSessionId.set('session-1')
-  $gateway.set({ request } as never)
+  setPrimaryGateway({ request } as never, 'default')
   setClarifyRequest({
     choices: null,
     lockedAnswers,
@@ -490,7 +493,8 @@ function renderLiveBatch(lockedAnswers?: Record<string, string>) {
       { choices: null, multiSelect: false, qid: 'q1', question: 'Name?' }
     ],
     requestId: 'request-batch',
-    sessionId: 'session-1'
+    sessionId: 'session-1',
+    scope: { connectionId: null, profile: 'default' }
   })
   renderClarify(<ClarifyTool {...liveBatchProps()} />)
 

--- a/apps/desktop/src/components/assistant-ui/clarify-tool.tsx
+++ b/apps/desktop/src/components/assistant-ui/clarify-tool.tsx
@@ -35,7 +35,7 @@ import {
   sessionClarifyRequest,
   warnDroppedChoices
 } from '@/store/clarify'
-import { $gateway } from '@/store/gateway'
+import { gatewayForScope } from '@/store/gateway'
 import { notifyError } from '@/store/notifications'
 
 import { selectMessageRunning } from './tool/fallback-model'
@@ -397,7 +397,6 @@ function ClarifyToolPending(props: ToolCallMessagePartProps) {
 function ClarifyToolSinglePending({ fromArgs, request }: { fromArgs: ClarifyArgs; request: ClarifyRequest | null }) {
   const { t } = useI18n()
   const copy = t.assistant.clarify
-  const gateway = useStore($gateway)
 
   const matchingRequest = useMemo(() => {
     if (!request || request.questions?.length) {
@@ -449,6 +448,8 @@ function ClarifyToolSinglePending({ fromArgs, request }: { fromArgs: ClarifyArgs
         return
       }
 
+      const gateway = gatewayForScope(matchingRequest.scope)
+
       if (!gateway) {
         notifyError(new Error(copy.gatewayDisconnected), copy.sendFailed)
 
@@ -470,7 +471,7 @@ function ClarifyToolSinglePending({ fromArgs, request }: { fromArgs: ClarifyArgs
         setSubmitting(false)
       }
     },
-    [copy.gatewayDisconnected, copy.notReady, copy.sendFailed, gateway, matchingRequest, ready]
+    [copy.gatewayDisconnected, copy.notReady, copy.sendFailed, matchingRequest, ready]
   )
 
   const trimmedDraft = draft.trim()
@@ -910,7 +911,6 @@ const emptyStage = { choices: [] as string[], draft: '' }
 function ClarifyToolBatchPending({ request }: { request: ClarifyRequest | null }) {
   const { t } = useI18n()
   const copy = t.assistant.clarify
-  const gateway = useStore($gateway)
 
   // qids only exist on the gateway request — args are a hydration-race
   // fallback for display, never answerable (no ids to respond with).
@@ -970,8 +970,16 @@ function ClarifyToolBatchPending({ request }: { request: ClarifyRequest | null }
   const allStaged = answeredCount === questions.length
 
   const confirmAll = useCallback(async () => {
-    if (!request || !gateway) {
-      notifyError(new Error(request ? copy.gatewayDisconnected : copy.notReady), copy.sendFailed)
+    if (!request) {
+      notifyError(new Error(copy.notReady), copy.sendFailed)
+
+      return
+    }
+
+    const gateway = gatewayForScope(request.scope)
+
+    if (!gateway) {
+      notifyError(new Error(copy.gatewayDisconnected), copy.sendFailed)
 
       return
     }
@@ -1000,7 +1008,7 @@ function ClarifyToolBatchPending({ request }: { request: ClarifyRequest | null }
       notifyError(error, copy.sendFailed)
       setSubmitting(false)
     }
-  }, [copy, gateway, questions, request, stagedAnswer])
+  }, [copy, questions, request, stagedAnswer])
 
   const toggleChoice = useCallback((question: ClarifyQuestion, choice: string) => {
     setStaged(current => {
@@ -1026,13 +1034,14 @@ function ClarifyToolBatchPending({ request }: { request: ClarifyRequest | null }
     }
 
     clearClarifyRequest(request.requestId, request.sessionId)
+    const gateway = gatewayForScope(request.scope)
 
     try {
       await gateway?.request('clarify.respond', { answer: '', request_id: request.requestId })
     } catch {
       // The tool times out on its own; a failed skip must never block the UI.
     }
-  }, [gateway, request])
+  }, [request])
 
   const handleSubmit = useCallback(
     (event: FormEvent<HTMLFormElement>) => {

--- a/apps/desktop/src/components/assistant-ui/mcp-setup-tool.tsx
+++ b/apps/desktop/src/components/assistant-ui/mcp-setup-tool.tsx
@@ -30,7 +30,7 @@ import { completeMcpDesktopOAuth, McpOAuthCancelled } from '@/lib/mcp-dashboard-
 import { directoryEntry } from '@/lib/mcp-directory'
 import { prettyName } from '@/lib/text'
 import { cn } from '@/lib/utils'
-import { $gateway } from '@/store/gateway'
+import { gatewayForScope } from '@/store/gateway'
 import { clearMcpSetupRequest, type McpSetupOutcome, sessionMcpSetupRequest } from '@/store/mcp-setup'
 import { notifyError } from '@/store/notifications'
 import { invalidateMcpSuggestionIndex } from '@/store/suggestion-providers/mcp'
@@ -171,7 +171,7 @@ function McpSetupPending({ args }: ToolCallMessagePartProps) {
   const sessionId = useStore(useSessionView().$runtimeId)
   const $request = useMemo(() => sessionMcpSetupRequest(sessionId), [sessionId])
   const request = useStore($request)
-  const gateway = useStore($gateway)
+  const sourceScope = request?.scope ?? null
   const fromArgs = useMemo(() => readSetupArgs(args), [args])
 
   const server = fromArgs.server || request?.server || ''
@@ -199,6 +199,8 @@ function McpSetupPending({ args }: ToolCallMessagePartProps) {
       if (!request || sessionMcpSetupRequest(request.sessionId).get()?.requestId !== request.requestId) {
         return
       }
+
+      const gateway = gatewayForScope(request.scope)
 
       if (!gateway) {
         notifyError(new Error(copy.gatewayDisconnected), copy.sendFailed)
@@ -237,7 +239,7 @@ function McpSetupPending({ args }: ToolCallMessagePartProps) {
         notifyError(error, copy.sendFailed)
       }
     },
-    [copy.gatewayDisconnected, copy.reloadFailed, copy.sendFailed, gateway, request]
+    [copy.gatewayDisconnected, copy.reloadFailed, copy.sendFailed, request]
   )
 
   const decline = useCallback(() => {
@@ -249,6 +251,12 @@ function McpSetupPending({ args }: ToolCallMessagePartProps) {
   }, [respond, server])
 
   const approve = useCallback(async () => {
+    if (!request || !gatewayForScope(request.scope)) {
+      notifyError(new Error(copy.gatewayDisconnected), copy.sendFailed)
+
+      return
+    }
+
     cancelRef.current = false
     setWorking(true)
 
@@ -264,7 +272,7 @@ function McpSetupPending({ args }: ToolCallMessagePartProps) {
 
     try {
       if (action === 'enable') {
-        await setMcpServerEnabled(server, true)
+        await setMcpServerEnabled(server, true, sourceScope)
         triggerHaptic('submit')
         await respond({ server, status: 'enabled' })
 
@@ -274,10 +282,10 @@ function McpSetupPending({ args }: ToolCallMessagePartProps) {
       if (action === 'authorize') {
         const flow = await completeMcpDesktopOAuth({
           serverName: server,
-          start: authMcpServer,
-          status: getMcpOAuthFlow,
+          start: name => authMcpServer(name, sourceScope),
+          status: flowId => getMcpOAuthFlow(flowId, sourceScope),
           cancelled: () => cancelRef.current,
-          cancel: cancelMcpOAuthFlow,
+          cancel: flowId => cancelMcpOAuthFlow(flowId, sourceScope),
           openExternal: url => window.hermesDesktop.openExternal(url)
         })
 
@@ -295,7 +303,7 @@ function McpSetupPending({ args }: ToolCallMessagePartProps) {
       let resolved = entry
 
       if (resolved === undefined) {
-        const catalog = await getMcpCatalog()
+        const catalog = await getMcpCatalog(sourceScope)
         resolved = catalog.entries.find(candidate => candidate.name === server) ?? null
         setEntry(resolved)
       }
@@ -314,21 +322,21 @@ function McpSetupPending({ args }: ToolCallMessagePartProps) {
         // flow dies after the config write (cancel, closed OAuth tab), roll
         // the write back — decline means "no server", not an unauthorized
         // entry squatting in mcp_servers (authoritative-write rule).
-        await addMcpServer({ name: known.name, url: known.url })
+        await addMcpServer({ name: known.name, url: known.url }, sourceScope)
 
         let flow
 
         try {
           flow = await completeMcpDesktopOAuth({
             serverName: known.name,
-            start: authMcpServer,
-            status: getMcpOAuthFlow,
+            start: name => authMcpServer(name, sourceScope),
+            status: flowId => getMcpOAuthFlow(flowId, sourceScope),
             cancelled: () => cancelRef.current,
-            cancel: cancelMcpOAuthFlow,
+            cancel: flowId => cancelMcpOAuthFlow(flowId, sourceScope),
             openExternal: url => window.hermesDesktop.openExternal(url)
           })
         } catch (error) {
-          await removeMcpServer(known.name).catch(() => {
+          await removeMcpServer(known.name, sourceScope).catch(() => {
             // Rollback is best-effort; the primary error/cancel wins.
           })
           throw error
@@ -349,13 +357,13 @@ function McpSetupPending({ args }: ToolCallMessagePartProps) {
         return
       }
 
-      const res = await installMcpCatalogEntry(server, envDraft)
+      const res = await installMcpCatalogEntry(server, envDraft, sourceScope)
 
       // Git-backed entries clone in the background — poll to completion so a
       // non-zero exit surfaces as a real failure instead of a false success.
       if (res.background && res.action) {
         for (;;) {
-          const status = throwIfCancelled(await getActionStatus(res.action, 1))
+          const status = throwIfCancelled(await getActionStatus(res.action, 1, sourceScope))
 
           if (!status.running) {
             if (status.exit_code !== 0) {
@@ -387,7 +395,7 @@ function McpSetupPending({ args }: ToolCallMessagePartProps) {
     } finally {
       setWorking(false)
     }
-  }, [action, copy, entry, envDraft, respond, server])
+  }, [action, copy, entry, envDraft, request, respond, server, sourceScope])
 
   const title =
     action === 'enable'

--- a/apps/desktop/src/components/assistant-ui/tool/approval.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/tool/approval.test.tsx
@@ -2,7 +2,7 @@ import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-li
 import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest'
 
 import type { HermesGateway } from '@/hermes'
-import { $gateway } from '@/store/gateway'
+import { setPrimaryGateway } from '@/store/gateway'
 import { $approvalRequest, clearAllPrompts, setApprovalRequest } from '@/store/prompts'
 import { $activeSessionId } from '@/store/session'
 
@@ -36,12 +36,19 @@ function setRequest(
   extra: { choices?: string[]; smartDenied?: boolean } = {}
 ) {
   $activeSessionId.set('sess-1')
-  setApprovalRequest({ allowPermanent, command, description: 'dangerous command', sessionId: 'sess-1', ...extra })
+  setApprovalRequest({
+    allowPermanent,
+    command,
+    description: 'dangerous command',
+    sessionId: 'sess-1',
+    scope: { connectionId: null, profile: 'default' },
+    ...extra
+  })
 }
 
 function mockGateway() {
   const request = vi.fn().mockResolvedValue({ resolved: true })
-  $gateway.set({ request } as unknown as HermesGateway)
+  setPrimaryGateway({ request } as unknown as HermesGateway, 'default')
 
   return request
 }
@@ -50,7 +57,7 @@ afterEach(() => {
   cleanup()
   clearAllPrompts()
   $activeSessionId.set(null)
-  $gateway.set(null)
+  setPrimaryGateway(null)
 })
 
 describe('PendingToolApproval', () => {
@@ -86,6 +93,21 @@ describe('PendingToolApproval', () => {
       expect(request).toHaveBeenCalledWith('approval.respond', { choice: 'once', session_id: 'sess-1' })
     })
     expect($approvalRequest.get()).toBeNull()
+  })
+
+  it('re-resolves the scoped gateway when the user answers', async () => {
+    const stale = mockGateway()
+    setRequest()
+    render(<PendingToolApproval part={part('terminal')} />)
+
+    const current = vi.fn().mockResolvedValue({ resolved: true })
+    setPrimaryGateway({ request: current } as unknown as HermesGateway, 'default')
+    fireEvent.click(screen.getByRole('button', { name: /Run/ }))
+
+    await waitFor(() => {
+      expect(current).toHaveBeenCalledWith('approval.respond', { choice: 'once', session_id: 'sess-1' })
+    })
+    expect(stale).not.toHaveBeenCalled()
   })
 
   it('reveals the full command inline when the Command toggle is clicked', () => {

--- a/apps/desktop/src/components/assistant-ui/tool/approval.tsx
+++ b/apps/desktop/src/components/assistant-ui/tool/approval.tsx
@@ -18,7 +18,7 @@ import { useI18n } from '@/i18n'
 import { triggerHaptic } from '@/lib/haptics'
 import { AlertCircle, ChevronDown, Loader2 } from '@/lib/icons'
 import { cn } from '@/lib/utils'
-import { $gateway } from '@/store/gateway'
+import { gatewayForScope } from '@/store/gateway'
 import { notifyError } from '@/store/notifications'
 import {
   type ApprovalRequest,
@@ -106,7 +106,6 @@ const isMac = typeof navigator !== 'undefined' && /Mac|iP(hone|ad|od)/.test(navi
 const ApprovalBar: FC<{ request: ApprovalRequest; surface: 'floating' | 'inline' }> = ({ request, surface }) => {
   const { t } = useI18n()
   const copy = t.assistant.approval
-  const gateway = useStore($gateway)
   const [submitting, setSubmitting] = useState<ApprovalChoice | null>(null)
   // "Always allow" persists the pattern to ~/.hermes/config.yaml permanently, so
   // it goes through a confirm step rather than firing straight from the menu.
@@ -134,6 +133,8 @@ const ApprovalBar: FC<{ request: ApprovalRequest; surface: 'floating' | 'inline'
         return
       }
 
+      const gateway = gatewayForScope(request.scope)
+
       if (!gateway) {
         notifyError(new Error(copy.gatewayDisconnected), copy.sendFailed)
 
@@ -150,13 +151,13 @@ const ApprovalBar: FC<{ request: ApprovalRequest; surface: 'floating' | 'inline'
         })
         triggerHaptic(choice === 'deny' ? 'cancel' : 'submit')
         clearApprovalRequest(request.sessionId, request.requestId)
-        void replayPendingApproval(gateway, request.sessionId).catch(() => undefined)
+        void replayPendingApproval(gateway, request.sessionId, request.scope).catch(() => undefined)
       } catch (error) {
         notifyError(error, copy.sendFailed)
         setSubmitting(null)
       }
     },
-    [busy, copy.gatewayDisconnected, copy.sendFailed, gateway, request.requestId, request.sessionId]
+    [busy, copy.gatewayDisconnected, copy.sendFailed, request]
   )
 
   // ⌘/Ctrl+Enter → Run, Esc → Reject.

--- a/apps/desktop/src/components/prompt-overlays.test.tsx
+++ b/apps/desktop/src/components/prompt-overlays.test.tsx
@@ -2,7 +2,7 @@ import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/re
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { I18nProvider } from '@/i18n'
-import { $gateway } from '@/store/gateway'
+import { setPrimaryGateway } from '@/store/gateway'
 import { notifyError } from '@/store/notifications'
 import { $secretRequest, $sudoRequest, clearAllPrompts, setSecretRequest, setSudoRequest } from '@/store/prompts'
 import { $activeSessionId } from '@/store/session'
@@ -24,7 +24,7 @@ afterEach(() => {
   cleanup()
   clearAllPrompts()
   $activeSessionId.set(null)
-  $gateway.set(null)
+  setPrimaryGateway(null)
   vi.clearAllMocks()
 })
 
@@ -33,8 +33,12 @@ describe('PromptOverlays', () => {
     const request = vi.fn().mockRejectedValue(new Error('no pending password request'))
 
     $activeSessionId.set('s1')
-    $gateway.set({ request } as never)
-    setSudoRequest({ requestId: 'sudo-1', sessionId: 's1' })
+    setPrimaryGateway({ request } as never, 'default')
+    setSudoRequest({
+      requestId: 'sudo-1',
+      sessionId: 's1',
+      scope: { connectionId: null, profile: 'default' }
+    })
 
     renderPrompts()
 
@@ -51,8 +55,14 @@ describe('PromptOverlays', () => {
     const request = vi.fn().mockRejectedValue(new Error('no pending value request'))
 
     $activeSessionId.set('s1')
-    $gateway.set({ request } as never)
-    setSecretRequest({ envVar: 'TEST_SECRET', prompt: 'Paste a secret', requestId: 'secret-1', sessionId: 's1' })
+    setPrimaryGateway({ request } as never, 'default')
+    setSecretRequest({
+      envVar: 'TEST_SECRET',
+      prompt: 'Paste a secret',
+      requestId: 'secret-1',
+      sessionId: 's1',
+      scope: { connectionId: null, profile: 'default' }
+    })
 
     renderPrompts()
 

--- a/apps/desktop/src/components/prompt-overlays.tsx
+++ b/apps/desktop/src/components/prompt-overlays.tsx
@@ -18,7 +18,7 @@ import { useI18n } from '@/i18n'
 import { isMissingPendingPromptRequest } from '@/lib/gateway-rpc'
 import { triggerHaptic } from '@/lib/haptics'
 import { KeyRound, Loader2, Lock } from '@/lib/icons'
-import { $gateway } from '@/store/gateway'
+import { gatewayForScope } from '@/store/gateway'
 import { notifyError } from '@/store/notifications'
 import { clearSecretRequest, clearSudoRequest, sessionSecretRequest, sessionSudoRequest } from '@/store/prompts'
 
@@ -40,7 +40,6 @@ function SudoDialog({ sessionId }: { sessionId: string | null }) {
   const copy = t.prompts
   const $request = useMemo(() => sessionSudoRequest(sessionId), [sessionId])
   const request = useStore($request)
-  const gateway = useStore($gateway)
   const [password, setPassword] = useState('')
   const [submitting, setSubmitting] = useState(false)
 
@@ -54,6 +53,8 @@ function SudoDialog({ sessionId }: { sessionId: string | null }) {
       if (!request) {
         return
       }
+
+      const gateway = gatewayForScope(request.scope)
 
       if (!gateway) {
         notifyError(new Error(copy.gatewayDisconnected), copy.sudoSendFailed)
@@ -81,7 +82,7 @@ function SudoDialog({ sessionId }: { sessionId: string | null }) {
         setSubmitting(false)
       }
     },
-    [copy.gatewayDisconnected, copy.sudoSendFailed, gateway, request]
+    [copy.gatewayDisconnected, copy.sudoSendFailed, request]
   )
 
   // Cancel → empty password. The backend treats an empty sudo response as a
@@ -143,7 +144,6 @@ function SecretDialog({ sessionId }: { sessionId: string | null }) {
   const copy = t.prompts
   const $request = useMemo(() => sessionSecretRequest(sessionId), [sessionId])
   const request = useStore($request)
-  const gateway = useStore($gateway)
   const [value, setValue] = useState('')
   const [submitting, setSubmitting] = useState(false)
 
@@ -157,6 +157,8 @@ function SecretDialog({ sessionId }: { sessionId: string | null }) {
       if (!request) {
         return
       }
+
+      const gateway = gatewayForScope(request.scope)
 
       if (!gateway) {
         notifyError(new Error(copy.gatewayDisconnected), copy.secretSendFailed)
@@ -184,7 +186,7 @@ function SecretDialog({ sessionId }: { sessionId: string | null }) {
         setSubmitting(false)
       }
     },
-    [copy.gatewayDisconnected, copy.secretSendFailed, gateway, request]
+    [copy.gatewayDisconnected, copy.secretSendFailed, request]
   )
 
   const onOpenChange = useCallback(

--- a/apps/desktop/src/store/clarify.test.ts
+++ b/apps/desktop/src/store/clarify.test.ts
@@ -11,7 +11,7 @@ import {
   setClarifyRequest,
   skipClarifyRequest
 } from './clarify'
-import { $gateway } from './gateway'
+import { setPrimaryGateway } from './gateway'
 import { $activeSessionId } from './session'
 
 function clarify(sessionId: string | null, requestId: string): ClarifyRequest {
@@ -20,7 +20,8 @@ function clarify(sessionId: string | null, requestId: string): ClarifyRequest {
     question: `question-${requestId}`,
     choices: null,
     multiSelect: false,
-    sessionId
+    sessionId,
+    scope: { connectionId: null, profile: 'default' }
   }
 }
 
@@ -92,12 +93,12 @@ describe('skipClarifyRequest', () => {
   beforeEach(() => {
     $clarifyRequests.set({})
     request.mockClear()
-    $gateway.set({ request } as unknown as ReturnType<typeof $gateway.get>)
+    setPrimaryGateway({ request } as never, 'default')
   })
 
   afterEach(() => {
     $clarifyRequests.set({})
-    $gateway.set(null)
+    setPrimaryGateway(null)
   })
 
   it('answers the session\u2019s clarify with an empty answer and drops it', async () => {
@@ -123,6 +124,15 @@ describe('skipClarifyRequest', () => {
     request.mockRejectedValueOnce(new Error('socket closed'))
 
     await expect(skipClarifyRequest('session-a')).resolves.toBe(true)
+    expect(hasClarifyRequest('session-a')).toBe(false)
+  })
+
+  it('does not send an unscoped request through another gateway', async () => {
+    setClarifyRequest({ ...clarify('session-a', 'req-a'), scope: null })
+
+    await expect(skipClarifyRequest('session-a')).resolves.toBe(true)
+
+    expect(request).not.toHaveBeenCalled()
     expect(hasClarifyRequest('session-a')).toBe(false)
   })
 })

--- a/apps/desktop/src/store/clarify.ts
+++ b/apps/desktop/src/store/clarify.ts
@@ -1,6 +1,7 @@
+import type { GatewaySourceScope } from '@hermes/shared'
 import { atom, computed } from 'nanostores'
 
-import { $gateway } from './gateway'
+import { gatewayForScope } from './gateway'
 import { $activeSessionId } from './session'
 
 export interface ClarifyQuestion {
@@ -17,6 +18,7 @@ export interface ClarifyRequest {
   choices: string[] | null
   multiSelect: boolean
   sessionId: string | null
+  scope?: GatewaySourceScope | null
   /** Batch (multi-question) clarify: present instead of question/choices. */
   questions?: ClarifyQuestion[]
   /** Answers already locked server-side (reconnect replay): qid → answer. */
@@ -198,9 +200,10 @@ export async function skipClarifyRequest(sessionId: string | null | undefined): 
   // Clear first: the answer is already decided, and an in-flight RPC must not
   // leave a live card the user can answer a second time.
   clearClarifyRequest(request.requestId, request.sessionId)
+  const gateway = gatewayForScope(request.scope)
 
   try {
-    await $gateway.get()?.request('clarify.respond', { request_id: request.requestId, answer: '' })
+    await gateway?.request('clarify.respond', { request_id: request.requestId, answer: '' })
   } catch {
     // The tool times out on its own; a failed skip must never swallow the
     // message the user is actually sending.

--- a/apps/desktop/src/store/gateway-connection-scope.test.ts
+++ b/apps/desktop/src/store/gateway-connection-scope.test.ts
@@ -43,6 +43,8 @@ const {
   closeSecondaryGateways,
   configureGatewayRegistry,
   ensureGatewayForAgent,
+  gatewayForScope,
+  gatewaySourceScopeFromEvent,
   openGatewayForAgent,
   pruneSecondaryGateways,
   setPrimaryGateway
@@ -123,5 +125,26 @@ describe('pruneSecondaryGateways with registry-scoped entries', () => {
     pruneSecondaryGateways(new Set())
 
     expect(gatewayMocks.closed).toHaveLength(1)
+  })
+})
+
+describe('event source routing', () => {
+  it('keeps the primary and a same-named registry profile distinct', async () => {
+    const primary = gatewayForScope({ connectionId: null, profile: 'default' })
+
+    await openGatewayForAgent('homelab', 'default')
+
+    expect(gatewayForScope({ connectionId: null, profile: 'default' })).toBe(primary)
+    expect(gatewayForScope({ connectionId: 'homelab', profile: 'default' })).not.toBe(primary)
+  })
+
+  it('does not fall back when an event source tag is missing or malformed', () => {
+    expect(gatewaySourceScopeFromEvent({ profile: 'default' })).toEqual({
+      connectionId: null,
+      profile: 'default'
+    })
+    expect(gatewaySourceScopeFromEvent({ connectionId: '', profile: 'default' })).toBeNull()
+    expect(gatewaySourceScopeFromEvent({ connectionId: 'homelab' })).toBeNull()
+    expect(gatewayForScope(null)).toBeNull()
   })
 })

--- a/apps/desktop/src/store/gateway.ts
+++ b/apps/desktop/src/store/gateway.ts
@@ -1,4 +1,10 @@
-import { type ConnectionState, type GatewayEvent, registryBackendScopeKey, resolveGatewayWsUrl } from '@hermes/shared'
+import {
+  type ConnectionState,
+  type GatewayEvent,
+  type GatewaySourceScope,
+  registryBackendScopeKey,
+  resolveGatewayWsUrl
+} from '@hermes/shared'
 import { atom } from 'nanostores'
 
 import type { HermesConnection } from '@/global'
@@ -18,6 +24,40 @@ import { setConnection, setGatewayState } from '@/store/session'
 // only ever have the primary, so their path is byte-for-byte unchanged.
 
 const normKey = (profile: string | null | undefined): string => (profile ?? '').trim() || 'default'
+
+function normalizeSourceScope(scope: GatewaySourceScope | null | undefined): GatewaySourceScope | null {
+  const profile = typeof scope?.profile === 'string' ? scope.profile.trim() : ''
+
+  if (!scope || !profile) {
+    return null
+  }
+
+  if (scope.connectionId === null) {
+    return { connectionId: null, profile }
+  }
+
+  const connectionId = typeof scope.connectionId === 'string' ? scope.connectionId.trim() : ''
+
+  return connectionId ? { connectionId, profile } : null
+}
+
+export function gatewaySourceScopeFromEvent(
+  event: Pick<GatewayEvent, 'connectionId' | 'profile'>
+): GatewaySourceScope | null {
+  const profile = typeof event.profile === 'string' ? event.profile.trim() : ''
+
+  if (!profile) {
+    return null
+  }
+
+  if (event.connectionId === undefined) {
+    return { connectionId: null, profile }
+  }
+
+  const connectionId = typeof event.connectionId === 'string' ? event.connectionId.trim() : ''
+
+  return connectionId ? { connectionId, profile } : null
+}
 
 // Read connection state through a call so TS control-flow analysis doesn't
 // narrow the getter to a constant across guards (it genuinely changes).
@@ -178,6 +218,21 @@ export function emitLocalGatewayEvent(event: GatewayEvent): void {
 export function setPrimaryGateway(gateway: HermesGateway | null, profile = 'default'): void {
   g.primaryGateway = gateway
   g.primaryProfile = normKey(profile)
+}
+
+/** Resolve an already-registered source without falling back to another backend. */
+export function gatewayForScope(scope: GatewaySourceScope | null | undefined): HermesGateway | null {
+  const source = normalizeSourceScope(scope)
+
+  if (!source) {
+    return null
+  }
+
+  if (source.connectionId === null && normKey(source.profile) === g.primaryProfile) {
+    return g.primaryGateway
+  }
+
+  return g.secondaries.get(registryBackendScopeKey(source.connectionId, source.profile))?.gateway ?? null
 }
 
 export function isActivePrimary(): boolean {

--- a/apps/desktop/src/store/mcp-setup.ts
+++ b/apps/desktop/src/store/mcp-setup.ts
@@ -1,6 +1,7 @@
+import type { GatewaySourceScope } from '@hermes/shared'
 import { atom, computed } from 'nanostores'
 
-import { $gateway } from './gateway'
+import { gatewayForScope } from './gateway'
 
 /**
  * Pending `mcp.setup.request`s — the desktop half of the `setup_mcp` tool's
@@ -17,6 +18,7 @@ export interface McpSetupRequest {
   /** Agent-supplied one-liner: why this server helps right now. */
   reason: string
   sessionId: string | null
+  scope?: GatewaySourceScope | null
 }
 
 /** The card's answer, serialized back through `mcp.setup.respond`. */
@@ -103,9 +105,10 @@ export async function skipMcpSetupRequest(sessionId: string | null | undefined):
   // Clear first: the answer is already decided, and an in-flight RPC must not
   // leave a live card the user can answer a second time.
   clearMcpSetupRequest(request.requestId, request.sessionId)
+  const gateway = gatewayForScope(request.scope)
 
   try {
-    await $gateway.get()?.request('mcp.setup.respond', {
+    await gateway?.request('mcp.setup.respond', {
       request_id: request.requestId,
       result: JSON.stringify({ server: request.server, status: 'declined' })
     })

--- a/apps/desktop/src/store/native-notifications.test.ts
+++ b/apps/desktop/src/store/native-notifications.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { $gateway } from './gateway'
+import { setPrimaryGateway } from './gateway'
 import {
   clearPluginNotifyHandlers,
   dispatchNativeNotification,
@@ -14,7 +14,7 @@ import {
   setNativeNotifyKind
 } from './native-notifications'
 import { __resetNativeNotifyBaselineForTests, markNativeNotifyBaseline } from './notify-baseline'
-import { $approvalRequest, setApprovalRequest } from './prompts'
+import { $approvalRequest, clearAllPrompts, setApprovalRequest } from './prompts'
 import { $activeSessionId, setActiveSessionId } from './session'
 
 const desktopWindow = window as unknown as { hermesDesktop?: Window['hermesDesktop'] }
@@ -307,16 +307,22 @@ describe('respondToApprovalAction', () => {
 
   beforeEach(() => {
     request.mockClear()
-    $gateway.set({ request } as unknown as ReturnType<typeof $gateway.get>)
+    setPrimaryGateway({ request } as never, 'default')
   })
 
   afterEach(() => {
-    $gateway.set(null)
+    clearAllPrompts()
+    setPrimaryGateway(null)
   })
 
   it('approves via approval.respond {choice: "once"} and clears the prompt', async () => {
     setActiveSessionId('bg')
-    setApprovalRequest({ command: 'rm -rf /', description: 'dangerous', sessionId: 'bg' })
+    setApprovalRequest({
+      command: 'rm -rf /',
+      description: 'dangerous',
+      sessionId: 'bg',
+      scope: { connectionId: null, profile: 'default' }
+    })
 
     await respondToApprovalAction('bg', 'approve')
 
@@ -325,6 +331,12 @@ describe('respondToApprovalAction', () => {
   })
 
   it('rejects via approval.respond {choice: "deny"}', async () => {
+    setApprovalRequest({
+      command: 'rm -rf /',
+      description: 'dangerous',
+      sessionId: 'bg',
+      scope: { connectionId: null, profile: 'default' }
+    })
     await respondToApprovalAction('bg', 'reject')
     expect(request).toHaveBeenCalledWith('approval.respond', { choice: 'deny', session_id: 'bg' })
   })
@@ -335,7 +347,13 @@ describe('respondToApprovalAction', () => {
   })
 
   it('no-ops without a gateway', async () => {
-    $gateway.set(null)
+    setApprovalRequest({
+      command: 'rm -rf /',
+      description: 'dangerous',
+      sessionId: 'bg',
+      scope: { connectionId: null, profile: 'default' }
+    })
+    setPrimaryGateway(null)
     await respondToApprovalAction('bg', 'approve')
     expect(request).not.toHaveBeenCalled()
   })

--- a/apps/desktop/src/store/native-notifications.ts
+++ b/apps/desktop/src/store/native-notifications.ts
@@ -3,9 +3,9 @@ import { atom } from 'nanostores'
 import { type HermesOpenTarget, resolveHermesOpenPath } from '@/lib/hermes-open-target'
 import { persistString, storedString } from '@/lib/storage'
 
-import { $gateway } from './gateway'
+import { gatewayForScope } from './gateway'
 import { withinNativeNotifyBaseline } from './notify-baseline'
-import { clearApprovalRequest } from './prompts'
+import { clearApprovalRequest, sessionApprovalRequest } from './prompts'
 import { $activeSessionId } from './session'
 
 export type { HermesOpenTarget }
@@ -352,15 +352,20 @@ export async function respondToApprovalAction(sessionId: null | string, actionId
     return
   }
 
-  const gateway = $gateway.get()
+  const approval = sessionApprovalRequest(sessionId).get()
+  const gateway = gatewayForScope(approval?.scope)
 
-  if (!gateway) {
+  if (!approval || !gateway) {
     return
   }
 
   try {
-    await gateway.request('approval.respond', { choice, session_id: sessionId ?? undefined })
-    clearApprovalRequest(sessionId)
+    await gateway.request('approval.respond', {
+      choice,
+      ...(approval.requestId ? { request_id: approval.requestId } : {}),
+      session_id: sessionId ?? undefined
+    })
+    clearApprovalRequest(sessionId, approval.requestId)
   } catch {
     // Leave the prompt parked so the user can still resolve it in-app.
   }

--- a/apps/desktop/src/store/prompts.ts
+++ b/apps/desktop/src/store/prompts.ts
@@ -1,3 +1,4 @@
+import type { GatewaySourceScope } from '@hermes/shared'
 import { atom, computed, type ReadableAtom } from 'nanostores'
 
 import { $clarifyRequest, $clarifyRequests } from './clarify'
@@ -19,6 +20,7 @@ const keyFor = (sessionId: string | null | undefined): string => sessionId ?? ''
 
 interface KeyedPrompt {
   sessionId: string | null
+  scope?: GatewaySourceScope | null
 }
 
 interface PromptStore<T extends KeyedPrompt> {
@@ -126,7 +128,11 @@ export async function receiveApprovalRequest(gateway: ApprovalGateway | null, re
   }
 }
 
-export async function replayPendingApproval(gateway: ApprovalGateway | null, sessionId: string | null): Promise<void> {
+export async function replayPendingApproval(
+  gateway: ApprovalGateway | null,
+  sessionId: string | null,
+  scope?: GatewaySourceScope | null
+): Promise<void> {
   if (!gateway || !sessionId) {
     return
   }
@@ -151,6 +157,7 @@ export async function replayPendingApproval(gateway: ApprovalGateway | null, ses
     description: typeof pending.description === 'string' ? pending.description : 'dangerous command',
     requestId: pending.request_id,
     sessionId,
+    scope,
     smartDenied: pending.smart_denied === true
   })
 }

--- a/apps/shared/src/index.ts
+++ b/apps/shared/src/index.ts
@@ -52,6 +52,7 @@ export {
   type GatewayEvent,
   type GatewayEventName,
   type GatewayRequestId,
+  type GatewaySourceScope,
   type JsonRpcErrorPayload,
   type JsonRpcFrame,
   JsonRpcGatewayClient,

--- a/apps/shared/src/json-rpc-gateway.ts
+++ b/apps/shared/src/json-rpc-gateway.ts
@@ -23,6 +23,12 @@ export type GatewayEventName =
   | 'skin.changed'
   | (string & {})
 
+/** Exact Desktop backend that emitted an event. */
+export interface GatewaySourceScope {
+  connectionId: null | string
+  profile: string
+}
+
 export interface GatewayEvent<P = unknown> {
   payload?: P
   /** Renderer-side source tag added by the Desktop gateway registry. */


### PR DESCRIPTION
## Summary

- Preserve the connection and profile that originated each Desktop blocking request.
- Send approval, clarify, sudo, secret, MCP setup, and Desktop-read responses only through that exact gateway.
- Route MCP setup REST operations through the same registry connection, including the required remote profile query.
- Fail closed when a source socket or source identifier is unavailable, rather than replying through the currently selected backend.

## Validation

- `npm exec -- vitest run --project ui src/store/gateway-source-routing.test.ts src/store/clarify.test.ts src/store/native-notifications.test.ts src/hermes.test.ts src/components/assistant-ui/tool/approval.test.tsx src/components/assistant-ui/clarify-tool.test.tsx src/components/prompt-overlays.test.tsx`
- `npm exec -- tsc -p tsconfig.json --noEmit`
- `npm exec -- tsc -p tsconfig.electron.json --noEmit`
- `npm exec -- tsc -p tsconfig.e2e.json --noEmit`
- `npm run build`
- `npm exec -- playwright test e2e/connection-scoped-api.spec.ts --reporter=list`
- Targeted ESLint and Prettier checks
- `git diff --check upstream/main...HEAD`
- `scripts/check-windows-footguns.py --diff upstream/main`

The Playwright regression launches Electron with the real Hermes backend, registers a second remote source, and invokes the production API bridge with that source scope. It confirms that the request reaches the named source with the requested profile query, rather than the window's default backend.
