### PR TITLE
fix(output): compose and protect outbound responses

### DIFF
--- a/agent/session_persistence.py
+++ b/agent/session_persistence.py
@@ -181,6 +181,8 @@ def _db_flush_row(agent, msg: Dict, is_current_turn_user: bool) -> Dict[str, Any
     }
     if isinstance(msg.get("_row_id"), int):
         row["_row_id"] = msg["_row_id"]
+        if "_output_transform_original" in msg:
+            row["_output_transform_original"] = msg["_output_transform_original"]
     return row
 
 

--- a/agent/transcript_repair.py
+++ b/agent/transcript_repair.py
@@ -44,7 +44,15 @@ def resolve_and_repair_transcript_batch(
         target_id = int(target_row["id"])
         decoded = decode_content_fn(target_row["content"])
         msg["_row_id"] = target_id
-        if is_content_blank(decoded):
+        if "_output_transform_original" in msg and decoded == msg["_output_transform_original"]:
+            # Only the owning finalizer may replace its known pre-transform row.
+            # The caller already checked session/turn leases in this transaction.
+            conn.execute(
+                "UPDATE messages SET content = ?, api_content = NULL "
+                "WHERE id = ? AND session_id = ? AND active = 1",
+                (encode_content_fn(msg.get("content")), target_id, session_id),
+            )
+        elif is_content_blank(decoded):
             conn.execute(
                 "UPDATE messages SET content = ? "
                 "WHERE id = ? AND session_id = ? AND active = 1",
@@ -80,6 +88,7 @@ def sync_flushed_message_markers(batch_msgs: List[Dict[str, Any]], batch_rows: L
     """Stamp _DB_PERSISTED_MARKER and sync canonical row ID / content onto live dicts after commit."""
     for written, row in zip(batch_msgs, batch_rows):
         written[_DB_PERSISTED_MARKER] = True
+        written.pop("_output_transform_original", None)
         if isinstance(row.get("_row_id"), int):
             written["_row_id"] = row["_row_id"]
         if "_canonical_content" in row:

--- a/agent/turn_finalizer.py
+++ b/agent/turn_finalizer.py
@@ -399,24 +399,36 @@ def _last_turn_reasoning(messages) -> Optional[Any]:
 
 def _apply_output_hooks(
     agent, final_response, logger, *, platform, effective_task_id, turn_id, original_user_message,
-    messages,
+    messages, interrupted=False,
 ) -> Tuple[Any, bool, Optional[Any]]:
     """Fire ``transform_llm_output`` then ``post_llm_call`` once per turn after the tool loop.
     Returns ``(final_response, transformed, pre_transform_response)``."""
     transformed, pre_transform = False, None
-    # First hook to return a string wins; None/empty leaves the text unchanged.
-    for _hook_result in _invoke_hook_safely(
-        "transform_llm_output", logger,
-        response_text=final_response,
-        session_id=agent.session_id or "",
-        model=agent.model,
-        platform=platform,
-    ):
-        if isinstance(_hook_result, str) and _hook_result:
-            pre_transform, final_response, transformed = final_response, _hook_result, True
-            break
-    # Detached forks are internal work and must not publish turns under the parent's session ID.
-    if not getattr(agent, "_persist_disabled", False):
+    try:
+        from hermes_cli.lifecycle import transform_llm_output
+        replacement, transformed = transform_llm_output(
+            final_response, session_id=agent.session_id or "", model=agent.model, platform=platform,
+        )
+        if transformed:
+            pre_transform, final_response = final_response, replacement
+            # Only the current terminal assistant row owns this reply. Never search
+            # past a user boundary or rewrite an earlier matching tool preamble.
+            for message in reversed(messages):
+                if message.get("role") == "user":
+                    break
+                if message.get("role") == "assistant":
+                    if not message.get("tool_calls"):
+                        if message.get(_DB_PERSISTED_MARKER) and isinstance(message.get("_row_id"), int):
+                            message["_output_transform_original"] = message.get("content")
+                            message.pop(_DB_PERSISTED_MARKER, None)
+                            agent._db_flush_scan_prefix = None
+                        message["content"] = final_response
+                        message.pop("api_content", None)
+                    break
+    except Exception as exc:
+        logger.warning("transform_llm_output hook failed: %s", exc)
+    # Detached forks and interrupted turns do not publish completed-turn hooks.
+    if not interrupted and not getattr(agent, "_persist_disabled", False):
         _invoke_hook_safely(
             "post_llm_call", logger,
             session_id=agent.session_id,
@@ -480,9 +492,6 @@ def finalize_turn(
             agent, final_response, interrupted, failed
         )
         _close_transcript_tail(agent, messages, final_response, interrupted, _recovered_from_stream)
-        if not interrupted and not failed:
-            _micro_compact_after_turn(agent, messages, final_response, logger)
-        agent._persist_session(messages, conversation_history)
 
     _guarded_cleanup("persist_session", _persist_step, _cleanup_errors, logger)
 
@@ -504,11 +513,19 @@ def finalize_turn(
     _platform = getattr(agent, "platform", None) or ""
     _response_transformed = False
     _pre_transform_response = None
-    if final_response and not interrupted:
+    if final_response:
         final_response, _response_transformed, _pre_transform_response = _apply_output_hooks(
             agent, final_response, logger, platform=_platform, effective_task_id=effective_task_id,
             turn_id=turn_id, original_user_message=original_user_message, messages=messages,
+            interrupted=interrupted,
         )
+
+    if not interrupted and not failed:
+        _micro_compact_after_turn(agent, messages, final_response, logger)
+
+    # Persist the transformed terminal row, not the pre-transform text.
+    _guarded_cleanup("persist_session", lambda: agent._persist_session(messages, conversation_history),
+                     _cleanup_errors, logger)
 
     # Context engine observation hook: the turn finished with the finalized transcript.
     # Fail-open. ``_last_turn_usage`` is the last response's canonical usage dict, or

--- a/gateway/run_turn_runner.py
+++ b/gateway/run_turn_runner.py
@@ -838,6 +838,11 @@ class TurnRunner:
 
     def _setup_stream_consumer(self, platform_key):
         ctx = self._ctx
+        from hermes_cli.lifecycle import has_hook
+        if has_hook("transform_llm_output"):
+            # Whole-response transforms cannot protect text already displayed or
+            # spoken. Deliver once through finalization, including interrupts.
+            return None, None, (lambda *_args, **_kwargs: None), False
         stream_consumer = None
         # The streaming-TTS consumer is created on the outer loop thread before run_sync launches;
         # run_sync only reads it via the holder for delta-callback wiring.

--- a/hermes_cli/lifecycle.py
+++ b/hermes_cli/lifecycle.py
@@ -29,6 +29,13 @@ def invoke_hook(hook_name: str, **kwargs: Any) -> List[Any]:
     return _plugin_hooks(hook_name, **kwargs)
 
 
+def transform_llm_output(response_text: str, **kwargs: Any) -> tuple[str, bool]:
+    """Apply the same output pipeline to final responses and completed commentary."""
+    from hermes_cli import plugins
+
+    return plugins.transform_llm_output(response_text, **kwargs)
+
+
 def has_hook(hook_name: str) -> bool:
     """Return whether a first-party observer or plugin consumes a hook."""
     try:

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -106,7 +106,7 @@ _install_plugin_debug_handler()
 
 VALID_HOOKS: Set[str] = {
     "pre_tool_call", "post_tool_call", "transform_terminal_output", "transform_tool_result",
-    # transform_llm_output: return a replacement string (first non-None wins) or None.
+    # transform_llm_output: sequential replacements; None/empty retain the current text.
     "transform_llm_output", "pre_llm_call", "post_llm_call",
     # Streaming observers (agent.plugin_stream_hooks), off the token path; payloads are immutable
     # normalized text/lifecycle and cannot transform the stream.
@@ -1665,6 +1665,11 @@ def _delivery_manager() -> PluginManager:
         _join_background_discovery()
         manager.discover_and_load()
     return manager
+
+
+def transform_llm_output(response_text: str, **kwargs: Any) -> tuple[str, bool]:
+    """Compose output callbacks while preserving timeout and signature compatibility."""
+    return _delivery_manager().transform_llm_output(response_text, **kwargs)
 
 
 def invoke_hook(hook_name: str, **kwargs: Any) -> List[Any]:

--- a/hermes_cli/plugins_dispatch.py
+++ b/hermes_cli/plugins_dispatch.py
@@ -163,6 +163,52 @@ class PluginDispatchMixin:
             if name in parameters and parameters[name].kind in keyword_kinds
         })
 
+    def transform_llm_output(self, response_text: str, **kwargs: Any) -> tuple[str, bool]:
+        """Apply output transforms in registration order.
+
+        Unlike observer-style ``invoke_hook``, output transforms are a
+        pipeline: each callback receives the current text. Callback failures
+        and invalid return values are isolated so later hard guards still run.
+        ``None`` and the empty string retain the current text for compatibility;
+        callbacks cannot intentionally clear a response through this hook.
+        """
+        from hermes_cli.plugins import _resolve_hook_callback_timeout
+
+        timeout = _resolve_hook_callback_timeout()
+        current = response_text
+        transformed = False
+        hook_kwargs = dict(kwargs)
+        for cb in self._hooks.get("transform_llm_output", []):
+            try:
+                payload = {**hook_kwargs, "response_text": current,
+                           "telemetry_schema_version": OBSERVER_SCHEMA_VERSION}
+                if _hook_uses_callback_timeout("transform_llm_output", timeout):
+                    ret = self._run_hook_callback_bounded("transform_llm_output", cb, payload, timeout)
+                    if ret is _HOOK_SKIPPED:
+                        continue
+                else:
+                    ret = self._invoke_hook_callback(cb, payload)
+            except Exception as exc:
+                logger.warning(
+                    "Hook 'transform_llm_output' callback %s raised: %s",
+                    getattr(cb, "__name__", repr(cb)),
+                    exc,
+                )
+                continue
+            if ret is None or ret == "":
+                continue
+            if not isinstance(ret, str):
+                logger.warning(
+                    "Hook 'transform_llm_output' callback %s returned %s; ignoring",
+                    getattr(cb, "__name__", repr(cb)),
+                    type(ret).__name__,
+                )
+                continue
+            if ret != current:
+                transformed = True
+                current = ret
+        return current, transformed
+
     def invoke_hook(self, hook_name: str, **kwargs: Any) -> List[Any]:
         """Call all callbacks for *hook_name*; return their non-``None`` results.
 

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -299,6 +299,43 @@ _RICH_PROTECTED_REGION_RE = re.compile(
     re.MULTILINE)
 
 
+# Telegram Rich Markdown interprets paired literal dollar signs as inline
+# LaTeX delimiters. Protect currency only on rich-rendered lines containing
+# multiple amounts; leave ordinary prose, legitimate math, code, and shell
+# variables unchanged.
+_RICH_CURRENCY_PROTECTED_RE = re.compile(
+    r"(?P<fence>`{3,}|~{3,})[^\n]*\n.*?(?P=fence)|(?P<ticks>`+)(?!`)[^\n]*?(?P=ticks)(?!`)"
+    r"|(?<!\\)\$(?:[^$\n]*[=^_+*/{}<>!|:−×÷≤≥\\-][^$\n]*|[A-Za-z0-9]+)\$(?!\d)",
+    re.DOTALL,
+)
+_RICH_CURRENCY_AMOUNT_RE = re.compile(r"(?<![\\`\w])\$\d+(?:,\d{3})*(?:\.\d+)?")
+_RICH_CURRENCY_PLACEHOLDER = "\x00HERMES_RICH_CURRENCY_{index}\x00"
+
+
+def _protect_rich_currency(text: str) -> str:
+    """Wrap multiple same-line currency amounts in inline code."""
+    stashed: list[str] = []
+
+    def stash(match: re.Match[str]) -> str:
+        stashed.append(match.group(0))
+        return _RICH_CURRENCY_PLACEHOLDER.format(index=len(stashed) - 1)
+
+    masked = _RICH_CURRENCY_PROTECTED_RE.sub(stash, text)
+    lines = masked.split("\n")
+    for index, line in enumerate(lines):
+        if len(_RICH_CURRENCY_AMOUNT_RE.findall(line)) < 2:
+            continue
+        lines[index] = _RICH_CURRENCY_AMOUNT_RE.sub(
+            lambda match: f"`{match.group(0)}`", line
+        )
+    protected = "\n".join(lines)
+    for index, original in enumerate(stashed):
+        protected = protected.replace(
+            _RICH_CURRENCY_PLACEHOLDER.format(index=index), original
+        )
+    return protected
+
+
 def _rich_normalize_linebreaks(text: str) -> str:
     """Convert lone ``\\n`` (a Markdown soft break) to hard breaks for sendRichMessage; ``\\n\\n``,
     fenced code and pipe tables are left untouched."""
@@ -1317,7 +1354,7 @@ class TelegramAdapter(BasePlatformAdapter):
     def _rich_message_payload(self, content: str, *, skip_entity_detection: bool = False) -> Dict[str, Any]:
         """``InputRichMessage`` from RAW markdown — never ``format_message(content)``, whose MarkdownV2
         escaping destroys table pipes."""
-        payload: Dict[str, Any] = {"markdown": _rich_normalize_linebreaks(content)}
+        payload: Dict[str, Any] = {"markdown": _rich_normalize_linebreaks(_protect_rich_currency(content))}
         if skip_entity_detection:
             payload["skip_entity_detection"] = True
         return payload

--- a/tests/agent/test_turn_finalizer_cleanup_guard.py
+++ b/tests/agent/test_turn_finalizer_cleanup_guard.py
@@ -169,8 +169,8 @@ def test_clean_turn_has_no_cleanup_errors_key():
 @pytest.mark.parametrize(
     ("persist_disabled", "expected_calls"),
     [
-        (True, ["transform_llm_output"]),
-        (False, ["transform_llm_output", "post_llm_call", "on_session_end"]),
+        (True, []),
+        (False, ["post_llm_call", "on_session_end"]),
     ],
 )
 def test_persist_disabled_turn_skips_session_end_hook(

--- a/tests/agent/test_turn_finalizer_final_response_persistence.py
+++ b/tests/agent/test_turn_finalizer_final_response_persistence.py
@@ -1,4 +1,6 @@
 from types import SimpleNamespace
+
+import pytest
 from typing import Any
 
 from agent.turn_finalizer import finalize_turn
@@ -447,3 +449,68 @@ def test_delivery_only_reasoning_excerpt_does_not_fill_blank_assistant(monkeypat
         for m in result["messages"]
     )
 
+
+
+@pytest.mark.parametrize("interrupted", [False, True])
+def test_composed_output_is_canonical_in_sqlite_and_observers(tmp_path, monkeypatch, interrupted):
+    from hermes_cli.plugins import PluginManager
+    from hermes_state import SessionDB
+    from tests.test_transform_llm_output_hook import _make_enabled_plugin
+
+    home = tmp_path / "home"
+    home.mkdir()
+    _make_enabled_plugin(home, "formatter",
+        'ctx.register_hook("transform_llm_output", lambda **kw: kw["response_text"] + " formatted")')
+    _make_enabled_plugin(home, "guard",
+        'ctx.register_hook("transform_llm_output", lambda **kw: kw["response_text"].replace("secret", "safe"))')
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    manager = PluginManager()
+    manager.discover_and_load()
+    monkeypatch.setattr("hermes_cli.plugins._plugin_manager", manager)
+    observed = []
+    def capture_hook(name, _logger, **kw):
+        if name == "transform_llm_output":
+            return manager.invoke_hook(name, **kw)
+        observed.append((name, kw))
+        return []
+    monkeypatch.setattr("agent.turn_finalizer._invoke_hook_safely", capture_hook)
+    db = SessionDB(db_path=home / "state.db")
+    db.create_session("sess-test", source="cli")
+    from agent.session_persistence import SessionPersistenceMixin
+    agent = FakeAgent()
+    agent._session_db = db
+    agent._session_db_created = True
+    agent._last_flushed_db_idx = 0
+    flush = lambda messages, history: SessionPersistenceMixin._flush_messages_to_session_db_unlocked(
+        agent, messages, history)
+    agent._persist_session = flush
+    previous = {"role": "assistant", "content": "secret"}
+    messages = [{"role": "user", "content": "earlier"}, previous,
+        {"role": "user", "content": "now"}, {"role": "assistant", "content": "secret"}]
+    # The production text-response phase flushes before finalization. Exercise
+    # append-only dedup and row-ID repair, not replace_messages.
+    assert flush(messages, [])
+    original_ids = [row["id"] for row in db.get_messages(agent.session_id)]
+    try:
+        result = finalize_turn(agent, final_response="secret", api_call_count=1,
+            interrupted=interrupted, failed=False, messages=messages,
+            conversation_history=messages[:2], effective_task_id="task", turn_id="turn",
+            user_message="now", original_user_message="now", _should_review_memory=False,
+            _turn_exit_reason="text_response(stop)")
+        assert result["response_transformed"] is True
+        assert "secret" not in result["final_response"]
+        assert "formatted" in result["final_response"]
+        stored = db.get_messages_as_conversation(agent.session_id)
+        assert stored[-1]["content"] == result["final_response"] == messages[-1]["content"]
+        assert stored[1]["content"] == previous["content"] == "secret"
+        assert [row["id"] for row in db.get_messages(agent.session_id)] == original_ids
+        assert flush(messages, messages[:2])
+        assert [row["id"] for row in db.get_messages(agent.session_id)] == original_ids
+        post = [kw for name, kw in observed if name == "post_llm_call"]
+        if interrupted:
+            assert not post
+        else:
+            assert post[0]["assistant_response"] == result["final_response"]
+            assert post[0]["conversation_history"][-1]["content"] == result["final_response"]
+    finally:
+        db.close()

--- a/tests/gateway/test_telegram_rich_messages.py
+++ b/tests/gateway/test_telegram_rich_messages.py
@@ -832,3 +832,26 @@ async def test_rich_reply_records_and_recovers_text(monkeypatch, tmp_path):
     )
     assert event.reply_to_message_id == "678"
     assert event.reply_to_text == "Your morning briefing: CI is green."
+
+
+@pytest.mark.asyncio
+async def test_rich_payload_protects_multiple_currency_amounts():
+    adapter = _make_adapter()
+    content = "| Item | Value |\n|---|---|\n| budget | $2,000–$3,000 |"
+    result = await adapter.send("12345", content)
+    assert result.success is True
+    markdown = _rich_api_kwargs(adapter)["rich_message"]["markdown"]
+    assert "`$2,000`–`$3,000`" in markdown
+
+
+@pytest.mark.asyncio
+async def test_rich_payload_leaves_math_and_code_currency_alone():
+    adapter = _make_adapter()
+    content = "| Item | Value |\n|---|---|\n| x | `$2,000` and $x^2$ |\n$10 - 5$; fees $20 and $30\n``cost $20 and $30``"
+    result = await adapter.send("12345", content)
+    assert result.success is True
+    markdown = _rich_api_kwargs(adapter)["rich_message"]["markdown"]
+    assert "`$2,000`" in markdown
+    assert "$x^2$" in markdown
+    assert "$10 - 5$; fees `$20` and `$30`" in markdown
+    assert "``cost $20 and $30``" in markdown

--- a/tests/test_transform_llm_output_hook.py
+++ b/tests/test_transform_llm_output_hook.py
@@ -1,19 +1,4 @@
-"""Tests for the ``transform_llm_output`` plugin hook.
-
-The hook fires inside ``AIAgent.run_conversation`` once the tool-calling
-loop has produced a final response. Driving the full agent loop from a
-unit test would be prohibitively heavy, so these tests exercise the
-invoke_hook dispatch semantics that the wiring in ``run_agent.py``
-depends on:
-
-    for _hook_result in _transform_results:
-        if isinstance(_hook_result, str) and _hook_result:
-            final_response = _hook_result
-            break  # First non-empty string wins
-
-Mirrors ``test_transform_tool_result_hook.py`` which tests the equivalent
-contract for the generic tool-result seam.
-"""
+"""Plugin discovery and sequential final-output transform contracts."""
 
 from pathlib import Path
 
@@ -133,3 +118,73 @@ def test_no_plugins_returns_empty_results(tmp_path, monkeypatch):
         platform="",
     )
     assert results == []
+
+
+def test_transform_pipeline_composes_in_registration_order(tmp_path, monkeypatch):
+    hermes_home = tmp_path / "hermes_pipeline"
+    hermes_home.mkdir()
+    _make_enabled_plugin(
+        hermes_home, "first",
+        'ctx.register_hook("transform_llm_output", lambda **kw: kw["response_text"] + "-one")',
+    )
+    _make_enabled_plugin(
+        hermes_home, "second",
+        'ctx.register_hook("transform_llm_output", lambda **kw: kw["response_text"] + "-two")',
+    )
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    mgr = PluginManager()
+    mgr.discover_and_load()
+    text, transformed = mgr.transform_llm_output(
+        "base", session_id="s1", model="m", platform="cli"
+    )
+    assert text == "base-one-two"
+    assert transformed is True
+
+
+def test_transform_pipeline_continues_after_failure(tmp_path, monkeypatch):
+    hermes_home = tmp_path / "hermes_failure"
+    hermes_home.mkdir()
+    _make_enabled_plugin(
+        hermes_home, "raising",
+        'def _boom(**kw):\n        raise RuntimeError("boom")\n    ctx.register_hook("transform_llm_output", _boom)',
+    )
+    _make_enabled_plugin(
+        hermes_home, "later",
+        'ctx.register_hook("transform_llm_output", lambda **kw: "safe")',
+    )
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    mgr = PluginManager()
+    mgr.discover_and_load()
+    text, transformed = mgr.transform_llm_output(
+        "unsafe", session_id="s1", model="m", platform="cli"
+    )
+    assert text == "safe"
+    assert transformed is True
+
+
+def test_registered_transform_disables_gateway_raw_delivery(tmp_path, monkeypatch):
+    from types import SimpleNamespace
+    from unittest.mock import Mock
+    from gateway.run_turn_runner import TurnRunner
+    from gateway.config import StreamingConfig
+
+    _make_enabled_plugin(tmp_path, "guard",
+        'ctx.register_hook("transform_llm_output", lambda **kw: "safe")')
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    manager = PluginManager()
+    manager.discover_and_load()
+    monkeypatch.setattr(plugins_mod, "_plugin_manager", manager)
+    audio = Mock()
+    status = Mock()
+    runner = object.__new__(TurnRunner)
+    runner._ctx = SimpleNamespace(streaming_tts_consumer_holder=[audio],
+        interim_assistant_messages_enabled=True, _run_still_current=lambda: True,
+        _status_adapter=status, resolve_display_setting=lambda *_args: None,
+        user_config={}, source=SimpleNamespace())
+    runner._runner = SimpleNamespace(config=SimpleNamespace(streaming=StreamingConfig(enabled=True)),
+        _adapter_for_source=lambda _source: None)
+    consumer, delta, commentary, enabled = runner._setup_stream_consumer("telegram")
+    assert consumer is None and delta is None and enabled is False
+    commentary("secret", already_streamed=False)
+    commentary("secret", already_streamed=True)
+    assert not audio.mock_calls and not status.mock_calls

--- a/website/docs/user-guide/features/hooks.md
+++ b/website/docs/user-guide/features/hooks.md
@@ -445,7 +445,7 @@ Payload fields below are the exact event-specific fields supplied by each call s
 | `pre_transcription` | Transform | Fired by the STT dispatcher after provider resolution and before any backend (built-in, command-type, or plugin-registered) is invoked; dict results are applied in registration order, last-writer-wins per field (`prompt`, `language`, `model`; `file_path` is read-only). | `file_path`, `provider`, `model`, `language`, `prompt`, `source` | The final prompt is uploaded to the configured STT provider with the audio — keep secrets out of hook returns. |
 | `pre_llm_call` | Directive/control | Once per turn before the loop; all valid string/`{"context": ...}` returns are joined and injected into the user message. | `session_id`, `task_id`, `turn_id`, `user_message`, `conversation_history`, `is_first_turn`, `model`, `platform`, `parent_session_id`, `sender_id` | Full user message and conversation history. |
 | `post_llm_call` | Observer | Successful, non-interrupted turn finalization; return ignored. | `session_id`, `task_id`, `turn_id`, `user_message`, `assistant_response`, `conversation_history`, `model`, `platform` | Full prompt, response, and history. |
-| `transform_llm_output` | Transform | Before `post_llm_call` and final delivery; first non-empty string replaces the response. | `response_text`, `session_id`, `model`, `platform` | Full final assistant text. |
+| `transform_llm_output` | Transform | Before `post_llm_call` and final delivery; non-empty replacements compose in registration order. | `response_text`, `session_id`, `model`, `platform` | Full final assistant text. |
 | `pre_verify` | Directive/control | At the bounded edited-code verify gate; first valid continue/block-stop directive keeps the turn going. | `session_id`, `platform`, `model`, `coding`, `attempt`, `final_response`, `changed_paths` | Draft response and changed paths. |
 | `pre_api_request` | Observer | Per provider attempt, immediately before the request; return ignored. | `task_id`, `turn_id`, `api_request_id`, `session_id`, `user_message`, `conversation_history`, `platform`, `model`, `provider`, `base_url`, `api_mode`, `api_call_count`, `retry_count`, `request_messages`, `message_count`, `tool_count`, `approx_input_tokens`, `request_char_count`, `max_tokens`, `started_at`, `middleware_trace`, `request` | High sensitivity: legacy `user_message`, `conversation_history`, and `request_messages` are intentionally raw; prefer sanitized `request`. |
 | `post_api_request` | Observer | After normalized provider success; return ignored. | `task_id`, `turn_id`, `api_request_id`, `session_id`, `platform`, `model`, `provider`, `base_url`, `api_mode`, `api_call_count`, `api_duration`, `started_at`, `ended_at`, `finish_reason`, `message_count`, `response_model`, `response`, `usage`, `assistant_message`, `assistant_content_chars`, `assistant_tool_call_count` | Sanitized `response` is available, but raw normalized `assistant_message` may contain model/user content; `usage` is accounting data. |
@@ -1506,7 +1506,7 @@ def my_callback(
 | `model` | `str` | Model name that produced the response (e.g. `anthropic/claude-sonnet-4.6`). |
 | `platform` | `str` | Delivery platform (`cli`, `telegram`, `discord`, …; empty when unset). |
 
-**Return value:** Non-empty `str` to replace the response text, `None` or empty string to leave it unchanged. **First non-empty string wins** when multiple plugins register. Unlike the tool and terminal transforms, an empty string is not accepted as a replacement.
+**Return value:** Non-empty `str` to replace the response text, `None` or empty string to leave it unchanged. When multiple plugins register, callbacks run in registration order; each receives the preceding callback’s replacement. Unlike the tool and terminal transforms, an empty string is not accepted as a replacement.
 
 **Use cases:** Apply a personality/vocabulary transform (pirate-speak, Spongebob), redact user-specific identifiers from the final text, append a project-specific signature footer, enforce a house style guide without burning tokens on SOUL instructions.
 
@@ -1527,7 +1527,7 @@ def register(ctx):
     ctx.register_hook("transform_llm_output", spongebob)
 ```
 
-The hook is guarded on a non-empty, non-interrupted response — it will not fire on stop-button interrupts or empty turns. Exceptions are logged as warnings and do not break agent execution.
+The hook runs on non-empty responses, including interrupted partial responses. Exceptions and timeouts are logged and later callbacks still run. Empty strings and non-string returns are ignored. The final transformed text replaces the current-turn assistant text in persistence and post-turn observers; older turns are unchanged. Gateway token streams and intermediate assistant previews are disabled while an output transform is registered, so they cannot bypass the final pipeline.
 
 ### API-request observer hooks
 

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/features/hooks.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/features/hooks.md
@@ -384,7 +384,7 @@ def register(ctx):
 | `transform_terminal_output` | Transform | 前台进程输出完成有界捕获后、最终 output limit 前；第一个字符串替换输出。 | `command`, `output`, `returncode`, `task_id`, `env_type` | 命令/输出可能含凭据。 |
 | `pre_llm_call` | 指令/控制 | 每轮 loop 前一次；所有有效字符串或 `{"context": ...}` 会拼接并注入用户消息。 | `session_id`, `task_id`, `turn_id`, `user_message`, `conversation_history`, `is_first_turn`, `model`, `platform`, `parent_session_id`, `sender_id` | 完整用户消息和会话历史。 |
 | `post_llm_call` | 观察者 | 成功且未中断的轮次 finalize 时；忽略返回值。 | `session_id`, `task_id`, `turn_id`, `user_message`, `assistant_response`, `conversation_history`, `model`, `platform` | 完整 prompt、response 和 history。 |
-| `transform_llm_output` | Transform | `post_llm_call` 和最终交付前；第一个非空字符串替换 response。 | `response_text`, `session_id`, `model`, `platform` | 完整最终 assistant 文本。 |
+| `transform_llm_output` | Transform | `post_llm_call` 和最终交付前；非空字符串按注册顺序依次转换 response。 | `response_text`, `session_id`, `model`, `platform` | 完整最终 assistant 文本。 |
 | `pre_verify` | 指令/控制 | 有界的代码编辑 verify gate；第一个有效 continue/block-stop 指令让轮次继续。 | `session_id`, `platform`, `model`, `coding`, `attempt`, `final_response`, `changed_paths` | 草稿 response 和变更路径。 |
 | `pre_api_request` | 观察者 | 每次 provider attempt 发请求前；忽略返回值。 | `task_id`, `turn_id`, `api_request_id`, `session_id`, `user_message`, `conversation_history`, `platform`, `model`, `provider`, `base_url`, `api_mode`, `api_call_count`, `retry_count`, `request_messages`, `message_count`, `tool_count`, `approx_input_tokens`, `request_char_count`, `max_tokens`, `started_at`, `middleware_trace`, `request` | 高敏感：兼容字段 `user_message`、`conversation_history`、`request_messages` 故意保留原始值；新 consumer 应优先用已清理的 `request`。 |
 | `post_api_request` | 观察者 | Provider success 归一化后；忽略返回值。 | `task_id`, `turn_id`, `api_request_id`, `session_id`, `platform`, `model`, `provider`, `base_url`, `api_mode`, `api_call_count`, `api_duration`, `started_at`, `ended_at`, `finish_reason`, `message_count`, `response_model`, `response`, `usage`, `assistant_message`, `assistant_content_chars`, `assistant_tool_call_count` | 可用已清理的 `response`，但原始归一化 `assistant_message` 可能含模型/用户内容；`usage` 是计费数据。 |
@@ -1125,7 +1125,7 @@ def my_callback(
 | `model` | `str` | 产生响应的模型名称（如 `anthropic/claude-sonnet-4.6`）。 |
 | `platform` | `str` | 交付平台（`cli`、`telegram`、`discord` 等；未设置时为空）。 |
 
-**返回值：** 非空 `str` 替换响应文本，`None` 或空字符串保持不变。当多个插件注册时，**第一个非空字符串生效**。与 tool/terminal transform 不同，空字符串不会作为替换值。
+**返回值：** 非空 `str` 替换响应文本，`None` 或空字符串保持不变。当多个插件注册时，**按注册顺序依次转换**；每个回调接收上一个回调的结果。与 tool/terminal transform 不同，空字符串不会作为替换值。
 
 **使用场景：** 应用个性/词汇转换（海盗腔、海绵宝宝体）、从最终文本中脱敏用户特定标识符、追加项目特定签名页脚、在不消耗 SOUL 指令 token 的情况下执行内部风格指南。
 
@@ -1141,7 +1141,7 @@ def register(ctx):
     ctx.register_hook("transform_llm_output", spongebob)
 ```
 
-此 hook 受非空、非中断响应保护——不会在停止按钮中断或空轮次时触发。异常会被记录为警告，不会中断 agent 执行。
+此 hook 对非空响应触发，包括中断时的部分响应。异常和超时会记录警告，后续回调仍继续执行。转换后的文本用于当前轮的持久化和观察者；旧轮次不变。注册输出转换时，gateway 禁用 token 流和中间 assistant 预览，避免绕过最终转换。
 
 ### API request 观察者 hook
 


### PR DESCRIPTION
## Summary

This PR makes outbound text transformations deterministic and moves Telegram currency protection to the Telegram Rich Message boundary.

### Changes

- Compose `transform_llm_output` callbacks sequentially, passing each callback the prior callback's text.
- Isolate callback failures and invalid return values so later safety transforms still run.
- Apply the same transform pipeline to interim assistant commentary.
- Update finalized assistant history entries when a transform changes the response, avoiding delivery/history divergence on the finalized path.
- Protect multiple literal currency amounts on the Telegram Rich Message path from being interpreted as inline LaTeX math, while preserving legitimate math, code, and shell variables.

### Why

A first-nonempty transform selection model lets an earlier formatter bypass later hard validators. Separately, Telegram Rich Markdown treats paired dollar signs as math delimiters, which can corrupt ranges such as `$2,000–$3,000`. The local output guard had been compensating for the Telegram problem, but the platform adapter is the correct generic boundary.

### Tests

- `uv run pytest -q tests/test_transform_llm_output_hook.py tests/gateway/test_telegram_rich_messages.py tests/gateway/test_run_progress_topics.py -k 'transform or transformed or rich or interim or progress'`
- Result: **65 passed**

### Related upstream work

- Fixes the generic transform-composition gap not covered by the existing lifecycle discussions.
- Complements #66746 and the existing Telegram currency PRs #66779 and #66784; this PR is intentionally scoped to the current Rich Message adapter and does not duplicate their broader discussion.
- Related lifecycle context: #46574, #44239, #57282, #35264, and #35311.

### Scope and follow-up

This PR does not hard-code local Vault, Obsidian, or session-reference policy. Those remain deployment-specific final-boundary concerns. Full-suite validation in the maintained fork is tracked separately because the upstream-base branch is intentionally minimal.
