### PR TITLE
fix(approval,qqbot): skip routine-low tirith warns, re-identify after 4009

### DIFF
--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -395,6 +395,17 @@ class QQAdapter(BasePlatformAdapter):
                     self._access_token = None
                     self._token_expires_at = 0.0
 
+                # QQ sends opcode 7 before 4009 to request a fresh connection.
+                # A stale session cannot be resumed reliably after that pair;
+                # clear the resume cursor so the next Hello performs Identify.
+                if code == 4009 and self._session_id is not None:
+                    logger.info(
+                        "[%s] Session timed out (4009), clearing resume state for re-identify",
+                        self._log_tag,
+                    )
+                    self._session_id = None
+                    self._last_seq = None
+
                 if code in self._SESSION_INVALID_CLOSE_CODES:
                     logger.info("[%s] Session error (%d), clearing session for re-identify", self._log_tag, code)
                     self._session_id = None

--- a/tests/tools/test_approval.py
+++ b/tests/tools/test_approval.py
@@ -2054,3 +2054,54 @@ class TestLifecycleGuardLaunchctlParity:
             "launchctl print system/com.apple.WindowServer",
         ):
             assert contains_gateway_lifecycle_command(cmd) is False, cmd
+
+
+class TestTirithLowSeveritySkip:
+    """Verify that routine low/info severity warnings are skipped, while higher or missing fail closed."""
+
+    def test_skips_low_and_info_warnings(self, monkeypatch):
+        import tools.approval as app
+        from unittest.mock import patch
+        monkeypatch.setenv("HERMES_INTERACTIVE", "1")
+        monkeypatch.setattr(app, "detect_dangerous_command", lambda cmd: (False, None, None))
+        monkeypatch.setattr(app, "_tirith_scan", lambda cmd: {
+            "action": "warn",
+            "findings": [{"rule_id": "r1", "severity": "LOW"}, {"rule_id": "r2", "severity": "INFO"}],
+        })
+        cfg = {"approvals": {"mode": "manual"}}
+        with patch("hermes_cli.config.load_config_readonly", return_value=cfg):
+            decision = app.check_all_command_guards("echo safe", "local")
+        assert decision.get("action") == "allow" or decision.get("approved") is True
+
+    def test_shows_warn_for_high_severity(self, monkeypatch):
+        import tools.approval as app
+        from unittest.mock import patch
+        monkeypatch.setenv("HERMES_INTERACTIVE", "1")
+        monkeypatch.setattr(app, "detect_dangerous_command", lambda cmd: (False, None, None))
+        monkeypatch.setattr(app, "_tirith_scan", lambda cmd: {
+            "action": "warn",
+            "findings": [{"rule_id": "r1", "severity": "HIGH"}],
+        })
+        monkeypatch.setattr(app, "is_approved", lambda sk, tk: False)
+        cfg = {"approvals": {"mode": "manual"}}
+        with patch("hermes_cli.config.load_config_readonly", return_value=cfg):
+            decision = app.check_all_command_guards(
+                "echo dangerous", "local", approval_callback=lambda *a, **kw: "deny")
+        assert decision.get("approved") is False
+
+    def test_missing_severity_fails_closed(self, monkeypatch):
+        import tools.approval as app
+        from unittest.mock import patch
+        monkeypatch.setenv("HERMES_INTERACTIVE", "1")
+        monkeypatch.setattr(app, "detect_dangerous_command", lambda cmd: (False, None, None))
+        monkeypatch.setattr(app, "_tirith_scan", lambda cmd: {
+            "action": "warn",
+            "findings": [{"rule_id": "r1", "severity": ""}],
+        })
+        monkeypatch.setattr(app, "is_approved", lambda sk, tk: False)
+        cfg = {"approvals": {"mode": "manual"}}
+        with patch("hermes_cli.config.load_config_readonly", return_value=cfg):
+            decision = app.check_all_command_guards(
+                "echo suspicious", "local", approval_callback=lambda *a, **kw: "deny")
+        assert decision.get("approved") is False
+

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -1013,10 +1013,18 @@ def check_all_command_guards(command: str, env_type: str,
     session_key = get_current_session_key()
     if tirith_result["action"] in {"block", "warn"}:
         findings = tirith_result.get("findings") or []
-        rule_id = findings[0].get("rule_id", "unknown") if findings else "unknown"
-        tirith_key = f"tirith:{rule_id}"
-        if not is_approved(session_key, tirith_key):
-            warnings.append((tirith_key, _format_tirith_description(tirith_result), True))
+        _skip_low_warn = False
+        if tirith_result["action"] == "warn" and findings:
+            _severities = {str(f.get("severity", "")).strip().upper() for f in findings}
+            # Only skip when all findings carry an explicit, low-risk severity.
+            # A missing or empty severity must fail-closed (show the warning).
+            if _severities and all(s in {"LOW", "INFO"} for s in _severities):
+                _skip_low_warn = True
+        if not _skip_low_warn:
+            rule_id = findings[0].get("rule_id", "unknown") if findings else "unknown"
+            tirith_key = f"tirith:{rule_id}"
+            if not is_approved(session_key, tirith_key):
+                warnings.append((tirith_key, _format_tirith_description(tirith_result), True))
     if is_dangerous and not is_approved(session_key, pattern_key):
         warnings.append((pattern_key, description, False))
     if not warnings:


### PR DESCRIPTION
## What

Two platform/UX fixes:

1. **approval**: when tirith reports `action=warn` and every finding severity is LOW/INFO (routine cleanup demoted by operator policy), skip the interactive approval prompt instead of surfacing a warn modal with no Always button. Block and HIGH/CRITICAL paths are unchanged.

2. **qqbot**: QQ sends opcode 7 before 4009 to request a fresh connection; a stale session cannot be resumed reliably after that pair. Clear the resume cursor so the next Hello performs a full Identify instead of looping on 4009.