### PR TITLE
fix(gateway): keep async startup hooks off the readiness path

### DIFF
--- a/gateway/hooks.py
+++ b/gateway/hooks.py
@@ -61,10 +61,11 @@ class HookRegistry:
         await registry.emit("agent:start", {"platform": "telegram", ...})
     """
 
-    def __init__(self):
+    def __init__(self, background_tasks: Optional[set[asyncio.Task]] = None):
         # event_type -> [handler_fn, ...]
         self._handlers: Dict[str, List[Callable]] = {}
         self._loaded_hooks: List[dict] = []  # metadata for listing
+        self._background_tasks = background_tasks if background_tasks is not None else set()
 
     @property
     def loaded_hooks(self) -> List[dict]:
@@ -174,6 +175,16 @@ class HookRegistry:
             handlers.extend(self._handlers.get(wildcard_key, []))
         return handlers
 
+    @staticmethod
+    def _report_background_hook_failure(event_type: str, task: asyncio.Task) -> None:
+        if task.cancelled():
+            return
+
+        try:
+            task.result()
+        except Exception as e:
+            print(f"[hooks] Error in handler for '{event_type}': {e}", flush=True)
+
     async def emit(self, event_type: str, context: Optional[Dict[str, Any]] = None) -> None:
         """
         Fire all handlers registered for an event, discarding return values.
@@ -193,8 +204,17 @@ class HookRegistry:
         for fn in self._resolve_handlers(event_type):
             try:
                 result = fn(event_type, context)
-                # Support both sync and async handlers
                 if asyncio.iscoroutine(result):
+                    if event_type == "gateway:startup":
+                        task = asyncio.create_task(result)
+                        self._background_tasks.add(task)
+                        task.add_done_callback(self._background_tasks.discard)
+                        task.add_done_callback(
+                            lambda completed: self._report_background_hook_failure(
+                                event_type, completed
+                            )
+                        )
+                        continue
                     await result
             except Exception as e:
                 print(f"[hooks] Error in handler for '{event_type}': {e}", flush=True)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -6833,10 +6833,6 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         self.pairing_store = PairingStore()
         self.pairing_stores: Dict[str, "PairingStore"] = {}
         
-        # Event hook system
-        from gateway.hooks import HookRegistry
-        self.hooks = HookRegistry()
-
         # Per-chat voice reply mode: "off" | "voice_only" | "all"
         self._voice_mode: Dict[str, str] = self._load_voice_modes()
         # Recent voice transcripts per (guild,user) for duplicate suppression.
@@ -6846,6 +6842,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         # Track background tasks to prevent garbage collection mid-execution
         self._background_tasks: set = set()
+
+        # Event hook system
+        from gateway.hooks import HookRegistry
+        self.hooks = HookRegistry(background_tasks=self._background_tasks)
 
         # Event-loop liveness heartbeat (#66892): rewritten every 30s while
         # the loop is dispatching. External supervisors use the file mtime /

--- a/tests/gateway/test_hooks.py
+++ b/tests/gateway/test_hooks.py
@@ -1,5 +1,6 @@
 """Tests for gateway/hooks.py — event hook system."""
 
+import asyncio
 from unittest.mock import patch
 
 import pytest
@@ -60,6 +61,51 @@ class TestDiscoverAndLoad:
 
 
 class TestEmit:
+
+    @pytest.mark.asyncio
+    async def test_default_registry_keeps_startup_handler_alive(self):
+        started = asyncio.Event()
+        release = asyncio.Event()
+
+        async def slow_startup_handler(_event_type, _context):
+            started.set()
+            await release.wait()
+
+        reg = HookRegistry()
+        reg._handlers["gateway:startup"] = [slow_startup_handler]
+
+        await reg.emit("gateway:startup", {})
+        await started.wait()
+        assert len(reg._background_tasks) == 1
+
+        release.set()
+        await asyncio.gather(*reg._background_tasks)
+        assert reg._background_tasks == set()
+
+    @pytest.mark.asyncio
+    async def test_startup_async_handler_does_not_block_gateway_readiness(self):
+        started = asyncio.Event()
+        release = asyncio.Event()
+
+        async def slow_startup_handler(_event_type, _context):
+            started.set()
+            await release.wait()
+
+        background_tasks = set()
+        reg = HookRegistry(background_tasks=background_tasks)
+        reg._handlers["gateway:startup"] = [slow_startup_handler]
+
+        emitted = asyncio.create_task(reg.emit("gateway:startup", {}))
+        try:
+            await started.wait()
+            assert emitted.done()
+            assert len(background_tasks) == 1
+        finally:
+            release.set()
+            await emitted
+
+        await asyncio.gather(*background_tasks)
+        assert background_tasks == set()
 
     @pytest.mark.asyncio
     async def test_emit_calls_async_handler(self, tmp_path):
@@ -138,5 +184,3 @@ class TestEmitCollect:
         results = await reg.emit_collect("command:x", {})
 
         assert results == [{"decision": "deny"}]
-
-


### PR DESCRIPTION
## Summary

Fixes #87518.

- Run coroutine `gateway:startup` hooks in the background so third-party startup I/O cannot delay gateway readiness.
- Register those tasks in `GatewayRunner._background_tasks`, preserving the existing idle and shutdown lifecycle.
- Report exceptions from detached hook tasks through the existing hook error path.
- Preserve synchronous startup-hook behavior and all non-startup hook ordering/await semantics.

## Validation

- `PYTHONASYNCIODEBUG=1 ... pytest tests/gateway/test_hooks.py tests/gateway/test_gateway_shutdown.py tests/gateway/test_cancel_background_drain.py -q` → 21 passed
- `ruff check gateway/hooks.py gateway/run.py tests/gateway/test_hooks.py`
- Manual HookRegistry probe: a blocked async startup hook returned from `emit()` immediately, remained lifecycle-tracked until release, and was removed after completion.
- Review/QA/security/context gates passed for commit `5aa51b07d04542f219befb88fccdd8d2524dd3f9`.

## Scope

This deliberately handles coroutine startup hooks only. Making arbitrary blocking synchronous hooks nonblocking requires a separate lifecycle design, because moving them to the default executor can delay process shutdown.
