### PR TITLE
fix(gateway): keep secondary-profile cron briefs in gateway transcripts

### DIFF
--- a/gateway/mirror.py
+++ b/gateway/mirror.py
@@ -12,14 +12,28 @@ the full SessionStore machinery.
 import json
 import logging
 from datetime import datetime
+from pathlib import Path
 from typing import Optional
 
-from hermes_cli.config import get_hermes_home
+from hermes_constants import get_process_hermes_home
 
 logger = logging.getLogger(__name__)
 
-_SESSIONS_DIR = get_hermes_home() / "sessions"
-_SESSIONS_INDEX = _SESSIONS_DIR / "sessions.json"
+def _gateway_sessions_dir() -> Path:
+    """Return the gateway process's shared session directory.
+
+    Multiplexed turns install a context-local profile home, but the gateway
+    ``SessionStore`` is created before those scopes and persists every routed
+    chat under the process launch home. Mirroring must resolve the same store.
+    """
+    return get_process_hermes_home() / "sessions"
+
+
+def _gateway_session_db():
+    """Open the SQLite store owned by the gateway process."""
+    from hermes_state import SessionDB
+
+    return SessionDB(db_path=get_process_hermes_home() / "state.db")
 
 
 def mirror_to_session(
@@ -113,8 +127,7 @@ def _find_session_id(
     """
     # Primary: state.db
     try:
-        from hermes_state import SessionDB
-        db = SessionDB()
+        db = _gateway_session_db()
         try:
             finder = getattr(db, "find_session_by_origin", None)
             if callable(finder):
@@ -132,11 +145,12 @@ def _find_session_id(
         logger.debug("Mirror state.db session lookup failed: %s", e)
 
     # Fallback: sessions.json (pre-migration databases)
-    if not _SESSIONS_INDEX.exists():
+    sessions_index = _gateway_sessions_dir() / "sessions.json"
+    if not sessions_index.exists():
         return None
 
     try:
-        with open(_SESSIONS_INDEX, encoding="utf-8") as f:
+        with open(sessions_index, encoding="utf-8") as f:
             data = json.load(f)
     except Exception:
         return None
@@ -192,8 +206,7 @@ def _append_to_sqlite(session_id: str, message: dict) -> None:
     """Append a message to the SQLite session database."""
     db = None
     try:
-        from hermes_state import SessionDB
-        db = SessionDB()
+        db = _gateway_session_db()
         db.append_message(
             session_id=session_id,
             role=message.get("role", "assistant"),

--- a/tests/gateway/test_mirror.py
+++ b/tests/gateway/test_mirror.py
@@ -11,7 +11,7 @@ from gateway.mirror import (
 
 
 def _setup_sessions(tmp_path, sessions_data):
-    """Helper to write a fake sessions.json and patch module-level paths."""
+    """Helper to write a fake sessions.json."""
     sessions_dir = tmp_path / "sessions"
     sessions_dir.mkdir(parents=True, exist_ok=True)
     index_file = sessions_dir / "sessions.json"
@@ -29,8 +29,9 @@ class TestFindSessionId:
             }
         })
 
-        with patch.object(mirror_mod, "_SESSIONS_DIR", sessions_dir), \
-             patch.object(mirror_mod, "_SESSIONS_INDEX", index_file):
+        with patch.object(
+            mirror_mod, "_gateway_sessions_dir", return_value=sessions_dir
+        ):
             result = _find_session_id("telegram", "12345")
 
         assert result == "sess_abc"
@@ -49,8 +50,9 @@ class TestFindSessionId:
             },
         })
 
-        with patch.object(mirror_mod, "_SESSIONS_DIR", sessions_dir), \
-             patch.object(mirror_mod, "_SESSIONS_INDEX", index_file):
+        with patch.object(
+            mirror_mod, "_gateway_sessions_dir", return_value=sessions_dir
+        ):
             result = _find_session_id("telegram", "12345")
 
         assert result == "sess_new"
@@ -69,14 +71,99 @@ class TestFindSessionId:
             },
         })
 
-        with patch.object(mirror_mod, "_SESSIONS_DIR", sessions_dir), \
-             patch.object(mirror_mod, "_SESSIONS_INDEX", index_file):
+        with patch.object(
+            mirror_mod, "_gateway_sessions_dir", return_value=sessions_dir
+        ):
             result = _find_session_id("telegram", "-1001", thread_id="10")
 
         assert result == "sess_topic_a"
 
+    def test_legacy_index_ignores_secondary_profile_scope(self, tmp_path, monkeypatch):
+        from hermes_constants import (
+            reset_hermes_home_override,
+            set_hermes_home_override,
+        )
+
+        gateway_home = tmp_path / "gateway"
+        secondary_home = gateway_home / "profiles" / "secondary"
+        sessions_dir, _ = _setup_sessions(gateway_home, {
+            "secondary-chat": {
+                "session_id": "sess_secondary",
+                "origin": {"platform": "telegram", "chat_id": "12345"},
+                "updated_at": "2026-01-01T00:00:00",
+            }
+        })
+        secondary_home.mkdir(parents=True)
+        monkeypatch.setenv("HERMES_HOME", str(gateway_home))
+        empty_db = MagicMock()
+        empty_db.find_session_by_origin.return_value = None
+
+        token = set_hermes_home_override(secondary_home)
+        try:
+            with patch(
+                "gateway.mirror._gateway_session_db", return_value=empty_db
+            ):
+                result = _find_session_id("telegram", "12345")
+        finally:
+            reset_hermes_home_override(token)
+
+        assert sessions_dir == mirror_mod._gateway_sessions_dir()
+        assert result == "sess_secondary"
+        empty_db.close.assert_called_once()
+
 
 class TestMirrorToSession:
+
+    def test_mirrors_to_gateway_store_inside_secondary_profile_scope(
+        self, tmp_path, monkeypatch
+    ):
+        """A routed profile scope must not redirect the gateway transcript DB."""
+        from hermes_constants import (
+            reset_hermes_home_override,
+            set_hermes_home_override,
+        )
+        from hermes_state import SessionDB
+
+        gateway_home = tmp_path / "gateway"
+        secondary_home = gateway_home / "profiles" / "secondary"
+        gateway_home.mkdir()
+        secondary_home.mkdir(parents=True)
+        monkeypatch.setenv("HERMES_HOME", str(gateway_home))
+
+        gateway_db = SessionDB(db_path=gateway_home / "state.db")
+        gateway_db.create_session(
+            "gw-secondary-chat",
+            "telegram",
+            user_id="user-1",
+            session_key="agent:secondary:telegram:dm",
+            chat_id="chat-1",
+            chat_type="dm",
+        )
+        gateway_db.close()
+
+        token = set_hermes_home_override(secondary_home)
+        try:
+            mirrored = mirror_to_session(
+                "telegram",
+                "chat-1",
+                "secondary profile cron brief",
+                source_label="cron:test-job",
+                user_id="user-1",
+                role="user",
+            )
+        finally:
+            reset_hermes_home_override(token)
+
+        assert mirrored is True
+        gateway_db = SessionDB(db_path=gateway_home / "state.db")
+        try:
+            assert [
+                (message["role"], message["content"])
+                for message in gateway_db.get_messages("gw-secondary-chat")
+            ] == [("user", "secondary profile cron brief")]
+        finally:
+            gateway_db.close()
+        assert not (secondary_home / "state.db").exists()
 
 
     def test_successful_mirror_uses_user_id_for_group_session(self, tmp_path):
@@ -93,8 +180,9 @@ class TestMirrorToSession:
             },
         })
 
-        with patch.object(mirror_mod, "_SESSIONS_DIR", sessions_dir), \
-             patch.object(mirror_mod, "_SESSIONS_INDEX", index_file), \
+        with patch.object(
+            mirror_mod, "_gateway_sessions_dir", return_value=sessions_dir
+        ), \
              patch("gateway.mirror._append_to_sqlite") as mock_sqlite:
             result = mirror_to_session(
                 "telegram",
@@ -111,8 +199,9 @@ class TestMirrorToSession:
     def test_no_matching_session(self, tmp_path):
         sessions_dir, index_file = _setup_sessions(tmp_path, {})
 
-        with patch.object(mirror_mod, "_SESSIONS_DIR", sessions_dir), \
-             patch.object(mirror_mod, "_SESSIONS_INDEX", index_file):
+        with patch.object(
+            mirror_mod, "_gateway_sessions_dir", return_value=sessions_dir
+        ):
             result = mirror_to_session("telegram", "99999", "Hello!")
 
         assert result is False
@@ -124,7 +213,7 @@ class TestAppendToSqlite:
         from gateway.mirror import _append_to_sqlite
         mock_db = MagicMock()
 
-        with patch("hermes_state.SessionDB", return_value=mock_db):
+        with patch("gateway.mirror._gateway_session_db", return_value=mock_db):
             _append_to_sqlite("sess_1", {"role": "assistant", "content": "hello"})
 
         mock_db.append_message.assert_called_once()

--- a/tests/manual/cron_inchannel_e2e.py
+++ b/tests/manual/cron_inchannel_e2e.py
@@ -35,8 +35,7 @@ from pathlib import Path
 
 
 def _fresh_home():
-    """Point HERMES_HOME at a throwaway dir BEFORE importing gateway modules
-    (mirror.py binds _SESSIONS_INDEX from get_hermes_home() at import time)."""
+    """Point the gateway process home at a throwaway directory."""
     d = tempfile.mkdtemp(prefix="cron_inchannel_e2e_")
     os.environ["HERMES_HOME"] = d
     return Path(d)
@@ -49,11 +48,6 @@ import cron.scheduler as sched  # noqa: E402
 import gateway.mirror as mirror  # noqa: E402
 from gateway.config import GatewayConfig, Platform  # noqa: E402
 from gateway.session import SessionStore, SessionSource, build_session_key  # noqa: E402
-
-# Force mirror.py's module-level index path to our temp home (it may have bound
-# a different get_hermes_home() at import if something imported it earlier).
-mirror._SESSIONS_DIR = HOME / "sessions"
-mirror._SESSIONS_INDEX = HOME / "sessions" / "sessions.json"
 
 BRIEF = "brief: PRs need review\n- Harden: session lifecycle teardown"
 
@@ -105,7 +99,7 @@ def _run_scenario(name, chat_id, is_dm, reply_chat_type):
     sid = mirror._find_session_id("slack", chat_id, thread_id=None, user_id="U_HUMAN")
     assert sid, f"{name}: _find_session_id found NO session — the reply would dead-end"
     # Read the session transcript back and confirm the brief text is present.
-    idx = mirror._SESSIONS_INDEX
+    idx = mirror._gateway_sessions_dir() / "sessions.json"
     import json
     data = json.loads(idx.read_text())
     entry = next((e for e in data.values() if isinstance(e, dict) and e.get("session_id") == sid), None)


### PR DESCRIPTION
## What does this PR do?

Secondary-profile cron jobs with `attach_to_session: true` can report successful delivery while silently omitting the brief from the live gateway conversation. This change keeps mirror lookup and append operations on the gateway process-owned session store, so routed cron deliveries remain available in the transcript that receives later replies.

### Symptom

With `gateway.multiplex_profiles: true`, a cron job routed through a secondary profile delivers its message but `mirror_to_session()` returns false and the target gateway transcript does not contain the brief.

### Impact

Continuable cron jobs for secondary profiles lose their in-conversation context even though delivery succeeds. A later reply reaches a transcript that never recorded the cron brief.

### Bug Cause

**Trigger:** `gateway/mirror.py:130` in `_find_session_id()` while a multiplexed turn has installed a secondary-profile runtime scope.

**Causal chain:**
1. The gateway creates its shared session store under the process launch home.
2. A secondary-profile cron delivery enters a context-local profile scope, and mirror lookup previously opened `SessionDB()` from that scoped home.
3. The target gateway session is absent from the secondary database, so mirroring exits before appending the brief to the live transcript.

**Why it is wrong:** The mirror used ambient profile state even though the owning gateway session store is process-scoped. Changing only lookup would also leave append vulnerable to writing into a different database.

**Working sibling / contrast:** The same origin mirrors successfully outside the secondary scope because the ambient home then matches the gateway process home.

**Ruled out:** Session-origin matching is not the failure. The same platform, chat, thread, and user origin succeeds when only the active profile scope changes.

### Fix

Resolve both SQLite lookup and append from `get_process_hermes_home()`, and resolve the legacy `sessions.json` fallback dynamically from that same process-owned home. Regression coverage verifies that a secondary profile scope appends only to the gateway database and does not create a secondary `state.db`.

## Related Issue

Closes #87531

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/mirror.py` - keep mirror lookup, append, and legacy fallback on the gateway process-owned session store.
- `tests/gateway/test_mirror.py` - cover SQLite and legacy-index behavior inside a secondary profile scope.
- `tests/manual/cron_inchannel_e2e.py` - use the dynamic gateway session path in the offline end-to-end harness.

## How to Test

1. Start from a gateway process home with a session matching a platform, chat, thread, and user origin.
2. Enter a secondary profile runtime scope and mirror a unique cron brief to that origin.
3. Confirm the brief is appended to the process-owned session and no secondary-profile `state.db` is created.
4. Run the focused automated tests:

```bash
scripts/run_tests.sh tests/gateway/test_mirror.py tests/cron/test_scheduler.py -k 'mirror or seed_cron'
```

5. Run the offline cron session harness:

```bash
PYTHONPATH="$PWD" python tests/manual/cron_inchannel_e2e.py
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Relevant documentation is N/A; behavior and private helper semantics are documented in code.
- [x] Config example changes are N/A; no config keys changed.
- [x] Contributor or architecture guide changes are N/A; no workflow contract changed.
- [x] Cross-platform impact was considered; the fix uses profile-aware `pathlib.Path` operations.
- [x] Tool description or schema changes are N/A; no tool contract changed.

## Screenshots / Logs

Focused automated tests passed: 12 passed. The offline channel and DM scenarios also passed. REAL_ENV verification reproduced the base failure, then confirmed the fixed path appended only to the gateway process-owned store while secondary-profile storage remained untouched.
