### PR TITLE
fix(desktop): add repository field for electron-builder publish resolution

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -287,5 +287,9 @@
       "uninstallDisplayName": "Hermes",
       "warningsAsErrors": false
     }
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/NousResearch/Hermes-Agent.git"
   }
 }


### PR DESCRIPTION
**Problem:** The desktop build fails with `Cannot detect repository by .git/config` when `GITHUB_TOKEN` is present in the environment. electron-builder auto-detects GitHub as the publish provider when both `GITHUB_TOKEN` and CI detection are active, and that path hard-requires the `repository` field. Reproduced deterministically: `CI=1 GITHUB_TOKEN=x npm run pack` fails; either variable alone only warns.

**Root cause:** `apps/desktop/package.json` is missing the `repository` field. The root `package.json` already has it — the desktop workspace just never received it.

**Fix:** Add `repository` to `apps/desktop/package.json`, matching the root package.json. Verified: the previously-failing build now completes and the app launches.

---

## What does this PR do?

Adds the `repository` field to `apps/desktop/package.json` so electron-builder can resolve publish configuration when `GITHUB_TOKEN` + CI detection are both present. Without it, any desktop build on a machine with `GITHUB_TOKEN` set fails during the afterPack stage.

## Related Issue

No existing issue — found while setting up the desktop app locally.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/package.json` — added `repository` field (`git+https://github.com/NousResearch/Hermes-Agent.git`, matching root package.json)

## How to Test

1. `cd apps/desktop && CI=1 GITHUB_TOKEN=x npm run builder -- --dir` → fails with `Cannot detect repository` **before** the fix
2. Apply the fix → same command completes successfully
3. `hermes desktop` builds and launches normally

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(desktop): …`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix (1 file, 4 lines)
- [ ] I've run `pytest tests/ -q` and all tests pass — metadata-only change; no test code touched
- [ ] I've added tests for my changes — N/A (metadata-only; existing build suite covers it)
- [x] I've tested on my platform: Ubuntu (Linux x64)

### Documentation & Housekeeping

- [x] N/A — no docs, config keys, architecture, or tool behavior changed

## Screenshots / Logs

**Failure (before fix):**

```
⨯ Cannot detect repository by .git/config. Please specify "repository" in the package.json
```

**Success (after fix):** build completes; `release/linux-unpacked/Hermes` launches.
