### PR TITLE
fix(agent): cap compaction threshold floor at 85% of the context window

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -608,6 +608,28 @@ def _image_error_max_dimension(error: Exception) -> Optional[int]:
     return None
 
 
+def _pressure_with_real_floor(compressor: Any, rough_tokens: int) -> int:
+    """Floor the rough pre-API pressure estimate at the last REAL prompt size.
+
+    The chars/4 rough estimate under-counts Cyrillic (and other non-ASCII
+    scripts) by up to ~2x, so a session can sit at the provider's real context
+    ceiling while the rough figure stays under the compaction threshold — on
+    silent-clip providers (ollama /v1) that is a truncation death spiral the
+    reactive overflow handler never sees (observed live: real prompts
+    64,842→64,995 against a 55,705 threshold). The provider's own last
+    reported prompt_tokens is authoritative; never let the pressure figure
+    fall below it. Skipped for exactly one turn after a compaction, when
+    last_real_prompt_tokens still holds the stale pre-compression value
+    (#36718's awaiting_real_usage_after_compression window).
+    """
+    last_real = int(getattr(compressor, "last_real_prompt_tokens", 0) or 0)
+    if last_real > rough_tokens and not getattr(
+        compressor, "awaiting_real_usage_after_compression", False
+    ):
+        return last_real
+    return rough_tokens
+
+
 def _ollama_context_limit_error(agent: Any, request_tokens: int) -> Optional[str]:
     """Return a user-facing error when Ollama is loaded with too little context."""
     if not getattr(agent, "tools", None):
@@ -2859,6 +2881,9 @@ def run_conversation(
         )
         if _anchored_pressure is not None:
             request_pressure_tokens = _anchored_pressure
+        request_pressure_tokens = _pressure_with_real_floor(
+            agent.context_compressor, request_pressure_tokens
+        )
         total_chars = approx_tokens * 4
         # Stash this request's rough estimate so update_from_response() can
         # pair it with the provider's real prompt count — the (rough, real)

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -3592,13 +3592,20 @@ def estimate_tokens_rough(text: str) -> int:
     if text.isascii():
         # O(1) fast path — ASCII text cannot contain token-dense CJK chars.
         return (len(text) + 3) // 4
-    dense = len(text) - len(_CJK_DENSE_RE.sub("", text))
+    stripped = _CJK_DENSE_RE.sub("", text)
+    dense = len(text) - len(stripped)
     if not dense:
-        # Non-ASCII but no CJK (accents, Cyrillic, emoji, ...): keep the
-        # classic ~4 chars/token rule.
-        return (len(text) + 3) // 4
-    sparse = len(text) - dense
-    return dense + ((sparse + 3) // 4)
+        # Non-ASCII but no CJK (accents, Cyrillic, emoji, ...): count UTF-8
+        # BYTES at ~4/token instead of characters. The byte width is the
+        # corrective: Cyrillic/Greek/Arabic are 2 bytes per char, so they
+        # count as ~chars/2 — matching their real BPE cost (~2-3 chars per
+        # token) where chars/4 under-counted them ~2x and let sessions ride
+        # the provider's context ceiling below the compaction threshold.
+        # ASCII spans inside mixed text still count at 1 byte each.
+        return (len(text.encode("utf-8")) + 3) // 4
+    # Mixed CJK + other: dense chars stay ~1 token each; the sparse
+    # remainder is byte-counted for the same corrective.
+    return dense + ((len(stripped.encode("utf-8")) + 3) // 4)
 
 
 def estimate_messages_tokens_rough(

--- a/tests/agent/test_cjk_token_estimation.py
+++ b/tests/agent/test_cjk_token_estimation.py
@@ -49,15 +49,16 @@ def test_cjk_tail_does_not_expand_to_english_char_budget():
 
 
 def _reference_per_char_estimate(text: str) -> int:
-    """The pre-perf-gate per-character reference implementation."""
+    """Per-character reference: CJK ~1 token/char, everything else UTF-8
+    bytes/4 (the byte width corrects Cyrillic/Greek/Arabic under-counting)."""
     dense = 0
-    sparse = 0
+    sparse_bytes = 0
     for ch in text:
         if _is_cjk_token_dense_char(ch):
             dense += 1
         else:
-            sparse += 1
-    return dense + ((sparse + 3) // 4)
+            sparse_bytes += len(ch.encode("utf-8"))
+    return dense + ((sparse_bytes + 3) // 4)
 
 
 def test_perf_gated_estimator_matches_per_char_reference():
@@ -79,3 +80,11 @@ def test_perf_gated_estimator_matches_per_char_reference():
 
 
 
+def test_cyrillic_counts_by_utf8_bytes():
+    # «русский текст» = 12 Cyrillic chars (2 bytes each) + 1 ASCII space:
+    # 25 bytes -> ceil(25/4) = 7 tokens; the old chars/4 rule said 4 —
+    # the ~2x under-count that let real prompts ride the context ceiling.
+    from agent.model_metadata import estimate_tokens_rough
+    assert estimate_tokens_rough("русский текст") == 7
+    # Pure ASCII unchanged.
+    assert estimate_tokens_rough("a" * 400) == 100

--- a/tests/run_agent/test_infinite_compaction_loop.py
+++ b/tests/run_agent/test_infinite_compaction_loop.py
@@ -262,3 +262,33 @@ class TestCodexSparkShortSessionBoundary:
             f"This would cause the silent context wipe described in #48621."
         )
         assert comp.has_content_to_compress(messages) is True
+
+
+class TestPressureRealFloor:
+    """Regression: Cyrillic-heavy sessions under-count in the rough estimate,
+    letting real prompts ride the provider window (64,842→64,995 observed)
+    while the pre-API gate saw sub-threshold pressure."""
+
+    def _compressor(self, last_real, awaiting=False):
+        class _C:
+            last_real_prompt_tokens = last_real
+            awaiting_real_usage_after_compression = awaiting
+        return _C()
+
+    def test_real_floor_lifts_undercounted_rough(self):
+        from agent.conversation_loop import _pressure_with_real_floor
+        assert _pressure_with_real_floor(self._compressor(64_842), 45_000) == 64_842
+
+    def test_rough_wins_when_larger(self):
+        from agent.conversation_loop import _pressure_with_real_floor
+        assert _pressure_with_real_floor(self._compressor(30_000), 45_000) == 45_000
+
+    def test_stale_real_ignored_right_after_compaction(self):
+        from agent.conversation_loop import _pressure_with_real_floor
+        compressor = self._compressor(64_842, awaiting=True)
+        assert _pressure_with_real_floor(compressor, 20_000) == 20_000
+
+    def test_zero_and_missing_real_are_safe(self):
+        from agent.conversation_loop import _pressure_with_real_floor
+        assert _pressure_with_real_floor(self._compressor(0), 10_000) == 10_000
+        assert _pressure_with_real_floor(object(), 10_000) == 10_000


### PR DESCRIPTION
## Symptom

On a local model with a 65,536-token window (served through ollama's OpenAI-compatible `/v1` endpoint), a busy session degenerated into ~18-minute turns that ended with:

> ⚠️ Processing stopped: Response remained truncated after 4 continuation attempts. Try again.

The proxy ledger for the failing turn shows each continuation retry re-sending a window-filling prompt for a shrinking sliver of output, and every retry paying a full multi-minute prefill:

| call | prompt tokens | output tokens before length-stop (= window − prompt) |
|---|---|---|
| continuation 1 | 65,120 | 416 |
| continuation 2 | 65,171 | 365 |
| continuation 3 | 65,222 | 314 |
| continuation 4 | 65,273 | 263 |

## Root cause

`_compute_threshold_tokens` floors the compaction trigger at `MINIMUM_CONTEXT_LENGTH` (64,000) so large-context models don't compact prematurely, and only degrades to the 85% trigger when the floor *meets or exceeds* the effective window (NousResearch/hermes-agent#14690). Near-minimum windows slip through that equality check: at `context_length == 65536` the threshold passes through at 64,000 — **97.7% of the window**, ~1.5K tokens of output room — so the pre-API compaction gate effectively can never fire.

The design's reactive backstop ("the provider rejects the request before usage reaches 100%") also never fires on providers that silently truncate over-window prompts instead of returning a context-overflow error — ollama's `/v1` endpoint does exactly that. The combination is the death spiral above: length-truncated response → continuation retry → even fuller prompt → truncated again → give up after 4 attempts.

## Fix

Cap the floored threshold at `_MIN_CTX_TRIGGER_RATIO` (85%) of the effective input budget whenever the floor is the binding term:

- 65,536 window: 64,000 → **55,705**
- 70,000 window: 64,000 → **59,500**
- 100,000 window: 64,000 (floor binding but under the cap) — unchanged
- 372,000 window at the default 50%: 186,000 — unchanged
- an explicit `threshold_percent` above 0.85 is user intent, not the floor — not capped

The existing `floored >= effective_window` branch is kept for the case where the percentage itself reaches the window.

## Tests

New regression test `test_threshold_floor_capped_at_85_percent_of_window` covers the four cases above. Existing suites pass: `tests/agent/test_context_compressor.py` (137 passed), plus the threshold-adjacent files `test_ollama_num_ctx`, `test_infinite_compaction_loop`, `test_per_model_threshold_init_ordering`, `test_native_compaction`, `test_compression_trigger_excludes_reasoning`, `test_413_compression`, `test_proactive_prune_loop_wiring` (104 passed).

The patched build is deployed on the affected setup.

## Follow-up: two more holes in the same failure class (added after live soak)

The 85% cap alone did not fully kill the spiral on non-English sessions — the same day it recurred with real prompts 64,842 → 64,995 against the 55,705 threshold. Two additional commits close the remaining path:

1. **Floor the pre-API pressure at the last real prompt size** (`_pressure_with_real_floor`). The rough chars/4 estimate under-counts Cyrillic ~2x, so the pre-API gate saw sub-threshold pressure while the provider was already clipping; the length-continuation retry path re-enters the API call without passing the post-response gate, so no other gate could catch it. The provider's last reported `prompt_tokens` is authoritative and script-independent; the floor is skipped only during the one-turn `awaiting_real_usage_after_compression` window where that value is known-stale (NousResearch/hermes-agent#36718).
2. **Count non-CJK sparse text by UTF-8 bytes in the rough estimator.** The encoding width is the corrective: ASCII unchanged (1 byte/char), 2-byte scripts (Cyrillic/Greek/Arabic) count at ~chars/2 matching their real BPE cost, and the CJK dense path keeps its ~1 token/char rule with the byte-counted sparse remainder. The `isascii()` O(1) fast path is preserved.

Tests: `_pressure_with_real_floor` unit coverage (floor lifts under-counted rough, rough wins when larger, stale-after-compaction window ignored, missing attrs safe) and a Cyrillic byte-count regression; the per-char reference in `test_cjk_token_estimation.py` is updated to the byte semantics. Full local suites: 152 passed across `test_cjk_token_estimation.py`, `test_context_compressor.py`, `test_infinite_compaction_loop.py`.
