### PR TITLE
fix(cli): dispatch /goal control and /subgoal commands inline while agent is running

### DIFF
--- a/hermes_cli/cli_info_mixin.py
+++ b/hermes_cli/cli_info_mixin.py
@@ -453,6 +453,42 @@ class CLIInfoMixin:
         ``CommandDef`` entries declare ``busy_policy="dispatch"``; the classic CLI honours it here)."""
         return self._busy_inline_command(text, has_images, ("bg", "btw"))
 
+    def _should_handle_goal_command_inline(
+        self, text: str, has_images: bool = False
+    ) -> bool:
+        """Return True when /goal control commands or /subgoal should be dispatched while the agent runs.
+
+        Commands like ``/goal gate add ...``, ``/goal wait ...``, ``/goal unwait``,
+        ``/goal pause``, ``/goal resume``, ``/goal show``, ``/goal status``, and ``/subgoal``
+        control the active GoalState while an iterative goal loop is executing.
+        Queuing them through ``_pending_input`` defers execution until the goal turn or
+        entire goal is over, leading to 'no active goal' errors (#87446).
+        """
+        from cli import _looks_like_slash_command
+        if not text or has_images or not _looks_like_slash_command(text):
+            return False
+        if not getattr(self, "_agent_running", False):
+            return False
+        try:
+            from hermes_cli.commands import resolve_command
+            tokens = text.strip().split(None, 2)
+            base = tokens[0].lower().lstrip('/')
+            cmd = resolve_command(base)
+            if not cmd:
+                return False
+            if cmd.name == "subgoal":
+                return True
+            if cmd.name == "goal":
+                sub = tokens[1].lower() if len(tokens) > 1 else ""
+                if sub in {"gate", "wait", "unwait", "pause", "resume", "status", "show"}:
+                    return True
+                if len(tokens) == 1:
+                    return True
+                return False
+            return False
+        except Exception:
+            return False
+
     def handle_bang_shell(self, text: str) -> bool:
         """Run a ``!<command>`` submission. Returns True when it was handled.
 

--- a/hermes_cli/cli_info_mixin.py
+++ b/hermes_cli/cli_info_mixin.py
@@ -480,6 +480,9 @@ class CLIInfoMixin:
                 return True
             if cmd.name == "goal":
                 sub = tokens[1].lower() if len(tokens) > 1 else ""
+                # Control verbs intentionally own the first-token namespace:
+                # `/goal pause the rollout` is a pause command, not new goal
+                # prose. New goal text must use a non-control first token.
                 if sub in {"gate", "wait", "unwait", "pause", "resume", "status", "show"}:
                     return True
                 if len(tokens) == 1:

--- a/hermes_cli/cli_tui_mixin.py
+++ b/hermes_cli/cli_tui_mixin.py
@@ -1368,7 +1368,8 @@ class CLITuiMixin:
                     event.app.exit()
         elif (
             self._should_handle_steer_command_inline(text, has_images=has_images)
-            or self._should_handle_background_command_inline(text, has_images=has_images)):
+            or self._should_handle_background_command_inline(text, has_images=has_images)
+            or self._should_handle_goal_command_inline(text, has_images=has_images)):
             self.process_command(text)
         else:
             return False

--- a/tests/cli/test_cli_goal_busy_dispatch.py
+++ b/tests/cli/test_cli_goal_busy_dispatch.py
@@ -1,0 +1,143 @@
+"""Regression tests for classic-CLI mid-run /goal gate and goal-control dispatch (#87446).
+
+Background
+----------
+When a user sets busy_input_mode="queue" and enters `/goal gate add ...` or other
+goal control subcommands (/goal wait, /goal unwait, /goal pause, /goal resume,
+/goal show, /goal status, /subgoal) while a goal turn is running, the command
+was previously queued into `_pending_input` instead of being dispatched immediately.
+Because `_pending_input` is only processed after the goal loop or turn finishes,
+the goal is often completed or inactive by the time `/goal gate add` runs,
+surfacing as `/goal gate add: no active goal` and preventing quality gates
+from attaching to the active goal.
+
+These tests exercise `_should_handle_goal_command_inline` across all goal control
+commands, new-goal text prompts, and idle/busy states.
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+from unittest.mock import MagicMock, patch
+
+
+def _make_cli():
+    """Create a HermesCLI instance with prompt_toolkit stubbed out."""
+    _clean_config = {
+        "model": {
+            "default": "anthropic/claude-opus-4.6",
+            "base_url": "https://openrouter.ai/api/v1",
+            "provider": "auto",
+        },
+        "display": {"compact": False, "tool_progress": "all"},
+        "agent": {},
+        "terminal": {"env_type": "local"},
+    }
+    clean_env = {"LLM_MODEL": "", "HERMES_MAX_ITERATIONS": ""}
+    prompt_toolkit_stubs = {
+        "prompt_toolkit": MagicMock(),
+        "prompt_toolkit.history": MagicMock(),
+        "prompt_toolkit.styles": MagicMock(),
+        "prompt_toolkit.patch_stdout": MagicMock(),
+        "prompt_toolkit.application": MagicMock(),
+        "prompt_toolkit.layout": MagicMock(),
+        "prompt_toolkit.layout.processors": MagicMock(),
+        "prompt_toolkit.filters": MagicMock(),
+        "prompt_toolkit.layout.dimension": MagicMock(),
+        "prompt_toolkit.layout.menus": MagicMock(),
+        "prompt_toolkit.widgets": MagicMock(),
+        "prompt_toolkit.key_binding": MagicMock(),
+        "prompt_toolkit.completion": MagicMock(),
+        "prompt_toolkit.formatted_text": MagicMock(),
+        "prompt_toolkit.auto_suggest": MagicMock(),
+    }
+    with patch.dict(sys.modules, prompt_toolkit_stubs), patch.dict(
+        "os.environ", clean_env, clear=False
+    ):
+        import cli as _cli_mod
+
+        _cli_mod = importlib.reload(_cli_mod)
+        with patch.object(_cli_mod, "get_tool_definitions", return_value=[]), patch.dict(
+            _cli_mod.__dict__, {"CLI_CONFIG": _clean_config}
+        ):
+            return _cli_mod.HermesCLI()
+
+
+class TestGoalInlineDetector:
+    def test_detects_goal_gate_commands_when_agent_running(self):
+        cli = _make_cli()
+        cli._agent_running = True
+        assert (
+            cli._should_handle_goal_command_inline(
+                "/goal gate add sh -c 'pytest tests/'"
+            )
+            is True
+        )
+        assert cli._should_handle_goal_command_inline("/goal gate list") is True
+        assert cli._should_handle_goal_command_inline("/goal gate") is True
+        assert cli._should_handle_goal_command_inline("/goal gate remove 1") is True
+        assert cli._should_handle_goal_command_inline("/goal gate clear") is True
+
+    def test_detects_goal_control_commands_when_agent_running(self):
+        cli = _make_cli()
+        cli._agent_running = True
+        assert cli._should_handle_goal_command_inline("/goal wait 1234") is True
+        assert cli._should_handle_goal_command_inline("/goal unwait") is True
+        assert cli._should_handle_goal_command_inline("/goal pause") is True
+        assert cli._should_handle_goal_command_inline("/goal resume") is True
+        assert cli._should_handle_goal_command_inline("/goal show") is True
+        assert cli._should_handle_goal_command_inline("/goal status") is True
+        assert cli._should_handle_goal_command_inline("/goal") is True
+
+    def test_detects_subgoal_command_when_agent_running(self):
+        cli = _make_cli()
+        cli._agent_running = True
+        assert (
+            cli._should_handle_goal_command_inline("/subgoal all tests must pass")
+            is True
+        )
+
+    def test_does_not_inline_new_goal_prompts_while_busy(self):
+        """Setting a brand-new goal text is a new goal loop and queues normally."""
+        cli = _make_cli()
+        cli._agent_running = True
+        assert (
+            cli._should_handle_goal_command_inline(
+                "/goal Create four files in notes/m04/"
+            )
+            is False
+        )
+        assert (
+            cli._should_handle_goal_command_inline(
+                "/goal draft Refactor payment gateway"
+            )
+            is False
+        )
+
+    def test_ignores_when_agent_idle(self):
+        """Idle input falls through to the normal command dispatch."""
+        cli = _make_cli()
+        cli._agent_running = False
+        assert (
+            cli._should_handle_goal_command_inline(
+                "/goal gate add sh -c 'pytest tests/'"
+            )
+            is False
+        )
+
+    def test_ignores_with_attached_images(self):
+        cli = _make_cli()
+        cli._agent_running = True
+        assert (
+            cli._should_handle_goal_command_inline(
+                "/goal gate add test", has_images=True
+            )
+            is False
+        )
+
+    def test_ignores_non_slash_input(self):
+        cli = _make_cli()
+        cli._agent_running = True
+        assert cli._should_handle_goal_command_inline("goal gate add test") is False
+        assert cli._should_handle_goal_command_inline("") is False

--- a/tests/cli/test_cli_goal_busy_dispatch.py
+++ b/tests/cli/test_cli_goal_busy_dispatch.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import importlib
 import sys
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 
@@ -141,3 +142,27 @@ class TestGoalInlineDetector:
         cli._agent_running = True
         assert cli._should_handle_goal_command_inline("goal gate add test") is False
         assert cli._should_handle_goal_command_inline("") is False
+
+    def test_goal_controls_do_not_touch_running_agent(self):
+        """Inline goal controls mutate GoalState only, never the active agent."""
+        cli = _make_cli()
+        cli._agent_running = True
+        cli.agent = MagicMock()
+        manager = MagicMock()
+        manager.add_gate.return_value = SimpleNamespace(
+            command="pytest -q",
+            max_retries=1,
+            timeout_seconds=30,
+        )
+        manager.has_goal.return_value = True
+        manager.add_subgoal.return_value = "keep the API stable"
+        manager.state = SimpleNamespace(subgoals=["keep the API stable"])
+        cli._get_goal_manager = lambda: manager
+
+        with patch("cli._cprint"):
+            cli._handle_goal_command("/goal gate add pytest -q")
+            cli._handle_subgoal_command("/subgoal keep the API stable")
+
+        manager.add_gate.assert_called_once_with("pytest -q")
+        manager.add_subgoal.assert_called_once_with("keep the API stable")
+        assert cli.agent.method_calls == []


### PR DESCRIPTION
## What does this PR do?

It dispatches `/goal` control commands and `/subgoal` inline while the classic CLI agent is running. This lets users attach gates and change active goal state during the current turn instead of waiting until the goal has already finished.

## Related Issue

Closes #87446

## Type of Change

- [x] Bug fix (non-breaking change)

## Changes Made

- `cli.py`: detect `/goal` control commands and `/subgoal` for inline dispatch alongside `/steer` and `/background`.
- Control verbs intentionally win the first-token ambiguity, while new goal prose continues to queue normally.
- `tests/cli/test_cli_goal_busy_dispatch.py`: cover control commands, subgoals, new goal prompts, idle/image input, and verify goal controls do not call the running agent.

## How to Test

- `uv run --locked --extra dev pytest tests/cli/test_cli_goal_busy_dispatch.py tests/cli/test_cli_background_busy_path.py tests/cli/test_cli_steer_busy_path.py tests/cli/test_busy_input_mode_command.py tests/cli/test_cli_init.py tests/hermes_cli/test_goals.py -q` - 103 passed, 1 skipped.
- `scripts/check.sh --project hermes-agent --worktree worktrees/hermes-agent/87446` - all blocking gates passed; ty remains advisory with only pre-existing diagnostics and its known checkpoint-manager cycle panic.

## Checklist

### Code

- [x] I've read the Contributing Guide.
- [x] The commit message follows Conventional Commits.
- [x] Existing related PRs were inspected; this updates the existing PR only.
- [x] The PR contains only changes related to this fix.
- [x] Relevant tests pass.
- [x] Regression tests cover busy/idle dispatch and agent isolation.
- [x] Cross-platform impact was considered; this is CLI command routing.

### Documentation & Housekeeping

- [x] No user-facing configuration or workflow changed, so documentation updates are not required.
- [x] No configuration keys changed.
- [x] No tool schema changed.
- [x] No new dependency was added.

## Screenshots / Logs

Rebased onto current `main` (`4209d371a`). Conflict in `cli.py`: kept main's split `/steer` and `/bg`/`/btw` inline branches, then added a matching `/goal` control + `/subgoal` branch. Focused suite: 103 passed, 1 skipped.