### PR TITLE
fix(shell-hooks): warn when configured hooks are never registered

### DIFF
--- a/agent/shell_hooks.py
+++ b/agent/shell_hooks.py
@@ -185,6 +185,12 @@ _STDERR_MESSAGE_LIMIT = 400
 _registered: Set[Tuple[str, Optional[str], str]] = set()
 _registered_lock = threading.Lock()
 
+# One-shot guard for the "configured but never registered" warning below.
+# Separate from ``_registered_lock`` so the warning path never contends
+# with registration.
+_unregistered_warning_lock = threading.Lock()
+_unregistered_warning_emitted = False
+
 # Intra-process lock for allowlist read-modify-write on platforms that
 # lack ``fcntl`` (non-POSIX).  Kept separate from ``_registered_lock``
 # because ``register_from_config`` already holds ``_registered_lock`` when
@@ -332,6 +338,85 @@ def iter_configured_hooks(cfg: Optional[Dict[str, Any]]) -> List[ShellHookSpec]:
     return _parse_hooks_block(cfg.get("hooks"))
 
 
+def warn_if_configured_but_unregistered(
+    cfg: Optional[Dict[str, Any]] = None,
+) -> bool:
+    """Warn once if ``hooks:`` is configured but nothing ever registered it.
+
+    :func:`register_from_config` is the only path that wires the ``hooks:``
+    block onto the plugin manager, and it is called from the CLI and
+    gateway entry points.  Code that drives :class:`AIAgent` directly — the
+    supported embedding path documented in "Using Hermes as a Python
+    Library" — never reaches those call sites, so a populated ``hooks:``
+    block is inert: every ``invoke_hook()`` dispatch finds zero handlers
+    and the configured scripts never run.
+
+    Nothing about that is observable today.  There is no error, no log
+    line, and ``hermes hooks list`` still shows the hooks as configured
+    because it reads the config rather than the manager.  This turns that
+    silence into one actionable warning.
+
+    Advisory only: it never registers anything and never raises.  Returns
+    ``True`` when a warning was emitted.
+    """
+    global _unregistered_warning_emitted
+
+    with _unregistered_warning_lock:
+        if _unregistered_warning_emitted:
+            return False
+
+        with _registered_lock:
+            if _registered:
+                # Something already registered hooks in this process, so
+                # the bridge is live and there is nothing to warn about.
+                return False
+
+        # Safe mode skips registration deliberately (see
+        # ``register_from_config``); warning there would be noise.
+        from utils import env_var_enabled
+
+        if env_var_enabled("HERMES_SAFE_MODE"):
+            return False
+
+        if cfg is None:
+            try:
+                # Read-only fast path: this check only reads ``hooks:`` and
+                # discards the parsed specs, so it does not need the
+                # defensive deepcopy ``load_config()`` pays for. Every
+                # ``AIAgent`` construction reaches here when no hooks are
+                # configured, so the deepcopy would be pure overhead on a
+                # path that never mutates.
+                from hermes_cli.config import load_config_readonly
+
+                cfg = load_config_readonly()
+            except Exception:
+                logger.debug(
+                    "could not load config for shell-hook registration check",
+                    exc_info=True,
+                )
+                return False
+
+        specs = iter_configured_hooks(cfg)
+        if not specs:
+            return False
+
+        events = sorted({spec.event for spec in specs})
+        logger.warning(
+            "%d shell hook(s) are configured for %s but none are registered "
+            "in this process, so they will not fire. register_from_config() "
+            "wires the `hooks:` block onto the plugin manager and is only "
+            "called by the CLI and gateway entry points; embedders driving "
+            "AIAgent directly must call it themselves: "
+            "`from agent.shell_hooks import register_from_config; "
+            "from hermes_cli.config import load_config; "
+            "register_from_config(load_config())`.",
+            len(specs),
+            ", ".join(events),
+        )
+        _unregistered_warning_emitted = True
+        return True
+
+
 def re_register_config_hooks() -> None:
     """Re-register shell hooks from config after a plugin force-reload.
 
@@ -355,8 +440,12 @@ def re_register_config_hooks() -> None:
 
 def reset_for_tests() -> None:
     """Clear the idempotence set.  Test-only helper."""
+    global _unregistered_warning_emitted
+
     with _registered_lock:
         _registered.clear()
+    with _unregistered_warning_lock:
+        _unregistered_warning_emitted = False
 
 
 # ---------------------------------------------------------------------------

--- a/run_agent.py
+++ b/run_agent.py
@@ -599,6 +599,18 @@ class AIAgent:
             pass_session_id=pass_session_id,
         )
 
+        # Advisory: a populated ``hooks:`` block is inert unless something
+        # called ``register_from_config()``, which only the CLI and gateway
+        # entry points do.  Embedders constructing AIAgent directly would
+        # otherwise get silently dead hooks.  One-shot per process and
+        # never fatal.
+        try:
+            from agent.shell_hooks import warn_if_configured_but_unregistered
+
+            warn_if_configured_but_unregistered()
+        except Exception:
+            logger.debug("shell-hook registration check failed", exc_info=True)
+
     def _get_session_db_for_recall(self):
         """Return a SessionDB for recall, lazily creating it if an entrypoint forgot.
 

--- a/tests/agent/test_shell_hooks_unregistered_warning.py
+++ b/tests/agent/test_shell_hooks_unregistered_warning.py
@@ -1,0 +1,78 @@
+"""Tests for the "configured but never registered" shell-hook warning.
+
+``register_from_config()`` is the only path that wires the ``hooks:`` block
+onto the plugin manager, and only the CLI and gateway entry points call it.
+Embedders driving ``AIAgent`` directly get a silently inert ``hooks:`` block.
+``warn_if_configured_but_unregistered()`` makes that state observable.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from agent import shell_hooks
+
+
+@pytest.fixture(autouse=True)
+def _reset_registration_state():
+    shell_hooks.reset_for_tests()
+    yield
+    shell_hooks.reset_for_tests()
+
+
+def _cfg(command: str = "/tmp/hook.sh") -> dict:
+    return {"hooks": {"post_tool_call": [{"command": command}]}}
+
+
+def test_warns_when_hooks_configured_but_nothing_registered(caplog):
+    with caplog.at_level(logging.WARNING, logger=shell_hooks.logger.name):
+        assert shell_hooks.warn_if_configured_but_unregistered(_cfg()) is True
+
+    assert "post_tool_call" in caplog.text
+    # The warning must name the fix, not just the symptom.
+    assert "register_from_config" in caplog.text
+
+
+def test_warning_is_one_shot_per_process(caplog):
+    assert shell_hooks.warn_if_configured_but_unregistered(_cfg()) is True
+
+    # caplog accumulates across the whole test, so drop the first warning
+    # before asserting the second call stays silent.
+    caplog.clear()
+
+    with caplog.at_level(logging.WARNING, logger=shell_hooks.logger.name):
+        assert shell_hooks.warn_if_configured_but_unregistered(_cfg()) is False
+
+    assert caplog.text == ""
+
+
+def test_silent_when_no_hooks_configured():
+    assert shell_hooks.warn_if_configured_but_unregistered({}) is False
+    assert shell_hooks.warn_if_configured_but_unregistered({"hooks": {}}) is False
+
+
+def test_silent_when_registration_already_happened():
+    # Simulate a CLI/gateway boot having registered a hook.
+    shell_hooks._registered.add(("post_tool_call", None, "/tmp/hook.sh"))
+
+    assert shell_hooks.warn_if_configured_but_unregistered(_cfg()) is False
+
+
+def test_silent_in_safe_mode(monkeypatch):
+    # Safe mode skips registration deliberately; warning there is noise.
+    monkeypatch.setenv("HERMES_SAFE_MODE", "1")
+
+    assert shell_hooks.warn_if_configured_but_unregistered(_cfg()) is False
+
+
+def test_never_raises_on_unloadable_config(monkeypatch):
+    def _boom():
+        raise RuntimeError("no config here")
+
+    monkeypatch.setattr("hermes_cli.config.load_config_readonly", _boom)
+
+    # cfg=None takes the config-loading path; a failure must degrade to a
+    # no-op rather than break agent construction.
+    assert shell_hooks.warn_if_configured_but_unregistered() is False


### PR DESCRIPTION
## What does this PR do?

`agent.shell_hooks.register_from_config()` is the only path that wires the
`hooks:` block onto the plugin manager. Code that drives `AIAgent` directly —
the embedding path documented in "Using Hermes as a Python Library" — never
reaches that call, so a populated `hooks:` block is inert: every
`invoke_hook()` dispatch finds zero handlers and the configured scripts never
run.

Nothing about that state is observable. There is no error and no log line, and
`hermes hooks list` still reports the hooks as configured because it reads the
config rather than the manager. The failure mode is that hooks appear correctly
wired and simply never fire.

This adds `warn_if_configured_but_unregistered()`, which emits **one warning per
process** when `hooks:` parses to at least one spec and nothing has registered in
this process, naming the affected events and the exact call that fixes it.
`AIAgent.__init__` calls it behind a `try/except`.

**This is advisory only.** It registers nothing and changes no behavior. It stays
silent when hooks are already registered, when none are configured, under
`HERMES_SAFE_MODE`, and when the config cannot be loaded.

### Why this shape

There is an existing cluster of PRs adding `register_from_config()` calls to
individual surfaces (serve/dashboard, TUI, Web UI, ACP). This PR deliberately
does **not** do that — it is orthogonal and should not conflict with whichever
of those lands. Auto-registering global hooks from a per-instance constructor
is a different and much larger decision: subagents construct many `AIAgent`
instances, and consent prompts would then fire from library code. Making the
silent state observable is the part that is safe to do unconditionally, and it
keeps reporting the truth no matter which surfaces get fixed.

## Related Issue

This is a diagnostic, so it does not close the registration bugs — it makes them
self-reporting instead of silent. It is most directly a runtime counterpart to:

Refs #69836 — `hooks doctor` reports hooks healthy without verifying that any
process actually registered them. (#70460 addresses that from the CLI side by
scoping doctor's verdict; this warns from the runtime side. They are
complementary, not overlapping.)

Refs #85367, #83980, #41457 — the "configured hooks never registered on
surface X" cluster. Each of those stays silent today; with this change any such
surface announces itself.

Happy to retarget or split if maintainers would rather see this land against a
single issue.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/shell_hooks.py` — add `warn_if_configured_but_unregistered()`, plus a
  dedicated one-shot guard (`_unregistered_warning_lock`,
  `_unregistered_warning_emitted`) kept separate from `_registered_lock` so the
  warning path never contends with registration. `reset_for_tests()` clears the
  new guard.
- `run_agent.py` — call it once from `AIAgent.__init__`, wrapped in
  `try/except` so a diagnostic can never break agent construction.
- The config read uses `load_config_readonly()` rather than `load_config()`:
  the check only reads `hooks:` and discards the parsed specs, and when no
  hooks are configured every `AIAgent` construction reaches this path, so the
  defensive deepcopy would be pure overhead on a path that never mutates.
- `tests/agent/test_shell_hooks_unregistered_warning.py` — new, 6 cases.

## How to Test

1. Put a hook in `config.yaml`:
   ```yaml
   hooks:
     pre_tool_call:
       - command: "echo fired"
   ```
2. Drive `AIAgent` directly (the library path), without calling
   `register_from_config()`. Before this change: silence, and the hook never
   fires. After: one `WARNING` naming `pre_tool_call` and the call to add.
3. Now call `register_from_config(load_config())` first and construct again —
   the warning is silent, because registration happened.
4. `pytest tests/agent/test_shell_hooks_unregistered_warning.py -q`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate — the existing hooks PRs all add `register_from_config()` calls to specific surfaces; none add a runtime diagnostic
- [x] My PR contains **only** changes related to this fix
- [x] I've run the hook suites locally on the CI environment (`uv sync --locked
      --python 3.11`): `tests/agent/test_shell_hooks.py`,
      `test_shell_hooks_consent.py` and the new file — 61 passed. Deferring the
      full `tests/ -q` sweep to CI, which runs it per-file
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15 (Darwin 25.5)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (docstrings on the new function) — the
      user-facing hooks docs describe configuration, which is unchanged
- [x] N/A — no config keys added or changed
- [x] N/A — no architecture or workflow change
- [x] Cross-platform: no platform-specific code; the new path is a lock, a
      config read, and a `logger.warning`
- [x] N/A — no tool behavior changed
