### PR TITLE
feat(desktop-sdk): expose focused-session state atoms to plugins (salvage #80461)

### DIFF
--- a/apps/desktop/src/sdk/host-state.test.ts
+++ b/apps/desktop/src/sdk/host-state.test.ts
@@ -59,7 +59,7 @@ describe('host.state focused-session atoms', () => {
   })
 
   it('follows the interacted tile while the primary-only atom stays put', async () => {
-    const { host, session } = await setup()
+    const { host, session, states } = await setup()
     const tree = await import('@/components/pane-shell/tree/store')
     const model = await import('@/components/pane-shell/tree/model')
     const { registry } = await import('@/contrib/registry')
@@ -85,9 +85,30 @@ describe('host.state focused-session atoms', () => {
     const primaryBefore = session.$activeSessionId.get()
     const primarySelection = session.$selectedStoredSessionId.get()
 
+    // Bind the tile to a live runtime with its own usage, so the readout
+    // atoms (focusedSessionId / focusedUsage) — not just the navigation id —
+    // are proven to follow the tile.
+    const tileUsage = {
+      calls: 3,
+      input: 1200,
+      output: 300,
+      total: 1500,
+      context_used: 42000,
+      context_max: 200000,
+      context_percent: 21,
+      cost_usd: 0.0123
+    }
+
+    states.$sessionTiles.set([{ storedSessionId: 'tile-a', runtimeId: 'runtime-tile-a' }])
+    states.$sessionStates.set({
+      'runtime-tile-a': { storedSessionId: 'tile-a', usage: tileUsage } as never
+    })
+
     // Focusing the tile zone moves the focused atoms onto the tile's session…
     tree.noteActiveTreeGroup('grp-side')
     expect(host.state.focusedStoredSessionId.get()).toBe('tile-a')
+    expect(host.state.focusedSessionId.get()).toBe('runtime-tile-a')
+    expect(host.state.focusedUsage.get()).toBe(tileUsage)
     // …while the primary-only atom a plugin used to rely on does not move.
     expect(host.state.activeSessionId.get()).toBe(primaryBefore)
 

--- a/apps/desktop/src/sdk/host-state.test.ts
+++ b/apps/desktop/src/sdk/host-state.test.ts
@@ -1,10 +1,100 @@
-import { afterEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { createClientSessionState } from '@/lib/chat-runtime'
 import { $gatewayState } from '@/store/session'
 import { $sessionStates, dropSessionState, publishSessionState } from '@/store/session-states'
 
 import { host } from './index'
+
+// Plugins read app state exclusively through host.state — and before this
+// contract existed, only the PRIMARY workspace tab was reachable
+// ($activeSessionId). Clicking a tile never moved any plugin-visible atom,
+// and tile focus is pure renderer state that gateway RPC can never see, so
+// no plugin-side workaround was possible. These atoms are the plugin door to
+// the same focused-session signals the core statusbar reads
+// (use-statusbar-items.tsx).
+
+describe('host.state focused-session atoms', () => {
+  beforeEach(() => {
+    window.localStorage.clear()
+    vi.resetModules()
+  })
+
+  afterEach(() => {
+    vi.resetModules()
+  })
+
+  async function setup() {
+    const { host } = await import('@/sdk/index')
+    const states = await import('@/store/session-states')
+    const session = await import('@/store/session')
+
+    return { host, states, session }
+  }
+
+  it('exposes readonly atoms for the focused session (runtime id, stored id, usage)', async () => {
+    const { host } = await setup()
+
+    for (const key of ['focusedSessionId', 'focusedStoredSessionId', 'focusedUsage'] as const) {
+      const store = host.state[key]
+      expect(store, key).toBeDefined()
+      expect(typeof store.get, 'function', key)
+      expect(typeof store.listen, 'function', key)
+      expect(typeof store.subscribe, 'function', key)
+    }
+  })
+
+  it('mirrors the primary session while no tile is focused', async () => {
+    const { host, states } = await setup()
+
+    expect(host.state.focusedSessionId.get()).toBe(states.$focusedRuntimeId.get())
+    expect(host.state.focusedStoredSessionId.get()).toBe(states.$focusedStoredSessionId.get())
+  })
+
+  it('focusedUsage projects the focused session usage, null while unresolved', async () => {
+    const { host, states } = await setup()
+
+    const focused = states.$focusedSessionState.get()
+    expect(host.state.focusedUsage.get()).toBe(focused?.usage ?? null)
+  })
+
+  it('follows the interacted tile while the primary-only atom stays put', async () => {
+    const { host, session } = await setup()
+    const tree = await import('@/components/pane-shell/tree/store')
+    const model = await import('@/components/pane-shell/tree/model')
+    const { registry } = await import('@/contrib/registry')
+
+    // A second chat zone holding a session tile, next to the main workspace.
+    for (const id of ['workspace', 'session-tile:tile-a']) {
+      registry.register({
+        area: 'panes',
+        data: id === 'workspace' ? { placement: 'main', uncloseable: true } : { placement: 'main' },
+        id,
+        render: () => null,
+        title: id
+      })
+    }
+    tree.declareDefaultTree(
+      model.split('row', [
+        model.group(['workspace'], { active: 'workspace', id: 'grp-main' }),
+        model.group(['session-tile:tile-a'], { active: 'session-tile:tile-a', id: 'grp-side' })
+      ])
+    )
+
+    const primaryBefore = session.$activeSessionId.get()
+    const primarySelection = session.$selectedStoredSessionId.get()
+
+    // Focusing the tile zone moves the focused atoms onto the tile's session…
+    tree.noteActiveTreeGroup('grp-side')
+    expect(host.state.focusedStoredSessionId.get()).toBe('tile-a')
+    // …while the primary-only atom a plugin used to rely on does not move.
+    expect(host.state.activeSessionId.get()).toBe(primaryBefore)
+
+    // Focusing back homes to the primary's selection, whatever it is.
+    tree.noteActiveTreeGroup('grp-main')
+    expect(host.state.focusedStoredSessionId.get()).toBe(primarySelection)
+  })
+})
 
 describe('host.state busy vs gateway', () => {
   afterEach(() => {

--- a/apps/desktop/src/sdk/host-state.test.ts
+++ b/apps/desktop/src/sdk/host-state.test.ts
@@ -38,9 +38,9 @@ describe('host.state focused-session atoms', () => {
     for (const key of ['focusedSessionId', 'focusedStoredSessionId', 'focusedUsage'] as const) {
       const store = host.state[key]
       expect(store, key).toBeDefined()
-      expect(typeof store.get, 'function', key)
-      expect(typeof store.listen, 'function', key)
-      expect(typeof store.subscribe, 'function', key)
+      expect(typeof store.get, key).toBe('function')
+      expect(typeof store.listen, key).toBe('function')
+      expect(typeof store.subscribe, key).toBe('function')
     }
   })
 
@@ -74,6 +74,7 @@ describe('host.state focused-session atoms', () => {
         title: id
       })
     }
+
     tree.declareDefaultTree(
       model.split('row', [
         model.group(['workspace'], { active: 'workspace', id: 'grp-main' }),

--- a/apps/desktop/src/sdk/index.ts
+++ b/apps/desktop/src/sdk/index.ts
@@ -45,8 +45,14 @@ import {
   $gatewayState,
   $selectedStoredSessionId
 } from '@/store/session'
-import { $focusedSessionState, $focusedStoredSessionId, $sessionStates } from '@/store/session-states'
+import {
+  $focusedRuntimeId,
+  $focusedSessionState,
+  $focusedStoredSessionId,
+  $sessionStates
+} from '@/store/session-states'
 import { runGatewayRestart } from '@/store/system-actions'
+import type { UsageStats } from '@/types/hermes'
 
 // -- state: readonly views over the app's live atoms -------------------------
 
@@ -109,6 +115,10 @@ if (typeof window !== 'undefined') {
   $narrowViewport.listen(refresh)
 }
 
+/** Live usage of the FOCUSED session, projected out of the streamed session
+ *  state — the same readout the core statusbar's context chip paints. */
+const $focusedUsage = computed($focusedSessionState, state => state?.usage ?? null)
+
 export const host = {
   state: {
     /** Runtime id of the active chat session (null on a fresh draft). */
@@ -126,6 +136,17 @@ export const host = {
     busyBySession: readonlyAtom<Record<string, boolean>>($busyBySession),
     /** Active workspace cwd ('' when detached). */
     cwd: readonlyAtom<string>($currentCwd),
+    /** Runtime id of the FOCUSED chat session — the interacted tile, else the
+     *  primary. Prefer this over `activeSessionId` for any readout that
+     *  should follow the user between tiles (context, tokens, cost). */
+    focusedSessionId: readonlyAtom<null | string>($focusedRuntimeId),
+    /** Stored (durable) id of the focused session — for navigation and
+     *  session-list matching, where runtime ids don't survive reloads. */
+    focusedStoredSessionId: readonlyAtom<null | string>($focusedStoredSessionId),
+    /** Live usage snapshot of the focused session (`context_used` /
+     *  `context_max` / `context_percent`, token counts, `cost_usd`) —
+     *  streamed by the backend, no RPC needed. Null while unresolved. */
+    focusedUsage: readonlyAtom<null | UsageStats>($focusedUsage),
     /** Gateway socket state: 'idle' | 'connecting' | 'open' | …. Not turn-busy. */
     gateway: readonlyAtom<string>($gatewayState),
     /** Current main model slug. */

--- a/apps/desktop/src/sdk/index.ts
+++ b/apps/desktop/src/sdk/index.ts
@@ -145,8 +145,10 @@ export const host = {
     focusedStoredSessionId: readonlyAtom<null | string>($focusedStoredSessionId),
     /** Live usage snapshot of the focused session (`context_used` /
      *  `context_max` / `context_percent`, token counts, `cost_usd`) —
-     *  streamed by the backend, no RPC needed. Null while unresolved. */
-    focusedUsage: readonlyAtom<null | UsageStats>($focusedUsage),
+     *  streamed by the backend, no RPC needed. Null while unresolved.
+     *  Partial: the backend streams whichever fields changed, so every
+     *  field read needs a fallback. */
+    focusedUsage: readonlyAtom<null | Partial<UsageStats>>($focusedUsage),
     /** Gateway socket state: 'idle' | 'connecting' | 'open' | …. Not turn-busy. */
     gateway: readonlyAtom<string>($gatewayState),
     /** Current main model slug. */

--- a/apps/desktop/src/sdk/index.ts
+++ b/apps/desktop/src/sdk/index.ts
@@ -146,9 +146,9 @@ export const host = {
     /** Live usage snapshot of the focused session (`context_used` /
      *  `context_max` / `context_percent`, token counts, `cost_usd`) —
      *  streamed by the backend, no RPC needed. Null while unresolved.
-     *  Partial: the backend streams whichever fields changed, so every
-     *  field read needs a fallback. */
-    focusedUsage: readonlyAtom<null | Partial<UsageStats>>($focusedUsage),
+     *  The UsageStats-optional fields (context_*, cost_usd) arrive as the
+     *  backend reports them, so read them with a fallback. */
+    focusedUsage: readonlyAtom<null | UsageStats>($focusedUsage),
     /** Gateway socket state: 'idle' | 'connecting' | 'open' | …. Not turn-busy. */
     gateway: readonlyAtom<string>($gatewayState),
     /** Current main model slug. */

--- a/contributors/emails/lepetitprince716-prog@users.noreply.github.com
+++ b/contributors/emails/lepetitprince716-prog@users.noreply.github.com
@@ -1,0 +1,1 @@
+lepetitprince716-prog

--- a/skills/autonomous-ai-agents/hermes-agent/references/desktop-plugins.md
+++ b/skills/autonomous-ai-agents/hermes-agent/references/desktop-plugins.md
@@ -56,11 +56,16 @@ The ONLY import surface is `@hermes/plugin-sdk` (plus `react` /
 
 - `host.state.*` — readonly reactive atoms: `activeSessionId`, `busy`,
   `awaitingResponse`, `busyBySession`, `cwd`, `gateway` (socket state, not
-  turn-busy), `model`, `profile`, `viewport`.
-  `busy` is true while the focused chat is working after a send (thinking
-  and streaming). `awaitingResponse` is true until the first assistant
-  payload. `busyBySession` maps runtime session id → mid-turn, for rosters
-  that watch every session. Read with `.get()` in handlers,
+  turn-busy), `model`, `profile`, `viewport`, plus the tile-aware focused
+  session atoms: `focusedSessionId` (runtime id — key for `session.*` RPC),
+  `focusedStoredSessionId` (durable id — navigation / list matching), and
+  `focusedUsage` (live streamed `UsageStats` of the focused session, no RPC
+  needed). `busy` is true while the focused chat is working after a send
+  (thinking and streaming). `awaitingResponse` is true until the first
+  assistant payload. `busyBySession` maps runtime session id → mid-turn,
+  for rosters that watch every session. Prefer the focused atoms for any
+  readout that should follow the user between tiles. Read with `.get()`
+  in handlers,
   `useValue(atom)` in components.
 - `host.request(method, params)` — gateway JSON-RPC (sessions, config,
   skills, cron — everything the app uses).

--- a/website/docs/developer-guide/desktop-plugin-sdk.md
+++ b/website/docs/developer-guide/desktop-plugin-sdk.md
@@ -378,6 +378,9 @@ host.state.activeSessionId  // ReadableAtom<string | null>
 host.state.awaitingResponse // ReadableAtom<boolean>  true until the first assistant payload
 host.state.busy             // ReadableAtom<boolean>  focused chat is working after a send
 host.state.busyBySession    // ReadableAtom<Record<string, boolean>>  runtime id → mid-turn
+host.state.focusedSessionId // ReadableAtom<string | null>  (runtime id of the FOCUSED session — tile-aware; prefer for session.* RPC)
+host.state.focusedStoredSessionId // ReadableAtom<string | null>  (durable id — navigation / session-list matching)
+host.state.focusedUsage     // ReadableAtom<UsageStats | null>  (live streamed usage of the focused session, no RPC needed)
 host.state.cwd              // ReadableAtom<string>
 host.state.gateway          // ReadableAtom<string>  socket state ('idle' | 'connecting' | 'open' | …)
 host.state.model            // ReadableAtom<string>


### PR DESCRIPTION
## Summary
Desktop plugins can now follow the session the user is actually looking at: `host.state` gains `focusedSessionId`, `focusedStoredSessionId`, and `focusedUsage` — the same tile-aware focused-session signals the core statusbar reads. Salvages @lepetitprince716-prog's #80461 onto current main.

Before this, plugins only had the primary-tab `activeSessionId`; clicking a tile never moved any plugin-visible atom (tile focus is pure renderer state, invisible to RPC and the event stream), so session-scoped plugin readouts silently described the wrong chat.

## Changes
- `apps/desktop/src/sdk/index.ts`: three readonly atoms over existing `session-states` stores — zero new state; composes with `busy`/`awaitingResponse`/`busyBySession` from #87585/#87617
- `apps/desktop/src/sdk/host-state.test.ts`: contract tests woven into the existing suite, incl. a real two-zone tile-focus test (registry + pane tree) proving the focused atoms move while `activeSessionId` stays put
- Docs + skill reference updated for the combined `host.state` surface

## Validation
| | Result |
|---|---|
| vitest `src/sdk/` | 9/9 pass |
| `npm run check:lint` | 0 errors |
| Deletion audit vs main | only the import-union line |

## Infographic

![Focused-session atoms for plugins](https://v3b.fal.media/files/b/0aa68e0f/kVZitOpNL-TuDRSRvUrHZ_lHvJiTFh.png)
