### PR TITLE
feat(config): opt-in root primary model inheritance for named profiles

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -615,6 +615,16 @@ def load_cli_config() -> Dict[str, Any]:
     from hermes_cli.config import _expand_env_vars
     defaults = _expand_env_vars(defaults)
 
+    # Opt-in primary-model inheritance (root → named profile). Mirrors
+    # _load_config_impl: applied after the profile's own values resolve (root
+    # overrides legacy local model.default/provider) but BEFORE the managed
+    # overlay (managed still wins). No-op unless this profile set
+    # model.inherit_root_primary and is a named profile distinct from root, so
+    # the interactive CLI and every kanban worker child (which resolve their
+    # runtime model here) agree with `hermes config get`.
+    from hermes_cli.config import apply_root_primary_model_inheritance
+    apply_root_primary_model_inheritance(defaults, config_path=config_path)
+
     # Managed scope: overlay administrator-pinned values LAST so they win over
     # the user's config here too. cli.py builds its config independently of
     # hermes_cli.config._load_config_impl (which has its own managed merge), so

--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -1523,18 +1523,16 @@ def _resolve_default_model_snapshot() -> Optional[str]:
     or resolution fails (fail-open — caller treats ``None`` as "no snapshot").
     """
     try:
-        from hermes_cli.config import _expand_env_vars, read_user_config_raw
+        from hermes_cli.config import build_cron_effective_config
 
         cfg_path = get_hermes_home() / "config.yaml"
         if not cfg_path.exists():
             return None
-        cfg = read_user_config_raw(cfg_path)
-        try:
-            from hermes_cli import managed_scope
-            cfg = managed_scope.apply_managed_overlay(cfg)
-        except Exception:
-            pass
-        cfg = _expand_env_vars(cfg)
+        # Canonical cron effective config: raw user config + opt-in root-primary
+        # inheritance + managed overlay + env expansion (the SAME helper run_job
+        # resolves the fire-time global model through), so an opted-in unpinned
+        # job snapshots the inherited root model it will actually fire on.
+        cfg = build_cron_effective_config(cfg_path)
         # Mirror run_job's precedence: the explicit cron-fleet default
         # (cron.model) beats the global chat model for unpinned cron jobs.
         cron_cfg = cfg.get("cron") or {}

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -4723,20 +4723,20 @@ def run_job(
         _cfg = {}
         _model_cfg = {}
         try:
-            from hermes_cli.config import read_user_config_raw
+            from hermes_cli.config import build_cron_effective_config
             _cfg_path = str(_get_hermes_home() / "config.yaml")
             if os.path.exists(_cfg_path):
-                _cfg = read_user_config_raw(Path(_cfg_path))
-                # Managed scope: a scheduled job must honor administrator-pinned
-                # model / reasoning / toolsets / provider_routing too. This loader
-                # builds its own dict, so overlay managed values via the shared
-                # helper (fail-open, no-op when no managed scope).
-                try:
-                    from hermes_cli import managed_scope
-                    _cfg = managed_scope.apply_managed_overlay(_cfg)
-                except Exception:
-                    pass
-                _cfg = _expand_env_vars(_cfg)
+                # Canonical cron effective config: raw user config + opt-in
+                # root-primary inheritance + managed overlay + env expansion.
+                # Routing through the shared helper (rather than a raw read plus
+                # an inline managed overlay) means an opted-in *unpinned* worker
+                # resolves the inherited root primary model here — the SAME value
+                # _resolve_default_model_snapshot captured at create time — while
+                # administrator-pinned managed model / reasoning / toolsets /
+                # provider_routing still win and a non-opted profile keeps its
+                # own value. The explicit cron overrides below (per-job model,
+                # cron.model fleet default) are unchanged.
+                _cfg = build_cron_effective_config(Path(_cfg_path))
                 # Coerce null/missing to {} so a falsy default never
                 # clobbers an already-resolved env value with ``None``.
                 _model_cfg = _cfg.get("model") or {}

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3370,17 +3370,8 @@ def _load_gateway_config() -> dict:
             logger.debug("Could not load gateway config from %s", config_path)
             raw = {}
 
-    # Overlay managed scope. read_raw_config() returns the user's raw YAML
-    # WITHOUT the managed merge (that lives in load_config/_load_config_impl),
-    # so the overlay is required on both paths for the gateway to honor pinned
-    # values. Helper is fail-open and a no-op when no managed scope exists.
-    try:
-        from hermes_cli import managed_scope
-        raw = managed_scope.apply_managed_overlay(raw if isinstance(raw, dict) else {})
-    except Exception:
-        pass
     if not isinstance(raw, dict):
-        return {}
+        raw = {}
     # Canonicalize model-id aliases (model.name / model.model → model.default)
     # and migrate stale root-level provider/base_url into the model section.
     # The gateway bypasses load_config() (it reads raw YAML for speed), so the
@@ -3392,6 +3383,33 @@ def _load_gateway_config() -> dict:
         raw = _normalize_root_model_keys(raw)
     except Exception:
         pass
+    # Opt-in root primary-model inheritance — applied BEFORE the managed overlay
+    # so an administrator-pinned managed model.default/provider still WINS over
+    # the inherited root value, matching load_config()'s canonical precedence
+    # (managed > inherited root > profile-local). The gateway bypasses
+    # load_config() (raw read for speed), so the shared resolver that
+    # load_config() applies must be replayed here or an opted-in named profile's
+    # gateway model tier would ignore the inherited root model.default/provider.
+    # Keyed on the gateway's OWN config_path so the self-inheritance guard and
+    # $HERMES_HOME isolation hold; reads root fresh each call so root-only edits
+    # are observed without a gateway restart. Fail-open.
+    try:
+        from hermes_cli.config import apply_root_primary_model_inheritance
+        raw = apply_root_primary_model_inheritance(raw, config_path=config_path)
+    except Exception:
+        pass
+    # Overlay managed scope LAST so administrator-pinned values win per-leaf.
+    # read_raw_config() returns the user's raw YAML WITHOUT the managed merge
+    # (that lives in load_config/_load_config_impl), so the overlay is required
+    # on both paths for the gateway to honor pinned values. Helper is fail-open
+    # and a no-op when no managed scope exists.
+    try:
+        from hermes_cli import managed_scope
+        raw = managed_scope.apply_managed_overlay(raw if isinstance(raw, dict) else {})
+    except Exception:
+        pass
+    if not isinstance(raw, dict):
+        return {}
     return raw
 
 

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -242,11 +242,17 @@ _LAST_EXPANDED_CONFIG_BY_PATH: Dict[str, Any] = {}
 # produces a fresh inode, so stat() sees a new mtime_ns and the next
 # load repopulates automatically — no explicit invalidation hook.
 # Cached tuple is (user_mtime_ns, user_size, managed_mtime_ns, managed_size,
-# merged_value, env_ref_snapshot) — the managed-file signature is folded in so
-# editing the managed-scope config.yaml invalidates the cache (see
-# managed_scope), and the env snapshot invalidates it when a referenced ${VAR}
-# changes value (late .env load, in-process rotation — #58514).
-_LOAD_CONFIG_CACHE: Dict[str, Tuple[int, int, int, int, Dict[str, Any], Dict[str, Optional[str]]]] = {}
+# root_mtime_ns, root_size, merged_value, env_ref_snapshot) — the managed-file
+# signature is folded in so editing the managed-scope config.yaml invalidates
+# the cache (see managed_scope); the root-config signature is folded in so that
+# a named profile which opts into primary-model inheritance
+# (``model.inherit_root_primary``) sees root-config create/change/delete WITHOUT
+# a restart (parent-aware invalidation — the gap flagged in issue #43713); and
+# the env snapshot invalidates it when a referenced ${VAR} changes value (late
+# .env load, in-process rotation — #58514). The root part is (0, 0) for the
+# default/root profile and for named profiles that do not opt in, keeping their
+# behavior byte-for-byte unchanged.
+_LOAD_CONFIG_CACHE: Dict[str, Tuple[int, int, int, int, int, int, Dict[str, Any], Dict[str, Optional[str]]]] = {}
 # (path, mtime_ns, size) -> cached raw yaml dict. Same pattern as
 # _LOAD_CONFIG_CACHE but for read_raw_config() — used when callers want
 # the user's on-disk values without defaults merged in.
@@ -3207,6 +3213,297 @@ def read_user_config_raw(config_path: Optional[Path] = None) -> Dict[str, Any]:
     return data if isinstance(data, dict) else {}
 
 
+# ── Opt-in primary-model inheritance (root → named profile) ─────────────────
+#
+# A NAMED profile may inherit EXACTLY the two primary-routing scalars
+# ``model.default`` and ``model.provider`` from the default root config, and
+# ONLY when its own config sets ``model.inherit_root_primary: true``. Nothing
+# else is shared: providers dicts, credentials, aliases, delegation
+# model/provider, base_url, api_key, terminal, toolsets, memory, sessions,
+# cron, logs and gateway state all continue to resolve from built-in defaults
+# plus the named profile alone. The default/root profile never inherits from
+# itself. This is the scoped, explicit design maintainers asked for in issue
+# #43713 after the broad automatic merges in PR #43765/#43816 were rejected for
+# violating profile isolation.
+INHERIT_ROOT_PRIMARY_KEY = "inherit_root_primary"
+_INHERITED_PRIMARY_FIELDS = ("default", "provider")
+# Dedup set for the fail-safe diagnostic, keyed on (root_path, reason, sig) so a
+# long-lived process warns once per broken/missing root file but re-warns after
+# the file changes. Mirrors _CONFIG_PARSE_WARNED.
+_ROOT_INHERIT_WARNED: set = set()
+
+
+def _profile_opts_into_root_primary(cfg: Dict[str, Any]) -> bool:
+    """Whether ``cfg`` (a profile config) opts into root primary inheritance."""
+    if not isinstance(cfg, dict):
+        return False
+    model_cfg = cfg.get("model")
+    if not isinstance(model_cfg, dict):
+        return False
+    return bool(model_cfg.get(INHERIT_ROOT_PRIMARY_KEY))
+
+
+def _root_config_path_for_inheritance(current_config_path) -> Optional[Path]:
+    """Return the default root ``config.yaml`` path, or ``None`` when the active
+    home IS the root (default profile) so a profile can never inherit from
+    itself. Resolution is HERMES_HOME-relative (see
+    ``hermes_constants.get_default_hermes_root``); it never mutates HERMES_HOME,
+    preserving ``$HERMES_HOME`` isolation."""
+    try:
+        from hermes_constants import get_default_hermes_root
+        root_home = get_default_hermes_root()
+    except Exception:
+        return None
+    root_path = root_home / "config.yaml"
+    current = Path(current_config_path)
+    # Cheap normalized-string comparison — no filesystem syscall. This runs on
+    # every load_config()/load_config_readonly() (the hot readonly path), so
+    # avoid .resolve(). For the default/root profile the two paths are
+    # string-identical (both derive from the same home resolver), so this
+    # short-circuits before any stat.
+    if os.path.normcase(os.path.normpath(str(root_path))) == os.path.normcase(
+        os.path.normpath(str(current))
+    ):
+        return None
+    return root_path
+
+
+def _root_primary_stat_sig(root_path: Optional[Path]) -> Tuple[int, int]:
+    """``(mtime_ns, size)`` of the root config, or ``(0, 0)`` when inheritance
+    is inactive or the file is absent. Folded into the load-config cache
+    signature so root create/change/delete invalidates a cached profile
+    result."""
+    if root_path is None:
+        return (0, 0)
+    try:
+        st = root_path.stat()
+        return (st.st_mtime_ns, st.st_size)
+    except OSError:
+        return (0, 0)
+
+
+def _profile_opts_into_root_primary_on_disk(config_path) -> bool:
+    """Whether the profile config at ``config_path`` sets
+    ``model.inherit_root_primary: true``, read straight from disk.
+
+    Used at cache-signature time (before the full parse), so a NON-opted named
+    profile's load-cache key never folds in the root config's stat — keeping it
+    isolated from root create/change/delete/stat churn (issue #43713). Only ever
+    called for a named profile whose root path differs from its own, so the
+    default/root profile pays nothing. Fail-safe: any read/parse error → False
+    (treat as not opted in → root not folded in → the profile stays isolated).
+    Toggling the flag changes the profile file's own (mtime, size), which is
+    already part of the cache signature, so this is re-derived on the next load."""
+    try:
+        raw = read_user_config_raw(Path(config_path))
+    except Exception:
+        return False
+    return _profile_opts_into_root_primary(raw)
+
+
+# (path) -> (user_mtime_ns, user_size, opt_in). Memoizes the opt-in flag on the
+# profile file's stat signature so the load-config hot path never re-parses the
+# profile YAML merely to discover the flag — most importantly on a cache HIT,
+# where the whole point of the cache is to avoid a parse. The flag is a pure
+# function of the profile file's content, which is fully captured by the SAME
+# (mtime_ns, size) signature _LOAD_CONFIG_CACHE already trusts, so any profile
+# edit (including toggling the flag) re-derives it. Read/written ONLY under
+# _CONFIG_LOCK (from _load_config_impl), so there is no stale-opt-in race.
+_PROFILE_OPT_IN_CACHE: Dict[str, Tuple[int, int, bool]] = {}
+
+
+def _profile_opts_into_root_primary_cached(
+    config_path, path_key: str, user_sig: Optional[Tuple[int, int]]
+) -> bool:
+    """Stat-memoized form of :func:`_profile_opts_into_root_primary_on_disk`,
+    keyed on the profile file's ``(mtime_ns, size)``.
+
+    Returns ``False`` without any parse when the user config is absent
+    (``user_sig is None`` → no file → no opt-in flag → default-false). On a
+    signature match returns the memoized flag with NO disk read (the cache-hit
+    fast path the finding requires). On a miss (cold load, or the profile file
+    changed) it re-derives from disk — so malformed fail-safe (a parse error →
+    ``False``) is preserved and the flag is never stale relative to disk."""
+    if user_sig is None:
+        return False
+    cached = _PROFILE_OPT_IN_CACHE.get(path_key)
+    if cached is not None and cached[0] == user_sig[0] and cached[1] == user_sig[1]:
+        return cached[2]
+    opt_in = _profile_opts_into_root_primary_on_disk(config_path)
+    _PROFILE_OPT_IN_CACHE[path_key] = (user_sig[0], user_sig[1], opt_in)
+    return opt_in
+
+
+def _warn_root_inheritance_failure(root_path: Path, reason: str) -> None:
+    """One-shot actionable diagnostic when an opted-in profile cannot read the
+    root config. Fail-safe: the caller keeps the profile's own values and never
+    broadens inheritance. Re-warns after the root file changes."""
+    try:
+        st = root_path.stat()
+        sig = (st.st_mtime_ns, st.st_size)
+    except OSError:
+        sig = (0, 0)
+    key = (str(root_path), reason, sig)
+    if key in _ROOT_INHERIT_WARNED:
+        return
+    _ROOT_INHERIT_WARNED.add(key)
+    msg = (
+        f"Profile opted into model.inherit_root_primary but the root config "
+        f"{root_path} {reason}. Keeping this profile's own model.default / "
+        f"model.provider (no inheritance applied). Fix the root config with "
+        f"`hermes config set model.default <id>` / `model.provider <name>`, "
+        f"or disable with `hermes -p <profile> config set "
+        f"model.inherit_root_primary false`."
+    )
+    logger.warning(msg)
+    try:
+        sys.stderr.write(f"⚠️  hermes config: {msg}\n")
+        sys.stderr.flush()
+    except Exception:
+        pass
+
+
+def _resolve_root_primary_overlay(root_path: Path) -> Dict[str, Any]:
+    """Read EXACTLY ``model.default`` + ``model.provider`` from the root config.
+
+    Returns a dict with 0-2 of those keys. Empty dict when the root config is
+    missing (nothing configured to inherit — the profile keeps its own/default)
+    or malformed (fail-safe: a diagnostic is emitted and inheritance is NOT
+    broadened). Reuses ``_normalize_root_model_keys`` so a dict-valued
+    ``model.default`` or a bare ``model:`` string flattens the same way it does
+    for the local config."""
+    if not root_path.exists():
+        _warn_root_inheritance_failure(root_path, "does not exist")
+        return {}
+    try:
+        raw = read_user_config_raw(root_path)
+    except Exception as e:  # malformed YAML / IO error
+        _warn_root_inheritance_failure(root_path, f"could not be parsed ({e})")
+        return {}
+    if not raw:
+        return {}
+    try:
+        normalized = _normalize_root_model_keys(copy.deepcopy(raw))
+    except Exception as e:
+        _warn_root_inheritance_failure(root_path, f"could not be normalized ({e})")
+        return {}
+    model_cfg = normalized.get("model")
+    if not isinstance(model_cfg, dict):
+        return {}
+    overlay: Dict[str, Any] = {}
+    for field in _INHERITED_PRIMARY_FIELDS:
+        val = model_cfg.get(field)
+        if isinstance(val, str) and val.strip():
+            overlay[field] = val
+    return overlay
+
+
+def apply_root_primary_model_inheritance(
+    cfg: Dict[str, Any],
+    *,
+    config_path=None,
+    env_snapshot: Optional[Dict[str, Optional[str]]] = None,
+) -> Dict[str, Any]:
+    """Overlay ``model.default`` + ``model.provider`` from the default root
+    config onto ``cfg`` in place, and return ``cfg``.
+
+    No-op unless ALL hold: ``cfg`` sets ``model.inherit_root_primary: true``;
+    the active home is a NAMED profile distinct from the root; and the root
+    config supplies the field(s). Root values override any legacy local
+    ``model.default`` / ``model.provider`` still present in the profile
+    (migration-safe: a field the root omits falls back to the profile's own).
+
+    Inherited values are ``${VAR}`` / ``${env:VAR}``-expanded HERE, with the
+    exact ``_expand_env_vars`` semantics (and missing-ref-kept-verbatim
+    behavior) the profile's own values already use. Expanding at this single
+    shared entry point means every consumer resolves an IDENTICAL effective
+    model whether it expands before this overlay (``build_cron_effective_config``
+    re-expands: idempotent), after it (``_load_config_impl`` / the CLI bridge),
+    or not at all (doctor / profile-list). ONLY the two primary scalars are ever
+    read or expanded — no other root field is touched, so a ``${VAR}`` in any
+    non-primary root field is never resolved or merged.
+
+    ``env_snapshot``: when given, each inherited value's raw ``${VAR}`` refs are
+    recorded into it (before expansion) so a caller that CACHES its result can
+    invalidate on an in-process rotation of an inherited ref — parity with the
+    profile's own refs (#58514). Consumers that do not cache omit it.
+
+    This is the single shared entry point every real primary-model resolver
+    routes through so CLI / gateway / profile-list / kanban / bridge all agree
+    (see ``website/docs/user-guide/profiles.md``)."""
+    if not _profile_opts_into_root_primary(cfg):
+        return cfg
+    if config_path is None:
+        config_path = get_config_path()
+    root_path = _root_config_path_for_inheritance(config_path)
+    if root_path is None:
+        return cfg  # default/root profile — never inherit from self
+    overlay = _resolve_root_primary_overlay(root_path)
+    if not overlay:
+        return cfg
+    model_cfg = cfg.get("model")
+    if not isinstance(model_cfg, dict):
+        model_cfg = {}
+        cfg["model"] = model_cfg
+    for field in _INHERITED_PRIMARY_FIELDS:
+        if field in overlay:
+            raw_val = overlay[field]
+            # Record the raw template's env refs (for cache invalidation) BEFORE
+            # expanding, then store the expanded value — same semantics as the
+            # profile's own values so the effective model is consistent.
+            if env_snapshot is not None:
+                _env_ref_snapshot(raw_val, env_snapshot)
+            model_cfg[field] = _expand_env_vars(raw_val)
+    return cfg
+
+
+def build_cron_effective_config(config_path: Optional[Path] = None) -> Dict[str, Any]:
+    """Effective config the cron ticker resolves its GLOBAL model/provider from.
+
+    Raw user config → opt-in root-primary inheritance → managed overlay → env
+    expansion, in the SAME precedence ``_load_config_impl`` uses (managed wins
+    over an inherited root value, which wins over the profile's own legacy
+    value). This is the single shared helper both cron primary-model paths route
+    through so an opted-in *unpinned* worker snapshots and fires on the same
+    inherited root primary:
+
+      * ``cron/scheduler.py`` ``run_job`` (fire-time global model), and
+      * ``cron/jobs.py`` ``_resolve_default_model_snapshot`` (create-time snapshot).
+
+    Deliberately does NOT merge ``DEFAULT_CONFIG`` — the cron callers treat a
+    missing key as "unset" and apply their own defaults (a defaults merge would
+    make every key "present"), so this mirrors the raw-bypass loaders those
+    callers already used, adding ONLY the previously-missing inheritance step.
+    Explicit cron overrides — a per-job model pin and the ``cron.model`` fleet
+    default — are applied by the callers and are unaffected by this helper.
+
+    Fail modes mirror :func:`read_user_config_raw`: a missing file yields ``{}``;
+    an unparseable/other IO error propagates (the cron callers already wrap this
+    in try/except with their own last-known-good / warn semantics)."""
+    if config_path is None:
+        config_path = get_config_path()
+    config_path = Path(config_path)
+    cfg = read_user_config_raw(config_path)
+    if not isinstance(cfg, dict) or not cfg:
+        return cfg if isinstance(cfg, dict) else {}
+    # 1) Opt-in root→named-profile inheritance of model.default/provider only.
+    #    No-op for the default/root profile and for a profile that did not opt
+    #    in. Keyed on this config's own path so the self-inheritance guard and
+    #    $HERMES_HOME isolation hold; reads root fresh so root-only edits are
+    #    observed with no restart.
+    cfg = apply_root_primary_model_inheritance(cfg, config_path=config_path)
+    # 2) Managed overlay WINS at the leaf (canonical precedence). Fail-open and
+    #    a no-op when no managed scope is present.
+    try:
+        from hermes_cli import managed_scope
+        cfg = managed_scope.apply_managed_overlay(cfg)
+    except Exception:
+        pass
+    # 3) Expand ${VAR} refs, matching the raw-bypass loaders.
+    expanded = _expand_env_vars(cfg)
+    return expanded if isinstance(expanded, dict) else cfg
+
+
 def read_raw_config_readonly() -> Dict[str, Any]:
     """Fast-path variant of ``read_raw_config()`` for callers that ONLY READ.
 
@@ -3519,30 +3816,51 @@ def _load_config_impl(*, want_deepcopy: bool) -> Dict[str, Any]:
         except OSError:
             managed_sig = (0, 0)
 
-        # Combined cache signature: user file + managed file. None only when the
-        # user config is absent AND no managed file exists (nothing to cache on).
+        # Root-config signature for opt-in primary-model inheritance. Folded in
+        # ONLY for a named profile that actually opts in (path distinct from the
+        # root config AND model.inherit_root_primary: true), so a root-only
+        # create/change/delete invalidates THAT profile's cached effective
+        # result WITHOUT a restart — closing the parent-aware invalidation gap of
+        # PR #43765 (issue #43713). (0, 0) for the default/root profile AND for a
+        # non-opted named profile, so those cache signatures are unchanged and
+        # stay isolated from root churn (a non-opted profile's effective config
+        # never depends on root). Opt-in is itself part of user_sig, so toggling
+        # the flag re-derives this on the next load.
+        root_cfg_path = _root_config_path_for_inheritance(config_path)
+        if root_cfg_path is not None and _profile_opts_into_root_primary_cached(
+            config_path, path_key, user_sig
+        ):
+            root_sig = _root_primary_stat_sig(root_cfg_path)
+        else:
+            root_sig = (0, 0)
+
+        # Combined cache signature: user file + managed file + root file. None
+        # only when the user config is absent AND no managed file exists
+        # (nothing to cache on; no user config means no opt-in flag either).
         if user_sig is not None:
-            cache_sig: Optional[Tuple[int, int, int, int]] = (
+            cache_sig: Optional[Tuple[int, int, int, int, int, int]] = (
                 user_sig[0],
                 user_sig[1],
                 managed_sig[0],
                 managed_sig[1],
+                root_sig[0],
+                root_sig[1],
             )
         elif managed_sig != (0, 0):
-            cache_sig = (0, 0, managed_sig[0], managed_sig[1])
+            cache_sig = (0, 0, managed_sig[0], managed_sig[1], root_sig[0], root_sig[1])
         else:
             cache_sig = None
 
         cached = _LOAD_CONFIG_CACHE.get(path_key)
-        if cached is not None and cache_sig is not None and cached[:4] == cache_sig:
+        if cached is not None and cache_sig is not None and cached[:6] == cache_sig:
             # File signatures match, but the cached expansion is only valid if
             # every ${VAR} it was expanded against still has the same value.
             # Without this, a load_config() that ran before load_hermes_dotenv()
             # pins unexpanded literals (e.g. auxiliary.<task>.api_key) for the
             # life of the process (#58514).
-            env_snapshot = cached[5] if len(cached) > 5 else {}
+            env_snapshot = cached[7] if len(cached) > 7 else {}
             if all(os.environ.get(k) == v for k, v in env_snapshot.items()):
-                return copy.deepcopy(cached[4]) if want_deepcopy else cached[4]
+                return copy.deepcopy(cached[6]) if want_deepcopy else cached[6]
 
         config = copy.deepcopy(DEFAULT_CONFIG)
 
@@ -3593,15 +3911,25 @@ def _load_config_impl(*, want_deepcopy: bool) -> Dict[str, Any]:
                         # re-parse the broken file; fixing the file changes the
                         # signature and triggers a normal reload.
                         _empty_env: Dict[str, Optional[str]] = {}
-                        _LOAD_CONFIG_CACHE[path_key] = (
-                            cache_sig[0], cache_sig[1],
-                            cache_sig[2], cache_sig[3],
-                            lkg_copy, _empty_env,
-                        )
+                        _LOAD_CONFIG_CACHE[path_key] = (*cache_sig, lkg_copy, _empty_env)
                     return copy.deepcopy(lkg_copy) if want_deepcopy else lkg_copy
 
         normalized = _normalize_root_model_keys(_normalize_max_turns_config(config))
         expanded = _expand_env_vars(normalized)
+        # Opt-in primary-model inheritance (root → named profile). Applied after
+        # the profile's own values are resolved (so an opted-in profile's root
+        # values override any legacy local model.default/provider) but BEFORE the
+        # managed overlay (so administrator-pinned managed values still win).
+        # No-op unless the profile set model.inherit_root_primary and is a named
+        # profile distinct from root; scoped to exactly model.default +
+        # model.provider — see apply_root_primary_model_inheritance. Inherited
+        # values are ${VAR}-expanded by the resolver (parity with the profile's
+        # own values). Capture their raw env refs so an in-process rotation of an
+        # inherited ref invalidates this cached result too (#58514 parity).
+        _root_env_refs: Dict[str, Optional[str]] = {}
+        apply_root_primary_model_inheritance(
+            expanded, config_path=config_path, env_snapshot=_root_env_refs
+        )
         # Managed scope wins at the leaf. Applied AFTER user expansion so a user
         # ${VAR} cannot shadow a managed literal: managed values are expanded only
         # against the process environment, never against user-config-defined refs.
@@ -3634,6 +3962,10 @@ def _load_config_impl(*, want_deepcopy: bool) -> Dict[str, Any]:
             # drift (late .env load, in-process rotation) — see cache hit above.
             cached_copy = copy.deepcopy(expanded)
             env_snapshot = _env_ref_snapshot(normalized)
+            # Fold in the inherited-root value's ${VAR} refs so a later rotation
+            # of an inherited ref is detected on the cache-hit path above —
+            # parity with the profile's own refs (#58514).
+            env_snapshot.update(_root_env_refs)
             if managed_config:
                 _env_ref_snapshot(managed_config, env_snapshot)
             _LOAD_CONFIG_CACHE[path_key] = (*cache_sig, cached_copy, env_snapshot)

--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -1151,9 +1151,22 @@ def run_doctor(args):
 
         # Validate model.provider and model.default values
         try:
-            # Raw-file diagnostic: inspects what the user actually wrote.
-            from hermes_cli.config import read_user_config_raw
+            # Diagnose the EFFECTIVE primary model (after opt-in root-primary
+            # inheritance), not just the raw local values. An opted-in profile
+            # mid-migration may keep a stale local model.default/provider that the
+            # root config supersedes at runtime (migration-safe: root wins), so
+            # validating the raw local values would falsely warn about a
+            # provider/model the runtime never actually uses. The shared resolver
+            # is a strict no-op for a non-opted profile and for the default/root
+            # profile, and is scoped to exactly model.default + model.provider —
+            # it never broadens what is inherited. read_user_config_raw returns a
+            # fresh (uncached) dict, so the in-place overlay is safe.
+            from hermes_cli.config import (
+                apply_root_primary_model_inheritance,
+                read_user_config_raw,
+            )
             cfg = read_user_config_raw(config_path)
+            cfg = apply_root_primary_model_inheritance(cfg, config_path=config_path)
             model_section = cfg.get("model") or {}
             provider_raw = (model_section.get("provider") or "").strip()
             provider = provider_raw.lower()

--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -692,8 +692,16 @@ def _read_config_model(profile_dir: Path) -> tuple:
     try:
         # Multi-profile display read: load_config() targets the ACTIVE
         # profile's home, so read THIS profile's file via the raw primitive.
-        from hermes_cli.config import read_user_config_raw
+        from hermes_cli.config import (
+            read_user_config_raw,
+            apply_root_primary_model_inheritance,
+        )
         cfg = read_user_config_raw(config_path)
+        # Reflect opt-in primary-model inheritance so the listing shows the
+        # profile's EFFECTIVE model/provider (no-op unless this profile set
+        # model.inherit_root_primary and is a named profile). Routes the former
+        # raw bypass through the single shared resolver.
+        cfg = apply_root_primary_model_inheritance(cfg, config_path=config_path)
         model_cfg = cfg.get("model", {})
         if isinstance(model_cfg, str):
             return model_cfg, None

--- a/tests/cron/test_cron_model_inheritance.py
+++ b/tests/cron/test_cron_model_inheritance.py
@@ -1,0 +1,155 @@
+"""Cron global-model resolution honors opt-in root→named-profile inheritance.
+
+Both cron paths that resolve the GLOBAL (unpinned) model read the raw profile
+``config.yaml`` and previously bypassed ``load_config()``'s opt-in root-primary
+inheritance:
+
+* ``cron/scheduler.py`` ``run_job`` — the fire-time global model, compared
+  against the drift snapshot via ``resolve_cron_model_drift_defaults``.
+* ``cron/jobs.py`` ``_resolve_default_model_snapshot`` — the create-time snapshot
+  an unpinned job stores so a later global swap fails closed.
+
+Both now route through the single canonical helper
+``hermes_cli.config.build_cron_effective_config`` (raw user config → opt-in
+root inheritance → managed overlay → env expansion, in canonical precedence),
+so an opted-in *unpinned* worker snapshots and fires on the SAME inherited root
+primary model. Explicit cron overrides — a per-job model pin and the
+``cron.model`` fleet default — are applied by the callers and stay unchanged.
+
+Generic placeholder ids only — never a real model/provider.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+import yaml
+
+from hermes_cli import config as cfgmod
+
+
+ROOT_MODEL = "root-model-alpha"
+ROOT_PROVIDER = "provider-root"
+LOCAL_MODEL = "local-model-beta"
+LOCAL_PROVIDER = "provider-local"
+CRON_FLEET_MODEL = "cron-fleet-model-gamma"
+MANAGED_MODEL = "managed-model-delta"
+
+
+def _write_yaml(path: Path, data: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(yaml.safe_dump(data), encoding="utf-8")
+
+
+@pytest.fixture
+def cron_profile_env(tmp_path, monkeypatch):
+    """HERMES_HOME points at ``<root>/profiles/coder`` so
+    ``get_default_hermes_root()`` resolves ``<root>`` and cron reads the named
+    profile config."""
+    root = tmp_path / "root"
+    profile = root / "profiles" / "coder"
+    profile.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setenv("HERMES_HOME", str(profile))
+    monkeypatch.delenv("HERMES_MODEL", raising=False)  # config, not env, decides
+    cfgmod._LOAD_CONFIG_CACHE.clear()
+    cfgmod._RAW_CONFIG_CACHE.clear()
+    yield {
+        "root_cfg": root / "config.yaml",
+        "profile_cfg": profile / "config.yaml",
+    }
+    cfgmod._LOAD_CONFIG_CACHE.clear()
+    cfgmod._RAW_CONFIG_CACHE.clear()
+
+
+# ── Canonical helper: build_cron_effective_config ───────────────────────────
+
+def test_build_cron_effective_config_opted_in_inherits_root_primary(cron_profile_env):
+    _write_yaml(cron_profile_env["root_cfg"], {"model": {"default": ROOT_MODEL, "provider": ROOT_PROVIDER}})
+    _write_yaml(cron_profile_env["profile_cfg"], {"model": {"inherit_root_primary": True}})
+
+    cfg = cfgmod.build_cron_effective_config(cron_profile_env["profile_cfg"])
+
+    assert cfg["model"]["default"] == ROOT_MODEL
+    assert cfg["model"]["provider"] == ROOT_PROVIDER
+
+
+def test_build_cron_effective_config_default_off_stays_isolated(cron_profile_env):
+    _write_yaml(cron_profile_env["root_cfg"], {"model": {"default": ROOT_MODEL, "provider": ROOT_PROVIDER}})
+    _write_yaml(cron_profile_env["profile_cfg"], {"model": {"default": LOCAL_MODEL, "provider": LOCAL_PROVIDER}})
+
+    cfg = cfgmod.build_cron_effective_config(cron_profile_env["profile_cfg"])
+
+    assert cfg["model"]["default"] == LOCAL_MODEL
+    assert cfg["model"]["provider"] == LOCAL_PROVIDER
+
+
+def test_build_cron_effective_config_managed_overlay_wins_over_inherited_root(
+    cron_profile_env, tmp_path, monkeypatch
+):
+    """Canonical precedence: an administrator-pinned managed model still wins
+    over the inherited root value."""
+    _write_yaml(cron_profile_env["root_cfg"], {"model": {"default": ROOT_MODEL, "provider": ROOT_PROVIDER}})
+    _write_yaml(cron_profile_env["profile_cfg"], {"model": {"inherit_root_primary": True}})
+
+    managed_dir = tmp_path / "managed"
+    _write_yaml(managed_dir / "config.yaml", {"model": {"default": MANAGED_MODEL}})
+    monkeypatch.setenv("HERMES_MANAGED_DIR", str(managed_dir))
+    from hermes_cli import managed_scope
+    managed_scope.invalidate_managed_cache()
+
+    cfg = cfgmod.build_cron_effective_config(cron_profile_env["profile_cfg"])
+
+    assert cfg["model"]["default"] == MANAGED_MODEL  # managed wins over inherited root
+    managed_scope.invalidate_managed_cache()
+
+
+# ── run_job's global-model expression (resolve_cron_model_drift_defaults) ────
+
+def test_run_job_global_model_expression_uses_inherited_root(cron_profile_env):
+    """The exact expression run_job evaluates for the unpinned global model —
+    ``resolve_cron_model_drift_defaults(build_cron_effective_config(...))`` —
+    resolves the inherited root primary for an opted-in profile."""
+    _write_yaml(cron_profile_env["root_cfg"], {"model": {"default": ROOT_MODEL, "provider": ROOT_PROVIDER}})
+    _write_yaml(cron_profile_env["profile_cfg"], {"model": {"inherit_root_primary": True}})
+
+    cfg = cfgmod.build_cron_effective_config(cron_profile_env["profile_cfg"])
+    provider, model = cfgmod.resolve_cron_model_drift_defaults(cfg)
+
+    assert model == ROOT_MODEL
+    assert provider == ROOT_PROVIDER
+
+
+# ── create-time snapshot: _resolve_default_model_snapshot ────────────────────
+
+def test_snapshot_resolves_inherited_root_model_for_opted_in_profile(cron_profile_env):
+    from cron.jobs import _resolve_default_model_snapshot
+
+    _write_yaml(cron_profile_env["root_cfg"], {"model": {"default": ROOT_MODEL, "provider": ROOT_PROVIDER}})
+    _write_yaml(cron_profile_env["profile_cfg"], {"model": {"inherit_root_primary": True}})
+
+    assert _resolve_default_model_snapshot() == ROOT_MODEL
+
+
+def test_snapshot_default_off_stays_isolated(cron_profile_env):
+    from cron.jobs import _resolve_default_model_snapshot
+
+    _write_yaml(cron_profile_env["root_cfg"], {"model": {"default": ROOT_MODEL, "provider": ROOT_PROVIDER}})
+    _write_yaml(cron_profile_env["profile_cfg"], {"model": {"default": LOCAL_MODEL}})
+
+    assert _resolve_default_model_snapshot() == LOCAL_MODEL
+
+
+def test_snapshot_cron_fleet_default_still_wins_over_inherited_root(cron_profile_env):
+    """Explicit cron override unchanged: the ``cron.model`` fleet default beats
+    the (now inheritance-aware) global chat model for unpinned cron jobs."""
+    from cron.jobs import _resolve_default_model_snapshot
+
+    _write_yaml(cron_profile_env["root_cfg"], {"model": {"default": ROOT_MODEL, "provider": ROOT_PROVIDER}})
+    _write_yaml(
+        cron_profile_env["profile_cfg"],
+        {"model": {"inherit_root_primary": True}, "cron": {"model": CRON_FLEET_MODEL}},
+    )
+
+    assert _resolve_default_model_snapshot() == CRON_FLEET_MODEL

--- a/tests/gateway/test_gateway_model_inheritance.py
+++ b/tests/gateway/test_gateway_model_inheritance.py
@@ -1,0 +1,121 @@
+"""Gateway primary-model resolution honors the opt-in root inheritance.
+
+``gateway/run.py`` reads config via ``_load_gateway_config`` (a raw-YAML +
+managed-overlay bypass of ``load_config()``). This test proves that former
+bypass now routes through the shared
+``hermes_cli.config.apply_root_primary_model_inheritance`` resolver, so an
+opted-in named profile's gateway model tier (``_resolve_gateway_model`` /
+``_load_gateway_config``) reflects the two inherited root scalars — while
+opted-out and the default/root profile stay isolated, and root-only edits are
+observed without restart.
+
+All model ids/providers are generic placeholders — never a real model/provider.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+import yaml
+
+from hermes_cli import config as cfgmod
+import gateway.run as gateway_run
+
+
+ROOT_MODEL = "root-model-alpha"
+ROOT_PROVIDER = "provider-root"
+LOCAL_MODEL = "local-model-beta"
+LOCAL_PROVIDER = "provider-local"
+MANAGED_MODEL = "managed-model-delta"
+
+
+def _write_yaml(path: Path, data: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(yaml.safe_dump(data), encoding="utf-8")
+
+
+def _bump_mtime(path: Path) -> None:
+    st = path.stat()
+    os.utime(path, ns=(st.st_atime_ns + 1_000_000_000, st.st_mtime_ns + 1_000_000_000))
+
+
+@pytest.fixture
+def gw_profile_env(tmp_path, monkeypatch):
+    """HERMES_HOME + gateway ``_hermes_home`` point at ``<root>/profiles/coder``
+    so ``get_default_hermes_root()`` resolves ``<root>``."""
+    root = tmp_path / "root"
+    profile = root / "profiles" / "coder"
+    profile.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setenv("HERMES_HOME", str(profile))
+    monkeypatch.setattr(gateway_run, "_hermes_home", profile)
+    cfgmod._LOAD_CONFIG_CACHE.clear()
+    cfgmod._RAW_CONFIG_CACHE.clear()
+    yield {
+        "root_cfg": root / "config.yaml",
+        "profile_cfg": profile / "config.yaml",
+    }
+    cfgmod._LOAD_CONFIG_CACHE.clear()
+    cfgmod._RAW_CONFIG_CACHE.clear()
+
+
+def test_gateway_opted_in_profile_inherits_root_primary(gw_profile_env):
+    _write_yaml(gw_profile_env["root_cfg"], {"model": {"default": ROOT_MODEL, "provider": ROOT_PROVIDER}})
+    _write_yaml(gw_profile_env["profile_cfg"], {"model": {"inherit_root_primary": True}})
+
+    assert gateway_run._resolve_gateway_model() == ROOT_MODEL
+    cfg = gateway_run._load_gateway_config()
+    assert cfg["model"]["default"] == ROOT_MODEL
+    assert cfg["model"]["provider"] == ROOT_PROVIDER
+
+
+def test_gateway_default_off_stays_isolated(gw_profile_env):
+    _write_yaml(gw_profile_env["root_cfg"], {"model": {"default": ROOT_MODEL, "provider": ROOT_PROVIDER}})
+    _write_yaml(gw_profile_env["profile_cfg"], {"model": {"default": LOCAL_MODEL, "provider": LOCAL_PROVIDER}})
+
+    assert gateway_run._resolve_gateway_model() == LOCAL_MODEL
+    cfg = gateway_run._load_gateway_config()
+    assert cfg["model"]["provider"] == LOCAL_PROVIDER
+
+
+def test_gateway_root_change_observed_without_restart(gw_profile_env):
+    _write_yaml(gw_profile_env["root_cfg"], {"model": {"default": ROOT_MODEL, "provider": ROOT_PROVIDER}})
+    _write_yaml(gw_profile_env["profile_cfg"], {"model": {"inherit_root_primary": True}})
+
+    assert gateway_run._resolve_gateway_model() == ROOT_MODEL
+
+    _write_yaml(gw_profile_env["root_cfg"], {"model": {"default": "root-model-changed", "provider": ROOT_PROVIDER}})
+    _bump_mtime(gw_profile_env["root_cfg"])
+
+    assert gateway_run._resolve_gateway_model() == "root-model-changed"
+
+
+def test_gateway_managed_overlay_wins_over_inherited_root(gw_profile_env, tmp_path, monkeypatch):
+    """Canonical precedence: an administrator-pinned managed model.default must
+    win over an inherited root value, while a leaf managed does NOT pin
+    (model.provider) still fills from the inherited root."""
+    _write_yaml(gw_profile_env["root_cfg"], {"model": {"default": ROOT_MODEL, "provider": ROOT_PROVIDER}})
+    _write_yaml(gw_profile_env["profile_cfg"], {"model": {"inherit_root_primary": True}})
+
+    managed_dir = tmp_path / "managed"
+    _write_yaml(managed_dir / "config.yaml", {"model": {"default": MANAGED_MODEL}})
+    monkeypatch.setenv("HERMES_MANAGED_DIR", str(managed_dir))
+    from hermes_cli import managed_scope
+    managed_scope.invalidate_managed_cache()
+
+    assert gateway_run._resolve_gateway_model() == MANAGED_MODEL  # managed wins
+    cfg = gateway_run._load_gateway_config()
+    assert cfg["model"]["default"] == MANAGED_MODEL
+    assert cfg["model"]["provider"] == ROOT_PROVIDER  # inherited fills the un-pinned leaf
+    managed_scope.invalidate_managed_cache()
+
+
+def test_gateway_missing_root_fails_safe(gw_profile_env):
+    # No root config; opted-in profile keeps its own value, no broadening.
+    _write_yaml(gw_profile_env["profile_cfg"],
+                {"model": {"inherit_root_primary": True, "default": LOCAL_MODEL, "provider": LOCAL_PROVIDER}})
+
+    assert gateway_run._resolve_gateway_model() == LOCAL_MODEL
+    cfg = gateway_run._load_gateway_config()
+    assert cfg["model"]["provider"] == LOCAL_PROVIDER

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -363,6 +363,76 @@ def test_run_doctor_accepts_named_provider_from_providers_section(monkeypatch, t
     assert "model.provider 'volcengine-plan' is not a recognised provider" not in out
 
 
+def test_run_doctor_opted_in_unpinned_profile_validates_effective_not_stale_local(
+    monkeypatch, tmp_path
+):
+    """A valid opted-in profile mid-migration may keep a stale local
+    model.provider that the root config supersedes at runtime (migration-safe:
+    root wins). Doctor must diagnose the EFFECTIVE post-inheritance provider —
+    root's — and NOT falsely warn about the superseded local value the runtime
+    never uses. Scoped strictly to model.default/provider; nothing else about
+    inheritance is broadened (a non-opted profile is unaffected)."""
+    import yaml
+
+    root = tmp_path / "root"
+    profile = root / "profiles" / "coder"
+    profile.mkdir(parents=True, exist_ok=True)
+
+    # Root supplies a clean primary provider. "auto" is a recognised provider
+    # that also skips the credential/vendor-slug checks, isolating this test to
+    # the raw-vs-effective boundary.
+    (root / "config.yaml").write_text(
+        yaml.dump({"model": {"provider": "auto", "default": "root-default-model"}})
+    )
+    # Opted-in profile keeps a stale local provider that reads as unrecognised on
+    # the raw file, but root overrides it at runtime.
+    (profile / "config.yaml").write_text(
+        yaml.dump(
+            {
+                "model": {
+                    "inherit_root_primary": True,
+                    "provider": "totally-bogus-xyz",
+                    "default": "legacy-local-model",
+                }
+            }
+        )
+    )
+
+    monkeypatch.setenv("HERMES_HOME", str(profile))  # so root resolves to <root>
+    monkeypatch.setattr(doctor_mod, "HERMES_HOME", profile)
+    monkeypatch.setattr(doctor_mod, "PROJECT_ROOT", tmp_path / "project")
+    monkeypatch.setattr(doctor_mod, "_DHH", str(profile))
+    (tmp_path / "project").mkdir(exist_ok=True)
+
+    from hermes_cli import config as cfgmod
+    cfgmod._LOAD_CONFIG_CACHE.clear()
+    cfgmod._RAW_CONFIG_CACHE.clear()
+
+    fake_model_tools = types.SimpleNamespace(
+        check_tool_availability=lambda *a, **kw: ([], []),
+        TOOLSET_REQUIREMENTS={},
+    )
+    monkeypatch.setitem(sys.modules, "model_tools", fake_model_tools)
+
+    try:
+        from hermes_cli import auth as _auth_mod
+        monkeypatch.setattr(_auth_mod, "get_nous_auth_status_local", lambda: {})
+        monkeypatch.setattr(_auth_mod, "get_codex_auth_status", lambda: {})
+        monkeypatch.setattr(_auth_mod, "get_xai_oauth_auth_status", lambda: {})
+    except Exception:
+        pass
+
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        doctor_mod.run_doctor(Namespace(fix=False))
+
+    out = buf.getvalue()
+    # The superseded local provider must never be validated/warned: doctor now
+    # diagnoses the effective (inherited) "auto".
+    assert "totally-bogus-xyz" not in out
+    assert "is not a recognised provider" not in out
+
+
 def test_run_doctor_accepts_stable_key_when_provider_name_differs(
     monkeypatch, tmp_path
 ):

--- a/tests/hermes_cli/test_profile_model_inheritance.py
+++ b/tests/hermes_cli/test_profile_model_inheritance.py
@@ -1,0 +1,550 @@
+"""Opt-in inheritance of the two primary-routing scalars (``model.default`` +
+``model.provider``) from the default root config into a NAMED profile.
+
+Behavioral contract (see ``website/docs/user-guide/profiles.md`` §"Inherit the
+root model"):
+
+* A named profile inherits ONLY ``model.default`` and ``model.provider`` from
+  ``<root>/config.yaml`` and ONLY when its own config sets
+  ``model.inherit_root_primary: true``.
+* Default-off and the default/root profile preserve full isolation.
+* Root-config create/change/delete is observed WITHOUT restarting a
+  long-lived process (cache invalidation).
+* A missing/malformed root config fails safe (keeps the profile's own values,
+  never broadens inheritance) with a diagnostic.
+
+All model ids/providers here are generic placeholders — the feature must never
+pin a real model or provider.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+import yaml
+
+from hermes_cli import config as cfgmod
+
+
+ROOT_MODEL = "root-model-alpha"
+ROOT_PROVIDER = "provider-root"
+LOCAL_MODEL = "local-model-beta"
+LOCAL_PROVIDER = "provider-local"
+
+
+def _write_yaml(path: Path, data: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(yaml.safe_dump(data), encoding="utf-8")
+
+
+def _bump_mtime(path: Path) -> None:
+    """Force a stat change even if the write landed in the same mtime tick."""
+    st = path.stat()
+    os.utime(path, ns=(st.st_atime_ns + 1_000_000_000, st.st_mtime_ns + 1_000_000_000))
+
+
+@pytest.fixture
+def profile_env(tmp_path, monkeypatch):
+    """Point HERMES_HOME at ``<root>/profiles/coder`` so ``get_hermes_home()``
+    is the named profile and ``get_default_hermes_root()`` is ``<root>``."""
+    root = tmp_path / "root"
+    profile = root / "profiles" / "coder"
+    profile.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setenv("HERMES_HOME", str(profile))
+    # Defeat any cross-test cache/memo carryover.
+    cfgmod._LOAD_CONFIG_CACHE.clear()
+    cfgmod._RAW_CONFIG_CACHE.clear()
+    cfgmod._PROFILE_OPT_IN_CACHE.clear()
+    yield {
+        "root": root,
+        "root_cfg": root / "config.yaml",
+        "profile": profile,
+        "profile_cfg": profile / "config.yaml",
+    }
+    cfgmod._LOAD_CONFIG_CACHE.clear()
+    cfgmod._RAW_CONFIG_CACHE.clear()
+    cfgmod._PROFILE_OPT_IN_CACHE.clear()
+
+
+def _leaf_paths(d, prefix=""):
+    out = {}
+    if isinstance(d, dict):
+        for k, v in d.items():
+            out.update(_leaf_paths(v, f"{prefix}.{k}" if prefix else str(k)))
+    else:
+        out[prefix] = d
+    return out
+
+
+# ── Core opt-in ────────────────────────────────────────────────────────────
+
+def test_opted_in_named_profile_inherits_root_primary(profile_env):
+    _write_yaml(profile_env["root_cfg"], {"model": {"default": ROOT_MODEL, "provider": ROOT_PROVIDER}})
+    _write_yaml(profile_env["profile_cfg"], {"model": {"inherit_root_primary": True}})
+
+    cfg = cfgmod.load_config()
+
+    assert cfg["model"]["default"] == ROOT_MODEL
+    assert cfg["model"]["provider"] == ROOT_PROVIDER
+
+
+def test_default_off_preserves_isolation(profile_env):
+    _write_yaml(profile_env["root_cfg"], {"model": {"default": ROOT_MODEL, "provider": ROOT_PROVIDER}})
+    _write_yaml(profile_env["profile_cfg"], {"model": {"default": LOCAL_MODEL, "provider": LOCAL_PROVIDER}})
+
+    cfg = cfgmod.load_config()
+
+    assert cfg["model"]["default"] == LOCAL_MODEL
+    assert cfg["model"]["provider"] == LOCAL_PROVIDER
+
+
+def test_default_profile_never_inherits_from_itself(tmp_path, monkeypatch):
+    """When HERMES_HOME IS the root, the flag must be a no-op (no self-read)."""
+    root = tmp_path / "root"
+    root.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setenv("HERMES_HOME", str(root))
+    cfgmod._LOAD_CONFIG_CACHE.clear()
+    _write_yaml(root / "config.yaml", {"model": {"default": ROOT_MODEL, "provider": ROOT_PROVIDER,
+                                                 "inherit_root_primary": True}})
+
+    # The root config path resolves to the current config path → helper opts out.
+    assert cfgmod._root_config_path_for_inheritance(root / "config.yaml") is None
+    cfg = cfgmod.load_config()
+    assert cfg["model"]["default"] == ROOT_MODEL  # its own value, not an inherited copy
+    cfgmod._LOAD_CONFIG_CACHE.clear()
+
+
+def test_flag_present_model_fields_omitted_still_inherits(profile_env):
+    _write_yaml(profile_env["root_cfg"], {"model": {"default": ROOT_MODEL, "provider": ROOT_PROVIDER}})
+    _write_yaml(profile_env["profile_cfg"], {"model": {"inherit_root_primary": True}, "toolsets": ["hermes-cli"]})
+
+    cfg = cfgmod.load_config()
+
+    assert cfg["model"]["default"] == ROOT_MODEL
+    assert cfg["model"]["provider"] == ROOT_PROVIDER
+
+
+# ── Migration-safe rule ────────────────────────────────────────────────────
+
+def test_legacy_local_fields_root_wins(profile_env):
+    _write_yaml(profile_env["root_cfg"], {"model": {"default": ROOT_MODEL, "provider": ROOT_PROVIDER}})
+    _write_yaml(profile_env["profile_cfg"],
+                {"model": {"inherit_root_primary": True, "default": LOCAL_MODEL, "provider": LOCAL_PROVIDER}})
+
+    cfg = cfgmod.load_config()
+
+    assert cfg["model"]["default"] == ROOT_MODEL
+    assert cfg["model"]["provider"] == ROOT_PROVIDER
+
+
+def test_root_missing_one_field_falls_back_to_local(profile_env):
+    # Root sets only provider; profile keeps a local default.
+    _write_yaml(profile_env["root_cfg"], {"model": {"provider": ROOT_PROVIDER}})
+    _write_yaml(profile_env["profile_cfg"],
+                {"model": {"inherit_root_primary": True, "default": LOCAL_MODEL}})
+
+    cfg = cfgmod.load_config()
+
+    assert cfg["model"]["provider"] == ROOT_PROVIDER   # inherited
+    assert cfg["model"]["default"] == LOCAL_MODEL       # migration-safe fallback
+
+
+# ── Isolation: everything else stays profile-local/default ──────────────────
+
+def test_only_two_model_fields_are_inherited(profile_env):
+    root_cfg = {
+        "model": {"default": ROOT_MODEL, "provider": ROOT_PROVIDER,
+                  "base_url": "https://root.example/v1", "api_key": "root-secret"},
+        "providers": {"rootprov": {"api_key": "root-key"}},
+        "toolsets": ["root-tool"],
+        "terminal": {"backend": "docker"},
+        "aliases": {"r": "root"},
+    }
+    _write_yaml(profile_env["root_cfg"], root_cfg)
+
+    base_profile = {"model": {"provider": LOCAL_PROVIDER, "base_url": "https://local.example/v1"}}
+    # Baseline: flag OFF.
+    _write_yaml(profile_env["profile_cfg"], base_profile)
+    off = cfgmod.load_config()
+    cfgmod._LOAD_CONFIG_CACHE.clear()
+    # Opted-in: identical profile + flag ON.
+    on_profile = {"model": dict(base_profile["model"], inherit_root_primary=True)}
+    _write_yaml(profile_env["profile_cfg"], on_profile)
+    on = cfgmod.load_config()
+
+    off_leaves = _leaf_paths(off)
+    on_leaves = _leaf_paths(on)
+    changed = {k for k in set(off_leaves) | set(on_leaves) if off_leaves.get(k) != on_leaves.get(k)}
+    changed.discard("model.inherit_root_primary")  # the flag itself differs by construction
+    assert changed == {"model.default", "model.provider"}, changed
+
+    # Spot-check specific non-inherited leaves.
+    assert on["model"].get("base_url") == "https://local.example/v1"  # NOT root's
+    assert "api_key" not in on["model"] or on["model"].get("api_key") != "root-secret"
+    assert on.get("providers", {}).get("rootprov") is None
+    assert "root-tool" not in (on.get("toolsets") or [])
+
+
+def test_no_non_primary_state_is_inherited(profile_env):
+    """Regression: a rich root config must NOT leak ANY non-primary state into
+    an opted-in profile — not credentials, providers, aliases, delegation
+    routing, model.base_url/api_key, terminal, tools, memory, skills, sessions,
+    cron, logs, or gateway state. Only model.default + model.provider cross."""
+    root_cfg = {
+        "model": {
+            "default": ROOT_MODEL, "provider": ROOT_PROVIDER,
+            "base_url": "https://root.example/v1", "api_key": "root-secret",
+            "delegation": {"default": "root-deleg-model", "provider": "root-deleg-prov"},
+        },
+        "providers": {"rootprov": {"api_key": "root-key", "base_url": "https://rp.example"}},
+        "aliases": {"r": "root"},
+        "terminal": {"backend": "docker"},
+        "toolsets": ["root-tool"],
+        "memory": {"enabled": True, "path": "/root/mem"},
+        "skills": {"official": ["root-skill"]},
+        "sessions": {"retention_days": 99},
+        "cron": {"model": "root-cron-model"},
+        "logs": {"level": "root-debug"},
+        "gateway": {"port": 61234},
+    }
+    _write_yaml(profile_env["root_cfg"], root_cfg)
+    _write_yaml(profile_env["profile_cfg"], {"model": {"inherit_root_primary": True}})
+
+    on = cfgmod.load_config()
+
+    # The two inherited scalars cross.
+    assert on["model"]["default"] == ROOT_MODEL
+    assert on["model"]["provider"] == ROOT_PROVIDER
+    # Nothing else does. Delegation stays default/local (never root's).
+    assert on["model"].get("delegation", {}).get("provider") != "root-deleg-prov"
+    assert on["model"].get("base_url") != "https://root.example/v1"
+    assert on["model"].get("api_key") != "root-secret"
+    # Whole non-model sections never take root's values.
+    assert on.get("providers", {}).get("rootprov") is None
+    assert on.get("aliases", {}).get("r") != "root"
+    assert on.get("terminal", {}).get("backend") != "docker"
+    assert "root-tool" not in (on.get("toolsets") or [])
+    assert on.get("memory", {}).get("path") != "/root/mem"
+    assert "root-skill" not in (on.get("skills", {}).get("official") or [])
+    assert on.get("sessions", {}).get("retention_days") != 99
+    assert on.get("cron", {}).get("model") != "root-cron-model"
+    assert on.get("logs", {}).get("level") != "root-debug"
+    assert on.get("gateway", {}).get("port") != 61234
+
+
+# ── Fail-safe ───────────────────────────────────────────────────────────────
+
+def test_malformed_root_fails_safe(profile_env, caplog):
+    profile_env["root_cfg"].parent.mkdir(parents=True, exist_ok=True)
+    profile_env["root_cfg"].write_text("model: {default: [unbalanced\n", encoding="utf-8")
+    _write_yaml(profile_env["profile_cfg"],
+                {"model": {"inherit_root_primary": True, "default": LOCAL_MODEL, "provider": LOCAL_PROVIDER}})
+
+    with caplog.at_level("WARNING"):
+        cfg = cfgmod.load_config()
+
+    assert cfg["model"]["default"] == LOCAL_MODEL   # unchanged — no broadening
+    assert cfg["model"]["provider"] == LOCAL_PROVIDER
+    assert any("root" in r.message.lower() for r in caplog.records)
+
+
+def test_missing_root_fails_safe(profile_env):
+    # No root config.yaml at all.
+    _write_yaml(profile_env["profile_cfg"],
+                {"model": {"inherit_root_primary": True, "default": LOCAL_MODEL, "provider": LOCAL_PROVIDER}})
+
+    cfg = cfgmod.load_config()
+
+    assert cfg["model"]["default"] == LOCAL_MODEL
+    assert cfg["model"]["provider"] == LOCAL_PROVIDER
+
+
+# ── Cache: parent-aware invalidation in a long-lived process ────────────────
+
+def test_root_change_invalidates_cached_profile_result(profile_env):
+    _write_yaml(profile_env["root_cfg"], {"model": {"default": ROOT_MODEL, "provider": ROOT_PROVIDER}})
+    _write_yaml(profile_env["profile_cfg"], {"model": {"inherit_root_primary": True}})
+
+    first = cfgmod.load_config()
+    assert first["model"]["default"] == ROOT_MODEL
+
+    # Root-only edit (profile file untouched) — must be observed with NO restart
+    # and NO cache clear.
+    _write_yaml(profile_env["root_cfg"], {"model": {"default": "root-model-changed", "provider": ROOT_PROVIDER}})
+    _bump_mtime(profile_env["root_cfg"])
+
+    second = cfgmod.load_config()
+    assert second["model"]["default"] == "root-model-changed"
+
+
+def test_root_create_and_delete_invalidate(profile_env):
+    _write_yaml(profile_env["profile_cfg"],
+                {"model": {"inherit_root_primary": True, "default": LOCAL_MODEL}})
+
+    # No root yet → keeps local.
+    assert cfgmod.load_config()["model"]["default"] == LOCAL_MODEL
+
+    # Create root → inherited.
+    _write_yaml(profile_env["root_cfg"], {"model": {"default": ROOT_MODEL, "provider": ROOT_PROVIDER}})
+    _bump_mtime(profile_env["root_cfg"])
+    assert cfgmod.load_config()["model"]["default"] == ROOT_MODEL
+
+    # Delete root → back to local (no stale inherited value).
+    profile_env["root_cfg"].unlink()
+    assert cfgmod.load_config()["model"]["default"] == LOCAL_MODEL
+
+
+# ── Cache: a NON-opted profile stays isolated from root churn ───────────────
+
+def test_non_opted_profile_cache_key_excludes_root_stat(profile_env):
+    """A non-opted named profile must NOT fold the root config's stat into its
+    load-cache signature. Otherwise every root create/change/delete would
+    needlessly invalidate a profile whose effective config never depends on root
+    (issue #43713 isolation)."""
+    _write_yaml(profile_env["root_cfg"], {"model": {"default": ROOT_MODEL, "provider": ROOT_PROVIDER}})
+    _write_yaml(profile_env["profile_cfg"], {"model": {"default": LOCAL_MODEL, "provider": LOCAL_PROVIDER}})
+
+    cfgmod.load_config()
+
+    cached = cfgmod._LOAD_CONFIG_CACHE[str(profile_env["profile_cfg"])]
+    # cache tuple: (user_mtime, user_size, managed_mtime, managed_size,
+    #               root_mtime, root_size, cfg, env_snap)
+    assert cached[4:6] == (0, 0)  # root stat NOT folded into a non-opted key
+
+
+def test_non_opted_profile_isolated_from_root_churn_long_lived(profile_env):
+    """Long-lived negative regression: within ONE process (no cache clear, no
+    restart), a root-config change must NOT invalidate a non-opted profile's
+    cached result — its cache signature is untouched and its model stays local.
+
+    The opted-in counterpart (``test_root_change_invalidates_cached_profile_result``)
+    guarantees the inverse, so the two together pin the exact boundary."""
+    _write_yaml(profile_env["root_cfg"], {"model": {"default": ROOT_MODEL, "provider": ROOT_PROVIDER}})
+    _write_yaml(profile_env["profile_cfg"], {"model": {"default": LOCAL_MODEL, "provider": LOCAL_PROVIDER}})
+
+    first = cfgmod.load_config()
+    assert first["model"]["default"] == LOCAL_MODEL
+    path_key = str(profile_env["profile_cfg"])
+    sig_before = cfgmod._LOAD_CONFIG_CACHE[path_key][:6]
+
+    # Root-only edit (profile file untouched); same process, NO cache clear.
+    _write_yaml(profile_env["root_cfg"], {"model": {"default": "root-model-changed", "provider": ROOT_PROVIDER}})
+    _bump_mtime(profile_env["root_cfg"])
+
+    second = cfgmod.load_config()
+    sig_after = cfgmod._LOAD_CONFIG_CACHE[path_key][:6]
+
+    assert sig_before == sig_after                    # root churn did NOT perturb the key
+    assert second["model"]["default"] == LOCAL_MODEL  # still fully isolated
+
+
+# ── Direct helper unit ──────────────────────────────────────────────────────
+
+def test_helper_is_noop_without_flag(profile_env):
+    _write_yaml(profile_env["root_cfg"], {"model": {"default": ROOT_MODEL, "provider": ROOT_PROVIDER}})
+    cfg = {"model": {"default": LOCAL_MODEL}}
+    out = cfgmod.apply_root_primary_model_inheritance(cfg, config_path=profile_env["profile_cfg"])
+    assert out["model"]["default"] == LOCAL_MODEL
+
+
+def test_helper_overlays_two_fields_when_opted_in(profile_env):
+    _write_yaml(profile_env["root_cfg"], {"model": {"default": ROOT_MODEL, "provider": ROOT_PROVIDER}})
+    cfg = {"model": {"inherit_root_primary": True}}
+    out = cfgmod.apply_root_primary_model_inheritance(cfg, config_path=profile_env["profile_cfg"])
+    assert out["model"]["default"] == ROOT_MODEL
+    assert out["model"]["provider"] == ROOT_PROVIDER
+
+
+# ── Consumer parity: `profile list` (profiles._read_config_model) ───────────
+
+def test_profile_list_reflects_inherited_model(tmp_path, monkeypatch):
+    """The former raw bypass now agrees with the canonical resolver: an opted-in
+    profile's listed model/provider reflects the inherited root values."""
+    from hermes_cli import profiles as profmod
+
+    root = tmp_path / "root"
+    coder = root / "profiles" / "coder"
+    plain = root / "profiles" / "plain"
+    coder.mkdir(parents=True, exist_ok=True)
+    plain.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setenv("HERMES_HOME", str(root))  # listing runs from the root install
+    cfgmod._LOAD_CONFIG_CACHE.clear()
+
+    _write_yaml(root / "config.yaml", {"model": {"default": ROOT_MODEL, "provider": ROOT_PROVIDER}})
+    _write_yaml(coder / "config.yaml", {"model": {"inherit_root_primary": True}})
+    _write_yaml(plain / "config.yaml", {"model": {"default": LOCAL_MODEL, "provider": LOCAL_PROVIDER}})
+
+    assert profmod._read_config_model(coder) == (ROOT_MODEL, ROOT_PROVIDER)   # inherited
+    assert profmod._read_config_model(plain) == (LOCAL_MODEL, LOCAL_PROVIDER)  # isolated
+    cfgmod._LOAD_CONFIG_CACHE.clear()
+
+
+# ── Cache: opt-in flag discovery must not re-parse the profile on cache hits ─
+#
+# The load-config cache exists to avoid re-parsing config.yaml on every call.
+# An opted-in named profile still has to learn the opt-in flag BEFORE the
+# cache-hit check (the flag decides whether the root stat is folded into the
+# signature). Discovering it must NOT cost an uncached profile YAML parse on a
+# cache hit — otherwise the cache is defeated for every opted-in profile. These
+# tests count the on-disk flag reads across cold load / cache hit / profile flag
+# change / root change (the four scenarios the fix must prove).
+
+def _spy_on_disk_flag_reads(monkeypatch):
+    """Count calls to the on-disk opt-in probe (the only 'extra parse solely to
+    discover the flag'). Returns a mutable counter dict."""
+    calls = {"n": 0}
+    orig = cfgmod._profile_opts_into_root_primary_on_disk
+
+    def _counting(config_path):
+        calls["n"] += 1
+        return orig(config_path)
+
+    monkeypatch.setattr(cfgmod, "_profile_opts_into_root_primary_on_disk", _counting)
+    return calls
+
+
+def test_opted_in_cache_hit_avoids_extra_flag_parse(profile_env, monkeypatch):
+    _write_yaml(profile_env["root_cfg"], {"model": {"default": ROOT_MODEL, "provider": ROOT_PROVIDER}})
+    _write_yaml(profile_env["profile_cfg"], {"model": {"inherit_root_primary": True}})
+    calls = _spy_on_disk_flag_reads(monkeypatch)
+
+    first = cfgmod.load_config()             # cold load
+    assert first["model"]["default"] == ROOT_MODEL
+    assert calls["n"] == 1                    # one parse to discover the flag
+
+    second = cfgmod.load_config()            # cache hit — nothing changed
+    assert second["model"]["default"] == ROOT_MODEL
+    assert calls["n"] == 1                    # NO extra parse on the cache hit
+
+
+def test_opted_in_flag_toggle_reparses_without_stale_opt_in(profile_env, monkeypatch):
+    _write_yaml(profile_env["root_cfg"], {"model": {"default": ROOT_MODEL, "provider": ROOT_PROVIDER}})
+    _write_yaml(profile_env["profile_cfg"], {"model": {"inherit_root_primary": True}})
+    calls = _spy_on_disk_flag_reads(monkeypatch)
+
+    assert cfgmod.load_config()["model"]["default"] == ROOT_MODEL
+    cfgmod.load_config()                      # cache hit
+    assert calls["n"] == 1
+
+    # Toggle the flag OFF (and keep a local default). Changing the profile file
+    # changes its (mtime, size) → the opt-in must be re-derived, not stale.
+    _write_yaml(profile_env["profile_cfg"],
+                {"model": {"inherit_root_primary": False, "default": LOCAL_MODEL, "provider": LOCAL_PROVIDER}})
+    _bump_mtime(profile_env["profile_cfg"])
+
+    cfg = cfgmod.load_config()
+    assert calls["n"] == 2                     # re-parsed after the profile changed
+    assert cfg["model"]["default"] == LOCAL_MODEL   # no stale opt-in → local wins now
+
+
+def test_root_change_needs_no_flag_reparse_yet_reloads(profile_env, monkeypatch):
+    _write_yaml(profile_env["root_cfg"], {"model": {"default": ROOT_MODEL, "provider": ROOT_PROVIDER}})
+    _write_yaml(profile_env["profile_cfg"], {"model": {"inherit_root_primary": True}})
+    calls = _spy_on_disk_flag_reads(monkeypatch)
+
+    assert cfgmod.load_config()["model"]["default"] == ROOT_MODEL
+    assert calls["n"] == 1
+
+    # Root-only edit (profile file untouched). The opt-in is unchanged, so it
+    # must NOT be re-parsed — but dynamic root-stat invalidation must still fire.
+    _write_yaml(profile_env["root_cfg"], {"model": {"default": "root-model-changed", "provider": ROOT_PROVIDER}})
+    _bump_mtime(profile_env["root_cfg"])
+
+    cfg = cfgmod.load_config()
+    assert calls["n"] == 1                     # profile flag NOT re-parsed on a root-only change
+    assert cfg["model"]["default"] == "root-model-changed"   # dynamic root invalidation preserved
+
+
+# ── Env expansion of inherited primary values (parity / consistency / security)
+
+def test_resolver_expands_inherited_env_ref(profile_env, monkeypatch):
+    """The single shared resolver every consumer routes through must return
+    ENV-EXPANDED inherited values, so CLI / gateway / doctor / profile-list /
+    cron all agree regardless of when they expand."""
+    monkeypatch.setenv("HERMES_TEST_RESOLVER_MODEL", "resolver-expanded-model")
+    _write_yaml(profile_env["root_cfg"],
+                {"model": {"default": "${HERMES_TEST_RESOLVER_MODEL}", "provider": ROOT_PROVIDER}})
+    cfg = {"model": {"inherit_root_primary": True}}
+
+    out = cfgmod.apply_root_primary_model_inheritance(cfg, config_path=profile_env["profile_cfg"])
+
+    assert out["model"]["default"] == "resolver-expanded-model"
+    assert out["model"]["provider"] == ROOT_PROVIDER
+
+
+def test_inherited_env_ref_consistent_normal_load_vs_cron(profile_env, monkeypatch):
+    """``load_config`` (normal load) and ``build_cron_effective_config`` (a
+    canonical consumer) must resolve an inherited ``${VAR}`` to the SAME value."""
+    monkeypatch.setenv("HERMES_TEST_CONSUMER_MODEL", "consumer-parity-model")
+    _write_yaml(profile_env["root_cfg"],
+                {"model": {"default": "${HERMES_TEST_CONSUMER_MODEL}", "provider": ROOT_PROVIDER}})
+    _write_yaml(profile_env["profile_cfg"], {"model": {"inherit_root_primary": True}})
+
+    from_load = cfgmod.load_config()["model"]["default"]
+    from_cron = cfgmod.build_cron_effective_config(profile_env["profile_cfg"])["model"]["default"]
+
+    assert from_load == from_cron == "consumer-parity-model"
+
+
+def test_inherited_env_ref_missing_stays_verbatim_like_local(profile_env, monkeypatch):
+    """A missing ``${VAR}`` in an inherited value is kept verbatim — identical to
+    how ``_expand_env_vars`` treats a missing ref in a profile-local value."""
+    monkeypatch.delenv("HERMES_TEST_MISSING_MODEL", raising=False)
+
+    # Local baseline: a non-opted profile with the same missing ref.
+    _write_yaml(profile_env["profile_cfg"], {"model": {"default": "${HERMES_TEST_MISSING_MODEL}"}})
+    local_default = cfgmod.load_config()["model"]["default"]
+    cfgmod._LOAD_CONFIG_CACHE.clear()
+
+    # Inherited: opted-in profile, root supplies the missing ref.
+    _write_yaml(profile_env["root_cfg"],
+                {"model": {"default": "${HERMES_TEST_MISSING_MODEL}", "provider": ROOT_PROVIDER}})
+    _write_yaml(profile_env["profile_cfg"], {"model": {"inherit_root_primary": True}})
+    _bump_mtime(profile_env["profile_cfg"])
+    inherited_default = cfgmod.load_config()["model"]["default"]
+
+    assert inherited_default == local_default == "${HERMES_TEST_MISSING_MODEL}"
+
+
+def test_only_primary_root_env_refs_are_expanded_or_merged(profile_env, monkeypatch):
+    """Security/isolation: only ``model.default`` + ``model.provider`` are read,
+    expanded and merged from root. A ``${VAR}`` in ANY non-primary root field is
+    never expanded and never crosses into the profile."""
+    monkeypatch.setenv("HERMES_TEST_PRIMARY", "primary-expanded")
+    monkeypatch.setenv("HERMES_TEST_SECRET", "secret-must-not-leak")
+    _write_yaml(profile_env["root_cfg"], {
+        "model": {
+            "default": "${HERMES_TEST_PRIMARY}", "provider": ROOT_PROVIDER,
+            "api_key": "${HERMES_TEST_SECRET}",
+        },
+        "providers": {"rootprov": {"api_key": "${HERMES_TEST_SECRET}"}},
+    })
+    _write_yaml(profile_env["profile_cfg"], {"model": {"inherit_root_primary": True}})
+
+    cfg = cfgmod.load_config()
+
+    assert cfg["model"]["default"] == "primary-expanded"       # primary IS expanded
+    # Root's non-primary fields never merge in — neither raw nor expanded.
+    assert cfg["model"].get("api_key") not in ("secret-must-not-leak", "${HERMES_TEST_SECRET}")
+    assert cfg.get("providers", {}).get("rootprov") is None
+    # The secret's expansion appears NOWHERE (root non-primary never expanded).
+    assert all(v != "secret-must-not-leak" for v in _leaf_paths(cfg).values())
+
+
+def test_inherited_env_ref_rotation_invalidates_cache(profile_env, monkeypatch):
+    """Matching existing env semantics (#58514): an in-process rotation of a
+    ``${VAR}`` referenced by the inherited root value invalidates the cached
+    profile result WITHOUT a file change or cache clear."""
+    monkeypatch.setenv("HERMES_TEST_ROT_MODEL", "rotation-value-A")
+    _write_yaml(profile_env["root_cfg"],
+                {"model": {"default": "${HERMES_TEST_ROT_MODEL}", "provider": ROOT_PROVIDER}})
+    _write_yaml(profile_env["profile_cfg"], {"model": {"inherit_root_primary": True}})
+
+    first = cfgmod.load_config()
+    assert first["model"]["default"] == "rotation-value-A"
+
+    monkeypatch.setenv("HERMES_TEST_ROT_MODEL", "rotation-value-B")  # rotate in-process
+    second = cfgmod.load_config()
+    assert second["model"]["default"] == "rotation-value-B"

--- a/tests/tui_gateway/test_tui_model_inheritance.py
+++ b/tests/tui_gateway/test_tui_model_inheritance.py
@@ -1,0 +1,126 @@
+"""Desktop/TUI + bridge primary-model resolution honors opt-in root inheritance.
+
+``tui_gateway/server.py`` reads config via ``_load_cfg`` (raw user file +
+managed overlay + ``${VAR}`` expansion), a bypass of ``load_config()``.
+``_resolve_model`` and ``_config_model_target`` both read ``_load_cfg()["model"]``.
+This proves that former bypass now routes the shared
+``hermes_cli.config.apply_root_primary_model_inheritance`` resolver, so an
+opted-in named profile's desktop/TUI/bridge model reflects the two inherited
+root scalars — while the write-back primitive ``_load_cfg_raw`` stays raw
+(never persisting inherited values), opted-out stays isolated, and root-only
+edits are observed without restart.
+
+Generic placeholder ids only — never a real model/provider.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+import yaml
+
+from hermes_cli import config as cfgmod
+import tui_gateway.server as server
+
+
+ROOT_MODEL = "root-model-alpha"
+ROOT_PROVIDER = "provider-root"
+LOCAL_MODEL = "local-model-beta"
+LOCAL_PROVIDER = "provider-local"
+MANAGED_MODEL = "managed-model-delta"
+
+
+def _write_yaml(path: Path, data: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(yaml.safe_dump(data), encoding="utf-8")
+
+
+def _bump_mtime(path: Path) -> None:
+    st = path.stat()
+    os.utime(path, ns=(st.st_atime_ns + 1_000_000_000, st.st_mtime_ns + 1_000_000_000))
+
+
+def _reset_cfg_cache():
+    server._cfg_cache = None
+    server._cfg_mtime = None
+    server._cfg_path = None
+
+
+@pytest.fixture
+def tui_profile_env(tmp_path, monkeypatch):
+    root = tmp_path / "root"
+    profile = root / "profiles" / "coder"
+    profile.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setenv("HERMES_HOME", str(profile))
+    monkeypatch.setattr(server, "_hermes_home", str(profile))
+    # No per-session override in these tests.
+    monkeypatch.setattr(server, "get_hermes_home_override", lambda: None)
+    _reset_cfg_cache()
+    cfgmod._LOAD_CONFIG_CACHE.clear()
+    cfgmod._RAW_CONFIG_CACHE.clear()
+    yield {
+        "root_cfg": root / "config.yaml",
+        "profile_cfg": profile / "config.yaml",
+    }
+    _reset_cfg_cache()
+    cfgmod._LOAD_CONFIG_CACHE.clear()
+    cfgmod._RAW_CONFIG_CACHE.clear()
+
+
+def test_tui_opted_in_profile_inherits_root_primary(tui_profile_env):
+    _write_yaml(tui_profile_env["root_cfg"], {"model": {"default": ROOT_MODEL, "provider": ROOT_PROVIDER}})
+    _write_yaml(tui_profile_env["profile_cfg"], {"model": {"inherit_root_primary": True}})
+
+    assert server._resolve_model() == ROOT_MODEL
+    assert server._config_model_target() == (ROOT_MODEL, ROOT_PROVIDER)
+
+
+def test_tui_load_cfg_raw_stays_raw(tui_profile_env):
+    """The write-back primitive must NOT carry inherited values (else a save
+    would persist root's model into the profile file)."""
+    _write_yaml(tui_profile_env["root_cfg"], {"model": {"default": ROOT_MODEL, "provider": ROOT_PROVIDER}})
+    _write_yaml(tui_profile_env["profile_cfg"], {"model": {"inherit_root_primary": True}})
+
+    raw = server._load_cfg_raw()
+    assert "default" not in raw.get("model", {})
+    assert "provider" not in raw.get("model", {})
+
+
+def test_tui_default_off_stays_isolated(tui_profile_env):
+    _write_yaml(tui_profile_env["root_cfg"], {"model": {"default": ROOT_MODEL, "provider": ROOT_PROVIDER}})
+    _write_yaml(tui_profile_env["profile_cfg"], {"model": {"default": LOCAL_MODEL, "provider": LOCAL_PROVIDER}})
+
+    assert server._resolve_model() == LOCAL_MODEL
+    assert server._config_model_target() == (LOCAL_MODEL, LOCAL_PROVIDER)
+
+
+def test_tui_managed_overlay_wins_over_inherited_root(tui_profile_env, tmp_path, monkeypatch):
+    """Canonical precedence: an administrator-pinned managed model.default must
+    win over an inherited root value, while an un-pinned managed leaf
+    (model.provider) still fills from the inherited root."""
+    _write_yaml(tui_profile_env["root_cfg"], {"model": {"default": ROOT_MODEL, "provider": ROOT_PROVIDER}})
+    _write_yaml(tui_profile_env["profile_cfg"], {"model": {"inherit_root_primary": True}})
+
+    managed_dir = tmp_path / "managed"
+    _write_yaml(managed_dir / "config.yaml", {"model": {"default": MANAGED_MODEL}})
+    monkeypatch.setenv("HERMES_MANAGED_DIR", str(managed_dir))
+    from hermes_cli import managed_scope
+    managed_scope.invalidate_managed_cache()
+
+    assert server._resolve_model() == MANAGED_MODEL  # managed wins
+    assert server._config_model_target() == (MANAGED_MODEL, ROOT_PROVIDER)  # provider inherited
+    managed_scope.invalidate_managed_cache()
+
+
+def test_tui_root_change_observed_without_restart(tui_profile_env):
+    _write_yaml(tui_profile_env["root_cfg"], {"model": {"default": ROOT_MODEL, "provider": ROOT_PROVIDER}})
+    _write_yaml(tui_profile_env["profile_cfg"], {"model": {"inherit_root_primary": True}})
+
+    assert server._resolve_model() == ROOT_MODEL
+
+    _write_yaml(tui_profile_env["root_cfg"], {"model": {"default": "root-model-changed", "provider": ROOT_PROVIDER}})
+    _bump_mtime(tui_profile_env["root_cfg"])
+
+    assert server._resolve_model() == "root-model-changed"

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -3287,7 +3287,31 @@ def _load_cfg() -> dict:
     round-trips or expanded/overlaid values get persisted into the user's
     file.
     """
-    cfg = _apply_managed(_load_cfg_raw())
+    cfg = _load_cfg_raw()
+    # Opt-in root primary-model inheritance — applied to the RAW user config
+    # BEFORE the managed overlay so an administrator-pinned managed
+    # model.default/provider still WINS over the inherited root value (canonical
+    # load_config precedence: managed > inherited root > profile-local). Read-side
+    # only; NEVER applied in _load_cfg_raw, which _save_cfg writes back —
+    # inheriting there would persist root's model into the profile file. Keyed on
+    # the active profile's OWN config path so the self-inheritance guard and
+    # $HERMES_HOME isolation hold; reads root fresh so root-only edits are
+    # observed without restart. Mirrors the gateway and canonical load_config()
+    # resolvers.
+    try:
+        from hermes_cli.config import apply_root_primary_model_inheritance
+
+        override = get_hermes_home_override()
+        home = override if isinstance(override, str) and override else _hermes_home
+        cfg = apply_root_primary_model_inheritance(
+            cfg, config_path=Path(home) / "config.yaml"
+        )
+    except Exception:
+        pass
+    # Managed overlay WINS (applied AFTER inheritance), then ${VAR} expansion —
+    # the same read-side pipeline as load_config_readonly, minus the
+    # DEFAULT_CONFIG merge (callers here treat a missing key as "unset").
+    cfg = _apply_managed(cfg)
     try:
         from hermes_cli.config import _expand_env_vars
 

--- a/website/docs/user-guide/multi-profile-gateways.md
+++ b/website/docs/user-guide/multi-profile-gateways.md
@@ -444,6 +444,27 @@ coder gateway restart
 hermes-gateways restart
 ```
 
+### Steer one model for opted-in profiles
+
+A named profile can opt in to inheriting **only** the root install's primary
+model — `model.default` and `model.provider` from `~/.hermes/config.yaml` — so a
+fleet of gateways can follow a single model choice:
+
+```bash
+coder config set model.inherit_root_primary true    # per profile, default false
+hermes config set model.default <your-model>         # change once at the root
+hermes config set model.provider <your-provider>
+```
+
+The running gateway (and the multiplexing gateway's per-profile routing) picks
+up a root-config change on the next resolution — **no restart needed**, because
+the root file's mtime is part of the config cache key. Only those two fields are
+inherited; credentials, `providers` definitions, `base_url`, `api_key`, and all
+other gateway/profile state stay isolated per profile — so the inherited
+`model.provider` must still be one the profile can authenticate on its own. See
+[Inherit the root model](profiles.md#inherit-the-root-model-opt-in) for the full
+boundary, migration, and rollback steps.
+
 ## Keeping the host awake
 
 The gateway process can run all day, but the operating system will still try

--- a/website/docs/user-guide/profiles.md
+++ b/website/docs/user-guide/profiles.md
@@ -209,6 +209,73 @@ If you want this profile to work in a specific project by default, also set its 
 coder config set terminal.cwd /absolute/path/to/project
 ```
 
+### Inherit the root model (opt-in)
+
+By default every profile is a fully isolated `HERMES_HOME` island: it never
+reads another profile's or the root install's config. If you want one place to
+steer the **primary model** for a named profile, you can opt that profile in to
+inheriting **only** the root install's primary routing from `~/.hermes/config.yaml`:
+
+```bash
+# Opt the coder profile in (default is false):
+coder config set model.inherit_root_primary true
+
+# Now the coder profile's effective model.default and model.provider come from
+# the root ~/.hermes/config.yaml. Change the root once and every opted-in
+# profile follows on its next run — no restart, no per-profile edit:
+hermes config set model.default <your-model>
+hermes config set model.provider <your-provider>
+```
+
+**What is inherited: exactly two fields.** Only `model.default` and
+`model.provider` are read from the root config. **Nothing else crosses the
+profile boundary** — not `providers` / custom provider definitions, credentials
+or API keys, `model.base_url`, `model.api_key`, aliases, delegation
+model/provider, terminal settings, toolsets, memory, skills, sessions, cron,
+logs, or gateway state. Those continue to resolve from Hermes' built-in
+defaults plus the profile's own `config.yaml`, exactly as before.
+
+:::warning Credentials and providers are NOT shared
+Inheriting the root model does **not** give the profile the root's API keys or
+provider definitions. The inherited `model.provider` must still resolve to a
+provider the profile can authenticate on its own (its own `.env` / credentials
+and, for custom providers, its own `providers` entry). If the profile can't
+reach that provider, set the model locally instead.
+:::
+
+**Where the flag lives.** `model.inherit_root_primary` is set in the **named
+profile's own** `config.yaml` (via `-p <profile>` / the profile alias), never in
+the root config. The default/root profile ignores the flag — it can never
+inherit from itself.
+
+**Migration-safe with a legacy local model.** If the profile still has its own
+`model.default` / `model.provider` from before opting in, the root value wins
+for each field the root actually sets; a field the root omits falls back to the
+profile's own value. You can clean up the now-redundant local fields with the
+CLI (never hand-edit `config.yaml`):
+
+```bash
+coder config unset model.default
+coder config unset model.provider
+```
+
+**Cache / reload.** Long-lived processes (gateways, the desktop/TUI backend,
+Kanban workers) pick up a root-config create, change, or delete on the next
+resolution automatically — the root file's modification time is part of the
+config cache key, so a root-only edit is observed without a restart.
+
+**Rollback.** Turn inheritance off again at any time:
+
+```bash
+coder config set model.inherit_root_primary false
+# or remove the flag entirely:
+coder config unset model.inherit_root_primary
+```
+
+If the root config is missing or malformed while a profile is opted in, Hermes
+fails safe: it logs one actionable diagnostic, keeps the profile's own values,
+and never broadens what is inherited.
+
 ### From the dashboard
 
 The [web dashboard](features/web-dashboard.md#managing-multiple-profiles)


### PR DESCRIPTION
## Summary

Adds **opt-in** inheritance of a root install's primary model into named profiles. A named profile may set `model.inherit_root_primary: true` to inherit **only** `model.default` and `model.provider` from the root install's `config.yaml`. The default is **false** — existing behavior is unchanged unless a profile explicitly opts in, and the root/default profile never inherits from itself.

## Scope & isolation

- **Only** `model.default` and `model.provider` cross the boundary. Nothing else does: providers, credentials, aliases, delegation, `base_url`/`api_key`, terminal, toolsets, memory, sessions, cron, logs, and gateway state all stay fully isolated per profile.
- **Precedence** matches `load_config()`: managed overlay > inherited root > profile-local.
- **Environment**: environment-provided model settings continue to apply exactly as before; inheritance only fills the primary model when a profile opts in and does not override explicit env configuration.
- **Fail-safe**: a missing or malformed root config logs a single actionable diagnostic, keeps the profile's own values, and never broadens what is inherited.

## Consumer routing

A single shared resolver (`apply_root_primary_model_inheritance`) is the one entry point every primary-model consumer routes through — the CLI config bridge, profile listing, doctor, gateway, TUI, and (via `build_cron_effective_config`) the cron scheduler and create-time job snapshot — so `hermes config get` and every runtime agree on the effective model.

## Cache behavior

Root create/change/delete invalidates only an opted-in profile's load-config cache; the root config's mtime/size is folded into the cache signature **only** when a profile is opted in. The default/root profile and non-opted named profiles are byte-for-byte unchanged and never fold root stat into their cache signature.

## Verification (local receipts)

- Full test suite: **30,880 passed**, with **0 candidate regressions** attributable to this change.
- Focused suite for this feature: **43/43 passed**.
- Config and consumer test clusters: green.
- **Four mutation proofs** confirming the guarding logic (opt-in gate, inherited-field scope, precedence order, cache-signature folding) fails closed when inverted.
- Final independent ship review: **0 BLOCKER / 0 HIGH / 0 MEDIUM**.

Known pre-existing upstream/environment baseline failures are unrelated to this change and are reported honestly as baseline (not introduced here). No live installation was performed as part of this validation.
