### PR TITLE
fix(mcp): merge portable Agent Plugin MCP servers into hermes mcp commands

### DIFF
--- a/hermes_cli/mcp_config.py
+++ b/hermes_cli/mcp_config.py
@@ -660,6 +660,12 @@ def cmd_mcp_remove(args):
         return
     _success(f"Removed '{name}' from config")
 
+    if name in _get_mcp_servers():
+        _warning(
+            f"A portable Agent Plugin also provides '{name}'; it remains "
+            "active and was not removed."
+        )
+
     # Clean up OAuth tokens if they exist — route through MCPOAuthManager so
     # any provider instance cached in the current process (e.g. from an
     # earlier `hermes mcp test` in the same session) is evicted too.

--- a/hermes_cli/mcp_config.py
+++ b/hermes_cli/mcp_config.py
@@ -76,12 +76,29 @@ def _prompt(question: str, *, password: bool = False, default: str = "") -> str:
 # ─── Config Helpers ───────────────────────────────────────────────────────────
 
 def _get_mcp_servers(config: Optional[dict] = None) -> Dict[str, dict]:
-    """Return the ``mcp_servers`` dict from config, or empty dict."""
+    """Return the ``mcp_servers`` dict from config, merged with portable
+    Agent Plugin MCP servers so ``hermes mcp`` subcommands can see and
+    authenticate them too. Native entries win on name collision, matching
+    the precedence already used by the runtime tool layer.
+    """
     if config is None:
         config = load_config()
     servers = config.get("mcp_servers")
     if not servers or not isinstance(servers, dict):
-        return {}
+        servers = {}
+    else:
+        servers = dict(servers)
+
+    try:
+        from hermes_cli.plugins import discover_plugins, get_plugin_manager
+
+        discover_plugins()
+        for name, portable_cfg in get_plugin_manager().get_portable_mcp_servers().items():
+            if name not in servers:
+                servers[name] = portable_cfg
+    except Exception:
+        logger.debug("Failed to load portable MCP servers", exc_info=True)
+
     return servers
 
 
@@ -635,7 +652,12 @@ def cmd_mcp_remove(args):
         _info("Cancelled.")
         return
 
-    _remove_mcp_server(name)
+    if not _remove_mcp_server(name):
+        _error(
+            f"'{name}' is provided by a portable Agent Plugin, not the native "
+            "config — disable the plugin to remove it."
+        )
+        return
     _success(f"Removed '{name}' from config")
 
     # Clean up OAuth tokens if they exist — route through MCPOAuthManager so
@@ -975,6 +997,13 @@ def cmd_mcp_configure(args):
         available = list(servers.keys())
         if available:
             _info(f"Available: {', '.join(available)}")
+        return
+
+    if name not in load_config().get("mcp_servers", {}):
+        _error(
+            f"'{name}' is provided by a portable Agent Plugin, not the native "
+            "config, so its tool selection can't be edited here."
+        )
         return
 
     cfg = servers[name]

--- a/tests/hermes_cli/test_mcp_config.py
+++ b/tests/hermes_cli/test_mcp_config.py
@@ -655,6 +655,61 @@ class TestConfigHelpers:
         assert servers["mysvr"]["url"] == "https://example.com/mcp"
 
 
+    def test_portable_plugin_mcp_servers_are_visible(self, monkeypatch):
+        """A portable Agent Plugin MCP server must resolve through
+        ``hermes mcp`` commands (issue #87253), not just the runtime tool
+        layer — otherwise an OAuth one can never be authenticated."""
+        import hermes_cli.plugins as plugins_mod
+        from hermes_cli.mcp_config import _get_mcp_servers
+
+        monkeypatch.setattr(plugins_mod, "discover_plugins", lambda force=False: None)
+        monkeypatch.setattr(
+            plugins_mod,
+            "get_plugin_manager",
+            lambda: type(
+                "_Mgr",
+                (),
+                {
+                    "get_portable_mcp_servers": lambda self: {
+                        "agent-plugin-supabase-4d7594e5__supabase": {
+                            "url": "https://supabase.example/mcp",
+                            "auth": "oauth",
+                        }
+                    }
+                },
+            )(),
+        )
+
+        servers = _get_mcp_servers()
+
+        assert "agent-plugin-supabase-4d7594e5__supabase" in servers
+        assert servers["agent-plugin-supabase-4d7594e5__supabase"]["auth"] == "oauth"
+
+    def test_native_server_wins_name_collision_with_portable(self, monkeypatch):
+        from hermes_cli.mcp_config import _save_mcp_server, _get_mcp_servers
+        import hermes_cli.plugins as plugins_mod
+
+        _save_mcp_server("shared", {"url": "https://native.example/mcp"})
+
+        monkeypatch.setattr(plugins_mod, "discover_plugins", lambda force=False: None)
+        monkeypatch.setattr(
+            plugins_mod,
+            "get_plugin_manager",
+            lambda: type(
+                "_Mgr",
+                (),
+                {
+                    "get_portable_mcp_servers": lambda self: {
+                        "shared": {"url": "https://portable.example/mcp"}
+                    }
+                },
+            )(),
+        )
+
+        servers = _get_mcp_servers()
+
+        assert servers["shared"]["url"] == "https://native.example/mcp"
+
     def test_env_key_for_server(self):
         from hermes_cli.mcp_config import _env_key_for_server
 

--- a/tests/hermes_cli/test_mcp_config.py
+++ b/tests/hermes_cli/test_mcp_config.py
@@ -168,6 +168,47 @@ class TestMcpRemove:
         cmd_mcp_remove(_make_args(name="oauth-srv"))
         assert not token_file.exists()
 
+    def test_remove_native_warns_when_portable_of_same_name_remains(
+        self, tmp_path, capsys, monkeypatch
+    ):
+        """Native-wins precedence (#87253) means a name can resolve to both a
+        native and a portable entry. Removing the native one must not claim
+        the name is gone — the portable server is still live and resolvable
+        under that name afterward."""
+        import hermes_cli.plugins as plugins_mod
+
+        _seed_config(tmp_path, {
+            "shared": {"url": "https://native.example/mcp"},
+        })
+        monkeypatch.setattr("builtins.input", lambda _: "y")
+        monkeypatch.setattr(plugins_mod, "discover_plugins", lambda force=False: None)
+        monkeypatch.setattr(
+            plugins_mod,
+            "get_plugin_manager",
+            lambda: type(
+                "_Mgr",
+                (),
+                {
+                    "get_portable_mcp_servers": lambda self: {
+                        "shared": {"url": "https://portable.example/mcp"}
+                    }
+                },
+            )(),
+        )
+
+        from hermes_cli.mcp_config import cmd_mcp_remove
+
+        cmd_mcp_remove(_make_args(name="shared"))
+        out = capsys.readouterr().out
+
+        assert "Removed" in out
+        assert "portable Agent Plugin" in out
+
+        from hermes_cli.config import load_config
+
+        config = load_config()
+        assert "shared" not in config.get("mcp_servers", {})
+
 
 # ---------------------------------------------------------------------------
 # Tests: cmd_mcp_add

--- a/tests/tui_gateway/test_mcp_profile_rpcs.py
+++ b/tests/tui_gateway/test_mcp_profile_rpcs.py
@@ -175,6 +175,49 @@ def test_set_api_key_stdio_references_env_block(hermes_root):
     assert "LOCALTOOL_TOKEN=tok-xyz" in work_env
 
 
+def test_set_api_key_rejects_portable_only_name(hermes_root, monkeypatch):
+    """A portable Agent Plugin's MCP server is visible via the merged
+    ``_get_mcp_servers()`` (issue #87253) but must not be writable here — it
+    has no native config.yaml entry to update, and unconditionally writing
+    one would create a stale, credential-bearing shadow that permanently
+    shadows the live portable config under native-wins precedence."""
+    import hermes_cli.plugins as plugins_mod
+
+    root = hermes_root
+    portable_name = "agent-plugin-supabase-4d7594e5__supabase"
+    monkeypatch.setattr(plugins_mod, "discover_plugins", lambda force=False: None)
+    monkeypatch.setattr(
+        plugins_mod,
+        "get_plugin_manager",
+        lambda: type(
+            "_Mgr",
+            (),
+            {
+                "get_portable_mcp_servers": lambda self: {
+                    portable_name: {
+                        "url": "https://supabase.example/mcp",
+                        "auth": "oauth",
+                    }
+                }
+            },
+        )(),
+    )
+
+    resp = _call(
+        "mcp.servers.set_api_key",
+        {"profile": "work", "name": portable_name, "value": "sk-leaked-secret"},
+    )
+    assert "error" in resp
+    assert resp["error"]["code"] == 4064
+
+    work_cfg = _read_yaml(root / "profiles" / "work" / "config.yaml")
+    assert portable_name not in work_cfg.get("mcp_servers", {})
+    work_env_path = root / "profiles" / "work" / ".env"
+    assert not work_env_path.exists() or "sk-leaked-secret" not in work_env_path.read_text(
+        encoding="utf-8"
+    )
+
+
 def test_remove_scoped_to_profile(hermes_root):
     root = hermes_root
     _result(

--- a/tui_gateway/methods_tools.py
+++ b/tui_gateway/methods_tools.py
@@ -2077,9 +2077,17 @@ def _(rid, params: dict) -> dict:
             _strip_bearer_prefix,
         )
 
-        servers = _get_mcp_servers()
+        config = load_config()
+        servers = _get_mcp_servers(config)
         if name not in servers:
             return _err(rid, 4064, f"server '{name}' not found")
+        if name not in (config.get("mcp_servers") or {}):
+            return _err(
+                rid,
+                4064,
+                f"'{name}' is provided by a portable Agent Plugin, not the "
+                "native config, so its API key can't be set here.",
+            )
 
         env_var = str(params.get("env_var") or "").strip() or _env_key_for_server(name)
 


### PR DESCRIPTION
## What does this PR do?

`_get_mcp_servers()` in `hermes_cli/mcp_config.py` only read the native
`mcp_servers` config block, so every `hermes mcp` subcommand
(`add`/`remove`/`list`/`test`/`login`/`reauth`/`configure`) was blind to
a portable Agent Plugin's MCP server. The plugin loads fine and its
skills work at runtime — `tools/mcp_tool.py` already bridges native +
portable there — but the CLI/dashboard name resolution never did, so a
portable server that needs OAuth had no route to a token and was
permanently unauthenticatable.

This merges `PluginManager.get_portable_mcp_servers()` into
`_get_mcp_servers()`'s result, with native entries winning on name
collision — the same precedence already used by the runtime tool
layer in `tools/mcp_tool.py:5132`. Portable entries surface under
their existing namespaced key.

Several follow-on write paths needed a guard once portable names became
visible in the merged dict, or they would have behaved incorrectly:
- `hermes mcp remove <portable-name>` would delete nothing (not in
  native config) while still printing "Removed" — now reports that
  the server is plugin-owned and can't be removed this way.
- `hermes mcp configure <portable-name>` would have written a
  connection-less native stub entry (just a `tools` filter, no
  `url`/`command`) that then shadows the working portable one under
  the new native-wins precedence — now reports the same thing.
- `tui_gateway/methods_tools.py`'s `mcp.servers.set_api_key` RPC (used
  by the TUI/gateway to store credentials) reads the same merged
  `_get_mcp_servers()` and only checked `name not in servers` before
  unconditionally writing `cfg["mcp_servers"][name] = entry` with a
  real bearer token in it. Once portable names became visible, this
  path would succeed for a portable-only name and write a
  credential-bearing native shadow entry — worse than the pre-fix
  state, where the RPC correctly 404'd. This was caught in review
  (missed in the initial diff, which only audited `mcp_config.py`'s
  own call sites) and is now guarded the same way as `cmd_mcp_configure`.

## Related Issue

Fixes #87253

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/mcp_config.py`: `_get_mcp_servers()` now merges in
  `get_portable_mcp_servers()` (native wins on collision); guarded
  `cmd_mcp_remove` and `cmd_mcp_configure` against portable-only names.
- `tests/hermes_cli/test_mcp_config.py`: added
  `test_portable_plugin_mcp_servers_are_visible` and
  `test_native_server_wins_name_collision_with_portable`.
- `tui_gateway/methods_tools.py`: guarded the `mcp.servers.set_api_key`
  RPC handler against portable-only names, matching the
  `cmd_mcp_configure` guard.
- `tests/tui_gateway/test_mcp_profile_rpcs.py`: added
  `test_set_api_key_rejects_portable_only_name`.

## How to Test

1. Install a portable Agent Plugin whose `mcp.json` declares a remote
   OAuth MCP server.
2. `hermes mcp list` now shows it; `hermes mcp login <name>` can find
   it and run the OAuth flow.
3. Automated:
   `pytest tests/hermes_cli/test_mcp_config.py tests/tui_gateway/test_mcp_profile_rpcs.py`

### Test output

```
tests/hermes_cli/test_mcp_config.py .................................... [ 81%]
tests/tui_gateway/test_mcp_profile_rpcs.py .........                      [100%]
49 passed in 3.51s
```

Verified the new tests fail without their corresponding source fix:
- `test_portable_plugin_mcp_servers_are_visible`: reverted
  `hermes_cli/mcp_config.py` to `HEAD~1` → fails with
  `AssertionError: assert '...' in {}` (old `_get_mcp_servers()` never
  looked at portable servers). Restored → passes alongside the rest.
- `test_set_api_key_rejects_portable_only_name`: reverted the guard
  just added to `tui_gateway/methods_tools.py`'s `set_api_key` handler
  → the RPC returns `{'ok': True, ...}` and would write a
  credential-bearing native shadow entry for the portable-only name,
  reproducing the exact regression a reviewer caught before merge.
  Restored the guard → the RPC 4064s and no `config.yaml`/`.env` write
  happens.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix (no unrelated commits)
- [x] I've run the test suite for the affected file and it passes
- [x] I've added tests for my changes
- [ ] Tested on my platform — ran in a Linux CI container only

### Documentation & Housekeeping

- [x] N/A — no config keys or architecture changed

## Note on process

This fix was prepared by an AI coding agent (Claude) as part of an
automated contribution pipeline, with the diff, tests, and this
description reviewed before pushing.
