### PR TITLE
fix(cli): stop stacked prompt_toolkit status frames (mid-turn chrome + Windows orphans)

### DIFF
--- a/agent/display.py
+++ b/agent/display.py
@@ -1195,20 +1195,32 @@ class KawaiiSpinner:
             return False
 
     def _is_patch_stdout_proxy(self) -> bool:
-        """Return True when stdout is prompt_toolkit's StdoutProxy.
+        """Return True when stdout is prompt_toolkit's StdoutProxy (or any
+        wrapper that queues writes and injects newlines around each flush()).
 
         patch_stdout wraps sys.stdout in a StdoutProxy that queues writes and
         injects newlines around each flush().  The \\r overwrite never lands on
-        the correct line — each spinner frame ends up on its own line.
+        the correct line — each spinner frame ends up on its own line, which is
+        exactly the "repeated status frames" artifact reported in #70031
+        (Windows + interface=cli + streaming=false).  The CLI already drives a
+        TUI widget (_spinner_text) for spinner display, so KawaiiSpinner's \\r
+        animation is redundant under any such wrapper.
 
-        The CLI already drives a TUI widget (_spinner_text) for spinner display,
-        so KawaiiSpinner's \\r-based animation is redundant under StdoutProxy.
+        Detect both the canonical StdoutProxy class and duck-typed wrappers
+        (prompt_toolkit sets ``_patch_stdout`` on the proxy), because some
+        runtimes wrap stdout in a subclass/alias the exact isinstance() check
+        misses — leaving the redundant \\r animation running and stacking frames.
         """
         try:
             from prompt_toolkit.patch_stdout import StdoutProxy
-            return isinstance(self._out, StdoutProxy)
+
+            if isinstance(self._out, StdoutProxy):
+                return True
         except ImportError:
-            return False
+            pass
+        # Duck-type: any stdout proxy that buffers/redirects writes for
+        # prompt_toolkit's patch_stdout will expose this attribute.
+        return bool(getattr(self._out, "_patch_stdout", None) is not None)
 
     def _animate(self):
         # When stdout is not a real terminal (e.g. Docker, systemd, pipe),

--- a/cli.py
+++ b/cli.py
@@ -787,6 +787,62 @@ def load_cli_config() -> Dict[str, Any]:
 CLI_CONFIG = load_cli_config()
 
 
+def resolve_idle_refresh_interval() -> float:
+    """Idle wall-clock status-bar cadence (seconds) for the classic CLI.
+
+    Returns the configured ``display.cli_refresh_interval`` clamped to
+    ``[0.0, 30.0]``.  A value of 0.0 disables the periodic idle redraw.
+
+    This cadence drives the *background* ``spinner_loop`` repaint while the
+    agent is IDLE only.  It must NOT be handed to prompt_toolkit's own
+    ``Application.refresh_interval``: that timer fires regardless of agent
+    state, so while a turn is running it repaints the bottom chrome (spinner
+    + status bar) every N seconds.  In non-fullscreen mode each such redraw
+    can scroll the previous chrome copy up into scrollback — stacking repeated
+    kawaii spinner frames / status columns instead of overwriting them in
+    place.  That is the root cause of the "status lines repeat mid-turn"
+    artifact (#70031).  Mid-turn chrome still updates live because every
+    agent event (_on_thinking, tool start/complete, notices) explicitly calls
+    ``_invalidate`` — we only suppress the *periodic* redraw while busy.
+    See #48309 / #70031.
+    """
+    try:
+        raw = float(CLI_CONFIG.get("display", {}).get("cli_refresh_interval", 0) or 0)
+    except (TypeError, ValueError):
+        raw = 0.0
+    return max(0.0, min(raw, 30.0))
+
+
+def spinner_loop_branch(command_running: bool, agent_running: bool, idle_refresh: float) -> str:
+    """Pure decision for the classic-CLI background ``spinner_loop``.
+
+    Maps the three loop inputs to a single action token the loop performs:
+
+    * ``"repaint_fast"`` — a child command is running; repaint on a fast
+      cadence so its progress is visible.
+    * ``"stable"`` — the agent itself is running (no child command). Do NOT
+      background-repaint (#70031): the bottom chrome is refreshed live by the
+      agent-event callbacks (``_on_thinking``, ``_on_tool_start/_complete``,
+      notices), each of which calls ``_invalidate()``. A periodic redraw here
+      would scroll the prior chrome copy into scrollback and stack repeated
+      frames mid-turn.
+    * ``"idle_tick"`` — idle and a positive idle cadence is configured; tick
+      the wall-clock status-bar read-outs.
+    * ``"idle_stable"`` — idle with no periodic cadence; just sleep.
+
+    Kept as a pure, DI-testable function (no ``self``/thread state) so the
+    #70031 invariant survives a real unit test without reimplementing the
+    branch inline.
+    """
+    if command_running:
+        return "repaint_fast"
+    if agent_running:
+        return "stable"
+    if idle_refresh > 0:
+        return "idle_tick"
+    return "idle_stable"
+
+
 # Initialize centralized logging early — agent.log + errors.log in ~/.hermes/logs/.
 # This ensures CLI sessions produce a log trail even before AIAgent is instantiated.
 try:
@@ -6178,17 +6234,26 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         return 0 if self._use_minimal_tui_chrome(width=width) else 1
 
     def _spinner_widget_height(self, width: Optional[int] = None) -> int:
-        """Return the visible height for the spinner/status text line above the status bar."""
-        spinner_line = self._render_spinner_text()
-        if not spinner_line:
-            return 0
+        """Return the visible height for the spinner/status text line above the status bar.
+
+        The height is RESERVED at 1 (when not in minimal-chrome mode) even when
+        there is no spinner text yet.  This keeps the bottom-chrome canvas a
+        constant height between idle and active states.  If the height were to
+        grow from 0 (idle) to 1 (turn started, "_spinner_text" set) the new
+        canvas would be taller than the previous one, and in prompt_toolkit's
+        non-fullscreen renderer that forces a vertical scroll ("reserve
+        vertical space") which pushes the prior chrome copy up into scrollback
+        and stacks repeated status frames mid-turn (#70031, reproduced on
+        Windows PowerShell).  Reserving the line eliminates the height change,
+        so prompt_toolkit redraws the chrome in place instead of scrolling.
+        The actual spinner glyph is still only painted when text is present;
+        the blank reserved row simply holds the layout slot open.
+        """
         if self._use_minimal_tui_chrome(width=width):
+            # Minimal chrome drops the spinner line entirely to save rows.
             return 0
-        width = width or self._get_tui_terminal_width()
-        if width and width > 10:
-            import math
-            text_width = self._status_bar_display_width(spinner_line)
-            return max(1, math.ceil(text_width / width))
+        # Reserve the slot even when empty so the canvas height never changes
+        # between idle and active (see docstring / #70031).
         return 1
 
     def _render_spinner_text(self) -> str:
@@ -18058,7 +18123,13 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         spinner_widget = Window(
             content=FormattedTextControl(get_spinner_text),
             height=get_spinner_height,
-            wrap_lines=True,
+            # Mirror the status bar's wrap_lines=False: the spinner line is a
+            # reserved single row (_spinner_widget_height is always 1 in
+            # non-minimal-chrome mode), so wide text must not wrap onto a
+            # second row — that would defeat the constant-height invariant that
+            # prevents the mid-turn chrome stack (#70031). Long spinner text is
+            # clipped to one row instead.
+            wrap_lines=False,
         )
 
         # Petdex mascot — right-aligned half-block sprite above the prompt,
@@ -18682,12 +18753,23 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             mouse_support=False,
             **({"output": _cpr_disabled_output} if _cpr_disabled_output is not None else {}),
             # Read from display.cli_refresh_interval (default 0 = disabled).
-            # When non-zero, prompt_toolkit redraws the UI on this cadence
-            # during idle, keeping wall-clock status-bar read-outs ticking.
-            # Set to 0 to suppress background redraws entirely — avoids
-            # fighting terminal auto-scroll in non-fullscreen mode (Xshell,
-            # iTerm2, Windows Terminal). See #48309.
-            refresh_interval=float(CLI_CONFIG.get("display", {}).get("cli_refresh_interval", 0)),
+            # When non-zero, the background spinner_loop (below) triggers an
+            # invalidate on this cadence while the agent is IDLE, keeping
+            # wall-clock status-bar read-outs ticking.  We deliberately do
+            # NOT hand this to prompt_toolkit's own Application.refresh_interval
+            # here: that timer fires regardless of agent state, so while a turn
+            # is running it repaints the bottom chrome (spinner + status bar)
+            # every N seconds.  In non-fullscreen mode each such redraw can
+            # scroll the previous chrome copy up into scrollback — stacking
+            # repeated kawaii spinner frames / status columns instead of
+            # overwriting them in place.  This is the root cause of the
+            # "status lines repeat mid-turn" artifact (#70031), reproduced on
+            # Windows with display.cli_refresh_interval set.  Mid-turn chrome
+            # still updates live because every agent event (_on_thinking,
+            # tool start/complete, notices) explicitly calls _invalidate — we
+            # only suppress the *periodic* redraw while busy.  See #48309 /
+            # #70031.
+            refresh_interval=0.0,
             # Erase the live bottom chrome (status bar, input box, separator
             # rules) on exit instead of freezing a final copy into scrollback.
             # Without this, prompt_toolkit's render_as_done teardown repaints
@@ -18775,20 +18857,43 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
 
         self._install_resize_recovery(app)
 
+        # Idle wall-clock status-bar cadence (seconds). 0 = never background
+        # repaint idle. Mirrors display.cli_refresh_interval from config via
+        # resolve_idle_refresh_interval(); we read it here (not via
+        # Application.refresh_interval) so the periodic redraw only happens
+        # while IDLE — never mid-turn. See #70031. The clock still ticks while
+        # waiting for input; during a running turn the chrome is updated only
+        # by explicit _invalidate() calls from agent events, which keeps the
+        # status bar live without stacking scrollback.
+        _idle_refresh = resolve_idle_refresh_interval()
+
         def spinner_loop():
             while not self._should_exit:
                 if not self._app:
                     time.sleep(0.1)
                     continue
-                if self._command_running:
+                action = spinner_loop_branch(
+                    self._command_running, self._agent_running, _idle_refresh
+                )
+                if action == "repaint_fast":
                     self._invalidate(min_interval=0.1)
                     time.sleep(0.1)
+                elif action == "stable":
+                    # Agent is working but not waiting on a child command: do NOT
+                    # background-repaint. The bottom chrome (spinner + status
+                    # bar) is still refreshed live by the agent-event callbacks
+                    # (_on_thinking, _on_tool_start/_complete, notifications),
+                    # each of which calls _invalidate(). A periodic redraw here
+                    # would scroll the prior chrome copy into scrollback and
+                    # stack repeated frames — the #70031 artifact. Keep stable.
+                    time.sleep(0.2)
+                elif action == "idle_tick":
+                    # Idle: tick the wall-clock status-bar read-outs on the
+                    # configured cadence. Input/agent events still invalidate
+                    # explicitly when the UI actually changes.
+                    self._invalidate(min_interval=_idle_refresh)
+                    time.sleep(_idle_refresh)
                 else:
-                    # Do not repaint the idle prompt every second. In non-full-screen
-                    # prompt_toolkit mode, background redraws can fight tmux/Ghostty/cmux
-                    # viewport restoration after focus changes and visually move the
-                    # command input area. Keep idle stable; input/agent events still
-                    # invalidate explicitly when the UI actually changes.
                     time.sleep(0.2)
 
         spinner_thread = threading.Thread(target=spinner_loop, daemon=True)

--- a/cli.py
+++ b/cli.py
@@ -16354,6 +16354,17 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
 
     def run(self):
         """Run the interactive CLI loop with persistent input at bottom."""
+        # Reap orphaned TUI nodes from crashed prior launches before claiming
+        # a session slot. Without this, dead TUI trees left by unclean exits
+        # keep emitting prompt_toolkit chrome to the same terminal surface,
+        # stacking duplicate status frames on top of this session's UI.
+        try:
+            from hermes_cli.dashboard_procs import _reap_orphaned_tui_nodes
+
+            _reap_orphaned_tui_nodes(tui_dir=Path(__file__).resolve().parent / "ui-tui")
+        except Exception:
+            logger.debug("CLI TUI orphan reaper skipped", exc_info=True)
+
         if not self._claim_active_session("cli"):
             return
 

--- a/cli.py
+++ b/cli.py
@@ -805,11 +805,21 @@ def resolve_idle_refresh_interval() -> float:
     agent event (_on_thinking, tool start/complete, notices) explicitly calls
     ``_invalidate`` — we only suppress the *periodic* redraw while busy.
     See #48309 / #70031.
+
+    A missing key falls back to the deliberate configuration default
+    (``display.cli_refresh_interval = 1.0`` in ``hermes_cli.config``),
+    not to "disabled" — an explicit ``0`` opts out.
     """
     try:
-        raw = float(CLI_CONFIG.get("display", {}).get("cli_refresh_interval", 0) or 0)
+        from hermes_cli.config import DEFAULT_CONFIG
+
+        fallback = float(DEFAULT_CONFIG.get("display", {}).get("cli_refresh_interval", 1.0))
+    except Exception:
+        fallback = 1.0
+    try:
+        raw = float(CLI_CONFIG.get("display", {}).get("cli_refresh_interval", fallback))
     except (TypeError, ValueError):
-        raw = 0.0
+        raw = fallback
     return max(0.0, min(raw, 30.0))
 
 
@@ -6228,9 +6238,19 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         return 0 if self._use_minimal_tui_chrome(width=width) else 1
 
     def _agent_spacer_height(self, width: Optional[int] = None) -> int:
-        """Return the spacer height shown above the status bar while the agent runs."""
-        if not getattr(self, "_agent_running", False):
-            return 0
+        """Return the spacer height shown above the status bar.
+
+        The spacer row is RESERVED at 1 (when not in minimal-chrome mode)
+        whether or not the agent is running. This spacer and the spinner row
+        (_spinner_widget_height) are part of the same bottom-chrome canvas:
+        if either grows from 0 (idle) to 1 (turn started,
+        ``_agent_running`` becomes true) the canvas gets taller than the
+        previous frame, and prompt_toolkit's non-fullscreen renderer answers
+        a height increase by scrolling the old chrome into scrollback —
+        stacking repeated status frames mid-turn (#70031). Reserving both
+        rows keeps the total canvas height constant across idle/active
+        transitions so the chrome repaints in place.
+        """
         return 0 if self._use_minimal_tui_chrome(width=width) else 1
 
     def _spinner_widget_height(self, width: Optional[int] = None) -> int:

--- a/cli.py
+++ b/cli.py
@@ -853,6 +853,50 @@ def spinner_loop_branch(command_running: bool, agent_running: bool, idle_refresh
     return "idle_stable"
 
 
+def _build_classic_cli_application(
+    *,
+    layout,
+    key_bindings,
+    style,
+    output=None,
+    cursor=None,
+):
+    """Build the classic-CLI prompt_toolkit ``Application`` (#70031 pins).
+
+    Pure factory (no ``self``, no TTY touch) so tests can construct the
+    Application and assert its pins directly — the interactive run loop is
+    not unit-instantiable without a real terminal.
+
+    Two pins are load-bearing for the stacked-frames fix:
+
+    - ``refresh_interval=0.0`` — prompt_toolkit's own repaint timer is
+      disabled. The timer fires regardless of agent state, so while a turn
+      runs it repaints the bottom chrome every N seconds; in non-fullscreen
+      mode each redraw can scroll the previous chrome copy into scrollback,
+      stacking repeated spinner/status frames (#70031). The configured
+      ``display.cli_refresh_interval`` cadence is applied IDLE-only by the
+      background ``spinner_loop`` (see ``spinner_loop_branch``), never here.
+    - ``erase_when_done=True`` — teardown erases the live bottom chrome
+      instead of freezing a final copy into scrollback, where it would stack
+      with the next session's UI on resume (#38252).
+    """
+    kwargs = {}
+    if output is not None:
+        kwargs["output"] = output
+    if cursor is not None:
+        kwargs["cursor"] = cursor
+    return Application(
+        layout=layout,
+        key_bindings=key_bindings,
+        style=style,
+        full_screen=False,
+        mouse_support=False,
+        refresh_interval=0.0,
+        erase_when_done=True,
+        **kwargs,
+    )
+
+
 # Initialize centralized logging early — agent.log + errors.log in ~/.hermes/logs/.
 # This ensures CLI sessions produce a log trail even before AIAgent is instantiated.
 try:
@@ -18765,43 +18809,12 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         _cpr_disabled_output = _select_classic_cli_pt_output(sys.stdout)
 
         # Create the application
-        app = Application(
+        app = _build_classic_cli_application(
             layout=layout,
             key_bindings=kb,
             style=style,
-            full_screen=False,
-            mouse_support=False,
-            **({"output": _cpr_disabled_output} if _cpr_disabled_output is not None else {}),
-            # Read from display.cli_refresh_interval (default 0 = disabled).
-            # When non-zero, the background spinner_loop (below) triggers an
-            # invalidate on this cadence while the agent is IDLE, keeping
-            # wall-clock status-bar read-outs ticking.  We deliberately do
-            # NOT hand this to prompt_toolkit's own Application.refresh_interval
-            # here: that timer fires regardless of agent state, so while a turn
-            # is running it repaints the bottom chrome (spinner + status bar)
-            # every N seconds.  In non-fullscreen mode each such redraw can
-            # scroll the previous chrome copy up into scrollback — stacking
-            # repeated kawaii spinner frames / status columns instead of
-            # overwriting them in place.  This is the root cause of the
-            # "status lines repeat mid-turn" artifact (#70031), reproduced on
-            # Windows with display.cli_refresh_interval set.  Mid-turn chrome
-            # still updates live because every agent event (_on_thinking,
-            # tool start/complete, notices) explicitly calls _invalidate — we
-            # only suppress the *periodic* redraw while busy.  See #48309 /
-            # #70031.
-            refresh_interval=0.0,
-            # Erase the live bottom chrome (status bar, input box, separator
-            # rules) on exit instead of freezing a final copy into scrollback.
-            # Without this, prompt_toolkit's render_as_done teardown repaints
-            # the chrome one last time and leaves it stranded above the exit
-            # summary — so a dead status bar + empty prompt sit between the
-            # conversation transcript and the "Resume this session" block, and
-            # stack with the next session's UI on resume (#38252). The actual
-            # conversation transcript is printed through patch_stdout into
-            # normal scrollback and is unaffected; only the managed chrome is
-            # erased. Applies to every exit path (/exit, /quit, EOF, Ctrl+C).
-            erase_when_done=True,
-            **({'cursor': _STEADY_CURSOR} if _STEADY_CURSOR is not None else {}),
+            output=_cpr_disabled_output,
+            cursor=_STEADY_CURSOR,
         )
         _disable_prompt_toolkit_cpr_warning(app)
         self._app = app  # Store reference for clarify_callback

--- a/contributors/emails/6572003+iap@users.noreply.github.com
+++ b/contributors/emails/6572003+iap@users.noreply.github.com
@@ -1,0 +1,2 @@
+iap
+# fix/stacked-frames: stacked status frames (#70031)

--- a/hermes_cli/active_sessions.py
+++ b/hermes_cli/active_sessions.py
@@ -10,6 +10,8 @@ from __future__ import annotations
 import json
 import logging
 import os
+import re
+import sys
 import time
 import uuid
 from dataclasses import dataclass
@@ -19,6 +21,52 @@ from typing import Any, Optional
 from hermes_constants import get_hermes_home
 
 logger = logging.getLogger(__name__)
+
+
+def _get_terminal_surface_id() -> str:
+    """Return a best-effort identifier for the current terminal surface.
+
+    Used to prevent multiple Hermes CLI/TUI instances from sharing one TTY,
+    which causes stacked prompt_toolkit status frames on Windows.
+    """
+    try:
+        if sys.platform == "win32":
+            import ctypes
+
+            title_buf = ctypes.create_unicode_buffer(1024)
+            length = ctypes.windll.kernel32.GetConsoleTitleW(title_buf, 1024)
+            if length:
+                # Windows Terminal tabs share an HWND and console title, so
+                # same-titled tabs collide on the basic key. Prefer the
+                # per-tab WT_SESSION GUID when present, else fall back to the
+                # console window handle, then the bare title. Each tab gets a
+                # distinct key without relying on unstable titles.
+                wt_session = os.environ.get("WT_SESSION")
+                if wt_session:
+                    return f"win32-console:{title_buf.value}:wt:{wt_session}"
+                try:
+                    kernel32 = ctypes.windll.kernel32
+                    kernel32.GetConsoleWindow.restype = ctypes.c_void_p
+                    console_hwnd = kernel32.GetConsoleWindow()
+                    if console_hwnd:
+                        return f"win32-console:{title_buf.value}:hwnd:{console_hwnd}"
+                except Exception:
+                    pass
+                return f"win32-console:{title_buf.value}"
+            logger.warning(
+                "Terminal surface detection failed (empty console title); "
+                "same-surface duplicate-session guard is ineffective this launch"
+            )
+            return f"win32-pid:{os.getpid()}"
+        fd = sys.stdout.fileno()
+        return f"tty:{os.ttyname(fd)}"
+    except Exception:
+        logger.warning(
+            "Terminal surface detection raised; same-surface "
+            "duplicate-session guard is ineffective this launch",
+            exc_info=True,
+        )
+        return f"pid:{os.getpid()}"
 
 
 def coerce_max_concurrent_sessions(value: Any, key: str = "max_concurrent_sessions") -> Optional[int]:
@@ -222,6 +270,25 @@ def _optional_float(value: Any) -> Optional[float]:
         return None
 
 
+def _resolve_pid_exists():
+    """Lazy import of the authoritative cross-platform PID-existence check.
+
+    active_sessions no longer does ``from gateway.status import _pid_exists``
+    per-call.  A per-call import inside ``_pid_alive``'s inner try/except meant
+    any import failure in ``gateway.status`` (circular import, syntax error,
+    missing transitive dep, scaffold race) was silently caught and returned
+    False for every PID — wiping the entire active-session registry through
+    ``_prune_dead`` exactly when it matters most (startup).
+
+    Importing once at first call and reusing the reference keeps the blast
+    radius bounded: if the import itself fails, ``_PID_EXISTS`` is never bound
+    and every ``_pid_alive`` call raises — surfacing the real problem instead
+    of silently making every PID look dead.
+    """
+    global _PID_EXISTS
+    from gateway.status import _pid_exists as _PID_EXISTS  # noqa: WPS436
+
+
 def _pid_alive(pid: Any, process_start_time: Any = None) -> bool:
     try:
         pid_int = int(pid)
@@ -230,9 +297,8 @@ def _pid_alive(pid: Any, process_start_time: Any = None) -> bool:
     if pid_int <= 0:
         return False
     try:
-        from gateway.status import _pid_exists
-
-        exists = bool(_pid_exists(pid_int))
+        _resolve_pid_exists()
+        exists = bool(_PID_EXISTS(pid_int))
     except Exception:
         return False
     if not exists:
@@ -276,6 +342,38 @@ class ActiveSessionLease:
         release_active_session(self)
 
 
+def _normalize_surface(terminal_surface: str) -> str:
+    """Strip unstable per-pseudoconsole HWND suffixes for collision checks.
+
+    On Windows ConPTY, older code paths included ``:hwnd:<handle>`` in the
+    surface ID. Each ConPTY instance gets a unique HWND, so two Hermes
+    processes in the same terminal tab compute different surface IDs and
+    bypass the duplicate-session check. Normalizing by removing the HWND
+    suffix makes old and new entries collide correctly.
+
+    Windows Terminal entries carry a ``:wt:<guid>`` per-tab key instead; those
+    are left untouched by :func:`_surfaces_collide` so two same-titled WT tabs
+    (each with its own GUID) never falsely collide.
+    """
+    return re.sub(r":hwnd:[0-9a-fA-F]+$", "", terminal_surface)
+
+
+def _surfaces_collide(a: str, b: str) -> bool:
+    """True when two terminal-surface ids denote the same surface.
+
+    Exact match always collides. Otherwise HWND suffixes are stripped on both
+    sides so legacy ``:hwnd:`` entries still collide with new-format ids — but
+    only when neither side carries a ``:wt:`` tab GUID (a WT GUID is already
+    tab-unique; stripping around it would merge distinct tabs of the same
+    title).
+    """
+    if a == b:
+        return True
+    if ":wt:" in a or ":wt:" in b:
+        return False
+    return _normalize_surface(a) == _normalize_surface(b)
+
+
 def try_acquire_active_session(
     *,
     session_id: str,
@@ -286,23 +384,19 @@ def try_acquire_active_session(
     """Acquire an active-session slot.
 
     Returns ``(lease, None)`` on success.  When the cap is disabled, the lease is
-    a no-op object so callers can unconditionally call ``release()``.
+    a lightweight no-op that still records the surface in the registry so that
+    concurrent CLI/TUI instances on the same terminal surface can be detected
+    and refused (prevents stacked prompt_toolkit status frames).
     """
     max_sessions = resolve_max_concurrent_sessions(config)
     lease_id = uuid.uuid4().hex
-    if max_sessions is None:
-        return ActiveSessionLease(
-            lease_id=lease_id,
-            session_id=session_id,
-            surface=surface,
-            enabled=False,
-        ), None
-
+    terminal_surface = _get_terminal_surface_id()
     now = time.time()
     entry = {
         "lease_id": lease_id,
         "session_id": str(session_id),
         "surface": str(surface),
+        "terminal_surface": terminal_surface,
         "pid": os.getpid(),
         "process_start_time": _process_start_time(os.getpid()),
         "started_at": now,
@@ -320,17 +414,33 @@ def try_acquire_active_session(
         pruned = len(raw_entries) - len(entries)
         if pruned:
             logger.info("Pruned %d stale active session lease(s)", pruned)
-        active_count = len(entries)
-        if active_count >= max_sessions:
+
+        same_surface_holder = next(
+            (
+                e
+                for e in entries
+                if _surfaces_collide(e.get("terminal_surface", ""), terminal_surface)
+                and e.get("pid") != os.getpid()
+            ),
+            None,
+        )
+        if same_surface_holder:
+            _write_entries(state_path, entries)
+            return None, (
+                "Another Hermes session is already using this terminal surface. "
+                "Close the other session first, or switch to a different terminal."
+            )
+
+        if max_sessions is not None and len(entries) >= max_sessions:
             _write_entries(state_path, entries)
             logger.info(
                 "Active session limit reached: active=%d max=%d surface=%s",
-                active_count,
+                len(entries),
                 max_sessions,
                 surface,
             )
             return None, active_session_limit_message(
-                active_count, max_sessions, entries
+                len(entries), max_sessions, entries
             )
         entries.append(entry)
         _write_entries(state_path, entries)
@@ -339,6 +449,7 @@ def try_acquire_active_session(
         lease_id=lease_id,
         session_id=str(session_id),
         surface=str(surface),
+        enabled=max_sessions is not None,
         state_path=state_path,
         lock_path=_lock_path(),
     ), None
@@ -348,9 +459,8 @@ def release_active_session(lease: ActiveSessionLease) -> None:
     # Prefer the registry the lease was acquired against: the caller may be
     # running under a profile HERMES_HOME override (#85431).
     state_path = lease.state_path or _state_path()
-    lock_path = lease.lock_path or _lock_path()
     try:
-        with _FileLock(lock_path):
+        with _FileLock(lease.lock_path or _lock_path()):
             entries = _prune_dead(_read_entries(state_path))
             kept = [
                 entry
@@ -380,8 +490,7 @@ def transfer_active_session(
         return True
 
     state_path = lease.state_path or _state_path()
-    lock_path = lease.lock_path or _lock_path()
-    with _FileLock(lock_path):
+    with _FileLock(lease.lock_path or _lock_path()):
         entries = _prune_dead(_read_entries(state_path))
         updated = False
         for entry in entries:

--- a/hermes_cli/active_sessions.py
+++ b/hermes_cli/active_sessions.py
@@ -274,16 +274,14 @@ def _resolve_pid_exists():
     """Lazy import of the authoritative cross-platform PID-existence check.
 
     active_sessions no longer does ``from gateway.status import _pid_exists``
-    per-call.  A per-call import inside ``_pid_alive``'s inner try/except meant
-    any import failure in ``gateway.status`` (circular import, syntax error,
-    missing transitive dep, scaffold race) was silently caught and returned
-    False for every PID — wiping the entire active-session registry through
-    ``_prune_dead`` exactly when it matters most (startup).
+    per-call.  The binding is resolved once at first use and reused, so the
+    import machinery (and its failure modes: circular import, syntax error,
+    missing transitive dep, scaffold race) is exercised at most once per
+    process instead of on every ``_pid_alive`` call.
 
-    Importing once at first call and reusing the reference keeps the blast
-    radius bounded: if the import itself fails, ``_PID_EXISTS`` is never bound
-    and every ``_pid_alive`` call raises — surfacing the real problem instead
-    of silently making every PID look dead.
+    If the import fails, ``_PID_EXISTS`` is never bound and ``_pid_alive``
+    treats the PID as *unknown* — it fails closed (reports alive) so
+    ``_prune_dead`` spares every entry rather than wiping the registry.
     """
     global _PID_EXISTS
     from gateway.status import _pid_exists as _PID_EXISTS  # noqa: WPS436
@@ -298,6 +296,12 @@ def _pid_alive(pid: Any, process_start_time: Any = None) -> bool:
         return False
     try:
         _resolve_pid_exists()
+    except Exception:
+        # Checker unavailable: we cannot prove the PID dead. Report alive
+        # so _prune_dead spares entries instead of wiping the registry on
+        # an import failure in gateway.status.
+        return True
+    try:
         exists = bool(_PID_EXISTS(pid_int))
     except Exception:
         return False

--- a/hermes_cli/dashboard_procs.py
+++ b/hermes_cli/dashboard_procs.py
@@ -646,24 +646,550 @@ def _is_desktop_local_serve_cmdline(command: str) -> bool:
     return True
 
 
-def _process_ppid(pid: int) -> int | None:
-    """Best-effort parent pid lookup. None on failure."""
+# --- Orphaned TUI node reaper ------------------------------------------------
+#
+# ``hermes desktop`` / ``hermes --tui`` spawn a ``node`` TUI process
+# (``node ui-tui/dist/entry.js`` via _make_tui_argv). When the parent
+# ``hermes``/``python`` process exits uncleanly, the node child survives and
+# keeps emitting prompt_toolkit status chrome to a shared terminal, producing
+# the stacked/repeated status frames seen on Windows.
+#
+# Safety is the whole point: this MUST NOT kill anything except a Hermes TUI
+# node that is a true orphan. Two independent gates enforce that:
+#   (1) the executable must be verified Node (node / node.exe) — a process
+#       whose cmdline merely *mentions* ``ui-tui/dist/entry`` (a python
+#       shell, a notepad.exe, a grep) is never selected;
+#   (2) the node must be a true orphan — its launching parent has exited.
+
+# The launcher (_launch_tui in main.py) only ever launches these concrete
+# entry scripts (each via `node --expose-gc <entry>`):
+#   1. <ui-tui>/dist/entry.js             (development checkout / build)
+#   2. <HERMES_TUI_DIR>/dist/entry.js     (external prebuilt, via env)
+#   3. <hermes_cli>/tui_dist/entry.js     (wheel-bundled prebuilt)
+# We match ONLY those normalized, approved paths (not generic fragments), so an
+# unrelated `node --expose-gc /tmp/unrelated/dist/entry.js` is never reaped
+# (Greptile P1: generic entry paths match unrelated nodes).
+def _hermes_tui_entry_paths() -> set[str]:
+    """Return the normalized absolute entry.js paths Hermes can launch as TUI.
+
+    These are exactly the paths _launch_tui may pass to `node --expose-gc`.
+    The reaper matches a candidate cmdline's entry path against this set.
+    """
+    paths: set[str] = set()
+    # (3) wheel-bundled prebuilt: <hermes_cli>/tui_dist/entry.js
     try:
-        if sys.platform == "win32":
-            return None  # Windows orphan reap is handled by desktop tree-kill.
-        result = subprocess.run(
-            ["ps", "-o", "ppid=", "-p", str(pid)],
-            capture_output=True,
-            text=True,
-            encoding="utf-8",
-            errors="replace",
-            timeout=5,
-        )
-        if result.returncode != 0 or not result.stdout:
-            return None
-        return int(result.stdout.strip().split()[0])
-    except (ValueError, FileNotFoundError, subprocess.TimeoutExpired, OSError):
+        bundled = Path(__file__).resolve().parent / "tui_dist" / "entry.js"
+        paths.add(str(bundled))
+    except Exception:
+        pass
+    # (2) external prebuilt via HERMES_TUI_DIR
+    ext = os.environ.get("HERMES_TUI_DIR")
+    if ext:
+        try:
+            paths.add(str(Path(ext).resolve() / "dist" / "entry.js"))
+        except Exception:
+            pass
+    # (1) development checkout: <HERMES_HOME>/ui-tui/dist/entry.js
+    home = os.environ.get("HERMES_HOME")
+    if home:
+        try:
+            paths.add(str(Path(home).resolve() / "ui-tui" / "dist" / "entry.js"))
+        except Exception:
+            pass
+    # Also accept a ui-tui dir next to the hermes_cli package (checkout layout).
+    try:
+        checkout = Path(__file__).resolve().parent.parent / "ui-tui" / "dist" / "entry.js"
+        paths.add(str(checkout))
+    except Exception:
+        pass
+    return {p.lower() for p in paths}
+
+
+# Precomputed once at import; cheap and stable for a given home/env.
+_APPROVED_TUI_ENTRY_PATHS = _hermes_tui_entry_paths()
+
+
+def _is_tui_node_cmdline(cmd: str) -> bool:
+    """True iff *cmd* is a Hermes TUI node launch (one of the approved layouts).
+
+    Requires the Hermes launcher flag ``--expose-gc`` followed by an entry path
+    that normalizes to one of the concrete TUI entry scripts Hermes launches
+    (see ``_hermes_tui_entry_paths``). An unrelated node whose cmdline merely
+    contains ``dist/entry.js`` is NOT selected.
+    """
+    if "--expose-gc" not in cmd:
+        return False
+    # Find the path token that follows --expose-gc.
+    try:
+        tokens = cmd.split()
+        idx = tokens.index("--expose-gc")
+        entry = tokens[idx + 1] if idx + 1 < len(tokens) else ""
+    except (ValueError, IndexError):
+        return False
+    if not entry:
+        return False
+    try:
+        normalized = str(Path(entry).resolve()).lower()
+    except (OSError, ValueError):
+        normalized = entry.lower()
+    return normalized in _APPROVED_TUI_ENTRY_PATHS
+
+
+def _is_node_exe(command: str) -> bool:
+    """True iff the command's executable is Node (node / node.exe).
+
+    The first whitespace-delimited token of a process command line is normally
+    the executable. We resolve its basename case-insensitively so both POSIX
+    ``node`` and Windows ``node.exe`` match, and common shim forms
+    (``node.cmd``, ``node.bat``) are rejected as non-Node. Paths are stripped
+    of surrounding quotes (Windows wmic may quote the exe).
+
+    When the first token is not Node, a short multi-token prefix is tried: a
+    Node binary launched by absolute path whose path contains spaces (e.g.
+    ``C:\\Program Files\\nodejs\\node.exe``) is split by the cmdline join, so
+    the executable only reassembles across several tokens. Only a
+    path-qualified (separator-bearing) token may extend the head — a bare
+    ``node`` argument after a non-Node executable must not match. The
+    scanners prefer psutil's ``exe`` attribute (ground truth) over this
+    heuristic whenever it is available.
+    """
+    if not command:
+        return False
+    tokens = command.split()
+    if not tokens:
+        return False
+
+    def _basename_is_node(token: str) -> bool:
+        name = Path(token.strip('"').strip("'")).name.lower()
+        return name.strip('"').strip("'") in ("node", "node.exe")
+
+    if _basename_is_node(tokens[0]):
+        return True
+    # Reassemble a spaced absolute path: accept once a path-qualified token
+    # whose basename is node(.exe) completes the executable portion.
+    for token in tokens[1:5]:
+        token = token.strip('"').strip("'")
+        if ("/" in token or "\\" in token) and _basename_is_node(token):
+            return True
+    return False
+
+
+def _process_ppid(pid: int) -> int | None:
+    """Best-effort parent pid lookup, cross-platform via psutil.
+
+    Returns None on any failure. Uses psutil (a core dependency) rather than a
+    POSIX-only ``ps`` shell-out so Windows TUI nodes can also be evaluated for
+    orphanhood — a shell-out to ``ps`` returns nothing on Windows and would make
+    the entire Windows reaper unreachable.
+    """
+    try:
+        import psutil  # type: ignore
+
+        return psutil.Process(pid).ppid()
+    except Exception:
         return None
+
+
+def _is_alive_parent(ppid: int, child_create_time: float | None = None) -> bool:
+    """True iff *ppid* is a live process (psutil-free check).
+
+    When *child_create_time* is known, a PID-reuse check is applied: a real
+    parent is always older than its child, so a "parent" whose create time is
+    newer than the child's is an unrelated process that reused the dead
+    parent's PID — treat the parent as dead. Without the child's create time
+    (or when the parent's create time cannot be read), the check stays
+    fail-closed: spare the process.
+    """
+    if ppid <= 1:
+        return False  # reparented to init / already a true orphan
+    try:
+        import psutil  # type: ignore
+
+        if not psutil.pid_exists(ppid):
+            return False
+        if child_create_time is not None:
+            try:
+                parent_create_time = psutil.Process(ppid).create_time()
+            except psutil.Error:
+                return True  # cannot prove reuse; spare
+            if parent_create_time > child_create_time:
+                return False  # PID reused by a newer process: parent is dead
+        return True
+    except Exception:
+        # If we cannot determine liveness, err toward sparing the process.
+        return True
+
+
+def _tui_node_exclude_pids() -> set[int]:
+    """PIDs that must never be reaped by the TUI node reaper.
+
+    Mirrors the safety exclusions of the dashboard reaper:
+    - the current Python process and every ancestor whose exe is a Hermes venv
+      shim (so we never reap the live launcher that owns this launch);
+    - HERMES_DESKTOP_CHILD_PID entries (Desktop-managed backends).
+    Never raises.
+    """
+    exclude: set[int] = set()
+    try:
+        import psutil  # type: ignore
+    except Exception:
+        return exclude
+
+    seed = os.getpid()
+    exclude.add(seed)
+    try:
+        exclude.add(os.getppid())  # direct parent (the launcher / shell)
+    except Exception:
+        pass
+    # Desktop-managed live backend children must be spared.
+    raw_pid = os.environ.get("HERMES_DESKTOP_CHILD_PID")
+    if raw_pid:
+        for part in raw_pid.split(","):
+            part = part.strip()
+            if not part:
+                continue
+            try:
+                exclude.add(int(part))
+            except (ValueError, TypeError):
+                pass
+    # Exclude the whole ancestor chain whose exe is a Hermes venv shim.
+    try:
+        shim_paths: set[str] = set()
+        scripts_dir = _m()._venv_scripts_dir()
+        if scripts_dir is not None:
+            for shim in _m()._hermes_exe_shims(scripts_dir):
+                try:
+                    shim_paths.add(str(shim.resolve()).lower())
+                except OSError:
+                    shim_paths.add(str(shim).lower())
+    except Exception:
+        shim_paths = set()
+    if shim_paths:
+        try:
+            proc = psutil.Process(seed)
+            for ancestor in proc.parents():
+                try:
+                    anc_exe = ancestor.exe()
+                except Exception:
+                    continue
+                if not anc_exe:
+                    continue
+                try:
+                    anc_norm = str(Path(anc_exe).resolve()).lower()
+                except (OSError, ValueError):
+                    anc_norm = str(anc_exe).lower()
+                if anc_norm in shim_paths:
+                    try:
+                        exclude.add(int(ancestor.pid))
+                    except Exception:
+                        continue
+        except Exception:
+            pass
+    return exclude
+
+
+def _scan_posix_node_processes(
+    exclude: set[int]
+) -> list[tuple[int, str, tuple[float, str] | None]]:
+    """Scan POSIX for orphanable TUI node processes (psutil process_iter).
+
+    Returns ``(pid, cmdline, identity)`` tuples. A process is only returned
+    when BOTH:
+    - its executable is verified Node (gate 1), and
+    - its cmdline matches a TUI pattern.
+    ``identity`` is a NON-NONE stable (create_time, exe) snapshot taken from the
+    SAME process_iter observation as the cmdline (no separate lookup), so a PID
+    reused after this snapshot can never masquerade as the scanned process
+    (Greptile P1: scan identity reused). Excludes *exclude* PIDs and self.
+    Empty list on any error.
+    """
+    self_pid = os.getpid()
+    found: list[tuple[int, str, tuple[float, str] | None]] = []
+    try:
+        import psutil  # type: ignore
+    except Exception:
+        return []
+    try:
+        for proc in psutil.process_iter(["pid", "cmdline", "create_time", "exe"]):
+            try:
+                info = proc.info
+                pid = int(info.get("pid"))
+                cmd_parts = info.get("cmdline") or []
+                cmd = " ".join(str(c) for c in cmd_parts)
+            except (ValueError, TypeError, psutil.Error):
+                continue
+            if pid == self_pid or pid in exclude:
+                continue
+            if not cmd:
+                continue
+            # Prefer psutil's exe (ground truth) over the cmdline heuristic:
+            # a Node binary at a spaced path ("C:\Program Files\...") splits
+            # across cmdline tokens and defeats first-token matching.
+            exe_path = (proc.info.get("exe") or "").strip()
+            if exe_path:
+                if Path(exe_path).name.lower() not in ("node", "node.exe"):
+                    continue
+            elif not _is_node_exe(cmd):
+                continue
+            if not _is_tui_node_cmdline(cmd):
+                continue
+            try:
+                identity = (float(proc.info["create_time"]), (proc.info.get("exe") or "").lower())
+            except (TypeError, ValueError, psutil.Error):
+                identity = None
+            found.append((pid, cmd, identity))
+    except Exception:
+        return found
+    return found
+
+
+def _scan_windows_node_processes(
+    exclude: set[int]
+) -> list[tuple[int, str, tuple[float, str] | None]]:
+    """Scan Windows for orphanable TUI node processes (psutil process_iter).
+
+    Uses the SAME cross-platform process_iter snapshot as the POSIX scanner, so
+    identity (create_time, exe) is bound to the exact process whose cmdline was
+    read — no separate ``psutil.Process(pid)`` lookup that a PID reuse could fool
+    (Greptile P1: scan identity reused). This also removes the prior wmic
+    dependency entirely, so discovery still works on builds where wmic was
+    removed (Greptile P1: no WMIC fallback). Returns ``(pid, cmdline, identity)``
+    tuples. Empty list on any error.
+    """
+    self_pid = os.getpid()
+    found: list[tuple[int, str, tuple[float, str] | None]] = []
+    try:
+        import psutil  # type: ignore
+    except Exception:
+        return []
+    try:
+        for proc in psutil.process_iter(["pid", "cmdline", "create_time", "exe"]):
+            try:
+                info = proc.info
+                pid = int(info.get("pid"))
+                cmd_parts = info.get("cmdline") or []
+                cmd = " ".join(str(c) for c in cmd_parts)
+            except (ValueError, TypeError, psutil.Error):
+                continue
+            if pid == self_pid or pid in exclude:
+                continue
+            if not cmd:
+                continue
+            # Same exe-first rule as the POSIX scanner: psutil's exe is ground
+            # truth; the cmdline heuristic is only a fallback.
+            exe_path = (info.get("exe") or "").strip()
+            if exe_path:
+                if Path(exe_path).name.lower() not in ("node", "node.exe"):
+                    continue
+            elif not _is_node_exe(cmd):
+                continue
+            if not _is_tui_node_cmdline(cmd):
+                continue
+            try:
+                identity = (float(proc.info["create_time"]), (proc.info.get("exe") or "").lower())
+            except (TypeError, ValueError, psutil.Error):
+                identity = None
+            found.append((pid, cmd, identity))
+    except Exception:
+        return found
+    return found
+
+
+def _reap_orphaned_tui_nodes(
+    *,
+    tui_dir: Path | None = None,
+    signal_term: int | None = None,
+    signal_kill: int | None = None,
+    sleep_fn=None,
+    lock_owned_pids_fn=None,
+) -> dict[str, list]:
+    """Kill leftover ``node`` TUI processes (``ui-tui/dist/entry``) from prior launches.
+
+    ``hermes desktop`` and ``hermes --tui`` launch a ``node`` TUI process via
+    :func:`hermes_cli.main._launch_tui` (``node ui-tui/dist/entry.js``). That
+    call previously never reaped the previous launch's node tree: when the
+    parent ``hermes``/``python`` process died uncleanly, the node child
+    survived and kept emitting prompt_toolkit status chrome to a shared
+    terminal surface, producing the stacked/repeated status frames observed on
+    Windows (multiple independent TUI UIs sharing one TTY).
+
+    This is the TUI analogue of :func:`_reap_orphaned_desktop_local_serves`,
+    applied at TUI-launch time. It reuses the same safety model and the same
+    Windows ``taskkill /T /F`` tree-kill the rest of the codebase uses for
+    Windows process teardown; the POSIX path mirrors the SIGTERM-then-SIGKILL
+    grace of the desktop reaper.
+
+    Safety (never relaxes below what the dashboard reaper enforces):
+    - the process executable MUST be verified Node (``node``/``node.exe``):
+      a ``python``/``notepad.exe``/``grep`` cmdline that merely mentions
+      ``ui-tui/dist/entry`` is never selected (Greptile P1, #verified-node);
+    - only nodes that are true orphans — their parent ``hermes``/launcher has
+      exited (reparented to init on POSIX). A concurrently-running,
+      legitimately-owned TUI launched by another still-alive ``hermes`` process
+      keeps its parent and is never reaped, so a fresh launch cannot murder an
+      unrelated in-use session;
+    - never self / never the ancestor chain / never ``HERMES_DESKTOP_CHILD_PID``;
+    - never a PID a valid ``backend.lock.json`` claims (SSH remote backends
+      started by other clients/machines are legitimate, even at ppid 1);
+    - on Windows, the tree-kill (``/T /F``) reaps the node child's own
+      descendants along with it, matching Desktop ``forceKillProcessTree``;
+    - best-effort; failures are swallowed and never propagate to launch.
+
+    Returns the same ``{"matched", "killed", "failed"}`` shape as the dashboard
+    reaper for testability and consistency.
+    """
+    import signal as _signal
+    import time as _time
+
+    if signal_term is None:
+        signal_term = _signal.SIGTERM
+    if signal_kill is None:
+        signal_kill = getattr(_signal, "SIGKILL", _signal.SIGTERM)
+    if sleep_fn is None:
+        sleep_fn = _time.sleep
+    if lock_owned_pids_fn is None:
+        lock_owned_pids_fn = lambda: set()  # no external ownership claims by default
+
+    exclude = _tui_node_exclude_pids()
+    exclude.add(os.getpid())
+
+    if sys.platform == "win32":
+        scanned = _scan_windows_node_processes(exclude)
+    else:
+        scanned = _scan_posix_node_processes(exclude)
+
+    if not scanned:
+        return {"matched": [], "killed": [], "failed": []}
+
+    targets: list[tuple[int, str, tuple[float, str]]] = []
+    for pid, cmd, scan_identity in scanned:
+        if pid in exclude:
+            continue
+        # Re-check lock ownership defensively (lock files may be written
+        # between the scan and now). Defense in depth — never kill a freshly
+        # claimed owner.
+        try:
+            owned_now = set(lock_owned_pids_fn())
+        except Exception:
+            owned_now = set()
+        if pid in owned_now:
+            continue
+        # Only reap *orphaned* TUI nodes — those whose launcher parent has
+        # already exited. A live sibling TUI launched from another still-alive
+        # hermes process keeps its parent and must survive.
+        #
+        # Fail closed on an *unknown* parent on BOTH platforms: if we cannot
+        # establish that the launcher is dead, we must not reap (a concurrent
+        # live TUI would otherwise be killed). POSIX and Windows branches must
+        # agree here.
+        ppid = _process_ppid(pid)
+        if ppid is None:
+            # Parent lookup failed: cannot prove orphanhood, skip safely.
+            continue
+        # Pass the child's scan-time create time so _is_alive_parent can detect
+        # a reused parent PID (a real parent is always older than its child).
+        if _is_alive_parent(ppid, scan_identity[0] if scan_identity else None):
+            continue
+        # Require the NON-NONE identity captured by the scanner at scan time
+        # (bound to the exact process that passed the Node/TUI gates). If the
+        # scanner could not snapshot it, or it is empty, skip — we must not reap
+        # an unidentifiable PID, and we must not let a later PID reuse replace
+        # the baseline (Greptile P1: scan identity not preserved).
+        if not scan_identity or scan_identity[0] == 0.0 and scan_identity[1] == "":
+            continue
+        targets.append((pid, cmd, scan_identity))
+
+    if not targets:
+        return {"matched": [], "killed": [], "failed": []}
+
+    matched = [pid for pid, _cmd, _ident in targets]
+    killed: list[int] = []
+    failed: list[int] = []
+
+    def _current_identity(pid: int) -> tuple[float, str] | None:
+        """Live identity of *pid* now, or None if gone/unidentifiable."""
+        try:
+            import psutil  # type: ignore
+
+            proc = psutil.Process(pid)
+            return (proc.create_time(), (proc.exe() or "").lower())
+        except Exception:
+            return None
+
+    if sys.platform == "win32":
+        from hermes_cli._subprocess_compat import windows_hide_flags
+
+        for pid, _cmd, baseline in targets:
+            # Require a non-None identity that still matches the scanned process
+            # immediately before the forced tree-kill. A None, or a changed
+            # identity (PID reused by an unrelated process), means skip.
+            current = _current_identity(pid)
+            if current is None or current != baseline:
+                continue
+            try:
+                result = subprocess.run(
+                    ["taskkill", "/T", "/F", "/PID", str(pid)],
+                    capture_output=True,
+                    text=True,
+                    encoding="utf-8",
+                    errors="replace",
+                    timeout=10,
+                    creationflags=windows_hide_flags(),
+                    stdin=subprocess.DEVNULL,
+                    stdout=subprocess.DEVNULL,
+                    stderr=subprocess.DEVNULL,
+                )
+                if result.returncode == 0:
+                    killed.append(pid)
+                else:
+                    failed.append(pid)
+            except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
+                failed.append(pid)
+    else:
+        for pid, _cmd, baseline in targets:
+            # Re-validate right before SIGTERM: skip if the PID is now gone or
+            # belongs to a different (reused) process.
+            current = _current_identity(pid)
+            if current is None or current != baseline:
+                continue
+            try:
+                os.kill(pid, signal_term)
+            except ProcessLookupError:
+                killed.append(pid)
+                continue
+            except (PermissionError, OSError):
+                failed.append(pid)
+                continue
+        sleep_fn(1.5)
+
+        for pid, _cmd, baseline in targets:
+            if pid in failed:
+                continue
+            # Re-validate before escalating to SIGKILL: only the SAME process
+            # instance we SIGTERM'd may be killed. A None or changed identity
+            # (PID reused) means skip — never kill an unrelated replacement.
+            current = _current_identity(pid)
+            if current is None or current != baseline:
+                continue
+            try:
+                os.kill(pid, signal_kill)
+                killed.append(pid)
+            except ProcessLookupError:
+                killed.append(pid)
+            except OSError:
+                failed.append(pid)
+
+    if matched:
+        try:
+            print(
+                f"⟲ Reaped {len(killed)} orphaned TUI node process(es): "
+                f"{killed or matched}"
+            )
+        except Exception:
+            pass
+
+    return {"matched": matched, "killed": killed, "failed": failed}
+
 
 
 def _exclude_pids_from_env() -> set[int]:
@@ -957,3 +1483,147 @@ def _reap_orphaned_desktop_local_serves(
 
     return {"matched": matched, "killed": killed, "failed": failed}
 
+
+def _scan_windows_gateway_processes(
+    *,
+    exclude_pids: set[int] | None = None,
+) -> list[tuple[int, str]]:
+    """Return orphaned ``python.exe`` gateway processes on Windows.
+
+    Scans for ``python.exe`` processes whose command line contains
+    ``hermes_cli.main gateway run --replace`` and whose parent process is
+    dead. Returns ``(pid, cmdline)`` tuples. Excludes any PIDs in
+    ``exclude_pids``. Returns an empty list on any scan error.
+    """
+    if sys.platform != "win32":
+        return []
+    exclude_pids = exclude_pids or set()
+    try:
+        import psutil  # type: ignore
+
+        matches: list[tuple[int, str]] = []
+        for proc in psutil.process_iter(["pid", "name", "cmdline", "ppid"]):
+            try:
+                info = proc.info
+                pid = info.get("pid")
+                if not pid or pid in exclude_pids:
+                    continue
+                name = (info.get("name") or "").lower()
+                if name not in ("python.exe", "pythonw.exe"):
+                    continue
+                cmdline = " ".join(info.get("cmdline") or [])
+                if "hermes_cli.main gateway run --replace" not in cmdline:
+                    continue
+                ppid = info.get("ppid")
+                if ppid is None or ppid <= 1:
+                    continue
+                if _is_alive_parent(ppid):
+                    continue
+                matches.append((int(pid), cmdline))
+            except (psutil.NoSuchProcess, psutil.AccessDenied, psutil.ZombieProcess):
+                continue
+            except Exception:
+                continue
+        return matches
+    except Exception:
+        return []
+
+
+def _reap_orphaned_windows_gateway_processes(
+    *,
+    reason: str = "orphaned windows gateway python",
+) -> dict[str, list]:
+    """Kill orphaned ``python.exe`` gateway backends on Windows.
+
+    When a ``hermes gateway run --replace`` parent exits uncleanly, the
+    child ``python.exe`` can survive with a dead parent PID. These orphans
+    keep gateway state, port bindings, and MCP trees alive, causing
+    silent frontend/backend mismatches on the next launch (similar to the
+    desktop-local serve reaper, but for the gateway/python spawn shape on
+    Windows, which the POSIX-only ``_reap_orphaned_desktop_local_serves``
+    does not cover).
+
+    Safety:
+    - only processes whose cmdline matches ``hermes_cli.main gateway run --replace``
+    - only processes whose current ppid is dead (not merely reparented to
+      a live supervisor)
+    - never self / never ``HERMES_DESKTOP_CHILD_PID`` entries
+    - never a PID a valid ``backend.lock.json`` claims as its owner
+    - uses ``taskkill /T /F /PID`` tree-kill, same as the rest of the
+      Windows codebase
+    - best-effort; failures never raise to the caller
+    """
+    if sys.platform != "win32":
+        return {"matched": [], "killed": [], "failed": []}
+
+    exclude = _exclude_pids_from_env()
+    exclude.add(os.getpid())
+    try:
+        exclude.add(os.getppid())
+    except Exception:
+        pass
+    try:
+        exclude |= set(_lock_owned_serve_pids())
+    except Exception:
+        pass
+
+    try:
+        scanned = _scan_windows_gateway_processes(exclude_pids=exclude)
+    except Exception:
+        return {"matched": [], "killed": [], "failed": []}
+
+    targets: list[tuple[int, str]] = []
+    try:
+        owned_now = set(_lock_owned_serve_pids())
+    except Exception:
+        owned_now = set()
+    for pid, cmd in scanned:
+        if pid in owned_now:
+            continue
+        ppid = _process_ppid(pid)
+        if ppid is None:
+            continue
+        if _is_alive_parent(ppid):
+            continue
+        targets.append((pid, cmd))
+
+    if not targets:
+        return {"matched": [], "killed": [], "failed": []}
+
+    matched = [pid for pid, _ in targets]
+    killed: list[int] = []
+    failed: list[int] = []
+
+    from hermes_cli._subprocess_compat import windows_hide_flags
+
+    for pid, _cmd in targets:
+        try:
+            result = subprocess.run(
+                ["taskkill", "/T", "/F", "/PID", str(pid)],
+                capture_output=True,
+                text=True,
+                encoding="utf-8",
+                errors="replace",
+                timeout=10,
+                creationflags=windows_hide_flags(),
+                stdin=subprocess.DEVNULL,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            )
+            if result.returncode == 0:
+                killed.append(pid)
+            else:
+                failed.append(pid)
+        except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
+            failed.append(pid)
+
+    if matched:
+        try:
+            print(
+                f"⟲ Reaped {len(killed)} orphaned windows gateway "
+                f"process(es) ({reason}): {killed or matched}"
+            )
+        except Exception:
+            pass
+
+    return {"matched": matched, "killed": killed, "failed": failed}

--- a/hermes_cli/dashboard_procs.py
+++ b/hermes_cli/dashboard_procs.py
@@ -820,6 +820,17 @@ def _is_alive_parent(ppid: int, child_create_time: float | None = None) -> bool:
         return True
 
 
+def _current_process_identity(pid: int) -> tuple[float, str] | None:
+    """Live ``(create_time, exe)`` identity of *pid*, or None if gone/unreadable."""
+    try:
+        import psutil  # type: ignore
+
+        proc = psutil.Process(pid)
+        return (proc.create_time(), (proc.exe() or "").lower())
+    except Exception:
+        return None
+
+
 def _tui_node_exclude_pids() -> set[int]:
     """PIDs that must never be reaped by the TUI node reaper.
 
@@ -1106,16 +1117,6 @@ def _reap_orphaned_tui_nodes(
     killed: list[int] = []
     failed: list[int] = []
 
-    def _current_identity(pid: int) -> tuple[float, str] | None:
-        """Live identity of *pid* now, or None if gone/unidentifiable."""
-        try:
-            import psutil  # type: ignore
-
-            proc = psutil.Process(pid)
-            return (proc.create_time(), (proc.exe() or "").lower())
-        except Exception:
-            return None
-
     if sys.platform == "win32":
         from hermes_cli._subprocess_compat import windows_hide_flags
 
@@ -1123,7 +1124,7 @@ def _reap_orphaned_tui_nodes(
             # Require a non-None identity that still matches the scanned process
             # immediately before the forced tree-kill. A None, or a changed
             # identity (PID reused by an unrelated process), means skip.
-            current = _current_identity(pid)
+            current = _current_process_identity(pid)
             if current is None or current != baseline:
                 continue
             try:
@@ -1149,7 +1150,7 @@ def _reap_orphaned_tui_nodes(
         for pid, _cmd, baseline in targets:
             # Re-validate right before SIGTERM: skip if the PID is now gone or
             # belongs to a different (reused) process.
-            current = _current_identity(pid)
+            current = _current_process_identity(pid)
             if current is None or current != baseline:
                 continue
             try:
@@ -1168,7 +1169,7 @@ def _reap_orphaned_tui_nodes(
             # Re-validate before escalating to SIGKILL: only the SAME process
             # instance we SIGTERM'd may be killed. A None or changed identity
             # (PID reused) means skip — never kill an unrelated replacement.
-            current = _current_identity(pid)
+            current = _current_process_identity(pid)
             if current is None or current != baseline:
                 continue
             try:
@@ -1487,13 +1488,17 @@ def _reap_orphaned_desktop_local_serves(
 def _scan_windows_gateway_processes(
     *,
     exclude_pids: set[int] | None = None,
-) -> list[tuple[int, str]]:
-    """Return orphaned ``python.exe`` gateway processes on Windows.
+) -> list[tuple[int, str, tuple[float, str] | None]]:
+    """Return candidate ``python.exe`` gateway processes on Windows.
 
     Scans for ``python.exe`` processes whose command line contains
-    ``hermes_cli.main gateway run --replace`` and whose parent process is
-    dead. Returns ``(pid, cmdline)`` tuples. Excludes any PIDs in
-    ``exclude_pids``. Returns an empty list on any scan error.
+    ``hermes_cli.main gateway run --replace``. Returns
+    ``(pid, cmdline, identity)`` triples where ``identity`` is a scan-time
+    ``(create_time, exe)`` snapshot bound to the exact process_iter
+    observation (None if unavailable — the reaper skips those). Orphan
+    verification (dead parent, PID-reuse-aware) is done by the caller via
+    :func:`_is_alive_parent` with the scanned child's create time. Excludes
+    any PIDs in ``exclude_pids``. Returns an empty list on any scan error.
     """
     if sys.platform != "win32":
         return []
@@ -1501,8 +1506,10 @@ def _scan_windows_gateway_processes(
     try:
         import psutil  # type: ignore
 
-        matches: list[tuple[int, str]] = []
-        for proc in psutil.process_iter(["pid", "name", "cmdline", "ppid"]):
+        matches: list[tuple[int, str, tuple[float, str] | None]] = []
+        for proc in psutil.process_iter(
+            ["pid", "name", "cmdline", "create_time", "exe"]
+        ):
             try:
                 info = proc.info
                 pid = info.get("pid")
@@ -1514,12 +1521,14 @@ def _scan_windows_gateway_processes(
                 cmdline = " ".join(info.get("cmdline") or [])
                 if "hermes_cli.main gateway run --replace" not in cmdline:
                     continue
-                ppid = info.get("ppid")
-                if ppid is None or ppid <= 1:
-                    continue
-                if _is_alive_parent(ppid):
-                    continue
-                matches.append((int(pid), cmdline))
+                try:
+                    identity = (
+                        float(info["create_time"]),
+                        (info.get("exe") or "").lower(),
+                    )
+                except (TypeError, ValueError):
+                    identity = None
+                matches.append((int(pid), cmdline, identity))
             except (psutil.NoSuchProcess, psutil.AccessDenied, psutil.ZombieProcess):
                 continue
             except Exception:
@@ -1546,7 +1555,11 @@ def _reap_orphaned_windows_gateway_processes(
     Safety:
     - only processes whose cmdline matches ``hermes_cli.main gateway run --replace``
     - only processes whose current ppid is dead (not merely reparented to
-      a live supervisor)
+      a live supervisor), checked PID-reuse-aware against the scanned
+      child's create time (a reused parent PID cannot shield an orphan)
+    - only processes with a scan-time ``(create_time, exe)`` identity that
+      still matches immediately before the tree-kill (a PID reused between
+      scan and kill can never be killed)
     - never self / never ``HERMES_DESKTOP_CHILD_PID`` entries
     - never a PID a valid ``backend.lock.json`` claims as its owner
     - uses ``taskkill /T /F /PID`` tree-kill, same as the rest of the
@@ -1572,31 +1585,42 @@ def _reap_orphaned_windows_gateway_processes(
     except Exception:
         return {"matched": [], "killed": [], "failed": []}
 
-    targets: list[tuple[int, str]] = []
+    targets: list[tuple[int, str, tuple[float, str]]] = []
     try:
         owned_now = set(_lock_owned_serve_pids())
     except Exception:
         owned_now = set()
-    for pid, cmd in scanned:
+    for pid, cmd, scan_identity in scanned:
         if pid in owned_now:
+            continue
+        # Skip unidentifiable processes — same fail-closed rule as the TUI
+        # node reaper: never kill a PID we cannot bind to the scanned process.
+        if not scan_identity:
             continue
         ppid = _process_ppid(pid)
         if ppid is None:
             continue
-        if _is_alive_parent(ppid):
+        # Pass the child's scan-time create time so _is_alive_parent can
+        # detect a reused parent PID (a real parent is always older).
+        if _is_alive_parent(ppid, scan_identity[0]):
             continue
-        targets.append((pid, cmd))
+        targets.append((pid, cmd, scan_identity))
 
     if not targets:
         return {"matched": [], "killed": [], "failed": []}
 
-    matched = [pid for pid, _ in targets]
+    matched = [pid for pid, _, _ in targets]
     killed: list[int] = []
     failed: list[int] = []
 
     from hermes_cli._subprocess_compat import windows_hide_flags
 
-    for pid, _cmd in targets:
+    for pid, _cmd, baseline in targets:
+        # Identity must still match the scanned process right before the
+        # forced tree-kill; a gone or replaced (PID-reused) process is skipped.
+        current = _current_process_identity(pid)
+        if current is None or current != baseline:
+            continue
         try:
             result = subprocess.run(
                 ["taskkill", "/T", "/F", "/PID", str(pid)],

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -349,23 +349,35 @@ def _wants_tui_early(argv: "list[str] | None" = None) -> bool:
 def _suppress_mouse_residue_early() -> None:
     if os.environ.get("HERMES_TUI_NO_EARLY_DISABLE") == "1":
         return
-    if not _wants_tui_early():
-        return
-    try:
-        # Skip when stdout is redirected (`hermes --tui … >log`, CI capture):
-        # the bytes can't reach the terminal anyway and would just pollute
-        # the log with raw CSI.
-        if not os.isatty(1):
-            return
-        # Disable every mouse-tracking variant we know about. Idempotent and
-        # safe to send even when no tracking is currently asserted.
-        os.write(
-            1,
-            b"\x1b[?1003l\x1b[?1002l\x1b[?1001l\x1b[?1000l\x1b[?9l"
-            b"\x1b[?1006l\x1b[?1005l\x1b[?1015l\x1b[?1016l\x1b[?2029l",
-        )
-    except OSError:
-        pass
+    # Mouse-tracking residue suppression is TUI-specific: SGR/X10 mouse
+    # reports echo as ``^[[<…M`` text only during the window before the TUI
+    # takes stdin into raw mode. Skip entirely when TUI isn't wanted.
+    if _wants_tui_early():
+        try:
+            # Skip when stdout is redirected (`hermes --tui … >log`, CI capture):
+            # the bytes can't reach the terminal anyway and would just pollute
+            # the log with raw CSI.
+            if not os.isatty(1):
+                return
+            # Disable every mouse-tracking variant we know about. Idempotent and
+            # safe to send even when no tracking is currently asserted.
+            os.write(
+                1,
+                b"\x1b[?1003l\x1b[?1002l\x1b[?1001l\x1b[?1000l\x1b[?9l"
+                b"\x1b[?1006l\x1b[?1005l\x1b[?1015l\x1b[?1016l\x1b[?2029l",
+            )
+        except OSError:
+            pass
+    # Cursor blink suppression: applies to ALL interactive sessions (CLI and
+    # TUI). The cursor-blink cycle on Windows ConPTY / Windows Terminal can
+    # leave residual screen updates (flicker artifact). Disable it once at
+    # startup rather than fighting it per-frame. Safe on all terminals: ignored
+    # by those that don't support cursor-blink control.
+    if os.isatty(1) and os.environ.get("HERMES_NONINTERACTIVE") != "1":
+        try:
+            os.write(1, b"\x1b[?12l\x1b[?25h")
+        except OSError:
+            pass
 
 
 _suppress_mouse_residue_early()
@@ -2370,6 +2382,16 @@ def _launch_tui(
     """Replace current process with the TUI."""
     tui_dir = PROJECT_ROOT / "ui-tui"
 
+    # Best-effort: reap orphaned node TUI trees left by crashed prior launches
+    # (stacked prompt_toolkit status frames on Windows). The reaper only touches
+    # verified Node processes that are true orphans; it never blocks launch.
+    try:
+        from hermes_cli.dashboard_procs import _reap_orphaned_tui_nodes
+
+        _reap_orphaned_tui_nodes(tui_dir=tui_dir)
+    except Exception:
+        logger.debug("TUI orphan reaper skipped", exc_info=True)
+
     import tempfile
 
     # TUI child is a hermes process: propagate the profile-home contract via
@@ -2882,6 +2904,14 @@ def cmd_chat(args):
 def cmd_gateway(args):
     """Gateway management commands."""
     _sync_bundled_skills_quietly()
+
+    if sys.platform == "win32":
+        try:
+            from hermes_cli.dashboard_procs import _reap_orphaned_windows_gateway_processes
+
+            _reap_orphaned_windows_gateway_processes()
+        except Exception:
+            logger.debug("Windows gateway orphan reaper skipped", exc_info=True)
 
     from hermes_cli.gateway import gateway_command
 
@@ -11719,6 +11749,14 @@ def main():
             _recover_from_interrupted_install()
     except Exception:
         pass
+
+    if sys.platform == "win32":
+        try:
+            from hermes_cli.dashboard_procs import _reap_orphaned_windows_gateway_processes
+
+            _reap_orphaned_windows_gateway_processes()
+        except Exception:
+            logger.debug("Windows gateway orphan reaper skipped", exc_info=True)
 
     if _try_termux_fast_tui_launch():
         return

--- a/tests/agent/test_spinner_status_repeat.py
+++ b/tests/agent/test_spinner_status_repeat.py
@@ -1,0 +1,111 @@
+"""Regression test: KawaiiSpinner must not stack repeated status frames.
+
+Bug #70031: on Windows + interface=cli + streaming=false, mid-turn status
+frames repeated without clearing, filling output with stacked frames. Root
+cause: KawaiiSpinner clears the previous frame with a bare carriage return
+(\\r); when stdout is wrapped by prompt_toolkit's patch_stdout (or any proxy
+that injects newlines around flush()), the \\r overwrite never lands on the
+same line, so every animation tick is emitted on its own line.
+
+This test proves the spinner suppresses its \\r animation when stdout is a
+proxy that does not honor \\r in-place, writing the status only once instead of
+stacking frames. It is platform-agnostic (no Windows needed) by simulating a
+stdout whose \\r does not return to column 0.
+"""
+
+import threading
+import time
+
+import pytest
+
+from agent.display import KawaiiSpinner
+
+
+class _NoRewriteStdout:
+    """Simulates a proxy stdout where \\r does NOT return to column 0.
+
+    Real terminals honor ``\\r`` as 'go to column 0'; prompt_toolkit's
+    StdoutProxy and some Windows consoles do not, so each write becomes its
+    own line. We record writes as separate lines to model that.
+    """
+
+    def __init__(self):
+        self.lines = []
+        self._buf = ""
+
+    def isatty(self):
+        return True
+
+    def write(self, text):
+        # Emulate a stream that does NOT collapse \\r into the same line:
+        # every chunk is appended as a new logical line.
+        self.lines.append(text)
+        return len(text)
+
+    def flush(self):
+        pass
+
+
+class _PatchStdoutProxyLike:
+    """Mimics prompt_toolkit's StdoutProxy (sets _patch_stdout)."""
+
+    _patch_stdout = object()
+
+    def isatty(self):
+        return True
+
+    def write(self, text):
+        return len(text)
+
+    def flush(self):
+        pass
+
+
+def _run_spinner_for(spinner, seconds=0.4):
+    spinner.start()
+    time.sleep(seconds)
+    spinner.stop("done")
+    # Let the animation thread finish.
+    time.sleep(0.1)
+
+
+def test_spinner_does_not_stack_frames_on_non_rewriting_stdout():
+    """With a stdout that ignores \\r, the spinner must write only ONCE."""
+    out = _NoRewriteStdout()
+    sp = KawaiiSpinner(message="thinking", print_fn=lambda t: out.write(t))
+    # Force the captured _out to our simulated stream so _is_tty/_is_proxy
+    # inspect the right object.
+    sp._out = out
+    _run_spinner_for(sp)
+    # Under a non-rewriting stream the spinner should NOT emit a stream of
+    # distinct animation frames. It writes the single "[tool] message" line
+    # (non-TTY-ish path) and the final "done" line — never a stack of frames.
+    frame_like = [
+        ln for ln in out.lines if "thinking" in ln and ln.strip().startswith("[tool]")
+    ]
+    assert len(frame_like) <= 1, (
+        f"status stacked into {len(frame_like)} frames: {out.lines}"
+    )
+
+
+def test_spinner_treats_patch_stdout_proxy_as_suppressed():
+    """A proxy-like stdout (has _patch_stdout) suppresses \\r animation.
+
+    The animation loop must not run its per-tick \\r frames under a proxy;
+    only the final stop() clear is allowed (a single harmless \\r, not a
+    stack). We assert no \\r is written *during the run* (the stacking bug).
+    """
+    out = _PatchStdoutProxyLike()
+    recorded = []
+    sp = KawaiiSpinner(message="thinking", print_fn=lambda t: recorded.append(t))
+    sp._out = out
+    assert sp._is_patch_stdout_proxy() is True
+    # Run, capturing only in-run writes (stop()'s single clear is excluded).
+    sp.start()
+    time.sleep(0.4)
+    in_run = list(recorded)
+    sp.stop("done")
+    time.sleep(0.1)
+    assert all("\r" not in line for line in in_run), (
+        f"\\r frames leaked during run: {in_run}"
+    )

--- a/tests/cli/test_cli_status_bar.py
+++ b/tests/cli/test_cli_status_bar.py
@@ -219,23 +219,35 @@ class TestCLIStatusBar:
         assert cli_obj._spinner_widget_height(width=40) == 0
 
     def test_classic_cli_application_pins_refresh_interval_zero(self):
-        # #70031 review feedback on #73241: a regression of the
-        # Application(refresh_interval=0.0) pin must be caught. The classic
-        # CLI Application is constructed deep inside the interactive run
-        # loop (not unit-instantiable without a real TTY), so pin the
-        # construction site in source alongside the behavioral cadence
-        # split covered by test_spinner_loop_branch_* above.
-        import inspect
+        # #70031 review feedback on #73241 and #87278: a regression of the
+        # Application(refresh_interval=0.0) pin must be caught. The
+        # construction site is extracted into _build_classic_cli_application
+        # (a pure factory), so the pins are asserted on a real Application
+        # instance — no source inspection, no TTY.
+        from prompt_toolkit.application import Application
+        from prompt_toolkit.key_binding import KeyBindings
+        from prompt_toolkit.layout import Layout
+        from prompt_toolkit.layout.containers import Window
+        from prompt_toolkit.output import DummyOutput
 
-        source = inspect.getsource(cli_mod)
-        assert "refresh_interval=0.0" in source, (
+        app = cli_mod._build_classic_cli_application(
+            layout=Layout(Window()),
+            key_bindings=KeyBindings(),
+            style=None,
+            output=DummyOutput(),
+        )
+
+        assert isinstance(app, Application)
+        assert app.refresh_interval == 0.0, (
             "classic-CLI Application must pin refresh_interval=0.0 (#70031): "
             "prompt_toolkit's timer fires regardless of agent state and "
             "stacks chrome mid-turn"
         )
-        # The configured cadence must be read via resolve_idle_refresh_interval
-        # (idle-only), never handed straight back to the Application.
-        assert "refresh_interval=float(CLI_CONFIG" not in source
+        assert app.erase_when_done is True, (
+            "classic-CLI Application must erase chrome on exit (#38252): "
+            "a frozen final copy stacks with the next session's UI on resume"
+        )
+        assert app.full_screen is False
 
     def test_spinner_loop_branch_never_repaints_while_agent_runs(self):
         # #70031 invariant: while the agent runs (no child command) the

--- a/tests/cli/test_cli_status_bar.py
+++ b/tests/cli/test_cli_status_bar.py
@@ -200,6 +200,43 @@ class TestCLIStatusBar:
         cli_obj._spinner_text = "你" * 40
         assert cli_obj._spinner_widget_height(width=64) == 1
 
+    def test_bottom_chrome_canvas_height_constant_across_turn_lifecycle(self):
+        # #70031 review feedback on #73241: reserving only the spinner row is
+        # incomplete — the agent spacer (_agent_spacer_height) is part of the
+        # same bottom layout and previously flipped 0 -> 1 when the turn
+        # started, scrolling the old chrome into scrollback. Both rows must
+        # be reserved so total canvas height never changes idle -> active.
+        cli_obj = _make_cli()
+        cli_obj._tool_start_time = 0
+        for running in (False, True):
+            cli_obj._agent_running = running
+            idle_total = cli_obj._agent_spacer_height(width=64) + cli_obj._spinner_widget_height(width=64)
+            assert idle_total == 2, f"canvas height changed with _agent_running={running}"
+            assert cli_obj._agent_spacer_height(width=64) == 1
+        # Minimal (narrow) chrome drops both rows consistently.
+        cli_obj._agent_running = True
+        assert cli_obj._agent_spacer_height(width=40) == 0
+        assert cli_obj._spinner_widget_height(width=40) == 0
+
+    def test_classic_cli_application_pins_refresh_interval_zero(self):
+        # #70031 review feedback on #73241: a regression of the
+        # Application(refresh_interval=0.0) pin must be caught. The classic
+        # CLI Application is constructed deep inside the interactive run
+        # loop (not unit-instantiable without a real TTY), so pin the
+        # construction site in source alongside the behavioral cadence
+        # split covered by test_spinner_loop_branch_* above.
+        import inspect
+
+        source = inspect.getsource(cli_mod)
+        assert "refresh_interval=0.0" in source, (
+            "classic-CLI Application must pin refresh_interval=0.0 (#70031): "
+            "prompt_toolkit's timer fires regardless of agent state and "
+            "stacks chrome mid-turn"
+        )
+        # The configured cadence must be read via resolve_idle_refresh_interval
+        # (idle-only), never handed straight back to the Application.
+        assert "refresh_interval=float(CLI_CONFIG" not in source
+
     def test_spinner_loop_branch_never_repaints_while_agent_runs(self):
         # #70031 invariant: while the agent runs (no child command) the
         # background loop must NOT issue periodic repaints.
@@ -210,13 +247,21 @@ class TestCLIStatusBar:
         assert cli_mod.spinner_loop_branch(False, False, 0.0) == "idle_stable"
 
     def test_resolve_idle_refresh_interval_clamps_and_defaults(self):
-        assert cli_mod.resolve_idle_refresh_interval() == 0.0
+        from hermes_cli.config import DEFAULT_CONFIG
+
+        deliberate = float(DEFAULT_CONFIG["display"]["cli_refresh_interval"])
+        assert deliberate == 1.0  # config deliberately defaults to 1.0
+        # Missing key / junk falls back to the deliberate default, not 0.
+        with patch.object(cli_mod, "CLI_CONFIG", {}):
+            assert cli_mod.resolve_idle_refresh_interval() == deliberate
+        with patch.object(cli_mod, "CLI_CONFIG", {"display": {"cli_refresh_interval": "junk"}}):
+            assert cli_mod.resolve_idle_refresh_interval() == deliberate
         with patch.object(cli_mod, "CLI_CONFIG", {"display": {"cli_refresh_interval": 2.0}}):
             assert cli_mod.resolve_idle_refresh_interval() == 2.0
         with patch.object(cli_mod, "CLI_CONFIG", {"display": {"cli_refresh_interval": 99}}):
             assert cli_mod.resolve_idle_refresh_interval() == 30.0
-        with patch.object(cli_mod, "CLI_CONFIG", {"display": {"cli_refresh_interval": "junk"}}):
-            assert cli_mod.resolve_idle_refresh_interval() == 0.0
+        with patch.object(cli_mod, "CLI_CONFIG", {"display": {"cli_refresh_interval": 0}}):
+            assert cli_mod.resolve_idle_refresh_interval() == 0.0  # explicit opt-out
 
 
     def test_voice_status_bar_compacts_on_narrow_terminals(self):

--- a/tests/cli/test_cli_status_bar.py
+++ b/tests/cli/test_cli_status_bar.py
@@ -187,12 +187,36 @@ class TestCLIStatusBar:
 
 
 
-    def test_spinner_height_uses_display_width_for_wide_characters(self):
+    def test_spinner_height_reserved_constant_one_row(self):
+        # #70031: the spinner row height must stay 1 whether or not spinner
+        # text exists, so the chrome canvas never grows mid-turn (a height
+        # change forces prompt_toolkit to scroll the old chrome into
+        # scrollback, stacking repeated frames). Wide text is clipped by
+        # wrap_lines=False instead of wrapping to a second row.
         cli_obj = _make_cli()
-        cli_obj._spinner_text = "你" * 40
         cli_obj._tool_start_time = 0
 
-        assert cli_obj._spinner_widget_height(width=64) == 2
+        assert cli_obj._spinner_widget_height(width=64) == 1
+        cli_obj._spinner_text = "你" * 40
+        assert cli_obj._spinner_widget_height(width=64) == 1
+
+    def test_spinner_loop_branch_never_repaints_while_agent_runs(self):
+        # #70031 invariant: while the agent runs (no child command) the
+        # background loop must NOT issue periodic repaints.
+        assert cli_mod.spinner_loop_branch(True, False, 2.0) == "repaint_fast"
+        assert cli_mod.spinner_loop_branch(False, True, 2.0) == "stable"
+        assert cli_mod.spinner_loop_branch(False, True, 0.0) == "stable"
+        assert cli_mod.spinner_loop_branch(False, False, 2.0) == "idle_tick"
+        assert cli_mod.spinner_loop_branch(False, False, 0.0) == "idle_stable"
+
+    def test_resolve_idle_refresh_interval_clamps_and_defaults(self):
+        assert cli_mod.resolve_idle_refresh_interval() == 0.0
+        with patch.object(cli_mod, "CLI_CONFIG", {"display": {"cli_refresh_interval": 2.0}}):
+            assert cli_mod.resolve_idle_refresh_interval() == 2.0
+        with patch.object(cli_mod, "CLI_CONFIG", {"display": {"cli_refresh_interval": 99}}):
+            assert cli_mod.resolve_idle_refresh_interval() == 30.0
+        with patch.object(cli_mod, "CLI_CONFIG", {"display": {"cli_refresh_interval": "junk"}}):
+            assert cli_mod.resolve_idle_refresh_interval() == 0.0
 
 
     def test_voice_status_bar_compacts_on_narrow_terminals(self):

--- a/tests/hermes_cli/test_active_sessions.py
+++ b/tests/hermes_cli/test_active_sessions.py
@@ -240,3 +240,43 @@ def test_transfer_under_profile_home_override_targets_acquisition_registry(
     root_registry = root / "runtime" / "active_sessions.json"
     entries = active_sessions._read_entries(root_registry)
     assert [entry["session_id"] for entry in entries] == ["after"]
+
+
+# --- Surface collision / HWND normalization ------------------------------------
+
+
+def test_surfaces_collide_handles_hwnd_and_wt_keys():
+    from hermes_cli.active_sessions import _surfaces_collide
+
+    base = "win32-console:C:\\x\\hermes.exe"
+    # Legacy vs new HWND entries on the same tab must collide.
+    assert _surfaces_collide(f"{base}:hwnd:1704980", f"{base}:hwnd:deadbeef")
+    # Exact match always collides.
+    assert _surfaces_collide(f"{base}:hwnd:1704980", f"{base}:hwnd:1704980")
+    # Two Windows Terminal tabs of the same title have distinct wt GUIDs and
+    # must NOT collide.
+    assert not _surfaces_collide(f"{base}:wt:aaa", f"{base}:wt:bbb")
+    # Same WT tab (same GUID) collides.
+    assert _surfaces_collide(f"{base}:wt:aaa", f"{base}:wt:aaa")
+    # A wt entry and an hwnd entry are different surfaces.
+    assert not _surfaces_collide(f"{base}:wt:aaa", f"{base}:hwnd:1")
+    # Different titles never collide.
+    assert not _surfaces_collide(f"{base}:hwnd:1", "win32-console:other:hwnd:1")
+
+
+def test_pid_fallback_surface_detection_warns(caplog):
+    """Degraded surface ids (empty console title) must warn: the same-surface
+    guard is a silent no-op in that state."""
+    import logging
+    import sys as _sys
+    from unittest.mock import patch
+
+    from hermes_cli import active_sessions as aS
+
+    with patch.object(_sys, "platform", "win32"):
+        with patch("ctypes.windll", create=True) as windll:
+            windll.kernel32.GetConsoleTitleW.return_value = 0
+            with caplog.at_level(logging.WARNING):
+                surface = aS._get_terminal_surface_id()
+    assert surface.startswith("win32-pid:")
+    assert any("duplicate-session guard is ineffective" in r.message for r in caplog.records)

--- a/tests/hermes_cli/test_active_sessions.py
+++ b/tests/hermes_cli/test_active_sessions.py
@@ -280,3 +280,45 @@ def test_pid_fallback_surface_detection_warns(caplog):
                 surface = aS._get_terminal_surface_id()
     assert surface.startswith("win32-pid:")
     assert any("duplicate-session guard is ineffective" in r.message for r in caplog.records)
+
+
+# --- _pid_alive fail-closed on checker unavailability (#87278 review) ----------
+
+
+def test_pid_alive_spare_entries_when_checker_import_fails(monkeypatch):
+    """A gateway.status import failure must NOT make every PID look dead.
+
+    _prune_dead drops entries where _pid_alive is False; treating an import
+    failure as dead wipes the whole registry exactly when startup needs it.
+    The fail-closed contract: unknown liveness reports alive (spare).
+    """
+    from hermes_cli import active_sessions as aS
+
+    def _boom():
+        raise ImportError("gateway.status unavailable (test)")
+
+    monkeypatch.setattr(aS, "_resolve_pid_exists", _boom)
+    # Ensure no stale binding from another test leaks into this one.
+    monkeypatch.delattr(aS, "_PID_EXISTS", raising=False)
+
+    assert aS._pid_alive(12345) is True  # unknown -> spare
+    assert aS._pid_alive(99999) is True
+
+
+def test_pid_alive_uses_bound_checker_when_resolve_succeeds(monkeypatch):
+    from hermes_cli import active_sessions as aS
+
+    monkeypatch.setattr(aS, "_PID_EXISTS", lambda pid: pid == 42, raising=False)
+    monkeypatch.setattr(aS, "_resolve_pid_exists", lambda: None)
+
+    assert aS._pid_alive(42) is True
+    assert aS._pid_alive(43) is False
+
+
+def test_pid_alive_invalid_inputs_stay_dead():
+    from hermes_cli.active_sessions import _pid_alive
+
+    assert _pid_alive(None) is False
+    assert _pid_alive("junk") is False
+    assert _pid_alive(0) is False
+    assert _pid_alive(-5) is False

--- a/tests/hermes_cli/test_orphan_tui_nodes_reap.py
+++ b/tests/hermes_cli/test_orphan_tui_nodes_reap.py
@@ -1,0 +1,602 @@
+"""Orphaned TUI node reap at TUI launch.
+
+``hermes desktop`` / ``hermes --tui`` spawn ``node ui-tui/dist/entry.js``
+trees via :func:`hermes_cli.main._launch_tui`. When the parent ``hermes``
+process dies uncleanly the node child survives and keeps emitting
+prompt_toolkit status chrome to a shared terminal, producing the stacked /
+repeated status frames observed on Windows.
+
+This suite pins the two safety gates the reaper must enforce:
+
+1. **Verified-Node gate (Greptile P1):** a process whose *cmdline merely
+   mentions* ``ui-tui/dist/entry`` but whose executable is NOT node (a
+   ``python`` shell, a ``notepad.exe``) must never be selected for reaping.
+   This is tested against the REAL scanner by faking only the ``ps``/``wmic``
+   subprocess output.
+2. **Orphan gate:** only node processes whose launcher parent has already
+   exited (reparented to init) are reaped; a concurrently-running, live-parent
+   TUI is spared.
+
+The reaper is exercised with mocked kill so no real process is touched.
+"""
+
+import os
+import sys
+from unittest.mock import patch
+
+import pytest
+
+import hermes_cli.dashboard_procs as dp
+
+# Stable (create_time, exe) identity snapshot a scanner would capture for a node
+# process. Used by reaper-level tests whose scanners are mocked.
+IDENT = (1.0, "node")
+WINDOWS_IDENT = (1.0, "node.exe")
+
+
+def _norm(path):
+    from pathlib import Path
+
+    try:
+        return str(Path(path).resolve()).lower()
+    except Exception:
+        return path.lower()
+
+
+# --- Node-identity gate (P1) -------------------------------------------------
+
+
+def test_is_node_exe_accepts_node_only():
+    assert dp._is_node_exe("node ui-tui/dist/entry.js") is True
+    assert dp._is_node_exe("node.exe ui-tui/dist/entry.js") is True
+    assert dp._is_node_exe("/usr/bin/node ui-tui/dist/entry.js") is True
+    assert dp._is_node_exe('"node.exe" ui-tui') is True
+    assert dp._is_node_exe('"/usr/bin/node" ui-tui/dist/entry.js') is True
+
+
+def test_is_node_exe_rejects_non_node():
+    for cmd in (
+        "python ui-tui/dist/entry.js",
+        "notepad.exe --open ui-tui/dist/entry.js",
+        "/usr/bin/node.cmd ui-tui/dist/entry.js",
+        "node.bat ui-tui/dist/entry.js",
+        "grep -r ui-tui/dist/entry .",
+        "",
+    ):
+        assert dp._is_node_exe(cmd) is False
+
+
+def test_tui_cmdline_matches_only_approved_entry_paths():
+    """Greptile P1: generic `--expose-gc` + `dist/entry.js` must not match an
+    unrelated node app. Only entry paths Hermes actually launches are approved."""
+    approved = {
+        _norm("/x/ui-tui/dist/entry.js"),
+        _norm("/opt/hermes-tui/dist/entry.js"),
+        _norm("/lib/python3/site-packages/hermes_cli/tui_dist/entry.js"),
+    }
+    with patch.object(dp, "_APPROVED_TUI_ENTRY_PATHS", approved):
+        # Real Hermes launches (exact approved paths) match.
+        assert dp._is_tui_node_cmdline("node --expose-gc /x/ui-tui/dist/entry.js --session 1") is True
+        assert dp._is_tui_node_cmdline("node --expose-gc /opt/hermes-tui/dist/entry.js") is True
+        assert dp._is_tui_node_cmdline("node --expose-gc /lib/python3/site-packages/hermes_cli/tui_dist/entry.js") is True
+        # Greptile repro: unrelated node with the same generic fragment -> reject.
+        assert dp._is_tui_node_cmdline("node --expose-gc /tmp/unrelated/dist/entry.js") is False
+        # No --expose-gc launcher marker -> reject (even if path looks right).
+        assert dp._is_tui_node_cmdline("node /x/ui-tui/dist/entry.js") is False
+        # Path not in the approved set -> reject.
+        assert dp._is_tui_node_cmdline("node --expose-gc /some/other/app/dist/entry.js") is False
+
+
+def _fake_process_iter(entries):
+    """Patch psutil.process_iter to yield fake procs from *entries*.
+
+    *entries* is a list of dicts each with keys pid/cmdline/create_time/exe.
+    Each fake proc exposes ``.info`` returning that dict (single observation,
+    matching how the production scanner binds identity to cmdline).
+    """
+
+    class _Proc:
+        def __init__(self, info):
+            self.info = info
+
+    class _Iter:
+        def __iter__(self):
+            return (self._make(e) for e in entries)
+
+        @staticmethod
+        def _make(e):
+            return _Proc(e)
+
+    return _Iter()
+
+
+# Real launcher cmdlines always carry --expose-gc (see _launch_tui in main.py).
+POSIX_ENTRIES = [
+    {"pid": 111, "cmdline": ["node", "--expose-gc", "/x/ui-tui/dist/entry.js", "--session", "1"], "create_time": 1.0, "exe": "/usr/bin/node"},  # checkout
+    {"pid": 112, "cmdline": ["node", "--expose-gc", "/opt/hermes-tui/dist/entry.js"], "create_time": 1.1, "exe": "/usr/bin/node"},  # HERMES_TUI_DIR
+    {"pid": 113, "cmdline": ["node", "--expose-gc", "/lib/python3/site-packages/hermes_cli/tui_dist/entry.js"], "create_time": 1.2, "exe": "/usr/bin/node"},  # wheel bundle
+    {"pid": 222, "cmdline": ["python", "-c", "read('ui-tui/dist/entry.js')"], "create_time": 2.0, "exe": "/usr/bin/python"},  # non-Node
+    {"pid": 333, "cmdline": ["notepad.exe", "ui-tui\\dist\\entry"], "create_time": 3.0, "exe": "notepad.exe"},  # non-Node
+    {"pid": 444, "cmdline": ["node", "/usr/bin/vim", "notes", "about", "ui-tui"], "create_time": 4.0, "exe": "/usr/bin/node"},  # no TUI pattern
+    {"pid": 555, "cmdline": ["node", "/some/other/app/dist/entry.js"], "create_time": 5.0, "exe": "/usr/bin/node"},  # node but NOT Hermes (no --expose-gc)
+]
+
+
+def test_scan_posix_rejects_non_node_with_pattern():
+    """Drive the REAL POSIX scanner via psutil.process_iter (Greptile P1 PoC)."""
+    import psutil
+
+    approved = {
+        _norm("/x/ui-tui/dist/entry.js"),
+        _norm("/opt/hermes-tui/dist/entry.js"),
+        _norm("/lib/python3/site-packages/hermes_cli/tui_dist/entry.js"),
+    }
+    with patch.object(dp, "_APPROVED_TUI_ENTRY_PATHS", approved), patch.object(
+        psutil, "process_iter", return_value=_fake_process_iter(POSIX_ENTRIES)
+    ), patch("sys.platform", "darwin"):
+        found = dp._scan_posix_node_processes(set())
+    # All three supported Hermes TUI layouts (111/112/113) are selected; the
+    # python and notepad lines that merely contain the pattern are rejected,
+    # and a node process serving a non-Hermes dist/entry.js (555, no
+    # --expose-gc / not an approved path) is rejected (Greptile P1: broad match).
+    assert sorted(pid for pid, _c, _i in found) == [111, 112, 113]
+
+
+WINDOWS_ENTRIES = [
+    {"pid": 111, "cmdline": ["node.exe", "--expose-gc", "C:\\x\\ui-tui\\dist\\entry.js"], "create_time": 1.0, "exe": "C:\\node.exe"},  # checkout
+    {"pid": 112, "cmdline": ["node.exe", "--expose-gc", "C:\\hermes-tui\\dist\\entry.js"], "create_time": 1.1, "exe": "C:\\node.exe"},  # HERMES_TUI_DIR
+    {"pid": 222, "cmdline": ["python.exe", "-m", "hermes", "--tui", "ui-tui/dist/entry"], "create_time": 2.0, "exe": "python.exe"},  # non-Node
+    {"pid": 333, "cmdline": ["notepad.exe", "ui-tui\\dist\\entry"], "create_time": 3.0, "exe": "notepad.exe"},  # non-Node
+    {"pid": 444, "cmdline": ["node.exe", "C:\\some\\app\\dist\\entry.js"], "create_time": 4.0, "exe": "node.exe"},  # node, non-Hermes (no --expose-gc)
+]
+
+
+def test_scan_windows_rejects_non_node_with_pattern():
+    """Drive the REAL Windows scanner via psutil.process_iter (Greptile P1 PoC)."""
+    import psutil
+
+    approved = {
+        _norm("c:\\x\\ui-tui\\dist\\entry.js"),
+        _norm("c:\\hermes-tui\\dist\\entry.js"),
+    }
+    with patch.object(dp, "_APPROVED_TUI_ENTRY_PATHS", approved), patch.object(
+        psutil, "process_iter", return_value=_fake_process_iter(WINDOWS_ENTRIES)
+    ), patch("sys.platform", "win32"):
+        found = dp._scan_windows_node_processes(set())
+    # Both Hermes TUI layouts (111 checkout, 112 HERMES_TUI_DIR) selected;
+    # python/notepad and the non-Hermes node app (444) rejected.
+    assert sorted(pid for pid, _c, _i in found) == [111, 112]
+
+
+# --- Orphan gate (reaper-level) ---------------------------------------------
+
+
+def _fake_kill_collector():
+    terms: list[int] = []
+    live: set[int] = set()
+
+    def fake_kill(pid, sig):
+        if sig == 0:
+            if pid in live:
+                return None
+            raise ProcessLookupError()
+        if sig == 15:
+            terms.append(pid)
+            live.discard(pid)
+            return None
+        if sig == 9:
+            terms.append(pid)
+            live.discard(pid)
+            return None
+        return None
+
+    return terms, live, fake_kill
+
+
+def test_reap_only_kills_orphan_tui_nodes():
+    scanned = [
+        (111, "node --expose-gc /x/ui-tui/dist/entry.js --session 1", IDENT),  # orphan (ppid 1)
+        (222, "node --expose-gc /x/ui-tui/dist/entry.js --session 2", IDENT),  # live parent
+        (333, "node --expose-gc /x/ui-tui/dist/entry.js --session 3", IDENT),  # orphan (ppid 1)
+    ]
+    ppids = {111: 1, 222: 50, 333: 1, 444: 1}
+    terms, _live, fake_kill = _fake_kill_collector()
+    import psutil
+
+    class _Ident:
+        def create_time(self):
+            return 1.0
+
+        def exe(self):
+            return "node"
+
+    with patch.object(dp, "_scan_posix_node_processes", return_value=scanned), patch(
+        "os.kill", side_effect=fake_kill
+    ), patch("sys.platform", "darwin"), patch.object(
+        dp, "_process_ppid", side_effect=lambda pid: ppids.get(pid)
+    ), patch.object(
+        dp, "_is_alive_parent", side_effect=lambda ppid, ctime=None: ppid not in (0, 1)
+    ), patch.object(psutil, "Process", return_value=_Ident()):
+        result = dp._reap_orphaned_tui_nodes(
+            sleep_fn=lambda _s: None, signal_term=15, signal_kill=9
+        )
+    # matched = selected-for-reaping targets (orphans only).
+    assert set(result["matched"]) == {111, 333}
+    assert set(terms) == {111, 333}
+    assert set(result["killed"]) == {111, 333}
+
+
+def test_substring_ui_tui_in_other_cmdline_is_not_a_tui_node():
+    scanned = [(555, "grep -rl ui-tui/dist/entry ./src", IDENT)]
+    with patch.object(dp, "_scan_posix_node_processes", return_value=scanned), patch(
+        "sys.platform", "darwin"
+    ):
+        result = dp._reap_orphaned_tui_nodes(sleep_fn=lambda _s: None)
+    assert result["matched"] == []
+    assert result["killed"] == []
+
+
+def test_unknown_parent_lookup_is_skipped_safely():
+    """If the parent PID cannot be resolved, we cannot prove orphanhood, so the
+    process is spared (never kill on unknown)."""
+    scanned = [(111, "node --expose-gc /x/ui-tui/dist/entry.js", IDENT)]
+    with patch.object(dp, "_scan_posix_node_processes", return_value=scanned), patch(
+        "os.kill"
+    ) as mock_kill, patch("sys.platform", "darwin"), patch.object(
+        dp, "_process_ppid", return_value=None
+    ):
+        result = dp._reap_orphaned_tui_nodes(sleep_fn=lambda _s: None)
+    assert result["matched"] == []
+    mock_kill.assert_not_called()
+
+
+def test_empty_scan_no_reap():
+    with patch.object(dp, "_scan_posix_node_processes", return_value=[]), patch(
+        "sys.platform", "darwin"
+    ):
+        result = dp._reap_orphaned_tui_nodes(sleep_fn=lambda _s: None)
+    assert result == {"matched": [], "killed": [], "failed": []}
+
+
+# --- Regression: Greptile P1s -------------------------------------------------
+
+
+def test_windows_unknown_parent_is_not_reaped():
+    """P1: a Windows TUI node whose parent lookup fails (None) must NOT be
+    tree-killed. Failing closed matches the POSIX branch."""
+    scanned = [(424242, "node.exe --expose-gc C:\\x\\ui-tui\\dist\\entry.js", WINDOWS_IDENT)]
+    called = []
+
+    def fake_kill(pid, sig):
+        called.append((pid, sig))
+        return None
+
+    with patch.object(dp, "_scan_windows_node_processes", return_value=scanned), patch(
+        "os.kill", side_effect=fake_kill
+    ), patch("sys.platform", "win32"), patch.object(
+        dp, "_process_ppid", return_value=None
+    ):
+        result = dp._reap_orphaned_tui_nodes(sleep_fn=lambda _s: None)
+    assert result["matched"] == []
+    assert called == []  # no taskkill issued for unknown-parent node
+
+
+def test_posix_pid_reuse_skips_sigkill():
+    """P1: if a SIGTERM'd node exits and its PID is reused before the grace
+    period ends, the SIGKILL must NOT be delivered to the replacement."""
+    import psutil
+
+    scanned = [(111, "node --expose-gc /x/ui-tui/dist/entry.js", IDENT)]
+
+    class _Proc:
+        def __init__(self, ctime, exe):
+            self._ctime = ctime
+            self._exe = exe
+
+        def create_time(self):
+            return self._ctime
+
+        def exe(self):
+            return self._exe
+
+    original = _Proc(1.0, "node")  # matches scanner baseline IDENT
+    reused = _Proc(2000.0, "node")  # same exe, different instance (reused PID)
+
+    sigterms = []
+    proc_states = {"after_sleep": False}
+
+    def fake_kill(pid, sig):
+        if sig == 15:
+            sigterms.append(pid)
+        return None
+
+    def fake_process(pid):
+        # Before the grace sleep the selected PID is the original process; after
+        # the sleep a *different* process occupies the same PID.
+        return reused if proc_states["after_sleep"] else original
+
+    with patch.object(dp, "_scan_posix_node_processes", return_value=scanned), patch(
+        "os.kill", side_effect=fake_kill
+    ), patch("sys.platform", "darwin"), patch.object(
+        dp, "_process_ppid", return_value=1
+    ), patch.object(
+        dp, "_is_alive_parent", return_value=False
+    ), patch.object(
+        psutil, "Process", side_effect=fake_process
+    ):
+        def sleep(_s):
+            proc_states["after_sleep"] = True
+
+        result = dp._reap_orphaned_tui_nodes(sleep_fn=sleep)
+    # SIGTERM was attempted; SIGKILL must have been withheld (PID reused).
+    assert sigterms == [111]
+    assert 111 not in result["killed"]
+
+
+def test_windows_orphan_node_reaches_taskkill():
+    """Positive counterpart to the unknown-parent test: a Windows TUI node whose
+    launcher parent is confirmed dead (ppid 1 via psutil) IS reaped by taskkill.
+    (Greptile P1: Windows cleanup must be reachable, not always skipped.)"""
+    import psutil
+
+    scanned = [(111, "node.exe --expose-gc C:\\x\\ui-tui\\dist\\entry.js", WINDOWS_IDENT)]
+    taskkills = []
+
+    class _Proc:
+        def ppid(self):
+            return 1  # orphaned
+
+        def create_time(self):
+            return 1.0
+
+        def exe(self):
+            return "node.exe"
+
+    def fake_run(cmd, **kw):
+        if cmd[:1] == ["taskkill"]:
+            taskkills.append(cmd)
+            class R:
+                returncode = 0
+                stdout = ""
+                stderr = ""
+            return R()
+        raise AssertionError(f"unexpected subprocess: {cmd}")
+
+    with patch.object(dp, "_scan_windows_node_processes", return_value=scanned), patch(
+        "subprocess.run", side_effect=fake_run
+    ), patch("sys.platform", "win32"), patch.object(
+        dp, "_process_ppid", return_value=1
+    ), patch.object(
+        psutil, "Process", return_value=_Proc()
+    ):
+        result = dp._reap_orphaned_tui_nodes(sleep_fn=lambda _s: None)
+    assert result["matched"] == [111]
+    # taskkill /T /F /PID 111 was issued for the orphaned Windows node.
+    assert taskkills and "111" in taskkills[0]
+
+
+def test_windows_pid_reuse_skips_taskkill():
+    """P1: if the Node process exits and its PID is reused before taskkill, the
+    replacement must NOT be tree-killed."""
+    import psutil
+
+    scanned = [(111, "node.exe --expose-gc C:\\x\\ui-tui\\dist\\entry.js", WINDOWS_IDENT)]
+    taskkills = []
+
+    class _Proc:
+        def __init__(self, ctime):
+            self._ctime = ctime
+
+        def create_time(self):
+            return self._ctime
+
+        def exe(self):
+            return "node.exe"
+
+        def ppid(self):
+            return 1
+
+    original = _Proc(1000.0)
+    reused = _Proc(2000.0)  # same PID, different instance
+    calls = {"n": 0}
+
+    def fake_run(cmd, **kw):
+        if cmd[:1] == ["taskkill"]:
+            taskkills.append(cmd)
+            class R:
+                returncode = 0
+                stdout = ""
+                stderr = ""
+            return R()
+        raise AssertionError(f"unexpected subprocess: {cmd}")
+
+    def fake_process(pid):
+        # First identity query (at selection) sees the original; the revalidation
+        # before taskkill sees a different process at the same PID (reuse).
+        calls["n"] += 1
+        return reused if calls["n"] > 1 else original
+
+    with patch.object(dp, "_scan_windows_node_processes", return_value=scanned), patch(
+        "subprocess.run", side_effect=fake_run
+    ), patch("sys.platform", "win32"), patch.object(
+        dp, "_process_ppid", return_value=1
+    ), patch.object(
+        psutil, "Process", side_effect=fake_process
+    ):
+        result = dp._reap_orphaned_tui_nodes(sleep_fn=lambda _s: None)
+    assert taskkills == []  # no taskkill issued for the reused PID
+    assert 111 not in result["killed"]
+
+
+def test_greptile_prebaseline_reuse_424242():
+    """Exact repro of Greptile's P1 harness: a verified-Node TUI (PID 424242)
+    exits and its PID is reused *before* the kill. The replacement must NOT be
+    signalled. Identity is captured at scan time, so the reused PID's differing
+    live identity fails the pre-destructive-op check on both branches."""
+    import psutil
+
+    ident = (1.0, "node")
+    scanned = [(424242, "node --expose-gc /x/ui-tui/dist/entry.js", ident)]
+
+    class _Proc:
+        def __init__(self, ctime, exe):
+            self._ctime = ctime
+            self._exe = exe
+
+        def create_time(self):
+            return self._ctime
+
+        def exe(self):
+            return self._exe
+
+    original = _Proc(1.0, "node")
+    reused = _Proc(9.9, "python")  # replacement: different ctime AND exe
+    calls = {"n": 0}
+
+    sigkills = []
+
+    def fake_kill(pid, sig):
+        if sig == 9:
+            sigkills.append(pid)
+        return None
+
+    def fake_process(pid):
+        calls["n"] += 1
+        # First call (selection/idle) sees the original; at destruction the PID
+        # is already reused by an unrelated python process.
+        return reused if calls["n"] > 1 else original
+
+    with patch.object(dp, "_scan_posix_node_processes", return_value=scanned), patch(
+        "os.kill", side_effect=fake_kill
+    ), patch("sys.platform", "darwin"), patch.object(
+        dp, "_process_ppid", return_value=1
+    ), patch.object(
+        dp, "_is_alive_parent", return_value=False
+    ), patch.object(
+        psutil, "Process", side_effect=fake_process
+    ):
+        result = dp._reap_orphaned_tui_nodes(sleep_fn=lambda _s: None)
+    # 424242 was selected by the scanner (verified node, orphaned) and so appears
+    # in matched — that is expected. The safety property Greptile flagged is that
+    # the reused PID must never receive SIGKILL (the escalation). SIGTERM to the
+    # still-original process at t0 is correct; SIGKILL at t1 (when reused) is the
+    # bug, and it is prevented by the baseline re-validation.
+    assert 424242 in result["matched"]
+    assert 424242 not in result["killed"]
+    assert sigkills == []  # no SIGKILL to PID 424242 (replacement was reused)
+
+
+def test_windows_scanner_binds_identity_to_observation():
+    """P1: Windows discovery must not depend on wmic, and identity must be bound
+    to the same process_iter observation as the cmdline (no separate
+    psutil.Process(pid) lookup that PID reuse could poison)."""
+    import psutil
+
+    # A real Hermes TUI node, plus a node process that merely contains a
+    # ui-tui-style fragment but is NOT a Hermes launch (no --expose-gc).
+    entries = [
+        {"pid": 111, "cmdline": ["node.exe", "--expose-gc", "C:\\x\\ui-tui\\dist\\entry.js"], "create_time": 1.0, "exe": "C:\\node.exe"},
+        {"pid": 444, "cmdline": ["node.exe", "C:\\some\\app\\dist\\entry.js"], "create_time": 4.0, "exe": "node.exe"},
+    ]
+    captured = {}
+
+    def _iter():
+        for e in entries:
+            class _Proc:
+                info = e
+            captured.setdefault("used", 0)
+            captured["used"] += 1
+            yield _Proc()
+
+    with patch.object(
+        dp, "_APPROVED_TUI_ENTRY_PATHS", {_norm("C:\\x\\ui-tui\\dist\\entry.js")}
+    ), patch.object(psutil, "process_iter", return_value=_iter()), patch(
+        "sys.platform", "win32"
+    ):
+        found = dp._scan_windows_node_processes(set())
+    # Only the Hermes-launched node (111) is selected; the lookalike (444) is
+    # rejected because it lacks the --expose-gc launcher marker. Identity is
+    # taken from the same `info` dict as cmdline (no second Process() call).
+    assert [pid for pid, _c, _i in found] == [111]
+    for _pid, _c, identity in found:
+        assert identity == (1.0, "c:\\node.exe")
+
+
+
+# --- Parent-PID reuse detection (child-create-time bound) ---------------------
+
+
+def _win_reap_with_parent_age(parent_create_time, child_create_time=1.0, ppid=50):
+    """Run the Windows reaper with a fake parent whose create_time is
+    *parent_create_time*; returns the reaper result."""
+    import psutil
+
+    scanned = [(777, "node.exe --expose-gc C:\\x\\ui-tui\\dist\\entry.js", (child_create_time, "node.exe"))]
+
+    class _Proc:
+        def __init__(self, ctime, exe):
+            self._ctime = ctime
+            self._exe = exe
+
+        def create_time(self):
+            return self._ctime
+
+        def exe(self):
+            return self._exe
+
+    class _ParentProc(_Proc):
+        pass
+
+    procs = {777: _Proc(child_create_time, "node.exe"), ppid: _ParentProc(parent_create_time, "python.exe")}
+
+    taskkills = []
+
+    class _FakeResult:
+        returncode = 0
+
+    def fake_run(cmd, **kwargs):
+        taskkills.append(cmd)
+        return _FakeResult()
+
+    with patch.object(dp, "_scan_windows_node_processes", return_value=scanned), patch(
+        "sys.platform", "win32"
+    ), patch.object(dp, "_process_ppid", return_value=ppid), patch.object(
+        psutil, "pid_exists", side_effect=lambda p: p in procs
+    ), patch.object(
+        psutil, "Process", side_effect=lambda pid: procs[pid]
+    ), patch(
+        "hermes_cli._subprocess_compat.windows_hide_flags", return_value=0
+    ), patch(
+        "subprocess.run", side_effect=fake_run
+    ):
+        result = dp._reap_orphaned_tui_nodes(sleep_fn=lambda _s: None)
+    return result, taskkills
+
+
+def test_reused_parent_pid_is_treated_as_dead_parent():
+    """A dead parent's PID reused by a NEWER process must not shield an orphan:
+    a real parent is always older than its child."""
+    result, taskkills = _win_reap_with_parent_age(parent_create_time=5.0, child_create_time=1.0)
+    assert 777 in result["matched"]
+    assert 777 in result["killed"]
+    assert taskkills  # taskkill /T /F was issued
+
+
+def test_genuinely_live_older_parent_spares_node():
+    """A parent older than the child is a real live launcher: the node is spared."""
+    result, taskkills = _win_reap_with_parent_age(parent_create_time=0.5, child_create_time=1.0)
+    assert result["matched"] == []
+    assert taskkills == []
+
+
+def test_is_node_exe_handles_spaced_absolute_path():
+    r"""A Node binary at a path containing spaces (C:\Program Files\nodejs\)
+    splits across cmdline tokens; the exe gate must still recognize it or the
+    reaper silently never matches real TUI launches."""
+    assert dp._is_node_exe(
+        "C:\\Program Files\\nodejs\\node.exe --expose-gc C:\\x\\ui-tui\\dist\\entry.js"
+    ) is True
+    # A non-Node executable whose args merely mention a node path stays rejected.
+    assert dp._is_node_exe("python C:\\tools\\run.js ui-tui/dist/entry.js") is False
+    # Bare `node` as an argument (not path-qualified) after another exe is rejected.
+    assert dp._is_node_exe("python node ui-tui/dist/entry.js") is False

--- a/tests/hermes_cli/test_orphan_windows_gateway_reap.py
+++ b/tests/hermes_cli/test_orphan_windows_gateway_reap.py
@@ -1,0 +1,170 @@
+"""Windows gateway-orphan reaper tests (#87278 review point 3).
+
+The gateway reaper must match the TUI node reaper's safety model:
+- scan-time (create_time, exe) identity bound to the process_iter snapshot,
+- PID-reuse-aware orphan check (child create time handed to _is_alive_parent),
+- identity revalidated immediately before ``taskkill /T /F``.
+"""
+
+from unittest.mock import patch
+
+from hermes_cli import dashboard_procs as dp
+
+
+GW_CMD = "C:\\x\\python.exe -m hermes_cli.main gateway run --replace"
+IDENT = (1000.0, "c:\\x\\python.exe")
+
+
+class _FakeProc:
+    def __init__(self, info):
+        self.info = info
+
+
+def _fake_process_iter(entries):
+    def iter_proc(_attrs):
+        for e in entries:
+            yield _FakeProc(e)
+
+    return iter_proc
+
+
+# --- Scanner -------------------------------------------------------------------
+
+
+def test_scan_windows_gateway_returns_identity_triples():
+    import psutil
+
+    entries = [
+        {"pid": 111, "name": "python.exe", "cmdline": ["python.exe", "-m", "hermes_cli.main", "gateway", "run", "--replace"], "create_time": 1000.0, "exe": "C:\\x\\python.exe"},
+        {"pid": 222, "name": "pythonw.exe", "cmdline": ["pythonw.exe", "-m", "hermes_cli.main", "gateway", "run", "--replace"], "create_time": 2000.0, "exe": "C:\\x\\pythonw.exe"},
+        {"pid": 333, "name": "python.exe", "cmdline": ["python.exe", "-m", "hermes_cli.main", "gateway", "status"], "create_time": 3000.0, "exe": "C:\\x\\python.exe"},  # not run --replace
+        {"pid": 444, "name": "node.exe", "cmdline": ["node.exe", "-m", "hermes_cli.main", "gateway", "run", "--replace"], "create_time": 4000.0, "exe": "C:\\x\\node.exe"},  # not python
+        {"pid": 555, "name": "python.exe", "cmdline": ["python.exe", "-m", "hermes_cli.main", "gateway", "run", "--replace"], "create_time": None, "exe": None},  # identity unavailable
+    ]
+    with patch.object(psutil, "process_iter", _fake_process_iter(entries)), patch(
+        "sys.platform", "win32"
+    ):
+        found = dp._scan_windows_gateway_processes(exclude_pids=set())
+
+    by_pid = {pid: (cmd, ident) for pid, cmd, ident in found}
+    assert sorted(by_pid) == [111, 222, 555]
+    assert by_pid[111][1] == (1000.0, "c:\\x\\python.exe")
+    assert by_pid[222][1] == (2000.0, "c:\\x\\pythonw.exe")
+    assert by_pid[555][1] is None  # unavailable identity carried as None
+
+
+def test_scan_windows_gateway_skips_excluded_pids():
+    import psutil
+
+    entries = [
+        {"pid": 111, "name": "python.exe", "cmdline": ["python.exe", "-m", "hermes_cli.main", "gateway", "run", "--replace"], "create_time": 1000.0, "exe": "C:\\x\\python.exe"},
+    ]
+    with patch.object(psutil, "process_iter", _fake_process_iter(entries)), patch(
+        "sys.platform", "win32"
+    ):
+        assert dp._scan_windows_gateway_processes(exclude_pids={111}) == []
+
+
+# --- Reaper --------------------------------------------------------------------
+
+
+def _reap_with(scanned, *, alive_parent=False, current_identity=IDENT, ppid=1):
+    """Run the reaper with standard mocks; returns (result, taskkill_calls)."""
+    taskkills = []
+
+    class _Result:
+        returncode = 0
+
+    def fake_run(argv, **_kw):
+        taskkills.append(argv)
+        return _Result()
+
+    with patch("sys.platform", "win32"), patch.object(
+        dp, "_exclude_pids_from_env", return_value=set()
+    ), patch.object(
+        dp, "_lock_owned_serve_pids", return_value=set()
+    ), patch.object(
+        dp, "_scan_windows_gateway_processes", return_value=scanned
+    ), patch.object(
+        dp, "_process_ppid", return_value=ppid
+    ), patch.object(
+        dp, "_is_alive_parent", return_value=alive_parent
+    ) as alive_mock, patch.object(
+        dp, "_current_process_identity", return_value=current_identity
+    ), patch.object(
+        dp.subprocess, "run", side_effect=fake_run
+    ):
+        result = dp._reap_orphaned_windows_gateway_processes()
+
+    return result, taskkills, alive_mock
+
+
+def test_reap_kills_orphan_gateway_with_matching_identity():
+    scanned = [(111, GW_CMD, IDENT)]
+    result, taskkills, _ = _reap_with(scanned)
+
+    assert result["matched"] == [111]
+    assert result["killed"] == [111]
+    assert result["failed"] == []
+    assert len(taskkills) == 1
+    assert taskkills[0][:2] == ["taskkill", "/T"]
+
+
+def test_reap_passes_child_create_time_to_parent_check():
+    """The orphan check must be PID-reuse-aware: the scanned child's create
+    time is handed to _is_alive_parent so a reused parent PID cannot shield
+    an orphan."""
+    scanned = [(111, GW_CMD, IDENT)]
+    _result, _kills, alive_mock = _reap_with(scanned)
+
+    alive_mock.assert_called_once_with(1, 1000.0)  # (ppid, child create_time)
+
+
+def test_reap_skips_live_parent():
+    scanned = [(111, GW_CMD, IDENT)]
+    result, taskkills, _ = _reap_with(scanned, alive_parent=True)
+    assert result["matched"] == []
+    assert taskkills == []
+
+
+def test_reap_skips_pid_reused_between_scan_and_kill():
+    """If the PID was reused after the scan (identity changed), taskkill must
+    never fire at the replacement process."""
+    scanned = [(111, GW_CMD, IDENT)]
+    reused_identity = (9999.0, "c:\\elsewhere\\python.exe")
+    result, taskkills, _ = _reap_with(scanned, current_identity=reused_identity)
+    assert result["matched"] == [111]  # selected as an orphan target...
+    assert result["killed"] == []  # ...but never killed
+    assert taskkills == []
+
+
+def test_reap_skips_gone_pid_before_kill():
+    scanned = [(111, GW_CMD, IDENT)]
+    result, taskkills, _ = _reap_with(scanned, current_identity=None)
+    assert result["matched"] == [111]
+    assert result["killed"] == []
+    assert taskkills == []
+
+
+def test_reap_skips_unidentifiable_scan_entry():
+    """No scan-time identity -> cannot bind the PID to the scanned process;
+    fail closed and skip."""
+    scanned = [(111, GW_CMD, None)]
+    result, taskkills, _ = _reap_with(scanned)
+    assert result["matched"] == []
+    assert taskkills == []
+
+
+def test_reap_skips_unknown_parent():
+    scanned = [(111, GW_CMD, IDENT)]
+    with patch("sys.platform", "win32"), patch.object(
+        dp, "_exclude_pids_from_env", return_value=set()
+    ), patch.object(
+        dp, "_lock_owned_serve_pids", return_value=set()
+    ), patch.object(
+        dp, "_scan_windows_gateway_processes", return_value=scanned
+    ), patch.object(
+        dp, "_process_ppid", return_value=None
+    ):
+        result = dp._reap_orphaned_windows_gateway_processes()
+    assert result["matched"] == []


### PR DESCRIPTION
Fixes #70031 (reopened follow-up [comment](https://github.com/NousResearch/hermes-agent/issues/70031#issuecomment-5304321693)). Ports and completes the reviewed approaches from #71502 and #73241 (both closed unmerged), and adds a third mechanism verified on Windows.

## Root causes addressed

**1. Periodic mid-turn redraw (#73241 approach).** `Application.refresh_interval` fires a periodic redraw regardless of agent state. With the deliberate default `display.cli_refresh_interval = 1.0`, each mid-turn redraw scrolls the previous bottom-chrome copy into scrollback, stacking repeated spinner/status frames — the artifact in #70031. The classic-CLI `Application` is now pinned to `refresh_interval=0.0`; the configured cadence drives only the background `spinner_loop` while IDLE (`spinner_loop_branch`), so wall-clock status read-outs still tick between turns. Mid-turn chrome updates live via agent-event `_invalidate()` calls.

**2. Spinner proxy detection (#71502 approach).** `KawaiiSpinner` clears frames with a bare `\r`, which lands on its own line under `patch_stdout`'s `StdoutProxy`. The exact `isinstance` check missed wrapped/subclassed proxies; `_is_patch_stdout_proxy()` now also duck-types on the `_patch_stdout` attribute and suppresses the redundant `\r` animation.

**3. Constant bottom-canvas height (review feedback on #73241).** Both the spinner row and the agent spacer are now reserved at 1 row in non-minimal-chrome mode. A canvas height change between idle and active (previously: spinner 0→1 on text, spacer 0→1 on `_agent_running`) forces prompt_toolkit's non-fullscreen renderer to scroll the old chrome into scrollback. Wide spinner text is clipped (`wrap_lines=False`) instead of wrapping.

**4. Windows orphan TUI node reaper.** A node TUI tree whose launcher died uncleanly survives and keeps emitting chrome to the shared terminal surface, stacking frames even in fresh sessions. The reaper kills verified-Node true orphans at TUI launch, CLI startup, and gateway startup. The verified-Node gate prefers psutil's `exe` over the joined cmdline (a spaced node path like `C:\Program Files\nodejs` splits across tokens and previously made the gate reject every real TUI process — verified live), and parent liveness detects PID reuse (a real parent is always older than its child). `_process_ppid` becomes psutil-based so Windows orphans are evaluable (the previous POSIX-only `ps` shell-out always returned `None` on Windows).

**5. Same-surface lease guard.** `try_acquire_active_session` refuses a second live session on the same terminal surface, keyed by Windows Terminal `WT_SESSION` GUID, else console HWND, else console title. HWND suffixes are stripped for collision only when neither id carries a `wt` GUID (two same-titled WT tabs never falsely collide), and degraded detection (pid fallback) logs a warning instead of silently disabling the guard.

## Tests
- Regression tests for every mechanism: spinner proxy duck-typing, constant canvas height (spacer + spinner, addressing the #73241 review gap), `Application(refresh_interval=0.0)` pin, idle/active cadence split, deliberate `1.0` default semantics, reaper gates (spaced node path, PID reuse, fail-closed), surface collision matrix.
- 183+ tests passing across affected suites locally. Two failures (`test_resource_limits`, `test_config::test_default_path`) reproduce on clean upstream `main` and are unrelated.

Verified on Windows 10 (the reporting environment): live orphaned node process reaped end-to-end, no stacked frames across monitored sessions.