### PR TITLE
test(cron): regression test for bash arithmetic division in lifecycle guard (#87280)

### DIFF
--- a/tests/hermes_cli/test_gateway_restart_loop.py
+++ b/tests/hermes_cli/test_gateway_restart_loop.py
@@ -664,6 +664,23 @@ class TestLifecycleGuardModule:
         )
         check_gateway_lifecycle("clean prompt", str(script))
 
+    def test_bash_arithmetic_division_not_blocked(self, tmp_path):
+        """#87280: a .sh cron script using bash arithmetic division
+        $(( x / y )) must NOT be blocked.
+
+        Before the fix for #77131, the shell-script reference walk
+        tokenized the bare "/" operator as an executable path resolving
+        to the filesystem root, which failed the regular-file check and
+        hard-blocked every innocent .sh script containing arithmetic.
+        """
+        from cron.lifecycle_guard import check_gateway_lifecycle
+        script = tmp_path / "report.sh"
+        script.write_text(
+            "#!/usr/bin/env bash\n"
+            "echo $(( (100 - 50) / 86400 ))\n"
+        )
+        check_gateway_lifecycle(None, str(script))
+
     def test_python_script_with_literal_lifecycle_command_still_blocked(
         self, tmp_path
     ):


### PR DESCRIPTION
## Summary

Adds a regression test confirming that `.sh` cron scripts containing bash arithmetic division (`$(( x / y ))`) are not blocked by the gateway lifecycle guard.

Fixes #87280

## Root cause (already fixed)

The bare `/` token from the division operator was previously resolved to the filesystem root by `_iter_referenced_shell_scripts`, which hit the `not stat.S_ISREG(...)` branch in `_read_referenced_script` and returned `(None, unsafe=True)` — hard-blocking every innocent `.sh` script containing arithmetic.

The fix for #77131 (skip pure-separator tokens at `lifecycle_guard.py:397`) already handles this case. This PR adds the missing test to prevent regression.

## Test plan

```
python3 -m pytest tests/hermes_cli/test_gateway_restart_loop.py::TestLifecycleGuardModule::test_bash_arithmetic_division_not_blocked -xvs
```

All 126 tests in `test_gateway_restart_loop.py` pass.