### PR TITLE
feat(optional-skills): add squirrelscan — website QA/audit CLI skill

### DIFF
--- a/optional-skills/web-development/squirrelscan/SKILL.md
+++ b/optional-skills/web-development/squirrelscan/SKILL.md
@@ -1,0 +1,114 @@
+---
+name: squirrelscan
+description: Audit websites for SEO, performance, and security issues.
+version: 0.1.0
+author: squirrelscan contributors, Hermes Agent
+license: MIT
+platforms: [linux, macos, windows]
+metadata:
+  hermes:
+    tags: [Web, QA, SEO, Audit, CLI]
+    related_skills: [dogfood]
+---
+
+# squirrelscan
+
+squirrelscan is a website QA/audit CLI: 272 deterministic rules across 21 categories (Core SEO, crawlability, performance, security, accessibility, agent experience, and more). It crawls a site, scores it 0-100 per category, and emits machine-readable reports with exact fixes. The local audit engine is free and works offline; cloud features (browser rendering, publishing) require login and credits. Upstream also ships an optional MCP server (`squirrel mcp`), which this skill does not use.
+
+## When to Use
+
+- The user asks to audit, QA, or health-check a website (SEO, accessibility, performance, security headers, broken links).
+- After building or deploying a site, to verify quality before handoff.
+- The user wants a machine-readable issue list (JSON/markdown) to drive automated fixes.
+- CI-style gating: fail on score or severity thresholds.
+
+## Prerequisites
+
+- Node.js 18+ (npm). The npm package downloads a self-contained platform binary.
+- Install locally in a scratch/project dir (package name is `squirrelscan`, but the installed binary is `squirrel`):
+
+```
+terminal(command="mkdir -p ~/scratch/squirrelscan && cd ~/scratch/squirrelscan && npm install squirrelscan")
+```
+
+## How to Run
+
+Invoke through the Hermes `terminal` tool. The binary lands at `node_modules/.bin/squirrel` — show the full path once, then use it directly:
+
+```
+terminal(command="cd ~/scratch/squirrelscan && NO_TELEMETRY=1 ./node_modules/.bin/squirrel audit https://example.com --offline --format json --output report.json -y", timeout=600)
+```
+
+Notes:
+- The binary is `squirrel`, NOT the package name — there is no `squirrelscan` binary.
+- `--offline` skips cloud features, publishing, and telemetry; `NO_TELEMETRY=1` (any value) also disables telemetry and install registration.
+- Crawls can take minutes on large sites; cap with `--max-pages` and set a generous `terminal` timeout.
+- Read the JSON output afterwards with `read_file` (top-level keys: `meta`, `status`, `score`, `summary`, `issues`, `technologies`).
+
+## Quick Reference
+
+All commands verified against `squirrel --help` / `squirrel audit --help` / `squirrel report --help` (v0.0.85):
+
+- `squirrel audit <URL>` — crawl + run all rules on a URL
+- `squirrel audit <URL> --offline -y` — fully offline, no prompts
+- `squirrel audit <URL> -m 25` / `--max-pages 25` — cap crawled pages (default coverage `quick` = 25, cap 5000)
+- `squirrel audit <URL> --max-depth 2` — cap crawl depth from the seed
+- `squirrel audit <URL> -f json -o report.json` — formats: console, text, json, html, markdown, xml, llm
+- `squirrel audit <URL> --summary` — score + category breakdown only (console format)
+- `squirrel audit <URL> --fail-on "score<90,errors>0"` — exit 2 when a threshold trips (CI gating)
+- `squirrel audit <URL> --rule-include ax,perf` / `--rule-exclude images,social` — filter rule categories
+- `squirrel audit <URL> -r` / `--refresh` — ignore cache, full re-fetch
+- `squirrel audit <URL> -H "Name: Value"` — custom header on every crawl request (repeatable)
+- `squirrel report` — view latest stored audit; `squirrel report --list` lists recent audits
+- `squirrel report <id-or-domain> -f json --severity error --category core,links` — filtered re-query
+- `squirrel report --diff <baseline-id-or-domain>` — compare reports
+- `squirrel crawl` — crawl only, no analysis; `squirrel analyze` — run rules on a stored crawl
+- `squirrel init` — create squirrel.toml config
+- `squirrel self settings set telemetry false` — disable telemetry permanently
+
+## Procedure
+
+1. Install (once) into a scratch dir:
+
+```
+mkdir -p ~/scratch/squirrelscan && cd ~/scratch/squirrelscan && npm install squirrelscan
+```
+
+2. Run an offline audit with a page cap and JSON output (via `terminal`, timeout 600s):
+
+```
+cd ~/scratch/squirrelscan && NO_TELEMETRY=1 ./node_modules/.bin/squirrel audit https://TARGET --offline --max-pages 25 --format json --output report.json -y
+```
+
+3. Read the results with `read_file` on `report.json`, or summarize in the console:
+
+```
+./node_modules/.bin/squirrel report --summary
+```
+
+   JSON shape: `score.overall` (0-100) and `score.grade`, `score.groups` (seo/performance/security/ai with passed/warnings/failed counts), `score.categories` (per-category scores), `summary` ({passed, warnings, failed}), and `issues[]` — each issue has `ruleId`, `name`, `description`, `solution`, `category`, `group`, `severity`, `checks`.
+
+4. For agent-driven fixing, work through `issues[]` sorted by `severity`, applying each `solution`, then re-audit with `--refresh` and diff:
+
+```
+./node_modules/.bin/squirrel report --diff TARGET-DOMAIN
+```
+
+5. For CI-style gating, add `--fail-on "severity>=error"` and check the exit code (2 = threshold tripped).
+
+## Pitfalls
+
+- **Binary name trap**: the npm package is `squirrelscan` but the binary in `node_modules/.bin/` is `squirrel`. Running the package name fails.
+- **Telemetry on by default**: minimal (event name, version, random install ID) but enabled unless you pass `--offline`, set `NO_TELEMETRY=1`, or run `squirrel self settings set telemetry false`. The `report` command prints a telemetry notice on first runs.
+- **Cloud upsell paths**: `--publish` is the default when signed in; `--render`, `credits`, `keys`, and `auth` are cloud/account features. Basic audits need no account — stay `--offline` for deterministic local runs.
+- **Prompts**: audits may prompt for a project name; pass `-y` and/or `-n <name>` in unattended runs.
+- **Crawl time and scope**: default coverage `quick` caps at 25 pages; without `-m` a `full` run can crawl 500+ pages and take a long time. Bot protection (e.g. Cloudflare) can make results incomplete — the tool warns when it detects this.
+- **Results are stored**: audits persist to a local database (`~/.squirrel/`); `squirrel report` re-queries them without re-crawling.
+
+## Verification
+
+```
+terminal(command="cd ~/scratch/squirrelscan && NO_TELEMETRY=1 ./node_modules/.bin/squirrel audit https://example.com --offline --max-pages 5 --format json --output /tmp/sq-verify.json -y && python3 -c \"import json; d=json.load(open('/tmp/sq-verify.json')); print('score', d['score']['overall'], d['summary'])\"", timeout=600)
+```
+
+Expect a line like `score 31 {'passed': 89, 'warnings': 26, 'failed': 5}`.

--- a/tests/skills/test_squirrelscan_skill.py
+++ b/tests/skills/test_squirrelscan_skill.py
@@ -1,0 +1,87 @@
+"""Tests for the squirrelscan optional skill's SKILL.md."""
+
+import re
+from pathlib import Path
+
+import pytest
+import yaml
+
+_REL = "optional-skills/web-development/squirrelscan/SKILL.md"
+
+
+def _skill_path() -> Path:
+    staging = Path(__file__).resolve().parents[2] / _REL
+    if staging.exists():
+        return staging
+    return Path.home() / ".hermes/hermes-agent" / _REL
+
+
+@pytest.fixture(scope="module")
+def skill_text() -> str:
+    path = _skill_path()
+    assert path.exists(), f"SKILL.md not found at {path}"
+    return path.read_text(encoding="utf-8")
+
+
+@pytest.fixture(scope="module")
+def parts(skill_text):
+    assert skill_text.startswith("---\n"), "missing frontmatter"
+    _, fm, body = skill_text.split("---\n", 2)
+    return yaml.safe_load(fm), body
+
+
+def test_frontmatter_required_fields(parts):
+    fm, _ = parts
+    for field in ("name", "description", "version", "author", "license", "platforms"):
+        assert field in fm, f"missing frontmatter field: {field}"
+    assert fm["name"] == "squirrelscan"
+    assert fm["version"] == "0.1.0"
+
+
+def test_description_length_and_period(parts):
+    fm, _ = parts
+    desc = fm["description"]
+    assert isinstance(desc, str)
+    assert len(desc) <= 60, f"description too long: {len(desc)} chars"
+    assert desc.endswith("."), "description must end with a period"
+
+
+def test_license_mit(parts):
+    fm, _ = parts
+    assert fm["license"] == "MIT"
+
+
+def test_platforms_present(parts):
+    fm, _ = parts
+    platforms = fm["platforms"]
+    assert isinstance(platforms, list) and platforms
+    assert "linux" in platforms
+
+
+def test_hermes_metadata_tags(parts):
+    fm, _ = parts
+    tags = fm["metadata"]["hermes"]["tags"]
+    assert isinstance(tags, list) and tags
+
+
+def test_real_binary_name_documented(parts):
+    _, body = parts
+    # The npm package installs a binary named `squirrel`, not `squirrelscan`.
+    assert "squirrel audit" in body
+    assert "node_modules/.bin/squirrel" in body
+
+
+def test_wrong_invocation_form_absent(parts):
+    _, body = parts
+    assert "squirrelscan audit" not in body, (
+        "wrong binary form: package is 'squirrelscan' but the binary is 'squirrel'"
+    )
+
+
+def test_hermes_tool_framing(parts):
+    _, body = parts
+    assert "terminal" in body, "body must frame invocations via the Hermes terminal tool"
+
+
+def test_no_claude_residue(skill_text):
+    assert not re.search(r"(?i)claude", skill_text), "upstream Claude residue found"

--- a/website/docs/reference/optional-skills-catalog.md
+++ b/website/docs/reference/optional-skills-catalog.md
@@ -238,6 +238,7 @@ hermes skills uninstall <skill-name>
 |-------|-------------|
 | [**cloudflare-temporary-deploy**](/docs/user-guide/skills/optional/web-development/web-development-cloudflare-temporary-deploy) | Deploy a Worker live, no account, via wrangler --temporary. |
 | [**page-agent**](/docs/user-guide/skills/optional/web-development/web-development-page-agent) | Embed an in-page natural-language GUI copilot in web apps. |
+| [**squirrelscan**](/docs/user-guide/skills/optional/web-development/web-development-squirrelscan) | Audit websites for SEO, performance, and security issues. |
 
 ## yuanbao
 

--- a/website/docs/user-guide/skills/optional/web-development/web-development-squirrelscan.md
+++ b/website/docs/user-guide/skills/optional/web-development/web-development-squirrelscan.md
@@ -1,0 +1,132 @@
+---
+title: "Squirrelscan — Audit websites for SEO, performance, and security issues"
+sidebar_label: "Squirrelscan"
+description: "Audit websites for SEO, performance, and security issues"
+---
+
+{/* This page is auto-generated from the skill's SKILL.md by website/scripts/generate-skill-docs.py. Edit the source SKILL.md, not this page. */}
+
+# Squirrelscan
+
+Audit websites for SEO, performance, and security issues.
+
+## Skill metadata
+
+| | |
+|---|---|
+| Source | Optional — install with `hermes skills install official/web-development/squirrelscan` |
+| Path | `optional-skills/web-development/squirrelscan` |
+| Version | `0.1.0` |
+| Author | squirrelscan contributors, Hermes Agent |
+| License | MIT |
+| Platforms | linux, macos, windows |
+| Tags | `Web`, `QA`, `SEO`, `Audit`, `CLI` |
+| Related skills | [`dogfood`](/docs/user-guide/skills/bundled/software-development/software-development-dogfood) |
+
+## Reference: full SKILL.md
+
+:::info
+The following is the complete skill definition that Hermes loads when this skill is triggered. This is what the agent sees as instructions when the skill is active.
+:::
+
+# squirrelscan
+
+squirrelscan is a website QA/audit CLI: 272 deterministic rules across 21 categories (Core SEO, crawlability, performance, security, accessibility, agent experience, and more). It crawls a site, scores it 0-100 per category, and emits machine-readable reports with exact fixes. The local audit engine is free and works offline; cloud features (browser rendering, publishing) require login and credits. Upstream also ships an optional MCP server (`squirrel mcp`), which this skill does not use.
+
+## When to Use
+
+- The user asks to audit, QA, or health-check a website (SEO, accessibility, performance, security headers, broken links).
+- After building or deploying a site, to verify quality before handoff.
+- The user wants a machine-readable issue list (JSON/markdown) to drive automated fixes.
+- CI-style gating: fail on score or severity thresholds.
+
+## Prerequisites
+
+- Node.js 18+ (npm). The npm package downloads a self-contained platform binary.
+- Install locally in a scratch/project dir (package name is `squirrelscan`, but the installed binary is `squirrel`):
+
+```
+terminal(command="mkdir -p ~/scratch/squirrelscan && cd ~/scratch/squirrelscan && npm install squirrelscan")
+```
+
+## How to Run
+
+Invoke through the Hermes `terminal` tool. The binary lands at `node_modules/.bin/squirrel` — show the full path once, then use it directly:
+
+```
+terminal(command="cd ~/scratch/squirrelscan && NO_TELEMETRY=1 ./node_modules/.bin/squirrel audit https://example.com --offline --format json --output report.json -y", timeout=600)
+```
+
+Notes:
+- The binary is `squirrel`, NOT the package name — there is no `squirrelscan` binary.
+- `--offline` skips cloud features, publishing, and telemetry; `NO_TELEMETRY=1` (any value) also disables telemetry and install registration.
+- Crawls can take minutes on large sites; cap with `--max-pages` and set a generous `terminal` timeout.
+- Read the JSON output afterwards with `read_file` (top-level keys: `meta`, `status`, `score`, `summary`, `issues`, `technologies`).
+
+## Quick Reference
+
+All commands verified against `squirrel --help` / `squirrel audit --help` / `squirrel report --help` (v0.0.85):
+
+- `squirrel audit <URL>` — crawl + run all rules on a URL
+- `squirrel audit <URL> --offline -y` — fully offline, no prompts
+- `squirrel audit <URL> -m 25` / `--max-pages 25` — cap crawled pages (default coverage `quick` = 25, cap 5000)
+- `squirrel audit <URL> --max-depth 2` — cap crawl depth from the seed
+- `squirrel audit <URL> -f json -o report.json` — formats: console, text, json, html, markdown, xml, llm
+- `squirrel audit <URL> --summary` — score + category breakdown only (console format)
+- `squirrel audit <URL> --fail-on "score<90,errors>0"` — exit 2 when a threshold trips (CI gating)
+- `squirrel audit <URL> --rule-include ax,perf` / `--rule-exclude images,social` — filter rule categories
+- `squirrel audit <URL> -r` / `--refresh` — ignore cache, full re-fetch
+- `squirrel audit <URL> -H "Name: Value"` — custom header on every crawl request (repeatable)
+- `squirrel report` — view latest stored audit; `squirrel report --list` lists recent audits
+- `squirrel report <id-or-domain> -f json --severity error --category core,links` — filtered re-query
+- `squirrel report --diff <baseline-id-or-domain>` — compare reports
+- `squirrel crawl` — crawl only, no analysis; `squirrel analyze` — run rules on a stored crawl
+- `squirrel init` — create squirrel.toml config
+- `squirrel self settings set telemetry false` — disable telemetry permanently
+
+## Procedure
+
+1. Install (once) into a scratch dir:
+
+```
+mkdir -p ~/scratch/squirrelscan && cd ~/scratch/squirrelscan && npm install squirrelscan
+```
+
+2. Run an offline audit with a page cap and JSON output (via `terminal`, timeout 600s):
+
+```
+cd ~/scratch/squirrelscan && NO_TELEMETRY=1 ./node_modules/.bin/squirrel audit https://TARGET --offline --max-pages 25 --format json --output report.json -y
+```
+
+3. Read the results with `read_file` on `report.json`, or summarize in the console:
+
+```
+./node_modules/.bin/squirrel report --summary
+```
+
+   JSON shape: `score.overall` (0-100) and `score.grade`, `score.groups` (seo/performance/security/ai with passed/warnings/failed counts), `score.categories` (per-category scores), `summary` (&#123;passed, warnings, failed&#125;), and `issues[]` — each issue has `ruleId`, `name`, `description`, `solution`, `category`, `group`, `severity`, `checks`.
+
+4. For agent-driven fixing, work through `issues[]` sorted by `severity`, applying each `solution`, then re-audit with `--refresh` and diff:
+
+```
+./node_modules/.bin/squirrel report --diff TARGET-DOMAIN
+```
+
+5. For CI-style gating, add `--fail-on "severity>=error"` and check the exit code (2 = threshold tripped).
+
+## Pitfalls
+
+- **Binary name trap**: the npm package is `squirrelscan` but the binary in `node_modules/.bin/` is `squirrel`. Running the package name fails.
+- **Telemetry on by default**: minimal (event name, version, random install ID) but enabled unless you pass `--offline`, set `NO_TELEMETRY=1`, or run `squirrel self settings set telemetry false`. The `report` command prints a telemetry notice on first runs.
+- **Cloud upsell paths**: `--publish` is the default when signed in; `--render`, `credits`, `keys`, and `auth` are cloud/account features. Basic audits need no account — stay `--offline` for deterministic local runs.
+- **Prompts**: audits may prompt for a project name; pass `-y` and/or `-n <name>` in unattended runs.
+- **Crawl time and scope**: default coverage `quick` caps at 25 pages; without `-m` a `full` run can crawl 500+ pages and take a long time. Bot protection (e.g. Cloudflare) can make results incomplete — the tool warns when it detects this.
+- **Results are stored**: audits persist to a local database (`~/.squirrel/`); `squirrel report` re-queries them without re-crawling.
+
+## Verification
+
+```
+terminal(command="cd ~/scratch/squirrelscan && NO_TELEMETRY=1 ./node_modules/.bin/squirrel audit https://example.com --offline --max-pages 5 --format json --output /tmp/sq-verify.json -y && python3 -c \"import json; d=json.load(open('/tmp/sq-verify.json')); print('score', d['score']['overall'], d['summary'])\"", timeout=600)
+```
+
+Expect a line like `score 31 {'passed': 89, 'warnings': 26, 'failed': 5}`.

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -609,6 +609,7 @@ const sidebars: SidebarsConfig = {
                   items: [
                     'user-guide/skills/optional/web-development/web-development-cloudflare-temporary-deploy',
                     'user-guide/skills/optional/web-development/web-development-page-agent',
+                    'user-guide/skills/optional/web-development/web-development-squirrelscan',
                   ],
                 },
                 {


### PR DESCRIPTION
## Summary
Adds `squirrelscan` as an optional web-development skill — a ground-truth port of the trending website QA/audit CLI (272 deterministic rules across 21 categories: SEO, performance, security, accessibility, agent experience).

## Why now (trending evidence)
- Added to VoltAgent/awesome-agent-skills on 2026-08-13 (PR #814) — fresh curated-list signal
- Upstream repo: https://github.com/squirrelscan/squirrelscan (MIT, active daily releases, npm `squirrelscan`)
- Fits the "deterministic audit tool + agent applies exact fixes" pattern; no existing Hermes equivalent (dupe-swept PRs/issues for squirrelscan / site audit / SEO audit / website QA — no hits)

## Ground-truth verification (not written from memory)
- Installed `squirrelscan` v0.0.85 via npm in a scratch dir; confirmed the **binary is `squirrel`**, not the package name (documented as a Pitfall; staging test asserts the wrong form never appears)
- Every documented command/flag verified against `squirrel --help`, `squirrel audit --help`, `squirrel report --help`
- Live offline smoke audit against example.com: 1 page in 0.7s, JSON report with keys `meta/status/score/summary/issues/technologies`, score 31/F — observed output shape documented, not README claims
- Telemetry stance documented honestly: on by default, disabled via `--offline` / `NO_TELEMETRY=1` / `squirrel self settings set telemetry false`

## Changes
- `optional-skills/web-development/squirrelscan/SKILL.md` — 115 lines, Hermes-tool framing (`terminal`, `read_file`), description 57 chars
- `tests/skills/test_squirrelscan_skill.py` — 9 tests (frontmatter, description hardline, binary-name trap, de-Claude, Hermes framing)
- Docs: auto-gen page + one catalog row + one sidebar line (scope-disciplined regen)

## Validation
| Check | Result |
|---|---|
| `tests/skills/test_authoring_standards.py` + skill tests | 1199 passed |
| ruff on staged test | clean |
| Platforms | `[linux, macos, windows]` — npm ships per-platform binaries; upstream fixes Windows installer issues actively |
| License | MIT carried from upstream; upstream credited in `author:` |

## Infographic

Infographic generation degraded this run — FAL balance exhausted (`Exhausted balance` from fal.ai). Will attach on regen once billing is topped up.
