### PR TITLE
fix(desktop): show failed status for timed-out subagents in fallback stream path

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-message-stream/utils.test.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/utils.test.ts
@@ -63,4 +63,25 @@ describe('delegateTaskPayloads', () => {
 
     expect(spec).toMatchObject({ event_type: 'subagent.complete', status: 'failed' })
   })
+
+  it.each(['timeout', 'error', 'failed', 'failure', 'TIMEOUT'])(
+    'maps completion with result.status=%s to a failed subagent.complete',
+    (resultStatus) => {
+      const [spec] = delegateTaskPayloads(
+        payload({ name: 'delegate_task', result: { status: resultStatus, summary: 'timed out' } }),
+        'complete'
+      )
+
+      expect(spec).toMatchObject({ event_type: 'subagent.complete', status: 'failed' })
+    }
+  )
+
+  it('maps a successful completion to completed', () => {
+    const [spec] = delegateTaskPayloads(
+      payload({ name: 'delegate_task', result: { status: 'success', summary: 'done' } }),
+      'complete'
+    )
+
+    expect(spec).toMatchObject({ event_type: 'subagent.complete', status: 'completed' })
+  })
 })

--- a/apps/desktop/src/app/session/hooks/use-message-stream/utils.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/utils.ts
@@ -147,7 +147,9 @@ export function delegateTaskPayloads(
   const result = parseMaybeRecord(payload.result)
   const rawTasks = Array.isArray(args.tasks) ? args.tasks : []
   const tasks = rawTasks.length ? rawTasks.map(parseMaybeRecord) : [args]
-  const status = phase === 'complete' ? (payload.error ? 'failed' : 'completed') : 'running'
+  const resultStatus = typeof result.status === 'string' ? result.status.toLowerCase() : ''
+  const failedResult = Boolean(payload.error) || ['timeout', 'error', 'failed', 'failure'].includes(resultStatus)
+  const status = phase === 'complete' ? (failedResult ? 'failed' : 'completed') : 'running'
   const toolId = payload.tool_id || payload.tool_call_id || payload.id || 'delegate_task'
   const progressText = firstString(payload.preview, payload.message, payload.context)
 


### PR DESCRIPTION
## Summary
Timed-out subagents now render as failed on the Desktop fallback stream path instead of showing a permanent green "completed".

Root cause: `delegateTaskPayloads` treated every non-running phase without `payload.error` as completed; timeout results carry `result.status` only. Native path was fixed in #86592 — this is the remaining fallback path.

## Changes
- `apps/desktop/src/app/session/hooks/use-message-stream/utils.ts`: parse `result.status`; `timeout|error|failed|failure` → failed
- `utils.test.ts`: parameterized coverage incl. case-insensitivity

## Validation
| | Before | After |
|---|---|---|
| timeout result | completed ✅ (wrong) | failed ❌ |
| vitest | — | 12/12 |
| typecheck | — | clean |

Fixes #87200

## Infographic

![infographic](https://files.catbox.moe/ngxntq.png)
