### PR TITLE
fix(launchd): mark plist-managed gateway as externally supervised on macOS 26

### DIFF
--- a/contributors/emails/gfriesen1@users.noreply.github.com
+++ b/contributors/emails/gfriesen1@users.noreply.github.com
@@ -1,0 +1,1 @@
+gfriesen1

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -4638,6 +4638,16 @@ def generate_launchd_plist() -> str:
         <string>{venv_dir}</string>
         <key>HERMES_HOME</key>
         <string>{hermes_home}</string>
+        <!-- The stderr_timestamp wrapper makes the gateway a grandchild of
+             launchd. macOS 26 rewrites XPC_SERVICE_NAME to "0" for any
+             process launchd did not spawn directly, so the gateway's own
+             supervised-conflict guard misidentifies itself as a rogue
+             foreground start (it probes `launchctl list`, sees the live
+             wrapper PID, and refuses — wedging the service into a
+             KeepAlive respawn/refuse loop). This opt-in survives wrappers
+             and marks the process as the supervised service. -->
+        <key>HERMES_GATEWAY_EXTERNAL_SUPERVISOR</key>
+        <string>1</string>
     </dict>
 
     <key>LimitLoadToSessionType</key>

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -264,6 +264,25 @@ class TestGeneratedSystemdUnits:
 
 
 
+    def test_launchd_plist_marks_gateway_as_externally_supervised(self):
+        """The plist wraps `gateway run` in stderr_timestamp, making the gateway a
+        grandchild of launchd. macOS 26 rewrites XPC_SERVICE_NAME to "0" for any
+        process launchd didn't spawn directly, so the gateway loses its supervisor
+        marker and _guard_supervised_gateway_conflict misidentifies the service's
+        own startup as a rogue foreground run and refuses — wedging KeepAlive into
+        a respawn/refuse loop. The plist must emit
+        HERMES_GATEWAY_EXTERNAL_SUPERVISOR=1, the wrapper-survival opt-in from
+        gateway/restart.py, so the guard sees the service for what it is."""
+        import plistlib
+
+        plist = gateway_cli.generate_launchd_plist()
+
+        data = plistlib.loads(plist.encode())
+        assert (
+            data["EnvironmentVariables"]["HERMES_GATEWAY_EXTERNAL_SUPERVISOR"] == "1"
+        )
+
+
 class TestGatewayStopCleanup:
     @pytest.mark.linux_only
     def test_stop_only_kills_current_profile_by_default(self, tmp_path, monkeypatch):


### PR DESCRIPTION
## Problem

The 0.20.1 launchd plist template wraps `gateway run` in `stderr_timestamp` (for timestamped stderr in `gateway.error.log`), which makes the gateway a **grandchild** of launchd. On **macOS 26**, launchd rewrites `XPC_SERVICE_NAME` to `"0"` for any process it did not spawn directly, so the gateway loses its supervisor marker:

- `launchctl list` shows the live wrapper PID → `service_running=True`
- `is_gateway_supervisor_process()` sees `XPC_SERVICE_NAME="0"` → `False`
- `_guard_supervised_gateway_conflict` therefore misidentifies the service's *own* startup as a rogue foreground run and refuses with exit 1
- `KeepAlive` respawns it every ~30s → the gateway crash-loops (observed: 146 self-refusals on one host, taking down its builtin cron scheduler for ~75 minutes)

**Impact:** every launchd-supervised gateway on macOS 26 hits this on its first plist refresh after upgrading to 0.20.1 — i.e. the first `hermes gateway start`/daily refresh that regenerates the plist from the new template.

## Fix

Emit `HERMES_GATEWAY_EXTERNAL_SUPERVISOR=1` in the generated plist's `EnvironmentVariables`. This is the existing, documented wrapper-survival opt-in:

- `gateway/restart.py` — `EXTERNAL_GATEWAY_SUPERVISOR_ENV`: *"Unlike systemd's INVOCATION_ID and launchd's XPC_SERVICE_NAME, this survives wrappers that intentionally replace the child environment"*
- `website/docs/reference/cli-commands.md` — the `--external-supervisor` section: *"Use this when `sudo`, `env -i`, or another wrapper strips launchd/systemd's native environment marker"*

`_running_under_gateway_supervisor()` already lists this as the intended mechanism: *"wrapped services can opt in with `--external-supervisor` when their launcher strips the native systemd/launchd marker."* The plist template is that launcher, so the template should apply the opt-in itself rather than requiring users to hand-edit generated plists.

launchd owns the job either way (wrapper or direct spawn), so the opt-in is semantically correct in both paths — it only restores the marker the wrapper strips.

## Test

Added `test_launchd_plist_marks_gateway_as_externally_supervised` — asserts the generated plist parses via `plistlib` and carries the env var. Full launchd plist suite passes (19 tests), plus the external-supervisor and restart service-detection suites (11 tests).
