### PR TITLE
feat(cli): add CPU profiling flag

### DIFF
--- a/hermes_cli/_parser.py
+++ b/hermes_cli/_parser.py
@@ -125,6 +125,15 @@ def build_top_level_parser():
             "can always account for spend. No effect outside -z/--oneshot."
         ),
     )
+    parser.add_argument(
+        "--cpu-profile",
+        metavar="PATH",
+        default=None,
+        help=(
+            "Write a Python cProfile snapshot to PATH when the process exits. "
+            "Also writes PATH.txt with the top cumulative functions."
+        ),
+    )
     # --model / --provider are accepted at the top level so they can pair
     # with -z without needing the `chat` subcommand.  If neither -z nor a
     # subcommand consumes them, they fall through harmlessly as None.

--- a/hermes_cli/cpu_profile.py
+++ b/hermes_cli/cpu_profile.py
@@ -1,0 +1,70 @@
+"""CPU profiling support for Hermes CLI entrypoints.
+
+The profiler is intentionally process-scoped: the CLI enables it once after
+argument parsing and writes the profile at interpreter shutdown. This covers
+long-running commands such as ``gateway run`` and regular short commands
+without forcing every command handler through a wrapper.
+"""
+
+from __future__ import annotations
+
+import atexit
+import cProfile
+import logging
+import os
+import pstats
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+_profiler: cProfile.Profile | None = None
+_profile_path: Path | None = None
+
+
+def enable_cpu_profile(path: str | os.PathLike[str] | None) -> Path | None:
+    """Start process-wide CPU profiling and dump pstats data on exit.
+
+    Returns the resolved profile path when profiling was enabled. Repeated calls
+    are idempotent so fast-path/full-parser handoffs and tests cannot register
+    duplicate atexit writers.
+    """
+
+    global _profiler, _profile_path
+    if not path:
+        return None
+    target = Path(path).expanduser().resolve()
+    if _profiler is not None:
+        return _profile_path
+
+    target.parent.mkdir(parents=True, exist_ok=True)
+    profiler = cProfile.Profile()
+    profiler.enable()
+    _profiler = profiler
+    _profile_path = target
+    atexit.register(_write_cpu_profile)
+    os.environ["HERMES_CPU_PROFILE"] = str(target)
+    logger.info("CPU profiling enabled: %s", target)
+    return target
+
+
+def _write_cpu_profile() -> None:
+    global _profiler
+    profiler = _profiler
+    target = _profile_path
+    if profiler is None or target is None:
+        return
+    try:
+        profiler.disable()
+        target.parent.mkdir(parents=True, exist_ok=True)
+        profiler.dump_stats(str(target))
+        # Emit a tiny human-readable companion file so users can inspect the
+        # hottest functions without remembering the pstats incantation.
+        txt = target.with_suffix(target.suffix + ".txt")
+        with txt.open("w", encoding="utf-8") as fh:
+            stats = pstats.Stats(profiler, stream=fh).sort_stats("cumulative")
+            stats.print_stats(80)
+        logger.info("CPU profile written: %s", target)
+    except Exception:
+        logger.exception("Failed to write CPU profile: %s", target)
+    finally:
+        _profiler = None

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -572,6 +572,7 @@ def _apply_profile_override() -> None:
     # The exception is command-argv passthrough regions such as `mcp add --args`.
     value_flags = {
         "-z", "--oneshot",
+        "--cpu-profile",
         "-m", "--model",
         "--provider",
         "-t", "--toolsets",
@@ -11208,6 +11209,7 @@ _BUILTIN_SUBCOMMANDS = frozenset(
 _TOP_LEVEL_VALUE_FLAGS = frozenset(
     {
         "-z", "--oneshot",
+        "--cpu-profile",
         "-m", "--model",
         "--provider",
         "-t", "--toolsets",
@@ -11440,6 +11442,17 @@ def _apply_safe_mode(args) -> None:
     os.environ["HERMES_IGNORE_RULES"] = "1"
 
 
+def _enable_cpu_profile_from_args(args) -> None:
+    profile_path = getattr(args, "cpu_profile", None)
+    if not profile_path:
+        return
+    from hermes_cli.cpu_profile import enable_cpu_profile
+
+    enabled = enable_cpu_profile(profile_path)
+    if enabled is not None:
+        print(f"CPU profiling enabled: {enabled}", file=sys.stderr)
+
+
 def _set_chat_arg_defaults(args) -> None:
     for attr, default in [
         ("query", None),
@@ -11507,6 +11520,7 @@ def _try_fast_chat_launch() -> bool:
     if getattr(args, "command", None) not in {None, "chat"}:
         return False
 
+    _enable_cpu_profile_from_args(args)
     if getattr(args, "yolo", False):
         os.environ["HERMES_YOLO_MODE"] = "1"
     _prepare_agent_startup(args)
@@ -11567,6 +11581,7 @@ def _try_termux_fast_cli_launch() -> bool:
         _print_version_info(check_updates=False)
         return True
 
+    _enable_cpu_profile_from_args(args)
     if getattr(args, "oneshot", None):
         _prepare_agent_startup(args)
         _confirm_startup_expensive_model_override(args)
@@ -11637,6 +11652,7 @@ def _try_termux_fast_tui_launch() -> bool:
     if not _resolve_use_tui(args):
         return False
 
+    _enable_cpu_profile_from_args(args)
     cmd_chat(args)
     return True
 
@@ -13348,6 +13364,8 @@ def main():
     if args.version:
         cmd_version(args)
         return
+
+    _enable_cpu_profile_from_args(args)
 
     # --yolo: set HERMES_YOLO_MODE *before* plugin discovery.  The call to
     # _prepare_agent_startup() below triggers discover_plugins() → tool

--- a/tests/hermes_cli/test_cpu_profile.py
+++ b/tests/hermes_cli/test_cpu_profile.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import importlib
+import os
+import pstats
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_parser_accepts_cpu_profile_before_chat(tmp_path: Path):
+    from hermes_cli._parser import build_top_level_parser
+
+    parser, _subparsers, _chat = build_top_level_parser()
+    target = tmp_path / "hermes.prof"
+    args = parser.parse_args(["--cpu-profile", str(target), "chat"])
+
+    assert args.cpu_profile == str(target)
+    assert args.command == "chat"
+
+
+def test_enable_cpu_profile_writes_stats_and_text_summary(tmp_path: Path):
+    import hermes_cli.cpu_profile as cpu_profile
+
+    cpu_profile = importlib.reload(cpu_profile)
+    target = tmp_path / "nested" / "hermes.prof"
+
+    enabled = cpu_profile.enable_cpu_profile(target)
+    assert enabled == target.resolve()
+    sum(i * i for i in range(1000))
+    cpu_profile._write_cpu_profile()
+
+    assert target.exists()
+    assert target.with_suffix(target.suffix + ".txt").exists()
+    stats = pstats.Stats(str(target))
+    assert stats.total_calls > 0
+
+
+def test_cli_cpu_profile_smoke_writes_profile(tmp_path: Path):
+    target = tmp_path / "cli.prof"
+    hermes_home = tmp_path / "home"
+    hermes_home.mkdir()
+
+    env = os.environ.copy()
+    env.update({"HERMES_HOME": str(hermes_home), "PYTHONPATH": str(Path(__file__).resolve().parents[2])})
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "hermes_cli.main",
+            "--cpu-profile",
+            str(target),
+            "completion",
+            "bash",
+        ],
+        cwd=Path(__file__).resolve().parents[2],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+
+    assert result.returncode == 0, result.stderr[:1000]
+    assert "CPU profiling enabled:" in result.stderr
+    assert target.exists()
+    assert target.with_suffix(target.suffix + ".txt").exists()
+    assert pstats.Stats(str(target)).total_calls > 0


### PR DESCRIPTION
## Summary
Hermes can now write a process-wide CPU profile for CLI, gateway, cron, and other subcommands with `--cpu-profile PATH`.

Ported from anomalyco/opencode#42862 and adapted from Bun inspector profiles to Python `cProfile`/`pstats` output.

## Changes
- `hermes_cli/_parser.py`: adds the global `--cpu-profile PATH` flag.
- `hermes_cli/main.py`: enables profiling after parse on full and fast launch paths, before agent startup where applicable.
- `hermes_cli/cpu_profile.py`: starts process-wide profiling and writes `PATH` plus `PATH.txt` at interpreter shutdown.
- `tests/hermes_cli/test_cpu_profile.py`: parser, profiler, and real CLI smoke coverage.

## Validation
| Check | Result |
|---|---|
| `python -m py_compile` on changed Python files | pass |
| `scripts/run_tests.sh tests/hermes_cli/test_cpu_profile.py` | 3 passed |
| Real CLI smoke | covered by test: `python -m hermes_cli.main --cpu-profile <tmp>/cli.prof completion bash` writes valid pstats output |

Source: https://github.com/anomalyco/opencode/pull/42862

## Infographic

Skipped: image generation failed because the configured FAL account is out of balance (`Exhausted balance`).
