### PR TITLE
fix(models): pin Kimi Coding picker to live wire IDs only

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -384,39 +384,31 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "moonshotai/kimi-k2.6",
         "minimaxai/minimax-m3",
     ],
+    # Kimi Coding Plan live wire IDs only (GET api.kimi.com/coding/v1/models).
+    # Do not list retired catalog aliases (kimi-k3 / kimi-k2.*) — curated-first
+    # merge would pin those slugs above bare live ids and break selection.
     "kimi-coding": [
-        "kimi-k3",
-        "kimi-k2.7-code",
-        "kimi-k2.6",
-        "kimi-k2.5",
+        "k3",
+        "k3-256k",
         "kimi-for-coding",
         "kimi-for-coding-highspeed",
-        "kimi-k2-thinking",
-        "kimi-k2-thinking-turbo",
-        "kimi-k2-turbo-preview",
-        "kimi-k2-0905-preview",
     ],
     "kimi-coding-cn": [
-        "kimi-k3",
-        "kimi-k2.7-code",
-        "kimi-k2.7-code-highspeed",
-        "kimi-k2.6",
-        "kimi-k2.5",
-        "kimi-k2-thinking",
-        "kimi-k2-turbo-preview",
-        "kimi-k2-0905-preview",
+        "k3",
+        "k3-256k",
+        "kimi-for-coding",
+        "kimi-for-coding-highspeed",
     ],
     "stepfun": [
         "step-3.5-flash",
         "step-3.5-flash-2603",
     ],
+    # Moonshot (legacy direct) must not list Coding Plan-only SKUs
+    # (see TestKimiMoonshotModelListIsolation). Share the two flagship
+    # wire ids that Coding Plan and current Moonshot routing both accept.
     "moonshot": [
-        "kimi-k3",
-        "kimi-k2.6",
-        "kimi-k2.5",
-        "kimi-k2-thinking",
-        "kimi-k2-turbo-preview",
-        "kimi-k2-0905-preview",
+        "k3",
+        "k3-256k",
     ],
     "minimax": [
         "MiniMax-M3",
@@ -2583,8 +2575,38 @@ def _provider_keys(provider: str) -> set[str]:
 
 # Retired model IDs kept for /model auto-detect only — not shown in pickers.
 # DeepSeek cut these off on 2026-07-24; model_normalize remaps them on the wire.
+# Kimi Coding Plan retired public slugs (2026-07/08): live catalog is only
+# k3 / k3-256k / kimi-for-coding / kimi-for-coding-highspeed.
 _PROVIDER_RETIRED_ALIASES: dict[str, tuple[str, ...]] = {
     "deepseek": ("deepseek-chat", "deepseek-reasoner"),
+    "kimi-coding": (
+        "kimi-k3",
+        "kimi-k2.7-code",
+        "kimi-k2.6",
+        "kimi-k2.5",
+        "kimi-k2-thinking",
+        "kimi-k2-thinking-turbo",
+        "kimi-k2-turbo-preview",
+        "kimi-k2-0905-preview",
+    ),
+    "kimi-coding-cn": (
+        "kimi-k3",
+        "kimi-k2.7-code",
+        "kimi-k2.7-code-highspeed",
+        "kimi-k2.6",
+        "kimi-k2.5",
+        "kimi-k2-thinking",
+        "kimi-k2-turbo-preview",
+        "kimi-k2-0905-preview",
+    ),
+    "moonshot": (
+        "kimi-k3",
+        "kimi-k2.6",
+        "kimi-k2.5",
+        "kimi-k2-thinking",
+        "kimi-k2-turbo-preview",
+        "kimi-k2-0905-preview",
+    ),
 }
 
 
@@ -2620,8 +2642,10 @@ _BORROWED_MODEL_PROVIDERS: frozenset[str] = frozenset()
 # surfaced newest model stays at the top even when the live API lags. OpenCode
 # Zen / Go re-expose dozens of upstream vendors and rotate them frequently, so
 # their stale curated entries must not pollute the top of the picker. (#49129)
+# Kimi Coding Plan: live GET /v1/models is the SoT for wire ids (k3 / k3-256k /
+# kimi-for-coding*); retired public slugs must not win curated-first merge.
 _LIVE_FIRST_PICKER_PROVIDERS: frozenset[str] = frozenset(
-    {"opencode-zen", "opencode-go"}
+    {"opencode-zen", "opencode-go", "kimi-coding", "kimi-coding-cn"}
 )
 
 
@@ -3048,11 +3072,12 @@ def _model_dedup_key(model_id: str) -> str:
     """Case-insensitive dedup key that also folds picker-search aliases.
 
     Some providers serve the same model under both a curated public slug and
-    a bare live wire id (Kimi Coding Plan lists its flagship as ``k3`` while
-    the curated catalog carries ``kimi-k3``). Folding through the search-alias
-    table keeps the curated-first merge from emitting both as separate rows.
-    The row that survives is the primary list's entry; selection still sends
-    whichever id the surviving row carries.
+    a bare live wire id (Kimi Coding Plan flagship wire id is ``k3``; older
+    catalogs used ``kimi-k3``). Folding through the search-alias table keeps
+    the curated-first merge from emitting both as separate rows. The row that
+    survives is the primary list's entry; selection still sends whichever id
+    the surviving row carries — so curated Kimi lists must lead with the
+    live wire id (``k3``), not the retired public slug.
     """
     key = str(model_id).strip().lower()
     try:

--- a/tests/hermes_cli/test_model_search_alias_dedup.py
+++ b/tests/hermes_cli/test_model_search_alias_dedup.py
@@ -1,8 +1,8 @@
-"""Picker dedup must fold live bare wire-ids into their curated public slug.
+"""Picker merge must not double-list Kimi Coding live bare ids.
 
-Kimi Coding Plan live-discovers its flagship as the bare id ``k3`` while the
-curated catalog carries ``kimi-k3``. The curated-first picker merge must not
-render both as separate rows for the same model.
+Kimi Coding Plan live-discovers its flagship as the bare wire id ``k3``.
+The curated catalog now leads with the same live id (retired public slug
+``kimi-k3`` is alias-only). Merge must keep a single k3-family row.
 """
 
 from unittest.mock import patch
@@ -13,14 +13,16 @@ from hermes_cli.models import provider_model_ids
 
 class TestModelAliasCanonical:
     def test_bare_k3_folds_to_public_slug(self):
+        # Alias table still maps bare wire → legacy public slug for search
+        # / config compatibility; picker catalog itself leads with bare k3.
         assert model_alias_canonical("k3") == "kimi-k3"
         assert model_alias_canonical("K3") == "kimi-k3"
 
 
 class TestPickerMergeAliasDedup:
     def test_live_bare_k3_not_duplicated_against_curated_kimi_k3(self):
-        """Coding Plan key: live returns bare ``k3``; curated has ``kimi-k3``.
-        Exactly one k3-family row must survive (the curated slug leads)."""
+        """Coding Plan key: live returns bare ``k3``; curated also leads with
+        ``k3``. Exactly one k3-family row must survive (live bare id)."""
         with (
             patch(
                 "hermes_cli.auth.resolve_api_key_provider_credentials",
@@ -37,7 +39,9 @@ class TestPickerMergeAliasDedup:
             out = provider_model_ids("kimi-coding")
 
         k3_rows = [m for m in out if model_alias_canonical(m) == "kimi-k3"]
-        assert k3_rows == ["kimi-k3"], out
+        assert k3_rows == ["k3"], out
         # Live-only entries with no curated twin still surface.
         assert "kimi-for-coding" in out
+        # Retired public slug must not reappear as a second picker row.
+        assert "kimi-k3" not in out
 

--- a/tests/hermes_cli/test_models_dev_preferred_merge.py
+++ b/tests/hermes_cli/test_models_dev_preferred_merge.py
@@ -105,14 +105,17 @@ class TestProviderModelIdsPreferred:
             ):
                 custom_models = provider_model_ids("kimi-coding")
 
-        # The live bare wire id ``k3`` folds into the curated public slug
-        # ``kimi-k3`` (picker alias dedup) — one row, curated slug leads.
-        assert coding_models[0] == "kimi-k3"
-        assert all(model.lower() != "k3" for model in coding_models)
-        assert all(model.lower() != "k3" for model in legacy_models)
-        assert all(model.lower() != "k3" for model in custom_models)
-        # Legacy / custom endpoints never advertise the k3 family at all
-        # via live discovery (their curated floor may still carry kimi-k3).
+        # Live wire id ``k3`` is first-class on the coding endpoint catalog
+        # (retired public slug ``kimi-k3`` is no longer the picker lead).
+        assert coding_models[0] == "k3"
+        assert "k3" in {m.lower() for m in coding_models}
+        # Coding-plan live SoT must not reintroduce retired k2.* public slugs.
+        assert all("k2" not in m.lower() for m in coding_models)
+        assert all(m.lower() != "kimi-k3" for m in coding_models)
+        # Non-coding base URLs still inherit the curated floor (includes bare
+        # k3) but the retired public slug must not reappear as a picker row.
+        assert all(m.lower() != "kimi-k3" for m in legacy_models)
+        assert all(m.lower() != "kimi-k3" for m in custom_models)
 
     def test_kimi_setup_flow_uses_same_coding_plan_catalog(self):
         """The setup wizard must not carry a stale duplicate Kimi model list."""
@@ -133,7 +136,7 @@ class TestProviderModelIdsPreferred:
             _model_flow_kimi({}, current_model="")
 
         assert captured["models"] == _PROVIDER_MODELS["kimi-coding"]
-        assert captured["models"][0] == "kimi-k3"
+        assert captured["models"][0] == "k3"
 
 
 class TestOpenRouterAndNousUnchanged:


### PR DESCRIPTION
## Bug Description

Kimi Coding model pickers could show and select retired wire IDs (`kimi-k3`, `kimi-k2.*`) that no longer resolve on `api.kimi.com/coding`, while live bare IDs were ranked below curated stale entries.

## Root Cause

Curated-first merge preferred the static catalog over live provider listings, so dead slugs stayed at the top of the picker.

## Fix

- Catalog pinned to live wire set: `k3` / `k3-256k` / `kimi-for-coding*`
- `kimi-coding*` paths are live-first
- Retired slugs remain only in auto-detect aliases (not picker surface)

## How to Verify

1. Configure a `sk-kimi-` key against kimi-coding.
2. Open model picker for Kimi Coding — only live IDs appear.
3. Selecting a listed model issues a successful completion against the coding endpoint.

## Test Plan

- [ ] CI green on current main
- [x] Surgical single-file change (`hermes_cli/models.py`)

## Risk Assessment

Low — catalog/ranking only; aliases keep backward auto-detect for old config strings.

## Supersedes

Replaces stale [#76223](https://github.com/NousResearch/hermes-agent/pull/76223) (CI red against older base). That PR will be closed in favor of this rebase.
