### PR TITLE
feat(skills): gmail send/reply --body-file for shell-safe bodies

### DIFF
--- a/skills/productivity/google-workspace/scripts/google_api.py
+++ b/skills/productivity/google-workspace/scripts/google_api.py
@@ -1071,7 +1071,10 @@ def main():
     p = gmail_sub.add_parser("send")
     p.add_argument("--to", required=True)
     p.add_argument("--subject", required=True)
-    p.add_argument("--body", required=True)
+    body_group = p.add_mutually_exclusive_group(required=True)
+    body_group.add_argument("--body")
+    body_group.add_argument("--body-file", dest="body_file", metavar="FILE",
+                            help="Read body from file (avoids shell escaping issues)")
     p.add_argument("--cc", default="")
     p.add_argument("--from", dest="from_header", default="", help="Custom From header (e.g. '\"Agent Name\" <user@example.com>')")
     p.add_argument("--html", action="store_true", help="Send body as HTML")
@@ -1080,7 +1083,10 @@ def main():
 
     p = gmail_sub.add_parser("reply")
     p.add_argument("message_id", help="Message ID to reply to")
-    p.add_argument("--body", required=True)
+    body_group = p.add_mutually_exclusive_group(required=True)
+    body_group.add_argument("--body")
+    body_group.add_argument("--body-file", dest="body_file", metavar="FILE",
+                            help="Read body from file (avoids shell escaping issues)")
     p.add_argument("--from", dest="from_header", default="", help="Custom From header (e.g. '\"Agent Name\" <user@example.com>')")
     p.set_defaults(func=gmail_reply)
 
@@ -1218,6 +1224,9 @@ def main():
     p.set_defaults(func=docs_append)
 
     args = parser.parse_args()
+    if getattr(args, "body_file", None):
+        with open(args.body_file) as _bf:
+            args.body = _bf.read()
     args.func(args)
 
 

--- a/tests/skills/test_google_workspace_api.py
+++ b/tests/skills/test_google_workspace_api.py
@@ -195,3 +195,33 @@ def test_api_get_credentials_refresh_persists_authorized_user_type(api_module, m
     assert isinstance(creds, FakeCredentials)
     assert saved["token"] == "ya29.refreshed"
     assert saved["type"] == "authorized_user"
+
+
+def test_gmail_send_body_file_reads_file(api_module, tmp_path, monkeypatch):
+    """--body-file loads the message body from disk before dispatch."""
+    body_path = tmp_path / "body.txt"
+    body_path.write_text("Hello from a file\nwith 'quotes' and $vars intact.")
+
+    captured = {}
+    monkeypatch.setattr(
+        api_module, "gmail_send", lambda args: captured.update(body=args.body)
+    )
+    monkeypatch.setattr(
+        sys, "argv",
+        ["google_api.py", "gmail", "send", "--to", "a@b.c",
+         "--subject", "s", "--body-file", str(body_path)],
+    )
+    api_module.main()
+    assert captured["body"] == body_path.read_text()
+
+
+def test_gmail_send_body_and_body_file_mutually_exclusive(api_module, monkeypatch, capsys):
+    """Passing both --body and --body-file is an argparse error."""
+    monkeypatch.setattr(
+        sys, "argv",
+        ["google_api.py", "gmail", "send", "--to", "a@b.c",
+         "--subject", "s", "--body", "x", "--body-file", "y"],
+    )
+    with pytest.raises(SystemExit):
+        api_module.main()
+    assert "not allowed with" in capsys.readouterr().err


### PR DESCRIPTION
## Summary

- Add a `--body-file` alternative to `--body` on the google-workspace skill's `gmail send` and `gmail reply` subcommands, reading the message body from a file.
- `--body` and `--body-file` are a required mutually-exclusive pair — exactly one must be given, so existing callers are unaffected.
- Tests: body loaded verbatim from file (quotes/`$vars`/newlines intact); passing both flags is an argparse error.

## Why

Long or multi-line bodies — cron-generated emails, agent-drafted replies — currently require fragile shell escaping when the skill is driven via the terminal tool: quotes, backticks, and `$vars` in the body break the command line or arrive mangled. Writing the body to a temp file and passing `--body-file` sidesteps quoting entirely.

Searched open/merged PRs and issues for prior art on this flag; found none (kanban grew an analogous body-file input in #86991).

## Validation

- `pytest tests/skills/test_google_workspace_api.py` — 6 passed (4 existing + 2 new).
- Field-tested since 2026-08-03 driving a daily cron email pipeline (`gmail send --body-file` from a scheduler-invoked script).