### PR TITLE
fix(browser): avoid Windows chrome protocol chooser

### DIFF
--- a/tests/tools/test_browser_use_cli.py
+++ b/tests/tools/test_browser_use_cli.py
@@ -177,6 +177,65 @@ class TestSubprocessEnvironment:
         assert "/usr/bin" in parts
         assert "/home/u/.nvm/versions/node/v24.18.0/bin" in parts
 
+    def test_windows_subprocess_routes_chrome_urls_to_detected_browser(
+        self, monkeypatch
+    ):
+        """browser-harness opens chrome://inspect via stdlib webbrowser.
+
+        Windows' default webbrowser backend dispatches custom schemes through
+        the URL protocol registry, where chrome: is normally unregistered. A
+        direct BROWSER executable keeps that URI inside Chromium instead of
+        raising the native "Get an app to open this 'chrome' link" chooser.
+        """
+        import sys
+        from types import ModuleType
+
+        chrome = r"C:\Program Files\Google\Chrome\Application\chrome.exe"
+        browser_tool = ModuleType("tools.browser_tool")
+        browser_tool._build_browser_env = lambda: {}
+        monkeypatch.setitem(sys.modules, "tools.browser_tool", browser_tool)
+        monkeypatch.setattr(
+            "hermes_cli.browser_connect.get_chrome_debug_candidates",
+            lambda system: [chrome] if system == "Windows" else [],
+        )
+        monkeypatch.setattr(bu_cli.platform, "system", lambda: "Windows")
+
+        env = bu_cli._base_subprocess_env()
+
+        assert env["BROWSER"] == chrome
+
+    def test_windows_subprocess_preserves_explicit_browser_override(self, monkeypatch):
+        import sys
+        from types import ModuleType
+
+        browser_tool = ModuleType("tools.browser_tool")
+        browser_tool._build_browser_env = lambda: {"BROWSER": "custom-browser %s"}
+        monkeypatch.setitem(sys.modules, "tools.browser_tool", browser_tool)
+        monkeypatch.setattr(bu_cli.platform, "system", lambda: "Windows")
+        monkeypatch.setattr(
+            "hermes_cli.browser_connect.get_chrome_debug_candidates",
+            lambda _system: (_ for _ in ()).throw(
+                AssertionError("explicit BROWSER must skip candidate discovery")
+            ),
+        )
+
+        env = bu_cli._base_subprocess_env()
+
+        assert env["BROWSER"] == "custom-browser %s"
+
+    def test_non_windows_subprocess_does_not_force_browser(self, monkeypatch):
+        import sys
+        from types import ModuleType
+
+        browser_tool = ModuleType("tools.browser_tool")
+        browser_tool._build_browser_env = lambda: {}
+        monkeypatch.setitem(sys.modules, "tools.browser_tool", browser_tool)
+        monkeypatch.setattr(bu_cli.platform, "system", lambda: "Linux")
+
+        env = bu_cli._base_subprocess_env()
+
+        assert "BROWSER" not in env
+
 
 class TestToolSurfaceSwap:
     def test_legacy_browser_tools_hidden_in_cli_mode(self, monkeypatch):

--- a/tests/tools/test_browser_use_cli.py
+++ b/tests/tools/test_browser_use_cli.py
@@ -14,11 +14,48 @@ Covers the three seams the integration relies on:
 import json
 import os
 import stat
+import subprocess
 import time
+import webbrowser
 
 import pytest
 
 import tools.browser_use_cli as bu_cli
+
+
+# tests/conftest.py replaces webbrowser.get before each test to prevent real
+# browser launches. Keep the stdlib selector so this module can exercise it
+# safely with subprocess.Popen intercepted below.
+_STDLIB_WEBBROWSER_GET = webbrowser.get
+
+
+def _launch_browser_spec(monkeypatch, browser_spec, url):
+    """Launch through the real stdlib controller with no real subprocess."""
+    launched = []
+
+    class BrowserProcess:
+        def wait(self):
+            raise AssertionError("webbrowser waited for Chromium to exit")
+
+        def poll(self):
+            return None
+
+    def fake_popen(argv, **kwargs):
+        launched.append((argv, kwargs))
+        return BrowserProcess()
+
+    # Mirror stdlib's BROWSER registration for a bare command while keeping
+    # its global registry isolated. Command templates bypass this registry.
+    monkeypatch.setattr(
+        webbrowser,
+        "_browsers",
+        {browser_spec.lower(): [None, webbrowser.GenericBrowser(browser_spec)]},
+    )
+    monkeypatch.setattr(subprocess, "Popen", fake_popen)
+
+    controller = _STDLIB_WEBBROWSER_GET(browser_spec)
+    assert controller.open(url, new=2) is True
+    return launched
 
 
 @pytest.fixture(autouse=True)
@@ -177,23 +214,27 @@ class TestSubprocessEnvironment:
         assert "/usr/bin" in parts
         assert "/home/u/.nvm/versions/node/v24.18.0/bin" in parts
 
-    def test_windows_subprocess_routes_chrome_urls_to_detected_browser(
+    def test_windows_subprocess_opens_chrome_urls_without_waiting_or_shell(
         self, monkeypatch
     ):
         """browser-harness opens chrome://inspect via stdlib webbrowser.
 
-        Windows' default webbrowser backend dispatches custom schemes through
-        the URL protocol registry, where chrome: is normally unregistered. A
-        direct BROWSER executable keeps that URI inside Chromium instead of
-        raising the native "Get an app to open this 'chrome' link" chooser.
+        The generated BROWSER command must make stdlib's launcher return while
+        Chromium stays open. It must also preserve the executable path and URL
+        as separate argv entries instead of passing either through a shell.
         """
         import sys
         from types import ModuleType
 
         chrome = r"C:\Program Files\Google\Chrome\Application\chrome.exe"
+        url = 'chrome://inspect/#remote-debugging?literal=$(not-a-shell)&quote="kept"'
         browser_tool = ModuleType("tools.browser_tool")
         browser_tool._build_browser_env = lambda: {}
         monkeypatch.setitem(sys.modules, "tools.browser_tool", browser_tool)
+        monkeypatch.setattr(
+            "hermes_cli.browser_connect.detect_default_chromium",
+            lambda system: None if system == "Windows" else "unexpected",
+        )
         monkeypatch.setattr(
             "hermes_cli.browser_connect.get_chrome_debug_candidates",
             lambda system: [chrome] if system == "Windows" else [],
@@ -201,8 +242,46 @@ class TestSubprocessEnvironment:
         monkeypatch.setattr(bu_cli.platform, "system", lambda: "Windows")
 
         env = bu_cli._base_subprocess_env()
+        launched = _launch_browser_spec(monkeypatch, env["BROWSER"], url)
+        assert len(launched) == 1
+        argv, kwargs = launched[0]
+        assert argv == [chrome, url]
+        assert kwargs.get("shell", False) is False
 
-        assert env["BROWSER"] == chrome
+    def test_windows_subprocess_prefers_installed_default_chromium(self, monkeypatch):
+        import sys
+        from types import ModuleType
+
+        edge = r"C:\Program Files (x86)\Microsoft\Edge\Application\msedge.exe"
+        url = "chrome://inspect/#remote-debugging"
+        browser_tool = ModuleType("tools.browser_tool")
+        setattr(browser_tool, "_build_browser_env", lambda: {})
+        monkeypatch.setitem(sys.modules, "tools.browser_tool", browser_tool)
+        monkeypatch.setattr(
+            "hermes_cli.browser_connect.detect_default_chromium",
+            lambda system: "edge" if system == "Windows" else None,
+        )
+        monkeypatch.setattr(
+            "hermes_cli.browser_connect.chromium_executable",
+            lambda browser, system: (
+                edge if (browser, system) == ("edge", "Windows") else None
+            ),
+        )
+        monkeypatch.setattr(
+            "hermes_cli.browser_connect.get_chrome_debug_candidates",
+            lambda _system: (_ for _ in ()).throw(
+                AssertionError("installed default must win over fallback discovery")
+            ),
+        )
+        monkeypatch.setattr(bu_cli.platform, "system", lambda: "Windows")
+
+        env = bu_cli._base_subprocess_env()
+        launched = _launch_browser_spec(monkeypatch, env["BROWSER"], url)
+
+        assert len(launched) == 1
+        argv, kwargs = launched[0]
+        assert argv == [edge, url]
+        assert kwargs.get("shell", False) is False
 
     def test_windows_subprocess_preserves_explicit_browser_override(self, monkeypatch):
         import sys

--- a/tests/tools/test_browser_use_cli.py
+++ b/tests/tools/test_browser_use_cli.py
@@ -69,7 +69,7 @@ def _clean_env(monkeypatch):
 def _fake_cli(tmp_path, body):
     """Write an executable fake browser-use CLI and return its path."""
     script = tmp_path / "browser-use"
-    script.write_text("#!/bin/sh\n" + body)
+    script.write_text("#!/bin/sh\n" + body, encoding="utf-8")
     script.chmod(script.stat().st_mode | stat.S_IXUSR)
     return str(script)
 
@@ -1044,7 +1044,7 @@ class TestFindCliManagedBin:
         bin_dir = tmp_path / "home" / "bin"
         bin_dir.mkdir(parents=True)
         bu = bin_dir / "browser-use"
-        bu.write_text("#!/bin/sh\n")
+        bu.write_text("#!/bin/sh\n", encoding="utf-8")
         bu.chmod(bu.stat().st_mode | stat.S_IXUSR)
         assert bu_cli._find_cli_unpatched() == [str(bu)]
 
@@ -1052,7 +1052,7 @@ class TestFindCliManagedBin:
         bin_dir = tmp_path / "home" / "bin"
         bin_dir.mkdir(parents=True)
         uvx = bin_dir / "uvx"
-        uvx.write_text("#!/bin/sh\n")
+        uvx.write_text("#!/bin/sh\n", encoding="utf-8")
         uvx.chmod(uvx.stat().st_mode | stat.S_IXUSR)
         assert bu_cli._find_cli_unpatched() == [str(uvx), "browser-use"]
 
@@ -1066,7 +1066,7 @@ class TestFindCliManagedBin:
         cli_dir = tmp_path / "userhome" / ".local" / "bin"
         cli_dir.mkdir(parents=True)
         cli = cli_dir / "browser-use"
-        cli.write_text("#!/bin/sh\n")
+        cli.write_text("#!/bin/sh\n", encoding="utf-8")
         cli.chmod(cli.stat().st_mode | stat.S_IXUSR)
         assert bu_cli._find_cli_unpatched() == [str(cli)]
 
@@ -1078,12 +1078,12 @@ class TestFindCliManagedBin:
         user_dir = tmp_path / "userhome" / ".local" / "bin"
         user_dir.mkdir(parents=True)
         user_cli = user_dir / "browser-use"
-        user_cli.write_text("#!/bin/sh\n")
+        user_cli.write_text("#!/bin/sh\n", encoding="utf-8")
         user_cli.chmod(user_cli.stat().st_mode | stat.S_IXUSR)
         managed_dir = tmp_path / "home" / "bin"
         managed_dir.mkdir(parents=True)
         managed_cli = managed_dir / "browser-use"
-        managed_cli.write_text("#!/bin/sh\n")
+        managed_cli.write_text("#!/bin/sh\n", encoding="utf-8")
         managed_cli.chmod(managed_cli.stat().st_mode | stat.S_IXUSR)
         assert bu_cli._find_cli_unpatched() == [str(managed_cli)]
 
@@ -1092,13 +1092,13 @@ class TestFindCliManagedBin:
         path_dir = tmp_path / "onpath"
         path_dir.mkdir()
         path_cli = path_dir / "browser-use"
-        path_cli.write_text("#!/bin/sh\n")
+        path_cli.write_text("#!/bin/sh\n", encoding="utf-8")
         path_cli.chmod(path_cli.stat().st_mode | stat.S_IXUSR)
         monkeypatch.setenv("PATH", str(path_dir))
         managed_dir = tmp_path / "home" / "bin"
         managed_dir.mkdir(parents=True)
         managed_cli = managed_dir / "browser-use"
-        managed_cli.write_text("#!/bin/sh\n")
+        managed_cli.write_text("#!/bin/sh\n", encoding="utf-8")
         managed_cli.chmod(managed_cli.stat().st_mode | stat.S_IXUSR)
         assert bu_cli._find_cli_unpatched() == [str(managed_cli)]
 
@@ -1106,7 +1106,7 @@ class TestFindCliManagedBin:
         cli_dir = tmp_path / "userhome" / ".local" / "bin"
         cli_dir.mkdir(parents=True)
         uvx = cli_dir / "uvx"
-        uvx.write_text("#!/bin/sh\n")
+        uvx.write_text("#!/bin/sh\n", encoding="utf-8")
         uvx.chmod(uvx.stat().st_mode | stat.S_IXUSR)
         assert bu_cli._find_cli_unpatched() == [str(uvx), "browser-use"]
 
@@ -1134,7 +1134,7 @@ class TestInstallCli:
         bin_dir = tmp_path / "home" / "bin"
         bin_dir.mkdir(parents=True)
         cli = bin_dir / "browser-use"
-        cli.write_text("#!/bin/sh\n")
+        cli.write_text("#!/bin/sh\n", encoding="utf-8")
         cli.chmod(cli.stat().st_mode | stat.S_IXUSR)
         monkeypatch.setenv("HERMES_HOME", str(tmp_path / "home"))
         monkeypatch.setenv("PATH", str(tmp_path / "empty"))
@@ -1187,7 +1187,7 @@ class TestInstallCli:
         monkeypatch.setenv("HERMES_HOME", str(home))
         monkeypatch.setenv("PATH", str(tmp_path / "empty"))
         uv = tmp_path / "uv"
-        uv.write_text('#!/bin/sh\necho "no network" >&2\nexit 1\n')
+        uv.write_text('#!/bin/sh\necho "no network" >&2\nexit 1\n', encoding="utf-8")
         uv.chmod(uv.stat().st_mode | stat.S_IXUSR)
         import sys as _sys
         import types as _types

--- a/tools/browser_use_cli.py
+++ b/tools/browser_use_cli.py
@@ -9,6 +9,7 @@ import logging
 import os
 import platform
 import re
+import shlex
 import shutil
 import subprocess
 import time
@@ -132,11 +133,25 @@ def _base_subprocess_env() -> dict:
     # an app-chooser dialog. BROWSER makes stdlib invoke the detected Chromium
     # executable directly instead. Keep an explicit operator override intact.
     if platform.system() == "Windows" and not env.get("BROWSER"):
-        from hermes_cli.browser_connect import get_chrome_debug_candidates
+        from hermes_cli.browser_connect import (
+            chromium_executable,
+            detect_default_chromium,
+            get_chrome_debug_candidates,
+        )
 
-        candidates = get_chrome_debug_candidates("Windows")
-        if candidates:
-            env["BROWSER"] = candidates[0]
+        default_browser = detect_default_chromium("Windows")
+        executable = (
+            chromium_executable(default_browser, "Windows") if default_browser else None
+        )
+        if not executable:
+            candidates = get_chrome_debug_candidates("Windows")
+            executable = candidates[0] if candidates else None
+        if executable:
+            # ``%s`` plus a trailing ``&`` are stdlib webbrowser template
+            # syntax: it shlex-splits once, substitutes the URL into argv, and
+            # uses BackgroundBrowser (poll instead of wait). shlex.join keeps
+            # paths with spaces intact; neither path nor URL reaches a shell.
+            env["BROWSER"] = shlex.join([executable, "%s", "&"])
     return env
 
 

--- a/tools/browser_use_cli.py
+++ b/tools/browser_use_cli.py
@@ -7,6 +7,7 @@ instead of default browser tools
 import json
 import logging
 import os
+import platform
 import re
 import shutil
 import subprocess
@@ -124,6 +125,18 @@ def _base_subprocess_env() -> dict:
     # the PATH so coreutils are always reachable (see below).
     env["PATH"] = _floor_subprocess_path(env.get("PATH", ""))
     env.setdefault("ANONYMIZED_TELEMETRY", "false")
+    # browser-harness opens chrome://inspect through Python's stdlib
+    # webbrowser module when Chrome needs its remote-debugging toggle. On
+    # Windows the default backend sends that custom scheme through the OS URL
+    # registry, but Chrome normally does not register chrome:, so Windows shows
+    # an app-chooser dialog. BROWSER makes stdlib invoke the detected Chromium
+    # executable directly instead. Keep an explicit operator override intact.
+    if platform.system() == "Windows" and not env.get("BROWSER"):
+        from hermes_cli.browser_connect import get_chrome_debug_candidates
+
+        candidates = get_chrome_debug_candidates("Windows")
+        if candidates:
+            env["BROWSER"] = candidates[0]
     return env
 
 


### PR DESCRIPTION
## What does this PR do?

Prevents the Windows native **“Get an app to open this ‘chrome’ link”** chooser when Browser Use asks Chrome to enable remote debugging.

The updater timing was a correlation, not the cause. `scripts/desktop-update/windows.ps1 -SelfTestUi` exercised the Edge progress-shell launch/close path without activating the `chrome:` protocol. The actual source is Browser Harness 0.1.8: `browser_harness.admin._open_chrome_inspect()` calls Python’s `webbrowser.open("chrome://inspect/#remote-debugging")`. On Windows, the default `webbrowser` backend sends that custom scheme through the OS URL-protocol registry, where Chrome normally has no `chrome:` registration.

Hermes now sets the child process’s standard `BROWSER` variable to the already-detected Chromium executable on Windows. Python then launches Chromium directly, keeping the internal URL inside the browser instead of asking Windows to resolve `chrome:`. The existing `BROWSER` override remains authoritative, non-Windows behavior is unchanged, and no Desktop URL allowlist is widened.

## Related Issue

Related to #84507. Complements the guidance improvements in #84556 by fixing the underlying Windows dispatch path.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/browser_use_cli.py`: set `BROWSER` for every Windows Browser Use subprocess from the existing Chromium candidate resolver, unless the operator already set it.
- `tests/tools/test_browser_use_cli.py`: add regression coverage for detected Windows routing, explicit `BROWSER` override preservation, and non-Windows isolation (including a Windows Chrome path with spaces).
- `contributors/emails/bear@bearhuddleston.dev`: map the commit email to `BearHuddleston`, as required by the repository's contributor-attribution check.

## How to Test

1. Run the targeted subprocess-environment tests on Windows:
   ```text
   uv run --extra dev pytest tests/tools/test_browser_use_cli.py::TestSubprocessEnvironment -q
   ```
   Result: `5 passed`, including detected-browser routing, explicit-override preservation, and non-Windows isolation.
2. Run the affected test file in WSL/Linux (where its POSIX CLI fixtures are supported):
   ```text
   UV_PROJECT_ENVIRONMENT=/tmp/hermes-chrome-pr-venv uv run --extra dev pytest tests/tools/test_browser_use_cli.py -q
   ```
   Result: `95 passed`.
3. Run static checks:
   ```text
   uv run --extra dev ruff check tools/browser_use_cli.py tests/tools/test_browser_use_cli.py
   git diff --check origin/main...HEAD
   ```
   Result: both pass.
4. Run contributor-map validation:
   ```text
   uv run --extra dev pytest tests/scripts/test_contributor_map.py -q
   ```
   Result: `7 passed`.
5. Windows end-to-end protocol probe: temporarily route the existing per-user `chrome:` test handler to a logger, call the installed Browser Harness `_open_chrome_inspect()` once without `BROWSER` and once with Hermes’ fixed subprocess environment, then restore the original registry value. Observed:
   ```text
   pre_fix_protocol_activations="['chrome://inspect/#remote-debugging']"
   fixed_protocol_activations=''
   registry_restored=True
   ```
6. Sabotage proof: temporarily remove the new production block while retaining the regression test. The test fails with `KeyError: 'BROWSER'`; restoring the block returns it to green.

Windows-native full-file note: `71 passed, 22 failed`; the same 22 failures reproduce unchanged on `origin/main` because that file’s fake CLI fixtures are POSIX `#!/bin/sh` scripts and fail with `WinError 193` on native Windows. Desktop formatter/lint/typecheck/build were not run because the investigated Desktop/updater paths were ruled out and this PR changes only the Python Browser Use subprocess boundary. `ruff format --check` reports pre-existing whole-file formatting debt in both affected files; no bulk formatting was applied to avoid unrelated churn.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11, plus the affected file under WSL/Linux

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A (behavior is documented in the code comment and regression test)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — non-Windows behavior is unchanged
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Windows incident evidence:

- `desktop-update-handoff.log`: Edge progress shell launched at `2026-08-16T02:18:26-05:00`; update completed at `02:21:29`; Desktop relaunched at `02:21:37`.
- Native chooser screenshot: `2026-08-16 07:22:58` local display timestamp.
- Updater UI self-test with protocol interception: zero `chrome:` activations.
- Installed Browser Harness 0.1.8 source: `_open_chrome_inspect()` passes `chrome://inspect/#remote-debugging` to stdlib `webbrowser.open()`.
- Deterministic before/after probe: one exact OS protocol activation before the fix, zero after it, with the original per-user registry value restored after each run.
