### PR TITLE
fix(telegram): rebind TypeHandler after lazy PTB install

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -416,7 +416,7 @@ def check_telegram_requirements() -> bool:
     global TELEGRAM_AVAILABLE, Update, Bot, Message, InlineKeyboardButton
     global InlineKeyboardMarkup, LinkPreviewOptions, Application
     global CommandHandler, CallbackQueryHandler, TelegramMessageHandler
-    global ContextTypes, filters, ParseMode, ChatType, HTTPXRequest
+    global TypeHandler, ContextTypes, filters, ParseMode, ChatType, HTTPXRequest
     if TELEGRAM_AVAILABLE:
         return True
     try:
@@ -435,6 +435,7 @@ def check_telegram_requirements() -> bool:
             Application as _App, CommandHandler as _CH,
             CallbackQueryHandler as _CQH,
             MessageHandler as _MH,
+            TypeHandler as _TH,
             ContextTypes as _CT, filters as _filters,
         )
         from telegram.constants import ParseMode as _PM, ChatType as _CtT
@@ -451,6 +452,7 @@ def check_telegram_requirements() -> bool:
     CommandHandler = _CH
     CallbackQueryHandler = _CQH
     TelegramMessageHandler = _MH
+    TypeHandler = _TH
     ContextTypes = _CT
     filters = _filters
     ParseMode = _PM

--- a/tests/gateway/test_telegram_typehandler_rebind.py
+++ b/tests/gateway/test_telegram_typehandler_rebind.py
@@ -1,0 +1,58 @@
+"""Regression test: check_telegram_requirements() must rebind TypeHandler.
+
+When the adapter module loads while python-telegram-bot is missing, every PTB
+name falls back to typing.Any (mock mode). The registry then lazy-installs the
+SDK and calls check_telegram_requirements(), which re-imports the real classes
+and rebinds the module globals. It used to miss TypeHandler, so connect()
+failed with "Any cannot be instantiated" at `TypeHandler(Update, ...)` even
+after the dependency was restored. See adapter.py:4193.
+"""
+
+import typing
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("telegram")
+
+from gateway.config import PlatformConfig  # noqa: E402
+
+import plugins.platforms.telegram.adapter as telegram_mod  # noqa: E402
+
+
+class TestTypeHandlerRebind:
+    def test_mock_boot_recovery_rebinds_typehandler(self, monkeypatch):
+        """After mock-mode boot, the lazy-install recovery must restore
+        TypeHandler to the real class, not leave it as typing.Any."""
+        # Simulate the module having loaded while python-telegram-bot was
+        # missing: every PTB name is typing.Any (the except-ImportError branch).
+        monkeypatch.setattr(telegram_mod, "TELEGRAM_AVAILABLE", False)
+        for name in (
+            "Update", "Bot", "Message", "InlineKeyboardButton",
+            "InlineKeyboardMarkup", "Application", "CommandHandler",
+            "CallbackQueryHandler", "TypeHandler", "TelegramMessageHandler",
+            "HTTPXRequest",
+        ):
+            monkeypatch.setattr(telegram_mod, name, typing.Any)
+
+        assert telegram_mod.TypeHandler is typing.Any
+
+        # The registry's ensure_deps_fn runs the recovery path. With the real
+        # library importable, it re-imports and rebinds every mock name.
+        assert telegram_mod.check_telegram_requirements() is True
+
+        assert telegram_mod.TELEGRAM_AVAILABLE is True
+        assert telegram_mod.TypeHandler is not typing.Any
+
+        # The exact call connect() makes at adapter.py:4193 must not raise
+        # "Any cannot be instantiated" — the pre-fix failure. (Under the
+        # conftest telegram mock this returns a MagicMock; with the real
+        # library it returns a TypeHandler. Both are fine — the regression
+        # is that it no longer hits typing.Any's __init__.)
+        handler = telegram_mod.TypeHandler(telegram_mod.Update, lambda x: None)
+        assert handler is not None
+
+    def test_recovery_is_idempotent_when_lib_present(self, monkeypatch):
+        """A healthy module returns True without touching anything."""
+        monkeypatch.setattr(telegram_mod, "TELEGRAM_AVAILABLE", True)
+        assert telegram_mod.check_telegram_requirements() is True


### PR DESCRIPTION
## What

When the Telegram adapter module loads while python-telegram-bot is missing, every PTB name falls back to `typing.Any` (the mock branch). The gateway registry then lazy-installs the SDK and calls `check_telegram_requirements()`, which re-imports the real classes and rebinds the module globals.

It rebinds 15 names but **misses `TypeHandler`** — so after recovery, connect() hits `TypeHandler(Update, ...)` (adapter.py:4193) and raises:

```
TypeError: Any cannot be instantiated
```

Every reconnect retry fails identically because the module stays half-rebound for the process lifetime. The only fix today is a gateway restart (a fresh process imports PTB correctly).

## Why it bites

`hermes update` can leave python-telegram-bot unimportable in the venv (the managed-runtime rebuild wipes lazy deps; the update's refresh check is metadata-based and reports \"already current\" — see the #57828 comment in update_cmd.py). The first gateway boot after such an update lands in mock mode, the lazy installer restores the package, and the adapter is *supposed* to self-heal via `check_telegram_requirements()` — but the missing TypeHandler rebind makes the self-heal fail.

## Fix

Add `TypeHandler` to the re-import, the `global` declaration, and the rebind in `check_telegram_requirements()`.

## Test

`tests/gateway/test_telegram_typehandler_rebind.py`: boots the adapter in mock state (all PTB names = `typing.Any`), runs the recovery path, and asserts `TypeHandler` is rebound and the connect()-time call works. Fails on pre-fix code, passes with the fix.

- `pytest tests/gateway/ -k telegram`: 624 passed, 2 skipped
- `ruff check` on both changed files: clean