### PR TITLE
fix(whatsapp): stop empty resend on decryption retry

### DIFF
--- a/scripts/whatsapp-bridge/bridge.js
+++ b/scripts/whatsapp-bridge/bridge.js
@@ -44,6 +44,7 @@ import {
   inboundReadReceiptKeys,
   inferMediaType,
   mediaPayloadForFile,
+  missingMessageStoreLookup,
   pollCreationMessageFromPayload,
   pollUpdateForAggregation,
 } from './bridge_helpers.js';
@@ -410,13 +411,11 @@ async function startSocket() {
     browser: ['Hermes Agent', 'Chrome', '120.0'],
     syncFullHistory: false,
     markOnlineOnConnect: false,
-    // Required for Baileys 7.x: without this, incoming messages that need
-    // E2EE session re-establishment are silently dropped (msg.message === null)
-    getMessage: async (key) => {
-      // We don't maintain a message store, so return a placeholder.
-      // This is enough for Baileys to complete the retry handshake.
-      return { conversation: '' };
-    },
+    // We keep no durable outbound store, so a retried message cannot be
+    // reproduced. Baileys treats undefined as "message not available" and
+    // skips the resend; any placeholder object would be delivered as a real
+    // empty message. Session repair runs before this lookup either way.
+    getMessage: missingMessageStoreLookup,
   });
 
   sock.ev.on('creds.update', () => { saveCreds(); lidToPhone = buildLidMap(); });

--- a/scripts/whatsapp-bridge/bridge.native.test.mjs
+++ b/scripts/whatsapp-bridge/bridge.native.test.mjs
@@ -20,9 +20,21 @@ import {
   extractBridgeEvent,
   inboundReadReceiptKeys,
   mediaPayloadForFile,
+  missingMessageStoreLookup,
   pollCreationMessageFromPayload,
   pollUpdateForAggregation,
 } from './bridge_helpers.js';
+
+// -- missing outbound message store ---------------------------------------
+{
+  const unavailable = await missingMessageStoreLookup({
+    id: 'retry-after-cache-miss',
+    remoteJid: '15551234567@s.whatsapp.net',
+    fromMe: true,
+  });
+  assert.equal(unavailable, undefined);
+  console.log('  ✓ missing outbound store skips resend instead of sending an empty message');
+}
 
 // -- inbound read receipts ------------------------------------------------
 {

--- a/scripts/whatsapp-bridge/bridge_helpers.js
+++ b/scripts/whatsapp-bridge/bridge_helpers.js
@@ -65,6 +65,17 @@ export function createBoundedMessageStore(limit = 512) {
   return { remember, get };
 }
 
+/**
+ * Baileys asks getMessage to reproduce an outbound message after a peer's
+ * decryption retry cache misses. The bridge has no durable outbound store, so
+ * it cannot reproduce that message. Returning undefined is Baileys' native
+ * "message not available" signal; returning a placeholder object would make
+ * Baileys encrypt and send the placeholder as a real (empty) message.
+ */
+export async function missingMessageStoreLookup() {
+  return undefined;
+}
+
 export function pollCreationMessageSecret(pollCreation) {
   return pollCreation?.message?.messageContextInfo?.messageSecret
     || pollCreation?.messageContextInfo?.messageSecret


### PR DESCRIPTION
## Summary

When Baileys asks the WhatsApp bridge to reproduce an outbound message after a decryption-retry cache miss, Hermes currently returns `{ conversation: '' }`. Baileys treats that object as a real message and encrypts and sends it, so the peer can receive an empty message.

This change:

- exports a pure `missingMessageStoreLookup` callback that returns `undefined`, Baileys' “message not available” signal;
- wires the callback into `makeWASocket({ getMessage })`;
- adds a native bridge regression proving a cache miss does not create a placeholder resend.

Hermes still performs Baileys session repair before this callback. Because the bridge has no durable outbound message store, skipping an unavailable resend is the truthful behavior.

## Scope

WhatsApp Baileys bridge only. No observer/backfill, identity/LID, slash-command, notice, auth, or gateway behavior changes.

## Tests

- all six `scripts/whatsapp-bridge/*.test.mjs` files;
- `node --check` on all changed JavaScript files;
- ESLint on changed files, with no new findings over the current-main baseline;
- `git diff --check`.
