### PR TITLE
feat(desktop): show sender avatar and full body on inter-agent message cards

### DIFF
--- a/apps/desktop/src/components/assistant-ui/thread/agent-message.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/agent-message.test.tsx
@@ -1,6 +1,11 @@
-import { describe, expect, it } from 'vitest'
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it } from 'vitest'
 
-import { AGENT_MESSAGE_RE } from './user-message'
+import { AGENT_MESSAGE_RE, AgentMessageNote } from './user-message'
+
+afterEach(() => {
+  cleanup()
+})
 
 // Agent-to-agent deliveries render as a compact attributed timeline notice,
 // not a user bubble. This pins the detection contract: the Bot Mode prefix
@@ -46,5 +51,34 @@ describe('agent message detection', () => {
   it('does not match prose that merely contains the phrase', () => {
     expect(AGENT_MESSAGE_RE.test('I got a Message from 🤖 Hermes: earlier')).toBe(false)
     expect(AGENT_MESSAGE_RE.test('can you explain what Message from means?')).toBe(false)
+  })
+})
+
+// The card must read on its own in a busy multi-agent transcript: the body
+// visible without a click, and the sender identity exposed through stable
+// attributes rather than only inside prose a screen reader may not surface.
+describe('AgentMessageNote rendering', () => {
+  it('renders the delivered body without needing to expand anything', () => {
+    render(<AgentMessageNote text="Message from 🤖 Hermes: hello there" />)
+
+    expect(screen.getByText('hello there')).toBeTruthy()
+    expect(screen.queryByText('show message')).toBeNull()
+  })
+
+  it('exposes sender and handle as data attributes and an aria-label', () => {
+    render(<AgentMessageNote text="Message from 🤖 Eats Tests (@mr-tester): run them all" />)
+
+    const card = screen.getByLabelText('Message from Eats Tests (@mr-tester)')
+
+    expect(card.getAttribute('data-sender')).toBe('Eats Tests')
+    expect(card.getAttribute('data-handle')).toBe('mr-tester')
+    expect(screen.getByText('run them all')).toBeTruthy()
+  })
+
+  it('still shows the body when the sender has no avatar (robot fallback)', () => {
+    render(<AgentMessageNote text="Message from Turquoise: ready to work" />)
+
+    expect(screen.getByText('🤖')).toBeTruthy()
+    expect(screen.getByText('ready to work')).toBeTruthy()
   })
 })

--- a/apps/desktop/src/components/assistant-ui/thread/user-message.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/user-message.tsx
@@ -176,7 +176,7 @@ export async function resolveAgentAvatar(handle: string): Promise<null | string>
   return out
 }
 
-const AgentMessageNote: FC<{ text: string }> = ({ text }) => {
+export const AgentMessageNote: FC<{ text: string }> = ({ text }) => {
   const match = AGENT_MESSAGE_RE.exec(text)
   const sender = (match?.[1] || match?.[3] || 'agent').trim()
   const handle = (match?.[2] || match?.[3] || sender).trim()
@@ -197,35 +197,38 @@ const AgentMessageNote: FC<{ text: string }> = ({ text }) => {
     }
   }, [handle])
 
+  const handleDiffers = handle.toLowerCase() !== sender.toLowerCase()
+  const attribution = handleDiffers ? `${sender} (@${handle})` : sender
+
   // Grok-bots shape: an inter-agent delivery is a timeline EVENT, not a
-  // conversation bubble — a subtle centered notice ("Message from 🤖 X"),
-  // with the delivered text one click away instead of shouting in the
-  // transcript. The recipient's reply below it stays a normal assistant
-  // message, so the exchange still reads in order.
+  // conversation bubble — an attributed card with the sender's own avatar,
+  // not a generic glyph, and the delivered body always visible (a busy
+  // multi-agent conversation is unreadable if every turn needs a click to
+  // reveal what was actually said). The recipient's reply below it stays a
+  // normal assistant message, so the exchange still reads in order.
   return (
     <div
-      className="flex max-w-[min(86%,44rem)] flex-col gap-0.5 self-center px-2 py-0.5 text-[0.6875rem] leading-5 text-muted-foreground/60"
+      aria-label={`Message from ${attribution}`}
+      className="flex max-w-[min(86%,44rem)] flex-col gap-1 self-center rounded-lg border border-(--ui-stroke-tertiary) px-3 py-2"
+      data-handle={handle}
+      data-sender={sender}
       data-slot="aui_agent-message-note"
     >
-      <span className="flex items-center justify-center gap-1.5">
+      <div className="flex items-center gap-2 text-[0.6875rem] leading-4 text-muted-foreground/70">
         {avatar ? (
-          <img alt="" aria-hidden className="size-4 shrink-0 rounded-full object-cover" src={avatar} />
+          <img alt="" aria-hidden className="size-6 shrink-0 rounded-md object-cover" src={avatar} />
         ) : (
-          <span aria-hidden className="text-[0.8125rem] leading-none">
+          <span aria-hidden className="grid size-6 shrink-0 place-items-center text-sm leading-none">
             🤖
           </span>
         )}
-        <span className="wrap-anywhere">Message from {sender}</span>
-      </span>
+        <span className="wrap-anywhere font-medium text-foreground/80">{sender}</span>
+        {handleDiffers && <span className="wrap-anywhere text-muted-foreground/55">@{handle}</span>}
+      </div>
       {body && (
-        <details className="self-center">
-          <summary className="cursor-pointer select-none text-center text-muted-foreground/45 hover:text-muted-foreground/70">
-            show message
-          </summary>
-          <div className="mt-1 max-w-[36rem] rounded-lg border border-(--ui-stroke-tertiary) px-3 py-2 text-left text-[0.75rem] leading-5 text-foreground/85">
-            <UserMessageText text={body} />
-          </div>
-        </details>
+        <div className="pl-8 text-left text-[0.8125rem] leading-5 text-foreground/90" data-slot="aui_agent-message-body">
+          <UserMessageText text={body} />
+        </div>
       )}
     </div>
   )


### PR DESCRIPTION
Fixes #87212

## What changed

`AgentMessageNote` (the receiver-side inter-agent delivery card in
`apps/desktop/src/components/assistant-ui/thread/user-message.tsx`) rendered
a 16px robot glyph beside "Message from X" and hid the delivered body behind
a `<details>` "show message" disclosure. In a busy multi-agent conversation
that makes every turn a click to find out what was actually said, and the
avatar was too small to read as an identity marker.

This PR:

- Renders the sender's resolved avatar at a readable 24px square (`size-6`,
  `rounded-md`) instead of the previous 16px circle, with the same 🤖
  fallback when no avatar resolves (older gateway, brand-new bot, etc.).
- Shows the sender display name, plus the `@handle` when it differs from
  the display name (the `(@handle)` capture already existed in
  `AGENT_MESSAGE_RE`, it just wasn't surfaced).
- Always renders the delivered body — no more collapsed disclosure.
- Exposes the sender identity via `data-sender` / `data-handle` attributes
  and an `aria-label` on the card, for accessible labeling and stable
  hooks.

Detection (`AGENT_MESSAGE_RE`, the modern/emoji-less/legacy delivery prefix
regex) and the sender-side notices (`agent-delivery.tsx`) are untouched —
this only changes how the already-parsed sender/handle/body fields render.

## Test plan

Added `AgentMessageNote rendering` tests in
`apps/desktop/src/components/assistant-ui/thread/agent-message.test.tsx`
that render the component directly and assert:

- the delivered body is present with no "show message" disclosure in the
  DOM,
- the card carries `data-sender` / `data-handle` and an `aria-label`
  reflecting `sender (@handle)` when they differ,
- the robot-glyph fallback still shows and still doesn't hide the body when
  no avatar resolves.

Confirmed the new tests fail against the pre-fix source
(`git stash` the source file, keep the test file, rerun — component wasn't
exported and lacked the new markup, so all 3 new tests failed) and pass
after restoring the fix.

```
$ npx vitest run src/components/assistant-ui/thread/agent-message.test.tsx src/components/assistant-ui/thread/agent-delivery.test.tsx
 Test Files  2 passed (2)
      Tests  15 passed (15)

$ npx vitest run src/components/assistant-ui/thread/
 Test Files  23 passed (23)
      Tests  147 passed (147)

$ npx tsc --noEmit -p tsconfig.json
(clean)

$ npx eslint src/components/assistant-ui/thread/user-message.tsx src/components/assistant-ui/thread/agent-message.test.tsx
(clean)
```
