### PR TITLE
feat(video-gen): add Wan 2.7 FAL video family (t2v + i2v)

### DIFF
--- a/plugins/video_gen/fal/__init__.py
+++ b/plugins/video_gen/fal/__init__.py
@@ -273,6 +273,28 @@ FAL_FAMILIES: Dict[str, Dict[str, Any]] = {
         "audio": True,
         "negative": True,
     },
+    "wan-2.7": {
+        "display": "Wan 2.7",
+        "speed": "~60-180s",
+        "price": "premium",
+        "strengths": "Alibaba. 1080p, native/auto audio, first+last frame, 2-15s, lipsync.",
+        "tier": "premium",
+        "text_endpoint": "fal-ai/wan/v2.7/text-to-video",
+        "image_endpoint": "fal-ai/wan/v2.7/image-to-video",
+        # Wan 2.7 duration enum is 2..15 as JSON integers.
+        "duration_int": True,
+        # t2v accepts aspect_ratio; i2v derives it from the input image and
+        # declares no aspect_ratio field at all.
+        "image_drop_keys": ("aspect_ratio",),
+        "aspect_ratios": ("16:9", "9:16", "1:1", "4:3", "3:4"),
+        "resolutions": ("720p", "1080p"),
+        "durations": (2, 15),
+        # Audio is native/always-on (auto-generated background audio when no
+        # audio_url is given); there is no generate_audio key.
+        "audio": False,
+        "negative": True,
+        "seed": True,
+    },
     "happy-horse": {
         "display": "Happy Horse 1.0",
         "speed": "~60-120s",
@@ -713,7 +735,7 @@ class FALVideoGenProvider(VideoGenProvider):
         return {
             "name": "FAL",
             "badge": "paid",
-            "tag": "LTX, Pixverse, Seedance 2.0/2.5/Mini, Veo 3.1, MiniMax H3, FLUX 3, Kling 4K, Happy Horse, Grok Imagine, Gemini Omni — text-to-video & image-to-video",
+            "tag": "LTX, Pixverse, Seedance 2.0/2.5/Mini, Veo 3.1, MiniMax H3, FLUX 3, Kling 4K, Wan 2.7, Happy Horse, Grok Imagine, Gemini Omni — text-to-video & image-to-video",
             "env_vars": [
                 {
                     "key": "FAL_KEY",


### PR DESCRIPTION
## Summary
Adds Alibaba's Wan 2.7 as a new FAL video family — hermes `video_generate` users can now pick `wan-2.7` for text-to-video and image-to-video with 1080p output and native auto-generated audio.

## Changes
- `plugins/video_gen/fal/__init__.py`: new `wan-2.7` entry in `FAL_FAMILIES` (endpoints `fal-ai/wan/v2.7/text-to-video` / `image-to-video`); FAL setup-schema tag line updated.

## Schema mapping (verified against fal.ai llms.txt + OpenAPI for both endpoints)
- `duration`: integer enum 2–15 → `duration_int: True`, `durations: (2, 15)` (range → clamped)
- `resolution`: `720p`/`1080p`
- `aspect_ratio`: t2v enum `16:9, 9:16, 1:1, 4:3, 3:4`; the i2v schema has NO aspect_ratio field → `image_drop_keys: ("aspect_ratio",)`
- Audio is native/always-on (auto background audio when no `audio_url`) — no `generate_audio` key → `audio: False`
- `negative_prompt` and `seed` both present in the schema → enabled

## Validation
| Check | Result |
|---|---|
| Payload assertions (t2v int duration, i2v drops aspect_ratio, clamp 30→15, invalid resolution dropped, family key resolution incl. full endpoint + `fal-ai/wan/v2.7` stem) | all pass |
| `tests/plugins/video_gen/test_fal_plugin.py` + `tests/tools/test_video_generation_tool_surface_matrix.py` | 73 passed (surface-matrix auto-parametrizes the new family) |
| Live E2E (direct FAL, 2s @720p) | request built + submitted correctly through the real provider path; FAL returned `Exhausted balance` (account lock, not a schema error) — endpoint schema verified via OpenAPI instead |

## Cost notes
$0.10/sec at 720p, $0.15/sec at 1080p. Premium tier, comparable to Kling/Seedance. Nous Portal note: the managed fal-queue gateway may need portal-side allowlist + pricing rows for the two new endpoints before subscription users can use them.

## Trust notes
First-party FAL endpoint (Alibaba model hosted by FAL); no new dependencies, no new config keys.

## Infographic

![Wan 2.7 FAL video family](https://files.catbox.moe/ov0xm7.png)
