### PR TITLE
fix(desktop): tear down and recycle multi-gateway connections on remove/edit; pool cap counts real processes only

### DIFF
--- a/apps/desktop/electron/connection-registry.test.ts
+++ b/apps/desktop/electron/connection-registry.test.ts
@@ -15,6 +15,7 @@ import {
   backendScopeKey,
   backendScopePrefix,
   buildAgentRoster,
+  connectionDialFieldsChanged,
   connectionIdForLabel,
   labelKey,
   labelSlug,
@@ -522,4 +523,32 @@ test('upsertConnection replaces by id and appends new ids', () => {
 
   assert.equal(registry.connections.filter(c => c.id === a.id).length, 1)
   assert.equal(registry.connections.find(c => c.id === a.id)?.url, 'http://a:2')
+})
+
+// --- connectionDialFieldsChanged (edit → recycle decision) ---
+
+test('connectionDialFieldsChanged: label-only edits do not recycle', () => {
+  const before = { id: 'homelab', kind: 'remote', label: 'Homelab', url: 'http://10.0.0.5:9119', authMode: 'token', token: { encoding: 'safeStorage', value: 'abc' } } as const
+
+  assert.equal(connectionDialFieldsChanged(before, { ...before, label: 'Home lab (renamed)' }), false)
+  // Identity edit is also a no-op.
+  assert.equal(connectionDialFieldsChanged(before, { ...before }), false)
+})
+
+test('connectionDialFieldsChanged: url / auth / token changes recycle', () => {
+  const before = { id: 'homelab', kind: 'remote', label: 'Homelab', url: 'http://10.0.0.5:9119', authMode: 'token', token: { encoding: 'safeStorage', value: 'abc' } } as const
+
+  assert.equal(connectionDialFieldsChanged(before, { ...before, url: 'http://10.0.0.9:9119' }), true)
+  assert.equal(connectionDialFieldsChanged(before, { ...before, authMode: 'oauth', token: undefined }), true)
+  assert.equal(connectionDialFieldsChanged(before, { ...before, token: { encoding: 'safeStorage', value: 'NEW' } }), true)
+})
+
+test('connectionDialFieldsChanged: ssh routing fields recycle, kind change recycles', () => {
+  const before = { id: 'box', kind: 'ssh', label: 'Box', host: 'box.lan', user: 'me', port: 22 } as const
+
+  assert.equal(connectionDialFieldsChanged(before, { ...before, label: 'Box 2' }), false)
+  assert.equal(connectionDialFieldsChanged(before, { ...before, host: 'other.lan' }), true)
+  assert.equal(connectionDialFieldsChanged(before, { ...before, port: 2222 }), true)
+  assert.equal(connectionDialFieldsChanged(before, { ...before, remoteProfile: 'work' }), true)
+  assert.equal(connectionDialFieldsChanged(before, { id: 'box', kind: 'remote', label: 'Box', url: 'http://x:1' }), true)
 })

--- a/apps/desktop/electron/connection-registry.ts
+++ b/apps/desktop/electron/connection-registry.ts
@@ -414,6 +414,43 @@ export function mergeConnectionInput(input: ConnectionInput, existing?: null | R
   return merged
 }
 
+/**
+ * True when an edit changes how a connection is DIALED — endpoint, auth, or
+ * ssh routing fields — as opposed to a cosmetic label rename. Callers use
+ * this to decide whether live pooled backends / renderer sockets for the
+ * connection must be recycled after a save: a label-only edit keeps traffic
+ * flowing, while a url/token/host change means everything currently open
+ * points at the OLD target and must be torn down and re-dialed.
+ */
+export function connectionDialFieldsChanged(before: RegistryConnection, after: RegistryConnection): boolean {
+  if (before.kind !== after.kind) {
+    return true
+  }
+
+  const fields: (keyof RegistryConnection)[] = [
+    'url',
+    'authMode',
+    'org',
+    'host',
+    'user',
+    'port',
+    'keyPath',
+    'remoteHermesPath',
+    'remoteProfile'
+  ]
+
+  for (const field of fields) {
+    if ((before[field] ?? null) !== (after[field] ?? null)) {
+      return true
+    }
+  }
+
+  // Token envelopes are opaque here (main.ts encrypts). An edit that carries
+  // no new token inherits the stored envelope verbatim, so structural
+  // equality is exact for the label-only case.
+  return JSON.stringify(before.token ?? null) !== JSON.stringify(after.token ?? null)
+}
+
 // ── Registry-level operations (all pure: return a new registry) ────────────
 
 function localEntry(label = 'This device'): RegistryConnection {

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -9144,6 +9144,21 @@ function sendConnectionApplied() {
   webContents.send('hermes:connection:applied')
 }
 
+// Registry lifecycle push: a connection was removed or materially edited, so
+// every window must tear down (and, for edits, re-dial) its secondary sockets
+// scoped to that connection. Without this, a removed remote/cloud source keeps
+// its renderer WebSocket open and streaming as a ghost, and an edited one
+// keeps talking to the OLD endpoint until idle-reap.
+function broadcastConnectionsChanged(payload: { connectionId: string; reason: 'removed' | 'updated' }) {
+  for (const win of BrowserWindow.getAllWindows()) {
+    const { webContents } = win
+
+    if (webContents && !webContents.isDestroyed()) {
+      webContents.send('hermes:connections:changed', payload)
+    }
+  }
+}
+
 async function waitForBackendExit(child, timeoutMs = 5000) {
   if (!child || child.exitCode !== null || child.signalCode !== null) {
     return
@@ -11907,6 +11922,10 @@ ipcMain.handle('hermes:connections:remove', async (_event, id) => {
   // Tear down anything the removed connection still had running: pooled
   // backends under its composite keys and any ssh tunnel scopes it owned.
   stopRegistryConnectionBackends(key)
+  // And the renderer side: without this push, secondaries scoped to the
+  // removed connection keep their WebSocket open (remote/cloud have no local
+  // process to kill) and stream ghost events until page reload.
+  broadcastConnectionsChanged({ connectionId: key, reason: 'removed' })
 
   return { ok: true, registry: sanitizeConnectionsRegistry(registry) }
 })

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -108,6 +108,7 @@ import {
   shouldRemoveAppBundle,
   uninstallArgsForMode
 } from './desktop-uninstall'
+import { selectPoolEvictions } from './pool-eviction'
 import { describeDevCdpDecision, resolveDevCdpPort } from './dev-cdp'
 import { installEmbedReferer } from './embed-referer'
 import { createEventDeduper } from './event-dedupe'
@@ -9420,31 +9421,22 @@ function touchPoolBackend(profile) {
   }
 }
 
-// Evict least-recently-used pool backends until at most `keep` remain — but only
-// ever evict backends without a live renderer socket (stale beyond the keepalive
-// window). When every backend is actively kept alive we let the pool exceed the
-// soft cap rather than kill a running session.
+// Evict least-recently-used SPAWNED pool backends until at most `keep` remain —
+// but only ever evict backends without a live renderer socket (stale beyond the
+// keepalive window). When every backend is actively kept alive we let the pool
+// exceed the soft cap rather than kill a running session. Process-less
+// descriptor entries (remote/cloud registry sources, per-profile remote
+// overrides — `entry.process === null`) are excluded from the cap entirely:
+// they hold no local process, so counting them used to let a roster refresh
+// across N registered remote connections LRU-evict a REAL local backend that
+// was merely idle past the keepalive window. Descriptors are still reclaimed
+// by the idle reaper.
 function evictLruPoolBackends(keep) {
-  if (backendPool.size <= keep) {
-    return
-  }
+  const evictions = selectPoolEvictions(backendPool.entries(), Math.max(0, keep), Date.now(), POOL_KEEPALIVE_FRESH_MS)
 
-  const now = Date.now()
-
-  const evictable = [...backendPool.entries()]
-    .filter(([, entry]) => now - (entry.lastActiveAt || 0) > POOL_KEEPALIVE_FRESH_MS)
-    .sort((a, b) => (a[1].lastActiveAt || 0) - (b[1].lastActiveAt || 0))
-
-  let removable = backendPool.size - Math.max(0, keep)
-
-  for (const [profile] of evictable) {
-    if (removable <= 0) {
-      break
-    }
-
+  for (const profile of evictions) {
     rememberLog(`Evicting idle profile backend "${profile}" (LRU cap ${POOL_MAX_BACKENDS})`)
     stopPoolBackend(profile)
-    removable -= 1
   }
 }
 

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -86,6 +86,7 @@ import {
   backendScopeKey,
   backendScopePrefix,
   buildAgentRoster,
+  connectionDialFieldsChanged,
   mergeConnectionInput,
   migrateV1ToRegistry,
   normalizeConnectionInput,
@@ -108,7 +109,6 @@ import {
   shouldRemoveAppBundle,
   uninstallArgsForMode
 } from './desktop-uninstall'
-import { selectPoolEvictions } from './pool-eviction'
 import { describeDevCdpDecision, resolveDevCdpPort } from './dev-cdp'
 import { installEmbedReferer } from './embed-referer'
 import { createEventDeduper } from './event-dedupe'
@@ -213,6 +213,7 @@ import {
   electronProcessStartMarker,
   parentWatchdogEnv
 } from './parent-process-identity'
+import { selectPoolEvictions } from './pool-eviction'
 import { createKeepAwake } from './power-save'
 import { FirstRunSetupResetError, runPrimaryBackendStartup } from './primary-backend-startup'
 import { rehomePrimaryConnection } from './primary-connection-rehome'
@@ -8061,6 +8062,16 @@ function saveRegistryConnection(input: any = {}) {
   }
 
   writeDesktopConnectionsRegistry(upsertConnection(registry, entry))
+
+  // A dial-material edit (endpoint/auth/ssh routing — NOT a label rename)
+  // leaves pooled backends under `conn:<id>::*` and renderer sockets pointing
+  // at the OLD target while the UI shows the new one. Recycle them: stop this
+  // connection's pooled backends/tunnels and tell renderers to dispose+redial
+  // their secondaries for this connection id.
+  if (existing && connectionDialFieldsChanged(existing, entry)) {
+    stopRegistryConnectionBackends(entry.id)
+    broadcastConnectionsChanged({ connectionId: entry.id, reason: 'updated' })
+  }
 
   return sanitizeRegistryConnection(entry)
 }

--- a/apps/desktop/electron/pool-eviction.test.ts
+++ b/apps/desktop/electron/pool-eviction.test.ts
@@ -1,0 +1,85 @@
+/**
+ * Tests for electron/pool-eviction.ts — LRU cap accounting for the desktop
+ * backend pool. The cap exists to bound SPAWNED local backends (real child
+ * processes); process-less descriptor entries (remote/cloud registry sources,
+ * per-profile remote overrides) must not count against it, or a roster
+ * refresh across N registered remote connections evicts a real local backend
+ * that was merely idle past the keepalive window.
+ */
+
+import assert from 'node:assert/strict'
+
+import { test } from 'vitest'
+
+import { selectPoolEvictions } from './pool-eviction'
+
+const NOW = 1_000_000
+const FRESH_MS = 90_000
+
+/** A spawned local backend entry (has a child process). */
+const spawned = (idleMs: number) => ({ process: { pid: 123 }, lastActiveAt: NOW - idleMs })
+
+/** A process-less remote/cloud descriptor entry. */
+const descriptor = (idleMs: number) => ({ process: null, lastActiveAt: NOW - idleMs })
+
+test('process-less descriptors do not count toward the cap', () => {
+  // 1 real spawned backend idle beyond the keepalive window + 3 remote
+  // descriptors: total size (4) exceeds keep (2), but only ONE entry holds a
+  // process, so nothing may be evicted. This is the roster-refresh regression:
+  // the old size-based accounting evicted the real local backend here.
+  const entries: [string, ReturnType<typeof spawned>][] = [
+    ['default', spawned(120_000)],
+    ['conn:homelab::default', descriptor(0)],
+    ['conn:office::default', descriptor(0)],
+    ['conn:cloud-a::default', descriptor(0)]
+  ]
+
+  assert.deepEqual(selectPoolEvictions(entries, 2, NOW, FRESH_MS), [])
+})
+
+test('spawned backends over the cap are still LRU-evicted', () => {
+  const entries: [string, ReturnType<typeof spawned>][] = [
+    ['a', spawned(500_000)],
+    ['b', spawned(300_000)],
+    ['c', spawned(100_000)],
+    // Descriptors interleaved: must neither inflate the count nor be evicted.
+    ['conn:x::a', descriptor(999_000)]
+  ]
+
+  // keep=2 → one spawned backend over; evict the least-recently-used ('a').
+  assert.deepEqual(selectPoolEvictions(entries, 2, NOW, FRESH_MS), ['a'])
+})
+
+test('fresh spawned backends are spared even over the cap', () => {
+  const entries: [string, ReturnType<typeof spawned>][] = [
+    ['a', spawned(1_000)],
+    ['b', spawned(2_000)],
+    ['c', spawned(3_000)]
+  ]
+
+  // All within the keepalive window → the pool may exceed the soft cap.
+  assert.deepEqual(selectPoolEvictions(entries, 1, NOW, FRESH_MS), [])
+})
+
+test('evicts only enough stale spawned backends to reach the cap', () => {
+  const entries: [string, ReturnType<typeof spawned>][] = [
+    ['a', spawned(500_000)],
+    ['b', spawned(400_000)],
+    ['c', spawned(300_000)],
+    ['d', spawned(1_000)]
+  ]
+
+  // 4 spawned, keep 2 → remove 2, oldest first.
+  assert.deepEqual(selectPoolEvictions(entries, 2, NOW, FRESH_MS), ['a', 'b'])
+})
+
+test('descriptor-only pools never evict', () => {
+  const entries: [string, ReturnType<typeof descriptor>][] = [
+    ['conn:a::p', descriptor(999_000)],
+    ['conn:b::p', descriptor(999_000)],
+    ['conn:c::p', descriptor(999_000)],
+    ['conn:d::p', descriptor(999_000)]
+  ]
+
+  assert.deepEqual(selectPoolEvictions(entries, 2, NOW, FRESH_MS), [])
+})

--- a/apps/desktop/electron/pool-eviction.ts
+++ b/apps/desktop/electron/pool-eviction.ts
@@ -1,0 +1,58 @@
+// LRU cap accounting for the desktop backend pool.
+//
+// The pool holds two very different kinds of entries under one Map:
+//   1. SPAWNED local profile backends — a real child process each (the thing
+//      the POOL_MAX_BACKENDS cap exists to bound).
+//   2. Process-less connection DESCRIPTORS — remote/cloud registry sources and
+//      per-profile remote overrides (`entry.process === null`). These hold no
+//      local process; their only cost is a cached descriptor.
+//
+// Counting both kinds against the cap meant a roster refresh across N
+// registered remote connections could push the Map size over the cap and
+// LRU-evict a REAL spawned backend that had merely been idle past the
+// keepalive window. Cap accounting (and cap-driven eviction) therefore only
+// considers entries with a live child process; descriptor entries remain
+// subject to the idle reaper, just not to the process cap.
+
+export interface PoolEvictionEntry {
+  lastActiveAt?: null | number
+  process?: unknown
+}
+
+/**
+ * Pick which pool keys the LRU cap should evict so that at most `keep`
+ * SPAWNED backends remain. Only entries with a live child process count
+ * toward the cap or are eligible for cap eviction, and — as before — only
+ * entries idle beyond `freshMs` may be evicted (an actively kept-alive pool
+ * may exceed the soft cap rather than kill a running session).
+ */
+export function selectPoolEvictions<K>(
+  entries: Iterable<[K, PoolEvictionEntry]>,
+  keep: number,
+  now: number,
+  freshMs: number
+): K[] {
+  const spawned = [...entries].filter(([, entry]) => Boolean(entry.process))
+
+  if (spawned.length <= keep) {
+    return []
+  }
+
+  const evictable = spawned
+    .filter(([, entry]) => now - (entry.lastActiveAt || 0) > freshMs)
+    .sort((a, b) => (a[1].lastActiveAt || 0) - (b[1].lastActiveAt || 0))
+
+  let removable = spawned.length - Math.max(0, keep)
+  const evictions: K[] = []
+
+  for (const [key] of evictable) {
+    if (removable <= 0) {
+      break
+    }
+
+    evictions.push(key)
+    removable -= 1
+  }
+
+  return evictions
+}

--- a/apps/desktop/electron/preload.ts
+++ b/apps/desktop/electron/preload.ts
@@ -138,7 +138,16 @@ contextBridge.exposeInMainWorld('hermesDesktop', {
     setPrimary: id => ipcRenderer.invoke('hermes:connections:set-primary', id),
     test: id => ipcRenderer.invoke('hermes:connections:test', id),
     // Fan out `hermes update` to every eligible registered connection.
-    updateAll: () => ipcRenderer.invoke('hermes:connections:update-all')
+    updateAll: () => ipcRenderer.invoke('hermes:connections:update-all'),
+    // Registry lifecycle push (main → renderer): a connection was removed or
+    // materially edited, so secondaries scoped to it must be disposed (and,
+    // for edits, re-dialed at the new target).
+    onChanged: callback => {
+      const listener = (_event, payload) => callback(payload)
+      ipcRenderer.on('hermes:connections:changed', listener)
+
+      return () => ipcRenderer.removeListener('hermes:connections:changed', listener)
+    }
   },
   sshConfigHosts: () => ipcRenderer.invoke('hermes:ssh-config:hosts'),
   sshResolveHost: host => ipcRenderer.invoke('hermes:ssh-config:resolve', host),

--- a/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
@@ -17,6 +17,7 @@ import {
   $gateway,
   closeSecondaryGateways,
   configureGatewayRegistry,
+  disposeSecondariesForConnection,
   ensureGatewayForProfile,
   pruneSecondaryGateways,
   reconnectSecondaryGateways,
@@ -434,6 +435,18 @@ export function useGatewayBoot({
     const offPowerResume = desktop.onPowerResume?.(() => reconnectNow())
     const offConnectionApplied = desktop.onConnectionApplied?.(() => void softSwitch())
 
+    // Registry lifecycle: a removed connection's secondaries must close NOW
+    // (remote/cloud have no local process whose death would drop the socket —
+    // they'd keep streaming ghost events); a materially edited one is
+    // disposed AND re-dialed so its sockets target the new endpoint.
+    const offConnectionsChanged = desktop.connections?.onChanged?.(payload => {
+      if (!payload || typeof payload.connectionId !== 'string') {
+        return
+      }
+
+      disposeSecondariesForConnection(payload.connectionId, { redial: payload.reason === 'updated' })
+    })
+
     const onOnline = () => reconnectNow()
 
     const onVisible = () => {
@@ -636,6 +649,7 @@ export function useGatewayBoot({
       document.removeEventListener('visibilitychange', onVisible)
       offPowerResume?.()
       offConnectionApplied?.()
+      offConnectionsChanged?.()
       offState()
       offEvent()
       offExit()

--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -143,6 +143,13 @@ declare global {
         // Fan out `hermes update` to every eligible registered connection;
         // cloud entries are skipped (platform-managed), each row independent.
         updateAll?: () => Promise<{ ok: boolean; results: DesktopConnectionUpdateResult[] }>
+        // Registry lifecycle push: fired when a connection is removed or
+        // materially edited so the renderer can dispose (and re-dial) the
+        // secondary gateways scoped to it. Optional: older Electron mains
+        // don't emit it.
+        onChanged?: (
+          callback: (payload: { connectionId: string; reason: 'removed' | 'updated' }) => void
+        ) => () => void
       }
       sshConfigHosts: () => Promise<DesktopSshHostsResult>
       sshResolveHost: (host: string) => Promise<DesktopSshResolveResult>

--- a/apps/desktop/src/store/gateway-connection-lifecycle.test.ts
+++ b/apps/desktop/src/store/gateway-connection-lifecycle.test.ts
@@ -1,0 +1,195 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+// Connection lifecycle for registry-scoped secondary gateways:
+//
+//  1. Removing a connection must dispose its secondaries — remote/cloud
+//     sources have no local process whose death would drop the socket, so
+//     without an explicit dispose the WebSocket stays open and streams ghost
+//     events until page reload.
+//  2. A materially edited connection re-dials so fresh sockets target the
+//     NEW endpoint.
+//  3. When the Electron main reports the connection no longer exists
+//     (`No connection with id`), the reconnect loop fail-stops and evicts
+//     the entry instead of retrying forever.
+
+const gatewayMocks = vi.hoisted(() => {
+  const instances: { close: ReturnType<typeof vi.fn>; connectionState: string }[] = []
+
+  return {
+    connect: vi.fn(async (_wsUrl: string): Promise<void> => undefined),
+    instances
+  }
+})
+
+vi.mock('@/hermes', () => ({
+  HermesGateway: class {
+    connectionState = 'closed'
+    close = vi.fn(() => {
+      this.connectionState = 'closed'
+    })
+    connect = async (wsUrl: string): Promise<void> => {
+      await gatewayMocks.connect(wsUrl)
+      this.connectionState = 'open'
+    }
+    onEvent = vi.fn(() => () => {})
+    onState = vi.fn(() => () => {})
+    constructor() {
+      gatewayMocks.instances.push(this as never)
+    }
+  }
+}))
+vi.mock('@/store/session', () => ({
+  setConnection: vi.fn(),
+  setGatewayState: vi.fn()
+}))
+vi.mock('@/store/notify-baseline', () => ({ markNativeNotifyBaseline: vi.fn() }))
+
+const {
+  closeSecondaryGateways,
+  configureGatewayRegistry,
+  disposeSecondariesForConnection,
+  ensureActiveGatewayOpen,
+  ensureGatewayForAgent,
+  setPrimaryGateway
+} = await import('./gateway')
+
+function installDesktop(stub: Record<string, unknown>): void {
+  ;(window as unknown as { hermesDesktop: unknown }).hermesDesktop = stub
+}
+
+function descriptorFor(connectionId: string, profile: string) {
+  return {
+    authMode: 'token',
+    baseUrl: `https://${connectionId}.invalid`,
+    mode: 'remote',
+    profile,
+    token: 'fake-test-token',
+    wsUrl: `wss://${connectionId}.invalid/api/ws?profile=${profile}`
+  }
+}
+
+beforeEach(() => {
+  configureGatewayRegistry({ onEvent: vi.fn() } as never)
+  setPrimaryGateway({ connectionState: 'open' } as never, 'default')
+})
+
+afterEach(() => {
+  closeSecondaryGateways()
+  gatewayMocks.instances.length = 0
+  vi.clearAllMocks()
+  vi.useRealTimers()
+  delete (window as unknown as { hermesDesktop?: unknown }).hermesDesktop
+})
+
+describe('disposeSecondariesForConnection', () => {
+  it('closes and evicts every secondary scoped to the removed connection', async () => {
+    const getConnectionFor = vi.fn(async ({ connectionId, profile }: { connectionId: string; profile: string }) =>
+      descriptorFor(connectionId, profile)
+    )
+
+    installDesktop({ getConnectionFor })
+
+    await ensureGatewayForAgent('homelab', 'default')
+    await ensureGatewayForAgent('homelab', 'work')
+    await ensureGatewayForAgent('office', 'default')
+
+    expect(gatewayMocks.instances).toHaveLength(3)
+
+    disposeSecondariesForConnection('homelab')
+
+    // Both homelab sockets closed; the office socket untouched.
+    expect(gatewayMocks.instances[0].close).toHaveBeenCalledOnce()
+    expect(gatewayMocks.instances[1].close).toHaveBeenCalledOnce()
+    expect(gatewayMocks.instances[2].close).not.toHaveBeenCalled()
+
+    // No redial for a removal.
+    expect(getConnectionFor).toHaveBeenCalledTimes(3)
+  })
+
+  it('re-dials disposed secondaries when redial is requested (material edit)', async () => {
+    const getConnectionFor = vi.fn(async ({ connectionId, profile }: { connectionId: string; profile: string }) =>
+      descriptorFor(connectionId, profile)
+    )
+
+    installDesktop({ getConnectionFor })
+
+    await ensureGatewayForAgent('homelab', 'default')
+    expect(gatewayMocks.connect).toHaveBeenCalledTimes(1)
+
+    disposeSecondariesForConnection('homelab', { redial: true })
+
+    // The redial runs async through the normal open path — flush it.
+    await vi.waitFor(() => {
+      expect(gatewayMocks.connect).toHaveBeenCalledTimes(2)
+    })
+
+    // Old socket closed, fresh descriptor fetched (would carry the new URL).
+    expect(gatewayMocks.instances[0].close).toHaveBeenCalledOnce()
+    expect(getConnectionFor).toHaveBeenCalledTimes(2)
+  })
+
+  it('is a no-op for blank or unknown connection ids', async () => {
+    installDesktop({
+      getConnectionFor: vi.fn(async ({ connectionId, profile }: { connectionId: string; profile: string }) =>
+        descriptorFor(connectionId, profile)
+      )
+    })
+
+    await ensureGatewayForAgent('homelab', 'default')
+
+    disposeSecondariesForConnection('')
+    disposeSecondariesForConnection('ghost')
+
+    expect(gatewayMocks.instances[0].close).not.toHaveBeenCalled()
+  })
+})
+
+describe('reconnect fail-stop on a removed connection', () => {
+  it('evicts the entry instead of retrying when the registry no longer knows the id', async () => {
+    const getConnectionFor = vi
+      .fn()
+      .mockResolvedValueOnce(descriptorFor('homelab', 'default'))
+      .mockRejectedValue(new Error('No connection with id "homelab".'))
+
+    installDesktop({ getConnectionFor })
+
+    await ensureGatewayForAgent('homelab', 'default')
+    expect(gatewayMocks.instances).toHaveLength(1)
+
+    // Simulate the socket dropping after the connection was removed.
+    const socket = gatewayMocks.instances[0] as unknown as { connectionState: string }
+    socket.connectionState = 'closed'
+
+    // ensureActiveGatewayOpen drives reconnectSecondary for the active scope.
+    const result = await ensureActiveGatewayOpen()
+
+    expect(result).toBeNull()
+    // Fail-stop: the entry was disposed + evicted, so a second drive finds
+    // nothing to retry (no further getConnectionFor calls).
+    const callsAfterFailStop = getConnectionFor.mock.calls.length
+    await ensureActiveGatewayOpen()
+    expect(getConnectionFor.mock.calls.length).toBe(callsAfterFailStop)
+  })
+
+  it('keeps retrying on ordinary transport failures', async () => {
+    const getConnectionFor = vi
+      .fn()
+      .mockResolvedValueOnce(descriptorFor('homelab', 'default'))
+      .mockRejectedValueOnce(new Error('ECONNREFUSED'))
+      .mockResolvedValue(descriptorFor('homelab', 'default'))
+
+    installDesktop({ getConnectionFor })
+
+    await ensureGatewayForAgent('homelab', 'default')
+
+    const socket = gatewayMocks.instances[0] as unknown as { connectionState: string }
+    socket.connectionState = 'closed'
+
+    // First drive fails with a transport error → entry survives.
+    await ensureActiveGatewayOpen()
+    // Second drive succeeds against the surviving entry.
+    const reopened = await ensureActiveGatewayOpen()
+
+    expect(reopened).not.toBeNull()
+  })
+})

--- a/apps/desktop/src/store/gateway.ts
+++ b/apps/desktop/src/store/gateway.ts
@@ -235,8 +235,18 @@ async function reconnectSecondary(entry: Secondary): Promise<void> {
   try {
     await openSecondary(entry)
     entry.reconnectAttempt = 0
-  } catch {
-    // Transport failure → fall through to the backoff below.
+  } catch (error) {
+    // The registry no longer knows this connection (removed while we were
+    // backing off). Retrying forever can never succeed — fail-stop: dispose
+    // the entry and evict it instead of an infinite 15s-cap retry loop.
+    if (entry.connectionId && isMissingConnectionError(error)) {
+      entry.reconnecting = false
+      disposeSecondary(entry)
+      g.secondaries.delete(entry.scope)
+
+      return
+    }
+    // Other transport failure → fall through to the backoff below.
   } finally {
     entry.reconnecting = false
 
@@ -244,6 +254,15 @@ async function reconnectSecondary(entry: Secondary): Promise<void> {
       scheduleReconnect(entry)
     }
   }
+}
+
+// Electron's getConnectionFor rejects with `No connection with id "…"` when
+// the registry entry is gone. That is a permanent condition for the scoped
+// socket, unlike transient transport errors.
+function isMissingConnectionError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error ?? '')
+
+  return message.includes('No connection with id')
 }
 
 function createSecondary(profile: string, connectionId: null | string = null): Secondary {
@@ -531,6 +550,39 @@ export function closeSecondaryGateways(): void {
 
   g.secondaries.clear()
   restoreActiveToPrimaryIfEvicted()
+}
+
+// Registry lifecycle: a connection was removed or materially edited. Dispose
+// every secondary scoped to it (a removed remote/cloud source has no local
+// process to die, so without this its WebSocket stays open streaming ghost
+// events). With `redial` (the edit case) each disposed profile is re-dialed
+// through the normal open path so the fresh socket targets the NEW endpoint;
+// the active scope re-activates so the foreground keeps painting.
+export function disposeSecondariesForConnection(connectionId: string, opts: { redial?: boolean } = {}): void {
+  const id = String(connectionId || '').trim()
+
+  if (!id) {
+    return
+  }
+
+  for (const [key, entry] of [...g.secondaries]) {
+    if (entry.connectionId !== id) {
+      continue
+    }
+
+    const wasActive = key === g.activeKey
+
+    disposeSecondary(entry)
+    g.secondaries.delete(key)
+
+    if (opts.redial) {
+      const reopen = wasActive
+        ? ensureGatewayForAgent(entry.connectionId, entry.profile)
+        : openGatewayForAgent(entry.connectionId, entry.profile)
+
+      void reopen.catch(() => undefined)
+    }
+  }
 }
 
 // Self-accept so editing this module (or a fan-out that lands here) is an


### PR DESCRIPTION
## Summary

Fixes three lifecycle bugs in Desktop's multi-gateway connection management (registry connections + backend pool + renderer secondary sockets, introduced with the multi-source agents work):

1. **Removing a connection never tore down renderer state (HIGH).** `hermes:connections:remove` stopped pooled backends and ssh tunnels, but the renderer's `$gateway.secondaries` entries for the removed connection kept `wantOpen=true`. Remote/cloud sources have no local process to die, so the removed connection's WebSocket stayed open and kept streaming ghost events into the UI until page reload; if the socket did drop, `openSecondary → getConnectionFor` threw `No connection with id` and `scheduleReconnect` retried forever (backoff caps at 15s, entry never evicted — `pruneSecondaryGateways` spares it while its profile has live work).
2. **Editing a connection didn't recycle live backends/sockets (MEDIUM).** `saveRegistryConnection` only rewrote the registry file: a URL/token/host edit left pooled descriptors under `conn:<id>::*` and open renderer sockets pointing at the OLD endpoint — the UI showed the new target while traffic kept flowing to the old one until idle-reap.
3. **Pool cap counted weightless remote descriptors (LOW).** `ensureRegistryBackend` runs `evictLruPoolBackends(POOL_MAX_BACKENDS - 1)` on every creation, and process-less remote/cloud descriptor entries shared the cap with real spawned local backends — a roster refresh across N registered remote connections could LRU-evict a real local backend idle > 90s.

## Changes

- **`electron/main.ts`**
  - New `broadcastConnectionsChanged({connectionId, reason})` push on the new `hermes:connections:changed` channel (all windows).
  - `hermes:connections:remove` broadcasts `reason: 'removed'` after `stopRegistryConnectionBackends`.
  - `saveRegistryConnection` compares old vs new entry with the new `connectionDialFieldsChanged` helper; a dial-material edit (endpoint/auth/ssh routing — NOT a label rename) tears down the connection's pooled backends/tunnels and broadcasts `reason: 'updated'`.
  - `evictLruPoolBackends` now delegates to `selectPoolEvictions` (new `electron/pool-eviction.ts`): only entries with a live child process count toward the cap or are cap-evictable; descriptors remain subject to the idle reaper.
- **`electron/connection-registry.ts`** — new pure `connectionDialFieldsChanged(before, after)` (kind, url, authMode, org, ssh routing fields, token envelope; label excluded).
- **`electron/preload.ts` / `src/global.d.ts`** — `connections.onChanged` bridge (optional in typings so older mains stay compatible).
- **`src/store/gateway.ts`**
  - New `disposeSecondariesForConnection(connectionId, {redial})`: disposes + evicts every secondary scoped to the connection; with `redial` (edit case) each profile re-dials through the normal open path (active scope via `ensureGatewayForAgent`, background via `openGatewayForAgent`).
  - `reconnectSecondary` fail-stops: a `No connection with id` rejection from the Electron main disposes and evicts the entry instead of retrying forever; ordinary transport errors keep the existing full-jitter backoff.
- **`src/app/gateway/hooks/use-gateway-boot.ts`** — subscribes to `connections.onChanged` and drives `disposeSecondariesForConnection` (unsubscribed on teardown). No changes to `activeGateway()`/`ensureGatewayForAgent` internals (sibling PRs own those).

## Validation

- `npx vitest run electron/pool-eviction.test.ts electron/connection-registry.test.ts src/store/gateway-connection-lifecycle.test.ts src/app/gateway/hooks/use-gateway-boot.test.tsx` — **4 files, 52 tests passed** (new: 5 pool-eviction cap tests, 3 `connectionDialFieldsChanged` tests, 5 renderer lifecycle tests covering dispose-on-remove, dispose+redial-on-edit, no-op on unknown ids, reconnect fail-stop on missing connection, and continued retry on transport errors).
- `npm --prefix apps/desktop run typecheck` — clean (all three tsconfigs).
- `npm run lint` in `apps/desktop` — 0 errors (pre-existing warnings only).

## Infographic

![Connection lifecycle](https://v3b.fal.media/files/b/0aa68d1f/AQkQtDaNDwVzJSjpyBDWT_FM2aufcY.png)
