### PR TITLE
fix(telegram): log the ImportError that stubs the platform classes

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -233,6 +233,34 @@ async def _shutdown_abandoned_app(app) -> None:
         except Exception:
             logger.debug("Abandoned Telegram request shutdown failed", exc_info=True)
 
+def _report_telegram_import_failure() -> None:
+    """Log the swallowed ImportError that stubbed the Telegram classes.
+
+    Distinguishes a clean "package not installed" (a legitimate optional-
+    dependency state — debug only, no noise) from "installed but failed to
+    import" (broken or racing install, e.g. a pip dependency sync still
+    writing dist-info while the gateway restarts). The latter used to
+    surface only much later as the misleading downstream
+    ``Any cannot be instantiated`` error, with the real cause swallowed
+    (#87455).
+    """
+    try:
+        import importlib.util as _importlib_util
+
+        present = _importlib_util.find_spec("telegram") is not None
+    except Exception:
+        present = True  # cannot tell — assume broken and log the cause
+    if present:
+        logger.warning(
+            "[Telegram] python-telegram-bot is installed but failed to "
+            "import; the Telegram platform will be unavailable until the "
+            "process restarts",
+            exc_info=True,
+        )
+    else:
+        logger.debug("python-telegram-bot not installed; Telegram platform disabled")
+
+
 try:
     from telegram import Update, Bot, Message, InlineKeyboardButton, InlineKeyboardMarkup
     try:
@@ -252,6 +280,7 @@ try:
     from telegram.request import HTTPXRequest
     TELEGRAM_AVAILABLE = True
 except ImportError:
+    _report_telegram_import_failure()
     TELEGRAM_AVAILABLE = False
     Update = Any
     Bot = Any

--- a/tests/gateway/test_telegram_connect.py
+++ b/tests/gateway/test_telegram_connect.py
@@ -54,3 +54,60 @@ class TestTelegramUnconfiguredNonRetryable:
         assert adapter.fatal_error_retryable is False
         assert adapter.fatal_error_code == "missing_dependency"
 
+
+class TestTelegramImportFailureReporting:
+    """#87455: the ImportError that stubs the Telegram classes must be
+    diagnosable at the stub site — present-but-broken logs the swallowed
+    traceback; a clean not-installed stays quiet (debug only)."""
+
+    def test_installed_but_broken_import_logs_warning_with_traceback(
+        self, monkeypatch, caplog
+    ):
+        import importlib.util
+        import logging
+
+        monkeypatch.setattr(importlib.util, "find_spec", lambda name: object())
+
+        with caplog.at_level(logging.DEBUG):
+            try:
+                raise ImportError("partial dist-info race")
+            except ImportError:
+                telegram_mod._report_telegram_import_failure()
+
+        assert "failed to import" in caplog.text
+        assert any(record.exc_info for record in caplog.records)
+
+    def test_not_installed_stays_debug_only(self, monkeypatch, caplog):
+        import importlib.util
+        import logging
+
+        monkeypatch.setattr(importlib.util, "find_spec", lambda name: None)
+
+        with caplog.at_level(logging.DEBUG):
+            try:
+                raise ImportError("No module named 'telegram'")
+            except ImportError:
+                telegram_mod._report_telegram_import_failure()
+
+        assert "not installed" in caplog.text
+        assert not [
+            record for record in caplog.records if record.levelno >= logging.WARNING
+        ]
+
+    def test_unprobeable_install_is_treated_as_broken(self, monkeypatch, caplog):
+        import importlib.util
+        import logging
+
+        def _explode(name):
+            raise ValueError("finder misbehaving")
+
+        monkeypatch.setattr(importlib.util, "find_spec", _explode)
+
+        with caplog.at_level(logging.DEBUG):
+            try:
+                raise ImportError("original cause")
+            except ImportError:
+                telegram_mod._report_telegram_import_failure()
+
+        assert "failed to import" in caplog.text
+


### PR DESCRIPTION
## What does this PR do?

Makes the Telegram platform's silent ImportError diagnosable (#87455). `plugins/platforms/telegram/adapter.py` binds every Telegram class to `typing.Any` when `python-telegram-bot` fails to import, without recording why. A transient failure (e.g. a pip dependency sync racing a gateway restart, mid-written `dist-info`) then surfaced only much later as the misleading `Any cannot be instantiated` error, with the real cause swallowed.

`_report_telegram_import_failure()` is now called at the stub site and discriminates:

- **Clean not-installed** — a legitimate optional-dependency state (the platform is simply disabled): debug-level only, no noise for users who never configured Telegram.
- **Installed but failed to import** — broken or racing install: a `logger.warning` with `exc_info=True` carrying the original traceback, so operators see the actual `ModuleNotFoundError` instead of the downstream red herring.
- **Unprobeable** (`find_spec` itself raises): treated as broken, so the cause is logged rather than dropped.

Verified end-to-end by simulating a partial install (a meta-path finder pointing at a package whose `__init__` raises `ModuleNotFoundError`): the adapter now logs

```
WARNING plugins.platforms.telegram.adapter [Telegram] python-telegram-bot is installed but failed to import; the Telegram platform will be unavailable until the process restarts
ModuleNotFoundError: No module named 'telegram._partial'; 'telegram' is not a package
```

while still degrading gracefully (`TELEGRAM_AVAILABLE = False`).

## Related Issue

Fixes #87455

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/platforms/telegram/adapter.py` — new module-level `_report_telegram_import_failure()` (import-site diagnostics, discriminating not-installed vs installed-but-broken via `importlib.util.find_spec`), invoked from the `except ImportError:` stub block.
- `tests/gateway/test_telegram_connect.py` — three tests: installed-but-broken logs a warning carrying the traceback; clean not-installed stays debug-only with no warning records; an unprobeable install is treated as broken.

## How to Test

1. `uv run --extra acp pytest tests/gateway/test_telegram_connect.py -q` — Observed result: `4 passed`.
2. `uv run --extra acp pytest tests/test_telegram_polling_progress_ptb.py -q` — Observed result: `6 passed`.
3. Simulate the reported race (partial install whose import raises): a meta-path finder pointing at a package with `from telegram._partial import something` in `__init__.py`, then import the adapter — Observed result: the warning above with the real `ModuleNotFoundError`, and `TELEGRAM_AVAILABLE` still `False`.
4. With the package absent (or blocked via `sys.modules['telegram'] = None`), importing the adapter logs only the debug line `python-telegram-bot not installed; Telegram platform disabled`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
