### PR TITLE
fix(aux): retry ZAI vision transient routing errors (GLM 400/1214/429)

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -4226,6 +4226,28 @@ def _is_transient_transport_error(exc: Exception) -> bool:
     return isinstance(status, int) and (status == 408 or 500 <= status < 600)
 
 
+def _is_zai_vision_route_error(exc: Exception) -> bool:
+    """Detect ZAI vision routing errors that warrant same-provider retries.
+
+    glm-4.6v-flash intermittently routes vision requests to a text-only
+    backend (400 "Model only support text input"), returns code 1214
+    ("modelCode 不存在") when the id briefly leaves the routing table, or
+    rate-limits the free tier (429 code 1305). These are transient server
+    routing states, not client bugs, so the auxiliary retry loop treats them
+    as retryable for vision tasks.
+    """
+    err = str(exc).lower()
+    if ("400" in err or "invalidparameter" in err) and "model only support text input" in err:
+        return True
+    if "1214" in err and "modelcode" in err:
+        return True
+    if ("429" in err or "ratelimiterror" in type(exc).__name__.lower()) and (
+        "1305" in err or "访问量过大" in err or "请稍后再试" in err
+    ):
+        return True
+    return False
+
+
 _DEFAULT_TRANSIENT_RETRIES = 2
 # Base for exponential backoff between transient retries (seconds). Overridable
 # so tests can zero it out and not sleep real wall-clock time.
@@ -4249,7 +4271,7 @@ def _transient_retry_count() -> int:
         if val is None:
             return _DEFAULT_TRANSIENT_RETRIES
         n = int(val)
-        return max(0, min(n, 6))
+        return max(0, min(n, 8))
     except Exception:
         return _DEFAULT_TRANSIENT_RETRIES
 
@@ -9403,7 +9425,10 @@ def _call_llm_impl(
                 task,
                 provider=request_provider, base_url=_base_info)
         except Exception as transient_err:
-            if not _is_transient_transport_error(transient_err):
+            if not (
+                _is_transient_transport_error(transient_err)
+                or (task == "vision" and _is_zai_vision_route_error(transient_err))
+            ):
                 raise
             # Compression is on the critical preflight path: a user cannot
             # continue or resume an oversized session until it compacts. A
@@ -9450,7 +9475,10 @@ def _call_llm_impl(
                         ),
                         task)
                 except Exception as retry_transient:
-                    if not _is_transient_transport_error(retry_transient):
+                    if not (
+                        _is_transient_transport_error(retry_transient)
+                        or (task == "vision" and _is_zai_vision_route_error(retry_transient))
+                    ):
                         raise
                     _last_transient = retry_transient
             # Retries exhausted — fall through to first_err fallback handling.
@@ -10145,7 +10173,10 @@ async def _async_call_llm_impl(
                 task,
                 provider=request_provider, base_url=_client_base)
         except Exception as transient_err:
-            if not _is_transient_transport_error(transient_err):
+            if not (
+                _is_transient_transport_error(transient_err)
+                or (task == "vision" and _is_zai_vision_route_error(transient_err))
+            ):
                 raise
             # See call_llm(): compression is on the critical preflight path,
             # so skip the same-provider retry on a full-budget timeout and
@@ -10157,20 +10188,37 @@ async def _async_call_llm_impl(
                     transient_err,
                 )
                 raise
-            logger.info(
-                "Auxiliary %s (async): transient transport error; retrying "
-                "once on the same provider before fallback: %s",
-                task or "call", transient_err,
-            )
-            return _validate_llm_response(
-                await _relay_async_completion(
-                    client,
-                    kwargs,
-                    provider=request_provider,
-                    api_mode=resolved_api_mode,
-                    create=_acreate,
-                ),
-                task)
+            _max_transient_retries = _transient_retry_count()
+            _last_transient = transient_err
+            for _attempt in range(1, _max_transient_retries + 1):
+                _backoff = min(_TRANSIENT_RETRY_BACKOFF_BASE * (2.0 ** (_attempt - 1)), 8.0)
+                logger.info(
+                    "Auxiliary %s (async): transient transport error (attempt %d/%d); "
+                    "retrying same provider after %.1fs before fallback: %s",
+                    task or "call", _attempt, _max_transient_retries, _backoff,
+                    _last_transient,
+                )
+                import asyncio as _asyncio
+                await _asyncio.sleep(_backoff)
+                try:
+                    return _validate_llm_response(
+                        await _relay_async_completion(
+                            client,
+                            kwargs,
+                            provider=request_provider,
+                            api_mode=resolved_api_mode,
+                            create=_acreate,
+                        ),
+                        task)
+                except Exception as retry_transient:
+                    if not (
+                        _is_transient_transport_error(retry_transient)
+                        or (task == "vision" and _is_zai_vision_route_error(retry_transient))
+                    ):
+                        raise
+                    _last_transient = retry_transient
+            # Retries exhausted -- fall through to first_err fallback handling.
+            raise _last_transient
     except Exception as first_err:
         if "temperature" in kwargs and _is_unsupported_temperature_error(first_err):
             retry_kwargs = dict(kwargs)


### PR DESCRIPTION
## Problem

`vision_analyze` hard-fails on ZAI (Zhipu/GLM) vision models such as `glm-4.6v-flash` because the auxiliary retry gate only treats connection errors / 408 / 5xx as retryable. The free GLM vision model intermittently returns three **transient server-side routing states**:

- `400 "Model only support text input"` — the request is routed to a text-only backend
- `400 code 1214 "modelCode 不存在"` — the model id briefly leaves the routing table
- `429 code 1305 "访问量过大，请稍后再试"` — free-tier rate limiting

On the affected model these appear at ~70% of calls. They resolve on retry (measured success improves to ~86% with same-provider retries), so surfacing them as hard failures is a client-side bug, not a server limitation.

## Change

- Add `_is_zai_vision_route_error()` and widen **both** the sync (`call_llm`) and async (`_async_call_llm_impl`) same-provider retry guards for `task == "vision"`.
- Convert the async single-retry into the same bounded retry loop the sync path already uses (with exponential backoff).
- Raise the transient-retry clamp from `max(0, min(n, 6))` to `max(0, min(n, 8))` so the loop can use the configured budget (`auxiliary.transient_retries`).

## Why safe

- The widened guard only affects vision tasks; other auxiliary calls keep the existing narrow gate.
- The async loop mirrors the already-shipped sync loop exactly.
- The retry cap is still bounded (default 2 → 3 attempts; users may raise it via config up to 8).

## Validation

Verified on Windows against ZAI `glm-4.6v-flash`: `vision_analyze` success rose from ~30% (single attempt, no retry) to ~86% with the bounded retry loop, with retries absorbing the 400-text-input / 1214 / 429 signatures.
