### PR TITLE
fix(cli): batch resume dedup, oneshot yolo ordering, atomic update locks

### DIFF
--- a/batch_runner.py
+++ b/batch_runner.py
@@ -35,6 +35,7 @@ import json
 import logging
 import os
 import time
+from collections import Counter
 from pathlib import Path
 from typing import List, Dict, Any, Optional, Tuple
 from datetime import datetime
@@ -731,7 +732,7 @@ class BatchRunner:
         else:
             atomic_json_write(self.checkpoint_file, checkpoint_data)
     
-    def _scan_completed_prompts_by_content(self) -> set:
+    def _scan_completed_prompts_by_content(self) -> Counter:
         """
         Scan all batch files and extract completed prompts by their actual content.
         
@@ -739,9 +740,11 @@ class BatchRunner:
         rather than indices, allowing recovery even if indices don't match.
         
         Returns:
-            set: Set of prompt texts that have been successfully processed
+            Counter: prompt text -> number of successfully processed occurrences.
+            Occurrences are counted (not deduplicated into a set) so duplicate
+            prompts in the dataset are not silently dropped on --resume (#86523).
         """
-        completed_prompts = set()
+        completed_prompts = Counter()
         batch_files = sorted(self.output_dir.glob("batch_*.jsonl"))
         
         if not batch_files:
@@ -766,7 +769,7 @@ class BatchRunner:
                                 if msg.get("from") == "human":
                                     prompt_text = msg.get("value", "").strip()
                                     if prompt_text:
-                                        completed_prompts.add(prompt_text)
+                                        completed_prompts[prompt_text] += 1
                                     break  # Only need the first human message
                         except json.JSONDecodeError:
                             continue
@@ -775,12 +778,12 @@ class BatchRunner:
         
         return completed_prompts
     
-    def _filter_dataset_by_completed(self, completed_prompts: set) -> Tuple[List[Dict], List[int]]:
+    def _filter_dataset_by_completed(self, completed_prompts: Counter) -> Tuple[List[Dict], List[int]]:
         """
         Filter the dataset to exclude prompts that have already been completed.
         
         Args:
-            completed_prompts: Set of prompt texts that have been completed
+            completed_prompts: Counter of prompt text -> completed occurrences
             
         Returns:
             Tuple of (filtered_dataset, skipped_indices)
@@ -801,7 +804,11 @@ class BatchRunner:
                         prompt_text = (msg.get("content") or msg.get("value", "")).strip()
                         break
             
-            if prompt_text in completed_prompts:
+            # Skip only as many rows per prompt text as were actually
+            # completed (decrementing), so duplicate prompts beyond the
+            # completed count are still processed on resume (#86523).
+            if completed_prompts.get(prompt_text, 0) > 0:
+                completed_prompts[prompt_text] -= 1
                 skipped_indices.append(idx)
             else:
                 # Keep original index for tracking

--- a/hermes_cli/_early_recovery.py
+++ b/hermes_cli/_early_recovery.py
@@ -423,12 +423,22 @@ def recover_if_needed(
             os.write(fd, f"{os.getpid()}\n".encode())
             os.close(fd)
         except FileExistsError:
+            # After removing a stale lock, retry the atomic O_EXCL acquire
+            # and continue into the repair instead of returning — otherwise
+            # a crashed prior repair leaves the lock deleted but the repair
+            # deferred to the next launch, and this launch still crashes on
+            # "import main" (#86527).
             try:
                 if time.time() - lock_path.stat().st_mtime > 3600:
                     lock_path.unlink()
+                    fd = os.open(lock_path, os.O_CREAT | os.O_EXCL | os.O_WRONLY)
+                    os.write(fd, f"{os.getpid()}\n".encode())
+                    os.close(fd)
+                else:
+                    return
             except OSError:
-                pass
-            return
+                # FileExistsError included: another process won the race.
+                return
         except OSError:
             pass  # read-only fs / perms — proceed unlocked, install surfaces it
 
@@ -482,7 +492,16 @@ def _claim_recovery_lock(root: Path) -> bool:
         try:
             if time.time() - lock_path.stat().st_mtime > 3600:
                 lock_path.unlink()
+                # Retry the atomic acquire after clearing the stale lock —
+                # deleting it and returning False would defer the repair to
+                # the next launch even though nothing else holds the lock
+                # (#86527).
+                fd = os.open(lock_path, os.O_CREAT | os.O_EXCL | os.O_WRONLY)
+                os.write(fd, f"{os.getpid()}\n".encode())
+                os.close(fd)
+                return True
         except OSError:
+            # FileExistsError included: another process won the race.
             pass
         return False
     except OSError:

--- a/hermes_cli/oneshot.py
+++ b/hermes_cli/oneshot.py
@@ -190,6 +190,16 @@ def run_oneshot(
 
     Returns the exit code.  The caller owns process termination.
     """
+    # Auto-approve any shell / tool approvals.  Non-interactive by
+    # definition — a prompt would hang forever.  Set these BEFORE anything
+    # that can trigger plugin discovery (_validate_explicit_toolsets below
+    # joins the background discovery thread): tools.approval freezes
+    # HERMES_YOLO_MODE once at module import, so a plugin import chain
+    # touching it first would latch the freeze to False and silently disable
+    # oneshot's auto-bypass (#86526).
+    os.environ["HERMES_YOLO_MODE"] = "1"
+    os.environ["HERMES_ACCEPT_HOOKS"] = "1"
+
     # Silence every stdlib logger for the duration.  AIAgent, tools, and
     # provider adapters all log to stderr through the root logger; file
     # handlers added by setup_logging() keep working (they're attached to
@@ -215,11 +225,6 @@ def run_oneshot(
         sys.stderr.write(toolsets_error)
         return 2
     use_config_toolsets = _normalize_toolsets(toolsets) is None
-
-    # Auto-approve any shell / tool approvals.  Non-interactive by
-    # definition — a prompt would hang forever.
-    os.environ["HERMES_YOLO_MODE"] = "1"
-    os.environ["HERMES_ACCEPT_HOOKS"] = "1"
 
     # One-shot prints a single final response and exits: there is no later turn
     # for a detached subagent's completion to re-enter, and nothing here drains

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -4469,6 +4469,16 @@ def _cmd_update_impl(args, gateway_mode: bool):
             )
             sys.exit(1)
 
+    # Verify the git executable exists up front — a .git directory without
+    # git on PATH (slim containers, broken PATH) would otherwise die with a
+    # bare FileNotFoundError traceback, which the outer handler (it catches
+    # only CalledProcessError) does not turn into a readable message.
+    # Skipped on the Windows ZIP-update path, which needs no git (#86529).
+    if not use_zip_update and shutil.which("git") is None:
+        print("✗ git is required to update Hermes but was not found on PATH.")
+        print("  Install git (or fix your PATH) and retry.")
+        sys.exit(1)
+
     # On Windows, git can fail with "unable to write loose object file: Invalid argument"
     # due to filesystem atomicity issues. Set the recommended workaround.
     if sys.platform == "win32" and git_dir.exists():

--- a/hermes_cli/update_lock.py
+++ b/hermes_cli/update_lock.py
@@ -250,17 +250,39 @@ class UpdateLock:
             return False
         try:
             self.path.parent.mkdir(parents=True, exist_ok=True)
-            self.path.write_text(
-                f"{os.getpid()}\n{int(time.time())}\n", encoding="utf-8"
-            )
+            # Create the marker atomically with O_EXCL (same pattern as
+            # _early_recovery.py) instead of check-then-write write_text,
+            # closing the TOCTOU window where two updaters both read "no
+            # live lock" and both write; the loser of the race re-reads the
+            # holder and fails closed (#86528).
+            for _attempt in range(2):
+                try:
+                    fd = os.open(self.path, os.O_CREAT | os.O_EXCL | os.O_WRONLY)
+                    with os.fdopen(fd, "w", encoding="utf-8") as f:
+                        f.write(f"{os.getpid()}\n{int(time.time())}\n")
+                except FileExistsError:
+                    existing = read_live_update(path=self.path)
+                    if existing is None:
+                        if _attempt == 0:
+                            # Stale/malformed marker was cleaned up by the
+                            # re-read — one retry now that the path is clear.
+                            continue
+                        # Never read back as a live update — fail closed with
+                        # a placeholder so callers can still describe it.
+                        self.holder = UpdateHolder(pid=-1, age_seconds=0)
+                        return False
+                    if existing.pid == _handoff_pid() or _is_ancestor_pid(existing.pid):
+                        return True
+                    self.holder = existing
+                    return False
+                self.acquired = True
+                return True
         except OSError as exc:
             # Best-effort, exactly like the Rust guard: an unwritable marker
             # must not block the update itself (that would be a worse failure
             # than the race it prevents). Degrade to the pre-lock behavior.
             logger.debug("Could not write update marker %s: %s", self.path, exc)
             return True
-        self.acquired = True
-        return True
 
     def release(self) -> None:
         """Drop the marker if this process still owns it. Never raises."""

--- a/tests/hermes_cli/test_cmd_update.py
+++ b/tests/hermes_cli/test_cmd_update.py
@@ -1,6 +1,7 @@
 """Tests for cmd_update — branch fallback when remote branch doesn't exist."""
 
 import hashlib
+import shutil
 import subprocess
 from types import SimpleNamespace
 from unittest.mock import ANY, patch
@@ -8,6 +9,20 @@ from unittest.mock import ANY, patch
 import pytest
 
 from hermes_cli.main import cmd_update, PROJECT_ROOT
+
+_REAL_WHICH = shutil.which
+
+
+def _which_without_path_except_git(name, *args, **kwargs):
+    """Blanket "nothing on PATH" stand-in that still finds git.
+
+    Many tests here patch ``shutil.which`` away entirely to keep uv/npm off
+    the stage; the update flow's git preflight (#86529) legitimately needs
+    git to remain discoverable.
+    """
+    if name == "git":
+        return _REAL_WHICH(name, *args, **kwargs)
+    return None
 
 
 def _make_run_side_effect(branch="main", verify_ok=True, commit_count="0"):
@@ -222,7 +237,7 @@ class TestCmdUpdateBranchFallback:
 
 
 
-    @patch("shutil.which", return_value=None)
+    @patch("shutil.which", side_effect=_which_without_path_except_git)
     @patch("subprocess.run")
     def test_update_on_fork_checks_upstream_when_origin_up_to_date(
         self, mock_run, _mock_which, mock_args, capsys
@@ -254,7 +269,7 @@ class TestCmdUpdateBranchFallback:
 
     def test_update_non_interactive_runs_safe_config_migrations(self, mock_args, capsys):
         """Dashboard/web updates apply non-interactive migrations before restart."""
-        with patch("shutil.which", return_value=None), patch(
+        with patch("shutil.which", side_effect=_which_without_path_except_git), patch(
             "subprocess.run"
         ) as mock_run, patch("builtins.input") as mock_input, patch(
             "hermes_cli.config.get_missing_env_vars", return_value=["MISSING_KEY"]
@@ -298,7 +313,7 @@ class TestCmdUpdateMigrationPrompt:
         self, mock_args, capsys
     ):
         """Only the version moved → apply non-interactively, never prompt."""
-        with patch("shutil.which", return_value=None), patch(
+        with patch("shutil.which", side_effect=_which_without_path_except_git), patch(
             "subprocess.run"
         ) as mock_run, patch("builtins.input") as mock_input, patch(
             "hermes_cli.config.get_missing_env_vars", return_value=[]
@@ -336,7 +351,7 @@ class TestCmdUpdateMigrationPrompt:
         cfg_items = [
             {"key": "display.new_widget", "description": "New config option: display.new_widget"},
         ]
-        with patch("shutil.which", return_value=None), patch(
+        with patch("shutil.which", side_effect=_which_without_path_except_git), patch(
             "subprocess.run"
         ) as mock_run, patch("builtins.input", return_value="n"), patch(
             "hermes_cli.config.get_missing_env_vars", return_value=env_items
@@ -403,7 +418,7 @@ class TestCmdUpdateProfileSkillSync:
     from the seed_profile_skills loop, leaving it on stale skill content.
     """
 
-    @patch("shutil.which", return_value=None)
+    @patch("shutil.which", side_effect=_which_without_path_except_git)
     @patch("subprocess.run")
     def test_active_profile_included_in_skill_sync(
         self, mock_run, _mock_which, mock_args, capsys
@@ -441,7 +456,7 @@ class TestCmdUpdateProfileSkillSync:
             f"All profiles must be synced; got: {synced_paths}"
         )
 
-    @patch("shutil.which", return_value=None)
+    @patch("shutil.which", side_effect=_which_without_path_except_git)
     @patch("subprocess.run")
     def test_single_profile_default_is_synced(
         self, mock_run, _mock_which, mock_args, capsys
@@ -513,7 +528,7 @@ class TestCmdUpdateBranchFlag:
 
         return side_effect
 
-    @patch("shutil.which", return_value=None)
+    @patch("shutil.which", side_effect=_which_without_path_except_git)
     @patch("subprocess.run")
     def test_branch_flag_pulls_against_named_branch(self, mock_run, _mock_which, capsys):
         """--branch bb/gui makes rev-list and pull target origin/bb/gui."""
@@ -536,7 +551,7 @@ class TestCmdUpdateBranchFlag:
         assert any("origin/bb/gui" in c and "origin/main" not in c for c in merge_cmds), merge_cmds
 
 
-    @patch("shutil.which", return_value=None)
+    @patch("shutil.which", side_effect=_which_without_path_except_git)
     @patch("subprocess.run")
     def test_branch_flag_fails_when_branch_missing_everywhere(self, mock_run, _mock_which, capsys):
         """If branch doesn't exist locally OR on origin, exit non-zero with clear error."""
@@ -1193,3 +1208,58 @@ class TestUpdateNodeDependencies:
         assert cwd_calls, "expected at least one npm call"
         for cwd in cwd_calls:
             assert cwd == tmp_path, f"npm must run from PROJECT_ROOT; got cwd={cwd}"
+
+
+class TestMissingGitBinary:
+    """A .git checkout without git on PATH must fail with a readable message,
+    not a bare FileNotFoundError traceback (#86529)."""
+
+    def _stub_prelude(self, hm, update_cmd, monkeypatch, tmp_path):
+        (tmp_path / ".git").mkdir()
+        monkeypatch.setattr(hm, "PROJECT_ROOT", tmp_path)
+        monkeypatch.setattr(hm, "_is_windows", lambda: False)
+        monkeypatch.setattr(hm, "_capture_active_lazy_features", lambda: [])
+        monkeypatch.setattr(hm, "_capture_active_tool_dependencies", lambda: [])
+        monkeypatch.setattr(hm, "_run_pre_update_backup", lambda _args: None)
+        monkeypatch.setattr(hm, "_pause_windows_gateways_for_update", lambda: None)
+        monkeypatch.setattr(update_cmd, "_desktop_app_present", lambda _dir: False)
+
+    def test_missing_git_exits_with_friendly_error(self, tmp_path, monkeypatch, capsys):
+        from hermes_cli import main as hm
+        import hermes_cli.update_cmd as update_cmd
+
+        self._stub_prelude(hm, update_cmd, monkeypatch, tmp_path)
+        monkeypatch.setattr(update_cmd.shutil, "which", lambda _name: None)
+
+        with pytest.raises(SystemExit) as exc_info:
+            update_cmd._cmd_update_impl(
+                SimpleNamespace(yes=True, force=True, force_venv=True, branch=None),
+                gateway_mode=False,
+            )
+
+        assert exc_info.value.code == 1
+        out = capsys.readouterr().out
+        assert "git is required" in out
+
+    def test_present_git_passes_the_guard(self, tmp_path, monkeypatch):
+        """Control: with git on PATH the guard does not fire and the update
+        proceeds to the fetch."""
+        from hermes_cli import main as hm
+        import hermes_cli.update_cmd as update_cmd
+
+        self._stub_prelude(hm, update_cmd, monkeypatch, tmp_path)
+        monkeypatch.setattr(update_cmd.shutil, "which", lambda name: f"/usr/bin/{name}")
+        monkeypatch.setattr(update_cmd, "_discard_lockfile_churn", lambda *_a: None)
+        monkeypatch.setattr(update_cmd, "_normalize_managed_eol", lambda *_a: None)
+        monkeypatch.setattr(hm, "_get_origin_url", lambda *_a: "")
+
+        def sentinel_run(cmd, **_kwargs):
+            raise RuntimeError(f"reached subprocess: {cmd[:2]}")
+
+        monkeypatch.setattr(update_cmd.subprocess, "run", sentinel_run)
+
+        with pytest.raises(RuntimeError, match="reached subprocess"):
+            update_cmd._cmd_update_impl(
+                SimpleNamespace(yes=True, force=True, force_venv=True, branch=None),
+                gateway_mode=False,
+            )

--- a/tests/hermes_cli/test_early_recovery.py
+++ b/tests/hermes_cli/test_early_recovery.py
@@ -15,6 +15,7 @@ import os
 import subprocess
 import sys
 import textwrap
+import time
 from pathlib import Path
 
 import pytest
@@ -545,3 +546,55 @@ def test_bump_marker_attempts_handles_missing_and_corrupt_bodies(tmp_path):
 
 
 
+
+
+# ---------------------------------------------------------------------------
+# Stale-lock retry (#86527)
+# ---------------------------------------------------------------------------
+
+def test_claim_recovery_lock_retries_after_removing_stale_lock(tmp_path):
+    """A stale lock (> 1h) is removed AND re-acquired in the same call, so
+    the repair runs now instead of being deferred to the next launch."""
+    lock_path = tmp_path / ".update-incomplete.lock"
+    lock_path.write_text("99999999\n", encoding="utf-8")
+    stale = time.time() - 7200
+    os.utime(lock_path, (stale, stale))
+
+    assert er._claim_recovery_lock(tmp_path) is True
+    # We own the lock now — our pid, not the stale one.
+    assert lock_path.read_text(encoding="utf-8").splitlines()[0] == str(os.getpid())
+
+    er._release_recovery_lock(tmp_path)
+    assert not lock_path.exists()
+
+
+def test_claim_recovery_lock_fresh_lock_still_refused(tmp_path):
+    """A lock younger than the staleness horizon belongs to a live repair —
+    the claim must still fail."""
+    lock_path = tmp_path / ".update-incomplete.lock"
+    lock_path.write_text("99999999\n", encoding="utf-8")
+
+    assert er._claim_recovery_lock(tmp_path) is False
+    assert lock_path.read_text(encoding="utf-8").splitlines()[0] == "99999999"
+
+
+def test_claim_recovery_lock_stale_retry_lost_race_returns_false(tmp_path, monkeypatch):
+    """If another process wins the re-acquire race after we unlink the stale
+    lock, the claim fails closed instead of proceeding unlocked."""
+    lock_path = tmp_path / ".update-incomplete.lock"
+    lock_path.write_text("99999999\n", encoding="utf-8")
+    stale = time.time() - 7200
+    os.utime(lock_path, (stale, stale))
+
+    real_open = os.open
+
+    def losing_open(path, flags, *args, **kwargs):
+        if Path(path) == lock_path and flags & os.O_EXCL and not lock_path.exists():
+            raise FileExistsError(str(path))
+        return real_open(path, flags, *args, **kwargs)
+
+    monkeypatch.setattr(er.os, "open", losing_open)
+
+    assert er._claim_recovery_lock(tmp_path) is False
+    # The stale lock was still removed — the winner (simulated) owns the path.
+    assert not lock_path.exists()

--- a/tests/hermes_cli/test_oneshot_yolo_env_order.py
+++ b/tests/hermes_cli/test_oneshot_yolo_env_order.py
@@ -1,0 +1,38 @@
+"""Regression test: oneshot sets HERMES_YOLO_MODE before plugin discovery.
+
+tools.approval freezes HERMES_YOLO_MODE once at module import, so the env
+must be set before anything in run_oneshot can join the background plugin
+discovery thread (_validate_explicit_toolsets is the first such call).
+Setting it later risks a plugin import chain latching the freeze to False
+and silently disabling oneshot's approval auto-bypass (#86526).
+"""
+
+import logging
+import os
+
+import hermes_cli.oneshot as oneshot
+from hermes_cli.oneshot import run_oneshot
+
+
+def test_yolo_env_set_before_toolset_validation(monkeypatch):
+    seen = {}
+
+    def fake_validate(toolsets):
+        # Capture the env at the moment toolset validation (which can join
+        # plugin discovery) runs.
+        seen["yolo"] = os.environ.get("HERMES_YOLO_MODE")
+        seen["hooks"] = os.environ.get("HERMES_ACCEPT_HOOKS")
+        return None, "boom"  # force the early return; nothing heavy runs
+
+    monkeypatch.setattr(oneshot, "_validate_explicit_toolsets", fake_validate)
+    monkeypatch.delenv("HERMES_YOLO_MODE", raising=False)
+    monkeypatch.delenv("HERMES_ACCEPT_HOOKS", raising=False)
+    try:
+        rc = run_oneshot("hi")
+    finally:
+        # run_oneshot silences stdlib logging process-wide; restore it so
+        # later tests in this worker still log.
+        logging.disable(logging.NOTSET)
+
+    assert rc == 2
+    assert seen == {"yolo": "1", "hooks": "1"}

--- a/tests/hermes_cli/test_update_lock.py
+++ b/tests/hermes_cli/test_update_lock.py
@@ -262,3 +262,89 @@ class TestAncestryHandoff:
         assert lock.acquire() is False
         assert lock.holder is not None
         assert lock.holder.pid == DEAD_PID
+
+
+# ---------------------------------------------------------------------------
+# Atomic acquire (O_EXCL) — the check-then-write TOCTOU window (#86528)
+# ---------------------------------------------------------------------------
+
+def test_marker_appearing_between_check_and_write_fails_closed(marker, monkeypatch):
+    """The race this fixes: our pre-check read 'no live lock', but another
+    updater wrote its marker before our write landed. The old write_text
+    would have overwritten it; O_EXCL must refuse and name the holder."""
+    import hermes_cli.update_lock as ul
+
+    winner = UpdateLock(path=marker)
+    assert winner.acquire() is True
+
+    real_read = ul.read_live_update
+    calls = {"n": 0}
+
+    def blind_first_read(*args, **kwargs):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            return None  # the TOCTOU window: marker not yet visible to us
+        return real_read(*args, **kwargs)
+
+    monkeypatch.setattr(ul, "read_live_update", blind_first_read)
+
+    loser = UpdateLock(path=marker)
+    assert loser.acquire() is False
+    assert loser.acquired is False
+    assert loser.holder is not None
+    assert loser.holder.pid == os.getpid()
+    # The winner's marker is intact — never overwritten by the loser.
+    assert int(marker.read_text(encoding="utf-8").splitlines()[0]) == os.getpid()
+    # And the loser must not delete it on release.
+    loser.release()
+    assert marker.exists()
+
+
+def test_malformed_marker_appearing_mid_race_is_cleaned_and_retried(marker, monkeypatch):
+    """A concurrent non-atomic writer (Rust/Electron) can leave a partial
+    marker that the re-read treats as malformed and clears; one retry then
+    claims the now-free path."""
+    import hermes_cli.update_lock as ul
+
+    marker.write_text("", encoding="utf-8")  # partial write from another updater
+    # Blind only the pre-check (the TOCTOU window); the re-read after
+    # FileExistsError uses the real reader, which clears the malformed
+    # marker so the retry can claim the path.
+    real_read = ul.read_live_update
+    calls = {"n": 0}
+
+    def blind_first_read(*args, **kwargs):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            return None
+        return real_read(*args, **kwargs)
+
+    monkeypatch.setattr(ul, "read_live_update", blind_first_read)
+
+    lock = UpdateLock(path=marker)
+    assert lock.acquire() is True
+    assert int(marker.read_text(encoding="utf-8").splitlines()[0]) == os.getpid()
+
+
+def test_marker_that_never_reads_back_live_fails_closed(marker, monkeypatch):
+    """If the marker still can't be read back as a live update after the
+    cleanup retry, fail closed with a placeholder holder rather than
+    looping or proceeding unlocked."""
+    import hermes_cli.update_lock as ul
+
+    monkeypatch.setattr(ul, "read_live_update", lambda *a, **k: None)
+
+    real_open = os.open
+
+    def always_taken(path, flags, *args, **kwargs):
+        if os.fspath(path) == os.fspath(marker) and flags & os.O_EXCL:
+            raise FileExistsError(os.fspath(path))
+        return real_open(path, flags, *args, **kwargs)
+
+    monkeypatch.setattr(ul.os, "open", always_taken)
+
+    lock = UpdateLock(path=marker)
+    assert lock.acquire() is False
+    assert lock.acquired is False
+    assert lock.holder is not None
+    assert describe_holder(lock.holder)  # placeholder must still describe

--- a/tests/hermes_cli/test_update_yes_flag.py
+++ b/tests/hermes_cli/test_update_yes_flag.py
@@ -8,11 +8,23 @@ Covers:
      input() call) and the stash is applied automatically
 """
 
+import shutil
 import subprocess
 from types import SimpleNamespace
 from unittest.mock import patch
 
 from hermes_cli.main import cmd_update
+
+_REAL_WHICH = shutil.which
+
+
+def _which_without_path_except_git(name, *args, **kwargs):
+    """Blanket "nothing on PATH" stand-in that still finds git — these tests
+    hide uv/npm from the update flow, but the git preflight (#86529) needs
+    git to remain discoverable."""
+    if name == "git":
+        return _REAL_WHICH(name, *args, **kwargs)
+    return None
 
 
 def _make_run_side_effect(
@@ -55,7 +67,7 @@ class TestUpdateYesConfigMigration:
     @patch("hermes_cli.update_cmd._run_config_check_fresh", return_value=(1, 2))
     @patch("hermes_cli.config.get_missing_config_fields", return_value=[])
     @patch("hermes_cli.config.get_missing_env_vars", return_value=["NEW_KEY"])
-    @patch("shutil.which", return_value=None)
+    @patch("shutil.which", side_effect=_which_without_path_except_git)
     @patch("subprocess.run")
     def test_yes_auto_migrates_without_input(
         self,
@@ -96,7 +108,7 @@ class TestUpdateYesConfigMigration:
     @patch("hermes_cli.update_cmd._run_config_check_fresh", return_value=(1, 2))
     @patch("hermes_cli.config.get_missing_config_fields", return_value=[])
     @patch("hermes_cli.config.get_missing_env_vars", return_value=["NEW_KEY"])
-    @patch("shutil.which", return_value=None)
+    @patch("shutil.which", side_effect=_which_without_path_except_git)
     @patch("subprocess.run")
     def test_no_yes_flag_still_prompts_in_tty(
         self,
@@ -156,7 +168,7 @@ class TestUnicodeDecodeErrorInUpdatePrompts:
     @patch("hermes_cli.update_cmd._run_config_check_fresh", return_value=(1, 2))
     @patch("hermes_cli.config.get_missing_config_fields", return_value=[])
     @patch("hermes_cli.config.get_missing_env_vars", return_value=["NEW_KEY"])
-    @patch("shutil.which", return_value=None)
+    @patch("shutil.which", side_effect=_which_without_path_except_git)
     @patch("subprocess.run")
     def test_unicode_decode_error_in_tty_skips_and_prints_hint(
         self,

--- a/tests/test_batch_runner_checkpoint.py
+++ b/tests/test_batch_runner_checkpoint.py
@@ -239,3 +239,64 @@ class TestFinalCheckpointNoDuplicates:
             buggy.extend(br.get("completed_prompts", []))
         # Every index appears twice
         assert len(buggy) == 2 * len(set(buggy))
+
+
+class TestResumeDuplicatePrompts:
+    """--resume matches completed prompts by content with occurrence counts,
+    so duplicate prompts in the dataset are not silently dropped (#86523)."""
+
+    def _runner(self, tmp_path, dataset):
+        r = BatchRunner.__new__(BatchRunner)
+        r.output_dir = tmp_path
+        r.dataset = dataset
+        return r
+
+    def _write_completed(self, tmp_path, prompt, count=1, failed=False):
+        batch_file = tmp_path / "batch_1.jsonl"
+        with batch_file.open("a", encoding="utf-8") as f:
+            for _ in range(count):
+                entry = {
+                    "conversations": [{"from": "human", "value": prompt}],
+                }
+                if failed:
+                    entry["failed"] = True
+                f.write(json.dumps(entry) + "\n")
+
+    def test_only_completed_copies_are_skipped(self, tmp_path):
+        # One copy of the duplicate prompt completed before the interruption.
+        self._write_completed(tmp_path, "dup prompt", count=1)
+        runner = self._runner(tmp_path, [
+            {"prompt": "dup prompt"},
+            {"prompt": "dup prompt"},
+        ])
+
+        completed = runner._scan_completed_prompts_by_content()
+        filtered, skipped = runner._filter_dataset_by_completed(completed)
+
+        # The second copy must still be processed on resume.
+        assert skipped == [0]
+        assert [idx for idx, _ in filtered] == [1]
+
+    def test_all_copies_completed_skips_all(self, tmp_path):
+        self._write_completed(tmp_path, "dup prompt", count=2)
+        runner = self._runner(tmp_path, [
+            {"prompt": "dup prompt"},
+            {"prompt": "dup prompt"},
+        ])
+
+        completed = runner._scan_completed_prompts_by_content()
+        filtered, skipped = runner._filter_dataset_by_completed(completed)
+
+        assert skipped == [0, 1]
+        assert filtered == []
+
+    def test_failed_entries_do_not_count_as_completed(self, tmp_path):
+        self._write_completed(tmp_path, "dup prompt", count=1, failed=True)
+        runner = self._runner(tmp_path, [{"prompt": "dup prompt"}])
+
+        completed = runner._scan_completed_prompts_by_content()
+        filtered, skipped = runner._filter_dataset_by_completed(completed)
+
+        # Failed trajectories are retried, not skipped.
+        assert skipped == []
+        assert [idx for idx, _ in filtered] == [0]


### PR DESCRIPTION
## Summary

Five independent fixes across batch_runner / oneshot / update paths, one commit each, each with behavior-level regression tests:

- **fix(batch): resume dedup counts completions instead of dropping duplicate prompts** — `_scan_completed_prompts_by_content` now returns a `Counter`, so `--resume` skips only as many copies of a prompt as were actually completed. Closes #86523
- **fix(oneshot): set HERMES_YOLO_MODE before plugin discovery** — the env was set after `_validate_explicit_toolsets` joined the plugin-discovery thread, so the yolo freeze could latch `False` before the env existed. Closes #86526
- **fix(update): retry O_EXCL acquire after deleting a stale recovery lock** — both `_early_recovery` and `_claim_recovery_lock` deleted a stale lock and then returned without repairing, deferring repair to the next launch. Both now re-acquire atomically and proceed. Closes #86527
- **fix(update): make UpdateLock.acquire atomic (O_EXCL) and fail closed** — replaces check-then-write + non-atomic `write_text` with atomic creation; on contention it re-reads the holder and refuses, with one retry after clearing a stale/partial marker. Closes #86528
- **fix(update): friendly error when git is missing on POSIX** — `shutil.which("git")` preflight before subprocess calls, so a git-less `.git` install exits with a clear message instead of a raw traceback (ZIP update path unaffected). Closes #86529

Note: the git preflight required adjusting 11 existing tests that patched `shutil.which` to `None` globally (they now keep git discoverable while still hiding uv/npm, same simulated world otherwise).

## Tests

`scripts/run_tests.sh`: update surface 319 passed / 4 skipped (windows_only); batch_runner + oneshot + `tests/cli/` 1194 passed / 9 skipped; desktop/install 9 passed. No failures.
