### PR TITLE
fix(state): project multimodal text into trigram/CJK FTS indexes

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -70,6 +70,7 @@ from hermes_state_common import (  # noqa: F401  (re-exported for back-compat)
     _RESET_END_REASONS,
     _RESET_END_REASONS_SQL,
     _ephemeral_child_sql,
+    _fts_index_content_sql,
     _legacy_reset_child_sql,
     _shape_preview,
     _sql_session_last_active,
@@ -3410,9 +3411,9 @@ def _run_repair_strategies(
 # an external-content 'delete' op for a rowid the index never held is the
 # canonical FTS5 index-corruption hazard the v23 marker gating exists to
 # prevent.
-FTS_CJK_TABLE_SQL = """
+FTS_CJK_TABLE_SQL = f"""
 CREATE VIEW IF NOT EXISTS messages_fts_cjk_src AS
-    SELECT id, role, content, tool_name, tool_calls
+    SELECT id, role, {_fts_index_content_sql('content', 'fts_content')} AS content, tool_name, tool_calls
     FROM messages
     WHERE role <> 'tool';
 
@@ -3426,7 +3427,7 @@ CREATE VIRTUAL TABLE IF NOT EXISTS messages_fts_cjk USING fts5(
 );
 """
 
-FTS_CJK_TRIGGER_SQL = """
+FTS_CJK_TRIGGER_SQL = f"""
 CREATE TRIGGER IF NOT EXISTS messages_fts_cjk_insert AFTER INSERT ON messages
 WHEN new.role <> 'tool'
    AND (new.id > COALESCE((SELECT CAST(value AS INTEGER) FROM state_meta
@@ -3435,7 +3436,7 @@ WHEN new.role <> 'tool'
                             WHERE key = 'fts_cjk_rebuild_progress'), -1))
 BEGIN
     INSERT INTO messages_fts_cjk(rowid, content, tool_name, tool_calls)
-    VALUES (new.id, new.content, new.tool_name, new.tool_calls);
+    VALUES (new.id, {_fts_index_content_sql('new.content', 'new.fts_content')}, new.tool_name, new.tool_calls);
 END;
 
 CREATE TRIGGER IF NOT EXISTS messages_fts_cjk_delete AFTER DELETE ON messages
@@ -3446,12 +3447,13 @@ WHEN old.role <> 'tool'
                             WHERE key = 'fts_cjk_rebuild_progress'), -1))
 BEGIN
     INSERT INTO messages_fts_cjk(messages_fts_cjk, rowid, content, tool_name, tool_calls)
-    VALUES ('delete', old.id, old.content, old.tool_name, old.tool_calls);
+    VALUES ('delete', old.id, {_fts_index_content_sql('old.content', 'old.fts_content')}, old.tool_name, old.tool_calls);
 END;
 
 CREATE TRIGGER IF NOT EXISTS messages_fts_cjk_update
-AFTER UPDATE OF content, tool_name, tool_calls, role ON messages
+AFTER UPDATE OF content, fts_content, tool_name, tool_calls, role ON messages
 WHEN (old.content IS NOT new.content
+    OR old.fts_content IS NOT new.fts_content
     OR old.tool_name IS NOT new.tool_name
     OR old.tool_calls IS NOT new.tool_calls
     OR old.role IS NOT new.role)
@@ -3461,10 +3463,10 @@ WHEN (old.content IS NOT new.content
                             WHERE key = 'fts_cjk_rebuild_progress'), -1))
 BEGIN
     INSERT INTO messages_fts_cjk(messages_fts_cjk, rowid, content, tool_name, tool_calls)
-    SELECT 'delete', old.id, old.content, old.tool_name, old.tool_calls
+    SELECT 'delete', old.id, {_fts_index_content_sql('old.content', 'old.fts_content')}, old.tool_name, old.tool_calls
     WHERE old.role <> 'tool';
     INSERT INTO messages_fts_cjk(rowid, content, tool_name, tool_calls)
-    SELECT new.id, new.content, new.tool_name, new.tool_calls
+    SELECT new.id, {_fts_index_content_sql('new.content', 'new.fts_content')}, new.tool_name, new.tool_calls
     WHERE new.role <> 'tool';
 END;
 """
@@ -4873,6 +4875,60 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 "trigram/LIKE", exc_info=True,
             )
             self._fts_cjk_available = False
+
+    def _upgrade_fts_cjk_projection(self) -> bool:
+        """Rebuild the CJK-bigram index against the multimodal text
+        projection (#69672's companion fix — same idea as
+        :meth:`SessionSearchMixin._upgrade_fts_trigram_projection` in
+        hermes_state_search.py, kept here because it needs
+        ``FTS_CJK_TABLE_SQL``/``FTS_CJK_TRIGGER_SQL``, which live in this
+        module).
+
+        No-op when the tokenizer isn't loaded, the table doesn't exist yet,
+        or the view already reads ``fts_content``. Drops the view/triggers,
+        backfills ``fts_content``, then re-ensures the schema and runs the
+        FTS5 ``'rebuild'`` special command so existing rows re-index from
+        the projection. ``_ensure_fts_cjk_schema`` uses ``executescript()``,
+        which implicitly commits — it and the 'rebuild' insert must run
+        outside ``_execute_write()``'s ``BEGIN IMMEDIATE``, same rule as
+        every other CJK schema recreation in this class.
+        """
+        if not self._fts_cjk_loaded:
+            return False
+        with self._lock:
+            cjk_present = bool(self._conn.execute(
+                "SELECT 1 FROM sqlite_master WHERE type = 'table' "
+                "AND name = 'messages_fts_cjk'"
+            ).fetchone())
+            if not cjk_present or self._fts_view_uses_multimodal_projection(
+                self._conn, "messages_fts_cjk_src"
+            ):
+                return False
+
+        def _backfill_and_drop(conn):
+            self._backfill_fts_content(conn)
+            for trig in _FTS_CJK_TRIGGERS:
+                conn.execute(f"DROP TRIGGER IF EXISTS {trig}")
+            conn.execute("DROP VIEW IF EXISTS messages_fts_cjk_src")
+
+        self._execute_write(_backfill_and_drop)
+
+        with self._lock:
+            self._ensure_fts_cjk_schema(self._conn)
+            if not self._fts_cjk_available:
+                self._conn.commit()
+                raise sqlite3.OperationalError(
+                    "failed to recreate messages_fts_cjk during the "
+                    "multimodal-projection upgrade"
+                )
+            self._conn.execute(
+                "INSERT INTO messages_fts_cjk(messages_fts_cjk) VALUES('rebuild')"
+            )
+            self._conn.commit()
+        logger.info(
+            "Rebuilt messages_fts_cjk onto the multimodal text projection (#69672)."
+        )
+        return True
 
     @staticmethod
     def _drop_fts_triggers(cursor: sqlite3.Cursor) -> None:
@@ -10310,6 +10366,67 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 return content
         return content
 
+    @classmethod
+    def _fts_content(cls, stored_content: Any) -> Optional[str]:
+        """Text-only projection of ``stored_content`` for substring indexes.
+
+        Multimodal rows keep their sentinel-prefixed JSON verbatim in
+        ``content`` for replay, but only the explicit ``text`` parts belong
+        in the trigram/CJK substring indexes (#69672): ``image_url`` parts
+        commonly carry multi-megabyte base64 data that is neither a
+        meaningful search target nor safe to trigram-index (the embedded NUL
+        makes SQLite's trigram integrity check version-dependent). Returns
+        ``None`` for plain scalar content — the FTS view/triggers fall back
+        to indexing ``content`` directly in that case (see
+        ``_fts_index_content_sql`` in hermes_state_common.py).
+        """
+        decoded = cls._decode_content(stored_content)
+        if isinstance(decoded, list):
+            text_parts = [
+                part.get("text")
+                for part in decoded
+                if isinstance(part, dict)
+                and part.get("type") == "text"
+                and isinstance(part.get("text"), str)
+            ]
+            return " ".join(text_parts).replace("\x00", " ")
+        if isinstance(decoded, dict):
+            text = decoded.get("text") if decoded.get("type") == "text" else ""
+            return text.replace("\x00", " ") if isinstance(text, str) else ""
+        return None
+
+    def _backfill_fts_content(
+        self, conn, *, lo: Optional[int] = None, hi: Optional[int] = None
+    ) -> None:
+        """Populate ``fts_content`` for multimodal rows that lack it.
+
+        Called before a trigram/CJK backfill INSERT reads through a view
+        sourcing ``fts_content`` (see ``_fts_index_content_sql`` in
+        hermes_state_common.py), so the read never sees a NULL projection for
+        a row the sentinel check identifies as multimodal. Caller holds the
+        write transaction.
+
+        ``lo``/``hi`` scope the scan to one chunk's id range (exclusive
+        lower, inclusive upper — matching the chunk-loop callers) so a
+        per-chunk call stays O(chunk), not O(table); omit both for a one-shot
+        full-table backfill (the ``optimize_fts_storage`` projection-upgrade
+        path, run once).
+        """
+        query = (
+            "SELECT id, content FROM messages WHERE fts_content IS NULL "
+            "AND substr(CAST(content AS BLOB), 1, 6) = X'006A736F6E3A'"
+        )
+        params: tuple = ()
+        if lo is not None and hi is not None:
+            query += " AND id > ? AND id <= ?"
+            params = (lo, hi)
+        rows = conn.execute(query, params)
+        while batch := rows.fetchmany(500):
+            conn.executemany(
+                "UPDATE messages SET fts_content = ? WHERE id = ?",
+                [(self._fts_content(row[1]), row[0]) for row in batch],
+            )
+
     @staticmethod
     def _encode_display_metadata(display_metadata: Any) -> Optional[str]:
         """Serialize ``display_metadata`` for its TEXT column without double-encoding.
@@ -10560,6 +10677,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         # Multimodal content (list of parts) must be JSON-encoded: sqlite3
         # cannot bind list/dict parameters directly.
         stored_content = self._encode_content(content)
+        fts_content = self._fts_content(stored_content)
 
         message_timestamp = time.time()
         if timestamp is not None:
@@ -10585,15 +10703,16 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 turn_lease_ttl_seconds=turn_lease_ttl_seconds,
             )
             cursor = conn.execute(
-                """INSERT INTO messages (session_id, role, content, tool_call_id,
+                """INSERT INTO messages (session_id, role, content, fts_content, tool_call_id,
                    tool_calls, tool_name, effect_disposition, timestamp, token_count, finish_reason,
                    reasoning, reasoning_content, reasoning_details, codex_reasoning_items,
                    codex_message_items, platform_message_id, observed, active, api_content, display_kind, display_metadata)
-                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
                 (
                     session_id,
                     role,
                     stored_content,
+                    fts_content,
                     tool_call_id,
                     tool_calls_json,
                     _scrub_surrogates(tool_name),
@@ -11014,17 +11133,19 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             )
 
             api_content = msg.get("api_content")
+            stored_content = self._encode_content(msg.get("content"))
 
             cur = conn.execute(
-                """INSERT INTO messages (session_id, role, content, tool_call_id,
+                """INSERT INTO messages (session_id, role, content, fts_content, tool_call_id,
                    tool_calls, tool_name, effect_disposition, timestamp, token_count, finish_reason,
                    reasoning, reasoning_content, reasoning_details, codex_reasoning_items,
                    codex_message_items, platform_message_id, observed, active, api_content, display_kind, display_metadata)
-                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
                 (
                     session_id,
                     role,
-                    self._encode_content(msg.get("content")),
+                    stored_content,
+                    self._fts_content(stored_content),
                     msg.get("tool_call_id"),
                     tool_calls_json,
                     _scrub_surrogates(msg.get("tool_name")),

--- a/hermes_state_common.py
+++ b/hermes_state_common.py
@@ -326,7 +326,7 @@ def _sql_session_last_active_by_id(session_id_expr: str) -> str:
     )
 
 
-SCHEMA_VERSION = 26
+SCHEMA_VERSION = 27
 
 
 # FTS storage-layout version, tracked INDEPENDENTLY of SCHEMA_VERSION in the
@@ -337,7 +337,12 @@ SCHEMA_VERSION = 26
 # layout 0 (marker absent) with a working inline index until the user opts in.
 #   1 = v23 external-content layout (content/tool_name/tool_calls,
 #       tool-row-excluded trigram)
-FTS_STORAGE_VERSION = 1
+#   2 = multimodal text projection for the trigram/CJK indexes (#69672):
+#       sentinel-prefixed multimodal JSON is excluded from the substring
+#       indexes in favour of the ``fts_content`` text-only projection —
+#       removes the embedded NUL that makes trigram integrity checks
+#       SQLite-version-dependent, and stops indexing base64 image payloads.
+FTS_STORAGE_VERSION = 2
 
 
 # Cap on user-controlled FTS5 query input before regex/sanitizer processing.
@@ -432,6 +437,7 @@ CREATE TABLE IF NOT EXISTS messages (
     session_id TEXT NOT NULL REFERENCES sessions(id),
     role TEXT NOT NULL,
     content TEXT,
+    fts_content TEXT,
     tool_call_id TEXT,
     tool_calls TEXT,
     tool_name TEXT,
@@ -649,14 +655,35 @@ END;
 # of the text it covers), and ``role='tool'`` rows are ~90% of message bytes
 # while being almost entirely machine noise (base64 payloads, file dumps,
 # delegation transcripts).  The index therefore reads through
-# ``messages_fts_trigram_src``, a view that excludes tool rows — they stay
-# fully stored in ``messages`` and fully searchable via the standard
-# ``messages_fts`` index; they just don't get trigram (CJK substring)
-# treatment.  ``search_messages`` routes CJK queries that filter on
-# ``role='tool'`` to the LIKE fallback for the same reason.
-FTS_TRIGRAM_SQL = """
+# ``messages_fts_trigram_src``, a view that excludes tool rows and, for
+# multimodal rows, substitutes the SessionDB-maintained ``fts_content`` text
+# projection (see ``SessionDB._fts_content``) for the raw sentinel-prefixed
+# JSON — they stay fully stored in ``messages`` and fully searchable via the
+# standard ``messages_fts`` index; they just don't get trigram (CJK
+# substring) treatment on the raw JSON/base64.  ``search_messages`` routes
+# CJK queries that filter on ``role='tool'`` to the LIKE fallback for the
+# same reason.
+def _fts_index_content_sql(content: str, projection: str) -> str:
+    """SQL expression: the substring-index value for a message column pair.
+
+    ``content`` and ``projection`` are trusted SQL expressions (column refs
+    like ``new.content`` / ``new.fts_content``), never user input. Multimodal
+    content is stored JSON-encoded behind a 6-byte NUL ``json:`` sentinel
+    (``SessionDB._CONTENT_JSON_PREFIX``); ``X'006A736F6E3A'`` is that
+    sentinel's byte pattern (NUL + 'json:'). Comparing the raw column as a
+    BLOB avoids any TEXT-affinity/embedded-NUL literal ambiguity. Rows that
+    match get the precomputed text-only projection (never the base64/JSON
+    itself); everything else indexes unchanged, exactly as before.
+    """
+    return (
+        f"CASE WHEN substr(CAST({content} AS BLOB), 1, 6) = X'006A736F6E3A' "
+        f"THEN COALESCE({projection}, '') ELSE {content} END"
+    )
+
+
+FTS_TRIGRAM_SQL = f"""
 CREATE VIEW IF NOT EXISTS messages_fts_trigram_src AS
-    SELECT id, role, content, tool_name, tool_calls
+    SELECT id, role, {_fts_index_content_sql('content', 'fts_content')} AS content, tool_name, tool_calls
     FROM messages
     WHERE role <> 'tool';
 
@@ -677,7 +704,7 @@ WHEN new.role <> 'tool'
                             WHERE key = 'fts_rebuild_progress'), -1))
 BEGIN
     INSERT INTO messages_fts_trigram(rowid, content, tool_name, tool_calls)
-    VALUES (new.id, new.content, new.tool_name, new.tool_calls);
+    VALUES (new.id, {_fts_index_content_sql('new.content', 'new.fts_content')}, new.tool_name, new.tool_calls);
 END;
 
 CREATE TRIGGER IF NOT EXISTS messages_fts_trigram_delete AFTER DELETE ON messages
@@ -688,12 +715,13 @@ WHEN old.role <> 'tool'
                             WHERE key = 'fts_rebuild_progress'), -1))
 BEGIN
     INSERT INTO messages_fts_trigram(messages_fts_trigram, rowid, content, tool_name, tool_calls)
-    VALUES ('delete', old.id, old.content, old.tool_name, old.tool_calls);
+    VALUES ('delete', old.id, {_fts_index_content_sql('old.content', 'old.fts_content')}, old.tool_name, old.tool_calls);
 END;
 
 CREATE TRIGGER IF NOT EXISTS messages_fts_trigram_update
-AFTER UPDATE OF content, tool_name, tool_calls, role ON messages
+AFTER UPDATE OF content, fts_content, tool_name, tool_calls, role ON messages
 WHEN (old.content IS NOT new.content
+    OR old.fts_content IS NOT new.fts_content
     OR old.tool_name IS NOT new.tool_name
     OR old.tool_calls IS NOT new.tool_calls
     OR old.role IS NOT new.role)
@@ -703,10 +731,10 @@ WHEN (old.content IS NOT new.content
                             WHERE key = 'fts_rebuild_progress'), -1))
 BEGIN
     INSERT INTO messages_fts_trigram(messages_fts_trigram, rowid, content, tool_name, tool_calls)
-    SELECT 'delete', old.id, old.content, old.tool_name, old.tool_calls
+    SELECT 'delete', old.id, {_fts_index_content_sql('old.content', 'old.fts_content')}, old.tool_name, old.tool_calls
     WHERE old.role <> 'tool';
     INSERT INTO messages_fts_trigram(rowid, content, tool_name, tool_calls)
-    SELECT new.id, new.content, new.tool_name, new.tool_calls
+    SELECT new.id, {_fts_index_content_sql('new.content', 'new.fts_content')}, new.tool_name, new.tool_calls
     WHERE new.role <> 'tool';
 END;
 """

--- a/hermes_state_schema.py
+++ b/hermes_state_schema.py
@@ -1276,7 +1276,10 @@ class SessionSchemaMixin:
             # index against non-empty messages) is NOT stamped either —
             # the marker is the source of truth for "fully optimized", and
             # `fts_optimize_available()` keeps offering the resume until the
-            # transition actually completes.
+            # transition actually completes. A live trigram index still
+            # indexing raw multimodal JSON (#69672, fts_storage_version < 2)
+            # is likewise held back — only `optimize-storage`'s explicit
+            # rebuild advances it, same as every other opt-in FTS transition.
             if (
                 fts5_available
                 and not self._db_has_legacy_inline_fts(cursor)
@@ -1286,10 +1289,15 @@ class SessionSchemaMixin:
                 ).fetchone() is None
                 and not self._has_fts_trash(cursor)
                 and not self._fts_external_index_empty_with_messages(cursor)
+                and not self._fts_trigram_needs_multimodal_projection(cursor)
             ):
                 self.set_meta(
                     "fts_storage_version", str(FTS_STORAGE_VERSION), cursor=cursor
                 )
+            elif fts5_available and self._fts_trigram_needs_multimodal_projection(
+                cursor
+            ):
+                self.set_meta("fts_optimize_available", "1", cursor=cursor)
 
             # Advance schema_version to current for ALL non-FTS-layout
             # migrations. This is deliberately NOT gated on the FTS opt-in —

--- a/hermes_state_search.py
+++ b/hermes_state_search.py
@@ -26,6 +26,7 @@ from hermes_state_common import (
     MAX_FTS5_QUERY_CHARS,
     SCHEMA_VERSION,
     _FTS_CJK_TRIGGERS,
+    _fts_index_content_sql,
     escape_like as _escape_like,
     fts_rebuild_admission,
 )
@@ -157,9 +158,10 @@ class SessionSearchMixin:
                     (lo, hi),
                 )
                 if include_trigram:
+                    self._backfill_fts_content(conn, lo=lo, hi=hi)
                     conn.execute(
                         "INSERT INTO messages_fts_trigram(rowid, content, tool_name, tool_calls) "
-                        "SELECT m.id, m.content, m.tool_name, m.tool_calls "
+                        f"SELECT m.id, {_fts_index_content_sql('m.content', 'm.fts_content')}, m.tool_name, m.tool_calls "
                         "FROM messages m "
                         "WHERE m.id > ? AND m.id <= ? AND m.role <> 'tool' "
                         "AND NOT EXISTS (SELECT 1 FROM messages_fts_trigram_docsize d WHERE d.id = m.id)",
@@ -315,10 +317,11 @@ class SessionSearchMixin:
                 (progress, upper),
             )
             if include_trigram:
+                self._backfill_fts_content(conn, lo=progress, hi=upper)
                 conn.execute(
                     "INSERT INTO messages_fts_trigram"
                     "(rowid, content, tool_name, tool_calls) "
-                    "SELECT id, content, tool_name, tool_calls FROM messages "
+                    f"SELECT id, {_fts_index_content_sql('content', 'fts_content')}, tool_name, tool_calls FROM messages "
                     "WHERE id > ? AND id <= ? AND role <> 'tool'",
                     (progress, upper),
                 )
@@ -382,9 +385,10 @@ class SessionSearchMixin:
             if progress >= high_water:
                 return False
             upper = min(progress + chunk, high_water)
+            self._backfill_fts_content(conn, lo=progress, hi=upper)
             conn.execute(
                 "INSERT INTO messages_fts_cjk(rowid, content, tool_name, tool_calls) "
-                "SELECT id, content, tool_name, tool_calls FROM messages "
+                f"SELECT id, {_fts_index_content_sql('content', 'fts_content')}, tool_name, tool_calls FROM messages "
                 "WHERE id > ? AND id <= ? AND role <> 'tool'",
                 (progress, upper),
             )
@@ -417,9 +421,10 @@ class SessionSearchMixin:
             if hw_row is not None:
                 hw = int(hw_row[0])
                 lo, hi = hw - 1000, hw + 1000
+                self._backfill_fts_content(conn, lo=lo, hi=hi)
                 conn.execute(
                     "INSERT INTO messages_fts_cjk(rowid, content, tool_name, tool_calls) "
-                    "SELECT m.id, m.content, m.tool_name, m.tool_calls "
+                    f"SELECT m.id, {_fts_index_content_sql('m.content', 'm.fts_content')}, m.tool_name, m.tool_calls "
                     "FROM messages m "
                     "WHERE m.id > ? AND m.id <= ? AND m.role <> 'tool' "
                     "AND NOT EXISTS (SELECT 1 FROM messages_fts_cjk_docsize d WHERE d.id = m.id)",
@@ -639,18 +644,31 @@ class SessionSearchMixin:
     def fts_optimize_available(self) -> bool:
         """True when `optimize_fts_storage()` has work to do: either this DB
         is a legacy inline-FTS install that can be optimized to the v23
-        external-content schema, or a previous optimize run was interrupted
-        (legacy vtables already demoted, but backfill markers and/or trash
-        tables remain) and re-running would resume it, or the CJK-bigram
-        index needs a backfill/rebuild on this tokenizer-capable host, or
-        a prior demote left an empty external-content index without markers
-        (healable on re-run).
+        external-content schema, or the trigram/CJK index still indexes raw
+        multimodal JSON instead of the text-only projection (#69672), or a
+        previous optimize run was interrupted (legacy vtables already
+        demoted, but backfill markers and/or trash tables remain) and
+        re-running would resume it, or the CJK-bigram index needs a
+        backfill/rebuild on this tokenizer-capable host, or a prior demote
+        left an empty external-content index without markers (healable on
+        re-run).
         False for fresh and fully-optimized installs (and when FTS5 is
         unavailable)."""
         if not self._fts_enabled or self.read_only:
             return False
         with self._lock:
             if self._db_has_legacy_inline_fts(self._conn):
+                return True
+            # A live index still indexing raw multimodal JSON (#69672):
+            # offer the rebuild that projects it to text-only.
+            if self._fts_trigram_needs_multimodal_projection(self._conn):
+                return True
+            if self._fts_cjk_loaded and bool(self._conn.execute(
+                "SELECT 1 FROM sqlite_master WHERE type = 'table' "
+                "AND name = 'messages_fts_cjk'"
+            ).fetchone()) and not self._fts_view_uses_multimodal_projection(
+                self._conn, "messages_fts_cjk_src"
+            ):
                 return True
             # Interrupted optimize: demotion already removed the legacy
             # vtables (so the check above is False), but the transition is
@@ -745,6 +763,78 @@ class SessionSearchMixin:
             self._conn.commit()
         return hw
 
+    @staticmethod
+    def _fts_view_uses_multimodal_projection(cursor, view_name: str) -> bool:
+        """True when a content-source view already reads ``fts_content``.
+
+        A missing view (table absent, e.g. trigram unavailable on this
+        build) is treated as "nothing to upgrade" — ``True`` — so callers
+        don't offer an upgrade that has no view to rebuild.
+        """
+        row = cursor.execute(
+            "SELECT sql FROM sqlite_master WHERE type = 'view' AND name = ?",
+            (view_name,),
+        ).fetchone()
+        return row is None or "fts_content" in ((row[0] or "").lower())
+
+    def _fts_trigram_needs_multimodal_projection(self, cursor) -> bool:
+        """True when a live trigram index still indexes raw multimodal JSON."""
+        return self._trigram_available and not self._fts_view_uses_multimodal_projection(
+            cursor, "messages_fts_trigram_src"
+        )
+
+    def _upgrade_fts_trigram_projection(self) -> bool:
+        """Rebuild the trigram index against the multimodal text projection.
+
+        No-op (returns False) when the trigram index is unavailable or
+        already projected. Otherwise: backfill ``fts_content`` for every
+        multimodal row, drop the stale view/triggers, recreate them from the
+        current ``FTS_TRIGRAM_SQL`` (which reads through the projection —
+        see ``_fts_index_content_sql``), and run the FTS5 ``'rebuild'``
+        special command so every existing row re-indexes from the projected
+        content. A single foreground pass: unlike the legacy-demote backfill,
+        this has no chunked/resumable state of its own — it runs to
+        completion inside one call, the same way the existing repair path
+        (``_rebuild_fts_indexes``) already rebuilds this table in one shot.
+        """
+        if not self._trigram_available:
+            return False
+        with self._lock:
+            if self._fts_view_uses_multimodal_projection(
+                self._conn, "messages_fts_trigram_src"
+            ):
+                return False
+
+        def _backfill_and_drop(conn):
+            self._backfill_fts_content(conn)
+            self._drop_fts_triggers(conn)
+            conn.execute("DROP VIEW IF EXISTS messages_fts_trigram_src")
+
+        self._execute_write(_backfill_and_drop)
+
+        # Recreate outside the write transaction — _ensure_fts_schema uses
+        # executescript(), which implicitly commits and must not run inside
+        # _execute_write's BEGIN IMMEDIATE (same rule as the legacy-demote
+        # and CJK-recreate paths above).
+        with self._lock:
+            trigram_ok = self._ensure_fts_schema(
+                self._conn, "messages_fts_trigram", FTS_TRIGRAM_SQL
+            )
+            self._trigram_available = bool(trigram_ok)
+            if not trigram_ok:
+                raise sqlite3.OperationalError(
+                    "failed to recreate messages_fts_trigram during the "
+                    "multimodal-projection upgrade"
+                )
+            self._conn.execute(
+                "INSERT INTO messages_fts_trigram(messages_fts_trigram) VALUES('rebuild')"
+            )
+            self._conn.commit()
+        logger.info(
+            "Rebuilt messages_fts_trigram onto the multimodal text projection (#69672)."
+        )
+        return True
+
     def optimize_fts_storage(
         self,
         *,
@@ -802,6 +892,13 @@ class SessionSearchMixin:
                     )
                 self._conn.commit()
 
+        # An already-current-layout install whose trigram index still
+        # carries raw multimodal JSON (fts_storage_version < 2, #69672):
+        # rebuild it onto the text-only projection. No-op when already
+        # projected, unavailable, or a legacy demote just above created a
+        # freshly (and already correctly) projected view.
+        self._upgrade_fts_trigram_projection()
+
         # A stale CJK index (triggers dropped by a tokenizer-less process)
         # can only be recovered from scratch — reset it now so the cjk
         # backfill phase below rebuilds it. No-op without the tokenizer.
@@ -813,6 +910,9 @@ class SessionSearchMixin:
             with self._lock:
                 self._ensure_fts_cjk_schema(self._conn)
                 self._conn.commit()
+        # Same multimodal-projection upgrade as the trigram index above, for
+        # the CJK-bigram index (#69672). No-op when unavailable or current.
+        self._upgrade_fts_cjk_projection()
 
         def _emit(phase: str) -> None:
             if progress_cb is None:

--- a/tests/test_fts_cjk_bigram.py
+++ b/tests/test_fts_cjk_bigram.py
@@ -143,6 +143,96 @@ def test_existing_v23_db_gains_cjk_via_optimize(cjk_so, tmp_path, monkeypatch):
     d2.close()
 
 
+def test_optimize_rebuilds_v1_cjk_with_multimodal_projection(cjk_so, tmp_path, monkeypatch):
+    """#69672's CJK-index companion: an existing cjk index built before the
+    multimodal text projection still indexes raw sentinel-prefixed JSON
+    (and the base64 image payload inside it). `optimize_fts_storage()` must
+    rebuild it onto the text-only projection, same as the trigram index —
+    the reviewer-requested regression test for PR #69798's CJK branch,
+    covering text + an image payload + an FTS integrity check across the
+    upgrade."""
+    monkeypatch.setenv("HERMES_FTS5_CJK_SO", str(cjk_so))
+    db = SessionDB(db_path=tmp_path / "state.db")
+    try:
+        db.create_session(session_id="s1", source="cli", model="m")
+        db.append_message(
+            "s1",
+            role="user",
+            content=[
+                {"type": "text", "text": "레거시 검색 가능한 텍스트"},
+                {
+                    "type": "image_url",
+                    "image_url": {
+                        "url": "data:image/png;base64,legacycjkbase64payload"
+                    },
+                },
+            ],
+        )
+
+        def _restore_v1_cjk(conn):
+            for trig in (
+                "messages_fts_cjk_insert",
+                "messages_fts_cjk_delete",
+                "messages_fts_cjk_update",
+            ):
+                conn.execute(f"DROP TRIGGER IF EXISTS {trig}")
+            conn.execute("DROP VIEW messages_fts_cjk_src")
+            conn.executescript("""
+                CREATE VIEW messages_fts_cjk_src AS
+                    SELECT id, role, content, tool_name, tool_calls
+                    FROM messages WHERE role <> 'tool';
+                CREATE TRIGGER messages_fts_cjk_insert AFTER INSERT ON messages
+                WHEN new.role <> 'tool' BEGIN
+                    INSERT INTO messages_fts_cjk(rowid, content, tool_name, tool_calls)
+                    VALUES (new.id, new.content, new.tool_name, new.tool_calls);
+                END;
+                CREATE TRIGGER messages_fts_cjk_delete AFTER DELETE ON messages
+                WHEN old.role <> 'tool' BEGIN
+                    INSERT INTO messages_fts_cjk(messages_fts_cjk, rowid, content, tool_name, tool_calls)
+                    VALUES ('delete', old.id, old.content, old.tool_name, old.tool_calls);
+                END;
+                CREATE TRIGGER messages_fts_cjk_update AFTER UPDATE ON messages
+                WHEN old.role <> 'tool' BEGIN
+                    INSERT INTO messages_fts_cjk(messages_fts_cjk, rowid, content, tool_name, tool_calls)
+                    VALUES ('delete', old.id, old.content, old.tool_name, old.tool_calls);
+                    INSERT INTO messages_fts_cjk(rowid, content, tool_name, tool_calls)
+                    VALUES (new.id, new.content, new.tool_name, new.tool_calls);
+                END;
+            """)
+            conn.execute(
+                "INSERT INTO messages_fts_cjk(messages_fts_cjk) VALUES('rebuild')"
+            )
+
+        db._execute_write(_restore_v1_cjk)
+        assert not db._fts_view_uses_multimodal_projection(
+            db._conn, "messages_fts_cjk_src"
+        )
+
+        result = db.optimize_fts_storage(vacuum=False)
+        assert result["ok"] is True
+
+        assert db._fts_view_uses_multimodal_projection(
+            db._conn, "messages_fts_cjk_src"
+        )
+        projected = db._conn.execute(
+            "SELECT content FROM messages_fts_cjk_src"
+        ).fetchone()[0]
+        assert projected == "레거시 검색 가능한 텍스트"
+        assert "\x00" not in projected
+        assert "legacycjkbase64payload" not in projected
+
+        rows = db.search_messages("검색", limit=10)
+        assert rows
+        assert "legacycjkbase64payload" not in rows[0].get("snippet", "")
+
+        db._conn.execute(
+            "INSERT INTO messages_fts_cjk(messages_fts_cjk) VALUES('integrity-check')"
+        )
+        assert db._conn.execute("PRAGMA quick_check").fetchone()[0] == "ok"
+    finally:
+        db.close()
+
+
 def test_legacy_v22_optimize_lands_on_cjk(cjk_so, tmp_path, monkeypatch):
     """A legacy inline-FTS (pre-v23) DB optimized on a tokenizer-capable
     host comes out with BOTH the v23 external-content layout AND a complete

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -3751,6 +3751,140 @@ class TestFTSExternalContentMigration:
         finally:
             db.close()
 
+    def test_multimodal_trigram_indexes_text_without_image_payload(self, tmp_path):
+        """#69672: the trigram index must project multimodal content to its
+        text parts, never the sentinel-prefixed JSON or the base64 image
+        payload — that's what makes trigram integrity checks
+        SQLite-version-dependent, and it indexes unsearchable bytes."""
+        db = SessionDB(db_path=tmp_path / "fresh.db")
+        try:
+            db.create_session(session_id="s1", source="cli")
+            db.append_message(
+                "s1",
+                role="user",
+                content=[
+                    {"type": "text", "text": "searchable multimodal text"},
+                    {
+                        "type": "image_url",
+                        "image_url": {
+                            "url": "data:image/png;base64,unsearchablebase64payload"
+                        },
+                    },
+                ],
+            )
+
+            stored = db._conn.execute("SELECT content FROM messages").fetchone()[0]
+            fts_content = db._conn.execute(
+                "SELECT fts_content FROM messages"
+            ).fetchone()[0]
+            projected = db._conn.execute(
+                "SELECT content FROM messages_fts_trigram_src"
+            ).fetchone()[0]
+            assert stored.startswith("\x00json:")
+            assert fts_content == "searchable multimodal text"
+            assert projected == "searchable multimodal text"
+            assert "\x00" not in projected
+            assert "unsearchablebase64payload" not in projected
+            assert db._conn.execute(
+                "SELECT COUNT(*) FROM messages_fts_trigram "
+                "WHERE messages_fts_trigram MATCH 'searchable'"
+            ).fetchone()[0] == 1
+            assert db._conn.execute(
+                "SELECT COUNT(*) FROM messages_fts_trigram "
+                "WHERE messages_fts_trigram MATCH 'unsearchablebase64payload'"
+            ).fetchone()[0] == 0
+            db._conn.execute(
+                "INSERT INTO messages_fts_trigram(messages_fts_trigram, rank) "
+                "VALUES('integrity-check', 1)"
+            )
+            assert db._conn.execute("PRAGMA quick_check").fetchone()[0] == "ok"
+        finally:
+            db.close()
+
+    def test_optimize_rebuilds_v1_trigram_with_multimodal_projection(self, tmp_path):
+        """#69672: an older (fts_storage_version=1) external-content trigram
+        index that still indexes raw multimodal JSON is rebuilt onto the
+        text-only projection by `optimize_fts_storage()`."""
+        db = SessionDB(db_path=tmp_path / "v1.db")
+        try:
+            db.create_session(session_id="s1", source="cli")
+            db.append_message(
+                "s1",
+                role="user",
+                content=[
+                    {"type": "text", "text": "legacy searchable text"},
+                    {
+                        "type": "image_url",
+                        "image_url": {
+                            "url": "data:image/png;base64,legacybase64payload"
+                        },
+                    },
+                ],
+            )
+
+            def _restore_v1_trigram(conn):
+                for trigger in (
+                    "messages_fts_trigram_insert",
+                    "messages_fts_trigram_delete",
+                    "messages_fts_trigram_update",
+                ):
+                    conn.execute(f"DROP TRIGGER IF EXISTS {trigger}")
+                conn.execute("DROP VIEW messages_fts_trigram_src")
+                conn.executescript("""
+                    CREATE VIEW messages_fts_trigram_src AS
+                        SELECT id, role, content, tool_name, tool_calls
+                        FROM messages WHERE role <> 'tool';
+                    CREATE TRIGGER messages_fts_trigram_insert AFTER INSERT ON messages
+                    WHEN new.role <> 'tool' BEGIN
+                        INSERT INTO messages_fts_trigram(rowid, content, tool_name, tool_calls)
+                        VALUES (new.id, new.content, new.tool_name, new.tool_calls);
+                    END;
+                    CREATE TRIGGER messages_fts_trigram_delete AFTER DELETE ON messages
+                    WHEN old.role <> 'tool' BEGIN
+                        INSERT INTO messages_fts_trigram(messages_fts_trigram, rowid, content, tool_name, tool_calls)
+                        VALUES ('delete', old.id, old.content, old.tool_name, old.tool_calls);
+                    END;
+                    CREATE TRIGGER messages_fts_trigram_update AFTER UPDATE ON messages
+                    WHEN old.role <> 'tool' BEGIN
+                        INSERT INTO messages_fts_trigram(messages_fts_trigram, rowid, content, tool_name, tool_calls)
+                        VALUES ('delete', old.id, old.content, old.tool_name, old.tool_calls);
+                        INSERT INTO messages_fts_trigram(rowid, content, tool_name, tool_calls)
+                        VALUES (new.id, new.content, new.tool_name, new.tool_calls);
+                    END;
+                """)
+                conn.execute(
+                    "INSERT INTO state_meta (key, value) VALUES "
+                    "('fts_storage_version', '1') "
+                    "ON CONFLICT(key) DO UPDATE SET value = excluded.value"
+                )
+                conn.execute(
+                    "INSERT INTO messages_fts_trigram(messages_fts_trigram) VALUES('rebuild')"
+                )
+
+            db._execute_write(_restore_v1_trigram)
+            db._trigram_available = True
+            assert db.fts_optimize_available() is True
+
+            result = db.optimize_fts_storage(vacuum=False)
+
+            assert result["ok"] is True
+            assert db.get_meta("fts_storage_version") == str(
+                hermes_state.FTS_STORAGE_VERSION
+            )
+            projected = db._conn.execute(
+                "SELECT content FROM messages_fts_trigram_src"
+            ).fetchone()[0]
+            assert projected == "legacy searchable text"
+            assert "\x00" not in projected
+            assert "legacybase64payload" not in projected
+            db._conn.execute(
+                "INSERT INTO messages_fts_trigram(messages_fts_trigram, rank) "
+                "VALUES('integrity-check', 1)"
+            )
+            assert db._conn.execute("PRAGMA quick_check").fetchone()[0] == "ok"
+            assert db.fts_optimize_available() is False
+        finally:
+            db.close()
 
     def test_v23_cjk_tool_role_filter_uses_like_fallback(self, tmp_path):
         """A CJK query with role_filter=['tool'] must bypass the trigram index


### PR DESCRIPTION
## What does this PR do?

Projects sentinel-prefixed multimodal message content into a text-only field for the trigram and CJK-bigram FTS5 indexes, excluding `image_url`/base64 payloads. This removes the embedded NUL byte that makes trigram integrity checks SQLite-version-dependent (indexes built under one SQLite build report `malformed inverted index` under another), and stops indexing multi-megabyte base64 payloads that were never meaningfully searchable. Original content in `messages.content` is untouched for replay; the standard `messages_fts` (unicode61) index is untouched since it was never affected.

## Related Issue

Fixes #69672

## Relationship to other PRs

This supersedes the approach in #69798, which stalled because it was written against the pre-split `hermes_state.py` and the reviewer's requested fix (port to `hermes_state_common.py`/`hermes_state_search.py`, fix a transaction-boundary bug, add a CJK-upgrade regression test) fell outside that PR's original three-file scope. This PR:

- Ports the same multimodal-text-projection approach onto the current module split (`hermes_state_common.py`, `hermes_state_search.py`, `hermes_state_schema.py`, `hermes_state.py`).
- Fixes the transaction-boundary bug `teknium1` flagged on #69798: CJK schema recreation via `executescript()` implicitly commits and must run outside `_execute_write()`'s `BEGIN IMMEDIATE` — this version preserves that boundary.
- Adds the CJK-projection-upgrade regression test the reviewer asked for (text + image payload + FTS integrity check across the upgrade), plus trigram-side coverage.

Complementary to (not competing with) #86183, which adds reactive detect-and-self-repair on engine change — this PR is the preventive fix that stops new indexes from developing the version-dependent corruption in the first place.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `hermes_state_common.py`: added `fts_content` column to the `messages` schema, a shared `_fts_index_content_sql()` CASE expression used by the trigram view/triggers, `FTS_STORAGE_VERSION` bumped 1→2.
- `hermes_state.py`: mirrored the same projection into the CJK-bigram view/triggers, added `SessionDB._fts_content()` (text-only projection, excludes `image_url`/base64 parts) and `_backfill_fts_content()`, wired into both message-insert paths.
- `hermes_state_search.py`: deferred-rebuild backfill (`_fts_rebuild_finish`) and chunked rebuild (`fts_rebuild_step`) now backfill `fts_content` and route through the projection for both trigram and CJK.
- `hermes_state_schema.py`: `optimize_fts_storage()` gained a one-shot upgrade path (`_upgrade_fts_trigram_projection` / `_upgrade_fts_cjk_projection`) so existing v1-layout databases can adopt the projection via `hermes sessions optimize-storage`, with CJK schema recreation correctly run outside the write transaction.
- `tests/test_hermes_state.py`, `tests/test_fts_cjk_bigram.py`: multimodal text-only indexing, image-payload exclusion, FTS integrity post-write, upgrade-from-prior-layout, and the CJK-projection-upgrade regression test.

## How to Test

1. `uv pip install -e ".[all,dev]"` in a venv per `CONTRIBUTING.md`.
2. `pytest tests/test_hermes_state.py tests/test_fts_cjk_bigram.py -q -x --timeout=60`
3. Create a session with a text + `image_url` multimodal message; confirm the text matches `messages_fts_trigram` but the base64 token does not, then run the FTS5 `'integrity-check'` command.
4. For an existing pre-projection database, run `hermes sessions optimize-storage` and verify `PRAGMA quick_check` succeeds.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for existing PRs to make sure this isn't a duplicate (see Relationship to other PRs above)
- [x] My PR contains only changes related to this fix
- [x] I've run the relevant test files and they pass (259 passed locally; full-suite collection blocked locally by optional `fastapi`/`uvicorn` deps, consistent with prior contributor notes on #69798)
- [x] I've added tests for my changes
- [ ] I've tested on my platform — tested on Linux only

### Documentation & Housekeeping

- [x] N/A — no config keys, docs, or tool schemas changed