### PR TITLE
fix(cli): persist a cold-launch-safe desktop Exec

### DIFF
--- a/hermes_cli/linux_desktop_entry.py
+++ b/hermes_cli/linux_desktop_entry.py
@@ -57,16 +57,48 @@ def icon_path(project_root: Path) -> Path:
     return project_root / "apps" / "desktop" / "assets" / "icon.png"
 
 
-def resolve_exec_command() -> str:
+def _is_inside_checkout(path: Optional[str], project_root: Optional[Path]) -> bool:
+    """True when ``path`` lives inside the source checkout.
+
+    An entry point inside the checkout is the bare ``hermes`` launcher
+    script, not an installed wrapper. It runs under ``/usr/bin/env
+    python3`` and leans on the caller's interpreter and ``sys.path`` to
+    import ``hermes_cli``; a cold desktop-menu launch supplies neither.
+    """
+    if not path or project_root is None:
+        return False
+    try:
+        Path(path).resolve().relative_to(Path(project_root).resolve())
+    except (ValueError, OSError):
+        return False
+    return True
+
+
+def resolve_exec_command(project_root: Optional[Path] = None) -> str:
     """Build the absolute ``Exec=`` command line for ``hermes desktop``.
 
     Prefer the real ``hermes`` executable (argv[0] or PATH). When Hermes
     runs as a module with no launcher installed, use the current
     interpreter, also absolute.
+
+    ``resolve_hermes_bin()`` ranks ``sys.argv[0]`` first. That is right
+    for re-exec'ing *this* process, where argv[0] is runnable by
+    construction, and wrong for a value written to disk and run later by
+    the desktop environment. When this entry is what launched us, argv[0]
+    is the checkout's bare ``hermes`` script, so baking it back into
+    ``Exec`` breaks every later menu launch and never heals. It also makes
+    the rendered contents alternate between the wrapper and the script,
+    which defeats the unchanged-contents check below and rewrites the
+    entry on every other launch (#80439). Discard a checkout-internal
+    entry point and fall through to PATH, then to the interpreter.
     """
     from hermes_cli.relaunch import resolve_hermes_bin
 
     bin_path = resolve_hermes_bin()
+    if _is_inside_checkout(bin_path, project_root):
+        bin_path = shutil.which("hermes")
+        if _is_inside_checkout(bin_path, project_root):
+            bin_path = None
     if bin_path:
         argv = [str(Path(bin_path).resolve()), "desktop"]
     else:
@@ -154,7 +186,10 @@ def install_desktop_entry(project_root: Path) -> Optional[Path]:
     # Use the themed name when the checkout has no icon (a lite or
     # packaged install). A broken absolute path renders as no icon.
     icon_value = str(icon) if icon.is_file() else "hermes"
-    contents = render_desktop_entry(resolve_exec_command(), icon_value)
+    contents = render_desktop_entry(resolve_exec_command(project_root), icon_value)
+    # Imported inside the function so the module stays import-light for
+    # the uninstaller and the Electron main process.
+    from utils import atomic_write_text
 
     try:
         entry_path.parent.mkdir(parents=True, exist_ok=True)
@@ -162,9 +197,15 @@ def install_desktop_entry(project_root: Path) -> Optional[Path]:
         # churn the menu caches.
         if entry_path.is_file() and entry_path.read_text(encoding="utf-8") == contents:
             return entry_path
-        entry_path.write_text(contents, encoding="utf-8")
+        # Publish through the shared atomic writer: a truncate-then-write
+        # leaves a zero-length entry when the write is interrupted, which
+        # drops Hermes out of the menu and kills the taskbar pin for good.
+        # ``preserve_mode`` chmods the temp file before the replace, so an
+        # entry that is already 0o755 never transits mkstemp's 0o600.
+        atomic_write_text(entry_path, contents, preserve_mode=True, create_mode=0o755)
         # Some launchers (and older Plasma) offer the entry only when it
-        # is executable.
+        # is executable. Still forced here: preserve_mode carries over a
+        # mode the user (or an older Hermes) may have left non-executable.
         entry_path.chmod(0o755)
     except OSError:
         return None

--- a/hermes_cli/linux_desktop_entry.py
+++ b/hermes_cli/linux_desktop_entry.py
@@ -61,10 +61,10 @@ def icon_path(project_root: Path) -> Path:
 def _is_inside_checkout(path: Optional[str], project_root: Optional[Path]) -> bool:
     """True when ``path`` lives inside the source checkout.
 
-    An entry point inside the checkout is the bare ``hermes`` launcher
-    script, not an installed wrapper. It runs under ``/usr/bin/env
-    python3`` and leans on the caller's interpreter and ``sys.path`` to
-    import ``hermes_cli``; a cold desktop-menu launch supplies neither.
+    An entry point inside the checkout is normally the bare ``hermes``
+    script, not an installed wrapper. Its ``/usr/bin/env python3`` shebang
+    can select a system interpreter without Hermes' venv dependencies in a
+    cold desktop-menu environment.
     """
     if not path or project_root is None:
         return False
@@ -81,7 +81,7 @@ def _is_env_python_wrapper(path: str) -> bool:
     A ``#!/usr/bin/env python3`` shebang defers the interpreter choice to
     whatever ``PATH`` holds when the script runs. The desktop session's
     ``PATH`` is not the shell's, so such a wrapper can land on a system
-    interpreter with no Hermes venv on ``sys.path`` — the same stranded
+    interpreter without Hermes' venv dependencies — the same stranded
     entry ``_is_inside_checkout`` guards against, reached by shebang
     instead of by location. A hand-written ``~/bin/hermes``, or a console
     script from a non-venv editable install, fails that way while sitting

--- a/hermes_cli/linux_desktop_entry.py
+++ b/hermes_cli/linux_desktop_entry.py
@@ -9,7 +9,8 @@ Two values must be absolute for the entry to work:
 
   - ``Exec`` — the launcher runs without shell ``PATH`` customizations, so
     a bare ``hermes desktop`` fails when hermes lives in ``~/.local/bin``
-    or a venv. Resolve the real binary and write its full path.
+    or a venv. Write a full path, and one that does not itself go looking
+    for an interpreter on the session's ``PATH``.
   - ``Icon`` — an unqualified icon name needs an indexed icon theme. The
     spec allows an absolute path instead, so point at the app icon in the
     checkout. Do not copy the icon: ``Exec`` already depends on that tree.
@@ -74,6 +75,58 @@ def _is_inside_checkout(path: Optional[str], project_root: Optional[Path]) -> bo
     return True
 
 
+def _is_env_python_wrapper(path: str) -> bool:
+    """True when ``path`` picks its interpreter off ``PATH`` at exec time.
+
+    A ``#!/usr/bin/env python3`` shebang defers the interpreter choice to
+    whatever ``PATH`` holds when the script runs. The desktop session's
+    ``PATH`` is not the shell's, so such a wrapper can land on a system
+    interpreter with no Hermes venv on ``sys.path`` — the same stranded
+    entry ``_is_inside_checkout`` guards against, reached by shebang
+    instead of by location. A hand-written ``~/bin/hermes``, or a console
+    script from a non-venv editable install, fails that way while sitting
+    outside the checkout. An installed console script instead names its
+    own interpreter absolutely and carries no such dependency.
+
+    Require the shebang's program *basename* to be exactly ``env``, so a
+    hardcoded interpreter under a directory named ``envs`` does not match,
+    and require the command it runs to be a ``python*`` binary.
+    """
+    try:
+        with open(path, "rb") as handle:
+            shebang = handle.readline(256)
+    except OSError:
+        return False
+    if not shebang.startswith(b"#!"):
+        return False
+    tokens = shebang[2:].split()
+    if not tokens:
+        return False
+    if os.path.basename(tokens[0].decode("utf-8", "replace")) != "env":
+        return False
+    args = tokens[1:]
+    if args[:1] == [b"-S"]:
+        args = args[1:]
+    if not args:
+        return False
+    return os.path.basename(args[0].decode("utf-8", "replace")).startswith("python")
+
+
+def _is_durable_entry_point(path: Optional[str], project_root: Optional[Path]) -> bool:
+    """True when ``path`` is worth persisting into ``Exec=``.
+
+    Durable means it still starts Hermes months later from a cold menu
+    click, under the desktop session's own environment. Two ways to fail
+    that: living inside the checkout, and resolving ``python`` through
+    ``PATH``.
+    """
+    if not path:
+        return False
+    if _is_inside_checkout(path, project_root):
+        return False
+    return not _is_env_python_wrapper(path)
+
+
 def resolve_exec_command(project_root: Optional[Path] = None) -> str:
     """Build the absolute ``Exec=`` command line for ``hermes desktop``.
 
@@ -89,20 +142,32 @@ def resolve_exec_command(project_root: Optional[Path] = None) -> str:
     ``Exec`` breaks every later menu launch and never heals. It also makes
     the rendered contents alternate between the wrapper and the script,
     which defeats the unchanged-contents check below and rewrites the
-    entry on every other launch (#80439). Discard a checkout-internal
-    entry point and fall through to PATH, then to the interpreter.
+    entry on every other launch (#80439). Discard a candidate that is not
+    durable and fall through to PATH, then to the interpreter.
     """
     from hermes_cli.relaunch import resolve_hermes_bin
 
     bin_path = resolve_hermes_bin()
-    if _is_inside_checkout(bin_path, project_root):
+    if bin_path and not _is_durable_entry_point(bin_path, project_root):
+        # ``resolve_hermes_bin()`` already consulted PATH last, so only
+        # retry it when the candidate it returned came from argv[0].
         bin_path = shutil.which("hermes")
-        if _is_inside_checkout(bin_path, project_root):
+        if not _is_durable_entry_point(bin_path, project_root):
             bin_path = None
     if bin_path:
         argv = [str(Path(bin_path).resolve()), "desktop"]
     else:
-        argv = [str(Path(sys.executable).resolve()), "-m", "hermes_cli.main", "desktop"]
+        # Absolute, but NOT symlink-resolved. A venv's ``bin/python`` is a
+        # symlink to the base interpreter, and CPython decides it is inside
+        # a venv by looking for ``pyvenv.cfg`` beside the path it was
+        # *invoked* through. Dereferencing that symlink lands on the base
+        # interpreter — for a uv-created venv, under
+        # ``~/.local/share/uv/python/``, outside the venv entirely — so the
+        # venv's ``site-packages`` drops off ``sys.path`` and the persisted
+        # command cannot import ``hermes_cli`` at all. Every other site
+        # that spawns this same module keeps the invocation path:
+        # ``relaunch.py``, ``uninstall.py``, ``kanban_db.py``.
+        argv = [os.path.abspath(sys.executable), "-m", "hermes_cli.main", "desktop"]
     return " ".join(_quote_exec_arg(a) for a in argv)
 
 

--- a/tests/hermes_cli/test_linux_desktop_entry.py
+++ b/tests/hermes_cli/test_linux_desktop_entry.py
@@ -2,11 +2,13 @@
 
 from __future__ import annotations
 
+import errno
 import stat
 from pathlib import Path
 
 import pytest
 
+import utils
 from hermes_cli import linux_desktop_entry as lde
 
 
@@ -24,6 +26,25 @@ def _make_project(tmp_path: Path) -> Path:
     icon.parent.mkdir(parents=True)
     icon.write_bytes(b"\x89PNG fake")
     return root
+
+
+def _make_executable(path: Path) -> Path:
+    """Create an executable stand-in for a hermes entry point."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("#!/usr/bin/env python3\n", encoding="utf-8")
+    path.chmod(0o755)
+    return path
+
+
+def _fake_which(monkeypatch, hermes: "str | None") -> None:
+    """Pin ``shutil.which("hermes")``.
+
+    ``relaunch`` and this module share the one ``shutil`` module, so a
+    single patch covers both lookups.
+    """
+    monkeypatch.setattr(
+        lde.shutil, "which", lambda name: hermes if name == "hermes" else None
+    )
 
 
 def _parse(entry_text: str) -> dict:
@@ -88,6 +109,87 @@ def test_exec_falls_back_to_interpreter_module(tmp_path, xdg_home, monkeypatch):
     assert Path(exec_line.split(" ")[0]).is_absolute()
 
 
+# ---------------------------------------------------------------------------
+# Exec must not depend on what launched this process (#80439)
+# ---------------------------------------------------------------------------
+
+
+def test_exec_prefers_path_wrapper_over_checkout_argv0(tmp_path, xdg_home, monkeypatch):
+    root = _make_project(tmp_path)
+    checkout_script = _make_executable(root / "hermes")
+    wrapper = _make_executable(tmp_path / "local" / "bin" / "hermes")
+    # The desktop entry launched us, so argv[0] is the checkout script.
+    monkeypatch.setattr(lde.sys, "argv", [str(checkout_script), "desktop"])
+    _fake_which(monkeypatch, str(wrapper))
+    monkeypatch.setattr(lde, "refresh_desktop_databases", lambda _dir: [])
+
+    entry = lde.install_desktop_entry(root)
+    exec_line = _parse(entry.read_text(encoding="utf-8"))["Exec"]
+
+    expected = lde._quote_exec_arg(str(wrapper.resolve()))
+    assert exec_line == f"{expected} desktop"
+    assert str(checkout_script) not in exec_line
+
+
+def test_exec_rejects_checkout_argv0_when_no_wrapper_on_path(tmp_path, xdg_home, monkeypatch):
+    root = _make_project(tmp_path)
+    checkout_script = _make_executable(root / "hermes")
+    monkeypatch.setattr(lde.sys, "argv", [str(checkout_script), "desktop"])
+    _fake_which(monkeypatch, None)
+    monkeypatch.setattr(lde, "refresh_desktop_databases", lambda _dir: [])
+
+    entry = lde.install_desktop_entry(root)
+    exec_line = _parse(entry.read_text(encoding="utf-8"))["Exec"]
+
+    # The checkout's bare launcher runs under `/usr/bin/env python3` with
+    # no venv shim, so a cold menu launch cannot import hermes_cli through
+    # it. Persisting it strands the entry permanently.
+    assert str(checkout_script) not in exec_line
+    assert exec_line.endswith("-m hermes_cli.main desktop")
+    assert Path(exec_line.split(" ")[0]).is_absolute()
+
+
+def test_exec_accepts_argv0_outside_the_checkout(tmp_path, xdg_home, monkeypatch):
+    root = _make_project(tmp_path)
+    wrapper = _make_executable(tmp_path / "opt" / "bin" / "hermes")
+    monkeypatch.setattr(lde.sys, "argv", [str(wrapper), "desktop"])
+    _fake_which(monkeypatch, None)
+    monkeypatch.setattr(lde, "refresh_desktop_databases", lambda _dir: [])
+
+    entry = lde.install_desktop_entry(root)
+    exec_line = _parse(entry.read_text(encoding="utf-8"))["Exec"]
+
+    # Only checkout-internal entry points are rejected. An installed
+    # wrapper reached through argv[0] is still the best value to persist.
+    expected = lde._quote_exec_arg(str(wrapper.resolve()))
+    assert exec_line == f"{expected} desktop"
+
+
+def test_entry_is_stable_across_a_relaunch_through_itself(tmp_path, xdg_home, monkeypatch):
+    root = _make_project(tmp_path)
+    checkout_script = _make_executable(root / "hermes")
+    wrapper = _make_executable(tmp_path / "local" / "bin" / "hermes")
+    _fake_which(monkeypatch, str(wrapper))
+    refreshes: list[Path] = []
+    monkeypatch.setattr(lde, "refresh_desktop_databases", lambda d: refreshes.append(d) or [])
+
+    # Launch one: from a terminal, through the installed wrapper.
+    monkeypatch.setattr(lde.sys, "argv", [str(wrapper), "desktop"])
+    entry = lde.install_desktop_entry(root)
+    first = entry.read_text(encoding="utf-8")
+    assert len(refreshes) == 1
+
+    # Launch two: the menu runs the entry, so argv[0] is now whatever the
+    # entry pointed at. Feed back the worst case.
+    monkeypatch.setattr(lde.sys, "argv", [str(checkout_script), "desktop"])
+    lde.install_desktop_entry(root)
+
+    assert entry.read_text(encoding="utf-8") == first
+    # No rewrite means no menu-cache churn, so Plasma keeps the taskbar
+    # pin associated with this entry instead of spawning a second window.
+    assert len(refreshes) == 1
+
+
 def test_install_is_idempotent_and_skips_cache_refresh(tmp_path, xdg_home, monkeypatch):
     root = _make_project(tmp_path)
     monkeypatch.setattr("hermes_cli.relaunch.resolve_hermes_bin", lambda: "/usr/bin/hermes")
@@ -100,6 +202,43 @@ def test_install_is_idempotent_and_skips_cache_refresh(tmp_path, xdg_home, monke
     # Unchanged content → no rewrite, no menu-cache churn on every launch.
     lde.install_desktop_entry(root)
     assert len(calls) == 1
+
+
+def test_install_publishes_atomically_and_leaves_no_temp(tmp_path, xdg_home, monkeypatch):
+    root = _make_project(tmp_path)
+    monkeypatch.setattr(lde, "refresh_desktop_databases", lambda _dir: [])
+
+    monkeypatch.setattr("hermes_cli.relaunch.resolve_hermes_bin", lambda: "/usr/bin/hermes")
+    entry = lde.install_desktop_entry(root)
+    # Change the rendered contents so this is a real overwrite, not the
+    # unchanged-contents fast path.
+    monkeypatch.setattr("hermes_cli.relaunch.resolve_hermes_bin", lambda: "/opt/hermes/bin/hermes")
+    assert lde.install_desktop_entry(root) == entry
+
+    assert list(entry.parent.iterdir()) == [entry]
+    assert _parse(entry.read_text(encoding="utf-8"))["Exec"] == "/opt/hermes/bin/hermes desktop"
+    assert stat.S_IMODE(entry.stat().st_mode) == 0o755
+
+
+def test_failed_publish_leaves_the_existing_entry_intact(tmp_path, xdg_home, monkeypatch):
+    root = _make_project(tmp_path)
+    monkeypatch.setattr(lde, "refresh_desktop_databases", lambda _dir: [])
+    monkeypatch.setattr("hermes_cli.relaunch.resolve_hermes_bin", lambda: "/usr/bin/hermes")
+
+    entry = lde.install_desktop_entry(root)
+    published = entry.read_text(encoding="utf-8")
+
+    def boom(_tmp, _target):
+        raise OSError(errno.EIO, "the disk went away mid-publish")
+
+    monkeypatch.setattr(utils, "atomic_replace", boom)
+    monkeypatch.setattr("hermes_cli.relaunch.resolve_hermes_bin", lambda: "/opt/hermes/bin/hermes")
+
+    assert lde.install_desktop_entry(root) is None
+    # A truncate-then-write would have left a partial or zero-length
+    # entry here, dropping Hermes out of the menu and killing the pin.
+    assert entry.read_text(encoding="utf-8") == published
+    assert list(entry.parent.iterdir()) == [entry]
 
 
 def test_install_without_source_icon_uses_themed_name(tmp_path, xdg_home, monkeypatch):

--- a/tests/hermes_cli/test_linux_desktop_entry.py
+++ b/tests/hermes_cli/test_linux_desktop_entry.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import errno
 import os
+import shlex
+import subprocess
 import stat
 from pathlib import Path
 
@@ -140,6 +142,57 @@ def test_exec_prefers_path_wrapper_over_checkout_argv0(tmp_path, xdg_home, monke
     assert str(checkout_script) not in exec_line
 
 
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX launcher probe uses /bin/sh")
+def test_generated_exec_survives_a_cold_desktop_path(tmp_path, xdg_home, monkeypatch):
+    root = _make_project(tmp_path)
+    checkout_script = _make_executable(root / "hermes", ENV_PYTHON_SHEBANG)
+    checkout_script.write_text(
+        ENV_PYTHON_SHEBANG + "print('desktop-ok')\n",
+        encoding="utf-8",
+    )
+
+    wrapper = tmp_path / "launcher-bin" / "hermes"
+    wrapper.parent.mkdir()
+    wrapper.write_text(
+        "#!/bin/sh\n"
+        f"exec {shlex.quote(lde.sys.executable)} "
+        f"{shlex.quote(str(checkout_script))} \"$@\"\n",
+        encoding="utf-8",
+    )
+    wrapper.chmod(0o755)
+
+    # A cold desktop PATH resolves env-python to this deliberately unusable
+    # interpreter. The persisted Exec must instead select the absolute wrapper,
+    # which pins the already-working interpreter before launch.
+    desktop_bin = tmp_path / "desktop-bin"
+    desktop_bin.mkdir()
+    poison_python = desktop_bin / "python3"
+    poison_python.write_text("#!/bin/sh\nexit 97\n", encoding="utf-8")
+    poison_python.chmod(0o755)
+
+    monkeypatch.setattr(lde.sys, "argv", [str(checkout_script), "desktop"])
+    monkeypatch.setenv("PATH", str(wrapper.parent))
+    monkeypatch.setattr(lde, "refresh_desktop_databases", lambda _dir: [])
+
+    entry = lde.install_desktop_entry(root)
+    exec_argv = shlex.split(_parse(entry.read_text(encoding="utf-8"))["Exec"])
+    cold_cwd = tmp_path / "cold-cwd"
+    cold_cwd.mkdir()
+    result = subprocess.run(
+        exec_argv,
+        cwd=cold_cwd,
+        env={"PATH": str(desktop_bin)},
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert exec_argv[0] == str(wrapper.resolve())
+    assert result.returncode == 0, result.stderr
+    assert result.stdout == "desktop-ok\n"
+
+
 def test_exec_rejects_checkout_argv0_when_no_wrapper_on_path(tmp_path, xdg_home, monkeypatch):
     root = _make_project(tmp_path)
     checkout_script = _make_executable(root / "hermes", ENV_PYTHON_SHEBANG)
@@ -150,9 +203,9 @@ def test_exec_rejects_checkout_argv0_when_no_wrapper_on_path(tmp_path, xdg_home,
     entry = lde.install_desktop_entry(root)
     exec_line = _parse(entry.read_text(encoding="utf-8"))["Exec"]
 
-    # The checkout's bare launcher runs under `/usr/bin/env python3` with
-    # no venv shim, so a cold menu launch cannot import hermes_cli through
-    # it. Persisting it strands the entry permanently.
+    # The checkout's bare launcher runs under `/usr/bin/env python3`, so a
+    # cold menu launch can select a system interpreter without Hermes' venv
+    # dependencies. Persisting it strands the entry permanently.
     assert str(checkout_script) not in exec_line
     assert exec_line.endswith("-m hermes_cli.main desktop")
     assert Path(exec_line.split(" ")[0]).is_absolute()
@@ -207,8 +260,8 @@ def test_exec_rejects_env_python_wrapper_outside_the_checkout(tmp_path, xdg_home
     editable install, sits outside the checkout and so survives
     ``_is_inside_checkout`` — yet it still looks up ``python3`` on ``PATH``
     when it runs. A cold menu launch supplies the desktop session's
-    ``PATH``, not the shell's, and the interpreter it lands on need not
-    have Hermes on ``sys.path``. Rejecting by location alone is not enough.
+    ``PATH``, not the shell's, and can select an interpreter without Hermes'
+    venv dependencies. Rejecting by location alone is not enough.
     """
     root = _make_project(tmp_path)
     wrapper = _make_executable(tmp_path / "home" / "bin" / "hermes", ENV_PYTHON_SHEBANG)

--- a/tests/hermes_cli/test_linux_desktop_entry.py
+++ b/tests/hermes_cli/test_linux_desktop_entry.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import errno
+import os
 import stat
 from pathlib import Path
 
@@ -28,10 +29,18 @@ def _make_project(tmp_path: Path) -> Path:
     return root
 
 
-def _make_executable(path: Path) -> Path:
+#: What an installed console script's shebang looks like: its own
+#: interpreter, hardcoded absolute, with no ``PATH`` lookup at exec time.
+INSTALLED_SHEBANG = "#!/opt/hermes/venv/bin/python3\n"
+#: What the checkout's bare ``hermes`` launcher looks like: the
+#: interpreter is whatever ``PATH`` yields when the script runs.
+ENV_PYTHON_SHEBANG = "#!/usr/bin/env python3\n"
+
+
+def _make_executable(path: Path, shebang: str = INSTALLED_SHEBANG) -> Path:
     """Create an executable stand-in for a hermes entry point."""
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text("#!/usr/bin/env python3\n", encoding="utf-8")
+    path.write_text(shebang, encoding="utf-8")
     path.chmod(0o755)
     return path
 
@@ -116,7 +125,7 @@ def test_exec_falls_back_to_interpreter_module(tmp_path, xdg_home, monkeypatch):
 
 def test_exec_prefers_path_wrapper_over_checkout_argv0(tmp_path, xdg_home, monkeypatch):
     root = _make_project(tmp_path)
-    checkout_script = _make_executable(root / "hermes")
+    checkout_script = _make_executable(root / "hermes", ENV_PYTHON_SHEBANG)
     wrapper = _make_executable(tmp_path / "local" / "bin" / "hermes")
     # The desktop entry launched us, so argv[0] is the checkout script.
     monkeypatch.setattr(lde.sys, "argv", [str(checkout_script), "desktop"])
@@ -133,7 +142,7 @@ def test_exec_prefers_path_wrapper_over_checkout_argv0(tmp_path, xdg_home, monke
 
 def test_exec_rejects_checkout_argv0_when_no_wrapper_on_path(tmp_path, xdg_home, monkeypatch):
     root = _make_project(tmp_path)
-    checkout_script = _make_executable(root / "hermes")
+    checkout_script = _make_executable(root / "hermes", ENV_PYTHON_SHEBANG)
     monkeypatch.setattr(lde.sys, "argv", [str(checkout_script), "desktop"])
     _fake_which(monkeypatch, None)
     monkeypatch.setattr(lde, "refresh_desktop_databases", lambda _dir: [])
@@ -149,6 +158,122 @@ def test_exec_rejects_checkout_argv0_when_no_wrapper_on_path(tmp_path, xdg_home,
     assert Path(exec_line.split(" ")[0]).is_absolute()
 
 
+@pytest.mark.skipif(os.name == "nt", reason="symlink creation needs privileges on Windows")
+def test_exec_keeps_the_lexical_venv_interpreter_path(tmp_path, xdg_home, monkeypatch):
+    """The interpreter fallback persists the path Python was invoked
+    through, not the symlink target behind it.
+
+    A venv's ``bin/python`` is a symlink to a base interpreter, and CPython
+    decides it is inside a venv by finding ``pyvenv.cfg`` beside the
+    *invocation* path. A uv-created venv points that symlink at
+    ``~/.local/share/uv/python/...``, outside the venv, so a dereferenced
+    Exec starts an interpreter that has never heard of the venv's
+    ``site-packages`` and cannot import ``hermes_cli`` at all. Absolute is
+    not enough — the entry has to stay inside the venv.
+    """
+    root = _make_project(tmp_path)
+    base = tmp_path / "uv" / "python" / "cpython-3.11" / "bin" / "python3.11"
+    base.parent.mkdir(parents=True)
+    base.write_bytes(b"")
+    venv_python = tmp_path / "venv" / "bin" / "python"
+    venv_python.parent.mkdir(parents=True)
+    venv_python.symlink_to(base)
+    (venv_python.parent.parent / "pyvenv.cfg").write_text("home = /usr\n", encoding="utf-8")
+
+    monkeypatch.setattr(lde.sys, "executable", str(venv_python))
+    monkeypatch.setattr("hermes_cli.relaunch.resolve_hermes_bin", lambda: None)
+    monkeypatch.setattr(lde, "refresh_desktop_databases", lambda _dir: [])
+
+    entry = lde.install_desktop_entry(root)
+    exec_line = _parse(entry.read_text(encoding="utf-8"))["Exec"]
+
+    # Guard the fixture: this asserts nothing unless the interpreter really
+    # is a symlink pointing somewhere else.
+    assert venv_python.is_symlink()
+    assert os.path.realpath(venv_python) != str(venv_python)
+
+    assert exec_line == f"{lde._quote_exec_arg(str(venv_python))} -m hermes_cli.main desktop"
+    assert str(base) not in exec_line
+    # The reason the lexical path matters: pyvenv.cfg is beside it, so
+    # CPython still finds the venv. Beside the resolved target it is not.
+    persisted = Path(exec_line.split(" ", 1)[0])
+    assert (persisted.parent.parent / "pyvenv.cfg").is_file()
+
+
+def test_exec_rejects_env_python_wrapper_outside_the_checkout(tmp_path, xdg_home, monkeypatch):
+    """A ``#!/usr/bin/env python3`` wrapper is not durable wherever it lives.
+
+    A hand-rolled ``~/bin/hermes``, or a console script from a non-venv
+    editable install, sits outside the checkout and so survives
+    ``_is_inside_checkout`` — yet it still looks up ``python3`` on ``PATH``
+    when it runs. A cold menu launch supplies the desktop session's
+    ``PATH``, not the shell's, and the interpreter it lands on need not
+    have Hermes on ``sys.path``. Rejecting by location alone is not enough.
+    """
+    root = _make_project(tmp_path)
+    wrapper = _make_executable(tmp_path / "home" / "bin" / "hermes", ENV_PYTHON_SHEBANG)
+    monkeypatch.setattr(lde.sys, "argv", [str(wrapper), "desktop"])
+    _fake_which(monkeypatch, str(wrapper))
+    monkeypatch.setattr(lde, "refresh_desktop_databases", lambda _dir: [])
+
+    entry = lde.install_desktop_entry(root)
+    exec_line = _parse(entry.read_text(encoding="utf-8"))["Exec"]
+
+    assert str(wrapper) not in exec_line
+    expected = lde._quote_exec_arg(os.path.abspath(lde.sys.executable))
+    assert exec_line == f"{expected} -m hermes_cli.main desktop"
+
+
+def test_exec_keeps_an_interpreter_under_a_directory_named_envs(tmp_path, xdg_home, monkeypatch):
+    """The shebang check keys off the program's basename, not a substring.
+
+    ``#!/home/u/envs/hermes/bin/python3`` hardcodes its interpreter — that
+    is what an installed console script looks like. Matching ``env``
+    loosely would discard it and drop back to the ambient interpreter for
+    no reason.
+    """
+    root = _make_project(tmp_path)
+    wrapper = _make_executable(
+        tmp_path / "envs" / "hermes" / "bin" / "hermes",
+        "#!/home/u/envs/hermes/bin/python3\n",
+    )
+    monkeypatch.setattr(lde.sys, "argv", [str(wrapper), "desktop"])
+    _fake_which(monkeypatch, None)
+    monkeypatch.setattr(lde, "refresh_desktop_databases", lambda _dir: [])
+
+    entry = lde.install_desktop_entry(root)
+    exec_line = _parse(entry.read_text(encoding="utf-8"))["Exec"]
+
+    assert exec_line == f"{lde._quote_exec_arg(str(wrapper.resolve()))} desktop"
+
+
+@pytest.mark.parametrize(
+    "first_bytes,expected",
+    [
+        (b"#!/usr/bin/env python3\n", True),
+        (b"#!/usr/bin/env python\n", True),
+        (b"#!/usr/bin/env -S python3 -u\n", True),
+        (b"#!/opt/hermes/venv/bin/python3\n", False),
+        (b"#!/home/u/envs/hermes/bin/python3\n", False),
+        (b"#!/usr/bin/env node\n", False),
+        (b"#!/bin/sh\n", False),
+        (b"#!/usr/bin/env\n", False),
+        (b"\x7fELF\x02\x01\x01\x00", False),
+        (b"", False),
+    ],
+)
+def test_env_python_wrapper_detection(tmp_path, first_bytes, expected):
+    candidate = tmp_path / "hermes"
+    candidate.write_bytes(first_bytes)
+    assert lde._is_env_python_wrapper(str(candidate)) is expected
+
+
+def test_env_python_wrapper_detection_tolerates_an_unreadable_candidate(tmp_path):
+    # An unreadable candidate is not evidence of a PATH dependency, and it
+    # must not raise on the launch path either.
+    assert lde._is_env_python_wrapper(str(tmp_path / "does-not-exist")) is False
+
+
 def test_exec_accepts_argv0_outside_the_checkout(tmp_path, xdg_home, monkeypatch):
     root = _make_project(tmp_path)
     wrapper = _make_executable(tmp_path / "opt" / "bin" / "hermes")
@@ -159,15 +284,16 @@ def test_exec_accepts_argv0_outside_the_checkout(tmp_path, xdg_home, monkeypatch
     entry = lde.install_desktop_entry(root)
     exec_line = _parse(entry.read_text(encoding="utf-8"))["Exec"]
 
-    # Only checkout-internal entry points are rejected. An installed
-    # wrapper reached through argv[0] is still the best value to persist.
+    # Only non-durable entry points are rejected. An installed wrapper
+    # that names its own interpreter is still the best value to persist,
+    # even when argv[0] is how we found it.
     expected = lde._quote_exec_arg(str(wrapper.resolve()))
     assert exec_line == f"{expected} desktop"
 
 
 def test_entry_is_stable_across_a_relaunch_through_itself(tmp_path, xdg_home, monkeypatch):
     root = _make_project(tmp_path)
-    checkout_script = _make_executable(root / "hermes")
+    checkout_script = _make_executable(root / "hermes", ENV_PYTHON_SHEBANG)
     wrapper = _make_executable(tmp_path / "local" / "bin" / "hermes")
     _fake_which(monkeypatch, str(wrapper))
     refreshes: list[Path] = []


### PR DESCRIPTION
## What does this PR do?

Fixes the Linux/BSD desktop entry's persisted `Exec=` so it does not depend on whichever program happened to launch the current `hermes desktop` process.

On a source install, `resolve_hermes_bin()` can return the checkout's bare `hermes` script from `sys.argv[0]`. That script uses `#!/usr/bin/env python3`; a cold application-menu launch can therefore select a system Python without Hermes' venv dependencies. The generated entry can also alternate between that script and the installed wrapper, defeating the unchanged-content guard and rewriting the entry across launches.

This change rejects checkout-local and `env python*` candidates before persistence, retries the `hermes` wrapper on `PATH`, and falls back to the current interpreter's absolute lexical path so venv discovery through `pyvenv.cfg` remains intact. Entry publication uses the existing shared atomic writer.

### Existing PR overlap

This branch builds directly on #80547. Its two implementation commits were cherry-picked with `-x` and retain @briandevans as their author. The additional commit adds a subprocess regression that executes the generated `Exec` under a deliberately cold desktop `PATH`. Related alternative approaches were also reviewed in #80563 and #82040.

## Related Issue

Fixes #80439

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [ ] Tests only
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- `hermes_cli/linux_desktop_entry.py`: resolve a durable persisted launcher independently of transient `argv[0]`, preserve lexical venv interpreter paths, and publish the entry atomically.
- `tests/hermes_cli/test_linux_desktop_entry.py`: cover checkout scripts, PATH wrappers, `env python` shebangs, venv symlinks, quoting, interrupted publication, and an executed cold-PATH launcher scenario.

## How to Test

1. Make `sys.argv[0]` a checkout-local `hermes` script with `#!/usr/bin/env python3` and expose an absolute venv wrapper while generating the desktop entry.
2. Execute the generated `Exec` from an unrelated working directory under a desktop `PATH` whose `python3` deliberately exits 97.
3. Confirm the generated command selects the absolute wrapper, exits 0, and prints `desktop-ok`.

Targeted commands:

```text
.venv/bin/python -m pytest tests/hermes_cli/test_linux_desktop_entry.py -q -o addopts=
.venv/bin/python -m pytest tests/hermes_cli/test_gui_command.py tests/hermes_cli/test_gui_uninstall.py tests/hermes_cli/test_relaunch.py -q -o addopts=
.venv/bin/ruff check hermes_cli/linux_desktop_entry.py tests/hermes_cli/test_linux_desktop_entry.py
```

## Checklist

### Code

- [x] I've read the Contributing Guide.
- [x] My commit messages follow Conventional Commits.
- [x] I searched for existing PRs and documented the intentional overlap above.
- [x] My PR contains only changes related to this fix.
- [ ] I've run `pytest tests/ -q` and all tests pass. (Targeted suites were run; the full suite was not.)
- [x] I've added tests for my changes.
- [x] I've tested on macOS 26.5.2 with unit and real subprocess probes; no live Linux desktop session was available locally.

### Documentation & Housekeeping

- [x] Relevant documentation update: N/A; behavior and invariants are documented next to the resolver and tests.
- [x] `cli-config.yaml.example` update: N/A; no config keys changed.
- [x] `CONTRIBUTING.md` or `AGENTS.md` update: N/A; no architecture or workflow changed.
- [x] Cross-platform impact considered: installation remains gated to Linux/BSD; the executable probe is POSIX-gated.
- [x] Tool descriptions/schemas update: N/A; no tool contract changed.

## Screenshots / Logs

```text
Baseline at upstream/main 460d345642ee3d143a3e461abe39fd42b86a7e54:
- the generated Exec persisted the checkout script using `/usr/bin/env python3` even when a wrapper was available on PATH

Post-fix cold launch:
- generated Exec selected the absolute wrapper
- subprocess with a poison desktop `python3` exited 0
- stdout: desktop-ok

Automated checks:
- desktop-entry tests: 34 passed, 1 skipped
- adjacent CLI/relaunch tests: 40 passed, 1 skipped
- Ruff: All checks passed
```