### PR TITLE
feat(sessions): organize sessions with AI-assisted groups

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -12477,7 +12477,7 @@ def main():
     # =========================================================================
     sessions_parser = subparsers.add_parser(
         "sessions",
-        help="Manage session history (list, rename, export, prune, delete)",
+        help="Manage session history (list, group, rename, export, prune, delete)",
         description="View and manage the SQLite session store",
     )
     sessions_subparsers = sessions_parser.add_subparsers(dest="sessions_action")
@@ -12879,6 +12879,34 @@ def main():
     )
 
     sessions_subparsers.add_parser("stats", help="Show session store statistics")
+
+    sessions_group = sessions_subparsers.add_parser(
+        "group", help="Create groups and organize sessions into them"
+    )
+    sessions_group_subparsers = sessions_group.add_subparsers(dest="group_action")
+    sessions_group_create = sessions_group_subparsers.add_parser(
+        "create", help="Create a named session group"
+    )
+    sessions_group_create.add_argument("name", help="Group name")
+    sessions_group_create.add_argument("--color", help="Optional display color")
+    sessions_group_subparsers.add_parser("list", help="List session groups")
+    sessions_group_add = sessions_group_subparsers.add_parser(
+        "add", help="Move one or more sessions into a group"
+    )
+    sessions_group_add.add_argument("group", help="Group name or ID")
+    sessions_group_add.add_argument("session_ids", nargs="+", help="Session IDs or unique prefixes")
+    sessions_group_remove = sessions_group_subparsers.add_parser(
+        "remove", help="Remove one or more sessions from a group"
+    )
+    sessions_group_remove.add_argument("group", help="Group name or ID")
+    sessions_group_remove.add_argument("session_ids", nargs="+", help="Session IDs or unique prefixes")
+    sessions_group_delete = sessions_group_subparsers.add_parser(
+        "delete", help="Delete a group without deleting its sessions"
+    )
+    sessions_group_delete.add_argument("group", help="Group name or ID")
+    sessions_group_delete.add_argument(
+        "--yes", "-y", action="store_true", help="Skip confirmation"
+    )
 
     sessions_rename = sessions_subparsers.add_parser(
         "rename", help="Set or change a session's title"

--- a/hermes_cli/sessions_cmd.py
+++ b/hermes_cli/sessions_cmd.py
@@ -855,6 +855,51 @@ def cmd_sessions(args, sessions_parser=None):
                 exported += 1
         print(f"Exported {exported} session(s) to {output_dir}")
 
+    elif action == "group":
+        group_action = getattr(args, "group_action", None)
+        try:
+            if group_action == "create":
+                group = db.create_session_group(args.name, color=args.color)
+                print(f"Created session group '{group['name']}' ({group['id']}).")
+            elif group_action == "list":
+                groups = db.list_session_groups()
+                if not groups:
+                    print("No session groups found.")
+                else:
+                    print(f"{'Name':<30} {'Sessions':>8}  {'Color':<12} ID")
+                    print("─" * 78)
+                    for group in groups:
+                        print(
+                            f"{group['name'][:28]:<30} {group['session_count']:>8}  "
+                            f"{(group.get('color') or '—')[:10]:<12} {group['id']}"
+                        )
+            elif group_action in {"add", "remove"}:
+                resolved = []
+                for candidate in args.session_ids:
+                    session_id = db.resolve_session_id(candidate)
+                    if not session_id:
+                        raise ValueError(f"session not found: {candidate}")
+                    resolved.append(session_id)
+                if group_action == "add":
+                    count = db.assign_sessions_to_group(args.group, resolved)
+                    print(f"Added {count} session(s) to group '{args.group}'.")
+                else:
+                    count = db.remove_sessions_from_group(args.group, resolved)
+                    print(f"Removed {count} session(s) from group '{args.group}'.")
+            elif group_action == "delete":
+                if not args.yes and not _confirm_prompt(
+                    f"Delete session group '{args.group}'? Sessions will be kept. [y/N] "
+                ):
+                    print("Cancelled.")
+                elif db.delete_session_group(args.group):
+                    print(f"Deleted session group '{args.group}'. Sessions were kept.")
+                else:
+                    print(f"Session group '{args.group}' not found.")
+            else:
+                print("Use: hermes sessions group {create,list,add,remove,delete} ...")
+        except ValueError as exc:
+            print(f"Error: {exc}")
+
     elif action == "delete":
         resolved_session_id = db.resolve_session_id(args.session_id)
         if not resolved_session_id:

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -8416,6 +8416,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         include_pinned: bool = False,
         session_key: str = None,
         include_hidden: bool = False,
+        session_group_id: str = None,
     ) -> List[Dict[str, Any]]:
         """List sessions with preview (first user message) and last active timestamp.
 
@@ -8470,6 +8471,10 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         Pass ``session_key`` to restrict results to one stable gateway
         conversation scope (DM, group, channel, or thread, including the
         configured per-user isolation policy).
+
+        Pass ``session_group_id`` to restrict the SQL page to conversations
+        whose surfaced row or compression-chain continuation belongs to that
+        group. The predicate is applied before LIMIT/OFFSET.
         """
         # Rows carry token/cost totals — drain queued deltas first so
         # listings (sidebar, /resume, dashboards) show exact counters.
@@ -8600,6 +8605,13 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                     )
                     id_params.append(_like_pattern(compact_needle))
                 filter_clauses.append(search_clause + "))")
+            if session_group_id:
+                filter_clauses.append(
+                    "EXISTS (SELECT 1 FROM chain gq"
+                    " JOIN session_group_members gm ON gm.session_id = gq.cur_id"
+                    " WHERE gq.root_id = s.id AND gm.group_id = ?)"
+                )
+                id_params.append(session_group_id)
             if filter_clauses:
                 combined = " AND ".join(filter_clauses)
                 outer_where = (
@@ -8647,6 +8659,17 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             # only applies to the outer select.
             params = params + params + id_params + [limit, offset]
         else:
+            if session_group_id:
+                group_clause = (
+                    "s.id IN (SELECT session_id FROM session_group_members "
+                    "WHERE group_id = ?)"
+                )
+                where_sql = (
+                    f"{where_sql} AND {group_clause}"
+                    if where_sql
+                    else f"WHERE {group_clause}"
+                )
+                params.append(session_group_id)
             _sel = self._compact_session_cols() if compact_rows else "s.*"
             query = f"""
                 SELECT {_sel}{prompt_select},
@@ -10695,6 +10718,12 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 "GROUP BY g.id ORDER BY g.created_at ASC, g.name COLLATE NOCASE ASC"
             ).fetchall()
         return [dict(row) for row in rows]
+
+    def get_session_group(self, id_or_name: str) -> Optional[Dict[str, Any]]:
+        """Return one group by id or case-insensitive name."""
+        with self._lock:
+            row = self._resolve_session_group(self._conn, id_or_name)
+        return dict(row) if row is not None else None
 
     def session_ids_for_group(self, id_or_name: str) -> Optional[Set[str]]:
         """Return member ids, or ``None`` when the requested group is unknown."""

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -25,6 +25,7 @@ import os
 import queue
 import random
 import re
+import secrets
 import sqlite3
 import sys
 import threading
@@ -10639,6 +10640,137 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                     ids,
                 )
             return len(ids)
+
+        return self._execute_write(_do)
+
+    # =========================================================================
+    # Session groups
+    # =========================================================================
+
+    def create_session_group(self, name: str, color: str = None) -> Dict[str, Any]:
+        """Create a named session group and return its persisted metadata."""
+        group_name = str(name or "").strip()
+        if not group_name:
+            raise ValueError("session group name must not be empty")
+        if len(group_name) > 80:
+            raise ValueError("session group name must be at most 80 characters")
+        group_color = str(color or "").strip() or None
+        group_id = "sg_" + secrets.token_hex(4)
+        created_at = time.time()
+
+        def _do(conn):
+            conn.execute(
+                "INSERT INTO session_groups (id, name, color, created_at) VALUES (?, ?, ?, ?)",
+                (group_id, group_name, group_color, created_at),
+            )
+            return {
+                "id": group_id,
+                "name": group_name,
+                "color": group_color,
+                "created_at": created_at,
+                "session_count": 0,
+            }
+
+        try:
+            return self._execute_write(_do)
+        except sqlite3.IntegrityError as exc:
+            raise ValueError(f"session group already exists: {group_name}") from exc
+
+    def _resolve_session_group(self, conn, id_or_name: str):
+        key = str(id_or_name or "").strip()
+        if not key:
+            return None
+        return conn.execute(
+            "SELECT id, name, color, created_at FROM session_groups "
+            "WHERE id = ? OR name = ? COLLATE NOCASE",
+            (key, key),
+        ).fetchone()
+
+    def list_session_groups(self) -> List[Dict[str, Any]]:
+        """List groups with member counts, oldest groups first."""
+        with self._lock:
+            rows = self._conn.execute(
+                "SELECT g.id, g.name, g.color, g.created_at, COUNT(m.session_id) AS session_count "
+                "FROM session_groups g LEFT JOIN session_group_members m ON m.group_id = g.id "
+                "GROUP BY g.id ORDER BY g.created_at ASC, g.name COLLATE NOCASE ASC"
+            ).fetchall()
+        return [dict(row) for row in rows]
+
+    def session_ids_for_group(self, id_or_name: str) -> Optional[Set[str]]:
+        """Return member ids, or ``None`` when the requested group is unknown."""
+        with self._lock:
+            group = self._resolve_session_group(self._conn, id_or_name)
+            if group is None:
+                return None
+            rows = self._conn.execute(
+                "SELECT session_id FROM session_group_members WHERE group_id = ?",
+                (group["id"],),
+            ).fetchall()
+        return {str(row["session_id"]) for row in rows}
+
+    def assign_sessions_to_group(
+        self, id_or_name: str, session_ids: List[str]
+    ) -> int:
+        """Move existing sessions into one group. Returns assignments applied."""
+        unique_ids = list(dict.fromkeys(str(s).strip() for s in session_ids if str(s).strip()))
+        if not unique_ids:
+            return 0
+
+        def _do(conn):
+            group = self._resolve_session_group(conn, id_or_name)
+            if group is None:
+                raise ValueError(f"session group not found: {id_or_name}")
+            placeholders = ",".join("?" for _ in unique_ids)
+            existing = {
+                row["id"]
+                for row in conn.execute(
+                    f"SELECT id FROM sessions WHERE id IN ({placeholders})", unique_ids
+                ).fetchall()
+            }
+            missing = [sid for sid in unique_ids if sid not in existing]
+            if missing:
+                raise ValueError(f"session not found: {missing[0]}")
+            now = time.time()
+            conn.executemany(
+                "INSERT INTO session_group_members (session_id, group_id, added_at) "
+                "VALUES (?, ?, ?) ON CONFLICT(session_id) DO UPDATE SET "
+                "group_id = excluded.group_id, added_at = excluded.added_at",
+                [(sid, group["id"], now) for sid in unique_ids],
+            )
+            return len(unique_ids)
+
+        return self._execute_write(_do)
+
+    def remove_sessions_from_group(
+        self, id_or_name: str, session_ids: List[str]
+    ) -> int:
+        """Remove selected sessions from a group without deleting either."""
+        unique_ids = list(dict.fromkeys(str(s).strip() for s in session_ids if str(s).strip()))
+        if not unique_ids:
+            return 0
+
+        def _do(conn):
+            group = self._resolve_session_group(conn, id_or_name)
+            if group is None:
+                raise ValueError(f"session group not found: {id_or_name}")
+            placeholders = ",".join("?" for _ in unique_ids)
+            cur = conn.execute(
+                f"DELETE FROM session_group_members WHERE group_id = ? "
+                f"AND session_id IN ({placeholders})",
+                [group["id"], *unique_ids],
+            )
+            return cur.rowcount
+
+        return self._execute_write(_do)
+
+    def delete_session_group(self, id_or_name: str) -> bool:
+        """Delete a group while leaving all member sessions intact."""
+        def _do(conn):
+            group = self._resolve_session_group(conn, id_or_name)
+            if group is None:
+                return False
+            conn.execute("DELETE FROM session_group_members WHERE group_id = ?", (group["id"],))
+            return conn.execute("DELETE FROM session_groups WHERE id = ?", (group["id"],)).rowcount > 0
 
         return self._execute_write(_do)
 

--- a/hermes_state_common.py
+++ b/hermes_state_common.py
@@ -392,6 +392,19 @@ CREATE TABLE IF NOT EXISTS session_turn_leases (
     expires_at REAL NOT NULL
 );
 
+CREATE TABLE IF NOT EXISTS session_groups (
+    id TEXT PRIMARY KEY,
+    name TEXT NOT NULL COLLATE NOCASE UNIQUE,
+    color TEXT,
+    created_at REAL NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS session_group_members (
+    session_id TEXT PRIMARY KEY REFERENCES sessions(id) ON DELETE CASCADE,
+    group_id TEXT NOT NULL REFERENCES session_groups(id) ON DELETE CASCADE,
+    added_at REAL NOT NULL
+);
+
 CREATE TABLE IF NOT EXISTS async_delegations (
     delegation_id TEXT PRIMARY KEY,
     origin_session TEXT NOT NULL,
@@ -429,6 +442,8 @@ CREATE INDEX IF NOT EXISTS idx_messages_assistant_calls_by_session
     WHERE role = 'assistant' AND tool_calls IS NOT NULL;
 CREATE INDEX IF NOT EXISTS idx_compression_locks_expires ON compression_locks(expires_at);
 CREATE INDEX IF NOT EXISTS idx_session_turn_leases_expires ON session_turn_leases(expires_at);
+CREATE INDEX IF NOT EXISTS idx_session_group_members_group
+    ON session_group_members(group_id, added_at DESC);
 CREATE INDEX IF NOT EXISTS idx_session_model_usage_session ON session_model_usage(session_id);
 CREATE INDEX IF NOT EXISTS idx_session_model_usage_model ON session_model_usage(model);
 CREATE INDEX IF NOT EXISTS idx_async_delegations_delivery

--- a/hermes_state_search.py
+++ b/hermes_state_search.py
@@ -1552,12 +1552,22 @@ class SessionSearchMixin:
     def _append_session_group_filter(
         where: List[str], params: List[Any], session_group_id: Optional[str]
     ) -> None:
-        """Push session-group membership into a message query before LIMIT."""
+        """Push lineage-aware session-group membership before LIMIT."""
         if not session_group_id:
             return
         where.append(
-            "m.session_id IN (SELECT session_id FROM session_group_members "
-            "WHERE group_id = ?)"
+            "EXISTS ("
+            " WITH RECURSIVE lineage(id, parent_id) AS ("
+            "   SELECT s.id, s.parent_session_id FROM sessions s"
+            "   WHERE s.id = m.session_id"
+            "   UNION"
+            "   SELECT p.id, p.parent_session_id FROM sessions p"
+            "   JOIN lineage l ON p.id = l.parent_id"
+            " )"
+            " SELECT 1 FROM lineage l"
+            " JOIN session_group_members gm ON gm.session_id = l.id"
+            " WHERE gm.group_id = ?"
+            ")"
         )
         params.append(session_group_id)
 

--- a/hermes_state_search.py
+++ b/hermes_state_search.py
@@ -1345,6 +1345,7 @@ class SessionSearchMixin:
         role_filter: List[str] = None,
         limit: int = 20,
         offset: int = 0,
+        session_group_id: str = None,
     ) -> Optional[List[Dict[str, Any]]]:
         """Run a search against a substring-capable FTS index.
 
@@ -1384,6 +1385,9 @@ class SessionSearchMixin:
         if role_filter:
             tri_where.append(f"m.role IN ({','.join('?' for _ in role_filter)})")
             tri_params.extend(role_filter)
+        self._append_session_group_filter(
+            tri_where, tri_params, session_group_id
+        )
         tri_sql = f"""
             SELECT
                 m.id,
@@ -1422,6 +1426,7 @@ class SessionSearchMixin:
         sort: str = None,
         include_inactive: bool = False,
         fields: Optional[Collection[str]] = None,
+        session_group_id: str = None,
     ) -> List[Dict[str, Any]]:
         """Instrumented wrapper around :meth:`_search_messages_impl`.
 
@@ -1444,6 +1449,7 @@ class SessionSearchMixin:
                 sort=sort,
                 include_inactive=include_inactive,
                 fields=fields,
+                session_group_id=session_group_id,
             )
             return rows
         finally:
@@ -1542,6 +1548,19 @@ class SessionSearchMixin:
 
         return " OR ".join(compiled_groups), params, snippet_term
 
+    @staticmethod
+    def _append_session_group_filter(
+        where: List[str], params: List[Any], session_group_id: Optional[str]
+    ) -> None:
+        """Push session-group membership into a message query before LIMIT."""
+        if not session_group_id:
+            return
+        where.append(
+            "m.session_id IN (SELECT session_id FROM session_group_members "
+            "WHERE group_id = ?)"
+        )
+        params.append(session_group_id)
+
     def _search_messages_like_fallback(
         self,
         query: str,
@@ -1553,6 +1572,7 @@ class SessionSearchMixin:
         offset: int,
         sort: Optional[str],
         include_inactive: bool,
+        session_group_id: Optional[str],
     ) -> List[Dict[str, Any]]:
         """Search canonical messages while derived FTS state is stale."""
         predicate, params, snippet_term = self._compile_like_boolean_query(query)
@@ -1573,6 +1593,7 @@ class SessionSearchMixin:
         if role_filter:
             where.append(f"m.role IN ({','.join('?' for _ in role_filter)})")
             params.extend(role_filter)
+        self._append_session_group_filter(where, params, session_group_id)
 
         order = (
             "ASC"
@@ -1716,6 +1737,7 @@ class SessionSearchMixin:
         sort: str = None,
         include_inactive: bool = False,
         fields: Optional[Collection[str]] = None,
+        session_group_id: str = None,
     ) -> List[Dict[str, Any]]:
         """
         Full-text search across session messages using FTS5.
@@ -1768,6 +1790,7 @@ class SessionSearchMixin:
                 offset=offset,
                 sort=sort,
                 include_inactive=include_inactive,
+                session_group_id=session_group_id,
             )
             return self._finalize_search_matches(
                 matches, result_fields=result_fields
@@ -1817,6 +1840,10 @@ class SessionSearchMixin:
             role_placeholders = ",".join("?" for _ in role_filter)
             where_clauses.append(f"m.role IN ({role_placeholders})")
             params.extend(role_filter)
+
+        self._append_session_group_filter(
+            where_clauses, params, session_group_id
+        )
 
         where_sql = " AND ".join(where_clauses)
         params.extend([limit, offset])
@@ -1910,6 +1937,9 @@ class SessionSearchMixin:
                 if role_filter:
                     cjk_where.append(f"m.role IN ({','.join('?' for _ in role_filter)})")
                     cjk_params.extend(role_filter)
+                self._append_session_group_filter(
+                    cjk_where, cjk_params, session_group_id
+                )
                 cjk_sql = f"""
                     SELECT
                         m.id,
@@ -1998,6 +2028,9 @@ class SessionSearchMixin:
                 if role_filter:
                     tri_where.append(f"m.role IN ({','.join('?' for _ in role_filter)})")
                     tri_params.extend(role_filter)
+                self._append_session_group_filter(
+                    tri_where, tri_params, session_group_id
+                )
                 tri_sql = f"""
                     SELECT
                         m.id,
@@ -2091,6 +2124,9 @@ class SessionSearchMixin:
                 if role_filter:
                     like_where.append(f"m.role IN ({','.join('?' for _ in role_filter)})")
                     like_params.extend(role_filter)
+                self._append_session_group_filter(
+                    like_where, like_params, session_group_id
+                )
                 like_sql = f"""
                     SELECT m.id, m.session_id, m.role,
                            substr(m.content,
@@ -2150,6 +2186,7 @@ class SessionSearchMixin:
                     source_filter=source_filter,
                     exclude_sources=exclude_sources,
                     role_filter=role_filter,
+                    session_group_id=session_group_id,
                 )
                 seen_ids = {m["id"] for m in matches}
                 matches.extend(m for m in gap_matches if m["id"] not in seen_ids)
@@ -2190,6 +2227,7 @@ class SessionSearchMixin:
                     role_filter=role_filter,
                     limit=limit,
                     offset=offset,
+                    session_group_id=session_group_id,
                 )
                 if cjk_fb:
                     matches = cjk_fb
@@ -2207,6 +2245,7 @@ class SessionSearchMixin:
                     role_filter=role_filter,
                     limit=limit,
                     offset=offset,
+                    session_group_id=session_group_id,
                 )
                 if tri_matches:
                     matches = tri_matches
@@ -2222,6 +2261,7 @@ class SessionSearchMixin:
         source_filter: Optional[List[str]] = None,
         exclude_sources: Optional[List[str]] = None,
         role_filter: Optional[List[str]] = None,
+        session_group_id: Optional[str] = None,
     ) -> List[Dict[str, Any]]:
         """LIKE-scan the rows the deferred rebuild hasn't indexed yet.
 
@@ -2267,6 +2307,7 @@ class SessionSearchMixin:
         if role_filter:
             where.append(f"m.role IN ({','.join('?' for _ in role_filter)})")
             params.extend(role_filter)
+        self._append_session_group_filter(where, params, session_group_id)
 
         sql = f"""
             SELECT m.id, m.session_id, m.role,

--- a/skills/productivity/session-librarian/SKILL.md
+++ b/skills/productivity/session-librarian/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: session-librarian
-description: "Organize sessions by prompt: find, rename, archive, prune."
+description: "Organize sessions by prompt: group, find, rename, archive, prune."
 version: 1.0.0
 author: Hermes Agent + Teknium
 license: MIT
@@ -29,6 +29,7 @@ always shows the plan before touching anything.
 - "What sessions do I have about X?" / "What did we decide about X?"
 - "Rename these sessions to something meaningful."
 - "Clean up my session library" / "archive the stale ones."
+- "Organize my sessions" / "group these sessions by project."
 - "Fork that session into a follow-up focused on Y."
 - "Split this into one session per ticket" (see Parallel workstreams below).
 
@@ -38,6 +39,9 @@ always shows the plan before touching anything.
 |---|---|
 | Find sessions by topic, read content, summarize decisions | `session_search` tool (FTS5 over the message store) |
 | List/filter by metadata (age, source, cost, tokens, workspace) | `hermes sessions list` / `stats` via terminal |
+| Create/list groups | `hermes sessions group create/list` |
+| Add/remove group members | `hermes sessions group add/remove <group> <session-id...>` |
+| Search inside a group | `session_search(query=..., group="Group name")` |
 | Rename | `hermes sessions rename <session_id> <title...>` |
 | Bulk soft-hide (reversible) | `hermes sessions archive <filters>` |
 | Delete (destructive) | `hermes sessions delete` / `hermes sessions prune <filters>` |
@@ -63,6 +67,18 @@ which are proposed for deletion and why (duplicate of which keeper, stale,
 empty). Wait for the user's go-ahead. Exception: a single rename the user
 explicitly dictated can be done directly.
 
+For **"organize/group my sessions"**, use titles plus the short previews from
+`hermes sessions list` and targeted `session_search` results — never dump every
+full transcript into context. Propose a table with group name, optional color,
+session links/IDs, and a separate **Unsorted** list for weak matches. Do not
+create groups or move sessions until the user confirms the plan. After
+confirmation, create only missing groups, then apply membership in batches:
+
+```bash
+hermes sessions group create "Startup" --color blue
+hermes sessions group add "Startup" <session-id> <session-id> ...
+```
+
 ④ **Act with the safest primitive.**
 - Prefer `archive` (reversible soft-hide) over `delete`/`prune`.
 - Always run destructive commands with `--dry-run` first and show the output,
@@ -73,6 +89,7 @@ explicitly dictated can be done directly.
 ⑤ **Report.** Renames applied, sessions archived (count + how to undo:
 archived sessions remain in the DB and are listed with `--include-archived`),
 anything exported, anything skipped and why.
+For grouping, report each group's member count and leave Unsorted untouched.
 
 ## Parallel Workstreams
 

--- a/skills/productivity/session-librarian/SKILL.md
+++ b/skills/productivity/session-librarian/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: session-librarian
-description: "Organize sessions by prompt: group, find, rename, archive, prune."
+description: "Organize sessions by prompt: group, find, rename, archive."
 version: 1.0.0
 author: Hermes Agent + Teknium
 license: MIT

--- a/tests/state/test_session_groups.py
+++ b/tests/state/test_session_groups.py
@@ -1,0 +1,48 @@
+import pytest
+
+from hermes_state import SessionDB
+
+
+@pytest.fixture
+def db(tmp_path):
+    database = SessionDB(tmp_path / "state.db")
+    try:
+        yield database
+    finally:
+        database.close()
+
+
+def test_membership_moves_between_groups_and_preserves_sessions(db):
+    db.create_session("grouped-a", source="cli")
+    db.create_session("grouped-b", source="cli")
+    first = db.create_session_group("Startup", color="blue")
+    second = db.create_session_group("Job Hunt")
+
+    assert db.assign_sessions_to_group(first["id"], ["grouped-a", "grouped-b"]) == 2
+    assert db.session_ids_for_group("startup") == {"grouped-a", "grouped-b"}
+
+    assert db.assign_sessions_to_group(second["id"], ["grouped-b"]) == 1
+    assert db.session_ids_for_group(first["id"]) == {"grouped-a"}
+    assert db.session_ids_for_group("Job Hunt") == {"grouped-b"}
+
+    assert db.remove_sessions_from_group("Job Hunt", ["grouped-b"]) == 1
+    assert db.delete_session_group("Startup") is True
+    assert db.get_session("grouped-a") is not None
+    assert db.get_session("grouped-b") is not None
+
+
+def test_assignment_rejects_unknown_session_atomically(db):
+    db.create_session("known", source="cli")
+    db.create_session_group("Project")
+
+    with pytest.raises(ValueError, match="session not found: missing"):
+        db.assign_sessions_to_group("Project", ["known", "missing"])
+
+    assert db.session_ids_for_group("Project") == set()
+
+
+def test_duplicate_group_name_is_case_insensitive(db):
+    db.create_session_group("Startup")
+
+    with pytest.raises(ValueError, match="already exists"):
+        db.create_session_group("startup")

--- a/tests/tools/test_session_search.py
+++ b/tests/tools/test_session_search.py
@@ -99,7 +99,7 @@ class TestSchema:
             "sort",
             "profile",
         ]
-        assert parameters == [*historical_prefix, "detail"]
+        assert parameters == [*historical_prefix, "detail", "group"]
 
 
 class TestFormatTimestamp:
@@ -171,12 +171,39 @@ class TestBrowseShape:
         sids = [r["session_id"] for r in result["results"]]
         assert "s_newest" not in sids
 
+    def test_browse_can_be_scoped_to_a_session_group(self, db):
+        _seed_modpack_sessions(db)
+        db.create_session_group("Active Project")
+        db.assign_sessions_to_group("Active Project", ["s_middle"])
+
+        result = json.loads(session_search(db=db, group="active project"))
+
+        assert [row["session_id"] for row in result["results"]] == ["s_middle"]
+
 
 # =========================================================================
 # Discovery shape (with query)
 # =========================================================================
 
 class TestDiscoveryShape:
+    def test_discovery_can_be_scoped_to_a_session_group(self, db):
+        _seed_modpack_sessions(db)
+        db.create_session_group("Quest Work")
+        db.assign_sessions_to_group("Quest Work", ["s_middle"])
+
+        result = json.loads(
+            session_search(query="modpack", limit=3, db=db, group="Quest Work")
+        )
+
+        assert result["success"] is True
+        assert [row["session_id"] for row in result["results"]] == ["s_middle"]
+
+    def test_unknown_group_is_an_error(self, db):
+        result = json.loads(session_search(query="anything", db=db, group="missing"))
+
+        assert result["success"] is False
+        assert "session group not found" in result["error"]
+
     def test_discovery_field_plan_preserves_full_default_result(self, db, monkeypatch):
         _seed_modpack_sessions(db)
         original = db.search_messages

--- a/tests/tools/test_session_search.py
+++ b/tests/tools/test_session_search.py
@@ -237,6 +237,22 @@ class TestDiscoveryShape:
 
         assert [row["session_id"] for row in result["results"]] == ["grouped-old"]
 
+    def test_group_discovery_includes_matches_from_member_lineage(self, db):
+        db.create_session("grouped-root", source="cli")
+        db.create_session(
+            "continuation", source="cli", parent_session_id="grouped-root"
+        )
+        db.append_message("continuation", role="user", content="lineage needle")
+        db.create_session_group("Project")
+        db.assign_sessions_to_group("Project", ["grouped-root"])
+
+        result = json.loads(
+            session_search(query="lineage", db=db, group="Project", limit=3)
+        )
+
+        assert [row["session_id"] for row in result["results"]] == ["continuation"]
+        assert result["results"][0]["parent_session_id"] == "grouped-root"
+
     def test_unknown_group_is_an_error(self, db):
         result = json.loads(session_search(query="anything", db=db, group="missing"))
 

--- a/tests/tools/test_session_search.py
+++ b/tests/tools/test_session_search.py
@@ -180,6 +180,27 @@ class TestBrowseShape:
 
         assert [row["session_id"] for row in result["results"]] == ["s_middle"]
 
+    def test_group_browse_filters_before_global_recency_limit(self, db):
+        db.create_session("grouped-old", source="cli")
+        db._conn.execute(
+            "UPDATE sessions SET started_at = 1, last_activity_at = 1 "
+            "WHERE id = 'grouped-old'"
+        )
+        db.create_session_group("Old Project")
+        db.assign_sessions_to_group("Old Project", ["grouped-old"])
+        for index in range(20):
+            session_id = f"newer-{index}"
+            db.create_session(session_id, source="cli")
+            db._conn.execute(
+                "UPDATE sessions SET started_at = ?, last_activity_at = ? WHERE id = ?",
+                (100 + index, 100 + index, session_id),
+            )
+        db._conn.commit()
+
+        result = json.loads(session_search(db=db, group="Old Project", limit=3))
+
+        assert [row["session_id"] for row in result["results"]] == ["grouped-old"]
+
 
 # =========================================================================
 # Discovery shape (with query)
@@ -197,6 +218,24 @@ class TestDiscoveryShape:
 
         assert result["success"] is True
         assert [row["session_id"] for row in result["results"]] == ["s_middle"]
+
+    def test_group_discovery_filters_before_global_scan_limit(self, db):
+        db.create_session("grouped-old", source="cli")
+        db.append_message("grouped-old", role="user", content="needle")
+        db.create_session_group("Old Project")
+        db.assign_sessions_to_group("Old Project", ["grouped-old"])
+        for index in range(301):
+            session_id = f"newer-{index}"
+            db.create_session(session_id, source="cli")
+            db.append_message(session_id, role="user", content="needle")
+
+        result = json.loads(
+            session_search(
+                query="needle", sort="newest", db=db, group="Old Project", limit=3
+            )
+        )
+
+        assert [row["session_id"] for row in result["results"]] == ["grouped-old"]
 
     def test_unknown_group_is_an_error(self, db):
         result = json.loads(session_search(query="anything", db=db, group="missing"))

--- a/tools/session_search_tool.py
+++ b/tools/session_search_tool.py
@@ -488,6 +488,7 @@ def _list_recent_sessions(
     current_session_id: str = None,
     link_profile: str = None,
     group_session_ids: Optional[Set[str]] = None,
+    session_group_id: str = None,
 ) -> str:
     """Return metadata for the most recent sessions (no LLM calls, no FTS5)."""
     try:
@@ -502,6 +503,7 @@ def _list_recent_sessions(
             limit=limit + 15,
             exclude_sources=list(_HIDDEN_SESSION_SOURCES),
             order_by_last_active=True,
+            session_group_id=session_group_id,
         )  # fetch extra so we can skip current / compression roots
 
         current_root, has_compression_hop = (
@@ -512,8 +514,6 @@ def _list_recent_sessions(
         results = []
         for s in sessions:
             sid = s.get("id", "")
-            if group_session_ids is not None and sid not in group_session_ids:
-                continue
             if sid == current_session_id:
                 continue
             # Compression continuation: the root's original turns were
@@ -770,6 +770,7 @@ def _discover(
     current_session_id: str = None,
     link_profile: str = None,
     group_session_ids: Optional[Set[str]] = None,
+    session_group_id: str = None,
 ) -> str:
     """Discovery shape: FTS5 plus adaptive or full result hydration."""
     role_list = role_filter if role_filter else ["user", "assistant"]
@@ -792,6 +793,7 @@ def _discover(
             offset=0,
             sort=sort,
             fields=_DISCOVER_SEARCH_FIELDS,
+            session_group_id=session_group_id,
         )
     except Exception as e:
         logging.error("FTS5 search failed: %s", e, exc_info=True)
@@ -1011,10 +1013,13 @@ def _session_search_impl(
             current_session_id = None
 
     group_session_ids: Optional[Set[str]] = None
+    session_group_id: Optional[str] = None
     if isinstance(group, str) and group.strip():
-        group_session_ids = db.session_ids_for_group(group.strip())
-        if group_session_ids is None:
+        group_meta = db.get_session_group(group.strip())
+        if group_meta is None:
             return tool_error(f"session group not found: {group.strip()}", success=False)
+        session_group_id = group_meta["id"]
+        group_session_ids = db.session_ids_for_group(session_group_id)
 
     # Scroll shape takes precedence — explicit anchor beats any query.
     if (isinstance(session_id, str) and session_id.strip()) and around_message_id is not None:
@@ -1063,6 +1068,7 @@ def _session_search_impl(
             current_session_id,
             link_profile=profile,
             group_session_ids=group_session_ids,
+            session_group_id=session_group_id,
         )
 
     # Parse role_filter
@@ -1093,6 +1099,7 @@ def _session_search_impl(
         current_session_id=current_session_id,
         link_profile=profile,
         group_session_ids=group_session_ids,
+        session_group_id=session_group_id,
     )
 
 

--- a/tools/session_search_tool.py
+++ b/tools/session_search_tool.py
@@ -35,7 +35,7 @@ support.
 
 import json
 import logging
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional, Set, Union
 
 from hermes_state_common import _RESET_END_REASONS
 
@@ -482,7 +482,13 @@ def _read_session(db, session_id: str, head: int = 20, tail: int = 10, link_prof
     return json.dumps(response, ensure_ascii=False)
 
 
-def _list_recent_sessions(db, limit: int, current_session_id: str = None, link_profile: str = None) -> str:
+def _list_recent_sessions(
+    db,
+    limit: int,
+    current_session_id: str = None,
+    link_profile: str = None,
+    group_session_ids: Optional[Set[str]] = None,
+) -> str:
     """Return metadata for the most recent sessions (no LLM calls, no FTS5)."""
     try:
         # list_sessions_rich (include_children=False) already applies the
@@ -506,6 +512,8 @@ def _list_recent_sessions(db, limit: int, current_session_id: str = None, link_p
         results = []
         for s in sessions:
             sid = s.get("id", "")
+            if group_session_ids is not None and sid not in group_session_ids:
+                continue
             if sid == current_session_id:
                 continue
             # Compression continuation: the root's original turns were
@@ -761,11 +769,17 @@ def _discover(
     detail: str,
     current_session_id: str = None,
     link_profile: str = None,
+    group_session_ids: Optional[Set[str]] = None,
 ) -> str:
     """Discovery shape: FTS5 plus adaptive or full result hydration."""
     role_list = role_filter if role_filter else ["user", "assistant"]
     current_lineage_root = _resolve_lineage(db, current_session_id) if current_session_id else None
     title_result = _title_match_result(db, query, current_lineage_root)
+    if title_result and group_session_ids is not None:
+        title_sid = title_result.get("session_id")
+        title_root = title_result.get("_lineage_root")
+        if title_sid not in group_session_ids and title_root not in group_session_ids:
+            title_result = None
 
     try:
         raw_results = db.search_messages(
@@ -819,6 +833,12 @@ def _discover(
             break
         raw_sid = r["session_id"]
         resolved_sid, _ = _resolve_to_parent(db, raw_sid)
+        if (
+            group_session_ids is not None
+            and raw_sid not in group_session_ids
+            and resolved_sid not in group_session_ids
+        ):
+            continue
         # Skip the current session lineage — UNLESS the hit's transcript has
         # left live context. Three sub-cases:
         #
@@ -949,6 +969,7 @@ def _session_search_impl(
     profile: str = None,
     # Discovery result shaping (appended to preserve positional compatibility)
     detail: str = "adaptive",
+    group: str = None,
     *,
     _owned_dbs: Optional[List[Any]] = None,
 ) -> str:
@@ -988,6 +1009,12 @@ def _session_search_impl(
             if _owned_dbs is not None:
                 _owned_dbs.append(profile_db)
             current_session_id = None
+
+    group_session_ids: Optional[Set[str]] = None
+    if isinstance(group, str) and group.strip():
+        group_session_ids = db.session_ids_for_group(group.strip())
+        if group_session_ids is None:
+            return tool_error(f"session group not found: {group.strip()}", success=False)
 
     # Scroll shape takes precedence — explicit anchor beats any query.
     if (isinstance(session_id, str) and session_id.strip()) and around_message_id is not None:
@@ -1030,7 +1057,13 @@ def _session_search_impl(
 
     # Browse shape: no query → recent sessions.
     if not query or not isinstance(query, str) or not query.strip():
-        return _list_recent_sessions(db, limit, current_session_id, link_profile=profile)
+        return _list_recent_sessions(
+            db,
+            limit,
+            current_session_id,
+            link_profile=profile,
+            group_session_ids=group_session_ids,
+        )
 
     # Parse role_filter
     role_list: Optional[List[str]] = None
@@ -1059,6 +1092,7 @@ def _session_search_impl(
         detail=detail_norm,
         current_session_id=current_session_id,
         link_profile=profile,
+        group_session_ids=group_session_ids,
     )
 
 
@@ -1078,6 +1112,7 @@ def session_search(
     profile: str = None,
     # Discovery result shaping (appended to preserve positional compatibility)
     detail: str = "adaptive",
+    group: str = None,
 ) -> str:
     """Run session search and close databases opened by this invocation."""
     owned_dbs: List[Any] = []
@@ -1106,6 +1141,7 @@ def session_search(
             sort=sort,
             profile=profile,
             detail=detail,
+            group=group,
             _owned_dbs=owned_dbs,
         )
     finally:
@@ -1130,7 +1166,8 @@ SESSION_SEARCH_SCHEMA = {
     "description": (
         "Search past sessions stored in the local session DB, or scroll inside one. "
         "FTS5-backed retrieval over the SQLite message store. No LLM calls — every "
-        "shape returns actual messages from the DB.\n\n"
+        "shape returns actual messages from the DB. Discovery and browse can be "
+        "restricted to a named session group.\n\n"
         "SOURCE-FIRST LIMIT\n\n"
         "  This tool searches Hermes conversation history only. It is not evidence "
         "about the current contents of external sources. If the user provided a "
@@ -1290,6 +1327,13 @@ SESSION_SEARCH_SCHEMA = {
                     "Omit to use the current profile."
                 ),
             },
+            "group": {
+                "type": "string",
+                "description": (
+                    "Optional discovery/browse scope. Restrict results to sessions in "
+                    "this session-group name or ID."
+                ),
+            },
         },
         "required": [],
     },
@@ -1313,6 +1357,7 @@ registry.register(
         sort=args.get("sort"),
         detail=args.get("detail", "adaptive"),
         profile=args.get("profile"),
+        group=args.get("group"),
         db=kw.get("db"),
         current_session_id=kw.get("current_session_id"),
     ),


### PR DESCRIPTION
## What does this PR do?

This PR adds durable session groups that users and the agent can use to organize a flat session history by project or topic. It provides CLI group management, group-scoped `session_search`, and a session-librarian propose-confirm-apply workflow that uses titles and short previews instead of loading full transcripts.

### Motivation

Long-lived Hermes installations accumulate unrelated sessions in one chronological list. Search can retrieve known content, but it does not provide a persistent project-level structure or let later searches stay within one topic.

### Behavior

Users can create, list, and delete named groups, then add or remove sessions by ID or unique prefix. A session belongs to at most one group, while deleting a group leaves its sessions intact. The agent can browse or search within a named group and can propose an organization plan with an explicit Unsorted bucket before making any changes.

This change intentionally does not add Desktop sidebar rendering, drag-and-drop, or unsolicited reactive suggestions. Those remain separate UI and notification surfaces.

### Implementation

Session group metadata is stored in `state.db` with foreign-key cleanup and lineage-aware lookup. Group constraints are applied inside recency, FTS5, CJK/trigram, stale-index, and rebuild-gap queries before result limits so large global histories cannot starve valid group results. The existing `session_search` tool accepts an optional group name, and the bundled session-librarian skill documents the confirmation-first organization flow.

## Related Issue

Closes #87272

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Changes Made

- `hermes_state.py`, `hermes_state_common.py`, and `hermes_state_search.py` - persist group membership and apply lineage-aware group scope inside search queries.
- `hermes_cli/main.py` and `hermes_cli/sessions_cmd.py` - add `hermes sessions group create/list/add/remove/delete`.
- `tools/session_search_tool.py` - support group-scoped browse and discovery.
- `skills/productivity/session-librarian/SKILL.md` - define the AI-assisted propose-confirm-apply workflow.
- `tests/state/test_session_groups.py` and `tests/tools/test_session_search.py` - cover persistence, membership, result-limit starvation, and lineage behavior.

## How to Test

1. Create a group with `hermes sessions group create "Project Alpha" --color blue`.
2. Add sessions with `hermes sessions group add "Project Alpha" <session-id>...`, then verify `hermes sessions group list`.
3. Call `session_search` with `group="Project Alpha"` in browse and discovery modes and confirm results stay within the group.
4. Run the related test suites:

```bash
scripts/run_tests.sh tests/state/test_session_groups.py tests/tools/test_session_search.py tests/hermes_cli/test_sessions_delete.py
scripts/run_tests.sh tests/test_hermes_state.py -k search
```

Verified locally: 64 related tests passed, 19 state-search tests passed, the final 59-test session-search run passed, Ruff passed, and an isolated CLI create/add/list smoke test passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this feature (no unrelated commits)
- [x] I've run the repository test entry on the relevant suites and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation
- [x] Config example changes are N/A because this feature adds no config keys
- [x] Contributor guide changes are N/A because this feature does not change contributor workflows
- [x] I've considered cross-platform impact per the compatibility guide
- [x] I've updated the `session_search` tool description and schema

## Screenshots / Logs

N/A - this change adds storage, CLI, tool, and skill behavior without a new graphical surface.
