### PR TITLE
fix(matrix): apply the inviter allowlist to reconciled pending invites

### DIFF
--- a/contributors/emails/iain@orangesquash.org.uk
+++ b/contributors/emails/iain@orangesquash.org.uk
@@ -1,0 +1,1 @@
+iainlane

--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -3790,14 +3790,7 @@ class MatrixAdapter(BasePlatformAdapter):
         # federated Matrix user could invite the bot into arbitrary rooms,
         # exposing its presence and metadata. Mirrors the allow-list gate
         # used on the message/reaction paths.
-        allow_all = os.getenv("GATEWAY_ALLOW_ALL_USERS", "").lower() in {
-            "true",
-            "1",
-            "yes",
-        }
-        if not allow_all and not (
-            self._allowed_user_ids and inviter in self._allowed_user_ids
-        ):
+        if not self._is_authorized_inviter(inviter):
             logger.warning(
                 "Matrix: rejecting invite to %s from unauthorized user %s",
                 room_id,
@@ -3819,6 +3812,22 @@ class MatrixAdapter(BasePlatformAdapter):
             is_direct=is_direct and bool(inviter),
             inviter=inviter,
         )
+
+    def _is_authorized_inviter(self, inviter: str) -> bool:
+        """Whether an invite from this user may be auto-joined.
+
+        Fails closed: an unknown (empty) inviter or an empty allowlist
+        rejects the invite, unless GATEWAY_ALLOW_ALL_USERS opts out of
+        gating entirely.
+        """
+        allow_all = os.getenv("GATEWAY_ALLOW_ALL_USERS", "").lower() in {
+            "true",
+            "1",
+            "yes",
+        }
+        if allow_all:
+            return True
+        return bool(self._allowed_user_ids and inviter in self._allowed_user_ids)
 
     async def _join_room_by_id(self, room_id: str) -> bool:
         """Join a room by ID and refresh local caches on success."""
@@ -3896,6 +3905,25 @@ class MatrixAdapter(BasePlatformAdapter):
             # direct invite joined via reconciliation is never recorded in
             # m.direct and gets misclassified as a group.
             is_direct, inviter = self._extract_invite_dm_signal(invited_room)
+            # The inviter allowlist gate from _on_invite applies here too.
+            # Without it, an invite from an arbitrary federated user that
+            # arrives while the gateway is down would be auto-joined on
+            # restart, bypassing the gate. An inviter missing from the
+            # stripped invite state fails closed, like an empty sender in
+            # _on_invite.
+            if not self._is_authorized_inviter(inviter):
+                logger.warning(
+                    "Matrix: rejecting invite to %s from unauthorized user %s",
+                    room_id,
+                    inviter,
+                )
+                continue
+            if is_direct and not inviter:
+                logger.warning(
+                    "Matrix: joining direct invite to %s without recording it "
+                    "in m.direct because the invite state has no inviter",
+                    room_id,
+                )
             logger.info(
                 "Matrix: reconciling pending invite for %s (is_direct=%s)",
                 room_id,
@@ -3914,6 +3942,9 @@ class MatrixAdapter(BasePlatformAdapter):
         ``is_direct`` flag from the original invite; its sender is the
         inviter. Returns ``(False, "")`` when the signal is absent.
         """
+        if not self._user_id:
+            return False, ""
+
         if not isinstance(invited_room, dict):
             return False, ""
 

--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -3887,11 +3887,61 @@ class MatrixAdapter(BasePlatformAdapter):
         invites = rooms.get("invite", {})
         if not isinstance(invites, dict):
             return
-        for room_id in invites:
+        for room_id, invited_room in invites.items():
             if room_id in self._joined_rooms:
                 continue
-            logger.info("Matrix: reconciling pending invite for %s", room_id)
-            self._schedule_invite_join(str(room_id))
+            # A pending invite reconciled here (e.g. after a gateway
+            # restart) never fires _on_invite, so the DM signal must be
+            # read from the stripped invite state instead. Without it, a
+            # direct invite joined via reconciliation is never recorded in
+            # m.direct and gets misclassified as a group.
+            is_direct, inviter = self._extract_invite_dm_signal(invited_room)
+            logger.info(
+                "Matrix: reconciling pending invite for %s (is_direct=%s)",
+                room_id,
+                is_direct,
+            )
+            self._schedule_invite_join(
+                str(room_id),
+                is_direct=is_direct and bool(inviter),
+                inviter=inviter,
+            )
+
+    def _extract_invite_dm_signal(self, invited_room: Any) -> tuple[bool, str]:
+        """Read the is_direct flag and inviter from a room's invite_state.
+
+        The stripped ``m.room.member`` event for our own user carries the
+        ``is_direct`` flag from the original invite; its sender is the
+        inviter. Returns ``(False, "")`` when the signal is absent.
+        """
+        if not isinstance(invited_room, dict):
+            return False, ""
+
+        invite_state = invited_room.get("invite_state", {})
+        if not isinstance(invite_state, dict):
+            return False, ""
+
+        events = invite_state.get("events", [])
+        if not isinstance(events, list):
+            return False, ""
+
+        for event in events:
+            if not isinstance(event, dict):
+                continue
+            if event.get("type") != "m.room.member":
+                continue
+            if self._user_id and event.get("state_key") != self._user_id:
+                continue
+
+            content = event.get("content", {})
+            if not isinstance(content, dict):
+                continue
+            if content.get("membership") != "invite":
+                continue
+
+            return bool(content.get("is_direct")), str(event.get("sender", ""))
+
+        return False, ""
 
     # ------------------------------------------------------------------
     # Reactions (send, receive, processing lifecycle)

--- a/tests/gateway/test_matrix_dm_invite_recording.py
+++ b/tests/gateway/test_matrix_dm_invite_recording.py
@@ -183,34 +183,20 @@ class TestPendingInviteReconciliationRecordsDM:
         )
         assert adapter._dm_rooms.get("!dm_room:example.org") is True
 
-    @pytest.mark.parametrize(
-        "invite_state",
-        [
-            pytest.param(None, id="no-invite-state"),
-            pytest.param({"events": []}, id="empty-events"),
-            pytest.param(
-                {"events": [_member_invite_event(is_direct=False)]},
-                id="not-direct",
-            ),
-            pytest.param(
-                {"events": [_member_invite_event(state_key="@other:example.org")]},
-                id="member-event-for-other-user",
-            ),
-            pytest.param(
-                {"events": [_member_invite_event(sender="")]},
-                id="missing-inviter",
-            ),
-        ],
-    )
     @pytest.mark.asyncio
-    async def test_reconciled_invite_without_dm_signal_does_not_record(
-        self, invite_state
-    ):
+    async def test_reconciled_non_direct_invite_does_not_record(self):
+        """A pending invite without the is_direct flag joins (the inviter
+        is allow-listed) but records nothing in m.direct. Invites whose
+        inviter cannot be read from the stripped state at all are covered
+        by test_matrix_pending_invite_auth.py: they are rejected outright
+        by the inviter allowlist gate, so no join happens either."""
         adapter = _make_adapter()
         adapter._join_room_by_id = AsyncMock(return_value=True)
         adapter._record_dm_room = AsyncMock()
 
-        sync_data = _invite_sync_data(invite_state=invite_state)
+        sync_data = _invite_sync_data(
+            invite_state={"events": [_member_invite_event(is_direct=False)]}
+        )
         adapter._schedule_pending_invite_joins(sync_data)
         await self._drain_invite_tasks(adapter)
 

--- a/tests/gateway/test_matrix_dm_invite_recording.py
+++ b/tests/gateway/test_matrix_dm_invite_recording.py
@@ -102,6 +102,123 @@ class TestOnInviteRecordsDM:
 
 
 # ---------------------------------------------------------------------------
+# _schedule_pending_invite_joins DM recording
+# ---------------------------------------------------------------------------
+
+
+def _member_invite_event(
+    state_key="@hermes:example.org",
+    sender="@alice:example.org",
+    is_direct=True,
+    membership="invite",
+):
+    """Create a stripped m.room.member event as found in invite_state."""
+    return {
+        "type": "m.room.member",
+        "state_key": state_key,
+        "sender": sender,
+        "content": {"membership": membership, "is_direct": is_direct},
+    }
+
+
+def _invite_sync_data(room_id="!dm_room:example.org", invite_state=None):
+    """Create a sync payload with one pending invite room."""
+    room = {} if invite_state is None else {"invite_state": invite_state}
+    return {"rooms": {"invite": {room_id: room}}, "next_batch": "s1"}
+
+
+class TestPendingInviteReconciliationRecordsDM:
+    """_schedule_pending_invite_joins threads the DM signal from invite_state.
+
+    After a gateway restart a direct invite is reconciled from sync's
+    ``rooms.invite`` rather than a live invite event. The stripped
+    ``m.room.member`` event in ``invite_state`` still carries ``is_direct``
+    and the inviter; without threading them through, the room is never
+    recorded in ``m.direct`` and is misclassified as a group (surfaced by
+    the triage of #62493).
+    """
+
+    @staticmethod
+    async def _drain_invite_tasks(adapter):
+        """Await any tasks _schedule_invite_join spawned."""
+        for task in list(adapter._invite_join_tasks.values()):
+            await task
+
+    @pytest.mark.asyncio
+    async def test_reconciled_direct_invite_records_dm(self):
+        adapter = _make_adapter()
+        adapter._join_room_by_id = AsyncMock(return_value=True)
+        adapter._record_dm_room = AsyncMock()
+
+        sync_data = _invite_sync_data(
+            invite_state={"events": [_member_invite_event(is_direct=True)]}
+        )
+        adapter._schedule_pending_invite_joins(sync_data)
+        await self._drain_invite_tasks(adapter)
+
+        adapter._join_room_by_id.assert_awaited_once_with("!dm_room:example.org")
+        adapter._record_dm_room.assert_awaited_once_with(
+            "!dm_room:example.org", "@alice:example.org"
+        )
+
+    @pytest.mark.asyncio
+    async def test_reconciled_direct_invite_ends_up_classified_as_dm(self):
+        """End to end: the reconciled room lands in _dm_rooms as a DM."""
+        adapter = _make_adapter()
+        adapter._join_room_by_id = AsyncMock(return_value=True)
+        adapter._client = MagicMock()
+        adapter._client.get_account_data = AsyncMock(
+            side_effect=Exception("M_NOT_FOUND")
+        )
+        adapter._client.set_account_data = AsyncMock()
+
+        sync_data = _invite_sync_data(
+            invite_state={"events": [_member_invite_event(is_direct=True)]}
+        )
+        adapter._schedule_pending_invite_joins(sync_data)
+        await self._drain_invite_tasks(adapter)
+
+        adapter._client.set_account_data.assert_awaited_once_with(
+            "m.direct", {"@alice:example.org": ["!dm_room:example.org"]}
+        )
+        assert adapter._dm_rooms.get("!dm_room:example.org") is True
+
+    @pytest.mark.parametrize(
+        "invite_state",
+        [
+            pytest.param(None, id="no-invite-state"),
+            pytest.param({"events": []}, id="empty-events"),
+            pytest.param(
+                {"events": [_member_invite_event(is_direct=False)]},
+                id="not-direct",
+            ),
+            pytest.param(
+                {"events": [_member_invite_event(state_key="@other:example.org")]},
+                id="member-event-for-other-user",
+            ),
+            pytest.param(
+                {"events": [_member_invite_event(sender="")]},
+                id="missing-inviter",
+            ),
+        ],
+    )
+    @pytest.mark.asyncio
+    async def test_reconciled_invite_without_dm_signal_does_not_record(
+        self, invite_state
+    ):
+        adapter = _make_adapter()
+        adapter._join_room_by_id = AsyncMock(return_value=True)
+        adapter._record_dm_room = AsyncMock()
+
+        sync_data = _invite_sync_data(invite_state=invite_state)
+        adapter._schedule_pending_invite_joins(sync_data)
+        await self._drain_invite_tasks(adapter)
+
+        adapter._join_room_by_id.assert_awaited_once_with("!dm_room:example.org")
+        adapter._record_dm_room.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
 # _record_dm_room
 # ---------------------------------------------------------------------------
 

--- a/tests/gateway/test_matrix_pending_invite_auth.py
+++ b/tests/gateway/test_matrix_pending_invite_auth.py
@@ -1,0 +1,190 @@
+"""Tests for the inviter allowlist gate on pending-invite reconciliation.
+
+``_on_invite`` only auto-joins when the inviter is allow-listed, but a
+pending invite reconciled from sync's ``rooms.invite`` after a gateway
+restart never fires ``_on_invite``. ``_schedule_pending_invite_joins``
+must apply the same gate, reading the inviter from the stripped invite
+state, or an invite from an arbitrary federated user that arrives while
+the gateway is down gets auto-joined on restart.
+"""
+
+import logging
+import time
+from unittest.mock import AsyncMock
+
+import pytest
+
+from gateway.config import PlatformConfig
+
+
+def _make_adapter():
+    """Create a MatrixAdapter with mocked config and a one-user allowlist."""
+    from plugins.platforms.matrix.adapter import MatrixAdapter
+
+    config = PlatformConfig(
+        enabled=True,
+        token="syt_test_token",
+        extra={
+            "homeserver": "https://matrix.example.org",
+            "user_id": "@hermes:example.org",
+        },
+    )
+    adapter = MatrixAdapter(config)
+    adapter._text_batch_delay_seconds = 0
+    adapter.handle_message = AsyncMock()
+    adapter._startup_ts = time.time() - 10
+    adapter._allowed_user_ids = {"@alice:example.org"}
+    adapter._join_room_by_id = AsyncMock(return_value=True)
+    adapter._record_dm_room = AsyncMock()
+    return adapter
+
+
+def _member_invite_event(
+    state_key="@hermes:example.org",
+    sender="@alice:example.org",
+    is_direct=True,
+    membership="invite",
+):
+    """Create a stripped m.room.member event as found in invite_state."""
+    return {
+        "type": "m.room.member",
+        "state_key": state_key,
+        "sender": sender,
+        "content": {"membership": membership, "is_direct": is_direct},
+    }
+
+
+def _invite_sync_data(room_id="!pending_room:example.org", invite_state=None):
+    """Create a sync payload with one pending invite room."""
+    room = {} if invite_state is None else {"invite_state": invite_state}
+    return {"rooms": {"invite": {room_id: room}}, "next_batch": "s1"}
+
+
+async def _drain_invite_tasks(adapter):
+    """Await any tasks _schedule_invite_join spawned."""
+    for task in list(adapter._invite_join_tasks.values()):
+        await task
+
+
+class TestPendingInviteAuthorization:
+    """_schedule_pending_invite_joins applies _on_invite's inviter gate.
+
+    Rejection mirrors _on_invite exactly: no join is scheduled (so no
+    entry lands in _invite_join_tasks), nothing is recorded in m.direct,
+    and the pending invite is otherwise left untouched.
+    """
+
+    @pytest.mark.asyncio
+    async def test_allowed_inviter_is_joined(self):
+        adapter = _make_adapter()
+
+        sync_data = _invite_sync_data(invite_state={"events": [_member_invite_event()]})
+        adapter._schedule_pending_invite_joins(sync_data)
+        await _drain_invite_tasks(adapter)
+
+        adapter._join_room_by_id.assert_awaited_once_with("!pending_room:example.org")
+        adapter._record_dm_room.assert_awaited_once_with(
+            "!pending_room:example.org", "@alice:example.org"
+        )
+
+    @pytest.mark.asyncio
+    async def test_unknown_bot_user_id_fails_closed(self):
+        adapter = _make_adapter()
+        adapter._user_id = ""
+
+        sync_data = _invite_sync_data(invite_state={"events": [_member_invite_event()]})
+        adapter._schedule_pending_invite_joins(sync_data)
+        await _drain_invite_tasks(adapter)
+
+        adapter._join_room_by_id.assert_not_awaited()
+        adapter._record_dm_room.assert_not_awaited()
+        assert adapter._invite_join_tasks == {}
+
+    @pytest.mark.parametrize(
+        "invite_state",
+        [
+            pytest.param(
+                {"events": [_member_invite_event(sender="@mallory:evil.example")]},
+                id="non-allowed-inviter",
+            ),
+            pytest.param(None, id="no-invite-state"),
+            pytest.param({"events": []}, id="empty-events"),
+            pytest.param(
+                {"events": [_member_invite_event(state_key="@other:example.org")]},
+                id="member-event-for-other-user",
+            ),
+            pytest.param(
+                {"events": [_member_invite_event(sender="")]},
+                id="missing-inviter",
+            ),
+        ],
+    )
+    @pytest.mark.asyncio
+    async def test_unauthorized_or_unknown_inviter_is_not_joined(self, invite_state):
+        """An inviter outside the allowlist, or one that cannot be read
+        from the stripped invite state at all, fails closed like
+        _on_invite: no join is scheduled and nothing is recorded."""
+        adapter = _make_adapter()
+
+        sync_data = _invite_sync_data(invite_state=invite_state)
+        adapter._schedule_pending_invite_joins(sync_data)
+        await _drain_invite_tasks(adapter)
+
+        adapter._join_room_by_id.assert_not_awaited()
+        adapter._record_dm_room.assert_not_awaited()
+        assert adapter._invite_join_tasks == {}
+
+    @pytest.mark.asyncio
+    async def test_empty_allowlist_fails_closed(self):
+        """With no allowlist configured, _on_invite rejects every invite;
+        reconciliation must do the same."""
+        adapter = _make_adapter()
+        adapter._allowed_user_ids = set()
+
+        sync_data = _invite_sync_data(invite_state={"events": [_member_invite_event()]})
+        adapter._schedule_pending_invite_joins(sync_data)
+        await _drain_invite_tasks(adapter)
+
+        adapter._join_room_by_id.assert_not_awaited()
+        adapter._record_dm_room.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_allow_all_env_bypasses_gate(self, monkeypatch):
+        """GATEWAY_ALLOW_ALL_USERS disables the gate, exactly as it does
+        for _on_invite, even when the inviter is unknown."""
+        monkeypatch.setenv("GATEWAY_ALLOW_ALL_USERS", "true")
+        adapter = _make_adapter()
+        adapter._allowed_user_ids = set()
+
+        sync_data = _invite_sync_data(invite_state=None)
+        adapter._schedule_pending_invite_joins(sync_data)
+        await _drain_invite_tasks(adapter)
+
+        adapter._join_room_by_id.assert_awaited_once_with("!pending_room:example.org")
+        adapter._record_dm_room.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_allow_all_logs_direct_invite_without_inviter(
+        self, monkeypatch, caplog
+    ):
+        monkeypatch.setenv("GATEWAY_ALLOW_ALL_USERS", "true")
+        adapter = _make_adapter()
+        adapter._allowed_user_ids = set()
+
+        sync_data = _invite_sync_data(
+            invite_state={"events": [_member_invite_event(sender="")]}
+        )
+        with caplog.at_level(
+            logging.WARNING,
+            logger="plugins.platforms.matrix.adapter",
+        ):
+            adapter._schedule_pending_invite_joins(sync_data)
+            await _drain_invite_tasks(adapter)
+
+        adapter._join_room_by_id.assert_awaited_once_with("!pending_room:example.org")
+        adapter._record_dm_room.assert_not_awaited()
+        assert [record.getMessage() for record in caplog.records] == [
+            "Matrix: joining direct invite to !pending_room:example.org "
+            "without recording it in m.direct because the invite state "
+            "has no inviter"
+        ]


### PR DESCRIPTION
## What does this PR do?

`_on_invite` gates Matrix auto-join on an allow-listed inviter: unless
`GATEWAY_ALLOW_ALL_USERS` is set, an invite is rejected when the inviter is
not in `_allowed_user_ids`. The restart-reconciliation path has no such
gate: `_schedule_pending_invite_joins` reconciles every room in
`rooms.invite` from the sync response and schedules a join for each one. An
invite from an arbitrary federated user that arrives while the gateway is
down is therefore auto-joined on restart, bypassing the allowlist.

This PR applies the same gate on the reconciliation path. The inviter is
read from the stripped invite state (the `m.room.member` event for our own
user; its sender is the inviter), the gate logic is extracted into a shared
`_is_authorized_inviter` helper so the two paths cannot drift, and an
invite with an unreadable inviter fails closed, matching how `_on_invite`
treats an empty sender. Rejected invites are logged and left pending on the
server, exactly like a rejected live invite.

The first commit is shared with #51802 (it reads the DM signal from the
stripped invite state and records reconciled direct invites in `m.direct`);
this PR reuses its inviter extraction. The two PRs compose in either order;
whichever lands second rebases onto an identical commit.

## Related Issue

No existing issue; found while working on the invite-reconciliation path
for #51802 (itself surfaced by the triage of #62493).

## Type of Change

- [x] 🔒 Security fix

## Changes Made

- `plugins/platforms/matrix/adapter.py`: extract the `_on_invite` allowlist
  gate into `_is_authorized_inviter` and apply it in
  `_schedule_pending_invite_joins`, failing closed on an unknown inviter.
- `tests/gateway/test_matrix_pending_invite_auth.py` (new): allowed inviter
  is joined and DM-recorded; parametrised reject cases (non-allowed
  inviter, missing or malformed invite state, missing sender) assert no
  join and no `m.direct` write; empty allowlist fails closed;
  `GATEWAY_ALLOW_ALL_USERS=true` bypasses the gate, mirroring `_on_invite`.
- `tests/gateway/test_matrix_dm_invite_recording.py`: the signal-less
  reconciliation cases move to the new file (they are now rejected rather
  than joined-without-recording).

## How to Test

1. `pytest tests/gateway/test_matrix_pending_invite_auth.py -q` (10 tests).
2. To see the bug on `main`: the reject-case tests fail, showing the join
   task being scheduled for a non-allowed inviter.
3. `pytest tests/gateway/test_matrix.py tests/gateway/test_matrix_dm_invite_recording.py -q`:
   129 passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass (targeted suites run
  locally: 129 passed across the three Matrix invite/DM test files; the
  full suite runs in CI)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Review follow-up (2026-08-16)

This is now the base of the Matrix stack. Pending-invite reconciliation applies the same inviter allowlist as live invites, and the downstream DM branch no longer carries a duplicate path that could be merged without this gate.

Validation: the pending-invite and DM-invite suites — 17 passed; targeted Ruff checks passed.

Matrix merge order: **#87258 → #51802 → #51804 → #62088**.
