### PR TITLE
fix(models): resolve callable key_cmd credentials instead of coercing them

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -19,7 +19,7 @@ import urllib.error
 import time
 from difflib import get_close_matches
 from pathlib import Path
-from typing import Any, NamedTuple, Optional, TYPE_CHECKING
+from typing import Any, Callable, NamedTuple, Optional, TYPE_CHECKING
 
 if TYPE_CHECKING:
     from typing import TypeGuard
@@ -29,6 +29,49 @@ from hermes_cli.urllib_security import open_credentialed_url
 from utils import base_url_host_matches
 
 logger = logging.getLogger(__name__)
+
+# What ``api_key`` actually is across this module. ``resolve_runtime_provider()``
+# hands back a zero-arg callable for the ``key_cmd`` / Entra ID paths (a bearer
+# minted per request) and a plain string everywhere else. Annotating these
+# helpers ``Optional[str]`` hid exactly the bug class ``_materialized_api_key``
+# fixes, so the callable is spelled out in the signatures instead.
+ApiKeyLike = Optional[str | Callable[[], str]]
+
+
+def _materialized_api_key(api_key: Any) -> str:
+    """Return *api_key* as a string, minting it when it is a token provider.
+
+    ``api_key`` reaches this module from ``resolve_runtime_provider()``, which
+    hands back a **callable** for the ``key_cmd`` (short-lived bearer) and
+    Entra ID auth paths — the wire clients invoke it per request. The helpers
+    here build HTTP requests by hand instead, so they need a concrete value:
+    passing the callable through puts the object itself in an
+    ``x-api-key`` / ``Authorization`` header, or blows up on ``.strip()`` /
+    ``.startswith()``.
+
+    Minting failures degrade to ``""`` rather than propagating: these call
+    sites only probe a ``/models`` catalog, and their callers already treat an
+    unreachable catalog as "accept the model unverified". Raising here would
+    turn a best-effort probe into a failed ``/model`` switch.
+    """
+    if api_key is None:
+        return ""
+    if isinstance(api_key, str):
+        return api_key.strip()
+    if callable(api_key):
+        try:
+            minted = api_key()
+        except Exception as exc:  # noqa: BLE001 — probe is best-effort
+            logger.debug("Token provider could not mint for model probe: %s", exc)
+            return ""
+        return minted.strip() if isinstance(minted, str) else ""
+    # Not a string, not callable, not None — some unexpected type. Do NOT
+    # ``str()`` it: that yields "<Foo object at 0x…>", which is long enough and
+    # non-placeholder enough to pass every credential check and get sent to the
+    # provider verbatim. Degrade to "" like the mint-failure path above.
+    logger.debug("Ignoring api_key of unsupported type %s for model probe", type(api_key).__name__)
+    return ""
+
 
 # Identify ourselves so endpoints fronted by Cloudflare's Browser Integrity
 # Check (error 1010) don't reject the default ``Python-urllib/*`` signature.
@@ -2106,7 +2149,7 @@ def compute_sale_discount(
 
 
 def fetch_models_with_pricing(
-    api_key: str | None = None,
+    api_key: ApiKeyLike = None,
     base_url: str = "https://openrouter.ai/api",
     timeout: float = 8.0,
     *,
@@ -2138,7 +2181,7 @@ def fetch_models_with_pricing(
         "User-Agent": _HERMES_USER_AGENT,
     }
     if api_key:
-        headers["Authorization"] = f"Bearer {api_key}"
+        headers["Authorization"] = f"Bearer {_materialized_api_key(api_key)}"
 
     try:
         req = urllib.request.Request(url, headers=headers)
@@ -3678,7 +3721,7 @@ def _fetch_anthropic_models(
     timeout: float = 5.0,
     *,
     base_url: Optional[str] = None,
-    api_key: Optional[str] = None,
+    api_key: ApiKeyLike = None,
 ) -> Optional[list[str]]:
     """Fetch available models from the Anthropic /v1/models endpoint.
 
@@ -3691,7 +3734,9 @@ def _fetch_anthropic_models(
     except ImportError:
         return None
 
-    token = (api_key or "").strip() or resolve_anthropic_token()
+    # A ``key_cmd`` / Entra credential is a callable token provider; mint it
+    # before any string inspection (``_is_oauth_token`` calls ``.startswith``).
+    token = _materialized_api_key(api_key) or resolve_anthropic_token()
     if not token:
         return None
 
@@ -3825,7 +3870,7 @@ _GITHUB_MODEL_CATALOG_CACHE_TTL = 300  # 5 minutes
 
 
 def fetch_github_model_catalog(
-    api_key: Optional[str] = None, timeout: float = 5.0
+    api_key: ApiKeyLike = None, timeout: float = 5.0
 ) -> Optional[list[dict[str, Any]]]:
     """Fetch the live GitHub Copilot model catalog for this account."""
     global _github_model_catalog_cache, _github_model_catalog_cache_key
@@ -3844,7 +3889,7 @@ def fetch_github_model_catalog(
     if api_key:
         attempts.append({
             **copilot_default_headers(),
-            "Authorization": f"Bearer {api_key}",
+            "Authorization": f"Bearer {_materialized_api_key(api_key)}",
         })
     attempts.append(copilot_default_headers())
 
@@ -3945,10 +3990,10 @@ def _lmstudio_server_root(base_url: Optional[str]) -> Optional[str]:
     return root or None
 
 
-def _lmstudio_request_headers(api_key: Optional[str] = None) -> dict:
+def _lmstudio_request_headers(api_key: ApiKeyLike = None) -> dict:
     """Build HTTP headers for LM Studio native API requests."""
     headers = {"User-Agent": _HERMES_USER_AGENT}
-    token = str(api_key or "").strip()
+    token = _materialized_api_key(api_key)
     if token:
         headers["Authorization"] = f"Bearer {token}"
     return headers
@@ -4221,7 +4266,7 @@ def lmstudio_model_reasoning_options(
 def ollama_model_supports_thinking(
     model: str,
     base_url: Optional[str],
-    api_key: Optional[str] = None,
+    api_key: ApiKeyLike = None,
     timeout: float = 5.0,
 ) -> Optional[bool]:
     """Return True if an Ollama (Cloud or local) model advertises ``thinking``.
@@ -4250,7 +4295,7 @@ def ollama_model_supports_thinking(
     if not bare_model:
         return None
 
-    token = str(api_key or "").strip()
+    token = _materialized_api_key(api_key)
     headers = {"Authorization": f"Bearer {token}"} if token else {}
 
     try:
@@ -4631,7 +4676,7 @@ def github_model_reasoning_efforts(
 
 
 def probe_api_models(
-    api_key: Optional[str],
+    api_key: ApiKeyLike,
     base_url: Optional[str],
     timeout: float = 5.0,
     api_mode: Optional[str] = None,
@@ -4677,11 +4722,16 @@ def probe_api_models(
     headers: dict[str, str] = {"User-Agent": _HERMES_USER_AGENT}
     if urllib.parse.urlparse(normalized).hostname == "generativelanguage.googleapis.com":
         headers["X-Goog-Api-Client"] = f"hermes-agent/{_HERMES_VERSION}"
-    if api_key and api_mode == "anthropic_messages":
-        headers["x-api-key"] = api_key
+    # A ``key_cmd`` / Entra credential arrives as a callable token provider.
+    # Mint it here: this request is built by hand, so the callable would
+    # otherwise be set AS the header value and urllib would reject it (or, in
+    # older Pythons, str() the object into the auth header).
+    materialized_key = _materialized_api_key(api_key)
+    if materialized_key and api_mode == "anthropic_messages":
+        headers["x-api-key"] = materialized_key
         headers["anthropic-version"] = "2023-06-01"
-    elif api_key:
-        headers["Authorization"] = f"Bearer {api_key}"
+    elif materialized_key:
+        headers["Authorization"] = f"Bearer {materialized_key}"
     if normalized.startswith(COPILOT_BASE_URL):
         headers.update(copilot_default_headers())
     if isinstance(request_headers, dict):
@@ -4976,7 +5026,7 @@ def _fetch_ai_gateway_models(timeout: float = 5.0) -> Optional[list[str]]:
 
 
 def fetch_api_models(
-    api_key: Optional[str],
+    api_key: ApiKeyLike,
     base_url: Optional[str],
     timeout: float = 5.0,
     api_mode: Optional[str] = None,
@@ -4997,7 +5047,7 @@ def fetch_api_models(
 
 
 def _custom_endpoint_fingerprint(
-    api_key: Optional[str],
+    api_key: ApiKeyLike,
     api_mode: Optional[str],
     headers: Optional[dict[str, str]],
 ) -> str:
@@ -5011,8 +5061,20 @@ def _custom_endpoint_fingerprint(
     """
     import hashlib
 
+    if isinstance(api_key, str):
+        credential_part = api_key
+    elif api_key is None:
+        credential_part = ""
+    else:
+        # A callable credential (``key_cmd`` / Entra) mints a NEW bearer on its
+        # own schedule. Hashing the minted value would change the fingerprint on
+        # every rotation, so every catalog read would miss the cache and
+        # re-probe. Every callable therefore contributes the same constant; the
+        # endpoint URL in the cache key already scopes the entry.
+        credential_part = "callable-token-provider"
+
     blob = "|".join((
-        api_key or "",
+        credential_part,
         api_mode or "",
         json.dumps(headers or {}, sort_keys=True),
     )).encode("utf-8", errors="replace")
@@ -5039,7 +5101,7 @@ def _cache_entry_valid(entry: Any, fp: str) -> "TypeGuard[dict[str, Any]]":
 
 
 def cached_fetch_api_models(
-    api_key: Optional[str],
+    api_key: ApiKeyLike,
     base_url: Optional[str],
     *,
     timeout: float = 5.0,

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -6,11 +6,20 @@ import logging
 import os
 import re
 from urllib.parse import urlparse
-from typing import Any, Dict, Optional
+from typing import Any, Callable, Dict, Optional
 
 logger = logging.getLogger(__name__)
 
+# What an explicit api_key actually is at this boundary. Most callers pass a
+# string, but the ``key_cmd`` / Entra ID / MiniMax OAuth paths pass a zero-arg
+# callable that mints a bearer per request — and a ``/model`` switch feeds that
+# same callable back in as ``explicit_api_key`` on the next turn. Annotating
+# this ``Optional[str]`` is what hid the coercion bug ``is_token_provider``
+# guards, so the callable is spelled out. Mirrors ``hermes_cli.models``.
+ApiKeyLike = Optional[str | Callable[[], str]]
+
 from hermes_cli import auth as auth_mod
+from agent.azure_identity_adapter import is_token_provider
 from agent.credential_pool import (
     CredentialPool,
     PooledCredential,
@@ -1716,6 +1725,59 @@ def _resolve_explicit_runtime(
 
 
 def resolve_runtime_provider(
+    *,
+    requested: Optional[str] = None,
+    explicit_api_key: ApiKeyLike = None,
+    explicit_base_url: Optional[str] = None,
+    target_model: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Resolve runtime provider credentials for agent execution.
+
+    Thin boundary around :func:`_resolve_runtime_provider_resolved` that keeps
+    a callable ``explicit_api_key`` out of the string-coercing resolver
+    branches. A callable is a per-request token provider (``key_cmd``, Entra
+    ID, MiniMax OAuth): it is withheld on the way in — so the resolver behaves
+    exactly as it does for a caller that passed no explicit key, and a
+    configured ``key_cmd`` is re-minted rather than shadowed — then restored on
+    the way out, since the callable IS the credential the caller already held.
+
+    Why the boundary and not the branches: the resolver normalizes an explicit
+    key with ``str(explicit_api_key or "").strip()`` in several places, and
+    ``str()`` runs before ``.strip()`` — so a callable silently becomes its
+    ``repr`` and gets sent to the provider as the credential. One guard here
+    covers every branch; teaching each branch about callables does not.
+
+    This is the round-trip a ``/model`` switch performs: ``cli.py`` persists
+    the resolved ``api_key`` into ``self._explicit_api_key``, and the next
+    turn's ``_ensure_runtime_credentials()`` feeds it straight back in here.
+    """
+    if is_token_provider(explicit_api_key):
+        _token_provider: Optional[Callable[[], str]] = explicit_api_key  # type: ignore[assignment]
+        _explicit_text: Optional[str] = None
+    else:
+        _token_provider = None
+        _explicit_text = explicit_api_key  # type: ignore[assignment]
+
+    runtime = _resolve_runtime_provider_resolved(
+        requested=requested,
+        explicit_api_key=_explicit_text,
+        explicit_base_url=explicit_base_url,
+        target_model=target_model,
+    )
+    if _token_provider is not None and isinstance(runtime, dict):
+        # Only reinstate the caller's provider when the resolver did not
+        # already supply a live credential of its own (a credential pool
+        # entry, or a freshly built key_cmd provider for this same entry).
+        # Overwriting one of those would discard the resolver's decision.
+        _resolved = runtime.get("api_key")
+        if is_token_provider(_resolved):
+            pass
+        elif not has_usable_secret(_resolved) or _resolved == "no-key-required":
+            runtime["api_key"] = _token_provider
+    return runtime
+
+
+def _resolve_runtime_provider_resolved(
     *,
     requested: Optional[str] = None,
     explicit_api_key: Optional[str] = None,

--- a/tests/agent/test_command_token_source.py
+++ b/tests/agent/test_command_token_source.py
@@ -201,6 +201,117 @@ class TestResolutionYieldsACallable:
         assert runtime["api_key"] == "sk-explicit-override"
 
 
+class TestCallableExplicitKeySurvivesReResolution:
+    """A callable ``explicit_api_key`` must round-trip, not become its repr.
+
+    This is the ``/model`` switch path. ``cli.py`` persists the resolved
+    ``api_key`` into ``self._explicit_api_key``, and the next turn's
+    ``_ensure_runtime_credentials()`` feeds it straight back into
+    ``resolve_runtime_provider(explicit_api_key=…)``. Every resolver branch
+    normalized it with ``str(explicit_api_key or "").strip()`` — and ``str()``
+    runs BEFORE ``.strip()``, so the callable became
+    ``"<…CommandTokenSource object at 0x…>"``. That repr is long enough and
+    non-placeholder enough to satisfy ``has_usable_secret()``, so two things
+    broke at once: the repr was handed to the SDK as the credential, and the
+    ``key_cmd`` guard saw an "explicit key" and never minted a real token.
+
+    On the anthropic_messages wire the damage is a hard crash rather than a
+    401: a callable routes to the per-request bearer-hook client, while a
+    string routes to ``x-api-key`` — and an empty/garbage string leaves the
+    Anthropic SDK with neither header, raising
+    ``TypeError: Could not resolve authentication method``.
+    """
+
+    CONFIG = {
+        "providers": {
+            "dbx": {
+                "base_url": "https://example.invalid/anthropic",
+                "api_mode": "anthropic_messages",
+                "model": "m1",
+                "key_cmd": "printf minted-token",
+            }
+        }
+    }
+
+    @staticmethod
+    def _patch(monkeypatch, config):
+        from hermes_cli import runtime_provider as rp
+
+        monkeypatch.setattr(rp, "load_config", lambda *a, **k: config)
+        monkeypatch.setattr("hermes_cli.config.load_config", lambda *a, **k: config)
+        return rp
+
+    def test_callable_round_trips_as_a_callable(self, monkeypatch):
+        rp = self._patch(monkeypatch, self.CONFIG)
+
+        first = rp.resolve_runtime_provider(requested="custom:dbx")["api_key"]
+        assert callable(first)
+
+        # The switch persisted `first`; the next turn re-resolves with it.
+        second = rp.resolve_runtime_provider(
+            requested="custom:dbx", explicit_api_key=first
+        )["api_key"]
+        assert callable(second), "a callable must never be coerced to its repr"
+        assert second() == "minted-token"
+
+    def test_repr_is_never_returned_as_the_credential(self, monkeypatch):
+        rp = self._patch(monkeypatch, self.CONFIG)
+
+        provider = rp.resolve_runtime_provider(requested="custom:dbx")["api_key"]
+        resolved = rp.resolve_runtime_provider(
+            requested="custom:dbx", explicit_api_key=provider
+        )["api_key"]
+        assert not (isinstance(resolved, str) and "object at 0x" in resolved)
+
+    def test_round_tripped_callable_keeps_the_bearer_hook_path(self, monkeypatch):
+        """The wire-level consequence: bearer hook, not an empty x-api-key.
+
+        Guards the reported crash directly — an empty/garbage string here
+        leaves the Anthropic SDK with no auth header at all.
+        """
+        import agent.anthropic_adapter as aa
+
+        rp = self._patch(monkeypatch, self.CONFIG)
+        provider = rp.resolve_runtime_provider(requested="custom:dbx")["api_key"]
+        runtime = rp.resolve_runtime_provider(
+            requested="custom:dbx", explicit_api_key=provider
+        )
+
+        client = aa.build_anthropic_client(runtime["api_key"], runtime["base_url"])
+        # Bearer-hook clients clear api_key so ANTHROPIC_API_KEY can't leak in
+        # as a second x-api-key, and carry a sentinel auth_token the hook
+        # overwrites per request.
+        assert client.api_key is None
+        assert client.auth_token
+
+
+class TestCatalogCacheFingerprintIgnoresRotation:
+    """A real ``CommandTokenSource`` must not bust the model-catalog cache.
+
+    The general contract is covered against a stand-in provider in
+    ``tests/hermes_cli/test_callable_credential_model_probe.py``; this pins it
+    to the actual ``key_cmd`` type, whose two instances genuinely mint
+    different values through a subprocess.
+    """
+
+    @staticmethod
+    def _fp(api_key):
+        from hermes_cli.models import _custom_endpoint_fingerprint
+
+        return _custom_endpoint_fingerprint(api_key, "chat_completions", None)
+
+    def test_two_different_mints_share_one_fingerprint(self):
+        first = build_command_token_provider("printf token-one", "dbx")
+        second = build_command_token_provider("printf token-two", "dbx")
+        assert first is not None and second is not None
+        assert first() != second(), "guard: the providers must mint different values"
+        assert self._fp(first) == self._fp(second)
+
+    def test_rotating_a_static_key_still_busts_the_cache(self):
+        """The callable carve-out must not weaken the static-key case."""
+        assert self._fp("key-v1") != self._fp("key-v2")
+
+
 class TestCallableKeyGetsBearerAuth:
     """A callable api_key must reach the Anthropic bearer-hook client path.
 

--- a/tests/hermes_cli/test_callable_credential_model_probe.py
+++ b/tests/hermes_cli/test_callable_credential_model_probe.py
@@ -1,0 +1,210 @@
+"""Callable-credential contract for the model-catalog probe helpers.
+
+``resolve_runtime_provider()`` returns a **callable** token provider — not a
+string — for the ``key_cmd`` and Entra ID auth paths, because gateways that
+issue short-lived bearers (Databricks AI Gateway, internal OIDC brokers) go
+stale mid-session and 401. Both wire clients invoke that callable per request.
+
+The ``/models`` catalog helpers in ``hermes_cli.models`` build their HTTP
+requests by hand rather than going through a wire client, so each one that
+touches ``api_key`` has to mint it first. When they don't, a ``key_cmd``
+provider breaks three different ways:
+
+* ``_fetch_anthropic_models`` — ``.strip()`` / ``.startswith()`` on the
+  provider object raises ``AttributeError``;
+* ``probe_api_models`` — the provider object lands in the ``x-api-key`` /
+  ``Authorization`` header value instead of a token;
+* ``_custom_endpoint_fingerprint`` — ``"|".join()`` raises ``TypeError``, which
+  propagates out of ``cached_fetch_api_models``.
+
+These assert the behavior contract (a real token reaches the wire, and the
+cache fingerprint stays stable across rotations), not the call shape.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+
+def _provider(token: str = "minted-token"):
+    """A minimal stand-in for ``CommandTokenSource``: callable, not a str."""
+
+    class _TokenProvider:
+        def __init__(self):
+            self.calls = 0
+
+        def __call__(self):
+            self.calls += 1
+            return token
+
+    return _TokenProvider()
+
+
+class TestMaterializedApiKey:
+    def test_string_key_is_stripped(self):
+        import hermes_cli.models as mod
+
+        assert mod._materialized_api_key("  sk-key  ") == "sk-key"
+
+    def test_none_becomes_empty(self):
+        import hermes_cli.models as mod
+
+        assert mod._materialized_api_key(None) == ""
+
+    def test_callable_is_minted(self):
+        import hermes_cli.models as mod
+
+        tp = _provider("  minted  ")
+        assert mod._materialized_api_key(tp) == "minted"
+        assert tp.calls == 1, "the provider must be invoked, not stringified"
+
+    def test_mint_failure_degrades_to_empty(self):
+        """A probe is best-effort: callers treat '' as 'no catalog available'.
+
+        Raising here would turn an unreachable catalog into a failed ``/model``
+        switch, which is strictly worse than accepting the model unverified.
+        """
+        import hermes_cli.models as mod
+
+        def _boom():
+            raise RuntimeError("token command exited 1")
+
+        assert mod._materialized_api_key(_boom) == ""
+
+    def test_non_string_mint_result_is_rejected(self):
+        import hermes_cli.models as mod
+
+        assert mod._materialized_api_key(lambda: object()) == ""
+
+
+class TestProbeSendsAMintedToken:
+    """The token, not the provider object, must reach the request headers."""
+
+    def _headers_for(self, api_key, **kwargs):
+        import hermes_cli.models as mod
+
+        captured: dict[str, dict[str, str]] = {}
+
+        def _spy(req, **_kw):
+            captured["headers"] = dict(req.headers)
+            raise RuntimeError("stop after header build")
+
+        with patch.object(mod, "_urlopen_model_catalog_request", _spy):
+            mod.probe_api_models(api_key, "https://gw.example.invalid", **kwargs)
+        return captured.get("headers") or {}
+
+    def _auth_values(self, headers):
+        return {
+            k.lower(): v
+            for k, v in headers.items()
+            if k.lower() in ("x-api-key", "authorization")
+        }
+
+    def test_anthropic_mode_sends_minted_token_as_x_api_key(self):
+        headers = self._headers_for(_provider("minted-token"), api_mode="anthropic_messages")
+        auth = self._auth_values(headers)
+        assert auth.get("x-api-key") == "minted-token"
+
+    def test_openai_mode_sends_minted_token_as_bearer(self):
+        headers = self._headers_for(_provider("minted-token"))
+        auth = self._auth_values(headers)
+        assert auth.get("authorization") == "Bearer minted-token"
+
+    @pytest.mark.parametrize("api_mode", [None, "anthropic_messages"])
+    def test_no_header_value_is_a_repr_of_the_provider(self, api_mode):
+        """The regression guard: an object repr in an auth header is the bug."""
+        headers = self._headers_for(_provider("minted-token"), api_mode=api_mode)
+        for value in self._auth_values(headers).values():
+            assert isinstance(value, str)
+            assert "object at 0x" not in value
+
+    def test_a_string_key_still_works(self):
+        headers = self._headers_for("sk-static")
+        assert self._auth_values(headers).get("authorization") == "Bearer sk-static"
+
+
+class TestAnthropicCatalogAcceptsACallable:
+    def test_callable_key_does_not_raise(self):
+        """``_is_oauth_token`` calls ``.startswith`` — it needs a real str."""
+        import hermes_cli.models as mod
+
+        with patch.object(mod, "_urlopen_model_catalog_request", side_effect=OSError("offline")):
+            # Returning None (unreachable) is fine; raising AttributeError is not.
+            assert mod._fetch_anthropic_models(
+                base_url="https://gw.example.invalid", api_key=_provider()
+            ) is None
+
+    def test_minted_token_reaches_the_x_api_key_header(self):
+        import hermes_cli.models as mod
+
+        captured: dict[str, dict[str, str]] = {}
+
+        def _spy(req, **_kw):
+            captured["headers"] = dict(req.headers)
+            raise OSError("stop after header build")
+
+        with patch.object(mod, "_urlopen_model_catalog_request", _spy):
+            mod._fetch_anthropic_models(
+                base_url="https://gw.example.invalid", api_key=_provider("minted-token")
+            )
+
+        values = {k.lower(): v for k, v in (captured.get("headers") or {}).items()}
+        assert values.get("x-api-key") == "minted-token"
+
+
+class TestFingerprintIsStableAcrossRotation:
+    """A rotating bearer must not bust the catalog cache on every mint.
+
+    Hashing the minted VALUE would change the fingerprint each rotation, so
+    every catalog read would miss and re-probe — defeating the
+    stale-while-revalidate tier the cache exists to provide. The endpoint URL
+    in the cache key already scopes the entry.
+    """
+
+    def test_two_different_mints_share_one_fingerprint(self):
+        import hermes_cli.models as mod
+
+        first = mod._custom_endpoint_fingerprint(_provider("token-v1"), "anthropic_messages", None)
+        second = mod._custom_endpoint_fingerprint(_provider("token-v2"), "anthropic_messages", None)
+        assert first == second
+
+    def test_callable_does_not_raise(self):
+        import hermes_cli.models as mod
+
+        assert isinstance(
+            mod._custom_endpoint_fingerprint(_provider(), None, None), str
+        )
+
+    def test_api_mode_still_busts_the_fingerprint(self):
+        """The stand-in must not flatten the other inputs into one bucket."""
+        import hermes_cli.models as mod
+
+        tp = _provider()
+        assert mod._custom_endpoint_fingerprint(tp, "anthropic_messages", None) != \
+            mod._custom_endpoint_fingerprint(tp, "chat_completions", None)
+
+    def test_headers_still_bust_the_fingerprint(self):
+        import hermes_cli.models as mod
+
+        tp = _provider()
+        assert mod._custom_endpoint_fingerprint(tp, None, {"X-Tenant": "a"}) != \
+            mod._custom_endpoint_fingerprint(tp, None, {"X-Tenant": "b"})
+
+    def test_a_callable_and_a_static_key_do_not_collide(self):
+        import hermes_cli.models as mod
+
+        assert mod._custom_endpoint_fingerprint(_provider(), None, None) != \
+            mod._custom_endpoint_fingerprint("sk-static", None, None)
+
+    def test_cached_fetch_api_models_survives_a_callable(self):
+        """The TypeError propagated out of the cache wrapper before the fix."""
+        import hermes_cli.models as mod
+
+        with patch.object(mod, "_load_provider_models_cache", return_value={}), \
+             patch.object(mod, "_save_provider_models_cache"), \
+             patch.object(mod, "fetch_api_models", return_value=["m1"]) as live:
+            out = mod.cached_fetch_api_models(_provider(), "https://gw.example.invalid/v1")
+        assert out == ["m1"]
+        live.assert_called_once()


### PR DESCRIPTION
`resolve_runtime_provider()` returns a **callable** token provider — not a
string — for the `key_cmd` and Entra ID auth paths, because gateways that
issue short-lived bearers (Databricks AI Gateway, internal OIDC brokers) go
stale mid-session and 401. Both wire clients invoke that callable per request.

Two groups of call sites assumed `api_key` was always a string, so connecting
to a `key_cmd`-backed provider broke on the second turn and on every catalog
read.

`hermes_cli/runtime_provider.py` — the `/model`-switch round-trip
------------------------------------------------------------------
`cli.py` persists the resolved `api_key` into `self._explicit_api_key`, and
the next turn's `_ensure_runtime_credentials()` feeds it straight back in as
`explicit_api_key`. Several resolver branches normalize that with
`(explicit_api_key or "").strip()` / `str(explicit_api_key or "").strip()`:

* the custom-provider branch raises `AttributeError: 'CommandTokenSource'
  object has no attribute 'strip'` outright (models.py's sibling defect, one
  layer up);
* the branches that go through `str()` first are worse — the callable becomes
  its `repr`, a ~60-char string that `has_usable_secret()` happily accepts, so
  the repr is handed to the SDK as the credential AND the `key_cmd` guard sees
  an "explicit key" and never mints a real token.

Fixed at the boundary rather than in each branch: `resolve_runtime_provider()`
becomes a thin wrapper that withholds a callable on the way in (the resolver
then behaves exactly as it does for a caller that passed no explicit key, so a
configured `key_cmd` is re-minted rather than shadowed) and restores it on the
way out — but only when the resolver did not supply a live credential of its
own, so a pool entry or a freshly built provider still wins. One guard covers
every branch; teaching each branch about callables does not.

`hermes_cli/models.py` — the `/models` catalog probes
-----------------------------------------------------
These build their HTTP requests by hand rather than going through a wire
client, and so need a concrete token. Three failures:

* `_fetch_anthropic_models` — `(api_key or "").strip()` raises; papering over
  `strip` moves the failure one line down to `_is_oauth_token`, which needs
  `.startswith`.
* `probe_api_models` — the provider object is interpolated into the
  `x-api-key` / `Authorization` header value, so the request carries
  `<CommandTokenSource object at 0x…>` instead of a token.
* `_custom_endpoint_fingerprint` — `"|".join()` raises `TypeError: sequence
  item 0: expected str instance`, which propagates out of
  `cached_fetch_api_models`.

Net effect: model validation silently degraded to "accepted unverified"
(masking the failure), and the catalog cache path raised outright.

Adds `_materialized_api_key()`, which mints a callable credential to a
concrete string, and routes every hand-built-header site through it —
including `_lmstudio_request_headers`, `ollama_model_supports_thinking`,
`fetch_models_with_pricing` and `fetch_github_model_catalog`, which used
`str(api_key or "")` and so failed quietly with an object repr in the auth
header rather than raising. Mint failures degrade to `""` because these are
best-effort probes whose callers already treat an unreachable catalog as
"accept the model unverified"; raising would turn a probe into a failed
`/model` switch. An unexpected non-string non-callable degrades to `""` for
the same reason it is never `str()`-ed: an object repr passes every credential
check and reaches the provider verbatim.

`_custom_endpoint_fingerprint` hashes a stable stand-in for callables instead
of the minted value: a rotating bearer would otherwise change the fingerprint
on every mint, missing the cache on every catalog read and defeating the
stale-while-revalidate tier. The endpoint URL in the cache key already scopes
the entry.

Also widens the `api_key` annotations in both modules from `Optional[str]` to
an `ApiKeyLike` alias that spells out the callable — the too-narrow annotation
is what hid this bug class.

Verified against a real `CommandTokenSource` on a Databricks AI Gateway
`key_cmd` provider: the `x-api-key` header now carries a minted JWT. 21 of the
29 new tests fail on current main and all pass with the fix.