### PR TITLE
fix(tui): honor config.yaml checkpoints.enabled in _launch_tui

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -2438,8 +2438,23 @@ def _launch_tui(
         env["HERMES_TUI_QUERY"] = query
     if image:
         env["HERMES_TUI_IMAGE"] = image
+    # TUI checkpoints: CLI flag > config.yaml (mirrors cli.py:4899 and
+    # gateway/run.py:_checkpoint_agent_kwargs — see fix for #87010).
     if checkpoints:
         env["HERMES_TUI_CHECKPOINTS"] = "1"
+    else:
+        try:
+            from cli import CLI_CONFIG
+            cp_cfg = CLI_CONFIG.get("checkpoints", {})
+            if isinstance(cp_cfg, bool):
+                cp_cfg = {"enabled": cp_cfg}
+            if isinstance(cp_cfg, dict) and cp_cfg.get("enabled", False):
+                env["HERMES_TUI_CHECKPOINTS"] = "1"
+        except Exception:
+            logger.debug(
+                "Failed to read checkpoints.enabled from CLI_CONFIG for TUI launch",
+                exc_info=True,
+            )
     if pass_session_id:
         env["HERMES_TUI_PASS_SESSION_ID"] = "1"
     if max_turns is not None:

--- a/tests/hermes_cli/test_tui_resume_flow.py
+++ b/tests/hermes_cli/test_tui_resume_flow.py
@@ -256,6 +256,118 @@ def test_launch_tui_exports_model_provider_and_toolsets(monkeypatch, main_mod):
 
 
 
+def test_launch_tui_satisfies_checkpoints_from_config_yaml(monkeypatch, main_mod):
+    """config.yaml checkpoints.enabled should be honored by _launch_tui
+    (regression test for #87010 — the TUI previously only honored the
+    explicit --checkpoints CLI flag)."""
+    captured = {}
+
+    monkeypatch.setattr(
+        main_mod,
+        "_make_tui_argv",
+        lambda tui_dir, tui_dev: (["node", "dist/entry.js"], Path(".")),
+    )
+
+    def fake_call(argv, cwd=None, env=None):
+        captured["env"] = env
+        return 1
+
+    monkeypatch.setattr(main_mod.subprocess, "call", fake_call)
+
+    import cli as cli_module
+
+    monkeypatch.setattr(cli_module, "CLI_CONFIG", {"checkpoints": {"enabled": True}})
+
+    with pytest.raises(SystemExit):
+        main_mod._launch_tui()
+
+    assert captured["env"]["HERMES_TUI_CHECKPOINTS"] == "1"
+
+
+def test_launch_tui_checkpoints_cli_flag_overrides_config_off(
+    monkeypatch, main_mod
+):
+    """Explicit --checkpoints=True should still set the env var even when
+    config.yaml has checkpoints.enabled=False."""
+    captured = {}
+
+    monkeypatch.setattr(
+        main_mod,
+        "_make_tui_argv",
+        lambda tui_dir, tui_dev: (["node", "dist/entry.js"], Path(".")),
+    )
+
+    def fake_call(argv, cwd=None, env=None):
+        captured["env"] = env
+        return 1
+
+    monkeypatch.setattr(main_mod.subprocess, "call", fake_call)
+
+    import cli as cli_module
+
+    monkeypatch.setattr(cli_module, "CLI_CONFIG", {"checkpoints": {"enabled": False}})
+
+    with pytest.raises(SystemExit):
+        main_mod._launch_tui(checkpoints=True)
+
+    assert captured["env"]["HERMES_TUI_CHECKPOINTS"] == "1"
+
+
+def test_launch_tui_no_checkpoints_when_config_disabled(monkeypatch, main_mod):
+    """When neither the flag nor the config enables checkpoints, the env var
+    must be absent so the TUI child does not silently create checkpoints."""
+    captured = {}
+
+    monkeypatch.setattr(
+        main_mod,
+        "_make_tui_argv",
+        lambda tui_dir, tui_dev: (["node", "dist/entry.js"], Path(".")),
+    )
+
+    def fake_call(argv, cwd=None, env=None):
+        captured["env"] = env
+        return 1
+
+    monkeypatch.setattr(main_mod.subprocess, "call", fake_call)
+
+    import cli as cli_module
+
+    monkeypatch.setattr(
+        cli_module, "CLI_CONFIG", {"checkpoints": {"enabled": False}}
+    )
+
+    with pytest.raises(SystemExit):
+        main_mod._launch_tui()
+
+    assert "HERMES_TUI_CHECKPOINTS" not in captured["env"]
+
+
+def test_launch_tui_checkpoints_accepts_top_level_bool(monkeypatch, main_mod):
+    """`checkpoints: true` (bare bool, not a dict) should also be honored."""
+    captured = {}
+
+    monkeypatch.setattr(
+        main_mod,
+        "_make_tui_argv",
+        lambda tui_dir, tui_dev: (["node", "dist/entry.js"], Path(".")),
+    )
+
+    def fake_call(argv, cwd=None, env=None):
+        captured["env"] = env
+        return 1
+
+    monkeypatch.setattr(main_mod.subprocess, "call", fake_call)
+
+    import cli as cli_module
+
+    monkeypatch.setattr(cli_module, "CLI_CONFIG", {"checkpoints": True})
+
+    with pytest.raises(SystemExit):
+        main_mod._launch_tui()
+
+    assert captured["env"]["HERMES_TUI_CHECKPOINTS"] == "1"
+
+
 def test_make_tui_argv_dev_prebuilds_hermes_ink(monkeypatch, main_mod, tmp_path):
     tui_dir = tmp_path / "ui-tui"
     tsx = tui_dir / "node_modules" / ".bin" / "tsx"


### PR DESCRIPTION
## Summary

The TUI entry point (`hermes` with no subcommand) only set `HERMES_TUI_CHECKPOINTS` when the explicit `--checkpoints` CLI flag was passed. A user who enabled checkpoints via `hermes config set checkpoints.enabled true` (or by editing `~/.hermes/config.yaml` by hand) saw **no checkpoints created in TUI sessions**, with no error or warning — the Checkpoint Manager was silently a no-op.

Both the `hermes chat` CLI path (`cli.py:4899`) and the messaging-gateway path (`gateway/run.py:_checkpoint_agent_kwargs`) already read the `checkpoints:` block from config with the documented CLI flag > config precedence. The TUI path had no equivalent config-aware wiring.

This change drops the same precedence into `_launch_tui`: when the explicit `--checkpoints` flag is not passed, the env var is set if and only if `config.yaml`'s `checkpoints.enabled` is truthy. Both the dict form (`checkpoints: { enabled: true }`) and the bare-bool form (`checkpoints: true`) are accepted, mirroring `cli.py`.

## Reproduction (from #87010)

1. `hermes config set checkpoints.enabled true`
2. Verify: `hermes config get checkpoints.enabled` → `true`
3. Launch the TUI: `hermes` (no `--checkpoints` flag)
4. In session, edit an existing file via the `patch`/`write_file` tool
5. Run `hermes checkpoints list` from a separate shell → still reports `Projects: 0`, no checkpoint created

After the fix, step 5 shows a non-zero checkpoint store matching the gateway/chat behavior.

## Root cause

- `tui_gateway/server.py` builds the agent's checkpoint kwargs as `checkpoints_enabled=is_truthy_value(os.environ.get("HERMES_TUI_CHECKPOINTS"))` — config.yaml was never consulted here.
- `hermes_cli/main.py:_launch_tui()` only set `HERMES_TUI_CHECKPOINTS` when the `--checkpoints` CLI flag was true, with no fallback to `CLI_CONFIG.get("checkpoints", {}).get("enabled")` the way `cli.py` does on the non-TUI CLI path.

## Fix

In `hermes_cli/main.py:_launch_tui()`, when `--checkpoints` was not explicitly passed, fall back to `config.yaml`'s `checkpoints.enabled`:

```python
if checkpoints:
    env["HERMES_TUI_CHECKPOINTS"] = "1"
else:
    try:
        from cli import CLI_CONFIG
        cp_cfg = CLI_CONFIG.get("checkpoints", {})
        if isinstance(cp_cfg, bool):
            cp_cfg = {"enabled": cp_cfg}
        if isinstance(cp_cfg, dict) and cp_cfg.get("enabled", False):
            env["HERMES_TUI_CHECKPOINTS"] = "1"
    except Exception:
        logger.debug(...)
```

The CLI flag (`--checkpoints`) continues to take precedence over the config — same precedence as `cli.py` and `gateway/run.py`.

## Tests

Added four new tests to `tests/hermes_cli/test_tui_resume_flow.py`:

1. `test_launch_tui_satisfies_checkpoints_from_config_yaml` — config.yaml `checkpoints.enabled: true` propagates to `HERMES_TUI_CHECKPOINTS=1` (the fix's primary case).
2. `test_launch_tui_checkpoints_cli_flag_overrides_config_off` — explicit `--checkpoints=True` still wins when config has `enabled: false`.
3. `test_launch_tui_no_checkpoints_when_config_disabled` — env var is absent when neither flag nor config enables checkpoints (no silent default-on).
4. `test_launch_tui_checkpoints_accepts_top_level_bool` — the bare-bool form `checkpoints: true` is also honored.

All 10 tests in the file pass (`scripts/run_tests.sh` equivalent: `pytest tests/hermes_cli/test_tui_resume_flow.py`).

## Files

- `hermes_cli/main.py` — 15 lines added in `_launch_tui()` only.
- `tests/hermes_cli/test_tui_resume_flow.py` — 112 lines added (4 new tests).

No changes to CLI surface, gateway, or TUI child code. Pure environment-variable wiring in the TUI launcher.

## Related

- `cli.py:4899` — the equivalent config-fallback pattern for the non-TUI CLI path.
- `gateway/run.py:_checkpoint_agent_kwargs()` — the equivalent config-fallback pattern for the gateway, covered by `tests/gateway/test_checkpoint_config.py`.
- `tui_gateway/server.py:6894` — the consumer that reads the env var; no change needed.

Closes #87010