### PR TITLE
fix(cron): validate explicit toolset availability

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -3903,6 +3903,56 @@ def _preflight_check_provider_key(job: dict, cfg: dict) -> Optional[str]:
     return None
 
 
+def _preflight_check_toolsets(job: dict, cfg: dict) -> Optional[str]:
+    """Block explicit per-job toolsets that resolve to zero usable tools.
+
+    A non-empty ``enabled_toolsets`` value is an operator-authored allowlist.
+    Silently dropping an unavailable entry can leave an execution job with a
+    misleading partial capability surface (for example, ``file`` without the
+    requested ``web`` tools). Default/platform toolsets remain best-effort.
+    """
+    if job.get("no_agent"):
+        return None
+
+    requested = job.get("enabled_toolsets")
+    if isinstance(requested, str):
+        requested = [requested]
+    if not isinstance(requested, list) or not requested:
+        return None
+
+    from hermes_cli.tools_config import enabled_mcp_server_names
+
+    mcp_names = set(enabled_mcp_server_names(cfg))
+
+    from model_tools import get_tool_definitions
+
+    disabled = _resolve_cron_disabled_toolsets(cfg)
+    non_registry_toolsets = {"no_mcp", "context_engine"}
+    for raw_name in requested:
+        name = str(raw_name).strip()
+        if (
+            not name
+            or name in mcp_names
+            or name in disabled
+            or name in non_registry_toolsets
+        ):
+            continue
+        definitions = get_tool_definitions(
+            enabled_toolsets=[name],
+            disabled_toolsets=disabled,
+            quiet_mode=True,
+            skip_tool_search_assembly=True,
+        )
+        if not definitions:
+            return (
+                f"requested toolset '{name}' resolves to zero available tools "
+                "in this cron runtime. Configure its required provider, "
+                "credentials, package, or system dependency; remove it from "
+                "the job; or add an operational fallback toolset."
+            )
+    return None
+
+
 def _preflight_check_delivery(job: dict) -> Optional[str]:
     """Check the job's delivery target(s) resolve to configured platforms.
 
@@ -4031,6 +4081,7 @@ def _preflight_job_config(job: dict, cfg: dict) -> Optional[str]:
     """
     for name, check in (
         ("provider_key", lambda: _preflight_check_provider_key(job, cfg)),
+        ("toolsets", lambda: _preflight_check_toolsets(job, cfg)),
         ("skills", lambda: _preflight_check_skills(job)),
         ("delivery", lambda: _preflight_check_delivery(job)),
     ):

--- a/tests/cron/test_preflight_config.py
+++ b/tests/cron/test_preflight_config.py
@@ -314,6 +314,130 @@ class TestSkillReadiness:
         assert agent_constructed is True
 
 
+class TestExplicitToolsetAvailability:
+    def test_unavailable_explicit_toolset_blocks_before_agent(self, tmp_path):
+        """An explicitly requested toolset that resolves to zero tools blocks.
+
+        ``enabled_toolsets`` is an allowlist, but an explicit entry is also an
+        operator assertion that the capability exists. Silently dropping an
+        unavailable entry can turn an execution job into a planning-only job.
+        """
+
+        def fake_tool_definitions(*, enabled_toolsets=None, **_kwargs):
+            if enabled_toolsets == ["web"]:
+                return []
+            return [{"function": {"name": "read_file"}}]
+
+        job = _job(enabled_toolsets=["file", "web"])
+        with cron_jobs.use_cron_store(tmp_path):
+            cron_jobs.save_jobs([job])
+            with patch(
+                "model_tools.get_tool_definitions",
+                side_effect=fake_tool_definitions,
+            ):
+                success, output, final_response, error, agent_constructed = \
+                    _run_job_patched(job, tmp_path)
+
+        assert agent_constructed is False
+        assert success is False
+        assert error is not None and "[blocked_config]" in error
+        assert "web" in f"{error} {output}"
+        assert "zero" in f"{error} {output}".lower()
+
+    def test_available_explicit_toolsets_run_normally(self, tmp_path):
+        def fake_tool_definitions(*, enabled_toolsets=None, **_kwargs):
+            names = {
+                "file": "read_file",
+                "web": "web_search",
+            }
+            return [
+                {"function": {"name": names[name]}}
+                for name in enabled_toolsets or []
+                if name in names
+            ]
+
+        job = _job(enabled_toolsets=["file", "web"])
+        with cron_jobs.use_cron_store(tmp_path):
+            cron_jobs.save_jobs([job])
+            with patch(
+                "model_tools.get_tool_definitions",
+                side_effect=fake_tool_definitions,
+            ):
+                success, _output, _final, error, agent_constructed = \
+                    _run_job_patched(job, tmp_path)
+
+        assert success is True
+        assert error is None
+        assert agent_constructed is True
+
+
+    def test_no_mcp_sentinel_is_not_treated_as_missing_toolset(self, tmp_path):
+        job = _job(enabled_toolsets=["file", "no_mcp"])
+        with cron_jobs.use_cron_store(tmp_path):
+            cron_jobs.save_jobs([job])
+            success, _output, _final, error, agent_constructed = \
+                _run_job_patched(job, tmp_path)
+
+        assert success is True
+        assert error is None
+        assert agent_constructed is True
+
+    def test_context_engine_is_not_treated_as_empty_static_toolset(self, tmp_path):
+        job = _job(enabled_toolsets=["context_engine"])
+        with cron_jobs.use_cron_store(tmp_path):
+            cron_jobs.save_jobs([job])
+            success, _output, _final, error, agent_constructed = \
+                _run_job_patched(job, tmp_path)
+
+        assert success is True
+        assert error is None
+        assert agent_constructed is True
+
+    def test_policy_disabled_toolset_does_not_block(self, tmp_path):
+        job = _job(enabled_toolsets=["memory", "file"])
+        with cron_jobs.use_cron_store(tmp_path):
+            cron_jobs.save_jobs([job])
+            success, _output, _final, error, agent_constructed = \
+                _run_job_patched(job, tmp_path)
+
+        assert success is True
+        assert error is None
+        assert agent_constructed is True
+
+    def test_no_agent_job_bypasses_toolset_preflight(self, tmp_path):
+        job = _job(no_agent=True, enabled_toolsets=["unavailable"])
+        assert sched._preflight_check_toolsets(job, {}) is None
+
+    def test_toolset_resolution_error_fails_open(self, tmp_path):
+        job = _job(enabled_toolsets=["web"])
+        with cron_jobs.use_cron_store(tmp_path):
+            cron_jobs.save_jobs([job])
+            with patch(
+                "model_tools.get_tool_definitions",
+                side_effect=RuntimeError("registry unavailable"),
+            ):
+                success, _output, _final, error, agent_constructed = \
+                    _run_job_patched(job, tmp_path)
+
+        assert success is True
+        assert error is None
+        assert agent_constructed is True
+
+
+    def test_mcp_name_resolution_error_fails_open(self):
+        job = _job(enabled_toolsets=["configured_mcp"])
+        with patch(
+            "hermes_cli.runtime_provider.resolve_runtime_provider",
+            return_value=dict(_RUNTIME),
+        ), patch(
+            "hermes_cli.tools_config.enabled_mcp_server_names",
+            side_effect=RuntimeError("MCP config unavailable"),
+        ), patch("model_tools.get_tool_definitions", return_value=[]):
+            reason = sched._preflight_job_config(job, {})
+
+        assert reason is None
+
+
 class TestDeliveryPlatform:
     def test_unknown_delivery_platform_blocks(self, tmp_path):
         job = _job(deliver="notaplatform")

--- a/website/docs/user-guide/features/cron.md
+++ b/website/docs/user-guide/features/cron.md
@@ -632,6 +632,19 @@ Cron jobs inherit your configured fallback providers and credential pool rotatio
 
 This means cron jobs that run at high frequency or during peak hours are more resilient — a single rate-limited key won't fail the entire run.
 
+## Toolset preflight
+
+A non-empty per-job `enabled_toolsets` list is treated as an explicit capability contract. Before constructing the agent, Hermes resolves each requested toolset through the same runtime availability checks used for normal tools. If a requested toolset resolves to zero usable tools—for example, `web` with no configured provider or installed keyless backend—the run is marked `blocked_config`, no inference call is made, and the alert explains how to configure, remove, or replace the unavailable toolset.
+
+This check applies only to explicit per-job allowlists. Platform/default toolsets remain best-effort, MCP server toolsets keep their own discovery path, toolsets intentionally disabled by cron policy (such as interactive clarification or memory) are skipped, and non-registry control or late-bound entries such as `no_mcp` and `context_engine` are not treated as missing dependencies.
+
+To opt out of all cron configuration preflight checks and restore the legacy run-and-fail behavior:
+
+```yaml
+cron:
+  preflight: false
+```
+
 ## Schedule formats
 
 The agent's final response is automatically delivered to the job's `deliver:` target — the agent no longer fires messages itself, so the user-facing content simply goes in the final response. To deliver to **additional or different** targets, list multiple `deliver:` targets on the cron job (comma-separated, e.g. `deliver: "telegram,discord"`) rather than having the agent send them.


### PR DESCRIPTION
## Summary
- preflight explicit per-job toolsets before constructing the cron agent
- return `blocked_config` when an ordinary requested toolset resolves to zero usable tools
- preserve MCP, policy-disabled, `no_mcp`, `context_engine`, no-agent, and fail-open compatibility paths
- document the capability-contract behavior

## Verification
- 8 explicit-toolset compatibility tests passed
- full cron suite: 718 passed, 1 skipped
- Ruff passed
- `git diff --check` passed
- final independent review found no blockers

## Scope
Only the cron scheduler, focused preflight tests, and cron documentation are included.