### PR TITLE
fix(desktop): translate the Voice "Echo Transcripts" field into zh-CN (#87580)

### DIFF
--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -602,6 +602,7 @@ export const zh: Translations = {
       },
       stt: {
         enabled: '语音转文字',
+        echoTranscripts: '回显转写文本',
         provider: '语音转文字提供方',
         local: {
           model: '本地转写模型',
@@ -749,6 +750,7 @@ export const zh: Translations = {
       },
       stt: {
         enabled: '启用本地或提供方支持的语音转写。',
+        echoTranscripts: '将语音消息的原始 🎙️ 转写结果回显到聊天中。',
         elevenlabs: {
           languageCode: '可选的 ISO-639-3 语言代码。留空让 ElevenLabs 自动检测。'
         }


### PR DESCRIPTION
## What

Under the `zh-CN` locale, the **Settings → Voice → Echo Transcripts** toggle kept an English label (`Echo Transcripts`) and English description (`Post the raw 🎙️ transcript of voice messages back to the chat.`) while every sibling STT control was translated.

## Why

`apps/desktop/src/app/settings/config-field.tsx` resolves field copy in this order:

```
fieldCopyForSchemaKey(t.settings.fieldLabels, key)   // locale table
  ?? fieldCopyForSchemaKey(FIELD_LABELS, key)        // en fallback in constants.ts
  ?? prettyName(...)
```

`fieldLabels.stt` / `fieldDescriptions.stt` in `apps/desktop/src/i18n/zh.ts` had every sibling key (`enabled`, `provider`, `local.*`, `openai.model`, `groq.model`, `mistral.model`, `elevenlabs.*`) **except** `echoTranscripts`, so the resolver fell through to the English constants.

## Change

Add `echoTranscripts` to both `fieldLabels.stt` and `fieldDescriptions.stt` in `zh.ts`, matching the casual tone of the surrounding entries:

- label: `回显转写文本`
- description: `将语音消息的原始 🎙️ 转写结果回显到聊天中。`

Data-only; no schema, no migration. `ja.ts` / `zh-hant.ts` have the same hole but are intentionally left for a separate locale-coverage pass (per the reporter's note).

## Test

- `apps/desktop` i18n vitest suites (`runtime.test.ts`, `context.test.tsx`) pass.
- Renderer `tsc` shows no new errors for `zh.ts` (`defineFieldCopy` accepts the loose `FieldCopyTree`).

Fixes #87580
