### PR TITLE
fix: distinguish DNS failures from offline state

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -2604,35 +2604,42 @@ class AIAgent:
         """Extract a human-readable one-liner from an API error.
 
         Handles Cloudflare HTML error pages (502, 503, etc.) by pulling the
-        <title> tag instead of dumping raw HTML. Network/DNS failures are
-        translated into an offline hint, including when an SDK wraps the
-        original OS error. Falls back to a truncated str(error) otherwise.
+        <title> tag instead of dumping raw HTML. DNS and routing failures are
+        identified separately, including when an SDK wraps the original OS
+        error. Falls back to a truncated str(error) otherwise.
         """
         raw = str(error)
 
-        # Linux, macOS, and Windows use different low-level messages when DNS
-        # cannot resolve the provider while the device is offline. SDKs often
-        # wrap that OSError in a generic "Connection error", so inspect the
-        # exception chain before showing the top-level message to the user.
-        network_resolution_markers = (
+        # Linux, macOS, and Windows use different low-level messages for DNS
+        # resolution failures. SDKs often wrap that OSError in a generic
+        # "Connection error", so inspect the exception chain. A DNS failure
+        # does not prove that the device's wider internet connection is down.
+        dns_resolution_markers = (
             "temporary failure in name resolution",
             "name or service not known",
             "nodename nor servname provided, or not known",
             "getaddrinfo failed",
             "no address associated with hostname",
+        )
+        routing_failure_markers = (
             "network is unreachable",
         )
         current: Optional[BaseException] = error
         seen: set[int] = set()
         while current is not None and id(current) not in seen:
             seen.add(id(current))
-            if any(
-                marker in str(current).lower()
-                for marker in network_resolution_markers
-            ):
+            current_message = str(current).lower()
+            if any(marker in current_message for marker in dns_resolution_markers):
                 return (
-                    "Hermes can't reach the model provider. You may be offline. "
-                    "Check your internet connection and try again."
+                    "Hermes couldn't resolve the model provider hostname (DNS failure). "
+                    "This does not mean the device is offline; VPN, DNS, or provider "
+                    "routing may be temporarily unavailable."
+                )
+            if any(marker in current_message for marker in routing_failure_markers):
+                return (
+                    "Hermes couldn't route this request to the model provider. "
+                    "This does not establish that the entire internet connection is "
+                    "offline."
                 )
             current = current.__cause__ or current.__context__
 

--- a/tests/run_agent/test_summarize_api_error.py
+++ b/tests/run_agent/test_summarize_api_error.py
@@ -46,10 +46,9 @@ def test_empty_body_falls_back_to_response_json_error_message():
         "nodename nor servname provided, or not known",
         "getaddrinfo failed",
         "No address associated with hostname",
-        "Network is unreachable",
     ],
 )
-def test_network_resolution_failure_explains_that_the_user_may_be_offline(
+def test_dns_resolution_failure_does_not_claim_the_device_is_offline(
     technical_message,
 ):
     error = OSError(-3, technical_message)
@@ -57,13 +56,14 @@ def test_network_resolution_failure_explains_that_the_user_may_be_offline(
     summary = AIAgent._summarize_api_error(error)
 
     assert summary == (
-        "Hermes can't reach the model provider. You may be offline. "
-        "Check your internet connection and try again."
+        "Hermes couldn't resolve the model provider hostname (DNS failure). "
+        "This does not mean the device is offline; VPN, DNS, or provider routing "
+        "may be temporarily unavailable."
     )
-    assert "name resolution" not in summary.lower()
+    assert "check your internet connection" not in summary.lower()
 
 
-def test_wrapped_dns_resolution_failure_gets_the_same_friendly_message():
+def test_wrapped_dns_resolution_failure_gets_the_same_accurate_message():
     try:
         try:
             raise OSError(-3, "Temporary failure in name resolution")
@@ -72,8 +72,21 @@ def test_wrapped_dns_resolution_failure_gets_the_same_friendly_message():
     except RuntimeError as error:
         summary = AIAgent._summarize_api_error(error)
 
-    assert "You may be offline" in summary
+    assert "DNS failure" in summary
+    assert "does not mean the device is offline" in summary
     assert "Connection error" not in summary
+
+
+def test_network_unreachable_does_not_tell_the_user_to_check_the_internet():
+    error = OSError(51, "Network is unreachable")
+
+    summary = AIAgent._summarize_api_error(error)
+
+    assert summary == (
+        "Hermes couldn't route this request to the model provider. "
+        "This does not establish that the entire internet connection is offline."
+    )
+    assert "check your internet connection" not in summary.lower()
 
 
 def test_unread_streaming_response_does_not_crash_and_falls_back_to_exception_message():


### PR DESCRIPTION
## Summary
- Separate DNS name-resolution failures from routing failures.
- Stop treating either condition as proof that the user’s device is offline.
- Preserve exception-chain inspection for SDK-wrapped connection errors.

## Motivation
On macOS 26.6.1, Wi‑Fi and general internet connectivity remained available while the system DNS service temporarily had no resolver assigned. xAI, Telegram, and Flow hostname lookups failed at the same time. The current message, “You may be offline. Check your internet connection,” incorrectly shifts diagnosis to the user and obscures DNS, VPN, or provider-routing failures.

## Tests
- `30 passed` across API-error summary and related provider recovery tests.
- DNS and routing regression cases included.

No model, provider, retry, authentication, or fallback behavior is changed.
