### PR TITLE
fix(whatsapp): supervise inbound poll task so its death can't silently stop inbound delivery

### DIFF
--- a/plugins/platforms/whatsapp/adapter.py
+++ b/plugins/platforms/whatsapp/adapter.py
@@ -659,7 +659,7 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                                     self._mark_connected()
                                     self._bridge_process = None  # Not managed by us
                                     self._http_session = aiohttp.ClientSession()
-                                    self._poll_task = asyncio.create_task(self._poll_messages())
+                                    self._poll_task = self._spawn_poll_task()
                                     return True
                                 stale_reason = (
                                     f"running={running_hash or 'unversioned'}, disk={disk_hash}"
@@ -816,7 +816,7 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             self._http_session = aiohttp.ClientSession()
 
             # Start message polling task
-            self._poll_task = asyncio.create_task(self._poll_messages())
+            self._poll_task = self._spawn_poll_task()
             
             self._mark_connected()
             print(f"[{self.name}] Bridge started on port {self._bridge_port}")
@@ -839,6 +839,54 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             except Exception:
                 pass
             self._bridge_log_fh = None
+
+    def _spawn_poll_task(self) -> "asyncio.Task":
+        """Create the poll task under supervision.
+
+        The 2026-08-15 incident: the poll task died silently while the rest of
+        the adapter stayed healthy — outbound sends kept working, /health kept
+        reporting connected, but nobody drained GET /messages for ~20h and 18
+        inbound messages were lost in the bridge's in-RAM queue. The class fix
+        is a done-callback supervisor: ANY termination of the poll task that
+        is not an orderly shutdown flips the adapter into the existing
+        fatal-retryable machinery, which tears it down and queues it for
+        background reconnection (gateway/run.py reconnect watcher).
+        """
+        task = asyncio.create_task(self._poll_messages())
+        task.add_done_callback(self._on_poll_task_done)
+        return task
+
+    def _on_poll_task_done(self, task: "asyncio.Task") -> None:
+        # Orderly paths: disconnect() cancels us / adapter is shutting down /
+        # a newer poll task has already replaced this one.
+        if getattr(self, "_shutting_down", False):
+            return
+        if task is not self._poll_task:
+            return
+        if self.has_fatal_error:
+            # _check_managed_bridge_exit already reported and queued reconnect.
+            return
+        exc: Optional[BaseException]
+        if task.cancelled():
+            exc = None
+            reason = "poll task cancelled outside shutdown"
+        else:
+            exc = task.exception()
+            reason = f"poll task exited unexpectedly ({exc!r})" if exc else "poll task returned"
+        message = f"WhatsApp inbound poller died: {reason}. Queueing reconnect."
+        # State first, logging second: the fatal flag must flip even if
+        # logging/name resolution throws (bare test adapters, teardown races).
+        self._set_fatal_error("whatsapp_poller_died", message, retryable=True)
+        try:
+            logger.error("[%s] %s", self.name, message)
+        except Exception:
+            logger.error("[whatsapp] %s", message)
+        # _notify_fatal_error is async; we are in a sync callback.
+        try:
+            loop = asyncio.get_running_loop()
+            loop.create_task(self._notify_fatal_error())
+        except RuntimeError:
+            pass  # loop already closed — process is going down anyway
 
     async def _check_managed_bridge_exit(self) -> Optional[str]:
         """Return a fatal error message if the managed bridge child exited."""
@@ -1324,16 +1372,25 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         return {"name": chat_id, "type": "dm"}
     
     async def _poll_messages(self) -> None:
-        """Poll the bridge for incoming messages."""
+        """Poll the bridge for incoming messages.
+
+        Termination contract (enforced by _on_poll_task_done): returning or
+        raising outside an orderly shutdown flips the adapter into
+        fatal-retryable and queues a reconnect. Never swallow a dead-loop
+        condition with a bare ``break`` — that pattern caused a silent
+        ~20h inbound outage (adapter healthy, nobody draining /messages).
+        """
         import aiohttp
 
         while self._running:
             if not self._http_session:
-                break
+                raise RuntimeError("bridge HTTP session vanished while poller running")
             bridge_exit = await self._check_managed_bridge_exit()
             if bridge_exit:
+                # _check_managed_bridge_exit already set the retryable fatal
+                # error and notified; this return is the orderly path.
                 print(f"[{self.name}] {bridge_exit}")
-                break
+                return
             try:
                 async with self._http_session.get(
                     f"http://127.0.0.1:{self._bridge_port}/messages",
@@ -1353,12 +1410,13 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                                 else:
                                     await self.handle_message(event)
             except asyncio.CancelledError:
-                break
+                raise  # orderly cancellation from disconnect(); supervisor ignores it
             except Exception as e:
                 bridge_exit = await self._check_managed_bridge_exit()
                 if bridge_exit:
+                    # Fatal already set + reconnect queued by the check.
                     print(f"[{self.name}] {bridge_exit}")
-                    break
+                    return
                 print(f"[{self.name}] Poll error: {e}")
                 await asyncio.sleep(5)
             

--- a/tests/plugins/test_whatsapp_poller_supervisor.py
+++ b/tests/plugins/test_whatsapp_poller_supervisor.py
@@ -1,0 +1,131 @@
+"""Regression tests for the WhatsApp inbound poller supervisor.
+
+Incident 2026-08-15: the poll task died silently (permanent ``break`` on a
+transient condition) while the adapter kept reporting healthy — outbound
+sends worked, /health said connected, but nobody drained GET /messages for
+~20h and 18 inbound messages were lost.
+
+Contract under test: ANY poll-task termination outside an orderly shutdown
+must flip the adapter into the fatal-retryable state so the gateway's
+reconnect watcher rebuilds it.
+"""
+
+import asyncio
+from typing import Optional
+
+import pytest
+
+from plugins.platforms.whatsapp.adapter import WhatsAppAdapter
+
+
+def _bare_adapter() -> WhatsAppAdapter:
+    a = WhatsAppAdapter.__new__(WhatsAppAdapter)
+    a._poll_task = None
+    a._shutting_down = False
+    a._running = True
+    a._fatal_error_code = None
+    a._fatal_error_message = None
+    a._fatal_error_retryable = True
+    a._fatal_error_handler = None
+
+    async def _noop_notify():
+        return None
+
+    a._notify_fatal_error = _noop_notify  # type: ignore[method-assign]
+    a._write_runtime_status_safe = lambda *args, **kwargs: None  # type: ignore[method-assign]
+    return a
+
+
+@pytest.mark.asyncio
+async def test_poller_crash_sets_retryable_fatal_error():
+    """A poll task that raises must mark the adapter fatal-retryable."""
+    adapter = _bare_adapter()
+
+    async def crashing_poll():
+        raise RuntimeError("bridge HTTP session vanished while poller running")
+
+    adapter._poll_messages = crashing_poll  # type: ignore[method-assign]
+    adapter._poll_task = adapter._spawn_poll_task()
+    with pytest.raises(RuntimeError):
+        await adapter._poll_task
+    await asyncio.sleep(0)  # let the done-callback run
+
+    assert adapter.has_fatal_error
+    assert adapter.fatal_error_code == "whatsapp_poller_died"
+    assert adapter.fatal_error_retryable
+
+
+@pytest.mark.asyncio
+async def test_poller_plain_return_sets_retryable_fatal_error():
+    """A poll task that just returns (the old silent-break bug) is an anomaly."""
+    adapter = _bare_adapter()
+
+    async def returning_poll():
+        return  # old behaviour: silent break -> task completes quietly
+
+    adapter._poll_messages = returning_poll  # type: ignore[method-assign]
+    adapter._poll_task = adapter._spawn_poll_task()
+    await adapter._poll_task
+    await asyncio.sleep(0)
+
+    assert adapter.has_fatal_error
+    assert adapter.fatal_error_code == "whatsapp_poller_died"
+    assert adapter.fatal_error_retryable
+
+
+@pytest.mark.asyncio
+async def test_poller_cancel_during_shutdown_is_orderly():
+    """disconnect() cancels the poller with _shutting_down set: no fatal."""
+    adapter = _bare_adapter()
+
+    async def long_poll():
+        await asyncio.sleep(3600)
+
+    adapter._poll_messages = long_poll  # type: ignore[method-assign]
+    adapter._poll_task = adapter._spawn_poll_task()
+    await asyncio.sleep(0)
+    adapter._shutting_down = True
+    adapter._poll_task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await adapter._poll_task
+    await asyncio.sleep(0)
+
+    assert not adapter.has_fatal_error
+
+
+@pytest.mark.asyncio
+async def test_poller_return_after_bridge_exit_fatal_is_not_double_reported():
+    """When _check_managed_bridge_exit already set the fatal error, the
+    supervisor must not overwrite its code."""
+    adapter = _bare_adapter()
+
+    async def poll_after_bridge_died():
+        adapter._set_fatal_error(
+            "whatsapp_bridge_exited", "bridge exited (code 1)", retryable=True
+        )
+        return
+
+    adapter._poll_messages = poll_after_bridge_died  # type: ignore[method-assign]
+    adapter._poll_task = adapter._spawn_poll_task()
+    await adapter._poll_task
+    await asyncio.sleep(0)
+
+    assert adapter.fatal_error_code == "whatsapp_bridge_exited"
+
+
+@pytest.mark.asyncio
+async def test_replaced_poll_task_termination_is_ignored():
+    """A superseded poll task (reconnect spawned a new one) must not poison
+    the fresh adapter state when the old task finishes."""
+    adapter = _bare_adapter()
+
+    async def returning_poll():
+        return
+
+    adapter._poll_messages = returning_poll  # type: ignore[method-assign]
+    old_task = adapter._spawn_poll_task()
+    adapter._poll_task = None  # a "newer" lifecycle already cleared/replaced it
+    await old_task
+    await asyncio.sleep(0)
+
+    assert not adapter.has_fatal_error


### PR DESCRIPTION
## What & why

`_poll_messages` can break out of its loop permanently on transient conditions (lost http session, bridge-exit check) and **nothing supervises the task**. When that happens the adapter stays 'healthy' — outbound sends keep working, `/health` reports connected — but nobody drains the bridge's `GET /messages` queue ever again. Inbound WhatsApp goes silently deaf; the bridge's in-RAM queue (`MAX_QUEUE_SIZE` with `shift()`) eventually drops messages on the floor.

Observed in production: **~20h inbound outage, 18 messages lost**. Signature: `queueLength` stuck at 18 across samples, tcpdump on the bridge port showing zero `/messages` polls, last inbound logged 20h earlier — while outbound cron deliveries kept succeeding.

## The fix (class, not site)

- `_spawn_poll_task()` attaches a **done-callback supervisor** to the poll task. Any termination outside an orderly shutdown (exception, plain return, stray cancel) flips the adapter into the **existing** fatal-retryable machinery → teardown + background reconnection via the reconnect watcher. No new retry loop invented.
- `_poll_messages` gets an explicit termination contract: lost http session **raises** (anomaly), bridge-exit paths **return** (orderly — `_check_managed_bridge_exit` already set the retryable fatal), `CancelledError` **propagates** (shutdown).
- Fatal state flips **before** logging so a logging failure can't skip the transition.

## How to test

```bash
pytest tests/plugins/test_whatsapp_poller_supervisor.py -v
```

5 regression tests, **RED-verified** against the unpatched adapter (all 5 fail without the fix): crash, silent return (the exact production bug), orderly cancel, no double-report, superseded-task ignored.

Manual: in a live gateway, SIGSTOP the bridge until the session drops (or kill the poll task) — the adapter logs 'inbound poller died', enters `retrying`, and the reconnect watcher rebuilds it. Before the fix: gateway stays 'connected' with inbound permanently dead.

## Platforms

Linux (Ubuntu aarch64, production gateway). Pure-Python asyncio change, no platform-specific I/O.

## Related

Complementary to #23785 (connect-time bridge restart race): that PR hardens startup, this one supervises the steady-state poll task. No overlap in mechanism.