### PR TITLE
fix(models): GLM-5.3 context length is 1M, not the 202K glm fallback

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -488,6 +488,7 @@ DEFAULT_CONTEXT_LENGTHS = {
     # ensures "glm-5.2" resolves to 1M while older variants still hit the
     # generic 202K fallback.
     "glm-5.2": 1_048_576,
+    "glm-5.3": 1_048_576,
     "glm": 202752,
     # xAI Grok — xAI /v1/models does not return context_length metadata,
     # so these hardcoded fallbacks prevent Hermes from probing-down to

--- a/tests/agent/test_model_metadata.py
+++ b/tests/agent/test_model_metadata.py
@@ -819,6 +819,25 @@ class TestGetModelContextLength:
         )
         assert result == 202752  # "glm" entry in DEFAULT_CONTEXT_LENGTHS
 
+    @patch("agent.model_metadata.fetch_model_metadata")
+    @patch("agent.model_metadata.fetch_endpoint_model_metadata")
+    def test_glm_5_3_resolves_to_1m(self, mock_endpoint_fetch, mock_fetch):
+        """GLM-5.3 ships with a 1M context window (like 5.2).
+
+        Z.AI's /v1/models returns no context_length metadata, so resolution
+        falls through to DEFAULT_CONTEXT_LENGTHS. Without an explicit entry,
+        "glm-5.3" substring-matched the generic "glm" fallback (202,752) and
+        Hermes compressed context ~5x too early on the coding endpoint.
+        Verified empirically: needle-in-a-haystack retrieval at 1,010,121
+        prompt tokens on api.z.ai/api/coding/paas/v4 succeeded; docs
+        https://docs.z.ai/guides/llm/glm-5.3.md lists Context Length: 1M.
+        """
+        mock_fetch.return_value = {}
+        mock_endpoint_fetch.return_value = {}
+
+        result = get_model_context_length("glm-5.3")
+        assert result == 1_048_576
+
 
 
 


### PR DESCRIPTION
## Problem

Hermes resolves glm-5.3's context window to **202,752 tokens** (the generic `"glm"` entry in `DEFAULT_CONTEXT_LENGTHS`) because:

- Z.AI's `/v1/models` returns no `context_length` metadata (only `id`/`created`/`owned_by`), so live probing can't learn it, and
- `glm-5.3` is absent from the hardcoded catalog while `glm-5.2` has an explicit 1M entry.

Effect: the session banner reports `◆ Context: 202K tokens (detected)`, and Hermes budgets tokens / triggers context compression ~5x too early on the coding endpoint (`api.z.ai/api/coding/paas/v4`).

## Verification

**Official docs** — [docs.z.ai/guides/llm/glm-5.3.md](https://docs.z.ai/guides/llm/glm-5.3.md): Context Length **1M**, Max Output Tokens **128K**.

**Live needle-in-a-haystack test** against `glm-5.3` on `api.z.ai/api/coding/paas/v4` — a secret phrase buried mid-prompt, model asked to quote it exactly:

| Prompt tokens | Latency | Retrieval |
|---|---|---|
| 203,982 | 38.9s | ✅ exact |
| 291,408 | 13.3s | ✅ exact |
| 485,646 | 24.3s | ✅ exact |
| 777,003 | 40.5s | ✅ exact |
| **1,010,121** | 56.6s | ✅ exact |

No errors, no truncation, up to 1.01M prompt tokens — consistent with a 1M window (same as glm-5.2, per the existing table comment's empirical verification of 5.2).

## Change

- `agent/model_metadata.py`: add `"glm-5.3": 1_048_576` next to the existing `glm-5.2` entry (longest-key-first substring matching then resolves glm-5.3 before the generic `glm` fallback).
- `tests/agent/test_model_metadata.py`: regression test `test_glm_5_3_resolves_to_1m` — all probes mocked empty, asserts the catalog returns 1,048,576.

## Test plan

- [x] `venv/bin/python -m pytest tests/agent/test_model_metadata.py -k glm -q` → 1 passed
- [x] Full test file unaffected (only additive entry; 82 tests in file)
- [x] No behavior change for glm / glm-5 / glm-5.1 / glm-5.2 (longest-key-first matching preserved)