### PR TITLE
fix(pricing): add GPT-5.4 family and GPT-5.2 entries to the official docs table

### DIFF
--- a/agent/usage_pricing.py
+++ b/agent/usage_pricing.py
@@ -194,6 +194,58 @@ _OFFICIAL_DOCS_PRICING: Dict[tuple[str, str], PricingEntry] = {
         source_url="https://openai.com/index/previewing-gpt-5-6-sol/",
         pricing_version="openai-gpt-5.6-2026-07",
     ),
+    # ── OpenAI GPT-5.4 / GPT-5.2 (snapshot 2026-08) ─────────────────────
+    # Numbers from the per-model docs pages (input / cached / output per
+    # 1M tokens). GPT-5.4/Pro 1.05M-context long-input surcharge (>272K
+    # prompts: 2x input / 1.5x output) is a serving-tier rule, not a table
+    # entry — not modeled here, same as 5.6 Fast mode.
+    # Sources: https://developers.openai.com/api/docs/models/gpt-5.4
+    #          https://developers.openai.com/api/docs/models/gpt-5.4-mini
+    (
+        "openai",
+        "gpt-5.4",
+    ): PricingEntry(
+        input_cost_per_million=Decimal("2.50"),
+        output_cost_per_million=Decimal("15.00"),
+        cache_read_cost_per_million=Decimal("0.25"),
+        source="official_docs_snapshot",
+        source_url="https://developers.openai.com/api/docs/models/gpt-5.4",
+        pricing_version="openai-pricing-2026-08",
+    ),
+    (
+        "openai",
+        "gpt-5.4-mini",
+    ): PricingEntry(
+        input_cost_per_million=Decimal("0.75"),
+        output_cost_per_million=Decimal("4.50"),
+        cache_read_cost_per_million=Decimal("0.075"),
+        source="official_docs_snapshot",
+        source_url="https://developers.openai.com/api/docs/models/gpt-5.4-mini",
+        pricing_version="openai-pricing-2026-08",
+    ),
+    (
+        "openai",
+        "gpt-5.4-nano",
+    ): PricingEntry(
+        input_cost_per_million=Decimal("0.20"),
+        output_cost_per_million=Decimal("1.25"),
+        cache_read_cost_per_million=Decimal("0.02"),
+        source="official_docs_snapshot",
+        source_url="https://developers.openai.com/api/docs/models/gpt-5.4-nano",
+        pricing_version="openai-pricing-2026-08",
+    ),
+    (
+        "openai",
+        "gpt-5.2",
+    ): PricingEntry(
+        input_cost_per_million=Decimal("1.75"),
+        output_cost_per_million=Decimal("14.00"),
+        cache_read_cost_per_million=Decimal("0.175"),
+        source="official_docs_snapshot",
+        source_url="https://developers.openai.com/api/docs/models/gpt-5.2",
+        pricing_version="openai-pricing-2026-08",
+    ),
+
     # ── Anthropic Claude 4.8 ─────────────────────────────────────────────
     # Same $5/$25 base pricing as 4.6/4.7.  Fast-mode variant is a separate
     # model ID with 2x premium (vs the 6x premium on older Opus generations).

--- a/tests/agent/test_usage_pricing_gpt54_family.py
+++ b/tests/agent/test_usage_pricing_gpt54_family.py
@@ -1,0 +1,37 @@
+"""Tests for GPT-5.4 / GPT-5.2 family pricing entries.
+
+Fleet audit finding (2026-08): sessions on openai-api gpt-5.4 /
+gpt-5.4-mini showed as unknown pricing in Hermes Insights because
+_OFFICIAL_DOCS_PRICING had no entries for the 5.4 generation — the
+table jumped from gpt-4.1 straight to gpt-5.6.
+"""
+
+from decimal import Decimal
+
+from agent.usage_pricing import get_pricing_entry, has_known_pricing
+
+
+def test_gpt54_family_entries_exist():
+    """Regression: the 5.4 generation must have pricing entries.
+
+    Before this fix, gpt-5.4 / gpt-5.4-mini sessions showed unknown cost
+    in Hermes Insights. Rates from the per-model docs pages (snapshot
+    2026-08).
+    """
+    expected = {
+        "gpt-5.4": ("2.50", "0.25", "15.00"),
+        "gpt-5.4-mini": ("0.75", "0.075", "4.50"),
+        "gpt-5.4-nano": ("0.20", "0.02", "1.25"),
+        "gpt-5.2": ("1.75", "0.175", "14.00"),
+    }
+    for model, (inp, cached, out) in expected.items():
+        entry = get_pricing_entry(model, provider="openai-api")
+        assert entry is not None, model
+        assert entry.input_cost_per_million == Decimal(inp), model
+        assert entry.output_cost_per_million == Decimal(out), model
+        assert entry.cache_read_cost_per_million == Decimal(cached), model
+
+
+def test_gpt54_family_has_known_pricing():
+    for model in ("gpt-5.4", "gpt-5.4-mini", "gpt-5.4-nano", "gpt-5.2"):
+        assert has_known_pricing(model, "openai-api", "https://api.openai.com/v1"), model


### PR DESCRIPTION
## Problem

Fleet audit finding: `_OFFICIAL_DOCS_PRICING` has no entries for the GPT-5.4 generation — the table jumps from gpt-4.1 straight to gpt-5.6. Sessions on `gpt-5.4` / `gpt-5.4-mini` show **unknown pricing** in Hermes Insights.

Found while fixing the same symptom for Z.AI / Ollama Cloud in #87360.

## What this adds

Four entries from the per-model docs pages (snapshot 2026-08, developers.openai.com/api/docs/models/):

| Model | Input | Cached | Output (per 1M) |
|---|---|---|---|
| gpt-5.4 | $2.50 | $0.25 | $15.00 |
| gpt-5.4-mini | $0.75 | $0.075 | $4.50 |
| gpt-5.4-nano | $0.20 | $0.02 | $1.25 |
| gpt-5.2 | $1.75 | $0.175 | $14.00 |

Notes:
- The 1.05M-context long-input surcharge (>272K tokens: 2x input / 1.5x output) is a serving-tier rule, not a table entry — same treatment as the existing 5.6 Fast-mode exclusion.
- Found while auditing: date-suffixed snapshot IDs (e.g. `gpt-5.4-2026-03-05`) don't resolve for **any** generation today, including 5.6 — out of scope here, flagging for maintainers.

## Testing

New `tests/agent/test_usage_pricing_gpt54_family.py` — regression (all four models resolve with exact rates) + `has_known_pricing` for the family. Full pricing suite green: 42/42.
