### PR TITLE
fix(skills): use python instead of python3 for Windows compat

### DIFF
--- a/optional-skills/web-development/har-derived-api-client/SKILL.md
+++ b/optional-skills/web-development/har-derived-api-client/SKILL.md
@@ -76,17 +76,17 @@ Resolve paths against this skill's directory. Canonical loop:
 
 ```bash
 # 1a. Capture, LOCAL browser (Hermes launched it)
-python3 scripts/har_capture.py "https://SITE/" out.har \
+python scripts/har_capture.py "https://SITE/" out.har \
   --action "fill:input[name=search]:my query" --action "sleep:3" --wait 2
 
 # 1b. Capture, CDP browser (cloud backend or /browser connect)
 #     get the endpoint from /browser connect or BROWSER_CDP_URL
-python3 scripts/har_capture_cdp.py "ws://HOST/devtools/browser/..." out.har \
+python scripts/har_capture_cdp.py "ws://HOST/devtools/browser/..." out.har \
   --goto "https://SITE/" --action "fill:input[name=search]:my query" \
   --action "sleep:3" --wait 2
 
 # 2. Derive — read the endpoints out of the HAR
-python3 scripts/har_to_client.py out.har --host SITE --max-body 400
+python scripts/har_to_client.py out.har --host SITE --max-body 400
 
 # 3. Replay — write a tiny client from the printed endpoint (see Procedure)
 ```
@@ -153,9 +153,9 @@ for p in r.json()["pages"]:
 End-to-end proof against a live site with no API key:
 
 ```bash
-python3 scripts/har_capture.py "https://en.wikipedia.org/wiki/Main_Page" /tmp/wiki.har \
+python scripts/har_capture.py "https://en.wikipedia.org/wiki/Main_Page" /tmp/wiki.har \
   --action "fill:input[name=search]:dune messiah" --action "sleep:3" --wait 2
-python3 scripts/har_to_client.py /tmp/wiki.har --host wikipedia.org --max-body 200
+python scripts/har_to_client.py /tmp/wiki.har --host wikipedia.org --max-body 200
 ```
 
 Expect the derivation to print `GET https://en.wikipedia.org/w/rest.php/v1/search/title`

--- a/skills/research/blocked-page-recovery/SKILL.md
+++ b/skills/research/blocked-page-recovery/SKILL.md
@@ -31,7 +31,7 @@ ladder, cheapest first.
 Run it in one shot with the bundled script:
 
 ```bash
-python3 scripts/recover_page.py "https://example.com/blocked-article" --json
+python scripts/recover_page.py "https://example.com/blocked-article" --json
 ```
 
 The script tries each route in order, validates every body (see "Fake


### PR DESCRIPTION
Follow-up to the Windows skill-compat sweep. These two skills referenced `python3` in their SKILL.md run instructions, which fails on native Windows where the launcher is `python`. Switched the documented invocations to `python` (Hermes' bundled scripts already handle the interpreter).