### PR TITLE
fix(gateway): expand env refs when resolving gateway model

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3369,11 +3369,20 @@ def _resolve_gateway_model(config: dict | None = None) -> str:
     openai-codex.
     """
     cfg = config if config is not None else _load_gateway_config()
+    # _load_gateway_config() reads raw YAML (bypassing load_config), so
+    # ${VAR} env references inside model.default are NOT expanded there.
+    # Expand here so a profile whose default model is an env ref (e.g.
+    # ${LOCAL_LLM_MODEL}) resolves to the real model name instead of being
+    # sent literally to the provider (404 "no router for requested model").
+    # No-op when the value is already a literal or unset.
+    from typing import cast
+    from hermes_cli.config import _expand_env_vars
     model_cfg = cfg.get("model", {})
     if isinstance(model_cfg, str):
-        return model_cfg
+        return cast(str, _expand_env_vars(model_cfg))
     elif isinstance(model_cfg, dict):
-        return model_cfg.get("default") or model_cfg.get("model") or ""
+        raw = model_cfg.get("default") or model_cfg.get("model") or ""
+        return cast(str, _expand_env_vars(raw))
     return ""
 
 


### PR DESCRIPTION
## Summary

The gateway resolves the active model from `config.yaml` via `_load_gateway_config()`, which reads **raw YAML** (deliberately bypassing `load_config()` for speed). Unlike `load_config()`, that path never runs `_expand_env_vars()`, so `${VAR}` references inside `model.default` were passed through **literally** to the provider.

## Root cause

A profile configured with an env-ref default model (e.g. `model.default: ${LOCAL_LLM_MODEL}`) made every gateway agent call send `"${LOCAL_LLM_MODEL}"` as the model name. Providers 404 on that (`llama-swap`: `no router for requested model`), and the gateway silently fell back to the fallback chain — so delegated/API calls never used the intended local model. Only the model name was affected: `base_url`/`api_key` still resolved correctly because they go through `resolve_runtime_provider()`, which does expand env refs. Configs with literal model names (the default) never hit this.

## Fix

`_resolve_gateway_model()` now runs `_expand_env_vars()` on the resolved model string before returning. It is a no-op when the value is already a literal or unset.

Both gateway surfaces call this helper, so one change covers:
- API-server path (`_create_agent` in `gateway/platforms/api_server.py`)
- Native channel path (`_resolve_model_for_channel` in `gateway/run.py`)

## Verification

- Reproduced: delegated call to the gateway sent `model=${LOCAL_LLM_MODEL}` to llama-swap → `404 no router for requested model` → fallback to the fallback model (observed in `agent.log`, 111 occurrences).
- After fix + gateway restart, the same delegated call logged `provider=custom model=Gemma-4-E4B-Fable5-FC-v2` against llama-swap, no 404, no fallback.
- `_expand_env_vars` is idempotent for literal values (unit-tested behavior in `hermes_cli/config.py`), so existing literal-model configs are unaffected.

## Test plan

- [ ] Existing gateway tests pass (any covering `_resolve_gateway_model` / `_resolve_model_for_channel`)
- [ ] Manual: configure `model.default: ${SOME_VAR}` with `SOME_VAR` set, start gateway, confirm the outbound request uses the expanded value
- [ ] Manual: confirm literal `model.default` configs still resolve unchanged
