### PR TITLE
fix(whatsapp): stop runtime dependency installs

### DIFF
--- a/gateway/platforms/whatsapp_common.py
+++ b/gateway/platforms/whatsapp_common.py
@@ -11,6 +11,7 @@ method: ``config`` (PlatformConfig), ``name``, ``_dm_policy`` / ``_group_policy`
 
 from __future__ import annotations
 
+import hashlib
 import json
 import logging
 import os
@@ -305,6 +306,54 @@ class WhatsAppBehaviorMixin:
             for i, original in enumerate(saved):
                 result = result.replace(f"\x00{tag}{i}\x00", original)
         return result
+
+
+_WHATSAPP_DEPENDENCY_STAMP = ".hermes-pkg-hash"
+
+
+def whatsapp_bridge_dependency_fingerprint(bridge_dir: Path) -> str:
+    """Return a stable fingerprint for the checked-in bridge manifests."""
+    digest = hashlib.sha256()
+    for name in ("package.json", "package-lock.json"):
+        path = bridge_dir / name
+        try:
+            content = path.read_bytes()
+        except OSError:
+            return ""
+        digest.update(name.encode("utf-8"))
+        digest.update(b"\0")
+        digest.update(content)
+        digest.update(b"\0")
+    return digest.hexdigest()
+
+
+def whatsapp_bridge_dependencies_fresh(bridge_dir: Path) -> bool:
+    """Return whether installed bridge dependencies match both manifests."""
+    node_modules = bridge_dir / "node_modules"
+    fingerprint = whatsapp_bridge_dependency_fingerprint(bridge_dir)
+    if not node_modules.is_dir() or not fingerprint:
+        return False
+    try:
+        recorded = (node_modules / _WHATSAPP_DEPENDENCY_STAMP).read_text(
+            encoding="utf-8"
+        ).strip()
+    except OSError:
+        return False
+    return recorded == fingerprint
+
+
+def record_whatsapp_bridge_dependency_fingerprint(bridge_dir: Path) -> bool:
+    """Stamp a successful explicit install with its manifest fingerprint."""
+    fingerprint = whatsapp_bridge_dependency_fingerprint(bridge_dir)
+    if not fingerprint:
+        return False
+    try:
+        (bridge_dir / "node_modules" / _WHATSAPP_DEPENDENCY_STAMP).write_text(
+            fingerprint, encoding="utf-8"
+        )
+    except OSError:
+        return False
+    return True
 
 
 def resolve_whatsapp_bridge_dir() -> Path:

--- a/hermes_cli/main_platform_setup.py
+++ b/hermes_cli/main_platform_setup.py
@@ -96,8 +96,12 @@ def _whatsapp_allowed_users(wa_mode: str, get_env_value, save_env_value) -> None
 
 def _whatsapp_install_bridge(bridge_dir) -> bool:
     """Step 4 of ``hermes whatsapp``: ``npm install`` the bridge when needed. False = stop."""
+    from gateway.platforms.whatsapp_common import (
+        record_whatsapp_bridge_dependency_fingerprint,
+        whatsapp_bridge_dependencies_fresh,
+    )
     from hermes_constants import find_node_executable, with_hermes_node_path
-    if (bridge_dir / "node_modules").exists():
+    if whatsapp_bridge_dependencies_fresh(bridge_dir):
         print("✓ Bridge dependencies already installed")
         return True
     print("\n→ Installing WhatsApp bridge dependencies (this can take a few minutes)...")
@@ -117,6 +121,9 @@ def _whatsapp_install_bridge(bridge_dir) -> bool:
         err = (result.stderr or "").strip()
         preview = "\n".join(err.splitlines()[-30:]) if err else "(no output)"
         _say("  ✗ npm install failed:", preview)
+        return False
+    if not record_whatsapp_bridge_dependency_fingerprint(bridge_dir):
+        print("  ✗ Dependencies installed, but their version stamp could not be written")
         return False
     print("  ✓ Dependencies installed")
     return True

--- a/hermes_cli/update_cmd_deps.py
+++ b/hermes_cli/update_cmd_deps.py
@@ -540,9 +540,41 @@ def _repair_node_deps_on_current_checkout(
     return bool(print_completion(completion_message))
 
 
+def _update_whatsapp_bridge_dependencies(npm: str, env: dict) -> bool:
+    """Refresh an installed WhatsApp bridge outside gateway runtime."""
+    from hermes_cli.update_cmd import _m
+    from gateway.platforms.whatsapp_common import (
+        record_whatsapp_bridge_dependency_fingerprint,
+        whatsapp_bridge_dependencies_fresh,
+    )
+
+    bridge_dir = _m().PROJECT_ROOT / "scripts" / "whatsapp-bridge"
+    if not (bridge_dir / "node_modules").is_dir():
+        return True
+    if whatsapp_bridge_dependencies_fresh(bridge_dir):
+        return True
+
+    print("→ Updating WhatsApp bridge dependencies...")
+    result = _m()._run_npm_install_deterministic(
+        npm,
+        bridge_dir,
+        extra_args=("--no-fund", "--no-audit", "--prefer-offline", "--progress=false"),
+        capture_output=False,
+        env=env,
+    )
+    if result.returncode != 0:
+        print("  ⚠ WhatsApp bridge npm install failed")
+        return False
+    if not record_whatsapp_bridge_dependency_fingerprint(bridge_dir):
+        print("  ⚠ WhatsApp bridge dependency version stamp could not be written")
+        return False
+    print("  ✓ WhatsApp bridge dependencies installed")
+    return True
+
+
 def _update_node_dependencies() -> list[str]:
-    """Refresh Node deps for ui-tui and web. Returns labels whose npm install failed (empty on
-    success) so the caller reports a partial update instead of ``Update complete!``.
+    """Refresh installed WhatsApp, ui-tui, and web Node deps. Return failed labels so the
+    caller reports a partial update instead of ``Update complete!``.
 
     See #30271.
     """
@@ -574,9 +606,13 @@ def _update_node_dependencies() -> list[str]:
             return ["ui-tui, web workspaces"] if has_workspace else []
         return []
 
-    from hermes_constants import get_default_hermes_root
+    from hermes_constants import get_default_hermes_root, with_hermes_node_path
     # node_modules is shared by every profile on this checkout: one per-checkout cache.
     shared_hermes_root = get_default_hermes_root()
+    nixos_env = with_hermes_node_path(_m()._nixos_build_env())
+    failures: list[str] = []
+    if not _update_whatsapp_bridge_dependencies(npm, nixos_env):
+        failures.append("WhatsApp bridge")
 
     # Best-effort npx cache warm before the lockfile-unchanged early return. Can block
     # ~11s on a cold cache — print first so it doesn't look like a hang.
@@ -589,7 +625,7 @@ def _update_node_dependencies() -> list[str]:
 
     if not _m()._npm_lockfile_changed(shared_hermes_root):
         logger.info("npm lockfile unchanged, skipping npm install")
-        return []
+        return failures
 
     # Root package.json has no deps of its own, so a workspace-scoped install prunes nothing
     # root-only. apps/desktop is deliberately never named: its Electron devDependency has a
@@ -602,9 +638,6 @@ def _update_node_dependencies() -> list[str]:
         # scoped install; apps/desktop stays excluded since it is never named above.
         "--include-workspace-root"]
 
-    from hermes_constants import with_hermes_node_path
-    nixos_env = with_hermes_node_path(_m()._nixos_build_env())
-
     # capture_output=False is deliberate: postinstall scripts print download progress and
     # capturing makes a long download look hung.
     # The chatty npm-deprecation noise during `hermes update` comes from the *desktop* build, not this step;
@@ -614,7 +647,7 @@ def _update_node_dependencies() -> list[str]:
     if result.returncode == 0:
         _record_npm_lockfile_hash(shared_hermes_root)
         print("  ✓ ui-tui, web workspaces installed (desktop skipped)")
-        return []
+        return failures
     print("  ⚠ npm install failed")
     stderr = (result.stderr or "").strip()
     if stderr:
@@ -623,7 +656,8 @@ def _update_node_dependencies() -> list[str]:
     print("  ⚠ Node.js dependency refresh did not complete cleanly; the")
     print("    installation may be in a mixed state (updated code, stale Node")
     print("    deps). Fix npm and re-run `hermes update`.")
-    return ["ui-tui, web workspaces"]
+    failures.append("ui-tui, web workspaces")
+    return failures
 
 
 def _venv_core_imports_healthy() -> tuple[bool, str]:

--- a/hermes_cli/web_routers/messaging.py
+++ b/hermes_cli/web_routers/messaging.py
@@ -336,7 +336,12 @@ def _whatsapp_linked_account_from_session(session_path: Path) -> tuple[str | Non
 
 def _ensure_whatsapp_bridge_dependencies(bridge_dir: Path) -> None:
     """Install bridge dependencies when the dashboard is the setup surface."""
-    if (bridge_dir / "node_modules").exists():
+    from gateway.platforms.whatsapp_common import (
+        record_whatsapp_bridge_dependency_fingerprint,
+        whatsapp_bridge_dependencies_fresh,
+    )
+
+    if whatsapp_bridge_dependencies_fresh(bridge_dir):
         return
 
     from hermes_constants import find_node_executable, with_hermes_node_path
@@ -362,6 +367,11 @@ def _ensure_whatsapp_bridge_dependencies(bridge_dir: Path) -> None:
     if result.returncode != 0:
         detail = "\n".join((result.stderr or result.stdout or "").strip().splitlines()[-10:])
         raise HTTPException(status_code=500, detail=f"npm install failed for WhatsApp bridge: {detail or 'no output'}")
+    if not record_whatsapp_bridge_dependency_fingerprint(bridge_dir):
+        raise HTTPException(
+            status_code=500,
+            detail="WhatsApp dependencies installed, but their version stamp could not be written.",
+        )
 
 
 def _spawn_whatsapp_pairing_process(session_path: Path, mode: str) -> subprocess.Popen:

--- a/plugins/platforms/whatsapp/adapter.py
+++ b/plugins/platforms/whatsapp/adapter.py
@@ -170,7 +170,10 @@ import sys
 sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
 
 from gateway.config import Platform, PlatformConfig
-from gateway.platforms.whatsapp_common import WhatsAppBehaviorMixin
+from gateway.platforms.whatsapp_common import (
+    WhatsAppBehaviorMixin,
+    whatsapp_bridge_dependencies_fresh,
+)
 from gateway.whatsapp_identity import to_whatsapp_jid
 from gateway.platforms.base import (
     BasePlatformAdapter, SendResult, SUPPORTED_DOCUMENT_TYPES, cache_image_from_url, cache_audio_from_url,
@@ -308,36 +311,6 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             except Exception:
                 return True, None
 
-    def _ensure_bridge_deps(self, bridge_dir: Path) -> bool:
-        """npm install when node_modules is missing OR package.json hash != stamp file. False = fatal error set."""
-        _dep_stamp = bridge_dir / "node_modules" / ".hermes-pkg-hash"  # holds the package.json hash of the last install
-        _pkg_hash = _file_content_hash(bridge_dir / "package.json")
-        try:
-            if (bridge_dir / "node_modules").exists() and _dep_stamp.read_text(encoding="utf-8").strip() == _pkg_hash and bool(_pkg_hash):
-                return True
-        except OSError:
-            pass
-        print(f"[{self.name}] Installing WhatsApp bridge dependencies...")
-        # Hermes-managed portable Node's npm.cmd first (Windows), then PATH.
-        _npm_bin = find_node_executable("npm") or "npm"
-        detail = ""
-        try:  # Default 300s accommodates slow systems like an Unraid NAS.
-            install_result = subprocess.run([_npm_bin, "install", "--silent"], cwd=str(bridge_dir), timeout=env_int("WHATSAPP_NPM_INSTALL_TIMEOUT", 300),
-                                            env=with_hermes_node_path(), **_RUN_TEXT)
-            if install_result.returncode == 0:
-                print(f"[{self.name}] Dependencies installed")
-                with suppress(OSError):  # Stamp is an optimization; install still succeeded
-                    if _pkg_hash:
-                        _dep_stamp.write_text(_pkg_hash, encoding="utf-8")
-                return True
-            print(f"[{self.name}] npm install failed: {install_result.stderr}")
-        except Exception as e:
-            print(f"[{self.name}] Failed to install dependencies: {e}")
-            detail = f" ({e})"
-        self._set_fatal_error("whatsapp_npm_install_failed", f"WhatsApp bridge npm install failed{detail}. Run `cd {bridge_dir} && {_npm_bin} install` "
-                              "manually, then restart `hermes gateway`.", retryable=False)
-        return False
-
     def _attach_to_bridge(self, managed_process) -> None:
         import aiohttp
         self._bridge_process = managed_process
@@ -436,6 +409,10 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
              "whatsapp_node_missing", "Node.js is not installed — install Node.js and re-run `hermes gateway`."),
             (bridge_path.exists, ("[%s] Bridge script not found: %s", self.name, bridge_path),
              "whatsapp_bridge_missing", f"WhatsApp bridge script missing at {bridge_path}."),
+            (lambda: whatsapp_bridge_dependencies_fresh(bridge_path.parent),
+             ("[%s] WhatsApp bridge dependencies are missing or stale. Run `hermes whatsapp` before starting the gateway.", self.name),
+             "whatsapp_bridge_dependencies_stale",
+             "WhatsApp bridge dependencies are missing or stale — run `hermes whatsapp`, then re-run `hermes gateway`."),
             (creds_path.exists, ("[%s] WhatsApp is enabled but not paired (no creds.json at %s). Pair from the dashboard or run "
                                  "`hermes whatsapp`; remove WHATSAPP_ENABLED from your .env to disable.", self.name, creds_path),
              "whatsapp_not_paired", "WhatsApp enabled but not paired — pair from the dashboard or run `hermes whatsapp`."),
@@ -461,8 +438,6 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         except Exception as e:
             logger.warning("[%s] Could not acquire session lock (non-fatal): %s", self.name, e)
         try:
-            if not self._ensure_bridge_deps(bridge_path.parent):
-                return False
             self._session_path.mkdir(parents=True, exist_ok=True)
             if await self._reuse_running_bridge(bridge_path):
                 return True

--- a/tests/gateway/test_whatsapp_connect.py
+++ b/tests/gateway/test_whatsapp_connect.py
@@ -99,6 +99,10 @@ def _connect_patches(mock_proc, mock_fh, mock_client_cls=None):
         patch("builtins.open", return_value=mock_fh),
         patch("plugins.platforms.whatsapp.adapter.asyncio.sleep", new_callable=AsyncMock),
         patch("plugins.platforms.whatsapp.adapter.asyncio.create_task"),
+        patch(
+            "plugins.platforms.whatsapp.adapter.whatsapp_bridge_dependencies_fresh",
+            return_value=True,
+        ),
     ]
     if mock_client_cls is not None:
         base.append(patch("aiohttp.ClientSession", mock_client_cls))
@@ -158,7 +162,7 @@ class TestDataInitialized:
         patches = _connect_patches(mock_proc, mock_fh, mock_client_cls)
 
         with patches[0], patches[1], patches[2], patches[3], patches[4], \
-             patches[5], patches[6], patches[7], patches[8], \
+             patches[5], patches[6], patches[7], patches[8], patches[9], \
              patch.object(type(adapter), "_poll_messages", return_value=MagicMock()):
             # Must NOT raise NameError
             result = await adapter.connect()
@@ -188,7 +192,7 @@ class TestFileHandleClosedOnError:
         patches = _connect_patches(mock_proc, mock_fh)
 
         with patches[0], patches[1], patches[2], patches[3], patches[4], \
-             patches[5], patches[6], patches[7]:
+             patches[5], patches[6], patches[7], patches[8]:
             result = await adapter.connect()
 
         assert result is False
@@ -196,31 +200,49 @@ class TestFileHandleClosedOnError:
         assert adapter._bridge_log_fh is None
 
 
-class TestConnectCleanup:
-    """Verify failure paths release the scoped session lock."""
+class TestConnectPreflight:
+    """Gateway startup verifies bridge dependencies without mutating them."""
 
-    @pytest.mark.asyncio
-    async def test_releases_lock_when_npm_install_fails(self):
-        adapter = _make_adapter()
+    def test_dependency_check_is_read_only_and_actionable(self, tmp_path):
+        bridge_dir = tmp_path / "bridge"
+        (bridge_dir / "node_modules").mkdir(parents=True)
+        (bridge_dir / "bridge.js").write_text("// bridge", encoding="utf-8")
+        (bridge_dir / "package.json").write_text(
+            '{"dependencies": {}}', encoding="utf-8"
+        )
+        (bridge_dir / "package-lock.json").write_text(
+            '{"lockfileVersion": 3}', encoding="utf-8"
+        )
+        session_path = tmp_path / "session"
+        session_path.mkdir()
+        (session_path / "creds.json").write_text("{}", encoding="utf-8")
 
-        def _path_exists(path_obj):
-            return not str(path_obj).endswith("node_modules")
+        stale_adapter = _make_adapter()
+        stale_adapter._bridge_script = str(bridge_dir / "bridge.js")
+        stale_adapter._session_path = session_path
+        fresh_adapter = _make_adapter()
+        fresh_adapter._bridge_script = str(bridge_dir / "bridge.js")
+        fresh_adapter._session_path = session_path
 
-        install_result = MagicMock(returncode=1, stderr="install failed")
+        with (
+            patch(
+                "plugins.platforms.whatsapp.adapter.check_whatsapp_requirements",
+                return_value=True,
+            ),
+            patch("subprocess.run") as mock_run,
+        ):
+            assert stale_adapter._preflight() is False
+            from gateway.platforms.whatsapp_common import (
+                record_whatsapp_bridge_dependency_fingerprint,
+            )
 
-        with patch("plugins.platforms.whatsapp.adapter.check_whatsapp_requirements", return_value=True), \
-             patch.object(Path, "exists", autospec=True, side_effect=_path_exists), \
-             patch("subprocess.run", return_value=install_result), \
-             patch("gateway.status.acquire_scoped_lock", return_value=(True, None)), \
-             patch("gateway.status.release_scoped_lock") as mock_release:
-            result = await adapter.connect()
+            assert record_whatsapp_bridge_dependency_fingerprint(bridge_dir) is True
+            assert fresh_adapter._preflight() is True
 
-        assert result is False
-        assert adapter.fatal_error_code == "whatsapp_npm_install_failed"
-        assert adapter.fatal_error_retryable is False
-        assert "npm install failed" in (adapter.fatal_error_message or "")
-        mock_release.assert_called_once_with("whatsapp-session", str(adapter._session_path))
-        assert adapter._platform_lock_identity is None
+        assert stale_adapter.fatal_error_code == "whatsapp_bridge_dependencies_stale"
+        assert stale_adapter.fatal_error_retryable is False
+        assert "hermes whatsapp" in (stale_adapter.fatal_error_message or "")
+        mock_run.assert_not_called()
 
 
 class TestBridgeRuntimeFailure:
@@ -300,7 +322,7 @@ class TestBridgeRuntimeFailure:
         patches = _connect_patches(mock_proc, mock_fh, mock_client_cls)
 
         with patches[0], patches[1], patches[2], patches[3], patches[4], \
-             patches[5], patches[6], patches[7], patches[8]:
+             patches[5], patches[6], patches[7], patches[8], patches[9]:
             result = await adapter.connect()
 
         assert result is False
@@ -512,11 +534,11 @@ class TestNoCredsPreflight:
         adapter.config = MagicMock()
         adapter._bridge_port = 19877
         bridge = tmp_path / "bridge.js"
-        bridge.write_text("// stub")
+        bridge.write_text("// stub", encoding="utf-8")
         adapter._bridge_script = str(bridge)
         session_dir = tmp_path / "session"
         session_dir.mkdir()
-        (session_dir / "creds.json").write_text("{}")
+        (session_dir / "creds.json").write_text("{}", encoding="utf-8")
         adapter._session_path = session_dir
         adapter._bridge_log_fh = None
         adapter._fatal_error_code = None

--- a/tests/hermes_cli/test_whatsapp_dependency_ownership.py
+++ b/tests/hermes_cli/test_whatsapp_dependency_ownership.py
@@ -1,0 +1,86 @@
+import subprocess
+
+from hermes_cli.main_platform_setup import _whatsapp_install_bridge
+from hermes_cli.web_routers.messaging import _ensure_whatsapp_bridge_dependencies
+
+
+def test_explicit_maintenance_paths_refresh_and_stamp_whatsapp_dependencies(
+    tmp_path, monkeypatch
+):
+    import hermes_cli.main as hm
+    import hermes_constants
+
+    checkout = tmp_path / "checkout"
+    bridge_dir = checkout / "scripts" / "whatsapp-bridge"
+    checkout.mkdir()
+    (checkout / "package.json").write_text("{}", encoding="utf-8")
+    (bridge_dir / "node_modules").mkdir(parents=True)
+    (bridge_dir / "package.json").write_text(
+        '{"dependencies": {}}', encoding="utf-8"
+    )
+    (bridge_dir / "package-lock.json").write_text(
+        '{"lockfileVersion": 3}', encoding="utf-8"
+    )
+
+    monkeypatch.setattr(hm, "PROJECT_ROOT", checkout)
+    monkeypatch.setattr(
+        hermes_constants,
+        "find_node_executable",
+        lambda _name: "/usr/bin/npm",
+    )
+    monkeypatch.setattr(
+        hermes_constants,
+        "with_hermes_node_path",
+        lambda _env=None: {},
+    )
+
+    installs = []
+    phase = ["cli"]
+
+    def fake_run(*_args, **_kwargs):
+        installs.append(phase[0])
+        return subprocess.CompletedProcess([], 0, stdout="", stderr="")
+
+    monkeypatch.setattr("subprocess.run", fake_run)
+
+    assert _whatsapp_install_bridge(bridge_dir) is True
+    stamp = bridge_dir / "node_modules" / ".hermes-pkg-hash"
+    cli_stamp = stamp.read_text(encoding="utf-8").strip()
+    assert cli_stamp
+
+    phase[0] = "dashboard"
+    (bridge_dir / "package.json").write_text(
+        '{"dependencies": {"a": "1"}}', encoding="utf-8"
+    )
+    _ensure_whatsapp_bridge_dependencies(bridge_dir)
+    dashboard_stamp = stamp.read_text(encoding="utf-8").strip()
+    assert dashboard_stamp and dashboard_stamp != cli_stamp
+
+    phase[0] = "update"
+    (bridge_dir / "package-lock.json").write_text(
+        '{"lockfileVersion": 3, "packages": {"a": {}}}', encoding="utf-8"
+    )
+
+    def fake_deterministic_install(*_args, **_kwargs):
+        installs.append(phase[0])
+        return subprocess.CompletedProcess([], 0, stdout="", stderr="")
+
+    monkeypatch.setattr(hm, "_run_npm_install_deterministic", fake_deterministic_install)
+    monkeypatch.setattr(hm, "_resolve_node_runtime_npm", lambda: "/usr/bin/npm")
+    monkeypatch.setattr(hm, "_nixos_build_env", lambda: {})
+    monkeypatch.setattr(hm, "_npm_lockfile_changed", lambda _root: False)
+    monkeypatch.setattr(
+        hermes_constants,
+        "get_default_hermes_root",
+        lambda: tmp_path / "hermes-home",
+    )
+    monkeypatch.setattr(
+        "tools.browser_tool_install.warm_agent_browser_npx_cache",
+        lambda: True,
+    )
+    from hermes_cli.update_cmd_deps import _update_node_dependencies
+
+    assert _update_node_dependencies() == []
+    update_stamp = stamp.read_text(encoding="utf-8").strip()
+    assert update_stamp and update_stamp != dashboard_stamp
+    assert installs == ["cli", "dashboard", "update"]

--- a/tests/hermes_cli/test_whatsapp_setup_ordering.py
+++ b/tests/hermes_cli/test_whatsapp_setup_ordering.py
@@ -40,7 +40,7 @@ def _env_value(hermes_home: Path, key: str) -> str | None:
     env_file = hermes_home / ".env"
     if not env_file.exists():
         return None
-    for line in env_file.read_text().splitlines():
+    for line in env_file.read_text(encoding="utf-8").splitlines():
         if "=" not in line:
             continue
         k, _, v = line.partition("=")
@@ -95,7 +95,7 @@ def test_existing_pairing_skip_branch_enables_whatsapp(isolated_home, monkeypatc
     # Pre-create a paired session WITHOUT WHATSAPP_ENABLED in .env.
     session = isolated_home / "whatsapp" / "session"
     session.mkdir(parents=True)
-    (session / "creds.json").write_text("{}")
+    (session / "creds.json").write_text("{}", encoding="utf-8")
     monkeypatch.setenv("WHATSAPP_MODE", "bot")
     monkeypatch.setenv("WHATSAPP_ALLOWED_USERS", "15551234567")
 
@@ -111,26 +111,10 @@ def test_existing_pairing_skip_branch_enables_whatsapp(isolated_home, monkeypatc
 
     monkeypatch.setattr("builtins.input", fake_input)
     monkeypatch.setattr("hermes_cli.main._require_tty", lambda *_a, **_kw: None)
-    # Skip the bridge npm install — we're testing setup-ordering, not bridge
-    # bootstrapping.  Pretend node_modules exists (Path.exists -> True for that
-    # specific check is hard to scope, so instead pretend npm install would
-    # succeed silently if reached).
     monkeypatch.setattr(
-        "subprocess.run",
-        lambda *_a, **_kw: MagicMock(returncode=0, stderr=""),
+        "gateway.platforms.whatsapp_common.whatsapp_bridge_dependencies_fresh",
+        lambda _bridge_dir: True,
     )
-    monkeypatch.setattr("shutil.which", lambda _name: "/usr/bin/npm")
-    # Patch (bridge_dir / "node_modules").exists() by stubbing Path.exists
-    # to True for that one specific subpath.  Easier: pre-create it as a
-    # symlink to /tmp.  But we can't write to the repo.  Instead, stub
-    # Path.exists wholesale to True for node_modules; the creds.json check
-    # in the same function still works because we wrote it ourselves.
-    _orig_exists = Path.exists
-    def _stub_exists(self):
-        if self.name == "node_modules":
-            return True
-        return _orig_exists(self)
-    monkeypatch.setattr(Path, "exists", _stub_exists)
 
     buf = io.StringIO()
     with redirect_stdout(buf):


### PR DESCRIPTION
## What does this PR do?

Removes package installation from WhatsApp gateway startup. The runtime now performs a read-only dependency freshness check and fails closed with the exact `hermes whatsapp` repair command when bridge dependencies are missing or stale.

Dependency mutation is owned by explicit maintenance surfaces:

- `hermes whatsapp` installs missing or stale bridge dependencies and records a manifest fingerprint.
- Dashboard pairing does the same before launching its explicit setup process.
- `hermes update` refreshes a stale, already-installed bridge even when the root workspace manifests are unchanged.

Freshness covers both `package.json` and `package-lock.json`; a successful explicit install writes the stamp consumed by runtime preflight.

## Related work

Merged #85176 correctly made runtime WhatsApp install failures non-retryable and actionable while installation still occurred inside gateway startup. This PR keeps that fail-closed classification and removes the runtime mutation entirely.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- Move WhatsApp dependency fingerprinting into the shared bridge-path owner.
- Replace adapter-side `npm install` with a read-only preflight check.
- Refresh and stamp dependencies from CLI setup, dashboard setup, and the updater.
- Carry WhatsApp refresh failures through the updater's existing partial-update result.
- Port the change to current-main modules instead of adding code to CLI facades.
- Keep two behavior invariants: runtime performs no install, and every explicit maintenance owner refreshes/stamps stale dependencies.

## Review feedback disposition

All four prior review points remain resolved:

1. `find_node_executable`, `with_hermes_node_path`, and `_file_content_hash` still have live requirements, bridge-process, and bridge-source-version callers; `env_int` was removed from the adapter with the runtime installer.
2. Missing or stale dependencies fail non-retryably with `hermes whatsapp`; setup surfaces repair missing/stale installs, and `hermes update` refreshes stale installed dependencies before its root-manifest early return.
3. The old adapter-local stamp machinery is removed. The shared package-plus-lock fingerprint is intentionally consumed by runtime and every explicit installer.
4. The runtime preflight regression proves stale and fresh checks invoke no install subprocess.

No maintainer review or inline findings are pending.

## How to Test

`./scripts/run_tests.sh tests/gateway/test_whatsapp_bridge_dir_resolution.py tests/gateway/test_whatsapp_connect.py tests/hermes_cli/test_cmd_update.py tests/hermes_cli/test_whatsapp_onboarding.py tests/hermes_cli/test_whatsapp_setup_ordering.py tests/hermes_cli/test_whatsapp_dependency_ownership.py`

Both new behavior invariants fail against current upstream `main` and pass on this head.

## Verification

- 62 focused tests passed; 5 platform-specific tests skipped on macOS and remain covered by Linux/Windows CI lanes.
- Focused Ruff passed.
- Plugin-compat pointer audit passed.
- Contributor attribution audit passed.
- `git diff --check` passed.

## Checklist

### Code

- [x] I've read the current contributing guide and area instructions.
- [x] My commit message follows Conventional Commits.
- [x] I inspected the full PR/comment/review history and merged overlap.
- [x] The patch contains only WhatsApp dependency ownership and its tests.
- [x] I added two current-main behavior invariants and proved they fail without the fix.
- [x] Tested on macOS 26.6.1 with Python 3.11.

### Documentation & Housekeeping

- [x] User documentation: N/A — the existing `hermes whatsapp` repair command remains the interface.
- [x] Config documentation: N/A — no keys changed.
- [x] Architecture documentation: N/A — code follows current setup/update module ownership.
- [x] Cross-platform behavior considered; platform-specific runtime tests remain assigned to CI.
- [x] Tool schema documentation: N/A — no tool schema changed.