### PR TITLE
fix(skills): preserve quarantine newlines on Windows

### DIFF
--- a/tests/tools/test_skills_hub.py
+++ b/tests/tools/test_skills_hub.py
@@ -427,9 +427,9 @@ class TestCheckForSkillUpdates:
         )
         skill_dir = tmp_path / "demo-skill"
         skill_dir.mkdir()
-        (skill_dir / "SKILL.md").write_text("same content")
+        (skill_dir / "SKILL.md").write_text("same content", encoding="utf-8", newline="")
         (skill_dir / "references").mkdir()
-        (skill_dir / "references" / "checklist.md").write_text("- [ ] security\n")
+        (skill_dir / "references" / "checklist.md").write_text("- [ ] security\n", encoding="utf-8", newline="")
 
         assert bundle_content_hash(bundle) == content_hash(skill_dir)
 

--- a/tests/tools/test_skills_hub_crlf.py
+++ b/tests/tools/test_skills_hub_crlf.py
@@ -1,0 +1,75 @@
+"""Focused regression tests for quarantine_bundle CRLF symmetry.
+
+Demonstrates the Windows text-mode newline translation bug and the fix:
+the quarantine write path must prevent implicit CRLF translation so the
+bytes on disk equal the bytes whose content hash is expected.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tools.skills_hub import quarantine_bundle
+
+
+@pytest.fixture
+def skills_root(tmp_path, monkeypatch):
+    """Isolate the skills dir (and thus the quarantine root) under tmp_path."""
+    import tools.skills_hub as sh
+
+    root = tmp_path / "skills"
+    root.mkdir()
+    monkeypatch.setattr(sh, "_skills_dir", lambda: root)
+    return root
+
+
+def _bundle(files):
+    from tools.skills_hub import SkillBundle
+
+    return SkillBundle(
+        name="crlf-demo",
+        files=files,
+        source="github",
+        identifier="owner/repo/crlf-demo",
+        trust_level="community",
+    )
+
+
+class TestQuarantineCRLFSymmetry:
+    def test_quarantine_write_preserves_lf_bytes(self, skills_root):
+        """On Windows, writing through a text-mode file would translate
+        ``\\n`` to ``\\r\\n``; the quarantine write path must preserve the
+        exact in-memory bytes so the on-disk hash matches the bundle hash."""
+        files = {"SKILL.md": "line one\nline two\n"}
+        bundle = _bundle(files)
+        dest = quarantine_bundle(bundle)
+
+        # The written bytes must match the in-memory bytes exactly.
+        written = (dest / "SKILL.md").read_bytes()
+        assert written == b"line one\nline two\n", (
+            f"quarantine wrote {written!r}; expected LF-only bytes"
+        )
+        assert b"\r\n" not in written
+
+    def test_quarantine_hash_matches_bundle_hash(self, skills_root):
+        """The on-disk quarantine content hash must equal the bundle content
+        hash — otherwise an update check after quarantine would see a
+        mismatch and report a false update."""
+        from tools.skills_hub import bundle_content_hash
+        from tools.skills_guard import content_hash
+
+        files = {"SKILL.md": "a\nb\nc\n", "notes.txt": "x\ny\n"}
+        bundle = _bundle(files)
+        dest = quarantine_bundle(bundle)
+
+        assert content_hash(dest) == bundle_content_hash(bundle)
+
+    def test_crlf_input_bytes_preserved_as_is(self, skills_root):
+        """If the bundle itself carries CRLF bytes, they are preserved —
+        the fix only disables *implicit* translation, it never rewrites
+        content."""
+        files = {"SKILL.md": "a\r\nb\r\n"}
+        bundle = _bundle(files)
+        dest = quarantine_bundle(bundle)
+        written = (dest / "SKILL.md").read_bytes()
+        assert written == b"a\r\nb\r\n"

--- a/tools/skills_hub.py
+++ b/tools/skills_hub.py
@@ -3853,7 +3853,9 @@ def quarantine_bundle(bundle: SkillBundle) -> Path:
         if isinstance(file_content, bytes):
             file_dest.write_bytes(file_content)
         else:
-            file_dest.write_text(file_content, encoding="utf-8")
+            # newline="" prevents implicit platform CRLF translation so the
+            # written bytes stay hash-symmetric with the in-memory bundle.
+            file_dest.write_text(file_content, encoding="utf-8", newline="")
 
     return dest
 


### PR DESCRIPTION
## What does this PR do?

On Windows, `Path.write_text(str, encoding="utf-8")` in `quarantine_bundle()` opens the file in text mode, which translates every `\n` to `\r\n` on disk. The skills registry hashes in-memory bundle content with `bundle_content_hash()` (str → utf-8 bytes) but hashes on-disk files with `content_hash()` (raw bytes). This produces a permanent hash mismatch on Windows:

- LF-only bundles land on disk as CRLF → can cause a persistent false `update_available` for affected text-based skills on Windows when newline translation changes the hashed bytes;
- Explicit CRLF in a bundle is doubled (`\r\r\n`), corrupting content bytes on install.

The fix is one line: write quarantine text entries with `newline=""` so no platform newline translation occurs. `newline=""` disables implicit newline translation, preserving the supplied newline characters.

Also corrects the existing `test_bundle_content_hash_matches_installed_content_hash` test harness (in `tests/tools/test_skills_hub.py`), which previously wrote its own fixture files with default `write_text` and would therefore fail its own hash-symmetry assertion on Windows.

## Related Issue

No matching issue found. Issue #41176 describes a similar symptom (permanent `update_available`) but with a different root cause (lock content_hash not refreshed on update).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- **`tools/skills_hub.py`** — `quarantine_bundle()`: write str content with `encoding="utf-8", newline=""` to prevent implicit Windows CRLF translation (1 line + comment)
- **`tests/tools/test_skills_hub_crlf.py`** (new) — 3 focused regression tests:
  1. LF content written as LF bytes
  2. Quarantine content hash equals bundle content hash
  3. Explicit CRLF preserved exactly (not doubled)
- **`tests/tools/test_skills_hub.py`** — Fix 2 `write_text` calls in `test_bundle_content_hash_matches_installed_content_hash` to use `newline=""` so the test fixture matches how quarantine now writes. Without this, the test itself would fail on Windows due to the same bug it asserts against.

## How to Test

```bash
# New dedicated CRLF tests
cd <clone> && python -m pytest tests/tools/test_skills_hub_crlf.py -v

# Existing quarantine + hash tests
python -m pytest tests/tools/test_skills_hub.py -k "quarantine or content_hash or hash" -v
```

Baseline confirmation (patch stashed, Windows host):
- The new 3 CRLF tests all fail on pristine upstream (LF→CRLF, hash mismatch, CRLF doubling).
- After the fix, all pass.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(skills): ...`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've run `pytest tests/tools/test_skills_hub_crlf.py` and `pytest tests/tools/test_skills_hub.py -k "quarantine or content_hash or hash"` — all pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: **Windows 11**

### Documentation & Housekeeping

- [x] I've considered cross-platform impact (Windows, macOS): `newline=""` disables implicit newline translation on all platforms; no code change needed for POSIX behavior
- [ ] Updated documentation — N/A (bug fix, no new feature)
- [ ] Updated config examples — N/A

## Screenshots / Logs

No public artifacts (owner-local only). Test evidence recorded inline:

- `python -m pytest tests/tools/test_skills_hub_crlf.py -v` → 3/3 PASSED (exit 0)
- `python -m pytest tests/tools/test_skills_hub.py -k "quarantine or content_hash or hash" -v` → 14 passed, 1 skipped (exit 0)

Baseline confirmation (patch stashed, pristine upstream, Windows host):
- The 3 new CRLF tests all fail on pristine upstream (LF→CRLF, hash mismatch, CRLF doubling).
- After the fix, all pass.
