### PR TITLE
fix(cron): skip profile .env reloads while multiplex isolation is active

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -1257,10 +1257,17 @@ def _run_no_agent_job(
     """
     # Load .env first so auto-delivery can resolve *_HOME_CHANNEL: the agent path's per-run dotenv
     # reload never runs for no_agent jobs. Does not override existing values.
+    # Under an active profile multiplexer the reload must be skipped:
+    # it would push the firing profile's .env values into the shared
+    # process-global os.environ, where every OTHER profile's subprocesses
+    # would inherit them after this fire. The firing profile's secrets
+    # are already authoritative through the secret scope (#87575).
     try:
+        from agent.secret_scope import is_multiplex_active
         from hermes_cli.env_loader import load_hermes_dotenv
 
-        load_hermes_dotenv(hermes_home=_get_hermes_home())
+        if not is_multiplex_active():
+            load_hermes_dotenv(hermes_home=_get_hermes_home())
     except Exception:
         logger.debug("Job '%s': no_agent .env reload failed", job_id, exc_info=True)
 
@@ -2173,11 +2180,18 @@ def _reload_dotenv_and_publish_delivery_target(job: dict) -> None:
     """Re-read .env for this run and publish the auto-deliver target into the session ContextVars."""
     # Reset the secret-source cache FIRST or a Bitwarden/BSM-backed secret is never re-resolved
     # (only the placeholder reloads -> 401s).
+    # Under an active profile multiplexer this reload is skipped: the
+    # firing profile's .env must never leak into the shared process-global
+    # os.environ, where other profiles' subprocesses would inherit it.
+    # The secret scope installed for this fire already makes the firing
+    # profile's secrets authoritative (#87575).
+    from agent.secret_scope import is_multiplex_active
     from hermes_cli.env_loader import load_hermes_dotenv, reset_secret_source_cache
     from gateway.session_context import _VAR_MAP
 
     reset_secret_source_cache()
-    load_hermes_dotenv(hermes_home=_get_hermes_home())
+    if not is_multiplex_active():
+        load_hermes_dotenv(hermes_home=_get_hermes_home())
 
     delivery_target = _resolve_delivery_target(job)
     if delivery_target:

--- a/tests/cron/test_cron_multiplex_dotenv_isolation.py
+++ b/tests/cron/test_cron_multiplex_dotenv_isolation.py
@@ -1,0 +1,179 @@
+"""Regression tests for #87575 — cron .env reloads must not leak profile secrets.
+
+Main scopes every multiplex cron fire to the firing profile: the ticker
+thread wraps the tick in that profile's ``HERMES_HOME`` override, and
+``_run_one_job_body`` installs the profile's secret and terminal scope around
+run and delivery. The remaining cross-profile leak was ``run_job`` itself:
+both of its ``load_hermes_dotenv`` reloads pushed the firing profile's .env
+values into the shared process-global ``os.environ``, where every OTHER
+profile's subprocesses would inherit them after the fire. Both reload sites
+are now skipped while profile isolation is active; the firing profile's
+secrets stay authoritative through the secret scope.
+
+Ensures:
+1. The ``no_agent`` script path skips ``load_hermes_dotenv`` under multiplex
+   isolation and still reloads for single-profile gateways.
+2. The agent path skips the pre-run reload under multiplex isolation and
+   still reloads for single-profile gateways.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import cron.scheduler as cron_scheduler
+from agent.secret_scope import is_multiplex_active, set_multiplex_active
+
+
+@pytest.fixture(autouse=True)
+def _restore_multiplex_flag():
+    original = is_multiplex_active()
+    yield
+    set_multiplex_active(original)
+
+
+@pytest.fixture()
+def dotenv_recorder(monkeypatch):
+    """Replace ``load_hermes_dotenv`` with a call recorder (no env mutation).
+
+    ``run_agent`` is imported up front because its module-level dotenv load
+    (run_agent.py startup behavior) would otherwise be attributed to
+    ``run_job`` on the first import inside a test.
+    """
+    import run_agent  # noqa: F401  (module import side effects land here)
+
+    calls: list[str] = []
+
+    def _record(hermes_home=None, **_kwargs):
+        calls.append(str(hermes_home))
+
+    import hermes_cli.env_loader as env_loader
+
+    monkeypatch.setattr(env_loader, "load_hermes_dotenv", _record)
+    return calls
+
+
+NO_AGENT_JOB = {
+    "id": "multiplex-dotenv-test",
+    "name": "Multiplex Dotenv Test",
+    "no_agent": True,
+    "script": "/does/not/matter.py",
+}
+
+
+def test_no_agent_dotenv_reload_skipped_under_multiplex(
+    tmp_path, monkeypatch, dotenv_recorder
+):
+    """A multiplex cron fire must not push the firing profile's .env into os.environ."""
+    set_multiplex_active(True)
+    monkeypatch.setattr(
+        cron_scheduler,
+        "_run_job_script_with_claim_heartbeat",
+        lambda job, script_path, workdir=None, cancel_event=None: (True, ""),
+    )
+
+    success, _doc, response, error = cron_scheduler.run_job(dict(NO_AGENT_JOB))
+
+    assert success is True
+    assert response == cron_scheduler.SILENT_MARKER
+    assert error is None
+    assert dotenv_recorder == []
+
+
+def test_no_agent_dotenv_reload_still_runs_single_profile(
+    tmp_path, monkeypatch, dotenv_recorder
+):
+    """Single-profile gateways keep the no_agent .env reload (delivery targets)."""
+    set_multiplex_active(False)
+    monkeypatch.setattr(
+        cron_scheduler,
+        "_run_job_script_with_claim_heartbeat",
+        lambda job, script_path, workdir=None, cancel_event=None: (True, ""),
+    )
+
+    success, _doc, _response, _error = cron_scheduler.run_job(dict(NO_AGENT_JOB))
+
+    assert success is True
+    assert len(dotenv_recorder) == 1
+
+
+AGENT_JOB = {
+    "id": "multiplex-dotenv-agent-test",
+    "name": "Multiplex Dotenv Agent Test",
+    "prompt": "Say done",
+}
+
+
+def _install_agent_mocks(monkeypatch):
+    """Drive run_job's agent path with fakes so no provider/session I/O happens."""
+
+    class _FakeAgent:
+        def __init__(self, *args, **kwargs):
+            self.session_db = kwargs.get("session_db")
+
+        def run_conversation(self, prompt, task_id=None):
+            return {
+                "completed": True,
+                "failed": False,
+                "final_response": "done",
+                "turn_exit_reason": "",
+            }
+
+        def close(self):
+            pass
+
+    class _FakeSessionDB:
+        def __init__(self, db_path=None, read_only=False):
+            pass
+
+        def set_session_title(self, *args, **kwargs):
+            pass
+
+        def end_session(self, *args, **kwargs):
+            pass
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr("hermes_state.SessionDB", _FakeSessionDB)
+    monkeypatch.setattr("run_agent.AIAgent", _FakeAgent)
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider.resolve_runtime_provider",
+        lambda **_kwargs: {
+            "api_key": "test-key",
+            "base_url": None,
+            "provider": "test-provider",
+            "api_mode": None,
+            "command": None,
+            "args": None,
+        },
+    )
+    monkeypatch.setattr("tools.mcp_tool_discovery.discover_mcp_tools", lambda: [])
+    monkeypatch.setattr(cron_scheduler, "get_fallback_chain", lambda _cfg: [])
+    monkeypatch.setattr(
+        cron_scheduler, "_guard_job_credential_exfil", lambda _job: None
+    )
+
+
+def test_agent_dotenv_reload_skipped_under_multiplex(monkeypatch, dotenv_recorder):
+    """The agent path's pre-run reload must be skipped under multiplex isolation."""
+    set_multiplex_active(True)
+    _install_agent_mocks(monkeypatch)
+
+    success, _doc, response, _error = cron_scheduler.run_job(dict(AGENT_JOB))
+
+    assert success is True
+    assert response == "done"
+    assert dotenv_recorder == []
+
+
+def test_agent_dotenv_reload_still_runs_single_profile(monkeypatch, dotenv_recorder):
+    """Single-profile gateways keep the pre-run .env/config reload (#33465)."""
+    set_multiplex_active(False)
+    _install_agent_mocks(monkeypatch)
+
+    success, _doc, response, _error = cron_scheduler.run_job(dict(AGENT_JOB))
+
+    assert success is True
+    assert response == "done"
+    assert len(dotenv_recorder) == 1


### PR DESCRIPTION
## What does this PR do?

On multiplexed gateways (`gateway.multiplex_profiles: true`), `run_job`'s own `.env` reloads leak the firing profile's secrets into the shared process environment. The multiplex cron ticker already scopes each fire to the firing profile's `HERMES_HOME`, and `_run_one_job_body` installs that profile's secret and terminal scope around run and delivery — but both of `run_job`'s `load_hermes_dotenv` calls still pushed the firing profile's `.env` values into the shared process-global `os.environ`, where every OTHER profile's subprocesses inherit them after the fire.

This PR closes that remaining gap: both reload sites are skipped while profile isolation is active. The firing profile's secrets stay authoritative through the secret scope, and single-profile gateways keep the reloads unchanged (the no_agent reload that resolves auto-delivery home channels, and the pre-run reload that re-resolves Bitwarden/BSM-backed secrets, #33465).

Scope note: the PR originally also extracted `profile_runtime_scope` into `agent/secret_scope.py` and wrapped cron execution with it. Upstream `main` has since landed equivalent (and stronger) coverage natively — the multiplex ticker wraps each profile's tick in `set_hermes_home_override` + `use_cron_store`, and `_run_one_job_body` now installs the profile's secret scope plus the terminal-policy seam (#68559). Those hunks were dropped in this rebase; what remains is the piece `main` does not cover.

## Related Issue

Closes #87575

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- **`cron/scheduler.py`** (`run_job`, both reload sites):
  - `no_agent` script path: `load_hermes_dotenv(hermes_home=...)` now runs only when `not is_multiplex_active()`.
  - agent path pre-run reload: same guard, after `reset_secret_source_cache()`.
  - Both sites keep the single-profile behavior byte-identical; under multiplex isolation the reload is a no-op because the firing profile's secrets are already authoritative through the secret scope.
- **`tests/cron/test_cron_multiplex_dotenv_isolation.py`**: new regression tests pinning both sites: reload skipped under an active multiplexer, still performed for single-profile gateways. The two multiplex tests fail on `origin/main` and pass with the guard.

## How to Test

1. Run the focused regression tests:
   ```bash
   python -m pytest tests/cron/test_cron_multiplex_dotenv_isolation.py
   ```
   The two `*_skipped_under_multiplex` tests fail on current `main` (the reload mutates `os.environ` under isolation) and pass with this change; the two single-profile controls prove the reloads still run without isolation.
2. `scripts/check.sh --project hermes-agent --worktree worktrees/hermes-agent/87575` — all blocking gates pass on the exact head.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS (Apple Silicon)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A