### PR TITLE
feat(sessions): archive stale open sessions during prune

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -12989,6 +12989,14 @@ def main():
         help="Also delete archived sessions (excluded by default)",
     )
     sessions_prune.add_argument(
+        "--include-live",
+        action="store_true",
+        help=(
+            "Archive matching open sessions instead of skipping them; "
+            "ended sessions are still permanently deleted"
+        ),
+    )
+    sessions_prune.add_argument(
         "--never-active",
         action="store_true",
         help=(

--- a/hermes_cli/sessions_cmd.py
+++ b/hermes_cli/sessions_cmd.py
@@ -942,13 +942,18 @@ def cmd_sessions(args, sessions_parser=None):
             filters["archived"] = False
 
         candidates = db.list_prune_candidates(**filters)
+        include_live = action == "prune" and getattr(args, "include_live", False)
         # Archive expands each selected row to its compression lineage, which
         # can include open continuations; a direct-open count would therefore
         # describe the eventual archive effect inaccurately.
         skipped_open = (
-            db.count_open_prune_matches(**filters) if action == "prune" else 0
+            db.count_open_prune_matches(
+                **({**filters, "archived": False} if include_live else filters)
+            )
+            if action == "prune"
+            else 0
         )
-        if skipped_open:
+        if skipped_open and not include_live:
             suffix = "" if skipped_open == 1 else "s"
             print(
                 f"Note: {skipped_open} open session{suffix} also match these "
@@ -956,20 +961,29 @@ def cmd_sessions(args, sessions_parser=None):
                 "sessions. Use `hermes sessions delete <id>` "
                 "to remove one explicitly."
             )
+        elif skipped_open:
+            suffix = "" if skipped_open == 1 else "s"
+            print(
+                f"Note: {skipped_open} matching open session{suffix} will be "
+                "archived, not deleted, so the operation remains reversible."
+            )
         verb = "Delete" if action == "prune" else "Archive"
-        if not candidates:
+        if not candidates and not (include_live and skipped_open):
             print(f"No sessions match ({describe_filters(filters)}).")
             return
 
         # Candidates are ordered by activity oldest-first. Surface that
         # span so a long-lived but recently used conversation cannot look
         # old merely because of its creation date.
-        _oldest = candidates[0].get("last_active")
-        _newest = candidates[-1].get("last_active")
-        _span = (
-            f"oldest activity {format_epoch(_oldest)}, "
-            f"newest activity {format_epoch(_newest)}"
-        )
+        if candidates:
+            _oldest = candidates[0].get("last_active")
+            _newest = candidates[-1].get("last_active")
+            _span = (
+                f"oldest activity {format_epoch(_oldest)}, "
+                f"newest activity {format_epoch(_newest)}"
+            )
+        else:
+            _span = "no ended sessions"
 
         if args.dry_run or not args.yes:
             shown = candidates if args.dry_run else candidates[:15]
@@ -988,12 +1002,24 @@ def cmd_sessions(args, sessions_parser=None):
             if len(candidates) > len(shown):
                 print(f"  … and {len(candidates) - len(shown)} more")
             if args.dry_run:
-                print(f"Dry run — nothing {'deleted' if action == 'prune' else 'archived'}.")
+                if include_live:
+                    print(
+                        f"Dry run — would delete {len(candidates)} ended session(s) "
+                        f"and archive {skipped_open} open session(s)."
+                    )
+                else:
+                    print(f"Dry run — nothing {'deleted' if action == 'prune' else 'archived'}.")
                 return
 
         if not args.yes:
+            prompt = f"{verb} these {len(candidates)} session(s) ({_span})? [y/N] "
+            if include_live:
+                prompt = (
+                    f"Delete {len(candidates)} ended session(s) and archive "
+                    f"{skipped_open} open session(s)? [y/N] "
+                )
             if not _confirm_prompt(
-                f"{verb} these {len(candidates)} session(s) ({_span})? [y/N] "
+                prompt
             ):
                 print("Cancelled.")
                 return
@@ -1001,7 +1027,14 @@ def cmd_sessions(args, sessions_parser=None):
         if action == "prune":
             sessions_dir = get_hermes_home() / "sessions"
             count = db.prune_sessions(sessions_dir=sessions_dir, **filters)
-            print(f"Pruned {count} session(s).")
+            if include_live:
+                archived = db.archive_open_prune_matches(**filters)
+                print(
+                    f"Pruned {count} ended session(s); archived {archived} "
+                    "open session(s)."
+                )
+            else:
+                print(f"Pruned {count} session(s).")
         else:
             count = db.archive_sessions(**filters)
             print(

--- a/hermes_cli/sessions_cmd.py
+++ b/hermes_cli/sessions_cmd.py
@@ -878,6 +878,13 @@ def cmd_sessions(args, sessions_parser=None):
         else:
             print(f"Session '{args.session_id}' not found.")
 
+    elif (
+        action == "prune"
+        and getattr(args, "never_active", False)
+        and getattr(args, "include_live", False)
+    ):
+        print("Error: --include-live cannot be combined with --never-active.")
+
     elif action == "prune" and getattr(args, "never_active", False):
         # Separate branch on purpose: the shared prune/archive selector is
         # pinned to `ended_at IS NOT NULL`, so never-closed rows sit outside

--- a/hermes_cli/sessions_cmd.py
+++ b/hermes_cli/sessions_cmd.py
@@ -950,13 +950,14 @@ def cmd_sessions(args, sessions_parser=None):
 
         candidates = db.list_prune_candidates(**filters)
         include_live = action == "prune" and getattr(args, "include_live", False)
+        archive_filters = (
+            {**filters, "archived": False} if include_live else filters
+        )
         # Archive expands each selected row to its compression lineage, which
         # can include open continuations; a direct-open count would therefore
         # describe the eventual archive effect inaccurately.
         skipped_open = (
-            db.count_open_prune_matches(
-                **({**filters, "archived": False} if include_live else filters)
-            )
+            db.count_open_prune_matches(**archive_filters)
             if action == "prune"
             else 0
         )
@@ -1035,7 +1036,7 @@ def cmd_sessions(args, sessions_parser=None):
             sessions_dir = get_hermes_home() / "sessions"
             count = db.prune_sessions(sessions_dir=sessions_dir, **filters)
             if include_live:
-                archived = db.archive_open_prune_matches(**filters)
+                archived = db.archive_open_prune_matches(**archive_filters)
                 print(
                     f"Pruned {count} ended session(s); archived {archived} "
                     "open session(s)."

--- a/hermes_cli/web_models.py
+++ b/hermes_cli/web_models.py
@@ -369,6 +369,7 @@ class SessionPrune(BaseModel):
     min_tool_calls: Optional[int] = None
     max_tool_calls: Optional[int] = None
     include_archived: bool = False
+    include_live: bool = False
     dry_run: bool = False
 
 

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -11876,9 +11876,10 @@ def _prune_sessions(body: SessionPrune):
             max_tool_calls=body.max_tool_calls,
             archived=None if body.include_archived else False,
         )
-        open_matches = db.count_open_prune_matches(
-            **({**filters, "archived": False} if body.include_live else filters)
+        archive_filters = (
+            {**filters, "archived": False} if body.include_live else filters
         )
+        open_matches = db.count_open_prune_matches(**archive_filters)
         if body.dry_run:
             rows = db.list_prune_candidates(**filters)
             result = {
@@ -11923,7 +11924,7 @@ def _prune_sessions(body: SessionPrune):
             "skipped_open": 0 if body.include_live else open_matches,
         }
         if body.include_live:
-            result["archived"] = db.archive_open_prune_matches(**filters)
+            result["archived"] = db.archive_open_prune_matches(**archive_filters)
         return result
     finally:
         db.close()

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -11876,14 +11876,17 @@ def _prune_sessions(body: SessionPrune):
             max_tool_calls=body.max_tool_calls,
             archived=None if body.include_archived else False,
         )
-        skipped_open = db.count_open_prune_matches(**filters)
+        open_matches = db.count_open_prune_matches(
+            **({**filters, "archived": False} if body.include_live else filters)
+        )
         if body.dry_run:
             rows = db.list_prune_candidates(**filters)
-            return {
+            result = {
                 "ok": True,
                 "removed": 0,
                 "matched": len(rows),
-                "skipped_open": skipped_open,
+                "matched_open": open_matches,
+                "skipped_open": 0 if body.include_live else open_matches,
                 # Rows are ordered by last activity, not creation time.
                 "oldest_last_active": rows[0]["last_active"] if rows else None,
                 "newest_last_active": rows[-1]["last_active"] if rows else None,
@@ -11906,12 +11909,22 @@ def _prune_sessions(body: SessionPrune):
                     for r in rows
                 ],
             }
+            if body.include_live:
+                result["archived"] = 0
+            return result
         sessions_dir = profile_home / "sessions"
         removed = db.prune_sessions(
             sessions_dir=sessions_dir if sessions_dir.exists() else None,
             **filters,
         )
-        return {"ok": True, "removed": removed, "skipped_open": skipped_open}
+        result = {
+            "ok": True,
+            "removed": removed,
+            "skipped_open": 0 if body.include_live else open_matches,
+        }
+        if body.include_live:
+            result["archived"] = db.archive_open_prune_matches(**filters)
+        return result
     finally:
         db.close()
 

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -11816,21 +11816,60 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
 
         This is deliberately separate from :meth:`prune_sessions`: destructive
         pruning must retain its ended-session guard. Only unarchived rows are
-        selected, and each match is archived through ``set_session_archived`` so
-        compression lineages remain hidden and recoverable as a unit.
+        selected, and every match's compression lineage is archived atomically
+        so the conversation remains hidden and recoverable as a unit.
         """
         filters["archived"] = False
         open_where, params = self._open_prune_filter_where(
             older_than_days, source, filters
         )
-        with self._lock:
-            cursor = self._conn.execute(
-                f"SELECT s.id FROM sessions s WHERE {open_where}", params
+
+        def _do(conn):
+            matched = int(
+                conn.execute(
+                    f"SELECT COUNT(*) FROM sessions s WHERE {open_where}", params
+                ).fetchone()[0]
             )
-            session_ids = [row["id"] for row in cursor.fetchall()]
-        for session_id in session_ids:
-            self.set_session_archived(session_id, True)
-        return len(session_ids)
+            if not matched:
+                return 0
+            conn.execute(
+                f"""
+                WITH RECURSIVE
+                  matches(id) AS (
+                    SELECT s.id FROM sessions s WHERE {open_where}
+                  ),
+                  ancestors(id) AS (
+                    SELECT id FROM matches
+                    UNION
+                    SELECT parent.id
+                    FROM ancestors a
+                    JOIN sessions child ON child.id = a.id
+                    JOIN sessions parent ON parent.id = child.parent_session_id
+                    WHERE parent.end_reason = 'compression'
+                  ),
+                  descendants(id) AS (
+                    SELECT id FROM matches
+                    UNION
+                    SELECT child.id
+                    FROM descendants d
+                    JOIN sessions parent ON parent.id = d.id
+                    JOIN sessions child ON child.parent_session_id = parent.id
+                    WHERE parent.end_reason = 'compression'
+                  ),
+                  lineage(id) AS (
+                    SELECT id FROM ancestors
+                    UNION
+                    SELECT id FROM descendants
+                  )
+                UPDATE sessions
+                SET archived = 1
+                WHERE id IN (SELECT id FROM lineage)
+                """,
+                params,
+            )
+            return matched
+
+        return self._execute_write(_do)
 
     def archive_sessions(
         self,

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -11783,17 +11783,54 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         why an otherwise matching session was skipped without making live
         sessions eligible for destructive pruning.
         """
-        self._apply_prune_age_filter(older_than_days, filters)
-        where, params = self._prune_filter_where(source=source, **filters)
-        ended_guard = "s.ended_at IS NOT NULL"
-        if not where.startswith(ended_guard):
-            raise RuntimeError("prune filter lost its ended-session safety guard")
-        open_where = f"s.ended_at IS NULL{where[len(ended_guard):]}"
+        open_where, params = self._open_prune_filter_where(
+            older_than_days, source, filters
+        )
         with self._lock:
             cursor = self._conn.execute(
                 f"SELECT COUNT(*) FROM sessions s WHERE {open_where}", params
             )
             return int(cursor.fetchone()[0])
+
+    def _open_prune_filter_where(
+        self,
+        older_than_days: Optional[float],
+        source: Optional[str],
+        filters: Dict[str, Any],
+    ) -> Tuple[str, List[Any]]:
+        """Build the prune filter with only its ended-session guard inverted."""
+        self._apply_prune_age_filter(older_than_days, filters)
+        where, params = self._prune_filter_where(source=source, **filters)
+        ended_guard = "s.ended_at IS NOT NULL"
+        if not where.startswith(ended_guard):
+            raise RuntimeError("prune filter lost its ended-session safety guard")
+        return f"s.ended_at IS NULL{where[len(ended_guard):]}", params
+
+    def archive_open_prune_matches(
+        self,
+        older_than_days: Optional[float] = None,
+        source: str = None,
+        **filters,
+    ) -> int:
+        """Archive unended sessions matching the otherwise-destructive prune filters.
+
+        This is deliberately separate from :meth:`prune_sessions`: destructive
+        pruning must retain its ended-session guard. Only unarchived rows are
+        selected, and each match is archived through ``set_session_archived`` so
+        compression lineages remain hidden and recoverable as a unit.
+        """
+        filters["archived"] = False
+        open_where, params = self._open_prune_filter_where(
+            older_than_days, source, filters
+        )
+        with self._lock:
+            cursor = self._conn.execute(
+                f"SELECT s.id FROM sessions s WHERE {open_where}", params
+            )
+            session_ids = [row["id"] for row in cursor.fetchall()]
+        for session_id in session_ids:
+            self.set_session_archived(session_id, True)
+        return len(session_ids)
 
     def archive_sessions(
         self,

--- a/tests/hermes_cli/test_dashboard_admin_endpoints.py
+++ b/tests/hermes_cli/test_dashboard_admin_endpoints.py
@@ -610,6 +610,35 @@ class TestSessionManagementEndpoints:
         assert db.get_session("include-live-open")["archived"] == 1
         db.close()
 
+    def test_prune_include_live_dry_run_reports_matches_without_archiving(self):
+        from hermes_state import SessionDB
+
+        db = SessionDB()
+        db.create_session(session_id="include-live-dry-run", source="dry-run-test")
+        db._conn.execute(
+            "UPDATE sessions SET started_at = ? WHERE id = ?",
+            (1.0, "include-live-dry-run"),
+        )
+        db._conn.commit()
+        db.close()
+
+        r = self.client.post(
+            "/api/sessions/prune",
+            json={
+                "older_than_days": 1,
+                "source": "dry-run-test",
+                "include_live": True,
+                "dry_run": True,
+            },
+        )
+
+        assert r.status_code == 200
+        assert r.json()["matched_open"] == 1
+        assert r.json()["archived"] == 0
+        db = SessionDB()
+        assert db.get_session("include-live-dry-run")["archived"] == 0
+        db.close()
+
 
 
 class TestSkillsHubSearchEndpoint:

--- a/tests/hermes_cli/test_dashboard_admin_endpoints.py
+++ b/tests/hermes_cli/test_dashboard_admin_endpoints.py
@@ -575,6 +575,41 @@ class TestSessionManagementEndpoints:
         assert db.get_session("sess-old-open") is not None
         db.close()
 
+    def test_prune_include_live_archives_open_and_deletes_ended_sessions(self):
+        from hermes_state import SessionDB
+
+        db = SessionDB()
+        db.create_session(session_id="include-live-open", source="include-live-test")
+        db.create_session(session_id="include-live-ended", source="include-live-test")
+        db.end_session("include-live-ended", "completed")
+        db._conn.execute(
+            "UPDATE sessions SET started_at = ? WHERE id IN (?, ?)",
+            (1.0, "include-live-open", "include-live-ended"),
+        )
+        db._conn.commit()
+        db.close()
+
+        r = self.client.post(
+            "/api/sessions/prune",
+            json={
+                "older_than_days": 1,
+                "source": "include-live-test",
+                "include_live": True,
+            },
+        )
+
+        assert r.status_code == 200
+        assert r.json() == {
+            "ok": True,
+            "removed": 1,
+            "archived": 1,
+            "skipped_open": 0,
+        }
+        db = SessionDB()
+        assert db.get_session("include-live-ended") is None
+        assert db.get_session("include-live-open")["archived"] == 1
+        db.close()
+
 
 
 class TestSkillsHubSearchEndpoint:

--- a/tests/hermes_cli/test_sessions_delete.py
+++ b/tests/hermes_cli/test_sessions_delete.py
@@ -39,7 +39,14 @@ def test_sessions_delete_accepts_unique_id_prefix(monkeypatch, capsys):
     assert "Deleted session '20260315_092437_c9a6ff'." in output
 
 
-def _run_prune(monkeypatch, capsys, argv_tail, candidates=None, skipped_open=0):
+def _run_prune(
+    monkeypatch,
+    capsys,
+    argv_tail,
+    candidates=None,
+    skipped_open=0,
+    allow_distinct_open_filters=False,
+):
     """Run `hermes sessions prune <argv_tail>` against a FakeDB, capturing
     the filter kwargs passed to list_prune_candidates. Auto-confirms."""
     import hermes_cli.main as main_mod
@@ -75,7 +82,10 @@ def _run_prune(monkeypatch, capsys, argv_tail, candidates=None, skipped_open=0):
             return rows
 
         def count_open_prune_matches(self, **kwargs):
-            assert kwargs == seen
+            if allow_distinct_open_filters:
+                seen["open_match_filters"] = kwargs
+            else:
+                assert kwargs == seen
             return skipped_open
 
         def prune_sessions(self, **kwargs):
@@ -160,6 +170,23 @@ def test_sessions_prune_include_live_runs_when_only_open_sessions_match(monkeypa
     assert archived_filters == filters
     assert "Pruned 0 ended session(s); archived 2 open session(s)." in out
     assert "No sessions match" not in out
+
+
+def test_sessions_prune_include_live_ignores_already_archived_open_sessions(
+    monkeypatch, capsys
+):
+    filters, _out = _run_prune(
+        monkeypatch,
+        capsys,
+        ["--include-archived", "--include-live", "--yes"],
+        skipped_open=2,
+        allow_distinct_open_filters=True,
+    )
+
+    archived_filters = filters.pop("archived_open_with")
+    open_match_filters = filters.pop("open_match_filters")
+    assert filters["archived"] is None
+    assert open_match_filters == archived_filters == {**filters, "archived": False}
 
 
 def test_sessions_prune_rejects_include_live_with_never_active(monkeypatch, capsys):

--- a/tests/hermes_cli/test_sessions_delete.py
+++ b/tests/hermes_cli/test_sessions_delete.py
@@ -81,6 +81,10 @@ def _run_prune(monkeypatch, capsys, argv_tail, candidates=None, skipped_open=0):
         def prune_sessions(self, **kwargs):
             return len(rows)
 
+        def archive_open_prune_matches(self, **kwargs):
+            seen["archived_open_with"] = kwargs
+            return skipped_open
+
         def close(self):
             pass
 
@@ -127,3 +131,32 @@ def test_sessions_prune_surfaces_matching_open_sessions(monkeypatch, capsys):
     assert "prune only deletes ended sessions" in out
     assert "hermes sessions delete <id>" in out
     assert "No sessions match" in out
+
+
+def test_sessions_prune_include_live_archives_matching_open_sessions(monkeypatch, capsys):
+    filters, out = _run_prune(
+        monkeypatch,
+        capsys,
+        ["--source", "cron", "--include-live", "--yes"],
+        skipped_open=2,
+    )
+
+    archived_filters = filters.pop("archived_open_with")
+    assert archived_filters == filters
+    assert "Pruned 2 ended session(s); archived 2 open session(s)." in out
+    assert "will be skipped" not in out
+
+
+def test_sessions_prune_include_live_runs_when_only_open_sessions_match(monkeypatch, capsys):
+    filters, out = _run_prune(
+        monkeypatch,
+        capsys,
+        ["--source", "cron", "--include-live", "--yes"],
+        candidates=[],
+        skipped_open=2,
+    )
+
+    archived_filters = filters.pop("archived_open_with")
+    assert archived_filters == filters
+    assert "Pruned 0 ended session(s); archived 2 open session(s)." in out
+    assert "No sessions match" not in out

--- a/tests/hermes_cli/test_sessions_delete.py
+++ b/tests/hermes_cli/test_sessions_delete.py
@@ -160,3 +160,41 @@ def test_sessions_prune_include_live_runs_when_only_open_sessions_match(monkeypa
     assert archived_filters == filters
     assert "Pruned 0 ended session(s); archived 2 open session(s)." in out
     assert "No sessions match" not in out
+
+
+def test_sessions_prune_rejects_include_live_with_never_active(monkeypatch, capsys):
+    import hermes_cli.main as main_mod
+    import hermes_state
+
+    called = False
+
+    class FakeDB:
+        def prune_never_active_keyed_sessions(self, **kwargs):
+            nonlocal called
+            called = True
+            return 1, 0
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr(hermes_state, "SessionDB", lambda: FakeDB())
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "hermes",
+            "sessions",
+            "prune",
+            "--never-active",
+            "--include-live",
+            "--yes",
+        ],
+    )
+
+    main_mod.main()
+
+    assert not called
+    assert (
+        "Error: --include-live cannot be combined with --never-active."
+        in capsys.readouterr().out
+    )

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -1175,6 +1175,41 @@ class TestPruneSessions:
         assert db.get_session("other-source")["archived"] == 0
         assert db.get_session("ended")["archived"] == 0
 
+    def test_archive_open_prune_matches_rolls_back_the_batch_on_failure(self, db):
+        db.create_session(session_id="first", source="cron")
+        db.create_session(session_id="second", source="cron")
+        old = time.time() - 200 * 86400
+        db._conn.execute(
+            "UPDATE sessions SET started_at = ? WHERE id IN (?, ?)",
+            (old, "first", "second"),
+        )
+        calls = 0
+
+        def fail_second_archive():
+            nonlocal calls
+            calls += 1
+            if calls == 2:
+                raise RuntimeError("forced archive failure")
+
+        db._conn.create_function("fail_second_archive", 0, fail_second_archive)
+        db._conn.execute(
+            """
+            CREATE TRIGGER fail_archive_batch
+            BEFORE UPDATE OF archived ON sessions
+            WHEN NEW.archived = 1
+            BEGIN
+                SELECT fail_second_archive();
+            END
+            """
+        )
+        db._conn.commit()
+
+        with pytest.raises(sqlite3.OperationalError):
+            db.archive_open_prune_matches(older_than_days=90, source="cron")
+
+        assert db.get_session("first")["archived"] == 0
+        assert db.get_session("second")["archived"] == 0
+
 
 
 

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -1154,6 +1154,27 @@ class TestPruneSessions:
             older_than_days=90, source="cron", archived=False
         )} == {"ended"}
 
+    def test_archive_open_prune_matches_preserves_ended_sessions(self, db):
+        db.create_session(session_id="matching-open", source="cron")
+        db.create_session(session_id="other-source", source="cli")
+        db.create_session(session_id="ended", source="cron")
+        db.end_session("ended", "completed")
+        old = time.time() - 200 * 86400
+        db._conn.execute(
+            "UPDATE sessions SET started_at = ? WHERE id IN (?, ?, ?)",
+            (old, "matching-open", "other-source", "ended"),
+        )
+        db._conn.commit()
+
+        archived = db.archive_open_prune_matches(
+            older_than_days=90, source="cron"
+        )
+
+        assert archived == 1
+        assert db.get_session("matching-open")["archived"] == 1
+        assert db.get_session("other-source")["archived"] == 0
+        assert db.get_session("ended")["archived"] == 0
+
 
 
 

--- a/web/src/lib/api.test.ts
+++ b/web/src/lib/api.test.ts
@@ -118,6 +118,33 @@ describe("api.getModelOptions", () => {
   });
 });
 
+describe("api.pruneSessions", () => {
+  it("passes the include-live archive option to the session API", async () => {
+    const fetchMock = jsonFetchMock({
+      ok: true,
+      removed: 1,
+      archived: 2,
+      skipped_open: 0,
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await api.pruneSessions(30, undefined, undefined, true);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/sessions/prune",
+      expect.objectContaining({
+        body: JSON.stringify({
+          older_than_days: 30,
+          source: undefined,
+          profile: undefined,
+          include_live: true,
+        }),
+        method: "POST",
+      }),
+    );
+  });
+});
+
 describe("api OAuth helpers", () => {
   it("starts OAuth login in gated mode without requiring an injected session token", async () => {
     vi.stubGlobal("window", { __HERMES_AUTH_REQUIRED__: true });

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -451,8 +451,14 @@ export const api = {
     older_than_days: number,
     source?: string,
     profile = getManagementProfile(),
+    include_live = false,
   ) =>
-    fetchJSON<{ ok: boolean; removed: number; skipped_open: number }>(
+    fetchJSON<{
+      ok: boolean;
+      removed: number;
+      archived?: number;
+      skipped_open: number;
+    }>(
       "/api/sessions/prune",
       {
         method: "POST",
@@ -461,6 +467,7 @@ export const api = {
           older_than_days,
           source,
           profile: profile || undefined,
+          include_live,
         }),
       },
     ),

--- a/web/src/lib/session-prune.test.ts
+++ b/web/src/lib/session-prune.test.ts
@@ -12,4 +12,16 @@ describe('formatSessionPruneResult', () => {
   it('keeps the existing success message when nothing was skipped', () => {
     expect(formatSessionPruneResult({ removed: 1, skipped_open: 0 })).toBe('Pruned 1 session')
   })
+
+  it('reports archived open sessions separately from deleted ended sessions', () => {
+    expect(formatSessionPruneResult({ removed: 2, archived: 3, skipped_open: 0 })).toBe(
+      'Pruned 2 ended sessions; archived 3 open sessions'
+    )
+  })
+
+  it('keeps the separate archive count when no open sessions matched', () => {
+    expect(formatSessionPruneResult({ removed: 1, archived: 0, skipped_open: 0 })).toBe(
+      'Pruned 1 ended session; archived 0 open sessions'
+    )
+  })
 })

--- a/web/src/lib/session-prune.ts
+++ b/web/src/lib/session-prune.ts
@@ -1,9 +1,13 @@
 interface SessionPruneResult {
   removed: number
+  archived?: number
   skipped_open: number
 }
 
 export function formatSessionPruneResult(result: SessionPruneResult): string {
+  if (result.archived !== undefined) {
+    return `Pruned ${result.removed} ended session${result.removed === 1 ? '' : 's'}; archived ${result.archived} open session${result.archived === 1 ? '' : 's'}`
+  }
   const removed = `Pruned ${result.removed} session${result.removed === 1 ? '' : 's'}`
   if (!result.skipped_open) return removed
 

--- a/web/src/pages/SessionsPage.tsx
+++ b/web/src/pages/SessionsPage.tsx
@@ -867,6 +867,7 @@ export default function SessionsPage() {
   const [stats, setStats] = useState<SessionStoreStats | null>(null);
   const [pruneOpen, setPruneOpen] = useState(false);
   const [pruneDays, setPruneDays] = useState("90");
+  const [pruneIncludeLive, setPruneIncludeLive] = useState(false);
   const [pruning, setPruning] = useState(false);
   const [importingSessions, setImportingSessions] = useState(false);
   const { toast, showToast } = useToast();
@@ -1499,7 +1500,12 @@ export default function SessionsPage() {
     }
     setPruning(true);
     try {
-      const resp = await api.pruneSessions(days);
+      const resp = await api.pruneSessions(
+        days,
+        undefined,
+        undefined,
+        pruneIncludeLive,
+      );
       showToast(formatSessionPruneResult(resp), "success");
       setPruneOpen(false);
       loadSessions(0);
@@ -1510,7 +1516,7 @@ export default function SessionsPage() {
     } finally {
       setPruning(false);
     }
-  }, [pruneDays, showToast, loadSessions, loadStats]);
+  }, [pruneDays, pruneIncludeLive, showToast, loadSessions, loadStats]);
 
   const pendingSession = sessionDelete.pendingId
     ? sessions.find((s) => s.id === sessionDelete.pendingId)
@@ -1633,8 +1639,9 @@ export default function SessionsPage() {
           <DialogHeader>
             <DialogTitle>Prune old sessions</DialogTitle>
             <DialogDescription>
-              Permanently remove archived sessions whose last activity is older
-              than the given number of days. Active sessions are never pruned.
+              Permanently remove ended sessions whose last activity is older than
+              the given number of days. Open sessions are skipped unless you
+              choose the reversible archive option below.
             </DialogDescription>
           </DialogHeader>
           <div className="flex flex-col gap-1.5">
@@ -1655,6 +1662,22 @@ export default function SessionsPage() {
               }}
               disabled={pruning}
             />
+            <div className="mt-2 flex items-start gap-2">
+              <Checkbox
+                checked={pruneIncludeLive}
+                id="prune-include-live"
+                onCheckedChange={(checked) =>
+                  setPruneIncludeLive(checked === true)
+                }
+                disabled={pruning}
+              />
+              <label
+                htmlFor="prune-include-live"
+                className="cursor-pointer text-xs text-muted-foreground"
+              >
+                Also archive matching open sessions (reversible)
+              </label>
+            </div>
           </div>
           <DialogFooter>
             <Button


### PR DESCRIPTION
## What does this PR do?

Adds an opt-in `--include-live` mode to session pruning so users can clean up stale open sessions without permanently deleting them. Matching ended sessions are still deleted, while matching open sessions are archived reversibly; the existing ended-only behavior remains the default.

### Motivation

The prune command intentionally protects open sessions, but that leaves long-idle open sessions in the active list with no bulk, reversible cleanup path. Users otherwise have to delete those sessions individually.

### Behavior

- `hermes sessions prune` keeps its current ended-session-only behavior.
- `hermes sessions prune --include-live` deletes matching ended sessions and archives matching open, unarchived sessions.
- Dry runs and completion output report deleted and archived counts separately.
- The dashboard prune confirmation exposes the same option and count breakdown.
- `--include-live` is rejected with `--never-active`, whose destructive mode cannot safely distinguish open sessions.

### Implementation

The shared session store now finds open prune matches with the same filters used for ended candidates and archives them through the lineage-aware archive path. CLI and dashboard request/response contracts expose the opt-in flag while preserving existing defaults. Focused Python and Vitest coverage exercises default pruning, live-session archival, dry-run/result reporting, API behavior, and the conflicting-mode guard.

## Related Issue

Closes #87638

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Changes Made

- `hermes_state.py` - select and reversibly archive open sessions matching prune filters.
- `hermes_cli/main.py` and `hermes_cli/sessions_cmd.py` - add `--include-live`, safety validation, preview output, and separate result counts.
- `hermes_cli/web_models.py` and `hermes_cli/web_server.py` - extend the dashboard prune API contract.
- `web/src/lib/api.ts`, `web/src/lib/session-prune.ts`, and `web/src/pages/SessionsPage.tsx` - expose the option and summarize deleted versus archived sessions.
- Focused Python and Vitest suites - cover the shared store, CLI, API, client contract, and dashboard summary behavior.

## How to Test

1. Create one ended session and one open session that match the same age/filter criteria.
2. Run `hermes sessions prune --include-live --dry-run` and verify separate delete/archive counts without changing either session.
3. Run the command with confirmation and verify the ended session is deleted while the open session appears in the archive and can be restored.
4. Run the focused automated suites:

```bash
scripts/run_tests.sh tests/test_hermes_state.py tests/hermes_cli/test_sessions_delete.py tests/hermes_cli/test_dashboard_admin_endpoints.py
cd web && npm test -- --run src/lib/api.test.ts src/lib/session-prune.test.ts
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repository test entry on the relevant tests and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Documentation updates are N/A because the CLI help and dashboard UI expose the option directly
- [x] `cli-config.yaml.example` is N/A because no configuration key changed
- [x] `CONTRIBUTING.md` and `AGENTS.md` are N/A because no architecture or workflow changed
- [x] I've considered cross-platform impact; the implementation uses shared Python, SQLite, and browser code without platform-specific behavior
- [x] Tool description/schema updates are N/A because no model tool changed
