### PR TITLE
fix(agent): canonicalize ALIASES providers in credential-pool mismatch guard (#87526)

### DIFF
--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -612,6 +612,22 @@ def _legacy_custom_pool_matches(
     return False
 
 
+def _canon_provider_id(name: str) -> str:
+    """Resolve a provider id through the shared ALIASES map.
+
+    Best-effort: returns the ALIASES-canonical id (``opencode-zen`` →
+    ``opencode``) so the same provider matches under either spelling, and
+    falls back to the input unchanged if the alias map can't be imported.
+    """
+    if not name:
+        return name
+    try:
+        from hermes_cli.providers import normalize_provider
+        return normalize_provider(name)
+    except Exception:
+        return name
+
+
 def credential_pool_matches_provider(
     pool_or_provider: Any,
     provider: Optional[str],
@@ -640,7 +656,17 @@ def credential_pool_matches_provider(
     if not pool_provider or not provider_norm:
         return False
     if not pool_provider.startswith(CUSTOM_POOL_PREFIX):
-        if pool_provider == provider_norm:
+        # Canonicalize both sides through the shared ALIASES map before the
+        # literal compare. The pool is seeded from the auth-registry slug
+        # (e.g. ``opencode-zen``), while a ``/model`` switch runs the provider
+        # through ``normalize_provider`` and stores the ALIASES-canonical id
+        # (``opencode``) on the session override. Comparing the two literally
+        # treats the same provider as a mismatch and skips pool rotation / 429
+        # retry / billing recovery for every provider whose canonical id
+        # differs from its slug (#87526). Genuinely different providers still
+        # differ after canonicalization, preserving fallback isolation
+        # (#33088/#33163).
+        if _canon_provider_id(pool_provider) == _canon_provider_id(provider_norm):
             return True
         return _keyed_custom_pool_matches(pool_provider, provider_norm, base_url)
     if provider_norm == "custom":

--- a/tests/agent/test_alias_pool_mismatch_guard.py
+++ b/tests/agent/test_alias_pool_mismatch_guard.py
@@ -1,0 +1,60 @@
+"""Regression tests for the credential-pool provider-mismatch guard with
+ALIASES-canonicalized providers (#87526).
+
+Two code paths name the same provider differently. The pool is seeded from
+the auth-registry slug (e.g. ``opencode-zen``), while a ``/model`` switch runs
+the provider through ``normalize_provider`` and stores the ALIASES-canonical
+id (``opencode``) on the session override. The defensive guard in
+``recover_with_credential_pool`` compared the two literally, logged
+"Credential pool provider mismatch: pool=opencode-zen, agent=opencode", and
+skipped recovery — so pool rotation / 429 retry / billing recovery never ran
+for ANY provider whose ALIASES canonical id differs from its slug.
+
+The fix canonicalizes both sides through the shared alias map before
+comparing, so the aliased pair matches while genuinely different providers
+still trip the guard (#33088/#33163: never mutate the primary's pool while a
+fallback provider is active).
+"""
+from unittest.mock import MagicMock
+
+from agent.agent_runtime_helpers import recover_with_credential_pool
+from agent.error_classifier import FailoverReason
+
+
+def _agent(provider, pool_provider):
+    agent = MagicMock()
+    agent.provider = provider
+    pool = MagicMock()
+    pool.provider = pool_provider
+    agent._credential_pool = pool
+    return agent, pool
+
+
+class TestAliasPoolMismatchGuard:
+
+    def test_aliased_provider_pair_is_not_guarded(self):
+        """agent carries the ALIASES-canonical id (``opencode``) while the
+        pool is seeded from the slug (``opencode-zen``) — the same provider,
+        so recovery must proceed and rotate rather than skip."""
+        agent, pool = _agent("opencode", "opencode-zen")
+        recovered, _ = recover_with_credential_pool(
+            agent,
+            status_code=402,
+            has_retried_429=False,
+            classified_reason=FailoverReason.billing,
+        )
+        assert recovered is True
+        pool.mark_exhausted_and_rotate.assert_called_once()
+
+    def test_genuinely_different_provider_still_guarded(self):
+        """A different provider (not an alias of the pool's) must still skip
+        pool mutation — the #33088/#33163 fallback-isolation contract."""
+        agent, pool = _agent("anthropic", "opencode-zen")
+        recovered, _ = recover_with_credential_pool(
+            agent,
+            status_code=402,
+            has_retried_429=False,
+            classified_reason=FailoverReason.billing,
+        )
+        assert recovered is False
+        assert not pool.method_calls


### PR DESCRIPTION
## Problem

Credential-pool rotation is silently skipped for any provider whose `ALIASES`
canonical id differs from its auth-registry slug (e.g. `opencode-zen` →
`opencode`). Round-robin/least-used rotation, 429 retry, and billing-exhaustion
recovery never fire — the user sees repeated 429s on a single key even with 2+
credentials in the pool.

Fixes #87526.

## Root cause

Two paths name the same provider differently:

- **Pool** — `CredentialPool.provider` is seeded from the auth-registry slug,
  `"opencode-zen"`.
- **Session override** — `switch_model()` sets `target_provider = pdef.id`,
  which for `opencode-zen` has already been run through `normalize_provider()`
  (ALIASES: `opencode-zen → opencode`), so the override stores `"opencode"`.

The guard in `recover_with_credential_pool()`
(`agent/agent_runtime_helpers.py`) compared the two literally:

```python
if pool_provider and current_provider != pool_provider:  # "opencode" != "opencode-zen"
    # → pool mutation skipped, rotation never fires
```

## Fix

Canonicalize **both** sides through the existing `normalize_provider()` (the
same alias map `switch_model` already uses) before the equality check. The same
provider under either spelling now matches, so rotation proceeds; genuinely
different providers — the #33088/#33163 fallback-isolation case this guard
exists to protect — still resolve to different canonical ids and stay guarded.
The `custom:<name>` special-case keeps using the raw strings, so its base_url
resolution is unchanged.

This is the issue's suggested option **B** (resolve both sides before
comparison), chosen over option A because it closes the whole concern
regardless of how the override provider got set, and keeps the change to the
single guard rather than the `/model` switch path.

## Tests

`tests/agent/test_alias_pool_mismatch_guard.py`:
- `test_aliased_provider_pair_is_not_guarded` — `agent=opencode` /
  `pool=opencode-zen` now proceeds to rotate on a billing 402.
- `test_genuinely_different_provider_still_guarded` — `agent=anthropic` /
  `pool=opencode-zen` still skips (fallback-isolation contract preserved).

The sibling `tests/agent/test_custom_pool_mismatch_guard.py` and the credential-
pool routing / fallback-isolation suites remain green.


---

**Update (rebased onto `main`):** upstream centralized this guard — the literal `pool_provider` compare in `recover_with_credential_pool` was replaced by `credential_pool_matches_provider()` in `agent/credential_pool.py`. The ALIASES canonicalization now lives inside that predicate's non-custom branch, so the fix is the single source of truth and covers every caller (not just `recover_with_credential_pool`). The `custom:<name>` alias handling upstream added is preserved untouched; the regression test is unchanged (it drives `recover_with_credential_pool` end-to-end). Verified the #87526 repro still fails on plain `main` (`credential_pool_matches_provider(pool="opencode-zen", "opencode")` → `False`) and passes with this change; full `tests/agent` credential-pool suite green (134 passed).
