### PR TITLE
fix(cli): route welcome banner + update notice through TUI-safe console

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -8055,8 +8055,14 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             if snapshot is not None:
                 self._defer_tool_warnings = True
                 toolset_map = snapshot["toolset_map"]
+                # Route Rich banner output through the TUI-safe console
+                # (ChatConsole -> _cprint -> prompt_toolkit's ANSI renderer)
+                # instead of self.console, which writes raw ANSI to stdout
+                # and gets mangled by patch_stdout's StdoutProxy into garbled
+                # '?[33m...?[0m' text (#2262). Mirrors the /clear fresh-start
+                # path (see _reset_session) that already uses ChatConsole().
                 build_welcome_banner(
-                    console=self.console,
+                    console=self._output_console(),
                     model=self.model,
                     cwd=cwd,
                     tools=snapshot["tools"],
@@ -8103,8 +8109,11 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                 tools = get_tool_definitions(enabled_toolsets=self.enabled_toolsets, quiet_mode=True)
                 availability = compute_toolset_availability(self.enabled_toolsets)
 
+                # See note above — route through the TUI-safe console so the
+                # banner's Rich ANSI isn't mangled into '?[33m...?[0m' by
+                # patch_stdout's StdoutProxy.
                 build_welcome_banner(
-                    console=self.console,
+                    console=self._output_console(),
                     model=self.model,
                     cwd=cwd,
                     tools=tools,


### PR DESCRIPTION
## What

Fixes garbled ANSI text in the interactive TUI transcript — startup banners render as literal `?[1;33m⚠ ... ?[0m` instead of colors.

## Root cause

`show_banner()` passed the raw `self.console` (a plain Rich `Console()`) to `build_welcome_banner`. Rich writes its ANSI output directly to stdout, and under the interactive TUI prompt_toolkit's `patch_stdout` `StdoutProxy` mangles the ESC byte (0x1B) into a literal `?`, producing `?[33m...?[0m` text. This is the same failure the codebase already documents at cli.py:12255 (`#2262`).

## Fix

Route both `build_welcome_banner` calls in `show_banner()` through `self._output_console()`, which returns `ChatConsole()` (→ `_cprint` → prompt_toolkit's ANSI renderer) once the TUI is live — matching the /clear fresh-start path that already uses `ChatConsole()`. This also covers the deferred update notice, which prints via the same console passed into `build_welcome_banner` (`_defer_update_notice`).

## Verification

- `tests/hermes_cli/test_banner.py` + `tests/tools/test_startup_latency_regressions.py`: 19 passed.
- The fix mirrors the proven-working /clear path.
