### PR TITLE
fix(tui): pass through Ctrl/Cmd+L so the dashboard redraw byte never inserts a stray 'l'

### DIFF
--- a/ui-tui/src/__tests__/textInputPassThrough.test.ts
+++ b/ui-tui/src/__tests__/textInputPassThrough.test.ts
@@ -50,4 +50,10 @@ describe('shouldPassThroughToGlobalHandler', () => {
     expect(shouldPassThroughToGlobalHandler('', key({ pageUp: true }))).toBe(true)
     expect(shouldPassThroughToGlobalHandler('', key({ pageDown: true }))).toBe(true)
   })
+
+  it('passes through the Ctrl+L redraw key so the composer never inserts a stray "l"', () => {
+    expect(shouldPassThroughToGlobalHandler('l', key({ ctrl: true }))).toBe(true)
+    // A plain (unmodified) "l" must still reach the composer as typing.
+    expect(shouldPassThroughToGlobalHandler('l', key())).toBe(false)
+  })
 })

--- a/ui-tui/src/components/textInput.tsx
+++ b/ui-tui/src/components/textInput.tsx
@@ -7,6 +7,7 @@ import { readClipboardText, writeClipboardText } from '../lib/clipboard.js'
 import { cursorLayout, offsetFromPosition } from '../lib/inputMetrics.js'
 import {
   DEFAULT_VOICE_RECORD_KEY,
+  isAction,
   isActionMod,
   isMac,
   isMacActionFallback,
@@ -1702,6 +1703,7 @@ export const shouldPassThroughToGlobalHandler = (
   (key.ctrl && input === 'c') ||
   (key.ctrl && input === 'x') ||
   (key.ctrl && input === 'o') ||
+  isAction(key, input, 'l') ||
   key.tab ||
   (key.shift && key.tab) ||
   key.pageUp ||


### PR DESCRIPTION
## Summary

Fixes #87069 — the dashboard Chat tab inserted a stray `l` into the composer on every session switch.

Root cause: `PtySession.attach()` injects a raw Ctrl-L byte (`0x0c`) to force a TUI repaint on keep-alive PTY reattach (#86332 / #68071). The Ink keypress parser maps that byte to a `ctrl+l` key event which reaches **both** listeners — the global hotkey handler (which redraws but doesn't stop propagation) and the composer's `TextInput`, which falls through to the generic insert branch and types a literal `l`.

## Change

One line: add `isAction(key, input, 'l')` to `shouldPassThroughToGlobalHandler` so the composer ignores the redraw keypress, mirroring the global handler's own `isAction(key, ch, 'l')` check in `useInputHandlers.ts`. Unmodified `l` still types normally; the existing ctrl+c/x/o pass-through entries are untouched.

## Test plan

- [x] `cd ui-tui && npx tsc --noEmit`
- [x] `cd ui-tui && npx vitest run src/__tests__/textInputPassThrough.test.ts` (7 passed)
- [x] `cd ui-tui && npx vitest run src/__tests__/textInput` (107 passed)
- [x] Manual: with the composer focused, Ctrl+L no longer inserts `l`; typing `l` normally is unaffected.

## Related

- Closes #87069
