### PR TITLE
fix(git): isolate internal git subprocess config

### DIFF
--- a/hermes_cli/_subprocess_compat.py
+++ b/hermes_cli/_subprocess_compat.py
@@ -359,6 +359,10 @@ def noninteractive_git_env(
       instead of prompting for credentials.
     * ``GCM_INTERACTIVE=Never`` — Git Credential Manager (the default
       credential helper on Windows installs) never pops its own dialog.
+    * isolated git config — inherited ``GIT_CONFIG_*`` overrides, global/system
+      config, pagers, editors, fsmonitor, external diff, and hooks are disabled
+      for the child process. A user's repo/global config should not be able to
+      hang or mutate Hermes's internal plumbing calls.
 
     ``GIT_ASKPASS`` / ``SSH_ASKPASS`` are deliberately left alone: when the
     user has a *working* askpass helper or ssh-agent configured, auth should
@@ -375,6 +379,43 @@ def noninteractive_git_env(
     env = dict(base if base is not None else os.environ)
     env["GIT_TERMINAL_PROMPT"] = "0"
     env["GCM_INTERACTIVE"] = "Never"
+
+    # Do not inherit caller-supplied config injection. We rebuild the
+    # GIT_CONFIG_COUNT block below so ambient -c values cannot re-enable
+    # pagers, hooks, fsmonitor, editors, or credential prompts.
+    for key in list(env):
+        if (
+            key == "GIT_CONFIG_PARAMETERS"
+            or key.startswith("GIT_CONFIG_KEY_")
+            or key.startswith("GIT_CONFIG_VALUE_")
+        ):
+            env.pop(key, None)
+    env.pop("GIT_CONFIG_COUNT", None)
+
+    devnull = os.devnull
+    env["GIT_CONFIG_GLOBAL"] = devnull
+    env["GIT_CONFIG_SYSTEM"] = devnull
+    env["GIT_CONFIG_NOSYSTEM"] = "1"
+    env["GIT_PAGER"] = "cat"
+    env["PAGER"] = "cat"
+    env["GIT_EDITOR"] = "true"
+
+    config_overrides = {
+        "credential.helper": "",
+        "core.askPass": "",
+        "core.fsmonitor": "false",
+        "core.untrackedCache": "false",
+        "core.hooksPath": devnull,
+        "core.pager": "cat",
+        "core.editor": "true",
+        "sequence.editor": "true",
+        "diff.external": "",
+    }
+    env["GIT_CONFIG_COUNT"] = str(len(config_overrides))
+    for idx, (key, value) in enumerate(config_overrides.items()):
+        env[f"GIT_CONFIG_KEY_{idx}"] = key
+        env[f"GIT_CONFIG_VALUE_{idx}"] = value
+
     return env
 
 

--- a/tests/hermes_cli/test_noninteractive_git.py
+++ b/tests/hermes_cli/test_noninteractive_git.py
@@ -56,6 +56,47 @@ class TestNoninteractiveGitEnv:
         env = noninteractive_git_env({"GIT_TERMINAL_PROMPT": "1"})
         assert env["GIT_TERMINAL_PROMPT"] == "0"
 
+    def test_strips_ambient_git_config_injection(self):
+        env = noninteractive_git_env(
+            {
+                "GIT_CONFIG_COUNT": "2",
+                "GIT_CONFIG_KEY_0": "core.pager",
+                "GIT_CONFIG_VALUE_0": "less",
+                "GIT_CONFIG_KEY_1": "core.hooksPath",
+                "GIT_CONFIG_VALUE_1": ".git/hooks",
+                "GIT_CONFIG_PARAMETERS": "'core.pager=less'",
+            }
+        )
+
+        assert env["GIT_CONFIG_COUNT"] != "2"
+        assert "GIT_CONFIG_PARAMETERS" not in env
+        values = {
+            env[f"GIT_CONFIG_KEY_{idx}"]: env[f"GIT_CONFIG_VALUE_{idx}"]
+            for idx in range(int(env["GIT_CONFIG_COUNT"]))
+        }
+        assert values["core.pager"] == "cat"
+        assert values["core.hooksPath"] == os.devnull
+        assert values["credential.helper"] == ""
+
+    def test_disables_pagers_hooks_editors_and_user_config(self):
+        env = noninteractive_git_env({})
+        values = {
+            env[f"GIT_CONFIG_KEY_{idx}"]: env[f"GIT_CONFIG_VALUE_{idx}"]
+            for idx in range(int(env["GIT_CONFIG_COUNT"]))
+        }
+
+        assert env["GIT_CONFIG_GLOBAL"] == os.devnull
+        assert env["GIT_CONFIG_SYSTEM"] == os.devnull
+        assert env["GIT_CONFIG_NOSYSTEM"] == "1"
+        assert env["GIT_PAGER"] == "cat"
+        assert env["PAGER"] == "cat"
+        assert env["GIT_EDITOR"] == "true"
+        assert values["core.fsmonitor"] == "false"
+        assert values["core.hooksPath"] == os.devnull
+        assert values["core.editor"] == "true"
+        assert values["sequence.editor"] == "true"
+        assert values["diff.external"] == ""
+
 
 # ---------------------------------------------------------------------------
 # 2. Real-git E2E: 401 remote fails fast instead of prompting


### PR DESCRIPTION
## Summary
Hermes internal git subprocesses now run with isolated non-interactive Git configuration, so user/global pagers, hooks, editors, fsmonitor, and ambient `GIT_CONFIG_*` injection cannot hang or mutate plumbing calls.

Port adapted from google-gemini/gemini-cli#28792. Hermes already had `GIT_TERMINAL_PROMPT=0` / `GCM_INTERACTIVE=Never`; this extends the shared helper to also neutralize config-driven prompts and side effects for existing internal call sites.

## Changes
- `hermes_cli/_subprocess_compat.py`: extend `noninteractive_git_env()` to scrub inherited Git config injection, ignore global/system config, and set safe overrides for hooks, pagers, editors, fsmonitor, credential helpers, and external diff.
- `tests/hermes_cli/test_noninteractive_git.py`: cover ambient config scrubbing and the new pager/hook/editor isolation contract.

## Validation
| Check | Result |
|---|---|
| `scripts/run_tests.sh tests/hermes_cli/test_noninteractive_git.py` | 7 passed |
| `python3 -m py_compile hermes_cli/_subprocess_compat.py tests/hermes_cli/test_noninteractive_git.py` | passed |
| Manual E2E | global `core.hooksPath` pre-commit hook fails without helper, succeeds with `noninteractive_git_env()` |
| `git diff --check` | passed |

## Source
- google-gemini/gemini-cli#28792

## Infographic
Generation attempted with the required style picker result (`bebop-jazznoir`, `bento-grid`) but the FAL backend returned `Exhausted balance`; no image was attached.