### PR TITLE
fix(desktop): registry local entry routes to the local runtime; fan-out events keyed by (connection, profile)

### DIFF
--- a/apps/desktop/electron/connection-registry.test.ts
+++ b/apps/desktop/electron/connection-registry.test.ts
@@ -25,6 +25,7 @@ import {
   normalizeRegistry,
   REGISTRY_VERSION,
   removeConnection,
+  resolveRegistryLocalRoute,
   setPrimaryConnection,
   uniqueLabel,
   updateEligibility,
@@ -125,6 +126,36 @@ test('backendScopeKey: non-local connections get an unambiguous composite', () =
   assert.ok(backendScopeKey('homelab', 'research').startsWith(backendScopePrefix('homelab')))
   assert.ok(!backendScopeKey('homelab-2', 'research').startsWith(backendScopePrefix('homelab')))
   assert.ok(!'research'.startsWith(backendScopePrefix('homelab')))
+})
+
+// --- resolveRegistryLocalRoute (registry 'local' entry vs the v1 route) ---
+
+test("registry local route: delegates to the legacy path when v1 is local (single-source users byte-identical)", () => {
+  assert.deepEqual(resolveRegistryLocalRoute('research', {}), { delegate: true, poolKey: 'research' })
+  assert.deepEqual(resolveRegistryLocalRoute('', {}), { delegate: true, poolKey: 'default' })
+  assert.deepEqual(resolveRegistryLocalRoute(null, { globalRemote: false }), { delegate: true, poolKey: 'default' })
+})
+
+test("registry local route: v1 REMOTE global mode forces a genuinely-local backend (migration scenario)", () => {
+  // The migration keeps the mandatory 'local' entry AND makes the v1 remote
+  // the registry primary. If 'local' delegated to the v1 route here, the
+  // roster's "This device" rows would enumerate + dial the REMOTE primary —
+  // every profile duplicated and local agents talking to the remote box.
+  const route = resolveRegistryLocalRoute('default', { globalRemote: true })
+
+  assert.equal(route.delegate, false)
+  // The forced-local child must NOT pool under the bare profile key: that
+  // slot is where the v1 route caches the REMOTE descriptor. The composite
+  // form is prefix-owned by the local connection and collision-free.
+  assert.equal(route.poolKey, 'conn:local::default')
+  assert.ok(route.poolKey.startsWith(backendScopePrefix(LOCAL_CONNECTION_ID)))
+  assert.notEqual(route.poolKey, backendScopeKey(LOCAL_CONNECTION_ID, 'default'))
+})
+
+test('registry local route: a per-profile remote override also forces local', () => {
+  const route = resolveRegistryLocalRoute('research', { profileRemoteOverride: true })
+
+  assert.deepEqual(route, { delegate: false, poolKey: 'conn:local::research' })
 })
 
 // --- buildAgentRoster (union roster + @name-device rule) ---

--- a/apps/desktop/electron/connection-registry.ts
+++ b/apps/desktop/electron/connection-registry.ts
@@ -164,6 +164,47 @@ export function backendScopePrefix(connectionId: string): string {
   return `conn:${String(connectionId).trim()}::`
 }
 
+export interface RegistryLocalRoute {
+  /** Reuse the legacy v1 ensureBackend path — it already resolves to the
+   * app's own local runtime, so single-source behavior stays byte-identical. */
+  delegate: boolean
+  /** Pool key for the forced-local child when not delegating. */
+  poolKey: string
+}
+
+/**
+ * How the registry's 'local' entry resolves a backend for `profile`.
+ *
+ * The 'local' entry means THIS machine's runtime — always. The legacy
+ * ensureBackend() path instead follows the v1 connection.json routing table,
+ * where a global remote mode (or a per-profile remote override) resolves to a
+ * REMOTE descriptor. A migrated user whose v1 global mode was remote gets that
+ * remote as the registry primary AND keeps the mandatory 'local' entry, so
+ * delegating 'local' to the v1 route made the roster's "This device" rows
+ * enumerate and dial the remote box: every profile appeared twice (forcing
+ * -slug handles) and "local" agents talked to the remote.
+ *
+ * When the v1 route is already local we delegate (legacy path, byte-identical
+ * pool keys). When v1 says remote, the local entry spawns its own genuinely
+ * local child under a composite pool key: backendScopeKey('local', p) maps to
+ * the BARE profile key by design, and that slot may already hold the v1
+ * route's REMOTE descriptor — so the forced-local child pools under the
+ * `conn:local::<profile>` form instead (colons are invalid in profile names,
+ * so it cannot collide).
+ */
+export function resolveRegistryLocalRoute(
+  profile: null | string | undefined,
+  opts: { globalRemote?: boolean; profileRemoteOverride?: boolean } = {}
+): RegistryLocalRoute {
+  const profileKey = String(profile ?? '').trim() || 'default'
+
+  if (opts.globalRemote || opts.profileRemoteOverride) {
+    return { delegate: false, poolKey: `${backendScopePrefix(LOCAL_CONNECTION_ID)}${profileKey}` }
+  }
+
+  return { delegate: true, poolKey: profileKey }
+}
+
 // ── Union agent roster ──────────────────────────────────────────────────────
 
 export interface ConnectionAgents {

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -91,6 +91,7 @@ import {
   normalizeConnectionInput,
   normalizeRegistry,
   removeConnection,
+  resolveRegistryLocalRoute,
   setPrimaryConnection,
   updateEligibility,
   upsertConnection
@@ -9263,10 +9264,11 @@ async function ensureBackend(profile) {
 
 // ── Registry-scoped backends (multi-connection, PR 2 of the campaign) ──────
 // Resolve a backend for (connectionId, profile) against the v2 registry.
-// The LOCAL connection routes through ensureBackend() untouched, so every
-// single-source path stays byte-identical; non-local connections pool under
-// the composite key from backendScopeKey() and reuse the same pool entry
-// lifecycle (LRU, idle reaper, touch) as per-profile local backends.
+// The LOCAL connection routes through ensureBackend() when the v1 route is
+// itself local (so every single-source path stays byte-identical), and forces
+// a genuinely-local child when the v1 mode says remote; non-local connections
+// pool under the composite key from backendScopeKey() and reuse the same pool
+// entry lifecycle (LRU, idle reaper, touch) as per-profile local backends.
 async function ensureRegistryBackend(connectionId, profile) {
   const registry = readDesktopConnectionsRegistry()
   const id = String(connectionId || '').trim() || registry.primary
@@ -9277,7 +9279,61 @@ async function ensureRegistryBackend(connectionId, profile) {
   }
 
   if (source.kind === 'local') {
-    return ensureBackend(profile)
+    // The registry's 'local' entry means THIS machine's runtime — always.
+    // ensureBackend() follows the v1 routing table, which resolves to a
+    // REMOTE descriptor when the v1 global mode is remote (or the profile
+    // has its own remote override). A migrated remote-mode user would then
+    // see the roster's "This device" rows enumerate + dial the remote box
+    // (every profile duplicated, -slug handles forced). Delegate only when
+    // the v1 route is genuinely local; otherwise spawn/reuse a forced-local
+    // child pooled under the composite 'conn:local::<profile>' key so it
+    // can't collide with the v1 remote descriptor cached at the bare key.
+    const profileKey = String(profile ?? '').trim() || 'default'
+
+    const localRoute = resolveRegistryLocalRoute(profileKey, {
+      globalRemote: globalRemoteActive(),
+      profileRemoteOverride: Boolean(profileHasRemoteOverride(profileKey))
+    })
+
+    if (localRoute.delegate) {
+      return ensureBackend(profile)
+    }
+
+    const existingLocal = backendPool.get(localRoute.poolKey)
+
+    if (existingLocal) {
+      existingLocal.lastActiveAt = Date.now()
+
+      return existingLocal.connectionPromise
+    }
+
+    evictLruPoolBackends(POOL_MAX_BACKENDS - 1)
+
+    const localEntry = {
+      process: null,
+      port: null,
+      token: null,
+      connectionPromise: null,
+      lastActiveAt: Date.now(),
+      remoteBaseUrl: null
+    }
+
+    localEntry.connectionPromise = spawnPoolBackend(profileKey, localEntry, {
+      forceLocal: true,
+      poolKey: localRoute.poolKey
+    }).catch(async error => {
+      if (backendPool.get(localRoute.poolKey) === localEntry) {
+        backendPool.delete(localRoute.poolKey)
+      }
+
+      stopBackendChild(localEntry.process)
+      await waitForBackendExit(localEntry.process)
+      throw error
+    })
+    backendPool.set(localRoute.poolKey, localEntry)
+    startPoolIdleReaper()
+
+    return localEntry.connectionPromise
   }
 
   const key = backendScopeKey(id, profile)
@@ -9477,7 +9533,13 @@ function startPoolIdleReaper() {
 // Spawn an additional dashboard backend pinned to a named profile. Mirrors the
 // local-spawn portion of startHermes() but without the boot-progress UI,
 // bootstrap, or remote handling (those belong to the primary backend only).
-async function spawnPoolBackend(profile, entry) {
+// `opts.forceLocal` skips remote resolution entirely (the registry 'local'
+// entry means THIS machine regardless of the v1 routing table); `opts.poolKey`
+// is the backendPool key when it differs from the profile name (composite
+// registry scopes) so the exit/error cleanup evicts the right entry.
+async function spawnPoolBackend(profile, entry, opts: { forceLocal?: boolean; poolKey?: string } = {}) {
+  const poolKey = opts.poolKey || profile
+
   await reapOrphanedBackendsOnce()
   // A profile may point at its OWN remote backend (connection.json
   // `profiles[name]`), or inherit the app-wide remote (env / global settings).
@@ -9485,7 +9547,7 @@ async function spawnPoolBackend(profile, entry) {
   // remote is reachable and hand back its connection descriptor. The pool
   // entry keeps `entry.process === null`, which stopPoolBackend/evict already
   // tolerate.
-  const remote = await resolveRemoteBackend(profile)
+  const remote = opts.forceLocal ? null : await resolveRemoteBackend(profile)
 
   if (remote) {
     await waitForHermes(remote.baseUrl, remote.token, undefined, remote.authMode)
@@ -9587,13 +9649,13 @@ async function spawnPoolBackend(profile, entry) {
   child.once('error', error => {
     rememberLog(`Hermes backend for profile "${profile}" failed to start: ${error.message}`)
     releaseBackendChild(child)
-    backendPool.delete(profile)
+    backendPool.delete(poolKey)
     rejectStart?.(error)
   })
   child.once('exit', (code, signal) => {
     rememberLog(`Hermes backend for profile "${profile}" exited (${signal || code})`)
     releaseBackendChild(child)
-    backendPool.delete(profile)
+    backendPool.delete(poolKey)
 
     if (!ready) {
       rejectStart?.(
@@ -11352,7 +11414,9 @@ function createWindow() {
 ipcMain.handle('hermes:connection', async (_event, profile) => ensureBackend(profile))
 // Registry-scoped variant: resolve a backend for (connectionId, profile).
 // connectionId '' / 'local' / the registry primary all behave sensibly; the
-// local kind delegates to ensureBackend so legacy behavior is untouched.
+// local kind delegates to ensureBackend when the v1 route is local, and
+// forces a genuinely-local child when the v1 global mode is remote (the
+// registry 'local' entry always means this machine).
 ipcMain.handle('hermes:connection:for', async (_event, payload) => {
   const { connectionId, profile } = payload && typeof payload === 'object' ? (payload as any) : ({} as any)
 

--- a/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
@@ -38,7 +38,13 @@ import {
   setCurrentCwd,
   setSessionsLoading
 } from '@/store/session'
-import { $attentionSessionIds, $workingSessionIds, resetTileRuntimeBindings } from '@/store/session-states'
+import {
+  $attentionSessionIds,
+  $workingSessionIds,
+  liveSessionScopes,
+  recordSessionEventScope,
+  resetTileRuntimeBindings
+} from '@/store/session-states'
 import { windowProfileOverride } from '@/store/windows'
 import type { RpcEvent } from '@/types/hermes'
 
@@ -394,7 +400,15 @@ export function useGatewayBoot({
     callbacksRef.current.onGatewayReady(gateway)
     setPrimaryGateway(gateway, survivor?.profile ?? normalizeProfileKey($activeGatewayProfile.get()))
     // Secondary (background-profile) sockets funnel into the same handler.
-    configureGatewayRegistry({ onEvent: event => callbacksRef.current.handleGatewayEvent(event) })
+    // Record each event's source scope first: registry-tagged events feed the
+    // (connectionId, profile) keep-set so two sources exposing the same
+    // profile name (every source has a 'default') can't collide.
+    configureGatewayRegistry({
+      onEvent: event => {
+        recordSessionEventScope(event)
+        callbacksRef.current.handleGatewayEvent(event)
+      }
+    })
 
     const offState = gateway.onState(st => {
       // Mirror to the composer only while the primary is the active profile —
@@ -458,7 +472,11 @@ export function useGatewayBoot({
     // to idle-reap. The active profile is always spared.
     const recomputeKeptGateways = () => {
       const live = new Set([...$workingSessionIds.get(), ...$attentionSessionIds.get()])
-      const keep = new Set<string>()
+      // Registry-scoped (connectionId, profile) scopes with live work. Two
+      // sources can expose the same profile name (every source has a
+      // 'default'), so bare profile names can't represent a non-local
+      // source's liveness without keeping the wrong gateway alive.
+      const keep = liveSessionScopes()
 
       for (const session of $sessions.get()) {
         if (live.has(session.id)) {

--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event.ts
@@ -1,4 +1,5 @@
 import type { BillingBlock } from '@hermes/shared'
+import { backendScopeKey } from '@hermes/shared'
 import type { HermesSkin } from '@hermes/shared/skin'
 import type { QueryClient } from '@tanstack/react-query'
 import { type MutableRefObject, useCallback, useEffect, useRef } from 'react'
@@ -27,7 +28,7 @@ import { billingCtaLabel, clearBillingBlock, runBillingRecovery, setBillingBlock
 import { clearClarifyRequest, normalizeChoices, setClarifyRequest, warnDroppedChoices } from '@/store/clarify'
 import { setSessionCompacting } from '@/store/compaction'
 import { refreshBackgroundProcesses } from '@/store/composer-status'
-import { $gateway } from '@/store/gateway'
+import { $gateway, activeGatewayConnectionId } from '@/store/gateway'
 import { applyGoalStatusText } from '@/store/goals'
 import {
   notifyCronChanged,
@@ -335,6 +336,18 @@ export function useGatewayEventHandler(deps: GatewayEventDeps) {
     (event: RpcEvent) => {
       const payload = event.payload as GatewayEventPayload | undefined
 
+      // "From the active profile" must mean "from the active SOURCE": every
+      // registered connection exposes a 'default' profile, so a bare profile
+      // comparison attributes gateway B's 'default' events to gateway A's
+      // 'default'. Compare the composite (connectionId, profile) scope with
+      // backendScopeKey — untagged (local/primary) events keep the legacy
+      // bare-profile behavior byte-identical.
+      const fromActiveSource = (): boolean =>
+        (!event.profile ||
+          normalizeProfileKey(event.profile) === normalizeProfileKey($activeGatewayProfile.get())) &&
+        backendScopeKey(event.connectionId ?? null, event.profile ?? null) ===
+          backendScopeKey(activeGatewayConnectionId(), event.profile ?? null)
+
       const occurredAt =
         typeof payload?.timestamp === 'number' && Number.isFinite(payload.timestamp)
           ? payload.timestamp
@@ -417,11 +430,8 @@ export function useGatewayEventHandler(deps: GatewayEventDeps) {
         return
       } else if (event.type === 'skin.changed') {
         // A runtime skin switch (Hermes activating an authored skin, or `/skin`
-        // on another surface). Only the active profile's change repaints.
-        const fromActiveProfile =
-          !event.profile || normalizeProfileKey(event.profile) === normalizeProfileKey($activeGatewayProfile.get())
-
-        if (fromActiveProfile) {
+        // on another surface). Only the active source+profile's change repaints.
+        if (fromActiveSource()) {
           ingestBackendSkin(payload as HermesSkin | undefined, { apply: true })
         }
 
@@ -435,12 +445,10 @@ export function useGatewayEventHandler(deps: GatewayEventDeps) {
       ) {
         // Change-watcher broadcasts (server._broadcast_watched_changes): the
         // backend's on-disk signature moved. Route to the live-sync ticks the
-        // former pollers now subscribe to. Only the active profile's changes
-        // apply — background profile sockets watch their own homes.
-        const fromActiveChangeProfile =
-          !event.profile || normalizeProfileKey(event.profile) === normalizeProfileKey($activeGatewayProfile.get())
-
-        if (fromActiveChangeProfile) {
+        // former pollers now subscribe to. Only the active source+profile's
+        // changes apply — background profile sockets (and other connections'
+        // gateways) watch their own homes.
+        if (fromActiveSource()) {
           if (event.type === 'pet.changed') {
             notifyPetChanged(payload as PetChangeMeta | undefined)
           } else if (event.type === 'cron.changed') {
@@ -504,7 +512,7 @@ export function useGatewayEventHandler(deps: GatewayEventDeps) {
           isActiveEvent &&
           typeof payload?.approval_mode === 'string' &&
           event.profile &&
-          normalizeProfileKey(event.profile) === normalizeProfileKey($activeGatewayProfile.get())
+          fromActiveSource()
         ) {
           reconcileApprovalModeForProfile(event.profile, payload.approval_mode)
         }

--- a/apps/desktop/src/store/gateway-connection-scope.test.ts
+++ b/apps/desktop/src/store/gateway-connection-scope.test.ts
@@ -1,0 +1,111 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+// Cross-connection event/prune scoping: every registered source exposes a
+// 'default' profile (the roster force-unshifts it), so any consumer keyed by
+// the bare profile name conflates two connected gateways' activity. These
+// tests pin the composite (connectionId, profile) keying:
+//  - pruneSecondaryGateways must NOT keep a registry-scoped socket alive off
+//    another source's same-named profile (and vice versa) — registry entries
+//    match only their composite backendScopeKey scope.
+//  - the session-states scope ledger (recordSessionEventScope /
+//    liveSessionScopes) turns registry-tagged live work into those composite
+//    keep-set entries, and ignores untagged local/primary events.
+
+const gatewayMocks = vi.hoisted(() => ({
+  closed: [] as string[],
+  setConnection: vi.fn()
+}))
+
+vi.mock('@/hermes', () => ({
+  HermesGateway: class {
+    connectionState = 'closed'
+    wsUrl = ''
+    connect = async (wsUrl: string): Promise<void> => {
+      this.wsUrl = wsUrl
+      this.connectionState = 'open'
+    }
+    close = (): void => {
+      gatewayMocks.closed.push(this.wsUrl)
+      this.connectionState = 'closed'
+    }
+    onEvent = vi.fn(() => () => {})
+    onState = vi.fn(() => () => {})
+  }
+}))
+vi.mock('@/store/session', () => ({
+  setConnection: gatewayMocks.setConnection,
+  setGatewayState: vi.fn()
+}))
+vi.mock('@/store/notify-baseline', () => ({ markNativeNotifyBaseline: vi.fn() }))
+
+const { closeSecondaryGateways, configureGatewayRegistry, openGatewayForAgent, pruneSecondaryGateways, setPrimaryGateway } =
+  await import('./gateway')
+
+function installDesktop(): void {
+  ;(window as unknown as { hermesDesktop: unknown }).hermesDesktop = {
+    getConnection: vi.fn(async () => ({
+      authMode: 'token',
+      profile: 'default',
+      token: 't',
+      wsUrl: 'wss://local.invalid/api/ws?token=t'
+    })),
+    getConnectionFor: vi.fn(async ({ connectionId, profile }: { connectionId: string; profile: string }) => ({
+      authMode: 'token',
+      connectionId,
+      profile,
+      token: 't',
+      wsUrl: `wss://${connectionId}.invalid/api/ws?profile=${profile}`
+    })),
+    getGatewayWsUrlFor: vi.fn(
+      async ({ connectionId, profile }: { connectionId: string; profile: string }) =>
+        `wss://${connectionId}.invalid/api/ws?profile=${profile}`
+    ),
+    touchBackend: vi.fn(async () => undefined)
+  }
+}
+
+beforeEach(() => {
+  installDesktop()
+  configureGatewayRegistry({ onEvent: vi.fn() })
+  setPrimaryGateway({ connectionState: 'open' } as never, 'default')
+  gatewayMocks.closed = []
+})
+
+afterEach(() => {
+  closeSecondaryGateways()
+  vi.clearAllMocks()
+  delete (window as unknown as { hermesDesktop?: unknown }).hermesDesktop
+})
+
+describe('pruneSecondaryGateways with registry-scoped entries', () => {
+  it("does not keep a registry socket alive off another source's same-named profile", async () => {
+    // Gateway B's 'default' — the roster row (connectionId 'homelab', profile
+    // 'default'). The keep-set carries the bare 'default' profile because the
+    // LOCAL source has live work; that must not pin homelab's socket.
+    await openGatewayForAgent('homelab', 'default')
+
+    pruneSecondaryGateways(new Set(['default']))
+
+    expect(gatewayMocks.closed).toEqual(['wss://homelab.invalid/api/ws?profile=default'])
+  })
+
+  it('keeps a registry socket whose composite scope has live work', async () => {
+    await openGatewayForAgent('homelab', 'default')
+
+    pruneSecondaryGateways(new Set(['conn:homelab::default']))
+
+    expect(gatewayMocks.closed).toEqual([])
+  })
+
+  it('still keeps a local (profile-keyed) secondary via its bare profile name', async () => {
+    await openGatewayForAgent(null, 'research')
+
+    pruneSecondaryGateways(new Set(['research']))
+
+    expect(gatewayMocks.closed).toEqual([])
+
+    pruneSecondaryGateways(new Set())
+
+    expect(gatewayMocks.closed).toHaveLength(1)
+  })
+})

--- a/apps/desktop/src/store/gateway.ts
+++ b/apps/desktop/src/store/gateway.ts
@@ -142,6 +142,22 @@ export function activeGateway(): HermesGateway | null {
   return g.secondaries.get(g.activeKey)?.gateway ?? null
 }
 
+/**
+ * The registry connection serving the gateway the user is currently looking
+ * at — null for the local/legacy primary path and for profile-keyed (local)
+ * secondaries. Event consumers pair this with the event's own `connectionId`
+ * tag so "from the active profile" really means "from the active SOURCE":
+ * two connected gateways can both expose a 'default' profile, and a bare
+ * profile comparison attributed gateway B's 'default' activity to gateway A.
+ */
+export function activeGatewayConnectionId(): null | string {
+  if (g.activeKey === g.primaryProfile) {
+    return null
+  }
+
+  return g.secondaries.get(g.activeKey)?.connectionId ?? null
+}
+
 // Mirror a backend's connection state into the global composer state, but only
 // when that backend is the one the user is currently looking at. Lets the
 // composer reflect the active profile's socket without a background reconnect
@@ -505,15 +521,17 @@ function restoreActiveToPrimaryIfEvicted(): void {
   }
 }
 
-// Close + evict secondaries whose profile is neither active nor in `keep`
-// (profiles with a running / needs-input session). Bounds cost to live work.
-// `keep` carries PROFILE names (session ownership is profile-keyed), so a
-// registry-scoped entry survives when ITS profile has live work — matching on
-// the composite key alone would prune every non-local socket the moment the
-// user looks away.
+// Close + evict secondaries whose scope is neither active nor in `keep`
+// (scopes with a running / needs-input session). Bounds cost to live work.
+// `keep` carries PROFILE names for local/legacy entries and composite
+// backendScopeKey(connectionId, profile) scopes for registry-sourced live
+// work. A registry-scoped entry matches ONLY on its composite key: every
+// source exposes a 'default' profile, so matching a non-local entry on the
+// bare profile name kept gateway B's 'default' socket alive off gateway A's
+// 'default' activity (and vice versa) — cross-connection attribution.
 export function pruneSecondaryGateways(keep: Set<string>): void {
   for (const [key, entry] of [...g.secondaries]) {
-    if (key === g.activeKey || keep.has(key) || keep.has(entry.profile)) {
+    if (key === g.activeKey || keep.has(key) || (!entry.connectionId && keep.has(entry.profile))) {
       continue
     }
 

--- a/apps/desktop/src/store/session-states-scopes.test.ts
+++ b/apps/desktop/src/store/session-states-scopes.test.ts
@@ -1,0 +1,74 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import { createClientSessionState } from '@/lib/chat-runtime'
+import {
+  $sessionStates,
+  clearAllSessionStates,
+  dropSessionState,
+  liveSessionScopes,
+  publishSessionState,
+  recordSessionEventScope
+} from '@/store/session-states'
+
+/**
+ * The (connectionId, profile) half of the gateway keep-set. Working/attention
+ * ids are profile-blind, and every registered source exposes a 'default'
+ * profile — so registry-sourced live work must surface as composite
+ * backendScopeKey scopes, while untagged local/primary events contribute
+ * nothing (their liveness keeps flowing through bare profile names).
+ */
+
+const state = (patch: Partial<ReturnType<typeof createClientSessionState>> = {}) => ({
+  ...createClientSessionState('stored-1'),
+  ...patch
+})
+
+beforeEach(() => {
+  clearAllSessionStates()
+  $sessionStates.set({})
+})
+
+describe('liveSessionScopes', () => {
+  it('maps a registry-tagged busy session to its composite scope', () => {
+    recordSessionEventScope({ connectionId: 'homelab', profile: 'default', session_id: 'rt-1' })
+    publishSessionState('rt-1', state({ busy: true }))
+
+    expect(liveSessionScopes()).toEqual(new Set(['conn:homelab::default']))
+  })
+
+  it('includes needs-input sessions and drops settled ones', () => {
+    recordSessionEventScope({ connectionId: 'homelab', profile: 'default', session_id: 'rt-1' })
+    publishSessionState('rt-1', state({ busy: false, needsInput: true }))
+
+    expect(liveSessionScopes()).toEqual(new Set(['conn:homelab::default']))
+
+    publishSessionState('rt-1', state({ busy: false, needsInput: false }))
+
+    expect(liveSessionScopes()).toEqual(new Set())
+  })
+
+  it('ignores untagged (local/primary) events — no connectionId, no scope', () => {
+    recordSessionEventScope({ profile: 'default', session_id: 'rt-1' })
+    publishSessionState('rt-1', state({ busy: true }))
+
+    expect(liveSessionScopes()).toEqual(new Set())
+  })
+
+  it("keeps two sources' same-named 'default' profiles distinct", () => {
+    recordSessionEventScope({ connectionId: 'homelab', profile: 'default', session_id: 'rt-a' })
+    recordSessionEventScope({ connectionId: 'spark', profile: 'default', session_id: 'rt-b' })
+    publishSessionState('rt-a', state({ busy: true }))
+    publishSessionState('rt-b', state({ busy: true }))
+
+    expect(liveSessionScopes()).toEqual(new Set(['conn:homelab::default', 'conn:spark::default']))
+  })
+
+  it('forgets a dropped runtime session', () => {
+    recordSessionEventScope({ connectionId: 'homelab', profile: 'default', session_id: 'rt-1' })
+    publishSessionState('rt-1', state({ busy: true }))
+    dropSessionState('rt-1')
+    publishSessionState('rt-1', state({ busy: true }))
+
+    expect(liveSessionScopes()).toEqual(new Set())
+  })
+})

--- a/apps/desktop/src/store/session-states.ts
+++ b/apps/desktop/src/store/session-states.ts
@@ -16,9 +16,8 @@
  * itself here as the delegate so tile UI stays dependency-light.
  */
 
-import { atom, computed } from 'nanostores'
-
 import { backendScopeKey } from '@hermes/shared'
+import { atom, computed } from 'nanostores'
 
 import type { ClientSessionState } from '@/app/types'
 import { findGroup, findGroupOfPane, type LayoutNode } from '@/components/pane-shell/tree/model'

--- a/apps/desktop/src/store/session-states.ts
+++ b/apps/desktop/src/store/session-states.ts
@@ -18,6 +18,8 @@
 
 import { atom, computed } from 'nanostores'
 
+import { backendScopeKey } from '@hermes/shared'
+
 import type { ClientSessionState } from '@/app/types'
 import { findGroup, findGroupOfPane, type LayoutNode } from '@/components/pane-shell/tree/model'
 import {
@@ -54,6 +56,49 @@ import { isSecondaryWindow } from './windows'
 // ---------------------------------------------------------------------------
 
 export const $sessionStates = atom<Record<string, ClientSessionState>>({})
+
+// ---------------------------------------------------------------------------
+// Event-source scopes: which registry connection's socket delivered a runtime
+// session's events. Working/attention membership alone is profile-blind — two
+// connected gateways can both expose a 'default' profile, so the gateway
+// keep-set (pruneSecondaryGateways) must key live work by the composite
+// (connectionId, profile) scope, not the bare profile name. Recorded at
+// event fan-in (use-gateway-boot); local/primary events carry no connectionId
+// and record nothing, so single-source behavior is untouched.
+// ---------------------------------------------------------------------------
+
+const sessionScopeByRuntimeId = new Map<string, string>()
+
+export function recordSessionEventScope(event: {
+  connectionId?: string
+  profile?: string
+  session_id?: string
+}): void {
+  if (event.session_id && event.connectionId) {
+    sessionScopeByRuntimeId.set(event.session_id, backendScopeKey(event.connectionId, event.profile))
+  }
+}
+
+/** Composite scopes of registry-sourced sessions that are live (busy or
+ * waiting on input) — the (connectionId, profile) half of the gateway
+ * keep-set. Local-source live work keeps flowing through profile names. */
+export function liveSessionScopes(): Set<string> {
+  const scopes = new Set<string>()
+
+  for (const [runtimeId, state] of Object.entries($sessionStates.get())) {
+    if (!state || (!state.busy && !state.needsInput)) {
+      continue
+    }
+
+    const scope = sessionScopeByRuntimeId.get(runtimeId)
+
+    if (scope) {
+      scopes.add(scope)
+    }
+  }
+
+  return scopes
+}
 
 // Stored session ids whose authoritative state is still busy, but whose
 // runtime has produced no state publish for the watchdog window. Silence is
@@ -302,6 +347,7 @@ export function dropSessionState(runtimeId: string) {
   // cached runtime is dropped in the meantime.
   clearWatchdog(runtimeId)
   clearSessionProviderWait(runtimeId)
+  sessionScopeByRuntimeId.delete(runtimeId)
 
   const current = $sessionStates.get()
   setSessionStalled(current[runtimeId]?.storedSessionId, false)
@@ -327,6 +373,7 @@ export function clearAllSessionStates() {
   sessionWatchdogTimers.clear()
   settledExpiry.clear()
   clearAllProviderWaits()
+  sessionScopeByRuntimeId.clear()
   $stalledSessionIds.set([])
   $sessionStates.set({})
 }

--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -455,6 +455,9 @@ export interface PaginatedSessions {
 export interface RpcEvent<T = unknown> {
   payload?: T
   profile?: string
+  /** Registry connection whose socket delivered the event (renderer-side tag;
+   * absent for the local/legacy primary path). */
+  connectionId?: string
   session_id?: string
   type: string
 }

--- a/apps/shared/src/json-rpc-gateway.ts
+++ b/apps/shared/src/json-rpc-gateway.ts
@@ -27,6 +27,9 @@ export interface GatewayEvent<P = unknown> {
   payload?: P
   /** Renderer-side source tag added by the Desktop gateway registry. */
   profile?: string
+  /** Registry connection whose socket delivered the event (renderer-side tag;
+   * absent for the local/legacy primary path). */
+  connectionId?: string
   session_id?: string
   type: GatewayEventName
 }


### PR DESCRIPTION
## Summary

Fixes two verified routing bugs in the Desktop multi-gateway (connection registry + agent roster) feature introduced by the multi-source campaign:

1. **Registry `local` entry routed through the v1 primary instead of the local runtime.** `ensureRegistryBackend` delegated `kind === 'local'` to `ensureBackend(profile)`, which follows the v1 `connection.json` routing table. For a migrated user whose v1 global mode was REMOTE (migration makes that remote the registry primary AND keeps the mandatory `local` entry), the roster's "This device" rows enumerated and dialed the REMOTE primary — every profile appeared twice (forcing `-slug` handles) and clicking a "This device" agent talked to the remote box.
2. **Fan-out events tagged with `connectionId`, but no consumer read it.** `src/store/gateway.ts` stamps secondary-gateway events with `connectionId`, yet working/attention tracking, the `pruneSecondaryGateways` keep-set, and the profile-scoped event gates (`skin.changed`, change-watcher broadcasts, approval-mode reconcile) keyed everything by session id + bare profile name. Every registered source exposes a `default` profile (the roster force-unshifts it), so two connected gateways collided: gateway B's `default` activity was attributed to gateway A's `default`.

## Changes

**Bug 1 — `electron/connection-registry.ts`, `electron/main.ts`**
- New pure `resolveRegistryLocalRoute(profile, { globalRemote, profileRemoteOverride })`: delegate to the legacy `ensureBackend` path only when the v1 route is itself local (single-source behavior byte-identical); otherwise force a genuinely-local backend.
- `ensureRegistryBackend` (`kind === 'local'`): when v1 says remote, spawn/reuse a forced-local pool child under the composite `conn:local::<profile>` key — the bare profile slot is where the v1 route caches the REMOTE descriptor, so the composite key avoids collision (colons are invalid in profile names).
- `spawnPoolBackend` gains `{ forceLocal, poolKey }` options: `forceLocal` skips `resolveRemoteBackend` entirely; `poolKey` makes the child's exit/error cleanup evict the correct composite pool entry.

**Bug 2 — renderer, keyed by the existing `backendScopeKey` helper (`@hermes/shared`)**
- `store/session-states.ts`: `recordSessionEventScope()` records each registry-tagged event's `(connectionId, profile)` scope per runtime session (untagged local/primary events record nothing); `liveSessionScopes()` projects busy/needs-input sessions as composite scopes. Cleared in `dropSessionState` / `clearAllSessionStates`.
- `use-gateway-boot.ts`: the registry `onEvent` fan-in records scopes before dispatch; `recomputeKeptGateways` seeds the prune keep-set with `liveSessionScopes()` alongside the profile names for local sessions.
- `store/gateway.ts`: `pruneSecondaryGateways` matches registry-scoped entries ONLY on their composite key (`!entry.connectionId && keep.has(entry.profile)` keeps the bare-profile match for local entries); new `activeGatewayConnectionId()` exposes the active source.
- `use-message-stream/gateway-event.ts`: the three "from the active profile" gates (`skin.changed`, change-watcher broadcasts, approval-mode reconcile) now compare the event's composite `backendScopeKey(event.connectionId, event.profile)` against the active gateway's connection — untagged events behave byte-identically.
- `RpcEvent` / shared `GatewayEvent` types gain the optional `connectionId` tag that the fan-out already emitted.

Display-only surfaces that already use roster handles are untouched, per scope agreement with sibling workers (no edits to `disposeSecondary` / `scheduleReconnect` / `activeGateway` / `ensureGatewayForAgent` internals).

## Validation

- Premises verified against `origin/main` (`a15de3454`) before changes: `ensureRegistryBackend` line 9219-9221 delegated local→`ensureBackend`; `gateway.ts` line 264 emitted `connectionId` with zero consumers (`event.connectionId` had no matches under `src/`).
- New regression tests:
  - `electron/connection-registry.test.ts`: 3 new tests including the migration scenario (v1 remote global mode ⇒ forced-local route under `conn:local::<profile>`, never the bare key).
  - `src/store/gateway-connection-scope.test.ts` (new): prune does NOT keep a registry socket alive off another source's same-named profile; composite keep-set entries do keep it; local profile-keyed secondaries unchanged.
  - `src/store/session-states-scopes.test.ts` (new): scope ledger — registry-tagged busy/needs-input sessions project composite scopes, untagged events project nothing, two sources' `default` profiles stay distinct, dropped runtimes are forgotten.
- Focused runs (apps/desktop): `npx vitest run electron/connection-registry.test.ts src/store/gateway-connection-scope.test.ts src/store/session-states-scopes.test.ts src/store/gateway-shared-remote.test.ts src/app/gateway/hooks/use-gateway-boot.test.tsx` → **5 files, 53 tests passed**; adjacent suites `src/app/session/hooks/use-message-stream` + session-states tests → **23 files, 146 tests passed**.
- `npm --prefix apps/desktop run typecheck` (renderer + electron + e2e tsconfigs) → clean.

## Infographic

![Registry routing](https://v3b.fal.media/files/b/0aa68d07/kJemQ9EX1V__5nJkgaASf_4gVGyNac.png)
