### PR TITLE
feat(desktop-sdk): host.deleteProfile — teardown-routed profile delete for plugins

### DIFF
--- a/apps/desktop/src/sdk/index.ts
+++ b/apps/desktop/src/sdk/index.ts
@@ -23,10 +23,18 @@ import { atom, type ReadableAtom } from 'nanostores'
 import { openSession, type OpenSessionIntent } from '@/app/open-session'
 import { $narrowViewport } from '@/components/pane-shell/tree/store'
 import { onGatewayEvent } from '@/contrib/events'
-import { getLogs, getStatus, type HermesGateway } from '@/hermes'
+import { deleteProfile, getLogs, getStatus, type HermesGateway } from '@/hermes'
 import { $gateway, ensureGatewayForAgent, openGatewayForAgent, openGatewayForProfile } from '@/store/gateway'
 import { notify, notifyError } from '@/store/notifications'
-import { $activeGatewayProfile, ensureGatewayProfile, newSessionInProfile, setShowAllProfiles } from '@/store/profile'
+import {
+  $activeGatewayProfile,
+  ensureGatewayProfile,
+  newSessionInProfile,
+  normalizeProfileKey,
+  selectProfile,
+  setActiveProfile,
+  setShowAllProfiles
+} from '@/store/profile'
 import { $activeSessionId, $currentCwd, $currentModel, $gatewayState } from '@/store/session'
 import { runGatewayRestart } from '@/store/system-actions'
 
@@ -111,6 +119,40 @@ export const host = {
     }
 
     void openGatewayForProfile(name).catch(() => undefined)
+  },
+
+  /** Delete a profile THROUGH the desktop's teardown-routed REST path — the
+   *  same door core surfaces use (DeleteProfileDialog). Electron intercepts
+   *  the DELETE, tears down that profile's pool/primary backend first, and
+   *  routes the follow-up request away from it, so a live (or hover-warmed)
+   *  backend can't hold the profile dir open or respawn mid-delete and
+   *  resurrect the directory (issue #52279). Plugins must prefer this over
+   *  `cli.exec ['profile','delete',…]`, which bypasses that interception
+   *  entirely. When the deleted profile was the live gateway's, the app is
+   *  re-homed to the default profile — same semantics as the core dialog.
+   *  Rejects with the backend's error when the delete fails. */
+  deleteProfile: async (profile: string): Promise<void> => {
+    const name = (profile ?? '').trim()
+
+    if (!name) {
+      throw new Error('deleteProfile: profile name required')
+    }
+
+    if (normalizeProfileKey(name) === 'default') {
+      throw new Error('The default profile cannot be deleted.')
+    }
+
+    // Capture before the delete; re-home after so our write is the last one
+    // (mirrors DeleteProfileDialog — a refreshActiveProfile racing the dying
+    // backend can't clobber the pill back to the deleted profile).
+    const wasActive = normalizeProfileKey(name) === normalizeProfileKey($activeGatewayProfile.get())
+
+    await deleteProfile(name)
+
+    if (wasActive) {
+      selectProfile('default')
+      setActiveProfile('default')
+    }
   },
 
   // ── Multi-source agents (the Bot Mode door) ───────────────────────────────


### PR DESCRIPTION
## Summary
Plugins can now delete profiles through the desktop's teardown-routed REST path via a new SDK verb, `host.deleteProfile(name)` — fixing the class of "can't delete a bot while its session is awake" errors in Bot Mode.

Root cause: plugin deletes went through `cli.exec ['profile','delete',…]`, which bypasses the Electron-side `DELETE /api/profiles` interception (`prepareProfileDeleteRequest`). A live pool backend — e.g. one the roster's hover pre-warm just woke, and right-click always hovers the row first — holds the profile dir open, and the renderer's socket reconnect respawns it mid-delete, recreating the directory (#52279).

## Changes
- `apps/desktop/src/sdk/index.ts`: new `host.deleteProfile(name)` — calls the existing REST `deleteProfile()` (teardown + route-away semantics for free), rejects `default`, re-homes the app to the default profile when the deleted profile was the live gateway's (mirrors `DeleteProfileDialog`'s last-write-wins ordering).

## Validation
| Check | Result |
|---|---|
| `npm run check:lint` (tsc ×3 + eslint, CI parity) | 0 errors (108 pre-existing warnings) |
| `npx vitest run src/store/profile.test.ts` | 11/11 pass |

Companion PR in NousResearch/Hermes-Bot-Mode switches `deleteBot()` to prefer this verb with a `cli.exec` fallback for older desktops.

Reported by @BkashJosi.

## Infographic

![SDK deleteProfile — teardown-routed delete](https://files.catbox.moe/t41hmo.png)
