### PR TITLE
fix(cron): route --model/--provider job pins through the selection-guard registry

### DIFF
--- a/hermes_cli/cron.py
+++ b/hermes_cli/cron.py
@@ -526,6 +526,12 @@ def cron_edit(args):
         print(color(f"Job not found: {args.job_id}", Colors.RED))
         return 1
 
+    # Same guard as `cron create`, but the job already exists, so hand the
+    # stored row over: `cron edit --provider <p>` with no --model re-routes the
+    # job's CURRENT pin, and that is the pair the guard has to judge.
+    if not _confirm_pinned_model(args, existing_job=job):
+        return 1
+
     existing_skills = list(job.get("skills") or ([] if not job.get("skill") else [job.get("skill")]))
     replacement_skills = _normalize_skills(getattr(args, "skill", None), getattr(args, "skills", None))
     add_skills = _normalize_skills(None, getattr(args, "add_skills", None)) or []

--- a/hermes_cli/cron.py
+++ b/hermes_cli/cron.py
@@ -6,6 +6,7 @@ pause/resume/run/remove, status, and tick.
 """
 
 import json
+import logging
 import sys
 from pathlib import Path
 from typing import Iterable, List, Optional
@@ -14,6 +15,8 @@ PROJECT_ROOT = Path(__file__).parent.parent.resolve()
 sys.path.insert(0, str(PROJECT_ROOT))
 
 from hermes_cli.colors import Colors, color
+
+logger = logging.getLogger(__name__)
 
 # Gateway-lifecycle command detection lives in ``cron.lifecycle_guard`` so it
 # can be shared across every job-creation path (CLI + the agent's ``cronjob``
@@ -339,6 +342,120 @@ def _print_active_jobs_summary(jobs) -> None:
             print(f"  Next run: {min(next_runs)}")
     else:
         print("  No active jobs")
+
+
+def _confirm_pinned_model(args, existing_job: Optional[dict] = None) -> bool:
+    """Run the selection-guard registry over a ``--model``/``--provider`` pin.
+
+    ``hermes cron create/edit --model`` is a model-selection surface, but it is
+    the one surface the unified registry never reached. ``hermes_cli.
+    model_selection_guards`` enumerates its call sites as "CLI picker, TUI,
+    dashboard, gateway ``/model``, Telegram/Discord pickers, TUI-gateway RPC" —
+    cron is on neither that list nor in the registry's callers. The pin flag
+    predates the registry, so the same model id that prints a cost or
+    data-training block and demands ``[y/N]`` as ``hermes -m <id>`` is stored
+    here in silence.
+
+    Create/edit time is also the ONLY moment a confirm is possible. The
+    scheduler resolves ``job["model"]`` and constructs the ``AIAgent``
+    in-process inside the gateway (``cron/scheduler.py``); it never re-enters
+    ``hermes_cli/main.py``, so ``_confirm_startup_expensive_model_override``
+    structurally cannot fire for a scheduled run — and a scheduled run has no
+    human at the terminal in any case. An unconfirmed pin therefore keeps
+    spending, or keeps shipping prompts to a training tier, on every tick.
+
+    Returns ``True`` when the pin may proceed (nothing pinned, no guard fired,
+    or the user confirmed) and ``False`` when the caller must abort. Evaluation
+    is fail-open: the registry's own contract is that "a misbehaving guard must
+    never break model selection", so any failure in here lets the job through.
+    """
+    explicit_model = str(getattr(args, "model", None) or "").strip()
+    explicit_provider = str(getattr(args, "model_provider", None) or "").strip()
+    if not explicit_model and not explicit_provider:
+        # Nothing is being pinned on this invocation. This also covers
+        # ``--model ""`` / ``--provider ""``, which CLEAR an existing pin —
+        # de-escalating back to the fleet default never needs a confirm.
+        return True
+
+    try:
+        from hermes_cli.config import load_config_readonly
+        from hermes_cli.model_selection_guards import combined_selection_warning
+    except Exception as exc:
+        logger.warning("cron model selection guard unavailable: %s", exc)
+        return True
+
+    try:
+        cfg = load_config_readonly()
+    except Exception as exc:
+        logger.warning("cron model selection guard could not load config: %s", exc)
+        cfg = {}
+    if not isinstance(cfg, dict):
+        cfg = {}
+    model_cfg = cfg.get("model")
+    if not isinstance(model_cfg, dict):
+        model_cfg = {}
+    cron_cfg = cfg.get("cron")
+    if not isinstance(cron_cfg, dict):
+        cron_cfg = {}
+    job = existing_job if isinstance(existing_job, dict) else {}
+
+    # Mirror the scheduler's documented precedence ("per-job override >
+    # cron.model > HERMES_MODEL env > config.yaml ``model:``") so the guard
+    # sees the model the job will actually run on when only ``--provider`` is
+    # pinned. ``HERMES_MODEL`` is deliberately not consulted: it belongs to the
+    # gateway process's environment, not this CLI's, and it can only decide the
+    # outcome when there is no explicit pin and no ``cron.model`` — i.e. when
+    # nothing is being pinned here anyway.
+    model = (
+        explicit_model
+        or str(job.get("model") or "").strip()
+        or str(cron_cfg.get("model") or "").strip()
+        or str(model_cfg.get("default") or "").strip()
+    )
+    if not model:
+        return True
+    provider = (
+        explicit_provider
+        or str(job.get("provider") or "").strip()
+        or str(cron_cfg.get("model_provider") or "").strip()
+        or str(model_cfg.get("provider") or "").strip()
+    )
+
+    try:
+        warning = combined_selection_warning(
+            model,
+            provider=provider,
+            base_url=str(model_cfg.get("base_url") or ""),
+            api_key=str(model_cfg.get("api_key") or ""),
+        )
+    except Exception as exc:
+        logger.warning(
+            "cron model selection guard failed for %s/%s: %s", provider, model, exc
+        )
+        return True
+    if warning is None:
+        return True
+
+    sys.stderr.write(warning.message + "\n")
+    if not sys.stdin.isatty():
+        # A scheduled job outlives this shell, so an unconfirmed pin cannot be
+        # walked back the way an interactive `hermes -m` invocation can. Refuse
+        # rather than store it. Nothing changes for a job whose model fires no
+        # guard, which is the overwhelmingly common case.
+        sys.stderr.write(
+            "Refusing to pin this model on a scheduled job in non-interactive "
+            "mode. Run interactively and confirm if you intend to use it.\n"
+        )
+        return False
+
+    try:
+        reply = input("Pin this model for every scheduled run? [y/N] ").strip().lower()
+    except (EOFError, KeyboardInterrupt):
+        reply = ""
+    if reply in {"y", "yes"}:
+        return True
+    sys.stderr.write("Model pin cancelled.\n")
+    return False
 
 
 def cron_create(args):

--- a/hermes_cli/cron.py
+++ b/hermes_cli/cron.py
@@ -369,8 +369,10 @@ def _confirm_pinned_model(args, existing_job: Optional[dict] = None) -> bool:
     is fail-open: the registry's own contract is that "a misbehaving guard must
     never break model selection", so any failure in here lets the job through.
     """
-    explicit_model = str(getattr(args, "model", None) or "").strip()
-    explicit_provider = str(getattr(args, "model_provider", None) or "").strip()
+    raw_model = getattr(args, "model", None)
+    raw_provider = getattr(args, "model_provider", None)
+    explicit_model = str(raw_model or "").strip()
+    explicit_provider = str(raw_provider or "").strip()
     if not explicit_model and not explicit_provider:
         # Nothing is being pinned on this invocation. This also covers
         # ``--model ""`` / ``--provider ""``, which CLEAR an existing pin —
@@ -399,6 +401,20 @@ def _confirm_pinned_model(args, existing_job: Optional[dict] = None) -> bool:
         cron_cfg = {}
     job = existing_job if isinstance(existing_job, dict) else {}
 
+    # An axis passed as "" is CLEARED by this very command, so the stored row
+    # must not supply it: `cron edit --model "" --provider <p>` leaves the job
+    # following cron.model / model.default, and that is the pair to judge — not
+    # the pin being removed. An axis that was not passed at all (``None``) does
+    # still inherit from the job.
+    job_model = (
+        "" if (raw_model is not None and not explicit_model)
+        else str(job.get("model") or "").strip()
+    )
+    job_provider = (
+        "" if (raw_provider is not None and not explicit_provider)
+        else str(job.get("provider") or "").strip()
+    )
+
     # Mirror the scheduler's documented precedence ("per-job override >
     # cron.model > HERMES_MODEL env > config.yaml ``model:``") so the guard
     # sees the model the job will actually run on when only ``--provider`` is
@@ -408,7 +424,7 @@ def _confirm_pinned_model(args, existing_job: Optional[dict] = None) -> bool:
     # nothing is being pinned here anyway.
     model = (
         explicit_model
-        or str(job.get("model") or "").strip()
+        or job_model
         or str(cron_cfg.get("model") or "").strip()
         or str(model_cfg.get("default") or "").strip()
     )
@@ -416,7 +432,7 @@ def _confirm_pinned_model(args, existing_job: Optional[dict] = None) -> bool:
         return True
     provider = (
         explicit_provider
-        or str(job.get("provider") or "").strip()
+        or job_provider
         or str(cron_cfg.get("model_provider") or "").strip()
         or str(model_cfg.get("provider") or "").strip()
     )

--- a/hermes_cli/cron.py
+++ b/hermes_cli/cron.py
@@ -459,6 +459,12 @@ def _confirm_pinned_model(args, existing_job: Optional[dict] = None) -> bool:
 
 
 def cron_create(args):
+    # Selection-time guards run BEFORE the job is stored: once written, the job
+    # fires unattended inside the gateway, where no confirm prompt is possible.
+    # No-ops unless --model/--provider was passed and a guard actually fires.
+    if not _confirm_pinned_model(args):
+        return 1
+
     # The gateway-lifecycle guard lives in cron.jobs.create_job so it fires on
     # every job-creation path (this CLI subcommand AND the agent's `cronjob`
     # model tool, which calls create_job directly). When it blocks, create_job

--- a/tests/hermes_cli/test_cron_model_selection_guard.py
+++ b/tests/hermes_cli/test_cron_model_selection_guard.py
@@ -1,0 +1,300 @@
+"""`hermes cron create/edit --model` must run the selection-guard registry.
+
+`hermes_cli.model_selection_guards` is the single evaluation point for
+selection-time guards, and its module docstring enumerates the surfaces that
+call it: CLI picker, TUI, dashboard, gateway `/model`, Telegram/Discord
+pickers, TUI-gateway RPC. Cron is on none of them, even though `--model` pins
+the model an unattended job runs on every tick.
+
+There is no second chance later: `cron/scheduler.py` reads `job["model"]` and
+constructs the `AIAgent` in-process inside the gateway, so it never re-enters
+`hermes_cli/main.py` and `_confirm_startup_expensive_model_override` cannot
+fire for a scheduled run. Create/edit time is the only reachable confirm point.
+
+`muse-spark-1.2-contributor` is the repo's own data-training-tier id (see
+`hermes_cli/model_data_policy_guard.py`), so these tests drive the real
+registry end to end instead of stubbing a warning payload. The provider is
+left as "custom" / unset throughout, which keeps the cost guard's pricing
+lookups offline.
+"""
+
+import io
+import sys
+from argparse import Namespace
+
+import pytest
+
+from hermes_cli import cron as cron_cli
+
+CONTRIBUTOR_MODEL = "muse-spark-1.2-contributor"
+ORDINARY_MODEL = "some/ordinary-model"
+
+
+class _FakeTtyStdin(io.StringIO):
+    """stdin that reports itself as a terminal, so the confirm branch runs."""
+
+    def isatty(self) -> bool:
+        return True
+
+
+@pytest.fixture(autouse=True)
+def stub_config(monkeypatch):
+    """Keep the guard off the developer's real on-disk config.yaml."""
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config_readonly",
+        lambda: {"model": {"default": ORDINARY_MODEL}},
+    )
+
+
+@pytest.fixture()
+def api_calls(monkeypatch):
+    """Record `_cron_api` calls instead of writing to the real job store."""
+    calls = []
+
+    def _fake_api(**kwargs):
+        calls.append(kwargs)
+        return {
+            "success": True,
+            "job_id": "job-1",
+            "name": "Nightly digest",
+            "schedule": "*/10 * * * *",
+            "next_run_at": "2026-01-01T00:00:00Z",
+            "job": {
+                "job_id": "job-1",
+                "name": "Nightly digest",
+                "schedule": "*/10 * * * *",
+            },
+        }
+
+    monkeypatch.setattr(cron_cli, "_cron_api", _fake_api)
+    monkeypatch.setattr(cron_cli, "_warn_if_gateway_not_running", lambda: None)
+    return calls
+
+
+@pytest.fixture()
+def stored_job(monkeypatch):
+    """A job already on a schedule, returned by `cron edit`'s ref lookup."""
+    job = {
+        "id": "job-1",
+        "name": "Nightly digest",
+        "schedule": "*/10 * * * *",
+        "model": None,
+        "provider": None,
+        "skills": [],
+    }
+    monkeypatch.setattr("cron.jobs.resolve_job_ref", lambda ref: job)
+    return job
+
+
+def _answer(monkeypatch, reply):
+    """Make the confirm prompt interactive and answer it with `reply`."""
+    monkeypatch.setattr(sys, "stdin", _FakeTtyStdin(reply + "\n"))
+    monkeypatch.setattr("builtins.input", lambda prompt="": reply)
+
+
+def _non_interactive(monkeypatch):
+    monkeypatch.setattr(sys, "stdin", io.StringIO(""))
+
+
+def _never_prompts(monkeypatch):
+    def _boom(prompt=""):
+        raise AssertionError("the guard prompted when no warning should fire")
+
+    monkeypatch.setattr("builtins.input", _boom)
+
+
+def _create_args(**overrides):
+    args = Namespace(
+        cron_command="create",
+        schedule="*/10 * * * *",
+        prompt="Summarize my inbox",
+        name="Nightly digest",
+        deliver=None,
+        repeat=None,
+        skill=None,
+        skills=None,
+        script=None,
+        workdir=None,
+        model=None,
+        model_provider=None,
+        no_agent=False,
+        monitor_script=None,
+        monitor_url=None,
+    )
+    for key, value in overrides.items():
+        setattr(args, key, value)
+    return args
+
+
+def _edit_args(**overrides):
+    args = Namespace(
+        cron_command="edit",
+        job_id="job-1",
+        schedule=None,
+        prompt=None,
+        name=None,
+        deliver=None,
+        repeat=None,
+        skill=None,
+        skills=None,
+        clear_skills=False,
+        add_skills=None,
+        remove_skills=None,
+        script=None,
+        workdir=None,
+        model=None,
+        model_provider=None,
+        no_agent=None,
+        monitor_script=None,
+        monitor_url=None,
+    )
+    for key, value in overrides.items():
+        setattr(args, key, value)
+    return args
+
+
+class TestCronCreatePinGuard:
+
+    def test_declined_pin_never_reaches_the_job_store(
+        self, monkeypatch, api_calls, capsys
+    ):
+        _answer(monkeypatch, "n")
+
+        rc = cron_cli.cron_create(_create_args(model=CONTRIBUTOR_MODEL))
+
+        assert rc == 1
+        assert api_calls == [], "a declined pin must not create the job"
+        err = capsys.readouterr().err
+        assert "TRAINS ON YOUR DATA" in err
+        assert "Model pin cancelled." in err
+
+    def test_confirmed_pin_is_stored_after_the_warning_is_shown(
+        self, monkeypatch, api_calls, capsys
+    ):
+        _answer(monkeypatch, "y")
+
+        rc = cron_cli.cron_create(_create_args(model=CONTRIBUTOR_MODEL))
+
+        assert rc == 0
+        assert len(api_calls) == 1
+        assert api_calls[0]["model"] == CONTRIBUTOR_MODEL
+        # The block has to actually reach the user — a confirm nobody was
+        # shown is the bug, not the fix.
+        assert "TRAINS ON YOUR DATA" in capsys.readouterr().err
+
+    def test_non_interactive_pin_is_refused(self, monkeypatch, api_calls, capsys):
+        _non_interactive(monkeypatch)
+
+        rc = cron_cli.cron_create(_create_args(model=CONTRIBUTOR_MODEL))
+
+        assert rc == 1
+        assert api_calls == []
+        err = capsys.readouterr().err
+        assert "TRAINS ON YOUR DATA" in err
+        assert "non-interactive mode" in err
+
+    def test_provider_only_pin_is_judged_against_the_configured_default(
+        self, monkeypatch, api_calls
+    ):
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config_readonly",
+            lambda: {"model": {"default": CONTRIBUTOR_MODEL}},
+        )
+        _answer(monkeypatch, "n")
+
+        rc = cron_cli.cron_create(_create_args(model_provider="custom"))
+
+        assert rc == 1
+        assert api_calls == []
+
+    def test_pin_that_fires_no_guard_is_not_blocked(self, monkeypatch, api_calls):
+        _never_prompts(monkeypatch)
+
+        rc = cron_cli.cron_create(_create_args(model=ORDINARY_MODEL))
+
+        assert rc == 0
+        assert len(api_calls) == 1
+
+    def test_no_pin_never_evaluates_the_guard(self, monkeypatch, api_calls):
+        evaluated = []
+        monkeypatch.setattr(
+            "hermes_cli.model_selection_guards.combined_selection_warning",
+            lambda *args, **kwargs: evaluated.append(args),
+        )
+        _never_prompts(monkeypatch)
+
+        rc = cron_cli.cron_create(_create_args())
+
+        assert rc == 0
+        assert evaluated == [], "the common path must not touch the registry"
+        assert len(api_calls) == 1
+
+    def test_guard_failure_never_blocks_job_creation(self, monkeypatch, api_calls):
+        def _boom(*args, **kwargs):
+            raise RuntimeError("bad guard")
+
+        monkeypatch.setattr(
+            "hermes_cli.model_selection_guards.combined_selection_warning", _boom
+        )
+        _never_prompts(monkeypatch)
+
+        rc = cron_cli.cron_create(_create_args(model=CONTRIBUTOR_MODEL))
+
+        assert rc == 0
+        assert len(api_calls) == 1
+
+
+class TestCronEditPinGuard:
+
+    def test_declined_pin_never_updates_the_job(
+        self, monkeypatch, api_calls, stored_job, capsys
+    ):
+        _answer(monkeypatch, "n")
+
+        rc = cron_cli.cron_edit(_edit_args(model=CONTRIBUTOR_MODEL))
+
+        assert rc == 1
+        assert api_calls == [], "a declined pin must not update the job"
+        err = capsys.readouterr().err
+        assert "TRAINS ON YOUR DATA" in err
+        assert "Model pin cancelled." in err
+
+    def test_provider_only_pin_is_judged_against_the_jobs_current_model(
+        self, monkeypatch, api_calls, stored_job
+    ):
+        # Re-routing an existing pin to another provider must be judged against
+        # the model the job is actually pinned to, not the config default.
+        stored_job["model"] = CONTRIBUTOR_MODEL
+        _answer(monkeypatch, "n")
+
+        rc = cron_cli.cron_edit(_edit_args(model_provider="custom"))
+
+        assert rc == 1
+        assert api_calls == []
+
+    def test_confirmed_pin_is_stored_after_the_warning_is_shown(
+        self, monkeypatch, api_calls, stored_job, capsys
+    ):
+        _answer(monkeypatch, "y")
+
+        rc = cron_cli.cron_edit(_edit_args(model=CONTRIBUTOR_MODEL))
+
+        assert rc == 0
+        assert len(api_calls) == 1
+        assert api_calls[0]["model"] == CONTRIBUTOR_MODEL
+        assert "TRAINS ON YOUR DATA" in capsys.readouterr().err
+
+    def test_clearing_a_pin_is_never_guarded(
+        self, monkeypatch, api_calls, stored_job
+    ):
+        # `--model ""` is the documented way to drop back to cron.model /
+        # model.default. De-escalation must not prompt, even on a job whose
+        # current pin would fire every guard in the registry.
+        stored_job["model"] = CONTRIBUTOR_MODEL
+        _never_prompts(monkeypatch)
+
+        rc = cron_cli.cron_edit(_edit_args(model="", model_provider=""))
+
+        assert rc == 0
+        assert len(api_calls) == 1
+        assert api_calls[0]["model"] == ""

--- a/tests/hermes_cli/test_cron_model_selection_guard.py
+++ b/tests/hermes_cli/test_cron_model_selection_guard.py
@@ -284,6 +284,41 @@ class TestCronEditPinGuard:
         assert api_calls[0]["model"] == CONTRIBUTOR_MODEL
         assert "TRAINS ON YOUR DATA" in capsys.readouterr().err
 
+    def test_clearing_the_model_while_setting_a_provider_drops_the_old_pin(
+        self, monkeypatch, api_calls, stored_job
+    ):
+        # `--model ""` removes the pin in the same command that sets a
+        # provider, so the guard must judge what the job will run on AFTER the
+        # edit (the fleet default), not the model being taken away.
+        stored_job["model"] = CONTRIBUTOR_MODEL
+        _never_prompts(monkeypatch)
+
+        rc = cron_cli.cron_edit(_edit_args(model="", model_provider="custom"))
+
+        assert rc == 0
+        assert len(api_calls) == 1
+
+    def test_clearing_the_model_falls_through_to_the_cron_fleet_default(
+        self, monkeypatch, api_calls, stored_job
+    ):
+        # The other half of the same rule: once the job's own pin is dropped,
+        # resolution continues down the scheduler's chain, so a guarded
+        # cron.model must still be caught.
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config_readonly",
+            lambda: {
+                "cron": {"model": CONTRIBUTOR_MODEL},
+                "model": {"default": ORDINARY_MODEL},
+            },
+        )
+        stored_job["model"] = ORDINARY_MODEL
+        _answer(monkeypatch, "n")
+
+        rc = cron_cli.cron_edit(_edit_args(model="", model_provider="custom"))
+
+        assert rc == 1
+        assert api_calls == []
+
     def test_clearing_a_pin_is_never_guarded(
         self, monkeypatch, api_calls, stored_job
     ):


### PR DESCRIPTION
## What does this PR do?

`hermes cron create/edit --model <id>` is a model-selection surface that never reaches the selection-guard registry, so it stores any model id in silence — including ids that every other surface refuses to accept without an explicit `[y/N]`.

**The invariant this restores is the repo's own.** `91665309429` *"feat(models): unify selection-time guards into one registry across all surfaces"* states that **all seven** model-selection surfaces now call the registry, and `hermes_cli/model_selection_guards.py`'s module docstring repeats the list: *CLI picker, TUI, dashboard, gateway `/model`, Telegram/Discord pickers, TUI-gateway RPC*. `hermes cron create/edit --model` is on neither list, and it is not in the registry's callers.

The omission is an ordering artifact, not a decision. `d464ae3652c` *"feat(cron): user-owned model pins + cron.model fleet default"* landed 2026-07-28, **17 days before** the sweep (`git merge-base --is-ancestor d464ae3652c 91665309429` → true), and the cost guard itself (`af978ecb17e`) predates both. The surface existed for both and the enumeration simply missed it.

This is the same shape as `6f53373eb2e` *"fix(cli): route startup guard through the selection-guard registry; cover the light oneshot fast-path"*, whose body calls itself the **third sibling site**. This is the fourth.

### The guard cannot fire later — create/edit time is the only reachable confirm point

This is the load-bearing half, because the obvious objection is "the startup guard catches it when the job runs".

- `cron/scheduler.py` reads `model = job.get("model") or os.getenv("HERMES_MODEL") or ""` and constructs `AIAgent(...)` **in-process inside the gateway**. It never re-enters `hermes_cli/main.py`, so `_confirm_startup_expensive_model_override` is structurally unreachable for a scheduled run.
- `git grep -nE "combined_selection_warning|selection_warnings|_confirm_startup_expensive" -- cron/ tools/cronjob_tools.py` → empty. Nothing in the cron path evaluates a guard.
- Cron never shells out to `hermes -m …` either, so there is no subprocess path back into the startup guard.
- A scheduled run is unattended by definition, so even a reachable prompt would have nobody to answer it.

**In-repo contrast:** the sibling "pin an unattended worker to a model" feature *is* guarded — `hermes_cli/kanban_db.py` builds `cmd.extend(["-m", task.model_override])` and shells out to `hermes`, so the worker's startup hits the guard. Same feature, two paths; cron is guarded on neither.

### Why this field in particular

`tools/cronjob_tools.py`, verbatim, on why the agent may not set this field:

> per-job inference pins are user-owned (dashboard, `hermes cron create/edit --model`, or hand-edited jobs). **The agent must not be able to point unattended spend at a different model.**

The repo already classifies this exact field as controlling unattended spend and restricts it to the human — and then never asks the human. Concretely:

```
hermes cron create --schedule "*/10 * * * *" --prompt "…" --model muse-spark-1.2-contributor
```

is accepted without a word, and ships that job's prompts and completions to a training tier every ten minutes, indefinitely. The identical id typed as `hermes -m muse-spark-1.2-contributor`, chosen in the `hermes model` picker, or sent as `/model` prints the full block and demands `[y/N]` first. Recurrence is the amplifier: an interactive mistake ends when the process exits, a pinned one does not.

## Related Issue

No filed issue — found by auditing the registry's stated surface coverage against its actual callers.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [x] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- **`hermes_cli/cron.py`** — new `_confirm_pinned_model(args, existing_job=None)`. Resolves the model the job will actually run on, runs it through `model_selection_guards.combined_selection_warning`, prints the block and asks for confirmation. Returns `True` when the pin may proceed, `False` when the caller must abort.
- **`hermes_cli/cron.py`** — `cron_create` calls it before `_cron_api(action="create")` and returns `1` on decline.
- **`hermes_cli/cron.py`** — `cron_edit` calls it after the job ref resolves, passing the stored row as `existing_job`, and returns `1` on decline.
- **`tests/hermes_cli/test_cron_model_selection_guard.py`** (new) — 11 cases; 7 fail against the pre-fix `cron.py`.

Design notes:

- **Resolution mirrors the scheduler.** `cron/scheduler.py` documents the precedence as *per-job override > `cron.model` > `HERMES_MODEL` env > config.yaml `model:`*; the helper follows the same chain so a `--provider`-only pin is judged against the model it will really route. `HERMES_MODEL` is deliberately skipped — it belongs to the gateway process's environment rather than the CLI's, and it can only decide the outcome in the case where nothing is being pinned at all.
- **Fail-open.** The registry's own contract is that *"a misbehaving guard must never break model selection"*, so an unavailable import, an unreadable config, or a raising guard lets job creation through untouched. A test pins this.
- **Clearing a pin is never guarded.** `--model ""` / `--provider ""` are the documented way to drop back to `cron.model` / `model.default`; that is de-escalation.
- **Non-interactive pins that fire a guard are refused** rather than silently stored, matching `_confirm_startup_expensive_model_override`. A scheduled job outlives the shell that created it, so an unconfirmed pin cannot be walked back the way an interactive `hermes -m` invocation can. Nothing changes for a model that fires no guard, which is the overwhelmingly common case.
- **The confirm belongs at the surface, not in `cron.jobs.create_job`.** `create_job` is a library entry point with no UX and no terminal, and the registry's design explicitly keeps the *rendering* half per-surface while centralising only the *evaluation* half.

### Sibling-site sweep

Every other place a cron model pin can be set, and its disposition:

| Site | Disposition |
|---|---|
| `hermes cron create --model` | **fixed here** |
| `hermes cron edit --model/--provider` | **fixed here** |
| `hermes kanban --model` (`hermes_cli/kanban_db.py`) | already guarded — shells out to `hermes -m`, hits the startup guard |
| `tui_gateway/methods_tools.py` `cron.manage` | `action="add"` forwards only name/schedule/prompt/repeat; it cannot set a model |
| `cron.model` fleet default | lands in the generic `hermes_cli/config.py::set_config_value`; not diff-local to cron |
| `tools/cronjob_tools.py` (agent tool) | already blocked from setting model/provider by design |
| **`POST /api/cron/jobs`** (`hermes_cli/web_server.py::_create_cron_job_sync`) | **shares the root cause, deliberately not in this PR** — see below |

The dashboard's cron endpoint accepts `body.model` / `body.provider` / `body.base_url` and forwards them to `create_job` unguarded, so it has the same hole. It is excluded on purpose: an HTTP endpoint has no stdin, so covering it means returning a `confirm_required` payload and teaching the frontend to render it — a new API contract, and a UX decision that is yours to make rather than mine to assume. Happy to follow up in a separate PR in whichever shape you prefer.

## How to Test

```
uv run --with pytest --with pytest-asyncio python3 -m pytest tests/hermes_cli/test_cron_model_selection_guard.py -v
```

Fails-before / passes-after, verified per test by restoring only the production file (`git checkout origin/main -- hermes_cli/cron.py`) and re-running:

| Test | Pre-fix result |
|---|---|
| `TestCronCreatePinGuard::test_declined_pin_never_reaches_the_job_store` | FAIL — job created despite the decline |
| `TestCronCreatePinGuard::test_confirmed_pin_is_stored_after_the_warning_is_shown` | FAIL — no block ever reaches stderr |
| `TestCronCreatePinGuard::test_non_interactive_pin_is_refused` | FAIL — pin stored silently |
| `TestCronCreatePinGuard::test_provider_only_pin_is_judged_against_the_configured_default` | FAIL |
| `TestCronEditPinGuard::test_declined_pin_never_updates_the_job` | FAIL |
| `TestCronEditPinGuard::test_provider_only_pin_is_judged_against_the_jobs_current_model` | FAIL |
| `TestCronEditPinGuard::test_confirmed_pin_is_stored_after_the_warning_is_shown` | FAIL |

The remaining four cases are no-behaviour-change guards and pass both before and after by design: an unpinned `cron create` must never touch the registry, a model that fires no guard must not prompt, `--model ""` must stay unguarded, and a raising guard must not block job creation.

Manual reproduction:

1. `hermes cron create --schedule "*/10 * * * *" --prompt "test" --model muse-spark-1.2-contributor` — on `main` the job is created in silence; with this change the data-training block prints and the pin needs `[y/N]`.
2. Answer `n` — nothing is written to the job store, exit code 1.
3. `hermes cron create --schedule "*/10 * * * *" --prompt "test"` with no `--model` — unchanged, no prompt, registry never consulted.

Tests run: the new file plus `tests/hermes_cli/test_cron.py`, `tests/hermes_cli/test_model_selection_guards.py`, `tests/hermes_cli/test_gateway_restart_loop.py` and the cron suites that import `hermes_cli.cron` — 235 passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — ran the focused + adjacent suites listed above (235 passed), not the full tree
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 25.4), Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — new behaviour is documented in `_confirm_pinned_model`'s docstring and the flags' existing `--help` text is unchanged
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A, no new config keys
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — stdlib `sys.stdin.isatty()` / `input()` only, no platform-specific paths
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A, the agent-facing `cronjob` tool is unchanged and still cannot set a model

## Related / Positioning

- **#86710** (*"fix(cli): let opted-in unattended agents use contributor tiers"*) is **adjacent, not colliding** — it touches `hermes_cli/main.py` and `hermes_cli/config_defaults.py` only, zero file overlap. Its premise is that unattended workers must not be *blocked at run time*, which is the same reason the confirm belongs at *create* time here. If it lands, extending its `security.allow_data_training_tiers_noninteractive` opt-in to this call site is a one-line follow-up; I've deliberately not depended on an unmerged PR.
- **#73968** (*"feat(cron): audit model pinning and drift-guard state"*) also touches `hermes_cli/cron.py`, but adds a read-only `cron audit-models` reporting subcommand in the `cron_command` dispatch — a different concern, a different hunk, no conflict.
- No open PR touches `hermes_cli/model_selection_guards.py`, `hermes_cli/model_data_policy_guard.py`, or adds a confirm to any cron path.
