### PR TITLE
fix(kanban): skip stop guard for delegated children

### DIFF
--- a/agent/kanban_stop.py
+++ b/agent/kanban_stop.py
@@ -25,14 +25,21 @@ _DEFAULT_MAX_ATTEMPTS = 2
 def kanban_stop_nudge_enabled() -> bool:
     """Return whether the kanban stop-guard is active for this process.
 
-    On when ``HERMES_KANBAN_TASK`` is set (dispatcher-spawned worker), unless
-    ``HERMES_KANBAN_STOP_NUDGE`` explicitly disables it.
+    On when ``HERMES_KANBAN_TASK`` is set and this execution owns the
+    dispatcher's Kanban task, unless ``HERMES_KANBAN_STOP_NUDGE`` explicitly
+    disables it.  Uses the canonical :func:`is_dispatcher_owned_worker_context`
+    predicate so the guard stays off for delegate_task children and in-process
+    cron jobs that merely inherit the worker's ``HERMES_KANBAN_*`` env vars.
     """
     env = os.environ.get("HERMES_KANBAN_STOP_NUDGE")
     if env is not None and env.strip().lower() in {"0", "false", "no", "off"}:
         return False
     task = (os.environ.get("HERMES_KANBAN_TASK") or "").strip()
-    return bool(task)
+    if not task:
+        return False
+    from agent.delegation_context import is_dispatcher_owned_worker_context
+
+    return is_dispatcher_owned_worker_context()
 
 
 def _tool_call_name(tc: Any) -> str:

--- a/tests/agent/test_kanban_stop.py
+++ b/tests/agent/test_kanban_stop.py
@@ -4,6 +4,10 @@ from __future__ import annotations
 
 import pytest
 
+from agent.delegation_context import (
+    delegated_child_context,
+    non_dispatcher_owned_context,
+)
 from agent.kanban_stop import (
     build_kanban_stop_nudge,
     kanban_stop_nudge_enabled,
@@ -72,6 +76,33 @@ def test_no_nudge_after_kanban_complete(clear_kanban_env):
     ]
     assert session_called_kanban_terminal(messages) is True
     assert build_kanban_stop_nudge(messages=messages) is None
+
+
+def test_delegated_child_disables_guard(clear_kanban_env):
+    """A delegate_task child must not fire the dispatcher-owned stop guard."""
+    clear_kanban_env.setenv("HERMES_KANBAN_TASK", "t_abc")
+    with delegated_child_context(session_id="child-1"):
+        assert kanban_stop_nudge_enabled() is False
+        assert build_kanban_stop_nudge(messages=[]) is None
+
+
+def test_non_dispatcher_owned_disables_guard(clear_kanban_env):
+    """In-process cron (non-dispatcher-owned) must not fire the guard."""
+    clear_kanban_env.setenv("HERMES_KANBAN_TASK", "t_abc")
+    with non_dispatcher_owned_context():
+        assert kanban_stop_nudge_enabled() is False
+        assert build_kanban_stop_nudge(messages=[]) is None
+
+
+def test_guard_restored_after_context_exit(clear_kanban_env):
+    """Leaving a child/non-dispatcher scope restores the guard for the worker."""
+    clear_kanban_env.setenv("HERMES_KANBAN_TASK", "t_abc")
+    with delegated_child_context(session_id="child-1"):
+        assert kanban_stop_nudge_enabled() is False
+    assert kanban_stop_nudge_enabled() is True
+    with non_dispatcher_owned_context():
+        assert kanban_stop_nudge_enabled() is False
+    assert kanban_stop_nudge_enabled() is True
 
 
 


### PR DESCRIPTION
## Summary
- gate the kanban stop nudge on the canonical dispatcher-owned context predicate
- suppress stop nudges for delegate_task children and in-process cron jobs inheriting worker env vars
- add behavioral coverage for delegated, non-dispatcher, and context-restoration cases

## Verification
- scripts/run_tests.sh tests/agent/test_kanban_stop.py tests/cron/test_cron_kanban_env_isolation.py (24 passed)
- python -m compileall -q agent/kanban_stop.py tests/agent/test_kanban_stop.py
- git diff --check