### PR TITLE
fix(pricing): resolve Z.AI Coding Plan and Ollama Cloud as subscription_included

### DIFF
--- a/agent/usage_pricing.py
+++ b/agent/usage_pricing.py
@@ -834,6 +834,133 @@ _OFFICIAL_DOCS_PRICING: Dict[tuple[str, str], PricingEntry] = {
         source_url="https://docs.fireworks.ai/serverless/pricing",
         pricing_version="fireworks-pricing-2026-07",
     ),
+    # ── Z.AI direct (pay-as-you-go api.z.ai/api/paas/v4) ─────────────────
+    # https://docs.z.ai/guides/overview/pricing (USD / 1M tokens; cached-
+    # input storage is limited-time free, omitted). Coding-plan endpoints
+    # (/api/coding/...) never hit this table — they route to
+    # billing_mode="subscription_included" in resolve_billing_route.
+    (
+        "zai",
+        "glm-5.2",
+    ): PricingEntry(
+        input_cost_per_million=Decimal("1.40"),
+        output_cost_per_million=Decimal("4.40"),
+        cache_read_cost_per_million=Decimal("0.26"),
+        source="official_docs_snapshot",
+        source_url="https://docs.z.ai/guides/overview/pricing",
+        pricing_version="zai-pricing-2026-08",
+    ),
+    (
+        "zai",
+        "glm-5.1",
+    ): PricingEntry(
+        input_cost_per_million=Decimal("1.40"),
+        output_cost_per_million=Decimal("4.40"),
+        cache_read_cost_per_million=Decimal("0.26"),
+        source="official_docs_snapshot",
+        source_url="https://docs.z.ai/guides/overview/pricing",
+        pricing_version="zai-pricing-2026-08",
+    ),
+    (
+        "zai",
+        "glm-5",
+    ): PricingEntry(
+        input_cost_per_million=Decimal("1.00"),
+        output_cost_per_million=Decimal("3.20"),
+        cache_read_cost_per_million=Decimal("0.20"),
+        source="official_docs_snapshot",
+        source_url="https://docs.z.ai/guides/overview/pricing",
+        pricing_version="zai-pricing-2026-08",
+    ),
+    (
+        "zai",
+        "glm-5-turbo",
+    ): PricingEntry(
+        input_cost_per_million=Decimal("1.20"),
+        output_cost_per_million=Decimal("4.00"),
+        cache_read_cost_per_million=Decimal("0.24"),
+        source="official_docs_snapshot",
+        source_url="https://docs.z.ai/guides/overview/pricing",
+        pricing_version="zai-pricing-2026-08",
+    ),
+    (
+        "zai",
+        "glm-4.7",
+    ): PricingEntry(
+        input_cost_per_million=Decimal("0.60"),
+        output_cost_per_million=Decimal("2.20"),
+        cache_read_cost_per_million=Decimal("0.11"),
+        source="official_docs_snapshot",
+        source_url="https://docs.z.ai/guides/overview/pricing",
+        pricing_version="zai-pricing-2026-08",
+    ),
+    (
+        "zai",
+        "glm-4.7-flashx",
+    ): PricingEntry(
+        input_cost_per_million=Decimal("0.07"),
+        output_cost_per_million=Decimal("0.40"),
+        cache_read_cost_per_million=Decimal("0.01"),
+        source="official_docs_snapshot",
+        source_url="https://docs.z.ai/guides/overview/pricing",
+        pricing_version="zai-pricing-2026-08",
+    ),
+    (
+        "zai",
+        "glm-4.6",
+    ): PricingEntry(
+        input_cost_per_million=Decimal("0.60"),
+        output_cost_per_million=Decimal("2.20"),
+        cache_read_cost_per_million=Decimal("0.11"),
+        source="official_docs_snapshot",
+        source_url="https://docs.z.ai/guides/overview/pricing",
+        pricing_version="zai-pricing-2026-08",
+    ),
+    (
+        "zai",
+        "glm-4.5",
+    ): PricingEntry(
+        input_cost_per_million=Decimal("0.60"),
+        output_cost_per_million=Decimal("2.20"),
+        cache_read_cost_per_million=Decimal("0.11"),
+        source="official_docs_snapshot",
+        source_url="https://docs.z.ai/guides/overview/pricing",
+        pricing_version="zai-pricing-2026-08",
+    ),
+    (
+        "zai",
+        "glm-4.5-x",
+    ): PricingEntry(
+        input_cost_per_million=Decimal("2.20"),
+        output_cost_per_million=Decimal("8.90"),
+        cache_read_cost_per_million=Decimal("0.45"),
+        source="official_docs_snapshot",
+        source_url="https://docs.z.ai/guides/overview/pricing",
+        pricing_version="zai-pricing-2026-08",
+    ),
+    (
+        "zai",
+        "glm-4.5-air",
+    ): PricingEntry(
+        input_cost_per_million=Decimal("0.20"),
+        output_cost_per_million=Decimal("1.10"),
+        cache_read_cost_per_million=Decimal("0.03"),
+        source="official_docs_snapshot",
+        source_url="https://docs.z.ai/guides/overview/pricing",
+        pricing_version="zai-pricing-2026-08",
+    ),
+    (
+        "zai",
+        "glm-4.5-airx",
+    ): PricingEntry(
+        input_cost_per_million=Decimal("1.10"),
+        output_cost_per_million=Decimal("4.50"),
+        cache_read_cost_per_million=Decimal("0.22"),
+        source="official_docs_snapshot",
+        source_url="https://docs.z.ai/guides/overview/pricing",
+        pricing_version="zai-pricing-2026-08",
+    ),
+
     (
         "fireworks",
         "glm-5p2",
@@ -1069,6 +1196,26 @@ def resolve_billing_route(
 
     if provider_name == "openai-codex":
         return BillingRoute(provider="openai-codex", model=model, base_url=base_url or "", billing_mode="subscription_included")
+    # Z.AI Coding Plan and Ollama Cloud bill by subscription quota, not
+    # per-token: usage eats plan allowance (Ollama publishes usage levels
+    # per model, Z.AI's coding plan is a fixed monthly seat) — there is no
+    # per-token charge to meter, so cost is $0 for spend-tracking purposes,
+    # exactly like openai-codex. Detection is by base_url host/path so the
+    # route holds even when the provider entry in config.yaml is renamed.
+    # Z.AI is split by endpoint (https://docs.z.ai/devpack/overview):
+    #   subscription — https://api.z.ai/api/coding/paas/v4 (Chat)
+    #                  https://api.z.ai/api/v1            (Responses)
+    #                  https://api.z.ai/api/anthropic      (Messages)
+    #   pay-as-you-go — https://api.z.ai/api/paas/v4 (per-token, resolves
+    #                   through the official-docs pricing table below).
+    if base_url_host_matches(base_url or "", "api.z.ai") and (
+        "/coding/" in base
+        or base.rstrip("/").endswith("/api/v1")
+        or base.rstrip("/").endswith("/api/anthropic")
+    ):
+        return BillingRoute(provider="zai", model=model, base_url=base_url or "", billing_mode="subscription_included")
+    if provider_name == "ollama-cloud" or base_url_host_matches(base_url or "", "ollama.com"):
+        return BillingRoute(provider="ollama-cloud", model=model, base_url=base_url or "", billing_mode="subscription_included")
     if provider_name == "openrouter" or base_url_host_matches(base_url or "", "openrouter.ai"):
         return BillingRoute(provider="openrouter", model=model, base_url=base_url or "", billing_mode="official_models_api")
     if provider_name == "nous" or base_url_host_matches(base_url or "", "inference-api.nousresearch.com"):

--- a/tests/agent/test_usage_pricing_zai_ollama.py
+++ b/tests/agent/test_usage_pricing_zai_ollama.py
@@ -1,0 +1,196 @@
+"""Tests for Z.AI and Ollama Cloud billing-route resolution.
+
+Fleet reality: `zai` and `ollama-cloud` provider entries in config.yaml
+point at subscription endpoints (Z.AI Coding Plan /api/coding/paas/v4,
+Ollama Cloud ollama.com/v1). These bill by plan quota — there is no
+per-token charge, so spend tracking must treat them as $0
+(subscription_included), exactly like openai-codex.
+
+Pay-as-you-go z.ai (api.z.ai/api/paas/v4) DOES bill per token — it gets
+real _OFFICIAL_DOCS_PRICING entries.
+"""
+
+from decimal import Decimal
+
+from agent.usage_pricing import (
+    _OFFICIAL_DOCS_PRICING,
+    get_pricing_entry,
+    has_known_pricing,
+    resolve_billing_route,
+)
+
+
+class TestZaiCodingPlanRoute:
+    def test_coding_plan_provider_subscription_included(self):
+        route = resolve_billing_route(
+            "glm-5.2", provider="zai", base_url="https://api.z.ai/api/coding/paas/v4"
+        )
+        assert route.billing_mode == "subscription_included"
+        assert route.provider == "zai"
+
+    def test_coding_plan_base_url_subscription_included(self):
+        # provider renamed in config.yaml — the /coding/ path segment is
+        # the durable signal
+        route = resolve_billing_route(
+            "glm-5.2",
+            provider="my-zai-rename",
+            base_url="https://api.z.ai/api/coding/paas/v4",
+        )
+        assert route.billing_mode == "subscription_included"
+
+    def test_coding_plan_responses_endpoint_subscription_included(self):
+        # https://api.z.ai/api/v1 (OpenAI Responses protocol) is a Coding
+        # Plan endpoint with no "/coding/" in the path
+        route = resolve_billing_route(
+            "glm-5.2",
+            provider="zai",
+            base_url="https://api.z.ai/api/v1",
+        )
+        assert route.billing_mode == "subscription_included"
+
+    def test_coding_plan_anthropic_endpoint_subscription_included(self):
+        # https://api.z.ai/api/anthropic (Anthropic Messages protocol)
+        route = resolve_billing_route(
+            "glm-5.2",
+            provider="zai",
+            base_url="https://api.z.ai/api/anthropic",
+        )
+        assert route.billing_mode == "subscription_included"
+
+    def test_coding_plan_has_known_pricing(self):
+        assert has_known_pricing(
+            "glm-5.2", "zai", "https://api.z.ai/api/coding/paas/v4"
+        )
+
+    def test_coding_plan_entry_costs_zero(self):
+        entry = get_pricing_entry(
+            "glm-5.2", provider="zai", base_url="https://api.z.ai/api/coding/paas/v4"
+        )
+        assert entry is not None
+        assert entry.input_cost_per_million == Decimal("0")
+        assert entry.output_cost_per_million == Decimal("0")
+
+
+class TestZaiPayAsYouGo:
+    def test_paas_endpoint_resolves_real_pricing(self):
+        # api.z.ai/api/paas/v4 (no /coding/) bills per token
+        entry = get_pricing_entry(
+            "glm-5.2", provider="zai", base_url="https://api.z.ai/api/paas/v4"
+        )
+        assert entry is not None
+        assert entry.input_cost_per_million == Decimal("1.40")
+        assert entry.output_cost_per_million == Decimal("4.40")
+        assert entry.cache_read_cost_per_million == Decimal("0.26")
+
+    def test_paas_has_known_pricing(self):
+        assert has_known_pricing("glm-5.2", "zai", "https://api.z.ai/api/paas/v4")
+
+    def test_paas_fleet_models_all_known(self):
+        for model in ("glm-5.2", "glm-5.1", "glm-4.7", "glm-4.5-air"):
+            assert has_known_pricing(
+                model, "zai", "https://api.z.ai/api/paas/v4"
+            ), model
+
+    def test_official_docs_table_has_zai_keys(self):
+        assert ("zai", "glm-5.2") in _OFFICIAL_DOCS_PRICING
+        assert ("zai", "glm-4.7") in _OFFICIAL_DOCS_PRICING
+        entry = _OFFICIAL_DOCS_PRICING[("zai", "glm-5.2")]
+        assert entry.source == "official_docs_snapshot"
+        assert entry.pricing_version == "zai-pricing-2026-08"
+
+
+class TestOllamaCloudRoute:
+    def test_ollama_cloud_provider_subscription_included(self):
+        route = resolve_billing_route(
+            "deepseek-v4-flash:0731",
+            provider="ollama-cloud",
+            base_url="https://ollama.com/v1",
+        )
+        assert route.billing_mode == "subscription_included"
+        assert route.provider == "ollama-cloud"
+
+    def test_ollama_cloud_host_match_subscription_included(self):
+        # provider renamed — ollama.com host is the durable signal
+        route = resolve_billing_route(
+            "deepseek-v4-flash:0731",
+            provider="renamed-provider",
+            base_url="https://ollama.com/v1",
+        )
+        assert route.billing_mode == "subscription_included"
+
+    def test_ollama_cloud_fleet_models_all_known(self):
+        for model in (
+            "deepseek-v4-flash:0731",
+            "deepseek-v4-pro:0813",
+            "kimi-k2.6:cloud",
+        ):
+            assert has_known_pricing(
+                model, "ollama-cloud", "https://ollama.com/v1"
+            ), model
+
+    def test_ollama_cloud_entry_costs_zero(self):
+        entry = get_pricing_entry(
+            "deepseek-v4-flash:0731",
+            provider="ollama-cloud",
+            base_url="https://ollama.com/v1",
+        )
+        assert entry is not None
+        assert entry.input_cost_per_million == Decimal("0")
+        assert entry.output_cost_per_million == Decimal("0")
+
+    def test_local_ollama_still_unknown(self):
+        # Local ollama (11434) must NOT get subscription treatment — it's
+        # self-hosted compute with no per-token price; it stays unknown
+        # exactly as before this change.
+        route = resolve_billing_route(
+            "llama4:8b", provider="ollama", base_url="http://127.0.0.1:11434/v1"
+        )
+        assert route.billing_mode == "unknown"
+        assert not has_known_pricing(
+            "llama4:8b", "ollama", "http://127.0.0.1:11434/v1"
+        )
+
+
+class TestExistingRoutesUnchanged:
+    def test_openrouter_still_official_models_api(self):
+        route = resolve_billing_route(
+            "z-ai/glm-5.2",
+            provider="openrouter",
+            base_url="https://openrouter.ai/api/v1",
+        )
+        assert route.billing_mode == "official_models_api"
+
+    def test_nous_still_official_models_api(self):
+        route = resolve_billing_route(
+            "Hermes-4",
+            provider="nous",
+            base_url="https://inference-api.nousresearch.com/v1",
+        )
+        assert route.billing_mode == "official_models_api"
+
+    def test_unknown_provider_still_unknown(self):
+        route = resolve_billing_route("mystery-model", provider="acme", base_url="")
+        assert route.billing_mode == "unknown"
+
+    def test_fireworks_glm_unaffected(self):
+        # fireworks glm entries existed before; zai branches must not shadow them
+        entry = get_pricing_entry(
+            "glm-5p2", provider="fireworks", base_url="https://api.fireworks.ai/v1"
+        )
+        assert entry is not None
+        assert entry.input_cost_per_million == Decimal("1.40")
+
+
+class TestFleetAuditScenario:
+    """The fleet-audit symptom: sessions on zai/ollama-cloud showed up as
+    'unknown pricing' in Hermes Insights. All fleet routes must resolve."""
+
+    def test_all_fleet_routes_resolve(self):
+        fleet = [
+            ("deepseek-v4-flash:0731", "ollama-cloud", "https://ollama.com/v1"),
+            ("deepseek-v4-pro:0813", "ollama-cloud", "https://ollama.com/v1"),
+            ("glm-5.2", "zai", "https://api.z.ai/api/coding/paas/v4"),
+            ("glm-5.3", "zai", "https://api.z.ai/api/coding/paas/v4"),
+        ]
+        for model, provider, base_url in fleet:
+            assert has_known_pricing(model, provider, base_url), (model, provider)


### PR DESCRIPTION
## Problem

Fleet audit finding: sessions on **Z.AI** (GLM Coding Plan) and **Ollama Cloud** show up as *unknown pricing* in Hermes Insights. In a 152-session sample, **82 had unknown pricing** — all on these two providers. `resolve_billing_route` has no branch for either, so `billing_mode` falls through to `"unknown"` and `has_known_pricing` returns False even though both are paid subscription seats where usage eats plan quota, not a metered per-token charge.

Notably, Hermes Agent is one of the officially listed GLM Coding Plan tools (docs.z.ai/devpack/overview), so this affects every Coding Plan user, not just our fleet.

## What this does

1. **Z.AI Coding Plan → `subscription_included`** ($0/token, same as openai-codex). Per the DevPack docs there are three Coding Plan endpoints — all covered:
   - `https://api.z.ai/api/coding/paas/v4` (OpenAI Chat)
   - `https://api.z.ai/api/v1` (OpenAI Responses)
   - `https://api.z.ai/api/anthropic` (Anthropic Messages)
   
   Detection is by `api.z.ai` host + path, so it survives provider renames in config.yaml.

2. **Ollama Cloud → `subscription_included`** — ollama.com host or `ollama-cloud` provider name. Ollama publishes usage levels per model against plan quota; there is no per-token meter to read.

3. **Z.AI pay-as-you-go → real pricing entries** — `_OFFICIAL_DOCS_PRICING` additions for the per-token endpoint (`api.z.ai/api/paas/v4`): GLM-5.2/5.1 ($1.40/$0.26/$4.40 per 1M in/cached/out), GLM-5, GLM-5-Turbo, GLM-4.7/4.6/4.5, GLM-4.7-FlashX, GLM-4.5-X, GLM-4.5-Air, GLM-4.5-AirX. Source: docs.z.ai/guides/overview/pricing (snapshot 2026-08).

4. **Local ollama deliberately stays unknown** — self-hosted compute has no per-token price; no behavior change.

## Testing

New `tests/agent/test_usage_pricing_zai_ollama.py` — 20 tests: all three Coding Plan endpoints, PAAS per-token pricing values, host-based detection under provider rename, local-ollama fallthrough, and regression guards on openrouter/nous/fireworks routes. All 20 pass; existing `test_usage_pricing.py` (40 tests) still green.

Fixes the 'unknown pricing' class of sessions for any GLM Coding Plan / Ollama Cloud user.