### PR TITLE
feat(kanban): prevent automatic dispatch from overwhelming hosts

### DIFF
--- a/docs/kanban/multi-gateway.md
+++ b/docs/kanban/multi-gateway.md
@@ -7,8 +7,8 @@ to platform APIs and delivers messages for its profile's subscribers.
 ## Single-dispatcher posture
 
 Only one gateway owns the kanban dispatcher. The owning gateway keeps
-`kanban.dispatch_in_gateway: true` (the default); every other gateway sets it
-to `false`.
+`kanban.dispatch_in_gateway: true`; the setting defaults to `false`, so every
+other gateway remains notification-only without extra configuration.
 
 **Why this matters:** dispatching is single-owner so multiple gateways do not
 race to spawn the same work. Notification delivery is profile-owned instead:
@@ -18,12 +18,13 @@ processes.
 
 ## Configuration
 
-On the dispatch-owning gateway (typically the `default` profile), no change is
-needed. On every other profile gateway, add to `~/.hermes/config.yaml`:
+On the dispatch-owning gateway (typically the `default` profile), add to
+`~/.hermes/config.yaml`:
 
 ```yaml
 kanban:
-  dispatch_in_gateway: false
+  dispatch_in_gateway: true
+  max_concurrent_workers: 3
 ```
 
 Or set the env var: `HERMES_KANBAN_DISPATCH_IN_GATEWAY=false`

--- a/gateway/kanban_watchers.py
+++ b/gateway/kanban_watchers.py
@@ -1182,7 +1182,7 @@ class GatewayKanbanWatchersMixin:
     async def _kanban_dispatcher_watcher(self) -> None:
         """Embedded kanban dispatcher — one tick every `dispatch_interval_seconds`.
 
-        Gated by `kanban.dispatch_in_gateway` in config.yaml (default True).
+        Gated by `kanban.dispatch_in_gateway` in config.yaml (default False).
         When true, the gateway hosts the single dispatcher for this profile:
         no separate `hermes kanban daemon` process needed. When false, the
         loop exits immediately and an external daemon is expected.
@@ -1217,7 +1217,7 @@ class GatewayKanbanWatchersMixin:
             logger.warning("kanban dispatcher: cannot load config (%s); disabled", exc)
             return
         kanban_cfg = cfg.get("kanban", {}) if isinstance(cfg, dict) else {}
-        if not kanban_cfg.get("dispatch_in_gateway", True):
+        if not kanban_cfg.get("dispatch_in_gateway", False):
             logger.info(
                 "kanban dispatcher: disabled via config kanban.dispatch_in_gateway=false"
             )
@@ -1268,6 +1268,26 @@ class GatewayKanbanWatchersMixin:
         max_spawn = kanban_cfg.get("max_spawn", None)
         if max_spawn is not None:
             logger.info("kanban dispatcher: max_spawn=%s", max_spawn)
+
+        raw_max_concurrent_workers = kanban_cfg.get("max_concurrent_workers", 3)
+        try:
+            max_concurrent_workers = int(raw_max_concurrent_workers)
+        except (TypeError, ValueError):
+            logger.warning(
+                "kanban dispatcher: invalid kanban.max_concurrent_workers=%r; using 3",
+                raw_max_concurrent_workers,
+            )
+            max_concurrent_workers = 3
+        if max_concurrent_workers < 1:
+            logger.warning(
+                "kanban dispatcher: kanban.max_concurrent_workers=%r is below 1; using 3",
+                raw_max_concurrent_workers,
+            )
+            max_concurrent_workers = 3
+        logger.info(
+            "kanban dispatcher: max_concurrent_workers=%d",
+            max_concurrent_workers,
+        )
 
         # Cap the number of simultaneously running tasks so slow workers
         # (local LLMs, resource-constrained hosts) don't pile up and time
@@ -1461,6 +1481,7 @@ class GatewayKanbanWatchersMixin:
                     conn,
                     board=slug,
                     max_spawn=max_spawn,
+                    max_concurrent_workers=max_concurrent_workers,
                     max_in_progress=max_in_progress,
                     failure_limit=failure_limit,
                     stale_timeout_seconds=stale_timeout_seconds,

--- a/gateway/kanban_watchers.py
+++ b/gateway/kanban_watchers.py
@@ -1207,19 +1207,23 @@ class GatewayKanbanWatchersMixin:
             logger.warning("kanban dispatcher: config loader unavailable; disabled")
             return
         env_override = os.environ.get("HERMES_KANBAN_DISPATCH_IN_GATEWAY", "").strip().lower()
-        if env_override in {"0", "false", "no", "off"}:
-            logger.info("kanban dispatcher: disabled via HERMES_KANBAN_DISPATCH_IN_GATEWAY env")
-            return
 
         try:
             cfg = _load_config()
         except Exception as exc:
             logger.warning("kanban dispatcher: cannot load config (%s); disabled", exc)
             return
-        kanban_cfg = cfg.get("kanban", {}) if isinstance(cfg, dict) else {}
-        if not kanban_cfg.get("dispatch_in_gateway", False):
+        raw_kanban_cfg = cfg.get("kanban", {}) if isinstance(cfg, dict) else {}
+        kanban_cfg = raw_kanban_cfg if isinstance(raw_kanban_cfg, dict) else {}
+        dispatch_enabled = (
+            env_override not in {"0", "false", "no", "off"}
+            if env_override
+            else bool(kanban_cfg.get("dispatch_in_gateway", False))
+        )
+        if not dispatch_enabled:
             logger.info(
-                "kanban dispatcher: disabled via config kanban.dispatch_in_gateway=false"
+                "kanban dispatcher: disabled; set kanban.dispatch_in_gateway=true "
+                "to enable automatic dispatch"
             )
             return
 
@@ -1229,9 +1233,8 @@ class GatewayKanbanWatchersMixin:
             logger.warning("kanban dispatcher: kanban_db not importable; dispatcher disabled")
             return
 
-        # Single-dispatcher backstop. dispatch_in_gateway defaults to true, so a
-        # new profile gateway (or a same-profile restart race) can silently
-        # start a second dispatcher; concurrent dispatchers double reclaim
+        # Single-dispatcher backstop. Config drift or a same-profile restart
+        # race can start a second dispatcher; concurrent dispatchers double reclaim
         # frequency, double claim-attempt events, and — with
         # wal_autocheckpoint=0 — concurrent manual WAL checkpoints can corrupt
         # index pages. The lock lives at the machine-global kanban root

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -12768,9 +12768,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         self._spawn_supervised(self._kanban_notifier_watcher, "kanban_notifier_watcher")
 
         # Start background kanban dispatcher — spawns workers for ready
-        # tasks. Gated by `kanban.dispatch_in_gateway` (default True).
-        # When false, users run `hermes kanban daemon` externally or
-        # simply don't use kanban; this loop becomes a no-op.
+        # tasks. Gated by the explicitly enabled
+        # `kanban.dispatch_in_gateway` setting. When false, ready tasks remain
+        # queued for one-shot/manual dispatch and this loop becomes a no-op.
         self._spawn_supervised(self._kanban_dispatcher_watcher, "kanban_dispatcher_watcher")
 
         # Start background reconnection watcher for platforms that failed at startup

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -2427,12 +2427,12 @@ DEFAULT_CONFIG = {
         # behaviour — e.g. for a profile that prefers explicit
         # ``kanban_notify-subscribe`` calls per task.
         "auto_subscribe_on_create": True,
-        # Run the dispatcher inside the gateway process. On by default —
-        # the cost is ~300µs every `dispatch_interval_seconds` when idle,
-        # and gateway is the supervisor users already have. Set to false
-        # only if you run the dispatcher as a separate systemd unit or
-        # don't want the gateway to spawn workers.
-        "dispatch_in_gateway": True,
+        # Run the dispatcher inside the gateway process. This is deliberately
+        # opt-in: installing or starting a messaging gateway must not silently
+        # turn every ready card into a worker process. Enable it explicitly on
+        # hosts that should own automatic dispatch. One-shot
+        # `hermes kanban dispatch` remains available while this is false.
+        "dispatch_in_gateway": False,
         # Automatically claim tasks in the first-class review column and spawn
         # the assigned profile with the bundled sdlc-review skill. Disable for
         # boards where every review is performed manually from the dashboard.
@@ -2440,6 +2440,11 @@ DEFAULT_CONFIG = {
         # Seconds between dispatcher ticks (idle or not). Lower = snappier
         # pickup of newly-ready tasks; higher = less SQL pressure.
         "dispatch_interval_seconds": 60,
+        # Host-wide worker cap shared by every board and dispatch entry point.
+        # This is distinct from max_in_progress (a per-board override) and the
+        # per-profile cap below. A small safe default prevents a newly enabled
+        # dispatcher from exhausting CPU, memory, or model quota on a fan-out.
+        "max_concurrent_workers": 3,
         # Auto-block after this many consecutive non-success attempts for the
         # same task/profile (spawn_failed, timed_out, or crashed). Reassignment
         # resets the streak for the new profile.

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -147,9 +147,9 @@ def _check_dispatcher_presence(
 
     Used by ``hermes kanban create`` (and callers) to warn when a task
     will sit in ``ready`` because nothing is there to pick it up.
-    Defensive against import failures and config-read errors — if the
-    probe itself errors, we return ``(True, "")`` so we don't spam
-    false warnings (better to miss a warning than to cry wolf).
+    Defensive against liveness-probe failures, which remain silent to avoid
+    false warnings. Configuration failures instead mirror the actual watcher
+    and report dispatch disabled because automatic dispatch fails closed.
 
     ``hermes_home`` scopes the probe to a named profile's directory. The
     dashboard plugin API passes it because the dashboard backend process can
@@ -183,10 +183,17 @@ def _check_dispatcher_presence(
     # Even if the gateway is up, dispatch_in_gateway may be off.
     try:
         from hermes_cli.config import load_config
-        cfg = load_config()
-        dispatch_on = bool(cfg.get("kanban", {}).get("dispatch_in_gateway", False))
+
+        env_override = os.environ.get(
+            "HERMES_KANBAN_DISPATCH_IN_GATEWAY", ""
+        ).strip().lower()
+        if env_override:
+            dispatch_on = env_override not in {"0", "false", "no", "off"}
+        else:
+            cfg = load_config()
+            dispatch_on = bool(cfg.get("kanban", {}).get("dispatch_in_gateway", False))
     except Exception:
-        dispatch_on = True  # can't tell — assume default
+        dispatch_on = False  # watcher also fails closed when config cannot load
 
     if pid and dispatch_on:
         return (True, f"gateway pid={pid}, dispatch enabled")
@@ -2749,13 +2756,15 @@ def _cmd_daemon(args: argparse.Namespace) -> int:
             "hermes kanban daemon: DEPRECATED — the dispatcher now runs\n"
             "inside the gateway. To use kanban:\n"
             "\n"
-            "    hermes gateway start       # starts the gateway + embedded dispatcher\n"
+            "    hermes config set kanban.dispatch_in_gateway true\n"
+            "    hermes gateway start       # starts the explicitly enabled dispatcher\n"
             "\n"
             "Ready tasks will be picked up on the next dispatcher tick\n"
             "(default: every 60 seconds). Configure via config.yaml:\n"
             "\n"
             "    kanban:\n"
-            "      dispatch_in_gateway: true      # default\n"
+            "      dispatch_in_gateway: true      # explicit opt-in; default false\n"
+            "      max_concurrent_workers: 3      # host-wide safety cap\n"
             "      dispatch_interval_seconds: 60\n"
             "      failure_limit: 2              # consecutive non-success attempts before auto-block\n"
             "\n"
@@ -2784,7 +2793,7 @@ def _cmd_daemon(args: argparse.Namespace) -> int:
         f"Kanban dispatcher running STANDALONE via --force "
         f"(interval={args.interval}s, pid={os.getpid()}). "
         f"Ctrl-C to stop. NOTE: if a gateway is also running with "
-        f"dispatch_in_gateway=true (default), you have two dispatchers "
+        f"dispatch_in_gateway=true, you have two dispatchers "
         f"racing for claims.",
         file=sys.stderr,
     )

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -139,7 +139,7 @@ def _check_dispatcher_presence(
     """Return ``(running, message)``.
 
     - ``running=True``: a gateway is alive for this HERMES_HOME and its
-      config has ``kanban.dispatch_in_gateway`` on (default). Message
+      config explicitly has ``kanban.dispatch_in_gateway`` on. Message
       is a short status line.
     - ``running=False``: either no gateway is running, or the gateway
       is running but the config flag is off. Message is human guidance
@@ -184,7 +184,7 @@ def _check_dispatcher_presence(
     try:
         from hermes_cli.config import load_config
         cfg = load_config()
-        dispatch_on = bool(cfg.get("kanban", {}).get("dispatch_in_gateway", True))
+        dispatch_on = bool(cfg.get("kanban", {}).get("dispatch_in_gateway", False))
     except Exception:
         dispatch_on = True  # can't tell — assume default
 
@@ -195,17 +195,17 @@ def _check_dispatcher_presence(
             False,
             "Gateway is running but kanban.dispatch_in_gateway=false in "
             "config.yaml — the task will sit in 'ready' until you flip it "
-            "back on and restart the gateway, OR run the legacy "
-            "standalone daemon (`hermes kanban daemon --force`)."
+            "on and restart the gateway, OR run a one-shot manual pass "
+            "(`hermes kanban dispatch`)."
         )
     return (
         False,
         "No gateway is running — the task will sit in 'ready' until you "
         "start it. Run:\n"
         "    hermes gateway start\n"
-        "The gateway hosts an embedded dispatcher (tick interval 60s by "
-        "default); your task will be picked up on the next tick after "
-        "the gateway comes up."
+        "Then explicitly enable `kanban.dispatch_in_gateway: true` in "
+        "config.yaml and restart it, or run `hermes kanban dispatch` for "
+        "a one-shot manual pass."
     )
 
 
@@ -2618,7 +2618,8 @@ def _cmd_tail(args: argparse.Namespace) -> int:
 
 def _cmd_dispatch(args: argparse.Namespace) -> int:
     # Honour kanban.default_assignee as the fallback for unassigned ready
-    # tasks (#27145), kanban.max_in_progress as the global concurrency cap
+    # tasks (#27145), kanban.max_concurrent_workers as the host-wide cap,
+    # kanban.max_in_progress as the per-board concurrency cap
     # (#33488), kanban.max_in_progress_per_profile as the per-profile
     # cap (#21582), and kanban.max_spawn as the per-tick spawn limit
     # (#28805). Same semantics as the gateway dispatch path so behavior
@@ -2643,6 +2644,9 @@ def _cmd_dispatch(args: argparse.Namespace) -> int:
             _kanban_cfg.get("max_in_progress_per_profile")
         )
         max_in_progress = _coerce_positive_int(_kanban_cfg.get("max_in_progress"))
+        max_concurrent_workers = _coerce_positive_int(
+            _kanban_cfg.get("max_concurrent_workers", 3)
+        ) or 3
         # CLI --max overrides config kanban.max_spawn when both are present;
         # CLI is the more explicit signal so it wins.
         cli_max = getattr(args, "max", None)
@@ -2653,12 +2657,14 @@ def _cmd_dispatch(args: argparse.Namespace) -> int:
         default_assignee = None
         max_in_progress_per_profile = None
         max_in_progress = None
+        max_concurrent_workers = 3
         max_spawn = getattr(args, "max", None)
     with kb.connect_closing() as conn:
         res = kb.dispatch_once(
             conn,
             dry_run=args.dry_run,
             max_spawn=max_spawn,
+            max_concurrent_workers=max_concurrent_workers,
             max_in_progress=max_in_progress,
             failure_limit=getattr(args, "failure_limit", kb.DEFAULT_SPAWN_FAILURE_LIMIT),
             default_assignee=default_assignee,
@@ -2848,9 +2854,21 @@ def _cmd_daemon(args: argparse.Namespace) -> int:
             return False
 
     try:
+        try:
+            from hermes_cli.config import load_config
+
+            raw_worker_cap = (load_config() or {}).get("kanban", {}).get(
+                "max_concurrent_workers", 3
+            )
+            max_concurrent_workers = int(raw_worker_cap)
+            if max_concurrent_workers < 1:
+                max_concurrent_workers = 3
+        except (TypeError, ValueError, AttributeError):
+            max_concurrent_workers = 3
         kb.run_daemon(
             interval=args.interval,
             max_spawn=args.max,
+            max_concurrent_workers=max_concurrent_workers,
             failure_limit=getattr(args, "failure_limit", kb.DEFAULT_SPAWN_FAILURE_LIMIT),
             on_tick=_on_tick,
         )

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -2872,7 +2872,7 @@ def _cmd_daemon(args: argparse.Namespace) -> int:
             max_concurrent_workers = int(raw_worker_cap)
             if max_concurrent_workers < 1:
                 max_concurrent_workers = 3
-        except (TypeError, ValueError, AttributeError):
+        except Exception:
             max_concurrent_workers = 3
         kb.run_daemon(
             interval=args.interval,

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -9519,6 +9519,62 @@ def review_dispatch_enabled() -> bool:
         return True
 
 
+def _count_running_workers_across_boards(
+    current_conn: sqlite3.Connection,
+    current_db_path: Path,
+) -> int:
+    """Count running tasks across every active board on this host.
+
+    Sibling boards are opened read-only so a capacity check neither creates a
+    missing database nor runs schema migrations. Unreadable boards raise and
+    let the caller fail closed instead of risking an unbounded worker burst.
+    """
+    current_path = current_db_path.resolve()
+    try:
+        paths = [
+            kanban_db_path(board=meta.get("slug") or DEFAULT_BOARD)
+            for meta in list_boards(include_archived=False)
+        ]
+    except Exception as exc:
+        raise RuntimeError("could not enumerate kanban boards") from exc
+    if all(path.resolve() != current_path for path in paths):
+        paths.append(current_path)
+
+    total = 0
+    seen: set[Path] = set()
+    for path in paths:
+        resolved = path.resolve()
+        if resolved in seen:
+            continue
+        seen.add(resolved)
+        if resolved == current_path:
+            total += int(
+                current_conn.execute(
+                    "SELECT COUNT(*) FROM tasks "
+                    "WHERE status = 'running' AND worker_pid IS NOT NULL"
+                ).fetchone()[0]
+            )
+            continue
+        if not resolved.is_file():
+            continue
+        try:
+            sibling = sqlite3.connect(
+                resolved.as_uri() + "?mode=ro", uri=True, timeout=1.0
+            )
+            try:
+                total += int(
+                    sibling.execute(
+                        "SELECT COUNT(*) FROM tasks "
+                        "WHERE status = 'running' AND worker_pid IS NOT NULL"
+                    ).fetchone()[0]
+                )
+            finally:
+                sibling.close()
+        except Exception as exc:
+            raise RuntimeError(f"could not read worker count from {resolved}") from exc
+    return total
+
+
 def dispatch_once(
     conn: sqlite3.Connection,
     *,
@@ -9526,6 +9582,7 @@ def dispatch_once(
     ttl_seconds: Optional[int] = None,
     dry_run: bool = False,
     max_spawn: Optional[int] = None,
+    max_concurrent_workers: Optional[int] = None,
     max_in_progress: Optional[int] = None,
     failure_limit: int = DEFAULT_SPAWN_FAILURE_LIMIT,
     stale_timeout_seconds: int = 0,
@@ -9545,9 +9602,10 @@ def dispatch_once(
     ``DispatchResult`` with ``skipped_locked=True`` and does no DB writes;
     the holder is already making progress on the same board.
 
-    The lock is keyed off the board's resolved DB path, so unrelated
-    boards tick in parallel. See :func:`_dispatch_tick_lock` for the
-    cross-process / cross-platform mechanics.
+    When ``max_concurrent_workers`` is set, a second machine-global dispatch
+    lock serializes the count-and-spawn decision across boards and processes.
+    The host-wide budget composes with the per-board and per-profile caps;
+    the strictest limit wins.
     """
     try:
         db_path = kanban_db_path(board=board)
@@ -9571,17 +9629,18 @@ def dispatch_once(
         )
         _fire_dispatch_tick_hook(result, board=board, dry_run=dry_run)
         return result
-    with _dispatch_tick_lock(db_path) as held:
-        if not held:
-            result = DispatchResult(skipped_locked=True)
-        else:
-            result = _dispatch_once_locked(
+
+    def _run_board_tick(effective_max_in_progress: Optional[int]) -> DispatchResult:
+        with _dispatch_tick_lock(db_path) as held:
+            if not held:
+                return DispatchResult(skipped_locked=True)
+            board_result = _dispatch_once_locked(
                 conn,
                 spawn_fn=spawn_fn,
                 ttl_seconds=ttl_seconds,
                 dry_run=dry_run,
                 max_spawn=max_spawn,
-                max_in_progress=max_in_progress,
+                max_in_progress=effective_max_in_progress,
                 failure_limit=failure_limit,
                 stale_timeout_seconds=stale_timeout_seconds,
                 board=board,
@@ -9593,7 +9652,42 @@ def dispatch_once(
             # checkpoint (see _maybe_checkpoint_wal; the -wal file size is
             # bounded by journal_size_limit on the writer's natural reset).
             _maybe_checkpoint_wal(conn, db_path)
-    # The dispatch lock has been released here. Fire the tick observer
+            return board_result
+
+    if isinstance(max_concurrent_workers, int) and max_concurrent_workers > 0:
+        global_lock_path = kanban_home() / "kanban" / ".worker-capacity"
+        with _dispatch_tick_lock(global_lock_path) as global_held:
+            if not global_held:
+                result = DispatchResult(skipped_locked=True)
+            else:
+                current_running = int(
+                    conn.execute(
+                        "SELECT COUNT(*) FROM tasks "
+                        "WHERE status = 'running' AND worker_pid IS NOT NULL"
+                    ).fetchone()[0]
+                )
+                try:
+                    global_running = _count_running_workers_across_boards(
+                        conn, db_path
+                    )
+                except Exception as exc:
+                    _log.warning(
+                        "kanban dispatch: host-wide worker count failed (%s); "
+                        "failing closed at max_concurrent_workers=%d",
+                        exc,
+                        max_concurrent_workers,
+                    )
+                    global_running = max_concurrent_workers
+                available = max(0, max_concurrent_workers - global_running)
+                host_board_limit = current_running + available
+                effective_max = host_board_limit
+                if max_in_progress is not None:
+                    effective_max = min(effective_max, max_in_progress)
+                result = _run_board_tick(effective_max)
+    else:
+        result = _run_board_tick(max_in_progress)
+
+    # Both dispatch locks have been released here. Fire the tick observer
     # strictly OUTSIDE the single-writer critical section (#56066 sweeper
     # finding / #64231 disposition): a slow subscriber must never extend
     # the lock hold and stall a sibling dispatcher's tick.
@@ -10561,6 +10655,7 @@ def run_daemon(
     *,
     interval: float = 60.0,
     max_spawn: Optional[int] = None,
+    max_concurrent_workers: Optional[int] = 3,
     failure_limit: int = DEFAULT_SPAWN_FAILURE_LIMIT,
     stop_event=None,
     on_tick=None,
@@ -10598,6 +10693,7 @@ def run_daemon(
                 res = dispatch_once(
                     conn,
                     max_spawn=max_spawn,
+                    max_concurrent_workers=max_concurrent_workers,
                     failure_limit=failure_limit,
                 )
             if on_tick is not None:

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -1681,7 +1681,7 @@ def _cross_process_init_lock(path: Path):
 
 
 @contextlib.contextmanager
-def _dispatch_tick_lock(db_path: Path):
+def _dispatch_tick_lock(db_path: Path, *, fail_open: bool = True):
     """Non-blocking single-writer guard around one dispatcher tick.
 
     Yields ``True`` when this process holds the board's dispatch lock and
@@ -1710,6 +1710,8 @@ def _dispatch_tick_lock(db_path: Path):
     platforms without ``fcntl``/``msvcrt`` the guard degrades to a no-op
     (yields ``True``) — single-writer enforcement is best-effort and the
     orphan-dispatcher scenario is specific to POSIX service managers.
+    Callers that protect a hard safety invariant may set ``fail_open=False``
+    so inability to create the lock skips the guarded operation.
     """
     lock_path = db_path.with_name(db_path.name + ".dispatch.lock")
     handle = None
@@ -1739,8 +1741,7 @@ def _dispatch_tick_lock(db_path: Path):
                 acquired = False
     except OSError:
         # Could not even open the lock file (permissions, read-only FS).
-        # Degrade to a no-op so a probe failure never blocks dispatch.
-        acquired = True
+        acquired = fail_open
         handle = None
     try:
         yield acquired
@@ -9531,10 +9532,18 @@ def _count_running_workers_across_boards(
     """
     current_path = current_db_path.resolve()
     try:
-        paths = [
-            kanban_db_path(board=meta.get("slug") or DEFAULT_BOARD)
-            for meta in list_boards(include_archived=False)
-        ]
+        paths = []
+        for meta in list_boards(include_archived=False):
+            slug = meta.get("slug") or DEFAULT_BOARD
+            # Do not use kanban_db_path() here: workers inherit a pinned
+            # HERMES_KANBAN_DB for isolation, and that override would collapse
+            # every sibling slug to the current board and undercount capacity.
+            path = (
+                kanban_home() / "kanban.db"
+                if slug == DEFAULT_BOARD
+                else board_dir(slug) / "kanban.db"
+            )
+            paths.append(path)
     except Exception as exc:
         raise RuntimeError("could not enumerate kanban boards") from exc
     if all(path.resolve() != current_path for path in paths):
@@ -9656,7 +9665,7 @@ def dispatch_once(
 
     if isinstance(max_concurrent_workers, int) and max_concurrent_workers > 0:
         global_lock_path = kanban_home() / "kanban" / ".worker-capacity"
-        with _dispatch_tick_lock(global_lock_path) as global_held:
+        with _dispatch_tick_lock(global_lock_path, fail_open=False) as global_held:
             if not global_held:
                 result = DispatchResult(skipped_locked=True)
             else:

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -9533,7 +9533,9 @@ def _count_running_workers_across_boards(
     current_path = current_db_path.resolve()
     try:
         paths = []
-        for meta in list_boards(include_archived=False):
+        # Archived boards can still have live worker processes until their
+        # current runs exit, so they continue to consume host capacity.
+        for meta in list_boards(include_archived=True):
             slug = meta.get("slug") or DEFAULT_BOARD
             # Do not use kanban_db_path() here: workers inherit a pinned
             # HERMES_KANBAN_DB for isolation, and that override would collapse

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -2294,7 +2294,7 @@ def dispatch(
         max_concurrent_workers = int(raw_worker_cap)
         if max_concurrent_workers < 1:
             max_concurrent_workers = 3
-    except (TypeError, ValueError, AttributeError):
+    except Exception:
         max_concurrent_workers = 3
     conn = _conn(board=board)
     try:

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -2285,10 +2285,25 @@ def dispatch(
     board: Optional[str] = Query(None),
 ):
     board = _resolve_board(board)
+    try:
+        from hermes_cli.config import load_config
+
+        raw_worker_cap = (load_config() or {}).get("kanban", {}).get(
+            "max_concurrent_workers", 3
+        )
+        max_concurrent_workers = int(raw_worker_cap)
+        if max_concurrent_workers < 1:
+            max_concurrent_workers = 3
+    except (TypeError, ValueError, AttributeError):
+        max_concurrent_workers = 3
     conn = _conn(board=board)
     try:
         result = kanban_db.dispatch_once(
-            conn, dry_run=dry_run, max_spawn=max_n, board=board,
+            conn,
+            dry_run=dry_run,
+            max_spawn=max_n,
+            max_concurrent_workers=max_concurrent_workers,
+            board=board,
         )
         # DispatchResult is a dataclass.
         try:

--- a/plugins/kanban/systemd/hermes-kanban-dispatcher.service
+++ b/plugins/kanban/systemd/hermes-kanban-dispatcher.service
@@ -1,8 +1,9 @@
-# DEPRECATED — the kanban dispatcher now runs inside the gateway by
-# default (config key: kanban.dispatch_in_gateway, default true). To
+# DEPRECATED — the kanban dispatcher can run inside the gateway after
+# explicit opt-in (config key: kanban.dispatch_in_gateway, default false). To
 # migrate:
 #
 #     systemctl --user disable --now hermes-kanban-dispatcher.service
+#     hermes config set kanban.dispatch_in_gateway true
 #     # then make sure a gateway is running; e.g. a systemd user unit
 #     # for `hermes gateway start`. The gateway hosts the dispatcher.
 #

--- a/skills/autonomous-ai-agents/hermes-agent/references/background-systems.md
+++ b/skills/autonomous-ai-agents/hermes-agent/references/background-systems.md
@@ -88,9 +88,10 @@ sessions still have zero `kanban_*` schema footprint unless configured.
   `kanban_link`; profiles that explicitly enable the `kanban` toolset
   outside a dispatcher-spawned task also get `kanban_list` and
   `kanban_unblock` for board routing.
-- **Dispatcher** runs inside the gateway by default
+- **Dispatcher** runs inside the gateway only after explicit opt-in
   (`kanban.dispatch_in_gateway: true`) — reclaims stale claims,
   promotes ready tasks, atomically claims, spawns assigned profiles.
+  A host-wide `kanban.max_concurrent_workers` cap defaults to 3.
   Auto-blocks a task after `failure_limit` consecutive spawn failures
   (default 2; configurable via `kanban.failure_limit` or per-task
   `max_retries`).

--- a/tests/hermes_cli/test_kanban_cli_dispatch_passthrough.py
+++ b/tests/hermes_cli/test_kanban_cli_dispatch_passthrough.py
@@ -40,6 +40,7 @@ def test_cli_dispatch_passes_max_in_progress_from_config(isolated_kanban_home, m
     fake_config = {
         "kanban": {
             "max_in_progress": 3,
+            "max_concurrent_workers": 4,
             "max_spawn": 5,
             "default_assignee": "default",
             "max_in_progress_per_profile": 2,
@@ -64,6 +65,7 @@ def test_cli_dispatch_passes_max_in_progress_from_config(isolated_kanban_home, m
     assert captured.get("max_in_progress") == 3, (
         f"CLI must pass kanban.max_in_progress from config; got {captured.get('max_in_progress')!r}"
     )
+    assert captured.get("max_concurrent_workers") == 4
     assert captured.get("max_spawn") == 5, (
         f"CLI must pass kanban.max_spawn from config when --max is not provided; got {captured.get('max_spawn')!r}"
     )

--- a/tests/hermes_cli/test_kanban_core_functionality.py
+++ b/tests/hermes_cli/test_kanban_core_functionality.py
@@ -947,16 +947,12 @@ def test_legacy_migration_no_legacy_columns_at_all(tmp_path):
 # Gateway-embedded dispatcher: config, CLI warnings, daemon deprecation stub
 # ---------------------------------------------------------------------------
 
-def test_config_default_dispatch_in_gateway_is_true():
-    """Default config must enable gateway-embedded dispatch out of the box.
-    Flipping this default to false is a user-visible behaviour change and
-    should require a conscious migration."""
+def test_config_defaults_require_dispatch_opt_in_and_bound_workers():
+    """Installing a gateway must not silently start an unbounded worker fan-out."""
     from hermes_cli.config import DEFAULT_CONFIG
     kanban = DEFAULT_CONFIG.get("kanban", {})
-    assert kanban.get("dispatch_in_gateway") is True, (
-        "kanban.dispatch_in_gateway default should be True; got "
-        f"{kanban.get('dispatch_in_gateway')!r}"
-    )
+    assert kanban.get("dispatch_in_gateway") is False
+    assert kanban.get("max_concurrent_workers") == 3
     interval = kanban.get("dispatch_interval_seconds")
     assert isinstance(interval, (int, float)) and interval >= 1, (
         f"dispatch_interval_seconds must be a positive number, got {interval!r}"

--- a/tests/hermes_cli/test_kanban_dispatch_safety.py
+++ b/tests/hermes_cli/test_kanban_dispatch_safety.py
@@ -124,6 +124,37 @@ def test_host_worker_cap_counts_siblings_from_pinned_worker_env(tmp_path, monkey
     assert len(result.spawned) == 1
 
 
+def test_host_worker_cap_counts_archived_boards_with_live_workers(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    from hermes_cli import kanban_db as kb
+    from hermes_cli import profiles
+
+    kb._INITIALIZED_PATHS.clear()
+    kb.create_board("archived")
+    monkeypatch.setattr(profiles, "profile_exists", lambda _name: True)
+    with kb.connect_closing(board="archived") as archived_conn:
+        task_id = kb.create_task(archived_conn, title="running", assignee="worker")
+        archived_conn.execute(
+            "UPDATE tasks SET status='running', worker_pid=950000 WHERE id=?",
+            (task_id,),
+        )
+        archived_conn.commit()
+    kb.write_board_metadata("archived", archived=True)
+
+    with kb.connect_closing(board="default") as default_conn:
+        for index in range(3):
+            kb.create_task(default_conn, title=f"ready-{index}", assignee="worker")
+        result = kb.dispatch_once(
+            default_conn,
+            board="default",
+            spawn_fn=lambda *_args, **_kwargs: 960_000,
+            max_concurrent_workers=3,
+        )
+
+    assert len(result.spawned) == 2
+
+
 def test_host_worker_cap_fails_closed_when_capacity_lock_cannot_open(
     tmp_path, monkeypatch
 ):
@@ -175,3 +206,29 @@ def test_dashboard_dispatch_passes_host_worker_cap(monkeypatch):
 
     plugin_api.dispatch(dry_run=False, max_n=8, board="default")
     assert captured["max_concurrent_workers"] == 2
+
+
+def test_dashboard_dispatch_uses_safe_cap_when_config_load_fails(monkeypatch):
+    from hermes_cli import kanban_db as kb
+    import hermes_cli.config as config
+    from plugins.kanban.dashboard import plugin_api
+
+    captured = {}
+
+    class FakeConn:
+        def close(self):
+            pass
+
+    def fail_config_load():
+        raise OSError("config unreadable")
+
+    monkeypatch.setattr(config, "load_config", fail_config_load)
+    monkeypatch.setattr(plugin_api, "_conn", lambda **_kwargs: FakeConn())
+    monkeypatch.setattr(
+        plugin_api.kanban_db,
+        "dispatch_once",
+        lambda _conn, **kwargs: captured.update(kwargs) or kb.DispatchResult(),
+    )
+
+    plugin_api.dispatch(dry_run=False, max_n=8, board="default")
+    assert captured["max_concurrent_workers"] == 3

--- a/tests/hermes_cli/test_kanban_dispatch_safety.py
+++ b/tests/hermes_cli/test_kanban_dispatch_safety.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+from pathlib import Path
 
 
 def test_gateway_dispatcher_requires_explicit_opt_in(monkeypatch):
@@ -15,6 +16,30 @@ def test_gateway_dispatcher_requires_explicit_opt_in(monkeypatch):
 
     asyncio.run(runner._kanban_dispatcher_watcher())
     assert not hasattr(runner, "_kanban_dispatcher_lock_handle")
+
+
+def test_gateway_dispatcher_positive_env_override_enables(monkeypatch):
+    from gateway.run import GatewayRunner
+    import gateway.kanban_watchers as watchers
+    import hermes_cli.config as config
+
+    runner = object.__new__(GatewayRunner)
+    runner._running = False
+    acquired = []
+    monkeypatch.setenv("HERMES_KANBAN_DISPATCH_IN_GATEWAY", "1")
+    monkeypatch.setattr(config, "load_config", lambda: {"kanban": {}})
+    monkeypatch.setattr(
+        watchers,
+        "_acquire_singleton_lock",
+        lambda path: (acquired.append(path), "held"),
+    )
+
+    async def no_sleep(_seconds):
+        return None
+
+    monkeypatch.setattr(watchers.asyncio, "sleep", no_sleep)
+    asyncio.run(runner._kanban_dispatcher_watcher())
+    assert acquired, "positive runtime override must reach dispatcher startup"
 
 
 def test_host_worker_cap_is_shared_across_boards(tmp_path, monkeypatch):
@@ -61,3 +86,92 @@ def test_host_worker_cap_is_shared_across_boards(tmp_path, monkeypatch):
     assert len(second.spawned) == 1
     assert second_running == 1
     assert second_ready == 1
+
+
+def test_host_worker_cap_counts_siblings_from_pinned_worker_env(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    from hermes_cli import kanban_db as kb
+    from hermes_cli import profiles
+
+    kb._INITIALIZED_PATHS.clear()
+    kb.create_board("second")
+    monkeypatch.setattr(profiles, "profile_exists", lambda _name: True)
+
+    with kb.connect_closing(board="second") as second_conn:
+        for index in range(2):
+            task_id = kb.create_task(
+                second_conn, title=f"running-{index}", assignee="worker"
+            )
+            second_conn.execute(
+                "UPDATE tasks SET status='running', worker_pid=? WHERE id=?",
+                (920_000 + index, task_id),
+            )
+        second_conn.commit()
+
+    default_path = kb.kanban_db_path(board="default")
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(default_path))
+    with kb.connect_closing(board="default") as default_conn:
+        for index in range(2):
+            kb.create_task(default_conn, title=f"ready-{index}", assignee="worker")
+        result = kb.dispatch_once(
+            default_conn,
+            board="default",
+            spawn_fn=lambda *_args, **_kwargs: 930_000,
+            max_concurrent_workers=3,
+        )
+
+    assert len(result.spawned) == 1
+
+
+def test_host_worker_cap_fails_closed_when_capacity_lock_cannot_open(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    from hermes_cli import kanban_db as kb
+    from hermes_cli import profiles
+
+    kb._INITIALIZED_PATHS.clear()
+    monkeypatch.setattr(profiles, "profile_exists", lambda _name: True)
+    with kb.connect_closing() as conn:
+        kb.create_task(conn, title="ready", assignee="worker")
+        original_open = Path.open
+
+        def guarded_open(path, *args, **kwargs):
+            if path.name == ".worker-capacity.dispatch.lock":
+                raise PermissionError("capacity lock denied")
+            return original_open(path, *args, **kwargs)
+
+        monkeypatch.setattr(Path, "open", guarded_open)
+        result = kb.dispatch_once(
+            conn,
+            spawn_fn=lambda *_args, **_kwargs: 940_000,
+            max_concurrent_workers=3,
+        )
+
+    assert result.skipped_locked is True
+    assert result.spawned == []
+
+
+def test_dashboard_dispatch_passes_host_worker_cap(monkeypatch):
+    from hermes_cli import kanban_db as kb
+    import hermes_cli.config as config
+    from plugins.kanban.dashboard import plugin_api
+
+    captured = {}
+
+    class FakeConn:
+        def close(self):
+            pass
+
+    monkeypatch.setattr(config, "load_config", lambda: {"kanban": {"max_concurrent_workers": 2}})
+    monkeypatch.setattr(plugin_api, "_conn", lambda **_kwargs: FakeConn())
+    monkeypatch.setattr(
+        plugin_api.kanban_db,
+        "dispatch_once",
+        lambda _conn, **kwargs: captured.update(kwargs) or kb.DispatchResult(),
+    )
+
+    plugin_api.dispatch(dry_run=False, max_n=8, board="default")
+    assert captured["max_concurrent_workers"] == 2

--- a/tests/hermes_cli/test_kanban_dispatch_safety.py
+++ b/tests/hermes_cli/test_kanban_dispatch_safety.py
@@ -1,0 +1,63 @@
+"""Safety contracts for automatic Kanban worker dispatch."""
+
+from __future__ import annotations
+
+import asyncio
+
+
+def test_gateway_dispatcher_requires_explicit_opt_in(monkeypatch):
+    from gateway.run import GatewayRunner
+    import hermes_cli.config as config
+
+    runner = object.__new__(GatewayRunner)
+    runner._running = True
+    monkeypatch.setattr(config, "load_config", lambda: {"kanban": {}})
+
+    asyncio.run(runner._kanban_dispatcher_watcher())
+    assert not hasattr(runner, "_kanban_dispatcher_lock_handle")
+
+
+def test_host_worker_cap_is_shared_across_boards(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    from hermes_cli import kanban_db as kb
+    from hermes_cli import profiles
+
+    kb._INITIALIZED_PATHS.clear()
+    kb.create_board("second")
+    monkeypatch.setattr(profiles, "profile_exists", lambda _name: True)
+    pids = iter(range(910_000, 910_010))
+
+    def spawn(*_args, **_kwargs):
+        return next(pids)
+
+    with kb.connect_closing(board="default") as default_conn:
+        for index in range(2):
+            kb.create_task(default_conn, title=f"default-{index}", assignee="worker")
+        first = kb.dispatch_once(
+            default_conn,
+            board="default",
+            spawn_fn=spawn,
+            max_concurrent_workers=3,
+        )
+
+    with kb.connect_closing(board="second") as second_conn:
+        for index in range(2):
+            kb.create_task(second_conn, title=f"second-{index}", assignee="worker")
+        second = kb.dispatch_once(
+            second_conn,
+            board="second",
+            spawn_fn=spawn,
+            max_concurrent_workers=3,
+        )
+        second_running = second_conn.execute(
+            "SELECT COUNT(*) FROM tasks WHERE status = 'running'"
+        ).fetchone()[0]
+        second_ready = second_conn.execute(
+            "SELECT COUNT(*) FROM tasks WHERE status = 'ready'"
+        ).fetchone()[0]
+
+    assert len(first.spawned) == 2
+    assert len(second.spawned) == 1
+    assert second_running == 1
+    assert second_ready == 1

--- a/toolsets.py
+++ b/toolsets.py
@@ -315,7 +315,7 @@ TOOLSETS = {
         "description": (
             "Kanban multi-agent coordination — only active when the agent "
             "is spawned by the kanban dispatcher (HERMES_KANBAN_TASK env "
-            "set). The dispatcher runs inside the gateway by default; see "
+            "set). Gateway dispatch is explicitly opt-in; see "
             "`kanban.dispatch_in_gateway` in config.yaml. Lets workers mark "
             "tasks done with structured handoffs, enter first-class review "
             "(request_review — not a block), return review changes, block for human input, "

--- a/website/docs/user-guide/features/kanban.md
+++ b/website/docs/user-guide/features/kanban.md
@@ -66,7 +66,7 @@ They coexist: a kanban worker may call `delegate_task` internally during its run
   - `scratch` (default) — fresh tmp dir under `~/.hermes/kanban/workspaces/<id>/` (or `~/.hermes/kanban/boards/<slug>/workspaces/<id>/` on non-default boards). **Deleted when the task completes** — scratch is ephemeral by design. Files explicitly declared through `kanban_complete(artifacts=[...])` are copied into durable per-task attachment storage before cleanup; existing deliverable paths in legacy completion summaries receive the same treatment. Other scratch files are removed. A missing declared scratch artifact keeps the task in-flight so the worker can correct the path and retry. Use `worktree:` or `dir:<path>` when the whole workspace should remain available. The first time a scratch workspace is created on an install, the dispatcher logs a warning and emits a `tip_scratch_workspace` event on the task (visible via `hermes kanban show <id>`).
   - `dir:<path>` — an existing shared directory (Obsidian vault, mail ops dir, per-account folder). **Must be an absolute path.** Relative paths like `dir:../tenants/foo/` are rejected at dispatch because they'd resolve against whatever CWD the dispatcher happens to be in, which is ambiguous and a confused-deputy escape vector. The path is otherwise trusted — it's your box, your filesystem, the worker runs with your uid. This is the trusted-local-user threat model; kanban is single-host by design. **Preserved on completion.**
   - `worktree` — a git worktree under `.worktrees/<id>/` for coding tasks. Use `worktree:<path>` to pin the exact target path. Worker-side `git worktree add` creates it, using `--branch` when provided. **Preserved on completion.**
-- **Dispatcher** — a long-lived loop that, every N seconds (default 60): reclaims stale claims, reclaims crashed workers (PID gone but TTL not yet expired), promotes ready tasks, atomically claims, spawns assigned profiles. Runs **inside the gateway** by default (`kanban.dispatch_in_gateway: true`). One dispatcher sweeps all boards per tick; workers are spawned with `HERMES_KANBAN_BOARD` pinned so they can't see other boards. After `kanban.failure_limit` consecutive spawn failures on the same task (default: 2) the dispatcher auto-blocks it with the last error as the reason — prevents thrashing on tasks whose profile doesn't exist, workspace can't mount, etc.
+- **Dispatcher** — a long-lived loop that, every N seconds (default 60): reclaims stale claims, reclaims crashed workers (PID gone but TTL not yet expired), promotes ready tasks, atomically claims, spawns assigned profiles. It can run inside the gateway after explicit opt-in (`kanban.dispatch_in_gateway: true`). One dispatcher sweeps all boards per tick; the default host-wide `kanban.max_concurrent_workers: 3` cap prevents fan-outs from exhausting the machine. Workers are spawned with `HERMES_KANBAN_BOARD` pinned so they can't see other boards. After `kanban.failure_limit` consecutive spawn failures on the same task the dispatcher auto-blocks it with the last error as the reason — prevents thrashing on tasks whose profile doesn't exist, workspace can't mount, etc.
 - **Tenant** — optional string namespace *within* a board. One specialist fleet can serve multiple businesses (`--tenant business-a`) with data isolation by workspace path and memory key prefix. Tenants are a soft filter; boards are the hard isolation boundary.
 
 ## Boards (multi-project)
@@ -199,7 +199,8 @@ The commands below are **you** (the human) setting up the board and creating tas
 # 1. Create the board (you)
 hermes kanban init
 
-# 2. Start the gateway (hosts the embedded dispatcher)
+# 2. Explicitly enable automatic dispatch, then start the gateway
+hermes config set kanban.dispatch_in_gateway true
 hermes gateway start
 
 # 3. Create a task (you — or an orchestrator agent via kanban_create)
@@ -215,16 +216,19 @@ hermes kanban stats
 
 When the dispatcher picks up `t_abcd` and spawns the `researcher` profile, the very first thing that worker's model does is call `kanban_show()` to read its task. It doesn't run `hermes kanban show t_abcd`.
 
-### Gateway-embedded dispatcher (default)
+### Gateway-embedded dispatcher (opt-in)
 
-The dispatcher runs inside the gateway process. Nothing to install, no
-separate service to manage — if the gateway is up, ready tasks get picked
-up on the next tick (60s by default).
+The dispatcher can run inside the gateway process, but automatic dispatch is
+off by default. This prevents installing or starting a messaging backend from
+silently turning every ready card into a worker. Enable it explicitly on the
+one gateway that should own dispatch. Otherwise cards remain in `ready` until
+you run `hermes kanban dispatch` manually.
 
 ```yaml
 # config.yaml
 kanban:
-  dispatch_in_gateway: true        # default
+  dispatch_in_gateway: true        # explicit opt-in; default is false
+  max_concurrent_workers: 3        # host-wide across all boards
   dispatch_interval_seconds: 60    # default
   review_dispatch: true            # default: spawn the assigned profile with
                                    # the bundled sdlc-review skill. Set false
@@ -791,13 +795,16 @@ All commands are also available as a slash command in the interactive CLI and in
 
 | Config key | Default | What it does |
 |------------|---------|--------------|
-| `kanban.max_in_progress` | unset (unlimited) | Caps the number of simultaneously running tasks. When the board already has N running, the dispatcher skips spawning more — useful for slow workers (local LLMs, resource-constrained hosts) so they finish what they have before more pile up and time out. Invalid or below-1 values log a warning and behave as unlimited. |
+| `kanban.max_concurrent_workers` | `3` | Host-wide worker cap shared across all boards and dispatch entry points. The count-and-spawn decision is cross-process locked so concurrent gateway/manual ticks cannot overbook it. Invalid or below-1 config values fall back to `3`. |
+| `kanban.max_in_progress` | unset (unlimited) | Optional per-board cap. When the board already has N running, the dispatcher skips spawning more. It composes with the host-wide cap; the stricter limit wins. |
 | `kanban.max_in_progress_per_profile` | unset (unlimited) | Per-profile variant of `max_in_progress` — caps how many tasks any single assignee profile may run concurrently. Useful when one profile is slow or rate-limited but others should keep flowing. Applies alongside the board-wide `max_in_progress`; both must allow a spawn for it to proceed. |
 | `kanban.auto_promote_children` | `true` | After `decompose_triage_task()` produces children with no parent-blocker dependencies, they're automatically promoted to `ready` so the dispatcher can pick them up. Set to `false` to require manual review — children stay in `todo` until you promote them. |
 | `kanban.default_workdir` | unset | Board-level default working directory applied to new tasks when neither `--workspace` nor the task itself overrides it. Per-task `workspace:` still wins. |
 
 ```yaml
 kanban:
+  dispatch_in_gateway: true
+  max_concurrent_workers: 3
   max_in_progress: 2
   auto_promote_children: false
   default_workdir: ~/work/active-project


### PR DESCRIPTION
## What does this PR do?

Starting a messaging gateway no longer silently turns ready Kanban cards into worker processes. Gateway dispatch now requires an explicit `kanban.dispatch_in_gateway: true` opt-in, and every dispatch entry point shares a host-wide `kanban.max_concurrent_workers` safety cap that defaults to 3.

The host cap composes with the existing per-board, per-profile, and per-tick limits. Capacity checks include all active and archived boards with live workers, serialize count-and-spawn decisions across processes, and fail closed when capacity cannot be established safely. Manual one-shot dispatch remains available when gateway dispatch is disabled.

## Related Issue

Closes #87284

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Changes Made

- `hermes_cli/config_defaults.py` - default gateway dispatch to disabled and add the host-wide worker cap.
- `gateway/kanban_watchers.py` and `gateway/run.py` - require explicit opt-in and pass the configured cap to embedded dispatch.
- `hermes_cli/kanban_db.py` - serialize capacity checks and count live workers across all boards before spawning.
- `hermes_cli/kanban.py` and `plugins/kanban/dashboard/plugin_api.py` - enforce the same safe cap for CLI, daemon, and dashboard dispatch paths.
- `tests/hermes_cli/test_kanban_dispatch_safety.py` and related tests - cover opt-in behavior, cross-board capacity, lock and config failures, archived workers, and entry-point passthrough.
- `website/docs/user-guide/features/kanban.md` and related references - document explicit enablement, defaults, and cap composition.

## How to Test

1. Leave `kanban.dispatch_in_gateway` unset, start the gateway, and confirm ready cards remain queued.
2. Set `kanban.dispatch_in_gateway: true`, create ready cards across multiple boards, and confirm no more than `kanban.max_concurrent_workers` live workers are spawned host-wide.
3. Run the focused automated coverage:

```bash
scripts/run_tests.sh tests/hermes_cli/test_kanban_dispatch_safety.py tests/hermes_cli/test_kanban_cli_dispatch_passthrough.py tests/hermes_cli/test_kanban_per_profile_cap.py
scripts/run_tests.sh tests/hermes_cli/test_kanban_core_functionality.py -k config_defaults_require_dispatch_opt_in_and_bound_workers
scripts/run_tests.sh tests/hermes_cli/test_kanban_review_lifecycle.py -k cap
uvx ruff check gateway/kanban_watchers.py gateway/run.py hermes_cli/config_defaults.py hermes_cli/kanban.py hermes_cli/kanban_db.py plugins/kanban/dashboard/plugin_api.py tests/hermes_cli/test_kanban_cli_dispatch_passthrough.py tests/hermes_cli/test_kanban_core_functionality.py tests/hermes_cli/test_kanban_dispatch_safety.py toolsets.py
```

Result: 14 focused tests passed, Ruff passed, and `git diff --check` passed at the reviewed tip.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this feature
- [x] I've run the repository test entry point on the relevant tests and all focused tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation
- [x] Config examples are covered in the Kanban user documentation; `cli-config.yaml.example` is N/A
- [x] `CONTRIBUTING.md` and `AGENTS.md` are N/A because this does not change contributor workflow
- [x] I've considered cross-platform impact; the capacity lock retains the existing POSIX and Windows locking paths
- [x] Tool descriptions and Kanban skill references were updated where dispatch defaults are described
