### PR TITLE
feat(gateway): per-platform suppress_text_when_voice for voice replies

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -1164,6 +1164,11 @@ platform_toolsets:
 #       # Route scripts default to a 30 second timeout. Scripts must live under
 #       # the active profile's scripts directory and receive webhook JSON on stdin.
 #       script_timeout_seconds: 30
+#   signal:
+#     # Drop the redundant written text when a voice reply (TTS speak or a
+#     # MEDIA voice clip) is delivered with no other non-voice content — useful
+#     # where voice notes arrive as caption-less attachments (e.g. Signal).
+#     suppress_text_when_voice: true
 #
 # Discord-specific settings (config.yaml top-level, not under platforms:):
 #

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -674,6 +674,16 @@ class PlatformConfig:
     # Telegram, Matrix, …) ignore it.
     typing_status_text: Optional[str] = None
 
+
+    # When True, a voice reply (auto-TTS speak or a MEDIA voice clip) that
+    # carries no other non-voice media (images/documents) suppresses the
+    # redundant written text on this platform. Useful where voice notes arrive
+    # as caption-less attachments (e.g. Signal), so the user doesn't receive
+    # audio and the same text twice. Default False preserves the historical
+    # always-send-text behavior; opt in per platform with
+    # ``platforms.<platform>.suppress_text_when_voice: true``.
+    suppress_text_when_voice: bool = False
+
     # Per-channel model/provider/system_prompt overrides (channel_id -> ChannelOverride)
     channel_overrides: Dict[str, ChannelOverride] = field(default_factory=dict)
 
@@ -687,6 +697,7 @@ class PlatformConfig:
             "reply_to_mode": self.reply_to_mode,
             "gateway_restart_notification": self.gateway_restart_notification,
             "typing_indicator": self.typing_indicator,
+            "suppress_text_when_voice": self.suppress_text_when_voice,
         }
         if self.typing_status_text is not None:
             result["typing_status_text"] = self.typing_status_text
@@ -731,6 +742,12 @@ class PlatformConfig:
         if _typing_text is None:
             _typing_text = extra.get("typing_status_text")
 
+
+        # suppress_text_when_voice takes the same two routes.
+        _suppress_voice = data.get("suppress_text_when_voice")
+        if _suppress_voice is None:
+            _suppress_voice = extra.get("suppress_text_when_voice")
+
         channel_overrides: Dict[str, ChannelOverride] = {}
         raw_overrides = data.get("channel_overrides") or {}
         if isinstance(raw_overrides, dict):
@@ -747,6 +764,7 @@ class PlatformConfig:
             gateway_restart_notification=_coerce_bool(_grn, True),
             typing_indicator=_coerce_bool(_typing, True),
             typing_status_text=_typing_text,
+            suppress_text_when_voice=_coerce_bool(_suppress_voice, False),
             channel_overrides=channel_overrides,
             extra=extra,
         )

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -6198,11 +6198,53 @@ class BasePlatformAdapter(ABC):
             max_ms = 2500
         return random.uniform(min_ms / 1000.0, max_ms / 1000.0)
 
+    def _should_suppress_text_on_voice(
+        self,
+        *,
+        voice_delivered: bool,
+        media_files,
+        images,
+        local_files,
+    ) -> bool:
+        """Return whether the redundant text reply should be dropped for a voice
+        delivery on this platform.
+
+        Enabled per platform by ``suppress_text_when_voice``. When on, a voice
+        reply — one that was actually delivered this turn (``voice_delivered``)
+        or a MEDIA voice clip still queued for delivery — with no other
+        non-voice content (images/documents) suppresses the written text. On
+        platforms whose voice notes arrive as caption-less attachments (e.g.
+        Signal) this avoids delivering audio plus the same text twice.
+        """
+        if not getattr(self.config, "suppress_text_when_voice", False):
+            return False
+        _has_voice = voice_delivered or any(
+            is_voice for _, is_voice in (media_files or [])
+        )
+        _has_non_voice = (
+            bool(images)
+            or bool(local_files)
+            or any(not is_voice for _, is_voice in (media_files or []))
+        )
+        return _has_voice and not _has_non_voice
+
     async def _process_message_background(self, event: MessageEvent, session_key: str) -> None:
         """Background task that actually processes the message."""
         # Track delivery outcomes for the processing-complete hook
         delivery_attempted = False
         delivery_succeeded = False
+        # Whether a voice reply was actually delivered this turn (auto-TTS or a
+        # MEDIA voice clip). Drives text suppression so the written text is
+        # only dropped when a voice really went out, and so a failed voice
+        # never gets reported as a successful delivery.
+        _voice_delivered_ok = False
+        # Text deferred until after a queued MEDIA voice clip is sent, so a
+        # failed voice can fall back to the text reply.
+        _deferred_text = None
+        # Whether the redundant text reply was suppressed in favor of a voice
+        # delivery this turn. Initialized so the success path can read it even
+        # when the ``if response:`` block is skipped for a falsy response.
+        _suppress_text = False
 
         def _record_delivery(result):
             nonlocal delivery_attempted, delivery_succeeded
@@ -6447,6 +6489,8 @@ class BasePlatformAdapter(ABC):
                             metadata=_final_thread_metadata,
                         )
                         _record_delivery(tts_result)
+                        if getattr(tts_result, "success", False):
+                            _voice_delivered_ok = True
                         _tts_caption_delivered = bool(
                             _tts_caption_delivered
                             or (
@@ -6470,12 +6514,12 @@ class BasePlatformAdapter(ABC):
                 # adapter while its in-flight handler was still producing a
                 # final response; that response is a new message, so resolve
                 # the current transport before sending it.
-                if text_content and not _tts_caption_delivered:
+                async def _send_text(text_to_send):
                     delivery_adapter = self._final_delivery_adapter(event.source)
                     logger.info(
                         "[%s] Sending response (%d chars) to %s",
                         delivery_adapter.name,
-                        len(text_content),
+                        len(text_to_send),
                         event.source.chat_id,
                     )
                     _reply_anchor = _reply_anchor_for_event(event)
@@ -6503,7 +6547,7 @@ class BasePlatformAdapter(ABC):
                                 _obligation_id = compute_obligation_id(
                                     session_key,
                                     str(getattr(event, "message_id", "") or ""),
-                                    text_content,
+                                    text_to_send,
                                 )
                                 await asyncio.to_thread(
                                     record_obligation,
@@ -6515,7 +6559,7 @@ class BasePlatformAdapter(ABC):
                                     ),
                                     chat_id=event.source.chat_id,
                                     thread_id=getattr(event.source, "thread_id", None),
-                                    content=text_content,
+                                    content=text_to_send,
                                 )
                                 await asyncio.to_thread(mark_attempting, _obligation_id)
                         except Exception:
@@ -6523,7 +6567,7 @@ class BasePlatformAdapter(ABC):
                             _obligation_id = None
                     result = await delivery_adapter._send_with_retry(
                         chat_id=event.source.chat_id,
-                        content=text_content,
+                        content=text_to_send,
                         reply_to=_reply_anchor,
                         metadata=_final_thread_metadata,
                     )
@@ -6561,6 +6605,27 @@ class BasePlatformAdapter(ABC):
                             message_id=result.message_id,
                             ttl_seconds=_ephemeral_ttl,
                         )
+                    return result
+
+                if text_content and not _tts_caption_delivered:
+                    # Optional per-platform text suppression for voice replies.
+                    # Suppress only when a voice was actually delivered (auto-TTS
+                    # already sent) or a MEDIA voice clip is still queued, and
+                    # there is no other non-voice content. A queued voice clip
+                    # defers the decision until after the media send so a failed
+                    # voice can fall back to the text reply.
+                    _suppress_text = self._should_suppress_text_on_voice(
+                        voice_delivered=_voice_delivered_ok,
+                        media_files=media_files,
+                        images=images,
+                        local_files=local_files,
+                    )
+                    if _suppress_text and any(is_voice for _, is_voice in media_files):
+                        _deferred_text = text_content
+                    elif not _suppress_text:
+                        await _send_text(text_content)
+                else:
+                    _suppress_text = False
 
                 # Human-like pacing delay between text and media
                 human_delay = self._get_human_delay()
@@ -6656,6 +6721,9 @@ class BasePlatformAdapter(ABC):
                                 metadata=_final_thread_metadata,
                             )
 
+                        if is_voice and getattr(media_result, "success", False):
+                            _voice_delivered_ok = True
+
                         if not media_result.success:
                             logger.warning("[%s] Failed to send media (%s): %s", self.name, ext, media_result.error)
                             await self._notify_media_delivery_failure(
@@ -6700,6 +6768,21 @@ class BasePlatformAdapter(ABC):
                     except Exception as file_err:
                         logger.error("[%s] Error sending local file %s: %s", self.name, file_path, file_err)
 
+                # Resolve deferred text (a queued MEDIA voice clip that would
+                # have suppressed the text). If the voice actually delivered,
+                # keep the text suppressed; otherwise send the text fallback so
+                # the user still receives the reply and the failure is surfaced.
+                if _deferred_text is not None:
+                    if _voice_delivered_ok:
+                        _suppress_text = True
+                    else:
+                        logger.error(
+                            "[%s] voice delivery failed; sending text fallback (%d chars) to %s",
+                            self.name, len(_deferred_text), event.source.chat_id,
+                        )
+                        await _send_text(_deferred_text)
+                        _suppress_text = False
+
                 # A3 (#29346): if a non-empty response produced nothing
                 # deliverable, fail loudly rather than dropping it in silence.
                 _anything_delivered = (
@@ -6716,6 +6799,15 @@ class BasePlatformAdapter(ABC):
 
             # Determine overall success for the processing hook
             processing_ok = delivery_succeeded if delivery_attempted else not bool(response)
+            # When the text was intentionally suppressed because a voice reply
+            # was ACTUALLY delivered this turn, delivery was NOT a failure — the
+            # voice WAS the delivery. A failed voice clears ``_suppress_text``
+            # (and sends the text fallback above), so it is reported honestly
+            # through delivery_attempted/delivery_succeeded instead.
+            if _suppress_text and _voice_delivered_ok:
+                delivery_attempted = True
+                delivery_succeeded = True
+                processing_ok = True
             # Clean up the per-turn streaming-TTS flag (#60671).
             self._streaming_tts_completed_turns.discard(
                 self._streaming_tts_turn_key(

--- a/tests/gateway/test_suppress_text_on_voice_delivery.py
+++ b/tests/gateway/test_suppress_text_on_voice_delivery.py
@@ -1,0 +1,221 @@
+"""Integration tests for the voice-delivery failure path.
+
+These exercise ``BasePlatformAdapter._process_message_background`` end-to-end
+for the reviewer scenario in the ``suppress_text_when_voice`` feature: the
+auto-TTS voice is generated but its *send* fails. The written text must still
+go out as a fallback, and the turn must be reported honestly — never masked as
+SUCCESS by the text-suppression shortcut when no voice actually landed.
+"""
+
+import asyncio
+import json
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from gateway.config import Platform, PlatformConfig
+from gateway.platforms.base import (
+    BasePlatformAdapter,
+    MessageEvent,
+    MessageType,
+    ProcessingOutcome,
+    SendResult,
+)
+from gateway.session import SessionSource, build_session_key
+
+
+class _DummyAdapter(BasePlatformAdapter):
+    def __init__(self, platform: Platform):
+        super().__init__(PlatformConfig(enabled=True, token="fake-token"), platform)
+        self.sent = []
+
+    async def connect(self, *, is_reconnect: bool = False) -> bool:
+        return True
+
+    async def disconnect(self) -> None:
+        return None
+
+    async def send(self, chat_id, content, reply_to=None, metadata=None) -> SendResult:
+        self.sent.append({"chat_id": chat_id, "content": content})
+        return SendResult(success=True, message_id="1")
+
+    async def send_typing(self, chat_id: str, metadata=None) -> None:
+        return None
+
+    async def stop_typing(self, chat_id: str, metadata=None) -> None:
+        return None
+
+    async def get_chat_info(self, chat_id: str):
+        return {"id": chat_id}
+
+
+def _make_voice_event(platform: Platform) -> MessageEvent:
+    return MessageEvent(
+        text="hello",
+        message_type=MessageType.VOICE,
+        source=SessionSource(
+            platform=platform,
+            chat_id="-1001",
+            chat_type="group",
+        ),
+        message_id="voice-1",
+    )
+
+
+def _hold_typing():
+    async def hold(*_args, **_kwargs):
+        await asyncio.Event().wait()
+
+    return hold
+
+
+def _fake_tts(*, text, output_path=None):
+    from pathlib import Path
+
+    Path(output_path).parent.mkdir(parents=True, exist_ok=True)
+    Path(output_path).write_bytes(b"fake audio")
+    return json.dumps({"success": True, "file_path": output_path})
+
+
+async def _run(adapter, *, voice_send_ok: bool, text_send_ok: bool):
+    adapter._keep_typing = _hold_typing()
+    adapter._should_auto_tts_for_chat = lambda _chat_id: True
+    adapter.config.suppress_text_when_voice = True
+    adapter.play_tts = AsyncMock(
+        return_value=SendResult(success=voice_send_ok, message_id="tts-1", error=None if voice_send_ok else "rpc down")
+    )
+    if not text_send_ok:
+        adapter._send_with_retry = AsyncMock(
+            return_value=SendResult(success=False, error="rpc down")
+        )
+    adapter.set_message_handler(lambda _event: asyncio.sleep(0, result="reply text"))
+    event = _make_voice_event(Platform.SIGNAL)
+
+    outcomes = []
+
+    async def _capture(hook_name, *args, **kwargs):
+        if hook_name == "on_processing_complete":
+            outcomes.append(args[-1])
+
+    with patch("tools.tts_tool.check_tts_requirements", return_value=True), patch(
+        "tools.tts_tool.text_to_speech_tool", side_effect=_fake_tts
+    ), patch.object(adapter, "_run_processing_hook", side_effect=_capture):
+        await adapter._process_message_background(event, build_session_key(event.source))
+    return adapter, outcomes
+
+
+@pytest.mark.asyncio
+async def test_voice_send_failure_falls_back_to_text():
+    """When the auto-TTS voice *send* fails, the text reply still goes out."""
+    adapter, outcomes = await _run(
+        _DummyAdapter(Platform.SIGNAL), voice_send_ok=False, text_send_ok=True
+    )
+    adapter.play_tts.assert_awaited()  # voice was attempted
+    assert any(m["content"] == "reply text" for m in adapter.sent), adapter.sent
+
+
+@pytest.mark.asyncio
+async def test_voice_send_failure_with_failed_text_reports_failure():
+    """Voice send fails *and* text fallback fails -> turn reports FAILURE.
+
+    This is the case the old ``if _suppress_text:`` shortcut got wrong: it
+    would mark the turn SUCCESS even though neither audio nor text landed.
+    """
+    adapter, outcomes = await _run(
+        _DummyAdapter(Platform.SIGNAL), voice_send_ok=False, text_send_ok=False
+    )
+    assert outcomes, "on_processing_complete hook did not fire"
+    assert outcomes[-1] is ProcessingOutcome.FAILURE
+
+
+@pytest.mark.asyncio
+async def test_voice_delivered_suppresses_text_and_reports_success():
+    """Voice delivered OK -> text suppressed and turn reported SUCCESS."""
+    adapter, outcomes = await _run(
+        _DummyAdapter(Platform.SIGNAL), voice_send_ok=True, text_send_ok=True
+    )
+    adapter.play_tts.assert_awaited()
+    # Text was suppressed (no redundant text), but the turn still succeeded.
+    assert not any(m["content"] == "reply text" for m in adapter.sent), adapter.sent
+    assert outcomes and outcomes[-1] is ProcessingOutcome.SUCCESS
+
+
+@pytest.mark.asyncio
+async def test_media_voice_clip_suppresses_text():
+    """An agent-attached voice clip (``[[audio_as_voice]]`` + ``MEDIA:`` tag)
+    also suppresses the redundant text, matching the auto-TTS path.
+
+    This is the agent-tool voice path: the model calls ``text_to_speech``,
+    which returns ``[[audio_as_voice]]\\nMEDIA:<path>``, and the gateway must
+    drop the written text the same way it does for auto-TTS voice.
+    """
+    from pathlib import Path
+
+    adapter = _DummyAdapter(Platform.SIGNAL)
+    adapter.config.suppress_text_when_voice = True
+    adapter._keep_typing = _hold_typing()
+    adapter._should_auto_tts_for_chat = lambda _chat_id: False  # no auto-TTS
+    adapter.send_voice = AsyncMock(
+        return_value=SendResult(success=True, message_id="voice-1")
+    )
+
+    voice_path = Path("/tmp/voice_test_clip.ogg")
+    voice_path.write_bytes(b"fake audio")
+
+    adapter.set_message_handler(
+        lambda _event: asyncio.sleep(
+            0, result=f"reply text\n\n[[audio_as_voice]]\nMEDIA:{voice_path}"
+        )
+    )
+    event = MessageEvent(
+        text="hello",
+        message_type=MessageType.TEXT,
+        source=SessionSource(
+            platform=Platform.SIGNAL, chat_id="-1001", chat_type="group"
+        ),
+        message_id="m-1",
+    )
+
+    with patch("tools.tts_tool.check_tts_requirements", return_value=True):
+        await adapter._process_message_background(event, build_session_key(event.source))
+
+    adapter.send_voice.assert_awaited()
+    assert not any(m["content"] == "reply text" for m in adapter.sent), adapter.sent
+
+
+@pytest.mark.asyncio
+async def test_media_voice_clip_send_failure_falls_back_to_text():
+    """If an agent-attached voice clip fails to send, the text fallback goes out
+    (deferred text is released instead of leaving the user with nothing)."""
+    from pathlib import Path
+
+    adapter = _DummyAdapter(Platform.SIGNAL)
+    adapter.config.suppress_text_when_voice = True
+    adapter._keep_typing = _hold_typing()
+    adapter._should_auto_tts_for_chat = lambda _chat_id: False
+    adapter.send_voice = AsyncMock(
+        return_value=SendResult(success=False, message_id=None, error="rpc down")
+    )
+
+    voice_path = Path("/tmp/voice_test_clip_fail.ogg")
+    voice_path.write_bytes(b"fake audio")
+
+    adapter.set_message_handler(
+        lambda _event: asyncio.sleep(
+            0, result=f"reply text\n\n[[audio_as_voice]]\nMEDIA:{voice_path}"
+        )
+    )
+    event = MessageEvent(
+        text="hello",
+        message_type=MessageType.TEXT,
+        source=SessionSource(
+            platform=Platform.SIGNAL, chat_id="-1001", chat_type="group"
+        ),
+        message_id="m-2",
+    )
+
+    with patch("tools.tts_tool.check_tts_requirements", return_value=True):
+        await adapter._process_message_background(event, build_session_key(event.source))
+
+    adapter.send_voice.assert_awaited()
+    assert any(m["content"] == "reply text" for m in adapter.sent), adapter.sent

--- a/tests/gateway/test_suppress_text_when_voice.py
+++ b/tests/gateway/test_suppress_text_when_voice.py
@@ -1,0 +1,103 @@
+"""Per-platform suppression of redundant text on voice replies.
+
+Covers the ``PlatformConfig.suppress_text_when_voice`` flag and the
+``_should_suppress_text_on_voice`` helper that decides when the written text
+should be dropped in favor of a voice reply.
+"""
+from gateway.config import Platform, PlatformConfig
+from gateway.platforms.base import BasePlatformAdapter
+
+
+# --- PlatformConfig.suppress_text_when_voice ------------------------------
+
+def test_suppress_text_when_voice_default_is_false():
+    assert PlatformConfig.from_dict({}).suppress_text_when_voice is False
+
+
+def test_suppress_text_when_voice_parsed_from_top_level():
+    pc = PlatformConfig.from_dict({"suppress_text_when_voice": True})
+    assert pc.suppress_text_when_voice is True
+
+
+def test_suppress_text_when_voice_parsed_from_extra():
+    pc = PlatformConfig.from_dict({"extra": {"suppress_text_when_voice": True}})
+    assert pc.suppress_text_when_voice is True
+
+
+def test_suppress_text_when_voice_round_trips_through_to_dict():
+    pc = PlatformConfig.from_dict({"suppress_text_when_voice": True})
+    assert pc.to_dict()["suppress_text_when_voice"] is True
+
+
+# --- _should_suppress_text_on_voice ---------------------------------------
+
+def _adapter(suppress_text_when_voice):
+    class _ConcreteAdapter(BasePlatformAdapter):
+        async def connect(self):
+            pass
+
+        async def disconnect(self):
+            pass
+
+        async def get_chat_info(self, chat_id):
+            return None
+
+        async def send(self, chat_id, content, **kwargs):
+            return True
+
+    return _ConcreteAdapter(
+        config=PlatformConfig.from_dict({"suppress_text_when_voice": suppress_text_when_voice}),
+        platform=Platform.SIGNAL,
+    )
+
+
+def test_suppress_off_never_suppresses_even_with_voice():
+    ad = _adapter(False)
+    assert ad._should_suppress_text_on_voice(
+        voice_delivered=True, media_files=[], images=[], local_files=[]
+    ) is False
+
+
+def test_suppress_on_with_delivered_voice_and_no_other_media():
+    ad = _adapter(True)
+    assert ad._should_suppress_text_on_voice(
+        voice_delivered=True, media_files=[], images=[], local_files=[]
+    ) is True
+
+
+def test_suppress_on_with_queued_voice_media():
+    ad = _adapter(True)
+    assert ad._should_suppress_text_on_voice(
+        voice_delivered=False, media_files=[("/tmp/voice.ogg", True)], images=[], local_files=[]
+    ) is True
+
+
+def test_suppress_on_with_non_voice_media_preserves_text():
+    ad = _adapter(True)
+    assert ad._should_suppress_text_on_voice(
+        voice_delivered=True,
+        media_files=[("/tmp/pic.png", False)],
+        images=["pic.png"],
+        local_files=[],
+    ) is False
+
+
+def test_suppress_on_with_image_preserves_text():
+    ad = _adapter(True)
+    assert ad._should_suppress_text_on_voice(
+        voice_delivered=True, media_files=[], images=["photo.png"], local_files=[]
+    ) is False
+
+
+def test_suppress_on_with_local_file_preserves_text():
+    ad = _adapter(True)
+    assert ad._should_suppress_text_on_voice(
+        voice_delivered=True, media_files=[], images=[], local_files=["/tmp/doc.pdf"]
+    ) is False
+
+
+def test_suppress_on_but_no_voice_delivered_or_queued():
+    ad = _adapter(True)
+    assert ad._should_suppress_text_on_voice(
+        voice_delivered=False, media_files=[], images=[], local_files=[]
+    ) is False


### PR DESCRIPTION
## What does this PR do?
Adds an opt-in per-platform `suppress_text_when_voice` config flag that drops the redundant written text when a voice reply (auto-TTS speak or a MEDIA voice clip) is delivered with no other non-voice content. On platforms whose voice notes arrive as caption-less attachments (e.g. Signal), this avoids the user receiving audio and the same text twice. Default off preserves existing behavior. Also fixes a latent bug where an empty handler response could raise `UnboundLocalError` by reading the suppression flag before it was initialized.

## Type of Change
- [x] ✨ New feature (non-breaking change that adds functionality)
- [x] 🐛 Bug fix (UnboundLocalError on empty responses)

## Changes Made
- `gateway/config.py` — added `PlatformConfig.suppress_text_when_voice: bool = False` (parsed from top-level or `extra`), serialized in `to_dict`.
- `gateway/platforms/base.py` — extracted `_should_suppress_text_on_voice()` helper; wired it into `_process_message_background`; initialized `_suppress_text = False` at function top (fixes the UnboundLocalError); kept the ✅-not-❌ success handling for suppressed voice delivery.
- `cli-config.yaml.example` — documented the key.
- `tests/gateway/test_suppress_text_when_voice.py` — config parsing + helper logic tests.

## How to Test
1. `platforms.signal.suppress_text_when_voice: true`.
2. Send a voice message on Signal that triggers a voice reply → only the voice clip, no redundant text; reaction shows ✅ not ❌.
3. On a platform with the flag unset (default false) → text is still sent.

## Checklist
- [x] Conventional commit message
- [x] PR contains only changes related to this feature
- [x] Tests added and passing
- [x] Tested on Linux (self-hosted HA1)