### PR TITLE
feat(cron): add persisted fresh-session readback

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -397,8 +397,14 @@ def _resolve_cron_enabled_toolsets(job: dict, cfg: dict) -> list[str] | None:
     surprise $4.63 run).
     """
     per_job = job.get("enabled_toolsets")
+    if isinstance(per_job, str):
+        per_job = [per_job.strip()] if per_job.strip() else []
+    elif isinstance(per_job, list):
+        per_job = [str(value).strip() for value in per_job if str(value).strip()]
+    else:
+        per_job = []
     if per_job:
-        return _merge_mcp_into_per_job_toolsets(list(per_job), cfg or {})
+        return _merge_mcp_into_per_job_toolsets(per_job, cfg or {})
     try:
         from hermes_cli.tools_config import _get_platform_tools  # lazy: avoid heavy import at cron module load
         return sorted(_get_platform_tools(cfg or {}, "cron"))

--- a/tests/cron/test_cronjob_schema.py
+++ b/tests/cron/test_cronjob_schema.py
@@ -1,21 +1,49 @@
 """Tests for the cronjob tool schema shape.
 
-Guards the description text that flags ``schedule`` (and ``prompt``) as
-REQUIRED for ``action=create`` — the load-bearing fix for description-driven
-models (e.g. Grok) that omit schedule when the schema only lists ``action``
-in ``required[]``. See issue #32427 / PR #32448.
+Guards the description text that flags ``schedule`` as always REQUIRED for
+``action=create`` and states when a prompt may be replaced by skills or a
+script. This is load-bearing for description-driven models (e.g. Grok) that
+omit schedule when the schema only lists ``action`` in ``required[]``. See
+issue #32427 / PR #32448.
 """
 
 from __future__ import annotations
 
 
 def test_cronjob_schema_action_description_flags_create_requirements():
-    """`action` description must state schedule + prompt are required for create."""
+    """`action` must keep schedule mandatory and document prompt alternatives."""
     from tools.cronjob_tools import CRONJOB_SCHEMA
 
     action_desc = CRONJOB_SCHEMA["parameters"]["properties"]["action"]["description"]
     assert "action=create" in action_desc
-    assert "schedule" in action_desc
-    assert "REQUIRED" in action_desc
+    assert "schedule is REQUIRED" in action_desc
+    assert "prompt is REQUIRED unless skills define the task" in action_desc
+    assert "no_agent=True requires script and ignores prompt" in action_desc
+
+
+def test_cronjob_schema_requires_fresh_session_contract_and_readback():
+    """The model-facing contract must define safe creation and proof of save."""
+    from tools.cronjob_tools import CRONJOB_SCHEMA
+
+    description = CRONJOB_SCHEMA["description"].lower()
+    for required_phrase in (
+        "fresh-session contract",
+        "exact input",
+        "expected output",
+        "tool boundary",
+        "working directory",
+        "delivery",
+        "model",
+        "skills",
+        "next_run_at",
+        "read back",
+    ):
+        assert required_phrase in description
+    assert "stop rather than schedule a guess" in description
+    assert "tasks that consume files or data" in description
+    assert "prompt, skills, or a no_agent script" in description
+    assert "for no_agent=true" in description
+    assert "script path and stdout" in description
+    assert "do not require or invent a prompt" in description
 
 

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -118,6 +118,14 @@ class TestPerJobToolsetMcpMerge:
         assert m_platform.call_args[0][1] == "cron"
         assert set(result) == set(sentinel)
 
+    def test_resolver_treats_legacy_string_as_one_toolset_name(self):
+        result = _resolve_cron_enabled_toolsets(
+            {"enabled_toolsets": "web"},
+            {},
+        )
+
+        assert result == ["web"]
+
 
 class TestResolveOrigin:
     def test_full_origin(self):

--- a/tests/tools/test_cronjob_tools.py
+++ b/tests/tools/test_cronjob_tools.py
@@ -246,6 +246,351 @@ class TestUnifiedCronjobTool:
         assert listing["jobs"][0]["name"] == "Server Check"
         assert listing["jobs"][0]["state"] == "scheduled"
 
+    def test_create_returns_persisted_fresh_session_contract(self, tmp_path, monkeypatch):
+        """Creation must read the saved record back instead of trusting the
+        object returned by the write path."""
+        from cron import scheduler
+        from cron.jobs import get_cron_output_dir, get_job
+
+        workdir = tmp_path / "project"
+        workdir.mkdir()
+        real_create = scheduler.create_job_with_scheduler_registration
+
+        def create_with_stale_return(**kwargs):
+            saved = real_create(**kwargs)
+            stale = dict(saved)
+            stale.update(
+                prompt="stale prompt",
+                deliver="stale-delivery",
+                next_run_at="stale-next-run",
+                workdir=None,
+            )
+            return stale
+
+        monkeypatch.setattr(
+            scheduler,
+            "create_job_with_scheduler_registration",
+            create_with_stale_return,
+        )
+
+        created = json.loads(
+            cronjob(
+                action="create",
+                prompt="Read input.json and write report.md. End with COMPLETE.",
+                schedule="every 1h",
+                name="Queue report",
+                deliver="local",
+                skills=["search-first"],
+                model="pinned-model",
+                provider="pinned-provider",
+                enabled_toolsets=["file"],
+                workdir=str(workdir),
+                attach_to_session=True,
+            )
+        )
+
+        assert created["success"] is True
+        assert created["readback_verified"] is True
+        stored = get_job(created["job_id"])
+        assert stored is not None
+        readback = created["readback"]
+        assert readback["job_id"] == stored["id"]
+        assert readback["name"] == stored["name"]
+        assert readback["schedule"] == stored["schedule_display"]
+        assert readback["workdir"] == stored["workdir"] == str(workdir.resolve())
+        assert readback["input"]["prompt"] == stored["prompt"]
+        assert readback["input"]["prompt_ignored"] is False
+        assert readback["input"]["no_agent"] is False
+        assert readback["session"] == {
+            "mode": "fresh",
+            "current_chat_context": False,
+        }
+        assert readback["output"]["local_output_dir"] == str(
+            get_cron_output_dir() / stored["id"]
+        )
+        assert readback["tool_boundary"] == {
+            "mode": "per_job_allowlist",
+            "enabled_toolsets": ["file"],
+            "effective_tools": "resolved_at_fire",
+        }
+        assert readback["delivery"] == stored["deliver"] == "local"
+        assert readback["attach_to_session"] == {
+            "policy": "explicit",
+            "value": True,
+            "effective": True,
+        }
+        assert readback["model"]["policy"] == "pinned"
+        assert readback["model"]["name"] == stored["model"] == "pinned-model"
+        assert readback["model"]["provider"] == stored["provider"] == "pinned-provider"
+        assert readback["model"]["base_url"] is None
+        assert readback["skills"] == stored["skills"] == ["search-first"]
+        assert readback["skills_ignored"] is False
+        assert readback["next_run_at"] == stored["next_run_at"]
+        assert created["job"]["next_run_at"] == stored["next_run_at"]
+
+    def test_create_readback_makes_default_boundaries_explicit(self):
+        """A simple reminder still has a complete, reviewable contract."""
+        from cron.jobs import get_job
+
+        created = json.loads(
+            cronjob(
+                action="create",
+                prompt="Remind me to stretch.",
+                schedule="every 1h",
+                name="Stretch reminder",
+            )
+        )
+
+        stored = get_job(created["job_id"])
+        assert stored is not None
+        readback = created["readback"]
+        assert readback["session"] == {
+            "mode": "fresh",
+            "current_chat_context": False,
+        }
+        assert readback["workdir"] is None
+        assert readback["input"]["prompt"] == stored["prompt"]
+        assert readback["input"]["script"] is None
+        assert readback["input"]["context_from"] == []
+        assert readback["tool_boundary"] == {
+            "mode": "runtime_default",
+            "enabled_toolsets": [],
+            "effective_tools": "resolved_at_fire",
+        }
+        assert readback["delivery"] == stored["deliver"]
+        assert readback["attach_to_session"] == {
+            "policy": "runtime_default",
+            "value": None,
+            "effective": "resolved_at_fire",
+        }
+        assert readback["model"]["policy"] == "inherited"
+        assert readback["model"]["name"] is None
+        assert readback["model"]["provider"] is None
+        assert readback["skills"] == []
+        assert readback["next_run_at"] == stored["next_run_at"]
+
+    def test_create_readback_marks_single_model_override_pinned(self):
+        created = json.loads(
+            cronjob(
+                action="create",
+                prompt="Summarize the local queue.",
+                schedule="every 1h",
+                model="pinned-model",
+            )
+        )
+
+        model = created["readback"]["model"]
+        assert model["policy"] == "pinned"
+        assert model["name"] == "pinned-model"
+        assert model["provider"] is None
+        assert model["base_url"] is None
+
+    def test_no_agent_readback_declares_no_agent_session(self):
+        created = json.loads(
+            cronjob(
+                action="create",
+                schedule="every 5m",
+                script="watchdog.py",
+                no_agent=True,
+                deliver="local",
+                prompt="ignored prompt",
+                skills=["ignored-skill"],
+                model="ignored-model",
+                enabled_toolsets=["web"],
+            )
+        )
+
+        assert created["success"] is True
+        readback = created["readback"]
+        assert readback["session"] == {
+            "mode": "none",
+            "current_chat_context": False,
+        }
+        assert readback["input"]["no_agent"] is True
+        assert readback["input"]["prompt"] == "ignored prompt"
+        assert readback["input"]["prompt_ignored"] is True
+        assert readback["input"]["script"] == "watchdog.py"
+        assert readback["tool_boundary"] == {
+            "mode": "not_applicable",
+            "enabled_toolsets": ["web"],
+            "effective_tools": "none",
+            "stored_policy_ignored": True,
+        }
+        assert readback["model"]["policy"] == "not_applicable"
+        assert readback["model"]["name"] == "ignored-model"
+        assert readback["model"]["stored_policy_ignored"] is True
+        assert readback["skills"] == ["ignored-skill"]
+        assert readback["skills_ignored"] is True
+
+    @pytest.mark.parametrize(
+        "readback_failure", ["missing", "get_error", "format_error"]
+    )
+    def test_create_does_not_claim_success_when_readback_fails(
+        self, monkeypatch, readback_failure
+    ):
+        """A completed write is not a verified schedule until readback succeeds."""
+        import tools.cronjob_tools as cronjob_tools
+
+        def fail_readback(_job_id):
+            if readback_failure == "get_error":
+                raise OSError("simulated readback failure")
+            return None
+
+        if readback_failure == "format_error":
+            def fail_format(_job):
+                raise ValueError("simulated readback formatting failure")
+
+            monkeypatch.setattr(
+                cronjob_tools, "_format_persisted_job_readback", fail_format
+            )
+        else:
+            monkeypatch.setattr(cronjob_tools, "get_job", fail_readback)
+
+        result = json.loads(
+            cronjob(
+                action="create",
+                prompt="Produce a local status report.",
+                schedule="every 1h",
+                name="Unreadable job",
+            )
+        )
+
+        assert result["success"] is False
+        assert result["job_saved"] is True
+        assert result["readback_verified"] is False
+        assert "read back" in result["error"]
+
+    def test_update_returns_persisted_fresh_session_contract(self, tmp_path, monkeypatch):
+        """An update response must reflect the stored record, including fields
+        that the write path did not mutate."""
+        from cron.jobs import get_job
+        import tools.cronjob_tools as cronjob_tools
+
+        workdir = tmp_path / "updated-project"
+        workdir.mkdir()
+        created = json.loads(
+            cronjob(
+                action="create",
+                prompt="Read old.json and write old.md.",
+                schedule="every 1h",
+                name="Original",
+                skills=["original-skill"],
+            )
+        )
+        real_update = cronjob_tools.update_job
+
+        def update_with_stale_return(job_id, updates):
+            saved = real_update(job_id, updates)
+            stale = dict(saved)
+            stale.update(
+                name="stale-name",
+                prompt="stale-prompt",
+                skills=["stale-skill"],
+                enabled_toolsets=["stale-toolset"],
+                next_run_at="stale-next-run",
+            )
+            return stale
+
+        monkeypatch.setattr(cronjob_tools, "update_job", update_with_stale_return)
+
+        updated = json.loads(
+            cronjob(
+                action="update",
+                job_id=created["job_id"],
+                name="Updated",
+                prompt="Read input.json and write report.md. End with COMPLETE.",
+                skills=["search-first"],
+                enabled_toolsets=["web"],
+                workdir=str(workdir),
+            )
+        )
+
+        assert updated["success"] is True
+        assert updated["readback_verified"] is True
+        stored = get_job(created["job_id"])
+        assert stored is not None
+        assert updated["job"]["name"] == stored["name"] == "Updated"
+        assert updated["readback"]["input"]["prompt"] == stored["prompt"]
+        assert updated["readback"]["workdir"] == stored["workdir"]
+        assert updated["readback"]["skills"] == stored["skills"] == ["search-first"]
+        assert updated["readback"]["tool_boundary"] == {
+            "mode": "per_job_allowlist",
+            "enabled_toolsets": ["web"],
+            "effective_tools": "resolved_at_fire",
+        }
+        assert updated["readback"]["next_run_at"] == stored["next_run_at"]
+
+    @pytest.mark.parametrize(
+        "readback_failure", ["missing", "get_error", "format_error"]
+    )
+    def test_update_does_not_claim_success_when_readback_fails(
+        self, monkeypatch, readback_failure
+    ):
+        """A saved edit without readback must be reported as unverified."""
+        import tools.cronjob_tools as cronjob_tools
+
+        created = json.loads(
+            cronjob(
+                action="create",
+                prompt="Produce a local status report.",
+                schedule="every 1h",
+                name="Before update",
+            )
+        )
+        def fail_readback(_job_id):
+            if readback_failure == "get_error":
+                raise OSError("simulated readback failure")
+            return None
+
+        if readback_failure == "format_error":
+            def fail_format(_job):
+                raise ValueError("simulated readback formatting failure")
+
+            monkeypatch.setattr(
+                cronjob_tools, "_format_persisted_job_readback", fail_format
+            )
+        else:
+            monkeypatch.setattr(cronjob_tools, "get_job", fail_readback)
+
+        result = json.loads(
+            cronjob(
+                action="update",
+                job_id=created["job_id"],
+                name="After update",
+            )
+        )
+
+        assert result["success"] is False
+        assert result["job_updated"] is True
+        assert result["readback_verified"] is False
+        assert "read back" in result["error"]
+
+    def test_update_does_not_claim_write_when_job_disappears(self, monkeypatch):
+        import tools.cronjob_tools as cronjob_tools
+
+        created = json.loads(
+            cronjob(
+                action="create",
+                prompt="Produce a local status report.",
+                schedule="every 1h",
+                name="Soon removed",
+            )
+        )
+        monkeypatch.setattr(cronjob_tools, "update_job", lambda _job_id, _updates: None)
+
+        result = json.loads(
+            cronjob(
+                action="update",
+                job_id=created["job_id"],
+                name="Never persisted",
+            )
+        )
+
+        assert result["success"] is False
+        assert result["job_updated"] is False
+        assert result["readback_verified"] is False
+        assert "not updated" in result["error"]
+
     def test_list_handles_partial_legacy_job_records(self):
         from cron.jobs import save_jobs
 
@@ -267,6 +612,44 @@ class TestUnifiedCronjobTool:
         assert listing["jobs"][0]["name"] == "abc123deadbe"
         assert listing["jobs"][0]["prompt_preview"] == ""
         assert listing["jobs"][0]["schedule"] == "every 60m"
+
+    def test_update_readback_normalizes_legacy_optional_shapes(self):
+        from datetime import datetime, timedelta, timezone
+
+        from cron.jobs import save_jobs
+
+        next_run = (datetime.now(timezone.utc) + timedelta(hours=1)).isoformat()
+        save_jobs(
+            [
+                {
+                    "id": "legacy-job",
+                    "name": "legacy job",
+                    "prompt": "Read legacy input",
+                    "schedule": {"kind": "interval", "interval_seconds": 3600},
+                    "schedule_display": "every 1h",
+                    "repeat": {"times": None, "completed": 0},
+                    "enabled": True,
+                    "state": "scheduled",
+                    "next_run_at": next_run,
+                    "created_at": datetime.now(timezone.utc).isoformat(),
+                    "enabled_toolsets": "web",
+                    "context_from": "upstream-job",
+                }
+            ]
+        )
+
+        updated = json.loads(
+            cronjob(action="update", job_id="legacy-job", name="legacy updated")
+        )
+
+        assert updated["success"] is True
+        assert updated["readback"]["tool_boundary"] == {
+            "mode": "per_job_allowlist",
+            "enabled_toolsets": ["web"],
+            "effective_tools": "resolved_at_fire",
+        }
+        assert updated["readback"]["input"]["context_from"] == ["upstream-job"]
+        assert updated["readback"]["skills"] == []
 
     def test_pause_and_resume(self):
         created = json.loads(cronjob(action="create", prompt="Check", schedule="every 1h"))

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -41,6 +41,7 @@ from cron.jobs import (
     AmbiguousJobReference,
     claim_job_for_fire,
     effective_job_state,
+    get_cron_output_dir,
     get_job,
     is_job_runnable,
     list_jobs,
@@ -661,6 +662,131 @@ def _format_job(job: Dict[str, Any]) -> Dict[str, Any]:
     return result
 
 
+def _read_persisted_job(job_id: str) -> Optional[Dict[str, Any]]:
+    """Read one saved job without turning storage errors into false success."""
+    try:
+        return get_job(job_id)
+    except Exception as exc:
+        logger.warning("Failed to read back persisted cron job %s: %s", job_id, exc)
+        return None
+
+
+def _format_persisted_job_readback(job: Dict[str, Any]) -> Dict[str, Any]:
+    """Build a complete fresh-session contract from one stored job record."""
+    prompt = str(job.get("prompt") or "")
+    skills = _canonical_skills(job.get("skill"), job.get("skills"))
+    job_id = str(job.get("id") or "unknown")
+    context_from = job.get("context_from")
+    if isinstance(context_from, str):
+        context_from = [context_from]
+    elif not isinstance(context_from, list):
+        context_from = []
+    raw_toolsets = job.get("enabled_toolsets")
+    if isinstance(raw_toolsets, str):
+        toolsets = [raw_toolsets.strip()] if raw_toolsets.strip() else []
+    elif isinstance(raw_toolsets, list):
+        toolsets = [str(value).strip() for value in raw_toolsets if str(value).strip()]
+    else:
+        toolsets = []
+    no_agent = bool(job.get("no_agent"))
+    if no_agent:
+        tool_boundary = {
+            "mode": "not_applicable",
+            "enabled_toolsets": toolsets,
+            "effective_tools": "none",
+            "stored_policy_ignored": True,
+        }
+        model_policy = "not_applicable"
+    else:
+        tool_boundary = {
+            "mode": "per_job_allowlist" if toolsets else "runtime_default",
+            "enabled_toolsets": toolsets,
+            "effective_tools": "resolved_at_fire",
+        }
+        model_policy = (
+            "pinned"
+            if any(
+                job.get(field) is not None
+                for field in ("model", "provider", "base_url")
+            )
+            else "inherited"
+        )
+    model_readback = {
+        "policy": model_policy,
+        "name": job.get("model"),
+        "provider": job.get("provider"),
+        "base_url": job.get("base_url"),
+        "model_snapshot": job.get("model_snapshot"),
+        "provider_snapshot": job.get("provider_snapshot"),
+    }
+    if no_agent:
+        model_readback["stored_policy_ignored"] = True
+    raw_attach_to_session = job.get("attach_to_session")
+    if isinstance(raw_attach_to_session, bool):
+        attach_to_session = {
+            "policy": "explicit",
+            "value": raw_attach_to_session,
+            "effective": raw_attach_to_session,
+        }
+    else:
+        attach_to_session = {
+            "policy": "runtime_default",
+            "value": None,
+            "effective": "resolved_at_fire",
+        }
+
+    return {
+        "source": "persisted",
+        "job_id": job_id,
+        "name": str(job.get("name") or job_id),
+        "schedule": job.get("schedule_display") or "?",
+        "enabled": job.get("enabled", True),
+        "state": effective_job_state(job),
+        "session": {
+            "mode": "none" if no_agent else "fresh",
+            "current_chat_context": False,
+        },
+        "workdir": job.get("workdir"),
+        "input": {
+            "prompt": prompt,
+            "prompt_ignored": no_agent,
+            "script": job.get("script"),
+            "monitor_script": job.get("monitor_script"),
+            "monitor_url": job.get("monitor_url"),
+            "context_from": context_from,
+            "no_agent": no_agent,
+        },
+        "output": {
+            "local_output_dir": str(get_cron_output_dir() / job_id),
+        },
+        "tool_boundary": tool_boundary,
+        "delivery": job.get("deliver", "local"),
+        "attach_to_session": attach_to_session,
+        "model": model_readback,
+        "skills": skills,
+        "skills_ignored": no_agent,
+        "next_run_at": job.get("next_run_at"),
+    }
+
+
+def _format_verified_job_readback(
+    job: Dict[str, Any],
+) -> Optional[Dict[str, Dict[str, Any]]]:
+    """Format a persisted job without turning formatter errors into success."""
+    try:
+        return {
+            "job": _format_job(job),
+            "readback": _format_persisted_job_readback(job),
+        }
+    except Exception as exc:
+        logger.warning(
+            "Failed to format persisted cron job readback %s: %s",
+            job.get("id", "unknown"),
+            exc,
+        )
+        return None
+
+
 def _execute_job_now(
     job: Dict[str, Any], extra_prompt: Optional[str] = None
 ) -> Dict[str, Any]:
@@ -1258,6 +1384,29 @@ def cronjob(
             except CronSchedulerRegistrationError as exc:
                 _partial = exc.to_dict()
                 return tool_error(_partial.pop("error"), success=False, **_partial)
+            persisted_job = _read_persisted_job(job["id"])
+            if persisted_job is None:
+                return tool_error(
+                    "Cron job was saved but its persisted configuration could "
+                    "not be read back. Inspect it with cronjob(action='list') "
+                    "before relying on the schedule.",
+                    success=False,
+                    job_id=job["id"],
+                    job_saved=True,
+                    readback_verified=False,
+                )
+            job = persisted_job
+            formatted_readback = _format_verified_job_readback(job)
+            if formatted_readback is None:
+                return tool_error(
+                    "Cron job was saved but its persisted configuration could "
+                    "not be read back and verified. Inspect it with "
+                    "cronjob(action='list') before relying on the schedule.",
+                    success=False,
+                    job_id=job["id"],
+                    job_saved=True,
+                    readback_verified=False,
+                )
             _create_message = f"Cron job '{job['name']}' created."
             _local_notice = _local_delivery_notice(job, _normalize_deliver_param(deliver))
             if _local_notice:
@@ -1273,7 +1422,9 @@ def cronjob(
                     "repeat": _repeat_display(job),
                     "deliver": job.get("deliver", "local"),
                     "next_run_at": job["next_run_at"],
-                    "job": _format_job(job),
+                    "job": formatted_readback["job"],
+                    "readback_verified": True,
+                    "readback": formatted_readback["readback"],
                     "message": _create_message,
                 },
                 indent=2,
@@ -1544,9 +1695,48 @@ def cronjob(
                     updates["enabled"] = True
             if not updates:
                 return tool_error("No updates provided.", success=False)
-            updated = update_job(job_id, updates)
+            updated_job = update_job(job_id, updates)
+            if updated_job is None:
+                return tool_error(
+                    "Cron job was not updated; it may have been removed before "
+                    "the change could be persisted.",
+                    success=False,
+                    job_id=job_id,
+                    job_updated=False,
+                    readback_verified=False,
+                )
             _notify_provider_jobs_changed_safe()
-            return json.dumps({"success": True, "job": _format_job(updated)}, indent=2)
+            persisted_job = _read_persisted_job(job_id)
+            if persisted_job is None:
+                return tool_error(
+                    "Cron job was updated but its persisted configuration could "
+                    "not be read back. Inspect it with cronjob(action='list') "
+                    "before relying on the change.",
+                    success=False,
+                    job_id=job_id,
+                    job_updated=True,
+                    readback_verified=False,
+                )
+            formatted_readback = _format_verified_job_readback(persisted_job)
+            if formatted_readback is None:
+                return tool_error(
+                    "Cron job was updated but its persisted configuration "
+                    "could not be read back and verified. Inspect it with "
+                    "cronjob(action='list') before relying on the change.",
+                    success=False,
+                    job_id=job_id,
+                    job_updated=True,
+                    readback_verified=False,
+                )
+            return json.dumps(
+                {
+                    "success": True,
+                    "job": formatted_readback["job"],
+                    "readback_verified": True,
+                    "readback": formatted_readback["readback"],
+                },
+                indent=2,
+            )
 
         return tool_error(f"Unknown cron action '{action}'", success=False)
 
@@ -1559,7 +1749,7 @@ CRONJOB_SCHEMA = {
     "name": "cronjob",
     "description": """Manage scheduled cron jobs with a single compressed tool.
 
-Use action='create' to schedule a new job from a prompt or one or more skills.
+Use action='create' to schedule a new job from a prompt, skills, or a no_agent script.
 Use action='list' to inspect jobs.
 Use action='update', 'pause', 'resume', 'remove', or 'run' to manage an existing job.
 
@@ -1568,6 +1758,9 @@ action='run' fires the job immediately in the BACKGROUND (like delegate_task): t
 To stop a job the user no longer wants: first action='list' to find the job_id, then action='remove' with that job_id. Never guess job IDs — always list first.
 
 Jobs run in a fresh session with no current-chat context, so prompts must be self-contained.
+Before create or update, define a fresh-session contract. For tasks that consume files or data, produce artifacts, or perform actions, the prompt must state the exact input, expected output or destination, execution ordering or acceptance rule, tool boundary (including network and external-action limits), and terminal success marker. Set an absolute working directory whenever the task depends on project files or relative paths. If a required detail is missing, stop rather than schedule a guess.
+For no_agent=True, the script path and stdout are the input/output contract; prompt, skills, model, and toolset settings are ignored. Do not require or invent a prompt — verify workdir, delivery, and next_run_at from readback instead.
+After create or update, the tool must read back the persisted record. Verify the returned readback's working directory, exact input, expected output location, tool boundary, delivery, model policy, skills, and next_run_at before claiming success. A successful write without verified readback is not confirmation.
 If skills are provided on create, the future cron run loads those skills in order, then follows the prompt as the task instruction.
 On update, passing skills=[] clears attached skills.
 
@@ -1581,7 +1774,7 @@ Scheduling from cron-run sessions is disabled by default and enabled via cron.al
         "properties": {
             "action": {
                 "type": "string",
-                "description": "One of: create, list, update, pause, resume, remove, run. When action=create, the 'schedule' and 'prompt' fields are REQUIRED."
+                "description": "One of: create, list, update, pause, resume, remove, run. When action=create, schedule is REQUIRED; prompt is REQUIRED unless skills define the task. no_agent=True requires script and ignores prompt."
             },
             "job_id": {
                 "type": "string",

--- a/website/docs/developer-guide/cron-internals.md
+++ b/website/docs/developer-guide/cron-internals.md
@@ -180,6 +180,54 @@ Each cron job runs in a completely fresh agent session:
 - The prompt must be self-contained — cron jobs cannot ask clarifying questions
 - The `cronjob` toolset is disabled (recursion guard)
 
+### Persisted configuration readback
+
+The model-facing `cronjob` tool treats create/update as a write followed by a
+separate read. After `create_job_with_scheduler_registration()` or
+`update_job()`, it calls `get_job()` and builds the response from that persisted
+record rather than the object returned by the write path. This catches stale or
+partially transformed return values before the agent claims configuration
+success.
+
+Successful create/update responses include `readback_verified: true` and a
+`readback` object produced by `_format_persisted_job_readback()`. It is the
+fresh-session execution contract and contains:
+
+- stored input: full prompt, script/monitor sources, `context_from`, and
+  `no_agent`,
+- normalized `workdir` and the profile-scoped local output directory,
+- the saved `enabled_toolsets` policy; runtime-effective tools remain explicitly
+  marked as resolved at fire time because global denials, MCP expansion, and
+  platform defaults may change,
+- delivery target and an `attach_to_session` policy that distinguishes an
+  explicit boolean from an unset value resolved through `cron.mirror_delivery`
+  at fire time,
+- model/provider/base URL pins plus write-time snapshots,
+- skills, schedule, state, and `next_run_at`.
+
+For `no_agent` records, `session.mode` is `none`; the script/stdout pair is the
+input/output contract. Stored model and toolset values are retained for audit,
+but their policies are `not_applicable`, effective tools are `none`, and both
+are marked as ignored at execution. Stored prompt and skills are also retained
+with `prompt_ignored` / `skills_ignored` flags.
+
+Legacy single-string `enabled_toolsets` values are normalized identically in
+readback and `_resolve_cron_enabled_toolsets()` so the displayed allowlist
+matches runtime behavior.
+
+Null/default values are retained so a detached reminder is as reviewable as a
+project job. If the post-write lookup returns no record, raises a storage error,
+or readback formatting fails, the tool logs the local diagnostic and returns
+`success: false` with
+`readback_verified: false` and a `job_saved` or `job_updated` marker; callers
+must not convert that partial outcome into a success message. If `update_job()`
+returns no record (for example, a concurrent removal), the response instead
+uses `job_updated: false` and skips provider notification/readback.
+
+This response contract is intentionally derived, not a second persisted schema.
+The persisted job record remains the single source of truth and existing jobs
+require no migration.
+
 ## Skill-Backed Jobs
 
 A cron job can attach one or more skills via the `skills` field. At execution time:

--- a/website/docs/user-guide/features/cron.md
+++ b/website/docs/user-guide/features/cron.md
@@ -67,6 +67,52 @@ Every morning at 9am, check Hacker News for AI news and send me a summary on Tel
 
 Hermes will use the unified `cronjob` tool internally.
 
+## Fresh-session contract and saved readback
+
+Every agent-backed job runs without the conversation that created it. Before
+Hermes creates or updates one through the `cronjob` tool, the stored task must
+therefore be a self-contained contract. For repository or file-based work, the
+contract should name:
+
+- the exact input or source,
+- the expected output or destination,
+- the ordering or acceptance rule,
+- the tool, network, and external-action boundary,
+- and any terminal success marker.
+
+Set an absolute `workdir` whenever the task depends on project-relative paths or
+repository instructions. If a required path, destination, or authority boundary
+is missing, Hermes stops instead of scheduling a guess. Simple reminders remain
+valid: their readback explicitly shows `workdir: null` and the inherited runtime
+policies.
+
+A successful write is not the confirmation. After `create` or `update`, the
+model-facing tool reads the job back from the persisted store and returns
+`readback_verified: true` plus a `readback` object containing:
+
+- fresh-session mode and the complete stored inputs (`prompt`, script/monitor
+  sources, and `context_from`),
+- `workdir` and the local cron output directory,
+- the saved per-job tool allowlist (effective tools are resolved again at fire
+  time),
+- delivery plus an `attach_to_session` policy: explicit overrides keep their
+  boolean value, while an absent override is marked `runtime_default` and
+  resolved against `cron.mirror_delivery` at fire time,
+- pinned or inherited model policy and write-time snapshots,
+- attached skills,
+- and the normalized schedule with `next_run_at`.
+
+For `no_agent: true`, the readback uses `session.mode: none`. The script path and
+stdout are the input/output contract; stored model and toolset values remain
+visible for audit but are marked `not_applicable` and ignored at execution.
+Stored prompt and skills are likewise retained with explicit `*_ignored` flags.
+Hermes does not require or invent a prompt for script-only jobs.
+
+If persistence succeeds but this readback fails, the response has
+`success: false`, `readback_verified: false`, and either `job_saved: true` or
+`job_updated: true`. Inspect the job with `cronjob(action="list")` before making
+another change; do not assume a retry is harmless.
+
 ## Pre-dispatch configuration validation
 
 Before constructing any agent machinery for a scheduled run, the scheduler


### PR DESCRIPTION
## Summary

- make agent-facing cron `create` and `update` reread the persisted job before reporting success
- return an explicit fresh-session readback covering workdir, inputs, outputs, tool policy, delivery, model policy, skills, schedule, and `next_run_at`
- fail closed when persisted readback is missing, raises, or cannot be formatted, while preserving accurate partial-write markers
- align `no_agent`, `attach_to_session`, and legacy single-string toolset readback with actual runtime semantics
- document the fresh-session contract and persisted readback behavior

## Why

Cron jobs run in fresh sessions without the chat context that created them. Before this change, the model-facing tool trusted the immediate mutation result and did not provide one structured confirmation of the persisted execution contract. This made it easier to schedule an under-specified workflow or claim success when post-write verification failed.

The readback is derived from the existing persisted job record; it does not add a second schema or require migration of existing `jobs.json` records.

## Behavior

- Successful `create` / `update`: `readback_verified: true` with a complete derived readback.
- Persisted write followed by failed lookup/formatting: `success: false`, `readback_verified: false`, and an accurate `job_saved` or `job_updated` marker.
- Concurrent removal during update: `job_updated: false`; no provider notification or false readback claim.
- Agent jobs: `session.mode: fresh`, with no current-chat context.
- `no_agent` jobs: `session.mode: none`; agent model/tools are `not_applicable`, and stored prompt/skills are marked ignored.
- Unset `attach_to_session`: reported as `runtime_default`, resolved against `cron.mirror_delivery` at fire time.
- Legacy `enabled_toolsets: "web"`: normalized consistently in both readback and scheduler runtime.

## Test plan

Tested on Windows 11:

- `scripts/run_tests.sh tests/tools/test_cronjob_tools.py tests/cron/test_cronjob_schema.py tests/cron/test_scheduler.py -q`
  - 172 passed, 0 failed
- broad `tests/cron/` run excluding baseline Windows-only incompatibilities (`test_tilde_expands`, POSIX file-permission cases, and process-tree cancellation)
  - 685 passed, 0 failed, 20 skipped
- `ruff check` on all changed Python files
- `git diff --check`
- independent fail-closed review of the final diff: passed with no security concerns, logic errors, or suggestions

No real cron job was created, updated, fired, or delivered during implementation or testing.
