### PR TITLE
fix(gateway): delivery-ledger row-cap prune must not delete undelivered obligations

### DIFF
--- a/gateway/delivery_ledger.py
+++ b/gateway/delivery_ledger.py
@@ -337,17 +337,34 @@ def _prune(now: Optional[float] = None) -> None:
             ).fetchone()[0]
             excess = max(0, total - _MAX_ROWS)
             if excess:
+                # Only settled rows are deletable. An obligation that is
+                # still pending/attempting/failed is output nobody has
+                # received yet: dropping it to honour a row cap would lose
+                # exactly what the ledger exists to protect. The cap may be
+                # exceeded instead (backpressure warning below).
                 conn.execute(
                     """DELETE FROM delivery_obligations WHERE obligation_id IN (
                          SELECT obligation_id FROM delivery_obligations
+                         WHERE state IN ('delivered', 'abandoned')
                          ORDER BY CASE state
                                     WHEN 'delivered' THEN 0
-                                    WHEN 'abandoned' THEN 1
-                                    ELSE 2
+                                    ELSE 1
                                   END, updated_at ASC
                          LIMIT ?)""",
                     (excess,),
                 )
+            open_rows = conn.execute(
+                """SELECT COUNT(*) FROM delivery_obligations
+                   WHERE state IN ('pending', 'attempting', 'failed')"""
+            ).fetchone()[0]
+        if open_rows > _MAX_ROWS:
+            logger.warning(
+                "delivery ledger backpressure: %d undelivered obligations exceed "
+                "the row cap of %d; rows are retained — investigate stalled "
+                "delivery instead of expecting retention to clear them",
+                open_rows,
+                _MAX_ROWS,
+            )
     except Exception:
         logger.debug("delivery ledger prune failed", exc_info=True)
 

--- a/tests/gateway/test_delivery_ledger_prune.py
+++ b/tests/gateway/test_delivery_ledger_prune.py
@@ -1,0 +1,78 @@
+"""Row-cap pruning must never delete undelivered obligations.
+
+The ledger exists so a reply that was owed but not yet delivered survives a
+gateway crash. The row-cap branch of ``_prune`` ordered candidates with
+settled states first, but did not FILTER on them — once the settled rows were
+exhausted, the excess deletions consumed pending/attempting/failed rows, i.e.
+exactly the output the ledger is supposed to protect.
+"""
+import sqlite3
+
+import pytest
+
+from gateway import delivery_ledger as dl
+
+
+@pytest.fixture(autouse=True)
+def _fresh_db(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setattr(dl, "_db_path", lambda: home / "state.db")
+    yield
+
+
+def _record(n: int, prefix: str) -> list[str]:
+    ids = []
+    for i in range(n):
+        oid = f"{prefix}-{i:04d}"
+        dl.record_obligation(
+            obligation_id=oid,
+            session_key=f"sess-{prefix}",
+            platform="telegram",
+            chat_id="chat-1",
+            thread_id=None,
+            content=f"reply {oid}",
+        )
+        ids.append(oid)
+    return ids
+
+
+def _states() -> dict[str, int]:
+    conn = sqlite3.connect(dl._db_path())
+    try:
+        rows = conn.execute(
+            "SELECT state, COUNT(*) FROM delivery_obligations GROUP BY state"
+        ).fetchall()
+        return {state: count for state, count in rows}
+    finally:
+        conn.close()
+
+
+def test_row_cap_prune_never_deletes_undelivered(monkeypatch):
+    monkeypatch.setattr(dl, "_MAX_ROWS", 10)
+
+    delivered = _record(8, "done")
+    for oid in delivered:
+        dl.mark_delivered(oid)
+    pending = _record(12, "owed")  # every record_obligation() call prunes
+
+    states = _states()
+    # All 12 undelivered obligations survive, even though the table exceeds
+    # the cap after the 8 settled rows are gone.
+    assert states.get("pending", 0) == len(pending)
+    # Settled rows were consumed to honour the cap as far as possible.
+    assert states.get("delivered", 0) <= 10
+
+
+def test_row_cap_prune_still_removes_settled_excess(monkeypatch):
+    monkeypatch.setattr(dl, "_MAX_ROWS", 5)
+
+    settled = _record(9, "done")
+    for oid in settled:
+        dl.mark_delivered(oid)
+    _record(1, "owed")  # triggers a prune with 9 settled + 1 pending
+
+    states = _states()
+    assert states.get("pending", 0) == 1
+    # 10 total - cap 5 = 5 excess, all taken from the settled rows.
+    assert states.get("delivered", 0) == 4


### PR DESCRIPTION
## Summary
The delivery ledger exists so a reply that was owed but not yet delivered survives a gateway crash. The row-cap branch of `_prune()` orders deletion candidates with settled states first, but does not **filter** on them — once the `delivered`/`abandoned` rows are exhausted, the excess deletions consume `pending`/`attempting`/`failed` rows: exactly the output the ledger is supposed to protect, silently dropped to honour the `_MAX_ROWS` bookkeeping cap.

## Fix
Restrict the cap-driven deletion to settled rows (`WHERE state IN ('delivered','abandoned')`). When undelivered obligations alone exceed the cap, retain them and emit a backpressure warning instead — a growing backlog of undelivered replies is a delivery stall to investigate, not data the retention layer may clear.

## Validation
`tests/gateway/test_delivery_ledger_prune.py`:
- 12 pending + 8 delivered over a cap of 10 → all 12 pending survive, settled rows are consumed;
- settled-only excess is still pruned down to the cap.

`tests/gateway/test_delivery_ledger_producer.py` passes unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)