### PR TITLE
fix(desktop): stop headless profile backends from masking API errors and probing the UI

### DIFF
--- a/apps/desktop/electron/dashboard-token.test.ts
+++ b/apps/desktop/electron/dashboard-token.test.ts
@@ -15,6 +15,7 @@ import {
   extractInjectedDashboardToken,
   fetchPublicText,
   isForeignBackendToken,
+  resolveManagedBackendToken,
   resolveServedDashboardToken
 } from './dashboard-token'
 
@@ -144,4 +145,34 @@ test('adoptServedDashboardToken falls back to the spawn token when the fetch fai
   assert.equal(token, 'spawn-token')
   assert.equal(logs.length, 1)
   assert.match(logs[0], /could not read served dashboard token \(Hermes backend\): boom/)
+})
+
+test('resolveManagedBackendToken uses the spawn token for headless serve', async () => {
+  const token = await resolveManagedBackendToken(
+    ['--profile', 'work', 'serve', '--port', '0'],
+    'http://127.0.0.1:9120',
+    'spawn-token',
+    {
+      childAlive: () => true,
+      fetchText: async () => {
+        throw new Error('headless serve must not fetch index.html')
+      }
+    }
+  )
+
+  assert.equal(token, 'spawn-token')
+})
+
+test('resolveManagedBackendToken adopts the served token for legacy dashboard fallback', async () => {
+  const token = await resolveManagedBackendToken(
+    ['dashboard', '--no-open', '--port', '0'],
+    'http://127.0.0.1:9120',
+    'spawn-token',
+    {
+      childAlive: () => true,
+      fetchText: async () => '<script>window.__HERMES_SESSION_TOKEN__="served-token";</script>'
+    }
+  )
+
+  assert.equal(token, 'served-token')
 })

--- a/apps/desktop/electron/dashboard-token.ts
+++ b/apps/desktop/electron/dashboard-token.ts
@@ -101,6 +101,20 @@ async function adoptServedDashboardToken(baseUrl, spawnToken, { childAlive, labe
   return servedToken
 }
 
+/**
+ * Real `hermes serve` children have no index page by contract, so their
+ * explicitly-pinned spawn token is already authoritative. Older runtimes are
+ * rewritten to `dashboard --no-open`; only that compatibility path still
+ * exposes an injected index token that must be reconciled.
+ */
+async function resolveManagedBackendToken(backendArgs, baseUrl, spawnToken, options) {
+  if (backendArgs.includes('serve')) {
+    return spawnToken
+  }
+
+  return adoptServedDashboardToken(baseUrl, spawnToken, options)
+}
+
 export {
   adoptServedDashboardToken,
   dashboardIndexUrl,
@@ -108,5 +122,6 @@ export {
   extractInjectedDashboardToken,
   fetchPublicText,
   isForeignBackendToken,
+  resolveManagedBackendToken,
   resolveServedDashboardToken
 }

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -96,7 +96,7 @@ import {
   upsertConnection
 } from './connection-registry'
 import { describeCrashReason, installCrashForensics } from './crash-forensics'
-import { adoptServedDashboardToken } from './dashboard-token'
+import { adoptServedDashboardToken, resolveManagedBackendToken } from './dashboard-token'
 import { loadOrCreateInstallationId, sshOwnershipId } from './desktop-installation'
 import { formatDesktopLogLine } from './desktop-log-line'
 import {
@@ -9555,7 +9555,7 @@ async function spawnPoolBackend(profile, entry) {
   await Promise.race([waitForHermes(baseUrl, token), startFailed])
   ready = true
 
-  const authToken = await adoptServedDashboardToken(baseUrl, token, {
+  const authToken = await resolveManagedBackendToken(backend.args, baseUrl, token, {
     childAlive: () => child.exitCode === null && !child.killed,
     label: `Hermes backend for profile "${profile}"`,
     rememberLog
@@ -9932,7 +9932,7 @@ async function startHermes() {
     backendReady = true
     backendStartFailure = null
 
-    const authToken = await adoptServedDashboardToken(baseUrl, token, {
+    const authToken = await resolveManagedBackendToken(backend.args, baseUrl, token, {
       childAlive: () => hermesProcess.exitCode === null && !hermesProcess.killed,
       rememberLog
     })

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -16845,6 +16845,11 @@ def mount_spa(application: FastAPI):
 
         @application.get("/{full_path:path}")
         async def no_frontend(full_path: str):
+            if full_path == "api" or full_path.startswith("api/"):
+                return JSONResponse(
+                    {"detail": f"No such API endpoint: /{full_path}"},
+                    status_code=404,
+                )
             return JSONResponse({"error": _msg}, status_code=404)
         return
 

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -4501,6 +4501,25 @@ class TestDesktopCronTicker:
             assert called.wait(3.0), "expected cron tick under HERMES_DESKTOP=1"
 
 
+class TestHeadlessSpaFallback:
+    def test_unmatched_api_path_reports_missing_endpoint(self, tmp_path, monkeypatch):
+        from fastapi import FastAPI
+        from starlette.testclient import TestClient
+        import hermes_cli.web_server as ws
+
+        monkeypatch.setattr(ws, "WEB_DIST", tmp_path / "missing-dist")
+        monkeypatch.setenv("HERMES_SERVE_HEADLESS", "1")
+        spa_app = FastAPI()
+        ws.mount_spa(spa_app)
+
+        response = TestClient(spa_app).get("/api/plugins/missing/state")
+
+        assert response.status_code == 404
+        assert response.json() == {
+            "detail": "No such API endpoint: /api/plugins/missing/state"
+        }
+
+
 class TestServeIndexMissingIndex:
     """_serve_index must not raise per-request when index.html vanishes
     (partial build, wiped dist) after mount_spa saw an existing dist dir.


### PR DESCRIPTION
## What does this PR do?

Headless `hermes serve` profile backends now preserve API-specific 404 responses and no longer probe a dashboard page that does not exist. Without this change, an unmatched plugin/API route is mislabeled as "web UI disabled", and each Desktop-managed backend performs a guaranteed failing `GET /` during startup even though the pinned spawn token is already authoritative.

### Symptom

A request to an unmatched `/api/*` route on a headless backend returns the SPA fallback error instead of an API endpoint error. Desktop startup also logs a failed dashboard-token read for every real `serve` child because it tries to scrape `/`, which is intentionally unavailable in headless mode.

### Impact

Desktop users and plugin operators receive a misleading response when diagnosing missing profile-scoped routes, while managed primary and pooled profile backends perform an unnecessary failing HTTP request during every startup. The verified affected path is the Electron-managed local `serve` backend on Windows; the HTTP fallback behavior itself is platform-independent.

### Bug Cause

**Trigger:** `hermes_cli/web_server.py:mount_spa` for unmatched `/api/*` requests and `apps/desktop/electron/main.ts:spawnPoolBackend` / `startHermes` after a managed backend becomes ready.

**Causal chain:**
1. `hermes serve` mounts a catch-all because the frontend is deliberately disabled.
2. The catch-all treats API misses as UI requests, while Desktop applies dashboard index-token adoption to both real `serve` and legacy `dashboard --no-open` children.
3. API clients receive the unrelated UI-disabled response, and real `serve` children incur a guaranteed 404 index probe before Desktop falls back to the token it already supplied.

**Why it is wrong:** Headless API misses and missing frontend assets are distinct protocols. Real `serve` also has an explicitly pinned spawn token and no index page by contract, so dashboard token scraping cannot produce a better token.

**Working sibling / contrast:** Older runtimes rewritten to `dashboard --no-open` still expose an injected index token and continue using the existing token-adoption path. Non-API frontend misses continue returning the deliberate UI-disabled response.

**Ruled out:** Named profiles are not expected to discover plugins installed only in the default profile. Plugin installation and enablement are profile-scoped, and REAL_ENV verification confirmed that preserving this isolation is the intended behavior.

### Fix

- Return explicit `No such API endpoint` JSON for unmatched `/api/*` paths while preserving the existing headless UI response for non-API paths.
- Resolve tokens for real `serve` children directly from the pinned spawn token, while retaining index-token adoption for the legacy `dashboard --no-open` compatibility path.
- Cover both branches with focused Python and Electron regression tests.

## Related Issue

Fixes #87197

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/web_server.py` - preserve API-specific JSON semantics in the no-frontend catch-all.
- `tests/hermes_cli/test_web_server.py` - verify unmatched headless API routes return the endpoint-specific 404.
- `apps/desktop/electron/dashboard-token.ts` - distinguish real `serve` token resolution from the legacy dashboard fallback.
- `apps/desktop/electron/main.ts` - use the managed backend token resolver for primary and pooled profile children.
- `apps/desktop/electron/dashboard-token.test.ts` - cover both real `serve` and legacy dashboard token behavior.

## How to Test

1. Launch real `hermes serve` backends for the primary and a named profile with a pinned token.
2. Confirm WebSocket authentication succeeds and an unmatched `/api/*` request returns `{"detail":"No such API endpoint: /..."}`, while `/` retains the UI-disabled 404.
3. Confirm a default-profile-only plugin route remains absent from the named profile and that real `serve` startup does not attempt an index-token fetch.
4. Run the focused automated tests:

```bash
scripts/run_tests.sh tests/hermes_cli/test_web_server.py
cd apps/desktop
npx vitest run electron/dashboard-token.test.ts
npm run typecheck
npx eslint electron/dashboard-token.ts electron/dashboard-token.test.ts electron/main.ts
```

Automated results: 154 passed and 5 skipped in the Python suite; 15 passed in the focused Electron suite; Desktop typecheck and focused ESLint passed. The committed tip was also verified against real primary and named-profile `serve` backends on Windows 11.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repository test entry on the relevant tests and all targeted tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - N/A, no user-facing configuration or workflow changed
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - N/A, no config keys changed
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - N/A, no architecture or workflow contract changed
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior - N/A, no model tool changed

## Screenshots / Logs

REAL_ENV verification reproduced the base API fallback and token-probe failures, then verified the committed tip across primary and named-profile real `serve` backends, WebSocket authentication, profile plugin isolation, and explicit unmatched-API JSON responses.
