### PR TITLE
fix(memory): hide built-in memory tool when both memory stores are disabled

### DIFF
--- a/hermes_cli/memory_setup.py
+++ b/hermes_cli/memory_setup.py
@@ -490,10 +490,11 @@ def cmd_status(args) -> None:
     user_mark = "enabled ✓" if user_profile_enabled else "disabled ✗"
 
     # Check if the memory tool is enabled for the CLI platform via the
-    # canonical resolver (handles composite toolsets like hermes-cli).
+    # canonical resolver and respects the check_fn gate when both stores are disabled.
     from hermes_cli.tools_config import _get_platform_tools
+    from tools.memory_tool import check_memory_requirements
     cli_tools = _get_platform_tools(config, "cli", include_default_mcp_servers=False)
-    memory_tool_enabled = "memory" in cli_tools
+    memory_tool_enabled = ("memory" in cli_tools) and check_memory_requirements()
     tool_mark = "enabled ✓" if memory_tool_enabled else "disabled ✗"
 
     print("\nMemory status\n" + "─" * 40)

--- a/model_tools.py
+++ b/model_tools.py
@@ -414,6 +414,29 @@ def get_tool_definitions(
     return result
 
 
+def _builtin_memory_tools_disabled() -> bool:
+    """True when the user has explicitly disabled BOTH built-in memory stores.
+
+    ``memory.memory_enabled: false`` + ``memory.user_profile_enabled: false``
+    means the operator opted into an external-provider-only memory surface
+    (e.g. Honcho). In that mode the built-in ``memory`` tool has no backing
+    store (agent_init never constructs MemoryStore), so exposing its schema
+    just invites calls that fail with "Memory is not available." Honcho /
+    other provider tools are injected separately and are unaffected.
+
+    Fails closed (False = keep the tool) if config can't be read.
+    """
+    try:
+        from hermes_cli.config import load_config
+        mem = (load_config() or {}).get("memory") or {}
+        return (
+            mem.get("memory_enabled") is False
+            and mem.get("user_profile_enabled") is False
+        )
+    except Exception:
+        return False
+
+
 def _compute_tool_definitions(
     enabled_toolsets: Optional[List[str]] = None,
     disabled_toolsets: Optional[List[str]] = None,
@@ -456,6 +479,12 @@ def _compute_tool_definitions(
         from toolsets import get_all_toolsets
         for ts_name in get_all_toolsets():
             tools_to_include.update(resolve_toolset(ts_name))
+
+    # Honcho-primary memory mode: when both built-in memory stores are
+    # disabled, drop the dead built-in `memory` schema. External provider
+    # tools (honcho_*) are injected later and unaffected.
+    if "memory" in tools_to_include and _builtin_memory_tools_disabled():
+        tools_to_include.discard("memory")
 
     # Always apply disabled toolsets as a subtraction step at the end.
     # This ensures that even if a composite toolset (like hermes-cli)

--- a/model_tools.py
+++ b/model_tools.py
@@ -417,22 +417,17 @@ def get_tool_definitions(
 def _builtin_memory_tools_disabled() -> bool:
     """True when the user has explicitly disabled BOTH built-in memory stores.
 
-    ``memory.memory_enabled: false`` + ``memory.user_profile_enabled: false``
-    means the operator opted into an external-provider-only memory surface
-    (e.g. Honcho). In that mode the built-in ``memory`` tool has no backing
-    store (agent_init never constructs MemoryStore), so exposing its schema
-    just invites calls that fail with "Memory is not available." Honcho /
-    other provider tools are injected separately and are unaffected.
+    Delegates to :func:`tools.memory_tool.check_memory_requirements` as the
+    single source of truth for the config gate.
 
-    Fails closed (False = keep the tool) if config can't be read.
+    ``model_tools._compute_tool_definitions`` applies this gate synchronously
+    on config fingerprint changes to bypass the 30 s TTL / 60 s flap-grace
+    window in :meth:`tools.registry.ToolRegistry.get_definitions` on a disable
+    flip.
     """
     try:
-        from hermes_cli.config import load_config
-        mem = (load_config() or {}).get("memory") or {}
-        return (
-            mem.get("memory_enabled") is False
-            and mem.get("user_profile_enabled") is False
-        )
+        from tools.memory_tool import check_memory_requirements
+        return not check_memory_requirements()
     except Exception:
         return False
 

--- a/tests/hermes_cli/test_memory_setup.py
+++ b/tests/hermes_cli/test_memory_setup.py
@@ -96,3 +96,35 @@ def test_install_dependencies_force_reinstalls_versioned_specs(tmp_path, monkeyp
 
     assert installed, "force=True must reach the install step"
     assert any("mem0ai>=2.0.10,<3" in specs for specs in installed)
+
+
+def test_cmd_status_memory_tool_gate_disabled(capsys, monkeypatch):
+    """When both memory stores are disabled, Memory status reports memory tool as disabled."""
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {"memory": {"memory_enabled": False, "user_profile_enabled": False}},
+    )
+    monkeypatch.setattr(memory_setup, "_get_available_providers", lambda: [])
+
+    memory_setup.cmd_status(SimpleNamespace())
+
+    captured = capsys.readouterr().out
+    assert "Memory tool:        disabled ✗" in captured
+    assert "Memory injection:   disabled ✗" in captured
+    assert "User profile:       disabled ✗" in captured
+
+
+def test_cmd_status_memory_tool_gate_enabled(capsys, monkeypatch):
+    """When at least one memory store is enabled, Memory status reports memory tool as enabled."""
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {"memory": {"memory_enabled": True, "user_profile_enabled": False}},
+    )
+    monkeypatch.setattr(memory_setup, "_get_available_providers", lambda: [])
+
+    memory_setup.cmd_status(SimpleNamespace())
+
+    captured = capsys.readouterr().out
+    assert "Memory tool:        enabled ✓" in captured
+    assert "Memory injection:   enabled ✓" in captured
+    assert "User profile:       disabled ✗" in captured

--- a/tests/tools/test_memory_tool.py
+++ b/tests/tools/test_memory_tool.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from tools.memory_tool import (
     MemoryStore,
     memory_tool,
+    check_memory_requirements,
     _scan_memory_content,
 )
 
@@ -18,6 +19,47 @@ def _blocked(content, pattern_id=None):
     assert "Blocked" in result
     if pattern_id:
         assert pattern_id in result, f"expected {pattern_id} in {result!r}"
+
+
+# =========================================================================
+# Config gate: check_memory_requirements respects memory_enabled flags
+# =========================================================================
+
+class TestMemoryToolConfigGate:
+    """Regression: a Honcho-primary profile (memory_enabled=False,
+    user_profile_enabled=False) must not advertise the built-in memory tool.
+    The gate reads hermes_cli.config.load_config lazily; we patch that."""
+
+    def _patch_cfg(self, monkeypatch, mem_cfg):
+        import hermes_cli.config as hc
+        monkeypatch.setattr(hc, "load_config", lambda: {"memory": mem_cfg})
+
+    def test_visible_when_both_enabled(self, monkeypatch):
+        self._patch_cfg(monkeypatch, {"memory_enabled": True, "user_profile_enabled": True})
+        assert check_memory_requirements() is True
+
+    def test_visible_when_only_memory_enabled(self, monkeypatch):
+        self._patch_cfg(monkeypatch, {"memory_enabled": True, "user_profile_enabled": False})
+        assert check_memory_requirements() is True
+
+    def test_visible_when_only_user_enabled(self, monkeypatch):
+        self._patch_cfg(monkeypatch, {"memory_enabled": False, "user_profile_enabled": True})
+        assert check_memory_requirements() is True
+
+    def test_hidden_when_both_disabled(self, monkeypatch):
+        self._patch_cfg(monkeypatch, {"memory_enabled": False, "user_profile_enabled": False})
+        assert check_memory_requirements() is False
+
+    def test_fails_open_when_no_memory_section(self, monkeypatch):
+        self._patch_cfg(monkeypatch, {})
+        assert check_memory_requirements() is True
+
+    def test_fails_open_on_config_error(self, monkeypatch):
+        import hermes_cli.config as hc
+        def _boom():
+            raise RuntimeError("config unreadable")
+        monkeypatch.setattr(hc, "load_config", _boom)
+        assert check_memory_requirements() is True
 
 
 # =========================================================================

--- a/tests/tools/test_memory_tool.py
+++ b/tests/tools/test_memory_tool.py
@@ -61,6 +61,23 @@ class TestMemoryToolConfigGate:
         monkeypatch.setattr(hc, "load_config", _boom)
         assert check_memory_requirements() is True
 
+    def test_model_tools_builtin_disabled_mirrors_gate(self, monkeypatch):
+        from model_tools import _builtin_memory_tools_disabled
+        self._patch_cfg(monkeypatch, {"memory_enabled": False, "user_profile_enabled": False})
+        assert _builtin_memory_tools_disabled() is True
+        self._patch_cfg(monkeypatch, {"memory_enabled": True, "user_profile_enabled": False})
+        assert _builtin_memory_tools_disabled() is False
+
+    def test_compute_tool_definitions_drops_memory_when_both_disabled(self, monkeypatch):
+        from model_tools import _compute_tool_definitions
+        self._patch_cfg(monkeypatch, {"memory_enabled": False, "user_profile_enabled": False})
+        tools = _compute_tool_definitions(enabled_toolsets=["memory"], quiet_mode=True)
+        assert not any(t["function"]["name"] == "memory" for t in tools)
+
+        self._patch_cfg(monkeypatch, {"memory_enabled": True, "user_profile_enabled": True})
+        tools_enabled = _compute_tool_definitions(enabled_toolsets=["memory"], quiet_mode=True)
+        assert any(t["function"]["name"] == "memory" for t in tools_enabled)
+
 
 # =========================================================================
 # Security scanning

--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -1144,8 +1144,24 @@ def memory_tool(
 
 
 def check_memory_requirements() -> bool:
-    """Memory tool has no external requirements -- always available."""
-    return True
+    """Gate the built-in memory tool on the active profile's config.
+
+    Hidden when BOTH built-in stores are disabled (external-provider-only
+    setups, e.g. Honcho-primary). Fails open: DEFAULT_CONFIG enables both
+    stores, and any config-read error keeps the tool available so normal
+    installs are unaffected. load_config() is imported lazily (and at call
+    time) so tests can monkeypatch hermes_cli.config.load_config.
+    """
+    try:
+        from hermes_cli.config import load_config
+
+        mem_cfg = (load_config() or {}).get("memory", {}) or {}
+        return bool(
+            mem_cfg.get("memory_enabled", True)
+            or mem_cfg.get("user_profile_enabled", True)
+        )
+    except Exception:
+        return True
 
 
 def apply_memory_pending(payload: Dict[str, Any], store: "MemoryStore") -> Dict[str, Any]:

--- a/website/docs/user-guide/features/memory.md
+++ b/website/docs/user-guide/features/memory.md
@@ -252,7 +252,7 @@ first, set `memory.write_approval: true`. It's a simple on/off gate applied to
 | `false` (default) | Write freely — the gate is off (the pre-gate behaviour). |
 | `true` | Require approval before anything is saved. In the interactive CLI, foreground writes prompt you inline (entries are small enough to read in full). Everywhere else — messaging platforms, scripts, and the background self-improvement review — writes are **staged** for review with `/memory pending`. |
 
-> To turn memory off entirely (not just gate it), set `memory_enabled: false`.
+> To turn memory off entirely (not just gate it), set both `memory_enabled: false` and `user_profile_enabled: false`. When both built-in stores are disabled, the built-in `memory` tool is automatically hidden.
 
 Review staged writes from the CLI or any messaging platform:
 


### PR DESCRIPTION
## Problem

When a profile disables both built-in memory stores (`memory.memory_enabled: false` and `memory.user_profile_enabled: false`) — such as in an external-provider-only setup (e.g. Honcho or Hindsight primary) — `agent_init` never constructs a `MemoryStore`. However, the built-in `memory` tool schema was still advertised to the model, leading to calls failing with `"Memory is not available"`.

## Solution & Hardening

1. **Config Gate in `tools/memory_tool.py`:**
   - `check_memory_requirements()` checks `load_config()` and returns `False` only when both `memory_enabled` and `user_profile_enabled` are explicitly disabled.
   - Fails open on unconfigured sections or read errors so default installs remain unaffected.

2. **Synchronous Tool Discard in `model_tools.py`:**
   - `_builtin_memory_tools_disabled()` delegates to `not check_memory_requirements()` (DRY).
   - `_compute_tool_definitions()` discards `"memory"` on turn-level config fingerprint changes, bypassing the 30s TTL / 60s flap-suppression window in `registry.get_definitions()` on disable flips.

3. **Status Panel & Docs Alignment:**
   - Updated `hermes memory status` (`hermes_cli/memory_setup.py`) to check `check_memory_requirements()`, accurately reporting `Memory tool: disabled ✗` when both stores are disabled.
   - Updated `website/docs/user-guide/features/memory.md` documentation.

4. **Testing:**
   - Added unit tests in `tests/tools/test_memory_tool.py` covering all 4 config permutations and fail-open behavior.
   - Added integration tests for `_compute_tool_definitions()` with `enabled_toolsets=["memory"]`.
   - Added CLI tests in `tests/hermes_cli/test_memory_setup.py` verifying status reporting.

Closes #86540