### PR TITLE
fix(update): decide ancestry link by link so an unreadable /proc/1 cannot hide the orchestrator

### DIFF
--- a/hermes_cli/update_lock.py
+++ b/hermes_cli/update_lock.py
@@ -73,6 +73,11 @@ MARKER_NAME = ".hermes-update-in-progress"
 # in apps/bootstrap-installer/src-tauri/src/update.rs — keep the name in sync.
 HANDOFF_PID_ENV = "HERMES_UPDATE_HANDOFF_PID"
 
+# Bound on the parent chain walked by _is_ancestor_pid. Real ancestries are a
+# handful of links (init -> desktop -> staged updater -> shim -> us); the cap
+# only exists so an unexpected chain can never spin the walk.
+_MAX_ANCESTRY_DEPTH = 128
+
 # Exit code meaning "another updater/instance owns this install right now".
 # Already the de-facto contract: the Windows shim + venv-holder guards in
 # _cmd_update_impl exit 2, and the Tauri updater matches on it
@@ -146,15 +151,46 @@ def _is_ancestor_pid(pid: int) -> bool:
     parent chain. This heals the fleet of staged ``hermes-setup`` binaries
     that predate the HANDOFF_PID_ENV export and can never send it.
 
-    Never includes our own pid, and any failure counts as "not an ancestor":
-    an unprovable ancestry must fall back to the normal refusal.
+    The chain is walked one link at a time and each ancestor is tested as it is
+    discovered. ``psutil.Process.parents()`` cannot be used here: it builds the
+    whole chain up to the lowest pid *before* returning, and its per-link
+    ``parent()`` tolerates only ``NoSuchProcess``. So any process we may not
+    inspect anywhere above us raises ``AccessDenied`` and discards the
+    ancestors already collected — including the orchestrator one link down.
+    That is not exotic: under firejail with ``ptrace_scope=1``, and in hardened
+    containers, ``/proc/1`` is unreadable, so the GUI update deadlocked against
+    its own parent on every attempt. Walking incrementally means a failure
+    *above* the match can no longer hide it.
+
+    Never includes our own pid, and any failure encountered before a match
+    counts as "not an ancestor": an unprovable ancestry must fall back to the
+    normal refusal.
     """
     if pid <= 0:
         return False
     try:
         import psutil
 
-        return any(parent.pid == pid for parent in psutil.Process().parents())
+        proc = psutil.Process()
+        seen = {proc.pid}
+        for _ in range(_MAX_ANCESTRY_DEPTH):
+            parent = proc.parent()
+            if parent is None:
+                return False
+            if parent.pid == pid:
+                return True
+            if parent.pid in seen:
+                # Defensive only: psutil's create_time check already rejects a
+                # reused ppid, so a true cycle should be unreachable.
+                return False
+            seen.add(parent.pid)
+            proc = parent
+        logger.debug(
+            "Gave up walking process ancestry for pid %s after %s links",
+            pid,
+            _MAX_ANCESTRY_DEPTH,
+        )
+        return False
     except Exception as exc:
         logger.debug("Could not walk process ancestry for pid %s: %s", pid, exc)
         return False

--- a/tests/hermes_cli/test_update_lock.py
+++ b/tests/hermes_cli/test_update_lock.py
@@ -58,7 +58,9 @@ def test_acquire_writes_pid_and_start_time(marker):
     assert lock.acquired is True
 
     lines = marker.read_text(encoding="utf-8").splitlines()
-    assert int(lines[0]) == os.getpid(), "the Electron gate probes this pid for liveness"
+    assert int(lines[0]) == os.getpid(), (
+        "the Electron gate probes this pid for liveness"
+    )
     assert int(lines[1]) == pytest.approx(time.time(), abs=5)
     assert len(lines) == 2, "wire format is exactly pid + started_at"
 
@@ -161,7 +163,9 @@ def test_describe_holder_names_the_pid_and_elapsed_time(marker):
     assert holder is not None
     message = describe_holder(holder)
 
-    assert str(os.getpid()) in message, "the user needs the pid to find the other update"
+    assert str(os.getpid()) in message, (
+        "the user needs the pid to find the other update"
+    )
     assert "already running" in message
 
 
@@ -172,7 +176,9 @@ def test_unwritable_marker_location_does_not_block_the_update(tmp_path):
     race the lock prevents.
     """
     lock = UpdateLock(path=tmp_path / "nonexistent-file" / "marker")
-    (tmp_path / "nonexistent-file").write_text("i am a file, not a dir", encoding="utf-8")
+    (tmp_path / "nonexistent-file").write_text(
+        "i am a file, not a dir", encoding="utf-8"
+    )
 
     assert lock.acquire() is True
     assert lock.acquired is False, "nothing was written, so there is nothing to release"
@@ -200,7 +206,9 @@ class TestHandoffFromOrchestratingUpdater:
         assert marker.exists(), "the parent still needs its marker after our stage ends"
         assert int(marker.read_text(encoding="utf-8").splitlines()[0]) == os.getpid()
 
-    def test_handoff_pid_that_is_not_the_live_holder_grants_nothing(self, marker, monkeypatch):
+    def test_handoff_pid_that_is_not_the_live_holder_grants_nothing(
+        self, marker, monkeypatch
+    ):
         """The env var alone must not bypass the lock."""
         marker.write_text(f"{os.getpid()}\n{int(time.time())}\n", encoding="utf-8")
         monkeypatch.setenv(HANDOFF_PID_ENV, str(os.getpid() + 1))
@@ -209,8 +217,14 @@ class TestHandoffFromOrchestratingUpdater:
         assert lock.acquire() is False
         assert lock.holder is not None
 
-    @pytest.mark.parametrize("value", ["", "not-a-pid", "-1", "0"], ids=["empty", "garbage", "negative", "zero"])
-    def test_malformed_handoff_values_fall_back_to_refusal(self, marker, monkeypatch, value):
+    @pytest.mark.parametrize(
+        "value",
+        ["", "not-a-pid", "-1", "0"],
+        ids=["empty", "garbage", "negative", "zero"],
+    )
+    def test_malformed_handoff_values_fall_back_to_refusal(
+        self, marker, monkeypatch, value
+    ):
         marker.write_text(f"{os.getpid()}\n{int(time.time())}\n", encoding="utf-8")
         monkeypatch.setenv(HANDOFF_PID_ENV, value)
 
@@ -262,3 +276,115 @@ class TestAncestryHandoff:
         assert lock.acquire() is False
         assert lock.holder is not None
         assert lock.holder.pid == DEAD_PID
+
+
+class _FakeProcess:
+    """One link of a stubbed parent chain.
+
+    ``error`` makes this link refuse inspection, standing in for a process the
+    sandbox will not let us read (psutil raises ``AccessDenied`` there).
+    """
+
+    def __init__(self, pid, parent=None, error=None):
+        self.pid = pid
+        self._parent = parent
+        self._error = error
+
+    def parent(self):
+        if self._error is not None:
+            raise self._error
+        return self._parent
+
+
+def _pin_ancestry(monkeypatch, leaf):
+    """Make ``psutil.Process()`` return the leaf of a stubbed chain."""
+    psutil = pytest.importorskip("psutil")
+    monkeypatch.setattr(psutil, "Process", lambda *a, **k: leaf)
+
+
+def _chain(*pids, blocked_above=False):
+    """Build us -> pids[0] -> pids[1] ... innermost first.
+
+    ``blocked_above`` caps the chain with a link that raises instead of
+    reporting its own parent — the sandboxed ``/proc/1`` case.
+    """
+    psutil = pytest.importorskip("psutil")
+    top = _FakeProcess(1, error=psutil.AccessDenied(pid=1)) if blocked_above else None
+    node = top
+    for pid in reversed(pids):
+        node = _FakeProcess(pid, parent=node)
+    return _FakeProcess(os.getpid(), parent=node)
+
+
+class TestAncestryUnderUnreadableProcesses:
+    """Regression: #87514 — an unreadable process ABOVE the orchestrator.
+
+    ``psutil.Process.parents()`` builds the whole chain before returning and
+    only tolerates ``NoSuchProcess`` per link, so one ``AccessDenied`` high up
+    threw away the ancestors already found. Under firejail with
+    ``ptrace_scope=1`` (and in hardened containers) ``/proc/1`` is unreadable,
+    so every desktop update refused its own orchestrator's fresh marker and
+    exited 2 forever. Ancestry must be decided link by link.
+    """
+
+    def test_ancestor_below_an_unreadable_process_is_still_found(self, monkeypatch):
+        from hermes_cli.update_lock import _is_ancestor_pid
+
+        _pin_ancestry(monkeypatch, _chain(2000, blocked_above=True))
+
+        assert _is_ancestor_pid(2000) is True, (
+            "the orchestrator is one link up; a process we cannot read above "
+            "it must not erase a match already proven"
+        )
+
+    def test_deeper_ancestor_below_an_unreadable_process_is_found(self, monkeypatch):
+        from hermes_cli.update_lock import _is_ancestor_pid
+
+        _pin_ancestry(monkeypatch, _chain(2000, 3000, blocked_above=True))
+
+        assert _is_ancestor_pid(3000) is True
+
+    def test_unreadable_process_below_the_match_still_refuses(self, monkeypatch):
+        """Failing before a match keeps the conservative refusal."""
+        from hermes_cli.update_lock import _is_ancestor_pid
+
+        _pin_ancestry(monkeypatch, _chain(blocked_above=True))
+
+        assert _is_ancestor_pid(2000) is False
+
+    def test_unrelated_pid_is_refused_on_a_fully_readable_chain(self, monkeypatch):
+        from hermes_cli.update_lock import _is_ancestor_pid
+
+        _pin_ancestry(monkeypatch, _chain(2000, 3000))
+
+        assert _is_ancestor_pid(DEAD_PID) is False
+
+    def test_our_own_pid_is_never_an_ancestor(self, monkeypatch):
+        from hermes_cli.update_lock import _is_ancestor_pid
+
+        _pin_ancestry(monkeypatch, _chain(2000))
+
+        assert _is_ancestor_pid(os.getpid()) is False
+
+    def test_walk_is_bounded(self, monkeypatch):
+        """A pathological chain terminates instead of spinning."""
+        from hermes_cli.update_lock import _MAX_ANCESTRY_DEPTH, _is_ancestor_pid
+
+        _pin_ancestry(monkeypatch, _chain(*range(2000, 2000 + _MAX_ANCESTRY_DEPTH * 2)))
+
+        assert _is_ancestor_pid(2000 + _MAX_ANCESTRY_DEPTH * 2 - 1) is False
+
+    def test_acquire_accepts_the_orchestrator_behind_an_unreadable_init(
+        self, marker, monkeypatch
+    ):
+        """The reporter's end-to-end symptom: exit 2 on every GUI update."""
+        monkeypatch.setattr("hermes_cli.update_lock._pid_alive", lambda pid: True)
+        _pin_ancestry(monkeypatch, _chain(2000, blocked_above=True))
+        marker.write_text(f"2000\n{int(time.time())}\n", encoding="utf-8")
+
+        lock = UpdateLock(path=marker)
+        assert lock.acquire() is True, "the hand-off child runs under 2000's claim"
+        assert lock.acquired is False, "the orchestrator's claim is not ours to own"
+
+        lock.release()
+        assert marker.exists(), "the orchestrator still needs its marker"


### PR DESCRIPTION
## What does this PR do?

Fixes a regression of #75847 in which the desktop in-app update can never complete on any host where a process above us in the parent chain is not inspectable.

`_is_ancestor_pid` recognises the orchestrating updater by asking psutil for our whole parent chain at once:

```python
return any(parent.pid == pid for parent in psutil.Process().parents())
```

Two properties of `psutil.Process.parents()` combine badly here:

1. **It is eager.** It walks all the way up to the lowest pid and returns a finished list, so the generator expression cannot short-circuit at the matching ancestor. The match is only ever tested after the full walk has already succeeded.
2. **Its per-link `parent()` tolerates only `NoSuchProcess`.** An `AccessDenied` from `Process(ppid).create_time()` propagates out of the entire `parents()` call.

So a single process we may not read, *anywhere above the ancestor we were looking for*, throws away the ancestors already collected. `_is_ancestor_pid`'s `except Exception` guard then returns False and `UpdateLock.acquire` treats a live orchestrator as a foreign concurrent updater.

Under firejail with `ptrace_scope=1` (and in hardened containers) `/proc/1` is exactly that unreadable process, so the reporter's hand-off child refused its own parent's two-second-old marker and exited 2 on every attempt, indefinitely:

```
hand-off start: root=~/.hermes/hermes-agent branch=main desktopPid=3 pid=16926
running: hermes update --yes --gateway --branch main
✗ Another Hermes update is already running (PID 16926, started 2s ago).
hermes update exit code: 2
```

The pid it names is the hand-off script that wrote the marker itself.

**Approach.** Walk the chain one link at a time and test each ancestor as it is discovered, so a failure *above* a match can no longer erase it. This is a strictly smaller behaviour change than tightening exception handling: the conservative contract is preserved exactly, because a failure encountered *before* any match still returns False. Unprovable ancestry still falls back to the normal refusal, and no unrelated concurrent updater becomes acceptable.

The alternative of catching `AccessDenied` inside a `parents()` call is not available, since the exception is raised by `parents()` itself after the useful information has already been discarded.

## Related Issue

Fixes #87514

Regression of #75847 (`fix(update): recognize an ancestor-held update lock as our own orchestrator`), which introduced the ancestry path.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/update_lock.py`: `_is_ancestor_pid` now ascends the parent chain link by link, returning True as soon as a link matches, instead of materialising the entire chain first. Added `_MAX_ANCESTRY_DEPTH` (128) plus a seen-pid guard so an unexpected chain cannot spin, and rewrote the docstring to record why `parents()` is not usable here.
- `tests/hermes_cli/test_update_lock.py`: new `TestAncestryUnderUnreadableProcesses` class with 7 regression tests.

No config keys, no public API change, no behaviour change on hosts where the whole chain is readable.

## How to Test

The reporter's standalone repro reproduces the psutil behaviour without Hermes, on a firejail host with `ptrace_scope=1`:

```sh
echo "$$" > /tmp/marker-test
out=$(python3 - <<'PY'
import psutil
owner = int(open('/tmp/marker-test').read().split()[0])
try:
    print('RESULT:', any(p.pid == owner for p in psutil.Process().parents()))
except Exception as e:
    print('RESULT: EXCEPTION', type(e).__name__, ':', e)
PY
); echo "captured: $out"
```

Sandboxed: `RESULT: EXCEPTION AccessDenied : (pid=1)`. Unsandboxed: `True`.

In-tree, the failure mode is covered without needing a sandbox by stubbing a parent chain whose top link raises `AccessDenied`:

1. `pytest tests/hermes_cli/test_update_lock.py -q` gives 32 passed.
2. Revert only `hermes_cli/update_lock.py` and re-run: `test_ancestor_below_an_unreadable_process_is_still_found`, `test_deeper_ancestor_below_an_unreadable_process_is_found` and the end-to-end `test_acquire_accepts_the_orchestrator_behind_an_unreadable_init` all fail. The three guardrail tests (unrelated pid refused, our own pid never an ancestor, failure *below* the match still refuses) pass both before and after, which is what pins that the refusal contract was not loosened.
3. `pytest tests/hermes_cli/test_update_lock.py tests/hermes_cli/test_update_self_lock.py tests/hermes_cli/test_update_concurrent_quarantine.py -q` gives 62 passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11 (Python 3.13, psutil 7.2.2)

A note on the test scope, in the interest of being accurate rather than just ticking the box: I ran the update-lock suites above plus `scripts/check-windows-footguns.py --all` (972 files, clean) and `ruff check` / `ruff format --check` (clean). I could not reproduce the sandboxed condition itself on Windows, which is why the regression tests stub the chain rather than depend on `/proc` permissions. That also makes them meaningful on every CI platform rather than Linux-only. CI runs the full suite across Linux/macOS/Windows.

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings). The `_is_ancestor_pid` docstring now explains the constraint, since the obvious `parents()` one-liner is a trap a future reader would otherwise reintroduce.
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys: N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows: N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility). `Process.parent()` is supported on all platforms psutil targets, and the tests are platform-neutral. macOS is a real beneficiary as well as Linux: `parent()` raises `AccessDenied` there for processes owned by other users, which includes `launchd` (pid 1), so the same all-or-nothing failure was reachable outside a sandbox.

---

Credit to @anatoleS for the report: the standalone driver script isolated this to psutil's contract rather than to Hermes, which is what made the eager-walk root cause quick to confirm.
