### PR TITLE
fix(auth): fence externally owned xAI refresh tokens

### DIFF
--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -774,7 +774,12 @@ class CredentialPool:
                     self._entries[idx] = new
                     return
 
-    def _persist(self, *, removed_ids: Optional[List[str]] = None) -> None:
+    def _persist(
+        self,
+        *,
+        removed_ids: Optional[List[str]] = None,
+        oauth_token_write_authority: Optional[str] = None,
+    ) -> None:
         # Self-locking (RLock): snapshotting self._entries must not race a
         # concurrent rotation when called from the deferred refresh path.
         with self._lock:
@@ -782,6 +787,7 @@ class CredentialPool:
                 self.provider,
                 [entry.to_dict() for entry in self._entries],
                 removed_ids=removed_ids,
+                oauth_token_write_authority=oauth_token_write_authority,
             )
 
     def _is_terminal_auth_failure(
@@ -2397,11 +2403,16 @@ class CredentialPool:
                 return None, None, f"No credential #{index}."
             return None, None, f'No credential matching "{raw}".'
 
-    def add_entry(self, entry: PooledCredential) -> PooledCredential:
+    def add_entry(
+        self,
+        entry: PooledCredential,
+        *,
+        oauth_token_write_authority: Optional[str] = None,
+    ) -> PooledCredential:
         with self._lock:
             entry = replace(entry, priority=_next_priority(self._entries))
             self._entries.append(entry)
-            self._persist()
+            self._persist(oauth_token_write_authority=oauth_token_write_authority)
             return entry
 
 

--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -1311,6 +1311,16 @@ class CredentialPool:
             logger.debug("Failed to sync %s pool entry back to auth store: %s", self.provider, exc)
 
     def _refresh_entry(self, entry: PooledCredential, *, force: bool) -> Optional[PooledCredential]:
+        if self.provider == "xai-oauth" and not auth_mod.runtime_owns_oauth_refresh(
+            self.provider
+        ):
+            synced = self._sync_xai_oauth_entry_from_pool_store(entry)
+            if synced is not entry:
+                return synced
+            logger.warning(
+                "credential pool: refusing xAI OAuth refresh because ownership is external"
+            )
+            return None
         if entry.auth_type != AUTH_TYPE_OAUTH or not entry.refresh_token:
             if force:
                 self._mark_exhausted(entry, None)
@@ -1767,6 +1777,10 @@ class CredentialPool:
 
     def _entry_needs_refresh(self, entry: PooledCredential) -> bool:
         if entry.auth_type != AUTH_TYPE_OAUTH:
+            return False
+        if self.provider == "xai-oauth" and not auth_mod.runtime_owns_oauth_refresh(
+            self.provider
+        ):
             return False
         if self.provider == "anthropic":
             if entry.expires_at_ms is None:

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -34,6 +34,8 @@ import time
 import uuid
 import webbrowser
 
+import yaml
+
 # httpx is imported lazily: it costs ~30ms at import time and hermes_cli.auth
 # is on the interactive-CLI startup path via credential_pool → auxiliary_client
 # → cli_commands_mixin, where no HTTP request is ever made before first use.
@@ -111,7 +113,7 @@ AUTH_LOCK_TIMEOUT_SECONDS = 15.0
 
 
 def runtime_owns_oauth_refresh(provider: str) -> bool:
-    """Return whether Hermes owns refresh-token writes for ``provider``.
+    """Return whether this runtime may spend ``provider`` refresh tokens.
 
     Standalone xAI behavior remains runtime-owned when no ownership setting is
     present. Once the setting exists, malformed or unknown values fail closed
@@ -123,11 +125,16 @@ def runtime_owns_oauth_refresh(provider: str) -> bool:
     if not config_path.exists():
         return True
     try:
-        config = read_raw_config()
+        config = yaml.safe_load(config_path.read_text(encoding="utf-8"))
     except Exception:
         logger.warning("OAuth refresh ownership unreadable; refusing runtime writes")
         return False
-    if not isinstance(config, dict) or "oauth" not in config:
+    if config is None:
+        return True
+    if not isinstance(config, dict):
+        logger.warning("OAuth refresh ownership is invalid; refusing runtime writes")
+        return False
+    if "oauth" not in config:
         return True
     oauth_config = config.get("oauth")
     if not isinstance(oauth_config, dict):
@@ -140,6 +147,63 @@ def runtime_owns_oauth_refresh(provider: str) -> bool:
         return False
     logger.warning("OAuth refresh owner must be runtime or external; refusing runtime writes")
     return False
+
+
+def _parse_persisted_timestamp(value: Any) -> Optional[float]:
+    """Normalize persisted epoch seconds, milliseconds, or ISO timestamps."""
+    if isinstance(value, (int, float)):
+        numeric_value = float(value)
+        return numeric_value / 1000.0 if numeric_value > 1_000_000_000_000 else numeric_value
+    if not isinstance(value, str) or not value.strip():
+        return None
+    try:
+        numeric_value = float(value)
+    except ValueError:
+        try:
+            return datetime.fromisoformat(value.strip().replace("Z", "+00:00")).timestamp()
+        except ValueError:
+            return None
+    return numeric_value / 1000.0 if numeric_value > 1_000_000_000_000 else numeric_value
+
+
+def _persisted_oauth_pool_entry_is_usable(entry: Dict[str, Any]) -> bool:
+    """Return whether scheduler-owned status permits use of a pool row."""
+    status = entry.get("last_status")
+    if status == "dead":
+        return False
+    if status != "exhausted":
+        return True
+    reset_at = _parse_persisted_timestamp(entry.get("last_error_reset_at"))
+    if reset_at is not None:
+        return time.time() >= reset_at
+    status_at = _parse_persisted_timestamp(entry.get("last_status_at"))
+    if status_at is None:
+        return True
+    cooldown_seconds = 300 if entry.get("last_error_code") == 401 else 3600
+    return time.time() >= status_at + cooldown_seconds
+
+
+def _selected_usable_oauth_pool_entry(provider_id: str) -> Optional[Dict[str, Any]]:
+    """Read the lowest-priority usable OAuth row from the persisted pool."""
+    entries = read_credential_pool(provider_id)
+    candidates = [
+        (index, entry)
+        for index, entry in enumerate(entries if isinstance(entries, list) else [])
+        if isinstance(entry, dict)
+        and entry.get("auth_type") == "oauth"
+        and isinstance(entry.get("access_token"), str)
+        and entry.get("access_token")
+        and _persisted_oauth_pool_entry_is_usable(entry)
+    ]
+    if not candidates:
+        return None
+
+    def selection_key(candidate: Tuple[int, Dict[str, Any]]) -> Tuple[int, int]:
+        index, entry = candidate
+        priority = entry.get("priority", 0)
+        return (priority if isinstance(priority, int) else 0, index)
+
+    return min(candidates, key=selection_key)[1]
 
 # Nous Portal defaults
 DEFAULT_NOUS_PORTAL_URL = "https://portal.nousresearch.com"
@@ -5105,6 +5169,13 @@ def _refresh_xai_oauth_tokens(
     redirect_uri: str = "",
     timeout_seconds: float,
 ) -> Dict[str, Any]:
+    if not runtime_owns_oauth_refresh("xai-oauth"):
+        raise AuthError(
+            "xAI OAuth refresh is owned externally; this runtime must not spend the refresh token.",
+            provider="xai-oauth",
+            code="xai_external_refresh_forbidden",
+            relogin_required=False,
+        )
     # Re-persist whatever auth_mode is already stored (legacy pre-device-code
     # logins may still carry ``oauth_pkce``): the refresh hot path must not
     # relabel how the grant was originally obtained.
@@ -5147,8 +5218,27 @@ def resolve_xai_oauth_runtime_credentials(
     refresh_if_expiring: bool = True,
     refresh_skew_seconds: Optional[int] = None,
 ) -> Dict[str, Any]:
-    data = _read_xai_oauth_tokens()
-    tokens = dict(data["tokens"])
+    runtime_refresh_allowed = runtime_owns_oauth_refresh("xai-oauth")
+    if runtime_refresh_allowed:
+        data = _read_xai_oauth_tokens()
+        tokens = dict(data["tokens"])
+    else:
+        scheduler_entry = _selected_usable_oauth_pool_entry("xai-oauth")
+        if scheduler_entry is None:
+            raise AuthError(
+                "xAI has no usable scheduler-owned OAuth credential.",
+                provider="xai-oauth",
+                code="xai_external_pool_unavailable",
+                relogin_required=False,
+            )
+        tokens = {
+            "access_token": scheduler_entry["access_token"],
+            "refresh_token": scheduler_entry.get("refresh_token", ""),
+        }
+        data = {
+            "tokens": tokens,
+            "last_refresh": scheduler_entry.get("last_refresh"),
+        }
     access_token = str(tokens.get("access_token", "") or "").strip()
     refresh_timeout_seconds = env_float("HERMES_XAI_REFRESH_TIMEOUT_SECONDS", 20)
     discovery = dict(data.get("discovery") or {})
@@ -5163,7 +5253,7 @@ def resolve_xai_oauth_runtime_credentials(
     should_refresh = bool(force_refresh)
     if (not should_refresh) and refresh_if_expiring:
         should_refresh = _xai_access_token_is_expiring(access_token, effective_skew)
-    if should_refresh:
+    if should_refresh and runtime_refresh_allowed:
         with _auth_store_lock(timeout_seconds=max(float(AUTH_LOCK_TIMEOUT_SECONDS), refresh_timeout_seconds + 5.0)):
             data = _read_xai_oauth_tokens(_lock=False)
             tokens = dict(data["tokens"])

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -109,6 +109,38 @@ except Exception:
 AUTH_STORE_VERSION = 1
 AUTH_LOCK_TIMEOUT_SECONDS = 15.0
 
+
+def runtime_owns_oauth_refresh(provider: str) -> bool:
+    """Return whether Hermes owns refresh-token writes for ``provider``.
+
+    Standalone xAI behavior remains runtime-owned when no ownership setting is
+    present. Once the setting exists, malformed or unknown values fail closed
+    so a typo cannot create a second refresh-token writer.
+    """
+    if provider != "xai-oauth":
+        return True
+    config_path = get_config_path()
+    if not config_path.exists():
+        return True
+    try:
+        config = read_raw_config()
+    except Exception:
+        logger.warning("OAuth refresh ownership unreadable; refusing runtime writes")
+        return False
+    if not isinstance(config, dict) or "oauth" not in config:
+        return True
+    oauth_config = config.get("oauth")
+    if not isinstance(oauth_config, dict):
+        logger.warning("OAuth refresh ownership is invalid; refusing runtime writes")
+        return False
+    refresh_owner = oauth_config.get("refresh_owner")
+    if refresh_owner == "runtime":
+        return True
+    if refresh_owner == "external":
+        return False
+    logger.warning("OAuth refresh owner must be runtime or external; refusing runtime writes")
+    return False
+
 # Nous Portal defaults
 DEFAULT_NOUS_PORTAL_URL = "https://portal.nousresearch.com"
 DEFAULT_NOUS_INFERENCE_URL = "https://inference-api.nousresearch.com/v1"
@@ -1717,6 +1749,7 @@ def write_credential_pool(
     entries: List[Dict[str, Any]],
     *,
     removed_ids: Optional[Iterable[str]] = None,
+    oauth_token_write_authority: Optional[str] = None,
 ) -> Path:
     """Persist one provider's credential pool under auth.json.
 
@@ -1735,6 +1768,11 @@ def write_credential_pool(
 
     Pass ``removed_ids`` for entries the caller intentionally removed, so the
     merge does not resurrect them from the on-disk copy.
+
+    Under external xAI ownership, only the exact ``external-scheduler``
+    authority may mutate existing OAuth rows. A genuine interactive login may
+    append a new row, but cannot overwrite or remove scheduler-owned rows.
+    Other writers preserve the OAuth material already on disk.
     """
     removed = {rid for rid in (removed_ids or ()) if rid}
     with _auth_store_lock():
@@ -1750,6 +1788,48 @@ def write_credential_pool(
         ]
         existing = pool.get(provider_id)
         existing_list = existing if isinstance(existing, list) else []
+        if (
+            oauth_token_write_authority != "external-scheduler"
+            and not runtime_owns_oauth_refresh(provider_id)
+        ):
+            existing_by_id_for_protection = {
+                entry.get("id"): entry
+                for entry in existing_list
+                if isinstance(entry, dict) and entry.get("id")
+            }
+            protected_oauth_ids = {
+                entry_id
+                for entry_id, entry in existing_by_id_for_protection.items()
+                if entry.get("auth_type") == "oauth" or entry.get("refresh_token")
+            }
+            allow_new_interactive = (
+                oauth_token_write_authority == "interactive-login"
+            )
+            protected_entries: List[Dict[str, Any]] = []
+            for incoming in sanitized_entries:
+                if not isinstance(incoming, dict):
+                    protected_entries.append(incoming)
+                    continue
+                incoming_id = incoming.get("id")
+                disk_entry = existing_by_id_for_protection.get(incoming_id)
+                incoming_is_oauth = (
+                    incoming.get("auth_type") == "oauth"
+                    or bool(incoming.get("refresh_token"))
+                )
+                if incoming_id in protected_oauth_ids:
+                    protected_entries.append(
+                        sanitize_borrowed_credential_payload(disk_entry, provider_id)
+                    )
+                elif incoming_is_oauth and not allow_new_interactive:
+                    continue
+                else:
+                    protected_entries.append(incoming)
+            sanitized_entries = protected_entries
+            removed = {
+                entry_id
+                for entry_id in removed
+                if entry_id not in protected_oauth_ids
+            }
         existing_by_id = {
             entry.get("id"): entry
             for entry in existing_list

--- a/hermes_cli/auth_commands.py
+++ b/hermes_cli/auth_commands.py
@@ -105,6 +105,20 @@ def _oauth_default_label(provider: str, count: int) -> str:
     return f"{provider}-oauth-{count}"
 
 
+def _xai_dedicated_lane_label(fallback: str) -> str:
+    """Return Fleet's agent-specific xAI lane label when identity is known."""
+    try:
+        from hermes_cli.profiles import get_active_profile_name
+
+        profile_name = get_active_profile_name()
+    except Exception:
+        return fallback
+    if profile_name in {"default", "custom"}:
+        return fallback
+    agent_name = profile_name.replace("-", " ").replace("_", " ").title()
+    return f"{agent_name} Grok Sub"
+
+
 def _api_key_default_label(count: int) -> str:
     return f"api-key-{count}"
 
@@ -354,6 +368,7 @@ def auth_add_command(args) -> None:
             creds["tokens"]["access_token"],
             _oauth_default_label(provider, len(pool.entries()) + 1),
         )
+        label = _xai_dedicated_lane_label(label)
         # Add a distinct, self-contained pool entry per account (matching the
         # openai-codex / qwen-oauth / minimax-oauth patterns) instead of
         # routing through the singleton ``_save_xai_oauth_tokens`` save path.
@@ -377,7 +392,7 @@ def auth_add_command(args) -> None:
             last_refresh=creds.get("last_refresh"),
         )
         first_credential = not pool.entries()
-        pool.add_entry(entry)
+        pool.add_entry(entry, oauth_token_write_authority="interactive-login")
         # Adding the first xAI credential should make it the active provider
         # (the old singleton save path did this implicitly via
         # _save_provider_state). Subsequent adds leave the active provider as-is.

--- a/tests/hermes_cli/test_xai_external_scheduler_contract.py
+++ b/tests/hermes_cli/test_xai_external_scheduler_contract.py
@@ -1,0 +1,162 @@
+"""Fleet-owned xAI OAuth refresh writer contract."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from hermes_cli.auth import DEFAULT_XAI_OAUTH_BASE_URL
+
+
+def _xai_entry(*, access_token: str, refresh_token: str, label: str = "Neo Grok Sub") -> dict:
+    return {
+        "id": "neo-grok-sub",
+        "label": label,
+        "auth_type": "oauth",
+        "priority": 0,
+        "source": "manual:device_code",
+        "access_token": access_token,
+        "refresh_token": refresh_token,
+        "base_url": DEFAULT_XAI_OAUTH_BASE_URL,
+    }
+
+
+def _write_external_store(hermes_home: Path) -> None:
+    hermes_home.mkdir(parents=True)
+    (hermes_home / "config.yaml").write_text(
+        "oauth:\n  refresh_owner: external\n",
+        encoding="utf-8",
+    )
+    (hermes_home / "auth.json").write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "providers": {},
+                "credential_pool": {
+                    "xai-oauth": [
+                        _xai_entry(
+                            access_token="old-access",
+                            refresh_token="old-refresh",
+                        )
+                    ]
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+def test_external_scheduler_authority_updates_xai_oauth_tokens(tmp_path, monkeypatch):
+    from hermes_cli.auth import read_credential_pool, write_credential_pool
+
+    hermes_home = tmp_path / "hermes"
+    _write_external_store(hermes_home)
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    write_credential_pool(
+        "xai-oauth",
+        [_xai_entry(access_token="new-access", refresh_token="new-refresh")],
+        oauth_token_write_authority="external-scheduler",
+    )
+
+    [persisted] = read_credential_pool("xai-oauth")
+    assert persisted["access_token"] == "new-access"
+    assert persisted["refresh_token"] == "new-refresh"
+
+
+@pytest.mark.parametrize("authority", [None, "scheduler", "external_scheduler"])
+def test_external_owner_rejects_unsanctioned_xai_token_writers(
+    tmp_path,
+    monkeypatch,
+    authority,
+):
+    from hermes_cli.auth import read_credential_pool, write_credential_pool
+
+    hermes_home = tmp_path / "hermes"
+    _write_external_store(hermes_home)
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    kwargs = {}
+    if authority is not None:
+        kwargs["oauth_token_write_authority"] = authority
+    write_credential_pool(
+        "xai-oauth",
+        [_xai_entry(access_token="stolen-access", refresh_token="stolen-refresh")],
+        **kwargs,
+    )
+
+    [persisted] = read_credential_pool("xai-oauth")
+    assert persisted["access_token"] == "old-access"
+    assert persisted["refresh_token"] == "old-refresh"
+
+
+def test_standalone_xai_pool_write_remains_compatible(tmp_path, monkeypatch):
+    from hermes_cli.auth import read_credential_pool, write_credential_pool
+
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir()
+    (hermes_home / "auth.json").write_text(
+        json.dumps({"version": 1, "providers": {}}),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    write_credential_pool(
+        "xai-oauth",
+        [_xai_entry(access_token="standalone-access", refresh_token="standalone-refresh")],
+    )
+
+    [persisted] = read_credential_pool("xai-oauth")
+    assert persisted["access_token"] == "standalone-access"
+    assert persisted["refresh_token"] == "standalone-refresh"
+
+
+@pytest.mark.parametrize("requested_label", [None, "Neo Grok Sub", "generic lane"])
+def test_interactive_xai_add_uses_named_profile_dedicated_lane_without_secret_output(
+    tmp_path,
+    monkeypatch,
+    capsys,
+    requested_label,
+):
+    from hermes_cli.auth_commands import auth_add_command
+
+    profile_home = tmp_path / ".hermes" / "profiles" / "neo"
+    _write_external_store(profile_home)
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.setenv("HERMES_HOME", str(profile_home))
+    monkeypatch.setattr(
+        "hermes_cli.auth._xai_oauth_device_code_login",
+        lambda **_kwargs: {
+            "tokens": {
+                "access_token": "interactive-access-secret",
+                "refresh_token": "interactive-refresh-secret",
+            },
+            "base_url": DEFAULT_XAI_OAUTH_BASE_URL,
+            "last_refresh": "2026-08-15T10:00:00Z",
+        },
+    )
+
+    auth_add_command(
+        SimpleNamespace(
+            provider="xai-oauth",
+            auth_type="oauth",
+            api_key=None,
+            label=requested_label,
+            timeout=3,
+            no_browser=True,
+        )
+    )
+
+    payload = json.loads((profile_home / "auth.json").read_text(encoding="utf-8"))
+    added = next(
+        entry
+        for entry in payload["credential_pool"]["xai-oauth"]
+        if entry["access_token"] == "interactive-access-secret"
+    )
+    assert added["label"] == "Neo Grok Sub"
+    output = capsys.readouterr().out
+    assert "interactive-access-secret" not in output
+    assert "interactive-refresh-secret" not in output

--- a/tests/hermes_cli/test_xai_external_scheduler_contract.py
+++ b/tests/hermes_cli/test_xai_external_scheduler_contract.py
@@ -3,12 +3,22 @@
 from __future__ import annotations
 
 import json
+import time
 from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
 
 from hermes_cli.auth import DEFAULT_XAI_OAUTH_BASE_URL
+
+
+def _jwt_with_exp(exp_epoch: int) -> str:
+    import base64
+
+    payload = base64.urlsafe_b64encode(
+        json.dumps({"exp": exp_epoch}).encode("utf-8")
+    ).rstrip(b"=")
+    return f"h.{payload.decode('utf-8')}.s"
 
 
 def _xai_entry(*, access_token: str, refresh_token: str, label: str = "Neo Grok Sub") -> dict:
@@ -112,6 +122,129 @@ def test_standalone_xai_pool_write_remains_compatible(tmp_path, monkeypatch):
     [persisted] = read_credential_pool("xai-oauth")
     assert persisted["access_token"] == "standalone-access"
     assert persisted["refresh_token"] == "standalone-refresh"
+
+
+@pytest.mark.parametrize(
+    "config_text",
+    [
+        "oauth:\n  refresh_owner: external\n",
+        "oauth:\n  refresh_owner: fleet\n",
+        "oauth: []\n",
+        "{]\n",
+    ],
+)
+def test_legacy_singleton_refresh_fails_closed_without_spending_external_token(
+    tmp_path,
+    monkeypatch,
+    config_text,
+):
+    from hermes_cli.auth import AuthError, _refresh_xai_oauth_tokens
+
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir()
+    (hermes_home / "config.yaml").write_text(config_text, encoding="utf-8")
+    (hermes_home / "auth.json").write_text(
+        json.dumps({"version": 1, "providers": {}}),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    refresh_calls = []
+    monkeypatch.setattr(
+        "hermes_cli.auth.refresh_xai_oauth_pure",
+        lambda *_args, **_kwargs: refresh_calls.append(True),
+    )
+
+    with pytest.raises(AuthError) as exc_info:
+        _refresh_xai_oauth_tokens(
+            {"access_token": "stale-access", "refresh_token": "fleet-refresh"},
+            token_endpoint="https://auth.x.ai/oauth2/token",
+            timeout_seconds=5.0,
+        )
+
+    assert exc_info.value.code == "xai_external_refresh_forbidden"
+    assert exc_info.value.relogin_required is False
+    assert refresh_calls == []
+
+
+def test_runtime_resolver_adopts_scheduler_pool_without_refreshing_singleton(
+    tmp_path,
+    monkeypatch,
+):
+    from hermes_cli.auth import resolve_xai_oauth_runtime_credentials
+
+    hermes_home = tmp_path / "hermes"
+    _write_external_store(hermes_home)
+    payload = json.loads((hermes_home / "auth.json").read_text(encoding="utf-8"))
+    payload["providers"]["xai-oauth"] = {
+        "tokens": {
+            "access_token": _jwt_with_exp(int(time.time()) - 60),
+            "refresh_token": "stale-singleton-refresh",
+        },
+        "discovery": {"token_endpoint": "https://auth.x.ai/oauth2/token"},
+    }
+    scheduler_access = _jwt_with_exp(int(time.time()) + 7200)
+    payload["credential_pool"]["xai-oauth"][0].update(
+        access_token=scheduler_access,
+        refresh_token="scheduler-refresh",
+    )
+    (hermes_home / "auth.json").write_text(json.dumps(payload), encoding="utf-8")
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    refresh_calls = []
+    monkeypatch.setattr(
+        "hermes_cli.auth.refresh_xai_oauth_pure",
+        lambda *_args, **_kwargs: refresh_calls.append(True),
+    )
+
+    credentials = resolve_xai_oauth_runtime_credentials(force_refresh=True)
+
+    assert credentials["api_key"] == scheduler_access
+    assert refresh_calls == []
+
+
+def test_external_pool_proactive_and_reactive_refresh_only_adopt_disk_tokens(
+    tmp_path,
+    monkeypatch,
+):
+    from agent.credential_pool import CredentialPool, PooledCredential
+
+    hermes_home = tmp_path / "hermes"
+    _write_external_store(hermes_home)
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    expiring_access = _jwt_with_exp(int(time.time()) + 30)
+    payload = json.loads((hermes_home / "auth.json").read_text(encoding="utf-8"))
+    payload["credential_pool"]["xai-oauth"][0]["access_token"] = expiring_access
+    (hermes_home / "auth.json").write_text(json.dumps(payload), encoding="utf-8")
+    entry = PooledCredential.from_dict(
+        "xai-oauth", payload["credential_pool"]["xai-oauth"][0]
+    )
+    pool = CredentialPool("xai-oauth", [entry])
+    refresh_calls = []
+    monkeypatch.setattr(
+        "hermes_cli.auth.refresh_xai_oauth_pure",
+        lambda *_args, **_kwargs: refresh_calls.append(True),
+    )
+
+    selected = pool.select()
+    assert selected is not None
+    assert selected.access_token == expiring_access
+    assert refresh_calls == []
+
+    assert pool.try_refresh_current() is None
+    assert refresh_calls == []
+
+    scheduler_access = _jwt_with_exp(int(time.time()) + 7200)
+    payload = json.loads((hermes_home / "auth.json").read_text(encoding="utf-8"))
+    payload["credential_pool"]["xai-oauth"][0].update(
+        access_token=scheduler_access,
+        refresh_token="scheduler-rotated-refresh",
+    )
+    (hermes_home / "auth.json").write_text(json.dumps(payload), encoding="utf-8")
+
+    adopted = pool.try_refresh_current()
+    assert adopted is not None
+    assert adopted.access_token == scheduler_access
+    assert adopted.refresh_token == "scheduler-rotated-refresh"
+    assert refresh_calls == []
 
 
 @pytest.mark.parametrize("requested_label", [None, "Neo Grok Sub", "generic lane"])


### PR DESCRIPTION
## Why does this feature exist?

Hermes currently allows runtime xAI refresh paths to spend refresh tokens even when a profile delegates refresh ownership to an external scheduler. Single-use xAI refresh tokens require one authoritative writer. Without an ownership fence, Hermes and Fleet can race, reuse a token, or overwrite a scheduler-persisted successor.

## What changed?

- Add explicit xAI refresh ownership resolution.
- Allow only exact `external-scheduler` authority to update externally owned xAI credential-pool rows.
- Fail closed for malformed or unknown ownership values.
- Block singleton, proactive, and reactive runtime refreshes when ownership is external.
- Adopt scheduler-written tokens from disk instead of spending the refresh token again.
- Preserve standalone Hermes behavior when ownership is unset.
- Preserve interactive OAuth login through explicit `interactive-login` authority.
- Give named profiles dedicated `<Agent> Grok Sub` labels.
- Keep CLI output free of access and refresh tokens.

## Behavioural Proof

Backend-only change. No rendered UI, layout, screenshot, audio, or interaction surface changed.

Behavior tests:

- `tests/hermes_cli/test_xai_external_scheduler_contract.py`
- `tests/hermes_cli/test_auth_xai_oauth_provider.py`
- `tests/agent/test_credential_pool.py`

Verified paths:

- Scheduler-authorized writes succeed under external ownership.
- Missing or incorrect authority preserves scheduler-owned rows.
- Runtime singleton, proactive, and reactive refresh paths do not spend externally owned tokens.
- Scheduler-written disk rows are adopted in memory.
- Standalone and interactive-login behavior remain compatible.
- Auth command output does not print tokens.

## Verification Summary

Exact rebased head: `ede86951df77ed54a674e10be93d4e1113954b3f`

- External scheduler contract: `14 passed`
- Adjacent xAI provider and credential-pool suites: `84 passed`
- Fresh independent exact-head run: `98 passed`, `0 failed`, `0 retries`
- Ruff: passed
- `git diff origin/main...HEAD --check`: passed
- Fresh-context read-only QA: PASS

Residual risk:

- The ownership fence is an application boundary, not a cryptographic boundary.
- The external scheduler must persist the expected pool shape with exact `external-scheduler` authority.
- Live scheduler timing and cross-process rotation are verified in the paired Fleet deployment, not in this Hermes-only PR.
