### PR TITLE
fix: bind gateway approval buttons to request ids

### DIFF
--- a/gateway/platforms/whatsapp_cloud.py
+++ b/gateway/platforms/whatsapp_cloud.py
@@ -340,7 +340,7 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         # fallback path, same as after a gateway restart).
         #   _clarify_state:        clarify_id → session_key (resolves via
         #                          tools.clarify_gateway.resolve_gateway_clarify)
-        #   _exec_approval_state:  approval_id → session_key (resolves via
+        #   _exec_approval_state:  approval_id → (session_key, request_id) (resolves via
         #                          tools.approval.resolve_gateway_approval)
         #   _slash_confirm_state:  confirm_id → session_key (resolves via
         #                          tools.slash_confirm.resolve)
@@ -877,6 +877,7 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
 
         approval_id = uuid.uuid4().hex[:12]
         reply_to = (metadata or {}).get("reply_to_message_id") if metadata else None
+        request_id = str((metadata or {}).get("approval_request_id") or "")
 
         interactive = {
             "type": "button",
@@ -897,7 +898,8 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
 
         result = await self._post_interactive(chat_id, interactive, reply_to=reply_to)
         if result.success:
-            self._bounded_put(self._exec_approval_state, approval_id, session_key)
+            state = (session_key, request_id) if request_id else session_key
+            self._bounded_put(self._exec_approval_state, approval_id, state)
         return result
 
     async def send_slash_confirm(
@@ -1799,16 +1801,20 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             if len(parts) != 3:
                 return False
             _, approval_id, choice = parts
-            session_key = self._exec_approval_state.pop(approval_id, None)
-            if not session_key:
+            approval_state = self._exec_approval_state.pop(approval_id, None)
+            if not approval_state:
                 logger.info(
                     "[whatsapp_cloud] approval tap with no matching state "
                     "(approval_id=%s) — likely stale; falling back to text",
                     approval_id,
                 )
                 return False
+            if isinstance(approval_state, tuple):
+                session_key, request_id = approval_state
+            else:
+                session_key, request_id = approval_state, ""
             if choice not in ("approve", "deny"):
-                self._exec_approval_state[approval_id] = session_key
+                self._exec_approval_state[approval_id] = approval_state
                 return False
             try:
                 from tools.approval import resolve_gateway_approval
@@ -1817,7 +1823,11 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                     "[whatsapp_cloud] approval resolver unavailable"
                 )
                 return False
-            count = resolve_gateway_approval(session_key, choice)
+            count = (
+                resolve_gateway_approval(session_key, choice, request_id=request_id)
+                if request_id
+                else resolve_gateway_approval(session_key, choice)
+            )
             if not count:
                 logger.info(
                     "[whatsapp_cloud] approval resolver reported no waiter "

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5826,13 +5826,17 @@ class TurnRunner:
             # false positives from MagicMock auto-attribute creation in tests.
             if getattr(type(ctx._status_adapter), "send_exec_approval", None) is not None:
                 try:
+                    approval_metadata = dict(ctx._status_thread_metadata or {})
+                    approval_request_id = approval_data.get("request_id")
+                    if approval_request_id:
+                        approval_metadata["approval_request_id"] = approval_request_id
                     _approval_fut = safe_schedule_threadsafe(
                         ctx._status_adapter.send_exec_approval(
                             chat_id=ctx._status_chat_id,
                             command=cmd,
                             session_key=_approval_session_key,
                             description=desc,
-                            metadata=ctx._status_thread_metadata,
+                            metadata=approval_metadata,
                             allow_permanent=approval_data.get("allow_permanent", True),
                             allow_session=approval_data.get("allow_session", True),
                             smart_denied=approval_data.get("smart_denied", False),

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -7488,6 +7488,7 @@ class DiscordAdapter(BasePlatformAdapter):
             )
             view = ExecApprovalView(
                 session_key=session_key,
+                request_id=str((metadata or {}).get("approval_request_id") or ""),
                 allowed_user_ids=self._allowed_user_ids,
                 allowed_role_ids=self._allowed_role_ids,
                 require_admin=require_admin,
@@ -8755,7 +8756,8 @@ def _define_discord_view_classes() -> None:
         def __init__(
             self,
             session_key: str,
-            allowed_user_ids: set,
+            request_id: str = "",
+            allowed_user_ids: set = None,
             allowed_role_ids: Optional[set] = None,
             require_admin: bool = False,
             admin_user_ids: Optional[set] = None,
@@ -8765,7 +8767,8 @@ def _define_discord_view_classes() -> None:
         ):
             super().__init__(timeout=_read_discord_prompt_timeout())
             self.session_key = session_key
-            self.allowed_user_ids = allowed_user_ids
+            self.request_id = request_id
+            self.allowed_user_ids = allowed_user_ids or set()
             self.allowed_role_ids = allowed_role_ids or set()
             # Opt-in admin gate for exec approval (default off → user-scope,
             # the v0.16-restored behavior). When on, the clicker must be in
@@ -8838,7 +8841,11 @@ def _define_discord_view_classes() -> None:
             # must not claim "Approved" — the command was already denied.
             try:
                 from tools.approval import resolve_gateway_approval
-                count = resolve_gateway_approval(self.session_key, choice)
+                count = (
+                    resolve_gateway_approval(self.session_key, choice, request_id=self.request_id)
+                    if self.request_id
+                    else resolve_gateway_approval(self.session_key, choice)
+                )
                 logger.info(
                     "Discord button resolved %d approval(s) for session %s (choice=%s, user=%s)",
                     count, self.session_key, choice, interaction.user.display_name,

--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -2073,6 +2073,7 @@ class FeishuAdapter(BasePlatformAdapter):
 
         try:
             approval_id = next(self._approval_counter)
+            request_id = str((metadata or {}).get("approval_request_id") or "")
 
             def _btn(label: str, action_name: str, btn_type: str = "default") -> dict:
                 return {
@@ -2121,6 +2122,7 @@ class FeishuAdapter(BasePlatformAdapter):
                     "session_key": session_key,
                     "message_id": result.message_id or "",
                     "chat_id": chat_id,
+                    "request_id": request_id,
                 }
             return result
         except Exception as exc:
@@ -2921,7 +2923,12 @@ class FeishuAdapter(BasePlatformAdapter):
             return
         try:
             from tools.approval import resolve_gateway_approval
-            count = resolve_gateway_approval(state["session_key"], choice)
+            request_id = str(state.get("request_id") or "")
+            count = (
+                resolve_gateway_approval(state["session_key"], choice, request_id=request_id)
+                if request_id
+                else resolve_gateway_approval(state["session_key"], choice)
+            )
             logger.info(
                 "Feishu button resolved %d approval(s) for session %s (choice=%s, user=%s)",
                 count, state["session_key"], choice, user_name,

--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -519,8 +519,10 @@ class _MatrixApprovalPrompt:
         resolved: bool = False,
         requester_user_id: str | None = None,
         expires_at: float | None = None,
+        request_id: str = "",
     ):
         self.session_key = session_key
+        self.request_id = request_id
         self.chat_id = chat_id
         self.message_id = message_id
         self.resolved = resolved
@@ -2623,6 +2625,7 @@ class MatrixAdapter(BasePlatformAdapter):
             return SendResult(success=False, error="Not connected")
 
         requester_user_id = str((metadata or {}).get("requester_user_id") or "") or None
+        request_id = str((metadata or {}).get("approval_request_id") or "")
         scope_choices = ""
         if smart_denied:
             scope_choices = "Smart DENY: owner override applies to this one operation only.\n"
@@ -2655,6 +2658,7 @@ class MatrixAdapter(BasePlatformAdapter):
             message_id=result.message_id,
             requester_user_id=requester_user_id,
             expires_at=time.monotonic() + max(self._approval_timeout_seconds, 0),
+            request_id=request_id,
         )
         old_event = self._approval_prompt_by_session.get(session_key)
         if old_event:
@@ -4022,7 +4026,11 @@ class MatrixAdapter(BasePlatformAdapter):
                 try:
                     from tools.approval import resolve_gateway_approval
 
-                    count = resolve_gateway_approval(prompt.session_key, choice)
+                    count = (
+                        resolve_gateway_approval(prompt.session_key, choice, request_id=prompt.request_id)
+                        if prompt.request_id
+                        else resolve_gateway_approval(prompt.session_key, choice)
+                    )
                     if count:
                         prompt.resolved = True
                         self._approval_prompts_by_event.pop(reacts_to, None)

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -6888,6 +6888,12 @@ class SlackAdapter(BasePlatformAdapter):
         )
         try:
             thread_ts = self._resolve_thread_ts(None, metadata)
+            request_id = str((metadata or {}).get("approval_request_id") or "")
+            approval_value = (
+                json.dumps({"session_key": session_key, "request_id": request_id}, separators=(",", ":"))
+                if request_id
+                else session_key
+            )
 
             # Slack hard-caps a section block's text at 3000 chars; an
             # oversized block fails the whole send with ``invalid_blocks``
@@ -6909,7 +6915,7 @@ class SlackAdapter(BasePlatformAdapter):
                     "text": {"type": "plain_text", "text": "Allow Once"},
                     "style": "primary",
                     "action_id": "hermes_approve_once",
-                    "value": session_key,
+                    "value": approval_value,
                 },
             ]
             if not smart_denied and allow_session:
@@ -6917,21 +6923,21 @@ class SlackAdapter(BasePlatformAdapter):
                     "type": "button",
                     "text": {"type": "plain_text", "text": "Allow Session"},
                     "action_id": "hermes_approve_session",
-                    "value": session_key,
+                    "value": approval_value,
                 })
                 if allow_permanent:
                     actions.append({
                         "type": "button",
                         "text": {"type": "plain_text", "text": "Always Allow"},
                         "action_id": "hermes_approve_always",
-                        "value": session_key,
+                        "value": approval_value,
                     })
             actions.append({
                 "type": "button",
                 "text": {"type": "plain_text", "text": "Deny"},
                 "style": "danger",
                 "action_id": "hermes_deny",
-                "value": session_key,
+                "value": approval_value,
             })
             blocks = [
                 {
@@ -7370,7 +7376,19 @@ class SlackAdapter(BasePlatformAdapter):
 
         team_id = self._event_team_id({}, body)
         action_id = action.get("action_id", "")
-        session_key = action.get("value", "")
+        approval_value = action.get("value", "")
+        request_id = ""
+        try:
+            approval_payload = json.loads(approval_value) if isinstance(approval_value, str) else {}
+        except Exception:
+            approval_payload = {}
+        if isinstance(approval_payload, dict):
+            session_key = str(approval_payload.get("session_key") or "")
+            request_id = str(approval_payload.get("request_id") or "")
+        else:
+            session_key = str(approval_value or "")
+        if not session_key:
+            session_key = str(approval_value or "")
         message = body.get("message", {})
         msg_ts = message.get("ts", "")
         channel_id = body.get("channel", {}).get("id", "")
@@ -7429,7 +7447,11 @@ class SlackAdapter(BasePlatformAdapter):
         try:
             from tools.approval import resolve_gateway_approval
 
-            count = resolve_gateway_approval(session_key, choice)
+            count = (
+                resolve_gateway_approval(session_key, choice, request_id=request_id)
+                if request_id
+                else resolve_gateway_approval(session_key, choice)
+            )
             logger.info(
                 "Slack button resolved %d approval(s) for session %s (choice=%s, user=%s)",
                 count,

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -882,8 +882,8 @@ class TelegramAdapter(BasePlatformAdapter):
         # Interactive model picker state per chat
         self._model_picker_state: Dict[str, dict] = {}
         self._choice_picker_state: Dict[str, dict] = {}
-        # Approval button state: message_id → session_key
-        self._approval_state: Dict[int, str] = {}
+        # Approval button state: local approval id → (session_key, request_id)
+        self._approval_state: Dict[int, tuple[str, str]] = {}
         # Slash-confirm button state: confirm_id → session_key (for /reload-mcp
         # and any other slash-confirm prompts; see GatewayRunner._request_slash_confirm).
         self._slash_confirm_state: Dict[str, str] = {}
@@ -6120,6 +6120,7 @@ class TelegramAdapter(BasePlatformAdapter):
 
         try:
             text = self._format_exec_approval(command, description, smart_denied)
+            request_id = str((metadata or {}).get("approval_request_id") or "")
 
             # Resolve thread context for thread replies
             thread_id = self._metadata_thread_id(metadata)
@@ -6170,8 +6171,10 @@ class TelegramAdapter(BasePlatformAdapter):
 
             msg = await self._send_message_with_thread_fallback(**kwargs)
 
-            # Store session_key keyed by approval_id for the callback handler
-            self._approval_state[approval_id] = session_key
+            # Store exact approval identity for the callback handler.  The
+            # request id prevents a stale button from resolving a later approval
+            # in the same chat session.
+            self._approval_state[approval_id] = (session_key, request_id)
 
             return SendResult(success=True, message_id=str(msg.message_id))
         except Exception as e:
@@ -7034,10 +7037,14 @@ class TelegramAdapter(BasePlatformAdapter):
                     await query.answer(text="⛔ You are not authorized to approve commands.")
                     return
 
-                session_key = self._approval_state.pop(approval_id, None)
-                if not session_key:
+                approval_state = self._approval_state.pop(approval_id, None)
+                if not approval_state:
                     await query.answer(text="This approval has already been resolved.")
                     return
+                if isinstance(approval_state, tuple):
+                    session_key, request_id = approval_state
+                else:
+                    session_key, request_id = approval_state, ""
 
                 user_display = getattr(query.from_user, "first_name", "User")
 
@@ -7049,7 +7056,11 @@ class TelegramAdapter(BasePlatformAdapter):
                 # regression follow-up: 60s waits made stale taps common).
                 try:
                     from tools.approval import resolve_gateway_approval
-                    count = resolve_gateway_approval(session_key, choice)
+                    count = (
+                resolve_gateway_approval(session_key, choice, request_id=request_id)
+                if request_id
+                else resolve_gateway_approval(session_key, choice)
+            )
                     logger.info(
                         "Telegram button resolved %d approval(s) for session %s (choice=%s, user=%s)",
                         count, session_key, choice, user_display,

--- a/tests/gateway/test_approve_deny_commands.py
+++ b/tests/gateway/test_approve_deny_commands.py
@@ -156,6 +156,27 @@ class TestBlockingGatewayApproval:
         assert not e2.event.is_set()
         assert len(_gateway_queues[session_key]) == 1
 
+    def test_request_id_mismatch_does_not_resolve_newer_approval(self):
+        """Stale buttons must not resolve a later approval in the same session."""
+        from tools.approval import (
+            resolve_gateway_approval,
+            _ApprovalEntry, _gateway_queues,
+        )
+        session_key = "test-request-id"
+        old = _ApprovalEntry({"command": "old", "request_id": "old-id"})
+        current = _ApprovalEntry({"command": "current", "request_id": "current-id"})
+        _gateway_queues[session_key] = [current]
+
+        count = resolve_gateway_approval(session_key, "once", request_id=old.data["request_id"])
+        assert count == 0
+        assert not current.event.is_set()
+        assert _gateway_queues[session_key] == [current]
+
+        count = resolve_gateway_approval(session_key, "deny", request_id=current.data["request_id"])
+        assert count == 1
+        assert current.event.is_set()
+        assert current.result == "deny"
+
 
 # ------------------------------------------------------------------
 # /approve command


### PR DESCRIPTION
## Summary
Gateway approval buttons now resolve only the exact pending approval request they were rendered for, so stale taps cannot approve a later command in the same chat session.

## Changes
- `gateway/run.py`: carries the approval queue `request_id` into button-render metadata.
- Telegram, Slack, Discord, Matrix, Feishu, WhatsApp Cloud: preserve that request id on interactive controls and pass it back to `resolve_gateway_approval`.
- `tests/gateway/test_approve_deny_commands.py`: covers request-id mismatch fail-closed behavior.

## Source
Ported the invariant from openclaw/openclaw#124381: cancelled/stale approval controls must not replay into later approval prompts.
Source PR: https://github.com/openclaw/openclaw/pull/124381

## Adaptation notes
OpenClaw fixed ask-fallback replay in its gateway approval manager. Hermes already had request-id-aware core approval resolution; the missing piece was the messaging adapter boundary, where buttons resolved by `session_key` only. This PR wires the existing request identity through the platform button metadata instead of adding a new approval system.

## Validation
| Check | Result |
|---|---|
| Targeted gateway button/approval tests | `180 passed` |
| Matrix approval tests | `2 passed` |
| E2E isolated `HERMES_HOME` request-id guard | stale id returned `0`, matching id resolved |
| `py_compile` changed runtime files | passed |

`python3 -m ruff check ...` could not run locally because this worktree environment lacks `ruff` (`No module named ruff`).

## Infographic
Infographic generation attempted with the configured style (`ukiyo-e`, `bento-grid`) but FAL returned `Exhausted balance`; no generated image is attached.
