### PR TITLE
fix(gemini): echo bridged tool_call name on the OpenAI-compatible path

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -3740,15 +3740,21 @@ def sanitize_api_messages(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]
     # name. Runs on the per-call copy, so the stored trajectory keeps the real
     # tool name for the session DB and the UI — only the wire payload changes.
     # A no-op for the native Gemini path, which already resolves the same name.
+    # A result whose assistant call frame is missing entirely never reaches
+    # here — pass 1 above drops it as an orphan — so the only results this pass
+    # sees are ones whose call name is knowable.
     call_names: Dict[str, str] = {}
     for msg in messages:
         if msg.get("role") == "assistant":
             for tc in msg.get("tool_calls") or []:
-                cid = _ra().AIAgent._get_tool_call_id_static(tc)
+                # Strip on insert to match the lookup below (and pass 1's
+                # ``result_call_ids``), so an id that arrives padded still
+                # pairs instead of silently skipping realignment.
+                cid = (_ra().AIAgent._get_tool_call_id_static(tc) or "").strip()
                 nm = _ra().AIAgent._get_tool_call_name_static(tc)
                 if cid and nm:
                     call_names[cid] = nm
-    realigned = 0
+    realigned: List[Tuple[str, str]] = []
     aligned: List[Dict[str, Any]] = []
     for msg in messages:
         if msg.get("role") == "tool":
@@ -3761,14 +3767,15 @@ def sanitize_api_messages(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]
             # must still pass through byte-identical for prompt caching.
             if expected and current and current != expected:
                 msg = {**msg, "name": expected}
-                realigned += 1
+                realigned.append((current, expected))
         aligned.append(msg)
     if realigned:
         messages = aligned
         _ra().logger.debug(
             "Pre-call sanitizer: realigned %d tool result name(s) with their "
-            "tool_call function name",
-            realigned,
+            "tool_call function name (%s)",
+            len(realigned),
+            ", ".join(f"{was} -> {now}" for was, now in realigned),
         )
     return messages
 

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -3716,6 +3716,60 @@ def sanitize_api_messages(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]
             "Pre-call sanitizer: removed %d duplicate tool_call_id reference(s)",
             removed_dupes,
         )
+
+    # 4. Align each tool result's wire-visible ``name`` with the function name
+    # of the call it answers. Google matches functionResponse.name against
+    # functionCall.name and rejects a mismatch with HTTP 400 "Request contains
+    # an invalid argument" (INVALID_ARGUMENT); behind an OpenAI-compatible
+    # gateway that surfaces only as a generic "Provider returned error".
+    #
+    # The mismatch is routine, not corruption. When tool_search defers
+    # MCP/plugin tools the model calls the bridge tool ``tool_call``, while
+    # ``make_tool_result_message()`` labels the result with the unwrapped
+    # internal tool name (``mcp__github__create_issue``) that dispatch, hooks,
+    # logging, and guardrails need. #72089 fixed exactly this for the native
+    # Gemini adapter, which now prefers ``tool_name_by_call_id`` over the
+    # result name; requests that reach Gemini through the OpenAI-compatible
+    # path (OpenRouter, Vertex/LiteLLM proxies, any OpenAI-shaped gateway) skip
+    # that translation entirely and still send the internal name on the wire.
+    #
+    # Normalizing here rather than in the OpenAI-compat serializer keeps it
+    # provider-agnostic: Gemini reaches Hermes under many model strings and
+    # base URLs, so sniffing for "is this really Google?" is unreliable, and
+    # every other provider either ignores the field or agrees with the call
+    # name. Runs on the per-call copy, so the stored trajectory keeps the real
+    # tool name for the session DB and the UI — only the wire payload changes.
+    # A no-op for the native Gemini path, which already resolves the same name.
+    call_names: Dict[str, str] = {}
+    for msg in messages:
+        if msg.get("role") == "assistant":
+            for tc in msg.get("tool_calls") or []:
+                cid = _ra().AIAgent._get_tool_call_id_static(tc)
+                nm = _ra().AIAgent._get_tool_call_name_static(tc)
+                if cid and nm:
+                    call_names[cid] = nm
+    realigned = 0
+    aligned: List[Dict[str, Any]] = []
+    for msg in messages:
+        if msg.get("role") == "tool":
+            cid = (msg.get("tool_call_id") or "").strip()
+            expected = call_names.get(cid)
+            current = msg.get("name")
+            # Only rewrite a name that is present and disagrees. A result with
+            # no ``name`` is already valid for Gemini (the id pairs it), so
+            # leave it absent rather than inventing a field: clean transcripts
+            # must still pass through byte-identical for prompt caching.
+            if expected and current and current != expected:
+                msg = {**msg, "name": expected}
+                realigned += 1
+        aligned.append(msg)
+    if realigned:
+        messages = aligned
+        _ra().logger.debug(
+            "Pre-call sanitizer: realigned %d tool result name(s) with their "
+            "tool_call function name",
+            realigned,
+        )
     return messages
 
 

--- a/tests/run_agent/test_message_sequence_repair.py
+++ b/tests/run_agent/test_message_sequence_repair.py
@@ -481,8 +481,8 @@ def test_sanitize_realigns_bridged_tool_result_name_with_call_name():
     assert messages[2]["name"] == "mcp__github__create_issue"
 
 
-def test_sanitize_leaves_matching_and_unpaired_tool_result_names_alone():
-    """Directly-called tools already agree; an unpaired name is left as-is."""
+def test_sanitize_leaves_already_matching_tool_result_name_alone():
+    """A directly-called tool already agrees — nothing to rewrite."""
     from agent.agent_runtime_helpers import sanitize_api_messages
 
     messages = [
@@ -514,3 +514,35 @@ def test_sanitize_does_not_invent_a_name_on_unnamed_tool_results():
     ]
     out = sanitize_api_messages(list(messages))
     assert out == messages
+
+
+def test_sanitize_realigns_bridged_name_when_call_id_is_padded():
+    """Ids are stripped on both sides, so a padded id still pairs."""
+    from agent.agent_runtime_helpers import sanitize_api_messages
+
+    messages = [
+        {"role": "user", "content": "file an issue"},
+        {"role": "assistant", "content": "",
+         "tool_calls": [{"id": " call_1 ", "type": "function",
+                         "function": {"name": "tool_call", "arguments": "{}"}}]},
+        {"role": "tool", "name": "mcp__github__create_issue",
+         "tool_call_id": "call_1", "content": "{}"},
+    ]
+    out = sanitize_api_messages(list(messages))
+    assert [m["name"] for m in out if m.get("role") == "tool"] == ["tool_call"]
+
+
+def test_sanitize_drops_bridged_result_whose_call_frame_was_pruned():
+    """A result cannot keep a stale name if it has no call frame to disagree
+    with: the orphan pass removes it before the realignment pass runs, so the
+    mismatch never reaches the provider."""
+    from agent.agent_runtime_helpers import sanitize_api_messages
+
+    messages = [
+        {"role": "user", "content": "file an issue"},
+        # assistant tool_calls frame dropped by compression
+        {"role": "tool", "name": "mcp__github__create_issue",
+         "tool_call_id": "call_1", "content": "{}"},
+    ]
+    out = sanitize_api_messages(list(messages))
+    assert [m.get("role") for m in out] == ["user"]

--- a/tests/run_agent/test_message_sequence_repair.py
+++ b/tests/run_agent/test_message_sequence_repair.py
@@ -440,3 +440,77 @@ def test_sanitize_dedup_drops_tool_calls_key_when_all_removed():
     assert "tool_calls" not in assistant2
     # Content should be preserved
     assert assistant2["content"] == "retrying"
+
+
+# ── Bridged tool_call: wire-visible response name must echo the call name ──
+# Google matches functionResponse.name against functionCall.name and rejects a
+# mismatch with HTTP 400 INVALID_ARGUMENT. #72089 fixed this for the native
+# Gemini adapter; requests reaching Gemini through an OpenAI-compatible
+# gateway (OpenRouter, Vertex/LiteLLM proxies) skip that translation, so the
+# chokepoint sanitizer has to hold the same invariant.
+
+
+def test_sanitize_realigns_bridged_tool_result_name_with_call_name():
+    """A tool_search-bridged result must go on the wire as ``tool_call``.
+
+    The executor labels the result with the unwrapped internal tool name for
+    dispatch/hooks/logging; Gemini sees that as a functionResponse whose name
+    does not match its functionCall and 400s.
+    """
+    from agent.agent_runtime_helpers import sanitize_api_messages
+
+    messages = [
+        {"role": "user", "content": "file an issue"},
+        {"role": "assistant", "content": "",
+         "tool_calls": [{"id": "call_1", "type": "function",
+                         "function": {
+                             "name": "tool_call",
+                             "arguments": ('{"name": "mcp__github__create_issue",'
+                                           ' "arguments": {"title": "Bug"}}'),
+                         }}]},
+        {"role": "tool", "name": "mcp__github__create_issue",
+         "tool_name": "mcp__github__create_issue",
+         "tool_call_id": "call_1", "content": '{"number": 123}'},
+    ]
+    out = sanitize_api_messages(list(messages))
+    result = [m for m in out if m.get("role") == "tool"][0]
+    assert result["name"] == "tool_call"
+    # The internal name stays available for the session DB / UI, and the
+    # caller's own message objects are untouched (per-call copy only).
+    assert result["tool_name"] == "mcp__github__create_issue"
+    assert messages[2]["name"] == "mcp__github__create_issue"
+
+
+def test_sanitize_leaves_matching_and_unpaired_tool_result_names_alone():
+    """Directly-called tools already agree; an unpaired name is left as-is."""
+    from agent.agent_runtime_helpers import sanitize_api_messages
+
+    messages = [
+        {"role": "user", "content": "weather?"},
+        {"role": "assistant", "content": None,
+         "tool_calls": [{"id": "call_1", "type": "function",
+                         "function": {"name": "get_weather", "arguments": "{}"}}]},
+        {"role": "tool", "name": "get_weather",
+         "tool_call_id": "call_1", "content": "sunny"},
+    ]
+    out = sanitize_api_messages(list(messages))
+    assert [m["name"] for m in out if m.get("role") == "tool"] == ["get_weather"]
+
+
+def test_sanitize_does_not_invent_a_name_on_unnamed_tool_results():
+    """A result with no ``name`` is already valid — the id pairs it.
+
+    Adding the field would make clean transcripts non-identical on the wire
+    and needlessly perturb prompt caching.
+    """
+    from agent.agent_runtime_helpers import sanitize_api_messages
+
+    messages = [
+        {"role": "user", "content": "run it"},
+        {"role": "assistant", "content": None,
+         "tool_calls": [{"id": "call_1", "type": "function",
+                         "function": {"name": "terminal", "arguments": "{}"}}]},
+        {"role": "tool", "tool_call_id": "call_1", "content": "ok"},
+    ]
+    out = sanitize_api_messages(list(messages))
+    assert out == messages


### PR DESCRIPTION
## What does this PR do?

Holds the `#72089` invariant — a tool result's wire-visible name must echo the `functionCall.name` it answers — on the **OpenAI-compatible** path as well as the native Gemini one.

`#72089` fixed `_translate_tool_result_to_gemini()` so the native adapter prefers `tool_name_by_call_id` over the result message's internal name. Requests that reach Gemini through an OpenAI-compatible gateway (OpenRouter, Vertex/LiteLLM proxies) never run that translation, so they still put the unwrapped internal tool name on the wire. Google matches `functionResponse.name` against `functionCall.name` and rejects the mismatch with HTTP 400 `INVALID_ARGUMENT`, which behind OpenRouter surfaces only as a bare `"Provider returned error"`.

The fix goes in `sanitize_api_messages()` — the documented final pre-API chokepoint, already home to comparable provider-strictness repairs (DeepSeek's empty `tool_calls` array, duplicate `tool_call_id`s) — rather than in the OpenAI-compat serializer. Rationale: Gemini arrives under many model strings and base URLs, so sniffing for "is this really Google?" is unreliable, while every other provider either ignores the field or already agrees with the call name. It is a no-op for the native path, which resolves the same name a layer down.

Two deliberate narrowings keep the blast radius minimal:

- **Only a `name` that is present and disagrees is rewritten.** A result with no `name` is already valid (the id pairs it), so the field is not invented — clean transcripts still pass through byte-identical, which `TestSanitizeApiMessages::test_clean_messages_pass_through` asserts and prompt caching depends on.
- **The rewrite lands on the per-call copy only.** The stored trajectory keeps the real tool name for the session DB and the UI; only the wire payload changes.

## Related Issue

Fixes #87628

Sibling of #72089 (native Gemini adapter, fixed in 01cb38e8ec).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/agent_runtime_helpers.py` — new pass 4 in `sanitize_api_messages()`: build `{tool_call_id: function name}` from the assistant turns, then realign any tool result whose `name` is present and disagrees.
- `tests/run_agent/test_message_sequence_repair.py` — three regression tests: bridged name is realigned (and the internal `tool_name` plus the caller's own message objects survive untouched), a directly-called tool that already agrees is left alone, and an unnamed result does not acquire a `name`.

## How to Test

Reproduced against live OpenRouter → Gemini before and after. Hermes writes a full request dump to `<profile>/sessions/request_dump_<session>_<ts>.json` on any API error; replaying that exact body reproduces the 400, and replaying it with the tool result's `name` realigned returns 200.

Isolating the field on a three-message transcript (bridge call + result), everything else identical:

| tool result `name` | result |
| --- | --- |
| `mcp__strava__get_recent_activities` | **HTTP 400** `INVALID_ARGUMENT` |
| `tool_call` | 200 OK |
| omitted | 200 OK |

End to end: a profile on `google/gemini-3.7-flash` via OpenRouter with three MCP servers failed on every turn that touched a deferred MCP tool, and works after the patch.

To reproduce from scratch:

1. Point a profile at `model.provider: openrouter` / `model.default: google/gemini-3.7-flash` with at least one MCP server configured, leaving `tools.tool_search.enabled` at its default `auto`.
2. Ask for something that reaches a deferred MCP tool.
3. Before: the tool runs, then the next request 400s and the session stays poisoned. After: the turn completes.

New tests fail on `main` and pass with the change:

```
$ pytest tests/run_agent/test_message_sequence_repair.py::test_sanitize_realigns_bridged_tool_result_name_with_call_name -q
E  - tool_call
E  + mcp__github__create_issue
1 failed
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — ran `pytest tests/run_agent/ -q` (1674 passed) plus `tests/agent/test_prompt_caching.py`; not the full suite. The 6 remaining failures in that directory are pre-existing in my environment (missing `anthropic` package) and reproduce with the change stashed.
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Debian 12, Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A (the rationale lives in the code comment, matching the surrounding passes)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A (pure dict manipulation, no platform surface)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
