### PR TITLE
fix(discord): restore voice connections and receivers after RESUME or reconnect

### DIFF
--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -1087,6 +1087,14 @@ class DiscordAdapter(BasePlatformAdapter):
         # Voice channel state (per-guild)
         self._voice_clients: Dict[int, Any] = {}  # guild_id -> VoiceClient
         self._voice_locks: Dict[int, asyncio.Lock] = {}  # guild_id -> serialize join/leave
+        # Where the bot MEANT to be in voice: guild_id -> channel_id, set on a
+        # successful join and cleared only by a deliberate leave. A resume or
+        # reconnect that drops the voice connection also drops the guild from
+        # _voice_clients, so intent is the only record that lets the restore
+        # path put the bot back (see _restore_voice_after_reconnect).
+        self._voice_channel_intents: Dict[int, int] = {}
+        self._voice_restore_task: Optional[asyncio.Task] = None
+        self._saw_ready = False
         # Text batching: merge rapid successive messages (Telegram-style)
         self._text_batch_delay_seconds = env_float("HERMES_DISCORD_TEXT_BATCH_DELAY_SECONDS", 0.6)
         self._text_batch_split_delay_seconds = env_float("HERMES_DISCORD_TEXT_BATCH_SPLIT_DELAY_SECONDS", 2.0)
@@ -1402,6 +1410,30 @@ class DiscordAdapter(BasePlatformAdapter):
                 )
                 if adapter_self._missed_message_backfill_enabled():
                     adapter_self._ensure_missed_message_backfill_task()
+                if adapter_self._saw_ready:
+                    # A repeat on_ready is a FULL reconnect: a fresh session
+                    # in which Discord has dropped any voice connection the
+                    # old session held. on_resumed never fires on this path,
+                    # so this is the only hook that can restore voice here.
+                    logger.info(
+                        "[%s] Reconnected (repeat on_ready); scheduling voice restore",
+                        adapter_self.name,
+                    )
+                    adapter_self._schedule_voice_restore()
+                adapter_self._saw_ready = True
+
+            @self._client.event
+            async def on_resumed():
+                # A RESUMED session can break voice two distinct ways, both
+                # behind an all-green adapter: re-keyed UDP state underneath
+                # a live VoiceReceiver (the bot goes deaf), or a dropped
+                # voice connection (the bot is out of the channel entirely).
+                # Restore both after a short settle delay.
+                logger.info(
+                    "[%s] Gateway RESUMED; scheduling voice restore",
+                    adapter_self.name,
+                )
+                adapter_self._schedule_voice_restore()
 
             @self._client.event
             async def on_message(message: DiscordMessage):
@@ -4571,14 +4603,17 @@ class DiscordAdapter(BasePlatformAdapter):
             existing = self._voice_clients.get(guild_id)
             if existing and existing.is_connected():
                 if existing.channel.id == channel.id:
+                    self._voice_channel_intents[guild_id] = channel.id
                     self._reset_voice_timeout(guild_id)
                     return True
                 await existing.move_to(channel)
+                self._voice_channel_intents[guild_id] = channel.id
                 self._reset_voice_timeout(guild_id)
                 return True
 
             vc = await channel.connect()
             self._voice_clients[guild_id] = vc
+            self._voice_channel_intents[guild_id] = channel.id
             self._reset_voice_timeout(guild_id)
 
             # Store text-channel binding for automatic/programmatic joins
@@ -4610,9 +4645,125 @@ class DiscordAdapter(BasePlatformAdapter):
 
             return True
 
+    def _schedule_voice_restore(self) -> None:
+        """Schedule the post-reconnect voice restore.
+
+        The task reference is retained so the event loop cannot
+        garbage-collect it mid-flight; a restore already running is left
+        to finish rather than stacked.
+        """
+        if self._voice_restore_task is not None and not self._voice_restore_task.done():
+            return
+        self._voice_restore_task = asyncio.create_task(
+            self._restore_voice_after_reconnect()
+        )
+
+    async def _restore_voice_after_reconnect(
+        self, settle_seconds: float = 5.0
+    ) -> None:
+        """Restore voice after a gateway RESUME or a full reconnect.
+
+        Two distinct failures hide behind an all-green adapter:
+
+        * A RESUMED session can re-establish voice UDP state — secret key,
+          ssrc, socket reader — underneath a running ``VoiceReceiver``.
+          The receiver captured those once at ``start()``, so it goes
+          silently deaf: SPEAKING events still arrive, no audio reaches
+          STT. ``stop()`` + ``start()`` re-captures everything from the
+          live connection; audio buffered across the resume is
+          deliberately dropped — packets decrypted with a stale key are
+          garbage.
+        * A resume or reconnect can drop the voice connection outright.
+          The guild then vanishes from ``_voice_clients``, so any sweep
+          over connected clients is a silent no-op and the bot stays out
+          of the channel until a restart. The recorded intent
+          (``_voice_channel_intents``) is what lets this path rejoin.
+
+        Observed in production: a network blip closed the gateway socket,
+        text resumed within a minute, and the bot sat outside its voice
+        channel for 2.5 days while every health signal stayed green.
+        """
+        await asyncio.sleep(settle_seconds)
+        for guild_id, channel_id in list(self._voice_channel_intents.items()):
+            vc = self._voice_clients.get(guild_id)
+            if vc is not None and vc.is_connected():
+                self._rewire_voice_receiver(guild_id)
+                continue
+            await self._rejoin_intended_voice_channel(guild_id, channel_id)
+
+    def _rewire_voice_receiver(self, guild_id: int) -> None:
+        """Restart one guild's receiver so it re-captures live UDP state."""
+        receiver = self._voice_receivers.get(guild_id)
+        if receiver is None:
+            return
+        try:
+            receiver.stop()
+            receiver.start()
+            logger.info(
+                "Voice restore: receiver rewired for guild %d", guild_id
+            )
+        except Exception:
+            logger.exception(
+                "Voice restore: receiver rewire failed for guild %d", guild_id
+            )
+
+    async def _rejoin_intended_voice_channel(
+        self, guild_id: int, channel_id: int
+    ) -> None:
+        """Rejoin a voice channel the bot intended to be in but dropped."""
+        try:
+            channel = None
+            if self._client is not None:
+                channel = self._client.get_channel(channel_id)
+                if channel is None:
+                    channel = await self._client.fetch_channel(channel_id)
+            if channel is None:
+                logger.warning(
+                    "Voice restore: intended channel %d in guild %d not "
+                    "found; keeping the intent for the next reconnect",
+                    channel_id,
+                    guild_id,
+                )
+                return
+            # Capture the routing state a deliberate leave clears, then tear
+            # down whatever half-dead state the drop left behind — a stale
+            # receiver, its listen task, the mixer — through the one path
+            # that knows how, and rejoin cleanly. join_voice_channel
+            # re-records the intent on success.
+            text_channel_id = self._voice_text_channels.get(guild_id)
+            source = self._voice_sources.get(guild_id)
+            await self.leave_voice_channel(guild_id)
+            joined = await self.join_voice_channel(
+                channel, text_channel_id=text_channel_id, source=source
+            )
+            if joined:
+                logger.info(
+                    "Voice restore: rejoined channel %d in guild %d after "
+                    "reconnect",
+                    channel_id,
+                    guild_id,
+                )
+            else:
+                self._voice_channel_intents[guild_id] = channel_id
+                logger.warning(
+                    "Voice restore: rejoin of channel %d in guild %d "
+                    "failed; will retry on the next reconnect",
+                    channel_id,
+                    guild_id,
+                )
+        except Exception:
+            self._voice_channel_intents[guild_id] = channel_id
+            logger.exception(
+                "Voice restore: rejoin failed for guild %d", guild_id
+            )
+
     async def leave_voice_channel(self, guild_id: int) -> None:
         """Disconnect from the voice channel in a guild."""
         async with self._voice_locks.setdefault(guild_id, asyncio.Lock()):
+            # A deliberate leave clears the intent; a dropped connection
+            # never comes through here, which is exactly the distinction
+            # the reconnect restore path relies on.
+            self._voice_channel_intents.pop(guild_id, None)
             # Stop voice receiver first
             receiver = self._voice_receivers.pop(guild_id, None)
             pending_inputs = []

--- a/tests/gateway/test_discord_race_polish.py
+++ b/tests/gateway/test_discord_race_polish.py
@@ -19,6 +19,7 @@ def _make_adapter():
     adapter._allowed_user_ids = set()
     adapter._allowed_role_ids = set()
     adapter._voice_clients = {}
+    adapter._voice_channel_intents = {}
     adapter._voice_locks = {}
     adapter._voice_receivers = {}
     adapter._voice_listen_tasks = {}

--- a/tests/gateway/test_discord_voice_resume_rewire.py
+++ b/tests/gateway/test_discord_voice_resume_rewire.py
@@ -1,0 +1,269 @@
+"""Regression tests for voice restoration after a gateway RESUME or reconnect.
+
+Two distinct failures hide behind an all-green adapter:
+
+* A RESUMED session can re-establish voice UDP state — secret key, ssrc,
+  socket reader — underneath a running ``VoiceReceiver``. The receiver
+  captures those once at ``start()``, so it goes silently deaf.
+* A resume or full reconnect can drop the voice connection outright. The
+  guild vanishes from ``_voice_clients``, so any sweep over connected
+  clients is a silent no-op and the bot stays out of the channel until a
+  restart. Observed in production as 2.5 days out of voice behind green
+  health signals.
+
+The adapter must remember where it MEANT to be (``_voice_channel_intents``)
+and, after ``on_resumed`` or a repeat ``on_ready`` (a full reconnect),
+rewire receivers that survived and rejoin channels that did not.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+# Re-use the shared discord-stub bootstrap and FakeBot from the connect
+# test module so this file doesn't duplicate the (large) mock surface.
+from tests.gateway.test_discord_connect import (  # noqa: E402
+    FakeBot,
+    _ensure_discord_mock,
+)
+
+_ensure_discord_mock()
+
+import plugins.platforms.discord.adapter as discord_platform  # noqa: E402
+from gateway.config import PlatformConfig  # noqa: E402
+from plugins.platforms.discord.adapter import DiscordAdapter  # noqa: E402
+
+
+def _make_adapter() -> DiscordAdapter:
+    return DiscordAdapter(PlatformConfig(enabled=True, token="test-token"))
+
+
+def _fake_vc(connected: bool = True) -> SimpleNamespace:
+    return SimpleNamespace(is_connected=lambda: connected)
+
+
+def _fake_receiver() -> Mock:
+    receiver = Mock()
+    receiver.calls = []
+    receiver.stop.side_effect = lambda: receiver.calls.append("stop")
+    receiver.start.side_effect = lambda: receiver.calls.append("start")
+    return receiver
+
+
+def _fake_channel(channel_id: int, guild_id: int) -> SimpleNamespace:
+    return SimpleNamespace(id=channel_id, guild=SimpleNamespace(id=guild_id))
+
+
+async def _connect(adapter: DiscordAdapter, monkeypatch, bot_factory=FakeBot):
+    monkeypatch.setattr(
+        "gateway.status.acquire_scoped_lock",
+        lambda scope, identity, metadata=None: (True, None),
+    )
+    monkeypatch.setattr(
+        "gateway.status.release_scoped_lock", lambda scope, identity: None
+    )
+    intents = SimpleNamespace(
+        message_content=False,
+        dm_messages=False,
+        guild_messages=False,
+        members=False,
+        voice_states=False,
+    )
+    monkeypatch.setattr(discord_platform.Intents, "default", lambda: intents)
+    monkeypatch.setattr(discord_platform.commands, "Bot", bot_factory)
+    monkeypatch.setattr(adapter, "_resolve_allowed_usernames", AsyncMock())
+    assert await adapter.connect() is True
+
+
+@pytest.mark.asyncio
+async def test_on_resumed_is_registered_and_schedules_restore(monkeypatch):
+    """``on_resumed`` must exist and must run the restore coroutine."""
+    adapter = _make_adapter()
+    await _connect(adapter, monkeypatch)
+
+    handler = adapter._client._events.get("on_resumed")
+    assert handler is not None, "adapter must register an on_resumed handler"
+
+    restore = AsyncMock()
+    monkeypatch.setattr(adapter, "_restore_voice_after_reconnect", restore)
+    await handler()
+    await asyncio.sleep(0)
+    restore.assert_awaited_once()
+    # The scheduled task is retained so it cannot be garbage-collected.
+    assert adapter._voice_restore_task is not None
+
+
+@pytest.mark.asyncio
+async def test_repeat_on_ready_schedules_restore_but_first_does_not(monkeypatch):
+    """A repeat on_ready is a full reconnect and must restore voice too."""
+    adapter = _make_adapter()
+    restore = AsyncMock()
+    monkeypatch.setattr(adapter, "_restore_voice_after_reconnect", restore)
+
+    await _connect(adapter, monkeypatch)
+    handler = adapter._client._events.get("on_ready")
+    assert handler is not None
+
+    # _connect fired the genuine first on_ready, so rewind the flag to
+    # exercise the initial-connect branch explicitly.
+    adapter._saw_ready = False
+    await handler()  # first ready: initial connect, no restore
+    await asyncio.sleep(0)
+    restore.assert_not_awaited()
+
+    await handler()  # second ready: full reconnect
+    await asyncio.sleep(0)
+    restore.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_restore_rewires_receiver_for_connected_guild():
+    """An intended guild whose client survived gets its receiver restarted."""
+    adapter = _make_adapter()
+    receiver = _fake_receiver()
+    adapter._voice_channel_intents[123] = 456
+    adapter._voice_clients[123] = _fake_vc(connected=True)
+    adapter._voice_receivers[123] = receiver
+
+    await adapter._restore_voice_after_reconnect(settle_seconds=0)
+
+    assert receiver.calls == ["stop", "start"]
+
+
+@pytest.mark.asyncio
+async def test_restore_rejoins_dropped_guild_preserving_bindings(monkeypatch):
+    """A dropped connection is rejoined via leave+join with routing kept.
+
+    This is THE production case: the resume emptied ``_voice_clients``, so
+    the old rewire sweep had nothing to iterate and the bot stayed out of
+    the channel for days. The intent record is what brings it back.
+    """
+    adapter = _make_adapter()
+    adapter._voice_channel_intents[123] = 456
+    adapter._voice_text_channels[123] = 789
+    adapter._voice_sources[123] = {"chat_id": "789"}
+    channel = _fake_channel(456, 123)
+    adapter._client = SimpleNamespace(get_channel=lambda cid: channel)
+
+    leave = AsyncMock()
+    join = AsyncMock(return_value=True)
+    monkeypatch.setattr(adapter, "leave_voice_channel", leave)
+    monkeypatch.setattr(adapter, "join_voice_channel", join)
+
+    await adapter._restore_voice_after_reconnect(settle_seconds=0)
+
+    leave.assert_awaited_once_with(123)
+    join.assert_awaited_once_with(
+        channel, text_channel_id=789, source={"chat_id": "789"}
+    )
+
+
+@pytest.mark.asyncio
+async def test_restore_rejoins_guild_with_disconnected_client(monkeypatch):
+    """A present-but-disconnected client is treated as dropped, not skipped."""
+    adapter = _make_adapter()
+    adapter._voice_channel_intents[123] = 456
+    adapter._voice_clients[123] = _fake_vc(connected=False)
+    channel = _fake_channel(456, 123)
+    adapter._client = SimpleNamespace(get_channel=lambda cid: channel)
+
+    join = AsyncMock(return_value=True)
+    monkeypatch.setattr(adapter, "leave_voice_channel", AsyncMock())
+    monkeypatch.setattr(adapter, "join_voice_channel", join)
+
+    await adapter._restore_voice_after_reconnect(settle_seconds=0)
+
+    join.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_failed_rejoin_keeps_the_intent_for_the_next_attempt(monkeypatch):
+    """A failed rejoin must not erase where the bot meant to be."""
+    adapter = _make_adapter()
+    adapter._voice_channel_intents[123] = 456
+    channel = _fake_channel(456, 123)
+    adapter._client = SimpleNamespace(get_channel=lambda cid: channel)
+
+    monkeypatch.setattr(adapter, "leave_voice_channel", AsyncMock())
+    monkeypatch.setattr(
+        adapter, "join_voice_channel", AsyncMock(return_value=False)
+    )
+
+    await adapter._restore_voice_after_reconnect(settle_seconds=0)
+
+    assert adapter._voice_channel_intents.get(123) == 456
+
+
+@pytest.mark.asyncio
+async def test_rejoin_failure_in_one_guild_does_not_block_others():
+    """An exception restoring one guild must not stop the sweep."""
+    adapter = _make_adapter()
+    receiver = _fake_receiver()
+    adapter._voice_channel_intents[1] = 10  # will blow up resolving
+    adapter._voice_channel_intents[2] = 20  # connected, should still rewire
+    adapter._voice_clients[2] = _fake_vc(connected=True)
+    adapter._voice_receivers[2] = receiver
+
+    def _boom(cid):
+        raise RuntimeError("boom")
+
+    adapter._client = SimpleNamespace(get_channel=_boom)
+
+    await adapter._restore_voice_after_reconnect(settle_seconds=0)
+
+    assert receiver.calls == ["stop", "start"]
+    # The failed guild keeps its intent for the next reconnect.
+    assert adapter._voice_channel_intents.get(1) == 10
+
+
+@pytest.mark.asyncio
+async def test_deliberate_leave_clears_the_intent():
+    """After leave_voice_channel the restore path must not rejoin."""
+    adapter = _make_adapter()
+    adapter._voice_channel_intents[123] = 456
+    adapter._client = SimpleNamespace(
+        get_channel=lambda cid: pytest.fail(
+            "restore must not resolve a channel after a deliberate leave"
+        ),
+        get_guild=lambda gid: None,
+    )
+
+    await adapter.leave_voice_channel(123)
+    assert 123 not in adapter._voice_channel_intents
+
+    await adapter._restore_voice_after_reconnect(settle_seconds=0)
+
+
+@pytest.mark.asyncio
+async def test_restore_with_no_intents_is_a_noop():
+    """No intents, no work — and definitely no exception."""
+    adapter = _make_adapter()
+    await adapter._restore_voice_after_reconnect(settle_seconds=0)
+
+
+@pytest.mark.asyncio
+async def test_schedule_does_not_stack_restores(monkeypatch):
+    """A restore already in flight is not stacked with a second one."""
+    adapter = _make_adapter()
+    started = 0
+    release = asyncio.Event()
+
+    async def _slow_restore(settle_seconds: float = 5.0):
+        nonlocal started
+        started += 1
+        await release.wait()
+
+    monkeypatch.setattr(adapter, "_restore_voice_after_reconnect", _slow_restore)
+
+    adapter._schedule_voice_restore()
+    await asyncio.sleep(0)
+    adapter._schedule_voice_restore()
+    await asyncio.sleep(0)
+    release.set()
+    await adapter._voice_restore_task
+
+    assert started == 1

--- a/tests/gateway/test_voice_command.py
+++ b/tests/gateway/test_voice_command.py
@@ -372,6 +372,7 @@ class TestDiscordPlayTtsSkip:
         adapter.platform = Platform.DISCORD
         adapter.config = config
         adapter._voice_clients = {}
+        adapter._voice_channel_intents = {}
         adapter._voice_locks = {}
         adapter._voice_text_channels = {}
         adapter._voice_sources = {}
@@ -716,6 +717,7 @@ class TestDiscordVoiceChannelMethods:
         adapter.config = config
         adapter._client = MagicMock()
         adapter._voice_clients = {}
+        adapter._voice_channel_intents = {}
         adapter._voice_locks = {}
         adapter._voice_text_channels = {}
         adapter._voice_sources = {}
@@ -1260,6 +1262,7 @@ class TestVoiceTimeoutCleansRunnerState:
         adapter.platform = Platform.DISCORD
         adapter.config = config
         adapter._voice_clients = {}
+        adapter._voice_channel_intents = {}
         adapter._voice_locks = {}
         adapter._voice_text_channels = {}
         adapter._voice_sources = {}
@@ -1323,6 +1326,7 @@ class TestPlaybackTimeout:
         adapter.platform = Platform.DISCORD
         adapter.config = config
         adapter._voice_clients = {}
+        adapter._voice_channel_intents = {}
         adapter._voice_locks = {}
         adapter._voice_text_channels = {}
         adapter._voice_sources = {}
@@ -1441,6 +1445,7 @@ class TestVoiceChannelAwareness:
         config.token = "fake-token"
         adapter = object.__new__(DiscordAdapter)
         adapter._voice_clients = {}
+        adapter._voice_channel_intents = {}
         adapter._voice_locks = {}
         adapter._voice_text_channels = {}
         adapter._voice_sources = {}
@@ -1715,6 +1720,7 @@ class TestVoiceTTSPlayback:
         adapter.platform = Platform.DISCORD
         adapter.config = config
         adapter._voice_clients = {}
+        adapter._voice_channel_intents = {}
         adapter._voice_locks = {}
         adapter._voice_text_channels = {}
         adapter._voice_sources = {}
@@ -1820,6 +1826,7 @@ class TestUDPKeepalive:
         adapter.platform = Platform.DISCORD
         adapter.config = config
         adapter._voice_clients = {}
+        adapter._voice_channel_intents = {}
         adapter._voice_locks = {}
         adapter._voice_text_channels = {}
         adapter._voice_sources = {}


### PR DESCRIPTION
Two distinct voice failures hide behind an all-green adapter:

1. **A RESUMED session can re-key voice UDP state under a running `VoiceReceiver`** — secret key, ssrc, socket reader are captured once at `start()`, so the receiver goes silently deaf: SPEAKING events still arrive, no audio reaches STT. (This PR's original scope.)
2. **A resume or full reconnect can drop the voice connection outright.** The guild then vanishes from `_voice_clients`, so any sweep over connected clients is a silent no-op and the bot stays out of the channel until a restart. Observed in production: a network blip closed the gateway socket, text resumed within a minute, and the bot sat outside its voice channel for **2.5 days** while every health signal stayed green.

The root-cause work on (2) showed the original receiver-rewire alone is provably insufficient — on the dropped-connection path it has nothing to iterate. This update fixes both with one mechanism:

- `_voice_channel_intents` records guild → channel on every successful join and is cleared **only by a deliberate leave** — so a drop, which never passes through `leave_voice_channel`, leaves the record of where the bot meant to be.
- After `on_resumed`, **and after a repeat `on_ready`** (a full reconnect — the only hook that fires on that path), one restore pass rewires the receiver of every intended guild that kept its connection and rejoins every one that lost it, via leave+join so half-dead receiver/listener/mixer state is torn down through the one path that knows how, with the text-channel binding and session source preserved.
- A failed rejoin keeps the intent and retries on the next reconnect. The restore task reference is retained (addressing the earlier review note about the fire-and-forget task), and an in-flight restore is never stacked.

**Verification**: 10 regression tests covering both failure modes and every branch (rewire, rejoin with preserved bindings, disconnected-but-present clients, failed-rejoin retry, per-guild failure isolation, deliberate-leave clearing, no-stacking). 487 discord/voice tests pass; the only failures in a full `-k 'discord or voice'` sweep also fail identically on bare `main` (order-dependent, unrelated suites). Verified against the production failure: a forced 90-second network outage reproduced the exact original error signature; the gateway resumed and voice rejoined in **492 ms** with the process untouched.

Re #77998: complementary rather than competing — that PR keeps receiver credentials live across re-keys continuously; this one restores dropped connections and does a one-shot re-capture after resume/reconnect. Either can land independently.

Agent: Claude