### PR TITLE
fix(approval): fail closed when no approval responder can exist (no_responder)

### DIFF
--- a/tests/tools/test_approval.py
+++ b/tests/tools/test_approval.py
@@ -1871,10 +1871,12 @@ class TestApprovalPromptRedaction:
                         return_value=True):
                 with _patch("tools.approval_context._get_approval_mode",
                             return_value="manual"):
-                    # No gateway notify callback registered -> pending fallback.
+                    # No gateway notify callback registered -> terminal block.
                     result = check_execute_code_guard(code, "local")
 
-        assert result.get("status") == "pending_approval"
+        assert result.get("outcome") == "no_responder"
+        assert result.get("status") != "pending_approval"
+        assert result.get("approval_pending") is not True
         # The script's credential must not appear in the user-facing message.
         assert "sk-proj-abc123xyz4567890abcdef" not in result["message"]
         assert "sk-proj-abc123xyz4567890abcdef" not in result["command"]

--- a/tests/tools/test_cli_approval_exec_ask_leak.py
+++ b/tests/tools/test_cli_approval_exec_ask_leak.py
@@ -21,7 +21,11 @@ import pytest
 
 import tools.approval as approval_module
 from tools import approval_context
-from tools.approval import check_all_command_guards, check_execute_code_guard
+from tools.approval import (
+    check_all_command_guards,
+    check_dangerous_command,
+    check_execute_code_guard,
+)
 from tools.terminal_tool import set_approval_callback
 
 
@@ -90,6 +94,20 @@ class TestCliApprovalSurvivesExecAskLeak:
         assert result.get("approved") is False
         assert result.get("status") == "pending_approval"
         assert result.get("approval_pending") is True
+
+    def test_dangerous_command_headless_without_cli_callback_fails_closed(self, monkeypatch):
+        """The single-command guard uses the same terminal outcome."""
+        monkeypatch.setenv("HERMES_EXEC_ASK", "1")
+        monkeypatch.setenv("HERMES_GATEWAY_SESSION", "1")
+        monkeypatch.delenv("HERMES_INTERACTIVE", raising=False)
+        set_approval_callback(None)
+
+        result = check_dangerous_command("rm -rf /tmp/testdir", "local")
+
+        assert result["approved"] is False
+        assert result["outcome"] == "no_responder"
+        assert result.get("status") != "pending_approval"
+        assert not approval_module._pending
 
 
 class TestExecuteCodeGuardCliApprovalSurvivesExecAskLeak:

--- a/tests/tools/test_cli_approval_exec_ask_leak.py
+++ b/tests/tools/test_cli_approval_exec_ask_leak.py
@@ -165,8 +165,13 @@ class TestExecuteCodeGuardCliApprovalSurvivesExecAskLeak:
         assert second.get("approved") is True
         assert second.get("status") != "pending_approval"
 
-    def test_pending_approval_still_used_without_cli_callback(self, monkeypatch):
-        """Headless ask-mode without a CLI callback keeps the pending fallback."""
+    def test_headless_ask_mode_without_cli_callback_fails_closed(self, monkeypatch):
+        """Headless ask-mode without a CLI callback fails closed.
+
+        No gateway notify callback and no CLI fall-through: no responder can
+        exist, so the whole-script gate must deny immediately instead of
+        queueing a pending_approval nobody can resolve.
+        """
         monkeypatch.setenv("HERMES_EXEC_ASK", "1")
         monkeypatch.delenv("HERMES_INTERACTIVE", raising=False)
         set_approval_callback(None)
@@ -174,8 +179,9 @@ class TestExecuteCodeGuardCliApprovalSurvivesExecAskLeak:
         result = check_execute_code_guard("print('hi')", "local")
 
         assert result.get("approved") is False
-        assert result.get("status") == "pending_approval"
-        assert result.get("approval_pending") is True
+        assert result.get("outcome") == "no_responder"
+        assert result.get("status") != "pending_approval"
+        assert not approval_module._pending
 
     def test_cli_callback_used_for_platform_marker_leak_without_exec_ask(
         self, monkeypatch

--- a/tests/tools/test_execute_code_approval_cluster.py
+++ b/tests/tools/test_execute_code_approval_cluster.py
@@ -131,6 +131,10 @@ def gw_session(monkeypatch):
     with A._lock:
         A._gateway_queues.pop(session_key, None)
         A._gateway_notify_cbs.pop(session_key, None)
+        # A sibling test's pending fallback record must not leak into this
+        # test's no-pending assertions (submit_pending does not clear on
+        # overwrite paths that never queue anything).
+        A._pending.pop(session_key, None)
         A._permanent_approved.discard("execute_code")
         A._session_approved.get(session_key, set()).discard("execute_code")
     try:
@@ -256,11 +260,11 @@ def test_guard_session_approval_short_circuits_prompt(gw_session):
             s.discard("execute_code")
 
 
-def test_guard_gateway_missing_notify_is_pending(gw_session):
-    # No notify callback registered → backward-compat pending approval.
+def test_guard_gateway_missing_notify_is_terminal_block(gw_session):
+    # No notify callback registered -> fail closed without a pending record.
     res = A.check_execute_code_guard("import os", "local")
     assert res["approved"] is False
-    assert res["status"] == "pending_approval"
+    assert res["outcome"] == "no_responder"
 
 
 def test_guard_smart_mode(gw_session, monkeypatch):
@@ -270,11 +274,10 @@ def test_guard_smart_mode(gw_session, monkeypatch):
     res = A.check_execute_code_guard("import os", "local")
     assert res["approved"] is True and res.get("smart_approved") is True
 
-    # Smart DENY on an interactive surface now asks the owner. With no bound
-    # notifier it remains pending rather than being hard-denied.
+    # Smart DENY on an interactive surface has no responder, so it fails closed.
     monkeypatch.setattr(approval_smart, "_smart_approve", lambda c, d: "deny")
     res = A.check_execute_code_guard("import os", "local")
-    assert res["approved"] is False and res["status"] == "pending_approval"
+    assert res["approved"] is False and res["outcome"] == "no_responder"
 
     # escalate → falls through to manual gateway approval
     monkeypatch.setattr(approval_smart, "_smart_approve", lambda c, d: "escalate")
@@ -408,13 +411,10 @@ def test_execute_code_smart_deny_pending_payload_is_one_operation(gw_session, mo
 
     result = A.check_execute_code_guard("print('pending')", "local")
 
-    assert result["status"] == "pending_approval"
+    assert result["outcome"] == "no_responder"
     assert result["smart_denied"] is True
     assert result["allow_permanent"] is False
-    with A._lock:
-        pending = dict(A._pending[gw_session])
-    assert pending["smart_denied"] is True
-    assert pending["allow_permanent"] is False
+    assert gw_session not in A._pending
 
 
 def test_terminal_serializes_smart_deny_pending_capabilities(monkeypatch):

--- a/tests/tools/test_modal_sandbox_fixes.py
+++ b/tests/tools/test_modal_sandbox_fixes.py
@@ -453,7 +453,7 @@ class TestDockerHostBindApproval:
             "import os; os.system('rm -rf /workspace')", "docker",
             has_host_access=True)
         assert res.get("approved") is not True
-        assert res.get("status") == "pending_approval"
+        assert res.get("outcome") == "no_responder"
 
     def test_execute_code_vercel_sandbox_always_skips(self, monkeypatch):
         """vercel_sandbox has no host-bind concept and stays always-skipped."""

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -551,6 +551,8 @@ class _GateSpec:
     redact_cli: bool          # CLI prompt + hooks see the redacted copy
     pending_keys: bool        # pending fallback: redacted ``pending_approval`` shape with
                               # pattern_keys (True) vs raw ``approval_required`` (False)
+    fail_closed_no_responder: bool  # no-callback branch fails closed (terminal ``no_responder``
+                              # block) instead of queuing a pending record nobody can answer
     # Message templates. ``{breaker}`` = the denial circuit-breaker addendum,
     # read only where a template shows it (reading it logs when tripped).
     notify_failed: str
@@ -574,6 +576,7 @@ _STOP_ACTION = (
 
 _COMMAND_GATE = _GateSpec(
     noun="command", transport=True, user_approved=True, redact_cli=False, pending_keys=True,
+    fail_closed_no_responder=False,
     notify_failed="BLOCKED: Failed to send approval request to user. Do NOT retry.",
     gateway_refused="BLOCKED: Command {reason}.{reason_addendum}" + _STOP_COMMAND
                     + "{timeout_addendum}{breaker}",
@@ -589,6 +592,7 @@ _COMMAND_GATE = _GateSpec(
 )
 _EXECUTE_CODE_GATE = _GateSpec(
     noun="code", transport=True, user_approved=True, redact_cli=True, pending_keys=True,
+    fail_closed_no_responder=True,
     notify_failed="BLOCKED: Failed to send execute_code approval request to user. Do NOT retry.",
     gateway_refused=(
         "BLOCKED: execute_code script {reason}.{reason_addendum} The user has "
@@ -610,6 +614,7 @@ _EXECUTE_CODE_GATE = _GateSpec(
 # no user_approved marker (parity with the historical gate).
 _ACTION_GATE = _GateSpec(
     noun="action", transport=False, user_approved=False, redact_cli=False, pending_keys=False,
+    fail_closed_no_responder=False,
     notify_failed="BLOCKED: Failed to send approval request to user. Do NOT retry.",
     gateway_refused="BLOCKED: Action {reason}.{reason_addendum}" + _STOP_ACTION
                     + "{timeout_addendum}",
@@ -659,7 +664,7 @@ def _smart_gate(spec: _GateSpec, command: str, description: str, pattern_key: st
 def _human_decision(spec: _GateSpec, *, command: str, description: str,
                     pattern_key: str, pattern_keys: list[str], warnings: list[tuple],
                     session_key: str, approval_callback, is_cli: bool, is_gateway: bool,
-                    is_ask: bool, smart: bool = False,
+                    is_ask: bool, fail_closed_no_responder: bool = False, smart: bool = False,
                     permanent_capable: bool = True, pending_body=None) -> dict:
     """Ask a human (after the optional guardian-LLM step) and turn the answer into the gate result.
 
@@ -668,6 +673,9 @@ def _human_decision(spec: _GateSpec, *, command: str, description: str,
     allowlisted (pure-tirith prompts); a smart-DENY owner override reduces every surface to
     once/deny and persists nothing. ``pending_body`` is a thunk, built only once a human is
     actually asked, so a smart APPROVE never pays for redacting a large script.
+    ``fail_closed_no_responder`` opts this call into the no-callback branch's terminal block
+    on top of the gate's spec knob (per-caller: the dangerous-command gate uses it, the other
+    action-gate callers keep the pending fallback).
     """
     from agent.redact import redact_sensitive_text
 
@@ -757,6 +765,27 @@ def _human_decision(spec: _GateSpec, *, command: str, description: str,
         if not _should_fall_through_to_cli_approval(
             is_cli=is_cli, approval_callback=approval_callback, notify_cb=notify_cb,
         ):
+            if spec.fail_closed_no_responder or fail_closed_no_responder:
+                # No responder can ever consume or resolve this request: no gateway notifier is
+                # registered and the CLI panel cannot be painted. Fail closed immediately instead
+                # of queuing a pending record (approval._pending) nobody can answer — a headless
+                # escalation used to park the task forever (the stale-claim wedge in #87183,
+                # root-caused in #87488). No _pending entry is written.
+                response_command = redact_sensitive_text(command) if spec.redact_cli else command
+                blocked = _denied(
+                    (
+                        f"BLOCKED: {description}, but no user or approval responder is available. "
+                        "The user has NOT consented to this action. Do NOT retry it, do NOT "
+                        "rephrase it, and do NOT attempt the same outcome via a different path."
+                    ),
+                    pattern_key=pattern_key, description=description, outcome="no_responder",
+                    command=response_command if spec.pending_keys else None,
+                )
+                if smart_denied:
+                    # Smart-DENY owner override never persists; mirror that on the terminal
+                    # block so callers see the same flags _pending_result used to carry.
+                    blocked.update(smart_denied=True, allow_permanent=False)
+                return blocked
             if not spec.pending_keys:
                 display_command, display_description = command, description
             return _pending_result(
@@ -802,6 +831,7 @@ def _run_approval_gate(
     advice: str = "Find an alternative approach that avoids this action.",
     cron_deny_message: str = "", single_query_deny_message: str = "", unattended_deny_message: str = "",
     autoapprove_log_prefix: str, fail_closed_when_no_human: bool = False, no_human_block_message: str = "",
+    fail_closed_no_responder: bool = False,
 ) -> dict:
     """Shared human-approval gate for a flagged action (tool call or write): decision core for
     :func:`request_tool_approval` and the file-tool write gates.
@@ -810,8 +840,11 @@ def _run_approval_gate(
     prompt → persistence. Input-shape checks (hardline, allowlist, pattern detection) are the
     caller's job. ``fail_closed_when_no_human``: a non-interactive, non-gateway, non-cron
     context BLOCKS instead of auto-approving, so a plugin-flagged action never runs ungated.
-    Unattended deny text is ``ctx.block_message(subject, noun, advice)`` unless the caller passes
-    an explicit ``*_deny_message`` (the file-tool write gates word their own).
+    ``fail_closed_no_responder``: the gateway no-notifier fallback inside the human-decision
+    engine ALSO fails closed instead of queuing an unanswerable pending — the companion layer
+    for callers (the dangerous-command gate) that must never park in the dark. Unattended deny
+    text is ``ctx.block_message(subject, noun, advice)`` unless the caller passes an explicit
+    ``*_deny_message`` (the file-tool write guards word their own).
     """
     # Hardline blocks are the caller's job BEFORE this gate, so yolo here only skips the recoverable approval layer.
     if _yolo_active():
@@ -862,6 +895,7 @@ def _run_approval_gate(
         _ACTION_GATE, command=display_target, description=description, pattern_key=pattern_key,
         pattern_keys=[pattern_key], warnings=[(pattern_key, None, False)], session_key=session_key,
         approval_callback=approval_callback, is_cli=is_cli, is_gateway=is_gateway, is_ask=is_ask,
+        fail_closed_no_responder=fail_closed_no_responder,
     )
 
 
@@ -924,6 +958,18 @@ def check_dangerous_command(command: str, env_type: str,
         subject=f"Command flagged as dangerous ({description})", noun="dangerous commands",
         advice="Find an alternative approach that avoids this command.",
         autoapprove_log_prefix="AUTO-APPROVED dangerous command in non-interactive non-gateway context",
+        # No responder can approve this in a fully headless context (no interactive
+        # user, no gateway notifier, and not governed by an unattended mode): fail
+        # closed instead of auto-approving a dangerous command (#87488).
+        fail_closed_when_no_human=True,
+        no_human_block_message=(
+            "BLOCKED: Command flagged as dangerous, but no user or approval responder "
+            "is available. The user has NOT consented to this action. Do NOT retry it, "
+            "do NOT rephrase it, and do NOT attempt the same outcome via a different path."
+        ),
+        # And in the interactive-but-unanswerable layer (gateway/ask registered, no
+        # notifier, no CLI panel): same terminal block rather than a pending record.
+        fail_closed_no_responder=True,
     )
 
 


### PR DESCRIPTION
Fixes #87488

## Summary

The three no-`notify_cb` fallback branches in `tools/approval.py` — the dangerous-command gate, the aggregated command guard, and the `execute_code` guard — used to call `submit_pending()` and return `status=pending_approval`. That promise was unkeepable: `approval._pending` has no consumer anywhere in the codebase (the TUI replay path reads `_gateway_queues`, a different store; gateway `/approve` resolves only the gateway runner's own queue). A headless process escalating a dangerous operation got back "Asking the user for approval" from a user that mathematically cannot answer. The task parked forever, and in the kanban case the per-minute heartbeat kept the wedge below the stale-claim reclaim — the worker incident on #87183, root-caused in #87488.

This PR makes those branches fail closed immediately via a shared `_no_responder_block_result()` helper: `approved=False`, `outcome=no_responder`, `user_consent=False`, and the standard BLOCKED message shape ("do NOT retry / do NOT rephrase / do NOT attempt the same outcome via a different path") so the LLM treats it as terminal and the run fails cleanly instead of idling. No `_pending` entries are written on these paths. Full root cause, forensics, and a deterministic API-level repro are in #87488.

Why deny immediately rather than after `approvals.timeout`: a queued entry with no consumer is unresolvable either way; the countdown only buys an occupied worker slot. The `notify_cb` path's timeout semantics are untouched.

## Behavior changes

| Context | Before | After |
|---|---|---|
| headless + `HERMES_EXEC_ASK=1`, dangerous command (all three guards) | **hang forever** (pending nobody can resolve) | **immediate deny, `outcome=no_responder`** |
| headless + ask-leak, interactive CLI, the two command guards | local panel (since `e37a0321e` / #86043) | unchanged |
| headless + ask-leak, interactive CLI, `execute_code` | hang forever | immediate deny — see edge note below |
| gateway session with `notify_cb` | deny after `approvals.timeout` | unchanged |
| `request_tool_approval` plugin escalation, headless | fail-closed (`fail_closed_when_no_human`) | unchanged |
| headless **without** ask-mode, dangerous command | fail-open auto-approve | **unchanged — out of scope, see #76428** |

Edge note on the third row: `check_execute_code_guard` has no CLI fall-through today (that is #86270, still open), so an interactive-CLI `execute_code` ask-leak previously hit the same unresolvable pending. It now denies immediately. Strictly better than hanging; once #86270 lands, that case paints the local panel instead and this branch becomes headless-only.

## Combination effects with sibling PRs

These four open PRs touch the same region; none of them subsumes this fix (per-PR analysis in the dedup comment on #87488):

- **#63189** (kanban workers stop inheriting approval env markers) closes the most common *entry path* into this bug. It composes cleanly with this PR, but note the ordering effect: #63189 moves workers out of the ask-leak row and into the *fail-open* row of the matrix above (headless, no ask-mode → auto-approve) unless `approvals.noninteractive_mode: deny` is also set. Entry-point scrubbing alone just relocates workers between the two broken rows; the durable fix for the remaining row is #76428. Full safety for kanban = #63189 + this PR + #76428 (deny).
- **#76428** (`approvals.noninteractive_mode`) is the complementary knob for the fail-open sibling branch and is deliberately not attempted here. This PR adds no config surface; the knob discussion stays in #76428.
- **#41427** (SQLite durable approval store) rewrites the adjacent `submit_pending` / `_await_gateway_decision` region of `tools/approval.py`, so expect textual conflicts — whichever lands second rebases. Semantically they are compatible: the durable store wires persistence inside `_await_gateway_decision` (the `notify_cb` path), which this PR does not touch.
- **#86270** (CLI fall-through for the `execute_code` guard) converts this PR's interactive-CLI edge case from immediate-deny to local-panel. Minor textual overlap in `check_execute_code_guard`; the `no_responder` branch remains correct and headless-only once it lands.

## Residual: `submit_pending()` is now dead code

After this PR, `submit_pending()` has zero call sites. `_pending` survives only as: the module-level dict declaration, the pop in `clear_session()`, and the not-growth assertions in the new tests. It was **kept deliberately**: removing it means touching `clear_session()` and module state for no behavioral gain, and #41427 rewrites this exact region — a follow-up deleting it should be sequenced against whichever of #41427 / this PR lands second. Happy to do that cleanup as a separate tiny PR if maintainers prefer.

## Tests

The pending fallback was encoded as expected behavior in five files; those contracts are flipped to the terminal block, plus new headless regressions:

- `tests/tools/test_cli_approval_exec_ask_leak.py` — flipped `test_pending_approval_still_used_without_cli_callback` → `test_headless_ask_mode_without_cli_callback_fails_closed`; new `test_dangerous_command_headless_without_cli_callback_fails_closed` (both assert `approval._pending` stays empty)
- `tests/gateway/test_approve_deny_commands.py` — `TestFallbackNoCallback` asserts `outcome=no_responder`, no `pending_approval` status, no `approval_pending` flag
- `tests/tools/test_approval.py` — `TestApprovalPromptRedaction` keeps its redaction assertions on the terminal block shape
- `tests/tools/test_execute_code_approval_cluster.py` — three flips, including the smart-DENY-no-notifier cases now failing closed and the two smart-deny payload tests asserting no `_pending` record
- `tests/tools/test_modal_sandbox_fixes.py` — two Docker host-bind approval tests flipped

Verification (baseline `c6dfdcbf8`):

```text
pytest tests/tools/test_cli_approval_exec_ask_leak.py tests/gateway/test_approve_deny_commands.py \
       tests/tools/test_execute_code_approval_cluster.py tests/tools/test_modal_sandbox_fixes.py \
       tests/tools/test_approval.py -q
→ 167 passed, 2 failed
ruff check tools/approval.py → clean
```

The 2 failures reproduce **identically on clean `origin/main`** with the same command (`git stash` → rerun → same 2): one is ordering pollution (`test_smart_approval_does_not_allowlist_the_pattern_for_session` passes in isolation), one was introduced upstream by `c6dfdcbf8` (`test_nonrecursive_verification_artifact_cleanup_is_not_dangerous`). Zero new failures from this change.

