### PR TITLE
feat(desktop): add plugin actions to Kanban task cards

### DIFF
--- a/apps/desktop/src/plugins/kanban/board.tsx
+++ b/apps/desktop/src/plugins/kanban/board.tsx
@@ -81,6 +81,7 @@ import { BoardSwitcher } from './board-switcher'
 import { TaskDrawer } from './drawer'
 import { EMPTY_OVERRIDE, ModelOverrideField, overrideCreateFields, type TaskModelOverride } from './model-override'
 import { OrchestrationPanel } from './orchestration'
+import { runKanbanTaskAction, taskActionContext, useKanbanTaskActions } from './task-actions'
 import { columnMeta, type KanbanBoard, type KanbanTask, type TaskEstimate } from './types'
 import {
   $newTaskLane,
@@ -238,6 +239,7 @@ function CardFooter({ arc, task }: { arc: ArcState | null; task: KanbanTask }) {
 }
 
 function Card({
+  board,
   columns,
   onDelete,
   onMove,
@@ -246,6 +248,7 @@ function Card({
   selected,
   task
 }: {
+  board: string
   columns: string[]
   onDelete: (id: string) => void
   onMove: (id: string, status: string) => void
@@ -260,6 +263,8 @@ function Card({
   const summary = task.latest_summary || task.body
   const fallback = useDefaultAssignee()
   const arc = arcState(task, fallback)
+  const cardActions = useKanbanTaskActions('card')
+  const menuActions = useKanbanTaskActions('context-menu')
 
   return (
     <ContextMenu>
@@ -294,7 +299,35 @@ function Card({
           {(arc === 'running' || arc === 'stale') && !dragging && !selected && (
             <span aria-hidden className={cn('kanban-arc', arc === 'stale' && 'kanban-arc--stale')} />
           )}
-          <span className="line-clamp-2 text-[0.8125rem] font-medium leading-snug text-foreground">
+          {cardActions.length > 0 && (
+            <div
+              className="absolute top-1.5 right-1.5 z-10 flex gap-0.5 opacity-0 transition-opacity group-hover:opacity-100 focus-within:opacity-100"
+              onMouseDown={event => event.stopPropagation()}
+            >
+              {cardActions.map(action => (
+                <button
+                  aria-label={action.label}
+                  className="grid size-6 place-items-center rounded text-(--ui-text-tertiary) hover:bg-(--chrome-action-hover) hover:text-foreground"
+                  draggable={false}
+                  key={action.id}
+                  onClick={event => {
+                    event.stopPropagation()
+                    void runKanbanTaskAction(action, taskActionContext(board, 'card', task))
+                  }}
+                  title={action.label}
+                  type="button"
+                >
+                  <Codicon name={action.codicon || 'comment-discussion'} size="0.85rem" />
+                </button>
+              ))}
+            </div>
+          )}
+          <span
+            className={cn(
+              'line-clamp-2 text-[0.8125rem] font-medium leading-snug text-foreground',
+              cardActions.length > 0 && 'pr-6'
+            )}
+          >
             {task.title || task.id}
           </span>
           {summary && (
@@ -312,6 +345,15 @@ function Card({
           <Codicon name={selected ? 'close' : 'check-all'} size="0.85rem" />
           {selected ? k.deselect : k.select(formatModifierToken('mod'))}
         </ContextMenuItem>
+        {menuActions.map(action => (
+          <ContextMenuItem
+            key={action.id}
+            onSelect={() => void runKanbanTaskAction(action, taskActionContext(board, 'context-menu', task))}
+          >
+            <Codicon name={action.codicon || 'comment-discussion'} size="0.85rem" />
+            {action.label}
+          </ContextMenuItem>
+        ))}
         <ContextMenuSeparator />
         {columns
           .filter(name => name !== task.status && !isLockedTarget(name))
@@ -334,6 +376,7 @@ function Card({
 // ── column ───────────────────────────────────────────────────────────────────
 
 function Column({
+  board,
   collapsed,
   column,
   columns,
@@ -346,6 +389,7 @@ function Column({
   onToggleSelect,
   selected
 }: {
+  board: string
   collapsed: boolean
   column: { name: string; tasks: KanbanTask[] }
   columns: string[]
@@ -472,6 +516,7 @@ function Column({
                 </div>
                 {tasks.map(task => (
                   <Card
+                    board={board}
                     columns={columns}
                     key={task.id}
                     onDelete={onDelete}
@@ -486,6 +531,7 @@ function Column({
             ))
           : column.tasks.map(task => (
               <Card
+                board={board}
                 columns={columns}
                 key={task.id}
                 onDelete={onDelete}
@@ -1084,6 +1130,8 @@ export function KanbanBoardPage() {
   const qc = useQueryClient()
   const slug = useValue($boardSlug)
   const [archived, setArchived] = useState(false)
+  const { data: boards } = useQuery({ queryFn: fetchBoards, queryKey: BOARDS_KEY, staleTime: 30_000 })
+  const resolvedSlug = slug || boards?.current || 'default'
 
   // Live updates ride the events socket (bindApi); this interval is only the
   // slow heartbeat for socketless paths (OAuth remotes, dropped connections).
@@ -1397,6 +1445,7 @@ export function KanbanBoardPage() {
 
             return (
               <Column
+                board={resolvedSlug}
                 collapsed={laneOverrides[col.name] ?? auto}
                 column={col}
                 columns={columnNames}
@@ -1425,7 +1474,7 @@ export function KanbanBoardPage() {
       )}
 
       <NewTaskDialog onClose={() => setAddStatus(null)} parents={parentOptions} target={addStatus} />
-      <TaskDrawer columns={columnNames} id={openId} onClose={() => setOpenId(null)} onOpen={setOpenId} />
+      <TaskDrawer board={resolvedSlug} columns={columnNames} id={openId} onClose={() => setOpenId(null)} onOpen={setOpenId} />
     </div>
   )
 }

--- a/apps/desktop/src/plugins/kanban/drawer.tsx
+++ b/apps/desktop/src/plugins/kanban/drawer.tsx
@@ -46,6 +46,7 @@ import {
   uploadAttachment
 } from './api'
 import { ModelOverrideField, overridePatch } from './model-override'
+import { runKanbanTaskAction, taskActionContext, useKanbanTaskActions } from './task-actions'
 import {
   type Diagnostic,
   type DiagnosticAction,
@@ -538,11 +539,13 @@ function EstimateSection({ id }: { id: string }) {
 }
 
 export function TaskDrawer({
+  board,
   columns,
   id,
   onClose,
   onOpen
 }: {
+  board: string
   columns: string[]
   id: null | string
   onClose: () => void
@@ -551,6 +554,7 @@ export function TaskDrawer({
   const k = useKanban()
   const qc = useQueryClient()
   const slug = useValue($boardSlug)
+  const taskActions = useKanbanTaskActions('drawer-menu')
 
   // Socket-invalidated (bindApi); the interval is only the socketless heartbeat.
   const { data: detail, error } = useQuery({
@@ -718,6 +722,15 @@ export function TaskDrawer({
                     <Codicon name="copy" size="0.85rem" />
                     {k.copyTitle}
                   </DropdownMenuItem>
+                  {taskActions.map(action => (
+                    <DropdownMenuItem
+                      key={action.id}
+                      onSelect={() => void runKanbanTaskAction(action, taskActionContext(board, 'drawer-menu', task))}
+                    >
+                      <Codicon name={action.codicon || 'comment-discussion'} size="0.85rem" />
+                      {action.label}
+                    </DropdownMenuItem>
+                  ))}
                   <DropdownMenuSeparator />
                   <DropdownMenuItem onSelect={mutate(() => patchTask(task.id, { status: 'archived' }), onClose)}>
                     <Codicon name="archive" size="0.85rem" />

--- a/apps/desktop/src/plugins/kanban/task-actions.test.ts
+++ b/apps/desktop/src/plugins/kanban/task-actions.test.ts
@@ -1,0 +1,34 @@
+import type { Contribution } from '@hermes/plugin-sdk'
+import { describe, expect, it, vi } from 'vitest'
+
+import { resolveKanbanTaskActions } from './task-actions'
+
+const action = (overrides: Record<string, unknown> = {}): Contribution => ({
+  area: 'kanban.task.actions',
+  data: { label: 'Discuss task', run: vi.fn(), ...overrides },
+  id: 'plugin:test:discuss'
+})
+
+describe('resolveKanbanTaskActions', () => {
+  it('keeps valid actions in contribution order', () => {
+    const resolved = resolveKanbanTaskActions([action(), action({ label: ' Second ' })], 'card')
+
+    expect(resolved.map(item => item.label)).toEqual(['Discuss task', 'Second'])
+  })
+
+  it('filters actions that do not target the requested location', () => {
+    const resolved = resolveKanbanTaskActions([action({ locations: ['drawer-menu'] })], 'card')
+
+    expect(resolved).toEqual([])
+  })
+
+  it('drops malformed payloads instead of breaking the Kanban host', () => {
+    const malformed = [
+      { area: 'kanban.task.actions', data: null, id: 'null' },
+      action({ label: '' }),
+      action({ run: 'not-a-function' })
+    ] satisfies Contribution[]
+
+    expect(resolveKanbanTaskActions(malformed, 'card')).toEqual([])
+  })
+})

--- a/apps/desktop/src/plugins/kanban/task-actions.ts
+++ b/apps/desktop/src/plugins/kanban/task-actions.ts
@@ -1,0 +1,68 @@
+import {
+  host,
+  KANBAN_TASK_ACTIONS_AREA,
+  type KanbanTaskActionContext,
+  type KanbanTaskActionContribution,
+  type KanbanTaskActionLocation,
+  useContributions
+} from '@hermes/plugin-sdk'
+
+import type { KanbanTask } from './types'
+
+export interface ResolvedKanbanTaskAction extends KanbanTaskActionContribution {
+  id: string
+}
+
+export function resolveKanbanTaskActions(
+  contributions: ReturnType<typeof useContributions>,
+  location: KanbanTaskActionLocation
+): ResolvedKanbanTaskAction[] {
+  return contributions.flatMap(contribution => {
+    const action = contribution.data as KanbanTaskActionContribution | null | undefined
+
+    if (!action || typeof action.label !== 'string' || !action.label.trim() || typeof action.run !== 'function') {
+      return []
+    }
+
+    if (action.locations && !action.locations.includes(location)) {
+      return []
+    }
+
+    return [{ ...action, id: contribution.id, label: action.label.trim() }]
+  })
+}
+
+export function useKanbanTaskActions(location: KanbanTaskActionLocation): ResolvedKanbanTaskAction[] {
+  return resolveKanbanTaskActions(useContributions(KANBAN_TASK_ACTIONS_AREA), location)
+}
+
+export function taskActionContext(
+  board: string,
+  location: KanbanTaskActionLocation,
+  task: KanbanTask
+): KanbanTaskActionContext {
+  return {
+    board,
+    location,
+    task: {
+      assignee: task.assignee,
+      body: task.body,
+      id: task.id,
+      priority: task.priority,
+      status: task.status,
+      tenant: task.tenant,
+      title: task.title
+    }
+  }
+}
+
+export async function runKanbanTaskAction(
+  action: ResolvedKanbanTaskAction,
+  context: KanbanTaskActionContext
+): Promise<void> {
+  try {
+    await action.run(context)
+  } catch (error) {
+    host.notifyError(error, `Could not run ${action.label}`)
+  }
+}

--- a/apps/desktop/src/sdk/index.ts
+++ b/apps/desktop/src/sdk/index.ts
@@ -342,6 +342,9 @@ export type {
  *  `ctx.register` stays the door for permanent contributions. Namespace the
  *  id with your plugin slug (`kanban:board-switcher`). */
 export { Contribute, type ContributeProps } from '@/contrib/react/contribute'
+/** Subscribe to every contribution in an area. Surface hosts use this to
+ * consume declarative actions supplied by external plugins. */
+export { useContributions } from '@/contrib/react/use-contributions'
 export type { Contribution } from '@/contrib/types'
 /** The live gateway instance type — for typing the `gateway` prop `McpTab`
  *  takes; obtain the instance from `host.getGateway()`. */
@@ -380,6 +383,32 @@ export { profileColor, profileColorSoft } from '@/lib/profile-color'
 export { queryClient } from '@/lib/query-client'
 
 export const PANES_AREA = 'panes'
+/** Kanban card/drawer actions contributed by desktop plugins. The Kanban host
+ * owns rendering; plugins provide a declarative label/icon plus a callback. */
+export const KANBAN_TASK_ACTIONS_AREA = 'kanban.task.actions'
+export type KanbanTaskActionLocation = 'card' | 'context-menu' | 'drawer-menu'
+export interface KanbanTaskActionContext {
+  /** Concrete board slug, never the empty "current board" sentinel. */
+  board: string
+  location: KanbanTaskActionLocation
+  task: {
+    assignee?: null | string
+    body?: null | string
+    id: string
+    priority?: number
+    status: string
+    tenant?: null | string
+    title: string
+  }
+}
+export interface KanbanTaskActionContribution {
+  /** VS Code codicon id rendered by the Kanban host. */
+  codicon?: string
+  label: string
+  /** Omit for all supported locations. */
+  locations?: readonly KanbanTaskActionLocation[]
+  run: (context: KanbanTaskActionContext) => Promise<void> | void
+}
 /** Hermes' reasoning levels + their compact labels, so a plugin surfacing a
  *  thinking depth uses the same scale and spelling as the rest of the app. */
 export {

--- a/website/docs/developer-guide/desktop-plugin-sdk.md
+++ b/website/docs/developer-guide/desktop-plugin-sdk.md
@@ -211,6 +211,34 @@ Import the area constants from the SDK; each area has its own `data` payload.
 | Keybind | `KEYBINDS_AREA` | `data: KeybindContribution` |
 | Theme | `THEMES_AREA` | `data` as a `DesktopTheme` |
 | Composer | `COMPOSER_AREAS.*` | render slots, or middleware / attachment providers |
+| Kanban task action | `KANBAN_TASK_ACTIONS_AREA` | `data: KanbanTaskActionContribution` |
+
+### Kanban task actions
+
+Kanban task actions are declarative: the host renders the native card button,
+card context-menu item, and task-drawer menu item. Plugins supply labels,
+codicons, placement, and a callback rather than arbitrary card JSX.
+
+```javascript
+import { KANBAN_TASK_ACTIONS_AREA } from '@hermes/plugin-sdk'
+
+ctx.register({
+  id: 'discuss-task',
+  area: KANBAN_TASK_ACTIONS_AREA,
+  data: {
+    label: 'Discuss task',
+    codicon: 'comment-discussion',
+    locations: ['card', 'context-menu', 'drawer-menu'],
+    run: ({ board, task, location }) => {
+      // `board` is the concrete board slug; `task.id` is the selected task.
+      // Action failures are isolated and surfaced by the Kanban host.
+    }
+  }
+})
+```
+
+Omit `locations` to show the action in every supported location. Card actions
+render as compact icon buttons; both menus use the same label and callback.
 
 ### Panes
 


### PR DESCRIPTION
## What does this PR do?

Adds a small, declarative Desktop plugin extension point for actions on built-in Kanban task cards.

External plugins can register `KANBAN_TASK_ACTIONS_AREA` contributions with a label, codicon, supported locations, and `run(context)` callback. Hermes owns all rendering and supplies the concrete board slug plus a bounded task snapshot. This keeps arbitrary plugin JSX out of the built-in card while allowing real external consumers such as [CLAM101/hermes-kanban-task-chat](https://github.com/CLAM101/hermes-kanban-task-chat).

The host renders actions as compact card buttons and native items in the card context menu and task-drawer overflow menu. Action failures are isolated and surfaced through the existing Desktop notification path.

## Related Issue

No issue. This has a concrete standalone plugin consumer linked above.

Related but not duplicate: #82299 adds built-in Specify/Decompose drawer actions and may require a small drawer rebase if it lands first. It does not add an external plugin action contract.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Add the public `KANBAN_TASK_ACTIONS_AREA`, contribution/context/location types, and contribution subscription export in `apps/desktop/src/sdk/index.ts`.
- Add `task-actions.ts` as the concrete Kanban consumer, with payload validation, location filtering, and failure isolation.
- Render contributed actions on task cards, card context menus, and task-drawer menus.
- Resolve the concrete current-board slug before invoking actions.
- Add focused contract tests covering defaults, malformed contributions, location filtering, and callbacks.
- Document the new area and registration shape in the Desktop Plugin SDK guide.

## How to Test

1. `cd apps/desktop && npm run typecheck`
2. `cd apps/desktop && npx eslint src/sdk/index.ts src/plugins/kanban/board.tsx src/plugins/kanban/drawer.tsx src/plugins/kanban/task-actions.ts src/plugins/kanban/task-actions.test.ts --no-cache`
3. `cd apps/desktop && npx vitest run --project ui src/plugins/kanban/task-actions.test.ts`
4. `cd apps/desktop && npm run build`

All four commands pass on current upstream `main` (`460d345642ee`).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass (Desktop-only change; the relevant Node/TypeScript gates above pass)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux 6.17, headless source build

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A, no config keys
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A, additive SDK area only
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — renderer-only, no platform APIs
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A, no model tools

## Screenshots / Logs

No screenshot is attached because this was built on a headless remote host. Typecheck, focused tests, lint, and the full production Desktop build pass. The PR is intentionally draft pending maintainer feedback and visual exercise in a Desktop app.
