### PR TITLE
fix(doctor): bound database and browser probes

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -303,21 +303,29 @@ def _has_healthy_oauth_fallback_for_apikey_provider(provider_label: str) -> bool
 
 
 def check_ok(text: str, detail: str = ""):
-    print(f"  {color('✓', Colors.GREEN)} {text}" + (f" {color(detail, Colors.DIM)}" if detail else ""))
+    print(f"  {color('✓', Colors.GREEN)} {text}" + (f" {color(detail, Colors.DIM)}" if detail else ""), flush=True)
 
 def check_warn(text: str, detail: str = ""):
-    print(f"  {color('⚠', Colors.YELLOW)} {text}" + (f" {color(detail, Colors.DIM)}" if detail else ""))
+    print(f"  {color('⚠', Colors.YELLOW)} {text}" + (f" {color(detail, Colors.DIM)}" if detail else ""), flush=True)
 
 def check_fail(text: str, detail: str = ""):
-    print(f"  {color('✗', Colors.RED)} {text}" + (f" {color(detail, Colors.DIM)}" if detail else ""))
+    print(f"  {color('✗', Colors.RED)} {text}" + (f" {color(detail, Colors.DIM)}" if detail else ""), flush=True)
 
 def check_info(text: str):
-    print(f"    {color('→', Colors.CYAN)} {text}")
+    print(f"    {color('→', Colors.CYAN)} {text}", flush=True)
 
 
 # ── state.db health/stats thresholds (advisory only — module constants,
 # deliberately NOT config: doctor warnings are guidance, not policy) ──
 STATE_DB_SIZE_WARN_BYTES = 1 * 1024 * 1024 * 1024   # 1 GiB logical size
+
+
+def _is_state_db_probe_timeout(reason: object) -> bool:
+    """Timeout is an inconclusive diagnostic, never corruption evidence."""
+    return isinstance(reason, str) and reason.startswith((
+        "quick state.db health probe timed out after ",
+        "deep state.db health probe timed out after ",
+    ))
 
 
 # Shared byte formatter, aliased to the name this module's three rendering
@@ -407,8 +415,8 @@ def _render_state_db_stats(stats: dict, holders=None) -> list:
 
 def _section(title: str) -> None:
     """Print a doctor section banner: blank line + bold cyan ◆ title."""
-    print()
-    print(color(f"◆ {title}", Colors.CYAN, Colors.BOLD))
+    print(flush=True)
+    print(color(f"◆ {title}", Colors.CYAN, Colors.BOLD), flush=True)
 
 
 def _fail_and_issue(text: str, detail: str, fix: str, issues: list[str]) -> None:
@@ -897,6 +905,7 @@ def managed_scope_check() -> None:
 def run_doctor(args):
     """Run diagnostic checks."""
     should_fix = getattr(args, 'fix', False)
+    deep_db_check = bool(getattr(args, 'deep', False))
     ack_target = getattr(args, 'ack', None)
 
     # Doctor runs from the interactive CLI, so CLI-gated tool availability
@@ -1699,13 +1708,49 @@ def run_doctor(args):
 
             # FTS write-health probe (#50502): `SELECT COUNT(*)` above succeeds
             # even when the FTS index is corrupt and every message write fails
-            # through the triggers. `_db_opens_cleanly` now drives a rolled-back
+            # through the triggers. `_db_opens_cleanly` drives a rolled-back
             # write so this otherwise-silent corruption class is surfaced (and
-            # repaired in place with --fix).
+            # repaired in place with --fix). The full integrity scan is opt-in:
+            # it is expensive on multi-GB databases and is selected by
+            # `hermes doctor --deep`.
             from hermes_state import _db_opens_cleanly, repair_state_db_schema
 
-            _write_reason = _db_opens_cleanly(state_db_path)
-            if _write_reason is not None:
+            from hermes_state import (
+                DEFAULT_DEEP_DB_PROBE_TIMEOUT,
+                DEFAULT_QUICK_DB_PROBE_TIMEOUT,
+            )
+
+            if deep_db_check:
+                check_info(
+                    f"state.db deep health probe started (full integrity_check; "
+                    f"bounded to {DEFAULT_DEEP_DB_PROBE_TIMEOUT:g}s)"
+                )
+            else:
+                check_info(
+                    f"state.db quick health probe started (bounded to "
+                    f"{DEFAULT_QUICK_DB_PROBE_TIMEOUT:g}s; full integrity_check "
+                    "skipped — use 'hermes doctor --deep' for the complete scan)"
+                )
+
+            def _state_db_probe_progress(message: str) -> None:
+                check_info(f"state.db probe: {message}")
+
+            _write_reason = _db_opens_cleanly(
+                state_db_path,
+                deep=deep_db_check,
+                progress_callback=_state_db_probe_progress,
+            )
+            if _is_state_db_probe_timeout(_write_reason):
+                check_warn(
+                    f"{_DHH}/state.db health probe was inconclusive",
+                    f"({_write_reason})",
+                )
+                manual_issues.append(
+                    "state.db health probe timed out — retry without competing "
+                    "database work; use 'hermes doctor --deep' only when a full "
+                    "offline integrity scan is required"
+                )
+            elif _write_reason is not None:
                 check_warn(
                     f"{_DHH}/state.db fails a write-health probe (FTS index may be corrupt)",
                     f"({_write_reason})",

--- a/hermes_cli/doctor_live.py
+++ b/hermes_cli/doctor_live.py
@@ -18,7 +18,9 @@ Design invariants:
 
 from __future__ import annotations
 
+import logging
 import os
+import uuid
 from dataclasses import dataclass
 from typing import Callable, List, Optional
 
@@ -29,6 +31,8 @@ from hermes_cli.doctor import (
     check_ok,
     check_warn,
 )
+
+logger = logging.getLogger(__name__)
 
 DEFAULT_PROBE_TIMEOUT = 10.0
 
@@ -75,27 +79,6 @@ def _http_get(url: str, headers: Optional[dict] = None,
 
 def _browser_available() -> bool:
     """Is the local browser automation backend (agent-browser) installed?"""
-    import shutil
-
-    if shutil.which("agent-browser"):
-        return True
-    try:
-        from hermes_cli.doctor import HERMES_HOME, PROJECT_ROOT
-
-        if (PROJECT_ROOT / "node_modules" / "agent-browser").exists():
-            return True
-        for candidate in (HERMES_HOME / "node" / "bin",
-                          HERMES_HOME / "node",
-                          HERMES_HOME / "node_modules" / ".bin"):
-            if shutil.which("agent-browser", path=str(candidate)):
-                return True
-    except Exception:
-        pass
-    # agent-browser resolves lazily via npx on the default install (#43564),
-    # invisible to the PATH/node_modules probes above. Mirror the rung
-    # hermes_cli.doctor uses so this probe can't diverge from it, including
-    # the Termux carve-out (bare npx is too fragile to advertise as ready
-    # there — see check_browser_requirements).
     try:
         from tools.browser_tool import (
             _find_agent_browser,
@@ -106,30 +89,55 @@ def _browser_available() -> bool:
     except Exception:
         return False
     if not _is_npx_agent_browser_sentinel(browser_cmd):
-        return False
+        # A concrete executable path is the same backend that the browser
+        # tools invoke. Do not substitute a Python Playwright import check.
+        return True
     return not _requires_real_termux_browser_install(browser_cmd)
 
 
 def _launch_browser_probe(timeout: float) -> tuple:
     """Launch a browser, open about:blank, close. Returns (ok, detail).
 
-    Uses Playwright directly (what agent-browser drives underneath) so the
-    probe owns the full lifecycle and always cleans up.
+    Reuses the exact ``agent-browser`` command/session machinery used by the
+    browser tools. Python Playwright is an implementation detail of that CLI,
+    not a Hermes runtime dependency; importing it here caused false negatives
+    whenever ``npx agent-browser`` was available without a Python Playwright
+    package. The helper owns cleanup even when the open command fails.
     """
+    task_id = f"_hermes_doctor_browser_probe_{uuid.uuid4().hex[:12]}"
     try:
-        from playwright.sync_api import sync_playwright
-    except ImportError:
-        return (False, "playwright not installed")
+        from tools.browser_tool import _run_browser_command, cleanup_browser
+    except Exception as exc:
+        return (False, f"agent-browser backend unavailable: {exc}")
 
-    with sync_playwright() as p:
-        browser = p.chromium.launch(headless=True,
-                                    timeout=timeout * 1000)
+    probe_error = None
+    cleanup_error = None
+    try:
+        result = _run_browser_command(
+            task_id,
+            "open",
+            ["about:blank"],
+            timeout=timeout,
+        )
+        if not isinstance(result, dict) or not result.get("success"):
+            detail = result.get("error") if isinstance(result, dict) else repr(result)
+            probe_error = f"agent-browser open failed: {detail}"
+    except Exception as exc:
+        probe_error = f"agent-browser probe failed: {exc}"
+    finally:
         try:
-            page = browser.new_page()
-            page.goto("about:blank", timeout=timeout * 1000)
-        finally:
-            browser.close()
-    return (True, "launched + about:blank + closed")
+            cleanup_browser(task_id)
+        except Exception as exc:
+            cleanup_error = str(exc)
+            logger.debug("doctor browser probe cleanup failed", exc_info=exc)
+
+    if probe_error is not None:
+        if cleanup_error is not None:
+            probe_error += f"; cleanup also failed: {cleanup_error}"
+        return (False, probe_error)
+    if cleanup_error is not None:
+        return (False, f"agent-browser launched about:blank but cleanup failed: {cleanup_error}")
+    return (True, "agent-browser launched + about:blank + closed")
 
 
 def _probe_mcp_server(name: str, config: dict, timeout: float):

--- a/hermes_cli/subcommands/doctor.py
+++ b/hermes_cli/subcommands/doctor.py
@@ -32,6 +32,14 @@ def build_doctor_parser(subparsers, *, cmd_doctor: Callable) -> None:
         ),
     )
     doctor_parser.add_argument(
+        "--deep",
+        action="store_true",
+        help=(
+            "Run the bounded full state.db PRAGMA integrity_check; omitted "
+            "by default so large databases get only the quick FTS/schema probe."
+        ),
+    )
+    doctor_parser.add_argument(
         "--ack",
         metavar="ADVISORY_ID",
         default=None,

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -93,6 +93,13 @@ logger = logging.getLogger(__name__)
 MAX_SAFE_RESUME_MESSAGES = 20_000
 MAX_SAFE_EXPORT_MESSAGES = 20_000
 
+# A routine doctor run must not spend minutes scanning a multi-gigabyte state
+# database.  Keep the full scan available to explicit diagnostic callers, but
+# give both modes a wall-clock boundary and a SQLite VM progress interrupt.
+DEFAULT_QUICK_DB_PROBE_TIMEOUT = 5.0
+DEFAULT_DEEP_DB_PROBE_TIMEOUT = 300.0
+_DB_PROBE_PROGRESS_OPS = 1_000
+
 
 def _configured_transcript_limit(key: str, fallback: int) -> int:
     """Resolve a transcript safety limit from config at call time.
@@ -2109,32 +2116,105 @@ def preflight_db_writability(
             _ensure_writable(p)
 
 
-def _db_opens_cleanly(db_path: Path) -> Optional[str]:
+def _db_opens_cleanly(
+    db_path: Path,
+    *,
+    deep: bool = True,
+    timeout: Optional[float] = None,
+    progress_callback: Optional[Callable[[str], None]] = None,
+) -> Optional[str]:
     """Probe a DB on a fresh connection. Returns None if healthy, else a reason.
 
-    Runs the same first-statement (``PRAGMA journal_mode``) that trips the
-    malformed-schema parse, then ``PRAGMA integrity_check`` and a canonical
-    ``sessions`` read, and finally a rolled-back ``messages`` write so that
-    FTS5 index corruption — which leaves base-table reads and
-    ``integrity_check`` passing while every ``INSERT INTO messages`` fails
-    through the FTS triggers — is reported as unhealthy rather than slipping
-    past as a false "ok" (#50502).
+    ``deep=True`` preserves the historical API used by repair/check-only
+    callers: it includes the complete ``PRAGMA integrity_check``. The doctor
+    command passes ``deep=False`` for its routine probe, which still checks the
+    first schema statement, canonical reads, FTS reads, and the rolled-back FTS
+    write path, but deliberately skips the table-wide integrity scan.
+
+    Both modes have a wall-clock deadline. SQLite's progress handler interrupts
+    long VM statements (including integrity_check), while the connection
+    timeout bounds lock acquisition. ``progress_callback`` is intentionally a
+    tiny diagnostic seam: doctor uses it to flush phase updates before a slow
+    operation starts, and other callers may omit it.
     """
-    conn = sqlite3.connect(str(db_path), isolation_level=None)
+    default_timeout = (
+        DEFAULT_DEEP_DB_PROBE_TIMEOUT if deep else DEFAULT_QUICK_DB_PROBE_TIMEOUT
+    )
     try:
+        probe_timeout = float(default_timeout if timeout is None else timeout)
+    except (TypeError, ValueError):
+        probe_timeout = default_timeout
+    if probe_timeout <= 0:
+        probe_timeout = default_timeout
+
+    deadline = time.monotonic() + probe_timeout
+    timed_out = False
+    conn = None
+
+    def notify(message: str) -> None:
+        if progress_callback is None:
+            return
+        try:
+            progress_callback(message)
+        except Exception:  # diagnostics must not change DB-health semantics
+            logger.debug("state.db probe progress callback failed", exc_info=True)
+
+    def progress_handler() -> int:
+        nonlocal timed_out
+        if time.monotonic() >= deadline:
+            timed_out = True
+            return 1
+        return 0
+
+    def timeout_reason() -> str:
+        mode = "deep" if deep else "quick"
+        return f"{mode} state.db health probe timed out after {probe_timeout:g}s"
+
+    def deadline_expired() -> bool:
+        return timed_out or time.monotonic() >= deadline
+
+    try:
+        notify("opening fresh SQLite connection")
+        conn = sqlite3.connect(
+            str(db_path), timeout=probe_timeout, isolation_level=None
+        )
+        # A progress handler is the only reliable wall-clock escape hatch for
+        # a long-running SQLite VM statement. The busy timeout above handles
+        # lock waits; this handles scans of large/corrupt databases.
+        conn.set_progress_handler(progress_handler, _DB_PROBE_PROGRESS_OPS)
+
         # Best-effort tokenizer load: a DB carrying the messages_fts_cjk
         # index needs the cjk_unicode61 extension before any statement can
         # touch that table — including the trigger-driven write probe below.
         # Without it, this probe sees the DB exactly as a tokenizer-less
         # SessionDB open would (which drops the cjk triggers to keep writes
         # working), so tokenizer absence must never classify as corruption.
+        notify("checking schema and journal mode")
         load_fts5_cjk_extension(conn)
         conn.execute("PRAGMA journal_mode").fetchone()
-        rows = conn.execute("PRAGMA integrity_check").fetchall()
-        problems = [str(r[0]) for r in rows if r and str(r[0]).lower() != "ok"]
-        if problems:
-            return "; ".join(problems[:3])
+        if deadline_expired():
+            return timeout_reason()
+
+        if deep:
+            notify(
+                "running full PRAGMA integrity_check "
+                f"(deadline {probe_timeout:g}s)"
+            )
+            rows = conn.execute("PRAGMA integrity_check").fetchall()
+            if deadline_expired():
+                return timeout_reason()
+            problems = [str(r[0]) for r in rows if r and str(r[0]).lower() != "ok"]
+            if problems:
+                return "; ".join(problems[:3])
+        else:
+            notify(
+                "skipping full PRAGMA integrity_check in quick mode "
+                "(use hermes doctor --deep for the complete scan)"
+            )
+
         conn.execute("SELECT COUNT(*) FROM sessions").fetchone()
+        if deadline_expired():
+            return timeout_reason()
 
         # FTS5 read probe: run a representative MATCH query against the
         # messages_fts* virtual tables. The FTS *write* probe below catches
@@ -2147,6 +2227,7 @@ def _db_opens_cleanly(db_path: Path) -> Optional[str]:
         # and any feature relying on FTS5 discovery then break silently
         # because the official repair tool's check-only path reports the
         # DB as healthy. #66724.
+        notify("checking FTS read paths")
         # Catch the full sqlite3 exception hierarchy (not just
         # OperationalError) so the malformed-shadow-table class is reported
         # rather than letting it crash the caller.
@@ -2163,7 +2244,11 @@ def _db_opens_cleanly(db_path: Path) -> Optional[str]:
                 conn.execute(
                     f"SELECT 1 FROM {fts_table} WHERE {fts_table} MATCH '\"\"' LIMIT 1"
                 ).fetchone()
+                if deadline_expired():
+                    return timeout_reason()
             except sqlite3.OperationalError as exc:
+                if deadline_expired():
+                    return timeout_reason()
                 # Use the canonical capability classifier instead of a
                 # hand-rolled substring check. On SQLite builds without the
                 # fts5 module, the legacy messages_fts table may exist on
@@ -2171,12 +2256,7 @@ def _db_opens_cleanly(db_path: Path) -> Optional[str]:
                 # against it raise OperationalError("no such module: fts5");
                 # the substring check below would misclassify that as
                 # corruption and send the DB into the repair path, whose
-                # final fallback deletes the messages_fts% schema
-                # (hermes_state.py:645-723). The supported degraded-runtime
-                # path (SessionDB._is_fts5_unavailable_error + the
-                # regression suite in tests/test_hermes_state.py:600-632)
-                # treats both "no such module: fts5" and
-                # "no such tokenizer: trigram" as the capability error.
+                # final fallback deletes the messages_fts% schema.
                 if SessionDB._is_fts5_unavailable_error(exc):
                     # Degraded runtime — not the corruption class we probe.
                     continue
@@ -2187,6 +2267,8 @@ def _db_opens_cleanly(db_path: Path) -> Optional[str]:
                     continue
                 return f"fts5 read probe failed on {fts_table}: {exc}"
             except sqlite3.DatabaseError as exc:
+                if deadline_expired():
+                    return timeout_reason()
                 # This is the corruption class #66724 actually wants caught:
                 # partial shadow-table damage where MATCH / snippet / rank
                 # queries raise DatabaseError("database disk image is malformed")
@@ -2199,6 +2281,7 @@ def _db_opens_cleanly(db_path: Path) -> Optional[str]:
         # best-effort — if the messages/sessions tables don't exist yet (brand
         # new file mid-init) the OperationalError is treated as "not yet a
         # populated DB", not corruption.
+        notify("checking FTS write path with a rolled-back probe")
         probe_session_id = f"_hermes_fts_health_probe_{time.time_ns()}"
         try:
             conn.execute("BEGIN IMMEDIATE")
@@ -2212,7 +2295,11 @@ def _db_opens_cleanly(db_path: Path) -> Optional[str]:
                 (probe_session_id, "user", "_fts_health_probe", time.time()),
             )
             conn.execute("ROLLBACK")
+            if deadline_expired():
+                return timeout_reason()
         except sqlite3.OperationalError as exc:
+            if deadline_expired():
+                return timeout_reason()
             # Missing tables / FTS disabled — not the corruption class we probe.
             try:
                 conn.execute("ROLLBACK")
@@ -2228,11 +2315,23 @@ def _db_opens_cleanly(db_path: Path) -> Optional[str]:
                 # a tokenizer-less one self-heals by dropping the triggers.
                 return None
             return str(exc)
+        notify("health probe completed")
         return None
+    except sqlite3.OperationalError as exc:
+        if deadline_expired():
+            return timeout_reason()
+        return str(exc)
     except sqlite3.DatabaseError as exc:
+        if deadline_expired():
+            return timeout_reason()
         return str(exc)
     finally:
-        conn.close()
+        if conn is not None:
+            try:
+                conn.set_progress_handler(None, 0)
+            except Exception:
+                pass
+            conn.close()
 
 
 def repair_state_db_schema(db_path: Path, *, backup: bool = True) -> Dict[str, Any]:

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -16,6 +16,32 @@ from hermes_cli import doctor as doctor_mod
 from hermes_cli.doctor import _has_provider_env_config
 
 
+def test_state_db_probe_timeout_is_not_corruption_evidence():
+    assert doctor_mod._is_state_db_probe_timeout(
+        "quick state.db health probe timed out after 5s"
+    )
+    assert doctor_mod._is_state_db_probe_timeout(
+        "deep state.db health probe timed out after 300s"
+    )
+    assert not doctor_mod._is_state_db_probe_timeout(
+        "fts5 read probe failed on messages_fts: database disk image is malformed"
+    )
+
+
+class TestDoctorOutputObservability:
+    def test_check_helpers_flush_non_tty_output(self, monkeypatch):
+        calls = []
+        monkeypatch.setattr(
+            "builtins.print",
+            lambda *args, **kwargs: calls.append((args, kwargs)),
+        )
+
+        doctor_mod.check_info("state.db probe started")
+
+        assert calls
+        assert calls[-1][1]["flush"] is True
+
+
 class TestDoctorPlatformHints:
     def test_termux_package_hint(self, monkeypatch):
         monkeypatch.setenv("TERMUX_VERSION", "0.118.3")

--- a/tests/hermes_cli/test_doctor_db_probe.py
+++ b/tests/hermes_cli/test_doctor_db_probe.py
@@ -1,0 +1,111 @@
+"""Regression tests for the bounded state.db health probe used by doctor."""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import hermes_state
+
+
+def _make_minimal_state_db(path: Path) -> None:
+    conn = sqlite3.connect(path)
+    conn.executescript(
+        """
+        CREATE TABLE sessions (
+            id TEXT PRIMARY KEY,
+            source TEXT,
+            started_at REAL
+        );
+        CREATE TABLE messages (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            session_id TEXT,
+            role TEXT,
+            content TEXT,
+            timestamp REAL
+        );
+        INSERT INTO sessions (id, source, started_at)
+            VALUES ('session-1', 'test', 0.0);
+        """
+    )
+    conn.commit()
+    conn.close()
+
+
+class _TracingConnection:
+    def __init__(self, connection, statements, progress_handlers):
+        self._connection = connection
+        self._statements = statements
+        self._progress_handlers = progress_handlers
+
+    def execute(self, sql, *args, **kwargs):
+        self._statements.append(str(sql))
+        return self._connection.execute(sql, *args, **kwargs)
+
+    def set_progress_handler(self, *args, **kwargs):
+        self._progress_handlers.append(args)
+        return self._connection.set_progress_handler(*args, **kwargs)
+
+    def __getattr__(self, name):
+        return getattr(self._connection, name)
+
+
+def _run_probe(path: Path, monkeypatch, *, deep: bool):
+    statements = []
+    progress_handlers = []
+    real_connect = hermes_state.sqlite3.connect
+
+    def traced_connect(*args, **kwargs):
+        return _TracingConnection(
+            real_connect(*args, **kwargs), statements, progress_handlers
+        )
+
+    monkeypatch.setattr(hermes_state.sqlite3, "connect", traced_connect)
+    progress = []
+    reason = hermes_state._db_opens_cleanly(
+        path,
+        deep=deep,
+        progress_callback=progress.append,
+    )
+    return reason, statements, progress_handlers, progress
+
+
+def test_quick_probe_skips_full_integrity_check_but_keeps_fts_write_probe(
+    tmp_path, monkeypatch
+):
+    path = tmp_path / "state.db"
+    _make_minimal_state_db(path)
+
+    reason, statements, progress_handlers, progress = _run_probe(
+        path, monkeypatch, deep=False
+    )
+
+    assert reason is None
+    assert not any("integrity_check" in statement.lower() for statement in statements)
+    assert any("INSERT INTO messages" in statement for statement in statements)
+    assert progress_handlers, "quick probes must install a SQLite progress deadline"
+    assert progress
+
+
+def test_deep_probe_is_explicit_and_retains_integrity_check(tmp_path, monkeypatch):
+    path = tmp_path / "state.db"
+    _make_minimal_state_db(path)
+
+    reason, statements, progress_handlers, progress = _run_probe(
+        path, monkeypatch, deep=True
+    )
+
+    assert reason is None
+    assert any("PRAGMA integrity_check" in statement for statement in statements)
+    assert progress_handlers
+    assert progress
+
+
+def test_quick_and_deep_probes_honor_tiny_wall_clock_budgets(tmp_path):
+    path = tmp_path / "state.db"
+    _make_minimal_state_db(path)
+
+    for deep in (False, True):
+        reason = hermes_state._db_opens_cleanly(path, deep=deep, timeout=1e-9)
+        mode = "deep" if deep else "quick"
+        assert reason == f"{mode} state.db health probe timed out after 1e-09s"

--- a/tests/hermes_cli/test_doctor_live.py
+++ b/tests/hermes_cli/test_doctor_live.py
@@ -6,6 +6,7 @@ All probes are mocked at the HTTP/client layer; no real network calls are made.
 from __future__ import annotations
 
 import argparse
+import sys
 from types import SimpleNamespace
 
 import pytest
@@ -49,6 +50,8 @@ class TestLiveFlagGating:
         assert args.live is False
         args = parser.parse_args(["doctor", "--live"])
         assert args.live is True
+        args = parser.parse_args(["doctor", "--deep"])
+        assert args.deep is True
 
     def test_no_live_flag_means_zero_probes(self, monkeypatch):
         called = []
@@ -230,6 +233,44 @@ class TestBrowserAvailableNpxRung:
         monkeypatch.setattr(bt, "_requires_real_termux_browser_install", lambda cmd: True)
 
         assert _real_browser_available() is False
+
+
+class TestBrowserProbeBackendContract:
+    def test_probe_uses_agent_browser_cli_without_python_playwright(self, monkeypatch):
+        calls = []
+        fake_browser_tool = SimpleNamespace(
+            _run_browser_command=lambda task_id, command, args, timeout: (
+                calls.append(("run", task_id, command, args, timeout))
+                or {"success": True, "data": {}}
+            ),
+            cleanup_browser=lambda task_id: calls.append(("cleanup", task_id)),
+        )
+        # The runtime backend is agent-browser; Python Playwright is not a
+        # Hermes dependency and must not be required by the doctor probe.
+        monkeypatch.setitem(sys.modules, "tools.browser_tool", fake_browser_tool)
+        monkeypatch.setitem(sys.modules, "playwright", None)
+
+        ok, detail = doctor_live._launch_browser_probe(1.0)
+
+        assert ok is True
+        assert "agent-browser" in detail
+        assert calls[0][0] == "run"
+        assert calls[0][2:] == ("open", ["about:blank"], 1.0)
+        assert calls[-1][0] == "cleanup"
+
+    def test_probe_reports_cleanup_failure_instead_of_claiming_closed(self, monkeypatch):
+        fake_browser_tool = SimpleNamespace(
+            _run_browser_command=lambda *args, **kwargs: {"success": True, "data": {}},
+            cleanup_browser=lambda _task_id: (_ for _ in ()).throw(RuntimeError("cleanup stuck")),
+        )
+        monkeypatch.setitem(sys.modules, "tools.browser_tool", fake_browser_tool)
+
+        ok, detail = doctor_live._launch_browser_probe(1.0)
+
+        assert ok is False
+        assert "cleanup failed" in detail
+        assert "cleanup stuck" in detail
+        assert "closed" not in detail
 
 
 class TestFailureIsolation:

--- a/website/docs/reference/cli-commands.md
+++ b/website/docs/reference/cli-commands.md
@@ -773,12 +773,14 @@ Subscriptions persist to `~/.hermes/webhook_subscriptions.json` and are hot-relo
 ## `hermes doctor`
 
 ```bash
-hermes doctor [--fix]
+hermes doctor [--fix] [--live] [--deep]
 ```
 
 | Option | Description |
 |--------|-------------|
 | `--fix` | Attempt automatic repairs where possible. |
+| `--live` | Opt in to bounded real-call probes for configured backends after the static checks. |
+| `--deep` | Run the bounded full `state.db` `PRAGMA integrity_check`. Ordinary doctor runs use a quick schema/FTS read/write probe and skip this table-wide scan, which can be slow on large databases. |
 
 ## `hermes dump`
 


### PR DESCRIPTION
## Summary
- keep normal `hermes doctor` on a bounded quick SQLite/FTS read-write probe; move full `PRAGMA integrity_check` behind explicit `--deep`
- add real wall-clock deadlines, flushed progress, and prevent timeouts from being misclassified/repaired as corruption
- probe Browser through the same `agent-browser` runtime as the actual tool instead of requiring Python Playwright
- treat browser cleanup failures as failed live probes

## Validation
- 3 doctor test files, 84 tests passed on current upstream `main`
- live 6.65 GB state.db quick probe completed in 0.003s with all phases reported
- `git diff --check`

## Environment note
The live browser probe now reaches the real runtime and correctly reports the host's separate npm cache `ENOTEMPTY` failure; this patch does not mask that runtime error.