### PR TITLE
feat(desktop): expose focused-chat busy turn flags on the plugin SDK (salvage #87558)

### DIFF
--- a/apps/desktop/src/plugins/example/plugin.tsx
+++ b/apps/desktop/src/plugins/example/plugin.tsx
@@ -39,10 +39,11 @@ const $events = atom(0)
 function ClickCounter() {
   const count = useValue($clicks)
   const events = useValue($events)
+  const busy = useValue(host.state.busy)
   const gateway = useValue(host.state.gateway)
 
   return (
-    <Tip label={`Example plugin — gateway ${gateway}, ${events} events heard`}>
+    <Tip label={`Example plugin: gateway ${gateway}, ${busy ? 'working' : 'idle'}, ${events} events heard`}>
       <button
         className={cn(
           'inline-flex h-full items-center gap-1 rounded-none px-1.5 text-[0.6875rem] tabular-nums transition-colors',

--- a/apps/desktop/src/sdk/index.test.ts
+++ b/apps/desktop/src/sdk/index.test.ts
@@ -1,0 +1,66 @@
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { createClientSessionState } from '@/lib/chat-runtime'
+import { host } from '@/sdk'
+import {
+  setActiveSessionId,
+  setAwaitingResponse,
+  setBusy
+} from '@/store/session'
+import { clearAllSessionStates, publishSessionState } from '@/store/session-states'
+
+describe('host.state turn flags', () => {
+  afterEach(() => {
+    setActiveSessionId(null)
+    setBusy(false)
+    setAwaitingResponse(false)
+    clearAllSessionStates()
+  })
+
+  it('uses the draft atoms when there is no runtime session', () => {
+    expect(host.state.busy.get()).toBe(false)
+    expect(host.state.awaitingResponse.get()).toBe(false)
+
+    setBusy(true)
+    setAwaitingResponse(true)
+
+    expect(host.state.busy.get()).toBe(true)
+    expect(host.state.awaitingResponse.get()).toBe(true)
+  })
+
+  it('reads the focused session slice once a runtime exists', () => {
+    setBusy(false)
+    setAwaitingResponse(false)
+    setActiveSessionId('rt-focus')
+    publishSessionState('rt-focus', {
+      ...createClientSessionState('stored-focus'),
+      awaitingResponse: true,
+      busy: true
+    })
+
+    expect(host.state.busy.get()).toBe(true)
+    expect(host.state.awaitingResponse.get()).toBe(true)
+
+    publishSessionState('rt-focus', {
+      ...createClientSessionState('stored-focus'),
+      awaitingResponse: false,
+      busy: true
+    })
+
+    expect(host.state.busy.get()).toBe(true)
+    expect(host.state.awaitingResponse.get()).toBe(false)
+  })
+
+  it('does not pick up a background session', () => {
+    setActiveSessionId('rt-focus')
+    publishSessionState('rt-focus', createClientSessionState('stored-focus'))
+    publishSessionState('rt-bg', {
+      ...createClientSessionState('stored-bg'),
+      awaitingResponse: true,
+      busy: true
+    })
+
+    expect(host.state.busy.get()).toBe(false)
+    expect(host.state.awaitingResponse.get()).toBe(false)
+  })
+})

--- a/apps/desktop/src/sdk/index.test.ts
+++ b/apps/desktop/src/sdk/index.test.ts
@@ -63,4 +63,51 @@ describe('host.state turn flags', () => {
     expect(host.state.busy.get()).toBe(false)
     expect(host.state.awaitingResponse.get()).toBe(false)
   })
+
+  it('follows a focused session tile, not the primary', async () => {
+    const tree = await import('@/components/pane-shell/tree/store')
+    const model = await import('@/components/pane-shell/tree/model')
+    const { registry } = await import('@/contrib/registry')
+    const { $sessionTiles } = await import('@/store/session-states')
+
+    // A second chat zone holding a session tile, next to the main workspace.
+    for (const id of ['workspace', 'session-tile:tile-a']) {
+      registry.register({
+        area: 'panes',
+        data: id === 'workspace' ? { placement: 'main', uncloseable: true } : { placement: 'main' },
+        id,
+        render: () => null,
+        title: id
+      })
+    }
+
+    tree.declareDefaultTree(
+      model.split('row', [
+        model.group(['workspace'], { active: 'workspace', id: 'grp-main' }),
+        model.group(['session-tile:tile-a'], { active: 'session-tile:tile-a', id: 'grp-side' })
+      ])
+    )
+
+    // Primary chat is idle; the tile's session is mid-turn.
+    setActiveSessionId('rt-primary')
+    publishSessionState('rt-primary', createClientSessionState('stored-primary'))
+    $sessionTiles.set([{ runtimeId: 'rt-tile-a', storedSessionId: 'tile-a' }])
+    publishSessionState('rt-tile-a', {
+      ...createClientSessionState('tile-a'),
+      awaitingResponse: true,
+      busy: true
+    })
+
+    // Focusing the tile zone moves the flags onto the tile's session…
+    tree.noteActiveTreeGroup('grp-side')
+    expect(host.state.busy.get()).toBe(true)
+    expect(host.state.awaitingResponse.get()).toBe(true)
+
+    // …and homing back to the workspace returns to the (idle) primary.
+    tree.noteActiveTreeGroup('grp-main')
+    expect(host.state.busy.get()).toBe(false)
+    expect(host.state.awaitingResponse.get()).toBe(false)
+
+    $sessionTiles.set([])
+  })
 })

--- a/apps/desktop/src/sdk/index.ts
+++ b/apps/desktop/src/sdk/index.ts
@@ -20,6 +20,7 @@
 
 import { atom, type ReadableAtom } from 'nanostores'
 
+import { PRIMARY_SESSION_VIEW } from '@/app/chat/session-view'
 import { openSession, type OpenSessionIntent } from '@/app/open-session'
 import { $narrowViewport } from '@/components/pane-shell/tree/store'
 import { onGatewayEvent } from '@/contrib/events'
@@ -68,6 +69,14 @@ export const host = {
   state: {
     /** Runtime id of the active chat session (null on a fresh draft). */
     activeSessionId: readonlyAtom<null | string>($activeSessionId),
+    /** True from send until the first assistant payload on the focused chat. */
+    awaitingResponse: readonlyAtom<boolean>(PRIMARY_SESSION_VIEW.$awaitingResponse),
+    /**
+     * True while the focused chat is working after a send. Covers the wait
+     * for the first token and the stream that follows. Same session as
+     * `activeSessionId`. A draft with no runtime id uses the global flag.
+     */
+    busy: readonlyAtom<boolean>(PRIMARY_SESSION_VIEW.$busy),
     /** Active workspace cwd ('' when detached). */
     cwd: readonlyAtom<string>($currentCwd),
     /** Gateway socket state: 'idle' | 'connecting' | 'open' | …. */

--- a/apps/desktop/src/sdk/index.ts
+++ b/apps/desktop/src/sdk/index.ts
@@ -18,10 +18,11 @@
  *  - `ui.*` — the design language, so plugin UI looks native by default.
  */
 
-import { atom, type ReadableAtom } from 'nanostores'
+import { atom, computed, type ReadableAtom } from 'nanostores'
 
 import { PRIMARY_SESSION_VIEW } from '@/app/chat/session-view'
 import { openSession, type OpenSessionIntent } from '@/app/open-session'
+import type { ClientSessionState } from '@/app/types'
 import { $narrowViewport } from '@/components/pane-shell/tree/store'
 import { onGatewayEvent } from '@/contrib/events'
 import { deleteProfile, getLogs, getStatus, type HermesGateway } from '@/hermes'
@@ -36,12 +37,43 @@ import {
   setActiveProfile,
   setShowAllProfiles
 } from '@/store/profile'
-import { $activeSessionId, $currentCwd, $currentModel, $gatewayState } from '@/store/session'
+import {
+  $activeSessionId,
+  $currentCwd,
+  $currentModel,
+  $gatewayState,
+  $selectedStoredSessionId
+} from '@/store/session'
+import { $focusedSessionState, $focusedStoredSessionId } from '@/store/session-states'
 import { runGatewayRestart } from '@/store/system-actions'
 
 // -- state: readonly views over the app's live atoms -------------------------
 
 const readonlyAtom = <T>(atomLike: ReadableAtom<T>): ReadableAtom<T> => atomLike
+
+/**
+ * Turn flag for the FOCUSED chat — same semantics as the statusbar's busy
+ * pulse. While the focused surface is the primary workspace (or a draft with
+ * no runtime slice yet) this reads the primary view, which itself falls back
+ * to the global draft atoms. Once a session TILE holds focus, the tile's own
+ * state slice is authoritative — a background session can never leak in.
+ */
+const focusedTurnFlag = (
+  select: (state: ClientSessionState) => boolean,
+  $primary: ReadableAtom<boolean>
+): ReadableAtom<boolean> =>
+  computed(
+    [$focusedStoredSessionId, $selectedStoredSessionId, $focusedSessionState, $primary],
+    (focused, selected, state, primary) =>
+      !focused || focused === selected ? primary : Boolean(state && select(state))
+  )
+
+const $focusedBusy = focusedTurnFlag(state => state.busy, PRIMARY_SESSION_VIEW.$busy)
+
+const $focusedAwaitingResponse = focusedTurnFlag(
+  state => state.awaitingResponse,
+  PRIMARY_SESSION_VIEW.$awaitingResponse
+)
 
 /** Window geometry + the app's responsive posture, one readonly rect. */
 export interface ViewportRect {
@@ -70,13 +102,14 @@ export const host = {
     /** Runtime id of the active chat session (null on a fresh draft). */
     activeSessionId: readonlyAtom<null | string>($activeSessionId),
     /** True from send until the first assistant payload on the focused chat. */
-    awaitingResponse: readonlyAtom<boolean>(PRIMARY_SESSION_VIEW.$awaitingResponse),
+    awaitingResponse: readonlyAtom<boolean>($focusedAwaitingResponse),
     /**
      * True while the focused chat is working after a send. Covers the wait
-     * for the first token and the stream that follows. Same session as
-     * `activeSessionId`. A draft with no runtime id uses the global flag.
+     * for the first token and the stream that follows. Follows tile focus —
+     * same signal the statusbar's busy pulse reads. A draft with no runtime
+     * id uses the global flag.
      */
-    busy: readonlyAtom<boolean>(PRIMARY_SESSION_VIEW.$busy),
+    busy: readonlyAtom<boolean>($focusedBusy),
     /** Active workspace cwd ('' when detached). */
     cwd: readonlyAtom<string>($currentCwd),
     /** Gateway socket state: 'idle' | 'connecting' | 'open' | …. */

--- a/skills/autonomous-ai-agents/hermes-agent/references/desktop-plugins.md
+++ b/skills/autonomous-ai-agents/hermes-agent/references/desktop-plugins.md
@@ -54,9 +54,11 @@ The ONLY import surface is `@hermes/plugin-sdk` (plus `react` /
 `react/jsx-runtime`, which resolve to the app's own React — write UI with
 `jsx()` calls, not JSX syntax; the file is not compiled).
 
-- `host.state.*` — readonly reactive atoms: `activeSessionId`, `cwd`,
-  `gateway`, `model`, `profile`, `viewport`. Read with `.get()` in handlers,
-  `useValue(atom)` in components.
+- `host.state.*` — readonly reactive atoms: `activeSessionId`, `busy`,
+  `awaitingResponse`, `cwd`, `gateway`, `model`, `profile`, `viewport`.
+  `busy` is true while the focused chat is working after a send (thinking
+  and streaming). `awaitingResponse` is true until the first assistant
+  payload. Read with `.get()` in handlers, `useValue(atom)` in components.
 - `host.request(method, params)` — gateway JSON-RPC (sessions, config,
   skills, cron — everything the app uses).
 - `host.onEvent(type, fn)` — live gateway events (`'*'` for all). Returns a

--- a/website/docs/developer-guide/desktop-plugin-sdk.md
+++ b/website/docs/developer-guide/desktop-plugin-sdk.md
@@ -409,7 +409,9 @@ probe) and `profiles.create` (`name`, `description`, `clone_from`,
 ws twins of the dashboard's `/api/profiles` REST routes.
 `host.state.busy` is the focused chat's live turn (thinking and streaming).
 `host.state.awaitingResponse` stays true from send until the first assistant
-payload. Both follow `activeSessionId`. Subscribe in a component:
+payload. Both follow the chat the user is actually looking at — the focused
+session tile when one holds focus, else the primary workspace chat (the same
+signal the statusbar's busy pulse reads). Subscribe in a component:
 
 ```javascript
 const busy = useValue(host.state.busy)

--- a/website/docs/developer-guide/desktop-plugin-sdk.md
+++ b/website/docs/developer-guide/desktop-plugin-sdk.md
@@ -374,6 +374,8 @@ components.
 
 ```ts
 host.state.activeSessionId  // ReadableAtom<string | null>
+host.state.awaitingResponse // ReadableAtom<boolean>  true until the first assistant payload
+host.state.busy             // ReadableAtom<boolean>  focused chat is working after a send
 host.state.cwd              // ReadableAtom<string>
 host.state.gateway          // ReadableAtom<string>  ('idle' | 'connecting' | 'open' | …)
 host.state.model            // ReadableAtom<string>
@@ -405,6 +407,17 @@ cron, kanban, …). Profile-shaped plugins get first-class methods too:
 probe) and `profiles.create` (`name`, `description`, `clone_from`,
 `clone_all`, `no_skills`, `soul`, optional `model` + `provider` pin) — the
 ws twins of the dashboard's `/api/profiles` REST routes.
+`host.state.busy` is the focused chat's live turn (thinking and streaming).
+`host.state.awaitingResponse` stays true from send until the first assistant
+payload. Both follow `activeSessionId`. Subscribe in a component:
+
+```javascript
+const busy = useValue(host.state.busy)
+```
+
+For token-level detail, listen with `host.onEvent` (`message.start`,
+`message.delta`, `message.complete`).
+
 `host.onEvent` streams live gateway events (message deltas,
 session lifecycle, tool activity). Listeners are isolated — a throw in your
 listener can't affect app dispatch. Every `host` door is async-safe: a sync throw


### PR DESCRIPTION
## Summary

Desktop plugins can now read the focused chat's live turn state: `host.state.busy` (send → end of stream) and `host.state.awaitingResponse` (send → first assistant payload) — salvage of #87558 by @Adolanium, extended so the flags genuinely follow the FOCUSED chat.

## Changes

- `apps/desktop/src/sdk/index.ts`: two new readonly atoms on `host.state`. Contributor's commit wired them to `PRIMARY_SESSION_VIEW`; follow-up commit routes them through the focused-session slice (`$focusedStoredSessionId` / `$focusedSessionState`) with the primary view (and its draft fallback) while the workspace holds focus — the same signal the statusbar's busy pulse reads, so a focused session tile reports its own turn, not the primary's.
- `apps/desktop/src/sdk/index.test.ts`: contributor's 3 tests (draft fallback, focused slice, background-session no-leak) + a new tile-focus test (tile mid-turn reads busy; homing back to the idle primary reads idle).
- `apps/desktop/src/plugins/example/plugin.tsx`: example tooltip shows working/idle.
- Docs (`desktop-plugin-sdk.md`) + skill note (`desktop-plugins.md`): new atoms documented; corrected "follow `activeSessionId`" wording to focused-chat semantics.

## Validation

| Check | Result |
|---|---|
| `npx vitest run src/sdk/index.test.ts` | 4/4 pass |
| `npm run check:lint` (tsc ×3 + eslint, CI parity) | 0 errors |
| Attribution audit | clean (`<id>+login` noreply, auto-resolved) |

Salvaged from #87558 with @Adolanium's authorship preserved; focused-slice follow-up is a separate commit.

## Infographic

![Busy turn flags infographic](https://v3b.fal.media/files/b/0aa68cab/wEnpv3tlvYCWaidy3L8Go_hYMOpFLA.png)
