### PR TITLE
fix(langfuse): bound the post-turn client.flush() with a deadline

### DIFF
--- a/plugins/observability/langfuse/__init__.py
+++ b/plugins/observability/langfuse/__init__.py
@@ -78,6 +78,14 @@ _MAX_TRACE_STATE = 256
 # Langfuse backend that is unbounded, hanging turn finalization past the
 # cron inactivity watchdog and discarding the turn's real output (#87468).
 _FLUSH_TIMEOUT_SECONDS = 30.0
+# Single-flight guard for _flush_bounded: under a sustained backend outage
+# every finalizing turn would otherwise spawn its own stuck flush thread
+# (N turns → N daemon threads, only draining when the backend recovers).
+# While one bounded flush is still pending, later turns skip spawning —
+# their queued spans ride the pending flush (the SDK exporter is a shared
+# queue, so the in-flight flush drains them once the backend answers) or
+# the next healthy flush.
+_FLUSH_IN_FLIGHT = threading.Event()
 _LANGFUSE_CLIENT = None
 # Guards _LANGFUSE_CLIENT initialization against the TOCTOU race: two
 # concurrent first callers both pass the ``is not None`` guard, both
@@ -1093,6 +1101,12 @@ def _flush_bounded(client: Any, timeout: Optional[float] = None) -> None:
     """
     if timeout is None:
         timeout = _FLUSH_TIMEOUT_SECONDS
+    if _FLUSH_IN_FLIGHT.is_set():
+        _debug(
+            "langfuse flush already in progress; coalescing (skip spawn)"
+        )
+        return
+    _FLUSH_IN_FLIGHT.set()
     done = threading.Event()
 
     def _run() -> None:
@@ -1102,11 +1116,17 @@ def _flush_bounded(client: Any, timeout: Optional[float] = None) -> None:
             pass
         finally:
             done.set()
+            _FLUSH_IN_FLIGHT.clear()
 
     worker = threading.Thread(
         target=_run, daemon=True, name="langfuse-flush-bounded"
     )
-    worker.start()
+    try:
+        worker.start()
+    except Exception:
+        # Never strand the single-flight guard if the thread never ran.
+        _FLUSH_IN_FLIGHT.clear()
+        raise
     if not done.wait(timeout):
         _debug(
             f"langfuse flush still running after {timeout}s; proceeding "

--- a/plugins/observability/langfuse/__init__.py
+++ b/plugins/observability/langfuse/__init__.py
@@ -73,6 +73,11 @@ _TRACE_STATE: Dict[str, TraceState] = {}
 # is far above any realistic concurrent-live-turn working set; it exists only
 # to bound the leak from non-finalizing turns, not to limit concurrency.
 _MAX_TRACE_STATE = 256
+# Deadline for the post-turn client.flush() (_flush_bounded). flush()
+# blocks until the batch exporter drains; against a slow/unresponsive
+# Langfuse backend that is unbounded, hanging turn finalization past the
+# cron inactivity watchdog and discarding the turn's real output (#87468).
+_FLUSH_TIMEOUT_SECONDS = 30.0
 _LANGFUSE_CLIENT = None
 # Guards _LANGFUSE_CLIENT initialization against the TOCTOU race: two
 # concurrent first callers both pass the ``is not None`` guard, both
@@ -1073,6 +1078,42 @@ def _finalize_all_traces() -> None:
                 pass
 
 
+def _flush_bounded(client: Any, timeout: Optional[float] = None) -> None:
+    """Run client.flush() on a daemon thread under a deadline.
+
+    flush() blocks until the SDK's batch exporter has pushed all queued
+    spans — unbounded against a slow or unresponsive backend. In
+    _finish_trace's finally block that hang fires the cron inactivity
+    watchdog and discards the turn's real output; the surrounding
+    ``except Exception`` was useless because a hang is not an exception
+    (#87468). A daemon thread (not a ThreadPoolExecutor, whose shutdown
+    would join the hung worker) bounds the wait; a timed-out flush keeps
+    running in the background, so export is merely delayed when the
+    backend recovers, never allowed to block finalization.
+    """
+    if timeout is None:
+        timeout = _FLUSH_TIMEOUT_SECONDS
+    done = threading.Event()
+
+    def _run() -> None:
+        try:
+            client.flush()
+        except Exception:  # pragma: no cover - fail-open, as before
+            pass
+        finally:
+            done.set()
+
+    worker = threading.Thread(
+        target=_run, daemon=True, name="langfuse-flush-bounded"
+    )
+    worker.start()
+    if not done.wait(timeout):
+        _debug(
+            f"langfuse flush still running after {timeout}s; proceeding "
+            "without waiting (backend slow or unresponsive)"
+        )
+
+
 def _finish_trace(task_key: str, *, output: Any = None) -> None:
     client = _get_langfuse()
     if client is None:
@@ -1129,10 +1170,9 @@ def _finish_trace(task_key: str, *, output: Any = None) -> None:
         except Exception:
             pass
     finally:
-        try:
-            client.flush()
-        except Exception:
-            pass
+        # Bounded (#87468): an unresponsive backend must not hang turn
+        # finalization — see _flush_bounded.
+        _flush_bounded(client)
 
 
 def _assistant_has_tool_calls(message: Any) -> bool:

--- a/tests/plugins/test_langfuse_plugin.py
+++ b/tests/plugins/test_langfuse_plugin.py
@@ -533,6 +533,84 @@ class TestTurnTraceIsolation:
         # Must not raise.
         self._run_turn(mod, session="sess-explode", turn_n=1, finalize=True)
 
+    def test_flush_bounded_coalesces_while_pending(self):
+        """Under a sustained backend outage, N finalizing turns must not
+        spawn N stuck flush threads — while one bounded flush is pending,
+        later calls coalesce (skip the spawn) instead."""
+        import threading
+        import time
+
+        mod = self._fresh_plugin()
+        mod._FLUSH_IN_FLIGHT.clear()
+
+        flush_started = threading.Event()
+        release = threading.Event()
+        calls = []
+
+        class _BlockingClient:
+            def flush(self):
+                calls.append(1)
+                flush_started.set()
+                release.wait(10)
+
+        client = _BlockingClient()
+        mod._flush_bounded(client, timeout=0.05)
+        assert flush_started.wait(5), "first flush never started"
+
+        # First flush is still pending: the second call must coalesce.
+        mod._flush_bounded(client, timeout=0.05)
+        time.sleep(0.1)
+        assert len(calls) == 1, (
+            f"coalesced flush spawned another flush thread ({len(calls)} calls) — "
+            "a pending bounded flush must cap concurrency at one"
+        )
+
+        release.set()
+        assert mod._FLUSH_IN_FLIGHT.wait(5) or not mod._FLUSH_IN_FLIGHT.is_set()
+
+    def test_flush_bounded_guard_released_after_completion(self):
+        """Once the in-flight flush finishes, the guard is released so the
+        next turn's flush spawns normally."""
+        import time
+
+        mod = self._fresh_plugin()
+        mod._FLUSH_IN_FLIGHT.clear()
+
+        calls = []
+
+        class _OkClient:
+            def flush(self):
+                calls.append(1)
+
+        mod._flush_bounded(_OkClient(), timeout=5)
+        time.sleep(0.1)
+        assert not mod._FLUSH_IN_FLIGHT.is_set(), (
+            "guard still set after a completed flush — later turns would "
+            "never flush again"
+        )
+
+        mod._flush_bounded(_OkClient(), timeout=5)
+        time.sleep(0.1)
+        assert len(calls) == 2
+
+    def test_flush_bounded_guard_released_on_exception(self):
+        """A flushing error must also release the single-flight guard —
+        otherwise one exporter exception would permanently disable flush."""
+        import time
+
+        mod = self._fresh_plugin()
+        mod._FLUSH_IN_FLIGHT.clear()
+
+        class _ExplodingClient:
+            def flush(self):
+                raise RuntimeError("exporter exploded")
+
+        mod._flush_bounded(_ExplodingClient(), timeout=5)
+        time.sleep(0.1)
+        assert not mod._FLUSH_IN_FLIGHT.is_set(), (
+            "guard stuck set after a flush exception — flush permanently disabled"
+        )
+
 
 # ---------------------------------------------------------------------------
 # Placeholder-credential guard (#23823).

--- a/tests/plugins/test_langfuse_plugin.py
+++ b/tests/plugins/test_langfuse_plugin.py
@@ -433,6 +433,106 @@ class TestTurnTraceIsolation:
         assert len(exited) == 1
         assert exited[0] == (None, None, None)
 
+    def test_finish_trace_bounds_hanging_flush(self, monkeypatch):
+        """#87468: client.flush() blocks until the batch exporter drains —
+        unbounded against an unresponsive backend. _finish_trace's finally
+        used to call it inline, so a hang stalled turn finalization past the
+        cron inactivity watchdog and discarded the turn's real output. The
+        bounded flush must let finalization proceed within the deadline."""
+        import threading
+        import time
+
+        mod = self._fresh_plugin()
+        monkeypatch.setattr(mod, "_end_observation", lambda *a, **k: None)
+        monkeypatch.setattr(mod, "_FLUSH_TIMEOUT_SECONDS", 0.05)
+        mod._TRACE_STATE.clear()
+
+        never = threading.Event()
+
+        class _HangingClient:
+            def create_trace_id(self, seed=None):
+                return f"trace::{seed}"
+
+            def start_as_current_observation(self, **kw):
+                client = self
+
+                class _CM:
+                    def __enter__(self):
+                        return client
+
+                    def __exit__(self, *exc):
+                        return False
+
+                return _CM()
+
+            def update(self, **kw):
+                pass
+
+            def end(self, **kw):
+                pass
+
+            def set_trace_io(self, **kw):
+                pass
+
+            def start_observation(self, **kw):
+                return self
+
+            def flush(self):
+                never.wait(30)  # simulate an unresponsive backend
+
+        monkeypatch.setattr(mod, "_get_langfuse", lambda: _HangingClient())
+
+        start = time.monotonic()
+        self._run_turn(mod, session="sess-hang", turn_n=1, finalize=True)
+        elapsed = time.monotonic() - start
+
+        assert elapsed < 5.0, (
+            f"_finish_trace blocked {elapsed:.1f}s on a hanging flush — "
+            "turn finalization must proceed within the flush deadline"
+        )
+
+    def test_finish_trace_swallows_flush_exception(self, monkeypatch):
+        """A flushing *error* (as opposed to a hang) stays fail-open."""
+        mod = self._fresh_plugin()
+        monkeypatch.setattr(mod, "_end_observation", lambda *a, **k: None)
+        mod._TRACE_STATE.clear()
+
+        class _ExplodingClient:
+            def create_trace_id(self, seed=None):
+                return f"trace::{seed}"
+
+            def start_as_current_observation(self, **kw):
+                client = self
+
+                class _CM:
+                    def __enter__(self):
+                        return client
+
+                    def __exit__(self, *exc):
+                        return False
+
+                return _CM()
+
+            def update(self, **kw):
+                pass
+
+            def end(self, **kw):
+                pass
+
+            def set_trace_io(self, **kw):
+                pass
+
+            def start_observation(self, **kw):
+                return self
+
+            def flush(self):
+                raise RuntimeError("exporter exploded")
+
+        monkeypatch.setattr(mod, "_get_langfuse", lambda: _ExplodingClient())
+
+        # Must not raise.
+        self._run_turn(mod, session="sess-explode", turn_n=1, finalize=True)
+
 
 # ---------------------------------------------------------------------------
 # Placeholder-credential guard (#23823).


### PR DESCRIPTION
## What does this PR do?

Bounds the Langfuse plugin's post-turn `client.flush()` (#87468). `flush()` blocks the calling thread until the SDK's batch exporter has pushed all queued spans — unbounded against a slow or unresponsive backend. `_finish_trace` called it inline in a `finally:` block (with `except Exception: pass` around it), so when the backend hung, turn finalization stalled past the cron inactivity watchdog — which has no visibility into plugin-hook execution — and the outer catch then **discarded the turn's real response**. The `except` was useless for the actual failure mode: a hang is not an exception.

`_flush_bounded()` runs `flush()` on a **daemon thread** and waits at most `_FLUSH_TIMEOUT_SECONDS` (30s). A daemon thread rather than a `ThreadPoolExecutor` because the executor's context-manager exit joins its worker, which would reintroduce the hang at `shutdown(wait=True)`. A timed-out flush keeps running in the background, so export is merely delayed when the backend recovers — never allowed to block finalization. `_finish_trace`'s finally now uses it; the atexit and `on_session_finalize` flush sites keep their existing inline form (process-exit / session-boundary paths, not the turn hot path from the report).

## Related Issue

Fixes #87468

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/observability/langfuse/__init__.py` — new `_FLUSH_TIMEOUT_SECONDS = 30.0` constant with rationale; new `_flush_bounded(client, timeout=None)` (daemon-thread flush under a deadline, timeout read at call time so it is patchable); `_finish_trace`'s `finally` now calls `_flush_bounded(client)` instead of inline `client.flush()`.
- `tests/plugins/test_langfuse_plugin.py` — `test_finish_trace_bounds_hanging_flush` (a flush that never completes must not block `_run_turn(finalize=True)` beyond the deadline, with the timeout monkeypatched to 0.05s); `test_finish_trace_swallows_flush_exception` (a flushing *error*, as opposed to a hang, stays fail-open).

## How to Test

1. `uv run --extra acp pytest tests/plugins/test_langfuse_plugin.py -q` — Observed result: `93 passed` (the full suite completes in ~2.3s, i.e. the bounded waits are real).
2. Observed result with the plugin change reverted: `test_finish_trace_bounds_hanging_flush` fails (the bounded-flush contract is absent).
3. Live shape from the report — a self-hosted Langfuse that stops responding: turns now finalize within ~30s of turn end instead of hanging to the cron inactivity watchdog, and the job keeps its real output; spans export late when the backend recovers.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
