### PR TITLE
fix(nemo_relay): bound plugin Relay marks so a wedged native pipeline cannot stall the agent

### DIFF
--- a/plugins/observability/nemo_relay/__init__.py
+++ b/plugins/observability/nemo_relay/__init__.py
@@ -412,8 +412,35 @@ class _Runtime:
                 state.relay_session,
                 callback,
                 *args,
+                # Bounded: this wrapper serves every mark/event the plugin
+                # emits (turn start/end, approvals, subagent marks), and it
+                # runs synchronously on the agent's conversation thread. The
+                # host default (timeout=None) is an UNBOUNDED native call —
+                # a wedged native Relay pipeline then blocks the agent
+                # between API calls with zero activity ticks until the cron
+                # 600s inactivity kill / gateway idle timeout fires (the
+                # core's scope push/pop/flush sites were bounded for the
+                # same reason after the 2026-08-10 delegation stall; these
+                # plugin marks were the missed sibling class). On breach we
+                # lose one telemetry span, never the agent.
+                timeout=relay_runtime._SCOPE_OP_TIMEOUT,
                 **kwargs,
             )
+        except TimeoutError:
+            # A wedged native pipeline is a session-level condition, not a
+            # one-off: flag it so close_session skips the (potentially very
+            # slow) ATIF export, and warn ONCE so the sick pipeline is
+            # visible before it costs anything bigger.
+            if not state.scope_errored:
+                logger.warning(
+                    "Relay scope operation for session %s exceeded %.0fs; "
+                    "native pipeline appears wedged — further exports for "
+                    "this session will be skipped",
+                    state.session_id,
+                    relay_runtime._SCOPE_OP_TIMEOUT,
+                )
+            state.scope_errored = True
+            raise
         except Exception:
             # A failed scope operation leaves the session's Relay/exporter
             # state unreliable; remember it so close_session can skip the

--- a/tests/plugins/test_nemo_relay_bounded_marks.py
+++ b/tests/plugins/test_nemo_relay_bounded_marks.py
@@ -1,0 +1,101 @@
+"""Plugin Relay marks must be bounded — never an unbounded native call.
+
+The nemo_relay plugin's ``_Runtime.run_in_session`` wrapper serves every
+mark/event the plugin emits (turn start/end, approvals, subagent marks) and
+runs synchronously on the agent's conversation thread. The host's
+``run_in_session`` default (``timeout=None``) is an unbounded native call: a
+wedged native Relay pipeline blocked the agent between API calls with zero
+activity ticks until the cron 600s inactivity kill fired (observed live
+2026-08-15 — two cron jobs and a gateway chat session died with
+``last_activity=API call #N completed``).
+
+The wrapper now always passes ``timeout=relay_runtime._SCOPE_OP_TIMEOUT`` to
+the host, and a breach flags ``scope_errored`` so ``close_session`` skips the
+ATIF export for the wedged session.
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+from types import SimpleNamespace
+
+import pytest
+
+from agent import relay_runtime as core_relay_runtime
+
+
+def _plugin_module():
+    mod = sys.modules.get("plugins.observability.nemo_relay")
+    if mod is None:
+        mod = importlib.import_module("plugins.observability.nemo_relay")
+    return mod
+
+
+def _make_runtime_and_state(host):
+    plugin = _plugin_module()
+    runtime = object.__new__(plugin._Runtime)
+    runtime.host = host
+    state = plugin._SessionState(session_id="s-bound")
+    state.relay_session = SimpleNamespace(session_id="s-bound")
+    return plugin, runtime, state
+
+
+def test_plugin_marks_pass_bounded_timeout_to_host():
+    """Every wrapper dispatch carries the core scope-op budget."""
+    seen = {}
+
+    class _Host:
+        def run_in_session(self, session, callback, *args, timeout=None, **kwargs):
+            seen["timeout"] = timeout
+            return callback(*args, **kwargs)
+
+    _plugin, runtime, state = _make_runtime_and_state(_Host())
+    result = runtime.run_in_session(state, lambda: "ok")
+
+    assert result == "ok"
+    assert seen["timeout"] == core_relay_runtime._SCOPE_OP_TIMEOUT
+    assert state.scope_errored is False
+
+
+def test_timeout_breach_flags_session_and_skips_atif_export():
+    """A wedged native call costs one span and disables the session export."""
+
+    class _WedgedHost:
+        def run_in_session(self, session, callback, *args, timeout=None, **kwargs):
+            raise TimeoutError(
+                f"Relay scope operation exceeded {timeout}s (session=s-bound)"
+            )
+
+    plugin, runtime, state = _make_runtime_and_state(_WedgedHost())
+
+    with pytest.raises(TimeoutError):
+        runtime.run_in_session(state, lambda: "never")
+
+    assert state.scope_errored is True
+
+    # export_atif must now skip without touching the exporter.
+    class _ExplodingExporter:
+        def export_json(self):  # pragma: no cover - must not be called
+            raise AssertionError("export ran for a scope-errored session")
+
+    state.atif_exporter = _ExplodingExporter()
+    runtime.settings = plugin._Settings(
+        atif_enabled=True, atif_output_directory="/tmp/never-used"
+    )
+    runtime.export_atif(state)  # no raise, no export
+
+
+def test_non_timeout_errors_still_flag_session():
+    """The pre-existing generic error path keeps its scope_errored contract."""
+
+    class _BrokenHost:
+        def run_in_session(self, session, callback, *args, timeout=None, **kwargs):
+            raise RuntimeError("scope handle is not at the top of the stack")
+
+    _plugin, runtime, state = _make_runtime_and_state(_BrokenHost())
+
+    with pytest.raises(RuntimeError):
+        runtime.run_in_session(state, lambda: "never")
+
+    assert state.scope_errored is True


### PR DESCRIPTION
## Summary
A wedged native Relay pipeline can no longer stall the agent between API calls — the nemo_relay plugin's marks (turn start/end, approvals, subagent events) are now bounded at the core scope-op budget (10s) instead of running as unbounded native calls on the conversation thread.

Root cause (observed live, Aug 15): the plugin's `run_in_session` wrapper passed no `timeout`, so the host default (`timeout=None`) ran every `runtime.mark()` synchronously and unbounded. With the native pipeline wedged, the agent thread blocked right after `_touch_activity("API call #N completed")` with zero further activity ticks → two cron jobs died at the 600s inactivity kill (`skill-ecosystem-scout`, `Daily Buzz Report`) and a gateway chat session at 1800s. The core's scope push/pop/flush/close sites were bounded with `_SCOPE_OP_TIMEOUT` after the 2026-08-10 delegation stall; the plugin's event marks were the missed sibling class.

Companion to #87254 (session-END finalize/export hang, merged): same sick pipeline, opposite end of the session — this one covers the mid-turn window where the cron jobs actually died.

## Changes
- `plugins/observability/nemo_relay/__init__.py`: wrapper always passes `timeout=relay_runtime._SCOPE_OP_TIMEOUT` to the host; a breach sets `scope_errored` (close_session then skips the ATIF export, per #87254) and warns once. Plugin-only diff.
- `tests/plugins/test_nemo_relay_bounded_marks.py`: budget reaches the host (sabotage-verified RED on pre-fix code), TimeoutError flags the session + disables its export, generic error path keeps its contract.

## Validation
| | Before | After |
|---|---|---|
| Wedged native pipeline during a mark | Agent blocked until cron 600s kill | Mark aborted at 10s, one span lost, agent continues |
| New tests on pre-fix code | test_plugin_marks_pass_bounded_timeout_to_host FAILS | 3/3 pass |

Pre-existing local failure `test_shared_metrics_and_rich_plugin_share_one_core_session` fails identically on pristine origin/main (env-dependent); CI arbitrates.

## Infographic

Infographic generation currently unavailable (FAL balance exhausted). Will attach via `gh pr edit` once image generation is restored.
