### PR TITLE
fix(tui_gateway): control RPCs no longer wait on the deferred agent build

### DIFF
--- a/tests/tui_gateway/test_control_rpcs_do_not_wait_for_agent.py
+++ b/tests/tui_gateway/test_control_rpcs_do_not_wait_for_agent.py
@@ -1,14 +1,16 @@
 """Control RPCs must not block on the deferred agent build.
 
-``approval.pending``, ``approval.received`` and ``approval.respond`` need the
-session RECORD — specifically ``session_key`` — and never the agent. All three
-reach ``tools.approval``'s module-global ``_gateway_queues``, which is keyed by
-``session_key`` alone and has no relationship to the session's ``agent_ready``
-event, so ``_sess``'s ``_wait_agent`` bought nothing at these sites and charged
-up to 30 seconds for it.
+``approval.pending``, ``approval.received``, ``approval.respond``,
+``process.kill`` and ``process.list`` need the session RECORD — specifically
+``session_key`` — and never the agent. The approval trio reaches
+``tools.approval``'s module-global ``_gateway_queues``, which is keyed by
+``session_key`` alone; ``process.*`` matches the same key against the global
+process registry. Neither structure has any relationship to the session's
+``agent_ready`` event, so ``_sess``'s ``_wait_agent`` bought nothing at these
+five sites and charged up to 30 seconds for it.
 
-None of the three is in ``_LONG_HANDLERS``, so that charge ran inline on the
-socket reader thread and stalled every RPC queued behind it — the exact
+Four of the five are not in ``_LONG_HANDLERS``, so that charge ran inline on
+the socket reader thread and stalled every RPC queued behind it — the exact
 failure mode ``_LONG_HANDLERS``' own comment cites ``approval.respond`` as the
 reason to protect against. And the wait is reachable by construction rather
 than by accident: the desktop replays pending approvals on ``gateway.ready`` /
@@ -153,3 +155,110 @@ def test_approval_rpcs_still_reject_an_unknown_session(no_build, method):
 
     assert response["error"]["code"] == 4001
 
+
+@pytest.fixture
+def registered_processes(session):
+    """One background process owned by this session and one owned by another.
+
+    The registry is a process-global singleton, so both entries are removed
+    again on teardown.
+    """
+    from tools.process_registry import ProcessSession, process_registry
+
+    sid, record = session
+    mine = ProcessSession(id="proc_mine", command="npm run dev", session_key=sid)
+    theirs = ProcessSession(id="proc_theirs", command="npm run other", session_key="other-session")
+    with process_registry._lock:
+        process_registry._running["proc_mine"] = mine
+        process_registry._running["proc_theirs"] = theirs
+    yield sid, record, mine, theirs
+    with process_registry._lock:
+        process_registry._running.pop("proc_mine", None)
+        process_registry._running.pop("proc_theirs", None)
+
+
+def test_process_list_reports_this_sessions_processes_while_building(registered_processes):
+    """The desktop status stack fills on a cold resume instead of sitting empty."""
+    sid, record, _mine, _theirs = registered_processes
+
+    response = call("process.list", {"session_id": sid})
+
+    assert "error" not in response, response
+    processes = response["result"]["processes"]
+    # Session scoping survives: the other session's process is not disclosed.
+    assert [p["session_id"] for p in processes] == ["proc_mine"]
+    assert not record["agent_ready"].is_set()
+
+
+def test_process_kill_still_refuses_another_sessions_process_while_building(
+    registered_processes,
+):
+    """4044, not 5032: the handler reaches its ownership check without waiting.
+
+    This is the discriminator for the whole change. Before the fix the wait
+    fired first and every one of these calls came back 5032 "agent
+    initialization timed out" — the ownership rule was never even consulted.
+    """
+    sid, record, _mine, _theirs = registered_processes
+
+    response = call("process.kill", {"session_id": sid, "process_id": "proc_theirs"})
+
+    assert response["error"]["code"] == 4044
+    assert not record["agent_ready"].is_set()
+
+
+def test_process_kill_still_reports_an_unknown_process_while_building(session):
+    """Same discriminator on the plain not-found path."""
+    sid, record = session
+
+    response = call("process.kill", {"session_id": sid, "process_id": "proc_absent"})
+
+    assert response["error"]["code"] == 4044
+    assert not record["agent_ready"].is_set()
+
+
+def test_process_kill_still_requires_a_process_id(session):
+    """Dropping the agent wait must not drop parameter validation."""
+    sid, _record = session
+
+    response = call("process.kill", {"session_id": sid})
+
+    assert response["error"]["code"] == 4012
+
+
+CONVERTED_CONTROL_RPCS = (
+    "approval.pending",
+    "approval.received",
+    "approval.respond",
+    "process.list",
+    "process.kill",
+)
+
+
+def test_converted_control_rpcs_skip_the_agent_wait_and_rollback_still_takes_it(
+    session, monkeypatch
+):
+    """Resolver-level proof that the sweep is complete AND correctly bounded.
+
+    The five control RPCs must reach ``_sess_building``; ``rollback.list`` is
+    deliberately NOT converted, because it resolves through
+    ``_with_checkpoints``, which dereferences ``session["agent"]``. Converting
+    it would fault mid-build rather than merely stall — the 5020 below is that
+    dereference failing against an unbuilt session, which is exactly why the
+    exclusion is reasoned and not an oversight. If either half of this ever
+    flips, the boundary drawn by this sweep has gone stale.
+    """
+    sid, _record = session
+    waited: list = []
+    monkeypatch.setattr(server, "_wait_agent", lambda s, rid: waited.append(rid) or None)
+
+    for method in CONVERTED_CONTROL_RPCS:
+        call(method, {"session_id": sid, "request_id": "req-1", "process_id": "proc_absent"})
+    assert waited == []
+
+    rollback = call("rollback.list", {"session_id": sid})
+
+    assert waited == [1]
+    assert rollback["error"]["code"] == 5020
+    # Names the dereference that keeps rollback.* out of this sweep.
+    assert "_checkpoint_mgr" in rollback["error"]["message"]

--- a/tests/tui_gateway/test_control_rpcs_do_not_wait_for_agent.py
+++ b/tests/tui_gateway/test_control_rpcs_do_not_wait_for_agent.py
@@ -1,0 +1,155 @@
+"""Control RPCs must not block on the deferred agent build.
+
+``approval.pending``, ``approval.received`` and ``approval.respond`` need the
+session RECORD — specifically ``session_key`` — and never the agent. All three
+reach ``tools.approval``'s module-global ``_gateway_queues``, which is keyed by
+``session_key`` alone and has no relationship to the session's ``agent_ready``
+event, so ``_sess``'s ``_wait_agent`` bought nothing at these sites and charged
+up to 30 seconds for it.
+
+None of the three is in ``_LONG_HANDLERS``, so that charge ran inline on the
+socket reader thread and stalled every RPC queued behind it — the exact
+failure mode ``_LONG_HANDLERS``' own comment cites ``approval.respond`` as the
+reason to protect against. And the wait is reachable by construction rather
+than by accident: the desktop replays pending approvals on ``gateway.ready`` /
+``session.info``, i.e. precisely while a cold resume's deferred build is still
+warming, and ``_start_agent_build`` deliberately early-returns for a lazy watch
+session spectating an in-flight child — leaving ``agent_ready`` unset for the
+whole child run, so these RPCs did not merely stall, they timed out at 5032.
+
+These are invariants, not timings: each handler must complete, and do its real
+work, while the build event is still unset.
+"""
+
+from __future__ import annotations
+
+import threading
+
+import pytest
+
+from tui_gateway import server
+
+
+def building_session(tmp_path, sid: str) -> dict:
+    """A session record whose deferred agent build has NOT completed."""
+    session = {
+        "agent": None,
+        "agent_ready": threading.Event(),  # deliberately never set
+        "agent_error": None,
+        "attached_images": [],
+        "cwd": str(tmp_path),
+        "history": [],
+        "history_lock": threading.RLock(),
+        "history_version": 0,
+        "profile_home": str(tmp_path),
+        "running": False,
+        "session_key": sid,
+        "transport": None,
+    }
+    server._sessions[sid] = session
+    return session
+
+
+@pytest.fixture
+def no_build(monkeypatch):
+    """Never let the real builder run — the point is the unfinished build."""
+    monkeypatch.setattr(server, "_start_agent_build", lambda sid, session: None)
+
+
+@pytest.fixture
+def session(tmp_path, no_build, request):
+    sid = f"control-{request.node.name}"
+    record = building_session(tmp_path, sid)
+    yield sid, record
+    server._sessions.pop(sid, None)
+
+
+def call(method: str, params: dict) -> dict:
+    return server._methods[method](1, params)
+
+
+@pytest.fixture
+def pending_approval(session):
+    """One unresolved approval queued under this session's key.
+
+    ``tools.approval`` has no public enqueue helper — the only producer is
+    ``_await_gateway_decision`` on the agent thread — so this mirrors its three
+    lines (build an ``_ApprovalEntry``, append it under ``_lock``) rather than
+    reaching for a seam that does not exist. The queue is popped again on
+    teardown because it is process-global state.
+    """
+    from tools import approval
+
+    sid, record = session
+    entry = approval._ApprovalEntry(
+        {"command": "rm -rf /tmp/scratch", "description": "delete scratch", "request_id": "req-1"}
+    )
+    with approval._lock:
+        approval._gateway_queues.setdefault(sid, []).append(entry)
+    yield sid, record, entry
+    with approval._lock:
+        approval._gateway_queues.pop(sid, None)
+
+
+def test_approval_pending_replays_the_queue_while_the_agent_is_building(pending_approval):
+    """The replay the desktop fires on reconnect must not wait for the build."""
+    sid, record, _entry = pending_approval
+
+    response = call("approval.pending", {"session_id": sid})
+
+    assert "error" not in response, response
+    approvals = response["result"]["approvals"]
+    assert [a["request_id"] for a in approvals] == ["req-1"]
+    assert approvals[0]["command"] == "rm -rf /tmp/scratch"
+    # The invariant that makes this a fix rather than a coincidence: the build
+    # never finished, and the replay landed anyway.
+    assert not record["agent_ready"].is_set()
+
+
+def test_approval_received_acknowledges_while_the_agent_is_building(pending_approval):
+    """Not waiting must not mean not acking — the entry is really flipped."""
+    sid, record, entry = pending_approval
+    assert entry.acknowledged is False
+
+    response = call("approval.received", {"session_id": sid, "request_id": "req-1"})
+
+    assert "error" not in response, response
+    assert response["result"]["acknowledged"] is True
+    assert entry.acknowledged is True
+    assert not record["agent_ready"].is_set()
+
+
+def test_approval_respond_resolves_while_the_agent_is_building(pending_approval):
+    """The RPC _LONG_HANDLERS exists to protect must itself run unblocked."""
+    sid, record, entry = pending_approval
+
+    response = call(
+        "approval.respond", {"session_id": sid, "request_id": "req-1", "choice": "deny"}
+    )
+
+    assert "error" not in response, response
+    assert response["result"]["resolved"] == 1
+    # The blocked agent thread is genuinely released, not just answered.
+    assert entry.result == "deny"
+    assert entry.event.is_set()
+    assert not record["agent_ready"].is_set()
+
+
+def test_approval_received_still_requires_a_request_id(session):
+    """Dropping the agent wait must not drop parameter validation."""
+    sid, _record = session
+
+    response = call("approval.received", {"session_id": sid})
+
+    assert response["error"]["code"] == 4006
+
+
+@pytest.mark.parametrize(
+    "method", ["approval.pending", "approval.received", "approval.respond"]
+)
+def test_approval_rpcs_still_reject_an_unknown_session(no_build, method):
+    """_sess_building keeps _sess_nowait's 4001 — validation is not the wait."""
+    response = call(method, {"session_id": "nope", "request_id": "req-1"})
+
+    assert response["error"]["code"] == 4001
+

--- a/tui_gateway/methods_prompt.py
+++ b/tui_gateway/methods_prompt.py
@@ -1379,9 +1379,19 @@ def _(rid, params: dict) -> dict:
     return _respond(rid, params, "value", allow_expired=True)
 
 
+# The three approval RPCs resolve via _sess_building for the reason spelled out
+# in its docstring: they need the session RECORD and not the agent. Every one of
+# them reaches tools.approval's module-global _gateway_queues, which is keyed by
+# session_key alone and has no relationship to the agent build — so _sess's
+# _wait_agent bought nothing here and charged up to 30 seconds for it. None of
+# the three is in _LONG_HANDLERS, so that charge landed inline on the socket
+# reader thread, which is the surface _LONG_HANDLERS' own comment cites
+# approval.respond as the reason to protect. The desktop replays pending
+# approvals on gateway.ready / session.info (approvalReplaySessionId), i.e.
+# precisely while a cold resume's deferred build is still warming.
 @method("approval.pending")
 def _(rid, params: dict) -> dict:
-    session, err = _sess(params, rid)
+    session, err = _sess_building(params, rid)
     if err:
         return err
     try:
@@ -1394,7 +1404,7 @@ def _(rid, params: dict) -> dict:
 
 @method("approval.received")
 def _(rid, params: dict) -> dict:
-    session, err = _sess(params, rid)
+    session, err = _sess_building(params, rid)
     if err:
         return err
     request_id = params.get("request_id")
@@ -1413,7 +1423,7 @@ def _(rid, params: dict) -> dict:
 
 @method("approval.respond")
 def _(rid, params: dict) -> dict:
-    session, err = _sess(params, rid)
+    session, err = _sess_building(params, rid)
     if err:
         return err
     try:

--- a/tui_gateway/methods_tools.py
+++ b/tui_gateway/methods_tools.py
@@ -48,8 +48,14 @@ def _(rid, params: dict) -> dict:
 
 @method("process.list")
 def _(rid, params: dict) -> dict:
-    """Session-scoped view of the background process registry (desktop status stack)."""
-    session, err = _sess(params, rid)
+    """Session-scoped view of the background process registry (desktop status stack).
+
+    Resolves via ``_sess_building``: ``_session_processes`` matches on
+    ``session_key`` against the global process registry and never touches the
+    agent, so waiting on the deferred build only left the status stack empty for
+    up to 30 seconds on a cold resume.
+    """
+    session, err = _sess_building(params, rid)
     if err:
         return err
     try:

--- a/tui_gateway/methods_tools.py
+++ b/tui_gateway/methods_tools.py
@@ -61,8 +61,14 @@ def _(rid, params: dict) -> dict:
 @method("process.kill")
 def _(rid, params: dict) -> dict:
     """Kill ONE background process — scoped to the caller's session so one
-    window can't reap another session's work (unlike process.stop's kill_all)."""
-    session, err = _sess(params, rid)
+    window can't reap another session's work (unlike process.stop's kill_all).
+
+    Resolves via ``_sess_building``: the ownership check reads ``session_key``
+    only. Unlike ``process.list`` this handler is NOT in ``_LONG_HANDLERS``, so
+    the old wait ran inline on the socket reader thread and stalled every RPC
+    queued behind a Stop the user had already pressed.
+    """
+    session, err = _sess_building(params, rid)
     if err:
         return err
     proc_id = str(params.get("process_id") or "")


### PR DESCRIPTION
## What does this PR do?

`_LONG_HANDLERS` exists, in its own words, to *"keep [slow handlers] off the main stdin loop so a slow portal can't stall `approval.respond` / `session.interrupt` / other RPCs."* The repo pools the billing RPCs specifically to protect `approval.respond` — and then `approval.respond` blocked itself for up to 30 seconds on the deferred agent build.

This finishes the `_sess_building` conversion across the five control RPCs that need the session **record** and never the agent. `_sess()` is exactly `_sess_building()` + `_wait_agent(timeout=30.0)`, and `_wait_agent` blocks on `agent_ready`, a `threading.Event` that stays unset until the deferred build completes (MCP discovery, model metadata, skills scan — "routinely tens of seconds on a cold start", per `_sess_building`'s own docstring).

At all five sites that wait bought nothing:

- `approval.pending` / `approval.received` / `approval.respond` reach `tools.approval`'s module-global `_gateway_queues`, keyed by `session_key` alone. It has no relationship to the tui_gateway session record or its `agent_ready` event.
- `process.list` / `process.kill` match `session_key` against the global process registry (`_session_processes`, `process_registry`).

None of the five dereferences `session["agent"]`.

**Four of the five are not in `_LONG_HANDLERS`**, so the wait ran inline on the socket reader thread and stalled every RPC queued behind it on the same socket — the precise failure mode `_sess_building` was introduced to fix for the attach RPCs.

**And this is a hard failure, not just latency.** `_start_agent_build` deliberately early-returns for a lazy watch session spectating an in-flight child:

```python
if session.get("lazy") and _child_run_active(str(session.get("session_key") or "")):
    return
```

`agent_ready` is therefore never set for that child's entire run, so these RPCs ran out the full cap and returned `5032 "agent initialization timed out"` — repeatedly. A `process.kill` the user asked for simply did not happen, and the ownership check that makes it safe was never even consulted.

The path is the common one rather than a corner case: the desktop replays pending approvals on `gateway.ready` and `session.info` (`approvalReplaySessionId`), i.e. on reconnect and session attach — exactly when a cold resume's deferred build is in flight. `get_pending_gateway_approval`'s docstring says the same thing: *"Reconnectable clients use this to restore an approval prompt…"*

Corroborating that `approval.respond` was the odd one out: the six sibling `*.respond` RPCs in `methods_prompt.py` (`clarify.respond`, `sudo.respond`, `secret.respond`, …) all route through `_respond()` and never call `_sess` at all.

### Sites deliberately NOT converted

This is the complete set for this root cause, and the exclusions are load-bearing:

| site | why excluded |
|---|---|
| `rollback.list` / `rollback.diff` / `rollback.restore` | resolve through `_with_checkpoints`, which dereferences `session["agent"]._checkpoint_mgr`. Converting these would **fault mid-build** instead of merely stalling. |
| `prompt.background`, `preview.restart`, `session.undo` / `compress` / `save` / `branch` | genuinely need the built agent. |
| `session.interrupt` | already converted in #75609; touching it here would collide with our own open PR. |

The last test in this PR pins that boundary at runtime: it asserts the five converted RPCs skip `_wait_agent` **and** that `rollback.list` still takes it and still fails on the `_checkpoint_mgr` dereference. If either half flips, the exclusion has gone stale and the suite says so.

## Related Issue

N/A — no filed issue; this completes the sweep merged in #86302, which converted the attach RPCs.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tui_gateway/methods_prompt.py` — `approval.pending`, `approval.received`, `approval.respond` resolve via `_sess_building`; one comment above the trio explains why.
- `tui_gateway/methods_tools.py` — `process.kill` (inline: reader-thread stall) and `process.list` (pooled: empty desktop status stack) resolve via `_sess_building`; rationale in each docstring.
- `tests/tui_gateway/test_control_rpcs_do_not_wait_for_agent.py` — new file, 12 tests. Deliberately a new file rather than an append to the 15k-line `tests/test_tui_gateway_server.py`, mirroring main's own layout for this contract.

Five commits: the approval sites, their tests, `process.kill`, `process.list`, and the process tests + boundary control. `process.kill` and `process.list` are separate commits because the defect they produce is different — a reader-thread stall versus a silently empty status pane.

## How to Test

```
pytest tests/tui_gateway/test_control_rpcs_do_not_wait_for_agent.py \
       tests/tui_gateway/test_attach_does_not_wait_for_agent.py -q
```

**Red before / green after — verified, not asserted.** The new test file was applied alone on top of unmodified `main` in a clean worktree:

```
9 failed, 3 passed in 241.32s (0:04:01)
```

Every converted site stalled the full cap, one test per site:

| test | red-before |
|---|---|
| `test_approval_pending_replays_the_queue_while_the_agent_is_building` | 30.01s → 5032 |
| `test_approval_received_acknowledges_while_the_agent_is_building` | 30.00s → 5032 |
| `test_approval_respond_resolves_while_the_agent_is_building` | 30.01s → 5032 |
| `test_process_list_reports_this_sessions_processes_while_building` | 30.00s → 5032 |
| `test_process_kill_still_refuses_another_sessions_process_while_building` | 30.01s → 5032 |
| `test_process_kill_still_reports_an_unknown_process_while_building` | 30.01s → 5032 |
| `test_process_kill_still_requires_a_process_id` | 30.01s → 5032 |
| `test_approval_received_still_requires_a_request_id` | 30.01s → 5032 |
| `test_converted_control_rpcs_skip_the_agent_wait_and_rollback_still_takes_it` | fails fast: 5 recorded `_wait_agent` calls instead of 0 |

The 3 that pass both before and after are the `4001` unknown-session guards — by design, they short-circuit ahead of the wait, which is what proves `_sess_building` keeps `_sess_nowait`'s validation.

After the fix: **12 passed in 0.21s** — the same suite, with the stalls gone. Each of the five commits was also checked out individually and the touched suite run at each (`59–71 passed`).

The tests assert behaviour, not timing: `approval.pending` must replay the queued approval, `approval.received` must flip `acknowledged`, `approval.respond` must resolve the entry *and* set its event so the blocked agent thread is released, and `process.list` must return only the calling session's processes.

## Related / Positioning

Of the 81 open PRs that touch either file, **#68375** (*"feat(tui): detach running turns into background"*) is the only one that rewrites any of these five handlers: it replaces `approval.respond`'s body wholesale and removes the `_sess(params, rid)` line this PR changes. It is currently `CONFLICTING` with main and was last updated 2026-08-02. If it lands first, this PR's `approval.respond` line becomes moot **at that one site only** — `approval.pending`, `approval.received`, `process.list` and `process.kill` are untouched by it. I kept `approval.respond` in scope because it is the site `_LONG_HANDLERS`' own comment names verbatim, and it is trivially droppable if you would rather take #68375's version there.

#75707 and #74376 carry the same line as diff context but do not modify it.

Adjacent prior art on the same *family* of problem (unblocking the RPC reader thread), neither overlapping: **#67789** pool-routes `subprocess.run` exec commands in `server.py`'s `dispatch`; **#41510** proposes pooling the attach handlers, the alternative remedy for the surface main already fixed with `_sess_building`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass <!-- ran the tui_gateway suites, not the full tree -->
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 25.4), Python 3.11.15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A <!-- pure call-site swap, no platform-specific code -->
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
