### PR TITLE
fix(tui): preserve Kanban notification ownership through compression

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -3029,6 +3029,10 @@ def _is_busy_error(exc: BaseException) -> bool:
     )
 
 
+class NotificationClaimBusyError(RuntimeError):
+    """A bounded notification cursor claim could not acquire the board writer."""
+
+
 def _execute_boundary_with_retry(conn: sqlite3.Connection, sql: str) -> None:
     for attempt in range(_BUSY_MAX_RETRIES + 1):
         try:
@@ -11400,6 +11404,61 @@ def unseen_events_for_sub(
     return max_id, out
 
 
+@contextlib.contextmanager
+def _notification_claim_txn(
+    conn: sqlite3.Connection, lock_wait_timeout_ms: Optional[int]
+):
+    """Run one cursor claim with an optional single board-lock wait."""
+    if lock_wait_timeout_ms is None:
+        with write_txn(conn):
+            yield
+        return
+    _assert_not_delegated_child_mutation()
+    if lock_wait_timeout_ms <= 0:
+        raise ValueError("lock_wait_timeout_ms must be positive")
+    if getattr(conn, "in_transaction", False):
+        raise RuntimeError("notification claim cannot start inside a transaction")
+
+    timeout_row = conn.execute("PRAGMA busy_timeout").fetchone()
+    previous_timeout_ms = (
+        int(timeout_row[0]) if timeout_row and timeout_row[0] is not None else 0
+    )
+    conn.execute(f"PRAGMA busy_timeout={int(lock_wait_timeout_ms)}")
+    try:
+        # Do not use write_txn's general retries here: each retry can consume
+        # another full busy timeout while the caller holds state.db reserved.
+        try:
+            conn.execute("BEGIN IMMEDIATE")
+        except sqlite3.OperationalError as exc:
+            if _is_busy_error(exc):
+                # Do not let SessionDB._execute_write mistake this board expiry
+                # for state.db contention and retry the whole ownership claim.
+                raise NotificationClaimBusyError(
+                    "notification board claim lock wait expired"
+                ) from exc
+            raise
+        try:
+            yield
+        except Exception:
+            try:
+                conn.execute("ROLLBACK")
+            except sqlite3.OperationalError:
+                pass
+            raise
+        else:
+            try:
+                conn.execute("COMMIT")
+            except Exception:
+                try:
+                    conn.execute("ROLLBACK")
+                except sqlite3.OperationalError:
+                    pass
+                raise
+            _check_file_length_invariant(conn)
+    finally:
+        conn.execute(f"PRAGMA busy_timeout={previous_timeout_ms}")
+
+
 def claim_unseen_events_for_sub(
     conn: sqlite3.Connection,
     *,
@@ -11408,6 +11467,7 @@ def claim_unseen_events_for_sub(
     chat_id: str,
     thread_id: Optional[str] = None,
     kinds: Optional[Iterable[str]] = None,
+    lock_wait_timeout_ms: Optional[int] = None,
 ) -> tuple[int, int, list[Event]]:
     """Atomically claim unseen notification events for one subscription.
 
@@ -11422,8 +11482,12 @@ def claim_unseen_events_for_sub(
     Callers should send the claimed events, then either leave the cursor at
     ``new_cursor`` on success or call :func:`rewind_notify_cursor` if delivery
     failed before any terminal unsubscribe removed the row.
+
+    ``lock_wait_timeout_ms`` bounds only this claim's board writer acquisition.
+    The general Kanban transaction timeout and retry policy remains unchanged.
     """
-    with write_txn(conn):
+
+    with _notification_claim_txn(conn, lock_wait_timeout_ms):
         row = conn.execute(
             "SELECT last_event_id FROM kanban_notify_subs "
             "WHERE task_id = ? AND platform = ? AND chat_id = ? AND thread_id = ?",

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -11201,6 +11201,28 @@ def list_notify_subs(
     return out
 
 
+def list_notify_subs_readonly(
+    db_path: Optional[Path] = None,
+    *,
+    board: Optional[str] = None,
+) -> list[dict]:
+    """List notification subscriptions without opening the board writable."""
+    path = db_path if db_path is not None else kanban_db_path(board=board)
+    if not path.exists():
+        return []
+    conn = sqlite3.connect(path.resolve().as_uri() + "?mode=ro", uri=True)
+    conn.row_factory = sqlite3.Row
+    try:
+        try:
+            return list_notify_subs(conn)
+        except sqlite3.OperationalError as exc:
+            if "no such table" in str(exc).lower():
+                return []
+            raise
+    finally:
+        conn.close()
+
+
 def count_notify_subs(
     db_path: Optional[Path] = None,
     *,

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -10061,6 +10061,82 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             "messages_after": messages_after,
         }
 
+    @staticmethod
+    def _resolve_notification_owner_on_conn(
+        conn: sqlite3.Connection, session_id: str
+    ) -> Optional[str]:
+        """Resolve one unambiguous compression lineage for cursor ownership.
+
+        General resume deliberately tolerates malformed historical state and
+        chooses the newest eligible child. Notification delivery cannot: a
+        guessed owner can consume another live session's event. This resolver
+        therefore returns ``None`` for a missing compression continuation,
+        multiple eligible children, a cycle, or an over-depth lineage. Query
+        errors propagate so callers fail closed rather than treating the input
+        session as authoritative.
+        """
+        if not session_id:
+            return None
+        current = session_id
+        seen = {current}
+        for _ in range(100):
+            parent = conn.execute(
+                "SELECT end_reason FROM sessions WHERE id = ?", (current,)
+            ).fetchone()
+            if parent is None:
+                return None
+            if parent["end_reason"] != "compression":
+                return current
+            children = conn.execute(
+                "SELECT child.id FROM sessions AS child "
+                "WHERE child.parent_session_id = ? "
+                "  AND json_extract(COALESCE(child.model_config, '{}'), '$._branched_from') IS NULL "
+                "  AND json_extract(COALESCE(child.model_config, '{}'), '$._delegate_from') IS NULL "
+                "  AND json_extract(COALESCE(child.model_config, '{}'), '$._reset_from') IS NULL "
+                f"  AND NOT {_legacy_reset_child_sql('child', _RESET_END_REASONS_SQL)} "
+                "  AND COALESCE(child.source, '') != 'tool' "
+                "ORDER BY child.id LIMIT 2",
+                (current,),
+            ).fetchall()
+            if len(children) != 1:
+                return None
+            child_id = children[0]["id"]
+            if not child_id or child_id in seen:
+                return None
+            seen.add(child_id)
+            current = child_id
+        return None
+
+    def resolve_notification_owner_session_id(
+        self, session_id: str
+    ) -> Optional[str]:
+        """Return the unique current owner of a TUI notification subscription."""
+        with self._read_ctx() as conn:
+            return self._resolve_notification_owner_on_conn(conn, session_id)
+
+    def claim_if_notification_owner(
+        self,
+        owner_session_id: str,
+        live_session_id: str,
+        claim: Callable[[], T],
+    ) -> Optional[T]:
+        """Run ``claim`` only while notification lineage ownership is stable.
+
+        ``BEGIN IMMEDIATE`` serializes compression publication across processes.
+        The state-db write reservation remains held through the board cursor CAS,
+        closing the resolve-to-claim race without advancing and rewinding.
+        """
+
+        def _claim_if_owner(conn: sqlite3.Connection) -> Optional[T]:
+            resolved = self._resolve_notification_owner_on_conn(
+                conn, owner_session_id
+            )
+            if resolved != live_session_id:
+                return None
+            return claim()
+
+        return self._execute_write(_claim_if_owner)
+
     def resolve_resume_session_id(self, session_id: str) -> str:
         """Redirect a resume target to the descendant session that holds the messages.
 

--- a/tests/tui_gateway/test_kanban_notify_poller.py
+++ b/tests/tui_gateway/test_kanban_notify_poller.py
@@ -11,10 +11,16 @@ These tests cover the delivery half that now lives in tui_gateway/server.py:
 unsubscribe) and ``_format_kanban_event_text``.
 """
 
+from contextlib import contextmanager
+from threading import Event, Thread
 from types import SimpleNamespace
 from unittest.mock import patch
 
+import pytest
+
 from hermes_cli import kanban_db as kb
+from hermes_state import SessionDB
+import tui_gateway.server as tui_server
 from tui_gateway.server import (
     _collect_kanban_notifications,
     _format_kanban_event_text,
@@ -53,7 +59,303 @@ def _sub_rows(tid: str) -> list:
         conn.close()
 
 
+@pytest.fixture(autouse=True)
+def _live_session_db(monkeypatch, tmp_path):
+    state_db = SessionDB(tmp_path / "default-state.db")
+    state_db.create_session(SESSION_KEY, source="desktop")
+    monkeypatch.setattr(tui_server, "_get_db", lambda: state_db)
+
+
 class TestCollectKanbanNotifications:
+    def test_parent_subscription_claims_only_at_live_multi_hop_compression_tip(
+        self, monkeypatch, tmp_path
+    ):
+        """A stale parent poller must not consume its live tip's event.
+
+        This is a current-main regression derived independently after inspecting
+        the lineage contract in PR #69035; no test bytes are copied from that PR.
+        """
+        state_db = SessionDB(tmp_path / "state.db")
+        state_db.create_session("parent", source="desktop")
+        state_db.end_session("parent", "compression")
+        state_db.create_session(
+            "middle", source="desktop", parent_session_id="parent"
+        )
+        state_db.end_session("middle", "compression")
+        state_db.create_session("tip", source="desktop", parent_session_id="middle")
+        state_db.append_message("tip", role="assistant", content="live continuation")
+        assert state_db.resolve_resume_session_id("parent") == "tip"
+        monkeypatch.setattr(tui_server, "_get_db", lambda: state_db)
+
+        tid = _create_subscribed_task(chat_id="parent")
+        conn = kb.connect()
+        try:
+            kb.block_task(conn, tid, reason="wake the live tip")
+        finally:
+            conn.close()
+        pre_cursor = _sub_rows(tid)[0]["last_event_id"]
+
+        # Neither the stale parent runtime nor an unrelated lineage may claim.
+        assert _collect_kanban_notifications(_session("parent")) == []
+        assert _collect_kanban_notifications(_session("unrelated")) == []
+        assert _sub_rows(tid)[0]["last_event_id"] == pre_cursor
+
+        first = _collect_kanban_notifications(_session("tip"))
+        assert len(first) == 1
+        assert tid in first[0]
+        assert "wake the live tip" in first[0]
+        assert _collect_kanban_notifications(_session("tip")) == []
+        assert _sub_rows(tid)[0]["last_event_id"] > pre_cursor
+
+    def test_new_session_is_a_hard_subscription_boundary(self, monkeypatch, tmp_path):
+        state_db = SessionDB(tmp_path / "state.db")
+        state_db.create_session("before-new", source="desktop")
+        state_db.end_session("before-new", "reset")
+        state_db.create_session(
+            "after-new",
+            source="desktop",
+            parent_session_id="before-new",
+            model_config={"_reset_from": "before-new"},
+        )
+        state_db.append_message("after-new", role="user", content="fresh conversation")
+        assert state_db.resolve_resume_session_id("before-new") == "before-new"
+        monkeypatch.setattr(tui_server, "_get_db", lambda: state_db)
+
+        tid = _create_subscribed_task(chat_id="before-new")
+        _complete(tid, summary="belongs to the old conversation")
+        pre_cursor = _sub_rows(tid)[0]["last_event_id"]
+
+        assert _collect_kanban_notifications(_session("after-new")) == []
+        assert _sub_rows(tid)[0]["last_event_id"] == pre_cursor
+
+    def test_real_ambiguous_compression_children_fail_closed(
+        self, monkeypatch, tmp_path
+    ):
+        state_db = SessionDB(tmp_path / "state.db")
+        state_db.create_session("parent", source="desktop")
+        state_db.end_session("parent", "compression")
+        state_db.create_session("older", source="desktop", parent_session_id="parent")
+        state_db.create_session("newer", source="desktop", parent_session_id="parent")
+        state_db.append_message("newer", role="assistant", content="chosen by resume")
+        state_db._conn.execute(
+            "UPDATE sessions SET started_at = CASE id "
+            "WHEN 'older' THEN 1 WHEN 'newer' THEN 2 ELSE started_at END"
+        )
+        state_db._conn.commit()
+        assert state_db.resolve_resume_session_id("parent") == "newer"
+        monkeypatch.setattr(tui_server, "_get_db", lambda: state_db)
+
+        tid = _create_subscribed_task(chat_id="parent")
+        _complete(tid, summary="ambiguous ownership must remain retryable")
+        pre_cursor = _sub_rows(tid)[0]["last_event_id"]
+
+        assert _collect_kanban_notifications(_session("newer")) == []
+        assert _sub_rows(tid)[0]["last_event_id"] == pre_cursor
+
+    def test_real_lineage_query_corruption_fails_closed(
+        self, monkeypatch, tmp_path
+    ):
+        state_db = SessionDB(tmp_path / "state.db")
+        state_db.create_session("parent", source="desktop")
+        state_db.end_session("parent", "compression")
+        state_db.create_session("child", source="desktop", parent_session_id="parent")
+        state_db._conn.execute(
+            "UPDATE sessions SET model_config = '{' WHERE id = 'child'"
+        )
+        state_db._conn.commit()
+        # The general resume helper intentionally degrades to the input id when
+        # a lineage query fails. Notification ownership must be stricter.
+        assert state_db.resolve_resume_session_id("parent") == "parent"
+        monkeypatch.setattr(tui_server, "_get_db", lambda: state_db)
+
+        tid = _create_subscribed_task(chat_id="parent")
+        _complete(tid, summary="corrupt lineage must remain retryable")
+        pre_cursor = _sub_rows(tid)[0]["last_event_id"]
+
+        assert _collect_kanban_notifications(_session("parent")) == []
+        assert _sub_rows(tid)[0]["last_event_id"] == pre_cursor
+
+    def test_cursor_claim_serializes_real_concurrent_compression_publication(
+        self, monkeypatch, tmp_path
+    ):
+        """The state ownership transaction must outlive the board cursor CAS."""
+        state_path = tmp_path / "state.db"
+        state_db = SessionDB(state_path)
+        compression_db = SessionDB(state_path)
+        state_db.create_session("parent", source="desktop")
+        monkeypatch.setattr(tui_server, "_get_db", lambda: state_db)
+
+        tid = _create_subscribed_task(chat_id="parent")
+        _complete(tid, summary="deliver before compression")
+        pre_cursor = _sub_rows(tid)[0]["last_event_id"]
+
+        original_write_txn = kb.write_txn
+        pause = {
+            "armed": False,
+            "entered": Event(),
+            "release": Event(),
+        }
+
+        @contextmanager
+        def pause_inside_board_claim(conn, *args, **kwargs):
+            with original_write_txn(conn, *args, **kwargs):
+                if pause["armed"]:
+                    pause["armed"] = False
+                    pause["entered"].set()
+                    assert pause["release"].wait(5), "board claim was never released"
+                yield
+
+        monkeypatch.setattr(kb, "write_txn", pause_inside_board_claim)
+
+        def start_thread(name, target):
+            outcome = {}
+
+            def run():
+                try:
+                    outcome["value"] = target()
+                except BaseException as exc:  # surfaced on the asserting thread
+                    outcome["error"] = exc
+
+            thread = Thread(target=run, name=name)
+            thread.start()
+            return thread, outcome
+
+        def publish(db, child_id, published):
+            db.publish_compression_child(
+                parent_session_id="parent",
+                child_session_id=child_id,
+                source="desktop",
+                messages=[{"role": "assistant", "content": "live continuation"}],
+                require_compression_lease=False,
+            )
+            published.set()
+
+        # Production path: pause after the real board BEGIN IMMEDIATE, while
+        # claim_if_notification_owner still owns the state BEGIN IMMEDIATE.
+        pause["armed"] = True
+        claim_thread, claim_outcome = start_thread(
+            "notify-claim", lambda: _collect_kanban_notifications(_session("parent"))
+        )
+        assert pause["entered"].wait(5), "collector never entered the board claim"
+
+        # Instrument the real SessionDB lock-retry boundary. This hook runs only
+        # after BEGIN IMMEDIATE has returned SQLITE_BUSY/locked, so reaching it
+        # proves actual state-lock contention rather than mere thread startup.
+        compression_contended = Event()
+        original_retry_sleep = compression_db._sleep_before_write_retry
+
+        def record_compression_contention(*args, **kwargs):
+            compression_contended.set()
+            return original_retry_sleep(*args, **kwargs)
+
+        monkeypatch.setattr(
+            compression_db, "_sleep_before_write_retry", record_compression_contention
+        )
+        compression_published = Event()
+        compression_thread, compression_outcome = start_thread(
+            "compression-publication",
+            lambda: publish(compression_db, "tip", compression_published),
+        )
+        assert compression_contended.wait(5), (
+            "compression publisher never contended on state BEGIN IMMEDIATE"
+        )
+        assert not compression_published.is_set()
+        pause["release"].set()
+        claim_thread.join(5)
+        compression_thread.join(5)
+        assert not claim_thread.is_alive()
+        assert not compression_thread.is_alive()
+        assert "error" not in claim_outcome, claim_outcome
+        assert "error" not in compression_outcome, compression_outcome
+
+        delivered = claim_outcome["value"]
+        assert len(delivered) == 1
+        assert "deliver before compression" in delivered[0]
+        claimed_cursor = _sub_rows(tid)[0]["last_event_id"]
+        assert claimed_cursor > pre_cursor
+        assert state_db.resolve_notification_owner_session_id("parent") == "tip"
+        assert _collect_kanban_notifications(_session("parent")) == []
+
+        # The successor owns only post-claim events and consumes each once.
+        conn = kb.connect()
+        try:
+            with kb.write_txn(conn):
+                conn.execute(
+                    "UPDATE tasks SET status = 'ready' WHERE id = ?", (tid,)
+                )
+                kb._append_event(conn, tid, "status", {"status": "ready"})
+        finally:
+            conn.close()
+        assert _sub_rows(tid)[0]["last_event_id"] == claimed_cursor
+        successor = _collect_kanban_notifications(_session("tip"))
+        assert len(successor) == 1
+        assert "ready" in successor[0]
+        assert _collect_kanban_notifications(_session("tip")) == []
+        conn = kb.connect()
+        try:
+            kb.remove_notify_sub(
+                conn,
+                task_id=tid,
+                platform="tui",
+                chat_id="parent",
+                thread_id="",
+            )
+        finally:
+            conn.close()
+
+        # Counterfactual: the old resolve-then-claim shape releases the state
+        # transaction before entering the exact same board CAS. With a fresh
+        # real state connection and deterministic barrier, compression now
+        # publishes while the board claim is paused and the stale parent takes
+        # the event. The production assertion above would therefore fail.
+        broken_path = tmp_path / "broken-state.db"
+        broken_state = SessionDB(broken_path)
+        broken_compression = SessionDB(broken_path)
+        broken_state.create_session("parent", source="desktop")
+        monkeypatch.setattr(tui_server, "_get_db", lambda: broken_state)
+
+        broken_tid = _create_subscribed_task(chat_id="parent")
+        _complete(broken_tid, summary="counterfactual stale claim")
+
+        def released_before_claim(owner_session_id, live_session_id, claim):
+            resolved = broken_state.resolve_notification_owner_session_id(
+                owner_session_id
+            )
+            return claim() if resolved == live_session_id else None
+
+        monkeypatch.setattr(
+            broken_state, "claim_if_notification_owner", released_before_claim
+        )
+        pause.update({"armed": True, "entered": Event(), "release": Event()})
+        broken_claim_thread, broken_claim_outcome = start_thread(
+            "broken-notify-claim",
+            lambda: _collect_kanban_notifications(_session("parent")),
+        )
+        assert pause["entered"].wait(5)
+        broken_published = Event()
+        broken_compression_thread, broken_compression_outcome = start_thread(
+            "broken-compression-publication",
+            lambda: publish(
+                broken_compression,
+                "broken-tip",
+                broken_published,
+            ),
+        )
+        assert broken_published.wait(5), "counterfactual did not expose the race"
+        pause["release"].set()
+        broken_claim_thread.join(5)
+        broken_compression_thread.join(5)
+        assert not broken_claim_thread.is_alive()
+        assert not broken_compression_thread.is_alive()
+        assert "error" not in broken_claim_outcome, broken_claim_outcome
+        assert "error" not in broken_compression_outcome, broken_compression_outcome
+        assert len(broken_claim_outcome["value"]) == 1
+        assert "counterfactual stale claim" in broken_claim_outcome["value"][0]
+        assert (
+            broken_state.resolve_notification_owner_session_id("parent")
+            == "broken-tip"
+        )
+
     def test_zero_sub_board_is_never_opened_writable(self):
         conn = kb.connect()
         conn.close()
@@ -175,7 +477,7 @@ class TestCollectKanbanNotifications:
         def fail_probe(*args, **kwargs):
             raise OSError("probe unavailable")
 
-        monkeypatch.setattr(kb, "count_notify_subs", fail_probe)
+        monkeypatch.setattr(kb, "list_notify_subs_readonly", fail_probe)
         with patch.object(kb, "connect", wraps=kb.connect) as spy_connect:
             texts = _collect_kanban_notifications(_session())
 

--- a/tests/tui_gateway/test_kanban_notify_poller.py
+++ b/tests/tui_gateway/test_kanban_notify_poller.py
@@ -12,7 +12,9 @@ unsubscribe) and ``_format_kanban_event_text``.
 """
 
 from contextlib import contextmanager
+import sqlite3
 from threading import Event, Thread
+import time
 from types import SimpleNamespace
 from unittest.mock import patch
 
@@ -67,6 +69,131 @@ def _live_session_db(monkeypatch, tmp_path):
 
 
 class TestCollectKanbanNotifications:
+    def test_bounded_claim_rejects_delegated_child_before_cursor_mutation(
+        self, monkeypatch
+    ):
+        tid = _create_subscribed_task()
+        _complete(tid, summary="delegated child must not claim")
+        pre_cursor = _sub_rows(tid)[0]["last_event_id"]
+
+        conn = kb.connect()
+        try:
+            monkeypatch.setenv("HERMES_DELEGATED_CHILD_CONTEXT", "1")
+            with pytest.raises(PermissionError, match="delegate_task child contexts"):
+                kb.claim_unseen_events_for_sub(
+                    conn,
+                    task_id=tid,
+                    platform="tui",
+                    chat_id=SESSION_KEY,
+                    lock_wait_timeout_ms=75,
+                )
+            assert _sub_rows(tid)[0]["last_event_id"] == pre_cursor
+
+            monkeypatch.delenv("HERMES_DELEGATED_CHILD_CONTEXT")
+            old_cursor, new_cursor, events = kb.claim_unseen_events_for_sub(
+                conn,
+                task_id=tid,
+                platform="tui",
+                chat_id=SESSION_KEY,
+                lock_wait_timeout_ms=75,
+            )
+        finally:
+            conn.close()
+
+        assert old_cursor == pre_cursor
+        assert new_cursor > old_cursor
+        assert len(events) == 1
+        assert events[0].kind == "completed"
+        assert _sub_rows(tid)[0]["last_event_id"] == new_cursor
+
+    def test_board_lock_expiry_releases_state_and_retries_claim_once(
+        self, monkeypatch, tmp_path
+    ):
+        """A contended board must not pin the state ownership transaction."""
+        state_path = tmp_path / "state.db"
+        state_db = SessionDB(state_path)
+        state_db.create_session("parent", source="desktop")
+        monkeypatch.setattr(tui_server, "_get_db", lambda: state_db)
+
+        tid = _create_subscribed_task(chat_id="parent")
+        _complete(tid, summary="retry after board contention")
+        pre_cursor = _sub_rows(tid)[0]["last_event_id"]
+
+        # Keep the general connection wait small enough for a fast RED while
+        # requiring the claim-specific path to fit within one bounded wait,
+        # rather than multiplying it by write_txn's boundary retries.
+        claim_budget_ms = 75
+        monkeypatch.setenv("HERMES_KANBAN_BUSY_TIMEOUT_MS", str(claim_budget_ms))
+        monkeypatch.setattr(
+            tui_server,
+            "_KANBAN_NOTIFY_CLAIM_BUSY_TIMEOUT_MS",
+            claim_budget_ms,
+            raising=False,
+        )
+
+        board_lock = kb.connect()
+        board_lock.execute("BEGIN IMMEDIATE")
+        claim_entered = Event()
+        original_claim = kb.claim_unseen_events_for_sub
+
+        def record_claim(*args, **kwargs):
+            claim_entered.set()
+            return original_claim(*args, **kwargs)
+
+        monkeypatch.setattr(kb, "claim_unseen_events_for_sub", record_claim)
+        outcome = {}
+
+        def collect():
+            started = time.monotonic()
+            try:
+                outcome["value"] = _collect_kanban_notifications(_session("parent"))
+            except BaseException as exc:  # surfaced on the asserting thread
+                outcome["error"] = exc
+            finally:
+                outcome["elapsed"] = time.monotonic() - started
+
+        claim_thread = Thread(target=collect, name="bounded-notify-claim")
+        claim_thread.start()
+        assert claim_entered.wait(5), "collector never reached the locked board claim"
+
+        state_write_done = Event()
+        state_outcome = {}
+
+        def write_state():
+            started = time.monotonic()
+            state_writer = sqlite3.connect(state_path, timeout=2, isolation_level=None)
+            try:
+                state_writer.execute("BEGIN IMMEDIATE")
+                state_writer.execute("ROLLBACK")
+            except BaseException as exc:  # surfaced on the asserting thread
+                state_outcome["error"] = exc
+            finally:
+                state_writer.close()
+                state_outcome["elapsed"] = time.monotonic() - started
+                state_write_done.set()
+
+        state_thread = Thread(target=write_state, name="state-writer-after-claim-expiry")
+        state_thread.start()
+        claim_thread.join(2)
+        assert not claim_thread.is_alive(), "board claim exceeded its bounded wait"
+        assert "error" not in outcome, outcome
+        assert outcome["value"] == []
+        assert outcome["elapsed"] < 0.5
+        assert state_write_done.wait(1), "state.db stayed reserved after claim expiry"
+        state_thread.join(1)
+        assert "error" not in state_outcome, state_outcome
+        assert state_outcome["elapsed"] < 0.5
+
+        assert _sub_rows(tid)[0]["last_event_id"] == pre_cursor
+        board_lock.execute("ROLLBACK")
+        board_lock.close()
+
+        retry = _collect_kanban_notifications(_session("parent"))
+        assert len(retry) == 1
+        assert "retry after board contention" in retry[0]
+        assert _collect_kanban_notifications(_session("parent")) == []
+        assert _sub_rows(tid)[0]["last_event_id"] > pre_cursor
+
     def test_parent_subscription_claims_only_at_live_multi_hop_compression_tip(
         self, monkeypatch, tmp_path
     ):
@@ -189,7 +316,7 @@ class TestCollectKanbanNotifications:
         _complete(tid, summary="deliver before compression")
         pre_cursor = _sub_rows(tid)[0]["last_event_id"]
 
-        original_write_txn = kb.write_txn
+        original_claim_txn = kb._notification_claim_txn
         pause = {
             "armed": False,
             "entered": Event(),
@@ -198,14 +325,14 @@ class TestCollectKanbanNotifications:
 
         @contextmanager
         def pause_inside_board_claim(conn, *args, **kwargs):
-            with original_write_txn(conn, *args, **kwargs):
+            with original_claim_txn(conn, *args, **kwargs):
                 if pause["armed"]:
                     pause["armed"] = False
                     pause["entered"].set()
                     assert pause["release"].wait(5), "board claim was never released"
                 yield
 
-        monkeypatch.setattr(kb, "write_txn", pause_inside_board_claim)
+        monkeypatch.setattr(kb, "_notification_claim_txn", pause_inside_board_claim)
 
         def start_thread(name, target):
             outcome = {}

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -9631,6 +9631,25 @@ def _collect_kanban_notifications(session: dict) -> list:
         from hermes_cli import kanban_db as _kb
     except Exception:
         return []
+    try:
+        session_db = _get_db()
+    except Exception:
+        return []
+    if session_db is None:
+        return []
+
+    def _subscription_belongs_here(sub: dict) -> bool:
+        owner_key = str(sub.get("chat_id") or "")
+        if not owner_key:
+            return False
+        try:
+            resolved_key = session_db.resolve_notification_owner_session_id(
+                owner_key
+            )
+        except Exception:
+            return False
+        return bool(resolved_key) and str(resolved_key) == session_key
+
     texts: list = []
     try:
         boards = _kb.list_boards(include_archived=False)
@@ -9656,15 +9675,19 @@ def _collect_kanban_notifications(session: dict) -> list:
         if resolved in seen_db_paths:
             continue
         seen_db_paths.add(resolved)
-        # A poller runs per live TUI/Desktop session. Avoid opening this board
-        # writable unless it has a subscription owned by this exact session;
-        # subscriptions for gateways or other sessions are not actionable here.
+        # A poller runs per live TUI/Desktop session. Inspect subscriptions
+        # read-only and resolve their durable owner through compression lineage
+        # before opening the board writable. Resolving even an exact raw-key
+        # match prevents a stale parent runtime from claiming its live tip's
+        # event. Missing or ambiguous lineage fails closed without moving the
+        # subscription cursor.
         try:
-            if _kb.count_notify_subs(
-                board=slug,
-                platform="tui",
-                chat_id=session_key,
-            ) == 0:
+            probe_subs = _kb.list_notify_subs_readonly(board=slug)
+            if not any(
+                (sub.get("platform") or "").lower() == "tui"
+                and _subscription_belongs_here(sub)
+                for sub in probe_subs
+            ):
                 continue
         except Exception:
             # Preserve delivery if the read-only probe cannot inspect a
@@ -9682,16 +9705,21 @@ def _collect_kanban_notifications(session: dict) -> list:
             for sub in subs:
                 if (sub.get("platform") or "").lower() != "tui":
                     continue
-                if sub.get("chat_id") != session_key:
-                    continue
-                _old, _new, events = _kb.claim_unseen_events_for_sub(
-                    conn,
-                    task_id=sub["task_id"],
-                    platform=sub["platform"],
-                    chat_id=sub["chat_id"],
-                    thread_id=sub.get("thread_id") or "",
-                    kinds=_KANBAN_NOTIFY_KINDS,
+                claimed = session_db.claim_if_notification_owner(
+                    str(sub.get("chat_id") or ""),
+                    session_key,
+                    lambda: _kb.claim_unseen_events_for_sub(
+                        conn,
+                        task_id=sub["task_id"],
+                        platform=sub["platform"],
+                        chat_id=sub["chat_id"],
+                        thread_id=sub.get("thread_id") or "",
+                        kinds=_KANBAN_NOTIFY_KINDS,
+                    ),
                 )
+                if claimed is None:
+                    continue
+                _old, _new, events = claimed
                 if not events:
                     continue
                 task = _kb.get_task(conn, sub["task_id"])

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -9466,6 +9466,10 @@ _KANBAN_NOTIFY_KINDS = (
     "status", "archived", "unblocked",
 )
 _KANBAN_SILENT_KINDS = frozenset({"archived", "unblocked"})
+# The ownership transaction reserves state.db until the board cursor CAS
+# commits. Bound only that board writer acquisition so general Kanban lock
+# retries cannot pin state writers for minutes under board contention.
+_KANBAN_NOTIFY_CLAIM_BUSY_TIMEOUT_MS = 1000
 _KANBAN_POLL_SECONDS = 5.0
 _LOOP_POLL_SECONDS = 5.0
 
@@ -9705,18 +9709,26 @@ def _collect_kanban_notifications(session: dict) -> list:
             for sub in subs:
                 if (sub.get("platform") or "").lower() != "tui":
                     continue
-                claimed = session_db.claim_if_notification_owner(
-                    str(sub.get("chat_id") or ""),
-                    session_key,
-                    lambda: _kb.claim_unseen_events_for_sub(
-                        conn,
-                        task_id=sub["task_id"],
-                        platform=sub["platform"],
-                        chat_id=sub["chat_id"],
-                        thread_id=sub.get("thread_id") or "",
-                        kinds=_KANBAN_NOTIFY_KINDS,
-                    ),
-                )
+                try:
+                    claimed = session_db.claim_if_notification_owner(
+                        str(sub.get("chat_id") or ""),
+                        session_key,
+                        lambda: _kb.claim_unseen_events_for_sub(
+                            conn,
+                            task_id=sub["task_id"],
+                            platform=sub["platform"],
+                            chat_id=sub["chat_id"],
+                            thread_id=sub.get("thread_id") or "",
+                            kinds=_KANBAN_NOTIFY_KINDS,
+                            lock_wait_timeout_ms=(
+                                _KANBAN_NOTIFY_CLAIM_BUSY_TIMEOUT_MS
+                            ),
+                        ),
+                    )
+                except _kb.NotificationClaimBusyError:
+                    # SessionDB rolled back state.db; leave the board cursor
+                    # unchanged so the next poll can retry the same event.
+                    continue
                 if claimed is None:
                     continue
                 _old, _new, events = claimed


### PR DESCRIPTION
## Problem

A TUI/Desktop session can keep polling a Kanban subscription after context compression rotates ownership to a successor session. The stale parent can then claim the live tip's event and advance the durable cursor. General resume resolution is intentionally tolerant of malformed historical state, but notification delivery cannot guess: an ambiguous or corrupt lineage must not consume another session's event.

## Approach

- add a strict notification-owner resolver that follows one unambiguous compression lineage and fails closed for missing, ambiguous, cyclic, over-depth, or unreadable lineage state;
- inspect notification subscriptions read-only before opening a board writable;
- hold the state database's `BEGIN IMMEDIATE` ownership transaction through the board cursor compare-and-swap, so compression publication cannot rotate ownership between resolution and claim;
- preserve `/new` as a hard subscription boundary and keep unrelated sessions isolated;
- add real SQLite, two-connection/two-thread regressions for compression rotation, ambiguous/corrupt lineage, exact-once cursor ownership, and the release-before-CAS counterfactual.

## Provenance

This current-main regression and repair were derived independently after inspecting the lineage contract in closed PR #69035 by Chan Park (@ChanPark03). No test bytes were copied from that PR; the attribution is also recorded in the regression docstring.

PR #77963 is related notification-lifecycle work, but its current four-file delta does not carry this compression-lineage ownership invariant: it does not add the strict notification owner resolver or hold state ownership through the board cursor claim.

## Verification

Native Windows, repository `.venv` Python 3.11.15 / pytest 9.1.1, disposable `HERMES_HOME`, with inherited `HERMES_KANBAN_*` and `HERMES_DELEGATED_CHILD_CONTEXT` removed:

- deterministic real-SQLite contention regression: 10/10 fresh contained passes;
- complete `tests/tui_gateway/test_kanban_notify_poller.py`: 19 passed;
- `tests/hermes_state/test_resolve_resume_session_id.py`: 4 passed;
- final post-stage contention regression: 1 passed;
- focused ambiguity, corruption, and rotation regressions: 3 passed;
- `tests/test_hermes_state.py -k "compression or reset or resolve"`: 25 passed;
- `tests/hermes_cli/test_kanban_count_notify_subs.py` plus `tests/gateway/test_kanban_notifier_zero_sub_gate.py`: 5 passed;
- Ruff 0.15.10 check on the four cumulative paths: passed on the corrected production generation; format check matched untouched same-SHA baseline (`4 files would be reformatted`) and made no mutation;
- `git diff --cached --check`: passed.

The final independent cumulative review returned PASS for the exact frozen staged generation below.

## Frozen identity

- current-main base / `HEAD`: `460d345642ee3d143a3e461abe39fd42b86a7e54`
- staged Git binary-diff hash: `85f2d1a532671df93abae3a8462850db6fcaf103`
- staged binary-diff SHA-256: `a5c95f34fac3483a2b31cfa8cafa45a6a51220b409e6146b3f2fea6c645dba71`
- staged tree: `bfd003ded0b6bd1e7416a826cadb24cc295c4a19`
- staged paths:
  - `hermes_cli/kanban_db.py`
  - `hermes_state.py`
  - `tests/tui_gateway/test_kanban_notify_poller.py`
  - `tui_gateway/server.py`

At packet preparation, `refs/remotes/origin/main` and a fresh `git ls-remote origin refs/heads/main` both matched the base SHA. Status contained exactly these four staged paths, with no unstaged or untracked paths.

## Risks and trade-offs

- Ownership correctness now spans two SQLite databases. The deliberate lock order is state ownership first, then the board cursor claim; this can briefly defer concurrent compression publication, but prevents stale ownership from consuming an event.
- Ambiguous, corrupt, or unavailable lineage state fails closed. That may delay a notification for retry rather than risk misdelivery or cursor loss.
- The read-only subscription probe adds a SQLite open/read before the writable claim path; missing boards/tables remain non-actionable.

## Exclusions

- no general rewrite of notification lifecycle or duplicate poller;
- no change to general resume fallback semantics;
- no schema migration, model tool, gateway/config/profile/service change, install, update, or Production activation;
- no claim that this implements all work in #69035 or #77963.
