### PR TITLE
fix(guard): treat directory-referenced script candidates as nothing to scan

### DIFF
--- a/cron/lifecycle_guard.py
+++ b/cron/lifecycle_guard.py
@@ -439,6 +439,15 @@ def _read_referenced_script(path: Path) -> tuple[Optional[str], bool]:
         return None, False
     try:
         metadata = os.fstat(descriptor)
+        if stat.S_ISDIR(metadata.st_mode):
+            # A path-shaped token in *argument text* (e.g. a multi-line
+            # `gh pr create --body` mentioning `github/repositories/`) can
+            # resolve to an existing directory in cwd. A directory is not a
+            # script — it can be neither executed nor read as one — so this
+            # is "nothing to scan" (mirroring the binary-sniff branch below),
+            # not a fail-closed block (#87401). Other non-regular types
+            # (FIFOs, devices, sockets) stay fail-closed.
+            return None, False
         if not stat.S_ISREG(metadata.st_mode):
             return None, True
         # Sniff a small prefix first: files that are clearly compiled

--- a/tests/hermes_cli/test_gateway_restart_loop.py
+++ b/tests/hermes_cli/test_gateway_restart_loop.py
@@ -724,6 +724,55 @@ class TestLifecycleGuardModule:
         assert text is None
         assert unsafe is False
 
+    def test_read_referenced_script_directory_is_nothing_to_scan(self, tmp_path):
+        """#87401: a path-shaped token in argument text (a multi-line
+        ``gh pr create --body`` mentioning ``github/repositories/``) can
+        resolve to an existing *directory* in cwd. A directory is not a
+        script — it must read as "nothing to scan", not trip the
+        non-regular fail-closed branch that used to block the command."""
+        from cron.lifecycle_guard import _read_referenced_script
+
+        text, unsafe = _read_referenced_script(tmp_path)
+        assert text is None
+        assert unsafe is False
+
+    def test_directory_token_in_multiline_argument_not_blocked(self, tmp_path):
+        """#87401 end-to-end: the referenced-script walk must not block an
+        innocuous ``gh pr create`` whose --body text mentions a repo-relative
+        path across a newline when the first segment matches an existing
+        directory in cwd."""
+        from cron.lifecycle_guard import (
+            contains_gateway_lifecycle_command_or_referenced_script,
+        )
+
+        (tmp_path / "github").mkdir()
+        # Real newline in the command: the continuation line tokenizes
+        # cleanly (per-line quoting mangled or stripped upstream, as in the
+        # gateway session from the report), so `github/` becomes the
+        # segment's executable candidate and resolves to the existing
+        # directory. Unpatched this is a hard block.
+        command = "gh pr create --title t --body x\ngithub/ 2 files (not a CI target)"
+        result = contains_gateway_lifecycle_command_or_referenced_script(
+            command, cwd=str(tmp_path)
+        )
+        assert result is False
+
+    def test_non_regular_referenced_script_still_fails_closed(self, tmp_path):
+        """#87401 guard: only directories became nothing-to-scan. Other
+        non-regular files (FIFOs, devices, sockets) keep the fail-closed
+        read so an unreadable candidate can never smuggle a lifecycle
+        command past the walk."""
+        import stat as stat_mod
+
+        from cron.lifecycle_guard import _read_referenced_script
+
+        fifo = tmp_path / "script.fifo"
+        os.mkfifo(fifo)
+        text, unsafe = _read_referenced_script(fifo)
+        assert text is None
+        assert unsafe is True
+        assert stat_mod.S_ISFIFO(fifo.stat().st_mode)
+
     def test_remote_read_fallback_binary_does_not_crash_guard(self):
         """#77703: in the gateway the referenced-script walk carries a
         ``read_remote_script`` fallback (SSH/Modal/Daytona backends read the
@@ -1205,9 +1254,13 @@ class TestLifecycleGuardNeverRaises:
         assert self._scan(f"bash {weird}") is False
 
     def test_directory_and_dev_null_fail_closed_not_crash(self, tmp_path):
-        # Non-regular files are suspicious (fail closed = blocked), but the
-        # important contract is: verdict, not exception.
-        assert self._scan(f"bash {tmp_path}") is True
+        # A directory reference is "nothing to scan" (#87401): a directory
+        # can be neither executed nor read as a script, so blocking on it
+        # only produced false positives (argument text mentioning a
+        # repo-relative path after a newline). Other non-regular files
+        # (devices, FIFOs) stay fail-closed, and the important contract
+        # is: verdict, not exception.
+        assert self._scan(f"bash {tmp_path}") is False
         assert self._scan("bash /dev/null") is True
 
     def test_magic_prefix_binaries_skipped_without_full_read(self, tmp_path):
@@ -1238,6 +1291,10 @@ class TestLifecycleGuardNeverRaises:
         binary.write_bytes(b"\x7fELF" + bytes(128))
         for value in ("nul\x00byte.sh", str(binary), "/nonexistent/x.sh"):
             check_gateway_lifecycle("clean prompt", value)  # must not raise
-        for value in ("/dev/null", str(tmp_path)):
+        # A directory script value is nothing to scan, not a lifecycle
+        # block (#87401) — the job fails at exec time with the shell's own
+        # "is a directory" error. /dev/null (a device) still fails closed.
+        check_gateway_lifecycle("clean prompt", str(tmp_path))  # must not raise
+        for value in ("/dev/null",):
             with pytest.raises(GatewayLifecycleBlocked):
                 check_gateway_lifecycle("clean prompt", value)


### PR DESCRIPTION
## What does this PR do?

Fixes a lifecycle-guard false positive (#87401): when a command's argument text contains a newline followed by a `word/`-shaped token whose first segment matches an existing directory in cwd, `_iter_command_segments` promotes that token to the continuation segment's *executable candidate*, `_resolve_terminal_script_path` resolves it to the directory, and `_read_referenced_script`'s non-regular fail-closed branch (`not stat.S_ISREG → (None, True)`) returned `unsafe=True` — hard-blocking a completely innocuous command (the report's case: `gh pr create` whose `--body` mentions `github/repositories/`) with the misleading "cannot restart or stop the gateway" message.

A directory can be neither executed nor read as a script, so resolving a candidate to a directory is now "nothing to scan", mirroring the existing binary-magic branch in the same function. **Other** non-regular types (FIFOs, character devices like `/dev/null`, sockets) keep the fail-closed read — those remain blocked, preserving the guard's defense-in-depth posture for genuinely unreadable candidates.

This intentionally narrows two previously-fail-closed assertions (a directory as `bash`'s script argument, and a directory as a cron job's script value): in both spots the "block" fired with a lifecycle message that had nothing to do with the actual problem (the script path is a directory); the shell's own `EISDIR` error at run time is the clearer outcome.

## Related Issue

Fixes #87401

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `cron/lifecycle_guard.py` — `_read_referenced_script`: add an `S_ISDIR` branch returning `(None, False)` (nothing to scan) before the non-regular fail-closed branch, with a comment documenting why directories are exempt while FIFOs/devices stay fail-closed.
- `tests/hermes_cli/test_gateway_restart_loop.py` — three new tests: `_read_referenced_script` on a directory returns nothing-to-scan; end-to-end multi-line `gh pr create` with a directory-resolving continuation token is not blocked; `_read_referenced_script` on a FIFO still returns `unsafe=True`. Updated the two contract tests (`test_directory_and_dev_null_fail_closed_not_crash`, `test_check_gateway_lifecycle_adversarial_script_values`) to reflect that directories no longer block while `/dev/null` still does.

## How to Test

1. `uv run --extra acp pytest tests/hermes_cli/test_gateway_restart_loop.py -q` — Observed result: `128 passed`.
2. `uv run --extra acp pytest tests/cron/ -q` — Observed result: `710 passed, 1 skipped`.
3. Direct repro of the report (should pass, i.e. not blocked, with this PR; unpatched `main` returns `True`):
   ```python
   import tempfile, os
   from cron.lifecycle_guard import contains_gateway_lifecycle_command_or_referenced_script
   with tempfile.TemporaryDirectory() as td:
       os.makedirs(os.path.join(td, "github"))
       cmd = "gh pr create --title t --body x\ngithub/ 2 files (not a CI target)"
       assert contains_gateway_lifecycle_command_or_referenced_script(cmd, cwd=td) is False
   ```
4. Fail-closed preserved: `contains_gateway_lifecycle_command_or_referenced_script("bash /dev/null")` should still return `True` (covered by the updated contract test and the new FIFO test).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
