### PR TITLE
feat(cli): accept natural-language /loop intervals

### DIFF
--- a/hermes_cli/loops.py
+++ b/hermes_cli/loops.py
@@ -48,6 +48,7 @@ from __future__ import annotations
 import hashlib
 import json
 import logging
+import math
 import re
 import time
 from dataclasses import dataclass, field, asdict
@@ -89,6 +90,15 @@ _INTERVAL_TOKEN_RE = re.compile(
     r"^(?=\d)(?:(\d+)h)?(?:(\d+)m)?(?:(\d+)s)?$", re.IGNORECASE
 )
 
+_NATURAL_INTERVAL_UNITS = {
+    "hour": 3600,
+    "hours": 3600,
+    "minute": 60,
+    "minutes": 60,
+    "second": 1,
+    "seconds": 1,
+}
+
 
 WAKEUP_PROMPT_TEMPLATE = (
     "[/loop wakeup #{tick}{cadence}]\n"
@@ -122,6 +132,16 @@ WAKEUP_PROMPT_WITH_UNTIL_TEMPLATE = (
 # ──────────────────────────────────────────────────────────────────────
 
 
+def _parse_ascii_int(value: str) -> Optional[int]:
+    """Parse user-entered ASCII digits without leaking conversion errors."""
+    if not value or not value.isascii() or not value.isdecimal():
+        return None
+    try:
+        return int(value)
+    except ValueError:
+        return None
+
+
 def parse_interval_token(token: str) -> Optional[int]:
     """Parse a compact interval token (``30s``/``5m``/``2h``/``1h30m``).
 
@@ -134,9 +154,37 @@ def parse_interval_token(token: str) -> Optional[int]:
     m = _INTERVAL_TOKEN_RE.match(token.strip())
     if not m:
         return None
-    h, mnt, s = (int(g) if g else 0 for g in m.groups())
+    values = [_parse_ascii_int(group) if group else 0 for group in m.groups()]
+    if any(value is None for value in values):
+        return None
+    h, mnt, s = values
     total = h * 3600 + mnt * 60 + s
     return total if total > 0 else None
+
+
+def _parse_natural_interval_prefix(text: str) -> Tuple[Optional[int], str]:
+    """Consume leading ``<number> <unit>`` pairs from loop arguments."""
+    tokens = text.split()
+    consumed = 0
+    total = 0
+    while consumed + 1 < len(tokens):
+        amount, unit = tokens[consumed : consumed + 2]
+        multiplier = _NATURAL_INTERVAL_UNITS.get(unit.lower())
+        if multiplier is None:
+            break
+        parsed_amount = _parse_ascii_int(amount)
+        if parsed_amount is None:
+            if amount.isascii() and amount.isdecimal():
+                raise ValueError("interval is too large")
+            return None, text
+        is_plural = unit.lower().endswith("s")
+        if (parsed_amount == 1) == is_plural:
+            return None, text
+        total += parsed_amount * multiplier
+        consumed += 2
+    if consumed == 0 or total <= 0:
+        return None, text
+    return total, " ".join(tokens[consumed:])
 
 
 def parse_loop_args(text: str) -> Dict[str, Any]:
@@ -145,6 +193,7 @@ def parse_loop_args(text: str) -> Dict[str, Any]:
     Recognized shapes::
 
         /loop 5m check the deploy status
+        /loop 2 hours check the pull requests
         /loop every 10m /babysit-prs
         /loop keep fixing the failing test until the suite passes
         /loop 2m poll CI --times 30
@@ -191,8 +240,11 @@ def parse_loop_args(text: str) -> Dict[str, Any]:
         raw = raw[: m_until.start()].strip()
 
     # Leading "every" sugar: /loop every 5m <prompt>
+    interval_source = raw
+    had_every = False
     tokens = raw.split(None, 1)
     if tokens and tokens[0].lower() == "every" and len(tokens) > 1:
+        had_every = True
         raw = tokens[1]
         tokens = raw.split(None, 1)
 
@@ -202,6 +254,13 @@ def parse_loop_args(text: str) -> Dict[str, Any]:
         if maybe is not None:
             interval = maybe
             raw = tokens[1].strip() if len(tokens) > 1 else ""
+        else:
+            try:
+                interval, remainder = _parse_natural_interval_prefix(raw)
+            except ValueError as exc:
+                result["error"] = str(exc)
+                return result
+            raw = remainder if interval is not None or not had_every else interval_source
 
     if not raw:
         result["error"] = "missing prompt (usage: /loop [interval] <prompt>)"
@@ -610,13 +669,19 @@ class LoopManager:
 
         now = time.time()
         if interval_seconds is not None:
-            interval = max(int(interval_seconds), min_interval_seconds())
+            try:
+                interval = float(max(int(interval_seconds), min_interval_seconds()))
+                next_due_at = now + interval
+            except (OverflowError, ValueError):
+                raise ValueError("loop interval is too large") from None
+            if not math.isfinite(next_due_at):
+                raise ValueError("loop interval is too large")
             state = LoopState(
                 prompt=prompt,
                 mode="interval",
-                interval_seconds=float(interval),
-                current_delay=float(interval),
-                next_due_at=now + interval,
+                interval_seconds=interval,
+                current_delay=interval,
+                next_due_at=next_due_at,
             )
         else:
             floor = self_paced_floor_seconds()
@@ -896,6 +961,7 @@ def dispatch_loop_command(
             "output": (
                 "Usage: /loop [interval] <prompt> [--times N] [--until <condition>]\n"
                 "  /loop 5m check the deploy status      — fixed cadence\n"
+                "  /loop 2 hours check pull requests     — natural-language cadence\n"
                 "  /loop every 10m /recap                — loop a slash command\n"
                 "  /loop keep fixing tests until green   — self-paced (backs off while output is unchanged)\n"
                 "  /loop 2m poll CI --times 30           — stop after 30 runs\n"

--- a/tests/hermes_cli/test_loops.py
+++ b/tests/hermes_cli/test_loops.py
@@ -79,6 +79,11 @@ class TestParseIntervalToken:
         assert parse_interval_token("0m") is None
         assert parse_interval_token("0s") is None
 
+    def test_oversized_amount_rejected(self):
+        from hermes_cli.loops import parse_interval_token
+
+        assert parse_interval_token(f"{'9' * 5000}h") is None
+
 
 class TestParseLoopArgs:
     def test_fixed_interval(self):
@@ -95,6 +100,78 @@ class TestParseLoopArgs:
         p = parse_loop_args("every 10m /recap")
         assert p["interval_seconds"] == 600
         assert p["prompt"] == "/recap"
+
+    @pytest.mark.parametrize(
+        ("text", "seconds", "prompt"),
+        [
+            ("2 hours check the pull requests", 7200, "check the pull requests"),
+            ("every 1 hour 30 minutes check CI", 5400, "check CI"),
+            ("45 seconds poll the queue", 45, "poll the queue"),
+            ("1 minute recap", 60, "recap"),
+        ],
+    )
+    def test_natural_language_interval(self, text, seconds, prompt):
+        from hermes_cli.loops import parse_loop_args
+
+        parsed = parse_loop_args(text)
+
+        assert parsed["interval_seconds"] == seconds
+        assert parsed["prompt"] == prompt
+        assert parsed["error"] is None
+
+    @pytest.mark.parametrize("amount", ["²", "①"])
+    def test_unsupported_natural_amount_remains_self_paced(self, amount):
+        from hermes_cli.loops import parse_loop_args
+
+        text = f"{amount} hours check the pull requests"
+        parsed = parse_loop_args(text)
+
+        assert parsed["interval_seconds"] is None
+        assert parsed["prompt"] == text
+        assert parsed["error"] is None
+
+    def test_oversized_natural_amount_returns_error(self):
+        from hermes_cli.loops import parse_loop_args
+
+        parsed = parse_loop_args(f"{'9' * 5000} hours check the pull requests")
+
+        assert parsed["interval_seconds"] is None
+        assert parsed["error"] == "interval is too large"
+
+    @pytest.mark.parametrize(
+        "text",
+        [
+            "3 second thoughts about the incident",
+            "5 minute the whole thing",
+            "1 hours check the queue",
+        ],
+    )
+    def test_mismatched_natural_unit_remains_self_paced(self, text):
+        from hermes_cli.loops import parse_loop_args
+
+        parsed = parse_loop_args(text)
+
+        assert parsed["interval_seconds"] is None
+        assert parsed["prompt"] == text
+        assert parsed["error"] is None
+
+    @pytest.mark.parametrize(
+        "text",
+        [
+            "1 hour 5 minute check CI",
+            "every 1 hour 5 minute check CI",
+            "1 hour ² minutes check CI",
+            "every 1 hour ² minutes check CI",
+        ],
+    )
+    def test_invalid_compound_natural_interval_remains_self_paced(self, text):
+        from hermes_cli.loops import parse_loop_args
+
+        parsed = parse_loop_args(text)
+
+        assert parsed["interval_seconds"] is None
+        assert parsed["prompt"] == text
+        assert parsed["error"] is None
 
     def test_self_paced(self):
         from hermes_cli.loops import parse_loop_args
@@ -620,6 +697,21 @@ class TestDispatchLoopCommand:
         result = dispatch_loop_command(mgr, "5m poll --times banana")
         assert result["created"] is False
         assert "--times" in result["output"]
+
+    @pytest.mark.parametrize(
+        "args",
+        [
+            f"{'9' * 308}h check",
+            f"{'9' * 308} hours check",
+        ],
+    )
+    def test_unrepresentable_interval_returns_error(self, hermes_home, args):
+        from hermes_cli.loops import LoopManager, dispatch_loop_command
+
+        result = dispatch_loop_command(LoopManager(session_id="d8"), args)
+
+        assert result["created"] is False
+        assert "interval is too large" in result["output"]
 
 
 # ──────────────────────────────────────────────────────────────────────

--- a/website/docs/user-guide/features/loops.md
+++ b/website/docs/user-guide/features/loops.md
@@ -39,10 +39,11 @@ Loop a slash command just as easily:
 
 ## The two cadence modes
 
-**Fixed interval — you set the clock.** Give an interval (`30s`, `5m`, `2h`, `1h30m`) and the loop fires on that schedule. Use it when the thing you're watching changes on its own timeline:
+**Fixed interval — you set the clock.** Give a compact interval (`30s`, `5m`, `2h`, `1h30m`) or write it naturally (`30 seconds`, `5 minutes`, `2 hours`, `1 hour 30 minutes`) and the loop fires on that schedule. Use it when the thing you're watching changes on its own timeline:
 
 ```
 /loop 2m poll the build at ci.example.com/job/42 and ping me the moment it finishes
+/loop every 2 hours check whether my pull requests need attention
 ```
 
 **Self-paced — Hermes sets the clock.** Omit the interval and the loop paces itself: it starts at the floor (1 minute by default), and while the agent's replies stop changing it backs off exponentially — 2m, 4m, 8m, up to the ceiling (15 minutes by default). The moment a reply differs from the last one, cadence snaps back to the floor. Change detection is a local digest comparison (timestamps are ignored), so idle waits cost nothing extra:


### PR DESCRIPTION
## Summary

- accept natural fixed-cadence prefixes such as `/loop 2 hours ...` and `/loop every 1 hour 30 minutes ...`
- keep bare leading numbers such as `/loop 3 things to verify` self-paced and unmodified
- safely reject unsupported, oversized, or unschedulable interval values instead of raising conversion errors
- document the natural-language syntax in `/loop help` and the user guide

## Problem

`/loop` previously recognized only compact interval tokens such as `2h`. A user entering the natural equivalent, `/loop 2 hours check the PRs`, silently created a self-paced loop whose default first wakeup is one minute. That is surprising unless the user already knows the compact syntax and can make an unintended loop run far more frequently than requested.

## Approach

The shared loop argument parser now consumes unambiguous leading `<ASCII number> <full unit>` pairs for `hour(s)`, `minute(s)`, and `second(s)`. Requiring a recognized unit preserves the existing ambiguity guard for prompts beginning with a bare number.

Numeric conversion and loop scheduling are also defensive: malformed Unicode numerics, Python integer-string-limit inputs, and values that cannot produce a finite due timestamp do not escape as exceptions.

## Validation

- TDD: the four natural-language cases failed before implementation and passed after
- TDD: malformed Unicode/oversized conversion regressions failed before their guards and passed after
- TDD: compact and natural end-to-end overflow cases failed before scheduling validation and passed after
- `python -m pytest tests/hermes_cli/test_loops.py tests/gateway/test_loop_command.py tests/tui_gateway/test_loop_command.py -q` — **87 passed**
- canonical hermetic runner for `tests/hermes_cli/test_loops.py` — **73 passed**
- `ruff check hermes_cli/loops.py tests/hermes_cli/test_loops.py` — passed
- `git diff --check` — passed
- Windows-footgun scan — passed
- independent final review — **APPROVE**, no high/medium findings

## Scope

This intentionally does not interpret spelled-out numbers such as `two hours`; it adds the common and unambiguous digit-plus-full-unit form without introducing a general natural-language date parser or new dependency.
