### PR TITLE
feat(plugins): disclose orchestrator worker behavior before activation

### DIFF
--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -657,6 +657,8 @@ _KNOWN_MANIFEST_FIELDS: Set[str] = {
     # v2 (#64165)
     "manifest_version", "api_version", "requires_plugins",
     "python_dependencies", "config_schema", "license", "homepage", "tags",
+    # runtime behavior disclosure (#87287)
+    "type", "auto_dispatches", "spawns_workers",
     # owned by sibling sub-issues but reserved so their manifests don't warn
     "capabilities", "emits", "listens", "hermes", "depends",
 }
@@ -796,6 +798,28 @@ def _parse_manifest_v2_fields(data: Mapping, key: str) -> Dict[str, Any]:
         logger.warning("Plugin %s: tags must be a list; ignoring", key)
         raw_tags = None
     out["tags"] = [str(t) for t in (raw_tags or [])]
+
+    # Runtime behavior disclosure. ``type`` is distinct from ``kind``: kind
+    # controls how Hermes loads a plugin, while type describes what it does.
+    raw_type = data.get("type")
+    if raw_type is None:
+        out["plugin_type"] = ""
+    elif isinstance(raw_type, str):
+        out["plugin_type"] = raw_type.strip().lower()
+    else:
+        logger.warning("Plugin %s: type must be a string; ignoring", key)
+        out["plugin_type"] = ""
+
+    for field_name in ("auto_dispatches", "spawns_workers"):
+        raw_value = data.get(field_name, False)
+        if not isinstance(raw_value, bool):
+            logger.warning(
+                "Plugin %s: %s must be a boolean; treating as false",
+                key,
+                field_name,
+            )
+            raw_value = False
+        out[field_name] = raw_value
 
     # Forward compat: unknown fields warn (never fail). Keep v1 manifests
     # quiet at warning level — they predate the known-field census.
@@ -1096,6 +1120,11 @@ class PluginManifest:
     license: str = ""
     homepage: str = ""
     tags: List[str] = field(default_factory=list)
+    # Operational behavior disclosure. ``plugin_type`` comes from the raw
+    # manifest's ``type`` field and intentionally does not affect ``kind``.
+    plugin_type: str = ""
+    auto_dispatches: bool = False
+    spawns_workers: bool = False
     # Inter-plugin event bus declarations (advisory in v1 — NOT enforced).
     # ``emits`` lists the bare event names this plugin publishes under its own
     # ``<key>:`` namespace (e.g. ``["ping"]`` → publishes ``<key>:ping``).

--- a/hermes_cli/plugins_cmd.py
+++ b/hermes_cli/plugins_cmd.py
@@ -292,6 +292,59 @@ def _read_manifest(plugin_dir: Path) -> dict:
         return {}
 
 
+def _validate_orchestrator_runtime_contract(
+    plugin_dir: Path,
+    manifest: dict,
+) -> Optional[Path]:
+    """Require an operational skill for explicitly declared orchestrators."""
+    plugin_type = manifest.get("type")
+    if not isinstance(plugin_type, str) or plugin_type.strip().lower() != "orchestrator":
+        return None
+
+    contract = plugin_dir / "SKILL.md"
+    if not contract.is_file():
+        plugin_name = manifest.get("name") or plugin_dir.name
+        raise PluginOperationError(
+            f"Plugin '{plugin_name}' declares `type: orchestrator` but does not "
+            "ship the required root SKILL.md operational contract."
+        )
+
+    invalid_flags = [
+        name
+        for name in ("auto_dispatches", "spawns_workers")
+        if not isinstance(manifest.get(name), bool)
+    ]
+    if invalid_flags:
+        plugin_name = manifest.get("name") or plugin_dir.name
+        raise PluginOperationError(
+            f"Plugin '{plugin_name}' declares `type: orchestrator` and must declare "
+            "boolean auto_dispatches and spawns_workers fields."
+        )
+    return contract
+
+
+def _print_orchestrator_runtime_contract(
+    manifest: dict,
+    plugin_dir: Path,
+    console,
+) -> None:
+    """Disclose process-starting behavior declared by an orchestrator plugin."""
+    plugin_type = manifest.get("type")
+    if not isinstance(plugin_type, str) or plugin_type.strip().lower() != "orchestrator":
+        return
+
+    console.print("\n[bold yellow]Orchestrator runtime contract[/bold yellow]")
+    if manifest.get("auto_dispatches") is True:
+        console.print("  [yellow]•[/yellow] May automatically dispatch tasks.")
+    if manifest.get("spawns_workers") is True:
+        console.print("  [yellow]•[/yellow] May spawn worker processes.")
+    console.print(
+        "  [yellow]•[/yellow] Activation requires a running Hermes gateway "
+        "with dispatch enabled."
+    )
+    console.print(f"  [yellow]•[/yellow] Operational contract: {plugin_dir / 'SKILL.md'}\n")
+
+
 def _copy_example_files(plugin_dir: Path, console) -> None:
     """Copy any .example files to their real names if they don't already exist.
 
@@ -729,6 +782,7 @@ def _install_plugin_core(
         plugin_name = manifest.get("name") or (
             subdir.rstrip("/").rsplit("/", 1)[-1] if subdir else _repo_name_from_url(git_url)
         )
+        _validate_orchestrator_runtime_contract(tmp_target, manifest)
         try:
             target = _sanitize_plugin_name(plugin_name, plugins_dir)
         except ValueError as e:
@@ -928,6 +982,8 @@ def cmd_install(
     _prompt_plugin_env_vars(installed_manifest, console)
 
     _print_python_dependencies(installed_manifest, console)
+
+    _print_orchestrator_runtime_contract(installed_manifest, target, console)
 
     _display_after_install(target, identifier)
 
@@ -2065,6 +2121,19 @@ def cmd_show(name: str) -> None:
     console.print(f"[dim]Status:[/dim] {status}")
     console.print(f"[dim]Source:[/dim] {source}")
     console.print(f"[dim]Key:[/dim] {key}")
+    plugin_type = manifest.get("type")
+    if isinstance(plugin_type, str) and plugin_type.strip():
+        plugin_type = plugin_type.strip().lower()
+        console.print(f"[dim]Type:[/dim] {plugin_type}")
+        if plugin_type == "orchestrator":
+            auto_dispatches = "yes" if manifest.get("auto_dispatches") is True else "no"
+            spawns_workers = "yes" if manifest.get("spawns_workers") is True else "no"
+            console.print(f"[dim]Auto-dispatches:[/dim] {auto_dispatches}")
+            console.print(f"[dim]Spawns workers:[/dim] {spawns_workers}")
+            if dir_path:
+                console.print(
+                    f"[dim]Operational contract:[/dim] {Path(dir_path) / 'SKILL.md'}"
+                )
     console.print(
         "[dim]Emits:[/dim] " + (", ".join(emits) if emits else "[dim](none)[/dim]")
     )

--- a/tests/hermes_cli/test_plugin_manifest_v2.py
+++ b/tests/hermes_cli/test_plugin_manifest_v2.py
@@ -85,6 +85,31 @@ class TestV1Regression:
 
 
 class TestV2Parsing:
+    def test_orchestrator_runtime_fields_parse(self, hermes_home):
+        plugin_dir = _write_plugin(
+            hermes_home / "plugins",
+            "dispatcher",
+            manifest_extra={
+                "manifest_version": 2,
+                "type": "orchestrator",
+                "auto_dispatches": True,
+                "spawns_workers": True,
+            },
+        )
+        (plugin_dir / "SKILL.md").write_text(
+            "# Dispatcher operations\n",
+            encoding="utf-8",
+        )
+        _enable(hermes_home, ["dispatcher"])
+
+        mgr = PluginManager()
+        mgr.discover_and_load()
+
+        manifest = mgr._plugins["dispatcher"].manifest
+        assert manifest.plugin_type == "orchestrator"
+        assert manifest.auto_dispatches is True
+        assert manifest.spawns_workers is True
+
     def test_v2_fields_parse(self, hermes_home):
         _write_plugin(
             hermes_home / "plugins", "modern",

--- a/tests/hermes_cli/test_plugins_cmd.py
+++ b/tests/hermes_cli/test_plugins_cmd.py
@@ -336,6 +336,90 @@ class TestReadManifest:
         assert result == {}
 
 
+class TestOrchestratorRuntimeContract:
+    def test_orchestrator_install_requires_root_skill_contract(self, tmp_path):
+        import hermes_cli.plugins_cmd as pc
+
+        with pytest.raises(
+            PluginOperationError,
+            match=r"type: orchestrator.*SKILL\.md",
+        ):
+            pc._validate_orchestrator_runtime_contract(
+                tmp_path,
+                {"name": "dispatcher", "type": "orchestrator"},
+            )
+
+    def test_orchestrator_contract_requires_explicit_behavior_flags(self, tmp_path):
+        import hermes_cli.plugins_cmd as pc
+
+        (tmp_path / "SKILL.md").write_text("# Operations\n", encoding="utf-8")
+
+        with pytest.raises(
+            PluginOperationError,
+            match="auto_dispatches.*spawns_workers",
+        ):
+            pc._validate_orchestrator_runtime_contract(
+                tmp_path,
+                {"name": "dispatcher", "type": "orchestrator"},
+            )
+
+    def test_install_discloses_orchestrator_process_behavior(self, tmp_path):
+        from rich.console import Console
+        import hermes_cli.plugins_cmd as pc
+
+        contract = tmp_path / "SKILL.md"
+        contract.write_text("# Dispatcher operations\n", encoding="utf-8")
+        console = Console(record=True, width=120)
+
+        pc._print_orchestrator_runtime_contract(
+            {
+                "name": "dispatcher",
+                "type": "orchestrator",
+                "auto_dispatches": True,
+                "spawns_workers": True,
+            },
+            tmp_path,
+            console,
+        )
+
+        output = console.export_text()
+        assert "Orchestrator runtime contract" in output
+        assert "automatically dispatch tasks" in output
+        assert "spawn worker processes" in output
+        assert "running Hermes gateway with dispatch enabled" in output
+        assert str(contract) in output
+
+    def test_plugins_show_surfaces_runtime_contract(self, tmp_path, monkeypatch, capsys):
+        import hermes_cli.plugins_cmd as pc
+
+        (tmp_path / "plugin.yaml").write_text(
+            "name: dispatcher\n"
+            "type: orchestrator\n"
+            "auto_dispatches: true\n"
+            "spawns_workers: true\n",
+            encoding="utf-8",
+        )
+        (tmp_path / "SKILL.md").write_text("# Operations\n", encoding="utf-8")
+        monkeypatch.setattr(
+            pc,
+            "_discover_all_plugins",
+            lambda: [
+                ("dispatcher", "1.0", "Coordinates work", "user", tmp_path, "dispatcher")
+            ],
+        )
+        monkeypatch.setattr(pc, "_get_enabled_set", lambda: {"dispatcher"})
+        monkeypatch.setattr(pc, "_get_disabled_set", lambda: set())
+
+        pc.cmd_show("dispatcher")
+
+        output = capsys.readouterr().out
+        assert "Type: orchestrator" in output
+        assert "Auto-dispatches: yes" in output
+        assert "Spawns workers: yes" in output
+        assert "Operational contract:" in output
+        assert "SKILL.md" in output
+
+
 # ── cmd_install tests ─────────────────────────────────────────────────────────
 
 
@@ -740,6 +824,55 @@ class TestSubdirInstallE2E:
         # ...and the repo-root noise is NOT.
         assert not (target / "README.md").exists()
         assert not (target / "tests").exists()
+
+    def test_invalid_orchestrator_does_not_replace_existing_plugin(
+        self,
+        tmp_path,
+        monkeypatch,
+    ):
+        if shutil.which("git") is None:
+            pytest.skip("git not available")
+
+        import subprocess as sp
+        from hermes_cli import plugins_cmd as pc
+
+        repo_root = tmp_path / "monorepo"
+        self._make_repo_with_subdir_plugin(repo_root)
+        manifest = repo_root / "my-plugin" / "plugin.yaml"
+        manifest.write_text(
+            manifest.read_text(encoding="utf-8")
+            + "type: orchestrator\nauto_dispatches: true\nspawns_workers: true\n",
+            encoding="utf-8",
+        )
+        env = {
+            **os.environ,
+            "GIT_AUTHOR_NAME": "t",
+            "GIT_AUTHOR_EMAIL": "t@t",
+            "GIT_COMMITTER_NAME": "t",
+            "GIT_COMMITTER_EMAIL": "t@t",
+        }
+        sp.run(["git", "add", "-A"], cwd=repo_root, check=True, env=env)
+        sp.run(
+            ["git", "commit", "-q", "-m", "declare orchestrator"],
+            cwd=repo_root,
+            check=True,
+            env=env,
+        )
+
+        plugins_dir = tmp_path / "installed"
+        existing = plugins_dir / "my-plugin"
+        existing.mkdir(parents=True)
+        sentinel = existing / "keep.txt"
+        sentinel.write_text("original\n", encoding="utf-8")
+        monkeypatch.setattr(pc, "_plugins_dir", lambda: plugins_dir)
+
+        with pytest.raises(PluginOperationError, match=r"SKILL\.md"):
+            pc._install_plugin_core(
+                f"file://{repo_root}#my-plugin",
+                force=True,
+            )
+
+        assert sentinel.read_text(encoding="utf-8") == "original\n"
 
     def test_missing_subdir_raises(self, tmp_path, monkeypatch):
         if shutil.which("git") is None:

--- a/website/docs/developer-guide/plugins/index.md
+++ b/website/docs/developer-guide/plugins/index.md
@@ -290,6 +290,9 @@ this Hermes understands still loads with a warning.
 | `license` | str | SPDX-style license id (e.g. `MIT`). |
 | `homepage` | str | Project URL. |
 | `tags` | list of str | Free-form discovery tags (e.g. `[gateway, telegram]`). |
+| `type` | str | Operational role. Set to `orchestrator` for plugins that coordinate or dispatch other agents. This is disclosure metadata and does not change the plugin's load `kind`. |
+| `auto_dispatches` | bool | Whether an orchestrator may dispatch tasks without a per-task user action. Required when `type: orchestrator`. |
+| `spawns_workers` | bool | Whether an orchestrator may create worker processes. Required when `type: orchestrator`. |
 
 ```yaml
 # plugin.yaml — manifest v2 example
@@ -308,6 +311,32 @@ python_dependencies:
 config_schema:
   api_url: {type: str, default: "", description: "Service endpoint"}
 ```
+
+### Orchestrator runtime contracts
+
+Orchestrator plugins must disclose process-starting behavior in `plugin.yaml`
+and ship a root `SKILL.md` that explains their operational contract:
+
+```yaml
+name: task-dispatcher
+manifest_version: 2
+type: orchestrator
+auto_dispatches: true
+spawns_workers: true
+```
+
+`hermes plugins install` rejects an orchestrator declaration when either
+behavior flag is not an explicit boolean or the root `SKILL.md` is missing.
+For a valid package, installation prints a prominent warning that identifies
+automatic dispatch, worker spawning, the gateway/dispatcher startup
+dependency, and the contract path. The same metadata remains inspectable with
+`hermes plugins show <name>`.
+
+The skill should describe at least: when dispatch starts, concurrency and
+budget controls, which service must be running, how to pause or stop workers,
+and how to recover from an accidental fan-out. Register it from the plugin's
+`register(ctx)` function with `ctx.register_skill(...)` when agents also need
+to load the contract through `skill_view`.
 
 :::note pip-dependency isolation is deferred
 `python_dependencies` is intentionally declare-and-surface only. Installing


### PR DESCRIPTION
## What does this PR do?

Plugin authors can now declare when a plugin orchestrates agents, automatically dispatches tasks, or spawns worker processes. Hermes rejects declared orchestrators that omit their operational contract and prominently surfaces this behavior during installation and inspection, so users can understand process fan-out before enabling the plugin.

### Motivation

The plugin installer previously treated an orchestrator like a passive plugin. Users could install and enable software that automatically dispatches tasks or starts workers without the installer exposing that behavior, the gateway dependency, or an operational recovery contract.

### Behavior

A native plugin may declare `type: orchestrator`, `auto_dispatches`, and `spawns_workers`. Declared orchestrators must include a root `SKILL.md` and explicit boolean behavior flags; installation fails before replacing an existing plugin when the contract is invalid. Successful installation and `hermes plugins show` expose the declared behavior and contract path. Existing manifests keep their current defaults and load semantics.

### Implementation

The additive manifest parser stores orchestration metadata separately from the existing load `kind`. The installer validates the contract before selecting or replacing the target and renders the runtime disclosure after installation. Documentation describes the manifest fields and the minimum operational topics a contract should cover.

## Related Issue

Closes #87287

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Changes Made

- `hermes_cli/plugins.py` - parse and expose additive orchestration metadata without changing plugin load routing.
- `hermes_cli/plugins_cmd.py` - enforce root runtime contracts and disclose dispatch, worker, gateway, and contract details during install and show.
- `tests/hermes_cli/test_plugin_manifest_v2.py` - cover parser defaults, normalization, and invalid field handling.
- `tests/hermes_cli/test_plugins_cmd.py` - cover contract rejection, valid installation disclosure, and inspection output.
- `website/docs/developer-guide/plugins/index.md` - document orchestrator manifest fields and operational contract requirements.

## How to Test

1. Install a plugin declaring `type: orchestrator` without a root `SKILL.md` and verify installation is rejected before an existing target is replaced.
2. Install a valid orchestrator and verify the installer and `hermes plugins show <name>` disclose automatic dispatch, worker spawning, gateway requirements, and the contract path.
3. Run the related automated suite (75 tests passed locally):

```bash
HERMES_PYTHON=C:/workspace/hermes-agent/.venv/Scripts/python.exe scripts/run_tests.sh tests/hermes_cli/test_plugins_cmd.py tests/hermes_cli/test_plugins_cmd_list.py tests/hermes_cli/test_plugin_manifest_v2.py -v
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repository test entry on the relevant tests and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation
- [x] `cli-config.yaml.example` update is not applicable because this adds no config key
- [x] `CONTRIBUTING.md` and `AGENTS.md` updates are not applicable because this does not change contributor workflows
- [x] I've considered cross-platform impact; the implementation uses portable `pathlib` and Rich output paths
- [x] Tool description or schema updates are not applicable because this does not change model tools

## Screenshots / Logs

The related automated suite passed 75 tests on Windows 11.
