### PR TITLE
feat(desktop): drag-resizable panes on the Capabilities Skills tab

### DIFF
--- a/apps/desktop/src/app/master-detail.tsx
+++ b/apps/desktop/src/app/master-detail.tsx
@@ -1,5 +1,5 @@
 import { useStore } from '@nanostores/react'
-import { type ReactNode, type PointerEvent as ReactPointerEvent, useEffect, useState } from 'react'
+import { Children, type CSSProperties, type ReactNode, type PointerEvent as ReactPointerEvent, useEffect, useRef, useState } from 'react'
 
 import { Button } from '@/components/ui/button'
 import { Codicon } from '@/components/ui/codicon'
@@ -9,7 +9,7 @@ import { Switch } from '@/components/ui/switch'
 import { Tip } from '@/components/ui/tooltip'
 import { useI18n } from '@/i18n'
 import { cn } from '@/lib/utils'
-import { $paneHeightOverride, $paneState, setPaneHeightOverride } from '@/store/panes'
+import { $paneHeightOverride, $paneState, $paneWidthOverride, setPaneHeightOverride, setPaneWidthOverride } from '@/store/panes'
 
 // Monospace capability chip (tool name, transport, …). Shared by the Skills
 // and MCP tabs so the pill reads identically everywhere.
@@ -34,20 +34,71 @@ export function ToolChip({ children, title }: { children: ReactNode; title?: str
 // The wide-rail track shared by every Capabilities tab (skills/tools/mcp) so
 // the three read as one page. Exported for pages that build their own grid
 // (the MCP tab's cursor-driven layout) but must stay in step.
-export const MASTER_DETAIL_WIDE_COLS = 'sm:grid-cols-[minmax(0,0.75fr)_minmax(0,1fr)]'
+// `--md-split` is the drag override slot: unset it falls back to the declared
+// track, so grids without a resize sash render exactly as before.
+export const MASTER_DETAIL_WIDE_COLS = 'sm:grid-cols-[minmax(0,var(--md-split,0.75fr))_minmax(0,1fr)]'
+
+// Column-seam drag clamps: the rail can't shrink below a readable row, the
+// detail keeps enough room for its centered column.
+const SPLIT_MIN_LEFT_PX = 180
+const SPLIT_MIN_RIGHT_PX = 320
 
 // `split="wide"` gives list-heavy pages a rail that shares the page with a
 // sparse detail (skills/tools/mcp); the default 14rem rail suits pages whose
-// detail carries the weight (messaging).
+// detail carries the weight (messaging). A `resizeId` turns the column seam
+// into a drag sash: the rail width persists in the pane store under that id
+// (same store as the terminal/editor panes), double-click resets to default.
 export function MasterDetail({
   children,
   pane,
+  resizeId,
   split = 'rail'
 }: {
   children: ReactNode
   pane?: ReactNode
+  /** Pane-store key — when set, the seam between the two columns becomes a
+   *  drag-resizable sash and the rail width persists under this id. */
+  resizeId?: string
   split?: 'rail' | 'wide'
 }) {
+  const gridRef = useRef<HTMLDivElement>(null)
+  // Unconditional hook (rules of hooks) — the '' atom is inert when no id.
+  const override = useStore($paneWidthOverride(resizeId ?? ''))
+  const [dragging, setDragging] = useState(false)
+
+  const startSplitDrag = (event: ReactPointerEvent<HTMLDivElement>) => {
+    const grid = gridRef.current
+
+    if (!resizeId || !grid || event.button !== 0) {
+      return
+    }
+
+    event.preventDefault()
+    const startX = event.clientX
+    const startWidth = (grid.children[0] as HTMLElement).getBoundingClientRect().width
+    const max = Math.max(SPLIT_MIN_LEFT_PX, grid.getBoundingClientRect().width - SPLIT_MIN_RIGHT_PX)
+    setDragging(true)
+
+    const onMove = (move: globalThis.PointerEvent) => {
+      setPaneWidthOverride(
+        resizeId,
+        Math.round(Math.min(max, Math.max(SPLIT_MIN_LEFT_PX, startWidth + (move.clientX - startX))))
+      )
+    }
+
+    const onUp = () => {
+      window.removeEventListener('pointermove', onMove)
+      setDragging(false)
+    }
+
+    window.addEventListener('pointermove', onMove)
+    window.addEventListener('pointerup', onUp, { once: true })
+  }
+
+  // With a sash the detail side gets a relative wrapper so the seam handle can
+  // sit on the boundary itself (junction-owned, like the shell's sashes).
+  const [list, ...rest] = Children.toArray(children)
+
   return (
     <div className="flex h-full min-h-0 flex-col">
       <div
@@ -55,8 +106,31 @@ export function MasterDetail({
           'grid min-h-0 flex-1 grid-cols-1',
           split === 'wide' ? MASTER_DETAIL_WIDE_COLS : 'sm:grid-cols-[14rem_minmax(0,1fr)]'
         )}
+        ref={gridRef}
+        style={override !== undefined ? ({ '--md-split': `${override}px` } as CSSProperties) : undefined}
       >
-        {children}
+        {resizeId ? (
+          <>
+            {list}
+            <div className="relative grid min-h-0 min-w-0">
+              <div
+                className="group/vsash absolute inset-y-0 left-0 z-10 hidden w-1 -translate-x-1/2 cursor-col-resize sm:block"
+                onDoubleClick={() => setPaneWidthOverride(resizeId, undefined)}
+                onPointerDown={startSplitDrag}
+              >
+                <div
+                  className={cn(
+                    'absolute inset-y-0 left-1/2 w-px -translate-x-1/2 transition-colors',
+                    dragging ? 'bg-(--ui-stroke-secondary)' : 'group-hover/vsash:bg-(--ui-stroke-secondary)'
+                  )}
+                />
+              </div>
+              {rest}
+            </div>
+          </>
+        ) : (
+          children
+        )}
       </div>
       {pane}
     </div>

--- a/apps/desktop/src/app/skills/embedded-hub-picker.tsx
+++ b/apps/desktop/src/app/skills/embedded-hub-picker.tsx
@@ -1,11 +1,13 @@
 import { useStore } from '@nanostores/react'
-import { useEffect, useState } from 'react'
+import { type PointerEvent as ReactPointerEvent, useEffect, useState } from 'react'
 
 import { Button } from '@/components/ui/button'
 import { useI18n } from '@/i18n'
 import { Loader2 } from '@/lib/icons'
+import { cn } from '@/lib/utils'
 import { $hubActions, installHubSkill, UPDATE_ALL_KEY, updateHubSkills } from '@/store/hub-actions'
 import { notify, notifyError } from '@/store/notifications'
+import { $paneHeightOverride, setPaneHeightOverride } from '@/store/panes'
 
 // The REAL Skills Hub page (docs site) embedded as a one-click picker — the
 // same trick the Bot Mode agent editor uses. `?embed=picker` hides the docs
@@ -16,6 +18,14 @@ import { notify, notifyError } from '@/store/notifications'
 // list invalidation), scoped to the Capabilities profile selector.
 const HUB_ORIGIN = 'https://hermes-agent.nousresearch.com'
 const HUB_PICKER_URL = `${HUB_ORIGIN}/docs/skills?embed=picker`
+
+// Hub viewport height: persisted through the shared pane store (same one the
+// terminal/editor panes use), dragged from the section's TOP edge — "pull the
+// hub up" — clamped so neither the hub nor the skills list above vanishes.
+const HUB_PANE_ID = 'capabilities-hub'
+const HUB_DEFAULT_PX = 380
+const HUB_MIN_PX = 120
+const HUB_MAX_VH = 0.75
 
 interface SkillPickMessage {
   identifier?: string
@@ -42,6 +52,40 @@ export function EmbeddedHubPicker({ installedNames, profile }: EmbeddedHubPicker
   const h = t.skills.hub
   const [open, setOpen] = useState(true)
   const updating = useStore($hubActions)[UPDATE_ALL_KEY]?.running ?? false
+  const heightOverride = useStore($paneHeightOverride(HUB_PANE_ID))
+  const height = heightOverride ?? HUB_DEFAULT_PX
+  const [dragging, setDragging] = useState(false)
+
+  // Top-edge sash: dragging UP grows the hub (shrinking the skills list above,
+  // which is the flex-1 sibling). Same gesture as DetailPane / the shell's
+  // bottom panes; double-click resets to the default height. The iframe gets
+  // pointer-events disabled for the duration or it swallows the pointermoves.
+  const startDrag = (event: ReactPointerEvent<HTMLDivElement>) => {
+    if (event.button !== 0) {
+      return
+    }
+
+    event.preventDefault()
+    const startY = event.clientY
+    const startHeight = height
+    const max = Math.round(window.innerHeight * HUB_MAX_VH)
+    setDragging(true)
+
+    const onMove = (move: globalThis.PointerEvent) => {
+      setPaneHeightOverride(
+        HUB_PANE_ID,
+        Math.round(Math.min(max, Math.max(HUB_MIN_PX, startHeight + (startY - move.clientY))))
+      )
+    }
+
+    const onUp = () => {
+      window.removeEventListener('pointermove', onMove)
+      setDragging(false)
+    }
+
+    window.addEventListener('pointermove', onMove)
+    window.addEventListener('pointerup', onUp, { once: true })
+  }
 
   // Picker messages from the embedded hub page. Origin-checked; installs route
   // through the same store pipeline the hub rows use, so the action log,
@@ -87,7 +131,20 @@ export function EmbeddedHubPicker({ installedNames, profile }: EmbeddedHubPicker
   }
 
   return (
-    <div className="border-t border-(--ui-stroke-secondary)">
+    <div className="relative border-t border-(--ui-stroke-secondary)">
+      {/* Top-edge drag sash — pull the whole hub section up/down. */}
+      <div
+        className="group/hubsash absolute inset-x-0 top-0 z-10 h-1 -translate-y-1/2 cursor-row-resize"
+        onDoubleClick={() => setPaneHeightOverride(HUB_PANE_ID, undefined)}
+        onPointerDown={startDrag}
+      >
+        <div
+          className={cn(
+            'absolute inset-x-0 top-1/2 h-px -translate-y-1/2 transition-colors',
+            dragging ? 'bg-(--ui-stroke-secondary)' : 'group-hover/hubsash:bg-(--ui-stroke-secondary)'
+          )}
+        />
+      </div>
       <div className="flex items-center justify-between px-3 py-1.5">
         <span className="text-[0.7rem] font-medium text-(--ui-text-tertiary)">{h.pickerTitle}</span>
         <div className="flex items-center gap-1">
@@ -102,21 +159,21 @@ export function EmbeddedHubPicker({ installedNames, profile }: EmbeddedHubPicker
       </div>
       {open && (
         <div className="grid gap-1 px-3 pb-2">
-          {/* Resizable viewport: native CSS resize handle lets the user drag it
-              larger/smaller. The iframe is rendered oversized and scaled DOWN
-              (133% × 0.75) so the hub page starts zoomed out — the cross-origin
-              page itself can't be styled, but scaling the frame is ours. */}
+          {/* Resizable viewport: height comes from the top-edge drag sash
+              above (persisted; double-click resets). The iframe is rendered
+              oversized and scaled DOWN (133% × 0.75) so the hub page starts
+              zoomed out — the cross-origin page itself can't be styled, but
+              scaling the frame is ours. */}
           <div
             style={{
               border: '1px solid var(--ui-stroke-secondary)',
               borderRadius: 8,
-              height: 380,
+              height,
               maxWidth: '100%',
-              minHeight: 200,
+              minHeight: HUB_MIN_PX,
               minWidth: 320,
               overflow: 'hidden',
               position: 'relative',
-              resize: 'vertical',
               width: '100%'
             }}
           >
@@ -127,6 +184,9 @@ export function EmbeddedHubPicker({ installedNames, profile }: EmbeddedHubPicker
                 background: 'transparent',
                 border: 'none',
                 height: '133.34%',
+                // While the sash drags, the cross-origin iframe must not eat
+                // the pointermove stream.
+                pointerEvents: dragging ? 'none' : 'auto',
                 transform: 'scale(0.75)',
                 transformOrigin: 'top left',
                 width: '133.34%'

--- a/apps/desktop/src/app/skills/index.tsx
+++ b/apps/desktop/src/app/skills/index.tsx
@@ -696,7 +696,7 @@ export function SkillsView({
                 {visibleSkills.length === 0 ? (
                   capabilityEmpty('skills')
                 ) : (
-                  <MasterDetail pane={skillEditorPane} split="wide">
+                  <MasterDetail pane={skillEditorPane} resizeId="capabilities-split" split="wide">
                     <ListColumn
                       header={
                         <ListStrip
@@ -754,7 +754,7 @@ export function SkillsView({
           ) : visibleToolsets.length === 0 ? (
             capabilityEmpty('tools')
           ) : (
-            <MasterDetail split="wide">
+            <MasterDetail resizeId="capabilities-split" split="wide">
               <ListColumn
                 header={
                   <ListStrip


### PR DESCRIPTION
## Summary
All three panes on the Capabilities → Skills tab are now drag-resizable: the list/detail column seam, the embedded Skills Hub pane (pull it up from its top edge), and the skill editor bottom pane (already had a sash).

## Changes
- `apps/desktop/src/app/master-detail.tsx`: `MasterDetail` gains an optional `resizeId` — the column seam between rail and detail becomes a drag sash (same visual language as `DetailPane`'s). Width persists in the shared pane store; double-click resets. `MASTER_DETAIL_WIDE_COLS` now routes through a `--md-split` CSS var with the old `0.75fr` fallback, so the MCP tab's shared grid renders exactly as before.
- `apps/desktop/src/app/skills/embedded-hub-picker.tsx`: replaces the native CSS corner-resize handle with a top-edge drag sash — dragging up grows the hub, the skills list above absorbs it. Height persists (`capabilities-hub` pane id), double-click resets, and the cross-origin iframe gets `pointer-events:none` during the gesture so it can't swallow the drag.
- `apps/desktop/src/app/skills/index.tsx`: Skills and Tools tabs pass a shared `resizeId="capabilities-split"` so the split stays consistent across tabs.

## Validation
| Check | Result |
|---|---|
| `tsc -p . --noEmit` | clean |
| `eslint` (3 touched files) | clean |
| `vitest src/app/skills/index.test.tsx` | 8/8 passed |

## Infographic

![Resizable Capabilities panes](https://files.catbox.moe/itzukp.png)
