### PR TITLE
fix(acp): tolerate None final_response after interrupted turns

### DIFF
--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -2002,7 +2002,14 @@ class HermesACPAgent(acp.Agent):
                     exc_info=True,
                 )
 
-        final_response = result.get("final_response", "")
+        # ``final_response`` is not guaranteed to be a str: interrupted or
+        # truncation-exhausted turns come back with an explicit None (e.g.
+        # conversation_loop returns ``partial_response or None``). The
+        # ``.get`` default only covers an *absent* key, so normalize None
+        # here — otherwise the startswith below raises AttributeError,
+        # which the ACP host sees as a JSON-RPC -32603 internal error while
+        # the session stays is_running and queued follow-ups wedge (#87387).
+        final_response = result.get("final_response") or ""
         cancelled = bool(state.cancel_event and state.cancel_event.is_set())
         interrupted = bool(result.get("interrupted")) or cancelled
         # Hermes' local "waiting for model response" interrupt status is metadata,

--- a/tests/acp/test_server.py
+++ b/tests/acp/test_server.py
@@ -446,6 +446,56 @@ class TestPrompt:
 
         assert captured.get("child") == resp.session_id
 
+    @pytest.mark.asyncio
+    async def test_prompt_survives_interrupted_turn_with_none_final_response(
+        self, agent, mock_manager
+    ):
+        """Regression (#87387): an interrupted turn can come back from
+        ``run_conversation`` with a present-but-None ``final_response`` (e.g.
+        the truncation-continuation path returns ``partial_response or None``).
+        The post-turn tail used to call ``final_response.startswith(...)``
+        whenever ``interrupted`` was set, raising AttributeError — surfaced to
+        the ACP host as a JSON-RPC -32603 internal error, with the session left
+        ``is_running`` and queued follow-ups wedged forever. The tail must
+        tolerate None: end the turn, return the session to idle, and drain the
+        queued follow-up.
+        """
+        import threading
+
+        resp = await agent.new_session(cwd=".")
+        state = mock_manager.get_session(resp.session_id)
+
+        calls: list[str] = []
+
+        def _run(*args, **kwargs):
+            calls.append(str(kwargs.get("user_message", "")))
+            state.cancel_event.set()
+            return {"final_response": None, "messages": [], "interrupted": True}
+
+        state.agent.run_conversation = _run
+        state.agent.model = "test-model"
+        state.agent.provider = "openrouter"
+        # prompt() clears the cancel event on entry, so the cancel has to
+        # land mid-turn (as a real SIGINT-driven session/cancel does).
+        state.cancel_event = threading.Event()
+        state.queued_prompts.append("follow-up after interrupt")
+
+        mock_conn = MagicMock(spec=acp.Client)
+        mock_conn.session_update = AsyncMock()
+        agent._conn = mock_conn
+
+        result = await agent.prompt(
+            prompt=[TextContentBlock(type="text", text="hi")],
+            session_id=resp.session_id,
+        )
+
+        assert isinstance(result, PromptResponse)
+        assert result.stop_reason == "cancelled"
+        assert state.is_running is False
+        # The queued follow-up must drain instead of wedging: the initial
+        # turn plus the drained follow-up both reached run_conversation.
+        assert len(calls) == 2
+
 
 
 


### PR DESCRIPTION
## What does this PR do?

Fixes a crash in the ACP adapter's post-turn tail: when a turn ends **interrupted** with a present-but-`None` `final_response`, the tail called `final_response.startswith(INTERRUPT_WAITING_FOR_MODEL_PREFIX)` and raised `AttributeError: 'NoneType' object has no attribute 'startswith'`, which the ACP host received as a JSON-RPC `-32603` internal error. Because the crash fired *before* `state.is_running = False` and before the queued-prompt drain loop, the session stayed "running" forever and queued follow-up messages were stuck — exactly the two symptoms in #87387.

`run_conversation` legitimately returns `None` for `final_response` (the key is present, the value is `None`): e.g. `conversation_loop.py` returns `"final_response": partial_response or None` on the truncation-continuation-exhausted path, and the main loop sets `final_response = None` on several acknowledgment/nudge continuation branches. The old `result.get("final_response", "")` default only covered an *absent* key, not an explicit `None`. This PR normalizes the value at the adapter boundary (`result.get("final_response") or ""`), so an interrupted turn now finishes cleanly: `stop_reason="cancelled"`, the session returns to idle, and queued follow-ups drain.

The issue also lists the remaining `startswith` candidates (`server.py` ~506/1667/1690/1712): all are already unreachable with `None` — 506 builds `data` via `str(... or "")`, and 1667/1690/1712 are guarded by `isinstance(user_content, str)` with `user_text` produced by `_extract_text()`, which always returns a `str`.

## Related Issue

Fixes #87387

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `acp_adapter/server.py` — normalize `final_response` to `""` when the turn result carries an explicit `None` (interrupted / truncation-exhausted turns), with a comment documenting the contract; this removes the only `None`-reachable `.startswith()` on the interrupt path.
- `tests/acp/test_server.py` — regression test `test_prompt_survives_interrupted_turn_with_none_final_response`: drives `prompt()` with `run_conversation` returning `{"final_response": None, "interrupted": True}` and a mid-turn `cancel_event.set()`, asserting `stop_reason == "cancelled"`, `state.is_running is False`, and that a queued follow-up drains (two `run_conversation` calls).

## How to Test

1. `uv run --extra acp pytest tests/acp/test_server.py -k none_final_response -q` — should pass with this PR.
2. Observed result on unpatched `upstream/main`: the same test fails with `AttributeError: 'NoneType' object has no attribute 'startswith'` at `acp_adapter/server.py:2012` — the exact signature reported on the host side in #87387 (`-32603`).
3. `uv run --extra acp pytest tests/acp/ -q` — Observed result: `127 passed`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
