### PR TITLE
feat(auth): add Codex credential usage admission limits

### DIFF
--- a/agent/account_usage.py
+++ b/agent/account_usage.py
@@ -9,7 +9,12 @@ from typing import TYPE_CHECKING, Any, Optional
 import httpx
 
 from agent.anthropic_adapter import _is_oauth_token, resolve_anthropic_token
-from hermes_cli.auth import AuthError, _read_codex_tokens, resolve_codex_runtime_credentials
+from hermes_cli.auth import (
+    AuthError,
+    _decode_jwt_claims,
+    _read_codex_tokens,
+    resolve_codex_runtime_credentials,
+)
 from hermes_cli.runtime_provider import resolve_runtime_provider
 
 if TYPE_CHECKING:
@@ -28,6 +33,7 @@ class AccountUsageWindow:
     used_percent: Optional[float] = None
     reset_at: Optional[datetime] = None
     detail: Optional[str] = None
+    limit_window_seconds: Optional[int] = None
 
 
 @dataclass(frozen=True)
@@ -40,6 +46,7 @@ class AccountUsageSnapshot:
     windows: tuple[AccountUsageWindow, ...] = ()
     details: tuple[str, ...] = ()
     unavailable_reason: Optional[str] = None
+    usage_windows_complete: bool = True
 
     @property
     def available(self) -> bool:
@@ -54,10 +61,16 @@ def _title_case_slug(value: Optional[str]) -> Optional[str]:
 
 
 def _parse_dt(value: Any) -> Optional[datetime]:
-    if value in {None, ""}:
+    if value is None or value == "" or isinstance(value, bool):
         return None
     if isinstance(value, (int, float)):
-        return datetime.fromtimestamp(float(value), tz=timezone.utc)
+        try:
+            timestamp = float(value)
+            if not math.isfinite(timestamp):
+                return None
+            return datetime.fromtimestamp(timestamp, tz=timezone.utc)
+        except (OverflowError, OSError, ValueError):
+            return None
     if isinstance(value, str):
         text = value.strip()
         if not text:
@@ -460,9 +473,25 @@ def _resolve_codex_usage_credentials(
     device-code logins in the pool, so quota diagnostics must not depend only
     on the older singleton store.
     """
+    def account_id_from_token(token: str) -> Optional[str]:
+        claims = _decode_jwt_claims(token)
+        auth_claims = claims.get("https://api.openai.com/auth")
+        if not isinstance(auth_claims, dict):
+            return None
+        account_id = auth_claims.get("chatgpt_account_id")
+        return (
+            account_id.strip()
+            if isinstance(account_id, str) and account_id.strip()
+            else None
+        )
+
     explicit_key = str(api_key or "").strip()
     if explicit_key:
-        return explicit_key, str(base_url or "").strip(), None
+        return (
+            explicit_key,
+            str(base_url or "").strip(),
+            account_id_from_token(explicit_key),
+        )
 
     # Tier 2: the native runtime resolver. It ALREADY falls back to the
     # credential pool when the singleton is empty (see
@@ -489,7 +518,12 @@ def _resolve_codex_usage_credentials(
         except AuthError:
             # Pool-only creds carry no singleton account_id; header is optional.
             logger.debug("codex ▸ /usage account_id read failed (best-effort)", exc_info=True)
-        return creds["api_key"], str(creds.get("base_url", "") or "").strip(), account_id
+        runtime_key = creds["api_key"]
+        return (
+            runtime_key,
+            str(creds.get("base_url", "") or "").strip(),
+            account_id or account_id_from_token(runtime_key),
+        )
     except AuthError:
         logger.debug("codex ▸ /usage runtime resolver returned no creds; trying pool", exc_info=True)
 
@@ -504,12 +538,18 @@ def _resolve_codex_usage_credentials(
     entry = pool.select()
     if entry is None:
         raise RuntimeError("No available openai-codex credential in credential pool")
-    return entry.runtime_api_key, str(entry.runtime_base_url or base_url or "").strip(), None
+    runtime_key = entry.runtime_api_key
+    return (
+        runtime_key,
+        str(entry.runtime_base_url or base_url or "").strip(),
+        account_id_from_token(runtime_key),
+    )
 
 
 def _fetch_codex_account_usage(
     base_url: Optional[str] = None,
     api_key: Optional[str] = None,
+    timeout: float = 15.0,
 ) -> Optional[AccountUsageSnapshot]:
     token, resolved_base_url, account_id = _resolve_codex_usage_credentials(base_url, api_key)
     headers = {
@@ -519,22 +559,67 @@ def _fetch_codex_account_usage(
     }
     if account_id:
         headers["ChatGPT-Account-Id"] = account_id
-    with httpx.Client(timeout=15.0) as client:
+    with httpx.Client(timeout=timeout) as client:
         response = client.get(_resolve_codex_usage_url(resolved_base_url), headers=headers)
         response.raise_for_status()
     payload = response.json() or {}
     rate_limit = payload.get("rate_limit") or {}
     windows: list[AccountUsageWindow] = []
+    usage_windows_complete = True
     for key, label in (("primary_window", "Session"), ("secondary_window", "Weekly")):
-        window = rate_limit.get(key) or {}
+        window = rate_limit.get(key)
+        if window is None:
+            usage_windows_complete = False
+            continue
+        if not isinstance(window, dict):
+            usage_windows_complete = False
+            continue
         used = window.get("used_percent")
         if used is None:
+            usage_windows_complete = False
             continue
+        if isinstance(used, bool) or not isinstance(used, (int, float)):
+            usage_windows_complete = False
+            continue
+        try:
+            used_percent = float(used)
+        except (TypeError, ValueError):
+            usage_windows_complete = False
+            continue
+        if not math.isfinite(used_percent) or not 0 <= used_percent <= 100:
+            usage_windows_complete = False
+            continue
+        raw_window_seconds = window.get("limit_window_seconds")
+        window_seconds = None
+        if raw_window_seconds is not None:
+            if isinstance(raw_window_seconds, int) and not isinstance(
+                raw_window_seconds, bool
+            ):
+                if raw_window_seconds > 0:
+                    window_seconds = raw_window_seconds
+                else:
+                    usage_windows_complete = False
+            elif isinstance(raw_window_seconds, float):
+                if (
+                    math.isfinite(raw_window_seconds)
+                    and raw_window_seconds > 0
+                    and raw_window_seconds.is_integer()
+                ):
+                    window_seconds = int(raw_window_seconds)
+                else:
+                    usage_windows_complete = False
+            else:
+                usage_windows_complete = False
+        raw_reset_at = window.get("reset_at")
+        reset_at = _parse_dt(raw_reset_at)
+        if raw_reset_at is not None and reset_at is None:
+            usage_windows_complete = False
         windows.append(
             AccountUsageWindow(
                 label=label,
-                used_percent=float(used),
-                reset_at=_parse_dt(window.get("reset_at")),
+                used_percent=used_percent,
+                reset_at=reset_at,
+                limit_window_seconds=window_seconds,
             )
         )
     details: list[str] = []
@@ -560,6 +645,7 @@ def _fetch_codex_account_usage(
         plan=_title_case_slug(payload.get("plan_type")),
         windows=tuple(windows),
         details=tuple(details),
+        usage_windows_complete=usage_windows_complete,
     )
 
 
@@ -886,13 +972,18 @@ def fetch_account_usage(
     *,
     base_url: Optional[str] = None,
     api_key: Optional[str] = None,
+    timeout: Optional[float] = None,
 ) -> Optional[AccountUsageSnapshot]:
     normalized = str(provider or "").strip().lower()
     if normalized in {"", "auto", "custom"}:
         return None
     try:
         if normalized == "openai-codex":
-            return _fetch_codex_account_usage(base_url=base_url, api_key=api_key)
+            return _fetch_codex_account_usage(
+                base_url=base_url,
+                api_key=api_key,
+                timeout=15.0 if timeout is None else timeout,
+            )
         if normalized == "anthropic":
             return _fetch_anthropic_account_usage()
         if normalized == "openrouter":

--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -2903,6 +2903,14 @@ def init_agent(
         "base_url": agent.base_url,
         "api_mode": agent.api_mode,
         "api_key": getattr(agent, "api_key", ""),
+        # Preserve pooled-credential provenance across fallback activation.
+        # The fallback provider may have no pool and clear the live binding;
+        # restoration must still know that the saved raw key came from a pool
+        # so it can reload that pool and re-run admission instead of bypassing
+        # a newly reached usage ceiling.
+        "credential_pool_entry_id": getattr(
+            agent, "_credential_pool_entry_id", None
+        ),
         "client_kwargs": dict(agent._client_kwargs),
         "use_prompt_caching": agent._use_prompt_caching,
         "use_native_cache_layout": agent._use_native_cache_layout,

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1238,7 +1238,15 @@ def recover_with_credential_pool(
         refresh_kwargs = {"api_key_hint": _api_key_hint}
         if _credential_id:
             refresh_kwargs["credential_id"] = _credential_id
-        refreshed = pool.try_refresh_matching(**refresh_kwargs)
+        refresh_with_status = getattr(
+            pool, "try_refresh_matching_with_admission_status", None
+        )
+        if callable(refresh_with_status):
+            refreshed, policy_denied_id = refresh_with_status(**refresh_kwargs)
+        else:
+            # Backward compatibility for third-party/lightweight pool adapters.
+            refreshed = pool.try_refresh_matching(**refresh_kwargs)
+            policy_denied_id = None
         if refreshed is not None:
             # ``try_refresh_matching()`` re-mints a fresh OAuth token and reports
             # success even when the upstream keeps rejecting it — a single-entry
@@ -1267,6 +1275,22 @@ def recover_with_credential_pool(
             _ra().logger.info("Credential auth failure — refreshed pool entry %s", getattr(refreshed, 'id', '?'))
             agent._swap_credential(refreshed)
             return True, has_retried_429
+        if policy_denied_id is not None:
+            # Refresh succeeded, but the same stable entry is at/above its
+            # configured admission ceiling. Do not mark it exhausted for the
+            # original 401: policy exclusion is separate from credential
+            # health. Select an eligible sibling or allow provider fallback.
+            next_entry = pool.select()
+            if next_entry is not None:
+                _ra().logger.info(
+                    "Credential auth refresh produced policy-excluded pool "
+                    "entry %s — selected eligible pool entry %s",
+                    policy_denied_id,
+                    getattr(next_entry, "id", "?"),
+                )
+                agent._swap_credential(next_entry)
+                return True, False
+            return False, has_retried_429
         # Refresh failed — rotate to next credential instead of giving up.
         # The failed entry is already marked exhausted by the refresh attempt.
         rotate_status = status_code if status_code is not None else 401
@@ -1532,15 +1556,22 @@ def restore_primary_runtime(agent) -> bool:
     # pool-rebind block below via ``prefetched_primary_pool`` so the load
     # happens at most once per restore.
     prefetched_primary_pool = None
+    preselected_primary_entry = None
     try:
         primary_provider = str(
             (agent._primary_runtime or {}).get("provider") or ""
         ).strip().lower()
+        primary_pool_entry_id = str(
+            (agent._primary_runtime or {}).get("credential_pool_entry_id") or ""
+        ).strip()
         pool = getattr(agent, "_credential_pool", None)
-        if not credential_pool_matches_provider(
-            pool,
-            primary_provider,
-            base_url=str((agent._primary_runtime or {}).get("base_url") or ""),
+        if (
+            (pool is None and primary_pool_entry_id)
+            or not credential_pool_matches_provider(
+                pool,
+                primary_provider,
+                base_url=str((agent._primary_runtime or {}).get("base_url") or ""),
+            )
         ):
             from agent.credential_pool import load_pool
 
@@ -1561,6 +1592,26 @@ def restore_primary_runtime(agent) -> bool:
                     agent.model,
                 )
             return False
+        if pool is not None:
+            from agent.credential_pool import (
+                get_pool_usage_limits,
+                usage_admission_policy_denied,
+            )
+
+            if get_pool_usage_limits(primary_provider):
+                preselected_primary_entry = pool.select()
+                if (
+                    preselected_primary_entry is None
+                    and usage_admission_policy_denied(primary_provider)
+                ):
+                    logger.info(
+                        "Primary %s is excluded by credential usage policy; "
+                        "staying on fallback %s/%s",
+                        primary_provider or "?",
+                        agent.provider,
+                        agent.model,
+                    )
+                    return False
     except Exception:
         logger.debug(
             "Reset-aware restore gate failed; falling back to per-turn retry",
@@ -1657,7 +1708,10 @@ def restore_primary_runtime(agent) -> bool:
                 pool_matches_primary = bool(primary_key) and primary_key == pool_provider
             except Exception:
                 pool_matches_primary = False
-        if pool is not None and pool_provider and not pool_matches_primary:
+        if not pool_matches_primary and (
+            prefetched_primary_pool is not None
+            or (pool is not None and pool_provider)
+        ):
             agent._credential_pool = None
             agent._credential_pool_entry_id = None
             try:
@@ -1686,8 +1740,10 @@ def restore_primary_runtime(agent) -> bool:
         # keep the snapshot key (the existing behavior).  Fixes #25205.
         agent._credential_pool_entry_id = None
         pool = getattr(agent, "_credential_pool", None)
-        if pool is not None and pool.has_available():
-            entry = pool.select()
+        if pool is not None and (
+            preselected_primary_entry is not None or pool.has_available()
+        ):
+            entry = preselected_primary_entry or pool.select()
             if entry is not None:
                 entry_provider = str(getattr(entry, "provider", "") or "").strip().lower()
                 entry_matches_primary = entry_provider == primary_provider
@@ -2659,6 +2715,7 @@ def switch_model(agent, new_model, new_provider, api_key='', base_url='', api_mo
                     "continuing without pool rotation this turn",
                     new_provider, _pool_exc,
                 )
+        sync_credential_pool_entry_id(agent)
         # ── Build new client ──
         if (new_provider or "").strip().lower() == "moa":
             from agent.moa_loop import build_moa_facade
@@ -2885,6 +2942,9 @@ def switch_model(agent, new_model, new_provider, api_key='', base_url='', api_mo
         "base_url": agent.base_url,
         "api_mode": agent.api_mode,
         "api_key": getattr(agent, "api_key", ""),
+        "credential_pool_entry_id": getattr(
+            agent, "_credential_pool_entry_id", None
+        ),
         "client_kwargs": dict(agent._client_kwargs),
         "use_prompt_caching": agent._use_prompt_caching,
         "use_native_cache_layout": agent._use_native_cache_layout,

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -160,7 +160,12 @@ def aux_probe_mode():
     finally:
         _aux_probe_state.active = prev
 
-from agent.credential_pool import load_pool
+from agent.credential_pool import (
+    get_pool_usage_limits,
+    load_pool,
+    usage_admission_credential_denied,
+    usage_admission_policy_denied,
+)
 from agent.model_metadata import MINIMUM_CONTEXT_LENGTH, get_model_context_length
 from hermes_cli.config import get_hermes_home
 from hermes_constants import OPENROUTER_BASE_URL
@@ -2602,6 +2607,8 @@ def _read_codex_access_token() -> Optional[str]:
         token = _pool_runtime_api_key(entry)
         if token:
             return token
+        if usage_admission_policy_denied("openai-codex"):
+            return None
 
     try:
         from hermes_cli.auth import _read_codex_tokens
@@ -3388,6 +3395,7 @@ def set_runtime_main(
     api_key: Any = "",
     api_mode: str = "",
     auth_mode: str = "",
+    credential_pool_entry_id: str = "",
     session_id: str = "",
     cache_scope: str = "",
 ) -> contextvars.Token:
@@ -3416,6 +3424,9 @@ def set_runtime_main(
         ),
         "api_mode": (api_mode or "").strip(),
         "auth_mode": (auth_mode or "").strip().lower(),
+        "credential_pool_entry_id": (
+            credential_pool_entry_id or ""
+        ).strip(),
         "session_id": (session_id or "").strip(),
         "cache_scope": (cache_scope or "").strip(),
     }
@@ -3661,7 +3672,12 @@ def _build_xai_oauth_aux_client(model: str) -> Tuple[Optional[Any], Optional[str
     return CodexAuxiliaryClient(real_client, model), model
 
 
-def _build_codex_client(model: str) -> Tuple[Optional[Any], Optional[str]]:
+def _build_codex_client(
+    model: str,
+    *,
+    access_token: Optional[str] = None,
+    base_url: Optional[str] = None,
+) -> Tuple[Optional[Any], Optional[str]]:
     """Build a CodexAuxiliaryClient for an explicitly-requested model.
 
     There is no auto-selection of the Codex model: the ChatGPT-account
@@ -3670,7 +3686,10 @@ def _build_codex_client(model: str) -> Tuple[Optional[Any], Optional[str]]:
     is responsible for passing the model (e.g. from the user's own
     ``model.model`` or ``auxiliary.<task>.model`` config).
 
-    Returns (None, None) when no Codex OAuth token is available.
+    ``access_token`` and ``base_url`` bind the client to a credential already
+    selected by the caller. This avoids a second pool selection choosing a
+    different account between admission, cache-key construction, and client
+    creation. Returns (None, None) when no Codex OAuth token is available.
     """
     if not model:
         logger.warning(
@@ -3678,25 +3697,35 @@ def _build_codex_client(model: str) -> Tuple[Optional[Any], Optional[str]]:
             "pass model explicitly (auxiliary.<task>.model in config.yaml)."
         )
         return None, None
-    pool_present, entry = _select_pool_entry("openai-codex")
-    if pool_present:
-        codex_token = _pool_runtime_api_key(entry)
-        if codex_token:
-            base_url = _pool_runtime_base_url(entry, _CODEX_AUX_BASE_URL) or _CODEX_AUX_BASE_URL
+    codex_token = str(access_token or "").strip()
+    resolved_base_url = str(base_url or "").strip()
+    if codex_token:
+        resolved_base_url = resolved_base_url or _CODEX_AUX_BASE_URL
+    else:
+        pool_present, entry = _select_pool_entry("openai-codex")
+        if pool_present:
+            codex_token = _pool_runtime_api_key(entry)
+            if codex_token:
+                resolved_base_url = (
+                    _pool_runtime_base_url(entry, _CODEX_AUX_BASE_URL)
+                    or _CODEX_AUX_BASE_URL
+                )
+            else:
+                if usage_admission_policy_denied("openai-codex"):
+                    return None, None
+                codex_token = _read_codex_access_token()
+                if not codex_token:
+                    return None, None
+                resolved_base_url = _CODEX_AUX_BASE_URL
         else:
             codex_token = _read_codex_access_token()
             if not codex_token:
                 return None, None
-            base_url = _CODEX_AUX_BASE_URL
-    else:
-        codex_token = _read_codex_access_token()
-        if not codex_token:
-            return None, None
-        base_url = _CODEX_AUX_BASE_URL
+            resolved_base_url = _CODEX_AUX_BASE_URL
     logger.debug("Auxiliary client: Codex OAuth (%s via Responses API)", model)
     real_client = _create_openai_client(
         api_key=codex_token,
-        base_url=base_url,
+        base_url=resolved_base_url,
         default_headers=_codex_cloudflare_headers(codex_token),
     )
     return CodexAuxiliaryClient(real_client, model), model
@@ -3891,7 +3920,10 @@ _AUTO_PROVIDER_LABELS = {
 }
 
 _MAIN_RUNTIME_FIELDS = ("provider", "model", "base_url", "api_key", "api_mode", "auth_mode")
-_MAIN_RUNTIME_CONTEXT_FIELDS = _MAIN_RUNTIME_FIELDS + ("requested_provider",)
+_MAIN_RUNTIME_CONTEXT_FIELDS = _MAIN_RUNTIME_FIELDS + (
+    "requested_provider",
+    "credential_pool_entry_id",
+)
 
 
 def _normalize_main_runtime(main_runtime: Optional[Dict[str, Any]]) -> Dict[str, Any]:
@@ -4432,10 +4464,27 @@ def _evict_cached_clients(provider: str) -> None:
     """Drop cached auxiliary clients for a provider so fresh creds are used."""
     normalized = _normalize_aux_provider(provider)
     with _client_cache_lock:
-        stale_keys = [
-            key for key in _client_cache
-            if _normalize_aux_provider(str(key[0])) == normalized
-        ]
+        stale_keys = []
+        for key, entry in _client_cache.items():
+            cached = entry[0]
+            effective_provider = str(
+                getattr(cached, "_hermes_aux_effective_provider", "") or ""
+            )
+            if not effective_provider:
+                real_client = getattr(cached, "_real_client", None)
+                effective_provider = str(
+                    getattr(
+                        real_client,
+                        "_hermes_aux_effective_provider",
+                        "",
+                    )
+                    or ""
+                )
+            if (
+                _normalize_aux_provider(str(key[0])) == normalized
+                or _normalize_aux_provider(effective_provider) == normalized
+            ):
+                stale_keys.append(key)
         for key in stale_keys:
             client = _client_cache.get(key, (None, None, None))[0]
             if client is not None:
@@ -4572,10 +4621,38 @@ def _recover_provider_pool(provider: str, exc: Exception, *, failed_api_key: str
     hint = failed_api_key or None
 
     if _is_auth_error(exc):
-        refreshed = pool.try_refresh_current()
+        refresh_matching = getattr(
+            pool, "try_refresh_matching_with_admission_status", None
+        )
+        refresh_current = getattr(
+            pool, "try_refresh_current_with_admission_status", None
+        )
+        if hint and callable(refresh_matching):
+            refreshed, policy_denied_id = refresh_matching(
+                api_key_hint=hint
+            )
+        elif callable(refresh_current):
+            refreshed, policy_denied_id = refresh_current()
+        else:
+            # Backward compatibility for third-party/lightweight pool adapters.
+            refresh_legacy_matching = getattr(pool, "try_refresh_matching", None)
+            if hint and callable(refresh_legacy_matching):
+                refreshed = refresh_legacy_matching(api_key_hint=hint)
+            else:
+                refreshed = pool.try_refresh_current()
+            policy_denied_id = None
         if refreshed is not None:
             _evict_cached_clients(normalized)
             return True
+        if policy_denied_id is not None:
+            # The forced refresh succeeded but the stable credential is over
+            # its configured admission ceiling. Keep policy state separate from
+            # credential health and retry only if an eligible sibling exists.
+            next_entry = pool.select()
+            if next_entry is not None:
+                _evict_cached_clients(normalized)
+                return True
+            return False
         next_entry = pool.mark_exhausted_and_rotate(
             status_code=status_code if status_code is not None else 401,
             error_context=error_context,
@@ -6323,10 +6400,20 @@ def resolve_provider_client(
                 "or auxiliary.<task>.model for per-task aux routing)."
             )
             return None, None
+        if explicit_api_key and usage_admission_credential_denied(
+            "openai-codex", explicit_api_key
+        ):
+            logger.info(
+                "resolve_provider_client: rejected a policy-denied "
+                "openai-codex credential"
+            )
+            return None, None
         if raw_codex:
             # Return the raw OpenAI client for callers that need direct
             # access to responses.stream() (e.g., the main agent loop).
-            codex_token = _read_codex_access_token()
+            codex_token = str(explicit_api_key or "").strip()
+            if not codex_token:
+                codex_token = _read_codex_access_token()
             if not codex_token:
                 logger.warning("resolve_provider_client: openai-codex requested "
                                "but no Codex OAuth token found (run: hermes model)")
@@ -6334,12 +6421,16 @@ def resolve_provider_client(
             final_model = _normalize_resolved_model(model, provider)
             raw_client = _create_openai_client(
                 api_key=codex_token,
-                base_url=_CODEX_AUX_BASE_URL,
+                base_url=explicit_base_url or _CODEX_AUX_BASE_URL,
                 default_headers=_codex_cloudflare_headers(codex_token),
             )
             return (raw_client, final_model)
         # Standard path: wrap in CodexAuxiliaryClient adapter
-        client, default = _build_codex_client(model)
+        client, default = _build_codex_client(
+            model,
+            access_token=explicit_api_key,
+            base_url=explicit_base_url,
+        )
         if client is None:
             logger.warning("resolve_provider_client: openai-codex requested "
                            "but no Codex OAuth token found (run: hermes model)")
@@ -7414,6 +7505,7 @@ def _client_cache_key(
     is_vision: bool = False,
     task: Optional[str] = None,
     model: Optional[str] = None,
+    pool_hint_override: Optional[str] = None,
 ) -> tuple:
     runtime = _normalize_main_runtime(main_runtime)
     runtime_key = tuple(
@@ -7428,7 +7520,11 @@ def _client_cache_key(
         if provider == "auto"
         else ""
     )
-    pool_hint = _pool_cache_hint(provider, main_runtime=main_runtime)
+    pool_hint = (
+        pool_hint_override
+        if pool_hint_override is not None
+        else _pool_cache_hint(provider, main_runtime=main_runtime)
+    )
     # The model MUST participate in the key. Two concurrent auxiliary calls to
     # the SAME provider/base_url/key but DIFFERENT models (e.g. a MoA reference
     # fan-out running opus + gpt-5.5 in parallel threads) would otherwise share
@@ -7740,17 +7836,108 @@ def _get_cached_client(
         except RuntimeError:
             pass
     runtime = _normalize_main_runtime(main_runtime)
+    admission_entry = None
+    pool_hint_override = None
+    explicit_credential_denied = False
+    admission_provider = _normalize_aux_provider(provider)
+    if admission_provider == "auto":
+        admission_provider = _normalize_aux_provider(
+            runtime.get("provider") or _read_main_provider()
+        )
+    runtime_api_key = runtime.get("api_key")
+    inherited_explicit_codex_key = (
+        admission_provider == "openai-codex"
+        and not api_key
+        and isinstance(runtime_api_key, str)
+        and bool(runtime_api_key.strip())
+        and not runtime.get("credential_pool_entry_id")
+    )
+    if (
+        admission_provider == "openai-codex"
+        and get_pool_usage_limits("openai-codex")
+    ):
+        if api_key or inherited_explicit_codex_key:
+            # Explicit credentials are keyed by their own fingerprint below.
+            pool_hint_override = ""
+            admission_api_key = (
+                api_key if api_key else str(runtime_api_key).strip()
+            )
+            explicit_credential_denied = usage_admission_credential_denied(
+                "openai-codex", admission_api_key
+            )
+        else:
+            pool_present, admission_entry = _select_pool_entry("openai-codex")
+            if (
+                pool_present
+                and admission_entry is None
+                and usage_admission_policy_denied("openai-codex")
+            ):
+                _evict_cached_clients("openai-codex")
+                # An explicit Codex auxiliary route must stop here, but an
+                # ``auto`` route still owns a fallback ladder.  Continue into
+                # resolve_provider_client("auto") so the next eligible provider
+                # can serve the auxiliary request.
+                if _normalize_aux_provider(provider) != "auto":
+                    return None, None
+            if admission_entry is not None:
+                admission_entry_id = str(
+                    getattr(admission_entry, "id", "") or ""
+                ).strip()
+                if admission_entry_id:
+                    pool_hint_override = f"openai-codex:{admission_entry_id}"
+
+    # Resolve the exact selected identity before constructing the cache key.
+    # Credential ID alone is insufficient because OAuth refresh can rotate the
+    # token and base URL while keeping the same stable pool ID.
+    effective_api_key = (
+        str(runtime_api_key).strip()
+        if inherited_explicit_codex_key
+        else api_key
+    )
+    effective_base_url = (
+        str(runtime.get("base_url") or "").strip() or None
+        if inherited_explicit_codex_key and not base_url
+        else base_url
+    )
+    if not effective_api_key:
+        selected_entry = admission_entry or _peek_pool_entry(
+            _normalize_aux_provider(provider)
+        )
+        if selected_entry is not None:
+            selected_key = _pool_runtime_api_key(selected_entry)
+            if selected_key:
+                effective_api_key = selected_key
+                if not effective_base_url:
+                    selected_provider = _normalize_aux_provider(
+                        str(getattr(selected_entry, "provider", "") or provider)
+                    )
+                    default_base_url = (
+                        _CODEX_AUX_BASE_URL
+                        if admission_entry is selected_entry
+                        or selected_provider == "openai-codex"
+                        else ""
+                    )
+                    effective_base_url = (
+                        _pool_runtime_base_url(selected_entry, default_base_url) or None
+                    )
     cache_key = _client_cache_key(
         provider,
         async_mode=async_mode,
-        base_url=base_url,
-        api_key=api_key,
+        base_url=effective_base_url,
+        api_key=effective_api_key,
         api_mode=api_mode,
         main_runtime=main_runtime,
         is_vision=is_vision,
         task=task,
         model=model,
+        pool_hint_override=pool_hint_override,
     )
+    if explicit_credential_denied:
+        with _client_cache_lock:
+            denied_entry = _client_cache.pop(cache_key, None)
+        if denied_entry is not None:
+            _close_cached_client(denied_entry[0])
+        return None, None
     with _client_cache_lock:
         if cache_key in _client_cache:
             cached_client, cached_default, cached_loop = _client_cache[cache_key]
@@ -7783,18 +7970,16 @@ def _get_cached_client(
     # always prefers env vars (first-entry bias), which bypasses pool rotation:
     # after key #1 is marked exhausted the retry would still get key #1 from
     # the env var and fail again, causing the retry2_err handler to mark key #2.
-    effective_api_key = api_key
-    if not effective_api_key:
-        _pe = _peek_pool_entry(_normalize_aux_provider(provider))
-        if _pe is not None:
-            _pk = _pool_runtime_api_key(_pe)
-            if _pk:
-                effective_api_key = _pk
+    resolved_provider = (
+        "openai-codex"
+        if admission_entry is not None and admission_provider == "openai-codex"
+        else provider
+    )
     client, default_model = resolve_provider_client(
-        provider,
+        resolved_provider,
         model,
         async_mode,
-        explicit_base_url=base_url,
+        explicit_base_url=effective_base_url,
         explicit_api_key=effective_api_key,
         api_mode=api_mode,
         main_runtime=runtime,

--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -3,6 +3,9 @@
 from __future__ import annotations
 
 import logging
+import concurrent.futures
+import hashlib
+import math
 import os
 import random
 import threading
@@ -43,6 +46,8 @@ from hermes_cli.auth import (
 )
 
 logger = logging.getLogger(__name__)
+_WARNED_INVALID_USAGE_LIMITS: Set[Tuple[str, str]] = set()
+_WARNED_UNMATCHED_USAGE_LIMITS: Set[Tuple[str, str]] = set()
 
 
 def _load_config_safe() -> Optional[dict]:
@@ -551,6 +556,287 @@ def get_pool_strategy(provider: str) -> str:
     return STRATEGY_FILL_FIRST
 
 
+def get_pool_usage_limits(provider: str) -> Dict[str, float]:
+    """Return configured soft usage ceilings keyed by credential ID."""
+    if provider != "openai-codex":
+        return {}
+    config = _load_config_safe()
+    if not isinstance(config, dict):
+        return {}
+    all_limits = config.get("credential_pool_usage_limits")
+    if not isinstance(all_limits, dict):
+        return {}
+    provider_limits = all_limits.get(provider)
+    if not isinstance(provider_limits, dict):
+        return {}
+    valid: Dict[str, float] = {}
+    for credential_id, raw_threshold in provider_limits.items():
+        normalized_id = str(credential_id or "").strip()
+        try:
+            threshold = float(raw_threshold)
+        except (TypeError, ValueError):
+            threshold = math.nan
+        if (
+            not normalized_id
+            or isinstance(raw_threshold, bool)
+            or not math.isfinite(threshold)
+            or threshold <= 0
+            or threshold > 100
+        ):
+            warning_key = (provider, normalized_id)
+            if warning_key not in _WARNED_INVALID_USAGE_LIMITS:
+                _WARNED_INVALID_USAGE_LIMITS.add(warning_key)
+                logger.warning(
+                    "credential pool: ignoring invalid usage limit for %s/%s",
+                    provider,
+                    normalized_id or "<empty-id>",
+                )
+            continue
+        valid[normalized_id] = threshold
+    return valid
+
+
+def _select_codex_policy_window(snapshot: Any) -> Optional[Any]:
+    """Choose the longest finite Codex usage window from a snapshot."""
+    if not getattr(snapshot, "usage_windows_complete", True):
+        return None
+    usable = []
+    duration_candidates = []
+    durations_absent = 0
+    reset_candidates = []
+    fetched_at = getattr(snapshot, "fetched_at", None)
+    timestamp_fn = getattr(fetched_at, "timestamp", None)
+    try:
+        raw_fetched_timestamp: Any = (
+            timestamp_fn() if callable(timestamp_fn) else math.nan
+        )
+        fetched_timestamp = float(raw_fetched_timestamp)
+    except (TypeError, ValueError, OverflowError):
+        fetched_timestamp = math.nan
+    for window in tuple(getattr(snapshot, "windows", ()) or ()):
+        raw_used_percent = getattr(window, "used_percent", None)
+        if (
+            raw_used_percent is None
+            or isinstance(raw_used_percent, bool)
+            or not isinstance(raw_used_percent, (int, float))
+        ):
+            return None
+        try:
+            used_percent = float(raw_used_percent)
+        except (TypeError, ValueError, OverflowError):
+            return None
+        if not math.isfinite(used_percent) or not 0 <= used_percent <= 100:
+            return None
+
+        # A reported reset that has already elapsed makes the whole snapshot
+        # stale, even when duration metadata is otherwise present.  Choosing
+        # that window could preserve a denial from the previous quota cycle.
+        reset_at = getattr(window, "reset_at", None)
+        reset_timestamp = None
+        if reset_at is not None:
+            try:
+                reset_timestamp = float(reset_at.timestamp())
+            except (AttributeError, TypeError, ValueError, OverflowError):
+                return None
+            if (
+                not math.isfinite(fetched_timestamp)
+                or not math.isfinite(reset_timestamp)
+                or reset_timestamp <= fetched_timestamp
+            ):
+                return None
+
+        usable.append(window)
+        duration = getattr(window, "limit_window_seconds", None)
+        if duration is None:
+            durations_absent += 1
+        else:
+            if not isinstance(duration, (int, float)) or isinstance(duration, bool):
+                return None
+            try:
+                duration_value = float(duration)
+            except (TypeError, ValueError, OverflowError):
+                return None
+            if not math.isfinite(duration_value) or duration_value <= 0:
+                return None
+            duration_candidates.append((duration_value, window))
+        if reset_timestamp is not None:
+            reset_candidates.append((reset_timestamp, window))
+    if usable and len(duration_candidates) == len(usable):
+        longest_duration = max(item[0] for item in duration_candidates)
+        longest = [
+            window
+            for duration, window in duration_candidates
+            if duration == longest_duration
+        ]
+        return longest[0] if len(longest) == 1 else None
+    if (
+        usable
+        and durations_absent == len(usable)
+        and len(reset_candidates) == len(usable)
+    ):
+        farthest_reset = max(item[0] for item in reset_candidates)
+        farthest = [
+            window
+            for reset, window in reset_candidates
+            if reset == farthest_reset
+        ]
+        return farthest[0] if len(farthest) == 1 else None
+    return None
+
+
+_USAGE_ADMISSION_SUCCESS_TTL_SECONDS = 300.0
+_USAGE_ADMISSION_ERROR_TTL_SECONDS = 30.0
+_USAGE_ADMISSION_PROBE_TIMEOUT_SECONDS = 3.0
+_USAGE_ADMISSION_PROBE_WAIT_SECONDS = 3.25
+_USAGE_ADMISSION_PROBE_EXECUTOR = concurrent.futures.ThreadPoolExecutor(
+    max_workers=16,
+    thread_name_prefix="hermes-codex-usage",
+)
+_USAGE_ADMISSION_INFLIGHT: Dict[
+    Tuple[str, str, str, str], concurrent.futures.Future[None]
+] = {}
+
+
+@dataclass(frozen=True)
+class _UsageAdmissionDecision:
+    checked_at: float
+    probe_succeeded: bool
+    used_percent: Optional[float]
+    reset_at: Optional[float]
+
+
+_USAGE_ADMISSION_CACHE: Dict[
+    Tuple[str, str, str, str], _UsageAdmissionDecision
+] = {}
+_USAGE_ADMISSION_CACHE_LOCK = threading.Lock()
+
+
+def _usage_admission_cache_key(
+    entry: PooledCredential,
+) -> Tuple[str, str, str, str]:
+    token_fingerprint = hashlib.sha256(
+        entry.runtime_api_key.encode("utf-8")
+    ).hexdigest()
+    return (
+        entry.provider,
+        entry.id,
+        token_fingerprint,
+        str(entry.runtime_base_url or "").strip().rstrip("/"),
+    )
+
+
+def _usage_admission_decision_is_fresh(
+    decision: _UsageAdmissionDecision,
+    now: float,
+) -> bool:
+    if decision.reset_at is not None:
+        try:
+            reset_at = float(decision.reset_at)
+        except (TypeError, ValueError, OverflowError):
+            return False
+        if not math.isfinite(reset_at) or reset_at <= time.time():
+            return False
+    ttl = (
+        _USAGE_ADMISSION_SUCCESS_TTL_SECONDS
+        if decision.probe_succeeded
+        else _USAGE_ADMISSION_ERROR_TTL_SECONDS
+    )
+    return now - decision.checked_at < ttl
+
+
+def _usage_admission_decision_denied(
+    decision: _UsageAdmissionDecision,
+    threshold: float,
+    now: float,
+) -> bool:
+    """Apply current policy to fresh cached telemetry."""
+    return bool(
+        _usage_admission_decision_is_fresh(decision, now)
+        and decision.probe_succeeded
+        and decision.used_percent is not None
+        and decision.used_percent >= threshold
+    )
+
+
+def usage_admission_policy_denied(provider: str) -> bool:
+    """Return whether a fresh configured decision excludes any credential."""
+    limits = get_pool_usage_limits(provider)
+    if not limits:
+        return False
+    now = time.monotonic()
+    with _USAGE_ADMISSION_CACHE_LOCK:
+        return any(
+            cache_provider == provider
+            and credential_id in limits
+            and _usage_admission_decision_denied(
+                decision, limits[credential_id], now
+            )
+            for (
+                cache_provider,
+                credential_id,
+                _token_fingerprint,
+                _base_url,
+            ), decision in _USAGE_ADMISSION_CACHE.items()
+        )
+
+
+def usage_admission_credential_denied(provider: str, api_key: str) -> bool:
+    """Return whether policy denies the credential behind ``api_key``.
+
+    Explicit runtime paths may be the first use of a configured pool token in a
+    process.  On a cache miss, match only that exact token to a configured stable
+    ID and refresh its pool telemetry before deciding.  Unrelated explicit
+    credentials remain outside the pool policy.
+    """
+    limits = get_pool_usage_limits(provider)
+    token = str(api_key or "").strip()
+    if not limits or not token:
+        return False
+    token_fingerprint = hashlib.sha256(token.encode("utf-8")).hexdigest()
+
+    def _cached_denial() -> bool:
+        now = time.monotonic()
+        with _USAGE_ADMISSION_CACHE_LOCK:
+            return any(
+                cache_provider == provider
+                and credential_id in limits
+                and cached_fingerprint == token_fingerprint
+                and _usage_admission_decision_denied(
+                    decision, limits[credential_id], now
+                )
+                for (
+                    cache_provider,
+                    credential_id,
+                    cached_fingerprint,
+                    _base_url,
+                ), decision in _USAGE_ADMISSION_CACHE.items()
+            )
+
+    if _cached_denial():
+        return True
+
+    # A cold explicit path has no cache entry yet.  Probe only when the token
+    # matches a configured pool credential; otherwise fail open and leave an
+    # unrelated explicit credential untouched.
+    try:
+        pool = load_pool(provider)
+        matching_entry = any(
+            entry.id in limits
+            and hashlib.sha256(entry.runtime_api_key.encode("utf-8")).hexdigest()
+            == token_fingerprint
+            for entry in pool.entries()
+        )
+    except Exception:
+        return False
+    if not matching_entry:
+        return False
+    try:
+        pool._refresh_usage_admission_cache()
+    except Exception:
+        return False
+    return _cached_denial()
+
+
 def credential_pool_matches_provider(
     pool_or_provider: Any,
     provider: Optional[str],
@@ -661,6 +947,7 @@ class CredentialPool:
         self._lock = threading.RLock()
         self._active_leases: Dict[str, int] = {}
         self._max_concurrent = DEFAULT_MAX_CONCURRENT_PER_CREDENTIAL
+        self._usage_limits: Dict[str, float] = {}
         # Monotonic timestamp of the last "no available entries" log, used to
         # throttle that message so an empty/exhausted pool cannot storm the
         # shared rotating log (see NO_AVAILABLE_ENTRIES_LOG_THROTTLE_SECONDS).
@@ -675,6 +962,167 @@ class CredentialPool:
         # loop runs unbounded and non-interruptible.  Reset whenever a real
         # entry is identified or an escape path returns None.
         self._unmatched_rotation_streak: int = 0
+
+    def _probe_usage_admission_entry(
+        self,
+        entry: PooledCredential,
+        cache_key: Tuple[str, str, str, str],
+    ) -> None:
+        """Probe and cache one entry. Network I/O never holds a pool lock."""
+        snapshot = None
+        try:
+            from agent.account_usage import fetch_account_usage
+
+            snapshot = fetch_account_usage(
+                "openai-codex",
+                base_url=entry.runtime_base_url,
+                api_key=entry.runtime_api_key,
+                timeout=_USAGE_ADMISSION_PROBE_TIMEOUT_SECONDS,
+            )
+        except Exception:
+            logger.debug(
+                "credential pool: Codex usage admission probe failed",
+                exc_info=True,
+            )
+
+        checked_at = time.monotonic()
+        window = _select_codex_policy_window(snapshot)
+        if window is None:
+            decision = _UsageAdmissionDecision(
+                checked_at=checked_at,
+                probe_succeeded=False,
+                used_percent=None,
+                reset_at=None,
+            )
+        else:
+            used_percent = float(window.used_percent)
+            reset_at = getattr(window, "reset_at", None)
+            try:
+                reset_timestamp = (
+                    float(reset_at.timestamp()) if reset_at is not None else None
+                )
+            except (AttributeError, TypeError, ValueError, OverflowError):
+                reset_timestamp = None
+            decision = _UsageAdmissionDecision(
+                checked_at=checked_at,
+                probe_succeeded=True,
+                used_percent=used_percent,
+                reset_at=reset_timestamp,
+            )
+
+        with _USAGE_ADMISSION_CACHE_LOCK:
+            # Preserve fresh decisions for other auth identities of the same
+            # stable credential ID. A delayed probe for an old OAuth token must
+            # not erase the refreshed token's decision.
+            stale_keys = [
+                key
+                for key, cached_decision in _USAGE_ADMISSION_CACHE.items()
+                if key[:2] == cache_key[:2]
+                and key != cache_key
+                and not _usage_admission_decision_is_fresh(
+                    cached_decision, checked_at
+                )
+            ]
+            for stale_key in stale_keys:
+                _USAGE_ADMISSION_CACHE.pop(stale_key, None)
+            _USAGE_ADMISSION_CACHE[cache_key] = decision
+
+    def _refresh_usage_admission_cache(
+        self,
+        candidate_entries: Optional[List[PooledCredential]] = None,
+    ) -> None:
+        """Refresh configured Codex decisions with one bounded parallel wait."""
+        limits = get_pool_usage_limits(self.provider)
+        with self._lock:
+            self._usage_limits = dict(limits)
+            if not limits:
+                return
+            entry_ids = {entry.id for entry in self._entries}
+            source_entries = (
+                list(candidate_entries)
+                if candidate_entries is not None
+                else self._entries
+            )
+            candidates = [
+                entry
+                for entry in source_entries
+                if entry.id in limits and entry.runtime_api_key
+            ]
+        for credential_id in limits.keys() - entry_ids:
+            warning_key = (self.provider, credential_id)
+            with _USAGE_ADMISSION_CACHE_LOCK:
+                warn = warning_key not in _WARNED_UNMATCHED_USAGE_LIMITS
+                _WARNED_UNMATCHED_USAGE_LIMITS.add(warning_key)
+            if warn:
+                logger.warning(
+                    "credential pool: usage limit configured for missing %s "
+                    "credential %s",
+                    self.provider,
+                    credential_id,
+                )
+        pending: list[concurrent.futures.Future[None]] = []
+        for entry in candidates:
+            cache_key = _usage_admission_cache_key(entry)
+            now = time.monotonic()
+            callback_registration = None
+            with _USAGE_ADMISSION_CACHE_LOCK:
+                cached = _USAGE_ADMISSION_CACHE.get(cache_key)
+                if cached is not None and _usage_admission_decision_is_fresh(
+                    cached, now
+                ):
+                    continue
+                future = _USAGE_ADMISSION_INFLIGHT.get(cache_key)
+                if future is None:
+                    future = _USAGE_ADMISSION_PROBE_EXECUTOR.submit(
+                        self._probe_usage_admission_entry,
+                        entry,
+                        cache_key,
+                    )
+                    _USAGE_ADMISSION_INFLIGHT[cache_key] = future
+                    callback_registration = (future, cache_key)
+                pending.append(future)
+
+            if callback_registration is not None:
+                registered_future, registered_key = callback_registration
+
+                def clear_inflight(
+                    completed: concurrent.futures.Future[None],
+                    *,
+                    key: Tuple[str, str, str, str] = registered_key,
+                ) -> None:
+                    with _USAGE_ADMISSION_CACHE_LOCK:
+                        if _USAGE_ADMISSION_INFLIGHT.get(key) is completed:
+                            _USAGE_ADMISSION_INFLIGHT.pop(key, None)
+
+                registered_future.add_done_callback(clear_inflight)
+
+        if pending:
+            done, _not_done = concurrent.futures.wait(
+                set(pending),
+                timeout=_USAGE_ADMISSION_PROBE_WAIT_SECONDS,
+            )
+            for future in done:
+                try:
+                    future.result()
+                except Exception:
+                    logger.debug(
+                        "credential pool: unexpected usage probe worker failure",
+                        exc_info=True,
+                    )
+
+    def _usage_admission_denied(self, entry: PooledCredential) -> bool:
+        if entry.id not in self._usage_limits or not entry.runtime_api_key:
+            return False
+        cache_key = _usage_admission_cache_key(entry)
+        now = time.monotonic()
+        with _USAGE_ADMISSION_CACHE_LOCK:
+            decision = _USAGE_ADMISSION_CACHE.get(cache_key)
+            return bool(
+                decision is not None
+                and _usage_admission_decision_denied(
+                    decision, self._usage_limits[entry.id], now
+                )
+            )
 
     def has_credentials(self) -> bool:
         with self._lock:
@@ -1784,9 +2232,11 @@ class CredentialPool:
         return False
 
     def select(self) -> Optional[PooledCredential]:
+        self._refresh_usage_admission_cache()
         entry, pending_refresh = self._select_under_lock()
         if pending_refresh:
             self._refresh_pending_entries(pending_refresh)
+            self._refresh_usage_admission_cache()
         if entry is not None:
             self._unmatched_rotation_streak = 0
             return entry
@@ -1970,6 +2420,8 @@ class CredentialPool:
                 if refreshed is None:
                     continue
                 entry = refreshed
+            if self._usage_admission_denied(entry):
+                continue
             available.append(entry)
         if entries_to_prune:
             pruned_ids = set(entries_to_prune)
@@ -2054,6 +2506,7 @@ class CredentialPool:
         credential_id: Optional[str] = None,
         failure_reason: Optional[str] = None,
     ) -> Optional[PooledCredential]:
+        self._refresh_usage_admission_cache()
         with self._lock:
             entry = None
             identity_supplied = bool(credential_id or api_key_hint)
@@ -2223,9 +2676,11 @@ class CredentialPool:
         a stable tie-breaker. When every credential is already at the soft cap,
         still return the least-leased one instead of blocking.
         """
+        self._refresh_usage_admission_cache()
         chosen_id, pending_refresh = self._acquire_lease_under_lock(credential_id)
         if pending_refresh:
             self._refresh_pending_entries(pending_refresh)
+            self._refresh_usage_admission_cache()
             # Mirror select(): if nothing was leasable but we just refreshed
             # deferred single-use-token entries, retry now that they are back
             # in rotation. Without this, a pool whose only entries all needed
@@ -2242,6 +2697,12 @@ class CredentialPool:
         """Run lease acquisition under the lock, returning id + pending refreshes."""
         with self._lock:
             if credential_id:
+                requested = next(
+                    (entry for entry in self._entries if entry.id == credential_id),
+                    None,
+                )
+                if requested is not None and self._usage_admission_denied(requested):
+                    return None, []
                 self._active_leases[credential_id] = self._active_leases.get(credential_id, 0) + 1
                 self._current_id = credential_id
                 return credential_id, []
@@ -2272,15 +2733,58 @@ class CredentialPool:
             else:
                 self._active_leases[credential_id] = count - 1
 
-    def try_refresh_current(self) -> Optional[PooledCredential]:
+    def _apply_admission_after_forced_refresh(
+        self,
+        refreshed: Optional[PooledCredential],
+    ) -> Tuple[Optional[PooledCredential], Optional[str]]:
+        """Admit a freshly minted token before it can be assigned.
+
+        Forced OAuth refresh changes the token fingerprint for the same stable
+        pool entry.  Probe that exact refreshed token outside the pool lock and
+        return the denied stable ID separately so recovery callers can select a
+        sibling without misclassifying policy denial as credential exhaustion.
+        Telemetry failure retains the policy's fail-open behavior.
+        """
+        if refreshed is None:
+            return None, None
+        self._refresh_usage_admission_cache(candidate_entries=[refreshed])
+        if self._usage_admission_denied(refreshed):
+            logger.info(
+                "credential pool: usage admission excludes refreshed %s "
+                "credential %s",
+                self.provider,
+                refreshed.id,
+            )
+            return None, refreshed.id
+        return refreshed, None
+
+    def try_refresh_current_with_admission_status(
+        self,
+    ) -> Tuple[Optional[PooledCredential], Optional[str]]:
         with self._lock:
-            return self._try_refresh_current_unlocked()
+            refreshed = self._try_refresh_current_unlocked()
+        return self._apply_admission_after_forced_refresh(refreshed)
+
+    def try_refresh_current(self) -> Optional[PooledCredential]:
+        refreshed, _denied_id = self.try_refresh_current_with_admission_status()
+        return refreshed
 
     def try_refresh_matching(
         self,
         api_key_hint: Optional[str] = None,
         credential_id: Optional[str] = None,
     ) -> Optional[PooledCredential]:
+        refreshed, _denied_id = self.try_refresh_matching_with_admission_status(
+            api_key_hint=api_key_hint,
+            credential_id=credential_id,
+        )
+        return refreshed
+
+    def try_refresh_matching_with_admission_status(
+        self,
+        api_key_hint: Optional[str] = None,
+        credential_id: Optional[str] = None,
+    ) -> Tuple[Optional[PooledCredential], Optional[str]]:
         """Force-refresh the entry that supplied the failed request.
 
         Direct provider integrations may reload the pool after a request has
@@ -2315,9 +2819,10 @@ class CredentialPool:
                         refresh=False
                     )[0]
             if entry is None:
-                return None
+                return None, None
             self._current_id = entry.id
-            return self._try_refresh_current_unlocked()
+            refreshed = self._try_refresh_current_unlocked()
+        return self._apply_admission_after_forced_refresh(refreshed)
 
     def _try_refresh_current_unlocked(self) -> Optional[PooledCredential]:
         entry = self._current_unlocked()

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -505,6 +505,9 @@ def build_turn_context(
             api_key=getattr(agent, "api_key", "") or "",
             api_mode=getattr(agent, "api_mode", "") or "",
             auth_mode=getattr(agent, "auth_mode", "") or "",
+            credential_pool_entry_id=(
+                getattr(agent, "_credential_pool_entry_id", "") or ""
+            ),
             session_id=getattr(agent, "session_id", "") or "",
             cache_scope=_cache_scope,
         )

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -29,6 +29,19 @@ runtime:
   nofile_soft_limit: 4096
 
 # =============================================================================
+# Credential Pool Routing (optional)
+# =============================================================================
+# Keep the default fill-first ordering while reserving selected credentials
+# once their longest reliable usage window reaches a configured percentage.
+# Find stable credential IDs with: hermes auth list <provider>
+#
+# credential_pool_strategies:
+#   openai-codex: fill_first
+# credential_pool_usage_limits:
+#   openai-codex:
+#     "a1b2c3": 80  # Exclude this credential from new assignments at >= 80% used.
+
+# =============================================================================
 # Model Configuration
 # =============================================================================
 model:

--- a/hermes_cli/auth_commands.py
+++ b/hermes_cli/auth_commands.py
@@ -457,7 +457,10 @@ def auth_list_command(args) -> None:
                 marker = "← "
             status = _format_exhausted_status(entry)
             source = _display_source(entry.source)
-            print(f"  #{idx}  {entry.label:<20} {entry.auth_type:<7} {source}{status} {marker}".rstrip())
+            print(
+                f"  #{idx}  {entry.label:<20} {entry.auth_type:<7} "
+                f"{source}{status} id={entry.id} {marker}".rstrip()
+            )
         print()
 
 

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -5030,6 +5030,7 @@ def _default_value_for_key(dotted_key: str):
 _OPEN_DICT_TOP_LEVEL_KEYS = frozenset({
     "providers",
     "credential_pool_strategies",
+    "credential_pool_usage_limits",
     "mcp_servers",
     "hooks",
     "quick_commands",

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -9,6 +9,7 @@ DEFAULT_CONFIG = {
     "providers": {},
     "fallback_providers": [],
     "credential_pool_strategies": {},
+    "credential_pool_usage_limits": {},
     "toolsets": ["hermes-cli"],
     # SQLite journal mode used by every Hermes database opener. WAL is the
     # normal default; set DELETE for weak-fsync/shared filesystems where WAL is

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -17,6 +17,8 @@ from agent.credential_pool import (
     credential_pool_matches_provider,
     get_custom_provider_pool_key,
     load_pool,
+    usage_admission_credential_denied,
+    usage_admission_policy_denied,
 )
 from agent.secret_scope import get_secret as _get_secret
 from hermes_cli.auth import (
@@ -1581,6 +1583,16 @@ def _resolve_explicit_runtime(
             last_refresh = creds.get("last_refresh")
             if not explicit_base_url:
                 base_url = creds.get("base_url", "").rstrip("/") or base_url
+        if api_key and usage_admission_credential_denied(
+            "openai-codex", api_key
+        ):
+            raise AuthError(
+                "The selected Codex credential is excluded by its configured "
+                "usage policy.",
+                provider="openai-codex",
+                code="codex_credential_usage_policy_denied",
+                relogin_required=False,
+            )
         return {
             "provider": "openai-codex",
             "api_mode": "codex_responses",
@@ -1971,7 +1983,6 @@ def resolve_runtime_provider(
                 pool=pool,
                 target_model=target_model,
             )
-
     if provider == "nous":
         try:
             from hermes_cli.providers import nous_api_mode
@@ -1998,6 +2009,13 @@ def resolve_runtime_provider(
 
     if provider == "openai-codex":
         try:
+            if usage_admission_policy_denied(provider):
+                raise AuthError(
+                    "No eligible Codex credential is available in the configured pool.",
+                    provider="openai-codex",
+                    code="codex_pool_no_eligible_credentials",
+                    relogin_required=False,
+                )
             creds = resolve_codex_runtime_credentials()
             return {
                 "provider": "openai-codex",

--- a/run_agent.py
+++ b/run_agent.py
@@ -5736,6 +5736,28 @@ class AIAgent:
             )
             return False
 
+        if self.provider == "openai-codex":
+            try:
+                from agent.credential_pool import usage_admission_credential_denied
+
+                singleton_denied = usage_admission_credential_denied(
+                    "openai-codex", new_key
+                )
+            except Exception:
+                # Usage admission is intentionally fail-open when telemetry or
+                # policy resolution is unavailable.
+                logger.debug(
+                    "OpenAI Codex singleton refresh admission check failed",
+                    exc_info=True,
+                )
+                singleton_denied = False
+            if singleton_denied:
+                logger.info(
+                    "OpenAI Codex singleton refresh produced a policy-excluded "
+                    "credential; refusing to install it"
+                )
+                return False
+
         self.api_key = api_key.strip()
         self.base_url = base_url.strip().rstrip("/")
         self._client_kwargs["api_key"] = self.api_key

--- a/tests/agent/test_account_usage.py
+++ b/tests/agent/test_account_usage.py
@@ -1,3 +1,5 @@
+import base64
+import json
 from types import SimpleNamespace
 
 import pytest
@@ -40,17 +42,21 @@ def codex_usage_payload():
             "primary_window": {
                 "used_percent": 21,
                 "reset_at": 1779846359,
+                "limit_window_seconds": 18_000,
             },
             "secondary_window": {
                 "used_percent": 4,
                 "reset_at": 1780230796,
+                "limit_window_seconds": 604_800,
             },
         },
         "credits": {"has_credits": False},
     }
 
 
-def test_codex_usage_prefers_explicit_live_agent_credentials(monkeypatch, codex_usage_payload):
+def test_codex_usage_prefers_explicit_live_agent_credentials(
+    monkeypatch, codex_usage_payload
+):
     calls = []
     monkeypatch.setattr(
         account_usage.httpx,
@@ -60,7 +66,9 @@ def test_codex_usage_prefers_explicit_live_agent_credentials(monkeypatch, codex_
     monkeypatch.setattr(
         account_usage,
         "resolve_codex_runtime_credentials",
-        lambda **kwargs: (_ for _ in ()).throw(AssertionError("legacy auth should not be used")),
+        lambda **kwargs: (_ for _ in ()).throw(
+            AssertionError("legacy auth should not be used")
+        ),
     )
 
     snapshot = account_usage.fetch_account_usage(
@@ -74,11 +82,277 @@ def test_codex_usage_prefers_explicit_live_agent_credentials(monkeypatch, codex_
     assert snapshot.plan == "Plus"
     assert [w.label for w in snapshot.windows] == ["Session", "Weekly"]
     assert snapshot.windows[0].used_percent == 21
+    assert snapshot.windows[0].limit_window_seconds == 18_000
+    assert snapshot.windows[1].limit_window_seconds == 604_800
     assert calls[0]["url"] == "https://chatgpt.com/backend-api/wham/usage"
     assert calls[0]["headers"]["Authorization"] == "Bearer live-agent-token"
 
 
-def test_codex_usage_falls_back_to_native_credential_pool(monkeypatch, codex_usage_payload):
+def test_codex_usage_marks_missing_reported_window_incomplete(
+    monkeypatch, codex_usage_payload
+):
+    calls = []
+    codex_usage_payload["rate_limit"].pop("secondary_window")
+    monkeypatch.setattr(
+        account_usage.httpx,
+        "Client",
+        lambda timeout: _FakeClient(calls, codex_usage_payload),
+    )
+
+    snapshot = account_usage.fetch_account_usage(
+        "openai-codex",
+        base_url="https://chatgpt.com/backend-api/codex",
+        api_key="live-agent-token",
+    )
+
+    assert snapshot is not None
+    assert len(snapshot.windows) == 1
+    assert snapshot.usage_windows_complete is False
+
+
+def test_codex_usage_explicit_workspace_jwt_sends_account_id_header(
+    monkeypatch, codex_usage_payload
+):
+    calls = []
+    claims = {
+        "https://api.openai.com/auth": {"chatgpt_account_id": "workspace-account"}
+    }
+    payload = base64.urlsafe_b64encode(json.dumps(claims).encode()).decode().rstrip("=")
+    token = f"header.{payload}.signature"
+    monkeypatch.setattr(
+        account_usage.httpx,
+        "Client",
+        lambda timeout: _FakeClient(calls, codex_usage_payload),
+    )
+
+    snapshot = account_usage.fetch_account_usage(
+        "openai-codex",
+        base_url="https://chatgpt.com/backend-api/codex",
+        api_key=token,
+    )
+
+    assert snapshot is not None
+    assert calls[0]["headers"]["ChatGPT-Account-Id"] == "workspace-account"
+
+
+@pytest.mark.parametrize(
+    "invalid_used_percent",
+    [True, -1, 101, float("nan"), "80", " 80 ", "8e1"],
+)
+def test_codex_usage_ignores_invalid_used_percent(
+    monkeypatch, codex_usage_payload, invalid_used_percent
+):
+    calls = []
+    codex_usage_payload["rate_limit"]["primary_window"]["used_percent"] = (
+        invalid_used_percent
+    )
+    codex_usage_payload["rate_limit"].pop("secondary_window")
+    monkeypatch.setattr(
+        account_usage.httpx,
+        "Client",
+        lambda timeout: _FakeClient(calls, codex_usage_payload),
+    )
+
+    snapshot = account_usage.fetch_account_usage(
+        "openai-codex",
+        base_url="https://chatgpt.com/backend-api/codex",
+        api_key="live-agent-token",
+    )
+
+    assert snapshot is not None
+    assert snapshot.windows == ()
+    assert snapshot.usage_windows_complete is False
+
+
+def test_codex_usage_marks_mixed_valid_and_invalid_windows_incomplete(
+    monkeypatch, codex_usage_payload
+):
+    calls = []
+    codex_usage_payload["rate_limit"]["primary_window"]["used_percent"] = "bad"
+    monkeypatch.setattr(
+        account_usage.httpx,
+        "Client",
+        lambda timeout: _FakeClient(calls, codex_usage_payload),
+    )
+
+    snapshot = account_usage.fetch_account_usage(
+        "openai-codex",
+        base_url="https://chatgpt.com/backend-api/codex",
+        api_key="live-agent-token",
+    )
+
+    assert snapshot is not None
+    assert [window.label for window in snapshot.windows] == ["Weekly"]
+    assert snapshot.usage_windows_complete is False
+
+    from agent.credential_pool import _select_codex_policy_window
+
+    assert _select_codex_policy_window(snapshot) is None
+
+
+@pytest.mark.parametrize("invalid_window_seconds", [0.5, 1.9])
+def test_codex_usage_rejects_fractional_window_seconds(
+    monkeypatch, codex_usage_payload, invalid_window_seconds
+):
+    calls = []
+    codex_usage_payload["rate_limit"].pop("secondary_window")
+    codex_usage_payload["rate_limit"]["primary_window"]["limit_window_seconds"] = (
+        invalid_window_seconds
+    )
+    monkeypatch.setattr(
+        account_usage.httpx,
+        "Client",
+        lambda timeout: _FakeClient(calls, codex_usage_payload),
+    )
+
+    snapshot = account_usage.fetch_account_usage(
+        "openai-codex",
+        base_url="https://chatgpt.com/backend-api/codex",
+        api_key="live-agent-token",
+    )
+
+    assert snapshot is not None
+    assert snapshot.windows[0].limit_window_seconds is None
+    assert snapshot.usage_windows_complete is False
+
+
+def test_codex_usage_preserves_large_integer_window_seconds(
+    monkeypatch, codex_usage_payload
+):
+    calls = []
+    huge_window_seconds = 10**400
+    codex_usage_payload["rate_limit"]["primary_window"]["limit_window_seconds"] = (
+        huge_window_seconds
+    )
+    monkeypatch.setattr(
+        account_usage.httpx,
+        "Client",
+        lambda timeout: _FakeClient(calls, codex_usage_payload),
+    )
+
+    snapshot = account_usage.fetch_account_usage(
+        "openai-codex",
+        base_url="https://chatgpt.com/backend-api/codex",
+        api_key="live-agent-token",
+    )
+
+    assert snapshot is not None
+    assert snapshot.windows[0].limit_window_seconds == huge_window_seconds
+    assert snapshot.usage_windows_complete is True
+
+
+@pytest.mark.parametrize(
+    "invalid_window_seconds",
+    [True, 0, -1, float("nan"), float("inf"), "604800"],
+)
+def test_codex_usage_marks_invalid_window_seconds_incomplete(
+    monkeypatch, codex_usage_payload, invalid_window_seconds
+):
+    calls = []
+    codex_usage_payload["rate_limit"].pop("secondary_window")
+    codex_usage_payload["rate_limit"]["primary_window"]["limit_window_seconds"] = (
+        invalid_window_seconds
+    )
+    monkeypatch.setattr(
+        account_usage.httpx,
+        "Client",
+        lambda timeout: _FakeClient(calls, codex_usage_payload),
+    )
+
+    snapshot = account_usage.fetch_account_usage(
+        "openai-codex",
+        base_url="https://chatgpt.com/backend-api/codex",
+        api_key="live-agent-token",
+    )
+
+    assert snapshot is not None
+    assert snapshot.windows[0].limit_window_seconds is None
+    assert snapshot.usage_windows_complete is False
+
+
+def test_codex_usage_accepts_integer_valued_float_window_seconds(
+    monkeypatch, codex_usage_payload
+):
+    calls = []
+    codex_usage_payload["rate_limit"]["primary_window"]["limit_window_seconds"] = (
+        604_800.0
+    )
+    monkeypatch.setattr(
+        account_usage.httpx,
+        "Client",
+        lambda timeout: _FakeClient(calls, codex_usage_payload),
+    )
+
+    snapshot = account_usage.fetch_account_usage(
+        "openai-codex",
+        base_url="https://chatgpt.com/backend-api/codex",
+        api_key="live-agent-token",
+    )
+
+    assert snapshot is not None
+    assert snapshot.windows[0].limit_window_seconds == 604_800
+    assert snapshot.usage_windows_complete is True
+
+
+@pytest.mark.parametrize(
+    "invalid_reset_at",
+    [True, "not-a-date", float("inf"), 10**400],
+)
+def test_codex_usage_marks_invalid_reset_metadata_incomplete(
+    monkeypatch, codex_usage_payload, invalid_reset_at
+):
+    calls = []
+    codex_usage_payload["rate_limit"]["primary_window"]["used_percent"] = 90
+    codex_usage_payload["rate_limit"]["primary_window"]["reset_at"] = invalid_reset_at
+    monkeypatch.setattr(
+        account_usage.httpx,
+        "Client",
+        lambda timeout: _FakeClient(calls, codex_usage_payload),
+    )
+
+    snapshot = account_usage.fetch_account_usage(
+        "openai-codex",
+        base_url="https://chatgpt.com/backend-api/codex",
+        api_key="live-agent-token",
+    )
+
+    assert snapshot is not None
+    assert snapshot.usage_windows_complete is False
+
+    from agent.credential_pool import _select_codex_policy_window
+
+    assert _select_codex_policy_window(snapshot) is None
+
+
+def test_window_duration_does_not_change_usage_rendering():
+    fetched_at = account_usage._utc_now()
+    without_duration = account_usage.AccountUsageSnapshot(
+        provider="openai-codex",
+        source="test",
+        fetched_at=fetched_at,
+        windows=(account_usage.AccountUsageWindow(label="Weekly", used_percent=21),),
+    )
+    with_duration = account_usage.AccountUsageSnapshot(
+        provider="openai-codex",
+        source="test",
+        fetched_at=fetched_at,
+        windows=(
+            account_usage.AccountUsageWindow(
+                label="Weekly",
+                used_percent=21,
+                limit_window_seconds=604_800,
+            ),
+        ),
+    )
+
+    assert account_usage.render_account_usage_lines(
+        with_duration
+    ) == account_usage.render_account_usage_lines(without_duration)
+
+
+def test_codex_usage_falls_back_to_native_credential_pool(
+    monkeypatch, codex_usage_payload
+):
     calls = []
     monkeypatch.setattr(
         account_usage.httpx,
@@ -92,7 +366,9 @@ def test_codex_usage_falls_back_to_native_credential_pool(monkeypatch, codex_usa
         account_usage,
         "resolve_codex_runtime_credentials",
         lambda **kwargs: (_ for _ in ()).throw(
-            account_usage.AuthError("no singleton auth", provider="openai-codex", code="codex_auth_missing")
+            account_usage.AuthError(
+                "no singleton auth", provider="openai-codex", code="codex_auth_missing"
+            )
         ),
     )
 
@@ -118,9 +394,9 @@ def test_codex_usage_falls_back_to_native_credential_pool(monkeypatch, codex_usa
     assert "ChatGPT-Account-Id" not in calls[0]["headers"]
 
 
-
-
-def test_codex_usage_account_id_read_failure_keeps_singleton_token(monkeypatch, codex_usage_payload):
+def test_codex_usage_account_id_read_failure_keeps_singleton_token(
+    monkeypatch, codex_usage_payload
+):
     """When the resolver succeeds but the separate account_id read raises, the
     working singleton token must still be used (best-effort account_id), NOT
     abandoned in favor of a header-less pool credential."""
@@ -142,7 +418,11 @@ def test_codex_usage_account_id_read_failure_keeps_singleton_token(monkeypatch, 
         account_usage,
         "_read_codex_tokens",
         lambda *a, **k: (_ for _ in ()).throw(
-            account_usage.AuthError("partial store", provider="openai-codex", code="codex_auth_invalid_shape")
+            account_usage.AuthError(
+                "partial store",
+                provider="openai-codex",
+                code="codex_auth_invalid_shape",
+            )
         ),
     )
 
@@ -151,7 +431,9 @@ def test_codex_usage_account_id_read_failure_keeps_singleton_token(monkeypatch, 
     monkeypatch.setattr(
         credential_pool,
         "load_pool",
-        lambda provider: (_ for _ in ()).throw(AssertionError("pool must not be consulted")),
+        lambda provider: (_ for _ in ()).throw(
+            AssertionError("pool must not be consulted")
+        ),
     )
 
     snapshot = account_usage.fetch_account_usage("openai-codex")
@@ -160,8 +442,6 @@ def test_codex_usage_account_id_read_failure_keeps_singleton_token(monkeypatch, 
     assert calls[0]["headers"]["Authorization"] == "Bearer singleton-token"
     # account_id read failed → header omitted, but the singleton token is kept.
     assert "ChatGPT-Account-Id" not in calls[0]["headers"]
-
-
 
 
 # ── Banked rate-limit reset credits (`/usage reset`) ─────────────────────────
@@ -186,7 +466,12 @@ class _FakeResetClient:
         return _FakeResponse(self.usage_payload)
 
     def post(self, url, headers=None, json=None):
-        self.calls.append({"method": "POST", "url": url, "headers": headers, "json": json})
+        self.calls.append({
+            "method": "POST",
+            "url": url,
+            "headers": headers,
+            "json": json,
+        })
         return _FakeResponse(self.consume_payload)
 
 
@@ -195,25 +480,14 @@ def _usage_payload_with_resets(primary_used, secondary_used, banked):
         "plan_type": "plus",
         "rate_limit": {
             "primary_window": {"used_percent": primary_used, "reset_at": 1779846359},
-            "secondary_window": {"used_percent": secondary_used, "reset_at": 1780230796},
+            "secondary_window": {
+                "used_percent": secondary_used,
+                "reset_at": 1780230796,
+            },
         },
         "rate_limit_reset_credits": {"available_count": banked},
         "credits": {"has_credits": False},
     }
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 
 
 def test_redeem_missing_credentials_reports_unavailable(monkeypatch):

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -2602,6 +2602,140 @@ class TestAuxiliaryAuthRefreshRetry:
 
 
 class TestAuxiliaryPoolRotationRetry:
+    def test_auth_refresh_policy_denial_selects_sibling_without_exhausting(self):
+        auth_err = Exception("unauthorized")
+        auth_err.status_code = 401
+        replacement = SimpleNamespace(id="cred-b")
+
+        class _Pool:
+            def has_credentials(self):
+                return True
+
+            def try_refresh_matching_with_admission_status(
+                self, *, api_key_hint=None, credential_id=None
+            ):
+                assert api_key_hint == "failed-token-a"
+                assert credential_id is None
+                return None, "cred-a"
+
+            def try_refresh_current_with_admission_status(self):
+                raise AssertionError("recovery must target the failed credential")
+
+            def select(self):
+                return replacement
+
+            def mark_exhausted_and_rotate(self, **kwargs):
+                raise AssertionError(
+                    "policy denial must not mutate exhaustion state"
+                )
+
+        pool = _Pool()
+        with (
+            patch("agent.auxiliary_client.load_pool", return_value=pool),
+            patch("agent.auxiliary_client._evict_cached_clients") as evict,
+        ):
+            from agent.auxiliary_client import _recover_provider_pool
+
+            assert (
+                _recover_provider_pool(
+                    "openai-codex",
+                    auth_err,
+                    failed_api_key="failed-token-a",
+                )
+                is True
+            )
+
+        evict.assert_called_once_with("openai-codex")
+
+    def test_auto_codex_keeps_unrelated_explicit_main_runtime_credential(self):
+        explicit_token = "unrelated-explicit-token"
+        pooled_entry = SimpleNamespace(
+            id="configured-entry",
+            provider="openai-codex",
+            runtime_api_key="configured-pool-token",
+            runtime_base_url="https://chatgpt.com/backend-api/codex",
+        )
+        pool = MagicMock()
+        pool.has_credentials.return_value = True
+        pool.select.return_value = pooled_entry
+        client = MagicMock()
+
+        import agent.auxiliary_client as aux
+
+        with (
+            patch(
+                "agent.auxiliary_client.get_pool_usage_limits",
+                return_value={"configured-entry": 80.0},
+            ),
+            patch("agent.auxiliary_client.load_pool", return_value=pool),
+            patch(
+                "agent.auxiliary_client.usage_admission_credential_denied",
+                return_value=False,
+            ) as denied,
+            patch(
+                "agent.auxiliary_client.resolve_provider_client",
+                return_value=(client, "gpt-5.4"),
+            ) as resolve,
+        ):
+            aux.shutdown_cached_clients()
+            try:
+                resolved, _model = aux._get_cached_client(
+                    "auto",
+                    "gpt-5.4",
+                    main_runtime={
+                        "provider": "openai-codex",
+                        "model": "gpt-5.4",
+                        "api_key": explicit_token,
+                        "base_url": "https://chatgpt.com/backend-api/codex",
+                        "api_mode": "codex_responses",
+                    },
+                )
+            finally:
+                aux.shutdown_cached_clients()
+
+        assert resolved is client
+        pool.select.assert_not_called()
+        denied.assert_called_once_with("openai-codex", explicit_token)
+        assert resolve.call_args.kwargs["explicit_api_key"] == explicit_token
+
+    def test_auto_codex_rejects_matching_denied_explicit_main_runtime_credential(
+        self,
+    ):
+        import agent.auxiliary_client as aux
+
+        pool = MagicMock()
+        pool.has_credentials.return_value = True
+        with (
+            patch(
+                "agent.auxiliary_client.get_pool_usage_limits",
+                return_value={"configured-entry": 80.0},
+            ),
+            patch("agent.auxiliary_client.load_pool", return_value=pool),
+            patch(
+                "agent.auxiliary_client.usage_admission_credential_denied",
+                return_value=True,
+            ) as denied,
+            patch("agent.auxiliary_client.resolve_provider_client") as resolve,
+        ):
+            aux.shutdown_cached_clients()
+            client, model = aux._get_cached_client(
+                "auto",
+                "gpt-5.4",
+                main_runtime={
+                    "provider": "openai-codex",
+                    "model": "gpt-5.4",
+                    "api_key": "matching-denied-token",
+                    "base_url": "https://chatgpt.com/backend-api/codex",
+                    "api_mode": "codex_responses",
+                },
+            )
+
+        assert client is None
+        assert model is None
+        pool.select.assert_not_called()
+        denied.assert_called_once_with("openai-codex", "matching-denied-token")
+        resolve.assert_not_called()
+
     def test_call_llm_rotates_explicit_codex_pool_on_429(self):
         rate_err = Exception("usage limit reached")
         rate_err.status_code = 429

--- a/tests/agent/test_codex_usage_admission_limit.py
+++ b/tests/agent/test_codex_usage_admission_limit.py
@@ -1,0 +1,2022 @@
+import concurrent.futures
+import threading
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+
+import pytest
+
+from agent.account_usage import AccountUsageSnapshot, AccountUsageWindow
+from agent.credential_pool import (
+    AUTH_TYPE_API_KEY,
+    AUTH_TYPE_OAUTH,
+    CredentialPool,
+    PooledCredential,
+)
+
+
+def _snapshot(*windows: AccountUsageWindow) -> AccountUsageSnapshot:
+    return AccountUsageSnapshot(
+        provider="openai-codex",
+        source="usage_api",
+        fetched_at=datetime.now(timezone.utc),
+        windows=tuple(windows),
+    )
+
+
+def _entry(
+    credential_id: str = "a1b2c3",
+    *,
+    token: str = "reserved-token",
+    priority: int = 0,
+) -> PooledCredential:
+    return PooledCredential(
+        provider="openai-codex",
+        id=credential_id,
+        label="codex-reserved",
+        auth_type=AUTH_TYPE_API_KEY,
+        priority=priority,
+        source="manual",
+        access_token=token,
+        base_url="https://chatgpt.com/backend-api/codex",
+    )
+
+
+def _select_id(pool: CredentialPool) -> str:
+    selected = pool.select()
+    assert selected is not None
+    return selected.id
+
+
+@pytest.fixture(autouse=True)
+def _clear_usage_admission_cache():
+    import agent.credential_pool as credential_pool
+
+    with credential_pool._USAGE_ADMISSION_CACHE_LOCK:
+        credential_pool._USAGE_ADMISSION_CACHE.clear()
+        credential_pool._USAGE_ADMISSION_INFLIGHT.clear()
+    yield
+    with credential_pool._USAGE_ADMISSION_CACHE_LOCK:
+        credential_pool._USAGE_ADMISSION_CACHE.clear()
+        credential_pool._USAGE_ADMISSION_INFLIGHT.clear()
+
+
+def test_policy_window_uses_longest_duration_not_primary_secondary_label():
+    from agent.credential_pool import _select_codex_policy_window
+
+    seven_day_primary = AccountUsageWindow(
+        label="Session",
+        used_percent=79,
+        limit_window_seconds=604_800,
+    )
+    five_hour_secondary = AccountUsageWindow(
+        label="Weekly",
+        used_percent=95,
+        limit_window_seconds=18_000,
+    )
+
+    selected = _select_codex_policy_window(
+        _snapshot(seven_day_primary, five_hour_secondary)
+    )
+
+    assert selected is seven_day_primary
+
+
+def test_policy_window_falls_back_to_farthest_reset():
+    from agent.credential_pool import _select_codex_policy_window
+
+    now = datetime.now(timezone.utc)
+    earlier = AccountUsageWindow(
+        label="Primary",
+        used_percent=95,
+        reset_at=now + timedelta(hours=2),
+    )
+    later = AccountUsageWindow(
+        label="Secondary",
+        used_percent=79,
+        reset_at=now + timedelta(days=5),
+    )
+
+    selected = _select_codex_policy_window(_snapshot(earlier, later))
+
+    assert selected is later
+
+
+def test_policy_window_without_duration_or_reset_fails_open():
+    from agent.credential_pool import _select_codex_policy_window
+
+    unknown = AccountUsageWindow(label="Unknown", used_percent=95)
+
+    assert _select_codex_policy_window(_snapshot(unknown)) is None
+
+
+def test_policy_window_mixed_durations_fail_open():
+    from agent.credential_pool import _select_codex_policy_window
+
+    now = datetime.now(timezone.utc)
+    shorter_with_duration = AccountUsageWindow(
+        label="Short",
+        used_percent=95,
+        limit_window_seconds=18_000,
+        reset_at=now + timedelta(hours=2),
+    )
+    longer_without_duration = AccountUsageWindow(
+        label="Long",
+        used_percent=79,
+        reset_at=now + timedelta(days=5),
+    )
+
+    assert (
+        _select_codex_policy_window(
+            _snapshot(shorter_with_duration, longer_without_duration)
+        )
+        is None
+    )
+
+
+@pytest.mark.parametrize("malformed_duration", ["604800", 0, -1, float("nan")])
+def test_policy_window_malformed_duration_with_complete_resets_fails_open(
+    malformed_duration,
+):
+    from agent.credential_pool import _select_codex_policy_window
+
+    now = datetime.now(timezone.utc)
+    valid = AccountUsageWindow(
+        label="Valid",
+        used_percent=79,
+        limit_window_seconds=18_000,
+        reset_at=now + timedelta(hours=2),
+    )
+    malformed = AccountUsageWindow(
+        label="Malformed",
+        used_percent=95,
+        limit_window_seconds=malformed_duration,
+        reset_at=now + timedelta(days=5),
+    )
+
+    assert _select_codex_policy_window(_snapshot(valid, malformed)) is None
+
+
+def test_policy_window_mixed_durations_without_complete_resets_fails_open():
+    from agent.credential_pool import _select_codex_policy_window
+
+    shorter_with_duration = AccountUsageWindow(
+        label="Short",
+        used_percent=95,
+        limit_window_seconds=18_000,
+        reset_at=datetime(2026, 8, 15, tzinfo=timezone.utc),
+    )
+    unknown_longer = AccountUsageWindow(label="Unknown", used_percent=79)
+
+    assert (
+        _select_codex_policy_window(_snapshot(shorter_with_duration, unknown_longer))
+        is None
+    )
+
+
+def test_policy_window_equal_longest_duration_tie_fails_open():
+    from agent.credential_pool import _select_codex_policy_window
+
+    first = AccountUsageWindow(
+        label="First",
+        used_percent=90,
+        limit_window_seconds=604_800,
+    )
+    second = AccountUsageWindow(
+        label="Second",
+        used_percent=10,
+        limit_window_seconds=604_800,
+    )
+
+    assert _select_codex_policy_window(_snapshot(first, second)) is None
+
+
+def test_policy_window_past_reset_fallback_fails_open():
+    from agent.credential_pool import _select_codex_policy_window
+
+    stale = AccountUsageWindow(
+        label="Stale",
+        used_percent=90,
+        reset_at=datetime(1970, 1, 1, 0, 0, 1, tzinfo=timezone.utc),
+    )
+
+    assert _select_codex_policy_window(_snapshot(stale)) is None
+
+
+def test_policy_window_duration_with_past_reset_fails_open():
+    from agent.credential_pool import _select_codex_policy_window
+
+    stale = AccountUsageWindow(
+        label="Stale weekly window",
+        used_percent=90,
+        limit_window_seconds=604_800,
+        reset_at=datetime(1970, 1, 1, 0, 0, 1, tzinfo=timezone.utc),
+    )
+
+    assert _select_codex_policy_window(_snapshot(stale)) is None
+
+
+def test_policy_window_huge_duration_fails_open_without_raising():
+    from agent.credential_pool import _select_codex_policy_window
+
+    malformed = AccountUsageWindow(
+        label="Malformed",
+        used_percent=90,
+        limit_window_seconds=10**400,
+    )
+
+    assert _select_codex_policy_window(_snapshot(malformed)) is None
+
+
+@pytest.mark.parametrize("used_percent", ["80", " 80 ", "8e1"])
+def test_policy_window_rejects_string_percentages(used_percent):
+    from agent.credential_pool import _select_codex_policy_window
+
+    malformed = AccountUsageWindow(
+        label="Weekly",
+        used_percent=used_percent,
+        limit_window_seconds=604_800,
+    )
+
+    assert _select_codex_policy_window(_snapshot(malformed)) is None
+
+
+def test_select_denies_credential_at_exact_threshold(monkeypatch):
+    import agent.account_usage as account_usage
+    import agent.credential_pool as credential_pool
+
+    calls = []
+    monkeypatch.setattr(
+        credential_pool,
+        "get_pool_usage_limits",
+        lambda provider: {"a1b2c3": 80.0},
+    )
+    monkeypatch.setattr(
+        account_usage,
+        "fetch_account_usage",
+        lambda provider, **kwargs: (
+            calls.append((provider, kwargs))
+            or _snapshot(
+                AccountUsageWindow(
+                    label="Primary",
+                    used_percent=80,
+                    limit_window_seconds=604_800,
+                )
+            )
+        ),
+    )
+
+    selected = CredentialPool("openai-codex", [_entry()]).select()
+
+    assert selected is None
+    assert calls == [
+        (
+            "openai-codex",
+            {
+                "base_url": "https://chatgpt.com/backend-api/codex",
+                "api_key": "reserved-token",
+                "timeout": 3.0,
+            },
+        )
+    ]
+
+
+def test_specific_lease_refuses_credential_at_threshold(monkeypatch):
+    import agent.account_usage as account_usage
+    import agent.credential_pool as credential_pool
+
+    monkeypatch.setattr(
+        credential_pool,
+        "get_pool_usage_limits",
+        lambda provider: {"a1b2c3": 80.0},
+    )
+    monkeypatch.setattr(
+        account_usage,
+        "fetch_account_usage",
+        lambda provider, **kwargs: _snapshot(
+            AccountUsageWindow(
+                label="Weekly",
+                used_percent=80,
+                limit_window_seconds=604_800,
+            )
+        ),
+    )
+    pool = CredentialPool("openai-codex", [_entry()])
+
+    assert pool.acquire_lease("a1b2c3") is None
+
+
+def test_failure_rotation_refreshes_limit_before_choosing_replacement(monkeypatch):
+    import agent.account_usage as account_usage
+    import agent.credential_pool as credential_pool
+
+    monkeypatch.setattr(
+        credential_pool,
+        "get_pool_usage_limits",
+        lambda provider: {"a1b2c3": 80.0},
+    )
+    monkeypatch.setattr(
+        account_usage,
+        "fetch_account_usage",
+        lambda provider, **kwargs: _snapshot(
+            AccountUsageWindow(
+                label="Weekly",
+                used_percent=80,
+                limit_window_seconds=604_800,
+            )
+        ),
+    )
+    pool = CredentialPool(
+        "openai-codex",
+        [
+            _entry("failed", token="failed-token", priority=0),
+            _entry(priority=1),
+        ],
+    )
+    pool._current_id = "failed"
+
+    replacement = pool.mark_exhausted_and_rotate(
+        status_code=429,
+        credential_id="failed",
+    )
+
+    assert replacement is None
+
+
+def test_auxiliary_fresh_pool_refresh_targets_failed_token_and_applies_admission(
+    monkeypatch,
+):
+    from dataclasses import replace
+
+    import agent.auxiliary_client as auxiliary_client
+    import agent.credential_pool as credential_pool
+
+    failed = PooledCredential(
+        provider="openai-codex",
+        id="configured-entry",
+        label="configured",
+        auth_type=AUTH_TYPE_OAUTH,
+        priority=0,
+        source="manual:device_code",
+        access_token="failed-old-token",
+        refresh_token="refresh-token",
+        base_url="https://chatgpt.com/backend-api/codex",
+    )
+    sibling = _entry("sibling-entry", token="sibling-token", priority=1)
+    pool = CredentialPool("openai-codex", [failed, sibling])
+    refreshed_ids = []
+
+    def _refresh_entry(entry, *, force=False):
+        assert force is True
+        refreshed_ids.append(entry.id)
+        refreshed = replace(entry, access_token="failed-fresh-token")
+        pool._replace_entry(entry, refreshed)
+        return refreshed
+
+    pool._refresh_entry = _refresh_entry
+    monkeypatch.setattr(
+        credential_pool,
+        "get_pool_usage_limits",
+        lambda _provider: {"configured-entry": 80.0},
+    )
+
+    def _usage(_provider, *, api_key, **_kwargs):
+        used = 90 if api_key == "failed-fresh-token" else 10
+        return _snapshot(
+            AccountUsageWindow(
+                label="Weekly",
+                used_percent=used,
+                limit_window_seconds=604_800,
+                reset_at=datetime.now(timezone.utc) + timedelta(days=7),
+            )
+        )
+
+    monkeypatch.setattr("agent.account_usage.fetch_account_usage", _usage)
+    monkeypatch.setattr(auxiliary_client, "load_pool", lambda _provider: pool)
+    evicted = []
+    monkeypatch.setattr(
+        auxiliary_client,
+        "_evict_cached_clients",
+        lambda provider: evicted.append(provider),
+    )
+
+    auth_error = Exception("unauthorized")
+    auth_error.status_code = 401
+
+    assert auxiliary_client._recover_provider_pool(
+        "openai-codex",
+        auth_error,
+        failed_api_key="failed-old-token",
+    )
+    assert refreshed_ids == ["configured-entry"]
+    assert pool.current().id == "sibling-entry"
+    assert pool.entries()[0].last_status is None
+    assert evicted == ["openai-codex"]
+
+
+def test_forced_refresh_rechecks_admission_for_new_token(monkeypatch):
+    import agent.account_usage as account_usage
+    import agent.credential_pool as credential_pool
+
+    monkeypatch.setattr(
+        credential_pool,
+        "get_pool_usage_limits",
+        lambda provider: {"a1b2c3": 80.0},
+    )
+    probes = []
+
+    def fetch_usage(provider, **kwargs):
+        probes.append(kwargs["api_key"])
+        return _snapshot(
+            AccountUsageWindow(
+                label="Weekly",
+                used_percent=80,
+                limit_window_seconds=604_800,
+            )
+        )
+
+    monkeypatch.setattr(account_usage, "fetch_account_usage", fetch_usage)
+    stale = _entry(token="stale-token")
+    refreshed = _entry(token="fresh-token")
+    pool = CredentialPool("openai-codex", [stale])
+    monkeypatch.setattr(pool, "_refresh_entry", lambda entry, force: refreshed)
+
+    entry, denied_id = pool.try_refresh_matching_with_admission_status(
+        credential_id="a1b2c3"
+    )
+
+    assert entry is None
+    assert denied_id == "a1b2c3"
+    assert probes == ["fresh-token"]
+
+
+def test_primary_auth_recovery_rotates_without_exhausting_policy_denied_refresh():
+    from agent.agent_runtime_helpers import recover_with_credential_pool
+    from agent.error_classifier import FailoverReason
+
+    replacement = _entry("next-id", token="next-token", priority=1)
+
+    class Pool:
+        provider = "openai-codex"
+
+        def try_refresh_matching_with_admission_status(self, **kwargs):
+            assert kwargs == {
+                "api_key_hint": "stale-token",
+                "credential_id": "a1b2c3",
+            }
+            return None, "a1b2c3"
+
+        def try_refresh_matching(self, **kwargs):
+            raise AssertionError("recovery must request admission status")
+
+        def select(self):
+            return replacement
+
+        def mark_exhausted_and_rotate(self, **kwargs):
+            raise AssertionError("policy denial must not mutate exhaustion state")
+
+    swapped = []
+    agent = SimpleNamespace(
+        _credential_pool=Pool(),
+        _credential_pool_entry_id="a1b2c3",
+        _auth_pool_refresh_counts={},
+        provider="openai-codex",
+        api_key="stale-token",
+        _is_entitlement_failure=lambda context, status: False,
+        _swap_credential=swapped.append,
+    )
+
+    recovered, retried = recover_with_credential_pool(
+        agent,
+        status_code=401,
+        has_retried_429=False,
+        classified_reason=FailoverReason.auth,
+        error_context={},
+    )
+
+    assert (recovered, retried) == (True, False)
+    assert swapped == [replacement]
+
+
+def test_successful_usage_probe_is_cached_for_five_minutes(monkeypatch):
+    import agent.account_usage as account_usage
+    import agent.credential_pool as credential_pool
+
+    calls = []
+    monkeypatch.setattr(
+        credential_pool,
+        "get_pool_usage_limits",
+        lambda provider: {"a1b2c3": 80.0},
+    )
+    monkeypatch.setattr(
+        account_usage,
+        "fetch_account_usage",
+        lambda provider, **kwargs: (
+            calls.append(kwargs)
+            or _snapshot(
+                AccountUsageWindow(
+                    label="Weekly",
+                    used_percent=79,
+                    limit_window_seconds=604_800,
+                )
+            )
+        ),
+    )
+    pool = CredentialPool("openai-codex", [_entry()])
+
+    assert _select_id(pool) == "a1b2c3"
+    assert _select_id(pool) == "a1b2c3"
+    assert len(calls) == 1
+
+
+def test_failed_probe_fails_open_then_retries_after_thirty_seconds(monkeypatch):
+    import agent.account_usage as account_usage
+    import agent.credential_pool as credential_pool
+
+    clock = [0.0]
+    calls = []
+    monkeypatch.setattr(credential_pool.time, "monotonic", lambda: clock[0])
+    monkeypatch.setattr(
+        credential_pool,
+        "get_pool_usage_limits",
+        lambda provider: {"a1b2c3": 80.0},
+    )
+
+    def fake_fetch(provider, **kwargs):
+        calls.append(kwargs)
+        if len(calls) == 1:
+            return None
+        return _snapshot(
+            AccountUsageWindow(
+                label="Weekly",
+                used_percent=80,
+                limit_window_seconds=604_800,
+            )
+        )
+
+    monkeypatch.setattr(account_usage, "fetch_account_usage", fake_fetch)
+    pool = CredentialPool("openai-codex", [_entry()])
+
+    assert _select_id(pool) == "a1b2c3"
+    clock[0] = 29.0
+    assert _select_id(pool) == "a1b2c3"
+    assert len(calls) == 1
+    clock[0] = 30.0
+    assert pool.select() is None
+    assert len(calls) == 2
+
+
+def test_cache_expiry_rechecks_and_readmits_after_reset(monkeypatch):
+    import agent.account_usage as account_usage
+    import agent.credential_pool as credential_pool
+
+    clock = [0.0]
+    used_values = iter((80, 0))
+    monkeypatch.setattr(credential_pool.time, "monotonic", lambda: clock[0])
+    monkeypatch.setattr(
+        credential_pool,
+        "get_pool_usage_limits",
+        lambda provider: {"a1b2c3": 80.0},
+    )
+    monkeypatch.setattr(
+        account_usage,
+        "fetch_account_usage",
+        lambda provider, **kwargs: _snapshot(
+            AccountUsageWindow(
+                label="Weekly",
+                used_percent=next(used_values),
+                limit_window_seconds=604_800,
+            )
+        ),
+    )
+    pool = CredentialPool("openai-codex", [_entry()])
+
+    assert pool.select() is None
+    clock[0] = 300.0
+    assert _select_id(pool) == "a1b2c3"
+
+
+def test_token_change_invalidates_cached_decision(monkeypatch):
+    import agent.account_usage as account_usage
+    import agent.credential_pool as credential_pool
+
+    calls = []
+    monkeypatch.setattr(
+        credential_pool,
+        "get_pool_usage_limits",
+        lambda provider: {"a1b2c3": 80.0},
+    )
+
+    def fake_fetch(provider, **kwargs):
+        calls.append(kwargs["api_key"])
+        return _snapshot(
+            AccountUsageWindow(
+                label="Weekly",
+                used_percent=80 if kwargs["api_key"] == "old-token" else 0,
+                limit_window_seconds=604_800,
+            )
+        )
+
+    monkeypatch.setattr(account_usage, "fetch_account_usage", fake_fetch)
+
+    assert CredentialPool("openai-codex", [_entry(token="old-token")]).select() is None
+    selected = CredentialPool("openai-codex", [_entry(token="new-token")]).select()
+
+    assert selected is not None
+    assert selected.id == "a1b2c3"
+    assert calls == ["old-token", "new-token"]
+
+
+def test_stale_token_probe_does_not_delete_fresh_token_cache(monkeypatch):
+    import agent.account_usage as account_usage
+    import agent.credential_pool as credential_pool
+
+    monkeypatch.setattr(
+        credential_pool,
+        "get_pool_usage_limits",
+        lambda provider: {"a1b2c3": 80.0},
+    )
+    monkeypatch.setattr(
+        account_usage,
+        "fetch_account_usage",
+        lambda provider, **kwargs: _snapshot(
+            AccountUsageWindow(
+                label="Weekly",
+                used_percent=10,
+                limit_window_seconds=604_800,
+            )
+        ),
+    )
+    fresh_entry = _entry(token="token-after-refresh")
+    stale_entry = _entry(token="token-before-refresh")
+    fresh_key = credential_pool._usage_admission_cache_key(fresh_entry)
+
+    assert CredentialPool("openai-codex", [fresh_entry]).select() is not None
+    assert CredentialPool("openai-codex", [stale_entry]).select() is not None
+
+    with credential_pool._USAGE_ADMISSION_CACHE_LOCK:
+        assert fresh_key in credential_pool._USAGE_ADMISSION_CACHE
+
+
+def test_usage_probe_runs_outside_pool_lock(monkeypatch):
+    import agent.account_usage as account_usage
+    import agent.credential_pool as credential_pool
+
+    monkeypatch.setattr(
+        credential_pool,
+        "get_pool_usage_limits",
+        lambda provider: {"a1b2c3": 80.0},
+    )
+    pool = CredentialPool("openai-codex", [_entry()])
+
+    def fake_fetch(provider, **kwargs):
+        assert not getattr(pool._lock, "_is_owned")()
+        return _snapshot(
+            AccountUsageWindow(
+                label="Weekly",
+                used_percent=79,
+                limit_window_seconds=604_800,
+            )
+        )
+
+    monkeypatch.setattr(account_usage, "fetch_account_usage", fake_fetch)
+
+    assert _select_id(pool) == "a1b2c3"
+
+
+def test_usage_cache_never_contains_raw_access_token(monkeypatch):
+    import agent.account_usage as account_usage
+    import agent.credential_pool as credential_pool
+
+    secret_token = "secret-vicky-access-token"
+    monkeypatch.setattr(
+        credential_pool,
+        "get_pool_usage_limits",
+        lambda provider: {"a1b2c3": 80.0},
+    )
+    monkeypatch.setattr(
+        account_usage,
+        "fetch_account_usage",
+        lambda provider, **kwargs: _snapshot(
+            AccountUsageWindow(
+                label="Weekly",
+                used_percent=79,
+                limit_window_seconds=604_800,
+            )
+        ),
+    )
+
+    CredentialPool("openai-codex", [_entry(token=secret_token)]).select()
+
+    with credential_pool._USAGE_ADMISSION_CACHE_LOCK:
+        assert secret_token not in repr(credential_pool._USAGE_ADMISSION_CACHE)
+
+
+def test_automatic_lease_skips_denied_credential(monkeypatch):
+    import agent.account_usage as account_usage
+    import agent.credential_pool as credential_pool
+
+    monkeypatch.setattr(
+        credential_pool,
+        "get_pool_usage_limits",
+        lambda provider: {"a1b2c3": 80.0},
+    )
+    monkeypatch.setattr(
+        account_usage,
+        "fetch_account_usage",
+        lambda provider, **kwargs: _snapshot(
+            AccountUsageWindow(
+                label="Weekly",
+                used_percent=80,
+                limit_window_seconds=604_800,
+            )
+        ),
+    )
+    pool = CredentialPool(
+        "openai-codex",
+        [
+            _entry(priority=0),
+            _entry("other", token="other-token", priority=1),
+        ],
+    )
+
+    assert pool.acquire_lease() == "other"
+
+
+def test_select_rechecks_usage_after_oauth_token_refresh(monkeypatch):
+    import agent.account_usage as account_usage
+    import agent.credential_pool as credential_pool
+
+    calls = []
+    entry = _entry(token="old-token")
+    entry.auth_type = AUTH_TYPE_OAUTH
+    pool = CredentialPool("openai-codex", [entry])
+    monkeypatch.setattr(
+        credential_pool,
+        "get_pool_usage_limits",
+        lambda provider: {"a1b2c3": 80.0},
+    )
+
+    def fake_fetch(provider, **kwargs):
+        calls.append(kwargs["api_key"])
+        if kwargs["api_key"] == "old-token":
+            return None
+        return _snapshot(
+            AccountUsageWindow(
+                label="Weekly",
+                used_percent=80,
+                limit_window_seconds=604_800,
+            )
+        )
+
+    monkeypatch.setattr(account_usage, "fetch_account_usage", fake_fetch)
+    monkeypatch.setattr(
+        pool,
+        "_entry_needs_refresh",
+        lambda candidate: candidate.access_token == "old-token",
+    )
+
+    def fake_refresh(pending):
+        entry.access_token = "new-token"
+
+    monkeypatch.setattr(pool, "_refresh_pending_entries", fake_refresh)
+
+    assert pool.select() is None
+    assert calls == ["old-token", "new-token"]
+
+
+def test_lease_rechecks_usage_after_oauth_token_refresh(monkeypatch):
+    import agent.account_usage as account_usage
+    import agent.credential_pool as credential_pool
+
+    calls = []
+    entry = _entry(token="old-token")
+    entry.auth_type = AUTH_TYPE_OAUTH
+    pool = CredentialPool("openai-codex", [entry])
+    monkeypatch.setattr(
+        credential_pool,
+        "get_pool_usage_limits",
+        lambda provider: {"a1b2c3": 80.0},
+    )
+
+    def fake_fetch(provider, **kwargs):
+        calls.append(kwargs["api_key"])
+        if kwargs["api_key"] == "old-token":
+            return None
+        return _snapshot(
+            AccountUsageWindow(
+                label="Weekly",
+                used_percent=80,
+                limit_window_seconds=604_800,
+            )
+        )
+
+    monkeypatch.setattr(account_usage, "fetch_account_usage", fake_fetch)
+    monkeypatch.setattr(
+        pool,
+        "_entry_needs_refresh",
+        lambda candidate: candidate.access_token == "old-token",
+    )
+
+    def fake_refresh(pending):
+        entry.access_token = "new-token"
+
+    monkeypatch.setattr(pool, "_refresh_pending_entries", fake_refresh)
+
+    assert pool.acquire_lease() is None
+    assert calls == ["old-token", "new-token"]
+
+
+def test_unmatched_configured_credential_warns_once(monkeypatch, caplog):
+    import agent.credential_pool as credential_pool
+
+    credential_pool._WARNED_UNMATCHED_USAGE_LIMITS.clear()
+    monkeypatch.setattr(
+        credential_pool,
+        "get_pool_usage_limits",
+        lambda provider: {"missing-id": 80.0},
+    )
+    pool = CredentialPool("openai-codex", [_entry("other")])
+
+    pool.select()
+    pool.select()
+
+    messages = [
+        record.getMessage()
+        for record in caplog.records
+        if "missing-id" in record.getMessage()
+    ]
+    assert len(messages) == 1
+
+
+def test_threshold_change_reuses_fresh_usage_but_recomputes_admission(monkeypatch):
+    import agent.account_usage as account_usage
+    import agent.credential_pool as credential_pool
+
+    threshold = [80.0]
+    calls = []
+    monkeypatch.setattr(
+        credential_pool,
+        "get_pool_usage_limits",
+        lambda provider: {"a1b2c3": threshold[0]},
+    )
+    monkeypatch.setattr(
+        account_usage,
+        "fetch_account_usage",
+        lambda provider, **kwargs: (
+            calls.append(kwargs)
+            or _snapshot(
+                AccountUsageWindow(
+                    label="Weekly",
+                    used_percent=85,
+                    limit_window_seconds=604_800,
+                )
+            )
+        ),
+    )
+    pool = CredentialPool("openai-codex", [_entry()])
+
+    assert pool.select() is None
+    threshold[0] = 90.0
+    assert _select_id(pool) == "a1b2c3"
+    assert len(calls) == 1
+
+
+def test_explicit_token_recomputes_cached_telemetry_after_threshold_change(monkeypatch):
+    import agent.account_usage as account_usage
+    import agent.credential_pool as credential_pool
+
+    threshold = [80.0]
+    calls = []
+    monkeypatch.setattr(
+        credential_pool,
+        "get_pool_usage_limits",
+        lambda provider: {"a1b2c3": threshold[0]},
+    )
+    monkeypatch.setattr(
+        credential_pool,
+        "load_pool",
+        lambda provider: pool,
+    )
+    monkeypatch.setattr(
+        account_usage,
+        "fetch_account_usage",
+        lambda provider, **kwargs: (
+            calls.append(kwargs)
+            or _snapshot(
+                AccountUsageWindow(
+                    label="Weekly",
+                    used_percent=85,
+                    limit_window_seconds=604_800,
+                )
+            )
+        ),
+    )
+    pool = CredentialPool("openai-codex", [_entry()])
+
+    assert pool.select() is None
+    threshold[0] = 90.0
+    assert credential_pool.usage_admission_policy_denied("openai-codex") is False
+    assert (
+        credential_pool.usage_admission_credential_denied(
+            "openai-codex", "reserved-token"
+        )
+        is False
+    )
+    assert len(calls) == 1
+
+
+def test_inflight_waiter_applies_its_current_threshold(monkeypatch):
+    import agent.account_usage as account_usage
+    import agent.credential_pool as credential_pool
+
+    threshold = [90.0]
+    probe_started = threading.Event()
+    release_probe = threading.Event()
+    monkeypatch.setattr(
+        credential_pool,
+        "get_pool_usage_limits",
+        lambda provider: {"a1b2c3": threshold[0]},
+    )
+
+    def fetch_usage(provider, **kwargs):
+        probe_started.set()
+        assert release_probe.wait(timeout=2)
+        return _snapshot(
+            AccountUsageWindow(
+                label="Weekly",
+                used_percent=85,
+                limit_window_seconds=604_800,
+            )
+        )
+
+    monkeypatch.setattr(account_usage, "fetch_account_usage", fetch_usage)
+    creator_pool = CredentialPool("openai-codex", [_entry()])
+    waiter_pool = CredentialPool("openai-codex", [_entry()])
+    results = {}
+
+    creator = threading.Thread(
+        target=lambda: results.setdefault("creator", creator_pool.select())
+    )
+    creator.start()
+    assert probe_started.wait(timeout=2)
+    threshold[0] = 80.0
+    waiter = threading.Thread(
+        target=lambda: results.setdefault("waiter", waiter_pool.select())
+    )
+    waiter.start()
+    release_probe.set()
+    creator.join(timeout=2)
+    waiter.join(timeout=2)
+
+    assert not creator.is_alive()
+    assert not waiter.is_alive()
+    assert results["creator"] is not None
+    assert results["waiter"] is None
+
+
+def test_completed_probe_callback_clears_inflight_without_reentrant_lock(
+    monkeypatch,
+):
+    import agent.credential_pool as credential_pool
+
+    class RejectReentrantLock:
+        def __init__(self):
+            self._lock = threading.Lock()
+            self._owner = None
+
+        def __enter__(self):
+            owner = threading.get_ident()
+            if self._owner == owner:
+                raise RuntimeError("reentrant cache lock acquisition")
+            self._lock.acquire()
+            self._owner = owner
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            self._owner = None
+            self._lock.release()
+
+    class CompletedExecutor:
+        def submit(self, fn, *args, **kwargs):
+            future = concurrent.futures.Future()
+            future.set_result(None)
+            return future
+
+    pool = CredentialPool("openai-codex", [_entry()])
+    cache_key = credential_pool._usage_admission_cache_key(pool.entries()[0])
+    with monkeypatch.context() as patcher:
+        patcher.setattr(
+            credential_pool,
+            "get_pool_usage_limits",
+            lambda provider: {"a1b2c3": 80.0},
+        )
+        patcher.setattr(
+            credential_pool,
+            "_USAGE_ADMISSION_CACHE_LOCK",
+            RejectReentrantLock(),
+        )
+        patcher.setattr(
+            credential_pool,
+            "_USAGE_ADMISSION_PROBE_EXECUTOR",
+            CompletedExecutor(),
+        )
+        pool._refresh_usage_admission_cache()
+
+    assert cache_key not in credential_pool._USAGE_ADMISSION_INFLIGHT
+
+
+def test_selection_reads_usage_limit_config_once_outside_entry_filter(monkeypatch):
+    import agent.account_usage as account_usage
+    import agent.credential_pool as credential_pool
+
+    config_calls = []
+    monkeypatch.setattr(
+        credential_pool,
+        "get_pool_usage_limits",
+        lambda provider: config_calls.append(provider) or {"a1b2c3": 80.0},
+    )
+    monkeypatch.setattr(
+        account_usage,
+        "fetch_account_usage",
+        lambda provider, **kwargs: _snapshot(
+            AccountUsageWindow(
+                label="Weekly",
+                used_percent=79,
+                limit_window_seconds=604_800,
+            )
+        ),
+    )
+
+    assert _select_id(CredentialPool("openai-codex", [_entry()])) == "a1b2c3"
+    assert config_calls == ["openai-codex"]
+
+
+def test_runtime_resolver_does_not_fall_back_to_singleton_after_pool_denial(
+    monkeypatch,
+):
+    import agent.account_usage as account_usage
+    import agent.credential_pool as credential_pool
+    import hermes_cli.runtime_provider as runtime_provider
+    from hermes_cli.auth import AuthError
+
+    singleton_calls = []
+    pool = CredentialPool("openai-codex", [_entry()])
+    monkeypatch.setattr(
+        credential_pool,
+        "get_pool_usage_limits",
+        lambda provider: {"a1b2c3": 80.0},
+    )
+    monkeypatch.setattr(
+        account_usage,
+        "fetch_account_usage",
+        lambda provider, **kwargs: _snapshot(
+            AccountUsageWindow(
+                label="Weekly",
+                used_percent=80,
+                limit_window_seconds=604_800,
+            )
+        ),
+    )
+    monkeypatch.setattr(
+        runtime_provider,
+        "resolve_provider",
+        lambda *args, **kwargs: "openai-codex",
+    )
+    monkeypatch.setattr(runtime_provider, "_get_model_config", lambda: {})
+    monkeypatch.setattr(
+        runtime_provider,
+        "_resolve_explicit_runtime",
+        lambda **kwargs: None,
+    )
+    monkeypatch.setattr(runtime_provider, "load_pool", lambda provider: pool)
+    monkeypatch.setattr(
+        runtime_provider,
+        "resolve_codex_runtime_credentials",
+        lambda: (
+            singleton_calls.append(True)
+            or {
+                "base_url": "https://chatgpt.com/backend-api/codex",
+                "api_key": "reserved-token",
+            }
+        ),
+    )
+
+    with pytest.raises(AuthError):
+        runtime_provider.resolve_runtime_provider(requested="openai-codex")
+    assert singleton_calls == []
+
+
+def test_auxiliary_codex_does_not_fall_back_after_pool_denial(monkeypatch):
+    import agent.auxiliary_client as auxiliary_client
+
+    singleton_calls = []
+    monkeypatch.setattr(
+        auxiliary_client,
+        "_select_pool_entry",
+        lambda provider: (True, None),
+    )
+    monkeypatch.setattr(
+        auxiliary_client,
+        "_read_codex_access_token",
+        lambda: singleton_calls.append(True) or "reserved-token",
+    )
+    monkeypatch.setattr(
+        auxiliary_client,
+        "usage_admission_policy_denied",
+        lambda provider: True,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        auxiliary_client,
+        "_create_openai_client",
+        lambda **kwargs: object(),
+    )
+
+    client, model = auxiliary_client._build_codex_client("gpt-5.6-codex")
+
+    assert client is None
+    assert model is None
+    assert singleton_calls == []
+
+
+def test_runtime_resolver_keeps_legacy_singleton_fallback_without_policy_denial(
+    monkeypatch,
+):
+    import hermes_cli.runtime_provider as runtime_provider
+
+    class EmptyPool:
+        def has_credentials(self):
+            return True
+
+        def select(self):
+            return None
+
+    singleton_calls = []
+    monkeypatch.setattr(
+        runtime_provider,
+        "resolve_provider",
+        lambda *args, **kwargs: "openai-codex",
+    )
+    monkeypatch.setattr(runtime_provider, "_get_model_config", lambda: {})
+    monkeypatch.setattr(
+        runtime_provider,
+        "_resolve_explicit_runtime",
+        lambda **kwargs: None,
+    )
+    monkeypatch.setattr(runtime_provider, "load_pool", lambda provider: EmptyPool())
+    monkeypatch.setattr(
+        runtime_provider,
+        "usage_admission_policy_denied",
+        lambda provider: False,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        runtime_provider,
+        "resolve_codex_runtime_credentials",
+        lambda: (
+            singleton_calls.append(True)
+            or {
+                "base_url": "https://chatgpt.com/backend-api/codex",
+                "api_key": "legacy-singleton-token",
+            }
+        ),
+    )
+
+    runtime = runtime_provider.resolve_runtime_provider(requested="openai-codex")
+
+    assert runtime["api_key"] == "legacy-singleton-token"
+    assert singleton_calls == [True]
+
+
+def test_auxiliary_codex_keeps_legacy_singleton_fallback_without_policy_denial(
+    monkeypatch,
+):
+    import agent.auxiliary_client as auxiliary_client
+
+    singleton_calls = []
+    fake_client = SimpleNamespace(
+        api_key="legacy-singleton-token",
+        base_url="https://chatgpt.com/backend-api/codex",
+        close=lambda: None,
+    )
+    monkeypatch.setattr(
+        auxiliary_client,
+        "_select_pool_entry",
+        lambda provider: (True, None),
+    )
+    monkeypatch.setattr(
+        auxiliary_client,
+        "usage_admission_policy_denied",
+        lambda provider: False,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        auxiliary_client,
+        "_read_codex_access_token",
+        lambda: singleton_calls.append(True) or "legacy-singleton-token",
+    )
+    monkeypatch.setattr(
+        auxiliary_client,
+        "_create_openai_client",
+        lambda **kwargs: fake_client,
+    )
+
+    client, model = auxiliary_client._build_codex_client("gpt-5.6-codex")
+
+    assert client is not None
+    assert model == "gpt-5.6-codex"
+    assert singleton_calls == [True]
+
+
+def test_raw_codex_token_does_not_fall_back_after_pool_denial(monkeypatch):
+    import agent.auxiliary_client as auxiliary_client
+    import hermes_cli.auth as auth
+
+    singleton_calls = []
+    monkeypatch.setattr(
+        auxiliary_client,
+        "_select_pool_entry",
+        lambda provider: (True, None),
+    )
+    monkeypatch.setattr(
+        auxiliary_client,
+        "usage_admission_policy_denied",
+        lambda provider: True,
+    )
+    monkeypatch.setattr(
+        auth,
+        "_read_codex_tokens",
+        lambda: (
+            singleton_calls.append(True)
+            or {"tokens": {"access_token": "legacy-singleton-token"}}
+        ),
+    )
+
+    assert auxiliary_client._read_codex_access_token() is None
+    assert singleton_calls == []
+
+
+def test_cached_auxiliary_codex_client_is_rechecked_after_policy_denial(monkeypatch):
+    import agent.auxiliary_client as auxiliary_client
+
+    cache_key = ("openai-codex", "codex-policy-test")
+    cached_client = SimpleNamespace(close=lambda: None)
+    monkeypatch.setattr(
+        auxiliary_client,
+        "_client_cache_key",
+        lambda *args, **kwargs: cache_key,
+    )
+    monkeypatch.setattr(
+        auxiliary_client,
+        "get_pool_usage_limits",
+        lambda provider: {"a1b2c3": 80.0},
+        raising=False,
+    )
+    monkeypatch.setattr(
+        auxiliary_client,
+        "_select_pool_entry",
+        lambda provider: (True, None),
+    )
+    monkeypatch.setattr(
+        auxiliary_client,
+        "usage_admission_policy_denied",
+        lambda provider: True,
+    )
+    with auxiliary_client._client_cache_lock:
+        auxiliary_client._client_cache.clear()
+        auxiliary_client._client_cache[cache_key] = (
+            cached_client,
+            "gpt-5.6-codex",
+            None,
+        )
+    try:
+        client, model = auxiliary_client._get_cached_client(
+            "openai-codex",
+            "gpt-5.6-codex",
+        )
+        assert client is None
+        assert model is None
+        assert cache_key not in auxiliary_client._client_cache
+    finally:
+        with auxiliary_client._client_cache_lock:
+            auxiliary_client._client_cache.clear()
+
+
+def test_cached_auxiliary_explicit_codex_client_rejects_denied_token(monkeypatch):
+    import agent.auxiliary_client as auxiliary_client
+
+    cache_key = ("openai-codex", "explicit-policy-test")
+    cached_client = SimpleNamespace(close=lambda: None)
+    monkeypatch.setattr(
+        auxiliary_client,
+        "_client_cache_key",
+        lambda *args, **kwargs: cache_key,
+    )
+    monkeypatch.setattr(
+        auxiliary_client,
+        "get_pool_usage_limits",
+        lambda provider: {"a1b2c3": 80.0},
+    )
+    monkeypatch.setattr(
+        auxiliary_client,
+        "usage_admission_credential_denied",
+        lambda provider, credential: credential == "denied-explicit-token",
+    )
+    with auxiliary_client._client_cache_lock:
+        auxiliary_client._client_cache.clear()
+        auxiliary_client._client_cache[cache_key] = (
+            cached_client,
+            "gpt-5.6-codex",
+            None,
+        )
+    try:
+        client, model = auxiliary_client._get_cached_client(
+            "openai-codex",
+            "gpt-5.6-codex",
+            api_key="denied-explicit-token",
+        )
+        assert client is None
+        assert model is None
+        assert cache_key not in auxiliary_client._client_cache
+    finally:
+        with auxiliary_client._client_cache_lock:
+            auxiliary_client._client_cache.clear()
+
+
+def test_cached_auxiliary_codex_uses_freshly_selected_eligible_entry(monkeypatch):
+    import agent.auxiliary_client as auxiliary_client
+
+    denied_key = ("openai-codex", "A")
+    eligible_key = ("openai-codex", "B")
+    denied_client = SimpleNamespace(marker="DENIED_A", close=lambda: None)
+    eligible_client = SimpleNamespace(marker="ELIGIBLE_B", close=lambda: None)
+    eligible_entry = SimpleNamespace(
+        id="B",
+        runtime_api_key="eligible-token",
+        access_token="eligible-token",
+    )
+
+    def cache_key(*args, **kwargs):
+        hint = kwargs.get("pool_hint_override")
+        return eligible_key if hint == "openai-codex:B" else denied_key
+
+    monkeypatch.setattr(auxiliary_client, "_client_cache_key", cache_key)
+    monkeypatch.setattr(
+        auxiliary_client,
+        "get_pool_usage_limits",
+        lambda provider: {"A": 80.0},
+    )
+    monkeypatch.setattr(
+        auxiliary_client,
+        "_select_pool_entry",
+        lambda provider: (True, eligible_entry),
+    )
+    monkeypatch.setattr(
+        auxiliary_client,
+        "usage_admission_policy_denied",
+        lambda provider: True,
+    )
+    with auxiliary_client._client_cache_lock:
+        auxiliary_client._client_cache.clear()
+        auxiliary_client._client_cache[denied_key] = (
+            denied_client,
+            "gpt-5.6-codex",
+            None,
+        )
+        auxiliary_client._client_cache[eligible_key] = (
+            eligible_client,
+            "gpt-5.6-codex",
+            None,
+        )
+    try:
+        client, _model = auxiliary_client._get_cached_client(
+            "openai-codex",
+            "gpt-5.6-codex",
+        )
+        assert client is eligible_client
+        assert client.marker == "ELIGIBLE_B"
+    finally:
+        with auxiliary_client._client_cache_lock:
+            auxiliary_client._client_cache.clear()
+
+
+def test_auxiliary_codex_build_uses_same_freshly_selected_entry(monkeypatch):
+    import agent.auxiliary_client as auxiliary_client
+
+    selected = SimpleNamespace(
+        id="B",
+        runtime_api_key="token-B",
+        runtime_base_url="https://chatgpt.com/backend-api/codex",
+        access_token="token-B",
+    )
+    built_with = []
+    built_client = SimpleNamespace(marker="BUILT_WITH_B", close=lambda: None)
+
+    monkeypatch.setattr(
+        auxiliary_client,
+        "get_pool_usage_limits",
+        lambda provider: {"A": 80.0},
+    )
+    monkeypatch.setattr(
+        auxiliary_client,
+        "_select_pool_entry",
+        lambda provider: (True, selected),
+    )
+    monkeypatch.setattr(
+        auxiliary_client,
+        "usage_admission_policy_denied",
+        lambda provider: True,
+    )
+
+    def build(model, *, access_token=None, base_url=None):
+        built_with.append((access_token, base_url))
+        return built_client, model
+
+    monkeypatch.setattr(auxiliary_client, "_build_codex_client", build)
+    with auxiliary_client._client_cache_lock:
+        auxiliary_client._client_cache.clear()
+    try:
+        client, _model = auxiliary_client._get_cached_client(
+            "openai-codex",
+            "gpt-5.6-codex",
+        )
+        assert client is built_client
+        assert built_with == [("token-B", "https://chatgpt.com/backend-api/codex")]
+    finally:
+        with auxiliary_client._client_cache_lock:
+            auxiliary_client._client_cache.clear()
+
+
+def test_auto_auxiliary_uses_freshly_selected_codex_entry(monkeypatch):
+    import agent.auxiliary_client as auxiliary_client
+
+    selected = SimpleNamespace(
+        id="B",
+        runtime_api_key="token-B",
+        runtime_base_url="https://chatgpt.com/backend-api/codex",
+        access_token="token-B",
+    )
+    calls = []
+    built_client = SimpleNamespace(marker="BUILT_WITH_B", close=lambda: None)
+    monkeypatch.setattr(
+        auxiliary_client,
+        "get_pool_usage_limits",
+        lambda provider: {"A": 80.0},
+    )
+    monkeypatch.setattr(
+        auxiliary_client,
+        "_select_pool_entry",
+        lambda provider: (True, selected),
+    )
+
+    def resolve(provider, model, async_mode=False, **kwargs):
+        calls.append((
+            provider,
+            kwargs.get("explicit_api_key"),
+            kwargs.get("explicit_base_url"),
+        ))
+        return built_client, model
+
+    monkeypatch.setattr(auxiliary_client, "resolve_provider_client", resolve)
+    with auxiliary_client._client_cache_lock:
+        auxiliary_client._client_cache.clear()
+    try:
+        client, _model = auxiliary_client._get_cached_client(
+            "auto",
+            "gpt-5.6-codex",
+            main_runtime={
+                "provider": "openai-codex",
+                "model": "gpt-5.6-codex",
+                "api_key": "denied-token-A",
+                "credential_pool_entry_id": "A",
+                "base_url": "https://chatgpt.com/backend-api/codex",
+            },
+        )
+        assert client is built_client
+        assert calls == [
+            (
+                "openai-codex",
+                "token-B",
+                "https://chatgpt.com/backend-api/codex",
+            )
+        ]
+    finally:
+        with auxiliary_client._client_cache_lock:
+            auxiliary_client._client_cache.clear()
+
+
+def test_auxiliary_cache_rebinds_after_same_id_codex_token_refresh(monkeypatch):
+    import agent.auxiliary_client as auxiliary_client
+
+    current = [
+        SimpleNamespace(
+            id="a1b2c3",
+            runtime_api_key="token-old",
+            runtime_base_url="https://old.example/codex",
+            access_token="token-old",
+        )
+    ]
+    built = []
+    monkeypatch.setattr(
+        auxiliary_client,
+        "get_pool_usage_limits",
+        lambda provider: {"a1b2c3": 80.0},
+    )
+    monkeypatch.setattr(
+        auxiliary_client,
+        "_select_pool_entry",
+        lambda provider: (True, current[0]),
+    )
+
+    def resolve(provider, model, async_mode=False, **kwargs):
+        client = SimpleNamespace(
+            api_key=kwargs.get("explicit_api_key"),
+            base_url=kwargs.get("explicit_base_url"),
+            close=lambda: None,
+        )
+        built.append(client)
+        return client, model
+
+    monkeypatch.setattr(auxiliary_client, "resolve_provider_client", resolve)
+    with auxiliary_client._client_cache_lock:
+        auxiliary_client._client_cache.clear()
+    try:
+        first, _model = auxiliary_client._get_cached_client(
+            "openai-codex", "gpt-5.6-codex"
+        )
+        current[0] = SimpleNamespace(
+            id="a1b2c3",
+            runtime_api_key="token-new",
+            runtime_base_url="https://new.example/codex",
+            access_token="token-new",
+        )
+        second, _model = auxiliary_client._get_cached_client(
+            "openai-codex", "gpt-5.6-codex"
+        )
+
+        assert first is not None
+        assert second is not None
+        assert first is not second
+        assert second.api_key == "token-new"
+        assert second.base_url == "https://new.example/codex"
+        assert len(built) == 2
+    finally:
+        with auxiliary_client._client_cache_lock:
+            auxiliary_client._client_cache.clear()
+
+
+def test_policy_denial_evicts_auto_clients_tagged_as_codex():
+    import agent.auxiliary_client as auxiliary_client
+
+    auto_key = ("auto", "cached-codex")
+    cached_client = SimpleNamespace(
+        _hermes_aux_effective_provider="openai-codex",
+        close=lambda: None,
+    )
+    with auxiliary_client._client_cache_lock:
+        auxiliary_client._client_cache.clear()
+        auxiliary_client._client_cache[auto_key] = (
+            cached_client,
+            "gpt-5.6-codex",
+            None,
+        )
+    try:
+        auxiliary_client._evict_cached_clients("openai-codex")
+        assert auto_key not in auxiliary_client._client_cache
+    finally:
+        with auxiliary_client._client_cache_lock:
+            auxiliary_client._client_cache.clear()
+
+
+def test_auto_auxiliary_continues_to_fallback_after_codex_policy_denial(
+    monkeypatch,
+):
+    import agent.auxiliary_client as auxiliary_client
+
+    fallback_client = SimpleNamespace(
+        _hermes_aux_effective_provider="openrouter",
+        close=lambda: None,
+    )
+    calls = []
+    monkeypatch.setattr(
+        auxiliary_client,
+        "get_pool_usage_limits",
+        lambda provider: {"a1b2c3": 80.0},
+    )
+    monkeypatch.setattr(
+        auxiliary_client,
+        "_select_pool_entry",
+        lambda provider: (True, None),
+    )
+    monkeypatch.setattr(
+        auxiliary_client,
+        "usage_admission_policy_denied",
+        lambda provider: True,
+    )
+    monkeypatch.setattr(
+        auxiliary_client, "_evict_cached_clients", lambda provider: None
+    )
+
+    def resolve(provider, model, async_mode=False, **kwargs):
+        calls.append((provider, model))
+        return fallback_client, "fallback-model"
+
+    monkeypatch.setattr(auxiliary_client, "resolve_provider_client", resolve)
+    with auxiliary_client._client_cache_lock:
+        auxiliary_client._client_cache.clear()
+    try:
+        client, model = auxiliary_client._get_cached_client(
+            "auto",
+            "gpt-5.6-codex",
+            main_runtime={
+                "provider": "openai-codex",
+                "model": "gpt-5.6-codex",
+            },
+        )
+
+        assert client is fallback_client
+        assert model == "gpt-5.6-codex"
+        assert calls == [("auto", "gpt-5.6-codex")]
+    finally:
+        with auxiliary_client._client_cache_lock:
+            auxiliary_client._client_cache.clear()
+
+
+def test_non_codex_auxiliary_pool_entry_never_inherits_codex_base_url(monkeypatch):
+    import agent.auxiliary_client as auxiliary_client
+
+    selected = SimpleNamespace(
+        id="deepseek-entry",
+        provider="deepseek",
+        runtime_api_key="legacy-pool-token",
+        runtime_base_url=None,
+        access_token="legacy-pool-token",
+    )
+    calls = []
+    monkeypatch.setattr(auxiliary_client, "get_pool_usage_limits", lambda provider: {})
+    monkeypatch.setattr(auxiliary_client, "_peek_pool_entry", lambda provider: selected)
+
+    def resolve(provider, model, async_mode=False, **kwargs):
+        calls.append(kwargs)
+        return SimpleNamespace(close=lambda: None), model
+
+    monkeypatch.setattr(auxiliary_client, "resolve_provider_client", resolve)
+    with auxiliary_client._client_cache_lock:
+        auxiliary_client._client_cache.clear()
+    try:
+        client, _model = auxiliary_client._get_cached_client(
+            "deepseek", "deepseek-chat"
+        )
+        assert client is not None
+        assert calls[0]["explicit_api_key"] == "legacy-pool-token"
+        assert calls[0]["explicit_base_url"] is None
+    finally:
+        with auxiliary_client._client_cache_lock:
+            auxiliary_client._client_cache.clear()
+
+
+def test_multiple_cold_admission_probes_run_concurrently(monkeypatch):
+    import threading
+
+    import agent.account_usage as account_usage
+    import agent.credential_pool as credential_pool
+
+    barrier = threading.Barrier(2)
+    monkeypatch.setattr(
+        credential_pool,
+        "get_pool_usage_limits",
+        lambda provider: {"A": 80.0, "B": 80.0},
+    )
+
+    def fetch(provider, **kwargs):
+        barrier.wait(timeout=1.0)
+        used = 80 if kwargs["api_key"] == "token-A" else 10
+        return _snapshot(
+            AccountUsageWindow(
+                label="Weekly",
+                used_percent=used,
+                limit_window_seconds=604_800,
+            )
+        )
+
+    monkeypatch.setattr(account_usage, "fetch_account_usage", fetch)
+    pool = CredentialPool(
+        "openai-codex",
+        [
+            _entry("A", token="token-A", priority=0),
+            _entry("B", token="token-B", priority=1),
+        ],
+    )
+
+    selected = pool.select()
+
+    assert selected is not None
+    assert selected.id == "B"
+
+
+@pytest.mark.parametrize("raw_codex", [False, True])
+def test_resolver_rejects_explicit_policy_denied_codex_token(monkeypatch, raw_codex):
+    import agent.account_usage as account_usage
+    import agent.auxiliary_client as auxiliary_client
+    import agent.credential_pool as credential_pool
+
+    monkeypatch.setattr(
+        credential_pool,
+        "get_pool_usage_limits",
+        lambda provider: {"a1b2c3": 80.0},
+    )
+    monkeypatch.setattr(
+        account_usage,
+        "fetch_account_usage",
+        lambda provider, **kwargs: _snapshot(
+            AccountUsageWindow(
+                label="Weekly",
+                used_percent=80,
+                limit_window_seconds=604_800,
+            )
+        ),
+    )
+    assert CredentialPool("openai-codex", [_entry()]).select() is None
+    assert (
+        credential_pool.usage_admission_credential_denied(
+            "openai-codex", "other-eligible-token"
+        )
+        is False
+    )
+
+    created = []
+    monkeypatch.setattr(
+        auxiliary_client,
+        "_create_openai_client",
+        lambda **kwargs: created.append(kwargs) or SimpleNamespace(**kwargs),
+    )
+
+    client, model = auxiliary_client.resolve_provider_client(
+        "openai-codex",
+        "gpt-5.6-codex",
+        raw_codex=raw_codex,
+        explicit_api_key="reserved-token",
+        explicit_base_url="https://chatgpt.com/backend-api/codex",
+    )
+
+    assert client is None
+    assert model is None
+    assert created == []
+
+
+def test_cold_explicit_matching_pool_token_is_probed_before_admission(monkeypatch):
+    import agent.account_usage as account_usage
+    import agent.credential_pool as credential_pool
+
+    pool = CredentialPool("openai-codex", [_entry()])
+    calls = []
+    monkeypatch.setattr(
+        credential_pool,
+        "get_pool_usage_limits",
+        lambda provider: {"a1b2c3": 80.0},
+    )
+    monkeypatch.setattr(credential_pool, "load_pool", lambda provider: pool)
+    monkeypatch.setattr(
+        account_usage,
+        "fetch_account_usage",
+        lambda provider, **kwargs: (
+            calls.append((provider, kwargs))
+            or _snapshot(
+                AccountUsageWindow(
+                    label="Weekly",
+                    used_percent=80,
+                    limit_window_seconds=604_800,
+                )
+            )
+        ),
+    )
+
+    assert (
+        credential_pool.usage_admission_credential_denied(
+            "openai-codex", "reserved-token"
+        )
+        is True
+    )
+    assert (
+        credential_pool.usage_admission_credential_denied(
+            "openai-codex", "unrelated-explicit-token"
+        )
+        is False
+    )
+    assert len(calls) == 1
+
+
+def test_denied_cache_decision_expires_at_quota_reset(monkeypatch):
+    import agent.credential_pool as credential_pool
+
+    now = [1_800_000_000.0]
+    monkeypatch.setattr(credential_pool.time, "time", lambda: now[0])
+    decision = credential_pool._UsageAdmissionDecision(
+        checked_at=10.0,
+        probe_succeeded=True,
+        used_percent=80.0,
+        reset_at=now[0] + 5.0,
+    )
+
+    assert credential_pool._usage_admission_decision_is_fresh(decision, 10.0)
+    now[0] += 5.0
+    assert not credential_pool._usage_admission_decision_is_fresh(decision, 10.0)
+
+
+def test_main_runtime_rejects_explicit_policy_denied_codex_token(monkeypatch):
+    import agent.account_usage as account_usage
+    import agent.credential_pool as credential_pool
+    import hermes_cli.runtime_provider as runtime_provider
+    from hermes_cli.auth import AuthError
+
+    monkeypatch.setattr(
+        credential_pool,
+        "get_pool_usage_limits",
+        lambda provider: {"a1b2c3": 80.0},
+    )
+    monkeypatch.setattr(
+        account_usage,
+        "fetch_account_usage",
+        lambda provider, **kwargs: _snapshot(
+            AccountUsageWindow(
+                label="Weekly",
+                used_percent=80,
+                limit_window_seconds=604_800,
+            )
+        ),
+    )
+    assert CredentialPool("openai-codex", [_entry()]).select() is None
+
+    with pytest.raises(AuthError) as exc_info:
+        runtime_provider._resolve_explicit_runtime(
+            provider="openai-codex",
+            requested_provider="openai-codex",
+            model_cfg={},
+            explicit_api_key="reserved-token",
+        )
+    assert exc_info.value.code == "codex_credential_usage_policy_denied"
+
+    allowed = runtime_provider._resolve_explicit_runtime(
+        provider="openai-codex",
+        requested_provider="openai-codex",
+        model_cfg={},
+        explicit_api_key="other-eligible-token",
+    )
+    assert allowed is not None
+    assert allowed["api_key"] == "other-eligible-token"
+
+
+def test_auxiliary_cache_hit_rejects_explicit_policy_denied_codex_token(
+    monkeypatch,
+):
+    import agent.auxiliary_client as auxiliary_client
+
+    cached_client = SimpleNamespace(
+        _hermes_aux_effective_provider="openai-codex",
+        close=lambda: None,
+    )
+    monkeypatch.setattr(
+        auxiliary_client,
+        "get_pool_usage_limits",
+        lambda provider: {"a1b2c3": 80.0},
+    )
+    monkeypatch.setattr(
+        auxiliary_client,
+        "usage_admission_credential_denied",
+        lambda provider, token: (
+            provider == "openai-codex" and token == "reserved-token"
+        ),
+    )
+    cache_key = auxiliary_client._client_cache_key(
+        "openai-codex",
+        async_mode=False,
+        base_url="https://chatgpt.com/backend-api/codex",
+        api_key="reserved-token",
+        model="gpt-5.6-codex",
+        pool_hint_override="",
+    )
+    with auxiliary_client._client_cache_lock:
+        auxiliary_client._client_cache[cache_key] = (
+            cached_client,
+            "gpt-5.6-codex",
+            None,
+        )
+    try:
+        client, model = auxiliary_client._get_cached_client(
+            "openai-codex",
+            "gpt-5.6-codex",
+            base_url="https://chatgpt.com/backend-api/codex",
+            api_key="reserved-token",
+        )
+        assert client is None
+        assert model is None
+        with auxiliary_client._client_cache_lock:
+            assert cache_key not in auxiliary_client._client_cache
+    finally:
+        with auxiliary_client._client_cache_lock:
+            auxiliary_client._client_cache.clear()
+
+
+def test_auto_runtime_falls_through_after_codex_pool_policy_denial(monkeypatch):
+    import hermes_cli.runtime_provider as runtime_provider
+
+    class DeniedPool:
+        def has_credentials(self):
+            return True
+
+        def select(self):
+            return None
+
+    singleton_calls = []
+    monkeypatch.setattr(
+        runtime_provider,
+        "resolve_provider",
+        lambda *args, **kwargs: "openai-codex",
+    )
+    monkeypatch.setattr(runtime_provider, "_get_model_config", lambda: {})
+    monkeypatch.setattr(
+        runtime_provider,
+        "_resolve_explicit_runtime",
+        lambda **kwargs: None,
+    )
+    monkeypatch.setattr(
+        runtime_provider,
+        "load_pool",
+        lambda provider: DeniedPool(),
+    )
+    monkeypatch.setattr(
+        runtime_provider,
+        "usage_admission_policy_denied",
+        lambda provider: True,
+    )
+    monkeypatch.setattr(
+        runtime_provider,
+        "resolve_codex_runtime_credentials",
+        lambda: singleton_calls.append(True),
+    )
+    monkeypatch.setattr(
+        runtime_provider,
+        "_resolve_openrouter_runtime",
+        lambda **kwargs: {
+            "provider": "openrouter",
+            "api_mode": "chat_completions",
+            "base_url": "https://openrouter.ai/api/v1",
+            "api_key": "unrelated-fallback-token",
+            "source": "test",
+            "requested_provider": "auto",
+        },
+    )
+
+    runtime = runtime_provider.resolve_runtime_provider(requested="auto")
+
+    assert runtime["provider"] == "openrouter"
+    assert runtime["api_key"] == "unrelated-fallback-token"
+    assert singleton_calls == []
+
+
+def test_explicit_unrelated_codex_token_does_not_relabel_as_pool_entry(monkeypatch):
+    import agent.auxiliary_client as auxiliary_client
+
+    selected_calls = []
+    cache_hints = []
+    built_with = []
+    built_client = SimpleNamespace(close=lambda: None)
+
+    monkeypatch.setattr(
+        auxiliary_client,
+        "get_pool_usage_limits",
+        lambda provider: {"a1b2c3": 80.0},
+    )
+    monkeypatch.setattr(
+        auxiliary_client,
+        "_select_pool_entry",
+        lambda provider: selected_calls.append(provider) or (True, _entry()),
+    )
+    original_cache_key = auxiliary_client._client_cache_key
+
+    def cache_key(*args, **kwargs):
+        cache_hints.append(kwargs.get("pool_hint_override"))
+        return original_cache_key(*args, **kwargs)
+
+    monkeypatch.setattr(auxiliary_client, "_client_cache_key", cache_key)
+
+    def build(model, *, access_token=None, base_url=None):
+        built_with.append((access_token, base_url))
+        return built_client, model
+
+    monkeypatch.setattr(auxiliary_client, "_build_codex_client", build)
+    with auxiliary_client._client_cache_lock:
+        auxiliary_client._client_cache.clear()
+    try:
+        client, _model = auxiliary_client._get_cached_client(
+            "openai-codex",
+            "gpt-5.6-codex",
+            api_key="unrelated-explicit-token",
+        )
+        assert client is built_client
+        assert selected_calls == []
+        assert cache_hints == [""]
+        assert built_with == [("unrelated-explicit-token", None)]
+    finally:
+        with auxiliary_client._client_cache_lock:
+            auxiliary_client._client_cache.clear()

--- a/tests/agent/test_credential_pool.py
+++ b/tests/agent/test_credential_pool.py
@@ -1280,6 +1280,53 @@ def test_least_used_strategy_selects_lowest_count(tmp_path, monkeypatch):
     assert entry.access_token == "sk-or-light"
 
 
+def test_codex_pool_usage_limit_is_read_by_credential_id(monkeypatch):
+    import agent.credential_pool as credential_pool
+
+    monkeypatch.setattr(
+        credential_pool,
+        "_load_config_safe",
+        lambda: {
+            "credential_pool_usage_limits": {
+                "openai-codex": {"a1b2c3": 80},
+            }
+        },
+    )
+
+    assert credential_pool.get_pool_usage_limits("openai-codex") == {
+        "a1b2c3": 80.0,
+    }
+
+
+def test_codex_pool_usage_limits_ignore_invalid_rows(monkeypatch):
+    import agent.credential_pool as credential_pool
+
+    monkeypatch.setattr(
+        credential_pool,
+        "_load_config_safe",
+        lambda: {
+            "credential_pool_usage_limits": {
+                "openai-codex": {
+                    "": 80,
+                    "zero": 0,
+                    "negative": -1,
+                    "too-high": 101,
+                    "not-a-number": "nope",
+                    "not-finite": float("inf"),
+                    "boolean": True,
+                    "string-number": "75",
+                    "valid": 50.5,
+                }
+            }
+        },
+    )
+
+    assert credential_pool.get_pool_usage_limits("openai-codex") == {
+        "string-number": 75.0,
+        "valid": 50.5,
+    }
+
+
 
 
 

--- a/tests/agent/test_restore_primary_pool_reselect.py
+++ b/tests/agent/test_restore_primary_pool_reselect.py
@@ -90,6 +90,7 @@ class TestRestorePrimaryPoolReselect:
             "base_url": "https://chatgpt.com/backend-api/codex",
             "api_mode": "codex_responses",
             "api_key": "original-key-entry-1",
+            "credential_pool_entry_id": "entry-1",
             "client_kwargs": {
                 "api_key": "original-key-entry-1",
                 "base_url": "https://chatgpt.com/backend-api/codex",
@@ -165,3 +166,106 @@ class TestRestorePrimaryPoolReselect:
         assert result is True
         assert "custom-endpoint.example.com" in agent.base_url
         assert "custom-endpoint.example.com" in agent._client_kwargs["base_url"]
+
+    def test_restore_stays_on_fallback_when_primary_pool_is_policy_denied(
+        self, monkeypatch
+    ):
+        from agent import account_usage, credential_pool
+
+        pool = _build_mock_pool([_make_entry("entry-1", "key-1", priority=0)])
+        agent = self._make_agent(pool)
+        agent.provider = "openrouter"
+        agent.model = "fallback-model"
+        agent.base_url = "https://openrouter.ai/api/v1"
+        agent.api_key = "fallback-key"
+        agent._client_kwargs = {
+            "api_key": "fallback-key",
+            "base_url": "https://openrouter.ai/api/v1",
+        }
+        monkeypatch.setattr(
+            credential_pool,
+            "get_pool_usage_limits",
+            lambda provider: {"entry-1": 80.0},
+        )
+        monkeypatch.setattr(
+            account_usage,
+            "fetch_account_usage",
+            lambda provider, **kwargs: account_usage.AccountUsageSnapshot(
+                provider="openai-codex",
+                source="test",
+                fetched_at=account_usage._utc_now(),
+                windows=(
+                    account_usage.AccountUsageWindow(
+                        label="Weekly",
+                        used_percent=80,
+                        limit_window_seconds=604_800,
+                    ),
+                ),
+            ),
+        )
+
+        result = agent._restore_primary_runtime()
+
+        assert result is False
+        assert agent.provider == "openrouter"
+        assert agent.api_key == "fallback-key"
+
+    def test_restore_reloads_missing_primary_pool_before_policy_admission(
+        self, monkeypatch
+    ):
+        from agent import account_usage, credential_pool
+
+        primary_pool = _build_mock_pool(
+            [_make_entry("entry-1", "original-key-entry-1", priority=0)]
+        )
+        agent = self._make_agent(primary_pool)
+        agent.provider = "openrouter"
+        agent.model = "fallback-model"
+        agent.base_url = "https://openrouter.ai/api/v1"
+        agent.api_key = "fallback-key"
+        agent._client_kwargs = {
+            "api_key": "fallback-key",
+            "base_url": "https://openrouter.ai/api/v1",
+        }
+        # A fallback without its own pool clears the attached primary pool.
+        agent._credential_pool = None
+        agent._credential_pool_entry_id = None
+        load_calls = []
+        probe_calls = []
+        monkeypatch.setattr(
+            credential_pool,
+            "load_pool",
+            lambda provider: load_calls.append(provider) or primary_pool,
+        )
+        monkeypatch.setattr(
+            credential_pool,
+            "get_pool_usage_limits",
+            lambda provider: {"entry-1": 80.0},
+        )
+        monkeypatch.setattr(
+            account_usage,
+            "fetch_account_usage",
+            lambda provider, **kwargs: (
+                probe_calls.append((provider, kwargs))
+                or account_usage.AccountUsageSnapshot(
+                    provider="openai-codex",
+                    source="test",
+                    fetched_at=account_usage._utc_now(),
+                    windows=(
+                        account_usage.AccountUsageWindow(
+                            label="Weekly",
+                            used_percent=80,
+                            limit_window_seconds=604_800,
+                        ),
+                    ),
+                )
+            ),
+        )
+
+        result = agent._restore_primary_runtime()
+
+        assert result is False
+        assert agent.provider == "openrouter"
+        assert agent.api_key == "fallback-key"
+        assert load_calls == ["openai-codex"]
+        assert len(probe_calls) == 1

--- a/tests/hermes_cli/test_auth_commands.py
+++ b/tests/hermes_cli/test_auth_commands.py
@@ -57,6 +57,21 @@ def _codex_pool_only_store(*, exhausted: bool = False) -> dict:
     }
 
 
+def test_auth_list_displays_stable_credential_id(tmp_path, monkeypatch, capsys):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    _write_auth_store(tmp_path, _codex_pool_only_store())
+
+    from hermes_cli.auth_commands import auth_list_command
+
+    class _Args:
+        provider = "openai-codex"
+
+    auth_list_command(_Args())
+
+    output = capsys.readouterr().out
+    assert "id=codex-1" in output
+
+
 @pytest.fixture(autouse=True)
 def _clear_provider_env(monkeypatch):
     for key in (

--- a/tests/hermes_cli/test_set_config_value.py
+++ b/tests/hermes_cli/test_set_config_value.py
@@ -91,6 +91,11 @@ class TestCatchAllPatterns:
 class TestConfigYamlRouting:
     """Regular config keys should go to config.yaml, NOT .env."""
 
+    def test_credential_pool_usage_limits_default_is_empty_mapping(self):
+        from hermes_cli.config_defaults import DEFAULT_CONFIG
+
+        assert DEFAULT_CONFIG["credential_pool_usage_limits"] == {}
+
     def test_simple_key(self, _isolated_hermes_home):
         set_config_value("model", "gpt-4o")
         config = _read_config(_isolated_hermes_home)
@@ -496,6 +501,7 @@ class TestValidateConfigKey:
         "telegram.bot_token",
         "mcp_servers.foo.command",
         "providers.openrouter.api_key",
+        "credential_pool_usage_limits.openai-codex.a1b2c3",
         "gateway.strict",
         "platforms.discord.enabled",
         "gateway.platforms.my_platform.extra.token",

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -1149,6 +1149,111 @@ def test_try_refresh_codex_client_credentials_handles_xai_oauth(monkeypatch):
     assert agent.api_key == "fresh-xai-token"
 
 
+def test_try_refresh_codex_singleton_rechecks_usage_admission(monkeypatch):
+    from datetime import datetime, timedelta, timezone
+
+    import agent.credential_pool as credential_pool
+    from agent.account_usage import AccountUsageSnapshot, AccountUsageWindow
+    from agent.credential_pool import (
+        AUTH_TYPE_OAUTH,
+        CredentialPool,
+        PooledCredential,
+    )
+
+    agent = _build_agent(monkeypatch)
+    agent.provider = "openai-codex"
+    agent.api_mode = "codex_responses"
+    agent._credential_pool = None
+    old_key = agent.api_key
+
+    def _fake_resolve(force_refresh=False, refresh_if_expiring=True, **_):
+        return {
+            "api_key": "fresh-singleton-token" if force_refresh else old_key,
+            "base_url": "https://chatgpt.com/backend-api/codex",
+        }
+
+    monkeypatch.setattr(
+        "hermes_cli.auth.resolve_codex_runtime_credentials",
+        _fake_resolve,
+    )
+    pool = CredentialPool(
+        "openai-codex",
+        [
+            PooledCredential(
+                provider="openai-codex",
+                id="singleton-entry",
+                label="singleton",
+                auth_type=AUTH_TYPE_OAUTH,
+                priority=0,
+                source="device_code",
+                access_token="fresh-singleton-token",
+                refresh_token="refresh-token",
+                base_url="https://chatgpt.com/backend-api/codex",
+            )
+        ],
+    )
+    monkeypatch.setattr(
+        credential_pool,
+        "get_pool_usage_limits",
+        lambda _provider: {"singleton-entry": 80.0},
+    )
+    monkeypatch.setattr(credential_pool, "load_pool", lambda _provider: pool)
+    probed_tokens = []
+
+    def _usage(_provider, *, api_key, **_kwargs):
+        probed_tokens.append(api_key)
+        return AccountUsageSnapshot(
+            provider="openai-codex",
+            source="usage_api",
+            fetched_at=datetime.now(timezone.utc),
+            windows=(
+                AccountUsageWindow(
+                    label="Weekly",
+                    used_percent=80,
+                    limit_window_seconds=604_800,
+                    reset_at=datetime.now(timezone.utc) + timedelta(days=7),
+                ),
+            ),
+        )
+
+    monkeypatch.setattr("agent.account_usage.fetch_account_usage", _usage)
+
+    assert agent._try_refresh_codex_client_credentials(force=True) is False
+    assert probed_tokens == ["fresh-singleton-token"]
+    assert agent.api_key == old_key
+
+
+def test_try_refresh_codex_singleton_admission_failure_fails_open(monkeypatch):
+    agent = _build_agent(monkeypatch)
+    agent.provider = "openai-codex"
+    agent.api_mode = "codex_responses"
+    agent._credential_pool = None
+    old_key = agent.api_key
+
+    def _fake_resolve(force_refresh=False, refresh_if_expiring=True, **_):
+        return {
+            "api_key": "fresh-singleton-token" if force_refresh else old_key,
+            "base_url": "https://chatgpt.com/backend-api/codex",
+        }
+
+    monkeypatch.setattr(
+        "hermes_cli.auth.resolve_codex_runtime_credentials",
+        _fake_resolve,
+    )
+    monkeypatch.setattr(
+        "agent.credential_pool.usage_admission_credential_denied",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(RuntimeError("probe failed")),
+    )
+    monkeypatch.setattr(
+        agent,
+        "_replace_primary_openai_client",
+        lambda *, reason: True,
+    )
+
+    assert agent._try_refresh_codex_client_credentials(force=True) is True
+    assert agent.api_key == "fresh-singleton-token"
+
+
 def test_try_refresh_codex_client_credentials_skips_xai_oauth_when_singleton_differs(monkeypatch):
     """An xai-oauth agent constructed with a non-singleton credential
     (e.g. a manual pool entry whose tokens belong to a different account

--- a/tests/run_agent/test_switch_model_pool_reload_52727.py
+++ b/tests/run_agent/test_switch_model_pool_reload_52727.py
@@ -113,6 +113,7 @@ class TestSwitchModelReloadsCredentialPool:
     def test_switch_to_same_provider_does_not_reload_pool(self):
         """Re-selecting the current provider must NOT churn the pool reference."""
         existing_pool = _make_pool("opencode-go")
+        existing_pool.entry_id_for_api_key.return_value = "entry-1"
         agent = _make_agent("opencode-go", "qwen-coder", existing_pool)
 
         load_pool_mock = MagicMock(name="load_pool")
@@ -130,6 +131,7 @@ class TestSwitchModelReloadsCredentialPool:
         # Pool must remain the same object — no churn for same-provider switch.
         assert agent._credential_pool is existing_pool
         load_pool_mock.assert_not_called()
+        assert agent._primary_runtime["credential_pool_entry_id"] == "entry-1"
 
     def test_switch_creates_pool_when_agent_had_none(self):
         """An agent without a pool that switches providers must acquire one."""

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -1005,6 +1005,91 @@ class TestChildCredentialPoolResolution(unittest.TestCase):
         result = _resolve_child_credential_pool("openrouter", parent)
         self.assertIs(result, mock_pool)
 
+    @patch(
+        "agent.credential_pool.usage_admission_credential_denied",
+        return_value=False,
+    )
+    def test_unrelated_explicit_codex_key_does_not_attach_provider_pool(
+        self, mock_denied
+    ):
+        parent = _make_mock_parent()
+        parent._credential_pool = MagicMock(provider="openai-codex")
+
+        result = _resolve_child_credential_pool(
+            "openai-codex",
+            parent,
+            "https://chatgpt.com/backend-api/codex",
+            explicit_api_key="unrelated-explicit-token",
+        )
+
+        self.assertIsNone(result)
+        mock_denied.assert_called_once_with(
+            "openai-codex", "unrelated-explicit-token"
+        )
+
+    @patch(
+        "agent.credential_pool.usage_admission_credential_denied",
+        return_value=True,
+    )
+    def test_matching_policy_denied_explicit_codex_key_fails_closed(
+        self, mock_denied
+    ):
+        parent = _make_mock_parent()
+
+        with self.assertRaisesRegex(ValueError, "usage policy"):
+            _resolve_child_credential_pool(
+                "openai-codex",
+                parent,
+                "https://chatgpt.com/backend-api/codex",
+                explicit_api_key="pooled-denied-token",
+            )
+
+        mock_denied.assert_called_once_with(
+            "openai-codex", "pooled-denied-token"
+        )
+
+    @patch(
+        "agent.credential_pool.usage_admission_credential_denied",
+        return_value=False,
+    )
+    @patch(
+        "tools.delegate_tool._load_config",
+        return_value={"api_key": "unrelated-explicit-token"},
+    )
+    def test_build_child_keeps_unrelated_explicit_codex_key_fixed(
+        self, _mock_cfg, mock_denied
+    ):
+        parent = _make_mock_parent()
+        parent.provider = "openai-codex"
+        parent.base_url = "https://chatgpt.com/backend-api/codex"
+        parent._credential_pool = MagicMock(provider="openai-codex")
+
+        with patch("run_agent.AIAgent") as mock_agent_cls:
+            child = MagicMock()
+            child._credential_pool = None
+            mock_agent_cls.return_value = child
+
+            built = _build_child_agent(
+                task_index=0,
+                goal="Use the explicit credential",
+                context=None,
+                toolsets=None,
+                model="gpt-5.5",
+                max_iterations=10,
+                task_count=1,
+                parent_agent=parent,
+                override_provider="openai-codex",
+                override_base_url="https://chatgpt.com/backend-api/codex",
+                override_api_key="unrelated-explicit-token",
+                override_api_mode="codex_responses",
+            )
+
+        self.assertIs(built, child)
+        self.assertIsNone(child._credential_pool)
+        mock_denied.assert_called_once_with(
+            "openai-codex", "unrelated-explicit-token"
+        )
+
     # --- Custom-endpoint identity resolution (issue #7833) ---
 
 
@@ -1048,6 +1133,11 @@ class TestChildCredentialLeasing(unittest.TestCase):
         child._credential_pool = MagicMock()
         child._credential_pool.acquire_lease.return_value = "cred-b"
         child._credential_pool.current.return_value = leased_entry
+        child._credential_pool.entries.return_value = [leased_entry]
+        child._credential_pool_entry_id = None
+        child._swap_credential.side_effect = lambda entry: setattr(
+            child, "_credential_pool_entry_id", entry.id
+        )
         child.run_conversation.return_value = {
             "final_response": "done",
             "completed": True,
@@ -1074,7 +1164,13 @@ class TestChildCredentialLeasing(unittest.TestCase):
         child = MagicMock()
         child._credential_pool = MagicMock()
         child._credential_pool.acquire_lease.return_value = "cred-a"
-        child._credential_pool.current.return_value = MagicMock(id="cred-a")
+        leased_entry = MagicMock(id="cred-a")
+        child._credential_pool.current.return_value = leased_entry
+        child._credential_pool.entries.return_value = [leased_entry]
+        child._credential_pool_entry_id = None
+        child._swap_credential.side_effect = lambda entry: setattr(
+            child, "_credential_pool_entry_id", entry.id
+        )
         child.run_conversation.side_effect = RuntimeError("boom")
 
         result = _run_single_child(
@@ -1085,7 +1181,147 @@ class TestChildCredentialLeasing(unittest.TestCase):
         )
 
         self.assertEqual(result["status"], "error")
+        child._swap_credential.assert_called_once_with(leased_entry)
+        child.run_conversation.assert_called_once()
         child._credential_pool.release_lease.assert_called_once_with("cred-a")
+
+    def test_run_single_child_stops_when_leased_credential_binding_fails(self):
+        from tools.delegate_tool import _run_single_child
+
+        child = MagicMock()
+        child._credential_pool = MagicMock(provider="openai-codex")
+        child._credential_pool.acquire_lease.return_value = "cred-b"
+        child._credential_pool.entries.return_value = [MagicMock(id="cred-b")]
+        child._swap_credential.side_effect = RuntimeError("binding failed")
+
+        result = _run_single_child(
+            task_index=4,
+            goal="Never use the inherited denied credential",
+            child=child,
+            parent_agent=_make_mock_parent(),
+        )
+
+        self.assertEqual(result["status"], "error")
+        self.assertEqual(result["exit_reason"], "credential_unavailable")
+        child.run_conversation.assert_not_called()
+        child._credential_pool.release_lease.assert_called_once_with("cred-b")
+
+    def test_run_single_child_binds_exact_leased_id_not_mutable_pool_cursor(self):
+        from tools.delegate_tool import _run_single_child
+
+        leased_entry = MagicMock(id="cred-a")
+        cursor_entry = MagicMock(id="cred-b")
+        child = MagicMock()
+        child._credential_pool = MagicMock(provider="openai-codex")
+        child._credential_pool.acquire_lease.return_value = "cred-a"
+        child._credential_pool.entries.return_value = [leased_entry, cursor_entry]
+        child._credential_pool.current.return_value = cursor_entry
+
+        def bind(entry):
+            child._credential_pool_entry_id = entry.id
+
+        child._swap_credential.side_effect = bind
+        child.run_conversation.return_value = {
+            "final_response": "done",
+            "completed": True,
+            "interrupted": False,
+            "api_calls": 1,
+            "messages": [],
+        }
+
+        result = _run_single_child(
+            task_index=5,
+            goal="Bind the exact leased credential",
+            child=child,
+            parent_agent=_make_mock_parent(),
+        )
+
+        self.assertEqual(result["status"], "completed")
+        child._swap_credential.assert_called_once_with(leased_entry)
+        child._credential_pool.release_lease.assert_called_once_with("cred-a")
+
+    def test_run_single_child_stops_when_lease_entry_cannot_be_resolved(self):
+        from tools.delegate_tool import _run_single_child
+
+        child = MagicMock()
+        child._credential_pool = MagicMock(provider="openai-codex")
+        child._credential_pool.acquire_lease.return_value = "cred-missing"
+        child._credential_pool.entries.return_value = [MagicMock(id="cred-other")]
+
+        result = _run_single_child(
+            task_index=6,
+            goal="Never run without the leased credential",
+            child=child,
+            parent_agent=_make_mock_parent(),
+        )
+
+        self.assertEqual(result["status"], "error")
+        self.assertEqual(result["exit_reason"], "credential_unavailable")
+        child.run_conversation.assert_not_called()
+        child._credential_pool.release_lease.assert_called_once_with("cred-missing")
+
+    @patch("agent.credential_pool.usage_admission_policy_denied", return_value=True)
+    def test_run_single_child_does_not_use_inherited_policy_denied_credential(
+        self, _policy_denied
+    ):
+        from tools.delegate_tool import _run_single_child
+
+        child = MagicMock()
+        child._credential_pool = MagicMock(provider="openai-codex")
+        child._credential_pool.acquire_lease.return_value = None
+        child._try_activate_fallback.return_value = False
+
+        result = _run_single_child(
+            task_index=2,
+            goal="Respect the Codex reserve",
+            child=child,
+            parent_agent=_make_mock_parent(),
+        )
+
+        self.assertEqual(result["status"], "error")
+        self.assertEqual(result["exit_reason"], "credential_unavailable")
+        child.run_conversation.assert_not_called()
+
+    @patch(
+        "agent.credential_pool.usage_admission_policy_denied",
+        side_effect=lambda provider: provider == "openai-codex",
+    )
+    def test_run_single_child_activates_fallback_after_policy_denial(
+        self, _policy_denied
+    ):
+        from tools.delegate_tool import _run_single_child
+
+        denied_pool = MagicMock(provider="openai-codex")
+        denied_pool.acquire_lease.return_value = None
+        fallback_pool = MagicMock(provider="anthropic")
+        fallback_pool.acquire_lease.return_value = None
+
+        child = MagicMock()
+        child._credential_pool = denied_pool
+
+        def activate_fallback():
+            child._credential_pool = fallback_pool
+            return True
+
+        child._try_activate_fallback.side_effect = activate_fallback
+        child.run_conversation.return_value = {
+            "final_response": "done on fallback",
+            "completed": True,
+            "interrupted": False,
+            "api_calls": 1,
+            "messages": [],
+        }
+
+        result = _run_single_child(
+            task_index=3,
+            goal="Use the configured fallback",
+            child=child,
+            parent_agent=_make_mock_parent(),
+        )
+
+        self.assertEqual(result["status"], "completed")
+        child._try_activate_fallback.assert_called_once_with()
+        child.run_conversation.assert_called_once()
 
 
 class TestDelegateHeartbeat(unittest.TestCase):

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -1646,6 +1646,15 @@ def _build_child_agent(
     if not override_base_url:
         effective_base_url = _inherit_parent_base_url(parent_agent, effective_base_url)
     effective_api_key = override_api_key or parent_api_key
+    configured_delegation_api_key = str(
+        delegation_cfg.get("api_key") or ""
+    ).strip()
+    explicit_delegation_api_key = (
+        effective_api_key
+        if configured_delegation_api_key
+        and configured_delegation_api_key == override_api_key
+        else None
+    )
     # Bug #20558 / PR #20563: api_mode must NOT be inherited when the child uses a
     # different provider than the parent — each provider has its own API surface
     # (e.g. MiniMax uses anthropic_messages, DeepSeek uses chat_completions).
@@ -1901,7 +1910,10 @@ def _build_child_agent(
     # Share a credential pool with the child when possible so subagents can
     # rotate credentials on rate limits instead of getting pinned to one key.
     child_pool = _resolve_child_credential_pool(
-        effective_provider, parent_agent, effective_base_url
+        effective_provider,
+        parent_agent,
+        effective_base_url,
+        explicit_api_key=explicit_delegation_api_key,
     )
     if child_pool is not None:
         child._credential_pool = child_pool
@@ -2328,15 +2340,95 @@ def _run_single_child(
 
     child_pool = getattr(child, "_credential_pool", None)
     leased_cred_id = None
+    credential_error = None
+
+    def _pool_policy_denied(pool: Any) -> bool:
+        try:
+            from agent.credential_pool import usage_admission_policy_denied
+
+            pool_provider = str(getattr(pool, "provider", "") or "")
+            return bool(
+                pool_provider and usage_admission_policy_denied(pool_provider)
+            )
+        except Exception as exc:
+            logger.debug("Failed to inspect child credential admission: %s", exc)
+            return False
+
+    def _bind_exact_lease(pool: Any, credential_id: str) -> None:
+        entries_method = getattr(pool, "entries", None)
+        swap_credential = getattr(child, "_swap_credential", None)
+        if not callable(entries_method) or not callable(swap_credential):
+            raise RuntimeError("child pool does not support exact lease binding")
+        leased_entry = next(
+            (
+                entry
+                for entry in entries_method()
+                if str(getattr(entry, "id", "") or "") == credential_id
+            ),
+            None,
+        )
+        if leased_entry is None:
+            raise RuntimeError("leased credential no longer exists in child pool")
+        swap_credential(leased_entry)
+        if str(getattr(child, "_credential_pool_entry_id", "") or "") != credential_id:
+            raise RuntimeError("child did not bind the exact leased credential")
+
     if child_pool is not None:
-        leased_cred_id = child_pool.acquire_lease()
+        raw_lease_id = child_pool.acquire_lease()
+        leased_cred_id = (
+            raw_lease_id.strip()
+            if isinstance(raw_lease_id, str) and raw_lease_id.strip()
+            else None
+        )
         if leased_cred_id is not None:
             try:
-                leased_entry = child_pool.current()
-                if leased_entry is not None and hasattr(child, "_swap_credential"):
-                    child._swap_credential(leased_entry)
+                _bind_exact_lease(child_pool, leased_cred_id)
             except Exception as exc:
                 logger.debug("Failed to bind child to leased credential: %s", exc)
+                credential_error = (
+                    "The leased credential could not be bound to the delegated "
+                    "child, so the child was not started."
+                )
+        else:
+            if _pool_policy_denied(child_pool):
+                activated = False
+                activate_fallback = getattr(child, "_try_activate_fallback", None)
+                if callable(activate_fallback):
+                    try:
+                        activated = bool(activate_fallback())
+                    except Exception as exc:
+                        logger.debug(
+                            "Failed to activate child fallback after policy denial: %s",
+                            exc,
+                        )
+                if activated:
+                    child_pool = getattr(child, "_credential_pool", None)
+                    if child_pool is not None:
+                        raw_lease_id = child_pool.acquire_lease()
+                        leased_cred_id = (
+                            raw_lease_id.strip()
+                            if isinstance(raw_lease_id, str) and raw_lease_id.strip()
+                            else None
+                        )
+                        if leased_cred_id is not None:
+                            try:
+                                _bind_exact_lease(child_pool, leased_cred_id)
+                            except Exception as exc:
+                                logger.debug(
+                                    "Failed to bind child to fallback lease: %s", exc
+                                )
+                                credential_error = (
+                                    "The fallback credential could not be bound "
+                                    "to the delegated child, so the child was not "
+                                    "started."
+                                )
+                if not activated or (
+                    leased_cred_id is None and _pool_policy_denied(child_pool)
+                ):
+                    credential_error = (
+                        "No credential is eligible under the configured usage "
+                        "admission policy, and no fallback provider is available."
+                    )
 
     # Heartbeat: periodically propagate child activity to the parent so the
     # gateway inactivity timeout doesn't fire while the subagent is working.
@@ -2499,6 +2591,17 @@ def _run_single_child(
             entry_dict["worktree"] = dict(_worktree_info)
 
     try:
+        if credential_error:
+            return {
+                "task_index": task_index,
+                "status": "error",
+                "summary": None,
+                "error": credential_error,
+                "exit_reason": "credential_unavailable",
+                "api_calls": 0,
+                "duration_seconds": round(time.monotonic() - child_start, 2),
+                "_child_role": getattr(child, "_delegate_role", None),
+            }
         _heartbeat_thread.start()
         if child_progress_cb:
             try:
@@ -4155,6 +4258,8 @@ def _resolve_child_credential_pool(
     effective_provider: Optional[str],
     parent_agent,
     effective_base_url: Optional[str] = None,
+    *,
+    explicit_api_key: Optional[str] = None,
 ):
     """Resolve a credential pool for the child agent.
 
@@ -4174,6 +4279,23 @@ def _resolve_child_credential_pool(
     ``custom:<name>`` pool key derived from the base_url) and only share the
     parent's pool when both resolve to the *same* custom endpoint.
     """
+    if explicit_api_key:
+        # An operator-supplied delegation.api_key is a fixed credential, not
+        # permission to substitute any sibling from that provider's pool.
+        # Matching pooled Codex tokens still honor their stable-ID policy;
+        # unrelated explicit tokens remain usable and never acquire a lease.
+        if str(effective_provider or "").strip().lower() == "openai-codex":
+            from agent.credential_pool import usage_admission_credential_denied
+
+            if usage_admission_credential_denied(
+                "openai-codex", explicit_api_key
+            ):
+                raise ValueError(
+                    "Explicit delegation credential is excluded by the "
+                    "configured usage policy"
+                )
+        return None
+
     if not effective_provider:
         return getattr(parent_agent, "_credential_pool", None)
 

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1097,6 +1097,20 @@ credential_pool_strategies:
 
 Options: `fill_first` (default), `round_robin`, `least_used`, `random`. See [Credential Pools](/user-guide/features/credential-pools) for full documentation.
 
+For ChatGPT/Codex pools, you can also keep an individual credential out of new
+work once its longest reported quota window reaches a percentage threshold:
+
+```yaml
+credential_pool_usage_limits:
+  openai-codex:
+    "abc123": 80  # stable credential ID from `hermes auth list openai-codex`
+```
+
+This is a soft admission limit: existing work can continue beyond the
+threshold. Hermes caches successful checks for five minutes, fails open when
+the usage endpoint is unavailable, and automatically readmits the credential
+after a fresh below-threshold result. See [Codex Soft Usage Limits](/user-guide/features/credential-pools#codex-soft-usage-limits) for semantics and rollback.
+
 ## Prompt caching
 
 Hermes turns on cross-session prompt caching automatically when the active provider supports it — no user config needed.

--- a/website/docs/user-guide/features/credential-pools.md
+++ b/website/docs/user-guide/features/credential-pools.md
@@ -134,6 +134,46 @@ credential_pool_strategies:
 | `least_used` | Always pick the key with the lowest request count |
 | `random` | Random selection among healthy keys |
 
+## Codex Soft Usage Limits
+
+Hermes can reserve part of an individual ChatGPT/Codex account's longest
+reported quota window. Configure the rule by the stable credential ID shown by
+`hermes auth list openai-codex`:
+
+```yaml
+credential_pool_usage_limits:
+  openai-codex:
+    "abc123": 80
+```
+
+The example excludes credential `abc123` from **new** selections and subagent
+leases when the longest usable Codex quota window reports `used_percent >= 80`.
+Other credentials retain their existing priority and rotation strategy. If no
+Codex credential remains eligible, Hermes continues through the configured
+fallback-provider chain.
+
+This is a soft admission limit, not a per-request hard cap. Work that already
+holds the credential may continue past the threshold. Successful usage probes
+are cached for five minutes; failed, missing, partial, or malformed probes fail
+open and are retried after 30 seconds. Configured credentials are probed
+concurrently, so cold selection waits for at most one three-second probe window
+(plus scheduling overhead), not one timeout per credential. Eligibility returns
+automatically after a fresh probe reports usage below the threshold. No policy
+state or access token is written to `auth.json`.
+
+Only `openai-codex` supports this setting. Thresholds must be finite numbers
+greater than 0 and at most 100. Rules for missing credential IDs are ignored
+with a warning.
+
+To disable a rule without removing or reauthorizing the credential:
+
+```bash
+hermes config unset credential_pool_usage_limits.openai-codex.abc123
+```
+
+Restart long-running Hermes processes after changing or removing the rule so
+they reload configuration and discard their in-memory probe cache.
+
 ## Error Recovery
 
 The pool handles different errors differently:


### PR DESCRIPTION
## What does this PR do?

Adds an opt-in, per-credential **soft usage admission limit** for pooled OpenAI Codex credentials.

Users with multiple ChatGPT/Codex subscriptions can reserve a credential before its longest reliable quota window is exhausted:

```yaml
credential_pool_usage_limits:
  openai-codex:
    "a1b2c3": 80
```

At `used_percent >= 80`, Hermes excludes that stable credential ID from **new assignments** while preserving the pool's configured strategy and priorities. Already-running work may continue, so this is deliberately a soft admission control rather than a hard request cap.

Why this approach:

- existing quota warnings and account pickers are informational;
- existing pool recovery rotates only after a provider error;
- this feature lets users reserve capacity proactively without mutating provider cooldown/error state or `auth.json`.

Telemetry ambiguity fails open. Hermes only applies the threshold when it can uniquely identify the longest reliable window. Missing, malformed, partial, tied, expired-reset, or otherwise ambiguous telemetry leaves the credential eligible.

## Related Issue / Prior Art

This PR is one concrete answer to the policy question tracked in #71095. It
chooses **per-stable-credential ceilings** and intentionally enters the existing
fallback-provider chain when no same-provider credential remains eligible.
That choice is explicit and reversible rather than a hidden global heuristic.

Directly overlapping proposals were reviewed:

- #56954 — sticky quota-aware Codex routing with a global low-watermark
- #21729 — skips near-empty Codex entries using configurable global thresholds
- #30461 — gateway routing by Codex credential source
- #47935 — provider-level usage guard

The first two share proactive routing and telemetry concerns, but this PR differs
in configuration and semantics: operators target individual stable credential
IDs, retain the existing pool strategy/order, deny at `>=` the configured
ceiling, and deliberately allow cross-provider fallback when every sibling is
excluded. The PR is opened as a draft so maintainers can choose consolidation
or this explicit per-entry contract before merge.

Adjacent work:

- #65400 / #65387 — fixes positional Session/Weekly display labels. This policy
  never trusts those labels; it selects a unique longest reliable duration and
  can rebase over the focused display fix if it lands first.
- #51597 — exact prior art for type-safe `_parse_dt` handling of unhashable reset
  values. This branch currently includes equivalent parser hardening; if that PR
  lands first, this draft should rebase and drop the duplicate hunk/tests while
  retaining the admission-policy work.
- #6551 and #84946 — advisory quota warnings
- #20075 — informational account selector and usage display
- #86072 and #78627 — failure-driven pool health and diagnostics

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] ✅ Tests (adding or improving test coverage)
- [x] 📝 Documentation update
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/account_usage.py`
  - retain quota-window duration and snapshot completeness metadata;
  - validate percentages and reset metadata defensively;
  - derive workspace account identity from explicit pooled JWTs and propagate the bounded usage-probe timeout.
- `agent/credential_pool.py`
  - parse stable-ID thresholds from `credential_pool_usage_limits`;
  - cache telemetry in process memory for 300 seconds on success and 30 seconds on failure, never beyond the provider reset;
  - fingerprint auth identity with SHA-256 instead of retaining raw tokens;
  - probe configured credentials concurrently with one bounded wait;
  - re-probe freshly minted forced-refresh tokens before assignment while keeping policy denial separate from exhaustion state;
  - apply admission checks outside the pool lock across selection, leases, OAuth refresh, and failure rotation.
- `agent/agent_init.py`, `agent/agent_runtime_helpers.py`, `agent/auxiliary_client.py`, `agent/turn_context.py`, `run_agent.py`, `hermes_cli/runtime_provider.py`, `tools/delegate_tool.py`
  - preserve stable pooled-credential provenance across fallback turns;
  - preserve unrelated explicit main-runtime credentials across automatic auxiliary routing while carrying pooled stable-ID provenance separately;
  - re-admit freshly minted singleton and exact failed auxiliary OAuth credentials before installing or retrying them;
  - prevent cross-turn restoration, singleton, explicit-token, cached-client, auxiliary, or delegation paths from resurrecting a denied entry;
  - preserve unrelated explicit credentials and the normal `auto` fallback ladder;
  - bind auxiliary construction/cache identity and delegated leases to the exact selected pool entry.
- `hermes_cli/auth_commands.py`
  - show non-secret stable credential IDs in `hermes auth list <provider>` so users can configure the policy without inspecting `auth.json`.
- `hermes_cli/config.py`, `hermes_cli/config_defaults.py`, `cli-config.yaml.example`, and user docs
  - register the open-dictionary config key and default; document behavior, caveats, and rollback.
- Tests
  - add boundary, ambiguity, cache, token-refresh race, explicit-token, auxiliary, runtime, lease, delegation, config, and ID-discovery coverage.

## Behavior and Safety Contract

- Threshold comparison is inclusive: `used_percent >= threshold` is ineligible.
- The policy currently applies only to explicitly configured `openai-codex` stable credential IDs.
- The longest unique `limit_window_seconds` wins; when duration metadata is wholly absent, a complete set of finite future resets may identify the farthest-reset window.
- Probe timeout: 3 seconds.
- Successful telemetry cache: 300 seconds; failed/malformed probe cache: 30 seconds.
- Network probes run outside the credential-pool lock.
- Probe failure or ambiguous telemetry fails open.
- Policy denial is distinct from 429 exhaustion, cooldowns, and invalid credentials.
- No policy state is persisted in `auth.json`.
- Raw credentials are neither logged nor stored in admission-cache keys.

## How to Test

1. Add at least two Codex credentials and discover their stable IDs:
   ```bash
   hermes auth list openai-codex
   ```
2. Configure a threshold for one stable ID:
   ```bash
   hermes config set credential_pool_usage_limits.openai-codex.a1b2c3 80
   ```
3. Verify selection behavior with complete longest-window telemetry:
   - 79% used → eligible
   - 80% used → excluded from new assignments
   - 81% used → excluded from new assignments
4. Remove the rule to roll back:
   ```bash
   hermes config unset credential_pool_usage_limits.openai-codex.a1b2c3
   ```
   Restart long-running Hermes processes to clear their in-memory telemetry caches.

Automated verification on current `origin/main`:

```text
scripts/run_tests.sh \
  tests/agent/test_codex_usage_admission_limit.py \
  tests/agent/test_account_usage.py \
  tests/agent/test_credential_pool.py \
  tests/agent/test_restore_primary_pool_reselect.py \
  tests/hermes_cli/test_set_config_value.py \
  tests/hermes_cli/test_auth_commands.py \
  tests/tools/test_delegate.py \
  tests/hermes_cli/test_runtime_provider_resolution.py \
  tests/run_agent/test_primary_runtime_restore.py \
  tests/run_agent/test_fallback_credential_isolation.py \
  tests/run_agent/test_switch_model_pool_reload_52727.py \
  tests/run_agent/test_run_agent_codex_responses.py \
  tests/agent/test_turn_context.py

495 passed, 0 failed
```

```text
scripts/run_tests.sh tests/agent/test_auxiliary_client.py \
  --deselect=tests/agent/test_auxiliary_client.py::TestCodexAuxiliaryAdapterTimeout::test_enforces_total_timeout_while_stream_keeps_emitting_events

183 passed, 0 failed
```

The deselected timing assertion also fails on an untouched worktree at the exact current `origin/main`; it is not introduced by this change.

Additional checks:

```text
ruff check (all changed Python files): passed
py_compile (all changed Python files): passed
git diff --check: passed
config example YAML parse: passed
temp-HERMES_HOME config set/get/unset round trip: passed
stable-ID auth-list E2E with temp HERMES_HOME: passed
private-identifier and production secret-literal scan: clean
Windows-footgun scan: 41 candidate findings = 41 on origin/main (no new findings)
```

Adjacent pool/quota coverage:

```text
scripts/run_tests.sh \
  tests/agent/test_credential_pool*.py \
  tests/hermes_cli/test_auth_codex_quota_probe.py \
  tests/run_agent/test_codex_xai_oauth_recovery.py

134 passed, 0 failed
```

Windows-footgun comparison (run once at `origin/main`, then at this head):

```text
python3 scripts/check-windows-footguns.py \
  agent/account_usage.py agent/agent_init.py \
  agent/agent_runtime_helpers.py agent/auxiliary_client.py \
  agent/credential_pool.py agent/turn_context.py run_agent.py \
  hermes_cli/auth_commands.py hermes_cli/config.py \
  hermes_cli/config_defaults.py hermes_cli/runtime_provider.py \
  tools/delegate_tool.py tests/agent/test_account_usage.py \
  tests/agent/test_auxiliary_client.py \
  tests/agent/test_codex_usage_admission_limit.py \
  tests/agent/test_credential_pool.py \
  tests/agent/test_restore_primary_pool_reselect.py \
  tests/agent/test_turn_context.py \
  tests/hermes_cli/test_auth_commands.py \
  tests/hermes_cli/test_set_config_value.py \
  tests/run_agent/test_run_agent_codex_responses.py \
  tests/run_agent/test_switch_model_pool_reload_52727.py \
  tests/tools/test_delegate.py
```

Both runs reported the same 41 pre-existing findings.

The full repository suite was not run to completion locally.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit follows Conventional Commits
- [x] I searched existing issues and PRs and documented the closest prior art above
- [x] My PR contains only changes related to this feature
- [ ] I've run the complete `pytest tests/ -q` suite — targeted current-main suites are documented above
- [x] I've added tests for the new behavior
- [x] I've tested on macOS 26.4.1 / Python 3.11.15

### Documentation & Housekeeping

- [x] Updated relevant user documentation
- [x] Updated `cli-config.yaml.example`
- [x] `CONTRIBUTING.md` / `AGENTS.md` changes are N/A
- [x] Considered cross-platform impact; implementation uses portable Python synchronization, hashing, and time primitives
- [x] Tool descriptions/schemas are N/A

## Screenshots / Logs

N/A — this is an auth/runtime policy with CLI configuration and automated regression coverage.
