### PR TITLE
feat(slack): add external resource authorization seam

### DIFF
--- a/gateway/authz_mixin.py
+++ b/gateway/authz_mixin.py
@@ -410,6 +410,19 @@ class GatewayAuthorizationMixin:
 
         adapter_profile = self._adapter_profile_for_source(source)
 
+        # External resource authorization is an adapter-owned edge check.  It
+        # runs after transport/upstream trust but before ordinary allowlists so
+        # an allowlist cannot bypass a configured remote membership policy.
+        adapter = self._authorization_adapter(source.platform, adapter_profile)
+        if adapter is not None:
+            try:
+                required = getattr(adapter, "external_resource_authorization_required", None)
+                check = getattr(adapter, "external_resource_authorized", None)
+                if callable(required) and required() and callable(check) and not check(source):
+                    return False
+            except Exception:
+                return False
+
         # Relay (and any adapter whose authorization is enforced by a trusted
         # authenticated upstream): the Team Gateway connector authenticates this
         # gateway's WS with a per-instance secret and resolves owner-only author

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2979,6 +2979,14 @@ class BasePlatformAdapter(ABC):
     # generic seam; Slack is merely the first consumer).
     supports_inchannel_continuable: bool = False
 
+    def external_resource_authorization_required(self) -> bool:
+        """Whether this adapter requires a remote resource-membership check."""
+        return False
+
+    def external_resource_authorized(self, source: Any) -> bool:
+        """Return the local, non-wire authorization result for *source*."""
+        return True
+
     # Whether a human is interactively present on this platform to answer a
     # "session restored — what next?" prompt.  The startup auto-resume turn
     # (``_schedule_resume_pending_sessions`` → the ``_is_resume_pending``

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -218,6 +218,10 @@ class SessionSource:
     # deliberately excluded from ``to_dict``/``from_dict`` so a peer can never
     # forge it across the wire or have it restored from persistence.
     delivered_via_upstream_relay: bool = False
+    # Local-only result of an adapter's external resource authorization check.
+    # Deliberately excluded from wire/persistence serialization: a remote event
+    # must never be able to assert this trust decision.
+    external_resource_authorized: bool = field(default=False, repr=False, compare=False)
 
     def __post_init__(self) -> None:
         # D-Q2.5 dual-field reconciliation: `scope_id` is canonical, `guild_id`

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -7254,62 +7254,91 @@ class SlackAdapter(BasePlatformAdapter):
         user_name: Optional[str] = None,
         team_id: str = "",
     ) -> bool:
-        """Return whether a Slack interactive caller may perform gated actions."""
+        """Check the ordinary synchronous Slack/gateway authorization policy."""
         normalized_user_id = str(user_id or "").strip()
         if not normalized_user_id:
             return False
-
         runner = getattr(getattr(self, "_message_handler", None), "__self__", None)
         auth_fn = getattr(runner, "_is_user_authorized", None)
         if callable(auth_fn):
             try:
                 from gateway.session import SessionSource
 
-                source = SessionSource(
+                return bool(auth_fn(SessionSource(
                     platform=Platform.SLACK,
                     chat_id=str(channel_id or normalized_user_id),
                     chat_type="dm" if str(channel_id or "").startswith("D") else "group",
                     user_id=normalized_user_id,
                     user_name=str(user_name).strip() if user_name else None,
                     scope_id=str(team_id) if team_id else None,
-                )
-                return bool(auth_fn(source))
+                )))
             except Exception:
-                logger.debug(
-                    "[Slack] Falling back to env-only interactive auth for user %s",
-                    normalized_user_id,
-                    exc_info=True,
-                )
-
+                logger.debug("[Slack] Gateway interactive auth failed", exc_info=True)
+                return False
         if os.getenv("SLACK_ALLOW_ALL_USERS", "").lower() in {"true", "1", "yes"}:
             return True
-
+        try:
+            from agent.secret_scope import get_secret
+        except Exception:
+            get_secret = lambda name: None
         def _env(name: str) -> str:
-            # Multiplex: profile .env is in secret_scope, not process environ.
-            try:
-                from agent.secret_scope import get_secret
+            value = get_secret(name)
+            return str(value).strip() if value else (os.getenv(name) or "").strip()
+        allowed = {
+            item.strip()
+            for name in ("SLACK_ALLOWED_USERS", "GATEWAY_ALLOWED_USERS")
+            for item in _env(name).split(",")
+            if item.strip()
+        }
+        if allowed:
+            return "*" in allowed or normalized_user_id in allowed
+        return _env("SLACK_ALLOW_ALL_USERS").lower() in {"true", "1", "yes"} or _env(
+            "GATEWAY_ALLOW_ALL_USERS"
+        ).lower() in {"true", "1", "yes"}
 
-                val = get_secret(name)
-                if val is not None and str(val).strip():
-                    return str(val).strip()
-            except Exception:
-                pass
-            return (os.getenv(name) or "").strip()
+    async def _authorize_interactive_user(
+        self,
+        user_id: str,
+        *,
+        channel_id: str = "",
+        user_name: Optional[str] = None,
+        team_id: str = "",
+    ) -> bool:
+        """Return whether a Slack interactive caller may perform gated actions.
 
-        allowed_ids = set()
-        platform_allowlist = _env("SLACK_ALLOWED_USERS")
-        if platform_allowlist:
-            allowed_ids.update(uid.strip() for uid in platform_allowlist.split(",") if uid.strip())
-        global_allowlist = _env("GATEWAY_ALLOWED_USERS")
-        if global_allowlist:
-            allowed_ids.update(uid.strip() for uid in global_allowlist.split(",") if uid.strip())
+        Block Kit actions do not pass through the normal message edge.  Run the
+        same external-resource check here before consulting the ordinary
+        gateway authorization predicate; otherwise configured membership
+        enforcement would either be bypassed or make every interactive action
+        fail at the final gate because it has no local marker.
+        """
+        normalized_user_id = str(user_id or "").strip()
+        if not normalized_user_id:
+            return False
 
-        if allowed_ids:
-            return "*" in allowed_ids or normalized_user_id in allowed_ids
+        from gateway.session import SessionSource
 
-        if _env("SLACK_ALLOW_ALL_USERS").lower() in {"true", "1", "yes"}:
-            return True
-        return _env("GATEWAY_ALLOW_ALL_USERS").lower() in {"true", "1", "yes"}
+        source = SessionSource(
+            platform=Platform.SLACK,
+            chat_id=str(channel_id or normalized_user_id),
+            chat_type="dm" if str(channel_id or "").startswith("D") else "group",
+            user_id=normalized_user_id,
+            user_name=str(user_name).strip() if user_name else None,
+            scope_id=str(team_id) if team_id else None,
+        )
+        if not await self._authorize_external_resource(
+            normalized_user_id,
+            chat_id=str(channel_id or normalized_user_id),
+            team_id=str(team_id or ""),
+            source=source,
+        ):
+            return False
+        return self._is_interactive_user_authorized(
+            normalized_user_id,
+            channel_id=channel_id,
+            user_name=user_name,
+            team_id=team_id,
+        )
 
     async def _handle_slash_confirm_action(self, ack, body, action) -> None:
         """Handle a slash-confirm button click from Block Kit."""
@@ -7323,7 +7352,7 @@ class SlackAdapter(BasePlatformAdapter):
         channel_id = body.get("channel", {}).get("id", "")
         user_name = body.get("user", {}).get("name", "unknown")
         user_id = body.get("user", {}).get("id", "")
-        if not self._is_interactive_user_authorized(
+        if not await self._authorize_interactive_user(
             user_id,
             channel_id=channel_id,
             user_name=user_name,
@@ -7446,6 +7475,12 @@ class SlackAdapter(BasePlatformAdapter):
         message = body.get("message", {}) or {}
         channel_id = (body.get("channel") or {}).get("id", "")
         user_id = (body.get("user") or {}).get("id", "")
+        team_id = self._event_team_id({}, body)
+        if not await self._authorize_interactive_user(
+            user_id, channel_id=channel_id, team_id=team_id
+        ):
+            logger.warning("[Slack] Unauthorized feedback click by %s - ignoring", user_id)
+            return
         logger.info(
             "[Slack] Feedback button clicked: value=%s user=%s channel=%s ts=%s",
             value,
@@ -7467,7 +7502,7 @@ class SlackAdapter(BasePlatformAdapter):
         user_name = body.get("user", {}).get("name", "unknown")
         user_id = body.get("user", {}).get("id", "")
 
-        if not self._is_interactive_user_authorized(
+        if not await self._authorize_interactive_user(
             user_id,
             channel_id=channel_id,
             user_name=user_name,
@@ -7626,11 +7661,13 @@ class SlackAdapter(BasePlatformAdapter):
         channel_id = body.get("channel", {}).get("id", "")
         user_name = body.get("user", {}).get("name", "unknown")
         user_id = body.get("user", {}).get("id", "")
+        team_id = self._event_team_id({}, body)
 
-        if not self._is_interactive_user_authorized(
+        if not await self._authorize_interactive_user(
             user_id,
             channel_id=channel_id,
             user_name=user_name,
+            team_id=team_id,
         ):
             logger.warning(
                 "[Slack] Unauthorized clarify click by %s (%s) - ignoring",
@@ -8337,6 +8374,21 @@ class SlackAdapter(BasePlatformAdapter):
             thread_id=thread_id,
             scope_id=team_id or None,
         )
+
+        # Native slash commands bypass the message-event edge, so authorize
+        # them before dispatching to the gateway.  Keep the result on the
+        # local source marker so the final gateway gate applies the same
+        # fail-closed predicate as ordinary Slack messages.
+        if not await self._authorize_external_resource(
+            str(user_id or ""),
+            chat_id=str(channel_id or ""),
+            team_id=str(team_id or ""),
+            source=source,
+        ):
+            logger.warning(
+                "[Slack] Unauthorized slash command by %s - ignoring", user_id
+            )
+            return
 
         event = MessageEvent(
             text=text,

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -2188,6 +2188,33 @@ class SlackAdapter(BasePlatformAdapter):
             # them at dispatch time.
             def _make_wrapper(cb, plugin_name):
                 async def _wrapped(ack, body, action):
+                    # Plugin callbacks are an interactive ingress just like
+                    # the built-in Block Kit handlers.  Authorize the Slack
+                    # user before invoking plugin code so a plugin cannot
+                    # perform side effects through this registration surface.
+                    body = body or {}
+                    user = body.get("user") or {}
+                    channel = body.get("channel") or {}
+                    user_id = str(user.get("id") or "").strip()
+                    channel_id = str(channel.get("id") or body.get("channel_id") or "")
+                    user_name = user.get("name") or user.get("username")
+                    team_id = self._event_team_id({}, body)
+                    if not await self._authorize_interactive_user(
+                        user_id,
+                        channel_id=channel_id,
+                        user_name=user_name,
+                        team_id=team_id,
+                    ):
+                        logger.warning(
+                            "[Slack] Unauthorized plugin action click by %s (%s) - ignoring",
+                            user_name or "unknown", user_id,
+                        )
+                        # Ack denied clicks without allowing plugin code to run.
+                        try:
+                            await ack()
+                        except Exception:
+                            pass
+                        return
                     try:
                         await cb(ack, body, action)
                     except Exception as exc:  # pragma: no cover - defensive
@@ -7253,6 +7280,7 @@ class SlackAdapter(BasePlatformAdapter):
         channel_id: str = "",
         user_name: Optional[str] = None,
         team_id: str = "",
+        source: Any = None,
     ) -> bool:
         """Check the ordinary synchronous Slack/gateway authorization policy."""
         normalized_user_id = str(user_id or "").strip()
@@ -7264,14 +7292,15 @@ class SlackAdapter(BasePlatformAdapter):
             try:
                 from gateway.session import SessionSource
 
-                return bool(auth_fn(SessionSource(
+                auth_source = source or SessionSource(
                     platform=Platform.SLACK,
                     chat_id=str(channel_id or normalized_user_id),
                     chat_type="dm" if str(channel_id or "").startswith("D") else "group",
                     user_id=normalized_user_id,
                     user_name=str(user_name).strip() if user_name else None,
                     scope_id=str(team_id) if team_id else None,
-                )))
+                )
+                return bool(auth_fn(auth_source))
             except Exception:
                 logger.debug("[Slack] Gateway interactive auth failed", exc_info=True)
                 return False
@@ -7338,6 +7367,7 @@ class SlackAdapter(BasePlatformAdapter):
             channel_id=channel_id,
             user_name=user_name,
             team_id=team_id,
+            source=source,
         )
 
     async def _handle_slash_confirm_action(self, ack, body, action) -> None:

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -17,6 +17,7 @@ import os
 import re
 import time
 import unicodedata
+from urllib.parse import urlencode
 from dataclasses import dataclass, field
 from typing import Callable, ClassVar, Dict, Optional, Any, Tuple, List
 
@@ -951,6 +952,9 @@ class SlackAdapter(BasePlatformAdapter):
         # the name cache. Used to catch peer-agent posts that arrive as plain
         # user messages without bot_id/subtype=bot_message markers.
         self._user_is_bot_cache: Dict[Tuple[str, str], bool] = {}
+        self._external_resource_cache: Dict[Tuple[str, str], float] = {}
+        self._EXTERNAL_RESOURCE_CACHE_TTL = 15.0
+        self._EXTERNAL_RESOURCE_CACHE_MAX = 1024
         self._socket_mode_task: Optional[asyncio.Task] = None
         # Multi-workspace support
         self._team_clients: Dict[str, Any] = {}  # team_id → WebClient
@@ -4285,6 +4289,77 @@ class SlackAdapter(BasePlatformAdapter):
 
     # ----- User identity resolution -----
 
+    def _external_resource_config(self) -> Optional[dict]:
+        value = (self.config.extra or {}).get("external_resource_authz")
+        return value if isinstance(value, dict) and value.get("resource") and value.get("endpoint") else None
+
+    def external_resource_authorization_required(self) -> bool:
+        return self._external_resource_config() is not None
+
+    def external_resource_authorized(self, source: Any) -> bool:
+        """Read only the local marker set by the async Slack edge check."""
+        if not self.external_resource_authorization_required():
+            return True
+        return getattr(source, "external_resource_authorized", False) is True
+
+    async def _authorize_external_resource(
+        self, user_id: str, *, chat_id: str, team_id: str, source: Any
+    ) -> bool:
+        config = self._external_resource_config()
+        if config is None:
+            return True
+        resource = str(config["resource"]).strip()
+        endpoint = str(config["endpoint"]).strip()
+        token_name = str(config.get("token_secret") or "").strip()
+        if not resource or not endpoint.startswith(("http://", "https://")) or not token_name:
+            return False
+        try:
+            token = get_secret(token_name)
+            if not token:
+                return False
+            client = self._get_client(chat_id, team_id=team_id or None) if chat_id else self._app.client
+            result = _slack_response_payload(await client.users_info(user=user_id))
+            user = result.get("user") if isinstance(result, dict) else None
+            profile = user.get("profile") if isinstance(user, dict) else None
+            email = profile.get("email") if isinstance(profile, dict) else None
+            if not isinstance(email, str) or not email.strip() or profile.get("email_verified") is not True:
+                return False
+            email = email.strip().lower()
+            key = (resource, email)
+            now = time.monotonic()
+            expiry = self._external_resource_cache.get(key)
+            if expiry is not None:
+                if expiry > now:
+                    source.external_resource_authorized = True
+                    return True
+                self._external_resource_cache.pop(key, None)
+            query = urlencode({"slug": resource, "email": email})
+            timeout = aiohttp.ClientTimeout(total=3.0)
+            headers = {"Authorization": f"Bearer {str(token).strip()}"}
+            separator = "&" if "?" in endpoint else "?"
+            async with aiohttp.ClientSession(timeout=timeout) as session:
+                async with session.get(f"{endpoint}{separator}{query}", headers=headers) as response:
+                    if response.status != 200:
+                        return False
+                    payload = await response.json(content_type=None)
+            if not isinstance(payload, dict) or payload.get("active") is not True:
+                return False
+            try:
+                cache_ttl = min(float(config.get("cache_ttl", 15.0)), 15.0)
+            except (TypeError, ValueError):
+                return False
+            if cache_ttl <= 0:
+                return False
+            self._external_resource_cache[key] = now + cache_ttl
+            if len(self._external_resource_cache) > self._EXTERNAL_RESOURCE_CACHE_MAX:
+                oldest = next(iter(self._external_resource_cache))
+                self._external_resource_cache.pop(oldest, None)
+            source.external_resource_authorized = True
+            return True
+        except Exception:
+            logger.warning("[Slack] external resource authorization failed", exc_info=True)
+            return False
+
     async def _resolve_user_name(
         self, user_id: str, chat_id: str = "", team_id: str = ""
     ) -> str:
@@ -6049,6 +6124,17 @@ class SlackAdapter(BasePlatformAdapter):
                 user_id=user_id,
                 user_name="",
             )
+            if not await self._authorize_external_resource(
+                user_id,
+                chat_id=channel_id,
+                team_id=str(team_id or ""),
+                source=_source,
+            ):
+                logger.warning(
+                    "[Slack] Early reject of user %s by external resource authorization",
+                    user_id,
+                )
+                return
             if not _auth_fn(_source):
                 logger.warning(
                     "[Slack] Early reject of unauthorized user %s in channel %s",
@@ -6056,6 +6142,9 @@ class SlackAdapter(BasePlatformAdapter):
                     channel_id,
                 )
                 return
+            _external_resource_authorized = _source.external_resource_authorized
+        else:
+            _external_resource_authorized = False
 
         # Build thread_ts for session keying.
         # In channels: fall back to ts so each top-level @mention starts a
@@ -6734,6 +6823,7 @@ class SlackAdapter(BasePlatformAdapter):
             # (they carry no user_id to match against the allowlist).
             is_bot=bool(event.get("bot_id")) or event.get("subtype") == "bot_message",
         )
+        source.external_resource_authorized = _external_resource_authorized
 
         # Per-channel ephemeral prompt
         from gateway.platforms.base import (

--- a/tests/gateway/test_slack_external_resource_authz.py
+++ b/tests/gateway/test_slack_external_resource_authz.py
@@ -106,25 +106,25 @@ async def test_expired_allow_is_not_used(adapter):
 
 @pytest.mark.asyncio
 async def test_interactive_path_requires_external_membership_before_gateway_auth(adapter):
+    seen = {}
+
     class Runner:
         def _is_user_authorized(self, source):
+            seen["marker"] = source.external_resource_authorized
             return True
 
     adapter._message_handler = Runner()._is_user_authorized
-    external = AsyncMock(return_value=False)
-    with patch.object(adapter, "_authorize_external_resource", external):
-        assert not await adapter._authorize_interactive_user(
-            "U1", channel_id="D1", team_id="T1"
-        )
-    external.assert_awaited_once()
+    async def external(_user_id, *, source, **_kwargs):
+        source.external_resource_authorized = True
+        return True
 
-    external.reset_mock()
-    external.return_value = True
+    external = AsyncMock(side_effect=external)
     with patch.object(adapter, "_authorize_external_resource", external):
         assert await adapter._authorize_interactive_user(
             "U1", channel_id="D1", team_id="T1"
         )
     external.assert_awaited_once()
+    assert seen["marker"] is True
 
 
 def test_disabled_behavior_and_wire_marker_fail_closed():

--- a/tests/gateway/test_slack_external_resource_authz.py
+++ b/tests/gateway/test_slack_external_resource_authz.py
@@ -1,0 +1,119 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+# Reuse the repository's dependency bootstrap for environments without Slack SDKs.
+import tests.gateway.test_slack  # noqa: F401
+from gateway.config import PlatformConfig, Platform
+from gateway.session import SessionSource
+from plugins.platforms.slack.adapter import SlackAdapter
+
+
+@pytest.fixture
+def adapter():
+    config = PlatformConfig(
+        enabled=True,
+        token="***",
+        extra={
+            "external_resource_authz": {
+                "resource": "agent-draper",
+                "endpoint": "https://access.example/api/admin/members",
+                "token_secret": "ACCESS_CENTER_READ_TOKEN",
+            }
+        },
+    )
+    result = SlackAdapter(config)
+    result._app = MagicMock()
+    result._app.client = AsyncMock()
+    result._get_client = MagicMock(return_value=result._app.client)
+    result._app.client.users_info = AsyncMock(return_value={
+        "user": {"profile": {"email": "User@Example.com", "email_verified": True}}
+    })
+    return result
+
+
+@pytest.mark.asyncio
+async def test_external_membership_allows_verified_member_and_caches(adapter):
+    response = MagicMock(status=200)
+    response.json = AsyncMock(return_value={"active": True})
+    request = MagicMock()
+    request.__aenter__ = AsyncMock(return_value=response)
+    request.__aexit__ = AsyncMock(return_value=None)
+    session = MagicMock()
+    session.get.return_value = request
+    session.__aenter__ = AsyncMock(return_value=session)
+    session.__aexit__ = AsyncMock(return_value=None)
+    source = SessionSource(Platform.SLACK, "D1", user_id="U1")
+    with patch("plugins.platforms.slack.adapter.get_secret", return_value="read-token"), patch(
+        "plugins.platforms.slack.adapter.aiohttp.ClientSession", return_value=session
+    ):
+        assert await adapter._authorize_external_resource("U1", chat_id="D1", team_id="T1", source=source)
+        assert await adapter._authorize_external_resource("U1", chat_id="D1", team_id="T1", source=source)
+    assert source.external_resource_authorized is True
+    assert session.get.call_count == 1
+    assert "email=user%40example.com" in session.get.call_args.args[0]
+
+
+@pytest.mark.asyncio
+async def test_external_membership_fails_closed_for_unverified_or_null(adapter):
+    source = SessionSource(Platform.SLACK, "D1", user_id="U1")
+    adapter._app.client.users_info.return_value = {
+        "user": {"profile": {"email": "user@example.com", "email_verified": False}}
+    }
+    with patch("plugins.platforms.slack.adapter.get_secret", return_value="read-token"):
+        assert not await adapter._authorize_external_resource("U1", chat_id="D1", team_id="T1", source=source)
+    adapter._app.client.users_info.return_value = {
+        "user": {"profile": {"email": "user@example.com", "email_verified": True}}
+    }
+    response = MagicMock(status=200)
+    response.json = AsyncMock(return_value=None)
+    request = MagicMock()
+    request.__aenter__ = AsyncMock(return_value=response)
+    request.__aexit__ = AsyncMock(return_value=None)
+    session = MagicMock()
+    session.get.return_value = request
+    session.__aenter__ = AsyncMock(return_value=session)
+    session.__aexit__ = AsyncMock(return_value=None)
+    with patch("plugins.platforms.slack.adapter.get_secret", return_value="read-token"), patch(
+        "plugins.platforms.slack.adapter.aiohttp.ClientSession", return_value=session
+    ):
+        assert not await adapter._authorize_external_resource("U1", chat_id="D1", team_id="T1", source=source)
+
+
+@pytest.mark.asyncio
+async def test_expired_allow_is_not_used(adapter):
+    source = SessionSource(Platform.SLACK, "D1", user_id="U1")
+    adapter._external_resource_cache[("agent-draper", "user@example.com")] = 1.0
+    adapter._app.client.users_info.return_value = {
+        "user": {"profile": {"email": "user@example.com", "email_verified": True}}
+    }
+    response = MagicMock(status=200)
+    response.json = AsyncMock(return_value={"member": True})
+    request = MagicMock()
+    request.__aenter__ = AsyncMock(return_value=response)
+    request.__aexit__ = AsyncMock(return_value=None)
+    session = MagicMock()
+    session.get.return_value = request
+    session.__aenter__ = AsyncMock(return_value=session)
+    session.__aexit__ = AsyncMock(return_value=None)
+    with patch("plugins.platforms.slack.adapter.get_secret", return_value="read-token"), patch(
+        "plugins.platforms.slack.adapter.aiohttp.ClientSession", return_value=session
+    ), patch("plugins.platforms.slack.adapter.time.monotonic", return_value=2.0):
+        assert not await adapter._authorize_external_resource("U1", chat_id="D1", team_id="T1", source=source)
+    assert source.external_resource_authorized is False
+
+
+def test_disabled_behavior_and_wire_marker_fail_closed():
+    adapter = SlackAdapter(PlatformConfig(enabled=True, token="***"))
+    source = SessionSource(Platform.SLACK, "D1", user_id="U1", external_resource_authorized=True)
+    assert not SessionSource.from_dict(source.to_dict()).external_resource_authorized
+    assert not adapter.external_resource_authorization_required()
+    assert adapter.external_resource_authorized(source)
+
+
+def test_required_adapter_needs_local_marker_for_final_gate(adapter):
+    source = SessionSource(Platform.SLACK, "D1", user_id="U1")
+    assert not adapter.external_resource_authorized(source)
+    source.external_resource_authorized = True
+    assert adapter.external_resource_authorized(source)

--- a/tests/gateway/test_slack_external_resource_authz.py
+++ b/tests/gateway/test_slack_external_resource_authz.py
@@ -104,6 +104,29 @@ async def test_expired_allow_is_not_used(adapter):
     assert source.external_resource_authorized is False
 
 
+@pytest.mark.asyncio
+async def test_interactive_path_requires_external_membership_before_gateway_auth(adapter):
+    class Runner:
+        def _is_user_authorized(self, source):
+            return True
+
+    adapter._message_handler = Runner()._is_user_authorized
+    external = AsyncMock(return_value=False)
+    with patch.object(adapter, "_authorize_external_resource", external):
+        assert not await adapter._authorize_interactive_user(
+            "U1", channel_id="D1", team_id="T1"
+        )
+    external.assert_awaited_once()
+
+    external.reset_mock()
+    external.return_value = True
+    with patch.object(adapter, "_authorize_external_resource", external):
+        assert await adapter._authorize_interactive_user(
+            "U1", channel_id="D1", team_id="T1"
+        )
+    external.assert_awaited_once()
+
+
 def test_disabled_behavior_and_wire_marker_fail_closed():
     adapter = SlackAdapter(PlatformConfig(enabled=True, token="***"))
     source = SessionSource(Platform.SLACK, "D1", user_id="U1", external_resource_authorized=True)

--- a/tests/gateway/test_slack_plugin_action_handlers.py
+++ b/tests/gateway/test_slack_plugin_action_handlers.py
@@ -213,6 +213,41 @@ class TestSlackAdapterPluginActionWiring:
         assert "hermes_approve_once" in action_ids
 
 
+    @pytest.mark.parametrize("authorized", [False, True])
+    def test_plugin_callback_is_gated_before_invocation(self, authorized):
+        """The connected wrapper denies/permits the real plugin callback path."""
+        callback = AsyncMock()
+        config = PlatformConfig(enabled=True, token="xoxb-fake")
+        adapter = SlackAdapter(config)
+        adapter._authorize_interactive_user = AsyncMock(return_value=authorized)
+
+        _result, registered = _connect_with_recording_app(
+            adapter,
+            plugin_handlers=[("plugin_action", callback, "test_plugin")],
+        )
+        wrapped = dict(registered)["plugin_action"]
+        ack = AsyncMock()
+        body = {
+            "user": {"id": "U_CLICK", "name": "clicker"},
+            "channel": {"id": "D123"},
+            "team": {"id": "T123"},
+        }
+        asyncio.run(wrapped(ack, body, {"action_id": "plugin_action"}))
+
+        adapter._authorize_interactive_user.assert_awaited_once_with(
+            "U_CLICK",
+            channel_id="D123",
+            user_name="clicker",
+            team_id="T123",
+        )
+        if authorized:
+            callback.assert_awaited_once_with(
+                ack, body, {"action_id": "plugin_action"}
+            )
+        else:
+            callback.assert_not_awaited()
+            ack.assert_awaited_once_with()
+
     def test_plugin_loader_failure_does_not_break_connect(self):
         """If get_plugin_manager() blows up, connect() must still succeed.
 


### PR DESCRIPTION
## Summary
- Add a provider-neutral external-resource authorization seam to the base adapter and final gateway authorization gate.
- Add Slack verified-email membership checks with bounded positive caching, fail-closed behavior, and a local-only non-wire authorization marker.
- Keep the implementation adapter-owned; no worker, queue, polling process, or external membership store.

## Verification
- `pytest -q tests/gateway/test_slack_external_resource_authz.py tests/gateway/test_auth_fallback.py tests/gateway/test_busy_session_auth_bypass.py tests/gateway/test_unauthorized_dm_behavior.py` — 22 passed
- `pytest -q tests/gateway/test_slack*.py` — 373 passed, 15 pre-existing warnings
- `ruff check` on changed files — passed
- `git diff --check` — passed
- Full `pytest -q` was attempted but could not complete because the environment hit disk-full / temporary logging failures; targeted and Slack suites passed.

## Security notes
- Missing secrets, unverified/missing Slack email, malformed/unknown membership responses, non-200 responses, invalid configuration, and exceptions deny.
- Positive cache is monotonic-time based, TTL-capped, and size-bounded; expired positives are never reused.
- The authorization marker is excluded from `SessionSource.to_dict()` / `from_dict()` and is rechecked at the final gateway gate.