### PR TITLE
fix(openviking): harden local server and .env handling

### DIFF
--- a/plugins/memory/openviking/__init__.py
+++ b/plugins/memory/openviking/__init__.py
@@ -1217,7 +1217,16 @@ def _env_line_safe(value: Any) -> str:
 def _write_env_vars(env_path: Path, env_writes: dict, remove_keys: tuple[str, ...] = ()) -> None:
     env_path.parent.mkdir(parents=True, exist_ok=True)
     remove_set = set(remove_keys) - set(env_writes)
-    existing_lines = env_path.read_text(encoding="utf-8").splitlines() if env_path.exists() else []
+    # Read exactly like the canonical .env reader in hermes_cli/config.py
+    # (save_env_value). A Windows editor can leave a UTF-8 BOM, which fails
+    # the key match on the first line so that key gets duplicated on write,
+    # or save the file as cp1252, which makes a strict utf-8 read raise and
+    # abort setup. Copying existing lines through must never do either.
+    existing_lines = (
+        env_path.read_text(encoding="utf-8-sig", errors="replace").splitlines()
+        if env_path.exists()
+        else []
+    )
     updated_keys = set()
     new_lines = []
     for line in existing_lines:

--- a/plugins/memory/openviking/__init__.py
+++ b/plugins/memory/openviking/__init__.py
@@ -1217,13 +1217,12 @@ def _env_line_safe(value: Any) -> str:
 def _write_env_vars(env_path: Path, env_writes: dict, remove_keys: tuple[str, ...] = ()) -> None:
     env_path.parent.mkdir(parents=True, exist_ok=True)
     remove_set = set(remove_keys) - set(env_writes)
-    # Read exactly like the canonical .env reader in hermes_cli/config.py
-    # (save_env_value). A Windows editor can leave a UTF-8 BOM, which fails
-    # the key match on the first line so that key gets duplicated on write,
-    # or save the file as cp1252, which makes a strict utf-8 read raise and
-    # abort setup. Copying existing lines through must never do either.
+    # A Windows editor can leave a UTF-8 BOM, which prevents the first key
+    # from matching, or save the file as cp1252, which makes a strict UTF-8
+    # read fail. Strip the BOM and round-trip undecodable bytes unchanged so
+    # updating one credential cannot corrupt an unrelated value.
     existing_lines = (
-        env_path.read_text(encoding="utf-8-sig", errors="replace").splitlines()
+        env_path.read_text(encoding="utf-8-sig", errors="surrogateescape").splitlines()
         if env_path.exists()
         else []
     )
@@ -1243,7 +1242,11 @@ def _write_env_vars(env_path: Path, env_writes: dict, remove_keys: tuple[str, ..
             new_lines.append(f"{key}={_env_line_safe(val)}")
     # Pre-create with 0600 so secrets are never briefly world-readable.
     _precreate_secret_file(env_path)
-    env_path.write_text("\n".join(new_lines) + ("\n" if new_lines else ""), encoding="utf-8")
+    env_path.write_text(
+        "\n".join(new_lines) + ("\n" if new_lines else ""),
+        encoding="utf-8",
+        errors="surrogateescape",
+    )
     _restrict_secret_file_permissions(env_path)
 
 

--- a/plugins/memory/openviking/__init__.py
+++ b/plugins/memory/openviking/__init__.py
@@ -1536,6 +1536,17 @@ def _start_local_openviking_server(endpoint: str) -> tuple[str, str]:
     log_path = _openviking_server_log_path()
     try:
         log_path.parent.mkdir(parents=True, exist_ok=True)
+        # Do not let the server child inherit this process's PYTHONPATH.
+        # On a Hermes install PYTHONPATH points at the Hermes venv
+        # site-packages, so openviking-server would import aiohttp and
+        # friends from the Hermes venv instead of its own (its venv's
+        # site-packages are shadowed because PYTHONPATH precedes them) —
+        # and on Windows the loaded DLLs then lock the Hermes venv,
+        # aborting `hermes update` with access-denied on .pyd files.
+        # Strip PYTHONPATH so the server resolves packages from its own
+        # venv. (#78153)
+        child_env = os.environ.copy()
+        child_env.pop("PYTHONPATH", None)
         with log_path.open("ab") as log_file:
             subprocess.Popen(
                 [server_cmd, "--host", host, "--port", str(port)],
@@ -1543,6 +1554,7 @@ def _start_local_openviking_server(endpoint: str) -> tuple[str, str]:
                 stderr=log_file,
                 stdin=subprocess.DEVNULL,
                 start_new_session=True,
+                env=child_env,
             )
     except Exception as e:
         return _LOCAL_SERVER_FAILED, f"Could not start openviking-server: {e}"

--- a/plugins/memory/openviking/__init__.py
+++ b/plugins/memory/openviking/__init__.py
@@ -1549,10 +1549,11 @@ def _start_local_openviking_server(endpoint: str) -> tuple[str, str]:
     try:
         log_path.parent.mkdir(parents=True, exist_ok=True)
         # Do not let the server child inherit this process's PYTHONPATH.
-        # On a Hermes install PYTHONPATH points at the Hermes venv
-        # site-packages, so openviking-server would import aiohttp and
-        # friends from the Hermes venv instead of its own (its venv's
-        # site-packages are shadowed because PYTHONPATH precedes them) —
+        # The Hermes Desktop backend can include the Hermes venv's
+        # site-packages in PYTHONPATH. If inherited, openviking-server would
+        # import aiohttp and friends from the Hermes venv instead of its own
+        # (its venv's site-packages are shadowed because PYTHONPATH precedes
+        # them) —
         # and on Windows the loaded DLLs then lock the Hermes venv,
         # aborting `hermes update` with access-denied on .pyd files.
         # Strip PYTHONPATH so the server resolves packages from its own

--- a/tests/plugins/memory/test_openviking_provider.py
+++ b/tests/plugins/memory/test_openviking_provider.py
@@ -392,6 +392,35 @@ def test_start_local_openviking_server_uses_endpoint_host_and_port(monkeypatch):
     assert kwargs["start_new_session"] is True
 
 
+def test_start_local_openviking_server_strips_pythonpath_from_child_env(monkeypatch):
+    """The spawned server must not inherit Hermes's PYTHONPATH (#78153).
+
+    Inheriting it makes openviking-server import packages from the Hermes
+    venv instead of its own, and on Windows locks Hermes venv DLLs so the
+    venv cannot be rebuilt during `hermes update`.
+    """
+    popen_calls = []
+
+    def fake_popen(args, **kwargs):
+        popen_calls.append((args, kwargs))
+        return object()
+
+    monkeypatch.setattr(openviking_module, "_local_openviking_port_is_open", lambda host, port: False)
+    monkeypatch.setattr(openviking_module.shutil, "which", lambda name: "/usr/local/bin/openviking-server")
+    monkeypatch.setattr(openviking_module.subprocess, "Popen", fake_popen)
+    monkeypatch.setenv("PYTHONPATH", "/opt/hermes/.venv/Lib/site-packages")
+    monkeypatch.setenv("HERMES_PROFILE", "test-profile")
+
+    state, _message = openviking_module._start_local_openviking_server("http://127.0.0.1:1934")
+
+    assert state == openviking_module._LOCAL_SERVER_STARTED
+    _, kwargs = popen_calls[0]
+    child_env = kwargs["env"]
+    assert child_env is not None
+    assert "PYTHONPATH" not in child_env
+    assert child_env.get("HERMES_PROFILE") == "test-profile"
+
+
 def test_start_local_openviking_server_does_not_spawn_when_port_already_open(monkeypatch):
     """A live listener means a second server would just die on DataDirectoryLocked."""
     probed = []

--- a/tests/plugins/memory/test_openviking_provider.py
+++ b/tests/plugins/memory/test_openviking_provider.py
@@ -1748,8 +1748,8 @@ class TestOpenVikingEnvWriter:
         _write_env_vars(env, {"OPENAI_API_KEY": "new"})
 
         lines = [l for l in env.read_text(encoding="utf-8-sig").splitlines() if l]
-        # The stale value must be gone, not shadowed by an appended duplicate:
-        # .env loaders keep the first occurrence, so a duplicate silently wins.
+        # The stale value must be gone, not left as a duplicate. Hermes and
+        # python-dotenv use the last occurrence, but the file must have one value.
         assert lines.count("OPENAI_API_KEY=new") == 1
         assert not any(l.endswith("=old") for l in lines)
         assert "OTHER=1" in lines

--- a/tests/plugins/memory/test_openviking_provider.py
+++ b/tests/plugins/memory/test_openviking_provider.py
@@ -1754,7 +1754,7 @@ class TestOpenVikingEnvWriter:
         assert not any(l.endswith("=old") for l in lines)
         assert "OTHER=1" in lines
 
-    def test_non_utf8_env_does_not_abort_setup(self, tmp_path):
+    def test_non_utf8_env_preserves_unrelated_bytes(self, tmp_path):
         from plugins.memory.openviking import _write_env_vars
 
         env = tmp_path / ".env"
@@ -1762,8 +1762,7 @@ class TestOpenVikingEnvWriter:
 
         _write_env_vars(env, {"OPENAI_API_KEY": "new"})
 
-        lines = env.read_text(encoding="utf-8-sig").splitlines()
-        assert "OPENAI_API_KEY=new" in lines
+        assert env.read_bytes() == b"NAME=caf\xe9\nOPENAI_API_KEY=new\n"
 
     def test_plain_env_is_unchanged_apart_from_the_write(self, tmp_path):
         from plugins.memory.openviking import _write_env_vars

--- a/tests/plugins/memory/test_openviking_provider.py
+++ b/tests/plugins/memory/test_openviking_provider.py
@@ -1729,3 +1729,50 @@ def test_is_available_false_without_any_endpoint(monkeypatch):
         openviking_module, "_load_hermes_openviking_config", lambda: {}
     )
     assert OpenVikingMemoryProvider().is_available() is False
+
+
+class TestOpenVikingEnvWriter:
+    """``_write_env_vars`` copies existing .env lines through on every update,
+    so how it *reads* them decides whether a credential update lands.
+
+    f1ea4a56c ("cover the remaining setup-time .env reads with utf-8-sig")
+    swept this class; this writer was missed.
+    """
+
+    def test_bom_prefixed_env_updates_in_place(self, tmp_path):
+        from plugins.memory.openviking import _write_env_vars
+
+        env = tmp_path / ".env"
+        env.write_bytes(b"\xef\xbb\xbfOPENAI_API_KEY=old\nOTHER=1\n")
+
+        _write_env_vars(env, {"OPENAI_API_KEY": "new"})
+
+        lines = [l for l in env.read_text(encoding="utf-8-sig").splitlines() if l]
+        # The stale value must be gone, not shadowed by an appended duplicate:
+        # .env loaders keep the first occurrence, so a duplicate silently wins.
+        assert lines.count("OPENAI_API_KEY=new") == 1
+        assert not any(l.endswith("=old") for l in lines)
+        assert "OTHER=1" in lines
+
+    def test_non_utf8_env_does_not_abort_setup(self, tmp_path):
+        from plugins.memory.openviking import _write_env_vars
+
+        env = tmp_path / ".env"
+        env.write_bytes(b"NAME=caf\xe9\nOPENAI_API_KEY=old\n")
+
+        _write_env_vars(env, {"OPENAI_API_KEY": "new"})
+
+        lines = env.read_text(encoding="utf-8-sig").splitlines()
+        assert "OPENAI_API_KEY=new" in lines
+
+    def test_plain_env_is_unchanged_apart_from_the_write(self, tmp_path):
+        from plugins.memory.openviking import _write_env_vars
+
+        env = tmp_path / ".env"
+        env.write_text("A=1\nOPENAI_API_KEY=old\nB=2\n", encoding="utf-8")
+
+        _write_env_vars(env, {"OPENAI_API_KEY": "new"})
+
+        assert env.read_text(encoding="utf-8").splitlines() == [
+            "A=1", "OPENAI_API_KEY=new", "B=2",
+        ]


### PR DESCRIPTION
## What does this PR do?

This PR consolidates #78219 and #78940. It fixes two OpenViking setup and startup failures.

First, the Hermes Desktop backend can include the Hermes virtual-environment packages in `PYTHONPATH`. An auto-started `openviking-server` inherited this path and could import those packages instead of its own. On Windows, loaded `.pyd` files could lock that environment and block `hermes update`.

Second, the OpenViking `.env` writer used strict UTF-8. A UTF-8 BOM prevented the first key from matching, which could leave a stale duplicate credential. A non-UTF-8 byte could stop setup. The new read path removes a BOM and preserves undecodable bytes when it updates another value.

The original authorship from #78219 and #78940 is preserved. The final follow-up commit changes the original replacement-character behavior so unrelated bytes remain unchanged.

## Related Issue

Fixes #78153

Consolidates #78219 and #78940.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Remove `PYTHONPATH` from the environment of an auto-started OpenViking server. Preserve all other environment variables.
- Read the Hermes `.env` file with `utf-8-sig` so a leading BOM does not change the first key.
- Use `surrogateescape` on read and write so unrelated non-UTF-8 bytes remain unchanged.
- Add regression tests for child environment isolation, BOM handling, byte preservation, and normal UTF-8 updates.

## How to Test

1. Run the focused OpenViking tests:

   ```bash
   HERMES_TEST_FILE_RETRIES=0 scripts/run_tests.sh tests/openviking_plugin/ tests/plugins/memory/test_openviking_endpoint_always_blocked.py tests/plugins/memory/test_openviking_provider.py tests/plugins/memory/test_openviking_shutdown.py -q
   ```

2. Run Ruff and the Windows footgun scan:

   ```bash
   ruff check .
   python scripts/check-windows-footguns.py --all
   ```

3. Confirm that the focused result is `105 passed`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.6 and targeted Windows compatibility checks

The complete macOS suite was started through `scripts/run_tests.sh tests/ -q`. It cannot be an all-green local gate in the standard development environment because some unrelated tests require optional Teams and WeCom dependencies, and one Linux abstract-socket test runs on macOS. The branch-specific OpenViking suite passes with retries disabled.

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```text
OpenViking scope: 105 passed, 0 failed
Ruff: All checks passed
Windows footgun scan: No Windows footguns found (973 files scanned)
```