### PR TITLE
fix(update): bound optional cua-driver refresh

### DIFF
--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -951,6 +951,11 @@ def install_cua_driver(
     ``hermes update`` already prints a contextual line before its update
     check, so it disables this to avoid printing the refresh twice.
 
+    The confirmed-update path is also bounded by
+    ``_CUA_BACKGROUND_UPDATE_TIMEOUT``. It runs as an optional, quiet part of
+    ``hermes update`` and must not inherit the explicit install command's
+    11-minute ceiling when an upstream prompt or UAC dialog is unattended.
+
     Returns True iff cua-driver is installed (or successfully refreshed)
     when the function returns. Supported on macOS, Windows, and Linux
     (Linux is alpha). Silently returns False on unsupported platforms.
@@ -1102,6 +1107,11 @@ def install_cua_driver(
         verbose=False,
         pin_version=confirmed_version,
         show_progress=show_installer_progress,
+        installer_timeout=(
+            _CUA_BACKGROUND_UPDATE_TIMEOUT
+            if require_confirmed_update
+            else None
+        ),
     )
     if ok and before:
         try:
@@ -1128,6 +1138,16 @@ def install_cua_driver(
 # "always times out" wedge (issue #58762). 660s = 600s lock window + 60s
 # headroom for the actual download/swap.
 _CUA_INSTALLER_TIMEOUT = 660
+
+# Optional refreshes launched by ``hermes update`` are quiet and unattended.
+# Keep their interruption bounded even when upstream waits on Read-Host or a
+# Windows UAC consent dialog. Explicit ``computer-use install --upgrade`` runs
+# retain the full installer ceiling above.
+_CUA_BACKGROUND_UPDATE_TIMEOUT = 120
+
+# Once the tree-kill has been issued, never wait indefinitely for a descendant
+# that inherited the captured stdout pipe to close it.
+_CUA_INSTALLER_REAP_TIMEOUT = 5
 
 # Upstream installer's stale-lock threshold (LOCK_STALE_AFTER_SECONDS in
 # _install-rust.sh). Used by the pre-clear below to avoid yanking a lock
@@ -1381,6 +1401,7 @@ def _run_cua_driver_installer(
     verbose: bool = True,
     pin_version: Optional[str] = None,
     show_progress: bool = True,
+    installer_timeout: Optional[float] = None,
 ) -> bool:
     """Run the upstream cua-driver installer for this platform.
 
@@ -1397,6 +1418,9 @@ def _run_cua_driver_installer(
     is bumped by Release Please *before* the release assets are published,
     so an unpinned run inside that window fails with a 404; pinning to the
     version ``check-update`` confirmed sidesteps the race entirely.
+
+    ``installer_timeout`` lets quiet callers use a shorter ceiling without
+    weakening the explicit install path's stale-lock recovery window.
     """
     import platform as _plat
     import shutil
@@ -1468,6 +1492,11 @@ def _run_cua_driver_installer(
         else:
             _print_info(f"→ {label} cua-driver (Computer Use)...")
     driver_cmd = _cua_driver_cmd()
+    timeout = (
+        _CUA_INSTALLER_TIMEOUT
+        if installer_timeout is None
+        else installer_timeout
+    )
 
     installer_env = _cua_driver_env()
     if pin_version:
@@ -1552,10 +1581,10 @@ def _run_cua_driver_installer(
                 **popen_kwargs
             )
             try:
-                proc.communicate(timeout=_CUA_INSTALLER_TIMEOUT)
+                proc.communicate(timeout=timeout)
             except subprocess.TimeoutExpired:
                 _kill_installer_tree(proc)
-                proc.communicate()
+                proc.communicate(timeout=_CUA_INSTALLER_REAP_TIMEOUT)
                 raise
             result = subprocess.CompletedProcess(
                 install_cmd, proc.returncode, stdout=None, stderr=None
@@ -1563,16 +1592,17 @@ def _run_cua_driver_installer(
         else:
             proc = subprocess.Popen(
                 install_cmd, shell=use_shell, env=installer_env,
+                stdin=subprocess.DEVNULL,
                 stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
                 text=True, encoding="utf-8", errors="replace",
                 creationflags=_post_setup_no_window_flags(),
                 **popen_kwargs
             )
             try:
-                out, _ = proc.communicate(timeout=_CUA_INSTALLER_TIMEOUT)
+                out, _ = proc.communicate(timeout=timeout)
             except subprocess.TimeoutExpired:
                 _kill_installer_tree(proc)
-                proc.communicate()
+                proc.communicate(timeout=_CUA_INSTALLER_REAP_TIMEOUT)
                 raise
             result = subprocess.CompletedProcess(
                 install_cmd, proc.returncode, stdout=out, stderr=None
@@ -1622,7 +1652,7 @@ def _run_cua_driver_installer(
     except subprocess.TimeoutExpired:
         _print_warning(
             f"    cua-driver {label.lower()} timed out after "
-            f"{_CUA_INSTALLER_TIMEOUT}s."
+            f"{timeout}s."
         )
         if not is_windows:
             _print_info(

--- a/tests/hermes_cli/test_install_cua_driver.py
+++ b/tests/hermes_cli/test_install_cua_driver.py
@@ -152,6 +152,46 @@ class TestInstallCuaDriverUpgrade:
 
         info.assert_not_called()
 
+    def test_quiet_refresh_closes_stdin_and_honors_custom_timeout(self):
+        """A background refresh must neither wait on a hidden prompt nor
+        inherit the explicit install command's 11-minute ceiling."""
+        import subprocess
+        from unittest.mock import MagicMock
+
+        from hermes_cli import tools_config
+
+        fake_proc = MagicMock()
+        fake_proc.pid = 1
+        fake_proc.returncode = 0
+        fake_proc.communicate.return_value = ("", None)
+
+        with patch(
+                 "subprocess.run",
+                 return_value=MagicMock(returncode=0, stderr=""),
+             ), \
+             patch("subprocess.Popen", return_value=fake_proc) as popen, \
+             patch.object(
+                 tools_config.shutil,
+                 "which",
+                 return_value="/usr/local/bin/cua-driver",
+             ), \
+             patch.object(tools_config, "_clear_stale_cua_install_lock"), \
+             patch.object(
+                 tools_config,
+                 "_repair_cua_driver_autostart_windows",
+                 return_value=True,
+             ), \
+             patch.object(tools_config, "_print_info"), \
+             patch.object(tools_config, "_print_success"):
+            assert tools_config._run_cua_driver_installer(
+                label="Refreshing",
+                verbose=False,
+                installer_timeout=120,
+            ) is True
+
+        assert popen.call_args.kwargs["stdin"] is subprocess.DEVNULL
+        fake_proc.communicate.assert_called_once_with(timeout=120)
+
     def test_upgrade_can_suppress_installer_progress(self):
         from hermes_cli import tools_config
 
@@ -323,6 +363,7 @@ class TestRequireConfirmedUpdate:
         ok, runner, _ = self._install(state, require_confirmed=True)
         assert ok is True
         runner.assert_called_once()
+        assert runner.call_args.kwargs["installer_timeout"] == 120
 
     def test_up_to_date_short_circuits(self):
         state = {"current_version": "0.6.0", "latest_version": "0.6.0",
@@ -732,6 +773,10 @@ class TestInstallerTimeoutKillsProcessGroup:
         parent.kill.assert_called_once_with()
         fake_proc.kill.assert_not_called()
         assert fake_proc.communicate.call_count == 2
+        assert (
+            fake_proc.communicate.call_args_list[1].kwargs["timeout"]
+            == tools_config._CUA_INSTALLER_REAP_TIMEOUT
+        )
 
     @pytest.mark.windows_only
     def test_windows_tree_enumeration_failure_falls_back_to_direct_kill(self):


### PR DESCRIPTION
## Summary

- cap the optional, confirmed cua-driver refresh inside `hermes update` at 120 seconds while retaining the 660-second ceiling for explicit installs
- close stdin for quiet installer subprocesses so invisible upstream prompts receive EOF instead of blocking
- bound post-timeout process reaping at 5 seconds after the existing recursive tree-kill attempt

## Why

A real Windows update left the upstream PowerShell installer alive after the user exited an apparently stalled refresh. The current 660-second ceiling is appropriate for an explicit install because the upstream installer has a 600-second stale-lock window, but it is disproportionate for an optional unattended step in `hermes update`. The unbounded second `communicate()` could also keep the updater waiting after tree termination if a descendant retained the captured output pipe.

This overlaps with #79871 on `stdin=DEVNULL`; this PR adds the field-derived updater-specific deadline and bounded reap as complementary hardening. Related to #79684.

## Verification

- RED first: new timeout/stdin and confirmed-update tests failed against `origin/main`
- targeted new/changed tests: 3 passed
- `test_install_cua_driver.py` excluding five baseline Windows portability failures: 29 passed, 15 skipped, 5 deselected
- the same five failures reproduce unchanged on the untouched baseline
- Ruff: passed for both changed files
- `git diff --check`: passed

The broad `test_cmd_update.py` invocation exceeded the local 420-second harness cap; it is not claimed green. This patch does not change `update_cmd.py`.
