### PR TITLE
fix(custom): add providers.<name>.reasoning_format to control the reasoning wire shape

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -194,6 +194,32 @@ model:
 #     model: databricks-claude-fable-5
 #     key_cmd: "databricks auth token -p MY-PROFILE"
 
+# Reasoning wire format (optional): reasoning_format
+# ------------------------------------------------------------------
+# provider=custom endpoints disagree on how reasoning controls are spelled on
+# the wire. When reasoning is enabled with an effort level, Hermes defaults to
+# a top-level `reasoning_effort` string — the native OpenAI-compatible shape
+# GLM/ARK and DashScope expect. OpenRouter-style gateways instead want a
+# nested `reasoning` object in the request body, and some strict proxies
+# reject either unknown field with a 400. Set `reasoning_format` on the
+# provider entry to pick the dialect your endpoint speaks:
+#
+#   top_level         (default; same as unset) top-level reasoning_effort
+#                     string. Disable sends reasoning_effort: "none" plus
+#                     extra_body.think: false (Ollama).
+#   reasoning_object  nested request-body object instead:
+#                     reasoning: {"enabled": true, "effort": "<level>"}
+#                     (disable sends {"enabled": false})
+#   none              never send reasoning fields for this endpoint — for
+#                     proxies that 400 on unrecognized parameters
+#
+# Unknown values are ignored (treated as unset).
+#
+# providers:
+#   my-gateway:
+#     base_url: "http://127.0.0.1:8317/v1"
+#     reasoning_format: reasoning_object
+
 # Named provider overrides (optional)
 # Use this for per-provider request timeouts, non-stream stale timeouts,
 # and per-model exceptions.

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1894,6 +1894,10 @@ def get_custom_provider_reasoning_format(
     ``reasoning`` object in the request body, and some proxies reject either
     unknown field with a 400. This per-provider key lets users pick the
     dialect their endpoint speaks (#72649).
+
+    If multiple entries normalize to the same route, entries are checked in
+    compatibility-list order and the first valid ``reasoning_format`` wins;
+    entries with missing or invalid values are skipped.
     """
     if not base_url:
         return None

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1388,8 +1388,8 @@ def _normalize_custom_provider_entry(
         "name", "api", "url", "base_url", "api_key", "key_env", "api_key_env",
         "key_cmd",
         "api_mode", "transport", "model", "default_model", "models",
-        "models_discovered",
-        "context_length", "rate_limit_delay",
+"models_discovered",
+        "context_length", "rate_limit_delay", "reasoning_format",
         "request_timeout_seconds", "stale_timeout_seconds",
         "discover_models", "extra_body", "extra_headers",
         "ssl_ca_cert", "ssl_verify",
@@ -1529,6 +1529,10 @@ def _normalize_custom_provider_entry(
     if isinstance(rate_limit_delay, (int, float)) and rate_limit_delay >= 0:
         normalized["rate_limit_delay"] = rate_limit_delay
 
+    reasoning_format = entry.get("reasoning_format")
+    if isinstance(reasoning_format, str) and reasoning_format.strip():
+        normalized["reasoning_format"] = reasoning_format.strip()
+
     discover_models = entry.get("discover_models")
     if isinstance(discover_models, bool):
         normalized["discover_models"] = discover_models
@@ -1580,6 +1584,7 @@ def _custom_provider_entry_to_provider_config(
         "models_discovered",
         "context_length",
         "rate_limit_delay",
+        "reasoning_format",
         "discover_models",
         "extra_body",
         "extra_headers",
@@ -1861,6 +1866,61 @@ def get_custom_provider_context_length(
             continue
         if ctx > 0:
             return ctx
+    return None
+
+
+# Accepted values for ``providers.<name>.reasoning_format``. Anything else is
+# treated as unset so a typo can never silently change the wire format.
+_CUSTOM_REASONING_FORMATS = {"top_level", "reasoning_object", "none"}
+
+
+def get_custom_provider_reasoning_format(
+    base_url: str,
+    custom_providers: Optional[List[Dict[str, Any]]] = None,
+    config: Optional[Dict[str, Any]] = None,
+) -> Optional[str]:
+    """Return the ``reasoning_format`` declared on the matching provider entry.
+
+    Matches the entry whose normalized route identity equals *base_url*,
+    mirroring :func:`get_custom_provider_context_length`, and returns one of
+    ``"top_level"`` / ``"reasoning_object"`` / ``"none"`` (case-insensitive in
+    config). Returns ``None`` when no entry matches, the entry declares no
+    format, or the value is not one of the accepted formats — callers treat
+    ``None`` as the historical default (``top_level``).
+
+    ``provider="custom"`` endpoints disagree on how reasoning controls are
+    spelled on the wire: GLM/ARK/DashScope read a top-level
+    ``reasoning_effort`` string, OpenRouter-style gateways expect a nested
+    ``reasoning`` object in the request body, and some proxies reject either
+    unknown field with a 400. This per-provider key lets users pick the
+    dialect their endpoint speaks (#72649).
+    """
+    if not base_url:
+        return None
+    if custom_providers is None:
+        try:
+            custom_providers = get_compatible_custom_providers(config)
+        except Exception:
+            return None
+    if not isinstance(custom_providers, list):
+        return None
+
+    target_url = normalize_route_base_url(base_url)
+    if not target_url:
+        return None
+
+    for entry in custom_providers:
+        if not isinstance(entry, dict):
+            continue
+        entry_url = normalize_route_base_url(entry.get("base_url"))
+        if not entry_url or entry_url != target_url:
+            continue
+        raw = entry.get("reasoning_format")
+        if not isinstance(raw, str):
+            continue
+        fmt = raw.strip().lower()
+        if fmt in _CUSTOM_REASONING_FORMATS:
+            return fmt
     return None
 
 

--- a/plugins/model-providers/custom/__init__.py
+++ b/plugins/model-providers/custom/__init__.py
@@ -18,10 +18,14 @@ Volcengine ARK, vLLM, llama.cpp). Key quirks:
     keeps the behavior above.
 """
 
+import logging
 from typing import Any
 
 from providers import register_provider
 from providers.base import ProviderProfile
+
+
+logger = logging.getLogger(__name__)
 
 
 class CustomProfile(ProviderProfile):
@@ -87,7 +91,10 @@ class CustomProfile(ProviderProfile):
             _enabled = reasoning_config.get("enabled", True)
             if _effort == "none" or _enabled is False:
                 if _format == "none":
-                    pass
+                    logger.warning(
+                        "reasoning_format='none' suppresses the explicit reasoning "
+                        "disable request; the endpoint's server-side default applies"
+                    )
                 elif _format == "reasoning_object":
                     extra_body["reasoning"] = {"enabled": False}
                 else:

--- a/plugins/model-providers/custom/__init__.py
+++ b/plugins/model-providers/custom/__init__.py
@@ -10,6 +10,12 @@ Volcengine ARK, vLLM, llama.cpp). Key quirks:
   - reasoning_config enabled + effort → top-level reasoning_effort
     (the native OpenAI-compatible format GLM/ARK expect; unset omits it
     so the endpoint's server default applies)
+  - providers.<name>.reasoning_format optionally overrides the wire shape
+    per endpoint (#72649): "reasoning_object" nests the config as
+    extra_body.reasoning = {"enabled": ..., "effort": ...} for
+    OpenRouter-style gateways, "none" suppresses reasoning fields entirely
+    for proxies that 400 on unknown params, and "top_level" (the default)
+    keeps the behavior above.
 """
 
 from typing import Any
@@ -20,6 +26,23 @@ from providers.base import ProviderProfile
 
 class CustomProfile(ProviderProfile):
     """Custom/Ollama local provider — think=false and num_ctx support."""
+
+    @staticmethod
+    def _resolve_reasoning_format(base_url: Any) -> str | None:
+        """Look up ``providers.<name>.reasoning_format`` for this endpoint.
+
+        Returns one of ``"top_level"`` / ``"reasoning_object"`` / ``"none"``,
+        or ``None`` when unset/unavailable — ``None`` and ``"top_level"``
+        both mean the historical default wire shape.
+        """
+        if not base_url or not isinstance(base_url, str):
+            return None
+        try:
+            from hermes_cli.config import get_custom_provider_reasoning_format
+
+            return get_custom_provider_reasoning_format(base_url)
+        except Exception:
+            return None
 
     def build_api_kwargs_extras(
         self,
@@ -51,31 +74,49 @@ class CustomProfile(ProviderProfile):
         # Ollama-only flag and thinking is already server-default-on for these
         # backends, so forcing it risks a 400 on GLM/vLLM endpoints that don't
         # recognize it. Mirrors the DeepSeek/Zai profile precedent.
+        #
+        # ``providers.<name>.reasoning_format`` overrides the wire shape per
+        # endpoint (#72649): "reasoning_object" nests the same intent as
+        # extra_body.reasoning = {"enabled": ..., "effort": ...}
+        # (OpenRouter-style gateways), "none" emits no reasoning fields at
+        # all (proxies that 400 on unknown params). Unset/"top_level" keeps
+        # the historical behavior above byte-for-byte.
         if reasoning_config and isinstance(reasoning_config, dict):
+            _format = self._resolve_reasoning_format(ctx.get("base_url"))
             _effort = (reasoning_config.get("effort") or "").strip().lower()
             _enabled = reasoning_config.get("enabled", True)
             if _effort == "none" or _enabled is False:
-                # Ollama's /v1/chat/completions silently ignores
-                # extra_body.think (only /api/chat honours it — ollama#14820)
-                # but respects the top-level reasoning_effort field, so both
-                # are needed to actually stop a thinking-capable model from
-                # reasoning (#25758). Endpoints that recognize neither simply
-                # ignore them.
-                top_level["reasoning_effort"] = "none"
-                extra_body["think"] = False
+                if _format == "none":
+                    pass
+                elif _format == "reasoning_object":
+                    extra_body["reasoning"] = {"enabled": False}
+                else:
+                    # Ollama's /v1/chat/completions silently ignores
+                    # extra_body.think (only /api/chat honours it — ollama#14820)
+                    # but respects the top-level reasoning_effort field, so both
+                    # are needed to actually stop a thinking-capable model from
+                    # reasoning (#25758). Endpoints that recognize neither simply
+                    # ignore them.
+                    top_level["reasoning_effort"] = "none"
+                    extra_body["think"] = False
             elif _effort:
-                # Clamp the internal ladder onto the widest OpenAI-compatible
-                # wire vocabulary (shared policy in agent.reasoning_effort) —
-                # GLM/ARK, vLLM and SGLang all top out at "max"; forwarding
-                # "ultra" verbatim is a guaranteed 400 (#89503).
-                from agent.reasoning_effort import (
-                    OPENAI_COMPAT_WIRE_EFFORTS,
-                    clamp_effort,
-                )
+                if _format == "none":
+                    pass
+                elif _format == "reasoning_object":
+                    extra_body["reasoning"] = {"enabled": True, "effort": _effort}
+                else:
+                    # Clamp the internal ladder onto the widest OpenAI-compatible
+                    # wire vocabulary (shared policy in agent.reasoning_effort) —
+                    # GLM/ARK, vLLM and SGLang all top out at "max"; forwarding
+                    # "ultra" verbatim is a guaranteed 400 (#89503).
+                    from agent.reasoning_effort import (
+                        OPENAI_COMPAT_WIRE_EFFORTS,
+                        clamp_effort,
+                    )
 
-                top_level["reasoning_effort"] = clamp_effort(
-                    _effort, OPENAI_COMPAT_WIRE_EFFORTS
-                )
+                    top_level["reasoning_effort"] = clamp_effort(
+                        _effort, OPENAI_COMPAT_WIRE_EFFORTS
+                    )
 
         return extra_body, top_level
 

--- a/tests/hermes_cli/test_custom_provider_reasoning_format.py
+++ b/tests/hermes_cli/test_custom_provider_reasoning_format.py
@@ -1,0 +1,159 @@
+"""Unit tests for ``get_custom_provider_reasoning_format``.
+
+The helper resolves ``providers.<name>.reasoning_format`` by normalized
+route identity (mirroring ``get_custom_provider_context_length``) and
+fails closed: anything that isn't exactly one of the three accepted
+dialects returns ``None``, which callers treat as the historical
+``top_level`` default — a typo must never silently change the wire format.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from hermes_cli.config import get_custom_provider_reasoning_format
+
+
+BASE_URL = "http://127.0.0.1:8317/v1"
+
+
+def _entry(**overrides):
+    entry = {"name": "cpa", "base_url": BASE_URL}
+    entry.update(overrides)
+    return entry
+
+
+class TestValueResolution:
+    @pytest.mark.parametrize("fmt", ["top_level", "reasoning_object", "none"])
+    def test_accepted_formats_round_trip(self, fmt):
+        result = get_custom_provider_reasoning_format(
+            BASE_URL, custom_providers=[_entry(reasoning_format=fmt)]
+        )
+        assert result == fmt
+
+    def test_case_and_whitespace_normalized(self):
+        result = get_custom_provider_reasoning_format(
+            BASE_URL,
+            custom_providers=[_entry(reasoning_format="  Reasoning_Object ")],
+        )
+        assert result == "reasoning_object"
+
+    @pytest.mark.parametrize(
+        "bad", ["object", "topLevel", "reasoning-object", "", "  ", "off"]
+    )
+    def test_unknown_values_fail_closed(self, bad):
+        """Typos return None so the caller keeps the historical default."""
+        result = get_custom_provider_reasoning_format(
+            BASE_URL, custom_providers=[_entry(reasoning_format=bad)]
+        )
+        assert result is None
+
+    @pytest.mark.parametrize("bad", [None, 5, True, ["top_level"], {"v": 1}])
+    def test_non_string_values_fail_closed(self, bad):
+        result = get_custom_provider_reasoning_format(
+            BASE_URL, custom_providers=[_entry(reasoning_format=bad)]
+        )
+        assert result is None
+
+    def test_missing_key_returns_none(self):
+        result = get_custom_provider_reasoning_format(
+            BASE_URL, custom_providers=[_entry()]
+        )
+        assert result is None
+
+    def test_invalid_entry_does_not_shadow_later_valid_one(self):
+        """Same-route duplicate entries: scan continues past an invalid value."""
+        result = get_custom_provider_reasoning_format(
+            BASE_URL,
+            custom_providers=[
+                _entry(reasoning_format="bogus"),
+                _entry(reasoning_format="reasoning_object"),
+            ],
+        )
+        assert result == "reasoning_object"
+
+
+class TestRouteMatching:
+    def test_trailing_slash_on_entry_still_matches(self):
+        result = get_custom_provider_reasoning_format(
+            BASE_URL,
+            custom_providers=[
+                _entry(base_url=BASE_URL + "/", reasoning_format="none")
+            ],
+        )
+        assert result == "none"
+
+    def test_trailing_slash_on_query_still_matches(self):
+        result = get_custom_provider_reasoning_format(
+            BASE_URL + "/",
+            custom_providers=[_entry(reasoning_format="none")],
+        )
+        assert result == "none"
+
+    def test_different_route_does_not_match(self):
+        result = get_custom_provider_reasoning_format(
+            "http://127.0.0.1:20128/v1",
+            custom_providers=[_entry(reasoning_format="reasoning_object")],
+        )
+        assert result is None
+
+    def test_only_matching_entry_is_consulted(self):
+        result = get_custom_provider_reasoning_format(
+            BASE_URL,
+            custom_providers=[
+                _entry(
+                    base_url="http://127.0.0.1:20128/v1",
+                    reasoning_format="none",
+                ),
+                _entry(reasoning_format="reasoning_object"),
+            ],
+        )
+        assert result == "reasoning_object"
+
+
+class TestDegenerateInputs:
+    def test_empty_base_url_returns_none(self):
+        result = get_custom_provider_reasoning_format(
+            "", custom_providers=[_entry(reasoning_format="none")]
+        )
+        assert result is None
+
+    def test_non_list_custom_providers_returns_none(self):
+        result = get_custom_provider_reasoning_format(
+            BASE_URL, custom_providers={"cpa": _entry()}
+        )
+        assert result is None
+
+    def test_non_dict_entries_are_skipped(self):
+        result = get_custom_provider_reasoning_format(
+            BASE_URL,
+            custom_providers=["junk", None, _entry(reasoning_format="none")],
+        )
+        assert result == "none"
+
+
+class TestConfigPath:
+    """End-to-end through get_compatible_custom_providers + the normalizer.
+
+    Pins that ``_normalize_custom_provider_entry`` passes ``reasoning_format``
+    through — without the passthrough, a ``providers:`` dict entry would
+    lose the key before this helper ever sees it.
+    """
+
+    def test_providers_dict_entry_resolves(self):
+        config = {
+            "providers": {
+                "cpa": {"api": BASE_URL, "reasoning_format": "reasoning_object"}
+            }
+        }
+        result = get_custom_provider_reasoning_format(BASE_URL, config=config)
+        assert result == "reasoning_object"
+
+    def test_legacy_custom_providers_list_resolves(self):
+        config = {
+            "custom_providers": [
+                {"name": "cpa", "base_url": BASE_URL, "reasoning_format": "none"}
+            ]
+        }
+        result = get_custom_provider_reasoning_format(BASE_URL, config=config)
+        assert result == "none"

--- a/tests/plugins/model_providers/test_custom_profile.py
+++ b/tests/plugins/model_providers/test_custom_profile.py
@@ -13,6 +13,9 @@ These tests pin the wire-shape contract:
                           including ``max``/``xhigh``
   - enabled + no effort → nothing emitted (endpoint's server default applies)
   - ollama_num_ctx      → extra_body.options.num_ctx, orthogonal to reasoning
+  - providers.<name>.reasoning_format overrides the dialect per endpoint
+    (#72649): "reasoning_object" nests extra_body.reasoning={enabled, effort},
+    "none" emits no reasoning fields, "top_level"/unset keeps the above.
 """
 
 from __future__ import annotations
@@ -105,5 +108,184 @@ class TestCustomReasoningWithNumCtx:
             reasoning_config=None, ollama_num_ctx=8192, model="qwen3"
         )
         assert eb == {"options": {"num_ctx": 8192}}
+        assert tl == {}
+
+
+class TestCustomReasoningFormatOverride:
+    """``providers.<name>.reasoning_format`` switches the reasoning wire dialect.
+
+    Custom endpoints disagree on how reasoning is spelled on the wire
+    (#72649): GLM/ARK read a top-level ``reasoning_effort`` string,
+    OpenRouter-style gateways expect a nested ``reasoning`` object, and some
+    proxies 400 on either unknown field. The config lookup is monkeypatched
+    at its import site so these tests pin only the profile's dispatch; the
+    classes above run with no lookup result at all, which is the
+    byte-for-byte-unchanged guarantee for existing configs.
+    """
+
+    BASE_URL = "http://127.0.0.1:8317/v1"
+
+    def _patch_format(self, monkeypatch, fmt):
+        """Route the profile's lazy config lookup to a canned answer."""
+        calls: list = []
+
+        def fake_lookup(base_url, custom_providers=None, config=None):
+            calls.append(base_url)
+            return fmt
+
+        monkeypatch.setattr(
+            "hermes_cli.config.get_custom_provider_reasoning_format",
+            fake_lookup,
+        )
+        return calls
+
+    def test_reasoning_object_enabled_nests_in_extra_body(
+        self, custom_profile, monkeypatch
+    ):
+        """reasoning_object + enabled → extra_body.reasoning object, nothing top-level.
+
+        This is the OpenRouter-style dialect. Efforts pass through verbatim —
+        gateways that accept the object shape validate effort themselves
+        (e.g. accept "ultra" that they reject as top-level reasoning_effort).
+        """
+        self._patch_format(monkeypatch, "reasoning_object")
+        eb, tl = custom_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": True, "effort": "ultra"},
+            model="glm-5.2",
+            base_url=self.BASE_URL,
+        )
+        assert eb == {"reasoning": {"enabled": True, "effort": "ultra"}}
+        assert tl == {}
+
+    def test_reasoning_object_disabled_sends_enabled_false(
+        self, custom_profile, monkeypatch
+    ):
+        """reasoning_object + disabled → {"enabled": False}, no think/effort fields."""
+        self._patch_format(monkeypatch, "reasoning_object")
+        eb, tl = custom_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": False},
+            model="glm-5.2",
+            base_url=self.BASE_URL,
+        )
+        assert eb == {"reasoning": {"enabled": False}}
+        assert tl == {}
+
+    def test_reasoning_object_effort_none_alias_disables(
+        self, custom_profile, monkeypatch
+    ):
+        """effort='none' is the disable alias in every dialect."""
+        self._patch_format(monkeypatch, "reasoning_object")
+        eb, tl = custom_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": True, "effort": "none"},
+            model="glm-5.2",
+            base_url=self.BASE_URL,
+        )
+        assert eb == {"reasoning": {"enabled": False}}
+        assert tl == {}
+
+    def test_format_none_enabled_emits_nothing(self, custom_profile, monkeypatch):
+        """reasoning_format='none' suppresses reasoning fields on enable.
+
+        For proxies (LiteLLM-style) that 400 on any unrecognized reasoning
+        field — the endpoint's server-side default applies.
+        """
+        self._patch_format(monkeypatch, "none")
+        eb, tl = custom_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": True, "effort": "high"},
+            model="glm-5.2",
+            base_url=self.BASE_URL,
+        )
+        assert eb == {}
+        assert tl == {}
+
+    def test_format_none_disabled_emits_nothing(self, custom_profile, monkeypatch):
+        """reasoning_format='none' also suppresses the disable fields.
+
+        Fixes the second failure mode in #72649: `/reasoning none` used to
+        400 on strict proxies because the disable path still sent
+        reasoning_effort + think.
+        """
+        self._patch_format(monkeypatch, "none")
+        eb, tl = custom_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": False},
+            model="glm-5.2",
+            base_url=self.BASE_URL,
+        )
+        assert eb == {}
+        assert tl == {}
+
+    def test_explicit_top_level_matches_default_enabled(
+        self, custom_profile, monkeypatch
+    ):
+        """reasoning_format='top_level' is the spelled-out default — identical wire."""
+        self._patch_format(monkeypatch, "top_level")
+        eb, tl = custom_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": True, "effort": "high"},
+            model="glm-5.2",
+            base_url=self.BASE_URL,
+        )
+        assert eb == {}
+        assert tl == {"reasoning_effort": "high"}
+
+    def test_explicit_top_level_matches_default_disabled(
+        self, custom_profile, monkeypatch
+    ):
+        self._patch_format(monkeypatch, "top_level")
+        eb, tl = custom_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": False},
+            model="glm-5.2",
+            base_url=self.BASE_URL,
+        )
+        assert eb == {"think": False}
+        assert tl == {"reasoning_effort": "none"}
+
+    def test_no_configured_format_falls_back_to_top_level(
+        self, custom_profile, monkeypatch
+    ):
+        """Lookup returning None (no providers entry / no key) → default dialect."""
+        calls = self._patch_format(monkeypatch, None)
+        eb, tl = custom_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": True, "effort": "high"},
+            model="glm-5.2",
+            base_url=self.BASE_URL,
+        )
+        assert eb == {}
+        assert tl == {"reasoning_effort": "high"}
+        assert calls == [self.BASE_URL]
+
+    def test_lookup_failure_falls_back_to_top_level(
+        self, custom_profile, monkeypatch
+    ):
+        """A crashing config lookup must never break the request build."""
+
+        def boom(base_url, custom_providers=None, config=None):
+            raise RuntimeError("config unavailable")
+
+        monkeypatch.setattr(
+            "hermes_cli.config.get_custom_provider_reasoning_format", boom
+        )
+        eb, tl = custom_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": True, "effort": "high"},
+            model="glm-5.2",
+            base_url=self.BASE_URL,
+        )
+        assert eb == {}
+        assert tl == {"reasoning_effort": "high"}
+
+    def test_reasoning_object_composes_with_num_ctx(
+        self, custom_profile, monkeypatch
+    ):
+        """num_ctx wiring is orthogonal to the reasoning dialect."""
+        self._patch_format(monkeypatch, "reasoning_object")
+        eb, tl = custom_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": True, "effort": "medium"},
+            ollama_num_ctx=8192,
+            model="qwen3",
+            base_url=self.BASE_URL,
+        )
+        assert eb == {
+            "options": {"num_ctx": 8192},
+            "reasoning": {"enabled": True, "effort": "medium"},
+        }
         assert tl == {}
 

--- a/tests/plugins/model_providers/test_custom_profile.py
+++ b/tests/plugins/model_providers/test_custom_profile.py
@@ -198,7 +198,9 @@ class TestCustomReasoningFormatOverride:
         assert eb == {}
         assert tl == {}
 
-    def test_format_none_disabled_emits_nothing(self, custom_profile, monkeypatch):
+    def test_format_none_disabled_emits_nothing_and_warns(
+        self, custom_profile, monkeypatch, caplog
+    ):
         """reasoning_format='none' also suppresses the disable fields.
 
         Fixes the second failure mode in #72649: `/reasoning none` used to
@@ -213,6 +215,7 @@ class TestCustomReasoningFormatOverride:
         )
         assert eb == {}
         assert tl == {}
+        assert "suppresses the explicit reasoning disable request" in caplog.text
 
     def test_explicit_top_level_matches_default_enabled(
         self, custom_profile, monkeypatch

--- a/website/docs/integrations/providers.md
+++ b/website/docs/integrations/providers.md
@@ -1280,7 +1280,7 @@ providers:
     transport: anthropic_messages  # for Anthropic-compatible proxies
 ```
 
-Each entry accepts: `api` (the endpoint base URL — `base_url`/`url` are accepted aliases), `name` (optional display name; defaults to the dict key), `key_env` or inline `api_key` or `key_cmd` (see below), `transport` (`chat_completions` / `anthropic_messages` / `codex_responses`), `default_model`, `models`, `context_length`, `discover_models`, `extra_body`, `extra_headers`, `ssl_ca_cert` / `ssl_verify`, and `enabled: false` to hide an entry without deleting it.
+Each entry accepts: `api` (the endpoint base URL — `base_url`/`url` are accepted aliases), `name` (optional display name; defaults to the dict key), `key_env` or inline `api_key` or `key_cmd` (see below), `transport` (`chat_completions` / `anthropic_messages` / `codex_responses`), `default_model`, `models`, `context_length`, `discover_models`, `extra_body`, `extra_headers`, `reasoning_format` (see below), `ssl_ca_cert` / `ssl_verify`, and `enabled: false` to hide an entry without deleting it.
 
 #### Command-minted credentials (`key_cmd`)
 
@@ -1333,6 +1333,25 @@ extra_body:
   chat_template_kwargs:
     enable_thinking: false
 ```
+
+#### Reasoning wire format (`reasoning_format`)
+
+Custom endpoints disagree on how reasoning controls are spelled on the wire. When reasoning is enabled with an effort level, Hermes defaults to sending a **top-level `reasoning_effort` string** — the native OpenAI-compatible shape GLM/ARK and DashScope expect. But OpenRouter-style gateways instead want a nested `reasoning` **object** in the request body, and some strict proxies reject either unknown field with a 400. Set `reasoning_format` on the provider entry to pick the dialect your endpoint speaks:
+
+```yaml
+providers:
+  my-gateway:
+    base_url: "http://127.0.0.1:8317/v1"
+    reasoning_format: reasoning_object
+```
+
+| Value | Enabled + effort | Disabled (`/reasoning none`) |
+|-------|------------------|------------------------------|
+| `top_level` (default; same as unset) | top-level `reasoning_effort: "<level>"` | top-level `reasoning_effort: "none"` + `extra_body.think: false` (Ollama) |
+| `reasoning_object` | `extra_body.reasoning: {"enabled": true, "effort": "<level>"}` | `extra_body.reasoning: {"enabled": false}` |
+| `none` | no reasoning fields sent | no reasoning fields sent |
+
+Efforts pass through verbatim in every dialect (including levels like `max` or `ultra` that only some backends accept — the endpoint validates them). Unknown `reasoning_format` values are ignored and fall back to the default, so a typo never silently changes the request shape. Use `none` when a proxy rejects any reasoning parameter — including the disable fields — with a 400.
 
 The `hermes model` → Custom Endpoint wizard now prompts for the API mode explicitly and persists your answer to `config.yaml` (as `transport` on the provider entry). URL-based auto-detection (e.g. `/anthropic` paths → `anthropic_messages`) still happens as a fallback when the field is left blank.
 


### PR DESCRIPTION
## What does this PR do?

`provider="custom"` endpoints disagree on how reasoning controls are spelled on the wire. `CustomProfile` unconditionally sends a **top-level `reasoning_effort` string** when reasoning is enabled with an effort — the native shape GLM-5.2/ARK/DashScope expect. But OpenRouter-style gateways expect a nested **`reasoning` object** in the request body (`{"enabled": ..., "effort": ...}`), and some strict proxies (LiteLLM-style) reject *either* unknown field with a 400. There is currently no way to tell Hermes which dialect a custom endpoint speaks, so those endpoints reject every reasoning-enabled request.

This PR adds an **opt-in** `providers.<name>.reasoning_format` config key with three values:

| Value | Enabled + effort | Disabled (`/reasoning none`) |
|-------|------------------|------------------------------|
| `top_level` (default; same as unset) | top-level `reasoning_effort: "<level>"` | top-level `reasoning_effort: "none"` + `extra_body.think: false` |
| `reasoning_object` | `extra_body.reasoning: {"enabled": true, "effort": "<level>"}` | `extra_body.reasoning: {"enabled": false}` |
| `none` | no reasoning fields sent | no reasoning fields sent |

Design notes:

- **Default behavior is byte-for-byte unchanged.** With no `reasoning_format` key (every existing config), the profile emits exactly what it emits today — all 11 pre-existing wire-shape tests pass unmodified. This deliberately does *not* flip any default (per #77030, which settled the DashScope default on top-level).
- `none` also fixes the second failure mode discussed in #72649: `/reasoning none` used to 400 on strict proxies because the *disable* path still sent `reasoning_effort` + `think`.
- Unknown values fail closed to the default — a typo can never silently change the request shape.
- The lookup mirrors `get_custom_provider_context_length` (normalized route-identity matching via `normalize_route_base_url`), is lazily imported in the profile, and any lookup failure falls back to the default dialect so request building can never break.
- Effort strings pass through verbatim in every dialect (including `max`/`ultra`) — the endpoint validates them, matching the existing top-level contract.

## Related Issue

Fixes #72649

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/model-providers/custom/__init__.py` — `CustomProfile.build_api_kwargs_extras` dispatches on the configured format (resolved from `base_url` via a lazy, exception-safe config lookup); unset/`top_level` keeps the existing branches verbatim
- `hermes_cli/config.py` — new `get_custom_provider_reasoning_format()` helper (route-identity matching, fail-closed enum validation); `_normalize_custom_provider_entry` passes `reasoning_format` through (+ known-keys list, v12 migration field list)
- `tests/plugins/model_providers/test_custom_profile.py` — new `TestCustomReasoningFormatOverride` class (10 tests: three dialects × enabled/disabled, fallback-on-None, fallback-on-lookup-crash, base_url plumbing, num_ctx composition); all 11 existing tests untouched and passing
- `tests/hermes_cli/test_custom_provider_reasoning_format.py` — new helper unit tests (16 tests: enum round-trip, case/whitespace normalization, fail-closed on invalid/non-string values, trailing-slash route matching, degenerate inputs, end-to-end through `providers:` dict and legacy `custom_providers:` list normalization)
- `cli-config.yaml.example` — documented the new key with all three values
- `website/docs/integrations/providers.md` — added `reasoning_format` to the accepted-keys list + a "Reasoning wire format" section with the dialect table

## How to Test

Reproduction (before this change), against an OpenRouter-style gateway registered as `provider=custom`:

1. `providers: {gw: {base_url: "http://127.0.0.1:8317/v1", ...}}` and set a reasoning effort (e.g. `reasoning_effort: "ultra"`)
2. Start a chat — the request carries top-level `reasoning_effort="ultra"`
3. Gateway rejects it: `level "ultra" not supported, valid levels: low, medium, high`
4. The same gateway accepts the identical request when reasoning is sent as `extra_body.reasoning={"enabled":true,"effort":"ultra"}` (verified with a hand-built request)
5. After this change, add `reasoning_format: reasoning_object` to the entry → requests are accepted; two independent local gateways verified (ports 8317 and 20128)

Automated:

```
$ python -m pytest tests/plugins/model_providers/test_custom_profile.py tests/hermes_cli/test_custom_provider_reasoning_format.py -q
...............................................                          [100%]
47 passed in 4.89s

$ python -m pytest tests/providers/test_provider_profiles.py -q
22 passed
```

`tests/hermes_cli/test_config.py`: 93 passed, 1 pre-existing machine-specific failure (`TestGetHermesHome.test_default_path`, asserts `~/.hermes` on a machine with a relocated Hermes home) — identical before and after this change on the same machine.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass (targeted suites above; one pre-existing environment-specific failure in `test_config.py` unrelated to this change)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11 (Python 3.11); real-gateway verification against two local OpenAI-compatible gateways

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — pure request-shaping logic, no OS surface; `scripts/check-windows-footguns.py` clean
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Top-level dialect rejected by an object-dialect gateway (the bug):

```
400 {"error": {"message": "level \"ultra\" not supported, valid levels: low, medium, high"}}
```

Same gateway, object dialect (what `reasoning_format: reasoning_object` now sends):

```
POST /v1/chat/completions  body: {..., "reasoning": {"enabled": true, "effort": "ultra"}}  → 200
```
