### PR TITLE
fix(models): route the AI Gateway catalog fetchers through the credential-redirect guard

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -4962,7 +4962,7 @@ def _fetch_ai_gateway_models(timeout: float = 5.0) -> Optional[list[str]]:
     }
     req = urllib.request.Request(url, headers=headers)
     try:
-        with urllib.request.urlopen(req, timeout=timeout) as resp:
+        with _urlopen_model_catalog_request(req, timeout=timeout) as resp:
             data = json.loads(resp.read().decode())
             return [
                 m["id"]

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -1889,7 +1889,7 @@ def fetch_ai_gateway_models(
             f"{AI_GATEWAY_BASE_URL.rstrip('/')}/models",
             headers={"Accept": "application/json"},
         )
-        with urllib.request.urlopen(req, timeout=timeout) as resp:
+        with _urlopen_model_catalog_request(req, timeout=timeout) as resp:
             payload = json.loads(resp.read().decode())
     except Exception:
         return list(_ai_gateway_catalog_cache or fallback)
@@ -2205,7 +2205,7 @@ def fetch_ai_gateway_pricing(
             f"{cache_key}/models",
             headers={"Accept": "application/json"},
         )
-        with urllib.request.urlopen(req, timeout=timeout) as resp:
+        with _urlopen_model_catalog_request(req, timeout=timeout) as resp:
             payload = json.loads(resp.read().decode())
     except Exception:
         return _cache_catalog(cache_key, {})

--- a/tests/hermes_cli/test_ai_gateway_models.py
+++ b/tests/hermes_cli/test_ai_gateway_models.py
@@ -3,15 +3,19 @@
 Vercel AI Gateway exposes ``/v1/models`` with a richer shape than OpenAI's
 spec (type, tags, pricing). The pricing object uses ``input`` / ``output``
 where hermes's shared picker expects ``prompt`` / ``completion``; these tests
-pin the translation and the curated-list filtering.
+pin the translation, the curated-list filtering, and the credential-redirect
+guard the AI Gateway catalog calls share with the rest of ``hermes_cli.models``.
 """
 import json
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from threading import Thread
 from unittest.mock import patch, MagicMock
 
 from hermes_cli import models as models_module
 from hermes_cli.models import (
     VERCEL_AI_GATEWAY_MODELS,
     _ai_gateway_model_is_free,
+    _fetch_ai_gateway_models,
     fetch_ai_gateway_models,
     fetch_ai_gateway_pricing,
 )
@@ -159,3 +163,83 @@ def test_fetch_ai_gateway_models_falls_back_on_error():
     with patch("hermes_cli.models._urlopen_model_catalog_request", side_effect=OSError("network")):
         result = fetch_ai_gateway_models(force_refresh=True)
     assert result == list(VERCEL_AI_GATEWAY_MODELS)
+
+
+def _serve(handler_cls) -> ThreadingHTTPServer:
+    """Start a throwaway loopback HTTP server on an ephemeral port."""
+    server = ThreadingHTTPServer(("127.0.0.1", 0), handler_cls)
+    Thread(target=server.serve_forever, daemon=True).start()
+    return server
+
+
+def test_ai_gateway_probe_drops_bearer_on_cross_origin_redirect(monkeypatch):
+    """``_fetch_ai_gateway_models`` must not forward the API key across a redirect.
+
+    The probe builds its own ``Request`` carrying ``Authorization: Bearer
+    <AI_GATEWAY_API_KEY>`` and resolves its host from the user-settable
+    ``AI_GATEWAY_BASE_URL``, so stdlib's default redirect handling would hand
+    the key to whatever host a ``302`` names. Drives the real
+    ``SafeCredentialRedirectHandler`` against two loopback servers -- one
+    redirects, the other records what it received -- rather than mocking the
+    security module, mirroring the wire-level tests in
+    ``tests/hermes_cli/test_urllib_security.py``.
+    """
+    received: list[dict[str, str]] = []
+
+    class _SinkHandler(BaseHTTPRequestHandler):
+        def do_GET(self):
+            received.append(
+                {name.lower(): value for name, value in self.headers.items()}
+            )
+            body = json.dumps(
+                {
+                    "data": [
+                        {
+                            "id": "gateway/redirected-model",
+                            "type": "language",
+                            "tags": ["tool-use"],
+                        }
+                    ]
+                }
+            ).encode()
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def log_message(self, _format, *_args):
+            pass
+
+    sink = _serve(_SinkHandler)
+    sink_port = sink.server_port
+
+    class _RedirectHandler(BaseHTTPRequestHandler):
+        def do_GET(self):
+            self.send_response(302)
+            self.send_header("Location", f"http://127.0.0.1:{sink_port}/models")
+            self.end_headers()
+
+        def log_message(self, _format, *_args):
+            pass
+
+    source = _serve(_RedirectHandler)
+
+    monkeypatch.setenv("AI_GATEWAY_API_KEY", "ai-gateway-secret")
+    monkeypatch.setenv(
+        "AI_GATEWAY_BASE_URL", f"http://127.0.0.1:{source.server_port}"
+    )
+    try:
+        result = _fetch_ai_gateway_models(timeout=5)
+    finally:
+        source.shutdown()
+        sink.shutdown()
+
+    # The redirect really was followed and its payload parsed, so the
+    # assertions below are about a request that actually reached the sink.
+    assert result == ["gateway/redirected-model"]
+    assert len(received) == 1
+    headers = received[0]
+    assert "authorization" not in headers
+    # Only the credential is dropped: the cross-origin-safe headers survive.
+    assert headers.get("user-agent", "").startswith("hermes-cli/")

--- a/tests/hermes_cli/test_ai_gateway_models.py
+++ b/tests/hermes_cli/test_ai_gateway_models.py
@@ -18,7 +18,7 @@ from hermes_cli.models import (
 
 
 def _mock_urlopen(payload):
-    """Build a urlopen() context manager mock returning the given payload."""
+    """Build a catalog-opener context manager mock returning the given payload."""
     resp = MagicMock()
     resp.read.return_value = json.dumps(payload).encode()
     ctx = MagicMock()
@@ -48,7 +48,7 @@ def test_ai_gateway_pricing_translates_input_output_to_prompt_completion():
             }
         ]
     }
-    with patch("urllib.request.urlopen", return_value=_mock_urlopen(payload)):
+    with patch("hermes_cli.models._urlopen_model_catalog_request", return_value=_mock_urlopen(payload)):
         result = fetch_ai_gateway_pricing(force_refresh=True)
 
     entry = result["moonshotai/kimi-k2.5"]
@@ -60,7 +60,7 @@ def test_ai_gateway_pricing_translates_input_output_to_prompt_completion():
 
 def test_ai_gateway_pricing_returns_empty_on_fetch_failure():
     _reset_caches()
-    with patch("urllib.request.urlopen", side_effect=OSError("network down")):
+    with patch("hermes_cli.models._urlopen_model_catalog_request", side_effect=OSError("network down")):
         result = fetch_ai_gateway_pricing(force_refresh=True)
     assert result == {}
 
@@ -73,7 +73,7 @@ def test_ai_gateway_pricing_skips_entries_without_pricing_dict():
             {"id": "a/b", "pricing": {"input": "0", "output": "0"}},
         ]
     }
-    with patch("urllib.request.urlopen", return_value=_mock_urlopen(payload)):
+    with patch("hermes_cli.models._urlopen_model_catalog_request", return_value=_mock_urlopen(payload)):
         result = fetch_ai_gateway_pricing(force_refresh=True)
     assert "x/y" not in result
     assert result["a/b"] == {"prompt": "0", "completion": "0"}
@@ -97,7 +97,7 @@ def test_fetch_ai_gateway_models_filters_against_live_catalog():
             for mid in live_ids
         ]
     }
-    with patch("urllib.request.urlopen", return_value=_mock_urlopen(payload)):
+    with patch("hermes_cli.models._urlopen_model_catalog_request", return_value=_mock_urlopen(payload)):
         result = fetch_ai_gateway_models(force_refresh=True)
 
     assert [mid for mid, _ in result] == live_ids
@@ -114,7 +114,7 @@ def test_fetch_ai_gateway_models_tags_free_models():
             {"id": second_id, "pricing": {"input": "0", "output": "0"}},
         ]
     }
-    with patch("urllib.request.urlopen", return_value=_mock_urlopen(payload)):
+    with patch("hermes_cli.models._urlopen_model_catalog_request", return_value=_mock_urlopen(payload)):
         result = fetch_ai_gateway_models(force_refresh=True)
 
     by_id = dict(result)
@@ -132,7 +132,7 @@ def test_free_moonshot_model_auto_promoted_to_top_even_if_not_curated():
             {"id": unlisted_free_moonshot, "pricing": {"input": "0", "output": "0"}},
         ]
     }
-    with patch("urllib.request.urlopen", return_value=_mock_urlopen(payload)):
+    with patch("hermes_cli.models._urlopen_model_catalog_request", return_value=_mock_urlopen(payload)):
         result = fetch_ai_gateway_models(force_refresh=True)
 
     assert result[0] == (unlisted_free_moonshot, "recommended")
@@ -148,7 +148,7 @@ def test_paid_moonshot_does_not_get_auto_promoted():
             {"id": "moonshotai/some-paid-variant", "pricing": {"input": "0.001", "output": "0.002"}},
         ]
     }
-    with patch("urllib.request.urlopen", return_value=_mock_urlopen(payload)):
+    with patch("hermes_cli.models._urlopen_model_catalog_request", return_value=_mock_urlopen(payload)):
         result = fetch_ai_gateway_models(force_refresh=True)
 
     assert result[0][0] == first_curated
@@ -156,6 +156,6 @@ def test_paid_moonshot_does_not_get_auto_promoted():
 
 def test_fetch_ai_gateway_models_falls_back_on_error():
     _reset_caches()
-    with patch("urllib.request.urlopen", side_effect=OSError("network")):
+    with patch("hermes_cli.models._urlopen_model_catalog_request", side_effect=OSError("network")):
         result = fetch_ai_gateway_models(force_refresh=True)
     assert result == list(VERCEL_AI_GATEWAY_MODELS)


### PR DESCRIPTION
## What does this PR do?

`hermes_cli/models.py` has one opener for catalog HTTP: `_urlopen_model_catalog_request`, a thin wrapper over `open_credentialed_url` from `hermes_cli/urllib_security.py`. That module's docstring states the policy — *"Security policy for credential-bearing stdlib urllib requests"* — and the wrapper's own docstring states the guarantee: *"Open catalog requests without forwarding headers across origins."*

On `main` the module has **eleven** call sites going through that wrapper and **three** going through raw `urllib.request.urlopen`. All three raw ones are the AI Gateway catalog calls, and one of them carries a credential:

```python
def _fetch_ai_gateway_models(timeout: float = 5.0) -> Optional[list[str]]:
    api_key = os.getenv("AI_GATEWAY_API_KEY", "").strip()
    ...
    base_url = os.getenv("AI_GATEWAY_BASE_URL", "").strip()   # user-settable
    ...
    headers = {"Authorization": f"Bearer {api_key}", ...}
    with urllib.request.urlopen(req, timeout=timeout) as resp:   # default redirect handling
```

Stdlib's default `HTTPRedirectHandler` re-sends every header it was given when it follows a redirect, including across origins. So a `302` from the configured gateway endpoint hands `AI_GATEWAY_API_KEY` to whatever host the `Location` header names. The endpoint is user-settable — the function reads `AI_GATEWAY_BASE_URL` from the environment and only falls back to the `hermes_constants` default when it is empty — so pointing the provider at a self-hosted or proxied gateway is enough to make the redirect reachable. The function swallows every exception and the picker path (`_fetch_ai_gateway_models` is called while building the AI Gateway model list) shows the built-in curated list on failure, so nothing surfaces to the user either way.

**This is not a new class of bug in this repo — it is a hole a revert punched in an already-completed sweep.** *"fix(models): strip credentials on catalog redirects"* and *"fix(security): enforce one redirect credential policy"* landed on 2026-07-11 and converted this file's catalog calls to the wrapper. These three functions were not in the file at the time: they had been deleted by *"remove Vercel AI Gateway and Vercel Sandbox (#33067)"* on 2026-05-27, so the sweep never saw them. On 2026-07-29 *"Revert 'remove Vercel AI Gateway and Vercel Sandbox (#33067)'"* restored them verbatim — including their pre-sweep raw `urlopen` calls and the eight pre-sweep `patch("urllib.request.urlopen")` mocks in their test file. `git merge-base --is-ancestor` confirms the sweep is an ancestor of the revert, so this is purely restored-stale code, not a design decision.

Same remedy and same shape as the merged *"fix(providers): route Actual's fetch_models through the credential-redirect guard"*. The mock repoint is the same one merged as *"fix(tests): patch catalog urlopen wrapper in gemini probe tests"*.

## Related Issue

No filed issue — found by auditing this module's raw `urllib.request.urlopen` call sites against the redirect-credential policy the module already implements.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [x] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

Three atomic commits.

1. **`fix(models): route the AI Gateway model probe through the catalog opener`** — `hermes_cli/models.py`, `_fetch_ai_gateway_models`. The credential-bearing site. Call-site change only: no new import (the file already imports `open_credentialed_url` and defines `_urlopen_model_catalog_request` a few lines below it), and no change to URL resolution, headers, or parsing.

2. **`fix(models): route the remaining AI Gateway catalog fetchers through the catalog opener`** — `hermes_cli/models.py`, `fetch_ai_gateway_models` and `fetch_ai_gateway_pricing`, plus the mock repoint in `tests/hermes_cli/test_ai_gateway_models.py`. These are the other two sites the same revert restored. **They carry no credential header today, so this is not a second leak** — but they are the only catalog fetchers in the module that bypass the wrapper, and the wrapper is where the module's whole HTTP policy lives, not only its redirect rule. `open_credentialed_url` resolves an explicit TLS context through `_resolved_https_context`, which honors `HERMES_CA_BUNDLE`, `REQUESTS_CA_BUNDLE` and `CURL_CA_BUNDLE` and falls back to certifi on macOS; plain `urlopen` honors none of those except `SSL_CERT_FILE`, which the stdlib reads on its own. So behind a TLS-inspecting proxy configured through Hermes, or on a macOS Python without a usable system trust store, these two calls fail verification while the module's other eleven succeed — and both swallow the exception, so the picker silently shows the built-in `VERCEL_AI_GATEWAY_MODELS` list with no live pricing and no error.

3. **`test(models): pin cross-origin credential stripping on the AI Gateway probe`** — `tests/hermes_cli/test_ai_gateway_models.py`. Wire-level regression test for `_fetch_ai_gateway_models`, which had no coverage at all.

### Coverage of the root cause

Every raw `urllib.request.urlopen` call site in `hermes_cli/models.py` is converted; the file now has **zero**. Deliberately *not* widened beyond this file:

| Elsewhere | Why not here |
|---|---|
| `gateway/relay/media.py`, `gateway/relay/__init__.py` | already covered by an open PR |
| `dashboard_register.py`, `gateway_enroll.py`, `nous_account.py`, `nous_billing.py` | already covered by an open PR |
| `copilot_auth.py`, `web_server.py` (ElevenLabs) | hardcoded hosts — no user-settable redirect origin |
| `banner.py`, `browser_connect.py`, `debug.py`, `diagnostics_upload.py`, `model_catalog.py`, `security_audit.py`, `webhook.py`, `tui_gateway/methods_images.py` | no credential header — outside the invariant |

## How to Test

```
uv run --with pytest --with pytest-asyncio python3 -m pytest \
  tests/hermes_cli/test_ai_gateway_models.py \
  tests/hermes_cli/test_urllib_security.py \
  tests/hermes_cli/test_models.py \
  tests/hermes_cli/test_model_validation.py -q
```
⇒ `85 passed` on this branch (84 on `main`; the extra one is the new test).

**Mutation proof for commit 1.** Revert only the `_fetch_ai_gateway_models` call site to `urllib.request.urlopen` and re-run:

```
FAILED tests/hermes_cli/test_ai_gateway_models.py::test_ai_gateway_probe_drops_bearer_on_cross_origin_redirect
E   AssertionError: assert 'authorization' not in {'accept-encoding': 'identity',
E     'host': '127.0.0.1:65211', 'authorization': 'Bearer ai-gateway-secret',
E     'user-agent': 'hermes-cli/0.20.1', ...}
1 failed, 9 passed
```

The other nine tests stay green, so the failure isolates that one hunk. The sink is a second local server on a different port; the assertion is the header it actually received off the wire, with the real `SafeCredentialRedirectHandler` in the path — `hermes_cli.urllib_security` is not mocked. The test also asserts the redirect was followed and its payload parsed, so it cannot pass vacuously on a connection error, and that `user-agent` still arrives: the guard drops the credential, not every header.

**Mutation proof for commit 2.** Restore `hermes_cli/models.py` from `origin/main` (`git checkout origin/main -- hermes_cli/models.py`) with this branch's test file in place ⇒ `8 failed, 2 passed`: the seven repointed tests plus the new redirect test. Restoring the branch's version ⇒ `10 passed`.

**Pre-existing baseline, unrelated to this PR.** Running `tests/hermes_cli/test_api_key_providers.py` in the same session as the files above fails `TestDeepInfraProviderProfile::test_profile_registered_with_alias_and_aux` with `KeyError: 'DEEPINFRA_API_KEY'`. It reproduces identically on a clean `origin/main` worktree with the same command (`1 failed, 188 passed` there vs `1 failed, 189 passed` here — the extra pass is the new test) and passes in isolation on both, so it is a cross-file ordering baseline, not a regression from this change.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — ran the four focused files above (`85 passed`), not the full suite
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS (Darwin 25.4), Python 3.11.15 via `uv run`

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — the test module docstring and the `_mock_urlopen` helper docstring, which named `urlopen()` after the repoint
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — no platform-specific code; the new test binds `127.0.0.1` on an ephemeral port, the same pattern `tests/hermes_cli/test_urllib_security.py` already uses in CI
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A
