### PR TITLE
fix(tts): let MiniMax infer emotion unless one is configured

### DIFF
--- a/tests/tools/test_tts_minimax_emotion.py
+++ b/tests/tools/test_tts_minimax_emotion.py
@@ -1,0 +1,209 @@
+"""MiniMax TTS emotion payload tests.
+
+The t2a_v2 ``voice_setting`` previously always carried an ``emotion`` field,
+defaulting to ``"neutral"``. MiniMax documents that when the field is omitted
+the model "automatically selects the most natural emotion based on text", so
+the hardcoded default silently disabled that inference for every request and
+flattened delivery. ``_minimax_voice_setting`` now includes the field only
+when a config sets an explicit value; an empty value or ``"auto"`` also omits
+it, so a config can state the intent explicitly.
+
+The wire-payload tests drive the real ``_generate_minimax_tts`` with a
+capture-then-raise ``requests.post`` stub. On a tree without the fix the
+omission test fails on the payload assertion (``emotion: neutral`` present)
+rather than erroring at collection, while the explicit-value cases pass by
+design. The helper is looked up per test rather than imported
+at module top, so collection succeeds on an unfixed tree and the helper tests
+fail at runtime instead of blocking the whole file.
+"""
+
+import logging
+
+import pytest
+
+import requests
+
+from tools import tts_tool_providers as tts_tool
+from tools.tts_tool_providers import DEFAULT_MINIMAX_VOICE_ID, _generate_minimax_tts
+
+
+FAKE_CREDENTIAL = "FAKE_MINIMAX_CREDENTIAL"
+
+
+@pytest.fixture(autouse=True)
+def _fake_minimax_credentials(monkeypatch):
+    monkeypatch.setattr(
+        "tools.tts_tool.get_env_value",
+        lambda name, default=None: (
+            {"MINIMAX_API_KEY": FAKE_CREDENTIAL}.get(name, default)
+        ),
+    )
+
+
+class TestVoiceSetting:
+    def test_unset_emotion_is_omitted(self):
+        setting = tts_tool._minimax_voice_setting({"voice_id": "v1"})
+        assert "emotion" not in setting
+        assert setting["voice_id"] == "v1"
+
+    @pytest.mark.parametrize("value", ["", None, "auto", "  Auto "])
+    def test_empty_and_auto_omit(self, value):
+        assert "emotion" not in tts_tool._minimax_voice_setting({"emotion": value})
+
+    def test_explicit_emotion_is_sent_case_folded(self):
+        assert tts_tool._minimax_voice_setting({"emotion": "Happy"})["emotion"] == "happy"
+
+    def test_voice_knobs_pass_through(self):
+        setting = tts_tool._minimax_voice_setting(
+            {"voice_id": "v", "speed": 1.2, "vol": 0.8, "pitch": -2},
+        )
+        assert (setting["voice_id"], setting["speed"],
+                setting["vol"], setting["pitch"]) == ("v", 1.2, 0.8, -2)
+
+    def test_defaults_when_config_empty(self):
+        setting = tts_tool._minimax_voice_setting({})
+        assert setting["voice_id"] == DEFAULT_MINIMAX_VOICE_ID
+        assert setting["speed"] == 1.0
+        assert setting["vol"] == 1.0
+        assert setting["pitch"] == 0
+
+
+class _RequestCaptured(Exception):
+    """Raised by the stub once the outgoing payload has been recorded."""
+
+
+def _capture_post(captured):
+    def fake_post(url, json=None, **kwargs):
+        captured["url"] = url
+        captured["payload"] = json
+        raise _RequestCaptured()
+    return fake_post
+
+
+class TestWirePayload:
+    def test_payload_omits_emotion_when_unset(self, monkeypatch, tmp_path):
+        """The generator must not invent an emotion the config never set."""
+        captured = {}
+        monkeypatch.setattr(requests, "post", _capture_post(captured))
+
+        cfg = {"minimax": {"model": "speech-2.8-turbo", "voice_id": "v1"}}
+        with pytest.raises(_RequestCaptured):
+            _generate_minimax_tts("hello", str(tmp_path / "clip.mp3"), cfg)
+
+        voice_setting = captured["payload"]["voice_setting"]
+        assert "emotion" not in voice_setting
+        assert voice_setting["voice_id"] == "v1"
+
+    @pytest.mark.parametrize("configured", ["calm", "neutral"])
+    def test_payload_carries_configured_emotion(self, monkeypatch, tmp_path,
+                                                configured):
+        """Explicit values reach the wire unchanged.
+
+        "neutral" is pinned by name because it is the documented migration
+        path back to the pre-fix delivery; a future enum validator must not
+        be able to drop it while these tests stay green.
+        """
+        captured = {}
+        monkeypatch.setattr(requests, "post", _capture_post(captured))
+
+        cfg = {"minimax": {"model": "speech-2.8-turbo", "voice_id": "v1",
+                           "emotion": configured}}
+        with pytest.raises(_RequestCaptured):
+            _generate_minimax_tts("hello", str(tmp_path / "clip.mp3"), cfg)
+
+        assert captured["payload"]["voice_setting"]["emotion"] == configured
+
+
+class TestUnrecognizedEmotion:
+    """An emotion the API will not recognize must be visible in the logs.
+
+    Before this, a typo like "happpy" was folded to lowercase and posted
+    verbatim, so the only symptom was an opaque MiniMax API error with
+    nothing pointing at the config that caused it.
+
+    The value is still sent rather than dropped. MiniMax owns this enum and
+    can extend it, and silently discarding a value the operator wrote is the
+    same class of bug as the hardcoded "neutral" this PR removes: Hermes
+    overriding stated intent. A warning names the offending value, so the
+    failure diagnoses itself either way.
+    """
+
+    def test_unrecognized_value_warns_and_is_still_sent(self, caplog):
+        with caplog.at_level(logging.WARNING, logger="tools.tts_tool"):
+            setting = tts_tool._minimax_voice_setting({"emotion": "happpy"})
+
+        assert setting["emotion"] == "happpy"
+        warnings = [r.getMessage() for r in caplog.records
+                    if r.levelno == logging.WARNING]
+        assert len(warnings) == 1
+        assert "happpy" in warnings[0]
+        assert "tts.minimax.emotion" in warnings[0]
+
+    @pytest.mark.parametrize("value", [
+        "happy", "sad", "angry", "fearful", "disgusted", "surprised", "calm",
+        "neutral", "Happy", "  CALM  ",
+    ])
+    def test_recognized_values_do_not_warn(self, caplog, value):
+        """Includes "neutral": the documented way back to the old delivery."""
+        with caplog.at_level(logging.WARNING, logger="tools.tts_tool"):
+            setting = tts_tool._minimax_voice_setting({"emotion": value})
+
+        assert setting["emotion"] == value.strip().lower()
+        assert [r.getMessage() for r in caplog.records
+                if r.levelno == logging.WARNING] == []
+
+    @pytest.mark.parametrize("value", ["", None, "auto", "  Auto  "])
+    def test_deliberate_omission_does_not_warn(self, caplog, value):
+        """Omitting the field is the intended default, not a mistake."""
+        with caplog.at_level(logging.WARNING, logger="tools.tts_tool"):
+            setting = tts_tool._minimax_voice_setting({"emotion": value})
+
+        assert "emotion" not in setting
+        assert [r.getMessage() for r in caplog.records
+                if r.levelno == logging.WARNING] == []
+
+    def test_non_string_value_warns(self, caplog):
+        """A numeric emotion stringifies, so it needs the same warning."""
+        with caplog.at_level(logging.WARNING, logger="tools.tts_tool"):
+            setting = tts_tool._minimax_voice_setting({"emotion": 5})
+
+        assert setting["emotion"] == "5"
+        warnings = [r.getMessage() for r in caplog.records
+                    if r.levelno == logging.WARNING]
+        assert len(warnings) == 1
+        assert "5" in warnings[0]
+
+
+class TestFlatEndpointPayload:
+    """Regression guard for the legacy v1/text_to_speech payload.
+
+    That branch is the only consumer of the function local voice_id, and it
+    builds a flat payload with no voice_setting at all, so it is easy to read
+    the local as dead once the nested payload moved into a helper. Deleting it
+    raises NameError on the first request to a text_to_speech endpoint. These
+    tests fail loudly if that happens.
+    """
+
+    FLAT_URL = "https://api.minimax.io/v1/text_to_speech"
+
+    def _capture(self, monkeypatch, tmp_path, minimax_config):
+        captured = {}
+        monkeypatch.setattr(requests, "post", _capture_post(captured))
+        with pytest.raises(_RequestCaptured):
+            _generate_minimax_tts("hello", str(tmp_path / "clip.mp3"),
+                                  {"minimax": minimax_config})
+        return captured
+
+    def test_flat_payload_carries_configured_voice_id(self, monkeypatch, tmp_path):
+        captured = self._capture(monkeypatch, tmp_path,
+                                 {"base_url": self.FLAT_URL, "voice_id": "v1"})
+
+        assert captured["url"] == self.FLAT_URL
+        assert captured["payload"]["voice_id"] == "v1"
+        assert "voice_setting" not in captured["payload"]
+
+    def test_flat_payload_falls_back_to_default_voice_id(self, monkeypatch, tmp_path):
+        captured = self._capture(monkeypatch, tmp_path,
+                                 {"base_url": self.FLAT_URL})
+
+        assert captured["payload"]["voice_id"] == DEFAULT_MINIMAX_VOICE_ID

--- a/tools/tts_tool_providers.py
+++ b/tools/tts_tool_providers.py
@@ -33,6 +33,20 @@ DEFAULT_MINIMAX_MODEL = "speech-02-hd"
 DEFAULT_MINIMAX_VOICE_ID = "English_expressive_narrator"
 DEFAULT_MINIMAX_BASE_URL = "https://api.minimax.io/v1/t2a_v2"
 DEFAULT_MINIMAX_CN_BASE_URL = "https://api.minimaxi.com/v1/t2a_v2"
+# Emotions MiniMax documents for the t2a_v2 voice_setting. "neutral" is not in
+# the published list but the API accepts it, and Hermes sent it on every request
+# until the hardcoded default was removed, so it stays recognized here: it is
+# the documented way back to the old flat delivery.
+MINIMAX_EMOTIONS = frozenset({
+    "happy",
+    "sad",
+    "angry",
+    "fearful",
+    "disgusted",
+    "surprised",
+    "calm",
+    "neutral",
+})
 DEFAULT_MISTRAL_TTS_MODEL = "voxtral-mini-tts-2603"
 DEFAULT_MISTRAL_TTS_VOICE_ID = "c69964a6-ab8b-4f8a-9465-ec0925096ec8"  # Paul - Neutral
 DEFAULT_XAI_VOICE_ID = "eve"
@@ -389,13 +403,54 @@ def _raise_minimax_api_error(result: Dict[str, Any]) -> None:
             f"MiniMax TTS API error (code {status_code}): {base_resp.get('status_msg', 'unknown error')}")
 
 
+def _minimax_voice_id(mm_config: Dict[str, Any]) -> str:
+    """Resolve the configured MiniMax voice id.
+
+    Both payload shapes need it (t2a_v2 nests it under voice_setting, the older
+    text_to_speech endpoint carries it flat), so the default lives in one place
+    and the two cannot drift apart.
+    """
+    return mm_config.get("voice_id", DEFAULT_MINIMAX_VOICE_ID)
+
+
+def _minimax_voice_setting(mm_config: Dict[str, Any]) -> Dict[str, Any]:
+    """Build the t2a_v2 voice_setting payload. (minimax-auto-emotion)
+
+    The emotion field is only sent when a config explicitly sets one. With
+    the field omitted, MiniMax "automatically selects the most natural
+    emotion based on text", which is the API's documented default; the old
+    hardcoded "neutral" fallback silently disabled that inference on every
+    request, flattening delivery. An empty value or "auto" also omits the
+    field, so a config can state the intent explicitly.
+    """
+    setting = {
+        "voice_id": _minimax_voice_id(mm_config),
+        "speed": mm_config.get("speed", 1.0),
+        "vol": mm_config.get("vol", 1.0),
+        "pitch": mm_config.get("pitch", 0),
+    }
+    emotion = str(mm_config.get("emotion") or "").strip().lower()
+    if emotion and emotion != "auto":
+        if emotion not in MINIMAX_EMOTIONS:
+            logger.warning(
+                "tts.minimax.emotion is %r, which is not an emotion MiniMax "
+                "documents (%s). Sending it as configured; if the API rejects "
+                "it, correct the value or unset it to let MiniMax infer the "
+                "emotion from the text.",
+                emotion,
+                ", ".join(sorted(MINIMAX_EMOTIONS)),
+            )
+        setting["emotion"] = emotion
+    return setting
+
+
 def _generate_minimax_tts(text: str, output_path: str, tts_config: Dict[str, Any]) -> str:
     """Generate audio via MiniMax: ``t2a_v2`` (nested payload, JSON reply with hex audio) or the legacy
     ``text_to_speech`` endpoint (flat payload, raw ``audio/*`` body), detected from the URL."""
     runtime = _resolve_minimax_tts_runtime(tts_config)
     mm_config = _section(tts_config, "minimax")
     model = mm_config.get("model", DEFAULT_MINIMAX_MODEL)
-    voice_id = mm_config.get("voice_id", DEFAULT_MINIMAX_VOICE_ID)
+    voice_id = _minimax_voice_id(mm_config)
     base_url = runtime.endpoint
     # MiniMax scopes TTS requests by GroupId (``?GroupId=<id>`` on the t2a_v2 URL): config or
     # MINIMAX_GROUP_ID, attached only when absent from the URL.
@@ -407,10 +462,7 @@ def _generate_minimax_tts(text: str, output_path: str, tts_config: Dict[str, Any
     if is_t2a_v2:
         payload = {
             "model": model, "text": text,
-            "voice_setting": {
-                "voice_id": voice_id, "speed": mm_config.get("speed", 1.0), "vol": mm_config.get("vol", 1.0),
-                "pitch": mm_config.get("pitch", 0), "emotion": mm_config.get("emotion", "neutral"),
-            },
+            "voice_setting": _minimax_voice_setting(mm_config),
             "audio_setting": {
                 "sample_rate": mm_config.get("sample_rate", 32000), "bitrate": mm_config.get("bitrate", 128000),
                 "format": "mp3", "channel": 1,

--- a/website/docs/user-guide/features/tts.md
+++ b/website/docs/user-guide/features/tts.md
@@ -65,6 +65,13 @@ tts:
     speed: 1                    # 0.5 - 2.0
     vol: 1                      # 0 - 10
     pitch: 0                    # -12 - 12
+    # emotion: "happy"          # Optional: happy, sad, angry, fearful, disgusted,
+    #                           # surprised, calm. Leave it unset (or set "auto") and
+    #                           # MiniMax infers the most natural emotion per request
+    #                           # from the text itself. Set "neutral" to keep the flat
+    #                           # delivery Hermes produced before this default was fixed.
+    #                           # Any other value is still sent as configured, with a
+    #                           # warning in the log, since MiniMax owns this list.
     # base_url: "https://tts.example/v1/t2a_v2"  # Optional endpoint override for the selected region
   mistral:
     model: "voxtral-mini-tts-2603"

--- a/website/docs/user-guide/features/voice-mode.md
+++ b/website/docs/user-guide/features/voice-mode.md
@@ -472,6 +472,14 @@ tts:
     ref_text: ''
     model: neuphonic/neutts-air-q4-gguf
     device: cpu
+  minimax:
+    model: "speech-02-hd"
+    voice_id: "English_expressive_narrator"
+    # emotion: "happy"             # optional: happy, sad, angry, fearful,
+    #                              # disgusted, surprised, calm. Leave it unset
+    #                              # and MiniMax picks the most natural emotion
+    #                              # for each request from the text itself; set
+    #                              # "neutral" to keep the previous flat delivery.
 ```
 
 ### Environment Variables


### PR DESCRIPTION
## What does this PR do?

`_generate_minimax_tts` always sends `voice_setting.emotion` to the t2a_v2 endpoint, falling back to `"neutral"` when the config sets nothing. MiniMax's API reference documents the opposite default: with the field omitted, the model "automatically selects the most natural emotion based on text". So the integration's fallback silently disables that inference on every request, and every MiniMax voice speaks with pinned neutral delivery regardless of what it is saying.

**Fix.** A new pure helper, `_minimax_voice_setting`, builds the `voice_setting` payload and includes `emotion` only when a config sets an explicit value. An empty value or `"auto"` also omits the field, so a config can state the intent explicitly, and explicit values are case folded before sending. The t2a_v2 payload builder calls the helper; the legacy flat `text_to_speech` branch never sent emotion and is untouched.

**This restores original behavior rather than inventing a new default.** The first MiniMax integration omitted the emotion field entirely. The hardcoded `"neutral"` arrived in `c875c0dc1` ("update MiniMax default model to speech-02 and correct API endpoint"), whose message is about the dead endpoint and model rename and never mentions emotion, so the pinning was an incidental byproduct of the endpoint correction, not a decision. MiniMax's own current request example also omits the field.

**Behavior change, disclosed.** Default output still changes for anyone who started using MiniMax after `c875c0dc1`: clips move from pinned neutral to model inferred emotion. Anyone who wants the flat sound keeps it with one line:

```yaml
tts:
  minimax:
    emotion: "neutral"
```

**Live verification.** Ran against the real API on `speech-2.8-turbo` with a cloned voice: the emotion omitted request is accepted (`base_resp.status_code 0`) and paces audibly differently from pinned neutral for identical words, confirming the field was suppressing real behavior.

## Related Issue

No existing issue. Found on a production install where a game show host voice delivered every reveal, joke and crowning in the same flat register; omitting the field restored natural delivery with no other change.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/tts_tool.py`: new module level `_minimax_voice_setting(mm_config)`; the t2a_v2 payload uses it; the now unused `emotion`/`speed`/`vol`/`pitch` locals are dropped (the flat branch only ever used `voice_id` and `model`).
- `tests/tools/test_tts_minimax_emotion.py`: 11 tests. Helper coverage (omission for unset, empty, `auto` in any casing; case folding; knob passthrough; defaults) plus wire payload tests that drive the real `_generate_minimax_tts` with a capture then raise `requests.post` stub. `emotion: "neutral"` is pinned by name because it is the documented migration path back to the pre fix delivery: a future enum validator cannot drop it while these tests stay green. The helper is looked up per test rather than imported at module top, so on an unpatched tree the file fails on assertions instead of erroring at collection.
- `website/docs/user-guide/features/tts.md` (the canonical MiniMax settings block) and `website/docs/user-guide/features/voice-mode.md`: the `minimax:` samples document the emotion values, the omit for automatic behavior, and the `"neutral"` migration line.

## How to Test

1. `pytest tests/tools/test_tts_minimax_emotion.py -q` gives 11 passed.
2. Proof of coverage: with `tools/tts_tool.py` reverted to main and the tests kept, **9 of 11 fail on behavioural assertions** (the wire payload carries `"emotion": "neutral"` that no config asked for). The two that pass either way assert explicitly configured values reach the wire, which was already true.
3. Regression sweep across the TTS suites (`test_tts_minimax_region`, `test_tts_speed`, `test_tts_instructions`, `test_tts_long_form_chunking`, `test_tts_provider_base_urls`, `test_tts_max_text_length`, `test_tts_response_body_cap`): **73 passed on this branch vs 62 on clean main**, exactly the 11 added, no other change.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 25.6) for the suites, plus the live API verification above from a Debian install.

On the unchecked box: I ran the eight TTS suites listed under How to Test (73 tests) rather than the whole tree, and left the box unticked because ticking it would not be true.

## Notes for review

- Duplicate sweep found no open PR touching the MiniMax emotion path. Adjacent: #85771 (MiniMax chunked PCM streaming provider, open) constructs its own payload; if it lands, the same omit unless configured rule would apply there, and this helper is reusable for it.
- `_minimax_voice_setting` deliberately reuses the exact existing defaults for `voice_id`, `speed`, `vol` and `pitch`, so the only wire level difference on any config is the presence or absence of `emotion`.
