### PR TITLE
fix(state): keep pinned rows out of the LIMIT page budget in list_sessions_rich

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -8620,6 +8620,19 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             where_clauses.append("s.hidden = 0")
 
         where_sql = f"WHERE {' AND '.join(where_clauses)}" if where_clauses else ""
+        # The pinned back-fill is the single source of pinned rows; the
+        # LIMIT/OFFSET page must not consume its own capacity on active pins
+        # (which would dilute "did we fill a full page" truncation checks and
+        # double-serve rows the back-fill also fetches). Apply the pinned=0
+        # filter to the page query only — the back-fill below reuses
+        # ``where_sql`` (without it) so its ``AND s.pinned = 1`` still matches.
+        page_where = where_sql
+        if include_pinned:
+            page_where = (
+                f"{where_sql} AND s.pinned = 0"
+                if where_sql
+                else "WHERE s.pinned = 0"
+            )
         # Snapshot the filter params before the query builders below extend
         # them with LIMIT/OFFSET — the pinned back-fill reuses the same WHERE.
         base_where_params = list(params)
@@ -8656,7 +8669,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             # races can insert the continuation row before the parent's
             # ended_at is written, while stale websocket siblings may satisfy
             # the timestamp test and hijack resume/list projection.
-            outer_where = where_sql
+            outer_where = page_where
             id_params: List[Any] = []
             filter_clauses: List[str] = []
 
@@ -8701,12 +8714,12 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             if filter_clauses:
                 combined = " AND ".join(filter_clauses)
                 outer_where = (
-                    f"{where_sql} AND {combined}" if where_sql else f"WHERE {combined}"
+                    f"{page_where} AND {combined}" if page_where else f"WHERE {combined}"
                 )
             _sel = self._compact_session_cols() if compact_rows else "s.*"
             query = f"""
                 WITH RECURSIVE chain(root_id, cur_id) AS (
-                    SELECT s.id, s.id FROM sessions s {where_sql}
+                    SELECT s.id, s.id FROM sessions s {page_where}
                     UNION ALL
                     SELECT c.root_id, child.id
                     FROM chain c
@@ -8758,7 +8771,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                     {_sql_session_last_active("s")} AS last_active
                 FROM sessions s
                 {prompt_join}
-                {where_sql}
+                {page_where}
                 ORDER BY s.started_at DESC
                 LIMIT ? OFFSET ?
             """

--- a/tests/hermes_state/test_list_sessions_rich_pinned_budget.py
+++ b/tests/hermes_state/test_list_sessions_rich_pinned_budget.py
@@ -1,0 +1,120 @@
+"""Regression tests for the pinned-budget fix in ``list_sessions_rich``.
+
+History / bug:
+- The sidebar's "load more" (再加载 N 个) button gates on a truncation flag
+  computed by the desktop backend: ``recents_truncated[name] = unpinned_count
+  >= recents_cap``, where ``unpinned_count`` is counted from the rows returned
+  by ``list_sessions_rich(limit=cap, include_pinned=True)``.
+- With ``include_pinned=True`` the LIMIT/OFFSET page was *not* excluding
+  pinned rows, so active pins consumed page capacity: a profile with 43
+  unpinned + 7 recently-active pinned rows in the first 50 returned
+  ``unpinned_count = 43 < 50`` and falsely cleared the "load more" flag even
+  though hundreds of unpinned sessions existed.
+- Fix: when ``include_pinned=True`` the page query applies ``s.pinned = 0``
+  (LIMIT capacity belongs to unpinned rows) and the pinned back-fill remains
+  the single source of pinned rows.
+"""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from hermes_state import SessionDB
+
+
+@pytest.fixture
+def db(tmp_path):
+    database = SessionDB(tmp_path / "state.db")
+    try:
+        yield database
+    finally:
+        database.close()
+
+
+def _seed(db: SessionDB, unpinned: int, pinned: int):
+    """Seed ``unpinned`` normal sessions and ``pinned`` active pin sessions.
+
+    Pinned sessions get the freshest ``started_at`` so, in the pre-fix
+    implementation, they would occupy the first rows of the LIMIT window.
+    """
+    base = time.time()
+    for i in range(unpinned):
+        db.create_session(f"u{i:03d}", source="cli")
+        db._conn.execute(
+            "UPDATE sessions SET started_at = ?, message_count = 1 WHERE id = ?",
+            (base - unpinned + i, f"u{i:03d}"),
+        )
+    for i in range(pinned):
+        db.create_session(f"p{i:03d}", source="cli")
+        db._conn.execute(
+            "UPDATE sessions SET started_at = ?, message_count = 1 WHERE id = ?",
+            (base + 100 + i, f"p{i:03d}"),  # fresher than every unpinned row
+        )
+        assert db.set_session_pinned(f"p{i:03d}", True) is True
+    db._conn.commit()
+
+
+def test_include_pinned_page_capacity_not_diluted_by_active_pins(db):
+    """55 unpinned + 10 freshly-active pins: the page must return 50 unpinned
+    rows (LIMIT budget intact) plus all 10 pinned back-fills — not 40+10."""
+    _seed(db, unpinned=55, pinned=10)
+
+    rows = db.list_sessions_rich(
+        limit=50,
+        offset=0,
+        order_by_last_active=True,
+        include_pinned=True,
+    )
+    unpinned = [s for s in rows if not s.get("pinned")]
+    pins = [s for s in rows if s.get("pinned")]
+
+    assert len(unpinned) == 50, (
+        "active pins must not consume the LIMIT page budget; "
+        f"got {len(unpinned)} unpinned rows"
+    )
+    assert len(pins) == 10, "all pinned rows must be back-filled"
+    assert len(rows) == 60
+
+    # The truncation signal the sidebar depends on.
+    assert len(unpinned) >= 50
+
+
+def test_include_pinned_short_list_no_fake_full_page(db):
+    """30 unpinned + 10 pins: page holds 30 unpinned (no fake full page), all
+    pins back-filled. This is the ''no more to load'' case."""
+    _seed(db, unpinned=30, pinned=10)
+
+    rows = db.list_sessions_rich(
+        limit=50,
+        offset=0,
+        order_by_last_active=True,
+        include_pinned=True,
+    )
+    unpinned = [s for s in rows if not s.get("pinned")]
+    pins = [s for s in rows if s.get("pinned")]
+
+    assert len(unpinned) == 30
+    assert len(pins) == 10
+    assert len(rows) == 40
+    assert len(unpinned) < 50
+
+
+def test_without_include_pinned_still_excludes_children_only(db):
+    """include_pinned=False must keep the historical behaviour: no pinned
+    back-fill, but pinned rows may still surface if they fall inside the
+    LIMIT window (the page query is unfiltered on pinned when no back-fill
+    is requested — back-compat with callers that page over everything)."""
+    _seed(db, unpinned=55, pinned=10)
+
+    rows = db.list_sessions_rich(
+        limit=50,
+        offset=0,
+        order_by_last_active=True,
+        include_pinned=False,
+    )
+    # With pinned rows freshest, the unfiltered page may include pins.
+    assert len(rows) == 50
+    # No back-fill happened: pins in the page are only the ones that fit.
+    assert all(s.get("pinned") for s in rows[:10])


### PR DESCRIPTION
## Bug Description

With `include_pinned=True`, freshly-active pinned rows were admitted into the `LIMIT`/`OFFSET` page window of `list_sessions_rich`. A profile with 43 unpinned + several active pins in the first 50 rows reported a "full page" of unpinned capacity incorrectly, clearing the sidebar "load more" truncation flag even though hundreds of unpinned sessions still existed. Pinned rows could also double-serve with the pinned back-fill.

## Root Cause

The page query shared the same `WHERE` as the pinned back-fill. Active pins consumed LIMIT budget that should belong only to unpinned rows.

## Fix

When `include_pinned=True`, the page query adds `s.pinned = 0` so LIMIT capacity belongs to unpinned rows. The existing pinned back-fill remains the single source of pinned rows (reuses the original `where_sql` without the page-only filter).

## How to Verify

1. Create 55 unpinned + 10 active pinned sessions in one profile.
2. Call `list_sessions_rich(include_pinned=True, limit=50)`.
3. Expect 50 unpinned rows + all 10 pins back-filled (no dilution, no double-serve).

## Test Plan

- [x] Added regression test `tests/hermes_state/test_list_sessions_rich_pinned_budget.py` (3 passed on current main base)
- [x] Existing related hermes_state paths exercised by the new file
- [ ] CI green

## Risk Assessment

Low — page filter is additive only when `include_pinned=True`; `include_pinned=False` keeps historical unfiltered-page behaviour. All four callers (sidebar recents, profiles, sessions list, api_server) benefit from the same path.
