### PR TITLE
fix(cli): recognize agent.reasoning_effort as a known config key

### DIFF
--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -300,6 +300,12 @@ DEFAULT_CONFIG = {
         # matches a key in this dict.
         # Edit directly in config.yaml (no CLI support due to dots in keys).
         "reasoning_overrides": {},
+
+        # Global reasoning effort: none|minimal|low|medium|high|xhigh|max|ultra.
+        # Empty string = provider default. Per-model reasoning_overrides take
+        # precedence. Set via `hermes config set agent.reasoning_effort <level>`
+        # or `/reasoning <level> --global`.
+        "reasoning_effort": "",
     },
 
     "terminal": {

--- a/tests/hermes_cli/test_set_config_value.py
+++ b/tests/hermes_cli/test_set_config_value.py
@@ -500,6 +500,7 @@ class TestValidateConfigKey:
         "platforms.discord.enabled",
         "gateway.platforms.my_platform.extra.token",
         "approvals.mode",
+        "agent.reasoning_effort",
     ])
     def test_known_keys_pass(self, key):
         from hermes_cli.config import _validate_config_key


### PR DESCRIPTION
## What Problem This Solves

`hermes config set agent.reasoning_effort high` emitted a false `⚠ 'agent.reasoning_effort' is not a recognized config key` warning even though `agent.reasoning_effort` is a documented, runtime-consumed config key (read at `hermes_constants.py:1363` via `agent_cfg.get("reasoning_effort", "")`). The value was saved correctly, but the warning (and a wrong "Did you mean: agent.reasoning_overrides" hint) misled users into thinking Hermes wouldn't read it. Closes #85741.

## Why This Change Was Made

`_validate_config_key()` in `hermes_cli/config.py` walks `DEFAULT_CONFIG` to decide known-vs-unknown. `DEFAULT_CONFIG["agent"]` had `reasoning_overrides` but no `reasoning_effort` field, so the walker hit an unknown sub-key and returned `(False, "agent.reasoning_overrides")`. Adding the field with the same default the runtime already uses (`""` = provider default) makes the validator recognize the key and silences the false warning without changing any runtime behavior.

## User Impact

- `hermes config set agent.reasoning_effort <level>` no longer prints a false "not a recognized config key" warning.
- The "Did you mean" hint for a typo like `agent.reasoning_effor` now correctly suggests `agent.reasoning_effort` instead of `agent.reasoning_overrides`.
- No behavior change for existing config loads: the runtime already reads `agent.reasoning_effort` with an `""` default, which is exactly what this adds to `DEFAULT_CONFIG`.

## Evidence

Validator behavior before/after (on this branch):

```
agent.reasoning_effort  -> (True, None)              # was (False, "agent.reasoning_overrides")
agent.reasoning_overrides -> (True, None)            # unchanged
agent.reasoning_effor (typo) -> (False, "agent.reasoning_effort")   # was (False, "agent.reasoning_overrides")
```

End-to-end repro:
```
$ hermes config set agent.reasoning_effort high
✓ Set agent.reasoning_effort = high in <config path>
# (no warning line — previously printed the ⚠ unrecognized-key notice)
```

Test run:
```
$ python -m pytest tests/hermes_cli/test_set_config_value.py -q
84 passed in 2.33s
```

Lint/build:
```
$ python -m ruff check hermes_cli/config_defaults.py tests/hermes_cli/test_set_config_value.py
All checks passed!
$ python -m py_compile hermes_cli/config_defaults.py tests/hermes_cli/test_set_config_value.py  # OK
```

## Notes for Reviewers

- This is a single-file schema fix (+6 lines in `config_defaults.py`) plus one parametrize entry in the test (+1 line). No runtime logic changes.
- The default value `""` matches the existing runtime read at `hermes_constants.py:1363` (`agent_cfg.get("reasoning_effort", "")`), so there is no behavior shift for users who never set this key.
- I did not bump `_config_version` because adding a new key to an existing section is handled by the deep-merge and does not require active migration (per the CONTRIBUTING note in `hermes_cli/config.py`).
- AI-assisted: drafted with opencode (GLM-5.2). I verified the fix by running the validator, the test file, ruff, and a live `set_config_value` repro on Windows.