### PR TITLE
fix(gateway): strip empty-content placeholder even with sender prefix

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -763,6 +763,38 @@ def _sanitize_gateway_final_response(platform: Any, text: str) -> str:
     return redacted
 
 
+_EMPTY_CONTENT_PLACEHOLDER = "(The user sent a message with no text content)"
+
+
+def _strip_empty_content_placeholder(user_text: str) -> str:
+    """Remove the adapter empty-content placeholder from a user message.
+
+    Discord delivers a captionless voice note as the literal
+    ``"(The user sent a message with no text content)"`` placeholder. In
+    shared multi-user sessions ``_prepare_inbound_message_text`` labels the
+    message with a sender prefix first (``"[Javi] (The user sent a message
+    with no text content)"``), so a bare equality check misses the prefixed
+    form and the placeholder leaks into the model's turn next to a perfectly
+    good STT transcript — the model then answers "your message came through
+    empty" even though it has the words. Strip the marker whether or not it
+    carries a ``[Name] `` prefix, and whether it stands alone or is embedded
+    among merged follow-up lines.
+    """
+    if not user_text:
+        return user_text
+    kept = []
+    for line in user_text.split("\n"):
+        stripped = line.strip()
+        if stripped == _EMPTY_CONTENT_PLACEHOLDER:
+            continue
+        if stripped.startswith("[") and stripped.endswith(
+            f"] {_EMPTY_CONTENT_PLACEHOLDER}"
+        ):
+            continue
+        kept.append(line)
+    return "\n".join(kept)
+
+
 def _prepare_gateway_status_message(platform: Any, event_type: str, message: str) -> Optional[str]:
     """Filter/sanitize agent status callbacks before platform delivery.
 
@@ -17613,7 +17645,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 _safe_user_name = (
                     f"{_safe_user_name} | Slack user <@{source.user_id}>"
                 )
-            message_text = f"[{_safe_user_name}] {message_text}"
+            # Don't attribute the adapter's empty-content placeholder: it's
+            # gateway-internal text (not user content), gets replaced by the
+            # STT transcript or a sentinel note, and prefixing it breaks the
+            # placeholder strip in _enrich_message_with_transcription.
+            if message_text.strip() != _EMPTY_CONTENT_PLACEHOLDER:
+                message_text = f"[{_safe_user_name}] {message_text}"
 
         # Prepend channel context from history backfill (if any).  This
         # happens after sender-prefix so the prefix only applies to the
@@ -23970,11 +24007,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             if not notes:
                 return user_text, []
             prefix = "\n\n".join(notes)
-            _placeholder = "(The user sent a message with no text content)"
-            if user_text and user_text.strip() == _placeholder:
-                return prefix, []
-            if user_text:
-                return f"{prefix}\n\n{user_text}", []
+            cleaned_text = _strip_empty_content_placeholder(user_text)
+            if cleaned_text.strip():
+                return f"{prefix}\n\n{cleaned_text.strip()}", []
             return prefix, []
 
         try:
@@ -23985,11 +24020,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         except ModuleNotFoundError as e:
             logger.error("Transcription module unavailable: %s", e)
             unavailable_note = "[voice message could not be transcribed]"
-            _placeholder = "(The user sent a message with no text content)"
-            if user_text and user_text.strip() == _placeholder:
-                return unavailable_note, []
-            if user_text:
-                return f"{unavailable_note}\n\n{user_text}", []
+            cleaned_text = _strip_empty_content_placeholder(user_text)
+            if cleaned_text.strip():
+                return f"{unavailable_note}\n\n{cleaned_text.strip()}", []
             return unavailable_note, []
 
         enriched_parts = []
@@ -24066,11 +24099,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             prefix = "\n\n".join(enriched_parts)
             # Strip the empty-content placeholder from the Discord adapter
             # when we successfully transcribed the audio — it's redundant.
-            _placeholder = "(The user sent a message with no text content)"
-            if user_text and user_text.strip() == _placeholder:
-                return prefix, successful_transcripts
-            if user_text:
-                return f"{prefix}\n\n{user_text}", successful_transcripts
+            # Match the prefixed form too: shared multi-user sessions label
+            # the message "[Name] (The user sent a message with no text
+            # content)" before enrichment, and leaking the marker into the
+            # model's turn next to the transcript makes it answer "your
+            # message came through empty" despite having the words.
+            cleaned_text = _strip_empty_content_placeholder(user_text)
+            if cleaned_text.strip():
+                return f"{prefix}\n\n{cleaned_text.strip()}", successful_transcripts
             return prefix, successful_transcripts
         return user_text, successful_transcripts
 

--- a/tests/gateway/test_shared_group_sender_prefix.py
+++ b/tests/gateway/test_shared_group_sender_prefix.py
@@ -47,3 +47,40 @@ async def test_preprocess_includes_slack_author_mention_for_shared_thread():
     assert result == "[Alice | Slack user <@U123>] mention me again"
 
 
+@pytest.mark.asyncio
+async def test_preprocess_does_not_prefix_empty_content_placeholder():
+    """The adapter's empty-content placeholder must not get a sender prefix:
+    shared-session labeling would turn it into ``"[Alice] (The user sent a
+    message with no text content)"``, which defeats the placeholder strip in
+    ``_enrich_message_with_transcription`` and makes the model answer "your
+    message came through empty" next to a good STT transcript."""
+    runner = _make_runner(
+        GatewayConfig(
+            platforms={
+                Platform.SLACK: PlatformConfig(enabled=True, token="fake"),
+            },
+        )
+    )
+    source = SessionSource(
+        platform=Platform.SLACK,
+        chat_id="C123",
+        chat_name="team-channel",
+        chat_type="group",
+        user_id="U123",
+        user_name="Alice",
+        thread_id="171.000",
+    )
+    event = MessageEvent(
+        text="(The user sent a message with no text content)",
+        source=source,
+    )
+
+    result = await runner._prepare_inbound_message_text(
+        event=event,
+        source=source,
+        history=[],
+    )
+
+    assert result == "(The user sent a message with no text content)"
+
+

--- a/tests/gateway/test_stt_config.py
+++ b/tests/gateway/test_stt_config.py
@@ -72,6 +72,67 @@ async def test_enrich_message_with_transcription_returns_tuple_for_empty_content
 
 
 @pytest.mark.asyncio
+async def test_enrich_message_with_transcription_strips_sender_prefixed_placeholder():
+    """Shared multi-user sessions label the captionless-voice placeholder as
+    ``"[Javi] (The user sent a message with no text content)"`` before STT
+    enrichment. The prefixed marker must be stripped too, or the model sees
+    an "empty" message next to the transcript and answers "your voice message
+    came through empty" despite having the words."""
+    from gateway.run import GatewayRunner
+
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner.config = GatewayConfig(stt_enabled=True)
+    runner._has_setup_skill = lambda: False
+
+    with patch(
+        "tools.transcription_tools.transcribe_audio",
+        return_value={
+            "success": True,
+            "transcript": "write me a user flow for the epic",
+            "provider": "local_command",
+        },
+    ):
+        result, transcripts = await runner._enrich_message_with_transcription(
+            "[Javi] (The user sent a message with no text content)",
+            ["/tmp/voice.ogg"],
+        )
+
+    assert "write me a user flow for the epic" in result
+    assert "(The user sent a message with no text content)" not in result
+    assert transcripts == ["write me a user flow for the epic"]
+
+
+@pytest.mark.asyncio
+async def test_enrich_message_with_transcription_strips_placeholder_embedded_in_merged_text():
+    """Merged follow-up events can embed the placeholder between real lines
+    (``'"note one"\n[Javi] (The user sent a message with no text content)\n[Javi] "note two"'``).
+    Every placeholder line is removed, not just a whole-text equality."""
+    from gateway.run import GatewayRunner
+
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner.config = GatewayConfig(stt_enabled=True)
+    runner._has_setup_skill = lambda: False
+
+    with patch(
+        "tools.transcription_tools.transcribe_audio",
+        return_value={
+            "success": True,
+            "transcript": "note one",
+            "provider": "local_command",
+        },
+    ):
+        result, transcripts = await runner._enrich_message_with_transcription(
+            '"note one"\n[Javi] (The user sent a message with no text content)\n[Javi] "note two"',
+            ["/tmp/voice.ogg"],
+        )
+
+    assert "note one" in result
+    assert "note two" in result
+    assert "(The user sent a message with no text content)" not in result
+    assert transcripts == ["note one"]
+
+
+@pytest.mark.asyncio
 async def test_enrich_message_with_transcription_guards_empty_transcript():
     """success=True with an empty/whitespace transcript must not emit empty
     quotes — it gets a sentinel note and is excluded from transcripts (#41603)."""


### PR DESCRIPTION
## Problem

Captionless Discord voice notes arrive as the literal `(The user sent a message with no text content)` placeholder. In shared multi-user sessions `_prepare_inbound_message_text` prefixes the sender first, so the exact-match strip in `_enrich_message_with_transcription` misses `[Javi] (The user sent a message with no text content)` and the marker leaks into the model's turn next to a good STT transcript — the model answers "your message came through empty" despite having the words.

## Fix

- Add `_strip_empty_content_placeholder()`: strips the marker with or without a `[Name]` prefix, standalone or embedded in merged follow-up lines.
- Use it in all three branches of `_enrich_message_with_transcription`.
- Don't apply the sender prefix to the placeholder in `_prepare_inbound_message_text` (gateway-internal text, replaced by the transcript or a sentinel note).
- 3 regression tests: prefixed placeholder, embedded placeholder, and no-prefix-on-placeholder.

## Verification

`pytest tests/gateway/test_shared_group_sender_prefix.py tests/gateway/test_stt_config.py` → 8 passed. `py_compile` clean.