### PR TITLE
fix(agent): treat 408/504 as transport errors, finalize single-query agents

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -3008,7 +3008,18 @@ def _is_timeout_error(exc: Exception) -> bool:
         from openai import APITimeoutError
         if isinstance(exc, APITimeoutError):
             return True
-    return "Timeout" in type(exc).__name__ or "timed out" in str(exc).lower()
+    status = getattr(exc, "status_code", None) or getattr(
+        getattr(exc, "response", None), "status_code", None
+    )
+    # HTTP 408/504 consume the request's full critical-path budget just like
+    # SDK timeout exceptions. Treat them as timeouts so compression does not
+    # retry the same origin before fallback.
+    if status in {408, 504}:
+        return True
+    if "Timeout" in type(exc).__name__:
+        return True
+    err_text = str(exc).lower()
+    return "timed out" in err_text or "time-out" in err_text
 
 
 def _is_connection_error(exc: Exception) -> bool:
@@ -3028,6 +3039,16 @@ def _is_connection_error(exc: Exception) -> bool:
     ))
 
 
+def _is_auxiliary_fallback_transport_error(exc: Exception) -> bool:
+    """Return True when the selected auxiliary route cannot serve this call."""
+    if _is_connection_error(exc):
+        return True
+    status = getattr(exc, "status_code", None) or getattr(
+        getattr(exc, "response", None), "status_code", None
+    )
+    return isinstance(status, int) and status in {408, 500, 502, 503, 504}
+
+
 def _is_transient_transport_error(exc: Exception) -> bool:
     """One-off transport blip worth retrying on the SAME provider: connection/stream-close errors plus pure 5xx/408.
 
@@ -3036,7 +3057,7 @@ def _is_transient_transport_error(exc: Exception) -> bool:
     if _is_connection_error(exc):
         return True
     status = getattr(exc, "status_code", None) or getattr(getattr(exc, "response", None), "status_code", None)
-    return isinstance(status, int) and (status == 408 or 500 <= status < 600)
+    return isinstance(status, int) and status in {408, 500, 502, 503, 504}
 
 
 _DEFAULT_TRANSIENT_RETRIES = 2
@@ -6585,7 +6606,7 @@ _RERAISE_ORIGINAL = object()
 _FALLBACK_REASONS: Tuple[Tuple[Callable[[Exception], bool], str], ...] = (
     (_is_auth_error, "auth error"), (_is_payment_error, "payment error"),
     (_is_rate_limit_error, "rate limit"), (_is_model_incompatible_error, "model incompatible with route"),
-    (_is_invalid_aux_response_error, "invalid provider response"), (_is_connection_error, "connection error"),
+    (_is_invalid_aux_response_error, "invalid provider response"), (_is_auxiliary_fallback_transport_error, "connection error"),
 )
 
 
@@ -6604,7 +6625,7 @@ def _rung(step: "_LadderStep", accept: Callable[[Exception], bool]):
 def _param_rung_accepts(exc: Exception) -> bool:
     """After a parameter-strip retry: fall through to the max_tokens/payment/auth
     chains with the stripped kwargs; re-raise anything those chains won't handle."""
-    return (_is_payment_error(exc) or _is_connection_error(exc) or _is_auth_error(exc)
+    return (_is_payment_error(exc) or _is_auxiliary_fallback_transport_error(exc) or _is_auth_error(exc)
             or "max_tokens" in str(exc) or "unsupported_parameter" in str(exc))
 
 
@@ -6660,7 +6681,7 @@ def _ladder_parameter_rungs(
         kwargs.pop("max_completion_tokens", None)
         resp, first_err = yield from _rung(
             _LadderStep("call", (client, kwargs)),
-            lambda exc: _is_payment_error(exc) or _is_connection_error(exc) or _is_rate_limit_error(exc),
+            lambda exc: _is_payment_error(exc) or _is_auxiliary_fallback_transport_error(exc) or _is_rate_limit_error(exc),
         )
         if first_err is None:
             return resp, None, kwargs
@@ -6710,7 +6731,7 @@ def _ladder_nous_rungs(
             "Auxiliary %s%s: refreshed Nous runtime credentials after paid account check, retrying")
         if step is not None:
             resp, first_err = yield from _rung(
-                step, lambda exc: _credential_rung_accepts(exc) or _is_connection_error(exc))
+                step, lambda exc: _credential_rung_accepts(exc) or _is_auxiliary_fallback_transport_error(exc))
             if first_err is None:
                 return resp, None
     if _is_auth_error(first_err) and client_is_nous:
@@ -6870,7 +6891,7 @@ def _aux_recovery_ladder(
     # rebuilds a fresh client instead of reusing the dead one. See issue #23432.
     # Mirror the sync path: drop poisoned clients on connection/timeout so the next aux call rebuilds. See
     # issue #23432.
-    if _is_connection_error(first_err):
+    if _is_auxiliary_fallback_transport_error(first_err):
         try:
             _evict_cached_client_instance(client)
         except Exception:

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -566,6 +566,11 @@ class _SummaryFailureKind:
         return next((reason for flagged, reason in reasons if flagged), "failed")
 
 
+def _is_transient_summary_upstream_status(status: Any) -> bool:
+    """Return True for temporary upstream statuses that must preserve history."""
+    return isinstance(status, int) and status in {408, 500, 502, 503, 504}
+
+
 def _classify_summary_failure(e: Exception) -> _SummaryFailureKind:
     """Classify a summary-call exception by status code / message shape."""
     status = _exc_status_code(e)
@@ -579,7 +584,7 @@ def _classify_summary_failure(e: Exception) -> _SummaryFailureKind:
         # APIResponseValidationError "expecting value"; treat as transient.
         json_decode=isinstance(e, json.JSONDecodeError) or "expecting value" in err,
         # httpx premature-close errors are transient; treat like a timeout, not a 60s cooldown.
-        streaming_closed=_is_connection_error(e),
+        streaming_closed=_is_connection_error(e) or _is_transient_summary_upstream_status(status),
         # HTTP 200 with empty body from a degraded provider, plus the sibling "no usable response"
         # shapes from _validate_llm_response.
         empty_content=isinstance(e, RuntimeError) and any(

--- a/cli.py
+++ b/cli.py
@@ -987,7 +987,14 @@ def _finalize_single_query(cli) -> None:
         _notify_single_query_session_finalize(cli)
         _run_cleanup(notify_session_finalize=False)
     finally:
-        cli._release_active_session()
+        try:
+            agent = getattr(cli, "agent", None)
+            if agent is not None:
+                agent.close()
+        except Exception:
+            logger.warning("Could not close single-query agent", exc_info=True)
+        finally:
+            cli._release_active_session()
 
 
 def _reset_terminal_input_modes_on_exit() -> None:

--- a/tests/cli/test_single_query_session_finalize.py
+++ b/tests/cli/test_single_query_session_finalize.py
@@ -201,3 +201,23 @@ def test_quiet_single_query_main_finalizes_while_preserving_exit_code(monkeypatc
     assert ("claim", "cli", True) in calls
     assert ("run", "hello", []) in calls
     assert calls[-1] == ("finalize", "quiet-session")
+
+
+def test_finalize_single_query_closes_agent(monkeypatch):
+    calls = []
+    fake_agent = SimpleNamespace(
+        session_id="agent-session",
+        platform="cli",
+        close=lambda: calls.append("agent_close"),
+    )
+    fake_cli = SimpleNamespace(
+        agent=fake_agent,
+        session_id="cli-session",
+        _release_active_session=lambda: calls.append("release"),
+    )
+    monkeypatch.setattr(cli, "_notify_single_query_session_finalize", lambda _cli: calls.append("finalize"))
+    monkeypatch.setattr(cli, "_run_cleanup", lambda **kwargs: calls.append("cleanup"))
+
+    cli._finalize_single_query(fake_cli)
+    assert calls == ["finalize", "cleanup", "agent_close", "release"]
+


### PR DESCRIPTION
## What

Three related fixes from production observations:

1. **auxiliary_client**: HTTP 408/504 consume the request's full critical-path budget just like SDK timeout exceptions. They were previously not recognized as timeouts, so compression retried the same origin before falling back. Also adds `_is_auxiliary_fallback_transport_error()` (connection errors + 408/5xx) for capacity/fallback decisions.

2. **context_compressor**: transient upstream summary statuses (408/429/5xx) now mark the summary attempt as a network failure so `compress()` preserves the session instead of dropping context.

3. **cli**: a completed `hermes chat -q` must call `AIAgent.close()` before releasing the lease; otherwise the session row stays active and SDK TLS finalizers can race interpreter teardown.