### PR TITLE
fix(context): prevent replay of compressed tool arguments

### DIFF
--- a/agent/anthropic_message_convert.py
+++ b/agent/anthropic_message_convert.py
@@ -685,6 +685,9 @@ def convert_messages_to_anthropic(
     ``base_url``/``model`` drive thinking-signature policy — third-party endpoints strip signatures
     (proprietary, they 400 on them); Kimi-family endpoints/models keep unsigned
     reasoning_content-derived blocks, which Kimi requires even when empty."""
+    from agent.tool_argument_integrity import neutralize_completed_incomplete_tool_calls
+    messages = neutralize_completed_incomplete_tool_calls(messages)
+
     system = None
     result: List[Dict[str, Any]] = []
     for m in messages:

--- a/agent/bedrock_adapter.py
+++ b/agent/bedrock_adapter.py
@@ -564,6 +564,9 @@ def convert_messages_to_converse(messages: List[Dict]) -> Tuple[Optional[List[Di
     """OpenAI messages → ``(system_blocks_or_None, converse_messages)``; tool results become ``toolResult``
     user blocks. Converse needs strict user/assistant alternation with a user turn first and last:
     same-role neighbours merge, placeholder user turns pad the ends."""
+    from agent.tool_argument_integrity import neutralize_completed_incomplete_tool_calls
+    messages = neutralize_completed_incomplete_tool_calls(messages)
+
     system_blocks: List[Dict] = []
     converse_msgs: List[Dict] = []
 

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1529,6 +1529,9 @@ def build_api_kwargs(agent, api_messages: list, tools_for_api: list | None = Non
     (chat_completions / codex_responses / anthropic_messages all route
     OpenCode models). No-op for every other provider.
     """
+    from agent.tool_argument_integrity import neutralize_completed_incomplete_tool_calls
+    api_messages = neutralize_completed_incomplete_tool_calls(api_messages)
+
     from agent.opencode_affinity import merge_opencode_session_headers
 
     kwargs = _build_api_kwargs_for_mode(agent, api_messages, tools_for_api)

--- a/agent/codex_responses_adapter.py
+++ b/agent/codex_responses_adapter.py
@@ -448,6 +448,11 @@ def _chat_messages_to_responses_input(
     Hermes' local history is never truncated by native compaction, so the full conversation is still on the
     wire.
     """
+    from agent.tool_argument_integrity import (
+        neutralize_completed_incomplete_tool_calls,
+    )
+
+    messages = neutralize_completed_incomplete_tool_calls(messages)
     items: List[Dict[str, Any]] = []
     # Parallel to ``items``: source chat message per item. Pruning reads a summary
     # carrier's provenance from the source; the converted item may be a lossy shape.

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -5,6 +5,7 @@ import contextlib
 import contextvars
 import copy
 import hashlib
+from agent.tool_argument_integrity import completed_tool_call_pairs
 import json
 import logging
 import sqlite3
@@ -1257,25 +1258,43 @@ def evict_stale_outbound_tool_images(
     return _retire_stale_tool_result_images(api_messages, keep_newest=keep_newest)
 
 
-def _truncate_tool_call_args_json(args: str, head_chars: int = 200) -> str:
-    """Shrink long string leaves in a tool-call arguments JSON blob, keeping it valid (providers 400 on malformed args)."""
+def _truncate_tool_call_args_json(args: str) -> str:
+    """Externalize a large historical tool-call argument object safely.
+
+    ``function.arguments`` must remain valid JSON for strict providers, but a
+    shortened command, patch, file body, or code string is not a safe summary:
+    a later model can mistake it for a complete operation and replay it. Once
+    an already-executed call reaches context pruning, replace the complete
+    argument object with non-replayable provenance instead of preserving any
+    executable field.
+
+    The original call remains in the persisted transcript. The compressed API
+    copy carries its exact character count and SHA-256 so diagnostics can prove
+    which payload was omitted without exposing or partially reconstructing it.
+    Invalid provider-specific non-JSON arguments are left unchanged because
+    replacing them could break the provider's own format.
+
+    """
+    if len(args) <= 500:
+        return args
     try:
-        parsed = json.loads(args)
+        json.loads(args)
     except (ValueError, TypeError):
         return args
 
-    def _shrink(obj: Any) -> Any:
-        if isinstance(obj, str):
-            return obj[:head_chars] + "...[truncated]" if len(obj) > head_chars else obj
-        if isinstance(obj, dict):
-            return {k: _shrink(v) for k, v in obj.items()}
-        if isinstance(obj, list):
-            return [_shrink(v) for v in obj]
-        return obj
-
-    shrunken = _shrink(parsed)
-    # ensure_ascii=False keeps CJK/emoji from bloating into \uXXXX
-    return json.dumps(shrunken, ensure_ascii=False)
+    provenance = {
+        "__hermes_incomplete_tool_arguments__": {
+            "version": 1,
+            "reason": "context_compression",
+            "arguments_omitted": True,
+            "replayable": False,
+            "original_chars": len(args),
+            "sha256": hashlib.sha256(
+                args.encode("utf-8", errors="surrogatepass")
+            ).hexdigest(),
+        }
+    }
+    return json.dumps(provenance, ensure_ascii=False)
 
 
 _IMAGE_PART_TYPES = frozenset({"image_url", "input_image", "image"})
@@ -2610,15 +2629,15 @@ class ContextCompressor(MicroCompactionMixin, ContextEngine):
         return pruned
 
     @staticmethod
-    def _truncate_tool_call_args_at(result: List[Dict[str, Any]], idx: int) -> bool:
+    def _truncate_tool_call_args_at(result: List[Dict[str, Any]], idx: int, completed_calls: set[tuple[int, int]]) -> bool:
         """Shrink large tool_call argument payloads at ``idx`` (inside the parsed JSON, so it stays valid)."""
         msg = result[idx]
         if msg.get("role") != "assistant" or not msg.get("tool_calls"):
             return False
         new_tcs = []
-        for tc in msg["tool_calls"]:
+        for call_index, tc in enumerate(msg["tool_calls"]):
             args = tc.get("function", {}).get("arguments", "") if isinstance(tc, dict) else ""
-            new_args = _truncate_tool_call_args_json(args) if len(args) > 500 else args
+            new_args = _truncate_tool_call_args_json(args) if (idx, call_index) in completed_calls and isinstance(args, str) and len(args) > 500 else args
             new_tcs.append(tc if new_args == args else {**tc, "function": {**tc["function"], "arguments": new_args}})
         modified = any(new is not old for new, old in zip(new_tcs, msg["tool_calls"]))
         if modified:
@@ -2659,6 +2678,7 @@ class ContextCompressor(MicroCompactionMixin, ContextEngine):
     def _pressure_demote_tail(
         self, result: List[Dict[str, Any]], prune_boundary: int, protect_tail_tokens: int,
         call_id_to_tool: Dict[str, tuple[str, str]], min_prune_chars: int,
+        completed_calls: set[tuple[int, int]],
     ) -> int:
         """Pass 4: demote inside the protected tail when it alone exceeds the soft budget (#61932).
         Keeps a short recent floor verbatim; overrides the skill guard (else the dead-end recurs).
@@ -2678,7 +2698,7 @@ class ContextCompressor(MicroCompactionMixin, ContextEngine):
             if self._demote_tool_result_at(result, i, call_id_to_tool, min_prune_chars):
                 demoted += 1
                 pressure_hits += 1
-            if self._truncate_tool_call_args_at(result, i):
+            if self._truncate_tool_call_args_at(result, i, completed_calls):
                 pressure_hits += 1
 
         if demote_end <= prune_boundary or _protected_region_tokens() <= soft_ceiling:
@@ -2715,6 +2735,7 @@ class ContextCompressor(MicroCompactionMixin, ContextEngine):
         if not messages:
             return messages, 0
         result = [m.copy() for m in messages]
+        completed_calls = set(completed_tool_call_pairs(result))
         call_id_to_tool = _tool_calls_by_id(result)
         prune_boundary = self._prune_boundary(result, protect_tail_count, protect_tail_tokens)
         pruned = self._dedupe_tool_results(result)
@@ -2729,14 +2750,14 @@ class ContextCompressor(MicroCompactionMixin, ContextEngine):
             for i in range(max(0, prune_boundary))
         )
         for i in range(max(0, prune_boundary)):
-            self._truncate_tool_call_args_at(result, i)
+            self._truncate_tool_call_args_at(result, i, completed_calls)
         # Pass 3.5: retire image payloads inside the protected tail; re-sent embeds otherwise make
         # compression look ineffective and trip anti-thrash. Newest frames stay live.
         # Newest frames stay live for follow-up QA; older ones become placeholders. See #92699.
         pruned += _retire_stale_tool_result_images(result)
         if protect_tail_tokens is not None and protect_tail_tokens > 0 and result:
             pruned += self._pressure_demote_tail(
-                result, prune_boundary, protect_tail_tokens, call_id_to_tool, min_prune_chars,
+                result, prune_boundary, protect_tail_tokens, call_id_to_tool, min_prune_chars, completed_calls,
             )
         return result, pruned
 

--- a/agent/tool_argument_integrity.py
+++ b/agent/tool_argument_integrity.py
@@ -1,0 +1,321 @@
+"""Shared integrity checks for non-replayable historical tool arguments."""
+
+from __future__ import annotations
+
+import json
+from copy import deepcopy
+from typing import Any, Optional
+
+INCOMPLETE_TOOL_ARGUMENTS_KEY = "__hermes_incomplete_tool_arguments__"
+
+_WIRE_HISTORY_NOTE = (
+    "[A completed compressed historical tool call is omitted from this "
+    "request; its stored transcript is unchanged.]"
+)
+
+
+def contains_incomplete_tool_arguments(value: Any) -> bool:
+    """Detect reserved lossy-history provenance at any nesting depth."""
+    if isinstance(value, dict):
+        if INCOMPLETE_TOOL_ARGUMENTS_KEY in value:
+            return True
+        return any(contains_incomplete_tool_arguments(item) for item in value.values())
+    if isinstance(value, list):
+        return any(contains_incomplete_tool_arguments(item) for item in value)
+    return False
+
+
+def _tool_call_has_incomplete_arguments(tool_call: Any) -> bool:
+    if not isinstance(tool_call, dict):
+        return False
+    function = tool_call.get("function")
+    if not isinstance(function, dict):
+        return False
+    arguments = function.get("arguments")
+    if isinstance(arguments, str):
+        try:
+            arguments = json.loads(arguments)
+        except (json.JSONDecodeError, TypeError):
+            return False
+    return contains_incomplete_tool_arguments(arguments)
+
+
+def completed_tool_call_pairs(
+    messages: list[dict[str, Any]],
+) -> dict[tuple[int, int], int]:
+    """Map unambiguous assistant calls to adjacent result positions."""
+    call_counts: dict[str, int] = {}
+    result_counts: dict[str, int] = {}
+    for message in messages:
+        if not isinstance(message, dict):
+            continue
+        if message.get("role") == "assistant":
+            tool_calls = message.get("tool_calls")
+            if isinstance(tool_calls, list):
+                for tool_call in tool_calls:
+                    if isinstance(tool_call, dict):
+                        call_id = tool_call.get("id")
+                        if isinstance(call_id, str) and call_id:
+                            call_counts[call_id] = call_counts.get(call_id, 0) + 1
+        elif message.get("role") == "tool":
+            call_id = message.get("tool_call_id")
+            if isinstance(call_id, str) and call_id:
+                result_counts[call_id] = result_counts.get(call_id, 0) + 1
+
+    pairs: dict[tuple[int, int], int] = {}
+    for assistant_index, message in enumerate(messages):
+        if not isinstance(message, dict) or message.get("role") != "assistant":
+            continue
+        tool_calls = message.get("tool_calls")
+        if not isinstance(tool_calls, list):
+            continue
+        calls_by_id: dict[str, list[int]] = {}
+        for call_index, tool_call in enumerate(tool_calls):
+            if isinstance(tool_call, dict):
+                call_id = tool_call.get("id")
+                if isinstance(call_id, str) and call_id:
+                    calls_by_id.setdefault(call_id, []).append(call_index)
+        results_by_id: dict[str, list[int]] = {}
+        for result_index in range(assistant_index + 1, len(messages)):
+            result = messages[result_index]
+            if not isinstance(result, dict) or result.get("role") != "tool":
+                break
+            call_id = result.get("tool_call_id")
+            if isinstance(call_id, str) and call_id:
+                results_by_id.setdefault(call_id, []).append(result_index)
+        for call_id, call_indices in calls_by_id.items():
+            result_indices = results_by_id.get(call_id, [])
+            if (
+                len(call_indices) == 1
+                and len(result_indices) == 1
+                and call_counts.get(call_id) == 1
+                and result_counts.get(call_id) == 1
+            ):
+                pairs[(assistant_index, call_indices[0])] = result_indices[0]
+    return pairs
+
+
+def neutralize_completed_incomplete_tool_calls(
+    messages: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Project canonical history into a conservative provider-safe request copy.
+
+    Compression provenance belongs in Hermes' canonical transcript so the
+    execution guard can fail closed. Once such a call has a tool result,
+    replaying the pair on a later provider request makes the marker look like
+    fresh executable arguments. Remove both sides of only those completed,
+    unambiguous pairs and leave a plain note.
+
+    An affected assistant turn is rebuilt only from canonical wire-neutral
+    fields (role, visible content, and any remaining ordinary tool calls).
+    Provider-native replay sidecars are deliberately discarded wholesale:
+    after one canonical tool call is removed, their IDs, inputs, signatures,
+    and cross-block ordering can no longer be trusted. The stored transcript
+    remains unchanged. Malformed non-dict history entries are also excluded
+    from the request projection rather than forwarded to provider schemas.
+    """
+    request_messages = [message for message in messages if isinstance(message, dict)]
+    pairs = completed_tool_call_pairs(request_messages)
+    neutralized_calls = {
+        position
+        for position in pairs
+        if _tool_call_has_incomplete_arguments(
+            request_messages[position[0]]["tool_calls"][position[1]]
+        )
+    }
+    if not neutralized_calls:
+        return messages if len(request_messages) == len(messages) else request_messages
+    neutralized_results = {pairs[position] for position in neutralized_calls}
+    note_boundaries: set[int] = set()
+    for assistant_index in {position[0] for position in neutralized_calls}:
+        tool_calls = request_messages[assistant_index].get("tool_calls")
+        if not isinstance(tool_calls, list) or not tool_calls:
+            continue
+        positions = [(assistant_index, index) for index in range(len(tool_calls))]
+        if not all(position in neutralized_calls for position in positions):
+            continue
+        result_indices = [pairs[position] for position in positions]
+        boundary = max(result_indices)
+        next_index = boundary + 1
+        while next_index < len(request_messages) and next_index in neutralized_results:
+            next_index += 1
+        if next_index < len(request_messages):
+            following = request_messages[next_index]
+            if following.get("role") == "assistant":
+                note_boundaries.add(boundary)
+
+    sanitized: list[dict[str, Any]] = []
+    for message_index, message in enumerate(request_messages):
+        if message_index in neutralized_results:
+            if message_index in note_boundaries:
+                sanitized.append({"role": "user", "content": _WIRE_HISTORY_NOTE})
+            continue
+        if message.get("role") != "assistant":
+            sanitized.append(message)
+            continue
+
+        tool_calls = message.get("tool_calls")
+        if not isinstance(tool_calls, list):
+            sanitized.append(message)
+            continue
+        kept_calls = [
+            call
+            for call_index, call in enumerate(tool_calls)
+            if (message_index, call_index) not in neutralized_calls
+        ]
+        if len(kept_calls) == len(tool_calls):
+            sanitized.append(message)
+            continue
+
+        content = deepcopy(message.get("content"))
+        if isinstance(content, list):
+            content.append({"type": "text", "text": _WIRE_HISTORY_NOTE})
+        elif isinstance(content, str) and content.strip():
+            content = f"{content.rstrip()}\n{_WIRE_HISTORY_NOTE}"
+        else:
+            content = _WIRE_HISTORY_NOTE
+
+        rebuilt: dict[str, Any] = {"role": "assistant", "content": content}
+        if kept_calls:
+            rebuilt["tool_calls"] = deepcopy(kept_calls)
+        sanitized.append(rebuilt)
+    return sanitized
+
+
+def incomplete_tool_arguments_block_message(value: Any) -> Optional[str]:
+    """Return the common fail-closed message for lossy historical arguments."""
+    if not contains_incomplete_tool_arguments(value):
+        return None
+    return (
+        "Hermes omitted these already-executed arguments during context "
+        "compression, so the tool was not executed. Reconstruct and issue a "
+        "new complete invocation from current user intent instead of replaying "
+        "this historical call."
+    )
+
+
+def incomplete_tool_arguments_error_result(value: Any) -> Optional[str]:
+    """Return the canonical structured rejection, or ``None`` when replayable."""
+    message = incomplete_tool_arguments_block_message(value)
+    if message is None:
+        return None
+    return json.dumps(
+        {
+            "error": "Incomplete historical tool arguments",
+            "error_type": "incomplete_historical_tool_arguments",
+            "message": message,
+        },
+        ensure_ascii=False,
+    )
+
+
+def _schema_accepts_container(schema: Any, kind: str) -> bool:
+    if not isinstance(schema, dict):
+        return False
+    schema_type = schema.get("type")
+    if schema_type == kind or (
+        isinstance(schema_type, list) and kind in schema_type
+    ):
+        return True
+    for union_key in ("anyOf", "oneOf", "allOf"):
+        branches = schema.get(union_key)
+        if isinstance(branches, list) and any(
+            _schema_accepts_container(branch, kind) for branch in branches
+        ):
+            return True
+    return False
+
+
+def _decode_schema_containers(
+    value: Any,
+    schema: Any,
+    *,
+    direct_container_required: bool = False,
+    top_level_arguments: bool = False,
+) -> Any:
+    """Pure preview of the container decoding performed by schema coercion."""
+    if not isinstance(schema, dict):
+        return value
+    decoded_from_string = False
+    if direct_container_required:
+        direct_type = schema.get("type")
+        direct_types = (
+            set(direct_type) if isinstance(direct_type, list) else {direct_type}
+        )
+        if not direct_types.intersection({"array", "object"}):
+            return value
+    if isinstance(value, str):
+        trimmed = value.strip()
+        accepts_array = _schema_accepts_container(schema, "array")
+        accepts_object = _schema_accepts_container(schema, "object")
+        if not (
+            (accepts_array and trimmed.startswith("["))
+            or (accepts_object and trimmed.startswith("{"))
+        ):
+            return value
+        try:
+            parsed = json.loads(trimmed)
+        except (json.JSONDecodeError, TypeError):
+            return value
+        if not (
+            (accepts_array and isinstance(parsed, list))
+            or (accepts_object and isinstance(parsed, dict))
+        ):
+            return value
+        value = parsed
+        decoded_from_string = True
+    if isinstance(value, list):
+        if (
+            direct_container_required
+            and not decoded_from_string
+            and schema.get("type") != "array"
+        ):
+            return value
+        item_schema = schema.get("items")
+        if not isinstance(item_schema, dict):
+            return value
+        return [_decode_schema_containers(item, item_schema) for item in value]
+    if isinstance(value, dict):
+        if (
+            direct_container_required
+            and not decoded_from_string
+            and schema.get("type") != "object"
+        ):
+            return value
+        properties = schema.get("properties")
+        if not isinstance(properties, dict):
+            return value
+        return {
+            key: _decode_schema_containers(
+                item,
+                properties.get(key),
+                direct_container_required=top_level_arguments,
+            )
+            if isinstance(properties.get(key), dict)
+            else item
+            for key, item in value.items()
+        }
+    return value
+
+
+def incomplete_tool_arguments_after_schema_decode(
+    value: Any, schema: Any
+) -> Optional[str]:
+    """Reject provenance that schema-guided container decoding would expose."""
+    return incomplete_tool_arguments_error_result(
+        _decode_schema_containers(value, schema, top_level_arguments=True)
+    )
+
+
+def is_incomplete_tool_arguments_error_result(value: Any) -> bool:
+    """Identify the canonical rejection without treating arbitrary text as policy."""
+    if not isinstance(value, str):
+        return False
+    try:
+        parsed = json.loads(value)
+    except (json.JSONDecodeError, TypeError):
+        return False
+    return (
+        isinstance(parsed, dict)
+        and parsed.get("error_type") == "incomplete_historical_tool_arguments"
+    )

--- a/agent/tool_argument_integrity.py
+++ b/agent/tool_argument_integrity.py
@@ -126,7 +126,7 @@ def neutralize_completed_incomplete_tool_calls(
     if not neutralized_calls:
         return messages if len(request_messages) == len(messages) else request_messages
     neutralized_results = {pairs[position] for position in neutralized_calls}
-    note_boundaries: set[int] = set()
+    coalesce_boundaries: set[int] = set()
     for assistant_index in {position[0] for position in neutralized_calls}:
         tool_calls = request_messages[assistant_index].get("tool_calls")
         if not isinstance(tool_calls, list) or not tool_calls:
@@ -142,13 +142,14 @@ def neutralize_completed_incomplete_tool_calls(
         if next_index < len(request_messages):
             following = request_messages[next_index]
             if following.get("role") == "assistant":
-                note_boundaries.add(boundary)
+                coalesce_boundaries.add(boundary)
 
     sanitized: list[dict[str, Any]] = []
+    merge_positions: set[int] = set()
     for message_index, message in enumerate(request_messages):
         if message_index in neutralized_results:
-            if message_index in note_boundaries:
-                sanitized.append({"role": "user", "content": _WIRE_HISTORY_NOTE})
+            if message_index in coalesce_boundaries:
+                merge_positions.add(len(sanitized))
             continue
         if message.get("role") != "assistant":
             sanitized.append(message)
@@ -179,7 +180,36 @@ def neutralize_completed_incomplete_tool_calls(
         if kept_calls:
             rebuilt["tool_calls"] = deepcopy(kept_calls)
         sanitized.append(rebuilt)
-    return sanitized
+    # Removing a complete tool round joins two assistant continuations, not
+    # two user turns. Coalesce only those newly adjacent continuations. Rebuild
+    # both participants from canonical fields: signed/native replay sidecars
+    # cannot describe the new combined content or block ordering safely.
+    projected: list[dict[str, Any]] = []
+    for index, message in enumerate(sanitized):
+        if (
+            index not in merge_positions
+            or not projected
+            or projected[-1].get("role") != "assistant"
+            or message.get("role") != "assistant"
+        ):
+            projected.append(message)
+            continue
+        previous = projected.pop()
+        left, right = previous.get("content"), message.get("content")
+        if isinstance(left, list) or isinstance(right, list):
+            content = []
+            for part in (left, right):
+                if isinstance(part, list):
+                    content.extend(deepcopy(part))
+                elif isinstance(part, str) and part:
+                    content.append({"type": "text", "text": part})
+        else:
+            content = "\n".join(part for part in (left, right) if isinstance(part, str) and part)
+        merged = {"role": "assistant", "content": content}
+        if message.get("tool_calls"):
+            merged["tool_calls"] = deepcopy(message["tool_calls"])
+        projected.append(merged)
+    return projected
 
 
 def incomplete_tool_arguments_block_message(value: Any) -> Optional[str]:
@@ -262,6 +292,11 @@ def _decode_schema_containers(
             or (accepts_object and isinstance(parsed, dict))
         ):
             return value
+        # coerce_tool_args returns immediately for a direct top-level array
+        # string. Its items are not recursively normalized on that path;
+        # previewing recursive normalization here would reject valid data.
+        if direct_container_required and schema.get("type") == "array":
+            return parsed
         value = parsed
         decoded_from_string = True
     if isinstance(value, list):

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -15,6 +15,13 @@ from pathlib import Path
 import logging
 import os
 import random
+import re
+from agent.tool_argument_integrity import (
+    INCOMPLETE_TOOL_ARGUMENTS_KEY,
+    incomplete_tool_arguments_after_schema_decode as _incomplete_after_schema_decode,
+    incomplete_tool_arguments_error_result as _incomplete_tool_arguments_error_result,
+    is_incomplete_tool_arguments_error_result as _is_incomplete_tool_arguments_error_result,
+)
 import threading
 import time
 from dataclasses import dataclass
@@ -55,6 +62,77 @@ from tools.tool_result_storage import (
 from tools.budget_config import BudgetConfig, DEFAULT_BUDGET, budget_for_context_window
 
 logger = logging.getLogger(__name__)
+
+
+_INCOMPLETE_KEY_ESCAPE_RE = re.compile(
+    "".join(
+        rf"(?:{re.escape(char)}|\\+u00{ord(char):02x})"
+        for char in INCOMPLETE_TOOL_ARGUMENTS_KEY
+    ),
+    re.IGNORECASE,
+)
+
+def _schema_decoded_integrity_result(
+    function_name: str, function_args: dict[str, Any]
+) -> Optional[str]:
+    """Purely preview schema container decoding before execution lifecycle."""
+    from tools.registry import registry
+
+    schema = registry.get_schema(function_name)
+    parameters = schema.get("parameters") if isinstance(schema, dict) else None
+    if not isinstance(parameters, dict):
+        return None
+    preview_args = function_args
+    try:
+        from tools.schema_sanitizer import unrename_tool_args
+
+        preview_args = unrename_tool_args(parameters, dict(function_args))
+    except Exception:
+        pass
+    return _incomplete_after_schema_decode(preview_args, parameters)
+
+
+def _may_contain_incomplete_provenance(value: Any) -> bool:
+    """Cheap gate for literal or JSON-escaped reserved provenance keys."""
+    if isinstance(value, str):
+        serialized = value
+    else:
+        try:
+            serialized = json.dumps(value, ensure_ascii=True)
+        except (TypeError, ValueError):
+            return False
+    return _INCOMPLETE_KEY_ESCAPE_RE.search(serialized) is not None
+
+
+def _integrity_preflight(function_name: str, raw_arguments: Any) -> Optional[str]:
+    """Return an integrity rejection before interrupt or lifecycle handling."""
+    function_args, parse_result = _parse_tool_arguments(raw_arguments)
+    if _is_incomplete_tool_arguments_error_result(parse_result):
+        return parse_result
+    if parse_result is not None:
+        return None
+    if not _may_contain_incomplete_provenance(raw_arguments):
+        return None
+
+    try:
+        from tools import tool_search as _ts
+
+        if function_name == _ts.TOOL_CALL_NAME:
+            underlying, underlying_args, error = _ts.resolve_underlying_call(
+                function_args
+            )
+            if not error and underlying:
+                direct_result = _incomplete_tool_arguments_error_result(
+                    underlying_args
+                )
+                if direct_result:
+                    return direct_result
+                return _schema_decoded_integrity_result(
+                    underlying, underlying_args
+                )
+    except Exception:
+        pass
+    return _schema_decoded_integrity_result(function_name, function_args)
 
 
 _pairing_tool_call_id = coalesce_tool_call_id  # canonical id used by the persisted assistant message
@@ -145,15 +223,23 @@ class _BatchAbandoned(BaseException):
 
 
 def _parse_tool_arguments(raw_arguments: Any) -> tuple[dict, Optional[str]]:
-    """Parse model-emitted arguments without repairing or coercing them."""
+    """Parse model-emitted arguments and reject lossy historical previews."""
     try:
         arguments = json.loads(raw_arguments)
     except (json.JSONDecodeError, TypeError):
         arguments = None
+    incomplete_result = _incomplete_tool_arguments_error_result(arguments)
+    if isinstance(arguments, dict) and incomplete_result:
+        return {}, incomplete_result
     if isinstance(arguments, dict):
         return arguments, None
     return {}, json.dumps(
-        {"error": "Invalid tool arguments", "message": "Tool arguments must be a valid JSON object; tool was not executed."},
+        {
+            "error": "Invalid tool arguments",
+            "message": (
+                "Tool arguments must be a valid JSON object; tool was not executed."
+            ),
+        },
         ensure_ascii=False,
     )
 
@@ -307,6 +393,11 @@ def _append_skipped_tool_results(
     append and returns False on the first failed flush when ``stop_on_flush_failure``."""
     for tc in tool_calls:
         name = _tc_name(tc)
+        integrity_result = _integrity_preflight(name, tc.function.arguments)
+        if integrity_result is not None:
+            if not _append_integrity_rejection(agent, messages, name, _pairing_tool_call_id(tc), integrity_result):
+                return False
+            continue
         result = content.format(name=name)
         messages.append(make_tool_result_message(name, result, _pairing_tool_call_id(tc), effect_disposition="none"))
         if hook_error_type is not None:
@@ -420,6 +511,9 @@ class _ParsedCall:
 
 def _parse_tool_call(agent, tool_call, *, flatten_probe: bool = False) -> _ParsedCall:
     name = _canonical_tool_name(tool_call.function.name)
+    integrity_result = _integrity_preflight(name, tool_call.function.arguments)
+    if integrity_result is not None:
+        return _ParsedCall(tool_call, name, {}, [], integrity_result, None)
     args, parse_error = _parse_tool_arguments(tool_call.function.arguments)
     scope_block = None
     if parse_error is None:
@@ -1343,10 +1437,20 @@ def _unfinished_tool_result(agent, ref: _ToolCallRef, *, timed_out: bool, timeou
     return function_result, tool_duration, effect_disposition
 
 
+def _append_integrity_rejection(agent, messages, name, call_id, result) -> bool:
+    """Only durable protocol pairing is allowed for a non-replayable call."""
+    messages.append(make_tool_result_message(name, result, call_id, effect_disposition="none"))
+    return _flush_session_db_after_tool_progress(agent, messages, stage=f"rejected incomplete tool arguments {name}")
+
+
 def _append_batch_results(agent, messages: list, effective_task_id: str, batch: _ConcurrentBatch, budget: BudgetConfig) -> bool:
     """Append every slot's result in original call order; returns False at the first
     failed flush (the caller must stop the batch)."""
     for i, pc in enumerate(batch.parsed_calls):
+        if _is_incomplete_tool_arguments_error_result(pc.parse_error):
+            if not _append_integrity_rejection(agent, messages, pc.name, _pairing_tool_call_id(pc.tool_call), pc.parse_error):
+                return False
+            continue
         r = batch.results[i]
         # A worker may finish between the deadline snapshot and this loop;
         # prefer its real result over a fabricated timeout.
@@ -1408,16 +1512,19 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
     # Resolved before the batch is built so the start-order gate can clamp under the deadline.
     timeout_s = _resolve_concurrent_tool_timeout()
     batch = _ConcurrentBatch(agent, messages, effective_task_id, parsed_calls, timeout_s)
-    agent._current_tool = tool_names_str
-    agent._touch_activity(f"executing {num_tools} tools concurrently: {tool_names_str}")
+    runnable = [pc for pc in parsed_calls if pc.parse_error is None]
+    if runnable:
+        runnable_names = ", ".join(pc.name for pc in runnable)
+        agent._current_tool = runnable_names
+        agent._touch_activity(f"executing {len(runnable)} tools concurrently: {runnable_names}")
 
-    spinner = _start_quiet_tool_spinner(agent, "", {}, label=f"⚡ running {num_tools} tools concurrently")
+    spinner = _start_quiet_tool_spinner(agent, "", {}, label=f"⚡ running {len(runnable)} tools concurrently") if runnable else None
     try:
         batch.run()
     finally:
         if spinner:
-            finished = [r for r in batch.results if r is not None]
-            spinner.stop(f"⚡ {len(finished)}/{num_tools} tools completed in {sum(r.duration for r in finished):.1f}s total")
+            finished = [r for pc, r in zip(parsed_calls, batch.results) if pc.parse_error is None and r is not None]
+            spinner.stop(f"⚡ {len(finished)}/{len(runnable)} tools completed in {sum(r.duration for r in finished):.1f}s total")
 
     if not _append_batch_results(agent, messages, effective_task_id, batch, _tool_budget):
         return
@@ -1663,6 +1770,10 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
 
         pc = _parse_tool_call(agent, tool_call, flatten_probe=True)
         ref = pc.ref(effective_task_id)
+        if _is_incomplete_tool_arguments_error_result(pc.parse_error):
+            if not _append_integrity_rejection(agent, messages, ref.name, ref.call_id, pc.parse_error):
+                return
+            continue
         if pc.parse_error is not None:
             if not _append_invalid_arguments_result(agent, messages, ref, pc.parse_error):
                 return

--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -340,6 +340,9 @@ class ChatCompletionsTransport(ProviderTransport):
 
         Returns the input list unchanged when nothing needs sanitizing.
         """
+        from agent.tool_argument_integrity import neutralize_completed_incomplete_tool_calls
+        messages = neutralize_completed_incomplete_tool_calls(messages)
+
         strip_extra_content = not _model_consumes_thought_signature(kwargs.get("model"))
         sanitized_pairs = [(m, _sanitize_message(m, strip_extra_content)) for m in messages]
         if all(s is None for _, s in sanitized_pairs):

--- a/model_tools.py
+++ b/model_tools.py
@@ -18,6 +18,7 @@ import threading
 import time
 from typing import Dict, Any, List, Optional, Tuple
 
+from agent.tool_argument_integrity import incomplete_tool_arguments_error_result
 from tools.registry import CHECK_FN_CACHE_BYPASS, check_fn_cache_scope, discover_builtin_tools, registry, tool_error
 from tools.registry import _MAX_TOOL_ERROR_CHARS as _TOOL_ERROR_MAX_LEN
 from toolsets import resolve_toolset, validate_toolset
@@ -815,6 +816,9 @@ def handle_function_call(
     bridge catalog to this session's grant (None = unrestricted).
     """
     function_args = coerce_tool_args(function_name, function_args)
+    incomplete_result = incomplete_tool_arguments_error_result(function_args)
+    if incomplete_result:
+        return incomplete_result
     if not isinstance(function_args, dict):
         function_args = {}
     trace = list(tool_request_middleware_trace or [])

--- a/tests/agent/conftest.py
+++ b/tests/agent/conftest.py
@@ -1,0 +1,31 @@
+"""Network isolation for compressed-argument security regression tests."""
+
+import socket
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _deny_integrity_test_network(request, monkeypatch):
+    name = request.path.name
+    if not (
+        name.startswith("test_compressed_tool_arguments_")
+        or name.startswith("test_tool_executor_integrity_")
+        or name in {"test_tool_executor_argument_integrity.py", "test_context_compressor.py"}
+    ):
+        yield
+        return
+    # Model-catalog discovery is unrelated to the integrity contract.
+    monkeypatch.setattr("agent.model_metadata.fetch_model_metadata", lambda **kwargs: {})
+    attempts = []
+
+    def denied(*args, **kwargs):
+        attempts.append("outbound socket operation")
+        raise AssertionError("Network forbidden in compressed-argument tests")
+
+    for attribute in ("connect", "connect_ex", "sendto"):
+        monkeypatch.setattr(socket.socket, attribute, denied)
+    monkeypatch.setattr(socket, "create_connection", denied)
+    monkeypatch.setattr(socket, "getaddrinfo", denied)
+    yield
+    assert not attempts, "Outbound network attempted, even if application swallowed the error"

--- a/tests/agent/test_compressed_tool_arguments_anthropic.py
+++ b/tests/agent/test_compressed_tool_arguments_anthropic.py
@@ -1,0 +1,37 @@
+import json
+
+from agent.anthropic_message_convert import _convert_assistant_message
+from agent.tool_argument_integrity import (
+    INCOMPLETE_TOOL_ARGUMENTS_KEY,
+    neutralize_completed_incomplete_tool_calls,
+)
+
+
+def tc(call_id, marker):
+    args = {INCOMPLETE_TOOL_ARGUMENTS_KEY: {"version": 1}} if marker else {"path": "ok"}
+    return {"id": call_id, "type": "function", "function": {"name": "read_file", "arguments": json.dumps(args)}}
+
+
+def test_anthropic_affected_turn_discards_signed_sidecar_and_keeps_complete_call():
+    messages = [
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [tc("bad", True), tc("good", False)],
+            "anthropic_content_blocks": [
+                {"type": "thinking", "thinking": "private", "signature": "sig"},
+                {"type": "tool_use", "id": "bad", "name": "read_file", "input": {}},
+                {"type": "tool_use", "id": "good", "name": "read_file", "input": {}},
+            ],
+        },
+        {"role": "tool", "tool_call_id": "bad", "content": "blocked"},
+        {"role": "tool", "tool_call_id": "good", "content": "ok"},
+    ]
+    wire = neutralize_completed_incomplete_tool_calls(messages)
+    converted = _convert_assistant_message(wire[0])
+    blocks = converted["content"]
+    assert not any(b.get("type") == "thinking" for b in blocks)
+    assert "anthropic_content_blocks" not in wire[0]
+    assert [b.get("id") for b in blocks if b.get("type") == "tool_use"] == ["good"]
+    assert any("compressed historical tool call" in b.get("text", "") for b in blocks)
+    assert [m.get("tool_call_id") for m in wire if m.get("role") == "tool"] == ["good"]

--- a/tests/agent/test_compressed_tool_arguments_completion.py
+++ b/tests/agent/test_compressed_tool_arguments_completion.py
@@ -1,0 +1,31 @@
+import json
+from unittest.mock import patch
+
+from agent.context_compressor import ContextCompressor
+from agent.tool_argument_integrity import INCOMPLETE_TOOL_ARGUMENTS_KEY
+
+
+def compressor():
+    with patch("agent.context_compressor.get_model_context_length", return_value=100000):
+        return ContextCompressor(model="test", quiet_mode=True)
+
+
+def call(call_id, payload):
+    return {"id": call_id, "type": "function", "function": {"name": "terminal", "arguments": json.dumps(payload)}}
+
+
+def test_pruning_only_marks_completed_large_tool_calls():
+    complete = call("done", {"command": "x" * 1000})
+    pending = call("pending", {"command": "y" * 1000})
+    original_pending = pending["function"]["arguments"]
+    messages = [
+        {"role": "assistant", "tool_calls": [complete]},
+        {"role": "tool", "tool_call_id": "done", "content": "ok"},
+        {"role": "user", "content": "next"},
+        {"role": "assistant", "tool_calls": [pending]},
+        {"role": "user", "content": "interrupted"},
+    ]
+    pruned, _ = compressor()._prune_old_tool_results(messages, protect_tail_count=0)
+    completed_args = json.loads(pruned[0]["tool_calls"][0]["function"]["arguments"])
+    assert INCOMPLETE_TOOL_ARGUMENTS_KEY in completed_args
+    assert pruned[3]["tool_calls"][0]["function"]["arguments"] == original_pending

--- a/tests/agent/test_compressed_tool_arguments_pairing.py
+++ b/tests/agent/test_compressed_tool_arguments_pairing.py
@@ -1,0 +1,51 @@
+import json
+
+from agent.tool_argument_integrity import (
+    INCOMPLETE_TOOL_ARGUMENTS_KEY,
+    neutralize_completed_incomplete_tool_calls,
+)
+
+
+def call(marker=False):
+    args = {INCOMPLETE_TOOL_ARGUMENTS_KEY: {"version": 1}} if marker else {"path": "x"}
+    return {"id": "same", "type": "function", "function": {"name": "read_file", "arguments": json.dumps(args)}}
+
+
+def assistant(marker=False):
+    return {"role": "assistant", "content": "", "tool_calls": [call(marker)]}
+
+
+def test_prior_pair_with_reused_id_does_not_complete_later_marker():
+    messages = [assistant(), {"role": "tool", "tool_call_id": "same", "content": "ok"}, {"role": "user", "content": "later"}, assistant(True)]
+    assert neutralize_completed_incomplete_tool_calls(messages) == messages
+
+
+def test_result_preceding_marker_does_not_complete_it():
+    messages = [{"role": "tool", "tool_call_id": "same", "content": "orphan"}, assistant(True)]
+    assert neutralize_completed_incomplete_tool_calls(messages) == messages
+
+
+def test_duplicate_ids_in_one_batch_remain_fail_closed():
+    messages = [
+        {"role": "assistant", "content": "", "tool_calls": [call(True), call()]},
+        {"role": "tool", "tool_call_id": "same", "content": "ambiguous"},
+    ]
+    assert neutralize_completed_incomplete_tool_calls(messages) == messages
+
+
+def test_duplicate_results_leave_marker_history_unchanged():
+    messages = [
+        assistant(True),
+        {"role": "tool", "tool_call_id": "same", "content": "first"},
+        {"role": "tool", "tool_call_id": "same", "content": "duplicate"},
+    ]
+    assert neutralize_completed_incomplete_tool_calls(messages) == messages
+
+
+def test_preceding_orphan_makes_later_pair_ambiguous():
+    messages = [
+        {"role": "tool", "tool_call_id": "same", "content": "orphan"},
+        assistant(True),
+        {"role": "tool", "tool_call_id": "same", "content": "later"},
+    ]
+    assert neutralize_completed_incomplete_tool_calls(messages) == messages

--- a/tests/agent/test_compressed_tool_arguments_wire_history.py
+++ b/tests/agent/test_compressed_tool_arguments_wire_history.py
@@ -1,0 +1,291 @@
+"""Wire-history regressions for compressed historical tool arguments."""
+
+from __future__ import annotations
+
+import copy
+import json
+
+from agent.codex_responses_adapter import _chat_messages_to_responses_input
+from agent.transports.chat_completions import ChatCompletionsTransport
+from agent.transports.anthropic import AnthropicTransport
+from agent.transports.bedrock import BedrockTransport
+from agent.tool_argument_integrity import neutralize_completed_incomplete_tool_calls
+
+
+MARKER = json.dumps(
+    {
+        "__hermes_incomplete_tool_arguments__": {
+            "arguments_omitted": True,
+            "original_chars": 12345,
+            "reason": "context_compression",
+            "replayable": False,
+            "sha256": "a" * 64,
+            "version": 1,
+        }
+    }
+)
+
+
+def _mixed_history():
+    return [
+        {"role": "user", "content": "inspect both"},
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {
+                    "id": "call_incomplete",
+                    "type": "function",
+                    "function": {"name": "terminal", "arguments": MARKER},
+                },
+                {
+                    "id": "call_complete",
+                    "type": "function",
+                    "function": {
+                        "name": "read_file",
+                        "arguments": '{"path":"README.md"}',
+                    },
+                },
+            ],
+        },
+        {
+            "role": "tool",
+            "tool_call_id": "call_incomplete",
+            "content": '{"error_type":"incomplete_historical_tool_arguments"}',
+        },
+        {
+            "role": "tool",
+            "tool_call_id": "call_complete",
+            "content": "README contents",
+        },
+        {"role": "assistant", "content": "done"},
+        {"role": "user", "content": "continue"},
+    ]
+
+
+def _assert_mixed_pairing_is_safe(payload):
+    serialized = json.dumps(payload)
+    assert "__hermes_incomplete_tool_arguments__" not in serialized
+    assert "call_incomplete" not in serialized
+    assert "call_complete" in serialized
+    assert "README contents" in serialized
+    assert "compressed historical tool call" in serialized.lower()
+
+
+def test_chat_request_copy_neutralizes_completed_marker_call_and_preserves_source():
+    history = _mixed_history()
+    original = copy.deepcopy(history)
+    transport = ChatCompletionsTransport()
+
+    first = transport.convert_messages(history, model="gpt-5.6")
+    second = transport.convert_messages(history, model="gpt-5.6")
+
+    assert first == second  # retries are deterministic
+    assert history == original  # persisted/resumed transcript remains canonical
+    _assert_mixed_pairing_is_safe(first)
+    complete_calls = first[1]["tool_calls"]
+    assert [call["id"] for call in complete_calls] == ["call_complete"]
+    assert [m.get("tool_call_id") for m in first if m.get("role") == "tool"] == [
+        "call_complete"
+    ]
+
+
+def test_codex_response_items_neutralize_completed_marker_call_and_keep_pairing():
+    history = _mixed_history()
+    original = copy.deepcopy(history)
+
+    first = _chat_messages_to_responses_input(history)
+    second = _chat_messages_to_responses_input(history)
+
+    assert first == second
+    assert history == original
+    _assert_mixed_pairing_is_safe(first)
+    function_calls = [item for item in first if item.get("type") == "function_call"]
+    outputs = [item for item in first if item.get("type") == "function_call_output"]
+    assert [item["call_id"] for item in function_calls] == ["call_complete"]
+    assert [item["call_id"] for item in outputs] == ["call_complete"]
+
+
+def test_marker_call_without_completed_result_remains_for_fail_closed_execution_guard():
+    history = _mixed_history()[:2]
+
+    chat = ChatCompletionsTransport().convert_messages(history, model="gpt-5.6")
+    codex = _chat_messages_to_responses_input(history)
+
+    assert "__hermes_incomplete_tool_arguments__" in json.dumps(chat)
+    assert "__hermes_incomplete_tool_arguments__" in json.dumps(codex)
+
+
+def _all_compressed_history(content="I will inspect it.", call_count=1):
+    calls = [
+        {
+            "id": f"call_incomplete_{index}",
+            "type": "function",
+            "function": {"name": "terminal", "arguments": MARKER},
+        }
+        for index in range(call_count)
+    ]
+    results = [
+        {
+            "role": "tool",
+            "tool_call_id": call["id"],
+            "content": "completed",
+        }
+        for call in calls
+    ]
+    return [
+        {"role": "user", "content": "inspect"},
+        {
+            "role": "assistant",
+            "content": content,
+            "tool_calls": calls,
+            "anthropic_content_blocks": [{"type": "text", "text": content}],
+            "codex_message_items": [
+                {
+                    "type": "message",
+                    "role": "assistant",
+                    "content": [{"type": "output_text", "text": content}],
+                }
+            ],
+        },
+        *results,
+        {"role": "assistant", "content": "Inspection finished."},
+        {"role": "user", "content": "continue"},
+    ]
+
+
+def test_all_compressed_chat_history_preserves_role_sequence_and_visible_text():
+    history = _all_compressed_history()
+    original = copy.deepcopy(history)
+    converted = ChatCompletionsTransport().convert_messages(history, model="gpt-5.6")
+
+    assert history == original
+    assert "__hermes_incomplete_tool_arguments__" not in json.dumps(converted)
+    assert all(
+        left.get("role") != "assistant" or right.get("role") != "assistant"
+        for left, right in zip(converted, converted[1:])
+    )
+    assistant_text = "\n".join(
+        str(message.get("content", ""))
+        for message in converted
+        if message.get("role") == "assistant"
+    )
+    assert "I will inspect it." in assistant_text
+    assert "Inspection finished." in assistant_text
+
+
+def test_all_compressed_anthropic_and_bedrock_history_preserves_role_sequence():
+    _system, converted = AnthropicTransport().convert_messages(
+        _all_compressed_history()
+    )
+    assert "__hermes_incomplete_tool_arguments__" not in json.dumps(converted)
+    assert all(
+        left.get("role") != right.get("role")
+        for left, right in zip(converted, converted[1:])
+    )
+
+
+def test_all_compressed_codex_history_has_no_callable_marker():
+    converted = _chat_messages_to_responses_input(_all_compressed_history())
+    serialized = json.dumps(converted)
+    assert "__hermes_incomplete_tool_arguments__" not in serialized
+    assert "I will inspect it." in serialized
+    assert "Inspection finished." in serialized
+
+
+def test_all_compressed_multi_call_history_is_provider_valid():
+    history = _all_compressed_history(call_count=2)
+    chat = ChatCompletionsTransport().convert_messages(history, model="gpt-5.6")
+    _system, anthropic_bedrock = AnthropicTransport().convert_messages(history)
+    codex = _chat_messages_to_responses_input(history)
+
+    for converted in (chat, anthropic_bedrock, codex):
+        assert "__hermes_incomplete_tool_arguments__" not in json.dumps(converted)
+    assert all(
+        left.get("role") != "assistant" or right.get("role") != "assistant"
+        for left, right in zip(chat, chat[1:])
+    )
+    assert all(
+        left.get("role") != right.get("role")
+        for left, right in zip(anthropic_bedrock, anthropic_bedrock[1:])
+    )
+
+
+def test_malformed_non_dict_history_is_dropped_from_every_provider_request():
+    history = _all_compressed_history()[:3] + [None]
+
+    chat = ChatCompletionsTransport().convert_messages(history, model="gpt-5.6")
+    _system, anthropic = AnthropicTransport().convert_messages(history)
+    bedrock = BedrockTransport().build_kwargs(model="anthropic.claude", messages=history)
+
+    assert None not in chat
+    assert all(isinstance(message, dict) for message in anthropic)
+    assert all(isinstance(message, dict) for message in bedrock["messages"])
+
+
+def test_affected_turn_discards_malformed_and_stale_anthropic_sidecars():
+    history = _all_compressed_history()
+    affected = history[1]
+    affected["anthropic_content_blocks"] = [
+        {
+            "type": "tool_use",
+            "id": [],
+            "name": "terminal",
+            "input": {"command": "must never survive"},
+        },
+        {
+            "type": "tool_use",
+            "id": "stale-unmatched",
+            "name": "terminal",
+            "input": {"command": "also must never survive"},
+        },
+        {"type": "thinking", "thinking": "signed after tool", "signature": "sig"},
+    ]
+
+    projected = neutralize_completed_incomplete_tool_calls(history)
+    _system, anthropic = AnthropicTransport().convert_messages(history)
+
+    assert "anthropic_content_blocks" not in projected[1]
+    serialized = json.dumps(anthropic)
+    assert "must never survive" not in serialized
+    assert "also must never survive" not in serialized
+    assert "signed after tool" not in serialized
+    assert '"signature": "sig"' not in serialized
+
+
+def test_affected_turn_discards_all_provider_native_sidecars():
+    history = _all_compressed_history()
+    affected = history[1]
+    affected["reasoning_details"] = [
+        {"type": "thinking", "thinking": "provider native", "signature": "sig"}
+    ]
+    affected["codex_reasoning_items"] = [{"type": "reasoning", "id": "r1"}]
+    affected["codex_message_items"] = [
+        {"type": "message", "role": "assistant", "content": "provider native"}
+    ]
+
+    projected = neutralize_completed_incomplete_tool_calls(history)
+
+    for key in (
+        "anthropic_content_blocks",
+        "reasoning_details",
+        "codex_reasoning_items",
+        "codex_message_items",
+    ):
+        assert key not in projected[1]
+
+
+def test_direct_bedrock_build_kwargs_neutralizes_completed_marker_call():
+    history = _mixed_history()
+    original = copy.deepcopy(history)
+
+    kwargs = BedrockTransport().build_kwargs(
+        model="anthropic.claude-3-5-sonnet", messages=history
+    )
+
+    assert history == original
+    serialized = json.dumps(kwargs)
+    assert "__hermes_incomplete_tool_arguments__" not in serialized
+    assert "call_incomplete" not in serialized
+    assert "call_complete" in serialized
+    assert "README contents" in serialized

--- a/tests/agent/test_compressed_tool_arguments_wire_history.py
+++ b/tests/agent/test_compressed_tool_arguments_wire_history.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import copy
 import json
 
+import pytest
+
 from agent.codex_responses_adapter import _chat_messages_to_responses_input
 from agent.transports.chat_completions import ChatCompletionsTransport
 from agent.transports.anthropic import AnthropicTransport
@@ -160,6 +162,9 @@ def test_all_compressed_chat_history_preserves_role_sequence_and_visible_text():
     converted = ChatCompletionsTransport().convert_messages(history, model="gpt-5.6")
 
     assert history == original
+    assert [m for m in converted if m.get("role") == "user"] == [
+        m for m in original if m.get("role") == "user"
+    ]
     assert "__hermes_incomplete_tool_arguments__" not in json.dumps(converted)
     assert all(
         left.get("role") != "assistant" or right.get("role") != "assistant"
@@ -289,3 +294,57 @@ def test_direct_bedrock_build_kwargs_neutralizes_completed_marker_call():
     assert "call_incomplete" not in serialized
     assert "call_complete" in serialized
     assert "README contents" in serialized
+
+
+@pytest.mark.parametrize("shape", ["text", "blocks", "empty", "chain", "mixed", "orphan"])
+def test_projection_preserves_authorship_across_removed_tool_boundaries(shape):
+    history = _all_compressed_history()
+    if shape == "blocks":
+        history[1]["content"] = [{"type": "text", "text": "first block"}]
+        history[3]["content"] = [{"type": "text", "text": "second block"}]
+    elif shape == "empty":
+        history[1]["content"] = None
+    elif shape == "chain":
+        more = _all_compressed_history("second round")[1:3]
+        more[0]["tool_calls"][0]["id"] = "round_two"
+        more[1]["tool_call_id"] = "round_two"
+        history[3:3] = more
+    elif shape == "mixed":
+        history[3:4] = _mixed_history()[1:5]
+    elif shape == "orphan":
+        history.insert(2, {"role": "tool", "tool_call_id": "unknown", "content": "orphan"})
+    history.insert(0, {"role": "system", "content": "byte-stable instructions"})
+    original = copy.deepcopy(history)
+    projected = neutralize_completed_incomplete_tool_calls(history)
+    assert history == original
+    assert neutralize_completed_incomplete_tool_calls(projected) == projected
+    assert [m for m in projected if m["role"] in {"user", "system"}] == [
+        m for m in history if m["role"] in {"user", "system"}
+    ]
+    assert [m for m in projected if m["role"] == "tool"] == [
+        m for m in history if m.get("tool_call_id") in {"unknown", "call_complete"}
+    ]
+    assert all(a["role"] != "assistant" or b["role"] != "assistant"
+               for a, b in zip(projected, projected[1:]))
+    visible = json.dumps([m.get("content") for m in projected if m["role"] == "assistant"])
+    for message in history:
+        if message["role"] == "assistant" and message.get("content"):
+            content = message["content"]
+            texts = [p["text"] for p in content] if isinstance(content, list) else [content]
+            assert all(text in visible for text in texts)
+    assert "__hermes_incomplete_tool_arguments__" not in json.dumps(projected)
+    # All-compressed histories have no tool-result user blocks, so actual user
+    # utterances can also be compared through every real provider converter.
+    if shape not in {"mixed", "orphan"}:
+        conversions = [
+            ChatCompletionsTransport().convert_messages(history, model="gpt-5.6"),
+            _chat_messages_to_responses_input(history),
+            AnthropicTransport().convert_messages(history)[1],
+            BedrockTransport().build_kwargs(model="anthropic.claude", messages=history)["messages"],
+        ]
+        for converted in conversions:
+            users = [m for m in converted if m.get("role") == "user"]
+            assert len(users) == 2
+            assert "inspect" in json.dumps(users[0])
+            assert "continue" in json.dumps(users[1])
+            assert "compressed historical tool call" not in json.dumps(users)

--- a/tests/agent/test_context_compressor.py
+++ b/tests/agent/test_context_compressor.py
@@ -2311,59 +2311,86 @@ class TestThresholdTokensCap:
 
 
 class TestTruncateToolCallArgsJson:
-    """Regression tests for #11762.
+    """Historical large tool arguments are non-replayable and auditable.
 
-    The previous implementation produced invalid JSON by slicing
-    ``function.arguments`` mid-string, which caused non-retryable 400s from
-    strict providers (observed on MiniMax) and stuck long sessions in a
-    re-send loop. The helper here must always emit parseable JSON whose
-    shape matches the original — shrunken, not corrupted.
+    Compression must never turn an executed command, patch, or write into a
+    plausible shortened operation that a later model can copy and execute.
     """
 
     def _helper(self):
         from agent.context_compressor import _truncate_tool_call_args_json
         return _truncate_tool_call_args_json
 
-    def test_shrunken_args_remain_valid_json(self):
+    def test_large_args_become_non_replayable_provenance(self):
+        import hashlib
         import json as _json
+
         shrink = self._helper()
         original = _json.dumps({
             "path": "~/.hermes/skills/shopping/browser-setup-notes.md",
             "content": "# Shopping Browser Setup Notes\n\n" + "abc " * 400,
         })
-        assert len(original) > 500
         shrunk = shrink(original)
-        parsed = _json.loads(shrunk)  # must not raise
-        assert parsed["path"] == "~/.hermes/skills/shopping/browser-setup-notes.md"
-        assert parsed["content"].endswith("...[truncated]")
+        parsed = _json.loads(shrunk)
+
+        assert set(parsed) == {"__hermes_incomplete_tool_arguments__"}
+        provenance = parsed["__hermes_incomplete_tool_arguments__"]
+        assert provenance["arguments_omitted"] is True
+        assert provenance["replayable"] is False
+        assert provenance["original_chars"] == len(original)
+        assert provenance["sha256"] == hashlib.sha256(original.encode()).hexdigest()
+        assert "path" not in parsed
+        assert "content" not in parsed
+        assert "...[truncated]" not in shrunk
         assert len(shrunk) < len(original)
 
-
-
-
-    def test_non_string_leaves_preserved(self):
+    def test_hashing_is_deterministic_for_non_bmp_and_lone_surrogates(self):
+        import hashlib
         import json as _json
+
         shrink = self._helper()
-        payload = _json.dumps({
-            "retries": 3,
-            "enabled": True,
-            "timeout": None,
-            "items": [1, 2, 3],
-            "note": "z" * 500,
-        })
-        parsed = _json.loads(shrink(payload))
-        assert parsed["retries"] == 3
-        assert parsed["enabled"] is True
-        assert parsed["timeout"] is None
-        assert parsed["items"] == [1, 2, 3]
-        assert parsed["note"].endswith("...[truncated]")
+        for text in ("😀" * 600, "\ud800" * 600):
+            original = _json.dumps({"content": text}, ensure_ascii=False)
+            provenance = _json.loads(shrink(original))[
+                "__hermes_incomplete_tool_arguments__"
+            ]
+            assert provenance["sha256"] == hashlib.sha256(
+                original.encode("utf-8", errors="surrogatepass")
+            ).hexdigest()
 
-
-
-    def test_pass3_emits_valid_json_for_downstream_provider(self):
-        """End-to-end: Pass 3 must never produce the exact failure payload
-        that caused the 400 loop (unterminated string, missing brace)."""
+    def test_operation_shapes_are_never_partially_preserved(self):
         import json as _json
+
+        shrink = self._helper()
+        payloads = [
+            {"command": "python3 -c " + "x" * 800},
+            {"mode": "replace", "path": "/tmp/a", "old_string": "a" * 600, "new_string": "b" * 600},
+            {"path": "/tmp/a", "content": "literal ...[truncated] marker\n" + "z" * 800},
+            {"code": "print('start')\n" + "pass\n" * 300},
+        ]
+        for payload in payloads:
+            parsed = _json.loads(shrink(_json.dumps(payload)))
+            assert set(parsed) == {"__hermes_incomplete_tool_arguments__"}
+            assert parsed["__hermes_incomplete_tool_arguments__"]["replayable"] is False
+
+    def test_short_legitimate_marker_content_is_preserved(self):
+        import json as _json
+
+        original = _json.dumps({"content": "Documentation containing ...[truncated] literally."})
+        assert self._helper()(original) == original
+
+    def test_invalid_non_json_arguments_are_preserved(self):
+        original = "provider-specific non-json arguments"
+        assert self._helper()(original) == original
+
+    def test_helper_exposes_no_ignored_truncation_parameter(self):
+        import inspect
+
+        assert list(inspect.signature(self._helper()).parameters) == ["args"]
+
+    def test_pass3_emits_valid_non_replayable_json(self):
+        import json as _json
+
         with patch("agent.context_compressor.get_model_context_length", return_value=100000):
             c = ContextCompressor(
                 model="test/model",
@@ -2377,7 +2404,6 @@ class TestTruncateToolCallArgsJson:
             "path": "~/.hermes/skills/shopping/browser-setup-notes.md",
             "content": huge_content,
         })
-        assert len(args_payload) > 500  # triggers the Pass-3 shrink
         messages = [
             {"role": "user", "content": "please write two files"},
             {"role": "assistant", "content": None, "tool_calls": [
@@ -2391,10 +2417,9 @@ class TestTruncateToolCallArgsJson:
         ]
         result, _ = c._prune_old_tool_results(messages, protect_tail_count=2)
         shrunk = result[1]["tool_calls"][0]["function"]["arguments"]
-        # Must parse — otherwise downstream provider returns 400
         parsed = _json.loads(shrunk)
-        assert parsed["path"] == "~/.hermes/skills/shopping/browser-setup-notes.md"
-        assert parsed["content"].endswith("...[truncated]")
+        assert set(parsed) == {"__hermes_incomplete_tool_arguments__"}
+        assert parsed["__hermes_incomplete_tool_arguments__"]["replayable"] is False
 
 
 class TestLazyContextResolution:

--- a/tests/agent/test_tool_executor_argument_integrity.py
+++ b/tests/agent/test_tool_executor_argument_integrity.py
@@ -1,0 +1,222 @@
+"""Fail-closed execution tests for compressed historical tool arguments."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from agent.tool_argument_integrity import (
+    incomplete_tool_arguments_after_schema_decode,
+    incomplete_tool_arguments_error_result,
+)
+from agent.tool_executor import _parse_tool_arguments
+from tools.tool_search import resolve_underlying_call
+
+
+RESERVED = "__hermes_incomplete_tool_arguments__"
+
+
+@pytest.mark.parametrize(
+    "shape",
+    [
+        {"command": "python -c 'print(1)'"},
+        {"path": "/tmp/read-only.txt", "offset": 1, "limit": 100},
+        {"path": "/tmp/a", "content": "payload"},
+        {"mode": "replace", "path": "/tmp/a", "old_string": "a", "new_string": "b"},
+    ],
+)
+def test_incomplete_provenance_blocks_operation_shapes(shape):
+    shape[RESERVED] = {
+        "version": 1,
+        "reason": "context_compression",
+        "replayable": False,
+    }
+    arguments, error = _parse_tool_arguments(json.dumps(shape))
+
+    assert arguments == {}
+    parsed_error = json.loads(error or "{}")
+    assert parsed_error["error_type"] == "incomplete_historical_tool_arguments"
+    assert "not executed" in parsed_error["message"]
+
+
+def test_nested_or_malformed_reserved_provenance_fails_closed():
+    for payload in (
+        {"outer": [{RESERVED: {"version": 1}}]},
+        {RESERVED: "malformed"},
+        {RESERVED: None},
+    ):
+        arguments, error = _parse_tool_arguments(json.dumps(payload))
+        assert arguments == {}
+        assert json.loads(error or "{}")["error_type"] == "incomplete_historical_tool_arguments"
+
+
+def test_literal_truncation_marker_is_not_treated_as_provenance():
+    payload = {
+        "path": "/tmp/a",
+        "content": "Documentation containing ...[truncated] literally.",
+    }
+    arguments, error = _parse_tool_arguments(json.dumps(payload))
+
+    assert error is None
+    assert arguments == payload
+
+
+def test_string_encoded_deferred_arguments_are_blocked_after_unwrap():
+    from tools.registry import registry
+
+    deferred_name = "mcp__integrity_probe__run"
+    registry.register(
+        name=deferred_name,
+        toolset="mcp-integrity-probe",
+        schema={
+            "name": deferred_name,
+            "description": "Integrity probe",
+            "parameters": {"type": "object", "properties": {}},
+        },
+        handler=lambda args, **kwargs: "{}",
+    )
+    outer = {
+        "name": deferred_name,
+        "arguments": json.dumps(
+            {
+                RESERVED: {
+                    "version": 1,
+                    "reason": "context_compression",
+                    "replayable": False,
+                }
+            }
+        ),
+    }
+    parsed, error = _parse_tool_arguments(json.dumps(outer))
+    assert error is None
+
+    _name, underlying, resolve_error = resolve_underlying_call(parsed)
+    assert resolve_error is None
+    result = incomplete_tool_arguments_error_result(underlying)
+    assert result is not None
+    parsed_result = json.loads(result)
+    assert parsed_result["error_type"] == "incomplete_historical_tool_arguments"
+    assert "not executed" in parsed_result["message"]
+
+
+def test_schema_coercion_cannot_materialize_incomplete_provenance_before_dispatch(monkeypatch):
+    import model_tools
+    from tools.registry import registry
+
+    tool_name = "integrity_schema_coercion_probe"
+    registry.register(
+        name=tool_name,
+        toolset="integrity-probe",
+        schema={
+            "name": tool_name,
+            "description": "Integrity coercion probe",
+            "parameters": {
+                "type": "object",
+                "properties": {"items": {"type": "array"}},
+            },
+        },
+        handler=lambda args, **kwargs: "should not run",
+    )
+    dispatches = []
+    monkeypatch.setattr(
+        registry,
+        "dispatch",
+        lambda name, args, **kwargs: dispatches.append((name, args)) or "dispatched",
+    )
+    encoded = json.dumps([
+        {
+            RESERVED: {
+                "version": 1,
+                "reason": "context_compression",
+                "replayable": False,
+            }
+        }
+    ])
+
+    result = model_tools.handle_function_call(
+        tool_name,
+        {"items": encoded},
+        skip_pre_tool_call_hook=True,
+        skip_tool_request_middleware=True,
+        skip_tool_execution_middleware=True,
+    )
+
+    assert dispatches == []
+    parsed = json.loads(result)
+    assert parsed["error_type"] == "incomplete_historical_tool_arguments"
+    assert "not executed" in parsed["message"]
+
+
+def test_root_union_without_direct_type_is_not_preview_decoded():
+    encoded = json.dumps([{RESERVED: {"version": 1, "replayable": False}}])
+    schema = {
+        "type": "object",
+        "properties": {
+            "items": {
+                "anyOf": [
+                    {"type": "array", "items": {"type": "object"}},
+                    {"type": "string"},
+                ]
+            }
+        },
+    }
+
+    assert incomplete_tool_arguments_after_schema_decode(
+        {"items": encoded}, schema
+    ) is None
+
+
+def test_root_type_list_is_preview_decoded_like_runtime():
+    encoded = json.dumps([{RESERVED: {"version": 1, "replayable": False}}])
+    schema = {
+        "type": "object",
+        "properties": {
+            "items": {
+                "type": ["array", "string"],
+                "items": {"type": "object"},
+            }
+        },
+    }
+
+    result = incomplete_tool_arguments_after_schema_decode(
+        {"items": encoded}, schema
+    )
+    assert json.loads(result or "{}")["error_type"] == "incomplete_historical_tool_arguments"
+
+
+def test_native_type_list_container_is_not_recursively_preview_decoded():
+    encoded_item = json.dumps({RESERVED: {"version": 1, "replayable": False}})
+    schema = {
+        "type": "object",
+        "properties": {
+            "items": {
+                "type": ["array", "string"],
+                "items": {"type": "object"},
+            }
+        },
+    }
+
+    assert incomplete_tool_arguments_after_schema_decode(
+        {"items": [encoded_item]}, schema
+    ) is None
+
+
+def test_nested_union_items_remain_preview_decoded():
+    encoded = json.dumps({RESERVED: {"version": 1, "replayable": False}})
+    schema = {
+        "type": "object",
+        "properties": {
+            "items": {
+                "type": "array",
+                "items": {
+                    "oneOf": [{"type": "object"}, {"type": "string"}]
+                },
+            }
+        },
+    }
+
+    result = incomplete_tool_arguments_after_schema_decode(
+        {"items": [encoded]}, schema
+    )
+    assert json.loads(result or "{}")["error_type"] == "incomplete_historical_tool_arguments"

--- a/tests/agent/test_tool_executor_argument_integrity.py
+++ b/tests/agent/test_tool_executor_argument_integrity.py
@@ -220,3 +220,33 @@ def test_nested_union_items_remain_preview_decoded():
         {"items": [encoded]}, schema
     )
     assert json.loads(result or "{}")["error_type"] == "incomplete_historical_tool_arguments"
+
+@pytest.mark.parametrize("array_type", ["array", ["array", "string"]])
+@pytest.mark.parametrize("encoded", [False, True])
+@pytest.mark.parametrize("item", ["literal", "provenance", "malformed"])
+def test_schema_integrity_preview_matches_runtime_array_strings(
+    monkeypatch, array_type, encoded, item
+):
+    from copy import deepcopy
+    from tools.arg_coercion import coerce_tool_args
+    from tools.registry import registry
+
+    marker = {RESERVED: {"version": 1, "replayable": False}}
+    value = {"literal": json.dumps(marker), "provenance": marker,
+             "malformed": "[not json"}[item]
+    items = [value]
+    args = {"items": json.dumps(items) if encoded else items}
+    original = deepcopy(args)
+    parameters = {
+        "type": "object",
+        "properties": {"items": {
+            "type": array_type,
+            "items": {"oneOf": [{"type": "object"}, {"type": "string"}]},
+        }},
+    }
+    monkeypatch.setattr(registry, "get_schema", lambda name: {"parameters": parameters})
+    runtime = coerce_tool_args("parity_probe", deepcopy(args))
+    assert incomplete_tool_arguments_after_schema_decode(args, parameters) == (
+        incomplete_tool_arguments_error_result(runtime)
+    )
+    assert args == original

--- a/tests/agent/test_tool_executor_integrity_lifecycle.py
+++ b/tests/agent/test_tool_executor_integrity_lifecycle.py
@@ -1,0 +1,293 @@
+"""Lifecycle rejection tests for incomplete historical tool calls."""
+
+import json
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from tests.run_agent.test_run_agent import agent, _mock_assistant_msg, _mock_tool_call
+
+RESERVED = "__hermes_incomplete_tool_arguments__"
+
+
+def _run(agent, concurrent, call, messages):
+    msg = _mock_assistant_msg(content="", tool_calls=[call])
+    method = agent._execute_tool_calls_concurrent if concurrent else agent._execute_tool_calls_sequential
+    method(msg, messages, "task-1")
+
+
+@pytest.mark.parametrize("concurrent", [False, True])
+def test_initial_rejection_skips_hooks_and_callbacks(agent, monkeypatch, concurrent):
+    events = []
+    monkeypatch.setattr("hermes_cli.lifecycle.has_hook", lambda name: True)
+    monkeypatch.setattr(
+        "hermes_cli.lifecycle.invoke_hook",
+        lambda *args, **kwargs: events.append("hook") or [],
+    )
+    agent.tool_progress_callback = lambda *args, **kwargs: events.append("progress")
+    agent.tool_start_callback = lambda *args, **kwargs: events.append("start")
+    agent.tool_complete_callback = lambda *args, **kwargs: events.append("complete")
+    agent._touch_activity = lambda *args, **kwargs: events.append("activity")
+    payload = {RESERVED: {"version": 1, "replayable": False}}
+    call = _mock_tool_call(name="terminal", arguments=json.dumps(payload), call_id="c1")
+    messages = []
+    with patch("model_tools.handle_function_call", side_effect=AssertionError("dispatch")):
+        _run(agent, concurrent, call, messages)
+    assert events == []
+    assert len(messages) == 1
+    assert json.loads(messages[0]["content"])["error_type"] == "incomplete_historical_tool_arguments"
+
+
+@pytest.mark.parametrize("concurrent", [False, True])
+def test_deferred_rejection_skips_middleware_hooks_and_callbacks(
+    agent, monkeypatch, concurrent
+):
+    from tools.registry import registry
+    from tools.tool_search import TOOL_CALL_NAME
+
+    events = []
+    tool_name = "mcp__integrity_lifecycle__run"
+    registry.register(
+        name=tool_name,
+        toolset="integrity-lifecycle",
+        schema={
+            "name": tool_name,
+            "description": "probe",
+            "parameters": {"type": "object", "properties": {}},
+        },
+        handler=lambda args, **kwargs: events.append("handler") or "handled",
+    )
+    middleware = lambda **kwargs: events.append("middleware") or None
+    manager = SimpleNamespace(
+        _middleware={"tool_request": [middleware], "tool_execution": [middleware]}
+    )
+    monkeypatch.setattr("hermes_cli.plugins.get_plugin_manager", lambda: manager)
+    monkeypatch.setattr("hermes_cli.lifecycle.has_hook", lambda name: True)
+    monkeypatch.setattr(
+        "hermes_cli.lifecycle.invoke_hook",
+        lambda *args, **kwargs: events.append("hook") or [],
+    )
+    agent.tool_progress_callback = lambda *args, **kwargs: events.append("progress")
+    agent.tool_start_callback = lambda *args, **kwargs: events.append("start")
+    agent.tool_complete_callback = lambda *args, **kwargs: events.append("complete")
+    agent._touch_activity = lambda *args, **kwargs: events.append("activity")
+    inner = json.dumps({RESERVED: {"version": 1, "replayable": False}})
+    outer = json.dumps({"name": tool_name, "arguments": inner})
+    call = _mock_tool_call(name=TOOL_CALL_NAME, arguments=outer, call_id="c1")
+    messages = []
+    with patch("model_tools.handle_function_call", side_effect=AssertionError("dispatch")):
+        _run(agent, concurrent, call, messages)
+    assert events == []
+    assert len(messages) == 1
+    result = json.loads(messages[0]["content"])
+    assert result["error_type"] == "incomplete_historical_tool_arguments"
+
+
+@pytest.mark.parametrize("concurrent", [False, True])
+def test_schema_decoded_rejection_skips_lifecycle(agent, monkeypatch, concurrent):
+    from tools.registry import registry
+
+    events = []
+    tool_name = "integrity_schema_lifecycle_probe"
+    registry.register(
+        name=tool_name,
+        toolset="integrity-lifecycle",
+        schema={
+            "name": tool_name,
+            "description": "probe",
+            "parameters": {
+                "type": "object",
+                "properties": {"items": {"type": "array"}},
+            },
+        },
+        handler=lambda args, **kwargs: events.append("handler") or "handled",
+    )
+    middleware = lambda **kwargs: events.append("middleware") or None
+    manager = SimpleNamespace(
+        _middleware={"tool_request": [middleware], "tool_execution": [middleware]}
+    )
+    monkeypatch.setattr("hermes_cli.plugins.get_plugin_manager", lambda: manager)
+    monkeypatch.setattr("hermes_cli.lifecycle.has_hook", lambda name: True)
+    monkeypatch.setattr(
+        "hermes_cli.lifecycle.invoke_hook",
+        lambda *args, **kwargs: events.append("hook") or [],
+    )
+    agent.tool_progress_callback = lambda *args, **kwargs: events.append("progress")
+    agent.tool_start_callback = lambda *args, **kwargs: events.append("start")
+    agent.tool_complete_callback = lambda *args, **kwargs: events.append("complete")
+    agent._touch_activity = lambda *args, **kwargs: events.append("activity")
+    encoded = json.dumps([{RESERVED: {"version": 1, "replayable": False}}])
+    call = _mock_tool_call(
+        name=tool_name,
+        arguments=json.dumps({"items": encoded}),
+        call_id="c1",
+    )
+    messages = []
+    with patch("model_tools.handle_function_call", side_effect=AssertionError("dispatch")):
+        _run(agent, concurrent, call, messages)
+    assert events == []
+    assert json.loads(messages[0]["content"])["error_type"] == "incomplete_historical_tool_arguments"
+
+
+@pytest.mark.parametrize("concurrent", [False, True])
+def test_escaped_schema_decoded_marker_skips_lifecycle(agent, monkeypatch, concurrent):
+    from tools.registry import registry
+
+    events = []
+    tool_name = "integrity_escaped_schema_lifecycle_probe"
+    registry.register(
+        name=tool_name,
+        toolset="integrity-lifecycle",
+        schema={
+            "name": tool_name,
+            "description": "probe",
+            "parameters": {
+                "type": "object",
+                "properties": {"items": {"type": "array"}},
+            },
+        },
+        handler=lambda args, **kwargs: events.append("handler") or "handled",
+    )
+    monkeypatch.setattr("hermes_cli.lifecycle.has_hook", lambda name: True)
+    monkeypatch.setattr(
+        "hermes_cli.lifecycle.invoke_hook",
+        lambda *args, **kwargs: events.append("hook") or [],
+    )
+    encoded = '[{"__hermes_incomplete_tool_argument\\u0073__":{"version":1}}]'
+    raw_arguments = json.dumps({"items": encoded})
+    assert RESERVED not in raw_arguments
+    call = _mock_tool_call(name=tool_name, arguments=raw_arguments, call_id="escaped")
+    messages = []
+    with patch("model_tools.handle_function_call", side_effect=AssertionError("dispatch")):
+        _run(agent, concurrent, call, messages)
+    assert events == []
+    assert json.loads(messages[0]["content"])["error_type"] == "incomplete_historical_tool_arguments"
+
+
+@pytest.mark.parametrize("concurrent", [False, True])
+def test_interrupt_does_not_bypass_integrity_rejection(agent, monkeypatch, concurrent):
+    events = []
+    monkeypatch.setattr("hermes_cli.lifecycle.has_hook", lambda name: True)
+    monkeypatch.setattr(
+        "hermes_cli.lifecycle.invoke_hook",
+        lambda *args, **kwargs: events.append("hook") or [],
+    )
+    agent.tool_complete_callback = lambda *args, **kwargs: events.append("complete")
+    agent._interrupt_requested = True
+    payload = {RESERVED: {"version": 1, "replayable": False}}
+    call = _mock_tool_call(name="terminal", arguments=json.dumps(payload), call_id="interrupted")
+    messages = []
+    with patch("model_tools.handle_function_call", side_effect=AssertionError("dispatch")):
+        _run(agent, concurrent, call, messages)
+    assert events == []
+    assert json.loads(messages[0]["content"])["error_type"] == "incomplete_historical_tool_arguments"
+
+
+@pytest.mark.parametrize("concurrent", [False, True])
+def test_interrupt_rejects_deferred_incomplete_arguments(agent, monkeypatch, concurrent):
+    from tools import tool_search
+    from tools.registry import registry
+
+    events = []
+    registry.register(
+        name="mcp__integrity_probe__run",
+        toolset="mcp-integrity-probe",
+        schema={
+            "name": "mcp__integrity_probe__run",
+            "description": "probe",
+            "parameters": {"type": "object", "properties": {}},
+        },
+        handler=lambda args, **kwargs: events.append("handler") or "handled",
+    )
+    agent._interrupt_requested = True
+    monkeypatch.setattr("hermes_cli.lifecycle.has_hook", lambda name: True)
+    monkeypatch.setattr(
+        "hermes_cli.lifecycle.invoke_hook",
+        lambda *args, **kwargs: events.append("hook") or [],
+    )
+    outer = {
+        "name": "mcp__integrity_probe__run",
+        "arguments": json.dumps(
+            {RESERVED: {"version": 1, "replayable": False}}
+        ),
+    }
+    call = _mock_tool_call(
+        name=tool_search.TOOL_CALL_NAME,
+        arguments=json.dumps(outer),
+        call_id="deferred-interrupted",
+    )
+    messages = []
+    with patch("model_tools.handle_function_call", side_effect=AssertionError("dispatch")):
+        _run(agent, concurrent, call, messages)
+    assert events == []
+    assert json.loads(messages[0]["content"])["error_type"] == "incomplete_historical_tool_arguments"
+
+
+def test_concurrent_spinner_counts_only_runnable_calls(agent, monkeypatch):
+    spinner_texts = []
+    completion_texts = []
+
+    class SpinnerProbe:
+        @staticmethod
+        def get_waiting_faces():
+            return ["face"]
+
+        def __init__(self, text, **kwargs):
+            del kwargs
+            spinner_texts.append(text)
+
+        def start(self):
+            pass
+
+        def stop(self, text=None):
+            completion_texts.append(text)
+
+    monkeypatch.setattr("agent.tool_executor.KawaiiSpinner", SpinnerProbe)
+    monkeypatch.setattr(agent, "_should_emit_quiet_tool_messages", lambda: True)
+    monkeypatch.setattr(agent, "_should_start_quiet_spinner", lambda: True)
+    blocked = _mock_tool_call(
+        name="terminal",
+        arguments=json.dumps({RESERVED: {"version": 1, "replayable": False}}),
+        call_id="blocked",
+    )
+    runnable = _mock_tool_call(
+        name="web_search",
+        arguments=json.dumps({"query": "Hermes"}),
+        call_id="runnable",
+    )
+    message = _mock_assistant_msg(content="", tool_calls=[blocked, runnable])
+
+    with patch("model_tools.handle_function_call", return_value="ok"):
+        agent._execute_tool_calls_concurrent(message, [], "task-1")
+
+    assert len(spinner_texts) == 1
+    assert "running 1 tools concurrently" in spinner_texts[0]
+    assert len(completion_texts) == 1
+    assert completion_texts[0].startswith("⚡ 1/1 tools completed")
+
+
+@pytest.mark.parametrize("concurrent", [False, True])
+def test_clean_arguments_skip_schema_integrity_preview(
+    agent, monkeypatch, concurrent
+):
+    call = _mock_tool_call(
+        name="web_search",
+        arguments=json.dumps({"query": "Hermes"}),
+        call_id="clean",
+    )
+    messages = []
+    monkeypatch.setattr(
+        "agent.tool_executor._schema_decoded_integrity_result",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("schema preview should be skipped")
+        ),
+    )
+
+    with patch("model_tools.handle_function_call", return_value="ok") as dispatch:
+        _run(agent, concurrent, call, messages)
+    dispatch.assert_called_once()
+    assert dispatch.call_args.args[:2] == ("web_search", {"query": "Hermes"})
+
+    assert len(messages) == 1
+    assert messages[0]["content"] == "ok"

--- a/tests/agent/test_tool_executor_integrity_lifecycle.py
+++ b/tests/agent/test_tool_executor_integrity_lifecycle.py
@@ -291,3 +291,45 @@ def test_clean_arguments_skip_schema_integrity_preview(
 
     assert len(messages) == 1
     assert messages[0]["content"] == "ok"
+
+
+@pytest.mark.parametrize("concurrent", [False, True])
+@pytest.mark.parametrize("encoded", [False, True])
+@pytest.mark.parametrize("array_type", ["array", ["array", "string"]])
+def test_literal_array_item_follows_runtime_coercion_through_dispatch(
+    agent, monkeypatch, concurrent, encoded, array_type
+):
+    from copy import deepcopy
+    from tools.arg_coercion import coerce_tool_args
+    from tools.registry import registry
+
+    name = "integrity_literal_array_probe"
+    handled = []
+    monkeypatch.setattr("hermes_cli.lifecycle.has_hook", lambda name: False)
+    monkeypatch.setattr("hermes_cli.plugins.get_plugin_manager",
+                        lambda: SimpleNamespace(_middleware={}))
+    registry.register(
+        name=name, toolset="integrity-lifecycle",
+        schema={"name": name, "description": "Local literal-string probe",
+                "parameters": {"type": "object", "properties": {"items": {
+                    "type": array_type,
+                    "items": {"oneOf": [{"type": "object"}, {"type": "string"}]},
+                }}}},
+        handler=lambda args, **kwargs: handled.append(deepcopy(args)) or "ok",
+    )
+    items = [json.dumps({RESERVED: {"version": 1}})]
+    args = {"items": json.dumps(items) if encoded else items}
+    runtime = coerce_tool_args(name, deepcopy(args))
+    # The real dispatcher/coercer/registry path runs only this local handler.
+    from agent.tool_argument_integrity import incomplete_tool_arguments_error_result
+    expected_error = incomplete_tool_arguments_error_result(runtime)
+    messages = []
+    call = _mock_tool_call(name=name, arguments=json.dumps(args), call_id="literal")
+    _run(agent, concurrent, call, messages)
+    assert len(messages) == 1
+    if expected_error is None:
+        assert handled == [runtime]
+        assert messages[0]["content"] == "ok"
+    else:
+        assert handled == []
+        assert messages[0]["content"] == expected_error


### PR DESCRIPTION
## Summary

- replace lossy context-compression argument placeholders with structured, non-replayable provenance
- reject incomplete historical arguments at the initial parser, deferred tool-search unwrap, and schema-guided coercion boundaries
- skip activity/current-tool mutation, spinner, relay, middleware, lifecycle hooks, callbacks, checkpoints, guardrails, and dispatch for those rejections while still appending the required protocol tool result
- preserve ordinary literal text containing `...[truncated]` and JSON-like strings that are not schema-coerced

## Why

A compressed historical tool call can remain in canonical context for provider continuity. Its original arguments are no longer available, so replaying a lossy placeholder can produce an unintended invocation. This change makes that state explicit and fail-closed without treating normal truncation text as provenance.

## Test plan

- `uv run --with pytest --with anthropic python -m pytest -q tests/agent/test_context_compressor.py tests/agent/test_tool_executor_argument_integrity.py tests/agent/test_tool_executor_integrity_lifecycle.py tests/agent/test_canon_args_memo_parity.py tests/run_agent/test_tool_call_guardrail_runtime.py tests/run_agent/test_run_agent.py tests/tools/test_code_execution.py`
  - 476 passed, 5 subtests passed
- `uvx ruff check` on changed production and test files
- `python3 -m py_compile` on changed Python files
- `git diff --check origin/main..HEAD`

The broader test command emits one existing `PytestUnhandledThreadExceptionWarning` from `_BarrierDB.flush_token_counts`; it still exits successfully.
