### PR TITLE
fix(config): enforce read-only config check

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -28,9 +28,10 @@ import tempfile
 import threading
 import time
 import unicodedata
+from contextlib import contextmanager
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Dict, Any, Optional, List, Tuple, Set
+from typing import Dict, Any, Optional, List, Tuple, Set, Iterator
 
 from hermes_cli.route_identity import normalize_route_base_url
 from hermes_cli.secret_prompt import masked_secret_prompt
@@ -3252,37 +3253,51 @@ def read_raw_config_readonly() -> Dict[str, Any]:
         return cached_copy
 
 
-def _is_read_only_config_check(argv: Optional[List[str]] = None) -> bool:
-    """Return whether the current CLI invocation is ``config check``.
+_CONFIG_WRITE_BLOCKS_LOCK = threading.RLock()
+_CONFIG_WRITE_BLOCKS: Dict[object, str] = {}
 
-    Profile selectors are accepted here even though ``hermes_cli.main``
-    normally removes them before dispatch. Keeping this guard independent of
-    dispatcher ordering also protects startup hooks that run after argument
-    parsing but before the subcommand handler.
-    """
-    args = list(sys.argv[1:] if argv is None else argv)
-    command_args: List[str] = []
-    index = 0
-    while index < len(args):
-        arg = args[index]
-        if arg == "--profile":
-            index += 2
-            continue
-        if arg.startswith("--profile=") or arg == "--default":
-            index += 1
-            continue
-        command_args.append(arg)
-        index += 1
-    return command_args[:2] == ["config", "check"]
+
+def _activate_config_write_block(reason: str) -> object:
+    """Block canonical config writers process-wide until the token is removed."""
+    token = object()
+    with _CONFIG_WRITE_BLOCKS_LOCK:
+        _CONFIG_WRITE_BLOCKS[token] = reason
+    return token
+
+
+def _deactivate_config_write_block(token: object) -> None:
+    with _CONFIG_WRITE_BLOCKS_LOCK:
+        _CONFIG_WRITE_BLOCKS.pop(token, None)
+
+
+@contextmanager
+def config_writes_blocked(reason: str) -> Iterator[None]:
+    """Scope a process-wide block around a read-only config operation."""
+    token = _activate_config_write_block(reason)
+    try:
+        yield
+    finally:
+        _deactivate_config_write_block(token)
+
+
+def _block_config_writes_for_process(reason: str) -> object:
+    """Install a non-expiring block for a dedicated read-only CLI process."""
+    return _activate_config_write_block(reason)
+
+
+def _config_write_block_reason() -> Optional[str]:
+    with _CONFIG_WRITE_BLOCKS_LOCK:
+        return next(iter(_CONFIG_WRITE_BLOCKS.values()), None)
 
 
 def require_readable_config_before_write(config_path: Optional[Path] = None) -> None:
     """Refuse config writes from read-only or unreadable contexts."""
     if config_path is None:
         config_path = get_config_path()
-    if _is_read_only_config_check():
+    block_reason = _config_write_block_reason()
+    if block_reason:
         raise RuntimeError(
-            f"Refusing to write {config_path}: `hermes config check` is read-only."
+            f"Refusing to write {config_path}: {block_reason}."
         )
     try:
         config_path.stat()
@@ -5538,7 +5553,16 @@ def unset_config_value(key: str):
 # Command handler
 # =============================================================================
 
+
 def config_command(args):
+    """Handle config subcommands with scoped policy for read-only actions."""
+    if getattr(args, 'config_command', None) == "check":
+        with config_writes_blocked("`hermes config check` is read-only"):
+            return _config_command_impl(args)
+    return _config_command_impl(args)
+
+
+def _config_command_impl(args):
     """Handle config subcommands."""
     subcmd = getattr(args, 'config_command', None)
     

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -3252,10 +3252,38 @@ def read_raw_config_readonly() -> Dict[str, Any]:
         return cached_copy
 
 
+def _is_read_only_config_check(argv: Optional[List[str]] = None) -> bool:
+    """Return whether the current CLI invocation is ``config check``.
+
+    Profile selectors are accepted here even though ``hermes_cli.main``
+    normally removes them before dispatch. Keeping this guard independent of
+    dispatcher ordering also protects startup hooks that run after argument
+    parsing but before the subcommand handler.
+    """
+    args = list(sys.argv[1:] if argv is None else argv)
+    command_args: List[str] = []
+    index = 0
+    while index < len(args):
+        arg = args[index]
+        if arg == "--profile":
+            index += 2
+            continue
+        if arg.startswith("--profile=") or arg == "--default":
+            index += 1
+            continue
+        command_args.append(arg)
+        index += 1
+    return command_args[:2] == ["config", "check"]
+
+
 def require_readable_config_before_write(config_path: Optional[Path] = None) -> None:
-    """Refuse to replace an existing config.yaml that cannot be read."""
+    """Refuse config writes from read-only or unreadable contexts."""
     if config_path is None:
         config_path = get_config_path()
+    if _is_read_only_config_check():
+        raise RuntimeError(
+            f"Refusing to write {config_path}: `hermes config check` is read-only."
+        )
     try:
         config_path.stat()
     except FileNotFoundError:

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -691,6 +691,58 @@ def _apply_profile_override() -> None:
 
 _apply_profile_override()
 
+# Top-level flags that consume the following token. Keep this in sync with
+# ``hermes_cli/_parser.py``. It is intentionally available before config
+# imports so startup policy can identify the command without running the full
+# argparse/plugin setup. Treat ``-c / --continue`` as value-taking here because
+# a following subcommand-looking token is its optional session-name value.
+_TOP_LEVEL_VALUE_FLAGS = frozenset({
+    "-z",
+    "--oneshot",
+    "-m",
+    "--model",
+    "--provider",
+    "-t",
+    "--toolsets",
+    "-r",
+    "--resume",
+    "-s",
+    "--skills",
+    "--usage-file",
+    "--in",
+    "-c",
+    "--continue",
+})
+
+
+def _top_level_positionals(argv: list[str], *, limit: int) -> list[str]:
+    """Return leading CLI positionals without mistaking option values for commands."""
+    positionals = []
+    i = 0
+    while i < len(argv) and len(positionals) < limit:
+        token = argv[i]
+        if token == "--":
+            positionals.extend(argv[i + 1 : i + 1 + limit - len(positionals)])
+            break
+        if token.startswith("-"):
+            if (
+                "=" not in token
+                and token in _TOP_LEVEL_VALUE_FLAGS
+                and i + 1 < len(argv)
+            ):
+                i += 2
+            else:
+                i += 1
+            continue
+        positionals.append(token)
+        i += 1
+    return positionals
+
+
+def _is_config_check_invocation(argv: list[str]) -> bool:
+    return _top_level_positionals(argv, limit=2) == ["config", "check"]
+
+
 # Load .env from ~/.hermes/.env first, then project root as dev fallback.
 # User-managed env files should override stale shell exports on restart.
 from hermes_cli.config import (
@@ -701,7 +753,7 @@ from hermes_cli.config import (
 from hermes_cli.env_loader import load_hermes_dotenv
 
 _CONFIG_CHECK_WRITE_BLOCK_TOKEN = None
-if sys.argv[1:3] == ["config", "check"]:
+if _is_config_check_invocation(sys.argv[1:]):
     _CONFIG_CHECK_WRITE_BLOCK_TOKEN = _block_config_writes_for_process(
         "`hermes config check` is read-only"
     )
@@ -11039,33 +11091,6 @@ _BUILTIN_SUBCOMMANDS = frozenset(
 )
 
 
-# Top-level flags that take a value. Needed by ``_first_positional_argv``
-# so that in ``hermes -m gpt5 chat``, ``gpt5`` is correctly skipped as a
-# flag value rather than misclassified as a subcommand. Kept in sync with
-# the top-level flags declared in ``hermes_cli/_parser.py``.
-#
-# Correctness-safe either way: missing an entry here only makes the
-# fast-path bail out too eagerly (we run plugin discovery when we didn't
-# need to); extra entries would make us skip a real positional.
-_TOP_LEVEL_VALUE_FLAGS = frozenset(
-    {
-        "-z", "--oneshot",
-        "-m", "--model",
-        "--provider",
-        "-t", "--toolsets",
-        "-r", "--resume",
-        "-s", "--skills",
-        "--usage-file",
-        "--in",
-        # ``-c / --continue`` is nargs='?' (optional value). Treat it as
-        # value-taking: if the next token is a subcommand-looking word
-        # the user almost certainly meant it as the session name, and
-        # either interpretation keeps us on the safe side.
-        "-c", "--continue",
-    }
-)
-
-
 def _first_positional_argv() -> str | None:
     """Return the first non-flag, non-flag-value token in ``sys.argv[1:]``.
 
@@ -11078,27 +11103,8 @@ def _first_positional_argv() -> str | None:
     bar`` flags degrade gracefully (``bar`` may be wrongly classified as
     a positional, which at worst forces a one-time plugin discovery).
     """
-    argv = sys.argv[1:]
-    i = 0
-    while i < len(argv):
-        tok = argv[i]
-        if tok == "--":
-            # Everything after ``--`` is positional.
-            if i + 1 < len(argv):
-                return argv[i + 1]
-            return None
-        if tok.startswith("-"):
-            # ``--flag=value`` carries its value inline — single token.
-            if "=" in tok:
-                i += 1
-                continue
-            if tok in _TOP_LEVEL_VALUE_FLAGS and i + 1 < len(argv):
-                i += 2
-                continue
-            i += 1
-            continue
-        return tok
-    return None
+    positionals = _top_level_positionals(sys.argv[1:], limit=1)
+    return positionals[0] if positionals else None
 
 
 def _plugin_cli_discovery_needed() -> bool:

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -693,8 +693,25 @@ _apply_profile_override()
 
 # Load .env from ~/.hermes/.env first, then project root as dev fallback.
 # User-managed env files should override stale shell exports on restart.
-from hermes_cli.config import get_hermes_home
+from hermes_cli.config import (
+    get_hermes_home,
+    _block_config_writes_for_process,
+    _deactivate_config_write_block,
+)
 from hermes_cli.env_loader import load_hermes_dotenv
+
+_CONFIG_CHECK_WRITE_BLOCK_TOKEN = None
+if sys.argv[1:3] == ["config", "check"]:
+    _CONFIG_CHECK_WRITE_BLOCK_TOKEN = _block_config_writes_for_process(
+        "`hermes config check` is read-only"
+    )
+
+
+def _release_config_check_write_block() -> None:
+    global _CONFIG_CHECK_WRITE_BLOCK_TOKEN
+    if _CONFIG_CHECK_WRITE_BLOCK_TOKEN is not None:
+        _deactivate_config_write_block(_CONFIG_CHECK_WRITE_BLOCK_TOKEN)
+        _CONFIG_CHECK_WRITE_BLOCK_TOKEN = None
 
 # Updating dependencies must not import optional secret-manager libraries into
 # the updater process before ``uv`` replaces the environment.  On Windows,
@@ -11689,6 +11706,14 @@ def _advertise_agent_env() -> None:
 
 
 def main():
+    """Run one CLI invocation and release process-scoped config policy."""
+    try:
+        return _main()
+    finally:
+        _release_config_check_write_block()
+
+
+def _main():
     """Main entry point for hermes CLI."""
     # Cosmetic: make the process show up as 'hermes' instead of 'python3.11'
     # in ps/top/htop.  Non-fatal — just a nicer UX.

--- a/tests/hermes_cli/test_config_check_readonly.py
+++ b/tests/hermes_cli/test_config_check_readonly.py
@@ -122,7 +122,13 @@ def _profile_cli_env(source_home: Path) -> dict[str, str]:
     return env
 
 
-def _run_profile_config_check(source_home: Path, target_name: str, env):
+def _run_profile_config_check(
+    source_home: Path,
+    target_name: str,
+    env,
+    *,
+    global_args=(),
+):
     return subprocess.run(
         [
             sys.executable,
@@ -130,6 +136,7 @@ def _run_profile_config_check(source_home: Path, target_name: str, env):
             "from hermes_cli.main import main; main()",
             "--profile",
             target_name,
+            *global_args,
             "config",
             "check",
         ],
@@ -163,7 +170,8 @@ def test_profile_scoped_cli_config_check_is_byte_identical(tmp_path):
     assert _fingerprint(target_config) == before
 
 
-def test_profile_scoped_cli_blocks_startup_hook_config_write(tmp_path):
+@pytest.mark.parametrize("global_args", [(), ("--yolo",), ("--cli",)])
+def test_profile_scoped_cli_blocks_startup_hook_config_write(tmp_path, global_args):
     source_home = tmp_path / "profiles" / "source"
     target_home = tmp_path / "profiles" / "target"
     source_home.mkdir(parents=True)
@@ -194,12 +202,35 @@ env_loader.load_hermes_dotenv = load_hermes_dotenv
     env = _profile_cli_env(source_home)
     env["PYTHONPATH"] = os.pathsep.join([str(bootstrap_dir), env["PYTHONPATH"]])
 
-    result = _run_profile_config_check(source_home, target_home.name, env)
+    result = _run_profile_config_check(
+        source_home,
+        target_home.name,
+        env,
+        global_args=global_args,
+    )
 
     assert result.returncode != 0
     assert "config check` is read-only" in result.stderr
     assert _fingerprint(source_config) == source_before
     assert _fingerprint(target_config) == before
+
+
+@pytest.mark.parametrize(
+    ("argv", "expected"),
+    [
+        (["--yolo", "config", "check"], True),
+        (["config", "--cli", "check"], True),
+        (["--model", "config", "check"], False),
+        (["--model", "gpt-5", "config", "check"], True),
+        (["--oneshot", "config", "check"], False),
+        (["mcp", "add", "demo", "--args", "config", "check"], False),
+        (["config", "get", "check"], False),
+    ],
+)
+def test_early_config_check_detection_ignores_values_and_passthrough(argv, expected):
+    from hermes_cli.main import _is_config_check_invocation
+
+    assert _is_config_check_invocation(argv) is expected
 
 
 def test_cli_process_guard_releases_after_dispatch(tmp_path):

--- a/tests/hermes_cli/test_config_check_readonly.py
+++ b/tests/hermes_cli/test_config_check_readonly.py
@@ -1,0 +1,81 @@
+"""Regression tests for the read-only ``hermes config check`` contract."""
+
+from __future__ import annotations
+
+import hashlib
+import sys
+from types import SimpleNamespace
+
+import pytest
+import yaml
+
+from hermes_cli import config as config_mod
+
+
+def _write_explicit_gate_config(tmp_path):
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(
+        yaml.safe_dump(
+            {
+                "_config_version": config_mod.DEFAULT_CONFIG["_config_version"],
+                "memory": {"write_approval": False},
+                "skills": {"write_approval": False},
+            },
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+    return config_path
+
+
+def _fingerprint(path):
+    stat = path.stat()
+    return hashlib.sha256(path.read_bytes()).hexdigest(), stat.st_mtime_ns
+
+
+def test_config_check_preserves_config_bytes_and_mtime(tmp_path, monkeypatch, capsys):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    config_path = _write_explicit_gate_config(tmp_path)
+    before = _fingerprint(config_path)
+
+    config_mod.config_command(SimpleNamespace(config_command="check"))
+
+    assert _fingerprint(config_path) == before
+    persisted = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    assert persisted["memory"]["write_approval"] is False
+    assert persisted["skills"]["write_approval"] is False
+    capsys.readouterr()
+
+
+def test_config_check_rejects_transitive_config_write(tmp_path, monkeypatch, capsys):
+    """A diagnostic imported by ``config check`` must not persist config."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["hermes", "--profile", "isolated", "config", "check"],
+    )
+    config_path = _write_explicit_gate_config(tmp_path)
+    before = _fingerprint(config_path)
+
+    def diagnostic_with_write_side_effect():
+        config = config_mod.load_config()
+        config["memory"]["write_approval"] = True
+        config["skills"]["write_approval"] = True
+        config_mod.save_config(config)
+        return []
+
+    monkeypatch.setattr(
+        config_mod,
+        "get_missing_config_fields",
+        diagnostic_with_write_side_effect,
+    )
+
+    with pytest.raises(RuntimeError, match=r"config check.*read-only"):
+        config_mod.config_command(SimpleNamespace(config_command="check"))
+
+    assert _fingerprint(config_path) == before
+    persisted = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    assert persisted["memory"]["write_approval"] is False
+    assert persisted["skills"]["write_approval"] is False
+    capsys.readouterr()

--- a/tests/hermes_cli/test_config_check_readonly.py
+++ b/tests/hermes_cli/test_config_check_readonly.py
@@ -3,7 +3,10 @@
 from __future__ import annotations
 
 import hashlib
+import os
+import subprocess
 import sys
+from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
@@ -12,14 +15,17 @@ import yaml
 from hermes_cli import config as config_mod
 
 
-def _write_explicit_gate_config(tmp_path):
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _write_explicit_gate_config(tmp_path, *, write_approval=False):
     config_path = tmp_path / "config.yaml"
     config_path.write_text(
         yaml.safe_dump(
             {
                 "_config_version": config_mod.DEFAULT_CONFIG["_config_version"],
-                "memory": {"write_approval": False},
-                "skills": {"write_approval": False},
+                "memory": {"write_approval": write_approval},
+                "skills": {"write_approval": write_approval},
             },
             sort_keys=False,
         ),
@@ -50,11 +56,7 @@ def test_config_check_preserves_config_bytes_and_mtime(tmp_path, monkeypatch, ca
 def test_config_check_rejects_transitive_config_write(tmp_path, monkeypatch, capsys):
     """A diagnostic imported by ``config check`` must not persist config."""
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
-    monkeypatch.setattr(
-        sys,
-        "argv",
-        ["hermes", "--profile", "isolated", "config", "check"],
-    )
+    monkeypatch.setattr(sys, "argv", ["pytest"])
     config_path = _write_explicit_gate_config(tmp_path)
     before = _fingerprint(config_path)
 
@@ -79,3 +81,153 @@ def test_config_check_rejects_transitive_config_write(tmp_path, monkeypatch, cap
     assert persisted["memory"]["write_approval"] is False
     assert persisted["skills"]["write_approval"] is False
     capsys.readouterr()
+
+
+def test_config_check_guard_is_scoped_from_mutating_commands(
+    tmp_path, monkeypatch, capsys
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    config_path = _write_explicit_gate_config(tmp_path)
+
+    config_mod.config_command(SimpleNamespace(config_command="check"))
+    config_mod.set_config_value("memory.write_approval", "true")
+    config_mod.unset_config_value("skills.write_approval")
+
+    persisted = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    assert persisted["memory"]["write_approval"] is True
+    assert "write_approval" not in persisted.get("skills", {})
+
+    persisted["_config_version"] = config_mod.DEFAULT_CONFIG["_config_version"] - 1
+    persisted["skills"] = {"write_approval": False}
+    config_path.write_text(yaml.safe_dump(persisted, sort_keys=False), encoding="utf-8")
+    config_mod._RAW_CONFIG_CACHE.clear()
+
+    config_mod.migrate_config(interactive=False, quiet=True)
+
+    migrated = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    assert migrated["_config_version"] == config_mod.DEFAULT_CONFIG["_config_version"]
+    assert migrated["memory"]["write_approval"] is True
+    assert migrated["skills"]["write_approval"] is False
+    capsys.readouterr()
+
+
+def _profile_cli_env(source_home: Path) -> dict[str, str]:
+    env = os.environ.copy()
+    env["HERMES_HOME"] = str(source_home)
+    env["HERMES_PROFILE"] = source_home.name
+    env["PYTHONPATH"] = os.pathsep.join([
+        str(REPO_ROOT),
+        env.get("PYTHONPATH", ""),
+    ]).rstrip(os.pathsep)
+    return env
+
+
+def _run_profile_config_check(source_home: Path, target_name: str, env):
+    return subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "from hermes_cli.main import main; main()",
+            "--profile",
+            target_name,
+            "config",
+            "check",
+        ],
+        cwd=REPO_ROOT,
+        env=env,
+        text=True,
+        capture_output=True,
+        timeout=30,
+        check=False,
+    )
+
+
+def test_profile_scoped_cli_config_check_is_byte_identical(tmp_path):
+    source_home = tmp_path / "profiles" / "source"
+    target_home = tmp_path / "profiles" / "target"
+    source_home.mkdir(parents=True)
+    target_home.mkdir(parents=True)
+    source_config = _write_explicit_gate_config(source_home, write_approval=True)
+    target_config = _write_explicit_gate_config(target_home)
+    source_before = _fingerprint(source_config)
+    before = _fingerprint(target_config)
+
+    result = _run_profile_config_check(
+        source_home,
+        target_home.name,
+        _profile_cli_env(source_home),
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert _fingerprint(source_config) == source_before
+    assert _fingerprint(target_config) == before
+
+
+def test_profile_scoped_cli_blocks_startup_hook_config_write(tmp_path):
+    source_home = tmp_path / "profiles" / "source"
+    target_home = tmp_path / "profiles" / "target"
+    source_home.mkdir(parents=True)
+    target_home.mkdir(parents=True)
+    source_config = _write_explicit_gate_config(source_home, write_approval=True)
+    target_config = _write_explicit_gate_config(target_home)
+    source_before = _fingerprint(source_config)
+    before = _fingerprint(target_config)
+
+    bootstrap_dir = tmp_path / "bootstrap"
+    bootstrap_dir.mkdir()
+    (bootstrap_dir / "sitecustomize.py").write_text(
+        """
+import hermes_cli.env_loader as env_loader
+
+def load_hermes_dotenv(*args, **kwargs):
+    from hermes_cli.config import load_config, save_config
+    config = load_config()
+    config["memory"]["write_approval"] = True
+    config["skills"]["write_approval"] = True
+    save_config(config)
+    return []
+
+env_loader.load_hermes_dotenv = load_hermes_dotenv
+""".lstrip(),
+        encoding="utf-8",
+    )
+    env = _profile_cli_env(source_home)
+    env["PYTHONPATH"] = os.pathsep.join([str(bootstrap_dir), env["PYTHONPATH"]])
+
+    result = _run_profile_config_check(source_home, target_home.name, env)
+
+    assert result.returncode != 0
+    assert "config check` is read-only" in result.stderr
+    assert _fingerprint(source_config) == source_before
+    assert _fingerprint(target_config) == before
+
+
+def test_cli_process_guard_releases_after_dispatch(tmp_path):
+    source_home = tmp_path / "profiles" / "source"
+    target_home = tmp_path / "profiles" / "target"
+    source_home.mkdir(parents=True)
+    target_home.mkdir(parents=True)
+    _write_explicit_gate_config(source_home, write_approval=True)
+    target_config = _write_explicit_gate_config(target_home)
+    script = f"""
+import sys
+sys.argv = ["hermes", "--profile", {target_home.name!r}, "config", "check"]
+from hermes_cli.main import main
+main()
+from hermes_cli.config import set_config_value
+set_config_value("memory.write_approval", "true")
+"""
+
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        cwd=REPO_ROOT,
+        env=_profile_cli_env(source_home),
+        text=True,
+        capture_output=True,
+        timeout=30,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    persisted = yaml.safe_load(target_config.read_text(encoding="utf-8"))
+    assert persisted["memory"]["write_approval"] is True


### PR DESCRIPTION
## Summary

- make `hermes config check` fail closed at the shared canonical `config.yaml` write chokepoint
- activate the guard before startup hooks for profile-scoped CLI invocations, and release it in `main()` even on failure
- scope the same policy around programmatic `config_command(check)` calls without relying on ambient `sys.argv`
- preserve `set`, `unset`, and migration write behavior after the read-only scope exits

## Investigation

I reproduced the original sequence in temporary profile trees using the installed revision and the incident config structure, with source gates `true/true` and target gates `false/false`. The native `config check` path was already byte-identical in isolation, so the exact historical writer could not be reproduced or attributed safely.

The guard therefore prevents any canonical in-process persistence path from writing during `config check`, including a startup hook that calls `save_config`. It intentionally does **not** claim to stop an unrelated process or an arbitrary direct filesystem write from mutating the same file concurrently; that remains a documented risk requiring separate stale-writer/CAS work if reproduced.

No command was run against the live Junior Dev profile.

## TDD evidence

- Initial RED: synthetic diagnostic writer changed both gates (`1 failed, 1 passed`).
- Review RED: programmatic `config_command(check)` bypassed the argv-dependent guard (`1 failed, 1 passed`).
- Final focused regression: `6 passed`.

The regression suite covers:

1. direct hash + `mtime_ns` identity with explicit `false/false` gates;
2. a transitive diagnostic `save_config` attempt under neutral argv;
3. post-scope `set`, `unset`, and schema `36 -> 37` migration writes;
4. real `--profile target config check` with source `true/true` and target `false/false`;
5. an injected startup hook attempting `save_config(true/true)`;
6. same-interpreter reuse after `main()` releases the process guard.

## Verification

- config suites: `116 passed, 1 skipped`
- CLI startup/update/setup/provider/ACP suites: `316 passed, 4 skipped`
- `uvx ruff==0.15.10 check` on changed files: passed
- `ruff format --check` on the new regression file: passed
- `git diff --check`: passed

## Review status

Two independent review rounds were run. Round 1's ambient-argv and coverage findings were fixed. Round 2 confirmed no secret/injection issue but flagged the remaining concurrent external-writer race described above. The PR remains Draft for maintainer/QA judgment on that boundary.
