### PR TITLE
fix(plugins): clearer bare-name install error when the community index is unreachable (#87565)

### DIFF
--- a/hermes_cli/plugins_cmd.py
+++ b/hermes_cli/plugins_cmd.py
@@ -679,6 +679,21 @@ def _resolve_index_name(identifier: str, console) -> tuple[str, Optional[str]]:
             for c in candidates:
                 console.print(f"  {c.name}  →  {c.install_identifier}")
             _fail(console, "Re-run with the exact name or the owner/repo identifier.")
+        if source == "seed":
+            # A "seed" source means the published index wasn't reachable
+            # (not published yet, offline, or blocked) and no cache was
+            # available, so bare-name resolution fell back to the bundled
+            # seed. Saying "not found in the community index" here is
+            # misleading — the index was never consulted. Point the user at
+            # the owner/repo form, which works regardless (#87565).
+            _fail(console, (
+                f"[red]Error:[/red] Plugin '{identifier}' isn't in the bundled "
+                "plugin seed, and the community index couldn't be fetched (it "
+                "may not be published yet, or you're offline), so bare-name "
+                "resolution is limited to the seed right now.\n"
+                "Install it directly with an `owner/repo` identifier "
+                "(e.g. `hermes plugins install owner/repo`), or run "
+                "`hermes plugins search <term>` to browse the seed."))
         _fail(console, (
             f"[red]Error:[/red] Plugin '{identifier}' was not found in the "
             f"community index ({source}). Use `hermes plugins search <term>` to "

--- a/tests/hermes_cli/test_plugin_index_search.py
+++ b/tests/hermes_cli/test_plugin_index_search.py
@@ -380,7 +380,12 @@ class TestInstallResolution:
         assert "hermes-media-studio" in out
         assert "hermes-telegram-business" in out
 
-    def test_install_unknown_name_exits(self, hermes_home, monkeypatch, capsys):
+    def test_install_unknown_name_seed_source_points_at_owner_repo(
+        self, hermes_home, monkeypatch, capsys
+    ):
+        # source="seed" means the community index was unreachable (unpublished
+        # / offline), so the message must not claim "not found in the index"
+        # and must steer the user to owner/repo instead (#87565).
         from hermes_cli import plugins_cmd
 
         monkeypatch.setattr(
@@ -389,7 +394,26 @@ class TestInstallResolution:
         with pytest.raises(SystemExit) as exc:
             plugins_cmd.cmd_install("totally-unknown", enable=False)
         assert exc.value.code == 1
-        assert "not found" in capsys.readouterr().out
+        out = capsys.readouterr().out
+        assert "owner/repo" in out
+        assert "couldn't be fetched" in out
+
+    def test_install_unknown_name_remote_source_says_not_found(
+        self, hermes_home, monkeypatch, capsys
+    ):
+        # With a populated remote/cache index, an unknown name genuinely was
+        # not found in the index — keep the direct message.
+        from hermes_cli import plugins_cmd
+
+        monkeypatch.setattr(
+            plugin_index, "load_index", lambda **kw: (_parse_entries(SAMPLE), "remote")
+        )
+        with pytest.raises(SystemExit) as exc:
+            plugins_cmd.cmd_install("totally-unknown", enable=False)
+        assert exc.value.code == 1
+        out = capsys.readouterr().out
+        assert "not found in the" in out
+        assert "community index (remote)" in out
 
     def test_owner_repo_passthrough_skips_index(self, hermes_home, monkeypatch):
         """Explicit owner/repo installs never consult the index."""


### PR DESCRIPTION
## Problem

The community plugin index seed repo (`NousResearch/hermes-plugin-index`) isn't
published yet, so `DEFAULT_INDEX_URL` 404s. `load_index()` then falls back
through the chain (fresh cache → remote → stale cache → **bundled seed**) and
returns `source="seed"`. A bare-name install of anything not in the seed fails
with:

```
Error: Plugin 'foo' was not found in the community index (seed). ...
```

which is misleading — the index was never reachable, so it was never actually
consulted. The user isn't told the index is unpublished/unreachable, and the
`owner/repo` form (which works fine today) isn't surfaced clearly.

Addresses #87565 (option 3). Publishing the seed repo (options 1/2) is a repo-
admin action outside this codebase; this covers the CLI-side error clarity that
helps every bare-name user *right now*, while the index is unpublished.

## Fix

Make `_resolve_index_name`'s not-found message source-aware, using the `source`
value already in scope:

- **`source == "seed"`** (index unreachable / unpublished / offline, no cache):
  say the index couldn't be fetched and point at the `owner/repo` form.
- **`remote` / `cache`** (a populated index really was consulted): keep the
  existing "not found in the community index (`<source>`)" wording.

Message-only change; no resolution behavior changes.

## Tests

`tests/hermes_cli/test_plugin_index_search.py`:
- `test_install_unknown_name_seed_source_points_at_owner_repo` — seed source
  surfaces the `owner/repo` guidance and drops the misleading "not found in the
  index" claim.
- `test_install_unknown_name_remote_source_says_not_found` — remote source
  keeps the direct wording.

(replaces the prior `test_install_unknown_name_exits`, which asserted the old
seed-source wording.)
