### PR TITLE
feat(gateway): per-platform STT transcript echo config

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -1164,6 +1164,10 @@ platform_toolsets:
 #       # Route scripts default to a 30 second timeout. Scripts must live under
 #       # the active profile's scripts directory and receive webhook JSON on stdin.
 #       script_timeout_seconds: 30
+#   signal:
+#     # Silence the 🎙️ STT transcript echo on this platform. Overrides the
+#     # global stt.echo_transcripts default for Signal only.
+#     show_stt_transcription: false
 #
 # Discord-specific settings (config.yaml top-level, not under platforms:):
 #

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -674,6 +674,14 @@ class PlatformConfig:
     # Telegram, Matrix, …) ignore it.
     typing_status_text: Optional[str] = None
 
+    # Whether to echo the 🎙️ STT transcript for inbound voice messages on this
+    # platform. Overrides the global ``stt_echo_transcripts`` default for this
+    # platform when set; ``None`` (default) defers to the global setting. Set
+    # ``platforms.<platform>.show_stt_transcription: false`` to silence the
+    # transcript echo here while keeping it enabled on other platforms.
+    show_stt_transcription: Optional[bool] = None
+
+
     # Per-channel model/provider/system_prompt overrides (channel_id -> ChannelOverride)
     channel_overrides: Dict[str, ChannelOverride] = field(default_factory=dict)
 
@@ -690,6 +698,8 @@ class PlatformConfig:
         }
         if self.typing_status_text is not None:
             result["typing_status_text"] = self.typing_status_text
+        if self.show_stt_transcription is not None:
+            result["show_stt_transcription"] = self.show_stt_transcription
         if self.token:
             result["token"] = self.token
         if self.api_key:
@@ -731,6 +741,13 @@ class PlatformConfig:
         if _typing_text is None:
             _typing_text = extra.get("typing_status_text")
 
+        # show_stt_transcription mirrors gateway_restart_notification /
+        # typing_indicator: it may arrive top-level or bridged into extra.
+        _show_stt = data.get("show_stt_transcription")
+        if _show_stt is None:
+            _show_stt = extra.get("show_stt_transcription")
+
+
         channel_overrides: Dict[str, ChannelOverride] = {}
         raw_overrides = data.get("channel_overrides") or {}
         if isinstance(raw_overrides, dict):
@@ -747,6 +764,7 @@ class PlatformConfig:
             gateway_restart_notification=_coerce_bool(_grn, True),
             typing_indicator=_coerce_bool(_typing, True),
             typing_status_text=_typing_text,
+            show_stt_transcription=_coerce_bool(_show_stt, None),
             channel_overrides=channel_overrides,
             extra=extra,
         )
@@ -957,7 +975,9 @@ class GatewayConfig:
 
     # STT settings
     stt_enabled: bool = True  # Whether to auto-transcribe inbound voice messages
-    stt_echo_transcripts: bool = True  # Whether to echo raw STT transcripts back to the user
+    # Whether to echo raw STT transcripts back to the user. Global default;
+    # a per-platform override can be set with ``platforms.<platform>.show_stt_transcription``.
+    stt_echo_transcripts: bool = True
 
     # Session isolation in shared chats
     group_sessions_per_user: bool = True  # Isolate group/channel sessions per participant when user IDs are available

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -17733,7 +17733,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 # when configured. Lets users verify STT quality in real-time,
                 # while allowing quiet STT for users who only want the agent to
                 # receive the transcription.
-                if _successful_transcripts and self._should_echo_stt_transcripts():
+                if _successful_transcripts and self._should_echo_stt_transcripts(source.platform):
                     _echo_adapter = self._adapter_for_source(source)
                     _echo_meta = self._thread_metadata_for_source(source, self._reply_anchor_for_event(event))
                     if _echo_adapter:
@@ -21604,9 +21604,29 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         return True
 
-    def _should_echo_stt_transcripts(self) -> bool:
-        """Return whether inbound voice/STT transcripts should be echoed to chat."""
-        return bool(getattr(self.config, "stt_echo_transcripts", True))
+    def _should_echo_stt_transcripts(self, platform=None) -> bool:
+        """Return whether inbound voice/STT transcripts should be echoed to chat.
+
+        The global ``stt_echo_transcripts`` default applies unless the given
+        platform configures ``show_stt_transcription`` (``PlatformConfig``),
+        which overrides it for that platform. ``platform`` may be a
+        ``Platform`` enum or a string platform id; it is normalized so a
+        per-platform override can never silently no-op on a key-type mismatch.
+        """
+        global_default = bool(getattr(self.config, "stt_echo_transcripts", True))
+        if platform is None:
+            return global_default
+        if not isinstance(platform, Platform):
+            try:
+                platform = Platform(platform)
+            except (TypeError, ValueError):
+                return global_default
+        pc = getattr(self.config, "platforms", {}).get(platform)
+        if pc is not None:
+            override = getattr(pc, "show_stt_transcription", None)
+            if override is not None:
+                return bool(override)
+        return global_default
 
     async def _send_voice_reply(self, event: MessageEvent, text: str) -> None:
         """Generate TTS audio and send as a voice message before the text reply."""
@@ -24238,7 +24258,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         """
         if (
             not transcripts
-            or not self._should_echo_stt_transcripts()
+            or not self._should_echo_stt_transcripts(getattr(source, "platform", None))
             or adapter is None
         ):
             return

--- a/tests/gateway/test_show_stt_transcription_config.py
+++ b/tests/gateway/test_show_stt_transcription_config.py
@@ -1,0 +1,88 @@
+"""Per-platform STT transcript echo configuration.
+
+Covers the ``PlatformConfig.show_stt_transcription`` per-platform override and
+the ``_should_echo_stt_transcripts(platform)`` resolution logic (including
+string/string-enum platform normalization).
+"""
+from types import SimpleNamespace
+
+from gateway.config import Platform, PlatformConfig
+from gateway.run import GatewayRunner
+
+
+# --- PlatformConfig.show_stt_transcription --------------------------------
+
+def test_show_stt_transcription_default_is_none():
+    assert PlatformConfig.from_dict({}).show_stt_transcription is None
+
+
+def test_show_stt_transcription_parsed_from_top_level():
+    pc = PlatformConfig.from_dict({"show_stt_transcription": False})
+    assert pc.show_stt_transcription is False
+
+
+def test_show_stt_transcription_parsed_from_extra():
+    pc = PlatformConfig.from_dict({"extra": {"show_stt_transcription": False}})
+    assert pc.show_stt_transcription is False
+
+
+def test_show_stt_transcription_round_trips_through_to_dict():
+    pc = PlatformConfig.from_dict({"show_stt_transcription": False})
+    assert pc.to_dict()["show_stt_transcription"] is False
+    # Omitted when None (backward compatible with older serialized output).
+    assert "show_stt_transcription" not in PlatformConfig.from_dict({}).to_dict()
+
+
+# --- _should_echo_stt_transcripts(platform) resolution --------------------
+
+def _runner(echo_default=True, platforms=None):
+    runner = object.__new__(GatewayRunner)
+    runner.config = SimpleNamespace(
+        stt_echo_transcripts=echo_default,
+        platforms=platforms or {},
+    )
+    return runner
+
+
+def test_echo_uses_global_default_when_no_override():
+    runner = _runner(echo_default=True)
+    assert runner._should_echo_stt_transcripts() is True
+    assert runner._should_echo_stt_transcripts(Platform.SIGNAL) is True
+    assert runner._should_echo_stt_transcripts(Platform.TELEGRAM) is True
+
+
+def test_echo_global_off_applies_to_all_when_no_override():
+    runner = _runner(echo_default=False)
+    assert runner._should_echo_stt_transcripts(Platform.SIGNAL) is False
+
+
+def test_echo_per_platform_false_overrides_global_true():
+    runner = _runner(
+        echo_default=True,
+        platforms={Platform.SIGNAL: PlatformConfig.from_dict({"show_stt_transcription": False})},
+    )
+    assert runner._should_echo_stt_transcripts(Platform.SIGNAL) is False
+    # Other platforms still use the global default.
+    assert runner._should_echo_stt_transcripts(Platform.TELEGRAM) is True
+
+
+def test_echo_per_platform_true_overrides_global_false():
+    runner = _runner(
+        echo_default=False,
+        platforms={Platform.SIGNAL: PlatformConfig.from_dict({"show_stt_transcription": True})},
+    )
+    assert runner._should_echo_stt_transcripts(Platform.SIGNAL) is True
+    assert runner._should_echo_stt_transcripts(Platform.TELEGRAM) is False
+
+
+def test_echo_string_platform_id_normalizes_to_enum():
+    runner = _runner(
+        echo_default=True,
+        platforms={Platform.SIGNAL: PlatformConfig.from_dict({"show_stt_transcription": False})},
+    )
+    assert runner._should_echo_stt_transcripts("signal") is False
+
+
+def test_echo_unknown_string_platform_falls_back_to_global():
+    runner = _runner(echo_default=True)
+    assert runner._should_echo_stt_transcripts("not-a-real-platform") is True

--- a/tests/gateway/test_telegram_voice_v0_regressions.py
+++ b/tests/gateway/test_telegram_voice_v0_regressions.py
@@ -117,7 +117,7 @@ def _run_agent_runner(adapter):
     runner._queued_events = {}
     runner._draining = False
     runner.hooks = SimpleNamespace(loaded_hooks=False)
-    runner._should_echo_stt_transcripts = lambda: True
+    runner._should_echo_stt_transcripts = lambda _platform: True
     return runner
 
 


### PR DESCRIPTION
## What does this PR do?
Makes STT transcript echo configurable per platform. The reserved-but-unused `platforms.<platform>.show_stt_transcription` key is now wired up as a real `PlatformConfig` field that overrides the global `stt_echo_transcripts` default for that platform, so operators can silence (or force) the 🎙️ transcript echo per platform via config instead of code.

## Type of Change
- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made
- `gateway/config.py` — added `PlatformConfig.show_stt_transcription: Optional[bool]` (parsed from top-level or `extra`), serialized in `to_dict`.
- `gateway/run.py` — `_should_echo_stt_transcripts(platform)` now resolves the per-platform override; both call sites pass the source platform.
- `cli-config.yaml.example` — documented the key.
- `tests/gateway/test_show_stt_transcription_config.py` — config parsing + resolution tests.
- `tests/gateway/test_telegram_voice_v0_regressions.py` — updated a mock lambda to accept the new platform argument.

## How to Test
1. `stt.echo_transcripts: true` globally, `platforms.signal.show_stt_transcription: false`.
2. Send a voice note on Signal → no 🎙️ transcript echo; on other platforms the echo still appears.
3. Flip the per-platform value → behavior reverses.

## Checklist
- [x] Conventional commit message
- [x] PR contains only changes related to this feature
- [x] Tests added and passing
- [x] Tested on Linux (self-hosted HA1)