### PR TITLE
fix(kanban): reject empty completion from the CLI path too

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -2252,6 +2252,15 @@ def _cmd_complete(args: argparse.Namespace) -> int:
         return 1
     summary = getattr(args, "summary", None)
     raw_meta = getattr(args, "metadata", None)
+    # Guard: an empty handoff (no summary, no result) is rejected by the
+    # kanban_complete tool handler; keep the CLI path in parity so cards
+    # can't be closed with a NULL result from here either.
+    if not (summary or args.result):
+        print(
+            "kanban: provide at least one of: summary (preferred), result",
+            file=sys.stderr,
+        )
+        return 2
     # Guard: structured handoff fields are per-run, so they'd be
     # copy-pasted identically across N runs — almost always a footgun.
     # Refuse instead of silently doing the wrong thing.

--- a/tests/hermes_cli/test_kanban_complete_empty_guard.py
+++ b/tests/hermes_cli/test_kanban_complete_empty_guard.py
@@ -1,0 +1,85 @@
+"""hermes kanban complete must reject an empty handoff (no summary, no result).
+
+The kanban_complete tool handler (tools/kanban_tools.py) refuses completions
+that carry neither a summary nor a result:
+
+    if not (summary or result):
+        return tool_error("provide at least one of: summary (preferred), result")
+
+The CLI path (hermes_cli.kanban._cmd_complete) must apply the same guard, or
+workers can mark cards done with a NULL result via the CLI even though the
+tool path forbids it.
+
+Uses mocks for kb.get_task / kb.complete_task (same idiom as the CLI judge
+gate tests); the guard logic is the unit under test.
+"""
+
+import argparse
+import types
+from contextlib import contextmanager
+from unittest.mock import MagicMock
+
+from hermes_cli.kanban import _cmd_complete
+
+
+def _run(monkeypatch, *, task_ids, summary=None, result=None):
+    fake_task = types.SimpleNamespace(
+        goal_mode=False,
+        title="Some task",
+        body="",
+    )
+    fake_conn = MagicMock()
+    complete_calls: list = []
+
+    def fake_connect_closing():
+        @contextmanager
+        def _cm():
+            yield fake_conn
+
+        return _cm()
+
+    def fake_complete_task(conn, tid, **kw):
+        complete_calls.append(tid)
+        return True
+
+    monkeypatch.setattr("hermes_cli.kanban.kb.get_task", lambda conn, tid: fake_task)
+    monkeypatch.setattr("hermes_cli.kanban.kb.complete_task", fake_complete_task)
+    monkeypatch.setattr("hermes_cli.kanban.kb.connect_closing", fake_connect_closing)
+    monkeypatch.setattr("hermes_cli.kanban._worker_run_id_for", lambda _: None)
+
+    args = argparse.Namespace(
+        task_ids=list(task_ids), summary=summary, result=result, metadata=None
+    )
+    return _cmd_complete(args), complete_calls
+
+
+def test_complete_without_summary_or_result_is_rejected(monkeypatch, capsys):
+    rc, complete_calls = _run(monkeypatch, task_ids=["t1"])
+    assert rc != 0, "empty completion must produce a non-zero exit code"
+    assert complete_calls == [], (
+        "complete_task must NOT be invoked for an empty completion"
+    )
+    err = capsys.readouterr().err
+    assert "provide at least one of" in err, (
+        "error message must match the kanban_complete tool handler"
+    )
+
+
+def test_complete_multi_id_without_result_is_rejected(monkeypatch, capsys):
+    # Multi-id complete only accepts --result; the empty guard must still fire.
+    rc, complete_calls = _run(monkeypatch, task_ids=["t1", "t2"])
+    assert rc != 0
+    assert complete_calls == []
+    assert "provide at least one of" in capsys.readouterr().err
+
+
+def test_complete_with_result_only_is_accepted(monkeypatch):
+    rc, complete_calls = _run(monkeypatch, task_ids=["t1"], result="PASS abc123")
+    assert rc == 0
+    assert complete_calls == ["t1"]
+
+
+def test_complete_with_summary_only_is_accepted(monkeypatch):
+    rc, complete_calls = _run(monkeypatch, task_ids=["t1"], summary="did the thing")
+    assert rc == 0
+    assert complete_calls == ["t1"]


### PR DESCRIPTION
## Symptom

`hermes kanban complete <id>` accepts a completion with **neither `--summary` nor `--result`**, marking the task done with a NULL result. The `kanban_complete` tool handler explicitly rejects this (`tools/kanban_tools.py`):

```python
if not (summary or result):
    return tool_error("provide at least one of: summary (preferred), result")
```

So the same empty handoff that the tool path refuses sails through the CLI path. Any workflow that relies on the completion result being present (reviewers reading the handoff, acceptance checks that expect evidence in the result field, lifecycle hooks) can encounter done cards with an empty handoff.

## Root cause

CLI/tool parity gap: `_cmd_complete` in `hermes_cli/kanban.py` validates multi-id + per-task flag combinations and applies the goal-judge gate, but never checks that the handoff is non-empty before calling `kb.complete_task`.

## Fix

Add the same non-empty guard to `_cmd_complete`, before any per-task work, with the same error message as the tool handler (exit code 2, consistent with the other CLI argument guards in that function):

- runs once up front, so multi-id completes (which only accept `--result`) are covered too
- the goal-judge path is unaffected — it already draws its evidence text from `summary or result`, which the guard now guarantees is non-empty

## Tests

New `tests/hermes_cli/test_kanban_complete_empty_guard.py` (same mock idiom as the CLI judge-gate tests):

- empty completion (single id) → rc != 0, `complete_task` not called, error message matches the tool handler — **red before the fix** (CLI printed `Completed t1`, rc 0)
- empty completion (multi id) → rejected
- `--result` only → accepted
- `--summary` only → accepted

```
$ python -m pytest tests/hermes_cli/test_kanban_complete_empty_guard.py tests/hermes_cli/test_kanban_goal_mode.py -q
8 passed

$ python -m pytest tests/hermes_cli/test_kanban_cli.py tests/hermes_cli/test_kanban_core_functionality.py \
    tests/hermes_cli/test_kanban_review_lifecycle.py tests/hermes_cli/test_kanban_review_lifecycle_complete.py -q
1 failed, 68 passed   # the one failure (test_pid_alive_detects_zombie) also fails on clean main — unrelated live-system os.kill guard
```