### PR TITLE
fix(vision): bound local image reads during the read (port of block/goose#11114)

### DIFF
--- a/tests/tools/test_image_source.py
+++ b/tests/tools/test_image_source.py
@@ -99,6 +99,79 @@ class TestLocalBackend:
         assert res.data == svg_bytes
 
 
+class TestBoundedHostRead:
+    """The host file read is bounded DURING the read (port of block/goose#11114).
+
+    Path.read_bytes() materialized the whole file before _finalize's cap
+    check, so an oversized file — or a sparse file whose leading bytes look
+    like a PNG — buffered fully into memory first."""
+
+    @pytest.mark.asyncio
+    async def test_oversized_regular_file_rejected_without_full_read(
+        self, tmp_path, monkeypatch
+    ):
+        isrc = _reload(monkeypatch, tmp_path / "hermes")
+        monkeypatch.setenv("TERMINAL_ENV", "local")
+        big = tmp_path / "big.png"
+        # Sparse file: stat reports > cap but no disk is consumed.
+        with big.open("wb") as fh:
+            fh.write(PNG)
+            fh.truncate(isrc._MAX_INGEST_BYTES + 1)
+        with pytest.raises(isrc.SourceTooLarge):
+            await isrc.resolve_image_source(str(big), isrc.ResolveContext())
+
+    @pytest.mark.asyncio
+    async def test_read_is_bounded_even_when_stat_lies(self, tmp_path, monkeypatch):
+        """If stat under-reports (proc-like/streaming source), the read itself
+        must stop at cap+1 and reject, not buffer unboundedly."""
+        isrc = _reload(monkeypatch, tmp_path / "hermes")
+        img = tmp_path / "grows.png"
+        img.write_bytes(PNG)
+
+        real_stat = Path.stat
+
+        def lying_stat(self, **kw):
+            st = real_stat(self, **kw)
+            if self.name == "grows.png":
+                fake = SimpleNamespace(**{a: getattr(st, a) for a in dir(st) if a.startswith("st_")})
+                fake.st_size = 10  # claims tiny
+                return fake
+            return st
+
+        reads = []
+
+        class BoundedProbe:
+            """Wrap the opened file to record the max single read size."""
+
+            def __init__(self, fh):
+                self._fh = fh
+
+            def read(self, n=-1):
+                reads.append(n)
+                return self._fh.read(n)
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *a):
+                self._fh.close()
+
+        real_open = Path.open
+
+        def probed_open(self, mode="r", *a, **kw):
+            fh = real_open(self, mode, *a, **kw)
+            if self.name == "grows.png" and "b" in mode:
+                return BoundedProbe(fh)
+            return fh
+
+        monkeypatch.setattr(Path, "stat", lying_stat)
+        monkeypatch.setattr(Path, "open", probed_open)
+        res = await isrc.resolve_image_source(str(img), isrc.ResolveContext())
+        assert res.data == PNG
+        # The read must have been budgeted (cap+1), never unbounded (-1).
+        assert reads and all(n == isrc._MAX_INGEST_BYTES + 1 for n in reads)
+
+
 class TestNonLocalBackendConfinement:
     """The security model: under a sandbox backend, host reads are confined to
     the media caches; every other path is read inside the sandbox."""

--- a/tools/image_source.py
+++ b/tools/image_source.py
@@ -49,6 +49,36 @@ from typing import Optional
 _MAX_INGEST_BYTES = 50 * 1024 * 1024
 
 
+def _read_host_bytes_bounded(path: Path, src: str) -> bytes:
+    """Read a host file with the ingest cap enforced DURING the read.
+
+    ``Path.read_bytes()`` materializes the whole file before ``_finalize``'s
+    size check runs, so pointing vision_analyze at a multi-GB file (or a
+    sparse file whose ``stat`` size lies low, or a FIFO/devnode that streams
+    unbounded) buffered it all into host memory first. Reading through
+    ``file.read(cap+1)`` bounds the allocation at the cap regardless of what
+    the filesystem claims the size is; the +1 byte distinguishes "exactly at
+    the cap" from "over the cap" without a stat round-trip. Same pattern as
+    the in-sandbox exec-read (``head -c cap+1``) and block/goose#11114's
+    bounded reader.
+
+    ``stat().st_size`` is still consulted first as a cheap fast-fail for
+    regular files that honestly report huge sizes — no bytes are read at all
+    in that case.
+    """
+    try:
+        st_size = path.stat().st_size
+    except OSError:
+        st_size = 0
+    if st_size > _MAX_INGEST_BYTES:
+        raise SourceTooLarge("media exceeds size limit", src=src, origin="file")
+    with path.open("rb") as fh:
+        data = fh.read(_MAX_INGEST_BYTES + 1)
+    if len(data) > _MAX_INGEST_BYTES:
+        raise SourceTooLarge("media exceeds size limit", src=src, origin="file")
+    return data
+
+
 class ImageResolutionError(Exception):
     def __init__(self, message: str, *, src: str = "", origin: str = ""):
         super().__init__(message)
@@ -144,7 +174,7 @@ async def resolve_image_source(
                 raise_if_read_blocked(str(host_target))
             except ValueError as exc:
                 raise SourceUnsafe(str(exc), src=s, origin="file")
-        data = await asyncio.to_thread(host_target.read_bytes)
+        data = await asyncio.to_thread(_read_host_bytes_bounded, host_target, s)
         return _finalize(data, "", "file", s, permitted)
     if _is_local_terminal_backend():
         # Local backend: any path was host-readable, so a miss simply means


### PR DESCRIPTION
## Summary
Local image reads in `resolve_image_source` are now bounded during the read, so an oversized or hostile file can never buffer more than the 50 MiB ingest cap (+1 byte) into host memory.

Port of [block/goose#11114](https://github.com/block/goose/pull/11114) (`fix(providers): bound local image reads`).

Root cause: the host-side path used `Path.read_bytes()`, which materializes the entire file before `_finalize`'s cap check runs — pointing `vision_analyze` at a multi-GB file (or a sparse/streaming source whose `stat` size under-reports) buffered it all first, and only then rejected it. The sibling in-sandbox exec-read was already bounded (`head -c cap+1`); the host read was the one unbounded path.

## Changes
- `tools/image_source.py`: new `_read_host_bytes_bounded()` — `stat` fast-fail for honestly-huge regular files (zero bytes read), then a single `read(cap+1)` so the allocation is bounded regardless of what the filesystem claims; host read path switched to it.
- `tests/tools/test_image_source.py`: new `TestBoundedHostRead` — sparse oversized file rejected; probe test asserts the read is budgeted (`cap+1`, never unbounded `read()`) even when `stat` lies.

## Validation
| | Before | After |
|---|---|---|
| multi-GB file via vision | fully buffered, then rejected | rejected at stat, 0 bytes read |
| sparse/lying-stat source | fully buffered | read stops at cap+1 |
| `tests/tools/test_image_source.py` | — | 20 passed |
| sabotage run (old `read_bytes` restored) | — | probe test fails, as it must |

## Infographic

![Bounded local image reads](https://files.catbox.moe/mo7fig.png)
