### PR TITLE
fix(cron): surface EMFILE during tick lock instead of silent stall

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -6346,7 +6346,22 @@ def tick(
             fcntl.flock(lock_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
         elif msvcrt:
             msvcrt.locking(lock_fd.fileno(), msvcrt.LK_NBLCK, 1)
-    except (OSError, IOError):
+    except (OSError, IOError) as _lock_err:
+        # FD exhaustion is NOT lock contention. The ticker retries every
+        # interval, so this self-heals once descriptors free up — but it must
+        # be VISIBLE: the old code logged at debug level and returned 0, which
+        # the provider loop read as a clean tick (ok=True), clearing the error
+        # marker and leaving the scheduler silently stalled while the gateway
+        # heartbeat kept beating (#87644).
+        import errno as _errno
+
+        if getattr(_lock_err, "errno", None) in (_errno.EMFILE, _errno.ENFILE):
+            logger.warning(
+                "Cron tick skipped: file descriptor exhaustion (errno %s) — "
+                "possible fd leak; will retry next tick",
+                getattr(_lock_err, "errno", None),
+            )
+            raise
         logger.debug("Tick skipped — another instance holds the lock")
         if lock_fd is not None:
             lock_fd.close()

--- a/tests/cron/test_cron_tick_emfile_lock.py
+++ b/tests/cron/test_cron_tick_emfile_lock.py
@@ -1,0 +1,46 @@
+"""#87644: FD exhaustion during tick lock acquisition must be visible.
+
+Previously an ``OSError`` (EMFILE/ENFILE) while opening the tick lock file
+was treated as lock contention: logged at debug level and returning 0. The
+provider loop read that as a clean tick (ok=True), clearing any error marker
+-- leaving the cron scheduler silently stalled for days while the gateway
+heartbeat kept reporting healthy. The tick must surface FD exhaustion so the
+failure is visible to ``hermes cron status`` / health checks and retries on
+the next tick once descriptors free up.
+"""
+
+from __future__ import annotations
+
+import builtins
+import errno
+
+import pytest
+
+from cron.scheduler import tick
+
+
+def test_tick_lock_emfile_raises_instead_of_silent_zero(monkeypatch):
+    real_open = builtins.open
+
+    def fake_open(path, *a, **kw):
+        if "cron" in str(path) and "lock" in str(path):
+            raise OSError(errno.EMFILE, "Too many open files")
+        return real_open(path, *a, **kw)
+
+    monkeypatch.setattr(builtins, "open", fake_open)
+    with pytest.raises(OSError) as exc:
+        tick(verbose=False)
+    assert exc.value.errno == errno.EMFILE
+
+
+def test_tick_lock_contention_still_returns_zero(monkeypatch):
+    """Non-EMFILE lock failures keep the old semantics (skip, not raise)."""
+    real_open = builtins.open
+
+    def fake_open(path, *a, **kw):
+        if "cron" in str(path) and "lock" in str(path):
+            raise OSError(errno.EACCES, "Permission denied")
+        return real_open(path, *a, **kw)
+
+    monkeypatch.setattr(builtins, "open", fake_open)
+    assert tick(verbose=False) == 0


### PR DESCRIPTION
Fixes #87644

## Problem
FD exhaustion (EMFILE) while opening the tick lock file was treated as lock contention: debug-level log + `return 0`. The provider loop reads that as a clean tick (`ok=True`) and clears the ticker error marker — so the cron scheduler stayed stalled for ~24h while the gateway heartbeat kept reporting healthy (silent death, invisible to supervision).

## Fix
`EMFILE`/`ENFILE` on the lock open now logs a clear warning and re-raises, so the provider records a ticker error and the heartbeat shows `success=False`. The loop retries the next tick and self-heals once descriptors free up. All other lock failures keep the old skip semantics.

## Verification
- Unit tests: EMFILE on lock open → `tick()` raises `OSError(errno 24)`; EACCES (ordinary contention) → still returns 0.
- Tests added in `tests/cron/test_cron_tick_emfile_lock.py`.