### PR TITLE
fix(computer-use): merge refs+content_refs in _ref_map for cua-driver 0.17+ (salvage #79515)

### DIFF
--- a/contributors/emails/2436887475@qq.com
+++ b/contributors/emails/2436887475@qq.com
@@ -1,0 +1,1 @@
+weisiwu

--- a/tests/tools/test_computer_use_cua_0_9.py
+++ b/tests/tools/test_computer_use_cua_0_9.py
@@ -559,6 +559,33 @@ def test_live_semantic_v2_content_refs_are_the_action_capabilities():
     assert refs == {"p7:3": {"click", "pointer"}}
 
 
+def test_split_refs_and_content_refs_merge_without_clobbering():
+    """cua-driver >= 0.17 splits the semantic_v2 payload: action-bearing refs
+    live in ``refs`` while ``content_refs`` re-lists every node with EMPTY
+    action lists. The old exclusive preference (content_refs first) dropped
+    all actions, making every click refuse with browser_ref_stale — caught
+    live on 0.19.3 against example.org (PR #79515 by weisiwu).
+    """
+    from tools.computer_use.browser_route import _ref_map
+
+    refs = _ref_map({
+        "status": "ok",
+        "refs": [
+            {"ref": "p1:1", "role": "link", "actions": ["click", "pointer"]},
+        ],
+        "content_refs": [
+            {"ref": "p1:0", "role": "rootwebarea", "actions": []},
+            # same ref re-listed with no actions — must NOT clobber
+            {"ref": "p1:1", "role": "link", "actions": []},
+            {"ref": "p1:2", "role": "heading", "actions": []},
+        ],
+    })
+
+    assert refs["p1:1"] == {"click", "pointer"}
+    assert refs["p1:0"] == set()
+    assert refs["p1:2"] == set()
+
+
 def test_dom_event_is_forwarded_only_when_explicitly_requested():
     driver = _BrowserDriver()
     route = _browser_route(driver)

--- a/tools/computer_use/browser_route.py
+++ b/tools/computer_use/browser_route.py
@@ -60,36 +60,44 @@ def _ref_map(payload: Dict[str, Any]) -> Dict[str, Set[str]]:
     cua-driver has emitted both mapping and list representations while the
     semantic snapshot contract evolved.  Accept both without weakening the
     capability rule: a ref with no declared action remains readable only.
+
+    cua-driver >= 0.17 splits the semantic_v2 payload: action-bearing refs
+    live in the ``refs`` array while ``content_refs`` carries every node
+    with empty action lists.  Merge both sources (plus the legacy
+    snapshot.refs forms) so click/pointer/type refs stay usable.
     """
     normalized: Dict[str, Set[str]] = {}
-    snapshot = payload.get("snapshot")
-    # semantic_v2 carries the authoritative action-bearing entries in
-    # ``content_refs``; some transitional builds also emitted a ``refs`` list
-    # or map. Prefer the richer live shape, then accept both older forms.
-    raw = payload.get("content_refs")
-    if not raw:
-        raw = payload.get("refs")
-    if raw is None and isinstance(snapshot, dict):
-        raw = snapshot.get("refs")
-    if isinstance(raw, dict):
-        entries: Iterable[tuple[Optional[str], Any]] = raw.items()
-    elif isinstance(raw, list):
-        entries = ((None, item) for item in raw)
-    else:
-        entries = ()
 
-    for key, value in entries:
-        if isinstance(value, dict):
-            ref = value.get("ref") or key
-            actions = value.get("actions")
+    def absorb(raw: Any) -> None:
+        if isinstance(raw, dict):
+            entries: Iterable[tuple[Optional[str], Any]] = raw.items()
+        elif isinstance(raw, list):
+            entries = ((None, item) for item in raw)
         else:
-            ref = key
-            actions = None
-        if not isinstance(ref, str) or not ref:
-            continue
-        normalized[ref] = {
-            action for action in (actions or []) if isinstance(action, str)
-        }
+            return
+        for key, value in entries:
+            if isinstance(value, dict):
+                ref = value.get("ref") or key
+                actions = value.get("actions")
+            else:
+                ref = key
+                actions = None
+            if not isinstance(ref, str) or not ref:
+                continue
+            action_set = {
+                action for action in (actions or []) if isinstance(action, str)
+            }
+            # Merge, never drop: content_refs entries carry empty action
+            # lists and must not clobber the same ref declared in ``refs``.
+            normalized[ref] = normalized.get(ref, set()) | action_set
+
+    # 0.17 authoritative action refs; older builds emit only ``refs``; some
+    # transitional builds emit a mapping. Absorb every shape.
+    absorb(payload.get("refs"))
+    absorb(payload.get("content_refs"))
+    snapshot = payload.get("snapshot")
+    if isinstance(snapshot, dict):
+        absorb(snapshot.get("refs"))
     return normalized
 
 


### PR DESCRIPTION
## Summary

Typed browser clicks/typing work again on current cua-driver builds: `_ref_map` now merges `refs` + `content_refs` instead of preferring one exclusively, so the action-bearing refs that cua-driver ≥ 0.17 ships in the split payload are no longer discarded. Salvage of #79515 by @weisiwu, confirmed live on a real desktop before salvaging.

Root cause: 0.17 split the semantic_v2 payload — action refs moved to `refs[]` while `content_refs[]` re-lists every node with empty action lists. Our `_ref_map` read `content_refs` first and stopped, so every ref registered with zero actions and every typed mutation refused with `browser_ref_stale`.

## Live proof (the bug and the fix)

Found while live-verifying the just-merged authorization work (#86342) on an unlocked desktop with cua-driver 0.19.3 + real Chrome:

| Step | Before (main) | After (this PR) |
|---|---|---|
| bind → snapshot | ok, "1 action ref, 5 content refs" | same |
| `cua_browser_click` on the `Learn more` link ref | refused `browser_ref_stale` | dispatched; page navigated to iana.org, verified by fresh snapshot |
| stale-ref reuse after mutation | n/a (never got there) | still refused `browser_verification_required` (guard intact) |

Trusted-input note from the same run: on Linux the driver refuses the trusted CDP route (`browser_input_trust_unavailable`, window would activate) and recommends the explicit `dom_event` downgrade — our wrapper surfaced the escalation losslessly and the explicit downgrade path worked as designed.

## Changes

- `tools/computer_use/browser_route.py`: `_ref_map` absorbs `refs`, `content_refs`, and legacy `snapshot.refs` shapes, unioning action sets per ref so empty re-listed entries never clobber action-bearing ones (contributor's commit, cherry-picked with authorship).
- `tests/tools/test_computer_use_cua_0_9.py`: regression test pinning the 0.17+ split-shape merge (our follow-up; the original PR had no test).
- `contributors/emails/`: mapping for @weisiwu.

## Validation

| Check | Result |
|---|---|
| Live E2E on unlocked desktop (bind → snapshot → click → verify iana.org) | PASS |
| Stale-ref + verification-required guards after merge | still refuse correctly |
| `test_computer_use_cua_0_9.py` + `test_computer_use_browser_authorization.py` | 69 passed |
| ruff | clean |

## Infographic

![Semantic ref merge fix — before/after and live proof](https://files.catbox.moe/zl6kgh.png)
