### PR TITLE
fix: retry title generation without response_format on gateway 400

### DIFF
--- a/agent/title_generator.py
+++ b/agent/title_generator.py
@@ -399,7 +399,7 @@ def generate_title(
         {"role": "user", "content": user_snippet},
     ]
 
-    try:
+    def _request_title(extra_body: Optional[dict]) -> str:
         response = call_llm(
             task="title_generation",
             messages=messages,
@@ -409,9 +409,27 @@ def generate_title(
             temperature=0.3,
             timeout=timeout,
             main_runtime=main_runtime,
-            extra_body={"response_format": _TITLE_RESPONSE_FORMAT},
+            extra_body=extra_body,
         )
-        content = response.choices[0].message.content or ""
+        return response.choices[0].message.content or ""
+
+    try:
+        try:
+            content = _request_title({"response_format": _TITLE_RESPONSE_FORMAT})
+        except Exception as e:
+            # Some gateways (e.g. OpenCode Zen "Console Go") reject the strict
+            # json_schema response_format outright with HTTP 400 instead of
+            # ignoring it. The prompt already demands a {"title": ...} object
+            # and _extract_title_text falls back through a loose JSON scan, so
+            # retry once without the constraint rather than dropping the title.
+            err = str(e)
+            if "response_format" in err or "invalid_request_error" in err:
+                logger.debug(
+                    "Title generation retrying without response_format after: %s", e
+                )
+                content = _request_title({})
+            else:
+                raise
         title = _clean_title(_extract_title_text(content))
         # Answer-shaped output guard: titling is a 3-7 word task, so a title
         # with many words is a model that ignored the task and answered

--- a/agent/title_generator.py
+++ b/agent/title_generator.py
@@ -419,13 +419,22 @@ def generate_title(
         except Exception as e:
             # Some gateways (e.g. OpenCode Zen "Console Go") reject the strict
             # json_schema response_format outright with HTTP 400 instead of
-            # ignoring it. The prompt already demands a {"title": ...} object
-            # and _extract_title_text falls back through a loose JSON scan, so
-            # retry once without the constraint rather than dropping the title.
+            # ignoring it. Retry once without the constraint: the prompt
+            # already demands a {"title": ...} object and _extract_title_text
+            # falls back through a loose JSON scan, so the retry still
+            # produces a title. Match on the 400 + invalid_request_error
+            # signal so an unrelated error that merely mentions
+            # "response_format" (e.g. an unknown-parameter typo) re-raises
+            # instead of being papered over.
             err = str(e)
-            if "response_format" in err or "invalid_request_error" in err:
-                logger.debug(
-                    "Title generation retrying without response_format after: %s", e
+            if (
+                "response_format" in err
+                and ("invalid_request_error" in err or "400" in err)
+            ):
+                logger.warning(
+                    "Title generation: provider rejected response_format "
+                    "(HTTP 400); retrying without structured output: %s",
+                    e,
                 )
                 content = _request_title({})
             else:

--- a/tests/agent/test_title_generator.py
+++ b/tests/agent/test_title_generator.py
@@ -171,6 +171,44 @@ class TestGenerateTitle:
         assert result == "Fix auth"
 
 
+    def test_prose_fallback_recovers_title_when_retry_returns_no_json(self):
+        """A provider that 400s on json_schema may also return plain prose
+        (no braces) on the retry — the loose-parse fallback must still title.
+        """
+
+        def _first_rejects_then_prose(*_args, **_kwargs):
+            if "response_format" in (_kwargs.get("extra_body") or {}):
+                raise RuntimeError(
+                    "HTTP 400: invalid_request_error: response_format type "
+                    "is unavailable now"
+                )
+            return MagicMock(choices=[MagicMock(message=MagicMock(content="Fix auth flow"))])
+
+        with patch("agent.title_generator.call_llm", side_effect=_first_rejects_then_prose):
+            result = generate_title("the auth is broken")
+
+        assert result == "Fix auth flow"
+
+
+    def test_non_response_format_error_is_not_retried(self):
+        """Errors that merely mention response_format (e.g. an unknown-parameter
+        typo, no 400/invalid_request_error signal) must propagate untouched.
+        """
+
+        def _unrelated_error(*_args, **_kwargs):
+            raise RuntimeError("provider returned unknown parameter response_format_extra")
+
+        captured = []
+        with patch("agent.title_generator.call_llm", side_effect=_unrelated_error):
+            result = generate_title(
+                "the auth is broken", failure_callback=lambda t, e: captured.append(e)
+            )
+
+        assert result is None
+        assert len(captured) == 1
+        assert "response_format_extra" in str(captured[0])
+
+
 
 
 

--- a/tests/agent/test_title_generator.py
+++ b/tests/agent/test_title_generator.py
@@ -146,6 +146,31 @@ class TestGenerateTitle:
         assert captured[0][1] is exc
 
 
+    def test_retries_without_response_format_when_gateway_rejects_json_schema(self):
+        """Gateways that 400 on json_schema must get one retry without it.
+
+        OpenCode Zen ("Console Go") rejects the strict json_schema
+        response_format outright; the prompt still demands a {"title": ...}
+        object and the loose parser recovers it.
+        """
+
+        def _first_rejects_then_plain(*_args, **_kwargs):
+            if "response_format" in (_kwargs.get("extra_body") or {}):
+                raise RuntimeError(
+                    "HTTP 400: Error from provider (Console Go): Upstream request "
+                    "failed: [invalid_request_error] This response_format type is "
+                    "unavailable now"
+                )
+            return MagicMock(
+                choices=[MagicMock(message=MagicMock(content='{"title": "Fix auth"}'))]
+            )
+
+        with patch("agent.title_generator.call_llm", side_effect=_first_rejects_then_plain):
+            result = generate_title("the auth is broken")
+
+        assert result == "Fix auth"
+
+
 
 
 


### PR DESCRIPTION
## Problem

Session auto-titling fails with:

```
Auxiliary title generation failed: HTTP 400: Error from provider (Console Go):
Upstream request failed: [invalid_request_error] This response_format type is unavailable now
```

`generate_title()` sends a strict `json_schema` `response_format` on every request. Some gateways — e.g. OpenCode Zen ("Console Go") — reject that payload outright with HTTP 400 instead of ignoring it. The parsing fallbacks in `_extract_title_text` (loose JSON scan / prose) never get a chance because the API call itself fails, so every new session ends up untitled and the user sees a warning banner.

## Fix

Retry once without `response_format` when the error message mentions `response_format` or is an `invalid_request_error`. The title prompt already demands a `{"title": ...}` object, and `_extract_title_text` falls back through a loose JSON scan, so the retry still yields a proper title — verified end-to-end against the OpenCode Zen gateway (first call 400, retry 200, title produced).

Non-response_format errors still propagate to the existing failure callback unchanged.

## Tests

Added `test_retries_without_response_format_when_gateway_rejects_json_schema` — first call rejects with the exact "Console Go" error, retry succeeds, title is parsed. Full `tests/agent/test_title_generator.py` suite passes (34 tests).