### PR TITLE
fix(cron): clear run_claim for one-shot jobs on dispatch failure (#86522)

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -2528,6 +2528,34 @@ def heartbeat_run_claim(job_id: str, *, expected_owner: str) -> bool:
     return False
 
 
+def clear_run_claim(job_id: str) -> bool:
+    """Clear a one-shot job's ``run_claim`` when its dispatch fails.
+
+    ``get_due_jobs`` stamps a ``run_claim`` before returning a one-shot as
+    due (#59229).  ``mark_job_run`` clears it on *successful* completion.
+    When dispatch itself fails (interpreter shutdown, executor submit error,
+    execution-creation error) the job never reaches ``mark_job_run`` and the
+    stale claim blocks re-dispatch until the TTL expires (default 30 min).
+
+    Calling this on every early-exit path restores the "the job stays due
+    and will fire on the next healthy tick" invariant that the scheduler
+    comment promises (#86522).
+    """
+    with _jobs_lock():
+        jobs = load_jobs()
+        for job in jobs:
+            if job.get("id") != job_id:
+                continue
+            if job.get("schedule", {}).get("kind") != "once":
+                return False
+            if job.get("run_claim") is not None:
+                job["run_claim"] = None
+                save_jobs(jobs)
+                return True
+            return False  # already cleared
+    return False
+
+
 def advance_next_runs(job_ids) -> int:
     """Batch form of :func:`advance_next_run` for the due-dispatch loop.
 

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -452,6 +452,7 @@ from cron.jobs import (
     claim_dispatch,
     claim_job_for_fire,
     fire_claim_fence,
+    clear_run_claim,
     get_due_jobs,
     heartbeat_fire_claim,
     heartbeat_run_claim,
@@ -6540,6 +6541,7 @@ def tick(
                     "Job '%s' not dispatched — interpreter is shutting down",
                     job.get("name", job_id),
                 )
+                clear_run_claim(job_id)
                 return None
             if not try_register_running_job(job_id):
                 logger.info("Job '%s' already running — skipping", job.get("name", job_id))
@@ -6557,6 +6559,7 @@ def tick(
                 # audit requirement: every add is paired with guaranteed
                 # cleanup).
                 release_running_job(job_id)
+                clear_run_claim(job_id)
                 logger.exception(
                     "Job '%s' not dispatched: execution creation failed: %s",
                     job.get("name", job_id),
@@ -6574,6 +6577,7 @@ def tick(
                 fut = pool.submit(_run_and_release)
             except Exception as submit_err:
                 release_running_job(job_id)
+                clear_run_claim(job_id)
                 finish_execution(
                     execution["id"],
                     success=False,


### PR DESCRIPTION
## Summary

`get_due_jobs()` stamps a `run_claim` on one-shot jobs before returning them as due (#59229). `mark_job_run()` clears it on successful completion. But when dispatch itself fails (interpreter shutdown, executor submit error, execution-creation error), the job never reaches `mark_job_run` and the stale claim blocks re-dispatch until the TTL expires (default 30 min).

## Root Cause

`_submit_with_guard()` in `scheduler.py` has three early-exit paths that release the in-flight running-job claim but leave `run_claim` intact:

1. **Interpreter shutting down** (line ~6540) — returns None, `run_claim` untouched
2. **Execution creation failure** (line ~6553) — calls `release_running_job`, `run_claim` untouched
3. **Executor submit failure** (line ~6575) — calls `release_running_job`, `run_claim` untouched

The scheduler comment says "the job stays due and will fire on the next healthy tick" — true for recurring jobs, false for one-shots whose `run_claim` blocks re-dispatch.

## Fix

- Add `clear_run_claim(job_id)` to `cron/jobs.py` — clears `run_claim` for one-shot jobs under the existing `_jobs_lock` + `load_jobs`/`save_jobs` CAS pattern
- Call it on all three early-exit paths in `_submit_with_guard`

## Testing

- 53 existing cron tests pass (run_claim, oneshot, dispatch related)
- `py_compile` passes for both files
- Changes limited to 2 files, 32 lines added

Fixes #86522
