### PR TITLE
fix: gateway hygiene compression must bypass anti-thrash guard with force=True

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -19001,6 +19001,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                                         lambda: _hyg_agent._compress_context(
                                             _hyg_msgs, "",
                                             approx_tokens=_approx_tokens,
+                                            force=True,
                                             commit_fence=_hyg_commit_fence,
                                         ),
                                     )


### PR DESCRIPTION
Gateway hygiene is the safety-net compression that MUST run to prevent context overflow. It was calling `_compress_context()` with `force=False` (default), which gets blocked by the anti-thrash guard when `_ineffective_compression_count >= 2` or `_fallback_compression_streak >= 2`.

When blocked, hygiene returns messages unchanged → context keeps growing → eventually hits provider hard limits → API disconnects.

Manual `/compress` already passes `force=True` (slash_commands.py:4283). Gateway hygiene should do the same since it's a mandatory safety-net, not an optional auto-compress attempt.

Fixes context bloating when anti-thrash guard is tripped.