### PR TITLE
fix(mcp): run catalog bootstraps without a shell

### DIFF
--- a/hermes_cli/_subprocess_compat.py
+++ b/hermes_cli/_subprocess_compat.py
@@ -17,6 +17,8 @@ import sys
 from pathlib import Path, PureWindowsPath
 from typing import Mapping, NamedTuple, Sequence
 
+from hermes_constants import find_node_executable
+
 __all__ = [
     "IS_WINDOWS",
     "resolve_node_command",
@@ -414,7 +416,7 @@ def _node_executable(
             removes_interior_js_from_pathext=removes_interior_js_from_pathext,
         )[0]
     else:
-        node = shutil.which("node.exe") or shutil.which("node")
+        node = find_node_executable("node")
     if node is None:
         return None
     if IS_WINDOWS:

--- a/hermes_cli/_subprocess_compat.py
+++ b/hermes_cli/_subprocess_compat.py
@@ -8,12 +8,14 @@
 
 from __future__ import annotations
 
+import json
 import os
 import re
 import shutil
 import subprocess
 import sys
-from typing import Mapping, Sequence
+from pathlib import Path, PureWindowsPath
+from typing import Mapping, NamedTuple, Sequence
 
 __all__ = [
     "IS_WINDOWS",
@@ -102,15 +104,717 @@ def split_command_line(line: str) -> list[str]:
     return out
 
 
-def resolve_node_command(name: str, argv: Sequence[str]) -> list[str]:
-    """Resolve a Node-ecosystem command name (``npm``, ``npx``, ``yarn``…) to an absolute-path argv.
+# -----------------------------------------------------------------------------
+# Node ecosystem launcher resolution
+# -----------------------------------------------------------------------------
 
-    On Windows these ship as ``.cmd`` batch shims that CreateProcessW won't execute by bare name;
-    ``shutil.which`` resolves via PATHEXT to a fully-qualified path whose extension routes it
-    through ``cmd.exe /c``.
+
+_NPM_CMD_SHIM_HEADER = (
+    "@echo off",
+    "goto start",
+    ":find_dp0",
+    "set dp0=%~dp0",
+    "exit /b",
+    ":start",
+    "setlocal",
+    "call :find_dp0",
+)
+_NPM_CMD_SHIM_GENERATED_COMMENT = ":: created by npm, please don't edit manually."
+_NPM_CMD_SHIM_LAUNCH_PREFIXES = (
+    "endlocal & goto #_undefined_# 2>nul || title %comspec% & ",
+    "endlocal & (call) || title %comspec% & ",
+)
+_NPM_CMD_SHIM_TARGET = re.compile(
+    r'^"%_prog%"\s+"(?P<target>%dp0%\\[^"\r\n]+)"\s+%\*$', re.I
+)
+_LEGACY_NODE_CMD_SHIM_LOCAL = re.compile(
+    r'^"%~dp0\\node\.exe"\s+"(?P<target>%~dp0\\[^"\r\n]+)"\s+%\*$',
+    re.I,
+)
+_LEGACY_NODE_CMD_SHIM_PATH = re.compile(
+    r'^node\s+"(?P<target>%~dp0\\[^"\r\n]+)"\s+%\*$',
+    re.I,
+)
+
+
+class _NodeShimTarget(NamedTuple):
+    entrypoint: Path
+    prefer_adjacent_node: bool
+    package_name: str | None = None
+    removes_interior_js_from_pathext: bool = False
+
+
+def _generated_cmd_shim_body(lines: list[str]) -> list[str]:
+    """Remove only npm's known generated preamble and leading blank lines."""
+    index = 0
+    while index < len(lines) and not lines[index].strip():
+        index += 1
+    if (
+        index < len(lines)
+        and lines[index].strip().casefold() == _NPM_CMD_SHIM_GENERATED_COMMENT
+    ):
+        index += 1
+        while index < len(lines) and not lines[index].strip():
+            index += 1
+    return lines[index:]
+
+
+def _modern_npm_cmd_shim_entrypoint(lines: list[str]) -> str | None:
+    """Extract a target from the current npm ``cmd-shim`` Node template."""
+    if tuple(line.casefold() for line in lines[:8]) != _NPM_CMD_SHIM_HEADER:
+        return None
+
+    body = [line.strip() for line in lines[8:] if line.strip()]
+    # Do not skip generated @SET declarations here. Native argv conversion
+    # cannot reproduce their environment without changing this API's contract.
+    index = 0
+    required_prefix = [
+        'if exist "%dp0%\\node.exe" (',
+        'set "_prog=%dp0%\\node.exe"',
+        ") else (",
+        'set "_prog=node"',
+    ]
+    if [line.casefold() for line in body[index : index + 4]] != required_prefix:
+        return None
+
+    index += 4
+    if index < len(body) and body[index].casefold() == (
+        "set pathext=%pathext:;.js;=;%"
+    ):
+        index += 1
+    if index >= len(body) or body[index] != ")":
+        return None
+    index += 1
+    if len(body) != index + 1:
+        return None
+
+    launch = body[index]
+    folded_launch = launch.casefold()
+    launch_prefix = next(
+        (
+            prefix
+            for prefix in _NPM_CMD_SHIM_LAUNCH_PREFIXES
+            if folded_launch.startswith(prefix)
+        ),
+        None,
+    )
+    if launch_prefix is None:
+        return None
+    native_command = launch[len(launch_prefix) :]
+    if native_command.casefold().startswith("set pathext=%pathext:;.js;=;% & "):
+        native_command = native_command[len("set PATHEXT=%PATHEXT:;.JS;=;% & ") :]
+    match = _NPM_CMD_SHIM_TARGET.fullmatch(native_command)
+    return match.group("target") if match else None
+
+
+def _npm_cli_cmd_shim_entrypoint(lines: list[str], command: str) -> str | None:
+    """Recognize npm/npx's exact release launcher and return its CLI file.
+
+    npm CLI ships hand-maintained Windows launchers rather than the generic
+    ``cmd-shim`` template. Match the complete non-blank template shipped from
+    npm 11.12.1 through 12.0.2 so a custom batch file cannot gain native
+    execution merely by declaring the same variables.
     """
-    resolved = shutil.which(name)
-    return [resolved or name, *argv]
+    if command not in {"npm", "npx"}:
+        return None
+    cli = command.upper()
+    cli_file = f"{command}-cli.js"
+    body = [line.strip() for line in lines if line.strip()]
+    expected = [
+        _NPM_CMD_SHIM_GENERATED_COMMENT,
+        "@ECHO OFF",
+        "SETLOCAL",
+        'SET "NODE_EXE=%~dp0\\node.exe"',
+        'IF NOT EXIST "%NODE_EXE%" (',
+        'SET "NODE_EXE=node"',
+        ")",
+        'SET "NPM_PREFIX_JS=%~dp0\\node_modules\\npm\\bin\\npm-prefix.js"',
+        f'SET "{cli}_CLI_JS=%~dp0\\node_modules\\npm\\bin\\{cli_file}"',
+        'FOR /F "delims=" %%F IN (\'CALL "%NODE_EXE%" "%NPM_PREFIX_JS%"\') DO (',
+        f'SET "NPM_PREFIX_{cli}_CLI_JS=%%F\\node_modules\\npm\\bin\\{cli_file}"',
+        ")",
+        f'IF EXIST "%NPM_PREFIX_{cli}_CLI_JS%" (',
+        f'SET "{cli}_CLI_JS=%NPM_PREFIX_{cli}_CLI_JS%"',
+        ")",
+        f'"%NODE_EXE%" "%{cli}_CLI_JS%" %*',
+    ]
+    if [line.casefold() for line in body] != [line.casefold() for line in expected]:
+        return None
+    return cli_file
+
+
+def _yarn_classic_cmd_shim_entrypoint(lines: list[str]) -> str | None:
+    """Extract Yarn Classic 1.22.22's exact direct-node target."""
+    body = [line.strip() for line in lines if line.strip()]
+    if [line.casefold() for line in body] != [
+        "@echo off",
+        'node "%~dp0\\yarn.js" %*',
+    ]:
+        return None
+    return "%~dp0\\yarn.js"
+
+
+def _yarn_classic_delegated_entrypoint(
+    shim_path: Path, lines: list[str]
+) -> str | None:
+    """Resolve Yarn Classic's exact ``yarnpkg.cmd`` one-hop delegation."""
+    body = [line.strip() for line in lines if line.strip()]
+    if [line.casefold() for line in body] != [
+        "@echo off",
+        '"%~dp0\\yarn.cmd" %*',
+    ]:
+        return None
+
+    yarn_shim = shim_path.parent / "yarn.cmd"
+    try:
+        yarn_lines = yarn_shim.read_text(encoding="utf-8-sig").splitlines()
+    except (OSError, UnicodeError):
+        return None
+    return _yarn_classic_cmd_shim_entrypoint(yarn_lines)
+
+
+def _corepack_cmd_shim_entrypoint(lines: list[str]) -> str | None:
+    """Extract a current Corepack ``@zkochan/cmd-shim`` target.
+
+    Corepack 0.34.6 ships this compact direct-node template both within its
+    npm package and in the ``nodewin`` layout copied into Node distributions.
+    No interpreter options or user environment assignments are accepted.
+    Package metadata still has to bind the returned target to the command.
+    """
+    body = [line.strip() for line in lines if line.strip()]
+    if len(body) != 7:
+        return None
+    expected = [
+        "@setlocal",
+        '@if exist "%~dp0\\node.exe" (',
+        None,
+        ") else (",
+        "@set pathext=%pathext:;.js;=;%",
+        None,
+        ")",
+    ]
+    folded = [line.casefold() for line in body]
+    if any(
+        value is not None and folded[index] != value
+        for index, value in enumerate(expected)
+    ):
+        return None
+
+    local_match = _LEGACY_NODE_CMD_SHIM_LOCAL.fullmatch(body[2])
+    path_match = _LEGACY_NODE_CMD_SHIM_PATH.fullmatch(body[5])
+    if not local_match or not path_match:
+        return None
+    local_target = local_match.group("target")
+    path_target = path_match.group("target")
+    return local_target if local_target.casefold() == path_target.casefold() else None
+
+
+def _legacy_node_cmd_shim_entrypoint(lines: list[str]) -> str | None:
+    """Extract a target from npm/Yarn's historical direct-node template."""
+    # A leading NODE_PATH declaration is intentionally not discarded: leaving
+    # the shim unresolved is safer than silently changing its launch semantics.
+    body = [line.strip() for line in lines if line.strip()]
+    folded = [line.casefold() for line in body]
+    if len(body) == 5:
+        structural = [
+            '@if exist "%~dp0\\node.exe" (',
+            None,
+            ") else (",
+            None,
+            ")",
+        ]
+        local_index, path_index = 1, 3
+    elif len(body) == 7:
+        structural = [
+            '@if exist "%~dp0\\node.exe" (',
+            None,
+            ") else (",
+            "@setlocal",
+            "@set pathext=%pathext:;.js;=;%",
+            None,
+            ")",
+        ]
+        local_index, path_index = 1, 5
+    else:
+        return None
+    if any(
+        expected is not None and folded[index] != expected
+        for index, expected in enumerate(structural)
+    ):
+        return None
+
+    local_match = _LEGACY_NODE_CMD_SHIM_LOCAL.fullmatch(body[local_index])
+    path_match = _LEGACY_NODE_CMD_SHIM_PATH.fullmatch(body[path_index])
+    if not local_match or not path_match:
+        return None
+    local_target = local_match.group("target")
+    path_target = path_match.group("target")
+    return local_target if local_target.casefold() == path_target.casefold() else None
+
+
+def _package_bin_entrypoint(
+    package_json: Path, command: str, package_name: str | None = None
+) -> Path | None:
+    """Return a contained, existing package ``bin`` entry for ``command``."""
+    try:
+        package = json.loads(package_json.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return None
+    if not isinstance(package, dict):
+        return None
+    if package_name is not None and str(package.get("name") or "").casefold() != (
+        package_name.casefold()
+    ):
+        return None
+
+    bins = package.get("bin")
+    relative: object = None
+    if isinstance(bins, dict):
+        relative = next(
+            (
+                value
+                for name, value in bins.items()
+                if str(name).casefold() == command
+            ),
+            None,
+        )
+    elif isinstance(bins, str):
+        declared_name = str(package.get("name") or "").rsplit("/", 1)[-1]
+        if declared_name.casefold() == command:
+            relative = bins
+    if not isinstance(relative, str) or not relative:
+        return None
+
+    package_dir = package_json.parent.resolve()
+    entrypoint = (package_dir / relative).resolve()
+    try:
+        entrypoint.relative_to(package_dir)
+    except ValueError:
+        return None
+    return entrypoint if entrypoint.is_file() else None
+
+
+def _node_executable(
+    shim_path: Path,
+    prefer_adjacent: bool,
+    cwd: str | os.PathLike[str] | None = None,
+    *,
+    search_cwd: bool = True,
+    removes_interior_js_from_pathext: bool = False,
+) -> str | None:
+    """Resolve the native Node executable used by a supported launcher."""
+    adjacent_node = shim_path.parent / "node.exe"
+    if prefer_adjacent and adjacent_node.is_file():
+        return str(adjacent_node.resolve())
+    if IS_WINDOWS and cwd is not None:
+        node = _which_windows_command_from_cwd(
+            "node",
+            cwd,
+            search_cwd=search_cwd,
+            removes_interior_js_from_pathext=removes_interior_js_from_pathext,
+        )[0]
+    else:
+        node = shutil.which("node.exe") or shutil.which("node")
+    if node is None:
+        return None
+    if IS_WINDOWS:
+        return node if Path(node).suffix.casefold() in {".com", ".exe"} else None
+    return None if node.casefold().endswith((".cmd", ".bat")) else node
+
+
+def _npm_cli_selected_entrypoint(
+    shim_path: Path,
+    command: str,
+    cli_file: str,
+    cwd: str | os.PathLike[str] | None,
+    *,
+    search_cwd: bool,
+) -> Path | None:
+    """Reproduce npm's prefix probe and preserve the CLI it selects."""
+    local_package = shim_path.parent / "node_modules" / "npm"
+    package_json = local_package / "package.json"
+    local_entrypoint = _package_bin_entrypoint(package_json, command, "npm")
+    expected_local = (local_package / "bin" / cli_file).resolve()
+    if local_entrypoint is None or local_entrypoint != expected_local:
+        return None
+
+    prefix_probe = (local_package / "bin" / "npm-prefix.js").resolve()
+    try:
+        prefix_probe.relative_to(local_package.resolve())
+    except ValueError:
+        return None
+    if not prefix_probe.is_file():
+        return None
+
+    node = _node_executable(
+        shim_path,
+        prefer_adjacent=True,
+        cwd=cwd,
+        search_cwd=search_cwd,
+    )
+    if node is None:
+        return None
+    try:
+        result = subprocess.run(
+            [node, str(prefix_probe)],
+            capture_output=True,
+            check=False,
+            creationflags=windows_hide_flags(),
+            cwd=os.fspath(cwd) if cwd is not None else None,
+            shell=False,
+            text=True,
+            timeout=10,
+        )
+    except (OSError, subprocess.SubprocessError, UnicodeError):
+        return None
+
+    stdout = result.stdout or ""
+    prefixes = [line.strip() for line in stdout.splitlines() if line.strip()]
+    if not prefixes:
+        return local_entrypoint
+    if len(prefixes) != 1:
+        return None
+
+    selected_prefix = Path(prefixes[0])
+    if not selected_prefix.is_absolute():
+        return None
+    selected_entrypoint = (
+        selected_prefix / "node_modules" / "npm" / "bin" / cli_file
+    ).resolve()
+    # npm's batch launcher changes targets only when this exact file exists.
+    return selected_entrypoint if selected_entrypoint.is_file() else local_entrypoint
+
+
+def _npm_cmd_shim_entrypoint(
+    shim_path: Path,
+    cwd: str | os.PathLike[str] | None,
+    *,
+    search_cwd: bool,
+) -> _NodeShimTarget | None:
+    """Return the native target semantics of a supported Node batch shim."""
+    try:
+        lines = shim_path.read_text(encoding="utf-8-sig").splitlines()
+    except (OSError, UnicodeError):
+        return None
+
+    command = shim_path.stem.casefold()
+    npm_cli_file = _npm_cli_cmd_shim_entrypoint(lines, command)
+    if npm_cli_file is not None:
+        selected = _npm_cli_selected_entrypoint(
+            shim_path,
+            command,
+            npm_cli_file,
+            cwd,
+            search_cwd=search_cwd,
+        )
+        if selected is None:
+            return None
+        return _NodeShimTarget(selected, True, "npm")
+
+    if command == "yarn":
+        target = _yarn_classic_cmd_shim_entrypoint(lines)
+        if target is not None:
+            relative_target = target[len("%~dp0\\") :]
+            entrypoint = (
+                shim_path.parent / relative_target.replace("\\", os.sep)
+            ).resolve()
+            return _NodeShimTarget(entrypoint, False, "yarn")
+    elif command == "yarnpkg":
+        target = _yarn_classic_delegated_entrypoint(shim_path, lines)
+        if target is not None:
+            relative_target = target[len("%~dp0\\") :]
+            entrypoint = (
+                shim_path.parent / relative_target.replace("\\", os.sep)
+            ).resolve()
+            return _NodeShimTarget(entrypoint, False, "yarn")
+
+    body = _generated_cmd_shim_body(lines)
+    target = _modern_npm_cmd_shim_entrypoint(body)
+    if target is None:
+        target = _corepack_cmd_shim_entrypoint(body)
+    if target is None:
+        target = _legacy_node_cmd_shim_entrypoint(body)
+    if target is None:
+        return None
+
+    folded_target = target.casefold()
+    prefix = "%dp0%\\" if folded_target.startswith("%dp0%\\") else "%~dp0\\"
+    relative_target = target[len(prefix) :]
+    entrypoint = (shim_path.parent / relative_target.replace("\\", os.sep)).resolve()
+    removes_interior_js_from_pathext = any(
+        "set pathext=%pathext:;.js;=;%" in line.casefold() for line in body
+    )
+    return _NodeShimTarget(
+        entrypoint,
+        True,
+        removes_interior_js_from_pathext=removes_interior_js_from_pathext,
+    )
+
+
+def _node_package_entrypoint(
+    shim: str,
+    cwd: str | os.PathLike[str] | None,
+    *,
+    search_cwd: bool,
+) -> list[str] | None:
+    """Return ``[node.exe, script]`` for an npm-generated Windows shim.
+
+    Batch shims cannot safely receive arbitrary argv: Windows can route them
+    through ``cmd.exe`` even when the caller passes ``shell=False``. npm's
+    shims are only launch adapters for a package ``bin`` entry, so resolve the
+    same package metadata and invoke that JavaScript entrypoint with Node
+    directly. Every subsequent value then remains in the native argv channel.
+    """
+    shim_path = Path(shim)
+    shim_target = _npm_cmd_shim_entrypoint(
+        shim_path,
+        cwd,
+        search_cwd=search_cwd,
+    )
+    if shim_target is None:
+        return None
+    shim_entrypoint = shim_target.entrypoint
+    command = shim_path.stem.casefold()
+    package_roots = [shim_path.parent / "node_modules"]
+    if shim_path.parent.name.casefold() == ".bin":
+        package_roots.insert(0, shim_path.parent.parent)
+
+    package_jsons: list[Path] = []
+    selected_package = shim_entrypoint.parent.parent / "package.json"
+    if selected_package.is_file():
+        package_jsons.append(selected_package)
+    packaged_corepack = shim_path.parent.parent / "package.json"
+    if packaged_corepack.is_file():
+        package_jsons.append(packaged_corepack)
+    for root in package_roots:
+        direct = root / command / "package.json"
+        if direct.is_file():
+            package_jsons.append(direct)
+        if root.is_dir():
+            package_jsons.extend(sorted(root.glob("*/package.json")))
+            package_jsons.extend(sorted(root.glob("@*/*/package.json")))
+
+    seen: set[Path] = set()
+    for package_json in package_jsons:
+        if package_json in seen:
+            continue
+        seen.add(package_json)
+        entrypoint = _package_bin_entrypoint(
+            package_json, command, shim_target.package_name
+        )
+        if entrypoint is None:
+            continue
+        if str(entrypoint).casefold() != str(shim_entrypoint).casefold():
+            continue
+
+        node = _node_executable(
+            shim_path,
+            prefer_adjacent=shim_target.prefer_adjacent_node,
+            cwd=cwd,
+            search_cwd=search_cwd,
+            removes_interior_js_from_pathext=(
+                shim_target.removes_interior_js_from_pathext
+            ),
+        )
+        if node:
+            return [node, str(entrypoint)]
+    return None
+
+
+def _windows_command_candidates(
+    name: str,
+    *,
+    removes_interior_js_from_pathext: bool = False,
+) -> list[str]:
+    """Return *name* candidates in native Windows PATHEXT order."""
+    pathext_source = os.environ.get("PATHEXT") or ".COM;.EXE;.BAT;.CMD"
+    if removes_interior_js_from_pathext:
+        # Corepack's ``%PATHEXT:;.JS;=;%`` is a literal substring
+        # replacement. It does not remove .JS when that token lacks a leading
+        # or trailing semicolon at a PATHEXT boundary.
+        pathext_source = re.sub(r";\.JS;", ";", pathext_source, flags=re.I)
+    pathext = [extension.strip() for extension in pathext_source.split(";")]
+    pathext = [extension for extension in pathext if extension]
+    candidates = [f"{name}{extension}" for extension in pathext]
+    if PureWindowsPath(name).suffix:
+        candidates.insert(0, name)
+    return candidates
+
+
+def _which_windows_explicit_command(
+    name: str,
+    *,
+    allowed_root: str | os.PathLike[str] | None = None,
+) -> str | None:
+    """Apply Python 3.12-style PATHEXT lookup to a path-qualified command."""
+    root = Path(allowed_root).resolve() if allowed_root is not None else None
+    for candidate_name in _windows_command_candidates(name):
+        candidate = Path(candidate_name)
+        if not candidate.is_file():
+            continue
+        if root is None:
+            return os.fspath(candidate)
+        resolved = candidate.resolve()
+        try:
+            resolved.relative_to(root)
+        except ValueError as exc:
+            raise ValueError(
+                "resolved Windows executable is outside its allowed root"
+            ) from exc
+        return os.fspath(resolved)
+    return None
+
+
+def _which_windows_command_from_cwd(
+    name: str,
+    cwd: str | os.PathLike[str],
+    *,
+    search_cwd: bool = True,
+    removes_interior_js_from_pathext: bool = False,
+) -> tuple[str | None, str]:
+    """Resolve a bare Windows command as though *cwd* were already active.
+
+    ``shutil.which`` may implicitly search the parent process's current
+    directory on Windows, even when a different child ``cwd`` will be passed
+    to ``subprocess``. Probe the intended child directory and each PATH entry
+    through an explicit path instead, retaining PATHEXT handling without
+    exposing Hermes's unrelated launch directory. Windows suppresses the
+    initial child-directory probe when ``NoDefaultCurrentDirectoryInExePath``
+    is present or ``search_cwd`` is false. Relative PATH entries remain
+    interpreted against the intended child directory; empty entries retain
+    that meaning only while current-directory search is enabled.
+
+    The second return value is an explicit, non-searching fallback. Passing it
+    to ``CreateProcessW`` fails closed when no candidate exists instead of
+    giving the operating system another chance to search the parent cwd.
+    """
+    child_cwd = Path(cwd).resolve()
+    searches_current_directory = search_cwd and (
+        "NoDefaultCurrentDirectoryInExePath" not in os.environ
+    )
+    search_dirs = [child_cwd] if searches_current_directory else []
+    for entry in os.get_exec_path():
+        if not entry and not searches_current_directory:
+            continue
+        directory = Path(entry) if entry else child_cwd
+        if not directory.is_absolute():
+            directory = child_cwd / directory
+        search_dirs.append(directory)
+
+    candidates = _windows_command_candidates(
+        name,
+        removes_interior_js_from_pathext=removes_interior_js_from_pathext,
+    )
+
+    seen: set[str] = set()
+    # Reuse the first directory that this helper will explicitly probe. This
+    # leaves CreateProcessW an absolute, non-searching miss without pointing it
+    # back at the repository when native cwd search is disabled. os.get_exec_path
+    # normally supplies at least one entry; retain an invalid Win32 component as
+    # the fail-closed boundary for a mocked or otherwise empty search path.
+    fallback_directory = search_dirs[0] if search_dirs else child_cwd / "<PATH>"
+    fallback = os.fspath(fallback_directory / name)
+    for directory in search_dirs:
+        key = os.path.normcase(os.path.abspath(os.fspath(directory))).casefold()
+        if key in seen:
+            continue
+        seen.add(key)
+        for candidate_name in candidates:
+            candidate = directory / candidate_name
+            if candidate.is_file():
+                return os.fspath(candidate), fallback
+    return None, fallback
+
+
+def resolve_node_command(
+    name: str,
+    argv: Sequence[str],
+    *,
+    cwd: str | os.PathLike[str] | None = None,
+    search_cwd: bool = True,
+    allowed_root: str | os.PathLike[str] | None = None,
+) -> list[str]:
+    """Resolve a Node-ecosystem command name to an absolute-path argv.
+
+    On Windows, commands like ``npm``, ``npx``, ``yarn``, ``pnpm``,
+    ``playwright``, ``prettier`` ship as ``.cmd`` files (batch shims).
+    ``subprocess.Popen(["npm", "install"])`` fails with WinError 193
+    because CreateProcessW doesn't execute batch files directly.
+
+    ``shutil.which`` *does* resolve ``.cmd`` via PATHEXT. When a Windows
+    ``cwd`` is supplied, bare commands reproduce cmd.exe's child-directory
+    search unless ``NoDefaultCurrentDirectoryInExePath`` opts out, then search
+    PATH without consulting Hermes's parent-process cwd. npm-generated batch
+    shims are resolved further to their package ``bin`` JavaScript entrypoint
+    and invoked with ``node.exe``. That avoids the implicit ``cmd.exe`` path,
+    where metacharacters in otherwise legitimate arguments can be
+    reinterpreted as shell syntax.
+
+    On POSIX ``shutil.which`` also returns a fully-qualified path when
+    found.  That's a small change from bare-name resolution (the OS does
+    its own PATH search) but functionally identical and has the side
+    benefit of making the argv reproducible in logs.
+
+    Behavior when the command is not on PATH:
+    - On Windows with ``cwd``: return an explicit path in the first searched
+      directory so a subsequent CreateProcessW call fails closed without
+      searching the parent-process directory.
+    - On Windows without ``cwd``: return the bare name — caller can still try
+      with ``shell=True`` as a last resort, OR the subsequent Popen will raise
+      FileNotFoundError with a readable error we want to surface.
+    - On POSIX: same.  Bare ``npm`` on a Linux box without npm installed
+      fails the same way it did before this function existed.
+
+    Args:
+        name: The command name to resolve (``npm``, ``npx``, ``node`` …).
+        argv: The remaining arguments.  Must NOT include ``name`` itself —
+            this function builds the full argv list.
+        cwd: The child working directory that governs bare executable search
+            and npm/npx prefix selection. Defaults to the current process
+            directory and ordinary ``shutil.which`` behavior.
+        search_cwd: Whether bare Windows commands may resolve from ``cwd``
+            before PATH. Defaults to native Windows search semantics.
+        allowed_root: Optional containment root for a path-qualified Windows
+            executable. The selected PATHEXT candidate must resolve within it.
+
+    Returns:
+        A list suitable for passing to subprocess.Popen/run/call.
+    """
+    fallback = name
+    windows_name = PureWindowsPath(name)
+    is_bare_windows_name = (
+        IS_WINDOWS
+        and cwd is not None
+        and "/" not in name
+        and "\\" not in name
+        and not windows_name.drive
+    )
+    if is_bare_windows_name:
+        resolved, fallback = _which_windows_command_from_cwd(
+            name,
+            cwd,
+            search_cwd=search_cwd,
+        )
+    elif IS_WINDOWS and (
+        "/" in name or "\\" in name or bool(windows_name.drive)
+    ):
+        resolved = _which_windows_explicit_command(
+            name,
+            allowed_root=allowed_root,
+        )
+    else:
+        resolved = shutil.which(name)
+    if resolved:
+        if IS_WINDOWS and resolved.lower().endswith((".cmd", ".bat")):
+            native = _node_package_entrypoint(
+                resolved,
+                cwd,
+                search_cwd=search_cwd,
+            )
+            if native:
+                return [*native, *argv]
+        return [resolved, *argv]
+    return [fallback, *argv]
 
 
 # Win32 CreationFlags — defined here because CREATE_NO_WINDOW / DETACHED_PROCESS aren't guaranteed
@@ -563,4 +1267,3 @@ def bounded_git_probe(argv: Sequence[str], *, timeout: float) -> str:
     if result is None or result.returncode != 0:
         return ""
     return (result.stdout or "").strip()
-

--- a/hermes_cli/mcp_catalog.py
+++ b/hermes_cli/mcp_catalog.py
@@ -6,17 +6,23 @@ approval (no community tier, no other trust signals). Manifests pin transport de
 
 from __future__ import annotations
 
+import ntpath
 import re
+import shlex
 import shutil
 import subprocess
 from dataclasses import dataclass, field
-from pathlib import Path
+from pathlib import Path, PureWindowsPath
 from typing import Any, Dict, List, Optional
 
 import yaml
 
 from hermes_constants import get_hermes_home, get_optional_mcps_dir
-from hermes_cli._subprocess_compat import noninteractive_git_env
+from hermes_cli._subprocess_compat import (
+    IS_WINDOWS,
+    noninteractive_git_env,
+    resolve_node_command,
+)
 from hermes_cli.colors import Colors, color
 from hermes_cli.config import load_config, save_config, get_env_value, save_env_value
 from hermes_cli.cli_output import prompt as _prompt_input
@@ -351,13 +357,189 @@ def _install_root() -> Path:
     return root
 
 
+def _split_windows_commandline(command: str) -> List[str]:
+    """Split a native Windows command line without applying POSIX escapes.
+
+    This follows the Microsoft C runtime backslash-and-double-quote rules used
+    by Python's Windows subprocess serialization. Ordinary path backslashes
+    remain literal; a backslash only escapes a quote immediately after it, and
+    paired quotes inside quoted text produce one literal quote.
+    """
+    argv: List[str] = []
+    index = 0
+    length = len(command)
+    while index < length:
+        while index < length and command[index] in " \t":
+            index += 1
+        if index == length:
+            break
+
+        value: List[str] = []
+        quoted = False
+        while index < length:
+            char = command[index]
+            if char in " \t" and not quoted:
+                break
+            if char == "\\":
+                start = index
+                while index < length and command[index] == "\\":
+                    index += 1
+                backslashes = index - start
+                if index < length and command[index] == '"':
+                    value.extend("\\" * (backslashes // 2))
+                    if backslashes % 2:
+                        value.append('"')
+                        index += 1
+                    elif (
+                        quoted
+                        and index + 1 < length
+                        and command[index + 1] == '"'
+                    ):
+                        value.append('"')
+                        index += 2
+                    else:
+                        quoted = not quoted
+                        index += 1
+                else:
+                    value.extend("\\" * backslashes)
+                continue
+            if char == '"':
+                if quoted and index + 1 < length and command[index + 1] == '"':
+                    value.append('"')
+                    index += 2
+                else:
+                    quoted = not quoted
+                    index += 1
+                continue
+            value.append(char)
+            index += 1
+
+        if quoted:
+            raise ValueError("unbalanced quotation in command line")
+        argv.append("".join(value))
+        while index < length and command[index] in " \t":
+            index += 1
+    return argv
+
+
+def _split_bootstrap_command(command: str) -> List[str]:
+    if IS_WINDOWS:
+        return _split_windows_commandline(command)
+    return shlex.split(command)
+
+
 def _run_bootstrap(cwd: Path, commands: List[str]) -> None:
-    """Execute bootstrap commands in *cwd*. Raise CatalogError on first failure."""
+    """Execute bootstrap commands in *cwd*. Raise CatalogError on first failure.
+
+    Commands use native Windows command-line quoting on Windows and ``shlex``
+    quoting on POSIX, then run as argv without a shell. Shell operators are
+    therefore literal arguments, not executable syntax; catalog entries that
+    need multiple steps must declare separate commands. Output is streamed to
+    the user's terminal for visibility.
+    """
     for cmd in commands:
-        _say(f"  $ {cmd}", Colors.DIM)
-        rc = subprocess.run(cmd, cwd=str(cwd), shell=True).returncode
-        if rc != 0:
-            raise CatalogError(f"bootstrap step failed (exit {rc}): {cmd}")
+        print(color(f"  $ {cmd}", Colors.DIM))
+        try:
+            argv = _split_bootstrap_command(cmd)
+        except ValueError as exc:
+            raise CatalogError(f"malformed bootstrap command: {cmd!r}") from exc
+        if not argv or not argv[0].strip():
+            raise CatalogError("bootstrap command is empty")
+        if IS_WINDOWS:
+            allowed_root = None
+            executable = PureWindowsPath(argv[0])
+            bootstrap_windows = PureWindowsPath(
+                ntpath.normpath(str(PureWindowsPath(cwd)))
+            )
+            if (
+                executable.drive
+                and not executable.root
+                and executable.drive.casefold() != bootstrap_windows.drive.casefold()
+            ):
+                raise CatalogError(
+                    "drive-relative bootstrap executable uses a different drive "
+                    f"from the bootstrap directory: {argv[0]}"
+                )
+            if (
+                executable.drive
+                and not executable.root
+                and executable.drive.casefold() == bootstrap_windows.drive.casefold()
+            ):
+                child_windows = PureWindowsPath(
+                    ntpath.normpath(str(bootstrap_windows.joinpath(executable)))
+                )
+                try:
+                    child_windows.relative_to(bootstrap_windows)
+                except ValueError as exc:
+                    raise CatalogError(
+                        "relative bootstrap executable resolves outside "
+                        f"bootstrap directory: {argv[0]}"
+                    ) from exc
+                if isinstance(cwd, Path):
+                    bootstrap_dir = cwd.resolve()
+                    child_executable = Path(child_windows).resolve()
+                    try:
+                        child_executable.relative_to(bootstrap_dir)
+                    except ValueError as exc:
+                        raise CatalogError(
+                            "relative bootstrap executable resolves outside "
+                            f"bootstrap directory: {argv[0]}"
+                        ) from exc
+                    argv[0] = str(child_executable)
+                    allowed_root = bootstrap_dir
+                else:
+                    argv[0] = str(child_windows)
+            elif not executable.anchor and ("/" in argv[0] or "\\" in argv[0]):
+                bootstrap_dir = cwd.resolve()
+                child_executable = cwd.joinpath(*executable.parts).resolve()
+                try:
+                    child_executable.relative_to(bootstrap_dir)
+                except ValueError as exc:
+                    raise CatalogError(
+                        "relative bootstrap executable resolves outside "
+                        f"bootstrap directory: {argv[0]}"
+                    ) from exc
+                argv[0] = str(child_executable)
+                allowed_root = bootstrap_dir
+            elif executable.anchor and not executable.is_absolute():
+                child_executable = PureWindowsPath(cwd).joinpath(executable)
+                if child_executable.is_absolute():
+                    argv[0] = str(child_executable)
+            resolve_kwargs: Dict[str, Any] = {"cwd": cwd, "search_cwd": False}
+            if allowed_root is not None:
+                resolve_kwargs["allowed_root"] = allowed_root
+            try:
+                argv = resolve_node_command(
+                    argv[0],
+                    argv[1:],
+                    **resolve_kwargs,
+                )
+            except ValueError as exc:
+                raise CatalogError(
+                    "relative bootstrap executable resolves outside "
+                    f"bootstrap directory: {argv[0]}"
+                ) from exc
+            if argv[0].lower().endswith((".cmd", ".bat")):
+                # Unresolved batch files still cross an implicit cmd.exe
+                # boundary. Node shims are converted to native node argv by
+                # resolve_node_command; reject every other batch launcher.
+                raise CatalogError(
+                    "bootstrap command resolves to a Windows batch launcher; "
+                    "use a native executable or Node package entrypoint"
+                )
+        try:
+            proc = subprocess.run(
+                argv,
+                cwd=str(cwd),
+                shell=False,
+                stdin=subprocess.DEVNULL,
+            )
+        except (OSError, ValueError) as exc:
+            raise CatalogError(f"bootstrap step failed to start: {cmd}") from exc
+        if proc.returncode != 0:
+            raise CatalogError(
+                f"bootstrap step failed (exit {proc.returncode}): {cmd}"
+            )
 
 
 def _do_git_install(entry: CatalogEntry) -> Path:

--- a/tests/hermes_cli/test_mcp_catalog.py
+++ b/tests/hermes_cli/test_mcp_catalog.py
@@ -7,8 +7,13 @@ launch an MCP is mocked.
 
 from __future__ import annotations
 
+import os
 import re
-from pathlib import Path
+import shlex
+import subprocess
+import sys
+from pathlib import Path, PureWindowsPath
+from typing import cast
 from unittest.mock import patch
 
 import pytest
@@ -899,3 +904,722 @@ class TestShippedCatalog:
                     )
 
         assert not problems, "unpinned catalog entries:\n" + "\n".join(problems)
+
+
+# ---------------------------------------------------------------------------
+# Bootstrap execution
+# ---------------------------------------------------------------------------
+
+
+class TestRunBootstrap:
+    def test_shell_metacharacters_are_literal_arguments(self, tmp_path):
+        """A bootstrap command cannot use shell redirection as a second command."""
+        from hermes_cli.mcp_catalog import _run_bootstrap
+
+        marker = tmp_path / "shell-redirection-ran"
+        python_argv = [sys.executable, "-c", "print('bootstrap')"]
+        command = (
+            subprocess.list2cmdline(python_argv)
+            if os.name == "nt"
+            else shlex.join(python_argv)
+        )
+
+        _run_bootstrap(tmp_path, [f'{command} > "{marker}"'])
+
+        assert not marker.exists()
+
+    def test_runs_each_command_as_argv_without_a_shell(self, tmp_path, monkeypatch):
+        import hermes_cli.mcp_catalog as mc
+
+        calls = []
+
+        def fake_run(argv, **kwargs):
+            calls.append((argv, kwargs))
+            return subprocess.CompletedProcess(argv, 0)
+
+        monkeypatch.setattr(mc, "IS_WINDOWS", False)
+        monkeypatch.setattr(mc.subprocess, "run", fake_run)
+
+        mc._run_bootstrap(tmp_path, ['python -m pip install "demo package"'])
+
+        assert calls == [
+            (
+                ["python", "-m", "pip", "install", "demo package"],
+                {
+                    "cwd": str(tmp_path),
+                    "shell": False,
+                    "stdin": subprocess.DEVNULL,
+                },
+            )
+        ]
+
+    def test_posix_relative_executable_keeps_child_cwd_resolution(
+        self, tmp_path, monkeypatch
+    ):
+        import hermes_cli.mcp_catalog as mc
+
+        calls = []
+        monkeypatch.setattr(mc, "IS_WINDOWS", False)
+        monkeypatch.setattr(
+            mc.subprocess,
+            "run",
+            lambda argv, **kwargs: (
+                calls.append((argv, kwargs)) or subprocess.CompletedProcess(argv, 0)
+            ),
+        )
+
+        mc._run_bootstrap(tmp_path, [".venv/bin/pip install demo"])
+
+        assert calls == [
+            (
+                [".venv/bin/pip", "install", "demo"],
+                {
+                    "cwd": str(tmp_path),
+                    "shell": False,
+                    "stdin": subprocess.DEVNULL,
+                },
+            )
+        ]
+
+    @pytest.mark.parametrize(
+        "argv",
+        [
+            [r"C:\work\python.exe", r"C:\work\demo.py"],
+            [
+                r"C:\Program Files\Python\python.exe",
+                r"C:\work\demo.py",
+                'say "hello"',
+                "trailing\\",
+            ],
+        ],
+    )
+    def test_windows_commandline_round_trips_native_quoting(self, argv):
+        from hermes_cli.mcp_catalog import _split_windows_commandline
+
+        assert _split_windows_commandline(subprocess.list2cmdline(argv)) == argv
+
+    @pytest.mark.parametrize(
+        ("command", "expected"),
+        [
+            ('tool.exe "say ""hello"""', ["tool.exe", 'say "hello"']),
+            (
+                r'tool.exe "prefix\\""suffix"',
+                ["tool.exe", 'prefix\\"suffix'],
+            ),
+        ],
+    )
+    def test_windows_commandline_preserves_crt_paired_quotes(
+        self, command, expected
+    ):
+        from hermes_cli.mcp_catalog import _split_windows_commandline
+
+        assert _split_windows_commandline(command) == expected
+
+    def test_windows_bootstrap_preserves_crt_paired_quotes(
+        self, tmp_path, monkeypatch
+    ):
+        import hermes_cli.mcp_catalog as mc
+
+        calls = []
+        monkeypatch.setattr(mc, "IS_WINDOWS", True)
+        monkeypatch.setattr(
+            mc,
+            "resolve_node_command",
+            lambda name, args, *, cwd, search_cwd: [name, *args],
+        )
+        monkeypatch.setattr(
+            mc.subprocess,
+            "run",
+            lambda argv, **kwargs: (
+                calls.append((argv, kwargs)) or subprocess.CompletedProcess(argv, 0)
+            ),
+        )
+
+        mc._run_bootstrap(tmp_path, ['tool.exe "say ""hello"""'])
+
+        assert calls == [
+            (
+                ["tool.exe", 'say "hello"'],
+                {
+                    "cwd": str(tmp_path),
+                    "shell": False,
+                    "stdin": subprocess.DEVNULL,
+                },
+            )
+        ]
+
+    def test_shipped_bootstrap_commands_keep_ordinary_argv_shape(self, monkeypatch):
+        import hermes_cli.mcp_catalog as mc
+
+        monkeypatch.setattr(mc, "IS_WINDOWS", False)
+
+        assert mc._split_bootstrap_command("python3 -m venv .venv") == [
+            "python3",
+            "-m",
+            "venv",
+            ".venv",
+        ]
+        assert mc._split_bootstrap_command(
+            ".venv/bin/pip install -r requirements.txt"
+        ) == [".venv/bin/pip", "install", "-r", "requirements.txt"]
+
+    def test_malformed_command_raises_catalog_error(self, tmp_path, monkeypatch):
+        import hermes_cli.mcp_catalog as mc
+
+        monkeypatch.setattr(mc, "IS_WINDOWS", False)
+
+        with pytest.raises(mc.CatalogError, match="malformed bootstrap command"):
+            mc._run_bootstrap(tmp_path, ['python -c "unterminated'])
+
+    def test_windows_malformed_command_raises_catalog_error(
+        self, tmp_path, monkeypatch
+    ):
+        import hermes_cli.mcp_catalog as mc
+
+        monkeypatch.setattr(mc, "IS_WINDOWS", True)
+
+        with pytest.raises(mc.CatalogError, match="malformed bootstrap command"):
+            mc._run_bootstrap(tmp_path, ['python -c "unterminated'])
+
+    @pytest.mark.parametrize("command", ["", '""', '"   "'])
+    def test_empty_executable_raises_catalog_error(
+        self, tmp_path, monkeypatch, command
+    ):
+        import hermes_cli.mcp_catalog as mc
+
+        monkeypatch.setattr(
+            mc.subprocess,
+            "run",
+            lambda *args, **kwargs: pytest.fail("empty executable was launched"),
+        )
+
+        with pytest.raises(mc.CatalogError, match="bootstrap command is empty"):
+            mc._run_bootstrap(tmp_path, [command])
+
+    def test_empty_non_executable_argument_is_preserved(self, tmp_path, monkeypatch):
+        import hermes_cli.mcp_catalog as mc
+
+        calls = []
+        monkeypatch.setattr(mc, "IS_WINDOWS", False)
+        monkeypatch.setattr(
+            mc.subprocess,
+            "run",
+            lambda argv, **kwargs: (
+                calls.append((argv, kwargs)) or subprocess.CompletedProcess(argv, 0)
+            ),
+        )
+
+        mc._run_bootstrap(tmp_path, ['python ""'])
+
+        assert calls == [
+            (
+                ["python", ""],
+                {
+                    "cwd": str(tmp_path),
+                    "shell": False,
+                    "stdin": subprocess.DEVNULL,
+                },
+            )
+        ]
+
+    def test_start_failure_raises_catalog_error(self, tmp_path, monkeypatch):
+        import hermes_cli.mcp_catalog as mc
+
+        monkeypatch.setattr(mc, "IS_WINDOWS", False)
+
+        def fail_to_start(*args, **kwargs):
+            raise FileNotFoundError("missing executable")
+
+        monkeypatch.setattr(mc.subprocess, "run", fail_to_start)
+
+        with pytest.raises(mc.CatalogError, match="bootstrap step failed to start"):
+            mc._run_bootstrap(tmp_path, ["missing-command --version"])
+
+    def test_invalid_process_argv_raises_catalog_error(self, tmp_path, monkeypatch):
+        import hermes_cli.mcp_catalog as mc
+
+        monkeypatch.setattr(mc, "IS_WINDOWS", False)
+
+        def reject_argv(*args, **kwargs):
+            raise ValueError("embedded null byte")
+
+        monkeypatch.setattr(mc.subprocess, "run", reject_argv)
+
+        with pytest.raises(mc.CatalogError, match="bootstrap step failed to start"):
+            mc._run_bootstrap(tmp_path, ["invalid-command --version"])
+
+    def test_nonzero_exit_names_original_command(self, tmp_path, monkeypatch):
+        import hermes_cli.mcp_catalog as mc
+
+        monkeypatch.setattr(mc, "IS_WINDOWS", False)
+        monkeypatch.setattr(
+            mc.subprocess,
+            "run",
+            lambda argv, **kwargs: subprocess.CompletedProcess(argv, 7),
+        )
+
+        with pytest.raises(mc.CatalogError, match=r"exit 7.*python -m pip"):
+            mc._run_bootstrap(tmp_path, ["python -m pip"])
+
+    def test_windows_resolves_node_launcher_without_a_shell(
+        self, tmp_path, monkeypatch
+    ):
+        import hermes_cli.mcp_catalog as mc
+
+        calls = []
+        resolve_calls = []
+        monkeypatch.setattr(mc, "IS_WINDOWS", True)
+        monkeypatch.setattr(
+            mc,
+            "resolve_node_command",
+            lambda name, args, *, cwd, search_cwd: resolve_calls.append(
+                (name, args, cwd, search_cwd)
+            )
+            or [
+                r"C:\Program Files\nodejs\node.exe",
+                r"C:\Program Files\nodejs\node_modules\npm\bin\npm-cli.js",
+                *args,
+            ],
+        )
+        monkeypatch.setattr(
+            mc.subprocess,
+            "run",
+            lambda argv, **kwargs: (
+                calls.append((argv, kwargs)) or subprocess.CompletedProcess(argv, 0)
+            ),
+        )
+
+        mc._run_bootstrap(
+            tmp_path,
+            [r'npm install pkg@^1.2.3 "100% (stable)!" & echo'],
+        )
+
+        assert resolve_calls == [
+            (
+                "npm",
+                ["install", "pkg@^1.2.3", "100% (stable)!", "&", "echo"],
+                tmp_path,
+                False,
+            )
+        ]
+        assert calls == [
+            (
+                [
+                    r"C:\Program Files\nodejs\node.exe",
+                    r"C:\Program Files\nodejs\node_modules\npm\bin\npm-cli.js",
+                    "install",
+                    "pkg@^1.2.3",
+                    "100% (stable)!",
+                    "&",
+                    "echo",
+                ],
+                {
+                    "cwd": str(tmp_path),
+                    "shell": False,
+                    "stdin": subprocess.DEVNULL,
+                },
+            )
+        ]
+
+    @pytest.mark.parametrize(
+        "executable",
+        [r".venv\Scripts\pip.exe", ".venv/Scripts/pip.exe"],
+    )
+    def test_windows_resolves_relative_executable_against_bootstrap_cwd(
+        self, tmp_path, monkeypatch, executable
+    ):
+        import hermes_cli.mcp_catalog as mc
+
+        resolve_calls = []
+        run_calls = []
+        expected_executable = str(
+            (tmp_path / ".venv" / "Scripts" / "pip.exe").resolve()
+        )
+
+        monkeypatch.setattr(mc, "IS_WINDOWS", True)
+        monkeypatch.setattr(
+            mc,
+            "resolve_node_command",
+            lambda name, args, *, cwd, search_cwd, allowed_root: resolve_calls.append(
+                (name, args, cwd, search_cwd, allowed_root)
+            )
+            or [name, *args],
+        )
+        monkeypatch.setattr(
+            mc.subprocess,
+            "run",
+            lambda argv, **kwargs: (
+                run_calls.append((argv, kwargs)) or subprocess.CompletedProcess(argv, 0)
+            ),
+        )
+
+        mc._run_bootstrap(
+            tmp_path,
+            [f"{executable} install -r requirements.txt"],
+        )
+
+        expected_argv = [
+            expected_executable,
+            "install",
+            "-r",
+            "requirements.txt",
+        ]
+        assert resolve_calls == [
+            (expected_executable, expected_argv[1:], tmp_path, False, tmp_path.resolve())
+        ]
+        assert run_calls == [
+            (
+                expected_argv,
+                {
+                    "cwd": str(tmp_path),
+                    "shell": False,
+                    "stdin": subprocess.DEVNULL,
+                },
+            )
+        ]
+
+    def test_windows_resolves_extensionless_relative_executable_with_pathext(
+        self, tmp_path, monkeypatch
+    ):
+        """Path-qualified commands retain cmd.exe's PATHEXT selection."""
+        import hermes_cli.mcp_catalog as mc
+        from hermes_cli import _subprocess_compat as sc
+
+        bin_dir = tmp_path / "bin"
+        bin_dir.mkdir()
+        executable_com = bin_dir / "tool.COM"
+        executable_exe = bin_dir / "tool.EXE"
+        executable_com.touch()
+        executable_exe.touch()
+        run_calls = []
+
+        monkeypatch.setenv("PATHEXT", ".COM;.EXE;.BAT;.CMD")
+        monkeypatch.setattr(mc, "IS_WINDOWS", True)
+        monkeypatch.setattr(sc, "IS_WINDOWS", True)
+        monkeypatch.setattr(
+            mc.subprocess,
+            "run",
+            lambda argv, **kwargs: (
+                run_calls.append((argv, kwargs)) or subprocess.CompletedProcess(argv, 0)
+            ),
+        )
+
+        mc._run_bootstrap(tmp_path, [r"bin\tool --version"])
+
+        assert run_calls == [
+            (
+                [str(executable_com.resolve()), "--version"],
+                {
+                    "cwd": str(tmp_path),
+                    "shell": False,
+                    "stdin": subprocess.DEVNULL,
+                },
+            )
+        ]
+
+    @pytest.mark.parametrize(
+        "executable",
+        [
+            r"..\outside.exe",
+            "../outside.exe",
+            r".venv\Scripts\..\..\..\outside.exe",
+            ".venv/Scripts/../../../outside.exe",
+        ],
+    )
+    def test_windows_rejects_relative_executable_escaping_bootstrap_cwd(
+        self, tmp_path, monkeypatch, executable
+    ):
+        import hermes_cli.mcp_catalog as mc
+
+        monkeypatch.setattr(mc, "IS_WINDOWS", True)
+        monkeypatch.setattr(
+            mc,
+            "resolve_node_command",
+            lambda *args, **kwargs: pytest.fail("escaping executable was resolved"),
+        )
+        monkeypatch.setattr(
+            mc.subprocess,
+            "run",
+            lambda *args, **kwargs: pytest.fail("escaping executable was launched"),
+        )
+
+        with pytest.raises(mc.CatalogError, match="outside bootstrap directory"):
+            mc._run_bootstrap(tmp_path, [f"{executable} --version"])
+
+    def test_windows_rejects_relative_executable_symlink_escape(
+        self, tmp_path, monkeypatch
+    ):
+        import hermes_cli.mcp_catalog as mc
+
+        outside = tmp_path.parent / f"{tmp_path.name}-outside"
+        outside.mkdir()
+        try:
+            (tmp_path / "bin").symlink_to(outside, target_is_directory=True)
+        except (NotImplementedError, OSError) as exc:
+            pytest.skip(f"symlink creation unavailable: {exc}")
+
+        monkeypatch.setattr(mc, "IS_WINDOWS", True)
+        monkeypatch.setattr(
+            mc,
+            "resolve_node_command",
+            lambda *args, **kwargs: pytest.fail("escaping executable was resolved"),
+        )
+        monkeypatch.setattr(
+            mc.subprocess,
+            "run",
+            lambda *args, **kwargs: pytest.fail("escaping executable was launched"),
+        )
+
+        with pytest.raises(mc.CatalogError, match="outside bootstrap directory"):
+            mc._run_bootstrap(tmp_path, [r"bin\tool.exe --version"])
+
+    def test_windows_rejects_pathext_candidate_symlink_escape(
+        self, tmp_path, monkeypatch
+    ):
+        import hermes_cli.mcp_catalog as mc
+        from hermes_cli import _subprocess_compat as sc
+
+        bin_dir = tmp_path / "bin"
+        bin_dir.mkdir()
+        outside = tmp_path.parent / f"{tmp_path.name}-outside.EXE"
+        outside.touch()
+        try:
+            (bin_dir / "tool.EXE").symlink_to(outside)
+        except (NotImplementedError, OSError) as exc:
+            pytest.skip(f"symlink creation unavailable: {exc}")
+
+        monkeypatch.setenv("PATHEXT", ".EXE")
+        monkeypatch.setattr(mc, "IS_WINDOWS", True)
+        monkeypatch.setattr(sc, "IS_WINDOWS", True)
+        monkeypatch.setattr(
+            mc.subprocess,
+            "run",
+            lambda *args, **kwargs: pytest.fail("escaping executable was launched"),
+        )
+
+        with pytest.raises(mc.CatalogError, match="outside bootstrap directory"):
+            mc._run_bootstrap(tmp_path, [r"bin\tool --version"])
+
+    @pytest.mark.parametrize(
+        ("executable", "expected"),
+        [
+            (r"\tools\tool.exe", r"D:\tools\tool.exe"),
+            (r"D:tools\tool.exe", r"D:\bootstrap\repo\tools\tool.exe"),
+        ],
+    )
+    def test_windows_resolves_drive_relative_executable_against_bootstrap_cwd(
+        self, monkeypatch, executable, expected
+    ):
+        """Root/same-drive paths inherit the bootstrap child's drive context."""
+        import hermes_cli.mcp_catalog as mc
+
+        bootstrap_cwd = cast(Path, PureWindowsPath(r"D:\bootstrap\repo"))
+        resolve_calls = []
+        run_calls = []
+
+        monkeypatch.setenv("NoDefaultCurrentDirectoryInExePath", "1")
+        monkeypatch.setattr(mc, "IS_WINDOWS", True)
+        monkeypatch.setattr(
+            mc,
+            "resolve_node_command",
+            lambda name, args, *, cwd, search_cwd: resolve_calls.append(
+                (name, args, cwd, search_cwd)
+            )
+            or [name, *args],
+        )
+        monkeypatch.setattr(
+            mc.subprocess,
+            "run",
+            lambda argv, **kwargs: (
+                run_calls.append((argv, kwargs)) or subprocess.CompletedProcess(argv, 0)
+            ),
+        )
+
+        mc._run_bootstrap(bootstrap_cwd, [f"{executable} --version"])
+
+        assert resolve_calls == [(expected, ["--version"], bootstrap_cwd, False)]
+        assert run_calls == [
+            (
+                [expected, "--version"],
+                {
+                    "cwd": str(bootstrap_cwd),
+                    "shell": False,
+                    "stdin": subprocess.DEVNULL,
+                },
+            )
+        ]
+
+    def test_windows_rejects_drive_relative_executable_escaping_bootstrap_cwd(
+        self, monkeypatch
+    ):
+        import hermes_cli.mcp_catalog as mc
+
+        bootstrap_cwd = cast(Path, PureWindowsPath(r"D:\bootstrap\repo"))
+        monkeypatch.setattr(mc, "IS_WINDOWS", True)
+        monkeypatch.setattr(
+            mc,
+            "resolve_node_command",
+            lambda *args, **kwargs: pytest.fail("escaping executable was resolved"),
+        )
+        monkeypatch.setattr(
+            mc.subprocess,
+            "run",
+            lambda *args, **kwargs: pytest.fail("escaping executable was launched"),
+        )
+
+        with pytest.raises(mc.CatalogError, match="outside bootstrap directory"):
+            mc._run_bootstrap(
+                bootstrap_cwd,
+                [r"D:..\..\outside.exe --version"],
+            )
+
+    def test_windows_rejects_drive_relative_executable_on_different_drive(
+        self, monkeypatch
+    ):
+        import hermes_cli.mcp_catalog as mc
+
+        bootstrap_cwd = cast(Path, PureWindowsPath(r"D:\bootstrap\repo"))
+        monkeypatch.setattr(mc, "IS_WINDOWS", True)
+        monkeypatch.setattr(
+            mc,
+            "resolve_node_command",
+            lambda *args, **kwargs: pytest.fail(
+                "different-drive relative executable was resolved"
+            ),
+        )
+        monkeypatch.setattr(
+            mc.subprocess,
+            "run",
+            lambda *args, **kwargs: pytest.fail(
+                "different-drive relative executable was launched"
+            ),
+        )
+
+        with pytest.raises(mc.CatalogError, match="different drive"):
+            mc._run_bootstrap(
+                bootstrap_cwd,
+                [r"C:tools\tool.exe --version"],
+            )
+
+    @pytest.mark.parametrize(
+        "executable",
+        [r"D:\tools\tool.exe", r"\\server\share\tools\tool.exe"],
+    )
+    def test_windows_preserves_fully_qualified_executable(
+        self, monkeypatch, executable
+    ):
+        """Drive-absolute and UNC executable spellings are cwd-independent."""
+        import hermes_cli.mcp_catalog as mc
+
+        bootstrap_cwd = cast(Path, PureWindowsPath(r"D:\bootstrap\repo"))
+        resolve_calls = []
+        monkeypatch.setattr(mc, "IS_WINDOWS", True)
+        monkeypatch.setattr(
+            mc,
+            "resolve_node_command",
+            lambda name, args, *, cwd, search_cwd: resolve_calls.append(
+                (name, args, cwd, search_cwd)
+            )
+            or [name, *args],
+        )
+        monkeypatch.setattr(
+            mc.subprocess,
+            "run",
+            lambda argv, **kwargs: subprocess.CompletedProcess(argv, 0),
+        )
+
+        mc._run_bootstrap(bootstrap_cwd, [f"{executable} --version"])
+
+        assert resolve_calls == [(executable, ["--version"], bootstrap_cwd, False)]
+
+    def test_windows_preserves_bare_executable_for_path_resolution(
+        self, monkeypatch
+    ):
+        import hermes_cli.mcp_catalog as mc
+
+        bootstrap_cwd = cast(Path, PureWindowsPath(r"D:\bootstrap\repo"))
+        resolve_calls = []
+        monkeypatch.setattr(mc, "IS_WINDOWS", True)
+        monkeypatch.setattr(
+            mc,
+            "resolve_node_command",
+            lambda name, args, *, cwd, search_cwd: resolve_calls.append(
+                (name, args, cwd, search_cwd)
+            )
+            or [name, *args],
+        )
+        monkeypatch.setattr(
+            mc.subprocess,
+            "run",
+            lambda argv, **kwargs: subprocess.CompletedProcess(argv, 0),
+        )
+
+        mc._run_bootstrap(bootstrap_cwd, ["pip install demo"])
+
+        assert resolve_calls == [
+            ("pip", ["install", "demo"], bootstrap_cwd, False)
+        ]
+
+    def test_windows_shipped_n8n_python_ignores_clone_local_executable(
+        self, tmp_path, monkeypatch
+    ):
+        import hermes_cli.mcp_catalog as mc
+        from hermes_cli import _subprocess_compat as sc
+
+        bootstrap_cwd = tmp_path / "n8n"
+        path_dir = tmp_path / "python-bin"
+        for directory in (bootstrap_cwd, path_dir):
+            directory.mkdir()
+        attacker = bootstrap_cwd / "python3.EXE"
+        safe_python = path_dir / "python3.EXE"
+        attacker.touch()
+        safe_python.touch()
+
+        run_calls = []
+        monkeypatch.setenv("PATH", str(path_dir))
+        monkeypatch.setenv("PATHEXT", ".COM;.EXE;.BAT;.CMD")
+        monkeypatch.setattr(mc, "IS_WINDOWS", True)
+        monkeypatch.setattr(sc, "IS_WINDOWS", True)
+        monkeypatch.setattr(
+            mc.subprocess,
+            "run",
+            lambda argv, **kwargs: (
+                run_calls.append((argv, kwargs)) or subprocess.CompletedProcess(argv, 0)
+            ),
+        )
+
+        mc._run_bootstrap(bootstrap_cwd, ["python3 -m venv .venv"])
+
+        assert run_calls == [
+            (
+                [str(safe_python), "-m", "venv", ".venv"],
+                {
+                    "cwd": str(bootstrap_cwd),
+                    "shell": False,
+                    "stdin": subprocess.DEVNULL,
+                },
+            )
+        ]
+
+    def test_windows_rejects_unresolved_batch_launcher(
+        self, tmp_path, monkeypatch
+    ):
+        import hermes_cli.mcp_catalog as mc
+
+        monkeypatch.setattr(mc, "IS_WINDOWS", True)
+        monkeypatch.setattr(
+            mc,
+            "resolve_node_command",
+            lambda name, args, *, cwd, search_cwd: [
+                r"C:\Program Files\nodejs\npm.cmd",
+                *args,
+            ],
+        )
+        monkeypatch.setattr(
+            mc.subprocess,
+            "run",
+            lambda *args, **kwargs: pytest.fail("unsafe batch command was launched"),
+        )
+
+        with pytest.raises(mc.CatalogError, match="Windows batch launcher"):
+            mc._run_bootstrap(tmp_path, ["legacy.cmd install"])

--- a/tests/hermes_cli/test_mcp_catalog.py
+++ b/tests/hermes_cli/test_mcp_catalog.py
@@ -905,6 +905,29 @@ class TestShippedCatalog:
 
         assert not problems, "unpinned catalog entries:\n" + "\n".join(problems)
 
+    def test_all_shipped_bootstrap_commands_are_native_argv(self, monkeypatch):
+        """Keep shell syntax and Windows batch launchers out of the catalog."""
+        monkeypatch.delenv("HERMES_OPTIONAL_MCPS", raising=False)
+        from hermes_cli.mcp_catalog import (
+            IS_WINDOWS,
+            _catalog_root,
+            _parse_manifest,
+            _split_bootstrap_command,
+        )
+
+        problems = []
+        for manifest in _catalog_root().glob("*/manifest.yaml"):
+            entry = _parse_manifest(manifest)
+            for command in entry.install.bootstrap if entry.install else ():
+                argv = _split_bootstrap_command(command)
+                has_shell_syntax = any(char in command for char in "&;|<>")
+                if not argv or has_shell_syntax:
+                    problems.append(f"{entry.name}: shell syntax in {command!r}")
+                elif IS_WINDOWS and argv[0].casefold().endswith((".cmd", ".bat")):
+                    problems.append(f"{entry.name}: batch launcher in {command!r}")
+
+        assert not problems, "unsafe catalog bootstrap commands:\n" + "\n".join(problems)
+
 
 # ---------------------------------------------------------------------------
 # Bootstrap execution

--- a/tests/tools/test_windows_native_support.py
+++ b/tests/tools/test_windows_native_support.py
@@ -911,7 +911,7 @@ class TestSubprocessCompatHelpers:
         assert sc._node_executable(
             tmp_path / "yarn.cmd", prefer_adjacent=False, cwd=tmp_path / "project"
         ) == str(node)
-        assert probes == ["node.exe", "node"]
+        assert probes == ["node"]
 
     def test_resolve_node_command_unwraps_windows_npm_shim(
         self, tmp_path, monkeypatch

--- a/tests/tools/test_windows_native_support.py
+++ b/tests/tools/test_windows_native_support.py
@@ -16,7 +16,8 @@ import os
 import signal
 import subprocess
 import sys
-from pathlib import Path
+from pathlib import Path, PureWindowsPath
+from typing import cast
 from unittest import mock
 from unittest.mock import MagicMock
 
@@ -425,6 +426,1361 @@ class TestSubprocessCompatHelpers:
         # First element is either an absolute path (sh found) or the bare
         # name (fallback) — both are acceptable behaviours.
 
+    def test_resolve_node_command_uses_bootstrap_cwd_before_windows_path(
+        self, tmp_path, monkeypatch
+    ):
+        """A bare command must not bind an executable from Hermes's cwd."""
+        from hermes_cli import _subprocess_compat as sc
+
+        launch_cwd = tmp_path / "hermes-launch"
+        bootstrap_cwd = tmp_path / "n8n"
+        path_dir = tmp_path / "python-bin"
+        for directory in (launch_cwd, bootstrap_cwd, path_dir):
+            directory.mkdir()
+        attacker = launch_cwd / "python3.EXE"
+        safe_python = path_dir / "python3.EXE"
+        attacker.touch()
+        safe_python.touch()
+
+        probes = []
+
+        def windows_which(command):
+            probes.append(command)
+            candidate = Path(command)
+            if candidate == Path("python3"):
+                return str(attacker)
+            if candidate == bootstrap_cwd / "python3":
+                return None
+            if candidate == path_dir / "python3":
+                return str(safe_python)
+            return None
+
+        monkeypatch.chdir(launch_cwd)
+        monkeypatch.delenv("NoDefaultCurrentDirectoryInExePath", raising=False)
+        monkeypatch.setenv("PATH", str(path_dir))
+        monkeypatch.setattr(sc, "IS_WINDOWS", True)
+        monkeypatch.setattr(sc.shutil, "which", windows_which)
+
+        assert sc.resolve_node_command(
+            "python3", ["-m", "venv", ".venv"], cwd=bootstrap_cwd
+        ) == [str(safe_python), "-m", "venv", ".venv"]
+        assert "python3" not in probes
+
+    def test_resolve_node_command_does_not_treat_drive_relative_name_as_bare(
+        self, monkeypatch
+    ):
+        """Windows drive-relative names must not enter bare-command lookup."""
+        from hermes_cli import _subprocess_compat as sc
+
+        bootstrap_cwd = cast(Path, PureWindowsPath(r"D:\bootstrap\repo"))
+        resolved = r"D:\bootstrap\repo\python.EXE"
+        probes = []
+
+        monkeypatch.setattr(sc, "IS_WINDOWS", True)
+        monkeypatch.setattr(
+            sc,
+            "_which_windows_command_from_cwd",
+            lambda *args, **kwargs: pytest.fail(
+                "drive-relative executable entered bare-command lookup"
+            ),
+        )
+        monkeypatch.setattr(
+            sc,
+            "_which_windows_explicit_command",
+            lambda name, *, allowed_root: probes.append((name, allowed_root))
+            or resolved,
+        )
+
+        assert sc.resolve_node_command(
+            r"D:python", ["--version"], cwd=bootstrap_cwd
+        ) == [resolved, "--version"]
+        assert probes == [(r"D:python", None)]
+
+    def test_resolve_node_command_honors_default_windows_cwd_search(
+        self, tmp_path, monkeypatch
+    ):
+        """Without the opt-out, the child cwd precedes explicit PATH entries."""
+        from hermes_cli import _subprocess_compat as sc
+
+        bootstrap_cwd = tmp_path / "project"
+        path_dir = tmp_path / "python-bin"
+        bootstrap_cwd.mkdir()
+        path_dir.mkdir()
+        local_python = bootstrap_cwd / "python3.EXE"
+        path_python = path_dir / "python3.EXE"
+        local_python.touch()
+        path_python.touch()
+
+        def windows_which(command):
+            candidate = Path(command)
+            if candidate == bootstrap_cwd / "python3":
+                return str(local_python)
+            if candidate == path_dir / "python3":
+                return str(path_python)
+            return None
+
+        monkeypatch.delenv("NoDefaultCurrentDirectoryInExePath", raising=False)
+        monkeypatch.setenv("PATH", str(path_dir))
+        monkeypatch.setattr(sc, "IS_WINDOWS", True)
+        monkeypatch.setattr(sc.shutil, "which", windows_which)
+
+        assert sc.resolve_node_command("python3", [], cwd=bootstrap_cwd) == [
+            str(local_python)
+        ]
+
+    def test_resolve_node_command_skips_windows_cwd_when_opted_out(
+        self, tmp_path, monkeypatch
+    ):
+        """The cmd.exe opt-out must restrict a bare bootstrap name to PATH."""
+        from hermes_cli import _subprocess_compat as sc
+
+        bootstrap_cwd = tmp_path / "cloned-repository"
+        path_dir = tmp_path / "python-bin"
+        bootstrap_cwd.mkdir()
+        path_dir.mkdir()
+        local_python = bootstrap_cwd / "python3.EXE"
+        path_python = path_dir / "python3.EXE"
+        local_python.touch()
+        path_python.touch()
+        probes = []
+
+        def windows_which(command):
+            probes.append(Path(command))
+            candidate = Path(command)
+            if candidate == bootstrap_cwd / "python3":
+                return str(local_python)
+            if candidate == path_dir / "python3":
+                return str(path_python)
+            return None
+
+        monkeypatch.setenv("NoDefaultCurrentDirectoryInExePath", "")
+        monkeypatch.setenv("PATH", str(path_dir))
+        monkeypatch.setattr(sc, "IS_WINDOWS", True)
+        monkeypatch.setattr(sc.shutil, "which", windows_which)
+
+        assert sc.resolve_node_command("python3", [], cwd=bootstrap_cwd) == [
+            str(path_python)
+        ]
+        assert bootstrap_cwd / "python3" not in probes
+
+    @pytest.mark.parametrize(
+        ("search_cwd", "opt_out", "expected_location"),
+        [
+            (False, False, "path"),
+            (True, True, "path"),
+            (True, False, "cwd"),
+        ],
+        ids=("search-disabled", "environment-opt-out", "search-enabled"),
+    )
+    def test_resolve_node_command_applies_empty_path_cwd_search_policy(
+        self, tmp_path, monkeypatch, search_cwd, opt_out, expected_location
+    ):
+        """Empty PATH entries cannot bypass an explicit cwd-search opt-out."""
+        from hermes_cli import _subprocess_compat as sc
+
+        bootstrap_cwd = tmp_path / "cloned-repository"
+        path_dir = tmp_path / "python-bin"
+        bootstrap_cwd.mkdir()
+        path_dir.mkdir()
+        local_python = bootstrap_cwd / "python3.EXE"
+        path_python = path_dir / "python3.EXE"
+        local_python.touch()
+        path_python.touch()
+
+        if opt_out:
+            monkeypatch.setenv("NoDefaultCurrentDirectoryInExePath", "1")
+        else:
+            monkeypatch.delenv("NoDefaultCurrentDirectoryInExePath", raising=False)
+        monkeypatch.setenv("PATH", os.pathsep.join(("", str(path_dir))))
+        monkeypatch.setenv("PATHEXT", ".EXE")
+        monkeypatch.setattr(sc, "IS_WINDOWS", True)
+
+        expected = local_python if expected_location == "cwd" else path_python
+        assert sc.resolve_node_command(
+            "python3", [], cwd=bootstrap_cwd, search_cwd=search_cwd
+        ) == [str(expected)]
+        if expected_location == "path":
+            monkeypatch.setenv("PATH", "")
+            assert sc.resolve_node_command(
+                "python3", [], cwd=bootstrap_cwd, search_cwd=search_cwd
+            ) == [str(bootstrap_cwd / "<PATH>" / "python3")]
+
+    def test_resolve_node_command_anchors_relative_windows_path_to_child_cwd(
+        self, tmp_path, monkeypatch
+    ):
+        """An explicit relative PATH entry stays child-cwd-relative under opt-out."""
+        from hermes_cli import _subprocess_compat as sc
+
+        launch_cwd = tmp_path / "hermes-launch"
+        bootstrap_cwd = tmp_path / "cloned-repository"
+        relative_bin = bootstrap_cwd / "tools"
+        for directory in (launch_cwd, bootstrap_cwd, relative_bin):
+            directory.mkdir()
+        attacker = launch_cwd / "python3.EXE"
+        path_python = relative_bin / "python3.EXE"
+        attacker.touch()
+        path_python.touch()
+        probes = []
+
+        def windows_which(command):
+            probes.append(Path(command))
+            candidate = Path(command)
+            if candidate == Path("python3"):
+                return str(attacker)
+            if candidate == relative_bin / "python3":
+                return str(path_python)
+            return None
+
+        monkeypatch.chdir(launch_cwd)
+        monkeypatch.setenv("NoDefaultCurrentDirectoryInExePath", "1")
+        monkeypatch.setenv("PATH", "tools")
+        monkeypatch.setattr(sc, "IS_WINDOWS", True)
+        monkeypatch.setattr(sc.shutil, "which", windows_which)
+
+        assert sc.resolve_node_command("python3", [], cwd=bootstrap_cwd) == [
+            str(path_python)
+        ]
+        assert probes == []
+
+    def test_resolve_node_command_uses_non_searching_opt_out_fallback(
+        self, tmp_path, monkeypatch
+    ):
+        """A PATH miss cannot fall back to a repository executable."""
+        from hermes_cli import _subprocess_compat as sc
+
+        bootstrap_cwd = tmp_path / "cloned-repository"
+        path_dir = tmp_path / "empty-bin"
+        bootstrap_cwd.mkdir()
+        path_dir.mkdir()
+        (bootstrap_cwd / "python3.EXE").touch()
+
+        monkeypatch.setenv("NoDefaultCurrentDirectoryInExePath", "1")
+        monkeypatch.setenv("PATH", str(path_dir))
+        monkeypatch.setattr(sc, "IS_WINDOWS", True)
+        monkeypatch.setattr(sc.shutil, "which", lambda command: None)
+
+        assert sc.resolve_node_command("python3", [], cwd=bootstrap_cwd) == [
+            str(path_dir / "python3")
+        ]
+
+    def test_resolve_node_command_anchors_missing_windows_command_to_cwd(
+        self, tmp_path, monkeypatch
+    ):
+        """A miss must not leave CreateProcessW a bare-name fallback."""
+        from hermes_cli import _subprocess_compat as sc
+
+        launch_cwd = tmp_path / "hermes-launch"
+        bootstrap_cwd = tmp_path / "n8n"
+        launch_cwd.mkdir()
+        bootstrap_cwd.mkdir()
+        attacker = launch_cwd / "python3.EXE"
+        attacker.touch()
+
+        def windows_which(command):
+            if Path(command) == Path("python3"):
+                return str(attacker)
+            return None
+
+        monkeypatch.chdir(launch_cwd)
+        monkeypatch.delenv("NoDefaultCurrentDirectoryInExePath", raising=False)
+        monkeypatch.setenv("PATH", "")
+        monkeypatch.setattr(sc, "IS_WINDOWS", True)
+        monkeypatch.setattr(sc.shutil, "which", windows_which)
+
+        assert sc.resolve_node_command(
+            "python3", ["-m", "venv", ".venv"], cwd=bootstrap_cwd
+        ) == [str(bootstrap_cwd / "python3"), "-m", "venv", ".venv"]
+
+    def test_resolve_node_command_anchors_shim_node_fallback_to_bootstrap_cwd(
+        self, tmp_path, monkeypatch
+    ):
+        """A supported shim must not bind Node from Hermes's launch cwd."""
+        import json
+
+        from hermes_cli import _subprocess_compat as sc
+
+        launch_cwd = tmp_path / "hermes-launch"
+        bootstrap_cwd = tmp_path / "project"
+        yarn_package = tmp_path / "yarn"
+        yarn_bin = yarn_package / "bin"
+        node_bin = tmp_path / "node-bin"
+        for directory in (launch_cwd, bootstrap_cwd, yarn_bin, node_bin):
+            directory.mkdir(parents=True)
+
+        attacker = launch_cwd / "node.exe"
+        safe_node = node_bin / "node.EXE"
+        shim = yarn_bin / "yarn.CMD"
+        entrypoint = yarn_bin / "yarn.js"
+        attacker.touch()
+        safe_node.touch()
+        entrypoint.touch()
+        shim.write_text(
+            '@echo off\r\nnode "%~dp0\\yarn.js" %*\r\n', encoding="utf-8"
+        )
+        (yarn_package / "package.json").write_text(
+            json.dumps({"name": "yarn", "bin": {"yarn": "bin/yarn.js"}}),
+            encoding="utf-8",
+        )
+
+        probes = []
+
+        def windows_which(command):
+            probes.append(command)
+            candidate = Path(command)
+            if candidate == Path("node.exe"):
+                return str(attacker)
+            if candidate == yarn_bin / "yarn":
+                return str(shim)
+            if candidate == node_bin / "node":
+                return str(safe_node)
+            return None
+
+        monkeypatch.chdir(launch_cwd)
+        monkeypatch.delenv("NoDefaultCurrentDirectoryInExePath", raising=False)
+        monkeypatch.setenv("PATH", os.pathsep.join((str(yarn_bin), str(node_bin))))
+        monkeypatch.setattr(sc, "IS_WINDOWS", True)
+        monkeypatch.setattr(sc.shutil, "which", windows_which)
+
+        assert sc.resolve_node_command(
+            "yarn", ["--version"], cwd=bootstrap_cwd
+        ) == [str(safe_node), str(entrypoint.resolve()), "--version"]
+        assert probes == []
+
+    def test_resolve_node_command_skips_windows_cwd_for_shim_node_fallback(
+        self, tmp_path, monkeypatch
+    ):
+        """Node fallback follows the same PATH-only opt-out as bootstrap names."""
+        import json
+
+        from hermes_cli import _subprocess_compat as sc
+
+        bootstrap_cwd = tmp_path / "cloned-repository"
+        yarn_package = tmp_path / "yarn"
+        yarn_bin = yarn_package / "bin"
+        node_bin = tmp_path / "node-bin"
+        for directory in (bootstrap_cwd, yarn_bin, node_bin):
+            directory.mkdir(parents=True)
+
+        local_node = bootstrap_cwd / "node.EXE"
+        path_node = node_bin / "node.EXE"
+        shim = yarn_bin / "yarn.CMD"
+        entrypoint = yarn_bin / "yarn.js"
+        local_node.touch()
+        path_node.touch()
+        entrypoint.touch()
+        shim.write_text(
+            '@echo off\r\nnode "%~dp0\\yarn.js" %*\r\n', encoding="utf-8"
+        )
+        (yarn_package / "package.json").write_text(
+            json.dumps({"name": "yarn", "bin": {"yarn": "bin/yarn.js"}}),
+            encoding="utf-8",
+        )
+        probes = []
+
+        def windows_which(command):
+            probes.append(Path(command))
+            candidate = Path(command)
+            if candidate == yarn_bin / "yarn":
+                return str(shim)
+            if candidate == bootstrap_cwd / "node":
+                return str(local_node)
+            if candidate == node_bin / "node":
+                return str(path_node)
+            return None
+
+        monkeypatch.setenv("NoDefaultCurrentDirectoryInExePath", "1")
+        monkeypatch.setenv("PATH", os.pathsep.join((str(yarn_bin), str(node_bin))))
+        monkeypatch.setattr(sc, "IS_WINDOWS", True)
+        monkeypatch.setattr(sc.shutil, "which", windows_which)
+
+        assert sc.resolve_node_command(
+            "yarn", ["--version"], cwd=bootstrap_cwd
+        ) == [str(path_node), str(entrypoint.resolve()), "--version"]
+        assert probes == []
+
+    def test_node_executable_preserves_windows_path_pathext_order(
+        self, tmp_path, monkeypatch
+    ):
+        """Do not skip an earlier PATH node.cmd for a later node.exe."""
+        from hermes_cli import _subprocess_compat as sc
+
+        bootstrap_cwd = tmp_path / "project"
+        first_bin = tmp_path / "first-bin"
+        second_bin = tmp_path / "second-bin"
+        for directory in (bootstrap_cwd, first_bin, second_bin):
+            directory.mkdir()
+        first_node = first_bin / "node.CMD"
+        second_node = second_bin / "node.EXE"
+        first_node.touch()
+        second_node.touch()
+
+        monkeypatch.setenv("NoDefaultCurrentDirectoryInExePath", "1")
+        monkeypatch.setenv("PATH", os.pathsep.join((str(first_bin), str(second_bin))))
+        monkeypatch.setenv("PATHEXT", ".CMD;.EXE")
+        monkeypatch.setattr(sc, "IS_WINDOWS", True)
+
+        assert sc._node_executable(
+            tmp_path / "yarn.cmd", prefer_adjacent=False, cwd=bootstrap_cwd
+        ) is None
+
+    def test_windows_explicit_path_probe_applies_pathext_without_shutil_which(
+        self, tmp_path, monkeypatch
+    ):
+        """Python 3.11 must find suffixed executables for explicit directories."""
+        from hermes_cli import _subprocess_compat as sc
+
+        bootstrap_cwd = tmp_path / "project"
+        path_dir = tmp_path / "python-bin"
+        bootstrap_cwd.mkdir()
+        path_dir.mkdir()
+        python = path_dir / "python3.EXE"
+        python.touch()
+
+        monkeypatch.setenv("NoDefaultCurrentDirectoryInExePath", "1")
+        monkeypatch.setenv("PATH", str(path_dir))
+        monkeypatch.setenv("PATHEXT", ".COM;.EXE;.BAT;.CMD")
+        monkeypatch.setattr(sc, "IS_WINDOWS", True)
+        monkeypatch.setattr(
+            sc.shutil,
+            "which",
+            lambda command: pytest.fail(
+                f"explicit Windows probe delegated to shutil.which: {command}"
+            ),
+        )
+
+        assert sc.resolve_node_command("python3", [], cwd=bootstrap_cwd) == [
+            str(python)
+        ]
+
+    def test_windows_explicit_suffixed_path_precedes_pathext_expansion(
+        self, tmp_path, monkeypatch
+    ):
+        """An existing suffixed path must not lose to PATHEXT expansion."""
+        from hermes_cli import _subprocess_compat as sc
+
+        path_dir = tmp_path / "bin"
+        path_dir.mkdir()
+        exact = path_dir / "tool.exe"
+        expanded = path_dir / "tool.exe.COM"
+        exact.touch()
+        expanded.touch()
+
+        monkeypatch.setenv("PATHEXT", ".COM;.CMD")
+        monkeypatch.setattr(sc, "IS_WINDOWS", True)
+
+        assert sc.resolve_node_command(str(exact), []) == [str(exact)]
+
+    def test_node_executable_strips_pathext_entry_whitespace(
+        self, tmp_path, monkeypatch
+    ):
+        """Accept whitespace-formatted PATHEXT while retaining dotted suffixes."""
+        from hermes_cli import _subprocess_compat as sc
+
+        bootstrap_cwd = tmp_path / "project"
+        node_bin = tmp_path / "node-bin"
+        bootstrap_cwd.mkdir()
+        node_bin.mkdir()
+        node = node_bin / "node.EXE"
+        node.touch()
+
+        monkeypatch.setenv("NoDefaultCurrentDirectoryInExePath", "1")
+        monkeypatch.setenv("PATH", str(node_bin))
+        monkeypatch.setenv("PATHEXT", ".COM; .EXE; .CMD")
+        monkeypatch.setattr(sc, "IS_WINDOWS", True)
+
+        assert sc._node_executable(
+            tmp_path / "yarn.cmd", prefer_adjacent=False, cwd=bootstrap_cwd
+        ) == str(node)
+
+    def test_node_executable_keeps_posix_path_resolution_with_cwd(
+        self, tmp_path, monkeypatch
+    ):
+        """Supplying a child cwd must not change the POSIX lookup seam."""
+        from hermes_cli import _subprocess_compat as sc
+
+        node = tmp_path / "node"
+        probes = []
+
+        def posix_which(command):
+            probes.append(command)
+            return str(node) if command == "node" else None
+
+        monkeypatch.setattr(sc, "IS_WINDOWS", False)
+        monkeypatch.setattr(sc.shutil, "which", posix_which)
+
+        assert sc._node_executable(
+            tmp_path / "yarn.cmd", prefer_adjacent=False, cwd=tmp_path / "project"
+        ) == str(node)
+        assert probes == ["node.exe", "node"]
+
+    def test_resolve_node_command_unwraps_windows_npm_shim(
+        self, tmp_path, monkeypatch
+    ):
+        import json
+
+        from hermes_cli import _subprocess_compat as sc
+
+        node = tmp_path / "node.exe"
+        shim = tmp_path / "npm.cmd"
+        package = tmp_path / "node_modules" / "npm"
+        entrypoint = package / "bin" / "npm-cli.js"
+        entrypoint.parent.mkdir(parents=True)
+        node.touch()
+        entrypoint.touch()
+        shim.write_text(
+            "@ECHO off\r\n"
+            "GOTO start\r\n"
+            ":find_dp0\r\n"
+            "SET dp0=%~dp0\r\n"
+            "EXIT /b\r\n"
+            ":start\r\n"
+            "SETLOCAL\r\n"
+            "CALL :find_dp0\r\n"
+            'IF EXIST "%dp0%\\node.exe" (\r\n'
+            '  SET "_prog=%dp0%\\node.exe"\r\n'
+            ") ELSE (\r\n"
+            '  SET "_prog=node"\r\n'
+            ")\r\n"
+            "\r\n"
+            "endLocal & goto #_undefined_# 2>NUL || title %COMSPEC% & "
+            'set PATHEXT=%PATHEXT:;.JS;=;% & "%_prog%"  '
+            '"%dp0%\\node_modules\\npm\\bin\\npm-cli.js" %*\r\n',
+            encoding="utf-8",
+        )
+        (package / "package.json").write_text(
+            json.dumps({"name": "npm", "bin": {"npm": "bin/npm-cli.js"}}),
+            encoding="utf-8",
+        )
+        monkeypatch.setattr(sc, "IS_WINDOWS", True)
+        monkeypatch.setattr(sc.shutil, "which", lambda name: str(shim))
+
+        assert sc.resolve_node_command("npm", ["install", "pkg@^1.2.3"]) == [
+            str(node.resolve()),
+            str(entrypoint.resolve()),
+            "install",
+            "pkg@^1.2.3",
+        ]
+
+    @pytest.mark.parametrize(
+        ("preamble", "launch_prefix"),
+        [
+            (
+                ":: Created by npm, please don't edit manually.\r\n\r\n",
+                "endLocal & goto #_undefined_# 2>NUL || title %COMSPEC% & ",
+            ),
+            (
+                "\r\n\r\n",
+                "ENDLOCAL & (CALL) || TITLE %COMSPEC% & ",
+            ),
+        ],
+    )
+    def test_resolve_node_command_accepts_supported_npm_shim_wrappers(
+        self, tmp_path, monkeypatch, preamble, launch_prefix
+    ):
+        import json
+
+        from hermes_cli import _subprocess_compat as sc
+
+        node = tmp_path / "node.exe"
+        shim = tmp_path / "npm.cmd"
+        package = tmp_path / "node_modules" / "npm"
+        entrypoint = package / "bin" / "npm-cli.js"
+        entrypoint.parent.mkdir(parents=True)
+        node.touch()
+        entrypoint.touch()
+        shim.write_text(
+            preamble + "@ECHO off\r\n"
+            "GOTO start\r\n"
+            ":find_dp0\r\n"
+            "SET dp0=%~dp0\r\n"
+            "EXIT /b\r\n"
+            ":start\r\n"
+            "SETLOCAL\r\n"
+            "CALL :find_dp0\r\n"
+            'IF EXIST "%dp0%\\node.exe" (\r\n'
+            '  SET "_prog=%dp0%\\node.exe"\r\n'
+            ") ELSE (\r\n"
+            '  SET "_prog=node"\r\n'
+            ")\r\n"
+            "\r\n" + launch_prefix + 'set PATHEXT=%PATHEXT:;.JS;=;% & "%_prog%"  '
+            '"%dp0%\\node_modules\\npm\\bin\\npm-cli.js" %*\r\n',
+            encoding="utf-8",
+        )
+        (package / "package.json").write_text(
+            json.dumps({"name": "npm", "bin": {"npm": "bin/npm-cli.js"}}),
+            encoding="utf-8",
+        )
+        monkeypatch.setattr(sc, "IS_WINDOWS", True)
+        monkeypatch.setattr(sc.shutil, "which", lambda name: str(shim))
+
+        assert sc.resolve_node_command("npm", ["install"]) == [
+            str(node.resolve()),
+            str(entrypoint.resolve()),
+            "install",
+        ]
+
+    @pytest.mark.parametrize(
+        ("npm_version", "command"),
+        [
+            ("11.12.1", "npm"),
+            ("11.17.0", "npm"),
+            ("11.17.0", "npx"),
+            ("12.0.2", "npm"),
+            ("12.0.2", "npx"),
+        ],
+    )
+    def test_resolve_node_command_accepts_current_npm_cli_launcher(
+        self, tmp_path, monkeypatch, npm_version, command
+    ):
+        """Use the exact bin/npm.cmd and bin/npx.cmd from supported npm tags."""
+        import json
+
+        from hermes_cli import _subprocess_compat as sc
+
+        node = tmp_path / "node.exe"
+        shim = tmp_path / f"{command}.cmd"
+        package = tmp_path / "node_modules" / "npm"
+        cli = command.upper()
+        cli_file = f"{command}-cli.js"
+        entrypoint = package / "bin" / cli_file
+        prefix_probe = package / "bin" / "npm-prefix.js"
+        entrypoint.parent.mkdir(parents=True)
+        node.touch()
+        entrypoint.touch()
+        prefix_probe.touch()
+        shim.write_text(
+            ":: Created by npm, please don't edit manually.\r\n"
+            "@ECHO OFF\r\n"
+            "\r\n"
+            "SETLOCAL\r\n"
+            "\r\n"
+            'SET "NODE_EXE=%~dp0\\node.exe"\r\n'
+            'IF NOT EXIST "%NODE_EXE%" (\r\n'
+            '  SET "NODE_EXE=node"\r\n'
+            ")\r\n"
+            "\r\n"
+            'SET "NPM_PREFIX_JS=%~dp0\\node_modules\\npm\\bin\\npm-prefix.js"\r\n'
+            f'SET "{cli}_CLI_JS=%~dp0\\node_modules\\npm\\bin\\{cli_file}"\r\n'
+            'FOR /F "delims=" %%F IN (\'CALL "%NODE_EXE%" "%NPM_PREFIX_JS%"\') DO (\r\n'
+            f'  SET "NPM_PREFIX_{cli}_CLI_JS=%%F\\node_modules\\npm\\bin\\{cli_file}"\r\n'
+            ")\r\n"
+            f'IF EXIST "%NPM_PREFIX_{cli}_CLI_JS%" (\r\n'
+            f'  SET "{cli}_CLI_JS=%NPM_PREFIX_{cli}_CLI_JS%"\r\n'
+            ")\r\n"
+            "\r\n"
+            f'"%NODE_EXE%" "%{cli}_CLI_JS%" %*\r\n',
+            encoding="utf-8",
+        )
+        (package / "package.json").write_text(
+            json.dumps(
+                {
+                    "name": "npm",
+                    "version": npm_version,
+                    "bin": {command: f"bin/{cli_file}"},
+                }
+            ),
+            encoding="utf-8",
+        )
+        monkeypatch.setattr(sc, "IS_WINDOWS", True)
+        monkeypatch.setattr(sc.shutil, "which", lambda name: str(shim))
+        monkeypatch.setattr(
+            sc.subprocess,
+            "run",
+            lambda *args, **kwargs: sc.subprocess.CompletedProcess(
+                args[0], 0, stdout="", stderr=""
+            ),
+        )
+
+        assert sc.resolve_node_command(command, ["install"]) == [
+            str(node.resolve()),
+            str(entrypoint.resolve()),
+            "install",
+        ]
+
+    @pytest.mark.parametrize("command", ["npm", "npx"])
+    def test_resolve_node_command_preserves_cwd_sensitive_npm_1202_prefix_selection(
+        self, tmp_path, monkeypatch, command
+    ):
+        """Mirror npm 12.0.2 selecting a project .npmrc global prefix."""
+        import json
+
+        from hermes_cli import _subprocess_compat as sc
+
+        node_bin = tmp_path / "node-bin"
+        node = node_bin / "node.EXE"
+        shim = tmp_path / f"{command}.CMD"
+        local_package = tmp_path / "node_modules" / "npm"
+        global_prefix = tmp_path / "global-prefix"
+        global_package = global_prefix / "node_modules" / "npm"
+        project = tmp_path / "project"
+        cli = command.upper()
+        cli_file = f"{command}-cli.js"
+        local_entrypoint = local_package / "bin" / cli_file
+        global_entrypoint = global_package / "bin" / cli_file
+        prefix_probe = local_package / "bin" / "npm-prefix.js"
+        local_entrypoint.parent.mkdir(parents=True)
+        global_entrypoint.parent.mkdir(parents=True)
+        project.mkdir()
+        node_bin.mkdir()
+        (project / ".npmrc").write_text(
+            f"prefix={global_prefix}\n", encoding="utf-8"
+        )
+        node.touch()
+        local_entrypoint.touch()
+        global_entrypoint.touch()
+        prefix_probe.touch()
+        shim.write_text(
+            ":: Created by npm, please don't edit manually.\r\n"
+            "@ECHO OFF\r\n\r\nSETLOCAL\r\n\r\n"
+            'SET "NODE_EXE=%~dp0\\node.exe"\r\n'
+            'IF NOT EXIST "%NODE_EXE%" (\r\n'
+            '  SET "NODE_EXE=node"\r\n)\r\n\r\n'
+            'SET "NPM_PREFIX_JS=%~dp0\\node_modules\\npm\\bin\\npm-prefix.js"\r\n'
+            f'SET "{cli}_CLI_JS=%~dp0\\node_modules\\npm\\bin\\{cli_file}"\r\n'
+            'FOR /F "delims=" %%F IN (\'CALL "%NODE_EXE%" "%NPM_PREFIX_JS%"\') DO (\r\n'
+            f'  SET "NPM_PREFIX_{cli}_CLI_JS=%%F\\node_modules\\npm\\bin\\{cli_file}"\r\n'
+            ")\r\n"
+            f'IF EXIST "%NPM_PREFIX_{cli}_CLI_JS%" (\r\n'
+            f'  SET "{cli}_CLI_JS=%NPM_PREFIX_{cli}_CLI_JS%"\r\n'
+            ")\r\n\r\n"
+            f'"%NODE_EXE%" "%{cli}_CLI_JS%" %*\r\n',
+            encoding="utf-8",
+        )
+        for package, version in ((local_package, "12.0.2"), (global_package, "12.0.2")):
+            (package / "package.json").write_text(
+                json.dumps(
+                    {
+                        "name": "npm",
+                        "version": version,
+                        "bin": {command: f"bin/{cli_file}"},
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+        calls = []
+
+        def run_prefix(argv, **kwargs):
+            calls.append((argv, kwargs))
+            probe_cwd = Path(kwargs.get("cwd") or Path.cwd())
+            npmrc = probe_cwd / ".npmrc"
+            configured_prefix = (
+                Path(npmrc.read_text(encoding="utf-8").split("=", 1)[1].strip())
+                if npmrc.is_file()
+                else tmp_path
+            )
+            return sc.subprocess.CompletedProcess(
+                argv, 0, stdout=f"{configured_prefix}\n", stderr=""
+            )
+
+        monkeypatch.setattr(sc, "IS_WINDOWS", True)
+        monkeypatch.setenv(
+            "PATH", os.pathsep.join((str(tmp_path), str(node_bin)))
+        )
+
+        probes = []
+
+        def windows_which(name):
+            probes.append(name)
+            candidate = Path(name)
+            if candidate == project / command:
+                return None
+            if candidate == tmp_path / command:
+                return str(shim)
+            if candidate == node_bin / "node":
+                return str(node)
+            return None
+
+        monkeypatch.setattr(
+            sc.shutil,
+            "which",
+            windows_which,
+        )
+        monkeypatch.setattr(sc.subprocess, "run", run_prefix)
+
+        assert sc.resolve_node_command(command, ["--version"], cwd=project) == [
+            str(node.resolve()),
+            str(global_entrypoint.resolve()),
+            "--version",
+        ]
+        assert calls == [
+            (
+                [str(node.resolve()), str(prefix_probe.resolve())],
+                {
+                    "capture_output": True,
+                    "check": False,
+                    "creationflags": sc.windows_hide_flags(),
+                    "cwd": str(project),
+                    "shell": False,
+                    "text": True,
+                    "timeout": 10,
+                },
+            )
+        ]
+        assert probes == []
+
+    def test_resolve_node_command_rejects_unbound_npm_prefix_selection(
+        self, tmp_path, monkeypatch
+    ):
+        """Never replace npm's selected global CLI with the adjacent package."""
+        import json
+
+        from hermes_cli import _subprocess_compat as sc
+
+        node = tmp_path / "node.exe"
+        shim = tmp_path / "npm.cmd"
+        local_package = tmp_path / "node_modules" / "npm"
+        global_prefix = tmp_path / "global-prefix"
+        global_entrypoint = global_prefix / "node_modules" / "npm" / "bin" / "npm-cli.js"
+        local_entrypoint = local_package / "bin" / "npm-cli.js"
+        prefix_probe = local_package / "bin" / "npm-prefix.js"
+        local_entrypoint.parent.mkdir(parents=True)
+        global_entrypoint.parent.mkdir(parents=True)
+        node.touch()
+        local_entrypoint.touch()
+        global_entrypoint.touch()
+        prefix_probe.touch()
+        shim.write_text(
+            ":: Created by npm, please don't edit manually.\r\n"
+            "@ECHO OFF\r\n\r\nSETLOCAL\r\n\r\n"
+            'SET "NODE_EXE=%~dp0\\node.exe"\r\n'
+            'IF NOT EXIST "%NODE_EXE%" (\r\n  SET "NODE_EXE=node"\r\n)\r\n\r\n'
+            'SET "NPM_PREFIX_JS=%~dp0\\node_modules\\npm\\bin\\npm-prefix.js"\r\n'
+            'SET "NPM_CLI_JS=%~dp0\\node_modules\\npm\\bin\\npm-cli.js"\r\n'
+            'FOR /F "delims=" %%F IN (\'CALL "%NODE_EXE%" "%NPM_PREFIX_JS%"\') DO (\r\n'
+            '  SET "NPM_PREFIX_NPM_CLI_JS=%%F\\node_modules\\npm\\bin\\npm-cli.js"\r\n'
+            ")\r\n"
+            'IF EXIST "%NPM_PREFIX_NPM_CLI_JS%" (\r\n'
+            '  SET "NPM_CLI_JS=%NPM_PREFIX_NPM_CLI_JS%"\r\n'
+            ")\r\n\r\n"
+            '"%NODE_EXE%" "%NPM_CLI_JS%" %*\r\n',
+            encoding="utf-8",
+        )
+        (local_package / "package.json").write_text(
+            json.dumps({"name": "npm", "bin": {"npm": "bin/npm-cli.js"}}),
+            encoding="utf-8",
+        )
+        monkeypatch.setattr(sc, "IS_WINDOWS", True)
+        monkeypatch.setattr(sc.shutil, "which", lambda name: str(shim))
+        monkeypatch.setattr(
+            sc.subprocess,
+            "run",
+            lambda argv, **kwargs: sc.subprocess.CompletedProcess(
+                argv, 0, stdout=f"{global_prefix}\n", stderr=""
+            ),
+        )
+
+        assert sc.resolve_node_command("npm", ["install"]) == [str(shim), "install"]
+
+    def test_resolve_node_command_accepts_corepack_0346_nodewin_launcher(
+        self, tmp_path, monkeypatch
+    ):
+        """Use Corepack 0.34.6's exact shims/nodewin/yarn.cmd body."""
+        import json
+
+        from hermes_cli import _subprocess_compat as sc
+
+        node = tmp_path / "node.exe"
+        shim = tmp_path / "yarn.cmd"
+        package = tmp_path / "node_modules" / "corepack"
+        entrypoint = package / "dist" / "yarn.js"
+        entrypoint.parent.mkdir(parents=True)
+        node.touch()
+        entrypoint.touch()
+        shim.write_text(
+            "@SETLOCAL\r\n"
+            '@IF EXIST "%~dp0\\node.exe" (\r\n'
+            '  "%~dp0\\node.exe"  "%~dp0\\node_modules\\corepack\\dist\\yarn.js" %*\r\n'
+            ") ELSE (\r\n"
+            "  @SET PATHEXT=%PATHEXT:;.JS;=;%\r\n"
+            '  node  "%~dp0\\node_modules\\corepack\\dist\\yarn.js" %*\r\n'
+            ")\r\n",
+            encoding="utf-8",
+        )
+        (package / "package.json").write_text(
+            json.dumps(
+                {
+                    "name": "corepack",
+                    "version": "0.34.6",
+                    "bin": {"yarn": "dist/yarn.js"},
+                }
+            ),
+            encoding="utf-8",
+        )
+        monkeypatch.setattr(sc, "IS_WINDOWS", True)
+        monkeypatch.setattr(sc.shutil, "which", lambda name: str(shim))
+
+        assert sc.resolve_node_command("yarn", ["--version"]) == [
+            str(node.resolve()),
+            str(entrypoint.resolve()),
+            "--version",
+        ]
+
+    @pytest.mark.parametrize(
+        ("pathext", "expected_native"),
+        [
+            (".JS;.COM;.EXE;.CMD", False),
+            (".COM;.JS;.EXE;.CMD", True),
+            (".COM;.EXE;.CMD;.JS", False),
+        ],
+        ids=("js-first", "js-interior", "js-last"),
+    )
+    def test_corepack_node_lookup_applies_boundary_sensitive_js_removal(
+        self, tmp_path, monkeypatch, pathext, expected_native
+    ):
+        """Match Corepack's literal interior ``;.JS;`` substitution."""
+        import json
+
+        from hermes_cli import _subprocess_compat as sc
+
+        project = tmp_path / "project"
+        package = tmp_path / "corepack"
+        shim_dir = package / "shims"
+        node_js_dir = tmp_path / "node-js"
+        node_exe_dir = tmp_path / "node-exe"
+        entrypoint = package / "dist" / "yarn.js"
+        shim = shim_dir / "yarn.CMD"
+        node_js = node_js_dir / "node.JS"
+        node_exe = node_exe_dir / "node.EXE"
+        for directory in (project, shim_dir, node_js_dir, node_exe_dir):
+            directory.mkdir(parents=True)
+        entrypoint.parent.mkdir()
+        entrypoint.touch()
+        node_js.touch()
+        node_exe.touch()
+        shim.write_text(
+            "@SETLOCAL\r\n"
+            '@IF EXIST "%~dp0\\node.exe" (\r\n'
+            '  "%~dp0\\node.exe"  "%~dp0\\..\\dist\\yarn.js" %*\r\n'
+            ") ELSE (\r\n"
+            "  @SET PATHEXT=%PATHEXT:;.JS;=;%\r\n"
+            '  node  "%~dp0\\..\\dist\\yarn.js" %*\r\n'
+            ")\r\n",
+            encoding="utf-8",
+        )
+        (package / "package.json").write_text(
+            json.dumps(
+                {
+                    "name": "corepack",
+                    "version": "0.34.6",
+                    "bin": {"yarn": "./dist/yarn.js"},
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        monkeypatch.setenv("NoDefaultCurrentDirectoryInExePath", "1")
+        monkeypatch.setenv(
+            "PATH",
+            os.pathsep.join((str(shim_dir), str(node_js_dir), str(node_exe_dir))),
+        )
+        monkeypatch.setenv("PATHEXT", pathext)
+        monkeypatch.setattr(sc, "IS_WINDOWS", True)
+
+        expected = (
+            [str(node_exe), str(entrypoint.resolve()), "--version"]
+            if expected_native
+            else [str(shim), "--version"]
+        )
+        assert sc.resolve_node_command("yarn", ["--version"], cwd=project) == expected
+
+    def test_resolve_node_command_accepts_corepack_0346_package_launcher(
+        self, tmp_path, monkeypatch
+    ):
+        """Use Corepack 0.34.6's exact shims/yarn.cmd package body."""
+        import json
+
+        from hermes_cli import _subprocess_compat as sc
+
+        node = tmp_path / "node.exe"
+        package = tmp_path / "corepack"
+        shim = package / "shims" / "yarn.cmd"
+        entrypoint = package / "dist" / "yarn.js"
+        shim.parent.mkdir(parents=True)
+        entrypoint.parent.mkdir()
+        node.touch()
+        entrypoint.touch()
+        shim.write_text(
+            "@SETLOCAL\r\n"
+            '@IF EXIST "%~dp0\\node.exe" (\r\n'
+            '  "%~dp0\\node.exe"  "%~dp0\\..\\dist\\yarn.js" %*\r\n'
+            ") ELSE (\r\n"
+            "  @SET PATHEXT=%PATHEXT:;.JS;=;%\r\n"
+            '  node  "%~dp0\\..\\dist\\yarn.js" %*\r\n'
+            ")\r\n",
+            encoding="utf-8",
+        )
+        (package / "package.json").write_text(
+            json.dumps(
+                {
+                    "name": "corepack",
+                    "version": "0.34.6",
+                    "bin": {"yarn": "./dist/yarn.js"},
+                }
+            ),
+            encoding="utf-8",
+        )
+        monkeypatch.setattr(sc, "IS_WINDOWS", True)
+        monkeypatch.setattr(
+            sc.shutil,
+            "which",
+            lambda name: str(shim) if name == "yarn" else str(node),
+        )
+
+        assert sc.resolve_node_command("yarn", ["--version"]) == [
+            str(node.resolve()),
+            str(entrypoint.resolve()),
+            "--version",
+        ]
+
+    def test_resolve_node_command_accepts_yarn_legacy_cmd_shim(
+        self, tmp_path, monkeypatch
+    ):
+        import json
+
+        from hermes_cli import _subprocess_compat as sc
+
+        node = tmp_path / "node.exe"
+        shim = tmp_path / "yarn.cmd"
+        package = tmp_path / "node_modules" / "yarn"
+        entrypoint = package / "bin" / "yarn.js"
+        entrypoint.parent.mkdir(parents=True)
+        node.touch()
+        entrypoint.touch()
+        shim.write_text(
+            '@IF EXIST "%~dp0\\node.exe" (\r\n'
+            '  "%~dp0\\node.exe" "%~dp0\\node_modules\\yarn\\bin\\yarn.js" %*\r\n'
+            ") ELSE (\r\n"
+            "  @SETLOCAL\r\n"
+            "  @SET PATHEXT=%PATHEXT:;.JS;=;%\r\n"
+            '  node "%~dp0\\node_modules\\yarn\\bin\\yarn.js" %*\r\n'
+            ")",
+            encoding="utf-8",
+        )
+        (package / "package.json").write_text(
+            json.dumps({"name": "yarn", "bin": {"yarn": "bin/yarn.js"}}),
+            encoding="utf-8",
+        )
+        monkeypatch.setattr(sc, "IS_WINDOWS", True)
+        monkeypatch.setattr(sc.shutil, "which", lambda name: str(shim))
+
+        assert sc.resolve_node_command("yarn", ["--version"]) == [
+            str(node.resolve()),
+            str(entrypoint.resolve()),
+            "--version",
+        ]
+
+    def test_resolve_node_command_accepts_yarn_classic_12222_launcher(
+        self, tmp_path, monkeypatch
+    ):
+        """Use Yarn Classic 1.22.22's exact bin/yarn.cmd body."""
+        import json
+
+        from hermes_cli import _subprocess_compat as sc
+
+        node = tmp_path / "node.exe"
+        package = tmp_path / "yarn"
+        shim = package / "bin" / "yarn.cmd"
+        entrypoint = package / "bin" / "yarn.js"
+        shim.parent.mkdir(parents=True)
+        node.touch()
+        entrypoint.touch()
+        shim.write_text('@echo off\r\nnode "%~dp0\\yarn.js" %*\r\n', encoding="utf-8")
+        (package / "package.json").write_text(
+            json.dumps(
+                {
+                    "name": "yarn",
+                    "version": "1.22.22",
+                    "bin": {"yarn": "./bin/yarn.js", "yarnpkg": "./bin/yarn.js"},
+                }
+            ),
+            encoding="utf-8",
+        )
+        monkeypatch.setattr(sc, "IS_WINDOWS", True)
+        monkeypatch.setattr(
+            sc.shutil,
+            "which",
+            lambda name: str(shim) if name == "yarn" else str(node),
+        )
+
+        assert sc.resolve_node_command("yarn", ["--version"]) == [
+            str(node),
+            str(entrypoint.resolve()),
+            "--version",
+        ]
+
+    def test_resolve_node_command_accepts_yarn_classic_12222_delegate(
+        self, tmp_path, monkeypatch
+    ):
+        """Resolve Yarn Classic's exact yarnpkg.cmd delegation without cmd.exe."""
+        import json
+
+        from hermes_cli import _subprocess_compat as sc
+
+        node = tmp_path / "node.exe"
+        package = tmp_path / "yarn"
+        yarn_shim = package / "bin" / "yarn.cmd"
+        yarnpkg_shim = package / "bin" / "yarnpkg.cmd"
+        entrypoint = package / "bin" / "yarn.js"
+        yarn_shim.parent.mkdir(parents=True)
+        node.touch()
+        entrypoint.touch()
+        yarn_shim.write_text(
+            '@echo off\r\nnode "%~dp0\\yarn.js" %*\r\n', encoding="utf-8"
+        )
+        yarnpkg_shim.write_text(
+            '@echo off\r\n"%~dp0\\yarn.cmd" %*\r\n', encoding="utf-8"
+        )
+        (package / "package.json").write_text(
+            json.dumps(
+                {
+                    "name": "yarn",
+                    "version": "1.22.22",
+                    "bin": {"yarn": "./bin/yarn.js", "yarnpkg": "./bin/yarn.js"},
+                }
+            ),
+            encoding="utf-8",
+        )
+        monkeypatch.setattr(sc, "IS_WINDOWS", True)
+        monkeypatch.setattr(
+            sc.shutil,
+            "which",
+            lambda name: str(yarnpkg_shim) if name == "yarnpkg" else str(node),
+        )
+
+        assert sc.resolve_node_command("yarnpkg", ["--version"]) == [
+            str(node),
+            str(entrypoint.resolve()),
+            "--version",
+        ]
+
+    @pytest.mark.parametrize(
+        ("command", "body"),
+        [
+            ("yarn", '@echo off\r\n@set FOO=bar\r\nnode "%~dp0\\yarn.js" %*\r\n'),
+            ("yarn", '@echo off\r\nnode --no-warnings "%~dp0\\yarn.js" %*\r\n'),
+            ("yarnpkg", '@echo off\r\n"%~dp0\\custom.cmd" %*\r\n'),
+        ],
+    )
+    def test_resolve_node_command_rejects_custom_yarn_classic_launcher(
+        self, tmp_path, monkeypatch, command, body
+    ):
+        from hermes_cli import _subprocess_compat as sc
+
+        shim = tmp_path / f"{command}.cmd"
+        (tmp_path / "yarn.js").touch()
+        shim.write_text(body, encoding="utf-8")
+        monkeypatch.setattr(sc, "IS_WINDOWS", True)
+        monkeypatch.setattr(sc.shutil, "which", lambda name: str(shim))
+
+        assert sc.resolve_node_command(command, ["--version"]) == [
+            str(shim),
+            "--version",
+        ]
+
+    @pytest.mark.parametrize(
+        "unsafe_fragment",
+        [
+            "@SET NODE_PATH=C:\\generated\\node_modules\r\n",
+            "@SET FOO=bar\r\n",
+        ],
+    )
+    def test_resolve_node_command_rejects_legacy_environment_assignment(
+        self, tmp_path, monkeypatch, unsafe_fragment
+    ):
+        from hermes_cli import _subprocess_compat as sc
+
+        shim = tmp_path / "yarn.cmd"
+        shim.write_text(
+            unsafe_fragment
+            + '@IF EXIST "%~dp0\\node.exe" (\r\n'
+            '  "%~dp0\\node.exe" "%~dp0\\node_modules\\yarn\\bin\\yarn.js" %*\r\n'
+            ") ELSE (\r\n"
+            "  @SETLOCAL\r\n"
+            "  @SET PATHEXT=%PATHEXT:;.JS;=;%\r\n"
+            '  node "%~dp0\\node_modules\\yarn\\bin\\yarn.js" %*\r\n'
+            ")",
+            encoding="utf-8",
+        )
+        monkeypatch.setattr(sc, "IS_WINDOWS", True)
+        monkeypatch.setattr(sc.shutil, "which", lambda name: str(shim))
+
+        assert sc.resolve_node_command("yarn", ["--version"]) == [
+            str(shim),
+            "--version",
+        ]
+
+    @pytest.mark.parametrize(
+        ("environment", "interpreter_args"),
+        [
+            ("@SET FOO=bar\r\n", ""),
+            ("", "--no-warnings "),
+            ("@SET FOO=bar\r\n", "--no-warnings "),
+        ],
+    )
+    def test_resolve_node_command_rejects_cmd_shim_flags_and_environment(
+        self, tmp_path, monkeypatch, environment, interpreter_args
+    ):
+        """Never drop shebang variables or interpreter arguments."""
+        import json
+
+        from hermes_cli import _subprocess_compat as sc
+
+        shim = tmp_path / "demo.cmd"
+        package = tmp_path / "node_modules" / "demo"
+        entrypoint = package / "demo.js"
+        package.mkdir(parents=True)
+        entrypoint.touch()
+        shim.write_text(
+            "@ECHO off\r\n"
+            "GOTO start\r\n"
+            ":find_dp0\r\n"
+            "SET dp0=%~dp0\r\n"
+            "EXIT /b\r\n"
+            ":start\r\n"
+            "SETLOCAL\r\n"
+            "CALL :find_dp0\r\n"
+            f"{environment}"
+            'IF EXIST "%dp0%\\node.exe" (\r\n'
+            '  SET "_prog=%dp0%\\node.exe"\r\n'
+            ") ELSE (\r\n"
+            '  SET "_prog=node"\r\n'
+            ")\r\n"
+            "endLocal & goto #_undefined_# 2>NUL || title %COMSPEC% & "
+            f'"%_prog%" {interpreter_args}'
+            '"%dp0%\\node_modules\\demo\\demo.js" %*\r\n',
+            encoding="utf-8",
+        )
+        (package / "package.json").write_text(
+            json.dumps({"name": "demo", "bin": {"demo": "demo.js"}}),
+            encoding="utf-8",
+        )
+        monkeypatch.setattr(sc, "IS_WINDOWS", True)
+        monkeypatch.setattr(sc.shutil, "which", lambda name: str(shim))
+
+        assert sc.resolve_node_command("demo", ["arg"]) == [str(shim), "arg"]
+
+    def test_resolve_node_command_rejects_legacy_shim_with_split_targets(
+        self, tmp_path, monkeypatch
+    ):
+        from hermes_cli import _subprocess_compat as sc
+
+        shim = tmp_path / "yarn.cmd"
+        shim.write_text(
+            '@IF EXIST "%~dp0\\node.exe" (\r\n'
+            '  "%~dp0\\node.exe" "%~dp0\\node_modules\\yarn\\bin\\yarn.js" %*\r\n'
+            ") ELSE (\r\n"
+            "  @SETLOCAL\r\n"
+            "  @SET PATHEXT=%PATHEXT:;.JS;=;%\r\n"
+            '  node "%~dp0\\custom.js" %*\r\n'
+            ")",
+            encoding="utf-8",
+        )
+        monkeypatch.setattr(sc, "IS_WINDOWS", True)
+        monkeypatch.setattr(sc.shutil, "which", lambda name: str(shim))
+
+        assert sc.resolve_node_command("yarn", ["--version"]) == [
+            str(shim),
+            "--version",
+        ]
+
+    def test_resolve_node_command_rejects_custom_npm_shim_preamble(
+        self, tmp_path, monkeypatch
+    ):
+        import json
+
+        from hermes_cli import _subprocess_compat as sc
+
+        shim = tmp_path / "npm.cmd"
+        package = tmp_path / "node_modules" / "npm"
+        entrypoint = package / "bin" / "npm-cli.js"
+        entrypoint.parent.mkdir(parents=True)
+        entrypoint.touch()
+        shim.write_text(
+            ":: custom wrapper\r\n"
+            "@ECHO off\r\n"
+            "GOTO start\r\n"
+            ":find_dp0\r\n"
+            "SET dp0=%~dp0\r\n"
+            "EXIT /b\r\n"
+            ":start\r\n"
+            "SETLOCAL\r\n"
+            "CALL :find_dp0\r\n"
+            'IF EXIST "%dp0%\\node.exe" (\r\n'
+            '  SET "_prog=%dp0%\\node.exe"\r\n'
+            ") ELSE (\r\n"
+            '  SET "_prog=node"\r\n'
+            ")\r\n"
+            "\r\n"
+            "endLocal & goto #_undefined_# 2>NUL || title %COMSPEC% & "
+            'set PATHEXT=%PATHEXT:;.JS;=;% & "%_prog%"  '
+            '"%dp0%\\node_modules\\npm\\bin\\npm-cli.js" %*\r\n',
+            encoding="utf-8",
+        )
+        (package / "package.json").write_text(
+            json.dumps({"name": "npm", "bin": {"npm": "bin/npm-cli.js"}}),
+            encoding="utf-8",
+        )
+        monkeypatch.setattr(sc, "IS_WINDOWS", True)
+        monkeypatch.setattr(sc.shutil, "which", lambda name: str(shim))
+
+        assert sc.resolve_node_command("npm", ["install"]) == [str(shim), "install"]
+
+    def test_resolve_node_command_keeps_unknown_batch_visible(
+        self, tmp_path, monkeypatch
+    ):
+        from hermes_cli import _subprocess_compat as sc
+
+        shim = tmp_path / "legacy.cmd"
+        shim.touch()
+        monkeypatch.setattr(sc, "IS_WINDOWS", True)
+        monkeypatch.setattr(sc.shutil, "which", lambda name: str(shim))
+
+        assert sc.resolve_node_command("legacy", ["arg"]) == [str(shim), "arg"]
+
+    def test_resolve_node_command_rejects_custom_batch_with_colliding_bin(
+        self, tmp_path, monkeypatch
+    ):
+        import json
+
+        from hermes_cli import _subprocess_compat as sc
+
+        shim = tmp_path / "legacy.cmd"
+        package = tmp_path / "node_modules" / "legacy"
+        entrypoint = package / "bin" / "legacy.js"
+        custom_target = tmp_path / "custom.js"
+        entrypoint.parent.mkdir(parents=True)
+        shim.write_text(
+            "@ECHO off\r\n"
+            "GOTO start\r\n"
+            ":find_dp0\r\n"
+            "SET dp0=%~dp0\r\n"
+            "EXIT /b\r\n"
+            ":start\r\n"
+            "SETLOCAL\r\n"
+            "CALL :find_dp0\r\n"
+            'IF EXIST "%dp0%\\node.exe" (\r\n'
+            '  SET "_prog=%dp0%\\node.exe"\r\n'
+            ") ELSE (\r\n"
+            '  SET "_prog=node"\r\n'
+            ")\r\n"
+            "\r\n"
+            "endLocal & goto #_undefined_# 2>NUL || title %COMSPEC% & "
+            'set PATHEXT=%PATHEXT:;.JS;=;% & "%_prog%"  '
+            '"%dp0%\\custom.js" %*\r\n',
+            encoding="utf-8",
+        )
+        entrypoint.touch()
+        custom_target.touch()
+        (package / "package.json").write_text(
+            json.dumps({"name": "legacy", "bin": {"legacy": "bin/legacy.js"}}),
+            encoding="utf-8",
+        )
+        monkeypatch.setattr(sc, "IS_WINDOWS", True)
+        monkeypatch.setattr(sc.shutil, "which", lambda name: str(shim))
+
+        assert sc.resolve_node_command("legacy", ["arg"]) == [str(shim), "arg"]
+
 
     @pytest.mark.windows_only
     def test_windows_detach_flags_exclude_detached_process(self):
@@ -453,6 +1809,19 @@ class TestSubprocessCompatHelpers:
         assert not sc.windows_detach_flags_without_breakaway() & 0x00000008, (
             "DETACHED_PROCESS must not be in the no-breakaway fallback either."
         )
+
+    @pytest.mark.parametrize(
+        ("is_windows", "expected"),
+        [(False, 0), (True, 0x08000000)],
+    )
+    def test_windows_hide_flags_match_platform(
+        self, monkeypatch, is_windows, expected
+    ):
+        from hermes_cli import _subprocess_compat as sc
+
+        monkeypatch.setattr(sc, "IS_WINDOWS", is_windows)
+
+        assert sc.windows_hide_flags() == expected
 
     @pytest.mark.windows_only
     def test_windows_detach_flags_includes_breakaway_from_job(self):


### PR DESCRIPTION
## Summary

MCP catalog bootstrap commands are manifest data, but they were previously passed to `subprocess.run(..., shell=True)`. This change moves that boundary to native argv execution:

- parse every bootstrap step into an argument vector;
- execute with `shell=False` and `stdin=DEVNULL`;
- keep catalog bootstrap steps separate rather than joining them into one shell program;
- reject malformed, escaping, ambiguous, or unsupported Windows launcher paths;
- preserve ordinary POSIX and Windows argv behavior, including PATH/PATHEXT lookup.

On Windows, the implementation parses command lines with CRT-compatible rules and converts only recognized npm, npx, Corepack, Yarn, and yarnpkg batch-launcher templates to provenance-checked native executables. Resolution is contained to the selected installation, uses the child working directory for path interpretation, and fails closed for unresolved or custom batch launchers. This also prevents current-directory executable planting from changing which launcher runs.

## Related work and review coverage

This proposal incorporates code and concrete review suggestions from the following related work. The canonical coverage PR #35545 remains open; this description does not claim that it has been replaced:

- #34973 identified the same shell-execution problem. Its relevant MCP shell-hardening direction is included; its unrelated SSRF changes are deliberately excluded from this focused fix.
- #35545 supplied the earlier direct implementation and malformed-command handling. This version incorporates that behavior while preserving the intentionally shell-oriented `quick_commands` feature and addressing review gaps around Windows `.cmd` launchers, empty commands, and start failures.
- #81367 supplied regression-test scenarios for literal shell metacharacters and separate bootstrap steps; those scenarios are included here.
- #81497 covered empty/missing bootstrap commands and process-start failures; those cases are included here.
- #83731 covered the basic plain-command and shell-metacharacter behavior; those cases are included here.
- Review feedback from liuhao1024 is reflected in malformed-input handling and the narrow execution boundary. Review feedback from teknium1 is reflected in the Windows `.cmd` compatibility design. Radical Edward's earlier implementation work is incorporated as the foundation of the consolidated fix.

The commit trailers credit Radical Edward, liuhao1024, teknium1, and Adolanium for the concrete code, review suggestions, and test cases incorporated into this version.

## Scope

The security invariant is narrow: catalog bootstrap strings never cross a command-shell boundary. This PR does not change the intentionally shell-based user-configured `quick_commands` feature and does not include the unrelated SSRF work from #34973.

## Previously recorded validation

- Focused MCP catalog suite: 62 passed.
- Combined focused MCP/Windows suite: 151 passed and 13 skipped; two unrelated import tests could not run under the bare host Python because `python-dotenv` is not installed there.
- Previously refreshed suite: 153 passed and 13 skipped.
- Earlier implementation validation: 162 focused tests, 231 broader tests, 49 focused resolver/path/launcher tests, and 200,000 CRT parser round trips passed, together with Ruff, ty, `py_compile`, and diff checks.
- Deep security and compatibility Cycle 14 reviews were clean. A prior CodeRabbit PATHEXT finding was fixed; the final retry was unavailable because of the provider seat limit and was treated as fail-open after independent validation.
- Native Windows execution was not available in this environment; Windows behavior is covered by deterministic mocked-platform and parser/resolver tests.

## Current compatibility boundary

A benign comparison against current main confirmed that a custom catalog step containing `first-command && second-command` changes behavior: main runs both commands, while this published branch passes `&& second-command` as literal arguments to the first executable. The branch does not explicitly reject or migrate that syntax. Shipped catalog examples inspected use separate steps, but custom compound commands remain a compatibility concern.

The previous CI failure was an administrative review-label gate. Its Windows test job passed; this is not evidence of a native-Windows npm runtime check. The validation above is retained from the published implementation record and was not rerun for this metadata update. Native Windows npm execution remains unverified here.

Updated by GPT-6 Astra with ultra reasoning in Codex Desktop. The account owner loosely reviews these actions and receives the usual GitHub notifications.

Fixes #81365
