### PR TITLE
fix(auth): retry transient Codex device poll failures

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -8272,11 +8272,18 @@ def _codex_device_code_login() -> Dict[str, Any]:
         with httpx.Client(timeout=httpx.Timeout(15.0)) as client:
             while _time.monotonic() - start < max_wait:
                 _time.sleep(poll_interval)
-                poll_resp = client.post(
-                    f"{issuer}/api/accounts/deviceauth/token",
-                    json={"device_auth_id": device_auth_id, "user_code": user_code},
-                    headers={"Content-Type": "application/json"},
-                )
+                try:
+                    poll_resp = client.post(
+                        f"{issuer}/api/accounts/deviceauth/token",
+                        json={"device_auth_id": device_auth_id, "user_code": user_code},
+                        headers={"Content-Type": "application/json"},
+                    )
+                except httpx.RequestError:
+                    # Transient network failure (slow TLS handshake, dropped
+                    # connection). Keep polling until max_wait — aborting here
+                    # orphans a device code the user may already have approved
+                    # in the browser.
+                    continue
 
                 if poll_resp.status_code == 200:
                     code_resp = poll_resp.json()

--- a/tests/hermes_cli/test_auth_codex_provider.py
+++ b/tests/hermes_cli/test_auth_codex_provider.py
@@ -510,6 +510,81 @@ def _patch_httpx(monkeypatch, response):
     monkeypatch.setattr("hermes_cli.auth.httpx.Client", _factory)
 
 
+def test_device_code_poll_retries_transient_http_error(monkeypatch):
+    """One transport failure must not orphan an already-issued device code."""
+    import time
+
+    import hermes_cli.auth as auth
+
+    client_outcomes = [
+        [
+            _StubHTTPResponse(
+                200,
+                {
+                    "user_code": "ABCD-EFGH",
+                    "device_auth_id": "device-auth-id",
+                    "interval": "3",
+                },
+            )
+        ],
+        [
+            auth.httpx.ConnectTimeout("slow TLS handshake"),
+            _StubHTTPResponse(
+                200,
+                {
+                    "authorization_code": "authorization-code",
+                    "code_verifier": "code-verifier",
+                },
+            ),
+        ],
+        [
+            _StubHTTPResponse(
+                200,
+                {
+                    "access_token": "access-token",
+                    "refresh_token": "refresh-token",
+                },
+            )
+        ],
+    ]
+    poll_attempts = []
+
+    class _SequencedClient:
+        def __init__(self, outcomes):
+            self._outcomes = outcomes
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return False
+
+        def post(self, url, **kwargs):
+            outcome = self._outcomes.pop(0)
+            if url.endswith("/api/accounts/deviceauth/token"):
+                poll_attempts.append(url)
+            if isinstance(outcome, Exception):
+                raise outcome
+            return outcome
+
+    def _client_factory(*args, **kwargs):
+        return _SequencedClient(client_outcomes.pop(0))
+
+    ticks = iter(range(10))
+    monkeypatch.setattr(auth.httpx, "Client", _client_factory)
+    monkeypatch.setattr(time, "sleep", lambda _seconds: None)
+    monkeypatch.setattr(time, "monotonic", lambda: next(ticks))
+
+    credentials = auth._codex_device_code_login()
+
+    assert credentials["tokens"] == {
+        "access_token": "access-token",
+        "refresh_token": "refresh-token",
+    }
+    assert len(poll_attempts) == 2
+    assert client_outcomes == []
+
+
 
 
 def test_refresh_429_classified_as_quota_not_auth_failure(monkeypatch):
@@ -607,7 +682,6 @@ def _patch_httpx_post(monkeypatch, responses):
             return next(seq)
 
     monkeypatch.setattr("hermes_cli.auth.httpx.Client", lambda *a, **k: _FakeClient())
-
 
 
 


### PR DESCRIPTION
## Problem

After OpenAI issues a Codex device code, Hermes polls the device-auth token endpoint until the user approves it. That poll request was unguarded: one transient transport failure such as `httpx.ConnectTimeout` aborted the entire login and orphaned a device code the user may already have approved in the browser.

## Fix

Catch `httpx.RequestError` only around the device-token poll request and continue polling. The existing 15-minute `max_wait` remains the hard bound, so a persistent outage still ends with the normal timeout.

HTTP responses keep their existing behavior: 200 succeeds, 403/404 remain pending, and unexpected statuses still raise `device_code_poll_error`. Initial device-code issuance and final token exchange are intentionally unchanged.

## Tests

Added an end-to-end regression that drives all three HTTP client phases:

1. a device code is issued;
2. the first poll raises `httpx.ConnectTimeout`;
3. the next poll succeeds;
4. authorization-code exchange returns access and refresh tokens.

The test asserts two poll attempts and the final credentials.

```text
12 passed
ruff: clean
git diff --check: clean
```
