### PR TITLE
fix(desktop): parse bold MEDIA markers with code-wrapped paths

### DIFF
--- a/apps/desktop/src/lib/chat-messages.test.ts
+++ b/apps/desktop/src/lib/chat-messages.test.ts
@@ -406,6 +406,12 @@ describe('renderMediaTags', () => {
     expect(renderMediaTags('MEDIA:/tmp/demo.mp4')).toBe('[Video: demo.mp4](#media:%2Ftmp%2Fdemo.mp4)')
   })
 
+  it('does not include Markdown emphasis or code delimiters in a MEDIA path', () => {
+    expect(renderMediaTags('**MEDIA:**`C:/Users/qinzi/Desktop/report.md`')).toBe(
+      '[File: report.md](#media:C%3A%2FUsers%2Fqinzi%2FDesktop%2Freport.md)'
+    )
+  })
+
   it('renders streamed assistant media once the tag is complete', () => {
     const parts = appendAssistantTextPart(appendAssistantTextPart([], 'ok\nMEDIA:'), '/tmp/voice.mp3')
     const text = chatMessageText({ id: 'a', role: 'assistant', parts })

--- a/apps/desktop/src/lib/chat-messages.ts
+++ b/apps/desktop/src/lib/chat-messages.ts
@@ -156,9 +156,18 @@ export function reasoningPart(text: string, timestamp?: number): ChatMessagePart
   return { type: 'reasoning', text, ...(timestamp !== undefined ? { timestamp } : {}) }
 }
 
-const MEDIA_LINE_RE = /(^|\n)[\t ]*[`"']?MEDIA:\s*(?<line>`[^`\n]+`|"[^"\n]+"|'[^'\n]+'|\S+)[`"']?[\t ]*(\n|$)/g
+const MEDIA_MARKER_RE = String.raw`(?:\*\*MEDIA:\*\*|MEDIA:)`
+const MEDIA_PATH_RE = String.raw`(?:\x60[^\x60\n]+\x60|"[^"\n]+"|'[^'\n]+'|\S+)`
 
-const MEDIA_TAG_RE = /[`"']?MEDIA:\s*(?<inline>`[^`\n]+`|"[^"\n]+"|'[^'\n]+'|\S+)[`"']?/g
+const MEDIA_LINE_RE = new RegExp(
+  String.raw`(^|\n)[\t ]*[\x60"']?${MEDIA_MARKER_RE}\s*(?<line>${MEDIA_PATH_RE})[\x60"']?[\t ]*(\n|$)`,
+  'g'
+)
+
+const MEDIA_TAG_RE = new RegExp(
+  String.raw`[\x60"']?${MEDIA_MARKER_RE}\s*(?<inline>${MEDIA_PATH_RE})[\x60"']?`,
+  'g'
+)
 
 function unquoteMediaPath(value: string): string {
   const trimmed = value.trim()


### PR DESCRIPTION
## Problem

Hermes Desktop recognizes a bare `MEDIA:` marker, but models also emit the marker itself in bold followed by a code-wrapped path:

```text
**MEDIA:**`C:/Users/me/Desktop/report.md`
```

`renderMediaTags()` currently starts matching at the inner `MEDIA:`. The closing marker emphasis and code delimiter are therefore captured as part of the path, producing an href like:

```text
#media:**%60C%3A%2FUsers%2Fme%2FDesktop%2Freport.md%60
```

On Windows this reaches `shell.openPath()` as a nonexistent path containing Markdown delimiters. The click can appear to do nothing: no file opens and the OS call may not produce a useful UI error.

## Change

- Treat `**MEDIA:**` as one supported marker variant alongside the existing bare `MEDIA:` marker.
- Keep marker matching separate from path matching, so emphasis and code delimiters never enter the encoded path.
- Add a regression test using the exact model-emitted shape above.

## Relation to existing work

This is an additional reproduction of #84361. It is intentionally narrower than the other open MEDIA parser PRs:

- #84542 handles trailing emphasis/prose punctuation such as `**MEDIA:/tmp/a.pdf**`.
- #62409 handles emphasis placed after a bare marker (for example, `MEDIA:**` followed by a code-wrapped path).
- #85790 handles spaced paths and Markdown link/image wrappers.
- #85788 handles non-ASCII basename display in `mediaName()`.

The exact `**MEDIA:**` + code-wrapped-path regression test still fails on the latest heads of #84542, #62409, and #85790. This PR only adds marker-level parsing and does not duplicate the non-ASCII label fix.

## Verification

- Regression test on current `origin/main`: **fails** with `#media:**%60C...md%60`.
- Same test on this branch: **passes** with `#media:C%3A%2F...md`.
- `chat-messages.test.ts`: **67/67 passed**.
- `markdown-text.media.test.tsx` (`jsdom`): **4/4 passed**.
- `npm exec tsc -- -p . --noEmit`: passed.
- ESLint on both changed files: passed.
- `git diff --check`: passed.
- `npm run build`: passed.
- Windows packaged Electron E2E: the rendered attachment click delivered the exact expected Windows path to the main process; after deployment, the real `.md` file opened successfully in MarkText.

## Scope / risk

The bare `MEDIA:` form and all existing path alternatives are preserved. The only new marker syntax is the observed `**MEDIA:**` form; other emphasis variants are deliberately out of scope.
