### PR TITLE
fix(install): report a managed Node that cannot start, and preinstall libatomic1

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -881,7 +881,7 @@ install_node() {
         log_info "Installing Node.js via pkg..."
         if pkg install -y nodejs >/dev/null; then
             local installed_ver
-            installed_ver=$(node --version 2>/dev/null)
+            installed_ver=$(node --version 2>/dev/null || true)
             log_success "Node.js $installed_ver installed via pkg"
             HAS_NODE=true
         else
@@ -974,6 +974,21 @@ install_node() {
     mv "$extracted_dir" "$HERMES_HOME/node"
     rm -rf "$tmp_dir"
 
+    # Node's official linux-x64 builds (observed: v26.7.0) link
+    # libatomic.so.1, which minimal Debian/Ubuntu images do not ship —
+    # the freshly downloaded binary then fails to start. Install the
+    # library up front, best-effort; the version probe below reports
+    # clearly if the binary still cannot run (#87460).
+    if [ "$OS" = "linux" ] && { [ "$DISTRO" = "ubuntu" ] || [ "$DISTRO" = "debian" ]; }; then
+        if command -v apt-get >/dev/null 2>&1; then
+            local sudo_cmd=""
+            if [ "$(id -u 2>/dev/null || echo 1000)" -ne 0 ]; then
+                command -v sudo >/dev/null 2>&1 && sudo_cmd="sudo"
+            fi
+            $sudo_cmd env DEBIAN_FRONTEND=noninteractive apt-get install -y -qq libatomic1 >/dev/null 2>&1 || true
+        fi
+    fi
+
     local node_link_dir
     node_link_dir="$(get_command_link_dir)"
     mkdir -p "$node_link_dir"
@@ -986,7 +1001,20 @@ install_node() {
     export PATH="$HERMES_HOME/node/bin:$PATH"
 
     local installed_ver
-    installed_ver=$("$HERMES_HOME/node/bin/node" --version 2>/dev/null)
+    if ! installed_ver=$("$HERMES_HOME/node/bin/node" --version 2>&1); then
+        # The downloaded Node exists but cannot start (observed: Node 26
+        # linux-x64 binaries link libatomic.so.1, missing on minimal
+        # Debian/Ubuntu). Under set -e this assignment used to abort the
+        # whole installer at exit 127 with the loader's explanation
+        # discarded by 2>/dev/null — installs died mid-sentence with no
+        # output at all (#87460). Degrade instead, and surface the real
+        # error the loader printed.
+        log_error "Downloaded Node.js failed to start:"
+        printf '%s\n' "$installed_ver" >&2
+        log_info "On Debian/Ubuntu the usual fix is: sudo apt-get install -y libatomic1"
+        HAS_NODE=false
+        return 0
+    fi
     log_success "Node.js $installed_ver installed to ~/.hermes/node/"
     HAS_NODE=true
 }

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -882,8 +882,17 @@ install_node() {
         if pkg install -y nodejs >/dev/null; then
             local installed_ver
             installed_ver=$(node --version 2>/dev/null || true)
-            log_success "Node.js $installed_ver installed via pkg"
-            HAS_NODE=true
+            if [ -n "$installed_ver" ]; then
+                log_success "Node.js $installed_ver installed via pkg"
+                HAS_NODE=true
+            else
+                # pkg succeeded but the binary cannot start — the same
+                # silent-success class the managed-download probe guards
+                # against (#87460). Degrade instead of claiming success.
+                log_error "Node.js installed via pkg failed to start:"
+                node --version >&2 || true
+                HAS_NODE=false
+            fi
         else
             log_warn "Failed to install Node.js via pkg"
             HAS_NODE=false
@@ -1008,10 +1017,14 @@ install_node() {
         # whole installer at exit 127 with the loader's explanation
         # discarded by 2>/dev/null — installs died mid-sentence with no
         # output at all (#87460). Degrade instead, and surface the real
-        # error the loader printed.
+        # error the loader printed. Remove the broken tree and the bin
+        # links so later steps and retry runs start clean instead of
+        # resolving `node` to a binary that cannot start.
         log_error "Downloaded Node.js failed to start:"
         printf '%s\n' "$installed_ver" >&2
         log_info "On Debian/Ubuntu the usual fix is: sudo apt-get install -y libatomic1"
+        rm -rf "$HERMES_HOME/node"
+        rm -f "$node_link_dir/node" "$node_link_dir/npm" "$node_link_dir/npx"
         HAS_NODE=false
         return 0
     fi

--- a/tests/test_install_sh_node_probe_87460.py
+++ b/tests/test_install_sh_node_probe_87460.py
@@ -153,6 +153,18 @@ def test_broken_node_degrades_with_clear_error(tmp_path: Path) -> None:
     assert "apt-get install -y libatomic1" in stdout + stderr
     assert "HAS_NODE=false" in stdout
     assert "HAS_NODE=true" not in stdout
+    # AI-review follow-up: the broken tree and bin links must not linger
+    # — retries and later installer steps resolve `node` cleanly.
+    home = tmp_path / "home"
+    link_dir = tmp_path / "links"
+    assert not (home / "node").exists(), "broken managed Node tree left behind"
+    assert not (link_dir / "node").exists(), "broken node symlink left behind"
+    assert not (link_dir / "npm").exists(), "broken npm symlink left behind"
+    # AI-review follow-up: the broken tree and bin links must not linger
+    # — retries and later installer steps resolve `node` cleanly.
+    assert not (home / "node").exists(), "broken managed Node tree left behind"
+    assert not (link_dir / "node").exists(), "broken node symlink left behind"
+    assert not (link_dir / "npm").exists(), "broken npm symlink left behind"
 
 
 def test_healthy_node_reports_success(tmp_path: Path) -> None:

--- a/tests/test_install_sh_node_probe_87460.py
+++ b/tests/test_install_sh_node_probe_87460.py
@@ -1,0 +1,169 @@
+"""Behavioral coverage for install_node's post-install version probe (#87460).
+
+The probe used to be `installed_ver=$(node --version 2>/dev/null)` under
+`set -e`: a Node binary that exists but cannot start (Node 26 linux-x64
+links libatomic.so.1, missing on minimal Debian/Ubuntu) aborted the whole
+installer at exit 127 with the loader's explanation discarded — installs
+died mid-sentence with no output at all. The probe must degrade with a
+clear error carrying the loader's message, and Debian/Ubuntu installs
+must attempt libatomic1 up front.
+"""
+
+from __future__ import annotations
+
+import io
+import os
+import re
+import subprocess
+import tarfile
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+INSTALL_SH = REPO_ROOT / "scripts" / "install.sh"
+
+
+def _extract_install_node() -> str:
+    src = INSTALL_SH.read_text(encoding="utf-8")
+    match = re.search(r"^install_node\(\) \{\n(.*?)^\}", src, re.S | re.M)
+    assert match is not None, "install_node() not found in scripts/install.sh"
+    return match.group(1)
+
+
+def _make_node_tarball(path: Path, node_body: str) -> None:
+    """A .tar.xz-named gzip archive — both bsdtar and modern GNU tar sniff
+    compression by content, so the extension mismatch is irrelevant here."""
+    root = "node-v26.7.0-linux-x64"
+    with tarfile.open(path, "w:gz") as tar:
+        for name, body, mode in (
+            (f"{root}/bin/node", node_body, 0o755),
+            (f"{root}/bin/npm", "#!/bin/sh\nexit 0\n", 0o755),
+            (f"{root}/bin/npx", "#!/bin/sh\nexit 0\n", 0o755),
+        ):
+            data = body.encode("utf-8")
+            info = tarfile.TarInfo(name=name)
+            info.size = len(data)
+            info.mode = mode
+            tar.addfile(info, io.BytesIO(data))
+
+
+def _run_install_node(tmp_path: Path, node_body: str) -> tuple[int, str, str, list[str]]:
+    bin_dir = tmp_path / "bin"
+    home = tmp_path / "home"
+    link_dir = tmp_path / "links"
+    fixture = tmp_path / "fixture.tar.xz"
+    apt_log = tmp_path / "apt-calls"
+
+    bin_dir.mkdir()
+    home.mkdir()
+    link_dir.mkdir()
+    _make_node_tarball(fixture, node_body)
+
+    def _stub(name: str, body: str) -> None:
+        stub = bin_dir / name
+        stub.write_text(body, encoding="utf-8")
+        stub.chmod(0o755)
+
+    _stub(
+        "uname",
+        "#!/bin/sh\n"
+        'if [ "${1:-}" = "-m" ]; then echo x86_64; else echo Linux; fi\n',
+    )
+    _stub(
+        "curl",
+        "#!/bin/sh\n"
+        "# Called as: curl -fsSL <index-url>        (stdout -> tarball name)\n"
+        "#           curl -fsSL <download-url> -o <path>\n"
+        "if [ \"${3:-}\" = \"-o\" ]; then\n"
+        '    cp "$FIXTURE" "$4"\n'
+        "else\n"
+        "    echo 'node-v26.7.0-linux-x64.tar.xz'\n"
+        "fi\n",
+    )
+    _stub("sudo", "#!/bin/sh\nshift_if_env() { :; }\nexec env \"$@\"\n")
+    _stub(
+        "apt-get",
+        "#!/bin/sh\nprintf '%s\\n' \"$*\" >> \"$APT_LOG\"\nexit 0\n",
+    )
+
+    env = os.environ.copy()
+    env.update(
+        {
+            "FIXTURE": str(fixture),
+            "APT_LOG": str(apt_log),
+            "PATH": f"{bin_dir}:{env['PATH']}",
+        }
+    )
+
+    driver = tmp_path / "driver.sh"
+    driver.write_text(
+        "#!/usr/bin/env bash\n"
+        "set -euo pipefail\n"
+        "OS=linux\n"
+        "DISTRO=ubuntu\n"
+        "NODE_VERSION=26\n"
+        f"HERMES_HOME={home}\n"
+        "HAS_NODE=maybe\n"
+        "log_info()    { printf 'INFO %s\\n' \"$*\"; }\n"
+        "log_success() { printf 'OK %s\\n' \"$*\"; }\n"
+        "log_warn()    { printf 'WARN %s\\n' \"$*\"; }\n"
+        "log_error()   { printf 'ERROR %s\\n' \"$*\" >&2; }\n"
+        f"get_command_link_dir() {{ echo {link_dir}; }}\n"
+        "configure_managed_node_npm_prefix() { return 0; }\n"
+        "install_node() {\n"
+        f"{_extract_install_node()}"
+        "}\n"
+        "install_node\n"
+        'printf "HAS_NODE=%s\\n" "$HAS_NODE"\n',
+        encoding="utf-8",
+    )
+
+    proc = subprocess.run(
+        ["bash", str(driver)],
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    apt_calls = (
+        apt_log.read_text(encoding="utf-8").splitlines()
+        if apt_log.exists()
+        else []
+    )
+    return proc.returncode, proc.stdout, proc.stderr, apt_calls
+
+
+BROKEN_NODE = (
+    "#!/bin/sh\n"
+    "echo 'node: error while loading shared libraries: libatomic.so.1: "
+    "cannot open shared object file: No such file or directory' >&2\n"
+    "exit 127\n"
+)
+
+HEALTHY_NODE = "#!/bin/sh\necho v26.7.0\n"
+
+
+def test_broken_node_degrades_with_clear_error(tmp_path: Path) -> None:
+    code, stdout, stderr, _ = _run_install_node(tmp_path, BROKEN_NODE)
+
+    # Old behavior: silent abort at exit 127 with no output (#87460).
+    assert code == 0, stderr
+    assert "Downloaded Node.js failed to start:" in stderr
+    assert "libatomic.so.1" in stderr
+    assert "apt-get install -y libatomic1" in stdout + stderr
+    assert "HAS_NODE=false" in stdout
+    assert "HAS_NODE=true" not in stdout
+
+
+def test_healthy_node_reports_success(tmp_path: Path) -> None:
+    code, stdout, stderr, _ = _run_install_node(tmp_path, HEALTHY_NODE)
+
+    assert code == 0, stderr
+    assert "Node.js v26.7.0 installed" in stdout
+    assert "HAS_NODE=true" in stdout
+
+
+def test_libatomic1_is_preinstalled_on_ubuntu(tmp_path: Path) -> None:
+    _, _, _, apt_calls = _run_install_node(tmp_path, HEALTHY_NODE)
+
+    assert any("libatomic1" in call for call in apt_calls), apt_calls


### PR DESCRIPTION
## What does this PR do?

Fixes the silent exit-127 installer death on minimal Ubuntu (#87460), at both layers the issue identifies:

1. **The probe no longer discards the failure.** `install_node`'s post-install check was `installed_ver=$(node --version 2>/dev/null)` under `set -e` — a downloaded Node that exists but cannot start made the assignment abort the whole installer with the loader's explanation thrown away, so installs died mid-sentence with empty stderr. The probe now runs in a condition position, captures stderr, and on failure degrades (`HAS_NODE=false`, matching every other failure path in `install_node`) while printing `Downloaded Node.js failed to start:` followed by the loader's actual message plus the `libatomic1` hint.
2. **The common cause is preinstalled.** Node's official `linux-x64` builds (observed: v26.7.0, resolved live from `latest-v26.x` so the exact build shifts under an unchanged script) link `libatomic.so.1`, which minimal Debian/Ubuntu images lack. `install_node` now installs `libatomic1` best-effort on Debian/Ubuntu before first launching the binary, using the script's existing `$sudo_cmd env DEBIAN_FRONTEND=... apt-get ... || true` idiom.

The Termux branch's same-shaped probe gets a `|| true` guard so a broken pkg-installed node cannot abort there either.

## Related Issue

Fixes #87460

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `scripts/install.sh` — `install_node`: libatomic1 preinstall block for linux/Debian-family before the binary first runs; version probe rewritten to `if ! installed_ver=$(... 2>&1)` with a `log_error` carrying the captured loader message and a `log_info` hint, degrading via `HAS_NODE=false` instead of aborting; Termux probe gets `|| true`.
- `tests/test_install_sh_node_probe_87460.py` — behavioral harness that extracts the real `install_node()` from the script and drives it with fake `uname`/`curl`/`sudo`/`apt-get` plus a fixture tarball: (a) a broken node binary must degrade with the loader message surfaced (old behavior: silent exit 127); (b) a healthy node reports success; (c) the apt call log shows `libatomic1` was attempted on Ubuntu.

## How to Test

1. `uv run --extra acp pytest tests/test_install_sh_node_probe_87460.py -q` — should pass.
2. `uv run --extra acp pytest tests/test_install_sh_node_probe_87460.py tests/test_install_sh_node_deps_failure.py tests/test_install_sh_node_npm_check.py tests/test_install_sh_node_global_prefix.py -q` — Observed result: `11 passed`.
3. Observed result with the probe unpatched (reverted `scripts/` only): `test_broken_node_degrades_with_clear_error` and `test_libatomic1_is_preinstalled_on_ubuntu` fail — the harness aborts at exit 127 with the error discarded, reproducing the report.
4. The issue's docker reproduction on `ubuntu:24.04` should now complete the Node stage (libatomic1 preinstalled) — and if a future Node build grows another missing dependency, the installer prints the loader's message instead of dying silently.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
