### PR TITLE
Bind dashboard token routes to providers and scopes

### DIFF
--- a/hermes_cli/dashboard_auth/token_auth.py
+++ b/hermes_cli/dashboard_auth/token_auth.py
@@ -12,10 +12,10 @@ How it fits the existing auth framework:
     cookie — it presents a bearer token in the ``Authorization`` header on a
     single request. That is what this seam verifies.
 
-  * A route opts in by registering its exact path via
-    :func:`register_token_route`. Only registered paths are token-authable;
-    everything else is untouched, so this can never accidentally widen the
-    auth surface of an existing route.
+  * A route opts in by registering its exact path, owning provider, and optional
+    required scopes via :func:`register_token_route`. Only registered paths are
+    token-authable, and credentials from one provider cannot authenticate a
+    different provider's route.
 
   * :func:`token_auth_middleware` runs OUTERMOST (installed last in
     ``web_server.py``). For a token route it fully owns the auth decision:
@@ -27,23 +27,25 @@ How it fits the existing auth framework:
     gates honour ``token_authenticated`` and skip enforcement, so a
     token-authed service request is never bounced to ``/login``.
 
-  * Fails closed: a token route with no registered token provider, no token,
-    or an unrecognised token gets 401 — never an open pass-through.
+  * Fails closed: a token route with no registered owning provider, no token,
+    an unrecognised token, or insufficient scopes gets rejected — never an open
+    pass-through.
 
-Provider stacking mirrors ``verify_session``: each ``supports_token`` provider
-is consulted in registration order until one returns a principal. A provider
-that doesn't recognise the token returns ``None`` and the seam moves on; a
-provider whose backing store is unreachable raises ``ProviderError``, which the
-seam remembers and surfaces as 503 only if NO provider accepts the token.
+Provider stacking remains available to direct callers of ``authenticate_token``;
+the middleware filters the stack to the provider that owns the matched route.
+A provider outage surfaces as 503 only when that owning provider cannot decide.
 """
 from __future__ import annotations
 
 import logging
 import threading
-from typing import Awaitable, Callable, Optional, Tuple
+from dataclasses import dataclass, field
+from typing import Awaitable, Callable, Iterable, Optional, Tuple
 
 from fastapi import Request
 from fastapi.responses import JSONResponse, Response
+
+from hermes_constants import hermes_home_key
 
 from hermes_cli.dashboard_auth import list_token_providers
 from hermes_cli.dashboard_auth.audit import AuditEvent, audit_log
@@ -51,27 +53,113 @@ from hermes_cli.dashboard_auth.base import ProviderError, TokenPrincipal
 
 _log = logging.getLogger(__name__)
 
-# Exact paths that accept non-interactive bearer-token auth. A route registers
-# itself here at import/startup; the seam only acts on registered paths.
-_token_routes: set[str] = set()
+@dataclass(frozen=True)
+class TokenRoutePolicy:
+    """Exact machine-auth ownership and authorization requirements for a route."""
+
+    provider: str
+    required_scopes: frozenset[str] = frozenset()
+
+
+@dataclass
+class TokenRouteRegistration:
+    """Disposable ownership of one profile-scoped token-route policy."""
+
+    scope: str
+    path: str
+    _registration_id: object = field(repr=False)
+    _disposed: bool = field(default=False, init=False, repr=False)
+
+    @property
+    def active(self) -> bool:
+        return not self._disposed
+
+    def dispose(self) -> None:
+        if self._disposed:
+            return
+        self._disposed = True
+        with _lock:
+            key = (self.scope, self.path)
+            registrations = _token_routes.get(key)
+            if registrations is None:
+                return
+            registrations.pop(self._registration_id, None)
+            if not registrations:
+                _token_routes.pop(key, None)
+
+
+# Route policies are profile-scoped and reference-counted by registration handle.
+# A path with differing live policies is poisoned and denied until the conflict
+# is removed; no registration can silently retain or steal first-writer authority.
+_token_routes: dict[tuple[str, str], dict[object, TokenRoutePolicy]] = {}
 _lock = threading.Lock()
 
 
-def register_token_route(path: str) -> None:
-    """Mark ``path`` (exact match) as token-authable.
+def register_token_route(
+    path: str,
+    *,
+    provider: Optional[str] = None,
+    required_scopes: Iterable[str] = (),
+    scope: Optional[str] = None,
+) -> Optional[TokenRouteRegistration]:
+    """Register a profile-scoped exact token route and return its cleanup handle.
 
-    Idempotent. Call at module import / app setup so the seam knows which
-    routes to guard. Registering a route does NOT make it public — it makes
-    it authenticate by token instead of by session cookie.
+    Every active token route must name its owning token provider. Calls using the
+    original one-argument API are accepted for source compatibility but register
+    nothing, leaving the route under ordinary interactive authentication until
+    the caller migrates to an explicit provider. Required scopes are
+    canonicalized as a set. Conflicting policies make the route fail closed
+    until the conflicting registration is disposed.
     """
+    if provider is None:
+        _log.warning(
+            "dashboard-auth: ignored unowned token route %r; pass provider= explicitly",
+            path,
+        )
+        return None
+    if isinstance(required_scopes, (str, bytes)):
+        raise ValueError("invalid token route policy")
+    try:
+        scopes = frozenset(required_scopes)
+    except TypeError as exc:
+        raise ValueError("invalid token route policy") from exc
+    if (
+        not isinstance(path, str)
+        or not path.startswith("/")
+        or "?" in path
+        or "#" in path
+        or not isinstance(provider, str)
+        or not provider
+        or any(not isinstance(item, str) or not item for item in scopes)
+        or not isinstance(scope, (str, type(None)))
+        or scope == ""
+    ):
+        raise ValueError("invalid token route policy")
+    route_scope = scope or hermes_home_key()
+    registration_id = object()
+    policy = TokenRoutePolicy(provider=provider, required_scopes=scopes)
     with _lock:
-        _token_routes.add(path)
+        _token_routes.setdefault((route_scope, path), {})[registration_id] = policy
+    return TokenRouteRegistration(route_scope, path, registration_id)
 
 
-def is_token_route(path: str) -> bool:
-    """True if ``path`` was registered as token-authable (exact match)."""
+def _token_route_policy(
+    path: str, *, scope: Optional[str] = None
+) -> tuple[Optional[TokenRoutePolicy], bool]:
     with _lock:
-        return path in _token_routes
+        registrations = _token_routes.get((scope or hermes_home_key(), path), {})
+        policies = set(registrations.values())
+    if not policies:
+        return None, False
+    if len(policies) != 1:
+        return None, True
+    return next(iter(policies)), False
+
+
+def is_token_route(path: str, *, scope: Optional[str] = None) -> bool:
+    """True if ``path`` has any live token-route registration in the profile."""
+    policy, conflict = _token_route_policy(path, scope=scope)
+    return policy is not None or conflict
 
 
 def clear_token_routes() -> None:
@@ -103,6 +191,8 @@ def extract_bearer_token(request: Request) -> str:
 
 def authenticate_token(
     request: Request,
+    *,
+    provider_name: Optional[str] = None,
 ) -> Tuple[Optional[TokenPrincipal], Optional[str]]:
     """Try every token provider against the request's bearer token.
 
@@ -120,6 +210,8 @@ def authenticate_token(
         return None, None
     unreachable: Optional[str] = None
     for provider in list_token_providers():
+        if provider_name is not None and provider.name != provider_name:
+            continue
         try:
             principal = provider.verify_token(token=token)
         except ProviderError as e:
@@ -137,6 +229,13 @@ def authenticate_token(
             )
             continue
         if principal is not None:
+            if principal.provider != provider.name:
+                _log.warning(
+                    "dashboard-auth: token provider %r returned principal for %r",
+                    provider.name,
+                    principal.provider,
+                )
+                continue
             return principal, None
     return None, unreachable
 
@@ -160,11 +259,37 @@ async def token_auth_middleware(
     enforcement, so a token-authed request is never redirected to ``/login``.
     """
     path = request.url.path
-    if not is_token_route(path):
+    policy, conflict = _token_route_policy(path)
+    if conflict:
+        audit_log(
+            AuditEvent.TOKEN_AUTH_FAILURE,
+            reason="route_policy_conflict",
+            path=path,
+            ip=_client_ip(request),
+        )
+        return JSONResponse(
+            {"error": "unavailable", "detail": "Token route unavailable"},
+            status_code=503,
+        )
+    if policy is None:
         return await call_next(request)
 
-    principal, unreachable = authenticate_token(request)
+    principal, unreachable = authenticate_token(
+        request, provider_name=policy.provider
+    )
     if principal is not None:
+        if not set(policy.required_scopes).issubset(principal.scopes):
+            audit_log(
+                AuditEvent.TOKEN_AUTH_FAILURE,
+                provider=principal.provider,
+                reason="insufficient_scope",
+                path=path,
+                ip=_client_ip(request),
+            )
+            return JSONResponse(
+                {"error": "forbidden", "detail": "Forbidden"},
+                status_code=403,
+            )
         request.state.token_principal = principal
         request.state.token_authenticated = True
         return await call_next(request)

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -2422,6 +2422,40 @@ class PluginContext:
         )
         return handle
 
+    def register_dashboard_token_route(
+        self,
+        path: str,
+        *,
+        provider: str,
+        required_scopes=(),
+    ) -> PluginRegistration:
+        """Register a profile-scoped machine-auth route with unload cleanup.
+
+        The provider must be registered separately through
+        :meth:`register_dashboard_auth_provider`; callers should stop if that
+        registration returns ``None``. Conflicting live route policies are
+        retained as a fail-closed poison until one owner unloads.
+        """
+        from hermes_cli.dashboard_auth.token_auth import register_token_route
+
+        registration = register_token_route(
+            path,
+            provider=provider,
+            required_scopes=required_scopes,
+            scope=self._manager.scope_key,
+        )
+        if registration is None:  # Explicit providers always produce a handle.
+            raise RuntimeError("dashboard token route registration was inert")
+        try:
+            return self._track(
+                "dashboard_token_route",
+                path,
+                registration.dispose,
+            )
+        except Exception:
+            registration.dispose()
+            raise
+
     # -- video gen provider registration -------------------------------------
 
     @_serialized_replacement

--- a/plugins/dashboard_auth/drain/__init__.py
+++ b/plugins/dashboard_auth/drain/__init__.py
@@ -270,19 +270,28 @@ def register(ctx) -> None:
         logger.warning("dashboard-auth-drain: %s", LAST_SKIP_REASON)
         return
 
-    ctx.register_dashboard_auth_provider(provider)
+    provider_registration = ctx.register_dashboard_auth_provider(provider)
+    if provider_registration is None:
+        LAST_SKIP_REASON = "Drain authentication provider registration failed; route disabled."
+        logger.warning("dashboard-auth-drain: %s", LAST_SKIP_REASON)
+        return
 
     # Opt the begin/cancel-drain endpoint into the generic token-auth seam so
     # the dashboard's interactive cookie gate doesn't bounce NAS's bearer call.
     try:
-        from hermes_cli.dashboard_auth.token_auth import register_token_route
-
-        register_token_route(DRAIN_ROUTE_PATH)
-    except Exception as exc:  # noqa: BLE001 — seam import must not crash plugin load
+        ctx.register_dashboard_token_route(
+            DRAIN_ROUTE_PATH,
+            provider=provider.name,
+            required_scopes=(scope,),
+        )
+    except Exception as exc:  # noqa: BLE001 — fail closed without crashing host
+        provider_registration.dispose()
+        LAST_SKIP_REASON = f"Drain token route registration failed: {exc}"
         logger.warning(
             "dashboard-auth-drain: could not register token route %s: %s",
             DRAIN_ROUTE_PATH, exc,
         )
+        return
 
     logger.info(
         "dashboard-auth-drain: registered drain service-credential provider "

--- a/tests/hermes_cli/test_dashboard_auth_plugin_hook.py
+++ b/tests/hermes_cli/test_dashboard_auth_plugin_hook.py
@@ -5,12 +5,17 @@ art).
 """
 from __future__ import annotations
 
-import pytest
+import asyncio
 
-from hermes_cli.dashboard_auth import clear_providers, get_provider
+import pytest
+from starlette.requests import Request
+from starlette.responses import JSONResponse
+
+from hermes_constants import hermes_home_key
+from hermes_cli.dashboard_auth import clear_providers, get_provider, register_provider
 from hermes_cli.dashboard_auth import token_auth
 from hermes_cli.dashboard_auth.base import (
-    DashboardAuthProvider, LoginStart, Session,
+    DashboardAuthProvider, LoginStart, Session, TokenPrincipal,
 )
 from hermes_cli.plugins import PluginContext, PluginManifest, PluginRegistration
 
@@ -18,6 +23,16 @@ from hermes_cli.plugins import PluginContext, PluginManifest, PluginRegistration
 class _Stub(DashboardAuthProvider):
     name = "stub"
     display_name = "Stub IdP"
+    supports_token = True
+
+    def verify_token(self, *, token):
+        if token != "profile-secret":
+            return None
+        return TokenPrincipal(
+            principal="profile-client",
+            provider=self.name,
+            scopes=("write",),
+        )
 
     def start_login(self, *, redirect_uri):
         return LoginStart(redirect_url="x", cookie_payload={})
@@ -33,6 +48,10 @@ class _Stub(DashboardAuthProvider):
 
     def revoke_session(self, *, refresh_token):
         return None
+
+
+async def _call_next_ok(_request):
+    return JSONResponse({"ok": True})
 
 
 class _MinimalManager:
@@ -98,6 +117,38 @@ def test_plugin_ctx_token_route_handle_cleans_up_profile_scoped_policy():
     assert not token_auth.is_token_route(
         "/api/plugin/machine", scope=_MinimalManager.scope_key
     )
+
+
+def test_active_profile_plugin_route_is_visible_to_token_middleware(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    manager = _MinimalManager()
+    manager.scope_key = hermes_home_key()
+    manifest = PluginManifest(name="dashboard-auth-active", version="0.0.1")
+    ctx = PluginContext(manifest=manifest, manager=manager)  # type: ignore[arg-type]
+    register_provider(_Stub())
+    handle = ctx.register_dashboard_token_route(
+        "/api/plugin/machine",
+        provider="stub",
+        required_scopes=("write",),
+    )
+    request = Request(
+        {
+            "type": "http",
+            "scheme": "https",
+            "server": ("example.test", 443),
+            "client": ("127.0.0.1", 1234),
+            "path": "/api/plugin/machine",
+            "query_string": b"",
+            "headers": [(b"authorization", b"Bearer profile-secret")],
+        }
+    )
+
+    response = asyncio.run(token_auth.token_auth_middleware(request, _call_next_ok))
+
+    assert response.status_code == 200
+    assert request.state.token_authenticated is True
+    assert request.state.token_principal.provider == "stub"
+    handle.dispose()
 
 
 def test_plugin_ctx_token_route_tracking_failure_rolls_back_raw_registration():

--- a/tests/hermes_cli/test_dashboard_auth_plugin_hook.py
+++ b/tests/hermes_cli/test_dashboard_auth_plugin_hook.py
@@ -8,10 +8,11 @@ from __future__ import annotations
 import pytest
 
 from hermes_cli.dashboard_auth import clear_providers, get_provider
+from hermes_cli.dashboard_auth import token_auth
 from hermes_cli.dashboard_auth.base import (
     DashboardAuthProvider, LoginStart, Session,
 )
-from hermes_cli.plugins import PluginContext, PluginManifest
+from hermes_cli.plugins import PluginContext, PluginManifest, PluginRegistration
 
 
 class _Stub(DashboardAuthProvider):
@@ -46,12 +47,23 @@ class _MinimalManager:
     _cli_ref = None
     _context_engine = None
     _tools: dict = {}
+    scope_key = "test-profile"
+
+    def _track_registration(self, manifest, kind, key, release):
+        return PluginRegistration(
+            kind=kind,
+            key=key,
+            release=release,
+            plugin_key=manifest.name,
+        )
 
 
 @pytest.fixture(autouse=True)
 def _isolated_registry():
     clear_providers()
+    token_auth.clear_token_routes()
     yield
+    token_auth.clear_token_routes()
     clear_providers()
 
 
@@ -63,6 +75,47 @@ def _make_ctx(name: str = "dashboard-auth-stub") -> PluginContext:
 def test_plugin_ctx_exposes_register_dashboard_auth_provider():
     ctx = _make_ctx()
     assert hasattr(ctx, "register_dashboard_auth_provider")
+    assert hasattr(ctx, "register_dashboard_token_route")
+
+
+def test_plugin_ctx_token_route_handle_cleans_up_profile_scoped_policy():
+    ctx = _make_ctx()
+    handle = ctx.register_dashboard_token_route(
+        "/api/plugin/machine",
+        provider="stub",
+        required_scopes=("write", "read"),
+    )
+
+    assert token_auth.is_token_route(
+        "/api/plugin/machine", scope=_MinimalManager.scope_key
+    )
+    assert not token_auth.is_token_route(
+        "/api/plugin/machine", scope="other-profile"
+    )
+
+    handle.dispose()
+
+    assert not token_auth.is_token_route(
+        "/api/plugin/machine", scope=_MinimalManager.scope_key
+    )
+
+
+def test_plugin_ctx_token_route_tracking_failure_rolls_back_raw_registration():
+    class FailingManager(_MinimalManager):
+        def _track_registration(self, manifest, kind, key, release):
+            raise RuntimeError("tracking unavailable")
+
+    manifest = PluginManifest(name="dashboard-auth-failing", version="0.0.1")
+    ctx = PluginContext(manifest=manifest, manager=FailingManager())  # type: ignore[arg-type]
+
+    with pytest.raises(RuntimeError, match="tracking unavailable"):
+        ctx.register_dashboard_token_route(
+            "/api/plugin/failing", provider="stub", required_scopes=("write",)
+        )
+
+    assert not token_auth.is_token_route(
+        "/api/plugin/failing", scope=FailingManager.scope_key
+    )
 
 
 def test_plugin_ctx_silently_ignores_non_provider(caplog):

--- a/tests/hermes_cli/test_dashboard_token_auth.py
+++ b/tests/hermes_cli/test_dashboard_token_auth.py
@@ -225,13 +225,152 @@ async def _call_next_ok(request):
 
 
 
+def test_legacy_unowned_registration_is_source_compatible_but_inert(caplog):
+    registration = token_auth.register_token_route("/api/legacy-machine")
+
+    assert registration is None
+    assert not token_auth.is_token_route("/api/legacy-machine")
+    assert "ignored unowned token route" in caplog.text
+
+
 def test_seam_rejects_wrong_token_401():
     register_provider(_TokenProvider(secret="good"))
-    token_auth.register_token_route("/api/gateway/drain")
+    token_auth.register_token_route("/api/gateway/drain", provider="tok")
     req = _FakeRequest(
         path="/api/gateway/drain", headers={"authorization": "Bearer bad"}
     )
     resp = _run(token_auth.token_auth_middleware(req, _call_next_ok))
     assert resp.status_code == 401
+
+
+def test_route_provider_binding_rejects_a_token_from_another_provider():
+    other = _TokenProvider(secret="shared", scopes=("empire.poll",))
+    other.name = "empire-client"
+    register_provider(other)
+    register_provider(_TokenProvider(secret="drain-secret", scopes=("drain",)))
+    token_auth.register_token_route(
+        "/api/gateway/drain", provider="tok", required_scopes=("drain",)
+    )
+    req = _FakeRequest(
+        path="/api/gateway/drain", headers={"authorization": "Bearer shared"}
+    )
+
+    resp = _run(token_auth.token_auth_middleware(req, _call_next_ok))
+
+    assert resp.status_code == 401
+    assert not hasattr(req.state, "token_authenticated")
+
+
+def test_route_scope_binding_rejects_an_authenticated_under_scoped_principal():
+    register_provider(_TokenProvider(secret="good", scopes=("poll",)))
+    token_auth.register_token_route(
+        "/api/client/decision", provider="tok", required_scopes=("decision",)
+    )
+    req = _FakeRequest(
+        path="/api/client/decision", headers={"authorization": "Bearer good"}
+    )
+
+    resp = _run(token_auth.token_auth_middleware(req, _call_next_ok))
+
+    assert resp.status_code == 403
+    assert not hasattr(req.state, "token_authenticated")
+
+
+def test_route_provider_and_scope_binding_accepts_only_the_exact_principal():
+    register_provider(_TokenProvider(secret="good", scopes=("decision", "body:abc")))
+    token_auth.register_token_route(
+        "/api/client/decision",
+        provider="tok",
+        required_scopes=("decision", "body:abc"),
+    )
+    req = _FakeRequest(
+        path="/api/client/decision", headers={"authorization": "Bearer good"}
+    )
+
+    resp = _run(token_auth.token_auth_middleware(req, _call_next_ok))
+
+    assert resp.status_code == 200
+    assert req.state.token_authenticated is True
+    assert req.state.token_principal.provider == "tok"
+
+
+def test_conflicting_token_route_registration_poisoning_is_fail_closed_and_disposable():
+    first_provider = _TokenProvider(secret="first-token")
+    first_provider.name = "first"
+    second_provider = _TokenProvider(secret="second-token")
+    second_provider.name = "second"
+    register_provider(first_provider)
+    register_provider(second_provider)
+    first = token_auth.register_token_route("/api/shared", provider="first")
+    second = token_auth.register_token_route("/api/shared", provider="second")
+    request = _FakeRequest(
+        path="/api/shared", headers={"authorization": "Bearer first-token"}
+    )
+
+    response = _run(token_auth.token_auth_middleware(request, _call_next_ok))
+
+    assert response.status_code == 503
+    assert not hasattr(request.state, "token_authenticated")
+
+    second.dispose()
+    request = _FakeRequest(
+        path="/api/shared", headers={"authorization": "Bearer first-token"}
+    )
+    response = _run(token_auth.token_auth_middleware(request, _call_next_ok))
+    assert response.status_code == 200
+    assert request.state.token_authenticated is True
+
+    first.dispose()
+    assert not token_auth.is_token_route("/api/shared")
+
+
+def test_scope_order_is_canonical_and_profile_registrations_are_isolated():
+    first = token_auth.register_token_route(
+        "/api/scoped",
+        provider="tok",
+        required_scopes=("read", "write"),
+        scope="profile-a",
+    )
+    second = token_auth.register_token_route(
+        "/api/scoped",
+        provider="tok",
+        required_scopes=("write", "read"),
+        scope="profile-a",
+    )
+    other = token_auth.register_token_route(
+        "/api/scoped", provider="other", scope="profile-b"
+    )
+
+    assert token_auth.is_token_route("/api/scoped", scope="profile-a")
+    policy, conflict = token_auth._token_route_policy("/api/scoped", scope="profile-a")
+    assert conflict is False
+    assert policy is not None
+    assert policy.required_scopes == frozenset({"read", "write"})
+    assert token_auth._token_route_policy("/api/scoped", scope="profile-b")[0].provider == "other"
+
+    first.dispose()
+    second.dispose()
+    other.dispose()
+
+
+def test_provider_cannot_spoof_another_provider_in_its_principal():
+    provider = _TokenProvider(secret="good")
+    provider.name = "owner"
+
+    def spoofed(*, token):
+        assert token == "good"
+        return TokenPrincipal(provider="other", principal="machine")
+
+    provider.verify_token = spoofed
+    register_provider(provider)
+    token_auth.register_token_route("/api/owned", provider="owner")
+    request = _FakeRequest(
+        path="/api/owned", headers={"authorization": "Bearer good"}
+    )
+
+    response = _run(token_auth.token_auth_middleware(request, _call_next_ok))
+
+    assert response.status_code == 401
+    assert not hasattr(request.state, "token_authenticated")
 
 

--- a/tests/plugins/dashboard_auth/test_drain_provider.py
+++ b/tests/plugins/dashboard_auth/test_drain_provider.py
@@ -145,8 +145,35 @@ class TestRegister:
         assert isinstance(provider, drain.DrainSecretProvider)
         assert provider.verify_token(token=s) is not None
         assert drain.LAST_SKIP_REASON == ""
-        # The drain endpoint is now token-authable.
-        assert token_auth.is_token_route(drain.DRAIN_ROUTE_PATH)
+        ctx.register_dashboard_token_route.assert_called_once_with(
+            drain.DRAIN_ROUTE_PATH,
+            provider=provider.name,
+            required_scopes=("drain",),
+        )
+
+    def test_provider_registration_failure_leaves_route_disabled(self, drain, monkeypatch):
+        monkeypatch.setenv("HERMES_DASHBOARD_DRAIN_SECRET", _strong_secret())
+        monkeypatch.setattr(drain, "_load_config_drain_auth_section", lambda: {})
+        ctx = MagicMock()
+        ctx.register_dashboard_auth_provider.return_value = None
+
+        drain.register(ctx)
+
+        ctx.register_dashboard_token_route.assert_not_called()
+        assert "registration failed" in drain.LAST_SKIP_REASON
+
+    def test_route_registration_failure_rolls_back_provider(self, drain, monkeypatch):
+        monkeypatch.setenv("HERMES_DASHBOARD_DRAIN_SECRET", _strong_secret())
+        monkeypatch.setattr(drain, "_load_config_drain_auth_section", lambda: {})
+        ctx = MagicMock()
+        provider_registration = MagicMock()
+        ctx.register_dashboard_auth_provider.return_value = provider_registration
+        ctx.register_dashboard_token_route.side_effect = ValueError("invalid policy")
+
+        drain.register(ctx)
+
+        provider_registration.dispose.assert_called_once_with()
+        assert "route registration failed" in drain.LAST_SKIP_REASON.lower()
 
     def test_config_scope_applied(self, drain, monkeypatch):
         s = _strong_secret()


### PR DESCRIPTION
## Summary

- bind each exact dashboard token route to one named token provider and optional required scopes
- make route registrations profile-scoped, reference-counted, disposable, and lifecycle-owned through `PluginContext`
- fail closed while conflicting live policies exist, then recover when the conflicting registration unloads
- prevent a provider from returning a principal for another provider
- update the drain plugin to register its provider and route transactionally with unload cleanup
- keep legacy one-argument `register_token_route(path)` calls source-compatible but intentionally inert until the caller names an owner

## Motivation

The current token middleware tries every token provider for every token-enabled route. A credential accepted by one provider can therefore authenticate an unrelated provider's route unless each handler independently reconstructs provider ownership and scope checks. The provider itself cannot compare a signed path claim with the actual request because `verify_token()` receives only the bearer token.

This change moves provider ownership and static scope enforcement into the middleware's exact-route policy, eliminating that cross-provider confused-deputy boundary while preserving the existing provider protocol.

## Safety and lifecycle

- Policies are keyed by the active Hermes-home/profile scope.
- Conflicting registrations poison the route with `503`; first registration never silently wins.
- Every explicit registration returns a disposable handle.
- `PluginContext.register_dashboard_token_route()` tracks cleanup and rolls back if lifecycle tracking fails.
- Drain does not register a route if provider registration fails and disposes the provider if route setup raises.
- Unowned legacy calls register nothing, so they cannot widen the authentication surface.

## Verification

- 246 dashboard-auth/plugin contract tests passed
- 37 focused changed-surface tests passed
- full Ruff check passed
- `git diff --check` passed
- two independent final reviews reported no high- or medium-severity blockers
