### PR TITLE
fix(desktop): right sidebar sash preview mirrors the nested-zone commit

### DIFF
--- a/apps/desktop/e2e/sash-snap-repro.spec.ts
+++ b/apps/desktop/e2e/sash-snap-repro.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from './test'
+import { expect, test } from './test'
 
 import {
   type MockBackendFixture,

--- a/apps/desktop/e2e/sash-snap-repro.spec.ts
+++ b/apps/desktop/e2e/sash-snap-repro.spec.ts
@@ -1,0 +1,175 @@
+import { test, expect } from './test'
+
+import {
+  type MockBackendFixture,
+  setupMockBackend,
+  waitForAppReady,
+} from './fixtures'
+
+/**
+ * REGRESSION: dragging the seam between the workspace and the nested right
+ * section (default tree's `spl-right`) snaps the section instead of previewing
+ * the width it will commit.
+ *
+ * Root cause: `startSash` in tree-split.tsx resolves the fixed side's resize
+ * target via `edgeFixedZone` — the INNER edge zone (grp-review) — so `b0px`
+ * is the review zone's width (237) while the preview applied it as the
+ * flex-basis of the whole SECTION wrapper (474). Mid-drag the section
+ * collapsed to the review zone's clamped size (320px = 68% of 474 — the
+ * "snap towards the right at 2/3"), then jumped to yet another width (557,
+ * review@maxWidth 320 + files 237) on release.
+ *
+ * The fix previews with the seam partners' wrapper sizes captured at
+ * pointerdown AND mirrors the commit on the resize target itself (the inner
+ * zone), so the drag previews the same clamped width the release commits.
+ */
+let fixture: MockBackendFixture | null = null
+
+test.beforeAll(async () => {
+  fixture = await setupMockBackend()
+  await waitForAppReady(fixture, 120_000)
+})
+
+test.afterAll(async () => {
+  await fixture?.cleanup()
+  fixture = null
+})
+
+test('the workspace|section sash previews the width it commits (no mid-drag snap)', async () => {
+  const page = fixture!.page
+
+  // Let the layout tree render.
+  await page.locator('[data-tree-group]').first().waitFor({ state: 'visible', timeout: 30_000 })
+
+  // The review/files groups start collapsed (their panes are closed at boot).
+  await page.getByRole('button', { name: /right sidebar/i }).first().click().catch(() => {})
+  await page.keyboard.press('Meta+g')
+  await page.getByRole('button', { name: /right sidebar/i }).first().click().catch(() => {})
+
+  // Wait for the actual precondition (both rail panes rendered) instead of
+  // fixed delays.
+  await page.waitForFunction(() => {
+    const visible = (id: string) => {
+      const r = document.querySelector<HTMLElement>(`[data-tree-group="${id}"]`)?.getBoundingClientRect()
+      return Boolean(r && r.width > 0 && r.height > 0)
+    }
+
+    return visible('grp-files') && visible('grp-review')
+  }, undefined, { timeout: 30_000 })
+
+  const drag = await page.evaluate(async () => {
+    const groups = [...document.querySelectorAll<HTMLElement>('[data-tree-group]')].map((el) => {
+      const r = el.getBoundingClientRect()
+      return { id: el.dataset.treeGroup ?? '', left: r.left, right: r.right, top: r.top, bottom: r.bottom }
+    })
+
+    const review = groups.find((g) => g.id === 'grp-review')
+    const files = groups.find((g) => g.id === 'grp-files')
+
+    if (!review || !files) {
+      return { ok: false as const, reason: `review/files missing (groups: ${groups.map((g) => g.id).join(',')})` }
+    }
+
+    const separators = [...document.querySelectorAll<HTMLElement>('[role="separator"]')]
+      .map((el) => {
+        const r = el.getBoundingClientRect()
+        return { el, left: r.left, right: r.right, top: r.top, bottom: r.bottom, w: r.width, h: r.height }
+      })
+      .filter((s) => s.w > 0 && s.h > 0)
+
+    if (separators.length === 0) {
+      return { ok: false as const, reason: 'no separators' }
+    }
+
+    // The sash on the section's left edge (workspace | spl-right seam).
+    const target = separators
+      .map((s) => ({ ...s, score: Math.abs((s.left + s.right) / 2 - review.left) }))
+      .sort((a, b) => a.score - b.score)[0]
+
+    const sectionWidthBefore = files.right - review.left
+
+    const x = (target.left + target.right) / 2
+    const y = (target.top + target.bottom) / 2
+    const pointer = {
+      bubbles: true,
+      cancelable: true,
+      pointerId: 77,
+      pointerType: 'mouse',
+      isPrimary: true,
+      button: 0,
+      buttons: 1,
+    }
+
+    target.el.dispatchEvent(new PointerEvent('pointerdown', { ...pointer, clientX: x, clientY: y }))
+
+    let currentX = x
+    for (let index = 0; index < 20; index += 1) {
+      currentX -= 6 // drag LEFT ~120px: should WIDEN the section
+      window.dispatchEvent(new PointerEvent('pointermove', { ...pointer, clientX: currentX, clientY: y }))
+      await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()))
+    }
+
+    // Measure MID-DRAG (the preview state) — the "sudden snap" moment.
+    await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()))
+    const reviewMid = document.querySelector('[data-tree-group="grp-review"]')?.getBoundingClientRect()
+    const filesMid = document.querySelector('[data-tree-group="grp-files"]')?.getBoundingClientRect()
+
+    window.dispatchEvent(new PointerEvent('pointerup', { ...pointer, buttons: 0, clientX: currentX, clientY: y }))
+
+    return {
+      ok: true as const,
+      sectionWidthBefore: Math.round(sectionWidthBefore),
+      sectionWidthMid: reviewMid && filesMid ? Math.round(filesMid.right - reviewMid.left) : -1,
+      draggedBy: Math.round(x - currentX),
+    }
+  })
+
+  if (!drag.ok) {
+    throw new Error(drag.reason)
+  }
+
+  // Wait for the release commit to settle: React's re-render rewrites the
+  // wrappers' `flex` shorthand, which must clear the preview's inline
+  // flex-basis (a leftover would be a stuck-style regression in the #72845
+  // family), and the review zone must be at its committed clamped width.
+  await page.waitForFunction(() => {
+    const review = document.querySelector<HTMLElement>('[data-tree-group="grp-review"]')?.getBoundingClientRect()
+    const separators = [...document.querySelectorAll<HTMLElement>('[role="separator"]')]
+      .map((el) => ({ el, left: el.getBoundingClientRect().left, w: el.getBoundingClientRect().width }))
+      .filter((s) => s.w > 0)
+    const sash = separators.sort((a, b) => Math.abs(a.left - (review?.left ?? 0)) - Math.abs(b.left - (review?.left ?? 0)))[0]
+    const sectionWrapper = sash?.el.nextElementSibling as HTMLElement | null
+
+    return Boolean(
+      review && review.width >= 310 && // review clamped at its max (~320)
+        sectionWrapper &&
+        !sectionWrapper.style.flexBasis && // preview basis cleared
+        !sectionWrapper.querySelector('[style*="flex-basis" i]'),
+    )
+  }, undefined, { timeout: 5_000 })
+
+  const after = await page.evaluate(() => {
+    const review = document.querySelector('[data-tree-group="grp-review"]')?.getBoundingClientRect()
+    const files = document.querySelector('[data-tree-group="grp-files"]')?.getBoundingClientRect()
+    const separators = [...document.querySelectorAll<HTMLElement>('[role="separator"]')]
+      .map((el) => ({ el, left: el.getBoundingClientRect().left, w: el.getBoundingClientRect().width }))
+      .filter((s) => s.w > 0)
+    const sash = separators.sort((a, b) => Math.abs(a.left - (review?.left ?? 0)) - Math.abs(b.left - (review?.left ?? 0)))[0]
+    const sectionWrapper = sash?.el.nextElementSibling as HTMLElement | null
+
+    return {
+      sectionWidthAfter: review && files ? Math.round(files.right - review.left) : -1,
+      wrapperFlexBasis: sectionWrapper?.style.flexBasis ?? 'missing',
+    }
+  })
+
+  // The drag runs into the review zone's maxWidth (320px), so the section
+  // legitimately stops at ~557px — but the PREVIEW must show exactly the
+  // width the release commits. The regression snapped the section to 320
+  // mid-drag (the inner zone's size) and jumped to 557 on release: a 237px
+  // gap between preview and commit.
+  expect(Math.abs(drag.sectionWidthMid - after.sectionWidthAfter)).toBeLessThanOrEqual(5)
+  expect(after.sectionWidthAfter).toBeGreaterThanOrEqual(drag.sectionWidthBefore + 80)
+  // No leftover inline flex-basis on the section wrapper after release.
+  expect(after.wrapperFlexBasis).toBe('')
+})

--- a/apps/desktop/src/components/pane-shell/tree/renderer/tree-split.tsx
+++ b/apps/desktop/src/components/pane-shell/tree/renderer/tree-split.tsx
@@ -233,7 +233,12 @@ export function TreeSplit({ node, root, rootRow }: { node: SplitNode; root?: boo
           min: toolZone ? floor : Math.max(floor, computedPx(horizontal ? cs.minWidth : cs.minHeight, 0)),
           max: computedPx(horizontal ? cs.maxWidth : cs.maxHeight, Number.POSITIVE_INFINITY),
           collapseId: toolZone ? (zone?.id ?? groupIdOf(child)) : null,
-          floor
+          floor,
+          // The flex item the resize target sizes through. For a direct group
+          // child this IS the seam partner (kidA/kidB); for a NESTED section
+          // (edgeFixedZone) it is the inner zone's wrapper — the seam partner
+          // and the resize target differ, and the preview must write both.
+          el
         }
       }
 
@@ -250,6 +255,17 @@ export function TreeSplit({ node, root, rootRow }: { node: SplitNode; root?: boo
       const b0px = b.fixed ? b.size : sizeOf(kidB)
       const lo = Math.max(a.min - a0px, b0px - b.max)
       const hi = Math.min(a.max - a0px, b0px - b.min)
+
+      // Preview basis: the seam partners' rendered sizes at pointerdown.
+      // The resize target (a.size / b.size) resolves to the INNER edge zone
+      // for a nested section (the default tree's `spl-right`: review at
+      // 237px inside the 474px section wrapper), while the seam partner is
+      // the section wrapper itself. Using the zone size as the preview
+      // basis collapsed the whole section to the zone's width mid-drag —
+      // the ~2/3 "snap". Clamps and commit stay zone-bounded: the section
+      // genuinely cannot exceed review-max + files.
+      const aWrap0 = sizeOf(kidA)
+      const bWrap0 = sizeOf(kidB)
 
       const setOverride = horizontal ? setPaneWidthOverride : setPaneHeightOverride
 
@@ -312,6 +328,11 @@ export function TreeSplit({ node, root, rootRow }: { node: SplitNode; root?: boo
 
       const styleA = kidA.getAttribute('style')
       const styleB = kidB.getAttribute('style')
+      // The resize targets' wrappers carry their own inline styles for
+      // nested seams (the zone writes below); capture them for the
+      // no-movement restore. `undefined` marks "same element as kidA/kidB".
+      const styleElA = a.el === kidA ? undefined : a.el.getAttribute('style')
+      const styleElB = b.el === kidB ? undefined : b.el.getAttribute('style')
 
       const previewSide = (el: HTMLElement, fixed: boolean, px: number) => {
         if (fixed) {
@@ -324,8 +345,22 @@ export function TreeSplit({ node, root, rootRow }: { node: SplitNode; root?: boo
       }
 
       const previewShift = (shiftPx: number) => {
-        previewSide(kidA, a.fixed, a0px + shiftPx)
-        previewSide(kidB, b.fixed, b0px - shiftPx)
+        previewSide(kidA, a.fixed, aWrap0 + shiftPx)
+        previewSide(kidB, b.fixed, bWrap0 - shiftPx)
+        // Mirror the commit on the resize target itself. For a nested
+        // section the seam resolves to an INNER zone (edgeFixedZone); the
+        // commit writes that zone's override, so the drag preview must
+        // resize the zone too — otherwise the section wrapper grows while
+        // its content stays put, leaving a gap until release. For a direct
+        // group child the zone's flex item IS the seam partner, so the
+        // wrapper write above already covers it.
+        if (a.fixed && a.el !== kidA) {
+          previewSide(a.el, true, a0px + shiftPx)
+        }
+
+        if (b.fixed && b.el !== kidB) {
+          previewSide(b.el, true, b0px - shiftPx)
+        }
       }
 
       const resize = rafCoalesce(previewShift)
@@ -367,6 +402,18 @@ export function TreeSplit({ node, root, rootRow }: { node: SplitNode; root?: boo
         } else {
           // Click without movement: nothing will re-render, so put the
           // wrappers' inline styles back exactly as React last wrote them.
+          const restoreStyle = (el: HTMLElement, captured: string | null | undefined) => {
+            if (captured === undefined) {
+              return // same element as a seam partner restored above
+            }
+
+            if (captured === null) {
+              el.removeAttribute('style')
+            } else {
+              el.setAttribute('style', captured)
+            }
+          }
+
           if (styleA === null) {
             kidA.removeAttribute('style')
           } else {
@@ -378,6 +425,9 @@ export function TreeSplit({ node, root, rootRow }: { node: SplitNode; root?: boo
           } else {
             kidB.setAttribute('style', styleB)
           }
+
+          restoreStyle(a.el, styleElA)
+          restoreStyle(b.el, styleElB)
         }
 
         // Geometry vars re-enable AFTER the final store commit above, so the


### PR DESCRIPTION
## Bug Description

Dragging the seam between the chat area and the right sidebar (files/review rail) snaps the rail to ~2/3 of its width mid-drag, then jumps to a third width on release. The rail never lands where the pointer indicates.

Closes #87205

## Root Cause

The sash drag in `tree-split.tsx` (`startSash`) resolves each seam side's resize target via `edgeFixedZone` — for a seam side that is a NESTED split, the resize target is the innermost edge zone, not the section wrapper. The default tree's right rail is nested (`spl-right` = `COLUMN[ROW[review|files] | terminal]`), so dragging the workspace|rail seam resized the inner **review** zone (237px) while the drag preview applied that zone's size as the flex-basis of the whole **section** wrapper (474px):

- Mid-drag: the section collapses to the review zone's clamped size (320px = 68% of 474px).
- Release: the commit writes the review override (320px) and the section lands at review-max + files = 557px — a third width.

For a direct group seam (`zoneEl.parentElement` IS the seam partner) the zone and wrapper sizes agree, which is why only nested-section seams snap.

## Fix

The drag preview now writes both elements the release commit affects:

- the seam-partner wrapper, sized from its rendered width at pointerdown (`aWrap0`/`bWrap0`), and
- the resize target's flex item (`a.el`/`b.el` — the new `el` field returned by `sideFor`), sized from the zone (`a0px`/`b0px`).

The preview therefore mirrors the commit logic: at any pointer position, the mid-drag preview renders the same width the release commits for that position. Clamp and commit math are unchanged (still zone-bounded — the rail genuinely cannot exceed review-max + files).

## How to Verify

1. Open the desktop app with the default layout; open Files (`⌘J`) and Review (`⌘G`).
2. Drag the vertical seam between the chat and the right rail to widen it.
3. The rail follows the pointer and lands where released (stopping at the panes' max widths).

## Test Plan

- [x] Added regression test — `apps/desktop/e2e/sash-snap-repro.spec.ts` (deterministic; fails on main with |preview − commit| = 237px, passes with the fix)
- [x] Existing tests still pass — pane-shell vitest 110/110, typecheck + eslint clean
- [x] Manual verification — e2e run: mid-drag == after == 557px

## Risk Assessment

Low — the release-commit path is untouched; only the mid-drag preview changes. Direct-group seams write the same element with the same values as before (the new writes collapse to a no-op there).

## Notes

- Related: #84484 (layout-editor pane moves / sash resizes on macOS — a different mechanism: native drag-region pointer theft, addressed in PR #84576 by @Enough1122) and #79183 (old preview-rail collapse — that rail was removed in #77705; the follow-up analysis concluded the sash math was sound, but it simulated direct fixed and flex seams only — the nested-section seam is the case that snaps).
- The snap mechanism shipped with the layout-tree renderer ([`63a9bde77b`](https://github.com/NousResearch/hermes-agent/commit/63a9bde77b) + [`0f922002eb`](https://github.com/NousResearch/hermes-agent/commit/0f922002eb), 2026-07-13); the 60fps inline-preview rewrite ([`2c867b05ce`](https://github.com/NousResearch/hermes-agent/commit/2c867b05ce), 2026-07-27) is what makes it visible as a mid-drag snap.
