### PR TITLE
fix(delegation): make HERMES_DELEGATED_CHILD_CONTEXT scrubbing symmetric and clear at gateway startup

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5174,6 +5174,12 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
     # Set here (not at import) so incidental gateway.run imports from CLI code don't poison it.
     os.environ["HERMES_EXEC_ASK"] = "1"
 
+    # Strip any stale delegated-child marker inherited from a parent shell
+    # (#87650): a long-lived gateway process is never a delegated child. Scoped
+    # to gateway startup (not module import) so incidental imports of
+    # gateway.run from tool/CLI code never scrub a legitimate child's marker.
+    os.environ.pop("HERMES_DELEGATED_CHILD_CONTEXT", None)
+
     from hermes_cli.resource_limits import apply_nofile_soft_limit
     apply_nofile_soft_limit()
 

--- a/gateway/run_shutdown.py
+++ b/gateway/run_shutdown.py
@@ -1252,6 +1252,7 @@ class GatewayShutdownMixin:
         from tools.environments.local import build_subprocess_env
         watcher_env = build_subprocess_env(scrub_secrets=False, inherit_profile_home=True)
         watcher_env.pop("_HERMES_GATEWAY", None)
+        watcher_env.pop("HERMES_DELEGATED_CHILD_CONTEXT", None)
         return watcher_env
 
     @staticmethod

--- a/hermes_cli/kanban_db_dispatch.py
+++ b/hermes_cli/kanban_db_dispatch.py
@@ -2188,6 +2188,7 @@ def _default_spawn(task: Task, workspace: str, *, board: Optional[str] = None) -
     from gateway.session_context import _VAR_MAP
     for key in _VAR_MAP:
         env.pop(key, None)
+    env.pop("HERMES_DELEGATED_CHILD_CONTEXT", None)
 
     # Inject HERMES_HOME so the worker reads the profile-scoped config.yaml:
     # without it the child's get_hermes_home() falls back to the DEFAULT

--- a/hermes_cli/kanban_db_dispatch.py
+++ b/hermes_cli/kanban_db_dispatch.py
@@ -2188,7 +2188,6 @@ def _default_spawn(task: Task, workspace: str, *, board: Optional[str] = None) -
     from gateway.session_context import _VAR_MAP
     for key in _VAR_MAP:
         env.pop(key, None)
-    env.pop("HERMES_DELEGATED_CHILD_CONTEXT", None)
 
     # Inject HERMES_HOME so the worker reads the profile-scoped config.yaml:
     # without it the child's get_hermes_home() falls back to the DEFAULT

--- a/tests/agent/test_delegated_child_context_scrub.py
+++ b/tests/agent/test_delegated_child_context_scrub.py
@@ -1,0 +1,76 @@
+"""Regression tests for #87650 — HERMES_DELEGATED_CHILD_CONTEXT marker symmetric scrubbing.
+
+Ensures:
+1. scrub_kanban_env and delegated_child_subprocess_env pop the marker when not in a delegated child.
+2. Long-lived process environments do not permanently retain the marker.
+3. Dispatcher worker spawn explicitly removes the marker.
+"""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import MagicMock, patch
+import pytest
+
+from agent.delegation_context import (
+    DELEGATED_CHILD_ENV_MARKER,
+    KANBAN_ENV_KEYS,
+    delegated_child_context,
+    delegated_child_subprocess_env,
+    is_delegated_child_context,
+    is_delegated_child_process_context,
+    scrub_kanban_env,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch):
+    monkeypatch.delenv(DELEGATED_CHILD_ENV_MARKER, raising=False)
+    for k in KANBAN_ENV_KEYS:
+        monkeypatch.delenv(k, raising=False)
+
+
+def test_scrub_kanban_env_symmetry():
+    """scrub_kanban_env removes the marker when is_delegated is False."""
+    env = {
+        "HERMES_KANBAN_TASK": "task-123",
+        "HERMES_KANBAN_DB": "/path/to/db",
+        DELEGATED_CHILD_ENV_MARKER: "1",
+        "PATH": "/usr/bin",
+    }
+    # Delegated scrub removes kanban keys and sets marker
+    scrubbed_del = scrub_kanban_env(env, is_delegated=True)
+    assert "HERMES_KANBAN_TASK" not in scrubbed_del
+    assert scrubbed_del[DELEGATED_CHILD_ENV_MARKER] == "1"
+
+    # Non-delegated scrub removes both kanban keys and marker
+    scrubbed_non = scrub_kanban_env(env, is_delegated=False)
+    assert "HERMES_KANBAN_TASK" not in scrubbed_non
+    assert DELEGATED_CHILD_ENV_MARKER not in scrubbed_non
+    assert scrubbed_non["PATH"] == "/usr/bin"
+
+
+def test_delegated_child_subprocess_env_cleans_non_delegated(monkeypatch):
+    """When not in a delegated child, delegated_child_subprocess_env strips stale marker from env."""
+    assert is_delegated_child_process_context() is False
+
+    stale_env = {
+        DELEGATED_CHILD_ENV_MARKER: "1",
+        "OTHER_VAR": "abc",
+    }
+    result = delegated_child_subprocess_env(stale_env)
+    assert result is not None
+    assert DELEGATED_CHILD_ENV_MARKER not in result
+    assert result["OTHER_VAR"] == "abc"
+
+
+def test_delegated_child_context_lifecycle():
+    """Inside delegated_child_context(), is_delegated_child_context() is True and resets upon exit."""
+    assert is_delegated_child_context() is False
+
+    with delegated_child_context("test-session"):
+        assert is_delegated_child_context() is True
+        env = delegated_child_subprocess_env({"CUSTOM": "1"})
+        assert env[DELEGATED_CHILD_ENV_MARKER] == "1"
+
+    assert is_delegated_child_context() is False

--- a/tests/agent/test_delegated_child_context_scrub.py
+++ b/tests/agent/test_delegated_child_context_scrub.py
@@ -1,15 +1,9 @@
-"""Regression tests for #87650 — HERMES_DELEGATED_CHILD_CONTEXT marker symmetric scrubbing.
-
-Ensures:
-1. scrub_kanban_env and delegated_child_subprocess_env pop the marker when not in a delegated child.
-2. Long-lived process environments do not permanently retain the marker.
-3. Dispatcher worker spawn explicitly removes the marker.
-"""
+"""Gateway owner boundaries clear stale lineage; ordinary descendants retain their write fence."""
 
 from __future__ import annotations
 
 import os
-from unittest.mock import MagicMock, patch
+
 import pytest
 
 from agent.delegation_context import (
@@ -30,8 +24,8 @@ def _clean_env(monkeypatch):
         monkeypatch.delenv(k, raising=False)
 
 
-def test_scrub_kanban_env_symmetry():
-    """scrub_kanban_env removes the marker when is_delegated is False."""
+def test_scrub_kanban_env_preserves_descendant_fence():
+    """Worker identity is removed while board routing and the write fence survive."""
     env = {
         "HERMES_KANBAN_TASK": "task-123",
         "HERMES_KANBAN_DB": "/path/to/db",
@@ -39,19 +33,17 @@ def test_scrub_kanban_env_symmetry():
         "PATH": "/usr/bin",
     }
     # Delegated scrub removes kanban keys and sets marker
-    scrubbed_del = scrub_kanban_env(env, is_delegated=True)
+    scrubbed_del = scrub_kanban_env(env)
     assert "HERMES_KANBAN_TASK" not in scrubbed_del
     assert scrubbed_del[DELEGATED_CHILD_ENV_MARKER] == "1"
 
-    # Non-delegated scrub removes both kanban keys and marker
-    scrubbed_non = scrub_kanban_env(env, is_delegated=False)
-    assert "HERMES_KANBAN_TASK" not in scrubbed_non
-    assert DELEGATED_CHILD_ENV_MARKER not in scrubbed_non
-    assert scrubbed_non["PATH"] == "/usr/bin"
+    assert scrubbed_del["HERMES_KANBAN_DB"] == "/path/to/db"
+    assert scrubbed_del["PATH"] == "/usr/bin"
+    assert env["HERMES_KANBAN_TASK"] == "task-123"
 
 
-def test_delegated_child_subprocess_env_cleans_non_delegated(monkeypatch):
-    """When not in a delegated child, delegated_child_subprocess_env strips stale marker from env."""
+def test_delegated_child_subprocess_env_preserves_explicit_fence():
+    """An explicit child environment carries a write fence even outside a local child context."""
     assert is_delegated_child_process_context() is False
 
     stale_env = {
@@ -60,7 +52,7 @@ def test_delegated_child_subprocess_env_cleans_non_delegated(monkeypatch):
     }
     result = delegated_child_subprocess_env(stale_env)
     assert result is not None
-    assert DELEGATED_CHILD_ENV_MARKER not in result
+    assert result[DELEGATED_CHILD_ENV_MARKER] == "1"
     assert result["OTHER_VAR"] == "abc"
 
 
@@ -74,3 +66,88 @@ def test_delegated_child_context_lifecycle():
         assert env[DELEGATED_CHILD_ENV_MARKER] == "1"
 
     assert is_delegated_child_context() is False
+
+
+def test_delegated_child_subprocess_env_none_keeps_plain_inheritance(monkeypatch):
+    """An ordinary process without a fence keeps the upstream env=None contract."""
+    monkeypatch.setenv("PATH", "/usr/bin:/bin")
+    assert delegated_child_subprocess_env() is None
+    assert os.environ["PATH"] == "/usr/bin:/bin"
+
+
+def test_delegated_child_subprocess_env_none_preserves_inherited_fence(monkeypatch):
+    """A real inherited marker survives the next spawn without mocking its predicate."""
+    monkeypatch.setenv(DELEGATED_CHILD_ENV_MARKER, "1")
+    assert is_delegated_child_process_context() is True
+    assert is_delegated_child_process_context() is True
+    result = delegated_child_subprocess_env()
+    assert result is not None
+    assert result[DELEGATED_CHILD_ENV_MARKER] == "1"
+    assert os.environ[DELEGATED_CHILD_ENV_MARKER] == "1"
+
+
+def test_gateway_run_import_preserves_delegated_child_marker():
+    """Importing gateway.run must not scrub the marker (#87668 review, point 1).
+
+    Tool code (send_message_tool, telegram adapter, relay runtime) lazily
+    imports gateway.run inside ordinary agent processes; a module-level pop
+    stripped a legitimate delegated child's marker on import.
+    """
+    import subprocess
+    import sys
+    from pathlib import Path
+
+    repo_root = Path(__file__).resolve().parents[2]
+    probe = (
+        "import os, sys; "
+        f"os.environ[{DELEGATED_CHILD_ENV_MARKER!r}] = '1'; "
+        "import gateway.run; "
+        f"sys.stdout.write(os.environ.get({DELEGATED_CHILD_ENV_MARKER!r}, ''))"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", probe],
+        cwd=str(repo_root),
+        capture_output=True,
+        text=True,
+        timeout=180,
+    )
+    assert result.returncode == 0, result.stderr
+    assert result.stdout == "1"
+
+
+def test_start_gateway_scrubs_stale_marker_at_startup(monkeypatch):
+    """The symmetric-scrub contract holds at real gateway startup."""
+    for var in ("HERMES_EXEC_ASK", "AI_AGENT", "HERMES_AGENT", "_HERMES_GATEWAY"):
+        monkeypatch.delenv(var, raising=False)
+    monkeypatch.setenv(DELEGATED_CHILD_ENV_MARKER, "1")
+
+    import gateway.run as gateway_run
+
+    import asyncio
+
+    import hermes_cli.resource_limits as resource_limits
+
+    def _stop_startup():
+        raise RuntimeError("startup-stop")
+
+    # Abort start_gateway immediately after the scrub under test.
+    monkeypatch.setattr(resource_limits, "apply_nofile_soft_limit", _stop_startup)
+
+    with pytest.raises(RuntimeError, match="startup-stop"):
+        asyncio.run(gateway_run.start_gateway())
+
+    assert DELEGATED_CHILD_ENV_MARKER not in os.environ
+
+
+def test_restart_watcher_clears_owner_markers_without_mutating_parent(monkeypatch):
+    from gateway.run_shutdown import GatewayShutdownMixin
+
+    monkeypatch.setenv(DELEGATED_CHILD_ENV_MARKER, "1")
+    monkeypatch.setenv("_HERMES_GATEWAY", "1")
+    monkeypatch.setenv("PATH", "/usr/bin:/bin")
+    watcher_env = GatewayShutdownMixin._restart_watcher_env()
+    assert DELEGATED_CHILD_ENV_MARKER not in watcher_env
+    assert "_HERMES_GATEWAY" not in watcher_env
+    assert watcher_env["PATH"] == "/usr/bin:/bin"
+    assert os.environ[DELEGATED_CHILD_ENV_MARKER] == "1"
+    assert os.environ["_HERMES_GATEWAY"] == "1"


### PR DESCRIPTION
## What does this PR do?

A gateway started from an environment carrying `HERMES_DELEGATED_CHILD_CONTEXT` is incorrectly treated as a delegated child, so Kanban mutations fail. This change clears the marker when the gateway starts and when it constructs its restart-watcher environment.

Current main already grants dispatcher workers a clean task scope in `hermes_cli/kanban_db_dispatch.py` (commit `b578261584`). It also deliberately preserves the marker as a write fence in ordinary descendants. This PR keeps that behavior intact and fixes the remaining gateway owner-boundary gap. Importing `gateway.run` does not change the marker.

## Related Issue

Closes #87650

Related open approaches: #87805 and #90885. This is an update to the existing PR; descendant write fences follow current main.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- **`gateway/run.py`**: Clear the inherited marker inside `start_gateway()`, alongside the existing startup-only environment handling.
- **`gateway/run_shutdown.py`**: Remove the marker from the restart watcher's environment without changing the parent environment.
- **`tests/agent/test_delegated_child_context_scrub.py`**: Exercise real startup, watcher environment construction and a subprocess import. Compatibility tests retain explicit and inherited descendant fences, board routing, context restoration and ordinary `env=None` inheritance.

## How to Test

Run the focused behavior and neighboring-path tests from the upstream repository root:

```bash
scripts/run_tests.sh tests/agent/test_delegated_child_context_scrub.py tests/tools/test_hermes_subprocess_env.py tests/tools/test_kanban_descendant_scope.py tests/cron/test_cron_kanban_env_isolation.py
```

The paired regression check uses identical committed test bytes on current main and this branch. The startup and restart-watcher cases are expected to fail on main; the complete regression file must pass on the branch. The real shell/CLI descendant checks protect the current upstream write-fence behavior.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- Validation: 44 passed, 0 failed, 1 existing Linux-only dispatcher test skipped on macOS. Full `pytest tests/ -q` was not run.
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS (Apple Silicon)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A