### PR TITLE
fix(auth): honor RFC 8628 poll interval and retry 429s in Nous device flow

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -5268,10 +5268,19 @@ def _nous_device_auth_timeout_message(portal_base_url: str) -> str:
     )
 
 
-def _effective_device_poll_interval(poll_interval: int) -> int:
+def _effective_device_poll_interval(poll_interval) -> int:
     """RFC 8628 §3.3 poll cadence: honor the server-directed interval,
-    floored at 5s (the portal rate-limits faster polling) and capped at 30s."""
-    return min(30, max(DEVICE_AUTH_POLL_MIN_INTERVAL_SECONDS, int(poll_interval)))
+    floored at 5s (the portal rate-limits faster polling) and capped at 30s.
+
+    The interval comes from the device-authorization response and is only
+    checked for presence, not type — a non-numeric payload must never crash
+    the login flow, so fall back to the RFC 8628 default cadence (5s).
+    """
+    try:
+        interval = int(poll_interval)
+    except (ValueError, TypeError):
+        interval = DEVICE_AUTH_POLL_MIN_INTERVAL_SECONDS
+    return min(30, max(DEVICE_AUTH_POLL_MIN_INTERVAL_SECONDS, interval))
 
 
 def _poll_for_token(

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -120,7 +120,12 @@ NOUS_DEVICE_CODE_SOURCE = "device_code"
 NOUS_AUTH_PATH_INVOKE_JWT = "invoke_jwt"
 ACCESS_TOKEN_REFRESH_SKEW_SECONDS = 120       # refresh 2 min before expiry
 NOUS_INVOKE_JWT_MIN_TTL_SECONDS = ACCESS_TOKEN_REFRESH_SKEW_SECONDS
-DEVICE_AUTH_POLL_INTERVAL_CAP_SECONDS = 1     # poll at most every 1s
+# RFC 8628 §3.3: the token poll must never run faster than the
+# server-directed `interval` — and no faster than 5s when the server omits
+# one. The old hard 1s "cap" clamped the portal's own interval down to 1s,
+# which the portal's rate limiter answers with 429s that aborted the flow
+# mid-approval and orphaned the server-side device approval (#87432).
+DEVICE_AUTH_POLL_MIN_INTERVAL_SECONDS = 5
 DEFAULT_CODEX_BASE_URL = "https://chatgpt.com/backend-api/codex"
 DEFAULT_XAI_OAUTH_BASE_URL = "https://api.x.ai/v1"
 MINIMAX_OAUTH_CLIENT_ID = "78257093-7e40-4613-99e0-527b14b39113"
@@ -5263,6 +5268,12 @@ def _nous_device_auth_timeout_message(portal_base_url: str) -> str:
     )
 
 
+def _effective_device_poll_interval(poll_interval: int) -> int:
+    """RFC 8628 §3.3 poll cadence: honor the server-directed interval,
+    floored at 5s (the portal rate-limits faster polling) and capped at 30s."""
+    return min(30, max(DEVICE_AUTH_POLL_MIN_INTERVAL_SECONDS, int(poll_interval)))
+
+
 def _poll_for_token(
     client: httpx.Client,
     portal_base_url: str,
@@ -5273,7 +5284,7 @@ def _poll_for_token(
 ) -> Dict[str, Any]:
     """Poll the token endpoint until the user approves or the code expires."""
     deadline = time.monotonic() + max(1, expires_in)
-    current_interval = max(1, min(poll_interval, DEVICE_AUTH_POLL_INTERVAL_CAP_SECONDS))
+    current_interval = _effective_device_poll_interval(poll_interval)
 
     while time.monotonic() < deadline:
         response = client.post(
@@ -5290,6 +5301,16 @@ def _poll_for_token(
             if "access_token" not in payload:
                 raise ValueError("Token response did not include access_token")
             return payload
+
+        if response.status_code == 429:
+            # Rate-limited mid-approval: treat as slow_down (RFC 8628 §3.5)
+            # and keep polling within the deadline. Aborting here used to
+            # crash the flow while the approval was already registered
+            # server-side, orphaning it and wedging the next device code
+            # with a misleading "device code was not recognized" (#87432).
+            current_interval = min(current_interval + 5, 30)
+            time.sleep(current_interval)
+            continue
 
         try:
             error_payload = response.json()
@@ -8961,7 +8982,7 @@ def _nous_device_code_login(
             except Exception:
                 pass
 
-        effective_interval = max(1, min(interval, DEVICE_AUTH_POLL_INTERVAL_CAP_SECONDS))
+        effective_interval = _effective_device_poll_interval(interval)
         print(f"Waiting for approval (polling every {effective_interval}s)...")
 
         token_data = _poll_for_token(

--- a/tests/hermes_cli/test_auth_nous_provider.py
+++ b/tests/hermes_cli/test_auth_nous_provider.py
@@ -1295,3 +1295,52 @@ def test_nous_device_code_login_timeout_raises_actionable_message(monkeypatch):
     assert "CAPTCHA" in msg
     assert "hermes portal" in msg
     assert "https://portal.nousresearch.com/login" in msg
+
+
+def test_effective_device_poll_interval_non_numeric_falls_back():
+    """The server-directed interval is only presence-checked, never
+    type-checked — a non-numeric payload must fall back to the RFC 8628
+    default cadence instead of raising ValueError mid-login."""
+    import hermes_cli.auth as auth_mod
+
+    assert auth_mod._effective_device_poll_interval("junk") == 5
+    assert auth_mod._effective_device_poll_interval("5.5") == 5
+    assert auth_mod._effective_device_poll_interval(None) == 5
+    # Numeric values keep the existing floor/cap behavior.
+    assert auth_mod._effective_device_poll_interval(12) == 12
+    assert auth_mod._effective_device_poll_interval(1) == 5
+    assert auth_mod._effective_device_poll_interval(120) == 30
+
+
+def test_poll_for_token_survives_junk_interval_payload(monkeypatch):
+    """End-to-end guard: a junk `interval` in the device-authorization
+    response must not crash the poller — it polls at the 5s default."""
+    import httpx
+    from typing import cast
+
+    import hermes_cli.auth as auth_mod
+
+    sleeps = _record_sleeps(monkeypatch, auth_mod)
+
+    class _PendingThenApproved:
+        def __init__(self):
+            self.calls = 0
+
+        def post(self, url, data=None):
+            request = httpx.Request("POST", url)
+            self.calls += 1
+            if self.calls == 1:
+                return httpx.Response(400, json={"error": "authorization_pending"}, request=request)
+            return httpx.Response(200, json={"access_token": "tok"}, request=request)
+
+    payload = auth_mod._poll_for_token(
+        client=cast(httpx.Client, _PendingThenApproved()),
+        portal_base_url="https://portal.nousresearch.com",
+        client_id="hermes-cli",
+        device_code="device",
+        expires_in=300,
+        poll_interval="not-a-number",
+    )
+
+    assert payload == {"access_token": "tok"}
+    assert sleeps == [5]

--- a/tests/hermes_cli/test_auth_nous_provider.py
+++ b/tests/hermes_cli/test_auth_nous_provider.py
@@ -1096,7 +1096,7 @@ class TestNousDeviceAuthTimeoutMessage:
         assert f"{DEFAULT_NOUS_PORTAL_URL.rstrip('/')}/login" in msg
 
 
-def test_poll_for_token_timeout_raises_actionable_message():
+def test_poll_for_token_timeout_raises_actionable_message(monkeypatch):
     """The poll deadline must raise the CAPTCHA-aware guidance at the SOURCE,
     so both the CLI login and the dashboard poller (web_server._nous_poller,
     which surfaces str(e) to the UI) inherit it."""
@@ -1104,6 +1104,10 @@ def test_poll_for_token_timeout_raises_actionable_message():
     import pytest
 
     import hermes_cli.auth as auth_mod
+
+    # The RFC 8628 floor makes each pending sleep >= 5s — skip the real
+    # wait; the deadline check runs between polls regardless.
+    monkeypatch.setattr(auth_mod.time, "sleep", lambda _s: None)
 
     class _PendingClient:
         def post(self, url, data=None):
@@ -1130,6 +1134,119 @@ def test_poll_for_token_timeout_raises_actionable_message():
     assert "CAPTCHA" in msg
     assert "hermes portal" in msg
     assert "https://portal.nousresearch.com/login" in msg
+
+
+def _record_sleeps(monkeypatch, auth_mod):
+    sleeps: list[float] = []
+    monkeypatch.setattr(auth_mod.time, "sleep", sleeps.append)
+    return sleeps
+
+
+def test_poll_for_token_429_backs_off_and_recovers(monkeypatch):
+    """#87432: a 429 from the token endpoint mid-approval must be retried
+    with backoff (RFC 8628 §3.5 slow_down semantics), not abort the flow —
+    an abort orphaned the server-side approval and wedged the next device
+    code with a misleading 'device code was not recognized'."""
+    import httpx
+    from typing import cast
+
+    import hermes_cli.auth as auth_mod
+
+    sleeps = _record_sleeps(monkeypatch, auth_mod)
+
+    class _RateLimitedThenApproved:
+        def __init__(self):
+            self.calls = 0
+
+        def post(self, url, data=None):
+            request = httpx.Request("POST", url)
+            self.calls += 1
+            if self.calls == 1:
+                return httpx.Response(429, json={"error": "rate_limited"}, request=request)
+            return httpx.Response(200, json={"access_token": "tok"}, request=request)
+
+    payload = auth_mod._poll_for_token(
+        client=cast(httpx.Client, _RateLimitedThenApproved()),
+        portal_base_url="https://portal.nousresearch.com",
+        client_id="hermes-cli",
+        device_code="device",
+        expires_in=300,
+        poll_interval=5,
+    )
+
+    assert payload == {"access_token": "tok"}
+    # 5s floor interval + 5s 429 backoff — one backing-off sleep, then the
+    # retry succeeded immediately.
+    assert sleeps == [10]
+
+
+def test_poll_for_token_honors_server_interval_slower_than_floor(monkeypatch):
+    """RFC 8628 §3.3: when the server directs a slower interval than the
+    5s floor, the client must slow down to it, not clamp it faster."""
+    import httpx
+    from typing import cast
+
+    import hermes_cli.auth as auth_mod
+
+    sleeps = _record_sleeps(monkeypatch, auth_mod)
+
+    class _PendingTwiceThenApproved:
+        def __init__(self):
+            self.calls = 0
+
+        def post(self, url, data=None):
+            request = httpx.Request("POST", url)
+            self.calls += 1
+            if self.calls <= 2:
+                return httpx.Response(400, json={"error": "authorization_pending"}, request=request)
+            return httpx.Response(200, json={"access_token": "tok"}, request=request)
+
+    payload = auth_mod._poll_for_token(
+        client=cast(httpx.Client, _PendingTwiceThenApproved()),
+        portal_base_url="https://portal.nousresearch.com",
+        client_id="hermes-cli",
+        device_code="device",
+        expires_in=300,
+        poll_interval=12,
+    )
+
+    assert payload == {"access_token": "tok"}
+    assert sleeps == [12, 12]
+
+
+def test_poll_for_token_floors_fast_server_interval(monkeypatch):
+    """#87432: the old code clamped the server interval to 1s, which the
+    portal rate limiter answered with 429s. A server interval below the
+    floor must be raised to it."""
+    import httpx
+    from typing import cast
+
+    import hermes_cli.auth as auth_mod
+
+    sleeps = _record_sleeps(monkeypatch, auth_mod)
+
+    class _PendingOnceThenApproved:
+        def __init__(self):
+            self.calls = 0
+
+        def post(self, url, data=None):
+            request = httpx.Request("POST", url)
+            self.calls += 1
+            if self.calls == 1:
+                return httpx.Response(400, json={"error": "authorization_pending"}, request=request)
+            return httpx.Response(200, json={"access_token": "tok"}, request=request)
+
+    payload = auth_mod._poll_for_token(
+        client=cast(httpx.Client, _PendingOnceThenApproved()),
+        portal_base_url="https://portal.nousresearch.com",
+        client_id="hermes-cli",
+        device_code="device",
+        expires_in=300,
+        poll_interval=1,
+    )
+
+    assert payload == {"access_token": "tok"}
+    assert sleeps == [auth_mod.DEVICE_AUTH_POLL_MIN_INTERVAL_SECONDS]
 
 
 def test_nous_device_code_login_timeout_raises_actionable_message(monkeypatch):


### PR DESCRIPTION
## What does this PR do?

Fixes the Nous device-authorization flow aborting mid-approval under rate limiting (#87432). Two cooperating defects:

1. **The poll cadence clamped the server's interval to 1s.** `_poll_for_token` computed `max(1, min(poll_interval, DEVICE_AUTH_POLL_INTERVAL_CAP_SECONDS))` with the cap set to `1`, so whatever interval the portal directed (RFC 8628 §3.3 `interval` field) was polled at 1/s — exactly the hammering the report observed. The clamp semantics were backwards: RFC 8628 needs a *floor*, not a cap. The constant is now `DEVICE_AUTH_POLL_MIN_INTERVAL_SECONDS = 5` and `_effective_device_poll_interval()` honors the server-directed interval, floored at 5s, capped at 30s.
2. **HTTP 429 was fatal.** Only `authorization_pending` and `slow_down` error codes continued the loop; a 429 (whatever its body shape — non-standard error code, or non-JSON body hitting `raise_for_status()`) raised and crashed the flow while the approval was already registered server-side — orphaning it and wedging the next device code with the misleading "device code was not recognized". A 429 status is now handled before body parsing as slow_down semantics: back off `+5s` (cap 30) and keep polling within the deadline (RFC 8628 §3.5).

The orphaned-approval cleanup itself is server-side (the portal expiring it) — preventing the client abort removes the wedge trigger.

## Related Issue

Fixes #87432

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/auth.py` — renamed `DEVICE_AUTH_POLL_INTERVAL_CAP_SECONDS` (1) to `DEVICE_AUTH_POLL_MIN_INTERVAL_SECONDS` (5) with an RFC 8628 rationale comment; added `_effective_device_poll_interval()` (honor server interval, 5s floor, 30s cap) used by both `_poll_for_token` and the login's "polling every Ns" message; `_poll_for_token` now treats HTTP 429 as retryable-with-backoff instead of fatal.
- `tests/hermes_cli/test_auth_nous_provider.py` — three new tests: 429 mid-approval backs off (+5s) and recovers with the token; a server interval slower than the floor is honored verbatim (`12 → 12`); a server interval below the floor is raised to it. The existing timeout test now monkeypatches `time.sleep` (the 5s floor would otherwise add a real 5s wait to that test).

## How to Test

1. `uv run --extra acp pytest tests/hermes_cli/test_auth_nous_provider.py -q` — Observed result: `34 passed`.
2. `uv run --extra acp pytest tests/hermes_cli/test_auth_nous_provider.py tests/hermes_cli/test_web_oauth_dispatch.py tests/hermes_cli/test_billing_scope_stepup.py -q` — Observed result: `50 passed`.
3. Observed result on unpatched `main`: the three new tests fail (429 aborts the flow with `RuntimeError`/`HTTPStatusError`; sleeps clamp to 1s), reproducing the report.
4. Live check: `hermes auth add nous` now prints `Waiting for approval (polling every 5s)...` (or the server-directed interval) and survives a portal 429.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
