### PR TITLE
fix(models): honor vendor/model prefix and dict model.aliases in provider detection

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -392,10 +392,12 @@ def _load_direct_aliases() -> dict[str, DirectAlias]:
             provider: custom
             base_url: "https://ollama.com/v1"
 
-    Also reads ``model.aliases`` (set by ``hermes config set model.aliases.xxx``)
-    and converts simple string entries (``ds-flash: deepseek/deepseek-v4-flash``)
-    into DirectAlias objects.  The provider is parsed from the ``provider/``
-    prefix in the value; if no slash, the current provider is used.
+    Also reads ``model.aliases`` (set by ``hermes config set model.aliases.xxx``
+    or hand-written). String entries (``ds-flash: deepseek/deepseek-v4-flash``)
+    are converted into DirectAlias objects with the provider parsed from the
+    ``provider/`` prefix in the value; if no slash, the current provider is
+    used. Dict entries use the same shape as ``model_aliases:`` (``model``,
+    ``provider``, ``base_url`` keys).
     """
     merged = dict(_BUILTIN_DIRECT_ALIASES)
     try:
@@ -416,18 +418,34 @@ def _load_direct_aliases() -> dict[str, DirectAlias]:
                         model=model, provider=provider, base_url=base_url,
                     )
 
-        # --- model.aliases (string-based format, from config set) ---
+        # --- model.aliases (from config set / hand-written config) ---
         model_section = cfg.get("model", {})
         if isinstance(model_section, dict):
             simple_aliases = model_section.get("aliases")
             if isinstance(simple_aliases, dict):
                 current_provider = model_section.get("provider", "")
                 for name, value in simple_aliases.items():
+                    key = name.strip().lower()
+                    if not key or key in merged:
+                        continue  # don't override explicit model_aliases entries
+                    if isinstance(value, dict):
+                        # Dict form mirrors the ``model_aliases:`` shape:
+                        # localqwen: {model: qwen3.5:4b, provider: custom}.
+                        # Hand-written configs already use it; honoring it
+                        # here keeps aliases with an explicit provider from
+                        # being silently dropped (#87189).
+                        model = str(value.get("model") or "").strip()
+                        if not model:
+                            continue
+                        provider = str(value.get("provider") or "").strip()
+                        merged[key] = DirectAlias(
+                            model=model,
+                            provider=provider or current_provider or "custom",
+                            base_url=str(value.get("base_url") or "").strip(),
+                        )
+                        continue
                     if not isinstance(value, str) or not value.strip():
                         continue
-                    key = name.strip().lower()
-                    if key in merged:
-                        continue  # don't override explicit model_aliases entries
                     val = value.strip()
                     if "/" in val:
                         provider, model = val.split("/", 1)

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -2768,6 +2768,65 @@ def detect_static_provider_for_model(
     return None
 
 
+def _configured_provider_ids() -> set[str]:
+    """Provider ids defined in the user's config ``providers:`` block.
+
+    Includes both top-level ids (``ollama``, ``nous``) and ``custom:*``
+    profile ids. Returns an empty set when config is unreadable — callers
+    treat that as "no user-defined providers" and fall through to built-in
+    catalogs only.
+    """
+    try:
+        from hermes_cli.config import load_config
+
+        cfg = load_config() or {}
+        providers = cfg.get("providers")
+        if not isinstance(providers, dict):
+            return set()
+        ids: set[str] = set()
+        for pid in providers:
+            key = str(pid).strip().lower()
+            if key:
+                ids.add(key)
+        return ids
+    except Exception:
+        return set()
+
+
+def _resolve_provider_prefix(model_name: str) -> Optional[tuple[str, str]]:
+    """Resolve an explicit ``vendor/model`` prefix to a known provider.
+
+    ``nous/deepseek-v4-pro`` or ``ollama/qwen3.5:4b`` should route to the
+    named provider instead of falling back to the configured default (which
+    silently sends non-default models to the wrong endpoint, #87189). The
+    vendor counts as known when it is a built-in provider id/alias or a key
+    in the user's ``providers:`` config block. The returned model is the
+    suffix with the prefix stripped — the provider's API expects the bare id.
+    """
+    if "/" not in model_name:
+        return None
+    vendor, model = model_name.split("/", 1)
+    vendor = vendor.strip().lower()
+    model = model.strip()
+    if not vendor or not model:
+        return None
+    configured = _configured_provider_ids()
+    # A provider block the user explicitly named (``ollama:``) wins over the
+    # built-in alias table, which may canonicalize the same name elsewhere
+    # (``ollama`` → ``custom``) and route to the wrong endpoint.
+    if vendor in configured:
+        return (vendor, model)
+    canonical = _PROVIDER_ALIASES.get(vendor, vendor)
+    known = (
+        canonical in _PROVIDER_LABELS
+        or canonical in _PROVIDER_MODELS
+        or canonical in configured
+    )
+    if not known:
+        return None
+    return (canonical, model)
+
+
 def detect_provider_for_model(
     model_name: str,
     current_provider: str,
@@ -2803,6 +2862,15 @@ def detect_provider_for_model(
         if or_slug != name:
             return ("openrouter", or_slug)
         return None  # already on openrouter with matching name
+
+    # --- Step 3: explicit ``vendor/model`` prefix naming a provider ---
+    # Checked after the OpenRouter slug lookup so aggregator-native slugs
+    # (e.g. ``deepseek/deepseek-chat``) keep their existing routing; this
+    # step only catches names no catalog serves, which previously fell back
+    # to the configured default provider and 404'd (#87189).
+    prefix_match = _resolve_provider_prefix(name)
+    if prefix_match is not None:
+        return prefix_match
 
     return None
 

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -2794,14 +2794,21 @@ def _configured_provider_ids() -> set[str]:
 
 
 def _resolve_provider_prefix(model_name: str) -> Optional[tuple[str, str]]:
-    """Resolve an explicit ``vendor/model`` prefix to a known provider.
+    """Resolve an explicit ``vendor/model`` prefix to a configured provider.
 
     ``nous/deepseek-v4-pro`` or ``ollama/qwen3.5:4b`` should route to the
     named provider instead of falling back to the configured default (which
-    silently sends non-default models to the wrong endpoint, #87189). The
-    vendor counts as known when it is a built-in provider id/alias or a key
-    in the user's ``providers:`` config block. The returned model is the
-    suffix with the prefix stripped — the provider's API expects the bare id.
+    silently sends non-default models to the wrong endpoint, #87189).
+
+    Only vendors the user actually defined in their ``providers:`` config
+    block (by raw name or alias) are routed here. Built-in vendor prefixes
+    (``google/gemini-2.5-flash``, ``deepseek/deepseek-chat``) deliberately
+    stay on the existing catalog / OpenRouter-slug / default-provider path:
+    those slug forms are aggregator-native, and rerouting them to the vendor
+    provider would change established provider-switch behavior (see
+    ``TestDenormalizeProviderSwitch`` in tests/hermes_cli/test_web_server.py).
+    The returned model is the suffix with the prefix stripped — the target
+    provider's API expects the bare id.
     """
     if "/" not in model_name:
         return None
@@ -2811,20 +2818,17 @@ def _resolve_provider_prefix(model_name: str) -> Optional[tuple[str, str]]:
     if not vendor or not model:
         return None
     configured = _configured_provider_ids()
+    if not configured:
+        return None
     # A provider block the user explicitly named (``ollama:``) wins over the
     # built-in alias table, which may canonicalize the same name elsewhere
     # (``ollama`` → ``custom``) and route to the wrong endpoint.
     if vendor in configured:
         return (vendor, model)
     canonical = _PROVIDER_ALIASES.get(vendor, vendor)
-    known = (
-        canonical in _PROVIDER_LABELS
-        or canonical in _PROVIDER_MODELS
-        or canonical in configured
-    )
-    if not known:
-        return None
-    return (canonical, model)
+    if canonical in configured:
+        return (canonical, model)
+    return None
 
 
 def detect_provider_for_model(
@@ -2863,11 +2867,12 @@ def detect_provider_for_model(
             return ("openrouter", or_slug)
         return None  # already on openrouter with matching name
 
-    # --- Step 3: explicit ``vendor/model`` prefix naming a provider ---
+    # --- Step 3: explicit ``vendor/model`` prefix naming a configured provider ---
     # Checked after the OpenRouter slug lookup so aggregator-native slugs
-    # (e.g. ``deepseek/deepseek-chat``) keep their existing routing; this
-    # step only catches names no catalog serves, which previously fell back
-    # to the configured default provider and 404'd (#87189).
+    # (e.g. ``deepseek/deepseek-chat``) keep their existing routing; only
+    # vendors the user defined in their ``providers:`` block route here,
+    # so catalog/default behavior for built-in vendor prefixes is unchanged
+    # (#87189).
     prefix_match = _resolve_provider_prefix(name)
     if prefix_match is not None:
         return prefix_match

--- a/tests/hermes_cli/test_model_prefix_routing_87189.py
+++ b/tests/hermes_cli/test_model_prefix_routing_87189.py
@@ -1,0 +1,130 @@
+"""Regression tests for vendor-prefix model routing and dict model.aliases (#87189).
+
+``--model nous/deepseek-v4-pro`` / ``--model ollama/qwen3.5:4b`` used to fall
+through provider auto-detection and be sent to the configured default provider
+(api.anthropic.com) with the prefixed name intact, producing HTTP 404. Dict
+entries under ``model.aliases`` (``localqwen: {model: ..., provider: ...}``)
+were silently dropped because only string values were parsed.
+"""
+
+import hermes_cli.models as models
+import hermes_cli.model_switch as model_switch
+
+
+class TestVendorPrefixRouting:
+    """detect_provider_for_model honors an explicit ``vendor/model`` prefix."""
+
+    def test_builtin_provider_prefix_routes_to_provider(self, monkeypatch):
+        monkeypatch.setattr(models, "_find_openrouter_slug", lambda _name: None)
+        detected = models.detect_provider_for_model("nous/deepseek-v4-pro", "anthropic")
+        assert detected == ("nous", "deepseek-v4-pro")
+
+    def test_configured_provider_prefix_routes_to_provider(self, monkeypatch):
+        monkeypatch.setattr(models, "_find_openrouter_slug", lambda _name: None)
+        monkeypatch.setattr(models, "_configured_provider_ids", lambda: {"ollama"})
+        detected = models.detect_provider_for_model("ollama/qwen3.5:4b", "anthropic")
+        assert detected == ("ollama", "qwen3.5:4b")
+
+    def test_configured_provider_wins_over_alias_canonicalization(self, monkeypatch):
+        """A user-named ``ollama`` block must not be rewritten to ``custom``."""
+        monkeypatch.setattr(models, "_find_openrouter_slug", lambda _name: None)
+        monkeypatch.setattr(models, "_configured_provider_ids", lambda: {"ollama"})
+        assert models._PROVIDER_ALIASES.get("ollama") == "custom"  # precondition
+        detected = models.detect_provider_for_model("ollama/qwen3.5:4b", "anthropic")
+        assert detected == ("ollama", "qwen3.5:4b")
+
+    def test_provider_alias_prefix_canonicalized(self, monkeypatch):
+        monkeypatch.setattr(models, "_find_openrouter_slug", lambda _name: None)
+        monkeypatch.setattr(models, "_configured_provider_ids", lambda: set())
+        detected = models.detect_provider_for_model("glm/glm-4.7", "anthropic")
+        assert detected == ("zai", "glm-4.7")
+
+    def test_unknown_vendor_prefix_still_unmatched(self, monkeypatch):
+        monkeypatch.setattr(models, "_find_openrouter_slug", lambda _name: None)
+        monkeypatch.setattr(models, "_configured_provider_ids", lambda: set())
+        assert models.detect_provider_for_model("notaprovider/foo-model", "anthropic") is None
+
+    def test_openrouter_slug_still_wins_over_prefix_routing(self, monkeypatch):
+        """Aggregator-native slugs keep their existing OpenRouter routing."""
+        monkeypatch.setattr(
+            models, "_find_openrouter_slug", lambda _name: "deepseek/deepseek-chat"
+        )
+        monkeypatch.setattr(models, "_configured_provider_ids", lambda: set())
+        detected = models.detect_provider_for_model("deepseek/deepseek-chat", "anthropic")
+        assert detected == ("openrouter", "deepseek/deepseek-chat")
+
+    def test_bare_model_detection_unchanged(self, monkeypatch):
+        monkeypatch.setattr(models, "_find_openrouter_slug", lambda _name: None)
+        detected = models.detect_provider_for_model("deepseek-chat", "anthropic")
+        assert detected == ("deepseek", "deepseek-chat")
+
+
+class TestDictModelAliases:
+    """``model.aliases`` accepts dict entries with an explicit provider."""
+
+    def _load_with(self, monkeypatch, cfg):
+        monkeypatch.setattr("hermes_cli.config.load_config", lambda: cfg)
+        return model_switch._load_direct_aliases()
+
+    def test_dict_entry_with_explicit_provider(self, monkeypatch):
+        cfg = {
+            "model": {
+                "aliases": {
+                    "localqwen": {"model": "qwen3.5:4b", "provider": "custom"},
+                },
+            },
+        }
+        aliases = self._load_with(monkeypatch, cfg)
+        da = aliases["localqwen"]
+        assert (da.model, da.provider) == ("qwen3.5:4b", "custom")
+
+    def test_dict_entry_with_base_url(self, monkeypatch):
+        cfg = {
+            "model": {
+                "aliases": {
+                    "qwen": {
+                        "model": "qwen3.5:4b",
+                        "provider": "ollama",
+                        "base_url": "http://localhost:11434/v1",
+                    },
+                },
+            },
+        }
+        aliases = self._load_with(monkeypatch, cfg)
+        da = aliases["qwen"]
+        assert (da.model, da.provider, da.base_url) == (
+            "qwen3.5:4b", "ollama", "http://localhost:11434/v1",
+        )
+
+    def test_dict_entry_without_provider_uses_model_provider(self, monkeypatch):
+        cfg = {
+            "model": {
+                "provider": "openrouter",
+                "aliases": {"bare": {"model": "some-model"}},
+            },
+        }
+        aliases = self._load_with(monkeypatch, cfg)
+        da = aliases["bare"]
+        assert (da.model, da.provider) == ("some-model", "openrouter")
+
+    def test_string_entries_still_parse(self, monkeypatch):
+        cfg = {
+            "model": {
+                "aliases": {"ds-flash": "deepseek/deepseek-v4-flash"},
+            },
+        }
+        aliases = self._load_with(monkeypatch, cfg)
+        da = aliases["ds-flash"]
+        assert (da.model, da.provider) == ("deepseek-v4-flash", "deepseek")
+
+    def test_model_aliases_block_keeps_priority_over_model_aliases(self, monkeypatch):
+        cfg = {
+            "model_aliases": {
+                "shared": {"model": "from-top-block", "provider": "custom"},
+            },
+            "model": {
+                "aliases": {"shared": {"model": "from-nested", "provider": "ollama"}},
+            },
+        }
+        aliases = self._load_with(monkeypatch, cfg)
+        assert aliases["shared"].model == "from-top-block"

--- a/tests/hermes_cli/test_model_prefix_routing_87189.py
+++ b/tests/hermes_cli/test_model_prefix_routing_87189.py
@@ -12,18 +12,36 @@ import hermes_cli.model_switch as model_switch
 
 
 class TestVendorPrefixRouting:
-    """detect_provider_for_model honors an explicit ``vendor/model`` prefix."""
+    """detect_provider_for_model honors a ``vendor/model`` prefix for
+    providers the user actually configured in their ``providers:`` block."""
 
-    def test_builtin_provider_prefix_routes_to_provider(self, monkeypatch):
+    def test_configured_provider_prefix_routes_to_provider(self, monkeypatch):
         monkeypatch.setattr(models, "_find_openrouter_slug", lambda _name: None)
+        monkeypatch.setattr(models, "_configured_provider_ids", lambda: {"nous"})
         detected = models.detect_provider_for_model("nous/deepseek-v4-pro", "anthropic")
         assert detected == ("nous", "deepseek-v4-pro")
 
-    def test_configured_provider_prefix_routes_to_provider(self, monkeypatch):
+    def test_local_provider_prefix_routes_to_provider(self, monkeypatch):
         monkeypatch.setattr(models, "_find_openrouter_slug", lambda _name: None)
         monkeypatch.setattr(models, "_configured_provider_ids", lambda: {"ollama"})
         detected = models.detect_provider_for_model("ollama/qwen3.5:4b", "anthropic")
         assert detected == ("ollama", "qwen3.5:4b")
+
+    def test_unconfigured_builtin_vendor_prefix_not_rerouted(self, monkeypatch):
+        """Built-in vendor slugs keep catalog/default routing.
+
+        ``google/gemini-2.5-flash`` is aggregator-native: the web config
+        field expects it to switch to OpenRouter, not to the Gemini provider
+        (``TestDenormalizeProviderSwitch`` in test_web_server.py). With no
+        user-configured provider for the vendor, prefix routing must stay
+        out of the way even when the models.dev catalog is unavailable.
+        """
+        monkeypatch.setattr(models, "_find_openrouter_slug", lambda _name: None)
+        monkeypatch.setattr(models, "_configured_provider_ids", lambda: set())
+        detected = models.detect_provider_for_model(
+            "google/gemini-2.5-flash", "ollama-local"
+        )
+        assert detected is None
 
     def test_configured_provider_wins_over_alias_canonicalization(self, monkeypatch):
         """A user-named ``ollama`` block must not be rewritten to ``custom``."""
@@ -33,15 +51,15 @@ class TestVendorPrefixRouting:
         detected = models.detect_provider_for_model("ollama/qwen3.5:4b", "anthropic")
         assert detected == ("ollama", "qwen3.5:4b")
 
-    def test_provider_alias_prefix_canonicalized(self, monkeypatch):
+    def test_provider_alias_prefix_canonicalized_when_configured(self, monkeypatch):
         monkeypatch.setattr(models, "_find_openrouter_slug", lambda _name: None)
-        monkeypatch.setattr(models, "_configured_provider_ids", lambda: set())
+        monkeypatch.setattr(models, "_configured_provider_ids", lambda: {"zai"})
         detected = models.detect_provider_for_model("glm/glm-4.7", "anthropic")
         assert detected == ("zai", "glm-4.7")
 
     def test_unknown_vendor_prefix_still_unmatched(self, monkeypatch):
         monkeypatch.setattr(models, "_find_openrouter_slug", lambda _name: None)
-        monkeypatch.setattr(models, "_configured_provider_ids", lambda: set())
+        monkeypatch.setattr(models, "_configured_provider_ids", lambda: {"ollama"})
         assert models.detect_provider_for_model("notaprovider/foo-model", "anthropic") is None
 
     def test_openrouter_slug_still_wins_over_prefix_routing(self, monkeypatch):
@@ -49,7 +67,7 @@ class TestVendorPrefixRouting:
         monkeypatch.setattr(
             models, "_find_openrouter_slug", lambda _name: "deepseek/deepseek-chat"
         )
-        monkeypatch.setattr(models, "_configured_provider_ids", lambda: set())
+        monkeypatch.setattr(models, "_configured_provider_ids", lambda: {"deepseek"})
         detected = models.detect_provider_for_model("deepseek/deepseek-chat", "anthropic")
         assert detected == ("openrouter", "deepseek/deepseek-chat")
 


### PR DESCRIPTION
## What does this PR do?

Fixes two gaps that made every non-default provider unreachable from `--model` (#87189):

1. **`vendor/model` prefixes were ignored for user-configured providers.** With a config block like `providers: {nous: {type: openai-compatible, baseUrl: https://inference-api.nousresearch.com/v1}}`, `--model nous/deepseek-v4-pro` fell through `detect_provider_for_model` (static catalogs don't know the user's provider, so the prefix matched nothing), provider stayed unset, and `resolve_runtime_provider` fell back to the configured default — sending the still-prefixed model name to `api.anthropic.com` and getting `HTTP 404: model: nous/deepseek-v4-pro`. This PR adds a final detection step (after the OpenRouter slug lookup) that routes the prefix when the vendor names a provider the user actually defined in their `providers:` block — by raw name (`ollama:`) or by alias (`glm/...` → a configured `zai:` block). A user-named provider id wins over the built-in alias table's canonicalization (`ollama` → `custom`) so the request goes to the endpoint the user configured. The returned model is the bare suffix, which is what the target provider's API expects.

   Deliberately **not** routed here: built-in vendor prefixes with no matching `providers:` block (e.g. `google/gemini-2.5-flash`, `deepseek/deepseek-chat`). Those slug forms are aggregator-native and keep their existing catalog / OpenRouter-slug / default-provider behavior — rerouting them would change established provider-switch semantics (see `TestDenormalizeProviderSwitch` in tests/hermes_cli/test_web_server.py).

2. **Dict entries under `model.aliases` were silently dropped.** `_load_direct_aliases` only parsed string values (`ds-flash: deepseek/deepseek-v4-flash`), so hand-written configs using the same dict shape as `model_aliases:` (`localqwen: {model: qwen3.5:4b, provider: custom}`) never became aliases and also fell through to the default provider. The dict shape is now accepted with the same fields (`model`, `provider`, `base_url`), and the existing precedence rule (top-level `model_aliases:` wins over nested `model.aliases`) is preserved.

## Related Issue

Fixes #87189

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/models.py`: new `_configured_provider_ids()` (reads `providers:` keys, empty set on any error) and `_resolve_provider_prefix()` (configured-providers-only prefix routing); wired into `detect_provider_for_model` as Step 3, after the OpenRouter slug check.
- `hermes_cli/model_switch.py`: `_load_direct_aliases` accepts dict-valued `model.aliases` entries; docstring updated.
- `tests/hermes_cli/test_model_prefix_routing_87189.py` (new): 13 regression tests — configured-provider prefix routing (nous portal + local ollama), user-named provider wins over alias canonicalization, alias prefix routes when the canonical provider is configured, unconfigured built-in vendor prefixes stay on the existing path (deterministic even without a models.dev catalog), unknown vendor unmatched, OpenRouter-slug priority, bare-name detection unchanged, plus dict-alias parsing (explicit provider, base_url, provider fallback, string entries, precedence).

## How to Test

1. `uv run --extra acp pytest tests/hermes_cli/test_model_prefix_routing_87189.py "tests/hermes_cli/test_web_server.py::TestDenormalizeProviderSwitch" -q` — should pass: 15 passed (observed result).
2. With a config containing `providers: {nous: {type: openai-compatible, baseUrl: https://inference-api.nousresearch.com/v1}}`: `hermes chat -q "hi" --model nous/deepseek-v4-pro` — Observed result: routes to `https://inference-api.nousresearch.com/v1` with model `deepseek-v4-pro`; previously printed `Provider: anthropic … HTTP 404: model: nous/deepseek-v4-pro`.
3. With `model.aliases.localqwen: {model: qwen3.5:4b, provider: custom}`: `hermes chat -q "hi" --model localqwen` — Observed result: routes to the custom provider instead of Anthropic.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the affected-area suites (prefix-routing + denormalize suites: 15 passed); full-suite verification delegated to CI
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (arm64)

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Not applicable — no UI change.
