### PR TITLE
fix(kanban): disclose automatic worker fan-out before gateway startup

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -1475,12 +1475,14 @@ def _cmd_init(args: argparse.Namespace) -> int:
     path = kb.init_db()
     print(f"Kanban DB initialized at {path}")
 
+    config_error = None
     try:
         from hermes_cli.config import load_config
 
         loaded = load_config()
         kanban_cfg = loaded.get("kanban", {}) if isinstance(loaded, dict) else {}
-    except Exception:
+    except Exception as exc:
+        config_error = exc
         kanban_cfg = {}
 
     env_dispatch_override = os.environ.get(
@@ -1492,14 +1494,21 @@ def _cmd_init(args: argparse.Namespace) -> int:
     review_dispatch = bool(kanban_cfg.get("review_dispatch", True))
     auto_decompose = bool(kanban_cfg.get("auto_decompose", True))
     print()
-    print("Operational contract (effective config):")
-    if dispatch_enabled:
+    if config_error is not None:
+        print(
+            "Operational contract unavailable: config could not be loaded; the "
+            "gateway dispatcher will remain disabled."
+        )
+        print(f"  Config error: {config_error}")
+    elif dispatch_enabled:
+        print("Operational contract (effective config):")
         claimable_statuses = "Ready and Review tasks" if review_dispatch else "Ready tasks"
         print(
             "  Gateway dispatch: enabled — a running gateway automatically claims "
             f"{claimable_statuses} and starts one OS worker process per claim."
         )
     else:
+        print("Operational contract (effective config):")
         if review_dispatch:
             print(
                 "  Gateway dispatch: disabled — Ready and Review tasks wait for a "
@@ -1510,18 +1519,19 @@ def _cmd_init(args: argparse.Namespace) -> int:
                 "  Gateway dispatch: disabled — Ready tasks wait for a manual "
                 "dispatch pass; Review tasks remain parked for human review."
             )
-    if auto_decompose and dispatch_enabled:
-        print(
-            "  Triage orchestration: automatic when the dispatcher runs — it "
-            "auto-decomposes Triage tasks into child tasks."
-        )
-    elif auto_decompose:
-        print(
-            "  Triage orchestration: configured but inactive while gateway dispatch "
-            "is disabled; Triage tasks stay parked until you decompose them manually."
-        )
-    else:
-        print("  Triage orchestration: manual — Triage tasks stay parked until you act.")
+    if config_error is None:
+        if auto_decompose and dispatch_enabled:
+            print(
+                "  Triage orchestration: automatic when the dispatcher runs — it "
+                "auto-decomposes Triage tasks into child tasks."
+            )
+        elif auto_decompose:
+            print(
+                "  Triage orchestration: configured but inactive while gateway dispatch "
+                "is disabled; Triage tasks stay parked until you decompose them manually."
+            )
+        else:
+            print("  Triage orchestration: manual — Triage tasks stay parked until you act.")
 
     def _positive_int(value):
         try:
@@ -1530,32 +1540,33 @@ def _cmd_init(args: argparse.Namespace) -> int:
             return None
         return parsed if parsed >= 1 else None
 
-    running_cap_specs = (
-        ("board", "max_in_progress"),
-        ("per-profile", "max_in_progress_per_profile"),
-    )
-    running_caps = []
-    for label, key in running_cap_specs:
-        value = _positive_int(kanban_cfg.get(key))
-        if value is not None:
-            running_caps.append(f"{label}={value}")
-    if running_caps:
-        print(f"  Running-worker concurrency caps: {', '.join(running_caps)}")
-    else:
-        print(
-            "  No worker concurrency cap is configured; every claimable task may "
-            "start a worker."
+    if config_error is None:
+        running_cap_specs = (
+            ("board", "max_in_progress"),
+            ("per-profile", "max_in_progress_per_profile"),
         )
-    max_spawn = _positive_int(kanban_cfg.get("max_spawn"))
-    if max_spawn is not None:
-        print(f"  Per-tick spawn limit: {max_spawn} (not a running-worker cap)")
-    else:
-        print("  No per-tick spawn limit is configured.")
-    print(
-        "  Workers run as the assignee profile with that profile's enabled tools "
-        "and approval policy. Review task descriptions and profile authority "
-        "before enabling automatic dispatch."
-    )
+        running_caps = []
+        for label, key in running_cap_specs:
+            value = _positive_int(kanban_cfg.get(key))
+            if value is not None:
+                running_caps.append(f"{label}={value}")
+        if running_caps:
+            print(f"  Running-worker concurrency caps: {', '.join(running_caps)}")
+        else:
+            print(
+                "  No worker concurrency cap is configured; every claimable task may "
+                "start a worker."
+            )
+        max_spawn = _positive_int(kanban_cfg.get("max_spawn"))
+        if max_spawn is not None:
+            print(f"  Per-tick spawn limit: {max_spawn} (not a running-worker cap)")
+        else:
+            print("  No per-tick spawn limit is configured.")
+        print(
+            "  Workers run as the assignee profile with that profile's enabled tools "
+            "and approval policy. Review task descriptions and profile authority "
+            "before enabling automatic dispatch."
+        )
 
     print()
     # Enumerate profiles on disk so the user knows what assignees are
@@ -1576,7 +1587,9 @@ def _cmd_init(args: argparse.Namespace) -> int:
         print("No profiles found under ~/.hermes/profiles/.")
         print("Create one with `hermes -p <name> setup` before assigning tasks.")
     print()
-    if dispatch_enabled:
+    if config_error is not None:
+        print("Resolve the config error before starting the gateway dispatcher.")
+    elif dispatch_enabled:
         print("Next step: start the gateway so ready tasks actually get picked up.")
         print("  hermes gateway start")
         print()

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -1483,7 +1483,12 @@ def _cmd_init(args: argparse.Namespace) -> int:
     except Exception:
         kanban_cfg = {}
 
-    dispatch_enabled = bool(kanban_cfg.get("dispatch_in_gateway", True))
+    env_dispatch_override = os.environ.get(
+        "HERMES_KANBAN_DISPATCH_IN_GATEWAY", ""
+    ).strip().lower()
+    dispatch_enabled = bool(kanban_cfg.get("dispatch_in_gateway", True)) and (
+        env_dispatch_override not in {"0", "false", "no", "off"}
+    )
     review_dispatch = bool(kanban_cfg.get("review_dispatch", True))
     auto_decompose = bool(kanban_cfg.get("auto_decompose", True))
     print()
@@ -1495,36 +1500,57 @@ def _cmd_init(args: argparse.Namespace) -> int:
             f"{claimable_statuses} and starts one OS worker process per claim."
         )
     else:
-        print(
-            "  Gateway dispatch: disabled — Ready and Review tasks wait for a "
-            "manual dispatch pass."
-        )
-    if auto_decompose:
+        if review_dispatch:
+            print(
+                "  Gateway dispatch: disabled — Ready and Review tasks wait for a "
+                "manual dispatch pass."
+            )
+        else:
+            print(
+                "  Gateway dispatch: disabled — Ready tasks wait for a manual "
+                "dispatch pass; Review tasks remain parked for human review."
+            )
+    if auto_decompose and dispatch_enabled:
         print(
             "  Triage orchestration: automatic when the dispatcher runs — it "
             "auto-decomposes Triage tasks into child tasks."
         )
+    elif auto_decompose:
+        print(
+            "  Triage orchestration: configured but inactive while gateway dispatch "
+            "is disabled; Triage tasks stay parked until you decompose them manually."
+        )
     else:
         print("  Triage orchestration: manual — Triage tasks stay parked until you act.")
 
-    cap_specs = (
-        ("host", "max_concurrent_workers"),
+    def _positive_int(value):
+        try:
+            parsed = int(value)
+        except (TypeError, ValueError):
+            return None
+        return parsed if parsed >= 1 else None
+
+    running_cap_specs = (
         ("board", "max_in_progress"),
         ("per-profile", "max_in_progress_per_profile"),
-        ("dispatcher", "max_spawn"),
     )
-    caps = []
-    for label, key in cap_specs:
-        raw = kanban_cfg.get(key)
-        if isinstance(raw, int) and not isinstance(raw, bool) and raw > 0:
-            caps.append(f"{label}={raw}")
-    if caps:
-        print(f"  Worker concurrency caps: {', '.join(caps)}")
+    running_caps = []
+    for label, key in running_cap_specs:
+        value = _positive_int(kanban_cfg.get(key))
+        if value is not None:
+            running_caps.append(f"{label}={value}")
+    if running_caps:
+        print(f"  Running-worker concurrency caps: {', '.join(running_caps)}")
     else:
         print(
             "  No worker concurrency cap is configured; every claimable task may "
             "start a worker."
         )
+    max_spawn = _positive_int(kanban_cfg.get("max_spawn"))
+    if max_spawn is not None:
+        print(f"  Per-tick spawn limit: {max_spawn} (not a running-worker cap)")
+    else:
+        print("  No per-tick spawn limit is configured.")
     print(
         "  Workers run as the assignee profile with that profile's enabled tools "
         "and approval policy. Review task descriptions and profile authority "

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -1475,6 +1475,62 @@ def _cmd_init(args: argparse.Namespace) -> int:
     path = kb.init_db()
     print(f"Kanban DB initialized at {path}")
 
+    try:
+        from hermes_cli.config import load_config
+
+        loaded = load_config()
+        kanban_cfg = loaded.get("kanban", {}) if isinstance(loaded, dict) else {}
+    except Exception:
+        kanban_cfg = {}
+
+    dispatch_enabled = bool(kanban_cfg.get("dispatch_in_gateway", True))
+    review_dispatch = bool(kanban_cfg.get("review_dispatch", True))
+    auto_decompose = bool(kanban_cfg.get("auto_decompose", True))
+    print()
+    print("Operational contract (effective config):")
+    if dispatch_enabled:
+        claimable_statuses = "Ready and Review tasks" if review_dispatch else "Ready tasks"
+        print(
+            "  Gateway dispatch: enabled — a running gateway automatically claims "
+            f"{claimable_statuses} and starts one OS worker process per claim."
+        )
+    else:
+        print(
+            "  Gateway dispatch: disabled — Ready and Review tasks wait for a "
+            "manual dispatch pass."
+        )
+    if auto_decompose:
+        print(
+            "  Triage orchestration: automatic when the dispatcher runs — it "
+            "auto-decomposes Triage tasks into child tasks."
+        )
+    else:
+        print("  Triage orchestration: manual — Triage tasks stay parked until you act.")
+
+    cap_specs = (
+        ("host", "max_concurrent_workers"),
+        ("board", "max_in_progress"),
+        ("per-profile", "max_in_progress_per_profile"),
+        ("dispatcher", "max_spawn"),
+    )
+    caps = []
+    for label, key in cap_specs:
+        raw = kanban_cfg.get(key)
+        if isinstance(raw, int) and not isinstance(raw, bool) and raw > 0:
+            caps.append(f"{label}={raw}")
+    if caps:
+        print(f"  Worker concurrency caps: {', '.join(caps)}")
+    else:
+        print(
+            "  No worker concurrency cap is configured; every claimable task may "
+            "start a worker."
+        )
+    print(
+        "  Workers run as the assignee profile with that profile's enabled tools "
+        "and approval policy. Review task descriptions and profile authority "
+        "before enabling automatic dispatch."
+    )
+
     print()
     # Enumerate profiles on disk so the user knows what assignees are
     # already addressable. Multica does this auto-detection on its
@@ -1494,14 +1550,19 @@ def _cmd_init(args: argparse.Namespace) -> int:
         print("No profiles found under ~/.hermes/profiles/.")
         print("Create one with `hermes -p <name> setup` before assigning tasks.")
     print()
-    print("Next step: start the gateway so ready tasks actually get picked up.")
-    print("  hermes gateway start")
-    print()
-    print(
-        "The gateway hosts an embedded dispatcher that ticks every 60 seconds\n"
-        "by default (config: kanban.dispatch_interval_seconds). Without a\n"
-        "running gateway, tasks stay in 'ready' forever."
-    )
+    if dispatch_enabled:
+        print("Next step: start the gateway so ready tasks actually get picked up.")
+        print("  hermes gateway start")
+        print()
+        print(
+            "The gateway hosts an embedded dispatcher that ticks every 60 seconds\n"
+            "by default (config: kanban.dispatch_interval_seconds). Without a\n"
+            "running gateway, tasks stay in 'ready' forever."
+        )
+    else:
+        print("Automatic dispatch is off. Ready tasks remain parked.")
+        print("Run `hermes kanban dispatch` for a manual pass, or explicitly set")
+        print("`kanban.dispatch_in_gateway: true` before starting the gateway.")
     return 0
 
 

--- a/tests/hermes_cli/test_kanban_init_dispatch_contract.py
+++ b/tests/hermes_cli/test_kanban_init_dispatch_contract.py
@@ -28,6 +28,7 @@ def test_init_discloses_automatic_worker_authority_and_uncapped_dispatch(
     assert "auto-decomposes Triage tasks" in output
     assert "one OS worker process per claim" in output
     assert "No worker concurrency cap is configured" in output
+    assert "No per-tick spawn limit is configured" in output
     assert "enabled tools and approval policy" in output
 
 
@@ -42,9 +43,9 @@ def test_init_reports_manual_modes_and_effective_concurrency_caps(
             "kanban": {
                 "dispatch_in_gateway": False,
                 "auto_decompose": False,
-                "max_concurrent_workers": 3,
-                "max_in_progress": 2,
+                "max_in_progress": "2",
                 "max_in_progress_per_profile": 1,
+                "max_spawn": "4",
             }
         },
     )
@@ -54,4 +55,31 @@ def test_init_reports_manual_modes_and_effective_concurrency_caps(
     output = capsys.readouterr().out
     assert "Gateway dispatch: disabled" in output
     assert "Triage orchestration: manual" in output
-    assert "Worker concurrency caps: host=3, board=2, per-profile=1" in output
+    assert "Running-worker concurrency caps: board=2, per-profile=1" in output
+    assert "Per-tick spawn limit: 4 (not a running-worker cap)" in output
+
+
+def test_init_honors_gateway_dispatch_environment_override(
+    monkeypatch, capsys, tmp_path: Path
+):
+    monkeypatch.setattr(kanban_cli.kb, "init_db", lambda: tmp_path / "kanban.db")
+    monkeypatch.setattr(kanban_cli.kb, "list_profiles_on_disk", lambda: [])
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {
+            "kanban": {
+                "dispatch_in_gateway": True,
+                "review_dispatch": False,
+                "auto_decompose": True,
+            }
+        },
+    )
+    monkeypatch.setenv("HERMES_KANBAN_DISPATCH_IN_GATEWAY", "off")
+
+    assert kanban_cli._cmd_init(Namespace()) == 0
+
+    output = capsys.readouterr().out
+    assert "Gateway dispatch: disabled" in output
+    assert "Ready tasks wait for a manual dispatch pass" in output
+    assert "Review tasks remain parked for human review" in output
+    assert "configured but inactive while gateway dispatch is disabled" in output

--- a/tests/hermes_cli/test_kanban_init_dispatch_contract.py
+++ b/tests/hermes_cli/test_kanban_init_dispatch_contract.py
@@ -83,3 +83,23 @@ def test_init_honors_gateway_dispatch_environment_override(
     assert "Ready tasks wait for a manual dispatch pass" in output
     assert "Review tasks remain parked for human review" in output
     assert "configured but inactive while gateway dispatch is disabled" in output
+
+
+def test_init_does_not_claim_dispatch_is_enabled_when_config_load_fails(
+    monkeypatch, capsys, tmp_path: Path
+):
+    monkeypatch.setattr(kanban_cli.kb, "init_db", lambda: tmp_path / "kanban.db")
+    monkeypatch.setattr(kanban_cli.kb, "list_profiles_on_disk", lambda: [])
+
+    def fail_config_load():
+        raise RuntimeError("cannot read config")
+
+    monkeypatch.setattr("hermes_cli.config.load_config", fail_config_load)
+
+    assert kanban_cli._cmd_init(Namespace()) == 0
+
+    output = capsys.readouterr().out
+    assert "Operational contract unavailable" in output
+    assert "gateway dispatcher will remain disabled" in output
+    assert "Resolve the config error before starting the gateway dispatcher" in output
+    assert "Gateway dispatch: enabled" not in output

--- a/tests/hermes_cli/test_kanban_init_dispatch_contract.py
+++ b/tests/hermes_cli/test_kanban_init_dispatch_contract.py
@@ -1,0 +1,57 @@
+"""Setup-time disclosure for Kanban's dispatcher runtime contract."""
+
+from argparse import Namespace
+from pathlib import Path
+
+from hermes_cli import kanban as kanban_cli
+
+
+def test_init_discloses_automatic_worker_authority_and_uncapped_dispatch(
+    monkeypatch, capsys, tmp_path: Path
+):
+    monkeypatch.setattr(kanban_cli.kb, "init_db", lambda: tmp_path / "kanban.db")
+    monkeypatch.setattr(kanban_cli.kb, "list_profiles_on_disk", lambda: ["dev"])
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {
+            "kanban": {
+                "dispatch_in_gateway": True,
+                "auto_decompose": True,
+            }
+        },
+    )
+
+    assert kanban_cli._cmd_init(Namespace()) == 0
+
+    output = capsys.readouterr().out
+    assert "automatically claims Ready and Review tasks" in output
+    assert "auto-decomposes Triage tasks" in output
+    assert "one OS worker process per claim" in output
+    assert "No worker concurrency cap is configured" in output
+    assert "enabled tools and approval policy" in output
+
+
+def test_init_reports_manual_modes_and_effective_concurrency_caps(
+    monkeypatch, capsys, tmp_path: Path
+):
+    monkeypatch.setattr(kanban_cli.kb, "init_db", lambda: tmp_path / "kanban.db")
+    monkeypatch.setattr(kanban_cli.kb, "list_profiles_on_disk", lambda: [])
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {
+            "kanban": {
+                "dispatch_in_gateway": False,
+                "auto_decompose": False,
+                "max_concurrent_workers": 3,
+                "max_in_progress": 2,
+                "max_in_progress_per_profile": 1,
+            }
+        },
+    )
+
+    assert kanban_cli._cmd_init(Namespace()) == 0
+
+    output = capsys.readouterr().out
+    assert "Gateway dispatch: disabled" in output
+    assert "Triage orchestration: manual" in output
+    assert "Worker concurrency caps: host=3, board=2, per-profile=1" in output

--- a/website/docs/user-guide/features/kanban.md
+++ b/website/docs/user-guide/features/kanban.md
@@ -193,6 +193,16 @@ sandbox so the absolute paths in the worker context are reachable.
 
 ## Quick start
 
+:::warning Review the dispatch contract before starting the gateway
+Kanban workers are full OS processes. When `kanban.dispatch_in_gateway` is
+enabled, a running gateway automatically claims Ready and Review tasks and
+starts workers under each assignee profile's enabled tools and approval policy.
+When `kanban.auto_decompose` is enabled, Triage tasks can also fan out into
+multiple child tasks automatically. Run `hermes kanban init` and review its
+effective-mode and concurrency-cap summary before starting the gateway; inspect
+task descriptions and assignee authority before enabling automatic dispatch.
+:::
+
 The commands below are **you** (the human) setting up the board and creating tasks. Once a task is assigned, the dispatcher spawns the assigned profile as a worker, and from there **the model drives the task through `kanban_*` tool calls, not CLI commands** — see [How workers interact with the board](#how-workers-interact-with-the-board).
 
 ```bash


### PR DESCRIPTION
## What does this PR do?

`hermes kanban init` previously told operators to start the gateway without showing that the effective configuration could automatically claim Ready and Review tasks, fan out Triage work, and start one OS worker per claim. That omission allowed automatic dispatch to be activated without understanding assignee authority or effective concurrency limits, which can create many workers and exhaust host resources.

This change prints the effective dispatch, review, triage, running-worker cap, and per-tick spawn behavior during initialization. It also fails closed when configuration cannot be loaded and puts the same operator warning before the documentation quick start.

### Symptom

Operators can initialize Kanban and follow the startup instructions without seeing that gateway startup may automatically claim tasks, decompose Triage work, and spawn OS workers under assignee profiles.

### Impact

A board with multiple claimable or Triage tasks can start more workers than the operator expects. The reported Windows incident produced more than 30 workers and required a hard restart; the broader blast radius is unknown.

### Bug Cause

**Trigger:** `hermes_cli/kanban.py` / `_cmd_init()` / successful Kanban initialization

**Causal chain:**
1. An operator initializes Kanban and reads the generated next-step guidance.
2. `_cmd_init()` recommends starting the gateway but omits automatic dispatch, decomposition, concurrency, and assignee-authority details.
3. The operator can start the gateway without realizing that existing tasks may immediately produce multiple worker processes.

**Why it is wrong:** Setup guidance activates a process-spawning subsystem without disclosing its effective behavior or limits at the decision point.

**Working sibling / contrast:** Detailed documentation describes dispatcher behavior later in the guide, but the initialization output and quick-start entry point did not surface it before gateway startup.

**Ruled out:** The reported destructive command did not execute, so this change does not add a Kanban-specific approval bypass. Worker commands continue to use each assignee profile normal tools and approval policy.

### Fix

Load the effective Kanban configuration during initialization, honor the documented gateway environment override, and report automatic versus manual dispatch, Review handling, Triage orchestration, actual running-worker caps, and the distinct per-tick spawn limit. When config loading fails, report dispatch as unavailable instead of claiming it is enabled. Add focused behavior tests and a pre-quick-start documentation warning.

## Related Issue

Closes #87283

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/kanban.py` - disclose the effective dispatcher runtime contract and fail closed on config errors.
- `tests/hermes_cli/test_kanban_init_dispatch_contract.py` - cover automatic, manual, environment-override, concurrency, and config-failure output.
- `website/docs/user-guide/features/kanban.md` - warn operators before the quick-start gateway command.

## How to Test

1. Run `scripts/run_tests.sh tests/hermes_cli/test_kanban_init_dispatch_contract.py`.
2. Run `scripts/run_tests.sh tests/hermes_cli/test_kanban_core_functionality.py -k config_default_dispatch_in_gateway_is_true` and the neighboring deprecated-daemon-help check.
3. Compile the changed Python files and run `git diff --check`.

Verified at commit `4a690d03e`: 4 focused tests passed, 2 neighboring checks passed, compilation passed, and the diff check passed.

## Checklist

### Code

- [x] I have read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this is not a duplicate
- [x] My PR contains only changes related to this fix
- [x] I ran the repository test entry on the relevant tests and all selected tests pass
- [x] I added tests for my changes
- [x] I tested on Windows 11

### Documentation & Housekeeping

- [x] I updated relevant documentation
- [x] Config example changes are N/A because this PR does not add or change config keys
- [x] Contributor workflow documentation changes are N/A
- [x] I considered cross-platform impact; the output and tests are platform-independent
- [x] Tool description and schema changes are N/A
