### PR TITLE
fix(compression): stop archive_and_compact replay duplicates and mark iteration-limit summaries terminal

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -3063,9 +3063,14 @@ def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
                 final_response = re.sub(r'<think>.*?</think>\s*', '', final_response, flags=re.DOTALL).strip()
             if final_response:
                 summary_call_outcome = "success"
+# A successful iteration-limit summary IS the turn's final
+                # answer: tag it as a terminal assistant message so the
+                # persisted row carries finish_reason='stop' (without this the
+                # DB row ends up finish_reason=NULL and surfaces look like an
+                # unfinished/interim bubble in desktop).
                 append_message(
                     messages,
-                    {"role": "assistant", "content": final_response},
+                    {"role": "assistant", "content": final_response, "finish_reason": "stop"},
                 )
             else:
                 final_response = "I reached the iteration limit and couldn't generate a summary."
@@ -3128,9 +3133,12 @@ def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
                     final_response = re.sub(r'<think>.*?</think>\s*', '', final_response, flags=re.DOTALL).strip()
                 if final_response:
                     summary_call_outcome = "success"
+# Same terminal-finish_reason tagging as the primary
+                    # summary path (see above): the retry summary is also the
+                    # turn's final answer.
                     append_message(
                         messages,
-                        {"role": "assistant", "content": final_response},
+                        {"role": "assistant", "content": final_response, "finish_reason": "stop"},
                     )
                 else:
                     final_response = "I reached the iteration limit and couldn't generate a summary."

--- a/agent/turn_finalizer.py
+++ b/agent/turn_finalizer.py
@@ -200,10 +200,28 @@ def finalize_turn(
     # must treat it as finished (terminal finish_reason, no resume_pending,
     # no "incomplete" client state). Only a fallback with NO response
     # (failed/interrupted, or the empty placeholder string) stays False.
+    #
+    # Exception: budget exhaustion while a verification gate is holding the
+    # composed answer (#61631 / #65919 §7). That path also exits with
+    # max_iterations_reached + a non-empty final_response, but the turn is
+    # intentionally NOT completed — resume must re-enter verification, and
+    # the composed report must survive without being treated as a finished
+    # summary. Detect via the pending-verification handoff and/or the
+    # assistant finish_reason stamped by the verification stop-loop.
+    _tail_finish = ""
+    for _m in reversed(messages or []):
+        if isinstance(_m, dict) and _m.get("role") == "assistant":
+            _tail_finish = str(_m.get("finish_reason") or "").lower()
+            break
+    _verification_held = bool(_pending_verification_response) or _tail_finish in {
+        "verification_required",
+        "verify_hook_continue",
+    }
     iteration_limit_with_response = (
         str(_turn_exit_reason).startswith("max_iterations_reached(")
         and final_response is not None
         and str(final_response).strip() != ""
+        and not _verification_held
     )
     completed = (
         final_response is not None

--- a/agent/turn_finalizer.py
+++ b/agent/turn_finalizer.py
@@ -194,12 +194,24 @@ def finalize_turn(
 
     # Determine if conversation completed successfully
     normal_text_response = str(_turn_exit_reason).startswith("text_response(")
+    # A max-iterations fallback that still produced a real final answer (the
+    # summary call succeeded) is a completed turn for persistence and event
+    # purposes: the user saw an actual final response, so downstream surfaces
+    # must treat it as finished (terminal finish_reason, no resume_pending,
+    # no "incomplete" client state). Only a fallback with NO response
+    # (failed/interrupted, or the empty placeholder string) stays False.
+    iteration_limit_with_response = (
+        str(_turn_exit_reason).startswith("max_iterations_reached(")
+        and final_response is not None
+        and str(final_response).strip() != ""
+    )
     completed = (
         final_response is not None
         and not failed
         and (
             api_call_count < agent.max_iterations
             or normal_text_response
+            or iteration_limit_with_response
         )
     )
 

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -9861,6 +9861,68 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                         f"Compression lease for {session_id!r} lost before "
                         "commit; refusing to publish a stale compaction"
                     )
+            # Compression-loop dedup probe. Repeated compression passes
+            # (preflight + post-response + next-turn preflight) re-insert
+            # near-identical rebuilt tails under the same session id. Without
+            # a guard the archived (active=0, compacted=1) layer accumulates
+            # duplicate copies of the same (role, content, timestamp) rows —
+            # ballooning the DB and polluting FTS search. Skip rows whose key
+            # matches a row archived within the last 60s (compression-loop
+            # duplicates share the same timestamp; a genuine user re-send is
+            # spaced minutes apart). Rows without a usable timestamp are never
+            # deduped (conservative).
+            _dedup_window = time.time() - 60
+            _archived_keys = set()
+            try:
+                _cur = conn.execute(
+                    "SELECT role, content, timestamp FROM messages "
+                    "WHERE session_id = ? AND active = 0 AND compacted = 1 "
+                    "AND timestamp >= ?",
+                    (session_id, _dedup_window),
+                )
+                for _r in _cur.fetchall():
+                    _archived_keys.add((_r[0], _r[1], _r[2]))
+            except Exception:
+                _archived_keys = set()
+            _to_insert = compacted_messages
+            if _archived_keys:
+                _filtered = []
+                for _m in compacted_messages:
+                    _ts = _m.get("timestamp")
+                    if _ts is None:
+                        _filtered.append(_m)
+                        continue
+                    try:
+                        _fts = (
+                            float(_ts.timestamp())
+                            if hasattr(_ts, "timestamp")
+                            else float(_ts)
+                        )
+                    except (TypeError, ValueError):
+                        _filtered.append(_m)
+                        continue
+                    _key = (
+                        _m.get("role", "unknown"),
+                        self._encode_content(_m.get("content")),
+                        _fts,
+                    )
+                    if _key in _archived_keys:
+                        continue
+                    _filtered.append(_m)
+                if not _filtered:
+                    # Every rebuilt row was already archived within the
+                    # window: this compression pass is a pure re-insert of
+                    # the same tail (e.g. a repeated preflight pass that made
+                    # no progress). Skip the archive+insert entirely so the
+                    # archived layer never accumulates duplicates and the live
+                    # set stays untouched.
+                    _count = conn.execute(
+                        "SELECT COUNT(*) FROM messages "
+                        "WHERE session_id = ? AND active = 1",
+                        (session_id,),
+                    ).fetchone()[0]
+                    return _count
+                _to_insert = _filtered
 
             patched_model_config = None
             if model_config_patch is not None:
@@ -9906,7 +9968,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 (session_id,),
             )
             inserted, tool_calls_total = self._insert_message_rows(
-                conn, session_id, compacted_messages
+                conn, session_id, _to_insert
             )
 
             if tail_ids:

--- a/tests/acp/test_session_db_private_access.py
+++ b/tests/acp/test_session_db_private_access.py
@@ -10,6 +10,7 @@ Verifies that:
 import ast
 import json
 import tempfile
+import time
 from pathlib import Path
 from unittest.mock import MagicMock, patch, call
 
@@ -178,3 +179,89 @@ class TestPersistRoundTrip:
         assert row["model"] == "stored-model", (
             "COALESCE must preserve the existing model when new value is NULL"
         )
+
+
+# ---------------------------------------------------------------------------
+# archive_and_compact — compression-loop dedup guard
+# ---------------------------------------------------------------------------
+
+
+class TestArchiveAndCompactDedup:
+    """Repeated compression passes must not re-insert rows they just archived.
+
+    Root cause (8/8-8/9 reports): preflight + post-response + next-turn
+    preflight compression passes each soft-archive the live set and insert
+    the rebuilt tail again, so the archived (active=0, compacted=1) layer
+    accumulates duplicate copies of the same (role, content, timestamp)
+    rows — ballooning the DB and polluting FTS search. The dedup probe
+    skips rows whose key was archived within the last 60s and turns a
+    fully-duplicate pass into a no-op.
+    """
+
+    @staticmethod
+    def _rebuilt_tail():
+        now = time.time()
+        return [
+            {"role": "user", "content": "执行第 1–4 步", "timestamp": now},
+            {"role": "assistant", "content": "开始执行", "timestamp": now + 1},
+        ]
+
+    def test_repeated_compaction_does_not_duplicate_archived_tail(self, tmp_path):
+        db = _tmp_db(tmp_path)
+        db.create_session("s-dedup", source="acp", model="test")
+        tail = self._rebuilt_tail()
+        db.append_messages_batch("s-dedup", list(tail))
+
+        db.archive_and_compact("s-dedup", list(tail))
+        db.archive_and_compact("s-dedup", list(tail))
+
+        # Second pass is a pure re-insert: nothing new may land.
+        rows = db.get_messages("s-dedup", include_inactive=True)
+        assert len(rows) == 4, f"expected 2 archived + 2 active, got {len(rows)}"
+        active = [r for r in rows if r["active"] == 1]
+        assert len(active) == 2
+
+    def test_fully_duplicate_pass_is_a_noop_returning_active_count(self, tmp_path):
+        db = _tmp_db(tmp_path)
+        db.create_session("s-noop", source="acp", model="test")
+        tail = self._rebuilt_tail()
+        db.append_messages_batch("s-noop", list(tail))
+        db.archive_and_compact("s-noop", list(tail))
+
+        before = db.get_messages("s-noop", include_inactive=True)
+        returned = db.archive_and_compact("s-noop", list(tail))
+
+        after = db.get_messages("s-noop", include_inactive=True)
+        assert len(after) == len(before), "fully duplicate pass must not add rows"
+        assert returned == 2, f"no-op must return the current active count, got {returned}"
+
+    def test_new_rows_still_inserted_beside_duplicates(self, tmp_path):
+        db = _tmp_db(tmp_path)
+        db.create_session("s-partial", source="acp", model="test")
+        tail = self._rebuilt_tail()
+        db.append_messages_batch("s-partial", list(tail))
+        db.archive_and_compact("s-partial", list(tail))
+
+        # Next pass re-inserts the same tail PLUS a genuinely new row.
+        now = time.time()
+        next_pass = list(tail) + [
+            {"role": "user", "content": "新的一轮提问", "timestamp": now + 10}
+        ]
+        db.archive_and_compact("s-partial", next_pass)
+
+        rows = db.get_messages("s-partial", include_inactive=True)
+        active = [r for r in rows if r["active"] == 1]
+        # Archived seed (2) + archived first tail (2) + active: only the NEW row.
+        assert len(active) == 1, f"expected only the new row active, got {len(active)}"
+        assert active[0]["content"] == "新的一轮提问"
+
+    def test_rows_without_timestamp_are_never_deduped(self, tmp_path):
+        db = _tmp_db(tmp_path)
+        db.create_session("s-nots", source="acp", model="test")
+        no_ts = [{"role": "user", "content": "无时间戳行"}]
+        db.archive_and_compact("s-nots", list(no_ts))
+        db.archive_and_compact("s-nots", list(no_ts))
+
+        rows = db.get_messages("s-nots", include_inactive=True)
+        # Conservative: no timestamp -> never deduped, both passes insert.
+        assert len(rows) == 2, f"expected 2 rows (no dedup), got {len(rows)}"

--- a/tests/agent/test_turn_finalizer_cleanup_guard.py
+++ b/tests/agent/test_turn_finalizer_cleanup_guard.py
@@ -160,7 +160,10 @@ def test_clean_turn_has_no_cleanup_errors_key():
     agent = _StubAgent(raise_in=())
     result = _run(agent)
     assert result["final_response"] == "PARTIAL SUMMARY FROM MODEL"
-    assert result["completed"] is False
+    # A max-iterations turn that still produced a real final answer is a
+    # completed turn (fix for iteration-limit summaries surfacing as
+    # unfinished/interim rows): the user saw an actual final response.
+    assert result["completed"] is True
     assert "cleanup_errors" not in result
 
 

--- a/tests/agent/test_turn_finalizer_iteration_limit_exit.py
+++ b/tests/agent/test_turn_finalizer_iteration_limit_exit.py
@@ -196,6 +196,58 @@ def test_pending_response_records_kanban_timeout(monkeypatch):
     )
 
 
+def test_max_iterations_with_real_final_response_is_completed():
+    """A max-iterations fallback that produced a real answer completes.
+
+    Regression: iteration-limit summaries used to persist with
+    completed=False / finish_reason=NULL, which made desktop render the
+    turn's final answer as an unfinished interim bubble. A successful
+    summary IS the turn's final response, so the turn is completed.
+    """
+    monkeypatch = pytest.MonkeyPatch()
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", lambda *_a, **_kw: [])
+    agent = _LimitAgent()
+
+    result = _finalize(
+        agent,
+        final_response="summary from extra call",
+        exit_reason="max_iterations_reached(60/60)",
+    )
+
+    assert result["completed"] is True
+    assert result["turn_exit_reason"] == "max_iterations_reached(60/60)"
+
+
+def test_max_iterations_without_final_response_not_completed():
+    """No response at all keeps completed=False (resume/recovery signal)."""
+    monkeypatch = pytest.MonkeyPatch()
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", lambda *_a, **_kw: [])
+    agent = _LimitAgent()
+
+    result = _finalize(
+        agent,
+        final_response=None,
+        exit_reason="max_iterations_reached(60/60)",
+    )
+
+    assert result["completed"] is False
+
+
+def test_max_iterations_empty_placeholder_not_completed():
+    """An empty placeholder string is not a real response."""
+    monkeypatch = pytest.MonkeyPatch()
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", lambda *_a, **_kw: [])
+    agent = _LimitAgent()
+
+    result = _finalize(
+        agent,
+        final_response="   ",
+        exit_reason="max_iterations_reached(60/60)",
+    )
+
+    assert result["completed"] is False
+
+
 def test_published_pending_candidate_is_not_duplicated_by_finalizer(monkeypatch):
     """When budget exhaustion preserves a verification candidate that is
     already the tail assistant message, the finalizer must NOT append a

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -4228,7 +4228,12 @@ class TestRunConversation:
             result = agent.run_conversation("do the kanban work")
 
         # The agent should have reported the task as not completed.
-        assert result["completed"] is False
+        # NOTE: `completed` now reflects "a real final answer was produced"
+        # (iteration-limit summaries are the turn's final response — see
+        # turn_finalizer.completed); the kanban failure signal is carried
+        # independently by _record_task_failure(outcome="timed_out") below,
+        # which is what trips the dispatcher's failure_limit breaker.
+        assert result["completed"] is True
 
         # _record_task_failure should have been called exactly once for
         # the exhaustion event, with outcome="timed_out".


### PR DESCRIPTION
## Bug Description

Repeated `archive_and_compact` passes (preflight + post-response + next-turn preflight) re-inserted near-identical rebuilt tails, bloating the archived (`active=0, compacted=1`) layer and polluting FTS. Separately, max-iterations summary replies were persisted without `finish_reason='stop'`, so desktop surfaces rendered them as unfinished/interim bubbles; iteration-limit turns that produced a real final response did not close the resume/event chain cleanly.

## Root Cause

1. `archive_and_compact` had no dedup against recently archived `(role, content, timestamp)` keys.
2. Iteration-limit summary path appended assistant content without a terminal finish reason; turn finalizer treated some successful limit exits as not-completed.

## Fix

- `hermes_state.archive_and_compact`: 60s dedup probe; fully-duplicate passes become no-ops. Preserves main's compression lease (`lock_holder`) check.
- `chat_completion_helpers.handle_max_iterations`: tag successful summaries with `finish_reason='stop'` via existing `append_message`.
- `turn_finalizer`: treat iteration-limit turns that produced a real final response as completed.

## How to Verify

1. Run a long session that compresses multiple times in a short window — archived layer should not accumulate identical replay rows.
2. Force max-iterations with a successful summary — DB row should carry `finish_reason='stop'` and resume chain should close.

## Test Plan

- [x] `tests/agent/test_turn_finalizer_iteration_limit_exit.py`
- [x] `tests/agent/test_turn_finalizer_cleanup_guard.py`
- [x] `tests/acp/test_session_db_private_access.py` (dedup/no-op path)
- [x] 24 passed locally on current main base
- [ ] CI green

## Risk Assessment

Medium — touches compression commit path. Dedup is conservative (no timestamp → never dedupe; 60s window only). Lease check from main is preserved ahead of the dedup probe.
