### PR TITLE
feat(desktop): pick which chat owns the Browser tab

### DIFF
--- a/apps/desktop/src/app/chat/right-rail/preview-chat-control.test.tsx
+++ b/apps/desktop/src/app/chat/right-rail/preview-chat-control.test.tsx
@@ -1,0 +1,70 @@
+import { cleanup, fireEvent, render } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { $activeSessionId, $selectedStoredSessionId, $sessions } from '@/store/session'
+
+import { $previewChat } from './preview-chat'
+import { PreviewChatControl } from './preview-chat-control'
+
+class TestResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+vi.stubGlobal('ResizeObserver', TestResizeObserver)
+
+beforeEach(() => {
+  $previewChat.set(null)
+  $activeSessionId.set('run-main')
+  $selectedStoredSessionId.set('stored-main')
+  $sessions.set([
+    {
+      archived: false,
+      cwd: null,
+      ended_at: null,
+      id: 'stored-main',
+      input_tokens: 0,
+      is_active: true,
+      last_active: 1,
+      message_count: 1,
+      model: null,
+      output_tokens: 0,
+      parent_session_id: null,
+      preview: null,
+      source: 'desktop',
+      started_at: 1,
+      title: 'Main chat',
+      tool_call_count: 0
+    }
+  ])
+})
+
+afterEach(() => {
+  cleanup()
+  $previewChat.set(null)
+  $activeSessionId.set(null)
+  $selectedStoredSessionId.set(null)
+  $sessions.set([])
+})
+
+describe('PreviewChatControl', () => {
+  it('pins the selected chat', () => {
+    const rendered = render(<PreviewChatControl />)
+
+    fireEvent.click(rendered.getByRole('button', { name: 'Select page for chat' }))
+    fireEvent.click(rendered.getByRole('option', { name: /Main chat/ }))
+
+    expect($previewChat.get()).toBe('run-main')
+  })
+
+  it('clears the pin', () => {
+    $previewChat.set('run-main')
+    const rendered = render(<PreviewChatControl />)
+
+    fireEvent.click(rendered.getByRole('button', { name: 'Select page for chat' }))
+    fireEvent.click(rendered.getByRole('option', { name: /Active tab/ }))
+
+    expect($previewChat.get()).toBeNull()
+  })
+})

--- a/apps/desktop/src/app/chat/right-rail/preview-chat-control.tsx
+++ b/apps/desktop/src/app/chat/right-rail/preview-chat-control.tsx
@@ -1,0 +1,73 @@
+/**
+ * Chat picker for the in-app browser toolbar.
+ *
+ * Lives beside the URL field. Picks which session `read_preview` should
+ * treat as the owner of the Browser tab. See preview-chat.ts.
+ */
+
+import { useStore } from '@nanostores/react'
+import { useState } from 'react'
+
+import { TooltipIconButton } from '@/components/assistant-ui/tooltip-icon-button'
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
+import { useI18n } from '@/i18n'
+import { MessageSquareText } from '@/lib/icons'
+import { cn } from '@/lib/utils'
+
+import { $previewChat, chatChoices, setPreviewChat } from './preview-chat'
+
+export function PreviewChatControl() {
+  const { t } = useI18n()
+  const copy = t.preview.web
+  const pinned = useStore($previewChat)
+  const [open, setOpen] = useState(false)
+  const choices = chatChoices()
+
+  const pick = (id: string | null) => {
+    setPreviewChat(id)
+    setOpen(false)
+  }
+
+  return (
+    <Popover onOpenChange={setOpen} open={open}>
+      <PopoverTrigger asChild>
+        <TooltipIconButton tooltip={copy.chat} type="button">
+          <MessageSquareText className={cn(pinned && 'text-primary')} />
+        </TooltipIconButton>
+      </PopoverTrigger>
+      <PopoverContent align="end" className="w-56 p-1.5" side="bottom">
+        <div aria-label={copy.chat} className="flex flex-col gap-0.5" role="listbox">
+          <button
+            className={cn(
+              'flex w-full items-center justify-between rounded-sm px-2 py-1 text-left text-xs',
+              pinned === null ? 'bg-accent text-accent-foreground' : 'hover:bg-accent/60'
+            )}
+            onClick={() => pick(null)}
+            role="option"
+            type="button"
+          >
+            <span>{copy.chatNone}</span>
+          </button>
+          {choices.map(choice => (
+            <button
+              className={cn(
+                'flex w-full items-center justify-between rounded-sm px-2 py-1 text-left text-xs',
+                pinned === choice.id ? 'bg-accent text-accent-foreground' : 'hover:bg-accent/60'
+              )}
+              key={choice.id}
+              onClick={() => pick(choice.id)}
+              role="option"
+              type="button"
+            >
+              <span className="min-w-0 truncate">{choice.label}</span>
+              {choice.kind === 'tile' && <span className="shrink-0 text-muted-foreground">{copy.chatTile}</span>}
+            </button>
+          ))}
+          {choices.length === 0 && (
+            <div className="px-2 py-1 text-[0.625rem] text-muted-foreground">{copy.chatEmpty}</div>
+          )}
+        </div>
+      </PopoverContent>
+    </Popover>
+  )
+}

--- a/apps/desktop/src/app/chat/right-rail/preview-chat.test.ts
+++ b/apps/desktop/src/app/chat/right-rail/preview-chat.test.ts
@@ -1,0 +1,80 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import { $activeSessionId, $selectedStoredSessionId, $sessions } from '@/store/session'
+import { $sessionTiles } from '@/store/session-states'
+
+import { $previewChat, chatChoices, setPreviewChat } from './preview-chat'
+
+describe('preview chat pin', () => {
+  beforeEach(() => {
+    $previewChat.set(null)
+    $activeSessionId.set(null)
+    $selectedStoredSessionId.set(null)
+    $sessions.set([])
+    $sessionTiles.set([])
+  })
+
+  afterEach(() => {
+    $previewChat.set(null)
+    $activeSessionId.set(null)
+    $selectedStoredSessionId.set(null)
+    $sessions.set([])
+    $sessionTiles.set([])
+  })
+
+  it('lists the primary chat and open tiles', () => {
+    $activeSessionId.set('run-main')
+    $selectedStoredSessionId.set('stored-main')
+    $sessions.set([
+      {
+        archived: false,
+        cwd: null,
+        ended_at: null,
+        id: 'stored-main',
+        input_tokens: 0,
+        is_active: true,
+        last_active: 1,
+        message_count: 1,
+        model: null,
+        output_tokens: 0,
+        parent_session_id: null,
+        preview: null,
+        source: 'desktop',
+        started_at: 1,
+        title: 'Main chat',
+        tool_call_count: 0
+      },
+      {
+        archived: false,
+        cwd: null,
+        ended_at: null,
+        id: 'stored-tile',
+        input_tokens: 0,
+        is_active: true,
+        last_active: 1,
+        message_count: 1,
+        model: null,
+        output_tokens: 0,
+        parent_session_id: null,
+        preview: null,
+        source: 'desktop',
+        started_at: 1,
+        title: 'Side tile',
+        tool_call_count: 0
+      }
+    ])
+    $sessionTiles.set([{ storedSessionId: 'stored-tile', runtimeId: 'run-tile' }])
+
+    expect(chatChoices()).toEqual([
+      { id: 'run-main', kind: 'primary', label: 'Main chat' },
+      { id: 'run-tile', kind: 'tile', label: 'Side tile' }
+    ])
+  })
+
+  it('stores a pin', () => {
+    setPreviewChat('run-tile')
+    expect($previewChat.get()).toBe('run-tile')
+    setPreviewChat(null)
+    expect($previewChat.get()).toBeNull()
+  })
+})

--- a/apps/desktop/src/app/chat/right-rail/preview-chat.ts
+++ b/apps/desktop/src/app/chat/right-rail/preview-chat.ts
@@ -1,0 +1,65 @@
+/**
+ * PREVIEW ↔ CHAT BINDING — which session `read_preview` should treat as
+ * the owner of the Browser tab.
+ *
+ * The Browser is a singleton (`url:browser`). Without a pin, `read_preview`
+ * reads whatever tab is in front. A pin lets the user say "this page is for
+ * that chat": when THAT session asks, the reader prefers the Browser tab
+ * even if a file peek is currently showing. Other sessions keep the
+ * look-at-the-front-tab behavior.
+ *
+ * Pin is a live runtime id (matches `preview.read.request`'s session_id).
+ * Not persisted — runtime ids die on restart.
+ */
+
+import { atom } from 'nanostores'
+
+import { sessionTitle } from '@/lib/chat-runtime'
+import { $activeSessionId, $selectedStoredSessionId, $sessions } from '@/store/session'
+import { $sessionTiles } from '@/store/session-states'
+
+export interface PreviewChatChoice {
+  id: string
+  kind: 'primary' | 'tile'
+  label: string
+}
+
+export const $previewChat = atom<string | null>(null)
+
+export function setPreviewChat(id: string | null): void {
+  $previewChat.set(id)
+}
+
+export function chatChoices(): PreviewChatChoice[] {
+  const sessions = $sessions.get()
+  const primaryRuntime = $activeSessionId.get()
+  const primaryStored = $selectedStoredSessionId.get()
+  const tiles = $sessionTiles.get()
+  const rows: PreviewChatChoice[] = []
+
+  if (primaryRuntime) {
+    const stored = primaryStored ? sessions.find(session => session.id === primaryStored) : undefined
+
+    rows.push({
+      id: primaryRuntime,
+      kind: 'primary',
+      label: stored ? sessionTitle(stored) : 'Chat'
+    })
+  }
+
+  for (const tile of tiles) {
+    if (!tile.runtimeId || tile.runtimeId === primaryRuntime) {
+      continue
+    }
+
+    const stored = sessions.find(session => session.id === tile.storedSessionId)
+
+    rows.push({
+      id: tile.runtimeId,
+      kind: 'tile',
+      label: stored ? sessionTitle(stored) : tile.storedSessionId
+    })
+  }
+
+  return rows
+}

--- a/apps/desktop/src/app/chat/right-rail/preview-pane.test.tsx
+++ b/apps/desktop/src/app/chat/right-rail/preview-pane.test.tsx
@@ -110,6 +110,118 @@ describe('PreviewPane console state', () => {
     forgetPreviewStripTools(tabId)
   })
 
+  it('shows the URL toolbar on the live embedded preview tile', async () => {
+    const tabId = 'url:http://localhost:5174'
+
+    forgetPreviewStripTools(tabId)
+
+    let rendered!: ReturnType<typeof render>
+    await act(async () => {
+      rendered = render(
+        <PreviewPane
+          embedded
+          tabId={tabId}
+          target={{
+            kind: 'url',
+            label: 'Preview',
+            source: 'http://localhost:5174',
+            url: 'http://localhost:5174'
+          }}
+        />
+      )
+    })
+
+    expect(rendered.getByRole('textbox', { name: 'Preview URL' })).toBeTruthy()
+    expect(rendered.getByRole('button', { name: 'Go back' })).toBeTruthy()
+    expect(rendered.container.querySelector('webview')).toBeInstanceOf(HTMLElement)
+
+    forgetPreviewStripTools(tabId)
+  })
+
+  it('keeps the address field while a page-in navigation happens', async () => {
+    const tabId = 'url:http://localhost:5174'
+
+    forgetPreviewStripTools(tabId)
+
+    let rendered!: ReturnType<typeof render>
+    await act(async () => {
+      rendered = render(
+        <PreviewPane
+          tabId={tabId}
+          target={{
+            kind: 'url',
+            label: 'Preview',
+            source: 'http://localhost:5174',
+            url: 'http://localhost:5174'
+          }}
+        />
+      )
+    })
+
+    const input = rendered.getByRole('textbox', { name: 'Preview URL' }) as HTMLInputElement
+    const webview = rendered.container.querySelector('webview')
+
+    expect(webview).toBeInstanceOf(HTMLElement)
+
+    await act(async () => {
+      fireEvent.focus(input)
+      fireEvent.change(input, { target: { value: 'https://example.com/typed' } })
+    })
+
+    expect(input.value).toBe('https://example.com/typed')
+
+    act(() => {
+      webview?.dispatchEvent(
+        Object.assign(new Event('did-navigate-in-page'), {
+          url: 'http://localhost:5174/pushed'
+        })
+      )
+    })
+
+    expect(input.value).toBe('https://example.com/typed')
+
+    forgetPreviewStripTools(tabId)
+  })
+
+  it('syncs back/forward on both navigate events', async () => {
+    const tabId = 'url:http://localhost:5174'
+
+    forgetPreviewStripTools(tabId)
+
+    let rendered!: ReturnType<typeof render>
+    await act(async () => {
+      rendered = render(
+        <PreviewPane
+          tabId={tabId}
+          target={{
+            kind: 'url',
+            label: 'Preview',
+            source: 'http://localhost:5174',
+            url: 'http://localhost:5174'
+          }}
+        />
+      )
+    })
+
+    const webview = rendered.container.querySelector('webview') as HTMLElement & {
+      canGoBack?: () => boolean
+      canGoForward?: () => boolean
+    }
+
+    expect(webview).toBeInstanceOf(HTMLElement)
+    webview.canGoBack = () => true
+    webview.canGoForward = () => false
+
+    act(() => {
+      webview.dispatchEvent(Object.assign(new Event('did-navigate-in-page'), { url: 'http://localhost:5174/next' }))
+    })
+
+    expect((rendered.getByRole('button', { name: 'Go back' }) as HTMLButtonElement).disabled).toBe(false)
+    expect((rendered.getByRole('button', { name: 'Go forward' }) as HTMLButtonElement).disabled).toBe(true)
+
+    forgetPreviewStripTools(tabId)
+  })
+
   it('renders authenticated remote HTML safely and honors source mode', async () => {
     const dataUrl = `data:text/html;base64,${btoa('<h1>remote</h1>')}`
 

--- a/apps/desktop/src/app/chat/right-rail/preview-pane.test.tsx
+++ b/apps/desktop/src/app/chat/right-rail/preview-pane.test.tsx
@@ -134,6 +134,7 @@ describe('PreviewPane console state', () => {
     expect(rendered.getByRole('textbox', { name: 'Preview URL' })).toBeTruthy()
     expect(rendered.getByRole('button', { name: 'Go back' })).toBeTruthy()
     expect(rendered.getByRole('button', { name: 'Preview viewport' })).toBeTruthy()
+    expect(rendered.getByRole('button', { name: 'Select page for chat' })).toBeTruthy()
     expect(rendered.container.querySelector('webview')).toBeInstanceOf(HTMLElement)
 
     forgetPreviewStripTools(tabId)

--- a/apps/desktop/src/app/chat/right-rail/preview-pane.test.tsx
+++ b/apps/desktop/src/app/chat/right-rail/preview-pane.test.tsx
@@ -133,6 +133,7 @@ describe('PreviewPane console state', () => {
 
     expect(rendered.getByRole('textbox', { name: 'Preview URL' })).toBeTruthy()
     expect(rendered.getByRole('button', { name: 'Go back' })).toBeTruthy()
+    expect(rendered.getByRole('button', { name: 'Preview viewport' })).toBeTruthy()
     expect(rendered.container.querySelector('webview')).toBeInstanceOf(HTMLElement)
 
     forgetPreviewStripTools(tabId)

--- a/apps/desktop/src/app/chat/right-rail/preview-pane.tsx
+++ b/apps/desktop/src/app/chat/right-rail/preview-pane.tsx
@@ -24,13 +24,19 @@ import { type ConsoleEntry } from './preview-console-state'
 import { LocalFilePreview, PreviewEmptyState } from './preview-file'
 import { registerPreviewPageReader } from './preview-reader'
 import { previewConsoleState, registerPreviewDevTools } from './preview-strip-tools'
+import { isHttpUrl, PreviewToolbar } from './preview-toolbar'
 
 type PreviewWebview = HTMLElement & {
+  canGoBack?: () => boolean
+  canGoForward?: () => boolean
   closeDevTools?: () => void
   executeJavaScript?: (code: string) => Promise<unknown>
   getTitle?: () => string
   getURL?: () => string
+  goBack?: () => void
+  goForward?: () => void
   isDevToolsOpened?: () => boolean
+  loadURL?: (url: string) => Promise<void> | void
   openDevTools?: () => void
   reload?: () => void
   reloadIgnoringCache?: () => void
@@ -146,6 +152,10 @@ export function PreviewPane({ embedded = false, onRestartServer, reloadRequest =
   const [loading, setLoading] = useState(true)
   const [loadError, setLoadError] = useState<PreviewLoadErrorState | null>(null)
   const [localReloadKey, setLocalReloadKey] = useState(0)
+  const [address, setAddress] = useState(target.url)
+  const [canGoBack, setCanGoBack] = useState(false)
+  const [canGoForward, setCanGoForward] = useState(false)
+  const addressFocusedRef = useRef(false)
 
   // Artifacts have no URL to load — they render from the registry, never in a
   // webview.
@@ -153,20 +163,21 @@ export function PreviewPane({ embedded = false, onRestartServer, reloadRequest =
     target.kind !== 'artifact' &&
     (target.kind === 'url' || (target.previewKind === 'html' && target.renderMode !== 'source'))
 
-  const isRemoteHtmlTarget =
-    target.kind === 'file' && target.previewKind === 'html' && Boolean(target.dataUrl || target.transient)
-
-  const isRemoteHtml = isRemoteHtmlTarget && target.renderMode !== 'source' && Boolean(target.dataUrl)
+  // `isRemoteHtml` keeps its original definition — fully rendered HTML in an
+  // iframe (skips the webview path). The toolbar is for actual webview tabs.
+  const isRemoteHtml =
+    target.kind === 'file' && target.previewKind === 'html' && target.renderMode !== 'source' && Boolean(target.dataUrl)
 
   const remoteHtmlDocument = useMemo(
     () => (isRemoteHtml ? remoteHtmlPreviewDocument(target.dataUrl!) : null),
     [isRemoteHtml, target.dataUrl]
   )
 
-  const currentLabel = compactUrl(currentUrl)
-
-  const previewLabel =
-    target.label && target.label.replace(/\/$/, '') !== currentLabel.replace(/\/$/, '') ? target.label : currentLabel
+  // Source-mode preview (HTML rendered as text, no webview/iframe): the URL
+  // label stays as an "open in default browser" affordance. The href/target
+  // are gated on this so the link is purely visual until the user clicks.
+  const isSourcePreviewTarget =
+    target.kind === 'file' && target.previewKind === 'html' && Boolean(target.dataUrl || target.transient)
 
   const restartingServer =
     previewServerRestart?.status === 'running' &&
@@ -245,6 +256,66 @@ export function PreviewPane({ embedded = false, onRestartServer, reloadRequest =
       webviewRef.current?.reload?.()
     }
   }, [isWebPreview])
+
+  const syncNavigationState = useCallback(() => {
+    const webview = webviewRef.current
+
+    setCanGoBack(Boolean(webview?.canGoBack?.()))
+    setCanGoForward(Boolean(webview?.canGoForward?.()))
+  }, [])
+
+  const goBack = useCallback(() => {
+    const webview = webviewRef.current
+
+    if (!webview?.canGoBack?.() || !webview.goBack) {
+      return
+    }
+
+    webview.goBack()
+    syncNavigationState()
+  }, [syncNavigationState])
+
+  const goForward = useCallback(() => {
+    const webview = webviewRef.current
+
+    if (!webview?.canGoForward?.() || !webview.goForward) {
+      return
+    }
+
+    webview.goForward()
+    syncNavigationState()
+  }, [syncNavigationState])
+
+  const submitAddress = useCallback((next: string) => {
+    const webview = webviewRef.current
+    const url = next.trim()
+
+    if (!isHttpUrl(url)) {
+      return
+    }
+
+    setLoadError(null)
+    setCurrentUrl(url)
+    setAddress(url)
+
+    if (webview?.loadURL) {
+      void Promise.resolve(webview.loadURL(url)).catch(() => undefined)
+    } else {
+      webview?.setAttribute('src', url)
+    }
+  }, [])
+
+  const handleAddressBlur = useCallback(() => {
+    addressFocusedRef.current = false
+
+    // Sync the address to the webview's actual current URL after the user is
+    // done typing — keeps the input truthful without clobbering mid-typing.
+    const live = webviewRef.current?.getURL?.() || currentUrl
+
+    if (live) {
+      setAddress(live)
+    }
+  }, [currentUrl])
 
   const appendConsoleEntry = useCallback(
     (entry: Omit<ConsoleEntry, 'id'>) => {
@@ -543,6 +614,9 @@ export function PreviewPane({ embedded = false, onRestartServer, reloadRequest =
     host.replaceChildren()
     webviewRef.current = null
     setCurrentUrl(target.url)
+    setAddress(target.url)
+    setCanGoBack(false)
+    setCanGoForward(false)
     setDevtoolsOpen(false)
     setLoadError(null)
     consoleState.reset()
@@ -592,7 +666,18 @@ export function PreviewPane({ embedded = false, onRestartServer, reloadRequest =
       if (detail.url) {
         setLoadError(null)
         setCurrentUrl(detail.url)
+
+        // Don't clobber the user's in-progress typing. The webview is the
+        // source of truth on blur — see `handleAddressBlur`.
+        if (!addressFocusedRef.current) {
+          setAddress(detail.url)
+        }
       }
+
+      // Both `did-navigate` and `did-navigate-in-page` can change the webview's
+      // history. Reading the back/forward state on either keeps the toolbar
+      // buttons truthful for SPA pushState navigation too.
+      syncNavigationState()
     }
 
     const onFail = (event: Event) => {
@@ -621,7 +706,12 @@ export function PreviewPane({ embedded = false, onRestartServer, reloadRequest =
     }
 
     const onStart = () => setLoading(true)
-    const onStop = () => setLoading(false)
+
+    const onStop = () => {
+      setLoading(false)
+      syncNavigationState()
+    }
+
     // The WEBVIEW is the source of truth for DevTools, not our click handler:
     // closing the DevTools window itself fires devtools-closed with no click,
     // and the glyph was left stuck "on" when we tracked it locally.
@@ -650,34 +740,52 @@ export function PreviewPane({ embedded = false, onRestartServer, reloadRequest =
       webview.removeEventListener('did-stop-loading', onStop)
       webview.remove()
     }
-  }, [appendConsoleEntry, consoleState, copy, isRemoteHtml, isWebPreview, target.url])
+  }, [appendConsoleEntry, consoleState, copy, isRemoteHtml, isWebPreview, syncNavigationState, target.url])
 
   return (
     <aside className="relative flex h-full w-full min-w-0 flex-col overflow-hidden bg-transparent text-muted-foreground">
       <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
-        {!embedded && (
+        {isWebPreview && !isRemoteHtml && (
+          <PreviewToolbar
+            address={address}
+            addressValid={isHttpUrl(address)}
+            canGoBack={canGoBack}
+            canGoForward={canGoForward}
+            loading={loading}
+            onAddressBlur={handleAddressBlur}
+            onAddressChange={setAddress}
+            onAddressFocus={() => {
+              addressFocusedRef.current = true
+            }}
+            onBack={goBack}
+            onForward={goForward}
+            onReload={reloadPreview}
+            onSubmit={submitAddress}
+            placeholder={currentUrl || copy.fallbackTitle}
+          />
+        )}
+        {!embedded && !isWebPreview && target.kind === 'file' && target.previewKind === 'html' && (
           <div className="pointer-events-none flex min-h-(--titlebar-height) items-center gap-1.5 border-b border-border/60 bg-background px-2 py-1">
             <div className="min-w-0 flex-1">
               <Tip label={copy.openTarget(currentUrl)}>
                 <a
                   className="pointer-events-auto inline max-w-full truncate text-left text-xs font-medium text-foreground underline-offset-4 decoration-current/20 transition-colors hover:text-primary hover:underline"
-                  href={isRemoteHtmlTarget ? undefined : currentUrl}
+                  href={isSourcePreviewTarget ? undefined : currentUrl}
                   onClick={event => {
-                    if (isRemoteHtmlTarget) {
+                    if (isSourcePreviewTarget) {
                       event.preventDefault()
                       void openPreviewTargetInBrowser(target).catch(error => notifyError(error, t.preview.unavailable))
                     }
                   }}
                   rel="noreferrer"
-                  target={isRemoteHtmlTarget ? undefined : '_blank'}
+                  target={isSourcePreviewTarget ? undefined : '_blank'}
                 >
-                  {previewLabel || copy.fallbackTitle}
+                  {copy.openTarget(currentUrl)}
                 </a>
               </Tip>
             </div>
           </div>
         )}
-
         <div
           className="pointer-events-auto relative min-h-0 flex-1 overflow-hidden bg-transparent"
           ref={previewContentRef}

--- a/apps/desktop/src/app/chat/right-rail/preview-pane.tsx
+++ b/apps/desktop/src/app/chat/right-rail/preview-pane.tsx
@@ -25,6 +25,7 @@ import { LocalFilePreview, PreviewEmptyState } from './preview-file'
 import { registerPreviewPageReader } from './preview-reader'
 import { previewConsoleState, registerPreviewDevTools } from './preview-strip-tools'
 import { isHttpUrl, PreviewToolbar } from './preview-toolbar'
+import { loadViewportMode, modeSize, saveViewportMode, scaleFor, type ViewportMode } from './preview-viewport'
 
 type PreviewWebview = HTMLElement & {
   canGoBack?: () => boolean
@@ -155,7 +156,11 @@ export function PreviewPane({ embedded = false, onRestartServer, reloadRequest =
   const [address, setAddress] = useState(target.url)
   const [canGoBack, setCanGoBack] = useState(false)
   const [canGoForward, setCanGoForward] = useState(false)
+  const [viewport, setViewport] = useState<ViewportMode>(() => loadViewportMode())
+  const [hostSize, setHostSize] = useState({ width: 0, height: 0 })
   const addressFocusedRef = useRef(false)
+  const guestSize = modeSize(viewport)
+  const guestScale = guestSize ? scaleFor(hostSize, guestSize) : 1
 
   // Artifacts have no URL to load — they render from the registry, never in a
   // webview.
@@ -317,6 +322,11 @@ export function PreviewPane({ embedded = false, onRestartServer, reloadRequest =
     }
   }, [currentUrl])
 
+  const handleViewportChange = useCallback((next: ViewportMode) => {
+    setViewport(next)
+    saveViewportMode(next)
+  }, [])
+
   const appendConsoleEntry = useCallback(
     (entry: Omit<ConsoleEntry, 'id'>) => {
       consoleShouldStickRef.current = isNearConsoleBottom(consoleBodyRef.current)
@@ -420,6 +430,24 @@ export function PreviewPane({ embedded = false, onRestartServer, reloadRequest =
       }
     })
   }, [isWebPreview, tabId])
+
+  useEffect(() => {
+    const host = previewContentRef.current
+
+    if (!host || typeof ResizeObserver === 'undefined') {
+      return
+    }
+
+    const apply = () => {
+      setHostSize({ width: host.clientWidth, height: host.clientHeight })
+    }
+
+    apply()
+    const observer = new ResizeObserver(apply)
+    observer.observe(host)
+
+    return () => observer.disconnect()
+  }, [])
 
   // eslint-disable-next-line no-restricted-syntax -- legitimate non-atom ref write (see eslint rule comment)
   useEffect(() => {
@@ -761,7 +789,9 @@ export function PreviewPane({ embedded = false, onRestartServer, reloadRequest =
             onForward={goForward}
             onReload={reloadPreview}
             onSubmit={submitAddress}
+            onViewportChange={handleViewportChange}
             placeholder={currentUrl || copy.fallbackTitle}
+            viewport={viewport}
           />
         )}
         {!embedded && !isWebPreview && target.kind === 'file' && target.previewKind === 'html' && (
@@ -793,9 +823,20 @@ export function PreviewPane({ embedded = false, onRestartServer, reloadRequest =
           <div
             className={cn(
               'absolute inset-0 flex bg-transparent',
+              guestSize && 'items-start justify-center overflow-hidden',
               (isRemoteHtml || !isWebPreview || loadError) && 'pointer-events-none opacity-0'
             )}
             ref={hostRef}
+            style={
+              guestSize
+                ? {
+                    width: guestSize.width,
+                    height: guestSize.height,
+                    transform: `scale(${guestScale})`,
+                    transformOrigin: 'top center'
+                  }
+                : undefined
+            }
           />
           {isRemoteHtml && (
             <iframe

--- a/apps/desktop/src/app/chat/right-rail/preview-reader.test.ts
+++ b/apps/desktop/src/app/chat/right-rail/preview-reader.test.ts
@@ -4,6 +4,7 @@ import { $rightRailActiveTabId, selectRightRailTab } from '@/store/layout'
 import { closeRightRail, openPreview, type PreviewTarget } from '@/store/preview'
 
 import { PREVIEW_READ_MAX_CHARS, readActivePreview, registerPreviewPageReader } from './preview-reader'
+import { $previewChat } from './preview-chat'
 
 function urlTarget(url: string): PreviewTarget {
   return { kind: 'url', label: 'Browser', source: url, url }
@@ -33,6 +34,7 @@ describe('readActivePreview (read_preview tool)', () => {
 
     cleanups = []
     closeRightRail()
+    $previewChat.set(null)
     window.localStorage.clear()
   })
 
@@ -136,5 +138,19 @@ describe('readActivePreview (read_preview tool)', () => {
     first()
 
     expect(await readActivePreview()).toMatchObject({ text: 'second' })
+  })
+
+  it('prefers the Browser tab when the asking session is pinned', async () => {
+    openPreview(urlTarget('https://example.com'), 'tool-result')
+    register('url:browser', async () => ({ text: 'page', title: 'Example', url: 'https://example.com' }))
+    openPreview(fileTarget('/work/notes.md'), 'file-browser')
+    $previewChat.set('run-main')
+
+    expect(await readActivePreview({ sessionId: 'run-main' })).toMatchObject({
+      kind: 'url',
+      text: 'page',
+      url: 'https://example.com'
+    })
+    expect(await readActivePreview({ sessionId: 'other' })).toMatchObject({ path: '/work/notes.md' })
   })
 })

--- a/apps/desktop/src/app/chat/right-rail/preview-reader.test.ts
+++ b/apps/desktop/src/app/chat/right-rail/preview-reader.test.ts
@@ -3,8 +3,8 @@ import { beforeEach, describe, expect, it } from 'vitest'
 import { $rightRailActiveTabId, selectRightRailTab } from '@/store/layout'
 import { closeRightRail, openPreview, type PreviewTarget } from '@/store/preview'
 
-import { PREVIEW_READ_MAX_CHARS, readActivePreview, registerPreviewPageReader } from './preview-reader'
 import { $previewChat } from './preview-chat'
+import { PREVIEW_READ_MAX_CHARS, readActivePreview, registerPreviewPageReader } from './preview-reader'
 
 function urlTarget(url: string): PreviewTarget {
   return { kind: 'url', label: 'Browser', source: url, url }

--- a/apps/desktop/src/app/chat/right-rail/preview-reader.ts
+++ b/apps/desktop/src/app/chat/right-rail/preview-reader.ts
@@ -15,6 +15,8 @@
 import { $rightRailActiveTabId } from '@/store/layout'
 import { $previewTabs } from '@/store/preview'
 
+import { $previewChat } from './preview-chat'
+
 export interface PreviewReadOptions {
   /** Characters to return from `start` (capped at PREVIEW_READ_MAX_CHARS). */
   count?: number
@@ -74,9 +76,13 @@ function windowText(
 }
 
 /** Read the ACTIVE preview tab. Null only when no tab is open at all. */
-export async function readActivePreview(opts: PreviewReadOptions = {}): Promise<PreviewReadResult | null> {
+export async function readActivePreview(
+  opts: PreviewReadOptions & { sessionId?: string } = {}
+): Promise<PreviewReadResult | null> {
   const tabs = $previewTabs.get()
-  const tab = tabs.find(t => t.id === $rightRailActiveTabId.get()) ?? tabs[0]
+  const pinned = opts.sessionId && $previewChat.get() === opts.sessionId
+  const browser = tabs.find(t => t.id === 'url:browser')
+  const tab = (pinned && browser) || tabs.find(t => t.id === $rightRailActiveTabId.get()) || tabs[0]
 
   if (!tab) {
     return null

--- a/apps/desktop/src/app/chat/right-rail/preview-toolbar.test.tsx
+++ b/apps/desktop/src/app/chat/right-rail/preview-toolbar.test.tsx
@@ -16,7 +16,9 @@ const baseProps = {
   onBack: vi.fn(),
   onForward: vi.fn(),
   onReload: vi.fn(),
-  onSubmit: vi.fn()
+  onSubmit: vi.fn(),
+  onViewportChange: vi.fn(),
+  viewport: { kind: 'free' as const }
 }
 
 afterEach(() => {

--- a/apps/desktop/src/app/chat/right-rail/preview-toolbar.test.tsx
+++ b/apps/desktop/src/app/chat/right-rail/preview-toolbar.test.tsx
@@ -1,0 +1,203 @@
+import { cleanup, fireEvent, render } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { isHttpUrl, PreviewToolbar } from './preview-toolbar'
+
+const baseProps = {
+  address: 'https://example.com',
+  addressValid: true,
+  canGoBack: false,
+  canGoForward: false,
+  loading: false,
+  placeholder: 'https://example.com',
+  onAddressBlur: vi.fn(),
+  onAddressChange: vi.fn(),
+  onAddressFocus: vi.fn(),
+  onBack: vi.fn(),
+  onForward: vi.fn(),
+  onReload: vi.fn(),
+  onSubmit: vi.fn()
+}
+
+afterEach(() => {
+  cleanup()
+  vi.clearAllMocks()
+})
+
+describe('isHttpUrl', () => {
+  it('accepts http and https URLs', () => {
+    expect(isHttpUrl('https://example.com/path')).toBe(true)
+    expect(isHttpUrl('http://localhost:3000/')).toBe(true)
+  })
+
+  it('rejects empty input', () => {
+    expect(isHttpUrl('')).toBe(false)
+    expect(isHttpUrl('   ')).toBe(false)
+  })
+
+  it('rejects non-web schemes', () => {
+    expect(isHttpUrl('file:///etc/passwd')).toBe(false)
+    expect(isHttpUrl('data:text/html,evil')).toBe(false)
+    expect(isHttpUrl('javascript:alert(1)')).toBe(false)
+    expect(isHttpUrl('about:blank')).toBe(false)
+  })
+
+  it('rejects non-URL strings', () => {
+    expect(isHttpUrl('example')).toBe(false)
+    expect(isHttpUrl('://broken')).toBe(false)
+  })
+
+  it('trims whitespace before validating', () => {
+    expect(isHttpUrl('  https://example.com  ')).toBe(true)
+  })
+})
+
+describe('PreviewToolbar', () => {
+  it('renders all four controls with the right tooltips and labels', () => {
+    const rendered = render(<PreviewToolbar {...baseProps} />)
+
+    expect(rendered.getByRole('button', { name: 'Go back' })).toBeTruthy()
+    expect(rendered.getByRole('button', { name: 'Go forward' })).toBeTruthy()
+    expect(rendered.getByRole('button', { name: 'Reload preview' })).toBeTruthy()
+    expect(rendered.getByRole('textbox', { name: 'Preview URL' })).toBeTruthy()
+    expect(rendered.getAllByRole('button', { name: 'Navigate preview' }).length).toBe(1)
+    expect(rendered.getByRole('form', { name: 'Navigate preview' })).toBeTruthy()
+  })
+
+  it('disables back and forward when there is no history', () => {
+    const rendered = render(<PreviewToolbar {...baseProps} canGoBack={false} canGoForward={false} />)
+
+    expect((rendered.getByRole('button', { name: 'Go back' }) as HTMLButtonElement).disabled).toBe(true)
+    expect((rendered.getByRole('button', { name: 'Go forward' }) as HTMLButtonElement).disabled).toBe(true)
+  })
+
+  it('enables back and forward when there is history', () => {
+    const rendered = render(<PreviewToolbar {...baseProps} canGoBack={true} canGoForward={true} />)
+
+    expect((rendered.getByRole('button', { name: 'Go back' }) as HTMLButtonElement).disabled).toBe(false)
+    expect((rendered.getByRole('button', { name: 'Go forward' }) as HTMLButtonElement).disabled).toBe(false)
+  })
+
+  it('marks the address invalid when addressValid is false and the input has content', () => {
+    const rendered = render(<PreviewToolbar {...baseProps} address="not a url" addressValid={false} />)
+
+    const input = rendered.getByRole('textbox', { name: 'Preview URL' }) as HTMLInputElement
+
+    expect(input.getAttribute('aria-invalid')).toBe('true')
+    expect((rendered.getByRole('button', { name: 'Navigate preview' }) as HTMLButtonElement).disabled).toBe(true)
+  })
+
+  it('does not mark the address invalid when the input is empty (no aria-invalid)', () => {
+    const rendered = render(<PreviewToolbar {...baseProps} address="" addressValid={false} />)
+
+    const input = rendered.getByRole('textbox', { name: 'Preview URL' }) as HTMLInputElement
+
+    expect(input.getAttribute('aria-invalid')).toBeNull()
+    expect((rendered.getByRole('button', { name: 'Navigate preview' }) as HTMLButtonElement).disabled).toBe(true)
+  })
+
+  it('fires onBack when the back button is clicked', () => {
+    const onBack = vi.fn()
+    const rendered = render(<PreviewToolbar {...baseProps} canGoBack={true} onBack={onBack} />)
+
+    fireEvent.click(rendered.getByRole('button', { name: 'Go back' }))
+
+    expect(onBack).toHaveBeenCalledOnce()
+  })
+
+  it('fires onForward when the forward button is clicked', () => {
+    const onForward = vi.fn()
+    const rendered = render(<PreviewToolbar {...baseProps} canGoForward={true} onForward={onForward} />)
+
+    fireEvent.click(rendered.getByRole('button', { name: 'Go forward' }))
+
+    expect(onForward).toHaveBeenCalledOnce()
+  })
+
+  it('fires onReload when the reload button is clicked', () => {
+    const onReload = vi.fn()
+    const rendered = render(<PreviewToolbar {...baseProps} onReload={onReload} />)
+
+    fireEvent.click(rendered.getByRole('button', { name: 'Reload preview' }))
+
+    expect(onReload).toHaveBeenCalledOnce()
+  })
+
+  it('submits the trimmed address on form submit when addressValid is true', () => {
+    const onSubmit = vi.fn()
+
+    const rendered = render(
+      <PreviewToolbar {...baseProps} address="  https://example.com/path  " onSubmit={onSubmit} />
+    )
+
+    fireEvent.submit(rendered.getByRole('form', { name: 'Navigate preview' }))
+
+    expect(onSubmit).toHaveBeenCalledWith('https://example.com/path')
+  })
+
+  it('does not submit when the address is invalid', () => {
+    const onSubmit = vi.fn()
+
+    const rendered = render(
+      <PreviewToolbar {...baseProps} address="not a url" addressValid={false} onSubmit={onSubmit} />
+    )
+
+    fireEvent.submit(rendered.getByRole('form', { name: 'Navigate preview' }))
+
+    expect(onSubmit).not.toHaveBeenCalled()
+  })
+
+  it('fires onAddressChange on every keystroke without clobbering', () => {
+    const onAddressChange = vi.fn()
+
+    const rendered = render(<PreviewToolbar {...baseProps} address="https://exam" onAddressChange={onAddressChange} />)
+
+    const input = rendered.getByRole('textbox', { name: 'Preview URL' }) as HTMLInputElement
+
+    fireEvent.change(input, { target: { value: 'https://example' } })
+
+    expect(onAddressChange).toHaveBeenCalledWith('https://example')
+  })
+
+  it('fires onAddressBlur when the input loses focus', () => {
+    const onAddressBlur = vi.fn()
+    const rendered = render(<PreviewToolbar {...baseProps} onAddressBlur={onAddressBlur} />)
+
+    const input = rendered.getByRole('textbox', { name: 'Preview URL' }) as HTMLInputElement
+
+    fireEvent.blur(input)
+
+    expect(onAddressBlur).toHaveBeenCalledOnce()
+  })
+
+  it('fires onAddressFocus when the input is focused', () => {
+    const onAddressFocus = vi.fn()
+    const rendered = render(<PreviewToolbar {...baseProps} onAddressFocus={onAddressFocus} />)
+
+    const input = rendered.getByRole('textbox', { name: 'Preview URL' }) as HTMLInputElement
+
+    fireEvent.focus(input)
+
+    expect(onAddressFocus).toHaveBeenCalledOnce()
+  })
+
+  it('rotates the reload icon while loading', () => {
+    const { container } = render(<PreviewToolbar {...baseProps} loading={true} />)
+
+    const reloadButton = container.querySelector('button[aria-label="Reload preview"]')
+    const reloadIcon = reloadButton?.querySelector('svg')
+
+    expect(reloadIcon).toBeTruthy()
+    expect(reloadIcon?.getAttribute('class') ?? '').toContain('animate-spin')
+  })
+
+  it('does not rotate the reload icon when idle', () => {
+    const { container } = render(<PreviewToolbar {...baseProps} loading={false} />)
+
+    const reloadButton = container.querySelector('button[aria-label="Reload preview"]')
+    const reloadIcon = reloadButton?.querySelector('svg')
+
+    expect(reloadIcon).toBeTruthy()
+    expect(reloadIcon?.getAttribute('class') ?? '').not.toContain('animate-spin')
+  })
+})

--- a/apps/desktop/src/app/chat/right-rail/preview-toolbar.tsx
+++ b/apps/desktop/src/app/chat/right-rail/preview-toolbar.tsx
@@ -1,0 +1,138 @@
+/**
+ * PREVIEW TOOLBAR — the URL bar for the in-app browser preview.
+ *
+ * The live preview tile (`preview.tsx`) mounts `PreviewPane` with `embedded`.
+ * After the layout-tree rewrite the tab strip owns the title, so the pane
+ * itself has no address chrome — this toolbar is the navigation surface.
+ *
+ * Back / forward / address / submit / reload. HTTP-only validation so the
+ * address bar can't open `file://` or `data:` in the `<webview>`.
+ *
+ * Controlled component. State lives in `PreviewPane` so the webview's event
+ * listeners stay close to the webview itself; this component just renders
+ * the chrome and forwards intent. Focus-aware address input: when the input
+ * is focused, `onAddressChange` is the user's keystrokes (not the webview's
+ * navigation events), so typing doesn't get clobbered by `pushState`.
+ */
+
+import { type FormEvent, useCallback } from 'react'
+
+import { TooltipIconButton } from '@/components/assistant-ui/tooltip-icon-button'
+import { Input } from '@/components/ui/input'
+import { useI18n } from '@/i18n'
+import { ArrowUpRight, ChevronLeft, ChevronRight, RefreshCw } from '@/lib/icons'
+import { cn } from '@/lib/utils'
+
+export interface PreviewToolbarProps {
+  /** The address to show in the input. */
+  address: string
+  /** True when the address parses as `http://` or `https://`. */
+  addressValid: boolean
+  /** True when the webview has at least one entry to go back to. */
+  canGoBack: boolean
+  /** True when the webview has at least one entry to go forward to. */
+  canGoForward: boolean
+  /** True while a navigation is in flight (drives the reload icon spin). */
+  loading: boolean
+  /** Placeholder shown in the address input when empty. */
+  placeholder: string
+
+  onAddressBlur: () => void
+  onAddressChange: (next: string) => void
+  onAddressFocus: () => void
+  onBack: () => void
+  onForward: () => void
+  onReload: () => void
+  onSubmit: (url: string) => void
+}
+
+/**
+ * Returns `true` if `raw` parses as an absolute HTTP/HTTPS URL. Rejects
+ * `file://`, `data:`, `javascript:`, and other schemes — the embedded
+ * `<webview>` should only render web content, never local files the
+ * renderer hasn't already approved.
+ */
+export function isHttpUrl(raw: string): boolean {
+  const trimmed = raw.trim()
+
+  if (!trimmed) {
+    return false
+  }
+
+  try {
+    const url = new URL(trimmed)
+
+    return url.protocol === 'http:' || url.protocol === 'https:'
+  } catch {
+    return false
+  }
+}
+
+export function PreviewToolbar({
+  address,
+  addressValid,
+  canGoBack,
+  canGoForward,
+  loading,
+  placeholder,
+  onAddressBlur,
+  onAddressChange,
+  onAddressFocus,
+  onBack,
+  onForward,
+  onReload,
+  onSubmit
+}: PreviewToolbarProps) {
+  const { t } = useI18n()
+  const copy = t.preview.web
+
+  const handleSubmit = useCallback(
+    (event: FormEvent<HTMLFormElement>) => {
+      event.preventDefault()
+
+      if (!addressValid) {
+        return
+      }
+
+      onSubmit(address.trim())
+    },
+    [address, addressValid, onSubmit]
+  )
+
+  return (
+    <form
+      aria-label={copy.navigate}
+      className="flex shrink-0 items-center gap-0.5 border-b border-border/60 bg-background px-1 py-1"
+      onSubmit={handleSubmit}
+    >
+      <TooltipIconButton disabled={!canGoBack} onClick={onBack} tooltip={copy.goBack} type="button">
+        <ChevronLeft />
+      </TooltipIconButton>
+      <TooltipIconButton disabled={!canGoForward} onClick={onForward} tooltip={copy.goForward} type="button">
+        <ChevronRight />
+      </TooltipIconButton>
+      <Input
+        aria-invalid={address.trim().length > 0 && !addressValid ? true : undefined}
+        aria-label={copy.address}
+        autoCapitalize="off"
+        autoComplete="off"
+        autoCorrect="off"
+        className={cn(loading && 'text-muted-foreground')}
+        inputMode="url"
+        onBlur={onAddressBlur}
+        onChange={event => onAddressChange(event.target.value)}
+        onFocus={onAddressFocus}
+        placeholder={placeholder}
+        size="xs"
+        spellCheck={false}
+        value={address}
+      />
+      <TooltipIconButton disabled={!addressValid} tooltip={copy.navigate} type="submit">
+        <ArrowUpRight />
+      </TooltipIconButton>
+      <TooltipIconButton onClick={onReload} tooltip={copy.reload} type="button">
+        <RefreshCw className={cn(loading && 'animate-spin')} />
+      </TooltipIconButton>
+    </form>
+  )
+}

--- a/apps/desktop/src/app/chat/right-rail/preview-toolbar.tsx
+++ b/apps/desktop/src/app/chat/right-rail/preview-toolbar.tsx
@@ -23,6 +23,9 @@ import { useI18n } from '@/i18n'
 import { ArrowUpRight, ChevronLeft, ChevronRight, RefreshCw } from '@/lib/icons'
 import { cn } from '@/lib/utils'
 
+import { type ViewportMode } from './preview-viewport'
+import { PreviewViewportControl } from './preview-viewport-control'
+
 export interface PreviewToolbarProps {
   /** The address to show in the input. */
   address: string
@@ -44,6 +47,8 @@ export interface PreviewToolbarProps {
   onForward: () => void
   onReload: () => void
   onSubmit: (url: string) => void
+  onViewportChange: (next: ViewportMode) => void
+  viewport: ViewportMode
 }
 
 /**
@@ -81,7 +86,9 @@ export function PreviewToolbar({
   onBack,
   onForward,
   onReload,
-  onSubmit
+  onSubmit,
+  onViewportChange,
+  viewport
 }: PreviewToolbarProps) {
   const { t } = useI18n()
   const copy = t.preview.web
@@ -133,6 +140,7 @@ export function PreviewToolbar({
       <TooltipIconButton onClick={onReload} tooltip={copy.reload} type="button">
         <RefreshCw className={cn(loading && 'animate-spin')} />
       </TooltipIconButton>
+      <PreviewViewportControl mode={viewport} onModeChange={onViewportChange} />
     </form>
   )
 }

--- a/apps/desktop/src/app/chat/right-rail/preview-toolbar.tsx
+++ b/apps/desktop/src/app/chat/right-rail/preview-toolbar.tsx
@@ -23,6 +23,7 @@ import { useI18n } from '@/i18n'
 import { ArrowUpRight, ChevronLeft, ChevronRight, RefreshCw } from '@/lib/icons'
 import { cn } from '@/lib/utils'
 
+import { PreviewChatControl } from './preview-chat-control'
 import { type ViewportMode } from './preview-viewport'
 import { PreviewViewportControl } from './preview-viewport-control'
 
@@ -141,6 +142,7 @@ export function PreviewToolbar({
         <RefreshCw className={cn(loading && 'animate-spin')} />
       </TooltipIconButton>
       <PreviewViewportControl mode={viewport} onModeChange={onViewportChange} />
+      <PreviewChatControl />
     </form>
   )
 }

--- a/apps/desktop/src/app/chat/right-rail/preview-viewport-control.test.tsx
+++ b/apps/desktop/src/app/chat/right-rail/preview-viewport-control.test.tsx
@@ -1,0 +1,41 @@
+import { cleanup, fireEvent, render } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { PreviewViewportControl } from './preview-viewport-control'
+
+class TestResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+vi.stubGlobal('ResizeObserver', TestResizeObserver)
+
+afterEach(() => {
+  cleanup()
+  vi.clearAllMocks()
+})
+
+describe('PreviewViewportControl', () => {
+  it('opens the picker and selects a preset', () => {
+    const onModeChange = vi.fn()
+    const rendered = render(<PreviewViewportControl mode={{ kind: 'free' }} onModeChange={onModeChange} />)
+
+    fireEvent.click(rendered.getByRole('button', { name: 'Preview viewport' }))
+    fireEvent.click(rendered.getByRole('option', { name: /Mobile/ }))
+
+    expect(onModeChange).toHaveBeenCalledWith({ kind: 'preset', id: 'mobile' })
+  })
+
+  it('applies a custom size', () => {
+    const onModeChange = vi.fn()
+    const rendered = render(<PreviewViewportControl mode={{ kind: 'free' }} onModeChange={onModeChange} />)
+
+    fireEvent.click(rendered.getByRole('button', { name: 'Preview viewport' }))
+    fireEvent.change(rendered.getByRole('textbox', { name: 'Viewport width' }), { target: { value: '390' } })
+    fireEvent.change(rendered.getByRole('textbox', { name: 'Viewport height' }), { target: { value: '844' } })
+    fireEvent.submit(rendered.getByRole('textbox', { name: 'Viewport width' }).closest('form')!)
+
+    expect(onModeChange).toHaveBeenCalledWith({ kind: 'custom', width: 390, height: 844 })
+  })
+})

--- a/apps/desktop/src/app/chat/right-rail/preview-viewport-control.tsx
+++ b/apps/desktop/src/app/chat/right-rail/preview-viewport-control.tsx
@@ -1,0 +1,140 @@
+/**
+ * Viewport picker for the in-app browser toolbar.
+ *
+ * Lives beside the address field (not the tab strip). Free-size is the
+ * default. Presets and custom W×H lock the guest CSS box; PreviewPane
+ * scales that box to fit the host.
+ */
+
+import { type FormEvent, useState } from 'react'
+
+import { TooltipIconButton } from '@/components/assistant-ui/tooltip-icon-button'
+import { Input } from '@/components/ui/input'
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
+import { useI18n } from '@/i18n'
+import { Maximize, Monitor } from '@/lib/icons'
+import { cn } from '@/lib/utils'
+
+import { clampSize, modeSize, VIEWPORT_PRESETS, type ViewportMode, type ViewportPresetId } from './preview-viewport'
+
+export interface PreviewViewportControlProps {
+  mode: ViewportMode
+  onModeChange: (next: ViewportMode) => void
+}
+
+export function PreviewViewportControl({ mode, onModeChange }: PreviewViewportControlProps) {
+  const { t } = useI18n()
+  const copy = t.preview.web
+  const [open, setOpen] = useState(false)
+  const locked = modeSize(mode)
+  const draft = locked ?? { width: 1280, height: 720 }
+  const [width, setWidth] = useState(String(draft.width))
+  const [height, setHeight] = useState(String(draft.height))
+
+  const applyCustom = (event: FormEvent) => {
+    event.preventDefault()
+    const next = clampSize(Number(width), Number(height))
+
+    if (!Number.isFinite(next.width) || !Number.isFinite(next.height)) {
+      return
+    }
+
+    setWidth(String(next.width))
+    setHeight(String(next.height))
+    onModeChange({ kind: 'custom', width: next.width, height: next.height })
+    setOpen(false)
+  }
+
+  const pick = (next: ViewportMode) => {
+    onModeChange(next)
+    const size = modeSize(next)
+
+    if (size) {
+      setWidth(String(size.width))
+      setHeight(String(size.height))
+    }
+
+    setOpen(false)
+  }
+
+  const label = locked ? `${locked.width}×${locked.height}` : copy.viewportFree
+
+  const presetLabel = (id: ViewportPresetId) => {
+    if (id === 'desktop') {
+      return copy.viewportDesktop
+    }
+
+    if (id === 'laptop') {
+      return copy.viewportLaptop
+    }
+
+    return copy.viewportMobile
+  }
+
+  return (
+    <Popover onOpenChange={setOpen} open={open}>
+      <PopoverTrigger asChild>
+        <TooltipIconButton tooltip={copy.viewport} type="button">
+          {mode.kind === 'free' ? <Maximize /> : <Monitor />}
+        </TooltipIconButton>
+      </PopoverTrigger>
+      <PopoverContent align="end" className="w-56 p-1.5" side="bottom">
+        <div aria-label={copy.viewport} className="flex flex-col gap-0.5" role="listbox">
+          <button
+            className={cn(
+              'flex w-full items-center justify-between rounded-sm px-2 py-1 text-left text-xs',
+              mode.kind === 'free' ? 'bg-accent text-accent-foreground' : 'hover:bg-accent/60'
+            )}
+            onClick={() => pick({ kind: 'free' })}
+            role="option"
+            type="button"
+          >
+            <span>{copy.viewportFree}</span>
+          </button>
+          {VIEWPORT_PRESETS.map(preset => (
+            <button
+              className={cn(
+                'flex w-full items-center justify-between rounded-sm px-2 py-1 text-left text-xs',
+                mode.kind === 'preset' && mode.id === preset.id
+                  ? 'bg-accent text-accent-foreground'
+                  : 'hover:bg-accent/60'
+              )}
+              key={preset.id}
+              onClick={() => pick({ kind: 'preset', id: preset.id })}
+              role="option"
+              type="button"
+            >
+              <span>{presetLabel(preset.id)}</span>
+              <span className="text-muted-foreground">
+                {preset.width}×{preset.height}
+              </span>
+            </button>
+          ))}
+          <form className="mt-1 flex items-center gap-1 px-1 py-1" onSubmit={applyCustom}>
+            <Input
+              aria-label={copy.viewportWidth}
+              className="w-14"
+              inputMode="numeric"
+              onChange={event => setWidth(event.target.value)}
+              size="xs"
+              value={width}
+            />
+            <span className="text-muted-foreground text-xs">×</span>
+            <Input
+              aria-label={copy.viewportHeight}
+              className="w-14"
+              inputMode="numeric"
+              onChange={event => setHeight(event.target.value)}
+              size="xs"
+              value={height}
+            />
+            <button className="text-xs underline-offset-2 hover:underline" type="submit">
+              {copy.viewportApply}
+            </button>
+          </form>
+          <div className="px-2 pb-0.5 text-[0.625rem] text-muted-foreground">{label}</div>
+        </div>
+      </PopoverContent>
+    </Popover>
+  )
+}

--- a/apps/desktop/src/app/chat/right-rail/preview-viewport.test.ts
+++ b/apps/desktop/src/app/chat/right-rail/preview-viewport.test.ts
@@ -1,0 +1,87 @@
+import { afterEach, describe, expect, it } from 'vitest'
+
+import {
+  clampSize,
+  loadViewportMode,
+  modeSize,
+  parseViewportMode,
+  saveViewportMode,
+  scaleFor,
+  VIEWPORT_LIMITS,
+  VIEWPORT_STORAGE_KEY
+} from './preview-viewport'
+
+afterEach(() => {
+  window.localStorage.clear()
+})
+
+describe('clampSize', () => {
+  it('keeps values inside the Zcode limits', () => {
+    expect(clampSize(1280, 720)).toEqual({ width: 1280, height: 720 })
+  })
+
+  it('clamps below the minimum', () => {
+    expect(clampSize(10, 10)).toEqual({
+      width: VIEWPORT_LIMITS.minWidth,
+      height: VIEWPORT_LIMITS.minHeight
+    })
+  })
+
+  it('clamps above the maximum', () => {
+    expect(clampSize(99999, 99999)).toEqual({
+      width: VIEWPORT_LIMITS.maxWidth,
+      height: VIEWPORT_LIMITS.maxHeight
+    })
+  })
+})
+
+describe('parseViewportMode', () => {
+  it('defaults unknown input to free size', () => {
+    expect(parseViewportMode(null)).toEqual({ kind: 'free' })
+    expect(parseViewportMode({ kind: 'nope' })).toEqual({ kind: 'free' })
+  })
+
+  it('accepts presets and custom sizes', () => {
+    expect(parseViewportMode({ kind: 'preset', id: 'mobile' })).toEqual({ kind: 'preset', id: 'mobile' })
+    expect(parseViewportMode({ kind: 'custom', width: 800, height: 600 })).toEqual({
+      kind: 'custom',
+      width: 800,
+      height: 600
+    })
+  })
+})
+
+describe('modeSize', () => {
+  it('returns null for free size', () => {
+    expect(modeSize({ kind: 'free' })).toBeNull()
+  })
+
+  it('returns preset and custom boxes', () => {
+    expect(modeSize({ kind: 'preset', id: 'desktop' })).toEqual({ width: 1920, height: 1080 })
+    expect(modeSize({ kind: 'custom', width: 390, height: 844 })).toEqual({ width: 390, height: 844 })
+  })
+})
+
+describe('scaleFor', () => {
+  it('does not upscale a guest that already fits', () => {
+    expect(scaleFor({ width: 1920, height: 1080 }, { width: 375, height: 667 })).toBe(1)
+  })
+
+  it('scales down to the tighter axis', () => {
+    expect(scaleFor({ width: 375, height: 200 }, { width: 750, height: 200 })).toBe(0.5)
+  })
+})
+
+describe('viewport storage', () => {
+  it('round-trips a mode through localStorage', () => {
+    saveViewportMode({ kind: 'preset', id: 'laptop' })
+    expect(window.localStorage.getItem(VIEWPORT_STORAGE_KEY)).toContain('laptop')
+    expect(loadViewportMode()).toEqual({ kind: 'preset', id: 'laptop' })
+  })
+
+  it('returns free size when storage is empty or corrupt', () => {
+    expect(loadViewportMode()).toEqual({ kind: 'free' })
+    window.localStorage.setItem(VIEWPORT_STORAGE_KEY, '{')
+    expect(loadViewportMode()).toEqual({ kind: 'free' })
+  })
+})

--- a/apps/desktop/src/app/chat/right-rail/preview-viewport.ts
+++ b/apps/desktop/src/app/chat/right-rail/preview-viewport.ts
@@ -1,0 +1,110 @@
+/**
+ * PREVIEW VIEWPORT — CSS-pixel size of the in-app browser guest.
+ *
+ * Free-size (default) lets the webview fill the pane. A locked size sets the
+ * guest to that CSS box and scales it to fit the host so media queries fire
+ * at the chosen width/height. `webview.setSize` is not used — it does not
+ * change the CSS viewport.
+ *
+ * Limits match Zcode `BROWSER_VIEWPORT_LIMITS` (320–3840 × 320–2160).
+ * Last mode is stored in localStorage so a second Browser tab can share it.
+ */
+
+export const VIEWPORT_STORAGE_KEY = 'hermes.desktop.preview.viewport.v1'
+
+export const VIEWPORT_LIMITS = {
+  minWidth: 320,
+  maxWidth: 3840,
+  minHeight: 320,
+  maxHeight: 2160
+} as const
+
+export const VIEWPORT_PRESETS = [
+  { id: 'desktop', width: 1920, height: 1080 },
+  { id: 'laptop', width: 1366, height: 768 },
+  { id: 'mobile', width: 375, height: 667 }
+] as const
+
+export type ViewportPresetId = (typeof VIEWPORT_PRESETS)[number]['id']
+
+export type ViewportMode =
+  { kind: 'free' } | { kind: 'preset'; id: ViewportPresetId } | { kind: 'custom'; width: number; height: number }
+
+export function clampDim(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, Math.round(value)))
+}
+
+export function clampSize(width: number, height: number): { width: number; height: number } {
+  return {
+    width: clampDim(width, VIEWPORT_LIMITS.minWidth, VIEWPORT_LIMITS.maxWidth),
+    height: clampDim(height, VIEWPORT_LIMITS.minHeight, VIEWPORT_LIMITS.maxHeight)
+  }
+}
+
+export function presetSize(id: ViewportPresetId): { width: number; height: number } {
+  const preset = VIEWPORT_PRESETS.find(item => item.id === id) ?? VIEWPORT_PRESETS[0]
+
+  return { width: preset.width, height: preset.height }
+}
+
+export function modeSize(mode: ViewportMode): { width: number; height: number } | null {
+  if (mode.kind === 'free') {
+    return null
+  }
+
+  if (mode.kind === 'preset') {
+    return presetSize(mode.id)
+  }
+
+  return clampSize(mode.width, mode.height)
+}
+
+export function parseViewportMode(raw: unknown): ViewportMode {
+  if (!raw || typeof raw !== 'object') {
+    return { kind: 'free' }
+  }
+
+  const value = raw as { kind?: unknown; id?: unknown; width?: unknown; height?: unknown }
+
+  if (value.kind === 'preset' && (value.id === 'desktop' || value.id === 'laptop' || value.id === 'mobile')) {
+    return { kind: 'preset', id: value.id }
+  }
+
+  if (value.kind === 'custom' && typeof value.width === 'number' && typeof value.height === 'number') {
+    const size = clampSize(value.width, value.height)
+
+    return { kind: 'custom', width: size.width, height: size.height }
+  }
+
+  return { kind: 'free' }
+}
+
+export function loadViewportMode(): ViewportMode {
+  try {
+    const raw = window.localStorage.getItem(VIEWPORT_STORAGE_KEY)
+
+    if (!raw) {
+      return { kind: 'free' }
+    }
+
+    return parseViewportMode(JSON.parse(raw))
+  } catch {
+    return { kind: 'free' }
+  }
+}
+
+export function saveViewportMode(mode: ViewportMode): void {
+  try {
+    window.localStorage.setItem(VIEWPORT_STORAGE_KEY, JSON.stringify(mode))
+  } catch {
+    // Nonfatal — private mode / quota.
+  }
+}
+
+export function scaleFor(host: { width: number; height: number }, guest: { width: number; height: number }): number {
+  if (host.width <= 0 || host.height <= 0 || guest.width <= 0 || guest.height <= 0) {
+    return 1
+  }
+
+  return Math.min(1, host.width / guest.width, host.height / guest.height)
+}

--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event.ts
@@ -1300,7 +1300,7 @@ export function useGatewayEventHandler(deps: GatewayEventDeps) {
           const start = typeof payload?.start === 'number' ? payload.start : undefined
           const count = typeof payload?.count === 'number' ? payload.count : undefined
 
-          void readActivePreview({ count, start }).then(result => {
+          void readActivePreview({ count, sessionId: sessionId ?? undefined, start }).then(result => {
             void $gateway.get()?.request('preview.read.respond', {
               request_id: requestId,
               text: result ? JSON.stringify(result) : ''

--- a/apps/desktop/src/i18n/ar.ts
+++ b/apps/desktop/src/i18n/ar.ts
@@ -2255,7 +2255,12 @@ export const ar = defineLocale({
       loadFailedConsole: (code, message) => `فشل التحميل${code ? ` (${code})` : ''}: ${message}`,
       unreachableDescription: 'تعذّر الوصول إلى صفحة المعاينة.',
       openTarget: url => `فتح ${url}`,
-      fallbackTitle: 'معاينة'
+      fallbackTitle: 'معاينة',
+      goBack: 'رجوع',
+      goForward: 'تقدم',
+      reload: 'إعادة تحميل المعاينة',
+      address: 'رابط المعاينة',
+      navigate: 'التنقل في المعاينة'
     }
   },
   zones: {

--- a/apps/desktop/src/i18n/ar.ts
+++ b/apps/desktop/src/i18n/ar.ts
@@ -2260,7 +2260,15 @@ export const ar = defineLocale({
       goForward: 'تقدم',
       reload: 'إعادة تحميل المعاينة',
       address: 'رابط المعاينة',
-      navigate: 'التنقل في المعاينة'
+      navigate: 'التنقل في المعاينة',
+      viewport: 'حجم المعاينة',
+      viewportFree: 'حجم حر',
+      viewportDesktop: 'سطح المكتب',
+      viewportLaptop: 'حاسوب محمول',
+      viewportMobile: 'جوال',
+      viewportWidth: 'العرض',
+      viewportHeight: 'الارتفاع',
+      viewportApply: 'تطبيق'
     }
   },
   zones: {

--- a/apps/desktop/src/i18n/ar.ts
+++ b/apps/desktop/src/i18n/ar.ts
@@ -2268,7 +2268,11 @@ export const ar = defineLocale({
       viewportMobile: 'جوال',
       viewportWidth: 'العرض',
       viewportHeight: 'الارتفاع',
-      viewportApply: 'تطبيق'
+      viewportApply: 'تطبيق',
+      chat: 'اختيار الصفحة للدردشة',
+      chatNone: 'التبويب النشط',
+      chatTile: 'بلاطة',
+      chatEmpty: 'لا توجد دردشات مفتوحة'
     }
   },
   zones: {

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -2827,7 +2827,15 @@ export const en: Translations = {
       goForward: 'Go forward',
       reload: 'Reload preview',
       address: 'Preview URL',
-      navigate: 'Navigate preview'
+      navigate: 'Navigate preview',
+      viewport: 'Preview viewport',
+      viewportFree: 'Free size',
+      viewportDesktop: 'Desktop',
+      viewportLaptop: 'Laptop',
+      viewportMobile: 'Mobile',
+      viewportWidth: 'Viewport width',
+      viewportHeight: 'Viewport height',
+      viewportApply: 'Apply'
     }
   },
 

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -2822,7 +2822,12 @@ export const en: Translations = {
       loadFailedConsole: (code, message) => `Load failed${code ? ` (${code})` : ''}: ${message}`,
       unreachableDescription: 'The preview page could not be reached.',
       openTarget: url => `Open ${url}`,
-      fallbackTitle: 'Preview'
+      fallbackTitle: 'Preview',
+      goBack: 'Go back',
+      goForward: 'Go forward',
+      reload: 'Reload preview',
+      address: 'Preview URL',
+      navigate: 'Navigate preview'
     }
   },
 

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -2835,7 +2835,11 @@ export const en: Translations = {
       viewportMobile: 'Mobile',
       viewportWidth: 'Viewport width',
       viewportHeight: 'Viewport height',
-      viewportApply: 'Apply'
+      viewportApply: 'Apply',
+      chat: 'Select page for chat',
+      chatNone: 'Active tab',
+      chatTile: 'Tile',
+      chatEmpty: 'No open chats'
     }
   },
 

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -2546,7 +2546,11 @@ export const ja = defineLocale({
       viewportMobile: 'モバイル',
       viewportWidth: '幅',
       viewportHeight: '高さ',
-      viewportApply: '適用'
+      viewportApply: '適用',
+      chat: 'チャット用にページを選ぶ',
+      chatNone: 'アクティブなタブ',
+      chatTile: 'タイル',
+      chatEmpty: '開いているチャットはありません'
     }
   },
 

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -2533,7 +2533,12 @@ export const ja = defineLocale({
       loadFailedConsole: (code, message) => `読み込みに失敗しました${code ? ` (${code})` : ''}: ${message}`,
       unreachableDescription: 'プレビューページに到達できませんでした。',
       openTarget: url => `${url} を開く`,
-      fallbackTitle: 'プレビュー'
+      fallbackTitle: 'プレビュー',
+      goBack: '戻る',
+      goForward: '進む',
+      reload: 'プレビューを再読み込み',
+      address: 'プレビュー URL',
+      navigate: 'プレビューをナビゲート'
     }
   },
 

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -2538,7 +2538,15 @@ export const ja = defineLocale({
       goForward: '進む',
       reload: 'プレビューを再読み込み',
       address: 'プレビュー URL',
-      navigate: 'プレビューをナビゲート'
+      navigate: 'プレビューをナビゲート',
+      viewport: 'プレビューの表示サイズ',
+      viewportFree: 'フリーサイズ',
+      viewportDesktop: 'デスクトップ',
+      viewportLaptop: 'ノートPC',
+      viewportMobile: 'モバイル',
+      viewportWidth: '幅',
+      viewportHeight: '高さ',
+      viewportApply: '適用'
     }
   },
 

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -2407,6 +2407,11 @@ export interface Translations {
       unreachableDescription: string
       openTarget: (url: string) => string
       fallbackTitle: string
+      goBack: string
+      goForward: string
+      reload: string
+      address: string
+      navigate: string
     }
   }
 

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -2420,6 +2420,10 @@ export interface Translations {
       viewportWidth: string
       viewportHeight: string
       viewportApply: string
+      chat: string
+      chatNone: string
+      chatTile: string
+      chatEmpty: string
     }
   }
 

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -2412,6 +2412,14 @@ export interface Translations {
       reload: string
       address: string
       navigate: string
+      viewport: string
+      viewportFree: string
+      viewportDesktop: string
+      viewportLaptop: string
+      viewportMobile: string
+      viewportWidth: string
+      viewportHeight: string
+      viewportApply: string
     }
   }
 

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -2458,7 +2458,15 @@ export const zhHant = defineLocale({
       goForward: '下一頁',
       reload: '重新載入預覽',
       address: '預覽網址',
-      navigate: '瀏覽預覽'
+      navigate: '瀏覽預覽',
+      viewport: '預覽檢視區',
+      viewportFree: '自由尺寸',
+      viewportDesktop: '桌面',
+      viewportLaptop: '筆電',
+      viewportMobile: '手機',
+      viewportWidth: '寬度',
+      viewportHeight: '高度',
+      viewportApply: '套用'
     }
   },
 

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -2466,7 +2466,11 @@ export const zhHant = defineLocale({
       viewportMobile: '手機',
       viewportWidth: '寬度',
       viewportHeight: '高度',
-      viewportApply: '套用'
+      viewportApply: '套用',
+      chat: '為對話選擇頁面',
+      chatNone: '目前分頁',
+      chatTile: '分欄',
+      chatEmpty: '沒有開啟的對話'
     }
   },
 

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -2453,7 +2453,12 @@ export const zhHant = defineLocale({
       loadFailedConsole: (code, message) => `載入失敗${code ? ` (${code})` : ''}：${message}`,
       unreachableDescription: '無法連線至預覽頁面。',
       openTarget: url => `開啟 ${url}`,
-      fallbackTitle: '預覽'
+      fallbackTitle: '預覽',
+      goBack: '上一頁',
+      goForward: '下一頁',
+      reload: '重新載入預覽',
+      address: '預覽網址',
+      navigate: '瀏覽預覽'
     }
   },
 

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -2995,7 +2995,12 @@ export const zh: Translations = {
       loadFailedConsole: (code, message) => `加载失败${code ? ` (${code})` : ''}: ${message}`,
       unreachableDescription: '无法访问预览页面。',
       openTarget: url => `打开 ${url}`,
-      fallbackTitle: '预览'
+      fallbackTitle: '预览',
+      goBack: '后退',
+      goForward: '前进',
+      reload: '重新加载预览',
+      address: '预览网址',
+      navigate: '浏览预览'
     }
   },
 

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -3000,7 +3000,15 @@ export const zh: Translations = {
       goForward: '前进',
       reload: '重新加载预览',
       address: '预览网址',
-      navigate: '浏览预览'
+      navigate: '浏览预览',
+      viewport: '预览视口',
+      viewportFree: '自由尺寸',
+      viewportDesktop: '桌面',
+      viewportLaptop: '笔记本',
+      viewportMobile: '手机',
+      viewportWidth: '宽度',
+      viewportHeight: '高度',
+      viewportApply: '应用'
     }
   },
 

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -3008,7 +3008,11 @@ export const zh: Translations = {
       viewportMobile: '手机',
       viewportWidth: '宽度',
       viewportHeight: '高度',
-      viewportApply: '应用'
+      viewportApply: '应用',
+      chat: '为对话选择页面',
+      chatNone: '当前标签',
+      chatTile: '分栏',
+      chatEmpty: '没有打开的对话'
     }
   },
 


### PR DESCRIPTION
## Summary

Stacks on #87349 (URL toolbar) and #87384 (viewport). The live Browser tile can now pin which chat owns the page for `read_preview`.

The Browser is a singleton (`url:browser`). Without a pin, `read_preview` still reads the tab in front. With a pin, **that session** gets the Browser tab even if a file peek is showing. Other sessions keep the front-tab behavior.

- Toolbar button beside the URL (same row as viewport) — not a strip glyph
- Lists the main chat + open session tiles
- Pin is a live runtime id — not persisted (runtime ids die on restart)
- `preview.read.request` passes the asking `sessionId` into `readActivePreview`

## Commits

| SHA | What |
|---|---|
| `0950b164a5` | #87349 — URL toolbar |
| `c0c22a23ec` | #87384 — viewport picker |
| `509975dc9d` | **this PR** — chat pin |

If the earlier PRs merge first, this rebases down to the last commit.

## Test plan

- [x] `npx tsc --noEmit`
- [x] `npx vitest run src/app/chat/right-rail/` (66)
- [x] `npx eslint` / `npx prettier --check` on changed files
- [ ] Human: pin main chat, peek a file, confirm that chat's `read_preview` still returns the page
- [ ] Human: a second (unpinned) session still reads the file peek
