### PR TITLE
fix(telegram): prevent Windows long-poll socket reuse deadlock

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -2430,17 +2430,31 @@ class TelegramAdapter(BasePlatformAdapter):
             polling_req = self._app.bot._request[0]  # noqa: SLF001
         except Exception:
             return
+        shutdown_ok = False
         try:
             # Bounded: a wedged CLOSE-WAIT socket can make this close hang
-            # forever and freeze the reconnect ladder (#66377).
-            await asyncio.wait_for(polling_req.shutdown(), timeout=_DRAIN_TIMEOUT)
+            # forever and freeze the reconnect ladder (#66377). The thread
+            # deadline abandons cancellation-shielded PTB/httpcore work instead
+            # of waiting for cancellation to propagate.
+            await _await_with_thread_deadline(
+                polling_req.shutdown(), timeout=_DRAIN_TIMEOUT
+            )
+            shutdown_ok = True
         except Exception:
             logger.debug(
                 "[%s] Polling request shutdown failed/timed out (non-fatal)",
                 self.name, exc_info=True,
             )
+        if not shutdown_ok:
+            # PTB's initialize() only creates a new client when the old client
+            # reports is_closed. A timed-out shutdown can leave that flag false,
+            # so initialize() becomes a no-op and the next polling generation
+            # reuses the CLOSE-WAIT socket (#87057).
+            self._replace_polling_http_client(polling_req)
         try:
-            await asyncio.wait_for(polling_req.initialize(), timeout=_DRAIN_TIMEOUT)
+            await _await_with_thread_deadline(
+                polling_req.initialize(), timeout=_DRAIN_TIMEOUT
+            )
             logger.debug(
                 "[%s] Polling request pool drained before reconnect", self.name
             )
@@ -2448,6 +2462,66 @@ class TelegramAdapter(BasePlatformAdapter):
             logger.debug(
                 "[%s] Polling request re-initialize failed/timed out (non-fatal)",
                 self.name, exc_info=True,
+            )
+            self._replace_polling_http_client(polling_req)
+
+    def _replace_polling_http_client(self, polling_req) -> None:
+        """Swap out a PTB client left open after a timed-out shutdown.
+
+        PTB 22.x does not expose a public request-client replacement API. The
+        polling request is isolated in ``Bot._request[0]`` and
+        ``HTTPXRequest._build_client`` is the same factory used by PTB during
+        normal initialization. Keep the private access narrowly contained here
+        so an upgrade can be audited in one place. If a future PTB removes these
+        attributes, the guarded fallback preserves the previous recovery path.
+        """
+        old_client = getattr(polling_req, "_client", None)
+        build_client = getattr(polling_req, "_build_client", None)
+        if old_client is None or not callable(build_client):
+            return
+        if getattr(old_client, "is_closed", True):
+            return
+        try:
+            polling_req._client = build_client()  # noqa: SLF001
+        except Exception:
+            logger.debug(
+                "[%s] Failed to replace stale Telegram polling HTTP client",
+                self.name,
+                exc_info=True,
+            )
+            return
+
+        logger.warning(
+            "[%s] Replaced stale Telegram getUpdates HTTP client after drain timeout",
+            self.name,
+        )
+
+        async def _close_old_client() -> None:
+            try:
+                # The stale client can be wedged in the same cancellation-
+                # swallowing httpcore scope as shutdown(). Do not use
+                # asyncio.wait_for() here: it waits for cancellation to
+                # propagate and would leave one detached cleanup task alive
+                # per reconnect attempt.
+                await _await_with_thread_deadline(
+                    old_client.aclose(), timeout=_DRAIN_TIMEOUT
+                )
+            except Exception:
+                logger.debug(
+                    "[%s] Stale Telegram polling client close did not complete",
+                    self.name,
+                    exc_info=True,
+                )
+
+        try:
+            task = asyncio.create_task(_close_old_client())
+            self._background_tasks.add(task)
+            task.add_done_callback(self._background_tasks.discard)
+        except Exception:
+            logger.debug(
+                "[%s] Could not schedule stale polling client cleanup",
+                self.name,
+                exc_info=True,
             )
 
     def _begin_polling_generation(self) -> tuple[int, asyncio.Event]:
@@ -4319,8 +4393,18 @@ class TelegramAdapter(BasePlatformAdapter):
                     max_keepalive_connections=_base_limits.max_keepalive_connections,
                     keepalive_expiry=_base_limits.keepalive_expiry,
                 )
+                # A long-poll request is continuously active, so keepalive
+                # expiry cannot protect it from a server-side connection close.
+                # Never hand getUpdates a pooled socket from a previous poll;
+                # ordinary Bot API requests retain the shared reusable pool.
+                _updates_limits = _httpx.Limits(
+                    max_connections=request_kwargs["connection_pool_size"],
+                    max_keepalive_connections=0,
+                    keepalive_expiry=_base_limits.keepalive_expiry,
+                )
             else:  # pragma: no cover — httpx always present alongside PTB
                 _pool_limits = None
+                _updates_limits = None
 
             def _with_limits(httpx_kwargs: Optional[dict] = None) -> dict:
                 """Merge tuned keepalive limits into httpx client kwargs.
@@ -4396,6 +4480,9 @@ class TelegramAdapter(BasePlatformAdapter):
                 _transport_kwargs: dict = {}
                 if _pool_limits is not None:
                     _transport_kwargs["limits"] = _pool_limits
+                _updates_transport_kwargs = dict(_transport_kwargs)
+                if _updates_limits is not None:
+                    _updates_transport_kwargs["limits"] = _updates_limits
                 request = HTTPXRequest(
                     **request_kwargs,
                     httpx_kwargs={
@@ -4408,7 +4495,8 @@ class TelegramAdapter(BasePlatformAdapter):
                     **request_kwargs,
                     httpx_kwargs={
                         "transport": TelegramFallbackTransport(
-                            fallback_ips, **_transport_kwargs
+                            fallback_ips,
+                            **_updates_transport_kwargs,
                         )
                     },
                 )
@@ -4418,14 +4506,16 @@ class TelegramAdapter(BasePlatformAdapter):
                     **request_kwargs, proxy=proxy_url, httpx_kwargs=_with_limits()
                 )
                 get_updates_request = HTTPXRequest(
-                    **request_kwargs, proxy=proxy_url, httpx_kwargs=_with_limits()
+                    **request_kwargs,
+                    proxy=proxy_url,
+                    httpx_kwargs={"limits": _updates_limits},
                 )
             else:
                 if disable_fallback:
                     logger.info("[%s] Telegram fallback-IP transport disabled via env", self.name)
                 request = HTTPXRequest(**request_kwargs, httpx_kwargs=_with_limits())
                 get_updates_request = HTTPXRequest(
-                    **request_kwargs, httpx_kwargs=_with_limits()
+                    **request_kwargs, httpx_kwargs={"limits": _updates_limits}
                 )
 
             get_updates_request = self._instrument_polling_request(get_updates_request)

--- a/tests/gateway/test_telegram_closewait_limits_31599.py
+++ b/tests/gateway/test_telegram_closewait_limits_31599.py
@@ -153,12 +153,21 @@ def _assert_keepalive_tight(instances):
         assert limits.max_connections is not None and limits.max_connections > 0
 
 
+def _assert_updates_pool_never_reuses(instance):
+    """The long-poll pool must not reuse server-closed connections (#87057)."""
+    limits = instance.kwargs.get("httpx_kwargs", {}).get("limits")
+    assert isinstance(limits, httpx.Limits)
+    assert limits.max_keepalive_connections == 0
+    assert limits.max_connections == 512
+
+
 def test_proxy_branch_general_pool_has_tight_keepalive(monkeypatch):
     """The proxy path the #31599 reporter hit must wire tuned limits."""
     instances = _drive_connect(monkeypatch, proxy_url="http://127.0.0.1:9/")
     # Both the general request pool and the get_updates pool are built here.
     assert len(instances) >= 2
-    _assert_keepalive_tight(instances)
+    _assert_keepalive_tight(instances[:1])
+    _assert_updates_pool_never_reuses(instances[1])
     # Sanity: the proxy was actually threaded through (we're on the proxy branch).
     assert any(inst.kwargs.get("proxy") == "http://127.0.0.1:9/" for inst in instances)
 
@@ -174,7 +183,7 @@ def test_fallback_branch_forwards_tuned_limits_to_inner_transports(monkeypatch):
     )
 
     assert len(instances) >= 2
-    for instance in instances:
+    for index, instance in enumerate(instances):
         transport = instance.kwargs["httpx_kwargs"]["transport"]
         assert isinstance(transport, tg_adapter.TelegramFallbackTransport)
         limits = transport._transport_kwargs["limits"]
@@ -182,6 +191,10 @@ def test_fallback_branch_forwards_tuned_limits_to_inner_transports(monkeypatch):
         assert limits.keepalive_expiry is not None
         assert limits.keepalive_expiry < 5.0
         assert limits.max_connections == 512
+        if index == 0:
+            assert limits.max_keepalive_connections >= 1
+        else:
+            assert limits.max_keepalive_connections == 0
 
     for instance in instances:
         asyncio.run(instance.kwargs["httpx_kwargs"]["transport"].aclose())

--- a/tests/gateway/test_telegram_network_reconnect.py
+++ b/tests/gateway/test_telegram_network_reconnect.py
@@ -686,3 +686,70 @@ async def test_disconnect_advances_past_cancellation_swallowing_lifecycle(monkey
 
     release.set()
     await asyncio.wait({wedged}, timeout=0.2)
+
+
+@pytest.mark.asyncio
+async def test_drain_replaces_client_when_close_wait_shutdown_hangs(monkeypatch):
+    """A timed-out drain must not let the next poll reuse the stale client."""
+    adapter = _make_adapter()
+
+    class _Client:
+        is_closed = False
+
+        async def aclose(self):
+            # Simulate httpcore cleanup that absorbs cancellation for a while.
+            # The detached cleanup must not stay registered forever.
+            for _ in range(20):
+                try:
+                    await asyncio.sleep(0.01)
+                except asyncio.CancelledError:
+                    continue
+
+    class _PollingRequest:
+        def __init__(self):
+            self._client = _Client()
+            self.rebuilt = []
+
+        def _build_client(self):
+            client = _Client()
+            self.rebuilt.append(client)
+            return client
+
+        async def shutdown(self):
+            await asyncio.Event().wait()
+
+        async def initialize(self):
+            # Mirrors PTB: initialize() does nothing while is_closed is false.
+            if self._client.is_closed:
+                self._client = self._build_client()
+
+    request = _PollingRequest()
+    original_client = request._client
+    app = MagicMock()
+    app.bot._request = (request, MagicMock())
+    adapter._app = app
+    monkeypatch.setattr(tg_adapter, "_DRAIN_TIMEOUT", 0.02)
+
+    ticks = 0
+
+    async def _ticker():
+        nonlocal ticks
+        while True:
+            ticks += 1
+            await asyncio.sleep(0.005)
+
+    ticker = asyncio.create_task(_ticker())
+    await adapter._drain_polling_connections()
+    ticker.cancel()
+    await asyncio.gather(ticker, return_exceptions=True)
+
+    assert request.rebuilt, "stale polling client must be replaced"
+    assert request._client is request.rebuilt[-1]
+    assert request._client is not original_client
+    assert ticks >= 2, "a wedged close must not block the asyncio event loop"
+
+    await asyncio.sleep(0.25)
+    assert not adapter._background_tasks, (
+        "stale-client cleanup must finish or abandon its own wedged close "
+        "without accumulating a background task"
+    )


### PR DESCRIPTION
## Summary

Fixes #87057.

Telegram polling could become permanently silent on Windows after a transient network failure. The gateway process, cron ticker, and heartbeat remained alive, but inbound Telegram updates stopped because the reconnect path could reuse a stale `CLOSE-WAIT` socket.

This change fixes the failure at the transport/recovery boundary:

- the dedicated `getUpdates` pool never reuses a keep-alive connection;
- a timed-out polling drain uses the wall-clock deadline helper rather than waiting for cancellation-shielded PTB/httpcore cleanup;
- if PTB leaves `HTTPXRequest._client.is_closed == False` after the timeout, the polling client is replaced before the next polling generation starts;
- a stale-client cleanup that also absorbs cancellation is bounded and abandoned safely, preventing one live cleanup task from accumulating per reconnect;
- the general Bot API pool remains reusable and is not interrupted, preserving concurrent sends and edits.

![Telegram long-poll recovery](https://files.catbox.moe/kykn7x.png)

> The infographic is hosted externally because this repository rejects committed PR-infographic binaries.

## Root cause

The existing recovery assumed that `HTTPXRequest.shutdown()` would either finish or leave the client marked closed. On the reported Windows failure, the underlying long-poll socket remained stuck in `CLOSE-WAIT`; `updater.stop()` and the polling request drain could exceed their await boundary while the HTTPX client still reported itself open.

PTB's `HTTPXRequest.initialize()` only builds a new client when the current client is closed. Consequently, the next `start_polling()` could inherit the same dead connection. Since the process itself was healthy, PID-based supervision could not detect the silent ingress failure.

A second contributing condition was connection reuse in the long-poll pool. `keepalive_expiry` only applies to idle connections, while a long poll remains active. A Telegram-side close could therefore be observed on the next poll before the pool had a chance to expire the socket.

## Implementation

### Dedicated polling transport

`getUpdates` now receives `httpx.Limits` with `max_keepalive_connections=0` on direct, proxy, and fallback-IP branches. The general request pool keeps the existing tuned reusable limits.

For the fallback-IP branch, the limits are passed to `TelegramFallbackTransport`, which owns the inner `AsyncHTTPTransport` instances. This avoids the known httpx behavior where client-level limits are ignored when a custom transport is supplied.

### Stale-client replacement

`_drain_polling_connections()` now:

1. bounds shutdown with `_await_with_thread_deadline()`;
2. detects a shutdown that did not complete;
3. replaces the polling request's stale PTB client using the same `_build_client()` factory PTB uses during normal initialization;
4. starts bounded best-effort cleanup of the old client;
5. bounds re-initialization and repeats the replacement fallback if initialization itself times out;
6. bounds best-effort cleanup of the replaced stale client with the same independent deadline, so cancellation-swallowing `aclose()` implementations cannot accumulate detached tasks.

The PTB private API access is deliberately isolated in `_replace_polling_http_client()` and documented for review when upgrading PTB.

## Regression coverage

Added/updated tests cover:

- `getUpdates` pool does not retain keep-alive connections;
- general request pool remains reusable;
- fallback-IP transports receive the polling-specific limits;
- a shutdown that hangs with `is_closed == False` causes a fresh polling client to be built;
- stale-client cleanup that absorbs cancellation is bounded and does not accumulate a registered background task;
- a concurrent ticker continues running while the drain is wedged;
- the focused stale-drain race probe passed 10/10 repeated runs;
- existing reconnect, conflict, startup, pending-update, and connectivity paths remain green.

## Validation

Local results:

```text
scripts/run_tests.sh \
  tests/gateway/test_telegram_closewait_limits_31599.py \
  tests/gateway/test_telegram_network.py \
  tests/gateway/test_telegram_network_reconnect.py \
  tests/gateway/test_telegram_polling_progress.py \
  tests/gateway/test_telegram_pending_update_probe.py \
  tests/gateway/test_telegram_conflict.py \
  tests/gateway/test_telegram_start_polling_timeout.py \
  tests/gateway/test_telegram_connect.py

67 passed, 0 failed
```

Additional checks:

- Ruff: passed
- `compileall`: passed
- Windows footgun scanner: passed
- `git diff --check`: passed
- PNG validation: `PNG`, `1600x900`, RGB, non-empty bounding box

A live Windows network reproduction against Telegram was not performed in this environment; the regression is reproduced deterministically with a hanging close and PTB-like client state.

## Relationship to #87111 and related work

This PR is intentionally complementary to #87111, not a replacement. #87111 provides the broader steady-state liveness watchdog and recovery escalation. This PR adds the transport invariant that prevents the dedicated `getUpdates` pool from reusing server-closed connections, plus a focused stale-client replacement at the existing drain boundary. The two protections cover different failure modes and can be reviewed or merged together without changing the general send pool.

- #84495 identifies the related ~39-second Telegram-side connection reuse pattern; its polling-pool policy is incorporated here.
- #58342 bounds `updater.stop()` call sites, but does not enforce the polling-pool no-reuse invariant or rebuild a client whose close timed out while still reporting open.
- #71240 covers local dispatcher stalls after updates have already been consumed; it is a different failure boundary.

No general request pool, message routing, webhook behavior, or configuration schema was changed.
