### PR TITLE
fix(desktop): match custom provider aliases in model catalog menu

### DIFF
--- a/apps/desktop/src/app/shell/model-catalog-menu.tsx
+++ b/apps/desktop/src/app/shell/model-catalog-menu.tsx
@@ -40,6 +40,14 @@ import type { ModelOptionProvider, ModelOptionsResponse } from '@/types/hermes'
 
 import { type FastControl, ModelEditSubmenu, resolveFastControl } from './model-edit-submenu'
 
+/** Whether a catalog row represents the session's current provider. Custom
+ *  providers report the canonical `custom:<key>` identity from `model.options`
+ *  while the row's slug is the bare config key, so exact slug equality never
+ *  matches — check the row's alias set too (#87035). */
+function isCurrentProvider(provider: ModelOptionProvider, currentProvider: string): boolean {
+  return provider.slug === currentProvider || (provider.aliases?.includes(currentProvider) ?? false)
+}
+
 // Lets the host dropdown (model-pill, a kanban field trigger, …) hand the panel
 // a way to dismiss itself so clicking a model row commits + closes, while the
 // hover-revealed edit submenu (reasoning/fast) stays open to play with (its
@@ -243,13 +251,17 @@ export function ModelCatalogMenu({
   // hover can't take rows out from under the keyboard.
   const pointerQuiet = usePointerQuiet()
 
-  const currentKey = current.provider === 'moa' ? `moa:${current.model}` : `${current.provider}:${current.model}`
+  const rowIsCurrent = (row: KbRow) =>
+    row.kind === 'moa'
+      ? current.provider === 'moa' && row.preset === current.model
+      : isCurrentProvider(row.provider, current.provider) &&
+        (row.family.id === current.model || row.family.fastId === current.model)
 
   const autoIndex = q
     ? kbRows.length > 0
       ? 0
       : -1
-    : kbRows.findIndex(row => row.key === currentKey || (row.kind === 'family' && row.family.fastId === current.model))
+    : kbRows.findIndex(row => rowIsCurrent(row) || (row.kind === 'family' && row.family.fastId === current.model))
 
   const kbIndex = kbOverride !== null && kbOverride < kbRows.length ? kbOverride : autoIndex
   const kbActiveKey = kbIndex >= 0 ? kbRows[kbIndex].key : null
@@ -277,7 +289,7 @@ export function ModelCatalogMenu({
       return
     }
 
-    if (row.key !== currentKey && row.family.fastId !== current.model) {
+    if (!rowIsCurrent(row) && row.family.fastId !== current.model) {
       void selectFamily(row.family, row.provider)
     }
 
@@ -384,7 +396,7 @@ export function ModelCatalogMenu({
                     // The active id may be the base or its -fast sibling; either
                     // way this one family row represents both.
                     const activeId =
-                      group.provider.slug === current.provider &&
+                      isCurrentProvider(group.provider, current.provider) &&
                       (current.model === family.id || current.model === family.fastId)
                         ? current.model
                         : null
@@ -561,7 +573,7 @@ function groupModels(
     // stable curated order, so selecting a model can't shuffle the list. While
     // SEARCHING the pin is skipped: a query means "show me matches".
     const activeId =
-      !q && provider.slug === current.provider && current.model
+      !q && isCurrentProvider(provider, current.provider) && current.model
         ? allFamilies.find(family => family.id === current.model || family.fastId === current.model)?.id
         : undefined
 

--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -405,6 +405,11 @@ export interface ModelOptionProvider {
   key_env?: string
   /** True for providers defined via the user's `providers:` config block. */
   is_user_defined?: boolean
+  /** User-defined providers only: every accepted identity for this endpoint
+   *  (bare config key, `custom:<key>`, normalized display name, …). A session's
+   *  `model.options` reports the canonical `custom:<key>` form, so "is this row
+   *  the current provider?" must check membership here, not slug equality. */
+  aliases?: string[]
   /** OpenAI-compatible endpoint for a user-defined provider. The backend
    *  exposes this as `api_url`; model assignments send it back as `base_url`
    *  so switching providers does not discard the selected local endpoint. */

--- a/hermes_cli/inventory.py
+++ b/hermes_cli/inventory.py
@@ -272,6 +272,7 @@ def build_models_payload(
         _apply_capabilities(rows)
     if featured:
         _apply_featured(rows)
+    _apply_custom_aliases(rows)
 
     return {
         "providers": rows,
@@ -503,6 +504,32 @@ def _apply_featured(rows: list[dict]) -> None:
         # Preserve the row's model order for stable rendering.
         order = {m: i for i, m in enumerate(models)}
         row["featured_models"] = sorted(featured, key=lambda m: order[m])
+
+
+def _apply_custom_aliases(rows: list[dict]) -> None:
+    """Attach the accepted identity set to each user-defined provider row.
+
+    A session's ``model.options`` reports the canonical ``custom:<key>``
+    identity (via ``canonical_custom_identity``), while catalog rows carry
+    the bare config key as ``slug``. GUI pickers compare the two to decide
+    which row is active; exact equality never matches for custom providers
+    (#87035). Exposing ``aliases`` — every current and legacy spelling from
+    :func:`hermes_cli.providers.custom_provider_aliases` — lets the frontend
+    do a membership check instead.
+    """
+    from hermes_cli.providers import custom_provider_aliases
+
+    for row in rows:
+        if not row.get("is_user_defined"):
+            continue
+        try:
+            row["aliases"] = sorted(
+                custom_provider_aliases(
+                    str(row.get("name", "")), str(row.get("slug", ""))
+                )
+            )
+        except Exception:
+            continue
 
 
 # ─── Internal: row post-processing ──────────────────────────────────────

--- a/tests/hermes_cli/test_inventory.py
+++ b/tests/hermes_cli/test_inventory.py
@@ -351,6 +351,38 @@ def _aggregator_row(slug: str, models: list[str]) -> dict:
     }
 
 
+def test_user_defined_rows_carry_alias_set_for_gui_current_match():
+    """Custom provider rows must expose `aliases` so the desktop picker can
+    match a session's canonical `custom:<key>` identity against the row's
+    bare-key slug (#87035). Built-in rows carry no aliases.
+    """
+    rows = [
+        {
+            "slug": "myep",
+            "name": "My Endpoint",
+            "models": ["my-model"],
+            "total_models": 1,
+            "is_current": True,
+            "is_user_defined": True,
+            "source": "user-config",
+            "api_url": "http://localhost:8000/v1",
+        },
+        _nous_row() | {"is_current": False},
+    ]
+    ctx = _empty_ctx(provider="custom:myep", model="my-model")
+
+    with _list_auth_returning(rows):
+        payload = build_models_payload(ctx)
+
+    by_slug = {r["slug"]: r for r in payload["providers"]}
+    aliases = by_slug["myep"]["aliases"]
+    # The canonical session identity must be matchable via the alias set.
+    assert "custom:myep" in aliases
+    assert "myep" in aliases
+    assert "custom:my-endpoint" in aliases
+    assert "aliases" not in by_slug["nous"]
+
+
 def test_aggregator_dedup_removes_overlapping_models():
     """Models served by a user-defined provider are removed from
     aggregator rows so the picker doesn't show them under the wrong


### PR DESCRIPTION
## Summary
The Desktop reasoning-effort picker and fast-toggle now work for sessions on configured custom providers.

Root cause: `model-catalog-menu.tsx` matched providers by exact slug equality; custom providers are addressed by any of several aliases (`custom:<slug>`, display-name forms), so the current-provider gate never matched and the picker silently no-opped.

## Changes
- `hermes_cli/inventory.py`: `build_models_payload` attaches the alias set (from `custom_provider_aliases`) to user-defined provider rows
- `apps/desktop/src/app/shell/model-catalog-menu.tsx`: `isCurrentProvider()` membership match at all 3 comparison sites
- `apps/desktop/src/types/hermes.ts`: `aliases?: string[]`
- `tests/hermes_cli/test_inventory.py`: alias-set regression test

## Validation
| | Result |
|---|---|
| pytest (inventory + model_switch custom) | 63 passed |
| desktop typecheck (3 tsconfigs) | clean |

Fixes #87035

## Infographic

![infographic](https://files.catbox.moe/5br6mh.png)
