### PR TITLE
fix(computer-use): placeholder-id targeting + macOS zero-display diagnosis (salvage #81340, #52949, #67259)

### DIFF
--- a/tests/tools/test_computer_use_display_count_guard.py
+++ b/tests/tools/test_computer_use_display_count_guard.py
@@ -1,0 +1,60 @@
+"""macOS ScreenCaptureKit display_count=0 diagnosability.
+
+Composed from PR #52949 (sujeet111, doctor guard) and PR #67259
+(webtecnica, actionable-hint direction): a headless Mac or asleep panel
+leaves SCK with zero shareable displays while TCC grants pass, so
+health_report says ok and every capture returns 0x0 silently. The guard
+turns that into a failed check + degraded overall + recovery hint.
+"""
+
+from tools.computer_use.doctor import _apply_display_count_guard
+
+
+def _report(status="pass", count=0, overall="ok", name="screen_capture_capability"):
+    return {
+        "overall": overall,
+        "checks": [
+            {
+                "name": name,
+                "status": status,
+                "message": "ScreenCaptureKit reachable",
+                "data": {"display_count": count},
+            }
+        ],
+    }
+
+
+def test_zero_displays_downgrades_ok_to_degraded():
+    out = _apply_display_count_guard(_report(count=0))
+    assert out["overall"] == "degraded"
+    assert out["checks"][0]["status"] == "fail"
+    assert "0 shareable" in out["checks"][0]["message"]
+    assert "dongle" in out["checks"][0]["hint"]
+
+
+def test_positive_display_count_untouched():
+    out = _apply_display_count_guard(_report(count=1))
+    assert out["overall"] == "ok"
+    assert out["checks"][0]["status"] == "pass"
+
+
+def test_already_failed_check_not_rewritten():
+    out = _apply_display_count_guard(_report(status="fail", count=0, overall="degraded"))
+    # Guard only flips pass->fail; an existing failure keeps its message.
+    assert out["checks"][0]["message"] == "ScreenCaptureKit reachable"
+
+
+def test_missing_data_and_other_checks_ignored():
+    out = _apply_display_count_guard(
+        {"overall": "ok", "checks": [{"name": "binary_version", "status": "pass"}]}
+    )
+    assert out["overall"] == "ok"
+    out2 = _apply_display_count_guard({"overall": "ok", "checks": "bogus"})
+    assert out2["overall"] == "ok"
+
+
+def test_overall_failed_not_upgraded():
+    out = _apply_display_count_guard(_report(count=0, overall="failed"))
+    # fail-worse states are never softened to degraded.
+    assert out["overall"] == "failed"
+    assert out["checks"][0]["status"] == "fail"

--- a/tests/tools/test_computer_use_placeholder_ids.py
+++ b/tests/tools/test_computer_use_placeholder_ids.py
@@ -1,0 +1,107 @@
+"""A zero-filled ``pid``/``window_id`` must not be read as exact targeting.
+
+Several providers emit every declared schema property on every tool call,
+filling unused optional integers with ``0``. ``capture()`` entered its
+exact-target branch for any non-``None`` id, so those calls dropped the
+caller's ``app=``, coerced both ids to ``None`` via ``_positive_int``, and
+failed with a message pointing at pid/window_id rather than the real problem.
+For that class of model ``capture(app=...)`` never worked at all.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Any, Dict, List
+from unittest.mock import MagicMock
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+def _backend_with_windows(windows: List[Dict[str, Any]]):
+    from tools.computer_use.cua_backend import CuaDriverBackend
+
+    backend = CuaDriverBackend()
+    backend._session = MagicMock()
+    backend._session.call_tool.return_value = {
+        "data": "",
+        "images": [],
+        "structuredContent": {"windows": windows},
+        "isError": False,
+    }
+    return backend
+
+
+_WINDOWS = [
+    {"app_name": "Fuwari", "pid": 100, "window_id": 1,
+     "is_on_screen": True, "title": "menu bar", "z_index": 0},
+    {"app_name": "Comet", "pid": 200, "window_id": 2,
+     "is_on_screen": True, "title": "Comet Browser", "z_index": 1},
+]
+
+
+def test_app_scoped_capture_survives_placeholder_ids():
+    """The bug: app= was discarded and the capture failed outright."""
+    backend = _backend_with_windows(_WINDOWS)
+
+    cap = backend.capture(mode="som", app="Comet", pid=0, window_id=0)
+
+    assert cap.app == "Comet", (
+        f"app= was dropped for a zero-filled call; got app={cap.app!r} "
+        f"detail={cap.window_title!r}"
+    )
+
+
+def test_frontmost_capture_survives_placeholder_ids():
+    """Frontmost capture is the same failure with no app= to drop."""
+    backend = _backend_with_windows(_WINDOWS)
+
+    cap = backend.capture(mode="som", pid=0, window_id=0)
+
+    # Frontmost is the highest z_index window.
+    assert cap.app == "Comet", f"frontmost capture failed; detail={cap.window_title!r}"
+
+
+def test_real_exact_target_still_wins_over_app():
+    """Guard: a genuine pid/window pair keeps its exact-targeting behaviour."""
+    backend = _backend_with_windows(_WINDOWS)
+
+    # Ids that match no enumerated window: only the exact branch can produce
+    # this label, so it proves discovery was bypassed rather than consulted.
+    cap = backend.capture(mode="som", app="Ghost", pid=999, window_id=99)
+
+    assert cap.app == "Ghost", f"exact targeting was bypassed; detail={cap.window_title!r}"
+
+
+def test_partial_target_still_reports_the_missing_half():
+    """Guard: one real id and one placeholder is a caller error, not discovery."""
+    backend = _backend_with_windows(_WINDOWS)
+
+    cap = backend.capture(mode="som", app="Comet", pid=200, window_id=0)
+
+    assert "requires both pid and window_id" in cap.window_title
+
+
+def test_malformed_ids_are_not_treated_as_placeholders():
+    """Guard: garbage must still reach the validation error, not be ignored."""
+    backend = _backend_with_windows(_WINDOWS)
+
+    cap = backend.capture(mode="som", app="Comet", pid="abc", window_id="def")
+
+    assert "positive integer" in cap.window_title
+
+
+def test_placeholder_predicate():
+    from tools.computer_use.cua_backend import _is_placeholder_id
+
+    assert _is_placeholder_id(0) is True
+    assert _is_placeholder_id("0") is True
+    assert _is_placeholder_id(-1) is True
+    assert _is_placeholder_id(200) is False
+    assert _is_placeholder_id("200") is False
+    # Garbage is not a placeholder: it must keep reaching the existing error.
+    assert _is_placeholder_id("abc") is False
+    assert _is_placeholder_id(None) is False
+    assert _is_placeholder_id(1.5) is False
+    # bools are ints in Python; False must not read as a placeholder id.
+    assert _is_placeholder_id(False) is False
+    assert _is_placeholder_id(True) is False

--- a/tools/computer_use/cua_backend.py
+++ b/tools/computer_use/cua_backend.py
@@ -1979,6 +1979,24 @@ def _positive_int(value: Any) -> Optional[int]:
     return parsed if parsed > 0 else None
 
 
+def _is_placeholder_id(value: Any) -> bool:
+    """True when *value* is a schema-filler id rather than a real target.
+
+    Several providers emit every declared schema property on every tool call,
+    filling unused optional integers with ``0``. A non-positive id cannot name
+    a window, so treating it as a targeting request drops the caller's ``app=``
+    and fails the capture. Malformed non-numeric values are deliberately NOT
+    placeholders: those still reach the existing validation error rather than
+    being silently ignored.
+    """
+    if isinstance(value, bool) or not isinstance(value, (int, str)):
+        return False
+    try:
+        return int(value) <= 0
+    except ValueError:
+        return False
+
+
 def _ingest_windows(raw_windows: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
     """Normalise cua-driver ``list_windows`` entries, dropping unusable ones.
 
@@ -2414,6 +2432,13 @@ class CuaDriverBackend(ComputerUseBackend):
         # PR's effective minimum (trycua/cua#1961 + #1908) is well past
         # that, so the fallback is gone — the wrapper now treats the
         # structured shape as the only contract.
+        # Drop schema-filler ids before they can be read as a targeting
+        # request, so `capture(app=...)` and frontmost capture still work for
+        # models that emit every optional property zero-filled.
+        if _is_placeholder_id(pid):
+            pid = None
+        if _is_placeholder_id(window_id):
+            window_id = None
         # An exact pid/window pair is both the stable capture_after target and
         # the escape hatch when app/window discovery is unavailable on X11.
         if pid is not None or window_id is not None:

--- a/tools/computer_use/cua_backend.py
+++ b/tools/computer_use/cua_backend.py
@@ -357,6 +357,15 @@ def _empty_discovery_reason() -> str:
         )
     if sys.platform == "linux" and not os.environ.get("DISPLAY"):
         return "no DISPLAY is set — X11/XWayland is not reachable from this process"
+    if sys.platform == "darwin":
+        # Headless Mac / asleep panel: ScreenCaptureKit has 0 shareable
+        # displays while TCC grants look fine (#67165, #52925 lineage).
+        return (
+            "window discovery returned no windows; on macOS this usually "
+            "means no shareable display (headless Mac or panel asleep) — "
+            "wake the display or attach a monitor/HDMI dummy, then run "
+            "`hermes computer-use doctor`"
+        )
     return (
         "window discovery returned no windows; run `hermes computer-use "
         "doctor` (display reachability, AX capability)"

--- a/tools/computer_use/doctor.py
+++ b/tools/computer_use/doctor.py
@@ -693,13 +693,53 @@ def _drive_health_report_or_fallback(
 ) -> Dict[str, Any]:
     """Prefer real health_report; on denial/non-schema, synthesize via probes."""
     try:
-        return _drive_health_report(
+        report = _drive_health_report(
             binary, include=include, skip=skip, timeout=timeout,
         )
     except HealthReportUnavailable as e:
-        return _compose_fallback_report(
+        report = _compose_fallback_report(
             binary, reason=str(e), timeout=timeout,
         )
+    return _apply_display_count_guard(report)
+
+
+def _apply_display_count_guard(report: Dict[str, Any]) -> Dict[str, Any]:
+    """Downgrade an 'ok' report whose screen capture has zero displays.
+
+    macOS ScreenCaptureKit reports ``display_count=0`` on headless Macs and
+    when the built-in panel is asleep — TCC grants are fine, health_report
+    can still say pass/ok, but every capture will come back 0x0. Marking
+    the check failed (with the recovery actions) turns an undiagnosable
+    silent failure into an actionable one. Applied at the report seam so
+    the real health_report path and the composed fallback both get it.
+
+    Composed from PR #52949 (sujeet111) and PR #67259 (webtecnica).
+    """
+    checks = report.get("checks")
+    if not isinstance(checks, list):
+        return report
+    for check in checks:
+        if not isinstance(check, dict):
+            continue
+        if check.get("name") != "screen_capture_capability":
+            continue
+        data = check.get("data")
+        count = data.get("display_count") if isinstance(data, dict) else None
+        if count == 0 and check.get("status") == "pass":
+            check["status"] = "fail"
+            check["message"] = (
+                "ScreenCaptureKit reachable but 0 shareable display(s) — "
+                "every capture will return 0x0."
+            )
+            check["hint"] = (
+                "Wake the built-in display, connect a monitor or HDMI dummy "
+                "dongle (e.g. Headless Ghost), or enable a virtual display "
+                "(Screen Sharing/VNC, BetterDisplay). Verify with "
+                "`system_profiler SPDisplaysDataType`."
+            )
+            if report.get("overall") == "ok":
+                report["overall"] = "degraded"
+    return report
 
 
 def _print_text_report(


### PR DESCRIPTION
## Summary

Two more real capture bugs from the computer_use backlog land in one cluster PR: model-emitted placeholder `pid=0/window_id=0` no longer kills every app-scoped capture (salvage of #81340 by @0xGr1mm, premise verified live on main), and macOS zero-display capture (`display_count=0` on headless/asleep Macs) now fails the doctor check with recovery actions instead of passing while every capture silently returns 0x0 (composed from #52949 by @sujeet111 and #67259 by @webtecnica).

## Changes

- `tools/computer_use/cua_backend.py`:
  - `_is_placeholder_id()` + capture() gating (cherry-picked from #81340, authorship preserved): schema-filler zero ids are ignored so `app=` targeting survives providers that emit every optional property; garbage values still reach the existing validation error.
  - `_empty_discovery_reason()` gains the darwin rung: empty discovery on macOS names the no-shareable-display cause and the recovery path.
- `tools/computer_use/doctor.py`: `_apply_display_count_guard()` at the report seam (covers both the real health_report path and the composed fallback): `screen_capture_capability` with `display_count=0` flips pass→fail with actionable hint (wake display / HDMI dummy / virtual display), overall ok→degraded. Never softens a `failed` overall.
- Tests: 6 placeholder-id tests (from #81340) + 5 new guard tests + the existing discovery-diagnosis suite = 18 cluster tests.

## Cluster verdicts (this PR resolves)

| Original | Verdict |
|---|---|
| #81340 @0xGr1mm | cherry-picked with authorship |
| #52949 @sujeet111 | composed (doctor guard direction; his branch predates the doctor rewrite) — Co-authored-by |
| #67259 @webtecnica | composed (hint text + empty-inventory direction; his `_load_windows` raise conflicts with the merged envelope normalization, and his `_ingest_windows` multi-key rename half is superseded by #74175) — Co-authored-by |
| Issue #81333 | fixed by the placeholder-id half |
| Issue #67165 | diagnosability half fixed (root cause remains upstream SCK) |

## Validation

| Check | Result |
|---|---|
| Cluster tests | 18 passed |
| Sibling computer_use suites | 143 passed |
| Live premise check on main | pid=0/window_id=0 confirmed entering exact-target branch before fix |
| ruff | clean |

## Infographic

![Capture-cluster salvage — placeholder ids + macOS zero-display](https://files.catbox.moe/qeiguf.png)
