### PR TITLE
docs(agent): fix outdated Turn Lifecycle and compression descriptions in agent-loop.md

### DIFF
--- a/website/docs/developer-guide/agent-loop.md
+++ b/website/docs/developer-guide/agent-loop.md
@@ -209,9 +209,10 @@ The fallback system also covers auxiliary tasks independently — vision, compre
 3. The last N messages are preserved intact (`compression.protect_last_n`, default: 20)
 4. Tool call/result message pairs are kept together (never split)
 5. By default, compression runs in place: the compacted transcript is soft-archived
-   under the same session id (`compression.in_place`, default `true`). A separate
-   "child" session is only created on the rotation path (e.g. session-id rotation
-   or degraded fallback compression)
+   under the same session id (`compression.in_place`, default `true`), so the session
+   keeps one durable id for life. A separate "child" session is only created on the
+   legacy rotation path — i.e. when `compression.in_place` is explicitly set to
+   `false`
 
 ### Session Persistence
 

--- a/website/docs/developer-guide/agent-loop.md
+++ b/website/docs/developer-guide/agent-loop.md
@@ -70,10 +70,9 @@ run_conversation()
      - chat_completions: OpenAI format as-is
      - codex_responses: convert to Responses API input items
      - anthropic_messages: convert via anthropic_adapter.py
-  6. Inject ephemeral prompt layers (budget warnings, context pressure)
-  7. Apply prompt caching markers if on Anthropic
-  8. Make interruptible API call (_interruptible_api_call)
-  9. Parse response:
+  6. Apply prompt caching markers if on Anthropic
+  7. Make interruptible API call (_interruptible_api_call)
+  8. Parse response:
      - If tool_calls: execute them, append results, loop back to step 5
      - If text response: persist session, flush memory if needed, return
 ```
@@ -209,7 +208,10 @@ The fallback system also covers auxiliary tasks independently — vision, compre
 2. Middle conversation turns are summarized into a compact summary
 3. The last N messages are preserved intact (`compression.protect_last_n`, default: 20)
 4. Tool call/result message pairs are kept together (never split)
-5. A new session lineage ID is generated (compression creates a "child" session)
+5. By default, compression runs in place: the compacted transcript is soft-archived
+   under the same session id (`compression.in_place`, default `true`). A separate
+   "child" session is only created on the rotation path (e.g. session-id rotation
+   or degraded fallback compression)
 
 ### Session Persistence
 


### PR DESCRIPTION
## What does this PR do?

Fixes two outdated descriptions in `website/docs/developer-guide/agent-loop.md` that no longer match the current code, so the developer guide stops teaching contributors two things that are not true anymore.

1. **Turn Lifecycle step 6: "Inject ephemeral prompt layers (budget warnings, context pressure)"** — the injection described here no longer exists in the code. There is no code path that appends budget/context-pressure warnings into the request messages or system prompt. The remaining budget machinery emits **user-facing UI notices** (`AgentNotice` via `agent/credits_tracker.py`, seeded by `conversation_loop.py:854`), not prompt-layer injections — distinct channels, and the doc described the prompt-injection one. Removed the step and re-numbered the following ones.

2. **"What Happens During Compression" step 5: "A new session lineage ID is generated (compression creates a 'child' session)"** — compression runs **in place** by default: `compression.in_place` defaults to `true` (see `hermes_cli/config_defaults.py:775` and `agent_init.py`), and the compacted transcript is soft-archived under the same session id — the session keeps one durable id for life. A separate "child" session is only created on the legacy rotation path, i.e. when `compression.in_place` is explicitly set to `false` (see `conversation_compression.py`, in-place branch vs "Rotation (legacy)" else branch).

## Related Issue

Fixes #87597

## Type of Change

- [x] 📝 Documentation update

## Changes Made

- `website/docs/developer-guide/agent-loop.md`: removed step 6 "Inject ephemeral prompt layers" from the Turn Lifecycle list and re-numbered steps 7-9 to 6-8.
- `website/docs/developer-guide/agent-loop.md`: rewrote "What Happens During Compression" step 5 to describe in-place compaction (same session id) as the default, with rotation to a child session only on the legacy `compression.in_place: false` path.

## How to Test

1. Documentation-only change — no runtime behavior is affected.
2. Optional: `grep -rn "budget warning\|context pressure" agent/` finds no prompt-injection implementation; `grep -rn "AgentNotice" agent/credits_tracker.py` shows the remaining budget warnings are user-facing notices.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.) — `docs(agent):`
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate — searched for "ephemeral prompt layers", "budget warnings", "child session" compression; the open docs PR #72765 only updates the run_agent.py forwarding map and does not touch these lines
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — N/A for a documentation-only change
- [ ] I've added tests for my changes — N/A for a documentation-only change
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — this PR is the documentation update itself
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) — N/A, docs only
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## For New Skills

N/A — not a skill PR.