### PR TITLE
fix(models): add glm-5.3 1M context window entry

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -501,12 +501,15 @@ DEFAULT_CONTEXT_LENGTHS = {
     # https://platform.minimax.io/docs/api-reference/text-chat-openai
     "minimax-m3": 1000000,
     "minimax": 204800,
-    # GLM — GLM-5.2 ships with a 1M context window (verified empirically:
-    # needle-in-a-haystack retrieval at 789K prompt tokens succeeded with
-    # zero errors on api.z.ai/api/coding/paas/v4).  Older GLM models
+    # GLM — GLM-5.2/5.3 ship with a 1M context window (5.2 verified
+    # empirically: needle-in-a-haystack retrieval at 789K prompt tokens
+    # succeeded with zero errors on api.z.ai/api/coding/paas/v4; 5.3 shares
+    # the same base model per Z.ai docs and was verified the same way at
+    # 766K prompt tokens on 2026-08-15).  Older GLM models
     # (5, 5.1, 5-turbo) are ~202K.  Longest-key-first substring matching
-    # ensures "glm-5.2" resolves to 1M while older variants still hit the
-    # generic 202K fallback.
+    # ensures "glm-5.2"/"glm-5.3" resolve to 1M while older variants still
+    # hit the generic 202K fallback.
+    "glm-5.3": 1_048_576,
     "glm-5.2": 1_048_576,
     "glm": 202752,
     # xAI Grok — xAI /v1/models does not return context_length metadata,


### PR DESCRIPTION
## What does this PR do?

Adds a specific `glm-5.3` entry to `DEFAULT_CONTEXT_LENGTHS` in `agent/model_metadata.py` pinning its context window to 1M tokens.

Without this entry, `glm-5.3` falls through to the generic `"glm": 202752` fallback (line 511), under-reporting the true window by ~5x. Hermes uses this value to decide when to trigger context compression, so a model configured as `glm-5.3` compresses ~5x earlier than necessary (and the user sees a wrong "context window" figure).

## Related Issue

No issue filed. The bug is a missing catalog entry for a newly-released model (same class as the `glm-5.2` 1M pin already on `main`).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/model_metadata.py` — added `"glm-5.3": 1_048_576` to `DEFAULT_CONTEXT_LENGTHS`, and extended the GLM comment to document the empirical verification for both 5.2 and 5.3.

## How to Test

1. Configure a Z.AI provider with `default_model: glm-5.3`.
2. Confirm Hermes resolves its context window to 1,048,576 (instead of 202,752).
3. Empirical verification performed against `https://api.z.ai/api/coding/paas/v4/chat/completions`: needle-in-a-haystack with 766,362 prompt tokens returned the hidden code exactly (zero errors), confirming the ~1M window. `glm-5.2` was verified the same way previously at 789K tokens.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/agent/test_model_metadata.py -q` and all tests pass (82/82)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features) — existing catalog test coverage applies; no new test case needed for a data-only entry
- [x] I've tested on my platform: Ubuntu (ARM64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A (comment updated in-place)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (no config key change)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) — N/A (static data entry)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A
