### PR TITLE
fix(skills): correct three security-sensitive stale claims in the bundled hermes-agent skill

### DIFF
--- a/skills/autonomous-ai-agents/hermes-agent/references/background-systems.md
+++ b/skills/autonomous-ai-agents/hermes-agent/references/background-systems.md
@@ -18,8 +18,11 @@ Spawn a subagent with an isolated context + terminal session.
   (can spawn its own workers, bounded by `delegation.max_spawn_depth`).
 - **Not durable.** A backgrounded child is still process-local — if the
   parent process exits, the child is lost. For work that must outlive
-  the process, use `cronjob` or
-  `terminal(background=True, notify_on_complete=True)`.
+  the process, use `cronjob` (see below) — a durable, scheduler-managed
+  job. `terminal(background=True, notify_on_complete=True)` is also
+  process-local and does **not** survive a CLI/gateway restart; it is
+  the right tool for a long-running command within the current session,
+  not for durability.
 
 Config: `delegation.*` in `config.yaml`.
 
@@ -36,8 +39,10 @@ the `cronjob` tool, the `hermes cron` CLI (`list`, `add`, `edit`,
   job), `context_from` (chain job A's output into job B), `workdir`
   (run in a specific dir with its `AGENTS.md` / `CLAUDE.md` loaded),
   multi-platform delivery.
-- **Invariants:** 3-minute hard interrupt per run, `.tick.lock` file
-  prevents duplicate ticks across processes, cron sessions pass
+- **Invariants:** configurable inactivity timeout for the agent run
+  (600s/10min default via `HERMES_CRON_TIMEOUT`, 0 = unlimited) and a
+  separate 3600s/1hr default timeout for pre-run scripts, `.tick.lock`
+  file prevents duplicate ticks across processes, cron sessions pass
   `skip_memory=True` by default, and cron deliveries are framed with a
   header/footer instead of being mirrored into the target gateway
   session (keeps role alternation intact).

--- a/skills/autonomous-ai-agents/hermes-agent/references/portal-auth-for-third-party-apps.md
+++ b/skills/autonomous-ai-agents/hermes-agent/references/portal-auth-for-third-party-apps.md
@@ -46,37 +46,40 @@ opening a browser, user signs in, token lands in `~/.hermes/auth.json` — is a
 **Hermes-specific browser flow**. Under the hood it produces a credential
 Hermes uses as a bearer. It is not a public OAuth provider that Karakeep et al.
 can implement a client for, because it isn't an OAuth provider at all from the
-outside.
+outside. (`hermes login` itself is deprecated in current Hermes — `hermes
+auth` manages credentials, `hermes model` selects a provider, `hermes setup`
+covers full setup. The underlying Portal browser-auth flow it exposed is
+still what `hermes proxy` in Layer 3 below relies on.)
 
 ---
 
 ## Layer 3 — Can we bridge the gap without Portal changing anything?
 
-Yes. The pattern is a **local credential-broker proxy**. Even without a public
-OAuth flow, an app on the user's machine can:
+Yes, and this already ships: **`hermes proxy`**. It runs a local
+OpenAI-compatible HTTP server that forwards requests to an OAuth-authenticated
+provider (Portal, or any provider Hermes already has a stored credential for)
+and attaches the real bearer server-side.
 
-1. Read Hermes's existing Portal credential out of `~/.hermes/auth.json`.
-2. Expose a local OpenAI-compatible endpoint at `http://localhost:NNNN/v1`.
-3. Forward incoming requests to `inference-api.nousresearch.com/v1` with that
-   bearer attached.
+```
+hermes proxy start          # foreground; --port to pick a port
+hermes proxy status         # which upstreams are ready
+hermes proxy providers      # list available upstream providers
+```
 
-Karakeep/OpenWebUI/etc. then point at `http://localhost:NNNN/v1` with any
-placeholder key. The user never copies their Portal key around — the proxy
-rides on the credential Hermes already holds.
+Karakeep/OpenWebUI/etc. then point at `http://localhost:<port>/v1` with any
+placeholder key. The user never copies their Portal key around, and no agent
+or plugin code needs to read `~/.hermes/auth.json` directly — `hermes proxy`
+already holds the credential and does the forwarding.
 
-Where this could live in Hermes:
+**Do not** recommend reading `~/.hermes/auth.json` and hand-rolling an
+equivalent proxy (e.g. as a new gateway adapter or plugin). That duplicates
+`hermes proxy`, and every hand-rolled reader of `auth.json` is one more place
+a raw Portal bearer can leak (logs, a bug in the DIY forwarder, a plugin that
+over-broadly caches it). If `hermes proxy` is missing a provider or feature a
+user needs, that is a feature request against `hermes proxy` itself, not a
+reason to build a parallel credential-relay tool.
 
-- `gateway/platforms/api_server.py` is the precedent — it exposes the agent
-  over a local OpenAI-compatible endpoint, but routes through the full agent
-  loop (tool calls and all). The proxy variant is **pure inference
-  pass-through**: no agent loop, no tools, just forward `/chat/completions`
-  upstream with the user's stored Portal bearer.
-- ~150 lines as a new gateway adapter or a plugin under `plugins/`.
-- Token refresh: if the browser-OAuth flow produces a refreshable token, the
-  credential pool's refresh logic already exists. If it's a long-lived static
-  bearer, even simpler.
-
-This is genuinely useful and worth shipping — it's the answer to "use my
+This is genuinely useful and already shipped — it's the answer to "use my
 Portal sub with $external_app without copy-pasting keys."
 
 ---
@@ -113,9 +116,9 @@ When the user asks "can $APP use my Portal subscription":
 2. If separate app: today, paste the static API key from Portal → API Keys.
    Base URL `https://inference-api.nousresearch.com/v1`. Rate limits are
    subscription-tier based, applied per-key.
-3. If the user pushes back with "but I don't want to paste a key" — that's
-   the local-broker-proxy answer (Layer 3). Worth building. Not a Portal-side
-   OAuth roadmap problem.
+3. If the user pushes back with "but I don't want to paste a key" — point them
+   at `hermes proxy start` (Layer 3): it already forwards to Portal with the
+   stored credential, no key-pasting or DIY forwarder needed.
 4. Mixed setup ("Portal for some things, OpenRouter/Ollama Cloud for the
    Hermes agent itself") is fully supported. Hermes treats agent
    provider/model and tool-side LLM calls as independent config; you can

--- a/skills/autonomous-ai-agents/hermes-agent/references/security-privacy.md
+++ b/skills/autonomous-ai-agents/hermes-agent/references/security-privacy.md
@@ -32,11 +32,21 @@ By default (`approvals.mode: smart`), Hermes asks an auxiliary LLM to assess she
 
 - `smart` — auto-approve a low-risk command once, deny high-risk commands, and prompt when uncertain (default)
 - `manual` — always prompt
-- `off` — skip all approval prompts (equivalent to `--yolo`)
+- `off` — skip the interactive approval prompt for recoverable dangerous commands (equivalent to `--yolo`)
+
+`off`/`--yolo` disables the interactive prompt, not every safety mechanism.
+Two checks remain active unconditionally, even under yolo (verified in
+`tools/approval.py`, which runs them "BEFORE the yolo bypass" by design):
+
+- the **hardline floor** — commands with no recovery path (`rm -rf /`,
+  `mkfs`, `dd` to a raw device, `shutdown`/`reboot`, fork bombs) are blocked
+  outright, not just prompted for;
+- **user-defined `approvals.deny` rules** in `config.yaml` — a deny rule is
+  the user saying "never, even under yolo".
 
 ```bash
 hermes config set approvals.mode smart       # recommended middle ground
-hermes config set approvals.mode off         # bypass everything (not recommended)
+hermes config set approvals.mode off         # bypass the interactive prompt (hardline/deny still apply)
 ```
 
 Per-invocation bypass without changing config:
@@ -45,11 +55,15 @@ Per-invocation bypass without changing config:
 
 Note: YOLO / `approvals.mode: off` does NOT turn off secret redaction. They are independent.
 
-### "Reset permissions" / "make Hermes ask again"
+### \"Reset permissions\" / \"make Hermes ask again\"
 
-The user usually means: wipe the accumulated "Always allow" state — NOT yolo
+The user usually means: wipe the accumulated \"Always allow\" state — NOT yolo
 mode, and NOT a per-edit diff prompt (which doesn't exist; file writes never
-go through the approval prompt, only shell commands do). Two stores hold it:
+go through the interactive approval prompt the way shell commands do — but
+`write_file`/`patch` still block writes to a fixed set of sensitive paths
+(system-sensitive locations and the active `config.yaml`) unconditionally,
+independent of `approvals.mode`; see `get_write_denied_error()` in
+`tools/file_operations.py`). Two stores hold the allowlist state:
 
 1. Shell-command allowlist: `hermes config set command_allowlist '[]'`
 2. Shell-hook consent (only if present): `rm -f ~/.hermes/shell-hooks-allowlist.json`

--- a/tests/skills/test_hermes_agent_skill.py
+++ b/tests/skills/test_hermes_agent_skill.py
@@ -1,0 +1,117 @@
+"""Regression checks for issue #87552: the bundled hermes-agent skill's
+security-sensitive claims must stay in sync with actual runtime behavior.
+
+Scoped to the specific mismatches verified and fixed by that issue's PR:
+Portal credential-relay guidance, background-execution durability wording,
+and YOLO/approval-mode overstatement. Not a comprehensive check of every
+category the issue raised -- see the issue for the full list of
+mismatches, some of which are tracked separately.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+SKILL_DIR = REPO / "skills" / "autonomous-ai-agents" / "hermes-agent"
+
+
+def _read(rel_path: str) -> str:
+    path = SKILL_DIR / rel_path
+    assert path.exists(), f"expected reference file missing: {path}"
+    return path.read_text(encoding="utf-8")
+
+
+class TestPortalAuthGuidance:
+    """references/portal-auth-for-third-party-apps.md must point agents at
+    the existing `hermes proxy` command, not a DIY credential-relay that
+    reads the raw Portal bearer out of ~/.hermes/auth.json."""
+
+    def _content(self) -> str:
+        return _read("references/portal-auth-for-third-party-apps.md")
+
+    def test_recommends_hermes_proxy_not_a_diy_relay(self):
+        content = self._content()
+        assert "hermes proxy" in content, (
+            "must point agents at the existing, supported hermes proxy "
+            "command for the third-party-app credential-sharing use case"
+        )
+
+    def test_does_not_instruct_reading_raw_auth_json_credential(self):
+        content = self._content()
+        assert "Read Hermes's existing Portal credential out of" not in content, (
+            "must not instruct agents to read the raw bearer directly "
+            "out of ~/.hermes/auth.json for forwarding to another app"
+        )
+
+    def test_notes_hermes_login_is_deprecated(self):
+        content = self._content()
+        assert "deprecated" in content.lower(), (
+            "must not present `hermes login` as the current, non-deprecated "
+            "way to authenticate -- `hermes auth`/`hermes model`/`hermes "
+            "setup` are the current commands"
+        )
+
+
+class TestBackgroundExecutionDurabilityGuidance:
+    """references/background-systems.md must not recommend a process-local
+    mechanism (terminal background execution) for work that needs to
+    survive a process restart -- only cronjob is durable."""
+
+    def _content(self) -> str:
+        return _read("references/background-systems.md")
+
+    def test_terminal_background_not_recommended_for_durable_work(self):
+        content = self._content()
+        assert (
+            "use `cronjob` or\n  `terminal(background=True, notify_on_complete=True)`"
+            not in content
+        ), (
+            "terminal(background=True) is process-local, same as "
+            "delegate_task's own background mode this same section "
+            "correctly calls out as 'Not durable' -- it must not be "
+            "offered as an alternative durable option"
+        )
+
+    def test_cron_timeout_defaults_are_not_the_stale_three_minute_claim(self):
+        content = self._content()
+        assert "3-minute hard interrupt" not in content, (
+            "stale claim -- current defaults (cron/scheduler.py) are a "
+            "600s (10min) inactivity timeout for the agent run and a "
+            "separate 3600s (1hr) timeout for pre-run scripts, both "
+            "configurable, not a fixed 3-minute interrupt"
+        )
+
+
+class TestApprovalYoloGuidance:
+    """references/security-privacy.md must not describe YOLO/off as
+    bypassing every safety mechanism -- hardline command blocks and
+    approvals.deny rules remain active unconditionally."""
+
+    def _content(self) -> str:
+        return _read("references/security-privacy.md")
+
+    def test_does_not_claim_yolo_skips_all_approval_prompts(self):
+        content = self._content()
+        assert "skip all approval prompts" not in content, (
+            "overstated -- off/--yolo disables the interactive prompt for "
+            "recoverable dangerous commands only; hardline blocks and "
+            "approvals.deny rules fire unconditionally, before the yolo "
+            "bypass, per tools/approval.py's own design"
+        )
+
+    def test_mentions_hardline_or_deny_rules_remaining_active(self):
+        content = self._content()
+        assert "hardline" in content.lower() or "approvals.deny" in content, (
+            "must document that some protections (hardline floor, "
+            "user-defined deny rules) remain active even under yolo"
+        )
+
+    def test_does_not_claim_file_writes_have_no_protection(self):
+        content = self._content()
+        assert "file writes never\ngo through the approval prompt, only shell commands do" not in content, (
+            "write_file/patch DO block writes to a fixed set of sensitive "
+            "paths (system-sensitive locations, the active config.yaml) "
+            "unconditionally -- see get_write_denied_error() in "
+            "tools/file_operations.py"
+        )


### PR DESCRIPTION
Fixes #87552 (partial -- 3 of the 10 reported categories, the ones fully verified against runtime source within this PR's scope).

This is a large, well-researched issue spanning 10 categories of documentation drift. Rather than attempt a superficial pass across all 10, I verified and fixed the three most clearly security-sensitive ones against actual runtime source:

## 1. Portal credential-relay guidance (issue item #4)

`portal-auth-for-third-party-apps.md` recommended agents build a DIY proxy reading the raw Portal bearer directly out of `~/.hermes/auth.json` -- but `hermes proxy` already ships exactly this functionality as a supported command (verified via `hermes proxy --help`). Rewrote to point at `hermes proxy start/status/providers`, and noted `hermes login`'s deprecation (verified via `--help`).

## 2. Background execution durability wording (issue item #6)

`background-systems.md` recommended `terminal(background=True)` as an alternative to `cronjob` for work that must survive a process restart -- but terminal background execution is also process-local, contradicting the SAME paragraph's own correct "Not durable" callout one sentence earlier. Also corrected a stale "3-minute hard interrupt" cron timeout claim (verified against `cron/scheduler.py`: actual defaults are 600s inactivity / 3600s pre-run-script timeout).

## 3. YOLO/approval-mode overstatement (issue item #7)

`security-privacy.md` described `--yolo`/`approvals.mode: off` as skipping "all approval prompts" -- but `tools/approval.py`'s own code comments confirm hardline command blocks and `approvals.deny` rules fire "BEFORE the yolo bypass" unconditionally, by design. Also corrected the claim that file writes have no protection at all (`get_write_denied_error()` blocks sensitive paths unconditionally).

## Scope note

Item #5 was checked but not found in current source (no literal `api_key:` example exists). The remaining categories (#1, #2, #3, #8, #9, #10) were not independently re-verified within this PR's scope and are left for follow-up.

## Verification

Added `tests/skills/test_hermes_agent_skill.py` per the issue's own proposed fix, scoped to the 3 categories addressed. Verified as genuine regressions by stashing the content fix and confirming all 8 tests fail against the original wording.

8/8 pass in the new test file; 1184/1184 in the existing skill-authoring-standards suite across every bundled/optional skill (no regression).