### PR TITLE
fix(run_agent): retire, don't hard-close, the shared OpenAI client on lazy recovery

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -5037,7 +5037,12 @@ class AIAgent:
             reason,
             self._client_log_context(),
         )
-        self._close_openai_client(old_client, reason=f"replace:{reason}", shared=True)
+        # #70773: same ownership hazard as _replace_primary_openai_client —
+        # this method can run on any thread that happens to need the shared
+        # client next, not necessarily the one owning old_client's in-flight
+        # FDs. Retire (FD-safe shutdown, release deferred to GC) instead of
+        # a hard close() here too.
+        self._retire_shared_openai_client(old_client, reason=f"replace:{reason}")
         return new_client
 
     def _cleanup_dead_connections(self) -> bool:

--- a/tests/run_agent/test_openai_client_lifecycle.py
+++ b/tests/run_agent/test_openai_client_lifecycle.py
@@ -131,7 +131,9 @@ def test_closed_shared_client_is_recreated_before_request(monkeypatch):
 
     assert result == {"ok": "fresh-request-client"}
     assert agent.client is replacement_shared
-    assert stale_shared.close_calls >= 1
+    # Lazy recovery retires the shared client without hard-closing it from
+    # the requesting thread; another thread may still be unwinding it.
+    assert stale_shared.close_calls == 0
     assert replacement_shared.close_calls == 0
     assert len(factory.calls) == 2
 
@@ -208,7 +210,9 @@ def test_streaming_call_recreates_closed_shared_client_before_request(monkeypatc
 
     assert response.choices[0].message.content == "Hello world"
     assert agent.client is replacement_shared
-    assert stale_shared.close_calls >= 1
+    # Lazy recovery retires the shared client without hard-closing it from
+    # the requesting thread; another thread may still be unwinding it.
+    assert stale_shared.close_calls == 0
     # The clean stream's wire client is cached for reuse across sequential
     # calls (not closed at request end); teardown really closes it.
     assert request_client.close_calls == 0

--- a/tests/run_agent/test_openai_client_reuse_close_safety.py
+++ b/tests/run_agent/test_openai_client_reuse_close_safety.py
@@ -1,0 +1,173 @@
+"""Regression test — and exhaustive stress test — for the fix to an
+FD-reuse-unsafe hard close that had been reintroduced on the "closed
+client" auto-recovery path.
+
+run_agent.py::AIAgent has two places that swap out the shared
+``self.client`` (the OpenAI SDK client used by the chat_completions /
+OpenAI route):
+
+- ``_replace_primary_openai_client`` (credential rotation) retires the old
+  client via ``_retire_shared_openai_client``, which only shuts down the
+  pooled sockets and explicitly defers ``client.close()`` / FD release to
+  garbage collection. Its own docstring explains why: the shared client
+  has no single owning thread, other workers may still be unwinding SSL
+  BIOs on it, and hard-closing releases raw FDs the kernel can immediately
+  recycle into an unrelated ``open()`` (e.g. ``kanban.db``) — the
+  SQLite-header-corruption bug tracked as #29507 / #70773, covered by
+  ``tests/run_agent/test_70773_shared_client_fd_corruption.py``.
+
+- ``_ensure_primary_openai_client`` (lazy recovery when a stale/closed
+  client is detected before a request) used to call ``_close_openai_client``
+  directly on the *old, shared* client instead — the exact hard-close
+  pattern the sibling function exists to avoid, and one the #70773 test
+  file never exercised.
+
+Fix: ``_ensure_primary_openai_client`` now also retires via
+``_retire_shared_openai_client`` instead of hard-closing.
+"""
+
+from __future__ import annotations
+
+import threading
+from typing import Any
+
+from run_agent import AIAgent
+
+
+class _FakeOpenAIClient:
+    """Not a ``unittest.mock.Mock`` on purpose — AIAgent._is_openai_client_closed
+    special-cases ``Mock`` instances to always report "not closed", which
+    would defeat this test."""
+
+    def __init__(self, *, is_closed: bool = False) -> None:
+        self.is_closed = is_closed
+        self.close_calls = 0
+
+    def close(self) -> None:
+        self.close_calls += 1
+
+
+def _bare_agent(*, client: Any) -> AIAgent:
+    agent = AIAgent.__new__(AIAgent)
+    agent.session_id = "test-openai-client-reuse"
+    agent.client = client
+    agent._client_kwargs = {}
+    agent.provider = "openai"
+    agent.base_url = "https://api.openai.com/v1"
+    agent.model = "gpt-test"
+    return agent
+
+
+class TestEnsurePrimaryClientRetiresSharedClient:
+    def test_ensure_primary_does_not_hard_close_the_stale_shared_client(
+        self, monkeypatch
+    ):
+        """Proves the fix: recovering from a closed shared client retires
+        it (FD-reuse-safe: shutdown + defer to GC) instead of calling
+        client.close() directly, matching _replace_primary_openai_client."""
+        old_client = _FakeOpenAIClient(is_closed=True)
+        new_client = _FakeOpenAIClient(is_closed=False)
+        agent = _bare_agent(client=old_client)
+
+        monkeypatch.setattr(
+            agent, "_create_openai_client", lambda *a, **kw: new_client
+        )
+        monkeypatch.setattr(agent, "_force_close_tcp_sockets", lambda client: 0)
+
+        result = agent._ensure_primary_openai_client(reason="test-recovery")
+
+        assert result is new_client
+        assert agent.client is new_client
+        assert old_client.close_calls == 0, (
+            "a hard close() landed on the old *shared* client — this is "
+            "exactly what _retire_shared_openai_client's docstring (and "
+            "#29507/#70773) says must never happen for a shared client "
+            "with unknown borrowers"
+        )
+
+    def test_replace_primary_does_not_hard_close_the_old_shared_client(
+        self, monkeypatch
+    ):
+        """Contrast case: the credential-rotation call site gets this
+        right — it must NOT call close() on the old shared client."""
+        old_client = _FakeOpenAIClient(is_closed=False)
+        new_client = _FakeOpenAIClient(is_closed=False)
+        agent = _bare_agent(client=old_client)
+        agent._client_lock = threading.RLock()
+
+        monkeypatch.setattr(
+            agent, "_create_openai_client", lambda *a, **kw: new_client
+        )
+        monkeypatch.setattr(agent, "_force_close_tcp_sockets", lambda client: 0)
+
+        ok = agent._replace_primary_openai_client(reason="test-rotation")
+
+        assert ok is True
+        assert agent.client is new_client
+        assert old_client.close_calls == 0, (
+            "credential rotation must defer FD release to GC, not hard-close "
+            "a shared client another thread may still be borrowing"
+        )
+
+
+class TestEnsurePrimaryClientExhaustive:
+    """Exhaustion / soak test requested alongside the fix: repeats the
+    recover-a-closed-shared-client path many times, including with real
+    concurrent borrower threads still "reading" the old client (simulating
+    an in-flight stream) while recovery runs, to make sure the fix holds
+    up under repeated and concurrent pressure — not just a single lucky
+    pass. Every agent/client pair is local to its iteration and dropped
+    immediately after, so memory stays flat across iterations."""
+
+    ITERATIONS = 300
+
+    def test_no_hard_close_across_many_recoveries_with_concurrent_borrowers(
+        self, monkeypatch
+    ):
+        failures: list[tuple[int, str]] = []
+
+        for i in range(self.ITERATIONS):
+            old_client = _FakeOpenAIClient(is_closed=True)
+            new_client = _FakeOpenAIClient(is_closed=False)
+            agent = _bare_agent(client=old_client)
+
+            monkeypatch.setattr(
+                agent, "_create_openai_client", lambda *a, **kw: new_client
+            )
+            monkeypatch.setattr(
+                agent, "_force_close_tcp_sockets", lambda client: 0
+            )
+
+            # Simulate another thread still "borrowing" the old client
+            # (e.g. unwinding a stream) concurrently with recovery — the
+            # scenario #70773 describes. It never touches close() itself;
+            # it just proves recovery doesn't need to wait for or race
+            # against borrowers because it no longer hard-closes at all.
+            borrower_done = threading.Event()
+
+            def _borrower(client=old_client):
+                for _ in range(50):
+                    _ = client.is_closed
+                borrower_done.set()
+
+            t = threading.Thread(target=_borrower, daemon=True)
+            t.start()
+
+            result = agent._ensure_primary_openai_client(
+                reason=f"exhaustive-{i}"
+            )
+
+            t.join(timeout=5)
+            if not borrower_done.is_set():
+                failures.append((i, "borrower thread never finished"))
+            elif result is not new_client:
+                failures.append((i, "did not return the new client"))
+            elif old_client.close_calls != 0:
+                failures.append(
+                    (i, f"hard close() called {old_client.close_calls}x")
+                )
+
+        assert not failures, (
+            f"{len(failures)}/{self.ITERATIONS} iterations failed "
+            f"(showing up to 5): {failures[:5]}"
+        )

--- a/tests/run_agent/test_openai_client_reuse_close_safety.py
+++ b/tests/run_agent/test_openai_client_reuse_close_safety.py
@@ -138,30 +138,52 @@ class TestEnsurePrimaryClientExhaustive:
                 agent, "_force_close_tcp_sockets", lambda client: 0
             )
 
-            # Simulate another thread still "borrowing" the old client
-            # (e.g. unwinding a stream) concurrently with recovery — the
-            # scenario #70773 describes. It never touches close() itself;
-            # it just proves recovery doesn't need to wait for or race
-            # against borrowers because it no longer hard-closes at all.
+            # Hold a real borrower reference across retirement. The start and
+            # release barriers guarantee that recovery overlaps the borrower;
+            # merely starting a thread here would allow it to finish before
+            # _ensure_primary_openai_client runs and would not test the race.
+            borrower_started = threading.Event()
+            borrower_release = threading.Event()
             borrower_done = threading.Event()
 
             def _borrower(client=old_client):
-                for _ in range(50):
-                    _ = client.is_closed
+                borrower_started.set()
+                borrower_release.wait(timeout=5)
+                _ = client.is_closed
                 borrower_done.set()
 
             t = threading.Thread(target=_borrower, daemon=True)
             t.start()
 
-            result = agent._ensure_primary_openai_client(
-                reason=f"exhaustive-{i}"
-            )
+            if not borrower_started.wait(timeout=5):
+                failures.append((i, "borrower thread never started"))
+                borrower_release.set()
+                t.join(timeout=5)
+                continue
+
+            shutdown_calls = []
+
+            def _shutdown_only(client):
+                shutdown_calls.append(client)
+                return 0
+
+            monkeypatch.setattr(agent, "_force_close_tcp_sockets", _shutdown_only)
+            try:
+                result = agent._ensure_primary_openai_client(
+                    reason=f"exhaustive-{i}"
+                )
+            finally:
+                borrower_release.set()
 
             t.join(timeout=5)
             if not borrower_done.is_set():
                 failures.append((i, "borrower thread never finished"))
             elif result is not new_client:
                 failures.append((i, "did not return the new client"))
+            elif shutdown_calls != [old_client]:
+                failures.append(
+                    (i, f"unexpected shutdown calls: {shutdown_calls!r}")
+                )
             elif old_client.close_calls != 0:
                 failures.append(
                     (i, f"hard close() called {old_client.close_calls}x")


### PR DESCRIPTION
Fixes #87423

## Summary

`_ensure_primary_openai_client` (lazy recovery when a stale/closed shared client is detected before a request — called from multiple threads: turn-summary generation, codex-direct streaming) called `_close_openai_client(old_client, ..., shared=True)` directly on the old *shared* client. That's a hard `client.close()` on an object with no single owning thread.

`_replace_primary_openai_client` (credential rotation) already does this correctly via `_retire_shared_openai_client`: `shutdown()` the pooled sockets (FD-safe from any thread) and defer FD release to garbage collection, specifically because hard-closing can release a raw FD the kernel immediately recycles into an unrelated `open()` (e.g. `kanban.db`) while another thread is still unwinding its SSL BIOs on the same client — the #29507/#70773 SQLite-header-corruption shape.

This PR switches `_ensure_primary_openai_client` to the same safe retirement path.

## Root cause

The #70773 fix covered the three in-request cleanup sites (stale watchdog, mid-tool retry, stream retry) plus `_replace_primary_openai_client`, and its regression suite (`tests/run_agent/test_70773_shared_client_fd_corruption.py`) locked all four in. `_ensure_primary_openai_client` performs conceptually the same "swap the shared client" operation but was never brought under that discipline or that test file's coverage — a gap in the original fix's blast radius, not a new regression.

## Exhaustion testing

Added `TestEnsurePrimaryClientExhaustive`: 300 iterations of the recovery path, each with a real concurrent "borrower" thread touching the old (about-to-be-retired) client while recovery runs on the main thread — the exact concurrency shape #70773 describes. Every iteration builds a fresh, local agent/client pair and joins its thread before the next iteration starts, so memory stays flat regardless of iteration count. Zero hard-closes across all 300.

```mermaid
%%{init: {'theme': 'dark', 'themeVariables': { 'primaryColor': '#00f0ff', 'mainBkg': '#0a0a16', 'primaryTextColor': '#ffffff', 'primaryBorderColor': '#ff007f', 'lineColor': '#00f0ff'}}}%%
graph TD
    A[⚡ Stale Shared Client Detected] --> B{🔒 _ensure_primary_openai_client}
    B -->|Before Fix| C[🚀 client.close - Hard FD Release]
    C -->|Kernel Recycles FD| D[💥 kanban.db Header Corruption]
    B -->|After Fix| E[🛡️ _retire_shared_openai_client]
    E -->|shutdown sockets, defer FDs to GC| F[✅ Safe for Any Borrower Thread]
```

## Test plan

- [x] `tests/run_agent/test_openai_client_reuse_close_safety.py` — new: proves `_ensure_primary_openai_client` no longer hard-closes, plus the 300-iteration concurrent-borrower soak, both green
- [x] `tests/run_agent/test_70773_shared_client_fd_corruption.py` — pre-existing #70773 suite, still green
- [x] `tests/run_agent/test_request_client_reuse_abort_races.py`, `tests/agent/test_request_client_reuse.py` — adjacent client-lifecycle coverage, still green

## Infographic : 


<img width="1376" height="768" alt="infographic_openai_retire_client_87426_matched_ukiyoe" src="https://github.com/user-attachments/assets/b28428e0-9e88-46a9-8150-5bcefa830f0f" />

 