### PR TITLE
fix(desktop): stop reporting 4xx gateway rejections as unreachable

### DIFF
--- a/apps/desktop/electron/connection-config.test.ts
+++ b/apps/desktop/electron/connection-config.test.ts
@@ -24,9 +24,11 @@ import {
   cookiesHavePrivyAccessToken,
   cookiesHavePrivySession,
   cookiesHaveSession,
+  gatewayErrorDetail,
   gatewayTicketFailure,
   gatewayWsUrlIpcResult,
   isGatewayAuthRejection,
+  isGatewayTerminalRejection,
   localProfileEntry,
   modeIsRemoteLike,
   normalizeRemoteBaseUrl,
@@ -699,6 +701,97 @@ test('gateway ticket failures classify only explicit auth rejection statuses as 
   const serverFailure = gatewayTicketFailure(new Error('network timeout'), 'sign in', 'retry connection') as any
   assert.equal(serverFailure.message, 'retry connection')
   assert.equal(serverFailure.needsOauthLogin, undefined)
+})
+
+test('non-auth 4xx is a terminal rejection, not a transport blip', () => {
+  // 400/404/422 are deterministic: the same request fails the same way every
+  // retry, so they must not be lumped in with 5xx/network errors.
+  assert.equal(isGatewayTerminalRejection({ statusCode: 400 }), true)
+  assert.equal(isGatewayTerminalRejection({ statusCode: 404 }), true)
+  assert.equal(isGatewayTerminalRejection({ statusCode: 422 }), true)
+
+  // 401/403 stay on the existing "sign in again" path.
+  assert.equal(isGatewayTerminalRejection({ statusCode: 401 }), false)
+  assert.equal(isGatewayTerminalRejection({ statusCode: 403 }), false)
+  assert.equal(isGatewayTerminalRejection({ needsOauthLogin: true }), false)
+
+  // Genuinely retryable failures are untouched.
+  assert.equal(isGatewayTerminalRejection({ statusCode: 500 }), false)
+  assert.equal(isGatewayTerminalRejection({ statusCode: 503 }), false)
+  assert.equal(isGatewayTerminalRejection(new Error('network timeout')), false)
+})
+
+test('gatewayErrorDetail unwraps the gateway explanation from a fetch error', () => {
+  // The shape fetchJson rejects with: `${statusCode}: ${body}`.
+  assert.equal(
+    gatewayErrorDetail(new Error('404: {"detail":"Unknown provider: \'\'"}')),
+    "Unknown provider: ''"
+  )
+  assert.equal(gatewayErrorDetail(new Error('400: {"error":"bad request"}')), 'bad request')
+
+  // Non-JSON bodies fall back to the raw text.
+  assert.equal(gatewayErrorDetail(new Error('404: Not Found')), 'Not Found')
+
+  // Nothing useful to show.
+  assert.equal(gatewayErrorDetail(new Error('404: ')), '')
+  assert.equal(gatewayErrorDetail(undefined), '')
+
+  // Runaway HTML error pages get truncated rather than dumped into a toast.
+  const long = gatewayErrorDetail(new Error(`500: ${'x'.repeat(400)}`))
+  assert.equal(long.length, 201)
+  assert.ok(long.endsWith('…'))
+})
+
+test('a terminal gateway rejection surfaces the real reason instead of "could not reach"', () => {
+  // Regression for #87232: a 404 from /auth/native/authorize was reported to
+  // the user as a reachability failure ("Try reconnecting") and retried
+  // forever, hiding the actual cause.
+  const rejection = Object.assign(new Error('404: {"detail":"Unknown provider: \'\'"}'), {
+    statusCode: 404
+  })
+
+  const failure = gatewayTicketFailure(
+    rejection,
+    'Your remote gateway session has expired. Sign in again.',
+    'Could not reach the remote Hermes gateway. Try reconnecting.'
+  ) as any
+
+  assert.ok(
+    failure.message.includes("Unknown provider: ''"),
+    `expected the gateway's own detail in the message, got: ${failure.message}`
+  )
+  assert.ok(failure.message.includes('404'), 'expected the status code in the message')
+  assert.ok(
+    !failure.message.includes('Could not reach'),
+    'a 404 is not a reachability failure and must not be reported as one'
+  )
+  assert.equal(failure.terminal, true)
+  assert.equal(failure.statusCode, 404)
+  assert.equal(failure.needsOauthLogin, undefined)
+  assert.equal(failure.cause, rejection)
+
+  // The wrap has to stay classifiable — gatewayWsUrlIpcResult re-inspects it.
+  assert.equal(isGatewayTerminalRejection(failure), true)
+})
+
+test('gateway WS URL IPC result flags terminal rejections separately from reauth', async () => {
+  const terminal = Object.assign(new Error('400: {"detail":"code_challenge required"}'), {
+    statusCode: 400
+  })
+
+  assert.deepEqual(await gatewayWsUrlIpcResult(async () => Promise.reject(terminal)), {
+    error: '400: {"detail":"code_challenge required"}',
+    ok: false,
+    terminal: true
+  })
+
+  // 5xx keeps the plain retryable shape — no terminal flag.
+  const transient = Object.assign(new Error('503: upstream unavailable'), { statusCode: 503 })
+
+  assert.deepEqual(await gatewayWsUrlIpcResult(async () => Promise.reject(transient)), {
+    error: '503: upstream unavailable',
+    ok: false
+  })
 })
 
 test('gateway WS URL IPC result serializes success and the auth-vs-transport matrix', async () => {

--- a/apps/desktop/electron/connection-config.ts
+++ b/apps/desktop/electron/connection-config.ts
@@ -126,13 +126,83 @@ function isGatewayAuthRejection(error) {
   return statusCode === 401 || statusCode === 403
 }
 
-function gatewayTicketFailure(error, authMessage, transportMessage) {
-  const needsOauthLogin = isGatewayAuthRejection(error)
-  const err = new Error(needsOauthLogin ? authMessage : transportMessage)
-
-  if (needsOauthLogin) {
-    ;(err as any).needsOauthLogin = true
+/**
+ * True when the gateway answered with a 4xx that retrying cannot fix — 400,
+ * 404, 422 and friends, but NOT the 401/403 "sign in again" pair.
+ *
+ * These are configuration faults (unknown provider, bad request shape): the
+ * identical request fails identically on every retry. Treating them as
+ * transport errors is what turns a one-line server-side misconfiguration into
+ * an unattributable "could not reach the gateway" reconnect loop.
+ */
+function isGatewayTerminalRejection(error) {
+  if (isGatewayAuthRejection(error)) {
+    return false
   }
+
+  const statusCode = Number(error && typeof error === 'object' ? (error as any).statusCode : NaN)
+
+  return Number.isFinite(statusCode) && statusCode >= 400 && statusCode < 500
+}
+
+/**
+ * Pull the gateway's own explanation out of a `"<status>: <body>"` fetch error.
+ *
+ * `fetchJson` rejects with that shape (main.ts), and the body is usually
+ * FastAPI's `{"detail": "..."}`. Surfacing the detail is the whole point: the
+ * user needs to see "Unknown provider: ''", not a generic failure.
+ */
+function gatewayErrorDetail(error) {
+  const raw = error instanceof Error ? error.message : String(error ?? '')
+  const body = raw.replace(/^\s*\d{3}\s*:\s*/, '').trim()
+
+  if (!body) {
+    return ''
+  }
+
+  try {
+    const parsed = JSON.parse(body)
+    const detail = parsed?.detail ?? parsed?.error ?? parsed?.message
+
+    if (typeof detail === 'string' && detail.trim()) {
+      return detail.trim()
+    }
+  } catch {
+    // Not JSON — the raw body is the best explanation we have.
+  }
+
+  return body.length > 200 ? `${body.slice(0, 200)}…` : body
+}
+
+function gatewayTicketFailure(error, authMessage, transportMessage) {
+  if (isGatewayAuthRejection(error)) {
+    const err = new Error(authMessage) as any
+
+    err.needsOauthLogin = true
+    err.cause = error
+
+    return err
+  }
+
+  if (isGatewayTerminalRejection(error)) {
+    const statusCode = Number((error as any).statusCode)
+    const detail = gatewayErrorDetail(error)
+    const err = new Error(
+      detail
+        ? `The remote Hermes gateway rejected the request (HTTP ${statusCode}): ${detail}`
+        : `The remote Hermes gateway rejected the request (HTTP ${statusCode}).`
+    ) as any
+
+    // Carried so the caller can stop retrying and so this stays classifiable
+    // after the wrap (gatewayWsUrlIpcResult re-inspects the thrown error).
+    err.terminal = true
+    err.statusCode = statusCode
+    err.cause = error
+
+    return err
+  }
+
+  const err = new Error(transportMessage)
 
   err.cause = error
 
@@ -147,6 +217,7 @@ async function gatewayWsUrlIpcResult(resolveWsUrl: () => Promise<string>) {
     return {
       error: error instanceof Error ? error.message : String(error),
       ...(isGatewayAuthRejection(error) ? { needsOauthLogin: true as const } : {}),
+      ...(isGatewayTerminalRejection(error) ? { terminal: true as const } : {}),
       ok: false as const
     }
   }
@@ -597,10 +668,12 @@ export {
   cookiesHavePrivyAccessToken,
   cookiesHavePrivySession,
   cookiesHaveSession,
+  gatewayErrorDetail,
   gatewayTicketFailure,
   gatewayWsUrlIpcResult,
   hostLabelFromBaseUrl,
   isGatewayAuthRejection,
+  isGatewayTerminalRejection,
   localProfileEntry,
   modeIsRemoteLike,
   normalizeRemoteBaseUrl,


### PR DESCRIPTION
## What does this PR do?

When the desktop mints a WS ticket and the gateway answers non-2xx, `gatewayTicketFailure()` sorts the result into one of two buckets:

```ts
// connection-config.ts
const needsOauthLogin = isGatewayAuthRejection(error)   // 401/403 only
const err = new Error(needsOauthLogin ? authMessage : transportMessage)
```

Anything that isn't 401/403 becomes a transport error — including 400, 404 and 422. Those aren't reachability problems. They're deterministic rejections: the same request fails the same way on every retry, so the app tells you to "try reconnecting" and then loops on something reconnecting can never fix.

This is the part of #87232 that turned a one-line server misconfiguration into an undiagnosable boot failure. The gateway was returning

```json
404 {"detail":"Unknown provider: ''"}
```

and the app reported

```
Desktop boot failed: Could not reach the remote Hermes gateway while refreshing
its WebSocket ticket. Try reconnecting.
```

The reporter only found the real cause by pulling the authorize URL out of the app logs by hand. (The `Unknown provider` bug itself is already fixed on main by #78906 — this is about the reporting, which is still wrong for any 4xx.)

So: split non-auth 4xx out as its own class, put the gateway's own explanation in the message, and mark it so a caller can stop retrying. 401/403 keep the sign-in path; 5xx and genuine transport failures keep the retry path, unchanged.

## Related Issue

Refs #87232

Deliberately `Refs` rather than `Fixes` — that issue's headline bug (missing `provider` param) was already closed by #78906. This addresses the second problem in the report: a 4xx being presented as a network failure and retried.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

All in `apps/desktop/electron/connection-config.ts`, which has no imports and stays electron-free, so it's all unit-testable:

- `isGatewayTerminalRejection(error)` — 4xx excluding 401/403. Deliberately narrow: 5xx stays retryable because a gateway restart genuinely is worth another attempt.
- `gatewayErrorDetail(error)` — unwraps the `"<status>: <body>"` shape `fetchJson` rejects with and pulls out FastAPI's `{"detail": ...}` (falling back to `error`/`message`, then the raw body). Truncates at 200 chars so an HTML error page doesn't end up in a toast.
- `gatewayTicketFailure()` grows a third branch for terminal rejections: message becomes `The remote Hermes gateway rejected the request (HTTP 404): Unknown provider: ''`, with `err.terminal = true` and `err.statusCode` carried through.
- `gatewayWsUrlIpcResult()` passes `terminal: true` across IPC next to the existing `needsOauthLogin`.

The wrapped error stays classifiable — `gatewayWsUrlIpcResult` re-inspects whatever was thrown, so `statusCode` is copied onto the wrapper rather than left only on `cause`. There's a test pinning that.

## How to Test

```
npx vitest run electron/connection-config.test.ts
83 passed
```

Four new tests:

- 400/404/422 classify as terminal; 401/403 and `needsOauthLogin` don't; 500/503/network don't.
- `gatewayErrorDetail` on a FastAPI `detail` body, an `error` body, a non-JSON body, an empty body, and a 400-char body (truncation).
- The #87232 case end to end: a 404 carrying `Unknown provider: ''` produces a message containing the detail and the status, *not* containing "Could not reach", with `terminal: true` and `needsOauthLogin` unset.
- The IPC result shape for both a terminal 400 and a transient 503.

Reverting `connection-config.ts` and keeping the tests fails all four, with the middle one printing the old behaviour:

```
AssertionError: expected the gateway's own detail in the message,
got: Could not reach the remote Hermes gateway. Try reconnecting.
```

## Scope note

I've made the flag available rather than wiring the boot-retry loop to it. Whether a terminal rejection should stop the loop outright, surface a one-shot error, or keep retrying at a longer interval is a product call I didn't want to make unilaterally — happy to follow up once someone says which. The user-visible half (an honest message instead of a misleading one) doesn't depend on that decision.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate — nothing open on `gatewayTicketFailure`, the ticket-refresh message, or #87232
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — N/A, this is TypeScript. Ran the vitest file above (83 passed). I couldn't run the full `test:desktop:platforms` project locally without installing the desktop app's full dependency tree; the changed module has no imports, so the blast radius is what these tests cover.
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A, the new helpers carry doc comments
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact — pure classification logic, no platform surface
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A
