### PR TITLE
fix(update): bootstrap Windows self-lock recovery outside Python

### DIFF
--- a/scripts/desktop-update/bootstrap.ps1
+++ b/scripts/desktop-update/bootstrap.ps1
@@ -1,0 +1,59 @@
+# bootstrap.ps1 -- dependency-free escape hatch for Windows update deadlocks.
+#
+# This script is intentionally independent from hermes_cli.  It is run by the
+# OS-level Desktop handoff after an update child exits with the recoverable
+# self-lock code (2).  Its job is to advance a pre-fix checkout to code that
+# contains the honest, post-fetch self-lock handling before starting Python
+# again.  It must remain compatible with Windows PowerShell 5.1.
+
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$InstallRoot,
+    [string]$Branch = "main",
+    [switch]$NoRelaunch
+)
+
+$ErrorActionPreference = "Stop"
+$root = [System.IO.Path]::GetFullPath($InstallRoot)
+$git = "git"
+$python = Join-Path $root "venv\Scripts\python.exe"
+
+function Invoke-Native([string]$FilePath, [string[]]$Arguments) {
+    & $FilePath @Arguments
+    if ($LASTEXITCODE -ne 0) {
+        throw "$FilePath $($Arguments -join ' ') exited with code $LASTEXITCODE"
+    }
+}
+
+if (-not (Test-Path -LiteralPath (Join-Path $root ".git"))) {
+    throw "Not a git checkout: $root"
+}
+if (-not (Test-Path -LiteralPath $python)) {
+    throw "Missing venv interpreter: $python"
+}
+
+# Do not silently destroy user work.  The normal updater owns stash policy;
+# this escape hatch only runs when that updater could not reach its new code.
+$status = (& $git -C $root status --porcelain 2>&1 | Out-String).Trim()
+if ($status) {
+    throw "Working tree is not clean; preserve local changes, then rerun the update bootstrap"
+}
+
+# This is deliberately a fresh, non-Python process.  The old updater may have
+# mapped cryptography._rust; git does not import the venv and can advance the
+# checkout without touching the locked extension.
+Invoke-Native $git @("-C", $root, "fetch", "origin", $Branch)
+Invoke-Native $git @("-C", $root, "merge", "--ff-only", "origin/$Branch")
+
+# Start a new interpreter only after the checkout has advanced.  The new
+# hermes_cli.main contains the post-fetch self-lock placement and early
+# recovery path.  --force is safe here because this script already verified
+# that the working tree is clean; the Python holder guard remains active.
+$pythonArgs = @("-m", "hermes_cli.main", "update", "--yes", "--gateway", "--force", "--branch", $Branch)
+& $python @pythonArgs
+$code = $LASTEXITCODE
+if ($code -ne 0) {
+    throw "Fresh Hermes updater exited with code $code"
+}
+
+exit 0

--- a/scripts/desktop-update/bootstrap.ps1
+++ b/scripts/desktop-update/bootstrap.ps1
@@ -18,6 +18,11 @@ $root = [System.IO.Path]::GetFullPath($InstallRoot)
 $git = "git"
 $python = Join-Path $root "venv\Scripts\python.exe"
 
+if ([string]::IsNullOrWhiteSpace($Branch) -or
+    $Branch -notmatch '^[A-Za-z0-9._/-]+$' -or $Branch.Contains("..")) {
+    throw "Invalid update branch: $Branch"
+}
+
 function Invoke-Native([string]$FilePath, [string[]]$Arguments) {
     & $FilePath @Arguments
     if ($LASTEXITCODE -ne 0) {
@@ -35,6 +40,9 @@ if (-not (Test-Path -LiteralPath $python)) {
 # Do not silently destroy user work.  The normal updater owns stash policy;
 # this escape hatch only runs when that updater could not reach its new code.
 $status = (& $git -C $root status --porcelain 2>&1 | Out-String).Trim()
+if ($LASTEXITCODE -ne 0) {
+    throw "Unable to inspect working tree: $root"
+}
 if ($status) {
     throw "Working tree is not clean; preserve local changes, then rerun the update bootstrap"
 }

--- a/scripts/desktop-update/windows.ps1
+++ b/scripts/desktop-update/windows.ps1
@@ -582,6 +582,28 @@ function Invoke-HermesStep([string]$Exe, [string[]]$HermesArgs, [string]$Tag) {
     return @{ Code = $proc.ExitCode; Output = $all }
 }
 
+function Invoke-UpdateBootstrap([string]$Root, [string]$Ref) {
+    # The Python updater can be too old to fetch the commit that fixes its own
+    # self-lock preflight.  Run the recovery from PowerShell (an OS component,
+    # not the locked venv interpreter) so git can advance the checkout first.
+    $bootstrap = Join-Path $Root "scripts\desktop-update\bootstrap.ps1"
+    if (-not (Test-Path -LiteralPath $bootstrap)) {
+        Write-HandoffLog "bootstrap unavailable in this checkout; preserving exit 2"
+        return $null
+    }
+    $powershell = Join-Path $env:SystemRoot "System32\WindowsPowerShell\v1.0\powershell.exe"
+    if (-not (Test-Path -LiteralPath $powershell)) {
+        Write-HandoffLog "bootstrap unavailable: Windows PowerShell not found"
+        return $null
+    }
+    $bootstrapArgs = @(
+        "-NoProfile", "-ExecutionPolicy", "Bypass", "-File", $bootstrap,
+        "-InstallRoot", $Root, "-Branch", $Ref, "-NoRelaunch"
+    )
+    Write-HandoffLog "self-lock exit 2: advancing checkout through external bootstrap"
+    return Invoke-HermesStep $powershell $bootstrapArgs "bootstrap"
+}
+
 $finalCode = 1
 $finalMsg = "update did not complete"
 
@@ -728,9 +750,24 @@ try {
     $res = Invoke-HermesStep $pythonExe $updateArgs "update"
     Write-HandoffLog "hermes update exit code: $($res.Code)"
 
+    # A pre-#86857 checkout can reject every Python update before it reaches
+    # git fetch.  The marker is the recoverable self-lock signal; use the
+    # OS-level bootstrap to fetch the fix and then retry from a fresh Python
+    # interpreter. Ordinary exit-2 safety refusals remain terminal.
+    if ($res.Code -eq 2 -and (Test-Path -LiteralPath (Join-Path $InstallRoot ".update-incomplete"))) {
+        $boot = Invoke-UpdateBootstrap $InstallRoot $Branch
+        if ($boot -and $boot.Code -eq 0) {
+            $res = @{ Code = 0; Output = $boot.Output }
+            Write-HandoffLog "external bootstrap completed the update"
+        } elseif ($boot) {
+            Write-HandoffLog "external bootstrap failed with exit code $($boot.Code)"
+        }
+    }
+
     if ($res.Code -ne 0 -and $res.Code -ne 2) {
         # One retry for the update-boundary class (fresh code on disk, stale
-        # code in memory). Exit 2 ("close all Hermes windows") is not retryable.
+        # code in memory). Non-marker exit 2 ("close all Hermes windows")
+        # remains terminal and is not retried.
         Write-HandoffLog "first attempt failed; retrying once (freshly pulled fix loads on the second run)"
         $res = Invoke-HermesStep $pythonExe $updateArgs "update"
         Write-HandoffLog "retry exit code: $($res.Code)"

--- a/scripts/desktop-update/windows.ps1
+++ b/scripts/desktop-update/windows.ps1
@@ -534,7 +534,7 @@ function Start-DesktopRelaunch {
     return $spawned
 }
 
-function Invoke-HermesStep([string]$Exe, [string[]]$HermesArgs, [string]$Tag) {
+function Invoke-ProcessStep([string]$Exe, [string[]]$ProcessArgs, [string]$Tag) {
     # The window shows nothing live, so no line-pump: both pipes drain
     # asynchronously (no deadlock however chatty the child) while a small
     # DoEvents loop keeps the marquee animating through long silent
@@ -547,7 +547,7 @@ function Invoke-HermesStep([string]$Exe, [string[]]$HermesArgs, [string]$Tag) {
     $psi.FileName = $Exe
     # .Arguments string (PS 5.1 / .NET Framework has no ArgumentList).
     # Args here are fixed flags + a branch ref; quote each defensively.
-    $psi.Arguments = ($HermesArgs | ForEach-Object { '"{0}"' -f ($_ -replace '"', '\"') }) -join ' '
+    $psi.Arguments = ($ProcessArgs | ForEach-Object { '"{0}"' -f ($_ -replace '"', '\"') }) -join ' '
     $psi.UseShellExecute = $false
     $psi.RedirectStandardOutput = $true
     $psi.RedirectStandardError = $true
@@ -582,6 +582,14 @@ function Invoke-HermesStep([string]$Exe, [string[]]$HermesArgs, [string]$Tag) {
     return @{ Code = $proc.ExitCode; Output = $all }
 }
 
+function Invoke-HermesStep([string]$Exe, [string[]]$HermesArgs, [string]$Tag) {
+    return Invoke-ProcessStep $Exe $HermesArgs $Tag
+}
+
+function Invoke-ExternalStep([string]$Exe, [string[]]$ProcessArgs, [string]$Tag) {
+    return Invoke-ProcessStep $Exe $ProcessArgs $Tag
+}
+
 function Invoke-UpdateBootstrap([string]$Root, [string]$Ref) {
     # The Python updater can be too old to fetch the commit that fixes its own
     # self-lock preflight.  Run the recovery from PowerShell (an OS component,
@@ -601,7 +609,7 @@ function Invoke-UpdateBootstrap([string]$Root, [string]$Ref) {
         "-InstallRoot", $Root, "-Branch", $Ref, "-NoRelaunch"
     )
     Write-HandoffLog "self-lock exit 2: advancing checkout through external bootstrap"
-    return Invoke-HermesStep $powershell $bootstrapArgs "bootstrap"
+    return Invoke-ExternalStep $powershell $bootstrapArgs "bootstrap"
 }
 
 $finalCode = 1

--- a/tests/run_agent/test_sequential_tool_timeout.py
+++ b/tests/run_agent/test_sequential_tool_timeout.py
@@ -93,26 +93,32 @@ def test_sequential_tool_timeout_emits_result_and_continues(tmp_path, monkeypatc
     calls = [_tool_call("hung"), _tool_call("next")]
     assistant = SimpleNamespace(tool_calls=calls)
     messages: list[dict] = []
-    monkeypatch.setenv("HERMES_CONCURRENT_TOOL_TIMEOUT_S", "0.05")
+    monkeypatch.setenv("HERMES_CONCURRENT_TOOL_TIMEOUT_S", "0.5")
 
     started = time.monotonic()
     try:
         with (
             patch("run_agent.handle_function_call", side_effect=_dispatch),
+            patch("model_tools.handle_function_call", side_effect=_dispatch),
             patch(
                 "agent.tool_executor._emit_terminal_post_tool_call",
                 side_effect=_capture_terminal_event,
             ),
         ):
             execute_tool_calls_sequential(agent, assistant, messages, "task")
+            # Under a heavily loaded CI worker the daemon thread can be
+            # scheduled just after the bounded call returns.  Observe its
+            # start before releasing the gate; otherwise the assertion below
+            # races the executor teardown rather than testing timeout behavior.
+            assert first_started.wait(timeout=1.0)
     finally:
         release_first.set()
 
     assert first_started.is_set()
-    assert time.monotonic() - started < 1.0
+    assert time.monotonic() - started < 2.0
     assert dispatched == ["hung", "next"]
     assert [message["tool_call_id"] for message in messages] == ["hung", "next"]
-    assert "timed out after 0.1s" in messages[0]["content"]
+    assert "timed out after 0.5s" in messages[0]["content"]
     assert messages[0]["effect_disposition"] == "unknown"
     assert messages[1]["content"] == "second result"
     timeout_events = [event for event in terminal_events if event.get("error_type") == "tool_timeout"]
@@ -142,7 +148,7 @@ def test_sequential_tool_timeout_suppresses_late_terminal_event(tmp_path, monkey
 
     calls = [_tool_call("hung"), _tool_call("next")]
     messages: list[dict] = []
-    monkeypatch.setenv("HERMES_CONCURRENT_TOOL_TIMEOUT_S", "0.05")
+    monkeypatch.setenv("HERMES_CONCURRENT_TOOL_TIMEOUT_S", "0.5")
 
     try:
         with (
@@ -184,7 +190,7 @@ def test_sequential_timeout_does_not_cut_clarify_human_wait(
     outlast ``HERMES_CONCURRENT_TOOL_TIMEOUT_S`` (default 420s).
     """
     agent = _make_agent(tmp_path)
-    monkeypatch.setenv("HERMES_CONCURRENT_TOOL_TIMEOUT_S", "0.05")
+    monkeypatch.setenv("HERMES_CONCURRENT_TOOL_TIMEOUT_S", "0.5")
     monkeypatch.setattr(
         "tools.clarify_gateway.get_clarify_timeout",
         lambda: clarify_timeout,
@@ -219,7 +225,7 @@ def test_sequential_timeout_does_not_cut_clarify_human_wait(
             "task",
         )
 
-    assert time.monotonic() - started < 1.0
+    assert time.monotonic() - started < 2.0
     assert [message["tool_call_id"] for message in messages] == ["clarify-1", "next"]
     payload = json.loads(messages[0]["content"])
     assert payload["user_response"] == "A"

--- a/tests/test_desktop_update_bootstrap.py
+++ b/tests/test_desktop_update_bootstrap.py
@@ -1,0 +1,57 @@
+"""Windows-host regression checks for the external update bootstrap."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+BOOTSTRAP = ROOT / "scripts" / "desktop-update" / "bootstrap.ps1"
+HANDOFF = ROOT / "scripts" / "desktop-update" / "windows.ps1"
+
+
+def _powershell() -> str:
+    return "powershell.exe"
+
+
+@pytest.mark.windows_only
+def test_update_scripts_parse_on_windows():
+    command = (
+        "$ErrorActionPreference='Stop'; "
+        f"$null=[scriptblock]::Create((Get-Content -Raw -LiteralPath '{BOOTSTRAP}')); "
+        f"$null=[scriptblock]::Create((Get-Content -Raw -LiteralPath '{HANDOFF}'))"
+    )
+    result = subprocess.run(
+        [_powershell(), "-NoProfile", "-Command", command],
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr or result.stdout
+
+
+@pytest.mark.windows_only
+def test_bootstrap_refuses_non_checkout_without_running_python(tmp_path):
+    result = subprocess.run(
+        [
+            _powershell(),
+            "-NoProfile",
+            "-ExecutionPolicy",
+            "Bypass",
+            "-File",
+            str(BOOTSTRAP),
+            "-InstallRoot",
+            str(tmp_path),
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    combined = result.stdout + result.stderr
+    assert result.returncode != 0
+    assert "Not a git checkout" in combined

--- a/tests/test_desktop_update_bootstrap.py
+++ b/tests/test_desktop_update_bootstrap.py
@@ -28,7 +28,7 @@ def test_update_scripts_parse_on_windows():
         [_powershell(), "-NoProfile", "-Command", command],
         capture_output=True,
         text=True,
-        encoding="utf-8",
+        encoding="mbcs",
         errors="replace",
         check=False,
     )
@@ -50,8 +50,36 @@ def test_bootstrap_refuses_non_checkout_without_running_python(tmp_path):
         ],
         capture_output=True,
         text=True,
+        encoding="mbcs",
+        errors="replace",
         check=False,
     )
     combined = result.stdout + result.stderr
     assert result.returncode != 0
     assert "Not a git checkout" in combined
+
+
+@pytest.mark.windows_only
+def test_bootstrap_rejects_invalid_branch_before_git_or_python(tmp_path):
+    result = subprocess.run(
+        [
+            _powershell(),
+            "-NoProfile",
+            "-ExecutionPolicy",
+            "Bypass",
+            "-File",
+            str(BOOTSTRAP),
+            "-InstallRoot",
+            str(tmp_path),
+            "-Branch",
+            "main;Write-Output INJECTION",
+        ],
+        capture_output=True,
+        text=True,
+        encoding="mbcs",
+        errors="replace",
+        check=False,
+    )
+    combined = result.stdout + result.stderr
+    assert result.returncode != 0
+    assert "Invalid update branch" in combined


### PR DESCRIPTION
## Summary

Fixes the missing bootstrap boundary in the Windows update deadlock reported by #87156.

A pre-#86857 Python updater can load `cryptography._rust`, write `.update-incomplete`, and exit before `git fetch`. Re-entering Python cannot reach the commit that fixes the preflight. This change lets the OS-level Desktop handoff advance the checkout without importing the venv first.

## Root cause

The old updater performs the self-lock check inside the Python process before the code fetch. Once that process has mapped a native extension, every retry follows the same exit-2 path and the fix remains unreachable.

## Fix

- Add `scripts/desktop-update/bootstrap.ps1`, a Windows PowerShell 5.1-compatible, dependency-free bootstrap.
- Invoke it only for exit code 2 when `.update-incomplete` exists.
- The bootstrap:
  - verifies the checkout and venv interpreter;
  - refuses to destroy a dirty working tree;
  - runs `git fetch` and fast-forward merge outside Python;
  - starts a fresh venv interpreter only after the checkout contains the newer updater.
- Ordinary exit-2 safety refusals remain terminal.
- Add Windows-host regression tests that execute PowerShell parsing and bootstrap refusal behavior.

## Why this is not a duplicate of #87002 / #86979

- #86979 owns Desktop marker-aware retry behavior.
- #87002 owns post-dependency pipeline resumption and currently has follow-up concerns around single-flight and per-stage retry state.
- This PR owns the earlier, distinct reachability boundary: escaping a pre-fix Python updater before it can fetch the fix.

The changes are complementary and should be integrated with those PRs rather than replacing them.

## Safety

- No Python code runs before the checkout advancement.
- No reset or stash is performed by the bootstrap.
- Dirty working trees fail closed instead of losing local changes.
- The bootstrap runs only for marker-backed self-lock deferrals, not arbitrary exit code 2 failures.
- The existing Python venv-holder guard remains active after the fresh interpreter starts.

## Validation

- `python -m pytest tests/test_desktop_update_bootstrap.py -q` — 3 passed.
- `python -m pytest tests/test_desktop_update_windows_python_handoff.py tests/test_desktop_update_bootstrap.py tests/run_agent/test_sequential_tool_timeout.py -q` — 11 passed; the CI-only scheduling race in the sequential-timeout test is covered with a stable 500 ms test deadline.
- PowerShell parsing of both scripts — passed on Windows PowerShell.
- `python -m py_compile tests/test_desktop_update_bootstrap.py` — passed.
- `git diff --check` — passed.
- `scripts/run_tests.sh` could not run in this checkout because the canonical test wrapper reported no `.venv`/`venv` with pytest.

## Deployment boundary for frozen installations

This fix is reachable automatically only when the Windows Desktop handoff already contains `scripts/desktop-update/bootstrap.ps1`. A handoff binary/script shipped before that bootstrap cannot fetch the bootstrap through the Python updater, because the old updater deadlocks before `git fetch`.

Therefore, the first release containing this bootstrap must be delivered through an independent signed Desktop update/installer channel, or the user must run the documented one-time manual bootstrap:

```powershell
Set-Location "$env:LOCALAPPDATA\hermes\hermes-agent"
git fetch origin main
git merge --ff-only origin/main
.\venv\Scripts\python.exe -m hermes_cli.main update --yes --gateway --force --branch main
```

The manual path must be run only after closing Hermes and with a clean working tree; it intentionally does not reset or stash local changes. After that boundary is crossed, future marker-backed self-lock deferrals can advance the checkout outside Python and continue normally.

This is a release-delivery constraint, not a reason to broaden the Python self-lock guard: changing the old Python process cannot make code reachable after that process has already locked its own updater dependency.

## Infographic

 
<img width="1376" height="768" alt="infographic_windows_selflock_87293" src="https://github.com/user-attachments/assets/c1743622-7250-468a-afe7-319c2b410155" />


## Release note

A frozen Desktop handoff from a build that predates this script still needs one bootstrap artifact delivered outside that frozen checkout (for example, the next signed Desktop release or a documented manual bootstrap). Once the handoff contains this script, the normal update path can reach the post-#86857 code without a manual `git reset`.

Fixes #87156
