### PR TITLE
fix(kanban): warn or inherit thread_id on notify-subscribe without --thread-id

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -2934,21 +2934,50 @@ def _cmd_stats(args: argparse.Namespace) -> int:
 
 
 def _cmd_notify_subscribe(args: argparse.Namespace) -> int:
+    thread_id = args.thread_id
+    inherited_from = None
     with kb.connect_closing() as conn:
         if kb.get_task(conn, args.task_id) is None:
             print(f"no such task: {args.task_id}", file=sys.stderr)
             return 1
+        if thread_id is None:
+            # Omitting --thread-id defaults to '' (the chat's root lane, not
+            # any topic/thread). If this task already has a subscription for
+            # the same platform+chat (e.g. the auto-subscribe made at task
+            # creation from that exact chat), reuse its thread_id instead of
+            # silently dropping back to the root lane.
+            for sub in kb.list_notify_subs(conn, args.task_id):
+                if (
+                    str(sub.get("platform", "")).lower() == args.platform.lower()
+                    and sub.get("chat_id") == args.chat_id
+                    and sub.get("thread_id")
+                ):
+                    thread_id = sub["thread_id"]
+                    inherited_from = sub
+                    break
         kb.add_notify_sub(
             conn, task_id=args.task_id,
             platform=args.platform, chat_id=args.chat_id,
             chat_type=args.chat_type,
-            thread_id=args.thread_id, user_id=args.user_id,
+            thread_id=thread_id, user_id=args.user_id,
             user_id_alt=getattr(args, "user_id_alt", None),
             notifier_profile=args.notifier_profile or _profile_author(),
             delivery_mode=getattr(args, "delivery_mode", None),
         )
+    if inherited_from is not None:
+        print(f"(no --thread-id given; inherited thread_id={thread_id} from this "
+              f"task's existing {args.platform}:{args.chat_id} subscription)",
+              file=sys.stderr)
+    elif (
+        thread_id is None
+        and args.platform.lower() == "telegram"
+        and args.chat_type in (None, "dm")
+    ):
+        print("warning: no --thread-id given and no existing subscription to "
+              "infer one from; the completion ping will be delivered to the "
+              "chat's DM root, not a specific topic", file=sys.stderr)
     print(f"Subscribed {args.platform}:{args.chat_id}"
-          + (f":{args.thread_id}" if args.thread_id else "")
+          + (f":{thread_id}" if thread_id else "")
           + f" to {args.task_id}")
     return 0
 

--- a/tests/hermes_cli/test_kanban_cli.py
+++ b/tests/hermes_cli/test_kanban_cli.py
@@ -167,6 +167,49 @@ def test_run_slash_reclaim_running_task(kanban_home):
     assert "ready" in out2.lower()
 
 
+# ---------------------------------------------------------------------------
+# /kanban notify-subscribe — omitted --thread-id (issue #87281)
+# ---------------------------------------------------------------------------
+
+
+def test_notify_subscribe_without_thread_id_inherits_existing_subscription(kanban_home):
+    """A manual re-subscribe for a chat that already has a threaded
+    subscription (e.g. from auto-subscribe-on-create) must not silently
+    fall back to the chat's DM root when --thread-id is omitted."""
+    with kb.connect_closing() as conn:
+        tid = kb.create_task(conn, title="dm topic task")
+        kb.add_notify_sub(
+            conn, task_id=tid, platform="telegram", chat_id="chat1",
+            thread_id="topic1",
+        )
+
+    out = kc.run_slash(f"notify-subscribe {tid} --platform telegram --chat-id chat1")
+
+    assert "inherited thread_id=topic1" in out, out
+    with kb.connect_closing() as conn:
+        subs = kb.list_notify_subs(conn, tid)
+    threaded = [s for s in subs if s["chat_id"] == "chat1"]
+    assert len(threaded) == 1, threaded
+    assert threaded[0]["thread_id"] == "topic1"
+
+
+def test_notify_subscribe_without_thread_id_warns_with_no_precedent(kanban_home):
+    """With no existing subscription to infer a thread from, a Telegram DM
+    subscribe without --thread-id must warn instead of silently routing to
+    the DM root."""
+    with kb.connect_closing() as conn:
+        tid = kb.create_task(conn, title="fresh dm task")
+
+    out = kc.run_slash(f"notify-subscribe {tid} --platform telegram --chat-id chat9")
+
+    assert "warning" in out.lower(), out
+    assert "DM root" in out, out
+    with kb.connect_closing() as conn:
+        subs = kb.list_notify_subs(conn, tid)
+    assert len(subs) == 1
+    assert subs[0]["thread_id"] == ""
+
+
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR do?

`hermes kanban notify-subscribe <task_id> --platform telegram --chat-id <chat>`
silently defaulted an omitted `--thread-id` to `''` (the chat's root
lane). For a task dispatched from a Telegram DM topic, an operator who
manually re-subscribes (or subscribes from a different surface) without
`--thread-id` got a subscription that delivers completion pings to the
DM root, not the topic the task came from — and nothing in the CLI
output or the `kanban_notify_subs` row flags the misroute. The operator
only discovers it after a completion goes unseen.

This PR closes the silent half of that gap:

- If the task already has a subscription for the same `platform` +
  `chat_id` that carries a `thread_id` (most commonly the one written by
  `_maybe_auto_subscribe` at task-creation time from that exact chat),
  a `notify-subscribe` call that omits `--thread-id` now **inherits**
  that thread_id instead of falling back to the root lane, and says so
  on stderr.
- Otherwise, for a Telegram target with `chat_type` unset or `dm`, it
  prints an explicit **warning** that the ping will land in the DM root
  rather than a specific topic, so the miss is visible immediately
  instead of discovered days later.

No schema change: this reuses subscription rows already written by the
existing auto-subscribe path.

## Related Issue

Fixes #87281

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/kanban.py`: `_cmd_notify_subscribe` looks up an existing
  same-task/platform/chat_id subscription's `thread_id` when
  `--thread-id` is omitted, and inherits it; otherwise warns for
  Telegram DM targets.
- `tests/hermes_cli/test_kanban_cli.py`: two new tests — inheriting an
  existing thread_id, and warning when there's no prior subscription to
  infer one from.

## How to Test

1. `HERMES_PYTHON=.venv/bin/python scripts/run_tests.sh tests/hermes_cli/test_kanban_cli.py -q`
2. Confirmed both new tests fail against the pre-fix source
   (`git checkout HEAD~1 -- hermes_cli/kanban.py`) with the old
   `"Subscribed telegram:chat1 to ..."` output containing neither
   `inherited thread_id=` nor `warning`, and pass again after restoring
   the fix.

```
Discovered 1 test files (~6 tests) under ['tests/hermes_cli/test_kanban_cli.py']; running with -j 8
[100.0% |     6/~6 | ✓6 | ✗0] ✓ tests/hermes_cli/test_kanban_cli.py (6✓, 1.2s)

=== Summary: 1 files, 6 tests passed, 0 failed (100% complete) in 1.2s (8 workers) ===
```

Also ran the wider notify/kanban-tools surface to check for regressions:

```
tests/hermes_cli/test_kanban_cli.py     6 passed
tests/hermes_cli/test_kanban_notify.py  26 passed
tests/hermes_cli/test_kanban_db.py      29 passed
tests/tools/test_kanban_tools.py        32 passed, 1 skipped (windows-only)
```

`ruff check hermes_cli/kanban.py tests/hermes_cli/test_kanban_cli.py` and
`scripts/check-windows-footguns.py` both pass clean.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `scripts/run_tests.sh` and the affected suites pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Linux

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A (CLI behavior only, no new flags/config keys)
- [x] `cli-config.yaml.example` — N/A (no new config keys)
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A (no architecture/workflow change)
- [x] Cross-platform impact — N/A (pure Python string/DB logic, no OS-specific paths)
- [x] Tool descriptions/schemas — N/A (CLI-only change, no agent tool surface touched)
