### PR TITLE
feat(agent): make background-review iteration budget configurable

### DIFF
--- a/agent/background_review.py
+++ b/agent/background_review.py
@@ -111,6 +111,34 @@ def _resolve_review_runtime(agent: Any) -> Dict[str, Any]:
         return parent
 
 
+# Historical hardcoded value — kept as the default so existing behavior is
+# unchanged when the config key is unset.
+_DEFAULT_REVIEW_MAX_ITERATIONS = 16
+
+
+def _resolve_review_max_iterations(agent: Any) -> int:
+    """Resolve the review fork's tool-calling iteration budget.
+
+    Default 16 (unchanged historical behavior). Configurable via
+    ``auxiliary.background_review.max_iterations`` so operators can bound the
+    worst-case cost of a review that never concludes "nothing to save" and
+    instead runs to the cap every time. Clamped to [1, 64]; any config-read
+    or parse failure falls back to the default (same best-effort pattern as
+    ``auxiliary_client._transient_retry_count``).
+    """
+    try:
+        from hermes_cli.config import load_config_readonly
+        cfg = load_config_readonly()
+        aux = cfg.get("auxiliary", {}) if isinstance(cfg.get("auxiliary"), dict) else {}
+        task = aux.get("background_review", {}) if isinstance(aux.get("background_review"), dict) else {}
+        val = task.get("max_iterations")
+        if val is None:
+            return _DEFAULT_REVIEW_MAX_ITERATIONS
+        return max(1, min(int(val), 64))
+    except Exception:
+        return _DEFAULT_REVIEW_MAX_ITERATIONS
+
+
 def _msg_text(m: Dict) -> str:
     c = m.get("content")
     if isinstance(c, str):
@@ -811,7 +839,7 @@ def _run_review_in_thread(
                         _fork_kwargs[_pref_attr] = _pref_val
             review_agent = AIAgent(
                 model=_rt.get("model") or agent.model,
-                max_iterations=16,
+                max_iterations=_resolve_review_max_iterations(agent),
                 quiet_mode=True,
                 platform=agent.platform,
                 provider=_rt.get("provider") or agent.provider,

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1127,6 +1127,12 @@ DEFAULT_CONFIG = {
             "timeout": 120,
             "extra_body": {},
             "reasoning_effort": "",  # per-task thinking level: none|minimal|low|medium|high|xhigh|max|ultra (empty = provider default)
+            # Tool-calling iteration budget for the review fork. Default 16
+            # matches historical behavior. The review has no "nothing to do"
+            # early-out — a session with nothing worth saving still burns the
+            # full budget before concluding "Nothing to save." Lower this to
+            # bound worst-case cost; clamped to [1, 64].
+            "max_iterations": 16,
         },
         "moa_reference": {
             "provider": "auto",

--- a/tests/run_agent/test_background_review.py
+++ b/tests/run_agent/test_background_review.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from unittest.mock import patch
+
 import run_agent as run_agent_module
 from run_agent import AIAgent
 
@@ -196,6 +198,44 @@ def test_background_review_runs_at_top_level(monkeypatch):
     )
 
     assert len(forks) == 1, "top-level review must still spawn the fork"
+
+
+def test_background_review_honors_configured_max_iterations(monkeypatch):
+    """``auxiliary.background_review.max_iterations`` must reach the fork's
+    ``AIAgent(max_iterations=...)`` — the review has no early-out on "nothing
+    to save", so an unbounded/undersized budget is the only cost lever an
+    operator has short of disabling the review outright (#87250)."""
+    forks = []
+
+    class FakeReviewAgent:
+        def __init__(self, **kwargs):
+            forks.append(kwargs)
+
+        def run_conversation(self, **kwargs):
+            pass
+
+        def shutdown_memory_provider(self):
+            pass
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr(run_agent_module, "AIAgent", FakeReviewAgent)
+    monkeypatch.setattr(run_agent_module.threading, "Thread", ImmediateThread)
+
+    agent = _bare_agent()
+    agent._delegate_depth = 0
+
+    cfg = {"auxiliary": {"background_review": {"max_iterations": 4}}}
+    with patch("hermes_cli.config.load_config_readonly", return_value=cfg):
+        AIAgent._spawn_background_review(
+            agent,
+            messages_snapshot=[{"role": "user", "content": "hello"}],
+            review_memory=True,
+        )
+
+    assert len(forks) == 1
+    assert forks[0]["max_iterations"] == 4
 
 
 def test_background_review_explicit_focus_runs_even_in_subagent(monkeypatch):

--- a/tests/run_agent/test_background_review_cost_controls.py
+++ b/tests/run_agent/test_background_review_cost_controls.py
@@ -158,3 +158,40 @@ def test_digest_records_tool_names_in_arc():
     digest = out[0]["content"]
     assert "USER: do the thing" in digest
     assert "tools: skill_view, patch" in digest
+
+
+# ---------------------------------------------------------------------------
+# _resolve_review_max_iterations — configurable iteration budget (#87250)
+# ---------------------------------------------------------------------------
+
+def test_max_iterations_unset_falls_back_to_default():
+    agent = _FakeAgent()
+    with patch("hermes_cli.config.load_config_readonly", return_value={}):
+        assert br._resolve_review_max_iterations(agent) == 16
+
+
+def test_max_iterations_honors_config_override():
+    agent = _FakeAgent()
+    cfg = {"auxiliary": {"background_review": {"max_iterations": 4}}}
+    with patch("hermes_cli.config.load_config_readonly", return_value=cfg):
+        assert br._resolve_review_max_iterations(agent) == 4
+
+
+def test_max_iterations_clamped_to_upper_bound():
+    agent = _FakeAgent()
+    cfg = {"auxiliary": {"background_review": {"max_iterations": 999}}}
+    with patch("hermes_cli.config.load_config_readonly", return_value=cfg):
+        assert br._resolve_review_max_iterations(agent) == 64
+
+
+def test_max_iterations_clamped_to_lower_bound():
+    agent = _FakeAgent()
+    cfg = {"auxiliary": {"background_review": {"max_iterations": 0}}}
+    with patch("hermes_cli.config.load_config_readonly", return_value=cfg):
+        assert br._resolve_review_max_iterations(agent) == 1
+
+
+def test_max_iterations_falls_back_to_default_on_config_error():
+    agent = _FakeAgent()
+    with patch("hermes_cli.config.load_config_readonly", side_effect=RuntimeError("boom")):
+        assert br._resolve_review_max_iterations(agent) == 16


### PR DESCRIPTION
## What does this PR do?

`spawn_background_review` forks an `AIAgent` with a hardcoded
`max_iterations=16` and no early-out on "nothing to save" — a session
where nothing is worth saving still burns the full 16-iteration budget
before concluding, and there was no way for an operator to change that
short of disabling the review entirely (zeroing the nudge intervals).

This adds `auxiliary.background_review.max_iterations` (default `16`,
clamped to `[1, 64]`) so operators can lower the worst-case cost of the
review fork directly, per the config key suggested in the issue.

This is a partial fix — it covers the *configurability* gap. The
*accounting* (persisting fork usage so it shows up in usage reports)
and *decoupling* (making the review strategy swappable) gaps described
in the issue are materially larger changes and are intentionally left
for follow-up rather than bundled here.

## Related Issue

Addresses (in part) #87250

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `agent/background_review.py`: add `_resolve_review_max_iterations()`
  (same best-effort/clamped pattern as
  `auxiliary_client._transient_retry_count`) and use it in place of the
  hardcoded `max_iterations=16` when constructing the review fork.
- `hermes_cli/config_defaults.py`: add `auxiliary.background_review.max_iterations`
  default (`16`, unchanged behavior when unset).
- Tests: unit coverage for the new resolver (unset/override/clamped/config-error
  fallback) plus a wiring test proving the configured value reaches
  `AIAgent(max_iterations=...)`.

## How to Test

1. Set `auxiliary.background_review.max_iterations: 4` in `config.yaml`.
2. Trigger a background review (e.g. `/refine` or a normal turn with the
   nudge interval elapsed).
3. The review fork now stops after at most 4 tool-calling iterations
   instead of 16.

Verified without a live model via the added tests (below) — proved each
new test fails against the pre-fix source (`git checkout HEAD~1 --
agent/background_review.py`) and passes after.

```
$ python -m pytest tests/run_agent/test_background_review_cost_controls.py tests/run_agent/test_background_review.py -q
........................                                               [100%]
24 passed in 1.44s
```

Full `tests/run_agent/` suite (1,633 passed, 7 failed, 8 skipped, 2
deselected) — the 7 failures are pre-existing in this environment
(missing optional `anthropic` package, plus two unrelated failures in
`test_nous_fallback_unavailable.py` / `test_switch_model_reasoning_override.py`)
and reproduce identically on the unmodified base commit; none touch
`background_review.py` or the changed config defaults.

Ruff clean on all four changed files. `git diff --check` clean.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature
- [x] I've run the test suite and all relevant tests pass
- [x] I've added tests for my changes
- [x] Tested on Linux (CI sandbox)

### Documentation & Housekeeping

- [x] N/A — no user-facing docs/README changes needed; the config key
  follows the existing undocumented-until-referenced pattern used by
  sibling `auxiliary.<task>.*` keys not covered in `cli-config.yaml.example`
  (e.g. `curator`, `monitor`, `skills_hub`)
- [x] N/A — `cli-config.yaml.example` has no dedicated block for
  `background_review` today (only a handful of auxiliary tasks get one);
  consistent with that convention, none added here
- [x] N/A — no architecture/workflow change
- [x] N/A — no cross-platform-sensitive code touched
- [x] N/A — no tool schema/behavior change

---

Developed with AI assistance (Claude).
