### PR TITLE
fix(tui_gateway): auto-continue claims the interrupted turn or abstains

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -30,6 +30,7 @@ import sys
 import threading
 import time
 from collections import deque
+from collections.abc import Iterable, Mapping
 from contextlib import contextmanager
 from pathlib import Path
 
@@ -164,6 +165,14 @@ class SessionExportTooLargeError(ValueError):
 
 
 _COMPRESSION_LOCK_HOLDER_PID_RE = re.compile(r"(?:^|:)pid=(\d+)(?::|$)")
+
+# Enough to re-submit any realistic prompt; keeps a pathological multi-megabyte
+# paste out of the interrupted-turn row on every turn.
+_INTERRUPTED_TURN_MAX_PROMPT_CHARS = 64_000
+# A record this old is past every usable auto-continue freshness window, and
+# without a sweep a conversation that is never resumed again keeps its row
+# forever. Same bound the desktop sidecar this table replaces enforced.
+_INTERRUPTED_TURN_MAX_AGE_SECS = 24 * 3600
 
 
 def _system_prompt_hash(system_prompt: str) -> str:
@@ -5977,6 +5986,247 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             )
 
         self._execute_write(_do)
+
+    # ── Interrupted turns ────────────────────────────────────────────────
+    #
+    # A turn that started running and never reached a terminal frame leaves a
+    # row in ``interrupted_turns``; ``session.resume`` reads it to decide
+    # whether to continue the interrupted prompt. Rows use the same
+    # compression-lineage root key as the turn lease, so a rotation mid-turn
+    # cannot orphan the record, and every mutation runs inside
+    # ``_execute_write`` (BEGIN IMMEDIATE) so concurrent processes serialize on
+    # the database instead of on a lock only one of them can see.
+    #
+    # Every method here is best-effort by design — this bookkeeping must never
+    # break a turn — so storage errors degrade to "no record" instead of
+    # raising, matching the file-backed implementation this replaces.
+
+    def record_interrupted_turn(
+        self,
+        session_id: str,
+        prompt: str,
+        *,
+        attempts: int = 0,
+        owner: Optional[str] = None,
+        cause: Optional[str] = None,
+    ) -> bool:
+        """Record the turn that is about to run, stamping ``owner`` on the row.
+
+        ``attempts`` counts how many automatic continuations led to this run: 0
+        for a user-initiated turn, N for the Nth re-run, which is what bounds
+        the crash-loop breaker.
+
+        Last writer wins. The row describes the turn running on this
+        conversation right now, and the row it replaces describes a turn that
+        already ended, so overwriting it is the correct record and is what lets
+        the attempts counter advance across a restart. The owner stamp is not
+        an admission decision; it is what makes the retire in
+        :meth:`clear_interrupted_turn` checkable.
+
+        Returns True when a row was written.
+        """
+        if not session_id:
+            return False
+        text = str(prompt or "")
+        if not text.strip():
+            return False
+        try:
+            attempt_count = max(0, int(attempts))
+        except (TypeError, ValueError):
+            attempt_count = 0
+        now = time.time()
+
+        def _do(conn):
+            conversation_id = self._session_turn_lease_key_on_conn(conn, session_id)
+            conn.execute(
+                "DELETE FROM interrupted_turns WHERE started_at < ?",
+                (now - _INTERRUPTED_TURN_MAX_AGE_SECS,),
+            )
+            conn.execute(
+                "INSERT INTO interrupted_turns "
+                "(conversation_id, prompt, attempts, started_at, owner, cause) "
+                "VALUES (?, ?, ?, ?, ?, ?) "
+                "ON CONFLICT(conversation_id) DO UPDATE SET "
+                "prompt = excluded.prompt, "
+                "attempts = excluded.attempts, "
+                "started_at = excluded.started_at, "
+                "owner = excluded.owner, "
+                "cause = excluded.cause",
+                (
+                    conversation_id,
+                    text[:_INTERRUPTED_TURN_MAX_PROMPT_CHARS],
+                    attempt_count,
+                    now,
+                    owner or None,
+                    cause or None,
+                ),
+            )
+            return True
+
+        try:
+            return bool(self._execute_write(_do))
+        except sqlite3.Error as exc:
+            logger.warning(
+                "record_interrupted_turn(%s) failed: %s", session_id, exc,
+            )
+            return False
+
+    def import_interrupted_turns(
+        self,
+        records: Iterable[Tuple[str, Mapping[str, Any]]],
+        *,
+        cause: str = "migrated",
+    ) -> int:
+        """Import legacy records in one transaction; returns rows written.
+
+        ``records`` yields ``(session_id, entry)`` pairs where ``entry`` holds
+        ``prompt``, ``attempts`` and ``started_at``. ``session_id`` is the key
+        the legacy record was filed under, which is the compression *segment*
+        the turn was running on; the resolver maps it to the lineage root this
+        table is keyed on, so a record written before a rotation lands on the
+        row a post-rotation resume actually reads. Because of that mapping two
+        legacy keys can resolve to a single row, and the first pair imported
+        wins — pass them newest first.
+
+        Imported rows carry no owner: the legacy format never recorded one, so
+        any process may retire them. A row already present also wins; it was
+        written by a live process and is newer than anything being imported.
+        """
+        pending = []
+        for session_id, entry in records:
+            if not session_id or not isinstance(entry, Mapping):
+                continue
+            text = str(entry.get("prompt") or "")
+            if not text.strip():
+                continue
+            try:
+                attempt_count = max(0, int(entry.get("attempts") or 0))
+                started = float(entry.get("started_at") or 0)
+            except (TypeError, ValueError):
+                continue
+            pending.append(
+                (
+                    str(session_id),
+                    text[:_INTERRUPTED_TURN_MAX_PROMPT_CHARS],
+                    attempt_count,
+                    started,
+                )
+            )
+        if not pending:
+            return 0
+
+        def _do(conn):
+            written = 0
+            for session_id, text, attempt_count, started in pending:
+                conversation_id = self._session_turn_lease_key_on_conn(
+                    conn, session_id
+                )
+                cursor = conn.execute(
+                    "INSERT OR IGNORE INTO interrupted_turns "
+                    "(conversation_id, prompt, attempts, started_at, owner, cause) "
+                    "VALUES (?, ?, ?, ?, NULL, ?)",
+                    (
+                        conversation_id,
+                        text,
+                        attempt_count,
+                        started,
+                        cause or None,
+                    ),
+                )
+                written += cursor.rowcount
+            return written
+
+        return int(self._execute_write(_do))
+
+    def read_interrupted_turn(self, session_id: str) -> Optional[dict]:
+        """The record left by a turn that never concluded, or None."""
+        if not session_id:
+            return None
+        try:
+            with self._read_ctx() as conn:
+                conversation_id = self._session_turn_lease_key_on_conn(
+                    conn, session_id
+                )
+                row = conn.execute(
+                    "SELECT prompt, attempts, started_at, owner, cause "
+                    "FROM interrupted_turns WHERE conversation_id = ?",
+                    (conversation_id,),
+                ).fetchone()
+        except sqlite3.Error as exc:
+            logger.warning(
+                "read_interrupted_turn(%s) failed: %s", session_id, exc,
+            )
+            return None
+        if row is None:
+            return None
+        prompt = str(row["prompt"] or "")
+        if not prompt.strip():
+            return None
+        try:
+            started_at = float(row["started_at"] or 0)
+            attempts = max(0, int(row["attempts"] or 0))
+        except (TypeError, ValueError):
+            return None
+        return {
+            "attempts": attempts,
+            "prompt": prompt,
+            "started_at": started_at,
+            "owner": row["owner"],
+            "cause": row["cause"],
+        }
+
+    def clear_interrupted_turn(
+        self,
+        session_id: str,
+        *,
+        owner: Optional[str],
+        force: bool = False,
+    ) -> bool:
+        """Retire the record of a turn that concluded; True when a row went.
+
+        ``owner`` is checked against the stamp
+        :meth:`record_interrupted_turn` wrote. A process may retire its own
+        record, and a legacy record that carries no owner, and nothing else:
+        without that check a process that merely tried to take the conversation
+        and gave up can delete the record of a turn still running elsewhere,
+        and a crash of that turn then recovers nothing.
+
+        ``force`` retires regardless of owner and exists for the scheduler's
+        policy deletions. A record past its freshness window or its attempt
+        ceiling is no longer actionable by any process, and the scheduler that
+        just made that determination is the right one to clear it.
+        """
+        if not session_id:
+            return False
+
+        def _do(conn):
+            conversation_id = self._session_turn_lease_key_on_conn(conn, session_id)
+            if force:
+                cursor = conn.execute(
+                    "DELETE FROM interrupted_turns WHERE conversation_id = ?",
+                    (conversation_id,),
+                )
+            elif owner:
+                cursor = conn.execute(
+                    "DELETE FROM interrupted_turns "
+                    "WHERE conversation_id = ? AND (owner = ? OR owner IS NULL)",
+                    (conversation_id, owner),
+                )
+            else:
+                cursor = conn.execute(
+                    "DELETE FROM interrupted_turns "
+                    "WHERE conversation_id = ? AND owner IS NULL",
+                    (conversation_id,),
+                )
+            return cursor.rowcount > 0
+
+        try:
+            return bool(self._execute_write(_do))
+        except sqlite3.Error as exc:
+            logger.warning(
+                "clear_interrupted_turn(%s) failed: %s", session_id, exc,
+            )
+            return False
 
     def get_compression_lock_holder(self, session_id: str) -> Optional[str]:
         """Return the current (non-expired) holder for ``session_id``, or None.

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -6091,18 +6091,44 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         Imported rows carry no owner: the legacy format never recorded one, so
         any process may retire them. A row already present also wins; it was
         written by a live process and is newer than anything being imported.
+
+        An entry the legacy file left unusable is dropped rather than imported
+        half-formed. Only the total is returned, so each drop is logged at
+        debug with its key and reason: a caller that renames the file aside on
+        success has no second chance to see what did not come across.
         """
         pending = []
         for session_id, entry in records:
             if not session_id or not isinstance(entry, Mapping):
+                logger.debug(
+                    "import_interrupted_turns: skipping %r, unusable entry "
+                    "of type %s",
+                    session_id,
+                    type(entry).__name__,
+                )
                 continue
             text = str(entry.get("prompt") or "")
             if not text.strip():
+                logger.debug(
+                    "import_interrupted_turns: skipping %r, empty prompt",
+                    session_id,
+                )
                 continue
+            raw_attempts = raw_started = None
             try:
-                attempt_count = max(0, int(entry.get("attempts") or 0))
-                started = float(entry.get("started_at") or 0)
-            except (TypeError, ValueError):
+                raw_attempts = entry.get("attempts")
+                raw_started = entry.get("started_at")
+                attempt_count = max(0, int(raw_attempts or 0))
+                started = float(raw_started or 0)
+            except (TypeError, ValueError) as exc:
+                logger.debug(
+                    "import_interrupted_turns: skipping %r, "
+                    "attempts=%r started_at=%r not numeric: %s",
+                    session_id,
+                    raw_attempts,
+                    raw_started,
+                    exc,
+                )
                 continue
             pending.append(
                 (

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -5987,6 +5987,53 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
 
         self._execute_write(_do)
 
+    def get_session_turn_lease_holder(self, session_id: str) -> Optional[str]:
+        """Return the live holder of this conversation's turn lease, or None.
+
+        The read-only counterpart to :meth:`try_acquire_session_turn_lease`,
+        for callers that need to know whether a turn is running elsewhere
+        without taking the conversation away from it. "Live" means what
+        acquisition means: a row that has not expired and whose holder the
+        dead-process probe does not prove gone. Probe doubt reads as live, so
+        a caller that stands down on a holder stands down conservatively.
+
+        A failed read raises rather than reporting None. "No holder" is a
+        licence: callers act on it, and one of the things they may do with it
+        is delete a record. An unreadable lease table is not evidence that
+        nobody is running the turn, so it must not be reported as if it were.
+        The caller decides what doubt means for its own path.
+        """
+        if not session_id:
+            return None
+        now = time.time()
+        try:
+            with self._read_ctx() as conn:
+                conversation_id = self._session_turn_lease_key_on_conn(
+                    conn, session_id
+                )
+                row = conn.execute(
+                    "SELECT holder, expires_at FROM session_turn_leases "
+                    "WHERE conversation_id = ?",
+                    (conversation_id,),
+                ).fetchone()
+        except sqlite3.Error as exc:
+            logger.warning(
+                "get_session_turn_lease_holder(%s) failed: %s", session_id, exc,
+            )
+            raise
+        if row is None:
+            return None
+        holder = str(row["holder"] or "")
+        if not holder:
+            return None
+        try:
+            expired = float(row["expires_at"]) <= now
+        except (TypeError, ValueError):
+            expired = False  # unreadable expiry is doubt, and doubt is live
+        if expired or _compression_lock_holder_process_is_dead(holder):
+            return None
+        return holder
+
     # ── Interrupted turns ────────────────────────────────────────────────
     #
     # A turn that started running and never reached a terminal frame leaves a
@@ -6253,6 +6300,117 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 "clear_interrupted_turn(%s) failed: %s", session_id, exc,
             )
             return False
+
+    def claim_interrupted_turn(
+        self,
+        session_id: str,
+        *,
+        expected: Mapping[str, Any],
+    ) -> Optional[dict]:
+        """Take one interrupted-turn record for re-running, or return None.
+
+        The claim is a compare-and-swap whose token is the record itself.
+        ``expected`` is the mapping :meth:`read_interrupted_turn` returned, and
+        the bump lands only while the row still carries every field of it —
+        ``attempts``, ``started_at``, ``prompt`` and ``owner``. Two processes
+        that read the same orphaned record therefore produce exactly one
+        claimant, because the loser's UPDATE matches no row.
+
+        Matching the whole record, rather than the counter alone, is what makes
+        the token a version rather than a value. ``attempts`` is not monotonic
+        across writers: :meth:`record_interrupted_turn` is last-writer-wins and
+        stamps ``attempts=0`` on every user-initiated turn, so a counter value
+        a reader saw can recur under a *different* turn. Any write by any
+        process replaces at least one of the four fields — a new turn brings a
+        new ``started_at`` and, from another process, a new ``owner`` — so an
+        intervening re-record invalidates the token and the claim loses, which
+        is the safe direction.
+
+        Nothing is deleted, so the process that stands down leaves the record
+        where it found it for a later resume: deferring a recovery costs one
+        resume, while running a conversation twice cannot be taken back.
+
+        The claim also mutates as little as it can: it bumps ``attempts`` and
+        touches nothing else. In particular it does not restamp ``owner``. That
+        column is the retire check in :meth:`clear_interrupted_turn`, and a
+        claimant that took it would leave the true owner unable to retire its
+        own record when its turn ended — the record of a finished turn would
+        then outlive it and be re-run later. A claimant that goes on to run the
+        turn re-records under its own owner on the way in, which is where that
+        stamp belongs.
+
+        The bump is durable before the caller starts anything fallible, which
+        is what stops a continuation that dies inside its own startup from
+        re-firing without end.
+
+        Storage failure is an abstention, not an exception: this runs on the
+        resume path, where the honest answer to "can this process take the
+        conversation" is no.
+
+        Returns the claimed record, ``attempts`` already incremented, or None.
+        """
+        if not session_id or not isinstance(expected, Mapping):
+            return None
+        try:
+            seen = max(0, int(expected.get("attempts") or 0))
+            seen_started_at = float(expected.get("started_at") or 0)
+        except (TypeError, ValueError):
+            return None
+        seen_prompt = str(expected.get("prompt") or "")
+        if not seen_prompt.strip():
+            return None
+        seen_owner = expected.get("owner")
+        seen_owner = None if seen_owner is None else str(seen_owner)
+
+        def _do(conn):
+            conversation_id = self._session_turn_lease_key_on_conn(conn, session_id)
+            # ``IS`` rather than ``=`` on the two nullable-in-practice columns:
+            # an imported legacy record carries owner NULL, and ``= NULL`` is
+            # never true, which would make such a record unclaimable forever.
+            cursor = conn.execute(
+                "UPDATE interrupted_turns SET attempts = ? "
+                "WHERE conversation_id = ? AND attempts = ? AND started_at IS ? "
+                "AND prompt IS ? AND owner IS ?",
+                (
+                    seen + 1,
+                    conversation_id,
+                    seen,
+                    seen_started_at,
+                    seen_prompt,
+                    seen_owner,
+                ),
+            )
+            if cursor.rowcount <= 0:
+                return None
+            row = conn.execute(
+                "SELECT prompt, attempts, started_at, owner, cause "
+                "FROM interrupted_turns WHERE conversation_id = ?",
+                (conversation_id,),
+            ).fetchone()
+            return dict(row) if row is not None else None
+
+        try:
+            claimed = self._execute_write(_do)
+        except sqlite3.Error as exc:
+            logger.warning(
+                "claim_interrupted_turn(%s) failed: %s", session_id, exc,
+            )
+            return None
+        if not claimed:
+            return None
+        prompt = str(claimed.get("prompt") or "")
+        if not prompt.strip():
+            return None
+        try:
+            return {
+                "attempts": max(0, int(claimed.get("attempts") or 0)),
+                "prompt": prompt,
+                "started_at": float(claimed.get("started_at") or 0),
+                "owner": claimed.get("owner"),
+                "cause": claimed.get("cause"),
+            }
+        except (TypeError, ValueError):
+            return None
 
     def get_compression_lock_holder(self, session_id: str) -> Optional[str]:
         """Return the current (non-expired) holder for ``session_id``, or None.

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -6189,7 +6189,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         record, and a legacy record that carries no owner, and nothing else:
         without that check a process that merely tried to take the conversation
         and gave up can delete the record of a turn still running elsewhere,
-        and a crash of that turn then recovers nothing.
+        and nothing then resumes that turn automatically.
 
         ``force`` retires regardless of owner and exists for the scheduler's
         policy deletions. A record past its freshness window or its attempt

--- a/hermes_state_common.py
+++ b/hermes_state_common.py
@@ -390,6 +390,22 @@ CREATE TABLE IF NOT EXISTS session_turn_leases (
     expires_at REAL NOT NULL
 );
 
+-- Durable record of a turn that started running and never reached a terminal
+-- frame, so session.resume can offer to continue it (see
+-- tui_gateway/server.py _maybe_schedule_auto_continue). Keyed on the same
+-- compression-lineage root as session_turn_leases so a rotation mid-turn does
+-- not orphan the record. ``owner`` is the process that started the turn; only
+-- that process may retire the record, which is what stops a second process
+-- from deleting a turn it never ran.
+CREATE TABLE IF NOT EXISTS interrupted_turns (
+    conversation_id TEXT PRIMARY KEY,
+    prompt TEXT NOT NULL,
+    attempts INTEGER NOT NULL DEFAULT 0,
+    started_at REAL NOT NULL,
+    owner TEXT,
+    cause TEXT
+);
+
 CREATE TABLE IF NOT EXISTS async_delegations (
     delegation_id TEXT PRIMARY KEY,
     origin_session TEXT NOT NULL,
@@ -427,6 +443,7 @@ CREATE INDEX IF NOT EXISTS idx_messages_assistant_calls_by_session
     WHERE role = 'assistant' AND tool_calls IS NOT NULL;
 CREATE INDEX IF NOT EXISTS idx_compression_locks_expires ON compression_locks(expires_at);
 CREATE INDEX IF NOT EXISTS idx_session_turn_leases_expires ON session_turn_leases(expires_at);
+CREATE INDEX IF NOT EXISTS idx_interrupted_turns_started ON interrupted_turns(started_at);
 CREATE INDEX IF NOT EXISTS idx_session_model_usage_session ON session_model_usage(session_id);
 CREATE INDEX IF NOT EXISTS idx_session_model_usage_model ON session_model_usage(model);
 CREATE INDEX IF NOT EXISTS idx_async_delegations_delivery

--- a/tests/state/test_interrupted_turns.py
+++ b/tests/state/test_interrupted_turns.py
@@ -1,0 +1,241 @@
+"""Durable interrupted-turn records in state.db.
+
+A turn that starts running and never reaches a terminal frame leaves a row in
+``interrupted_turns``; ``session.resume`` reads it to decide whether to continue
+the interrupted prompt. These records used to live in a JSON sidecar that every
+process rewrote in full and any process could delete. The properties pinned
+here are the ones the file could not have:
+
+* a write touches one conversation's row and no other's, even from a second
+  process handle;
+* only the process that recorded a turn may retire it, so a process that never
+  ran the turn cannot delete the record of one that is still running;
+* records imported from the legacy file carry no owner and stay retirable by
+  anyone, and their keys are resolved to the compression-lineage root the table
+  is keyed on.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+
+from hermes_state import SessionDB
+
+
+def _owner(tag: str) -> str:
+    return f"pid={os.getpid()}:platform={tag}"
+
+
+def test_interrupted_turn_roundtrip(tmp_path):
+    db = SessionDB(tmp_path / "state.db")
+
+    assert db.record_interrupted_turn(
+        "abc", "fix the bug", attempts=1, owner=_owner("a")
+    )
+
+    record = db.read_interrupted_turn("abc")
+    assert record is not None
+    assert record["prompt"] == "fix the bug"
+    assert record["attempts"] == 1
+    assert record["owner"] == _owner("a")
+    assert abs(record["started_at"] - time.time()) < 5
+
+    assert db.clear_interrupted_turn("abc", owner=_owner("a"))
+    assert db.read_interrupted_turn("abc") is None
+
+
+def test_empty_prompt_records_nothing(tmp_path):
+    db = SessionDB(tmp_path / "state.db")
+
+    assert not db.record_interrupted_turn("abc", "   ", owner=_owner("a"))
+    assert not db.record_interrupted_turn("", "prompt", owner=_owner("a"))
+    assert db.read_interrupted_turn("abc") is None
+
+
+def test_foreign_owner_cannot_retire_a_live_record(tmp_path):
+    """The record of a running turn survives another process retiring it.
+
+    This is the lease-timeout path: a second process submits on a conversation
+    the first is already running, its engine waits for the turn lease, times
+    out, and the gateway retires the record as it emits the terminal error
+    frame. The turn it retired belongs to someone else.
+    """
+    path = tmp_path / "state.db"
+    running = SessionDB(path)
+    timing_out = SessionDB(path)
+
+    running.record_interrupted_turn(
+        "conv", "the turn that is actually running", owner=_owner("running")
+    )
+
+    assert not timing_out.clear_interrupted_turn("conv", owner=_owner("timing-out"))
+
+    survivor = running.read_interrupted_turn("conv")
+    assert survivor is not None
+    assert survivor["prompt"] == "the turn that is actually running"
+    assert running.clear_interrupted_turn("conv", owner=_owner("running"))
+
+
+def test_write_does_not_clobber_another_conversation(tmp_path):
+    """Two handles recording different conversations both keep their record.
+
+    The sidecar loaded the whole map, changed one key and stored the map back,
+    so a write for one conversation could drop a record for another. A row is
+    a row.
+    """
+    path = tmp_path / "state.db"
+    first = SessionDB(path)
+    second = SessionDB(path)
+
+    first.record_interrupted_turn("conv-a", "prompt for A", owner=_owner("first"))
+    second.record_interrupted_turn("conv-b", "prompt for B", owner=_owner("second"))
+
+    assert first.read_interrupted_turn("conv-a")["prompt"] == "prompt for A"
+    assert first.read_interrupted_turn("conv-b")["prompt"] == "prompt for B"
+
+
+def test_recording_takes_ownership_of_the_row(tmp_path):
+    """A new turn's record replaces the spent one and carries the new owner.
+
+    A turn only starts after the previous one ended, so the row it replaces
+    describes a turn that is over — usually one whose process died, which is
+    exactly the case whose attempts counter has to keep advancing for the
+    crash-loop breaker to work.
+    """
+    path = tmp_path / "state.db"
+    crashed = SessionDB(path)
+    restarted = SessionDB(path)
+
+    crashed.record_interrupted_turn(
+        "conv", "the interrupted prompt", attempts=0, owner=_owner("crashed")
+    )
+    assert restarted.record_interrupted_turn(
+        "conv", "the interrupted prompt", attempts=1, owner=_owner("restarted")
+    )
+
+    record = restarted.read_interrupted_turn("conv")
+    assert record["attempts"] == 1
+    assert record["owner"] == _owner("restarted")
+    # The dead process's owner string no longer retires it; the live one does.
+    assert not restarted.clear_interrupted_turn("conv", owner=_owner("crashed"))
+    assert restarted.clear_interrupted_turn("conv", owner=_owner("restarted"))
+
+
+def test_force_retires_regardless_of_owner(tmp_path):
+    """The scheduler's policy deletion: past every window, actionable by none."""
+    db = SessionDB(tmp_path / "state.db")
+    db.record_interrupted_turn("conv", "stale prompt", owner=_owner("someone-else"))
+
+    assert db.clear_interrupted_turn("conv", owner=_owner("scheduler"), force=True)
+    assert db.read_interrupted_turn("conv") is None
+
+
+def test_imported_record_has_no_owner_and_stays_retirable(tmp_path):
+    """Legacy records never recorded an owner, so nobody is locked out of them."""
+    db = SessionDB(tmp_path / "state.db")
+
+    assert db.import_interrupted_turns(
+        [("conv", {"prompt": "legacy prompt", "attempts": 1, "started_at": time.time()})]
+    ) == 1
+
+    record = db.read_interrupted_turn("conv")
+    assert record["prompt"] == "legacy prompt"
+    assert record["attempts"] == 1
+    assert record["owner"] is None
+    assert record["cause"] == "migrated"
+
+    assert db.clear_interrupted_turn("conv", owner=_owner("any-process"))
+    assert db.read_interrupted_turn("conv") is None
+
+
+def test_import_does_not_overwrite_a_live_record(tmp_path):
+    """A row written by a running process is newer than anything being imported."""
+    db = SessionDB(tmp_path / "state.db")
+    db.record_interrupted_turn("conv", "live prompt", owner=_owner("live"))
+
+    assert db.import_interrupted_turns(
+        [("conv", {"prompt": "legacy prompt", "started_at": time.time() - 60})]
+    ) == 0
+
+    record = db.read_interrupted_turn("conv")
+    assert record["prompt"] == "live prompt"
+    assert record["owner"] == _owner("live")
+
+
+def test_records_are_keyed_on_the_conversation_root(tmp_path):
+    """Compression segments share one record, as they share one turn lease."""
+    db = SessionDB(tmp_path / "state.db")
+    db.create_session("root", source="test")
+    db.end_session("root", "compression")
+    db.create_session("child", source="test", parent_session_id="root")
+
+    db.record_interrupted_turn("root", "prompt before rotation", owner=_owner("a"))
+
+    # The resume after the rotation looks the record up under the child id.
+    record = db.read_interrupted_turn("child")
+    assert record is not None
+    assert record["prompt"] == "prompt before rotation"
+
+
+def test_import_translates_a_segment_key_to_the_root(tmp_path):
+    """Legacy records were filed under the segment, not the lineage root.
+
+    Without the translation a record written before a rotation would import to
+    a row no post-rotation resume ever reads.
+    """
+    db = SessionDB(tmp_path / "state.db")
+    db.create_session("root", source="test")
+    db.end_session("root", "compression")
+    db.create_session("child", source="test", parent_session_id="root")
+
+    assert db.import_interrupted_turns(
+        [(
+            "root",
+            {"prompt": "prompt from before the rotation", "started_at": time.time()},
+        )]
+    ) == 1
+
+    record = db.read_interrupted_turn("child")
+    assert record is not None
+    assert record["prompt"] == "prompt from before the rotation"
+    assert record["owner"] is None
+
+
+def test_two_legacy_segments_collapse_to_one_row_newest_first(tmp_path):
+    """Both segments of a rotated conversation resolve to the same row."""
+    db = SessionDB(tmp_path / "state.db")
+    db.create_session("root", source="test")
+    db.end_session("root", "compression")
+    db.create_session("child", source="test", parent_session_id="root")
+    now = time.time()
+
+    written = db.import_interrupted_turns([
+        ("child", {"prompt": "after the rotation", "started_at": now}),
+        ("root", {"prompt": "before the rotation", "started_at": now - 600}),
+    ])
+
+    assert written == 1
+    assert db.read_interrupted_turn("child")["prompt"] == "after the rotation"
+
+
+def test_records_older_than_a_day_are_swept_on_write(tmp_path):
+    """Same bound the sidecar enforced on every write."""
+    db = SessionDB(tmp_path / "state.db")
+    db.import_interrupted_turns([
+        ("ancient", {"prompt": "two days ago", "started_at": time.time() - 48 * 3600}),
+        ("recent", {"prompt": "an hour ago", "started_at": time.time() - 3600}),
+    ])
+    assert db.read_interrupted_turn("ancient") is not None
+
+    db.record_interrupted_turn("fresh", "now", owner=_owner("a"))
+
+    assert db.read_interrupted_turn("ancient") is None
+    assert db.read_interrupted_turn("recent") is not None
+    assert db.read_interrupted_turn("fresh") is not None
+
+
+def test_missing_record_reads_as_none(tmp_path):
+    db = SessionDB(tmp_path / "state.db")
+    assert db.read_interrupted_turn("nobody") is None
+    assert not db.clear_interrupted_turn("nobody", owner=_owner("a"))

--- a/tests/state/test_interrupted_turns.py
+++ b/tests/state/test_interrupted_turns.py
@@ -239,3 +239,175 @@ def test_missing_record_reads_as_none(tmp_path):
     db = SessionDB(tmp_path / "state.db")
     assert db.read_interrupted_turn("nobody") is None
     assert not db.clear_interrupted_turn("nobody", owner=_owner("a"))
+
+
+def test_two_racing_claimants_produce_exactly_one_winner(tmp_path):
+    """Two processes that both find one orphan: one runs it, one stands down.
+
+    Both read the record before either writes, which is the race a crash on a
+    shared HERMES_HOME produces when two clients resume the same conversation
+    at once. The claim is a compare-and-swap on the record they read, so the
+    second update matches no row.
+    """
+    path = tmp_path / "state.db"
+    first, second = SessionDB(path), SessionDB(path)
+    first.record_interrupted_turn("shared", "the interrupted prompt", owner=_owner("a"))
+
+    seen_first = first.read_interrupted_turn("shared")
+    seen_second = second.read_interrupted_turn("shared")
+    claimed_first = first.claim_interrupted_turn("shared", expected=seen_first)
+    claimed_second = second.claim_interrupted_turn("shared", expected=seen_second)
+
+    assert claimed_first is not None
+    assert claimed_first["prompt"] == "the interrupted prompt"
+    assert claimed_second is None
+    # The loser leaves the record exactly as the winner left it.
+    survivor = second.read_interrupted_turn("shared")
+    assert survivor["attempts"] == 1
+
+
+def test_a_claim_bumps_the_attempt_count_durably(tmp_path):
+    """The crash-loop ceiling has to advance before the caller does anything."""
+    db = SessionDB(tmp_path / "state.db")
+    db.record_interrupted_turn("abc", "crashy prompt", attempts=1, owner=_owner("a"))
+
+    claimed = db.claim_interrupted_turn(
+        "abc", expected=db.read_interrupted_turn("abc")
+    )
+
+    assert claimed["attempts"] == 2
+    assert db.read_interrupted_turn("abc")["attempts"] == 2
+
+
+def test_a_claim_against_a_record_that_moved_on_abstains(tmp_path):
+    """The owning process re-recorded it, so it is a live turn, not an orphan."""
+    db = SessionDB(tmp_path / "state.db")
+    db.record_interrupted_turn("abc", "prompt", attempts=1, owner=_owner("a"))
+    stale = dict(db.read_interrupted_turn("abc"), attempts=0)
+
+    assert db.claim_interrupted_turn("abc", expected=stale) is None
+    assert db.read_interrupted_turn("abc")["attempts"] == 1
+    assert db.read_interrupted_turn("abc")["owner"] == _owner("a")
+
+
+def test_a_re_record_between_read_and_claim_defeats_the_claim(tmp_path):
+    """The ABA the counter alone cannot see: same attempts, different turn.
+
+    ``record_interrupted_turn`` is last-writer-wins and stamps ``attempts=0``
+    on every user-initiated turn, so the value a resuming process read off an
+    orphan recurs the moment somebody starts a *new* turn on the same
+    conversation. The prologue that writes that row runs long before the
+    engine takes the turn lease, so "fresh record, no lease yet" is an
+    ordinary state and the lease peek reads it as free. Were the counter the
+    whole token, this claim would win and the resuming process would
+    auto-continue a prompt another process is running right now.
+    """
+    path = tmp_path / "state.db"
+    resuming, live = SessionDB(path), SessionDB(path)
+    resuming.record_interrupted_turn(
+        "shared", "the orphaned prompt", attempts=0, owner=_owner("crashed")
+    )
+
+    gate_read = resuming.read_interrupted_turn("shared")
+    assert gate_read["attempts"] == 0
+    # The other process starts a live user turn. Same counter value, new turn.
+    time.sleep(0.02)
+    live.record_interrupted_turn(
+        "shared", "the prompt that is running right now", attempts=0, owner=_owner("live")
+    )
+    assert live.read_interrupted_turn("shared")["attempts"] == 0
+
+    assert resuming.claim_interrupted_turn("shared", expected=gate_read) is None
+    survivor = live.read_interrupted_turn("shared")
+    assert survivor["prompt"] == "the prompt that is running right now"
+    assert survivor["attempts"] == 0
+    assert survivor["owner"] == _owner("live")
+
+
+def test_a_re_record_of_the_same_prompt_by_the_same_owner_defeats_the_claim(tmp_path):
+    """The narrow leg: only ``started_at`` moved, and that is enough.
+
+    A process that crashed and came back re-runs its own interrupted prompt
+    under its own owner stamp. Attempts, prompt and owner all match what the
+    resuming process read; the write is visible only in the timestamp, which
+    ``record_interrupted_turn`` stamps fresh on every write.
+    """
+    path = tmp_path / "state.db"
+    resuming, live = SessionDB(path), SessionDB(path)
+    resuming.record_interrupted_turn("shared", "same prompt", owner=_owner("same"))
+
+    gate_read = resuming.read_interrupted_turn("shared")
+    time.sleep(0.02)
+    live.record_interrupted_turn("shared", "same prompt", owner=_owner("same"))
+    fresh = live.read_interrupted_turn("shared")
+    assert fresh["attempts"] == gate_read["attempts"]
+    assert fresh["prompt"] == gate_read["prompt"]
+    assert fresh["owner"] == gate_read["owner"]
+    assert fresh["started_at"] > gate_read["started_at"]
+
+    assert resuming.claim_interrupted_turn("shared", expected=gate_read) is None
+    assert live.read_interrupted_turn("shared")["attempts"] == 0
+
+
+def test_a_claim_leaves_the_true_owner_able_to_retire_its_record(tmp_path):
+    """The claim must not take the stamp the retire check reads.
+
+    A claim can land on a record whose owner is alive — the row it matched may
+    have been re-recorded by a turn that is running, or written by a process
+    whose lease lapsed while it kept working. If the claim restamped ``owner``,
+    that process could never retire its own record when its turn concluded, and
+    the record of a finished turn would sit there for a later resume to re-run.
+    """
+    path = tmp_path / "state.db"
+    running, claimant = SessionDB(path), SessionDB(path)
+    running.record_interrupted_turn("shared", "the live prompt", owner=_owner("running"))
+
+    claimed = claimant.claim_interrupted_turn(
+        "shared", expected=claimant.read_interrupted_turn("shared")
+    )
+
+    assert claimed is not None
+    assert claimed["owner"] == _owner("running")
+    # The turn concludes in the process that actually ran it.
+    assert running.clear_interrupted_turn("shared", owner=_owner("running"))
+    assert running.read_interrupted_turn("shared") is None
+
+
+def test_a_claim_leaves_the_cause_column_alone(tmp_path):
+    """``cause`` describes where the record came from, not who holds it."""
+    db = SessionDB(tmp_path / "state.db")
+    db.import_interrupted_turns([("abc", {"prompt": "legacy", "attempts": 0, "started_at": time.time()})])
+    assert db.read_interrupted_turn("abc")["cause"] == "migrated"
+
+    claimed = db.claim_interrupted_turn(
+        "abc", expected=db.read_interrupted_turn("abc")
+    )
+
+    assert claimed["cause"] == "migrated"
+
+
+def test_a_claim_against_a_retired_record_abstains(tmp_path):
+    db = SessionDB(tmp_path / "state.db")
+
+    assert (
+        db.claim_interrupted_turn(
+            "abc",
+            expected={"attempts": 0, "started_at": time.time(), "prompt": "p", "owner": None},
+        )
+        is None
+    )
+
+
+def test_a_claim_resolves_the_compression_lineage_root(tmp_path):
+    """Same key space as the turn lease, so a rotation cannot hide a record."""
+    db = SessionDB(tmp_path / "state.db")
+    db.create_session("root", source="test")
+    db.end_session("root", "compression")
+    db.create_session("child", source="test", parent_session_id="root")
+    db.record_interrupted_turn("root", "recorded before the rotation", owner=None)
+
+    claimed = db.claim_interrupted_turn(
+        "child", expected=db.read_interrupted_turn("child")
+    )
+
+    assert claimed["prompt"] == "recorded before the rotation"

--- a/tests/state/test_session_turn_lease.py
+++ b/tests/state/test_session_turn_lease.py
@@ -667,3 +667,76 @@ def test_turn_lease_fence_walks_continuation_that_inherited_fork_markers(tmp_pat
     ]
     db.release_session_turn_lease("delegate-continuation", delegate_holder)
     db.release_session_turn_lease("branch-continuation", branch_holder)
+
+
+def test_lease_holder_reads_back_while_the_lease_is_live(tmp_path):
+    """A caller can ask who owns the conversation without taking it."""
+    db = SessionDB(tmp_path / "state.db")
+    db.create_session("shared", source="test")
+    holder = f"pid={os.getpid()}:turn=live:platform=test"
+
+    assert db.get_session_turn_lease_holder("shared") is None
+    assert db.try_acquire_session_turn_lease("shared", holder, ttl_seconds=300)
+    assert db.get_session_turn_lease_holder("shared") == holder
+
+    db.release_session_turn_lease("shared", holder)
+    assert db.get_session_turn_lease_holder("shared") is None
+
+
+def test_lease_holder_ignores_an_expired_row(tmp_path):
+    db = SessionDB(tmp_path / "state.db")
+    db.create_session("shared", source="test")
+    holder = f"pid={os.getpid()}:turn=expiring:platform=test"
+
+    assert db.try_acquire_session_turn_lease("shared", holder, ttl_seconds=0.1)
+    time.sleep(0.2)
+
+    assert db.get_session_turn_lease_holder("shared") is None
+
+
+def test_lease_holder_ignores_a_dead_process(tmp_path, monkeypatch: pytest.MonkeyPatch):
+    """A row a dead process left behind is not a running turn."""
+    db = SessionDB(tmp_path / "state.db")
+    db.create_session("shared", source="test")
+    dead_holder = "pid=424242:turn=dead:platform=test"
+    assert db.try_acquire_session_turn_lease("shared", dead_holder, ttl_seconds=300)
+
+    probed: list[int] = []
+
+    def pid_exists(pid: int) -> bool:
+        probed.append(pid)
+        return False
+
+    monkeypatch.setattr(hermes_state, "psutil", SimpleNamespace(pid_exists=pid_exists))
+
+    assert db.get_session_turn_lease_holder("shared") is None
+    assert probed == [424242]
+
+
+def test_lease_holder_keeps_a_holder_the_probe_cannot_judge(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+):
+    """Probe doubt reads as live, so a caller stands down conservatively."""
+    db = SessionDB(tmp_path / "state.db")
+    db.create_session("shared", source="test")
+    holder = "pid=424242:turn=unknown:platform=test"
+    assert db.try_acquire_session_turn_lease("shared", holder, ttl_seconds=300)
+
+    def pid_exists(pid: int) -> bool:
+        raise OSError("no answer")
+
+    monkeypatch.setattr(hermes_state, "psutil", SimpleNamespace(pid_exists=pid_exists))
+
+    assert db.get_session_turn_lease_holder("shared") == holder
+
+
+def test_lease_holder_resolves_the_compression_lineage_root(tmp_path):
+    db = SessionDB(tmp_path / "state.db")
+    db.create_session("root", source="test")
+    db.end_session("root", "compression")
+    db.create_session("child", source="test", parent_session_id="root")
+    holder = f"pid={os.getpid()}:turn=live:platform=test"
+
+    assert db.try_acquire_session_turn_lease("root", holder, ttl_seconds=300)
+
+    assert db.get_session_turn_lease_holder("child") == holder

--- a/tests/tui_gateway/test_auto_continue.py
+++ b/tests/tui_gateway/test_auto_continue.py
@@ -1,35 +1,36 @@
 """Crash-interrupted turns auto-continue on the next session.resume.
 
-A turn's durable marker (tui_gateway/turn_marker.py) is written when the turn
-starts running and cleared when it concludes — success, handled error, or
-interrupt. Only a process death leaves it behind, so a marker found at resume
+A turn's durable record (``interrupted_turns`` in state.db) is written when the
+turn starts running and cleared when it concludes — success, handled error, or
+interrupt. Only a process death leaves it behind, so a record found at resume
 time is positive proof the turn never finished. Contract pinned here:
 
-* the marker module round-trips, prunes stale entries, and tolerates a
-  corrupt sidecar;
-* ``_run_prompt_submit`` writes the marker before the turn and clears it in
+* ``_run_prompt_submit`` writes the record before the turn and clears it in
   the ``finally`` on both the success and exception paths (a handled failure
   is a concluded turn — its terminal frame + retained snapshot own recovery);
+* the retire is owner-checked: a process that never ran the turn cannot delete
+  the record of one still running elsewhere;
 * ``_maybe_schedule_auto_continue`` re-submits a fresh interrupted prompt as
   a continuation note (display_kind ``auto_continue``), refuses stale /
   disabled / crash-looping / already-running cases, and bounds attempts via
-  the marker's attempt counter.
+  the record's attempt counter;
+* the legacy JSON sidecar is imported once per HERMES_HOME and renamed aside,
+  with its keys resolved to the compression-lineage root the table uses.
 """
 
 from __future__ import annotations
 
+import json
 import threading
 import time
 import types
 
 import pytest
 
-from tui_gateway import server
-from tui_gateway.turn_marker import (
-    clear_turn_marker,
-    read_turn_marker,
-    record_turn_start,
-)
+from hermes_state import SessionDB
+from tui_gateway import server, turn_marker
+
+_FOREIGN_OWNER = "pid=999999:platform=other"
 
 
 class _InlineThread:
@@ -70,6 +71,24 @@ def _session(agent=None, **extra):
     }
 
 
+def _record(db, session_key, prompt, *, attempts=0, owner=_FOREIGN_OWNER):
+    """A record left by some other process's interrupted turn."""
+    assert db.record_interrupted_turn(
+        session_key, prompt, attempts=attempts, owner=owner
+    )
+
+
+def _read(db, session_key):
+    return db.read_interrupted_turn(session_key)
+
+
+def _write_sidecar(home, entries):
+    path = home / "desktop" / "interrupted_turns.json"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(entries), encoding="utf-8")
+    return path
+
+
 @pytest.fixture()
 def emits(monkeypatch):
     captured: list = []
@@ -83,13 +102,21 @@ def emits(monkeypatch):
 
 @pytest.fixture()
 def marker_home(monkeypatch, tmp_path):
-    """Point the server's marker storage at a temp HERMES_HOME."""
+    """Point the server's session home at a temp HERMES_HOME."""
     monkeypatch.setattr(server, "_hermes_home", tmp_path)
     return tmp_path
 
 
 @pytest.fixture()
-def turn_env(monkeypatch, tmp_path, marker_home):
+def turn_db(monkeypatch, marker_home):
+    """Point the server's state.db handle at a temp database."""
+    db = SessionDB(marker_home / "state.db")
+    monkeypatch.setattr(server, "_get_db", lambda: db)
+    return db
+
+
+@pytest.fixture()
+def turn_env(monkeypatch, tmp_path, turn_db):
     """Neutralize the turn pipeline's environment-heavy side paths."""
     monkeypatch.setattr(server.threading, "Thread", _InlineThread)
     monkeypatch.setattr(server, "_wire_callbacks", lambda sid: None)
@@ -101,40 +128,67 @@ def turn_env(monkeypatch, tmp_path, marker_home):
     monkeypatch.setattr(server, "_get_usage", lambda agent: {})
 
 
-# ── Marker module ──────────────────────────────────────────────────────
+# ── Record storage ─────────────────────────────────────────────────────
 
 
-def test_marker_roundtrip(tmp_path):
-    record_turn_start(tmp_path, "abc", "fix the bug", attempts=1)
+def test_record_roundtrip(turn_db):
+    _record(turn_db, "abc", "fix the bug", attempts=1)
 
-    marker = read_turn_marker(tmp_path, "abc")
+    marker = _read(turn_db, "abc")
     assert marker is not None
     assert marker["prompt"] == "fix the bug"
     assert marker["attempts"] == 1
     assert marker["started_at"] == pytest.approx(time.time(), abs=5)
 
-    clear_turn_marker(tmp_path, "abc")
-    assert read_turn_marker(tmp_path, "abc") is None
+    assert turn_db.clear_interrupted_turn("abc", owner=_FOREIGN_OWNER)
+    assert _read(turn_db, "abc") is None
 
 
-def test_marker_survives_corrupt_sidecar(tmp_path):
-    path = tmp_path / "desktop" / "interrupted_turns.json"
-    path.parent.mkdir(parents=True)
-    path.write_text("{not json")
+def test_a_foreign_process_cannot_retire_a_live_record(turn_db, marker_home):
+    """The record of a turn running elsewhere survives this process's retire.
 
-    assert read_turn_marker(tmp_path, "abc") is None
-    record_turn_start(tmp_path, "abc", "prompt")
-    assert read_turn_marker(tmp_path, "abc")["prompt"] == "prompt"
+    A second process that submits on a busy conversation waits for the turn
+    lease, times out, and emits a terminal error frame — and the frame path
+    retires the record as it goes. Before the owner check that deleted the
+    running turn's only durable trace.
+    """
+    _record(turn_db, "session-key", "the turn that is actually running")
+
+    server._retire_turn_marker(_session())
+
+    survivor = _read(turn_db, "session-key")
+    assert survivor is not None
+    assert survivor["prompt"] == "the turn that is actually running"
 
 
-# ── Turn lifecycle owns the marker ─────────────────────────────────────
+def test_retire_tolerates_the_keyless_call(turn_env, turn_db):
+    """``_emit_terminal_turn_error`` retires with no explicit keys."""
+    session = _session()
+    server._record_interrupted_turn(session, "session-key", "own turn")
+    assert _read(turn_db, "session-key") is not None
+
+    server._retire_turn_marker(session)
+
+    assert _read(turn_db, "session-key") is None
 
 
-def test_concluded_turn_clears_marker(emits, turn_env, marker_home):
+def test_retire_covers_a_key_compression_rotated_mid_turn(turn_env, turn_db):
+    session = _session(session_key="rotated-key")
+    server._record_interrupted_turn(session, "pre-rotation-key", "own turn")
+
+    server._retire_turn_marker(session, "pre-rotation-key")
+
+    assert _read(turn_db, "pre-rotation-key") is None
+
+
+# ── Turn lifecycle owns the record ─────────────────────────────────────
+
+
+def test_concluded_turn_clears_marker(emits, turn_env, turn_db):
     seen_mid_turn: list = []
 
     def _run(message, **kwargs):
-        seen_mid_turn.append(read_turn_marker(marker_home, "session-key"))
+        seen_mid_turn.append(_read(turn_db, "session-key"))
         return {"final_response": "done"}
 
     agent = types.SimpleNamespace(
@@ -149,12 +203,12 @@ def test_concluded_turn_clears_marker(emits, turn_env, marker_home):
     assert seen_mid_turn[0]["prompt"] == "do the thing"
     assert seen_mid_turn[0]["attempts"] == 0
     # … and cleared once the turn concluded.
-    assert read_turn_marker(marker_home, "session-key") is None
+    assert _read(turn_db, "session-key") is None
 
 
-def test_handled_failure_still_clears_marker(emits, turn_env, marker_home):
+def test_handled_failure_still_clears_marker(emits, turn_env, turn_db):
     """An exception is a CONCLUDED turn (terminal frame + retained snapshot own
-    recovery) — only a process death may leave the marker behind."""
+    recovery) — only a process death may leave the record behind."""
 
     def _boom(message, **kwargs):
         raise RuntimeError("provider exploded")
@@ -166,19 +220,19 @@ def test_handled_failure_still_clears_marker(emits, turn_env, marker_home):
 
     server._run_prompt_submit("rid", "sid", session, "do the thing")
 
-    assert read_turn_marker(marker_home, "session-key") is None
+    assert _read(turn_db, "session-key") is None
 
 
 def test_continuation_turn_records_attempt_and_original_prompt(
-    emits, turn_env, marker_home
+    emits, turn_env, turn_db
 ):
-    """A continuation's marker must carry the attempt count (crash-loop
+    """A continuation's record must carry the attempt count (crash-loop
     breaker) and the ORIGINAL prompt — recording its own recovery note would
     nest note inside note on a second crash."""
     seen: list = []
 
     def _run(message, **kwargs):
-        seen.append(read_turn_marker(marker_home, "session-key"))
+        seen.append(_read(turn_db, "session-key"))
         return {"final_response": "done"}
 
     agent = types.SimpleNamespace(
@@ -199,7 +253,39 @@ def test_continuation_turn_records_attempt_and_original_prompt(
     assert "_auto_continue_prompt" not in session
 
 
-def test_older_agent_still_gets_the_post_turn_stamp(emits, turn_env, marker_home):
+def test_continuation_takes_over_a_dead_process_record(emits, turn_env, turn_db):
+    """The attempts counter has to advance across a restart.
+
+    The record being continued was written by the process that died. Refusing
+    to overwrite another owner's row would freeze the counter and defeat the
+    crash-loop breaker, so a turn start takes the row over and stamps itself.
+    """
+    _record(turn_db, "session-key", "the original prompt", attempts=1)
+    seen: list = []
+
+    def _run(message, **kwargs):
+        seen.append(_read(turn_db, "session-key"))
+        return {"final_response": "done"}
+
+    agent = types.SimpleNamespace(
+        session_id="session-key", run_conversation=_run, clear_interrupt=lambda: None
+    )
+    session = _session(
+        agent=agent,
+        running=True,
+        _auto_continue_attempt=2,
+        _auto_continue_prompt="the original prompt",
+    )
+
+    server._run_prompt_submit("rid", "sid", session, "note")
+
+    assert seen[0]["attempts"] == 2
+    assert seen[0]["owner"] == server._turn_record_owner()
+    # This process owns it now, so its own retire lands.
+    assert _read(turn_db, "session-key") is None
+
+
+def test_older_agent_still_gets_the_post_turn_stamp(emits, turn_env, turn_db):
     """An agent whose run_conversation predates turn-start typing keeps the
     original behavior — the row is typed once the turn concludes."""
     stamped: list = []
@@ -232,7 +318,7 @@ def test_older_agent_still_gets_the_post_turn_stamp(emits, turn_env, marker_home
 
 
 @pytest.fixture()
-def schedule_env(monkeypatch, marker_home):
+def schedule_env(monkeypatch, turn_db):
     monkeypatch.setattr(server.threading, "Thread", _InlineThread)
     monkeypatch.setattr(server, "_start_agent_build", lambda sid, session: None)
     monkeypatch.setattr(server, "_wait_agent", lambda session, rid, timeout=30.0: None)
@@ -246,8 +332,8 @@ def schedule_env(monkeypatch, marker_home):
     return submitted
 
 
-def test_fresh_marker_schedules_continuation(emits, schedule_env, marker_home):
-    record_turn_start(marker_home, "session-key", "fix the flaky test")
+def test_fresh_marker_schedules_continuation(emits, schedule_env, turn_db):
+    _record(turn_db, "session-key", "fix the flaky test")
     session = _session()
 
     result = server._maybe_schedule_auto_continue("sid", session, "session-key")
@@ -263,8 +349,8 @@ def test_fresh_marker_schedules_continuation(emits, schedule_env, marker_home):
     assert ("message.start", "sid", None) in [(e, s, p) for e, s, p in emits]
 
 
-def test_stale_marker_is_cleared_not_continued(schedule_env, marker_home, monkeypatch):
-    record_turn_start(marker_home, "session-key", "old prompt")
+def test_stale_marker_is_cleared_not_continued(schedule_env, turn_db, monkeypatch):
+    _record(turn_db, "session-key", "old prompt")
     monkeypatch.setattr(
         server, "time", types.SimpleNamespace(time=lambda: time.time() + 3600)
     )
@@ -273,11 +359,11 @@ def test_stale_marker_is_cleared_not_continued(schedule_env, marker_home, monkey
 
     assert result is None
     assert not schedule_env
-    assert read_turn_marker(marker_home, "session-key") is None
+    assert _read(turn_db, "session-key") is None
 
 
-def test_config_widens_freshness_window(emits, schedule_env, marker_home, monkeypatch):
-    record_turn_start(marker_home, "session-key", "old prompt")
+def test_config_widens_freshness_window(emits, schedule_env, turn_db, monkeypatch):
+    _record(turn_db, "session-key", "old prompt")
     monkeypatch.setattr(
         server,
         "_load_cfg",
@@ -293,18 +379,18 @@ def test_config_widens_freshness_window(emits, schedule_env, marker_home, monkey
     assert len(schedule_env) == 1
 
 
-def test_exhausted_attempts_break_the_loop(schedule_env, marker_home):
-    record_turn_start(marker_home, "session-key", "crashy prompt", attempts=2)
+def test_exhausted_attempts_break_the_loop(schedule_env, turn_db):
+    _record(turn_db, "session-key", "crashy prompt", attempts=2)
 
     result = server._maybe_schedule_auto_continue("sid", _session(), "session-key")
 
     assert result is None
     assert not schedule_env
-    assert read_turn_marker(marker_home, "session-key") is None
+    assert _read(turn_db, "session-key") is None
 
 
-def test_disabled_by_config(schedule_env, marker_home, monkeypatch):
-    record_turn_start(marker_home, "session-key", "prompt")
+def test_disabled_by_config(schedule_env, turn_db, monkeypatch):
+    _record(turn_db, "session-key", "prompt")
     monkeypatch.setattr(
         server,
         "_load_cfg",
@@ -317,15 +403,15 @@ def test_disabled_by_config(schedule_env, marker_home, monkeypatch):
     assert not schedule_env
 
 
-def test_no_marker_means_no_continuation(schedule_env, marker_home):
+def test_no_marker_means_no_continuation(schedule_env, turn_db):
     assert server._maybe_schedule_auto_continue("sid", _session(), "session-key") is None
     assert not schedule_env
 
 
-def test_running_session_wins_over_continuation(emits, schedule_env, marker_home):
-    """A real user prompt that raced the kickoff keeps its turn; the marker is
+def test_running_session_wins_over_continuation(emits, schedule_env, turn_db):
+    """A real user prompt that raced the kickoff keeps its turn; the record is
     left for that turn's own conclusion to clear."""
-    record_turn_start(marker_home, "session-key", "prompt")
+    _record(turn_db, "session-key", "prompt")
     session = _session(running=True)
 
     result = server._maybe_schedule_auto_continue("sid", session, "session-key")
@@ -334,14 +420,14 @@ def test_running_session_wins_over_continuation(emits, schedule_env, marker_home
     assert result is not None
     assert not schedule_env
     assert session["_auto_continue_scheduled"] is False
-    assert read_turn_marker(marker_home, "session-key") is not None
+    assert _read(turn_db, "session-key") is not None
     # Nothing left behind for the racing user turn to inherit.
     assert "_auto_continue_attempt" not in session
     assert "_auto_continue_prompt" not in session
 
 
-def test_double_schedule_is_guarded(emits, schedule_env, marker_home):
-    record_turn_start(marker_home, "session-key", "prompt")
+def test_double_schedule_is_guarded(emits, schedule_env, turn_db):
+    _record(turn_db, "session-key", "prompt")
     session = _session()
 
     first = server._maybe_schedule_auto_continue("sid", session, "session-key")
@@ -353,9 +439,9 @@ def test_double_schedule_is_guarded(emits, schedule_env, marker_home):
 
 
 def test_failed_agent_build_leaves_marker_for_retry(
-    emits, schedule_env, marker_home, monkeypatch
+    emits, schedule_env, turn_db, monkeypatch
 ):
-    record_turn_start(marker_home, "session-key", "prompt")
+    _record(turn_db, "session-key", "prompt")
     monkeypatch.setattr(
         server,
         "_wait_agent",
@@ -368,9 +454,149 @@ def test_failed_agent_build_leaves_marker_for_retry(
     assert result is not None
     assert not schedule_env
     assert session["_auto_continue_scheduled"] is False
-    assert read_turn_marker(marker_home, "session-key") is not None
+    assert _read(turn_db, "session-key") is not None
 
 
-# ── End to end: continuation runs a real turn and clears the marker ────
+# ── Legacy sidecar import ──────────────────────────────────────────────
 
 
+def test_legacy_sidecar_imports_and_is_renamed_aside(schedule_env, turn_db, marker_home):
+    path = _write_sidecar(
+        marker_home,
+        {
+            "session-key": {
+                "attempts": 1,
+                "prompt": "the prompt the old build recorded",
+                "started_at": time.time(),
+            }
+        },
+    )
+
+    result = server._maybe_schedule_auto_continue("sid", _session(), "session-key")
+
+    assert result is not None
+    assert result["attempt"] == 2
+    (text, _kwargs), = schedule_env
+    assert "the prompt the old build recorded" in text
+    assert not path.exists()
+    assert (marker_home / "desktop" / "interrupted_turns.json.migrated").is_file()
+
+
+def test_legacy_sidecar_key_is_resolved_to_the_conversation_root(
+    schedule_env, turn_db, marker_home
+):
+    """The sidecar filed records under the compression SEGMENT.
+
+    A record written before a rotation has to land on the row the resume after
+    the rotation reads, which is the lineage root.
+    """
+    turn_db.create_session("root", source="test")
+    turn_db.end_session("root", "compression")
+    turn_db.create_session("child", source="test", parent_session_id="root")
+    _write_sidecar(
+        marker_home,
+        {
+            "root": {
+                "attempts": 0,
+                "prompt": "recorded before the rotation",
+                "started_at": time.time(),
+            }
+        },
+    )
+
+    result = server._maybe_schedule_auto_continue(
+        "sid", _session(session_key="child"), "child"
+    )
+
+    assert result is not None
+    (text, _kwargs), = schedule_env
+    assert "recorded before the rotation" in text
+
+
+def test_imported_record_carries_no_owner_and_stays_retirable(turn_db, marker_home):
+    _write_sidecar(
+        marker_home,
+        {
+            "session-key": {
+                "attempts": 0,
+                "prompt": "legacy prompt",
+                "started_at": time.time(),
+            }
+        },
+    )
+    session = _session()
+
+    server._migrate_turn_markers(session)
+
+    record = _read(turn_db, "session-key")
+    assert record["owner"] is None
+    assert record["cause"] == "migrated"
+    server._retire_turn_marker(session)
+    assert _read(turn_db, "session-key") is None
+
+
+def test_import_does_not_overwrite_a_live_record(turn_db, marker_home):
+    _record(turn_db, "session-key", "the live record", attempts=1)
+    _write_sidecar(
+        marker_home,
+        {
+            "session-key": {
+                "attempts": 0,
+                "prompt": "the legacy record",
+                "started_at": time.time() - 60,
+            }
+        },
+    )
+
+    server._migrate_turn_markers(_session())
+
+    record = _read(turn_db, "session-key")
+    assert record["prompt"] == "the live record"
+    assert record["attempts"] == 1
+
+
+def test_corrupt_legacy_sidecar_is_retired_without_breaking_resume(
+    schedule_env, turn_db, marker_home
+):
+    """The unreadable-file case the sidecar had to tolerate, now at import."""
+    path = marker_home / "desktop" / "interrupted_turns.json"
+    path.parent.mkdir(parents=True)
+    path.write_text("{not json", encoding="utf-8")
+    session = _session()
+
+    assert server._maybe_schedule_auto_continue("sid", session, "session-key") is None
+    assert not path.exists()
+
+    # Recording still works afterwards.
+    server._record_interrupted_turn(session, "session-key", "prompt")
+    assert _read(turn_db, "session-key")["prompt"] == "prompt"
+
+
+def test_failed_import_leaves_the_sidecar_for_the_next_resume(
+    turn_db, marker_home, monkeypatch
+):
+    path = _write_sidecar(
+        marker_home,
+        {
+            "session-key": {
+                "attempts": 0,
+                "prompt": "legacy prompt",
+                "started_at": time.time(),
+            }
+        },
+    )
+
+    def _boom(home):
+        raise OSError("rename denied")
+
+    monkeypatch.setattr(server, "retire_sidecar", _boom)
+    server._migrate_turn_markers(_session())
+    assert path.is_file()
+
+    monkeypatch.setattr(server, "retire_sidecar", turn_marker.retire_sidecar)
+    server._migrate_turn_markers(_session())
+    assert not path.exists()
+    assert _read(turn_db, "session-key")["prompt"] == "legacy prompt"
+
+
+# ── End to end: continuation runs a real turn and clears the record ────

--- a/tests/tui_gateway/test_auto_continue.py
+++ b/tests/tui_gateway/test_auto_continue.py
@@ -150,7 +150,9 @@ def test_a_foreign_process_cannot_retire_a_live_record(turn_db, marker_home):
     A second process that submits on a busy conversation waits for the turn
     lease, times out, and emits a terminal error frame — and the frame path
     retires the record as it goes. Before the owner check that deleted the
-    running turn's only durable trace.
+    scheduler's only durable pointer to the running turn: the prompt row
+    itself survives in the session DB, so what it cost was the automatic
+    resume, not the data.
     """
     _record(turn_db, "session-key", "the turn that is actually running")
 
@@ -390,7 +392,13 @@ def test_exhausted_attempts_break_the_loop(schedule_env, turn_db):
 
 
 def test_disabled_by_config(schedule_env, turn_db, monkeypatch):
-    _record(turn_db, "session-key", "prompt")
+    """Disabled here says nothing about a record another process owns.
+
+    ``enabled`` is this process's config, and the process that wrote the
+    record may be running with auto-continue on — so declining to continue is
+    not licence to retire someone else's live record.
+    """
+    _record(turn_db, "session-key", "the turn that is actually running")
     monkeypatch.setattr(
         server,
         "_load_cfg",
@@ -401,6 +409,27 @@ def test_disabled_by_config(schedule_env, turn_db, monkeypatch):
 
     assert result is None
     assert not schedule_env
+    survivor = _read(turn_db, "session-key")
+    assert survivor is not None
+    assert survivor["prompt"] == "the turn that is actually running"
+
+
+def test_disabled_by_config_still_clears_own_record(schedule_env, turn_db, monkeypatch):
+    """Its own record is retired: this process will never continue that turn."""
+    session = _session()
+    server._record_interrupted_turn(session, "session-key", "own turn")
+    assert _read(turn_db, "session-key") is not None
+    monkeypatch.setattr(
+        server,
+        "_load_cfg",
+        lambda: {"desktop": {"auto_continue": {"enabled": False}}},
+    )
+
+    result = server._maybe_schedule_auto_continue("sid", session, "session-key")
+
+    assert result is None
+    assert not schedule_env
+    assert _read(turn_db, "session-key") is None
 
 
 def test_no_marker_means_no_continuation(schedule_env, turn_db):

--- a/tests/tui_gateway/test_turn_admission.py
+++ b/tests/tui_gateway/test_turn_admission.py
@@ -1,0 +1,839 @@
+"""Admission: who is allowed to start a turn on a conversation, and how it refuses.
+
+Two ``hermes serve`` processes can share one ``HERMES_HOME``, so "is this
+conversation busy" is a cross-process question and the answer lives in
+``state.db``. Admission polarity is set by who initiated the turn:
+
+* machine-initiated (the auto-continue of a crash-interrupted turn) is
+  fail-closed. It peeks at the conversation's turn lease, and it consumes the
+  ``interrupted_turns`` row with a compare-and-swap that exactly one process
+  can win. Anything unproven resolves to abstaining, which defers the recovery
+  to the next resume rather than losing it: the record stays where it was.
+* user-initiated is fail-open. It waits a bounded time with a visible notice
+  and then refuses in the open, because a user who is watching would rather be
+  told the session is busy than be dropped.
+
+Caller class is carried by construction: ``_run_prompt_submit`` takes a
+``user_initiated`` keyword that the ``prompt.submit`` handler sets and no
+other dispatch site does. Every turn the gateway synthesizes for itself is
+therefore machine class by omission, which is the fail-safe default.
+
+The user-initiated half is dormant against engines whose ``run_conversation``
+cannot accept a caller-supplied lease holder, which is every engine today.
+Both arms are pinned here, so the day the engine gains the parameter the
+behavior it switches on is already covered.
+"""
+
+from __future__ import annotations
+
+import inspect
+import os
+import sqlite3
+import threading
+import time
+import types
+
+import pytest
+
+import hermes_state
+from hermes_state import SessionDB
+from tui_gateway import server
+
+_FOREIGN_OWNER = "pid=999999:platform=other"
+# A lease held by a process the dead-holder probe cannot write off. Real pid,
+# foreign turn: the probe never reclaims a live pid, which is the whole point.
+_LIVE_HOLDER = f"pid={os.getpid()}:turn=live:platform=other"
+_DEAD_HOLDER = "pid=999999:turn=dead:platform=other"
+
+
+class _InlineThread:
+    """Run threads synchronously so tests observe final state."""
+
+    def __init__(self, target=None, daemon=None, args=(), kwargs=None):
+        self._target = target
+        self._args = args
+        self._kwargs = kwargs or {}
+
+    def start(self):
+        if self._target is not None:
+            self._target(*self._args, **self._kwargs)
+
+    def is_alive(self):
+        return False
+
+    def join(self, timeout=None):
+        return None
+
+
+def _session(agent=None, **extra):
+    return {
+        "agent": agent if agent is not None else types.SimpleNamespace(),
+        "session_key": "session-key",
+        "history": [],
+        "history_lock": threading.Lock(),
+        "history_version": 0,
+        "running": False,
+        "attached_images": [],
+        "image_counter": 0,
+        "cols": 80,
+        "slash_worker": None,
+        "show_reasoning": False,
+        "tool_progress_mode": "all",
+        "inflight_turn": None,
+        **extra,
+    }
+
+
+def _record(db, session_key, prompt, *, attempts=0, owner=_FOREIGN_OWNER):
+    assert db.record_interrupted_turn(
+        session_key, prompt, attempts=attempts, owner=owner
+    )
+
+
+def _read(db, session_key):
+    return db.read_interrupted_turn(session_key)
+
+
+@pytest.fixture()
+def emits(monkeypatch):
+    captured: list = []
+    monkeypatch.setattr(
+        server,
+        "_emit",
+        lambda event, sid, payload=None: captured.append((event, sid, payload)),
+    )
+    return captured
+
+
+@pytest.fixture()
+def marker_home(monkeypatch, tmp_path):
+    monkeypatch.setattr(server, "_hermes_home", tmp_path)
+    return tmp_path
+
+
+@pytest.fixture()
+def turn_db(monkeypatch, marker_home):
+    db = SessionDB(marker_home / "state.db")
+    monkeypatch.setattr(server, "_get_db", lambda: db)
+    return db
+
+
+@pytest.fixture()
+def turn_env(monkeypatch, tmp_path, turn_db):
+    """Neutralize the turn pipeline's environment-heavy side paths."""
+    monkeypatch.setattr(server.threading, "Thread", _InlineThread)
+    monkeypatch.setattr(server, "_wire_callbacks", lambda sid: None)
+    monkeypatch.setattr(server, "_sync_agent_model_with_config", lambda sid, session: None)
+    monkeypatch.setattr(server, "_session_cwd", lambda session: str(tmp_path))
+    monkeypatch.setattr(server, "_register_session_cwd", lambda session: None)
+    monkeypatch.setattr(server, "_tts_stream_begin", lambda: None)
+    monkeypatch.setattr(server, "_sync_session_key_after_compress", lambda *a, **k: None)
+    monkeypatch.setattr(server, "_get_usage", lambda agent: {})
+
+
+@pytest.fixture()
+def schedule_env(monkeypatch, turn_db):
+    monkeypatch.setattr(server.threading, "Thread", _InlineThread)
+    monkeypatch.setattr(server, "_start_agent_build", lambda sid, session: None)
+    monkeypatch.setattr(server, "_wait_agent", lambda session, rid, timeout=30.0: None)
+    monkeypatch.setattr(server, "_load_cfg", lambda: {})
+    submitted: list = []
+    monkeypatch.setattr(
+        server,
+        "_run_prompt_submit",
+        lambda rid, sid, session, text, **kw: submitted.append((text, kw)),
+    )
+    return submitted
+
+
+# ── Machine-initiated admission: peek, then claim ──────────────────────
+
+
+def test_a_live_holder_defers_the_continuation(emits, schedule_env, turn_db):
+    """The other process is still running the turn: do not queue a second one.
+
+    The interrupted-turn record is proof that a turn started, not that it
+    stopped. While another process holds the conversation's turn lease the
+    record is that process's business, so the schedule abstains and leaves the
+    record untouched for a later resume that finds the conversation free.
+    """
+    _record(turn_db, "session-key", "the turn that is actually running")
+    assert turn_db.try_acquire_session_turn_lease(
+        "session-key", _LIVE_HOLDER, ttl_seconds=300
+    )
+
+    result = server._maybe_schedule_auto_continue("sid", _session(), "session-key")
+
+    assert result is None
+    assert not schedule_env
+    survivor = _read(turn_db, "session-key")
+    assert survivor is not None
+    assert survivor["attempts"] == 0
+    assert survivor["owner"] == _FOREIGN_OWNER
+
+
+def test_a_dead_holders_lease_does_not_block_the_continuation(
+    emits, schedule_env, turn_db, monkeypatch
+):
+    """A lease left behind by a process that died is not a running turn."""
+    _record(turn_db, "session-key", "fix the flaky test")
+    assert turn_db.try_acquire_session_turn_lease(
+        "session-key", _DEAD_HOLDER, ttl_seconds=300
+    )
+    probed: list[int] = []
+
+    def pid_exists(pid: int) -> bool:
+        probed.append(pid)
+        return False
+
+    monkeypatch.setattr(
+        hermes_state, "psutil", types.SimpleNamespace(pid_exists=pid_exists)
+    )
+
+    result = server._maybe_schedule_auto_continue("sid", _session(), "session-key")
+
+    assert probed == [999999]
+    assert result is not None
+    assert len(schedule_env) == 1
+
+
+def test_an_expired_lease_does_not_block_the_continuation(
+    emits, schedule_env, turn_db
+):
+    _record(turn_db, "session-key", "fix the flaky test")
+    assert turn_db.try_acquire_session_turn_lease(
+        "session-key", _LIVE_HOLDER, ttl_seconds=0.1
+    )
+    time.sleep(0.2)
+
+    result = server._maybe_schedule_auto_continue("sid", _session(), "session-key")
+
+    assert result is not None
+    assert len(schedule_env) == 1
+
+
+def test_the_claim_is_durable_before_the_kickoff(
+    emits, schedule_env, turn_db, monkeypatch
+):
+    """The attempts bump lands in storage before anything fallible starts.
+
+    A continuation that dies inside its own agent build must still count
+    against the crash-loop ceiling, or a build that always dies re-fires
+    forever.
+
+    The bump is also the ONLY thing the claim writes. The owner stamp is the
+    retire check, and a claimant that took it would leave the record's true
+    owner unable to retire its own record when its turn ended -- so a claim
+    that landed on a live turn would strand that turn's record for a later
+    resume to re-run. The claimant stamps itself the ordinary way, in the
+    turn prologue, on its way into the turn it actually runs.
+    """
+    seen: list = []
+    monkeypatch.setattr(
+        server,
+        "_start_agent_build",
+        lambda sid, session: seen.append(_read(turn_db, "session-key")),
+    )
+    _record(turn_db, "session-key", "crashy prompt")
+
+    result = server._maybe_schedule_auto_continue("sid", _session(), "session-key")
+
+    assert result["attempt"] == 1
+    assert seen and seen[0]["attempts"] == 1
+    assert seen[0]["owner"] == _FOREIGN_OWNER
+    assert seen[0]["owner"] != server._turn_record_owner()
+
+
+def test_a_turn_that_starts_between_the_read_and_the_claim_defeats_the_claim(
+    emits, schedule_env, turn_db, monkeypatch
+):
+    """The realizable ABA, driven through the scheduler end to end.
+
+    The gate reads an orphan at attempts=0. Another process then starts a real
+    user turn: its prologue re-records the row, last-writer-wins, at attempts=0
+    again -- and it does that long before the engine takes the turn lease, so
+    the peek in between has nothing to see and reads the conversation as free.
+    A claim whose token was the counter alone would match, and this process
+    would auto-continue the prompt the other process is running right now.
+
+    The window is injected at the peek because that is exactly where it lives:
+    between the gate's read and the compare-and-swap.
+    """
+    _record(turn_db, "session-key", "the ORPHANED prompt", attempts=0)
+
+    def _peek_then_a_live_turn_starts(session, key):
+        _record(
+            turn_db,
+            "session-key",
+            "the prompt the other process is running right now",
+            attempts=0,
+            owner="pid=424242:platform=other",
+        )
+        return False  # no lease yet: the engine acquires much later
+
+    monkeypatch.setattr(
+        server, "_turn_is_held_elsewhere", _peek_then_a_live_turn_starts
+    )
+
+    result = server._maybe_schedule_auto_continue("sid", _session(), "session-key")
+
+    assert result is None
+    assert not schedule_env
+    # The live turn's record is untouched, including its attempt count.
+    survivor = _read(turn_db, "session-key")
+    assert survivor["prompt"] == "the prompt the other process is running right now"
+    assert survivor["attempts"] == 0
+    assert survivor["owner"] == "pid=424242:platform=other"
+
+
+def test_a_claim_leaves_the_records_owner_able_to_retire_it(
+    emits, schedule_env, turn_db
+):
+    """A claim must not cost the true owner the ability to close its own turn.
+
+    ``clear_interrupted_turn`` is owner-checked, so a claim that restamped
+    ``owner`` would make the record of a COMPLETED turn unretireable by the
+    process that ran it -- and the next resume would auto-continue finished
+    work.
+    """
+    _record(turn_db, "session-key", "a turn that is still running")
+
+    assert server._maybe_schedule_auto_continue("sid", _session(), "session-key")
+
+    assert turn_db.clear_interrupted_turn("session-key", owner=_FOREIGN_OWNER)
+    assert _read(turn_db, "session-key") is None
+
+
+def test_a_storage_error_in_the_claim_abstains(emits, schedule_env, turn_db, monkeypatch):
+    """Not every sqlite error is a lock, and none of them may schedule a turn.
+
+    ``acquire_session_turn_lease`` re-raises anything it cannot classify as a
+    lock, so a claim built on it would propagate a disk error out of the
+    resume path. The claim swallows storage failure into an abstention
+    instead, which leaves the record for the next resume.
+    """
+
+    def _boom(*args, **kwargs):
+        raise sqlite3.OperationalError("disk I/O error")
+
+    _record(turn_db, "session-key", "prompt")
+    monkeypatch.setattr(turn_db, "_execute_write", _boom)
+
+    result = server._maybe_schedule_auto_continue("sid", _session(), "session-key")
+
+    assert result is None
+    assert not schedule_env
+    survivor = _read(turn_db, "session-key")
+    assert survivor is not None
+    assert survivor["attempts"] == 0
+
+
+def test_a_storage_error_in_the_peek_abstains(emits, schedule_env, turn_db, monkeypatch):
+    """Cannot read the lease means cannot rule out a running turn.
+
+    The substitute raises what the real accessor raises. ``sqlite3.Error`` is
+    not swallowed into a None down there: reporting no-holder off a failed
+    read would hand this function a licence the read never earned. So the
+    contract pinned here is the one that runs in production, not one that only
+    holds against a stub.
+    """
+
+    def _boom(*args, **kwargs):
+        raise sqlite3.OperationalError("disk I/O error")
+
+    _record(turn_db, "session-key", "prompt")
+    monkeypatch.setattr(turn_db, "get_session_turn_lease_holder", _boom)
+
+    result = server._maybe_schedule_auto_continue("sid", _session(), "session-key")
+
+    assert result is None
+    assert not schedule_env
+    assert _read(turn_db, "session-key")["attempts"] == 0
+
+
+# ── The note says only what the claim proved ───────────────────────────
+
+
+def test_the_recovery_note_claims_only_what_was_proved(turn_db):
+    """The note is read by the model, so it must not assert an unproven fact.
+
+    The claim proves two things: this process took the interrupted-turn
+    record, and no live turn-lease claim stood on the conversation when it
+    did. It does not prove that the process which started the turn stopped --
+    that process may be alive and simply past its lease -- and it does not
+    prove that nothing is running the conversation, because the peek can only
+    report on claims that were unexpired and whose holder the pid probe failed
+    to write off, at the instant it looked.
+
+    Asserting the old sentence's absence would not be enough on its own: a
+    rewrite could drop it and assert something equally unproven. The positive
+    claim is pinned too.
+    """
+    note = server._auto_continue_note("rerun the migration")
+
+    assert "the app or its backend process stopped" not in note
+    assert "no other process is running this conversation" not in note
+    assert "no completion was ever recorded for it" in note
+    assert (
+        "this process claimed that turn's record with no live turn held "
+        "on the conversation" in note
+    )
+    assert "rerun the migration" in note
+
+
+def test_both_recovery_note_matchers_still_match():
+    """Two consumers match this note by prefix; neither may be broken."""
+    from gateway.run import _is_auto_continue_noise
+
+    note = server._auto_continue_note("rerun the migration")
+
+    assert note.startswith(server._AUTO_CONTINUE_NOTE_PREFIX)
+    assert server._legacy_display_kind("user", note) == "auto_continue"
+    assert _is_auto_continue_noise(note) is True
+
+
+# ── User-initiated admission: dormant until the engine takes a holder ──
+#
+# The arm is entered on caller class, not on how the turn renders: the
+# ``user_initiated`` keyword is set at the ``prompt.submit`` handler and
+# nowhere else, so these tests set it the way that handler does. Everything
+# the gateway synthesizes for itself leaves it off and is covered below.
+
+
+def _agent(run, **extra):
+    return types.SimpleNamespace(
+        session_id="session-key",
+        run_conversation=run,
+        clear_interrupt=lambda: None,
+        **extra,
+    )
+
+
+def test_the_rpc_handler_is_the_only_user_initiated_dispatch():
+    """The flag's whole value is that exactly one call site sets it.
+
+    Read the source rather than the behavior: an internal dispatch that set it
+    would hand a machine-synthesized turn a bounded wait and a "send it again"
+    refusal aimed at a user who is not there, and no unit test of that caller
+    would notice while the arm is dormant.
+    """
+    import ast
+    import pathlib
+
+    package = pathlib.Path(server.__file__).resolve().parent
+    dispatches: list[tuple[str, int, bool]] = []
+    for path in sorted(package.glob("*.py")):
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            func = node.func
+            name = func.attr if isinstance(func, ast.Attribute) else getattr(func, "id", "")
+            if name != "_run_prompt_submit":
+                continue
+            flagged = any(
+                kw.arg == "user_initiated" and getattr(kw.value, "value", None) is True
+                for kw in node.keywords
+            )
+            dispatches.append((path.name, node.lineno, flagged))
+
+    assert [name for name, _line, flagged in dispatches if flagged] == [
+        "methods_prompt.py"
+    ], dispatches
+    # And the machine-class majority is real, not an empty set that would make
+    # the assertion above vacuous.
+    assert len([1 for _n, _l, flagged in dispatches if not flagged]) >= 8, dispatches
+
+
+def test_a_stock_engine_turn_takes_no_lease(emits, turn_env, turn_db):
+    """An engine that cannot be handed a holder is left entirely alone.
+
+    Pre-acquiring under a holder the engine never learns about would make the
+    engine's own acquire block on this process's row for its full wait and
+    then reclaim it at TTL, which is worse than not pre-acquiring at all.
+    """
+    seen: list = []
+
+    def _run(message, conversation_history=None, stream_callback=None, **kwargs):
+        seen.append(kwargs)
+        assert turn_db.get_session_turn_lease_holder("session-key") is None
+        return {"final_response": "done"}
+
+    server._run_prompt_submit(
+        "rid",
+        "sid",
+        _session(agent=_agent(_run), running=True),
+        "do the thing",
+        user_initiated=True,
+    )
+
+    assert seen and "session_turn_lease_holder" not in seen[0]
+    assert turn_db.get_session_turn_lease_holder("session-key") is None
+
+
+def test_a_holder_aware_engine_is_handed_a_preacquired_lease(
+    emits, turn_env, turn_db
+):
+    seen: list = []
+
+    def _run(
+        message,
+        conversation_history=None,
+        stream_callback=None,
+        session_turn_lease_holder=None,
+        session_turn_lease_ttl_seconds=None,
+        **kwargs,
+    ):
+        seen.append(session_turn_lease_holder)
+        assert (
+            turn_db.get_session_turn_lease_holder("session-key")
+            == session_turn_lease_holder
+        )
+        return {"final_response": "done"}
+
+    server._run_prompt_submit(
+        "rid",
+        "sid",
+        _session(agent=_agent(_run), running=True),
+        "do the thing",
+        user_initiated=True,
+    )
+
+    assert seen and seen[0]
+    # Released with the turn, so the next process in is not made to wait.
+    assert turn_db.get_session_turn_lease_holder("session-key") is None
+
+
+def test_a_busy_conversation_refuses_the_turn_without_starting_the_engine(
+    emits, turn_env, turn_db, monkeypatch
+):
+    """The bounded wait ends in a visible refusal, not a silent drop.
+
+    The user is watching, so the honest answer is that the message was not
+    sent and can be sent again. The interrupted-turn record belongs to the
+    process that is running, and the refusal does not touch it.
+    """
+    monkeypatch.setattr(server, "_TURN_LEASE_WAIT_SECONDS", 0.15)
+    monkeypatch.setattr(server, "_TURN_LEASE_WAIT_NOTICE_SECONDS", 0.0)
+    assert turn_db.try_acquire_session_turn_lease(
+        "session-key", _LIVE_HOLDER, ttl_seconds=300
+    )
+    _record(turn_db, "session-key", "the turn that is actually running")
+    started: list = []
+
+    def _run(
+        message,
+        conversation_history=None,
+        stream_callback=None,
+        session_turn_lease_holder=None,
+        **kwargs,
+    ):
+        started.append(message)
+        return {"final_response": "done"}
+
+    session = _session(agent=_agent(_run), running=True)
+    server._run_prompt_submit(
+        "rid", "sid", session, "do the thing", user_initiated=True
+    )
+
+    assert not started
+    completes = [p for event, _sid, p in emits if event == "message.complete"]
+    assert len(completes) == 1
+    assert completes[0]["status"] == "error"
+    assert completes[0]["recoverable"] is True
+    assert "again" in completes[0]["error"]
+    # A waiting notice reached the client rather than a silent stall.
+    assert any(event == "status.update" for event, _sid, _p in emits)
+    # The running process still owns its record.
+    survivor = _read(turn_db, "session-key")
+    assert survivor is not None
+    assert survivor["owner"] == _FOREIGN_OWNER
+    assert session["running"] is False
+
+
+def test_a_refused_turn_hands_off_anything_queued_behind_it(
+    emits, turn_env, turn_db, monkeypatch
+):
+    """A prompt sent during the wait was queued against this turn, which ended.
+
+    The normal path drains after its turn settles. A refusal settles a turn
+    too, and leaving the queue unattended would strand the message until some
+    later turn happened to run.
+    """
+    monkeypatch.setattr(server, "_TURN_LEASE_WAIT_SECONDS", 0.15)
+    drained: list = []
+    monkeypatch.setattr(
+        server,
+        "_drain_queued_prompt",
+        lambda rid, sid, session: drained.append(rid) or False,
+    )
+    assert turn_db.try_acquire_session_turn_lease(
+        "session-key", _LIVE_HOLDER, ttl_seconds=300
+    )
+
+    def _run(message, session_turn_lease_holder=None, **kwargs):
+        raise AssertionError("engine must not start")
+
+    server._run_prompt_submit(
+        "rid",
+        "sid",
+        _session(agent=_agent(_run), running=True),
+        "do the thing",
+        user_initiated=True,
+    )
+
+    assert drained == ["rid"]
+
+
+def test_a_refused_turn_restores_a_one_turn_model_override(
+    emits, turn_env, turn_db, monkeypatch
+):
+    """`/model --once` is scoped to a turn, and this turn never happened.
+
+    The override is popped off the session before admission runs and restored
+    only in the turn's `finally`. A refusal returns before that block, so
+    without an unwind here the next-turn-only model becomes the session's
+    model permanently.
+    """
+    monkeypatch.setattr(server, "_TURN_LEASE_WAIT_SECONDS", 0.15)
+    restored: list = []
+    monkeypatch.setattr(
+        server,
+        "_restore_agent_model_runtime",
+        lambda agent, snapshot: restored.append(snapshot),
+    )
+    reworked: list = []
+    monkeypatch.setattr(
+        server, "_restart_slash_worker", lambda sid, session: reworked.append("worker")
+    )
+    monkeypatch.setattr(
+        server, "_persist_live_session_runtime", lambda session: reworked.append("runtime")
+    )
+    monkeypatch.setattr(
+        server,
+        "_persist_live_session_system_prompt",
+        lambda session: reworked.append("prompt"),
+    )
+    assert turn_db.try_acquire_session_turn_lease(
+        "session-key", _LIVE_HOLDER, ttl_seconds=300
+    )
+    snapshot = {"model": "the model before /model --once"}
+
+    def _run(message, session_turn_lease_holder=None, **kwargs):
+        raise AssertionError("engine must not start")
+
+    session = _session(
+        agent=_agent(_run), running=True, one_turn_model_restore=snapshot
+    )
+    server._run_prompt_submit(
+        "rid", "sid", session, "do the thing", user_initiated=True
+    )
+
+    assert restored == [snapshot]
+    assert reworked == ["worker", "runtime", "prompt"]
+
+
+def test_a_refused_turn_gives_the_user_their_images_back(
+    emits, turn_env, turn_db, monkeypatch
+):
+    """The refusal says "send it again", so the attachments have to still be there.
+
+    The prologue claims `attached_images` off the session at submission time so
+    a later paste cannot be swallowed by this prompt. A refusal that kept that
+    claim would drop the images on the floor while telling the user to resend.
+    """
+    monkeypatch.setattr(server, "_TURN_LEASE_WAIT_SECONDS", 0.15)
+    assert turn_db.try_acquire_session_turn_lease(
+        "session-key", _LIVE_HOLDER, ttl_seconds=300
+    )
+
+    def _run(message, session_turn_lease_holder=None, **kwargs):
+        raise AssertionError("engine must not start")
+
+    session = _session(agent=_agent(_run), running=True)
+    session["attached_images"] = ["/tmp/one.png", "/tmp/two.png"]
+    server._run_prompt_submit(
+        "rid", "sid", session, "look at these", user_initiated=True
+    )
+
+    assert session["attached_images"] == ["/tmp/one.png", "/tmp/two.png"]
+
+
+def test_a_refused_turn_clears_the_auto_continue_latch(
+    emits, turn_env, turn_db, monkeypatch
+):
+    """`_auto_continue_scheduled` is a one-shot guard the turn end releases.
+
+    A refusal that left it set would silently disable crash recovery on this
+    in-memory session for as long as it lives.
+    """
+    monkeypatch.setattr(server, "_TURN_LEASE_WAIT_SECONDS", 0.15)
+    assert turn_db.try_acquire_session_turn_lease(
+        "session-key", _LIVE_HOLDER, ttl_seconds=300
+    )
+
+    def _run(message, session_turn_lease_holder=None, **kwargs):
+        raise AssertionError("engine must not start")
+
+    session = _session(agent=_agent(_run), running=True)
+    session["_auto_continue_scheduled"] = True
+    server._run_prompt_submit(
+        "rid", "sid", session, "do the thing", user_initiated=True
+    )
+
+    assert not session.get("_auto_continue_scheduled")
+
+
+def test_a_stopped_wait_refuses_without_burning_the_budget(
+    emits, turn_env, turn_db, monkeypatch
+):
+    """/stop during the wait ends it immediately."""
+    monkeypatch.setattr(server, "_TURN_LEASE_WAIT_SECONDS", 30.0)
+    assert turn_db.try_acquire_session_turn_lease(
+        "session-key", _LIVE_HOLDER, ttl_seconds=300
+    )
+    started: list = []
+
+    def _run(
+        message,
+        conversation_history=None,
+        stream_callback=None,
+        session_turn_lease_holder=None,
+        **kwargs,
+    ):
+        started.append(message)
+        return {"final_response": "done"}
+
+    session = _session(
+        agent=_agent(_run), running=True, _turn_cancel_requested=True
+    )
+    began = time.monotonic()
+    server._run_prompt_submit(
+        "rid", "sid", session, "do the thing", user_initiated=True
+    )
+
+    assert time.monotonic() - began < 10.0
+    assert not started
+    assert [p for event, _sid, p in emits if event == "message.complete"]
+
+
+def test_an_auto_continue_turn_does_not_pre_acquire(emits, turn_env, turn_db):
+    """Machine turns already made their admission decision by claiming.
+
+    A bounded wait with a busy notice is the user-turn answer; a machine turn
+    that finds the conversation busy abstains at schedule time instead, and
+    the engine's own acquire remains the backstop underneath it.
+    """
+    seen: list = []
+
+    def _run(
+        message,
+        conversation_history=None,
+        stream_callback=None,
+        session_turn_lease_holder=None,
+        **kwargs,
+    ):
+        seen.append(session_turn_lease_holder)
+        return {"final_response": "done"}
+
+    server._run_prompt_submit(
+        "rid",
+        "sid",
+        _session(agent=_agent(_run), running=True),
+        "note",
+        display_kind="auto_continue",
+    )
+
+    assert seen == [None]
+
+
+def test_a_machine_synthesized_turn_does_not_pre_acquire(emits, turn_env, turn_db):
+    """The default is machine class, so a new internal caller is safe by omission.
+
+    This is the shape the goal continuation, the loop wakeup tick and the
+    kanban notification batch all dispatch with: positional arguments only, no
+    `display_kind` of any kind. None of them has a person watching, so none of
+    them may inherit the bounded wait or the "send it again" refusal — even
+    against an engine that could take a holder, and even with the conversation
+    held by another process.
+    """
+    assert turn_db.try_acquire_session_turn_lease(
+        "session-key", _LIVE_HOLDER, ttl_seconds=300
+    )
+    seen: list = []
+
+    def _run(
+        message,
+        conversation_history=None,
+        stream_callback=None,
+        session_turn_lease_holder=None,
+        **kwargs,
+    ):
+        seen.append(session_turn_lease_holder)
+        return {"final_response": "done"}
+
+    began = time.monotonic()
+    session = _session(agent=_agent(_run), running=True)
+    server._run_prompt_submit("rid", "sid", session, "the goal judge says continue")
+
+    # No wait was served and no refusal was emitted: it ran straight through.
+    assert time.monotonic() - began < 10.0
+    assert seen == [None]
+    errors = [
+        p
+        for event, _sid, p in emits
+        if event == "message.complete" and p.get("status") == "error"
+    ]
+    assert not errors
+    # The other process still holds the conversation; the engine's own acquire
+    # is what serializes against it, exactly as it does today.
+    assert turn_db.get_session_turn_lease_holder("session-key") == _LIVE_HOLDER
+
+
+def test_the_display_kind_is_not_the_admission_discriminator(emits, turn_env, turn_db):
+    """A machine turn that carries its own `display_kind` is still machine class.
+
+    The async-delegation completion synth passes
+    `display_kind="async_delegation_complete"`, which is neither None nor
+    "auto_continue". Keying admission off that field would have put this turn
+    on the interactive arm.
+    """
+    assert turn_db.try_acquire_session_turn_lease(
+        "session-key", _LIVE_HOLDER, ttl_seconds=300
+    )
+    seen: list = []
+
+    def _run(
+        message,
+        conversation_history=None,
+        stream_callback=None,
+        session_turn_lease_holder=None,
+        **kwargs,
+    ):
+        seen.append(session_turn_lease_holder)
+        return {"final_response": "done"}
+
+    server._run_prompt_submit(
+        "rid",
+        "sid",
+        _session(agent=_agent(_run), running=True),
+        "delegation finished",
+        display_kind="async_delegation_complete",
+    )
+
+    assert seen == [None]
+
+
+def test_the_holder_probe_reads_the_engine_signature(turn_env, turn_db):
+    """The dormancy switch is the engine's own signature, nothing else."""
+
+    def _stock(message, conversation_history=None, **kwargs):
+        return {}
+
+    def _aware(message, conversation_history=None, session_turn_lease_holder=None, **kwargs):
+        return {}
+
+    assert "session_turn_lease_holder" not in inspect.signature(_stock).parameters
+    assert "session_turn_lease_holder" in inspect.signature(_aware).parameters
+    assert server._engine_takes_lease_holder(_agent(_stock)) is False
+    assert server._engine_takes_lease_holder(_agent(_aware)) is True

--- a/tests/tui_gateway/test_turn_admission.py
+++ b/tests/tui_gateway/test_turn_admission.py
@@ -5,8 +5,9 @@ conversation busy" is a cross-process question and the answer lives in
 ``state.db``. Admission polarity is set by who initiated the turn:
 
 * machine-initiated (the auto-continue of a crash-interrupted turn) is
-  fail-closed. It peeks at the conversation's turn lease, and it consumes the
-  ``interrupted_turns`` row with a compare-and-swap that exactly one process
+  fail-closed. It peeks at the conversation's turn lease before it does
+  anything at all to the ``interrupted_turns`` row -- continue it or retire it
+  -- and it consumes the row with a compare-and-swap that exactly one process
   can win. Anything unproven resolves to abstaining, which defers the recovery
   to the next resume rather than losing it: the record stays where it was.
 * user-initiated is fail-open. It waits a bounded time with a visible notice
@@ -170,6 +171,124 @@ def test_a_live_holder_defers_the_continuation(emits, schedule_env, turn_db):
     assert survivor is not None
     assert survivor["attempts"] == 0
     assert survivor["owner"] == _FOREIGN_OWNER
+
+
+def test_a_live_holder_defers_a_stale_record_too(
+    emits, schedule_env, turn_db, monkeypatch
+):
+    """The lease vetoes the policy retirements, not only the claim.
+
+    Freshness is a number in this process's config file, and the record it
+    would be applied to here belongs to a turn that is provably still running.
+    A process configured with a shorter window than the one running the turn
+    would otherwise force-delete a live turn's record -- the same deletion the
+    owner check exists to prevent, reached by a different route. The record is
+    left where it is; when the lease lapses the next resume applies the window
+    to it.
+    """
+    _record(turn_db, "session-key", "the turn that is actually running")
+    assert turn_db.try_acquire_session_turn_lease(
+        "session-key", _LIVE_HOLDER, ttl_seconds=300
+    )
+    # Server-side clock only: the lease row's expiry is read through
+    # hermes_state's own time, so the record goes stale while the lease stays
+    # live, which is the whole point of the case.
+    monkeypatch.setattr(
+        server, "time", types.SimpleNamespace(time=lambda: time.time() + 3600)
+    )
+
+    result = server._maybe_schedule_auto_continue("sid", _session(), "session-key")
+
+    assert result is None
+    assert not schedule_env
+    survivor = _read(turn_db, "session-key")
+    assert survivor is not None
+    assert survivor["attempts"] == 0
+    assert survivor["owner"] == _FOREIGN_OWNER
+
+
+def test_a_live_holder_defers_a_disabled_process_too(
+    emits, schedule_env, turn_db, monkeypatch
+):
+    """Turning auto-continue off does not license deleting a running turn's row.
+
+    The record here is this process's OWN, which is what makes the case
+    discriminating: the disabled arm's clear is owner-checked, so it would
+    land. It does not, because a lease is live on the conversation and a turn
+    that is running now needs its record whatever this process's config says
+    about continuing turns later.
+    """
+    session = _session()
+    server._record_interrupted_turn(session, "session-key", "own turn, still running")
+    assert _read(turn_db, "session-key") is not None
+    assert turn_db.try_acquire_session_turn_lease(
+        "session-key", _LIVE_HOLDER, ttl_seconds=300
+    )
+    monkeypatch.setattr(
+        server,
+        "_load_cfg",
+        lambda: {"desktop": {"auto_continue": {"enabled": False}}},
+    )
+
+    result = server._maybe_schedule_auto_continue("sid", session, "session-key")
+
+    assert result is None
+    assert not schedule_env
+    survivor = _read(turn_db, "session-key")
+    assert survivor is not None
+    assert survivor["prompt"] == "own turn, still running"
+
+
+def test_a_live_holder_defers_an_exhausted_record_too(
+    emits, schedule_env, turn_db
+):
+    """The third retirement arm, and the one that reads most like a fact.
+
+    An attempt count at the ceiling looks like a property of the record rather
+    than of the reader, but the ceiling it is compared against is this
+    process's config, and the count is only evidence that earlier continuations
+    were started. Neither says the turn running right now has stopped. The row
+    a live lease covers is that turn's own record, so deleting it here does not
+    stop a loop, it removes the trace the turn would crash into: if the turn
+    then dies, no record remains and nothing recovers it at all. Deferring
+    keeps the ceiling intact for the resume that follows the lease.
+    """
+    _record(turn_db, "session-key", "the turn that is actually running", attempts=2)
+    assert turn_db.try_acquire_session_turn_lease(
+        "session-key", _LIVE_HOLDER, ttl_seconds=300
+    )
+
+    result = server._maybe_schedule_auto_continue("sid", _session(), "session-key")
+
+    assert result is None
+    assert not schedule_env
+    survivor = _read(turn_db, "session-key")
+    assert survivor is not None
+    assert survivor["attempts"] == 2
+    assert survivor["owner"] == _FOREIGN_OWNER
+
+
+def test_no_holder_leaves_the_policy_retirements_intact(
+    schedule_env, turn_db, monkeypatch
+):
+    """The lease is a veto, not an exemption.
+
+    The companion to the two above, stated here rather than left implicit in
+    the freshness tests next door: with nothing holding the conversation, a
+    stale record is still collected. Otherwise the peek would have turned the
+    windows off.
+    """
+    _record(turn_db, "session-key", "old prompt")
+    assert turn_db.get_session_turn_lease_holder("session-key") is None
+    monkeypatch.setattr(
+        server, "time", types.SimpleNamespace(time=lambda: time.time() + 3600)
+    )
+
+    result = server._maybe_schedule_auto_continue("sid", _session(), "session-key")
+
+    assert result is None
+    assert not schedule_env
+    assert _read(turn_db, "session-key") is None
 
 
 def test_a_dead_holders_lease_does_not_block_the_continuation(

--- a/tui_gateway/methods_prompt.py
+++ b/tui_gateway/methods_prompt.py
@@ -695,7 +695,11 @@ def _(rid, params: dict) -> dict:
                     },
                 )
                 return
-        _run_prompt_submit(rid, sid, session, text)
+        # The one caller class that is a person waiting on a screen. It is the
+        # only dispatch allowed to wait on another process's turn and then
+        # refuse out loud; every internal caller of _run_prompt_submit leaves
+        # this off and is machine-class by default.
+        _run_prompt_submit(rid, sid, session, text, user_initiated=True)
 
     run_thread = threading.Thread(target=run_after_agent_ready, daemon=True)
     # Keep a handle so session.interrupt can tell a live turn from a stuck

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -39,9 +39,9 @@ from agent.skill_commands import describe_skill_invocation
 from agent.conversation_loop import INTERRUPT_WAITING_FOR_MODEL_PREFIX
 from tui_gateway import git_probe
 from tui_gateway.turn_marker import (
-    clear_turn_marker,
-    read_turn_marker,
-    record_turn_start,
+    read_turn_markers,
+    retire_sidecar,
+    sidecar_exists,
 )
 from tui_gateway.transport import (
     StdioTransport,
@@ -7602,20 +7602,138 @@ def _session_home(session: dict) -> Path:
     return Path(profile_home) if profile_home else Path(_hermes_home)
 
 
+def _turn_record_owner() -> str:
+    """This process's stamp on interrupted-turn records.
+
+    Same shape as the durable turn lease's holder (``run_agent.py`` mints
+    ``pid=<pid>:turn=<id>:platform=<platform>``) without the per-turn nonce: a
+    record outlives the turn that wrote it, and every turn in this process is
+    equally entitled to retire it. Computed per call rather than cached so a
+    forked child stamps its own pid.
+    """
+    return f"pid={os.getpid()}:platform=tui"
+
+
+def _record_interrupted_turn(
+    session: dict, key: str, prompt: str, *, attempts: int = 0
+) -> None:
+    """Record a turn that is about to run, stamped with this process."""
+    if not key or not isinstance(prompt, str) or not prompt.strip():
+        return
+    try:
+        with _session_db(session) as db:
+            if db is None:
+                return
+            db.record_interrupted_turn(
+                key, prompt, attempts=attempts, owner=_turn_record_owner()
+            )
+    except Exception:
+        logger.debug("failed to record interrupted turn for %s", key, exc_info=True)
+
+
+def _read_interrupted_turn(session: dict, key: str) -> dict | None:
+    """The record left by a turn on ``key`` that never concluded, or None."""
+    if not key:
+        return None
+    try:
+        with _session_db(session) as db:
+            if db is None:
+                return None
+            return db.read_interrupted_turn(key)
+    except Exception:
+        logger.debug("failed to read interrupted turn for %s", key, exc_info=True)
+        return None
+
+
+def _clear_interrupted_turn(session: dict, *keys: str, force: bool = False) -> None:
+    """Retire records this process owns; ``force`` retires regardless of owner."""
+    wanted = list(dict.fromkeys(key for key in keys if key))
+    if not wanted:
+        return
+    owner = _turn_record_owner()
+    try:
+        with _session_db(session) as db:
+            if db is None:
+                return
+            for key in wanted:
+                db.clear_interrupted_turn(key, owner=owner, force=force)
+    except Exception:
+        logger.debug("failed to clear interrupted turn", exc_info=True)
+
+
+_TURN_MARKER_MIGRATION_LOCK = threading.Lock()
+_TURN_MARKER_MIGRATION_WARNED: set[str] = set()
+
+
+def _migrate_turn_markers(session: dict) -> None:
+    """Import this home's legacy interrupted-turn sidecar, once, then rename it.
+
+    Lazy and per-HERMES_HOME rather than per-process: ``_session_home`` is
+    profile-aware, so one gateway can be serving two homes with a sidecar
+    each. The rename is the one-shot flag — a failure leaves the file in place
+    and the next resume retries; only the warning is deduplicated. Once a home
+    has no sidecar this costs one stat and takes no lock.
+
+    Legacy entries carry no owner, so they import as ``owner IS NULL`` and any
+    process may retire them, which is the same freedom the file gave.
+    """
+    home = _session_home(session)
+    if not sidecar_exists(home):
+        return
+    with _TURN_MARKER_MIGRATION_LOCK:
+        # Re-check: a concurrent resume on this home may have just finished.
+        if not sidecar_exists(home):
+            return
+        home_key = os.path.normcase(os.path.abspath(str(home)))
+        entries = read_turn_markers(home)
+        try:
+            with _session_db(session) as db:
+                if db is None:
+                    return
+                # Newest first: two sidecar keys can be segments of one
+                # compression lineage and therefore resolve to a single row,
+                # and the newest record is the one a resume should see.
+                imported = db.import_interrupted_turns(
+                    sorted(
+                        entries.items(),
+                        key=lambda item: item[1]["started_at"],
+                        reverse=True,
+                    )
+                )
+            retire_sidecar(home)
+        except Exception:
+            if home_key not in _TURN_MARKER_MIGRATION_WARNED:
+                _TURN_MARKER_MIGRATION_WARNED.add(home_key)
+                logger.warning(
+                    "could not import the legacy interrupted-turn sidecar; "
+                    "leaving it in place to retry on the next resume",
+                    exc_info=True,
+                )
+            return
+        _TURN_MARKER_MIGRATION_WARNED.discard(home_key)
+        if imported:
+            logger.info(
+                "imported %d legacy interrupted-turn record(s) into state.db",
+                imported,
+            )
+
+
 def _retire_turn_marker(session: dict, *keys: str) -> None:
-    """Drop the crash marker for a turn whose outcome is about to reach the client.
+    """Drop the crash record for a turn whose outcome is about to reach the client.
 
     Called immediately before the terminal frame rather than at the end of the
     turn thread: post-turn work (titles, memory sync, goal hooks) runs for a
     second or more after the client has its answer, and quitting inside that
-    window would leave a marker that looks like a crash — re-running a finished
+    window would leave a record that looks like a crash — re-running a finished
     turn on the next launch. Extra ``keys`` cover a session_key that
     compression rotated mid-turn.
+
+    Owner-checked: this retires the records this process wrote (and legacy
+    records that carry no owner). A turn running in another process keeps its
+    record even when this one decides the turn is over, because only the
+    process that ran the turn can know that it ended.
     """
-    home = _session_home(session)
-    for key in dict.fromkeys((*keys, str(session.get("session_key") or ""))):
-        if key:
-            clear_turn_marker(home, key)
+    _clear_interrupted_turn(session, *keys, str(session.get("session_key") or ""))
 
 
 def _auto_continue_note(prompt: str) -> str:
@@ -7642,8 +7760,8 @@ def _maybe_schedule_auto_continue(sid: str, session: dict, session_key: str) -> 
     same _run_prompt_submit machinery as every other synthesized turn — so
     the client that just resumed streams it live.
     """
-    home = _session_home(session)
-    marker = read_turn_marker(home, session_key)
+    _migrate_turn_markers(session)
+    marker = _read_interrupted_turn(session, session_key)
     if marker is None:
         return None
     enabled, freshness_secs, max_attempts = _auto_continue_config()
@@ -7651,7 +7769,9 @@ def _maybe_schedule_auto_continue(sid: str, session: dict, session_key: str) -> 
     if not enabled or age > freshness_secs or marker["attempts"] >= max_attempts:
         # Stale, disabled, or crash-looping: stop trying. The journal/partial
         # transcript still shows what happened; a manual message continues it.
-        clear_turn_marker(home, session_key)
+        # Retired regardless of owner — the record is past a window every
+        # process reads the same way, so it is actionable by none of them.
+        _clear_interrupted_turn(session, session_key, force=True)
         return None
     if session.get("_auto_continue_scheduled"):
         return None
@@ -10276,18 +10396,19 @@ def _run_prompt_submit(
         # True once a failed turn's snapshot was retained for resume replay —
         # tells the finally below to skip the normal inflight clear.
         turn_error_retained = False
-        # Durable crash marker: written before the turn runs, retired the
+        # Durable crash record: written before the turn runs, retired the
         # moment its outcome reaches the client (see _retire_turn_marker).
         # Any concluded turn — success, handled error, interrupt — retires
-        # it, so a marker that survives means the process died mid-turn;
+        # it, so a record that survives means the process died mid-turn;
         # session.resume auto-continues from it. Compression can rotate
         # session_key mid-turn, so remember the key we wrote under.
-        marker_home = _session_home(session)
         marker_key = str(session.get("session_key") or "")
         marker_attempt = int(session.pop("_auto_continue_attempt", 0) or 0)
         marker_text = session.pop("_auto_continue_prompt", None) or text
         if isinstance(marker_text, str) and marker_text.strip():
-            record_turn_start(marker_home, marker_key, marker_text, attempts=marker_attempt)
+            _record_interrupted_turn(
+                session, marker_key, marker_text, attempts=marker_attempt
+            )
         try:
             from tools.approval import (
                 reset_current_session_key,

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -7939,6 +7939,23 @@ def _maybe_schedule_auto_continue(sid: str, session: dict, session_key: str) -> 
     marker = _read_interrupted_turn(session, session_key)
     if marker is None:
         return None
+    # The lease is read before any policy is applied to the record, because a
+    # live lease answers a question none of the policies can: the record is
+    # evidence a turn started, not that it stopped, and a live lease says it is
+    # still running in some process. That makes the record that process's
+    # business until its lease lapses, and it outranks every reason this
+    # process has for retiring it. The freshness window and the attempt ceiling
+    # are read from this process's config, so two processes sharing a
+    # HERMES_HOME can disagree about them — and a turn that is provably alive
+    # is not stale to the process running it, whatever this one's numbers say.
+    # Nothing is cleared here: when the lease lapses, the next resume reads the
+    # record again and applies policy to it then.
+    if _turn_is_held_elsewhere(session, session_key):
+        logger.debug(
+            "auto-continue stood down for %s: the conversation's turn lease is held",
+            session_key,
+        )
+        return None
     enabled, freshness_secs, max_attempts = _auto_continue_config()
     age = time.time() - marker["started_at"]
     if age > freshness_secs or marker["attempts"] >= max_attempts:
@@ -7959,27 +7976,20 @@ def _maybe_schedule_auto_continue(sid: str, session: dict, session_key: str) -> 
     # Admission. Nobody typed this turn, so it is fail-closed: it runs only on
     # positive proof that this process may run it, and every unproven case
     # stands down silently. Two hermes serve processes can share one
-    # HERMES_HOME, so both halves are cross-process questions.
+    # HERMES_HOME, so this is a cross-process question, as the lease peek above
+    # already was.
     #
-    # First the lease, which answers "is the turn still running": the record
-    # is evidence a turn started, not that it stopped. Then the claim, which
-    # is the guarantee — a compare-and-swap on the whole record exactly one
-    # process can win, so two resumes racing the same orphan produce one
-    # continuation. The engine's own acquire still serializes underneath, but
-    # serializing a duplicate turn only makes it run second; this stops it
-    # being queued.
+    # The peek answered "is the turn still running". The claim is the
+    # guarantee — a compare-and-swap on the whole record exactly one process
+    # can win, so two resumes racing the same orphan produce one continuation.
+    # The engine's own acquire still serializes underneath, but serializing a
+    # duplicate turn only makes it run second; this stops it being queued.
     #
     # The token is `marker`, the record read at the top of this function, and
     # it is handed back whole. The counter alone would not do: every
     # user-initiated turn re-records with attempts=0 from a prologue that runs
     # long before the engine takes the lease, so a counter value read off an
     # orphan recurs under a live turn that the peek cannot yet see.
-    if _turn_is_held_elsewhere(session, session_key):
-        logger.debug(
-            "auto-continue stood down for %s: the conversation's turn lease is held",
-            session_key,
-        )
-        return None
     claimed = _claim_interrupted_turn(session, session_key, expected=marker)
     if claimed is None:
         logger.debug("auto-continue stood down for %s: record not claimed", session_key)

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -7602,6 +7602,23 @@ def _session_home(session: dict) -> Path:
     return Path(profile_home) if profile_home else Path(_hermes_home)
 
 
+# Cross-process turn lease, for the user-initiated path below. The TTL matches
+# the engine's (run_agent.py), because the lease this process takes is the one
+# the engine then runs the turn under. The wait is deliberately far shorter
+# than the engine's 1800s: a user is watching this one, and a wait that long
+# is indistinguishable from a hang. Fixed for now rather than configurable —
+# the path they govern is dormant (see _preacquire_turn_lease), so there is
+# nothing yet for an operator to tune. Config keys belong with the change that
+# turns the path on.
+_TURN_LEASE_TTL_SECONDS = 300.0
+_TURN_LEASE_WAIT_SECONDS = 120.0
+_TURN_LEASE_WAIT_NOTICE_SECONDS = 15.0
+_TURN_LEASE_BUSY_MESSAGE = (
+    "Another Hermes process is running this session. Your message was not "
+    "sent - wait for that turn to finish, then send it again."
+)
+
+
 def _turn_record_owner() -> str:
     """This process's stamp on interrupted-turn records.
 
@@ -7643,6 +7660,155 @@ def _read_interrupted_turn(session: dict, key: str) -> dict | None:
     except Exception:
         logger.debug("failed to read interrupted turn for %s", key, exc_info=True)
         return None
+
+
+def _claim_interrupted_turn(session: dict, key: str, *, expected: dict) -> dict | None:
+    """Take the record for re-running, or None when this process must stand down.
+
+    The claim is the admission decision for a machine-initiated turn, and it
+    is fail-closed: anything that is not a won compare-and-swap on the record
+    this process just read — a competing claimant, a record some process
+    rewrote between the read and the claim, a record already retired, a
+    storage failure — resolves to None. Standing down leaves the record for
+    the next resume, so nothing is lost by being wrong in this direction.
+
+    ``expected`` is the record :func:`_read_interrupted_turn` returned, handed
+    back whole: it is the version token, and every field of it has to still be
+    on the row for the claim to land.
+    """
+    if not key or not isinstance(expected, dict):
+        return None
+    try:
+        with _session_db(session) as db:
+            if db is None:
+                return None
+            return db.claim_interrupted_turn(key, expected=expected)
+    except Exception:
+        logger.debug("failed to claim interrupted turn for %s", key, exc_info=True)
+        return None
+
+
+def _turn_is_held_elsewhere(session: dict, key: str) -> bool:
+    """True when a live turn lease covers this conversation, or we cannot tell.
+
+    The interrupted-turn record proves a turn started, not that it stopped. A
+    live lease says the turn is still running in some process, which makes the
+    record that process's business until its lease lapses.
+
+    Every way of not getting an answer resolves to True. False is the licence
+    to act on the record, and no unreadable database is evidence that a turn
+    stopped.
+    """
+    if not key:
+        return False
+    try:
+        with _session_db(session) as db:
+            if db is None:
+                # No database to ask. Unreachable on the shared-DB path (the
+                # record read above came from one), but a profile handle can
+                # fail to open on its own, and defer is the safe answer.
+                return True
+            return bool(db.get_session_turn_lease_holder(key))
+    except Exception:
+        # Cannot read the lease means cannot rule out a running turn.
+        logger.debug("turn lease peek failed for %s", key, exc_info=True)
+        return True
+
+
+def _engine_takes_lease_holder(agent) -> bool:
+    """True when this engine can run a turn under a lease its caller took.
+
+    The same additive-parameter probe the turn-start display typing uses. An
+    engine without the parameter acquires its own lease under its own holder
+    string, so pre-acquiring here would leave it blocking on this process's
+    own row until it could reclaim it at TTL. The gate is what keeps that
+    from happening while the engine side of this is still on its way.
+    """
+    run_conversation = getattr(agent, "run_conversation", None)
+    if run_conversation is None:
+        return False
+    try:
+        return "session_turn_lease_holder" in inspect.signature(
+            run_conversation
+        ).parameters
+    except (TypeError, ValueError):
+        return False
+
+
+def _preacquire_turn_lease(sid: str, session: dict, key: str) -> tuple[bool, str | None]:
+    """Admission for a user-initiated turn: (admitted, holder to hand the engine).
+
+    Fail-open, because a person is waiting on this one: wait a bounded time
+    for whatever is running, say so while waiting, and refuse in the open if
+    the wait runs out. ``(True, None)`` means there was nothing to do — no
+    conversation key, no database, or an engine that cannot take a holder —
+    and the turn proceeds exactly as it does today.
+
+    A refusal is ``(False, None)``: the caller emits the terminal frame and
+    starts nothing. It leaves the interrupted-turn record alone, because that
+    record belongs to whichever process is running the turn.
+    """
+    if not key:
+        return True, None
+    agent = session.get("agent")
+    if agent is None or not _engine_takes_lease_holder(agent):
+        return True, None
+    holder = f"pid={os.getpid()}:turn={uuid.uuid4().hex[:12]}:platform=tui"
+
+    def _on_wait(elapsed: float) -> None:
+        text = (
+            "Another Hermes process is using this session; waiting for it to "
+            "finish before starting your turn…"
+            if elapsed < 1.0
+            else f"Still waiting for the other Hermes process on this session ({int(elapsed)}s)…"
+        )
+        _emit("status.update", sid, {"kind": "process", "text": text})
+
+    # Tracked separately from `admitted` because the acquire can succeed and
+    # the block can still raise on the way out (closing a profile handle, say).
+    # An acquired lease that nobody returns holds the conversation for the full
+    # TTL, and the caller is about to refuse the turn rather than run it.
+    acquired = False
+    try:
+        with _session_db(session) as db:
+            if db is None:
+                return True, None
+            admitted = db.acquire_session_turn_lease(
+                key,
+                holder,
+                ttl_seconds=_TURN_LEASE_TTL_SECONDS,
+                wait_seconds=_TURN_LEASE_WAIT_SECONDS,
+                on_wait=_on_wait,
+                wait_notice_interval_seconds=_TURN_LEASE_WAIT_NOTICE_SECONDS,
+                should_abort=lambda: bool(session.get("_turn_cancel_requested")),
+            )
+            acquired = bool(admitted)
+    except Exception:
+        # Storage is the only thing that can answer this, and a turn that
+        # cannot be serialized against another process is a turn that should
+        # not start. Refusing says so; it does not hang.
+        logger.warning("turn lease acquisition failed for %s", key, exc_info=True)
+        if acquired:
+            _release_turn_lease(session, key, holder)
+        return False, None
+    if not admitted:
+        return False, None
+    return True, holder
+
+
+def _release_turn_lease(session: dict, key: str, holder: str | None) -> None:
+    """Release a lease this process took; owner-scoped and idempotent."""
+    if not key or not holder:
+        return
+    try:
+        with _session_db(session) as db:
+            if db is None:
+                return
+            db.release_session_turn_lease(key, holder)
+    except Exception:
+        # The lease expires on its own; a failed release costs the next turn
+        # a wait, never correctness.
+        logger.debug("failed to release turn lease for %s", key, exc_info=True)
 
 
 def _clear_interrupted_turn(session: dict, *keys: str, force: bool = False) -> None:
@@ -7741,11 +7907,20 @@ def _auto_continue_note(prompt: str) -> str:
     # tooling recognizes both. The original prompt is embedded because a hard
     # crash persists nothing of the interrupted turn to the session DB — this
     # note is the only copy the model will see.
+    #
+    # The note asserts only what the claim proved, which is narrower than it
+    # sounds: this process took the record of the previous turn, and at the
+    # moment it admitted itself no live turn-lease claim stood on the
+    # conversation. It does NOT prove the process that started the turn is
+    # gone — that process may be alive and merely past its lease — which is
+    # why the old wording ("the app or its backend process stopped") had to
+    # go. Anything stronger here is a guess the model would act on.
     return (
-        f"{_AUTO_CONTINUE_NOTE_PREFIX} — the app or its backend process "
-        "stopped before the turn could finish. Some of the work may already "
-        "be complete; check the current state before redoing anything, then "
-        "finish the task. The interrupted request was:]\n\n"
+        f"{_AUTO_CONTINUE_NOTE_PREFIX} — no completion was ever recorded for "
+        "it, and this process claimed that turn's record with no live turn "
+        "held on the conversation. Some of the work may already be complete; "
+        "check the current state before redoing anything, then finish the "
+        "task. The interrupted request was:]\n\n"
         f"{prompt}"
     )
 
@@ -7781,8 +7956,40 @@ def _maybe_schedule_auto_continue(sid: str, session: dict, session_key: str) -> 
         return None
     if session.get("_auto_continue_scheduled"):
         return None
+    # Admission. Nobody typed this turn, so it is fail-closed: it runs only on
+    # positive proof that this process may run it, and every unproven case
+    # stands down silently. Two hermes serve processes can share one
+    # HERMES_HOME, so both halves are cross-process questions.
+    #
+    # First the lease, which answers "is the turn still running": the record
+    # is evidence a turn started, not that it stopped. Then the claim, which
+    # is the guarantee — a compare-and-swap on the whole record exactly one
+    # process can win, so two resumes racing the same orphan produce one
+    # continuation. The engine's own acquire still serializes underneath, but
+    # serializing a duplicate turn only makes it run second; this stops it
+    # being queued.
+    #
+    # The token is `marker`, the record read at the top of this function, and
+    # it is handed back whole. The counter alone would not do: every
+    # user-initiated turn re-records with attempts=0 from a prologue that runs
+    # long before the engine takes the lease, so a counter value read off an
+    # orphan recurs under a live turn that the peek cannot yet see.
+    if _turn_is_held_elsewhere(session, session_key):
+        logger.debug(
+            "auto-continue stood down for %s: the conversation's turn lease is held",
+            session_key,
+        )
+        return None
+    claimed = _claim_interrupted_turn(session, session_key, expected=marker)
+    if claimed is None:
+        logger.debug("auto-continue stood down for %s: record not claimed", session_key)
+        return None
     session["_auto_continue_scheduled"] = True
-    attempt = marker["attempts"] + 1
+    # The bumped counter is the one thing the claim changed. Everything else
+    # comes from `marker`, which the compare-and-swap has just proved is still
+    # what is on the row — so the age this function logged above and the
+    # timestamp it reports below are one read, not two.
+    attempt = claimed["attempts"]
     text = _auto_continue_note(marker["prompt"])
 
     def kickoff() -> None:
@@ -8241,7 +8448,9 @@ def _inflight_snapshot(session: dict) -> dict | None:
     return snapshot
 
 
-def _emit_terminal_turn_error(sid: str, session: dict, error: Any) -> None:
+def _emit_terminal_turn_error(
+    sid: str, session: dict, error: Any, *, retire_marker: bool = True
+) -> None:
     """Close a failed turn with a terminal ``message.complete`` frame.
 
     Emits the same ``status: "error"`` frame shape the returned-error path in
@@ -8249,6 +8458,11 @@ def _emit_terminal_turn_error(sid: str, session: dict, error: Any) -> None:
     uniform), and retains the failed turn via ``_fail_inflight_turn`` so a
     client that missed this frame (disconnect window) can recover it from
     ``session.resume``'s ``inflight`` payload.
+
+    ``retire_marker=False`` is for a turn that was refused before it ran: no
+    turn concluded here, so there is no crash record of ours to retire, and
+    the record that may be sitting there belongs to the turn running in the
+    other process.
     """
     with session["history_lock"]:
         _fail_inflight_turn(session, error)
@@ -8273,7 +8487,8 @@ def _emit_terminal_turn_error(sid: str, session: dict, error: Any) -> None:
         rendered = ""
     if rendered:
         payload["rendered"] = rendered
-    _retire_turn_marker(session)
+    if retire_marker:
+        _retire_turn_marker(session)
     _emit("message.complete", sid, payload)
 
 
@@ -10357,7 +10572,25 @@ def _run_prompt_submit(
     display_metadata: dict | None = None,
     image_paths: list[str] | None = None,
     queued_prompt_generation: int | None = None,
+    user_initiated: bool = False,
 ) -> None:
+    """Run one turn on this session's agent.
+
+    ``user_initiated`` is the caller class, and it is what the cross-process
+    admission below keys on: True means a person typed this and is watching
+    the screen, so the turn may wait and may refuse out loud. It is set at the
+    ``prompt.submit`` handler and nowhere else.
+
+    The default is False on purpose. This function is also the dispatch point
+    for every machine-synthesized turn in the gateway — auto-continue, goal
+    continuations, the loop wakeup tick, kanban and async-delegation
+    notification batches — and none of those has anyone to show a busy notice
+    to, so a new one added later must not inherit a bounded wait and a "send
+    it again" refusal by forgetting to opt out. ``display_kind`` cannot carry
+    this: it describes how the transcript renders a turn, several
+    machine-synthesized callers pass none at all, and the ones that do pass
+    values of their own.
+    """
     with session["history_lock"]:
         if (
             queued_prompt_generation is not None
@@ -10409,6 +10642,68 @@ def _run_prompt_submit(
         # session.resume auto-continues from it. Compression can rotate
         # session_key mid-turn, so remember the key we wrote under.
         marker_key = str(session.get("session_key") or "")
+        # Admission for a turn a person is waiting on, against the same
+        # cross-process lease the engine uses. Only a user-initiated turn takes
+        # this arm; a machine-synthesized one has nobody to show a busy notice
+        # to, and the auto-continue among them already made its decision by
+        # claiming or standing down at schedule time. Nothing happens on either
+        # path until the engine can be handed the holder this takes (see
+        # _preacquire_turn_lease).
+        lease_holder = None
+        if user_initiated:
+            admitted, lease_holder = _preacquire_turn_lease(sid, session, marker_key)
+            if not admitted:
+                # Refused before anything ran: no record written, no record
+                # retired, no engine started. The turn the user is waiting
+                # behind still owns the conversation and its own crash record.
+                #
+                # Everything the prologue above consumed has to go back,
+                # because this turn is not happening and the user is being
+                # told to send the message again. The `finally` below is the
+                # only other place these are unwound and this return never
+                # reaches it.
+                if one_turn_restore:
+                    # A `/model --once` override would otherwise become
+                    # permanent: the turn it was scoped to never ran.
+                    try:
+                        _restore_agent_model_runtime(agent, one_turn_restore)
+                        _restart_slash_worker(sid, session)
+                        _persist_live_session_runtime(session)
+                        _persist_live_session_system_prompt(session)
+                    except Exception:
+                        logger.debug(
+                            "TUI one-turn model restore failed", exc_info=True
+                        )
+                _emit_terminal_turn_error(
+                    sid, session, _TURN_LEASE_BUSY_MESSAGE, retire_marker=False
+                )
+                with session["history_lock"]:
+                    session["running"] = False
+                    session["last_active"] = time.time()
+                    if image_paths is None and images:
+                        # This call drained them off the session; a refusal
+                        # that kept them would lose the user's attachments
+                        # while telling them to resend. Same restore idiom as
+                        # the busy-submit path: ours first, then anything
+                        # attached while we were waiting.
+                        session["attached_images"] = images + list(
+                            session.get("attached_images", [])
+                        )
+                # Latching this would suppress every later auto-continue on
+                # this in-memory session; the finally below pops it for a turn
+                # that ran, so a refusal has to pop it too.
+                session.pop("_auto_continue_scheduled", None)
+                _emit_settled_session_info(sid, session, agent)
+                # A prompt sent while this one was waiting was queued against
+                # this turn, and this turn is over. Same hand-off the normal
+                # path makes below. That drained turn is dispatched internally
+                # rather than by the RPC handler, so it does not take this arm
+                # — it runs as it does today and the engine's own acquire
+                # serializes it, which is the fail-safe direction.
+                _drain_queued_prompt(rid, sid, session)
+                _current_runtime_session_record.reset(runtime_session_token)
+                reset_transport(transport_token)
+                return
         marker_attempt = int(session.pop("_auto_continue_attempt", 0) or 0)
         marker_text = session.pop("_auto_continue_prompt", None) or text
         if isinstance(marker_text, str) and marker_text.strip():
@@ -10657,6 +10952,16 @@ def _run_prompt_submit(
             if display_kind and "persist_user_display_kind" in _run_params:
                 run_kwargs["persist_user_display_kind"] = display_kind
                 run_kwargs["persist_user_display_metadata"] = display_metadata
+            if lease_holder and "session_turn_lease_holder" in _run_params:
+                # This process already holds the conversation and made the
+                # admission call. Hand the holder over so the engine arms its
+                # write fence with it instead of acquiring a second time under
+                # a different string, which would block on our own row.
+                run_kwargs["session_turn_lease_holder"] = lease_holder
+                if "session_turn_lease_ttl_seconds" in _run_params:
+                    run_kwargs["session_turn_lease_ttl_seconds"] = (
+                        _TURN_LEASE_TTL_SECONDS
+                    )
             # Auto-titling now fires inside the turn prologue (shared by every
             # surface). Hand the agent this session's live-rename hook so the
             # sidebar repaints the moment a title lands, rather than waiting
@@ -11140,6 +11445,9 @@ def _run_prompt_submit(
             # Backstop for turns that never reached a terminal frame (the
             # frame paths retire the marker as they emit).
             _retire_turn_marker(session, marker_key)
+            # Hand the conversation back. The engine does not release a lease
+            # it did not take, so this is the only release on that path.
+            _release_turn_lease(session, marker_key, lease_holder)
             session.pop("_auto_continue_scheduled", None)
             _emit_settled_session_info(sid, session, agent)
 

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -7766,12 +7766,18 @@ def _maybe_schedule_auto_continue(sid: str, session: dict, session_key: str) -> 
         return None
     enabled, freshness_secs, max_attempts = _auto_continue_config()
     age = time.time() - marker["started_at"]
-    if not enabled or age > freshness_secs or marker["attempts"] >= max_attempts:
-        # Stale, disabled, or crash-looping: stop trying. The journal/partial
-        # transcript still shows what happened; a manual message continues it.
-        # Retired regardless of owner — the record is past a window every
-        # process reads the same way, so it is actionable by none of them.
+    if age > freshness_secs or marker["attempts"] >= max_attempts:
+        # Stale or crash-looping: a policy retirement, so it is taken
+        # regardless of owner. The journal/partial transcript still shows what
+        # happened; a manual message continues it.
         _clear_interrupted_turn(session, session_key, force=True)
+        return None
+    if not enabled:
+        # Disabled is a local policy state, not a fact about the record:
+        # another process may run with auto-continue on, and this one may be
+        # re-enabled later. Retire only what this process owns (plus ownerless
+        # legacy imports) and leave a foreign owner's live record alone.
+        _clear_interrupted_turn(session, session_key)
         return None
     if session.get("_auto_continue_scheduled"):
         return None

--- a/tui_gateway/turn_marker.py
+++ b/tui_gateway/turn_marker.py
@@ -1,21 +1,22 @@
-"""Durable interrupted-turn markers for the desktop/TUI auto-continue path.
+"""Reader for the legacy interrupted-turn sidecar (migration only).
 
-A running turn's progress lives only in process memory (the agent flushes to
-SQLite at turn end, not mid-turn), so an app/backend/machine death mid-turn
-leaves no durable trace of the interrupted prompt. This sidecar is that
-trace: a marker is written when a turn starts running and cleared when the
-turn concludes — success, handled error, or interrupt all clear it, so only
-a process death leaves one behind. ``session.resume`` reads the marker to
-decide whether to auto-continue the interrupted turn (see
-``_maybe_schedule_auto_continue`` in ``tui_gateway/server.py``).
+Interrupted-turn records live in ``state.db``'s ``interrupted_turns`` table
+(see ``SessionDB.record_interrupted_turn``). Before that they lived in this
+JSON sidecar, one file per ``HERMES_HOME``, rewritten in full on every turn
+start. This module is what remains of it: a reader the gateway calls once per
+home to import surviving entries into the table, after which the file is
+renamed and never read again.
 
-Markers are stored per ``HERMES_HOME`` (callers pass the session's home so
-profile sessions keep their state in their own profile directory) and the
-file is bounded: writes prune entries older than ``_MAX_AGE_SECS`` and cap
-the total count, so an unlucky streak of crashes can't grow it unboundedly.
+Nothing writes the sidecar any more. The whole-file rewrite it used was
+synchronized only by a lock local to the writing process, so two processes
+sharing a home could each load the map, change one key, and store the result,
+silently dropping the other's record; and any process could delete any entry,
+including one belonging to a turn still running elsewhere. Both are structural
+properties of the file format, which is why the record moved to a table with
+per-row writes and an owner stamp.
 
-Every function is best-effort by design — marker bookkeeping must never
-break a turn — so I/O errors degrade to "no marker" instead of raising.
+Reads are best-effort: an unreadable or corrupt file degrades to "no entries"
+instead of raising, so a bad sidecar cannot block a resume.
 """
 
 from __future__ import annotations
@@ -23,9 +24,6 @@ from __future__ import annotations
 import json
 import logging
 import os
-import tempfile
-import threading
-import time
 from pathlib import Path
 from typing import Any
 
@@ -33,13 +31,7 @@ logger = logging.getLogger(__name__)
 
 _MARKER_DIR = "desktop"
 _MARKER_FILE = "interrupted_turns.json"
-_MAX_AGE_SECS = 24 * 3600
-_MAX_ENTRIES = 32
-# Enough to re-submit any realistic prompt; guards the sidecar against a
-# pathological multi-megabyte paste being journaled on every turn.
-_MAX_PROMPT_CHARS = 64_000
-
-_lock = threading.Lock()
+_MIGRATED_SUFFIX = ".migrated"
 
 
 def _marker_path(home: Path | str) -> Path:
@@ -53,99 +45,14 @@ def _load(path: Path) -> dict[str, dict]:
     except FileNotFoundError:
         return {}
     except Exception:
-        logger.debug("unreadable turn-marker file %s; starting fresh", path, exc_info=True)
+        logger.debug("unreadable turn-marker file %s; ignoring", path, exc_info=True)
         return {}
     if not isinstance(data, dict):
         return {}
     return {k: v for k, v in data.items() if isinstance(v, dict)}
 
 
-def _prune(entries: dict[str, dict], now: float) -> dict[str, dict]:
-    fresh = {
-        key: entry
-        for key, entry in entries.items()
-        if now - float(entry.get("started_at") or 0) <= _MAX_AGE_SECS
-    }
-    if len(fresh) <= _MAX_ENTRIES:
-        return fresh
-    newest = sorted(
-        fresh.items(),
-        key=lambda item: float(item[1].get("started_at") or 0),
-        reverse=True,
-    )[:_MAX_ENTRIES]
-    return dict(newest)
-
-
-def _store(path: Path, entries: dict[str, dict]) -> None:
-    if not entries:
-        path.unlink(missing_ok=True)
-        return
-    path.parent.mkdir(parents=True, exist_ok=True)
-    fd, tmp = tempfile.mkstemp(dir=path.parent, prefix=".turn-marker-")
-    try:
-        with os.fdopen(fd, "w", encoding="utf-8") as f:
-            json.dump(entries, f)
-        os.replace(tmp, path)
-    except Exception:
-        try:
-            os.unlink(tmp)
-        except OSError:
-            pass
-        raise
-
-
-def record_turn_start(
-    home: Path | str, session_key: str, prompt: str, *, attempts: int = 0
-) -> None:
-    """Persist the marker for a turn that is about to run.
-
-    ``attempts`` counts how many auto-continues led to this run: 0 for a
-    user-initiated turn, N for the Nth automatic re-run — the crash-loop
-    breaker reads it back on the next resume.
-    """
-    if not session_key or not prompt:
-        return
-    now = time.time()
-    entry = {
-        "attempts": max(0, int(attempts)),
-        "prompt": prompt[:_MAX_PROMPT_CHARS],
-        "started_at": now,
-    }
-    try:
-        with _lock:
-            path = _marker_path(home)
-            entries = _prune(_load(path), now)
-            entries[session_key] = entry
-            _store(path, entries)
-    except Exception:
-        logger.debug("failed to record turn marker for %s", session_key, exc_info=True)
-
-
-def clear_turn_marker(home: Path | str, session_key: str) -> None:
-    """Remove the marker once its turn concluded (any outcome the client saw)."""
-    if not session_key:
-        return
-    try:
-        with _lock:
-            path = _marker_path(home)
-            entries = _load(path)
-            if session_key not in entries:
-                return
-            del entries[session_key]
-            _store(path, entries)
-    except Exception:
-        logger.debug("failed to clear turn marker for %s", session_key, exc_info=True)
-
-
-def read_turn_marker(home: Path | str, session_key: str) -> dict[str, Any] | None:
-    """The marker left by a turn that never concluded, or None."""
-    if not session_key:
-        return None
-    try:
-        with _lock:
-            entry = _load(_marker_path(home)).get(session_key)
-    except Exception:
-        return None
+def _coerce_entry(entry: Any) -> dict[str, Any] | None:
     if not isinstance(entry, dict):
         return None
     prompt = str(entry.get("prompt") or "")
@@ -157,3 +64,40 @@ def read_turn_marker(home: Path | str, session_key: str) -> dict[str, Any] | Non
     except (TypeError, ValueError):
         return None
     return {"attempts": attempts, "prompt": prompt, "started_at": started_at}
+
+
+def sidecar_exists(home: Path | str) -> bool:
+    """Whether this home still has a sidecar left to import."""
+    try:
+        return _marker_path(home).is_file()
+    except Exception:
+        return False
+
+
+def retire_sidecar(home: Path | str) -> None:
+    """Rename the sidecar aside once its entries are in the table.
+
+    Raises on failure so the caller can leave the file where it is and retry
+    on the next resume; the rename is what makes the import one-shot.
+    """
+    path = _marker_path(home)
+    os.replace(path, path.with_name(path.name + _MIGRATED_SUFFIX))
+
+
+def read_turn_markers(home: Path | str) -> dict[str, dict[str, Any]]:
+    """Every usable entry in the legacy sidecar, keyed as the file keyed them.
+
+    Keys are the session key the turn was running under when it was recorded,
+    which is the compression segment rather than the lineage root the table is
+    keyed on — the importer resolves that.
+    """
+    try:
+        raw = _load(_marker_path(home))
+    except Exception:
+        return {}
+    entries = {}
+    for session_key, entry in raw.items():
+        coerced = _coerce_entry(entry)
+        if session_key and coerced is not None:
+            entries[str(session_key)] = coerced
+    return entries


### PR DESCRIPTION
## What does this PR do?

Stacked on #86786, which moves interrupted-turn records out of a JSON sidecar into `state.db` with an owner stamp. The diff opens with that PR's four commits, since a fork PR can only target a branch in this repository and a stacked one carries its parent; the delta asked for here is the last three. The interactive half depends on a second open PR, #86785, which teaches the engine to accept a turn lease its caller already took. That one has not merged, so the interactive arm ships dormant behind a signature probe and nothing on the user path changes on merge. Filed as a draft in deference to the open `needs-decision` on #67442: this implements the fail-closed machine-initiated posture that thread's caller-class split endorsed, and it moves to ready for review when that decision clears or a maintainer says to go ahead.

Two `hermes serve` processes sharing one `HERMES_HOME` can both decide to re-run the same interrupted turn, and today one of them is wrong.

`_maybe_schedule_auto_continue` (`tui_gateway/server.py:7635` at `2f094a264`) reads an interrupted-turn record and treats it as proof the turn stopped. It is not: the record says a turn started. Every gate there is local. Freshness and the attempt ceiling come from config, the dedupe is an in-memory flag on the session dict, and nothing reads `session_turn_leases`. So a second process resuming a conversation whose turn is still running in the first schedules a continuation, that continuation reaches the engine, the engine waits on the durable turn lease with `wait_seconds=1800.0` (`run_agent.py:8197`), and then runs the same prompt a second time. The merged lease serializes the duplicate turn. It does not prevent it.

This PR sets admission polarity by caller class, which is the rule proposed and endorsed on #67442.

Caller class is carried by construction rather than inferred. `_run_prompt_submit` takes a `user_initiated` keyword, and the `prompt.submit` handler in `tui_gateway/methods_prompt.py` is its only setter. Every turn the gateway synthesizes for itself leaves it off and is machine class by omission: the auto-continue kickoff, the goal continuation, the async-delegation completion synth, the kanban notification batch, the loop wakeup tick, the notification poller and the queued-prompt drain. `display_kind` could not carry this: it describes how a turn renders in the transcript, most of those callers pass none at all, and the ones that do pass values of their own such as `async_delegation_complete`, so keying admission off it would put machine-synthesized turns on the interactive arm. The default is False, so an internal dispatch added later is fail-safe by omission rather than by remembering to opt out.

Machine-initiated turns fail closed, and the first question comes before any existing gate. Is a live process holding this conversation's turn lease? If so the scheduler returns and the record is untouched: not continued, not retired. That ordering is load-bearing, because the gates below it can delete the record. Freshness and the ceiling are read from this process's config file, and a second process on the same `HERMES_HOME` may be running the turn under a wider window, so a record stale by these numbers can belong to a turn that is demonstrably still running. #86786 closed the same hole on the disabled arm by making its clear owner-checked. The owner check cannot close it here, because the record a live lease protects can be one this process owns, and a resume landing while this process's own turn is mid-flight would clear it out from under itself. That is reachable without a second process at all: `_find_live_session_by_key` matches a live session on the agent's own `session_id`, which follows a compression rotation to the child segment, while the record and the lease key on the lineage root, so a resume naming the pre-rotation id misses the live session, takes the cold path, and lands in this scheduler on a conversation this very process is mid-turn on. So the lease answer outranks every policy retirement, not just the claim, and deferring costs nothing a later resume does not recover.

With nothing holding the conversation, the freshness, ceiling and dedupe gates run exactly as they did, and then the last question: can this process take the record? The claim is a compare-and-swap, so two processes reading the same orphaned record produce exactly one claimant. Only a won claim schedules anything; every other outcome, storage error included, stands down.

The claim's token is the record the caller read, handed back whole, and the update lands only while the row still carries every field of it. The attempt counter alone cannot serve as that token, which is worth ruling out because it is the obvious design. `record_interrupted_turn` is last-writer-wins and stamps `attempts=0` on every user-initiated turn, from `_run_prompt_submit`'s prologue, which runs long before the engine acquires the turn lease. A fresh record at `attempts=0` with no lease row yet is therefore an ordinary state for a turn starting right now, and indistinguishable by counter from the orphan a resuming process read a moment earlier: a counter-only compare-and-swap would match, and the resuming process would auto-continue the prompt the other process is running. Matching the whole record closes that, since any write by any process replaces at least one field, so the token stops matching and the claim loses.

The claim also mutates as little as it can. It bumps `attempts` and touches nothing else, and it specifically does not restamp `owner`, which is the check in `clear_interrupted_turn` that decides who may retire a record. A claim that took the stamp would leave the record's true owner unable to retire its own record when its turn concluded, so a finished turn's record would sit there and a later resume would re-run completed work. A claimant that goes on to run the turn stamps itself the ordinary way, in the turn prologue.

Standing down defers a recovery. It does not lose one. The record stays where it was, and the next resume that finds the conversation free claims it. A queued duplicate turn cannot be undone the same way: the model has already been asked to redo work, and any side effect it repeats is spent. That asymmetry is why this direction is the conservative one, and why the deferred retirements are safe: a record that survives one resume too long is collected on the next, while a record deleted out from under a running turn is gone.

The claim is the guarantee and the peek is the veto. The compare-and-swap alone makes double consumption impossible across processes, and it is the thing that admits a continuation. The peek answers whether the turn is actually still running, and its answer only subtracts: it can stop a claim that would otherwise be legal, and a retirement that policy would otherwise take. They are two transactions rather than one, so a turn that starts between them can be claimed over; that case falls through to the engine's own acquire, which still serializes it, and is bounded by the record's attempt ceiling.

The engine's acquire stays the universal backstop. This path deliberately does not pre-acquire the lease: a caller-held lease the engine cannot be told about would make the engine block on the caller's own row for its full wait and then reclaim it at TTL.

User-initiated turns fail open. A person is waiting, so `_run_prompt_submit` waits a bounded 120s for whatever holds the conversation, emits a status notice every 15s while waiting, aborts immediately on `/stop`, and on timeout closes the turn with a terminal `message.complete` carrying `status: "error"` and `recoverable: true` and text saying the message was not sent and can be sent again. The engine never starts and the interrupted-turn record is not touched, because that record belongs to whichever process is running.

A refusal returns before the turn body, so it unwinds by hand what the prologue already consumed. A `/model --once` override is popped off the session before admission and otherwise restored only in the turn's `finally`, so without this the next-turn-only model would become the session's model permanently. The attached images are claimed off the session at submission time so a later paste cannot be swallowed by this prompt, and a refusal that kept them would drop the user's attachments while telling them to resend. The one-shot `_auto_continue_scheduled` latch is cleared, or crash recovery would be disabled on that in-memory session for as long as it lives. A prompt queued behind the refused turn is drained, since this turn has ended; that drained turn is dispatched internally rather than by the RPC handler, so it takes the machine arm and the engine's own acquire serializes it exactly as today.

That half is dormant. It arms only when `agent.run_conversation` accepts a `session_turn_lease_holder` parameter, probed through the same additive-parameter idiom this file already uses for `task_id` and `persist_user_display_kind`. No engine accepts one today, so nothing on the user path changes. #86785 is the companion PR that adds the parameter, and it is open rather than merged, so this arm stays dormant on merge of this one. Both states are tested, with a fake agent whose signature carries the parameter and one whose signature does not.

The recovery note now says what was established, and no more. Before:

```
[System note: Your previous turn was interrupted mid-run — the app or its
backend process stopped before the turn could finish. ...]
```

After:

```
[System note: Your previous turn was interrupted mid-run — no completion was
ever recorded for it, and this process claimed that turn's record with no
live turn held on the conversation. ...]
```

The old text asserted a fact the record never carried: the process that started the turn may be alive and merely past its lease. The new text is scoped to the two things the admission decision established, which is narrower than "nothing else is running this conversation". The peek can only report that no unexpired lease claim, whose holder the dead-process probe failed to disprove, stood on the conversation at the instant it looked. Both consumers that match this note by prefix still match, `_legacy_display_kind` in `tui_gateway/server.py` and `_is_auto_continue_noise` in `gateway/run.py:1580`, and a test asserts both plus the new positive claim.

Separating what is inherited from what is new: #86786 moves the records into `state.db`, adds the owner stamp, and splits the disabled arm so it stops deleting a foreign owner's record. This PR adds the lease peek and the compare-and-swap claim, raises the peek above the whole policy branch so the same protection covers the stale and attempt-exhausted arms, and adds the caller-class keyword with the dormant interactive arm behind it.

## Related Issue

Related to #86190. This is its admission-polarity element.
Related to #67442, which asked for the caller-class rule this implements and whose `needs-decision` is why this is filed as a draft.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

Two storage primitives, the scheduler and submit paths in `tui_gateway`, and three test files.

<details>
<summary>Per-file inventory</summary>

- `hermes_state.py`: new `SessionDB.get_session_turn_lease_holder`, a read-only peek returning a holder only while the row is unexpired and the dead-process probe does not prove the holder gone. Probe doubt reads as live; a `sqlite3.Error` is logged and re-raised rather than reported as no-holder, since no-holder is a licence the caller acts on.
- `hermes_state.py`: new `SessionDB.claim_interrupted_turn`, a compare-and-swap in one `_execute_write` predicated on `attempts = ? AND started_at IS ? AND prompt IS ? AND owner IS ?` against the record the caller read. It sets `attempts` and nothing else. `IS` rather than `=` on the nullable columns keeps an imported legacy record carrying `owner NULL` claimable. Storage failure returns `None` rather than raising, because `acquire_session_turn_lease` re-raises anything it cannot classify as a lock and this runs on the resume path.
- `tui_gateway/server.py`: `_maybe_schedule_auto_continue` gains the claim after its existing gates and the lease peek above all of them. A live lease returns with the record untouched, deferring the stale and attempt-exhausted retirements as well as the continuation. The continuation prompt, the logged age and the reported interrupt time all come from the one record the compare-and-swap pinned.
- `tui_gateway/server.py`: `_auto_continue_note` states what the claim proved and stops short of what it did not.
- `tui_gateway/server.py`: `_turn_is_held_elsewhere` and `_claim_interrupted_turn` wrappers, both resolving every exception to standing down. The peek wrapper reads a session database it cannot open as held, since False out of it licenses acting on the record.
- `tui_gateway/server.py`: `_run_prompt_submit` gains the `user_initiated` keyword, defaulting to False, and the interactive admission arm gates on it.
- `tui_gateway/server.py`: `_engine_takes_lease_holder`, `_preacquire_turn_lease` and `_release_turn_lease` for the user path, plus the admission block in `_run_prompt_submit`, the holder handoff into `run_kwargs`, and the release beside the existing marker retire. `_preacquire_turn_lease` releases a lease it acquired if its own cleanup raises, rather than leaking it to the TTL.
- `tui_gateway/server.py`: the refusal path restores the one-turn model override, returns the attached images, clears the auto-continue latch and drains the queue.
- `tui_gateway/methods_prompt.py`: the `prompt.submit` handler passes `user_initiated=True`, the only site that does.
- `tui_gateway/server.py`: `_emit_terminal_turn_error` gains `retire_marker`, defaulting to current behavior. The refusal path passes `False`, since no turn concluded there and the record belongs to the running process.
- `tests/state/test_interrupted_turns.py`: claim tests, including two handles racing one record, a re-record between read and claim under an unchanged attempt count, a re-record visible only in `started_at`, the owner's retire surviving a claim, and `cause` surviving a claim.
- `tests/state/test_session_turn_lease.py`: peek tests, including expiry, a dead holder, and a holder the probe cannot judge.
- `tests/tui_gateway/test_turn_admission.py`: new file, 27 tests covering both polarities, both dormancy states, the four refusal unwinds, the peek's precedence over each of the three retirement arms and over none when no lease is held, and a source-level assertion that exactly one dispatch site is user-initiated.

</details>

## How to Test

1. `pytest tests/tui_gateway/test_auto_continue.py -q`. All 25 pass and no commit in this delta touches that file, which is the evidence that the uncontended case is untouched: with no lease row the peek finds nothing, the gates decide as before, the claim wins, and the continuation schedules as before.
2. `pytest tests/tui_gateway/test_turn_admission.py tests/state/test_interrupted_turns.py tests/state/test_session_turn_lease.py -q`.
3. The scheduling defect: `test_a_live_holder_defers_the_continuation`.
4. The retirement defect: `test_a_live_holder_defers_a_stale_record_too`, `test_a_live_holder_defers_an_exhausted_record_too`, and `test_a_live_holder_defers_a_disabled_process_too`, which reaches the same deletion through the disabled arm on a record this process owns, the case the owner check cannot cover. `test_no_holder_leaves_the_policy_retirements_intact` is the converse, so the veto cannot quietly become an exemption that switches the windows off.
5. The token defect: `test_a_turn_that_starts_between_the_read_and_the_claim_defeats_the_claim` through the scheduler, `test_a_re_record_between_read_and_claim_defeats_the_claim` at the storage layer.
6. The retire defect: `test_a_claim_leaves_the_true_owner_able_to_retire_its_record`.

<details>
<summary>How to reproduce all four by hand, before this change</summary>

Scheduling: record an interrupted turn, take the conversation's turn lease under a live holder, then call `_maybe_schedule_auto_continue`. It returns a scheduling descriptor and dispatches a continuation.

Retirement: same setup, with the scheduler's clock pushed past the freshness window first. The record of the running turn is force-deleted.

Token: record an orphan at `attempts=0`, read it, have a second handle record a different prompt at `attempts=0` under a different owner, then claim with the first read's counter. A counter-only compare-and-swap wins and returns the second prompt.

Retire: claim a record whose owner is a second handle, then have that owner call `clear_interrupted_turn` with its own owner string. It returns False and the record survives a concluded turn.

</details>

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass: what was actually run on Windows is `tests/tui_gateway/` and `tests/state/`, where every remaining failure is name-identical to the unmodified base (pre-existing environment flakes) and no new failure appears; full-suite green expected on Linux CI.
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11, Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Uncertainty

The peek and the claim run in separate transactions, so a foreign turn acquiring the lease between them can be claimed over. Folding the peek into the claim's transaction would close that window; it was left out because the peek would then run a `psutil` probe inside a `BEGIN IMMEDIATE`, and because the two-step form keeps the read-only accessor independently useful, which is now also what lets it gate the retirements. A reviewer who prefers the single transaction should say so.

Both layers of the peek fail toward deferral, and that polarity is deliberate rather than incidental. `get_session_turn_lease_holder` logs and re-raises a `sqlite3.Error` instead of reporting no holder, and the gateway wrapper reads an unopenable session database, and any error escaping the accessor, alike as a live turn. The reason is what "no holder" now licenses: once the peek gates the retirements, reporting no-holder off a read that failed would let this process delete the record of a turn it never managed to look for. Deferring on doubt costs one resume. Retiring on doubt costs the recovery. A reviewer who thinks a read-only accessor should never raise has a fair point about the shape, and the alternative is a third return value the caller must handle; it raises here because a silent None is the one option that hands out a licence the read never earned.

The claim's version token is the record's own contents rather than a dedicated version column, because the table has no such column and its attempt counter cannot serve as one. The residual is a write that reproduces every matched field, requiring the same owner, the same prompt, the same attempt count, and a `started_at` that collides at the platform clock's granularity. `time.time()` is not arbitrarily fine: on this platform `time.get_clock_info("time").resolution` reports 15.625ms and adjacent calls return equal values almost always, so the timestamp is a coarse token on its own and is only strong in combination with the other three fields. A dedicated monotonic version column would be strictly better and is a reasonable thing to ask for; it was not added here because it changes the storage PR's schema underneath this one.

The peek treats any live holder as blocking, including one minted by this process. That is stricter than "foreign holder" and deliberate: a lease held here means a turn is running here, which is equally a reason not to queue a second, and the compression-rotation path above shows that reaching this scheduler mid-turn in one process is not hypothetical. Since the peek also gates the retirements, that strictness has a second cost whose duration depends on the failure. A lease nobody refreshes lapses at its 300s TTL, well inside the 900s default freshness window, so the record is collected on the following resume. A wedged but living turn keeps refreshing every 60s, so its record is deferred for as long as that lasts, with the outer bound the 24h owner-blind delete in `record_interrupted_turn` rather than the TTL. Deferring a sweep for a turn demonstrably still running is the intended trade, but it is a longer deferral than the TTL suggests and should be read that way.

The `user_initiated` flag is set at the `prompt.submit` handler only. A prompt arriving through the compute host is re-dispatched internally on the host side and therefore takes the machine-class default, as does a prompt drained from the busy queue. Both behave exactly as they do today, which is the fail-safe outcome, but neither gets the bounded wait and the visible refusal once the companion PR arms that arm. Extending the flag to those legs is a follow-on and is deliberately not in this diff.

Timing under contention has not been measured on a real two-process install. The tests use two `SessionDB` handles, which exercises the SQLite transaction boundary but shares one process.

Tested on Windows 11 with Python 3.11 only.

## What I did not do

- No engine change. The `session_turn_lease_holder` parameter this PR probes for is #86785's work, and until that lands the user-turn arm here stays dormant.
- No version column on `interrupted_turns`. The claim matches the record's existing fields instead, which needed no schema change on top of the storage PR this is stacked on.
- No holder identity change. The `start=` field that would let the dead-process probe survive PID recycling is a separate one-line regex change applying to the lease and the compression lock together.
- No third return value on the peek. It reports a holder or raises, rather than distinguishing "nobody holds it" from "could not tell" in its return type. The caller wants both to mean defer, so the exception carries it; a reviewer who wants the distinction in the signature should say so.
- No config keys. `_TURN_LEASE_TTL_SECONDS`, `_TURN_LEASE_WAIT_SECONDS` and `_TURN_LEASE_WAIT_NOTICE_SECONDS` are module constants because the path they govern is dormant. They belong under `sessions.turn_lease.*` and `desktop.turn_lease.*` when the companion PR turns that path on, and `agent.gateway_turn_lease_timeout` is a different lease and must not be reused.
- No `user_initiated` on the compute-host or queue-drain legs. Arming them is a follow-on.
- No history reload on claim. Acquiring a lease proves nobody holds the conversation now, not that nobody wrote to it since this process last built its in-memory history. The reload in `run_agent.py` is gated on having waited, so the sequential handoff case still runs on a stale snapshot. That is a live defect in merged code, separable from this one, and it is being reported on its own.
- No cross-process stop, steer or busy exposure. Those ride the same lease row and are follow-ons.
- No true two-process test. The race test uses two `SessionDB` handles against one database file, which is the transaction boundary that matters here but not a second interpreter. A subprocess-based harness is worth having and is named as follow-up work.
