### PR TITLE
[verified] fix(desktop): list named remote profiles from the profile store

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -214,7 +214,8 @@ import { decideProfileDeleteAction, profileNameFromDeleteRequest, resolveRoutePr
 import {
   fetchPrimaryProfileSessions,
   fetchRemoteProfileSessions,
-  mergeProfileSessionWindow
+  mergeProfileSessionWindow,
+  remoteProfileSharesGateway
 } from './profile-session-routing'
 import { createQuickEntryShortcut, quickEntryWindowBounds, sanitizeQuickEntrySettings } from './quick-entry'
 import { type ActiveWork, mergeActiveWork, normalizeActiveWork, quitPromptFor } from './quit-guard'
@@ -12367,11 +12368,12 @@ async function interceptSessionRequestForRemote(request) {
   }
 
   // Per-session read/mutation. Owner is in ?profile= (reads) or request.profile
-  // (mutations). Two remote shapes:
-  //  - per-profile override: route to that profile's own remote, sans profile
-  //    param (it serves its own state.db natively).
-  //  - global remote mode: ONE backend serves every profile via ?profile=, so
-  //    route there and KEEP the profile param so it opens the right state.db.
+  // (mutations). Three remote shapes:
+  //  - dedicated per-profile override: route to that profile's own remote, sans
+  //    profile param (it serves its own state.db natively).
+  //  - shared-gateway override: several Desktop profiles point at one host, so
+  //    KEEP ?profile= or the host opens its default store.
+  //  - global remote mode: ONE backend serves every profile via ?profile=.
   if (/^\/api\/sessions\/[^/]+(\/messages)?$/.test(pathname)) {
     const profile = (searchParams.get('profile') || request.profile || '').trim()
 
@@ -12385,6 +12387,20 @@ async function interceptSessionRequestForRemote(request) {
     const passthroughParams = new URLSearchParams(searchParams)
     passthroughParams.delete('profile')
     const passthroughQuery = passthroughParams.toString()
+    const sharedGateway = remoteProfileSharesGateway(profile, readDesktopConnectionConfig().profiles || {})
+
+    if (profileHasRemoteOverride(profile) && sharedGateway) {
+      passthroughParams.set('profile', profile)
+      const path = `${pathname}?${passthroughParams.toString()}`
+
+      if (method === 'GET') {
+        return fetchJsonForProfile(profile, path)
+      }
+
+      const body = request.body && typeof request.body === 'object' ? { ...request.body, profile } : { profile }
+
+      return requestJsonForProfile(profile, path, method, body)
+    }
 
     if (profileHasRemoteOverride(profile)) {
       if (method === 'GET') {

--- a/apps/desktop/electron/profile-session-routing.test.ts
+++ b/apps/desktop/electron/profile-session-routing.test.ts
@@ -5,7 +5,8 @@ import { test } from 'vitest'
 import {
   fetchPrimaryProfileSessions,
   fetchRemoteProfileSessions,
-  mergeProfileSessionWindow
+  mergeProfileSessionWindow,
+  remoteProfileSharesGateway
 } from './profile-session-routing'
 
 test('primary session reads use the profile-aware request path', async () => {
@@ -60,9 +61,9 @@ test('remote session reads split oversized sidebar windows into API-safe pages',
   )
 
   assert.deepEqual(calls, [
-    { profile: 'remote-work', path: '/api/sessions?limit=100&offset=0&order=updated' },
-    { profile: 'remote-work', path: '/api/sessions?limit=100&offset=100&order=updated' },
-    { profile: 'remote-work', path: '/api/sessions?limit=50&offset=200&order=updated' }
+    { profile: 'remote-work', path: '/api/profiles/sessions?profile=remote-work&limit=100&offset=0&order=updated' },
+    { profile: 'remote-work', path: '/api/profiles/sessions?profile=remote-work&limit=100&offset=100&order=updated' },
+    { profile: 'remote-work', path: '/api/profiles/sessions?profile=remote-work&limit=50&offset=200&order=updated' }
   ])
   assert.equal(result.sessions.length, 250)
   assert.equal(result.total, 250)
@@ -104,7 +105,10 @@ test('remote paging preserves offsets and deduplicates pinned backfill rows', as
     }
   )
 
-  assert.deepEqual(calls, ['/api/sessions?limit=100&offset=80', '/api/sessions?limit=50&offset=180'])
+  assert.deepEqual(calls, [
+    '/api/profiles/sessions?profile=remote-work&limit=100&offset=80',
+    '/api/profiles/sessions?profile=remote-work&limit=50&offset=180'
+  ])
   assert.deepEqual(
     result.sessions.map(row => (row as { id: string }).id),
     [...rows.slice(80, 230).map(row => row.id), 'session-20']
@@ -136,9 +140,9 @@ test('remote paging treats malformed totals as unknown instead of truncating the
     )
 
     assert.deepEqual(calls, [
-      '/api/sessions?limit=100&offset=0',
-      '/api/sessions?limit=100&offset=100',
-      '/api/sessions?limit=100&offset=200'
+      '/api/profiles/sessions?limit=100&offset=0&profile=remote-work',
+      '/api/profiles/sessions?limit=100&offset=100&profile=remote-work',
+      '/api/profiles/sessions?limit=100&offset=200&profile=remote-work'
     ])
     assert.equal(result.sessions.length, 250)
     assert.equal(result.total, 250)
@@ -172,6 +176,196 @@ test('remote session reads keep small requests on one call', async () => {
     }
   )
 
-  assert.deepEqual(calls, [{ profile: 'remote-work', path: '/api/sessions?limit=20&offset=0' }])
+  assert.deepEqual(calls, [
+    { profile: 'remote-work', path: '/api/profiles/sessions?profile=remote-work&limit=20&offset=0' }
+  ])
   assert.equal(result, expected)
+})
+
+test('remote session reads use the named profile on a shared gateway instead of the default /api/sessions store', async () => {
+  const calls: string[] = []
+
+  const named = {
+    sessions: [{ id: '20260815_095947_ac2552', title: 'Check channelsDVR guide data', profile: 'cableguy' }],
+    total: 1,
+    profile_totals: { cableguy: 1 }
+  }
+
+  const fallback = {
+    sessions: [{ id: '20260814_045259_3566c8', title: 'Resume OPNsense 26.7.2 maintenance' }],
+    total: 1
+  }
+
+  const result = await fetchRemoteProfileSessions(
+    'cableguy',
+    new URLSearchParams({ profile: 'cableguy', limit: '20', offset: '0', min_messages: '1', archived: 'exclude' }),
+    async (_profile, path) => {
+      calls.push(path)
+
+      return path.startsWith('/api/profiles/sessions') ? named : fallback
+    }
+  )
+
+  assert.equal(calls.some(path => path.startsWith('/api/profiles/sessions')), true)
+  assert.equal(
+    calls.some(path => path.startsWith('/api/sessions')),
+    false,
+    'must not leak the shared host default store once the named profile answers'
+  )
+  assert.deepEqual(
+    result.sessions.map(row => (row as { id: string }).id),
+    ['20260815_095947_ac2552']
+  )
+})
+
+test('remote session reads keep a 200 named list even when profile_totals omits the name', async () => {
+  const calls: string[] = []
+
+  const result = await fetchRemoteProfileSessions(
+    'cableguy',
+    new URLSearchParams({ profile: 'cableguy', limit: '20', offset: '0' }),
+    async (_profile, path) => {
+      calls.push(path)
+
+      if (path.startsWith('/api/profiles/sessions')) {
+        return { sessions: [], total: 0, profile_totals: {} }
+      }
+
+      return { sessions: [{ id: 'default-opnsense' }], total: 1 }
+    }
+  )
+
+  assert.deepEqual(calls, ['/api/profiles/sessions?profile=cableguy&limit=20&offset=0'])
+  assert.deepEqual(result.sessions, [])
+  assert.equal(result.total, 0)
+})
+
+test('remote session reads do not fall back to /api/sessions when the named list returns 5xx', async () => {
+  const calls: string[] = []
+
+  await assert.rejects(
+    () =>
+      fetchRemoteProfileSessions(
+        'cableguy',
+        new URLSearchParams({ profile: 'cableguy', limit: '20' }),
+        async (_profile, path) => {
+          calls.push(path)
+
+          if (path.startsWith('/api/profiles/sessions')) {
+            throw new Error('500: boom')
+          }
+
+          return { sessions: [{ id: 'default-opnsense' }], total: 1 }
+        }
+      ),
+    /500: boom/
+  )
+
+  assert.deepEqual(calls, ['/api/profiles/sessions?profile=cableguy&limit=20'])
+})
+
+test('remote session reads do not leak the default store when the named profile is unknown', async () => {
+  const calls: string[] = []
+
+  await assert.rejects(
+    () =>
+      fetchRemoteProfileSessions(
+        'cableguy',
+        new URLSearchParams({ profile: 'cableguy', limit: '20' }),
+        async (_profile, path) => {
+          calls.push(path)
+
+          if (path.startsWith('/api/profiles/sessions')) {
+            throw new Error('404: {"detail":"Profile \'cableguy\' does not exist."}')
+          }
+
+          return { sessions: [{ id: 'default-opnsense' }], total: 1 }
+        }
+      ),
+    /Profile 'cableguy' does not exist/
+  )
+
+  assert.deepEqual(calls, ['/api/profiles/sessions?profile=cableguy&limit=20'])
+})
+
+test('remote session reads fall back to /api/sessions when the named list endpoint is missing', async () => {
+  const calls: string[] = []
+  const fallback = { sessions: [{ id: 'dedicated-1' }], total: 1 }
+
+  const result = await fetchRemoteProfileSessions(
+    'remote-work',
+    new URLSearchParams({ profile: 'remote-work', limit: '20', offset: '0' }),
+    async (_profile, path) => {
+      calls.push(path)
+
+      if (path.startsWith('/api/profiles/sessions')) {
+        throw new Error('404: {"detail":"No such API endpoint: /api/profiles/sessions"}')
+      }
+
+      return fallback
+    }
+  )
+
+  assert.equal(calls[0], '/api/profiles/sessions?profile=remote-work&limit=20&offset=0')
+  assert.equal(
+    calls.some(path => path.startsWith('/api/sessions')),
+    true
+  )
+  assert.equal(result, fallback)
+})
+
+test('remote session reads try scoped /api/sessions before the unscoped default store', async () => {
+  const calls: string[] = []
+  const scoped = { sessions: [{ id: 'named-1' }], total: 1 }
+  const unscoped = { sessions: [{ id: 'default-opnsense' }], total: 1 }
+
+  const result = await fetchRemoteProfileSessions(
+    'cableguy',
+    new URLSearchParams({ profile: 'cableguy', limit: '20', offset: '0' }),
+    async (_profile, path) => {
+      calls.push(path)
+
+      if (path.startsWith('/api/profiles/sessions')) {
+        throw new Error('404: {"detail":"No such API endpoint: /api/profiles/sessions"}')
+      }
+
+      return path.includes('profile=cableguy') ? scoped : unscoped
+    }
+  )
+
+  assert.deepEqual(calls, [
+    '/api/profiles/sessions?profile=cableguy&limit=20&offset=0',
+    '/api/sessions?profile=cableguy&limit=20&offset=0'
+  ])
+  assert.equal(result, scoped)
+})
+
+test('remote session reads keep an empty named profile instead of leaking the default store', async () => {
+  const result = await fetchRemoteProfileSessions(
+    'cableguy',
+    new URLSearchParams({ profile: 'cableguy', limit: '20' }),
+    async (_profile, path) => {
+      if (path.startsWith('/api/profiles/sessions')) {
+        return { sessions: [], total: 0, profile_totals: { cableguy: 0 } }
+      }
+
+      return { sessions: [{ id: 'default-opnsense' }], total: 1 }
+    }
+  )
+
+  assert.deepEqual(result.sessions, [])
+  assert.equal(result.total, 0)
+})
+
+test('shared-gateway detection is URL identity, not profile name', () => {
+  const remotes = {
+    cableguy: { url: 'http://10.42.94.4:9119/' },
+    'ubuntu-server': { url: 'http://10.42.94.4:9119' },
+    dedicated: { url: 'http://10.42.94.38:9119' }
+  }
+
+  assert.equal(remoteProfileSharesGateway('cableguy', remotes), true)
+  assert.equal(remoteProfileSharesGateway('ubuntu-server', remotes), true)
+  assert.equal(remoteProfileSharesGateway('dedicated', remotes), false)
+  assert.equal(remoteProfileSharesGateway('missing', remotes), false)
 })

--- a/apps/desktop/electron/profile-session-routing.ts
+++ b/apps/desktop/electron/profile-session-routing.ts
@@ -88,16 +88,34 @@ export async function fetchPrimaryProfileSessions(
   }
 }
 
-export async function fetchRemoteProfileSessions(
+function isMissingListEndpointError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error ?? '')
+
+  if (
+    message.includes('got HTML') ||
+    message.includes('endpoint is likely missing') ||
+    message.includes('No such API endpoint')
+  ) {
+    return true
+  }
+
+  return /^404:/.test(message) && !/Profile ['"].*['"] does not exist/i.test(message)
+}
+
+// A shared remote gateway hosts many profiles. `/api/sessions` is that host's
+// default store, so a Desktop profile override must read the named profile
+// first. Any 200 from `/api/profiles/sessions` is authoritative. Missing
+// aggregator endpoints fall back to `/api/sessions?profile=` before the
+// unscoped dedicated-remote store.
+
+async function fetchPagedRemoteSessions(
   profile: string,
+  pathname: string,
   searchParams: URLSearchParams,
   fetchJsonForProfile: FetchJsonForProfile
 ): Promise<SessionListResponse> {
-  const params = new URLSearchParams(searchParams)
-  params.delete('profile') // the remote serves its own database
-
-  const requestedLimit = Number(params.get('limit'))
-  const requestedOffset = Number(params.get('offset') || '0')
+  const requestedLimit = Number(searchParams.get('limit'))
+  const requestedOffset = Number(searchParams.get('offset') || '0')
 
   const needsPaging =
     Number.isInteger(requestedLimit) &&
@@ -106,7 +124,7 @@ export async function fetchRemoteProfileSessions(
     requestedOffset >= 0
 
   if (!needsPaging) {
-    return (await fetchJsonForProfile(profile, `/api/sessions?${params}`)) as SessionListResponse
+    return (await fetchJsonForProfile(profile, `${pathname}?${searchParams}`)) as SessionListResponse
   }
 
   const sessions: unknown[] = []
@@ -118,12 +136,12 @@ export async function fetchRemoteProfileSessions(
   let targetOffset = requestedOffset + requestedLimit
 
   while (pageOffset < targetOffset) {
-    const pageParams = new URLSearchParams(params)
+    const pageParams = new URLSearchParams(searchParams)
     const pageLimit = Math.min(REMOTE_SESSION_PAGE_LIMIT, targetOffset - pageOffset)
     pageParams.set('limit', String(pageLimit))
     pageParams.set('offset', String(pageOffset))
 
-    const page = (await fetchJsonForProfile(profile, `/api/sessions?${pageParams}`)) as SessionListResponse
+    const page = (await fetchJsonForProfile(profile, `${pathname}?${pageParams}`)) as SessionListResponse
     firstPage ??= page
 
     const total = nonNegativeNumber(page.total)
@@ -132,7 +150,7 @@ export async function fetchRemoteProfileSessions(
     const windowedCount =
       total !== null ? Math.min(pageLimit, Math.max(0, total - pageOffset)) : Math.min(pageLimit, pageRows.length)
 
-    // /api/sessions appends pinned rows that fall outside the requested
+    // Both list endpoints append pinned rows that fall outside the requested
     // window. Keep those aside until all ordinary pages have been joined so
     // pagination preserves the same order as one larger request.
     for (const row of pageRows.slice(0, windowedCount)) {
@@ -188,4 +206,60 @@ export async function fetchRemoteProfileSessions(
     limit: requestedLimit,
     offset: requestedOffset
   }
+}
+
+export function remoteProfileSharesGateway(
+  profile: string,
+  remotes: Record<string, { url?: null | string } | undefined>
+): boolean {
+  const wanted = String(remotes[profile]?.url || '').replace(/\/+$/, '')
+
+  if (!wanted) {
+    return false
+  }
+
+  return Object.entries(remotes).some(([name, cfg]) => {
+    if (name === profile) {
+      return false
+    }
+
+    return String(cfg?.url || '').replace(/\/+$/, '') === wanted
+  })
+}
+
+export async function fetchRemoteProfileSessions(
+  profile: string,
+  searchParams: URLSearchParams,
+  fetchJsonForProfile: FetchJsonForProfile
+): Promise<SessionListResponse> {
+  const namedParams = new URLSearchParams(searchParams)
+  namedParams.set('profile', profile)
+
+  const defaultParams = new URLSearchParams(searchParams)
+  defaultParams.delete('profile')
+
+  try {
+    return await fetchPagedRemoteSessions(
+      profile,
+      '/api/profiles/sessions',
+      namedParams,
+      fetchJsonForProfile
+    )
+  } catch (error) {
+    // Dedicated remotes may only expose /api/sessions. A 5xx/timeout must not
+    // leak that host's default store.
+    if (!isMissingListEndpointError(error)) {
+      throw error
+    }
+  }
+
+  try {
+    return await fetchPagedRemoteSessions(profile, '/api/sessions', namedParams, fetchJsonForProfile)
+  } catch (error) {
+    if (!isMissingListEndpointError(error)) {
+      throw error
+    }
+  }
+
+  return fetchPagedRemoteSessions(profile, '/api/sessions', defaultParams, fetchJsonForProfile)
 }


### PR DESCRIPTION
## What does this PR do?

Named Desktop remotes that share a gateway were listed through `/api/sessions`. That endpoint returns the host **default** store, and Desktop then relabeled those rows as the named profile. Opening/resuming the same remotes also dropped `?profile=`, so the host opened the default store again.

This routes named remotes through `/api/profiles/sessions?profile=<name>` first:

- Any `200` from the aggregator is authoritative, including an empty named store (`total: 0` or omitted `profile_totals`).
- Fall back only when that endpoint is missing (`404` / HTML). Try `/api/sessions?profile=` before the unscoped dedicated-remote store.
- `5xx` / timeouts and `404 Profile does not exist` do **not** fall back to the default store.
- On a shared gateway, open/resume keeps `?profile=` so the host opens the right store.

## Related Issue

No existing issue. Related but not a duplicate of #83708 (messaging scoped to the active remote), #81457 (global sessions across local overrides), or closed #85932 (dedicated-remote resume). This PR is the shared-gateway list/open leak: named remotes were reading and opening the host default store.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `apps/desktop/electron/profile-session-routing.ts` — named-profile list first; trust any 200; missing-endpoint fallback via scoped then unscoped `/api/sessions`
- `apps/desktop/electron/main.ts` — keep `?profile=` on shared-gateway session open/resume
- `apps/desktop/electron/profile-session-routing.test.ts` — 15 cases covering shared-gateway empty/unknown profiles, 5xx, scoped fallback, and dedicated remotes

## How to Test

1. `cd apps/desktop && npx vitest run --project electron electron/profile-session-routing.test.ts`
2. Point two Desktop profiles at the same gateway, with sessions only in the named profile store.
3. Open the named profile in the sidebar: rows come from `/api/profiles/sessions?profile=<name>`, not the default store.
4. Resume a named-profile session on that shared gateway and confirm the request keeps `?profile=`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — N/A (JS-only Desktop change; targeted Vitest: 15 passed)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.0 (Darwin 27.0), arm64

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
