### PR TITLE
fix(gateway): keep one failed flush file from aborting pending-message recovery

### DIFF
--- a/gateway/shutdown_flush.py
+++ b/gateway/shutdown_flush.py
@@ -397,16 +397,24 @@ def recover_pending_to_db(
             )
             recovered += 1
             path.unlink(missing_ok=True)
-        except BaseException:
-            # Shutdown cancellation/interrupt must not strand an owned DB.
-            _close_owned_db()
-            raise
         except Exception as exc:
+            # Ordinary failures (an unparseable payload, a rejected
+            # append, an unlink error) must only skip THIS file: one
+            # unrecoverable file would otherwise abort the whole pass, and
+            # since it is never unlinked it would strand every remaining
+            # message on every subsequent boot.  This handler must stay
+            # ABOVE the BaseException handler below — Exception is a
+            # BaseException subclass, so the reverse order makes this
+            # branch unreachable.
             logger.warning(
                 "Failed to recover pending message from %s: %s",
                 path, exc,
             )
             # Leave the file for next startup retry.
+        except BaseException:
+            # Shutdown cancellation/interrupt must not strand an owned DB.
+            _close_owned_db()
+            raise
 
     _close_owned_db()
 

--- a/tests/gateway/test_shutdown_flush.py
+++ b/tests/gateway/test_shutdown_flush.py
@@ -133,6 +133,55 @@ def test_recover_closes_owned_db_when_unexpected_exception_escapes(
     assert db.closed is True
 
 
+def _write_flush_file(flush_dir: Path, name: str, session_id: str, text: str) -> Path:
+    """Write one well-formed pending-message flush file."""
+    path = flush_dir / name
+    path.write_text(
+        json.dumps(
+            {
+                "session_key": "agent:main:telegram:supergroup:123",
+                "reason": "shutdown",
+                "ts": 1700000000,
+                "data": {"text": text, "session_id": session_id},
+            }
+        ),
+        encoding="utf-8",
+    )
+    return path
+
+
+def test_recover_skips_failing_payload_and_continues(tmp_path, monkeypatch):
+    """One unrecoverable file must not abort recovery of the others.
+
+    Recovery walks ``sorted(glob("*.json"))``, so a file that raises an
+    ordinary exception used to propagate out of the whole pass.  Because
+    that file is never unlinked it would then re-poison every subsequent
+    boot, stranding a different subset of messages each time.
+    """
+    flush_dir = _make_flush_dir(tmp_path)
+    monkeypatch.setattr(
+        "gateway.shutdown_flush._get_flush_dir", lambda: flush_dir
+    )
+    bad = _write_flush_file(flush_dir, "pending-a.json", "sid-bad", "first")
+    good = _write_flush_file(flush_dir, "pending-b.json", "sid-good", "second")
+
+    class PartiallyFailingDB:
+        def __init__(self):
+            self.appended = []
+
+        def append_message(self, **kwargs):
+            if kwargs["session_id"] == "sid-bad":
+                raise RuntimeError("session is closed")
+            self.appended.append(kwargs["session_id"])
+
+    db = PartiallyFailingDB()
+    assert recover_pending_to_db(db) == 1
+    assert db.appended == ["sid-good"]
+    # The good file is consumed; the bad one is preserved for a retry.
+    assert not good.exists()
+    assert bad.exists()
+
+
 def test_serialise_object_with_text():
     obj = MagicMock()
     obj.text = "msg"

--- a/tests/gateway/test_shutdown_flush.py
+++ b/tests/gateway/test_shutdown_flush.py
@@ -204,6 +204,44 @@ def test_recover_survives_unparseable_payload(tmp_path, monkeypatch):
     assert corrupt.exists()
 
 
+def test_recover_closes_owned_db_when_interrupt_follows_tolerated_error(
+    tmp_path, monkeypatch
+):
+    """Tolerating ordinary errors must not weaken the interrupt contract.
+
+    #83226's guarantee is that an interrupt closes an owned SessionDB and
+    propagates.  That must still hold on a pass where an earlier file
+    already failed with an ordinary exception and was skipped.
+    """
+    flush_dir = _make_flush_dir(tmp_path)
+    monkeypatch.setattr(
+        "gateway.shutdown_flush._get_flush_dir", lambda: flush_dir
+    )
+    failed = _write_flush_file(flush_dir, "pending-a.json", "sid-bad", "first")
+    _write_flush_file(flush_dir, "pending-b.json", "sid-interrupt", "second")
+
+    class InterruptAfterErrorDB:
+        closed = False
+
+        def append_message(self, **kwargs):
+            if kwargs["session_id"] == "sid-bad":
+                raise RuntimeError("session is closed")
+            raise KeyboardInterrupt
+
+        def close(self):
+            self.closed = True
+
+    db = InterruptAfterErrorDB()
+    monkeypatch.setattr("hermes_state.SessionDB", lambda: db)
+
+    with pytest.raises(KeyboardInterrupt):
+        recover_pending_to_db()
+
+    assert db.closed is True
+    # The tolerated failure is still on disk for the next startup.
+    assert failed.exists()
+
+
 def test_serialise_object_with_text():
     obj = MagicMock()
     obj.text = "msg"

--- a/tests/gateway/test_shutdown_flush.py
+++ b/tests/gateway/test_shutdown_flush.py
@@ -182,6 +182,28 @@ def test_recover_skips_failing_payload_and_continues(tmp_path, monkeypatch):
     assert bad.exists()
 
 
+def test_recover_survives_unparseable_payload(tmp_path, monkeypatch):
+    """A corrupt flush file must be preserved, not abort the pass."""
+    flush_dir = _make_flush_dir(tmp_path)
+    monkeypatch.setattr(
+        "gateway.shutdown_flush._get_flush_dir", lambda: flush_dir
+    )
+    corrupt = flush_dir / "pending-a-bad.json"
+    corrupt.write_text("not json", encoding="utf-8")
+    good = _write_flush_file(flush_dir, "pending-b-good.json", "sid-good", "kept")
+
+    mock_db = MagicMock()
+    assert recover_pending_to_db(mock_db) == 1
+    mock_db.append_message.assert_called_once_with(
+        session_id="sid-good",
+        role="user",
+        content="kept",
+        timestamp=1700000000,
+    )
+    assert not good.exists()
+    assert corrupt.exists()
+
+
 def test_serialise_object_with_text():
     obj = MagicMock()
     obj.text = "msg"


### PR DESCRIPTION
## What does this PR do?

In `gateway/shutdown_flush.py`, `recover_pending_to_db()` walks the shutdown flush spool and appends each pending message back into `state.db`. Its per-file `try` currently orders the handlers like this:

```python
        except BaseException:
            # Shutdown cancellation/interrupt must not strand an owned DB.
            _close_owned_db()
            raise
        except Exception as exc:            # <-- unreachable
            logger.warning(
                "Failed to recover pending message from %s: %s", path, exc,
            )
            # Leave the file for next startup retry.
```

`Exception` is a subclass of `BaseException`, so the second handler can never be entered. Every ordinary failure takes the interrupt path instead: close the owned DB and re-raise.

**The user-visible symptom is silently lost messages after a restart.** One unrecoverable spool file aborts the *whole* recovery pass rather than being skipped. The file is only `unlink`ed after a successful append, so it survives and re-poisons the next boot. The pass iterates `sorted(flush_dir.glob("*.json"))` over `uuid4`-named payloads, so which of the remaining messages get stranded is effectively random and changes on every startup. And the only caller — `gateway/run.py`, right after `runner.start()` — wraps the call in `except Exception: pass`, so there is no traceback and no crash. The user just sees messages that never come back.

Real producers of an ordinary `Exception` on this path today: `json.loads` on a truncated or partially written payload, `session_db.append_message` rejecting a row (e.g. `CompressionSessionClosedError` for a session that compression closed between the spool write and the replay), and `path.unlink` raising `OSError`.

This restores the ordinary-error handler by putting it above the `BaseException` handler, and adds a comment at the site so the ordering is not lost again.

**This completes the intent of #83226 rather than reverting it.** That commit's goal was that an owned `SessionDB` never leaks on an exception path, and that guarantee is untouched here: the `BaseException` handler still closes the owned DB and re-raises, byte for byte. Its regression test `test_recover_closes_owned_db_when_unexpected_exception_escapes` raises `KeyboardInterrupt` — a `BaseException` that is *not* an `Exception` — and stays green under this change. The semantic widening to ordinary exceptions was collateral to an FD-leak fix, not its purpose.

### Sibling-site sweep

I ran an AST sweep over every `.py` file on `main` for any `try` whose handler list places a `BaseException` or bare handler *above* a later handler. It returns **exactly one** hit repo-wide: `gateway/shutdown_flush.py:400`. There is no sibling site to widen to — this PR is the complete fix for the root cause.

## Related Issue

Regression from #83226 (commit `39e480c051e`, *"fix(state): close leaked SessionDB connections on exception paths"*, landed on `main` 2026-08-14). `git show 39e480c051e~1:gateway/shutdown_flush.py` has only the `except Exception as exc:` handler; that commit inserted the `BaseException` block above it. No separate issue is filed for this.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/shutdown_flush.py` — in `recover_pending_to_db()`, move `except Exception as exc:` above `except BaseException:` so the ordinary-error branch is reachable again, and document at the site why the order matters. The `BaseException` body is unchanged.
- `tests/gateway/test_shutdown_flush.py` — three regression tests, placed beside the existing #83226 test so the contrast is visible in one screen:
  - `test_recover_skips_failing_payload_and_continues` — an `append_message` failure on one file skips only that file; the good file is recovered and unlinked, the bad one is preserved.
  - `test_recover_survives_unparseable_payload` — a corrupt payload fails at `json.loads`, before any DB work, and is preserved while the valid file beside it still recovers.
  - `test_recover_closes_owned_db_when_interrupt_follows_tolerated_error` — the interrupt contract still holds on a pass that already tolerated an ordinary error: the owned `SessionDB` is closed and the `KeyboardInterrupt` propagates.

Four commits: the fix, then one commit per regression test.

## How to Test

1. Run the suite for this module:
   ```
   pytest tests/gateway/test_shutdown_flush.py -v
   ```
   9 passed, including the pre-existing `test_recover_closes_owned_db_when_unexpected_exception_escapes`.

2. Confirm the three new tests are genuine regression tests — revert only the production hunk and re-run:
   ```
   git checkout origin/main -- gateway/shutdown_flush.py
   pytest tests/gateway/test_shutdown_flush.py -v
   ```
   ```
   FAILED test_recover_skips_failing_payload_and_continues
   FAILED test_recover_survives_unparseable_payload
   FAILED test_recover_closes_owned_db_when_interrupt_follows_tolerated_error
   3 failed, 6 passed
   ```
   The 6 pre-existing tests stay green in both directions; the 3 new ones fail before the fix and pass after.

3. Adjacent gateway flush/spool/shutdown suites (23 files) — `131 passed`. The one failure in that set, `test_shutdown_forensics.py::TestSpawnAsyncDiagnostic::test_spawns_subprocess_and_writes_output`, reproduces identically on clean `origin/main` with none of these changes applied; that file does not reference `shutdown_flush`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass <!-- ran the module suite + 23 adjacent gateway flush/spool/shutdown files, not the full suite -->
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 25.4), Python 3.11.15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A <!-- N/A: the module docstring's "deletes the flush file on success" contract is what this restores, no wording change needed -->
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A <!-- handler ordering is platform-independent; no OS-specific code touched -->
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Related / Positioning

I checked both duplicate nets before filing and neither shows an overlap:

- **By-file** (`gh pr list --json files`, newest 300 open PRs, #87079–#87659): no other open PR touches `gateway/shutdown_flush.py` in that window.
- **By-symbol, corpus-wide** (`gh search prs`): `recover_pending_to_db` → #75536, #84785; `shutdown_flush` → #84785; `BaseException` → 20 hits, none in this file.

Reading the added lines of each open PR that does touch this file confirms none of them touches these handlers:

- **#75536** (@spfcraze) adds a `session_resolver` parameter for `session_key` → `session_id` resolution.
- **#87030** (@ZHJay) changes `_get_flush_dir` only (managed-mode directory permissions).
- **#86409** (@kshitijk4poor) adds `_append_with_compression_adoption` and swaps two `append_message` call sites. That one is complementary to this PR and worth reading together: it removes a specific recurring `CompressionSessionClosedError` producer, while this PR makes *any* ordinary failure on this path non-fatal to the rest of the pass. Neither subsumes the other and they do not overlap textually.
- **#84785** (mine) touches this file ~40 lines above, in the spool replay ordering/fidelity path; its hunks end well before this handler block and it never references `BaseException` or `_close_owned_db`. Kept deliberately hunk-disjoint so the two can land in either order.

One note on approach: the tidier shape here would be to wrap the loop in `try: ... finally: _close_owned_db()`, which is closer to the wording of #83226's own commit body. I did not do that, because it re-indents the entire ~85-line loop body and would collide with the open #84785 above. The handler reorder is the whole behavioural fix on its own; the `finally` restructure is a readability change that is better made once, later, when nothing else is in flight over this function.
