### PR TITLE
fix(send_message): don't swallow cron delivery in plugin handler branch

### DIFF
--- a/tests/tools/test_send_message_plugin_extensibility.py
+++ b/tests/tools/test_send_message_plugin_extensibility.py
@@ -269,3 +269,64 @@ print(json.dumps({"host_send": host_send, "cron": cron,
     assert payload["host_send"]["chat_id"] == "@alice@example.com"
     assert payload["cron"]["chat_id"] == "@alice@example.com"
     assert payload["model_registered"] is False
+
+
+def test_cron_delivery_without_args_reaches_standalone_sender(monkeypatch):
+    """#87634: cron delivery calls _send_to_platform without a request dict.
+
+    A registered whole-request send_message_handler must NOT swallow the
+    delivery: the message, thread_id and media are only present in the
+    standalone sender contract, so the no-args path must fall through to
+    standalone_sender_fn instead of invoking the handler with {}.
+    """
+    from tools.send_message_tool import _send_to_platform
+
+    name = "cron-delivery-ext"
+    seen_handler: list = []
+    seen_standalone: list = []
+
+    def handler(args, chat_id, platform_name, pconfig):
+        seen_handler.append((dict(args), chat_id))
+        return {"success": True, "note": "handler"}
+
+    async def standalone(pconfig, chat_id, message, thread_id=None, **kw):
+        seen_standalone.append((chat_id, message, thread_id))
+        return {"success": True, "note": "standalone", "message_id": "m1"}
+
+    entry = PlatformEntry(
+        name=name,
+        label="Cron Delivery Ext",
+        adapter_factory=lambda cfg: None,
+        check_fn=lambda: True,
+        send_message_handler=handler,
+        standalone_sender_fn=standalone,
+    )
+    platform_registry.register(entry)
+    try:
+        pconfig = SimpleNamespace(enabled=True, token=None, extra={})
+        # cron shape: no request dict
+        res = asyncio.run(
+            _send_to_platform(
+                Platform(name), pconfig, "allowed@example.com",
+                "cron body", thread_id="topic-17",
+            )
+        )
+        assert not seen_handler, "whole-request handler must not run for cron delivery"
+        assert len(seen_standalone) == 1, "standalone sender must receive cron delivery"
+        chat_id, message, thread_id = seen_standalone[0]
+        assert chat_id == "allowed@example.com"
+        assert message == "cron body"
+        assert thread_id == "topic-17"
+        assert res.get("success") and res.get("note") == "standalone"
+        # real request shape: whole-request handler still wins
+        res2 = asyncio.run(
+            _send_to_platform(
+                Platform(name), pconfig, "allowed@example.com",
+                "req body", args={"message": "req body"},
+            )
+        )
+        assert len(seen_handler) == 1
+        assert seen_handler[0][0] == {"message": "req body"}
+        assert res2.get("note") == "handler"
+    finally:
+        platform_registry.unregister(name)

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -1289,11 +1289,17 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
 
             entry = platform_registry.get(platform_name)
             handler = entry.send_message_handler if entry is not None else None
-            if handler is not None:
+            # A whole-request handler expects the complete send_message request
+            # dict. Cron delivery and other standalone callers invoke
+            # _send_to_platform WITHOUT a request dict; handing the handler an
+            # empty dict silently drops the message, thread and media (#87634).
+            # Only take the whole-request path for a REAL request; otherwise
+            # fall through to the live adapter / standalone_sender_fn path.
+            if handler is not None and args:
                 try:
                     import inspect
 
-                    result = handler(args or {}, chat_id, platform_name, pconfig)
+                    result = handler(args, chat_id, platform_name, pconfig)
                     if inspect.isawaitable(result):
                         result = await result
                     return result


### PR DESCRIPTION
Fixes #87634

## Problem
Cron delivery calls `_send_to_platform` without a request dict. A plugin-registered `send_message_handler` was invoked with `{}` and returned immediately, so the message, `thread_id` and `media_files` were dropped and the registered `standalone_sender_fn` was never reached.

## Fix
Only take the whole-request handler path when a real request dict exists; otherwise fall through to the live adapter / `standalone_sender_fn` path (which already exists and was simply unreachable).

## Verification
- Behavioral test with a plugin registering both hooks: cron shape (no args) → standalone sender receives (chat_id, message, thread_id); request shape (with args) → handler receives the full dict.
- Regression test added to `tests/tools/test_send_message_plugin_extensibility.py`.