### PR TITLE
feat: support config.yaml env_files at runtime

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -33,6 +33,46 @@ from typing import Any, Dict, List, Optional
 
 from hermes_cli.timeouts import get_provider_request_timeout
 from agent.prompt_builder import format_steer_marker
+
+# Keys to redact in request debug dumps (case-insensitive match).
+_REDACTED_DUMP_KEYS: frozenset = frozenset({
+    "authorization",
+    "cookie",
+    "set-cookie",
+    "x-api-key",
+    "api_key",
+    "api-key",
+    "access_token",
+    "refresh_token",
+    "agent_key",
+    "id_token",
+    "bearer",
+    "token",
+    "password",
+    "secret",
+    "private_key",
+})
+
+
+def _redact_sensitive_dump_fields(obj: Any, _path: str = "") -> Any:
+    """Recursively walk *obj* and replace any value whose key name matches a
+    sensitive pattern with ``"[REDACTED]"``.
+
+    Works on nested dicts, lists, and primitive values.  Non-sensitive fields
+    are preserved unchanged.
+    """
+    if isinstance(obj, dict):
+        result: dict = {}
+        for k, v in obj.items():
+            if isinstance(k, str) and k.lower() in _REDACTED_DUMP_KEYS:
+                result[k] = "[REDACTED]"
+            else:
+                result[k] = _redact_sensitive_dump_fields(v, f"{_path}.{k}")
+        return result
+    if isinstance(obj, list):
+        return [_redact_sensitive_dump_fields(item, f"{_path}[{i}]")
+                for i, item in enumerate(obj)]
+    return obj
 from agent.tool_dispatch_helpers import _trajectory_normalize_msg, make_tool_result_message
 from agent.trajectory import convert_scratchpad_to_think
 from agent.credential_pool import STATUS_EXHAUSTED
@@ -1133,6 +1173,11 @@ def dump_api_request_debug(
                     _ra().logger.debug("Could not extract error response details: %s", e)
 
             dump_payload["error"] = error_info
+
+        # Redact sensitive fields before writing — prevents raw tokens from
+        # leaking into on-disk request dump files even when the request body
+        # or error response contains nested sensitive keys.
+        dump_payload = _redact_sensitive_dump_fields(dump_payload)
 
         timestamp = datetime.now().strftime("%Y%m%d_%H%M%S_%f")
         dump_file = agent.logs_dir / f"request_dump_{agent.session_id}_{timestamp}.json"

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -5327,8 +5327,31 @@ def save_config(config: Dict[str, Any]):
         _LAST_EXPANDED_CONFIG_BY_PATH[str(config_path)] = copy.deepcopy(current_normalized)
 
 
+def _resolve_env_files() -> list:
+    """Return extra env file paths declared in config.yaml:env_files.
+
+    Reads the raw config (mtime-cached) and returns a list of absolute
+    path strings. Missing keys or unparseable config degrade to [].
+    """
+    try:
+        cfg = read_raw_config()
+        if isinstance(cfg, dict):
+            ef = cfg.get("env_files")
+            if isinstance(ef, list):
+                return [str(Path(p)) for p in ef if p]
+    except Exception:
+        pass
+    return []
+
+
 def load_env() -> Dict[str, str]:
     """Load environment variables from ~/.hermes/.env.
+
+    Also merges any additional env files declared in config.yaml under
+    the top-level ``env_files`` list (external secret files such as
+    provider key files). Values from ``env_files`` override values from
+    ~/.hermes/.env; the process environment still wins because
+    ``get_env_value()`` consults ``os.environ`` first.
 
     Sanitizes lines before parsing so that corrupted files (e.g.
     concatenated KEY=VALUE pairs on a single line) are handled
@@ -5346,12 +5369,27 @@ def load_env() -> Dict[str, str]:
     global _env_cache
     env_path = get_env_path()
 
+    # Resolve any additional env files declared in config.yaml under the
+    # top-level `env_files` list. These let operators keep provider
+    # secrets in external files (e.g. /home/deploy/.lah-secrets/x.env)
+    # without duplicating values into ~/.hermes/.env.
+    extra_files = _resolve_env_files()
+
+    # Composite cache key: primary ~/.hermes/.env + every extra file's
+    # (mtime, size) so the memo invalidates when any watched file changes.
     try:
-        mtime = env_path.stat().st_mtime
-        size = env_path.stat().st_size
-        cache_key = (str(env_path), mtime, size)
-    except FileNotFoundError:
-        cache_key = (str(env_path), None, None)
+        items = []
+        if env_path.exists():
+            items.append((str(env_path), env_path.stat().st_mtime, env_path.stat().st_size))
+        else:
+            items.append((str(env_path), None, None))
+        for ef in extra_files:
+            p = Path(ef)
+            if p.exists():
+                items.append((str(p), p.stat().st_mtime, p.stat().st_size))
+            else:
+                items.append((str(p), None, None))
+        cache_key = tuple(items)
     except Exception:
         cache_key = None
 
@@ -5362,21 +5400,34 @@ def load_env() -> Dict[str, str]:
 
     env_vars: Dict[str, str] = {}
 
-    if env_path.exists():
-        # On Windows, open() defaults to the system locale (cp1252) which can
-        # fail on UTF-8 .env files. Always use explicit UTF-8; tolerate BOM
-        # via utf-8-sig since users may edit .env in Notepad which adds one.
+    def _read_file_lines(path: Path) -> list:
+        if not path.exists():
+            return []
         open_kw = {"encoding": "utf-8-sig", "errors": "replace"}
-        with open(env_path, **open_kw) as f:
+        with open(path, **open_kw) as f:
             raw_lines = f.readlines()
-        # Sanitize before parsing: split concatenated lines & drop stale
-        # placeholders so corrupted .env files don't produce invalid tokens.
-        lines = _sanitize_env_lines(raw_lines)
+        return _sanitize_env_lines(raw_lines)
+
+    def _merge_lines(lines: list) -> None:
         for line in lines:
-            line = line.strip()
-            if line and not line.startswith('#') and '=' in line:
-                key, _, value = line.partition('=')
+            s = line.strip()
+            if s and not s.startswith('#') and '=' in s:
+                key, _, value = s.partition('=')
                 env_vars[key.strip()] = value.strip().strip('"\'')
+
+    # Precedence (lowest → highest):
+    #   ~/.hermes/.env  <  config.yaml:env_files  <  process os.environ
+    # (process env wins because get_env_value() consults os.environ first.)
+    _merge_lines(_read_file_lines(env_path))
+
+    # env_files override ~/.hermes/.env values; a missing or unreadable
+    # extra file is non-fatal and treated as absent (Hermes convention:
+    # optional overrides must not break unrelated providers).
+    for ef in extra_files:
+        try:
+            _merge_lines(_read_file_lines(Path(ef)))
+        except Exception:
+            continue
 
     if cache_key is not None:
         _env_cache = (cache_key, dict(env_vars))

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -29,7 +29,7 @@ from hermes_cli.auth import (
     resolve_external_process_provider_credentials,
     has_usable_secret,
 )
-from hermes_cli.config import get_compatible_custom_providers, load_config
+from hermes_cli.config import get_compatible_custom_providers, get_env_value, load_config
 from hermes_constants import OPENROUTER_BASE_URL
 from utils import base_url_host_matches, base_url_hostname, env_int
 
@@ -154,7 +154,7 @@ def _host_derived_api_key(base_url: str) -> str:
     if sanitized in ("OPENAI", "OPENROUTER", "OLLAMA"):
         return ""
     env_name = f"{sanitized}_API_KEY"
-    return (os.getenv(env_name, "") or "").strip()
+    return (get_env_value(env_name) or "").strip()
 
 
 def _auto_detect_local_model(base_url: str) -> str:
@@ -526,9 +526,13 @@ def _get_named_custom_provider(requested_provider: str) -> Optional[Dict[str, An
                 continue
             # Match exact name or normalized name
             name_norm = _normalize_custom_provider_name(ep_name)
-            # Resolve the API key from the env var name stored in key_env
+            # Resolve the API key from the env var name stored in key_env.
+            # get_env_value() checks the process environment first, then
+            # ~/.hermes/.env and config.yaml:env_files — so custom provider
+            # keys declared in external env files resolve natively.
             key_env = str(entry.get("key_env", "") or "").strip()
-            resolved_api_key = os.getenv(key_env, "").strip() if key_env else ""
+            resolved_api_key = get_env_value(key_env) if key_env else None
+            resolved_api_key = (resolved_api_key or "").strip()
             # Fall back to inline api_key when key_env is absent or unresolvable
             if not resolved_api_key:
                 resolved_api_key = str(entry.get("api_key", "") or "").strip()
@@ -732,7 +736,7 @@ def _resolve_named_custom_runtime(
     api_key_candidates = [
         (explicit_api_key or "").strip(),
         str(custom_provider.get("api_key", "") or "").strip(),
-        os.getenv(str(custom_provider.get("key_env", "") or "").strip(), "").strip(),
+        (get_env_value(str(custom_provider.get("key_env", "") or "").strip()) or "").strip(),
         # Gate provider env keys on their authoritative hosts — sending
         # OPENAI_API_KEY to a local-llm endpoint leaks credentials (#28660).
         (os.getenv("OPENAI_API_KEY", "").strip()     if _cp_is_openai_url  else ""),

--- a/plugins/web/lah_discovery/__init__.py
+++ b/plugins/web/lah_discovery/__init__.py
@@ -1,0 +1,10 @@
+"""LAH Discovery Platform web plugin — bundled, auto-loaded, opt-in."""
+
+from __future__ import annotations
+
+from plugins.web.lah_discovery.provider import LahDiscoveryWebSearchProvider
+
+
+def register(ctx) -> None:
+    """Register the LAH Discovery Platform provider with the plugin context."""
+    ctx.register_web_search_provider(LahDiscoveryWebSearchProvider())

--- a/plugins/web/lah_discovery/plugin.yaml
+++ b/plugins/web/lah_discovery/plugin.yaml
@@ -1,0 +1,7 @@
+name: web-lah-discovery
+version: 1.0.0
+description: "LAH Discovery Platform — curated multi-source discovery (github, hackernews, blogs, documentation, forums, producthunt) via a self-hosted lah-discovery-platform REST API. Requires LAH_DISCOVERY_BASE_URL. NOTE: extract() takes a registered source_id (e.g. 'github'), not an arbitrary URL — this provider does not do general-purpose web extraction, see provider.py docstring."
+author: NousResearch
+kind: backend
+provides_web_providers:
+  - lah-discovery

--- a/plugins/web/lah_discovery/plugin.yaml
+++ b/plugins/web/lah_discovery/plugin.yaml
@@ -1,6 +1,6 @@
 name: web-lah-discovery
 version: 1.0.0
-description: "LAH Discovery Platform — curated multi-source discovery (github, hackernews, blogs, documentation, forums, producthunt) via a self-hosted lah-discovery-platform REST API. Requires LAH_DISCOVERY_BASE_URL. NOTE: extract() takes a registered source_id (e.g. 'github'), not an arbitrary URL — this provider does not do general-purpose web extraction, see provider.py docstring."
+description: "LAH Discovery Platform — opt-in HTTP client for a self-hosted lah-discovery-platform REST API. Requires LAH_DISCOVERY_BASE_URL and uses POST /extract with real URLs for direct content extraction. Not part of the default fallback chain."
 author: NousResearch
 kind: backend
 provides_web_providers:

--- a/plugins/web/lah_discovery/provider.py
+++ b/plugins/web/lah_discovery/provider.py
@@ -6,22 +6,23 @@ this plugin never imports the ``lah_discovery`` Python package and never
 touches ``crawl4ai`` directly. It is disabled (``is_available()`` returns
 False) unless ``LAH_DISCOVERY_BASE_URL`` is explicitly set.
 
-IMPORTANT — capability boundary, read before wiring this up:
-
-``lah-discovery-platform``'s REST API (as of its ``LAH_DISCOVERY_REST_API_SERVER``
-mission) exposes exactly one discovery endpoint, ``POST /discover/<source_id>``,
-which runs a curated pipeline against one of six *registered* sources
-(``github``, ``hackernews``, ``blogs``, ``documentation``, ``forums``,
-``producthunt``) — it has no endpoint for fetching an arbitrary URL. This
-plugin's :meth:`extract` therefore expects each entry in ``urls`` to be one
-of those six source_id strings, NOT a real URL, despite the ABC's normal
-"list of URLs" semantics. An unrecognized source_id fails closed (a per-item
-error entry, matching the existing legacy contract for per-URL failures —
-see :meth:`extract`), never a crash and never a fabricated result.
+As of lah-discovery-platform's ``POST /extract`` endpoint, this provider's
+:meth:`extract` sends the ``urls`` list through unchanged — each entry is a
+real URL, fetched directly via the platform's Discovery Facade (no Source
+Registry lookup, no curated multi-source pipeline). This replaces the
+earlier stopgap where each entry in ``urls`` had to be one of six
+registered ``source_id`` strings (``github``, ``hackernews``, ``blogs``,
+``documentation``, ``forums``, ``producthunt``) POSTed to
+``/discover/<source_id>`` — that capability gap is now closed. A failed
+fetch for one URL never fails the whole batch: the response carries a
+per-URL ``success``/``error`` result, and an unreachable API or malformed
+response fails every requested URL closed (a per-item error entry), never
+a crash and never a fabricated result.
 
 Only ``supports_extract()`` is implemented — there is no free-text search
-capability behind ``/discover/<source_id>``, so ``supports_search()`` is
-False and :meth:`search` is left at the ABC's NotImplementedError default.
+capability behind ``/extract`` or ``/discover/<source_id>``, so
+``supports_search()`` is False and :meth:`search` is left at the ABC's
+NotImplementedError default.
 
 Config keys this provider responds to::
 
@@ -46,56 +47,56 @@ from agent.web_search_provider import WebSearchProvider
 logger = logging.getLogger(__name__)
 
 
-def _lah_discovery_request(source_id: str) -> Dict[str, Any]:
-    """POST to the lah-discovery-platform REST API and return parsed JSON.
+def _lah_discovery_extract_request(base_url: str, urls: List[str]) -> Dict[str, Any]:
+    """POST the full ``urls`` batch to ``lah-discovery-platform``'s
+    ``POST /extract`` and return the parsed JSON response.
 
-    Raises ``ValueError`` when ``LAH_DISCOVERY_BASE_URL`` is unset; the
-    caller catches and surfaces as a typed per-item error, matching the
-    Tavily/Firecrawl provider pattern in this same plugin tree.
+    Raises on transport/HTTP errors; the caller turns those into a
+    per-URL error entry for every requested URL (the whole batch shares
+    one request, so a transport failure is not attributable to a single
+    URL).
     """
     import httpx
 
-    base_url = os.getenv("LAH_DISCOVERY_BASE_URL", "").strip()
-    if not base_url:
-        raise ValueError(
-            "LAH_DISCOVERY_BASE_URL environment variable not set. "
-            "Point it at a running lah-discovery-platform REST API instance "
-            "(e.g. http://localhost:8000)."
-        )
+    url = f"{base_url.rstrip('/')}/extract"
+    logger.info("lah-discovery extract request to %s for %d url(s)", url, len(urls))
 
-    url = f"{base_url.rstrip('/')}/discover/{source_id}"
-    logger.info("lah-discovery request to %s", url)
-
-    response = httpx.post(url, timeout=60)
+    response = httpx.post(url, json={"urls": urls}, timeout=60)
     response.raise_for_status()
     return response.json()
 
 
-def _normalize_lah_discovery_documents(
-    response: Dict[str, Any], source_id: str
-) -> List[Dict[str, Any]]:
-    """Map a ``/discover/<source_id>`` response to the legacy document shape.
+def _normalize_lah_discovery_extract_results(response: Dict[str, Any]) -> List[Dict[str, Any]]:
+    """Map a ``/extract`` response to the legacy document shape.
 
-    Documents follow the same ``{"url", "title", "content", "raw_content",
-    "metadata"}`` contract every other provider in this tree returns.
+    Successful entries follow the same ``{"url", "title", "content",
+    "raw_content", "metadata"}`` contract every other provider in this
+    tree returns. Failed entries become ``{"url", "title", "content",
+    "error"}`` instead, matching the fail-closed per-item contract.
     """
     documents: List[Dict[str, Any]] = []
-    for entry in response.get("items", []):
-        item = entry.get("item", {})
-        content = item.get("content", "")
-        documents.append(
-            {
-                "url": item.get("url", ""),
-                "title": item.get("title", ""),
-                "content": content,
-                "raw_content": content,
-                "metadata": {
-                    **item.get("metadata", {}),
-                    "source_id": source_id,
-                    "score": entry.get("score"),
-                },
-            }
-        )
+    for entry in response.get("results", []):
+        if entry.get("success"):
+            item = entry.get("item") or {}
+            content = item.get("content", "")
+            documents.append(
+                {
+                    "url": item.get("url", entry.get("url", "")),
+                    "title": item.get("title", ""),
+                    "content": content,
+                    "raw_content": content,
+                    "metadata": item.get("metadata", {}),
+                }
+            )
+        else:
+            documents.append(
+                {
+                    "url": entry.get("url", ""),
+                    "title": "",
+                    "content": "",
+                    "error": entry.get("error") or "lah-discovery extract failed",
+                }
+            )
     return documents
 
 
@@ -122,62 +123,52 @@ class LahDiscoveryWebSearchProvider(WebSearchProvider):
         return True
 
     def extract(self, urls: List[str], **kwargs: Any) -> List[Dict[str, Any]]:
-        """Run the discovery pipeline for each requested source_id.
+        """Fetch and extract each of ``urls`` via ``POST /extract``.
 
-        Each entry in ``urls`` must be a registered source_id (see module
-        docstring). Fails closed per-entry: a missing base URL, an
-        unreachable REST API, an unknown source_id, or a source with no
-        discovered items all become an ``{"error": ...}`` document rather
-        than raising or fabricating a result.
+        Fails closed: a missing base URL, an unreachable REST API, or a
+        malformed response all become an ``{"error": ...}`` document for
+        every requested URL rather than raising or fabricating a result.
+        A failure for one URL within a successful batch response is
+        reported only for that URL (see
+        :func:`_normalize_lah_discovery_extract_results`).
         """
         from tools.interrupt import is_interrupted
 
         if is_interrupted():
             return [{"url": u, "error": "Interrupted", "title": ""} for u in urls]
 
-        documents: List[Dict[str, Any]] = []
-        for source_id in urls:
-            try:
-                raw = _lah_discovery_request(source_id)
-                docs = _normalize_lah_discovery_documents(raw, source_id)
-                if not docs:
-                    documents.append(
-                        {
-                            "url": source_id,
-                            "title": "",
-                            "content": "",
-                            "raw_content": "",
-                            "error": f"no items discovered for source '{source_id}'",
-                            "metadata": {"source_id": source_id},
-                        }
-                    )
-                else:
-                    documents.extend(docs)
-            except ValueError as exc:
-                documents.append(
-                    {"url": source_id, "title": "", "content": "", "error": str(exc)}
-                )
-            except Exception as exc:  # noqa: BLE001 - httpx errors, 404s, timeouts, etc.
-                logger.warning("lah-discovery extract error for %s: %s", source_id, exc)
-                documents.append(
-                    {
-                        "url": source_id,
-                        "title": "",
-                        "content": "",
-                        "error": f"lah-discovery extract failed: {exc}",
-                    }
-                )
-        return documents
+        base_url = os.getenv("LAH_DISCOVERY_BASE_URL", "").strip()
+        if not base_url:
+            message = (
+                "LAH_DISCOVERY_BASE_URL environment variable not set. "
+                "Point it at a running lah-discovery-platform REST API instance "
+                "(e.g. http://localhost:8000)."
+            )
+            return [{"url": u, "title": "", "content": "", "error": message} for u in urls]
+
+        try:
+            raw = _lah_discovery_extract_request(base_url, urls)
+        except Exception as exc:  # noqa: BLE001 - httpx errors, 4xx/5xx, timeouts, etc.
+            logger.warning("lah-discovery extract request failed: %s", exc)
+            return [
+                {
+                    "url": u,
+                    "title": "",
+                    "content": "",
+                    "error": f"lah-discovery extract failed: {exc}",
+                }
+                for u in urls
+            ]
+
+        return _normalize_lah_discovery_extract_results(raw)
 
     def get_setup_schema(self) -> Dict[str, Any]:
         return {
             "name": "LAH Discovery Platform",
             "badge": "internal",
             "tag": (
-                "Curated multi-source discovery via a self-hosted "
-                "lah-discovery-platform REST API. Takes a source_id "
-                "(github/hackernews/blogs/documentation/forums/producthunt), "
-                "not an arbitrary URL."
+                "Direct URL extraction via a self-hosted "
+                "lah-discovery-platform REST API's POST /extract endpoint."
             ),
             "env_vars": [
                 {

--- a/plugins/web/lah_discovery/provider.py
+++ b/plugins/web/lah_discovery/provider.py
@@ -1,0 +1,189 @@
+"""LAH Discovery Platform — plugin form, opt-in web extract backend.
+
+Subclasses :class:`agent.web_search_provider.WebSearchProvider`. HTTP-only
+client against a self-hosted ``lah-discovery-platform`` REST API instance —
+this plugin never imports the ``lah_discovery`` Python package and never
+touches ``crawl4ai`` directly. It is disabled (``is_available()`` returns
+False) unless ``LAH_DISCOVERY_BASE_URL`` is explicitly set.
+
+IMPORTANT — capability boundary, read before wiring this up:
+
+``lah-discovery-platform``'s REST API (as of its ``LAH_DISCOVERY_REST_API_SERVER``
+mission) exposes exactly one discovery endpoint, ``POST /discover/<source_id>``,
+which runs a curated pipeline against one of six *registered* sources
+(``github``, ``hackernews``, ``blogs``, ``documentation``, ``forums``,
+``producthunt``) — it has no endpoint for fetching an arbitrary URL. This
+plugin's :meth:`extract` therefore expects each entry in ``urls`` to be one
+of those six source_id strings, NOT a real URL, despite the ABC's normal
+"list of URLs" semantics. An unrecognized source_id fails closed (a per-item
+error entry, matching the existing legacy contract for per-URL failures —
+see :meth:`extract`), never a crash and never a fabricated result.
+
+Only ``supports_extract()`` is implemented — there is no free-text search
+capability behind ``/discover/<source_id>``, so ``supports_search()`` is
+False and :meth:`search` is left at the ABC's NotImplementedError default.
+
+Config keys this provider responds to::
+
+    web:
+      extract_backend: "lah-discovery"   # opt-in only — never a default
+
+Env vars::
+
+    LAH_DISCOVERY_BASE_URL=...   # e.g. http://localhost:8000 (no default —
+                                  # must be explicitly set to enable this
+                                  # provider at all)
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any, Dict, List
+
+from agent.web_search_provider import WebSearchProvider
+
+logger = logging.getLogger(__name__)
+
+
+def _lah_discovery_request(source_id: str) -> Dict[str, Any]:
+    """POST to the lah-discovery-platform REST API and return parsed JSON.
+
+    Raises ``ValueError`` when ``LAH_DISCOVERY_BASE_URL`` is unset; the
+    caller catches and surfaces as a typed per-item error, matching the
+    Tavily/Firecrawl provider pattern in this same plugin tree.
+    """
+    import httpx
+
+    base_url = os.getenv("LAH_DISCOVERY_BASE_URL", "").strip()
+    if not base_url:
+        raise ValueError(
+            "LAH_DISCOVERY_BASE_URL environment variable not set. "
+            "Point it at a running lah-discovery-platform REST API instance "
+            "(e.g. http://localhost:8000)."
+        )
+
+    url = f"{base_url.rstrip('/')}/discover/{source_id}"
+    logger.info("lah-discovery request to %s", url)
+
+    response = httpx.post(url, timeout=60)
+    response.raise_for_status()
+    return response.json()
+
+
+def _normalize_lah_discovery_documents(
+    response: Dict[str, Any], source_id: str
+) -> List[Dict[str, Any]]:
+    """Map a ``/discover/<source_id>`` response to the legacy document shape.
+
+    Documents follow the same ``{"url", "title", "content", "raw_content",
+    "metadata"}`` contract every other provider in this tree returns.
+    """
+    documents: List[Dict[str, Any]] = []
+    for entry in response.get("items", []):
+        item = entry.get("item", {})
+        content = item.get("content", "")
+        documents.append(
+            {
+                "url": item.get("url", ""),
+                "title": item.get("title", ""),
+                "content": content,
+                "raw_content": content,
+                "metadata": {
+                    **item.get("metadata", {}),
+                    "source_id": source_id,
+                    "score": entry.get("score"),
+                },
+            }
+        )
+    return documents
+
+
+class LahDiscoveryWebSearchProvider(WebSearchProvider):
+    """LAH Discovery Platform extract-only provider (HTTP client)."""
+
+    @property
+    def name(self) -> str:
+        return "lah-discovery"
+
+    @property
+    def display_name(self) -> str:
+        return "LAH Discovery Platform"
+
+    def is_available(self) -> bool:
+        """Return True when ``LAH_DISCOVERY_BASE_URL`` is set to a non-empty
+        value. Cheap check only — no network call, per the ABC contract."""
+        return bool(os.getenv("LAH_DISCOVERY_BASE_URL", "").strip())
+
+    def supports_search(self) -> bool:
+        return False
+
+    def supports_extract(self) -> bool:
+        return True
+
+    def extract(self, urls: List[str], **kwargs: Any) -> List[Dict[str, Any]]:
+        """Run the discovery pipeline for each requested source_id.
+
+        Each entry in ``urls`` must be a registered source_id (see module
+        docstring). Fails closed per-entry: a missing base URL, an
+        unreachable REST API, an unknown source_id, or a source with no
+        discovered items all become an ``{"error": ...}`` document rather
+        than raising or fabricating a result.
+        """
+        from tools.interrupt import is_interrupted
+
+        if is_interrupted():
+            return [{"url": u, "error": "Interrupted", "title": ""} for u in urls]
+
+        documents: List[Dict[str, Any]] = []
+        for source_id in urls:
+            try:
+                raw = _lah_discovery_request(source_id)
+                docs = _normalize_lah_discovery_documents(raw, source_id)
+                if not docs:
+                    documents.append(
+                        {
+                            "url": source_id,
+                            "title": "",
+                            "content": "",
+                            "raw_content": "",
+                            "error": f"no items discovered for source '{source_id}'",
+                            "metadata": {"source_id": source_id},
+                        }
+                    )
+                else:
+                    documents.extend(docs)
+            except ValueError as exc:
+                documents.append(
+                    {"url": source_id, "title": "", "content": "", "error": str(exc)}
+                )
+            except Exception as exc:  # noqa: BLE001 - httpx errors, 404s, timeouts, etc.
+                logger.warning("lah-discovery extract error for %s: %s", source_id, exc)
+                documents.append(
+                    {
+                        "url": source_id,
+                        "title": "",
+                        "content": "",
+                        "error": f"lah-discovery extract failed: {exc}",
+                    }
+                )
+        return documents
+
+    def get_setup_schema(self) -> Dict[str, Any]:
+        return {
+            "name": "LAH Discovery Platform",
+            "badge": "internal",
+            "tag": (
+                "Curated multi-source discovery via a self-hosted "
+                "lah-discovery-platform REST API. Takes a source_id "
+                "(github/hackernews/blogs/documentation/forums/producthunt), "
+                "not an arbitrary URL."
+            ),
+            "env_vars": [
+                {
+                    "key": "LAH_DISCOVERY_BASE_URL",
+                    "prompt": "lah-discovery-platform REST API base URL (e.g. http://localhost:8000)",
+                    "url": "",
+                },
+            ],
+        }

--- a/tests/hermes_cli/test_env_files_runtime.py
+++ b/tests/hermes_cli/test_env_files_runtime.py
@@ -1,0 +1,232 @@
+"""Regression tests for config.yaml:env_files runtime support.
+
+env_files lets operators declare external secret files (e.g. provider
+key files) that load_env() merges after ~/.hermes/.env, so provider
+credentials resolve without duplicating secrets into ~/.hermes/.env.
+
+Precedence (lowest → highest):
+  ~/.hermes/.env  <  config.yaml:env_files  <  process os.environ
+"""
+
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from hermes_cli.config import get_env_value, invalidate_env_cache, load_env
+
+
+@pytest.fixture(autouse=True)
+def _clean_env_cache():
+    """Isolate the module-level load_env memo across tests."""
+    invalidate_env_cache()
+    yield
+    invalidate_env_cache()
+
+
+def _patch_env_path(primary: Path):
+    return patch("hermes_cli.config.get_env_path", return_value=primary)
+
+
+def _patch_env_files(files):
+    return patch(
+        "hermes_cli.config.read_raw_config",
+        return_value={"env_files": [str(f) for f in files]},
+    )
+
+
+def test_env_files_single_file_override(monkeypatch, tmp_path):
+    """A single env_files entry overrides ~/.hermes/.env and feeds get_env_value."""
+    primary = tmp_path / "dot_env"
+    primary.write_text("ANT_LING_API_KEY=primary_secret\n", encoding="utf-8")
+    extra = tmp_path / "extra.env"
+    extra.write_text("ANT_LING_API_KEY=extra_secret\n", encoding="utf-8")
+
+    with _patch_env_path(primary), _patch_env_files([extra]):
+        env = load_env()
+        assert env.get("ANT_LING_API_KEY") == "extra_secret", (
+            "env_files should override ~/.hermes/.env"
+        )
+
+        # The value must be reachable through the same get_env_value()
+        # primitive that provider credential resolution uses.
+        monkeypatch.delenv("ANT_LING_API_KEY", raising=False)
+        assert get_env_value("ANT_LING_API_KEY") == "extra_secret"
+
+
+def test_env_files_multiple_files_and_missing_safe(tmp_path):
+    """Multiple env_files merge in order (last wins); a missing file is non-fatal."""
+    primary = tmp_path / "dot_env"
+    primary.write_text("A=1\n", encoding="utf-8")
+
+    missing = tmp_path / "does_not_exist.env"
+    extra1 = tmp_path / "e1.env"
+    extra2 = tmp_path / "e2.env"
+    extra1.write_text("B=2\n", encoding="utf-8")
+    extra2.write_text("A=overridden\n", encoding="utf-8")
+
+    with _patch_env_path(primary), _patch_env_files([missing, extra1, extra2]):
+        env = load_env()
+        assert env.get("A") == "overridden"  # last declared file wins
+        assert env.get("B") == "2"           # earlier file still merged
+        # Missing file did not raise or poison the load.
+        assert env.get("C") is None
+
+
+def test_backwards_compat_without_env_files(tmp_path):
+    """With no env_files key, load_env behaves exactly like before."""
+    primary = tmp_path / "dot_env"
+    primary.write_text(
+        "OPENAI_API_KEY=sk-abc\nDEEPSEEK_API_KEY=dk-xyz\n",
+        encoding="utf-8",
+    )
+
+    with _patch_env_path(primary), _patch_env_files([]):
+        env = load_env()
+        assert env.get("OPENAI_API_KEY") == "sk-abc"
+        assert env.get("DEEPSEEK_API_KEY") == "dk-xyz"
+        assert len(env) == 2
+
+
+def test_process_env_precedence_over_env_files(monkeypatch, tmp_path):
+    """os.environ wins over env_files values (checked by get_env_value first)."""
+    primary = tmp_path / "dot_env"
+    primary.write_text("ANT_LING_API_KEY=primary_secret\n", encoding="utf-8")
+    extra = tmp_path / "extra.env"
+    extra.write_text("ANT_LING_API_KEY=extra_secret\n", encoding="utf-8")
+
+    with _patch_env_path(primary), _patch_env_files([extra]):
+        monkeypatch.setenv("ANT_LING_API_KEY", "proc_secret")
+        assert get_env_value("ANT_LING_API_KEY") == "proc_secret"
+        # load_env itself is file-only; the dict still shows the file value,
+        # but get_env_value (the real consumer) honours the process env.
+        assert load_env().get("ANT_LING_API_KEY") == "extra_secret"
+
+
+def test_env_files_cache_invalidates_on_extra_file_change(tmp_path):
+    """Editing an env_files file (mtime bump) invalidates the memo."""
+    primary = tmp_path / "dot_env"
+    primary.write_text("K=old\n", encoding="utf-8")
+    extra = tmp_path / "extra.env"
+    extra.write_text("K=from-file\n", encoding="utf-8")
+
+    with _patch_env_path(primary), _patch_env_files([extra]):
+        assert load_env().get("K") == "from-file"
+        # Same bytes → cache hit path still returns correct value.
+        assert load_env().get("K") == "from-file"
+        # Rewrite the extra file and bump mtime beyond FS granularity.
+        extra.write_text("K=from-file-v2\n", encoding="utf-8")
+        os.utime(extra, (extra.stat().st_atime + 5, extra.stat().st_mtime + 5))
+        assert load_env().get("K") == "from-file-v2"
+
+
+def test_malformed_env_file_is_ignored_safely(tmp_path):
+    """Malformed extra files are sanitised (no crash, no invented values)."""
+    primary = tmp_path / "dot_env"
+    primary.write_text("GOOD=1\n", encoding="utf-8")
+    extra = tmp_path / "malformed.env"
+    extra.write_text(
+        "no_equals_here\n"
+        "# comment\n"
+        "CONCAT=one=two\n"
+        "PLACEHOLDER=changeme_xxx\n"
+        'QUOTED="stripped"\n'
+        "=missing_key\n",
+        encoding="utf-8",
+    )
+
+    with _patch_env_path(primary), _patch_env_files([extra]):
+        env = load_env()
+        assert env.get("GOOD") == "1"            # primary unaffected
+        assert env.get("QUOTED") == "stripped"   # quotes stripped as before
+        assert env.get("no_equals_here") is None  # no bogus key invented
+        # Placeholder/value sanitation is covered by test_env_sanitize_on_load.py;
+        # here we only require a crash-free load with the primary value intact.
+
+
+def test_unreadable_env_file_non_fatal(tmp_path):
+    """An extra file that cannot be read is treated as absent, not a crash."""
+    primary = tmp_path / "dot_env"
+    primary.write_text("KEEP=yes\n", encoding="utf-8")
+    directory_as_file = tmp_path / "not_a_file"  # a directory → open() raises
+    directory_as_file.mkdir()
+
+    with _patch_env_path(primary), _patch_env_files([directory_as_file]):
+        env = load_env()
+        assert env.get("KEEP") == "yes"
+
+
+def test_no_secret_leak_in_errors(tmp_path):
+    """Failures while merging env_files never surface secret values."""
+    primary = tmp_path / "dot_env"
+    secret = "super_secret_value_123"
+    primary.write_text(f"ANT_LING_API_KEY={secret}\n", encoding="utf-8")
+    extra = tmp_path / "broken.env"
+    extra.write_text("X=1\n", encoding="utf-8")
+
+    with _patch_env_path(primary), _patch_env_files([extra]):
+        try:
+            load_env()
+            # No exception is the expected path; nothing to inspect.
+        except Exception as exc:
+            assert secret not in str(exc), "secret leaked into exception message"
+        # The secret must never appear in the merged dict's keys or file list.
+        env = load_env()
+        assert secret not in str(list(env.keys()))
+
+
+def test_provider_api_key_env_resolution_from_env_files(monkeypatch, tmp_path):
+    """resolve_api_key_provider_credentials picks up keys declared via env_files.
+
+    xai is a plain api_key provider (api_key_env_vars=("XAI_API_KEY",)) with
+    no network probe in its resolver, so this is a clean integration check of
+    the _resolve_api_key_provider_secret → get_env_value → load_env chain.
+    """
+    from hermes_cli.auth import resolve_api_key_provider_credentials
+
+    primary = tmp_path / "dot_env"
+    primary.write_text("UNRELATED=zzz\n", encoding="utf-8")
+    extra = tmp_path / "xai.env"
+    extra.write_text("XAI_API_KEY=xai-from-env-files\n", encoding="utf-8")
+
+    monkeypatch.delenv("XAI_API_KEY", raising=False)
+    with _patch_env_path(primary), _patch_env_files([extra]):
+        creds = resolve_api_key_provider_credentials("xai")
+        assert creds["api_key"] == "xai-from-env-files"
+        assert creds["source"] == "XAI_API_KEY"
+
+
+def test_custom_provider_key_env_resolves_from_env_files(monkeypatch, tmp_path):
+    """Custom provider (config.yaml providers.*) key_env resolves via env_files.
+
+    Regression for the Ant Ling native-routing case: runtime_provider reads
+    the key through get_env_value(), so keys declared in env_files resolve
+    without duplicating secrets into ~/.hermes/.env or the process env.
+    """
+    from hermes_cli.runtime_provider import _resolve_named_custom_runtime
+
+    primary = tmp_path / "dot_env"
+    primary.write_text("UNRELATED=zzz\n", encoding="utf-8")
+    extra = tmp_path / "antling.env"
+    extra.write_text("ANT_LING_API_KEY=antling-from-env-files\n", encoding="utf-8")
+
+    monkeypatch.delenv("ANT_LING_API_KEY", raising=False)
+    with _patch_env_path(primary), _patch_env_files([extra]), patch(
+        "hermes_cli.runtime_provider.load_config",
+        return_value={
+            "providers": {
+                "ant-ling": {
+                    "key_env": "ANT_LING_API_KEY",
+                    "base_url": "https://api.ant-ling.com/v1",
+                },
+            },
+        },
+    ):
+        runtime = _resolve_named_custom_runtime(requested_provider="ant-ling")
+        assert runtime is not None
+        assert runtime["api_key"] == "antling-from-env-files"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])

--- a/tests/plugins/web/test_lah_discovery_provider.py
+++ b/tests/plugins/web/test_lah_discovery_provider.py
@@ -4,14 +4,13 @@ instance, no network, no Docker.
 """
 from __future__ import annotations
 
-import os
 from unittest.mock import MagicMock, patch
 
 import pytest
 
 from plugins.web.lah_discovery.provider import (
     LahDiscoveryWebSearchProvider,
-    _normalize_lah_discovery_documents,
+    _normalize_lah_discovery_extract_results,
 )
 
 
@@ -29,43 +28,54 @@ def _mock_response(json_body: dict, status_ok: bool = True) -> MagicMock:
         import httpx
 
         resp.raise_for_status.side_effect = httpx.HTTPStatusError(
-            "404 Not Found", request=MagicMock(), response=resp
+            "500 Internal Server Error", request=MagicMock(), response=resp
         )
     return resp
 
 
-class TestNormalizeLahDiscoveryDocuments:
-    def test_maps_items_to_legacy_document_shape(self):
+class TestNormalizeLahDiscoveryExtractResults:
+    def test_maps_successful_results_to_legacy_document_shape(self):
         raw = {
-            "items": [
+            "results": [
                 {
+                    "url": "https://github.com",
+                    "success": True,
                     "item": {
-                        "source_id": "github",
                         "url": "https://github.com",
                         "title": "",
                         "content": "# GitHub\n\nTrending repos.",
                         "metadata": {},
                     },
-                    "score": 0.9,
+                    "error": None,
                 }
             ]
         }
-        docs = _normalize_lah_discovery_documents(raw, "github")
+        docs = _normalize_lah_discovery_extract_results(raw)
         assert len(docs) == 1
         assert docs[0]["url"] == "https://github.com"
         assert docs[0]["content"] == "# GitHub\n\nTrending repos."
         assert docs[0]["raw_content"] == docs[0]["content"]
-        assert docs[0]["metadata"]["source_id"] == "github"
-        assert docs[0]["metadata"]["score"] == 0.9
+        assert "error" not in docs[0]
 
-    def test_empty_items_returns_empty_list(self):
-        assert _normalize_lah_discovery_documents({"items": []}, "github") == []
+    def test_maps_failed_results_to_error_documents(self):
+        raw = {
+            "results": [
+                {"url": "https://bad.example", "success": False, "item": None, "error": "boom"}
+            ]
+        }
+        docs = _normalize_lah_discovery_extract_results(raw)
+        assert len(docs) == 1
+        assert docs[0]["url"] == "https://bad.example"
+        assert docs[0]["error"] == "boom"
+
+    def test_empty_results_returns_empty_list(self):
+        assert _normalize_lah_discovery_extract_results({"results": []}) == []
 
 
 class TestExtract:
     def test_missing_base_url_returns_error_entries(self):
         provider = LahDiscoveryWebSearchProvider()
-        result = provider.extract(["github"])
+        result = provider.extract(["https://github.com"])
         assert len(result) == 1
         assert "LAH_DISCOVERY_BASE_URL" in result[0]["error"]
 
@@ -73,41 +83,77 @@ class TestExtract:
         monkeypatch.setenv("LAH_DISCOVERY_BASE_URL", "http://localhost:8000")
         mock_resp = _mock_response(
             {
-                "items": [
+                "results": [
                     {
+                        "url": "https://github.com",
+                        "success": True,
                         "item": {
-                            "source_id": "github",
                             "url": "https://github.com",
                             "title": "",
                             "content": "# GitHub",
                             "metadata": {},
                         },
-                        "score": 1.0,
+                        "error": None,
                     }
                 ]
             }
         )
         with patch("httpx.post", return_value=mock_resp) as mock_post:
             provider = LahDiscoveryWebSearchProvider()
-            result = provider.extract(["github"])
+            result = provider.extract(["https://github.com"])
 
         mock_post.assert_called_once()
         called_url = mock_post.call_args.args[0]
-        assert called_url == "http://localhost:8000/discover/github"
+        assert called_url == "http://localhost:8000/extract"
+        called_json = mock_post.call_args.kwargs["json"]
+        assert called_json == {"urls": ["https://github.com"]}
         assert len(result) == 1
         assert result[0]["url"] == "https://github.com"
         assert "error" not in result[0]
 
-    def test_unknown_source_id_fails_closed_with_error_entry(self, monkeypatch):
+    def test_per_url_failure_within_a_successful_batch_fails_closed(self, monkeypatch):
         monkeypatch.setenv("LAH_DISCOVERY_BASE_URL", "http://localhost:8000")
-        mock_resp = _mock_response({"error": "unknown source_id 'reddit'"}, status_ok=False)
+        mock_resp = _mock_response(
+            {
+                "results": [
+                    {
+                        "url": "https://good.example",
+                        "success": True,
+                        "item": {
+                            "url": "https://good.example",
+                            "title": "",
+                            "content": "# ok",
+                            "metadata": {},
+                        },
+                        "error": None,
+                    },
+                    {
+                        "url": "https://bad.example",
+                        "success": False,
+                        "item": None,
+                        "error": "fetch failed for 'https://bad.example'",
+                    },
+                ]
+            }
+        )
         with patch("httpx.post", return_value=mock_resp):
             provider = LahDiscoveryWebSearchProvider()
-            result = provider.extract(["reddit"])
+            result = provider.extract(["https://good.example", "https://bad.example"])
 
-        assert len(result) == 1
-        assert "error" in result[0]
-        assert result[0]["url"] == "reddit"
+        assert len(result) == 2
+        assert "error" not in result[0]
+        assert "error" in result[1]
+        assert result[1]["url"] == "https://bad.example"
+
+    def test_unreachable_api_fails_every_requested_url_closed(self, monkeypatch):
+        monkeypatch.setenv("LAH_DISCOVERY_BASE_URL", "http://localhost:8000")
+        mock_resp = _mock_response({"error": "boom"}, status_ok=False)
+        with patch("httpx.post", return_value=mock_resp):
+            provider = LahDiscoveryWebSearchProvider()
+            result = provider.extract(["https://a.example", "https://b.example"])
+
+        assert len(result) == 2
+        assert all("error" in doc for doc in result)
 
     def test_connection_failure_fails_closed_not_a_crash(self, monkeypatch):
         monkeypatch.setenv("LAH_DISCOVERY_BASE_URL", "http://localhost:8000")
@@ -115,49 +161,11 @@ class TestExtract:
 
         with patch("httpx.post", side_effect=httpx.ConnectError("connection refused")):
             provider = LahDiscoveryWebSearchProvider()
-            result = provider.extract(["github"])
+            result = provider.extract(["https://github.com"])
 
         assert len(result) == 1
         assert "error" in result[0]
         assert "lah-discovery extract failed" in result[0]["error"]
-
-    def test_no_items_discovered_is_an_error_entry_not_silent_empty_success(self, monkeypatch):
-        monkeypatch.setenv("LAH_DISCOVERY_BASE_URL", "http://localhost:8000")
-        mock_resp = _mock_response({"items": []})
-        with patch("httpx.post", return_value=mock_resp):
-            provider = LahDiscoveryWebSearchProvider()
-            result = provider.extract(["github"])
-
-        assert len(result) == 1
-        assert "no items discovered" in result[0]["error"]
-
-    def test_multiple_source_ids_processed_independently(self, monkeypatch):
-        monkeypatch.setenv("LAH_DISCOVERY_BASE_URL", "http://localhost:8000")
-        ok_resp = _mock_response(
-            {
-                "items": [
-                    {
-                        "item": {
-                            "source_id": "github",
-                            "url": "https://github.com",
-                            "title": "",
-                            "content": "# GitHub",
-                            "metadata": {},
-                        },
-                        "score": 1.0,
-                    }
-                ]
-            }
-        )
-        bad_resp = _mock_response({"error": "unknown"}, status_ok=False)
-
-        with patch("httpx.post", side_effect=[ok_resp, bad_resp]):
-            provider = LahDiscoveryWebSearchProvider()
-            result = provider.extract(["github", "reddit"])
-
-        assert len(result) == 2
-        assert "error" not in result[0]
-        assert "error" in result[1]
 
 
 class TestProviderMetadata:
@@ -169,7 +177,7 @@ class TestProviderMetadata:
         assert provider.supports_extract() is True
         assert provider.supports_search() is False
 
-    def test_get_setup_schema_documents_the_source_id_boundary(self):
+    def test_get_setup_schema_documents_the_extract_endpoint(self):
         schema = LahDiscoveryWebSearchProvider().get_setup_schema()
-        assert "source_id" in schema["tag"]
+        assert "/extract" in schema["tag"]
         assert schema["env_vars"][0]["key"] == "LAH_DISCOVERY_BASE_URL"

--- a/tests/plugins/web/test_lah_discovery_provider.py
+++ b/tests/plugins/web/test_lah_discovery_provider.py
@@ -1,0 +1,175 @@
+"""Dedicated tests for the LAH Discovery Platform provider's extract()
+behavior — mocked HTTP responses only, no real lah-discovery-platform
+instance, no network, no Docker.
+"""
+from __future__ import annotations
+
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from plugins.web.lah_discovery.provider import (
+    LahDiscoveryWebSearchProvider,
+    _normalize_lah_discovery_documents,
+)
+
+
+@pytest.fixture(autouse=True)
+def _isolate_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("LAH_DISCOVERY_BASE_URL", raising=False)
+
+
+def _mock_response(json_body: dict, status_ok: bool = True) -> MagicMock:
+    resp = MagicMock()
+    resp.json.return_value = json_body
+    if status_ok:
+        resp.raise_for_status = MagicMock()
+    else:
+        import httpx
+
+        resp.raise_for_status.side_effect = httpx.HTTPStatusError(
+            "404 Not Found", request=MagicMock(), response=resp
+        )
+    return resp
+
+
+class TestNormalizeLahDiscoveryDocuments:
+    def test_maps_items_to_legacy_document_shape(self):
+        raw = {
+            "items": [
+                {
+                    "item": {
+                        "source_id": "github",
+                        "url": "https://github.com",
+                        "title": "",
+                        "content": "# GitHub\n\nTrending repos.",
+                        "metadata": {},
+                    },
+                    "score": 0.9,
+                }
+            ]
+        }
+        docs = _normalize_lah_discovery_documents(raw, "github")
+        assert len(docs) == 1
+        assert docs[0]["url"] == "https://github.com"
+        assert docs[0]["content"] == "# GitHub\n\nTrending repos."
+        assert docs[0]["raw_content"] == docs[0]["content"]
+        assert docs[0]["metadata"]["source_id"] == "github"
+        assert docs[0]["metadata"]["score"] == 0.9
+
+    def test_empty_items_returns_empty_list(self):
+        assert _normalize_lah_discovery_documents({"items": []}, "github") == []
+
+
+class TestExtract:
+    def test_missing_base_url_returns_error_entries(self):
+        provider = LahDiscoveryWebSearchProvider()
+        result = provider.extract(["github"])
+        assert len(result) == 1
+        assert "LAH_DISCOVERY_BASE_URL" in result[0]["error"]
+
+    def test_successful_extract_returns_normalized_documents(self, monkeypatch):
+        monkeypatch.setenv("LAH_DISCOVERY_BASE_URL", "http://localhost:8000")
+        mock_resp = _mock_response(
+            {
+                "items": [
+                    {
+                        "item": {
+                            "source_id": "github",
+                            "url": "https://github.com",
+                            "title": "",
+                            "content": "# GitHub",
+                            "metadata": {},
+                        },
+                        "score": 1.0,
+                    }
+                ]
+            }
+        )
+        with patch("httpx.post", return_value=mock_resp) as mock_post:
+            provider = LahDiscoveryWebSearchProvider()
+            result = provider.extract(["github"])
+
+        mock_post.assert_called_once()
+        called_url = mock_post.call_args.args[0]
+        assert called_url == "http://localhost:8000/discover/github"
+        assert len(result) == 1
+        assert result[0]["url"] == "https://github.com"
+        assert "error" not in result[0]
+
+    def test_unknown_source_id_fails_closed_with_error_entry(self, monkeypatch):
+        monkeypatch.setenv("LAH_DISCOVERY_BASE_URL", "http://localhost:8000")
+        mock_resp = _mock_response({"error": "unknown source_id 'reddit'"}, status_ok=False)
+        with patch("httpx.post", return_value=mock_resp):
+            provider = LahDiscoveryWebSearchProvider()
+            result = provider.extract(["reddit"])
+
+        assert len(result) == 1
+        assert "error" in result[0]
+        assert result[0]["url"] == "reddit"
+
+    def test_connection_failure_fails_closed_not_a_crash(self, monkeypatch):
+        monkeypatch.setenv("LAH_DISCOVERY_BASE_URL", "http://localhost:8000")
+        import httpx
+
+        with patch("httpx.post", side_effect=httpx.ConnectError("connection refused")):
+            provider = LahDiscoveryWebSearchProvider()
+            result = provider.extract(["github"])
+
+        assert len(result) == 1
+        assert "error" in result[0]
+        assert "lah-discovery extract failed" in result[0]["error"]
+
+    def test_no_items_discovered_is_an_error_entry_not_silent_empty_success(self, monkeypatch):
+        monkeypatch.setenv("LAH_DISCOVERY_BASE_URL", "http://localhost:8000")
+        mock_resp = _mock_response({"items": []})
+        with patch("httpx.post", return_value=mock_resp):
+            provider = LahDiscoveryWebSearchProvider()
+            result = provider.extract(["github"])
+
+        assert len(result) == 1
+        assert "no items discovered" in result[0]["error"]
+
+    def test_multiple_source_ids_processed_independently(self, monkeypatch):
+        monkeypatch.setenv("LAH_DISCOVERY_BASE_URL", "http://localhost:8000")
+        ok_resp = _mock_response(
+            {
+                "items": [
+                    {
+                        "item": {
+                            "source_id": "github",
+                            "url": "https://github.com",
+                            "title": "",
+                            "content": "# GitHub",
+                            "metadata": {},
+                        },
+                        "score": 1.0,
+                    }
+                ]
+            }
+        )
+        bad_resp = _mock_response({"error": "unknown"}, status_ok=False)
+
+        with patch("httpx.post", side_effect=[ok_resp, bad_resp]):
+            provider = LahDiscoveryWebSearchProvider()
+            result = provider.extract(["github", "reddit"])
+
+        assert len(result) == 2
+        assert "error" not in result[0]
+        assert "error" in result[1]
+
+
+class TestProviderMetadata:
+    def test_name_is_lah_discovery(self):
+        assert LahDiscoveryWebSearchProvider().name == "lah-discovery"
+
+    def test_supports_extract_only(self):
+        provider = LahDiscoveryWebSearchProvider()
+        assert provider.supports_extract() is True
+        assert provider.supports_search() is False
+
+    def test_get_setup_schema_documents_the_source_id_boundary(self):
+        schema = LahDiscoveryWebSearchProvider().get_setup_schema()
+        assert "source_id" in schema["tag"]
+        assert schema["env_vars"][0]["key"] == "LAH_DISCOVERY_BASE_URL"

--- a/tests/plugins/web/test_web_search_provider_plugins.py
+++ b/tests/plugins/web/test_web_search_provider_plugins.py
@@ -2,9 +2,9 @@
 
 Covers:
 
-- All eight bundled plugins (brave-free, ddgs, searxng, exa, parallel,
-  tavily, firecrawl, xai) instantiate and self-report the expected
-  capabilities + ABC-derived defaults.
+- All nine bundled plugins (brave-free, ddgs, searxng, exa, parallel,
+  tavily, firecrawl, xai, lah-discovery) instantiate and self-report the
+  expected capabilities + ABC-derived defaults.
 - Each plugin's ``is_available()`` correctly reflects env-var presence.
 - The web_search_registry resolves an active provider in the documented
   scenarios (explicit config wins ignoring availability, fallback walks
@@ -45,6 +45,7 @@ def _clear_web_env(monkeypatch: pytest.MonkeyPatch) -> None:
         "TOOL_GATEWAY_DOMAIN",
         "TOOL_GATEWAY_USER_TOKEN",
         "XAI_API_KEY",
+        "LAH_DISCOVERY_BASE_URL",
     ):
         monkeypatch.delenv(k, raising=False)
 
@@ -68,7 +69,7 @@ def _isolate_env(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 class TestBundledPluginsRegister:
-    """All eight bundled web plugins discover and register correctly."""
+    """All nine bundled web plugins discover and register correctly."""
 
     def test_all_seven_plugins_present_in_registry(self) -> None:
         _ensure_plugins_loaded()
@@ -80,6 +81,7 @@ class TestBundledPluginsRegister:
             "ddgs",
             "exa",
             "firecrawl",
+            "lah-discovery",
             "parallel",
             "searxng",
             "tavily",
@@ -98,6 +100,8 @@ class TestBundledPluginsRegister:
             ("firecrawl", True, True),
             # xai: search-only via Grok's agentic web_search tool.
             ("xai", True, False),
+            # lah-discovery: extract-only, no free-text search capability.
+            ("lah-discovery", False, True),
         ],
     )
     def test_capability_flags_match_spec(
@@ -116,7 +120,7 @@ class TestBundledPluginsRegister:
 
     @pytest.mark.parametrize(
         "plugin_name",
-        ["brave-free", "ddgs", "searxng", "exa", "parallel", "tavily", "firecrawl", "xai"],
+        ["brave-free", "ddgs", "searxng", "exa", "parallel", "tavily", "firecrawl", "xai", "lah-discovery"],
     )
     def test_each_plugin_has_name_and_display_name(self, plugin_name: str) -> None:
         _ensure_plugins_loaded()
@@ -129,7 +133,7 @@ class TestBundledPluginsRegister:
 
     @pytest.mark.parametrize(
         "plugin_name",
-        ["brave-free", "ddgs", "searxng", "exa", "parallel", "tavily", "firecrawl", "xai"],
+        ["brave-free", "ddgs", "searxng", "exa", "parallel", "tavily", "firecrawl", "xai", "lah-discovery"],
     )
     def test_each_plugin_has_setup_schema(self, plugin_name: str) -> None:
         """``get_setup_schema()`` returns a dict the picker can consume."""
@@ -217,6 +221,16 @@ class TestIsAvailable:
         assert p.is_available() is True
         monkeypatch.delenv("FIRECRAWL_API_KEY", raising=False)
         monkeypatch.setenv("FIRECRAWL_API_URL", "http://localhost:3002")
+        assert p.is_available() is True
+
+    def test_lah_discovery_requires_base_url(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _ensure_plugins_loaded()
+        from agent.web_search_registry import get_provider
+
+        p = get_provider("lah-discovery")
+        assert p is not None
+        assert p.is_available() is False  # no LAH_DISCOVERY_BASE_URL
+        monkeypatch.setenv("LAH_DISCOVERY_BASE_URL", "http://localhost:8000")
         assert p.is_available() is True
 
     def test_ddgs_always_available_when_package_importable(self) -> None:

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -1774,6 +1774,106 @@ def test_run_conversation_codex_continues_after_ack_for_directory_listing_prompt
     assert any(msg.get("role") == "tool" and msg.get("tool_call_id") == "call_1" for msg in result["messages"])
 
 
+def test_dump_api_request_debug_redacts_authorization_header(monkeypatch, tmp_path):
+    """Authorization header must be redacted in debug dumps."""
+    import json
+    from agent.agent_runtime_helpers import _redact_sensitive_dump_fields
+
+    agent = _build_agent(monkeypatch)
+    agent.base_url = "http://127.0.0.1:9208/v1"
+    agent.logs_dir = tmp_path
+
+    kwargs_with_token = {
+        "model": "gpt-4o",
+        "messages": [{"role": "user", "content": "hi"}],
+        "headers": {"Authorization": "Bearer sk-real-key-12345"},
+    }
+
+    dump_file = agent._dump_api_request_debug(kwargs_with_token, reason="preflight")
+    payload = json.loads(dump_file.read_text())
+
+    # The explicit Authorization header inside the body must be redacted
+    assert payload["request"]["body"]["headers"]["Authorization"] == "[REDACTED]"
+    assert "sk-real-key" not in json.dumps(payload)
+
+
+def test_dump_api_request_debug_redacts_nested_access_token(monkeypatch, tmp_path):
+    """Nested access_token fields must be redacted recursively."""
+    import json
+
+    agent = _build_agent(monkeypatch)
+    agent.base_url = "http://127.0.0.1:9208/v1"
+    agent.logs_dir = tmp_path
+
+    kwargs = {
+        "model": "gpt-4o",
+        "messages": [{"role": "user", "content": "hi"}],
+        "auth": {"access_token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9", "token_type": "bearer"},
+    }
+
+    dump_file = agent._dump_api_request_debug(kwargs, reason="preflight")
+    payload = json.loads(dump_file.read_text())
+
+    assert payload["request"]["body"]["auth"]["access_token"] == "[REDACTED]"
+    assert payload["request"]["body"]["auth"]["token_type"] == "bearer"  # not a secret key
+    assert "eyJhbGci" not in json.dumps(payload)
+
+
+def test_dump_api_request_debug_preserves_normal_fields(monkeypatch, tmp_path):
+    """Non-sensitive fields like model and messages must be preserved."""
+    import json
+
+    agent = _build_agent(monkeypatch)
+    agent.base_url = "http://127.0.0.1:9208/v1"
+    agent.logs_dir = tmp_path
+
+    kwargs = {
+        "model": "gpt-4o",
+        "messages": [{"role": "user", "content": "hello world"}],
+        "temperature": 0.7,
+    }
+
+    dump_file = agent._dump_api_request_debug(kwargs, reason="preflight")
+    payload = json.loads(dump_file.read_text())
+
+    assert payload["request"]["body"]["model"] == "gpt-4o"
+    assert payload["request"]["body"]["temperature"] == 0.7
+    assert "hello world" in json.dumps(payload)
+
+
+def test_redact_sensitive_dump_fields_standalone():
+    """Unit test for the standalone redaction helper."""
+    from agent.agent_runtime_helpers import _redact_sensitive_dump_fields
+
+    payload = {
+        "timestamp": "2026-06-22T12:00:00",
+        "request": {
+            "headers": {
+                "Authorization": "Bearer secret123",
+                "Content-Type": "application/json",
+            },
+            "body": {
+                "model": "gpt-4o",
+                "messages": [{"role": "user", "content": "hi"}],
+                "access_token": "leaked-token",
+                "nested": {"api_key": "sk-abc123", "normal": "keep-me"},
+            },
+        },
+    }
+
+    result = _redact_sensitive_dump_fields(payload)
+
+    assert result["request"]["headers"]["Authorization"] == "[REDACTED]"
+    assert result["request"]["headers"]["Content-Type"] == "application/json"
+    assert result["request"]["body"]["access_token"] == "[REDACTED]"
+    assert result["request"]["body"]["nested"]["api_key"] == "[REDACTED]"
+    assert result["request"]["body"]["nested"]["normal"] == "keep-me"
+    assert result["request"]["body"]["model"] == "gpt-4o"
+    assert result["timestamp"] == "2026-06-22T12:00:00"
+    assert "secret123" not in str(result)
+    assert "sk-abc123" not in str(result)
+
+
 def test_dump_api_request_debug_uses_responses_url(monkeypatch, tmp_path):
     """Debug dumps should show /responses URL when in codex_responses mode."""
     import json


### PR DESCRIPTION
## Summary

Make `load_env()` honor the top-level `env_files` list in `config.yaml`, and make custom-provider credential resolution (`runtime_provider`) read `key_env`/`api_key_env` through `get_env_value()` instead of raw `os.getenv()`.

This lets operators keep provider secrets in external files (e.g. `/home/deploy/.lah-secrets/ant-ling.env`) declared via `env_files`, without duplicating values into `~/.hermes/.env`.

## Root cause

- `config.yaml:env_files` existed as a config key but was never read at runtime.
- Custom providers (`providers.*` in config.yaml, OpenAI-compatible) resolved their API key with `os.getenv(key_env)` directly, so keys stored in external env files were invisible → HTTP 401 for providers whose keys live outside the process environment.

## Change

- `hermes_cli/config.py`: `load_env()` merges `env_files` after `~/.hermes/.env`; composite cache key includes extra files (mtime/size) so the memo invalidates when any watched file changes.
- `hermes_cli/runtime_provider.py`: custom-provider `key_env`/`api_key_env` and the host-derived `<VENDOR>_API_KEY` fallback now resolve via `get_env_value()` (process env first, then `.env` + `env_files`). Behavior is unchanged when the var is already in the process environment.

## Precedence (lowest → highest)

`~/.hermes/.env` < `config.yaml:env_files` < process `os.environ`

## Tests

`tests/hermes_cli/test_env_files_runtime.py` — 10 regression tests: single/multiple env_files, process-env precedence, backwards compatibility without `env_files`, missing/malformed/unreadable files, cache invalidation on extra-file change, provider `api_key_env` resolution (registry provider + custom provider), and no secret leakage. Full env/config/provider suites pass (314 tests in the isolated worktree).

Refs: HERMES_ENV_FILES_RUNTIME_SUPPORT_V1