### PR TITLE
fix(agent): skip inaccessible paths in git-root prompt walk

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -90,11 +90,23 @@ def _find_git_root(start: Path) -> Optional[Path]:
 
     Returns the directory containing ``.git``, or ``None`` if we hit the
     filesystem root without finding one.
+
+    Inaccessible parents (PermissionError/OSError from ``exists()``) are
+    skipped so gateway profiles with an unreadable ``terminal.cwd`` still
+    build a system prompt (#85758).
     """
-    current = start.resolve()
+    try:
+        current = start.resolve()
+    except OSError:
+        # Unreadable start path — treat as no git root rather than crash prompt build.
+        return None
     for parent in [current, *current.parents]:
-        if (parent / ".git").exists():
-            return parent
+        try:
+            if (parent / ".git").exists():
+                return parent
+        except OSError:
+            # PermissionError is an OSError; also catch other stat failures.
+            continue
     return None
 
 
@@ -109,7 +121,10 @@ def _find_hermes_md(cwd: Path) -> Optional[Path]:
     ``None`` if nothing is found.
     """
     stop_at = _find_git_root(cwd)
-    current = cwd.resolve()
+    try:
+        current = cwd.resolve()
+    except OSError:
+        return None
 
     # When there is no git root, only check cwd itself – walking parents
     # could pick up a .hermes.md planted in /tmp, /home, etc.
@@ -118,8 +133,12 @@ def _find_hermes_md(cwd: Path) -> Optional[Path]:
     for directory in search_dirs:
         for name in _HERMES_MD_NAMES:
             candidate = directory / name
-            if candidate.is_file():
-                return candidate
+            try:
+                if candidate.is_file():
+                    return candidate
+            except OSError:
+                # PermissionError is an OSError; skip inaccessible candidates.
+                continue
         if stop_at and directory == stop_at:
             break
     return None

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -626,6 +626,49 @@ class TestFindGitRoot:
         if result is not None:
             assert (result / ".git").exists()
 
+    def test_skips_permission_error_on_exists(self, tmp_path):
+        """_find_git_root must not raise when exists() raises PermissionError (#85758)."""
+        from pathlib import Path
+        from unittest.mock import patch
+
+        start = tmp_path / "work"
+        start.mkdir()
+        with patch.object(Path, "exists", side_effect=PermissionError("Permission denied")):
+            assert _find_git_root(start) is None
+
+    def test_permission_error_on_resolve_returns_none(self, tmp_path):
+        """Unreadable start.resolve() must not crash prompt build (#85758)."""
+        from pathlib import Path
+        from unittest.mock import patch
+
+        start = tmp_path / "work"
+        start.mkdir()
+        with patch.object(Path, "resolve", side_effect=PermissionError("Permission denied")):
+            assert _find_git_root(start) is None
+
+    def test_permission_error_continues_to_accessible_git(self, tmp_path):
+        """Skip inaccessible parents and still find a higher accessible .git (#85758)."""
+        from pathlib import Path
+        from unittest.mock import patch
+
+        root_git = tmp_path / "root_git"
+        denied = root_git / "denied"
+        work = denied / "work"
+        work.mkdir(parents=True)
+        (root_git / ".git").mkdir()
+
+        original_exists = Path.exists
+
+        def patched_exists(self):
+            # Walk order: work → denied → root_git → ...
+            # Simulate denied/.git being unreadable while root_git/.git works.
+            if self == denied / ".git":
+                raise PermissionError("Permission denied")
+            return original_exists(self)
+
+        with patch.object(Path, "exists", patched_exists):
+            assert _find_git_root(work) == root_git
+
 
 class TestStripYamlFrontmatter:
     def test_strips_frontmatter(self):


### PR DESCRIPTION
## Problem

Gateway profiles can set `terminal.cwd` to a path the process user cannot access (common Docker sandbox default: `/root` while the gateway runs as a non-root user). During system prompt construction, `_find_git_root()` called `Path.exists()` on parent `/.git` candidates. `exists()` uses `os.stat()` and **raises** `PermissionError` on inaccessible directories instead of returning `False`.

That exception escapes prompt build → every gateway message fails with “Sorry, I encountered an unexpected error.”

## Root cause

`agent/prompt_builder.py` — `_find_git_root()` (and sibling `_find_hermes_md` file checks) had no `OSError` handling around `resolve()` / `exists()` / `is_file()`.

## Fix

- Catch `OSError` on `start.resolve()` and return `None`
- Catch `OSError` on each `(parent / ".git").exists()` and continue the walk
- Same pattern for `_find_hermes_md` candidate `is_file()` and `cwd.resolve()`

Matches existing PermissionError house style elsewhere in the agent (`#6214` subdirectory hints).

## Why it matters

Unreadable `terminal.cwd` is a **hard outage** for gateway agents (Telegram/Discord/etc.), not a degraded feature. Smallest fix restores prompt build without requiring operators to change sandbox layout first.

## Test plan

```bash
python -m pytest tests/agent/test_prompt_builder.py::TestFindGitRoot -q
```

**6 passed** @ `1c19ac338`

- `test_skips_permission_error_on_exists`
- `test_permission_error_on_resolve_returns_none`
- `test_permission_error_continues_to_accessible_git`
- plus existing find-git-root cases

## Risk

Low. Fail-open toward “no git root / no hermes.md” — same as a missing `.git`, which already skips parent hermes.md walks for injection safety.

## Closest work

`none found` — no open PR for #85758 / `_find_git_root` PermissionError.

Fixes #85758

### Acceptance retest (2026-08-18)
Rebased onto current `main`. Mini proof @ `f479c57ea`: tests/agent/test_prompt_builder.py -k git_root/permission — 6 passed.

## Mini retest (2026-08-24 acceptance)
- Head `78e00793ec` · pytest -k "git_root or prompt_builder" → 76 passed (+6 skip)
- Rebased onto current upstream `main` (force-with-lease, pre-review)
