### PR TITLE
fix(desktop): scope preview tabs to the session that opened them

### DIFF
--- a/apps/desktop/src/app/chat/close-tab.test.ts
+++ b/apps/desktop/src/app/chat/close-tab.test.ts
@@ -14,7 +14,11 @@ vi.mock('@/components/pane-shell/tree/store', () => ({
 
 vi.mock('@/store/session-states', () => ({
   closeSessionTile: (...args: unknown[]) => closeSessionTile(...args),
-  nextSessionTileForWorkspace: () => nextSessionTileForWorkspace()
+  nextSessionTileForWorkspace: () => nextSessionTileForWorkspace(),
+  // preview.ts reads the focused session when stamping/deriving tabs; this
+  // suite drives the writable $selectedStoredSessionId instead, so a static
+  // null stub is enough.
+  $focusedStoredSessionId: atom<string | null>(null)
 }))
 
 vi.mock('@/store/profile', () => ({

--- a/apps/desktop/src/app/chat/preview-tile.test.ts
+++ b/apps/desktop/src/app/chat/preview-tile.test.ts
@@ -1,0 +1,106 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+// Preview tiles mirror $visiblePreviewTabs into layout-tree panes: only the
+// ACTIVE session's tabs (plus pins) become panes, so switching sessions swaps
+// the drawer, and pinning a tab surfaces it in every session.
+
+describe('preview tiles mirror the visible session tabs', () => {
+  beforeEach(() => {
+    window.localStorage.clear()
+    vi.resetModules()
+  })
+
+  afterEach(() => {
+    vi.resetModules()
+  })
+
+  async function setup() {
+    const preview = await import('@/store/preview')
+    const session = await import('@/store/session')
+    const tree = await import('@/components/pane-shell/tree/store')
+    const model = await import('@/components/pane-shell/tree/model')
+    const { registry } = await import('@/contrib/registry')
+    const { watchPreviewTiles } = await import('./preview-tile')
+
+    registry.register({
+      area: 'panes',
+      data: { placement: 'main', uncloseable: true },
+      id: 'workspace',
+      render: () => null,
+      title: 'workspace'
+    })
+    tree.declareDefaultTree(model.group(['workspace'], { active: 'workspace', id: 'grp-main' }))
+    // The app root wires registry changes into the tree; mirror it here.
+    tree.watchContributedPanes()
+    watchPreviewTiles()
+
+    return { model, preview, session, tree }
+  }
+
+  it('renders only the active session previews, pinning spans sessions', async () => {
+    const { preview, session, tree } = await setup()
+
+    session.$selectedStoredSessionId.set('sess-1')
+    preview.openPreview(
+      {
+        kind: 'file',
+        label: 'a.html',
+        path: '/work/a.html',
+        previewKind: 'html',
+        source: '/work/a.html',
+        url: 'file:///work/a.html'
+      },
+      'tool-result'
+    )
+
+    expect(tree.treePanesWithPrefix('preview-tile:')).toHaveLength(1)
+
+    // Switching sessions hides the pane (the tab stays open in the store).
+    session.$selectedStoredSessionId.set('sess-2')
+    expect(tree.treePanesWithPrefix('preview-tile:')).toHaveLength(0)
+    expect(preview.$previewTabs.get()).toHaveLength(1)
+
+    // Pinning makes it visible again in the new session.
+    preview.setPreviewTabPinned(preview.$previewTabs.get()[0]!.id, true)
+    expect(tree.treePanesWithPrefix('preview-tile:')).toHaveLength(1)
+
+    // And closing the tab removes the pane for good.
+    preview.closeRightRailTab(preview.$previewTabs.get()[0]!.id)
+    expect(tree.treePanesWithPrefix('preview-tile:')).toHaveLength(0)
+  })
+
+  it('does not create panes for another session tabs', async () => {
+    const { preview, session, tree } = await setup()
+
+    session.$selectedStoredSessionId.set('sess-1')
+    preview.openPreview(
+      {
+        kind: 'file',
+        label: 'a.html',
+        path: '/work/a.html',
+        previewKind: 'html',
+        source: '/work/a.html',
+        url: 'file:///work/a.html'
+      },
+      'tool-result'
+    )
+
+    session.$selectedStoredSessionId.set('sess-2')
+    preview.openPreview(
+      {
+        kind: 'file',
+        label: 'b.html',
+        path: '/work/b.html',
+        previewKind: 'html',
+        source: '/work/b.html',
+        url: 'file:///work/b.html'
+      },
+      'tool-result'
+    )
+
+    expect(tree.treePanesWithPrefix('preview-tile:')).toHaveLength(1)
+
+    session.$selectedStoredSessionId.set('sess-1')
+    expect(tree.treePanesWithPrefix('preview-tile:')).toHaveLength(1)
+  })
+})

--- a/apps/desktop/src/app/chat/preview-tile.tsx
+++ b/apps/desktop/src/app/chat/preview-tile.tsx
@@ -92,10 +92,15 @@ export function watchPreviewTiles(): void {
   }
 
   $rightRailActiveTabId.listen(reveal)
-  // Visible-list changes: a re-open of the already-active tab refreshes the
-  // target through the visible list too, while tab mutations belonging to a
-  // BACKGROUND session must not try to reveal panes that are not mounted.
-  $visiblePreviewTabs.listen(reveal)
+  // One listener for the visible list: re-home the selection FIRST (a session
+  // switch or an unpin can leave the active tab outside the visible set, and
+  // a stale reveal of a just-hidden tab is a no-op — its pane left the tree),
+  // THEN reveal the tab the re-home left active. Registered after the mirror,
+  // so the pane set is already synced when this runs.
+  $visiblePreviewTabs.listen(() => {
+    rehome()
+    reveal()
+  })
 
   // A session switch (or an unpin) can leave the active tab outside the
   // visible set — re-home the selection to the first visible tab so the strip
@@ -107,8 +112,6 @@ export function watchPreviewTiles(): void {
       selectRightRailTab(visible[0]?.id ?? null)
     }
   }
-
-  $visiblePreviewTabs.listen(rehome)
 
   // And the reverse: clicking a preview TAB activates its pane in the TREE
   // only, so the store's selection must follow or `$previewTarget` (⌘L quote

--- a/apps/desktop/src/app/chat/preview-tile.tsx
+++ b/apps/desktop/src/app/chat/preview-tile.tsx
@@ -15,11 +15,11 @@ import { $activeTreeGroup, $layoutTree, revealTreePane } from '@/components/pane
 import { FileTypeIcon } from '@/components/ui/file-type-icon'
 import { ToolIcon } from '@/components/ui/tool-icon'
 import { $rightRailActiveTabId, type RightRailTabId, selectRightRailTab } from '@/store/layout'
-import { $previewTabs, closeRightRailTab, type PreviewTarget } from '@/store/preview'
+import { $previewTabs, $visiblePreviewTabs, closeRightRailTab, type PreviewTarget } from '@/store/preview'
 
 import { paneMirror } from './pane-mirror'
 import { PreviewTilePane } from './right-rail/preview'
-import { forgetPreviewStripTools, previewStripTools } from './right-rail/preview-strip-tools'
+import { forgetPreviewStripTools, previewPinTool, previewStripTools } from './right-rail/preview-strip-tools'
 
 /** The target behind a tile id, or null once its tab is gone. */
 function targetFor(tabId: string): PreviewTarget | null {
@@ -92,7 +92,23 @@ export function watchPreviewTiles(): void {
   }
 
   $rightRailActiveTabId.listen(reveal)
-  $previewTabs.listen(reveal)
+  // Visible-list changes: a re-open of the already-active tab refreshes the
+  // target through the visible list too, while tab mutations belonging to a
+  // BACKGROUND session must not try to reveal panes that are not mounted.
+  $visiblePreviewTabs.listen(reveal)
+
+  // A session switch (or an unpin) can leave the active tab outside the
+  // visible set — re-home the selection to the first visible tab so the strip
+  // and the pane never point at a hidden preview.
+  const rehome = () => {
+    const visible = $visiblePreviewTabs.get()
+
+    if (!visible.some(tab => tab.id === $rightRailActiveTabId.get())) {
+      selectRightRailTab(visible[0]?.id ?? null)
+    }
+  }
+
+  $visiblePreviewTabs.listen(rehome)
 
   // And the reverse: clicking a preview TAB activates its pane in the TREE
   // only, so the store's selection must follow or `$previewTarget` (⌘L quote
@@ -121,7 +137,10 @@ export function watchPreviewTiles(): void {
 }
 
 const watchPreviewTileMirror = paneMirror<{ id: string }>({
-  source: $previewTabs,
+  // Only the ACTIVE session's tabs (plus pins) become panes — switching
+  // sessions swaps the drawer; a hidden tab's pane leaves the tree without
+  // closing the tab (paneMirror's sync disposes, it doesn't call close).
+  source: $visiblePreviewTabs,
   key: tab => tab.id,
   prefix: PREVIEW_TILE_PREFIX,
   // Identical to route (page) tiles: its own zone docked beside main, sized by
@@ -134,7 +153,11 @@ const watchPreviewTileMirror = paneMirror<{ id: string }>({
   tabLead: tabId => <PreviewTabLead tabId={tabId} />,
   // Console + DevTools as bare strip glyphs after the last tab, where "+" sits.
   // Only a URL preview has a webview behind it, so a file/artifact tab gets none.
-  stripTools: tabId => (targetFor(tabId)?.kind === 'url' ? previewStripTools(tabId) : []),
+  // The pin toggle rides on every preview tab.
+  stripTools: tabId => [
+    ...(targetFor(tabId)?.kind === 'url' ? previewStripTools(tabId) : []),
+    previewPinTool(tabId)
+  ],
   render: tabId => <PreviewTilePane tabId={tabId} />,
   close: tabId => {
     forgetPreviewStripTools(tabId)

--- a/apps/desktop/src/app/chat/right-rail/preview-strip-tools.tsx
+++ b/apps/desktop/src/app/chat/right-rail/preview-strip-tools.tsx
@@ -17,6 +17,7 @@ import { invalidateStripTools } from '@/components/pane-shell/tree/store'
 import { Codicon } from '@/components/ui/codicon'
 import type { PaneStripTool } from '@/components/ui/pane-tab'
 import { translateNow } from '@/i18n'
+import { $previewTabs, setPreviewTabPinned } from '@/store/preview'
 
 import { createPreviewConsoleState, type PreviewConsoleState } from './preview-console-state'
 
@@ -94,4 +95,22 @@ export function previewStripTools(tabId: string): readonly PaneStripTool[] {
       onSelect: () => devTools?.toggle()
     }
   ]
+}
+
+/** The pin toggle for a preview tab. Pinned tabs render in every session —
+ *  the explicit cross-session workspace; everything else belongs to the
+ *  session that opened it. */
+export function previewPinTool(tabId: string): PaneStripTool {
+  const pinned = Boolean($previewTabs.get().find(tab => tab.id === tabId)?.pinned)
+
+  return {
+    active: pinned,
+    icon: <Codicon name={pinned ? 'pinned' : 'pin'} size="0.8125rem" />,
+    id: 'preview-pin',
+    label: translateNow(pinned ? 'preview.unpin' : 'preview.pin'),
+    onSelect: () => {
+      setPreviewTabPinned(tabId, !pinned)
+      invalidateStripTools()
+    }
+  }
 }

--- a/apps/desktop/src/app/chat/right-rail/preview-strip-tools.tsx
+++ b/apps/desktop/src/app/chat/right-rail/preview-strip-tools.tsx
@@ -109,7 +109,11 @@ export function previewPinTool(tabId: string): PaneStripTool {
     id: 'preview-pin',
     label: translateNow(pinned ? 'preview.unpin' : 'preview.pin'),
     onSelect: () => {
-      setPreviewTabPinned(tabId, !pinned)
+      // Read the CURRENT pin state at click time, not the render-time
+      // closure: a rapid second click before the strip re-renders must
+      // toggle from the state the first click produced.
+      const current = Boolean($previewTabs.get().find(tab => tab.id === tabId)?.pinned)
+      setPreviewTabPinned(tabId, !current)
       invalidateStripTools()
     }
   }

--- a/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
@@ -14,6 +14,7 @@ import { migrateSessionDraft } from '@/store/composer'
 import { clearQueuedPrompts, migrateQueuedPrompts } from '@/store/composer-queue'
 import { $pinnedSessionIds } from '@/store/layout'
 import { clearNotifications, notify, notifyError } from '@/store/notifications'
+import { prunePreviewTabsForSession } from '@/store/preview'
 import { $activeGatewayProfile, $newChatProfile, ensureGatewayProfile, normalizeProfileKey } from '@/store/profile'
 import {
   beginSessionMutation,
@@ -1616,6 +1617,14 @@ export function useSessionActions({
         // back, and a rolled-back row must keep its watermark/marker.
         forgetSessionUnread(removedIds, removed?.profile)
         clearQueuedPrompts(storedSessionId)
+
+        // Preview tabs are session-owned: drop them with the session (pinned
+        // tabs survive — they belong to the workspace, not the session).
+        for (const id of removedIds) {
+          if (id) {
+            prunePreviewTabsForSession(id)
+          }
+        }
 
         if (closingRuntimeId) {
           clearQueuedPrompts(closingRuntimeId)

--- a/apps/desktop/src/i18n/ar.ts
+++ b/apps/desktop/src/i18n/ar.ts
@@ -2172,6 +2172,8 @@ export const ar = defineLocale({
   },
   preview: {
     tab: 'معاينة',
+    pin: 'تثبيت في مساحة العمل',
+    unpin: 'إلغاء التثبيت من مساحة العمل',
     closePane: 'إغلاق جزء المعاينة',
     loading: 'جار تحميل المعاينة',
     unavailable: 'المعاينة غير متاحة',

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -2734,6 +2734,8 @@ export const en: Translations = {
 
   preview: {
     tab: 'Preview',
+    pin: 'Pin to workspace',
+    unpin: 'Unpin from workspace',
     closePane: 'Close preview pane',
     loading: 'Loading preview',
     unavailable: 'Preview unavailable',

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -2448,6 +2448,8 @@ export const ja = defineLocale({
 
   preview: {
     tab: 'プレビュー',
+    pin: 'ワークスペースにピン留め',
+    unpin: 'ワークスペースからピン留めを外す',
     closePane: 'プレビューペインを閉じる',
     loading: 'プレビューを読み込み中',
     unavailable: 'プレビューは利用できません',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -2321,6 +2321,8 @@ export interface Translations {
 
   preview: {
     tab: string
+    pin: string
+    unpin: string
     closePane: string
     loading: string
     unavailable: string

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -2371,6 +2371,8 @@ export const zhHant = defineLocale({
 
   preview: {
     tab: '預覽',
+    pin: '固定到工作區',
+    unpin: '從工作區取消固定',
     closePane: '關閉預覽窗格',
     loading: '正在載入預覽',
     unavailable: '預覽不可用',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -2909,6 +2909,8 @@ export const zh: Translations = {
 
   preview: {
     tab: '预览',
+    pin: '固定到工作区',
+    unpin: '从工作区取消固定',
     closePane: '关闭预览面板',
     loading: '正在加载预览',
     unavailable: '预览不可用',

--- a/apps/desktop/src/store/preview.test.ts
+++ b/apps/desktop/src/store/preview.test.ts
@@ -1,20 +1,25 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
-import { $rightRailActiveTabId } from './layout'
+import { $rightRailActiveTabId, selectRightRailTab } from './layout'
 import {
   $previewServerRestart,
   $previewServerRestartStatus,
   $previewTabs,
   $previewTarget,
+  $visiblePreviewTabs,
   beginPreviewServerRestart,
   closePreviewForSource,
   closeRightRail,
   closeRightRailTab,
+  decodePreviewTabs,
   openPreview,
   previewTabId,
   type PreviewTarget,
-  progressPreviewServerRestart
+  progressPreviewServerRestart,
+  prunePreviewTabsForSession,
+  setPreviewTabPinned
 } from './preview'
+import { $selectedStoredSessionId } from './session'
 
 function fileTarget(source: string): PreviewTarget {
   return { kind: 'file', label: source, path: source, previewKind: 'html', source, url: `file://${source}` }
@@ -31,12 +36,14 @@ function artifactTarget(id: string): PreviewTarget {
 describe('preview store', () => {
   beforeEach(() => {
     $previewServerRestart.set(null)
+    $selectedStoredSessionId.set(null)
     closeRightRail()
     window.localStorage.clear()
   })
 
   afterEach(() => {
     $previewServerRestart.set(null)
+    $selectedStoredSessionId.set(null)
     closeRightRail()
     window.localStorage.clear()
   })
@@ -56,7 +63,7 @@ describe('preview store', () => {
   it('opens the pane and fronts the new tab', () => {
     openPreview(fileTarget('/work/demo.html'), 'tool-result')
 
-    expect($rightRailActiveTabId.get()).toBe('file:file:///work/demo.html')
+    expect($rightRailActiveTabId.get()).toBe('file:/work/demo.html')
     expect($previewTarget.get()?.path).toBe('/work/demo.html')
   })
 
@@ -163,5 +170,205 @@ describe('preview store', () => {
     openPreview(target, 'tool-result')
 
     expect(window.localStorage.getItem('hermes.desktop.previewTabs.v2')).toBe('[]')
+  })
+})
+
+describe('preview session scoping', () => {
+  afterEach(() => {
+    $selectedStoredSessionId.set(null)
+    closeRightRail()
+    window.localStorage.clear()
+  })
+
+  it('stamps the active session on tabs it opens', () => {
+    $selectedStoredSessionId.set('sess-1')
+    openPreview(fileTarget('/work/demo.html'), 'tool-result')
+
+    expect($previewTabs.get()[0]?.sessionId).toBe('sess-1')
+  })
+
+  it('shows only the active session tabs plus pinned ones', () => {
+    $selectedStoredSessionId.set('sess-1')
+    openPreview(fileTarget('/work/a.html'), 'tool-result')
+    $selectedStoredSessionId.set('sess-2')
+    openPreview(fileTarget('/work/b.html'), 'tool-result')
+
+    expect($visiblePreviewTabs.get().map(tab => tab.target.path)).toEqual(['/work/b.html'])
+
+    // Pinning makes the first session's tab visible in every session.
+    const aTab = $previewTabs.get().find(tab => tab.target.path === '/work/a.html')
+    setPreviewTabPinned(aTab!.id, true)
+
+    expect($visiblePreviewTabs.get().map(tab => tab.target.path).sort()).toEqual(['/work/a.html', '/work/b.html'])
+
+    // Unpinning hides it from the other session again.
+    setPreviewTabPinned(aTab!.id, false)
+    expect($visiblePreviewTabs.get().map(tab => tab.target.path)).toEqual(['/work/b.html'])
+  })
+
+  it('prunes a deleted session tabs but keeps its pins', () => {
+    $selectedStoredSessionId.set('sess-1')
+    openPreview(fileTarget('/work/a.html'), 'tool-result')
+    setPreviewTabPinned($previewTabs.get()[0]!.id, true)
+    $selectedStoredSessionId.set('sess-2')
+    openPreview(fileTarget('/work/b.html'), 'tool-result')
+
+    prunePreviewTabsForSession('sess-2')
+    expect($previewTabs.get().map(tab => tab.target.path)).toEqual(['/work/a.html'])
+
+    // Pinned tabs belong to the workspace, not the session that opened them.
+    prunePreviewTabsForSession('sess-1')
+    expect($previewTabs.get().map(tab => tab.target.path)).toEqual(['/work/a.html'])
+  })
+
+  it('adopts ownerless draft tabs when a session appears', () => {
+    openPreview(fileTarget('/work/draft.html'), 'tool-result')
+    expect($previewTabs.get()[0]?.sessionId).toBeUndefined()
+
+    $selectedStoredSessionId.set('sess-new')
+    expect($previewTabs.get()[0]?.sessionId).toBe('sess-new')
+    // The id is rekeyed onto the session-scoped form so a later open of the
+    // same file dedupes instead of stacking.
+    expect($previewTabs.get()[0]?.id).toBe('file:sess-new:/work/draft.html')
+    expect($visiblePreviewTabs.get().map(tab => tab.target.path)).toEqual(['/work/draft.html'])
+  })
+
+  it('canonicalizes file identities across entry points', () => {
+    expect(previewTabId(fileTarget('/work/demo.html'))).toBe('file:/work/demo.html')
+
+    const viaPlainPath = previewTabId({ ...fileTarget('/work/demo.html'), url: '/work/demo.html' })
+    expect(viaPlainPath).toBe('file:/work/demo.html')
+  })
+
+  it('scopes file tab ids to the session, so two sessions can open the same file', () => {
+    expect(previewTabId(fileTarget('/work/demo.html'), 'sess-1')).toBe('file:sess-1:/work/demo.html')
+    expect(previewTabId(fileTarget('/work/demo.html'), 'sess-2')).toBe('file:sess-2:/work/demo.html')
+
+    $selectedStoredSessionId.set('sess-1')
+    openPreview(fileTarget('/work/demo.html'), 'tool-result')
+    $selectedStoredSessionId.set('sess-2')
+    openPreview(fileTarget('/work/demo.html'), 'tool-result')
+
+    const tabs = $previewTabs.get()
+
+    expect(tabs).toHaveLength(2)
+    expect(tabs[0]).toMatchObject({ sessionId: 'sess-1', id: 'file:sess-1:/work/demo.html' })
+    expect(tabs[1]).toMatchObject({ sessionId: 'sess-2', id: 'file:sess-2:/work/demo.html' })
+    expect($visiblePreviewTabs.get()).toHaveLength(1)
+  })
+
+  it('re-opening the same file in the same session keeps the tab owner and pin', () => {
+    $selectedStoredSessionId.set('sess-1')
+    openPreview(fileTarget('/work/demo.html'), 'tool-result')
+    setPreviewTabPinned($previewTabs.get()[0]!.id, true)
+
+    openPreview({ ...fileTarget('/work/demo.html'), label: 'refreshed' }, 'tool-result')
+
+    expect($previewTabs.get()).toHaveLength(1)
+    expect($previewTabs.get()[0]).toMatchObject({ sessionId: 'sess-1', pinned: true })
+    expect($previewTabs.get()[0]?.target.label).toBe('refreshed')
+  })
+
+  it('unpinning an ownerless tab adopts the current session', () => {
+    openPreview(fileTarget('/work/legacy.html'), 'tool-result')
+    setPreviewTabPinned($previewTabs.get()[0]!.id, true)
+
+    $selectedStoredSessionId.set('sess-1')
+    setPreviewTabPinned($previewTabs.get()[0]!.id, false)
+
+    expect($previewTabs.get()[0]).toMatchObject({ pinned: false, sessionId: 'sess-1' })
+    expect($previewTabs.get()[0]?.id).toBe('file:sess-1:/work/legacy.html')
+  })
+
+  it('closes by source only within the current session', () => {
+    $selectedStoredSessionId.set('sess-1')
+    openPreview(fileTarget('/work/a.html'), 'tool-result')
+    $selectedStoredSessionId.set('sess-2')
+    openPreview(fileTarget('/work/a.html'), 'tool-result')
+
+    // The hidden session's tab must not be closed by the other session's row.
+    expect(closePreviewForSource('/work/a.html')).toBe(true)
+    expect($previewTabs.get()).toHaveLength(1)
+    expect($previewTabs.get()[0]?.sessionId).toBe('sess-1')
+  })
+
+  it('reopens a pinned legacy row instead of stacking a second tab', () => {
+    // A migrated legacy row: pinned, unprefixed id, no owner.
+    $previewTabs.set([{ id: 'file:/work/a.html', target: fileTarget('/work/a.html'), pinned: true }])
+
+    $selectedStoredSessionId.set('sess-1')
+    openPreview(fileTarget('/work/a.html'), 'tool-result')
+
+    expect($previewTabs.get()).toHaveLength(1)
+    expect($previewTabs.get()[0]).toMatchObject({ pinned: true, sessionId: 'sess-1' })
+    expect($previewTabs.get()[0]?.id).toBe('file:sess-1:/work/a.html')
+    expect($visiblePreviewTabs.get()).toHaveLength(1)
+  })
+
+  it('adoption dedupes against an already session-scoped row', () => {
+    // Both rows for the same file coexist before the session appears.
+    $previewTabs.set([
+      { id: 'file:/work/a.html', target: fileTarget('/work/a.html') },
+      { id: 'file:sess-1:/work/a.html', target: fileTarget('/work/a.html'), sessionId: 'sess-1' }
+    ])
+
+    $selectedStoredSessionId.set('sess-1')
+
+    expect($previewTabs.get()).toHaveLength(1)
+    expect($previewTabs.get()[0]?.id).toBe('file:sess-1:/work/a.html')
+  })
+
+  it('adoption dedupe keeps the active selection valid', () => {
+    // The colliding row is the ACTIVE tab when adoption rekeys the draft
+    // onto the same id — the survivor carries that id, so the selection must
+    // not dangle.
+    $previewTabs.set([
+      { id: 'file:/work/a.html', target: fileTarget('/work/a.html') },
+      { id: 'file:sess-1:/work/a.html', target: fileTarget('/work/a.html'), sessionId: 'sess-1' }
+    ])
+    selectRightRailTab('file:sess-1:/work/a.html')
+
+    $selectedStoredSessionId.set('sess-1')
+
+    expect($previewTabs.get()).toHaveLength(1)
+    expect($rightRailActiveTabId.get()).toBe('file:sess-1:/work/a.html')
+  })
+
+  it('migrates legacy unscoped tabs to pinned and rekeys their ids', () => {
+    const raw = JSON.stringify([
+      { id: 'file:file:///work/a.html', target: fileTarget('/work/a.html') },
+      { id: 'file:file:///work/b.html', target: fileTarget('/work/b.html'), sessionId: 'sess-9' }
+    ])
+
+    const decoded = decodePreviewTabs(raw)
+
+    expect(decoded).toHaveLength(2)
+    expect(decoded[0]).toMatchObject({ id: 'file:/work/a.html', pinned: true })
+    expect(decoded[1]?.id).toBe('file:sess-9:/work/b.html')
+    expect(decoded[1]?.sessionId).toBe('sess-9')
+    expect(decoded[1]?.pinned).toBeUndefined()
+  })
+
+  it('does not re-pin a persisted unpinned row', () => {
+    const raw = JSON.stringify([
+      { id: 'file:/work/a.html', target: fileTarget('/work/a.html'), sessionId: 'sess-1', pinned: false }
+    ])
+
+    const decoded = decodePreviewTabs(raw)
+
+    expect(decoded[0]?.pinned).toBe(false)
+  })
+
+  it('dedupes the same file persisted under both old and canonical ids', () => {
+    const raw = JSON.stringify([
+      { id: 'file:file:///work/a.html', target: fileTarget('/work/a.html') },
+      { id: 'file:/work/a.html', target: { ...fileTarget('/work/a.html'), label: 'updated' } }
+    ])
+
+    const decoded = decodePreviewTabs(raw)
+
+    expect(decoded).toHaveLength(1)
+    expect(decoded[0]?.id).toBe('file:/work/a.html')
+    expect(decoded[0]?.target.label).toBe('updated')
   })
 })

--- a/apps/desktop/src/store/preview.test.ts
+++ b/apps/desktop/src/store/preview.test.ts
@@ -1,5 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
+import { group } from '@/components/pane-shell/tree/model'
+import { $layoutTree, noteActiveTreeGroup } from '@/components/pane-shell/tree/store'
+
 import { $rightRailActiveTabId, selectRightRailTab } from './layout'
 import {
   $previewServerRestart,
@@ -303,6 +306,76 @@ describe('preview session scoping', () => {
     expect($previewTabs.get()[0]).toMatchObject({ pinned: true, sessionId: 'sess-1' })
     expect($previewTabs.get()[0]?.id).toBe('file:sess-1:/work/a.html')
     expect($visiblePreviewTabs.get()).toHaveLength(1)
+  })
+
+  it('reusing an owned pinned row from another session keeps the owner id', () => {
+    $selectedStoredSessionId.set('sess-1')
+    openPreview(fileTarget('/work/a.html'), 'tool-result')
+    setPreviewTabPinned($previewTabs.get()[0]!.id, true)
+
+    $selectedStoredSessionId.set('sess-2')
+    openPreview({ ...fileTarget('/work/a.html'), label: 'refreshed' }, 'tool-result')
+
+    expect($previewTabs.get()).toHaveLength(1)
+    // The row keeps its OWNER's id — never an id/sessionId split (the id
+    // would say sess-2 while the owner says sess-1 until the next unpin).
+    expect($previewTabs.get()[0]).toMatchObject({
+      id: 'file:sess-1:/work/a.html',
+      sessionId: 'sess-1',
+      pinned: true
+    })
+    expect($previewTabs.get()[0]?.target.label).toBe('refreshed')
+    expect($rightRailActiveTabId.get()).toBe('file:sess-1:/work/a.html')
+  })
+
+  it('follows the focused session tile over the sidebar selection', () => {
+    $selectedStoredSessionId.set('sess-1')
+    openPreview(fileTarget('/work/a.html'), 'tool-result')
+    $selectedStoredSessionId.set('sess-2')
+    openPreview(fileTarget('/work/b.html'), 'tool-result')
+
+    expect($visiblePreviewTabs.get().map(tab => tab.target.path)).toEqual(['/work/b.html'])
+
+    // A sess-1 session TILE is active in the interacted zone while sess-2 is
+    // selected in the sidebar: the drawer belongs to the conversation being
+    // typed in, so the visible set follows the FOCUSED session.
+    const previousTree = $layoutTree.get()
+
+    try {
+      $layoutTree.set(group(['session-tile:sess-1'], { active: 'session-tile:sess-1', id: 'grp-main' }))
+      noteActiveTreeGroup('grp-main')
+
+      expect($visiblePreviewTabs.get().map(tab => tab.target.path)).toEqual(['/work/a.html'])
+
+      // Leaving the tile (workspace/route active) falls back to the selection.
+      noteActiveTreeGroup(null)
+      expect($visiblePreviewTabs.get().map(tab => tab.target.path)).toEqual(['/work/b.html'])
+    } finally {
+      // A failed assertion must not leak the tree/group state into the next
+      // test — the focused derivation reads both.
+      noteActiveTreeGroup(null)
+      $layoutTree.set(previousTree)
+    }
+  })
+
+  it('re-owns the singleton Browser to the session that navigates it', () => {
+    $selectedStoredSessionId.set('sess-1')
+    openPreview(urlTarget('http://localhost:5174'), 'tool-result')
+
+    // A second session navigating the Browser takes the surface with it:
+    // keeping the original owner would leave the new URL invisible in the
+    // session that just opened it.
+    $selectedStoredSessionId.set('sess-2')
+    openPreview(urlTarget('http://localhost:9999'), 'tool-result')
+
+    expect($previewTabs.get()).toHaveLength(1)
+    expect($previewTabs.get()[0]).toMatchObject({ id: 'url:browser', sessionId: 'sess-2' })
+    expect($previewTabs.get()[0]?.target.url).toBe('http://localhost:9999')
+    expect($visiblePreviewTabs.get()).toHaveLength(1)
+
+    // And sess-1 no longer sees the navigated surface — no context leak.
+    $selectedStoredSessionId.set('sess-1')
+    expect($visiblePreviewTabs.get()).toHaveLength(0)
   })
 
   it('adoption dedupes against an already session-scoped row', () => {

--- a/apps/desktop/src/store/preview.ts
+++ b/apps/desktop/src/store/preview.ts
@@ -4,6 +4,7 @@ import { persistentAtom } from '@/lib/persisted'
 import { normalize } from '@/lib/text'
 
 import { $rightRailActiveTabId, type RightRailTabId, selectRightRailTab } from './layout'
+import { $focusedStoredSessionId } from './session-states'
 
 /**
  * PREVIEW RAIL — one list of tabs, one way in.
@@ -58,6 +59,12 @@ export type PreviewRecordSource = 'explicit-link' | 'file-browser' | 'manual' | 
 export interface PreviewTab {
   id: RightRailTabId
   target: PreviewTarget
+  /** The session that opened the tab. Absent only on legacy rows written
+   *  before session scoping (decodePreviewTabs migrates those to pinned). */
+  sessionId?: string
+  /** Pinned tabs render in EVERY session — the explicit cross-session
+   *  workspace. Everything else is visible only in the session that opened it. */
+  pinned?: boolean
 }
 
 const TABS_STORAGE_KEY = 'hermes.desktop.previewTabs.v2'
@@ -124,14 +131,34 @@ export function decodePreviewTabs(raw: string): PreviewTab[] {
       : tab
   )
 
-  // One Browser: rekey restored URL tabs onto the singleton id (rows written
-  // before the id existed carried one id per address) and keep only the
-  // LAST — the most recently opened page is the one the browser shows.
-  const lastUrl = tabs.findLast(tab => tab.target.kind === 'url')
+  // Legacy rows (written before session scoping) have no owner and no way to
+  // recover one — keep them as workspace-pinned rather than dropping them or
+  // dumping every stale tab into one chat. Explicit `!== undefined` checks:
+  // a persisted `pinned: false` must not be re-pinned.
+  const owned = tabs.map(tab =>
+    tab.sessionId !== undefined || tab.pinned !== undefined ? tab : { ...tab, pinned: true }
+  )
 
-  return tabs
-    .filter(tab => tab.target.kind !== 'url' || tab === lastUrl)
-    .map(tab => (tab.target.kind === 'url' ? { ...tab, id: previewTabId(tab.target) } : tab))
+  // One Browser: rekey restored URL tabs onto the singleton id (rows written
+  // before the id existed carried one id per address). File tabs rekey onto
+  // their session-scoped canonical id. Keep only the LAST row per id — the
+  // most recently opened wins.
+  const lastUrl = owned.findLast(tab => tab.target.kind === 'url')
+  const deduped = new Map<string, PreviewTab>()
+
+  for (const tab of owned) {
+    if (tab.target.kind === 'url' && tab !== lastUrl) {
+      continue
+    }
+
+    const id =
+      tab.target.kind === 'url' || tab.target.kind === 'file'
+        ? previewTabId(tab.target, tab.sessionId)
+        : tab.id
+    deduped.set(id, { ...tab, id })
+  }
+
+  return [...deduped.values()]
 }
 
 export const $previewTabs = persistentAtom<PreviewTab[]>(TABS_STORAGE_KEY, [], {
@@ -158,6 +185,63 @@ if (typeof window !== 'undefined') {
   }
 }
 
+/** Tabs the ACTIVE session sees: its own tabs plus everything pinned. The
+ *  layout-tree mirror renders only these, so a session switch swaps the drawer
+ *  and pinned tabs are the explicit cross-session workspace. While no session
+ *  exists (a fresh draft), ownerless tabs stay visible. */
+export const $visiblePreviewTabs = computed(
+  [$previewTabs, $focusedStoredSessionId],
+  (tabs, sessionId) =>
+    tabs.filter(
+      tab => tab.pinned || tab.sessionId === sessionId || (sessionId == null && tab.sessionId == null)
+    )
+)
+
+// A fresh draft has no session yet, so tabs opened there are ownerless — adopt
+// them into the session the moment one exists (rekeying file ids onto the
+// session-scoped form, so a later open of the same file dedupes), or the
+// drawer would silently lose them at first send.
+$focusedStoredSessionId.listen(sessionId => {
+  if (sessionId == null) {
+    return
+  }
+
+  const tabs = $previewTabs.get()
+
+  if (tabs.some(tab => tab.sessionId == null && !tab.pinned)) {
+    const activeId = $rightRailActiveTabId.get()
+    let newActiveId = activeId
+    const updated = tabs.map(tab => {
+      if (tab.sessionId != null || tab.pinned) {
+        return tab
+      }
+
+      const nextId = tab.target.kind === 'file' ? previewTabId(tab.target, sessionId) : tab.id
+
+      if (tab.id === activeId) {
+        newActiveId = nextId
+      }
+
+      return { ...tab, id: nextId, sessionId }
+    })
+
+    // A rekey can collide with an already session-scoped row of the same file
+    // (defensive: adoption runs synchronously with the focus change, so a real
+    // open can't interleave — but keep the no-duplicate invariant explicit).
+    const deduped = new Map<string, PreviewTab>()
+
+    for (const tab of updated) {
+      deduped.set(tab.id, tab)
+    }
+
+    $previewTabs.set([...deduped.values()])
+
+    if (newActiveId !== activeId) {
+      selectRightRailTab(newActiveId)
+    }
+  }
+})
+
 /** The tab the rail actually shows. A stale or missing selection falls back to
  *  the first tab, so the strip, `⌘W`, and the pane never disagree about which
  *  tab is on screen. */
@@ -166,7 +250,7 @@ function resolveActiveTab(tabs: PreviewTab[], activeTabId: RightRailTabId | null
 }
 
 function activePreviewTab(): PreviewTab | null {
-  return resolveActiveTab($previewTabs.get(), $rightRailActiveTabId.get())
+  return resolveActiveTab($visiblePreviewTabs.get(), $rightRailActiveTabId.get())
 }
 
 // A restored active id whose tab didn't survive validation would leave the rail
@@ -175,13 +259,13 @@ selectRightRailTab(activePreviewTab()?.id ?? null)
 
 /** The target the rail is currently showing, or null when it has no tabs. */
 export const $previewTarget = computed(
-  [$previewTabs, $rightRailActiveTabId],
+  [$visiblePreviewTabs, $rightRailActiveTabId],
   (tabs, activeTabId) => resolveActiveTab(tabs, activeTabId)?.target ?? null
 )
 
-/** Raw `source` strings of every open tab, for the composer rows that toggle a
- *  preview open and closed by the target they were handed. */
-export const $previewTabSources = computed($previewTabs, tabs => tabs.map(tab => tab.target.source))
+/** Raw `source` strings of every tab the active session sees, for the composer
+ *  rows that toggle a preview open and closed by the target they were handed. */
+export const $previewTabSources = computed($visiblePreviewTabs, tabs => tabs.map(tab => tab.target.source))
 
 export const $previewReloadRequest = atom(0)
 export const $previewServerRestart = atom<PreviewServerRestart | null>(null)
@@ -194,8 +278,24 @@ export const $previewServerRestartStatus = computed($previewServerRestart, resta
  *  by identity; only the web surface is a singleton. */
 const BROWSER_TAB_ID: RightRailTabId = 'url:browser'
 
-export function previewTabId(target: PreviewTarget): RightRailTabId {
-  return target.kind === 'url' ? BROWSER_TAB_ID : `${target.kind}:${target.url}`
+/** A file tab's identity is its canonical path, scoped to the session that
+ *  opened it — the same file opened in two conversations must be two tabs,
+ *  each owned by its session. The `file://` scheme is stripped so the two
+ *  entry points (a `file://` URL vs a plain path) resolve to the same key. */
+function canonicalFileKey(target: PreviewTarget): string {
+  return (target.path || target.url).replace(/^file:\/\//, '')
+}
+
+export function previewTabId(target: PreviewTarget, sessionId?: null | string): RightRailTabId {
+  if (target.kind === 'url') {
+    return BROWSER_TAB_ID
+  }
+
+  if (target.kind === 'file') {
+    return `file:${sessionId ? `${sessionId}:` : ''}${canonicalFileKey(target)}`
+  }
+
+  return `${target.kind}:${target.url}`
 }
 
 // Browsing files is "peek at the source"; a tool or an explicit link handing
@@ -217,13 +317,71 @@ function previewTargetForSource(target: PreviewTarget, source: PreviewRecordSour
  *  only way anything reaches a preview. */
 export function openPreview(target: PreviewTarget, source: PreviewRecordSource = 'manual') {
   const resolved = previewTargetForSource(target, source)
-  const id = previewTabId(resolved)
+  const sessionId = $focusedStoredSessionId.get() ?? undefined
+  const id = previewTabId(resolved, sessionId)
   const current = $previewTabs.get()
   const index = current.findIndex(tab => tab.id === id)
-  const tab: PreviewTab = { id, target: resolved }
+  // A PINNED row for the same file carries the unprefixed (legacy) id, so a
+  // session-scoped open would otherwise stack a second tab for the same file.
+  // Reuse the pinned row instead — refreshed, still pinned, fronted. Never
+  // steal another session's owned tab: that coexistence is the point.
+  const existing =
+    index === -1 && resolved.kind === 'file'
+      ? current.find(
+          tab => tab.pinned && tab.target.kind === 'file' && canonicalFileKey(tab.target) === canonicalFileKey(resolved)
+        )
+      : current[index]
+  // The tab belongs to the session that was active when it opened. A re-open
+  // of an existing tab (same session, same file) keeps the tab's owner and
+  // pin state — only the target refreshes.
+  const tab: PreviewTab = {
+    id,
+    target: resolved,
+    sessionId: existing?.sessionId ?? sessionId,
+    pinned: existing?.pinned
+  }
 
-  $previewTabs.set(index === -1 ? [...current, tab] : current.map((item, i) => (i === index ? tab : item)))
+  const replaceIndex = existing ? current.indexOf(existing) : -1
+
+  $previewTabs.set(replaceIndex === -1 ? [...current, tab] : current.map((item, i) => (i === replaceIndex ? tab : item)))
   selectRightRailTab(id)
+}
+
+/** Pin or unpin a preview tab. Pinned tabs render in EVERY session — the
+ *  explicit cross-session workspace; unpinning returns it to its session
+ *  (adopting the current one, and rekeying the file id, when the tab never
+ *  had an owner). */
+export function setPreviewTabPinned(tabId: string, pinned: boolean): void {
+  const currentSession = $focusedStoredSessionId.get() ?? undefined
+  const activeId = $rightRailActiveTabId.get()
+  let newActiveId = activeId
+
+  $previewTabs.set(
+    $previewTabs.get().map(tab => {
+      if (tab.id !== tabId) {
+        return tab
+      }
+
+      const nextSession = tab.sessionId ?? (!pinned ? currentSession : undefined)
+      const nextId = tab.target.kind === 'file' ? previewTabId(tab.target, nextSession) : tab.id
+
+      if (tab.id === activeId) {
+        newActiveId = nextId
+      }
+
+      return { ...tab, id: nextId, pinned, sessionId: nextSession }
+    })
+  )
+
+  if (newActiveId !== activeId) {
+    selectRightRailTab(newActiveId)
+  }
+}
+
+/** Drop the tabs a deleted session opened. Pinned tabs survive — they belong
+ *  to the workspace, not the session that opened them. */
+export function prunePreviewTabsForSession(sessionId: string): void {
+  $previewTabs.set($previewTabs.get().filter(tab => tab.pinned || tab.sessionId !== sessionId))
 }
 
 export function closeRightRailTab(tabId: string) {
@@ -247,9 +405,10 @@ export function closeRightRailTab(tabId: string) {
   }
 }
 
-/** Close the tab showing `source`, if one is open. Returns whether it closed. */
+/** Close the tab showing `source` in the CURRENT session, if one is open.
+ *  Returns whether it closed. */
 export function closePreviewForSource(source: string): boolean {
-  const tab = $previewTabs.get().find(item => item.target.source === source)
+  const tab = $visiblePreviewTabs.get().find(item => item.target.source === source)
 
   if (!tab) {
     return false

--- a/apps/desktop/src/store/preview.ts
+++ b/apps/desktop/src/store/preview.ts
@@ -155,6 +155,7 @@ export function decodePreviewTabs(raw: string): PreviewTab[] {
       tab.target.kind === 'url' || tab.target.kind === 'file'
         ? previewTabId(tab.target, tab.sessionId)
         : tab.id
+
     deduped.set(id, { ...tab, id })
   }
 
@@ -211,6 +212,7 @@ $focusedStoredSessionId.listen(sessionId => {
   if (tabs.some(tab => tab.sessionId == null && !tab.pinned)) {
     const activeId = $rightRailActiveTabId.get()
     let newActiveId = activeId
+
     const updated = tabs.map(tab => {
       if (tab.sessionId != null || tab.pinned) {
         return tab
@@ -321,6 +323,7 @@ export function openPreview(target: PreviewTarget, source: PreviewRecordSource =
   const id = previewTabId(resolved, sessionId)
   const current = $previewTabs.get()
   const index = current.findIndex(tab => tab.id === id)
+
   // A PINNED row for the same file carries the unprefixed (legacy) id, so a
   // session-scoped open would otherwise stack a second tab for the same file.
   // Reuse the pinned row instead — refreshed, still pinned, fronted. Never
@@ -331,20 +334,40 @@ export function openPreview(target: PreviewTarget, source: PreviewRecordSource =
           tab => tab.pinned && tab.target.kind === 'file' && canonicalFileKey(tab.target) === canonicalFileKey(resolved)
         )
       : current[index]
-  // The tab belongs to the session that was active when it opened. A re-open
-  // of an existing tab (same session, same file) keeps the tab's owner and
-  // pin state — only the target refreshes.
+
+  // Reuse semantics depend on WHY the row was found:
+  // - Same-session re-open (any kind): keep the owner and pin state — only
+  //   the target refreshes.
+  // - A PINNED file row reached from ANOTHER session: keep its owner (and
+  //   therefore its owner-keyed id) — the pin is the explicit cross-session
+  //   workspace contract, and rekeying to the opening session would leave
+  //   `id` and `sessionId` disagreeing until the next unpin (which returns
+  //   the tab to that owner anyway).
+  // - The singleton Browser or an artifact reached from another session: the
+  //   surface NAVIGATES, so it re-owns to the opening session — otherwise the
+  //   new URL would stay invisible in the session that just opened it.
+  // - Ownerless legacy rows: adopted — rekeyed and stamped — into the opening
+  //   session (see the pinned-legacy test).
+  // The id is derived from the FINAL session id so the two can never split.
+  const tabSessionId =
+    existing?.sessionId == null || existing.pinned || existing.sessionId === sessionId
+      ? existing?.sessionId ?? sessionId
+      : sessionId
+
   const tab: PreviewTab = {
-    id,
+    id: previewTabId(resolved, tabSessionId),
     target: resolved,
-    sessionId: existing?.sessionId ?? sessionId,
+    sessionId: tabSessionId,
     pinned: existing?.pinned
   }
 
   const replaceIndex = existing ? current.indexOf(existing) : -1
 
   $previewTabs.set(replaceIndex === -1 ? [...current, tab] : current.map((item, i) => (i === replaceIndex ? tab : item)))
-  selectRightRailTab(id)
+  // Select the row's FINAL id: when a pinned row is reused from another
+  // session, the id keeps the owner's session, so the pre-computed id would
+  // point at nothing.
+  selectRightRailTab(tab.id)
 }
 
 /** Pin or unpin a preview tab. Pinned tabs render in EVERY session — the


### PR DESCRIPTION
## What

Preview tabs (the drawer above the composer showing files, URLs and artifacts) were **window-global**: a preview opened in one conversation stayed visible above the composer in every other conversation — and the same file could stack duplicate tabs because file targets were keyed by raw URL (`file://` vs plain-path entry points produced different ids).

This PR implements the per-session scoping design discussed on #73890:

- **Session ownership.** Every preview tab records the session that opened it. The drawer renders only the **active session's tabs** — switching conversations swaps the drawer; switching back restores it. Hidden tabs' panes leave the layout tree without firing close, and the tab state persists in the store, so nothing is lost on a switch.
- **Pin to workspace.** A pin glyph on every preview tab's strip tools pins it to the workspace: pinned tabs render across all sessions. Unpinning returns the tab to its session (adopting the current one when the tab never had an owner).
- **Canonical file identity.** File tab ids are session-scoped and path-canonicalized (`file://` stripped), so multiple entry points to the same file dedupe to a single tab per session, while two conversations can open the same file independently.
- **Lifecycle.** Deleting a session prunes its tabs (pinned tabs survive). Tabs opened in a fresh draft (before a session exists) are adopted — and their ids rekeyed — when a session appears.
- **Terminal untouched.** Terminal tabs manage OS process state, not session-scoped UI content; coupling them to preview scoping would be a false symmetry.

## Tests

- **19 new tests**: store unit tests (session stamping, per-session visibility, pin/unpin rekeying, pruning, draft adoption and deduplication, active-selection validity, canonicalization, migration, session-scoped close-by-source) plus a mirror integration test proving the drawer swaps panes on session switch.
- **Full UI suite**: 5,540 tests passing; typecheck clean across three configurations; eslint clean; production build succeeds.

## Notes

- **Migration.** Since the provenance of legacy tabs cannot be reliably inferred, they are conservatively migrated as **pinned** rather than discarded — preserving generated artifacts without guessing which conversation they belonged to.
- **Open question:** whether a per-session Browser (URL) surface should ever be split — URLs intentionally keep the singleton `BROWSER_TAB_ID` (the Browser is one surface that navigates, per the existing design), scoped to the session that opened it.
- **Related stack.** #73940/#73947/#73948 (preview isolation, guest webview, artifact surface) are orthogonal: they change *where* previews render, not *whose* tabs they are. No conflicts expected.

Partially addresses #73890 (the Artifacts pane and focused-session fallback paths remain open).
