### PR TITLE
docs(plugins): index Liquid Glass desktop theme

### DIFF
--- a/hermes_cli/data/plugin_index.json
+++ b/hermes_cli/data/plugin_index.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "generated_at": "2026-08-12T00:00:00Z",
+  "generated_at": "2026-08-16T00:00:00Z",
   "plugins": [
     {
       "name": "hermes-media-studio",
@@ -25,6 +25,18 @@
       "capabilities": ["platform"],
       "api_version": 1,
       "added_at": "2026-08-12"
+    },
+    {
+      "name": "liquid-glass-wal",
+      "description": "Linux-native pywal and Hyprland liquid glass theme for Hermes Desktop, with live wallpaper-driven colors.",
+      "author": "kvnloo",
+      "tags": ["desktop", "theme", "pywal", "hyprland", "linux"],
+      "repo": "kvnloo/hermes-liquid-glass",
+      "ref": "b84e5415b7d3a28cd63408214abe434c7b767775",
+      "homepage": "https://github.com/kvnloo/hermes-liquid-glass",
+      "capabilities": ["desktop"],
+      "api_version": 1,
+      "added_at": "2026-08-16"
     },
     {
       "name": "plugin-llm-example",


### PR DESCRIPTION
## Problem

Hermes Desktop users need a discoverable, pinned community-index entry for the standalone Liquid Glass pywal/Hyprland theme. Without the bundled seed metadata, offline plugin search cannot resolve the plugin by name.

## Minimal approach

Add one `liquid-glass-wal` entry to `hermes_cli/data/plugin_index.json`, pinned to the immutable source commit `b84e5415b7d3a28cd63408214abe434c7b767775`. The entry declares only the existing `desktop` capability and leaves the index/API schema versions unchanged.

## Tests

- `scripts/run_tests.sh tests/hermes_cli/test_plugin_index_search.py tests/hermes_cli/test_plugin_packs.py -q`
- 74 passed
- Verified the pinned GitHub commit exists and its `plugin.yaml` describes an inert Python half plus opt-in Desktop plugin.
- Verified the branch is exactly one commit ahead of current `main`, with only `hermes_cli/data/plugin_index.json` changed.

## Risk / rollback

Low: this is metadata-only and installs remain disabled by default behind the existing review/consent flow. Rollback is a one-file revert removing the index entry.

## Non-goals

- No Hermes core or runtime changes.
- No plugin source vendoring or code audit.
- No automatic enablement, capability grant, or installation.
- No upstream merge performed by this PR update.
