### PR TITLE
fix(caching): engage prompt caching for LiteLLM Claude on the OpenAI wire (envelope layout)

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -2299,9 +2299,19 @@ def anthropic_prompt_cache_policy(
     # Also consulted for a LiteLLM route on the OpenAI wire: that grant is
     # inferred from the provider/host name, so an operator who explicitly
     # declares prompt_caching for the route+model must still win over the
-    # inference — in either direction.
+    # inference — in either direction. Narrowed to the routes the LiteLLM
+    # branch below can actually grant (chat_completions + Claude): the lookup
+    # calls get_compatible_custom_providers, which rebuilds its normalized
+    # view on every call (~1.5ms uncached), and this function runs per
+    # request destination. Widening it unconditionally regressed the
+    # non-declaring common case ~200x (7.5us -> 1528us).
     custom_prompt_caching = None
-    if is_anthropic_wire or _is_litellm_route(provider_lower, eff_base_url):
+    _litellm_openai_wire = (
+        eff_api_mode == "chat_completions"
+        and is_claude
+        and _is_litellm_route(provider_lower, eff_base_url)
+    )
+    if is_anthropic_wire or _litellm_openai_wire:
         try:
             from hermes_cli.config import get_custom_provider_model_capability
 
@@ -2402,11 +2412,7 @@ def anthropic_prompt_cache_policy(
     # Gated on chat_completions explicitly rather than `not
     # is_anthropic_wire`: codex_responses / bedrock_converse are separate
     # transports with their own marker handling and must not be swept in.
-    if (
-        eff_api_mode == "chat_completions"
-        and is_claude
-        and _is_litellm_route(provider_lower, eff_base_url)
-    ):
+    if _litellm_openai_wire:
         return True, False
 
     # MiniMax on its Anthropic-compatible endpoint serves its own

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -2145,6 +2145,30 @@ def plan_cache_sections_for_destination(
     return plan.messages, plan.tools
 
 
+def _is_litellm_route(provider_lower: str, base_url: str) -> bool:
+    """True when a route is a LiteLLM proxy, by provider id or host token.
+
+    Provider naming varies per install (``litellm``, ``custom:litellm``, or a
+    bare ``custom`` alias pointed at a LiteLLM host), so both signals are
+    checked. The host side matches ``litellm`` as a whole dot- or
+    hyphen-delimited label token rather than a raw substring:
+    ``base_url_hostname``'s own docstring names substring host matching as the
+    false-positive class to avoid, and a plain ``"litellm" in hostname`` grants
+    Anthropic markers to unrelated hosts like ``notlitellm.example.com``.
+    A ``litellm`` *path* segment never qualifies — only the host does.
+    """
+    if "litellm" in provider_lower:
+        return True
+    hostname = base_url_hostname(base_url)
+    if not hostname:
+        return False
+    return any(
+        "litellm" == token
+        for label in hostname.split(".")
+        for token in label.split("-")
+    )
+
+
 def anthropic_prompt_cache_policy(
     agent,
     *,
@@ -2269,8 +2293,13 @@ def anthropic_prompt_cache_policy(
     # capability declaration instead; explicit false is authoritative too.
     # This preserves the runtime model id (and therefore request/cache keys)
     # while avoiding unsafe alias-name guesses.
+    #
+    # Also consulted for a LiteLLM route on the OpenAI wire: that grant is
+    # inferred from the provider/host name, so an operator who explicitly
+    # declares prompt_caching for the route+model must still win over the
+    # inference — in either direction.
     custom_prompt_caching = None
-    if is_anthropic_wire:
+    if is_anthropic_wire or _is_litellm_route(provider_lower, eff_base_url):
         try:
             from hermes_cli.config import get_custom_provider_model_capability
 
@@ -2286,7 +2315,11 @@ def anthropic_prompt_cache_policy(
                 _cap_exc,
             )
     if custom_prompt_caching is not None:
-        return custom_prompt_caching, custom_prompt_caching
+        # Layout follows the transport, not the declaration: the native
+        # inner-block form is only honored on the Anthropic Messages wire
+        # (see the LiteLLM OpenAI-wire branch below for why a top-level
+        # marker is dropped or 400s on chat_completions).
+        return custom_prompt_caching, custom_prompt_caching and is_anthropic_wire
 
     # MiniMax-M3 rides MiniMax's server-side automatic prefix cache on the
     # Anthropic wire (content-keyed, no marker needed); explicit cache_control
@@ -2337,27 +2370,42 @@ def anthropic_prompt_cache_policy(
     # LiteLLM fronting a Claude model on the OpenAI-compatible wire.
     # The branch above only matches LiteLLM in Anthropic proxy mode
     # (api_mode == "anthropic_messages"). A LiteLLM deployment that
-    # exposes /v1/chat/completions instead (api_mode == "chat_completions",
-    # /v1/messages returns 404) matches no grant branch above and falls
-    # through to (False, False): no cache_control is injected, the system
-    # prompt goes on the wire as a plain string, and the provider serves
-    # zero cache hits — the entire prompt is re-billed at full price every
-    # turn. Same failure class already documented above for Qwen/DashScope.
-    # The endpoint supports Anthropic-style cache_control fine; only the
-    # provider detection missed it.
+    # exposes /v1/chat/completions instead matched no grant branch above
+    # and fell through to (False, False): no cache_control is injected, the
+    # system prompt goes on the wire as a plain string, and the provider
+    # serves zero cache hits — the entire prompt is re-billed at full price
+    # every turn. Same failure class already documented above for
+    # Qwen/DashScope. The endpoint supports Anthropic-style cache_control
+    # fine; only the provider detection missed it (#84506).
     #
     # Gated on the Claude family only: a Gemini/GPT/Qwen route through the
-    # same proxy must not receive markers. Matches on the provider string
-    # OR the base_url host, because provider naming varies per install
-    # (`litellm`, `custom:litellm`, or a bare `custom` alias pointed at a
-    # LiteLLM host). Emits the native inner-block layout so the wire shape
-    # matches the anthropic_messages branch for the same gateway.
-    _is_litellm_endpoint = (
-        "litellm" in provider_lower
-        or "litellm" in base_url_hostname(eff_base_url).lower()
-    )
-    if _is_litellm_endpoint and is_claude and not is_anthropic_wire:
-        return True, True
+    # same proxy must not receive markers — some strict OpenAI-wire relays
+    # reject the cache_control block format outright (cf. the DeepSeek /
+    # OpenCode exclusion below, #77217).
+    #
+    # Envelope layout (native_anthropic=False), matching every other
+    # OpenAI-wire grant in this function. The native inner-block layout
+    # writes a TOP-LEVEL msg["cache_control"] on role:tool and
+    # empty-content messages and relies on the Anthropic adapter to
+    # relocate it — but that adapter only runs for api_mode ==
+    # "anthropic_messages" (agent/transports/anthropic.py), and the
+    # chat_completions transport performs no relocation. On this wire the
+    # native layout therefore (a) silently loses those breakpoints, spending
+    # 2 of the 4 available on markers the provider never sees, and (b) when
+    # LiteLLM relocates a top-level marker itself for an OpenRouter-backed
+    # Claude route, lands it on an empty text block — the HTTP 400
+    # "text content blocks must contain" shape handled in
+    # agent/anthropic_adapter.py (#69512).
+    #
+    # Gated on chat_completions explicitly rather than `not
+    # is_anthropic_wire`: codex_responses / bedrock_converse are separate
+    # transports with their own marker handling and must not be swept in.
+    if (
+        eff_api_mode == "chat_completions"
+        and is_claude
+        and _is_litellm_route(provider_lower, eff_base_url)
+    ):
+        return True, False
 
     # MiniMax on its Anthropic-compatible endpoint serves its own
     # model family (MiniMax-M2.7, M2.5, M2.1, M2) with documented

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -2334,6 +2334,31 @@ def anthropic_prompt_cache_policy(
         # Third-party Anthropic-compatible gateway.
         return True, True
 
+    # LiteLLM fronting a Claude model on the OpenAI-compatible wire.
+    # The branch above only matches LiteLLM in Anthropic proxy mode
+    # (api_mode == "anthropic_messages"). A LiteLLM deployment that
+    # exposes /v1/chat/completions instead (api_mode == "chat_completions",
+    # /v1/messages returns 404) matches no grant branch above and falls
+    # through to (False, False): no cache_control is injected, the system
+    # prompt goes on the wire as a plain string, and the provider serves
+    # zero cache hits — the entire prompt is re-billed at full price every
+    # turn. Same failure class already documented above for Qwen/DashScope.
+    # The endpoint supports Anthropic-style cache_control fine; only the
+    # provider detection missed it.
+    #
+    # Gated on the Claude family only: a Gemini/GPT/Qwen route through the
+    # same proxy must not receive markers. Matches on the provider string
+    # OR the base_url host, because provider naming varies per install
+    # (`litellm`, `custom:litellm`, or a bare `custom` alias pointed at a
+    # LiteLLM host). Emits the native inner-block layout so the wire shape
+    # matches the anthropic_messages branch for the same gateway.
+    _is_litellm_endpoint = (
+        "litellm" in provider_lower
+        or "litellm" in base_url_hostname(eff_base_url).lower()
+    )
+    if _is_litellm_endpoint and is_claude and not is_anthropic_wire:
+        return True, True
+
     # MiniMax on its Anthropic-compatible endpoint serves its own
     # model family (MiniMax-M2.7, M2.5, M2.1, M2) with documented
     # cache_control support (0.1× read pricing, 5-minute TTL).  The

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -2150,23 +2150,25 @@ def _is_litellm_route(provider_lower: str, base_url: str) -> bool:
 
     Provider naming varies per install (``litellm``, ``custom:litellm``, or a
     bare ``custom`` alias pointed at a LiteLLM host), so both signals are
-    checked. The host side matches ``litellm`` as a whole dot- or
-    hyphen-delimited label token rather than a raw substring:
-    ``base_url_hostname``'s own docstring names substring host matching as the
-    false-positive class to avoid, and a plain ``"litellm" in hostname`` grants
-    Anthropic markers to unrelated hosts like ``notlitellm.example.com``.
+    checked. Both match ``litellm`` as a whole delimited token rather than a
+    raw substring: ``base_url_hostname``'s own docstring names substring host
+    matching as the false-positive class to avoid, and a plain
+    ``"litellm" in ...`` grants Anthropic markers to unrelated routes like
+    ``notlitellm.example.com`` or a provider named ``custom:notlitellm``.
     A ``litellm`` *path* segment never qualifies — only the host does.
     """
-    if "litellm" in provider_lower:
+    if _has_litellm_token(provider_lower, ":-_/"):
         return True
-    hostname = base_url_hostname(base_url)
-    if not hostname:
+    return _has_litellm_token(base_url_hostname(base_url), ".-")
+
+
+def _has_litellm_token(value: str, delimiters: str) -> bool:
+    """True when ``value`` contains ``litellm`` as a whole delimited token."""
+    if not value:
         return False
-    return any(
-        "litellm" == token
-        for label in hostname.split(".")
-        for token in label.split("-")
-    )
+    for delimiter in delimiters:
+        value = value.replace(delimiter, " ")
+    return "litellm" in value.split()
 
 
 def anthropic_prompt_cache_policy(

--- a/tests/run_agent/test_anthropic_prompt_cache_policy.py
+++ b/tests/run_agent/test_anthropic_prompt_cache_policy.py
@@ -658,6 +658,34 @@ class TestLiteLLMOpenAIWire:
         assert agent._anthropic_prompt_cache_policy() == (False, False)
 
     @pytest.mark.parametrize(
+        "provider", ["custom:notlitellm", "notlitellm", "mylitellmthing"]
+    )
+    def test_litellm_lookalike_provider_names_do_not_cache(self, provider):
+        # The provider signal is token-wise for the same reason as the host:
+        # a user-named provider that merely contains "litellm" is not a
+        # LiteLLM route and must not be handed Anthropic markers.
+        agent = _make_agent(
+            provider=provider,
+            base_url="https://gateway.attacker.example/v1",
+            api_mode="chat_completions",
+            model="claude-opus-4.8",
+        )
+        assert agent._anthropic_prompt_cache_policy() == (False, False)
+
+    @pytest.mark.parametrize(
+        "provider", ["litellm", "custom:litellm", "litellm-router", "LiteLLM"]
+    )
+    def test_litellm_provider_spellings_still_cache(self, provider):
+        # ...while every real spelling of a LiteLLM provider id still matches.
+        agent = _make_agent(
+            provider=provider,
+            base_url="https://gateway.internal.example/v1",
+            api_mode="chat_completions",
+            model="claude-opus-4.8",
+        )
+        assert agent._anthropic_prompt_cache_policy() == (True, False)
+
+    @pytest.mark.parametrize(
         "api_mode", ["codex_responses", "bedrock_converse", "codex_app_server"]
     )
     def test_litellm_claude_on_other_transports_does_not_cache(self, api_mode):

--- a/tests/run_agent/test_anthropic_prompt_cache_policy.py
+++ b/tests/run_agent/test_anthropic_prompt_cache_policy.py
@@ -558,9 +558,9 @@ class TestLiteLLMOpenAIWire:
     grant branch and fell through to (False, False): zero cache hits, the
     full prompt re-billed every turn. The endpoint accepts Anthropic-style
     cache_control fine — only the provider detection missed it. Claude gets
-    the grant with the native inner-block layout; non-Claude models routed
-    through the same proxy get nothing (they may not tolerate the marker
-    block format).
+    the grant with the envelope layout (the only layout honored on this
+    wire); non-Claude models routed through the same proxy get nothing
+    (they may not tolerate the marker block format).
     """
 
     @pytest.mark.parametrize(
@@ -581,7 +581,7 @@ class TestLiteLLMOpenAIWire:
             "claude-3-7-sonnet",
         ],
     )
-    def test_claude_on_litellm_openai_wire_caches_with_native_layout(
+    def test_claude_on_litellm_openai_wire_caches_with_envelope_layout(
         self, provider, base_url, model
     ):
         agent = _make_agent(
@@ -590,7 +590,7 @@ class TestLiteLLMOpenAIWire:
             api_mode="chat_completions",
             model=model,
         )
-        assert agent._anthropic_prompt_cache_policy() == (True, True)
+        assert agent._anthropic_prompt_cache_policy() == (True, False)
 
     @pytest.mark.parametrize(
         "model",
@@ -634,6 +634,129 @@ class TestLiteLLMOpenAIWire:
             model="claude-opus-4.8",
         )
         assert agent._anthropic_prompt_cache_policy() == (True, True)
+
+    @pytest.mark.parametrize(
+        "base_url",
+        [
+            # "litellm" as a substring of a longer label is NOT a LiteLLM host.
+            "https://notlitellm.attacker.example/v1",
+            "https://foolitellmbar.example/v1",
+            # A "litellm" PATH segment on an unrelated host must not qualify.
+            "https://gateway.attacker.example/litellm/v1",
+        ],
+    )
+    def test_litellm_lookalike_hosts_do_not_cache(self, base_url):
+        # Host matching is label-token-wise, not substring: a Claude-named
+        # model on an unrelated strict OpenAI-wire relay must not receive
+        # Anthropic markers (it may reject the block format, cf. #77217).
+        agent = _make_agent(
+            provider="custom",
+            base_url=base_url,
+            api_mode="chat_completions",
+            model="claude-opus-4.8",
+        )
+        assert agent._anthropic_prompt_cache_policy() == (False, False)
+
+    @pytest.mark.parametrize(
+        "api_mode", ["codex_responses", "bedrock_converse", "codex_app_server"]
+    )
+    def test_litellm_claude_on_other_transports_does_not_cache(self, api_mode):
+        # The grant is scoped to chat_completions. Other transports carry
+        # their own marker handling and must not be swept in by a blanket
+        # "not anthropic_messages" gate.
+        agent = _make_agent(
+            provider="custom:litellm",
+            base_url="https://litellm.internal.example.com/v1",
+            api_mode=api_mode,
+            model="claude-opus-4.8",
+        )
+        assert agent._anthropic_prompt_cache_policy() == (False, False)
+
+    def test_operator_capability_declaration_overrides_litellm_inference(self):
+        # The LiteLLM grant is inferred from the provider/host name, so an
+        # explicit per-model declaration must still win — otherwise an
+        # operator who turned caching off for a known-broken route on this
+        # proxy is silently overridden.
+        agent = _make_agent(
+            provider="custom:litellm",
+            base_url="https://litellm.internal.example.com/v1",
+            api_mode="chat_completions",
+            model="claude-opus-4.8",
+        )
+        agent._custom_providers = [
+            {
+                "name": "litellm",
+                "base_url": "https://litellm.internal.example.com/v1",
+                "models": {"claude-opus-4.8": {"prompt_caching": False}},
+            }
+        ]
+        assert agent._anthropic_prompt_cache_policy() == (False, False)
+
+    def test_capability_declared_true_keeps_envelope_layout_on_openai_wire(self):
+        # An explicit prompt_caching: true must not promote the request to the
+        # native inner-block layout on chat_completions — the layout follows
+        # the transport, and a top-level marker is dropped there.
+        agent = _make_agent(
+            provider="custom:litellm",
+            base_url="https://litellm.internal.example.com/v1",
+            api_mode="chat_completions",
+            model="claude-opus-4.8",
+        )
+        agent._custom_providers = [
+            {
+                "name": "litellm",
+                "base_url": "https://litellm.internal.example.com/v1",
+                "models": {"claude-opus-4.8": {"prompt_caching": True}},
+            }
+        ]
+        assert agent._anthropic_prompt_cache_policy() == (True, False)
+
+    def test_litellm_openai_wire_emits_no_top_level_marker(self):
+        # Wire-shape contract, not just the policy tuple: on chat_completions
+        # every breakpoint must land INSIDE a content part. A top-level
+        # msg["cache_control"] is never relocated on this transport, so it is
+        # both a lost breakpoint and (once a relay relocates it onto an empty
+        # assistant turn) the HTTP 400 empty-text-block shape (#69512).
+        from agent.agent_runtime_helpers import plan_cache_sections_for_destination
+
+        messages = [
+            {"role": "system", "content": "SYSTEM " * 200},
+            {"role": "user", "content": "go"},
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "c0",
+                        "type": "function",
+                        "function": {"name": "terminal", "arguments": "{}"},
+                    }
+                ],
+            },
+            {"role": "tool", "tool_call_id": "c0", "content": "output " * 100},
+            {"role": "assistant", "content": "done"},
+        ]
+        planned, _tools = plan_cache_sections_for_destination(
+            messages,
+            None,
+            provider="custom:litellm",
+            base_url="https://litellm.internal.example.com/v1",
+            api_mode="chat_completions",
+            model="claude-opus-4.8",
+            cache_disabled=False,
+            cache_ttl="5m",
+        )
+        assert not [m for m in planned if "cache_control" in m], (
+            "no breakpoint may sit on the message envelope on the OpenAI wire"
+        )
+        inner = [
+            m
+            for m in planned
+            if isinstance(m.get("content"), list)
+            for part in m["content"]
+            if isinstance(part, dict) and "cache_control" in part
+        ]
+        assert inner, "the OpenAI-wire grant must still place real breakpoints"
 
 
 class TestNousPortalAnthropicWire:

--- a/tests/run_agent/test_anthropic_prompt_cache_policy.py
+++ b/tests/run_agent/test_anthropic_prompt_cache_policy.py
@@ -550,6 +550,92 @@ class TestDeepSeekOpenCode:
         assert agent._anthropic_prompt_cache_policy() == (False, False)
 
 
+class TestLiteLLMOpenAIWire:
+    """LiteLLM fronting a Claude model on the OpenAI-compatible wire (#84506).
+
+    A LiteLLM proxy exposing /v1/chat/completions (api_mode ==
+    "chat_completions", /v1/messages returns 404) previously matched no
+    grant branch and fell through to (False, False): zero cache hits, the
+    full prompt re-billed every turn. The endpoint accepts Anthropic-style
+    cache_control fine — only the provider detection missed it. Claude gets
+    the grant with the native inner-block layout; non-Claude models routed
+    through the same proxy get nothing (they may not tolerate the marker
+    block format).
+    """
+
+    @pytest.mark.parametrize(
+        "provider,base_url",
+        [
+            # Provider-string signal: names vary per install.
+            ("litellm", "https://my-litellm-host.example.com/v1"),
+            ("custom:litellm", "https://my-litellm-host.example.com/v1"),
+            # Host signal: bare `custom` alias pointed at a LiteLLM host.
+            ("custom", "https://litellm.internal.example.com/v1"),
+        ],
+    )
+    @pytest.mark.parametrize(
+        "model",
+        [
+            "claude-opus-4.8",
+            "anthropic/claude-sonnet-4.6",
+            "claude-3-7-sonnet",
+        ],
+    )
+    def test_claude_on_litellm_openai_wire_caches_with_native_layout(
+        self, provider, base_url, model
+    ):
+        agent = _make_agent(
+            provider=provider,
+            base_url=base_url,
+            api_mode="chat_completions",
+            model=model,
+        )
+        assert agent._anthropic_prompt_cache_policy() == (True, True)
+
+    @pytest.mark.parametrize(
+        "model",
+        [
+            "openai/gpt-5.4",
+            "gemini-2.5-pro",
+            "qwen3.6-plus",
+            "deepseek-v4-pro",
+        ],
+    )
+    def test_non_claude_on_litellm_openai_wire_does_not_cache(self, model):
+        # No over-reach: a Gemini/GPT/Qwen/DeepSeek route through the same
+        # LiteLLM proxy must not receive Anthropic cache_control markers.
+        agent = _make_agent(
+            provider="litellm",
+            base_url="https://litellm.internal.example.com/v1",
+            api_mode="chat_completions",
+            model=model,
+        )
+        assert agent._anthropic_prompt_cache_policy() == (False, False)
+
+    def test_litellm_claude_operator_disable_still_wins(self):
+        # prompt_caching.cache_ttl: false — the _cache_disabled early return
+        # must survive the new branch.
+        agent = _make_agent(
+            provider="litellm",
+            base_url="https://litellm.internal.example.com/v1",
+            api_mode="chat_completions",
+            model="claude-opus-4.8",
+        )
+        agent._cache_disabled = True
+        assert agent._anthropic_prompt_cache_policy() == (False, False)
+
+    def test_litellm_in_anthropic_proxy_mode_still_uses_native_layout(self):
+        # Adjacent behavior: LiteLLM reached over the native Anthropic wire
+        # keeps hitting the pre-existing is_anthropic_wire branch (True, True).
+        agent = _make_agent(
+            provider="litellm",
+            base_url="https://litellm.internal.example.com",
+            api_mode="anthropic_messages",
+            model="claude-opus-4.8",
+        )
+        assert agent._anthropic_prompt_cache_policy() == (True, True)
+
+
 class TestNousPortalAnthropicWire:
     def test_portal_claude_on_the_messages_wire_uses_the_native_layout(self):
         agent = _make_agent(

--- a/tests/run_agent/test_anthropic_prompt_cache_policy.py
+++ b/tests/run_agent/test_anthropic_prompt_cache_policy.py
@@ -571,6 +571,8 @@ class TestLiteLLMOpenAIWire:
             ("custom:litellm", "https://my-litellm-host.example.com/v1"),
             # Host signal: bare `custom` alias pointed at a LiteLLM host.
             ("custom", "https://litellm.internal.example.com/v1"),
+            # Host signal, hyphen-delimited label (self-hosted naming).
+            ("custom", "https://my-litellm-gw.internal.example.com/v1"),
         ],
     )
     @pytest.mark.parametrize(
@@ -578,7 +580,6 @@ class TestLiteLLMOpenAIWire:
         [
             "claude-opus-4.8",
             "anthropic/claude-sonnet-4.6",
-            "claude-3-7-sonnet",
         ],
     )
     def test_claude_on_litellm_openai_wire_caches_with_envelope_layout(
@@ -737,6 +738,40 @@ class TestLiteLLMOpenAIWire:
                 "models": {"claude-opus-4.8": {"prompt_caching": True}},
             }
         ]
+        assert agent._anthropic_prompt_cache_policy() == (True, False)
+
+    def test_capability_declared_false_wins_over_openrouter_grant(self):
+        # A litellm-named provider pointed at OpenRouter previously took the
+        # OpenRouter branch and ignored an explicit per-model opt-out, because
+        # the capability lookup was gated on the Anthropic wire. The operator's
+        # declaration now wins on this wire too.
+        agent = _make_agent(
+            provider="custom:litellm",
+            base_url="https://openrouter.ai/api/v1",
+            api_mode="chat_completions",
+            model="claude-opus-4.8",
+        )
+        agent._custom_providers = [
+            {
+                "name": "litellm",
+                "base_url": "https://openrouter.ai/api/v1",
+                "models": {"claude-opus-4.8": {"prompt_caching": False}},
+            }
+        ]
+        assert agent._anthropic_prompt_cache_policy() == (False, False)
+
+    def test_litellm_provider_on_lookalike_host_still_grants(self):
+        # Precedence is intentional and pinned: the provider id is an
+        # independent signal, so an explicitly litellm-named provider grants
+        # even when the HOST is a lookalike. Only the host-derived signal is
+        # token-gated (see test_litellm_lookalike_hosts_do_not_cache, which
+        # uses provider="custom").
+        agent = _make_agent(
+            provider="custom:litellm",
+            base_url="https://notlitellm.attacker.example/v1",
+            api_mode="chat_completions",
+            model="claude-opus-4.8",
+        )
         assert agent._anthropic_prompt_cache_policy() == (True, False)
 
     def test_litellm_openai_wire_emits_no_top_level_marker(self):


### PR DESCRIPTION
## Summary

LiteLLM-fronted Claude on the OpenAI-compatible wire now gets prompt caching, with the marker layout that wire actually honors. Salvage of #84982 (@justinbowes) onto current `main`, plus a follow-up commit that fixes the marker layout and three scoping gaps.

`anthropic_prompt_cache_policy()` only granted Anthropic `cache_control` to a LiteLLM endpoint reached over the native Anthropic wire. A LiteLLM deployment exposing `/v1/chat/completions` instead (with `/v1/messages` returning 404) matched no grant branch and fell through to `(False, False)` — no markers, system prompt on the wire as a plain string, zero cache hits, full prompt re-billed every turn, silently. Reproduced on current `main`:

```python
anthropic_prompt_cache_policy(agent)  # provider=custom:litellm, api_mode=chat_completions, model=claude-opus-5
# -> (False, False)
```

Fixes #84506.

## Commits

1. **@justinbowes' original fix, cherry-picked** — authorship preserved. Adds the grant branch plus the `TestLiteLLMOpenAIWire` matrix.
2. **Envelope layout + three scoping fixes** (below).
3. **Token-wise provider matching** — self-review caught that commit 2 fixed substring matching on the *host* but left the *provider id* as a bare substring, so `custom:notlitellm` still matched. Same bug class, half-fixed.
4. **Perf narrowing** — benchmarking commit 2 showed the widened capability-lookup gate pulled every litellm-ish `chat_completions` route into a config read, including non-Claude models the grant can never match. Narrowed to the exact grant condition and computed once.

## Why the layout changed from `(True, True)` to `(True, False)`

This was the open question on #84982, and @Enough1122 raised it in #84550/#87039 on consistency grounds. @justinbowes' counter was fair — consistency isn't correctness, and he asked to settle it with measurements rather than a style argument. So we measured it.

`use_native_layout=True` makes `_apply_cache_marker` write a **top-level** `msg["cache_control"]` on `role:tool` and empty-content messages, relying on the Anthropic adapter to relocate it into the content block. That adapter only runs for `api_mode == "anthropic_messages"` (`agent/transports/anthropic.py:251`), and `agent/transports/chat_completions.py` performs no relocation at all. On this wire those markers are emitted as an unrecognized top-level field and lost.

Measured on a 3-tool-turn transcript, feeding Hermes's own planner output through the real `litellm` library:

| | breakpoints honored | empty marked text blocks |
|---|---|---|
| `(True, True)` | **2 of 4** | **1** |
| `(True, False)` | **4 of 4** | 0 |

The second column is the sharper problem. When LiteLLM itself relocates a top-level marker for an OpenRouter-backed Claude route (`OpenrouterConfig._move_cache_control_to_content`), the marker lands on an empty assistant turn (pure `tool_calls`) and produces a `cache_control`-marked **empty text block** — the HTTP 400 `"text content blocks must contain"` shape already guarded in `agent/anthropic_adapter.py` (#69512). That's the same failure class as the DeepSeek/OpenCode exclusion (#77217) the original PR cites to justify gating on Claude.

Two corroborating in-repo signals: the envelope layout is what every other OpenAI-wire grant in this function returns (OpenRouter Claude/Kimi, Portal Qwen, Alibaba/Qwen), and the function's own docstring says markers go on the envelope for "OpenRouter **and OpenAI-wire proxies**".

@justinbowes also flagged, correctly, that for a plain-string system prompt both layouts are byte-identical — so the headline ~0%→~96% result reproduces under either. The difference is entirely breakpoint placement on tool-result turns, which is what the table above measures.

## Other fixes in commit 2

- **Host matching** — `"litellm" in base_url_hostname(...)` is the substring false-positive class `base_url_hostname`'s own docstring warns against; it granted markers to `notlitellm.attacker.example`, `foolitellmbar.example`, etc. Replaced with a label-token match in a named helper (`_is_litellm_route`), so `litellm` must be a whole dot- or hyphen-delimited token. All three original test hosts still match; a `litellm` **path** segment on an unrelated host still doesn't. (#87039 made the same host-only call deliberately — kept.)
- **Transport gate** — `not is_anthropic_wire` also swept in `codex_responses`, `bedrock_converse`, `codex_app_server`. Now gated on `api_mode == "chat_completions"`.
- **Operator override** — the grant is inferred from a provider/host *name*, but the custom-provider capability lookup was gated on `is_anthropic_wire`, so an explicit `prompt_caching: false` for the route+model was honored on `/v1/messages` and **silently ignored** on `/v1/chat/completions`. The lookup now also runs for a LiteLLM route, and its layout follows the transport rather than the declaration (an explicit `true` must not promote a `chat_completions` request to the native layout). `prompt_caching.cache_ttl: false` already won correctly and still does.

## Validation

| | Before | After |
|---|---|---|
| Grant on LiteLLM `chat_completions` + Claude | `(False, False)` | `(True, False)` |
| Breakpoints honored on that wire | 0 | 4 of 4 |
| Empty marked text blocks (400 shape) | — | 0 |
| Lookalike host `notlitellm.attacker.example` | — | `(False, False)` |
| Explicit `prompt_caching: false` on that wire | ignored | honored |

- **82 tests pass** across `tests/run_agent/test_anthropic_prompt_cache_policy.py` and `tests/agent/test_prompt_cache_ttl_propagation.py`; 165 pass across the wider cache/prompt selection.
- **Mutation-checked**: reverting each fix individually turns its guard red — no vacuous tests.
- **Differential matrix, 9,900 configs vs `origin/main`** (15 providers x 11 base URLs x 6 api_modes x 10 models): 147 behavior changes, **all** of them `(False, False) -> (True, False)`. Zero non-`chat_completions` routes changed, zero non-Claude models changed, zero `(True, True)` anywhere. A lookalike *host* alone never grants — only an explicit litellm provider id does.
- **Perf** (realistic install, `config.yaml` present so the mtime cache engages), vs `origin/main`: live-agent policy 20.6us -> 61.7us; destination planning 219.3us -> 347.7us. Non-LiteLLM routes flat (openrouter Claude ~7.9us).
- Adds the **wire-shape contract** the original matrix was missing: it asserts no breakpoint sits on the message envelope, rather than only checking the returned tuple. That gap is why 15 green tests didn't catch the layout issue.
- `ruff` clean.

Prompt-caching invariants: markers stay request-local (`build_prompt_cache_plan` deep-copies), system-prompt bytes unchanged, `_cache_disabled` early return still precedes every grant. Single chokepoint — main loop, MoA, and auxiliary all resolve through this one function, so no sibling call path needs a separate fix.

## Credit

Original diagnosis, reproduction, measurements, and proposed patch by **@ottosulin** in #84506. Implementation and test matrix by **@justinbowes** in #84982 (cherry-picked here with authorship preserved). The envelope-layout call was raised by **@Enough1122** in #84550/#87039 — this PR confirms it with wire-level measurements, and adopts the host-only matching from #84550.

Depends on #87516 (attribution mapping for `justin@bowes.org`) — merge that first or `check-attribution` fails.

Closes #84982.
