### PR TITLE
feat(memory): add zero-wait current-turn Hindsight recall

### DIFF
--- a/agent/memory_manager.py
+++ b/agent/memory_manager.py
@@ -544,6 +544,31 @@ class MemoryManager:
                 )
         return "\n\n".join(parts)
 
+    def start_prefetch_all(
+        self,
+        query: str,
+        *,
+        session_id: str = "",
+        turn_number: int = 0,
+    ) -> None:
+        """Let providers start current-turn recall without delaying the turn."""
+        clean_query = self._strip_skill_scaffolding(query)
+        if not clean_query:
+            return
+        for provider in self._providers:
+            try:
+                provider.start_prefetch(
+                    clean_query,
+                    session_id=session_id,
+                    turn_number=turn_number,
+                )
+            except Exception as e:
+                logger.debug(
+                    "Memory provider '%s' start_prefetch failed (non-fatal): %s",
+                    provider.name,
+                    e,
+                )
+
     def _prefetch_provider(
         self, provider: MemoryProvider, query: str, *, session_id: str = ""
     ) -> str:

--- a/agent/memory_provider.py
+++ b/agent/memory_provider.py
@@ -177,6 +177,20 @@ class MemoryProvider(ABC):
         """
         return ""
 
+    def start_prefetch(
+        self,
+        query: str,
+        *,
+        session_id: str = "",
+        turn_number: int = 0,
+    ) -> None:
+        """Optionally start current-turn recall without waiting.
+
+        Called near turn start. Providers may begin asynchronous work here;
+        :meth:`prefetch` later collects only results that are already ready.
+        The default is a no-op, preserving existing provider behavior.
+        """
+
     def queue_prefetch(self, query: str, *, session_id: str = "") -> None:
         """Queue a background recall for the NEXT turn.
 

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -700,6 +700,24 @@ def build_turn_context(
     # Preserve the original user message (no nudge injection).
     original_user_message = persist_user_message if persist_user_message is not None else user_message
 
+    # Give memory providers the full remainder of the turn prologue to recall
+    # against the current query. This hook must return immediately; providers
+    # collect only already-ready results at the existing prefetch boundary
+    # below, before api_content is finalized and persisted.
+    if agent._memory_manager:
+        try:
+            _early_query = (
+                original_user_message if isinstance(original_user_message, str) else ""
+            )
+            if not is_trivial_prompt(_early_query):
+                agent._memory_manager.start_prefetch_all(
+                    _early_query,
+                    session_id=agent.session_id or "",
+                    turn_number=agent._user_turn_count,
+                )
+        except Exception:
+            pass
+
     # Track memory nudge trigger (turn-based, checked here).
     should_review_memory = False
     if (agent._memory_nudge_interval > 0

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -704,6 +704,7 @@ def build_turn_context(
     # against the current query. This hook must return immediately; providers
     # collect only already-ready results at the existing prefetch boundary
     # below, before api_content is finalized and persisted.
+    _early_prefetch_session_id = agent.session_id or ""
     if agent._memory_manager:
         try:
             _early_query = (
@@ -712,7 +713,7 @@ def build_turn_context(
             if not is_trivial_prompt(_early_query):
                 agent._memory_manager.start_prefetch_all(
                     _early_query,
-                    session_id=agent.session_id or "",
+                    session_id=_early_prefetch_session_id,
                     turn_number=agent._user_turn_count,
                 )
         except Exception:
@@ -1299,7 +1300,24 @@ def build_turn_context(
         try:
             _query = original_user_message if isinstance(original_user_message, str) else ""
             if not is_trivial_prompt(_query):
-                ext_prefetch_cache = agent._memory_manager.prefetch_all(_query) or ""
+                _prefetch_session_id = agent.session_id or ""
+                # Compression may rotate the session after the early launch.
+                # Hindsight correctly invalidates the old generation at that
+                # boundary, so give the new session its own launch before the
+                # zero-wait collection point.
+                if _prefetch_session_id != _early_prefetch_session_id:
+                    agent._memory_manager.start_prefetch_all(
+                        _query,
+                        session_id=_prefetch_session_id,
+                        turn_number=agent._user_turn_count,
+                    )
+                ext_prefetch_cache = (
+                    agent._memory_manager.prefetch_all(
+                        _query,
+                        session_id=_prefetch_session_id,
+                    )
+                    or ""
+                )
         except Exception:
             pass
         # Deterministic, model-independent recall indicator: when memory was

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -705,6 +705,7 @@ def build_turn_context(
     # collect only already-ready results at the existing prefetch boundary
     # below, before api_content is finalized and persisted.
     _early_prefetch_session_id = agent.session_id or ""
+    _prefetch_invalidated_by_idle_compression = False
     if agent._memory_manager:
         try:
             _early_query = (
@@ -857,6 +858,7 @@ def build_turn_context(
                 # must leave the turn's flush baseline and user-message index
                 # untouched.
                 if messages is not _idle_input:
+                    _prefetch_invalidated_by_idle_compression = True
                     conversation_history = conversation_history_after_compression(
                         agent, messages, conversation_history
                     )
@@ -1301,11 +1303,15 @@ def build_turn_context(
             _query = original_user_message if isinstance(original_user_message, str) else ""
             if not is_trivial_prompt(_query):
                 _prefetch_session_id = agent.session_id or ""
-                # Compression may rotate the session after the early launch.
-                # Hindsight correctly invalidates the old generation at that
-                # boundary, so give the new session its own launch before the
+                # Compression may invalidate the early launch, either by
+                # rotating the session or by rewinding it in place. Give the
+                # post-compression generation its own launch before the
                 # zero-wait collection point.
-                if _prefetch_session_id != _early_prefetch_session_id:
+                if (
+                    _prefetch_session_id != _early_prefetch_session_id
+                    or _prefetch_invalidated_by_idle_compression
+                    or _preflight_compressed
+                ):
                     agent._memory_manager.start_prefetch_all(
                         _query,
                         session_id=_prefetch_session_id,

--- a/plugins/memory/hindsight/README.md
+++ b/plugins/memory/hindsight/README.md
@@ -78,6 +78,7 @@ Config file: `~/.hermes/hindsight/config.json`
 | `recall_types` | `observation` | Fact types surfaced by recall (both auto-recall and the `hindsight_recall` tool). Comma-separated string or JSON list. **Default narrowed to `observation` only** (see "Behavior change" below). Set to `observation,world,experience` to also include raw facts. |
 | `auto_recall` | `true` | Automatically recall memories before each turn |
 | `recall_sync` | `false` | Recall synchronously against the *current* message each turn (higher relevance, adds recall latency). Default off: recall runs in the background and is injected on the next turn. |
+| `recall_async` | `false` | Start current-message recall at turn start without waiting. Inject it when ready before request construction; otherwise carry the late result to the next turn. `recall_sync` takes precedence when both are enabled. |
 | `recall_indicator` | `true` | Show a `👁️ Hindsight — recalled N memories` status line when auto-recall injects memory. Turn off for customer-facing agents. |
 
 > **Behavior change — `recall_types` defaults to `observation` only.**

--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -68,6 +68,14 @@ class _RecallResult:
     text: str
     count: int
 
+
+@dataclass(frozen=True)
+class _ReadyRecall:
+    session_id: str
+    turn_number: int
+    query: str
+    result: _RecallResult
+
 _DEFAULT_API_URL = "https://api.hindsight.vectorize.io"
 _DEFAULT_LOCAL_URL = "http://localhost:8888"
 # Keep in sync with tools/lazy_deps.py ("memory.hindsight") and plugin.yaml.
@@ -773,6 +781,10 @@ class HindsightMemoryProvider(MemoryProvider):
         self._prefetch_count = 0
         self._prefetch_lock = threading.Lock()
         self._prefetch_thread = None
+        self._opportunistic_ready: list[_ReadyRecall] = []
+        self._opportunistic_generation = 0
+        self._opportunistic_inflight: tuple[str, int, str] | None = None
+        self._opportunistic_pending: tuple[str, int, str] | None = None
         # State for the model-independent recall indicator (see recall_status()).
         # _last_recall_returned tracks whether the most recent prefetch() handed
         # any memory to the agent this turn; _last_recall_count is how many.
@@ -845,6 +857,7 @@ class HindsightMemoryProvider(MemoryProvider):
         # Recall controls
         self._auto_recall = True
         self._recall_sync = False
+        self._recall_async = False
         self._recall_max_tokens = 4096
         # Default to observation-only recall. Observations are Hindsight's
         # consolidated knowledge layer — deduplicated, evidence-grounded
@@ -1193,6 +1206,7 @@ class HindsightMemoryProvider(MemoryProvider):
             {"key": "recall_types", "description": "Fact types to surface on recall — applies to both auto-recall and the hindsight_recall tool (comma-separated or list). Defaults to observation-only — observations are Hindsight's consolidated, deduplicated, evidence-grounded knowledge layer; raw world/experience facts are the supporting evidence observations already summarize. Set to e.g. 'observation,world,experience' to also include raw facts.", "default": "observation"},
             {"key": "auto_recall", "description": "Automatically recall memories before each turn", "default": True},
             {"key": "recall_sync", "description": "Recall synchronously against the current message before each turn (higher relevance, adds recall latency to the turn). Default off: recall runs in the background and is injected on the next turn.", "default": False},
+            {"key": "recall_async", "description": "Start recall for the current message at turn start and inject it only if ready before request construction, without waiting. Late results remain available for the next turn. recall_sync takes precedence.", "default": False},
             {"key": "recall_indicator", "description": "Show a '👁️ Hindsight — recalled N memories' status line when auto-recall injects memory (turn off for customer-facing agents)", "default": True},
             {"key": "retain_indicator", "description": "Show a '👁️ Hindsight — saving to memory…' status line when a turn is saved to memory (turn off for customer-facing agents)", "default": True},
             {"key": "auto_retain", "description": "Automatically retain conversation turns", "default": True},
@@ -1701,6 +1715,7 @@ class HindsightMemoryProvider(MemoryProvider):
         # Recall controls
         self._auto_recall = self._config.get("auto_recall", True)
         self._recall_sync = bool(self._config.get("recall_sync", False))
+        self._recall_async = bool(self._config.get("recall_async", False))
         self._recall_max_tokens = int(self._config.get("recall_max_tokens", 4096))
         # Default narrows recall to observation-only; pass an explicit
         # `recall_types` list in config.json to broaden (e.g. include
@@ -1923,6 +1938,47 @@ class HindsightMemoryProvider(MemoryProvider):
             self._record_recall_indicator(returned=bool(recalled.text), count=recalled.count)
             return self._format_recall(recalled.text)
 
+        if self._recall_async:
+            active_session = str(session_id or self._session_id or "")
+            with self._prefetch_lock:
+                current_idx = next(
+                    (
+                        idx
+                        for idx, ready in enumerate(self._opportunistic_ready)
+                        if ready.session_id == active_session and ready.query == query
+                    ),
+                    None,
+                )
+                fallback_idx = next(
+                    (
+                        idx
+                        for idx, ready in enumerate(self._opportunistic_ready)
+                        if ready.session_id == active_session
+                    ),
+                    None,
+                )
+                if current_idx is not None:
+                    ready = self._opportunistic_ready[current_idx]
+                    # A query-aligned result supersedes every older fallback
+                    # owned by this session; retaining them would inject stale
+                    # context on a later turn and let the queue grow forever.
+                    self._opportunistic_ready = [
+                        item
+                        for item in self._opportunistic_ready
+                        if item.session_id != active_session
+                    ]
+                else:
+                    ready = (
+                        self._opportunistic_ready.pop(fallback_idx)
+                        if fallback_idx is not None
+                        else None
+                    )
+            recalled = ready.result if ready is not None else _RecallResult("", 0)
+            self._record_recall_indicator(
+                returned=bool(recalled.text), count=recalled.count
+            )
+            return self._format_recall(recalled.text)
+
         # Default: return the result the background worker prefetched for the
         # previous turn (cheap buffer read, capped join).
         if self._prefetch_thread and self._prefetch_thread.is_alive():
@@ -1935,6 +1991,54 @@ class HindsightMemoryProvider(MemoryProvider):
             self._prefetch_count = 0
         self._record_recall_indicator(returned=bool(result), count=count)
         return self._format_recall(result)
+
+    def start_prefetch(
+        self,
+        query: str,
+        *,
+        session_id: str = "",
+        turn_number: int = 0,
+    ) -> None:
+        """Start an opt-in current-turn recall without delaying the turn."""
+        if self._recall_sync or not self._recall_async or self._recall_disabled():
+            return
+        key = (str(session_id or self._session_id or ""), int(turn_number), query)
+        with self._prefetch_lock:
+            if self._opportunistic_inflight == key or any(
+                (ready.session_id, ready.turn_number, ready.query) == key
+                for ready in self._opportunistic_ready
+            ):
+                return
+            if self._opportunistic_inflight is not None:
+                self._opportunistic_pending = key
+                return
+            generation = self._opportunistic_generation
+            self._opportunistic_inflight = key
+
+        def _run():
+            active_key = key
+            active_generation = generation
+            while active_key is not None:
+                recalled = self._do_recall(active_key[2])
+                with self._prefetch_lock:
+                    current_generation = self._opportunistic_generation
+                    if active_generation == current_generation and recalled.text:
+                        self._opportunistic_ready.append(
+                            _ReadyRecall(
+                                active_key[0], active_key[1], active_key[2], recalled
+                            )
+                        )
+                    active_key = self._opportunistic_pending
+                    self._opportunistic_pending = None
+                    self._opportunistic_inflight = active_key
+                    active_generation = current_generation
+
+        self._prefetch_thread = threading.Thread(
+            target=_run,
+            daemon=True,
+            name="hindsight-prefetch",
+        )
+        self._prefetch_thread.start()
 
     def recall_status(self) -> Optional[RecallStatus]:
         """Report the count injected by the last prefetch (for the UI indicator).
@@ -1950,7 +2054,7 @@ class HindsightMemoryProvider(MemoryProvider):
     def queue_prefetch(self, query: str, *, session_id: str = "") -> None:
         # In synchronous mode prefetch() does a live recall each turn, so
         # there's nothing to prime in the background.
-        if self._recall_sync:
+        if self._recall_sync or self._recall_async:
             return
         if self._recall_disabled():
             return
@@ -2358,6 +2462,12 @@ class HindsightMemoryProvider(MemoryProvider):
             self._prefetch_thread.join(timeout=3.0)
         with self._prefetch_lock:
             self._prefetch_result = ""
+            self._prefetch_count = 0
+            self._opportunistic_generation += 1
+            self._opportunistic_ready.clear()
+            self._opportunistic_pending = None
+            if not (self._prefetch_thread and self._prefetch_thread.is_alive()):
+                self._opportunistic_inflight = None
 
         # 3. Now rotate to the new session.
         if parent_session_id:

--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -2464,9 +2464,34 @@ class HindsightMemoryProvider(MemoryProvider):
         with self._prefetch_lock:
             self._prefetch_result = ""
             self._prefetch_count = 0
-            self._opportunistic_generation += 1
-            self._opportunistic_ready.clear()
-            self._opportunistic_pending = None
+            if new_id == self._session_id:
+                # Rewind/in-place compression invalidates every result owned by
+                # this session's previous transcript generation.
+                self._opportunistic_generation += 1
+                self._opportunistic_ready.clear()
+                self._opportunistic_pending = None
+            else:
+                # /new publishes the agent's new session id before its deferred
+                # provider boundary completes. Preserve work that a prompt has
+                # already launched for that new id while rejecting old-session
+                # results. If the active call is old, bumping the generation
+                # drops it; the worker rebases a preserved new-session pending
+                # key onto the new generation when it advances.
+                self._opportunistic_ready = [
+                    item
+                    for item in self._opportunistic_ready
+                    if item.session_id == new_id
+                ]
+                if (
+                    self._opportunistic_pending is not None
+                    and self._opportunistic_pending[0] != new_id
+                ):
+                    self._opportunistic_pending = None
+                if (
+                    self._opportunistic_inflight is not None
+                    and self._opportunistic_inflight[0] != new_id
+                ):
+                    self._opportunistic_generation += 1
             if not (self._prefetch_thread and self._prefetch_thread.is_alive()):
                 self._opportunistic_inflight = None
 

--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -1944,8 +1944,9 @@ class HindsightMemoryProvider(MemoryProvider):
                 current_idx = next(
                     (
                         idx
-                        for idx, ready in enumerate(self._opportunistic_ready)
-                        if ready.session_id == active_session and ready.query == query
+                        for idx in range(len(self._opportunistic_ready) - 1, -1, -1)
+                        if self._opportunistic_ready[idx].session_id == active_session
+                        and self._opportunistic_ready[idx].query == query
                     ),
                     None,
                 )

--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -2464,12 +2464,22 @@ class HindsightMemoryProvider(MemoryProvider):
         with self._prefetch_lock:
             self._prefetch_result = ""
             self._prefetch_count = 0
+            prefetch_alive = bool(
+                self._prefetch_thread and self._prefetch_thread.is_alive()
+            )
             if new_id == self._session_id:
                 # Rewind/in-place compression invalidates every result owned by
-                # this session's previous transcript generation.
+                # this session's previous transcript generation. A live worker
+                # cannot be cancelled, so queue its latest requested key to run
+                # again after the stale generation is rejected.
+                retry_key = (
+                    self._opportunistic_pending or self._opportunistic_inflight
+                    if prefetch_alive
+                    else None
+                )
                 self._opportunistic_generation += 1
                 self._opportunistic_ready.clear()
-                self._opportunistic_pending = None
+                self._opportunistic_pending = retry_key
             else:
                 # /new publishes the agent's new session id before its deferred
                 # provider boundary completes. Preserve work that a prompt has
@@ -2492,7 +2502,7 @@ class HindsightMemoryProvider(MemoryProvider):
                     and self._opportunistic_inflight[0] != new_id
                 ):
                     self._opportunistic_generation += 1
-            if not (self._prefetch_thread and self._prefetch_thread.is_alive()):
+            if not prefetch_alive:
                 self._opportunistic_inflight = None
 
         # 3. Now rotate to the new session.

--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -2470,11 +2470,12 @@ class HindsightMemoryProvider(MemoryProvider):
             if new_id == self._session_id:
                 # Rewind/in-place compression invalidates every result owned by
                 # this session's previous transcript generation. A live worker
-                # cannot be cancelled, so queue its latest requested key to run
-                # again after the stale generation is rejected.
+                # cannot be cancelled. Compression still owns the current turn,
+                # so queue its latest requested key to run again after the stale
+                # generation is rejected; rewind/reset boundaries must drop it.
                 retry_key = (
                     self._opportunistic_pending or self._opportunistic_inflight
-                    if prefetch_alive
+                    if prefetch_alive and kwargs.get("reason") == "compression"
                     else None
                 )
                 self._opportunistic_generation += 1

--- a/tests/agent/test_api_content_sidecar.py
+++ b/tests/agent/test_api_content_sidecar.py
@@ -246,6 +246,31 @@ def _stub_runtime_main():
 
 
 class TestPrologueStamping:
+    def test_starts_current_recall_before_collecting_ready_context(self):
+        agent = _FakeAgent()
+        calls = []
+        agent._memory_manager = types.SimpleNamespace(
+            start_prefetch_all=lambda query, **kwargs: calls.append(
+                ("start", query, kwargs)
+            ),
+            on_turn_start=lambda *args, **kwargs: calls.append(("turn", args, kwargs)),
+            prefetch_all=lambda query: calls.append(("collect", query)) or "ready memory",
+            describe_recall=lambda: "",
+        )
+
+        with patch("hermes_cli.plugins.invoke_hook", return_value=[]):
+            ctx = _build(agent, user_message="current query")
+
+        assert calls[0] == (
+            "start",
+            "current query",
+            {"session_id": "sess-1", "turn_number": 1},
+        )
+        assert next(i for i, call in enumerate(calls) if call[0] == "start") < next(
+            i for i, call in enumerate(calls) if call[0] == "collect"
+        )
+        assert "ready memory" in ctx.ext_prefetch_cache
+
     def test_stamps_api_content_from_plugin_context(self):
         agent = _FakeAgent()
         with patch(

--- a/tests/agent/test_api_content_sidecar.py
+++ b/tests/agent/test_api_content_sidecar.py
@@ -254,7 +254,9 @@ class TestPrologueStamping:
                 ("start", query, kwargs)
             ),
             on_turn_start=lambda *args, **kwargs: calls.append(("turn", args, kwargs)),
-            prefetch_all=lambda query: calls.append(("collect", query)) or "ready memory",
+            prefetch_all=lambda query, **kwargs: calls.append(
+                ("collect", query, kwargs)
+            ) or "ready memory",
             describe_recall=lambda: "",
         )
 
@@ -270,6 +272,45 @@ class TestPrologueStamping:
             i for i, call in enumerate(calls) if call[0] == "collect"
         )
         assert "ready memory" in ctx.ext_prefetch_cache
+
+    def test_restarts_current_recall_when_prologue_rotates_session(self):
+        agent = _FakeAgent()
+        calls = []
+        agent._memory_manager = types.SimpleNamespace(
+            start_prefetch_all=lambda query, **kwargs: calls.append(
+                ("start", query, kwargs)
+            ),
+            on_turn_start=lambda *args, **kwargs: None,
+            prefetch_all=lambda query, **kwargs: calls.append(
+                ("collect", query, kwargs)
+            ) or "",
+            describe_recall=lambda: "",
+        )
+
+        def _rotate_session(*_args, **_kwargs):
+            agent.session_id = "sess-2"
+            return []
+
+        with patch("hermes_cli.plugins.invoke_hook", side_effect=_rotate_session):
+            _build(agent, user_message="current query")
+
+        assert [call for call in calls if call[0] == "start"] == [
+            (
+                "start",
+                "current query",
+                {"session_id": "sess-1", "turn_number": 1},
+            ),
+            (
+                "start",
+                "current query",
+                {"session_id": "sess-2", "turn_number": 1},
+            ),
+        ]
+        assert calls[-1] == (
+            "collect",
+            "current query",
+            {"session_id": "sess-2"},
+        )
 
     def test_stamps_api_content_from_plugin_context(self):
         agent = _FakeAgent()

--- a/tests/agent/test_memory_provider.py
+++ b/tests/agent/test_memory_provider.py
@@ -25,6 +25,7 @@ class FakeMemoryProvider(MemoryProvider):
         self.initialized = False
         self.synced_turns = []
         self.prefetch_queries = []
+        self.started_prefetches = []
         self.queued_prefetches = []
         self.turn_starts = []
         self.session_end_called = False
@@ -51,6 +52,9 @@ class FakeMemoryProvider(MemoryProvider):
     def prefetch(self, query, *, session_id=""):
         self.prefetch_queries.append(query)
         return self._prefetch_result
+
+    def start_prefetch(self, query, *, session_id="", turn_number=0):
+        self.started_prefetches.append((query, session_id, turn_number))
 
     def queue_prefetch(self, query, *, session_id=""):
         self.queued_prefetches.append(query)
@@ -152,6 +156,15 @@ class TestMemoryManager:
         assert mgr.get_all_tool_schemas() == []
         assert mgr.build_system_prompt() == ""
         assert mgr.prefetch_all("test") == ""
+
+    def test_start_prefetch_all_propagates_query_identity(self):
+        mgr = MemoryManager()
+        provider = FakeMemoryProvider("builtin")
+        mgr.add_provider(provider)
+
+        mgr.start_prefetch_all("current query", session_id="session-1", turn_number=7)
+
+        assert provider.started_prefetches == [("current query", "session-1", 7)]
 
     def test_add_provider(self):
         mgr = MemoryManager()

--- a/tests/agent/test_memory_session_switch.py
+++ b/tests/agent/test_memory_session_switch.py
@@ -187,6 +187,11 @@ def _make_hindsight_provider():
     provider._prefetch_thread = None
     provider._prefetch_lock = threading.Lock()
     provider._prefetch_result = ""
+    provider._prefetch_count = 0
+    provider._opportunistic_generation = 0
+    provider._opportunistic_ready = []
+    provider._opportunistic_inflight = None
+    provider._opportunistic_pending = None
     # Sync thread tracking (legacy alias at the writer).
     provider._sync_thread = None
     # Writer queue infra the flush-on-switch path enqueues onto. We stub

--- a/tests/agent/test_turn_context.py
+++ b/tests/agent/test_turn_context.py
@@ -246,7 +246,7 @@ def test_prefetch_runs_for_substantive_user_message():
     agent, mm = _agent_with_memory_manager()
     query = "what did we decide about the deploy pipeline?"
     ctx = _build(agent, user_message=query)
-    mm.prefetch_all.assert_called_once_with(query)
+    mm.prefetch_all.assert_called_once_with(query, session_id="sess-1")
     assert ctx.ext_prefetch_cache == "REMEMBERED CONTEXT"
 
 

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -682,6 +682,26 @@ class TestPrefetch:
         )
         assert p.prefetch("next query", session_id="test-session") == ""
 
+    def test_recall_async_repeated_query_prefers_current_turn(self, provider_with_config):
+        p = provider_with_config(recall_async=True)
+
+        async def _recall(**kwargs):
+            turn = p._client.arecall.await_count
+            return SimpleNamespace(
+                results=[SimpleNamespace(text=f"memory from turn {turn}")]
+            )
+
+        p._client.arecall = AsyncMock(side_effect=_recall)
+        p.start_prefetch("same query", session_id="test-session", turn_number=1)
+        p._prefetch_thread.join(timeout=2.0)
+        p.start_prefetch("same query", session_id="test-session", turn_number=2)
+        p._prefetch_thread.join(timeout=2.0)
+
+        result = p.prefetch("same query", session_id="test-session")
+        assert "memory from turn 2" in result
+        assert "memory from turn 1" not in result
+        assert p.prefetch("next query", session_id="test-session") == ""
+
     def test_async_default_ignores_current_query_and_reads_buffer(self, provider):
         # Default (recall_sync off): prefetch returns the buffered result and
         # does NOT issue a live recall for the current query.

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -671,7 +671,7 @@ class TestPrefetch:
         real_join = worker.join
         worker.join = lambda timeout=None: None
 
-        p.on_session_switch("test-session")
+        p.on_session_switch("test-session", reason="compression")
         p.start_prefetch("current query", session_id="test-session", turn_number=1)
         release_first.set()
         real_join(timeout=2.0)
@@ -680,6 +680,34 @@ class TestPrefetch:
         assert "current query" in p.prefetch(
             "current query", session_id="test-session"
         )
+
+    def test_recall_async_drops_inflight_after_same_session_rewind(
+        self, provider_with_config
+    ):
+        p = provider_with_config(recall_async=True)
+        recall_started = threading.Event()
+        release_recall = threading.Event()
+        queries = []
+
+        async def _recall(**kwargs):
+            queries.append(kwargs["query"])
+            recall_started.set()
+            release_recall.wait(timeout=2.0)
+            return SimpleNamespace(results=[SimpleNamespace(text=kwargs["query"])])
+
+        p._client.arecall = AsyncMock(side_effect=_recall)
+        p.start_prefetch("removed query", session_id="test-session", turn_number=1)
+        assert recall_started.wait(timeout=2.0)
+        worker = p._prefetch_thread
+        real_join = worker.join
+        worker.join = lambda timeout=None: None
+
+        p.on_session_switch("test-session", rewound=True)
+        release_recall.set()
+        real_join(timeout=2.0)
+
+        assert queries == ["removed query"]
+        assert p.prefetch("next query", session_id="test-session") == ""
 
     def test_recall_async_never_waits_and_carries_late_result(self, provider_with_config):
         p = provider_with_config(recall_async=True)

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -649,6 +649,38 @@ class TestPrefetch:
 
         assert "new query" in p.prefetch("next query", session_id="new-session")
 
+    def test_recall_async_retries_inflight_after_same_session_compression(
+        self, provider_with_config
+    ):
+        p = provider_with_config(recall_async=True)
+        first_started = threading.Event()
+        release_first = threading.Event()
+        queries = []
+
+        async def _recall(**kwargs):
+            queries.append(kwargs["query"])
+            if len(queries) == 1:
+                first_started.set()
+                release_first.wait(timeout=2.0)
+            return SimpleNamespace(results=[SimpleNamespace(text=kwargs["query"])])
+
+        p._client.arecall = AsyncMock(side_effect=_recall)
+        p.start_prefetch("current query", session_id="test-session", turn_number=1)
+        assert first_started.wait(timeout=2.0)
+        worker = p._prefetch_thread
+        real_join = worker.join
+        worker.join = lambda timeout=None: None
+
+        p.on_session_switch("test-session")
+        p.start_prefetch("current query", session_id="test-session", turn_number=1)
+        release_first.set()
+        real_join(timeout=2.0)
+
+        assert queries == ["current query", "current query"]
+        assert "current query" in p.prefetch(
+            "current query", session_id="test-session"
+        )
+
     def test_recall_async_never_waits_and_carries_late_result(self, provider_with_config):
         p = provider_with_config(recall_async=True)
         recall_started = threading.Event()

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -624,6 +624,31 @@ class TestPrefetch:
 
         assert new_completed.wait(timeout=2.0)
 
+    def test_recall_async_preserves_new_session_inflight_before_deferred_switch(
+        self, provider_with_config
+    ):
+        p = provider_with_config(recall_async=True)
+        recall_started = threading.Event()
+        release_recall = threading.Event()
+
+        async def _recall(**kwargs):
+            recall_started.set()
+            release_recall.wait(timeout=2.0)
+            return SimpleNamespace(results=[SimpleNamespace(text=kwargs["query"])])
+
+        p._client.arecall = AsyncMock(side_effect=_recall)
+        p.start_prefetch("new query", session_id="new-session", turn_number=1)
+        assert recall_started.wait(timeout=2.0)
+        worker = p._prefetch_thread
+        real_join = worker.join
+        worker.join = lambda timeout=None: None
+
+        p.on_session_switch("new-session")
+        release_recall.set()
+        real_join(timeout=2.0)
+
+        assert "new query" in p.prefetch("next query", session_id="new-session")
+
     def test_recall_async_never_waits_and_carries_late_result(self, provider_with_config):
         p = provider_with_config(recall_async=True)
         recall_started = threading.Event()

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -10,6 +10,7 @@ import os
 import re
 import stat
 import sys
+import threading
 import time
 from pathlib import Path
 from types import SimpleNamespace
@@ -538,6 +539,148 @@ class TestPrefetch:
         p = provider_with_config(recall_sync=True)
         p.queue_prefetch("anything")
         assert p._prefetch_thread is None
+
+    def test_recall_async_injects_current_query_when_ready(self, provider_with_config):
+        p = provider_with_config(recall_async=True)
+        completed = threading.Event()
+
+        async def _recall(**kwargs):
+            completed.set()
+            return SimpleNamespace(
+                results=[SimpleNamespace(text=f"memory for {kwargs['query']}")]
+            )
+
+        p._client.arecall = AsyncMock(side_effect=_recall)
+
+        p.start_prefetch("current query", session_id="test-session", turn_number=1)
+        assert completed.wait(timeout=2.0)
+        p._prefetch_thread.join(timeout=2.0)
+
+        result = p.prefetch("current query", session_id="test-session")
+        assert "memory for current query" in result
+        p._client.arecall.assert_called_once()
+
+    def test_recall_async_single_flight_runs_latest_pending_query(self, provider_with_config):
+        p = provider_with_config(recall_async=True)
+        first_started = threading.Event()
+        release_first = threading.Event()
+        second_completed = threading.Event()
+        queries = []
+
+        async def _recall(**kwargs):
+            query = kwargs["query"]
+            queries.append(query)
+            if query == "first query":
+                first_started.set()
+                release_first.wait(timeout=2.0)
+            else:
+                second_completed.set()
+            return SimpleNamespace(results=[SimpleNamespace(text=f"memory for {query}")])
+
+        p._client.arecall = AsyncMock(side_effect=_recall)
+
+        p.start_prefetch("first query", session_id="test-session", turn_number=1)
+        assert first_started.wait(timeout=2.0)
+        p.start_prefetch("second query", session_id="test-session", turn_number=2)
+        release_first.set()
+
+        assert second_completed.wait(timeout=2.0)
+        p._prefetch_thread.join(timeout=2.0)
+        assert queries == ["first query", "second query"]
+
+    def test_recall_async_drops_ready_result_across_session_switch(self, provider_with_config):
+        p = provider_with_config(recall_async=True)
+        p.start_prefetch("old query", session_id="test-session", turn_number=1)
+        p._prefetch_thread.join(timeout=2.0)
+
+        p.on_session_switch("new-session")
+        p.on_session_switch("test-session")
+
+        assert p.prefetch("old query", session_id="test-session") == ""
+
+    def test_recall_async_queues_new_session_behind_stale_inflight(self, provider_with_config):
+        p = provider_with_config(recall_async=True)
+        old_started = threading.Event()
+        release_old = threading.Event()
+        new_completed = threading.Event()
+
+        async def _recall(**kwargs):
+            if kwargs["query"] == "old query":
+                old_started.set()
+                release_old.wait(timeout=2.0)
+            else:
+                new_completed.set()
+            return SimpleNamespace(results=[SimpleNamespace(text=kwargs["query"])])
+
+        p._client.arecall = AsyncMock(side_effect=_recall)
+        p.start_prefetch("old query", session_id="test-session", turn_number=1)
+        assert old_started.wait(timeout=2.0)
+        p._prefetch_thread.join = lambda timeout=None: None
+
+        p.on_session_switch("new-session")
+        p.start_prefetch("new query", session_id="new-session", turn_number=1)
+        assert not new_completed.is_set()
+        release_old.set()
+
+        assert new_completed.wait(timeout=2.0)
+
+    def test_recall_async_never_waits_and_carries_late_result(self, provider_with_config):
+        p = provider_with_config(recall_async=True)
+        recall_started = threading.Event()
+        release_recall = threading.Event()
+        collect_returned = threading.Event()
+        collected = []
+
+        async def _recall(**kwargs):
+            recall_started.set()
+            release_recall.wait(timeout=2.0)
+            return SimpleNamespace(results=[SimpleNamespace(text="late memory")])
+
+        p._client.arecall = AsyncMock(side_effect=_recall)
+        p.start_prefetch("slow query", session_id="test-session", turn_number=1)
+        assert recall_started.wait(timeout=2.0)
+
+        def _collect():
+            collected.append(p.prefetch("slow query", session_id="test-session"))
+            collect_returned.set()
+
+        collector = threading.Thread(target=_collect)
+        collector.start()
+        assert collect_returned.wait(timeout=0.5)
+        assert collected == [""]
+
+        release_recall.set()
+        p._prefetch_thread.join(timeout=2.0)
+        assert "late memory" in p.prefetch("next query", session_id="test-session")
+
+    def test_recall_sync_takes_precedence_over_recall_async(self, provider_with_config):
+        p = provider_with_config(recall_sync=True, recall_async=True)
+
+        p.start_prefetch("current query", session_id="test-session", turn_number=1)
+        assert p._prefetch_thread is None
+
+        result = p.prefetch("current query", session_id="test-session")
+        assert "Memory 1" in result
+        p._client.arecall.assert_called_once()
+
+    def test_recall_async_current_result_supersedes_older_fallback(self, provider_with_config):
+        p = provider_with_config(recall_async=True)
+
+        async def _recall(**kwargs):
+            return SimpleNamespace(
+                results=[SimpleNamespace(text=f"memory for {kwargs['query']}")]
+            )
+
+        p._client.arecall = AsyncMock(side_effect=_recall)
+        p.start_prefetch("old query", session_id="test-session", turn_number=1)
+        p._prefetch_thread.join(timeout=2.0)
+        p.start_prefetch("current query", session_id="test-session", turn_number=2)
+        p._prefetch_thread.join(timeout=2.0)
+
+        assert "memory for current query" in p.prefetch(
+            "current query", session_id="test-session"
+        )
+        assert p.prefetch("next query", session_id="test-session") == ""
 
     def test_async_default_ignores_current_query_and_reads_buffer(self, provider):
         # Default (recall_sync off): prefetch returns the buffered result and


### PR DESCRIPTION
## What does this PR do?

Adds an opt-in `recall_async` mode for Hindsight so a current-query recall can enrich the same turn when it completes during request preparation, without intentionally delaying model dispatch. If recall is not ready, the result remains available for the next turn, preserving the zero-wait behavior while improving first-turn and query-aligned recall opportunities.

### Motivation

Hindsight currently offers either previous-turn background recall or current-turn synchronous recall. Users who want current-query relevance must accept recall latency, while background recall cannot benefit the first turn and may surface context for the preceding query.

### Behavior

When `recall_async` is enabled, Hermes starts recall near turn start and collects only results already available at the existing pre-request memory sidecar boundary. Late results carry forward to the next turn; requests already in flight are never mutated. The mode is disabled by default, and `recall_sync` takes precedence when both options are configured.

### Implementation

The provider-neutral memory lifecycle now exposes a non-blocking turn-start hook while retaining collection at the existing prompt assembly boundary. Hindsight owns session, turn, query, and generation identity; serializes recalls with latest-pending deduplication; and rejects results invalidated by session switches, compression, or rewind. Deterministic regression tests cover ready-current injection, late carryover, single-flight behavior, repeated-query ownership, session transitions, compression invalidation, rewind rejection, and prompt-sidecar ordering.

## Related Issue

Closes #87178

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Changes Made

- `agent/memory_provider.py` - add the optional provider-neutral current-turn prefetch hook.
- `agent/memory_manager.py` - dispatch non-blocking prefetch starts across configured providers.
- `agent/turn_context.py` - launch recall early and collect only ready results before API content is finalized.
- `plugins/memory/hindsight/__init__.py` - implement opt-in async recall ownership, deduplication, carryover, and invalidation handling.
- `plugins/memory/hindsight/README.md` - document `recall_async` behavior and precedence.
- `tests/agent/` and `tests/plugins/memory/` - cover lifecycle propagation, sidecar ordering, and Hindsight concurrency boundaries.

## How to Test

1. Set `"recall_async": true` in `~/.hermes/hindsight/config.json` and send a prompt with Hindsight auto-recall enabled.
2. Confirm a recall that finishes during turn preparation is included before the first model request, while a slower recall does not delay dispatch and is available on the next turn.
3. Run the related automated suite:

```bash
scripts/run_tests.sh tests/agent/test_memory_provider.py tests/agent/test_api_content_sidecar.py tests/agent/test_memory_session_switch.py tests/agent/test_turn_context.py tests/plugins/memory/test_hindsight_provider.py
```

Result: 211 passed, 1 skipped.

```bash
uv run ruff check agent/memory_manager.py agent/memory_provider.py agent/turn_context.py plugins/memory/hindsight/__init__.py tests/agent/test_memory_provider.py tests/agent/test_api_content_sidecar.py tests/agent/test_memory_session_switch.py tests/agent/test_turn_context.py tests/plugins/memory/test_hindsight_provider.py
```

Result: passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this feature
- [x] I've run the repository test entry on the relevant tests and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation
- [x] `cli-config.yaml.example` is N/A because this provider setting lives in the Hindsight plugin config
- [x] `CONTRIBUTING.md` and `AGENTS.md` are N/A because contributor workflows are unchanged
- [x] I've considered cross-platform impact; the lifecycle uses platform-neutral Python synchronization
- [x] Tool descriptions and schemas are N/A because no model tool behavior changed
