### PR TITLE
fix(agent): stop old user images from bloating every model request

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1871,6 +1871,17 @@ def init_agent(
         _agent_section = {}
     agent._tool_use_enforcement = _agent_section.get("tool_use_enforcement", "auto")
 
+    try:
+        agent.max_history_user_images = max(
+            0, int(_agent_section.get("max_history_user_images", 3))
+        )
+    except (TypeError, ValueError):
+        logger.warning(
+            "Invalid agent.max_history_user_images=%r; using 3.",
+            _agent_section.get("max_history_user_images"),
+        )
+        agent.max_history_user_images = 3
+
     # Intent-ack continuation config: "auto" (default — codex_responses only,
     # the historical gate), true (all api_modes), false (never), or a list of
     # model-name substrings.  Resolved against the active api_mode/model in the

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -29,6 +29,7 @@ from typing import Any, Dict, Optional
 
 from hermes_cli.timeouts import get_provider_request_timeout, get_provider_stale_timeout
 from hermes_constants import PARTIAL_STREAM_STUB_ID, FINISH_REASON_LENGTH
+from agent.context_compressor import _evict_historical_user_images
 from agent.error_classifier import (
     FailoverReason,
     PROVIDER_STREAM_NON_JSON_ERROR_CODE,
@@ -2909,6 +2910,14 @@ def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
         # _thinking_prefill must survive until here so the drop pass can
         # recognize stubs after reasoning fields are stripped.
         api_messages = agent._drop_thinking_only_and_merge_users(api_messages)
+
+        # This path hand-builds its request instead of passing through the main
+        # conversation loop, so apply the same request-only historical user
+        # image cap before the provider call.
+        api_messages = _evict_historical_user_images(
+            api_messages,
+            max_keep=getattr(agent, "max_history_user_images", 3),
+        )
 
         # Strip all remaining underscore-prefixed scaffolding keys before the
         # wire. The summary path calls chat.completions.create() directly,

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -1452,6 +1452,9 @@ def _truncate_tool_call_args_json(args: str, head_chars: int = 200) -> str:
 
 
 _IMAGE_PART_TYPES = frozenset({"image_url", "input_image", "image"})
+HISTORICAL_USER_IMAGE_PLACEHOLDER = (
+    "[Attached image removed from this request; original remains in session history]"
+)
 
 
 def _is_image_part(part: Any) -> bool:
@@ -1472,6 +1475,74 @@ def _content_has_images(content: Any) -> bool:
     if not isinstance(content, list):
         return False
     return any(_is_image_part(p) for p in content)
+
+
+def _evict_historical_user_images(
+    messages: List[Dict[str, Any]],
+    *,
+    max_keep: int,
+) -> List[Dict[str, Any]]:
+    """Cap image parts in historical user turns on an outbound request copy.
+
+    The newest user turn is protected in full so every image the user just
+    attached reaches the model on its first request. Older user-image parts are
+    counted newest-first across turns; parts outside ``max_keep`` become stable
+    text placeholders. Tool and assistant images are outside this policy.
+
+    ``max_keep <= 0`` preserves the legacy behavior. Touched messages and their
+    content lists are copied, so persisted history remains byte-identical.
+    """
+    if max_keep <= 0 or not messages:
+        return messages
+
+    newest_user_idx = -1
+    for idx in range(len(messages) - 1, -1, -1):
+        msg = messages[idx]
+        if isinstance(msg, dict) and msg.get("role") == "user":
+            newest_user_idx = idx
+            break
+
+    if newest_user_idx <= 0:
+        return messages
+
+    remaining = max_keep
+    changed = False
+    result: List[Dict[str, Any]] = list(messages)
+    for idx in range(newest_user_idx - 1, -1, -1):
+        msg = messages[idx]
+        if not isinstance(msg, dict) or msg.get("role") != "user":
+            continue
+        content = msg.get("content")
+        if not _content_has_images(content):
+            continue
+
+        new_parts: List[Any] = list(content)
+        message_changed = False
+        for part_idx in range(len(content) - 1, -1, -1):
+            if not _is_image_part(content[part_idx]):
+                continue
+            if remaining > 0:
+                remaining -= 1
+                continue
+            placeholder_type = (
+                "input_text"
+                if content[part_idx].get("type") == "input_image"
+                else "text"
+            )
+            new_parts[part_idx] = {
+                "type": placeholder_type,
+                "text": HISTORICAL_USER_IMAGE_PLACEHOLDER,
+            }
+            message_changed = True
+
+        if message_changed:
+            new_msg = msg.copy()
+            new_msg["content"] = new_parts
+            drop_stale_api_content(new_msg)
+            result[idx] = new_msg
+            changed = True
+
+    return result if changed else messages
 
 
 def _strip_images_from_content(content: Any) -> Any:

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -35,6 +35,7 @@ from agent.conversation_compression import (
     compression_skipped_due_to_lock,
     conversation_history_after_compression,
 )
+from agent.context_compressor import _evict_historical_user_images
 from agent.context_engine import automatic_compaction_status_message
 from agent.display import KawaiiSpinner
 from agent.error_classifier import FailoverReason, classify_api_error
@@ -2276,6 +2277,16 @@ def run_conversation(
         # lone surrogates (U+D800-U+DFFF) that crash json.dumps() inside
         # the OpenAI SDK. Sanitizing here prevents the 3-retry cycle.
         _sanitize_messages_surrogates(api_messages)
+
+        # Bound retransmission of user-uploaded images without rewriting the
+        # persisted transcript. The current user turn is protected in full;
+        # older images roll out newest-first under the configured cap. Run
+        # before cache planning so an eviction changes the prefix once, then
+        # remains byte-stable on subsequent requests.
+        api_messages = _evict_historical_user_images(
+            api_messages,
+            max_keep=getattr(agent, "max_history_user_images", 3),
+        )
 
         # NOTE (empty-content class fix): no send-time pad loop here.  The
         # single owner for "never send a turn strict wire validation rejects

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -929,6 +929,12 @@ agent:
   # Recommended: 20-30 for focused tasks, 50-100 for open exploration
   max_turns: 500
 
+  # Maximum user-attached images retained from older turns in each outbound
+  # request. Images on the current user turn are always sent in full. Older
+  # images beyond this newest-first cap become placeholders in the request
+  # only; the original session history remains intact. 0 disables eviction.
+  max_history_user_images: 3
+
   # Inactivity timeout for gateway agent runs (seconds, 0 = unlimited).
   # The agent can run indefinitely when actively calling tools or receiving
   # API responses.  Only fires after the agent has been idle for this duration.

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -44,6 +44,10 @@ DEFAULT_CONFIG = {
     },
     "agent": {
         "max_turns": 500,
+        # Maximum user-attached images retained from historical turns in each
+        # outbound request. The current user turn is always preserved in full;
+        # 0 disables request-time eviction.
+        "max_history_user_images": 3,
         # Inactivity timeout for gateway agent execution (seconds).
         # The agent can run indefinitely as long as it's actively calling
         # tools or receiving API responses.  Only fires when the agent has

--- a/tests/agent/test_history_user_image_eviction.py
+++ b/tests/agent/test_history_user_image_eviction.py
@@ -1,0 +1,126 @@
+"""Behavior tests for request-time historical user-image eviction."""
+
+from __future__ import annotations
+
+from agent.context_compressor import (
+    HISTORICAL_USER_IMAGE_PLACEHOLDER,
+    _content_has_images,
+    _evict_historical_user_images,
+    _is_image_part,
+)
+
+
+def _image(label: str) -> dict:
+    return {
+        "type": "image_url",
+        "image_url": {"url": f"data:image/png;base64,{label}"},
+    }
+
+
+def _image_labels(message: dict) -> list[str]:
+    labels = []
+    for part in message.get("content", []):
+        if _is_image_part(part):
+            labels.append(part["image_url"]["url"].rsplit(",", 1)[-1])
+    return labels
+
+
+def test_non_positive_limit_preserves_current_behavior_by_identity():
+    messages = [{"role": "user", "content": [_image("old")]}]
+
+    assert _evict_historical_user_images(messages, max_keep=0) is messages
+    assert _evict_historical_user_images(messages, max_keep=-1) is messages
+
+
+def test_current_user_image_batch_is_never_capped_before_first_send():
+    old = {"role": "user", "content": [_image("old-a"), _image("old-b")]}
+    assistant = {"role": "assistant", "content": "send another batch"}
+    current = {"role": "user", "content": [_image("new-a"), _image("new-b")]}
+    messages = [old, assistant, current]
+
+    output = _evict_historical_user_images(messages, max_keep=1)
+
+    assert _image_labels(output[0]) == ["old-b"]
+    assert _image_labels(output[2]) == ["new-a", "new-b"]
+    assert output[2] is current
+    assert _image_labels(old) == ["old-a", "old-b"]
+
+
+def test_text_followup_makes_previous_image_batch_historical():
+    image_turn = {
+        "role": "user",
+        "content": [
+            {"type": "text", "text": "compare these"},
+            _image("a"),
+            _image("b"),
+            _image("c"),
+        ],
+    }
+    messages = [
+        image_turn,
+        {"role": "assistant", "content": "done"},
+        {"role": "user", "content": "continue"},
+    ]
+
+    output = _evict_historical_user_images(messages, max_keep=2)
+
+    assert _image_labels(output[0]) == ["b", "c"]
+    placeholders = [
+        part
+        for part in output[0]["content"]
+        if part == {"type": "text", "text": HISTORICAL_USER_IMAGE_PLACEHOLDER}
+    ]
+    assert len(placeholders) == 1
+    assert _image_labels(image_turn) == ["a", "b", "c"]
+
+
+def test_limit_counts_individual_images_across_historical_user_turns():
+    messages = [
+        {"role": "user", "content": [_image("oldest")]},
+        {"role": "assistant", "content": "one"},
+        {"role": "user", "content": [_image("middle-a"), _image("middle-b")]},
+        {"role": "assistant", "content": "two"},
+        {"role": "user", "content": "latest text"},
+    ]
+
+    output = _evict_historical_user_images(messages, max_keep=2)
+
+    assert not _content_has_images(output[0]["content"])
+    assert _image_labels(output[2]) == ["middle-a", "middle-b"]
+
+
+def test_responses_image_uses_input_text_placeholder():
+    responses_image = {
+        "type": "input_image",
+        "image_url": "data:image/png;base64,b2xk",
+    }
+    messages = [
+        {"role": "user", "content": [responses_image, _image("newer")]},
+        {"role": "assistant", "content": "done"},
+        {"role": "user", "content": "continue"},
+    ]
+
+    output = _evict_historical_user_images(messages, max_keep=1)
+
+    assert output[0]["content"][0] == {
+        "type": "input_text",
+        "text": HISTORICAL_USER_IMAGE_PLACEHOLDER,
+    }
+
+
+def test_non_user_images_and_untouched_messages_pass_through():
+    tool = {"role": "tool", "content": [_image("tool-shot")]}
+    assistant = {"role": "assistant", "content": "ok"}
+    messages = [
+        {"role": "user", "content": [_image("old")]},
+        tool,
+        assistant,
+        {"role": "user", "content": "continue"},
+    ]
+
+    output = _evict_historical_user_images(messages, max_keep=1)
+
+    assert output is messages
+    assert output[1] is tool
+    assert _image_labels(output[1]) == ["tool-shot"]
+    assert output[2] is assistant

--- a/tests/run_agent/test_history_user_image_eviction.py
+++ b/tests/run_agent/test_history_user_image_eviction.py
@@ -1,0 +1,133 @@
+"""Request-path coverage for historical user-image eviction."""
+
+from __future__ import annotations
+
+import base64
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from agent.chat_completion_helpers import handle_max_iterations
+from agent.context_compressor import _is_image_part
+from run_agent import AIAgent
+
+
+def _image(label: str) -> dict:
+    payload = base64.b64encode(label.encode()).decode()
+    return {
+        "type": "image_url",
+        "image_url": {"url": f"data:image/png;base64,{payload}"},
+    }
+
+
+def _images(message: dict) -> list[dict]:
+    content = message.get("content")
+    if not isinstance(content, list):
+        return []
+    return [part for part in content if _is_image_part(part)]
+
+
+def _response(text: str = "ok") -> SimpleNamespace:
+    message = SimpleNamespace(
+        content=text,
+        tool_calls=None,
+        reasoning_content=None,
+        reasoning=None,
+    )
+    return SimpleNamespace(
+        choices=[SimpleNamespace(message=message, finish_reason="stop")],
+        model="openai/gpt-4o",
+        usage=None,
+    )
+
+
+@pytest.fixture
+def agent() -> AIAgent:
+    with (
+        patch("run_agent.get_tool_definitions", return_value=[]),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        instance = AIAgent(
+            api_key="test-key",
+            base_url="https://openrouter.ai/api/v1",
+            provider="openrouter",
+            model="openai/gpt-4o",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+    instance.client = MagicMock()
+    instance.client.chat.completions.create.return_value = _response()
+    instance._cached_system_prompt = "You are helpful."
+    instance._use_prompt_caching = False
+    instance.compression_enabled = False
+    instance.save_trajectories = False
+    instance.max_history_user_images = 1
+    instance._model_supports_vision = lambda: True
+    return instance
+
+
+def test_main_loop_caps_historical_images_without_mutating_history(agent):
+    image_turn = {
+        "role": "user",
+        "content": [
+            {"type": "text", "text": "compare"},
+            _image("first"),
+            _image("second"),
+        ],
+    }
+    history = [image_turn, {"role": "assistant", "content": "done"}]
+
+    with (
+        patch.object(agent, "_persist_session"),
+        patch.object(agent, "_save_trajectory"),
+        patch.object(agent, "_cleanup_task_resources"),
+    ):
+        result = agent.run_conversation("continue", conversation_history=history)
+
+    assert result["completed"] is True
+    sent = agent.client.chat.completions.create.call_args.kwargs["messages"]
+    sent_image_turn = next(
+        message
+        for message in sent
+        if message.get("role") == "user" and isinstance(message.get("content"), list)
+    )
+    assert len(_images(sent_image_turn)) == 1
+    assert _images(sent_image_turn)[0] == _image("second")
+    assert len(_images(image_turn)) == 2
+
+
+def test_max_iterations_summary_applies_same_cap(agent):
+    captured = {}
+
+    class _Completions:
+        def create(self, **kwargs):
+            captured.update(kwargs)
+            return "RAW"
+
+    client = SimpleNamespace(chat=SimpleNamespace(completions=_Completions()))
+    transport = SimpleNamespace(
+        normalize_response=lambda _response: SimpleNamespace(content="SUMMARY")
+    )
+    image_turn = {
+        "role": "user",
+        "content": [_image("first"), _image("second")],
+    }
+    messages = [image_turn, {"role": "assistant", "content": "done"}]
+
+    with (
+        patch.object(agent, "_ensure_primary_openai_client", return_value=client),
+        patch.object(agent, "_get_transport", return_value=transport),
+    ):
+        output = handle_max_iterations(agent, messages, 5)
+
+    assert output == "SUMMARY"
+    sent_image_turn = next(
+        message
+        for message in captured["messages"]
+        if message.get("role") == "user" and isinstance(message.get("content"), list)
+    )
+    assert len(_images(sent_image_turn)) == 1
+    assert len(_images(image_turn)) == 2

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1009,11 +1009,14 @@ Instead, when the budget is actually exhausted (500/500), Hermes injects one mes
 agent:
   max_turns: 500               # Max iterations per conversation turn (default: 500)
   api_max_retries: 3           # Retries per provider before fallback engages (default: 3)
+  max_history_user_images: 3   # Retain this many images from older user turns
 ```
 
 When the iteration budget is fully exhausted, the CLI shows a notification to the user: `⚠ Iteration budget reached (500/500) — response may be incomplete`.
 
 `agent.api_max_retries` controls how many times Hermes retries a provider API call on transient errors (rate limits, connection drops, 5xx) **before** fallback-provider switching engages. The default is `3` — four attempts total. If you have [fallback providers](/user-guide/features/fallback-providers) configured and want to fail over faster, drop this to `0` so the first transient error on your primary immediately hands off to the fallback instead of churning retries against the flaky endpoint.
+
+`agent.max_history_user_images` bounds user-uploaded image payloads in each outbound request. Hermes always sends every image on the current user turn, then retains only the newest configured number of image parts from older user turns. Older parts become short placeholders in the request copy; persisted session history keeps the original images unchanged. Set the value to `0` to disable request-time eviction.
 
 ## Verify-on-Stop (coding verification)
 


### PR DESCRIPTION
## What does this PR do?

Historical user-uploaded images can remain in every provider request indefinitely when a session stays below the compression threshold. A reported three-image turn added about 2.9 MB to every request, producing about 58 MB of redundant daily upload at 20 calls per day. This PR bounds older user-image payloads at request time while preserving the current user turn and the original persisted session history.

### Symptom

After a user uploads images and continues the conversation, the original base64 image data is sent again with every later model request. Large-context models may never trigger compression, so the repeated payload has no practical eviction point.

### Impact

Users with image-bearing sessions can incur repeated multi-megabyte request bodies, additional upload latency, and unnecessary provider traffic on every later turn. The reported production example retained 4,047,677 base64 characters from one three-image message for 19 days.

### Bug Cause

**Trigger:** `agent/conversation_loop.py:2281` / outbound request assembly with historical user image parts

**Causal chain:**
1. A user uploads one or more images, then sends later follow-up messages.
2. Request assembly copies the persisted multimodal user turn into each outbound request without a request-time user-image limit.
3. The same base64 payload is uploaded on every request until compression eventually strips it, which may not happen on large-context models.

**Why it is wrong:** Historical user images had no bounded request-time lifecycle independent of compression. The compressor's historical-media pass only runs when compression is triggered and deliberately preserves the newest image-bearing user turn as its anchor.

**Working sibling / contrast:** Non-vision models strip images for compatibility, but vision-capable models retain them. Tool-result screenshot pruning is a separate role-specific path and does not cap user uploads.

**Ruled out:** Token-threshold tuning does not solve the request payload lifecycle because large-window sessions can remain below the compression threshold indefinitely, and the newest image-bearing anchor remains preserved when compression does run.

### Fix

Add a request-only newest-first cap for image parts in older user turns. The newest user turn is always preserved in full, evicted parts become stable text placeholders, and copy-on-write handling keeps persisted history unchanged. Apply the same policy to the main conversation loop and the max-iterations summary request before prompt-cache planning. Expose `agent.max_history_user_images` with a default of 3 and allow `0` to preserve the previous behavior.

## Related Issue

Closes #87513

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Documentation update
- [x] Tests (adding or improving test coverage)

## Changes Made

- `agent/context_compressor.py` - add copy-on-write historical user-image eviction with provider-compatible placeholders.
- `agent/conversation_loop.py` - apply the cap before prompt-cache planning and provider dispatch.
- `agent/chat_completion_helpers.py` - apply the same cap to max-iterations summary requests.
- `agent/agent_init.py` and `hermes_cli/config_defaults.py` - load and default the new agent setting.
- `cli-config.yaml.example` and `website/docs/user-guide/configuration.md` - document behavior and disable semantics.
- `tests/agent/test_history_user_image_eviction.py` and `tests/run_agent/test_history_user_image_eviction.py` - cover retention order, current-turn preservation, provider shapes, request-path parity, and history immutability.

## How to Test

1. Configure `agent.max_history_user_images: 1`.
2. Send a user turn with two images, then send a text-only follow-up.
3. Verify the outbound provider request retains only the newest historical image, the older image becomes a placeholder, and the persisted history still contains both originals.
4. Run the focused request and transformation coverage:

```bash
scripts/run_tests.sh tests/agent/test_history_user_image_eviction.py tests/run_agent/test_history_user_image_eviction.py
```

Result: 8 tests passed. The broader related suite also passed 117 tests across 7 files on the reviewed commit.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repository test entry on the relevant tests and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings)
- [x] I've updated `cli-config.yaml.example` because this PR adds a config key
- [x] N/A - no contributor workflow or architecture guide changes are required
- [x] I've considered cross-platform impact per the compatibility guide; the transformation is platform-independent
- [x] N/A - no tool descriptions or schemas changed

## Screenshots / Logs

```text
2 files, 8 tests passed, 0 failed
Related suite: 7 files, 117 tests passed, 0 failed
```
