### PR TITLE
fix: support Python 3.14+ ThreadPoolExecutor API in DaemonThreadPoolExecutor

### DIFF
--- a/tools/daemon_pool.py
+++ b/tools/daemon_pool.py
@@ -26,6 +26,7 @@ explicit bounded joins.
 
 from __future__ import annotations
 
+import sys
 import threading
 import weakref
 from concurrent.futures import ThreadPoolExecutor
@@ -38,8 +39,8 @@ class DaemonThreadPoolExecutor(ThreadPoolExecutor):
     """ThreadPoolExecutor variant whose workers do not block process exit."""
 
     def _adjust_thread_count(self) -> None:
-        # Mirrors CPython's implementation (3.14+) with two changes:
-        # daemon=True and no _threads_queues registration.
+        # Mirrors CPython's implementation (version-gated for 3.11-3.13 vs 3.14+)
+        # with two changes: daemon=True and no _threads_queues registration.
         if self._idle_semaphore.acquire(timeout=0):
             return
 
@@ -49,14 +50,26 @@ class DaemonThreadPoolExecutor(ThreadPoolExecutor):
         num_threads = len(self._threads)
         if num_threads < self._max_workers:
             thread_name = "%s_%d" % (self._thread_name_prefix or self, num_threads)
-            t = threading.Thread(
-                name=thread_name,
-                target=_worker,
-                args=(
+            if sys.version_info >= (3, 14):
+                # Python 3.14+ bundles initializer/initargs into a context object
+                worker_args = (
                     weakref.ref(self, weakref_cb),
                     self._create_worker_context(),
                     self._work_queue,
-                ),
+                )
+            else:
+                # Python 3.11-3.13: legacy _worker(executor_reference, work_queue,
+                # initializer, initargs) signature
+                worker_args = (
+                    weakref.ref(self, weakref_cb),
+                    self._work_queue,
+                    self._initializer,
+                    self._initargs,
+                )
+            t = threading.Thread(
+                name=thread_name,
+                target=_worker,
+                args=worker_args,
                 daemon=True,
             )
             t.start()

--- a/tools/daemon_pool.py
+++ b/tools/daemon_pool.py
@@ -38,7 +38,7 @@ class DaemonThreadPoolExecutor(ThreadPoolExecutor):
     """ThreadPoolExecutor variant whose workers do not block process exit."""
 
     def _adjust_thread_count(self) -> None:
-        # Mirrors CPython's implementation (3.8–3.13) with two changes:
+        # Mirrors CPython's implementation (3.14+) with two changes:
         # daemon=True and no _threads_queues registration.
         if self._idle_semaphore.acquire(timeout=0):
             return
@@ -54,9 +54,8 @@ class DaemonThreadPoolExecutor(ThreadPoolExecutor):
                 target=_worker,
                 args=(
                     weakref.ref(self, weakref_cb),
+                    self._create_worker_context(),
                     self._work_queue,
-                    self._initializer,
-                    self._initargs,
                 ),
                 daemon=True,
             )


### PR DESCRIPTION
Python 3.14 removed self._initializer and self._initargs from ThreadPoolExecutor internal API. The _worker function now takes a context object via self._create_worker_context() instead.

This broke DaemonThreadPoolExecutor._adjust_thread_count() with:
  DaemonThreadPoolExecutor object has no attribute _initializer

Fix: Replace self._initializer/self._initargs with self._create_worker_context(), matching Python 3.14s updated _worker(executor_reference, ctx, work_queue) signature. Daemon thread and skipped _threads_queues registration preserved.

Verified on Python 3.14.4: import, create, submit, shutdown all OK.