### PR TITLE
fix: propagate thread-scoped stream failures

### DIFF
--- a/agent/thread_scoped_output.py
+++ b/agent/thread_scoped_output.py
@@ -80,23 +80,13 @@ class _ThreadRoutingStream:
 
     # --- file-like surface ------------------------------------------------
     def write(self, data):  # type: ignore[no-untyped-def]
-        try:
-            return self._target().write(data)
-        except Exception:
-            return len(data) if isinstance(data, str) else 0
+        return self._target().write(data)
 
     def flush(self):  # type: ignore[no-untyped-def]
-        try:
-            return self._target().flush()
-        except Exception:
-            return None
+        return self._target().flush()
 
     def writelines(self, lines):  # type: ignore[no-untyped-def]
-        target = self._target()
-        try:
-            return target.writelines(lines)
-        except Exception:
-            return None
+        return self._target().writelines(lines)
 
     def isatty(self) -> bool:
         try:

--- a/tests/agent/test_thread_scoped_output.py
+++ b/tests/agent/test_thread_scoped_output.py
@@ -13,8 +13,50 @@ import sys
 import threading
 import time
 
+import pytest
+
 import agent.thread_scoped_output as thread_output
-from agent.thread_scoped_output import thread_scoped_silence
+from agent.thread_scoped_output import _RoutingState, _ThreadRoutingStream, thread_scoped_silence
+
+
+class _WriteFailingStream(io.StringIO):
+    def write(self, data):
+        raise OSError("stream is closed")
+
+
+class _FlushFailingStream(io.StringIO):
+    def flush(self):
+        raise OSError("stream is closed")
+
+
+class _WritelinesFailingStream(io.StringIO):
+    def writelines(self, lines):
+        raise OSError("stream is closed")
+
+
+def _routing_stream(passthrough):
+    return _ThreadRoutingStream(passthrough, _RoutingState(io.StringIO()))
+
+
+def test_write_propagates_passthrough_stream_failure():
+    stream = _routing_stream(_WriteFailingStream())
+
+    with pytest.raises(OSError, match="stream is closed"):
+        stream.write("response")
+
+
+def test_flush_propagates_passthrough_stream_failure():
+    stream = _routing_stream(_FlushFailingStream())
+
+    with pytest.raises(OSError, match="stream is closed"):
+        stream.flush()
+
+
+def test_writelines_propagates_passthrough_stream_failure():
+    stream = _routing_stream(_WritelinesFailingStream())
+
+    with pytest.raises(OSError, match="stream is closed"):
+        stream.writelines(["response", "\n"])
 
 
 def _run_with_real_stream(fn):


### PR DESCRIPTION
## Summary
- preserve `TextIO` failure semantics in thread-scoped output routing
- add focused regression coverage for failing `write`, `flush`, and `writelines` sinks

## Validation
- `scripts/run_tests.sh tests/agent/test_thread_scoped_output.py -q` (6 passed)
- `ruff check agent/thread_scoped_output.py tests/agent/test_thread_scoped_output.py`
- `scripts/run_tests.sh` (unrelated baseline failures: 78 tests across 19 files; focused module passed)