### PR TITLE
fix(desktop): clear sticky billing error after successful failover

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/message-stream.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/message-stream.ts
@@ -352,8 +352,12 @@ export function handleMessageStreamEvent(ctx: GatewayEventContext): boolean {
 
     // Structured billing wall forwarded by the gateway (out of credits /
     // payment required) — cache it + raise a billing-specific toast.
+    // A successful terminal frame (no billing payload) clears any sticky
+    // wall left from a recovered failover attempt on this session (#87248).
     if (payload?.billing) {
       surfaceBillingBlock(sessionId, payload.billing)
+    } else if (payload?.status !== 'error' && !failure) {
+      clearBillingBlock(sessionId)
     }
 
     if (isActiveEvent) {

--- a/apps/desktop/src/app/session/hooks/use-message-stream/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/index.ts
@@ -625,10 +625,23 @@ export function useMessageStream({
             return { ...settled, error: completionError, parts: settled.parts.filter(part => part.type !== 'text') }
           }
 
+          if (completionError) {
+            return {
+              ...settled,
+              error: completionError,
+              parts: completeOpenTimelineParts(replaceTextPart(settled.parts), occurredAt)
+            }
+          }
+
+          // Successful completion must drop any error retained from an earlier
+          // failed provider attempt on this same stream id (billing failover
+          // that recovered mid-turn — #87248). Spreading `settled` alone would
+          // keep `message.error` forever.
+          const { error: _clearedError, ...withoutError } = settled
+
           return {
-            ...settled,
-            parts: completeOpenTimelineParts(replaceTextPart(settled.parts), occurredAt),
-            ...(completionError ? { error: completionError } : {})
+            ...withoutError,
+            parts: completeOpenTimelineParts(replaceTextPart(settled.parts), occurredAt)
           }
         }
 
@@ -679,6 +692,14 @@ export function useMessageStream({
             )
 
             if (existing.pending || (!interimBoundaryPending && finalText && existingText === finalText)) {
+              nextMessages = prev.map((message, messageIndex) =>
+                messageIndex === index ? completeMessage(message) : message
+              )
+            } else if (existing.error && finalText && !completionError) {
+              // Recovered provider attempt: a successful terminal frame after
+              // a retained error on the same tail assistant (billing failover
+              // that completed cleanly — #87248). Settle in place so the
+              // sticky error bubble is replaced by the real reply.
               nextMessages = prev.map((message, messageIndex) =>
                 messageIndex === index ? completeMessage(message) : message
               )

--- a/apps/desktop/src/app/session/hooks/use-message-stream/terminal-error-frame.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/terminal-error-frame.test.tsx
@@ -112,4 +112,32 @@ describe('terminal error message.complete frames', () => {
     expect(bubble?.error).toBe('kaput')
     expect(bubble?.errorSurface).toBeUndefined()
   })
+
+  it('clears a retained error when the same stream later completes successfully (#87248)', async () => {
+    mountStream()
+    await start()
+    await delta('partial')
+
+    await completeWithError({
+      text: 'HTTP 402: You have depleted your monthly included credits',
+      error: 'HTTP 402: You have depleted your monthly included credits',
+      recoverable: true
+    })
+
+    expect(lastAssistant()?.error).toMatch(/HTTP 402/)
+
+    // In-place failover recovery lands a successful complete on the same stream.
+    await act(() =>
+      stream.handleEvent({
+        payload: { status: 'complete', text: 'Recovered answer from fallback' },
+        session_id: SID,
+        type: 'message.complete'
+      })
+    )
+
+    const bubble = lastAssistant()
+    expect(bubble?.error).toBeUndefined()
+    expect(chatMessageText(bubble!)).toBe('Recovered answer from fallback')
+    expect(getState().messages.filter(m => m.role === 'assistant')).toHaveLength(1)
+  })
 })

--- a/apps/desktop/src/lib/chat-messages.test.ts
+++ b/apps/desktop/src/lib/chat-messages.test.ts
@@ -707,6 +707,41 @@ describe('preserveLocalAssistantErrors', () => {
     expect(assistant?.error).toBe('OpenRouter 403')
     expect(assistant?.pending).toBe(false)
   })
+
+  it('does not re-graft a billing error onto a successfully recovered reply (#87248)', () => {
+    const nextMessages: ChatMessage[] = [
+      {
+        id: 'user-1',
+        parts: [{ text: 'hello', type: 'text' }],
+        role: 'user'
+      },
+      {
+        id: 'assistant-stream-1',
+        parts: [{ text: 'hi from fallback provider', type: 'text' }],
+        role: 'assistant'
+      }
+    ]
+
+    const currentMessages: ChatMessage[] = [
+      {
+        id: 'user-1',
+        parts: [{ text: 'hello', type: 'text' }],
+        role: 'user'
+      },
+      {
+        error: 'HTTP 402: You have depleted your monthly included credits',
+        id: 'assistant-stream-1',
+        parts: [{ text: 'hi from fallback provider', type: 'text' }],
+        role: 'assistant'
+      }
+    ]
+
+    const merged = preserveLocalAssistantErrors(nextMessages, currentMessages)
+    const assistant = merged.find(message => message.id === 'assistant-stream-1')
+
+    expect(assistant?.error).toBeUndefined()
+    expect(chatMessageText(assistant!)).toBe('hi from fallback provider')
+  })
 })
 
 describe('upsertToolPart', () => {

--- a/apps/desktop/src/lib/chat-messages/index.ts
+++ b/apps/desktop/src/lib/chat-messages/index.ts
@@ -13,7 +13,11 @@ export {
   textPart
 } from './parts'
 export type { UnspokenTurnSpeech } from './parts'
-export { branchGroupForUser, preserveLocalAssistantErrors } from './reconciliation'
+export {
+  assistantLooksSuccessfullySettled,
+  branchGroupForUser,
+  preserveLocalAssistantErrors
+} from './reconciliation'
 export {
   restorePendingClarifyToolCall,
   sealOpenToolParts,

--- a/apps/desktop/src/lib/chat-messages/reconciliation.ts
+++ b/apps/desktop/src/lib/chat-messages/reconciliation.ts
@@ -118,6 +118,32 @@ function reconcileLocalAssistantTimeline(nextMessages: ChatMessage[], currentMes
   })
 }
 
+/**
+ * True when the assistant row already looks like a successfully settled reply
+ * (visible text and/or finished tool work). Used so a retained local error from
+ * a recovered provider attempt is not re-grafted onto a successful completion
+ * during session.info hydration (#87248).
+ */
+export function assistantLooksSuccessfullySettled(message: ChatMessage): boolean {
+  if (message.role !== 'assistant' || message.error || message.hidden || message.pending) {
+    return false
+  }
+
+  if (chatMessageText(message).trim()) {
+    return true
+  }
+
+  return message.parts.some(part => {
+    if (part.type !== 'tool-call') {
+      return false
+    }
+
+    const status = 'status' in part ? String(part.status ?? '') : ''
+
+    return status === 'complete' || status === 'done' || status === 'error' || status === 'failed'
+  })
+}
+
 export function preserveLocalAssistantErrors(
   nextMessages: ChatMessage[],
   currentMessages: ChatMessage[]
@@ -133,6 +159,13 @@ export function preserveLocalAssistantErrors(
     const local = localById.get(message.id)
 
     if (!local || local.role !== 'assistant' || !local.error || local.hidden) {
+      return message
+    }
+
+    // Successful failover / recovery: the hydrated row is already a real reply.
+    // Re-grafting the earlier billing/provider error makes a one-shot failure
+    // look permanent across every session.info flush (#87248).
+    if (assistantLooksSuccessfullySettled(message)) {
       return message
     }
 

--- a/apps/desktop/src/store/billing-block.test.ts
+++ b/apps/desktop/src/store/billing-block.test.ts
@@ -2,8 +2,10 @@ import type { BillingBlock } from '@hermes/shared'
 import { beforeEach, expect, test, vi } from 'vitest'
 
 vi.mock('@/lib/external-link', () => ({ openExternalLink: vi.fn() }))
+vi.mock('@/store/notifications', () => ({ dismissNotification: vi.fn() }))
 
 import { openExternalLink } from '@/lib/external-link'
+import { dismissNotification } from '@/store/notifications'
 
 import {
   $billingBlock,
@@ -52,6 +54,7 @@ test('clearBillingBlock with no arg clears any active block', () => {
   setBillingBlock('s1', makeBlock())
   clearBillingBlock()
   expect($billingBlock.get()).toBeNull()
+  expect(dismissNotification).toHaveBeenCalledWith('billing-block:openai')
 })
 
 test('runBillingRecovery routes Nous to in-app Settings, never an external link', () => {

--- a/apps/desktop/src/store/billing-block.ts
+++ b/apps/desktop/src/store/billing-block.ts
@@ -2,13 +2,16 @@ import type { BillingBlock } from '@hermes/shared'
 import { atom } from 'nanostores'
 
 import { openExternalLink } from '@/lib/external-link'
+import { dismissNotification } from '@/store/notifications'
 
 /**
  * The active inference billing wall, if any. Set from the gateway
  * `message.complete` / `error` event when a turn fails with
  * `FailoverReason.billing` (see `agent/billing_links.py`). One global slot: a
  * credit wall on the active session's provider is the whole app's problem, and
- * the newest block wins. Cleared when a new turn starts or the user dismisses.
+ * the newest block wins. Cleared when a new turn starts, a later turn on the
+ * same session completes successfully without a billing payload, or the user
+ * dismisses.
  */
 export interface ActiveBillingBlock {
   block: BillingBlock
@@ -43,6 +46,9 @@ export function clearBillingBlock(sessionId?: string): void {
   }
 
   $billingBlock.set(null)
+  // surfaceBillingBlock raises a sticky toast keyed by provider — drop it with
+  // the banner so a recovered failover does not leave a permanent credit wall.
+  dismissNotification(`billing-block:${current.block.provider}`)
 }
 
 export function requestBillingSettings(): void {


### PR DESCRIPTION
## Problem

After a provider billing/402 failure auto-failovers and the turn **succeeds**, Desktop still shows the failed attempt as a permanent red error bubble. `session.info` re-grafts it via `preserveLocalAssistantErrors`, so it looks like billing fails on every later turn until app restart.

## Root cause

1. `completeAssistantMessage` spread the prior `message.error` onto successful completions.
2. `preserveLocalAssistantErrors` always reattached local errors onto same-id hydrations, even when the hydrated row was already a settled success reply.
3. `$billingBlock` + sticky toast cleared only on the *next* `message.start`, not on successful recovery of the same session.

## Fix

- Strip retained `error` on successful `message.complete` (and settle in place onto a tail error bubble when recovery completes).
- Skip error re-graft when the next assistant row looks successfully settled (`assistantLooksSuccessfullySettled`).
- Clear billing block + dismiss `billing-block:<provider>` toast on successful complete without a billing payload.

Ported onto the post-split modules: `chat-messages/reconciliation.ts` and `gateway-event/message-stream.ts`.

## Why it matters

User-visible Desktop billing UX: a one-shot recovered failover must not look like a recurring credit wall.

## Test plan

```bash
cd apps/desktop
npm run test:ui -- \
  src/lib/chat-messages.test.ts \
  src/store/billing-block.test.ts \
  src/app/session/hooks/use-message-stream/terminal-error-frame.test.tsx
```

**79 passed** @ `3ab659ece3`

Named coverage:
- `preserveLocalAssistantErrors` — no re-graft after recovered success (#87248)
- terminal error frame — success after retained error clears bubble in place
- `clearBillingBlock` dismisses sticky toast

## Risk

Low / desktop-only. True terminal failures still retain errors (empty hydration path unchanged). Billing walls still surface when `message.complete` carries `billing`.

## Closest work

none found for this exact sticky-bubble class (issue still open)

Fixes #87248

### Acceptance retest (2026-08-20)

Re-ported onto current `main` after module split made the prior head CONFLICTING. Mini proof @ `3ab659ece3`: 79 passed (same three files).

## Mini retest (2026-08-24 acceptance)
- Head `2c740ec94d` · npm run test:ui chat-messages+billing+terminal-error → 85 passed
- Rebased onto current upstream `main` (force-with-lease, pre-review)
