### PR TITLE
fix(desktop): forward Windows SSH loopback previews

### DIFF
--- a/apps/desktop/electron/forwarded-preview-session.test.ts
+++ b/apps/desktop/electron/forwarded-preview-session.test.ts
@@ -1,0 +1,93 @@
+import assert from 'node:assert/strict'
+
+import { test } from 'vitest'
+
+import { leaseForwardedPreviewSession } from './forwarded-preview-session'
+
+test('isolates a forwarded preview and revokes it at the tunnel deadline', async () => {
+  let beforeRequest: ((details: { url: string }, callback: (result: { cancel: boolean }) => void) => void) | undefined
+  let permissionCheck: (() => boolean) | undefined
+
+  let permissionRequest:
+    ((contents: unknown, permission: string, callback: (allowed: boolean) => void) => void) | undefined
+
+  let willDownload: ((event: { preventDefault: () => void }) => void) | undefined
+  let devicePermission: (() => boolean) | undefined
+  let displayMediaRequest: ((request: unknown, callback: (streams: object) => void) => void) | undefined
+  let expire: (() => void) | undefined
+  let closeCalls = 0
+
+  const lease = leaseForwardedPreviewSession(
+    {
+      closeAllConnections: async () => {
+        closeCalls += 1
+      },
+      on: (_event, handler) => {
+        willDownload = handler
+      },
+      setDevicePermissionHandler: handler => {
+        devicePermission = handler
+      },
+      setDisplayMediaRequestHandler: handler => {
+        displayMediaRequest = handler
+      },
+      setPermissionCheckHandler: handler => {
+        permissionCheck = handler
+      },
+      setPermissionRequestHandler: handler => {
+        permissionRequest = handler
+      },
+      webRequest: {
+        onBeforeRequest: (_filter, handler) => {
+          beforeRequest = handler
+        }
+      }
+    },
+    'http://127.0.0.1:49152/report.html',
+    1_000,
+    {
+      now: () => 999,
+      setTimer: callback => {
+        expire = callback
+
+        return { unref: () => undefined }
+      }
+    }
+  )
+
+  assert.ok(lease)
+  assert.equal(permissionCheck?.(), false)
+  let permissionAllowed = true
+  permissionRequest?.(null, 'geolocation', allowed => {
+    permissionAllowed = allowed
+  })
+  assert.equal(permissionAllowed, false)
+  assert.equal(devicePermission?.(), false)
+  let displayStreams: object | undefined
+  displayMediaRequest?.({}, streams => {
+    displayStreams = streams
+  })
+  assert.deepEqual(displayStreams, {})
+  let downloadPrevented = false
+  willDownload?.({ preventDefault: () => (downloadPrevented = true) })
+  assert.equal(downloadPrevented, true)
+
+  const cancelled = (url: string) => {
+    let result: { cancel: boolean } | undefined
+    beforeRequest?.({ url }, value => {
+      result = value
+    })
+
+    return result?.cancel
+  }
+
+  assert.equal(cancelled('http://127.0.0.1:49152/app.js'), false)
+  assert.equal(cancelled('ws://127.0.0.1:49152/hmr'), false)
+  assert.equal(cancelled('http://127.0.0.1:3000/private'), true)
+  assert.equal(cancelled('file:///C:/Users/example/secret.txt'), true)
+
+  expire?.()
+  await Promise.resolve()
+  assert.equal(cancelled('http://127.0.0.1:49152/app.js'), true)
+  assert.equal(closeCalls, 1)
+})

--- a/apps/desktop/electron/forwarded-preview-session.ts
+++ b/apps/desktop/electron/forwarded-preview-session.ts
@@ -1,0 +1,79 @@
+interface ForwardedPreviewSession {
+  closeAllConnections: () => Promise<void>
+  on: (event: 'will-download', handler: (event: { preventDefault: () => void }) => void) => unknown
+  setDevicePermissionHandler?: (handler: () => boolean) => void
+  setDisplayMediaRequestHandler?: (
+    handler: (request: unknown, callback: (streams: Record<string, never>) => void) => void
+  ) => void
+  setPermissionCheckHandler: (handler: () => boolean) => void
+  setPermissionRequestHandler: (
+    handler: (webContents: unknown, permission: string, callback: (allowed: boolean) => void) => void
+  ) => void
+  webRequest: {
+    onBeforeRequest: (
+      filter: { urls: string[] },
+      handler: (details: { url: string }, callback: (result: { cancel: boolean }) => void) => void
+    ) => void
+  }
+}
+
+interface LeaseOptions {
+  now?: () => number
+  setTimer?: (callback: () => void, delayMs: number) => ReturnType<typeof setTimeout> | { unref?: () => void }
+}
+
+function networkOrigin(raw: string): string | null {
+  try {
+    const url = new URL(raw)
+    const protocol = url.protocol === 'ws:' ? 'http:' : url.protocol === 'wss:' ? 'https:' : url.protocol
+
+    if (protocol !== 'http:' && protocol !== 'https:') {
+      return null
+    }
+
+    return `${protocol}//${url.hostname.toLowerCase()}:${url.port || (protocol === 'https:' ? '443' : '80')}`
+  } catch {
+    return null
+  }
+}
+
+export function leaseForwardedPreviewSession(
+  previewSession: ForwardedPreviewSession,
+  forwardedUrl: string,
+  expiresAt: number,
+  options: LeaseOptions = {}
+): { revoke: () => void } | null {
+  const allowedOrigin = networkOrigin(forwardedUrl)
+  const remainingMs = expiresAt - (options.now ?? Date.now)()
+
+  if (!allowedOrigin || !Number.isFinite(remainingMs) || remainingMs <= 0) {
+    return null
+  }
+
+  let revoked = false
+  previewSession.setPermissionCheckHandler(() => false)
+  previewSession.setPermissionRequestHandler((_contents, _permission, callback) => callback(false))
+  previewSession.setDevicePermissionHandler?.(() => false)
+  previewSession.setDisplayMediaRequestHandler?.((_request, callback) => callback({}))
+  previewSession.on('will-download', event => event.preventDefault())
+  previewSession.webRequest.onBeforeRequest({ urls: ['<all_urls>'] }, (details, callback) => {
+    const url = details.url
+    const allowed = url.startsWith('data:') || url.startsWith('about:') || networkOrigin(url) === allowedOrigin
+    callback({ cancel: revoked || !allowed })
+  })
+
+  const revoke = () => {
+    if (revoked) {
+      return
+    }
+
+    revoked = true
+    void previewSession.closeAllConnections()
+  }
+
+  const timer = (options.setTimer ?? setTimeout)(revoke, remainingMs)
+
+  ;(timer as { unref?: () => void }).unref?.()
+
+  return { revoke }
+}

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -126,6 +126,7 @@ import {
   stopFind
 } from './find-in-page'
 import { createFirstRunSetupGate } from './first-run-setup-gate'
+import { leaseForwardedPreviewSession } from './forwarded-preview-session'
 import { readDirForIpc } from './fs-read-dir'
 import {
   filenameFromContentDisposition,
@@ -208,6 +209,7 @@ import { runNativeLogin } from './native-oauth-login'
 import { loadNativeTokenSet, type NativeTokenStoreIo, persistNativeTokenSet } from './native-token-store'
 import { serializeJsonBody, setJsonRequestHeaders } from './oauth-net-request'
 import { createKeepAwake } from './power-save'
+import { classifyPreviewBackendRoute } from './preview-backend-route'
 import { FirstRunSetupResetError, runPrimaryBackendStartup } from './primary-backend-startup'
 import { rehomePrimaryConnection } from './primary-connection-rehome'
 import { decideProfileDeleteAction, profileNameFromDeleteRequest, resolveRouteProfile } from './profile-delete-routing'
@@ -245,6 +247,13 @@ import {
   redactSecrets,
   SshConnection
 } from './ssh-connection'
+import { refreshSshOwner, SshOwnerRegistry } from './ssh-owner-registry'
+import {
+  isLoopbackPreviewTarget,
+  openSshPreviewForward,
+  parseSshPreviewTarget,
+  revokeSshPreviewCapabilities
+} from './ssh-preview-target'
 import { createStreamThrottle } from './stream-throttle'
 import { nativeOverlayWidth as computeNativeOverlayWidth, macTitleBarOverlayHeight } from './titlebar-overlay-width'
 import {
@@ -5328,7 +5337,7 @@ async function previewFileTarget(rawTarget, baseDir) {
   }
 }
 
-function previewUrlTarget(rawTarget) {
+function previewUrlTarget(rawTarget, allowPublic = false) {
   const raw = String(rawTarget || '').trim()
   const url = new URL(raw)
 
@@ -5336,7 +5345,7 @@ function previewUrlTarget(rawTarget) {
     return null
   }
 
-  if (!LOCAL_PREVIEW_HOSTS.has(url.hostname.toLowerCase())) {
+  if (!allowPublic && !LOCAL_PREVIEW_HOSTS.has(url.hostname.toLowerCase())) {
     return null
   }
 
@@ -5352,7 +5361,142 @@ function previewUrlTarget(rawTarget) {
   }
 }
 
-async function normalizePreviewTarget(rawTarget, baseDir) {
+async function sshForwardedPreviewTarget(rawTarget, sourceProfile, sourceConnectionId) {
+  if (!isLoopbackPreviewTarget(rawTarget)) {
+    return undefined
+  }
+
+  const profile = String(sourceProfile || '').trim()
+  const connectionId = String(sourceConnectionId || '').trim()
+  const config = readDesktopConnectionConfig()
+
+  const registryConnection = connectionId
+    ? readDesktopConnectionsRegistry().connections.find(connection => connection.id === connectionId)
+    : null
+
+  const route = classifyPreviewBackendRoute({
+    globalMode: config.mode,
+    hasEnvRemote: Boolean(process.env.HERMES_DESKTOP_REMOTE_URL),
+    hasProfileRemote: Boolean(profileRemoteOverride(config, profile)),
+    hasProfileSsh: Boolean(profileSshOverride(config, profile)),
+    registryConnectionKind: registryConnection?.kind ?? null,
+    sourceConnectionId: connectionId,
+    sourceProfile: profile
+  })
+
+  if (route === 'untrusted' || route === 'remote') {
+    return null
+  }
+
+  if (route === 'local') {
+    return previewUrlTarget(rawTarget)
+  }
+
+  const sshTarget = connectionId
+    ? (() => {
+        const scope = backendScopeKey(connectionId, profile)
+        const state = sshConnections.get(scope)
+
+        return state?.ssh ? { scope, ssh: state.ssh } : 'pending'
+      })()
+    : activeSshTerminalTarget(profile)
+
+  if (!sshTarget || sshTarget === 'pending' || process.platform !== 'win32') {
+    return null
+  }
+
+  const target = parseSshPreviewTarget(rawTarget)
+  const state = sshConnections.get(sshTarget.scope)
+
+  if (!target || !state || state.ssh !== sshTarget.ssh) {
+    return null
+  }
+
+  state.previewForwards ??= new Set()
+  let capability
+  let partition = ''
+  let partitionLease
+
+  const forwardLease = await openSshPreviewForward(target, {
+    cancel: (localPort, remotePort) => sshTarget.ssh.cancelForward(localPort, remotePort),
+    closeTransport: async () => {
+      if (sshConnections.get(sshTarget.scope) === state && state.ssh === sshTarget.ssh) {
+        await teardownSshConnectionByScope(sshTarget.scope, state, capability)
+
+        return
+      }
+
+      // Owner-wide cleanup is already closing this exact state. Do not await
+      // the in-flight teardown from a sibling close callback (that would cycle
+      // teardown -> sibling.close -> teardown).
+      if (sshConnections.getClosing(sshTarget.scope) === state) {
+        return
+      }
+
+      await revokeSshPreviewCapabilities(state.previewForwards || [], capability)
+      await sshTarget.ssh.close()
+    },
+    forward: (localPort, remotePort) => sshTarget.ssh.forward(localPort, remotePort),
+    isCurrent: () => sshConnections.get(sshTarget.scope) === state && state.ssh === sshTarget.ssh,
+    onClose: () => capability?.revoke(),
+    pickLocalPort: async () => Number(await pickLocalPort())
+  })
+
+  if (!forwardLease) {
+    return null
+  }
+
+  if (sshConnections.get(sshTarget.scope) !== state || state.ssh !== sshTarget.ssh) {
+    await forwardLease.close()
+
+    return null
+  }
+
+  partition = `hermes-preview-forwarded-${crypto.randomUUID()}`
+
+  try {
+    partitionLease = leaseForwardedPreviewSession(
+      session.fromPartition(partition, { cache: false }),
+      forwardLease.rewrittenUrl,
+      forwardLease.expiresAt
+    )
+  } catch {
+    await forwardLease.close()
+
+    return null
+  }
+
+  if (!partitionLease) {
+    await forwardLease.close()
+
+    return null
+  }
+
+  capability = {
+    close: async () => {
+      capability.revoke()
+      await forwardLease.close()
+    },
+    revoke: () => {
+      partitionLease.revoke()
+      state.previewForwards.delete(capability)
+      sshPreviewForwardsByPartition.delete(partition)
+    }
+  }
+  sshPreviewForwardsByPartition.set(partition, capability)
+  state.previewForwards.add(capability)
+
+  return {
+    kind: 'url',
+    label: previewLabelForUrl(new URL(target.sourceUrl)),
+    previewPartition: partition,
+    source: target.sourceUrl,
+    transient: true,
+    url: forwardLease.rewrittenUrl
+  }
+}
+
+async function normalizePreviewTarget(rawTarget, baseDir, sourceProfile, sourceConnectionId) {
   const raw = String(rawTarget || '').trim()
 
   if (!raw) {
@@ -5361,6 +5505,19 @@ async function normalizePreviewTarget(rawTarget, baseDir) {
 
   try {
     if (/^https?:\/\//i.test(raw)) {
+      const profile = String(sourceProfile || '').trim()
+      const routed = await sshForwardedPreviewTarget(raw, profile, sourceConnectionId)
+
+      if (routed !== undefined) {
+        return routed ? { ...routed, profileValidated: true } : null
+      }
+
+      if (profile) {
+        const normalized = previewUrlTarget(raw, true)
+
+        return normalized ? { ...normalized, profileValidated: true } : null
+      }
+
       return previewUrlTarget(raw)
     }
 
@@ -8363,7 +8520,9 @@ async function buildRemoteConnection(
   }
 }
 
-const sshConnections = new Map<string, any>()
+const sshConnections = new SshOwnerRegistry<any>()
+const sshTeardownRetryTimers = new Map<string, ReturnType<typeof setTimeout>>()
+const sshPreviewForwardsByPartition = new Map<string, { close: () => Promise<void> }>()
 const desktopInstallationId = loadOrCreateInstallationId(DESKTOP_INSTALLATION_PATH)
 
 const sshBootstrapCoordinator = createBootstrapCoordinator()
@@ -8399,43 +8558,76 @@ async function sshProbeReuseProof(baseUrl, token, spawnNonce) {
   }
 }
 
-async function teardownSshConnection(profile) {
-  const scope = sshScopeKey(profile)
-  const state = sshConnections.get(scope)
-
-  if (!state) {
+function scheduleSshTeardownRetry(scope, state) {
+  if (sshTeardownRetryTimers.has(scope)) {
     return
   }
 
-  sshConnections.delete(scope)
+  const timer = setTimeout(() => {
+    sshTeardownRetryTimers.delete(scope)
+    void teardownSshConnectionByScope(scope, state).catch(() => undefined)
+  }, 1_000)
 
-  for (const [id, info] of [...terminalSessions.entries()]) {
-    if (info.sshScope === scope) {
-      disposeTerminalSession(id)
-    }
-  }
+  timer.unref?.()
+  sshTeardownRetryTimers.set(scope, timer)
+}
 
+async function teardownSshConnectionByScope(scope, expectedState = undefined, excludedPreviewForward = undefined) {
   try {
-    if (state.localPort && state.remotePort) {
-      await state.ssh.cancelForward(state.localPort, state.remotePort)
-    }
-  } catch {
-    // best effort
-  }
+    const claimed = await sshConnections.teardown(scope, expectedState, async state => {
+      // Registry teardown removes this owner from active routing before cleanup,
+      // while retaining it in the closing set until close() proves authoritative
+      // transport death. Revoke every sibling partition before touching SSH.
+      await revokeSshPreviewCapabilities(state.previewForwards || [], excludedPreviewForward)
 
-  try {
-    await state.ssh.close()
-  } catch {
-    // best effort
+      for (const [id, info] of [...terminalSessions.entries()]) {
+        if (info.sshScope === scope) {
+          disposeTerminalSession(id)
+        }
+      }
+
+      try {
+        if (state.localPort && state.remotePort) {
+          await state.ssh.cancelForward(state.localPort, state.remotePort)
+        }
+      } catch {
+        // The authoritative close below tears down every listener on the owner.
+      }
+
+      await state.ssh.close()
+    })
+
+    if (claimed) {
+      const timer = sshTeardownRetryTimers.get(scope)
+
+      if (timer) {
+        clearTimeout(timer)
+        sshTeardownRetryTimers.delete(scope)
+      }
+    }
+
+    return claimed
+  } catch (error) {
+    const state = expectedState || sshConnections.getClosing(scope)
+
+    if (state) {
+      scheduleSshTeardownRetry(scope, state)
+    }
+
+    throw error
   }
+}
+
+async function teardownSshConnection(profile, excludedPreviewForward = undefined) {
+  return teardownSshConnectionByScope(sshScopeKey(profile), undefined, excludedPreviewForward)
 }
 
 // CRITICAL: this must mirror resolveRemoteBackend's precedence, not just return
 // any cached SSH state. A per-profile token/OAuth override wins over a global
 // SSH connection — so if the active profile resolves to a NON-SSH backend, the
 // terminal must NOT fall through to a global SSH host.
-function activeSshTerminalTarget() {
-  const profile = primaryProfileKey()
+function activeSshTerminalTarget(optionalProfile) {
+  const profile = String(optionalProfile || '').trim() || primaryProfileKey()
   const config = readDesktopConnectionConfig()
 
   if (profileSshOverride(config, profile)) {
@@ -8498,6 +8690,12 @@ async function bootstrapSshConnection(profile, sshConfig, reuseToken, source) {
 async function bootstrapSshConnectionInner(profile, sshConfig, reuseToken, source, fingerprint, lease) {
   const scope = sshScopeKey(profile)
   const hostLabel = sshConfig.user ? `${sshConfig.user}@${sshConfig.host}` : sshConfig.host
+  const closing = sshConnections.getClosing(scope)
+
+  if (closing) {
+    await teardownSshConnectionByScope(scope, closing)
+  }
+
   const existing = sshConnections.get(scope)
 
   if (existing && existing.fingerprint !== fingerprint) {
@@ -8507,14 +8705,8 @@ async function bootstrapSshConnectionInner(profile, sshConfig, reuseToken, sourc
   let ssh = sshConnections.get(scope)?.ssh
 
   if (ssh && !(await ssh.isAlive())) {
-    try {
-      await ssh.close()
-    } catch {
-      void 0
-    }
-
+    await teardownSshConnection(profile)
     ssh = null
-    sshConnections.delete(scope)
   }
 
   const created = !ssh
@@ -8586,9 +8778,16 @@ async function bootstrapSshConnectionInner(profile, sshConfig, reuseToken, sourc
   persistSshConnectionToken(profile, source, result.token)
 
   removeForceCleanup()
-  sshConnections.set(scope, {
+
+  const previousOwner = sshConnections.get(scope)
+
+  const previousPreviewForwards =
+    previousOwner?.ssh === ssh ? previousOwner.previewForwards || new Set() : new Set()
+
+  refreshSshOwner(sshConnections, scope, {
     ssh,
     fingerprint,
+    previewForwards: previousPreviewForwards,
     localPort: result.localPort,
     remotePort: result.remotePort,
     pid: result.pid,
@@ -12830,9 +13029,30 @@ ipcMain.handle('hermes:saveClipboardImage', async () => {
   return ''
 })
 
-ipcMain.handle('hermes:normalizePreviewTarget', (_event, target, baseDir) =>
-  normalizePreviewTarget(String(target || ''), baseDir ? String(baseDir) : '')
+ipcMain.handle('hermes:normalizePreviewTarget', (_event, target, baseDir, profile, connectionId) =>
+  normalizePreviewTarget(
+    String(target || ''),
+    baseDir ? String(baseDir) : '',
+    profile ? String(profile) : '',
+    connectionId ? String(connectionId) : ''
+  )
 )
+
+ipcMain.handle('hermes:releasePreviewForward', async (_event, rawPartition) => {
+  const capability = sshPreviewForwardsByPartition.get(String(rawPartition || ''))
+
+  if (!capability) {
+    return false
+  }
+
+  try {
+    await capability.close()
+
+    return true
+  } catch {
+    return false
+  }
+})
 
 ipcMain.handle('hermes:watchPreviewFile', (_event, url) => watchPreviewFile(String(url || '')))
 
@@ -14288,18 +14508,27 @@ app.on('before-quit', event => {
     })
   }
 
-  if ((sshConnections.size > 0 || sshBootstrapCoordinator.promises().length > 0) && !sshQuitTeardownDone) {
+  if (
+    (sshConnections.size > 0 ||
+      sshConnections.promises().length > 0 ||
+      sshBootstrapCoordinator.promises().length > 0) &&
+    !sshQuitTeardownDone
+  ) {
     event.preventDefault()
     sshBootstrapCoordinator.cancelAll()
     const scopes = [...sshConnections.keys()]
 
     const pending = Promise.allSettled([
-      ...scopes.map(scope => teardownSshConnection(scope || null)),
+      ...scopes.map(scope => teardownSshConnectionByScope(scope)),
+      ...sshConnections.promises(),
       ...sshBootstrapCoordinator.promises()
     ])
 
     void Promise.race([pending, new Promise(resolve => setTimeout(resolve, 4_000))]).then(async () => {
-      await sshBootstrapCoordinator.forceCleanupAll()
+      await Promise.allSettled([
+        sshBootstrapCoordinator.forceCleanupAll(),
+        sshConnections.forceCleanup(state => state.ssh.forceClose())
+      ])
       sshQuitTeardownDone = true
       app.quit()
     })

--- a/apps/desktop/electron/preload.ts
+++ b/apps/desktop/electron/preload.ts
@@ -184,7 +184,9 @@ contextBridge.exposeInMainWorld('hermesDesktop', {
       return ''
     }
   },
-  normalizePreviewTarget: (target, baseDir) => ipcRenderer.invoke('hermes:normalizePreviewTarget', target, baseDir),
+  normalizePreviewTarget: (target, baseDir, profile, connectionId) =>
+    ipcRenderer.invoke('hermes:normalizePreviewTarget', target, baseDir, profile, connectionId),
+  releasePreviewForward: partition => ipcRenderer.invoke('hermes:releasePreviewForward', partition),
   watchPreviewFile: url => ipcRenderer.invoke('hermes:watchPreviewFile', url),
   watchDirectory: dir => ipcRenderer.invoke('hermes:watchDirectory', dir),
   stopPreviewFileWatch: id => ipcRenderer.invoke('hermes:stopPreviewFileWatch', id),

--- a/apps/desktop/electron/preview-backend-route.test.ts
+++ b/apps/desktop/electron/preview-backend-route.test.ts
@@ -1,0 +1,70 @@
+import assert from 'node:assert/strict'
+
+import { test } from 'vitest'
+
+import { classifyPreviewBackendRoute } from './preview-backend-route'
+
+test('requires explicit locally stamped profile provenance for loopback previews', () => {
+  assert.equal(
+    classifyPreviewBackendRoute({
+      globalMode: 'local',
+      hasEnvRemote: false,
+      hasProfileRemote: false,
+      hasProfileSsh: false,
+      sourceProfile: ''
+    }),
+    'untrusted'
+  )
+})
+
+test('mirrors backend precedence when classifying a stamped preview source', () => {
+  const base = { hasEnvRemote: false, sourceProfile: 'work' }
+
+  assert.equal(
+    classifyPreviewBackendRoute({ ...base, globalMode: 'ssh', hasProfileRemote: false, hasProfileSsh: true }),
+    'ssh'
+  )
+  assert.equal(
+    classifyPreviewBackendRoute({ ...base, globalMode: 'ssh', hasProfileRemote: true, hasProfileSsh: false }),
+    'remote'
+  )
+  assert.equal(
+    classifyPreviewBackendRoute({
+      ...base,
+      globalMode: 'local',
+      hasEnvRemote: true,
+      hasProfileRemote: false,
+      hasProfileSsh: false
+    }),
+    'remote'
+  )
+  assert.equal(
+    classifyPreviewBackendRoute({ ...base, globalMode: 'ssh', hasProfileRemote: false, hasProfileSsh: false }),
+    'ssh'
+  )
+  assert.equal(
+    classifyPreviewBackendRoute({ ...base, globalMode: 'cloud', hasProfileRemote: false, hasProfileSsh: false }),
+    'remote'
+  )
+  assert.equal(
+    classifyPreviewBackendRoute({ ...base, globalMode: 'local', hasProfileRemote: false, hasProfileSsh: false }),
+    'local'
+  )
+})
+
+
+test('binds registry preview routing to the exact stamped connection', () => {
+  const base = {
+    globalMode: 'local',
+    hasEnvRemote: false,
+    hasProfileRemote: false,
+    hasProfileSsh: false,
+    sourceConnectionId: 'grace-ssh',
+    sourceProfile: 'work'
+  }
+
+  assert.equal(classifyPreviewBackendRoute({ ...base, registryConnectionKind: 'ssh' }), 'ssh')
+  assert.equal(classifyPreviewBackendRoute({ ...base, registryConnectionKind: 'remote' }), 'remote')
+  assert.equal(classifyPreviewBackendRoute({ ...base, registryConnectionKind: 'local' }), 'local')
+  assert.equal(classifyPreviewBackendRoute({ ...base, registryConnectionKind: null }), 'untrusted')
+})

--- a/apps/desktop/electron/preview-backend-route.ts
+++ b/apps/desktop/electron/preview-backend-route.ts
@@ -1,0 +1,56 @@
+export type PreviewBackendRoute = 'local' | 'remote' | 'ssh' | 'untrusted'
+
+export interface PreviewBackendRouteInput {
+  globalMode: string
+  hasEnvRemote: boolean
+  hasProfileRemote: boolean
+  hasProfileSsh: boolean
+  registryConnectionKind?: 'cloud' | 'local' | 'remote' | 'ssh' | null
+  sourceConnectionId?: string
+  sourceProfile: string
+}
+
+/** Mirror backend precedence without treating missing provenance as client-local. */
+export function classifyPreviewBackendRoute({
+  globalMode,
+  hasEnvRemote,
+  hasProfileRemote,
+  hasProfileSsh,
+  registryConnectionKind,
+  sourceConnectionId,
+  sourceProfile
+}: PreviewBackendRouteInput): PreviewBackendRoute {
+  if (!String(sourceProfile || '').trim()) {
+    return 'untrusted'
+  }
+
+  if (String(sourceConnectionId || '').trim()) {
+    if (registryConnectionKind === 'ssh') {
+      return 'ssh'
+    }
+
+    if (registryConnectionKind === 'remote' || registryConnectionKind === 'cloud') {
+      return 'remote'
+    }
+
+    return registryConnectionKind === 'local' ? 'local' : 'untrusted'
+  }
+
+  if (hasProfileSsh) {
+    return 'ssh'
+  }
+
+  if (hasProfileRemote || hasEnvRemote) {
+    return 'remote'
+  }
+
+  if (globalMode === 'ssh') {
+    return 'ssh'
+  }
+
+  if (globalMode === 'remote' || globalMode === 'cloud') {
+    return 'remote'
+  }
+
+  return 'local'
+}

--- a/apps/desktop/electron/ssh-connection.test.ts
+++ b/apps/desktop/electron/ssh-connection.test.ts
@@ -474,6 +474,13 @@ test('no-mux: open() classifies auth failure', async () => {
   await assert.rejects(conn.open(), (err: any) => err.kind === 'auth-failed')
 })
 
+test('mux cancelForward rejects a non-zero OpenSSH cancellation result', async () => {
+  const spawnFn = scriptedSpawn([{ code: 255, stderr: 'cancel failed: unknown port forwarding' }])
+  const conn = new SshConnection({ host: 'box', user: 'me' }, { spawnFn, controlDir: '/tmp/d', mux: true })
+
+  await assert.rejects(conn.cancelForward(49152, 8765), /cancel failed: unknown port forwarding/)
+})
+
 test('no-mux: forward spawns a persistent -N -L child; cancel + close kill it', async () => {
   // Real listener stands in for the tunnel's local end so waitForLocalPort sees it.
   const net = await import('node:net')
@@ -839,6 +846,38 @@ test('failed ControlMaster close disowns the master instead of retrying it', asy
   await conn.close()
   assert.equal(conn._opened, false)
   assert.equal(spawnFn.calls.length, 1)
+})
+
+test('forceClose escalates retained no-mux tunnel children to SIGKILL', async () => {
+  const child: any = new EventEmitter()
+  const signals: unknown[] = []
+  child.exitCode = null
+  child.signalCode = null
+
+  child.kill = (signal?: unknown) => {
+    signals.push(signal)
+
+    if (signal === 'SIGKILL') {
+      process.nextTick(() => {
+        child.signalCode = 'SIGKILL'
+        child.emit('exit', null, 'SIGKILL')
+      })
+
+      return true
+    }
+
+    return false
+  }
+
+  const conn = new SshConnection({ host: 'box', user: 'me' }, { mux: false })
+  conn._opened = true
+  conn._tunnels.set('preview', { alive: true, child })
+
+  await conn.forceClose()
+
+  assert.deepEqual(signals, ['SIGKILL'])
+  assert.equal(conn._tunnels.size, 0)
+  assert.equal(conn._opened, false)
 })
 
 test('stopTunnelChild waits for process exit', async () => {

--- a/apps/desktop/electron/ssh-connection.ts
+++ b/apps/desktop/electron/ssh-connection.ts
@@ -417,7 +417,7 @@ function runSsh(args, { timeoutMs, spawnFn = spawn, stdin = 'ignore', stdinData 
   })
 }
 
-function stopTunnelChild(child, timeoutMs = 5_000) {
+function stopTunnelChild(child, timeoutMs = 5_000, signal?: NodeJS.Signals | number) {
   if (!child || child.exitCode != null || child.signalCode != null) {
     return Promise.resolve()
   }
@@ -444,7 +444,7 @@ function stopTunnelChild(child, timeoutMs = 5_000) {
     child.once('error', onError)
 
     try {
-      if (!child.kill()) {
+      if (!child.kill(signal)) {
         finish(new Error('SSH tunnel termination was refused.'))
       }
     } catch (error) {
@@ -800,8 +800,9 @@ class SshConnection {
     }
   }
 
-  // Cancel a previously-established forward. Best-effort: a failure here is
-  // logged but not thrown (close tears everything down anyway).
+  // Cancel a previously-established forward. Failure is authoritative: callers
+  // that own a capability must fall back to closing the shared transport rather
+  // than forgetting a listener OpenSSH failed to remove.
   async cancelForward(localPort, remotePort, remoteHost = '127.0.0.1') {
     const spec = forwardSpec(localPort, remotePort, remoteHost)
 
@@ -819,12 +820,19 @@ class SshConnection {
 
     const args = buildControlArgs(this, 'cancel', ['-L', spec], this._connectTimeoutMs)
 
+    let result
+
     try {
-      await runSsh(args, { timeoutMs: this._forwardTimeoutMs, spawnFn: this._spawnFn })
-      this._logLine(`cancelled forward 127.0.0.1:${localPort}`)
-    } catch (error: any) {
-      this._logLine(`cancelForward failed (ignored): ${error.message}`)
+      result = await runSsh(args, { timeoutMs: this._forwardTimeoutMs, spawnFn: this._spawnFn })
+    } catch (error) {
+      throw this._fail(error)
     }
+
+    if (result.code !== 0) {
+      throw this._fail(result.stderr)
+    }
+
+    this._logLine(`cancelled forward 127.0.0.1:${localPort}`)
   }
 
   // Tear down. Mux: exit the master (drops every forward with it). No-mux:
@@ -870,6 +878,34 @@ class SshConnection {
     }
 
     this._opened = false
+  }
+
+  // Bounded shutdown escalation for no-mux Windows tunnel children retained
+  // after a graceful cancellation/close failure.
+  async forceClose() {
+    if (this._mux) {
+      await this.close()
+
+      return
+    }
+
+    const failures: unknown[] = []
+
+    for (const [spec, tunnel] of this._tunnels) {
+      try {
+        await stopTunnelChild(tunnel.child, 1_000, 'SIGKILL')
+        this._tunnels.delete(spec)
+      } catch (error) {
+        failures.push(error)
+      }
+    }
+
+    if (failures.length > 0) {
+      throw new AggregateError(failures, 'One or more SSH tunnel processes resisted force-close.')
+    }
+
+    this._opened = false
+    this._logLine('connection force-closed (no-mux tunnels killed)')
   }
 }
 

--- a/apps/desktop/electron/ssh-owner-registry.test.ts
+++ b/apps/desktop/electron/ssh-owner-registry.test.ts
@@ -1,0 +1,87 @@
+import assert from 'node:assert/strict'
+
+import { test } from 'vitest'
+
+import { refreshSshOwner, SshOwnerRegistry } from './ssh-owner-registry'
+
+test('retains a failed teardown owner outside the active routing map until retry succeeds', async () => {
+  const registry = new SshOwnerRegistry<object>()
+  const owner = {}
+  let attempts = 0
+  registry.set('', owner)
+
+  await assert.rejects(
+    registry.teardown('', owner, async () => {
+      attempts += 1
+      throw new Error('transport still alive')
+    }),
+    /transport still alive/
+  )
+
+  assert.equal(registry.get(''), undefined, 'closing owner cannot authorize new work')
+  assert.equal(registry.size, 1, 'failed owner remains visible to quit cleanup')
+  assert.deepEqual([...registry.keys()], [''])
+
+  await registry.teardown('', owner, async () => {
+    attempts += 1
+  })
+
+  assert.equal(attempts, 2)
+  assert.equal(registry.size, 0)
+})
+
+test('teardown is scoped to the exact captured owner', async () => {
+  const registry = new SshOwnerRegistry<object>()
+  const current = {}
+  const stale = {}
+  let cleaned = false
+  registry.set('', current)
+
+  const claimed = await registry.teardown('', stale, async () => {
+    cleaned = true
+  })
+
+  assert.equal(claimed, false)
+  assert.equal(cleaned, false)
+  assert.equal(registry.get(''), current)
+})
+
+test('same-transport refresh preserves the owner identity captured by preview capabilities', () => {
+  const registry = new SshOwnerRegistry<{
+    ssh: object
+    fingerprint: string
+    previewForwards: Set<object>
+  }>()
+
+  const ssh = {}
+  const previewForwards = new Set<object>([{}])
+  const capturedOwner = { ssh, fingerprint: 'old', previewForwards }
+  registry.set('work', capturedOwner)
+
+  const refreshed = refreshSshOwner(registry, 'work', {
+    ssh,
+    fingerprint: 'new',
+    previewForwards
+  })
+
+  assert.equal(refreshed, capturedOwner)
+  assert.equal(registry.get('work'), capturedOwner)
+  assert.equal(capturedOwner.fingerprint, 'new')
+  assert.equal(capturedOwner.previewForwards, previewForwards)
+})
+
+test('force cleanup includes owners retained after a failed normal teardown', async () => {
+  const registry = new SshOwnerRegistry<object>()
+  const owner = {}
+  registry.set('work', owner)
+
+  await assert.rejects(registry.teardown('work', owner, async () => Promise.reject(new Error('stuck'))))
+
+  const forced: object[] = []
+  await registry.forceCleanup(async state => {
+    forced.push(state)
+  })
+
+  assert.deepEqual(forced, [owner])
+  assert.equal(registry.size, 0)
+})

--- a/apps/desktop/electron/ssh-owner-registry.ts
+++ b/apps/desktop/electron/ssh-owner-registry.ts
@@ -1,0 +1,127 @@
+export class SshOwnerRegistry<T> {
+  private readonly active = new Map<string, T>()
+  private readonly closing = new Map<string, T>()
+  private readonly attempts = new Map<string, Promise<boolean>>()
+
+  get size(): number {
+    return new Set([...this.active.keys(), ...this.closing.keys()]).size
+  }
+
+  get(scope: string): T | undefined {
+    return this.active.get(scope)
+  }
+
+  getClosing(scope: string): T | undefined {
+    return this.closing.get(scope)
+  }
+
+  set(scope: string, state: T): void {
+    const closing = this.closing.get(scope)
+
+    if (closing && closing !== state) {
+      throw new Error(`SSH owner scope is still closing: ${scope || '<global>'}`)
+    }
+
+    this.closing.delete(scope)
+    this.active.set(scope, state)
+  }
+
+  keys(): IterableIterator<string> {
+    return new Set([...this.active.keys(), ...this.closing.keys()]).values()
+  }
+
+  promises(): Promise<boolean>[] {
+    return [...this.attempts.values()]
+  }
+
+  async teardown(scope: string, expected: T | undefined, cleanup: (state: T) => Promise<void>): Promise<boolean> {
+    let state = this.active.get(scope)
+
+    if (!state) {
+      state = this.closing.get(scope)
+    }
+
+    if (!state || (expected && state !== expected)) {
+      return false
+    }
+
+    if (this.active.get(scope) === state) {
+      this.active.delete(scope)
+      this.closing.set(scope, state)
+    }
+
+    const inFlight = this.attempts.get(scope)
+
+    if (inFlight) {
+      return inFlight
+    }
+
+    const attempt = (async () => {
+      await cleanup(state)
+
+      if (this.closing.get(scope) === state) {
+        this.closing.delete(scope)
+      }
+
+      return true
+    })()
+
+    this.attempts.set(scope, attempt)
+
+    try {
+      return await attempt
+    } finally {
+      if (this.attempts.get(scope) === attempt) {
+        this.attempts.delete(scope)
+      }
+    }
+  }
+
+  async forceCleanup(cleanup: (state: T) => Promise<void>): Promise<void> {
+    const snapshot = new Map<string, T>([...this.closing.entries(), ...this.active.entries()])
+
+    for (const [scope, state] of snapshot) {
+      if (this.active.get(scope) === state) {
+        this.active.delete(scope)
+        this.closing.set(scope, state)
+      }
+    }
+
+    const results = await Promise.allSettled(
+      [...snapshot.entries()].map(async ([scope, state]) => {
+        await cleanup(state)
+
+        if (this.closing.get(scope) === state) {
+          this.closing.delete(scope)
+        }
+      })
+    )
+
+    const failures = results.filter((result): result is PromiseRejectedResult => result.status === 'rejected')
+
+    if (failures.length > 0) {
+      throw new AggregateError(
+        failures.map(result => result.reason),
+        'One or more SSH owners could not be force-cleaned.'
+      )
+    }
+  }
+}
+
+export function refreshSshOwner<T extends { ssh: unknown }>(
+  registry: SshOwnerRegistry<T>,
+  scope: string,
+  next: T
+): T {
+  const current = registry.get(scope)
+
+  if (current && current.ssh === next.ssh) {
+    Object.assign(current, next)
+
+    return current
+  }
+
+  registry.set(scope, next)
+
+  return next
+}

--- a/apps/desktop/electron/ssh-preview-target.test.ts
+++ b/apps/desktop/electron/ssh-preview-target.test.ts
@@ -1,0 +1,242 @@
+import assert from 'node:assert/strict'
+
+import { test, vi } from 'vitest'
+
+import {
+  isLoopbackPreviewTarget,
+  openSshPreviewForward,
+  parseSshPreviewTarget,
+  revokeSshPreviewCapabilities
+} from './ssh-preview-target'
+
+test('accepts the reported remote loopback preview endpoint', () => {
+  const target = parseSshPreviewTarget('http://127.0.0.1:8765/DeepSeek-vs-Qwen38-on-Spark.html')
+
+  assert.deepEqual(target, {
+    remotePort: 8765,
+    sourceUrl: 'http://127.0.0.1:8765/DeepSeek-vs-Qwen38-on-Spark.html'
+  })
+})
+
+test('accepts only the narrow loopback aliases and preview ports', () => {
+  assert.deepEqual(parseSshPreviewTarget('http://localhost:3000/'), {
+    remotePort: 3000,
+    sourceUrl: 'http://localhost:3000/'
+  })
+  assert.deepEqual(parseSshPreviewTarget('http://0.0.0.0:8765/'), {
+    remotePort: 8765,
+    sourceUrl: 'http://0.0.0.0:8765/'
+  })
+})
+
+test('rejects credential-bearing preview URLs', () => {
+  assert.equal(parseSshPreviewTarget('http://user:password@127.0.0.1:8765/report.html'), null)
+})
+
+test('rejects alternate IPv4 spellings that canonicalize to loopback', () => {
+  for (const host of ['127.1', '2130706433', '0x7f000001', '0177.0.0.1', '127.000.000.001']) {
+    const raw = `http://${host}:8765/report.html`
+
+    assert.equal(isLoopbackPreviewTarget(raw), true)
+    assert.equal(parseSshPreviewTarget(raw), null)
+  }
+})
+
+test('detects unsupported loopback-looking targets so they fail closed', () => {
+  assert.equal(isLoopbackPreviewTarget('http://127.0.0.2:8765/'), true)
+  assert.equal(isLoopbackPreviewTarget('http://admin.localhost:8765/'), true)
+  assert.equal(isLoopbackPreviewTarget('http://[::1]:8765/'), true)
+  assert.equal(isLoopbackPreviewTarget('http://[::ffff:127.0.0.1]:8765/'), true)
+  assert.equal(isLoopbackPreviewTarget('https://example.com/'), false)
+})
+
+test('forwards a validated SSH preview without a second authorization prompt', async () => {
+  let forwarded = false
+  const target = parseSshPreviewTarget('http://127.0.0.1:8765/report.html')!
+
+  const lease = await openSshPreviewForward(target, {
+    cancel: async () => undefined,
+    closeTransport: async () => undefined,
+    forward: async () => {
+      forwarded = true
+    },
+    pickLocalPort: async () => 49152
+  })
+
+  assert.ok(lease)
+  assert.equal(forwarded, true)
+  await lease.close()
+})
+
+test('closes the owning transport when forward materialization fails', async () => {
+  let transportCloses = 0
+  const target = parseSshPreviewTarget('http://127.0.0.1:8765/report.html')!
+
+  await assert.rejects(
+    openSshPreviewForward(target, {
+      cancel: async () => undefined,
+      closeTransport: async () => {
+        transportCloses += 1
+      },
+      forward: async () => {
+        throw new Error('forward setup failed')
+      },
+      pickLocalPort: async () => 49152
+    }),
+    /forward setup failed/
+  )
+  assert.equal(transportCloses, 1)
+})
+
+test('does not forward after the selected SSH transport is replaced', async () => {
+  let forwarded = false
+  const target = parseSshPreviewTarget('http://127.0.0.1:8765/report.html')!
+
+  const lease = await openSshPreviewForward(target, {
+    cancel: async () => undefined,
+    closeTransport: async () => undefined,
+    forward: async () => {
+      forwarded = true
+    },
+    isCurrent: () => false,
+    pickLocalPort: async () => 49152
+  })
+
+  assert.equal(lease, null)
+  assert.equal(forwarded, false)
+})
+
+test('opens one disposable tunnel and expires it after fifteen minutes', async () => {
+  vi.useFakeTimers()
+  vi.setSystemTime(0)
+  const forwarded: Array<[number, number]> = []
+  const cancelled: Array<[number, number]> = []
+  const target = parseSshPreviewTarget('http://127.0.0.1:8765/report.html?view=full')!
+
+  const lease = await openSshPreviewForward(target, {
+    cancel: async (localPort, remotePort) => {
+      cancelled.push([localPort, remotePort])
+    },
+    closeTransport: async () => undefined,
+    forward: async (localPort, remotePort) => {
+      forwarded.push([localPort, remotePort])
+    },
+    pickLocalPort: async () => 49152
+  })
+
+  assert.ok(lease)
+  assert.deepEqual(forwarded, [[49152, 8765]])
+  assert.equal(lease.rewrittenUrl, 'http://127.0.0.1:49152/report.html?view=full')
+  assert.equal(lease.expiresAt, 15 * 60 * 1000)
+
+  await vi.advanceTimersByTimeAsync(15 * 60 * 1000)
+  assert.deepEqual(cancelled, [[49152, 8765]])
+  vi.useRealTimers()
+})
+
+test('closes the owning transport when tunnel cancellation fails', async () => {
+  let transportCloses = 0
+  const target = parseSshPreviewTarget('http://127.0.0.1:8765/report.html')!
+
+  const lease = await openSshPreviewForward(target, {
+    cancel: async () => {
+      throw new Error('cancel failed')
+    },
+    closeTransport: async () => {
+      transportCloses += 1
+    },
+    forward: async () => undefined,
+    pickLocalPort: async () => 49153
+  })
+
+  assert.ok(lease)
+  await lease.close()
+  assert.equal(transportCloses, 1)
+})
+
+test('reports disposal once so transport state can forget the capability', async () => {
+  let disposed = 0
+  const target = parseSshPreviewTarget('http://127.0.0.1:8765/report.html')!
+
+  const lease = await openSshPreviewForward(target, {
+    cancel: async () => undefined,
+    closeTransport: async () => undefined,
+    forward: async () => undefined,
+    onClose: () => {
+      disposed += 1
+    },
+    pickLocalPort: async () => 49154
+  })
+
+  assert.ok(lease)
+  await lease.close()
+  await lease.close()
+  assert.equal(disposed, 1)
+})
+
+test('retries cleanup until the expired listener or its transport closes', async () => {
+  vi.useFakeTimers()
+  vi.setSystemTime(0)
+
+  try {
+    let closeAttempts = 0
+    let disposed = 0
+
+    const lease = await openSshPreviewForward(
+      { remotePort: 8765, sourceUrl: 'http://127.0.0.1:8765/report.html' },
+      {
+        cancel: async () => {
+          throw new Error('cancel failed')
+        },
+        closeTransport: async () => {
+          closeAttempts += 1
+
+          if (closeAttempts === 1) {
+            throw new Error('transport close failed')
+          }
+        },
+        forward: async () => undefined,
+        onClose: () => {
+          disposed += 1
+        },
+        pickLocalPort: async () => 49152
+      }
+    )
+
+    assert.ok(lease)
+    await assert.rejects(lease.close(), /transport close failed/)
+    assert.equal(disposed, 0)
+
+    await vi.advanceTimersByTimeAsync(1000)
+    assert.equal(closeAttempts, 2)
+    assert.equal(disposed, 1)
+  } finally {
+    vi.useRealTimers()
+  }
+})
+
+test('revokes every sibling capability before shared transport teardown', async () => {
+  const events: string[] = []
+
+  const current = {
+    close: async () => {
+      events.push('close:current')
+    },
+    revoke: () => {
+      events.push('revoke:current')
+    }
+  }
+
+  const sibling = {
+    close: async () => {
+      events.push('close:sibling')
+    },
+    revoke: () => {
+      events.push('revoke:sibling')
+    }
+  }
+
+  await revokeSshPreviewCapabilities(new Set([current, sibling]), current)
+
+  assert.deepEqual(events, ['revoke:current', 'revoke:sibling', 'close:sibling'])
+})

--- a/apps/desktop/electron/ssh-preview-target.ts
+++ b/apps/desktop/electron/ssh-preview-target.ts
@@ -1,0 +1,205 @@
+const ALLOWED_PREVIEW_HOSTS = new Set(['0.0.0.0', '127.0.0.1', 'localhost'])
+const ALLOWED_PREVIEW_PORTS = new Set([3000, 8765])
+
+export const SSH_PREVIEW_FORWARD_LEASE_MS = 15 * 60 * 1000
+
+export interface SshPreviewTarget {
+  remotePort: number
+  sourceUrl: string
+}
+
+export interface SshPreviewForwardDeps {
+  cancel: (localPort: number, remotePort: number) => Promise<void>
+  closeTransport: () => Promise<void>
+  forward: (localPort: number, remotePort: number) => Promise<void>
+  isCurrent?: () => boolean
+  onClose?: () => void
+  pickLocalPort: () => Promise<number>
+}
+
+export interface SshPreviewForwardLease {
+  close: () => Promise<void>
+  expiresAt: number
+  localPort: number
+  remotePort: number
+  rewrittenUrl: string
+}
+
+export interface SshPreviewCapability {
+  close: () => Promise<void>
+  revoke: () => void
+}
+
+/** Revoke every partition first, then dispose siblings without awaiting the caller itself. */
+export async function revokeSshPreviewCapabilities(
+  capabilities: Iterable<SshPreviewCapability>,
+  excluded?: SshPreviewCapability
+): Promise<void> {
+  const snapshot = [...capabilities]
+
+  for (const capability of snapshot) {
+    capability.revoke()
+  }
+
+  await Promise.allSettled(snapshot.filter(capability => capability !== excluded).map(capability => capability.close()))
+}
+
+export async function openSshPreviewForward(
+  target: SshPreviewTarget,
+  deps: SshPreviewForwardDeps
+): Promise<SshPreviewForwardLease | null> {
+  const expiresAt = Date.now() + SSH_PREVIEW_FORWARD_LEASE_MS
+  const localPort = await deps.pickLocalPort()
+
+  if (deps.isCurrent && !deps.isCurrent()) {
+    return null
+  }
+
+  try {
+    await deps.forward(localPort, target.remotePort)
+  } catch (error) {
+    try {
+      await deps.closeTransport()
+    } catch (cleanupError) {
+      throw new AggregateError(
+        [error, cleanupError],
+        `SSH preview forward failed and transport cleanup failed: ${String(error)}`
+      )
+    }
+
+    throw error
+  }
+
+  let closed = false
+  let closing: Promise<void> | null = null
+  let timer: ReturnType<typeof setTimeout> | null = null
+
+  const close = async () => {
+    if (closed) {
+      return
+    }
+
+    if (closing) {
+      return closing
+    }
+
+    if (timer) {
+      clearTimeout(timer)
+      timer = null
+    }
+
+    closing = (async () => {
+      try {
+        await deps.cancel(localPort, target.remotePort)
+      } catch {
+        await deps.closeTransport()
+      }
+
+      closed = true
+      deps.onClose?.()
+    })()
+
+    try {
+      await closing
+    } catch (error) {
+      scheduleClose(1000)
+      throw error
+    } finally {
+      closing = null
+    }
+  }
+
+  const scheduleClose = (delay: number) => {
+    if (closed || timer) {
+      return
+    }
+
+    timer = setTimeout(() => {
+      timer = null
+      void close().catch(() => undefined)
+    }, delay)
+    ;(timer as ReturnType<typeof setTimeout> & { unref?: () => void }).unref?.()
+  }
+
+  if (Date.now() >= expiresAt) {
+    await close()
+
+    return null
+  }
+
+  const rewritten = new URL(target.sourceUrl)
+  rewritten.hostname = '127.0.0.1'
+  rewritten.port = String(localPort)
+  scheduleClose(expiresAt - Date.now())
+
+  return {
+    close,
+    expiresAt,
+    localPort,
+    remotePort: target.remotePort,
+    rewrittenUrl: rewritten.toString()
+  }
+}
+
+export function isLoopbackPreviewTarget(rawTarget: string): boolean {
+  try {
+    const url = new URL(String(rawTarget || '').trim())
+
+    const hostname = url.hostname
+      .replace(/^\[|\]$/g, '')
+      .toLowerCase()
+      .replace(/\.+$/, '')
+
+    const mappedIpv4 = hostname.match(/^::ffff:([0-9a-f]{1,4}):[0-9a-f]{1,4}$/)
+    const mappedLoopback = mappedIpv4 ? Number.parseInt(mappedIpv4[1], 16) >> 8 === 127 : false
+
+    return (
+      hostname === 'localhost' ||
+      hostname.endsWith('.localhost') ||
+      hostname === '0.0.0.0' ||
+      hostname === '::' ||
+      hostname === '::1' ||
+      /^127(?:\.|$)/.test(hostname) ||
+      mappedLoopback
+    )
+  } catch {
+    return false
+  }
+}
+
+export function parseSshPreviewTarget(rawTarget: string): SshPreviewTarget | null {
+  try {
+    const raw = String(rawTarget || '').trim()
+    const authority = raw.match(/^https?:\/\/(0\.0\.0\.0|127\.0\.0\.1|localhost):(3000|8765)(?=$|[/?#])/i)
+
+    if (!authority) {
+      return null
+    }
+
+    const url = new URL(raw)
+
+    if ((url.protocol !== 'http:' && url.protocol !== 'https:') || url.username || url.password) {
+      return null
+    }
+
+    const hostname = url.hostname.toLowerCase()
+    const remotePort = Number(url.port)
+
+    // WHATWG URL canonicalization turns spellings such as 127.1, 2130706433,
+    // 0x7f000001, and octal IPv4 into 127.0.0.1. Require the raw authority to
+    // use one of the three literal policy spellings before trusting the parsed
+    // destination, then verify parsing preserved that exact host and port.
+    if (
+      authority[1].toLowerCase() !== hostname ||
+      Number(authority[2]) !== remotePort ||
+      !ALLOWED_PREVIEW_HOSTS.has(hostname) ||
+      !ALLOWED_PREVIEW_PORTS.has(remotePort)
+    ) {
+      return null
+    }
+
+    return { remotePort, sourceUrl: url.toString() }
+  } catch {
+    return null
+  }
+}

--- a/apps/desktop/src/app/chat/composer/attachments.tsx
+++ b/apps/desktop/src/app/chat/composer/attachments.tsx
@@ -50,7 +50,9 @@ function AttachmentPill({ attachment, onRemove }: { attachment: ComposerAttachme
 
   // The tile's cwd when this pill lives in a tile composer, not the primary's:
   // a relative attachment path has to resolve against its own session's root.
-  const cwd = useStore(useSessionView().$cwd)
+  const sessionView = useSessionView()
+  const cwd = useStore(sessionView.$cwd)
+  const profile = useStore(sessionView.$profile)
   const isUploading = attachment.uploadState === 'uploading'
   const hasUploadError = attachment.uploadState === 'error'
 
@@ -134,7 +136,7 @@ function AttachmentPill({ attachment, onRemove }: { attachment: ComposerAttachme
     }
 
     try {
-      const preview = await normalizeOrLocalPreviewTarget(target, cwd || undefined)
+      const preview = await normalizeOrLocalPreviewTarget(target, cwd || undefined, profile)
 
       if (!preview) {
         throw new Error(c.couldNotPreview(attachment.label))

--- a/apps/desktop/src/app/chat/composer/model-pill.test.tsx
+++ b/apps/desktop/src/app/chat/composer/model-pill.test.tsx
@@ -96,6 +96,7 @@ describe('ModelPill per-surface model label', () => {
       $messagesEmpty: atom(true),
       $model: atom('tile/claude-sonnet'),
       $provider: atom('anthropic'),
+      $profile: atom('default'),
       $reasoningEffort: atom('high'),
       $runtimeId: atom('tile-runtime'),
       $storedId: atom('stored-tile')

--- a/apps/desktop/src/app/chat/composer/status-stack/preview-row.test.tsx
+++ b/apps/desktop/src/app/chat/composer/status-stack/preview-row.test.tsx
@@ -30,7 +30,7 @@ describe('PreviewStatusRow', () => {
     fireEvent.pointerMove(screen.getByText('preview.html'), { pointerType: 'mouse' })
     await screen.findByRole('tooltip')
 
-    const content = document.querySelector<HTMLElement>('[data-slot="tooltip-content"]')
+    const content = globalThis.document.querySelector<HTMLElement>('[data-slot="tooltip-content"]')
     const label = content?.firstElementChild?.firstElementChild
 
     expect(content).not.toBeNull()
@@ -72,6 +72,51 @@ describe('PreviewStatusRow', () => {
     await waitFor(() => {
       expect($previewTabs.get()).toEqual([
         expect.objectContaining({ target: expect.objectContaining({ kind: 'file', path: remotePath }) })
+      ])
+    })
+    expect(openPreviewInBrowser).not.toHaveBeenCalled()
+  })
+
+  it('keeps forwarded SSH artifacts in their restricted in-app partition', async () => {
+    const source = 'http://127.0.0.1:8765/report.html'
+    const openPreviewInBrowser = vi.fn(async () => undefined)
+
+    Object.defineProperty(window, 'hermesDesktop', {
+      configurable: true,
+      value: {
+        normalizePreviewTarget: vi.fn(async () => ({
+          kind: 'url',
+          label: 'report.html',
+          previewPartition: 'hermes-preview-forwarded-00000000-0000-4000-8000-000000000003',
+          profileValidated: true,
+          source,
+          transient: true,
+          url: 'http://127.0.0.1:49154/report.html'
+        })),
+        openPreviewInBrowser
+      }
+    })
+
+    render(
+      <PreviewStatusRow
+        item={{
+          connectionId: 'grace-ssh',
+          cwd: '/home/agent',
+          id: source,
+          label: 'report.html',
+          profile: 'grace-profile',
+          target: source
+        }}
+        onDismiss={() => undefined}
+      />
+    )
+
+    fireEvent.click(screen.getByText('report.html'))
+
+    await waitFor(() => {
+      expect(window.hermesDesktop.normalizePreviewTarget).toHaveBeenCalledWith(source, '/home/agent', 'grace-profile', 'grace-ssh')
+      expect($previewTabs.get()).toEqual([
+        expect.objectContaining({ target: expect.objectContaining({ previewPartition: expect.any(String), source }) })
       ])
     })
     expect(openPreviewInBrowser).not.toHaveBeenCalled()

--- a/apps/desktop/src/app/chat/composer/status-stack/preview-row.tsx
+++ b/apps/desktop/src/app/chat/composer/status-stack/preview-row.tsx
@@ -27,7 +27,7 @@ export const PreviewStatusRow = memo(function PreviewStatusRow({ item, onDismiss
   const isOpen = openSources.includes(item.target)
 
   const resolveTarget = async () => {
-    const target = await normalizeOrLocalPreviewTarget(item.target, item.cwd || undefined)
+    const target = await normalizeOrLocalPreviewTarget(item.target, item.cwd || undefined, item.profile, item.connectionId)
 
     if (!target) {
       throw new Error(`Could not open preview target: ${item.target}`)
@@ -68,7 +68,10 @@ export const PreviewStatusRow = memo(function PreviewStatusRow({ item, onDismiss
       // in-app preview pane so its filesystem adapter reads via the gateway.
       // (Remote HTML stays on openPreviewTargetInBrowser, which stages a
       // sanitized local copy before opening it.)
-      if (target.kind === 'file' && target.previewKind !== 'html' && isDesktopFsRemoteMode()) {
+      if (
+        target.previewPartition ||
+        (target.kind === 'file' && target.previewKind !== 'html' && isDesktopFsRemoteMode())
+      ) {
         openPreview(target, 'tool-result')
 
         return

--- a/apps/desktop/src/app/chat/right-rail/preview-pane.test.tsx
+++ b/apps/desktop/src/app/chat/right-rail/preview-pane.test.tsx
@@ -25,6 +25,7 @@ function stubPdfObjectUrls() {
 
 describe('PreviewPane console state', () => {
   beforeEach(() => {
+    Object.defineProperty(HTMLElement.prototype, 'scrollTo', { configurable: true, value: vi.fn() })
     vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) =>
       window.setTimeout(() => callback(Date.now()), 0)
     )
@@ -108,6 +109,55 @@ describe('PreviewPane console state', () => {
     expect(previewConsoleState(tabId).$logs.get().at(-1)?.message).toBe('streamed log line')
 
     forgetPreviewStripTools(tabId)
+  })
+
+  it('keeps an SSH-forwarded preview in its isolated partition', async () => {
+    const onRestartServer = vi.fn(async () => 'restart-task')
+    const openExternal = vi.fn(async () => undefined)
+    Object.defineProperty(window, 'hermesDesktop', {
+      configurable: true,
+      value: { openExternal }
+    })
+    const remoteUrl = 'http://127.0.0.1:8765/report.html'
+    const forwardedUrl = 'http://127.0.0.1:49152/report.html'
+    const partition = 'hermes-preview-forwarded-00000000-0000-4000-8000-000000000001'
+
+    const rendered = render(
+      <PreviewPane
+        onRestartServer={onRestartServer}
+        target={{
+          kind: 'url',
+          label: 'report.html',
+          previewPartition: partition,
+          source: remoteUrl,
+          transient: true,
+          url: forwardedUrl
+        }}
+      />
+    )
+
+    const webview = rendered.container.querySelector('webview')
+
+    expect(webview?.getAttribute('partition')).toBe(partition)
+    expect(rendered.container.querySelector(`a[href="${forwardedUrl}"]`)).toBeNull()
+
+    act(() => {
+      webview?.dispatchEvent(
+        Object.assign(new Event('did-fail-load'), {
+          errorCode: -102,
+          errorDescription: 'ERR_CONNECTION_REFUSED',
+          validatedURL: forwardedUrl
+        })
+      )
+    })
+
+    const errorText = rendered.getByText(/\(-102\)/)
+    expect(errorText.closest('a')).toBeNull()
+    fireEvent.click(errorText)
+    expect(openExternal).not.toHaveBeenCalled()
+
+    fireEvent.click(await rendered.findByText('Ask Hermes to restart the server'))
+    await waitFor(() => expect(onRestartServer).toHaveBeenCalledWith(remoteUrl, expect.anything()))
   })
 
   it('renders authenticated remote HTML safely and honors source mode', async () => {

--- a/apps/desktop/src/app/chat/right-rail/preview-pane.tsx
+++ b/apps/desktop/src/app/chat/right-rail/preview-pane.tsx
@@ -76,12 +76,14 @@ function isModuleMimeError(message: string): boolean {
 }
 
 function PreviewLoadError({
+  allowExternal = true,
   consoleHeight = 0,
   error,
   onRestartServer,
   onRetry,
   restarting
 }: {
+  allowExternal?: boolean
   consoleHeight?: number
   error: PreviewLoadErrorState
   onRestartServer?: () => void
@@ -95,17 +97,24 @@ function PreviewLoadError({
     <PreviewEmptyState
       body={
         <>
-          <a
-            className="pointer-events-auto block font-mono text-muted-foreground/90 underline decoration-current/20 underline-offset-4 transition-colors hover:text-foreground"
-            href={error.url}
-            onClick={event => {
-              event.preventDefault()
-              void window.hermesDesktop?.openExternal(error.url)
-            }}
-          >
-            {compactUrl(error.url)}
-            {error.code ? ` (${error.code})` : ''}
-          </a>
+          {allowExternal ? (
+            <a
+              className="pointer-events-auto block font-mono text-muted-foreground/90 underline decoration-current/20 underline-offset-4 transition-colors hover:text-foreground"
+              href={error.url}
+              onClick={event => {
+                event.preventDefault()
+                void window.hermesDesktop?.openExternal(error.url)
+              }}
+            >
+              {compactUrl(error.url)}
+              {error.code ? ` (${error.code})` : ''}
+            </a>
+          ) : (
+            <span className="block font-mono text-muted-foreground/90">
+              {compactUrl(error.url)}
+              {error.code ? ` (${error.code})` : ''}
+            </span>
+          )}
           <div className="mt-1 text-[0.6875rem] text-muted-foreground/70">{error.description}</div>
         </>
       }
@@ -267,7 +276,7 @@ export function PreviewPane({ embedded = false, onRestartServer, reloadRequest =
 
     try {
       const context = consoleState.$logs.get().slice(-12).map(formatLogLine).join('\n')
-      const taskId = await onRestartServer(currentUrl, context || undefined)
+      const taskId = await onRestartServer(target.previewPartition ? target.source : currentUrl, context || undefined)
 
       appendConsoleEntry({
         level: 1,
@@ -287,7 +296,7 @@ export function PreviewPane({ embedded = false, onRestartServer, reloadRequest =
       })
       notifyError(error, copy.restartFailed)
     }
-  }, [appendConsoleEntry, consoleState, copy, currentUrl, onRestartServer])
+  }, [appendConsoleEntry, consoleState, copy, currentUrl, onRestartServer, target.previewPartition, target.source])
 
   const toggleDevTools = useCallback(() => {
     const webview = webviewRef.current
@@ -556,7 +565,7 @@ export function PreviewPane({ embedded = false, onRestartServer, reloadRequest =
 
     const webview = document.createElement('webview') as PreviewWebview
     webview.className = 'flex h-full w-full flex-1 bg-transparent'
-    webview.setAttribute('partition', 'persist:hermes-preview')
+    webview.setAttribute('partition', target.previewPartition || 'persist:hermes-preview')
     webview.setAttribute('src', target.url)
     webview.setAttribute('webpreferences', 'contextIsolation=yes,nodeIntegration=no,sandbox=yes')
 
@@ -650,7 +659,7 @@ export function PreviewPane({ embedded = false, onRestartServer, reloadRequest =
       webview.removeEventListener('did-stop-loading', onStop)
       webview.remove()
     }
-  }, [appendConsoleEntry, consoleState, copy, isRemoteHtml, isWebPreview, target.url])
+  }, [appendConsoleEntry, consoleState, copy, isRemoteHtml, isWebPreview, target.previewPartition, target.url])
 
   return (
     <aside className="relative flex h-full w-full min-w-0 flex-col overflow-hidden bg-transparent text-muted-foreground">
@@ -661,15 +670,17 @@ export function PreviewPane({ embedded = false, onRestartServer, reloadRequest =
               <Tip label={copy.openTarget(currentUrl)}>
                 <a
                   className="pointer-events-auto inline max-w-full truncate text-left text-xs font-medium text-foreground underline-offset-4 decoration-current/20 transition-colors hover:text-primary hover:underline"
-                  href={isRemoteHtmlTarget ? undefined : currentUrl}
+                  href={isRemoteHtmlTarget || target.previewPartition ? undefined : currentUrl}
                   onClick={event => {
                     if (isRemoteHtmlTarget) {
                       event.preventDefault()
                       void openPreviewTargetInBrowser(target).catch(error => notifyError(error, t.preview.unavailable))
+                    } else if (target.previewPartition) {
+                      event.preventDefault()
                     }
                   }}
                   rel="noreferrer"
-                  target={isRemoteHtmlTarget ? undefined : '_blank'}
+                  target={isRemoteHtmlTarget || target.previewPartition ? undefined : '_blank'}
                 >
                   {previewLabel || copy.fallbackTitle}
                 </a>
@@ -706,6 +717,7 @@ export function PreviewPane({ embedded = false, onRestartServer, reloadRequest =
             ))}
           {loadError && (
             <PreviewLoadError
+              allowExternal={!target.previewPartition}
               consoleHeight={consoleOpen ? consoleHeight : 0}
               error={loadError}
               onRestartServer={target.kind === 'url' && onRestartServer ? () => void restartServer() : undefined}

--- a/apps/desktop/src/app/chat/session-tile.tsx
+++ b/apps/desktop/src/app/chat/session-tile.tsx
@@ -98,6 +98,7 @@ function buildTileView(storedSessionId: string): SessionView {
     $messagesEmpty: computed($messages, messages => messages.length === 0),
     $model: computed($state, state => state?.model ?? ''),
     $provider: computed($state, state => state?.provider ?? ''),
+    $profile: atom($activeGatewayProfile.get()),
     $reasoningEffort: computed($state, state => state?.reasoningEffort ?? ''),
     $runtimeId,
     // Constant for the tile's lifetime — a plain atom, not a computed.

--- a/apps/desktop/src/app/chat/session-view.tsx
+++ b/apps/desktop/src/app/chat/session-view.tsx
@@ -3,6 +3,7 @@ import { createContext, useContext } from 'react'
 
 import type { ClientSessionState } from '@/app/types'
 import type { ChatMessage } from '@/lib/chat-messages'
+import { $activeGatewayProfile } from '@/store/profile'
 import {
   $activeSessionId,
   $awaitingResponse,
@@ -13,7 +14,8 @@ import {
   $currentProvider,
   $currentReasoningEffort,
   $messages,
-  $selectedStoredSessionId
+  $selectedStoredSessionId,
+  $sessions
 } from '@/store/session'
 import { $sessionStates } from '@/store/session-states'
 
@@ -51,6 +53,7 @@ export interface SessionView {
   $cwd: ReadableAtom<string>
   $model: ReadableAtom<string>
   $provider: ReadableAtom<string>
+  $profile: ReadableAtom<string>
   $fast: ReadableAtom<boolean>
   $reasoningEffort: ReadableAtom<string>
 }
@@ -76,6 +79,19 @@ function primaryField<T>(select: (state: ClientSessionState) => T, $draft: Reada
 
 const $primaryMessages = primaryField<ChatMessage[]>(state => state.messages, $messages)
 
+const $primaryProfile = computed(
+  [$selectedStoredSessionId, $sessions, $activeGatewayProfile],
+  (storedId, sessions, activeProfile) => {
+    if (!storedId) {
+      return activeProfile
+    }
+
+    const session = sessions.find(item => item.id === storedId)
+
+    return session ? session.profile || 'default' : activeProfile
+  }
+)
+
 export const PRIMARY_SESSION_VIEW: SessionView = {
   kind: 'primary',
   $awaitingResponse: primaryField<boolean>(state => state.awaitingResponse, $awaitingResponse),
@@ -87,6 +103,7 @@ export const PRIMARY_SESSION_VIEW: SessionView = {
   $messagesEmpty: computed($primaryMessages, messages => messages.length === 0),
   $model: primaryField<string>(state => state.model, $currentModel),
   $provider: primaryField<string>(state => state.provider, $currentProvider),
+  $profile: $primaryProfile,
   $reasoningEffort: primaryField<string>(state => state.reasoningEffort, $currentReasoningEffort),
   $runtimeId: $activeSessionId,
   $storedId: $selectedStoredSessionId

--- a/apps/desktop/src/app/gateway/hooks/use-gateway-boot.test.tsx
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-boot.test.tsx
@@ -2,7 +2,9 @@ import { act, cleanup, render } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { $desktopBoot } from '@/store/boot'
+import { $activeGatewayProfile } from '@/store/profile'
 import { $currentCwd, $gatewayState } from '@/store/session'
+import type { RpcEvent } from '@/types/hermes'
 
 import { takeGatewaySurvivor } from './gateway-hmr-survivor'
 import { useGatewayBoot } from './use-gateway-boot'
@@ -69,6 +71,12 @@ class FakeWebSocket {
     this.emit('close', {})
   }
 
+  message(params: Record<string, unknown>) {
+    this.emit('message', {
+      data: JSON.stringify({ jsonrpc: '2.0', method: 'event', params })
+    })
+  }
+
   private emit(type: string, ev: unknown) {
     for (const fn of this.listeners[type] ?? []) {
       fn(ev)
@@ -76,13 +84,24 @@ class FakeWebSocket {
   }
 }
 
-function fakeDesktop() {
-  const conn = {
-    authMode: 'token' as const,
+function fakeDesktop(profile = 'default', connectionId?: string, includeDescriptorProfile = true) {
+  const conn: {
+    authMode: 'token'
+    baseUrl: string
+    connectionId?: string
+    profile?: string
+    token: string
+    wsUrl: string
+  } = {
+    authMode: 'token',
     baseUrl: 'https://vps.example.com',
-    profile: 'default',
+    connectionId,
     token: 't',
     wsUrl: 'wss://vps.example.com/api/ws?token=t'
+  }
+
+  if (includeDescriptorProfile) {
+    conn.profile = profile
   }
 
   return {
@@ -109,17 +128,22 @@ function fakeDesktop() {
     onPowerResume: vi.fn(() => () => undefined),
     onWindowStateChanged: vi.fn(() => () => undefined),
     touchBackend: vi.fn(async () => undefined),
-    profile: { get: vi.fn(async () => ({ profile: 'default' })) }
+    profile: { get: vi.fn(async () => ({ profile })) }
   }
 }
 
 function Harness({
   beforeConnectionSwitch = () => undefined,
+  handleGatewayEvent = () => undefined,
   refreshSessions
-}: { beforeConnectionSwitch?: () => void; refreshSessions?: () => Promise<void> } = {}) {
+}: {
+  beforeConnectionSwitch?: () => void
+  handleGatewayEvent?: (event: RpcEvent) => void
+  refreshSessions?: () => Promise<void>
+} = {}) {
   useGatewayBoot({
     beforeConnectionSwitch,
-    handleGatewayEvent: () => undefined,
+    handleGatewayEvent,
     onConnectionReady: () => undefined,
     onGatewayReady: () => undefined,
     refreshHermesConfig: async () => undefined,
@@ -149,6 +173,7 @@ beforeEach(() => {
   connectionApplied = null
   ;(globalThis as { WebSocket: unknown }).WebSocket = FakeWebSocket
   ;(window as { hermesDesktop?: unknown }).hermesDesktop = fakeDesktop()
+  $activeGatewayProfile.set('default')
   $gatewayState.set('idle')
   $desktopBoot.set({
     error: null,
@@ -248,6 +273,71 @@ describe('useGatewayBoot remote reconnect loop (real hook, fake socket)', () => 
     expect(beforeConnectionSwitch).toHaveBeenCalledTimes(1)
     await flushAsync()
     expect($gatewayState.get()).toBe('open')
+  })
+
+  it('stamps primary gateway events with the profile used to establish the socket', async () => {
+    const handleGatewayEvent = vi.fn()
+
+    ;(window as { hermesDesktop?: unknown }).hermesDesktop = fakeDesktop('named-remote', 'grace-ssh')
+
+    render(<Harness handleGatewayEvent={handleGatewayEvent} />)
+    await flushAsync()
+
+    act(() => {
+      FakeWebSocket.instances[0].message({ type: 'status.update' })
+    })
+
+    expect(handleGatewayEvent).toHaveBeenCalledWith(
+      expect.objectContaining({ connectionId: 'grace-ssh', profile: 'named-remote', type: 'status.update' })
+    )
+  })
+
+  it('stamps a named primary from main authority when its production descriptor omits profile', async () => {
+    const handleGatewayEvent = vi.fn()
+
+    ;(window as { hermesDesktop?: unknown }).hermesDesktop = fakeDesktop('named-ssh', undefined, false)
+
+    render(<Harness handleGatewayEvent={handleGatewayEvent} />)
+    await flushAsync()
+
+    act(() => {
+      FakeWebSocket.instances[0].message({ type: 'status.update' })
+    })
+
+    expect(handleGatewayEvent).toHaveBeenCalledWith(
+      expect.objectContaining({ profile: 'named-ssh', type: 'status.update' })
+    )
+  })
+
+  it('pins profile provenance before a profile-less primary descriptor resolves', async () => {
+    const handleGatewayEvent = vi.fn()
+    const desktop = fakeDesktop('named-ssh', undefined, false)
+    let mainProfile = 'named-ssh'
+    const getConnection = desktop.getConnection
+
+    desktop.profile.get = vi.fn(async () => ({ profile: mainProfile }))
+    desktop.getConnection = vi.fn(async () => {
+      const connection = await getConnection()
+
+      // A concurrent profile switch writes the new preference before old-primary
+      // teardown/reload finishes. Provenance must stay bound to the connection
+      // request, not a later profile snapshot.
+      mainProfile = 'default'
+
+      return connection
+    })
+    ;(window as { hermesDesktop?: unknown }).hermesDesktop = desktop
+
+    render(<Harness handleGatewayEvent={handleGatewayEvent} />)
+    await flushAsync()
+
+    act(() => {
+      FakeWebSocket.instances[0].message({ type: 'status.update' })
+    })
+
+    expect(handleGatewayEvent).toHaveBeenCalledWith(
+      expect.objectContaining({ profile: 'named-ssh', type: 'status.update' })
+    )
   })
 
   it('a remote that drops post-boot keeps looping with NO boot.error (the dead-end CONNECTING combo)', async () => {

--- a/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
@@ -117,6 +117,8 @@ export function useGatewayBoot({
     // signals that fire around wake (power resume, network online, the window
     // becoming visible).
     let bootCompleted = false
+    let sourceProfile = ''
+    let sourceConnectionId = ''
     let reconnecting = false
     let reconnectTimer: ReturnType<typeof setTimeout> | null = null
     let reconnectAttempt = 0
@@ -133,6 +135,38 @@ export function useGatewayBoot({
     // dead-end CONNECTING screen. Reset on a clean open or a manual/
     // wake-driven reconnect.
     let escalated = false
+
+    const primaryProfileAuthority = async (): Promise<string> => {
+      try {
+        const profileApi = desktop.profile
+
+        if (!profileApi?.get) {
+          return ''
+        }
+
+        const snapshot = await profileApi.get()
+
+        if (!snapshot || !Object.prototype.hasOwnProperty.call(snapshot, 'profile')) {
+          return ''
+        }
+
+        return normalizeProfileKey(snapshot.profile)
+      } catch {
+        return ''
+      }
+    }
+
+    const sourceProfileForConnection = (connection: HermesConnection, requestedProfile: string): string => {
+      const descriptorProfile = String(connection.profile || '').trim()
+
+      if (descriptorProfile) {
+        return normalizeProfileKey(descriptorProfile)
+      }
+
+      const requested = String(requestedProfile || '').trim()
+
+      return requested ? normalizeProfileKey(requested) : ''
+    }
 
     // Wrap the live getter in a call so TS control-flow analysis doesn't narrow
     // `connectionState` to a constant across the early-return guards (the state
@@ -161,7 +195,10 @@ export function useGatewayBoot({
         // "Starting Hermes…". The probe is a no-op for a healthy or local backend.
         await desktop.revalidateConnection?.().catch(() => undefined)
 
-        const conn = await desktop.getConnection($activeGatewayProfile.get())
+        const requestedProfile = String($activeGatewayProfile.get() || '').trim()
+        const conn = await desktop.getConnection(requestedProfile || undefined)
+        sourceProfile = sourceProfileForConnection(conn, requestedProfile)
+        sourceConnectionId = String(conn.connectionId || '').trim()
 
         if (cancelled) {
           return
@@ -309,8 +346,13 @@ export function useGatewayBoot({
         closeSecondaryGateways()
 
         // Same override rule as boot(): a profile-pinned helper window stays
-        // on its pinned profile's backend across a soft switch.
-        const conn = await desktop.getConnection(windowProfileOverride() ?? undefined)
+        // on its pinned profile's backend across a soft switch. Capture main's
+        // authority before requesting the connection so a concurrent profile
+        // write cannot relabel the resulting socket.
+        const requestedProfile = windowProfileOverride() ?? (await primaryProfileAuthority())
+        const conn = await desktop.getConnection(requestedProfile || undefined)
+        sourceProfile = sourceProfileForConnection(conn, requestedProfile)
+        sourceConnectionId = String(conn.connectionId || '').trim()
 
         if (cancelled) {
           return
@@ -423,10 +465,17 @@ export function useGatewayBoot({
       }
     })
 
-    const sourceProfile = normalizeProfileKey($activeGatewayProfile.get())
+    if (survivor?.profile) {
+      sourceProfile = normalizeProfileKey(survivor.profile)
+      sourceConnectionId = String(survivor.connection?.connectionId || '').trim()
+    }
 
     const offEvent = gateway.onEvent(event =>
-      callbacksRef.current.handleGatewayEvent({ ...event, profile: sourceProfile })
+      callbacksRef.current.handleGatewayEvent({
+        ...event,
+        connectionId: sourceConnectionId || undefined,
+        profile: sourceProfile
+      })
     )
 
     // Wake signals: power resume (macOS/Windows), network coming back, and the
@@ -502,8 +551,13 @@ export function useGatewayBoot({
       try {
         // A profile-pinned helper window (the HUD) dials its target profile's
         // backend directly — ensureBackend spawns/reuses it from the pool.
-        // Everything else keeps dialing the primary.
-        const conn = await desktop.getConnection(windowProfileOverride() ?? undefined)
+        // Everything else keeps dialing the primary. Capture main's profile
+        // authority before requesting the connection: profile.set writes the
+        // new preference before old-primary teardown/reload completes.
+        const requestedProfile = windowProfileOverride() ?? (await primaryProfileAuthority())
+        const conn = await desktop.getConnection(requestedProfile || undefined)
+        sourceProfile = sourceProfileForConnection(conn, requestedProfile)
+        sourceConnectionId = String(conn.connectionId || '').trim()
 
         if (cancelled) {
           return

--- a/apps/desktop/src/app/session/hooks/preview-open.test.tsx
+++ b/apps/desktop/src/app/session/hooks/preview-open.test.tsx
@@ -4,6 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { assistantTextPart, type ChatMessage } from '@/lib/chat-messages'
 import { $previewTabs, $previewTarget, closeRightRail, type PreviewTarget } from '@/store/preview'
+import { $previewStatusBySession, clearPreviewArtifacts, recordPreviewArtifact } from '@/store/preview-status'
 import { $activeSessionId, $currentCwd, $messages, $selectedStoredSessionId } from '@/store/session'
 import type { RpcEvent } from '@/types/hermes'
 
@@ -52,6 +53,7 @@ describe('open_preview', () => {
     $currentCwd.set('/work')
     $messages.set([])
     closeRightRail()
+    clearPreviewArtifacts(RUNTIME_SESSION_ID)
     window.localStorage.clear()
 
     Object.defineProperty(window, 'hermesDesktop', {
@@ -64,6 +66,7 @@ describe('open_preview', () => {
     cleanup()
     $messages.set([])
     closeRightRail()
+    clearPreviewArtifacts(RUNTIME_SESSION_ID)
     $activeSessionId.set(null)
     $selectedStoredSessionId.set(null)
     window.localStorage.clear()
@@ -96,6 +99,45 @@ describe('open_preview', () => {
     })
 
     expect($previewTarget.get()?.path).toBe('/tmp/artifact-test.html')
+  })
+
+  it('routes normalization with the locally stamped source profile', async () => {
+    render(<Harness />)
+
+    await act(async () => {
+      handleEvent({
+        connectionId: 'grace-ssh',
+        payload: { url: 'http://127.0.0.1:8765/report.html' },
+        profile: 'grace-profile',
+        session_id: RUNTIME_SESSION_ID,
+        type: 'preview.open'
+      } as unknown as RpcEvent)
+    })
+
+    await waitFor(() =>
+      expect(window.hermesDesktop.normalizePreviewTarget).toHaveBeenCalledWith(
+        'http://127.0.0.1:8765/report.html',
+        '/work',
+        'grace-profile',
+        'grace-ssh'
+      )
+    )
+  })
+
+  it('retains the stamped profile for a later status-row normalization', async () => {
+    render(<Harness />)
+
+    await act(async () => {
+      handleEvent({
+        payload: { text: 'server ready' },
+        profile: 'grace-profile',
+        session_id: RUNTIME_SESSION_ID,
+        type: 'message.delta'
+      } as unknown as RpcEvent)
+    })
+    recordPreviewArtifact(RUNTIME_SESSION_ID, 'http://127.0.0.1:8765/report.html', '/work')
+
+    expect($previewStatusBySession.get()[RUNTIME_SESSION_ID]?.[0].profile).toBe('grace-profile')
   })
 
   it('ignores an open from a session that is not the one on screen', async () => {

--- a/apps/desktop/src/app/session/hooks/use-preview-routing.ts
+++ b/apps/desktop/src/app/session/hooks/use-preview-routing.ts
@@ -10,6 +10,8 @@ import {
   progressPreviewServerRestart,
   requestPreviewReload
 } from '@/store/preview'
+import { recordPreviewSessionProfile } from '@/store/preview-status'
+import { normalizeProfileKey } from '@/store/profile'
 import { $activeSessionId, $currentCwd } from '@/store/session'
 import { $focusedRuntimeId, $sessionTiles } from '@/store/session-states'
 import type { RpcEvent } from '@/types/hermes'
@@ -59,6 +61,14 @@ export function usePreviewRouting({ baseHandleGatewayEvent, currentCwd, requestG
 
   const handleDesktopGatewayEvent = useCallback<EventHandler>(
     event => {
+      if (event.session_id && event.profile) {
+        recordPreviewSessionProfile(
+          event.session_id,
+          normalizeProfileKey(event.profile),
+          String(event.connectionId || '').trim()
+        )
+      }
+
       baseHandleGatewayEvent(event)
 
       if (event.type === 'preview.open') {
@@ -81,7 +91,12 @@ export function usePreviewRouting({ baseHandleGatewayEvent, currentCwd, requestG
           $sessionTiles.get().some(tile => tile.runtimeId === sid)
 
         if (target && (!event.session_id || onScreen(event.session_id))) {
-          void normalizeOrLocalPreviewTarget(target, $currentCwd.get() || currentCwd || undefined).then(resolved => {
+          void normalizeOrLocalPreviewTarget(
+            target,
+            $currentCwd.get() || currentCwd || undefined,
+            normalizeProfileKey(event.profile),
+            String(event.connectionId || '').trim()
+          ).then(resolved => {
             if (resolved) {
               const trimmedLabel = typeof label === 'string' ? label.trim() : ''
               openPreview(trimmedLabel ? { ...resolved, label: trimmedLabel } : resolved, 'tool-result')

--- a/apps/desktop/src/components/chat/preview-attachment.test.tsx
+++ b/apps/desktop/src/components/chat/preview-attachment.test.tsx
@@ -1,0 +1,57 @@
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { atom } from 'nanostores'
+import { afterEach, expect, it, vi } from 'vitest'
+
+import { PRIMARY_SESSION_VIEW, SessionViewProvider } from '@/app/chat/session-view'
+import { closeRightRail } from '@/store/preview'
+import { clearPreviewArtifacts, recordPreviewSessionProfile } from '@/store/preview-status'
+
+import { PreviewAttachment } from './preview-attachment'
+
+afterEach(() => {
+  cleanup()
+  closeRightRail()
+  vi.restoreAllMocks()
+})
+
+it('normalizes transcript loopback previews with their owning session profile', async () => {
+  const source = 'http://127.0.0.1:8765/report.html'
+  const runtimeId = 'runtime-registry-ssh'
+  recordPreviewSessionProfile(runtimeId, 'named-remote', 'grace-ssh')
+
+  const normalizePreviewTarget = vi.fn(async () => ({
+    kind: 'url' as const,
+    label: 'report.html',
+    previewPartition: 'hermes-preview-forwarded-test',
+    profileValidated: true,
+    source,
+    transient: true,
+    url: 'http://127.0.0.1:49152/report.html'
+  }))
+
+  Object.defineProperty(window, 'hermesDesktop', {
+    configurable: true,
+    value: { normalizePreviewTarget }
+  })
+
+  render(
+    <SessionViewProvider
+      value={{
+        ...PRIMARY_SESSION_VIEW,
+        $cwd: atom('/work'),
+        $profile: atom('named-remote'),
+        $runtimeId: atom(runtimeId)
+      } as never}
+    >
+      <PreviewAttachment target={source} />
+    </SessionViewProvider>
+  )
+
+  fireEvent.click(screen.getByRole('button'))
+
+  await waitFor(() => {
+    expect(normalizePreviewTarget).toHaveBeenCalledWith(source, '/work', 'named-remote', 'grace-ssh')
+  })
+
+  clearPreviewArtifacts(runtimeId)
+})

--- a/apps/desktop/src/components/chat/preview-attachment.tsx
+++ b/apps/desktop/src/components/chat/preview-attachment.tsx
@@ -8,12 +8,16 @@ import { normalizeOrLocalPreviewTarget } from '@/lib/local-preview'
 import { previewName } from '@/lib/preview-targets'
 import { notifyError } from '@/store/notifications'
 import { $previewTabSources, closePreviewForSource, openPreview, type PreviewRecordSource } from '@/store/preview'
+import { previewSessionSource } from '@/store/preview-status'
 
 export function PreviewAttachment({ source = 'manual', target }: { source?: PreviewRecordSource; target: string }) {
   const { t } = useI18n()
   // This link lives in one session's transcript; resolve it against THAT
   // session's cwd, not the primary chat's.
-  const cwd = useStore(useSessionView().$cwd)
+  const sessionView = useSessionView()
+  const cwd = useStore(sessionView.$cwd)
+  const profile = useStore(sessionView.$profile)
+  const runtimeId = useStore(sessionView.$runtimeId)
   const openSources = useStore($previewTabSources)
   const [opening, setOpening] = useState(false)
   const cwdRef = useRef(cwd)
@@ -60,7 +64,14 @@ export function PreviewAttachment({ source = 'manual', target }: { source?: Prev
     setOpening(true)
 
     try {
-      const preview = await normalizeOrLocalPreviewTarget(requestTarget, requestCwd || undefined)
+      const provenance = previewSessionSource(runtimeId || '')
+
+      const preview = await normalizeOrLocalPreviewTarget(
+        requestTarget,
+        requestCwd || undefined,
+        provenance?.profile || profile,
+        provenance?.connectionId
+      )
 
       if (
         !mountedRef.current ||

--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -207,7 +207,13 @@ declare global {
       saveImageBuffer: (data: ArrayBuffer | Uint8Array, ext: string) => Promise<string>
       saveClipboardImage: () => Promise<string>
       getPathForFile: (file: File) => string
-      normalizePreviewTarget: (target: string, baseDir?: string) => Promise<HermesPreviewTarget | null>
+      normalizePreviewTarget: (
+        target: string,
+        baseDir?: string,
+        profile?: string,
+        connectionId?: string
+      ) => Promise<HermesPreviewTarget | null>
+      releasePreviewForward: (partition: string) => Promise<boolean>
       watchPreviewFile: (url: string) => Promise<HermesPreviewWatch>
       /** Watch a directory for entry churn (disk-plugin door); same watcher
        *  registry + onPreviewFileChanged channel as watchPreviewFile. Optional:
@@ -994,9 +1000,12 @@ export interface HermesPreviewTarget {
   language?: string
   mimeType?: string
   path?: string
+  profileValidated?: true
+  previewPartition?: string
   previewKind?: 'binary' | 'html' | 'image' | 'pdf' | 'text'
   renderMode?: 'preview' | 'source'
   source: string
+  transient?: boolean
   url: string
 }
 

--- a/apps/desktop/src/lib/local-preview.test.ts
+++ b/apps/desktop/src/lib/local-preview.test.ts
@@ -144,6 +144,23 @@ describe('remote HTML previews', () => {
     expect(openPreviewInBrowser).toHaveBeenCalledWith(remoteTarget.url)
   })
 
+  it('refuses to open a forwarded target outside its restricted partition', async () => {
+    const openPreviewInBrowser = vi.fn(async () => undefined)
+    window.hermesDesktop = { openPreviewInBrowser } as never
+
+    await expect(
+      openPreviewTargetInBrowser({
+        kind: 'url',
+        label: 'report.html',
+        previewPartition: 'hermes-preview-forwarded-00000000-0000-4000-8000-000000000004',
+        source: 'http://127.0.0.1:8765/report.html',
+        transient: true,
+        url: 'http://127.0.0.1:49155/report.html'
+      })
+    ).rejects.toThrow(/restricted preview partition/i)
+    expect(openPreviewInBrowser).not.toHaveBeenCalled()
+  })
+
   it('keeps local HTML source browser opens on their existing path', async () => {
     const openPreviewInBrowser = vi.fn(async () => undefined)
     window.hermesDesktop = { openPreviewInBrowser } as never
@@ -195,5 +212,64 @@ describe('PDF previews', () => {
       previewKind: 'pdf'
     })
     expect(readDesktopFileDataUrl).not.toHaveBeenCalled()
+  })
+
+  it('passes immutable connection and profile provenance to main-process normalization', async () => {
+    const normalizePreviewTarget = vi.fn(async () => null)
+    window.hermesDesktop = { normalizePreviewTarget } as never
+
+    await normalizeOrLocalPreviewTarget(
+      'http://127.0.0.1:8765/report.html',
+      '/work',
+      'grace-profile',
+      'grace-ssh'
+    )
+
+    expect(normalizePreviewTarget).toHaveBeenCalledWith(
+      'http://127.0.0.1:8765/report.html',
+      '/work',
+      'grace-profile',
+      'grace-ssh'
+    )
+  })
+
+  it('rejects an old main-process loopback result that lacks profile validation', async () => {
+    window.hermesDesktop = {
+      normalizePreviewTarget: vi.fn(async target => ({
+        kind: 'url',
+        label: 'report.html',
+        source: target,
+        url: target
+      }))
+    } as never
+
+    const target = await normalizeOrLocalPreviewTarget('http://127.0.0.1:8765/report.html', '/work', 'grace-profile')
+
+    expect(target).toBeNull()
+  })
+
+  it('fails closed when a loopback URL has no locally stamped profile provenance', async () => {
+    window.hermesDesktop = {
+      normalizePreviewTarget: vi.fn(async target => ({
+        kind: 'url',
+        label: 'report.html',
+        source: target,
+        url: target
+      }))
+    } as never
+
+    const target = await normalizeOrLocalPreviewTarget('http://127.0.0.1:8765/report.html', '/work')
+
+    expect(target).toBeNull()
+  })
+
+  it('does not reopen a rejected SSH loopback target against client localhost', async () => {
+    window.hermesDesktop = {
+      normalizePreviewTarget: vi.fn(async () => null)
+    } as never
+
+    const target = await normalizeOrLocalPreviewTarget('http://127.0.0.1:8765/report.html', '/work', 'grace-profile')
+
+    expect(target).toBeNull()
   })
 })

--- a/apps/desktop/src/lib/local-preview.ts
+++ b/apps/desktop/src/lib/local-preview.ts
@@ -56,6 +56,30 @@ function extension(value: string) {
   return idx >= 0 ? clean.slice(idx).toLowerCase() : ''
 }
 
+function isLoopbackHttpTarget(value: string) {
+  try {
+    const url = new URL(value.trim())
+
+    const hostname = url.hostname
+      .replace(/^\[|\]$/g, '')
+      .toLowerCase()
+      .replace(/\.+$/, '')
+
+    return (
+      (url.protocol === 'http:' || url.protocol === 'https:') &&
+      (hostname === 'localhost' ||
+        hostname.endsWith('.localhost') ||
+        hostname === '0.0.0.0' ||
+        hostname === '::' ||
+        hostname === '::1' ||
+        /^127(?:\.|$)/.test(hostname) ||
+        hostname.startsWith('::ffff:'))
+    )
+  } catch {
+    return false
+  }
+}
+
 function joinPath(base: string, rel: string) {
   if (!base) {
     return rel
@@ -145,6 +169,10 @@ export function remoteHtmlPreviewDocument(dataUrl: string): string | null {
 }
 
 export async function openPreviewTargetInBrowser(target: PreviewTarget): Promise<void> {
+  if (target.previewPartition) {
+    throw new Error('Forwarded content must remain in its restricted preview partition')
+  }
+
   const bridge = window.hermesDesktop
 
   if (!bridge?.openPreviewInBrowser) {
@@ -259,10 +287,25 @@ async function enrichPreviewTarget(target: PreviewTarget | null): Promise<Previe
 
 export async function normalizeOrLocalPreviewTarget(
   rawTarget: string,
-  cwd?: string | null
+  cwd?: string | null,
+  profile?: string | null,
+  connectionId?: string | null
 ): Promise<PreviewTarget | null> {
+  if (isLoopbackHttpTarget(rawTarget) && !String(profile || '').trim()) {
+    return null
+  }
+
   try {
-    const normalized = await window.hermesDesktop?.normalizePreviewTarget?.(rawTarget, cwd || undefined)
+    const normalized = await window.hermesDesktop?.normalizePreviewTarget?.(
+      rawTarget,
+      cwd || undefined,
+      profile || undefined,
+      connectionId || undefined
+    )
+
+    if (normalized && profile && isLoopbackHttpTarget(rawTarget) && normalized.profileValidated !== true) {
+      return null
+    }
 
     if (normalized) {
       return enrichPreviewTarget(normalized)
@@ -270,6 +313,10 @@ export async function normalizeOrLocalPreviewTarget(
   } catch {
     // Running Electron may still have the old HTML-only preview IPC. Fall
     // through to renderer-side local classification so text/images still open.
+  }
+
+  if (profile && /^https?:\/\//i.test(rawTarget.trim())) {
+    return null
   }
 
   return enrichPreviewTarget(localPreviewTarget(rawTarget, cwd))

--- a/apps/desktop/src/store/gateway-shared-remote.test.ts
+++ b/apps/desktop/src/store/gateway-shared-remote.test.ts
@@ -15,6 +15,8 @@ const gatewayMocks = vi.hoisted(() => ({
   connect: vi.fn(async (_wsUrl: string): Promise<void> => {
     throw new Error('dialed a socket for a shared-primary profile')
   }),
+  eventHandlers: [] as Array<(event: Record<string, unknown>) => void>,
+  onEvent: vi.fn(),
   setConnection: vi.fn()
 }))
 
@@ -26,7 +28,11 @@ vi.mock('@/hermes', () => ({
       this.connectionState = 'open'
     }
     close = vi.fn()
-    onEvent = vi.fn(() => () => {})
+    onEvent = vi.fn((handler: (event: Record<string, unknown>) => void) => {
+      gatewayMocks.eventHandlers.push(handler)
+
+      return () => {}
+    })
     onState = vi.fn(() => () => {})
   }
 }))
@@ -57,8 +63,9 @@ function makePrimary(): { connectionState: string } {
 }
 
 beforeEach(() => {
+  gatewayMocks.eventHandlers.length = 0
   configureGatewayRegistry({
-    onEvent: vi.fn(),
+    onEvent: gatewayMocks.onEvent,
     primaryProfile: 'default'
   } as never)
 })
@@ -110,6 +117,31 @@ describe('ensureGatewayForProfile under a shared global remote', () => {
     expect(gatewayMocks.connect).toHaveBeenCalledOnce()
     expect(gatewayMocks.connect).toHaveBeenCalledWith(remoteWsUrl)
     expect($gateway.get()).not.toBe(primary)
+  })
+
+  it('strips a wire-supplied connection ID from legacy secondary events', async () => {
+    setPrimaryGateway(makePrimary() as never, 'default')
+    installDesktop({
+      getConnection: vi.fn(async () => ({
+        authMode: 'token',
+        baseUrl: 'https://worker.invalid',
+        mode: 'remote',
+        profile: 'worker',
+        wsUrl: 'wss://worker.invalid/api/ws?token=fake-test-token'
+      }))
+    })
+    gatewayMocks.connect.mockResolvedValueOnce(undefined)
+
+    await ensureGatewayForProfile('worker')
+    gatewayMocks.eventHandlers.at(-1)?.({
+      connectionId: 'forged-wire-id',
+      profile: 'forged-wire-profile',
+      type: 'status.update'
+    })
+
+    expect(gatewayMocks.onEvent).toHaveBeenCalledWith(
+      expect.objectContaining({ connectionId: undefined, profile: 'worker', type: 'status.update' })
+    )
   })
 
   it('refreshes the active connection after a pooled profile reconnect succeeds', async () => {

--- a/apps/desktop/src/store/gateway.ts
+++ b/apps/desktop/src/store/gateway.ts
@@ -22,8 +22,10 @@ const normKey = (profile: string | null | undefined): string => (profile ?? '').
 // narrow the getter to a constant across guards (it genuinely changes).
 const isOpen = (gateway: HermesGateway | null): boolean => gateway?.connectionState === 'open'
 
+type DesktopGatewayEvent = GatewayEvent & { connectionId?: string }
+
 interface RegistryConfig {
-  onEvent: (event: GatewayEvent) => void
+  onEvent: (event: DesktopGatewayEvent) => void
 }
 
 // ── Secondary (pool) backends ──────────────────────────────────────────────
@@ -258,10 +260,11 @@ function createSecondary(profile: string, connectionId: null | string = null): S
     wantOpen: true
   }
 
-  // Events keep carrying the bare profile — session routing is profile-keyed
-  // everywhere. connectionId rides along for surfaces that need the source.
+  // Both provenance fields are stamped locally. Registry sockets retain
+  // their exact immutable connection ID; legacy sockets explicitly clear any
+  // wire-supplied ID instead of letting it establish routing authority.
   entry.offEvent = gateway.onEvent(event =>
-    g.config?.onEvent({ ...event, profile, ...(connectionId ? { connectionId } : {}) })
+    g.config?.onEvent({ ...event, connectionId: connectionId || undefined, profile })
   )
   entry.offState = gateway.onState(state => {
     reportGatewayState(scope, state)

--- a/apps/desktop/src/store/preview-status.test.ts
+++ b/apps/desktop/src/store/preview-status.test.ts
@@ -4,10 +4,14 @@ import {
   $previewStatusBySession,
   clearPreviewArtifacts,
   dismissPreviewArtifact,
-  recordPreviewArtifact
+  recordPreviewArtifact,
+  recordPreviewSessionProfile
 } from './preview-status'
 
-beforeEach(() => $previewStatusBySession.set({}))
+beforeEach(() => {
+  $previewStatusBySession.set({})
+  clearPreviewArtifacts('s1')
+})
 
 describe('recordPreviewArtifact', () => {
   it('appends new targets newest-last and is idempotent', () => {
@@ -16,6 +20,14 @@ describe('recordPreviewArtifact', () => {
     recordPreviewArtifact('s1', '/a/index.html', '/work')
 
     expect($previewStatusBySession.get().s1.map(i => i.id)).toEqual(['/a/index.html', '/a/about.html'])
+  })
+
+  it('stamps artifacts with the first locally observed session profile', () => {
+    recordPreviewSessionProfile('s1', 'grace-profile', 'grace-ssh')
+    recordPreviewSessionProfile('s1', 'different-profile', 'different-connection')
+    recordPreviewArtifact('s1', 'http://127.0.0.1:8765/report.html', '/work')
+
+    expect($previewStatusBySession.get().s1[0]).toMatchObject({ connectionId: 'grace-ssh', profile: 'grace-profile' })
   })
 
   it('caps the list and derives a label', () => {

--- a/apps/desktop/src/store/preview-status.ts
+++ b/apps/desktop/src/store/preview-status.ts
@@ -12,17 +12,44 @@ import { previewName } from '@/lib/preview-targets'
  * target the inline card used, so detection parity is exact.
  */
 export interface PreviewArtifact {
+  /** Immutable locally stamped registry connection that produced this artifact. */
+  connectionId?: string
   /** cwd captured at detection so a relative path still resolves on click. */
   cwd: string
   /** Dedupe key + display id (the raw target). */
   id: string
   label: string
+  /** Immutable locally stamped gateway profile that produced this artifact. */
+  profile?: string
   target: string
 }
 
 const MAX_PER_SESSION = 4
+export interface PreviewSessionSource {
+  connectionId?: string
+  profile: string
+}
+
+const previewSourceBySession = new Map<string, PreviewSessionSource>()
 
 export const $previewStatusBySession = atom<Record<string, PreviewArtifact[]>>({})
+
+export function previewSessionSource(sid: string): PreviewSessionSource | undefined {
+  return previewSourceBySession.get(sid.trim())
+}
+
+export function recordPreviewSessionProfile(sid: string, profile: string, connectionId = '') {
+  const sessionId = sid.trim()
+  const sourceProfile = profile.trim()
+  const sourceConnectionId = connectionId.trim()
+
+  if (sessionId && sourceProfile && !previewSourceBySession.has(sessionId)) {
+    previewSourceBySession.set(sessionId, {
+      connectionId: sourceConnectionId || undefined,
+      profile: sourceProfile
+    })
+  }
+}
 
 const writePreviews = (sid: string, items: PreviewArtifact[]) => {
   const current = $previewStatusBySession.get()
@@ -55,12 +82,20 @@ export function recordPreviewArtifact(sid: string, target: string, cwd: string) 
   }
 
   const list = $previewStatusBySession.get()[sid] ?? []
+  const source = previewSourceBySession.get(sid)
+  const existingIndex = list.findIndex(item => item.id === raw)
 
-  if (list.some(item => item.id === raw)) {
+  if (existingIndex >= 0) {
+    if (source && !list[existingIndex].profile) {
+      const next = [...list]
+      next[existingIndex] = { ...next[existingIndex], ...source }
+      writePreviews(sid, next)
+    }
+
     return
   }
 
-  writePreviews(sid, [...list, { cwd, id: raw, label: previewName(raw), target: raw }].slice(-MAX_PER_SESSION))
+  writePreviews(sid, [...list, { ...source, cwd, id: raw, label: previewName(raw), target: raw }].slice(-MAX_PER_SESSION))
 }
 
 export function dismissPreviewArtifact(sid: string, id: string) {
@@ -75,5 +110,6 @@ export function dismissPreviewArtifact(sid: string, id: string) {
 }
 
 export function clearPreviewArtifacts(sid: string) {
+  previewSourceBySession.delete(sid)
   writePreviews(sid, [])
 }

--- a/apps/desktop/src/store/preview.test.ts
+++ b/apps/desktop/src/store/preview.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { $rightRailActiveTabId } from './layout'
 import {
@@ -80,6 +80,46 @@ describe('preview store', () => {
     expect(urlTabs).toHaveLength(1)
     expect(urlTabs[0].target.url).toBe('https://www.reddit.com')
     expect($rightRailActiveTabId.get()).toBe(urlTabs[0].id)
+  })
+
+  it('releases a forwarded Browser target when another URL replaces it', () => {
+    const releasePreviewForward = vi.fn(async () => true)
+    Object.defineProperty(window, 'hermesDesktop', {
+      configurable: true,
+      value: { releasePreviewForward }
+    })
+
+    const forwarded = {
+      ...urlTarget('http://127.0.0.1:8765/report.html'),
+      previewPartition: 'hermes-preview-forwarded-00000000-0000-4000-8000-000000000001',
+      transient: true,
+      url: 'http://127.0.0.1:49152/report.html'
+    }
+
+    openPreview(forwarded, 'tool-result')
+    openPreview(urlTarget('https://example.com'), 'tool-result')
+
+    expect(releasePreviewForward).toHaveBeenCalledWith(forwarded.previewPartition)
+  })
+
+  it('releases a forwarded Browser target when its tab closes', () => {
+    const releasePreviewForward = vi.fn(async () => true)
+    Object.defineProperty(window, 'hermesDesktop', {
+      configurable: true,
+      value: { releasePreviewForward }
+    })
+
+    const forwarded = {
+      ...urlTarget('http://127.0.0.1:8765/report.html'),
+      previewPartition: 'hermes-preview-forwarded-00000000-0000-4000-8000-000000000002',
+      transient: true,
+      url: 'http://127.0.0.1:49153/report.html'
+    }
+
+    openPreview(forwarded, 'tool-result')
+    closeRightRailTab(previewTabId(forwarded))
+
+    expect(releasePreviewForward).toHaveBeenCalledWith(forwarded.previewPartition)
   })
 
   it('re-fronts an existing tab instead of duplicating it, refreshing its target', () => {

--- a/apps/desktop/src/store/preview.ts
+++ b/apps/desktop/src/store/preview.ts
@@ -35,6 +35,8 @@ export interface PreviewTarget {
   language?: string
   mimeType?: string
   path?: string
+  /** Main-process-minted, non-persistent partition for an SSH-forwarded preview. */
+  previewPartition?: string
   previewKind?: 'binary' | 'html' | 'image' | 'pdf' | 'text'
   renderMode?: 'preview' | 'source'
   source: string
@@ -212,6 +214,12 @@ function previewTargetForSource(target: PreviewTarget, source: PreviewRecordSour
   return { ...target, renderMode: isFilePreviewSource(source) ? 'source' : 'preview' }
 }
 
+function releasePreviewTarget(target: PreviewTarget | undefined) {
+  if (target?.previewPartition) {
+    void window.hermesDesktop?.releasePreviewForward?.(target.previewPartition)
+  }
+}
+
 /** Open (or re-front) the tab for `target`. Re-opening an existing tab refreshes
  *  its target so a stale label/path can't outlive the thing it points at. The
  *  only way anything reaches a preview. */
@@ -221,6 +229,11 @@ export function openPreview(target: PreviewTarget, source: PreviewRecordSource =
   const current = $previewTabs.get()
   const index = current.findIndex(tab => tab.id === id)
   const tab: PreviewTab = { id, target: resolved }
+  const replaced = index === -1 ? undefined : current[index]?.target
+
+  if (replaced?.previewPartition !== resolved.previewPartition) {
+    releasePreviewTarget(replaced)
+  }
 
   $previewTabs.set(index === -1 ? [...current, tab] : current.map((item, i) => (i === index ? tab : item)))
   selectRightRailTab(id)
@@ -236,6 +249,7 @@ export function closeRightRailTab(tabId: string) {
 
   const next = current.filter(tab => tab.id !== tabId)
 
+  releasePreviewTarget(current[index]?.target)
   $previewTabs.set(next)
 
   if ($rightRailActiveTabId.get() === tabId) {
@@ -272,6 +286,10 @@ export function closeArtifactPreviewTabs() {
 
 /** Close every tab so the rail's panes leave the tree. */
 export function closeRightRail() {
+  for (const tab of $previewTabs.get()) {
+    releasePreviewTarget(tab.target)
+  }
+
   $previewTabs.set([])
   selectRightRailTab(null)
 }

--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -448,6 +448,8 @@ export interface PaginatedSessions {
 }
 
 export interface RpcEvent<T = unknown> {
+  /** Locally stamped registry connection; never trusted from the wire. */
+  connectionId?: string
   payload?: T
   profile?: string
   session_id?: string


### PR DESCRIPTION
## What does this PR do?

Fixes Windows Desktop previews for SSH-connected agents when the agent returns a remote-loopback URL such as `http://127.0.0.1:8765/...`.

Without this change, Electron resolves that address against the Windows client rather than the remote SSH host, so a healthy remote page appears as "Server not found." This implementation opens a narrowly allowlisted local forward through the exact authenticated SSH transport, preserves the original remote URL, and exposes only an opaque capability plus an ephemeral Windows-loopback URL to the renderer.

Forwarding authority is bound to stable main-process profile provenance, the local registry `connectionId`, and the exact live `SshConnection`. Targets and browser sessions are restricted, and capabilities are revoked on release, replacement, expiry, SSH teardown, transport invalidation, connection/profile changes, cancellation failure, and app shutdown.

## Related Issue

No related issue found after searching the issue tracker and open PRs for SSH/Windows loopback preview failures.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/electron/{main.ts,preload.ts,ssh-connection.ts,ssh-owner-registry.ts}`: resolve forwarding through the exact registered SSH connection and revoke/retry lifecycle cleanup safely.
- `apps/desktop/electron/{ssh-preview-target.ts,preview-backend-route.ts}`: enforce Windows-only fail-closed routing and a strict HTTP(S), loopback-host, and port allowlist.
- `apps/desktop/electron/forwarded-preview-session.ts`: create unique nonpersistent restricted Electron partitions for forwarded previews.
- `apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts` and `apps/desktop/src/store/gateway.ts`: preserve authoritative profile/connection provenance and replace wire-supplied connection identity with the local registry identity.
- `apps/desktop/src/{store,lib,components,app}/**`: retain original and forwarded URLs separately, propagate opaque release capabilities, and release forwards when preview state changes.
- Added focused Electron and renderer regressions for target validation, route authority, owner identity, cancellation/teardown, restricted sessions, profile snapshot races, wire provenance, URL retention, release, retry, and shutdown behavior.

## How to Test

1. On Windows 11, connect Hermes Desktop to a remote Hermes profile using **Connect via SSH**.
2. On the remote host, bind a page only to an allowlisted loopback target, for example: `python3 -m http.server 8765 --bind 127.0.0.1`.
3. Open a Desktop preview for `http://127.0.0.1:8765/<page>` and verify the page renders even though the same URL is not directly reachable from Windows; verify the original remote URL remains available for restart.
4. Release/replace the preview, reconnect or tear down SSH, and quit Desktop; verify each ephemeral local listener closes.

Automated validation performed:

- Electron/platform suite: 1,230 passed, 2 pending, 0 failed across 141 suites
- Full Desktop UI suite: 4,323 passed, 0 failed
- Final focused provenance/routing suite: 39/39 passed
- Desktop typecheck, production build, native Windows build, full ESLint (0 errors), and `git diff --check`
- Secret and dangerous-added-line scans

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — N/A: this is a Desktop-only TypeScript/Electron change; all applicable Desktop suites are listed above
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A: no user-facing configuration or documented API changed
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A: no config keys changed
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A: no contributor workflow changed
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — the new forwarding path is explicitly Windows-gated; non-Windows behavior is unchanged
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A: no model tool or protocol schema changed

## Screenshots / Logs

Manual Windows/SSH validation:

```text
remote loopback page: HTTP 200
same URL from Windows: unreachable as expected
forwarded Browser preview: rendered successfully
original remote URL: preserved
explicit release: forwarded listener closed
Desktop shutdown: forwarded listener and SSH/CDP test endpoints closed
```
