### PR TITLE
feat(tui_gateway): announce session mirroring and stamp turn origins on the wire

### DIFF
--- a/tests/fixtures/session-resume-active-turn.json
+++ b/tests/fixtures/session-resume-active-turn.json
@@ -25,5 +25,6 @@
   "session_key": "stored-running",
   "started_at": 1700000000.0,
   "status": "working",
-  "turn_started_at": 1700000123.5
+  "turn_started_at": 1700000123.5,
+  "watching": false
 }

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -5294,27 +5294,60 @@ def test_finalize_session_closes_slash_worker(monkeypatch):
 
 
 def test_close_transport_rebinds_session_to_remaining_viewer(monkeypatch):
-    """Closing a pop-out window's transport must re-bind the session to a
-    still-open window instead of stranding it on the drop sentinel (#83716)."""
+    """Closing a pop-out window's transport must leave the session with the
+    still-open window instead of stranding it on the drop sentinel (#83716).
+
+    The rebind #83716 added is gone; multi-client fan-out subsumes it. Both
+    windows are attached to the slot at once, so the pop-out is a fan-out peer
+    rather than a viewer waiting to be promoted, and closing it detaches that
+    peer and collapses the slot back onto the main window. This pins the same
+    guarantee through the mechanism that replaced the rebind: the session is
+    not parked, not reaped, not handed to the orphan reaper, and the surviving
+    window keeps receiving frames.
+    """
     reap_calls = []
     monkeypatch.setattr(server, "_schedule_ws_orphan_reap", lambda sid: reap_calls.append(sid))
 
     class _LiveTransport:
-        def write(self, *a, **k):
+        def __init__(self):
+            self.frames = []
+
+        def write(self, obj=None, *a, **k):
+            self.frames.append(obj)
             return True
 
     main = _LiveTransport()
     popout = _LiveTransport()
-    session = _session(transport=popout, running=False)
+    session = _session(transport=None, running=False)
+    # Build the state the way production does: every window that resumes goes
+    # through _live_session_payload, which attaches it into the slot and then
+    # stamps it into the viewers registry.
+    server._attach_session_transport(session, main)
+    server._attach_session_transport(session, popout)
     session["viewers"] = {main: 100.0, popout: 200.0}
     server._sessions["multi-sid"] = session
+    assert isinstance(session["transport"], server.FanoutTransport)
 
-    reaped, detached = server._close_sessions_for_transport(popout)
+    try:
+        reaped, detached = server._close_sessions_for_transport(popout)
 
-    assert reaped == 0 and detached == 0
-    assert session["transport"] is main
-    assert "multi-sid" not in reap_calls
-    assert server._ws_session_is_orphaned(session) is False
+        assert reaped == 0 and detached == 0
+        # One peer left, so the fan-out collapses back to the bare transport —
+        # the slot is indistinguishable from a session that never fanned out.
+        assert session["transport"] is main
+        assert "multi-sid" not in reap_calls
+        assert server._ws_session_is_orphaned(session) is False
+
+        # And it is still a working stream, not just a surviving reference.
+        server._emit("message.delta", "multi-sid", {"text": "still here"})
+        assert [(f.get("params") or {}).get("type") for f in main.frames] == [
+            "message.delta"
+        ]
+        assert popout.frames == []
+    finally:
+        # The fake slot must not outlive the test: _sessions is module state and
+        # later sweeps would walk it.
+        server._sessions.pop("multi-sid", None)
 
 
 def test_close_transport_detaches_when_no_viewers_remain(monkeypatch):
@@ -5340,7 +5373,15 @@ def test_close_transport_detaches_when_no_viewers_remain(monkeypatch):
 
 
 def test_close_transport_skips_dead_remaining_viewers(monkeypatch):
-    """A viewer whose socket is already dead must not win the re-bind."""
+    """A viewer whose socket is already dead must not hold the session open.
+
+    #83716's rebind refused to hand the session to a dead viewer; fan-out
+    membership keeps that filter through _transport_is_live_peer, which is what
+    decides whether anything survives the departing client. Both windows are
+    ATTACHED here, which is the state production builds — a viewer that was
+    never attached leaves the slot single-client and exercises the ordinary park
+    path instead of this one.
+    """
     reap_calls = []
     monkeypatch.setattr(server, "_schedule_ws_orphan_reap", lambda sid: reap_calls.append(sid))
 
@@ -5349,17 +5390,25 @@ def test_close_transport_skips_dead_remaining_viewers(monkeypatch):
             return True
 
     dead = _LiveTransport()
+    popout = _LiveTransport()
+    session = _session(transport=None, running=False)
+    server._attach_session_transport(session, dead)
+    server._attach_session_transport(session, popout)
+    session["viewers"] = {dead: 100.0, popout: 200.0}
+    assert isinstance(session["transport"], server.FanoutTransport)
+    # The socket goes away without a disconnect reaching the gateway; the latch
+    # _transport_is_dead reads is the only trace it leaves behind.
     dead._closed = True
-    owner = _LiveTransport()
-    session = _session(transport=owner, running=False)
-    session["viewers"] = {dead: 100.0, owner: 200.0}
     server._sessions["dead-viewer-sid"] = session
 
-    reaped, detached = server._close_sessions_for_transport(owner)
+    try:
+        reaped, detached = server._close_sessions_for_transport(popout)
 
-    assert detached == 1
-    assert session["transport"] is server._detached_ws_transport
-    assert reap_calls == ["dead-viewer-sid"]
+        assert reaped == 0 and detached == 1
+        assert session["transport"] is server._detached_ws_transport
+        assert reap_calls == ["dead-viewer-sid"]
+    finally:
+        server._sessions.pop("dead-viewer-sid", None)
 
 
 def test_live_session_payload_registers_transport_as_viewer():

--- a/tests/tui_gateway/test_multi_client_fanout.py
+++ b/tests/tui_gateway/test_multi_client_fanout.py
@@ -656,6 +656,38 @@ def test_queued_prompt_drain_keeps_both_clients_attached(monkeypatch):
     assert b.types() == ["message.delta"]
 
 
+def test_queued_prompt_drain_skips_a_queuer_that_disconnected(monkeypatch):
+    """B goes away while its prompt waits: the prompt runs, the dead pin does not.
+
+    Attaching a transport whose client already left would pin a dead peer into
+    the slot until the first failed write prunes it. A keeps its stream and
+    stays the only attached client.
+    """
+    dispatched = []
+    monkeypatch.setattr(
+        server,
+        "_run_prompt_submit",
+        lambda rid, sid, _session, text, **kw: dispatched.append((rid, text)),
+    )
+
+    a, b = _FakeClient("a"), _FakeClient("b")
+    session = _session(transport=a)
+    server._enqueue_prompt(session, "from B", b)
+    b._closed = True  # what _transport_is_dead reads: B's socket went away
+    server._sessions["sid"] = session
+    try:
+        assert server._drain_queued_prompt("drain", "sid", session) is True
+        server._emit("message.delta", "sid", {"text": "drained answer"})
+    finally:
+        server._sessions.pop("sid", None)
+
+    assert dispatched == [("drain", "from B")]  # drain semantics unchanged
+    assert session["transport"] is a
+    assert server._session_transport_contains(session, b) is False
+    assert a.types() == ["message.delta"]
+    assert b.types() == []
+
+
 def test_queued_prompt_drain_still_rebinds_a_single_client_session(monkeypatch):
     """(j) Control: with one client the drain lands on the queuer's transport."""
     monkeypatch.setattr(server, "_run_prompt_submit", lambda *a, **k: None)

--- a/tests/tui_gateway/test_multi_client_fanout.py
+++ b/tests/tui_gateway/test_multi_client_fanout.py
@@ -327,6 +327,197 @@ def test_a_fanout_with_no_live_peer_is_dead():
     assert server._transport_is_dead(FanoutTransport()) is True
 
 
+def test_steer_authority_recognizes_the_exact_client_inside_a_fanout():
+    """Wrapping attached peers must not revoke the commissioning peer's authority."""
+    owner, watcher, stranger = (
+        _FakeClient("owner"),
+        _FakeClient("watcher"),
+        _FakeClient("stranger"),
+    )
+    session = _session(transport=FanoutTransport(owner, watcher))
+    server._sessions["sid"] = session
+    try:
+        token = server.bind_transport(owner)
+        try:
+            assert server._current_session_steer_authority("sid") == (owner, session)
+        finally:
+            server.reset_transport(token)
+
+        token = server.bind_transport(stranger)
+        try:
+            assert server._current_session_steer_authority("sid") == (None, None)
+        finally:
+            server.reset_transport(token)
+    finally:
+        server._sessions.pop("sid", None)
+
+
+def test_steer_authority_is_granted_to_an_attached_watcher():
+    """A client that attached to watch a session may also steer its subagents.
+
+    This is INTENTIONAL and wider than the pre-fan-out rule, which admitted only
+    whichever client happened to hold the transport slot. A mirrored session has
+    no single owner in that slot, so authority is membership in it. Narrowing
+    this back to the commissioning peer would need a per-subagent record of who
+    commissioned it, which this change does not add; the widening is stated in
+    the pull request description, and this test pins it so it cannot be changed
+    silently in either direction.
+    """
+    owner, watcher, stranger = (
+        _FakeClient("owner"),
+        _FakeClient("watcher"),
+        _FakeClient("stranger"),
+    )
+    session = _session(transport=owner)
+    server._attach_session_transport(session, watcher)
+    solo = _session(transport=owner)
+    server._sessions["sid"] = session
+    server._sessions["solo"] = solo
+    try:
+        token = server.bind_transport(watcher)
+        try:
+            assert server._current_session_steer_authority("sid") == (watcher, session)
+            # Control: on a single-client session the same watcher is a stranger,
+            # so the widening reaches attached clients and nobody else.
+            assert server._current_session_steer_authority("solo") == (None, None)
+        finally:
+            server.reset_transport(token)
+
+        token = server.bind_transport(stranger)
+        try:
+            assert server._current_session_steer_authority("sid") == (None, None)
+        finally:
+            server.reset_transport(token)
+    finally:
+        server._sessions.pop("sid", None)
+        server._sessions.pop("solo", None)
+
+
+# ── browser-control session ownership ──────────────────────────────────────
+#
+# The four browser.controller.* handlers gate on the session slot exactly as
+# subagent.steer did, so fan-out breaks them the same way and the fix is the
+# same predicate. These tests pin the gate itself: they assert on the ownership
+# error message and stop at the NEXT gate ("no controller registered for this
+# session"), so a later broker change cannot make them pass vacuously.
+
+_CONTROLLER_IDENTITY = {"user_id": "user-fixture", "provider": "provider-fixture"}
+_NOT_OWNED = "session is not owned by this transport"
+_NO_CONTROLLER = "no controller registered for this session"
+
+
+def _controller_client(name: str) -> _FakeClient:
+    """A fan-out client that also carries a server-authenticated identity."""
+    client = _FakeClient(name)
+    client.auth_identity = dict(_CONTROLLER_IDENTITY)
+    return client
+
+
+def _controller_rpc(transport, method_name: str, **params) -> dict:
+    return server.dispatch(
+        {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": method_name,
+            "params": params,
+        },
+        transport,
+    )
+
+
+def _error_message(response: dict) -> str | None:
+    return (response.get("error") or {}).get("message")
+
+
+def test_browser_control_ownership_gate_admits_a_peer_inside_a_fanout():
+    """Wrapping attached peers must not revoke browser control for all of them."""
+    owner, watcher, stranger = (
+        _controller_client("owner"),
+        _controller_client("watcher"),
+        _controller_client("stranger"),
+    )
+    session = _session(transport=FanoutTransport(owner, watcher), profile="default")
+    server._sessions["sid"] = session
+    try:
+        # The peer that would have registered the controller clears the
+        # ownership gate and stops at the next one.
+        assert _error_message(_controller_rpc(owner, "browser.controller.heartbeat", session_id="sid")) == _NO_CONTROLLER
+        # Widened, exactly as the steer conversion widened steer: any attached
+        # peer clears the session gate. The broker's is_owner check below it is
+        # what still refuses a peer that did not register the controller.
+        assert _error_message(_controller_rpc(watcher, "browser.controller.heartbeat", session_id="sid")) == _NO_CONTROLLER
+        # An unattached client is still refused at the ownership gate.
+        assert _error_message(_controller_rpc(stranger, "browser.controller.heartbeat", session_id="sid")) == _NOT_OWNED
+    finally:
+        server._sessions.pop("sid", None)
+
+
+def test_browser_control_ownership_gate_is_unchanged_for_a_single_client():
+    """Control: a bare slot still compares by identity on all four handlers."""
+    owner, stranger = _controller_client("owner"), _controller_client("stranger")
+    session = _session(transport=owner, profile="default")
+    server._sessions["solo"] = session
+    try:
+        for method_name in (
+            "browser.controller.heartbeat",
+            "browser.controller.result",
+            "browser.controller.detach",
+        ):
+            assert _error_message(_controller_rpc(stranger, method_name, session_id="solo")) == _NOT_OWNED
+        assert _error_message(_controller_rpc(owner, "browser.controller.heartbeat", session_id="solo")) == _NO_CONTROLLER
+    finally:
+        server._sessions.pop("solo", None)
+
+
+def test_browser_controller_registers_and_detaches_inside_a_fanout(monkeypatch):
+    """End to end: registration on a mirrored session, then a clean detach."""
+    from gateway import browser_control_broker
+
+    monkeypatch.setattr(
+        "gateway.browser_control_broker.browser_control_enabled", lambda: True
+    )
+    owner, watcher, stranger = (
+        _controller_client("owner"),
+        _controller_client("watcher"),
+        _controller_client("stranger"),
+    )
+    session = _session(transport=FanoutTransport(owner, watcher), profile="default")
+    server._sessions["sid"] = session
+    registration = {}
+    try:
+        registration = _controller_rpc(
+            owner,
+            "browser.controller.register",
+            session_id="sid",
+            controller_id="controller-fixture",
+            browser_profile_id="browser-profile-fixture",
+            capabilities=["controller.noop"],
+            protocol_version=browser_control_broker.BROWSER_CONTROL_PROTOCOL_VERSION,
+        )
+        assert registration.get("error") is None, registration
+        assert registration["result"]["scope"]["session_id"] == "sid"
+
+        # The registering peer owns the controller; the fan-out peer that did
+        # not register clears the session gate and is refused by the broker.
+        assert _controller_rpc(owner, "browser.controller.heartbeat", session_id="sid")["result"] == {"ok": True}
+        assert _error_message(_controller_rpc(watcher, "browser.controller.heartbeat", session_id="sid")) == "controller is not owned by this transport"
+        assert _error_message(_controller_rpc(stranger, "browser.controller.heartbeat", session_id="sid")) == _NOT_OWNED
+
+        detached = _controller_rpc(owner, "browser.controller.detach", session_id="sid")
+        assert detached.get("error") is None, detached
+    finally:
+        if registration.get("result"):
+            broker = browser_control_broker.get_browser_control_broker()
+            scope = broker.scope_for_session(
+                session_id="sid",
+                principal_id=registration["result"]["scope"]["principal_id"],
+                transport_family=registration["result"]["scope"]["transport_family"],
+            )
+            if scope is not None:
+                broker.detach(scope, notify_controller=False)
+        server._sessions.pop("sid", None)
+
+
 # ── event delivery ─────────────────────────────────────────────────────────
 
 

--- a/tests/tui_gateway/test_multi_client_fanout.py
+++ b/tests/tui_gateway/test_multi_client_fanout.py
@@ -1,0 +1,813 @@
+"""A session streams to EVERY attached client, not just the newest one.
+
+Before this, ``session["transport"]`` held exactly one client and every
+``prompt.submit`` / ``session.resume`` / ``session.activate`` / queued-prompt
+drain rebound it — so a second client either saw nothing, stole the stream from
+the first, or silenced the turn the first was reading. The slot now holds a
+``FanoutTransport`` as soon as a second client attaches, and the disconnect path
+detaches instead of parking whenever another client is still there.
+
+Single-client behaviour is the control condition throughout: with one client
+attached the slot holds the bare transport and every path behaves exactly as it
+did before fan-out existed.
+"""
+
+import threading
+import types
+
+from tui_gateway import server
+from tui_gateway.transport import FanoutTransport
+
+
+class _FakeClient:
+    """A connected client: records the frames it receives.
+
+    ``ok`` False models a peer that has gone away (``write`` returns False, the
+    gateway's peer-gone signal); ``boom`` models a wedged peer whose write
+    raises. Both must be pruned without disturbing the healthy clients.
+    """
+
+    def __init__(self, name: str, *, ok: bool = True, boom: bool = False) -> None:
+        self.name = name
+        self.frames: list[dict] = []
+        self.closed = False
+        self._ok = ok
+        self._boom = boom
+
+    def write(self, obj: dict) -> bool:
+        if self._boom:
+            raise RuntimeError(f"{self.name} is wedged")
+        self.frames.append(obj)
+        return self._ok
+
+    def close(self) -> None:
+        self.closed = True
+
+    def types(self) -> list[str]:
+        return [(f.get("params") or {}).get("type") for f in self.frames]
+
+
+def _session(**extra) -> dict:
+    return {
+        "agent": None,
+        "session_key": "session-key",
+        "history": [],
+        "history_lock": threading.Lock(),
+        "history_version": 0,
+        "running": False,
+        "attached_images": [],
+        "transport": None,
+        **extra,
+    }
+
+
+# ── FanoutTransport ────────────────────────────────────────────────────────
+
+
+def test_fanout_delivers_to_every_attached_transport():
+    a, b = _FakeClient("a"), _FakeClient("b")
+    fan = FanoutTransport(a, b)
+
+    assert fan.write({"frame": 1}) is True
+    assert a.frames == b.frames == [{"frame": 1}]
+    assert fan.transports() == [a, b]
+
+
+def test_fanout_attach_is_idempotent_and_detach_is_by_identity():
+    a, b = _FakeClient("a"), _FakeClient("b")
+    fan = FanoutTransport(a)
+
+    assert fan.attach(a) is False  # already attached
+    assert fan.attach(b) is True
+    assert fan.contains(a) and fan.contains(b)
+    assert fan.has_transports(excluding=a) is True
+
+    assert fan.detach(a) is True
+    assert fan.detach(a) is False
+    assert fan.transports() == [b]
+    assert fan.has_transports(excluding=b) is False
+
+
+def test_fanout_prunes_a_wedged_peer_without_disturbing_the_rest():
+    """(g) A raising peer is dropped; the healthy client keeps its stream."""
+    healthy, wedged = _FakeClient("healthy"), _FakeClient("wedged", boom=True)
+    fan = FanoutTransport(wedged, healthy)
+
+    assert fan.write({"frame": 1}) is True
+    assert healthy.frames == [{"frame": 1}]
+    assert fan.transports() == [healthy]
+
+    # And the pruning is permanent — no retry storm against the wedged peer.
+    assert fan.write({"frame": 2}) is True
+    assert len(healthy.frames) == 2
+
+
+def test_fanout_prunes_a_peer_that_reports_gone_and_reports_all_dead():
+    gone = _FakeClient("gone", ok=False)
+    fan = FanoutTransport(gone)
+
+    # write() returned False -> peer gone -> pruned, and an empty fan-out
+    # reports peer-gone exactly like a single dead transport would.
+    assert fan.write({"frame": 1}) is False
+    assert fan.transports() == []
+    assert fan.write({"frame": 2}) is False
+
+
+def test_fanout_close_releases_peers_without_closing_their_sockets():
+    a = _FakeClient("a")
+    fan = FanoutTransport(a)
+
+    fan.close()
+
+    assert fan.transports() == []
+    # Each client owns its own socket; the WS handler closes it on disconnect.
+    assert a.closed is False
+
+
+# ── attach ladder ──────────────────────────────────────────────────────────
+
+
+def test_attach_replaces_an_empty_or_stdio_slot_without_wrapping():
+    """The single-client shape is unchanged: no FanoutTransport in sight."""
+    a = _FakeClient("a")
+
+    empty = _session(transport=None)
+    assert server._attach_session_transport(empty, a) is True
+    assert empty["transport"] is a
+
+    stdio = _session(transport=server._stdio_transport)
+    assert server._attach_session_transport(stdio, a) is True
+    assert stdio["transport"] is a
+
+    parked = _session(transport=server._detached_ws_transport)
+    assert server._attach_session_transport(parked, a) is True
+    assert parked["transport"] is a
+
+
+def test_attach_of_the_same_transport_is_a_noop():
+    a = _FakeClient("a")
+    session = _session(transport=a)
+
+    assert server._attach_session_transport(session, a) is True
+    assert session["transport"] is a
+
+
+def test_attach_of_a_second_client_wraps_both_and_a_third_joins_the_fanout():
+    a, b, c = _FakeClient("a"), _FakeClient("b"), _FakeClient("c")
+    session = _session(transport=a)
+
+    server._attach_session_transport(session, b)
+    assert isinstance(session["transport"], FanoutTransport)
+    assert session["transport"].transports() == [a, b]
+
+    server._attach_session_transport(session, c)
+    assert session["transport"].transports() == [a, b, c]
+
+
+def test_attach_never_lets_stdio_displace_a_live_client():
+    """An unbound-context activate must not silence the websocket that owns it."""
+    a = _FakeClient("a")
+    session = _session(transport=a)
+
+    assert server._attach_session_transport(session, server._stdio_transport) is False
+    assert session["transport"] is a
+
+
+def test_attach_flattens_a_fanout_argument_instead_of_nesting_it():
+    a, b, c = _FakeClient("a"), _FakeClient("b"), _FakeClient("c")
+    session = _session(transport=a)
+    server._attach_session_transport(session, b)
+
+    server._attach_session_transport(session, FanoutTransport(b, c))
+
+    assert session["transport"].transports() == [a, b, c]
+
+
+def test_attach_flattens_a_fanout_argument_onto_a_single_client_slot(monkeypatch):
+    """The nesting the queued-prompt paths can actually reach.
+
+    A busy submit pins ``t or session["transport"]`` to the queued prompt, so
+    the envelope can hold the FAN-OUT that was in the slot, and the drain hands
+    that straight back to attach. Flattening only when the slot ALREADY fans out
+    leaves the leaf-slot case nesting one fan-out inside another, and every
+    reader of the slot scans a single level — ``FanoutTransport.contains``, the
+    steer-authority check, detach — so a peer in the inner fan-out is invisible
+    to all of them, and a peer in BOTH levels is written to twice per frame.
+    """
+    a, b = _FakeClient("a"), _FakeClient("b")
+
+    # (1) A fan-out arriving at a leaf slot is flattened into it, not wrapped.
+    session = _session(transport=a)
+    assert server._attach_session_transport(session, FanoutTransport(a, b)) is True
+    slot = session["transport"]
+    assert isinstance(slot, FanoutTransport)
+    assert slot.transports() == [a, b]
+    assert not any(isinstance(t, FanoutTransport) for t in slot.transports())
+    assert server._session_transport_contains(session, b) is True
+
+    # (2) The sequence that produces it. Two clients attach, so the slot holds a
+    # fan-out; a busy submit captures that slot in the queued envelope; the
+    # second client disconnects and the slot collapses back to the first; the
+    # drain then attaches the captured fan-out to a leaf slot.
+    monkeypatch.setattr(server, "_run_prompt_submit", lambda *a_, **k: None)
+
+    drained = _session(transport=a)
+    server._attach_session_transport(drained, b)
+    captured = drained["transport"]
+    assert isinstance(captured, FanoutTransport)
+    server._enqueue_prompt(drained, "queued while busy", captured)
+
+    assert server._detach_session_transport(drained, b) is True
+    assert drained["transport"] is a
+
+    server._sessions["flatten-sid"] = drained
+    try:
+        assert server._drain_queued_prompt("drain", "flatten-sid", drained) is True
+        # Flat: the captured fan-out lost b to the same detach that collapsed
+        # the slot, so flattening it re-attaches only a, which is already there.
+        assert drained["transport"] is a
+        server._emit("message.delta", "flatten-sid", {"text": "once"})
+    finally:
+        server._sessions.pop("flatten-sid", None)
+
+    # Nesting would have put a inside the slot AND under it: one frame, two
+    # writes to the same client.
+    assert a.types() == ["message.delta"]
+
+
+def test_detach_collapses_back_to_the_single_remaining_client():
+    a, b = _FakeClient("a"), _FakeClient("b")
+    session = _session(transport=a)
+    server._attach_session_transport(session, b)
+
+    assert server._detach_session_transport(session, a) is True
+    assert session["transport"] is b
+    assert server._detach_session_transport(session, b) is False
+
+
+def test_detach_of_a_single_client_leaves_the_slot_for_the_caller_to_park():
+    a = _FakeClient("a")
+    session = _session(transport=a)
+
+    # False == "no live client remains" — the disconnect path parks the sentinel.
+    assert server._detach_session_transport(session, a) is False
+    assert session["transport"] is a
+
+
+def test_live_transport_predicates_ignore_stdio_and_the_drop_sentinel():
+    a = _FakeClient("a")
+
+    assert server._session_has_live_transport(_session(transport=a)) is True
+    assert server._session_has_live_transport(_session(transport=a), excluding=a) is False
+    assert server._session_has_live_transport(_session(transport=None)) is False
+    assert (
+        server._session_has_live_transport(_session(transport=server._stdio_transport))
+        is False
+    )
+    assert (
+        server._session_has_live_transport(
+            _session(transport=server._detached_ws_transport)
+        )
+        is False
+    )
+
+
+def test_a_closed_socket_is_not_a_live_peer():
+    """A transport that already latched ``_closed`` is a departed client.
+
+    ``_transport_is_live_peer`` ended on a bare ``return True``, so a WSTransport
+    whose socket had gone away still counted as a live peer: a session whose only
+    remaining peer was that dead socket answered "another client is still here"
+    and escaped both the park and the reap. ``_transport_is_dead`` is the
+    module's deadness predicate; the ladder now defers to it.
+    """
+    dead = _FakeClient("dead")
+    dead._closed = True  # the flag WSTransport latches when its socket goes away
+
+    assert server._transport_is_live_peer(dead) is False
+    assert server._session_has_live_transport(_session(transport=dead)) is False
+
+    # And a fan-out that collapses onto a dead peer is parked, not skipped: the
+    # live client leaving was the last real client.
+    live_client = _FakeClient("live")
+    session = _session(transport=FanoutTransport(live_client, dead))
+    server._sessions["dead-peer-sid"] = session
+    try:
+        assert server._close_sessions_for_transport(live_client) == (0, 1)
+        assert session["transport"] is server._detached_ws_transport
+    finally:
+        server._sessions.pop("dead-peer-sid", None)
+
+
+def test_a_fanout_with_no_live_peer_is_dead():
+    """``_transport_is_dead`` is the reapers' gate, and a fan-out could not fail it.
+
+    A ``FanoutTransport`` is never the drop sentinel and its ``__slots__`` give
+    it no ``_closed``, so a session that fanned out once read as alive forever:
+    the TTL reaper, the LRU cap and the disconnect revalidation all ask this one
+    predicate. A fan-out reaches the no-live-peer state without any disconnect
+    passing through ``_close_sessions_for_transport`` — a write that returns
+    False or raises prunes that peer — so the empty case is reachable, and it is
+    dead.
+    """
+    a, b = _FakeClient("a"), _FakeClient("b")
+    session = _session(transport=a)
+    server._attach_session_transport(session, b)
+    assert isinstance(session["transport"], FanoutTransport)
+    assert server._transport_is_dead(session["transport"]) is False
+
+    # One peer gone, one still reading: the session keeps its client.
+    a._closed = True  # the flag WSTransport latches when its socket goes away
+    assert server._transport_is_dead(session["transport"]) is False
+
+    b._closed = True
+    assert server._transport_is_dead(session["transport"]) is True
+
+    # Pruning every peer leaves the fan-out empty, which is nobody attached.
+    assert server._transport_is_dead(FanoutTransport()) is True
+
+
+# ── event delivery ─────────────────────────────────────────────────────────
+
+
+def test_two_attached_clients_both_receive_a_session_event(monkeypatch):
+    """(a) The headline behaviour: one emit, two clients."""
+    a, b = _FakeClient("a"), _FakeClient("b")
+    session = _session(transport=a)
+    server._attach_session_transport(session, b)
+    server._sessions["sid"] = session
+    try:
+        server._emit("message.delta", "sid", {"text": "hi"})
+    finally:
+        server._sessions.pop("sid", None)
+
+    assert a.types() == ["message.delta"]
+    assert b.types() == ["message.delta"]
+    assert a.frames[0] == b.frames[0]
+
+
+def test_a_single_client_session_writes_through_the_bare_transport(monkeypatch):
+    """(j) Control: nothing about the one-client path changed."""
+    a = _FakeClient("a")
+    server._sessions["sid"] = _session(transport=a)
+    try:
+        assert server._sessions["sid"]["transport"] is a
+        server._emit("message.delta", "sid", {"text": "hi"})
+    finally:
+        server._sessions.pop("sid", None)
+
+    # The replay contract stamps a monotonic ``seq`` on every WS event frame.
+    # Strip it: this control test is about ROUTING, not numbering.
+    frames = [
+        {**f, "params": {k: v for k, v in f["params"].items() if k != "seq"}}
+        for f in a.frames
+    ]
+    assert frames == [
+        {
+            "jsonrpc": "2.0",
+            "method": "event",
+            "params": {
+                "type": "message.delta",
+                "session_id": "sid",
+                "payload": {"text": "hi"},
+            },
+        }
+    ]
+
+
+def test_both_attached_clients_receive_the_terminal_message_complete():
+    """The frame that ENDS a turn fans out too, not just the streaming deltas.
+
+    ``message.complete`` is how a client knows the turn is over. A mirrored
+    session that delivered deltas but dropped the terminal frame would leave the
+    second client rendering a turn that never finishes.
+    """
+    a, b = _FakeClient("a"), _FakeClient("b")
+    session = _session(transport=a)
+    server._attach_session_transport(session, b)
+    server._sessions["sid"] = session
+    try:
+        server._emit("message.delta", "sid", {"text": "par"})
+        server._emit("message.complete", "sid", {"text": "part", "status": "ok"})
+    finally:
+        server._sessions.pop("sid", None)
+
+    assert a.types() == ["message.delta", "message.complete"]
+    assert b.types() == ["message.delta", "message.complete"]
+    assert a.frames[-1] == b.frames[-1]
+    assert a.frames[-1]["params"]["payload"] == {"text": "part", "status": "ok"}
+
+    # Control: the one-client path delivers the same terminal frame through the
+    # bare transport, with no fan-out in the slot.
+    solo = _FakeClient("solo")
+    server._sessions["solo-sid"] = _session(transport=solo)
+    try:
+        assert server._sessions["solo-sid"]["transport"] is solo
+        server._emit("message.complete", "solo-sid", {"text": "part", "status": "ok"})
+    finally:
+        server._sessions.pop("solo-sid", None)
+
+    assert solo.types() == ["message.complete"]
+    assert solo.frames[-1]["params"]["payload"] == {"text": "part", "status": "ok"}
+
+
+# ── prompt.submit / queued drain ───────────────────────────────────────────
+
+
+def test_second_clients_submit_attaches_and_the_first_keeps_streaming(monkeypatch):
+    """(c) A second client's prompt.submit must not cut the first one out."""
+    monkeypatch.setattr(server, "_run_prompt_submit", lambda *a, **k: None)
+    monkeypatch.setattr(server, "_ensure_active_session_slot", lambda *a, **k: None)
+
+    watcher, submitter = _FakeClient("watcher"), _FakeClient("submitter")
+    session = _session(transport=watcher, agent=types.SimpleNamespace())
+    server._sessions["sid"] = session
+    token = server.bind_transport(submitter)
+    try:
+        server._methods["prompt.submit"]("r1", {"session_id": "sid", "text": "hello"})
+        server._emit("message.delta", "sid", {"text": "answer"})
+    finally:
+        server.reset_transport(token)
+        server._sessions.pop("sid", None)
+
+    assert isinstance(session["transport"], FanoutTransport)
+    assert watcher.types() == ["message.delta"]
+    assert submitter.types() == ["message.delta"]
+
+
+def test_queued_prompt_drain_keeps_both_clients_attached(monkeypatch):
+    """(d) The hole every competing patch missed: the drain used to rebind.
+
+    Client A is streaming; client B submits mid-turn, so B's prompt is queued
+    with B's transport pinned to it. When the drain fires it must ATTACH B —
+    rebinding pinned the whole drained turn to B and silenced A.
+    """
+    dispatched = []
+    monkeypatch.setattr(
+        server,
+        "_run_prompt_submit",
+        lambda rid, sid, _session, text, **kw: dispatched.append((rid, text)),
+    )
+
+    a, b = _FakeClient("a"), _FakeClient("b")
+    session = _session(transport=a)
+    server._enqueue_prompt(session, "from B", b)
+    server._sessions["sid"] = session
+    try:
+        assert server._drain_queued_prompt("drain", "sid", session) is True
+        server._emit("message.delta", "sid", {"text": "drained answer"})
+    finally:
+        server._sessions.pop("sid", None)
+
+    assert dispatched == [("drain", "from B")]
+    assert isinstance(session["transport"], FanoutTransport)
+    assert a.types() == ["message.delta"]
+    assert b.types() == ["message.delta"]
+
+
+def test_queued_prompt_drain_still_rebinds_a_single_client_session(monkeypatch):
+    """(j) Control: with one client the drain lands on the queuer's transport."""
+    monkeypatch.setattr(server, "_run_prompt_submit", lambda *a, **k: None)
+
+    b = _FakeClient("b")
+    session = _session(transport=server._detached_ws_transport)
+    server._enqueue_prompt(session, "from B", b)
+
+    assert server._drain_queued_prompt("drain", "sid", session) is True
+    assert session["transport"] is b
+
+
+# ── disconnect ─────────────────────────────────────────────────────────────
+
+
+def test_watcher_disconnect_leaves_the_other_client_streaming():
+    """(e) One client leaving must not park or reap a session someone is reading."""
+    a, watcher = _FakeClient("a"), _FakeClient("watcher")
+    session = _session(transport=a)
+    server._attach_session_transport(session, watcher)
+    server._sessions["sid"] = session
+    try:
+        assert server._close_sessions_for_transport(watcher) == (0, 0)
+        assert session["transport"] is a
+        assert server._ws_session_is_orphaned(session) is False
+        server._emit("message.delta", "sid", {"text": "still here"})
+    finally:
+        server._sessions.pop("sid", None)
+
+    assert a.types() == ["message.delta"]
+    assert watcher.types() == []
+
+
+def test_last_client_disconnect_parks_exactly_as_before(monkeypatch):
+    """(f) Once the last client goes, today's park + grace-reap path runs."""
+    monkeypatch.setattr(server, "_WS_ORPHAN_REAP_GRACE_S", 0)
+
+    a, watcher = _FakeClient("a"), _FakeClient("watcher")
+    session = _session(transport=a)
+    server._attach_session_transport(session, watcher)
+    server._sessions["sid"] = session
+    try:
+        assert server._close_sessions_for_transport(watcher) == (0, 0)
+        assert server._close_sessions_for_transport(a) == (0, 1)
+        assert session["transport"] is server._detached_ws_transport
+        assert server._ws_session_is_orphaned(session) is True
+    finally:
+        server._sessions.pop("sid", None)
+
+
+def test_last_client_disconnect_reaps_a_close_on_disconnect_session(monkeypatch):
+    """(f) close_on_disconnect still fires — but only for the LAST client."""
+    # The disconnect path claims the session with _pop_session_by_id and finishes
+    # the close through _teardown_popped_session, so that is what this stubs; the
+    # sid is asserted through the pop rather than through the call arguments.
+    closed = []
+
+    def _fake_teardown(session, *, end_reason: str = "tui_close") -> bool:
+        closed.append((session, end_reason))
+        return True
+
+    monkeypatch.setattr(server, "_teardown_popped_session", _fake_teardown)
+
+    a, watcher = _FakeClient("a"), _FakeClient("watcher")
+    session = _session(transport=a, close_on_disconnect=True)
+    server._attach_session_transport(session, watcher)
+    server._sessions["sid"] = session
+    try:
+        assert server._close_sessions_for_transport(watcher) == (0, 0)
+        assert closed == []
+        assert server._close_sessions_for_transport(
+            a, end_reason="ws_disconnect"
+        ) == (1, 0)
+        assert "sid" not in server._sessions
+    finally:
+        server._sessions.pop("sid", None)
+
+    assert closed == [(session, "ws_disconnect")]
+
+
+def test_orphan_check_spares_a_session_that_still_has_a_fanout_peer():
+    # _ws_session_is_orphaned stayed slot-identity based on main: a fan-out is
+    # never the drop sentinel, and the disconnect path only parks the sentinel
+    # once the last peer is gone, so these hold without a liveness rewrite.
+    a, watcher = _FakeClient("a"), _FakeClient("watcher")
+    session = _session(transport=a)
+    server._attach_session_transport(session, watcher)
+
+    assert server._ws_session_is_orphaned(session) is False
+
+    # Losing one of two clients collapses the slot but keeps the session live.
+    assert server._detach_session_transport(session, a) is True
+    assert server._ws_session_is_orphaned(session) is False
+
+    # Losing the last one reports "no client left"; the caller then parks the
+    # drop sentinel, which is what makes the session orphaned.
+    assert server._detach_session_transport(session, watcher) is False
+    session["transport"] = server._detached_ws_transport
+    assert server._ws_session_is_orphaned(session) is True
+
+
+# ---------------------------------------------------------------------------
+# Concurrent fan-out delivery
+#
+# A SERIAL ``FanoutTransport.write`` — each peer written in turn — would let a
+# client whose write parks for the full ``tui_gateway.ws._WS_WRITE_TIMEOUT_S``
+# (10s, the non-streaming path's ``fut.result`` wait for a stalled event loop)
+# hold the same frame back from every healthy client behind it in the list.
+# That is the property these tests pin, so the writes run concurrently, with two
+# cases deliberately kept inline: a lone peer (single-client sessions must not
+# change at all) and a caller that is already on an event loop (handing that
+# write to a pool thread would make the pool thread block on the loop it just
+# left, freezing both).
+#
+# Extra imports for this block: ``asyncio`` below, plus a function-local
+# ``tui_gateway.transport`` in the deadline test (it monkeypatches a module
+# constant). Everything else — ``threading``, ``FanoutTransport``,
+# ``_FakeClient`` — comes from the top of this file.
+# ---------------------------------------------------------------------------
+
+import asyncio
+
+
+class _SlowPeer:
+    """A peer whose write parks until the test releases it.
+
+    Models the real stall: a non-streaming ``WSTransport.write`` blocks on
+    ``fut.result(timeout=_WS_WRITE_TIMEOUT_S)`` while the owning event loop is
+    busy, so the emitting thread sits inside that one peer's write for seconds.
+    """
+
+    def __init__(self, name: str = "slow") -> None:
+        self.name = name
+        self.frames: list[dict] = []
+        self.entered = threading.Event()
+        self.release = threading.Event()
+        self.closed = False
+
+    def write(self, obj: dict) -> bool:
+        self.entered.set()
+        # Bounded: a regression must fail the assertion below, never hang the
+        # suite waiting for a release that the failing path never reaches.
+        self.release.wait(timeout=5.0)
+        self.frames.append(obj)
+        return True
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class _SignallingPeer:
+    """A healthy peer that announces each frame the moment it lands."""
+
+    def __init__(self, name: str = "healthy") -> None:
+        self.name = name
+        self.frames: list[dict] = []
+        self.got_frame = threading.Event()
+        self.closed = False
+
+    def write(self, obj: dict) -> bool:
+        self.frames.append(obj)
+        self.got_frame.set()
+        return True
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class _ThreadRecordingPeer:
+    """A healthy peer that records which thread each of its writes ran on."""
+
+    def __init__(self, name: str = "peer") -> None:
+        self.name = name
+        self.frames: list[dict] = []
+        self.threads: list[threading.Thread] = []
+        self.closed = False
+
+    def write(self, obj: dict) -> bool:
+        self.threads.append(threading.current_thread())
+        self.frames.append(obj)
+        return True
+
+    def close(self) -> None:
+        self.closed = True
+
+
+def _healthy_peer_is_not_held_behind(slow_first: bool) -> None:
+    """One wedged peer, one healthy peer, one ``write`` from a worker thread.
+
+    The healthy peer must hold the frame while the wedged peer is still parked
+    inside its own write. Asserted for both list orders so the fix cannot be a
+    special case that only ever hurries the first (or the last) peer along.
+    """
+    slow = _SlowPeer()
+    healthy = _SignallingPeer()
+    peers = (slow, healthy) if slow_first else (healthy, slow)
+    fanout = FanoutTransport(*peers)
+    frame = {"jsonrpc": "2.0", "method": "event", "params": {"type": "message.complete"}}
+
+    returned = threading.Event()
+    result: dict = {}
+
+    def emit() -> None:
+        try:
+            result["ok"] = fanout.write(frame)
+        finally:
+            returned.set()
+
+    # Emit from a worker thread, which is where the gateway's event writes come
+    # from: ``handle_ws`` runs ``server.dispatch`` on ``asyncio.to_thread``.
+    worker = threading.Thread(target=emit, name="fanout-emitter", daemon=True)
+    worker.start()
+    try:
+        assert slow.entered.wait(timeout=2.0), "the wedged peer never got the frame"
+        assert healthy.got_frame.wait(timeout=2.0), (
+            "the healthy peer did not get the frame while a wedged peer held its "
+            "write open — the fan-out is still serial"
+        )
+        assert healthy.frames == [frame]
+        assert slow.frames == []
+    finally:
+        slow.release.set()
+        assert returned.wait(timeout=5.0), "the fan-out write never returned"
+        worker.join(timeout=5.0)
+
+    # The fan-out still collects: the wedged peer's frame landed before the
+    # call returned, and both peers stay attached.
+    assert slow.frames == [frame]
+    assert result["ok"] is True
+    assert fanout.transports() == [*peers]
+
+
+def test_a_wedged_peer_does_not_hold_the_frame_from_a_healthy_peer_behind_it():
+    _healthy_peer_is_not_held_behind(slow_first=True)
+
+
+def test_a_wedged_peer_does_not_hold_the_frame_from_a_healthy_peer_ahead_of_it():
+    _healthy_peer_is_not_held_behind(slow_first=False)
+
+
+def test_a_write_from_inside_an_event_loop_stays_on_the_loop_thread():
+    """The deadlock the concurrent path must never introduce.
+
+    ``WSTransport.write`` fires and forgets when it can see it is running on
+    its own loop, and BLOCKS on ``fut.result`` when it cannot. Hand a
+    loop-thread write to a pool thread and that pool thread takes the blocking
+    path, waiting on a loop that is itself waiting on the pool — the whole
+    gateway stalls for the write timeout. So an on-loop caller stays inline.
+    """
+    a, b = _ThreadRecordingPeer("a"), _ThreadRecordingPeer("b")
+    fanout = FanoutTransport(a, b)
+    frame = {"params": {"type": "message.complete"}}
+    outcome: dict = {}
+
+    async def emit() -> None:
+        outcome["loop_thread"] = threading.current_thread()
+        outcome["ok"] = fanout.write(frame)
+
+    # Driven from a side thread with a bounded join so a real deadlock fails
+    # this test instead of hanging the run.
+    runner = threading.Thread(target=lambda: asyncio.run(emit()), daemon=True)
+    runner.start()
+    runner.join(timeout=5.0)
+    assert not runner.is_alive(), "fan-out write from the event loop did not return"
+
+    assert outcome["ok"] is True
+    assert a.frames == [frame] and b.frames == [frame]
+    assert a.threads == [outcome["loop_thread"]]
+    assert b.threads == [outcome["loop_thread"]]
+
+
+def test_a_lone_peer_is_written_on_the_calling_thread():
+    """Single-client sessions keep the exact behaviour they had before."""
+    only = _ThreadRecordingPeer("only")
+    fanout = FanoutTransport(only)
+
+    frame = {"params": {"type": "message.complete"}}
+    assert fanout.write(frame) is True
+
+    assert only.frames == [frame]
+    assert only.threads == [threading.current_thread()]
+
+
+def test_the_concurrent_path_prunes_dead_peers_and_still_delivers():
+    """Pruning is unchanged: ``False`` and a raise both detach the peer."""
+    gone = _FakeClient("gone", ok=False)
+    wedged = _FakeClient("wedged", boom=True)
+    healthy = _FakeClient("healthy")
+    fanout = FanoutTransport(gone, wedged, healthy)
+
+    frame = {"params": {"type": "message.complete"}}
+    assert fanout.write(frame) is True
+
+    assert healthy.frames == [frame]
+    assert fanout.transports() == [healthy]
+
+
+def test_the_concurrent_path_reports_peer_gone_when_every_peer_is_dead():
+    gone = _FakeClient("gone", ok=False)
+    wedged = _FakeClient("wedged", boom=True)
+    fanout = FanoutTransport(gone, wedged)
+
+    assert fanout.write({"params": {"type": "message.complete"}}) is False
+    assert fanout.transports() == []
+
+
+def test_consecutive_frames_reach_every_peer_in_order():
+    """The fan-out collects before returning, so frame A is on every peer
+    before frame B is dispatched to any of them."""
+    a, b = _ThreadRecordingPeer("a"), _ThreadRecordingPeer("b")
+    fanout = FanoutTransport(a, b)
+    first = {"params": {"type": "message.delta", "text": "1"}}
+    second = {"params": {"type": "message.complete"}}
+
+    assert fanout.write(first) is True
+    # Collect-before-return: nothing is still in flight when write() answers.
+    assert a.frames == [first] and b.frames == [first]
+
+    assert fanout.write(second) is True
+    assert a.frames == [first, second]
+    assert b.frames == [first, second]
+
+
+def test_a_peer_that_misses_the_deadline_is_kept_and_counts_as_delivered(monkeypatch):
+    """Slow is not dead.
+
+    A peer still writing when the fan-out deadline expires stays attached and
+    the frame counts as in flight — which is what ``WSTransport.write`` itself
+    reports when its own write times out. Here it is the ONLY live peer, so the
+    ``True`` return rests entirely on it.
+    """
+    from tui_gateway import transport as transport_module
+
+    monkeypatch.setattr(transport_module, "_FANOUT_WRITE_DEADLINE_S", 0.05)
+
+    slow = _SlowPeer()
+    gone = _FakeClient("gone", ok=False)
+    fanout = FanoutTransport(slow, gone)
+    frame = {"params": {"type": "message.complete"}}
+
+    assert fanout.write(frame) is True
+    # The dead peer is pruned; the slow one is not.
+    assert fanout.transports() == [slow]
+    assert slow.frames == []
+
+    slow.release.set()

--- a/tests/tui_gateway/test_multi_client_fanout.py
+++ b/tests/tui_gateway/test_multi_client_fanout.py
@@ -12,10 +12,13 @@ attached the slot holds the bare transport and every path behaves exactly as it
 did before fan-out existed.
 """
 
+import asyncio
+import json
 import threading
 import types
 
 from tui_gateway import server
+from tui_gateway import ws as ws_mod
 from tui_gateway.transport import FanoutTransport
 
 
@@ -25,12 +28,23 @@ class _FakeClient:
     ``ok`` False models a peer that has gone away (``write`` returns False, the
     gateway's peer-gone signal); ``boom`` models a wedged peer whose write
     raises. Both must be pruned without disturbing the healthy clients.
+
+    ``transport_id`` mirrors the opaque per-connection id ``tui_gateway.ws``
+    mints at accept — the value the wire contract calls ``origin``.
     """
 
-    def __init__(self, name: str, *, ok: bool = True, boom: bool = False) -> None:
+    def __init__(
+        self,
+        name: str,
+        *,
+        ok: bool = True,
+        boom: bool = False,
+        transport_id: str | None = None,
+    ) -> None:
         self.name = name
         self.frames: list[dict] = []
         self.closed = False
+        self.transport_id = transport_id if transport_id is not None else f"tid-{name}"
         self._ok = ok
         self._boom = boom
 
@@ -1034,3 +1048,252 @@ def test_a_peer_that_misses_the_deadline_is_kept_and_counts_as_delivered(monkeyp
     assert slow.frames == []
 
     slow.release.set()
+
+
+# ── wire contract: gateway.ready ───────────────────────────────────────────
+
+
+def test_gateway_ready_announces_session_mirroring_and_this_connections_origin(
+    monkeypatch,
+):
+    """(h) The client learns the backend mirrors, and learns its own id."""
+    monkeypatch.setattr(server, "_WS_ORPHAN_REAP_GRACE_S", 0)
+    monkeypatch.setattr(server, "resolve_skin", lambda: {"name": "test-skin"})
+
+    created = []
+    real_transport = ws_mod.WSTransport
+    monkeypatch.setattr(
+        ws_mod,
+        "WSTransport",
+        lambda ws, loop, **kw: created.append(real_transport(ws, loop, **kw))
+        or created[-1],
+    )
+    sent = []
+
+    class FakeWS:
+        async def accept(self):
+            pass
+
+        async def send_text(self, line):
+            sent.append(json.loads(line))
+
+        async def receive_text(self):
+            raise ws_mod._WebSocketDisconnect()
+
+        async def close(self):
+            pass
+
+    asyncio.run(ws_mod.handle_ws(FakeWS()))
+
+    ready = [f for f in sent if (f.get("params") or {}).get("type") == "gateway.ready"]
+    assert len(ready) == 1
+    payload = ready[0]["params"]["payload"]
+    assert payload["session_mirroring"] is True
+    assert payload["origin"] == created[0].transport_id
+    # Additive only — the pre-existing keys are untouched.
+    assert payload["change_events"] is True
+    assert payload["skin"] == {"name": "test-skin"}
+
+
+def test_each_ws_connection_gets_its_own_opaque_origin():
+    loop = asyncio.new_event_loop()
+    try:
+        first = ws_mod.WSTransport(object(), loop, peer="a")
+        second = ws_mod.WSTransport(object(), loop, peer="b")
+        assert first.transport_id and second.transport_id
+        assert first.transport_id != second.transport_id
+    finally:
+        loop.close()
+
+
+# ── wire contract: event origin ────────────────────────────────────────────
+
+
+def test_event_frames_carry_the_submitters_origin_during_its_turn(monkeypatch):
+    """(i) Both clients see the frame; both can tell WHO started the turn."""
+    monkeypatch.setattr(server, "_run_prompt_submit", lambda *a, **k: None)
+    monkeypatch.setattr(server, "_ensure_active_session_slot", lambda *a, **k: None)
+
+    watcher = _FakeClient("watcher", transport_id="conn-watcher")
+    submitter = _FakeClient("submitter", transport_id="conn-submitter")
+    session = _session(transport=watcher, agent=types.SimpleNamespace())
+    server._sessions["sid"] = session
+    token = server.bind_transport(submitter)
+    try:
+        server._methods["prompt.submit"]("r1", {"session_id": "sid", "text": "hello"})
+        server._emit("message.delta", "sid", {"text": "answer"})
+    finally:
+        server.reset_transport(token)
+        server._sessions.pop("sid", None)
+
+    assert session["turn_origin"] == "conn-submitter"
+    for client in (watcher, submitter):
+        assert client.frames[0]["params"]["origin"] == "conn-submitter"
+
+
+def test_event_frames_omit_origin_when_no_client_started_the_turn():
+    """(j) A stdio/unknown origin adds no key at all — frames keep their shape."""
+    server._sessions["sid"] = _session(transport=None)
+    try:
+        frame = server._event_frame("message.delta", "sid", {"text": "hi"})
+        assert "origin" not in frame["params"]
+
+        # Empty string is "unknown", not an origin worth wiring.
+        server._sessions["sid"]["turn_origin"] = ""
+        assert "origin" not in server._event_frame("message.delta", "sid")["params"]
+    finally:
+        server._sessions.pop("sid", None)
+
+    # Session-less global broadcasts never carry an origin either.
+    assert "origin" not in server._event_frame("skin.changed", "")["params"]
+
+
+def test_a_mid_turn_submit_that_redirects_leaves_the_running_turns_origin(monkeypatch):
+    """A turn belongs to the client that CLAIMED it, not to whoever typed last.
+
+    A's turn is running. B types into the session it is mirroring, and under the
+    default ``interrupt`` policy a redirect-capable agent takes the
+    redirect-in-place branch: the live turn is corrected, no new turn starts,
+    and B's submit answers ``redirected``. Every remaining frame of A's turn —
+    ``message.complete`` included — therefore still belongs to A.
+
+    Stamping the origin at attach time instead inverted the attribution for the
+    rest of the turn: A watched its own turn finish under B's origin and
+    un-latched, while B latched a turn it had never started.
+    """
+    # An empty config selects the default busy policy (``interrupt``) without
+    # depending on the developer's config.yaml.
+    monkeypatch.setattr(server, "_load_cfg", lambda: {})
+    monkeypatch.setattr(server, "_run_prompt_submit", lambda *a, **k: None)
+    monkeypatch.setattr(server, "_ensure_active_session_slot", lambda *a, **k: None)
+
+    redirects: list[str] = []
+    agent = types.SimpleNamespace(
+        _supports_active_turn_redirect=True,
+        redirect=lambda text: bool(redirects.append(text)) or True,
+    )
+    a = _FakeClient("a", transport_id="conn-a")
+    b = _FakeClient("b", transport_id="conn-b")
+    session = _session(
+        transport=a,
+        agent=agent,
+        running=True,
+        turn_origin="conn-a",
+        inflight_turn={"user": "A's prompt", "assistant": "partial "},
+    )
+    server._sessions["sid"] = session
+    token = server.bind_transport(b)
+    try:
+        response = server._methods["prompt.submit"](
+            "r1", {"session_id": "sid", "text": "actually, in Rust"}
+        )
+        server._emit("message.complete", "sid", {"text": "A's answer"})
+    finally:
+        server.reset_transport(token)
+        server._sessions.pop("sid", None)
+
+    assert response["result"]["status"] == "redirected"
+    assert redirects == ["actually, in Rust"]
+    # B is attached now — it is watching — but it did not take the turn.
+    assert isinstance(session["transport"], FanoutTransport)
+    assert session["turn_origin"] == "conn-a"
+    for client in (a, b):
+        assert client.types() == ["message.complete"]
+        assert client.frames[-1]["params"]["origin"] == "conn-a"
+
+
+def test_an_uncontended_submit_still_stamps_the_submitter(monkeypatch):
+    """(j) Control: on an IDLE session the claim is the submitter's, as before."""
+    monkeypatch.setattr(server, "_load_cfg", lambda: {})
+    monkeypatch.setattr(server, "_run_prompt_submit", lambda *a, **k: None)
+    monkeypatch.setattr(server, "_ensure_active_session_slot", lambda *a, **k: None)
+
+    b = _FakeClient("b", transport_id="conn-b")
+    session = _session(transport=None, agent=types.SimpleNamespace(), turn_origin="conn-a")
+    server._sessions["sid"] = session
+    token = server.bind_transport(b)
+    try:
+        response = server._methods["prompt.submit"](
+            "r1", {"session_id": "sid", "text": "hello"}
+        )
+    finally:
+        server.reset_transport(token)
+        server._sessions.pop("sid", None)
+
+    assert "error" not in response
+    assert session["turn_origin"] == "conn-b"
+
+
+def test_queued_prompt_drain_stamps_the_queuers_origin(monkeypatch):
+    """The drained turn belongs to whoever queued it, not whoever is driving.
+
+    The whole lifecycle: B's mid-turn prompt is QUEUED under the ``queue``
+    policy, which starts no turn, so A keeps the origin for the rest of its own
+    turn. The stamp moves to B only when the drain claims the next turn.
+    """
+    monkeypatch.setattr(
+        server, "_load_cfg", lambda: {"display": {"busy_input_mode": "queue"}}
+    )
+    monkeypatch.setattr(server, "_run_prompt_submit", lambda *a, **k: None)
+    monkeypatch.setattr(server, "_ensure_active_session_slot", lambda *a, **k: None)
+
+    a = _FakeClient("a", transport_id="conn-a")
+    b = _FakeClient("b", transport_id="conn-b")
+    session = _session(transport=a, running=True, turn_origin="conn-a")
+    server._sessions["sid"] = session
+    token = server.bind_transport(b)
+    try:
+        response = server._methods["prompt.submit"](
+            "r1", {"session_id": "sid", "text": "from B"}
+        )
+        assert response["result"]["status"] == "queued"
+        # A's turn is still the live one: it keeps its frames.
+        assert session["turn_origin"] == "conn-a"
+
+        session["running"] = False
+        assert server._drain_queued_prompt("drain", "sid", session) is True
+        server._emit("message.delta", "sid", {"text": "drained"})
+    finally:
+        server.reset_transport(token)
+        server._sessions.pop("sid", None)
+
+    assert session["turn_origin"] == "conn-b"
+    assert a.frames[0]["params"]["origin"] == "conn-b"
+    assert b.frames[0]["params"]["origin"] == "conn-b"
+
+
+def test_a_drained_turn_is_the_queuers_even_after_the_queuer_disconnects(monkeypatch):
+    """A queuer that left still owns the turn its prompt starts.
+
+    The drain skips ATTACHING a transport whose client is gone, but attribution
+    and delivery are different questions: the turn is still that client's work.
+    Recording the origin only for a live queuer would leave the drained turn
+    wearing the PREVIOUS turn's origin, which is the inversion this section
+    exists to prevent, so the stamp is taken before the liveness check.
+    """
+    dispatched = []
+    monkeypatch.setattr(
+        server,
+        "_run_prompt_submit",
+        lambda rid, sid, _session, text, **kw: dispatched.append((rid, text)),
+    )
+
+    a = _FakeClient("a", transport_id="conn-a")
+    b = _FakeClient("b", transport_id="conn-b")
+    # A's turn has ended and left its origin behind: the stale value the drained
+    # turn must not inherit.
+    session = _session(transport=a, turn_origin="conn-a")
+    server._enqueue_prompt(session, "from B", b)
+    b._closed = True  # B's socket went away while its prompt sat in the queue
+    server._sessions["sid"] = session
+    try:
+        assert server._drain_queued_prompt("drain", "sid", session) is True
+        server._emit("message.delta", "sid", {"text": "drained answer"})
+    finally:
+        server._sessions.pop("sid", None)
+
+    assert dispatched == [("drain", "from B")]  # the prompt still runs
+    assert session["transport"] is a  # the dead pin was skipped
+    assert session["turn_origin"] == "conn-b"  # but the turn is B's
+    assert a.frames[0]["params"]["origin"] == "conn-b"  # not A's, not stale
+    assert b.types() == []  # B is gone; nothing was delivered to it

--- a/tests/tui_gateway/test_multi_client_fanout.py
+++ b/tests/tui_gateway/test_multi_client_fanout.py
@@ -13,9 +13,12 @@ did before fan-out existed.
 """
 
 import asyncio
+import contextlib
 import json
 import threading
 import types
+
+import pytest
 
 from tui_gateway import server
 from tui_gateway import ws as ws_mod
@@ -1297,3 +1300,186 @@ def test_a_drained_turn_is_the_queuers_even_after_the_queuer_disconnects(monkeyp
     assert session["turn_origin"] == "conn-b"  # but the turn is B's
     assert a.frames[0]["params"]["origin"] == "conn-b"  # not A's, not stale
     assert b.types() == []  # B is gone; nothing was delivered to it
+
+
+# ── wire contract: resume/activate watching ────────────────────────────────
+
+
+class _FakeResumeDB:
+    """Just enough SessionDB for session.resume's live-reuse + cold paths."""
+
+    def __init__(self, session_id: str) -> None:
+        self._id = session_id
+
+    def get_session(self, target):
+        return {"id": self._id} if target == self._id else None
+
+    def get_session_by_title(self, _title):
+        return None
+
+    def reopen_session(self, _target):
+        return None
+
+    def get_ancestor_display_prefix(self, _target):
+        return []
+
+    def get_resume_conversations(self, _session_id):
+        return ([], [])
+
+    def get_messages_as_conversation(self, _target, **_kwargs):
+        return []
+
+
+def _resume(transport, **params):
+    token = server.bind_transport(transport)
+    try:
+        return server.handle_request(
+            {"id": "r1", "method": "session.resume", "params": params}
+        )["result"]
+    finally:
+        server.reset_transport(token)
+
+
+@pytest.fixture()
+def restores_process_caches():
+    """Undo the process-global caches a REAL resume/activate warms.
+
+    The tests below drive the real ``session.resume`` / ``session.activate`` handlers rather
+    than a double, so they read config and the launch ``state.db`` handle and leave both
+    cached on ``tui_gateway.server`` for the rest of the session.
+    ``tests/tui_gateway/test_stale_provider_resume_live.py``'s ``live_home`` fixture repoints
+    the same globals at an isolated HERMES_HOME and is the test that notices when one carries
+    over, so put them back — and close a launch handle opened here instead of leaking it.
+    """
+    cached = {
+        name: getattr(server, name)
+        for name in ("_db", "_db_error", "_cfg_cache", "_cfg_mtime", "_cfg_path")
+    }
+    yield
+    if server._db is not None and server._db is not cached["_db"]:
+        with contextlib.suppress(Exception):
+            server._db.close()
+    for name, value in cached.items():
+        setattr(server, name, value)
+
+
+def test_resume_of_a_live_session_attaches_and_reports_watching(monkeypatch, restores_process_caches):
+    """(b) The second client mirrors the session; it does not steal it."""
+    monkeypatch.setattr(server, "_get_db", lambda: _FakeResumeDB("stored-1"))
+    monkeypatch.setattr(server, "_enable_gateway_prompts", lambda: None)
+
+    owner = _FakeClient("owner")
+    joiner = _FakeClient("joiner")
+    session = _session(session_key="stored-1", transport=owner, created_at=1.0)
+    server._sessions["live"] = session
+    try:
+        result = _resume(joiner, session_id="stored-1")
+
+        assert result["watching"] is True
+        assert result["session_id"] == "live"  # reused, not rebuilt
+        assert isinstance(session["transport"], FanoutTransport)
+        assert session["transport"].transports() == [owner, joiner]
+
+        server._emit("message.delta", "live", {"text": "shared"})
+    finally:
+        server._sessions.pop("live", None)
+
+    assert owner.types() == ["message.delta"]
+    assert joiner.types() == ["message.delta"]
+
+
+def test_resume_ignores_an_unrecognized_param(monkeypatch, restores_process_caches):
+    """``watching`` is a report, so nothing on the request side selects it.
+
+    The same live-session resume is run twice, once with an extra key no
+    handler reads. Both give the same result shape and the same attach: a
+    client cannot ask for or opt out of mirroring, and a client that sends a
+    hint the gateway does not know is answered as if it had not.
+    """
+    monkeypatch.setattr(server, "_get_db", lambda: _FakeResumeDB("stored-5"))
+    monkeypatch.setattr(server, "_enable_gateway_prompts", lambda: None)
+
+    def _resume_once(**extra) -> tuple[dict, list]:
+        owner = _FakeClient("owner")
+        joiner = _FakeClient("joiner")
+        session = _session(session_key="stored-5", transport=owner, created_at=1.0)
+        server._sessions["live"] = session
+        try:
+            result = _resume(joiner, session_id="stored-5", **extra)
+            return result, session["transport"].transports()
+        finally:
+            server._sessions.pop("live", None)
+
+    plain, plain_peers = _resume_once()
+    extra, extra_peers = _resume_once(watch=True)
+
+    assert set(extra) == set(plain)
+    assert extra["session_id"] == plain["session_id"] == "live"
+    assert extra["resumed"] == plain["resumed"] == "stored-5"
+    assert extra["watching"] is True and plain["watching"] is True
+    assert len(extra_peers) == len(plain_peers) == 2
+
+
+def test_resume_by_the_client_already_attached_is_not_watching(monkeypatch, restores_process_caches):
+    """Reconnect/refresh by the same client is not "someone else is driving"."""
+    monkeypatch.setattr(server, "_get_db", lambda: _FakeResumeDB("stored-1"))
+    monkeypatch.setattr(server, "_enable_gateway_prompts", lambda: None)
+
+    owner = _FakeClient("owner")
+    server._sessions["live"] = _session(
+        session_key="stored-1", transport=owner, created_at=1.0
+    )
+    try:
+        assert _resume(owner, session_id="stored-1")["watching"] is False
+    finally:
+        server._sessions.pop("live", None)
+
+
+def test_cold_resume_reports_not_watching(monkeypatch, restores_process_caches):
+    """Nobody was here first — this client owns the session it just registered."""
+    monkeypatch.setattr(server, "_get_db", lambda: _FakeResumeDB("stored-2"))
+    monkeypatch.setattr(server, "_enable_gateway_prompts", lambda: None)
+    monkeypatch.setattr(server, "_schedule_agent_build", lambda *a, **k: None)
+    monkeypatch.setattr(server, "_schedule_session_cap_enforcement", lambda *a, **k: None)
+    monkeypatch.setattr(server, "_maybe_schedule_auto_continue", lambda *a, **k: None)
+
+    client = _FakeClient("solo")
+    result = _resume(client, session_id="stored-2")
+    try:
+        assert result["watching"] is False
+        assert server._sessions[result["session_id"]]["transport"] is client
+    finally:
+        server._sessions.pop(result["session_id"], None)
+
+
+def test_lazy_watch_resume_reports_not_watching(monkeypatch, restores_process_caches):
+    """A lazy child-watch window registers its own session record."""
+    monkeypatch.setattr(server, "_get_db", lambda: _FakeResumeDB("stored-3"))
+    monkeypatch.setattr(server, "_enable_gateway_prompts", lambda: None)
+    monkeypatch.setattr(server, "_child_run_active", lambda _key: False)
+
+    client = _FakeClient("watch-window")
+    result = _resume(client, session_id="stored-3", lazy=True)
+    try:
+        assert result["watching"] is False
+        assert server._sessions[result["session_id"]]["transport"] is client
+    finally:
+        server._sessions.pop(result["session_id"], None)
+
+
+def test_activate_of_a_live_session_attaches_and_reports_watching(restores_process_caches):
+    owner = _FakeClient("owner")
+    joiner = _FakeClient("joiner")
+    session = _session(session_key="stored-4", transport=owner, created_at=1.0)
+    server._sessions["live"] = session
+    token = server.bind_transport(joiner)
+    try:
+        result = server.handle_request(
+            {"id": "r1", "method": "session.activate", "params": {"session_id": "live"}}
+        )["result"]
+
+        assert result["watching"] is True
+        assert session["transport"].transports() == [owner, joiner]
+    finally:
+        server.reset_transport(token)
+        server._sessions.pop("live", None)

--- a/tui_gateway/methods_browser_control.py
+++ b/tui_gateway/methods_browser_control.py
@@ -3,10 +3,12 @@
 The controller extension registers over the authenticated ``/api/ws`` gateway. Everything
 binds to the SERVER-MINTED identity (``WSTransport.auth_identity``, stamped from the single-use
 ticket); a client-supplied ``principal_id`` is ignored and replaced by a digest of it. Broker
-frames are re-enveloped as Gateway ``event`` frames; ``result`` resolves a command only on the
-owning transport for the exact attached scope (the broker's exact-scope ``complete`` is the
-backstop). Capabilities come from the broker's explicit allowlist (no raw CDP/eval/uploads).
-Bodies are rebound onto server.py's globals (bind_module publishes this module's helpers too).
+frames are re-enveloped as Gateway ``event`` frames; ``result`` resolves a command only when the
+request arrives on a transport ATTACHED to the session and that transport is the broker-recorded
+owner of the exact attached scope (the broker's exact-scope ``complete`` is the backstop).
+Capabilities come from the broker's explicit allowlist (no raw CDP/eval/uploads). Bodies are
+rebound onto server.py's globals (bind_module publishes this module's helpers too), which is how
+the session gate reaches ``_session_transport_contains`` with no import of its own.
 """
 
 from __future__ import annotations
@@ -81,9 +83,10 @@ def _controller_method(
     """Register a handler behind the shared fail-closed (4403) controller gates.
 
     Order: ``precheck(rid, params)`` (may return an error envelope) → caller holds a
-    server-authenticated, non-internal identity → the named session exists and its
-    ``transport`` is exactly the caller → when ``lookup_scope``, a scope is attached for
-    this session/principal/family and the caller owns it. Then
+    server-authenticated, non-internal identity → the named session exists and the caller is
+    ATTACHED to it, directly or through the ``FanoutTransport`` a mirrored session holds in its
+    slot → when ``lookup_scope``, a scope is attached for this session/principal/family and the
+    caller owns it. Then
     ``fn(rid, params, transport, identity, session_id, broker, scope, session)`` runs.
     """
 
@@ -102,7 +105,11 @@ def _controller_method(
             session_id = str(params.get("session_id") or "")
             with _sessions_lock:
                 session = _sessions.get(session_id)
-                if session is None or session.get("transport") is not transport:
+                # Membership, not slot identity: a mirrored session holds a FanoutTransport, which is
+                # identical to no peer's transport, so slot identity would refuse every client here — the
+                # peer that registered the controller included. The broker's is_owner check below still
+                # keys on the transport that attached the scope.
+                if not _session_transport_contains(session, transport):
                     return _err(rid, _ERR_FORBIDDEN, "session is not owned by this transport")
             broker = browser_control_broker.get_browser_control_broker()
             scope = None
@@ -190,7 +197,11 @@ def _(rid, params: dict, _transport, _identity, _session_id, broker, scope, _ses
 
 @_controller_method("browser.controller.heartbeat")
 def _(rid, params: dict, *_gate) -> dict:
-    """Acknowledge a heartbeat only for this transport's attached controller."""
+    """Acknowledge a heartbeat only for this transport's own attached controller.
+
+    The session gate admits any client attached to the session, including a fan-out peer; the
+    broker's ``is_owner`` check then narrows the answer to the transport that actually registered
+    the controller."""
     return _ok(rid, {"ok": True})
 
 

--- a/tui_gateway/methods_prompt.py
+++ b/tui_gateway/methods_prompt.py
@@ -572,10 +572,12 @@ def _(rid, params: dict) -> dict:
     turn_isolation = _session_uses_compute_host(session, _load_dashboard_process_isolation_config())
     if internal_hosted_submit and turn_isolation:
         return _err(rid, 4121, "hosted room turns do not support isolated compute workers yet")
-    # Re-bind to the current transport: streaming must stay on the active websocket even
-    # if a disconnect/fallback moved the session to stdio.
+    # Attach the current transport: streaming must stay on the active websocket even if a
+    # disconnect/fallback moved the session to stdio — and, since it attaches rather than rebinds,
+    # a second client submitting a prompt no longer cuts the first client out of the session it is
+    # watching.
     if (t := current_transport()) is not None:
-        session["transport"] = t
+        _attach_session_transport(session, t)
     # Claim the turn against a possibly-running session (busy/queued reply, else fall
     # through once ``running`` is observed False).  The provider interrupt happens after
     # history_lock is released (a non-interruptible tool may hold it); if the old turn

--- a/tui_gateway/methods_prompt.py
+++ b/tui_gateway/methods_prompt.py
@@ -503,9 +503,11 @@ _TRUNCATION_PARAMS = (
 
 
 def _lock_in_submit_turn(
-    rid, sid, session, text, params, has_truncation, requested_rebind_ids, hosted_task):
+    rid, sid, session, text, params, has_truncation, requested_rebind_ids, hosted_task, *, origin: str = ""):
     """Under ``history_lock``: refuse watch-child races / malformed truncation, apply the
-    cut, mark the turn running + in flight.  Returns ``(err, survivor_fields)``."""
+    cut, mark the turn running + in flight.  Returns ``(err, survivor_fields)``.
+    ``origin`` is the submitting connection's opaque id, captured where prompt.submit
+    attaches and stamped here, WITH the claim, so mirrored peers can attribute the turn."""
     fields = {}
     with session["history_lock"]:
         # A watch session's run lives in the PARENT turn (own running flag False); typing
@@ -523,6 +525,12 @@ def _lock_in_submit_turn(
             if err is not None:
                 return err, {}
         session["running"] = True
+        # This client owns the turn it just claimed: every session event the turn produces is stamped
+        # with this connection's origin, so mirrored peers can render "someone else is driving" instead
+        # of mistaking the stream for their own. Stamped WITH the claim, under the same lock, the way the
+        # queued drain and the auto-continue kickoff stamp theirs. "" (stdio, internal callers) means
+        # unknown and is omitted from the frames entirely.
+        session["turn_origin"] = origin
         session["_turn_cancel_requested"] = False
         session["last_active"] = time.time()
         if hosted_task is not None:
@@ -576,8 +584,14 @@ def _(rid, params: dict) -> dict:
     # disconnect/fallback moved the session to stdio — and, since it attaches rather than rebinds,
     # a second client submitting a prompt no longer cuts the first client out of the session it is
     # watching.
+    submit_origin = ""
     if (t := current_transport()) is not None:
         _attach_session_transport(session, t)
+        # CAPTURED here, STAMPED at the claim below (_lock_in_submit_turn). Attaching is not claiming:
+        # a submit that lands mid-turn redirects, queues, or is refused without ever starting a turn,
+        # and must not repaint the frames of the turn that IS running with the origin of the client
+        # that merely typed over it.
+        submit_origin = _transport_origin(t)
     # Claim the turn against a possibly-running session (busy/queued reply, else fall
     # through once ``running`` is observed False).  The provider interrupt happens after
     # history_lock is released (a non-interruptible tool may hold it); if the old turn
@@ -599,7 +613,8 @@ def _(rid, params: dict) -> dict:
         {r for r in raw_rebind_ids if isinstance(r, int) and not isinstance(r, bool)}
         if isinstance(raw_rebind_ids, list) else None)
     err, survivor_fields = _lock_in_submit_turn(
-        rid, sid, session, text, params, has_truncation, requested_rebind_ids, hosted_task)
+        rid, sid, session, text, params, has_truncation, requested_rebind_ids, hosted_task,
+        origin=submit_origin)
     if err is not None:
         return err
     if turn_isolation:

--- a/tui_gateway/methods_session.py
+++ b/tui_gateway/methods_session.py
@@ -519,18 +519,21 @@ def _find_live_unpersisted(needle: str, home) -> str:
 
 def _resume_live_unpersisted(ctx: _Resume, live_sid: str, live: dict) -> dict:
     """Reattach a LIVE lazy session with no state.db row yet (every fresh Bot Chat; a 404 here killed messaging
-    for never-spoken bots). Rebind the transport and cancel the armed orphan-reap Timer (a WS drop may have
+    for never-spoken bots). Attach the transport and cancel the armed orphan-reap Timer (a WS drop may have
     sentinel-parked the record) or it fires against this client."""
     if ctx.owns_db:
         _release_db(ctx.db)
     live["last_active"] = time.time()
     if (transport := current_transport()) is not None:
         # This resume reattaches the live record. A lazy session (no state.db row yet — every fresh Bot
-        # Chat) that was sentinel-parked by a WS drop MUST be rebound here, or it keeps the drop sentinel
+        # Chat) that was sentinel-parked by a WS drop MUST be reattached here, or it keeps the drop sentinel
         # and the armed orphan-reap Timer fires against a client that is attached right now — the
         # unpersisted sibling of the storm-killer paths (#91276).
         with live.setdefault("history_lock", threading.Lock()):
-            live["transport"] = transport
+            # Attach additively so a second client resuming this live record does not steal the stream
+            # from the one already attached; attaching a live transport also un-parks a sentinel slot,
+            # which is what #91276 needed here.
+            _attach_session_transport(live, transport)
             live.setdefault("viewers", {})[transport] = time.time()
     _cancel_ws_orphan_reap(live_sid)
     history = live.get("history") or []
@@ -629,7 +632,8 @@ def _resume_guard(ctx: _Resume) -> dict | None:
 
 def _resume_reuse_live(ctx: _Resume, sid: str, session: dict) -> dict:
     """Reattach an already-live session under the resume lock (held across the client-gone check,
-    transport rebind and reap cancel so grace expiry is atomic)."""
+    transport attach and reap cancel so grace expiry is atomic). _live_session_payload ATTACHES this
+    caller alongside the client(s) already streaming instead of taking the slot from them."""
     with _session_resume_lock:
         if _sessions.get(sid) is not session:
             return _err(ctx.rid, 4007, "session no longer live; retry resume")
@@ -889,7 +893,10 @@ def _(rid, params: dict) -> dict:
 
 @_session_method("session.activate")
 def _(rid, params: dict, session: dict) -> dict:
-    """Attach the frontend to a live TUI session without closing the previously focused one."""
+    """Attach the frontend to a live TUI session without closing the previously focused one.
+
+    _live_session_payload ATTACHES this caller to the session rather than rebinding it, so activating a
+    session someone else is already streaming mirrors it instead of stealing it."""
     return _ok(rid, _live_session_payload(
         str(params.get("session_id") or ""), session, touch=True, transport=current_transport() or _stdio_transport,
         omit_messages=is_truthy_value(params.get("omit_messages", False))))

--- a/tui_gateway/methods_session.py
+++ b/tui_gateway/methods_session.py
@@ -640,9 +640,14 @@ def _resume_reuse_live(ctx: _Resume, sid: str, session: dict) -> dict:
         if session.get("_client_gone_interrupt_requested"):
             return _err(ctx.rid, 4009, "session disconnect interrupt settling")
         _cancel_ws_orphan_reap(sid)  # unconditionally: the fast path must never race the reap Timer
+        caller = current_transport() or _stdio_transport
+        # Read BEFORE the attach below: "watching" means somebody ELSE was already on this session when we
+        # arrived, i.e. this client joined a stream in progress rather than taking the session over.
+        watching = _session_has_live_transport(session, excluding=caller)
         payload = _live_session_payload(sid, session, cols=ctx.cols, touch=True, omit_messages=ctx.omit_messages,
-                                        transport=current_transport() or _stdio_transport)
+                                        transport=caller)
         payload["resumed"] = ctx.target
+        payload["watching"] = watching
         if ctx.defer_history:
             payload.update(messages=[], hydrating=bool(session.get("resume_hydrating")),
                            message_count=int(session.get("resume_message_count") or payload["message_count"]))
@@ -662,10 +667,14 @@ def _resume_response(
         messages = ctx.messages(display)
     if message_count is None:
         message_count = len(count_source) if ctx.omit_messages else len(messages)
+    # Every path that reaches here REGISTERED the live session for this caller — lazy child-watch, deferred,
+    # cold and eager alike — so nobody else was streaming it when the caller arrived. A resume that found a
+    # session already live returns through _resume_reuse_live instead, which computes ``watching`` for real.
     payload = {"session_id": sid, "resumed": ctx.target, "message_count": message_count, "messages": messages,
                **({"messages_omitted": ctx.omit_messages} if hydrating is None else {"hydrating": hydrating}),
                "info": info, "inflight": None, "running": running, "session_key": ctx.target,
-               "started_at": record["created_at"] if started_at is None else started_at, "status": status}
+               "started_at": record["created_at"] if started_at is None else started_at, "status": status,
+               "watching": False}
     if auto_continue is not None:
         payload["auto_continue"] = auto_continue
     return _ok(ctx.rid, _attach_todo_state(payload, record))
@@ -897,9 +906,15 @@ def _(rid, params: dict, session: dict) -> dict:
 
     _live_session_payload ATTACHES this caller to the session rather than rebinding it, so activating a
     session someone else is already streaming mirrors it instead of stealing it."""
-    return _ok(rid, _live_session_payload(
-        str(params.get("session_id") or ""), session, touch=True, transport=current_transport() or _stdio_transport,
-        omit_messages=is_truthy_value(params.get("omit_messages", False))))
+    caller = current_transport() or _stdio_transport
+    # Read before the attach, same contract as session.resume: True means this client joined a session
+    # another client is already streaming.
+    watching = _session_has_live_transport(session, excluding=caller)
+    payload = _live_session_payload(
+        str(params.get("session_id") or ""), session, touch=True, transport=caller,
+        omit_messages=is_truthy_value(params.get("omit_messages", False)))
+    payload["watching"] = watching
+    return _ok(rid, payload)
 
 
 @method("session.delete")

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -914,16 +914,20 @@ def handle_request(req: dict) -> dict | None:
 
 def _current_session_steer_authority(session_id: str) -> tuple[Transport | None, dict | None]:
     """Unforgeable steering authority for this RPC context: the public session id is only a lookup
-    hint; authority is the identity of BOTH the ContextVar-bound transport and the live in-memory
-    record under that id, so transport rebinding, removal or id reuse invalidates an earlier generation."""
+    hint; authority requires the ContextVar-bound transport to be ATTACHED to the live in-memory record
+    under that id, so transport detachment, session removal or id reuse invalidates an earlier generation."""
     transport = current_transport()
     if transport is None or not session_id:
         return None, None
     expected_session = _current_runtime_session_record.get()
     with _sessions_lock:
         session = _sessions.get(session_id)
+        # Membership, not slot identity: a mirrored session stores a FanoutTransport in the slot, so slot
+        # identity alone would reject every client, the peer that commissioned the subagent included.
+        # Authority is membership in the slot, which also grants it to any client attached to mirror the
+        # session (see tests/tui_gateway/test_multi_client_fanout.py).
         if (session is None or (expected_session is not None and session is not expected_session)
-                or session.get("transport") is not transport):
+                or not _session_transport_contains(session, transport)):
             return None, None
         return transport, session
 

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -34,7 +34,8 @@ from agent.conversation_loop import INTERRUPT_WAITING_FOR_MODEL_PREFIX  # noqa: 
 from tui_gateway import git_probe
 from tui_gateway._env import env_float, env_int
 from tui_gateway.turn_marker import clear_turn_marker, read_turn_marker, record_turn_start  # noqa: F401
-from tui_gateway.transport import (StdioTransport, Transport, bind_transport, current_transport, reset_transport)
+from tui_gateway.transport import (FanoutTransport, StdioTransport, Transport, bind_transport,
+                                   current_transport, reset_transport)
 
 logger = logging.getLogger(__name__)
 
@@ -207,6 +208,180 @@ _stdio_transport = StdioTransport(lambda: _real_stdout, _stdout_lock)
 # Detached websocket sessions use a drop sink instead of stdio: Desktop embeds the gateway in-process
 # and captures stdout into logs, so stale frames must not fall through while a session awaits resume/reap.
 _detached_ws_transport = _DropTransport()
+
+
+# ── multi-client fan-out ─────────────────────────────────────────────────────
+#
+# A session's ``transport`` slot holds either ONE transport — the historical,
+# single-client shape, byte-identical to pre-fan-out behaviour — or a
+# ``FanoutTransport`` wrapping several. Because the fan-out satisfies the same
+# Transport protocol, ``write_json`` and every other reader of the slot are
+# untouched; only the attach/detach ladder below knows the difference.
+#
+# ``_session_transport_lock`` serializes the read-modify-write of that one slot.
+# It is a LEAF lock: nothing under it acquires ``_sessions_lock`` or a session's
+# ``history_lock`` (the fan-out's own lock is likewise a leaf), so it is safe to
+# take while holding either of those.
+_session_transport_lock = threading.Lock()
+
+
+def _transport_is_live_peer(transport) -> bool:
+    """True when *transport* is a real, currently attached client.
+
+    Excluded: the parked drop sentinel (by definition clientless) and stdio,
+    which is the process-wide fallback sink — a standalone ``hermes --tui``
+    writes there, but nothing "attaches" to it and a second client can never
+    share it.
+    """
+    if transport is None:
+        return False
+    if transport is _detached_ws_transport or transport is _stdio_transport:
+        return False
+    if isinstance(transport, (_DropTransport, StdioTransport)):
+        return False
+    # A socket that already latched ``_closed`` is a departed client, not a live
+    # peer: without this, a stale WSTransport keeps a session out of the park /
+    # reap path and keeps answering "another client is still here".
+    # ``_transport_is_dead`` is the deadness predicate this module shares with
+    # the reaper (defined in ``session_reaper``, published onto this namespace
+    # by ``method_ctx.bind_module``; module globals resolve at call time).
+    return not _transport_is_dead(transport)
+
+
+def _session_transport_contains(session: dict | None, transport) -> bool:
+    """True when *transport* is attached to *session*, directly or via fan-out."""
+    if not session or transport is None:
+        return False
+    existing = session.get("transport")
+    if existing is transport:
+        return True
+    if isinstance(existing, FanoutTransport):
+        return existing.contains(transport)
+    return False
+
+
+def _session_live_transports(session: dict | None) -> list:
+    """Every live client attached to *session* (empty for a parked/stdio slot)."""
+    existing = (session or {}).get("transport")
+    if isinstance(existing, FanoutTransport):
+        return [t for t in existing.transports() if _transport_is_live_peer(t)]
+    return [existing] if _transport_is_live_peer(existing) else []
+
+
+def _session_has_live_transport(session: dict | None, *, excluding=None) -> bool:
+    """True when *session* still has a live client attached, ignoring *excluding*.
+
+    ``excluding`` answers whether another live client remains once one peer is
+    ignored, which is what the detach and orphan paths need: whether anything
+    survives the departing transport.
+    """
+    return any(t is not excluding for t in _session_live_transports(session))
+
+
+def _attach_session_transport(session: dict | None, transport) -> bool:
+    """Attach *transport* to *session* ADDITIVELY — never steal the slot.
+
+    A ``FanoutTransport`` argument is FLATTENED before the ladder runs, whatever
+    the slot holds: each of its peers is attached as a leaf, so the slot never
+    nests one fan-out inside another. The queued-prompt paths make that
+    reachable — a busy submit records ``session["transport"]`` as the prompt's
+    transport, which is the fan-out itself when two clients are attached, and
+    the drain hands it back here after a disconnect has collapsed the slot to a
+    single client. Nesting would blind every single-level reader of the slot
+    (``FanoutTransport.contains``, the steer-authority scan, detach) to the
+    inner peers, so a client inside the inner fan-out could never be found,
+    parked, reaped, or granted authority over its own turn.
+
+    The ladder, for the leaf newcomer that always reaches it:
+
+    * same object already in the slot → no-op;
+    * the slot already fans out → attach into it;
+    * the slot is empty / stdio / the parked drop sentinel → take the slot,
+      which is exactly what the old rebind did;
+    * otherwise → wrap the incumbent and the newcomer in a ``FanoutTransport``
+      so both clients keep streaming.
+
+    A non-peer newcomer (stdio, drop sentinel) never displaces a live client:
+    an activate/resume dispatched without a bound websocket must not silence the
+    socket that owns the session.
+
+    Returns ``True`` when *transport* is attached afterwards.
+    """
+    if not session or transport is None:
+        return False
+    if isinstance(transport, FanoutTransport):
+        # Flatten OUTSIDE the lock — _session_transport_lock is not reentrant.
+        # Each peer then walks the ladder on its own, so a peer whose socket
+        # died while the prompt sat in the queue is dropped by the liveness rung
+        # instead of being pinned back into the slot.
+        attached = False
+        for peer in transport.transports():
+            if _attach_session_transport(session, peer):
+                attached = True
+        return attached
+    with _session_transport_lock:
+        existing = session.get("transport")
+        if existing is transport:
+            return True
+        if isinstance(existing, FanoutTransport):
+            if isinstance(transport, FanoutTransport):
+                for member in transport.transports():
+                    existing.attach(member)
+            else:
+                existing.attach(transport)
+            return True
+        if not _transport_is_live_peer(transport):
+            if _transport_is_live_peer(existing):
+                return False
+            session["transport"] = transport
+            return True
+        if not _transport_is_live_peer(existing):
+            session["transport"] = transport
+            return True
+        session["transport"] = FanoutTransport(existing, transport)
+        return True
+
+
+def _detach_session_transport(session: dict | None, transport) -> bool:
+    """Detach *transport* from *session*'s slot.
+
+    Returns ``True`` when a live client OTHER than *transport* remains — i.e.
+    the session must keep streaming and must NOT be parked or reaped. A
+    single-client session leaves the departing transport in the slot, exactly as
+    before fan-out existed; its caller parks the drop sentinel over it.
+    """
+    if not session:
+        return False
+    with _session_transport_lock:
+        existing = session.get("transport")
+        if isinstance(existing, FanoutTransport):
+            existing.detach(transport)
+            remaining = existing.transports()
+            if len(remaining) == 1:
+                # Collapse: a session back down to one client is indistinguishable
+                # from one that never fanned out.
+                session["transport"] = remaining[0]
+    return _session_has_live_transport(session, excluding=transport)
+
+
+def _detach_transport_from_sessions(transport) -> list[tuple[str, dict]]:
+    """Detach *transport* from every session holding it.
+
+    Returns the ``(sid, session)`` pairs left with NO live client — the ones the
+    disconnect path must park or reap. Sessions that retain another attached
+    client keep streaming and are not returned.
+    """
+    with _sessions_lock:
+        attached = [
+            (sid, s)
+            for sid, s in _sessions.items()
+            if _session_transport_contains(s, transport)
+        ]
+    return [
+        (sid, session)
+        for sid, session in attached
+        if not _detach_session_transport(session, transport)
+    ]
 
 
 def _prepend_tool_paths(env: dict[str, str]) -> dict[str, str]:
@@ -2693,9 +2868,12 @@ def _live_session_payload(
         if cols is not None:
             session["cols"] = cols
         if transport is not None:
-            session["transport"] = transport
-            # Every transport that showed this session (pop-outs resume the same sid); on disconnect the last
-            # viewer becomes the transport instead of the drop sentinel.
+            # Resume/activate of a LIVE session ATTACHES the caller alongside whoever is already streaming
+            # instead of rebinding the slot — the old rebind is what made a second client steal the stream.
+            _attach_session_transport(session, transport)
+            # Every transport that showed this session (pop-outs resume the same sid). Fan-out membership now
+            # carries the surviving-window case the disconnect path used this for; the registry is still
+            # written and still pruned on disconnect.
             session.setdefault("viewers", {})[transport] = time.time()
             # See #83716.
             if transport is not _detached_ws_transport:

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -745,6 +745,14 @@ def write_json(obj: dict) -> bool:
 
 def _event_frame(event: str, sid: str, payload: dict | None = None) -> dict:
     params: dict = {"type": event, "session_id": sid, **({"payload": payload} if payload is not None else {})}
+    # Multi-client fan-out: tell every mirrored client WHICH client started the turn this frame belongs to —
+    # its own connection's ``origin`` (announced in gateway.ready), a peer's, or "auto_continue" for the
+    # crash-recovery kickoff. Stamped here, at frame creation, so it costs one dict read and every emitter
+    # gets it for free. Purely additive: the key is omitted whenever the origin is unknown, which is always
+    # the case for a stdio TUI and for a session-less broadcast, so no frame changes shape for a
+    # single-client deployment.
+    if sid and (origin := str((_sessions.get(sid) or {}).get("turn_origin") or "")):
+        params["origin"] = origin
     return {"jsonrpc": "2.0", "method": "event", "params": params}
 
 
@@ -769,6 +777,15 @@ def unregister_live_transport(transport: Transport | None) -> None:
     """Stop tracking a transport (call on disconnect). Idempotent."""
     with _live_transports_lock:
         _live_transports.discard(transport)
+
+
+def _transport_origin(transport) -> str:
+    """The opaque per-connection id of *transport*, or ``""`` when it has none.
+
+    Set by ``tui_gateway.ws`` on each accepted WebSocket. stdio and test doubles
+    have none, which is why ``origin`` is omitted rather than emitted empty.
+    """
+    return str(getattr(transport, "transport_id", "") or "")
 
 
 def _broadcast_global_event(event: str, payload: dict | None = None) -> None:

--- a/tui_gateway/session_auto_continue.py
+++ b/tui_gateway/session_auto_continue.py
@@ -106,6 +106,9 @@ def _maybe_schedule_auto_continue(sid: str, session: dict, session_key: str) -> 
             # Marker inputs read back by _run_prompt_submit: attempt count (crash breaker) and the ORIGINAL prompt (no
             # nested notes). Set here, not at schedule time, so a bail above leaves nothing for a racing user turn.
             session["_auto_continue_attempt"], session["_auto_continue_prompt"] = attempt, marker["prompt"]
+            # No client started this turn — the gateway did, recovering a crash. Mirrored clients see origin
+            # "auto_continue" and know the stream is nobody's typing.
+            session["turn_origin"] = "auto_continue"
         try:
             _emit("status.update", sid, {"kind": "process", "text": "Resuming interrupted turn…"})
             _emit("message.start", sid)
@@ -290,8 +293,13 @@ def _drain_queued_prompt(rid, sid: str, session: dict) -> bool:
         # ATTACHED, not rebound: a mid-turn prompt from a second client used to silence the first for the
         # whole drained turn. A peer that disconnected while its prompt sat in the queue is skipped: the
         # prompt still runs, only the dead pin is dropped.
-        if queued_transport is not None and not _transport_is_dead(queued_transport):
-            _attach_session_transport(session, queued_transport)
+        if queued_transport is not None:
+            # The drained turn belongs to whoever QUEUED it, not to whoever happened to be driving the
+            # session when it finally fires. The dead-peer skip is about the attach only: a queuer that
+            # dropped while its prompt waited still owns the turn that prompt starts.
+            session["turn_origin"] = _transport_origin(queued_transport)
+            if not _transport_is_dead(queued_transport):
+                _attach_session_transport(session, queued_transport)
     use_compute_host = _session_uses_compute_host(session)
     with session["history_lock"]:
         if int(session.get("_queued_prompt_generation", 0)) != queue_generation:

--- a/tui_gateway/session_auto_continue.py
+++ b/tui_gateway/session_auto_continue.py
@@ -285,11 +285,13 @@ def _drain_queued_prompt(rid, sid: str, session: dict) -> bool:
         queue_generation = int(session.get("_queued_prompt_generation", 0))
         _ac_set_queue(session, session.get("queued_prompts") or [])
         session["running"] = True
-        if queued.get("transport") is not None:
-            # The queuer's transport is pinned so the drained turn reaches the client that sent it — but
-            # ATTACHED, not rebound: a mid-turn prompt from a second client used to silence the first for the
-            # whole drained turn.
-            _attach_session_transport(session, queued["transport"])
+        queued_transport = queued.get("transport")
+        # The queuer's transport is pinned so the drained turn reaches the client that sent it — but
+        # ATTACHED, not rebound: a mid-turn prompt from a second client used to silence the first for the
+        # whole drained turn. A peer that disconnected while its prompt sat in the queue is skipped: the
+        # prompt still runs, only the dead pin is dropped.
+        if queued_transport is not None and not _transport_is_dead(queued_transport):
+            _attach_session_transport(session, queued_transport)
     use_compute_host = _session_uses_compute_host(session)
     with session["history_lock"]:
         if int(session.get("_queued_prompt_generation", 0)) != queue_generation:

--- a/tui_gateway/session_auto_continue.py
+++ b/tui_gateway/session_auto_continue.py
@@ -286,7 +286,10 @@ def _drain_queued_prompt(rid, sid: str, session: dict) -> bool:
         _ac_set_queue(session, session.get("queued_prompts") or [])
         session["running"] = True
         if queued.get("transport") is not None:
-            session["transport"] = queued["transport"]
+            # The queuer's transport is pinned so the drained turn reaches the client that sent it — but
+            # ATTACHED, not rebound: a mid-turn prompt from a second client used to silence the first for the
+            # whole drained turn.
+            _attach_session_transport(session, queued["transport"])
     use_compute_host = _session_uses_compute_host(session)
     with session["history_lock"]:
         if int(session.get("_queued_prompt_generation", 0)) != queue_generation:

--- a/tui_gateway/session_lifecycle.py
+++ b/tui_gateway/session_lifecycle.py
@@ -536,39 +536,45 @@ def _schedule_ws_orphan_reap(sid: str, *, delay_s: float | None = None) -> None:
 def _close_sessions_for_transport(transport, *, end_reason: str = "ws_disconnect") -> tuple[int, int]:
     """Single WS-disconnect teardown entry point: reap close_on_disconnect sessions (sidecar/dashboard) immediately;
     re-point the rest at the detached transport (later emits miss the dead socket) for the grace-windowed WS-orphan
-    reaper. Returns ``(reaped, detached)`` counts."""
-    with _sessions_lock:
-        owned = [(sid, s) for sid, s in _sessions.items() if s.get("transport") is transport]
+    reaper. Returns ``(reaped, detached)`` counts.
+
+    Multi-client fan-out: the departing transport is DETACHED from every session first. A session that still has
+    another client attached keeps streaming and is neither parked nor reaped — a watcher leaving must not end the
+    turn the remaining client is reading. Only the sessions left clientless take the historical
+    close_on_disconnect / park-sentinel path, so a single-client disconnect behaves exactly as it always has."""
+    clientless = _detach_transport_from_sessions(transport)
     reaped = detached = 0
-    for sid, session in owned:
+    for sid, session in clientless:
         claimed_for_teardown = None
         should_schedule_reap = False
-        # session.resume fast-path rebinds under _session_resume_lock: take it so a reconnect can't move the transport
-        # between check and claim.
+        # session.resume fast-path attaches under _session_resume_lock: take it so a reconnect can't attach
+        # between the detach above and the claim.
         with _session_resume_lock, _sessions_lock:
             current = _sessions.get(sid)
             if current is not session:
                 continue
-            if current.get("transport") is not transport:
-                # The reconnect owns this session now; drop only the old viewer registration.
-                (current.get("viewers") or {}).pop(transport, None)
-                continue
+            # Prune the departing viewer registration in every branch; it must not affect the new owner.
+            (current.get("viewers") or {}).pop(transport, None)
+            # Revalidate before claiming (#77129, kept under fan-out): between _detach_transport_from_sessions
+            # returning this session as clientless and this claim, a concurrent session.resume can attach a NEW
+            # live transport. Tearing the session down, or parking the sentinel over it, would knock an attached
+            # client into detached state and arm an orphan reap against a session that has a live owner. Attach
+            # and detach both serialize on _session_transport_lock, so this check is race-free against them; that
+            # lock is a leaf, so taking it under _sessions_lock is safe and _session_has_live_transport does not
+            # re-acquire it.
+            with _session_transport_lock:
+                if _session_has_live_transport(current, excluding=transport):
+                    continue
             if current.get("close_on_disconnect"):
                 claimed_for_teardown = _pop_session_by_id(sid)
             else:
                 # Point at the drop sentinel (NOT real stdio) so _ws_session_is_orphaned recognizes it; standalone
-                # `hermes --tui` keeps real _stdio. UNLESS another window (pop-out viewer) still shows the session:
-                # re-bind to the most recent surviving viewer instead.
-                viewers = current.get("viewers") or {}
-                # See #83716.
-                viewers.pop(transport, None)
-                live = [vt for vt, ts in sorted(viewers.items(), key=lambda kv: kv[1]) if not _transport_is_dead(vt)]
-                if live:
-                    current["transport"] = live[-1]
-                else:
-                    current["transport"] = _detached_ws_transport
-                    current.pop("_client_gone_interrupt_requested", None)
-                    should_schedule_reap = True
+                # `hermes --tui` keeps real _stdio. The #83716 rebind-to-surviving-viewer is subsumed by fan-out
+                # membership: a pop-out window is a fan-out peer, so a session that still shows in another window
+                # is never returned here as clientless.
+                current["transport"] = _detached_ws_transport
+                current.pop("_client_gone_interrupt_requested", None)
+                should_schedule_reap = True
         if claimed_for_teardown is not None:
             reaped += _teardown_popped_session(claimed_for_teardown, end_reason=end_reason)
         elif should_schedule_reap:

--- a/tui_gateway/session_reaper.py
+++ b/tui_gateway/session_reaper.py
@@ -133,7 +133,18 @@ def install_exit_flush_signal_handlers() -> bool:
 def _transport_is_dead(transport) -> bool:
     # _detached_ws_transport is the post-disconnect drop sentinel. _stdio_transport is the REAL transport for
     # standalone `hermes --tui` and must NOT count as dead.
-    return transport is _detached_ws_transport or getattr(transport, "_closed", None) is True
+    if transport is _detached_ws_transport:
+        return True
+    if isinstance(transport, FanoutTransport):
+        # A fan-out is never the sentinel and has no ``_closed`` of its own, so without this arm every
+        # multi-client session reads as alive forever — the TTL reaper, the LRU cap and the #77129 disconnect
+        # revalidation all gate on this predicate. A fan-out can legitimately end up empty, or holding nothing
+        # but closed sockets, with no disconnect passing through _close_sessions_for_transport: a failed write
+        # prunes the peer that failed. It is dead exactly when no peer of its own is alive, and an empty one is
+        # dead. Peers are always leaf transports (attach flattens a fan-out argument instead of nesting it), so
+        # this recurses one level at most.
+        return all(_transport_is_dead(peer) for peer in transport.transports())
+    return getattr(transport, "_closed", None) is True
 
 
 def _session_is_lru_evictable(sid: str, session: dict) -> bool:

--- a/tui_gateway/transport.py
+++ b/tui_gateway/transport.py
@@ -9,6 +9,8 @@ A :class:`Transport` forwards a JSON-serialisable dict to its peer, so one dispa
 
 from __future__ import annotations
 
+import asyncio
+import concurrent.futures
 import contextlib
 import contextvars
 import errno
@@ -16,6 +18,7 @@ import json
 import logging
 import os
 import threading
+import time
 from typing import Any, Callable, Optional, Protocol, runtime_checkable
 
 # Errno values that mean "the peer is gone" rather than "the host has a real I/O problem". Anything
@@ -31,6 +34,64 @@ logger = logging.getLogger(__name__)
 # while the gateway still emits) flush can block long enough to starve the worker pool. Python text stdout is
 # fully buffered on a pipe, so this ONLY makes sense with ``-u``/``PYTHONUNBUFFERED=1``; otherwise the TUI hangs.
 _DISABLE_FLUSH = (os.environ.get("HERMES_TUI_GATEWAY_NO_FLUSH", "") or "").strip().lower() in {"1", "true", "yes", "on"}
+
+# Worker pool behind FanoutTransport.write.  A non-streaming WebSocket write
+# blocks the calling thread while the owning event loop flushes the frame — up
+# to ``tui_gateway.ws._WS_WRITE_TIMEOUT_S`` (10s) when that loop is stalled —
+# so walking a session's peers one at a time lets one wedged client hold the
+# frame back from every healthy client behind it.  The pool is created lazily
+# and only ever used when a session has more than one peer, so the ordinary
+# single-client gateway never starts a thread.
+#
+# Sizing: these workers are idle except while a peer is actually wedged, so the
+# cap only has to cover the wedged peers of all sessions at once.  If it were
+# ever saturated the excess writes queue and run in submission order, which is
+# the pre-pool behaviour — degraded, not broken.
+_FANOUT_POOL_MAX_WORKERS = 32
+
+# Wall-clock bound on ONE fan-out write, measured from before the first peer is
+# dispatched.  Deliberately larger than ``tui_gateway.ws._WS_WRITE_TIMEOUT_S``
+# (10.0) so a merely-slow peer reaches its own timeout and reports for itself;
+# this deadline only exists so a peer that never returns at all cannot pin the
+# emitting thread forever.  Not imported from ``tui_gateway.ws``: that module
+# imports ``tui_gateway.server``, which imports this one, so the import would
+# be circular.  Drift is harmless — a peer that misses this deadline is treated
+# as in-flight, not as dead (see ``FanoutTransport.write``).
+_FANOUT_WRITE_DEADLINE_S = 12.0
+
+_fanout_pool: "concurrent.futures.ThreadPoolExecutor | None" = None
+_fanout_pool_lock = threading.Lock()
+
+
+def _fanout_write_pool() -> "concurrent.futures.ThreadPoolExecutor":
+    """The shared fan-out pool, created on first multi-peer write."""
+    global _fanout_pool
+    pool = _fanout_pool
+    if pool is not None:
+        return pool
+    with _fanout_pool_lock:
+        if _fanout_pool is None:
+            _fanout_pool = concurrent.futures.ThreadPoolExecutor(
+                max_workers=_FANOUT_POOL_MAX_WORKERS,
+                thread_name_prefix="tui-fanout",
+            )
+        return _fanout_pool
+
+
+def _caller_is_on_event_loop() -> bool:
+    """True when the CALLING thread is running an asyncio event loop.
+
+    Mirrors the probe in ``tui_gateway.ws.WSTransport.write``, which takes a
+    fire-and-forget path when it can see it is on its own loop and a BLOCKING
+    ``fut.result`` path when it cannot.  ``FanoutTransport`` owns no loop and
+    its peers may sit on different ones, so the test here is the conservative
+    one: if this thread is running any loop at all, keep the peer writes on it.
+    """
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        return False
+    return True
 
 
 @runtime_checkable
@@ -113,6 +174,208 @@ class StdioTransport:
 
     def close(self) -> None:
         return None
+
+
+class FanoutTransport:
+    """Delivers one JSON frame to every client attached to a session.
+
+    A session's ``transport`` slot used to hold exactly one client, so every
+    ``prompt.submit`` / ``session.resume`` / ``session.activate`` / queued-prompt
+    drain REBOUND it and whichever client was there before went silent.  This
+    object goes in the same slot and satisfies the same :class:`Transport`
+    protocol, so ``server.write_json`` — and every other reader of that slot —
+    is unchanged; the only difference is that N clients receive the frame
+    instead of the most recent one.
+
+    Scope: this carries a session's ASYNC EVENT stream only.  Request/response
+    RPCs still answer on the request's context-bound transport
+    (``dispatch`` → ``current_transport()``), so a client only ever sees replies
+    to its own calls.
+
+    Peers are pruned on failure: a transport that returns ``False`` (peer gone)
+    or raises is dropped from the fan-out instead of being written to forever.
+    Pruning is about dead peers, not slow ones — a client that is merely wedged
+    is kept, and :meth:`write` runs the peer writes concurrently so its stall
+    stays its own.
+    """
+
+    __slots__ = ("_lock", "_transports")
+
+    def __init__(self, *transports: "Transport") -> None:
+        self._lock = threading.Lock()
+        self._transports: list["Transport"] = []
+        for transport in transports:
+            self.attach(transport)
+
+    def attach(self, transport: "Transport") -> bool:
+        """Add *transport*. Returns ``True`` when it was not already attached."""
+        if transport is None or transport is self:
+            return False
+        with self._lock:
+            for existing in self._transports:
+                if existing is transport:
+                    return False
+            self._transports.append(transport)
+            return True
+
+    def detach(self, transport: "Transport") -> bool:
+        """Remove *transport*. Returns ``True`` when it was attached."""
+        with self._lock:
+            for idx, existing in enumerate(self._transports):
+                if existing is transport:
+                    del self._transports[idx]
+                    return True
+        return False
+
+    def contains(self, transport: "Transport") -> bool:
+        with self._lock:
+            return any(existing is transport for existing in self._transports)
+
+    def transports(self) -> list["Transport"]:
+        """A snapshot of the attached transports (safe to iterate)."""
+        with self._lock:
+            return list(self._transports)
+
+    def has_transports(self, *, excluding: "Transport | None" = None) -> bool:
+        """True when any transport other than *excluding* is still attached."""
+        with self._lock:
+            return any(existing is not excluding for existing in self._transports)
+
+    @staticmethod
+    def _deliver(transport: "Transport", obj: dict, dead: list) -> bool:
+        """Write *obj* to one peer inline.  Records a dead peer in *dead*.
+
+        Returns ``True`` when the peer took the frame.
+        """
+        try:
+            ok = transport.write(obj)
+        except Exception:
+            logger.debug("fanout write failed; pruning peer", exc_info=True)
+            dead.append(transport)
+            return False
+        if ok:
+            return True
+        dead.append(transport)
+        return False
+
+    def write(self, obj: dict) -> bool:
+        """Deliver *obj* to every attached transport.
+
+        Iterates a SNAPSHOT and never holds the lock across a peer write, so a
+        peer write can never block an attach or a detach.
+
+        With more than one peer the writes run CONCURRENTLY: every peer but one
+        is handed to a shared worker pool and the last runs on the calling
+        thread, which is going to block here anyway.  Serial delivery would let
+        a client wedged for the full WS write timeout hold the frame back from
+        every healthy client behind it in the list; this way each peer's stall
+        is its own.  Two cases stay inline:
+
+        * exactly one peer, so a single-client session is untouched;
+        * a caller already running on an event loop.  ``WSTransport.write``
+          fires and forgets when it sees its own loop and BLOCKS on
+          ``fut.result`` when it does not, so moving a loop-thread write onto a
+          pool thread would make that thread wait on the loop it just left
+          while the loop waits on it — a full write-timeout freeze.
+
+        Pruning is unchanged: a peer that returns ``False`` or raises is
+        detached, whichever path it took.  A peer that has not answered by
+        ``_FANOUT_WRITE_DEADLINE_S`` is NOT pruned — slow is not dead — and
+        counts as delivered, which is what ``WSTransport.write`` itself reports
+        when its own write times out: the frame is queued on that peer's loop
+        and flushes when the loop breathes.  If that peer really is gone, its
+        next write returns ``False`` promptly and prunes it then.
+
+        The collect happens before the return, so frame A is on every peer that
+        answered within the deadline before frame B is dispatched to any of
+        them.  A peer whose write was still queued on the pool when the deadline
+        passed is the exception: the next frame can reach that peer's own
+        ``_token_lock`` while the previous one is still waiting for it, and the
+        lock — not this method — decides the order they land in.  Within a peer,
+        ordering is that peer's own business (``WSTransport`` queues under its
+        token lock, ``StdioTransport`` writes under its stream lock);
+        ``server.write_json`` takes no lock, so concurrent emitters interleave
+        here exactly as they already did.
+
+        Returns ``True`` when at least one client accepted the frame or still
+        has it in flight — an all-dead fan-out reports peer-gone exactly like a
+        single dead transport would.
+        """
+        targets = self.transports()
+        if not targets:
+            return False
+
+        dead: list["Transport"] = []
+        delivered = False
+
+        if len(targets) == 1 or _caller_is_on_event_loop():
+            for transport in targets:
+                if self._deliver(transport, obj, dead):
+                    delivered = True
+            for transport in dead:
+                self.detach(transport)
+            return delivered
+
+        deadline = time.monotonic() + _FANOUT_WRITE_DEADLINE_S
+        pool = _fanout_write_pool()
+        dispatched: list[tuple["Transport", "concurrent.futures.Future | None"]] = []
+        for transport in targets[:-1]:
+            try:
+                dispatched.append((transport, pool.submit(transport.write, obj)))
+            except RuntimeError:
+                # Pool refused the work (interpreter shutting down).  Deliver
+                # inline below rather than dropping the frame.
+                dispatched.append((transport, None))
+
+        # The last peer runs here: one fewer worker per write, and a two-client
+        # session costs a single pool thread.
+        if self._deliver(targets[-1], obj, dead):
+            delivered = True
+
+        # One deadline for the whole batch, then read only the futures that
+        # finished.  Waiting first and calling ``result()`` on a settled future
+        # keeps our deadline distinguishable from a peer that raised: on 3.11+
+        # ``concurrent.futures.TimeoutError`` IS the builtin ``TimeoutError``,
+        # so a ``result(timeout=...)`` cannot tell the two apart.
+        futures = [fut for _, fut in dispatched if fut is not None]
+        if futures:
+            concurrent.futures.wait(
+                futures, timeout=max(0.0, deadline - time.monotonic())
+            )
+
+        for transport, fut in dispatched:
+            if fut is None:
+                if self._deliver(transport, obj, dead):
+                    delivered = True
+                continue
+            if not fut.done():
+                # Slow, not dead: leave it attached and count the frame as in
+                # flight.  Cancelling would not stop a write already running.
+                logger.warning(
+                    "fanout write still pending after %ss; peer left attached",
+                    _FANOUT_WRITE_DEADLINE_S,
+                )
+                delivered = True
+                continue
+            try:
+                ok = fut.result()
+            except Exception:
+                logger.debug("fanout write failed; pruning peer", exc_info=True)
+                dead.append(transport)
+                continue
+            if ok:
+                delivered = True
+            else:
+                dead.append(transport)
+
+        for transport in dead:
+            self.detach(transport)
+        return delivered
+
+    def close(self) -> None:
+        """Detach every peer. Does NOT close them — each owns its own socket."""
+        with self._lock:
+            self._transports = []
 
 
 class TeeTransport:

--- a/tui_gateway/ws.py
+++ b/tui_gateway/ws.py
@@ -12,6 +12,7 @@ import logging
 import socket
 import threading
 import time
+import uuid
 from typing import Any
 
 from tui_gateway import server
@@ -89,6 +90,10 @@ class WSTransport:
         #: for legacy-token/stdio. RPC params can never populate it: sole identity authority for browser controllers.
         self.auth_identity = auth_identity
         self._closed = False
+        # Opaque per-connection id, minted at accept. Announced to this client as gateway.ready's ``origin``
+        # and stamped onto the session event frames of turns this client starts, so a mirrored client can
+        # tell its own turn from a peer's. Never reused across connections.
+        self.transport_id = uuid.uuid4().hex
         # Token-coalescing buffer. The lock guards the buffer + "armed" flag against worker threads
         # calling write(); the timer handle is only ever touched on the loop thread.
         self._token_lock = threading.Lock()
@@ -268,11 +273,16 @@ async def handle_ws(ws: Any, *, auth_identity: dict | None = None, subprotocol: 
         skin_payload = await asyncio.to_thread(server.resolve_skin)
         # change_events: this backend broadcasts pet/cron/sessions.changed, so clients can demote legacy
         # polls to backstops. replay_epoch lets reconnecting clients detect a backend restart and reset
-        # their per-session seq watermarks (event_replay).
+        # their per-session seq watermarks (event_replay). session_mirroring: this backend fans a session's
+        # events out to every attached client instead of rebinding the session to the newest one, so a
+        # client may resume or activate a session someone else is driving without stealing it. origin: this
+        # connection's opaque id — a session event carrying the same origin belongs to a turn THIS client
+        # started.
         ready_ok = await transport.write_async({
             "jsonrpc": "2.0", "method": "event",
             "params": {"type": "gateway.ready", "payload": {
                 "skin": skin_payload, "change_events": True, "heartbeat": True, "replay_epoch": replay_epoch(),
+                "session_mirroring": True, "origin": transport.transport_id,
             }},
         })
         if ready_ok:


### PR DESCRIPTION
## What does this PR do?

A draft stacked on #86784, the transport fan-out fix, carrying the wire-contract half. Five commits show and the first three are #86784's at `df52ccfd40`, since a branch on an unmerged base cannot show its delta alone; the delta is the last two, and the tip is `34d48614a5`. Both branches sit on `79445a496c`, so this one is re-ported over the same decomposition (#102117) #86784 is: `tests/fixtures/session-resume-active-turn.json` and its exact-equality test still pin the `session.resume` result to the byte, so the commit that adds a result key updates the fixture. #86784's comment offered the whole wire contract as a draft rather than a surprise after the fix landed, and this is it. Close it without ceremony if it is noise. It flips to ready when #86784 lands and this rebases onto main.

Under fan-out, two clients on one session get the same frames and no frame says whose turn produced it. A client cannot attribute what it renders, nor tell whether to latch its composer for its own user or leave it free for a peer. Resume and activate have the mirror gap: joining a stream someone else started returns a result identical to registering the session yourself. This PR adds the minimum for both. It does not add a user-message event, so a client still learns what its peer typed only when it reconciles history at the end of a turn; what it adds is the ability to tell whose turn is streaming.

| Field | Message | Placement | Value |
| --- | --- | --- | --- |
| `session_mirroring` | `gateway.ready` | `params.payload` | `true` on the websocket gateway |
| `origin` | `gateway.ready` | `params.payload` | this connection's opaque id |
| `origin` | session events built by `_event_frame` | `params`, alongside `type` and `session_id` | the id of the client whose prompt claimed the turn, or `"auto_continue"` for the crash-recovery kickoff, and omitted entirely when no turn origin is known |
| `watching` | `session.resume` and `session.activate` results | RPC result | `true` when another live client was already attached at the moment the caller arrived |

Each accepted websocket mints an opaque id at accept (`uuid4().hex`, never reused across connections), returned to that client as `origin` on `gateway.ready`. The session records who started the current turn: `prompt.submit` the submitter, the queued drain the client that queued the prompt rather than whoever is driving when it fires, the auto-continue kickoff `"auto_continue"` so a crash-recovery stream is not attributed to a person. `_event_frame` (`tui_gateway/server.py:571` at `79445a496c`) reads that value and adds `origin` to `params`.

The submit and the kickoff record the origin where they claim the turn, under the history lock and beside the line marking the session running; the drain records the queuer at drain time, where its turn is claimed. That placement is the correctness argument. A prompt arriving mid-turn starts no turn: under the default busy policy a redirect-capable agent folds the correction into the live turn and answers `redirected`, and otherwise the prompt is queued for the next turn or refused. Recording at the point the submitting client attaches would repaint the running turn's remaining frames, `message.complete` included, with the id of the peer that merely typed over it, inverting attribution both ways: the starter reads its own completion as a peer's, and the peer reads a turn it never started as its own. The drain stamps the queuer whether or not that client is still connected, since the turn is its work either way. `prompt.submit` reads the submitter's origin where it attaches and hands it to the private helper that claims the turn, rather than re-reading it at the claim, so the stamp carries the origin read at attach time and the claim site cannot pick up a different transport.

The change is additive. The key is omitted wherever the origin is unknown, which covers a stdio TUI, a session-less broadcast, and every frame on a backend that never had a second client attach, so no existing frame changes shape and a client ignoring all three fields behaves as it does today.

Feature detection is `gateway.ready`: no `session_mirroring` in the payload means the backend stamps no origins, so `origin` must not be relied on. `tui_gateway/entry.py`'s second `gateway.ready` for the stdio gateway (`tui_gateway/entry.py:257-261` at `79445a496c`) is deliberately left alone, since that path serves one client, mints no per-connection id and stamps no origin, so the missing flag is the correct answer rather than an omission.

Two design calls a reviewer may want to argue with:

`origin` rides on `params` beside `type` and `session_id` rather than inside `payload`, because payloads are built by each emitting site and there are many, so stamping there means touching every emitter and inventing a rule for payloads that are a list or absent. `params` is the envelope `_event_frame` builds for every event emitted through `_emit`, so the stamp is one line covering current and future emitters. The cost is that `origin` sits a level up from the data it describes.

The stamp misses two frames, named here rather than left to a grep. `tui_gateway/host_supervisor.py:430` at `79445a496c` hand-builds an `error` frame when a compute-host turn fails, so that frame carries no `origin`. Under the opt-in per-turn process isolation the child builds the turn's frames and the parent relays them verbatim with no copy of the parent's turn origin, so `origin` is absent for the whole isolated turn rather than one frame of it. Neither is a regression and both are safe the same way: a missing key reads as unknown, which is what it is. Closing them means carrying the origin across the host boundary, which belongs with the process-isolation work.

`session_mirroring` is a hardcoded bool rather than a capability-list entry, matching the house style for this handshake: `gateway.ready` already carries `change_events` as a bare `true` for the same purpose (`tui_gateway/ws.py:275` at `79445a496c`), letting clients demote a legacy poll. A list is a better long-term shape, a worse fit for a two-field addition, and a larger protocol change than this PR asks for.

## Related Issue

Depends on #86784, which carries the credit for the architecture: `FanoutTransport`, the attach and detach ladder, and the invariant that RPC replies stay on the request-bound transport are a port of @OmarB97's #40822. #86784 extracts the backend half so it can land without the session-presence substrate #40822 stacks on (#40814, still open, carried whole inside #40822's first commit). If #40822 lands first, both PRs should be closed or rebased down to the delta.

Related, not fixed here: #79064, whose first root cause is the transport rebind #86784 fixes, and #55564, which reports the `prompt.submit` half of the same rebind. This PR adds nothing to that fix; it makes the mirrored result usable by a client that needs to attribute a turn.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)

## Changes Made

Everything below is in the two commits on top of #86784: the gateway files for the origin machinery, one for `watching`, the shared resume fixture, and the fan-out test file.

<details>
<summary>Per-file inventory</summary>

- `tui_gateway/ws.py`: each `WSTransport` mints `transport_id` at accept, and `gateway.ready` gains `session_mirroring` and `origin` in its payload alongside the existing `skin` and `change_events`.
- `tui_gateway/server.py`: `_transport_origin` reads a transport's `transport_id` back off it and returns `""` for a transport that has none, such as stdio.
- `tui_gateway/server.py`: `_event_frame` stamps `params["origin"]` from the session's `turn_origin`, omitting the key when it is unknown.
- `tui_gateway/session_auto_continue.py`: `_drain_queued_prompt` records the queuing client as the drained turn's origin, before and independently of the guard that skips attaching a queuer which has since disconnected, so that guard governs the attach and not the attribution. `_maybe_schedule_auto_continue` records `"auto_continue"`.
- `tui_gateway/methods_prompt.py`: `prompt.submit` captures the submitter's origin where it attaches and passes it to `_lock_in_submit_turn`, which records it under the history lock at the point the prompt claims the turn, so a submit that redirects, queues or is refused leaves the running turn's origin untouched.
- `tui_gateway/methods_session.py`: `session.resume` and `session.activate` compute `watching` before attaching the caller, so it answers "did I join a stream already in progress" rather than "is anyone attached now". `session.resume` computes it in `_resume_reuse_live`, the single live-reuse path (`methods_session.py:646` at `34d48614a5`), and writes `false` in `_resume_response`, the single builder every register-the-session path shares (`:677`); between them they cover every success return of `session.resume` except `_resume_live_unpersisted` (`:521`), the never-persisted Bot Chat reattach, which returns a minimal lazy payload and carried no `watching` before the decomposition either. `session.activate` computes it once (`:912`). So `false` now covers every path that registers the live session for the caller: cold, eager, deferred and the lazy child-watch window, because the decomposition made all four share one payload builder. The deferred resume did not carry the key before this rebase and now does; it is a deliberate widening and the commit message says so.
- `tests/fixtures/session-resume-active-turn.json`: one key, `"watching": false`. `test_session_resume_active_turn_payload_matches_desktop_fixture` compares it for exact equality against a real serialized `session.resume` result, so any new result key lands there. The value is what the gateway serializes for that scenario, which has no second client attached, read off the failing assertion rather than written by hand. Its other consumer, the desktop `use-session-actions` test, reads only the turn-timer fields and needed no change.
- `tests/tui_gateway/test_multi_client_fanout.py`: 14 tests in three sections, covering the `gateway.ready` announcement and per-connection id; the origin stamp on a submitted turn, a drained turn, and a drained turn whose queuer disconnected; the two mid-turn cases where a peer's prompt must not take the origin; the omitted key when the origin is unknown; `watching` on the live-reuse, already-attached, cold, lazy and activate paths; and tolerance of an unrecognized request parameter.

</details>

## How to Test

1. Two clients, one session: start a turn in one and open that session from the other. Both render it, every event frame carries `origin` equal to the first client's `gateway.ready` id, so the second can tell the turn is not its own, and its resume result carries `watching: true`.

2. The origin stamp without a UI. Save the script below at the repository root and run `python repro_origin_stamp.py`. Importing the gateway rebinds `sys.stdout` to `stderr`, since stdout is its JSON-RPC channel, so these lines arrive on stderr.

<details>
<summary>Repro script and observed output</summary>

```python
import threading

from tui_gateway import server


class Client:
    def __init__(self, name, transport_id):
        self.name = name
        self.transport_id = transport_id
        self.frames = []

    def write(self, obj):
        self.frames.append(obj)
        return True

    def close(self):
        pass


session = {
    "agent": None,
    "session_key": "session-key",
    "history": [],
    "history_lock": threading.Lock(),
    "history_version": 0,
    "running": False,
    "attached_images": [],
    "transport": None,
}

a, b = Client("A", "conn-a"), Client("B", "conn-b")
session["transport"] = a
server._sessions["sid"] = session

# B opens the live session the way session.resume does.
server._live_session_payload("sid", session, touch=True, transport=b)

# A starts a turn. prompt.submit captures A's origin when it attaches the
# transport and records it here, where the prompt claims the turn.
session["turn_origin"] = server._transport_origin(a)
server._emit("message.delta", "sid", {"text": "hello"})

for client in (a, b):
    params = client.frames[0]["params"]
    print(f"{client.name} sees {params['type']} origin={params.get('origin')!r}")
```

On #86784's branch without this one, neither client can attribute the frame:

```text
A sees message.delta origin=None
B sees message.delta origin=None
```

On this branch the frame names the client whose turn it is:

```text
A sees message.delta origin='conn-a'
B sees message.delta origin='conn-a'
```

</details>

3. `pytest tests/tui_gateway/test_multi_client_fanout.py -q` gives `54 passed`, which is #86784's 40 plus this branch's 14. The file cannot be run at #86784's head at all, because it needs `_transport_origin`, `session["turn_origin"]` and `WSTransport.transport_id`, none of which exist there. The attribution measurement is the other way round: the whole directory on this branch with these 14 tests deselected gives `4 failed, 1008 passed`, identical to #86784's head in population, count and failure list.

4. `pytest tests/tui_gateway/test_protocol.py -q` gives `68 passed`; it holds `test_session_resume_active_turn_payload_matches_desktop_fixture`, which without this PR's fixture line fails with `Left contains 1 more item: {'watching': False}`, every other item identical.

5. `pytest tests/tui_gateway/ -q` on Windows 11, with the same deselect and ignore #86784 uses, gives `4 failed, 1022 passed, 1 deselected` here against `4 failed, 1008 passed, 1 deselected` at #86784's head; every failing name is pre-existing on this platform and some flap run to run. Details below.

6. Each commit is green alone: the first, the origin machinery and its tests, gives `48 passed` on the fan-out file with no `watching` tests present, which is #86784's 40 plus that commit's 8.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate. #40822 covers the fan-out architecture #86784 stacks on and is credited above; it adds no wire fields.
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits). Two commits, seven files, +528 / -13, on top of #86784. One is the shared resume fixture the new result key obliges me to update, and the seventh is `tui_gateway/session_auto_continue.py`, which took two of `server.py`'s hunks in the decomposition.
- [ ] I've run `pytest tests/ -q` and all tests pass. Not claimed. `tests/tui_gateway/` was run with a control run of the same directory at #86784's tip; the remaining failures are pre-existing on this platform and are listed below.
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A. The three fields are documented in comments at the sites that emit them, including why `origin` is omitted rather than sent empty.
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A. No config keys.
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A.
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A. No platform surface is touched; `scripts/check-windows-footguns.py --diff` over this delta reports nothing across the six files it scans, and `ruff check` passes on the six Python files among the seven.
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A.

## Screenshots / Logs

Focused file on this branch:

```text
......................................................                   [100%]
54 passed in 17.34s
```

The protocol file, which owns the resume fixture's exact-equality test:

```text
....................................................................     [100%]
68 passed in 25.07s
```

<details>
<summary>Full tests/tui_gateway run, branch vs control at #86784's head, back to back on one machine</summary>

Full directory on this branch:

```text
FAILED tests/tui_gateway/test_bot_relay_methods.py::test_deliver_write_failure_still_removes_tempfile
FAILED tests/tui_gateway/test_compute_host.py::test_compute_host_line_json_hello_and_shutdown
FAILED tests/tui_gateway/test_compute_host_late_compress_ack.py::test_late_ack_handlers_are_bounded_by_ttl_and_cap
FAILED tests/tui_gateway/test_entry_import_off_main_thread.py::test_entry_imports_cleanly_from_worker_thread
4 failed, 1022 passed, 1 deselected in 289.90s (0:04:49)
```

The same directory at #86784's head, same machine and runner, taken back to back with the run above:

```text
=========================== short test summary info ===========================
FAILED tests/tui_gateway/test_bot_relay_methods.py::test_deliver_write_failure_still_removes_tempfile
FAILED tests/tui_gateway/test_compute_host.py::test_compute_host_line_json_hello_and_shutdown
FAILED tests/tui_gateway/test_entry_import_off_main_thread.py::test_entry_imports_cleanly_from_worker_thread
FAILED tests/tui_gateway/test_slash_worker_mcp_discovery.py::test_profile_local_mcp_tool_is_visible_in_slash_worker
4 failed, 1008 passed, 1 deselected in 433.60s (0:07:13)
```

</details>

Every failing name is pre-existing here. Three are the stable core and appear on every tree in every round: a tempfile write, a compute-host line-JSON exchange, and `signal.SIGPIPE` not existing on Windows. Everything past those three is a timing or subprocess flake that fires at #86784's head at least as often as here, and the whole directory was run twice on this branch rather than once so the flake set is measured rather than assumed. Collected rises from 1012 to 1026, exactly the 14 tests this branch adds, and that count is the stable signal, so expect a handful of failures from this set on Windows and read the collected number instead.

```text
✓ No Windows footguns found (6 file(s) scanned).
```

## Uncertainty

`turn_origin` is written when a turn is claimed and never cleared, so an event emitted while the session is idle carries the most recent turn's origin rather than none. The guarantee is the in-turn case for a turn claimed by a submit, a drain, or the kickoff: from the claim until that turn ends, every frame `_event_frame` builds names the claimant, and a peer submitting mid-turn does not change it. The idle case is not guaranteed, and nothing treats the field as a liveness signal. Clearing it means finding every teardown path, interrupted and errored included, and getting that wrong drops the origin off a turn's last frames, which is worse. If a maintainer wants it cleared, the contract narrows and the docs above need the narrower wording.

The same gap has a second face. Several gateway-internal turns claim the session without recording an origin, so their frames carry whatever the previous turn left: the loop and wakeup ticks, the kanban notification batches, the delegation completion turns, and the goal continuation all set the session running and dispatch directly. The three sites recorded here are the ones a mirrored client is trying to attribute; the synthesized ones want a fourth value meaning "the gateway did this", and naming it is a wider conversation than this PR.

A drained turn is stamped with the queuer's id even after that client disconnects, which is honest, the turn is its prompt, but does mean an `origin` can name a connection nobody holds. Attached clients read it as not theirs, which is what they need. `test_a_drained_turn_is_the_queuers_even_after_the_queuer_disconnects` pins it, because the alternative leaves a drained turn wearing the previous turn's origin.

Verified on Windows only. Nothing here is platform-specific and the new tests touch no platform surface, but they have not run on Linux or macOS.

The `gateway.ready` test drives a fake websocket through the real `handle_ws`, closer to the wire than the rest of the file but still not a real socket. Every other test uses fake client objects, this directory's convention.

The origin is an opaque per-connection id, so it changes on reconnect: a client that reconnects mid-turn sees its earlier turn stamped with an id it no longer holds and reads that turn as a peer's. Making the id survive a reconnect means giving it a lifetime and an owner, a session-identity question rather than a wire-format one.

## What I did not do

No user-message event. `origin` says whose turn is streaming; it does not carry what that client typed, and nothing on the wire does, so a peer still reconstructs a mirrored user's prompt from history at the end of the turn. Adding such an event is a protocol addition with its own privacy and ordering questions and is not attempted here.

No request parameter. A client cannot ask to mirror or ask not to, because the attach is unconditional and a flag would report intent rather than fact.

`origin` is not persisted: it appears in no stored transcript, no `session.history`, and no REST response, only on live event frames and the `gateway.ready` handshake.

No identity on an origin. It names a connection, not a user or a device, and nothing in it resolves to a principal. Per-client identity on the wire needs the ticket auth path to carry a principal first, which #86784 describes and does not attempt either.

No capability negotiation. The client is told what the backend does; it cannot ask for anything different.

`tui_gateway/entry.py`, the stdio gateway, is untouched and announces no mirroring.

