### PR TITLE
fix(security): honor fail-closed circuit breaker

### DIFF
--- a/tests/tools/test_tirith_security.py
+++ b/tests/tools/test_tirith_security.py
@@ -629,6 +629,38 @@ class TestSpawnWarningDedup:
 
 
 # ---------------------------------------------------------------------------
+# Circuit-breaker policy must preserve fail-closed semantics
+# ---------------------------------------------------------------------------
+
+class TestCircuitBreakerFailPolicy:
+    @patch("tools.tirith_security._load_security_config")
+    def test_open_circuit_blocks_when_fail_closed(self, mock_cfg):
+        mock_cfg.return_value = {
+            "tirith_enabled": True, "tirith_path": "tirith",
+            "tirith_timeout": 5, "tirith_fail_open": False,
+        }
+        _tirith_mod._circuit_open = True
+
+        result = check_command_security("echo hi")
+
+        assert result["action"] == "block"
+        assert "fail-closed" in result["summary"]
+
+    @patch("tools.tirith_security._load_security_config")
+    def test_open_circuit_still_allows_when_fail_open(self, mock_cfg):
+        mock_cfg.return_value = {
+            "tirith_enabled": True, "tirith_path": "tirith",
+            "tirith_timeout": 5, "tirith_fail_open": True,
+        }
+        _tirith_mod._circuit_open = True
+
+        result = check_command_security("echo hi")
+
+        assert result["action"] == "allow"
+        assert "circuit breaker" in result["summary"]
+
+
+# ---------------------------------------------------------------------------
 # .app TLD suppression (issue #24461)
 # ---------------------------------------------------------------------------
 

--- a/tools/tirith_security.py
+++ b/tools/tirith_security.py
@@ -745,13 +745,22 @@ def check_command_security(command: str) -> dict:
     if not cfg["tirith_enabled"]:
         return {"action": "allow", "findings": [], "summary": ""}
 
-    # Circuit breaker: if tirith has crashed _CRASH_LIMIT times in a row,
-    # stop trying for the rest of the process.  Without this, a corrupted
-    # or missing binary causes every tool call to hit the same spawn failure
-    # → fail-open → agent retry loop, hanging the user for 20+ minutes
-    # (issue #41400).
+    # Circuit breaker: stop invoking a repeatedly failing scanner, but preserve
+    # the configured availability policy. In fail-closed mode an open breaker
+    # must remain a block; otherwise repeated scanner failures silently turn a
+    # strict policy back into fail-open for the rest of the process.
     if _circuit_open:
-        return {"action": "allow", "findings": [], "summary": "tirith disabled (circuit breaker)"}
+        if cfg["tirith_fail_open"]:
+            return {
+                "action": "allow",
+                "findings": [],
+                "summary": "tirith disabled (circuit breaker, fail-open)",
+            }
+        return {
+            "action": "block",
+            "findings": [],
+            "summary": "tirith disabled (circuit breaker, fail-closed)",
+        }
 
     # Unsupported platform (Windows etc.) — tirith has no binary here and
     # never will. Skip the resolver entirely so we don't even try to spawn.


### PR DESCRIPTION
## Problem

When tirith is configured `fail-closed` (`tirith_fail_open: false`), repeated
scanner spawn failures open the crash circuit breaker — and the open breaker
returns `{"action": "allow"}` unconditionally. A strict fail-closed policy is
therefore silently converted back into fail-open for the rest of the process:

```python
if _circuit_open:
    return {"action": "allow", "findings": [], "summary": "tirith disabled (circuit breaker)"}
```

A corrupted or missing tirith binary then turns every tool call into a silent
allow — the exact opposite of the configured availability policy.

## Fix

Honor the configured policy when the breaker is open:

- `tirith_fail_open: true` → keep current behavior (`allow`, summary notes fail-open)
- `tirith_fail_open: false` → `block` with `fail-closed` summary

## Tests

Two new cases in `TestCircuitBreakerFailPolicy` (tests/tools/test_tirith_security.py):

- open circuit + fail-closed config → action must be `block`, summary contains `fail-closed`
- open circuit + fail-open config → action must be `allow` (regression guard)

Full file: 43 passed locally.

## Context

This fix has been running on a production deployment since 2026-08-10 as a
local patch; a `hermes update` to v0.20.1 upstreamed 51 commits and dropped
the local patch (upstream main still has the fail-open circuit-breaker
behavior), so this PR re-proposes it upstream.
