### PR TITLE
feat(image-gen): add Grok Imagine Image 2.0 to the FAL image catalog

### DIFF
--- a/tools/image_generation_tool.py
+++ b/tools/image_generation_tool.py
@@ -658,6 +658,40 @@ FAL_MODELS: Dict[str, Dict[str, Any]] = {
         },
         "upscale": True,
     },
+    "xai/grok-imagine-image/v2.0/text-to-image": {
+        "display": "Grok Imagine Image 2.0",
+        "speed": "~5s",
+        "strengths": "xAI. Design-grade typography/layout, instruction following",
+        "price": "$0.06/image (1K medium)",
+        "size_style": "aspect_ratio",
+        "sizes": {
+            "landscape": "16:9",
+            "square": "1:1",
+            "portrait": "9:16",
+        },
+        "defaults": {
+            "num_images": 1,
+            "output_format": "png",
+            # 1k + medium is the cheapest sensible tier ($0.06/image);
+            # 2k roughly +33% per image.
+            "resolution": "1k",
+            "quality": "medium",
+        },
+        "supports": {
+            "prompt", "aspect_ratio", "num_images", "output_format",
+            "resolution", "quality", "sync_mode",
+        },
+        "upscale": True,   # 1k native is sub-2MP
+        # Edit endpoint takes `image_urls` (max 3) + the same knobs;
+        # aspect_ratio defaults to "auto" (follows the first input image),
+        # so we don't send it on edits.
+        "edit_endpoint": "xai/grok-imagine-image/v2.0/edit",
+        "edit_supports": {
+            "prompt", "image_urls", "num_images", "output_format",
+            "resolution", "quality", "sync_mode",
+        },
+        "max_reference_images": 3,
+    },
 }
 
 # Default model is the fastest reasonable option. Kept cheap and sub-1s.


### PR DESCRIPTION
## Summary
Adds xAI's Grok Imagine Image 2.0 (released Aug 7, on FAL since this week) to the FAL image catalog — `image_generate` users can now select a design-grade model focused on typography/layout planning, with editing support.

## Changes
- `tools/image_generation_tool.py`: new `xai/grok-imagine-image/v2.0/text-to-image` entry in `FAL_MODELS` with `edit_endpoint: xai/grok-imagine-image/v2.0/edit` (`image_urls`, max 3 references).

## Schema mapping (verified against fal.ai llms.txt + OpenAPI for both endpoints)
- `size_style: aspect_ratio` — schema takes 13 ratio enums; we map landscape/square/portrait → 16:9 / 1:1 / 9:16
- Defaults pinned to `resolution: 1k` + `quality: medium` = **$0.06/image** (predictable billing; 2k is +33%)
- No `seed` param in the schema — correctly absent from `supports`
- Edit endpoint's `aspect_ratio` defaults to `auto` (follows input image) — we don't send it on edits
- `upscale: True` (1k native is sub-2MP, per the default-on upscale policy)

## Validation
| Check | Result |
|---|---|
| Payload assertions (t2i maps ratios + pins 1k/medium; seed dropped; edit payload has image_urls, no aspect_ratio; both payloads ⊆ whitelists) | all pass |
| `tests/tools/test_image_generation.py`, `test_image_generation_image_to_image.py`, `tests/plugins/image_gen/test_fal_provider.py` | 69 passed (incl. the upscale-policy + edit-contract invariant tests, which auto-cover the new entry) |
| Live E2E via `image_generate_tool` (direct FAL) | blocked by `Exhausted balance` on the FAL account (lock, not a schema error); payloads verified against OpenAPI |

## Comparison vs existing
Complements the xAI *native* image plugin (`plugins/image_gen/xai`, grok-imagine-image 1.x via xAI key): this entry runs 2.0 through FAL, so Nous-subscription/FAL users get it without an xAI key. Distinct niche vs GPT Image 2 (broad photorealism) — Image 2.0 is #2 on Arena for both t2i and editing and targets design/typography work.

## Trust notes
First-party FAL endpoint; no new dependencies or config keys.

## Infographic

![Grok Imagine Image 2.0 on FAL](https://files.catbox.moe/4l45i0.png)
