### PR TITLE
fix(acp): make installed skill slash commands usable from ACP hosts

### DIFF
--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -1710,13 +1710,17 @@ class HermesACPAgent(acp.Agent):
         # send the whole multimodal prompt to the agent instead of treating it as
         # an ACP command.
         if text_only_prompt and isinstance(user_content, str) and user_text.startswith("/"):
-            response_text = self._handle_slash_command(user_text, state)
-            if response_text is not None:
-                if self._conn:
-                    update = acp.update_agent_message_text(response_text)
-                    await self._conn.session_update(session_id, update)
-                    await self._send_usage_update(state)
-                return PromptResponse(stop_reason="end_turn")
+            skill_message = self._build_skill_invocation(user_text, state)
+            if skill_message is not None:
+                user_content = skill_message
+            else:
+                response_text = self._handle_slash_command(user_text, state)
+                if response_text is not None:
+                    if self._conn:
+                        update = acp.update_agent_message_text(response_text)
+                        await self._conn.session_update(session_id, update)
+                        await self._send_usage_update(state)
+                    return PromptResponse(stop_reason="end_turn")
 
         # If the client sends another regular text prompt while this ACP session
         # is running, route it through the core active-turn redirect. Rich media
@@ -2067,6 +2071,7 @@ class HermesACPAgent(acp.Agent):
     @classmethod
     def _available_commands(cls) -> list[AvailableCommand]:
         commands: list[AvailableCommand] = []
+        seen: set[str] = set()
         for spec in cls._ADVERTISED_COMMANDS:
             input_hint = spec.get("input_hint")
             commands.append(
@@ -2078,6 +2083,26 @@ class HermesACPAgent(acp.Agent):
                     else None,
                 )
             )
+            seen.add(spec["name"])
+
+        try:
+            from agent.skill_commands import get_skill_commands
+
+            for command_key, skill_info in sorted(get_skill_commands().items()):
+                name = command_key.lstrip("/")
+                if not name or name in seen:
+                    continue
+                description = str(skill_info.get("description") or "").strip()
+                commands.append(
+                    AvailableCommand(
+                        name=name,
+                        description=description or f"Invoke the {name} skill",
+                        input=UnstructuredCommandInput(hint="instructions for the skill"),
+                    )
+                )
+                seen.add(name)
+        except Exception:
+            logger.warning("Failed to discover ACP skill slash commands", exc_info=True)
         return commands
 
     async def _send_available_commands_update(self, session_id: str) -> None:
@@ -2108,6 +2133,37 @@ class HermesACPAgent(acp.Agent):
         loop.call_soon(
             asyncio.create_task, self._send_available_commands_update(session_id)
         )
+
+    def _build_skill_invocation(self, text: str, state: SessionState) -> str | None:
+        """Expand an installed skill slash command into the normal agent prompt."""
+        parts = text.split(maxsplit=1)
+        command = parts[0].lstrip("/").lower()
+        instruction = parts[1].strip() if len(parts) > 1 else ""
+        if command in self._SLASH_COMMANDS:
+            return None
+
+        try:
+            from agent.runtime_cwd import set_session_cwd
+            from agent.skill_commands import (
+                build_skill_invocation_message,
+                resolve_skill_command_key,
+            )
+
+            def _build() -> str | None:
+                set_session_cwd(state.cwd)
+                command_key = resolve_skill_command_key(command)
+                if command_key is None:
+                    return None
+                return build_skill_invocation_message(
+                    command_key,
+                    instruction,
+                    task_id=state.session_id,
+                )
+
+            return contextvars.copy_context().run(_build)
+        except Exception:
+            logger.error("Skill slash command /%s failed", command, exc_info=True)
+            return None
 
     def _handle_slash_command(self, text: str, state: SessionState) -> str | None:
         """Dispatch a slash command and return the response text.
@@ -2160,8 +2216,8 @@ class HermesACPAgent(acp.Agent):
 
     def _cmd_help(self, args: str, state: SessionState) -> str:
         lines = ["Available commands:", ""]
-        for cmd, desc in self._SLASH_COMMANDS.items():
-            lines.append(f"  /{cmd:10s}  {desc}")
+        for command in self._available_commands():
+            lines.append(f"  /{command.name:10s}  {command.description}")
         lines.append("")
         lines.append("Unrecognized /commands are sent to the model as normal messages.")
         return "\n".join(lines)

--- a/tests/acp_adapter/test_acp_commands.py
+++ b/tests/acp_adapter/test_acp_commands.py
@@ -4,6 +4,7 @@ from types import ModuleType, SimpleNamespace
 import pytest
 from acp.schema import TextContentBlock
 
+from agent import skill_commands
 from acp_adapter.server import HermesACPAgent
 from acp_adapter.session import SessionManager
 
@@ -71,6 +72,79 @@ def make_agent_and_state():
     conn = CaptureConn()
     acp_agent.on_connect(conn)
     return acp_agent, state, fake, conn
+
+
+def install_skill(tmp_path, monkeypatch, name="acp-helper"):
+    skills_root = tmp_path / "skills"
+    skill_dir = skills_root / name
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(
+        f"""---
+name: {name}
+description: Help with ACP tasks.
+---
+
+# ACP helper
+
+Follow the ACP helper instructions.
+"""
+    )
+    monkeypatch.setattr("tools.skills_tool.SKILLS_DIR", skills_root)
+    skill_commands.scan_skill_commands()
+
+
+def test_acp_advertises_installed_skill_commands(tmp_path, monkeypatch):
+    install_skill(tmp_path, monkeypatch)
+
+    commands = {command.name: command for command in HermesACPAgent._available_commands()}
+
+    assert commands["acp-helper"].description == "Help with ACP tasks."
+
+
+@pytest.mark.asyncio
+async def test_acp_help_lists_installed_skill_commands(tmp_path, monkeypatch):
+    install_skill(tmp_path, monkeypatch)
+    acp_agent, state, fake, conn = make_agent_and_state()
+
+    await acp_agent.prompt(
+        session_id=state.session_id,
+        prompt=[TextContentBlock(type="text", text="/help")],
+    )
+
+    assert fake.runs == []
+    assert any("/acp-helper" in update.content.text for _, update in conn.updates)
+
+
+@pytest.mark.asyncio
+async def test_acp_skill_slash_command_loads_skill_for_agent(tmp_path, monkeypatch):
+    install_skill(tmp_path, monkeypatch)
+    acp_agent, state, fake, _conn = make_agent_and_state()
+
+    response = await acp_agent.prompt(
+        session_id=state.session_id,
+        prompt=[TextContentBlock(type="text", text="/acp-helper fix command discovery")],
+    )
+
+    assert response.stop_reason == "end_turn"
+    assert len(fake.runs) == 1
+    assert "Follow the ACP helper instructions." in fake.runs[0]
+    assert "fix command discovery" in fake.runs[0]
+
+
+@pytest.mark.asyncio
+async def test_acp_builtin_slash_command_takes_precedence_over_same_named_skill(
+    tmp_path, monkeypatch
+):
+    install_skill(tmp_path, monkeypatch, name="help")
+    acp_agent, state, fake, conn = make_agent_and_state()
+
+    await acp_agent.prompt(
+        session_id=state.session_id,
+        prompt=[TextContentBlock(type="text", text="/help")],
+    )
+
+    assert fake.runs == []
+    assert any("Available commands:" in update.content.text for _, update in conn.updates)
 
 
 def test_acp_real_agent_gets_session_db_for_recall(monkeypatch):


### PR DESCRIPTION
## What does this PR do?

ACP clients now receive installed skill slash commands in their advertised command list and can invoke them through the same shared skill loader used by other Hermes surfaces. Previously, ACP exposed only nine built-in commands, so skill commands were absent from host menus and a fully typed skill command fell through to the model as literal text.

### Symptom

An ACP host cannot render installed Hermes skills in its slash-command menu. Typing a complete command such as `/acp-helper fix command discovery` does not load the skill and instead sends the unchanged slash text to the model.

### Impact

ACP users cannot discover or reliably invoke installed skills through the slash-command workflow available in CLI, TUI, gateway, and desktop surfaces. The affected scope is ACP command advertisement and text slash-command dispatch.

### Bug Cause

**Trigger:** `acp_adapter/server.py:2072` in `HermesACPAgent._available_commands()` and the text slash-command branch in `HermesACPAgent.prompt()`.

**Causal chain:**
1. An ACP session starts or the user enters an installed skill slash command.
2. `_available_commands()` emits only the static built-in list, while `_handle_slash_command()` recognizes only built-in handlers.
3. The host cannot advertise the skill, and typed skill commands fall through unchanged to the normal model prompt.

**Why it is wrong:** ACP had no dynamic bridge to the shared skill command registry or invocation-message builder.

**Working sibling / contrast:** CLI, TUI, gateway, and desktop paths resolve installed commands and expand them with `build_skill_invocation_message()` before normal agent execution.

**Ruled out:** This is not an ACP protocol limitation. The existing server already sends `available_commands_update`; the missing data and dispatch behavior were inside the ACP adapter.

### Fix

- Append installed skill commands to ACP command advertisements and `/help`, while preserving built-in command precedence.
- Resolve skill names through the shared resolver, including underscore/hyphen normalization, and build the normal skill invocation prompt under the ACP session cwd and session id.
- Preserve the original typed slash text for persistence while sending the expanded skill payload through the normal agent path.
- Add regression coverage with a real temporary `SKILL.md` for advertisement, help output, dispatch, and built-in precedence.

## Related Issue

Closes #87421

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `acp_adapter/server.py` - advertise installed skills and dispatch their slash commands through the shared skill loader.
- `tests/acp_adapter/test_acp_commands.py` - cover dynamic discovery, help output, invocation expansion, and built-in precedence.

## How to Test

1. Install a skill with a slash-command-compatible name, start an ACP session, and confirm the host command list includes it.
2. Invoke the skill command with arguments and confirm the agent receives the expanded skill instructions rather than the literal slash text.
3. Run the focused regression suite:

```bash
scripts/run_tests.sh tests/acp_adapter/test_acp_commands.py
```

Result: 7 passed.

A broader `scripts/run_tests.sh tests/acp/ tests/acp_adapter/` run passed 143 tests. Two pre-existing Windows-specific tests failed outside this change: Proactor pipe registration with `WinError 6` and `/mnt/d/...` URI translation.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run the repository test entry on the relevant tests
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Relevant documentation is unchanged because this restores the documented skill slash-command behavior
- [x] `cli-config.yaml.example` is N/A because no configuration keys changed
- [x] `CONTRIBUTING.md` and `AGENTS.md` are N/A because no architecture or workflow changed
- [x] I've considered cross-platform impact; the implementation uses platform-independent Python paths and shared registries
- [x] Tool descriptions and schemas are N/A because no model tool behavior changed

## Screenshots / Logs

Focused verification: `scripts/run_tests.sh tests/acp_adapter/test_acp_commands.py` - 7 passed.
