### PR TITLE
fix(desktop): registry-agent gateway scoping — no silent primary fallback, connection sync, shared switch mutex

### DIFF
--- a/apps/desktop/src/sdk/index.ts
+++ b/apps/desktop/src/sdk/index.ts
@@ -24,10 +24,11 @@ import { openSession, type OpenSessionIntent } from '@/app/open-session'
 import { $narrowViewport } from '@/components/pane-shell/tree/store'
 import { onGatewayEvent } from '@/contrib/events'
 import { deleteProfile, getLogs, getStatus, type HermesGateway } from '@/hermes'
-import { $gateway, ensureGatewayForAgent, openGatewayForAgent, openGatewayForProfile } from '@/store/gateway'
+import { $gateway, openGatewayForAgent, openGatewayForProfile } from '@/store/gateway'
 import { notify, notifyError } from '@/store/notifications'
 import {
   $activeGatewayProfile,
+  ensureGatewayAgent,
   ensureGatewayProfile,
   newSessionInProfile,
   normalizeProfileKey,
@@ -190,11 +191,13 @@ export const host = {
   },
 
   /** Activate an agent's gateway (dialing it if needed) so subsequent
-   *  host.request calls hit that agent's backend. The local source falls
+   *  host.request calls hit that agent's backend. Goes through the store's
+   *  serialized activation path so $connection / $activeGatewayProfile follow
+   *  and rapid switches can't land out of order. The local source falls
    *  through to the profile path — single-source plugins keep working
    *  against older behavior unchanged. */
   ensureAgent: async (connectionId: null | string, profile: string): Promise<void> =>
-    ensureGatewayForAgent(connectionId, (profile ?? '').trim() || 'default'),
+    ensureGatewayAgent(connectionId, (profile ?? '').trim() || 'default'),
 
   openSession: async (
     storedSessionId: string,

--- a/apps/desktop/src/store/gateway-agent-scope.test.ts
+++ b/apps/desktop/src/store/gateway-agent-scope.test.ts
@@ -1,0 +1,142 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+// Registry-agent scoping regression (multi-source roster): the active key can
+// name a `conn:<id>::<profile>` scope whose secondaries entry gets evicted by
+// a teardown path (closeSecondaryGateways during a soft gateway switch,
+// pruneSecondaryGateways). activeGateway() used to silently fall back to the
+// PRIMARY gateway for a missing NAMED scope — every send/session op then hit
+// the wrong machine with no error. These tests pin the invariant: a missing
+// named scope never resolves to the primary; every eviction site explicitly
+// re-points the active key at the primary so `activeKey` always resolves.
+
+const gatewayMocks = vi.hoisted(() => ({
+  connect: vi.fn(async (_wsUrl: string): Promise<void> => undefined),
+  setConnection: vi.fn(),
+  setGatewayState: vi.fn()
+}))
+
+vi.mock('@/hermes', () => ({
+  HermesGateway: class {
+    connectionState = 'closed'
+    connect = async (wsUrl: string): Promise<void> => {
+      await gatewayMocks.connect(wsUrl)
+      this.connectionState = 'open'
+    }
+    close = (): void => {
+      this.connectionState = 'closed'
+    }
+    onEvent = vi.fn(() => () => {})
+    onState = vi.fn(() => () => {})
+  }
+}))
+vi.mock('@/store/session', () => ({
+  setConnection: gatewayMocks.setConnection,
+  setGatewayState: gatewayMocks.setGatewayState
+}))
+vi.mock('@/store/notify-baseline', () => ({ markNativeNotifyBaseline: vi.fn() }))
+
+const {
+  $gateway,
+  activeGateway,
+  closeSecondaryGateways,
+  configureGatewayRegistry,
+  ensureGatewayForAgent,
+  isActivePrimary,
+  pruneSecondaryGateways,
+  setPrimaryGateway
+} = await import('./gateway')
+
+interface DesktopStub {
+  getConnection: ReturnType<typeof vi.fn>
+  getConnectionFor: ReturnType<typeof vi.fn>
+}
+
+function installDesktop(stub: DesktopStub): void {
+  ;(window as unknown as { hermesDesktop: unknown }).hermesDesktop = stub
+}
+
+function makePrimary(): { connectionState: string } {
+  return { connectionState: 'open' }
+}
+
+const agentConn = {
+  authMode: 'token',
+  baseUrl: 'https://homelab.invalid',
+  mode: 'remote',
+  profile: 'research',
+  token: 'fake-test-token',
+  wsUrl: 'wss://homelab.invalid/api/ws?token=fake-test-token'
+}
+
+function installAgentDesktop(): DesktopStub {
+  const stub: DesktopStub = {
+    getConnection: vi.fn(async () => agentConn),
+    getConnectionFor: vi.fn(async () => agentConn)
+  }
+
+  installDesktop(stub)
+
+  return stub
+}
+
+beforeEach(() => {
+  configureGatewayRegistry({ onEvent: vi.fn() })
+})
+
+afterEach(() => {
+  closeSecondaryGateways()
+  vi.clearAllMocks()
+  delete (window as unknown as { hermesDesktop?: unknown }).hermesDesktop
+})
+
+describe('registry-agent scope eviction (activeGateway must never silently hit the primary)', () => {
+  it('activates the agent socket, not the primary, for a registry scope', async () => {
+    const primary = makePrimary()
+    setPrimaryGateway(primary as never, 'default')
+    installAgentDesktop()
+
+    await ensureGatewayForAgent('homelab', 'research')
+
+    expect(isActivePrimary()).toBe(false)
+    expect(activeGateway()).not.toBe(primary)
+    expect($gateway.get()).not.toBe(primary)
+    expect(gatewayMocks.connect).toHaveBeenCalledWith(agentConn.wsUrl)
+  })
+
+  it('closeSecondaryGateways re-points the active key at the primary instead of dangling', async () => {
+    const primary = makePrimary()
+    setPrimaryGateway(primary as never, 'default')
+    installAgentDesktop()
+
+    await ensureGatewayForAgent('homelab', 'research')
+    expect(isActivePrimary()).toBe(false)
+
+    // The soft gateway switch path (use-gateway-boot) tears every secondary
+    // down without knowing which one was active.
+    closeSecondaryGateways()
+
+    // Regression: activeKey used to keep naming the evicted scope while
+    // activeGateway() fell back to the primary — wrong machine, no error.
+    // Now the teardown restores the primary EXPLICITLY (atoms follow).
+    expect(isActivePrimary()).toBe(true)
+    expect(activeGateway()).toBe(primary)
+    expect($gateway.get()).toBe(primary)
+  })
+
+  it('pruneSecondaryGateways never evicts the active scope and keeps the invariant', async () => {
+    const primary = makePrimary()
+    setPrimaryGateway(primary as never, 'default')
+    installAgentDesktop()
+
+    await ensureGatewayForAgent('homelab', 'research')
+    const agentGateway = activeGateway()
+
+    // Empty keep-set: everything non-active is evictable — the active agent
+    // scope must survive, and the active pointer must still resolve to it.
+    pruneSecondaryGateways(new Set())
+
+    expect(isActivePrimary()).toBe(false)
+    expect(activeGateway()).toBe(agentGateway)
+    expect($gateway.get()).toBe(agentGateway)
+  })
+})

--- a/apps/desktop/src/store/gateway.ts
+++ b/apps/desktop/src/store/gateway.ts
@@ -134,7 +134,12 @@ export function activeGateway(): HermesGateway | null {
     return g.primaryGateway
   }
 
-  return g.secondaries.get(g.activeKey)?.gateway ?? g.primaryGateway
+  // A named scope resolves to ITS socket or nothing. Falling back to the
+  // primary here would silently route calls (sends, session ops, roster
+  // requests) to the WRONG backend whenever the scope's entry is gone —
+  // teardown sites keep the invariant "activeKey always resolves" by
+  // re-pointing the active key at the primary when they evict it.
+  return g.secondaries.get(g.activeKey)?.gateway ?? null
 }
 
 // Mirror a backend's connection state into the global composer state, but only
@@ -488,6 +493,18 @@ function disposeSecondary(entry: Secondary): void {
   entry.gateway.close()
 }
 
+// Invariant restore for every eviction path: if the active key names a
+// secondary that no longer exists, fall back to the primary EXPLICITLY (atoms
+// and composer state follow) instead of leaving a dangling key that
+// activeGateway() can no longer resolve. Without this, a soft gateway switch
+// (closeSecondaryGateways in use-gateway-boot) left activeKey pointing at an
+// evicted registry scope and every call silently hit the primary backend.
+function restoreActiveToPrimaryIfEvicted(): void {
+  if (g.activeKey !== g.primaryProfile && !g.secondaries.has(g.activeKey)) {
+    setActive(g.primaryProfile)
+  }
+}
+
 // Close + evict secondaries whose profile is neither active nor in `keep`
 // (profiles with a running / needs-input session). Bounds cost to live work.
 // `keep` carries PROFILE names (session ownership is profile-keyed), so a
@@ -503,6 +520,8 @@ export function pruneSecondaryGateways(keep: Set<string>): void {
     disposeSecondary(entry)
     g.secondaries.delete(key)
   }
+
+  restoreActiveToPrimaryIfEvicted()
 }
 
 export function closeSecondaryGateways(): void {
@@ -511,6 +530,7 @@ export function closeSecondaryGateways(): void {
   }
 
   g.secondaries.clear()
+  restoreActiveToPrimaryIfEvicted()
 }
 
 // Self-accept so editing this module (or a fan-out that lands here) is an

--- a/apps/desktop/src/store/profile-agent-activation.test.ts
+++ b/apps/desktop/src/store/profile-agent-activation.test.ts
@@ -1,0 +1,173 @@
+import { atom } from 'nanostores'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { HermesConnection } from '@/global'
+
+// Registry-agent activation (ensureGatewayAgent — the SDK ensureAgent door).
+// Two regressions pinned here:
+//  1. Activating an ALREADY-OPEN registry agent must still resync
+//     $connection (via getConnectionFor) and move $activeGatewayProfile —
+//     previously only a freshly-dialed socket synced $connection (inside
+//     openSecondary), so re-activating an open agent left REST/fs/media and
+//     image-attach routing on the previous backend (same class as #46651).
+//  2. Agent activations share the gatewaySwitch mutex with profile switches —
+//     without it, two rapid activations could complete out of order and the
+//     EARLIER setActive() landed last.
+
+const ensureGatewayForAgent = vi.fn(async (_connectionId: null | string, _profile: string) => undefined)
+const ensureGatewayForProfile = vi.fn(async (_profile: string) => undefined)
+const openGatewayForProfile = vi.fn(async (_profile: string) => undefined)
+const $gateway = atom<unknown>({ id: 'live-socket' })
+const resetStarmapGraph = vi.fn()
+
+vi.mock('@/store/gateway', () => ({
+  $gateway,
+  ensureGatewayForAgent,
+  ensureGatewayForProfile,
+  openGatewayForProfile
+}))
+vi.mock('@/hermes', () => ({
+  getProfiles: vi.fn(async () => ({ profiles: [] })),
+  setApiRequestProfile: vi.fn()
+}))
+vi.mock('@/lib/query-client', () => ({ invalidateProfileScopedQueries: vi.fn() }))
+vi.mock('@/store/starmap', () => ({ resetStarmapGraph }))
+
+const { $activeGatewayProfile, ensureGatewayAgent, ensureGatewayProfile } = await import('./profile')
+const { $connection } = await import('./session')
+
+const agentConn = (over: Partial<HermesConnection> = {}): HermesConnection =>
+  ({ baseUrl: 'https://homelab.invalid', mode: 'remote', profile: 'research', ...over }) as HermesConnection
+
+const localConn = (over: Partial<HermesConnection> = {}): HermesConnection =>
+  ({ baseUrl: '', mode: 'local', profile: 'default', ...over }) as HermesConnection
+
+const getConnection = vi.fn<(profile?: string | null) => Promise<HermesConnection>>()
+const getConnectionFor = vi.fn<(payload: { connectionId?: null | string; profile?: null | string }) => Promise<HermesConnection>>()
+
+function deferred(): { promise: Promise<void>; resolve: () => void } {
+  let resolve!: () => void
+
+  const promise = new Promise<void>(r => {
+    resolve = r
+  })
+
+  return { promise, resolve }
+}
+
+beforeEach(() => {
+  getConnection.mockReset()
+  getConnectionFor.mockReset()
+  ensureGatewayForAgent.mockClear()
+  ensureGatewayForProfile.mockClear()
+  $gateway.set({ id: 'live-socket' })
+  $activeGatewayProfile.set('default')
+  $connection.set(localConn())
+  vi.stubGlobal('window', { hermesDesktop: { getConnection, getConnectionFor } })
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  $connection.set(null)
+})
+
+describe('ensureGatewayAgent → $connection / $activeGatewayProfile sync', () => {
+  it('resyncs $connection and $activeGatewayProfile even when the agent socket is already open', async () => {
+    // The store-level activation resolves instantly (socket already open) —
+    // exactly the case that used to skip the sync entirely.
+    getConnectionFor.mockResolvedValue(agentConn())
+
+    await ensureGatewayAgent('homelab', 'research')
+
+    expect(ensureGatewayForAgent).toHaveBeenCalledWith('homelab', 'research')
+    expect(getConnectionFor).toHaveBeenCalledWith({ connectionId: 'homelab', profile: 'research' })
+    expect($activeGatewayProfile.get()).toBe('research')
+    expect($connection.get()?.mode).toBe('remote')
+    expect($connection.get()?.profile).toBe('research')
+  })
+
+  it('leaves the prior connection intact when the descriptor fetch fails', async () => {
+    getConnectionFor.mockRejectedValue(new Error('source unreachable'))
+
+    await ensureGatewayAgent('homelab', 'research')
+
+    expect($activeGatewayProfile.get()).toBe('research')
+    // Best-effort: boot/reconnect resyncs later; we must not null it out here.
+    expect($connection.get()?.mode).toBe('local')
+  })
+
+  it('falls through to the profile path for a local/null connectionId', async () => {
+    getConnection.mockResolvedValue(agentConn({ mode: 'local', profile: 'research' }))
+
+    await ensureGatewayAgent(null, 'research')
+
+    expect(ensureGatewayForProfile).toHaveBeenCalledWith('research')
+    expect(ensureGatewayForAgent).not.toHaveBeenCalled()
+    expect(getConnectionFor).not.toHaveBeenCalled()
+  })
+})
+
+describe('ensureGatewayAgent shares the gatewaySwitch mutex with profile switches', () => {
+  it('serializes an agent activation behind an in-flight profile switch', async () => {
+    const profileGate = deferred()
+    const order: string[] = []
+
+    ensureGatewayForProfile.mockImplementation(async (profile: string) => {
+      order.push(`profile:${profile}`)
+      await profileGate.promise
+    })
+    ensureGatewayForAgent.mockImplementation(async (_connectionId, profile) => {
+      order.push(`agent:${profile}`)
+    })
+    getConnection.mockResolvedValue(localConn({ profile: 'worker' }))
+    getConnectionFor.mockResolvedValue(agentConn())
+
+    // Start a profile switch that stalls mid-flight, then an agent
+    // activation. The agent activation must NOT start until the profile
+    // switch settles — otherwise the earlier setActive could land last.
+    const profileSwitch = ensureGatewayProfile('worker')
+    await Promise.resolve()
+    const agentSwitch = ensureGatewayAgent('homelab', 'research')
+    await Promise.resolve()
+
+    expect(order).toEqual(['profile:worker'])
+
+    profileGate.resolve()
+    await profileSwitch
+    await agentSwitch
+
+    expect(order).toEqual(['profile:worker', 'agent:research'])
+    // The LAST activation wins the active pointer.
+    expect($activeGatewayProfile.get()).toBe('research')
+    expect($connection.get()?.profile).toBe('research')
+  })
+
+  it('serializes a profile switch behind an in-flight agent activation', async () => {
+    const agentGate = deferred()
+    const order: string[] = []
+
+    ensureGatewayForAgent.mockImplementation(async (_connectionId, profile) => {
+      order.push(`agent:${profile}`)
+      await agentGate.promise
+    })
+    ensureGatewayForProfile.mockImplementation(async (profile: string) => {
+      order.push(`profile:${profile}`)
+    })
+    getConnection.mockResolvedValue(localConn({ profile: 'worker' }))
+    getConnectionFor.mockResolvedValue(agentConn())
+
+    const agentSwitch = ensureGatewayAgent('homelab', 'research')
+    await Promise.resolve()
+    const profileSwitch = ensureGatewayProfile('worker')
+    await Promise.resolve()
+
+    expect(order).toEqual(['agent:research'])
+
+    agentGate.resolve()
+    await agentSwitch
+    await profileSwitch
+
+    expect(order).toEqual(['agent:research', 'profile:worker'])
+    expect($activeGatewayProfile.get()).toBe('worker')
+  })
+})

--- a/apps/desktop/src/store/profile.test.ts
+++ b/apps/desktop/src/store/profile.test.ts
@@ -7,11 +7,12 @@ import type { ProfileInfo } from '@/types/hermes'
 // Keep profile.ts's side-effecting imports inert: the gateway socket layer and
 // the REST query client must not run for real in a unit test.
 const ensureGatewayForProfile = vi.fn(async () => undefined)
+const ensureGatewayForAgent = vi.fn(async () => undefined)
 const openGatewayForProfile = vi.fn(async (_profile: string) => undefined)
 const $gateway = atom<unknown>({ id: 'live-socket' })
 const resetStarmapGraph = vi.fn()
 
-vi.mock('@/store/gateway', () => ({ $gateway, ensureGatewayForProfile, openGatewayForProfile }))
+vi.mock('@/store/gateway', () => ({ $gateway, ensureGatewayForAgent, ensureGatewayForProfile, openGatewayForProfile }))
 vi.mock('@/hermes', () => ({
   getProfiles: vi.fn(async () => ({ profiles: [] })),
   setApiRequestProfile: vi.fn()

--- a/apps/desktop/src/store/profile.ts
+++ b/apps/desktop/src/store/profile.ts
@@ -1,3 +1,4 @@
+import { backendScopeKey } from '@hermes/shared'
 import { atom, computed } from 'nanostores'
 
 import { getProfiles, setApiRequestProfile, STARTUP_REQUEST_TIMEOUT_MS } from '@/hermes'
@@ -12,7 +13,7 @@ import {
   storedStringRecord
 } from '@/lib/storage'
 import { invalidateCronModelImpactScopeState } from '@/store/cron-model-impact-scope'
-import { $gateway, ensureGatewayForProfile, openGatewayForProfile } from '@/store/gateway'
+import { $gateway, ensureGatewayForAgent, ensureGatewayForProfile, openGatewayForProfile } from '@/store/gateway'
 import { setConnection } from '@/store/session'
 import { resetStarmapGraph } from '@/store/starmap'
 import type { ProfileInfo } from '@/types/hermes'
@@ -297,6 +298,66 @@ export async function ensureGatewayProfile(profile: string | null | undefined): 
     // The active backend just changed; resync $connection so remote-aware
     // paths (image.attach_bytes vs image.attach, /api/fs/*, /api/media) follow.
     await syncConnectionToActiveProfile(target)
+  })()
+
+  try {
+    await gatewaySwitch
+  } finally {
+    gatewaySwitch = null
+    $gatewaySwapTarget.set(null)
+  }
+}
+
+// Registry-aware sibling of syncConnectionToActiveProfile: a connection-scoped
+// agent's descriptor comes from getConnectionFor (its SOURCE connection), not
+// getConnection (the local pool). Same best-effort contract.
+async function syncConnectionToActiveAgent(connectionId: string, profile: string): Promise<void> {
+  const getConnectionFor = window.hermesDesktop?.getConnectionFor
+
+  if (!getConnectionFor) {
+    return
+  }
+
+  try {
+    setConnection(await getConnectionFor({ connectionId, profile }))
+  } catch {
+    // Leave the prior connection in place; boot/reconnect resyncs it later.
+  }
+}
+
+// Activate a connection-scoped agent's gateway — the (connectionId, profile)
+// analogue of ensureGatewayProfile, and the door the SDK's ensureAgent goes
+// through. Two invariants the raw store call (ensureGatewayForAgent) does not
+// provide on its own:
+//  - Every activation moves $activeGatewayProfile and resyncs $connection,
+//    exactly like the profile path — otherwise activating an ALREADY-OPEN
+//    registry agent left both describing the previous backend, routing
+//    /api/fs, /api/media and image.attach to the wrong machine (the same
+//    class as #46651) and pointing newSessionInProfile at the stale profile.
+//  - Activations share the gatewaySwitch mutex with profile switches, so a
+//    rapid agent↔profile (or agent↔agent) interleave can't finish out of
+//    order and leave the EARLIER setActive() as the last write.
+// A local/null connectionId falls through to the profile path verbatim.
+export async function ensureGatewayAgent(connectionId: null | string, profile: string): Promise<void> {
+  const target = normalizeProfileKey(profile)
+  const connection = (connectionId ?? '').trim() || null
+
+  if (!connection || backendScopeKey(connection, target) === target) {
+    return ensureGatewayProfile(target)
+  }
+
+  // Serialize against any in-flight profile/agent switch (shared mutex).
+  if (gatewaySwitch) {
+    await gatewaySwitch.catch(() => undefined)
+  }
+
+  $gatewaySwapTarget.set(target)
+  gatewaySwitch = (async () => {
+    await ensureGatewayForAgent(connection, target)
+    $activeGatewayProfile.set(target)
+    // The active backend just changed; resync $connection so remote-aware
+    // paths (image.attach_bytes vs image.attach, /api/fs/*, /api/media) follow.
+    await syncConnectionToActiveAgent(connection, target)
   })()
 
   try {


### PR DESCRIPTION
# fix(desktop): registry-agent gateway scoping — no silent primary fallback, connection sync, shared switch mutex

## Summary

Fixes three renderer gateway-store bugs from the multi-source agents audit (follow-up to `feat(desktop): multi-source agents end-to-end`): a missing named gateway scope silently routed calls to the PRIMARY backend (wrong machine, no error), registry-agent activation never synced `$connection` / `$activeGatewayProfile` (wrong-machine `/api/fs`, `/api/media`, `image.attach` — same class as #46651), and agent activations bypassed the `gatewaySwitch` mutex so rapid switches could land out of order.

## Changes

- **`activeGateway()` never falls back to the primary for a named scope** (`src/store/gateway.ts`): a `conn:<id>::<profile>` (or pooled-profile) active key resolves to its own socket or `null`. To keep the "activeKey always resolves" invariant, every eviction path — `closeSecondaryGateways()` (soft gateway switch in `use-gateway-boot`) and `pruneSecondaryGateways()` — now explicitly restores the primary as active (`restoreActiveToPrimaryIfEvicted`) when it evicts the active scope, so `$gateway` and the composer state follow instead of dangling.
- **New `ensureGatewayAgent()` in `src/store/profile.ts`** — the `(connectionId, profile)` analogue of `ensureGatewayProfile` and the door the SDK's `ensureAgent` now routes through:
  - moves `$activeGatewayProfile` on **every** activation (not just fresh dials), so `newSessionInProfile($activeGatewayProfile.get())` and profile-scoped REST routing target the agent just activated;
  - resyncs `$connection` from `getConnectionFor` (the agent's SOURCE connection) with the same best-effort contract as `syncConnectionToActiveProfile` — a failed descriptor fetch leaves the prior connection for boot/reconnect to resync;
  - **shares the existing `gatewaySwitch` mutex** with profile switches (no second primitive), so agent↔profile and agent↔agent interleaves complete in order and the last activation wins the active pointer;
  - local/`null` connectionId falls through to `ensureGatewayProfile` verbatim — single-source plugins unchanged.
- **`src/sdk/index.ts`**: `host.ensureAgent` calls `ensureGatewayAgent` instead of the raw store `ensureGatewayForAgent`.
- **Regression tests**: `src/store/gateway-agent-scope.test.ts` (eviction invariant: close/prune never leave a dangling active key, missing named scope never resolves to primary) and `src/store/profile-agent-activation.test.ts` (already-open agent still syncs `$connection`/`$activeGatewayProfile`; deferred-promise races proving both mutex orderings; local fall-through; best-effort descriptor failure). Existing `profile.test.ts` gateway mock extended for the new import.

## Validation

| Check | Result |
| --- | --- |
| `npx vitest run src/store/gateway-agent-scope.test.ts src/store/profile-agent-activation.test.ts src/store/profile.test.ts src/store/gateway-shared-remote.test.ts` | 4 files, 22 tests passed |
| `npx vitest run src/store` (full store suite) | 76 files, 849 tests passed |
| `npm --prefix apps/desktop run typecheck` (renderer + electron + e2e tsconfigs) | clean |
| `npx eslint` on all touched files | clean |

All three bug premises verified against `origin/main` (a15de3454) before fixing: the `?? g.primaryGateway` fallback at `gateway.ts:137`, `setConnection` firing only inside `openSecondary` on fresh dials, and `ensureGatewayForAgent` → `setActive` with no serialization.

## Infographic

![Gateway scope integrity](https://v3b.fal.media/files/b/0aa68d05/O2l87aJ72AdrzkEoQjsqc_hjsPZvOo.png)
