### PR TITLE
fix(providers): fail closed on malformed base URL in get_hostname

### DIFF
--- a/providers/base.py
+++ b/providers/base.py
@@ -122,12 +122,20 @@ class ProviderProfile:
 
         Uses self.hostname if set explicitly, otherwise derives it from base_url.
         e.g. 'https://api.gmi-serving.com/v1' → 'api.gmi-serving.com'
+
+        Fails closed: a malformed base_url (e.g. an unmatched IPv6 bracket, for
+        which ``urlparse`` raises ``ValueError: Invalid IPv6 URL``) yields ``""``
+        rather than raising, so URL-based provider detection cannot abort setup
+        on bad custom-endpoint configuration.
         """
         if self.hostname:
             return self.hostname
         if self.base_url:
             from urllib.parse import urlparse
-            return urlparse(self.base_url).hostname or ""
+            try:
+                return urlparse(self.base_url).hostname or ""
+            except ValueError:
+                return ""
         return ""
 
     def prepare_messages(self, messages: list[dict[str, Any]]) -> list[dict[str, Any]]:

--- a/tests/providers/test_get_hostname_malformed_url.py
+++ b/tests/providers/test_get_hostname_malformed_url.py
@@ -1,0 +1,31 @@
+"""ProviderProfile.get_hostname() must fail closed on a malformed base_url.
+
+Sibling of issue #87219 / PR #87220 (which fixed the shared
+``utils.base_url_hostname`` helper): ``get_hostname`` derives a hostname from
+``base_url`` for URL-based provider detection and its contract returns ``""``
+when no hostname is available, but a malformed bracketed IPv6 URL makes
+``urllib.parse`` raise ``ValueError: Invalid IPv6 URL`` instead. Because this
+runs during provider/URL classification, the exception could abort setup on a
+bad custom endpoint before normal validation. It must return ``""`` instead.
+"""
+
+from providers.base import ProviderProfile
+
+
+class TestGetHostnameMalformedUrl:
+    def test_malformed_base_url_returns_empty(self):
+        # Unmatched IPv6 bracket: urlparse raises "ValueError: Invalid IPv6 URL".
+        profile = ProviderProfile(name="custom", base_url="http://[::1")
+        assert profile.get_hostname() == ""
+
+    def test_valid_base_url_still_resolves(self):
+        profile = ProviderProfile(
+            name="custom", base_url="https://api.gmi-serving.com/v1"
+        )
+        assert profile.get_hostname() == "api.gmi-serving.com"
+
+    def test_explicit_hostname_short_circuits_malformed_base_url(self):
+        profile = ProviderProfile(
+            name="custom", hostname="api.example.com", base_url="http://[::1"
+        )
+        assert profile.get_hostname() == "api.example.com"


### PR DESCRIPTION
## Summary

- Contain `urllib.parse.ValueError` in `ProviderProfile.get_hostname()`
- Treat a malformed bracketed IPv6 `base_url` as no hostname (`""`), matching the method's documented fail-closed contract
- Add regression coverage for the malformed case plus the valid-host and explicit-`hostname` paths

## Root cause and impact

`get_hostname()` derives a provider hostname from `base_url` for URL-based provider detection, and its contract returns `""` when no hostname is available. But `urlparse("http://[::1")` raises `ValueError: Invalid IPv6 URL` on an unmatched IPv6 bracket, so a malformed custom endpoint could abort provider setup during classification instead of reaching normal validation/client-error handling.

This is a sibling of #87219: that issue is scoped to the shared `utils.base_url_hostname()` helper (fixed in #87220), but `providers/base.ProviderProfile.get_hostname()` is a separate hostname-from-`base_url` derivation with the identical latent crash and the same `or ""` fail-closed intent. The other `urlparse(base_url).hostname` call sites (`agent/transports/chat_completions.py`, `hermes_cli/auth.py`) already wrap the call and are unaffected.

The fix fails closed: invalid input returns `""`, so it cannot be classified as any known provider host. Valid-host behavior is unchanged.

## Validation

```text
scripts/run_tests.sh tests/providers/test_get_hostname_malformed_url.py -q
3 tests passed

scripts/run_tests.sh tests/plugins/model_providers/test_upstage_profile.py -q
18 tests passed

ruff check providers/base.py tests/providers/test_get_hostname_malformed_url.py
All checks passed!

git diff --check
(clean)
```

Related to #87219.
