### PR TITLE
fix(acp): guard None final_response in ACP prompt handler (#86798)

### DIFF
--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -2002,7 +2002,7 @@ class HermesACPAgent(acp.Agent):
                     exc_info=True,
                 )
 
-        final_response = result.get("final_response", "")
+        final_response = result.get("final_response") or ""
         cancelled = bool(state.cancel_event and state.cancel_event.is_set())
         interrupted = bool(result.get("interrupted")) or cancelled
         # Hermes' local "waiting for model response" interrupt status is metadata,


### PR DESCRIPTION
## Summary

When a turn is interrupted mid-flight, `turn_finalizer` returns `final_response: None` (the key exists in the dict but the value is `None`). `result.get("final_response", "")` returns `None` — not the empty-string default — because `.get()` only uses the default when the key is *missing*.

The subsequent `final_response.startswith()` on line 2012 crashes with `AttributeError: 'NoneType' object has no attribute 'startswith'`. This exception propagates before the queued-prompt drain loop, so queued user messages stay "queued" forever.

## Fix

Change `result.get("final_response", "")` to `result.get("final_response") or ""` — the same pattern already used in `curator.py`, `delegate_tool.py`, `feishu_comment.py`, `oneshot.py`, and `scheduler.py`.

Single line change. No test changes needed (ACP adapter tests have a pre-existing `ModuleNotFoundError: acp` collection error unrelated to this fix).

Fixes #86798
