### PR TITLE
fix(install): replay captured npm output when a blocking npm install fails

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -2308,11 +2308,20 @@ install_node_deps() {
         # A failed npm install used to still print "✓ Node.js dependencies
         # installed", hiding the degradation from the user (#77003). Now it
         # fails the install outright instead of burying the warning (#85297).
-        if ! run_with_timeout "$NODE_DEPS_TIMEOUT" npm install --silent; then
-            log_error "npm install failed or timed out; Node.js dependencies were not installed"
+        # Capture npm's output so the failure that aborts the install is
+        # diagnosable — --silent alone leaves nothing to tell EBADENGINE from
+        # ETARGET from a network timeout from a registry 5xx (#87340). Same
+        # capture-and-replay pattern as the camofox install below.
+        local log_file
+        log_file="$(mktemp)"
+        if ! run_with_timeout "$NODE_DEPS_TIMEOUT" npm install --silent >"$log_file" 2>&1; then
+            log_error "npm install failed or timed out; Node.js dependencies were not installed:"
+            cat "$log_file" >&2
+            rm -f "$log_file"
             restore_dirty_lockfiles "$INSTALL_DIR"
             return 1
         fi
+        rm -f "$log_file"
         log_success "Node.js dependencies installed"
 
         # Install Playwright browser + system dependencies.
@@ -2413,12 +2422,18 @@ install_node_deps() {
         cd "$INSTALL_DIR/ui-tui"
         # Time-boxed: a stalled registry fetch would otherwise hang here (#39219).
         # Report success only on actual success, same as node-deps above
-        # (#77003) — and fail the install outright (#85297).
-        if ! run_with_timeout "$NODE_DEPS_TIMEOUT" npm install --silent; then
-            log_error "TUI npm install failed or timed out; TUI dependencies were not installed"
+        # (#77003) — and fail the install outright (#85297). Capture and
+        # replay npm's output on failure for the same reason (#87340).
+        local tui_log_file
+        tui_log_file="$(mktemp)"
+        if ! run_with_timeout "$NODE_DEPS_TIMEOUT" npm install --silent >"$tui_log_file" 2>&1; then
+            log_error "TUI npm install failed or timed out; TUI dependencies were not installed:"
+            cat "$tui_log_file" >&2
+            rm -f "$tui_log_file"
             restore_dirty_lockfiles "$INSTALL_DIR"
             return 1
         fi
+        rm -f "$tui_log_file"
         log_success "TUI dependencies installed"
     fi
 

--- a/tests/test_install_sh_node_deps_failure.py
+++ b/tests/test_install_sh_node_deps_failure.py
@@ -111,6 +111,10 @@ def test_root_node_dependency_failure_is_fatal(tmp_path: Path) -> None:
     assert "Node.js dependencies installed" not in proc.stdout
     assert "TUI dependencies installed" not in proc.stdout
     assert not (install_dir / "node_modules").exists()
+    # The failure is install-blocking, so npm's own diagnostics must be
+    # replayed — one opaque line is not enough to tell EBADENGINE from a
+    # network timeout (#87340).
+    assert "simulated npm lifecycle failure" in proc.stderr
 
 
 def test_tui_node_dependency_failure_is_fatal(tmp_path: Path) -> None:
@@ -126,6 +130,7 @@ def test_tui_node_dependency_failure_is_fatal(tmp_path: Path) -> None:
     assert calls == [str(install_dir), str(tui_dir)]
     assert "Node.js dependencies installed" in proc.stdout
     assert "TUI dependencies installed" not in proc.stdout
+    assert "simulated npm lifecycle failure" in proc.stderr
 
 
 def test_node_dependency_success_remains_successful(tmp_path: Path) -> None:


### PR DESCRIPTION
## What does this PR do?

Since #85537, a failed `npm install` correctly aborts the installer — but both install-blocking call sites run `npm install --silent` with no output capture, so the failure that now stops the install prints exactly one line and no npm diagnostics (#87340). There is no way to tell EBADENGINE from ETARGET from a network timeout from a registry 5xx; #87093 is stuck at `needs-repro` precisely because the installer printed nothing further to paste.

This PR applies the capture-and-replay pattern the same file already uses for the camofox global install (mktemp log, redirect stdout+stderr, `cat` the log to stderr on failure, remove it on both paths) to the two blocking sites:

- `install_node_deps` root `package.json` install (browser tools)
- `install_node_deps` TUI install

The happy path stays `--silent`; only failures gain output.

## Related Issue

Fixes #87340

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `scripts/install.sh`: both blocking `npm install` sites now capture npm's output to a temp file and replay it to stderr on failure before returning 1, mirroring the camofox install's existing pattern; comments note why (#87340).
- `tests/test_install_sh_node_deps_failure.py`: the two fatal-failure tests now also assert that the stub npm's stderr diagnostic ("simulated npm lifecycle failure") is replayed in the stage's stderr — Observed result: passes with the change; without it the one-line log_error carries no npm output.

## How to Test

1. `uv run --extra acp pytest tests/test_install_sh_node_deps_failure.py -q` — should pass: 3 passed (observed result).
2. `uv run --extra acp pytest tests/ -q -k 'install_sh or install_commit or node_deps'` — should pass: 66 passed, 7 skipped (observed result).
3. Manual: run the `node-deps` stage against a registry that returns an error — Observed result: the installer's failure block now includes npm's own error text after the `✗` line, instead of the `✗` line alone.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the installer-related suites (66 passed, 7 skipped); full-suite verification delegated to CI
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A (inline comment included)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A (bash installer; mktemp/cat are POSIX)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Not applicable — stderr text replay; before/after is one opaque line vs. that line followed by npm's diagnostics.
