### PR TITLE
fix(skills): stop self-claim warning flood from concurrent skill scans

### DIFF
--- a/agent/skill_commands.py
+++ b/agent/skill_commands.py
@@ -8,6 +8,7 @@ import json
 import logging
 import os
 import re
+import threading
 from pathlib import Path
 from typing import Any, Dict, Optional
 
@@ -24,6 +25,12 @@ logger = logging.getLogger(__name__)
 _skill_commands: Dict[str, Dict[str, Any]] = {}
 _skill_commands_platform: Optional[str] = None
 _skill_commands_home: Optional[str] = None
+# Guards the atomic publish/snapshot of the shared command map and its platform
+# tag. The scan itself runs unlocked (it walks the skills dir and can be slow);
+# only the final swap of the fully-built map — and the paired read-back in
+# ``get_skill_commands`` / ``reload_skills`` — take the lock. This is what lets
+# overlapping scans publish whole maps instead of interleaving their writes.
+_skill_commands_lock = threading.Lock()
 # Patterns for sanitizing skill names into clean hyphen-separated slugs.
 _SKILL_INVALID_CHARS = re.compile(r"[^a-z0-9-]")
 _SKILL_MULTI_HYPHEN = re.compile(r"-{2,}")
@@ -419,13 +426,29 @@ def _build_skill_message(
 def scan_skill_commands() -> Dict[str, Dict[str, Any]]:
     """Scan ~/.hermes/skills/ and return a mapping of /command -> skill info.
 
+    Builds into a local dict and publishes it to ``_skill_commands`` in one
+    atomic swap under ``_skill_commands_lock``. Building locally (instead of
+    mutating the shared global in place) means overlapping scans — several
+    session boots landing in the same gateway ``serve`` process at once — can
+    no longer interleave their writes and log a bogus "already claimed by
+    itself" warning per skill (#74574).
+
     Returns:
         Dict mapping "/skill-name" to {name, description, skill_md_path, skill_dir}.
     """
     global _skill_commands, _skill_commands_platform, _skill_commands_home
-    _skill_commands_platform = _resolve_skill_commands_platform()
-    _skill_commands_home = _resolve_skill_commands_home()
-    _skill_commands = {}
+
+    # Resolve the platform scope once, up front. It feeds the disabled-skill
+    # filter and is published alongside the map so ``get_skill_commands`` can
+    # detect a platform change without a second lookup.
+    platform = _resolve_skill_commands_platform()
+    home = _resolve_skill_commands_home()
+
+    # Build the full command map into a LOCAL dict. Every dedup check below
+    # runs against local state (``seen_names`` for raw names, ``local_commands``
+    # for normalized slugs) — never the shared global — so a concurrent scan's
+    # publish can't corrupt this scan's dedup.
+    local_commands: Dict[str, Dict[str, Any]] = {}
     try:
         from tools.skills_tool import SKILLS_DIR, _parse_frontmatter, skill_matches_platform, skill_matches_environment, _get_disabled_skill_names
         from agent.skill_utils import get_external_skills_dirs, iter_skill_index_files
@@ -493,14 +516,14 @@ def scan_skill_commands() -> Dict[str, Dict[str, Any]]:
                     # slug (e.g. "git_helper" vs "git-helper"). First-wins
                     # preserves local-before-external precedence.
                     cmd_key = f"/{cmd_name}"
-                    if cmd_key in _skill_commands:
+                    if cmd_key in local_commands:
                         logger.warning(
                             "Skill %r maps to slash command %s already claimed "
                             "by %r; keeping the first and skipping this one.",
-                            name, cmd_key, _skill_commands[cmd_key]["name"],
+                            name, cmd_key, local_commands[cmd_key]["name"],
                         )
                         continue
-                    _skill_commands[cmd_key] = {
+                    local_commands[cmd_key] = {
                         "name": name,
                         "description": description or f"Invoke the {name} skill",
                         "skill_md_path": str(skill_md),
@@ -510,7 +533,15 @@ def scan_skill_commands() -> Dict[str, Dict[str, Any]]:
                     continue
     except Exception:
         pass
-    return _skill_commands
+
+    # Publish atomically: swap the fully-built map (and its platform tag) into
+    # the globals in one locked step. Readers only ever observe a complete map.
+    with _skill_commands_lock:
+        _skill_commands = local_commands
+        _skill_commands_platform = platform
+        _skill_commands_home = home
+
+    return local_commands
 
 
 def get_skill_commands() -> Dict[str, Dict[str, Any]]:
@@ -521,14 +552,22 @@ def get_skill_commands() -> Dict[str, Dict[str, Any]]:
     sees its own ``skills.platform_disabled`` view (#14536), and when the
     active profile's Hermes home changes (e.g. Desktop switching profiles
     mid-session) so each profile sees its own ``skills.external_dirs`` (#88023).
+
+    The map and its platform tag are snapshotted together under the publish
+    lock so a concurrent scan's swap can't leave us comparing a fresh map
+    against a stale platform tag.
     """
+    with _skill_commands_lock:
+        commands = _skill_commands
+        commands_platform = _skill_commands_platform
+        commands_home = _skill_commands_home
     if (
-        not _skill_commands
-        or _skill_commands_platform != _resolve_skill_commands_platform()
-        or _skill_commands_home != _resolve_skill_commands_home()
+        not commands
+        or commands_platform != _resolve_skill_commands_platform()
+        or commands_home != _resolve_skill_commands_home()
     ):
-        scan_skill_commands()
-    return _skill_commands
+        return scan_skill_commands()
+    return commands
 
 
 def reload_skills() -> Dict[str, Any]:
@@ -570,10 +609,11 @@ def reload_skills() -> Dict[str, Any]:
             out[bare] = (info or {}).get("description") or ""
         return out
 
-    before = _snapshot(_skill_commands)
+    with _skill_commands_lock:
+        before = _snapshot(_skill_commands)
 
-    # Rescan the skills dir. ``scan_skill_commands`` resets
-    # ``_skill_commands = {}`` internally and repopulates it.
+    # Rescan the skills dir. ``scan_skill_commands`` builds into a local map
+    # and publishes it atomically; the return value is that newly-built map.
     new_commands = scan_skill_commands()
 
     after = _snapshot(new_commands)

--- a/tests/agent/test_skill_commands.py
+++ b/tests/agent/test_skill_commands.py
@@ -349,6 +349,81 @@ class TestScanSkillCommands:
         assert any("already claimed" in r.message for r in caplog.records)
 
 
+class TestScanSkillCommandsConcurrency:
+    """Concurrent scans must not log self-claim warnings (#74574).
+
+    ``scan_skill_commands`` used to build the shared ``_skill_commands``
+    global in place, so two overlapping scans — several session boots landing
+    in one gateway ``serve`` process at the same time — interleaved their
+    resets and dedup checks and logged a bogus "already claimed by itself"
+    warning per skill. The fix builds locally and publishes atomically, so
+    concurrent scans must emit zero such warnings and leave a complete map.
+    """
+
+    def test_concurrent_scans_produce_no_self_claim_warnings(
+        self, tmp_path, caplog
+    ):
+        import logging as _logging
+        import threading as _threading
+
+        import agent.skill_commands as sc_mod
+
+        # A generous skill set widens the file-I/O window so the scans
+        # genuinely overlap instead of running back-to-back.
+        names = [f"skill-{i:02d}" for i in range(40)]
+
+        with (
+            patch("tools.skills_tool.SKILLS_DIR", tmp_path),
+            patch(
+                "tools.skills_tool._get_disabled_skill_names",
+                return_value=set(),
+            ),
+            patch.object(sc_mod, "_skill_commands", {}),
+            patch.object(sc_mod, "_skill_commands_platform", None),
+        ):
+            for name in names:
+                _make_skill(tmp_path, name)
+
+            results = []
+            barrier = _threading.Barrier(6)  # 5 workers + this main thread
+
+            def worker():
+                barrier.wait()
+                results.append(dict(scan_skill_commands()))
+
+            threads = [
+                _threading.Thread(target=worker, name=f"scan-{i}")
+                for i in range(5)
+            ]
+            with caplog.at_level(
+                _logging.WARNING, logger="agent.skill_commands"
+            ):
+                for t in threads:
+                    t.start()
+                barrier.wait()  # release all workers simultaneously
+                for t in threads:
+                    t.join()
+
+            final_global = dict(sc_mod._skill_commands)
+
+        # Zero self-claim warnings — the regression this fix targets.
+        self_claim = [
+            r for r in caplog.records if "already claimed" in r.message
+        ]
+        assert self_claim == [], [r.message for r in self_claim]
+
+        # Every worker observed the same complete, correct map.
+        expected_keys = {f"/{name}" for name in names}
+        assert len(results) == 5
+        for result in results:
+            assert set(result) == expected_keys
+            for name in names:
+                assert result[f"/{name}"]["name"] == name
+
+        # The published global is also complete and correct.
+        assert set(final_global) == expected_keys
+
+
 class TestResolveSkillCommandKey:
     """Telegram bot-command names disallow hyphens, so the menu registers
     skills with hyphens swapped for underscores. When Telegram autocomplete


### PR DESCRIPTION
## What does this PR do?

Fixes the `skill-commands` data race that floods `~/.hermes/logs/errors.log` with `... already claimed by 'itself'` warnings whenever multiple sessions boot concurrently in the same process.

`scan_skill_commands()` built its result by mutating the module-global `_skill_commands` dict with no synchronization. The TUI gateway `serve` process boots several sessions at once (Bot Chat relays + desktop sessions via the `ThreadPoolExecutor` in `tui_gateway/server.py`), so overlapping scans interleave: each scan resets the shared dict mid-flight, then its dedup check (`cmd_key in _skill_commands`) runs against the *other* scan's partially-built entries, producing one bogus "already claimed by itself" warning per skill. The final map was still correct (first-wins), so this was functionally benign but logged thousands of spurious warnings per day.

This PR makes the scan build into a local dict and publish `_skill_commands` + `_skill_commands_platform` atomically under a `threading.Lock`. Dedup now runs against the local map (never the shared global), so concurrent scans can't corrupt each other's dedup state. The paired reads in `get_skill_commands()` and `reload_skills()` take the same lock so a reader never observes a torn map/platform pair.

Adds a concurrency regression test, verified RED → GREEN (see How to Test).

## Related Issue

Fixes #74574

**Prior art:** #74960 uses the same lock + atomic-publish approach but has been open and stale since 2026-08-05 with no CI result (`mergeable: UNKNOWN`). #74624 (closed, unmerged) only suppressed the warning cosmetically. This PR adds a concurrent-scan regression test (RED→GREEN proven) and is green against current `main`.
## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/skill_commands.py`
  - Added a module-level `_skill_commands_lock = threading.Lock()` guarding the  publish/snapshot of the shared command map + platform tag.
  - `scan_skill_commands()` now builds into a local `local_commands` dict and publishes it (with the platform tag) in one atomic swap under the lock; the
    dedup check compares against `local_commands`, not the shared global.
  - `get_skill_commands()` snapshots the map + platform tag together under the lock.
  - `reload_skills()` takes the lock when snapshotting pre-reload state.
- `tests/agent/test_skill_commands.py`
  - Added `TestScanSkillCommandsConcurrency::test_concurrent_scans_produce_no_self_claim_warnings`  (5 threads × 40 skills, barrier-released) asserting zero self-claim warnings
    and an identical, complete final map.

## How to Test

1. Regression test (GREEN on this branch):
   ```bash
   scripts/run_tests.sh tests/agent/test_skill_commands.py -k TestScanSkillCommandsConcurrency -q
   ```
2. Prove the test catches the bug (RED on current `main`): check out `main`
   (or `git stash` the `agent/skill_commands.py` change) and re-run step 1 — it   fails with a flood of `already claimed by itself` warnings (19 in one 5-thread run).
3. Affected scope:
   ```bash
   scripts/run_tests.sh tests/agent/test_skill_commands.py tests/agent/test_skill_commands_reload.py tests/cli/test_cli_reload_skills.py tests/gateway/test_reload_skills_command.py tests/gateway/test_reload_skills_discord_resync.py -q
   ```   → 35 passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the affected scope (35 tests) via `scripts/run_tests.sh`, all pass; the full `pytest tests/` suite runs in CI
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux (Debian 13)

### Documentation & Housekeeping

- [N/A] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [N/A] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [N/A] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [N/A] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Regression test on `main` (RED — reproduces the bug):

```
WARNING  agent.skill_commands:skill_commands.py:479 Skill 'skill-35' maps to slash command /skill-35 already claimed by 'skill-35'; keeping the first and skipping this one.
... (18 more self-claim warnings in one 5-thread run) ...
```

Same test on this branch (GREEN): 0 warnings, identical complete map.
Additional logs from `ERRORS.log` per Aug 15 2026:
```python
2026-08-15 19:50:59,631 WARNING agent.skill_commands: Skill 'inspecting-hermes-desktop-dom' maps to slash command /inspecting-hermes-desktop-dom already claimed by 'inspecting-hermes-desktop-dom'; keeping the first and skipping this one.
2026-08-15 19:50:59,633 WARNING agent.skill_commands: Skill 'plan' maps to slash command /plan already claimed by 'plan'; keeping the first and skipping this one.
2026-08-15 19:50:59,635 WARNING agent.skill_commands: Skill 'pre-install-audit' maps to slash command /pre-install-audit already claimed by 'pre-install-audit'; keeping the first and skipping this one.
2026-08-15 19:50:59,635 WARNING agent.skill_commands: Skill 'simplify-code' maps to slash command /simplify-code already claimed by 'simplify-code'; keeping the first and skipping this one.
2026-08-15 19:50:59,636 WARNING agent.skill_commands: Skill 'spike' maps to slash command /spike already claimed by 'spike'; keeping the first and skipping this one.
2026-08-15 19:50:59,637 WARNING agent.skill_commands: Skill 'subagent-driven-development' maps to slash command /subagent-driven-development already claimed by 'subagent-driven-development'; keeping the first and skipping this one.
2026-08-15 19:50:59,639 WARNING agent.skill_commands: Skill 'test-driven-development' maps to slash command /test-driven-development already claimed by 'test-driven-development'; keeping the first and skipping this one.
2026-08-15 19:50:59,643 WARNING agent.skill_commands: Skill 'web-ui-verification' maps to slash command /web-ui-verification already claimed by 'web-ui-verification'; keeping the first and skipping this one.
2026-08-15 19:50:59,648 WARNING agent.skill_commands: Skill 'static-site-publishing' maps to slash command /static-site-publishing already claimed by 'static-site-publishing'; keeping the first and skipping this one.
2026-08-15 19:50:59,648 WARNING agent.skill_commands: Skill 'to-issues' maps to slash command /to-issues already claimed by 'to-issues'; keeping the first and skipping this one.
2026-08-15 19:50:59,648 WARNING agent.skill_commands: Skill 'to-prd' maps to slash command /to-prd already claimed by 'to-prd'; keeping the first and skipping this one.
2026-08-15 19:50:59,649 WARNING agent.skill_commands: Skill 'triage' maps to slash command /triage already claimed by 'triage'; keeping the first and skipping this one.
2026-08-15 19:50:59,649 WARNING agent.skill_commands: Skill 'write-a-skill' maps to slash command /write-a-skill already claimed by 'write-a-skill'; keeping the first and skipping this one.
2026-08-15 19:50:59,649 WARNING agent.skill_commands: Skill 'zoom-out' maps to slash command /zoom-out already claimed by 'zoom-out'; keeping the first and skipping this one. 
```