### PR TITLE
fix(gateway): keep an ancestor gateway visible so the update it spawned can pause it

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -472,10 +472,17 @@ def _scan_gateway_pids(
     a live gateway when the PID file is stale/missing, and ``--all`` sweeps can
     discover gateways outside the current profile.
     """
-    # Exclude the entire ancestor chain so the CLI process that invoked this
-    # scan (e.g. ``hermes gateway status``) is never mistaken for a running
-    # gateway.  See #13242.
-    exclude_pids = exclude_pids | _get_ancestor_pids()
+    # Ancestors are suppressed so the CLI process that invoked this scan (e.g.
+    # ``hermes gateway status``) is never mistaken for a running gateway (see
+    # #13242) -- but NOT unconditionally. ``hermes update --gateway`` is
+    # spawned BY the gateway when ``/update`` is issued from a messaging
+    # platform, which puts a real ``gateway run`` in our own ancestor chain.
+    # Excluding it hid the gateway from the update pause machinery, so the
+    # update never paused it and then aborted on the venv-holder guard with
+    # "Other Hermes processes are running from this install's venv" (#87594).
+    # Held separately from ``exclude_pids`` (which the CALLER owns and means
+    # unconditionally) and consulted with the command line in hand below.
+    ancestor_pids = _get_ancestor_pids()
     pids: list[int] = []
     # Strict command-line matcher shared with gateway.status: requires the
     # actual ``gateway run`` subcommand (or the dedicated entrypoints), so this
@@ -523,6 +530,20 @@ def _scan_gateway_pids(
         if looks_like_gateway_command_line(command):
             return True
         return include_restart_managers and looks_like_gateway_runtime_command_line(command)
+
+    def _suppressed_as_ancestor(pid: int, command: str) -> bool:
+        """True when ``pid`` is our own ancestor and is not a gateway runtime.
+
+        The #13242 exclusion exists to keep the invoking CLI (``hermes gateway
+        status``, ``hermes update``) from being counted as a gateway. Those
+        command lines are not gateway runtimes, so gating the exclusion on the
+        matcher preserves that intent exactly while leaving a real ``gateway
+        run`` parent visible -- which is what the update pause path needs when
+        the gateway is the process that spawned it.
+        """
+        if pid not in ancestor_pids:
+            return False
+        return not looks_like_gateway_runtime_command_line(command)
 
     try:
         if is_windows():
@@ -597,9 +618,13 @@ def _scan_gateway_pids(
                         all_profiles or _matches_current_profile(current_cmd)
                     ):
                         try:
-                            _append_unique_pid(pids, int(pid_str), exclude_pids)
+                            scanned_pid = int(pid_str)
                         except ValueError:
-                            pass
+                            scanned_pid = None
+                        if scanned_pid is not None and not _suppressed_as_ancestor(
+                            scanned_pid, current_cmd
+                        ):
+                            _append_unique_pid(pids, scanned_pid, exclude_pids)
                     current_cmd = ""
         else:
             # Try /proc first (works in Docker without procps installed),
@@ -618,8 +643,10 @@ def _scan_gateway_pids(
                             with open(f"/proc/{pid}/cmdline", "rb") as _f:
                                 cmdline = _f.read().decode("utf-8", errors="replace")
                             cmdline = cmdline.replace("\x00", " ")
-                            if _matches_gateway_runtime(cmdline) and (
-                                all_profiles or _matches_current_profile(cmdline)
+                            if (
+                                _matches_gateway_runtime(cmdline)
+                                and (all_profiles or _matches_current_profile(cmdline))
+                                and not _suppressed_as_ancestor(pid, cmdline)
                             ):
                                 _append_unique_pid(pids, pid, exclude_pids)
                         except (OSError, PermissionError):
@@ -661,8 +688,10 @@ def _scan_gateway_pids(
 
                     if pid is None:
                         continue
-                    if _matches_gateway_runtime(command) and (
-                        all_profiles or _matches_current_profile(command)
+                    if (
+                        _matches_gateway_runtime(command)
+                        and (all_profiles or _matches_current_profile(command))
+                        and not _suppressed_as_ancestor(pid, command)
                     ):
                         _append_unique_pid(pids, pid, exclude_pids)
     except (OSError, subprocess.TimeoutExpired):

--- a/tests/hermes_cli/test_gateway_scan_ancestor_gateway.py
+++ b/tests/hermes_cli/test_gateway_scan_ancestor_gateway.py
@@ -1,0 +1,165 @@
+"""The ancestor exclusion in ``_scan_gateway_pids`` must not hide a real gateway.
+
+``hermes update --gateway`` is spawned BY the gateway when ``/update`` is issued
+from a messaging platform, so the gateway sits in the updater's own ancestor
+chain. The blanket ancestor exclusion (added for #13242, to stop ``hermes
+gateway status`` counting the CLI that invoked it) therefore hid the gateway
+from the update pause machinery: nothing was paused, the update mutated the venv
+while the gateway still held ``.pyd`` files, and the venv-holder guard aborted
+with "Other Hermes processes are running from this install's venv" (#87594).
+
+The exclusion is now gated on the command line: an ancestor that looks like a
+gateway runtime stays visible, everything else is still suppressed.
+
+The Windows arm is exercised here because that is where the reported failure
+lives (``.pyd`` locking is what makes the pause mandatory), and it is stubbed
+end to end so these run on any host.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import hermes_cli.gateway as gateway_mod
+
+_GATEWAY_CMD = "C:/h/venv/Scripts/pythonw.exe -m hermes_cli.main gateway run --replace"
+_UPDATER_CMD = "C:/h/venv/Scripts/python.exe -m hermes_cli.main update --yes --gateway"
+_STATUS_CMD = "C:/h/venv/Scripts/python.exe -m hermes_cli.main gateway status"
+
+GATEWAY_PID = 14112
+UPDATER_PID = 22001
+
+
+def _wmic_listing(entries: dict[int, str]) -> str:
+    """Render ``wmic process get ProcessId,CommandLine /FORMAT:LIST`` output."""
+    blocks = [f"CommandLine={cmd}\nProcessId={pid}\n" for pid, cmd in entries.items()]
+
+    return "\n".join(blocks)
+
+
+def _scan(
+    entries: dict[int, str], ancestors: set[int], exclude: set[int] | None = None
+):
+    """Run the Windows scan arm against a stubbed process table."""
+    result = MagicMock(returncode=0, stdout=_wmic_listing(entries))
+
+    with (
+        patch("hermes_cli.gateway.is_windows", return_value=True),
+        patch("hermes_cli.gateway.shutil.which", return_value="C:/Windows/wmic.exe"),
+        patch("hermes_cli.gateway.subprocess.run", return_value=result),
+        patch("hermes_cli.gateway._get_ancestor_pids", return_value=ancestors),
+        # Stub-collapsing is a separate Windows concern (venv launcher pairs)
+        # and would need a live process table; identity keeps it out of the way.
+        patch(
+            "hermes_cli.gateway._filter_venv_launcher_stubs", side_effect=lambda p: p
+        ),
+    ):
+        return gateway_mod._scan_gateway_pids(exclude or set(), all_profiles=True)
+
+
+class TestAncestorGatewayStaysVisible:
+    def test_gateway_that_spawned_us_is_reported(self):
+        """The #87594 failure: updater spawned by the gateway saw no gateway."""
+        pids = _scan(
+            {GATEWAY_PID: _GATEWAY_CMD, UPDATER_PID: _UPDATER_CMD},
+            ancestors={UPDATER_PID, GATEWAY_PID, 4},
+        )
+
+        assert GATEWAY_PID in pids, (
+            "a real `gateway run` in our ancestor chain is the process the "
+            "update pause path exists to find"
+        )
+
+    def test_updater_ancestor_is_not_reported(self):
+        """The updater is in its own ancestor chain and is not a gateway."""
+        pids = _scan(
+            {GATEWAY_PID: _GATEWAY_CMD, UPDATER_PID: _UPDATER_CMD},
+            ancestors={UPDATER_PID, GATEWAY_PID, 4},
+        )
+
+        assert UPDATER_PID not in pids
+
+    def test_non_gateway_ancestor_is_still_excluded(self):
+        """#13242 must keep holding: the invoking CLI is not a gateway."""
+        pids = _scan({UPDATER_PID: _UPDATER_CMD}, ancestors={UPDATER_PID})
+
+        assert pids == []
+
+    def test_gateway_status_ancestor_is_still_excluded(self):
+        """`gateway status` is the original #13242 case, verbatim."""
+        pids = _scan({4242: _STATUS_CMD}, ancestors={4242})
+
+        assert pids == []
+
+    def test_caller_supplied_exclusions_stay_unconditional(self):
+        """``exclude_pids`` belongs to the caller and outranks the matcher."""
+        pids = _scan(
+            {GATEWAY_PID: _GATEWAY_CMD},
+            ancestors=set(),
+            exclude={GATEWAY_PID},
+        )
+
+        assert pids == []
+
+    def test_unrelated_gateway_is_unaffected(self):
+        """A gateway that is not an ancestor was never in question."""
+        pids = _scan({GATEWAY_PID: _GATEWAY_CMD}, ancestors={UPDATER_PID})
+
+        assert pids == [GATEWAY_PID]
+
+
+@pytest.mark.linux_only
+class TestAncestorGatewayViaProc:
+    """Same contract on the /proc arm, which is what Linux hosts take."""
+
+    def _proc_scan(self, entries: dict[int, str], ancestors: set[int]):
+        def _isdir(path):
+            return str(path) == "/proc"
+
+        def _listdir(path):
+            if str(path) == "/proc":
+                return [str(pid) for pid in entries]
+            raise FileNotFoundError(path)
+
+        def _open(path, mode="r", **kwargs):
+            path_str = str(path)
+            if "/cmdline" not in path_str:
+                raise FileNotFoundError(path)
+            pid = int(path_str.split("/proc/")[1].split("/")[0])
+            handle = MagicMock()
+            handle.read.return_value = (
+                entries.get(pid, "").encode("utf-8").replace(b" ", b"\x00")
+            )
+            handle.__enter__ = lambda s: s
+            handle.__exit__ = MagicMock(return_value=False)
+
+            return handle
+
+        with (
+            patch("os.path.isdir", side_effect=_isdir),
+            patch("os.listdir", side_effect=_listdir),
+            patch("builtins.open", side_effect=_open),
+            patch("hermes_cli.gateway._get_ancestor_pids", return_value=ancestors),
+            patch("subprocess.run"),
+        ):
+            return gateway_mod._scan_gateway_pids(set(), all_profiles=True)
+
+    def test_gateway_that_spawned_us_is_reported(self):
+        pids = self._proc_scan(
+            {
+                GATEWAY_PID: "python -m hermes_cli.main gateway run",
+                UPDATER_PID: "python -m hermes_cli.main update --yes --gateway",
+            },
+            ancestors={UPDATER_PID, GATEWAY_PID, 1},
+        )
+
+        assert GATEWAY_PID in pids
+        assert UPDATER_PID not in pids
+
+    def test_non_gateway_ancestor_is_still_excluded(self):
+        pids = self._proc_scan(
+            {UPDATER_PID: "python -m hermes_cli.main update --yes --gateway"},
+            ancestors={UPDATER_PID},
+        )
+
+        assert pids == []

--- a/tests/hermes_cli/test_gateway_scan_ancestor_gateway.py
+++ b/tests/hermes_cli/test_gateway_scan_ancestor_gateway.py
@@ -25,6 +25,7 @@ import hermes_cli.gateway as gateway_mod
 _GATEWAY_CMD = "C:/h/venv/Scripts/pythonw.exe -m hermes_cli.main gateway run --replace"
 _UPDATER_CMD = "C:/h/venv/Scripts/python.exe -m hermes_cli.main update --yes --gateway"
 _STATUS_CMD = "C:/h/venv/Scripts/python.exe -m hermes_cli.main gateway status"
+_RESTART_CMD = "C:/h/venv/Scripts/pythonw.exe -m hermes_cli.main gateway restart"
 
 GATEWAY_PID = 14112
 UPDATER_PID = 22001
@@ -38,7 +39,10 @@ def _wmic_listing(entries: dict[int, str]) -> str:
 
 
 def _scan(
-    entries: dict[int, str], ancestors: set[int], exclude: set[int] | None = None
+    entries: dict[int, str],
+    ancestors: set[int],
+    exclude: set[int] | None = None,
+    include_restart_managers: bool = False,
 ):
     """Run the Windows scan arm against a stubbed process table."""
     result = MagicMock(returncode=0, stdout=_wmic_listing(entries))
@@ -54,7 +58,75 @@ def _scan(
             "hermes_cli.gateway._filter_venv_launcher_stubs", side_effect=lambda p: p
         ),
     ):
-        return gateway_mod._scan_gateway_pids(exclude or set(), all_profiles=True)
+        return gateway_mod._scan_gateway_pids(
+            exclude or set(),
+            all_profiles=True,
+            include_restart_managers=include_restart_managers,
+        )
+
+
+class TestSuppressionPredicateCannotDiverge:
+    """The suppression predicate must never be narrower than the include one.
+
+    Raised in review: ``_suppressed_as_ancestor`` gates on
+    ``looks_like_gateway_runtime_command_line`` while the include decision uses
+    ``_matches_gateway_runtime``, so a command matching the include predicate
+    but not the suppression one would still be hidden and #87594 would return
+    in that shape. That set is empty today, and these pin it that way rather
+    than leaving the argument in a comment.
+    """
+
+    def test_strict_matcher_is_a_subset_of_the_runtime_matcher(self):
+        """``run`` is in ``{run, restart}``, so strict implies runtime."""
+        from gateway.status import (
+            looks_like_gateway_command_line,
+            looks_like_gateway_runtime_command_line,
+        )
+
+        commands = [
+            _GATEWAY_CMD,
+            _UPDATER_CMD,
+            _STATUS_CMD,
+            _RESTART_CMD,
+            "python -m hermes_cli.main gateway run",
+            "python -m hermes_cli.main gateway dashboard",
+            "hermes gateway run --replace",
+            "hermes gateway restart",
+            "python -m tui_gateway",
+            "",
+        ]
+
+        for command in commands:
+            if looks_like_gateway_command_line(command):
+                assert looks_like_gateway_runtime_command_line(command), (
+                    f"{command!r} is included by the strict matcher but would "
+                    "be suppressed as an ancestor: the two predicates have "
+                    "diverged and #87594 is reachable again"
+                )
+
+    def test_restart_hosted_runtime_ancestor_stays_visible(self):
+        """The other accepted subcommand form, which the first tests omitted.
+
+        A no-supervisor ``gateway restart`` runs ``run_gateway()`` in its own
+        process, so it hosts the runtime and holds the ``.pyd`` files while its
+        argv still says ``restart``. Windows takes exactly this path, because
+        ``include_restart_managers`` is ``not supports_systemd_services()``.
+
+        This does not discriminate between the two candidate gatings: where
+        ``include_restart_managers`` is False a restart process is not included
+        at all, and where it is True both predicates accept it. The difference
+        is robustness under future edits, which
+        ``test_strict_matcher_is_a_subset_of_the_runtime_matcher`` is what
+        actually guards.
+        """
+        pids = _scan(
+            {GATEWAY_PID: _RESTART_CMD, UPDATER_PID: _UPDATER_CMD},
+            ancestors={UPDATER_PID, GATEWAY_PID, 4},
+            include_restart_managers=True,
+        )
+
+        assert GATEWAY_PID in pids
+        assert UPDATER_PID not in pids
 
 
 class TestAncestorGatewayStaysVisible:


### PR DESCRIPTION
## Summary

`hermes update --gateway` is spawned **by** the gateway when a user issues `/update` from a messaging platform. That puts a real `gateway run` process in the updater's own ancestor chain, and `_scan_gateway_pids` was excluding every ancestor unconditionally, so the scan reported no gateway at all.

The consequences, in the order the reporter hits them:

1. `find_gateway_pids(all_profiles=True)` returns `[]`.
2. The update pause path has nothing to pause, so the gateway keeps running.
3. The updater mutates the venv while the gateway still holds its `.pyd` files.
4. The venv-holder guard aborts with `Other Hermes processes are running from this install's venv`.

On Windows step 3 is the one that matters, because open `.pyd` handles cannot be replaced in place, which is exactly why the pause exists. The user is left having to kill the gateway by hand.

The blanket ancestor exclusion came from #13242, whose real case is narrower: keep the CLI that *invoked* the scan (`hermes gateway status`, `hermes update`) from being counted as a running gateway. Two facts make the narrower rule safe:

- `looks_like_gateway_command_line` requires the subcommand to be exactly `run`, and the runtime matcher accepts only `{run, restart}`. Neither `gateway status` nor `update` can match either one.
- The ancestor exclusion is applied **after** the strict matcher has already accepted a process. So by the time it fires, the only thing it can still remove is a genuine gateway runtime, which is precisely the bug.

So this gates the exclusion on the command line instead of removing it: an ancestor that looks like a gateway runtime stays visible, everything else is still suppressed. #13242's behaviour is preserved verbatim.

## Changes

- **`hermes_cli/gateway.py`**
  - Hold the ancestor set separately from `exclude_pids`. `exclude_pids` belongs to the caller and stays unconditional; ancestry is a heuristic that the scan now resolves with the command line in hand.
  - Add `_suppressed_as_ancestor(pid, command)`, true only when the pid is our ancestor **and** its command line does not look like a gateway runtime.
  - Wire it into all three scan arms so behaviour is identical everywhere: Windows `wmic`, POSIX `/proc`, and the `ps` fallback.
- **`tests/hermes_cli/test_gateway_scan_ancestor_gateway.py`** (new): 8 regression tests.

I deliberately did **not** take the larger option of dropping the ancestor exclusion entirely. It would also fix the bug, and the analysis above suggests it is probably safe, but it changes behaviour for every caller rather than only the broken one, and the #13242 report is old enough that I would rather keep its guarantee mechanical than argue it away.

`ruff format` wants to reformat pre-existing unrelated code in `hermes_cli/gateway.py` (the PATH concatenation near the top and several `text=True, encoding=...` blocks). That is already true on a clean `upstream/main`, so I left it alone rather than bury this diff in unrelated churn.

## Testing

New file, 8 cases:

- `TestAncestorGatewayStaysVisible` (6 cases, Windows arm). Stubbed end to end so it runs on any host, since Windows is where the reported failure lives.
- `TestAncestorGatewayViaProc` (2 cases, `@pytest.mark.linux_only`). Same contract through the `/proc` arm that Linux hosts actually take.

Both the fix case and the #13242 guardrails are covered on purpose:

| Test | Asserts |
| --- | --- |
| `test_gateway_that_spawned_us_is_reported` | the reported bug: a real `gateway run` ancestor is found |
| `test_updater_ancestor_is_not_reported` | the updater is in its own chain and is still not a gateway |
| `test_non_gateway_ancestor_is_still_excluded` | #13242 still holds |
| `test_gateway_status_ancestor_is_still_excluded` | #13242's original case, verbatim |
| `test_caller_supplied_exclusions_stay_unconditional` | `exclude_pids` still outranks the matcher |
| `test_unrelated_gateway_is_unaffected` | a non-ancestor gateway was never in question |

Verified the tests actually catch the regression by stashing `hermes_cli/gateway.py` and re-running:

```
$ git stash push hermes_cli/gateway.py
$ pytest tests/hermes_cli/test_gateway_scan_ancestor_gateway.py -q
1 failed, 5 passed, 2 skipped

test_gateway_that_spawned_us_is_reported
  AssertionError: a real `gateway run` in our ancestor chain is the process the
  update pause path exists to find
  assert 14112 in []
```

That empty list is the reporter's `list(find_gateway_pids(all_profiles=True)) == []`. The two #13242 guardrail tests pass both before and after the fix, which is the evidence that the older contract is not loosened.

With the fix applied:

```
$ pytest tests/hermes_cli/test_gateway_scan_ancestor_gateway.py -q
6 passed, 2 skipped

$ pytest tests/hermes_cli/test_gateway.py tests/hermes_cli/test_gateway_proc_fallback.py \
         tests/hermes_cli/test_gateway_windows.py \
         tests/hermes_cli/test_gateway_scan_ancestor_gateway.py \
         tests/hermes_cli/test_subcommands_profile_gateway.py -q
39 passed, 9 skipped

$ ruff check hermes_cli/gateway.py tests/hermes_cli/test_gateway_scan_ancestor_gateway.py
All checks passed!

$ python scripts/check-windows-footguns.py --all
973 files checked, no issues
```

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor / code quality
- [ ] Test coverage

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (no user-facing behaviour change; the fix restores the documented pause)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Cross-platform

- [x] No hardcoded path separators; nothing new touches paths at all
- [x] All three scan arms updated identically, so Windows, Linux `/proc`, and the `ps` fallback share one rule
- [x] Windows behaviour is covered by tests that run on every host, not gated behind a marker
- [x] `scripts/check-windows-footguns.py --all` clean

Fixes #87594
