### PR TITLE
fix(desktop): localize the Kanban sidebar nav and "Open board" labels (#87577)

### DIFF
--- a/apps/desktop/src/plugins/kanban/plugin.tsx
+++ b/apps/desktop/src/plugins/kanban/plugin.tsx
@@ -114,7 +114,7 @@ const plugin: HermesPlugin = {
         id: 'nav',
         area: SIDEBAR_NAV_AREA,
         order: 50,
-        data: { codicon: 'project', label: 'Kanban', path: '/kanban' } satisfies SidebarNavContribution
+        data: { codicon: 'project', label: ctx.i18n.t('nav'), path: '/kanban' } satisfies SidebarNavContribution
       },
       {
         id: 'count',
@@ -127,7 +127,7 @@ const plugin: HermesPlugin = {
         area: PALETTE_AREA,
         data: {
           id: 'kanban.open',
-          label: 'Kanban: Open board',
+          label: ctx.i18n.t('openBoard'),
           keywords: ['kanban', 'board', 'tasks', 'agents'],
           run: () => host.navigate('/kanban')
         } satisfies PaletteContribution


### PR DESCRIPTION
## What

The Kanban plugin's **sidebar nav row** and the **"Kanban: Open board"** command-palette entry stayed English under non-English locales (`看板` expected in zh-CN), while every other sidebar item translated correctly.

## Why

Both labels were hardcoded literals in the `register()` contribution config:

```ts
{ id: 'nav',  ..., data: { ..., label: 'Kanban', ... } }
{ id: 'open', ..., data: { id: 'kanban.open', label: 'Kanban: Open board', ... } }
```

The plugin's i18n table (`i18n.ts`) already defines `nav` and `openBoard` for `en` / `ja` / `zh` / `zh-hant`, and the sibling `new-task` palette + keybind entries in the same block already resolve their label via `ctx.i18n.t('newTaskCommand')`.

## Change

Route the two labels through the same seam:

- `label: 'Kanban'` → `label: ctx.i18n.t('nav')`
- `label: 'Kanban: Open board'` → `label: ctx.i18n.t('openBoard')`

This mirrors the established register-time i18n resolution the `newTaskCommand` entries in the same `registerMany` block already use — minimal and consistent, no new render wrappers. `plugin.name` / `plugin.description` are intentionally left English (plugin identifier), per the reporter's out-of-scope note. No schema, no migration.

## Test

- `apps/desktop` kanban vitest suite passes (9 tests).
- Renderer `tsc` reports no errors in `plugin.tsx` (`ctx.i18n.t` returns `string`, same as the existing `newTaskCommand` usage).

Fixes #87577
