### PR TITLE
fix(gateway): keep status caches bounded across awaits

### DIFF
--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -2955,7 +2955,10 @@ class SlackAdapter(BasePlatformAdapter):
                 chat_id, cached_id, content, finalize=False, metadata=metadata,
             )
             if result.success:
-                if result.message_id:
+                if (
+                    result.message_id
+                    and self._status_message_ids.get(key) == cached_id
+                ):
                     self._status_message_ids[key] = str(result.message_id)
                 return result
             # Edit failed — clear the cached ts and fall through to a fresh send.

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -903,6 +903,7 @@ class TelegramAdapter(BasePlatformAdapter):
         # Tracks status bubbles owned by this adapter so subsequent calls with the
         # same key edit the same message instead of appending new ones (#30045).
         self._status_message_ids: Dict[tuple, str] = {}
+        self._STATUS_MESSAGE_IDS_MAX = 2000
         # Last truncated mid-stream preview delivered per (chat_id, message_id).
         # Once an oversized streaming edit saturates at the 4096 preview cap,
         # every subsequent progressive edit truncates to the SAME text; sending
@@ -5429,13 +5430,22 @@ class TelegramAdapter(BasePlatformAdapter):
                 chat_id, cached_id, content, finalize=True, metadata=metadata,
             )
             if result.success:
-                if result.message_id:
+                if (
+                    result.message_id
+                    and self._status_message_ids.get(key) == cached_id
+                ):
                     self._status_message_ids[key] = str(result.message_id)
                 return result
             # Edit failed — clear the cached id and fall through to a fresh send.
             self._status_message_ids.pop(key, None)
         result = await self.send(chat_id, content, metadata=metadata)
         if result.success and result.message_id:
+            if len(self._status_message_ids) >= self._STATUS_MESSAGE_IDS_MAX:
+                # Simple FIFO trim: drop the oldest half to bound memory.
+                for stale in list(self._status_message_ids)[
+                    : self._STATUS_MESSAGE_IDS_MAX // 2
+                ]:
+                    self._status_message_ids.pop(stale, None)
             self._status_message_ids[key] = str(result.message_id)
         return result
 

--- a/tests/gateway/test_slack_status_update.py
+++ b/tests/gateway/test_slack_status_update.py
@@ -9,6 +9,7 @@ The status-update path must:
 
 from __future__ import annotations
 
+import asyncio
 import sys
 from unittest.mock import AsyncMock, MagicMock
 
@@ -47,6 +48,7 @@ import plugins.platforms.slack.adapter as _slack_mod  # noqa: E402
 _slack_mod.SLACK_AVAILABLE = True
 
 from gateway.config import PlatformConfig  # noqa: E402
+from gateway.platforms.base import SendResult  # noqa: E402
 from plugins.platforms.slack.adapter import SlackAdapter  # noqa: E402
 
 
@@ -92,5 +94,48 @@ async def test_distinct_keys_do_not_crosstalk(adapter):
     client = adapter._get_client.return_value
     assert client.chat_postMessage.call_count == 2
     assert client.chat_update.call_count == 0
+
+
+@pytest.mark.asyncio
+async def test_concurrent_cached_edits_do_not_reinsert_evicted_status_keys(adapter):
+    adapter._STATUS_MESSAGE_IDS_MAX = 4
+    thread_id = METADATA["thread_id"]
+    old_keys = [
+        (f"C_{channel_id}", thread_id, "lifecycle") for channel_id in range(4)
+    ]
+    adapter._status_message_ids.update(
+        {key: str(message_id) for message_id, key in enumerate(old_keys)}
+    )
+    edit_started = {"0": asyncio.Event(), "1": asyncio.Event()}
+    release_edits = asyncio.Event()
+
+    async def blocked_successful_edit(chat_id, message_id, content, **kwargs):
+        edit_started[message_id].set()
+        await release_edits.wait()
+        return SendResult(success=True, message_id=message_id)
+
+    adapter.edit_message = AsyncMock(side_effect=blocked_successful_edit)
+
+    pending_edits = [
+        asyncio.create_task(
+            adapter.send_or_update_status(
+                f"C_{channel_id}", "lifecycle", "updating", metadata=METADATA
+            )
+        )
+        for channel_id in range(2)
+    ]
+    await asyncio.gather(*(event.wait() for event in edit_started.values()))
+
+    fresh_key = ("C_4", thread_id, "lifecycle")
+    fresh_result = await adapter.send_or_update_status(
+        "C_4", "lifecycle", "starting", metadata=METADATA
+    )
+    release_edits.set()
+    await asyncio.gather(*pending_edits)
+
+    assert len(adapter._status_message_ids) <= adapter._STATUS_MESSAGE_IDS_MAX
+    assert adapter._status_message_ids[fresh_key] == fresh_result.message_id
+    assert old_keys[0] not in adapter._status_message_ids
+    assert old_keys[1] not in adapter._status_message_ids
 
 

--- a/tests/gateway/test_telegram_status_update.py
+++ b/tests/gateway/test_telegram_status_update.py
@@ -9,6 +9,7 @@ The status-update path must:
 
 from __future__ import annotations
 
+import asyncio
 import sys
 import types
 from types import SimpleNamespace
@@ -103,5 +104,58 @@ async def test_distinct_status_keys_do_not_collide(adapter):
     adapter.edit_message.assert_not_awaited()
     assert adapter._status_message_ids[("chat-1", "lifecycle")] == "100"
     assert adapter._status_message_ids[("chat-1", "model-switch")] == "200"
+
+
+@pytest.mark.asyncio
+async def test_status_message_cache_stays_bounded_and_keeps_newest_entry(adapter):
+    """Distinct chats cannot grow the cache past its configured bound."""
+    adapter._STATUS_MESSAGE_IDS_MAX = 4
+    adapter.send.side_effect = [
+        SendResult(success=True, message_id=str(message_id))
+        for message_id in range(10)
+    ]
+
+    for chat_id in range(10):
+        await adapter.send_or_update_status(str(chat_id), "lifecycle", "starting")
+
+    assert len(adapter._status_message_ids) <= adapter._STATUS_MESSAGE_IDS_MAX
+    assert adapter._status_message_ids[("9", "lifecycle")] == "9"
+
+
+@pytest.mark.asyncio
+async def test_concurrent_cached_edits_do_not_reinsert_evicted_status_keys(adapter):
+    adapter._STATUS_MESSAGE_IDS_MAX = 4
+    old_keys = [(str(chat_id), "lifecycle") for chat_id in range(4)]
+    adapter._status_message_ids.update(
+        {key: str(message_id) for message_id, key in enumerate(old_keys)}
+    )
+    edit_started = {"0": asyncio.Event(), "1": asyncio.Event()}
+    release_edits = asyncio.Event()
+
+    async def blocked_successful_edit(chat_id, message_id, content, **kwargs):
+        edit_started[message_id].set()
+        await release_edits.wait()
+        return SendResult(success=True, message_id=message_id)
+
+    adapter.edit_message.side_effect = blocked_successful_edit
+    adapter.send.return_value = SendResult(success=True, message_id="4")
+
+    pending_edits = [
+        asyncio.create_task(
+            adapter.send_or_update_status(str(chat_id), "lifecycle", "updating")
+        )
+        for chat_id in range(2)
+    ]
+    await asyncio.gather(*(event.wait() for event in edit_started.values()))
+
+    fresh_key = ("4", "lifecycle")
+    await adapter.send_or_update_status(*fresh_key, "starting")
+    release_edits.set()
+    await asyncio.gather(*pending_edits)
+
+    assert len(adapter._status_message_ids) <= adapter._STATUS_MESSAGE_IDS_MAX
+    assert adapter._status_message_ids[fresh_key] == "4"
+    assert old_keys[0] not in adapter._status_message_ids
+    assert old_keys[1] not in adapter._status_message_ids
 
 


### PR DESCRIPTION
Fixes #87479

## Summary

- bound Telegram's in-memory status-message cache at 2,000 entries
- evict the oldest half before inserting a fresh Telegram entry at capacity
- prevent concurrent successful edits from reinserting entries evicted while network I/O was in flight
- close that post-`await` reinsertion race in both Telegram and Slack

## Problem

`TelegramAdapter.send_or_update_status()` cached one message ID for every distinct `(chat_id, status_key)` but had no capacity bound. Long-lived gateways serving new chats therefore retained stale status IDs indefinitely.

Slack already had a FIFO bound for the same status-bubble cache shape. During independent review of the Telegram sibling fix, a second class-level bug was reproduced in both adapters: a cached edit could read an entry, await network I/O, and then reinsert that entry after a concurrent fresh send had evicted it. The cache could therefore exceed its configured maximum despite the FIFO trim.

## Approach

1. Give Telegram the same 2,000-entry/oldest-half FIFO policy already used by Slack.
2. In both adapters, update a successful edited message ID only if the cache key still maps to the ID read before the `await`.
3. If another coroutine removed or replaced that entry while I/O was in flight, do not resurrect or overwrite it.

No lock or new abstraction is needed: the compare-and-write block contains no `await`, so it runs atomically within the adapter event loop.

## Regression proof

### Serial growth

The Telegram regression uses a low instance limit, sends statuses to ten distinct chats, and verifies that the mapping stays bounded and the newest entry remains.

Verified RED on unpatched Telegram code:

```text
AssertionError: assert 10 <= 4
1 failed
```

### Concurrent reinsertion

Deterministic `asyncio.Event` tests for both adapters:

1. preseed four entries at max four;
2. start two cached edits and pause them inside `edit_message()`;
3. insert a fresh fifth status, evicting the oldest half;
4. release both edits;
5. verify the cache remains bounded, the fresh entry survives, and evicted keys are not reinserted.

Verified RED before the compare guard:

```text
Telegram: 5 entries > max 4
Slack:    5 entries > max 4
2 failed
```

Verified GREEN after the fix:

```text
HERMES_PYTHON=/Users/michaelai/hermes-agent/.venv/bin/python \
  scripts/run_tests.sh \
  tests/gateway/test_telegram_status_update.py \
  tests/gateway/test_slack_status_update.py

7 passed, 0 failed
```

Additional gates:

- exact concurrent regressions: 2 passed
- Ruff check on all four changed files: passed
- `git diff --check`: passed
- added-line security scan: no findings

## Scope

This is limited to the two adapters that implement `send_or_update_status`. It does not introduce a generic cache abstraction or change status rendering, routing, editing, or edit-failure fallback semantics.

---

**NL:** Telegram krijgt een begrensde statuscache. Telegram en Slack voorkomen daarnaast dat gelijktijdige edits reeds opgeruimde cache-items opnieuw terugplaatsen.
