### PR TITLE
fix(install): add NixOS-aware Playwright browser path handling

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -2394,6 +2394,30 @@ install_node_deps() {
                         log_warn "Playwright browser installation failed — install dependencies above and retry."
                     }
                     ;;
+                nixos)
+                    # NixOS has no apt/dnf/pacman for Playwright to shell out to, and
+                    # `npx playwright install chromium` downloads into
+                    # $PLAYWRIGHT_BROWSERS_PATH — which, on a system that already
+                    # provides `pkgs.playwright-driver.browsers`, is typically pointed
+                    # at that read-only /nix/store path. Attempting the download there
+                    # fails with EROFS instead of a helpful message, so skip it and
+                    # point the user at the Nix-native path instead.
+                    if [ -n "${PLAYWRIGHT_BROWSERS_PATH:-}" ] && [ ! -w "${PLAYWRIGHT_BROWSERS_PATH}" ]; then
+                        log_warn "PLAYWRIGHT_BROWSERS_PATH ($PLAYWRIGHT_BROWSERS_PATH) is read-only — skipping npx playwright install."
+                        log_info "This is expected if it points at pkgs.playwright-driver.browsers; Chromium is already available there."
+                        log_info "If browser tools can't find it, add pkgs.playwright-driver.browsers to your system/home config and re-export PLAYWRIGHT_BROWSERS_PATH."
+                    else
+                        log_warn "Playwright does not support automatic dependency installation on NixOS."
+                        log_info "Chromium's system libraries are best supplied via pkgs.playwright-driver.browsers (nixpkgs) rather than 'npx playwright install'."
+                        log_info "Add it to your configuration.nix / home-manager config and set:"
+                        log_info "  PLAYWRIGHT_BROWSERS_PATH = \"\${pkgs.playwright-driver.browsers}\";"
+                        log_info "  PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD = \"1\";"
+                        log_info "Falling back to a plain download attempt for now:"
+                        cd "$INSTALL_DIR" && run_playwright_install 600 npx playwright install chromium || {
+                            log_warn "Playwright browser installation failed — see the nixpkgs guidance above."
+                        }
+                    fi
+                    ;;
                 *)
                     log_warn "Playwright does not support automatic dependency installation on $DISTRO."
                     log_info "Install Chromium/browser system dependencies for your distribution, then run:"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -2402,7 +2402,11 @@ install_node_deps() {
                     # at that read-only /nix/store path. Attempting the download there
                     # fails with EROFS instead of a helpful message, so skip it and
                     # point the user at the Nix-native path instead.
-                    if [ -n "${PLAYWRIGHT_BROWSERS_PATH:-}" ] && [ ! -w "${PLAYWRIGHT_BROWSERS_PATH}" ]; then
+                    #
+                    # `-e` guards against treating a not-yet-created (but writable
+                    # once mkdir'd) target dir as read-only — only a path that
+                    # *exists* and fails `-w` is the genuine /nix/store case.
+                    if [ -n "${PLAYWRIGHT_BROWSERS_PATH:-}" ] && [ -e "${PLAYWRIGHT_BROWSERS_PATH}" ] && [ ! -w "${PLAYWRIGHT_BROWSERS_PATH}" ]; then
                         log_warn "PLAYWRIGHT_BROWSERS_PATH ($PLAYWRIGHT_BROWSERS_PATH) is read-only — skipping npx playwright install."
                         log_info "This is expected if it points at pkgs.playwright-driver.browsers; Chromium is already available there."
                         log_info "If browser tools can't find it, add pkgs.playwright-driver.browsers to your system/home config and re-export PLAYWRIGHT_BROWSERS_PATH."
@@ -2412,7 +2416,9 @@ install_node_deps() {
                         log_info "Add it to your configuration.nix / home-manager config and set:"
                         log_info "  PLAYWRIGHT_BROWSERS_PATH = \"\${pkgs.playwright-driver.browsers}\";"
                         log_info "  PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD = \"1\";"
-                        log_info "Falling back to a plain download attempt for now:"
+                        log_info "Falling back to a best-effort download for now — this is NOT the supported"
+                        log_info "path on NixOS and will most likely still fail at runtime on missing system"
+                        log_info "libraries (no apt/dnf to install them from). Use pkgs.playwright-driver.browsers above instead."
                         cd "$INSTALL_DIR" && run_playwright_install 600 npx playwright install chromium || {
                             log_warn "Playwright browser installation failed — see the nixpkgs guidance above."
                         }


### PR DESCRIPTION
Fixes #87457

## Summary
- On NixOS, the installer's distro-detection falls into the generic catch-all branch and runs `npx playwright install chromium`, which downloads into `$PLAYWRIGHT_BROWSERS_PATH`.
- Many NixOS setups point `PLAYWRIGHT_BROWSERS_PATH` at the read-only `/nix/store` path from `pkgs.playwright-driver.browsers` (the idiomatic way to supply Playwright's Chromium on NixOS). The download then fails with `EROFS` instead of a clear message.
- This adds an explicit `nixos)` case: if `PLAYWRIGHT_BROWSERS_PATH` is set and read-only, skip the doomed install and explain that Chromium is likely already available there; otherwise fall back to the existing generic behavior with nixpkgs-specific guidance (`pkgs.playwright-driver.browsers` + `PLAYWRIGHT_BROWSERS_PATH`/`PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD`).

## Test plan
- [x] `bash -n scripts/install.sh` passes
- [x] Reproduced the original failure on a real NixOS/WSL box (`Failed to install browsers / Error: EROFS: read-only file system, mkdir '.../playwright-browsers/__dirlock'`) and confirmed the new branch's messaging/skip logic addresses it
- [ ] Maintainer review of message wording / whether nixpkgs guidance should live elsewhere (e.g. docs)