### PR TITLE
fix(gateway): forward supervisor marker through stderr_timestamp wrapper

### DIFF
--- a/hermes_cli/stderr_timestamp.py
+++ b/hermes_cli/stderr_timestamp.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import os
 import re
 import signal
 import subprocess
@@ -83,6 +84,18 @@ def _parse_args(argv: Sequence[str] | None) -> argparse.Namespace:
 def main(argv: Sequence[str] | None = None) -> int:
     args = _parse_args(argv)
     log_path: Path = args.error_log
+
+    # macOS launchd sets XPC_SERVICE_NAME to the job label only for its DIRECT
+    # child. This wrapper re-execs the real gateway as a grandchild via
+    # Popen, and on macOS 26 the grandchild sees the interactive-shell
+    # sentinel "0" instead — so the gateway's supervised-conflict guard
+    # (``_guard_supervised_gateway_conflict``) fails to recognize itself as
+    # launchd-owned, detects its own service as "already running", and
+    # exit(1)s into a KeepAlive respawn loop. Re-export the supervisor
+    # marker through the escape hatch designed for wrappers that replace
+    # the child environment (gateway/restart.py EXTERNAL_GATEWAY_SUPERVISOR_ENV).
+    if os.environ.get("XPC_SERVICE_NAME", "") not in ("", "0"):
+        os.environ.setdefault("HERMES_GATEWAY_EXTERNAL_SUPERVISOR", "1")
 
     try:
         proc = subprocess.Popen(args.command, stderr=subprocess.PIPE)

--- a/tests/hermes_cli/test_stderr_timestamp.py
+++ b/tests/hermes_cli/test_stderr_timestamp.py
@@ -1,5 +1,6 @@
 """Tests for hermes_cli.stderr_timestamp."""
 
+import json
 import re
 import sys
 
@@ -34,3 +35,70 @@ def test_main_timestamps_each_stderr_line(tmp_path):
     assert re.fullmatch(f"{timestamp} first failure", lines[0])
     assert re.fullmatch(f"{timestamp} second failure without newline", lines[1])
     assert lines[2] == "2026-07-15 12:34:56,789 already timestamped"
+
+
+def test_main_exports_supervisor_marker_to_grandchild(tmp_path, monkeypatch):
+    """launchd's XPC_SERVICE_NAME must survive the wrapper into the grandchild.
+
+    launchd sets the job label only on its DIRECT child (this wrapper). The
+    real gateway runs as a grandchild where macOS 26 reports the
+    interactive-shell sentinel "0" — losing the supervisor marker wedges the
+    gateway's self-conflict guard into a KeepAlive respawn loop. The wrapper
+    must forward the marker via HERMES_GATEWAY_EXTERNAL_SUPERVISOR.
+    """
+    log_path = tmp_path / "gateway.error.log"
+    out_path = tmp_path / "grandchild_env.json"
+    code = (
+        "import json, os\n"
+        f"open({str(out_path)!r}, 'w').write("
+        "json.dumps({k: os.environ.get(k) for k in "
+        "['XPC_SERVICE_NAME', 'HERMES_GATEWAY_EXTERNAL_SUPERVISOR']}))\n"
+    )
+
+    monkeypatch.setenv("XPC_SERVICE_NAME", "ai.hermes.gateway")
+    monkeypatch.delenv("HERMES_GATEWAY_EXTERNAL_SUPERVISOR", raising=False)
+
+    rc = stderr_timestamp.main(
+        [
+            "--error-log",
+            str(log_path),
+            "--",
+            sys.executable,
+            "-c",
+            code,
+        ]
+    )
+
+    assert rc == 0
+    env = json.loads(out_path.read_text(encoding="utf-8"))
+    assert env["HERMES_GATEWAY_EXTERNAL_SUPERVISOR"] == "1"
+
+
+def test_main_leaves_shell_sentinel_alone(tmp_path, monkeypatch):
+    """Interactive shells (XPC sentinel "0") must NOT gain a supervisor marker."""
+    log_path = tmp_path / "gateway.error.log"
+    out_path = tmp_path / "grandchild_env.json"
+    code = (
+        "import json, os\n"
+        f"open({str(out_path)!r}, 'w').write("
+        "json.dumps({'HERMES_GATEWAY_EXTERNAL_SUPERVISOR': "
+        "os.environ.get('HERMES_GATEWAY_EXTERNAL_SUPERVISOR')}))\n"
+    )
+
+    monkeypatch.setenv("XPC_SERVICE_NAME", "0")
+    monkeypatch.delenv("HERMES_GATEWAY_EXTERNAL_SUPERVISOR", raising=False)
+
+    rc = stderr_timestamp.main(
+        [
+            "--error-log",
+            str(log_path),
+            "--",
+            sys.executable,
+            "-c",
+            code,
+        ]
+    )
+
+    assert rc == 0
+    env = json.loads(out_path.read_text(encoding="utf-8"))
+    assert env["HERMES_GATEWAY_EXTERNAL_SUPERVISOR"] is None


### PR DESCRIPTION
## Summary

On macOS 26, launchd sets `XPC_SERVICE_NAME` to the job label **only for its direct child**. The launchd plist wraps the gateway in `hermes_cli.stderr_timestamp` to timestamp raw stderr lines, so the real gateway runs as a **grandchild** — where `XPC_SERVICE_NAME` degrades to the interactive-shell sentinel `"0"`.

The supervised-conflict guard (`_guard_supervised_gateway_conflict` in `hermes_cli/gateway.py`) then fails to recognize the gateway as launchd-owned, detects its own service as "already running", and exits 1 — wedging the unit into a KeepAlive respawn loop where every restart refuses to start:

```
✗ A gateway is already running under launchd for this profile.
  ... (exit 1, KeepAlive respawns, repeat forever)
```

Verified on macOS 26 with a real launchd job running the exact plist command chain:

| process | XPC_SERVICE_NAME |
|---|---|
| launchd direct child (`sh`) | `ai.hermes.xpctest2` (label) |
| grandchild via `stderr_timestamp` Popen | `"0"` (sentinel) |

## Fix

Forward the supervisor identity through the escape hatch designed for wrappers that replace the child environment: when `hermes_cli.stderr_timestamp` itself sees a real launchd job label, it sets `HERMES_GATEWAY_EXTERNAL_SUPERVISOR=1` for the grandchild (`EXTERNAL_GATEWAY_SUPERVISOR_ENV` in `gateway/restart.py`).

The sentinel `"0"` (interactive shell) is explicitly left alone, so a manual foreground run still trips the conflict guard as designed.

## Test Plan

- [x] New unit tests: label forwarded to grandchild / shell sentinel left alone (`tests/hermes_cli/test_stderr_timestamp.py`, 3/3 pass via `scripts/run_tests.sh`)
- [x] E2E on macOS 26: temporary launchd job running the real plist command chain — grandchild now receives `HERMES_GATEWAY_EXTERNAL_SUPERVISOR=1`
- [x] Live gateway service recovered: `launchctl print` shows `state = running`, `last exit code = (never exited)`, telegram connected, no more respawn loop