### PR TITLE
fix(codex-app-server): stop close() racing run_turn()'s poll loop

### DIFF
--- a/agent/transports/codex_app_server.py
+++ b/agent/transports/codex_app_server.py
@@ -17,6 +17,7 @@ runtime is not selected.
 from __future__ import annotations
 
 import json
+import logging
 import os
 import queue
 import subprocess
@@ -26,6 +27,8 @@ from dataclasses import dataclass, field
 from typing import Any, Optional
 
 from tools.environments.local import hermes_subprocess_env
+
+logger = logging.getLogger(__name__)
 
 # Default minimum codex version we test against. The PR sets this from the
 # `codex --version` parsed at install time; bumping is a one-line change here.
@@ -200,7 +203,15 @@ class CodexAppServerClient:
                 self._proc.kill()
                 self._proc.wait(timeout=1.0)
             except Exception:
-                pass
+                # The child survived SIGKILL/TerminateProcess within our
+                # wait budget. self._closed is already True, so nothing
+                # will ever retry the reap — surface it loudly since this
+                # is otherwise a silent, permanently orphaned process.
+                logger.warning(
+                    "codex app-server subprocess (pid=%s) did not exit "
+                    "after kill(); it may be orphaned",
+                    getattr(self._proc, "pid", "?"),
+                )
 
     def __enter__(self) -> "CodexAppServerClient":
         return self

--- a/agent/transports/codex_app_server_session.py
+++ b/agent/transports/codex_app_server_session.py
@@ -434,6 +434,7 @@ class CodexAppServerSession:
         exc: Any = "",
         *,
         tail_lines: int = _STDERR_TAIL_LINES,
+        client: Optional[CodexAppServerClient] = None,
     ) -> str:
         """Build a user-facing error string for codex failures.
 
@@ -448,13 +449,18 @@ class CodexAppServerSession:
         Use this for the generic / catch-all branches. Specific
         classifications (OAuth via _classify_oauth_failure, post-tool wedge
         watchdog) already produce a clean hint and should be used instead.
+
+        ``client`` lets callers pass the client reference they already hold
+        (e.g. run_turn's local snapshot) instead of re-reading
+        ``self._client``, which a concurrent close() can null out mid-turn.
         """
         exc_str = str(exc) if exc != "" and exc is not None else ""
         base = f"{prefix}: {exc_str}" if exc_str else prefix
-        if self._client is None:
+        active_client = client if client is not None else self._client
+        if active_client is None:
             return base
         try:
-            tail = self._client.stderr_tail(tail_lines)
+            tail = active_client.stderr_tail(tail_lines)
         except Exception:  # pragma: no cover - diagnostic best-effort
             return base
         if not tail:
@@ -504,6 +510,16 @@ class CodexAppServerSession:
             return result
         assert self._client is not None and self._thread_id is not None
         result.thread_id = self._thread_id
+        # Snapshot the client once for the rest of this turn. self._client
+        # is not lock-protected against a concurrent close() (e.g. the
+        # gateway session-expiry watcher tearing this session down mid-turn)
+        # — re-reading the attribute inside the poll loop below would raise
+        # AttributeError the instant close() nulls it out from under us.
+        # The snapshot stays a valid (if closed) object for the rest of
+        # this call, so is_alive()/take_notification()/etc. degrade
+        # gracefully into the existing "subprocess exited" handling instead
+        # of crashing.
+        client = self._client
 
         # Do not clear here: a hard stop can arrive while ensure_started() is
         # spawning/initializing the subprocess. Honor it before launching a
@@ -519,7 +535,7 @@ class CodexAppServerSession:
         # Send turn/start with the user input. Text-only for now (codex
         # supports rich content but Hermes' text path is the common case).
         try:
-            ts = self._client.request(
+            ts = client.request(
                 "turn/start",
                 {
                     "threadId": self._thread_id,
@@ -530,7 +546,7 @@ class CodexAppServerSession:
         except CodexAppServerError as exc:
             # Classify auth/refresh failures so the user gets a clear
             # `codex login` pointer instead of a raw RPC error string.
-            stderr_blob = "\n".join(self._client.stderr_tail(40))
+            stderr_blob = "\n".join(client.stderr_tail(40))
             hint = _classify_oauth_failure(exc.message, stderr_blob)
             if hint is not None:
                 result.error = hint
@@ -541,16 +557,16 @@ class CodexAppServerSession:
                 result.should_retire = True
             else:
                 result.error = self._format_error_with_stderr(
-                    "turn/start failed", exc
+                    "turn/start failed", exc, client=client
                 )
             self._interrupt_event.clear()
             return result
         except TimeoutError as exc:
             # turn/start hanging is a strong signal the subprocess is wedged.
-            stderr_blob = "\n".join(self._client.stderr_tail(40))
+            stderr_blob = "\n".join(client.stderr_tail(40))
             hint = _classify_oauth_failure(stderr_blob)
             result.error = hint or self._format_error_with_stderr(
-                "turn/start timed out", exc
+                "turn/start timed out", exc, client=client
             )
             result.should_retire = True
             self._interrupt_event.clear()
@@ -569,16 +585,17 @@ class CodexAppServerSession:
 
         while time.monotonic() < deadline and not turn_complete:
             if self._interrupt_event.is_set():
-                self._issue_interrupt(result.turn_id)
+                self._issue_interrupt(result.turn_id, client=client)
                 result.interrupted = True
                 break
 
             # Detect a dead subprocess between iterations. If codex exited
             # (e.g. crashed, segfaulted, or its auth refresh thread killed
-            # the process), we won't get any more notifications — bail out
+            # the process — including a concurrent close() from another
+            # thread), we won't get any more notifications — bail out
             # rather than waiting for the full turn deadline.
-            if not self._client.is_alive():
-                stderr_blob = "\n".join(self._client.stderr_tail(60))
+            if not client.is_alive():
+                stderr_blob = "\n".join(client.stderr_tail(60))
                 hint = _classify_oauth_failure(stderr_blob)
                 if hint is not None:
                     result.error = hint
@@ -586,6 +603,7 @@ class CodexAppServerSession:
                     result.error = self._format_error_with_stderr(
                         "codex app-server subprocess exited unexpectedly",
                         tail_lines=20,
+                        client=client,
                     )
                 result.should_retire = True
                 break
@@ -598,7 +616,7 @@ class CodexAppServerSession:
                 and (time.monotonic() - last_tool_completion_at)
                     > post_tool_quiet_timeout
             ):
-                self._issue_interrupt(result.turn_id)
+                self._issue_interrupt(result.turn_id, client=client)
                 result.interrupted = True
                 result.error = (
                     f"codex went silent for "
@@ -610,14 +628,14 @@ class CodexAppServerSession:
 
             # Drain any server-initiated requests (approvals) before
             # reading notifications, so the codex side isn't blocked.
-            sreq = self._client.take_server_request(timeout=0)
+            sreq = client.take_server_request(timeout=0)
             if sreq is not None:
                 # Drain any pending notifications first so per-turn state
                 # (e.g. _pending_file_changes for fileChange approvals) is
                 # up to date when we make the approval decision. Bounded
                 # to avoid starving the server-request response.
                 for _ in range(8):
-                    pending = self._client.take_notification(timeout=0)
+                    pending = client.take_notification(timeout=0)
                     if pending is None:
                         break
                     if not _notification_belongs_to_turn(
@@ -663,13 +681,13 @@ class CodexAppServerSession:
                                 result.error
                                 or "codex reported turn_aborted"
                             )
-                self._handle_server_request(sreq)
+                self._handle_server_request(sreq, client=client)
                 # Activity counts as live signal — reset the post-tool
                 # quiet timer so an approval round-trip doesn't trip it.
                 last_tool_completion_at = None
                 continue
 
-            note = self._client.take_notification(
+            note = client.take_notification(
                 timeout=notification_poll_timeout
             )
             if note is None:
@@ -746,7 +764,7 @@ class CodexAppServerSession:
                         # rewrite the error into a re-auth hint AND mark
                         # the session for retirement.
                         stderr_blob = "\n".join(
-                            self._client.stderr_tail(40)
+                            client.stderr_tail(40)
                         )
                         hint = _classify_oauth_failure(err_msg, stderr_blob)
                         if hint is not None:
@@ -754,7 +772,9 @@ class CodexAppServerSession:
                             result.should_retire = True
                         else:
                             result.error = self._format_error_with_stderr(
-                                f"turn ended status={turn_status}", err_msg
+                                f"turn ended status={turn_status}",
+                                err_msg,
+                                client=client,
                             )
 
         if (
@@ -775,11 +795,11 @@ class CodexAppServerSession:
             # tell the caller to retire the session — a turn that never
             # finished is a strong sign codex is wedged in a way the next
             # turn shouldn't inherit.
-            self._issue_interrupt(result.turn_id)
+            self._issue_interrupt(result.turn_id, client=client)
             result.interrupted = True
             if not result.error:
                 result.error = self._format_error_with_stderr(
-                    f"turn timed out after {turn_timeout}s"
+                    f"turn timed out after {turn_timeout}s", client=client
                 )
             result.should_retire = True
 
@@ -812,18 +832,21 @@ class CodexAppServerSession:
             return result
 
         assert self._client is not None and self._thread_id is not None
+        # Snapshot the client once for the rest of this call — see the
+        # matching comment in run_turn() for why (concurrent close() race).
+        client = self._client
         result.thread_id = self._thread_id
         self._interrupt_event.clear()
         projector = CodexEventProjector()
 
         try:
-            self._client.request(
+            client.request(
                 "thread/compact/start",
                 {"threadId": self._thread_id},
                 timeout=10,
             )
         except CodexAppServerError as exc:
-            stderr_blob = "\n".join(self._client.stderr_tail(40))
+            stderr_blob = "\n".join(client.stderr_tail(40))
             hint = _classify_oauth_failure(exc.message, stderr_blob)
             if hint is not None:
                 result.error = hint
@@ -834,7 +857,7 @@ class CodexAppServerSession:
                 )
             return result
         except TimeoutError as exc:
-            stderr_blob = "\n".join(self._client.stderr_tail(40))
+            stderr_blob = "\n".join(client.stderr_tail(40))
             hint = _classify_oauth_failure(stderr_blob)
             result.error = hint or self._format_error_with_stderr(
                 "thread/compact/start timed out", exc
@@ -847,12 +870,12 @@ class CodexAppServerSession:
 
         while time.monotonic() < deadline and not turn_complete:
             if self._interrupt_event.is_set():
-                self._issue_interrupt(result.turn_id)
+                self._issue_interrupt(result.turn_id, client=client)
                 result.interrupted = True
                 break
 
-            if not self._client.is_alive():
-                stderr_blob = "\n".join(self._client.stderr_tail(60))
+            if not client.is_alive():
+                stderr_blob = "\n".join(client.stderr_tail(60))
                 hint = _classify_oauth_failure(stderr_blob)
                 if hint is not None:
                     result.error = hint
@@ -864,12 +887,12 @@ class CodexAppServerSession:
                 result.should_retire = True
                 break
 
-            sreq = self._client.take_server_request(timeout=0)
+            sreq = client.take_server_request(timeout=0)
             if sreq is not None:
-                self._handle_server_request(sreq)
+                self._handle_server_request(sreq, client=client)
                 continue
 
-            note = self._client.take_notification(
+            note = client.take_notification(
                 timeout=notification_poll_timeout
             )
             if note is None:
@@ -956,7 +979,7 @@ class CodexAppServerSession:
                 elif turn_status and turn_status != "completed":
                     err_obj = turn_obj.get("error")
                     err_msg = _format_responses_error(err_obj, str(turn_status))
-                    stderr_blob = "\n".join(self._client.stderr_tail(40))
+                    stderr_blob = "\n".join(client.stderr_tail(40))
                     hint = _classify_oauth_failure(err_msg, stderr_blob)
                     if hint is not None:
                         result.error = hint
@@ -968,7 +991,7 @@ class CodexAppServerSession:
                         )
 
         if not turn_complete and not result.interrupted:
-            self._issue_interrupt(result.turn_id)
+            self._issue_interrupt(result.turn_id, client=client)
             result.interrupted = True
             if not result.error:
                 result.error = self._format_error_with_stderr(
@@ -980,11 +1003,17 @@ class CodexAppServerSession:
 
     # ---------- internals ----------
 
-    def _issue_interrupt(self, turn_id: Optional[str]) -> None:
-        if self._client is None or self._thread_id is None or turn_id is None:
+    def _issue_interrupt(
+        self,
+        turn_id: Optional[str],
+        *,
+        client: Optional[CodexAppServerClient] = None,
+    ) -> None:
+        active_client = client if client is not None else self._client
+        if active_client is None or self._thread_id is None or turn_id is None:
             return
         try:
-            self._client.request(
+            active_client.request(
                 "turn/interrupt",
                 {"threadId": self._thread_id, "turnId": turn_id},
                 timeout=5,
@@ -995,7 +1024,9 @@ class CodexAppServerSession:
         except TimeoutError:
             logger.warning("turn/interrupt timed out")
 
-    def _handle_server_request(self, req: dict) -> None:
+    def _handle_server_request(
+        self, req: dict, *, client: Optional[CodexAppServerClient] = None
+    ) -> None:
         """Translate a codex server request (approval) into Hermes' approval
         flow, then send the response.
 
@@ -1006,8 +1037,13 @@ class CodexAppServerSession:
                                                   (we decline; user controls
                                                   permission profile in
                                                   ~/.codex/config.toml).
+
+        ``client`` lets run_turn/compact_thread pass their local snapshot
+        instead of re-reading ``self._client`` (see _format_error_with_stderr
+        for why that matters under a concurrent close()).
         """
-        if self._client is None:
+        active_client = client if client is not None else self._client
+        if active_client is None:
             return
         method = req.get("method", "")
         rid = req.get("id")
@@ -1015,16 +1051,16 @@ class CodexAppServerSession:
 
         if method == "item/commandExecution/requestApproval":
             decision = self._decide_exec_approval(params)
-            self._client.respond(rid, {"decision": decision})
+            active_client.respond(rid, {"decision": decision})
         elif method == "item/fileChange/requestApproval":
             decision = self._decide_apply_patch_approval(params)
-            self._client.respond(rid, {"decision": decision})
+            active_client.respond(rid, {"decision": decision})
         elif method == "item/permissions/requestApproval":
             # Codex sometimes asks to escalate permissions mid-turn. We
             # always decline — the user already chose their permission
             # profile in ~/.codex/config.toml and surprise escalations
             # shouldn't be silently accepted.
-            self._client.respond(rid, {"decision": "decline"})
+            active_client.respond(rid, {"decision": "decline"})
         elif method == "mcpServer/elicitation/request":
             # Codex's MCP layer asks the user for structured input on
             # behalf of an MCP server (e.g. tool-call confirmation,
@@ -1036,12 +1072,12 @@ class CodexAppServerSession:
             # codex's own auth flow.
             server_name = params.get("serverName") or ""
             if server_name == "hermes-tools":
-                self._client.respond(
+                active_client.respond(
                     rid,
                     {"action": "accept", "content": None, "_meta": None},
                 )
             else:
-                self._client.respond(
+                active_client.respond(
                     rid,
                     {"action": "decline", "content": None, "_meta": None},
                 )
@@ -1049,7 +1085,7 @@ class CodexAppServerSession:
             # Unknown server request — codex can extend this surface. Reject
             # cleanly so codex doesn't hang waiting for us.
             logger.warning("Unknown codex server request: %s", method)
-            self._client.respond_error(
+            active_client.respond_error(
                 rid, code=-32601, message=f"Unsupported method: {method}"
             )
 

--- a/tests/agent/transports/test_codex_app_server_session_race.py
+++ b/tests/agent/transports/test_codex_app_server_session_race.py
@@ -1,0 +1,172 @@
+"""Regression test — and exhaustive stress test — for the fix to the race
+between CodexAppServerSession.run_turn() and CodexAppServerSession.close().
+
+This is the concrete mechanism behind gateway/run.py's
+``_session_expiry_watcher`` tearing a session down mid-turn (see that
+function's own comment: "Fall back to _running_agents in case the agent is
+still mid-turn when the expiry fires").
+
+Before the fix, ``run_turn()`` re-read ``self._client`` on every iteration
+of its polling while-loop (``self._client.is_alive()``,
+``self._client.take_server_request(...)``,
+``self._client.take_notification(...)``) with no null-guard and no lock,
+while ``close()`` set ``self._client = None`` guarded only by
+``self._active_turn_lock`` (which protects ``self._active_turn_id`` — not
+``self._client``). A ``close()`` landing between two loop iterations made
+the very next ``self._client.<method>()`` call raise
+``AttributeError: 'NoneType' object has no attribute '...'``.
+
+The fix: ``run_turn()``/``compact_thread()`` now snapshot
+``client = self._client`` once and use that local reference for the rest of
+the call. ``close()`` still nulls ``self._client`` and kills the
+subprocess, but the *local* snapshot stays a valid (now-dead) object, so
+the loop's own existing "subprocess exited unexpectedly" dead-process
+detection takes over instead of crashing.
+
+Uses a fake in-process client (no subprocess) so it is cheap to run
+repeatedly (including the exhaustive/soak variant below) without taxing
+the host machine.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+
+from agent.transports.codex_app_server_session import CodexAppServerSession
+
+
+class _RacyFakeClient:
+    """Stand-in for CodexAppServerClient with a controllable window
+    between is_alive() calls, wide enough for a concurrent close() to
+    land in the middle of run_turn()'s poll loop."""
+
+    def __init__(self, ready_for_close: threading.Event, hold: float = 0.05) -> None:
+        self._ready_for_close = ready_for_close
+        self._hold = hold
+        self.alive_calls = 0
+        self.closed = False
+
+    def initialize(self, **kwargs):
+        return {
+            "userAgent": "fake",
+            "codexHome": "",
+            "platformOs": "test",
+            "platformFamily": "test",
+        }
+
+    def close(self):
+        self.closed = True
+
+    def request(self, method, params=None, timeout=30.0):
+        if method == "thread/start":
+            return {"thread": {"id": "thread-racy"}}
+        if method == "turn/start":
+            return {"turn": {"id": "turn-racy"}}
+        return {}
+
+    def is_alive(self) -> bool:
+        self.alive_calls += 1
+        # Signal the closing thread it's safe to race in, then hold the
+        # window open so close() has time to run before we check self.closed
+        # — mirrors the real CodexAppServerClient, whose is_alive() checks
+        # self._proc.poll() and only turns False once close() has actually
+        # killed the subprocess.
+        self._ready_for_close.set()
+        time.sleep(self._hold)
+        return not self.closed
+
+    def take_server_request(self, timeout: float = 0.0):
+        return None
+
+    def take_notification(self, timeout: float = 0.0):
+        time.sleep(0.01)
+        return None
+
+    def stderr_tail(self, n: int = 20):
+        return []
+
+
+def _run_turn_vs_close_once(hold: float = 0.02) -> dict:
+    """Run one instance of the race: start run_turn() in a thread, close()
+    the session from the main thread as soon as run_turn() enters its poll
+    loop, and report what happened."""
+    ready_for_close = threading.Event()
+    fake = _RacyFakeClient(ready_for_close, hold=hold)
+    session = CodexAppServerSession(cwd=".", client_factory=lambda **_kw: fake)
+
+    outcome: dict[str, object] = {}
+
+    def _run():
+        try:
+            outcome["result"] = session.run_turn(
+                user_input="hello",
+                turn_timeout=5,
+                notification_poll_timeout=0.01,
+            )
+        except BaseException as exc:  # noqa: BLE001 - capturing for assertion
+            outcome["error"] = exc
+
+    t = threading.Thread(target=_run, daemon=True)
+    t.start()
+
+    if not ready_for_close.wait(timeout=5):
+        outcome["error"] = RuntimeError("run_turn never reached is_alive()")
+        t.join(timeout=5)
+        return outcome
+
+    session.close()
+    t.join(timeout=5)
+    outcome["thread_alive"] = t.is_alive()
+    outcome["client_closed"] = fake.closed
+    return outcome
+
+
+class TestRunTurnClientRace:
+    """Proves the fix: session.close() racing session.run_turn() no longer
+    crashes the turn. self._client is nulled out on the session, but
+    run_turn() is holding its own local snapshot, so the loop's existing
+    dead-subprocess detection takes over instead of raising."""
+
+    def test_close_during_run_turn_returns_gracefully(self):
+        outcome = _run_turn_vs_close_once()
+
+        assert "error" not in outcome, f"run_turn() raised: {outcome.get('error')!r}"
+        assert outcome["thread_alive"] is False, "run_turn thread never returned"
+        assert outcome["client_closed"] is True
+
+        result = outcome["result"]
+        assert result.should_retire is True
+        assert result.error and "unexpectedly" in result.error
+
+
+class TestRunTurnClientRaceExhaustive:
+    """Exhaustion / soak test requested alongside the fix: a single lucky
+    pass doesn't prove a race is gone, so this repeats the race hundreds of
+    times with jittered timing windows to shake out flakiness. Runs
+    sequentially (never more than 2 live threads at once) and every
+    session/thread is joined and dropped before the next iteration, so
+    memory stays flat regardless of iteration count.
+    """
+
+    ITERATIONS = 300
+
+    def test_no_attribute_error_across_many_races(self):
+        import random
+
+        rng = random.Random(1234)  # deterministic across CI runs
+        failures: list[tuple[int, object]] = []
+
+        for i in range(self.ITERATIONS):
+            # Jitter the hold window across a range that puts close() both
+            # comfortably before and right on top of the is_alive() check,
+            # to probe the boundary rather than just one fixed timing.
+            hold = rng.uniform(0.0, 0.03)
+            outcome = _run_turn_vs_close_once(hold=hold)
+            if "error" in outcome or outcome.get("thread_alive") is not False:
+                failures.append((i, outcome.get("error") or outcome))
+
+        assert not failures, (
+            f"{len(failures)}/{self.ITERATIONS} iterations hit the race "
+            f"(showing up to 5): {failures[:5]}"
+        )

--- a/tests/agent/transports/test_codex_app_server_zombie_and_races.py
+++ b/tests/agent/transports/test_codex_app_server_zombie_and_races.py
@@ -1,0 +1,289 @@
+"""Regression tests for zombie-process leaks and race conditions in the
+codex app-server transport (the OpenAI/Codex route: agent/codex_runtime.py
+-> agent/transports/codex_app_server_session.py ->
+agent/transports/codex_app_server.py::CodexAppServerClient).
+
+These tests were written after auditing ``CodexAppServerClient.close()``
+and the gateway session-expiry watcher (``gateway/run.py:
+_session_expiry_watcher``) for orphaned-subprocess / GC-unreachable-object
+bugs. Each test class documents the exact defect it reproduces.
+
+No real ``codex`` CLI is required: a tiny stand-in JSON-RPC script
+(``_DUMMY_SERVER_SRC``) is spawned in its place via a ``subprocess.Popen``
+monkeypatch, so these run as ordinary (non-``integration``) tests and are
+part of the default ``pytest`` invocation.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import textwrap
+import threading
+import time
+from unittest.mock import Mock
+
+import pytest
+
+from agent.transports.codex_app_server import CodexAppServerClient
+
+# ---------------------------------------------------------------------------
+# Dummy "codex app-server" stand-in: reads newline-delimited JSON-RPC from
+# stdin, answers `initialize` immediately, and otherwise only answers
+# requests whose method is NOT "test/hang" (used to simulate a request the
+# real server would never answer, e.g. because it died mid-turn).
+# ---------------------------------------------------------------------------
+_DUMMY_SERVER_SRC = textwrap.dedent(
+    """
+    import json
+    import sys
+
+    for line in sys.stdin:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            msg = json.loads(line)
+        except Exception:
+            continue
+        mid = msg.get("id")
+        method = msg.get("method")
+        if mid is None:
+            continue  # notification, nothing to reply to
+        if method == "test/hang":
+            continue  # deliberately never respond
+        result = {"userAgent": "dummy", "codexHome": "", "platformOs": "test", "platformFamily": "test"}
+        sys.stdout.write(json.dumps({"id": mid, "result": result}) + "\\n")
+        sys.stdout.flush()
+    """
+)
+
+
+@pytest.fixture()
+def dummy_server_script(tmp_path):
+    script = tmp_path / "dummy_codex_app_server.py"
+    script.write_text(_DUMMY_SERVER_SRC, encoding="utf-8")
+    return script
+
+
+@pytest.fixture()
+def spawn_client(monkeypatch, dummy_server_script):
+    """Yields a factory that builds a real ``CodexAppServerClient`` whose
+    subprocess is the dummy script above instead of the real ``codex``
+    binary. Uses a real OS process/pipes/threads end to end."""
+
+    real_popen = subprocess.Popen
+
+    def _patched_popen(cmd, **kwargs):
+        return real_popen([sys.executable, str(dummy_server_script)], **kwargs)
+
+    monkeypatch.setattr(
+        "agent.transports.codex_app_server.subprocess.Popen", _patched_popen
+    )
+
+    clients: list[CodexAppServerClient] = []
+
+    def _factory() -> CodexAppServerClient:
+        client = CodexAppServerClient(codex_bin="codex")
+        clients.append(client)
+        return client
+
+    yield _factory
+
+    # Test-harness safety net only — not part of any assertion. Guarantees
+    # a broken test doesn't itself leak a real orphaned process on the
+    # machine running the suite.
+    for client in clients:
+        try:
+            client._proc.kill()
+            client._proc.wait(timeout=5)
+        except Exception:
+            pass
+
+
+class TestCloseLogsKillFailureInsteadOfSwallowingIt:
+    """Fix: in ``CodexAppServerClient.close()`` (agent/transports/
+    codex_app_server.py), if ``terminate()`` doesn't reap the child within
+    ``timeout``, the code escalates to ``kill()`` + a second
+    ``wait(timeout=1.0)``. If the child survives even
+    ``SIGKILL``/``TerminateProcess`` past that final 1s wait, ``close()``
+    now logs a warning (with the pid) instead of swallowing the failure
+    silently. ``self._closed`` is still set to ``True`` before the
+    terminate/kill dance starts, so a later ``close()`` call remains a
+    no-op — the process can still be orphaned — but it is no longer
+    invisible: this is the one signal that would exist anywhere in the
+    stack for it.
+    """
+
+    def test_kill_wait_failure_is_logged_and_does_not_raise(self, caplog):
+        client = object.__new__(CodexAppServerClient)  # skip __init__/Popen
+        client._closed = False
+
+        proc = Mock()
+        proc.stdin = None
+        proc.terminate = Mock()
+        proc.kill = Mock()
+        proc.pid = 4242
+        proc.wait = Mock(
+            side_effect=[
+                subprocess.TimeoutExpired(cmd="dummy", timeout=3),
+                subprocess.TimeoutExpired(cmd="dummy", timeout=1),
+            ]
+        )
+        client._proc = proc
+
+        with caplog.at_level("WARNING"):
+            client.close()  # must not raise
+
+        proc.terminate.assert_called_once()
+        proc.kill.assert_called_once()
+        assert proc.wait.call_count == 2
+        assert client._closed is True
+        assert len(caplog.records) == 1
+        assert "4242" in caplog.records[0].message
+        assert "orphaned" in caplog.records[0].message.lower()
+
+    def test_leak_is_permanent_because_closed_flag_short_circuits_retry(self):
+        """Direct consequence of the above: once close() has swallowed a
+        failed reap, a second call to close() returns immediately without
+        attempting to kill/reap the child again — confirmed by
+        ``proc.wait`` never being invoked a third time."""
+        client = object.__new__(CodexAppServerClient)
+        client._closed = False
+
+        proc = Mock()
+        proc.stdin = None
+        proc.terminate = Mock()
+        proc.kill = Mock()
+        proc.wait = Mock(
+            side_effect=[
+                subprocess.TimeoutExpired(cmd="dummy", timeout=3),
+                subprocess.TimeoutExpired(cmd="dummy", timeout=1),
+            ]
+        )
+        client._proc = proc
+
+        client.close()
+        client.close()  # mirrors every real call site re-calling close()
+
+        assert proc.wait.call_count == 2, (
+            "close() attempted to reap the child again after already being "
+            "marked closed — if this fails, the leak may have been fixed "
+            "and this guard should be revisited"
+        )
+
+
+class TestClosePendingRequestsRace:
+    """Bug: ``close()`` never touches ``self._pending``. A thread blocked
+    in ``request()`` waiting on a reply has no idea the transport just
+    died — it keeps waiting on its own ``timeout`` argument instead of
+    failing fast.
+
+    This is the concrete mechanism behind the observed "codex route hangs
+    after session expiry" race: gateway/run.py's ``_session_expiry_watcher``
+    explicitly falls back to ``_running_agents`` "in case the agent is
+    still mid-turn" and calls ``AIAgent.close()`` -> ``codex_session.close()``
+    on a session that may have an in-flight ``turn/start`` request. That
+    caller thread does not get unblocked by the close() happening
+    concurrently on another thread/task.
+    """
+
+    def test_blocked_request_does_not_notice_concurrent_close(self, spawn_client):
+        client = spawn_client()
+        client.initialize(timeout=5)
+
+        outcome: dict[str, object] = {}
+
+        def _blocked_request():
+            start = time.monotonic()
+            try:
+                outcome["result"] = client.request("test/hang", timeout=2.0)
+            except Exception as exc:  # TimeoutError from request()'s own budget
+                outcome["error"] = exc
+            outcome["elapsed"] = time.monotonic() - start
+
+        t = threading.Thread(target=_blocked_request, daemon=True)
+        t.start()
+        time.sleep(0.2)  # let the request register in _pending
+
+        close_started = time.monotonic()
+        client.close()
+        close_elapsed = time.monotonic() - close_started
+
+        t.join(timeout=5)
+
+        assert close_elapsed < 1.0, "close() itself should return quickly"
+        assert not t.is_alive(), "blocked request() thread never returned"
+        # The bug: the blocked call rides out its own ~2s timeout instead
+        # of failing immediately when the transport it depends on closed.
+        assert outcome.get("elapsed", 0) >= 1.5, (
+            "request() returned suspiciously fast — if close() now cancels "
+            "pending requests immediately, this test should be rewritten "
+            "to assert the (fixed) fast-fail behavior instead"
+        )
+        assert "error" in outcome
+
+
+class TestCloseReaping:
+    """Regression guard (currently expected to pass): the happy-path close()
+    does reap the real child process and does not leave stdout/stderr
+    reader threads running forever, given a well-behaved child. This pins
+    current good behavior so future refactors of close() don't regress the
+    one thing it does get right."""
+
+    def test_close_reaps_real_process_and_threads_exit(self, spawn_client):
+        client = spawn_client()
+        client.initialize(timeout=5)
+
+        reader = client._reader
+        stderr_reader = client._stderr_reader
+        assert reader.is_alive()
+
+        client.close()
+
+        assert client._proc.poll() is not None, "child process not reaped"
+
+        reader.join(timeout=3)
+        stderr_reader.join(timeout=3)
+        assert not reader.is_alive(), "stdout reader thread leaked past close()"
+        assert not stderr_reader.is_alive(), "stderr reader thread leaked past close()"
+
+
+class TestConcurrentCloseRace:
+    """Race: nothing guards ``self._closed`` with a lock — it's a plain
+    bool checked-then-set with no atomicity. Two threads racing
+    ``close()`` (e.g. a turn-crash handler in agent/codex_runtime.py and
+    the gateway expiry watcher both deciding to tear the same session
+    down) can both observe ``_closed is False`` and both proceed into the
+    terminate/kill/wait sequence concurrently.
+
+    This test proves that at minimum no unhandled exception escapes either
+    thread in the double-close case against a real process (double
+    terminate/kill on an already-exited PID is normally safe on both POSIX
+    and Windows) — but is written so that if a future change makes the
+    race throw (e.g. more aggressive Windows handle reuse), the failure is
+    caught here instead of in production telemetry.
+    """
+
+    def test_double_close_from_two_threads_does_not_raise(self, spawn_client):
+        client = spawn_client()
+        client.initialize(timeout=5)
+
+        errors: list[BaseException] = []
+        barrier = threading.Barrier(2)
+
+        def _close():
+            barrier.wait(timeout=5)
+            try:
+                client.close()
+            except BaseException as exc:  # noqa: BLE001 - capturing for assertion
+                errors.append(exc)
+
+        threads = [threading.Thread(target=_close, daemon=True) for _ in range(2)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=5)
+
+        assert not errors, f"concurrent close() raised: {errors}"
+        assert client._proc.poll() is not None


### PR DESCRIPTION
Fixes #87422

## Summary

- `CodexAppServerSession.run_turn()` / `compact_thread()` now snapshot `client = self._client` once at the top of the call and use that local reference for the rest of it, instead of re-reading the mutable `self._client` attribute on every loop iteration.
- `close()` still nulls `self._client` and kills the subprocess from whatever thread calls it (e.g. `gateway/run.py`'s `_session_expiry_watcher` tearing a session down mid-turn), but the turn's local snapshot stays a valid — if now-dead — object, so the loop's own existing "subprocess exited unexpectedly" detection takes over gracefully instead of crashing with `AttributeError: 'NoneType' object has no attribute '...'`.
- `_format_error_with_stderr`, `_issue_interrupt`, and `_handle_server_request` grew an optional `client` kwarg so callers can pass their local snapshot; all three still default to `self._client` for callers outside the hot loop (unchanged behavior there).
- Bonus: `CodexAppServerClient.close()` used to swallow a failed post-`kill()` reap completely silently (the module imported no `logging` at all — permanently orphaning the subprocess with zero observability anywhere in the stack). It now logs a warning with the pid.

## Root cause

`self._active_turn_lock` was introduced to protect `self._active_turn_id`, but `self._client` — the actual resource the turn loop depends on for its entire lifetime — was never covered by any lock or snapshot discipline. `close()` treats "nulling the reference" as an atomic hand-off; `run_turn()` treated "the reference is stable for the duration of my call" as an unstated assumption. Both were true in the common case (no concurrent close), which is why this shipped and stayed latent until a real concurrent teardown (the session-expiry watcher) exercised it.

## Exhaustion testing

A single lucky pass doesn't prove a race is gone, so alongside the direct regression test there's a 300-iteration soak test (`TestRunTurnClientRaceExhaustive`) that reruns the exact race with a jittered timing window on every iteration (`close()` landing anywhere from immediately before to right on top of the `is_alive()` check), asserting zero `AttributeError`s and a clean thread return across all 300. It runs sequentially — never more than 2 live threads at once, no subprocess, fake in-process client — so it stays cheap on both time (~7s) and memory regardless of iteration count.

```mermaid
%%{init: {'theme': 'dark', 'themeVariables': { 'primaryColor': '#8b0000', 'mainBkg': '#0a0204', 'primaryTextColor': '#ffccd5', 'primaryBorderColor': '#ff0038', 'lineColor': '#ff0038'}}}%%
graph TD
    A[🩸 Session Expiry Watcher] -->|Mid-Turn Teardown| B[⚔️ session.close]
    B -->|self._client = None| C{🔥 run_turn Poll Loop}
    C -->|Before Fix: self._client.is_alive| D[💀 AttributeError Crash]
    C -->|After Fix: local client.is_alive| E[🕯️ Dead-Process Detection]
    E -->|Graceful| F[⚰️ TurnResult should_retire=True]
```

## Test plan

- [x] `tests/agent/transports/test_codex_app_server_session_race.py` — direct reproduction + 300-iteration exhaustion soak, both green
- [x] `tests/agent/transports/test_codex_app_server_zombie_and_races.py` — updated for the close()-logging bonus fix, green
- [x] `tests/agent/transports/test_codex_app_server_session.py`, `tests/run_agent/test_codex_app_server_compaction.py`, `tests/run_agent/test_codex_app_server_integration.py`, `tests/run_agent/test_codex_app_server_lifecycle.py` — full pre-existing coverage for this transport still green (255 tests total across `tests/agent/transports/`)

 