### PR TITLE
fix(gateway): allow delegated work to drain before restart

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -10165,10 +10165,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 return True
             return bool(self._active_cron_job_count()) and now < cron_deadline
 
-        # Both budgets at 0 leave this loop unentered, which is the legacy
-        # "interrupt immediately" behaviour — expressed as an expired
-        # deadline rather than a special case, so the timed_out value below
-        # is always computed from real state instead of asserted up front.
+        # A zero budget remains an explicit opt-in for tests/operators that
+        # need immediate interruption.  Normal fresh installs use the
+        # non-zero default from config_defaults, giving active model/API and
+        # delegated work a bounded opportunity to publish completion state.
         while _still_draining():
             _maybe_update_status()
             await asyncio.sleep(0.1)

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -79,14 +79,15 @@ DEFAULT_CONFIG = {
         },
         # Force-interrupt budget once gateway stop()/drain has begun
         # (seconds). Applies to SIGTERM/external stop and to the final
-        # phase of in-band restart after any after-turn wait. 0 = interrupt
-        # immediately (the default).
+        # phase of in-band restart after any after-turn wait. 180 seconds
+        # gives in-flight model/API calls and delegated children a bounded
+        # window to unwind before they are interrupted.
         #
-        # Keep this short and under systemd TimeoutStopSec — a long value
+        # Keep this bounded and under systemd TimeoutStopSec — a long value
         # here invites SIGKILL-mid-cleanup. For in-band restart
         # (/restart, SIGUSR1), prefer restart_after_turn_timeout below so
         # active turns finish *before* stop() begins (#77184).
-        "restart_drain_timeout": 0,
+        "restart_drain_timeout": 180,
         # Cron-only floor under the stop()/drain wait (seconds). A chat turn
         # interrupted by a restart is announced to the user and resumed on
         # their next message; an interrupted cron run is written to jobs.json

--- a/tests/gateway/test_restart_drain.py
+++ b/tests/gateway/test_restart_drain.py
@@ -14,6 +14,18 @@ from gateway.session import SessionEntry, build_session_key
 from tests.gateway.restart_test_helpers import make_restart_runner, make_restart_source
 
 
+def test_restart_drain_default_allows_in_flight_work_to_unwind():
+    """The shipped default must not interrupt every turn immediately.
+
+    A zero-second force-interrupt budget made a gateway restart send SIGTERM,
+    skip the drain, and mark an in-flight subagent interrupted before it could
+    publish its durable completion.  The operator-level mitigation is
+    ``agent.restart_drain_timeout=180``; keep that behavior durable for fresh
+    configs as well.
+    """
+    assert DEFAULT_GATEWAY_RESTART_DRAIN_TIMEOUT == 180.0
+
+
 @pytest.mark.asyncio
 async def test_restart_command_while_busy_requests_drain_without_interrupt(monkeypatch):
     # Ensure INVOCATION_ID is NOT set — systemd sets this in service mode,


### PR DESCRIPTION
## Summary
- change the fresh-install gateway restart drain default from 0s to 180s
- preserve explicit 0s as an immediate-interrupt opt-in
- add a regression assertion for the shipped default

## Why
A zero-second drain causes SIGTERM/restart to interrupt active model calls and delegated work immediately, before durable completion delivery can finish. The bounded 180-second default gives in-flight work time to unwind while retaining the existing watchdog and cleanup bounds.

## Validation
- `git diff --check`
- `python3 -m compileall -q gateway/run.py gateway/restart.py hermes_cli/config_defaults.py tools/async_delegation.py tools/delegate_tool.py`
- `186 passed, 2 skipped` across focused gateway/delegation delivery, restart-drain, shutdown, resume, API-run, and ledger tests

## Rollout
The live installation is separately configured with `agent.restart_drain_timeout: 180`. The running gateway was not restarted in this change.