### PR TITLE
fix(cli): resolve model routes before startup provider defaults

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -4797,6 +4797,21 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         # clobber an explicit override with the session's stored model.
         self._explicit_model_override = bool(model)
         self.model = model or _config_model or _DEFAULT_CONFIG_MODEL
+        _startup_provider_override = ""
+        _startup_base_url_override = ""
+        if self.model:
+            from hermes_cli.model_switch import resolve_startup_model_route
+
+            _startup_route = resolve_startup_model_route(
+                self.model,
+                explicit_provider=provider or "",
+                user_providers=CLI_CONFIG.get("providers"),
+                custom_providers=CLI_CONFIG.get("custom_providers"),
+            )
+            if _startup_route is not None:
+                self.model = _startup_route.model
+                _startup_provider_override = _startup_route.provider
+                _startup_base_url_override = _startup_route.base_url
         # A ``moa:<preset>`` model string selects the MoA virtual provider in
         # one shot (parity with interactive ``/moa`` and the model picker). Do
         # this before provider resolution so ``-Q -m moa:<preset>`` routes
@@ -4840,6 +4855,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         self.requested_provider = (
             _moa_provider_override
             or provider
+            or _startup_provider_override
             or _nested_provider
             or CLI_CONFIG["model"].get("provider")
             or os.getenv("HERMES_INFERENCE_PROVIDER")
@@ -4852,6 +4868,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         self.acp_args: list[str] = []
         self.base_url = (
             base_url
+            or _startup_base_url_override
             or CLI_CONFIG["model"].get("base_url", "")
             or os.getenv("OPENROUTER_BASE_URL", "")
         ) or None

--- a/docs/assets/model-routing-87189.svg
+++ b/docs/assets/model-routing-87189.svg
@@ -1,0 +1,61 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="620" viewBox="0 0 1200 620" role="img" aria-labelledby="title desc">
+  <title id="title">Hermes model startup routing fix</title>
+  <desc id="desc">A diagram showing aliases and provider/model inputs converging at startup routing before runtime provider resolution.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1"><stop stop-color="#07111f"/><stop offset="1" stop-color="#101b31"/></linearGradient>
+    <linearGradient id="good" x1="0" x2="1"><stop stop-color="#064e3b"/><stop offset="1" stop-color="#065f46"/></linearGradient>
+    <linearGradient id="bad" x1="0" x2="1"><stop stop-color="#7f1d1d"/><stop offset="1" stop-color="#991b1b"/></linearGradient>
+    <filter id="shadow"><feDropShadow dx="0" dy="8" stdDeviation="8" flood-color="#000" flood-opacity=".35"/></filter>
+    <marker id="arrow" markerWidth="10" markerHeight="10" refX="8" refY="5" orient="auto"><path d="M0,0 L10,5 L0,10 z" fill="#67e8f9"/></marker>
+    <pattern id="grid" width="40" height="40" patternUnits="userSpaceOnUse"><path d="M40 0H0V40" fill="none" stroke="#334155" stroke-opacity=".22"/></pattern>
+    <style>
+      .h{font:700 28px 'Segoe UI',sans-serif;fill:#e2e8f0}.s{font:14px 'Segoe UI',sans-serif;fill:#94a3b8}.t{font:600 17px 'Segoe UI',sans-serif;fill:#f8fafc}.m{font:14px Consolas,monospace;fill:#cbd5e1}.small{font:12px 'Segoe UI',sans-serif;fill:#cbd5e1}.label{font:700 12px 'Segoe UI',sans-serif;letter-spacing:1.4px;fill:#67e8f9}
+    </style>
+  </defs>
+  <rect width="1200" height="620" rx="22" fill="url(#bg)"/>
+  <rect x="20" y="20" width="1160" height="580" rx="16" fill="url(#grid)"/>
+  <text x="60" y="70" class="h">Issue #87189 · startup model routing</text>
+  <text x="60" y="100" class="s">Resolve the requested route before the configured default provider can take ownership.</text>
+
+  <rect x="60" y="145" width="310" height="105" rx="12" fill="#172554" stroke="#818cf8" stroke-width="2" filter="url(#shadow)"/>
+  <text x="82" y="177" class="label">INPUT</text>
+  <text x="82" y="207" class="m">--model nous/deepseek-v4-pro</text>
+  <text x="82" y="230" class="small">or a configured model alias</text>
+
+  <rect x="445" y="130" width="310" height="135" rx="12" fill="url(#good)" stroke="#34d399" stroke-width="2" filter="url(#shadow)"/>
+  <text x="467" y="163" class="label" style="fill:#a7f3d0">FIXED CHOKE POINT</text>
+  <text x="467" y="195" class="t">resolve_startup_model_route</text>
+  <text x="467" y="220" class="small">alias → model + provider + base_url</text>
+  <text x="467" y="243" class="small">prefix → configured provider only</text>
+
+  <rect x="830" y="145" width="310" height="105" rx="12" fill="#164e63" stroke="#22d3ee" stroke-width="2" filter="url(#shadow)"/>
+  <text x="852" y="177" class="label">RUNTIME</text>
+  <text x="852" y="207" class="m">provider = nous</text>
+  <text x="852" y="230" class="m">model = deepseek-v4-pro</text>
+
+  <path d="M370 197H435" stroke="#67e8f9" stroke-width="3" marker-end="url(#arrow)"/>
+  <path d="M755 197H820" stroke="#67e8f9" stroke-width="3" marker-end="url(#arrow)"/>
+
+  <rect x="60" y="330" width="310" height="105" rx="12" fill="url(#bad)" stroke="#fb7185" stroke-width="2" filter="url(#shadow)"/>
+  <text x="82" y="362" class="label" style="fill:#fecdd3">BEFORE</text>
+  <text x="82" y="392" class="m">model = nous/deepseek-v4-pro</text>
+  <text x="82" y="417" class="m">provider = anthropic</text>
+
+  <rect x="445" y="315" width="310" height="135" rx="12" fill="#1e293b" stroke="#64748b" stroke-width="2" filter="url(#shadow)"/>
+  <text x="467" y="348" class="label" style="fill:#fda4af">WRONG FALLBACK</text>
+  <text x="467" y="380" class="t">configured default wins</text>
+  <text x="467" y="408" class="small">requested provider never participates</text>
+  <text x="467" y="432" class="small">route reaches the wrong endpoint</text>
+
+  <rect x="830" y="330" width="310" height="105" rx="12" fill="#3f1d2e" stroke="#fb7185" stroke-width="2" filter="url(#shadow)"/>
+  <text x="852" y="362" class="label" style="fill:#fecdd3">FAILURE</text>
+  <text x="852" y="392" class="m">api.anthropic.com</text>
+  <text x="852" y="417" class="m">HTTP 404: model not found</text>
+
+  <path d="M215 260V320" stroke="#fb7185" stroke-width="3" stroke-dasharray="7 6" marker-end="url(#arrow)"/>
+  <path d="M600 275V305" stroke="#fb7185" stroke-width="3" stroke-dasharray="7 6" marker-end="url(#arrow)"/>
+  <path d="M755 382H820" stroke="#fb7185" stroke-width="3" stroke-dasharray="7 6" marker-end="url(#arrow)"/>
+
+  <rect x="60" y="505" width="1080" height="58" rx="10" fill="#0f172a" stroke="#334155"/>
+  <circle cx="87" cy="534" r="7" fill="#34d399"/><text x="106" y="540" class="small">Regression coverage: CLI startup · oneshot · aliases · configured provider/model prefixes · aggregator namespace preservation</text>
+</svg>

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -423,11 +423,23 @@ def _load_direct_aliases() -> dict[str, DirectAlias]:
             if isinstance(simple_aliases, dict):
                 current_provider = model_section.get("provider", "")
                 for name, value in simple_aliases.items():
-                    if not isinstance(value, str) or not value.strip():
-                        continue
                     key = name.strip().lower()
                     if key in merged:
                         continue  # don't override explicit model_aliases entries
+                    if isinstance(value, dict):
+                        model = str(value.get("model") or "").strip()
+                        if not model:
+                            continue
+                        merged[key] = DirectAlias(
+                            model=model,
+                            provider=str(
+                                value.get("provider") or current_provider or "custom"
+                            ).strip(),
+                            base_url=str(value.get("base_url") or "").strip(),
+                        )
+                        continue
+                    if not isinstance(value, str) or not value.strip():
+                        continue
                     val = value.strip()
                     if "/" in val:
                         provider, model = val.split("/", 1)
@@ -454,6 +466,78 @@ def _ensure_direct_aliases() -> None:
     """
     if not DIRECT_ALIASES:
         DIRECT_ALIASES.update(_load_direct_aliases())
+
+
+class StartupModelRoute(NamedTuple):
+    """Model/provider pair resolved before an agent is constructed."""
+
+    model: str
+    provider: str = ""
+    base_url: str = ""
+
+
+def resolve_startup_model_route(
+    raw_model: str,
+    *,
+    explicit_provider: str = "",
+    user_providers: Optional[dict] = None,
+    custom_providers: Optional[list] = None,
+) -> Optional[StartupModelRoute]:
+    """Resolve aliases and configured ``provider/model`` input at startup.
+
+    ``HermesCLI`` is constructed before the interactive ``/model`` pipeline
+    runs.  Keeping this small resolver at the same boundary as
+    ``DIRECT_ALIASES`` prevents startup from attaching the configured default
+    provider to an explicitly requested model. Provider/model strings are
+    consumed only for providers present in user configuration; aggregator
+    namespaces remain untouched.
+    """
+    raw = str(raw_model or "").strip()
+    if not raw:
+        return None
+
+    _ensure_direct_aliases()
+    direct = DIRECT_ALIASES.get(raw.lower())
+    if direct is not None:
+        return StartupModelRoute(
+            model=direct.model,
+            provider=(explicit_provider or direct.provider),
+            base_url=direct.base_url,
+        )
+
+    if explicit_provider or "/" not in raw:
+        return None
+    prefix, model = (part.strip() for part in raw.split("/", 1))
+    if not prefix or not model:
+        return None
+
+    configured = {
+        str(name).strip().lower()
+        for name in (user_providers or {})
+        if str(name).strip()
+    }
+    configured.update(
+        f"custom:{entry.get('name', '').strip().lower()}"
+        for entry in (custom_providers or [])
+        if isinstance(entry, dict) and str(entry.get("name") or "").strip()
+    )
+    try:
+        from hermes_cli.models import normalize_provider
+
+        canonical = normalize_provider(prefix)
+    except Exception:
+        canonical = prefix.lower()
+
+    if prefix.lower() in configured:
+        provider = prefix
+    elif canonical.lower() in configured:
+        provider = canonical
+    else:
+        return None
+
+    if is_aggregator(canonical):
+        return None
+    return StartupModelRoute(model=model, provider=provider)
 
 
 # ---------------------------------------------------------------------------

--- a/hermes_cli/oneshot.py
+++ b/hermes_cli/oneshot.py
@@ -369,6 +369,20 @@ def _run_agent(
         # path and the configured provider is already correct).
         explicit_model = (model or "").strip() or env_model
         if explicit_model:
+            from hermes_cli.model_switch import resolve_startup_model_route
+
+            startup_route = resolve_startup_model_route(
+                explicit_model,
+                explicit_provider=provider or "",
+                user_providers=cfg.get("providers"),
+                custom_providers=cfg.get("custom_providers"),
+            )
+            if startup_route is not None:
+                effective_model = startup_route.model
+                if effective_provider is None:
+                    effective_provider = startup_route.provider or None
+                if startup_route.base_url:
+                    explicit_base_url_from_alias = startup_route.base_url.rstrip("/")
             # First check DIRECT_ALIASES populated from config.yaml `model_aliases:`.
             # These map a user-defined alias to (model, provider, base_url) for
             # endpoints not in any catalog (local servers, custom proxies, etc.).
@@ -395,6 +409,16 @@ def _run_agent(
                 detected = detect_provider_for_model(explicit_model, current_provider)
                 if detected:
                     effective_provider, effective_model = detected
+
+            # The startup resolver owns explicit provider/model and alias
+            # selections. Do not let the legacy catalog fallback overwrite
+            # that route later in this compatibility path.
+            if startup_route is not None:
+                effective_model = startup_route.model
+                if effective_provider is None or not (provider or "").strip():
+                    effective_provider = startup_route.provider or None
+                if startup_route.base_url:
+                    explicit_base_url_from_alias = startup_route.base_url.rstrip("/")
 
     runtime = resolve_runtime_provider(
         requested=effective_provider,

--- a/tests/cli/test_cli_init.py
+++ b/tests/cli/test_cli_init.py
@@ -443,6 +443,25 @@ class TestNestedDictModelDefaultPairing:
         assert cli.requested_provider == "anthropic"
         assert cli.provider == "anthropic"
 
+    def test_provider_prefixed_startup_model_overrides_stale_provider(self):
+        cli = _make_cli(
+            config_overrides={
+                "model": {
+                    "default": "anthropic/claude-opus-4.6",
+                    "provider": "anthropic",
+                },
+                "providers": {
+                    "nous": {
+                        "base_url": "https://inference-api.nousresearch.com/v1",
+                    },
+                },
+            },
+            model="nous/deepseek-v4-pro",
+        )
+
+        assert cli.model == "deepseek-v4-pro"
+        assert cli.requested_provider == "nous"
+
 
 class TestRootLevelProviderOverride:
     """Root-level provider/base_url in config.yaml must NOT override model.provider."""

--- a/tests/hermes_cli/test_startup_model_routing_87189.py
+++ b/tests/hermes_cli/test_startup_model_routing_87189.py
@@ -1,0 +1,67 @@
+"""Regression tests for startup model/provider routing (#87189)."""
+
+from hermes_cli import model_switch
+
+
+def test_startup_route_uses_configured_nous_provider(monkeypatch):
+    monkeypatch.setattr(model_switch, "DIRECT_ALIASES", {})
+    route = model_switch.resolve_startup_model_route(
+        "nous/deepseek-v4-pro",
+        user_providers={"nous": {"base_url": "https://inference.example/v1"}},
+    )
+    assert route == model_switch.StartupModelRoute("deepseek-v4-pro", "nous", "")
+
+
+def test_startup_route_keeps_configured_custom_provider_name(monkeypatch):
+    monkeypatch.setattr(model_switch, "DIRECT_ALIASES", {})
+    route = model_switch.resolve_startup_model_route(
+        "ollama/qwen3.5:4b",
+        user_providers={"ollama": {"base_url": "http://localhost:11434/v1"}},
+    )
+    assert route == model_switch.StartupModelRoute("qwen3.5:4b", "ollama", "")
+
+
+def test_startup_route_does_not_consume_aggregator_namespace(monkeypatch):
+    monkeypatch.setattr(model_switch, "DIRECT_ALIASES", {})
+    route = model_switch.resolve_startup_model_route(
+        "openrouter/anthropic/claude-sonnet",
+        user_providers={"openrouter": {"base_url": "https://openrouter.ai/api/v1"}},
+    )
+    assert route is None
+
+
+def test_startup_route_resolves_dict_alias_and_preserves_endpoint(monkeypatch):
+    monkeypatch.setattr(
+        model_switch,
+        "DIRECT_ALIASES",
+        {
+            "localqwen": model_switch.DirectAlias(
+                "qwen3.5:4b", "custom", "http://localhost:11434/v1"
+            )
+        },
+    )
+    route = model_switch.resolve_startup_model_route("localqwen")
+    assert route == model_switch.StartupModelRoute(
+        "qwen3.5:4b", "custom", "http://localhost:11434/v1"
+    )
+
+
+def test_model_aliases_dict_entries_are_loaded(monkeypatch):
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {
+            "model": {
+                "aliases": {
+                    "localqwen": {
+                        "model": "qwen3.5:4b",
+                        "provider": "custom",
+                        "base_url": "http://localhost:11434/v1",
+                    }
+                }
+            }
+        },
+    )
+    aliases = model_switch._load_direct_aliases()
+    assert aliases["localqwen"] == model_switch.DirectAlias(
+        "qwen3.5:4b", "custom", "http://localhost:11434/v1"
+    )

--- a/website/docs/reference/slash-commands.md
+++ b/website/docs/reference/slash-commands.md
@@ -175,7 +175,7 @@ String-only prompt shortcuts are not supported as quick commands. Put longer reu
 
 ### Custom model aliases
 
-Define your own short names for models you use often, then reach them with `/model <alias>` in the CLI or any messaging platform. Aliases work identically in both, on session-only (default) and `--global` switches.
+Define your own short names for models you use often, then reach them with `/model <alias>` in a running session, `hermes chat --model <alias>` at startup, or any messaging platform. Aliases work identically in these paths, on session-only (default) and `--global` switches.
 
 Two config formats are supported:
 

--- a/website/docs/user-guide/configuring-models.md
+++ b/website/docs/user-guide/configuring-models.md
@@ -261,7 +261,7 @@ A one-turn switch breaks the provider's prompt-cache prefix twice (switching out
 
 ### Custom aliases
 
-Define your own short names for models you reach for often, then use `/model <alias>` in the CLI or any messaging platform. There are two equivalent formats — pick whichever fits your workflow.
+Define your own short names for models you reach for often, then use `/model <alias>` in a running session or `hermes chat --model <alias>` at startup. There are two equivalent formats — pick whichever fits your workflow.
 
 **Canonical (top-level `model_aliases:`)** — full control over provider + base_url:
 


### PR DESCRIPTION
## Summary

Fixes #87189.

This PR fixes the production startup path that was still attaching the configured default provider to an explicitly requested model. It resolves the route before `HermesCLI` constructs the runtime agent.

![Startup model routing before and after](https://github.com/JoaoMarcos44/hermes-agent/blob/fix/87189-startup-model-routing/docs/assets/model-routing-87189.svg?raw=true)

## Root cause

The existing alias/model-switch machinery was available for `/model` and selected one-shot paths, but the normal `hermes chat --model ...` startup path did this first:

```text
requested model -> HermesCLI.model
configured model.provider -> HermesCLI.requested_provider
runtime provider resolution
```

That meant an input such as `nous/deepseek-v4-pro` or an alias with `provider: ollama` could retain the configured `anthropic` provider. The request then reached the Anthropic endpoint with a non-Anthropic model and failed with HTTP 404.

The related open PR #87210 improves provider detection, but its new detection path is not called by `HermesCLI.__init__`; it therefore does not cover the interactive `hermes chat --model` production choke point. This PR owns that missing startup integration rather than adding another catalog-only detector.

## What changed

- Add `resolve_startup_model_route()` beside the existing direct-alias loader.
  - Resolves top-level direct aliases before provider defaults are attached.
  - Resolves `provider/model` only when the provider is present in user configuration.
  - Preserves user-named providers such as `ollama` instead of rewriting them to the generic `custom` bucket.
  - Leaves aggregator namespaces such as `openrouter/anthropic/...` untouched.
- Wire the resolver into `HermesCLI` initialization, the actual interactive/query startup path.
- Apply the same startup route to the one-shot path and prevent its legacy catalog fallback from overwriting an explicit startup route.
- Accept dictionary entries in `model.aliases`, including `model`, `provider`, and `base_url`.
- Document `hermes chat --model <alias>` in the user and slash-command documentation.
- Add an SVG root-cause/route-flow infographic under `docs/assets/` and embed it above.

## Non-duplication rationale

Related work was reviewed before implementation:

- #62491 / #62534: CLI model aliases, but limited to the alias-init path and not the provider/model startup route addressed here.
- #87210: provider detection and nested alias parsing, but its detection is not wired into `HermesCLI.__init__`; the interactive reproduction remains uncovered by its tests.

This PR deliberately fixes the missing production integration at the shared startup boundary and adds an integration regression test for `HermesCLI`, instead of copying or competing with a catalog-only implementation.

## Regression coverage

- Configured `nous/deepseek-v4-pro` overrides a stale `anthropic` default during `HermesCLI` initialization.
- Configured `ollama/qwen3.5:4b` keeps the configured provider name.
- Aggregator namespaces are not consumed as provider prefixes.
- Direct aliases preserve their model, provider, and endpoint.
- Dictionary-form `model.aliases` entries load correctly.
- One-shot startup preserves the explicit startup route after legacy fallback detection.

## Validation

Local validation:

```text
5 passed — tests/hermes_cli/test_startup_model_routing_87189.py
1 passed — targeted HermesCLI startup regression
python -m py_compile — passed
 git diff --check — passed
```

The repository wrapper `scripts/run_tests.sh` was unavailable in this environment because the isolated worktree has no `.venv`/`venv` with pytest; focused tests were run with the system Python/pytest and are reported separately.

## Risk

Low and localized:

- No provider credentials or transport implementations changed.
- Explicit `--provider` remains authoritative.
- Unconfigured slash-bearing model IDs are left untouched.
- Aggregator model namespaces are protected from reinterpretation.
