### PR TITLE
fix(state): WAL probe fallback, bare-SELECT locking, writable_schema finally, read-pool self-heal

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -3672,28 +3672,42 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         """
         conn = self._checkout_read_conn()
         if conn is not None:
+            broken = False
             try:
                 yield conn
+            except sqlite3.DatabaseError:
+                # A DatabaseError marks the pooled read connection as broken
+                # or stale (backing file replaced / truncated — the same
+                # scenario _reconnect_after_notadb self-heals on the write
+                # side). Destroy it instead of returning it to the pool so
+                # the next checkout reopens; otherwise the LIFO order hands
+                # the same broken connection to every subsequent query until
+                # process restart.
+                broken = True
+                raise
             finally:
-                returned = False
-                with self._read_conns_lock:
-                    if not self._read_conns_closed:
-                        try:
-                            self._read_pool.put_nowait(conn)
-                            returned = True
-                        except queue.Full:
-                            pass
-                if not returned:
-                    # close() has already drained the pool, so this connection
-                    # is surplus. Close it here — dropping it on the floor is
-                    # what leaked the fd.
-                    #
-                    # queue.Full is now unreachable in practice (permits and
-                    # maxsize are both _READ_POOL_MAX, so there can never be a
-                    # ninth connection to return), but the branch stays: it is
-                    # load-bearing if those two ever drift apart, and a leak is
-                    # the failure mode it prevents.
+                if broken:
                     self._close_read_conn(conn)
+                else:
+                    returned = False
+                    with self._read_conns_lock:
+                        if not self._read_conns_closed:
+                            try:
+                                self._read_pool.put_nowait(conn)
+                                returned = True
+                            except queue.Full:
+                                pass
+                    if not returned:
+                        # close() has already drained the pool, so this connection
+                        # is surplus. Close it here — dropping it on the floor is
+                        # what leaked the fd.
+                        #
+                        # queue.Full is now unreachable in practice (permits and
+                        # maxsize are both _READ_POOL_MAX, so there can never be a
+                        # ninth connection to return), but the branch stays: it is
+                        # load-bearing if those two ever drift apart, and a leak is
+                        # the failure mode it prevents.
+                        self._close_read_conn(conn)
             return
         with self._lock:
             yield self._conn

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -6668,11 +6668,15 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         if not session_id:
             return None
         now = time.time()
-        row = self._conn.execute(
-            "SELECT holder FROM compression_locks "
-            "WHERE session_id = ? AND expires_at >= ?",
-            (session_id, now),
-        ).fetchone()
+        # Read via _read_ctx (degrades to self._lock when WAL is inactive) —
+        # a bare self._conn read joins any in-flight BEGIN IMMEDIATE
+        # transaction and can see rows that later roll back.
+        with self._read_ctx() as conn:
+            row = conn.execute(
+                "SELECT holder FROM compression_locks "
+                "WHERE session_id = ? AND expires_at >= ?",
+                (session_id, now),
+            ).fetchone()
         if row is None:
             return None
         return row["holder"] if isinstance(row, sqlite3.Row) else row[0]
@@ -6746,11 +6750,16 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         # No-op fast path: skip the transaction when there is nothing to
         # clear. Read-only, no write lock.
         try:
-            row = self._conn.execute(
-                "SELECT last_activity_description, last_activity_provenance "
-                "FROM sessions WHERE id = ?",
-                (session_id,),
-            ).fetchone()
+            # Read via _read_ctx (degrades to self._lock when WAL is
+            # inactive) — a bare self._conn read joins any in-flight
+            # BEGIN IMMEDIATE transaction and can see rows that later
+            # roll back.
+            with self._read_ctx() as conn:
+                row = conn.execute(
+                    "SELECT last_activity_description, last_activity_provenance "
+                    "FROM sessions WHERE id = ?",
+                    (session_id,),
+                ).fetchone()
         except sqlite3.Error:
             row = None
         if row is not None:
@@ -12924,12 +12933,17 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         no handoff record.
         """
         try:
-            cur = self._conn.execute(
-                "SELECT handoff_state, handoff_platform, handoff_error "
-                "FROM sessions WHERE id = ?",
-                (session_id,),
-            )
-            row = cur.fetchone()
+            # Read via _read_ctx (degrades to self._lock when WAL is
+            # inactive) — a bare self._conn read joins any in-flight
+            # BEGIN IMMEDIATE transaction and can see rows that later
+            # roll back.
+            with self._read_ctx() as conn:
+                cur = conn.execute(
+                    "SELECT handoff_state, handoff_platform, handoff_error "
+                    "FROM sessions WHERE id = ?",
+                    (session_id,),
+                )
+                row = cur.fetchone()
             if not row:
                 return None
             return {
@@ -12946,15 +12960,20 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         Used by the gateway's handoff watcher.
         """
         try:
-            cur = self._conn.execute(
-                "SELECT s.*, "
-                "COALESCE(sp.prompt, s.system_prompt) AS _system_prompt_resolved "
-                "FROM sessions s "
-                "LEFT JOIN system_prompts sp ON sp.hash = s.system_prompt_hash "
-                "WHERE s.handoff_state = 'pending' "
-                "ORDER BY s.started_at ASC"
-            )
-            return [self._session_row_dict(r) for r in cur.fetchall()]
+            # Read via _read_ctx (degrades to self._lock when WAL is
+            # inactive) — a bare self._conn read joins any in-flight
+            # BEGIN IMMEDIATE transaction and can see rows that later
+            # roll back.
+            with self._read_ctx() as conn:
+                cur = conn.execute(
+                    "SELECT s.*, "
+                    "COALESCE(sp.prompt, s.system_prompt) AS _system_prompt_resolved "
+                    "FROM sessions s "
+                    "LEFT JOIN system_prompts sp ON sp.hash = s.system_prompt_hash "
+                    "WHERE s.handoff_state = 'pending' "
+                    "ORDER BY s.started_at ASC"
+                )
+                return [self._session_row_dict(r) for r in cur.fetchall()]
         except Exception:
             return []
 

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -1318,7 +1318,12 @@ def _apply_delete_for_wal_reset_bug(
                 "this process does not exclusively own"
             )
         _log_wal_reset_bug_once(db_label, kept_wal=True, indeterminate=True)
-        return "wal"
+        # Report "delete", not "wal", for the indeterminate probe: claiming
+        # "wal" would set _wal_active=True and enable the lock-free read pool
+        # on a DB that may actually be in rollback-journal mode (raw
+        # SQLITE_BUSY on reads); claiming "delete" only costs queuing on the
+        # write lock — slow but correct.
+        return "delete"
 
     actual = ""
     try:

--- a/hermes_state_search.py
+++ b/hermes_state_search.py
@@ -699,12 +699,18 @@ class SessionSearchMixin:
             ).fetchone())
             if had:
                 conn.execute("PRAGMA writable_schema=ON")
-                conn.execute(
-                    "DELETE FROM sqlite_master WHERE type = 'table' "
-                    "AND name IN ('messages_fts', 'messages_fts_trigram') "
-                    "AND sql LIKE 'CREATE VIRTUAL TABLE%'"
-                )
-                conn.execute("PRAGMA writable_schema=RESET")
+                try:
+                    conn.execute(
+                        "DELETE FROM sqlite_master WHERE type = 'table' "
+                        "AND name IN ('messages_fts', 'messages_fts_trigram') "
+                        "AND sql LIKE 'CREATE VIRTUAL TABLE%'"
+                    )
+                finally:
+                    # writable_schema is a connection-level switch that does
+                    # not roll back with the transaction — RESET must run even
+                    # when the DELETE raises, or the long-lived write
+                    # connection stays degraded until process exit.
+                    conn.execute("PRAGMA writable_schema=RESET")
                 shadows = [
                     r[0] for r in conn.execute(
                         "SELECT name FROM sqlite_master WHERE type = 'table' "


### PR DESCRIPTION
## Summary

Four independent SQLite/state-layer fixes, one commit each:

- **fix(state): report delete, not wal, for the indeterminate journal-mode probe** — when the WAL-reset-bug probe is indeterminate, returning `"wal"` wrongly enables the lock-free read pool; the conservative `"delete"` keeps reads serialized through `_lock`. Closes #86515
- **fix(state): route four bare-SELECT read paths through `_read_ctx`** — `get_compression_lock_holder`, the `clear_session_activity_labels` fast path, `get_handoff_state`, and `list_pending_handoffs` read on the shared write connection and can observe uncommitted data. Closes #86516
- **fix(state_search): reset writable_schema in a finally** — the legacy-FTS demote left `PRAGMA writable_schema=ON` latched on the long-lived write connection when the DELETE raised. Closes #86517
- **fix(state): destroy broken read-pool connections instead of returning them** — `_read_ctx` now mirrors the write side's `_reconnect_after_notadb` self-heal: a `DatabaseError` checkout is closed (permit released) instead of being returned to the pool. Closes #86518

## Tests

359 passed / 19 skipped across 15 related test files (hermes_state, session_db read pool/path split, state_db malformed/notadb self-heal, FTS search), plus 150 passed in `tests/hermes_state/`. No failures.
