### PR TITLE
fix(kanban): skip the dispatch tick when the lock file cannot be opened

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -1738,9 +1738,27 @@ def _dispatch_tick_lock(db_path: Path):
             except (BlockingIOError, OSError):
                 acquired = False
     except OSError:
-        # Could not even open the lock file (permissions, read-only FS).
-        # Degrade to a no-op so a probe failure never blocks dispatch.
-        acquired = True
+        # Could not even open the lock file: antivirus or a sync client
+        # (OneDrive, Dropbox) holding it open on Windows, a permissions blip, a
+        # read-only mount. Skip this tick rather than proceeding as if we held
+        # the lock, because we cannot tell an unlockable file from a file
+        # another dispatcher already owns, and guessing "nobody owns it" is the
+        # multi-writer case this lock exists to prevent (#35240).
+        #
+        # Deliberately NOT the same call the docstring reserves for a platform
+        # with no fcntl/msvcrt, which is meant to degrade to a no-op: a missing
+        # locking primitive is a permanent property of the platform, so failing
+        # closed there would disable dispatch forever, while this is transient
+        # and re-evaluated every tick. Skipping is already the documented
+        # behaviour of a dispatcher that loses the lock, so the cost of being
+        # wrong here is one deferred interval rather than an outage.
+        #
+        # (That no-op is currently unreachable: the import sites below catch
+        # OSError / AttributeError, and a missing module raises ImportError,
+        # which is neither. Out of scope for this fix - it is a crash rather
+        # than a fail-open, in a branch this change does not touch - and is
+        # tracked separately in #89653.)
+        acquired = False
         handle = None
     try:
         yield acquired

--- a/tests/hermes_cli/test_kanban_dispatch_lock.py
+++ b/tests/hermes_cli/test_kanban_dispatch_lock.py
@@ -77,3 +77,62 @@ def test_lock_is_board_scoped(conn):
             assert held_b is True, "a lock on a different board must be independent"
 
 
+def test_unopenable_lock_file_skips_the_tick(conn, monkeypatch):
+    """A lock file we cannot even open must SKIP the tick, not proceed (#87609).
+
+    Regression: the open failure degraded to ``acquired = True``, so the tick
+    ran as though it held the board lock. That is the multi-writer case the
+    lock exists to prevent, and it fires on exactly the environmental faults
+    (antivirus or a sync client holding the file on Windows, a permissions
+    blip) that are most likely to hit two gateways at once.
+    """
+    db_path = kb.kanban_db_path(board="default")
+    real_open = Path.open
+
+    def refuse_lock_file(self, *args, **kwargs):
+        if self.name.endswith(".dispatch.lock"):
+            raise OSError(13, "Permission denied")
+        return real_open(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "open", refuse_lock_file)
+
+    with kb._dispatch_tick_lock(db_path) as held:
+        assert held is False, (
+            "an unopenable lock file cannot prove we are the sole writer, so "
+            "the tick must be skipped rather than assumed safe"
+        )
+
+
+def test_unopenable_lock_file_does_not_dispatch(conn, monkeypatch):
+    """The end-to-end consequence: no spawn happens on such a tick."""
+    kb.create_task(conn, title="t", assignee="w")
+    real_open = Path.open
+    spawn_calls: list = []
+
+    def spy_spawn(task, workspace_path, board=None):
+        spawn_calls.append(getattr(task, "id", task))
+        return 999999
+
+    def refuse_lock_file(self, *args, **kwargs):
+        if self.name.endswith(".dispatch.lock"):
+            raise OSError(13, "Permission denied")
+        return real_open(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "open", refuse_lock_file)
+    result = kb.dispatch_once(conn, spawn_fn=spy_spawn)
+
+    assert result.skipped_locked is True
+    assert result.spawned == []
+    assert spawn_calls == [], "a dispatcher that cannot lock must not spawn"
+
+
+def test_lock_still_works_when_the_file_is_openable(conn):
+    """Guardrail: the normal path is untouched — a free lock is still acquired.
+
+    Without this, making the error path fail closed could pass by breaking
+    acquisition outright.
+    """
+    db_path = kb.kanban_db_path(board="default")
+
+    with kb._dispatch_tick_lock(db_path) as held:
+        assert held is True


### PR DESCRIPTION
## Summary

`_dispatch_tick_lock` treated a failure to **open** the board's `.dispatch.lock` as permission to proceed:

```python
except OSError:
    # Could not even open the lock file (permissions, read-only FS).
    # Degrade to a no-op so a probe failure never blocks dispatch.
    acquired = True
```

A tick that could not establish it was the sole writer therefore ran as though it held the lock. That is exactly the multi-writer scenario the lock was added for in #35240, and this function's own docstring names the consequence: two dispatchers that each believe they own the file "both pass SQLite `busy_timeout` and then race on WAL frames, the documented root cause of multi-writer corruption".

The failure mode is also not independent of the risk it guards. On Windows an unopenable lock file usually means antivirus or a sync client (OneDrive, Dropbox) is holding it, which is a machine in exactly the state where a second gateway is plausible, so the guard degraded open in the conditions that most need it.

## Why skipping is the conservative answer here

Skipping is already what this function does when it loses the lock. The guard is non-blocking by design: a losing dispatcher skips its tick and retries next interval, and `dispatch_once` reports `skipped_locked=True` with no writes. An unopenable lock file is transient and re-evaluated every tick, so the cost of being wrong is one deferred interval, weighed against database corruption on the other side.

I deliberately left the **missing `fcntl`/`msvcrt`** degradation alone. That one is a permanent property of the platform rather than a transient fault, so failing closed there would disable dispatch forever instead of for one interval, and the docstring documents it as an intentional no-op. The distinction between "this platform can never lock" and "this file could not be opened right now" is the whole basis of the change, and it is written into the comment so the next reader does not collapse the two back together.

## Scope: this is one of the two halves of #87609

The issue reports two fail-open sites. This PR fixes the `hermes_cli/kanban_db.py` one only.

The other, `gateway/kanban_watchers.py::_acquire_singleton_lock`, is a different kind of decision and I did not want to smuggle it in here. That lock is acquired **once and held for the process lifetime** (`self._kanban_dispatcher_lock_handle`, "hold for process lifetime" at the call site), so failing it closed does not defer a tick, it stops that gateway from dispatching at all for as long as it runs. That is an availability decision for maintainers, and doing it well probably wants the reporter's own optional suggestion, a DB-level lease row with owner/heartbeat/TTL, rather than a one-line flip. I have written the analysis up on the issue so it is not lost.

Happy to do that half too, in this PR or a follow-up, if you tell me which way you want it to go.

## Related open work

#58420 also touches `_dispatch_tick_lock`, adding an mtime heartbeat inside the `if acquired:` block, immediately above the hunk this PR changes. Different concern and different line, but adjacent enough that whichever lands second may want a trivial rebase. Flagging rather than assuming.

## Testing

Three new cases in the existing `tests/hermes_cli/test_kanban_dispatch_lock.py`, following that file's fixtures:

| Test | Asserts |
| --- | --- |
| `test_unopenable_lock_file_skips_the_tick` | the lock itself yields `False` when the file cannot be opened |
| `test_unopenable_lock_file_does_not_dispatch` | the consequence: `skipped_locked=True`, nothing spawned |
| `test_lock_still_works_when_the_file_is_openable` | guardrail: a free lock is still acquired |

Verified the first two actually catch the regression, by stashing the source change and re-running:

```
$ git stash push hermes_cli/kanban_db.py
$ pytest tests/hermes_cli/test_kanban_dispatch_lock.py -q
FAILED test_unopenable_lock_file_skips_the_tick
FAILED test_unopenable_lock_file_does_not_dispatch
2 failed, 3 passed
```

The guardrail passes both with and without the fix, which is what makes it a guardrail: the change cannot pass by breaking acquisition outright.

With the fix applied:

```
$ pytest tests/hermes_cli/test_kanban_dispatch_lock.py -q
5 passed

$ pytest tests/hermes_cli/test_kanban_dispatch_lock.py \
         tests/hermes_cli/test_kanban_core_functionality.py \
         tests/gateway/test_kanban_watchers_mixin.py -q
1 failed, 28 passed, 1 skipped

$ ruff check hermes_cli/kanban_db.py tests/hermes_cli/test_kanban_dispatch_lock.py
All checks passed!

$ python scripts/check-windows-footguns.py --all
973 files checked, no issues
```

The one failure is `test_kanban_core_functionality.py::test_protocol_violation_budget_not_consumed_by_other_failures`, which is **pre-existing and unrelated**: it fails identically on a clean `upstream/main` worktree with none of this branch's changes applied.

`ruff format --check` reports both touched files as needing reformatting, and that is also pre-existing: `kanban_db.py` alone has 212 wanted hunks on clean `main`, and the test file's two wanted hunks are stray blank lines that predate this branch. `ruff format --diff` shows nothing wanted inside the lines this PR adds, so I left both files alone rather than bury a 4-line fix in unrelated churn.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor / code quality
- [ ] Test coverage

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (the behaviour change is described in the function's own comment; no user-facing docs cover this internal guard)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Cross-platform

- [x] The changed branch is platform-neutral; it sits above the `fcntl` / `msvcrt` split, so POSIX and Windows get identical behaviour
- [x] The platform-specific degradation path (no `fcntl` / `msvcrt`) is explicitly preserved
- [x] Tests stub `Path.open` rather than relying on real filesystem permissions, so they run identically on every OS
- [x] `scripts/check-windows-footguns.py --all` clean

Fixes #87609
