### PR TITLE
fix(install): drop --foreground from run_with_timeout so deadlines kill descendants (#87320)

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -2126,6 +2126,14 @@ run_with_timeout() {
             # `--foreground`, `timeout` puts COMMAND in its own process group
             # and the deadline kill reaches that whole group, so the download
             # actually dies with it.
+            #
+            # Accepted tradeoff: this reintroduces the #35166 behavior the flag was
+            # added to avoid — a terminal Ctrl+C now reaches `timeout`'s own process
+            # group, not COMMAND directly, so interactive interrupt only force-kills
+            # at the deadline instead of immediately. Every real caller here (npx,
+            # npm, uv, bash -c) spawns the actual work as a descendant, so
+            # `--foreground`'s benefit never applied to them while its cost
+            # (surviving descendants) did.
             if "$timeout_bin" -k 10 1 true >/dev/null 2>&1; then
                 "$timeout_bin" -k 10 "$timeout_seconds" "$@"
             else

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -2108,17 +2108,26 @@ run_with_timeout() {
             timeout_bin="gtimeout"
         fi
         if [ -n "$timeout_bin" ]; then
-            # GNU `timeout` runs the command in its own process group, so a
-            # terminal Ctrl+C is delivered to `timeout` but never reaches the
-            # child — the download looks frozen and ignores Ctrl+C (#35166).
-            # `--foreground` keeps the command in the shell's foreground group
-            # so Ctrl+C reaches it; `-k 10` sends SIGKILL 10s after the deadline
-            # so a wedged download can't outlive the timeout. Both flags are
-            # GNU-only — probe once and fall back to plain `timeout` on BusyBox
-            # (Alpine). When neither binary exists (stock macOS) we drop to the
-            # pure-shell watchdog below.
-            if "$timeout_bin" --foreground -k 10 1 true >/dev/null 2>&1; then
-                "$timeout_bin" --foreground -k 10 "$timeout_seconds" "$@"
+            # `-k 10` sends SIGKILL 10s after the deadline so a wedged command
+            # can't outlive the timeout. GNU-only — probe once and fall back to
+            # plain `timeout` on BusyBox (Alpine). When neither binary exists
+            # (stock macOS) we drop to the pure-shell watchdog below.
+            #
+            # Deliberately NOT using `--foreground`: per GNU timeout's own docs,
+            # "in this mode, children of COMMAND will not be timed out". `npx
+            # playwright install` runs the actual download in a *child* node
+            # process spawned by npx (COMMAND), not in npx itself — with
+            # `--foreground` that child survives the deadline and keeps
+            # downloading in the background indefinitely (reproduced locally:
+            # the grandchild process was still alive well after `timeout`
+            # returned 124). That orphaned process is what made installs hang
+            # on Arch (#87320) even though this function itself "timed out"
+            # and the installer logged a warning and moved on. Without
+            # `--foreground`, `timeout` puts COMMAND in its own process group
+            # and the deadline kill reaches that whole group, so the download
+            # actually dies with it.
+            if "$timeout_bin" -k 10 1 true >/dev/null 2>&1; then
+                "$timeout_bin" -k 10 "$timeout_seconds" "$@"
             else
                 "$timeout_bin" "$timeout_seconds" "$@"
             fi

--- a/tests/test_install_sh_browser_install.py
+++ b/tests/test_install_sh_browser_install.py
@@ -59,23 +59,90 @@ def test_install_script_supports_skip_browser_flag() -> None:
 
 
 
-def test_browser_install_timeout_stays_interruptible() -> None:
-    """The Playwright download must stay Ctrl+C-able and force-kill if wedged.
+def test_browser_install_timeout_force_kills_wedged_download() -> None:
+    """A wedged Playwright download must be force-killed after the deadline.
 
-    GNU `timeout` runs the child in its own process group, so a terminal Ctrl+C
-    reaches `timeout` but never the download — it looks frozen and ignores
-    Ctrl+C (#35166). `--foreground` keeps it in the shell's foreground group;
-    `-k 10` guarantees a SIGKILL after the deadline. Both are GNU-only, so the
+    `-k 10` guarantees a SIGKILL 10s after the deadline. GNU-only, so the
     installer probes support once and falls back to plain `timeout`.
+
+    Deliberately NOT `--foreground`: per GNU timeout's own docs, "children of
+    COMMAND will not be timed out" in that mode. `npx playwright install`'s
+    actual download runs in a child node process spawned by npx (COMMAND),
+    not in npx itself, so `--foreground` let that child survive the deadline
+    and keep downloading in the background forever — the installer logged a
+    timeout warning and moved on, but the orphaned download kept the terminal
+    from ever returning (#87320). See test_run_with_timeout_kills_descendant_
+    process below for a behavioral proof.
     """
     text = INSTALL_SH.read_text()
 
     # GNU-flag probe + the guarded invocation must both be present. The timeout
     # binary is parameterized ($timeout_bin) so macOS gtimeout works too (#39219).
-    assert '"$timeout_bin" --foreground -k 10 1 true' in text
-    assert '"$timeout_bin" --foreground -k 10 "$timeout_seconds" "$@"' in text
+    assert '"$timeout_bin" -k 10 1 true' in text
+    assert '"$timeout_bin" -k 10 "$timeout_seconds" "$@"' in text
     # Plain-timeout fallback preserved for BusyBox/non-GNU.
     assert '"$timeout_bin" "$timeout_seconds" "$@"' in text
+    # The interruptibility tradeoff that caused #87320 must not come back: no
+    # actual invocation of $timeout_bin may pass --foreground (comments in the
+    # function may still mention the flag by name to explain why it's gone).
+    assert '"$timeout_bin" --foreground' not in text
+
+
+def test_run_with_timeout_kills_descendant_process() -> None:
+    """The deadline must reach grandchildren, not just the direct command.
+
+    `npx playwright install` is COMMAND from run_with_timeout's point of view,
+    but the actual download runs in a *child* node process npx spawns. Model
+    that shape with a script that backgrounds a further child (like npx ->
+    node) and confirm the grandchild is dead once run_with_timeout returns —
+    this is the exact defect `--foreground` caused in #87320 (checked out on
+    HEAD~1, this test fails: the grandchild is still alive after the "timeout"
+    fires).
+    """
+    import os
+    import shutil
+    import subprocess
+    import tempfile
+
+    import pytest
+
+    if shutil.which("timeout") is None:
+        pytest.skip("GNU coreutils `timeout` not available")
+
+    body = _extract_function_body(INSTALL_SH.read_text(), "run_with_timeout")
+
+    with tempfile.TemporaryDirectory() as td:
+        pidfile = Path(td) / "child.pid"
+        outer_cmd = Path(td) / "outer_cmd.sh"
+        outer_cmd.write_text(
+            "#!/bin/bash\n"
+            "(sleep 20) &\n"
+            'echo $! > "$1"\n'
+            "wait\n"
+        )
+        outer_cmd.chmod(0o755)
+
+        harness = f"""
+set -u
+{body}
+
+run_with_timeout 1 {outer_cmd} {pidfile}
+echo "FINAL_RC=$?"
+"""
+        proc = subprocess.run(
+            ["bash", "-c", harness], capture_output=True, text=True, timeout=30
+        )
+        final_rc = None
+        for line in proc.stdout.splitlines():
+            if line.startswith("FINAL_RC="):
+                final_rc = int(line.split("=", 1)[1])
+        assert final_rc == 124, proc.stdout + proc.stderr
+
+        child_pid = int(pidfile.read_text().strip())
+        # run_with_timeout has already returned; the grandchild must be gone,
+        # not merely orphaned-but-running.
+        with pytest.raises(ProcessLookupError):
+            os.kill(child_pid, 0)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR do?

Fixes the root cause behind `#87320` ("Install scripts gets stuck on Playwright on Arch"): `run_with_timeout()` in `scripts/install.sh` wraps `npx playwright install ...` in `timeout --foreground -k 10 <seconds>`. Per GNU coreutils' own docs, `--foreground` means *"children of COMMAND will not be timed out."*

`npx` (the COMMAND passed to `run_with_timeout`) spawns the actual Playwright install/download work as a **child** node process — the download itself never runs inside `npx` directly. So when the 600s deadline fires, `timeout` kills `npx`, `run_with_timeout` returns 124, the installer logs "Playwright browser installation failed" and moves on... but the orphaned child node process (the one actually talking to the CDN) is never signaled and keeps running in the background indefinitely. That's what makes the whole `curl | bash` install look permanently stuck even though the script itself has logically continued — the orphan keeps stdout/the terminal alive.

Dropping `--foreground` lets `timeout` put COMMAND in its own process group, so the deadline-triggered SIGTERM/SIGKILL escalation (`-k 10`) reaches that whole group — descendants included — instead of just the immediate process.

### Verified locally (not just theorized)

- Reproduced the exact shape with a real `npx`-wrapped binary that spawns a child node process and backgrounds it: with `--foreground`, the child process was still alive well after `timeout` returned exit 124. Without `--foreground`, the child was dead by the time `run_with_timeout` returned.
- Confirmed against the GNU coreutils 9.4 man page: `--foreground: ... in this mode, children of COMMAND will not be timed out.`

### Tradeoff, called out explicitly

`--foreground` was added in a follow-up to #35166 specifically so a terminal Ctrl+C reaches the wrapped command directly (rather than only reaching `timeout` itself). Removing it does give up that direct-Ctrl+C-forwarding property for the rare case where the immediate COMMAND itself (not a descendant) is what hangs. But every real caller of `run_with_timeout` in this script (`npx`, `npm`, `uv`, `bash -c ...`) spawns further child processes to do the actual work, so `--foreground`'s benefit never actually applied to any of them — while its cost (descendants surviving the deadline) does. Happy to adjust if there's a reason to keep `--foreground` I'm missing.

## Related Issue

Fixes #87320

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `scripts/install.sh`: `run_with_timeout()` no longer passes `--foreground` to GNU `timeout`/`gtimeout`; keeps `-k 10`. Updated the surrounding comment to explain why (with the #87320 reference).
- `tests/test_install_sh_browser_install.py`:
  - Updated `test_browser_install_timeout_stays_interruptible` → `test_browser_install_timeout_force_kills_wedged_download` to assert `--foreground` is no longer passed to `$timeout_bin`, and keep asserting the `-k 10` guard + BusyBox fallback are intact.
  - Added `test_run_with_timeout_kills_descendant_process`: a behavioral test that extracts the real `run_with_timeout()` function body from `install.sh`, runs it against a script that backgrounds a further child process (modeling npx → node), and asserts the grandchild process is actually dead once `run_with_timeout` returns. This fails on the pre-fix code (grandchild survives) and passes after the fix.

## How to Test

1. `python -m pytest tests/test_install_sh_browser_install.py -v`
2. To see the bug reproduce: `git checkout HEAD~1 -- scripts/install.sh && python -m pytest tests/test_install_sh_browser_install.py -v` (2 failures), then `git checkout HEAD -- scripts/install.sh` to restore.

### Actual test output (this branch)

```
tests/test_install_sh_browser_install.py::test_install_script_honors_explicit_browser_override_only PASSED
tests/test_install_sh_browser_install.py::test_playwright_installs_are_timeout_guarded PASSED
tests/test_install_sh_browser_install.py::test_install_script_supports_skip_browser_flag PASSED
tests/test_install_sh_browser_install.py::test_browser_install_timeout_force_kills_wedged_download PASSED
tests/test_install_sh_browser_install.py::test_run_with_timeout_kills_descendant_process PASSED
tests/test_install_sh_browser_install.py::test_override_retry_fires_on_ubuntu_26 PASSED
tests/test_install_sh_browser_install.py::test_override_retry_fires_on_debian_14 PASSED
tests/test_install_sh_browser_install.py::test_no_retry_when_native_succeeds_on_ubuntu_26 PASSED
tests/test_install_sh_browser_install.py::test_ensure_browser_no_longer_npm_installs_agent_browser PASSED
tests/test_install_sh_browser_install.py::test_ensure_browser_still_ignore_scripts_and_timeout_guarded PASSED
tests/test_install_sh_browser_install.py::test_ensure_browser_no_longer_references_agent_browser_binary_path PASSED

============================== 11 passed in 6.28s ==============================
```

### Same suite against the pre-fix source (proves the test catches the bug)

```
tests/test_install_sh_browser_install.py::test_browser_install_timeout_force_kills_wedged_download FAILED
tests/test_install_sh_browser_install.py::test_run_with_timeout_kills_descendant_process FAILED
  Failed: DID NOT RAISE ProcessLookupError

========================= 2 failed, 9 passed in 25.32s =========================
```

Also ran `bash -n scripts/install.sh` (syntax OK) and `shellcheck scripts/install.sh` (no new findings vs. `main`).

## Checklist

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(install): ...`)
- [x] I searched for existing PRs to make sure this isn't a duplicate (checked #79725, #80533, #35323, #77402 — none touch `run_with_timeout`/Playwright)
- [x] My PR contains **only** changes related to this fix
- [x] I've run the relevant tests (`tests/test_install_sh_browser_install.py`) and they pass — full-suite `pytest tests/ -q` wasn't runnable in this sandbox (no project venv/`uv` available), but no other test file references `--foreground` or `run_with_timeout`'s removed flag
- [x] I've added a test for this change
- [x] Tested on: Linux (GNU coreutils `timeout` 9.4)

### Documentation & Housekeeping

- [x] N/A — no docs/config/architecture changes

## AI assistance disclosure

This PR was prepared with AI assistance (an autonomous coding agent). The root cause was independently verified by reading GNU coreutils' `timeout` documentation and reproducing the exact failure mode locally (a real `npx`-style parent/child process pair) before writing the fix, rather than taking the issue report at face value.
