### PR TITLE
fix(cron): call-time store paths, UTC claimed_at, one-shot run_claim release

### DIFF
--- a/cron/executions.py
+++ b/cron/executions.py
@@ -12,6 +12,7 @@ import sqlite3
 import threading
 import uuid
 from contextlib import contextmanager
+from datetime import timezone
 from typing import Any, Dict, Iterator, List, Optional
 
 from hermes_constants import get_hermes_home
@@ -25,6 +26,13 @@ MAX_TERMINAL_EXECUTIONS = 1000
 _TERMINAL_STATES = ("completed", "failed", "unknown")
 _lock = threading.RLock()
 _PROCESS_ID = uuid.uuid4().hex
+
+
+def _utc_now_iso() -> str:
+    # Store timestamps in UTC (offset always +00:00) so lexicographic TEXT
+    # ordering of claimed_at matches absolute time across DST transitions and
+    # HERMES_TIMEZONE changes (#86520).
+    return _hermes_now().astimezone(timezone.utc).isoformat()
 
 
 def _connect() -> sqlite3.Connection:
@@ -138,7 +146,7 @@ def _prune_unlocked(conn: sqlite3.Connection) -> None:
 
 def create_execution(job_id: str, *, source: str) -> Dict[str, Any]:
     """Persist a claimed attempt before executor/provider dispatch."""
-    now = _hermes_now().isoformat()
+    now = _utc_now_iso()
     execution_id = uuid.uuid4().hex
     pid = os.getpid()
     with _transaction() as conn:
@@ -160,7 +168,7 @@ def create_execution(job_id: str, *, source: str) -> Dict[str, Any]:
 
 def mark_execution_running(execution_id: str) -> Optional[Dict[str, Any]]:
     """Transition one claimed attempt to running exactly once."""
-    now = _hermes_now().isoformat()
+    now = _utc_now_iso()
     with _transaction() as conn:
         cur = conn.execute(
             """UPDATE executions SET status='running', started_at=?
@@ -181,7 +189,7 @@ def finish_execution(
     delivery_outcome: Optional[str] = None,
 ) -> Optional[Dict[str, Any]]:
     """Write a terminal result once; terminal attempts cannot be rewritten."""
-    now = _hermes_now().isoformat()
+    now = _utc_now_iso()
     status = "completed" if success else "failed"
     detail = None if success else (str(error) if error else "unknown failure")
     with _transaction() as conn:
@@ -202,7 +210,7 @@ def finish_execution(
 
 def recover_interrupted_executions() -> int:
     """Mark provably abandoned attempts unknown without scheduling retries."""
-    now = _hermes_now().isoformat()
+    now = _utc_now_iso()
     changed = 0
     recovered: List[Dict[str, Any]] = []
     with _transaction() as conn:

--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -2528,6 +2528,42 @@ def heartbeat_run_claim(job_id: str, *, expected_owner: str) -> bool:
     return False
 
 
+def clear_run_claim(job_id: str, *, expected_owner: Optional[str] = None) -> bool:
+    """Clear a one-shot's ``run_claim`` when its dispatch never ran.
+
+    Skip/failure paths in the scheduler (interpreter shutdown, ledger-write
+    failure, pool.submit failure) leave the claim stamped by
+    _get_due_jobs_locked in place, so the next healthy tick reads a fresh
+    claim and skips the job — a one-shot could arrive up to the claim TTL
+    late (#86522). Clearing here lets the next tick pick it up immediately.
+
+    ``expected_owner`` (copied from the dispatched job's claim) makes the
+    clear compare-and-swap: a stale path must not wipe a claim another
+    scheduler process has since taken over.
+
+    Returns True if this job's one-shot claim was cleared; False when the
+    job, claim, or ownership does not match.
+    """
+    with _jobs_lock():
+        jobs = load_jobs()
+        for job in jobs:
+            if job.get("id") != job_id:
+                continue
+            if job.get("schedule", {}).get("kind") != "once":
+                return False
+            claim = job.get("run_claim")
+            if claim is None:
+                return False
+            if expected_owner is not None and (
+                not isinstance(claim, dict) or claim.get("by") != expected_owner
+            ):
+                return False
+            job["run_claim"] = None
+            save_jobs(jobs)
+            return True
+    return False
+
+
 def advance_next_runs(job_ids) -> int:
     """Batch form of :func:`advance_next_run` for the due-dispatch loop.
 

--- a/cron/notepad.py
+++ b/cron/notepad.py
@@ -26,21 +26,32 @@ from __future__ import annotations
 import sqlite3
 import threading
 from contextlib import contextmanager
+from pathlib import Path
 from typing import Any, Dict, Iterator, List, Optional
 
 from hermes_constants import get_hermes_home
 from hermes_time import now as _hermes_now
 
-NOTEPAD_FILE = get_hermes_home().resolve() / "cron" / "notepad.db"
+# Optional test override. Production resolves the path at transaction time so
+# multiplexed profile ticks (set_hermes_home_override) cannot leak one
+# profile's notepad rows into the import-time home — and remove_job's
+# clear_notepad cannot wipe the wrong profile's DB (#86519). Same pattern as
+# cron/executions.py.
+NOTEPAD_FILE: Optional[Path] = None
 MAX_VALUE_BYTES = 16 * 1024
 MAX_KEY_CHARS = 128
 MAX_JOB_TOTAL_BYTES = 64 * 1024
 _lock = threading.RLock()
 
 
+def _current_notepad_file() -> Path:
+    return NOTEPAD_FILE or (get_hermes_home().resolve() / "cron" / "notepad.db")
+
+
 def _connect() -> sqlite3.Connection:
-    NOTEPAD_FILE.parent.mkdir(parents=True, exist_ok=True)
-    return sqlite3.connect(NOTEPAD_FILE, timeout=5)
+    path = _current_notepad_file()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    return sqlite3.connect(path, timeout=5)
 
 
 def _initialize_schema(conn: sqlite3.Connection) -> None:
@@ -155,7 +166,7 @@ def clear_notepad(job_id: str) -> int:
     Called from ``cron.jobs.remove_job`` so deleted jobs don't orphan their
     rows. No-ops without creating the DB when no notepad file exists yet.
     """
-    if not NOTEPAD_FILE.exists():
+    if not _current_notepad_file().exists():
         return 0
     with _transaction() as conn:
         cur = conn.execute(

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -451,6 +451,7 @@ from cron.jobs import (
     advance_next_runs,
     claim_dispatch,
     claim_job_for_fire,
+    clear_run_claim,
     fire_claim_fence,
     get_due_jobs,
     heartbeat_fire_claim,
@@ -6530,6 +6531,28 @@ def tick(
             membership is released in the worker's finally block.
             """
             job_id = job["id"]
+
+            def _clear_oneshot_run_claim() -> None:
+                # A skipped/failed one-shot dispatch must not keep the
+                # run_claim stamped by _get_due_jobs_locked until the TTL
+                # expires — clear it so the next healthy tick picks the job
+                # up immediately (#86522). Best-effort: never break the
+                # skip path.
+                schedule = job.get("schedule")
+                if not isinstance(schedule, dict) or schedule.get("kind") != "once":
+                    return
+                try:
+                    clear_run_claim(
+                        job_id,
+                        expected_owner=(job.get("run_claim") or {}).get("by"),
+                    )
+                except Exception:
+                    logger.debug(
+                        "Job '%s': failed to clear one-shot run_claim",
+                        job.get("name", job_id),
+                        exc_info=True,
+                    )
+
             # A tick can race gateway teardown: once the interpreter is
             # finalizing, ``pool.submit`` raises "cannot schedule new futures
             # after interpreter shutdown" and crashes the tick. Skip cleanly —
@@ -6540,6 +6563,7 @@ def tick(
                     "Job '%s' not dispatched — interpreter is shutting down",
                     job.get("name", job_id),
                 )
+                _clear_oneshot_run_claim()
                 return None
             if not try_register_running_job(job_id):
                 logger.info("Job '%s' already running — skipping", job.get("name", job_id))
@@ -6562,6 +6586,7 @@ def tick(
                     job.get("name", job_id),
                     execution_err,
                 )
+                _clear_oneshot_run_claim()
                 return None
 
             def _run_and_release(j=dispatched_job, ctx=_ctx):
@@ -6579,6 +6604,7 @@ def tick(
                     success=False,
                     error=f"Executor dispatch failed: {submit_err}",
                 )
+                _clear_oneshot_run_claim()
                 # Interpreter began finalizing between the guard above and the
                 # submit — release the in-flight claim we just took and skip.
                 if isinstance(submit_err, RuntimeError) and _interpreter_shutting_down(submit_err):

--- a/cron/suggestions.py
+++ b/cron/suggestions.py
@@ -45,8 +45,17 @@ logger = logging.getLogger(__name__)
 # Per-profile by design (issue #4707): suggestions live alongside the active
 # profile's cron store. Anchor on get_hermes_home() (profile home), not the
 # shared default root. See cron/jobs.py for the full rationale.
-CRON_DIR = get_hermes_home().resolve() / "cron"
-SUGGESTIONS_FILE = CRON_DIR / "suggestions.json"
+#
+# Optional test overrides. Production resolves the path at call time so
+# multiplexed profile ticks (set_hermes_home_override) cannot leak one
+# profile's suggestions into the import-time home (#86519). Same pattern as
+# cron/executions.py.
+CRON_DIR: Optional[Path] = None
+SUGGESTIONS_FILE: Optional[Path] = None
+
+
+def _current_suggestions_file() -> Path:
+    return SUGGESTIONS_FILE or (get_hermes_home().resolve() / "cron" / "suggestions.json")
 
 # In-process lock protecting load->modify->save cycles (the background review
 # fork and the main agent can both write).
@@ -70,14 +79,15 @@ def _secure_file(path: Path) -> None:
 
 
 def _ensure_dir() -> None:
-    CRON_DIR.mkdir(parents=True, exist_ok=True)
+    _current_suggestions_file().parent.mkdir(parents=True, exist_ok=True)
 
 
 def _load_raw() -> Dict[str, Any]:
-    if not SUGGESTIONS_FILE.exists():
+    suggestions_file = _current_suggestions_file()
+    if not suggestions_file.exists():
         return {"suggestions": []}
     try:
-        with open(SUGGESTIONS_FILE, "r", encoding="utf-8") as f:
+        with open(suggestions_file, "r", encoding="utf-8") as f:
             data = json.load(f)
     except (json.JSONDecodeError, OSError) as e:
         logger.warning("suggestions.json unreadable (%s); starting empty", e)
@@ -92,7 +102,8 @@ def _load_raw() -> Dict[str, Any]:
 
 def _save_raw(suggestions: List[Dict[str, Any]]) -> None:
     _ensure_dir()
-    fd, tmp_path = tempfile.mkstemp(dir=str(SUGGESTIONS_FILE.parent), suffix=".tmp", prefix=".sugg_")
+    suggestions_file = _current_suggestions_file()
+    fd, tmp_path = tempfile.mkstemp(dir=str(suggestions_file.parent), suffix=".tmp", prefix=".sugg_")
     try:
         with os.fdopen(fd, "w", encoding="utf-8") as f:
             json.dump(
@@ -102,8 +113,8 @@ def _save_raw(suggestions: List[Dict[str, Any]]) -> None:
             )
             f.flush()
             os.fsync(f.fileno())
-        atomic_replace(tmp_path, SUGGESTIONS_FILE)
-        _secure_file(SUGGESTIONS_FILE)
+        atomic_replace(tmp_path, suggestions_file)
+        _secure_file(suggestions_file)
     except BaseException:
         try:
             os.unlink(tmp_path)

--- a/tests/cron/test_jobs.py
+++ b/tests/cron/test_jobs.py
@@ -22,6 +22,7 @@ from cron.jobs import (
     claim_dispatch,
     claim_job_for_fire,
     heartbeat_run_claim,
+    clear_run_claim,
     get_due_jobs,
     save_job_output,
     _hermes_now,
@@ -803,6 +804,62 @@ class TestGetDueJobs:
             "at": original_at,
             "by": "new-owner",
         }
+
+
+class TestClearRunClaim:
+    """#86522: a one-shot skipped/failed at dispatch must not keep its
+    run_claim until the TTL expires."""
+
+    def _save_claimed_oneshot(self, job_id="oneshot", owner="owner-1"):
+        run_at = (_hermes_now() - timedelta(seconds=5)).isoformat()
+        save_jobs([{
+            "id": job_id, "name": "R", "prompt": "x",
+            "schedule": {"kind": "once", "run_at": run_at},
+            "next_run_at": run_at, "enabled": True, "state": "scheduled",
+            "repeat": {"times": 1, "completed": 0},
+            "run_claim": {"at": _hermes_now().isoformat(), "by": owner},
+        }])
+
+    def test_clear_lets_next_tick_redispatch_immediately(self, tmp_cron_dir):
+        """Without the clear, the fresh claim makes the next healthy tick
+        skip the job for up to the claim TTL (default 30 min)."""
+        self._save_claimed_oneshot()
+
+        # A healthy tick right after a failed dispatch skips the claimed job.
+        assert get_due_jobs() == []
+
+        assert clear_run_claim("oneshot", expected_owner="owner-1") is True
+        assert get_job("oneshot")["run_claim"] is None
+
+        # The very next tick picks the job up again.
+        assert [j["id"] for j in get_due_jobs()] == ["oneshot"]
+
+    def test_rejects_mismatched_owner(self, tmp_cron_dir):
+        """CAS: a stale skip path must not wipe a claim another scheduler
+        process has since taken over."""
+        self._save_claimed_oneshot()
+
+        assert clear_run_claim("oneshot", expected_owner="other-owner") is False
+        assert get_job("oneshot")["run_claim"]["by"] == "owner-1"
+
+    def test_noop_for_recurring_job(self, tmp_cron_dir):
+        future = (_hermes_now() + timedelta(hours=1)).isoformat()
+        save_jobs([{
+            "id": "recur", "name": "R", "prompt": "x",
+            "schedule": {"kind": "cron", "expr": "0 9 * * *"},
+            "next_run_at": future, "enabled": True, "state": "scheduled",
+            "run_claim": {"at": _hermes_now().isoformat(), "by": "owner-1"},
+        }])
+
+        assert clear_run_claim("recur", expected_owner="owner-1") is False
+        assert get_job("recur")["run_claim"] is not None
+
+    def test_noop_without_claim_or_job(self, tmp_cron_dir):
+        self._save_claimed_oneshot()
+        save_jobs([{**get_job("oneshot"), "run_claim": None}])
+
+        assert clear_run_claim("oneshot", expected_owner="owner-1") is False
+        assert clear_run_claim("missing", expected_owner="owner-1") is False
 
 
 class TestEnabledToolsets:


### PR DESCRIPTION
## Summary

Three independent cron-subsystem fixes, one commit each:

- **fix(cron): resolve notepad/suggestions store paths at call time** — `cron/notepad.py` and `cron/suggestions.py` froze `get_hermes_home().resolve()` at import time, so multiplex profile switches wrote the B profile's notepad/suggestions into the default profile's store. Both now follow the same `Optional[Path] = None` + call-time resolution pattern that `cron/executions.py` already uses on main. Closes #86519
- **fix(cron): stamp claimed_at in UTC** — `claimed_at` was stored as an offset-bearing local ISO string; lexicographic `ORDER BY` diverges from absolute time across DST/timezone changes. All four write points now emit UTC (`+00:00`), making lexicographic order equal to chronological order. Closes #86520
  - Note on existing rows: pre-existing rows keep their local offsets and age out via the existing terminal-row prune; there is no migration framework in `executions.py` today. Happy to add a one-time migration or dual-key transition if reviewers prefer.
- **fix(cron): clear one-shot run_claim on dispatch failure** — a one-shot job stamped with `run_claim` but skipped/failed at dispatch was silently delayed up to the claim TTL (default 30 min). Adds `clear_run_claim(job_id, expected_owner=...)` (CAS, only `kind == "once"`) and calls it from all three dispatch-failure paths in `_submit_with_guard`. Closes #86522
  - Includes 4 new regression tests in `tests/cron/test_jobs.py::TestClearRunClaim`.

## Tests

`pytest tests/cron/ -q`: 714 passed, 1 skipped, no failures.
