### PR TITLE
Inspired by Claude Code: cap local terminal memory

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -3376,6 +3376,7 @@ TERMINAL_CONFIG_ENV_MAP = {
     "degraded_mode": "TERMINAL_DEGRADED_MODE",
     "cwd": "TERMINAL_CWD",
     "timeout": "TERMINAL_TIMEOUT",
+    "local_memory_max_mb": "TERMINAL_LOCAL_MEMORY_MAX_MB",
     "lifetime_seconds": "TERMINAL_LIFETIME_SECONDS",
     "docker_image": "TERMINAL_DOCKER_IMAGE",
     "docker_forward_env": "TERMINAL_DOCKER_FORWARD_ENV",

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -330,6 +330,13 @@ DEFAULT_CONFIG = {
         # it here without patching the built desktop app.
         "font_family": "",
         "timeout": 180,
+        # Optional local-backend address-space cap for each foreground shell
+        # command, in MiB. Inspired by Claude Code's opt-in Bash memory cgroup
+        # guard: a runaway build should fail inside the tool call instead of
+        # stalling the Hermes session. Empty/0 disables the foreground cap.
+        # Gateway background tasks use the same value when systemd scope
+        # isolation is available.
+        "local_memory_max_mb": "",
         # Bounded grace period (seconds) between SIGTERM and an escalated
         # SIGKILL when terminating a host process tree (browser daemons, etc.).
         # A daemon that stalls in its SIGTERM handler is force-killed after this

--- a/tests/tools/test_local_memory_limit.py
+++ b/tests/tools/test_local_memory_limit.py
@@ -1,0 +1,64 @@
+import json
+import os
+import sys
+
+import pytest
+
+
+def test_terminal_config_bridges_local_memory_limit(monkeypatch):
+    from hermes_cli.config import apply_terminal_config_to_env
+
+    env = {}
+    apply_terminal_config_to_env(
+        env=env,
+        config={"terminal": {"backend": "local", "local_memory_max_mb": 256}},
+        override=True,
+    )
+
+    assert env["TERMINAL_LOCAL_MEMORY_MAX_MB"] == "256"
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="resource limits are POSIX-only")
+def test_local_terminal_foreground_inherits_memory_limit(monkeypatch, tmp_path):
+    from tools import terminal_tool as tt
+
+    monkeypatch.setenv("TERMINAL_ENV", "local")
+    monkeypatch.setenv("TERMINAL_CWD", str(tmp_path))
+    monkeypatch.setenv("TERMINAL_LOCAL_MEMORY_MAX_MB", "128")
+    monkeypatch.setattr(tt, "_terminal_config_bridge_attempted", True)
+    tt.cleanup_all_environments()
+
+    command = (
+        f"{sys.executable} -c "
+        "'import resource; print(resource.getrlimit(resource.RLIMIT_AS)[0])'"
+    )
+    try:
+        result = json.loads(tt.terminal_tool(command=command, timeout=10))
+    finally:
+        tt.cleanup_all_environments()
+
+    assert result["exit_code"] == 0
+    assert result["output"].strip().splitlines()[0] == str(128 * 1024 * 1024)
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="resource limits are POSIX-only")
+def test_local_terminal_memory_limit_zero_disables_cap(monkeypatch, tmp_path):
+    from tools import terminal_tool as tt
+
+    monkeypatch.setenv("TERMINAL_ENV", "local")
+    monkeypatch.setenv("TERMINAL_CWD", str(tmp_path))
+    monkeypatch.setenv("TERMINAL_LOCAL_MEMORY_MAX_MB", "0")
+    monkeypatch.setattr(tt, "_terminal_config_bridge_attempted", True)
+    tt.cleanup_all_environments()
+
+    command = (
+        f"{sys.executable} -c "
+        "'import resource; print(resource.getrlimit(resource.RLIMIT_AS)[0])'"
+    )
+    try:
+        result = json.loads(tt.terminal_tool(command=command, timeout=10))
+    finally:
+        tt.cleanup_all_environments()
+
+    assert result["exit_code"] == 0
+    assert result["output"].strip().splitlines()[0] == "-1"

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -22,6 +22,68 @@ _IS_WINDOWS = platform.system() == "Windows"
 logger = logging.getLogger(__name__)
 
 
+_MIN_LOCAL_MEMORY_MAX_MB = 64
+
+
+def _configured_local_memory_max_bytes() -> int | None:
+    """Return the opt-in per-command local memory cap in bytes.
+
+    ``terminal.local_memory_max_mb`` is bridged into
+    ``TERMINAL_LOCAL_MEMORY_MAX_MB`` by the config layer so child processes and
+    background executors see the same setting. Empty/0 disables the foreground
+    cap. Invalid values are ignored with a warning instead of breaking terminal
+    startup.
+    """
+    raw = os.getenv("TERMINAL_LOCAL_MEMORY_MAX_MB", "").strip()
+    if not raw:
+        return None
+    try:
+        mb = int(raw)
+    except ValueError:
+        logger.warning(
+            "Ignoring invalid TERMINAL_LOCAL_MEMORY_MAX_MB=%r; expected an integer MiB value.",
+            raw,
+        )
+        return None
+    if mb <= 0:
+        return None
+    if mb < _MIN_LOCAL_MEMORY_MAX_MB:
+        logger.warning(
+            "Ignoring TERMINAL_LOCAL_MEMORY_MAX_MB=%r; minimum is %d MiB.",
+            raw,
+            _MIN_LOCAL_MEMORY_MAX_MB,
+        )
+        return None
+    return mb * 1024 * 1024
+
+
+def _local_memory_limit_preexec():
+    """Build a POSIX preexec_fn that caps foreground local shell memory.
+
+    The limit applies to the bash wrapper and descendants via ``RLIMIT_AS``.
+    This is a best-effort local equivalent of Claude Code's opt-in Bash memory
+    cgroup guard; it is intentionally disabled on Windows where ``resource`` is
+    unavailable.
+    """
+    if _IS_WINDOWS:
+        return None
+    memory_max = _configured_local_memory_max_bytes()
+    if memory_max is None:
+        return None
+
+    def _apply_limit() -> None:
+        try:
+            import resource
+
+            resource.setrlimit(resource.RLIMIT_AS, (memory_max, memory_max))
+        except Exception:
+            # Avoid logging from preexec_fn: after fork in a multi-threaded
+            # process, taking locks can deadlock the child before exec.
+            pass
+
+    return _apply_limit
+
+
 def _msys_to_windows_path(cwd: str) -> str:
     """Translate a Git Bash / MSYS-style POSIX path (``/c/Users/x``) to the
     native Windows form (``C:\\Users\\x``) so ``os.path.isdir`` and
@@ -1528,6 +1590,9 @@ class LocalEnvironment(BaseEnvironment):
         _popen_cwd = self.cwd
 
         _popen_kwargs = {"creationflags": windows_hide_flags()} if _IS_WINDOWS else {}
+        memory_limit_preexec = _local_memory_limit_preexec()
+        if memory_limit_preexec is not None:
+            _popen_kwargs["preexec_fn"] = memory_limit_preexec
 
         proc = subprocess.Popen(
             args,

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -245,6 +245,7 @@ These variables configure the [Tool Gateway](/user-guide/features/tool-gateway) 
 | `TERMINAL_DAYTONA_IMAGE` | Daytona sandbox image |
 | `TERMINAL_VERCEL_RUNTIME` | Vercel Sandbox runtime (`node24`, `node22`, `python3.13`) |
 | `TERMINAL_TIMEOUT` | Command timeout in seconds |
+| `TERMINAL_LOCAL_MEMORY_MAX_MB` | Optional local-backend foreground command memory cap in MiB. Prefer `terminal.local_memory_max_mb` in `config.yaml`; empty/0 disables. |
 | `TERMINAL_LIFETIME_SECONDS` | Max lifetime for terminal sessions in seconds |
 | `TERMINAL_CWD` | Deprecated direct override for gateway/cron terminal sessions. Prefer `terminal.cwd` in `config.yaml`; CLI still uses the launch directory. |
 | `SUDO_PASSWORD` | Enable sudo without interactive prompt |

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -142,6 +142,7 @@ terminal:
   cwd: "."          # Gateway/cron working directory (CLI always uses launch dir)
   font_family: ""   # Desktop terminal font; e.g. "MesloLGS NF"
   timeout: 180      # Per-command timeout in seconds
+  local_memory_max_mb: ""  # Optional local-backend foreground command memory cap (MiB)
   home_mode: auto   # auto | real | profile — subprocess HOME policy
   env_passthrough: []  # Env var names to forward to sandboxed execution (terminal + execute_code)
   singularity_image: "docker://nikolaik/python-nodejs:python3.11-nodejs20"  # Container image for Singularity backend
@@ -172,7 +173,14 @@ The default. Commands run directly on your machine with no isolation. No special
 ```yaml
 terminal:
   backend: local
+  local_memory_max_mb: ""  # Set e.g. 4096 to cap foreground commands at 4 GiB
 ```
+
+`terminal.local_memory_max_mb` is an opt-in guard for runaway local shell
+commands. When set to an integer MiB value (minimum 64), Hermes applies a
+per-command POSIX address-space limit to foreground `terminal` calls on Linux
+and macOS. Empty or `0` disables the cap. Gateway background tasks also use the
+same setting when systemd scope isolation is available.
 
 By default, local tool subprocesses keep your real OS-user `HOME`. This lets
 external CLIs such as `git`, `ssh`, `gh`, `az`, `npm`, Claude Code, and Codex
@@ -335,6 +343,7 @@ Every key under `terminal:` has an env-var override of the form `TERMINAL_<KEY_U
 | `TERMINAL_CONTAINER_PERSISTENT` | `container_persistent` | `true` / `false` — controls the bind-mount workspace dirs, distinct from `docker_persist_across_processes` |
 | `TERMINAL_LIFETIME_SECONDS` | `lifetime_seconds` | Idle reaper window |
 | `TERMINAL_TIMEOUT` | `timeout` | Per-command timeout |
+| `TERMINAL_LOCAL_MEMORY_MAX_MB` | `local_memory_max_mb` | Optional local-backend foreground command memory cap in MiB |
 | `HERMES_DOCKER_BINARY` | _none_ | Force a specific docker/podman binary path |
 
 ### SSH Backend

--- a/website/docs/user-guide/features/tools.md
+++ b/website/docs/user-guide/features/tools.md
@@ -190,6 +190,10 @@ terminal:
   container_persistent: true    # Persist filesystem across sessions (default: true)
 ```
 
+For the local backend, set `terminal.local_memory_max_mb` to an integer MiB
+value if you want foreground shell commands to fail inside the tool call instead
+of consuming unbounded host memory. Empty or `0` leaves local commands uncapped.
+
 When `container_persistent: true`, installed packages, files, and config survive across sessions.
 
 ### Container Security

--- a/website/static/img/pr/claude-code-local-memory-guard.svg
+++ b/website/static/img/pr/claude-code-local-memory-guard.svg
@@ -1,0 +1,64 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 1200" width="1200" height="1200" role="img" aria-labelledby="title desc">
+  <title id="title">Local Terminal Memory Guard</title>
+  <desc id="desc">A mission-patch style infographic for a Hermes Agent PR adding an opt-in local terminal memory cap.</desc>
+  <defs>
+    <radialGradient id="bg" cx="50%" cy="45%" r="70%">
+      <stop offset="0" stop-color="#151922"/>
+      <stop offset="1" stop-color="#050608"/>
+    </radialGradient>
+    <linearGradient id="blue" x1="0" x2="1">
+      <stop offset="0" stop-color="#6ad8ff"/>
+      <stop offset="1" stop-color="#2f7dff"/>
+    </linearGradient>
+    <filter id="soft" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="8" stdDeviation="10" flood-color="#000" flood-opacity="0.45"/>
+    </filter>
+    <pattern id="stitch" width="12" height="12" patternUnits="userSpaceOnUse">
+      <path d="M0 6h6" stroke="#2b3039" stroke-width="2"/>
+      <path d="M6 0v6" stroke="#1b2028" stroke-width="2"/>
+    </pattern>
+  </defs>
+
+  <rect width="1200" height="1200" fill="#06070a"/>
+  <circle cx="600" cy="600" r="552" fill="url(#bg)" stroke="#d8cfbd" stroke-width="18"/>
+  <circle cx="600" cy="600" r="518" fill="url(#stitch)" opacity="0.42" stroke="#a9693f" stroke-width="6" stroke-dasharray="20 16"/>
+  <circle cx="600" cy="600" r="468" fill="none" stroke="#445064" stroke-width="3" stroke-dasharray="4 12"/>
+
+  <text x="600" y="130" text-anchor="middle" fill="#f3ead8" font-family="Arial Black, Impact, sans-serif" font-size="48" letter-spacing="4">LOCAL TERMINAL</text>
+  <text x="600" y="184" text-anchor="middle" fill="#f3ead8" font-family="Arial Black, Impact, sans-serif" font-size="48" letter-spacing="4">MEMORY GUARD</text>
+  <text x="600" y="226" text-anchor="middle" fill="#82d8ff" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="23" letter-spacing="2">Claude Code-inspired safety cap</text>
+
+  <g filter="url(#soft)">
+    <rect x="220" y="290" width="360" height="210" rx="28" fill="#111722" stroke="#d8cfbd" stroke-width="5"/>
+    <rect x="620" y="290" width="360" height="210" rx="28" fill="#111722" stroke="#d8cfbd" stroke-width="5"/>
+    <rect x="220" y="540" width="360" height="210" rx="28" fill="#111722" stroke="#d8cfbd" stroke-width="5"/>
+    <rect x="620" y="540" width="360" height="210" rx="28" fill="#111722" stroke="#d8cfbd" stroke-width="5"/>
+  </g>
+
+  <g font-family="Arial Black, Impact, sans-serif" letter-spacing="2">
+    <text x="400" y="350" text-anchor="middle" fill="#f3ead8" font-size="26">CONFIG KNOB</text>
+    <text x="800" y="350" text-anchor="middle" fill="#f3ead8" font-size="26">FOREGROUND CAP</text>
+    <text x="400" y="600" text-anchor="middle" fill="#f3ead8" font-size="26">SHARED BRIDGE</text>
+    <text x="800" y="600" text-anchor="middle" fill="#f3ead8" font-size="26">VERIFIED</text>
+  </g>
+
+  <g font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="26" fill="#9fe6ff">
+    <text x="400" y="410" text-anchor="middle">terminal.</text>
+    <text x="400" y="445" text-anchor="middle">local_memory_max_mb</text>
+    <text x="800" y="425" text-anchor="middle">RLIMIT_AS</text>
+    <text x="800" y="460" text-anchor="middle">per command</text>
+    <text x="400" y="665" text-anchor="middle">TERMINAL_LOCAL</text>
+    <text x="400" y="700" text-anchor="middle">_MEMORY_MAX_MB</text>
+    <text x="800" y="665" text-anchor="middle">3 tests</text>
+    <text x="800" y="700" text-anchor="middle">+ isolated E2E</text>
+  </g>
+
+  <g transform="translate(600 850)">
+    <circle cx="0" cy="0" r="96" fill="#0e141f" stroke="url(#blue)" stroke-width="10"/>
+    <path d="M-54 30h108M-42 0h84M-30-30h60" stroke="#f3ead8" stroke-width="14" stroke-linecap="round"/>
+    <path d="M-78-70l78-28 78 28-18 122L0 88-60 52z" fill="none" stroke="#a9693f" stroke-width="8" stroke-linejoin="round"/>
+    <text x="0" y="142" text-anchor="middle" fill="#f3ead8" font-family="Arial Black, Impact, sans-serif" font-size="25" letter-spacing="3">RUNAWAY BUILD CONTAINED</text>
+  </g>
+
+  <text x="600" y="1110" text-anchor="middle" fill="#d8cfbd" font-family="Arial Black, Impact, sans-serif" font-size="34" letter-spacing="5">Nous Research</text>
+</svg>


### PR DESCRIPTION
## Summary
Hermes local terminal commands can now opt into a per-command memory cap, adapting Claude Code v2.1.233's Bash memory guard to Hermes' config-driven terminal backend.

## Source
- Claude Code changelog v2.1.233: https://code.claude.com/docs/en/changelog#2-1-233
- GitHub release v2.1.233: https://github.com/anthropics/claude-code/releases/tag/v2.1.233

Claude Code added opt-in memory cgroup support for Bash tool commands on Linux via `CLAUDE_CODE_TOOL_MEMORY_LIMIT` so a runaway build cannot stall the session.

## How our implementation differs
| Claude Code | Hermes |
|---|---|
| Env-var-facing `CLAUDE_CODE_TOOL_MEMORY_LIMIT` | User-facing `terminal.local_memory_max_mb` in `config.yaml`, bridged to `TERMINAL_LOCAL_MEMORY_MAX_MB` internally |
| Linux cgroup guard for Bash tool commands | POSIX foreground local commands use `RLIMIT_AS`; existing gateway background systemd scopes read the same env bridge |
| CLI-specific | Shared config bridge covers CLI, gateway, TUI, cron, and child processes |

## Changes
- `hermes_cli/config_defaults.py`: adds `terminal.local_memory_max_mb` default/docs.
- `hermes_cli/config.py`: bridges the config key into `TERMINAL_LOCAL_MEMORY_MAX_MB`.
- `tools/environments/local.py`: applies an opt-in foreground local command address-space limit before exec.
- `tests/tools/test_local_memory_limit.py`: verifies config bridging, enabled cap inheritance, and disabled behavior.
- Docs: configuration, tool backend guide, and env-var reference.

## Validation
| Check | Result |
|---|---|
| `python3 -m py_compile tools/environments/local.py hermes_cli/config.py hermes_cli/config_defaults.py tests/tools/test_local_memory_limit.py` | Pass |
| `HERMES_PYTHON=/home/teknium/.hermes/hermes-agent/.venv/bin/python scripts/run_tests.sh tests/tools/test_local_memory_limit.py` | 3/3 passed |
| Isolated `HERMES_HOME` E2E with real config + real `terminal_tool` import | `RLIMIT_AS=134217728`, env bridge `128` |
| `corepack npm run build:fast` in `website/` | Pass; existing broken `/docs/llms.txt` + `/docs/llms-full.txt` warnings only |

## Infographic

![local terminal memory guard](https://raw.githubusercontent.com/NousResearch/hermes-agent/refs/heads/claude-code-inspired/local-terminal-memory-limit/website/static/img/pr/claude-code-local-memory-guard.svg)
