### PR TITLE
feat(desktop): URL toolbar for in-app browser preview

### DIFF
--- a/apps/desktop/src/app/chat/right-rail/preview-pane.test.tsx
+++ b/apps/desktop/src/app/chat/right-rail/preview-pane.test.tsx
@@ -110,6 +110,118 @@ describe('PreviewPane console state', () => {
     forgetPreviewStripTools(tabId)
   })
 
+  it('shows the URL toolbar on the live embedded preview tile', async () => {
+    const tabId = 'url:http://localhost:5174'
+
+    forgetPreviewStripTools(tabId)
+
+    let rendered!: ReturnType<typeof render>
+    await act(async () => {
+      rendered = render(
+        <PreviewPane
+          embedded
+          tabId={tabId}
+          target={{
+            kind: 'url',
+            label: 'Preview',
+            source: 'http://localhost:5174',
+            url: 'http://localhost:5174'
+          }}
+        />
+      )
+    })
+
+    expect(rendered.getByRole('textbox', { name: 'Preview URL' })).toBeTruthy()
+    expect(rendered.getByRole('button', { name: 'Go back' })).toBeTruthy()
+    expect(rendered.container.querySelector('webview')).toBeInstanceOf(HTMLElement)
+
+    forgetPreviewStripTools(tabId)
+  })
+
+  it('keeps the address field while a page-in navigation happens', async () => {
+    const tabId = 'url:http://localhost:5174'
+
+    forgetPreviewStripTools(tabId)
+
+    let rendered!: ReturnType<typeof render>
+    await act(async () => {
+      rendered = render(
+        <PreviewPane
+          tabId={tabId}
+          target={{
+            kind: 'url',
+            label: 'Preview',
+            source: 'http://localhost:5174',
+            url: 'http://localhost:5174'
+          }}
+        />
+      )
+    })
+
+    const input = rendered.getByRole('textbox', { name: 'Preview URL' }) as HTMLInputElement
+    const webview = rendered.container.querySelector('webview')
+
+    expect(webview).toBeInstanceOf(HTMLElement)
+
+    await act(async () => {
+      fireEvent.focus(input)
+      fireEvent.change(input, { target: { value: 'https://example.com/typed' } })
+    })
+
+    expect(input.value).toBe('https://example.com/typed')
+
+    act(() => {
+      webview?.dispatchEvent(
+        Object.assign(new Event('did-navigate-in-page'), {
+          url: 'http://localhost:5174/pushed'
+        })
+      )
+    })
+
+    expect(input.value).toBe('https://example.com/typed')
+
+    forgetPreviewStripTools(tabId)
+  })
+
+  it('syncs back/forward on both navigate events', async () => {
+    const tabId = 'url:http://localhost:5174'
+
+    forgetPreviewStripTools(tabId)
+
+    let rendered!: ReturnType<typeof render>
+    await act(async () => {
+      rendered = render(
+        <PreviewPane
+          tabId={tabId}
+          target={{
+            kind: 'url',
+            label: 'Preview',
+            source: 'http://localhost:5174',
+            url: 'http://localhost:5174'
+          }}
+        />
+      )
+    })
+
+    const webview = rendered.container.querySelector('webview') as HTMLElement & {
+      canGoBack?: () => boolean
+      canGoForward?: () => boolean
+    }
+
+    expect(webview).toBeInstanceOf(HTMLElement)
+    webview.canGoBack = () => true
+    webview.canGoForward = () => false
+
+    act(() => {
+      webview.dispatchEvent(Object.assign(new Event('did-navigate-in-page'), { url: 'http://localhost:5174/next' }))
+    })
+
+    expect((rendered.getByRole('button', { name: 'Go back' }) as HTMLButtonElement).disabled).toBe(false)
+    expect((rendered.getByRole('button', { name: 'Go forward' }) as HTMLButtonElement).disabled).toBe(true)
+
+    forgetPreviewStripTools(tabId)
+  })
+
   it('renders authenticated remote HTML safely and honors source mode', async () => {
     const dataUrl = `data:text/html;base64,${btoa('<h1>remote</h1>')}`
 

--- a/apps/desktop/src/app/chat/right-rail/preview-pane.tsx
+++ b/apps/desktop/src/app/chat/right-rail/preview-pane.tsx
@@ -24,13 +24,19 @@ import { type ConsoleEntry } from './preview-console-state'
 import { LocalFilePreview, PreviewEmptyState } from './preview-file'
 import { registerPreviewPageReader } from './preview-reader'
 import { previewConsoleState, registerPreviewDevTools } from './preview-strip-tools'
+import { isHttpUrl, PreviewToolbar } from './preview-toolbar'
 
 type PreviewWebview = HTMLElement & {
+  canGoBack?: () => boolean
+  canGoForward?: () => boolean
   closeDevTools?: () => void
   executeJavaScript?: (code: string) => Promise<unknown>
   getTitle?: () => string
   getURL?: () => string
+  goBack?: () => void
+  goForward?: () => void
   isDevToolsOpened?: () => boolean
+  loadURL?: (url: string) => Promise<void> | void
   openDevTools?: () => void
   reload?: () => void
   reloadIgnoringCache?: () => void
@@ -146,6 +152,10 @@ export function PreviewPane({ embedded = false, onRestartServer, reloadRequest =
   const [loading, setLoading] = useState(true)
   const [loadError, setLoadError] = useState<PreviewLoadErrorState | null>(null)
   const [localReloadKey, setLocalReloadKey] = useState(0)
+  const [address, setAddress] = useState(target.url)
+  const [canGoBack, setCanGoBack] = useState(false)
+  const [canGoForward, setCanGoForward] = useState(false)
+  const addressFocusedRef = useRef(false)
 
   // Artifacts have no URL to load — they render from the registry, never in a
   // webview.
@@ -153,20 +163,21 @@ export function PreviewPane({ embedded = false, onRestartServer, reloadRequest =
     target.kind !== 'artifact' &&
     (target.kind === 'url' || (target.previewKind === 'html' && target.renderMode !== 'source'))
 
-  const isRemoteHtmlTarget =
-    target.kind === 'file' && target.previewKind === 'html' && Boolean(target.dataUrl || target.transient)
-
-  const isRemoteHtml = isRemoteHtmlTarget && target.renderMode !== 'source' && Boolean(target.dataUrl)
+  // `isRemoteHtml` keeps its original definition — fully rendered HTML in an
+  // iframe (skips the webview path). The toolbar is for actual webview tabs.
+  const isRemoteHtml =
+    target.kind === 'file' && target.previewKind === 'html' && target.renderMode !== 'source' && Boolean(target.dataUrl)
 
   const remoteHtmlDocument = useMemo(
     () => (isRemoteHtml ? remoteHtmlPreviewDocument(target.dataUrl!) : null),
     [isRemoteHtml, target.dataUrl]
   )
 
-  const currentLabel = compactUrl(currentUrl)
-
-  const previewLabel =
-    target.label && target.label.replace(/\/$/, '') !== currentLabel.replace(/\/$/, '') ? target.label : currentLabel
+  // Source-mode preview (HTML rendered as text, no webview/iframe): the URL
+  // label stays as an "open in default browser" affordance. The href/target
+  // are gated on this so the link is purely visual until the user clicks.
+  const isSourcePreviewTarget =
+    target.kind === 'file' && target.previewKind === 'html' && Boolean(target.dataUrl || target.transient)
 
   const restartingServer =
     previewServerRestart?.status === 'running' &&
@@ -245,6 +256,66 @@ export function PreviewPane({ embedded = false, onRestartServer, reloadRequest =
       webviewRef.current?.reload?.()
     }
   }, [isWebPreview])
+
+  const syncNavigationState = useCallback(() => {
+    const webview = webviewRef.current
+
+    setCanGoBack(Boolean(webview?.canGoBack?.()))
+    setCanGoForward(Boolean(webview?.canGoForward?.()))
+  }, [])
+
+  const goBack = useCallback(() => {
+    const webview = webviewRef.current
+
+    if (!webview?.canGoBack?.() || !webview.goBack) {
+      return
+    }
+
+    webview.goBack()
+    syncNavigationState()
+  }, [syncNavigationState])
+
+  const goForward = useCallback(() => {
+    const webview = webviewRef.current
+
+    if (!webview?.canGoForward?.() || !webview.goForward) {
+      return
+    }
+
+    webview.goForward()
+    syncNavigationState()
+  }, [syncNavigationState])
+
+  const submitAddress = useCallback((next: string) => {
+    const webview = webviewRef.current
+    const url = next.trim()
+
+    if (!isHttpUrl(url)) {
+      return
+    }
+
+    setLoadError(null)
+    setCurrentUrl(url)
+    setAddress(url)
+
+    if (webview?.loadURL) {
+      void Promise.resolve(webview.loadURL(url)).catch(() => undefined)
+    } else {
+      webview?.setAttribute('src', url)
+    }
+  }, [])
+
+  const handleAddressBlur = useCallback(() => {
+    addressFocusedRef.current = false
+
+    // Sync the address to the webview's actual current URL after the user is
+    // done typing — keeps the input truthful without clobbering mid-typing.
+    const live = webviewRef.current?.getURL?.() || currentUrl
+
+    if (live) {
+      setAddress(live)
+    }
+  }, [currentUrl])
 
   const appendConsoleEntry = useCallback(
     (entry: Omit<ConsoleEntry, 'id'>) => {
@@ -543,6 +614,9 @@ export function PreviewPane({ embedded = false, onRestartServer, reloadRequest =
     host.replaceChildren()
     webviewRef.current = null
     setCurrentUrl(target.url)
+    setAddress(target.url)
+    setCanGoBack(false)
+    setCanGoForward(false)
     setDevtoolsOpen(false)
     setLoadError(null)
     consoleState.reset()
@@ -592,7 +666,18 @@ export function PreviewPane({ embedded = false, onRestartServer, reloadRequest =
       if (detail.url) {
         setLoadError(null)
         setCurrentUrl(detail.url)
+
+        // Don't clobber the user's in-progress typing. The webview is the
+        // source of truth on blur — see `handleAddressBlur`.
+        if (!addressFocusedRef.current) {
+          setAddress(detail.url)
+        }
       }
+
+      // Both `did-navigate` and `did-navigate-in-page` can change the webview's
+      // history. Reading the back/forward state on either keeps the toolbar
+      // buttons truthful for SPA pushState navigation too.
+      syncNavigationState()
     }
 
     const onFail = (event: Event) => {
@@ -621,7 +706,12 @@ export function PreviewPane({ embedded = false, onRestartServer, reloadRequest =
     }
 
     const onStart = () => setLoading(true)
-    const onStop = () => setLoading(false)
+
+    const onStop = () => {
+      setLoading(false)
+      syncNavigationState()
+    }
+
     // The WEBVIEW is the source of truth for DevTools, not our click handler:
     // closing the DevTools window itself fires devtools-closed with no click,
     // and the glyph was left stuck "on" when we tracked it locally.
@@ -650,34 +740,52 @@ export function PreviewPane({ embedded = false, onRestartServer, reloadRequest =
       webview.removeEventListener('did-stop-loading', onStop)
       webview.remove()
     }
-  }, [appendConsoleEntry, consoleState, copy, isRemoteHtml, isWebPreview, target.url])
+  }, [appendConsoleEntry, consoleState, copy, isRemoteHtml, isWebPreview, syncNavigationState, target.url])
 
   return (
     <aside className="relative flex h-full w-full min-w-0 flex-col overflow-hidden bg-transparent text-muted-foreground">
       <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
-        {!embedded && (
+        {isWebPreview && !isRemoteHtml && (
+          <PreviewToolbar
+            address={address}
+            addressValid={isHttpUrl(address)}
+            canGoBack={canGoBack}
+            canGoForward={canGoForward}
+            loading={loading}
+            onAddressBlur={handleAddressBlur}
+            onAddressChange={setAddress}
+            onAddressFocus={() => {
+              addressFocusedRef.current = true
+            }}
+            onBack={goBack}
+            onForward={goForward}
+            onReload={reloadPreview}
+            onSubmit={submitAddress}
+            placeholder={currentUrl || copy.fallbackTitle}
+          />
+        )}
+        {!embedded && !isWebPreview && target.kind === 'file' && target.previewKind === 'html' && (
           <div className="pointer-events-none flex min-h-(--titlebar-height) items-center gap-1.5 border-b border-border/60 bg-background px-2 py-1">
             <div className="min-w-0 flex-1">
               <Tip label={copy.openTarget(currentUrl)}>
                 <a
                   className="pointer-events-auto inline max-w-full truncate text-left text-xs font-medium text-foreground underline-offset-4 decoration-current/20 transition-colors hover:text-primary hover:underline"
-                  href={isRemoteHtmlTarget ? undefined : currentUrl}
+                  href={isSourcePreviewTarget ? undefined : currentUrl}
                   onClick={event => {
-                    if (isRemoteHtmlTarget) {
+                    if (isSourcePreviewTarget) {
                       event.preventDefault()
                       void openPreviewTargetInBrowser(target).catch(error => notifyError(error, t.preview.unavailable))
                     }
                   }}
                   rel="noreferrer"
-                  target={isRemoteHtmlTarget ? undefined : '_blank'}
+                  target={isSourcePreviewTarget ? undefined : '_blank'}
                 >
-                  {previewLabel || copy.fallbackTitle}
+                  {copy.openTarget(currentUrl)}
                 </a>
               </Tip>
             </div>
           </div>
         )}
-
         <div
           className="pointer-events-auto relative min-h-0 flex-1 overflow-hidden bg-transparent"
           ref={previewContentRef}

--- a/apps/desktop/src/app/chat/right-rail/preview-pane.tsx
+++ b/apps/desktop/src/app/chat/right-rail/preview-pane.tsx
@@ -156,6 +156,7 @@ export function PreviewPane({ embedded = false, onRestartServer, reloadRequest =
   const [canGoBack, setCanGoBack] = useState(false)
   const [canGoForward, setCanGoForward] = useState(false)
   const addressFocusedRef = useRef(false)
+  const submittedAddressRef = useRef(false)
 
   // Artifacts have no URL to load — they render from the registry, never in a
   // webview.
@@ -286,27 +287,45 @@ export function PreviewPane({ embedded = false, onRestartServer, reloadRequest =
     syncNavigationState()
   }, [syncNavigationState])
 
-  const submitAddress = useCallback((next: string) => {
-    const webview = webviewRef.current
-    const url = next.trim()
+  const submitAddress = useCallback(
+    (next: string) => {
+      const webview = webviewRef.current
+      const url = next.trim()
 
-    if (!isHttpUrl(url)) {
-      return
-    }
+      if (!isHttpUrl(url)) {
+        return
+      }
 
-    setLoadError(null)
-    setCurrentUrl(url)
-    setAddress(url)
+      setLoadError(null)
+      setCurrentUrl(url)
+      setAddress(url)
+      submittedAddressRef.current = true
 
-    if (webview?.loadURL) {
-      void Promise.resolve(webview.loadURL(url)).catch(() => undefined)
-    } else {
-      webview?.setAttribute('src', url)
-    }
-  }, [])
+      if (webview?.loadURL) {
+        void Promise.resolve(webview.loadURL(url)).catch(error => {
+          setLoadError({
+            description: error instanceof Error ? error.message : copy.unreachableDescription,
+            url
+          })
+          setLoading(false)
+        })
+      } else {
+        webview?.setAttribute('src', url)
+      }
+    },
+    [copy.unreachableDescription]
+  )
 
   const handleAddressBlur = useCallback(() => {
     addressFocusedRef.current = false
+
+    // Don't snap back if the user just submitted — mousedown on Go fires
+    // submit, then blur. getURL() is still the previous page until did-navigate.
+    if (submittedAddressRef.current) {
+      submittedAddressRef.current = false
+
+      return
+    }
 
     // Sync the address to the webview's actual current URL after the user is
     // done typing — keeps the input truthful without clobbering mid-typing.

--- a/apps/desktop/src/app/chat/right-rail/preview-toolbar.test.tsx
+++ b/apps/desktop/src/app/chat/right-rail/preview-toolbar.test.tsx
@@ -60,7 +60,7 @@ describe('PreviewToolbar', () => {
     expect(rendered.getByRole('button', { name: 'Go forward' })).toBeTruthy()
     expect(rendered.getByRole('button', { name: 'Reload preview' })).toBeTruthy()
     expect(rendered.getByRole('textbox', { name: 'Preview URL' })).toBeTruthy()
-    expect(rendered.getAllByRole('button', { name: 'Navigate preview' }).length).toBe(1)
+    expect(rendered.getByRole('button', { name: 'Go to address' })).toBeTruthy()
     expect(rendered.getByRole('form', { name: 'Navigate preview' })).toBeTruthy()
   })
 
@@ -84,7 +84,7 @@ describe('PreviewToolbar', () => {
     const input = rendered.getByRole('textbox', { name: 'Preview URL' }) as HTMLInputElement
 
     expect(input.getAttribute('aria-invalid')).toBe('true')
-    expect((rendered.getByRole('button', { name: 'Navigate preview' }) as HTMLButtonElement).disabled).toBe(true)
+    expect((rendered.getByRole('button', { name: 'Go to address' }) as HTMLButtonElement).disabled).toBe(true)
   })
 
   it('does not mark the address invalid when the input is empty (no aria-invalid)', () => {
@@ -93,7 +93,7 @@ describe('PreviewToolbar', () => {
     const input = rendered.getByRole('textbox', { name: 'Preview URL' }) as HTMLInputElement
 
     expect(input.getAttribute('aria-invalid')).toBeNull()
-    expect((rendered.getByRole('button', { name: 'Navigate preview' }) as HTMLButtonElement).disabled).toBe(true)
+    expect((rendered.getByRole('button', { name: 'Go to address' }) as HTMLButtonElement).disabled).toBe(true)
   })
 
   it('fires onBack when the back button is clicked', () => {

--- a/apps/desktop/src/app/chat/right-rail/preview-toolbar.test.tsx
+++ b/apps/desktop/src/app/chat/right-rail/preview-toolbar.test.tsx
@@ -1,0 +1,203 @@
+import { cleanup, fireEvent, render } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { isHttpUrl, PreviewToolbar } from './preview-toolbar'
+
+const baseProps = {
+  address: 'https://example.com',
+  addressValid: true,
+  canGoBack: false,
+  canGoForward: false,
+  loading: false,
+  placeholder: 'https://example.com',
+  onAddressBlur: vi.fn(),
+  onAddressChange: vi.fn(),
+  onAddressFocus: vi.fn(),
+  onBack: vi.fn(),
+  onForward: vi.fn(),
+  onReload: vi.fn(),
+  onSubmit: vi.fn()
+}
+
+afterEach(() => {
+  cleanup()
+  vi.clearAllMocks()
+})
+
+describe('isHttpUrl', () => {
+  it('accepts http and https URLs', () => {
+    expect(isHttpUrl('https://example.com/path')).toBe(true)
+    expect(isHttpUrl('http://localhost:3000/')).toBe(true)
+  })
+
+  it('rejects empty input', () => {
+    expect(isHttpUrl('')).toBe(false)
+    expect(isHttpUrl('   ')).toBe(false)
+  })
+
+  it('rejects non-web schemes', () => {
+    expect(isHttpUrl('file:///etc/passwd')).toBe(false)
+    expect(isHttpUrl('data:text/html,evil')).toBe(false)
+    expect(isHttpUrl('javascript:alert(1)')).toBe(false)
+    expect(isHttpUrl('about:blank')).toBe(false)
+  })
+
+  it('rejects non-URL strings', () => {
+    expect(isHttpUrl('example')).toBe(false)
+    expect(isHttpUrl('://broken')).toBe(false)
+  })
+
+  it('trims whitespace before validating', () => {
+    expect(isHttpUrl('  https://example.com  ')).toBe(true)
+  })
+})
+
+describe('PreviewToolbar', () => {
+  it('renders all four controls with the right tooltips and labels', () => {
+    const rendered = render(<PreviewToolbar {...baseProps} />)
+
+    expect(rendered.getByRole('button', { name: 'Go back' })).toBeTruthy()
+    expect(rendered.getByRole('button', { name: 'Go forward' })).toBeTruthy()
+    expect(rendered.getByRole('button', { name: 'Reload preview' })).toBeTruthy()
+    expect(rendered.getByRole('textbox', { name: 'Preview URL' })).toBeTruthy()
+    expect(rendered.getAllByRole('button', { name: 'Navigate preview' }).length).toBe(1)
+    expect(rendered.getByRole('form', { name: 'Navigate preview' })).toBeTruthy()
+  })
+
+  it('disables back and forward when there is no history', () => {
+    const rendered = render(<PreviewToolbar {...baseProps} canGoBack={false} canGoForward={false} />)
+
+    expect((rendered.getByRole('button', { name: 'Go back' }) as HTMLButtonElement).disabled).toBe(true)
+    expect((rendered.getByRole('button', { name: 'Go forward' }) as HTMLButtonElement).disabled).toBe(true)
+  })
+
+  it('enables back and forward when there is history', () => {
+    const rendered = render(<PreviewToolbar {...baseProps} canGoBack={true} canGoForward={true} />)
+
+    expect((rendered.getByRole('button', { name: 'Go back' }) as HTMLButtonElement).disabled).toBe(false)
+    expect((rendered.getByRole('button', { name: 'Go forward' }) as HTMLButtonElement).disabled).toBe(false)
+  })
+
+  it('marks the address invalid when addressValid is false and the input has content', () => {
+    const rendered = render(<PreviewToolbar {...baseProps} address="not a url" addressValid={false} />)
+
+    const input = rendered.getByRole('textbox', { name: 'Preview URL' }) as HTMLInputElement
+
+    expect(input.getAttribute('aria-invalid')).toBe('true')
+    expect((rendered.getByRole('button', { name: 'Navigate preview' }) as HTMLButtonElement).disabled).toBe(true)
+  })
+
+  it('does not mark the address invalid when the input is empty (no aria-invalid)', () => {
+    const rendered = render(<PreviewToolbar {...baseProps} address="" addressValid={false} />)
+
+    const input = rendered.getByRole('textbox', { name: 'Preview URL' }) as HTMLInputElement
+
+    expect(input.getAttribute('aria-invalid')).toBeNull()
+    expect((rendered.getByRole('button', { name: 'Navigate preview' }) as HTMLButtonElement).disabled).toBe(true)
+  })
+
+  it('fires onBack when the back button is clicked', () => {
+    const onBack = vi.fn()
+    const rendered = render(<PreviewToolbar {...baseProps} canGoBack={true} onBack={onBack} />)
+
+    fireEvent.click(rendered.getByRole('button', { name: 'Go back' }))
+
+    expect(onBack).toHaveBeenCalledOnce()
+  })
+
+  it('fires onForward when the forward button is clicked', () => {
+    const onForward = vi.fn()
+    const rendered = render(<PreviewToolbar {...baseProps} canGoForward={true} onForward={onForward} />)
+
+    fireEvent.click(rendered.getByRole('button', { name: 'Go forward' }))
+
+    expect(onForward).toHaveBeenCalledOnce()
+  })
+
+  it('fires onReload when the reload button is clicked', () => {
+    const onReload = vi.fn()
+    const rendered = render(<PreviewToolbar {...baseProps} onReload={onReload} />)
+
+    fireEvent.click(rendered.getByRole('button', { name: 'Reload preview' }))
+
+    expect(onReload).toHaveBeenCalledOnce()
+  })
+
+  it('submits the trimmed address on form submit when addressValid is true', () => {
+    const onSubmit = vi.fn()
+
+    const rendered = render(
+      <PreviewToolbar {...baseProps} address="  https://example.com/path  " onSubmit={onSubmit} />
+    )
+
+    fireEvent.submit(rendered.getByRole('form', { name: 'Navigate preview' }))
+
+    expect(onSubmit).toHaveBeenCalledWith('https://example.com/path')
+  })
+
+  it('does not submit when the address is invalid', () => {
+    const onSubmit = vi.fn()
+
+    const rendered = render(
+      <PreviewToolbar {...baseProps} address="not a url" addressValid={false} onSubmit={onSubmit} />
+    )
+
+    fireEvent.submit(rendered.getByRole('form', { name: 'Navigate preview' }))
+
+    expect(onSubmit).not.toHaveBeenCalled()
+  })
+
+  it('fires onAddressChange on every keystroke without clobbering', () => {
+    const onAddressChange = vi.fn()
+
+    const rendered = render(<PreviewToolbar {...baseProps} address="https://exam" onAddressChange={onAddressChange} />)
+
+    const input = rendered.getByRole('textbox', { name: 'Preview URL' }) as HTMLInputElement
+
+    fireEvent.change(input, { target: { value: 'https://example' } })
+
+    expect(onAddressChange).toHaveBeenCalledWith('https://example')
+  })
+
+  it('fires onAddressBlur when the input loses focus', () => {
+    const onAddressBlur = vi.fn()
+    const rendered = render(<PreviewToolbar {...baseProps} onAddressBlur={onAddressBlur} />)
+
+    const input = rendered.getByRole('textbox', { name: 'Preview URL' }) as HTMLInputElement
+
+    fireEvent.blur(input)
+
+    expect(onAddressBlur).toHaveBeenCalledOnce()
+  })
+
+  it('fires onAddressFocus when the input is focused', () => {
+    const onAddressFocus = vi.fn()
+    const rendered = render(<PreviewToolbar {...baseProps} onAddressFocus={onAddressFocus} />)
+
+    const input = rendered.getByRole('textbox', { name: 'Preview URL' }) as HTMLInputElement
+
+    fireEvent.focus(input)
+
+    expect(onAddressFocus).toHaveBeenCalledOnce()
+  })
+
+  it('rotates the reload icon while loading', () => {
+    const { container } = render(<PreviewToolbar {...baseProps} loading={true} />)
+
+    const reloadButton = container.querySelector('button[aria-label="Reload preview"]')
+    const reloadIcon = reloadButton?.querySelector('svg')
+
+    expect(reloadIcon).toBeTruthy()
+    expect(reloadIcon?.getAttribute('class') ?? '').toContain('animate-spin')
+  })
+
+  it('does not rotate the reload icon when idle', () => {
+    const { container } = render(<PreviewToolbar {...baseProps} loading={false} />)
+
+    const reloadButton = container.querySelector('button[aria-label="Reload preview"]')
+    const reloadIcon = reloadButton?.querySelector('svg')
+
+    expect(reloadIcon).toBeTruthy()
+    expect(reloadIcon?.getAttribute('class') ?? '').not.toContain('animate-spin')
+  })
+})

--- a/apps/desktop/src/app/chat/right-rail/preview-toolbar.tsx
+++ b/apps/desktop/src/app/chat/right-rail/preview-toolbar.tsx
@@ -127,7 +127,7 @@ export function PreviewToolbar({
         spellCheck={false}
         value={address}
       />
-      <TooltipIconButton disabled={!addressValid} tooltip={copy.navigate} type="submit">
+      <TooltipIconButton disabled={!addressValid} tooltip={copy.go} type="submit">
         <ArrowUpRight />
       </TooltipIconButton>
       <TooltipIconButton onClick={onReload} tooltip={copy.reload} type="button">

--- a/apps/desktop/src/app/chat/right-rail/preview-toolbar.tsx
+++ b/apps/desktop/src/app/chat/right-rail/preview-toolbar.tsx
@@ -1,0 +1,138 @@
+/**
+ * PREVIEW TOOLBAR — the URL bar for the in-app browser preview.
+ *
+ * The live preview tile (`preview.tsx`) mounts `PreviewPane` with `embedded`.
+ * After the layout-tree rewrite the tab strip owns the title, so the pane
+ * itself has no address chrome — this toolbar is the navigation surface.
+ *
+ * Back / forward / address / submit / reload. HTTP-only validation so the
+ * address bar can't open `file://` or `data:` in the `<webview>`.
+ *
+ * Controlled component. State lives in `PreviewPane` so the webview's event
+ * listeners stay close to the webview itself; this component just renders
+ * the chrome and forwards intent. Focus-aware address input: when the input
+ * is focused, `onAddressChange` is the user's keystrokes (not the webview's
+ * navigation events), so typing doesn't get clobbered by `pushState`.
+ */
+
+import { type FormEvent, useCallback } from 'react'
+
+import { TooltipIconButton } from '@/components/assistant-ui/tooltip-icon-button'
+import { Input } from '@/components/ui/input'
+import { useI18n } from '@/i18n'
+import { ArrowUpRight, ChevronLeft, ChevronRight, RefreshCw } from '@/lib/icons'
+import { cn } from '@/lib/utils'
+
+export interface PreviewToolbarProps {
+  /** The address to show in the input. */
+  address: string
+  /** True when the address parses as `http://` or `https://`. */
+  addressValid: boolean
+  /** True when the webview has at least one entry to go back to. */
+  canGoBack: boolean
+  /** True when the webview has at least one entry to go forward to. */
+  canGoForward: boolean
+  /** True while a navigation is in flight (drives the reload icon spin). */
+  loading: boolean
+  /** Placeholder shown in the address input when empty. */
+  placeholder: string
+
+  onAddressBlur: () => void
+  onAddressChange: (next: string) => void
+  onAddressFocus: () => void
+  onBack: () => void
+  onForward: () => void
+  onReload: () => void
+  onSubmit: (url: string) => void
+}
+
+/**
+ * Returns `true` if `raw` parses as an absolute HTTP/HTTPS URL. Rejects
+ * `file://`, `data:`, `javascript:`, and other schemes — the embedded
+ * `<webview>` should only render web content, never local files the
+ * renderer hasn't already approved.
+ */
+export function isHttpUrl(raw: string): boolean {
+  const trimmed = raw.trim()
+
+  if (!trimmed) {
+    return false
+  }
+
+  try {
+    const url = new URL(trimmed)
+
+    return url.protocol === 'http:' || url.protocol === 'https:'
+  } catch {
+    return false
+  }
+}
+
+export function PreviewToolbar({
+  address,
+  addressValid,
+  canGoBack,
+  canGoForward,
+  loading,
+  placeholder,
+  onAddressBlur,
+  onAddressChange,
+  onAddressFocus,
+  onBack,
+  onForward,
+  onReload,
+  onSubmit
+}: PreviewToolbarProps) {
+  const { t } = useI18n()
+  const copy = t.preview.web
+
+  const handleSubmit = useCallback(
+    (event: FormEvent<HTMLFormElement>) => {
+      event.preventDefault()
+
+      if (!addressValid) {
+        return
+      }
+
+      onSubmit(address.trim())
+    },
+    [address, addressValid, onSubmit]
+  )
+
+  return (
+    <form
+      aria-label={copy.navigate}
+      className="flex shrink-0 items-center gap-0.5 border-b border-border/60 bg-background px-1 py-1"
+      onSubmit={handleSubmit}
+    >
+      <TooltipIconButton disabled={!canGoBack} onClick={onBack} tooltip={copy.goBack} type="button">
+        <ChevronLeft />
+      </TooltipIconButton>
+      <TooltipIconButton disabled={!canGoForward} onClick={onForward} tooltip={copy.goForward} type="button">
+        <ChevronRight />
+      </TooltipIconButton>
+      <Input
+        aria-invalid={address.trim().length > 0 && !addressValid ? true : undefined}
+        aria-label={copy.address}
+        autoCapitalize="off"
+        autoComplete="off"
+        autoCorrect="off"
+        className={cn(loading && 'text-muted-foreground')}
+        inputMode="url"
+        onBlur={onAddressBlur}
+        onChange={event => onAddressChange(event.target.value)}
+        onFocus={onAddressFocus}
+        placeholder={placeholder}
+        size="xs"
+        spellCheck={false}
+        value={address}
+      />
+      <TooltipIconButton disabled={!addressValid} tooltip={copy.navigate} type="submit">
+        <ArrowUpRight />
+      </TooltipIconButton>
+      <TooltipIconButton onClick={onReload} tooltip={copy.reload} type="button">
+        <RefreshCw className={cn(loading && 'animate-spin')} />
+      </TooltipIconButton>
+    </form>
+  )
+}

--- a/apps/desktop/src/i18n/ar.ts
+++ b/apps/desktop/src/i18n/ar.ts
@@ -2260,7 +2260,8 @@ export const ar = defineLocale({
       goForward: 'تقدم',
       reload: 'إعادة تحميل المعاينة',
       address: 'رابط المعاينة',
-      navigate: 'التنقل في المعاينة'
+      navigate: 'التنقل في المعاينة',
+      go: 'الانتقال إلى العنوان'
     }
   },
   zones: {

--- a/apps/desktop/src/i18n/ar.ts
+++ b/apps/desktop/src/i18n/ar.ts
@@ -2255,7 +2255,12 @@ export const ar = defineLocale({
       loadFailedConsole: (code, message) => `فشل التحميل${code ? ` (${code})` : ''}: ${message}`,
       unreachableDescription: 'تعذّر الوصول إلى صفحة المعاينة.',
       openTarget: url => `فتح ${url}`,
-      fallbackTitle: 'معاينة'
+      fallbackTitle: 'معاينة',
+      goBack: 'رجوع',
+      goForward: 'تقدم',
+      reload: 'إعادة تحميل المعاينة',
+      address: 'رابط المعاينة',
+      navigate: 'التنقل في المعاينة'
     }
   },
   zones: {

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -2822,7 +2822,12 @@ export const en: Translations = {
       loadFailedConsole: (code, message) => `Load failed${code ? ` (${code})` : ''}: ${message}`,
       unreachableDescription: 'The preview page could not be reached.',
       openTarget: url => `Open ${url}`,
-      fallbackTitle: 'Preview'
+      fallbackTitle: 'Preview',
+      goBack: 'Go back',
+      goForward: 'Go forward',
+      reload: 'Reload preview',
+      address: 'Preview URL',
+      navigate: 'Navigate preview'
     }
   },
 

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -2827,7 +2827,8 @@ export const en: Translations = {
       goForward: 'Go forward',
       reload: 'Reload preview',
       address: 'Preview URL',
-      navigate: 'Navigate preview'
+      navigate: 'Navigate preview',
+      go: 'Go to address'
     }
   },
 

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -2533,7 +2533,12 @@ export const ja = defineLocale({
       loadFailedConsole: (code, message) => `読み込みに失敗しました${code ? ` (${code})` : ''}: ${message}`,
       unreachableDescription: 'プレビューページに到達できませんでした。',
       openTarget: url => `${url} を開く`,
-      fallbackTitle: 'プレビュー'
+      fallbackTitle: 'プレビュー',
+      goBack: '戻る',
+      goForward: '進む',
+      reload: 'プレビューを再読み込み',
+      address: 'プレビュー URL',
+      navigate: 'プレビューをナビゲート'
     }
   },
 

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -2538,7 +2538,8 @@ export const ja = defineLocale({
       goForward: '進む',
       reload: 'プレビューを再読み込み',
       address: 'プレビュー URL',
-      navigate: 'プレビューをナビゲート'
+      navigate: 'プレビューをナビゲート',
+      go: 'このアドレスへ移動'
     }
   },
 

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -2407,6 +2407,11 @@ export interface Translations {
       unreachableDescription: string
       openTarget: (url: string) => string
       fallbackTitle: string
+      goBack: string
+      goForward: string
+      reload: string
+      address: string
+      navigate: string
     }
   }
 

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -2412,6 +2412,7 @@ export interface Translations {
       reload: string
       address: string
       navigate: string
+      go: string
     }
   }
 

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -2453,7 +2453,12 @@ export const zhHant = defineLocale({
       loadFailedConsole: (code, message) => `載入失敗${code ? ` (${code})` : ''}：${message}`,
       unreachableDescription: '無法連線至預覽頁面。',
       openTarget: url => `開啟 ${url}`,
-      fallbackTitle: '預覽'
+      fallbackTitle: '預覽',
+      goBack: '上一頁',
+      goForward: '下一頁',
+      reload: '重新載入預覽',
+      address: '預覽網址',
+      navigate: '瀏覽預覽'
     }
   },
 

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -2458,7 +2458,8 @@ export const zhHant = defineLocale({
       goForward: '下一頁',
       reload: '重新載入預覽',
       address: '預覽網址',
-      navigate: '瀏覽預覽'
+      navigate: '瀏覽預覽',
+      go: '前往網址'
     }
   },
 

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -2995,7 +2995,12 @@ export const zh: Translations = {
       loadFailedConsole: (code, message) => `加载失败${code ? ` (${code})` : ''}: ${message}`,
       unreachableDescription: '无法访问预览页面。',
       openTarget: url => `打开 ${url}`,
-      fallbackTitle: '预览'
+      fallbackTitle: '预览',
+      goBack: '后退',
+      goForward: '前进',
+      reload: '重新加载预览',
+      address: '预览网址',
+      navigate: '浏览预览'
     }
   },
 

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -3000,7 +3000,8 @@ export const zh: Translations = {
       goForward: '前进',
       reload: '重新加载预览',
       address: '预览网址',
-      navigate: '浏览预览'
+      navigate: '浏览预览',
+      go: '转到地址'
     }
   },
 


### PR DESCRIPTION
## Summary

The live in-app browser (`PreviewTilePane`) mounts `PreviewPane` with `embedded`. After the layout-tree rewrite (#77705) the tab strip owns the title, so the pane body has no address chrome — no URL field, no back/forward, no reload inside the page.

This adds a URL toolbar on that live webview path:

- back / forward / address / submit / reload
- HTTP(S) only — `file://`, `data:`, `javascript:` are rejected
- address input stays under the user while they type (`pushState` / in-page nav does not clobber it)
- back/forward state updates on both `did-navigate` and `did-navigate-in-page` (SPA history)

The toolbar is a controlled component. Navigation state lives next to the webview listeners in `PreviewPane`. The focus flag is a ref so typing does not remount the webview.

Source-mode / remote HTML previews keep a file-open label. Artifacts and local files are unchanged. `read_preview` still reads the webview via `executeJavaScript`, not the toolbar.

Supersedes #63598. Same user-facing controls, plus the in-page history sync, focus-aware address field, extracted component, and tests. Credit to @haykguy for the original toolbar shape. Replaces #87332 (closed) — that first PR assumed a live clickable URL label; the embedded tile never rendered one.

## Commit

- `0950b164a5` `feat(desktop): URL toolbar for in-app browser preview`

## vs #63598

| | #63598 | this PR |
|---|---|---|
| Live `embedded` tile | old rail titlebar | toolbar on the real `preview.tsx` mount |
| Back / forward / address / reload | yes | yes |
| HTTP(S) only | yes | yes |
| `did-navigate-in-page` history sync | no | yes |
| Focus-aware address (no remount) | no | yes |
| Extracted component + tests | inline | `preview-toolbar.tsx` + 20 unit + 3 pane tests |
| i18n | 4 locales | 5 (`ar` included) |

## Changes

- `apps/desktop/src/app/chat/right-rail/preview-toolbar.tsx` — toolbar + `isHttpUrl()`
- `apps/desktop/src/app/chat/right-rail/preview-toolbar.test.tsx` — 20 unit tests
- `apps/desktop/src/app/chat/right-rail/preview-pane.tsx` — wire toolbar on the live webview path, history sync, focus-aware address
- `apps/desktop/src/app/chat/right-rail/preview-pane.test.tsx` — embedded toolbar, focus clobber, `did-navigate-in-page` history
- `apps/desktop/src/i18n/{en,ja,zh,zh-hant,ar,types}.ts` — `goBack` / `goForward` / `reload` / `address` / `navigate`

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx eslint` + `npx prettier --check` on changed files
- [x] `npx vitest run src/app/chat/right-rail/` — 48 tests
- [x] `npx vitest run src/app/chat/` — 641 tests
- [ ] Manual: open a Browser pane → type a path → Enter loads → back/forward update after in-page nav → invalid `file://` stays disabled

## Scope note

This PR is the URL toolbar only. Viewport control, tab-for-chat selection, and extra browser actions are follow-ups.
