### PR TITLE
feat(plugins): index hermes-ambient-watch in the community seed

### DIFF
--- a/hermes_cli/data/plugin_index.json
+++ b/hermes_cli/data/plugin_index.json
@@ -63,6 +63,19 @@
       "capabilities": ["tools"],
       "api_version": 1,
       "added_at": "2026-08-12"
+    },
+    {
+      "name": "hermes-ambient-watch",
+      "description": "Claude-Tag-style ambient mode for Slack — judges quiet threads with one bounded LLM call and posts at most one nudge per thread ever, under USD spend caps that decline rather than truncate. Shadow mode first, fail-closed.",
+      "author": "sepivip",
+      "tags": ["slack", "gateway", "ambient", "messaging", "budget"],
+      "repo": "sepivip/hermes-ambient-watch",
+      "subdir": "ambient-watch",
+      "ref": "6274c2358a7cbe559de32477ea139a0a0958c42a",
+      "homepage": "https://github.com/sepivip/hermes-ambient-watch",
+      "capabilities": ["gateway", "cron", "llm"],
+      "api_version": 1,
+      "added_at": "2026-08-16"
     }
   ]
 }


### PR DESCRIPTION
## What does this PR do?

Adds one entry to the community plugin index seed (`hermes_cli/data/plugin_index.json`) for **hermes-ambient-watch** — a Claude-Tag-style ambient mode for Slack, published as a standalone plugin repo per the placement policy in CONTRIBUTING.md.

The plugin passively watches allowlisted Slack channels, asks a bounded auxiliary-LLM judge which quiet threads would actually welcome a reply, and posts at most one ≤200-character nudge per thread, ever — under USD spend caps that decline work rather than truncate it. It ships in shadow mode and fails closed throughout.

Notable properties for review:

- **Existing plugin surface only** — three hooks (`pre_gateway_dispatch`, `pre_tool_call`, `post_api_request`) plus `ctx.register_auxiliary_task`; no core changes. Judgment routes through the `ambient_watch_judge` auxiliary task so operators can pin a cheap model.
- **No agent session ever sees channel text.** The sweep is a `--no-agent` cron job and delivery is direct. Three containment layers (sanitize-at-source, excerpt-free stdout, an unconditional data-directory jail on `pre_tool_call`) exist because a live incident proved they were needed — written up in the repo README.
- **439 tests** pass against current main (`45af7a71`), including suites that drive the real plugin loader, `cron.scheduler._run_job_script`, and `GatewayRunner._handle_message`. A parity audit against Anthropic's published Claude Tag behavior is maintained in the repo's PARITY.md.

Relates to #80338 (Slack feature-parity / Hermes Tag lane): this is an out-of-tree take on the ambient/proactivity slice, isolated behind a recorder module so a future core `message:observed` tap could replace its ingestion with a one-module swap.

## Related Issue

No dedicated issue; relates to #80338. Searched open and closed PRs/issues for prior ambient-mode work — none found. #86214 touches the same seed file; this entry is appended last so the merge stays trivial in either order.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `hermes_cli/data/plugin_index.json` — one appended entry (+13 lines), pinned to immutable ref `6274c2358a7cbe559de32477ea139a0a0958c42a` (tag `v0.1.0`), with `subdir: "ambient-watch"`.

## How to Test

1. `python -c "from hermes_cli.plugin_index import _load_seed_entries; print([e.name for e in _load_seed_entries()])"` — the entry parses through the real loader.
2. `pytest tests/hermes_cli/test_plugin_index_search.py tests/hermes_cli/test_plugin_packs.py -q` — 74 passed with the edited seed.
3. `hermes plugins install sepivip/hermes-ambient-watch/ambient-watch` — normal consent/review flow; the plugin installs **not enabled** and stays dormant and fail-closed until configured (go-live runbook is in its README).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the tests directly covering this change: `tests/hermes_cli/test_plugin_index_search.py` + `tests/hermes_cli/test_plugin_packs.py` — 74 passed against the edited seed; deferring the full sweep to CI (for transparency: a pre-existing collection error in `test_doctor_journal_modes.py` reproduces identically on an *unmodified* checkout in a runtime venv, unrelated to this data-only change)
- [x] Tests for my changes — N/A (data-only index entry; the format is covered by the existing index tests)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Relevant documentation — N/A (the index is self-describing; install/operate docs live in the plugin's README)
- [x] `cli-config.yaml.example` — N/A (no config keys added)
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] Cross-platform impact — N/A for the seed change itself (the plugin is developed and soaked on Windows)
- [x] Tool descriptions/schemas — N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)
