### PR TITLE
fix(mcp): fall back to ps --ppid when /proc children file is empty on WSL2

### DIFF
--- a/tests/tools/test_mcp_stability.py
+++ b/tests/tools/test_mcp_stability.py
@@ -3,6 +3,7 @@
 import asyncio
 import os
 import signal
+import sys
 from unittest.mock import patch, MagicMock
 
 import pytest
@@ -55,6 +56,98 @@ class TestMCPLoopExceptionHandler:
 # Fix 2: stdio PID tracking
 # ---------------------------------------------------------------------------
 
+
+class TestSnapshotChildPidsFallbacks:
+    """_snapshot_child_pids falls through /proc → ps → psutil on WSL2 empty reads."""
+
+    def test_proc_children_empty_falls_through_to_ps(self, monkeypatch, tmp_path):
+        """/proc children file readable but EMPTY → ps --ppid fallback used."""
+        import tools.mcp_tool as mcp_mod
+
+        # 1. Force the /proc read to return an empty file
+        empty_children = tmp_path / "children"
+        empty_children.write_text("")
+
+        _real_open = open
+
+        def fake_open(path, *args, **kwargs):
+            if str(path).startswith("/proc/") and str(path).endswith("/children"):
+                return _real_open(empty_children, *args, **kwargs)
+            return _real_open(path, *args, **kwargs)
+
+        monkeypatch.setattr(
+            "builtins.open", fake_open, raising=True
+        )
+
+        # 2. Mock the ps fallback to return a known PID set
+        fake_proc = MagicMock()
+        fake_proc.returncode = 0
+        fake_proc.stdout = "4242\n"
+        monkeypatch.setattr(
+            mcp_mod.subprocess, "run", lambda *a, **kw: fake_proc
+        )
+
+        result = mcp_mod._snapshot_child_pids()
+        assert result == {4242}
+
+    def test_proc_children_empty_ps_empty_falls_through_to_psutil(self, monkeypatch, tmp_path):
+        """/proc empty AND ps returns nothing → psutil fallback used."""
+        import tools.mcp_tool as mcp_mod
+
+        empty_children = tmp_path / "children"
+        empty_children.write_text("")
+
+        _real_open = open
+
+        def fake_open(path, *args, **kwargs):
+            if str(path).startswith("/proc/") and str(path).endswith("/children"):
+                return _real_open(empty_children, *args, **kwargs)
+            return _real_open(path, *args, **kwargs)
+
+        monkeypatch.setattr("builtins.open", fake_open, raising=True)
+
+        fake_proc = MagicMock()
+        fake_proc.returncode = 0
+        fake_proc.stdout = ""
+        monkeypatch.setattr(
+            mcp_mod.subprocess, "run", lambda *a, **kw: fake_proc
+        )
+
+        fake_psutil = MagicMock()
+        fake_child = MagicMock()
+        fake_child.pid = 7777
+        fake_psutil.Process.return_value.children.return_value = [fake_child]
+        monkeypatch.setitem(sys.modules, "psutil", fake_psutil)
+
+        result = mcp_mod._snapshot_child_pids()
+        assert result == {7777}
+
+    def test_proc_children_populated_skips_fallbacks(self, monkeypatch, tmp_path):
+        """/proc children with data → returned directly, no subprocess spawn."""
+        import tools.mcp_tool as mcp_mod
+
+        children_file = tmp_path / "children"
+        children_file.write_text("1111 2222\n")
+
+        _real_open = open
+
+        def fake_open(path, *args, **kwargs):
+            if str(path).startswith("/proc/") and str(path).endswith("/children"):
+                return _real_open(children_file, *args, **kwargs)
+            return _real_open(path, *args, **kwargs)
+
+        monkeypatch.setattr("builtins.open", fake_open, raising=True)
+
+        # If the code tried to spawn ps, this would raise (mock returns garbage)
+        def boom(*a, **kw):
+            raise AssertionError("subprocess.run must not be called when /proc has data")
+
+        monkeypatch.setattr(mcp_mod.subprocess, "run", boom)
+
+        result = mcp_mod._snapshot_child_pids()
+        assert result == {1111, 2222}
+
+
 class TestStdioPidTracking:
     """_snapshot_child_pids and _stdio_pids track subprocess PIDs."""
 
@@ -65,6 +158,7 @@ class TestStdioPidTracking:
         # All elements should be ints
         for pid in result:
             assert isinstance(pid, int)
+
 
 
     def test_kill_orphaned_handles_dead_pids(self):

--- a/tests/tools/test_mcp_stability.py
+++ b/tests/tools/test_mcp_stability.py
@@ -79,19 +79,23 @@ class TestSnapshotChildPidsFallbacks:
             "builtins.open", fake_open, raising=True
         )
 
-        # 2. Mock the ps fallback to return a known PID set
+        # 2. Mock the ps fallback to return a known PID set.  The mock
+        # mimics the real behavior: ps lists ITSELF (its ppid is the
+        # caller), so stdout contains the child pid plus the ps pid.
         fake_proc = MagicMock()
+        fake_proc.pid = 9999  # pid of the spawned ps itself
         fake_proc.returncode = 0
-        fake_proc.stdout = "4242\n"
+        fake_proc.communicate.return_value = ("4242\n9999\n", None)
         monkeypatch.setattr(
-            mcp_mod.subprocess, "run", lambda *a, **kw: fake_proc
+            mcp_mod.subprocess, "Popen", lambda *a, **kw: fake_proc
         )
 
         result = mcp_mod._snapshot_child_pids()
+        # The ps self-pid must be excluded from the snapshot.
         assert result == {4242}
 
     def test_proc_children_empty_ps_empty_falls_through_to_psutil(self, monkeypatch, tmp_path):
-        """/proc empty AND ps returns nothing → psutil fallback used."""
+        """ps returns only its own pid (no real children) → treated as empty, psutil used."""
         import tools.mcp_tool as mcp_mod
 
         empty_children = tmp_path / "children"
@@ -107,10 +111,11 @@ class TestSnapshotChildPidsFallbacks:
         monkeypatch.setattr("builtins.open", fake_open, raising=True)
 
         fake_proc = MagicMock()
+        fake_proc.pid = 9999
         fake_proc.returncode = 0
-        fake_proc.stdout = ""
+        fake_proc.communicate.return_value = ("9999\n", None)
         monkeypatch.setattr(
-            mcp_mod.subprocess, "run", lambda *a, **kw: fake_proc
+            mcp_mod.subprocess, "Popen", lambda *a, **kw: fake_proc
         )
 
         fake_psutil = MagicMock()
@@ -140,12 +145,44 @@ class TestSnapshotChildPidsFallbacks:
 
         # If the code tried to spawn ps, this would raise (mock returns garbage)
         def boom(*a, **kw):
-            raise AssertionError("subprocess.run must not be called when /proc has data")
+            raise AssertionError("subprocess.Popen must not be called when /proc has data")
 
-        monkeypatch.setattr(mcp_mod.subprocess, "run", boom)
+        monkeypatch.setattr(mcp_mod.subprocess, "Popen", boom)
 
         result = mcp_mod._snapshot_child_pids()
         assert result == {1111, 2222}
+
+    def test_ps_fallback_excludes_ps_own_pid(self, monkeypatch, tmp_path):
+        """ps --ppid lists itself (its PPID is the caller) — the ps subprocess's
+        own pid must never leak into the snapshot (review point on #87367)."""
+        import tools.mcp_tool as mcp_mod
+
+        empty_children = tmp_path / "children"
+        empty_children.write_text("")
+
+        _real_open = open
+
+        def fake_open(path, *args, **kwargs):
+            if str(path).startswith("/proc/") and str(path).endswith("/children"):
+                return _real_open(empty_children, *args, **kwargs)
+            return _real_open(path, *args, **kwargs)
+
+        monkeypatch.setattr("builtins.open", fake_open, raising=True)
+
+        # Real-world shape: stdout lists the actual child AND the ps
+        # process itself.  The self-pid differs per ps invocation (fresh
+        # pid each spawn), so it cannot cancel out across snapshots.
+        fake_proc = MagicMock()
+        fake_proc.pid = 9999
+        fake_proc.returncode = 0
+        fake_proc.communicate.return_value = ("4242\n9999\n", None)
+        monkeypatch.setattr(
+            mcp_mod.subprocess, "Popen", lambda *a, **kw: fake_proc
+        )
+
+        result = mcp_mod._snapshot_child_pids()
+        assert 9999 not in result
+        assert result == {4242}
 
 
 class TestStdioPidTracking:

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -107,6 +107,7 @@ import os
 import random
 import re
 import shutil
+import subprocess
 import sys
 import threading
 import time
@@ -4741,17 +4742,36 @@ _stdio_pgids: Dict[int, int] = {}  # pid -> pgid
 def _snapshot_child_pids() -> set:
     """Return a set of current child process PIDs.
 
-    Uses /proc on Linux, falls back to psutil, then empty set.
-    Used by _run_stdio to identify the subprocess spawned by stdio_client.
+    Uses /proc on Linux, falls back to `ps --ppid`, then psutil, then
+    empty set.  Used by _run_stdio to identify the subprocess spawned by
+    stdio_client.
     """
     my_pid = os.getpid()
 
-    # Linux: read from /proc
+    # Linux: read from /proc.  Some kernels (notably WSL2) can return a
+    # readable but EMPTY children file — treat that as "no data" rather
+    # than "no children" and fall through to the ps/psutil fallbacks.
     try:
         children_path = f"/proc/{my_pid}/task/{my_pid}/children"
         with open(children_path, encoding="utf-8") as f:
-            return {int(p) for p in f.read().split() if p.strip()}
+            pids = {int(p) for p in f.read().split() if p.strip()}
+        if pids:
+            return pids
     except (FileNotFoundError, OSError, ValueError):
+        pass
+
+    # Fallback: ps --ppid (works where /proc children data is missing or
+    # empty, including WSL2 kernels that do not maintain that file)
+    try:
+        out = subprocess.run(
+            ["ps", "--ppid", str(my_pid), "-o", "pid="],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        if out.returncode == 0 and out.stdout.strip():
+            return {int(p) for p in out.stdout.split() if p.strip()}
+    except Exception:
         pass
 
     # Fallback: psutil

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -4761,18 +4761,36 @@ def _snapshot_child_pids() -> set:
         pass
 
     # Fallback: ps --ppid (works where /proc children data is missing or
-    # empty, including WSL2 kernels that do not maintain that file)
+    # empty, including WSL2 kernels that do not maintain that file).
+    # Spawned via Popen so the ps subprocess's own PID is known: ps lists
+    # itself (its PPID is my_pid), so subtract it from the result — a
+    # snapshot consumer must never see a transient pid that is already
+    # gone by the time it inspects the set.
+    ps_proc = None
     try:
-        out = subprocess.run(
+        ps_proc = subprocess.Popen(
             ["ps", "--ppid", str(my_pid), "-o", "pid="],
-            capture_output=True,
+            stdout=subprocess.PIPE,
             text=True,
-            timeout=5,
         )
-        if out.returncode == 0 and out.stdout.strip():
-            return {int(p) for p in out.stdout.split() if p.strip()}
+        out, _ = ps_proc.communicate(timeout=5)
+        if ps_proc.returncode == 0:
+            # ps lists itself (its PPID is the caller) — subtract the ps
+            # subprocess's own pid.  If nothing remains, fall through to
+            # psutil for a second opinion (matches the pre-fallback
+            # semantics of treating an empty answer as "no data").
+            pids = {int(p) for p in out.split() if p.strip()} - {ps_proc.pid}
+            if pids:
+                return pids
     except Exception:
-        pass
+        # Reap the child on timeout/decode errors so it cannot linger as
+        # a zombie (best-effort; the snapshot itself stays best-effort).
+        if ps_proc is not None:
+            try:
+                ps_proc.kill()
+                ps_proc.communicate(timeout=1)
+            except Exception:
+                pass
 
     # Fallback: psutil
     try:


### PR DESCRIPTION
## Problem

`_snapshot_child_pids()` in `tools/mcp_tool.py` reads `/proc/<pid>/task/<pid>/children` and returned the parsed set unconditionally. On some kernels — notably WSL2 — that file is readable but **empty**, so the function returned `set()` directly and the psutil fallback was never reached (`tools/mcp_tool.py:4751-4753` at the time of #32962's review). Consequence: the stdio spawn PID delta was always empty, so orphaned MCP subprocesses were never tracked into `_stdio_pids` and never reaped on reconnect/shutdown — the original "Killing stale mcp-ssh-manager PIDs" loop from the WSL2 report.

## Solution

Minimal, focused change in `_snapshot_child_pids()`:

1. An empty `/proc` children read is treated as **"no data", not "no children"** — the function falls through instead of returning.
2. New fallback between /proc and psutil: `ps --ppid <pid> -o pid=`, which enumerates children correctly on WSL2 kernels that do not maintain the children file.

Current parking, reconnect, authentication-recovery, circuit-breaker, and `_rpc_lock` semantics are untouched.

## Tests

Three regression tests added to `TestSnapshotChildPidsFallbacks` (`tests/tools/test_mcp_stability.py`):

- `/proc` children readable but empty → `ps --ppid` fallback is used (mocked `subprocess.run`)
- `/proc` empty AND `ps` returns nothing → psutil fallback is used
- `/proc` children populated → returned directly, no `subprocess.run` call (asserted via sentinel)

Full file: 17 passed + the 3 new; the 2 remaining failures (`test_run_stdio_reaps_orphans_before_spawn`, `test_reload_timeout_does_not_block_forever`) fail identically on unpatched `origin/main` in this environment — missing optional deps (`stdio_client` mock target / `rich`), unrelated to this change.

## Relationship to prior PRs

This is the salvage of the focused PID-tracking portion of #32962 per the triage review there — #32962 will be closed in favor of this PR. The `ps --ppid` approach also mirrors closed #30689 (the focused reference implementation superseded by #32962 at the time).