### PR TITLE
fix(tools-config): stop reconfigure flow clobbering image_gen.use_gateway on managed FAL rows

### DIFF
--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -4948,7 +4948,13 @@ def _reconfigure_provider(
                 img_cfg = config.setdefault("image_gen", {})
                 if isinstance(img_cfg, dict):
                     img_cfg["provider"] = "fal"
-                    img_cfg["use_gateway"] = False
+                    # A managed (Nous Subscription) row also carries
+                    # imagegen_backend="fal" — the model picker runs AFTER
+                    # _write_provider_config set use_gateway=True, so an
+                    # unconditional False here silently flipped managed
+                    # picks onto the user's personal FAL_KEY (same class
+                    # as fe63353cb, which fixed the plugin-provider path).
+                    img_cfg["use_gateway"] = bool(managed_feature)
         # STT providers prompt for model selection on reconfig too.
         if provider.get("stt_provider") and not managed_feature:
             _configure_stt_model(provider["stt_provider"], config)
@@ -4991,7 +4997,9 @@ def _reconfigure_provider(
             img_cfg = config.setdefault("image_gen", {})
             if isinstance(img_cfg, dict):
                 img_cfg["provider"] = "fal"
-                img_cfg["use_gateway"] = False
+                # Same managed-row guard as the no-env-vars branch above:
+                # never clobber a Nous-managed pick back onto direct keys.
+                img_cfg["use_gateway"] = bool(managed_feature)
 
     # STT providers prompt for model selection on reconfig too.
     if provider.get("stt_provider") and not managed_feature:

--- a/tests/hermes_cli/test_imagegen_managed_gateway.py
+++ b/tests/hermes_cli/test_imagegen_managed_gateway.py
@@ -65,3 +65,60 @@ def test_image_and_video_selectors_share_the_gateway_contract(monkeypatch):
         _select_plugin_video_gen_provider("fal", config, use_gateway=use_gateway)
         assert config["image_gen"]["use_gateway"] is use_gateway
         assert config["video_gen"]["use_gateway"] is use_gateway
+
+
+def _quiet_reconfigure(monkeypatch):
+    """Silence prints + model pickers for _reconfigure_provider paths."""
+    import hermes_cli.tools_config as tc
+
+    monkeypatch.setattr(tc, "_print_success", lambda *a, **k: None)
+    monkeypatch.setattr(tc, "_print_info", lambda *a, **k: None, raising=False)
+    monkeypatch.setattr(tc, "_print_warning", lambda *a, **k: None, raising=False)
+    monkeypatch.setattr(tc, "_configure_imagegen_model", lambda *a, **k: None)
+    monkeypatch.setattr(tc, "_run_post_setup", lambda *a, **k: None, raising=False)
+    # Managed rows gate on live Portal auth — stub it green.
+    import hermes_cli.nous_subscription as ns
+
+    monkeypatch.setattr(ns, "ensure_nous_portal_access", lambda **k: True)
+
+
+def test_reconfigure_managed_fal_row_keeps_gateway_flag(monkeypatch):
+    """The sibling bug of fe63353cb: the legacy-backend model-pick step in
+    _reconfigure_provider hardcoded use_gateway=False AFTER the managed
+    branch wrote True — a Nous Subscription user re-entering the picker to
+    change models was silently flipped onto their personal FAL_KEY."""
+    _quiet_reconfigure(monkeypatch)
+    import hermes_cli.tools_config as tc
+
+    managed_row = {
+        "name": "Nous Subscription",
+        "env_vars": [],
+        "requires_nous_auth": True,
+        "managed_nous_feature": "image_gen",
+        "override_env_vars": ["FAL_KEY"],
+        "imagegen_backend": "fal",
+    }
+    config = {"image_gen": {"model": "fal-ai/gpt-image-2"}}
+
+    tc._reconfigure_provider(managed_row, config)
+
+    assert config["image_gen"]["provider"] == "fal"
+    assert config["image_gen"]["use_gateway"] is True
+
+
+def test_reconfigure_direct_fal_row_clears_gateway_flag(monkeypatch):
+    """Direct-key FAL reconfig must still clear the flag (historical
+    behavior for genuinely non-managed picks)."""
+    _quiet_reconfigure(monkeypatch)
+    import hermes_cli.tools_config as tc
+
+    direct_row = {
+        "name": "FAL.ai",
+        "env_vars": [],
+        "imagegen_backend": "fal",
+    }
+    config = {"image_gen": {"use_gateway": True}}
+
+    tc._reconfigure_provider(direct_row, config)
+
+    assert config["image_gen"]["use_gateway"] is False


### PR DESCRIPTION
## Summary
Nous-managed FAL image-gen picks now survive the model-picker step in the reconfigure flow — previously `_reconfigure_provider` clobbered `image_gen.use_gateway` back to `False` right after the managed branch wrote `True`, silently routing every generation to the user's personal FAL_KEY instead of the Nous subscription.

Root cause: the "Nous Subscription" image_gen row carries `imagegen_backend: "fal"`, and the legacy-backend model-pick step wrote `use_gateway = False` unconditionally at two sites. Same class as fe63353cb, which fixed the plugin-provider selector but missed the reconfigure flow.

## Changes
- `hermes_cli/tools_config.py`: both `_reconfigure_provider` sites now write `bool(managed_feature)` instead of hardcoded `False` (matches the existing correct site in `_configure_provider`)
- `tests/hermes_cli/test_imagegen_managed_gateway.py`: 2 regression tests driven through the real `TOOL_CATEGORIES` managed row + a direct-key row

## Validation
| | Before | After |
|---|---|---|
| Managed pick + model reconfigure | `use_gateway: false` (personal key billed, drained to lockout) | `use_gateway: true` (subscription billed) |
| Direct-key FAL reconfigure | `use_gateway: false` | `use_gateway: false` (unchanged) |
| New tests vs sabotaged (old) code | — | fail as expected |
| `tests/hermes_cli/test_imagegen_managed_gateway.py` + `test_tools_config.py` | — | 53/53 pass |

Live-verified: repaired config generates through the gateway (Nous-billed) successfully.

## Infographic

![Managed gateway flag clobber fix](https://v3b.fal.media/files/b/0aa68bde/YzVPfPSdIy0TzOPZ3skwm_bxEmschW.png)
