### PR TITLE
fix: fail closed on malformed base URL hosts

### DIFF
--- a/tests/test_base_url_hostname.py
+++ b/tests/test_base_url_hostname.py
@@ -43,6 +43,13 @@ def test_port_is_ignored():
     assert base_url_hostname("https://api.openai.com:443/v1") == "api.openai.com"
 
 
+def test_malformed_ipv6_url_fails_closed():
+    malformed = "http://[::1"
+
+    assert base_url_hostname(malformed) == ""
+    assert base_url_host_matches(malformed, "api.openai.com") is False
+
+
 
 
 # ─── base_url_host_matches ────────────────────────────────────────────────
@@ -117,4 +124,3 @@ class TestOllamaUrlHostCheck:
         assert base_url_host_matches(
             "https://ollama.com/api/generate", "ollama.com"
         ) is True
-

--- a/utils.py
+++ b/utils.py
@@ -861,8 +861,13 @@ def base_url_hostname(base_url: str) -> str:
     raw = (base_url or "").strip()
     if not raw:
         return ""
-    parsed = urlparse(raw if "://" in raw else f"//{raw}")
-    return (parsed.hostname or "").lower().rstrip(".")
+    try:
+        parsed = urlparse(raw if "://" in raw else f"//{raw}")
+        return (parsed.hostname or "").lower().rstrip(".")
+    except ValueError:
+        # urllib rejects malformed bracketed IPv6 netlocs. Provider routing
+        # is a hostname classification step, so invalid input is no match.
+        return ""
 
 
 # ─── Model Capability Detection ──────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- contain `urllib.parse.ValueError` in the shared base-URL hostname classifier
- treat malformed bracketed IPv6 URLs as no hostname/no provider match
- add regression coverage for both hostname extraction and domain matching

## Root cause and impact

`urlparse()` raises `ValueError: Invalid IPv6 URL` for an unmatched IPv6 bracket. `base_url_hostname()` did not contain that exception even though its contract returns `""` when a hostname is unavailable. Because provider routing and `AIAgent.base_url` initialization use this helper, a malformed custom endpoint could abort initialization during classification instead of reaching the normal validation/client error path.

The fix fails closed: invalid input returns `""`, so it cannot be classified as any known provider host. Existing valid-host behavior is unchanged.

Fixes #87219

## Validation

```text
scripts/run_tests.sh tests/test_base_url_hostname.py tests/hermes_cli/test_base_url_host_identity.py -q
28 passed

ruff check utils.py tests/test_base_url_hostname.py
All checks passed!

git diff --check
(clean)
```