### PR TITLE
fix(gateway): keep startup hooks from blocking gateway readiness

### DIFF
--- a/gateway/hooks.py
+++ b/gateway/hooks.py
@@ -65,6 +65,7 @@ class HookRegistry:
         # event_type -> [handler_fn, ...]
         self._handlers: Dict[str, List[Callable]] = {}
         self._loaded_hooks: List[dict] = []  # metadata for listing
+        self._background_tasks: set[asyncio.Task[Any]] = set()
 
     @property
     def loaded_hooks(self) -> List[dict]:
@@ -174,6 +175,19 @@ class HookRegistry:
             handlers.extend(self._handlers.get(wildcard_key, []))
         return handlers
 
+    async def _run_background_handler(self, event_type: str, result: Any) -> None:
+        """Await a best-effort handler while preserving normal error reporting."""
+        try:
+            await result
+        except Exception as e:
+            print(f"[hooks] Error in handler for '{event_type}': {e}", flush=True)
+
+    def _schedule_background_handler(self, event_type: str, result: Any) -> None:
+        """Schedule and retain a handler task until it finishes."""
+        task = asyncio.create_task(self._run_background_handler(event_type, result))
+        self._background_tasks.add(task)
+        task.add_done_callback(self._background_tasks.discard)
+
     async def emit(self, event_type: str, context: Optional[Dict[str, Any]] = None) -> None:
         """
         Fire all handlers registered for an event, discarding return values.
@@ -195,7 +209,10 @@ class HookRegistry:
                 result = fn(event_type, context)
                 # Support both sync and async handlers
                 if asyncio.iscoroutine(result):
-                    await result
+                    if event_type == "gateway:startup":
+                        self._schedule_background_handler(event_type, result)
+                    else:
+                        await result
             except Exception as e:
                 print(f"[hooks] Error in handler for '{event_type}': {e}", flush=True)
 

--- a/tests/gateway/test_hooks.py
+++ b/tests/gateway/test_hooks.py
@@ -1,5 +1,6 @@
 """Tests for gateway/hooks.py — event hook system."""
 
+import asyncio
 from unittest.mock import patch
 
 import pytest
@@ -105,6 +106,68 @@ class TestEmit:
 
         await reg.emit("command:reset", {})
         assert "command:reset" in results
+
+    @pytest.mark.asyncio
+    async def test_gateway_startup_does_not_await_async_handler(self):
+        reg = HookRegistry()
+        started = asyncio.Event()
+        release = asyncio.Event()
+
+        async def stalled_handler(_event_type, _context):
+            started.set()
+            await release.wait()
+
+        reg._handlers["gateway:startup"] = [stalled_handler]
+
+        await asyncio.wait_for(reg.emit("gateway:startup", {}), timeout=2.0)
+        await asyncio.wait_for(started.wait(), timeout=2.0)
+
+        release.set()
+        await asyncio.gather(*reg._background_tasks)
+
+    @pytest.mark.asyncio
+    async def test_gateway_startup_reports_background_handler_errors(self, capsys):
+        reg = HookRegistry()
+
+        async def failing_handler(_event_type, _context):
+            raise RuntimeError("startup failed")
+
+        reg._handlers["gateway:startup"] = [failing_handler]
+
+        await reg.emit("gateway:startup", {})
+        await asyncio.sleep(0)
+
+        assert (
+            "Error in handler for 'gateway:startup': startup failed"
+            in capsys.readouterr().out
+        )
+
+    @pytest.mark.asyncio
+    async def test_non_startup_async_handlers_remain_ordered_and_awaited(self):
+        reg = HookRegistry()
+        started = asyncio.Event()
+        release = asyncio.Event()
+        calls = []
+
+        async def first_handler(_event_type, _context):
+            calls.append("first:start")
+            started.set()
+            await release.wait()
+            calls.append("first:end")
+
+        async def second_handler(_event_type, _context):
+            calls.append("second")
+
+        reg._handlers["agent:end"] = [first_handler, second_handler]
+
+        emit_task = asyncio.create_task(reg.emit("agent:end", {}))
+        await asyncio.wait_for(started.wait(), timeout=2.0)
+        assert calls == ["first:start"]
+
+        release.set()
+        await emit_task
+
+        assert calls == ["first:start", "first:end", "second"]
 
 
 class TestEmitCollect:


### PR DESCRIPTION
## What does this PR do?

A stalled async `gateway:startup` hook no longer prevents the gateway from completing its startup sequence. Startup hook coroutines now run as retained best-effort background tasks, while other lifecycle and decision hooks keep their ordered awaited behavior.

### Symptom

When an async `gateway:startup` hook waits indefinitely, such as during unavailable optional dependency discovery, `GatewayRunner.start()` never advances past hook dispatch and the gateway does not finish becoming ready.

### Impact

Operators using async startup hooks can lose gateway availability whenever one hook stalls. The affected startup sequence does not reach its later readiness work until the hook returns.

### Bug Cause

**Trigger:** `gateway/hooks.py:191` / `HookRegistry.emit()` handling an async `gateway:startup` handler

**Causal chain:**
1. Gateway startup emits `gateway:startup` and invokes each registered handler.
2. `HookRegistry.emit()` awaited every coroutine result inline, including best-effort startup handlers.
3. A startup hook stalled on optional dependency or external I/O kept the gateway startup coroutine suspended indefinitely.

**Why it is wrong:** Startup notification hooks are best-effort work and must not sit on the gateway readiness path.

**Working sibling / contrast:** Other lifecycle hooks intentionally retain ordered awaited execution, and `emit_collect()` remains ordered because it returns decision results to callers.

**Ruled out:** Synchronous handlers and decision-hook collection were not changed; the reproduced failure is specifically caused by awaiting a `gateway:startup` coroutine result.

### Fix

Schedule async `gateway:startup` results as retained background tasks, remove each task after completion, and preserve existing exception reporting inside the task. Keep all non-startup async handlers awaited in registration order.

## Related Issue

Closes #87518

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/hooks.py` - run async gateway startup handlers off the readiness path while retaining tasks and reporting failures.
- `tests/gateway/test_hooks.py` - cover stalled startup handlers, background exceptions, and unchanged ordered awaiting for other events.

## How to Test

1. Register an async `gateway:startup` handler that waits on an unset `asyncio.Event`.
2. Confirm `HookRegistry.emit("gateway:startup", {})` returns before the event is released.
3. Run the focused hook suite:

```bash
scripts/run_tests.sh tests/gateway/test_hooks.py
```

Result: 10 passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repository test entry on the focused hook suite and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - N/A, behavior is internal and covered by tests
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - N/A, no config changes
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - N/A, no architecture or workflow changes
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) - asyncio task scheduling is platform-independent
- [x] I've updated tool descriptions/schemas if I changed tool behavior - N/A, no model tool changes

## Screenshots / Logs

Not applicable. The focused automated suite passed 10 tests.
