### PR TITLE
fix(desktop): always send a durable truncation address on rewind/edit/regenerate

### DIFF
--- a/apps/desktop/src/app/chat/session-tile-actions.ts
+++ b/apps/desktop/src/app/chat/session-tile-actions.ts
@@ -13,7 +13,6 @@ import { useCallback, useMemo, useRef } from 'react'
 
 import { useGatewayRequest } from '@/app/gateway/hooks/use-gateway-request'
 import type { ClientSessionState } from '@/app/types'
-import { PROMPT_SUBMIT_REQUEST_TIMEOUT_MS } from '@/hermes'
 import { useI18n } from '@/i18n'
 import { textPart } from '@/lib/chat-messages'
 import { SLASH_COMMAND_RE } from '@/lib/chat-runtime'
@@ -44,9 +43,7 @@ import {
   planRestore,
   rebindSurvivorRowIds,
   runRewindSubmit,
-  survivorRowIdsFrom,
-  type SurvivorUserRowIds,
-  truncateSubmitParams
+  type SurvivorUserRowIds
 } from '../session/hooks/use-prompt-actions/rewind'
 import { useSubmitPrompt } from '../session/hooks/use-prompt-actions/submit'
 import {
@@ -394,7 +391,8 @@ export function useSessionTileActions({ runtimeId, scope, storedSessionId }: Ses
       truncateOrdinal: number | undefined,
       interruptFirst: boolean,
       truncateMessageId?: string,
-      truncateRowId?: number
+      truncateRowId?: number,
+      sourceText?: string
     ) =>
       runRewindSubmit(
         requestGateway,
@@ -409,7 +407,8 @@ export function useSessionTileActions({ runtimeId, scope, storedSessionId }: Ses
             runtimeIdRef.current = recoveredId
           }
         },
-        truncateRowId
+        truncateRowId,
+        sourceText
       ),
     [requestGateway]
   )
@@ -447,23 +446,15 @@ export function useSessionTileActions({ runtimeId, scope, storedSessionId }: Ses
       update(current => applyReloadOptimistic(current, plan))
 
       try {
-        const result = await requestGateway<{ survivor_user_row_ids?: unknown }>(
-          'prompt.submit',
-          {
-            session_id: runtimeIdRef.current,
-            text: plan.text,
-            ...truncateSubmitParams(plan.truncateOrdinal, plan.truncateMessageId, plan.truncateRowId)
-          },
-          PROMPT_SUBMIT_REQUEST_TIMEOUT_MS
+        applySurvivorRowIds(
+          await submitRewind(plan.text, plan.truncateOrdinal, false, plan.truncateMessageId, plan.truncateRowId, plan.sourceText)
         )
-
-        applySurvivorRowIds(survivorRowIdsFrom(result))
       } catch (err) {
         update(current => ({ ...current, busy: false, awaitingResponse: false }))
         notifyError(err, copy.regenerateFailed)
       }
     },
-    [applySurvivorRowIds, copy.regenerateFailed, readState, requestGateway, update]
+    [applySurvivorRowIds, copy.regenerateFailed, readState, submitRewind, update]
   )
 
   const restoreToMessage = useCallback(
@@ -490,7 +481,8 @@ export function useSessionTileActions({ runtimeId, scope, storedSessionId }: Ses
             plan.truncateOrdinal,
             interruptFirst,
             plan.truncateMessageId,
-            plan.truncateRowId
+            plan.truncateRowId,
+            plan.sourceText
           )
         )
       } catch (err) {
@@ -530,7 +522,8 @@ export function useSessionTileActions({ runtimeId, scope, storedSessionId }: Ses
             plan.truncateOrdinal,
             interruptFirst,
             plan.truncateMessageId,
-            plan.truncateRowId
+            plan.truncateRowId,
+            plan.sourceText
           )
         )
       } catch (err) {

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/index.ts
@@ -2,7 +2,7 @@ import type { AppendMessage, ThreadMessage } from '@assistant-ui/react'
 import { useStore } from '@nanostores/react'
 import { type MutableRefObject, useCallback, useEffect, useRef } from 'react'
 
-import { PROMPT_SUBMIT_REQUEST_TIMEOUT_MS, transcribeAudio } from '@/hermes'
+import { transcribeAudio } from '@/hermes'
 import { useI18n } from '@/i18n'
 import { stripAnsi } from '@/lib/ansi'
 import { type ChatMessage, textPart } from '@/lib/chat-messages'
@@ -60,9 +60,7 @@ import {
   planRestore,
   rebindSurvivorRowIds,
   runRewindSubmit,
-  survivorRowIdsFrom,
-  type SurvivorUserRowIds,
-  truncateSubmitParams
+  type SurvivorUserRowIds
 } from './rewind'
 import { useSlashCommand } from './slash'
 import { useSubmitPrompt } from './submit'
@@ -826,6 +824,37 @@ export function usePromptActions({
     [updateSessionState]
   )
 
+  const submitRewindPrompt = useCallback(
+    (
+      sessionId: string,
+      text: string,
+      truncateOrdinal: number | undefined,
+      truncateMessageId: string | undefined,
+      interruptFirst: boolean,
+      truncateRowId?: number,
+      sourceText?: string
+    ) =>
+      runRewindSubmit(
+        requestGateway,
+        sessionId,
+        text,
+        truncateOrdinal,
+        truncateMessageId,
+        interruptFirst,
+        {
+          storedSessionId: selectedStoredSessionIdRef.current,
+          onSessionRecovered: recoveredId => {
+            activeSessionIdRef.current = recoveredId
+            setActiveSessionId(recoveredId)
+          }
+        },
+        truncateRowId,
+        sourceText
+      ),
+    [activeSessionIdRef, requestGateway, selectedStoredSessionIdRef]
+  )
+
+
   const reloadFromMessage = useCallback(
     async (parentId: string | null) => {
       // Ref, not the closure-captured prop — a truncating resubmit aimed at a
@@ -846,17 +875,17 @@ export function usePromptActions({
       updateSessionState(sessionId, state => applyReloadOptimistic(state, plan))
 
       try {
-        const result = await requestGateway<{ survivor_user_row_ids?: unknown }>(
-          'prompt.submit',
-          {
-            session_id: sessionId,
-            text: plan.text,
-            ...truncateSubmitParams(plan.truncateOrdinal, plan.truncateMessageId, plan.truncateRowId)
-          },
-          PROMPT_SUBMIT_REQUEST_TIMEOUT_MS
+        const survivorRowIds = await submitRewindPrompt(
+          sessionId,
+          plan.text,
+          plan.truncateOrdinal,
+          plan.truncateMessageId,
+          false,
+          plan.truncateRowId,
+          plan.sourceText
         )
 
-        applySurvivorRowIds(sessionId, survivorRowIdsFrom(result))
+        applySurvivorRowIds(sessionId, survivorRowIds)
       } catch (err) {
         updateSessionState(sessionId, state => ({
           ...state,
@@ -866,7 +895,7 @@ export function usePromptActions({
         notifyError(err, copy.regenerateFailed)
       }
     },
-    [activeSessionIdRef, applySurvivorRowIds, copy.regenerateFailed, requestGateway, updateSessionState]
+    [activeSessionIdRef, applySurvivorRowIds, copy.regenerateFailed, submitRewindPrompt, updateSessionState]
   )
 
   // Cursor-style "restore checkpoint": rewind the conversation to a past user
@@ -878,34 +907,6 @@ export function usePromptActions({
   // interrupting an idle agent can leave a stale interrupt flag that cancels the
   // fresh turn. Live/stuck turns interrupt first, and a raced "session busy"
   // response interrupts + retries through the shared busy gate.
-  const submitRewindPrompt = useCallback(
-    (
-      sessionId: string,
-      text: string,
-      truncateOrdinal: number | undefined,
-      truncateMessageId: string | undefined,
-      interruptFirst: boolean,
-      truncateRowId?: number
-    ) =>
-      runRewindSubmit(
-        requestGateway,
-        sessionId,
-        text,
-        truncateOrdinal,
-        truncateMessageId,
-        interruptFirst,
-        {
-          storedSessionId: selectedStoredSessionIdRef.current,
-          onSessionRecovered: recoveredId => {
-            activeSessionIdRef.current = recoveredId
-            setActiveSessionId(recoveredId)
-          }
-        },
-        truncateRowId
-      ),
-    [activeSessionIdRef, requestGateway, selectedStoredSessionIdRef]
-  )
-
   const restoreToMessage = useCallback(
     async (messageId: string, target?: RestoreMessageTarget) => {
       // Ref, not the closure-captured prop — a rewind is destructive, so a
@@ -946,7 +947,8 @@ export function usePromptActions({
           plan.truncateOrdinal,
           plan.truncateMessageId,
           interruptFirst,
-          plan.truncateRowId
+          plan.truncateRowId,
+          plan.sourceText
         )
 
         applySurvivorRowIds(sessionId, survivorRowIds)
@@ -1009,7 +1011,8 @@ export function usePromptActions({
           plan.truncateOrdinal,
           plan.truncateMessageId,
           interruptFirst,
-          plan.truncateRowId
+          plan.truncateRowId,
+          plan.sourceText
         )
 
         applySurvivorRowIds(sessionId, survivorRowIds)

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/rewind.test.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/rewind.test.ts
@@ -5,7 +5,12 @@ import { type ChatMessage, textPart } from '@/lib/chat-messages'
 import {
   appendMidTurnUserMessage,
   finalizeInterruptedMessages,
+  planEdit,
+  planReload,
+  planRestore,
   rebindSurvivorRowIds,
+  resolveDurableRowId,
+  runRewindSubmit,
   survivorRowIdsFrom,
   truncateSubmitParams
 } from './rewind'
@@ -259,5 +264,205 @@ describe('finalizeInterruptedMessages', () => {
     expect(message.parts).toHaveLength(1)
     expect(message.parts[0].completedAt).toBe(11.25)
     expect(message.completedAt).toBe(11.25)
+
+  })
+})
+
+describe('failed-turn-aware ordinal space', () => {
+  const user = (id: string, rowId?: number): ChatMessage => ({
+    id,
+    role: 'user',
+    parts: [textPart(`text ${id}`)],
+    ...(rowId !== undefined ? { rowId } : {})
+  })
+
+  const assistant = (id: string, rowId?: number): ChatMessage => ({
+    id,
+    role: 'assistant',
+    parts: [textPart(`reply ${id}`)],
+    ...(rowId !== undefined ? { rowId } : {})
+  })
+
+  const failedAssistant = (id: string): ChatMessage => ({
+    id,
+    role: 'assistant',
+    parts: [textPart(`err ${id}`)],
+    error: 'provider down'
+  })
+
+  it('planEdit/planReload skip failed turns when counting ordinals (#41275)', () => {
+    // u0 failed (never persisted), u1/u2 succeeded. Backend counts u1 before
+    // u2, so editing u2 must aim at ordinal 1, not 2.
+    const messages: ChatMessage[] = [
+      user('u0', undefined),
+      failedAssistant('a0'),
+      user('u1', 11),
+      assistant('a1', 12),
+      user('u2', 13),
+      assistant('a2', 14)
+    ]
+
+    const reload = planReload(messages, 'a2')
+
+    expect(reload?.truncateOrdinal).toBe(1)
+    expect(reload?.truncateRowId).toBe(13)
+  })
+
+  it('planEdit still flags failed turns via the shared helper', () => {
+    const messages: ChatMessage[] = [user('u0', 11), assistant('a0', 12), user('u1', undefined), failedAssistant('a1')]
+
+    const plan = planEdit(messages, {
+      role: 'user',
+      sourceId: 'u1',
+      parentId: null,
+      content: [{ type: 'text', text: 'better text' }]
+    } as never)
+
+    expect(plan?.isFailedTurn).toBe(true)
+    expect(plan?.truncateOrdinal).toBeUndefined()
+    expect(plan?.sourceText).toBe('text u1')
+  })
+
+  it('planReload degrades a failed turn to a plain resubmit (#86623)', () => {
+    const messages: ChatMessage[] = [user('u0', 11), assistant('a0', 12), user('u1', undefined), failedAssistant('a1')]
+
+    const reload = planReload(messages, 'a1')
+
+    expect(reload?.text).toBe('text u1')
+    expect(reload?.truncateOrdinal).toBeUndefined()
+    expect(reload?.truncateRowId).toBeUndefined()
+    expect(reload?.truncateMessageId).toBeUndefined()
+  })
+
+  it('planRestore degrades a failed turn to a plain resubmit', () => {
+    const messages: ChatMessage[] = [user('u0', 11), assistant('a0', 12), user('u1', undefined), failedAssistant('a1')]
+
+    const plan = planRestore(messages, 'u1')
+
+    expect(plan.truncateOrdinal).toBeUndefined()
+    expect(plan.truncateRowId).toBeUndefined()
+    expect(plan.truncateMessageId).toBeUndefined()
+  })
+
+  it('rebindSurvivorRowIds skips failed turns — they hold no survivor slot', () => {
+    const messages: ChatMessage[] = [user('u0', 1), failedAssistant('a0'), user('u1', 3), assistant('a1', 4)]
+    const rebound = rebindSurvivorRowIds(messages, [9])
+
+    // u0 failed: untouched. u1 is survivor ordinal 0.
+    expect(rebound[0].rowId).toBe(1)
+    expect(rebound[2].rowId).toBe(9)
+  })
+})
+
+describe('resolveDurableRowId', () => {
+  const gatewayWith = (messages: unknown[]) => {
+    const request = (async (method: string) => {
+      expect(method).toBe('session.history')
+
+      return { messages }
+    }) as <T>(method: string, params?: Record<string, unknown>, timeoutMs?: number) => Promise<T>
+
+    return request
+  }
+
+  it('resolves a unique content match to its durable row id', async () => {
+    const request = gatewayWith([
+      { role: 'user', text: 'first prompt', row_id: 11 },
+      { role: 'assistant', text: 'reply', row_id: 12 },
+      { role: 'user', text: 'typo prompt', row_id: 13 }
+    ])
+
+    expect(await resolveDurableRowId(request, 'sid', 'typo prompt', 1)).toBe(13)
+  })
+
+  it('ignores synthetic user-role injections (display_kind rows)', async () => {
+    const request = gatewayWith([
+      { role: 'user', text: 'real prompt', row_id: 11 },
+      { role: 'user', text: 'real prompt', row_id: 12, display_kind: 'auto_continue' }
+    ])
+
+    expect(await resolveDurableRowId(request, 'sid', 'real prompt', 0)).toBe(11)
+  })
+
+  it('refuses ambiguous matches unless the target is provably the newest turn', async () => {
+    const request = gatewayWith([
+      { role: 'user', text: 'same text', row_id: 11 },
+      { role: 'user', text: 'same text', row_id: 13 }
+    ])
+
+    // Ambiguous + target not the latest -> undefined (plain resubmit).
+    expect(await resolveDurableRowId(request, 'sid', 'same text', 0)).toBeUndefined()
+    // Ambiguous + target IS the latest persisted turn -> last match wins.
+    expect(await resolveDurableRowId(request, 'sid', 'same text', 1)).toBe(13)
+  })
+
+  it('returns undefined on gateway failure or empty text', async () => {
+    const failing = (async () => {
+      throw new Error('boom')
+    }) as <T>(method: string) => Promise<T>
+
+    expect(await resolveDurableRowId(failing, 'sid', 'text', 0)).toBeUndefined()
+    expect(await resolveDurableRowId(gatewayWith([]), 'sid', '   ', 0)).toBeUndefined()
+  })
+})
+
+describe('runRewindSubmit durable-address discipline (#87059)', () => {
+  interface Call {
+    method: string
+    params?: Record<string, unknown>
+  }
+
+  const historyMessages = [
+    { role: 'user', text: 'first prompt', row_id: 11 },
+    { role: 'assistant', text: 'ok', row_id: 12 },
+    { role: 'user', text: 'typo prompt', row_id: 13 }
+  ]
+
+  const makeGateway = (calls: Call[]) =>
+    (async (method: string, params?: Record<string, unknown>) => {
+      calls.push({ method, params })
+
+      if (method === 'session.history') {
+        return { messages: historyMessages }
+      }
+
+      return { status: 'streaming' }
+    }) as <T>(method: string, params?: Record<string, unknown>, timeoutMs?: number) => Promise<T>
+
+  it('resolves a missing rowId by content before submitting, and drops the client ordinal', async () => {
+    const calls: Call[] = []
+
+    await runRewindSubmit(makeGateway(calls), 'sid', 'fixed prompt', 5, undefined, false, undefined, undefined, 'typo prompt')
+
+    const submit = calls.find(call => call.method === 'prompt.submit')
+
+    expect(submit?.params?.truncate_before_row_id).toBe(13)
+    expect(submit?.params?.truncate_before_user_ordinal).toBeUndefined()
+    expect(submit?.params?.confirm_truncate).toBe(true)
+  })
+
+  it('degrades to a plain resubmit when the row id cannot be resolved', async () => {
+    const calls: Call[] = []
+
+    await runRewindSubmit(makeGateway(calls), 'sid', 'fixed prompt', 5, undefined, false, undefined, undefined, 'unknown text')
+
+    const submit = calls.find(call => call.method === 'prompt.submit')
+
+    expect(submit?.params?.truncate_before_row_id).toBeUndefined()
+    expect(submit?.params?.truncate_before_user_ordinal).toBeUndefined()
+    expect(submit?.params?.confirm_truncate).toBeUndefined()
+  })
+
+  it('leaves a bound durable rowId untouched (no extra history call)', async () => {
+    const calls: Call[] = []
+
+    await runRewindSubmit(makeGateway(calls), 'sid', 'fixed prompt', 1, undefined, false, undefined, 13, 'typo prompt')
+
+    expect(calls.some(call => call.method === 'session.history')).toBe(false)
+
+    const submit = calls.find(call => call.method === 'prompt.submit')
+
+    expect(submit?.params?.truncate_before_row_id).toBe(13)
+    expect(submit?.params?.truncate_before_user_ordinal).toBe(1)
   })
 })

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/rewind.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/rewind.ts
@@ -23,9 +23,10 @@ import {
 
 import {
   appendText,
+  isFailedUserTurn,
   isSessionBusyError,
-  isVisibleUserMessage,
   visibleUserIndexAtOrdinal,
+  visibleUserMessageIndices,
   visibleUserOrdinal,
   withSessionBusyRetry,
   withSessionNotFoundResume
@@ -70,10 +71,13 @@ export function survivorRowIdsFrom(result: PromptSubmitResult | undefined): Surv
  * stale id now addresses an archived row and would be refused with 4018.
  */
 export function rebindSurvivorRowIds(messages: ChatMessage[], survivorRowIds: SurvivorUserRowIds): ChatMessage[] {
+  // Same ordinal space as the truncate math: visible AND persisted (failed
+  // turns never reached the gateway, so they hold no survivor slot).
+  const indices = new Set(visibleUserMessageIndices(messages))
   let ordinal = 0
 
-  return messages.map(message => {
-    if (!isVisibleUserMessage(message)) {
+  return messages.map((message, index) => {
+    if (!indices.has(index)) {
       return message
     }
 
@@ -86,6 +90,21 @@ export function rebindSurvivorRowIds(messages: ChatMessage[], survivorRowIds: Su
 
     return message.rowId === undefined ? message : { ...message, rowId: undefined }
   })
+}
+
+/**
+ * Renderer-synthetic message ids (`${timestamp}-${index}-${role}` from
+ * chat-messages.ts, plus older `user-…` / `assistant-…` shapes). Gateway
+ * history never carries them — only durable `row_id` / platform message_id.
+ */
+export function isSyntheticRendererId(messageId: string | undefined): boolean {
+  return (
+    typeof messageId === 'string' &&
+    (messageId.startsWith('user-') ||
+      messageId.startsWith('assistant-') ||
+      messageId.includes('-synthetic-') ||
+      /^\d+-\d+-(user|assistant|tools)\b/.test(messageId))
+  )
 }
 
 /**
@@ -104,17 +123,8 @@ export function truncateSubmitParams(
   const hasOrdinal = typeof truncateOrdinal === 'number' && Number.isInteger(truncateOrdinal) && truncateOrdinal >= 0
   const hasRowId = typeof truncateRowId === 'number' && Number.isInteger(truncateRowId)
 
-  // Renderer ids are ephemeral (`${timestamp}-${index}-${role}` from
-  // chat-messages.ts, plus older `user-…` / `assistant-…` shapes). Gateway
-  // history never carries them — only durable `row_id` / platform message_id.
-  const isSyntheticId =
-    typeof truncateMessageId === 'string' &&
-    (truncateMessageId.startsWith('user-') ||
-      truncateMessageId.startsWith('assistant-') ||
-      truncateMessageId.includes('-synthetic-') ||
-      /^\d+-\d+-(user|assistant|tools)\b/.test(truncateMessageId))
-
-  const hasMessageId = typeof truncateMessageId === 'string' && truncateMessageId.length > 0 && !isSyntheticId
+  const hasMessageId =
+    typeof truncateMessageId === 'string' && truncateMessageId.length > 0 && !isSyntheticRendererId(truncateMessageId)
 
   if (!hasOrdinal && !hasMessageId && !hasRowId) {
     return {}
@@ -127,6 +137,68 @@ export function truncateSubmitParams(
     ...(hasRowId ? { truncate_before_row_id: truncateRowId } : {}),
     ...(truncateOrdinal === 0 ? { confirm_empty_truncate: true } : {})
   }
+}
+
+interface DurableHistoryMessage {
+  display_kind?: string
+  role?: string
+  row_id?: unknown
+  text?: string
+}
+
+/**
+ * Resolve the durable row id of a user turn by CONTENT against the gateway's
+ * stamped transcript (`session.history` ships `row_id` per persisted row).
+ *
+ * The edit-after-interrupt bubble has no bound rowId (the durable row exists —
+ * the client just never learned its id), and renderer/gateway ordinal spaces
+ * diverge, so ordinal math cannot substitute (#87059: a 12-turn divergence cut
+ * 78 messages). Content matching is exact-or-nothing: a unique text match wins;
+ * ambiguity prefers the LAST match only when `expectedOrdinal` says the target
+ * is the latest persisted turn (the edit-after-interrupt shape — the just-sent
+ * message is by definition the newest). Anything else returns undefined and the
+ * caller degrades to a plain resubmit, never a guessed cut.
+ */
+export async function resolveDurableRowId(
+  requestGateway: RequestGateway,
+  sessionId: string,
+  sourceText: string,
+  expectedOrdinal: number | undefined
+): Promise<number | undefined> {
+  const wanted = sourceText.trim()
+
+  if (!wanted) {
+    return undefined
+  }
+
+  let messages: DurableHistoryMessage[]
+
+  try {
+    const result = await requestGateway<{ messages?: unknown }>('session.history', { session_id: sessionId })
+
+    messages = Array.isArray(result?.messages) ? (result.messages as DurableHistoryMessage[]) : []
+  } catch {
+    return undefined
+  }
+
+  const durableUsers = messages.filter(
+    message =>
+      message.role === 'user' && !message.display_kind && typeof message.row_id === 'number' && Number.isInteger(message.row_id)
+  )
+
+  const matches = durableUsers.filter(message => (message.text ?? '').trim() === wanted)
+
+  if (matches.length === 1) {
+    return matches[0].row_id as number
+  }
+
+  if (matches.length > 1 && typeof expectedOrdinal === 'number' && expectedOrdinal >= durableUsers.length - 1) {
+    const last = matches[matches.length - 1]
+
+    return durableUsers[durableUsers.length - 1] === last ? (last.row_id as number) : undefined
+  }
+
+  return undefined
 }
 
 /**
@@ -147,11 +219,45 @@ export async function runRewindSubmit(
   truncateMessageId: string | undefined,
   interruptFirst: boolean,
   recovery?: { storedSessionId?: null | string; onSessionRecovered?: (sessionId: string) => void },
-  truncateRowId?: number
+  truncateRowId?: number,
+  sourceText?: string
 ): Promise<SurvivorUserRowIds | undefined> {
   // Recovery may rebind the live id mid-flight; interrupt/submit must both
   // follow it rather than pinning the dead one.
   let liveSessionId = sessionId
+
+  // A truncation without a durable address is the #87059 shape: the gateway
+  // fails it closed (4004) for any persisted session, so sending it can only
+  // produce an error. Resolve the row id by content first (the durable row
+  // usually exists — the bubble just never learned its id, e.g. edit after an
+  // interrupted turn). When resolution fails too, degrade to a PLAIN resubmit:
+  // append the corrected text without dropping anything, never guess a cut.
+  let resolvedRowId = truncateRowId
+  let resolvedOrdinal = truncateOrdinal
+  let resolvedMessageId = truncateMessageId
+
+  const wantsTruncation =
+    typeof truncateOrdinal === 'number' ||
+    typeof truncateRowId === 'number' ||
+    (typeof truncateMessageId === 'string' && truncateMessageId.length > 0 && !isSyntheticRendererId(truncateMessageId))
+
+  const hasDurableAddress =
+    typeof truncateRowId === 'number' ||
+    (typeof truncateMessageId === 'string' && truncateMessageId.length > 0 && !isSyntheticRendererId(truncateMessageId))
+
+  if (wantsTruncation && !hasDurableAddress) {
+    resolvedRowId =
+      sourceText === undefined
+        ? undefined
+        : await resolveDurableRowId(requestGateway, liveSessionId, sourceText, truncateOrdinal)
+
+    // Either way the client-side ordinal is untrustworthy here (its space can
+    // diverge from the gateway's — the #87059 root). Resolved: the row id alone
+    // is the address; sending the divergent ordinal too would trip the
+    // gateway's 4030 cross-check. Unresolved: plain resubmit, no truncation.
+    resolvedOrdinal = undefined
+    resolvedMessageId = undefined
+  }
 
   const interrupt = async () => {
     try {
@@ -167,7 +273,15 @@ export async function runRewindSubmit(
       {
         session_id: targetId,
         text,
-        ...truncateSubmitParams(truncateOrdinal, truncateMessageId, truncateRowId)
+        ...truncateSubmitParams(resolvedOrdinal, resolvedMessageId, resolvedRowId),
+        // A first-turn rewind resolves to an empty transcript, which the
+        // gateway additionally gates behind confirm_empty_truncate. In
+        // resolved-row-id mode the ordinal was dropped (see above), so carry
+        // the flag from the caller's ordinal-0 belief: required when right,
+        // ignored by the gateway when the cut isn't actually empty.
+        ...(resolvedRowId !== undefined && resolvedOrdinal === undefined && truncateOrdinal === 0
+          ? { confirm_empty_truncate: true }
+          : {})
       },
       PROMPT_SUBMIT_REQUEST_TIMEOUT_MS
     )
@@ -274,8 +388,10 @@ export function appendMidTurnUserMessage<
 
 export interface ReloadPlan {
   branchGroupId: string
+  /** Original persisted text of the turn — the durable-row-id content key. */
+  sourceText: string
   text: string
-  truncateOrdinal: number
+  truncateOrdinal: number | undefined
   truncateMessageId?: string
   truncateRowId?: number
   userIndex: number
@@ -305,12 +421,17 @@ export function planReload(messages: ChatMessage[], parentId: null | string): nu
       ? messages[parentIndex]
       : messages.slice(userIndex + 1).find(m => m.role === 'assistant')
 
+  // Failed turn: the user msg never reached the gateway, so any truncation
+  // address would mis-aim (#86573/#86623) — resubmit plainly instead.
+  const isFailedTurn = isFailedUserTurn(messages, userIndex)
+
   return {
     branchGroupId: targetAssistant?.branchGroupId ?? branchGroupForUser(userMessage),
+    sourceText: text,
     text,
-    truncateOrdinal: visibleUserOrdinal(messages, userIndex),
-    truncateMessageId: userMessage.id,
-    truncateRowId: userMessage.rowId,
+    truncateOrdinal: isFailedTurn ? undefined : visibleUserOrdinal(messages, userIndex),
+    truncateMessageId: isFailedTurn ? undefined : userMessage.id,
+    truncateRowId: isFailedTurn ? undefined : userMessage.rowId,
     userIndex
   }
 }
@@ -347,8 +468,10 @@ export interface RestoreTarget {
 
 export interface RestorePlan {
   sourceIndex: number
+  /** Original persisted text of the turn — the durable-row-id content key. */
+  sourceText: string
   text: string
-  truncateOrdinal: number
+  truncateOrdinal: number | undefined
   truncateMessageId?: string
   truncateRowId?: number
 }
@@ -369,18 +492,30 @@ export function planRestore(messages: ChatMessage[], messageId: string, target?:
     throw new Error('Could not find the message to restore.')
   }
 
-  const text = (chatMessageText(source).trim() || target?.text?.trim() || '').trim()
+  const sourceText = chatMessageText(source).trim()
+  const text = (sourceText || target?.text?.trim() || '').trim()
 
   if (!text) {
     throw new Error('Cannot restore an empty message.')
   }
+
+  // Failed turn: the target user msg never reached the gateway, so any
+  // truncation address would mis-aim (#86573/#86623) — resubmit plainly.
+  const isFailedTurn = isFailedUserTurn(messages, sourceIndex)
 
   const truncateOrdinal =
     target?.userOrdinal === null || target?.userOrdinal === undefined
       ? visibleUserOrdinal(messages, sourceIndex)
       : target.userOrdinal
 
-  return { sourceIndex, text, truncateOrdinal, truncateMessageId: source.id, truncateRowId: source.rowId }
+  return {
+    sourceIndex,
+    sourceText: sourceText || text,
+    text,
+    truncateOrdinal: isFailedTurn ? undefined : truncateOrdinal,
+    truncateMessageId: isFailedTurn ? undefined : source.id,
+    truncateRowId: isFailedTurn ? undefined : source.rowId
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -391,6 +526,8 @@ export interface EditPlan {
   editedMessage: ChatMessage
   isFailedTurn: boolean
   sourceIndex: number
+  /** Original persisted text of the edited turn — the durable-row-id content key. */
+  sourceText: string
   text: string
   truncateOrdinal: number | undefined
   truncateMessageId?: string
@@ -415,13 +552,13 @@ export function planEdit(messages: ChatMessage[], edited: AppendMessage): EditPl
 
   // Failed turn: the optimistic user msg never reached the gateway, so a
   // truncate-by-ordinal would 422 — resubmit plainly instead.
-  const nextMessage = messages[sourceIndex + 1]
-  const isFailedTurn = nextMessage?.role === 'assistant' && Boolean(nextMessage.error)
+  const isFailedTurn = isFailedUserTurn(messages, sourceIndex)
 
   return {
     editedMessage: { ...source, parts: [textPart(text)] },
     isFailedTurn,
     sourceIndex,
+    sourceText: chatMessageText(source).trim(),
     text,
     truncateOrdinal: isFailedTurn ? undefined : visibleUserOrdinal(messages, sourceIndex),
     truncateMessageId: isFailedTurn ? undefined : source.id,

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/utils.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/utils.ts
@@ -603,28 +603,45 @@ export function isVisibleUserMessage(message: ChatMessage): boolean {
   return message.role === 'user' && !message.hidden
 }
 
+/**
+ * A user turn whose submit failed: the optimistic bubble stayed in the
+ * transcript (followed by an assistant error), but the turn never reached the
+ * gateway, so it does not exist in backend history. Every backend-facing
+ * user-turn count must skip these or every later ordinal overshoots the
+ * gateway's index and the rewind mis-aims / gets refused (#41275, #86573).
+ */
+export function isFailedUserTurn(messages: readonly ChatMessage[], index: number): boolean {
+  const next = messages[index + 1]
+
+  return next?.role === 'assistant' && Boolean(next.error)
+}
+
+/**
+ * Indices of the user turns the backend also knows about — visible AND not
+ * failed. This is the ONE ordinal space shared with the gateway: truncate
+ * ordinals, ordinal→index resolution, survivor-rowId rebinding, and durable
+ * row-id resolution all iterate exactly this list.
+ */
+export function visibleUserMessageIndices(messages: readonly ChatMessage[]): number[] {
+  const indices: number[] = []
+
+  for (let index = 0; index < messages.length; index += 1) {
+    if (isVisibleUserMessage(messages[index]) && !isFailedUserTurn(messages, index)) {
+      indices.push(index)
+    }
+  }
+
+  return indices
+}
+
 export function visibleUserOrdinal(messages: readonly ChatMessage[], end: number): number {
-  return messages.slice(0, end).filter(isVisibleUserMessage).length
+  return visibleUserMessageIndices(messages).filter(index => index < end).length
 }
 
 export function visibleUserIndexAtOrdinal(messages: readonly ChatMessage[], targetOrdinal: number): number {
-  let ordinal = 0
+  const indices = visibleUserMessageIndices(messages)
 
-  for (let index = 0; index < messages.length; index += 1) {
-    const message = messages[index]
-
-    if (!isVisibleUserMessage(message)) {
-      continue
-    }
-
-    if (ordinal === targetOrdinal) {
-      return index
-    }
-
-    ordinal += 1
-  }
-
-  return -1
+  return targetOrdinal >= 0 && targetOrdinal < indices.length ? indices[targetOrdinal] : -1
 }
 
 export interface SubmitTextOptions {

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -12956,6 +12956,42 @@ def test_session_history_uses_session_profile_db(monkeypatch, tmp_path):
         server._sessions.pop("sid", None)
 
 
+def test_session_history_ships_durable_row_ids(monkeypatch):
+    """session.history must request row-id stamps — clients resolve truncation
+    targets by content against this projection (#87059 client half)."""
+    seen: dict = {}
+
+    class _Db:
+        def get_messages_as_conversation(self, _key, include_ancestors=False, include_row_ids=False, **_kwargs):
+            seen["include_row_ids"] = include_row_ids
+
+            return [
+                {"role": "user", "content": "hello", "_row_id": 41},
+                {"role": "assistant", "content": "hi"},
+            ]
+
+    server._sessions["rowid-hist-sid"] = {
+        "session_key": "rowid-sess",
+        "history": [],
+        "history_lock": __import__("threading").Lock(),
+        "running": False,
+        "agent": None,
+        "created_at": 1.0,
+        "last_active": 1.0,
+    }
+    monkeypatch.setattr(server, "_get_db", lambda: _Db())
+    try:
+        resp = server.handle_request(
+            {"id": "1", "method": "session.history", "params": {"session_id": "rowid-hist-sid"}}
+        )
+        assert "result" in resp, resp
+        assert seen.get("include_row_ids") is True
+        user_rows = [m for m in resp["result"]["messages"] if m.get("role") == "user"]
+        assert user_rows and user_rows[0].get("row_id") == 41
+    finally:
+        server._sessions.pop("rowid-hist-sid", None)
+
+
 def test_session_status_uses_session_profile_db(monkeypatch, tmp_path):
     """session.status must load meta from the session profile state.db."""
     profile_home = tmp_path / "profiles" / "mlperf"

--- a/tui_gateway/methods_session.py
+++ b/tui_gateway/methods_session.py
@@ -2493,8 +2493,16 @@ def _(rid, params: dict) -> dict:
         with _session_db(session) as db:
             if db is not None:
                 try:
+                    # include_row_ids: the durable row id is how clients address
+                    # a specific persisted turn (reactions, and the Desktop's
+                    # content-based truncation-target resolution — #87059). The
+                    # projection in _history_to_messages only forwards row_id
+                    # when the row carries a stamp, so an unstamped read here
+                    # silently strips the one durable address clients can use.
                     history = db.get_messages_as_conversation(
-                        session["session_key"], include_ancestors=True
+                        session["session_key"],
+                        include_ancestors=True,
+                        include_row_ids=True,
                     )
                 except Exception:
                     pass


### PR DESCRIPTION
## Summary

Desktop rewind/edit/regenerate now always addresses the turn it means: every truncating `prompt.submit` carries a durable `truncate_before_row_id`, resolved by content from the gateway's stamped transcript when the bubble never learned its id — and when no durable address can be proven, the client degrades to a plain resubmit instead of a guessed cut. Client half of #87059 (the gateway half, #87150, fails ordinal-only truncation closed; this PR removes the user-facing error that fail-closed left behind).

Root cause recap: the renderer counts visible user bubbles while the gateway counts persisted user rows (synthetic injections, failed turns) — the two ordinal spaces diverge, and an edit of an interrupted turn had no bound rowId, so the Desktop fell back to ordinal-only addressing (78-message mis-cut in #87059; refused with 4004 since #87150).

## Changes

- `use-prompt-actions/rewind.ts`:
  - `resolveDurableRowId()` — resolves a turn's durable row id by exact content match against `session.history` (which ships `row_id` per persisted row). Exact-or-nothing: unique match wins; ambiguity accepted only when the target is provably the newest persisted turn (the edit-after-interrupt shape); anything else → no truncation.
  - `runRewindSubmit()` — when a truncation request lacks a durable address, resolve first; on failure degrade to a plain resubmit. The divergent client ordinal is dropped either way.
  - `planReload`/`planRestore` — degrade failed turns to plain resubmit (extends #86623's `planEdit` pattern); all plans carry `sourceText` as the content key.
  - `rebindSurvivorRowIds` — iterates the same failed-turn-aware ordinal space as the truncate math.
- `use-prompt-actions/utils.ts`: `visibleUserMessageIndices()` — the ONE backend-facing ordinal space (visible AND persisted), shared by ordinal math, ordinal→index resolution, and survivor rebinding. Failed turns are skipped (salvages #41275 by @vondelomlo, relocated onto the split modules).
- `session-tile-actions.ts`: tile regenerate goes through the shared `runRewindSubmit` primitive instead of a raw `prompt.submit`, so both surfaces keep the same discipline.

## Validation

| Scenario | Before | After |
|---|---|---|
| Edit after interrupted turn (no bound rowId) | ordinal-only → 4004 error (post-#87150) / 78-msg mis-cut (pre) | row id resolved by content → exact 1-turn cut |
| Unresolvable target (ambiguous/missing content) | mis-aimed cut or error | plain resubmit, history untouched |
| Regenerate after a failed turn | every later ordinal overshoots (4018, regenerate dead) | failed turns excluded from ordinal space |
| Tests | — | 825/825 desktop vitest pass; typecheck (3 tsconfigs) + eslint 0 errors |

## Attribution

Commit 1 salvages #41275 (@vondelomlo) — failed-turn ordinal skip — preserved as author.

## Infographic

Infographic generation temporarily unavailable (image backend balance exhausted at PR time); will be added by `gh pr edit` when the backend recovers.
