### PR TITLE
fix(discord): honor rate limits when auto-creating threads

### DIFF
--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -2301,61 +2301,83 @@ class DiscordAdapter(BasePlatformAdapter):
 
     @staticmethod
     def _extract_discord_retry_after(exc: BaseException) -> Optional[float]:
+        """Return a valid Discord retry delay without inventing a fallback."""
+        def _coerce_delay(value: Any) -> Optional[float]:
+            try:
+                delay = float(value)
+            except (TypeError, ValueError, OverflowError):
+                return None
+            return delay if math.isfinite(delay) and delay >= 0 else None
+
         value = getattr(exc, "retry_after", None)
         if value is not None:
-            try:
-                return max(1.0, float(value))
-            except (TypeError, ValueError):
-                return None
+            delay = _coerce_delay(value)
+            if delay is not None:
+                return delay
+
         response = getattr(exc, "response", None)
         headers = getattr(response, "headers", None)
         if headers:
-            for key in ("Retry-After", "X-RateLimit-Reset-After"):
+            candidate_keys = (
+                "Retry-After",
+                "retry-after",
+                "X-RateLimit-Reset-After",
+                "x-ratelimit-reset-after",
+            )
+            for key in candidate_keys:
                 try:
                     raw = headers.get(key)
                 except Exception:
                     raw = None
                 if raw is None:
                     continue
-                try:
-                    return max(1.0, float(raw))
-                except (TypeError, ValueError):
-                    continue
+                delay = _coerce_delay(raw)
+                if delay is not None:
+                    return delay
+            try:
+                items = headers.items()
+                for key, raw in items:
+                    if str(key).lower() not in {"retry-after", "x-ratelimit-reset-after"}:
+                        continue
+                    delay = _coerce_delay(raw)
+                    if delay is not None:
+                        return delay
+            except (AttributeError, TypeError):
+                pass
         return None
 
     @staticmethod
     def _is_discord_rate_limit(exc: BaseException) -> bool:
-        """True only for exceptions that look like Discord 429 rate limits.
-
-        Narrower than ``hasattr(exc, 'retry_after')``: discord.py's own
-        ``RateLimited`` exception and any HTTPException with status 429
-        qualify. This prevents suppressing unrelated failures that happen
-        to expose a ``retry_after`` attribute."""
-        # discord.py emits RateLimited / HTTPException subclasses for 429s.
-        # Guard with isinstance-of-class so a mocked ``discord`` module
-        # (where attrs are MagicMocks, not types) doesn't trip isinstance.
+        """True only for Discord 429/rate-limit exceptions."""
         if DISCORD_AVAILABLE and discord is not None:
-            for attr_name in ("RateLimited", "HTTPException"):
-                cls = getattr(discord, attr_name, None)
-                if not isinstance(cls, type):
-                    continue
-                if isinstance(exc, cls):
-                    if attr_name == "RateLimited":
-                        return True
-                    status = getattr(exc, "status", None)
-                    if status == 429:
-                        return True
-        # Fallback duck-type: something named like a rate-limit with a
-        # numeric retry_after. Covers mocked clients in tests and exotic
-        # transports, without swallowing arbitrary exceptions.
+            rate_limited_type = getattr(getattr(discord, "errors", None), "RateLimited", None)
+            if isinstance(rate_limited_type, type) and isinstance(exc, rate_limited_type):
+                return True
+            http_exception_type = getattr(getattr(discord, "errors", None), "HTTPException", None)
+            if isinstance(http_exception_type, type) and isinstance(exc, http_exception_type):
+                status = getattr(exc, "status", None)
+                if status is None:
+                    status = getattr(exc, "status_code", None)
+                if status == 429:
+                    return True
+
         name = type(exc).__name__.lower()
-        if ("ratelimit" in name or "rate_limit" in name) and getattr(exc, "retry_after", None) is not None:
-            return True
+        status = getattr(exc, "status", None)
+        if status is None:
+            status = getattr(exc, "status_code", None)
         response = getattr(exc, "response", None)
-        status = getattr(response, "status", None) or getattr(response, "status_code", None)
-        if status == 429:
-            return True
-        return False
+        if status is None and response is not None:
+            status = getattr(response, "status", None)
+            if status is None:
+                status = getattr(response, "status_code", None)
+
+        # Keep the compatibility path narrow: an unrelated exception can be
+        # named ``RateLimitError`` without being a Discord 429.  A name match
+        # must carry a second rate-limit/Discord marker before it can suppress
+        # the seed-message fallback.
+        if "ratelimit" in name or "rate_limit" in name:
+            return status == 429 or response is not None or hasattr(exc, "retry_after")
+        return status == 429
 
     @staticmethod
     def _is_discord_unknown_interaction(exc: BaseException) -> bool:
@@ -5585,7 +5607,7 @@ class DiscordAdapter(BasePlatformAdapter):
                                 chat_id, e,
                             )
                             return
-                        await asyncio.sleep(retry_after)
+                        await asyncio.sleep(max(1.0, retry_after))
                         continue
                     await asyncio.sleep(12)
             except asyncio.CancelledError:
@@ -7182,11 +7204,11 @@ class DiscordAdapter(BasePlatformAdapter):
     async def _auto_create_thread(self, message: 'DiscordMessage') -> Optional[Any]:
         """Create a thread from a user message for auto-threading.
 
-        Returns the created thread object, or ``None`` on failure. Both the
-        primary ``message.create_thread`` and the seed-message fallback are
-        retried once after a short backoff so transient connect errors
-        (e.g. ``Cannot connect to host discord.com:443``) don't immediately
-        burn through to the caller's failure path (#20243).
+        Returns the created thread object, or ``None`` on failure. Transient
+        connection errors retry through the seed-message fallback. Discord
+        rate limits are handled separately: the fallback is suppressed, the
+        requested ``Retry-After`` interval is honored, and only the original
+        thread request is retried once.
         """
         thread_name = self._derive_auto_thread_name(message.content or "")
         display_name = getattr(getattr(message, "author", None), "display_name", None) or "unknown user"
@@ -7194,6 +7216,7 @@ class DiscordAdapter(BasePlatformAdapter):
 
         last_direct_error: Exception | None = None
         last_fallback_error: Exception | None = None
+        direct_rate_limit_retry = False
 
         for attempt in range(2):
             try:
@@ -7205,6 +7228,40 @@ class DiscordAdapter(BasePlatformAdapter):
                 return thread
             except Exception as direct_error:
                 last_direct_error = direct_error
+
+                # Discord's rate-limit exceptions must not enter the seed-message
+                # fallback: that fallback makes another REST request while the
+                # route/global bucket is blocked and can turn one 429 into a burst
+                # of additional 429s.  Wait for Discord's requested interval and
+                # retry only the original operation once.
+                if self._is_discord_rate_limit(direct_error):
+                    retry_after = self._extract_discord_retry_after(direct_error)
+                    if retry_after is None or not math.isfinite(retry_after) or retry_after < 0:
+                        logger.warning(
+                            "[%s] Discord rate-limited auto-thread direct creation but provided no valid Retry-After; stopping",
+                            self.name,
+                        )
+                        break
+                    logger.warning(
+                        "[%s] Discord rate-limited auto-thread direct creation; retrying in %.2f seconds",
+                        self.name,
+                        retry_after,
+                    )
+                    if attempt == 0:
+                        await asyncio.sleep(retry_after)
+                        direct_rate_limit_retry = True
+                        continue
+                    break
+
+                if direct_rate_limit_retry:
+                    logger.warning(
+                        "[%s] Auto-thread creation failed after rate-limit retry; suppressing fallback: %s",
+                        self.name,
+                        direct_error,
+                    )
+                    break
+
+                seed_msg = None
                 try:
                     seed_msg = await message.channel.send(
                         f"\U0001f9f5 Thread created by Hermes: **{thread_name}**"
@@ -7221,6 +7278,48 @@ class DiscordAdapter(BasePlatformAdapter):
                     return thread
                 except Exception as fallback_error:
                     last_fallback_error = fallback_error
+                    if self._is_discord_rate_limit(fallback_error):
+                        # A seed-send 429 cannot be retried by repeating the seed:
+                        # no seed message exists, and doing so would duplicate the
+                        # fallback side effect if a transport returns one later.
+                        if seed_msg is None:
+                            logger.warning(
+                                "[%s] Discord rate-limited auto-thread seed send; stopping without resend",
+                                self.name,
+                            )
+                            break
+                        retry_after = self._extract_discord_retry_after(fallback_error)
+                        if retry_after is None or not math.isfinite(retry_after) or retry_after < 0:
+                            logger.warning(
+                                "[%s] Discord rate-limited auto-thread fallback creation but provided no valid Retry-After; stopping",
+                                self.name,
+                            )
+                            break
+                        logger.warning(
+                            "[%s] Discord rate-limited auto-thread fallback creation; retrying in %.2f seconds",
+                            self.name,
+                            retry_after,
+                        )
+                        await asyncio.sleep(retry_after)
+                        try:
+                            thread = await seed_msg.create_thread(
+                                name=thread_name,
+                                auto_archive_duration=1440,
+                                reason=reason,
+                            )
+                            try:
+                                setattr(thread, "_hermes_auto_thread_initial_name", thread_name)
+                            except Exception:
+                                pass
+                            return thread
+                        except Exception as retry_error:
+                            last_fallback_error = retry_error
+                            logger.warning(
+                                "[%s] Auto-thread fallback creation failed after rate-limit retry: %s",
+                                self.name,
+                                retry_error,
+                            )
+                            break
                     if attempt == 0:
                         # Brief backoff before the second attempt — most failures
                         # in this path are transient connect errors that recover

--- a/tests/gateway/test_discord_slash_commands.py
+++ b/tests/gateway/test_discord_slash_commands.py
@@ -1,8 +1,9 @@
 """Tests for native Discord slash command fast-paths (thread creation & auto-thread)."""
 
+import asyncio
+import sys
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
-import sys
 
 import pytest
 
@@ -425,6 +426,351 @@ async def test_auto_create_thread_strips_mention_syntax_from_name(adapter):
     assert "<@" not in name, f"role/user mention leaked: {name!r}"
     assert "<#" not in name, f"channel mention leaked: {name!r}"
     assert name == "please help"
+
+
+def _make_rate_limited(retry_after):
+    """Build the real discord.py exception or a compatible test fake."""
+    class RateLimitedWithoutDelay(Exception):
+        retry_after = None
+
+    if retry_after is None:
+        return RateLimitedWithoutDelay()
+    errors = getattr(_discord_mod, "errors", None)
+    rate_limited_type = getattr(errors, "RateLimited", None)
+    if isinstance(rate_limited_type, type):
+        return rate_limited_type(retry_after)
+
+    class RateLimited(Exception):
+        def __init__(self, delay):
+            self.retry_after = delay
+
+    return RateLimited(retry_after)
+
+
+def test_is_discord_rate_limit_rejects_class_name_only_exception(adapter):
+    class UnrelatedRateLimitError(Exception):
+        pass
+
+    assert not adapter._is_discord_rate_limit(UnrelatedRateLimitError())
+
+
+@pytest.mark.asyncio
+async def test_auto_create_thread_rate_limited_retries_direct_without_seed(adapter):
+    thread = SimpleNamespace(id=999, name="please help")
+    message = SimpleNamespace(
+        id=123,
+        content="please help",
+        create_thread=AsyncMock(side_effect=[_make_rate_limited(2.5), thread]),
+        channel=SimpleNamespace(id=100, name="general", send=AsyncMock()),
+        author=SimpleNamespace(display_name="Jezza"),
+    )
+
+    with patch("plugins.platforms.discord.adapter.asyncio.sleep", new_callable=AsyncMock) as sleep:
+        result = await adapter._auto_create_thread(message)
+
+    assert result is thread
+    sleep.assert_awaited_once_with(2.5)
+    assert message.create_thread.await_count == 2
+    assert message.channel.send.await_count == 0
+
+
+@pytest.mark.asyncio
+async def test_auto_create_thread_rate_limit_without_retry_after_stops(adapter):
+    message = SimpleNamespace(
+        content="missing delay",
+        create_thread=AsyncMock(side_effect=[_make_rate_limited(None), SimpleNamespace(id=999)]),
+        channel=SimpleNamespace(send=AsyncMock()),
+        author=SimpleNamespace(display_name="Jezza"),
+    )
+
+    with patch("plugins.platforms.discord.adapter.asyncio.sleep", new_callable=AsyncMock) as sleep:
+        result = await adapter._auto_create_thread(message)
+
+    assert result is None
+    sleep.assert_not_awaited()
+    assert message.create_thread.await_count == 1
+    assert message.channel.send.await_count == 0
+
+
+@pytest.mark.asyncio
+async def test_auto_create_thread_http_429_retries_without_seed(adapter):
+    class Http429(Exception):
+        status = 429
+
+        def __init__(self):
+            self.response = SimpleNamespace(headers={"Retry-After": "4.25"})
+
+    thread = SimpleNamespace(id=1000, name="rate limited")
+    message = SimpleNamespace(
+        content="rate limited",
+        create_thread=AsyncMock(side_effect=[Http429(), thread]),
+        channel=SimpleNamespace(send=AsyncMock()),
+        author=SimpleNamespace(display_name="Jezza"),
+    )
+
+    with patch("plugins.platforms.discord.adapter.asyncio.sleep", new_callable=AsyncMock) as sleep:
+        result = await adapter._auto_create_thread(message)
+
+    assert result is thread
+    sleep.assert_awaited_once_with(4.25)
+    assert message.channel.send.await_count == 0
+
+
+@pytest.mark.asyncio
+async def test_auto_create_thread_http_429_status_code_uses_header_delay(adapter):
+    class Http429(Exception):
+        status_code = 429
+
+        def __init__(self):
+            self.response = SimpleNamespace(headers={"x-ratelimit-reset-after": "1.25"})
+
+    thread = SimpleNamespace(id=1003, name="status code")
+    message = SimpleNamespace(
+        content="status code",
+        create_thread=AsyncMock(side_effect=[Http429(), thread]),
+        channel=SimpleNamespace(send=AsyncMock(side_effect=AssertionError("seed must not be sent"))),
+        author=SimpleNamespace(display_name="Jezza"),
+    )
+
+    with patch("plugins.platforms.discord.adapter.asyncio.sleep", new_callable=AsyncMock) as sleep:
+        result = await adapter._auto_create_thread(message)
+
+    assert result is thread
+    sleep.assert_awaited_once_with(1.25)
+    message.channel.send.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_auto_create_thread_invalid_exception_delay_falls_back_to_header(adapter):
+    class Http429(Exception):
+        retry_after = "not-a-delay"
+        status = 429
+
+        def __init__(self):
+            self.response = SimpleNamespace(headers={"Retry-After": "2.75"})
+
+    thread = SimpleNamespace(id=1004, name="header fallback")
+    message = SimpleNamespace(
+        content="header fallback",
+        create_thread=AsyncMock(side_effect=[Http429(), thread]),
+        channel=SimpleNamespace(send=AsyncMock(side_effect=AssertionError("seed must not be sent"))),
+        author=SimpleNamespace(display_name="Jezza"),
+    )
+
+    with patch("plugins.platforms.discord.adapter.asyncio.sleep", new_callable=AsyncMock) as sleep:
+        result = await adapter._auto_create_thread(message)
+
+    assert result is thread
+    sleep.assert_awaited_once_with(2.75)
+    message.channel.send.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_auto_create_thread_header_lookup_is_case_insensitive(adapter):
+    class Http429(Exception):
+        status = 429
+
+        def __init__(self):
+            self.response = SimpleNamespace(headers={"rEtRy-AfTeR": "1.5"})
+
+    thread = SimpleNamespace(id=1005, name="case insensitive")
+    message = SimpleNamespace(
+        content="case insensitive",
+        create_thread=AsyncMock(side_effect=[Http429(), thread]),
+        channel=SimpleNamespace(send=AsyncMock()),
+        author=SimpleNamespace(display_name="Jezza"),
+    )
+
+    with patch("plugins.platforms.discord.adapter.asyncio.sleep", new_callable=AsyncMock) as sleep:
+        result = await adapter._auto_create_thread(message)
+
+    assert result is thread
+    sleep.assert_awaited_once_with(1.5)
+    message.channel.send.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_auto_create_thread_negative_rate_limit_delay_stops_without_fallback(adapter):
+    message = SimpleNamespace(
+        content="negative delay",
+        create_thread=AsyncMock(side_effect=[_make_rate_limited(-1.0), SimpleNamespace(id=999)]),
+        channel=SimpleNamespace(send=AsyncMock()),
+        author=SimpleNamespace(display_name="Jezza"),
+    )
+
+    with patch("plugins.platforms.discord.adapter.asyncio.sleep", new_callable=AsyncMock) as sleep:
+        result = await adapter._auto_create_thread(message)
+
+    assert result is None
+    sleep.assert_not_awaited()
+    assert message.create_thread.await_count == 1
+    assert message.channel.send.await_count == 0
+
+
+@pytest.mark.asyncio
+async def test_auto_create_thread_nonfinite_rate_limit_delay_stops_without_fallback(adapter):
+    message = SimpleNamespace(
+        content="nonfinite delay",
+        create_thread=AsyncMock(side_effect=[_make_rate_limited(float("inf")), SimpleNamespace(id=999)]),
+        channel=SimpleNamespace(send=AsyncMock()),
+        author=SimpleNamespace(display_name="Jezza"),
+    )
+
+    with patch("plugins.platforms.discord.adapter.asyncio.sleep", new_callable=AsyncMock) as sleep:
+        result = await adapter._auto_create_thread(message)
+
+    assert result is None
+    sleep.assert_not_awaited()
+    assert message.create_thread.await_count == 1
+    assert message.channel.send.await_count == 0
+
+
+@pytest.mark.asyncio
+async def test_auto_create_thread_second_rate_limit_stops_without_fallback(adapter):
+    message = SimpleNamespace(
+        content="still limited",
+        create_thread=AsyncMock(side_effect=[_make_rate_limited(2.5), _make_rate_limited(8.0)]),
+        channel=SimpleNamespace(send=AsyncMock()),
+        author=SimpleNamespace(display_name="Jezza"),
+    )
+
+    with patch("plugins.platforms.discord.adapter.asyncio.sleep", new_callable=AsyncMock) as sleep:
+        result = await adapter._auto_create_thread(message)
+
+    assert result is None
+    sleep.assert_awaited_once_with(2.5)
+    assert message.create_thread.await_count == 2
+    assert message.channel.send.await_count == 0
+
+
+@pytest.mark.asyncio
+async def test_auto_create_thread_rate_limit_retry_failure_stops_without_fallback(adapter):
+    message = SimpleNamespace(
+        content="rate limit then ordinary failure",
+        create_thread=AsyncMock(side_effect=[_make_rate_limited(2.5), RuntimeError("still failed")]),
+        channel=SimpleNamespace(send=AsyncMock()),
+        author=SimpleNamespace(display_name="Jezza"),
+    )
+
+    with patch("plugins.platforms.discord.adapter.asyncio.sleep", new_callable=AsyncMock) as sleep:
+        result = await adapter._auto_create_thread(message)
+
+    assert result is None
+    sleep.assert_awaited_once_with(2.5)
+    assert message.create_thread.await_count == 2
+    assert message.channel.send.await_count == 0
+
+
+@pytest.mark.asyncio
+async def test_auto_create_thread_fallback_rate_limit_retries_only_thread_create(adapter):
+    thread = SimpleNamespace(id=1001, name="fallback rate limited")
+    seed_message = SimpleNamespace(
+        create_thread=AsyncMock(side_effect=[_make_rate_limited(3.75), thread]),
+    )
+    channel = SimpleNamespace(send=AsyncMock(return_value=seed_message))
+    message = SimpleNamespace(
+        content="fallback rate limited",
+        create_thread=AsyncMock(side_effect=RuntimeError("ordinary direct failure")),
+        channel=channel,
+        author=SimpleNamespace(display_name="Jezza"),
+    )
+
+    with patch("plugins.platforms.discord.adapter.asyncio.sleep", new_callable=AsyncMock) as sleep:
+        result = await adapter._auto_create_thread(message)
+
+    assert result is thread
+    sleep.assert_awaited_once_with(3.75)
+    assert message.create_thread.await_count == 1
+    assert channel.send.await_count == 1
+    assert seed_message.create_thread.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_auto_create_thread_fallback_second_rate_limit_stops_without_seed_resend(adapter):
+    seed_message = SimpleNamespace(
+        create_thread=AsyncMock(side_effect=[_make_rate_limited(3.75), _make_rate_limited(8.0)]),
+    )
+    channel = SimpleNamespace(send=AsyncMock(return_value=seed_message))
+    message = SimpleNamespace(
+        content="fallback still limited",
+        create_thread=AsyncMock(side_effect=RuntimeError("ordinary direct failure")),
+        channel=channel,
+        author=SimpleNamespace(display_name="Jezza"),
+    )
+
+    with patch("plugins.platforms.discord.adapter.asyncio.sleep", new_callable=AsyncMock) as sleep:
+        result = await adapter._auto_create_thread(message)
+
+    assert result is None
+    sleep.assert_awaited_once_with(3.75)
+    assert message.create_thread.await_count == 1
+    assert channel.send.await_count == 1
+    assert seed_message.create_thread.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_auto_create_thread_seed_send_rate_limit_stops_without_resend(adapter):
+    channel = SimpleNamespace(send=AsyncMock(side_effect=_make_rate_limited(3.5)))
+    message = SimpleNamespace(
+        content="seed send rate limited",
+        create_thread=AsyncMock(side_effect=RuntimeError("ordinary direct failure")),
+        channel=channel,
+        author=SimpleNamespace(display_name="Jezza"),
+    )
+
+    with patch("plugins.platforms.discord.adapter.asyncio.sleep", new_callable=AsyncMock) as sleep:
+        result = await adapter._auto_create_thread(message)
+
+    assert result is None
+    sleep.assert_not_awaited()
+    assert message.create_thread.await_count == 1
+    assert channel.send.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_send_typing_rate_limit_with_zero_delay_uses_positive_sleep(adapter):
+    class RateLimitedZeroDelay(Exception):
+        retry_after = 0.0
+
+    request = AsyncMock(side_effect=RateLimitedZeroDelay())
+    adapter._client.http = SimpleNamespace(request=request)
+    real_sleep = asyncio.sleep
+
+    async def yield_once(_delay):
+        await real_sleep(0)
+
+    with patch("plugins.platforms.discord.adapter.asyncio.sleep", new_callable=AsyncMock) as sleep:
+        sleep.side_effect = yield_once
+        await adapter.send_typing("typing-zero-delay")
+        for _ in range(10):
+            await real_sleep(0)
+            if any(call.args == (1.0,) for call in sleep.await_args_list):
+                break
+        await adapter.stop_typing("typing-zero-delay")
+
+    assert any(call.args == (1.0,) for call in sleep.await_args_list)
+
+
+@pytest.mark.asyncio
+async def test_auto_create_thread_ordinary_errors_keep_fallback_and_retry(adapter):
+    thread = SimpleNamespace(id=1002, name="ordinary retry")
+    seed_message = SimpleNamespace(create_thread=AsyncMock(side_effect=RuntimeError("fallback failed")))
+    channel = SimpleNamespace(send=AsyncMock(return_value=seed_message))
+    message = SimpleNamespace(
+        content="ordinary retry",
+        create_thread=AsyncMock(side_effect=RuntimeError("direct failed")),
+        channel=channel,
+        author=SimpleNamespace(display_name="Jezza"),
+    )
+
+    with patch("plugins.platforms.discord.adapter.asyncio.sleep", new_callable=AsyncMock) as sleep:
+        result = await adapter._auto_create_thread(message)
+
+    assert result is None
+    sleep.assert_awaited_once_with(0.75)
+    assert message.create_thread.await_count == 2
+    assert channel.send.await_count == 2
+    assert seed_message.create_thread.await_count == 2
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What does this PR do?

Fixes Discord HTTP 429 handling during automatic thread creation. The direct `Message.create_thread` path previously entered the seed-message fallback and additional retries after a rate limit, causing more REST requests while the Discord bucket was blocked.

This change keeps automatic thread creation enabled and limits 429 recovery to one retry of the same REST operation after Discord's requested delay.

## Related Issue

N/A — no existing issue was identified for this fix.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `plugins/platforms/discord/adapter.py`
  - Detect `discord.errors.RateLimited` and HTTP 429 responses, including `status_code` and response-header variants.
  - Prefer `retry_after`, then `Retry-After` / `X-RateLimit-Reset-After` headers.
  - Stop without guessing when the delay is missing or invalid.
  - Suppress seed-message fallback for direct 429s.
  - Retry the same direct or fallback `create_thread` operation at most once.
  - Do not resend a seed message after a fallback rate limit.
- `tests/gateway/test_discord_slash_commands.py`
  - Add regression coverage for direct, HTTP-header, invalid-delay, repeated-429, fallback-create, seed-send, and non-429 behavior.

## How to Test

1. Run the focused suite:
   `scripts/run_tests.sh tests/gateway/test_discord_slash_commands.py -q`
2. Run the related Discord gateway suites:
   `scripts/run_tests.sh tests/gateway/test_discord_slash_commands.py tests/gateway/test_discord_slash_auth.py -q`
3. Run lint, syntax, and whitespace checks:
   `./.venv/bin/ruff check plugins/platforms/discord/adapter.py tests/gateway/test_discord_slash_commands.py`
   `./.venv/bin/python -m compileall -q plugins/platforms/discord/adapter.py tests/gateway/test_discord_slash_commands.py`
   `git diff --check`
4. Run the gateway suite with the CI-parity wrapper:
   `scripts/run_tests.sh tests/gateway/ -q`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — the CI-parity gateway run passed 5,713 tests with 2 unrelated pre-existing WeCom callback failures (`ET` is `None`)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu/Linux, Python 3.11.15, discord.py 2.7.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation (docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

### Verification Notes

- Focused auto-thread suite: **27 passed**.
- Related Discord auth/command suites: **42 passed**.
- Gateway suite: **5,713 passed, 2 failed, 29 skipped**. The two failures are in the unrelated WeCom callback tests and fail because `ET` is `None`; no Discord tests failed.
- Ruff, `compileall`, and `git diff --check`: passed.
- GitHub currently reports no checks for this branch; merge state is blocked until repository-side requirements/checks are available.

## For New Skills

Not applicable.

## Screenshots / Logs

Not applicable; this is a backend retry-handling fix. Full local test output is available in the PR discussion if needed.