### PR TITLE
fix(update): avoid cryptography self-lock on Windows (salvage of #77517 by @duclucky)

### DIFF
--- a/agent/secret_sources/bitwarden.py
+++ b/agent/secret_sources/bitwarden.py
@@ -47,10 +47,6 @@ import zipfile
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple
 
-from cryptography.hazmat.primitives import hashes
-from cryptography.hazmat.primitives.ciphers.aead import AESGCM
-from cryptography.hazmat.primitives.kdf.hkdf import HKDF
-
 from agent.secret_sources._cache import (
     CachedFetch as _CachedFetch,
     DiskCache,
@@ -375,6 +371,13 @@ def _b64d(text: str) -> bytes:
 
 def _derive_encrypted_cache_key(access_token: str, salt: bytes) -> bytes:
     """Derive the local cache encryption key from the bootstrap BWS token."""
+    # Keep the native cryptography extension lazy.  Most CLI commands import
+    # this module while building argparse, even though only encrypted-cache
+    # reads/writes need it.  Eagerly importing it maps ``_rust.pyd`` into a
+    # Windows updater and prevents uv from replacing that file (#73381).
+    from cryptography.hazmat.primitives import hashes
+    from cryptography.hazmat.primitives.kdf.hkdf import HKDF
+
     return HKDF(
         algorithm=hashes.SHA256(),
         length=32,
@@ -397,6 +400,8 @@ def _write_encrypted_disk_cache(
     """
     path = _encrypted_disk_cache_path(home_path)
     try:
+        from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+
         cache_dir = path.parent
         cache_dir.mkdir(parents=True, exist_ok=True)
         try:
@@ -459,6 +464,8 @@ def _read_encrypted_disk_cache(
         return None
     path = _encrypted_disk_cache_path(home_path)
     try:
+        from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+
         payload = json.loads(path.read_text(encoding="utf-8"))
         if not isinstance(payload, dict):
             return None

--- a/hermes_cli/env_loader.py
+++ b/hermes_cli/env_loader.py
@@ -471,6 +471,7 @@ def load_hermes_dotenv(
     *,
     hermes_home: str | os.PathLike | None = None,
     project_env: str | os.PathLike | None = None,
+    load_external_secrets: bool = True,
 ) -> list[Path]:
     """Load Hermes environment files with user config taking precedence.
 
@@ -479,6 +480,9 @@ def load_hermes_dotenv(
     - project `.env` acts as a dev fallback and only fills missing values when
       the user env exists.
     - if no user env exists, the project `.env` also overrides stale shell vars.
+    - callers that only maintain the installation can set
+      ``load_external_secrets=False`` to avoid loading optional secret-manager
+      dependencies into the process that replaces that same environment.
     """
     loaded: list[Path] = []
 
@@ -517,14 +521,20 @@ def load_hermes_dotenv(
         _load_dotenv_with_fallback(project_env_path, override=not loaded)
         loaded.append(project_env_path)
 
-    # A fresh ``hermes update`` retry may have completed a deferred dependency
-    # install before importing this module.  Do not remap native secret-source
-    # dependencies in that same updater process or the self-lock preflight will
-    # recreate the marker and exit 2 again.  Dotenv and managed env still load;
-    # only external source resolution is unnecessary for the updater.
+    # External secret sources are skipped in two updater situations:
+    # 1. ``load_external_secrets=False`` — the caller is an ``update``
+    #    invocation that must not import optional secret-manager libraries
+    #    (Bitwarden → cryptography → ``_rust.pyd``) into the process that
+    #    replaces that same environment on Windows (#73381, #86735).
+    # 2. A fresh ``hermes update`` retry just completed a deferred dependency
+    #    install before importing this module.  Do not remap native
+    #    secret-source dependencies in that same updater process or the
+    #    self-lock preflight will recreate the marker and exit 2 again.
+    # Dotenv and managed env still load in both cases; only external source
+    # resolution is unnecessary for the updater.
     from hermes_cli import _early_recovery
 
-    if not _early_recovery._should_skip_external_secret_sources():
+    if load_external_secrets and not _early_recovery._should_skip_external_secret_sources():
         _apply_external_secret_sources(home_path)
     _apply_managed_env()
 

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -696,7 +696,17 @@ _apply_profile_override()
 from hermes_cli.config import get_hermes_home
 from hermes_cli.env_loader import load_hermes_dotenv
 
-load_hermes_dotenv(project_env=PROJECT_ROOT / ".env")
+# Updating dependencies must not import optional secret-manager libraries into
+# the updater process before ``uv`` replaces the environment.  On Windows,
+# Bitwarden's cryptography import maps ``_rust.pyd`` and the parent updater then
+# prevents its own child installer from replacing that file (#73381).  Profile
+# flags have already been stripped above, so the first remaining argument is
+# the authoritative argparse subcommand.  Dotenv/managed config still loads;
+# only external secret fetches are unnecessary for installation maintenance.
+load_hermes_dotenv(
+    project_env=PROJECT_ROOT / ".env",
+    load_external_secrets=sys.argv[1:2] != ["update"],
+)
 
 # Bridge security.redact_secrets from config.yaml → HERMES_REDACT_SECRETS env
 # var BEFORE hermes_logging imports agent.redact (which snapshots the flag at

--- a/tests/hermes_cli/test_update_secret_import_lock.py
+++ b/tests/hermes_cli/test_update_secret_import_lock.py
@@ -1,0 +1,119 @@
+"""Regression coverage for Windows updater self-locking native dependencies.
+
+External secret backends are useful during normal Hermes startup, but the
+updater must not load them before replacing packages in its own environment.
+On Windows, importing Bitwarden's ``cryptography`` dependency maps
+``_rust.pyd`` into the updater process and prevents ``uv`` from replacing it.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import env_loader
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _probe_startup_modules(
+    tmp_path: Path, argv: list[str], *, run_main: bool = False
+) -> set[str]:
+    home = tmp_path / "hermes-home"
+    home.mkdir()
+    (home / "config.yaml").write_text(
+        """\
+secrets:
+  bitwarden:
+    enabled: true
+    project_id: test-project
+""",
+        encoding="utf-8",
+    )
+
+    dispatch = (
+        "hermes_main.cmd_update = lambda _args: 0\n"
+        "hermes_main.main()\n"
+        if run_main
+        else ""
+    )
+    probe = (
+        "import json, sys\n"
+        f"sys.argv = {argv!r}\n"
+        "import hermes_cli.main as hermes_main\n"
+        f"{dispatch}"
+        "print('LOADED_MODULES=' + json.dumps(sorted(sys.modules)))\n"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", probe],
+        capture_output=True,
+        text=True,
+        timeout=120,
+        cwd=REPO_ROOT,
+        env={**os.environ, "HERMES_HOME": str(home), "BWS_ACCESS_TOKEN": ""},
+    )
+    assert result.returncode == 0, result.stderr
+    line = next(
+        line for line in result.stdout.splitlines() if line.startswith("LOADED_MODULES=")
+    )
+    return set(json.loads(line.removeprefix("LOADED_MODULES=")))
+
+
+def test_update_startup_does_not_import_bitwarden_or_cryptography(tmp_path):
+    loaded = _probe_startup_modules(tmp_path, ["hermes", "update", "--check"])
+
+    assert "agent.secret_sources.bitwarden" not in loaded
+    assert not any(
+        name == "cryptography" or name.startswith("cryptography.") for name in loaded
+    )
+
+
+def test_complete_update_dispatch_does_not_import_cryptography(tmp_path):
+    """Building every CLI parser used to re-import Bitwarden via secrets_cli."""
+    loaded = _probe_startup_modules(
+        tmp_path,
+        ["hermes", "update", "--check"],
+        run_main=True,
+    )
+
+    assert not any(
+        name == "cryptography" or name.startswith("cryptography.") for name in loaded
+    )
+
+
+def test_normal_startup_still_loads_enabled_external_secret_source(tmp_path):
+    loaded = _probe_startup_modules(tmp_path, ["hermes", "chat"])
+
+    assert "agent.secret_sources.bitwarden" in loaded
+
+
+@pytest.mark.parametrize("external_secrets", [True, False])
+def test_dotenv_loading_is_preserved_when_external_secrets_are_skipped(
+    tmp_path, monkeypatch, external_secrets
+):
+    home = tmp_path / "hermes-home"
+    home.mkdir()
+    env_file = home / ".env"
+    env_file.write_text("UPDATE_TEST_VALUE=from-dotenv\n", encoding="utf-8")
+    applied = []
+    monkeypatch.delenv("UPDATE_TEST_VALUE", raising=False)
+    monkeypatch.setattr(
+        env_loader,
+        "_apply_external_secret_sources",
+        lambda path: applied.append(path),
+    )
+
+    loaded = env_loader.load_hermes_dotenv(
+        hermes_home=home,
+        load_external_secrets=external_secrets,
+    )
+
+    assert loaded == [env_file]
+    assert os.environ["UPDATE_TEST_VALUE"] == "from-dotenv"
+    assert applied == ([home] if external_secrets else [])


### PR DESCRIPTION
## Summary
`hermes update` on Windows can never complete: every CLI process imports Bitwarden's `cryptography` (`_rust.pyd`) at startup via external secret-source resolution, so the updater's self-lock preflight always fires, defers the dependency sync with exit 2, and the desktop hand-off relaunches the old build — a permanent defer loop with no working update path (#86735, P0).

This salvages @duclucky's PR #77517: make the cryptography imports in `agent/secret_sources/bitwarden.py` lazy (only encrypted-cache reads/writes need them), and skip external secret-source resolution entirely when the CLI invocation is `update` (`load_hermes_dotenv(load_external_secrets=False)`).

## Changes
- `agent/secret_sources/bitwarden.py`: move the three `cryptography.hazmat` imports into `_derive_encrypted_cache_key` / `_write_encrypted_disk_cache` / `_read_encrypted_disk_cache`
- `hermes_cli/env_loader.py`: new `load_external_secrets` kwarg; merged with the existing `_should_skip_external_secret_sources()` post-recovery guard (both must allow before `_apply_external_secret_sources` runs)
- `hermes_cli/main.py`: pass `load_external_secrets=sys.argv[1:2] != ["update"]`
- `tests/hermes_cli/test_update_secret_import_lock.py`: subprocess probes asserting the update path never imports `cryptography`, and normal startup still resolves the enabled secret source

## Validation
| | Before | After |
|---|---|---|
| `hermes update` (Windows, Bitwarden configured or not) | self-lock defer loop, exit 2 forever | dependency sync runs |
| `tests/hermes_cli/test_update_secret_import_lock.py` | n/a | 5/5 pass |
| self-lock + early-recovery suites | — | 40/41 pass (1 pre-existing fail on origin/main, env-specific) |

## Infographic

![Windows update self-lock fixed](https://v3b.fal.media/files/b/0aa67aa1/JOfw5JSGLgjvkVxbREHcm_VLronnTj.png)
