### PR TITLE
feat(gateway): Add Linear webhook signature validation

### DIFF
--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -1105,6 +1105,14 @@ class WebhookAdapter(BasePlatformAdapter):
         if gl_token:
             return _hmac_str_equal(gl_token, secret)
 
+        # Linear: linear-signature = <hex HMAC-SHA256 of raw body>
+        lin_sig = request.headers.get("linear-signature", "")
+        if lin_sig:
+            expected_lin = hmac.new(
+                secret.encode(), body, hashlib.sha256
+            ).hexdigest()
+            return _hmac_str_equal(lin_sig, expected_lin)
+
         # Generic V2: X-Webhook-Signature-V2 = <hex HMAC-SHA256 of "<timestamp>.<body>">
         #             X-Webhook-Timestamp = <unix seconds> (required for V2)
         # Checked independently of (and before) legacy V1 below — a sender

--- a/tests/gateway/test_webhook_adapter.py
+++ b/tests/gateway/test_webhook_adapter.py
@@ -104,6 +104,16 @@ def _generic_signature(body: bytes, secret: str) -> str:
     return hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
 
 
+def _linear_signature(body: bytes, secret: str) -> str:
+    """Compute linear-signature (plain HMAC-SHA256 hex) for *body*.
+
+    Linear signs the raw request body with the webhook signing key and
+    delivers the result in the ``linear-signature`` header — the same
+    algorithm as the generic V1 signature, under a vendor-specific header.
+    """
+    return hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
+
+
 def _generic_v2_signature(body: bytes, secret: str, timestamp: str) -> str:
     """Compute X-Webhook-Signature-V2 (HMAC-SHA256 of "<timestamp>.<body>")."""
     signed_content = timestamp.encode() + b"." + body
@@ -149,6 +159,7 @@ class TestValidateSignature:
             "X-Hub-Signature-256",
             "X-Gitlab-Token",
             "X-Webhook-Signature",
+            "linear-signature",
         ):
             req = _mock_request(headers={header: hostile})
             # Must return False, never raise.
@@ -277,6 +288,34 @@ class TestValidateSignature:
             }
         )
         assert adapter._validate_signature(req, body, secret) is True
+
+
+    def test_validate_linear_signature_valid(self):
+        """A Linear webhook with a correct linear-signature header validates."""
+        adapter = _make_adapter()
+        body = b'{"action":"create","type":"Issue","data":{"id":"BH-1"}}'
+        secret = "lin-wh-secret"
+        sig = _linear_signature(body, secret)
+        req = _mock_request(headers={"linear-signature": sig})
+        assert adapter._validate_signature(req, body, secret) is True
+
+    def test_validate_linear_signature_tampered_rejects(self):
+        """A Linear webhook whose body was altered after signing is rejected."""
+        adapter = _make_adapter()
+        body = b'{"action":"create","type":"Issue"}'
+        secret = "lin-wh-secret"
+        sig = _linear_signature(body, secret)
+        tampered = b'{"action":"delete","type":"Issue"}'
+        req = _mock_request(headers={"linear-signature": sig})
+        assert adapter._validate_signature(req, tampered, secret) is False
+
+    def test_validate_linear_signature_wrong_secret_rejects(self):
+        """A signature computed with a different key must not validate."""
+        adapter = _make_adapter()
+        body = b'{"action":"create"}'
+        sig = _linear_signature(body, "attacker-key")
+        req = _mock_request(headers={"linear-signature": sig})
+        assert adapter._validate_signature(req, body, "real-key") is False
 
 
 # ===================================================================


### PR DESCRIPTION
# Implement HMAC-SHA256 signature validation for Linear webhooks

Implement HMAC-SHA256 signature validation for incoming Linear webhooks using the `linear-signature` header. This ensures the authenticity and integrity of payloads received from Linear.

Fixes #87348.

## What does this PR do?

Adds HMAC-SHA256 signature verification for incoming Linear webhooks. Linear signs the raw request body with the webhook signing key and delivers the result in the `linear-signature` header. Hermes's webhook adapter (`gateway/platforms/webhook.py`) did not recognize this header, so any Linear route with a secret configured was rejected as "no recognized signature header" — forcing users to run Linear webhooks unauthenticated (`INSECURE_NO_AUTH`) or not use them at all.

This PR registers Linear's header name with the adapter's existing HMAC-SHA256 verifier. The algorithm Linear uses is already implemented (hex HMAC-SHA256 of the raw body); the gap was purely the missing header-name branch. It reuses the timing-safe `_hmac_str_equal` helper and adds no dependencies, so it's a minimal ~8-line change that restores authenticated Linear webhook support.

## Related Issue

Fixes #87348

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] 🔒 Security fix

## Changes Made

- `gateway/platforms/webhook.py` — added a `linear-signature` branch to `WebhookAdapter._validate_signature()`, placed after the GitLab branch and before the generic V2 branch. It computes the expected signature as `hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()` and compares against the `linear-signature` header using the existing timing-safe `_hmac_str_equal`.
- `tests/gateway/test_webhook_adapter.py` — added `_linear_signature()` helper plus three tests: valid signature accepted, tampered body rejected, and wrong-secret rejected. Also added `linear-signature` to the existing non-ASCII hostile-header test so the crash-safety case is covered.

## How to Test

1. Configure a Linear webhook with a signing key (Linear → Settings → API → Webhooks), pointing at a Hermes webhook route.
2. Subscribe a route with the same secret: `hermes webhook subscribe linear --secret <key>` (or set `secret` on the route in `webhook_subscriptions.json`).
3. Trigger a Linear event (create/update an issue, or post a comment).
4. Confirm the request is accepted and processed (previously it was rejected with "secret configured but no signature header found" / "no recognized signature header").
5. Negative check: send the same payload with a wrong `linear-signature` value and confirm it's rejected with a signature mismatch.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: <!-- macOS 26.5 -->

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

_No screenshots. Log evidence (before/after) can be supplied on request — the rejected-then-accepted delivery is visible in `gateway.log` when reproducing the steps above._
