### PR TITLE
feat(desktop): add busy turn flags to plugin SDK

### DIFF
--- a/apps/desktop/src/plugins/example/plugin.tsx
+++ b/apps/desktop/src/plugins/example/plugin.tsx
@@ -39,10 +39,11 @@ const $events = atom(0)
 function ClickCounter() {
   const count = useValue($clicks)
   const events = useValue($events)
+  const busy = useValue(host.state.busy)
   const gateway = useValue(host.state.gateway)
 
   return (
-    <Tip label={`Example plugin — gateway ${gateway}, ${events} events heard`}>
+    <Tip label={`Example plugin: gateway ${gateway}, ${busy ? 'working' : 'idle'}, ${events} events heard`}>
       <button
         className={cn(
           'inline-flex h-full items-center gap-1 rounded-none px-1.5 text-[0.6875rem] tabular-nums transition-colors',

--- a/apps/desktop/src/sdk/index.test.ts
+++ b/apps/desktop/src/sdk/index.test.ts
@@ -1,0 +1,66 @@
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { createClientSessionState } from '@/lib/chat-runtime'
+import { host } from '@/sdk'
+import {
+  setActiveSessionId,
+  setAwaitingResponse,
+  setBusy
+} from '@/store/session'
+import { clearAllSessionStates, publishSessionState } from '@/store/session-states'
+
+describe('host.state turn flags', () => {
+  afterEach(() => {
+    setActiveSessionId(null)
+    setBusy(false)
+    setAwaitingResponse(false)
+    clearAllSessionStates()
+  })
+
+  it('uses the draft atoms when there is no runtime session', () => {
+    expect(host.state.busy.get()).toBe(false)
+    expect(host.state.awaitingResponse.get()).toBe(false)
+
+    setBusy(true)
+    setAwaitingResponse(true)
+
+    expect(host.state.busy.get()).toBe(true)
+    expect(host.state.awaitingResponse.get()).toBe(true)
+  })
+
+  it('reads the focused session slice once a runtime exists', () => {
+    setBusy(false)
+    setAwaitingResponse(false)
+    setActiveSessionId('rt-focus')
+    publishSessionState('rt-focus', {
+      ...createClientSessionState('stored-focus'),
+      awaitingResponse: true,
+      busy: true
+    })
+
+    expect(host.state.busy.get()).toBe(true)
+    expect(host.state.awaitingResponse.get()).toBe(true)
+
+    publishSessionState('rt-focus', {
+      ...createClientSessionState('stored-focus'),
+      awaitingResponse: false,
+      busy: true
+    })
+
+    expect(host.state.busy.get()).toBe(true)
+    expect(host.state.awaitingResponse.get()).toBe(false)
+  })
+
+  it('does not pick up a background session', () => {
+    setActiveSessionId('rt-focus')
+    publishSessionState('rt-focus', createClientSessionState('stored-focus'))
+    publishSessionState('rt-bg', {
+      ...createClientSessionState('stored-bg'),
+      awaitingResponse: true,
+      busy: true
+    })
+
+    expect(host.state.busy.get()).toBe(false)
+    expect(host.state.awaitingResponse.get()).toBe(false)
+  })
+})

--- a/apps/desktop/src/sdk/index.ts
+++ b/apps/desktop/src/sdk/index.ts
@@ -20,6 +20,7 @@
 
 import { atom, type ReadableAtom } from 'nanostores'
 
+import { PRIMARY_SESSION_VIEW } from '@/app/chat/session-view'
 import { openSession, type OpenSessionIntent } from '@/app/open-session'
 import { $narrowViewport } from '@/components/pane-shell/tree/store'
 import { onGatewayEvent } from '@/contrib/events'
@@ -60,6 +61,14 @@ export const host = {
   state: {
     /** Runtime id of the active chat session (null on a fresh draft). */
     activeSessionId: readonlyAtom<null | string>($activeSessionId),
+    /** True from send until the first assistant payload on the focused chat. */
+    awaitingResponse: readonlyAtom<boolean>(PRIMARY_SESSION_VIEW.$awaitingResponse),
+    /**
+     * True while the focused chat is working after a send. Covers the wait
+     * for the first token and the stream that follows. Same session as
+     * `activeSessionId`. A draft with no runtime id uses the global flag.
+     */
+    busy: readonlyAtom<boolean>(PRIMARY_SESSION_VIEW.$busy),
     /** Active workspace cwd ('' when detached). */
     cwd: readonlyAtom<string>($currentCwd),
     /** Gateway socket state: 'idle' | 'connecting' | 'open' | …. */

--- a/skills/autonomous-ai-agents/hermes-agent/references/desktop-plugins.md
+++ b/skills/autonomous-ai-agents/hermes-agent/references/desktop-plugins.md
@@ -54,9 +54,11 @@ The ONLY import surface is `@hermes/plugin-sdk` (plus `react` /
 `react/jsx-runtime`, which resolve to the app's own React — write UI with
 `jsx()` calls, not JSX syntax; the file is not compiled).
 
-- `host.state.*` — readonly reactive atoms: `activeSessionId`, `cwd`,
-  `gateway`, `model`, `profile`, `viewport`. Read with `.get()` in handlers,
-  `useValue(atom)` in components.
+- `host.state.*` — readonly reactive atoms: `activeSessionId`, `busy`,
+  `awaitingResponse`, `cwd`, `gateway`, `model`, `profile`, `viewport`.
+  `busy` is true while the focused chat is working after a send (thinking
+  and streaming). `awaitingResponse` is true until the first assistant
+  payload. Read with `.get()` in handlers, `useValue(atom)` in components.
 - `host.request(method, params)` — gateway JSON-RPC (sessions, config,
   skills, cron — everything the app uses).
 - `host.onEvent(type, fn)` — live gateway events (`'*'` for all). Returns a

--- a/website/docs/developer-guide/desktop-plugin-sdk.md
+++ b/website/docs/developer-guide/desktop-plugin-sdk.md
@@ -374,6 +374,8 @@ components.
 
 ```ts
 host.state.activeSessionId  // ReadableAtom<string | null>
+host.state.awaitingResponse // ReadableAtom<boolean>  true until the first assistant payload
+host.state.busy             // ReadableAtom<boolean>  focused chat is working after a send
 host.state.cwd              // ReadableAtom<string>
 host.state.gateway          // ReadableAtom<string>  ('idle' | 'connecting' | 'open' | …)
 host.state.model            // ReadableAtom<string>
@@ -405,6 +407,17 @@ cron, kanban, …). Profile-shaped plugins get first-class methods too:
 probe) and `profiles.create` (`name`, `description`, `clone_from`,
 `clone_all`, `no_skills`, `soul`, optional `model` + `provider` pin) — the
 ws twins of the dashboard's `/api/profiles` REST routes.
+`host.state.busy` is the focused chat's live turn (thinking and streaming).
+`host.state.awaitingResponse` stays true from send until the first assistant
+payload. Both follow `activeSessionId`. Subscribe in a component:
+
+```javascript
+const busy = useValue(host.state.busy)
+```
+
+For token-level detail, listen with `host.onEvent` (`message.start`,
+`message.delta`, `message.complete`).
+
 `host.onEvent` streams live gateway events (message deltas,
 session lifecycle, tool activity). Listeners are isolated — a throw in your
 listener can't affect app dispatch. Every `host` door is async-safe: a sync throw


### PR DESCRIPTION
## What does this PR do?

Desktop plugins can now read whether the focused chat is working after the user sends a message.

`host.state` already had the session, model, and gateway socket. It did not have a live turn flag. Plugins that want to react (a chip, an avatar pose) had to rebuild that from gateway events.

This adds two readonly atoms:

- `host.state.busy`: true while the focused chat is working (the wait and the stream)
- `host.state.awaitingResponse`: true from send until the first assistant output

Both follow `PRIMARY_SESSION_VIEW`, the same slice the chat pane uses. A draft with no runtime id uses the global flags. A background turn does not leak.

Old plugins keep working. They ignore the new keys.

## Related Issue

Fixes #87557

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/sdk/index.ts`: add `host.state.busy` and `host.state.awaitingResponse`
- `apps/desktop/src/sdk/index.test.ts`: draft fallback, focused slice, no leak from a background session
- `apps/desktop/src/plugins/example/plugin.tsx`: show working or idle in the example tooltip
- `website/docs/developer-guide/desktop-plugin-sdk.md`: document the new atoms
- `skills/autonomous-ai-agents/hermes-agent/references/desktop-plugins.md`: same atoms in the skill note

## How to Test

1. From `apps/desktop`, run `npm run test:ui -- src/sdk/index.test.ts`
2. In a desktop plugin, read `host.state.busy` with `useValue`
3. Send a message in the focused chat. The flag should stay true until the turn ends
4. Switch to another chat while the first turn is still running. The flag should follow the focused chat

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

This is renderer only. No OS specific paths. No new config keys. No tool schema change. I did not run the full Python suite. I ran the desktop vitest file for this change.

## Screenshots / Logs

N/A
