### PR TITLE
fix(cli): render the deferred update notice through prompt_toolkit

### DIFF
--- a/hermes_cli/banner.py
+++ b/hermes_cli/banner.py
@@ -710,6 +710,48 @@ def _format_update_notice(behind: int) -> str:
     return line
 
 
+def _prompt_toolkit_app_running() -> bool:
+    """True when an interactive prompt_toolkit ``Application`` owns the terminal."""
+    try:
+        from prompt_toolkit.application import get_app_or_none
+        app = get_app_or_none()
+    except Exception:
+        return False
+    return app is not None and getattr(app, "_is_running", False)
+
+
+def _emit_update_notice(console: "Console", markup: str) -> None:
+    r"""Print the update notice so colors survive prompt_toolkit's stdout proxy.
+
+    While the interactive chat loop runs, stdout is prompt_toolkit's
+    ``StdoutProxy``, whose ``Vt100_Output.write()`` replaces every ``\x1b``
+    with ``?`` "for safely writing text". A plain ``console.print()`` from the
+    deferred-notice thread therefore renders as literal ``?[1;33m…`` instead of
+    a colored line. Capture Rich's render and hand it to ``cprint``, which
+    routes through prompt_toolkit's own ANSI parser, when an application is
+    running; otherwise print straight to the console as before.
+    """
+    if not _prompt_toolkit_app_running():
+        console.print(markup)
+        return
+    try:
+        import io
+        from rich.console import Console as _RichConsole
+
+        buf = io.StringIO()
+        _RichConsole(
+            file=buf,
+            force_terminal=True,
+            color_system="truecolor",
+            highlight=False,
+            width=shutil.get_terminal_size((80, 24)).columns,
+        ).print(markup)
+        for line in buf.getvalue().rstrip("\n").split("\n"):
+            cprint(line)
+    except Exception:
+        console.print(markup)
+
+
 _deferred_update_notice_started = False
 
 
@@ -731,7 +773,7 @@ def _defer_update_notice(console: "Console", max_wait: float = 30.0) -> None:
             behind = _update_result
             if behind is None or behind == 0:
                 return
-            console.print(_format_update_notice(behind))
+            _emit_update_notice(console, _format_update_notice(behind))
         except Exception:
             pass  # never break the session over an update notice
 

--- a/tests/hermes_cli/test_banner.py
+++ b/tests/hermes_cli/test_banner.py
@@ -83,3 +83,117 @@ def test_build_welcome_banner_non_moa_unchanged(tmp_path, monkeypatch):
     out = console.export_text()
     assert "claude-opus-4.8" in out
     assert "MoA:" not in out
+
+
+# ---------------------------------------------------------------------------
+# Deferred update notice (#87444)
+# ---------------------------------------------------------------------------
+
+_NOTICE_MARKUP = (
+    "[bold yellow]⚠ 35 commits behind[/]"
+    "[dim yellow] — run [bold]hermes update[/bold] to update[/]"
+)
+
+
+def test_emit_update_notice_uses_plain_console_when_no_app_is_running():
+    """Outside the interactive loop the notice goes straight to Rich as before."""
+    from types import SimpleNamespace
+
+    printed = []
+    console = SimpleNamespace(print=lambda markup: printed.append(markup))
+
+    with patch.object(banner, "_prompt_toolkit_app_running", return_value=False):
+        banner._emit_update_notice(console, _NOTICE_MARKUP)
+
+    assert printed == [_NOTICE_MARKUP]
+
+
+def test_emit_update_notice_routes_through_cprint_while_app_is_running():
+    """With a live prompt_toolkit app the notice is pre-rendered and cprint-ed.
+
+    Regression for #87444: a bare ``console.print()`` here reaches
+    prompt_toolkit's ``StdoutProxy``, whose ``Vt100_Output.write()`` rewrites
+    every ESC to ``?``, so the warning displayed as literal ``?[1;33m…`` text.
+    """
+    from types import SimpleNamespace
+
+    emitted = []
+    console = SimpleNamespace(
+        print=lambda markup: emitted.append(("console", markup))
+    )
+
+    with (
+        patch.object(banner, "_prompt_toolkit_app_running", return_value=True),
+        patch.object(banner, "cprint", lambda line: emitted.append(("cprint", line))),
+    ):
+        banner._emit_update_notice(console, _NOTICE_MARKUP)
+
+    assert emitted, "notice was not emitted at all"
+    assert all(channel == "cprint" for channel, _ in emitted), (
+        f"expected the prompt_toolkit-safe path only, got {emitted}"
+    )
+
+    rendered = "\n".join(line for _, line in emitted)
+    assert "\x1b[" in rendered, "no real ANSI escapes — colors would be lost"
+    assert "[bold yellow]" not in rendered, "Rich markup leaked out unrendered"
+    assert "35 commits behind" in rendered
+
+
+def test_emit_update_notice_falls_back_to_console_when_cprint_fails():
+    """A broken prompt_toolkit output must not swallow the notice entirely."""
+    from types import SimpleNamespace
+
+    emitted = []
+    console = SimpleNamespace(
+        print=lambda markup: emitted.append(("console", markup))
+    )
+
+    def _boom(_line):
+        raise RuntimeError("no console screen buffer")
+
+    with (
+        patch.object(banner, "_prompt_toolkit_app_running", return_value=True),
+        patch.object(banner, "cprint", _boom),
+    ):
+        banner._emit_update_notice(console, _NOTICE_MARKUP)
+
+    assert emitted == [("console", _NOTICE_MARKUP)]
+
+
+def test_defer_update_notice_emits_through_the_ansi_safe_path():
+    """The deferred thread must not bypass ``_emit_update_notice``."""
+    import threading
+    import time
+    from types import SimpleNamespace
+
+    calls = []
+    prev_started = banner._deferred_update_notice_started
+    prev_result = banner._update_result
+    prev_done = banner._update_check_done
+
+    banner._deferred_update_notice_started = False
+    banner._update_result = 35
+    banner._update_check_done = threading.Event()
+    banner._update_check_done.set()
+
+    try:
+        with (
+            patch.object(
+                banner, "_format_update_notice", lambda behind: f"MARKUP-{behind}"
+            ),
+            patch.object(
+                banner, "_emit_update_notice", lambda _c, markup: calls.append(markup)
+            ),
+        ):
+            banner._defer_update_notice(
+                SimpleNamespace(print=lambda *_a, **_k: None), max_wait=5.0
+            )
+            deadline = time.monotonic() + 5.0
+            while not calls and time.monotonic() < deadline:
+                time.sleep(0.01)
+    finally:
+        banner._deferred_update_notice_started = prev_started
+        banner._update_result = prev_result
+        banner._update_check_done = prev_done
+
+    assert calls == ["MARKUP-35"]


### PR DESCRIPTION
## What does this PR do?

The "N commits behind" line that appears a moment after startup renders as raw escape codes instead of colour:

```
?[1;33m⚠ 35 commits behind?[0m?[2;33m — run ?[0m?[1;2;33mhermes update?[0m?[2;33m to update?[0m
```

When the update check beats the 50ms banner window the count gets folded into the banner itself and looks fine, so this only shows up when the check is slow — roughly once per cache expiry, which is why it feels random rather than broken.

The deferred path prints from a daemon thread with a plain Rich `console.print()`. By the time it fires, the interactive prompt_toolkit `Application` has taken stdout through `patch_stdout`, and everything written there goes via `Vt100_Output.write()`:

```python
# prompt_toolkit/output/vt100.py:523
self._buffer.append(data.replace("\x1b", "?"))
```

which rewrites Rich's escapes to `?` before they reach the terminal. The comment on that method is "Removes vt100 escape codes. -- used for safely writing text", so it's doing what it's meant to; we're just writing to the wrong place.

The codebase already solves this three times over — `_cprint()` (cli.py:3303), `_cli_visible_print()` (cli.py:3443) and `ChatConsole` (cli.py:4285) all render to a string and hand that to prompt_toolkit's ANSI parser instead of writing escapes at stdout. The deferred notice just never got wired to any of them. This does the same thing using banner.py's own `cprint()`.

## Related Issue

Fixes #87444

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

`hermes_cli/banner.py`

- `_prompt_toolkit_app_running()` — the same `get_app_or_none()` + `_is_running` probe `_cli_visible_print()` uses.
- `_emit_update_notice(console, markup)` — renders the markup and pushes it through `cprint()` when an Application is live, otherwise plain `console.print()`. If the prompt_toolkit write raises it falls back to the console, so a broken output can't swallow the notice outright.
- `_defer_update_notice._wait_and_print()` calls that instead of `console.print()`.

`tests/hermes_cli/test_banner.py` — four tests, described below.

Nothing changes outside the interactive loop. With no Application running it's the same `console.print(markup)` call it always was.

## How to Test

You don't need a slow network to see it — this is what StdoutProxy does to the rendered line:

```python
import io
from rich.console import Console
import hermes_cli.banner as banner

buf = io.StringIO()
Console(file=buf, force_terminal=True, color_system="truecolor",
        highlight=False, width=100).print(banner._format_update_notice(35))
print(repr(buf.getvalue().rstrip("\n").replace("\x1b", "?")))
```

That prints the string from the issue. After this change `cprint()` receives `\x1b[1;33m⚠ 35 commits behind\x1b[0m…` with the escapes intact and prompt_toolkit renders it as colour.

For the real path: delete `~/.hermes/.update_check`, be a few commits behind `origin/main`, and start `hermes` somewhere the check takes longer than 50ms.

```
pytest tests/hermes_cli/test_banner.py -q
7 passed
```

The four new tests cover the plain console path, the prompt_toolkit path (asserts a real `\x1b[` reaches `cprint` and that no Rich markup leaks through unrendered), the fallback when `cprint` throws, and `_defer_update_notice` itself so it can't quietly regress to a bare `console.print()`. All four fail if you revert banner.py and keep the tests.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate — nothing on the deferred notice or on #87444
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — ran `tests/hermes_cli/test_banner.py` (7 passed) and `ruff check` on both changed files. Couldn't run the whole suite locally: my env is missing `httpx`/`starlette`, which a big chunk of collection needs. Nothing in this diff touches either.
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (arm64), Python 3.12

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A, both new helpers carry docstrings
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact — `cprint()` already degrades to `print()` on Windows when prompt_toolkit can't get a console (`NoConsoleScreenBufferError`), and the new fallback sits behind that
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A
