### PR TITLE
fix(delegation): report failed children as failed, not completed

### DIFF
--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -667,6 +667,75 @@ class TestDelegateObservability(unittest.TestCase):
             result = json.loads(delegate_task(goal="Test empty sentinel", parent_agent=parent))
             self.assertEqual(result["results"][0]["status"], "failed")
 
+    def test_failed_child_with_error_summary_marks_status_failed(self):
+        """Regression: a child whose loop gave up on a structured failure
+        (``failed=True``, ``completed=False``, e.g. "API call failed after 3
+        retries: HTTP 524") returns that error message as final_response.
+        Status was derived from summary alone, so the non-empty error text
+        made the batch report show the task as ✓ status=completed. The
+        ``failed`` flag must win over a non-empty summary."""
+        parent = _make_mock_parent(depth=0)
+
+        with patch("run_agent.AIAgent") as MockAgent:
+            mock_child = MagicMock()
+            mock_child.model = "claude-sonnet-4-6"
+            mock_child.session_prompt_tokens = 0
+            mock_child.session_completion_tokens = 0
+            mock_child.run_conversation.return_value = {
+                "final_response": (
+                    "API call failed after 3 retries: HTTP 524 — origin timeout"
+                ),
+                "completed": False,
+                "failed": True,
+                "error": "HTTP 524 — origin timeout",
+                "failure_reason": "server_error",
+                "interrupted": False,
+                "api_calls": 3,
+                "messages": [],
+            }
+            MockAgent.return_value = mock_child
+
+            result = json.loads(
+                delegate_task(goal="Test failed child", parent_agent=parent)
+            )
+            entry = result["results"][0]
+            self.assertEqual(entry["status"], "failed")
+            # The classified reason must survive into the batch entry so the
+            # parent can tell a quota wall from a real task error.
+            self.assertEqual(entry["failure_reason"], "server_error")
+            self.assertEqual(entry["error"], "HTTP 524 — origin timeout")
+            # A structured failure is not budget truncation.
+            self.assertEqual(entry["exit_reason"], "error")
+            self.assertFalse(entry["truncated"])
+
+    def test_successful_child_still_completed(self):
+        """Control for the failed-flag check: a child that succeeds
+        (``completed=True``, no ``failed`` flag) must keep reporting
+        status=completed — the fix must not change success behavior."""
+        parent = _make_mock_parent(depth=0)
+
+        with patch("run_agent.AIAgent") as MockAgent:
+            mock_child = MagicMock()
+            mock_child.model = "claude-sonnet-4-6"
+            mock_child.session_prompt_tokens = 0
+            mock_child.session_completion_tokens = 0
+            mock_child.run_conversation.return_value = {
+                "final_response": "All done.",
+                "completed": True,
+                "interrupted": False,
+                "api_calls": 2,
+                "messages": [],
+            }
+            MockAgent.return_value = mock_child
+
+            result = json.loads(
+                delegate_task(goal="Test success control", parent_agent=parent)
+            )
+            entry = result["results"][0]
+            self.assertEqual(entry["status"], "completed")
+            self.assertEqual(entry["exit_reason"], "completed")
+            self.assertNotIn("failure_reason", entry)
+
 
 class TestSubagentCostRollup(unittest.TestCase):
     """Port of Kilo-Org/kilocode#9448 — parent's session_estimated_cost_usd

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -2850,8 +2850,18 @@ def _run_single_child(
         # it instead of silently accepting zero-content "success".
         _empty_sentinel = summary.strip() == "(empty)"
 
+        # The child loop returns ``failed=True`` (with ``completed=False``)
+        # when it gave up on a structured failure — e.g. "API call failed
+        # after N retries: HTTP 524".  In that case ``final_response`` is an
+        # error message, not usable output, so a non-empty summary must NOT
+        # be read as success.  Deriving status from summary alone reported
+        # these children as "completed" with a ✓ in the batch report.
+        _child_failed = bool(result.get("failed"))
+
         if interrupted:
             status = "interrupted"
+        elif _child_failed:
+            status = "failed"
         elif summary and not _empty_sentinel:
             # A summary means the subagent produced usable output.
             # exit_reason ("completed" vs "max_iterations") already
@@ -2903,6 +2913,10 @@ def _run_single_child(
             exit_reason = "interrupted"
         elif completed:
             exit_reason = "completed"
+        elif _child_failed:
+            # A structured child failure is not budget truncation — reporting
+            # it as "max_iterations" would also set truncated=True below.
+            exit_reason = "error"
         else:
             exit_reason = "max_iterations"
 
@@ -2966,6 +2980,12 @@ def _run_single_child(
         )
         if status == "failed":
             entry["error"] = result.get("error", "Subagent did not produce a response.")
+            # Classified reason from the child loop (e.g. "rate_limit",
+            # "billing", "server_error") — lets the parent distinguish a
+            # quota wall from a real task error without parsing prose.
+            _failure_reason = result.get("failure_reason")
+            if isinstance(_failure_reason, str) and _failure_reason:
+                entry["failure_reason"] = _failure_reason
 
         # T1-24: schema-validation outcome — emitted ONLY when a schema was
         # requested, so legacy (schema-less) payloads keep their exact shape.


### PR DESCRIPTION
## Symptom

A delegation batch report shows a task whose final response is an error message — e.g. `API call failed after 3 retries: HTTP 524 …` — as **`✓ status=completed`**. The parent then treats the error text as a successful subagent summary.

## Reproduction

Dispatch `delegate_task` and have the child's provider fail all retries (any structured failure — 524 origin timeout, 5xx, exhausted retries). The child loop returns:

```python
{
    "final_response": "API call failed after 3 retries: HTTP 524 …",
    "completed": False,
    "failed": True,
    "failure_reason": "server_error",
    ...
}
```

The batch report renders the task with a ✓ and `status=completed`; `exit_reason` comes out as `max_iterations` and `truncated=True`, both wrong.

## Root cause

`_run_single_child` (tools/delegate_tool.py) derives the entry status from the summary alone:

```python
elif summary and not _empty_sentinel:
    status = "completed"
```

`agent/conversation_loop.py` returns the error message *as* `final_response` alongside `completed=False / failed=True / failure_reason=…`, so the non-empty error text satisfies the summary check. The `failed` flag is never consulted anywhere in `delegate_tool.py` (`grep 'result.get("failed")'` → no hits before this change). Only the `"(empty)"` sentinel was mapped to failed. The ✓ icon then follows from `status == "completed"`.

Both the single-task path and the batch executor path funnel through `_run_single_child`, so this one status-determination site is the shared choke point — the fix there covers the whole class.

## Fix

At the status-determination site in `_run_single_child`:

- `failed=True` on the child result now wins over a non-empty summary → `status="failed"`.
- The child's classified `failure_reason` (`rate_limit` / `billing` / `server_error` / …) is propagated onto the batch entry, so the parent can distinguish a quota wall from a real task error without parsing prose (same intent as the existing kanban-worker consumer of this field).
- `exit_reason` for a structured failure is `"error"` instead of falling through to `"max_iterations"`, which also wrongly set `truncated=True`.

Successful children (`completed=True`, no `failed` flag) are untouched.

## Tests

`tests/tools/test_delegate.py`, following the existing `test_empty_sentinel_marks_status_failed` idiom (behavior contract on the child-result → batch-entry relation, no snapshots):

- `test_failed_child_with_error_summary_marks_status_failed` — **red on current main** (`AssertionError: 'completed' != 'failed'`), green with the fix. Asserts `status`, `failure_reason`, `error`, `exit_reason`, `truncated`.
- `test_successful_child_still_completed` — control: success behavior unchanged, no `failure_reason` key leaks onto completed entries.

```
tests/tools/test_delegate.py ................ 68 passed
delegation-related suites (test_delegate, test_async_delegation,
test_delegate_batch_validation, test_delegate_output_schema,
test_delegation_live_log, test_subagent_steer,
test_delegate_cascade_49148, test_delegate_kanban_isolation,
test_delegate_subagent_timeout_diagnostic) ... 189 passed
test_delegate_apiserver_background + test_zombie_process_cleanup ... 18 passed
```
