### PR TITLE
fix(telegram): re-import TypeHandler in lazy-install path

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -415,7 +415,7 @@ def check_telegram_requirements() -> bool:
     """
     global TELEGRAM_AVAILABLE, Update, Bot, Message, InlineKeyboardButton
     global InlineKeyboardMarkup, LinkPreviewOptions, Application
-    global CommandHandler, CallbackQueryHandler, TelegramMessageHandler
+    global CommandHandler, CallbackQueryHandler, TelegramMessageHandler, TypeHandler
     global ContextTypes, filters, ParseMode, ChatType, HTTPXRequest
     if TELEGRAM_AVAILABLE:
         return True
@@ -434,7 +434,7 @@ def check_telegram_requirements() -> bool:
         from telegram.ext import (
             Application as _App, CommandHandler as _CH,
             CallbackQueryHandler as _CQH,
-            MessageHandler as _MH,
+            MessageHandler as _MH, TypeHandler as _TH,
             ContextTypes as _CT, filters as _filters,
         )
         from telegram.constants import ParseMode as _PM, ChatType as _CtT
@@ -451,6 +451,7 @@ def check_telegram_requirements() -> bool:
     CommandHandler = _CH
     CallbackQueryHandler = _CQH
     TelegramMessageHandler = _MH
+    TypeHandler = _TH
     ContextTypes = _CT
     filters = _filters
     ParseMode = _PM


### PR DESCRIPTION
## Summary

`check_telegram_requirements()` re-imports and rebinds every `telegram.ext`
class after lazy-installing python-telegram-bot, **except `TypeHandler`**.
After a lazy-install, `TypeHandler` stays `typing.Any`, so the subsequent
`app.add_handler(TypeHandler(Update, ...))` call raises ("`Any` cannot be
instantiated") and the Telegram adapter crashes on every retry while other
platforms stay connected.

## Root cause

`check_telegram_requirements()` is missing `TypeHandler` in the same three
places every other `telegram.ext` class is handled:

1. the `global` declaration,
2. the re-import block (`from telegram.ext import (...)`),
3. the rebind block (`TypeHandler = _TH`).

## Reproduction

1. Remove python-telegram-bot from the environment.
2. Start the gateway so the module-level import hits the `except ImportError`
   fallback (all Telegram aliases become `Any`).
3. Let `check_telegram_requirements()` lazy-install the SDK and re-import.

`TypeHandler` remains `Any` and handler registration fails.

This was observed in the wild during a `hermes update` that restarted the
gateway mid-dependency-install.

## Fix

Add `TypeHandler` to the `global` declaration, the re-import, and the rebind
block (3 lines). No behavior change for the normal (already-installed) path.

## Environment

- Observed on a `hermes update` that restarted the gateway mid-install.
- python-telegram-bot re-installed via `tools.lazy_deps.ensure("platform.telegram")`.
