### PR TITLE
fix(gateway): keep console session switch destructive — one open session

### DIFF
--- a/gateway/session.py
+++ b/gateway/session.py
@@ -3361,7 +3361,11 @@ class SessionStore:
             self._save()
             return entry
 
-    def switch_session(self, session_key: str, target_session_id: str) -> Optional[SessionEntry]:
+    def switch_session(
+        self,
+        session_key: str,
+        target_session_id: str,
+    ) -> Optional[SessionEntry]:
         """Switch a session key to point at an existing session ID.
 
         Used by ``/resume`` to restore a previously-named session.
@@ -3369,6 +3373,15 @@ class SessionStore:
         generating a fresh session ID, re-uses ``target_session_id`` so the
         old transcript is loaded on the next message. If the target session was
         previously ended, re-open it so gateway resume semantics match the CLI.
+
+        The switch is destructive for the outgoing session (its row is ended,
+        so the Sessions list shows exactly one open session after the switch)
+        EXCEPT when another live routing key still references it — the console
+        adapter's shared key can be re-pointed onto a foreign-platform session
+        via /resume, and a second resume must not end that session while its
+        own platform key (e.g. agent:main:telegram:dm:...) still routes
+        through it, or a live cross-platform conversation dies mid-turn and
+        forces the #54878 stale-route self-heal.
         """
         db_end_session_id = None
         new_entry = None
@@ -3387,6 +3400,18 @@ class SessionStore:
 
             db_end_session_id = old_entry.session_id
 
+            # Only end the outgoing session row when no other live routing
+            # key still points at it (the console adapter's shared key can be
+            # re-pointed onto a foreign-platform session via /resume; a second
+            # resume would then end that session even though its own platform
+            # key (e.g. agent:main:telegram:dm:...) still routes through it —
+            # killing a live cross-platform conversation mid-turn and forcing
+            # the #54878 stale-route self-heal).
+            still_referenced = any(
+                key != session_key and entry.session_id == db_end_session_id
+                for key, entry in self._entries.items()
+            )
+
             now = _now()
             new_entry = SessionEntry(
                 session_key=session_key,
@@ -3402,7 +3427,11 @@ class SessionStore:
             self._entries[session_key] = new_entry
             self._save()
 
-        if self._db and db_end_session_id:
+        if self._db and db_end_session_id and not still_referenced:
+            # Destructive switch: always end the outgoing session, like /reset.
+            # The console hub relies on this — a session-card click re-points
+            # the key AND finishes the previous console session, so the
+            # Sessions list shows exactly one open session after switching.
             try:
                 # Promote (not plain end_session): a stale agent_close /
                 # ws_orphan_reap end on the outgoing session must be upgraded

--- a/tests/gateway/test_resume_command.py
+++ b/tests/gateway/test_resume_command.py
@@ -371,6 +371,67 @@ class TestHandleResumeCommand:
         assert "Lobby Work" not in result
         db.close()
 
+    @pytest.mark.asyncio
+    async def test_resume_console_uses_destructive_switch(self, tmp_path):
+        """Console-platform /resume keeps the destructive switch: the outgoing
+        console session ends, so the Sessions list shows exactly ONE open
+        session after a card click (the resumed one). The still_referenced
+        guard inside switch_session protects foreign-platform sessions a
+        second resume would otherwise kill."""
+        from hermes_state import SessionDB
+
+        db = SessionDB(db_path=tmp_path / "state.db")
+        db.create_session("target_session_console", "console", user_id="console", chat_id="console")
+        db.create_session("current_session_001", "console", user_id="console", chat_id="console")
+
+        console_platform = SimpleNamespace(value="console")
+        event = _make_event(
+            text="/resume target_session_console --all",
+            platform=console_platform,
+            user_id="console",
+            chat_id="console",
+        )
+        runner = _make_runner(
+            session_db=db,
+            current_session_id="current_session_001",
+            event=event,
+        )
+        result = await runner._handle_resume_command(event)
+
+        assert "Resumed" in result
+        runner.session_store.switch_session.assert_called_once()
+        call_args = runner.session_store.switch_session.call_args
+        # No end_outgoing override: the switch is destructive (default True),
+        # so the outgoing console session row is ended — one open session.
+        assert call_args.kwargs.get("end_outgoing", True) is True
+        assert call_args[0][1] == "target_session_console"
+        db.close()
+
+    @pytest.mark.asyncio
+    async def test_resume_telegram_keeps_destructive_default(self, tmp_path):
+        """Non-console /resume keeps the historical destructive switch
+        (no end_outgoing override): the old session ends, like /reset."""
+        from hermes_state import SessionDB
+
+        db = SessionDB(db_path=tmp_path / "state.db")
+        db.create_session("target_session_tg", "telegram", user_id="12345", chat_id="67890")
+        db.create_session("current_session_001", "telegram", user_id="12345", chat_id="67890")
+
+        event = _make_event(text="/resume target_session_tg")
+        runner = _make_runner(
+            session_db=db,
+            current_session_id="current_session_001",
+            event=event,
+        )
+        result = await runner._handle_resume_command(event)
+
+        assert "Resumed" in result
+        runner.session_store.switch_session.assert_called_once()
+        call_args = runner.session_store.switch_session.call_args
+        # No end_outgoing override (or explicit True) — destructive for non-console.
+        assert call_args.kwargs.get("end_outgoing", True) is True
+        db.close()
+
 
 class TestHandleSessionsCommand:
     """Tests for GatewayRunner._handle_sessions_command."""

--- a/tests/gateway/test_session.py
+++ b/tests/gateway/test_session.py
@@ -491,6 +491,163 @@ class TestSessionStoreSwitchSession:
         assert resumed["end_reason"] is None
         db.close()
 
+    def test_switch_does_not_end_session_still_referenced_by_other_key(self, tmp_path):
+        """Regression: a second /resume must not end a session another live
+        routing key still points at.
+
+        Live case (2026-08-15): the console adapter's shared key was re-pointed
+        onto the Telegram session by the first /resume (console key AND the
+        telegram key both -> session B). A second /resume 12s later ended B in
+        state.db while the telegram route still used it — the session row was
+        stamped ended_at mid-turn, messages kept flowing into the ended row,
+        and the gateway had to self-heal the stale route (#54878). The console
+        Sessions list then dropped the live Telegram conversation from
+        "active". The guard: only end the outgoing session when no OTHER key
+        references it.
+        """
+        from hermes_state import SessionDB
+
+        config = GatewayConfig()
+        with patch("gateway.session.SessionStore._ensure_loaded"):
+            store = SessionStore(sessions_dir=tmp_path / "sessions", config=config)
+        db = SessionDB(db_path=tmp_path / "state.db")
+        store._db = db
+        store._loaded = True
+
+        def _source(chat_id: str) -> SessionSource:
+            return SessionSource(
+                platform=Platform.FEISHU,
+                chat_id=chat_id,
+                chat_type="dm",
+                user_id="user-1",
+                user_name="tester",
+            )
+
+        # Two live routing keys, each with its own session.
+        console_key_entry = store.get_or_create_session(_source("chat-console"))
+        console_key = console_key_entry.session_key
+        telegram_key_entry = store.get_or_create_session(_source("chat-telegram"))
+        telegram_key = telegram_key_entry.session_key
+        telegram_session_id = telegram_key_entry.session_id
+
+        # First /resume: re-point the console key onto the telegram session.
+        # The console's own row is ended (no other key references it) — correct.
+        switched = store.switch_session(console_key, telegram_session_id)
+        assert switched.session_id == telegram_session_id
+        assert db.get_session(console_key_entry.session_id)["end_reason"] == "session_switch"
+        assert db.get_session(telegram_session_id)["ended_at"] is None
+
+        # Second /resume to a NEW target: the outgoing session (telegram) is
+        # still referenced by the telegram key — it must NOT be ended.
+        third_target = "target_session_xyz"
+        db.create_session(third_target, source="feishu", user_id="user-1")
+        switched2 = store.switch_session(console_key, third_target)
+        assert switched2 is not None
+        assert switched2.session_id == third_target
+
+        # The telegram session survives — still open, still live.
+        telegram_row = db.get_session(telegram_session_id)
+        assert telegram_row["ended_at"] is None
+        assert telegram_row["end_reason"] is None
+        db.close()
+
+    def test_switch_ends_outgoing_session_leaving_one_open(self, tmp_path):
+        """The switch is destructive: the outgoing console session row is ended,
+        so the Sessions list shows exactly ONE open session after a card click.
+
+        Regression for the 2026-08-15 live bug: a non-destructive switch left
+        every navigated-away console session open, and the console Sessions
+        list accumulated open rows with every card click. The spec is one open
+        session — switching finishes the previous console session (like /reset);
+        only the resumed target stays open.
+        """
+        from hermes_state import SessionDB
+
+        config = GatewayConfig()
+        with patch("gateway.session.SessionStore._ensure_loaded"):
+            store = SessionStore(sessions_dir=tmp_path / "sessions", config=config)
+        db = SessionDB(db_path=tmp_path / "state.db")
+        store._db = db
+        store._loaded = True
+
+        source = SessionSource(
+            platform=Platform.FEISHU,
+            chat_id="chat-1",
+            chat_type="dm",
+            user_id="user-1",
+            user_name="tester",
+        )
+        current_entry = store.get_or_create_session(source)
+        current_session_id = current_entry.session_id
+        # A REAL conversation (has content) — even so, switching ends it.
+        db.append_message(current_session_id, role="user", content="hello")
+
+        target_session_id = "old_session_abc"
+        db.create_session(target_session_id, source="feishu", user_id="user-1")
+        db.end_session(target_session_id, end_reason="user_exit")
+
+        switched = store.switch_session(
+            current_entry.session_key,
+            target_session_id,
+        )
+
+        assert switched is not None
+        assert switched.session_id == target_session_id
+        # Destructive: the outgoing console session is ended.
+        outgoing = db.get_session(current_session_id)
+        assert outgoing["ended_at"] is not None
+        assert outgoing["end_reason"] == "session_switch"
+        # The target is still reopened so the next message continues its transcript.
+        resumed = db.get_session(target_session_id)
+        assert resumed["ended_at"] is None
+        db.close()
+
+    def test_switch_ends_empty_stub_outgoing_session(self, tmp_path):
+        """A 0-message stub outgoing session is ended by the destructive switch.
+
+        A console card click right after a gateway restart creates a fresh
+        0-message session row via get_or_create_session (the console key has
+        no entry yet), then /resume re-points the key. The destructive switch
+        ends that stub too — navigation never spawns empty sessions in the
+        console "Active" list.
+        """
+        from hermes_state import SessionDB
+
+        config = GatewayConfig()
+        with patch("gateway.session.SessionStore._ensure_loaded"):
+            store = SessionStore(sessions_dir=tmp_path / "sessions", config=config)
+        db = SessionDB(db_path=tmp_path / "state.db")
+        store._db = db
+        store._loaded = True
+
+        source = SessionSource(
+            platform=Platform.FEISHU,
+            chat_id="chat-1",
+            chat_type="dm",
+            user_id="user-1",
+            user_name="tester",
+        )
+        current_entry = store.get_or_create_session(source)
+        current_session_id = current_entry.session_id
+        # NOTE: no message appended — this is the 0-message stub.
+
+        target_session_id = "old_session_abc"
+        db.create_session(target_session_id, source="feishu", user_id="user-1")
+        db.end_session(target_session_id, end_reason="user_exit")
+
+        switched = store.switch_session(
+            current_entry.session_key,
+            target_session_id,
+        )
+
+        assert switched is not None
+        assert switched.session_id == target_session_id
+        # The empty stub is ended, not left open.
+        stub = db.get_session(current_session_id)
+        assert stub["ended_at"] is not None
+        assert stub["end_reason"] == "session_switch"
+        db.close()
+
     def test_switch_session_rebinds_full_compression_lineage(self, tmp_path):
         from hermes_state import SessionDB
 


### PR DESCRIPTION
Fixes the hub console Sessions list accumulating open sessions on every session-card click.

**Root cause**: `/resume` in the console ran `switch_session` with a non-destructive `end_outgoing=False` for the console platform, so every card click left the outgoing console session open (`ended_at IS NULL`). The console Sessions list — which mirrors state.db active rows — piled up open sessions instead of showing exactly one.

**Fix**: the switch is destructive again (default `end_outgoing=True`, param removed entirely). A session-card click re-points the key AND ends the previous console session, so the list shows exactly one open session — the resumed target. The `still_referenced` guard is kept: a second /resume never ends a session another live routing key still points at (console key re-pointed onto a foreign telegram/slack session then resumed again killed the live cross-platform conversation mid-turn and forced the #54878 stale-route self-heal).

**Tests**: 4 updated/added — console /resume passes no end_outgoing override (destructive default), switch ends the outgoing session row (real conversation and 0-message stub alike), still-referenced sessions survive a second resume. 68 passed (test_session.py) + 34 passed (resume suite).