### PR TITLE
feat(desktop): add NSScreenCaptureUsageDescription to macOS bundle

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -230,7 +230,8 @@
         "CFBundleName": "Hermes",
         "NSAudioCaptureUsageDescription": "Hermes uses audio capture for voice conversations.",
         "NSCameraUsageDescription": "Hermes uses the camera when a plugin or feature you enable requests it.",
-        "NSMicrophoneUsageDescription": "Hermes uses the microphone for voice input and voice conversations."
+        "NSMicrophoneUsageDescription": "Hermes uses the microphone for voice input and voice conversations.",
+        "NSScreenCaptureUsageDescription": "Hermes captures the screen when you ask the agent to screenshot or record it."
       },
       "gatekeeperAssess": false,
       "hardenedRuntime": true,


### PR DESCRIPTION
## Problem

The packaged macOS bundle has no `NSScreenCaptureUsageDescription`. When the app (or a plugin driving `desktopCapturer` / ScreenCaptureKit) first requests screen access, macOS shows a bare Screen Recording prompt with no purpose string — and some request flows fail silently instead of prompting.

## Change

Add the purpose string to `build.mac.extendInfo` in `apps/desktop/package.json`, alongside the existing audio / camera / microphone strings.

## Test plan

Packed locally (`npm run pack`, `--dir`) and verified the key lands in the built bundle:

```
$ plutil -extract NSScreenCaptureUsageDescription raw release/mac-arm64/Hermes.app/Contents/Info.plist
Hermes captures the screen when you ask the agent to screenshot or record it.
```

`package.json` parses (`python -m json.tool`).
