### PR TITLE
fix(desktop): defer credential-warning onboarding to the first chat attempt

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/submit.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/submit.ts
@@ -20,7 +20,7 @@ import {
 } from '@/store/composer'
 import { $hudMode } from '@/store/hud'
 import { clearNotifications, notify, notifyError } from '@/store/notifications'
-import { requestDesktopOnboarding } from '@/store/onboarding'
+import { consumePendingCredentialWarning, requestDesktopOnboarding } from '@/store/onboarding'
 import {
   $sessions,
   resolveComposerSessionKey,
@@ -178,6 +178,23 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
       if (isVoicePlaybackActive()) {
         markVoicePlaybackInterrupted()
         stopVoicePlayback()
+      }
+
+      // The gateway already told us this profile has no usable provider (a
+      // credential warning arrived with the session's runtime info, deferred
+      // instead of popping onboarding on the mere profile switch). The user
+      // is now actually trying to chat — THIS is the moment to open
+      // onboarding, before a send the gateway said will fail. The draft
+      // stays in the composer; once a provider is configured they just hit
+      // Enter again.
+      if (!options?.fromQueue) {
+        const deferredCredentialWarning = consumePendingCredentialWarning()
+
+        if (deferredCredentialWarning) {
+          requestDesktopOnboarding(deferredCredentialWarning)
+
+          return false
+        }
       }
 
       // Barged mid-speech (here or via the voice loop's VAD)? Flag the submit

--- a/apps/desktop/src/app/session/hooks/use-session-actions/utils.test.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/utils.test.ts
@@ -3,7 +3,7 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import { textWithoutReferenceLines, WIRE_REFERENCE_KINDS } from '@/components/assistant-ui/reference-kinds'
 import { type ChatMessage, type ChatMessagePart, chatMessageText } from '@/lib/chat-messages'
 import { $approvalModes, approvalModeForProfile } from '@/store/approval-mode'
-import { $desktopOnboarding } from '@/store/onboarding'
+import { $desktopOnboarding, consumePendingCredentialWarning } from '@/store/onboarding'
 import { $activeGatewayProfile } from '@/store/profile'
 import {
   $currentBranch,
@@ -73,25 +73,41 @@ const initialOnboardingState = $desktopOnboarding.get()
 
 describe('applyRuntimeInfo credential warnings', () => {
   beforeEach(() => {
+    consumePendingCredentialWarning()
     $desktopOnboarding.set({ ...initialOnboardingState, reason: null, requested: false })
   })
 
   afterEach(() => {
+    consumePendingCredentialWarning()
     $desktopOnboarding.set(initialOnboardingState)
   })
 
-  it('requests setup for the exact empty-key warning returned by the server', () => {
+  it('defers the empty-key warning to submit time instead of popping onboarding on switch', () => {
     const warning = "No API key configured for provider 'openrouter'. First message will fail."
 
     applyRuntimeInfo({ credential_warning: warning })
 
-    expect($desktopOnboarding.get()).toMatchObject({ reason: warning, requested: true })
+    // Merely switching to (or activating a session on) the unconfigured
+    // profile must NOT open the blocking overlay…
+    expect($desktopOnboarding.get()).toMatchObject({ reason: null, requested: false })
+    // …but the warning is staged for the submit path to consume.
+    expect(consumePendingCredentialWarning()).toBe(warning)
+    // Consuming clears it — the next submit doesn't double-fire.
+    expect(consumePendingCredentialWarning()).toBeNull()
+  })
+
+  it('a warning-free session event clears the stash (profile healed or switched away)', () => {
+    applyRuntimeInfo({ credential_warning: "No API key configured for provider 'openrouter'. First message will fail." })
+    applyRuntimeInfo({ model: 'gpt-5' })
+
+    expect(consumePendingCredentialWarning()).toBeNull()
   })
 
   it('ignores an auxiliary-provider warning', () => {
     applyRuntimeInfo({ credential_warning: 'OPENROUTER_API_KEY not set' })
 
     expect($desktopOnboarding.get()).toMatchObject({ reason: null, requested: false })
+    expect(consumePendingCredentialWarning()).toBeNull()
   })
 })
 

--- a/apps/desktop/src/store/onboarding.ts
+++ b/apps/desktop/src/store/onboarding.ts
@@ -390,14 +390,38 @@ export function requestDesktopOnboarding(reason = DEFAULT_ONBOARDING_REASON) {
   patch({ reason: reason.trim() || DEFAULT_ONBOARDING_REASON, requested: true })
 }
 
+/** Credential warning delivered passively (session create/activate/resume
+ *  runtime info, stream heartbeats) — e.g. right after switching to a
+ *  profile that has no provider configured. Popping the blocking onboarding
+ *  overlay here punishes merely LOOKING at an unconfigured profile, so the
+ *  warning is deferred instead: stashed until the user actually tries to
+ *  chat, where the submit path consumes it and opens onboarding before the
+ *  doomed send. The latest warning wins; a session event without a warning
+ *  clears the stash (the profile became configured, or the user switched
+ *  back to a healthy one). */
+let pendingCredentialWarning: null | string = null
+
 export function requestDesktopOnboardingForCredentialWarning(reason: null | string | undefined) {
   const warning = reason?.trim()
 
   if (!warning || !isProviderSetupErrorMessage(warning)) {
+    pendingCredentialWarning = null
+
     return
   }
 
-  requestDesktopOnboarding(warning)
+  pendingCredentialWarning = warning
+}
+
+/** Submit-time gate: returns the deferred credential warning (and clears it)
+ *  so the caller can open onboarding instead of sending a prompt that the
+ *  gateway already said will fail. Null when the active profile is healthy. */
+export function consumePendingCredentialWarning(): null | string {
+  const warning = pendingCredentialWarning
+
+  pendingCredentialWarning = null
+
+  return warning
 }
 
 // Open the onboarding provider selector on demand from an already-configured


### PR DESCRIPTION
## Summary
Switching to a profile/bot with no provider configured no longer pops the blocking onboarding overlay ("connect Nous Portal / providers", "gateway isn't ready") — it now opens only when the user actually tries to chat with that profile.

Root cause: `applyRuntimeInfo` and the stream heartbeat path fed every passive `credential_warning` straight into `requestDesktopOnboarding`, so merely looking at an unconfigured profile forced the overlay.

## Changes
- `store/onboarding.ts`: passive credential warnings are stashed (`pendingCredentialWarning`) instead of opening the overlay; new `consumePendingCredentialWarning()` for the submit path. A warning-free session event clears the stash (profile healed / switched away).
- `use-prompt-actions/submit.ts`: user-initiated submits consume the stash and open onboarding before the doomed send, keeping the draft in the composer. Queue drains skip the gate.
- `use-session-actions/utils.test.ts`: tests updated to pin the deferred behavior (no popup on switch, stash consumed once, cleared by healthy events, auxiliary warnings still ignored).

Turn-error paths (an actual failed send) still open onboarding immediately — unchanged.

## Validation
| | Before | After |
|---|---|---|
| Switch to unconfigured profile | blocking onboarding overlay | nothing — browse freely |
| Send a message on it | send fails, then overlay | overlay opens pre-send, draft kept |
| Targeted vitest | — | utils 107/107, onboarding + prompt-actions 221/221 |
| `npm run check:lint` | — | 0 errors |

## Infographic

![Defer provider-setup popup](https://files.catbox.moe/8bn2y3.png)
