### PR TITLE
fix(delegation): report schema-invalid child results as failed, not completed

### DIFF
--- a/tests/tools/test_delegate_output_schema.py
+++ b/tests/tools/test_delegate_output_schema.py
@@ -259,6 +259,52 @@ class TestRunSingleChildSchemaValidation:
         assert len(child.calls) == 1
         assert entry.get("schema_valid") is False
 
+    def test_schema_failure_reported_as_failed_not_completed(self):
+        """Regression: a final answer that still violates the declared
+        output contract after the bounded retry (here the classic empty
+        ``{}`` fallback) must be reported status="failed", not
+        "completed". Otherwise the batch report prints a ✓ and
+        orchestrators that read only status/icon accept an empty verdict
+        — schema_valid/schema_errors carry the detail, but status must
+        agree with them."""
+        child = _StubChild(["not json at all", "{}"])
+        child._delegate_output_schema = ADDRESS_SCHEMA
+        entry = _run(child)
+        assert entry["schema_valid"] is False
+        assert entry["schema_errors"]
+        assert entry["status"] == "failed"
+        # the failed entry names the schema violation, not the generic
+        # "no response" error — the child DID respond, unusably
+        assert "output_schema" in entry.get("error", "")
+        # the invalid final text is still propagated for debugging
+        assert entry["summary"] == "{}"
+
+    def test_schema_failure_without_retry_reported_as_failed(self):
+        """Same class, first-try path: retry turn raises, leaving the
+        original non-JSON answer in place — status must still be failed."""
+        child = _StubChild(["nope"])
+        child._delegate_output_schema = ADDRESS_SCHEMA
+
+        original = child.run_conversation
+
+        def flaky(user_message, task_id=None, **kw):
+            if child.calls:
+                raise RuntimeError("child died on retry")
+            return original(user_message, task_id=task_id, **kw)
+
+        child.run_conversation = flaky
+        entry = _run(child)
+        assert entry["schema_valid"] is False
+        assert entry["status"] == "failed"
+
+    def test_schema_valid_entry_still_completed(self):
+        """Guard: schema_valid=True keeps status="completed" untouched."""
+        child = _StubChild(['{"city": "Berlin"}'])
+        child._delegate_output_schema = ADDRESS_SCHEMA
+        entry = _run(child)
+        assert entry["status"] == "completed"
+        assert "error" not in entry
+
 
 # ---------------------------------------------------------------------------
 # delegate_task dispatch-time schema handling

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -2852,6 +2852,17 @@ def _run_single_child(
 
         if interrupted:
             status = "interrupted"
+        elif _schema_valid is False:
+            # T1-24 follow-up: a schema was declared and the final answer —
+            # after the one bounded retry — still violates it (empty `{}`
+            # fallback included). A summary exists, but it is unusable under
+            # the contract the caller asked for, so it must not be reported
+            # as a completed delegation: the batch line would print ✓ and
+            # orchestrators that read only status/icon would accept an
+            # empty verdict. schema_valid/schema_errors (below) carry the
+            # detail; status has to agree with them. _schema_valid stays
+            # None on schema-less runs, which never take this branch.
+            status = "failed"
         elif summary and not _empty_sentinel:
             # A summary means the subagent produced usable output.
             # exit_reason ("completed" vs "max_iterations") already
@@ -2965,7 +2976,22 @@ def _run_single_child(
             else "unknown"
         )
         if status == "failed":
-            entry["error"] = result.get("error", "Subagent did not produce a response.")
+            if _schema_valid is False and summary and not _empty_sentinel:
+                # The child DID respond — the response just violates the
+                # declared contract. Name that instead of the generic
+                # "no response" error; schema_errors (below) hold the
+                # validator's specifics verbatim.
+                entry["error"] = (
+                    "Final answer does not satisfy the declared "
+                    "output_schema (after 1 retry)."
+                    if _schema_retries
+                    else "Final answer does not satisfy the declared "
+                    "output_schema."
+                )
+            else:
+                entry["error"] = result.get(
+                    "error", "Subagent did not produce a response."
+                )
 
         # T1-24: schema-validation outcome — emitted ONLY when a schema was
         # requested, so legacy (schema-less) payloads keep their exact shape.


### PR DESCRIPTION
## Summary

A `delegate_task` child dispatched with an `output_schema` whose final answer **still violates the schema after the one bounded retry** — including the common empty `{}` fallback — was reported `status="completed"` with a ✓ in the batch report.

Since the structured-output feature landed (d6ee58b58), the result entry does carry `schema_valid=false` + `schema_errors` on failure, but the status derivation in `_run_single_child` (`tools/delegate_tool.py`) only checks for a non-empty summary and never consults the validation outcome:

```python
elif summary and not _empty_sentinel:
    status = "completed"
```

So every consumer that reads only `status` is deceived by a contract-violating verdict:
- the batch report prints `✓` (`icon = "✓" if status == "completed" else "✗"`),
- orchestrator parents that branch on `status` accept an empty/unusable result as success,
- `agent/subagent_lifecycle.py` maps it to `SubagentState.SUCCEEDED`,
- the live-transcript manifest records `completed`.

## Fix

In the status derivation, treat `_schema_valid is False` as a failure, between the `interrupted` and summary checks:

- `status = "failed"` when a schema was declared and the final answer (post-retry) fails validation — the existing `"failed"` vocabulary is reused rather than inventing a new status value, so all downstream consumers (icons, lifecycle mapping, manifest, orchestrators) handle it with zero changes.
- The failed entry's `error` names the schema violation ("Final answer does not satisfy the declared output_schema…") instead of the misleading generic "Subagent did not produce a response."; `schema_errors` keep propagating verbatim and the invalid final text stays in `summary` for debugging.
- `_schema_valid` remains `None` on schema-less delegations, so their entries stay byte-identical (wire-shape pinning), and `schema_valid=true` children are untouched.
- Single-goal and batch paths share `_run_single_child`, so both are covered by the one choke point.

## Tests

New regression tests in `tests/tools/test_delegate_output_schema.py` (red on current main, green with the fix):

- `test_schema_failure_reported_as_failed_not_completed` — invalid first try, retry returns `{}`: entry is `failed` with a schema-specific `error`, `schema_errors` present, invalid text still in `summary`.
- `test_schema_failure_without_retry_reported_as_failed` — retry turn raises; original invalid answer stays: still `failed`.
- `test_schema_valid_entry_still_completed` — guard: valid answer keeps `status="completed"` and gains no `error` key.

```
tests/tools/test_delegate_output_schema.py ...........................  27 passed
delegation suite (test_delegate*.py, 12 files)                          162 passed
tests/agent/test_subagent_lifecycle.py + stop_hook + progress            22 passed
```

Before the fix, the two new regression tests fail with `AssertionError: assert 'completed' == 'failed'`.

## Notes

- Sits alongside #87523 (failed children reported as failed via the child's `failed` flag) — same choke point, independent branch/condition; no dependency between the two, trivial to resolve if both land.
- No new keys, no schema surface change, no config: only the value of the existing `status` field on entries that already carry `schema_valid=false`.
