### PR TITLE
fix(pricing): strip date suffixes when resolving snapshot model ids

### DIFF
--- a/agent/usage_pricing.py
+++ b/agent/usage_pricing.py
@@ -1182,6 +1182,18 @@ def _lookup_official_docs_pricing(route: BillingRoute) -> Optional[PricingEntry]
             entry = _OFFICIAL_DOCS_PRICING.get((route.provider, normalized))
             if entry:
                 return entry
+    # Vendor snapshot ids pin a dated variant of a base model —
+    # gpt-5.4-2026-03-05, claude-opus-4-8-20260801,
+    # gpt-5.6-sol-2026-07-09 — and bill at the base model's rates (only the
+    # weights are frozen, never the price). Strip the trailing date in both
+    # documented formats (ISO with dashes, and the compact form Anthropic
+    # uses) and retry on the base before giving up, so pinned sessions
+    # don't price as unknown.
+    stripped = re.sub(r"-\d{4}-\d{2}-\d{2}$|-\d{8}$", "", model)
+    if stripped != model:
+        entry = _OFFICIAL_DOCS_PRICING.get((route.provider, stripped))
+        if entry:
+            return entry
     return None
 
 

--- a/tests/agent/test_usage_pricing_snapshot_ids.py
+++ b/tests/agent/test_usage_pricing_snapshot_ids.py
@@ -1,0 +1,50 @@
+"""Tests for snapshot-id date-suffix stripping in pricing lookups.
+
+Fleet audit finding (2026-08): vendor snapshot ids — gpt-5.6-sol-2026-07-09,
+gpt-5.4-2026-03-05, claude-opus-4-8-20260801 — resolved to no pricing entry
+because _OFFICIAL_DOCS_PRICING is keyed on base names only. Sessions pinned
+to a snapshot showed unknown cost in Hermes Insights even though snapshots
+bill at the base model's rates.
+"""
+
+from agent.usage_pricing import get_pricing_entry
+
+
+# (provider, base, snapshot) — snapshot must resolve to the base's rates.
+SNAPSHOT_MATRIX = [
+    ("openai", "gpt-5.6-sol", "gpt-5.6-sol-2026-07-09"),       # ISO dashed
+    ("openai", "gpt-5.6-luna", "gpt-5.6-luna-2026-07-09"),     # ISO dashed
+    ("openai", "o3", "o3-2025-04-16"),                          # ISO dashed
+    ("openai", "gpt-4.1", "gpt-4.1-2025-04-14"),               # ISO dashed
+    ("openai", "gpt-4o", "gpt-4o-2024-11-20"),                 # ISO dashed
+    ("anthropic", "claude-opus-4-8", "claude-opus-4-8-20260801"),  # compact
+]
+
+
+def test_snapshot_ids_bill_at_base_rates():
+    """Invariant: a dated snapshot of a base model prices identically to the
+    base — only the weights are frozen, never the price."""
+    for provider, base, snapshot in SNAPSHOT_MATRIX:
+        base_entry = get_pricing_entry(base, provider=provider)
+        snap_entry = get_pricing_entry(snapshot, provider=provider)
+        assert snap_entry is not None, snapshot
+        assert base_entry is not None, base
+        assert snap_entry.input_cost_per_million == base_entry.input_cost_per_million, snapshot
+        assert snap_entry.output_cost_per_million == base_entry.output_cost_per_million, snapshot
+        assert snap_entry.cache_read_cost_per_million == base_entry.cache_read_cost_per_million, snapshot
+
+
+def test_dated_table_keys_still_direct_hit():
+    """The table carries some dated keys natively (claude-opus-4-7-20250507).
+    Direct lookup must keep winning — stripping is a fallback, not a
+    replacement."""
+    entry = get_pricing_entry("claude-opus-4-7-20250507", provider="anthropic")
+    assert entry is not None
+    assert entry.input_cost_per_million is not None
+
+
+def test_unknown_model_stays_unknown():
+    """Negative control: an 8-digit suffix must not make an unknown model
+    resolve. Stripping only retries; it never invents pricing."""
+    assert get_pricing_entry("no-such-model-12345678", provider="openai") is None
+    assert get_pricing_entry("no-such-model-2026-01-01", provider="openai") is None


### PR DESCRIPTION
## Problem

Found during the fleet pricing audit (#87360, #87365): vendor **snapshot ids** resolve to no pricing entry for every provider, so sessions pinned to a dated snapshot show **unknown cost** in Hermes Insights even though snapshots bill at the base model's rates.

```
gpt-5.6-sol-2026-07-09  -> None   (base gpt-5.6-sol is in the table)
o3-2025-04-16           -> None
gpt-4.1-2025-04-14      -> None
claude-opus-4-8-20260801 -> None  (base claude-opus-4-8 is in the table)
```

`_lookup_official_docs_pricing` has per-provider normalizers (Anthropic dot-notation, Bedrock region prefixes + trailing `-v\d+`/`:\d+`/`-\d{8}` components), but no generic date-suffix fallback for OpenAI/Z.AI/DeepSeek/Gemini snapshot ids.

## Fix

Strip the trailing date in both documented formats — ISO dashed (`-2026-03-05`, OpenAI) and compact (`-20260801`, Anthropic) — and retry the base key. Runs **last**, after direct lookup and provider normalizers, so natively-dated table keys (e.g. `claude-opus-4-7-20250507`) keep winning on direct hit.

## Testing

`tests/agent/test_usage_pricing_snapshot_ids.py`:
- **Invariant matrix**: 6 snapshot ids across OpenAI + Anthropic must bill identically to their base entries (input/output/cache-read).
- **Direct-hit precedence**: natively-dated keys still resolve via direct lookup.
- **Negative control**: unknown models with date suffixes stay unknown — stripping retries, never invents.

Full pricing suite green: 43/43.
