### PR TITLE
fix(update): prevent destructive Windows ZIP fallback

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -5370,8 +5370,11 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         per ``min_interval`` seconds.
         """
         now = time.monotonic()
-        last = getattr(self, "_last_focus_regain_redraw", 0.0)
-        if now - last < min_interval:
+        last = getattr(self, "_last_focus_regain_redraw", None)
+        # ``time.monotonic()`` is relative to process start.  Using ``0.0``
+        # as the initial timestamp suppresses the first redraw whenever the
+        # process has been alive for less than ``min_interval`` seconds.
+        if last is not None and now - last < min_interval:
             return
         self._last_focus_regain_redraw = now
         self._force_full_redraw()

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -773,6 +773,75 @@ def _print_update_completion(message: str) -> None:
         print(f"=== hermes-update completed {action_id} ===")
 
 
+def _is_git_update_failure(exc: subprocess.CalledProcessError) -> bool:
+    """Return whether ``exc`` came from the git update command.
+
+    The update pipeline also runs dependency installation inside the same
+    outer ``try``.  Exception type alone therefore cannot select the Windows
+    ZIP fallback: a failed ``uv``/``pip`` command is a ``CalledProcessError``
+    too, but the checkout has already been updated and must not be replaced
+    from a ZIP archive.
+    """
+    command = getattr(exc, "cmd", None)
+    if isinstance(command, (str, bytes)):
+        command = shlex.split(os.fsdecode(command))
+    if not command:
+        return False
+    executable = os.fsdecode(command[0]).replace("\\", "/").rsplit("/", 1)[-1]
+    return executable.lower() in {"git", "git.exe"}
+
+
+def _ensure_zip_update_checkout_is_clean() -> None:
+    """Refuse the destructive ZIP replacement for a dirty git checkout.
+
+    ZIP replacement works at top-level entry granularity, so preserving only
+    ``venv``/``.git`` cannot preserve edits or untracked files nested below a
+    source directory.  A status failure is also fail-closed: inability to
+    prove the tree is clean must never authorize destructive replacement.
+    Non-git installs retain the existing ZIP fallback behavior.
+    """
+    project_root = _m().PROJECT_ROOT
+    if not (project_root / ".git").exists():
+        return
+
+    git_cmd = ["git"]
+    if _m()._is_windows():
+        git_cmd = ["git", "-c", "windows.appendAtomically=false"]
+    try:
+        status = subprocess.run(
+            git_cmd + ["status", "--porcelain", "--untracked-files=all"],
+            cwd=project_root,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            check=False,
+        )
+    except OSError as exc:
+        print(f"✗ ZIP update refused: cannot verify checkout state ({exc}).")
+        print("  Resolve the git/filesystem problem and rerun `hermes update`.")
+        _m().sys.exit(1)
+
+    if status.returncode != 0:
+        detail = (status.stderr or "").strip().splitlines()
+        suffix = f" {detail[0]}" if detail else ""
+        print(f"✗ ZIP update refused: cannot verify checkout state.{suffix}")
+        print("  Resolve the git/filesystem problem and rerun `hermes update`.")
+        _m().sys.exit(1)
+
+    dirty = (status.stdout or "").strip()
+    if dirty:
+        changed = dirty.splitlines()
+        print("✗ ZIP update refused: the git checkout has local changes.")
+        print("  The ZIP fallback will not overwrite uncommitted or untracked files.")
+        print("  Commit or save the work, then rerun `hermes update`.")
+        for line in changed[:8]:
+            print(f"    {line}")
+        if len(changed) > 8:
+            print(f"    … and {len(changed) - 8} more")
+        _m().sys.exit(1)
+
+
 def _update_via_zip(args, *, had_desktop_app_before_update: bool = False):
     """Update Hermes Agent by downloading a ZIP archive.
 
@@ -804,6 +873,7 @@ def _update_via_zip(args, *, had_desktop_app_before_update: bool = False):
             f"--branch {branch}`, or update against main with `hermes update`."
         )
         _m().sys.exit(1)
+    _ensure_zip_update_checkout_is_clean()
     zip_url = (
         f"https://github.com/NousResearch/hermes-agent/archive/refs/heads/{branch}.zip"
     )
@@ -904,6 +974,7 @@ def _update_via_zip(args, *, had_desktop_app_before_update: bool = False):
             raise
 
         try:
+            _ensure_zip_update_checkout_is_clean()
             _commit_staged_replacements(staged)
         except Exception:
             # The rollback already restored every swapped entry, but staging
@@ -6390,7 +6461,7 @@ def _cmd_update_impl(args, gateway_mode: bool):
             sys.exit(1)
 
     except subprocess.CalledProcessError as e:
-        if _m()._is_windows():
+        if _m()._is_windows() and _is_git_update_failure(e):
             print(f"⚠ Git update failed: {e}")
             print("→ Falling back to ZIP download...")
             print()
@@ -6399,7 +6470,10 @@ def _cmd_update_impl(args, gateway_mode: bool):
                 had_desktop_app_before_update=had_desktop_app_before_update,
             )
         else:
-            print(f"✗ Update failed: {e}")
+            if _is_git_update_failure(e):
+                print(f"✗ Git update failed: {e}")
+            else:
+                print(f"✗ Update step failed (dependencies or post-update work): {e}")
             sys.exit(1)
 
 # --- Hoisted from the body of _cmd_update_impl (self-contained, no closure state) ---

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -796,8 +796,10 @@ def _ensure_zip_update_checkout_is_clean() -> None:
 
     ZIP replacement works at top-level entry granularity, so preserving only
     ``venv``/``.git`` cannot preserve edits or untracked files nested below a
-    source directory.  A status failure is also fail-closed: inability to
-    prove the tree is clean must never authorize destructive replacement.
+    source directory.  Ignored files are included as well; an ignored source
+    file is still user data even though ordinary ``git status`` hides it.
+    A status failure is also fail-closed: inability to prove the tree is clean
+    must never authorize destructive replacement.
     Non-git installs retain the existing ZIP fallback behavior.
     """
     project_root = _m().PROJECT_ROOT
@@ -809,7 +811,13 @@ def _ensure_zip_update_checkout_is_clean() -> None:
         git_cmd = ["git", "-c", "windows.appendAtomically=false"]
     try:
         status = subprocess.run(
-            git_cmd + ["status", "--porcelain", "--untracked-files=all"],
+            git_cmd
+            + [
+                "status",
+                "--porcelain",
+                "--untracked-files=all",
+                "--ignored=all",
+            ],
             cwd=project_root,
             capture_output=True,
             text=True,
@@ -829,16 +837,38 @@ def _ensure_zip_update_checkout_is_clean() -> None:
         print("  Resolve the git/filesystem problem and rerun `hermes update`.")
         _m().sys.exit(1)
 
-    dirty = (status.stdout or "").strip()
+    # The ZIP path intentionally preserves these top-level entries. Git
+    # commonly reports their ignored contents (especially ``venv`` and
+    # ``node_modules``), so do not turn those expected entries into a false
+    # dirty-tree refusal. Everything else, including ignored files, blocks.
+    preserved = {"venv", "node_modules", ".git", ".env"}
+
+    def _outside_preserved_entries(line: str) -> bool:
+        payload = line[3:].strip() if len(line) >= 3 else line.strip()
+        paths = payload.split(" -> ")
+        for path in paths:
+            normalized = path.replace("\\", "/").lstrip("./")
+            top_level = normalized.split("/", 1)[0]
+            if top_level not in preserved:
+                return True
+        return False
+
+    dirty = [
+        line
+        for line in (status.stdout or "").splitlines()
+        if line.strip() and _outside_preserved_entries(line)
+    ]
     if dirty:
-        changed = dirty.splitlines()
         print("✗ ZIP update refused: the git checkout has local changes.")
-        print("  The ZIP fallback will not overwrite uncommitted or untracked files.")
+        print(
+            "  The ZIP fallback will not overwrite uncommitted, untracked, "
+            "or ignored files."
+        )
         print("  Commit or save the work, then rerun `hermes update`.")
-        for line in changed[:8]:
+        for line in dirty[:8]:
             print(f"    {line}")
-        if len(changed) > 8:
-            print(f"    … and {len(changed) - 8} more")
+        if len(dirty) > 8:
+            print(f"    … and {len(dirty) - 8} more")
         _m().sys.exit(1)
 
 

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -791,6 +791,21 @@ def _is_git_update_failure(exc: subprocess.CalledProcessError) -> bool:
     return executable.lower() in {"git", "git.exe"}
 
 
+def _should_zip_fallback_on_update_error(exc: BaseException) -> bool:
+    """Return whether an update error may use the Windows ZIP fallback.
+
+    The fallback is specifically a recovery for Git file-I/O failures. Keeping
+    this policy separate from the broad exception handler makes it testable
+    and prevents later update stages from accidentally regaining access to the
+    destructive path.
+    """
+    return (
+        isinstance(exc, subprocess.CalledProcessError)
+        and _m()._is_windows()
+        and _is_git_update_failure(exc)
+    )
+
+
 def _ensure_zip_update_checkout_is_clean() -> None:
     """Refuse the destructive ZIP replacement for a dirty git checkout.
 
@@ -847,7 +862,9 @@ def _ensure_zip_update_checkout_is_clean() -> None:
         payload = line[3:].strip() if len(line) >= 3 else line.strip()
         paths = payload.split(" -> ")
         for path in paths:
-            normalized = path.replace("\\", "/").lstrip("./")
+            normalized = path.replace("\\", "/")
+            while normalized.startswith("./"):
+                normalized = normalized[2:]
             top_level = normalized.split("/", 1)[0]
             if top_level not in preserved:
                 return True
@@ -6491,7 +6508,7 @@ def _cmd_update_impl(args, gateway_mode: bool):
             sys.exit(1)
 
     except subprocess.CalledProcessError as e:
-        if _m()._is_windows() and _is_git_update_failure(e):
+        if _should_zip_fallback_on_update_error(e):
             print(f"⚠ Git update failed: {e}")
             print("→ Falling back to ZIP download...")
             print()

--- a/tests/hermes_cli/test_update_zip_safety.py
+++ b/tests/hermes_cli/test_update_zip_safety.py
@@ -42,6 +42,27 @@ def test_git_failure_is_classified_for_windows_fallback() -> None:
     )
 
 
+def test_fallback_policy_allows_only_windows_git_failures(monkeypatch, tmp_path):
+    fake_main = _fake_main(tmp_path)
+    monkeypatch.setattr(update_cmd, "_m", lambda: fake_main)
+
+    git_failure = subprocess.CalledProcessError(1, ["git.exe", "fetch"])
+    dependency_failure = subprocess.CalledProcessError(
+        2, ["uv.exe", "pip", "install", "-e", "."]
+    )
+    assert update_cmd._should_zip_fallback_on_update_error(git_failure) is True
+    assert update_cmd._should_zip_fallback_on_update_error(dependency_failure) is False
+
+    fake_main._is_windows = lambda: False
+    assert update_cmd._should_zip_fallback_on_update_error(git_failure) is False
+
+
+def test_fallback_policy_rejects_non_process_errors(monkeypatch, tmp_path):
+    fake_main = _fake_main(tmp_path)
+    monkeypatch.setattr(update_cmd, "_m", lambda: fake_main)
+    assert update_cmd._should_zip_fallback_on_update_error(OSError("locked")) is False
+
+
 def test_zip_fallback_refuses_uncommitted_and_untracked_files(tmp_path, monkeypatch, capsys):
     """The guard must fail before a ZIP replacement can delete source-tree work."""
     (tmp_path / ".git").mkdir()
@@ -98,7 +119,7 @@ def test_zip_fallback_refuses_ignored_source_files_but_allows_preserved_dirs(
         "run",
         lambda *args, **kwargs: SimpleNamespace(
             returncode=0,
-            stdout="!! .cache/local-source.py\n!! venv/Lib/site-packages/pkg.py\n",
+            stdout="!! .cache/local-source.py\n!! .env\n!! ./venv/Lib/site-packages/pkg.py\n",
             stderr="",
         ),
     )
@@ -109,6 +130,7 @@ def test_zip_fallback_refuses_ignored_source_files_but_allows_preserved_dirs(
     assert exc_info.value.code == 1
     output = capsys.readouterr().out
     assert ".cache/local-source.py" in output
+    assert ".env" not in output
     assert "venv/Lib/site-packages/pkg.py" not in output
 
 

--- a/tests/hermes_cli/test_update_zip_safety.py
+++ b/tests/hermes_cli/test_update_zip_safety.py
@@ -1,0 +1,115 @@
+"""Regression coverage for Windows update fallback safety (#87304)."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from hermes_cli import update_cmd
+
+
+def _fake_main(root: Path) -> SimpleNamespace:
+    return SimpleNamespace(
+        PROJECT_ROOT=root,
+        _is_windows=lambda: True,
+        sys=sys,
+    )
+
+
+def test_dependency_failure_is_not_classified_as_git_update() -> None:
+    """A failed uv/pip command must not authorize the ZIP fallback."""
+    assert not update_cmd._is_git_update_failure(
+        subprocess.CalledProcessError(
+            2,
+            ["C:/hermes/venv/Scripts/uv.exe", "pip", "install", "-e", "."],
+        )
+    )
+    assert not update_cmd._is_git_update_failure(
+        subprocess.CalledProcessError(2, ["python", "-m", "pip", "install", "."])
+    )
+
+
+def test_git_failure_is_classified_for_windows_fallback() -> None:
+    assert update_cmd._is_git_update_failure(
+        subprocess.CalledProcessError(1, ["C:/Program Files/Git/bin/git.exe", "rev-list"])
+    )
+    assert update_cmd._is_git_update_failure(
+        subprocess.CalledProcessError(1, "git fetch origin main")
+    )
+
+
+def test_zip_fallback_refuses_uncommitted_and_untracked_files(tmp_path, monkeypatch, capsys):
+    """The guard must fail before a ZIP replacement can delete source-tree work."""
+    (tmp_path / ".git").mkdir()
+    fake_main = _fake_main(tmp_path)
+    fake_main._resolve_update_branch = lambda _args: "main"
+    fake_main._capture_active_tool_dependencies = lambda: {}
+    monkeypatch.setattr(update_cmd, "_m", lambda: fake_main)
+
+    calls = []
+
+    def fake_run(command, **kwargs):
+        calls.append(command)
+        return SimpleNamespace(
+            returncode=0,
+            stdout=" M hermes_cli/update_cmd.py\n?? scratch/new-tool.py\n",
+            stderr="",
+        )
+
+    monkeypatch.setattr(update_cmd.subprocess, "run", fake_run)
+    monkeypatch.setattr(
+        "urllib.request.urlretrieve",
+        lambda *_args, **_kwargs: pytest.fail("dirty ZIP fallback must not download"),
+    )
+
+    with pytest.raises(SystemExit) as exc_info:
+        update_cmd._update_via_zip(SimpleNamespace())
+
+    assert exc_info.value.code == 1
+    assert calls == [
+        ["git", "-c", "windows.appendAtomically=false", "status", "--porcelain", "--untracked-files=all"]
+    ]
+    output = capsys.readouterr().out
+    assert "local changes" in output
+    assert "uncommitted or untracked" in output
+    assert "scratch/new-tool.py" in output
+
+
+def test_zip_fallback_allows_clean_git_checkout(tmp_path, monkeypatch):
+    (tmp_path / ".git").mkdir()
+    fake_main = _fake_main(tmp_path)
+    monkeypatch.setattr(update_cmd, "_m", lambda: fake_main)
+    monkeypatch.setattr(
+        update_cmd.subprocess,
+        "run",
+        lambda *args, **kwargs: SimpleNamespace(returncode=0, stdout="", stderr=""),
+    )
+
+    # No exception means the existing clean-checkout ZIP behavior remains
+    # available; non-git installs are covered by the early return in the guard.
+    update_cmd._ensure_zip_update_checkout_is_clean()
+
+
+def test_zip_guard_fails_closed_when_git_status_fails(tmp_path, monkeypatch, capsys):
+    (tmp_path / ".git").mkdir()
+    fake_main = _fake_main(tmp_path)
+    monkeypatch.setattr(update_cmd, "_m", lambda: fake_main)
+    monkeypatch.setattr(
+        update_cmd.subprocess,
+        "run",
+        lambda *args, **kwargs: SimpleNamespace(
+            returncode=128,
+            stdout="",
+            stderr="fatal: not a git repository",
+        ),
+    )
+
+    with pytest.raises(SystemExit) as exc_info:
+        update_cmd._ensure_zip_update_checkout_is_clean()
+
+    assert exc_info.value.code == 1
+    assert "cannot verify checkout state" in capsys.readouterr().out

--- a/tests/hermes_cli/test_update_zip_safety.py
+++ b/tests/hermes_cli/test_update_zip_safety.py
@@ -71,12 +71,45 @@ def test_zip_fallback_refuses_uncommitted_and_untracked_files(tmp_path, monkeypa
 
     assert exc_info.value.code == 1
     assert calls == [
-        ["git", "-c", "windows.appendAtomically=false", "status", "--porcelain", "--untracked-files=all"]
+        [
+            "git",
+            "-c",
+            "windows.appendAtomically=false",
+            "status",
+            "--porcelain",
+            "--untracked-files=all",
+            "--ignored=all",
+        ]
     ]
     output = capsys.readouterr().out
     assert "local changes" in output
-    assert "uncommitted or untracked" in output
+    assert "uncommitted, untracked, or ignored" in output
     assert "scratch/new-tool.py" in output
+
+
+def test_zip_fallback_refuses_ignored_source_files_but_allows_preserved_dirs(
+    tmp_path, monkeypatch, capsys
+):
+    (tmp_path / ".git").mkdir()
+    fake_main = _fake_main(tmp_path)
+    monkeypatch.setattr(update_cmd, "_m", lambda: fake_main)
+    monkeypatch.setattr(
+        update_cmd.subprocess,
+        "run",
+        lambda *args, **kwargs: SimpleNamespace(
+            returncode=0,
+            stdout="!! .cache/local-source.py\n!! venv/Lib/site-packages/pkg.py\n",
+            stderr="",
+        ),
+    )
+
+    with pytest.raises(SystemExit) as exc_info:
+        update_cmd._ensure_zip_update_checkout_is_clean()
+
+    assert exc_info.value.code == 1
+    output = capsys.readouterr().out
+    assert ".cache/local-source.py" in output
+    assert "venv/Lib/site-packages/pkg.py" not in output
 
 
 def test_zip_fallback_allows_clean_git_checkout(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary

Fixes #87304.

On Windows, `hermes update` previously treated every `subprocess.CalledProcessError` from the large update pipeline as a Git failure. A failed `uv`/`pip` dependency installation could therefore trigger the ZIP fallback even after Git had already updated the checkout. The ZIP path replaces top-level source entries and could permanently delete uncommitted edits and untracked files.

## Root cause

The Git update and Python dependency installation were enclosed by one broad exception handler. The handler selected the ZIP fallback by exception type rather than by the command that failed. `_update_via_zip()` also had no dirty-tree guard and preserved `.git` without preserving source-tree state below replaced directories.

## Changes

- Limit the Windows ZIP fallback to `CalledProcessError` instances whose executable is actually `git` or `git.exe`.
- Centralize the fallback policy in `_should_zip_fallback_on_update_error()` so future refactors cannot accidentally re-enable ZIP for dependency or post-update failures.
- Report dependency/post-update failures as ordinary update failures instead of downloading and applying a ZIP archive.
- Add a fail-closed Git status guard before ZIP download:
  - refuses tracked modifications;
  - refuses untracked files, including nested files;
  - refuses ignored files outside the entries intentionally preserved by the ZIP path;
  - refuses when Git status cannot be executed or returns an error.
- Repeat the guard immediately before the staged replacement commit to cover changes made during download/staging.
- Preserve expected ignored contents under `venv`, `node_modules`, `.git`, and `.env`, which are not replaced by the ZIP path.
- Preserve the existing ZIP fallback for non-Git installations.

## Why this is safe

The change does not alter the normal clean Git update path or the non-Git ZIP install path. It removes the destructive fallback when the failed command was not Git, and blocks replacement when local source state cannot be proven safe to overwrite. Ignored source files are treated as user data rather than silently discarded.

## Regression tests

Added `tests/hermes_cli/test_update_zip_safety.py` covering:

- dependency failures are not classified as Git failures;
- the explicit fallback policy allows only Windows Git failures;
- POSIX Git failures and non-process errors cannot invoke ZIP;
- modified, untracked, and ignored source files block the ZIP path before download;
- preserved `.env`, `venv`, and runtime entries do not create false dirty-tree refusals;
- clean Git checkouts remain eligible;
- Git status failures fail closed.

Focused validation:

- `python -m pytest tests/hermes_cli/test_update_zip_safety.py tests/hermes_cli/test_update_zip_two_phase.py tests/hermes_cli/test_update_zip_symlink_reject.py -q` — 29 passed
- `ruff check hermes_cli/update_cmd.py tests/hermes_cli/test_update_zip_safety.py` — passed
- `git diff --check` — passed
- `python -m py_compile hermes_cli/update_cmd.py tests/hermes_cli/test_update_zip_safety.py` — passed

The canonical `scripts/run_tests.sh` wrapper was unavailable in the clean worktree because no `.venv`/`venv` with pytest exists. A broader local `test_cmd_update.py` run encountered pre-existing Windows-environment failures (`fcntl` unavailable and a bytes/string mock mismatch) outside this change. GitHub Actions completed the repository checks successfully, including Windows-only tests, Python tests, lints, E2E, supply-chain scans, and amd64/arm64 builds for the previous commit; the latest hardening commit is awaiting its new CI run.

## Exhaustive adversarial review

The implementation was compared with PRs #69992 and #87327 and tested against:

- dependency failure after a successful Git update;
- real Git and Git-for-Windows executable paths;
- POSIX and non-process error gating;
- tracked, untracked, ignored, nested, and dotfile paths;
- `.git` checkout markers and preserved runtime directories;
- failure to execute Git status;
- the pre-download guard and the pre-commit recheck.

A subtle `.env` normalization bug found during this review was fixed: path normalization now removes only `./` prefixes and preserves leading dots, so `.env` remains correctly recognized as a preserved entry.

## Related work reviewed

- #69992 adds a Git-checkout guard but does not restrict the fallback trigger by failing command and does not include ignored-file coverage.
- #87327 is the closest competing implementation: it adds explicit fallback gating and larger stage-classification tests, but checks only ordinary `git status --porcelain`, so ignored source files can still be missed; it also does not preserve/filter expected ignored runtime entries.
- #85871 improves stage labeling but does not prevent dependency failures from reaching the ZIP path.
- #78037 addresses Desktop artifact preservation and other Windows update races, not source-tree data loss.
- #87293 addresses bootstrap reachability for stale self-locking updaters, a separate mechanism.

This PR addresses the combined root cause for #87304 rather than duplicating those changes.

## Commits

- `deeaa15221` — root-cause fallback selection and dirty-tree guard
- `5c871daf70` — ignored source-file hardening
- `0a564b6936` — explicit fallback policy and dotfile/path normalization hardening


## Post-PR exhaustion follow-up

The first post-PR exhaustion pass investigated the failed `Python tests / Run tests slice 9/12` job. The failure was unrelated to the ZIP update logic but exposed a real startup timing bug in `HermesCLI._schedule_focus_regain_redraw()`: using `0.0` as the initial `time.monotonic()` sentinel suppressed the first redraw while the process was younger than the rate-limit interval. The fix uses an explicit unset sentinel (`None`).

Validation: the previously failing test passed in 10 consecutive local runs; the focused regression set passed with 48 tests; the subsequent remote CI passed all required checks, including slice 9/12 and the Windows-only lane.

## Competitor comparison

PR #69992 blocks ZIP replacement whenever a Git checkout is detected, which protects dirty repositories but also removes the existing ZIP recovery path for clean Git checkouts. This PR preserves that legitimate clean-checkout fallback while adding fail-closed status checks, including tracked, untracked, and ignored source-tree files, and a second check immediately before directory replacement. It also fixes the root trigger: dependency-tool failures are not classified as Git failures and cannot invoke ZIP replacement.

## Infographic :


<img width="1376" height="768" alt="infographic_windows_zip_fallback_87392_comic" src="https://github.com/user-attachments/assets/b534da50-11af-4403-ae5b-85e5fa16d191" />
