### PR TITLE
feat(zai): add glm-5.3 support (1M context, coding-plan probes, reasoning_effort)

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -501,12 +501,13 @@ DEFAULT_CONTEXT_LENGTHS = {
     # https://platform.minimax.io/docs/api-reference/text-chat-openai
     "minimax-m3": 1000000,
     "minimax": 204800,
-    # GLM — GLM-5.2 ships with a 1M context window (verified empirically:
-    # needle-in-a-haystack retrieval at 789K prompt tokens succeeded with
-    # zero errors on api.z.ai/api/coding/paas/v4).  Older GLM models
-    # (5, 5.1, 5-turbo) are ~202K.  Longest-key-first substring matching
-    # ensures "glm-5.2" resolves to 1M while older variants still hit the
-    # generic 202K fallback.
+    # GLM — GLM-5.2 and GLM-5.3 ship with a 1M context window (5.2 verified
+    # empirically: needle-in-a-haystack retrieval at 789K prompt tokens
+    # succeeded with zero errors on api.z.ai/api/coding/paas/v4; 5.3 matches
+    # per Z.AI release docs).  Older GLM models (5, 5.1, 5-turbo) are ~202K.
+    # Longest-key-first substring matching ensures "glm-5.2"/"glm-5.3"
+    # resolve to 1M while older variants still hit the generic 202K fallback.
+    "glm-5.3": 1_048_576,
     "glm-5.2": 1_048_576,
     "glm": 202752,
     # xAI Grok — xAI /v1/models does not return context_length metadata,

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -733,8 +733,8 @@ ZAI_ENDPOINTS = [
     # (id, base_url, probe_models, label)
     ("global",        "https://api.z.ai/api/paas/v4",        ["glm-5"],   "Global"),
     ("cn",            "https://open.bigmodel.cn/api/paas/v4", ["glm-5"],   "China"),
-    ("coding-global", "https://api.z.ai/api/coding/paas/v4",  ["glm-5.2", "glm-5.1", "glm-5v-turbo", "glm-4.7"], "Global (Coding Plan)"),
-    ("coding-cn",     "https://open.bigmodel.cn/api/coding/paas/v4", ["glm-5.2", "glm-5.1", "glm-5v-turbo", "glm-4.7"], "China (Coding Plan)"),
+    ("coding-global", "https://api.z.ai/api/coding/paas/v4",  ["glm-5.3", "glm-5.2", "glm-5.1", "glm-5v-turbo", "glm-4.7"], "Global (Coding Plan)"),
+    ("coding-cn",     "https://open.bigmodel.cn/api/coding/paas/v4", ["glm-5.3", "glm-5.2", "glm-5.1", "glm-5v-turbo", "glm-4.7"], "China (Coding Plan)"),
 ]
 
 

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -363,6 +363,7 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "gemini-3.1-flash-lite-preview",
     ],
     "zai": [
+        "glm-5.3",
         "glm-5.2",
         "glm-5.1",
         "glm-5",

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -99,7 +99,7 @@ _DEFAULT_PROVIDER_MODELS = {
         "google/gemini-3-flash-preview", "google/gemini-3.1-flash-lite-preview",
         "google/gemini-2.5-pro", "google/gemini-2.5-flash",
     ],
-    "zai": ["glm-5.2", "glm-5.1", "glm-5", "glm-4.7", "glm-4.5", "glm-4.5-flash"],
+    "zai": ["glm-5.3", "glm-5.2", "glm-5.1", "glm-5", "glm-4.7", "glm-4.5", "glm-4.5-flash"],
     "kimi-coding": ["kimi-k3", "kimi-k2.6", "kimi-k2.5", "kimi-k2-thinking", "kimi-k2-turbo-preview"],
     "kimi-coding-cn": ["kimi-k3", "kimi-k2.6", "kimi-k2.5", "kimi-k2-thinking", "kimi-k2-turbo-preview"],
     "stepfun": ["step-3.5-flash", "step-3.5-flash-2603"],

--- a/plugins/model-providers/zai/__init__.py
+++ b/plugins/model-providers/zai/__init__.py
@@ -59,6 +59,19 @@ def _is_glm_5_2(model: str | None) -> bool:
     return any(token in m for token in ("glm-5.2", "glm-5-2", "glm-5p2"))
 
 
+def _is_glm_5_3(model: str | None) -> bool:
+    """Detect GLM-5.3 across the alias spellings providers use.
+
+    GLM-5.3 exposes the same native ``reasoning_effort`` knob (``high`` /
+    ``max``) as GLM-5.2 on the OpenAI-compatible endpoint, so it shares the
+    same effort-mapping path.
+    """
+    m = (model or "").strip().lower()
+    if not m:
+        return False
+    return any(token in m for token in ("glm-5.3", "glm-5-3", "glm-5p3"))
+
+
 def _glm_5_2_reasoning_effort(reasoning_config: dict | None) -> str | None:
     """Map Hermes reasoning effort onto GLM-5.2's native ``high``/``max``.
 
@@ -91,7 +104,7 @@ class ZaiProfile(ProviderProfile):
         extra_body: dict[str, Any] = {}
         top_level: dict[str, Any] = {}
 
-        if not _model_supports_thinking(model) and not _is_glm_5_2(model):
+        if not _model_supports_thinking(model) and not _is_glm_5_2(model) and not _is_glm_5_3(model):
             return extra_body, top_level
 
         # Only emit when the user expressed a preference; omitting the field
@@ -100,7 +113,7 @@ class ZaiProfile(ProviderProfile):
             enabled = reasoning_config.get("enabled") is not False
             extra_body["thinking"] = {"type": "enabled" if enabled else "disabled"}
 
-        if _is_glm_5_2(model):
+        if _is_glm_5_2(model) or _is_glm_5_3(model):
             effort = _glm_5_2_reasoning_effort(reasoning_config)
             if effort is not None:
                 top_level["reasoning_effort"] = effort
@@ -116,6 +129,7 @@ zai = ZaiProfile(
     description="Z.AI / GLM — Zhipu AI models",
     signup_url="https://z.ai/",
     fallback_models=(
+        "glm-5.3",
         "glm-5.2",
         "glm-5",
         "glm-4-9b",

--- a/tests/plugins/model_providers/test_zai_profile.py
+++ b/tests/plugins/model_providers/test_zai_profile.py
@@ -124,6 +124,44 @@ class TestZaiGLM52ReasoningEffort:
         )
         assert top_level == {"reasoning_effort": "max"}
 
+class TestZaiGLM53ReasoningEffort:
+    """GLM-5.3 shares GLM-5.2's native ``reasoning_effort`` knob."""
+
+    @pytest.mark.parametrize(
+        "model",
+        ["glm-5.3", "z-ai/glm-5.3", "glm-5-3", "glm-5p3"],
+    )
+    def test_alias_spellings_recognized(self, zai_profile, model):
+        _, top_level = zai_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": True, "effort": "max"},
+            model=model,
+        )
+        assert top_level == {"reasoning_effort": "max"}
+
+    def test_high_maps_to_high(self, zai_profile):
+        extra_body, top_level = zai_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": True, "effort": "high"},
+            model="glm-5.3",
+        )
+        assert extra_body == {"thinking": {"type": "enabled"}}
+        assert top_level == {"reasoning_effort": "high"}
+
+    def test_strong_efforts_map_to_max(self, zai_profile):
+        extra_body, top_level = zai_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": True, "effort": "xhigh"},
+            model="glm-5.3",
+        )
+        assert extra_body == {"thinking": {"type": "enabled"}}
+        assert top_level == {"reasoning_effort": "max"}
+
+    def test_disabled_sends_no_effort(self, zai_profile):
+        extra_body, top_level = zai_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": False, "effort": "high"},
+            model="glm-5.3",
+        )
+        assert extra_body == {"thinking": {"type": "disabled"}}
+        assert top_level == {}
+
     @pytest.mark.parametrize(
         "model",
         ["glm-5.1", "glm-5", "glm-4.7", "glm-4-9b", "", None],


### PR DESCRIPTION
## Summary
- Adds glm-5.3 to the zai provider across the full model surface: `hermes_cli/models.py` picker list, `hermes_cli/setup.py` wizard list, `hermes_cli/auth.py` coding-plan endpoint probes (global + CN), `agent/model_metadata.py` context table, and the zai provider plugin (`fallback_models` + `_is_glm_5_3()` alias matcher).
- Context: glm-5.3 ships with a **1M context window**, same as glm-5.2 (verified against the live Z.AI coding-plan endpoint — model listed since Aug 14). Without its own `DEFAULT_CONTEXT_LENGTHS` entry, longest-key-first substring matching falls through to the generic glm fallback (202,752).
- glm-5.3 shares glm-5.2's native `reasoning_effort` (`high`/`max`) knob on the OpenAI-compatible endpoint, so the alias matcher reuses the same effort-mapping path.
- Deliberately **not** added to OpenRouter/nous lists: model not yet on OpenRouter's live catalog (verified); those lists fetch live catalogs so entries appear automatically once listed.

## Testing
- `tests/plugins/model_providers/test_zai_profile.py` — new `TestZaiGLM53ReasoningEffort` class (alias spellings param, high→high, xhigh→max, disabled→no effort): 36 zai profile tests pass.
- Adjacent suites: `tests/hermes_cli/test_model_validation.py` + `tests/hermes_cli/test_provider_live_curated_merge.py` — 67 passed total.
- `get_model_context_length`: glm-5.3 → 1,048,576; glm-5.2 → 1,048,576; glm-5.1 → 204,800 (older variants unaffected).