### PR TITLE
fix(plugins): rank pre_tool_call block above approve

### DIFF
--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -6071,6 +6071,15 @@ def _get_pre_tool_call_directive_details(
         # Snapshot the accumulated modify state as it stood when this approve
         # was seen: deferring the return must not retroactively pull in modify
         # directives that follow it.
+        #
+        # The copy is shallow, matching the ``dict(args)`` the accumulator
+        # itself is built from, and that is sufficient here: a later ``modify``
+        # reaches the accumulator only through ``modified_args.update(partial)``,
+        # which rebinds top-level keys rather than mutating the values behind
+        # them, so it cannot reach through this snapshot's shared references.
+        # Deep-copying would instead diverge from the documented shallow-merge
+        # contract for ``modify`` and silently break hooks that pass unpicklable
+        # or identity-significant objects through the args.
         first_approve = _PreToolCallDirective(
             action="approve", message=message, rule_key=rule_key,
             modified_args=dict(modified_args) if modified_args is not None else None,

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -5998,8 +5998,11 @@ def _get_pre_tool_call_directive_details(
     - ``rule_key`` is optional and only honored for ``approve`` directives. It
       lets plugins choose the allowlist grain for `[a]lways` approvals.
 
-    The first valid directive wins. Invalid or irrelevant hook return values
-    are silently ignored so existing observer-only hooks are unaffected.
+    Directive precedence is ``block`` > ``approve`` > no directive, NOT hook
+    registration order: any plugin's veto wins over another plugin's request
+    for human confirmation. Within a single action the first valid directive
+    wins. Invalid or irrelevant hook return values are silently ignored so
+    existing observer-only hooks are unaffected.
     """
     allowed = getattr(_thread_tool_whitelist, "allowed", None)
     if allowed is not None and tool_name not in allowed:
@@ -6025,6 +6028,10 @@ def _get_pre_tool_call_directive_details(
 
     block_msg: Optional[str] = None
     modified_args: Optional[Dict[str, Any]] = None
+    # A later plugin's block must not be shadowed by an earlier plugin's
+    # approve, so approve is held back until the whole result list has been
+    # scanned for a veto.
+    first_approve: Optional[_PreToolCallDirective] = None
 
     for result in hook_results:
         if not isinstance(result, dict):
@@ -6046,19 +6053,31 @@ def _get_pre_tool_call_directive_details(
             continue
         message = result.get("message")
         message = message if isinstance(message, str) and message else None
-        # A block directive requires a message (it becomes the tool result);
-        # an approve directive can carry an optional reason.
-        if action == "block" and not message:
+        if action == "block":
+            # A block directive requires a message (it becomes the tool
+            # result); a message-less block is invalid and ignored.
+            if not message:
+                continue
+            return _PreToolCallDirective(
+                action="block", message=message, modified_args=modified_args,
+            )
+        # approve — may omit a message (an optional reason).
+        if first_approve is not None:
             continue
-        rule_key = result.get("rule_key") if action == "approve" else None
+        rule_key = result.get("rule_key")
         rule_key = rule_key.strip() if isinstance(rule_key, str) else None
         if not rule_key:
             rule_key = None
-        return _PreToolCallDirective(
-            action=action, message=message, rule_key=rule_key,
-            modified_args=modified_args,
+        # Snapshot the accumulated modify state as it stood when this approve
+        # was seen: deferring the return must not retroactively pull in modify
+        # directives that follow it.
+        first_approve = _PreToolCallDirective(
+            action="approve", message=message, rule_key=rule_key,
+            modified_args=dict(modified_args) if modified_args is not None else None,
         )
 
+    if first_approve is not None:
+        return first_approve
     return _PreToolCallDirective(modified_args=modified_args)
 
 

--- a/tests/hermes_cli/test_plugins.py
+++ b/tests/hermes_cli/test_plugins.py
@@ -1045,6 +1045,93 @@ class TestPreToolCallDirective:
         )
         assert get_pre_tool_call_directive("write_file", {}) == ("approve", None)
 
+    def test_later_block_outranks_earlier_approve(self, monkeypatch):
+        """A security plugin's veto must not be shadowed by an earlier
+        plugin's approve (registration order is not precedence)."""
+        from hermes_cli.plugins import get_pre_tool_call_directive
+        monkeypatch.setattr(
+            "hermes_cli.plugins.invoke_hook",
+            lambda hook_name, **kwargs: [
+                {"action": "approve", "message": "earlier plugin approves"},
+                {"action": "block", "message": "later security plugin blocks"},
+            ],
+        )
+        assert get_pre_tool_call_directive("write_file", {}) == (
+            "block", "later security plugin blocks")
+
+    def test_earlier_block_still_wins(self, monkeypatch):
+        from hermes_cli.plugins import get_pre_tool_call_directive
+        monkeypatch.setattr(
+            "hermes_cli.plugins.invoke_hook",
+            lambda hook_name, **kwargs: [
+                {"action": "block", "message": "security plugin blocks"},
+                {"action": "approve", "message": "later plugin approves"},
+            ],
+        )
+        assert get_pre_tool_call_directive("write_file", {}) == (
+            "block", "security plugin blocks")
+
+    def test_message_less_block_does_not_suppress_approve(self, monkeypatch):
+        """An invalid (message-less) block stays ignored, so the approve
+        directive is still returned rather than swallowed."""
+        from hermes_cli.plugins import get_pre_tool_call_directive
+        monkeypatch.setattr(
+            "hermes_cli.plugins.invoke_hook",
+            lambda hook_name, **kwargs: [
+                {"action": "block"},
+                {"action": "approve", "message": "needs human ok"},
+            ],
+        )
+        assert get_pre_tool_call_directive("write_file", {}) == (
+            "approve", "needs human ok")
+
+    def test_first_approve_wins_among_approves(self, monkeypatch):
+        """Precedence only reorders block vs approve — among approves the
+        first valid one still wins, including its rule_key."""
+        from hermes_cli.plugins import _get_pre_tool_call_directive_details
+        monkeypatch.setattr(
+            "hermes_cli.plugins.invoke_hook",
+            lambda hook_name, **kwargs: [
+                {"action": "nonsense"},
+                {"action": "approve", "message": "first", "rule_key": "write_file:ssh"},
+                {"action": "approve", "message": "second", "rule_key": "write_file:other"},
+            ],
+        )
+        details = _get_pre_tool_call_directive_details("write_file", {})
+        assert details.action == "approve"
+        assert details.message == "first"
+        assert details.rule_key == "write_file:ssh"
+
+    def test_deferred_approve_does_not_absorb_later_modify(self, monkeypatch):
+        """Holding approve back to look for a block must not retroactively
+        pull in modify directives that come after it."""
+        from hermes_cli.plugins import _get_pre_tool_call_directive_details
+        monkeypatch.setattr(
+            "hermes_cli.plugins.invoke_hook",
+            lambda hook_name, **kwargs: [
+                {"action": "modify", "args": {"before": 1}},
+                {"action": "approve", "message": "needs human ok"},
+                {"action": "modify", "args": {"after": 2}},
+            ],
+        )
+        details = _get_pre_tool_call_directive_details("write_file", {"orig": 0})
+        assert details.action == "approve"
+        assert details.modified_args == {"orig": 0, "before": 1}
+
+    def test_block_still_carries_accumulated_modify(self, monkeypatch):
+        """A block returned early keeps the modify state accumulated so far."""
+        from hermes_cli.plugins import _get_pre_tool_call_directive_details
+        monkeypatch.setattr(
+            "hermes_cli.plugins.invoke_hook",
+            lambda hook_name, **kwargs: [
+                {"action": "modify", "args": {"before": 1}},
+                {"action": "block", "message": "vetoed"},
+            ],
+        )
+        details = _get_pre_tool_call_directive_details("write_file", {"orig": 0})
+        assert details.action == "block"
+        assert details.modified_args == {"orig": 0, "before": 1}
+
 
 class TestResolvePreToolBlock:
     """Tests for the single dispatch-site chokepoint that resolves a

--- a/website/docs/user-guide/features/hooks.md
+++ b/website/docs/user-guide/features/hooks.md
@@ -551,7 +551,7 @@ return {"action": "block", "message": "Reason the tool call was blocked"}
 return {"action": "approve", "message": "Why approval is required", "rule_key": "optional:scope"}
 ```
 
-The first valid directive wins (Python plugins registered first, then shell hooks). `block` requires a non-empty `message` and short-circuits the tool with that text as the error returned to the model. `approve` escalates the call to the existing human-approval gate; `message` and `rule_key` are optional, and denial, timeout, or gate error fails closed. Other return values are ignored, so existing observer-only callbacks keep working unchanged.
+Directives are ranked `block` > `approve`, not by hook registration order: one plugin's veto always wins over another plugin's request for confirmation. Within a single action the first valid directive wins (Python plugins registered first, then shell hooks). `block` requires a non-empty `message` and short-circuits the tool with that text as the error returned to the model. `approve` escalates the call to the existing human-approval gate; `message` and `rule_key` are optional, and denial, timeout, or gate error fails closed. Other return values are ignored, so existing observer-only callbacks keep working unchanged.
 
 **Return value — rewrite the tool's arguments:**
 

--- a/website/docs/user-guide/features/hooks.md
+++ b/website/docs/user-guide/features/hooks.md
@@ -561,6 +561,14 @@ return {"action": "modify", "args": {"new_string": "fixed content"}}
 
 The returned `args` dictionary is shallow-merged over the original tool arguments before the tool executes. Multiple `modify` hooks accumulate — each hook's keys are merged into one accumulated dict built from the original args, so hook A changing `path` and hook B changing `content` both survive. If two hooks modify the same key, the later hook wins.
 
+The merge is shallow at every level: a `modify` directive replaces a top-level key, it does not merge into the value underneath it. Return a whole new value for the key you are changing rather than mutating a nested object you received, because nested values are shared with the original arguments and mutating one in place affects every other reader of them.
+
+:::warning Behaviour change for plugin authors
+
+`block` now outranks `approve` regardless of registration order. Previously the first valid directive won outright, so a plugin registered earlier returning `approve` suppressed a later plugin's `block`. If you relied on ordering to let a permissive plugin pre-empt a restrictive one, that pairing now blocks instead of prompting. Nothing changes for hooks that return only one kind of directive, for observer-only hooks, or for `modify`.
+
+:::
+
 Shell hooks also accept the Claude Code-compatible format:
 
 ```json


### PR DESCRIPTION
## What does this PR do?

`_get_pre_tool_call_directive_details()` aggregated plugin `pre_tool_call` results with **first-valid-wins** semantics, so hook registration order — not severity — decided the outcome. A plugin returning `{"action": "approve"}` registered ahead of a security plugin returning `{"action": "block"}` made the block unreachable: the loop returned on the first valid directive of either kind.

That is backwards for the one case the directive exists to serve. An `approve` only escalates to the human-approval gate, but under `approvals.mode: off` (yolo-equivalent) an approve directive means **no prompt at all** — so a Safe Mode / startup-integrity / policy plugin's veto was silently discarded and the tool call ran unchallenged.

The fix holds the first `approve` back until the whole result list has been scanned for a veto, making precedence **`block` > `approve` > no directive** regardless of registration order. This mirrors how the approval layer already treats a deny from any source as decisive, and how the thread tool-whitelist block short-circuits ahead of the hooks.

Deliberately narrow — no change to hook invocation, to the directive shape, or to what counts as a valid directive:

- Within a single action the first valid directive still wins, including its `rule_key` for `approve`.
- A message-less `block` is still invalid and still ignored — and now correctly falls through to a later `approve` rather than swallowing it.
- Invalid/irrelevant return values are still silently ignored, so observer-only hooks are unaffected.

## Related Issue

Fixes #87420

## Type of Change

- [x] 🔒 Security fix

(Also a bug fix; filing it under security because the failure mode is a silently-dropped plugin veto on a tool call.)

## Changes Made

- `hermes_cli/plugins.py` — `_get_pre_tool_call_directive_details()`: return immediately on the first valid `block`; buffer the first valid `approve` and return it only after the full result list has been scanned. Docstring updated to state the precedence rule instead of "the first valid directive wins".
- `tests/hermes_cli/test_plugins.py` — four regression tests in `TestPreToolCallDirective`:
  - `test_later_block_outranks_earlier_approve` — the issue's exact repro (fails before this change, passes after)
  - `test_earlier_block_still_wins` — the reverse order is unchanged
  - `test_message_less_block_does_not_suppress_approve` — an invalid block does not swallow a valid approve
  - `test_first_approve_wins_among_approves` — precedence only reorders block vs approve; among approves the first still wins, `rule_key` included
- `website/docs/user-guide/features/hooks.md` — documented the precedence rule in the `pre_tool_call` directive section, which previously stated only "The first valid directive wins."

## How to Test

Before the change, the reporter's repro returns `('approve', 'earlier plugin approves')`; after it, `('block', 'later security plugin blocks')`:

```bash
python -c "
from unittest.mock import patch
from hermes_cli.plugins import get_pre_tool_call_directive
results = [
    {'action': 'approve', 'message': 'earlier plugin approves'},
    {'action': 'block',   'message': 'later security plugin blocks'},
]
with patch('hermes_cli.lifecycle.invoke_hook', return_value=results):
    print(get_pre_tool_call_directive('write_file', {}))
"
```

Regression tests:

```bash
pytest tests/hermes_cli/test_plugins.py -q          # 60 passed
pytest tests/hermes_cli/test_plugins.py -q -k "PreToolCall or ResolvePreTool"
python scripts/check-windows-footguns.py --all      # clean, 972 files
ruff check hermes_cli/plugins.py tests/hermes_cli/test_plugins.py
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate — searched both the issue number and the fix area (`get_pre_tool_call_directive`, `pre_tool_call` precedence); the only prior work is #58698 (merged, added the `approve` action) and #11816 (open, unrelated to precedence)
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — ran the relevant suites (`tests/hermes_cli/`, `tests/tools/test_approval.py`) rather than the full tree. One pre-existing, unrelated collection error is present on Windows: `tests/hermes_cli/test_doctor_journal_modes.py` fails at import with `AttributeError: module 'os' has no attribute 'geteuid'`. That file is untouched by this PR and fails identically on a clean `upstream/main`.
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11 (Python 3.11 venv)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — docstring + `website/docs/user-guide/features/hooks.md`
- [x] N/A — no config keys added or changed
- [x] N/A — no architecture or workflow change
- [x] I've considered cross-platform impact (Windows, macOS) — pure control-flow change, no platform-specific primitives; `check-windows-footguns.py --all` is clean
- [x] N/A — no tool descriptions or schemas changed

Credit to @yangc222 for the report, the precise root-cause location, and the repro — the semantics implemented here are the ones proposed in the issue.
