### PR TITLE
fix(auxiliary): stop an availability probe from caching its client stub

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -7801,6 +7801,23 @@ def _get_cached_client(
         is_vision=is_vision,
         task=task,
     )
+    if isinstance(client, _AuxProbeClientStub):
+        # Probe stubs must never enter the cache, same rule _store_cached_client
+        # states at the other write path into ``_client_cache``. This inline
+        # block is the second writer and lost the guard, so an availability
+        # probe left its stub behind and every later hit on that key returned a
+        # non-functional client. The damage is not deferred to a runtime call
+        # either: the hit path runs _compat_model -> _is_openrouter_client,
+        # whose ``getattr(client, "_client", None)`` cannot absorb the stub's
+        # deliberate RuntimeError because a getattr default only swallows
+        # AttributeError. check_vision_requirements catches that and reports
+        # False, so vision_analyze and browser_vision vanished for the rest of
+        # the process after the first probe (#87654).
+        #
+        # Returning rather than calling _store_cached_client because the block
+        # below also owns FIFO eviction and closing a concurrently built loser,
+        # neither of which _store_cached_client does.
+        return client, model or default_model
     if client is not None:
         # For async clients, remember which loop they were created on so we
         # can detect stale entries later.

--- a/tests/tools/test_startup_latency_regressions.py
+++ b/tests/tools/test_startup_latency_regressions.py
@@ -11,9 +11,17 @@ These pin the CLI cold-start contract established in the sub-400ms pass:
 import sys
 import threading
 import time
+from types import SimpleNamespace
 from unittest.mock import patch
 
 import pytest
+
+
+def _drop_cached_provider(aux, provider: str) -> None:
+    """Remove every cache entry a test created, keyed by its unique provider."""
+    with aux._client_cache_lock:
+        for key in [k for k in aux._client_cache if k[0] == provider]:
+            del aux._client_cache[key]
 
 
 class TestAuxProbeMode:
@@ -33,6 +41,72 @@ class TestAuxProbeMode:
         aux._store_cached_client(key, stub, "m")
         with aux._client_cache_lock:
             assert key not in aux._client_cache
+
+    def test_probe_stub_never_cached_by_get_cached_client(self):
+        """The inline cache in _get_cached_client is the second writer into
+        ``_client_cache`` and must uphold the same rule (#87654)."""
+        import agent.auxiliary_client as aux
+
+        provider = "probe-test-87654-a"
+        try:
+            with patch.object(
+                aux,
+                "resolve_provider_client",
+                lambda *a, **k: (aux._AuxProbeClientStub(), "vendor/m"),
+            ):
+                with aux.aux_probe_mode():
+                    client, _model = aux._get_cached_client(provider, model="vendor/m")
+            assert isinstance(client, aux._AuxProbeClientStub)
+            with aux._client_cache_lock:
+                assert not any(k[0] == provider for k in aux._client_cache)
+        finally:
+            _drop_cached_provider(aux, provider)
+
+    def test_repeat_probe_is_stable_for_slash_bearing_models(self):
+        """A cached stub poisoned the next probe, so the answer flipped after
+        the first call and the vision tools disappeared (#87654).
+
+        Unpatched this raises RuntimeError on the second call: the cache hit
+        runs _compat_model -> _is_openrouter_client, whose
+        ``getattr(client, "_client", None)`` only absorbs AttributeError.
+        A slash-free model would mask it, so the model id matters here.
+        """
+        import agent.auxiliary_client as aux
+
+        provider = "probe-test-87654-b"
+        try:
+            with patch.object(
+                aux,
+                "resolve_provider_client",
+                lambda *a, **k: (aux._AuxProbeClientStub(), "vendor/m"),
+            ):
+                with aux.aux_probe_mode():
+                    seen = [
+                        aux._get_cached_client(provider, model="vendor/m")[0]
+                        for _ in range(3)
+                    ]
+            assert all(isinstance(c, aux._AuxProbeClientStub) for c in seen)
+        finally:
+            _drop_cached_provider(aux, provider)
+
+    def test_real_clients_are_still_cached(self):
+        """Guardrail: the stub bypass must not disable caching generally."""
+        import agent.auxiliary_client as aux
+
+        provider = "probe-test-87654-c"
+        real = SimpleNamespace(base_url="https://x.invalid/v1")
+        try:
+            with patch.object(
+                aux, "resolve_provider_client", lambda *a, **k: (real, "vendor/m")
+            ):
+                first, _ = aux._get_cached_client(provider, model="vendor/m")
+                second, _ = aux._get_cached_client(provider, model="vendor/m")
+            assert first is real
+            assert second is real
+            with aux._client_cache_lock:
+                assert any(k[0] == provider for k in aux._client_cache)
+        finally:
+            _drop_cached_provider(aux, provider)
 
     def test_probe_stub_raises_on_runtime_use(self):
         import agent.auxiliary_client as aux


### PR DESCRIPTION
## What does this PR do?

`_client_cache` in `agent/auxiliary_client.py` has two writers, and only one of them refuses to store an availability-probe stub.

`_store_cached_client` (L7446) opens with `if isinstance(client, _AuxProbeClientStub): return`, commented "Probe stubs must never enter the cache". The inline cache write inside `_get_cached_client` (L7819) is the second writer and has no such guard, so a tool-gating probe running under `aux_probe_mode()` left its `_AuxProbeClientStub` in the cache under its own key.

The next probe on that key hit the cache, and that path is not inert. Both cache-hit returns (L7767 async-loop-ok, L7778 sync) go through `_compat_model`, which for a slash-bearing model id calls `_is_openrouter_client`, which does:

```python
for obj in (client, getattr(client, "_client", None), getattr(client, "client", None)):
```

A `getattr` default only absorbs `AttributeError`, and the stub's `__getattr__` deliberately raises `RuntimeError` ("aux_probe_mode is for availability checks only"). So the exception propagated out to `check_vision_requirements`, which catches `Exception` and returns False.

The user-visible result in a long-running gateway is that `vision_analyze` and `browser_vision` answer True on the first probe and False on every probe after it, so the tools vanish from every session for the rest of the process lifetime while the dashboard still reports the toolset enabled. `check_browser_vision_requirements` shares the path. A model id without a `/` masks the bug entirely, because `_compat_model` only introspects the client when `model and "/" in model`.

**Why this fix.** Returning the stub uncached restores the invariant the codebase already states in two places, rather than adding a new one. It is deliberately not a call to `_store_cached_client`: the inline block also owns FIFO eviction and closing a concurrently built loser, neither of which `_store_cached_client` does, so delegating would change unrelated behaviour.

**What I did not change.** `_is_openrouter_client` could also be hardened to survive a raising `__getattr__`, but the stub raises loudly on purpose so that a leak into a runtime path is noisy rather than silent. Making it swallow `RuntimeError` would weaken that signal to fix a bug whose actual cause is the cache write, so I left it alone.

## Related Issue

Fixes #87654

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- **`agent/auxiliary_client.py`** — in `_get_cached_client`, return an `_AuxProbeClientStub` without caching it, mirroring the guard `_store_cached_client` already applies at the other write path. Comment records why it returns instead of delegating.
- **`tests/tools/test_startup_latency_regressions.py`** — three tests in `TestAuxProbeMode`, next to the existing `test_probe_stub_never_cached` which pins the same invariant on the other writer, plus a `_drop_cached_provider` helper so each test cleans up the entries it created.

## How to Test

1. Reproduce on `main`: the report's loop calls `check_vision_requirements()` five times in one process with `auxiliary.vision.provider: custom:<name>` and a model id containing `/`, and prints `True, False, False, False, False`. A repeatable probe must not flip.
2. Prove it at the unit level without any provider config:

   ```
   pytest tests/tools/test_startup_latency_regressions.py -q
   ```

   On `main` with only the test file applied, `test_probe_stub_never_cached_by_get_cached_client` and `test_repeat_probe_is_stable_for_slash_bearing_models` both fail with the exact reported error:

   ```
   RuntimeError: _AuxProbeClientStub used as a real client (attribute '_client');
   aux_probe_mode is for availability checks only
   agent\auxiliary_client.py:140: RuntimeError
   ```

   With the fix applied: `19 passed`.
3. Guardrail against over-correcting: `test_real_clients_are_still_cached` asserts a non-stub client is still stored and returned from the cache on the second call. It passes both with and without the fix, so it constrains the fix rather than restating it.
4. Wider run: `pytest tests/tools/test_startup_latency_regressions.py tests/tools/test_vision_tools.py tests/agent/test_vision_routing_31179.py -q` gives `60 passed`, plus one pre-existing failure, `test_vision_routing_31179.py::TestTextOnlyMainSkippedForVision::test_vision_capable_main_used`, which fails identically on a clean `upstream/main` checkout with no Nous credentials configured and is unrelated to this change.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11 (Python 3.12). The report is from Docker/Linux; the change is pure Python with no platform-dependent behaviour.

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A (the invariant is documented in-code at both write paths and in the stub's own docstring; the comment at the newly guarded site now states it too)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A (no config keys)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A (no paths, processes, or encodings involved; `scripts/check-windows-footguns.py --all` clean across 973 files)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A (tool availability is restored to its documented behaviour; no schema change)

## Screenshots / Logs

Before, from the report (one process, five identical calls):

```
1 True
2 False
3 False
4 False
5 False
```

Failure on `main` with only the tests applied:

```
FAILED tests/tools/test_startup_latency_regressions.py::TestAuxProbeMode::test_probe_stub_never_cached_by_get_cached_client
FAILED tests/tools/test_startup_latency_regressions.py::TestAuxProbeMode::test_repeat_probe_is_stable_for_slash_bearing_models
2 failed, 17 passed
```

With the fix:

```
19 passed in 2.74s
```

Note on formatting: `agent/auxiliary_client.py` and `tests/tools/test_startup_latency_regressions.py` are not `ruff format` compliant on `upstream/main` today. I measured 290 wanted hunks on a clean checkout and 290 with this change applied, so the added lines are format-clean and I deliberately did not reformat, to keep the diff limited to the fix.
