### PR TITLE
build(vite): migrate remaining configs to import.meta.dirname (web, bootstrap-installer)

### DIFF
--- a/apps/bootstrap-installer/vite.config.ts
+++ b/apps/bootstrap-installer/vite.config.ts
@@ -18,7 +18,7 @@ export default defineConfig({
   plugins: [react(), tailwindcss()],
   resolve: {
     alias: {
-      '@': path.resolve(__dirname, './src')
+      '@': path.resolve(import.meta.dirname, './src')
     }
   },
   clearScreen: false,

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -61,8 +61,8 @@ export default defineConfig({
   plugins: [react(), tailwindcss(), hermesDevToken()],
   resolve: {
     alias: {
-      "@": path.resolve(__dirname, "./src"),
-      "@hermes/shared": path.resolve(__dirname, "../apps/shared/src"),
+      "@": path.resolve(import.meta.dirname, "./src"),
+      "@hermes/shared": path.resolve(import.meta.dirname, "../apps/shared/src"),
     },
     // When @nous-research/ui is symlinked via `file:../../design-language`,
     // Node's module resolution would pick up shared deps from

--- a/web/vitest.config.ts
+++ b/web/vitest.config.ts
@@ -6,7 +6,7 @@ export default defineConfig({
   plugins: [react()],
   resolve: {
     alias: {
-      "@": path.resolve(__dirname, "./src"),
+      "@": path.resolve(import.meta.dirname, "./src"),
     },
   },
   test: {


### PR DESCRIPTION
## What does this PR do?

Vite 8 prints this on every dashboard build (and on `hermes update`, which builds it):

```
(!) Your Vite config uses features that are unsupported by `configLoader: 'native'`,
    which is planned to become the default in a future major version of Vite:
   - `__dirname` (vite.config.ts:64:25). Use `import.meta.dirname` instead
```

The current default loader (`bundle`) pre-bundles the config with esbuild, so `__dirname` resolves. `native` imports the `.ts` config directly as an ES module, where `__dirname` does not exist. When the default flips, these configs stop loading.

Confirmed against the installed vite 8.2.0 by loading the real config under each loader before the change:

```
bundle  OK   alias @ = .../web/src
native  FAIL __dirname is not defined in ES module scope
```

#86895 already migrates `apps/desktop/vite.config.ts`. This PR covers the three config files that one leaves behind, so nothing in the repo is left on `__dirname`. **No file overlap with #86895** — the two merge independently in either order.

`import.meta.dirname` requires Node >= 20.11; the root `package.json` already declares `"node": ">=22.22.0"`.

## Related Issue

Refs #79664

## Type of Change

- [x] ♻️ Refactor (no behavior change)

## Changes Made

- `web/vite.config.ts` — `__dirname` → `import.meta.dirname` (2 sites, the `@` and `@hermes/shared` aliases)
- `web/vitest.config.ts` — same, 1 site
- `apps/bootstrap-installer/vite.config.ts` — same, 1 site

Repo-wide check after the change: no `__dirname` remains in any `vite.config.ts` / `vitest.config.ts` outside `apps/desktop` (#86895's scope).

## How to Test

1. `cd web && npx vite build` — builds clean, warning gone.
2. Load each config under both loaders and confirm the resolved aliases are byte-identical:

   ```js
   import { loadConfigFromFile } from 'vite'
   for (const loader of ['bundle', 'native'])
     await loadConfigFromFile({ command: 'build', mode: 'production' },
       'web/vite.config.ts', 'web', 'silent', undefined, loader)
   ```

   Result — all three configs, both loaders:

   ```
   bundle OK    web/vite.config.ts                       @ -> .../web/src
   native OK    web/vite.config.ts                       @ -> .../web/src
   bundle OK    web/vitest.config.ts                     @ -> .../web/src
   native OK    web/vitest.config.ts                     @ -> .../web/src
   bundle OK    apps/bootstrap-installer/vite.config.ts  @ -> .../apps/bootstrap-installer/src
   native OK    apps/bootstrap-installer/vite.config.ts  @ -> .../apps/bootstrap-installer/src
   ```

3. `cd web && npx vitest run` — 34 files, 258 tests, all passing.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for existing PRs — found #86895 (`apps/desktop` only) and issue #79664; this PR is scoped to the non-overlapping remainder
- [x] My PR contains **only** changes related to this fix
- [ ] I've run `pytest tests/ -q` — N/A, no Python touched. Ran the JS suite for the affected package instead: `web` vitest, 258/258 passing
- [ ] I've added tests — N/A, build-config change with no runtime surface; verified by loading both configs under both loaders (above)
- [x] I've tested on my platform: Ubuntu 24.04, Node v22.23.2, vite 8.2.0

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A
- [x] I've updated `cli-config.yaml.example` — N/A
- [x] I've updated `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] I've considered cross-platform impact — `import.meta.dirname` is platform-independent and returns a platform-native path exactly as `__dirname` did; `path.resolve` consumes both identically
- [x] I've updated tool descriptions/schemas — N/A