### PR TITLE
fix(acp): run end-of-session memory commit on session/close

### DIFF
--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -25,6 +25,7 @@ from acp.schema import (
     AvailableCommandsUpdate,
     BlobResourceContents,
     ClientCapabilities,
+    CloseSessionResponse,
     EmbeddedResourceContentBlock,
     ForkSessionResponse,
     ImageContentBlock,
@@ -46,6 +47,7 @@ from acp.schema import (
     SetSessionModeResponse,
     ResourceContentBlock,
     SessionCapabilities,
+    SessionCloseCapabilities,
     SessionForkCapabilities,
     SessionInfoUpdate,
     SessionListCapabilities,
@@ -1162,6 +1164,7 @@ class HermesACPAgent(acp.Agent):
                 load_session=True,
                 prompt_capabilities=PromptCapabilities(image=True),
                 session_capabilities=SessionCapabilities(
+                    close=SessionCloseCapabilities(),
                     fork=SessionForkCapabilities(),
                     list=SessionListCapabilities(),
                     resume=SessionResumeCapabilities(),
@@ -1622,6 +1625,49 @@ class HermesACPAgent(acp.Agent):
 
         next_cursor = sessions[-1].session_id if has_more and sessions else None
         return ListSessionsResponse(sessions=sessions, next_cursor=next_cursor)
+
+    async def close_session(
+        self, session_id: str, **kwargs: Any
+    ) -> Optional[CloseSessionResponse]:
+        """session/close (unstable): the host is done with this session.
+
+        Runs the same end-of-session memory path as CLI exit —
+        ``shutdown_memory_provider`` with the live transcript so memory
+        providers' ``on_session_end`` hooks commit the real conversation
+        (cli.py mirrors this for the #15165 empty-transcript bug) — then
+        drops the session. Without this handler the host's close was a
+        silent no-op, and providers relying on the end-of-session commit
+        (openviking, mem0, honcho, ...) silently lost it in ACP mode
+        (#87448).
+        """
+        state = self.session_manager.get_session(session_id)
+        if state is None:
+            # Idempotent close for an unknown / already-closed session.
+            return CloseSessionResponse()
+
+        def _shutdown_memory() -> None:
+            shutdown = getattr(state.agent, "shutdown_memory_provider", None)
+            if not callable(shutdown):
+                return
+            # Forward the transcript so on_session_end sees the real
+            # conversation, not an empty list.
+            session_msgs = getattr(state.agent, "_session_messages", None)
+            if isinstance(session_msgs, list):
+                shutdown(session_msgs)
+            else:
+                shutdown()
+
+        loop = asyncio.get_running_loop()
+        try:
+            await loop.run_in_executor(_executor, _shutdown_memory)
+        except Exception:
+            logger.warning(
+                "Memory shutdown failed while closing ACP session %s",
+                session_id,
+                exc_info=True,
+            )
+        self.session_manager.remove_session(session_id)
+        return CloseSessionResponse()
 
     # ---- Prompt (core) ------------------------------------------------------
 

--- a/tests/acp/test_server.py
+++ b/tests/acp/test_server.py
@@ -16,6 +16,7 @@ from acp.schema import (
     AgentThoughtChunk,
     AuthenticateResponse,
     AvailableCommandsUpdate,
+    CloseSessionResponse,
     Implementation,
     InitializeResponse,
     LoadSessionResponse,
@@ -360,6 +361,80 @@ class TestListAndFork:
 
 
 
+
+
+# ---------------------------------------------------------------------------
+# session/close
+# ---------------------------------------------------------------------------
+
+
+class TestCloseSession:
+    @pytest.mark.asyncio
+    async def test_close_session_commits_memory_and_removes_session(
+        self, agent, mock_manager
+    ):
+        """#87448: the host's session/close must run the CLI-exit memory path
+        (shutdown_memory_provider with the live transcript, so providers'
+        on_session_end hooks see the real conversation) and then drop the
+        session."""
+        resp = await agent.new_session(cwd=".")
+        state = mock_manager.get_session(resp.session_id)
+
+        calls: list = []
+
+        def _shutdown(messages=None):
+            calls.append(messages)
+
+        state.agent.shutdown_memory_provider = _shutdown
+        state.agent._session_messages = [
+            {"role": "user", "content": "hi"},
+            {"role": "assistant", "content": "hello"},
+        ]
+
+        result = await agent.close_session(session_id=resp.session_id)
+
+        assert isinstance(result, CloseSessionResponse)
+        assert calls == [
+            [
+                {"role": "user", "content": "hi"},
+                {"role": "assistant", "content": "hello"},
+            ]
+        ]
+        assert mock_manager.get_session(resp.session_id) is None
+
+    @pytest.mark.asyncio
+    async def test_close_session_unknown_session_is_idempotent(self, agent):
+        result = await agent.close_session(session_id="nonexistent")
+
+        assert isinstance(result, CloseSessionResponse)
+
+    @pytest.mark.asyncio
+    async def test_router_dispatches_unstable_session_close(
+        self, agent, mock_manager
+    ):
+        """session/close is an unstable method — prove the dispatch wiring
+        (router built with use_unstable_protocol=True, as entry.py does)
+        reaches close_session, not just that the method exists."""
+        new_resp = await agent.new_session(cwd=".")
+        state = mock_manager.get_session(new_resp.session_id)
+
+        calls: list = []
+        state.agent.shutdown_memory_provider = lambda messages=None: calls.append(
+            messages
+        )
+        state.agent._session_messages = [{"role": "user", "content": "hi"}]
+
+        router = build_agent_router(agent, use_unstable_protocol=True)
+        result = await router(
+            "session/close",
+            {"sessionId": new_resp.session_id},
+            False,
+        )
+
+        # normalize_result serializes the (all-default) CloseSessionResponse.
+        assert result == {}
+        assert calls == [[{"role": "user", "content": "hi"}]]
+        assert mock_manager.get_session(new_resp.session_id) is None
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR do?

Gives the ACP adapter a `session/close` handler (#87448). The unstable `session/close` method was never implemented — `entry.py` already runs with `use_unstable_protocol=True`, so the SDK router is willing to dispatch it, but `HermesACPAgent` had no `close_session`, making a host closing a session a silent no-op on the Hermes side. Memory providers that commit at end-of-session via `on_session_end` (openviking, mem0, honcho, hindsight, …) therefore never received their commit in ACP mode — only per-turn tool writes and compaction-time commits survived, so a short session's memory was lost when the host closed/terminated it.

`close_session` now mirrors the CLI exit path (`cli.py` cleanup): it calls `agent.shutdown_memory_provider(_session_messages)` — forwarding the live transcript so `on_session_end` hooks see the real conversation (the #15165 empty-transcript lesson) — on the adapter's executor so a slow provider flush can't block the event loop, then removes the session from the in-memory manager and the persisted DB. Closing an unknown/already-closed session is idempotent. The `close` capability is advertised in `initialize`'s `SessionCapabilities` so hosts know they can use it.

The SIGTERM-graceful-shutdown variant (host kills the process instead of calling `session/close`) is deliberately out of scope — that needs an entry.py signal handler with its own lifecycle questions; the protocol-level close is the clean fix.

## Related Issue

Fixes #87448

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `acp_adapter/server.py` — new `close_session` handler (memory shutdown with transcript on the executor, then `session_manager.remove_session`); `CloseSessionResponse` + `SessionCloseCapabilities` imports; `close=SessionCloseCapabilities()` advertised in `initialize`.
- `tests/acp/test_server.py` — new `TestCloseSession`: close commits memory with the real transcript and removes the session; close of an unknown session is idempotent; the unstable router dispatch (`session/close` → handler) is wired (router built with `use_unstable_protocol=True`, as `entry.py` does).

## How to Test

1. `uv run --extra acp pytest tests/acp/test_server.py -k TestCloseSession -q` — should pass.
2. `uv run --extra acp pytest tests/acp/ -q` — Observed result: `129 passed`.
3. Observed result with the handler removed (unpatched `main`): all three tests fail — `close_session` attribute missing / session never removed — i.e. the no-op close the issue reports.
4. Live: with a memory provider configured, drive `hermes acp` from a host that calls `session/close` (e.g. Paseo archive) and confirm the provider's `on_session_end` fires with the session transcript.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
