### PR TITLE
fix(kanban): keep initially blocked children sticky

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -4462,10 +4462,11 @@ def _has_sticky_block(conn: sqlite3.Connection, task_id: str) -> bool:
       automatically once the underlying conditions change (e.g. parents
       finish, transient infra error clears).
 
-    The cheapest signal that distinguishes these is the most recent
-    ``"created"`` / ``"blocked"`` / ``"unblocked"`` event for the task.
-    A blocked creation or explicit block is sticky until a newer explicit
-    ``"unblocked"`` event fires, and ``recompute_ready`` must not
+    The cheapest signal that distinguishes these is the most recent audited
+    gate transition: ``"created"``, ``"blocked"``, ``"unblocked"``,
+    ``"promoted_manual"``, or dashboard ``"status"``. A blocked creation,
+    explicit block, or status move to blocked is sticky until a newer
+    operator transition clears it, and ``recompute_ready`` must not
     auto-promote it.
 
     Returns ``False`` when there is no sticky event (e.g. the task was set
@@ -4475,11 +4476,13 @@ def _has_sticky_block(conn: sqlite3.Connection, task_id: str) -> bool:
     """
     row = conn.execute(
         "SELECT kind, payload FROM task_events "
-        "WHERE task_id = ? AND kind IN ('created', 'blocked', 'unblocked') "
+        "WHERE task_id = ? AND kind IN ("
+        "'created', 'blocked', 'unblocked', 'promoted_manual', 'status'"
+        ") "
         "ORDER BY id DESC LIMIT 1",
         (task_id,),
     ).fetchone()
-    if not row or row["kind"] == "unblocked":
+    if not row:
         return False
     if row["kind"] == "blocked":
         return True
@@ -4487,7 +4490,11 @@ def _has_sticky_block(conn: sqlite3.Connection, task_id: str) -> bool:
         payload = json.loads(row["payload"]) if row["payload"] else {}
     except (json.JSONDecodeError, TypeError):
         payload = {}
-    return isinstance(payload, dict) and payload.get("status") == "blocked"
+    return (
+        row["kind"] in {"created", "status"}
+        and isinstance(payload, dict)
+        and payload.get("status") == "blocked"
+    )
 
 
 def _resume_status_from_events(conn: sqlite3.Connection, task_id: str) -> str:

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -4441,8 +4441,7 @@ def _synthesize_ended_run(
 # ---------------------------------------------------------------------------
 
 def _has_sticky_block(conn: sqlite3.Connection, task_id: str) -> bool:
-    """Return True when ``task_id`` is sticky-blocked by an explicit
-    worker/operator ``kanban_block`` call (#28712).
+    """Return True when ``task_id`` is sticky-blocked by an explicit gate.
 
     A ``blocked`` status can come from two very different sources:
 
@@ -4452,30 +4451,43 @@ def _has_sticky_block(conn: sqlite3.Connection, task_id: str) -> bool:
       should stay blocked until an operator unblocks it.  The block tool
       emits a ``"blocked"`` event row in ``task_events``.
 
+    * **Created blocked** — ``create_task(initial_status="blocked")`` parks
+      a human-ops card directly in the blocked lane.  It records that gate
+      on the existing ``"created"`` event as ``status="blocked"`` rather
+      than emitting a separate ``"blocked"`` event.
+
     * **Circuit-breaker** — ``_record_task_failure`` tripped after
       repeated crashes / spawn failures / timeouts.  This emits
       ``"gave_up"``, *not* ``"blocked"``, and is meant to recover
       automatically once the underlying conditions change (e.g. parents
       finish, transient infra error clears).
 
-    The cheapest signal that distinguishes the two is the most recent
-    ``"blocked"`` / ``"unblocked"`` event for the task.  If the most
-    recent one is ``"blocked"`` (or there is a ``"blocked"`` event and
-    no ``"unblocked"`` event has fired since), the task is sticky and
-    ``recompute_ready`` must *not* auto-promote it.
+    The cheapest signal that distinguishes these is the most recent
+    ``"created"`` / ``"blocked"`` / ``"unblocked"`` event for the task.
+    A blocked creation or explicit block is sticky until a newer explicit
+    ``"unblocked"`` event fires, and ``recompute_ready`` must not
+    auto-promote it.
 
-    Returns ``False`` when there is no such event at all (e.g. the task
-    was set to ``status='blocked'`` by the circuit breaker or by direct
-    DB manipulation) — preserves the pre-#28712 auto-recover semantics
-    for that path.
+    Returns ``False`` when there is no sticky event (e.g. the task was set
+    to ``status='blocked'`` by the circuit breaker or by direct DB
+    manipulation) — preserves the pre-#28712 auto-recover semantics for
+    that path.
     """
     row = conn.execute(
-        "SELECT kind FROM task_events "
-        "WHERE task_id = ? AND kind IN ('blocked', 'unblocked') "
+        "SELECT kind, payload FROM task_events "
+        "WHERE task_id = ? AND kind IN ('created', 'blocked', 'unblocked') "
         "ORDER BY id DESC LIMIT 1",
         (task_id,),
     ).fetchone()
-    return bool(row) and row["kind"] == "blocked"
+    if not row or row["kind"] == "unblocked":
+        return False
+    if row["kind"] == "blocked":
+        return True
+    try:
+        payload = json.loads(row["payload"]) if row["payload"] else {}
+    except (json.JSONDecodeError, TypeError):
+        payload = {}
+    return isinstance(payload, dict) and payload.get("status") == "blocked"
 
 
 def _resume_status_from_events(conn: sqlite3.Connection, task_id: str) -> str:

--- a/tests/hermes_cli/test_kanban_blocked_sticky.py
+++ b/tests/hermes_cli/test_kanban_blocked_sticky.py
@@ -76,6 +76,58 @@ def test_worker_block_is_not_auto_promoted_by_recompute_ready(kanban_home: Path)
             assert kb.get_task(conn, tid).status == "blocked"
 
 
+def test_initially_blocked_child_requires_explicit_unblock_after_parent_completion(
+    kanban_home: Path,
+) -> None:
+    """A child created as blocked is a human gate, not a dependency wait."""
+    with kb.connect() as conn:
+        parent_id = kb.create_task(conn, title="implementation")
+        blocked_child_id = kb.create_task(
+            conn,
+            title="human approval",
+            parents=[parent_id],
+            initial_status="blocked",
+        )
+        ready_child_id = kb.create_task(
+            conn,
+            title="ordinary dependent",
+            parents=[parent_id],
+        )
+
+        blocked_child = kb.get_task(conn, blocked_child_id)
+        ready_child = kb.get_task(conn, ready_child_id)
+        assert blocked_child is not None and blocked_child.status == "blocked"
+        assert ready_child is not None and ready_child.status == "todo"
+
+        parent = kb.claim_task(conn, parent_id, claimer="test-parent")
+        assert parent is not None
+        assert kb.complete_task(
+            conn,
+            parent_id,
+            summary="implementation complete",
+            expected_run_id=parent.current_run_id,
+        )
+
+        blocked_child = kb.get_task(conn, blocked_child_id)
+        ready_child = kb.get_task(conn, ready_child_id)
+        assert ready_child is not None and ready_child.status == "ready"
+        assert blocked_child is not None and blocked_child.status == "blocked"
+        assert kb.claim_task(conn, blocked_child_id, claimer="must-not-claim") is None
+        before_unblock_events = {
+            row["kind"]
+            for row in conn.execute(
+                "SELECT kind FROM task_events WHERE task_id = ?",
+                (blocked_child_id,),
+            ).fetchall()
+        }
+        assert before_unblock_events.isdisjoint({"promoted", "claimed", "spawned"})
+
+        assert kb.unblock_task(conn, blocked_child_id)
+        blocked_child = kb.get_task(conn, blocked_child_id)
+        assert blocked_child is not None and blocked_child.status == "ready"
+        assert kb.claim_task(conn, blocked_child_id, claimer="after-unblock") is not None
+
+
 
 
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_kanban_blocked_sticky.py
+++ b/tests/hermes_cli/test_kanban_blocked_sticky.py
@@ -29,12 +29,31 @@ landed via #28754 / #28781 ahead of this fix.
 
 from __future__ import annotations
 
+import importlib.util
+import sys
 import time
 from pathlib import Path
 
 import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
 
 from hermes_cli import kanban_db as kb
+
+
+def _load_dashboard_router():
+    repo_root = Path(__file__).resolve().parents[2]
+    plugin_file = repo_root / "plugins" / "kanban" / "dashboard" / "plugin_api.py"
+    assert plugin_file.exists(), f"plugin file missing: {plugin_file}"
+    spec = importlib.util.spec_from_file_location(
+        "hermes_dashboard_plugin_kanban_blocked_sticky_test",
+        plugin_file,
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module.router
 
 
 @pytest.fixture
@@ -46,6 +65,13 @@ def kanban_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     monkeypatch.setattr(Path, "home", lambda: tmp_path)
     kb.init_db()
     return home
+
+
+@pytest.fixture
+def dashboard_client(kanban_home: Path) -> TestClient:
+    app = FastAPI()
+    app.include_router(_load_dashboard_router(), prefix="/api/plugins/kanban")
+    return TestClient(app)
 
 
 # ---------------------------------------------------------------------------
@@ -131,6 +157,7 @@ def test_initially_blocked_child_requires_explicit_unblock_after_parent_completi
 @pytest.mark.parametrize("transition", ["promote", "status"])
 def test_operator_transition_clears_initial_block_stickiness(
     kanban_home: Path,
+    dashboard_client: TestClient,
     transition: str,
 ) -> None:
     """Audited operator overrides must not poison later breaker recovery."""
@@ -145,17 +172,11 @@ def test_operator_transition_clears_initial_block_stickiness(
             ok, error = kb.promote_task(conn, task_id, actor="operator")
             assert ok and error is None
         else:
-            with kb.write_txn(conn):
-                conn.execute(
-                    "UPDATE tasks SET status = 'todo' WHERE id = ?",
-                    (task_id,),
-                )
-                kb._append_event(
-                    conn,
-                    task_id,
-                    "status",
-                    {"status": "todo", "requested_status": "todo"},
-                )
+            response = dashboard_client.patch(
+                f"/api/plugins/kanban/tasks/{task_id}",
+                json={"status": "todo"},
+            )
+            assert response.status_code == 200, response.text
             assert kb.recompute_ready(conn) == 1
 
         claimed = kb.claim_task(conn, task_id, claimer="test-worker")

--- a/tests/hermes_cli/test_kanban_blocked_sticky.py
+++ b/tests/hermes_cli/test_kanban_blocked_sticky.py
@@ -128,6 +128,55 @@ def test_initially_blocked_child_requires_explicit_unblock_after_parent_completi
         assert kb.claim_task(conn, blocked_child_id, claimer="after-unblock") is not None
 
 
+@pytest.mark.parametrize("transition", ["promote", "status"])
+def test_operator_transition_clears_initial_block_stickiness(
+    kanban_home: Path,
+    transition: str,
+) -> None:
+    """Audited operator overrides must not poison later breaker recovery."""
+    with kb.connect() as conn:
+        task_id = kb.create_task(
+            conn,
+            title="human gate",
+            initial_status="blocked",
+        )
+
+        if transition == "promote":
+            ok, error = kb.promote_task(conn, task_id, actor="operator")
+            assert ok and error is None
+        else:
+            with kb.write_txn(conn):
+                conn.execute(
+                    "UPDATE tasks SET status = 'todo' WHERE id = ?",
+                    (task_id,),
+                )
+                kb._append_event(
+                    conn,
+                    task_id,
+                    "status",
+                    {"status": "todo", "requested_status": "todo"},
+                )
+            assert kb.recompute_ready(conn) == 1
+
+        claimed = kb.claim_task(conn, task_id, claimer="test-worker")
+        assert claimed is not None
+        assert kb._record_task_failure(
+            conn,
+            task_id,
+            "spawn failed",
+            outcome="spawn_failed",
+            failure_limit=1,
+            release_claim=True,
+            end_run=True,
+        )
+        blocked = kb.get_task(conn, task_id)
+        assert blocked is not None and blocked.status == "blocked"
+
+        assert kb.recompute_ready(conn) == 1
+        recovered = kb.get_task(conn, task_id)
+        assert recovered is not None and recovered.status == "ready"
+
+
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- keep children created with `initial_status="blocked"` sticky when their parents complete
- recognize audited operator overrides (`unblocked`, manual promotion, and dashboard status moves) so circuit-breaker recovery still works
- add isolated temp-`HERMES_HOME` coverage for parent completion, claim prevention, explicit unblock, normal dependency promotion, and the real dashboard PATCH path

## Root cause

`create_task(initial_status="blocked")` records the gate only in the `created` event payload. `_has_sticky_block()` previously inspected only `blocked`/`unblocked` events, so `recompute_ready()` treated the child as a recoverable circuit-breaker block and promoted it after the parent completed.

## Test plan

- [x] RED reproduction: blocked child became `ready` after parent completion on `origin/main`
- [x] `scripts/run_tests.sh tests/hermes_cli/test_kanban_blocked_sticky.py -q` (5 passed)
- [x] focused Kanban/dashboard regression set (54 passed, 1 skipped)
- [x] Ruff on both changed files
- [x] full repository suite completed on the same SHA: 77 failures across 26 unrelated files, with no Kanban failure; `test_health_detailed_returns_ok` reproduces on clean `origin/main`, and the remaining failures are outside this diff (timing/load, optional providers, and host-policy fixtures)

The PR remains draft because the full baseline is not green and GitHub reported no checks for the fork branch.

Internal tracking: IT-52.
