### PR TITLE
feat: make minimum context length configurable

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -2666,10 +2666,11 @@ def init_agent(
             f"Model {agent.model} has a context window of {_ctx:,} tokens, "
             f"which is below the minimum {_minimum_context_length:,} required "
             f"by Hermes Agent.  Choose a model with at least "
-            f"{_minimum_context_length // 1000}K context.  If your server "
+            f"{_minimum_context_length:,} tokens of context.  If your server "
             f"reports a window smaller than the model's true window, set "
             f"model.context_length in config.yaml to the real value "
-            f"(this must be at least {_minimum_context_length // 1000}K)."
+            f"(this must be at least {_minimum_context_length:,}).  To run "
+            f"smaller models anyway, lower agent.minimum_context_length."
         )
 
     # Nous Hermes 3/4 are chat models, not tool-call-tuned. The interactive

--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -35,8 +35,8 @@ from agent.iteration_budget import IterationBudget
 from agent.memory_manager import StreamingContextScrubber
 from agent.session_activity import ActivityProvenance
 from agent.model_metadata import (
-    MINIMUM_CONTEXT_LENGTH,
     fetch_model_metadata,
+    get_minimum_context_length,
     is_local_endpoint,
     query_ollama_num_ctx,
 )
@@ -2651,23 +2651,25 @@ def init_agent(
     )
 
     # Reject models whose context window is below the minimum required
-    # for reliable tool-calling workflows (64K tokens).
+    # for reliable tool-calling workflows (default 64K tokens, overridable
+    # via agent.minimum_context_length in config.yaml).
     _ctx = getattr(agent.context_compressor, "context_length", 0)
+    _minimum_context_length = get_minimum_context_length()
     _allow_lmstudio_explicit_below_floor = (
         str(getattr(agent, "provider", "") or "").strip().lower() == "lmstudio"
         and isinstance(agent._config_context_length, int)
         and not isinstance(agent._config_context_length, bool)
         and agent._config_context_length > 0
     )
-    if _ctx and _ctx < MINIMUM_CONTEXT_LENGTH and not _allow_lmstudio_explicit_below_floor:
+    if _ctx and _ctx < _minimum_context_length and not _allow_lmstudio_explicit_below_floor:
         raise ValueError(
             f"Model {agent.model} has a context window of {_ctx:,} tokens, "
-            f"which is below the minimum {MINIMUM_CONTEXT_LENGTH:,} required "
+            f"which is below the minimum {_minimum_context_length:,} required "
             f"by Hermes Agent.  Choose a model with at least "
-            f"{MINIMUM_CONTEXT_LENGTH // 1000}K context.  If your server "
+            f"{_minimum_context_length // 1000}K context.  If your server "
             f"reports a window smaller than the model's true window, set "
             f"model.context_length in config.yaml to the real value "
-            f"(this must be at least {MINIMUM_CONTEXT_LENGTH // 1000}K)."
+            f"(this must be at least {_minimum_context_length // 1000}K)."
         )
 
     # Nous Hermes 3/4 are chat models, not tool-call-tuned. The interactive

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -161,7 +161,7 @@ def aux_probe_mode():
         _aux_probe_state.active = prev
 
 from agent.credential_pool import load_pool
-from agent.model_metadata import MINIMUM_CONTEXT_LENGTH, get_model_context_length
+from agent.model_metadata import get_minimum_context_length, get_model_context_length
 from hermes_cli.config import get_hermes_home
 from hermes_constants import OPENROUTER_BASE_URL
 from utils import base_url_host_matches, base_url_hostname, env_float, is_truthy_value, model_forces_max_completion_tokens, normalize_proxy_env_vars
@@ -5404,8 +5404,9 @@ def _task_minimum_context_length(task: Optional[str]) -> Optional[int]:
     """Return the minimum context length required for an auxiliary task.
 
     Only ``compression`` carries an explicit minimum today (the same
-    ``MINIMUM_CONTEXT_LENGTH`` (64K) floor that
-    ``check_compression_model_feasibility`` already enforces at startup).
+    configured ``agent.minimum_context_length`` floor that
+    ``check_compression_model_feasibility`` already enforces at startup;
+    default ``MINIMUM_CONTEXT_LENGTH`` = 64K).
     Other tasks (``vision``, ``title_generation``, ``web_extract``,
     ``skills_hub``, ``mcp``, ``session_search``) return ``None`` — they
     have no per-task context floor and the runtime chain must remain
@@ -5417,7 +5418,7 @@ def _task_minimum_context_length(task: Optional[str]) -> Optional[int]:
     if not task:
         return None
     if task == "compression":
-        return MINIMUM_CONTEXT_LENGTH
+        return get_minimum_context_length()
     return None
 
 

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -34,10 +34,10 @@ from agent.auxiliary_client import (
 from agent.context_engine import ContextEngine, sanitize_memory_context
 from agent.error_classifier import FailoverReason, classify_api_error
 from agent.model_metadata import (
-    MINIMUM_CONTEXT_LENGTH,
-    get_model_context_length,
     estimate_messages_tokens_rough,
     estimate_tokens_rough,
+    get_minimum_context_length,
+    get_model_context_length,
 )
 from agent.redact import redact_sensitive_text
 from agent.turn_context import drop_stale_api_content
@@ -2745,7 +2745,8 @@ class ContextCompressor(ContextEngine):
         """Compute the compaction trigger threshold in tokens.
 
         The base value is ``effective_input_budget * threshold_percent``, floored
-        at ``MINIMUM_CONTEXT_LENGTH`` so large-context models don't compress
+        at the configured minimum context length (``agent.minimum_context_length``,
+        default ``MINIMUM_CONTEXT_LENGTH``) so large-context models don't compress
         prematurely at 50%. BUT that floor degenerates at small windows: for a
         model whose ``context_length`` is at/below the minimum (e.g. a 64K
         local model), ``max(0.5*64000, 64000) == 64000`` makes the threshold
@@ -2770,7 +2771,7 @@ class ContextCompressor(ContextEngine):
         if effective_window <= 0:
             effective_window = context_length
         pct_value = int(effective_window * threshold_percent)
-        floored = max(pct_value, MINIMUM_CONTEXT_LENGTH)
+        floored = max(pct_value, get_minimum_context_length())
         # If flooring pushed the threshold to/over the effective window it can
         # never be reached. Trigger at 85% of the effective input budget so a
         # minimum-context model rides most of its budget before compacting

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -1632,7 +1632,7 @@ def check_compression_model_feasibility(agent: Any) -> None:
             get_text_auxiliary_client,
         )
         from agent.model_metadata import (
-            MINIMUM_CONTEXT_LENGTH,
+            get_minimum_context_length,
             get_model_context_length,
         )
 
@@ -1704,18 +1704,20 @@ def check_compression_model_feasibility(agent: Any) -> None:
         )
 
         # Hard floor: the auxiliary compression model must have at least
-        # MINIMUM_CONTEXT_LENGTH (64K) tokens of context.  The main model
+        # the configured minimum context length (agent.minimum_context_length,
+        # default MINIMUM_CONTEXT_LENGTH = 64K) of context.  The main model
         # is already required to meet this floor (checked earlier in
         # __init__), so the compression model must too — otherwise it
         # cannot summarise a full threshold-sized window of main-model
         # content.  Mirrors the main-model rejection pattern.
-        if aux_context and aux_context < MINIMUM_CONTEXT_LENGTH:
+        minimum_context_length = get_minimum_context_length()
+        if aux_context and aux_context < minimum_context_length:
             raise ValueError(
                 f"Auxiliary compression model {aux_model} has a context "
                 f"window of {aux_context:,} tokens, which is below the "
-                f"minimum {MINIMUM_CONTEXT_LENGTH:,} required by Hermes "
+                f"minimum {minimum_context_length:,} required by Hermes "
                 f"Agent.  Choose a compression model with at least "
-                f"{MINIMUM_CONTEXT_LENGTH // 1000}K context (set "
+                f"{minimum_context_length // 1000}K context (set "
                 f"auxiliary.compression.model in config.yaml), or set "
                 f"auxiliary.compression.context_length to override the "
                 f"detected value if it is wrong."
@@ -1725,8 +1727,8 @@ def check_compression_model_feasibility(agent: Any) -> None:
         if aux_context < threshold:
             # Auto-correct: lower the live session threshold so
             # compression actually works this session.  The hard floor
-            # above guarantees aux_context >= MINIMUM_CONTEXT_LENGTH,
-            # so the new threshold is always >= 64K.
+            # above guarantees aux_context >= the configured minimum,
+            # so the new threshold is always >= that floor.
             #
             # The compression summariser sends a single user-role
             # prompt (no system prompt, no tools) to the aux model, so

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -5,8 +5,9 @@ Three concerns live here:
 * :func:`check_compression_model_feasibility` — startup probe of the
   configured auxiliary compression model.  Warns when the aux context
   window can't fit the main model's compression threshold; auto-lowers
-  the session threshold when possible; hard-rejects auxes below
-  ``MINIMUM_CONTEXT_LENGTH``.
+  the session threshold when possible; hard-rejects auxes below the
+  configured floor (``agent.minimum_context_length``, default
+  ``MINIMUM_CONTEXT_LENGTH``).
 
 * :func:`replay_compression_warning` — re-emit a stored warning through
   the gateway ``status_callback`` once it's wired up (the callback is
@@ -1717,7 +1718,7 @@ def check_compression_model_feasibility(agent: Any) -> None:
                 f"window of {aux_context:,} tokens, which is below the "
                 f"minimum {minimum_context_length:,} required by Hermes "
                 f"Agent.  Choose a compression model with at least "
-                f"{minimum_context_length // 1000}K context (set "
+                f"{minimum_context_length:,} tokens of context (set "
                 f"auxiliary.compression.model in config.yaml), or set "
                 f"auxiliary.compression.context_length to override the "
                 f"detected value if it is wrong."

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -448,16 +448,22 @@ def _ollama_context_limit_error(agent: Any, request_tokens: int) -> Optional[str
         getattr(agent, "session_id", None) or "none",
     )
 
+    # Never recommend a num_ctx below the configured floor — a raised
+    # agent.minimum_context_length would otherwise be handed guidance that
+    # still trips the very check that produced this message.
+    suggested_ctx = max(65_536, minimum_context_length)
+
     return (
         f"Ollama loaded `{model}` with only {runtime_ctx:,} tokens of runtime "
         f"context, but Hermes needs at least {minimum_context_length:,} tokens "
         "for reliable tool use.\n\n"
         "Increase the Ollama context for this model and restart/reload the "
-        "model before trying again. A known-good starting point is 65,536 "
-        "tokens. In Hermes config, set `model.ollama_num_ctx: 65536` "
-        "(and `model.context_length: 65536` if you also override the displayed "
-        "model context). If you manage the model through an Ollama Modelfile, "
-        "set `PARAMETER num_ctx 65536` there instead."
+        f"model before trying again. A known-good starting point is "
+        f"{suggested_ctx:,} tokens. In Hermes config, set "
+        f"`model.ollama_num_ctx: {suggested_ctx}` (and "
+        f"`model.context_length: {suggested_ctx}` if you also override the "
+        "displayed model context). If you manage the model through an Ollama "
+        f"Modelfile, set `PARAMETER num_ctx {suggested_ctx}` there instead."
     )
 
 

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -65,11 +65,11 @@ from agent.message_sanitization import (
 # monkeypatch get_hermes_home to return a str).
 _STALE_MARKER_RE = re.compile(r"^\[[A-Za-z_][A-Za-z0-9_.-]*\]$")
 from agent.model_metadata import (
-    MINIMUM_CONTEXT_LENGTH,
     _estimate_tools_tokens_rough,
     estimate_messages_tokens_rough,
     estimate_request_tokens_rough,
     get_context_length_from_provider_error,
+    get_minimum_context_length,
     is_output_cap_error,
     parse_available_output_tokens_from_error,
     save_context_length,
@@ -424,7 +424,8 @@ def _ollama_context_limit_error(agent: Any, request_tokens: int) -> Optional[str
     runtime_ctx = getattr(agent, "_ollama_num_ctx", None)
     if not isinstance(runtime_ctx, int) or runtime_ctx <= 0:
         return None
-    if runtime_ctx >= MINIMUM_CONTEXT_LENGTH:
+    minimum_context_length = get_minimum_context_length()
+    if runtime_ctx >= minimum_context_length:
         return None
 
     model = getattr(agent, "model", "") or "the selected model"
@@ -441,7 +442,7 @@ def _ollama_context_limit_error(agent: Any, request_tokens: int) -> Optional[str
         provider,
         base_url,
         runtime_ctx,
-        MINIMUM_CONTEXT_LENGTH,
+        minimum_context_length,
         request_tokens,
         tool_count,
         getattr(agent, "session_id", None) or "none",
@@ -449,7 +450,7 @@ def _ollama_context_limit_error(agent: Any, request_tokens: int) -> Optional[str
 
     return (
         f"Ollama loaded `{model}` with only {runtime_ctx:,} tokens of runtime "
-        f"context, but Hermes needs at least {MINIMUM_CONTEXT_LENGTH:,} tokens "
+        f"context, but Hermes needs at least {minimum_context_length:,} tokens "
         "for reliable tool use.\n\n"
         "Increase the Ollama context for this model and restart/reload the "
         "model before trying again. A known-good starting point is 65,536 "

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -404,6 +404,25 @@ def _warn_context_length_fallback(model: str, base_url: str) -> None:
 # Sessions, model switches, and cron jobs should reject models below this.
 MINIMUM_CONTEXT_LENGTH = 64_000
 
+# Invalid ``agent.minimum_context_length`` values already warned about, so the
+# hot paths that consult the floor (threshold math, per-request guards) log
+# once instead of on every call.
+_MINIMUM_CONTEXT_WARNED: set = set()
+
+
+def _warn_invalid_minimum_context_length(value: Any) -> None:
+    """Warn (once per bad value) that a configured floor override was ignored."""
+    key = repr(value)
+    if key in _MINIMUM_CONTEXT_WARNED:
+        return
+    _MINIMUM_CONTEXT_WARNED.add(key)
+    logger.warning(
+        "Ignoring agent.minimum_context_length=%s in config.yaml — expected a "
+        "positive integer number of tokens (e.g. 32768). Falling back to the "
+        "built-in minimum of %s.",
+        key, f"{MINIMUM_CONTEXT_LENGTH:,}",
+    )
+
 
 def get_minimum_context_length(config: Optional[Dict[str, Any]] = None) -> int:
     """Return the configured minimum context length required by Hermes Agent.
@@ -430,15 +449,17 @@ def get_minimum_context_length(config: Optional[Dict[str, Any]] = None) -> int:
         agent_cfg = config.get("agent")
         if isinstance(agent_cfg, dict):
             value = agent_cfg.get("minimum_context_length")
-    if isinstance(value, bool):
-        value = None
-    # Accept only real integers — floats and numeric strings are treated as
-    # config garbage rather than being silently truncated (int("12.5") would
-    # raise; int(12.5) == 12 would otherwise sneak through as "valid").
-    if not isinstance(value, int):
-        value = None
-    if value and value > 0:
+    # Accept only real positive integers — bools, floats and numeric strings
+    # are treated as config garbage rather than being silently coerced
+    # (int("12.5") would raise; int(12.5) == 12 would otherwise sneak through
+    # as "valid").  A value that IS present but unusable is warned about once
+    # so the override isn't silently ignored while the user watches the floor
+    # reject their model anyway.
+    if value is None:
+        return MINIMUM_CONTEXT_LENGTH
+    if isinstance(value, int) and not isinstance(value, bool) and value > 0:
         return value
+    _warn_invalid_minimum_context_length(value)
     return MINIMUM_CONTEXT_LENGTH
 
 # Short-lived in-process cache for local-server context probes. Bounds the

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -404,6 +404,43 @@ def _warn_context_length_fallback(model: str, base_url: str) -> None:
 # Sessions, model switches, and cron jobs should reject models below this.
 MINIMUM_CONTEXT_LENGTH = 64_000
 
+
+def get_minimum_context_length(config: Optional[Dict[str, Any]] = None) -> int:
+    """Return the configured minimum context length required by Hermes Agent.
+
+    Reads ``agent.minimum_context_length`` from ``config.yaml`` and falls
+    back to :data:`MINIMUM_CONTEXT_LENGTH` (64,000) when the key is absent,
+    unset, or not a positive integer.  Lowering the value lets users run
+    local models with smaller windows (e.g. Ollama with ``num_ctx 32768``)
+    that would otherwise be rejected at startup.
+
+    When ``config`` is ``None`` the read-only config cache is consulted
+    lazily, so this helper is safe to call from hot paths and from modules
+    that must not import :mod:`hermes_cli.config` at import time.  A config
+    dict already in hand can be passed explicitly to skip that lookup.
+    """
+    if config is None:
+        try:
+            from hermes_cli.config import load_config_readonly
+            config = load_config_readonly()
+        except Exception:  # pragma: no cover — config IO should not break the floor
+            config = None
+    value: Any = None
+    if isinstance(config, dict):
+        agent_cfg = config.get("agent")
+        if isinstance(agent_cfg, dict):
+            value = agent_cfg.get("minimum_context_length")
+    if isinstance(value, bool):
+        value = None
+    # Accept only real integers — floats and numeric strings are treated as
+    # config garbage rather than being silently truncated (int("12.5") would
+    # raise; int(12.5) == 12 would otherwise sneak through as "valid").
+    if not isinstance(value, int):
+        value = None
+    if value and value > 0:
+        return value
+    return MINIMUM_CONTEXT_LENGTH
+
 # Short-lived in-process cache for local-server context probes. Bounds the
 # probe rate when the new local-endpoint live-probe paths (reconcile-on-hit +
 # pre-defaults step 7) resolve the same model several times during one startup
@@ -842,7 +879,7 @@ def _maybe_cache_local_context_length(
     minimum-context guidance — they must not be normalized into the on-disk cache
     as if they were valid operating limits.
     """
-    if length >= MINIMUM_CONTEXT_LENGTH:
+    if length >= get_minimum_context_length():
         save_context_length(model, base_url, length)
 
 
@@ -864,12 +901,13 @@ def _reconcile_local_cached_context_length(
     sub-64K window as config.
     """
     live_ctx = _query_local_context_length(model, base_url, api_key=api_key)
+    minimum_context_length = get_minimum_context_length()
     if live_ctx and live_ctx > 0 and live_ctx != cached:
-        if live_ctx < MINIMUM_CONTEXT_LENGTH:
+        if live_ctx < minimum_context_length:
             logger.info(
                 "Live local probe for %s@%s reports %s (< minimum %s); "
                 "invalidating stale cache — agent init should reject",
-                model, base_url, f"{live_ctx:,}", f"{MINIMUM_CONTEXT_LENGTH:,}",
+                model, base_url, f"{live_ctx:,}", f"{minimum_context_length:,}",
             )
             _invalidate_cached_context_length(model, base_url)
             return live_ctx

--- a/cli.py
+++ b/cli.py
@@ -8099,15 +8099,16 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
 
         # Warn about low context lengths (common with local servers). Keep
         # this tied to the runtime guard so guidance cannot drift again.
-        from agent.model_metadata import MINIMUM_CONTEXT_LENGTH
-        if ctx_len and ctx_len < MINIMUM_CONTEXT_LENGTH:
+        from agent.model_metadata import get_minimum_context_length
+        minimum_context_length = get_minimum_context_length()
+        if ctx_len and ctx_len < minimum_context_length:
             self._console_print()
             self._console_print(
                 f"[yellow]⚠️  Context length is only {ctx_len:,} tokens — "
                 f"this is likely too low for agent use with tools.[/]"
             )
             self._console_print(
-                f"[dim]   Hermes needs at least {MINIMUM_CONTEXT_LENGTH:,} tokens. Tool schemas + system prompt use a large fixed prefix.[/]"
+                f"[dim]   Hermes needs at least {minimum_context_length:,} tokens. Tool schemas + system prompt use a large fixed prefix.[/]"
             )
             base_url = getattr(self, "base_url", "") or ""
             from urllib.parse import urlparse as _urlparse
@@ -8119,7 +8120,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             _host = base_url_hostname(base_url)
             if _port == 11434 or "ollama" in _host:
                 self._console_print(
-                    f"[dim]   Ollama fix: OLLAMA_CONTEXT_LENGTH={MINIMUM_CONTEXT_LENGTH} ollama serve[/]"
+                    f"[dim]   Ollama fix: OLLAMA_CONTEXT_LENGTH={minimum_context_length} ollama serve[/]"
                 )
             elif _port == 1234:
                 self._console_print(

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -44,6 +44,13 @@ DEFAULT_CONFIG = {
     },
     "agent": {
         "max_turns": 500,
+        # Minimum context length (tokens) required to run Hermes Agent.
+        # Models with smaller windows are rejected at startup because they
+        # cannot keep enough working memory for tool-calling workflows.
+        # Lower this to run local servers with smaller models (e.g. Ollama
+        # with num_ctx 32768).  Absent/zero/negative/garbage values fall
+        # back to the built-in default (64,000).
+        "minimum_context_length": 64000,
         # Inactivity timeout for gateway agent execution (seconds).
         # The agent can run indefinitely as long as it's actively calling
         # tools or receiving API responses.  Only fires when the agent has

--- a/hermes_cli/context_switch_guard.py
+++ b/hermes_cli/context_switch_guard.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 
 from typing import Any, Callable, List, Optional
 
-from agent.model_metadata import MINIMUM_CONTEXT_LENGTH
+from agent.model_metadata import get_minimum_context_length
 from hermes_cli.model_switch import ModelSwitchResult, resolve_display_context_length
 
 
@@ -26,7 +26,7 @@ def _append_warning(result: ModelSwitchResult, text: str) -> None:
 
 
 def _threshold_tokens(context_length: int, threshold_percent: float) -> int:
-    return max(int(context_length * threshold_percent), MINIMUM_CONTEXT_LENGTH)
+    return max(int(context_length * threshold_percent), get_minimum_context_length())
 
 
 def _estimate_tokens(agent: Any, messages: Optional[List[dict]]) -> Optional[int]:

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -4078,13 +4078,13 @@ class TestCompressionFallbackContextFilter:
     # compression-specific filter does NOT affect vision chains.
 
     def test_compression_task_uses_minimum_context_constant(self):
-        """The task minimum for compression must equal MINIMUM_CONTEXT_LENGTH
+        """The task minimum for compression must equal the configured floor
         so the runtime fallback stays consistent with the startup feasibility
         check in agent/conversation_compression.py."""
         from agent.auxiliary_client import _task_minimum_context_length
-        from agent.model_metadata import MINIMUM_CONTEXT_LENGTH
+        from agent.model_metadata import get_minimum_context_length
 
-        assert _task_minimum_context_length("compression") == MINIMUM_CONTEXT_LENGTH
+        assert _task_minimum_context_length("compression") == get_minimum_context_length()
         # Non-compression tasks have no minimum (None)
         assert _task_minimum_context_length("vision") is None
         assert _task_minimum_context_length("title_generation") is None
@@ -4095,6 +4095,16 @@ class TestCompressionFallbackContextFilter:
         # Empty / unknown tasks have no minimum
         assert _task_minimum_context_length("") is None
         assert _task_minimum_context_length(None) is None
+
+    def test_compression_task_minimum_follows_config_override(self, monkeypatch):
+        """A lowered agent.minimum_context_length must relax the runtime aux
+        filter too, otherwise a 32K aux model configured on purpose would be
+        skipped even though startup accepted it."""
+        import agent.auxiliary_client as ac
+
+        monkeypatch.setattr(ac, "get_minimum_context_length", lambda *a, **kw: 32_768)
+        assert ac._task_minimum_context_length("compression") == 32_768
+        assert ac._task_minimum_context_length("vision") is None
 
 
 class TestCustomEndpointApiKeyInheritance:

--- a/tests/agent/test_context_compressor.py
+++ b/tests/agent/test_context_compressor.py
@@ -415,9 +415,10 @@ class TestCompress:
         auto-compression could never fire. It now triggers at 85% of the
         window — high enough not to waste the small budget, below 100% so it
         actually fires."""
-        from agent.context_compressor import MINIMUM_CONTEXT_LENGTH
-        t = ContextCompressor._compute_threshold_tokens(MINIMUM_CONTEXT_LENGTH, 0.50)
-        assert t < MINIMUM_CONTEXT_LENGTH
+        from agent.model_metadata import get_minimum_context_length
+        minimum_context_length = get_minimum_context_length()
+        t = ContextCompressor._compute_threshold_tokens(minimum_context_length, 0.50)
+        assert t < minimum_context_length
         assert t == 54400  # 85% of 64000
 
 

--- a/tests/agent/test_context_compressor.py
+++ b/tests/agent/test_context_compressor.py
@@ -409,17 +409,34 @@ class TestCompress:
             f"#49307), found {count}x:\n{summary}"
         )
 
-    def test_threshold_below_window_at_minimum_ctx(self):
-        """Regression for #14690: at context_length == MINIMUM_CONTEXT_LENGTH
-        the floored threshold used to equal the whole window, so
+    def test_threshold_below_window_at_minimum_ctx(self, monkeypatch):
+        """Regression for #14690: at context_length == the minimum context
+        length the floored threshold used to equal the whole window, so
         auto-compression could never fire. It now triggers at 85% of the
         window — high enough not to waste the small budget, below 100% so it
-        actually fires."""
-        from agent.model_metadata import get_minimum_context_length
-        minimum_context_length = get_minimum_context_length()
-        t = ContextCompressor._compute_threshold_tokens(minimum_context_length, 0.50)
-        assert t < minimum_context_length
+        actually fires.
+
+        Pinned to the built-in 64K default so the hard-coded expectation can't
+        drift with an ambient agent.minimum_context_length override."""
+        import agent.context_compressor as cc
+        from agent.model_metadata import MINIMUM_CONTEXT_LENGTH
+
+        monkeypatch.setattr(
+            cc, "get_minimum_context_length", lambda *a, **kw: MINIMUM_CONTEXT_LENGTH
+        )
+        t = ContextCompressor._compute_threshold_tokens(MINIMUM_CONTEXT_LENGTH, 0.50)
+        assert t < MINIMUM_CONTEXT_LENGTH
         assert t == 54400  # 85% of 64000
+
+    def test_threshold_floor_follows_configured_minimum(self, monkeypatch):
+        """The floor tracks agent.minimum_context_length, not the constant:
+        a 32K floor lets a 100K model compact at the 50% ratio value instead
+        of being pushed up to 64K."""
+        import agent.context_compressor as cc
+
+        monkeypatch.setattr(cc, "get_minimum_context_length", lambda *a, **kw: 32_000)
+        t = ContextCompressor._compute_threshold_tokens(100_000, 0.50)
+        assert t == 50_000
 
 
 

--- a/tests/agent/test_model_metadata.py
+++ b/tests/agent/test_model_metadata.py
@@ -1635,3 +1635,26 @@ class TestFallbackWarning:
             if r.levelno == logging.WARNING and "falling back" in r.getMessage()
         ]
         assert len(fallback_warnings) == 0
+
+
+class TestGetMinimumContextLength:
+    """Tests for get_minimum_context_length() — config override and fallback."""
+
+    def test_default_when_config_absent(self):
+        from agent.model_metadata import get_minimum_context_length
+        assert get_minimum_context_length(None) == 64000
+
+    def test_default_when_key_absent(self):
+        from agent.model_metadata import get_minimum_context_length
+        assert get_minimum_context_length({"agent": {"max_turns": 100}}) == 64000
+
+    def test_override(self):
+        from agent.model_metadata import get_minimum_context_length
+        cfg = {"agent": {"minimum_context_length": 32768}}
+        assert get_minimum_context_length(cfg) == 32768
+
+    @pytest.mark.parametrize("bad", [0, -1, "garbage", 12.5, True, False, None, "", []])
+    def test_garbage_falls_back_to_default(self, bad):
+        from agent.model_metadata import get_minimum_context_length
+        cfg = {"agent": {"minimum_context_length": bad}}
+        assert get_minimum_context_length(cfg) == 64000

--- a/tests/agent/test_model_metadata.py
+++ b/tests/agent/test_model_metadata.py
@@ -1648,6 +1648,11 @@ class TestGetMinimumContextLength:
         from agent.model_metadata import get_minimum_context_length
         assert get_minimum_context_length({"agent": {"max_turns": 100}}) == 64000
 
+    @pytest.mark.parametrize("cfg", [{}, {"agent": None}, {"agent": "nope"}, "not-a-dict"])
+    def test_default_for_malformed_config(self, cfg):
+        from agent.model_metadata import get_minimum_context_length
+        assert get_minimum_context_length(cfg) == 64000
+
     def test_override(self):
         from agent.model_metadata import get_minimum_context_length
         cfg = {"agent": {"minimum_context_length": 32768}}
@@ -1658,3 +1663,60 @@ class TestGetMinimumContextLength:
         from agent.model_metadata import get_minimum_context_length
         cfg = {"agent": {"minimum_context_length": bad}}
         assert get_minimum_context_length(cfg) == 64000
+
+    def test_reads_config_when_not_passed(self, monkeypatch):
+        """The config=None path must actually resolve agent.minimum_context_length
+        through load_config_readonly — the whole feature rides on this lookup."""
+        import hermes_cli.config as cfg_mod
+        from agent.model_metadata import get_minimum_context_length
+
+        monkeypatch.setattr(
+            cfg_mod, "load_config_readonly",
+            lambda: {"agent": {"minimum_context_length": 32768}},
+        )
+        assert get_minimum_context_length() == 32768
+
+    def test_config_load_failure_falls_back_to_default(self, monkeypatch):
+        """A broken/unreadable config must not take the floor down with it."""
+        import hermes_cli.config as cfg_mod
+        from agent.model_metadata import get_minimum_context_length
+
+        def _boom():
+            raise RuntimeError("config unreadable")
+
+        monkeypatch.setattr(cfg_mod, "load_config_readonly", _boom)
+        assert get_minimum_context_length() == 64000
+
+    def test_invalid_value_warns_once(self, caplog):
+        """An override that is present but unusable must not be silently
+        dropped — the user would otherwise watch the floor reject their model
+        with no hint that their config value was ignored."""
+        import logging
+
+        import agent.model_metadata as mm
+
+        mm._MINIMUM_CONTEXT_WARNED.clear()
+        cfg = {"agent": {"minimum_context_length": "32768"}}
+        with caplog.at_level(logging.WARNING, logger=mm.logger.name):
+            assert mm.get_minimum_context_length(cfg) == 64000
+            assert mm.get_minimum_context_length(cfg) == 64000
+
+        warnings = [
+            r for r in caplog.records
+            if "agent.minimum_context_length" in r.getMessage()
+        ]
+        assert len(warnings) == 1
+
+    def test_absent_value_does_not_warn(self, caplog):
+        import logging
+
+        import agent.model_metadata as mm
+
+        mm._MINIMUM_CONTEXT_WARNED.clear()
+        with caplog.at_level(logging.WARNING, logger=mm.logger.name):
+            assert mm.get_minimum_context_length({"agent": {}}) == 64000
+
+        assert not [
+            r for r in caplog.records
+            if "agent.minimum_context_length" in r.getMessage()
+        ]

--- a/website/docs/integrations/providers.md
+++ b/website/docs/integrations/providers.md
@@ -729,6 +729,8 @@ Ollama does **not** use your model's full context window by default. Depending o
 
 Hermes Agent requires at least **64,000 tokens** of context for agent use with tools. Smaller windows are rejected at startup because the system prompt, tool schemas, and working conversation state need enough room for reliable multi-step workflows.
 
+If your hardware can't reach 64K, lower the floor with `agent.minimum_context_length` (see [Configuration](/user-guide/configuration#agent)) — expect shorter sessions and more frequent compaction.
+
 **How to increase it** (pick one):
 
 ```bash


### PR DESCRIPTION
## Problem

`MINIMUM_CONTEXT_LENGTH` is hardcoded to 64,000 tokens in `agent/model_metadata.py` and enforced at agent startup. Users running **local models with smaller windows** (e.g. Ollama with `num_ctx 32768` on memory-constrained machines, LM Studio, llama.cpp) hit:

```
ValueError: Model gemma3:12b has a context window of 32,768 tokens, which is below the minimum 64,000 required by Hermes Agent.
```

There was no supported way to lower the floor — the only escape hatch was a hardcoded exception for `lmstudio` providers.

## Solution

Add a config key `agent.minimum_context_length` (default `64000`) and a helper `get_minimum_context_length(config=None)` in `agent/model_metadata.py` that reads it with validation (only positive real ints are accepted; `0`, negatives, floats, bools, strings and garbage fall back to the built-in default).

All hardcoded uses now consult the configured value:
- `agent/agent_init.py` — startup rejection check + error message
- `agent/model_metadata.py` — local context probe caching/reconciliation
- `agent/context_compressor.py` — compression threshold floor (regression #14690 logic preserved)
- `agent/conversation_compression.py` — aux-model hard floor
- `agent/auxiliary_client.py` — task minimum context
- `agent/conversation_loop.py` — Ollama runtime-context warning
- `cli.py` — banner warning (including the `OLLAMA_CONTEXT_LENGTH=` hint)
- `hermes_cli/context_switch_guard.py` — switch threshold
- `hermes_cli/config_defaults.py` — new key in `DEFAULT_CONFIG["agent"]`

## Testing

- New tests: `TestGetMinimumContextLength` in `tests/agent/test_model_metadata.py` (default, override, garbage/zero/bool/float fallback).
- Updated `tests/agent/test_context_compressor.py::test_threshold_below_window_at_minimum_ctx` to use the helper instead of the removed re-export.
- Ran: `pytest tests/agent/test_auxiliary_client.py tests/agent/test_model_metadata.py tests/agent/test_context_compressor.py tests/cli/test_cli_context_warning.py tests/run_agent/test_compression_feasibility.py -q` → **428 passed**.
