### PR TITLE
fix(install): reject non-40-char --commit SHAs and abort on unfetchable pins

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -120,7 +120,17 @@ while [[ $# -gt 0 ]]; do
             shift 2
             ;;
         --commit|-Commit)
-            INSTALL_COMMIT="$2"
+            # A pin the installer cannot honor is worse than no pin: the
+            # fetch-by-SHA below only works for full 40-char SHAs (the remote
+            # refuses abbreviated refs), and an invalid target used to fall
+            # through to a successful-looking unpinned install (#87268).
+            if [ -z "$2" ] || ! [[ "$2" =~ ^[0-9a-fA-F]{40}$ ]]; then
+                echo "--commit needs a full 40-character commit SHA (got: ${2:-<none>})"
+                echo "Abbreviated SHAs cannot be fetched from the remote. Resolve the full SHA with:"
+                echo "  git ls-remote https://github.com/NousResearch/hermes-agent.git | grep <short-sha>"
+                exit 1
+            fi
+            INSTALL_COMMIT="$(printf '%s' "$2" | tr '[:upper:]' '[:lower:]')"
             shift 2
             ;;
         --force-commit|-ForceCommit)
@@ -176,7 +186,7 @@ while [[ $# -gt 0 ]]; do
             echo "                   'hermes update' runs never inject bundled skills either"
             echo "  --branch NAME  Git branch to install (default: main)"
             echo "  --commit SHA   Pin checkout to a specific commit after clone/update"
-            echo "                   (ignored when it would roll an existing install back)"
+            echo "                   (full 40-char SHA; ignored when it would roll an existing install back)"
             echo "  --force-commit Apply --commit even if it rolls the install backwards"
             echo "  --manifest     Print desktop bootstrap stage manifest as JSON"
             echo "  --stage NAME   Run one desktop bootstrap stage"
@@ -1393,21 +1403,36 @@ EOF
         # current venv. Only pin when the target is not already an ancestor of
         # HEAD; a fresh clone has no such ancestry and pins normally.
         if ! git cat-file -e "$INSTALL_COMMIT^{commit}" 2>/dev/null; then
-            git fetch origin "$INSTALL_COMMIT" || true
+            if ! git fetch origin "$INSTALL_COMMIT"; then
+                log_error "Failed to fetch pinned commit $INSTALL_COMMIT from origin."
+                log_info "The commit may not exist, or is not reachable from any branch."
+                log_info "Refusing to continue with an unpinned checkout — this install was pinned deliberately."
+                exit 1
+            fi
+        fi
+        if ! git rev-parse --verify --quiet "$INSTALL_COMMIT^{commit}" >/dev/null 2>&1; then
+            log_error "Pinned commit $INSTALL_COMMIT was not found in the repository."
+            exit 1
         fi
         if git rev-parse --verify --quiet HEAD >/dev/null 2>&1 \
            && git merge-base --is-ancestor "$INSTALL_COMMIT" HEAD 2>/dev/null \
            && [ "$(git rev-parse "$INSTALL_COMMIT^{commit}" 2>/dev/null)" != "$(git rev-parse HEAD)" ]; then
             if [ "$FORCE_COMMIT" = true ]; then
                 log_warn "--force-commit: rolling this install back to $INSTALL_COMMIT."
-                git checkout --detach "$INSTALL_COMMIT"
+                if ! git checkout --detach "$INSTALL_COMMIT"; then
+                    log_error "Failed to check out pinned commit $INSTALL_COMMIT."
+                    exit 1
+                fi
             else
                 log_warn "Ignoring --commit $INSTALL_COMMIT: the checkout is already newer."
                 log_warn "Pinning to it would roll this install back. Pass --force-commit to override."
             fi
         else
             log_info "Pinning checkout to commit $INSTALL_COMMIT..."
-            git checkout --detach "$INSTALL_COMMIT"
+            if ! git checkout --detach "$INSTALL_COMMIT"; then
+                log_error "Failed to check out pinned commit $INSTALL_COMMIT."
+                exit 1
+            fi
         fi
     fi
 

--- a/tests/test_install_sh_commit_validation.py
+++ b/tests/test_install_sh_commit_validation.py
@@ -1,0 +1,162 @@
+"""Regression: ``install.sh --commit`` must fail closed (#87268).
+
+An abbreviated (or otherwise invalid) SHA used to fall through the whole
+install: the by-SHA fetch was swallowed by ``|| true`` (the remote refuses
+abbreviated refs), the following ``git checkout --detach`` misparsed the
+unknown name as a pathspec, and the installer still printed success and
+exited 0 — leaving the user on the branch tip while believing they were
+pinned. These tests pin both halves of the fix:
+
+- argument parsing rejects anything that is not a full 40-char hex SHA;
+- the pin block aborts the install when the target cannot be fetched or
+  checked out, instead of continuing unpinned.
+"""
+
+from __future__ import annotations
+
+import re
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+INSTALL_SH = REPO_ROOT / "scripts" / "install.sh"
+
+pytestmark = pytest.mark.skipif(
+    shutil.which("git") is None or shutil.which("bash") is None,
+    reason="needs git and bash",
+)
+
+_VALID_SHA = "0123456789abcdef0123456789abcdef01234567"
+
+
+def _git(cwd: Path, *args: str) -> str:
+    return subprocess.run(
+        ["git", "-c", "user.email=t@t", "-c", "user.name=t", *args],
+        cwd=cwd,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+
+
+def _extract_case_branch() -> str:
+    """Pull the ``--commit)`` case branch out of install.sh's arg parsing."""
+    text = INSTALL_SH.read_text()
+    match = re.search(
+        r"--commit\|-Commit\)(?:(?!^\s+--)[^\n]*\n)+?^\s+;;",
+        text,
+        re.MULTILINE,
+    )
+    assert match is not None, "--commit case branch not found in install.sh"
+    return match.group(0)
+
+
+def _extract_pin_block() -> str:
+    """Pull the commit-pin block out of install.sh's update_repo()."""
+    text = INSTALL_SH.read_text()
+    match = re.search(
+        r'if \[ -n "\$INSTALL_COMMIT" \]; then.*?\n    fi\n',
+        text,
+        re.DOTALL,
+    )
+    assert match is not None, "commit-pin block not found in install.sh"
+    return match.group(0)
+
+
+def _run_parse_branch(*args: str) -> subprocess.CompletedProcess:
+    """Execute install.sh's --commit branch inside a minimal case loop."""
+    script = "\n".join(
+        [
+            "INSTALL_COMMIT=''",
+            "while [[ $# -gt 0 ]]; do",
+            "    case $1 in",
+            _extract_case_branch(),
+            "        *) shift ;;",
+            "    esac",
+            "done",
+            'echo "INSTALL_COMMIT=$INSTALL_COMMIT"',
+        ]
+    )
+    return subprocess.run(
+        ["bash", "-c", script, "--", *args],
+        capture_output=True,
+        text=True,
+    )
+
+
+def _run_pin_block(repo_dir: Path, commit: str) -> subprocess.CompletedProcess:
+    """Execute install.sh's pin block standalone, like the real script (no set -e)."""
+    script = "\n".join(
+        [
+            "log_info() { echo \"INFO $*\"; }",
+            "log_warn() { echo \"WARN $*\"; }",
+            "log_error() { echo \"ERROR $*\"; }",
+            f'INSTALL_COMMIT="{commit}"',
+            "FORCE_COMMIT=false",
+            f'cd "{repo_dir}"',
+            _extract_pin_block(),
+            'echo "PIN_BLOCK_COMPLETED"',
+        ]
+    )
+    return subprocess.run(
+        ["bash", "-c", script],
+        capture_output=True,
+        text=True,
+    )
+
+
+class TestCommitArgumentValidation:
+    def test_abbreviated_sha_rejected(self):
+        result = _run_parse_branch("--commit", "56e2ba5")
+        assert result.returncode == 1
+        assert "40-character" in result.stdout
+
+    def test_non_hex_sha_rejected(self):
+        result = _run_parse_branch("--commit", "z" * 40)
+        assert result.returncode == 1
+        assert "40-character" in result.stdout
+
+    def test_missing_value_rejected(self):
+        result = _run_parse_branch("--commit")
+        assert result.returncode == 1
+        assert "40-character" in result.stdout
+
+    def test_valid_sha_accepted_and_lowercased(self):
+        result = _run_parse_branch("--commit", _VALID_SHA.upper())
+        assert result.returncode == 0
+        assert f"INSTALL_COMMIT={_VALID_SHA}" in result.stdout
+
+
+class TestPinFailsClosed:
+    @pytest.fixture
+    def repo(self, tmp_path):
+        repo_dir = tmp_path / "repo"
+        repo_dir.mkdir()
+        _git(repo_dir, "init", "-q", "-b", "main")
+        (repo_dir / "f.txt").write_text("rev0\n")
+        _git(repo_dir, "add", "f.txt")
+        _git(repo_dir, "commit", "-qm", "rev0")
+        return repo_dir
+
+    def test_unfetchable_pin_aborts_instead_of_continuing(self, repo):
+        """The reported bug: fetch fails, install used to continue unpinned."""
+        head_before = _git(repo, "rev-parse", "HEAD")
+
+        result = _run_pin_block(repo, _VALID_SHA)
+
+        assert result.returncode == 1, "an unfetchable pin must abort the install"
+        assert "PIN_BLOCK_COMPLETED" not in result.stdout
+        assert "Failed to fetch pinned commit" in result.stdout
+        assert _git(repo, "rev-parse", "HEAD") == head_before
+
+    def test_fetchable_pin_still_checks_out(self, repo):
+        sha = _git(repo, "rev-parse", "HEAD")
+
+        result = _run_pin_block(repo, sha)
+
+        assert result.returncode == 0
+        assert "PIN_BLOCK_COMPLETED" in result.stdout
+        assert _git(repo, "rev-parse", "HEAD") == sha


### PR DESCRIPTION
## What does this PR do?

Makes `install.sh --commit` fail closed instead of silently installing unpinned (#87268). Previously, passing an abbreviated SHA (the natural thing to type — the help text just said `SHA`) produced a successful-looking unpinned install:

- the by-SHA fetch was swallowed by `|| true` (the remote refuses abbreviated refs: `couldn't find remote ref`),
- the following `git checkout --detach` misparsed the unknown name as a pathspec (`--detach does not take a path argument`),
- neither failure was checked, so the install continued on the branch tip and exited 0 while the user believed they were pinned.

Two changes, both from the issue's "Expected" section:

1. **Up-front argument validation**: `--commit` now requires a full 40-character hex SHA and rejects anything else immediately (before any clone happens), with a hint on how to resolve a short SHA via `git ls-remote`. The value is lowercased so the bootstrap marker records a canonical form.
2. **Hard failure on unfetchable/uncheckable pins**: the `|| true` is gone — if the fetch of the pin target fails, or the object is not present afterwards, or the detached checkout fails, the installer aborts with a clear error. A user passing `--commit` is exactly the user who cares which code they run.

The bootstrap installer's baked-in `BUILD_PIN_COMMIT` is always a full 40-char SHA, so the desktop retry flow is unaffected by the validation.

## Related Issue

Fixes #87268

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `scripts/install.sh`: `--commit`/`-Commit` case branch validates a full 40-char hex SHA (missing/garbage values now error instead of silently continuing, and `shift 2` no longer runs on a missing value); pin block in `update_repo()` aborts on fetch/resolve/checkout failure; help text updated.
- `tests/test_install_sh_commit_validation.py` (new): 6 tests — abbreviated SHA, non-hex, and missing value rejected at parse time; valid SHA accepted and lowercased; unfetchable pin aborts with exit 1 (asserting the checkout is untouched and the block did not complete) instead of continuing; a fetchable pin still checks out.

## How to Test

1. `uv run --extra acp pytest tests/test_install_sh_commit_validation.py tests/test_install_commit_pin_rollback.py -q` — should pass: 10 passed (observed result; the 4 rollback-semantics tests are unchanged).
2. `uv run --extra acp pytest tests/ -q -k 'install_sh or install_commit or ...'` — should pass: 73 passed, 8 skipped (observed result).
3. Manual repro from the issue — Observed result: `install.sh --commit 56e2ba5` now prints `--commit needs a full 40-character commit SHA (got: 56e2ba5)` plus a `git ls-remote` hint and exits 1 before cloning; previously it cloned, printed two git fatals, and exited 0 on the branch tip.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the install.sh-related suites (73 passed, 8 skipped); full-suite verification delegated to CI
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A (help text updated in the change)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A (install.ps1 has its own copy of the pin logic; the bash path is what the issue hit)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Not applicable — CLI text output; before/after behavior shown in the description and tests.
