### PR TITLE
fix(cli): compute PROJECT_ROOT locally in Termux fast version path

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -363,8 +363,12 @@ def _read_openai_version_fast() -> str | None:
 def _print_fast_version_info() -> None:
     from hermes_cli import __release_date__, __version__
 
+    # PROJECT_ROOT is defined later in this module (after the argparse imports),
+    # so the Termux pre-import fast path must compute it locally instead of
+    # referencing the module-level name (NameError on `hermes --version`).
+    _fast_project_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
     print(f"Hermes Agent v{__version__} ({__release_date__})")
-    print(f"Install directory: {PROJECT_ROOT}")
+    print(f"Install directory: {_fast_project_root}")
 
     print(f"Python: {sys.version.split()[0]}")
 


### PR DESCRIPTION
## Problem

`hermes --version` crashes on every Termux install:

```
Traceback (most recent call last):
  File ".../usr/bin/hermes", line 3, in <module>
    from hermes_cli.main import main
  File ".../hermes-agent/hermes_cli/main.py", line 388, in <module>
    if _try_termux_ultrafast_version():
  File ".../hermes_cli/main.py", line 384, in _try_termux_ultrafast_version
    _print_fast_version_info()
  File ".../hermes_cli/main.py", line 367, in _print_fast_version_info
    print(f"Install directory: {PROJECT_ROOT}")
NameError: name 'PROJECT_ROOT' is not defined
```

## Root cause

`_print_fast_version_info()` references the module-level `PROJECT_ROOT`, but that name is only assigned later in `main.py` (after the argparse imports). The Termux pre-import fast path runs `_try_termux_ultrafast_version()` at module import time — before `PROJECT_ROOT` exists — so `hermes --version` always raises `NameError` on Termux.

This is a Termux-only bug because the fast path is gated on `_is_termux_startup_environment_fast()`; other platforms take the slower path where `PROJECT_ROOT` is already defined.

## Fix

Compute the install directory from `__file__` inside `_print_fast_version_info()` instead of referencing the not-yet-defined module global:

```python
_fast_project_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
```

## Verification

- Before: `hermes --version` → `NameError` traceback (exit code nonzero)
- After: prints version, install directory, Python and OpenAI SDK versions cleanly
