### PR TITLE
chore: map justin@bowes.org to @justinbowes

### DIFF
--- a/contributors/emails/justin@bowes.org
+++ b/contributors/emails/justin@bowes.org
@@ -1,0 +1,2 @@
+justinbowes
+# PR #84982 salvage


### PR DESCRIPTION
Attribution mapping needed by the #84982 salvage.

`justin@bowes.org` is not linked to a public GitHub account, so `contributor_audit.py --strict` reports it as an unmapped email and blocks any PR carrying that commit. Login confirmed from the #84982 author field (@justinbowes).

Added via `scripts/add_contributor.py` (one file per email under `contributors/emails/`) rather than editing the frozen `AUTHOR_MAP` dict, per that script's docstring.

## Validation
| | Before | After |
|---|---|---|
| `contributor_audit.py --strict` | `STRICT MODE FAILURE: 1 new unmapped email(s)` | clean |

Merge this before the #84982 salvage — the audit runs against `main`.