### PR TITLE
feat(desktop): opt-in self-signed macOS signing helper in run-electron-builder

### DIFF
--- a/apps/desktop/scripts/run-electron-builder.mjs
+++ b/apps/desktop/scripts/run-electron-builder.mjs
@@ -36,6 +36,74 @@ function electronBuilderCli() {
   return path.join(path.dirname(pkgJson), rel)
 }
 
+// Dev-only helper, inert unless HERMES_MAC_TIMESTAMP=none is exported.
+// electron-builder's argv passthrough (-c.mac.timestamp=none) can already
+// skip the timestamp server; this helper adds what argv cannot: a preflight
+// keychain probe that warns up front when CSC_NAME is missing, instead of
+// discovering mid-build that osx-sign failed and fell back to ad-hoc.
+// Ad-hoc designated requirements bind the bundle identifier to the binary
+// cdhash, which changes on every pack — macOS then treats each repack as a
+// new app and re-prompts for TCC permissions (Screen Recording,
+// Accessibility) the user already granted. Release/CI flows that set
+// CSC_NAME without this env are completely untouched (no probe, no args).
+function macSelfSignedDevArgs() {
+  if (process.platform !== "darwin") return []
+  if ((process.env.HERMES_MAC_TIMESTAMP || "").toLowerCase() !== "none") return []
+
+  const identity = process.env.CSC_NAME
+  // electron-builder sentinels for "do not sign" — a timestamp flag is
+  // meaningless for an unsigned build.
+  if (identity === "none" || identity === "-") return []
+
+  // Skipping Apple's timestamp server is equally possible via electron-
+  // builder's argv passthrough (-c.mac.timestamp=none); this helper exists
+  // for the preflight: fail loudly NOW when CSC_NAME is not in the keychain,
+  // instead of discovering mid-build that osx-sign fell back to ad-hoc.
+  const args = [`-c.mac.timestamp=none`]
+  console.log(
+    "[run-electron-builder] HERMES_MAC_TIMESTAMP=none → -c.mac.timestamp=none " +
+      "(self-signed identity: skip Apple timestamp server)"
+  )
+
+  if (!identity) {
+    console.warn(
+      "[run-electron-builder] HERMES_MAC_TIMESTAMP=none set but CSC_NAME is " +
+        "not: skipping the timestamp server WITHOUT selecting an identity — " +
+        "electron-builder will auto-detect one, or sign ad-hoc. Set CSC_NAME " +
+        "to pin the intended identity."
+    )
+    return args
+  }
+
+  const probe = spawnSync("security", ["find-identity", "-v", "-p", "codesigning"], {
+    encoding: "utf8",
+    timeout: 5000,
+  })
+  if (probe.status !== 0 || !keychainHasIdentity(probe, identity)) {
+    console.warn(
+      `[run-electron-builder] CSC_NAME="${identity}" not found among keychain ` +
+        "code-signing identities; signing will fail or fall back to ad-hoc."
+    )
+  }
+  return args
+}
+
+// `security find-identity -v` prints lines like:  1) ABCDEF0123… "Developer ID …"
+// Match the exact quoted name, never substrings (CSC_NAME=Apple must not
+// false-pass against "Developer ID Application: …"; a TEAMID fragment must
+// not false-pass either). The 40-hex cert hash printed before the quoted
+// name is also accepted, since CSC_NAME=<hash> is a valid way to pin one.
+function keychainHasIdentity(probe, identity) {
+  const text = `${probe.stdout || ""}\n${probe.stderr || ""}`
+  const isHash = /^[0-9A-Fa-f]{40}$/.test(identity)
+  for (const line of text.split("\n")) {
+    const m = line.match(/"((?:[^"\\]|\\.)*)"/)
+    if (m && m[1] === identity) return true
+    if (isHash && line.includes(identity)) return true
+  }
+  return false
+}
+
 const dist = electronDistDir()
 const args = []
 if (dist && fs.existsSync(distBinary(dist))) {
@@ -46,6 +114,7 @@ if (dist && fs.existsSync(distBinary(dist))) {
       "via @electron/get (electronVersion + ELECTRON_MIRROR)."
   )
 }
+args.push(...macSelfSignedDevArgs())
 args.push(...process.argv.slice(2))
 
 const result = spawnSync(process.execPath, [electronBuilderCli(), ...args], {


### PR DESCRIPTION
## Problem

When repacking the desktop app locally on macOS with a **self-signed signing identity** (a common setup for developers dogfooding a local build):

1. `osx-sign` defaults to Apple's timestamp server, which self-signed certificates cannot use.
2. The timestamp step fails and the build silently falls back to **ad-hoc** signing.
3. Ad-hoc designated requirements bind the bundle identifier to the binary **cdhash**, which changes on every pack.
4. macOS therefore treats each repack as a brand-new app, and TCC permissions the user already granted (Screen Recording, Accessibility, …) are lost / re-prompted on every rebuild.

## Change

`apps/desktop/scripts/run-electron-builder.mjs` gains `macSelfSignedDevArgs()`, **inert unless `HERMES_MAC_TIMESTAMP=none` is exported** — release/CI flows that set `CSC_NAME` without it are completely untouched (no probe, no args):

- Forwards `-c.mac.timestamp=none` so self-signed identities skip the timestamp server instead of falling back to ad-hoc. (electron-builder's argv passthrough can do this too; this helper exists for the preflight below.)
- Probes the login keychain first (exact quoted-name match, 40-hex hash accepted, 5s timeout) and warns loudly when `CSC_NAME` is missing, instead of failing opaquely mid-build.
- Honors electron-builder's "do not sign" sentinels (`CSC_NAME=none` / `-`): no probe, no args.
- Warns when the timestamp flag is set without `CSC_NAME` (identity would then be auto-detected).

## Test plan

macOS (darwin arm64), branch based on `origin/main` @ 165c889e5.

Wrapper behavior matrix (`node scripts/run-electron-builder.mjs --help`):

| Env | Result |
|---|---|
| (none) | silent — no probe, no args |
| `CSC_NAME=<real identity>` | silent — no probe, no args |
| `CSC_NAME` + `HERMES_MAC_TIMESTAMP=none` | forwards `-c.mac.timestamp=none`, probe passes silently |
| `CSC_NAME=none` + flag | silent — sentinel honored, nothing injected |
| `CSC_NAME=<missing>` + flag | loud preflight warning |
| `CSC_NAME=Apple` + flag (substring trap) | warning — exact match, no false pass |
| flag without `CSC_NAME` | forwards flag + warns identity will be auto-detected |

End-to-end — packed the app (`npm run pack`, `--dir`) with `CSC_NAME=<self-signed identity>` + `HERMES_MAC_TIMESTAMP=none`:

```
$ codesign -dv --verbose=4 release/mac-arm64/Hermes.app
Authority=<self-signed identity>        # note: no Timestamp= line — TSA skipped

$ codesign -d -r - release/mac-arm64/Hermes.app
designated => identifier "com.nousresearch.hermes" and certificate root = H"…"
```

The designated requirement pins `certificate root` (stable across repacks) instead of `cdhash` — the exact property that keeps TCC grants valid across rebuilds.

`node --check` passes.
