### PR TITLE
fix(sandbox): trust the sandbox CA for Node so npm works through the MITM proxy

### DIFF
--- a/scripts/sandbox/stage2-run.sh
+++ b/scripts/sandbox/stage2-run.sh
@@ -196,6 +196,15 @@ if [ "$DEV_SANDBOX_INTERACTIVE" = true ]; then
   dev_mounts=(--dev /dev)
 fi
 
+# Every payload TLS client must trust the SANDBOX CA: all HTTP(S) goes
+# through the MITM proxy, which terminates each connection with a
+# sandbox-CA-minted cert and re-validates upstream against the real CA
+# bundle itself (real-ca.pem, passed to proxy.py below). Node reads
+# NODE_EXTRA_CA_CERTS instead of SSL_CERT_FILE, so it gets ca.pem too --
+# pointing it at the real bundle made npm reject the proxy's certs
+# (UNABLE_TO_VERIFY_LEAF_SIGNATURE) and the proxy log the abort as an
+# SSLEOFError. curl/git/openssl get the same ca.pem via their own vars.
+
 exec bwrap \
   --unshare-pid \
   --die-with-parent --proc /proc --tmpfs /tmp \
@@ -216,7 +225,7 @@ exec bwrap \
   --setenv CURL_CA_BUNDLE /work/certs/ca.pem \
   --setenv SSL_CERT_FILE /work/certs/ca.pem \
   --setenv GIT_SSL_CAINFO /work/certs/ca.pem \
-  --setenv NODE_EXTRA_CA_CERTS /work/certs/real-ca.pem \
+  --setenv NODE_EXTRA_CA_CERTS /work/certs/ca.pem \
   --setenv OPENSSL_CONF /work/certs/openssl.cnf \
   --setenv HTTP_PROXY http://127.0.0.1:8080 \
   --setenv HTTPS_PROXY http://127.0.0.1:8080 \

--- a/scripts/sandbox/stage2-run.sh
+++ b/scripts/sandbox/stage2-run.sh
@@ -204,6 +204,11 @@ fi
 # pointing it at the real bundle made npm reject the proxy's certs
 # (UNABLE_TO_VERIFY_LEAF_SIGNATURE) and the proxy log the abort as an
 # SSLEOFError. curl/git/openssl get the same ca.pem via their own vars.
+# One asymmetry to note: the *_FILE vars replace the trust store, but
+# NODE_EXTRA_CA_CERTS is additive -- Node keeps its built-in bundle --
+# so a Node process that somehow bypassed the proxy could still reach
+# public CAs directly. The *_PROXY vars are the enforcement; the CA
+# vars are only the trust plumbing.
 
 exec bwrap \
   --unshare-pid \

--- a/tests/test_sandbox_stage2_node_ca.py
+++ b/tests/test_sandbox_stage2_node_ca.py
@@ -1,0 +1,43 @@
+"""The sandbox payload must trust the sandbox CA, not the real bundle.
+
+Every TLS client inside the sandbox talks to the MITM proxy, which
+terminates HTTPS with a cert minted by the sandbox CA and validates
+upstream against the real CA bundle itself. Node is the one payload
+client that reads NODE_EXTRA_CA_CERTS instead of SSL_CERT_FILE; pointing
+it at the real bundle made npm reject the proxy's minted certs
+(UNABLE_TO_VERIFY_LEAF_SIGNATURE) while curl/git/uv kept working, which
+surfaced as npm-install failures in the Install & Update E2E workflow
+and as the proxy logging each aborted handshake as an SSLEOFError
+(#87093).
+"""
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+STAGE2 = REPO_ROOT / "scripts" / "sandbox" / "stage2-run.sh"
+
+
+def test_payload_clients_trust_the_sandbox_ca() -> None:
+    text = STAGE2.read_text()
+
+    # Every payload-side CA variable points at the sandbox CA...
+    assert "--setenv CURL_CA_BUNDLE /work/certs/ca.pem \\" in text
+    assert "--setenv SSL_CERT_FILE /work/certs/ca.pem \\" in text
+    assert "--setenv GIT_SSL_CAINFO /work/certs/ca.pem \\" in text
+    # ...including Node's, which reads NODE_EXTRA_CA_CERTS instead of
+    # SSL_CERT_FILE.
+    assert "--setenv NODE_EXTRA_CA_CERTS /work/certs/ca.pem \\" in text
+    # The real bundle must never be handed to a payload client as its
+    # trust anchor.
+    assert "--setenv NODE_EXTRA_CA_CERTS /work/certs/real-ca.pem" not in text
+
+
+def test_proxy_still_validates_upstream_against_the_real_ca() -> None:
+    """The trust split: payload trusts the sandbox CA, proxy trusts real CAs."""
+    text = STAGE2.read_text()
+
+    # proxy.py's third argument is the real CA bundle.
+    assert (
+        "python3 /work/proxy.py /work/http /work/certs /work/certs/real-ca.pem"
+        in text
+    )


### PR DESCRIPTION
## Problem

`Install & Update E2E` has been red on every scheduled run since 2026-08-13 19:40 UTC. Every `installer` leg dies on:

```
✗ npm install failed or timed out; Node.js dependencies were not installed
```

and the sandbox `proxy.log` is a wall of:

```
proxy request failed: SSLEOFError(8, '[SSL: UNEXPECTED_EOF_WHILE_READING] ...')
```

## Root cause

`stage2-run.sh` pointed `NODE_EXTRA_CA_CERTS` at the **real** CA bundle, while every other payload TLS client (curl, git, openssl, uv via `SSL_CERT_FILE`) trusts the **sandbox** CA. But inside the sandbox all HTTPS goes through the MITM proxy, which terminates each connection with a sandbox-CA-minted cert and re-validates upstream against the real CA itself. The trust split is: payload → sandbox CA; proxy → real CA.

Node reads `NODE_EXTRA_CA_CERTS` instead of `SSL_CERT_FILE`, so npm validated the proxy's minted cert against real roots, rejected it with `UNABLE_TO_VERIFY_LEAF_SIGNATURE`, and aborted the handshake — which the proxy logged as an `SSLEOFError`. uv/curl/git succeeding through the same proxy in the same run was the tell that this was a trust split, not a network outage.

Why it surfaced now: npm-in-sandbox has failed since the sandbox shipped (visible as `⚠ npm install failed` warnings in old green runs), but `install.sh` tolerated npm failure and printed success anyway (#77003). #85537 correctly made the failure fatal — and the E2E went red.

## Fix

One line: `NODE_EXTRA_CA_CERTS` now gets the sandbox CA like every other payload client, plus a comment explaining the trust split so nobody "fixes" it back. The proxy's own upstream validation against the real bundle is untouched.

## Verification

- Reproduced locally outside CI: running the sandbox `proxy.py` with a scratch CA, `npm view left-pad version` through it fails with `UNABLE_TO_VERIFY_LEAF_SIGNATURE` when `NODE_EXTRA_CA_CERTS` holds the real bundle (and the proxy logs the exact `SSLEOFError` from CI), and succeeds when it holds the sandbox CA.
- New regression test `tests/test_sandbox_stage2_node_ca.py` asserts the CA contract for all payload clients and that the real bundle still reaches only the proxy.
- `bash -n` clean; `pytest tests/test_sandbox_stage2_node_ca.py` passes.

## Notes

- The `uv.lock` stale warning in the same logs is separate noise (installer falls back to a PyPI resolve and continues); not addressed here.
- The reporter side of #87093 (real Debian machine, no sandbox) may be a different failure than the CI one fixed here — worth keeping open until their npm output lands via #87340.
