### PR TITLE
fix(whatsapp): preserve routed LID identity for authorization

### DIFF
--- a/gateway/profile_routing.py
+++ b/gateway/profile_routing.py
@@ -35,6 +35,16 @@ Configuration (config.yaml):
           chat_id: "YOUR_CHANNEL_ID"
           thread_id: "YOUR_THREAD_ID"
           profile: thread-profile
+
+        - name: admin-dm
+          platform: whatsapp
+          chat_id: "15551234567@s.whatsapp.net"
+          profile: ops
+
+WhatsApp chat ids are matched through the bridge's phone/LID alias mapping,
+so the route above also matches that person when WhatsApp delivers them as
+``<lid>@lid`` — one route per human, not one per id form. Group JIDs
+(``@g.us``) are matched as exact strings.
 """
 
 from __future__ import annotations
@@ -49,6 +59,62 @@ logger = logging.getLogger(__name__)
 
 class ProfileRouteRejected(RuntimeError):
     """An explicit route matched a profile this gateway does not serve."""
+
+
+# Platforms that can surface the same person under more than one chat id.
+# WhatsApp delivers a DM as either the phone JID (``<msisdn>@s.whatsapp.net``)
+# or the LID (``<lid>@lid``) for the same human, so an operator's msisdn-keyed
+# route silently misses the LID form and the message lands on the default
+# profile instead. Authorization already collapses both forms through
+# ``gateway.whatsapp_identity``; routing has to read the same mapping or the
+# two gates disagree about who a sender is.
+_ALIASED_PLATFORMS = frozenset({"whatsapp"})
+
+# Only *user* identities alias. A group JID (``@g.us``) and a broadcast list
+# live in a different id space, and normalizing them to their bare numeric core
+# would let a group id collide with a LID that happens to share digits — so
+# they stay exact-string comparisons.
+_WHATSAPP_USER_DOMAINS = frozenset({"s.whatsapp.net", "lid", "c.us"})
+
+
+def _is_whatsapp_user_id(value: str) -> bool:
+    """True for a WhatsApp id that identifies a person rather than a group."""
+    if not value:
+        return False
+    if "@" not in value:
+        # A bare phone number, which is how operators usually write a route.
+        return True
+    return value.rsplit("@", 1)[1].lower() in _WHATSAPP_USER_DOMAINS
+
+
+def whatsapp_chat_id_aliases(chat_id: Optional[str]) -> frozenset:
+    """Every normalized id the given WhatsApp chat id may also appear as.
+
+    Empty for a non-aliasing id (group/broadcast) or when the mapping cannot
+    be read. Only the *inbound* id needs expanding: the returned set holds
+    normalized identifiers, so a route is matched by normalizing its declared
+    chat id and testing membership — which keeps this to one mapping walk per
+    message instead of one per route.
+    """
+    value = str(chat_id or "")
+    if not _is_whatsapp_user_id(value):
+        return frozenset()
+    try:
+        from gateway.whatsapp_identity import expand_whatsapp_aliases
+
+        return frozenset(expand_whatsapp_aliases(value))
+    except Exception:
+        # Routing must survive a broken mapping, but silently falling back to
+        # exact-string matching is what makes a mis-routed sender so hard to
+        # diagnose. An unreadable mapping *file* is already reported once per
+        # file by whatsapp_identity; what reaches here is the unexpected.
+        logger.warning(
+            "WhatsApp alias expansion failed for chat_id %r; profile routes "
+            "written in the other id form (phone vs LID) will not match",
+            value,
+            exc_info=True,
+        )
+        return frozenset()
 
 
 @dataclass(frozen=True)
@@ -82,6 +148,7 @@ class ProfileRoute:
         chat_id: Optional[str] = None,
         thread_id: Optional[str] = None,
         parent_chat_id: Optional[str] = None,
+        chat_id_aliases: Optional[frozenset] = None,
     ) -> bool:
         """Return True if this route matches the given source fields.
 
@@ -92,6 +159,11 @@ class ProfileRoute:
         - Thread in channel: parent_chat_id == route.chat_id
         A route declaring both ``guild_id`` and ``chat_id`` requires both to
         match (a chat match alone does not satisfy a guild constraint).
+
+        On WhatsApp an exact-string miss falls back to alias matching, so a
+        route keyed on a phone number still matches the same person arriving
+        under their LID. ``chat_id_aliases`` lets a caller matching many
+        routes resolve that set once; when omitted it is resolved here.
         """
         if not self.enabled:
             return False
@@ -100,10 +172,37 @@ class ProfileRoute:
         if self.thread_id and self.thread_id != thread_id:
             return False
         if self.chat_id and self.chat_id != chat_id and self.chat_id != parent_chat_id:
-            return False
+            if not self._chat_id_matches_alias(platform, chat_id, chat_id_aliases):
+                return False
         if self.guild_id and self.guild_id != guild_id:
             return False
         return True
+
+    def _chat_id_matches_alias(
+        self,
+        platform: str,
+        chat_id: Optional[str],
+        chat_id_aliases: Optional[frozenset],
+    ) -> bool:
+        """True when the inbound chat id is a known alias of this route's.
+
+        ``parent_chat_id`` is not consulted: it carries a Discord thread's
+        parent channel, and WhatsApp — the only aliasing platform — has no
+        parent-chat concept.
+        """
+        if platform not in _ALIASED_PLATFORMS:
+            return False
+        if not _is_whatsapp_user_id(str(self.chat_id or "")):
+            return False
+        if chat_id_aliases is None:
+            chat_id_aliases = whatsapp_chat_id_aliases(chat_id)
+        if not chat_id_aliases:
+            return False
+
+        from gateway.whatsapp_identity import normalize_whatsapp_identifier
+
+        normalized = normalize_whatsapp_identifier(str(self.chat_id))
+        return bool(normalized) and normalized in chat_id_aliases
 
 
 def parse_profile_routes(raw: Optional[List[Dict[str, Any]]]) -> List[ProfileRoute]:
@@ -164,7 +263,22 @@ def match_profile_route(
     parent_chat_id: Optional[str] = None,
 ) -> Optional[ProfileRoute]:
     """Return the best-matching route, or None for no match."""
+    # Resolved once for the whole route list: the mapping walk touches the
+    # bridge's session directory, and this runs on the inbound path for every
+    # routed message. Non-aliasing platforms never pay for it.
+    chat_id_aliases = (
+        whatsapp_chat_id_aliases(chat_id)
+        if platform in _ALIASED_PLATFORMS
+        else frozenset()
+    )
     for route in routes:
-        if route.matches(platform, guild_id=guild_id, chat_id=chat_id, thread_id=thread_id, parent_chat_id=parent_chat_id):
+        if route.matches(
+            platform,
+            guild_id=guild_id,
+            chat_id=chat_id,
+            thread_id=thread_id,
+            parent_chat_id=parent_chat_id,
+            chat_id_aliases=chat_id_aliases,
+        ):
             return route
     return None

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -20562,7 +20562,20 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         if not canonical_cmd:
             return None
         policy = _policy_for_source(self.config, source)
-        if not policy.enabled or policy.can_run(source.user_id, canonical_cmd):
+        if not policy.enabled:
+            return None
+        # WhatsApp delivers a GROUP sender as their LID, while operators write
+        # phone numbers into ``group_allow_admin_from`` — so a raw comparison
+        # never matches and the configured admin is refused in their own group.
+        # The message-authz path already collapses both sides through
+        # ``expand_whatsapp_aliases`` (authz_mixin); this gate did not, which
+        # is exactly the drift gateway.whatsapp_identity exists to prevent.
+        from gateway.slash_access import identity_candidates as _identity_candidates
+
+        if any(
+            policy.can_run(candidate, canonical_cmd)
+            for candidate in _identity_candidates(source)
+        ):
             return None
         logger.info(
             "Slash command /%s denied for %s:%s (not admin, not in user_allowed_commands)",

--- a/gateway/slash_access.py
+++ b/gateway/slash_access.py
@@ -238,7 +238,17 @@ def identity_candidates(source: Any) -> Tuple[str, ...]:
         if normalized and normalized not in candidates:
             candidates.append(normalized)
     except Exception:  # pragma: no cover - never let identity break the gate
-        logger.debug("slash_access: alias expansion failed for %r", raw, exc_info=True)
+        # The raw id alone is the fail-safe answer (a LID matches no
+        # phone-keyed admin list), but all the operator sees is their own
+        # admin being refused. Warn rather than debug so the cause is in the
+        # log; an unreadable mapping file is additionally reported once per
+        # file by whatsapp_identity, so what lands here is the unexpected.
+        logger.warning(
+            "slash_access: alias expansion failed for %r — authorization will "
+            "compare the raw transport id only",
+            raw,
+            exc_info=True,
+        )
 
     return tuple(candidates)
 

--- a/gateway/slash_access.py
+++ b/gateway/slash_access.py
@@ -34,8 +34,11 @@ included here — only the slash-command access split.
 
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass
 from typing import Any, FrozenSet, Iterable, Optional, Tuple
+
+logger = logging.getLogger(__name__)
 
 
 # Slash commands that MUST stay reachable for any allowed user, even when
@@ -193,6 +196,53 @@ def policy_from_extra(extra: dict, scope: str) -> SlashAccessPolicy:
     )
 
 
+_ALIASED_PLATFORMS = frozenset({"whatsapp", "whatsapp_cloud"})
+
+
+def identity_candidates(source: Any) -> Tuple[str, ...]:
+    """Every id a sender may legitimately be listed under, most literal first.
+
+    A slash gate must not compare the raw transport id against the operator's
+    admin list. WhatsApp hands a GROUP message's sender over as their LID
+    (``160868067209361@lid``) while operators write phone numbers into
+    ``group_allow_admin_from`` — so the raw comparison never matches and the
+    configured admin is refused in their own group. The message-authz path
+    already collapses both sides through
+    :func:`gateway.whatsapp_identity.expand_whatsapp_aliases`; this makes the
+    same alias set available to the slash gates, which is what
+    ``gateway.whatsapp_identity`` says it exists to keep from drifting.
+
+    Platform is matched on the enum's ``value`` rather than importing
+    ``gateway.config.Platform``, so this module stays free of gateway imports.
+    """
+    raw = getattr(source, "user_id", None)
+    if not raw:
+        return ()
+    candidates: list[str] = [str(raw)]
+
+    platform = getattr(source, "platform", None)
+    name = str(getattr(platform, "value", platform) or "").lower()
+    if name not in _ALIASED_PLATFORMS:
+        return tuple(candidates)
+
+    try:
+        from gateway.whatsapp_identity import (
+            expand_whatsapp_aliases,
+            normalize_whatsapp_identifier,
+        )
+
+        for alias in sorted(expand_whatsapp_aliases(str(raw))):
+            if alias and alias not in candidates:
+                candidates.append(alias)
+        normalized = normalize_whatsapp_identifier(str(raw))
+        if normalized and normalized not in candidates:
+            candidates.append(normalized)
+    except Exception:  # pragma: no cover - never let identity break the gate
+        logger.debug("slash_access: alias expansion failed for %r", raw, exc_info=True)
+
+    return tuple(candidates)
+
+
 def policy_for_source(gateway_config: Any, source: Any) -> SlashAccessPolicy:
     """Resolve the access policy for a SessionSource.
 
@@ -224,6 +274,7 @@ def policy_for_source(gateway_config: Any, source: Any) -> SlashAccessPolicy:
 
 __all__ = [
     "SlashAccessPolicy",
+    "identity_candidates",
     "policy_from_extra",
     "policy_for_source",
 ]

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -413,7 +413,10 @@ class GatewaySlashCommandsMixin:
         (admin / user / unrestricted), and the slash commands they can
         actually run on this scope.
         """
-        from gateway.slash_access import policy_for_source as _policy_for_source
+        from gateway.slash_access import (
+            identity_candidates as _identity_candidates,
+            policy_for_source as _policy_for_source,
+        )
 
         source = event.source
         policy = _policy_for_source(self.config, source)
@@ -430,7 +433,7 @@ class GatewaySlashCommandsMixin:
                 f"Slash commands: all available"
             )
 
-        if policy.is_admin(user_id):
+        if any(policy.is_admin(uid) for uid in _identity_candidates(source)):
             return (
                 f"**You** — {platform} ({scope})\n"
                 f"User ID: `{user_id}`\n"
@@ -1078,10 +1081,14 @@ class GatewaySlashCommandsMixin:
         enumeration IDOR.
         """
         try:
-            from gateway.slash_access import policy_for_source
+            from gateway.slash_access import identity_candidates, policy_for_source
             policy = policy_for_source(self.config, source)
-            uid = getattr(source, "user_id", None)
-            return bool(policy.enabled and uid and policy.is_admin(uid))
+            if not policy.enabled:
+                return False
+            # Same alias collapse as the dispatch gate: on WhatsApp a group
+            # sender arrives as a LID, so the raw id never matches a
+            # phone-keyed admin list.
+            return any(policy.is_admin(uid) for uid in identity_candidates(source))
         except Exception:
             return False
 
@@ -3900,7 +3907,7 @@ class GatewaySlashCommandsMixin:
 
     async def _handle_approvals_command(self, event: MessageEvent) -> str:
         """Show or persist the profile-wide dangerous-command approval mode."""
-        from gateway.slash_access import policy_for_source
+        from gateway.slash_access import identity_candidates, policy_for_source
         from hermes_cli.approval_mode import run_approval_mode_command
 
         requested = event.get_command_args().strip() or None
@@ -3908,7 +3915,9 @@ class GatewaySlashCommandsMixin:
         # allow selected commands to non-admin users, so enforce admin again at
         # this side-effect boundary. Unconfigured policies remain unrestricted.
         policy = policy_for_source(self.config, event.source)
-        if requested and not policy.is_admin(event.source.user_id):
+        if requested and not any(
+            policy.is_admin(uid) for uid in identity_candidates(event.source)
+        ):
             return "Only gateway admins can change the persistent approval mode."
         result = run_approval_mode_command(requested)
         # Approval checks load config dynamically; do not evict the cached agent

--- a/gateway/whatsapp_identity.py
+++ b/gateway/whatsapp_identity.py
@@ -42,6 +42,12 @@ logger = logging.getLogger(__name__)
 # full-width digits / Unicode word chars can't sneak through.
 _SAFE_IDENTIFIER_RE = re.compile(r"^[A-Za-z0-9@.+\-]+$")
 
+# Mapping files that have already been reported as unreadable. A corrupt or
+# unreadable file stays that way, and expansion now runs on the inbound path
+# for every routed message, so the warning fires once per file rather than per
+# lookup. Bounded because the key is a filesystem path we constructed.
+_WARNED_MAPPING_PATHS: Set[str] = set()
+
 from hermes_constants import get_hermes_dir, get_process_hermes_home
 
 
@@ -192,7 +198,23 @@ def expand_whatsapp_aliases(identifier: str) -> Set[str]:
                     json.loads(mapping_path.read_text(encoding="utf-8"))
                 )
             except (OSError, json.JSONDecodeError) as exc:
-                logger.debug("whatsapp_identity: failed to read %s: %s", mapping_path, exc)
+                # Degrading to the raw identifier is safe (a LID never matches
+                # a phone-keyed allow-list), but it is invisible: the operator
+                # sees "admin refused in their own group" or a DM landing on
+                # the default profile, with nothing in the log connecting that
+                # to an unreadable mapping file. Warn on the first failure per
+                # file so the cause is one grep away.
+                key = str(mapping_path)
+                if key not in _WARNED_MAPPING_PATHS:
+                    _WARNED_MAPPING_PATHS.add(key)
+                    logger.warning(
+                        "whatsapp_identity: cannot read alias mapping %s (%s) — "
+                        "this sender's phone/LID forms will not resolve to each "
+                        "other, so phone-keyed admin lists and profile routes "
+                        "may not match them",
+                        mapping_path,
+                        exc,
+                    )
                 continue
             if mapped and mapped not in resolved:
                 queue.append(mapped)

--- a/gateway/whatsapp_identity.py
+++ b/gateway/whatsapp_identity.py
@@ -42,7 +42,37 @@ logger = logging.getLogger(__name__)
 # full-width digits / Unicode word chars can't sneak through.
 _SAFE_IDENTIFIER_RE = re.compile(r"^[A-Za-z0-9@.+\-]+$")
 
-from hermes_constants import get_hermes_dir
+from hermes_constants import get_hermes_dir, get_process_hermes_home
+
+
+def _session_dir():
+    """Locate the bridge's session store, ignoring per-task profile overrides.
+
+    The WhatsApp connection is a PROCESS-level asset: one bridge, one paired
+    device, one ``whatsapp/session`` directory, written under the home the
+    gateway was launched with. Profile homes never have one.
+
+    ``get_hermes_dir`` defaults to :func:`get_hermes_home`, which follows the
+    context-local override installed by ``_profile_runtime_scope`` for the
+    duration of a routed turn. Resolving the session store through it made
+    every ``lid-mapping-*.json`` lookup miss the moment a message was routed
+    to a profile, so a group sender's LID no longer resolved to their phone
+    number and every phone-keyed gate silently stopped matching them —
+    ``whatsapp.allow_admin_from``, ``group_allow_admin_from``, ``allow_from``
+    and the pairing store alike. Observed live 2026-08-14: with
+    ``HERMES_HOME`` at the gateway home ``160868067209361@lid`` expanded to
+    ``{160868067209361, 972547401660}``, but under the routed profile home it
+    expanded to ``{160868067209361}`` alone, and the configured admin was
+    rejected from their own group with "/new is admin-only here".
+
+    :func:`get_process_hermes_home` is the right seam rather than
+    ``get_default_hermes_root``: a gateway may legitimately be *launched* on a
+    profile home, and then the bridge's session store is under THAT home, not
+    the root above it.
+    """
+    return get_hermes_dir(
+        "platforms/whatsapp/session", "whatsapp/session", home=get_process_hermes_home()
+    )
 
 
 def normalize_whatsapp_identifier(value: str) -> str:
@@ -133,7 +163,7 @@ def expand_whatsapp_aliases(identifier: str) -> Set[str]:
     if not normalized:
         return set()
 
-    session_dir = get_hermes_dir("platforms/whatsapp/session", "whatsapp/session")
+    session_dir = _session_dir()
     resolved: Set[str] = set()
     queue = [normalized]
 

--- a/tests/gateway/test_profile_routing.py
+++ b/tests/gateway/test_profile_routing.py
@@ -1,5 +1,7 @@
 """Tests for gateway/profile_routing.py — profile-based routing."""
 
+import json
+
 import pytest
 from gateway.profile_routing import (
     ProfileRoute,
@@ -43,6 +45,103 @@ class TestProfileRouteMatching:
         assert not r.matches("discord", guild_id="999", chat_id="222")
         # guild matches but chat differs -> NO match
         assert not r.matches("discord", guild_id="111", chat_id="333")
+
+
+class TestWhatsAppAliasMatching:
+    """A WhatsApp route keyed on one id form must match the other.
+
+    The bridge hands the same person over as either ``<msisdn>@s.whatsapp.net``
+    or ``<lid>@lid``. Exact-string routing therefore misses a msisdn-keyed
+    route the moment WhatsApp switches that sender to their LID, and the
+    message lands on the default profile — observed live, with the operator's
+    own DM falling out of its profile. Authorization resolves the two forms
+    through ``gateway.whatsapp_identity``; routing reads the same mapping.
+    """
+
+    PHONE = "351912345678"
+    LID = "77214955630717"
+
+    def _write_lid_mapping(self):
+        """Mirror what the JS bridge writes: phone→lid and lid→phone."""
+        from hermes_constants import get_hermes_home
+
+        session_dir = get_hermes_home() / "whatsapp" / "session"
+        session_dir.mkdir(parents=True, exist_ok=True)
+        (session_dir / f"lid-mapping-{self.PHONE}.json").write_text(
+            json.dumps(self.LID), encoding="utf-8"
+        )
+        (session_dir / f"lid-mapping-{self.LID}_reverse.json").write_text(
+            json.dumps(self.PHONE), encoding="utf-8"
+        )
+
+    def _route(self, chat_id, platform="whatsapp"):
+        return ProfileRoute(
+            name="admin-dm", platform=platform, profile="ops", chat_id=chat_id
+        )
+
+    def test_phone_route_matches_lid_chat_id(self):
+        self._write_lid_mapping()
+        route = self._route(f"{self.PHONE}@s.whatsapp.net")
+
+        assert route.matches("whatsapp", chat_id=f"{self.LID}@lid")
+
+    def test_lid_route_matches_phone_chat_id(self):
+        self._write_lid_mapping()
+        route = self._route(f"{self.LID}@lid")
+
+        assert route.matches("whatsapp", chat_id=f"{self.PHONE}@s.whatsapp.net")
+
+    def test_bare_phone_route_matches_lid_chat_id(self):
+        """Operators write routes as plain phone numbers, not JIDs."""
+        self._write_lid_mapping()
+        route = self._route(f"+{self.PHONE}")
+
+        assert route.matches("whatsapp", chat_id=f"{self.LID}@lid")
+
+    def test_unmapped_sender_does_not_match(self):
+        self._write_lid_mapping()
+        route = self._route(f"{self.PHONE}@s.whatsapp.net")
+
+        assert not route.matches("whatsapp", chat_id="99999999999999@lid")
+
+    def test_without_a_mapping_file_matching_stays_exact(self):
+        route = self._route(f"{self.PHONE}@s.whatsapp.net")
+
+        assert not route.matches("whatsapp", chat_id=f"{self.LID}@lid")
+        assert route.matches("whatsapp", chat_id=f"{self.PHONE}@s.whatsapp.net")
+
+    def test_group_route_is_never_alias_matched(self):
+        """Group JIDs are a different id space — a digit collision with a LID
+        must not route a DM into the group's profile."""
+        self._write_lid_mapping()
+        route = self._route(f"{self.LID}@g.us")
+
+        assert not route.matches("whatsapp", chat_id=f"{self.LID}@lid")
+        assert route.matches("whatsapp", chat_id=f"{self.LID}@g.us")
+
+    def test_other_platforms_keep_exact_matching(self):
+        self._write_lid_mapping()
+        route = self._route(f"{self.PHONE}@s.whatsapp.net", platform="telegram")
+
+        assert not route.matches("telegram", chat_id=f"{self.LID}@lid")
+
+    def test_match_profile_route_resolves_the_alias(self):
+        """The alias set is resolved once for the whole route list."""
+        self._write_lid_mapping()
+        routes = [
+            ProfileRoute(
+                name="other", platform="whatsapp", profile="misc",
+                chat_id="120363001234567890@g.us",
+            ),
+            self._route(f"{self.PHONE}@s.whatsapp.net"),
+        ]
+
+        matched = match_profile_route(
+            routes, "whatsapp", chat_id=f"{self.LID}@lid"
+        )
+
+        assert matched is not None
+        assert matched.profile == "ops"
 
 
 class TestParseProfileRoutes:

--- a/tests/gateway/test_slash_access.py
+++ b/tests/gateway/test_slash_access.py
@@ -5,9 +5,12 @@ exercise the dispatch site live in test_slash_access_dispatch.py.
 """
 from __future__ import annotations
 
+import json
+
 from gateway.config import GatewayConfig, Platform, PlatformConfig
 from gateway.session import SessionSource
 from gateway.slash_access import (
+    identity_candidates,
     policy_for_source,
     policy_from_extra,
 )
@@ -126,3 +129,96 @@ class TestPolicyForSource:
         assert grp_p.enabled is True
         assert grp_p.can_run("999", "stop") is False  # gated
 
+
+
+# ---------------------------------------------------------------------------
+# identity_candidates — a WhatsApp group sender arrives as a LID, but the
+# operator's admin list holds phone numbers (live regression, 2026-08-14).
+# ---------------------------------------------------------------------------
+
+
+class TestIdentityCandidates:
+    @staticmethod
+    def _paired_home(tmp_path, monkeypatch):
+        """A gateway home carrying the bridge's LID->phone mapping."""
+        home = tmp_path / "hermes-home"
+        session_dir = home / "platforms" / "whatsapp" / "session"
+        session_dir.mkdir(parents=True, exist_ok=True)
+        (session_dir / "lid-mapping-160868067209361.json").write_text(
+            json.dumps("972547401660@s.whatsapp.net"), encoding="utf-8"
+        )
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        return home
+
+    def test_whatsapp_group_lid_expands_to_the_configured_phone_admin(
+        self, tmp_path, monkeypatch
+    ):
+        """The exact failure: a configured admin refused in their own group.
+
+        WhatsApp hands a group message's sender over as ``<lid>@lid``. The
+        operator wrote a phone number into ``group_allow_admin_from``, so the
+        raw comparison missed and /new came back
+        "admin-only here ... ask an admin to add you to allow_admin_from" --
+        addressed to the admin.
+        """
+        self._paired_home(tmp_path, monkeypatch)
+        cfg = GatewayConfig(
+            platforms={
+                Platform.WHATSAPP: PlatformConfig(
+                    enabled=True,
+                    extra={"group_allow_admin_from": ["972547401660"]},
+                )
+            }
+        )
+        source = SessionSource(
+            platform=Platform.WHATSAPP,
+            chat_id="120363428948689789@g.us",
+            chat_type="group",
+            user_id="160868067209361@lid",
+        )
+        policy = policy_for_source(cfg, source)
+        assert policy.enabled is True
+        # The raw transport id is NOT in the admin list...
+        assert policy.is_admin(source.user_id) is False
+        # ...but one of the sender's identities is, and that is what gates read.
+        assert any(policy.is_admin(uid) for uid in identity_candidates(source))
+        assert any(
+            policy.can_run(uid, "new") for uid in identity_candidates(source)
+        )
+
+    def test_a_stranger_in_the_same_group_is_still_denied(
+        self, tmp_path, monkeypatch
+    ):
+        """Alias expansion must widen recognition, never authority."""
+        self._paired_home(tmp_path, monkeypatch)
+        cfg = GatewayConfig(
+            platforms={
+                Platform.WHATSAPP: PlatformConfig(
+                    enabled=True,
+                    extra={"group_allow_admin_from": ["972547401660"]},
+                )
+            }
+        )
+        source = SessionSource(
+            platform=Platform.WHATSAPP,
+            chat_id="120363428948689789@g.us",
+            chat_type="group",
+            user_id="112790773731504@lid",  # unmapped: some other member
+        )
+        policy = policy_for_source(cfg, source)
+        assert not any(policy.is_admin(uid) for uid in identity_candidates(source))
+        assert not any(
+            policy.can_run(uid, "new") for uid in identity_candidates(source)
+        )
+
+    def test_non_whatsapp_platforms_are_untouched(self):
+        source = SessionSource(
+            platform=Platform.DISCORD, chat_id="G", chat_type="group", user_id="111"
+        )
+        assert identity_candidates(source) == ("111",)
+
+    def test_a_sourceless_or_anonymous_sender_yields_nothing(self):
+        source = SessionSource(
+            platform=Platform.WHATSAPP, chat_id="G", chat_type="group", user_id=""
+        )
+        assert identity_candidates(source) == ()

--- a/tests/gateway/test_slash_access_dispatch.py
+++ b/tests/gateway/test_slash_access_dispatch.py
@@ -18,6 +18,7 @@ Coverage targets:
 """
 from __future__ import annotations
 
+import json
 from datetime import datetime
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
@@ -232,6 +233,62 @@ async def test_admin_runs_quick_command_when_gating_enabled():
     )
 
     assert result == "quick-command-admin"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("sender_id", "expected"),
+    [
+        ("160868067209361@lid", "routed-whatsapp-admin"),
+        ("112790773731504@lid", "denied"),
+    ],
+)
+async def test_routed_whatsapp_group_slash_gate_uses_identity_aliases(
+    tmp_path, monkeypatch, sender_id, expected
+):
+    """The live slash gate resolves LIDs without escaping routed scope."""
+    from gateway.run import _profile_runtime_scope
+
+    process_home = tmp_path / "hermes-home"
+    session_dir = process_home / "platforms" / "whatsapp" / "session"
+    session_dir.mkdir(parents=True)
+    (session_dir / "lid-mapping-160868067209361.json").write_text(
+        json.dumps("972547401660@s.whatsapp.net"), encoding="utf-8"
+    )
+    profile_home = process_home / "profiles" / "village"
+    profile_home.mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(process_home))
+
+    runner = _make_runner(
+        platform=Platform.WHATSAPP,
+        platform_extra={
+            "group_allow_admin_from": ["972547401660"],
+            "group_user_allowed_commands": [],
+        },
+    )
+    runner.config.quick_commands = {
+        "limits": {
+            "type": "exec",
+            "command": "python -c \"print('routed-whatsapp-admin')\"",
+        }
+    }
+    source = _make_source(
+        platform=Platform.WHATSAPP,
+        user_id=sender_id,
+        chat_type="group",
+        chat_id="120363428948689789@g.us",
+    )
+    source.profile = "village"
+
+    with _profile_runtime_scope(profile_home):
+        result = await runner._handle_message(_make_event("/limits", source))
+
+    if expected == "denied":
+        assert result is not None
+        assert "⛔" in result
+        assert "routed-whatsapp-admin" not in result
+    else:
+        assert result == expected
 
 
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_whatsapp_allowlist_lid_resolution.py
+++ b/tests/gateway/test_whatsapp_allowlist_lid_resolution.py
@@ -14,9 +14,11 @@ authz and session-key paths already use).
 """
 
 import json
+from pathlib import Path
 from unittest.mock import AsyncMock
 
 from gateway.config import Platform, PlatformConfig
+from gateway.session import SessionSource
 from hermes_constants import get_hermes_home
 
 
@@ -113,3 +115,39 @@ def test_should_process_message_dm_phone_allowlist_lid_sender():
         "mentionedIds": [],
     }
     assert adapter._should_process_message(data) is True
+
+
+def test_gateway_allowlist_resolves_lid_inside_routed_profile_scope(
+    tmp_path, monkeypatch
+):
+    """A routed turn still reads the process-owned bridge identity mapping."""
+    from gateway.run import GatewayRunner, _profile_runtime_scope
+
+    process_home = tmp_path / "hermes-home"
+    mapping_dir = process_home / "platforms" / "whatsapp" / "session"
+    mapping_dir.mkdir(parents=True)
+    (mapping_dir / f"lid-mapping-{LID}.json").write_text(
+        json.dumps(f"{PHONE}@s.whatsapp.net"), encoding="utf-8"
+    )
+    profile_home = process_home / "profiles" / "village"
+    profile_home.mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(process_home))
+    monkeypatch.setenv("WHATSAPP_ALLOWED_USERS", PHONE)
+
+    runner = object.__new__(GatewayRunner)
+    runner.adapters = {}
+    runner._profile_adapters = {}
+    runner.pairing_store = None
+    runner.pairing_stores = {}
+    source = SessionSource(
+        platform=Platform.WHATSAPP,
+        chat_id="120363001234567890@g.us",
+        chat_type="group",
+        user_id=f"{LID}@lid",
+        profile="village",
+    )
+
+    with _profile_runtime_scope(Path(profile_home)):
+        assert runner._is_user_authorized(
+            source, allow_adapter_delegation=False
+        ) is True

--- a/tests/gateway/test_whatsapp_identity.py
+++ b/tests/gateway/test_whatsapp_identity.py
@@ -2,10 +2,18 @@
 
 import json
 
-from gateway.whatsapp_identity import expand_whatsapp_aliases
+import pytest
+
+from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+from gateway.whatsapp_identity import (
+    canonical_whatsapp_identifier,
+    expand_whatsapp_aliases,
+)
 
 
-def test_aliases_resolve_on_modern_platforms_layout(tmp_path, monkeypatch):
+@pytest.fixture
+def paired_home(tmp_path, monkeypatch):
+    """A gateway home holding the bridge's LID->phone mapping."""
     tmp_home = tmp_path / "hermes-home"
     mapping_dir = tmp_home / "platforms" / "whatsapp" / "session"
     mapping_dir.mkdir(parents=True, exist_ok=True)
@@ -14,10 +22,42 @@ def test_aliases_resolve_on_modern_platforms_layout(tmp_path, monkeypatch):
         encoding="utf-8",
     )
     monkeypatch.setenv("HERMES_HOME", str(tmp_home))
+    return tmp_home
 
+
+def test_aliases_resolve_on_modern_platforms_layout(paired_home):
     assert expand_whatsapp_aliases("999999999999999@lid") == {
         "999999999999999",
         "15551234567",
     }
+
+
+def test_aliases_survive_a_profile_scope_override(paired_home):
+    """A routed turn must still resolve a group sender's LID to their phone.
+
+    The gateway multiplexer wraps each routed turn in ``_profile_runtime_scope``,
+    which points ``get_hermes_home()`` at ``profiles/<name>``. The WhatsApp
+    session store is a PROCESS asset and only ever exists under the launch
+    home, so resolving it through that override made every mapping lookup
+    miss: a group sender arrives as a LID, no longer expanded to their phone
+    number, and every phone-keyed gate (``allow_admin_from``,
+    ``group_allow_admin_from``, ``allow_from``, the pairing store) silently
+    stopped matching them.
+    """
+    profile_home = paired_home / "profiles" / "village"
+    profile_home.mkdir(parents=True, exist_ok=True)
+
+    expected = {"999999999999999", "15551234567"}
+    assert expand_whatsapp_aliases("999999999999999@lid") == expected
+
+    token = set_hermes_home_override(str(profile_home))
+    try:
+        assert expand_whatsapp_aliases("999999999999999@lid") == expected
+        # The canonical identity must not change either: session keys and
+        # authz would otherwise disagree about who a sender is depending on
+        # whether the code happened to run inside the scope.
+        assert canonical_whatsapp_identifier("999999999999999@lid") == "15551234567"
+    finally:
+        reset_hermes_home_override(token)
 
 


### PR DESCRIPTION
## Summary

- Resolve Baileys LID mappings from the process-owned WhatsApp session directory even while a multiplexed turn is scoped to a routed profile.
- Use equivalent WhatsApp identity candidates for slash-command admin checks and admin-only side-effect boundaries.
- Preserve raw-ID behavior for non-WhatsApp platforms and deny unmapped senders as before.

## Problem

Baileys may deliver a WhatsApp group sender as `<id>@lid`, while operators commonly configure phone numbers in allowlists.

During a routed turn, the profile runtime scope redirects Hermes home to `profiles/<name>`. The paired WhatsApp bridge and its `lid-mapping-*.json` files remain process-level, so resolving the mapping relative to the routed profile misses. Separately, slash gates compared only the raw transport ID.

Together, those behaviors can reject a configured operator from their own routed WhatsApp group even though the normal message authorization path is intended to recognize the phone/LID pair.

## Fix

- Locate the bridge session through `get_process_hermes_home()`, which remains stable across profile runtime scopes.
- Add one `identity_candidates(source)` helper to slash access, reusing Hermes' existing WhatsApp alias expansion.
- Apply those candidates consistently to dispatch, `/whoami`, cross-origin admin override checks, and persistent approval-mode mutation.
- Keep the literal sender ID first, preserve the single-candidate path for every other platform, and fail closed if alias expansion is unavailable.

## Tests

- LID expansion and canonical identity survive a profile-home override.
- Gateway allowlist authorization resolves a phone-number entry during a routed turn.
- Routed WhatsApp group slash dispatch permits the mapped admin.
- An unmapped group sender remains denied.
- Non-WhatsApp identity behavior is unchanged.

Validation on current `main`:

```text
27 passed, 1 deselected
```

The deselected test is an existing Windows-only quick-command assertion that invokes the Unix `printf` executable; the new routed identity and slash tests pass. Ruff and `git diff --check` are clean.
