### PR TITLE
fix(cron): rebase unpinned snapshots on official model upgrades

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -2233,6 +2233,70 @@ def clear_drift_alerted(job_id: str) -> None:
     _set_alert_flag(job_id, "drift_alerted", False)
 
 
+def rebase_unpinned_inference_snapshots(
+    *,
+    provider: Any = None,
+    model: Any = None,
+) -> List[str]:
+    """Rebase unpinned snapshot axes after an official global model/provider write.
+
+    Unpinned jobs follow the global default. An operator writing
+    ``model.default`` / ``model.provider`` (``hermes model``, ``hermes config
+    set``, TUI ``/model``) is an intentional upgrade — including MoA preset
+    renames like ``grok-4.5->m3`` → ``m3->grok-4.6``. Rebase those snapshots
+    in place so the #44585 fire-time guard does not skip the next tick.
+
+    Pinned axes, ``no_agent`` jobs, and jobs with no snapshot on that axis
+    are left alone. Returns the job ids that were rewritten.
+    """
+    new_provider = _normalize_job_optional_text(provider)
+    new_model = _normalize_job_optional_text(model)
+    if new_provider is None and new_model is None:
+        return []
+
+    rewritten: List[str] = []
+    with _jobs_lock():
+        jobs = load_jobs()
+        changed = False
+        for i, job in enumerate(jobs):
+            if not isinstance(job, dict) or bool(job.get("no_agent")):
+                continue
+            if not is_job_runnable(job):
+                continue
+            job_id = _coerce_job_text(job.get("id")).strip()
+            if not job_id:
+                continue
+            updated = dict(job)
+            axis_changed = False
+            if (
+                new_provider is not None
+                and not _normalize_job_optional_text(updated.get("provider"))
+                and _normalize_job_optional_text(updated.get("provider_snapshot"))
+            ):
+                snapshot = _normalize_job_optional_text(updated.get("provider_snapshot"))
+                if snapshot and snapshot.lower() != new_provider.lower():
+                    updated["provider_snapshot"] = new_provider
+                    axis_changed = True
+            if (
+                new_model is not None
+                and not _normalize_job_optional_text(updated.get("model"))
+                and _normalize_job_optional_text(updated.get("model_snapshot"))
+            ):
+                snapshot = _normalize_job_optional_text(updated.get("model_snapshot"))
+                if snapshot and snapshot.lower() != new_model.lower():
+                    updated["model_snapshot"] = new_model
+                    axis_changed = True
+            if not axis_changed:
+                continue
+            updated.pop("drift_alerted", None)
+            jobs[i] = updated
+            rewritten.append(job_id)
+            changed = True
+        if changed:
+            save_jobs(jobs)
+    return rewritten
+
+
 def _mark_job_run_locked(
     job_id: str,
     success: bool,

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -4972,12 +4972,55 @@ def _load_cron_jobs_for_config_warning() -> List[Dict[str, Any]]:
         return []
 
 
+def rebase_unpinned_cron_jobs_after_model_config_change(
+    key: str,
+    value: Any,
+    config: Optional[Dict[str, Any]] = None,
+) -> List[str]:
+    """Rebase unpinned cron snapshots after an official model/provider write.
+
+    Operator-facing writes (``hermes config set``, ``hermes model``, TUI
+    ``/model``) are intentional upgrades, including MoA preset renames.
+    Rebase matching unpinned snapshots so the fire-time #44585 guard does
+    not skip the next tick. The runtime skip still fires for drift that was
+    not written through this path (hand-edited config, env-only swaps).
+
+    Returns the job ids that were rewritten. Best-effort: a store error
+    never fails the config write that already landed.
+    """
+    axis = _cron_model_drift_axis_for_config_key(key)
+    if axis is None:
+        return []
+    new_value = _model_assignment_text(value)
+    if not new_value:
+        return []
+    if not cron_model_drift_guard_enabled(config):
+        return []
+    if _cron_fleet_default_covers_axis(axis, config):
+        return []
+    try:
+        from cron.jobs import rebase_unpinned_inference_snapshots
+    except Exception:
+        return []
+    try:
+        if axis == "provider":
+            return rebase_unpinned_inference_snapshots(provider=new_value)
+        return rebase_unpinned_inference_snapshots(model=new_value)
+    except Exception:
+        return []
+
+
 def warn_unpinned_cron_jobs_after_model_config_change(
     key: str,
     value: Any,
     config: Optional[Dict[str, Any]] = None,
 ) -> None:
-    """Warn when a global model/provider change will trip cron's drift guard."""
+    """Rebase unpinned snapshots after an official model/provider change.
+
+    Intentional upgrades (including MoA preset renames) should not skip the
+    next cron tick. Hand-edited or env-only drift still fail closed at fire
+    time via the #44585 guard.
+    """
     axis = _cron_model_drift_axis_for_config_key(key)
     if axis is None:
         return
@@ -4985,6 +5028,18 @@ def warn_unpinned_cron_jobs_after_model_config_change(
     new_value = _model_assignment_text(value)
     if not new_value:
         return
+    rewritten = rebase_unpinned_cron_jobs_after_model_config_change(
+        key, value, config
+    )
+    if rewritten:
+        noun = "job" if len(rewritten) == 1 else "jobs"
+        print(
+            f"✓ Rebased {len(rewritten)} unpinned cron {noun} to the new "
+            f"global {axis} ({new_value}). The spend-safety guard still "
+            "skips jobs whose snapshots were not updated by this write."
+        )
+        return
+
     impact = build_cron_model_impact(
         current_provider=new_value if axis == "provider" else "",
         current_model=new_value if axis == "model" else "",

--- a/tests/cron/test_cron_rebase_unpinned.py
+++ b/tests/cron/test_cron_rebase_unpinned.py
@@ -1,0 +1,115 @@
+"""Official model/provider writes rebase unpinned cron snapshots.
+
+The #44585 fire-time guard still fails closed for ambient drift (hand-edited
+config, env-only swaps). Operator-facing writes through hermes config /
+hermes model / TUI /model must rebase snapshots so a preset rename does
+not skip the next tick.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import cron.jobs as jobs
+
+
+def _isolate_storage(monkeypatch, existing: list[dict[str, Any]]):
+    store = {"jobs": [dict(job) for job in existing]}
+
+    def _load() -> list[dict[str, Any]]:
+        return [dict(job) for job in store["jobs"]]
+
+    def _save(updated, **_kwargs) -> None:
+        store["jobs"] = [dict(job) for job in updated]
+
+    monkeypatch.setattr(jobs, "load_jobs", _load, raising=True)
+    monkeypatch.setattr(jobs, "save_jobs", _save, raising=True)
+    return store
+
+
+def test_rebases_unpinned_model_snapshot_and_clears_alert(monkeypatch) -> None:
+    store = _isolate_storage(
+        monkeypatch,
+        [
+            {
+                "id": "drain",
+                "enabled": True,
+                "model": None,
+                "provider": None,
+                "model_snapshot": "grok-4.5->m3",
+                "provider_snapshot": "moa",
+                "drift_alerted": True,
+            }
+        ],
+    )
+
+    rewritten = jobs.rebase_unpinned_inference_snapshots(model="m3->grok-4.6")
+
+    assert rewritten == ["drain"]
+    job = store["jobs"][0]
+    assert job["model_snapshot"] == "m3->grok-4.6"
+    assert job["provider_snapshot"] == "moa"
+    assert "drift_alerted" not in job
+
+
+def test_leaves_pinned_no_agent_and_matching_snapshots_alone(monkeypatch) -> None:
+    store = _isolate_storage(
+        monkeypatch,
+        [
+            {
+                "id": "pinned",
+                "enabled": True,
+                "model": "keep-me",
+                "model_snapshot": "old-model",
+            },
+            {
+                "id": "script",
+                "enabled": True,
+                "no_agent": True,
+                "model_snapshot": "old-model",
+            },
+            {
+                "id": "already-current",
+                "enabled": True,
+                "model": None,
+                "model_snapshot": "m3->grok-4.6",
+            },
+            {
+                "id": "paused",
+                "enabled": False,
+                "state": "paused",
+                "model_snapshot": "old-model",
+            },
+        ],
+    )
+
+    rewritten = jobs.rebase_unpinned_inference_snapshots(model="m3->grok-4.6")
+
+    assert rewritten == []
+    assert store["jobs"][0]["model_snapshot"] == "old-model"
+    assert store["jobs"][1]["model_snapshot"] == "old-model"
+    assert store["jobs"][2]["model_snapshot"] == "m3->grok-4.6"
+    assert store["jobs"][3]["model_snapshot"] == "old-model"
+
+
+def test_provider_axis_is_independent_of_model(monkeypatch) -> None:
+    store = _isolate_storage(
+        monkeypatch,
+        [
+            {
+                "id": "both",
+                "enabled": True,
+                "model": None,
+                "provider": None,
+                "model_snapshot": "old-model",
+                "provider_snapshot": "openrouter",
+            }
+        ],
+    )
+
+    rewritten = jobs.rebase_unpinned_inference_snapshots(provider="moa")
+
+    assert rewritten == ["both"]
+    job = store["jobs"][0]
+    assert job["provider_snapshot"] == "moa"
+    assert job["model_snapshot"] == "old-model"

--- a/tests/hermes_cli/test_set_config_value.py
+++ b/tests/hermes_cli/test_set_config_value.py
@@ -300,11 +300,40 @@ def _write_cron_jobs(tmp_path, jobs):
 
 
 class TestCronModelDriftConfigWarning:
-    """Warn operators before unpinned snapshot-bearing cron jobs fail closed."""
+    """Official model writes rebase unpinned snapshots instead of skipping."""
 
+    def test_model_default_write_rebases_unpinned_snapshot(
+        self,
+        _isolated_hermes_home,
+        capsys,
+    ):
+        _write_cron_jobs(
+            _isolated_hermes_home,
+            [
+                {
+                    "id": "model-drift-job",
+                    "enabled": True,
+                    "model": None,
+                    "provider": None,
+                    "model_snapshot": "grok-4.5->m3",
+                    "provider_snapshot": "moa",
+                    "drift_alerted": True,
+                }
+            ],
+        )
 
+        set_config_value("model.default", "m3->grok-4.6")
 
-
+        captured = capsys.readouterr()
+        assert "Rebased 1 unpinned cron job" in captured.out
+        assert "fail closed" not in captured.out
+        stored = json.loads(
+            (_isolated_hermes_home / "cron" / "jobs.json").read_text(encoding="utf-8")
+        )
+        job = stored["jobs"][0]
+        assert job["model_snapshot"] == "m3->grok-4.6"
+        assert job["provider_snapshot"] == "moa"
+        assert "drift_alerted" not in job
 
     def test_explicit_opt_out_suppresses_warning(
         self,

--- a/website/docs/user-guide/features/cron.md
+++ b/website/docs/user-guide/features/cron.md
@@ -96,9 +96,14 @@ Or: `hermes config set cron.preflight false`
 
 ## Letting unpinned jobs track global defaults
 
-The model/provider drift guard is enabled by default. If your unpinned cron
-jobs should deliberately follow every global model or provider change, disable
-it in `config.yaml`:
+The model/provider drift guard is enabled by default. Official upgrades made
+through `hermes config set`, `hermes model`, or TUI `/model` rebase unpinned
+job snapshots automatically, including MoA preset renames. Hand-edited
+`config.yaml` and env-only swaps still fail closed at the next tick.
+
+If your unpinned cron jobs should deliberately follow every global model or
+provider change — including those unofficial paths — disable the guard in
+`config.yaml`:
 
 ```yaml
 cron:


### PR DESCRIPTION
## What does this PR do?

Official model/provider writes (`hermes config set`, `hermes model`, TUI `/model`) now rebase unpinned cron snapshots so a deliberate preset rename does not skip the next tick.

Unpinned jobs are supposed to follow the global default. After #44585 they also carry `provider_snapshot` / `model_snapshot` from creation time. A MoA preset rename (`grok-4.5->m3` -> `m3->grok-4.6`) is an operator-owned upgrade, but the fire-time guard treats it as ambient drift and fails closed. The only documented remediations today pin the job (stops tracking the default) or require an explicit resnap command.

This path heals only official writes. Hand-edited `config.yaml` and env-only swaps still fail closed.

## Related Issue

Related to #44585 (spend-safety guard). Complements, does not replace, the explicit remediations in:

- #80648 (`resnap` command / tool)
- #86001 (`--resnapshot` flag)
- #79312 (non-string snapshot coercion)

Those stay useful for unofficial / ambient drift. This PR is the delete-the-skip behavior for an official model switch.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `cron/jobs.py` — add `rebase_unpinned_inference_snapshots()`; leave pinned / `no_agent` / matching snapshots alone; clear `drift_alerted` when rewritten
- `hermes_cli/config.py` — official model/provider writes call the rebase helper from `warn_unpinned_cron_jobs_after_model_config_change()` (now write + warn, not warn-only)
- `tests/cron/test_cron_rebase_unpinned.py` — rebase helper unit tests
- `tests/hermes_cli/test_set_config_value.py` — `hermes config set model.default` rebases the snapshot
- `website/docs/user-guide/features/cron.md` — document official-write rebase vs unofficial fail-closed

## How to Test

1. Create an unpinned agent cron job while `model.default` is `old-preset`. Confirm `model_snapshot` is `old-preset`.
2. Run `hermes config set model.default new-preset`.
3. Confirm the job stays unpinned, `model_snapshot` is now `new-preset`, and the next tick is not skipped.
4. Hand-edit `config.yaml` `model.default` without going through `hermes config set` / `hermes model` / TUI `/model`. Confirm the next tick still fails closed.

Automated:

```
pytest tests/cron/test_cron_rebase_unpinned.py tests/hermes_cli/test_set_config_value.py::TestCronModelDriftConfigWarning -v
```

Result on 2026-08-16, macOS 26.5.2, Python 3.14.5: **10 passed**.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.5.2

Full `pytest tests/ -q` was not run. Targeted rebase/drift tests above passed 10/10. Pre-existing `TestModelDriftGuard` failures on this host are `hermes_cli.env_loader` import noise under system Python 3.14, not this change.

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

No new config keys. No tool schema change. The cron docs section on tracking global defaults was updated.

## AI disclosure

AI was used (partial). Authoring model: MoA preset `m3->grok-4.6` (acting/aggregator `xai-oauth:grok-4.6`, reference `minimax:minimax-m3`) via Hermes Agent. Human inviter asked for the Hermes-src fix and then for this PR. Left **draft** until that human reviews the diff and marks ready.

## Screenshots / Logs

```
============================== 10 passed in 2.18s ==============================
```
