### PR TITLE
Fail closed on invalid cron delivery contracts

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -1563,6 +1563,49 @@ def _normalize_job_optional_text(value: Any, *, strip_trailing_slash: bool = Fal
     return text or None
 
 
+def _normalize_response_contract(value: Any) -> Optional[Dict[str, Any]]:
+    if value is None:
+        return None
+    if not isinstance(value, dict):
+        raise ValueError("response_contract must be an object")
+
+    unknown_fields = set(value) - {"required_patterns", "forbidden_patterns", "on_failure"}
+    if unknown_fields:
+        raise ValueError(
+            "response_contract has unsupported field(s): "
+            + ", ".join(sorted(unknown_fields))
+        )
+
+    def _patterns(field: str) -> List[str]:
+        raw_patterns = value.get(field, [])
+        if not isinstance(raw_patterns, list):
+            raise ValueError(f"response_contract.{field} must be a list of strings")
+        normalized = []
+        for pattern in raw_patterns:
+            if not isinstance(pattern, str) or not pattern.strip():
+                raise ValueError(
+                    f"response_contract.{field} must contain non-empty strings"
+                )
+            normalized.append(pattern.strip())
+        return normalized
+
+    required_patterns = _patterns("required_patterns")
+    forbidden_patterns = _patterns("forbidden_patterns")
+    if not required_patterns and not forbidden_patterns:
+        raise ValueError(
+            "response_contract requires required_patterns or forbidden_patterns"
+        )
+
+    on_failure = value.get("on_failure", "fail")
+    if on_failure != "fail":
+        raise ValueError("response_contract.on_failure must be 'fail'")
+    return {
+        "required_patterns": required_patterns,
+        "forbidden_patterns": forbidden_patterns,
+        "on_failure": "fail",
+    }
+
+
 def _compute_provider_model_snapshots(
     *,
     provider: Any,
@@ -1668,6 +1711,7 @@ def create_job(
     attach_to_session: Optional[bool] = None,
     monitor_script: Optional[str] = None,
     monitor_url: Optional[str] = None,
+    response_contract: Optional[Dict[str, Any]] = None,
 ) -> Dict[str, Any]:
     """
     Create a new cron job.
@@ -1761,6 +1805,7 @@ def create_job(
     normalized_monitor_script = normalized_monitor_script or None
     normalized_monitor_url = str(monitor_url).strip() if isinstance(monitor_url, str) else None
     normalized_monitor_url = normalized_monitor_url or None
+    normalized_response_contract = _normalize_response_contract(response_contract)
 
     # Monitor-mode validation: exactly one source, and monitor mode only
     # makes sense when there IS an agent to suppress/wake.
@@ -1854,6 +1899,8 @@ def create_job(
         "last_status": None,
         "last_error": None,
         "last_delivery_error": None,
+        "last_response_contract_error": None,
+        "response_contract": normalized_response_contract,
         # Delivery configuration
         "deliver": deliver,
         "origin": origin,  # Tracks where job was created for "origin" delivery
@@ -1970,6 +2017,11 @@ def update_job(job_id: str, updates: Dict[str, Any]) -> Optional[Dict[str, Any]]
                     _mv = updates[_mon_field]
                     _mv = str(_mv).strip() if isinstance(_mv, str) else None
                     updates[_mon_field] = _mv or None
+
+            if "response_contract" in updates:
+                updates["response_contract"] = _normalize_response_contract(
+                    updates["response_contract"]
+                )
 
             previous_inference_axes = _normalized_inference_axes(job)
             updated = _apply_skill_fields({**job, **updates})
@@ -2167,6 +2219,7 @@ def mark_job_run(
     delivery_error: Optional[str] = None,
     status: Optional[str] = None,
     *,
+    response_contract_error: Optional[str] = None,
     expected_fire_owner: Optional[str] = None,
 ) -> bool:
     with _fire_job_lock(job_id) as acquired:
@@ -2178,6 +2231,7 @@ def mark_job_run(
             error,
             delivery_error,
             status=status,
+            response_contract_error=response_contract_error,
             expected_fire_owner=expected_fire_owner,
         )
 
@@ -2240,6 +2294,7 @@ def _mark_job_run_locked(
     delivery_error: Optional[str] = None,
     *,
     status: Optional[str] = None,
+    response_contract_error: Optional[str] = None,
     expected_fire_owner: Optional[str] = None,
 ) -> bool:
     """
@@ -2284,6 +2339,7 @@ def _mark_job_run_locked(
                     job.pop("drift_alerted", None)
                 # Track delivery failures separately — cleared on successful delivery
                 job["last_delivery_error"] = delivery_error
+                job["last_response_contract_error"] = response_contract_error
                 # Clear any external-fire claim so a re-armed recurring job can
                 # be claimed again on its next fire (Phase 4C CAS).
                 job["fire_claim"] = None

--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -1564,7 +1564,7 @@ def _normalize_job_optional_text(value: Any, *, strip_trailing_slash: bool = Fal
 
 
 def _normalize_response_contract(value: Any) -> Optional[Dict[str, Any]]:
-    if value is None:
+    if value is None or value == {}:
         return None
     if not isinstance(value, dict):
         raise ValueError("response_contract must be an object")
@@ -1580,11 +1580,17 @@ def _normalize_response_contract(value: Any) -> Optional[Dict[str, Any]]:
         raw_patterns = value.get(field, [])
         if not isinstance(raw_patterns, list):
             raise ValueError(f"response_contract.{field} must be a list of strings")
+        if len(raw_patterns) > 32:
+            raise ValueError(f"response_contract.{field} cannot contain more than 32 patterns")
         normalized = []
         for pattern in raw_patterns:
             if not isinstance(pattern, str) or not pattern.strip():
                 raise ValueError(
                     f"response_contract.{field} must contain non-empty strings"
+                )
+            if len(pattern) > 512:
+                raise ValueError(
+                    f"response_contract.{field} patterns cannot exceed 512 characters"
                 )
             normalized.append(pattern.strip())
         return normalized

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -466,6 +466,32 @@ from cron.executions import create_execution, finish_execution, mark_execution_r
 # locally for audit.
 SILENT_MARKER = "[SILENT]"
 
+
+def _validate_response_contract(job: dict, response: str) -> Optional[str]:
+    contract = job.get("response_contract")
+    if not isinstance(contract, dict) or contract.get("on_failure", "fail") != "fail":
+        return None
+
+    required_patterns = contract.get("required_patterns", [])
+    forbidden_patterns = contract.get("forbidden_patterns", [])
+    if not isinstance(required_patterns, list) or not isinstance(forbidden_patterns, list):
+        return "stored response contract is invalid"
+
+    missing = [
+        pattern for pattern in required_patterns
+        if isinstance(pattern, str) and pattern not in response
+    ]
+    matched = [
+        pattern for pattern in forbidden_patterns
+        if isinstance(pattern, str) and pattern in response
+    ]
+    details = []
+    if missing:
+        details.append("missing required pattern(s): " + ", ".join(repr(p) for p in missing))
+    if matched:
+        details.append("matched forbidden pattern(s): " + ", ".join(repr(p) for p in matched))
+    return "; ".join(details) or None
+
 # Canonical silence tokens recognized in cron output.  Cron's contract is
 # intentionally looser than the gateway's exact-whole-response rule: the cron
 # system prompt *instructs* the agent to emit "[SILENT]", and real agents often
@@ -5941,6 +5967,7 @@ def _run_one_job_body(
         # deferred agent is still torn down. Otherwise the outer `except` would
         # swallow the error and leak the agent's subprocesses/clients (#10200).
         blocked_config = False
+        response_contract_error = None
         side_effect_ownership_lost = False
         try:
             with _side_effect_fence() as owns_output:
@@ -5963,6 +5990,12 @@ def _run_one_job_body(
                     "Interrupted by gateway shutdown before the run finished "
                     "(tool subprocess was killed mid-flight)."
                 )
+
+            if success:
+                response_contract_error = _validate_response_contract(job, final_response)
+                if response_contract_error:
+                    success = False
+                    error = f"Response contract failed: {response_contract_error}"
 
             # Deliver the final response to the origin/target chat.
             # If the agent responded with [SILENT], skip delivery (but
@@ -6021,6 +6054,8 @@ def _run_one_job_body(
             # responses: do not deliver a blank message, and let the
             # empty-response guard below mark the run as a soft failure.
             should_deliver = bool(deliver_content.strip())
+            if response_contract_error:
+                should_deliver = False
             if blocked_config_silent or drift_skip_silent:
                 should_deliver = False
             unresolved_origin = False
@@ -6131,10 +6166,14 @@ def _run_one_job_body(
             return True
 
         mark_kwargs = {"delivery_error": delivery_error}
+        if response_contract_error:
+            mark_kwargs["response_contract_error"] = response_contract_error
         if fire_owner is not None:
             mark_kwargs["expected_fire_owner"] = fire_owner
         if blocked_config:
             mark_kwargs["status"] = "blocked_config"
+        elif response_contract_error:
+            mark_kwargs["status"] = "response_contract_failed"
         marked = mark_job_run(job["id"], success, error, **mark_kwargs)
         if fire_owner is not None and not marked:
             finish_execution(

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -469,27 +469,30 @@ SILENT_MARKER = "[SILENT]"
 
 def _validate_response_contract(job: dict, response: str) -> Optional[str]:
     contract = job.get("response_contract")
-    if not isinstance(contract, dict) or contract.get("on_failure", "fail") != "fail":
+    if contract is None:
         return None
+    if not isinstance(contract, dict) or contract.get("on_failure", "fail") != "fail":
+        return "stored response contract is invalid"
 
     required_patterns = contract.get("required_patterns", [])
     forbidden_patterns = contract.get("forbidden_patterns", [])
     if not isinstance(required_patterns, list) or not isinstance(forbidden_patterns, list):
         return "stored response contract is invalid"
+    if not required_patterns and not forbidden_patterns:
+        return "stored response contract is invalid"
+    if any(
+        not isinstance(pattern, str) or not pattern.strip()
+        for pattern in [*required_patterns, *forbidden_patterns]
+    ):
+        return "stored response contract is invalid"
 
-    missing = [
-        pattern for pattern in required_patterns
-        if isinstance(pattern, str) and pattern not in response
-    ]
-    matched = [
-        pattern for pattern in forbidden_patterns
-        if isinstance(pattern, str) and pattern in response
-    ]
+    missing = [pattern for pattern in required_patterns if pattern not in response]
+    matched = [pattern for pattern in forbidden_patterns if pattern in response]
     details = []
     if missing:
-        details.append("missing required pattern(s): " + ", ".join(repr(p) for p in missing))
+        details.append("required response content is missing")
     if matched:
-        details.append("matched forbidden pattern(s): " + ", ".join(repr(p) for p in matched))
+        details.append("forbidden response content is present")
     return "; ".join(details) or None
 
 # Canonical silence tokens recognized in cron output.  Cron's contract is
@@ -5970,13 +5973,6 @@ def _run_one_job_body(
         response_contract_error = None
         side_effect_ownership_lost = False
         try:
-            with _side_effect_fence() as owns_output:
-                if not owns_output:
-                    raise _FireClaimLostDuringSideEffect
-                output_file = save_job_output(job["id"], output)
-            if verbose:
-                logger.info("Output saved to: %s", output_file)
-
             # If the gateway shutdown killed this job's tool subprocess
             # mid-flight (#60432), the agent may still have produced a
             # plausible-looking final_response from the truncated output --
@@ -5997,9 +5993,18 @@ def _run_one_job_body(
                     success = False
                     error = f"Response contract failed: {response_contract_error}"
 
+            if not response_contract_error:
+                with _side_effect_fence() as owns_output:
+                    if not owns_output:
+                        raise _FireClaimLostDuringSideEffect
+                    output_file = save_job_output(job["id"], output)
+                if verbose:
+                    logger.info("Output saved to: %s", output_file)
+
             # Deliver the final response to the origin/target chat.
-            # If the agent responded with [SILENT], skip delivery (but
-            # output is already saved above).  Failed jobs always deliver.
+            # If the agent responded with [SILENT], skip delivery. Failed jobs
+            # normally deliver a failure alert, except contract failures: their
+            # output is neither saved nor delivered.
             #
             # Exception: a run blocked by pre-dispatch config validation
             # (T1-26) alerts exactly ONCE — the silent marker means the

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -5647,7 +5647,7 @@ class APIServerAdapter(BasePlatformAdapter):
 
     _JOB_ID_RE = __import__("re").compile(r"[a-f0-9]{12}")
     # Allowed fields for update — prevents clients injecting arbitrary keys
-    _UPDATE_ALLOWED_FIELDS = {"name", "schedule", "prompt", "deliver", "skills", "skill", "repeat", "enabled"}
+    _UPDATE_ALLOWED_FIELDS = {"name", "schedule", "prompt", "deliver", "skills", "skill", "repeat", "enabled", "response_contract"}
     _MAX_NAME_LENGTH = 200
     _MAX_PROMPT_LENGTH = 5000
 
@@ -5705,6 +5705,7 @@ class APIServerAdapter(BasePlatformAdapter):
             deliver = body.get("deliver", "local")
             skills = body.get("skills")
             repeat = body.get("repeat")
+            response_contract = body.get("response_contract")
 
             if not name:
                 return web.json_response({"error": "Name is required"}, status=400)
@@ -5736,6 +5737,8 @@ class APIServerAdapter(BasePlatformAdapter):
                 kwargs["skills"] = skills
             if repeat is not None:
                 kwargs["repeat"] = repeat
+            if response_contract is not None:
+                kwargs["response_contract"] = response_contract
 
             job = _cron_create(**kwargs)
             return web.json_response({"job": job})

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -5744,6 +5744,8 @@ class APIServerAdapter(BasePlatformAdapter):
             return web.json_response({"job": job})
         except _CronSchedulerRegistrationError as e:
             return web.json_response(e.to_dict(), status=424)
+        except ValueError as e:
+            return web.json_response({"error": _redact_api_error_text(e)}, status=400)
         except Exception as e:
             return web.json_response({"error": _redact_api_error_text(e)}, status=500)
 
@@ -5801,6 +5803,8 @@ class APIServerAdapter(BasePlatformAdapter):
                 return web.json_response({"error": "Job not found"}, status=404)
             _notify_cron_provider_jobs_changed()
             return web.json_response({"job": job})
+        except ValueError as e:
+            return web.json_response({"error": _redact_api_error_text(e)}, status=400)
         except Exception as e:
             return web.json_response({"error": _redact_api_error_text(e)}, status=500)
 

--- a/hermes_cli/cron.py
+++ b/hermes_cli/cron.py
@@ -48,6 +48,18 @@ def _cron_api(**kwargs):
     return json.loads(cronjob_tool(**kwargs))
 
 
+def _parse_response_contract(value: Optional[str]):
+    if value is None:
+        return None
+    try:
+        parsed = json.loads(value)
+    except json.JSONDecodeError as exc:
+        raise ValueError("--response-contract must be valid JSON") from exc
+    if not isinstance(parsed, dict):
+        raise ValueError("--response-contract must be a JSON object")
+    return parsed
+
+
 def _active_cron_provider_name() -> str:
     """Name of the resolved cron scheduler provider ('builtin', 'chronos', …).
 
@@ -348,6 +360,14 @@ def cron_create(args):
     # raises GatewayLifecycleBlocked, the `cronjob` tool wrapper catches it and
     # returns it as result["error"], and the `if not result.get("success")`
     # branch below prints it in red and exits 1 — same UX as before.
+    try:
+        response_contract = _parse_response_contract(
+            getattr(args, "response_contract", None)
+        )
+    except ValueError as exc:
+        print(color(str(exc), Colors.RED))
+        return 1
+
     result = _cron_api(
         action="create",
         schedule=args.schedule,
@@ -364,6 +384,7 @@ def cron_create(args):
         no_agent=getattr(args, "no_agent", False) or None,
         monitor_script=getattr(args, "monitor_script", None),
         monitor_url=getattr(args, "monitor_url", None),
+        response_contract=response_contract,
     )
     if not result.get("success"):
         print(color(f"Failed to create job: {result.get('error', 'unknown error')}", Colors.RED))
@@ -419,6 +440,14 @@ def cron_edit(args):
             if skill not in final_skills:
                 final_skills.append(skill)
 
+    try:
+        response_contract = _parse_response_contract(
+            getattr(args, "response_contract", None)
+        )
+    except ValueError as exc:
+        print(color(str(exc), Colors.RED))
+        return 1
+
     result = _cron_api(
         action="update",
         job_id=args.job_id,
@@ -435,6 +464,7 @@ def cron_edit(args):
         no_agent=getattr(args, "no_agent", None),
         monitor_script=getattr(args, "monitor_script", None),
         monitor_url=getattr(args, "monitor_url", None),
+        response_contract=response_contract,
     )
     if not result.get("success"):
         print(color(f"Failed to update job: {result.get('error', 'unknown error')}", Colors.RED))

--- a/hermes_cli/subcommands/cron.py
+++ b/hermes_cli/subcommands/cron.py
@@ -40,6 +40,10 @@ def build_cron_parser(subparsers, *, cmd_cron: Callable) -> None:
     )
     cron_create.add_argument("--repeat", type=int, help="Optional repeat count")
     cron_create.add_argument(
+        "--response-contract",
+        help="JSON response contract with required_patterns, forbidden_patterns, and optional on_failure=fail.",
+    )
+    cron_create.add_argument(
         "--skill",
         dest="skills",
         action="append",
@@ -116,6 +120,10 @@ def build_cron_parser(subparsers, *, cmd_cron: Callable) -> None:
     cron_edit.add_argument("--name", help="New job name")
     cron_edit.add_argument("--deliver", help="New delivery target")
     cron_edit.add_argument("--repeat", type=int, help="New repeat count")
+    cron_edit.add_argument(
+        "--response-contract",
+        help="Replace the response contract with JSON. Pass {} to clear it.",
+    )
     cron_edit.add_argument(
         "--skill",
         dest="skills",

--- a/hermes_cli/web_models.py
+++ b/hermes_cli/web_models.py
@@ -388,6 +388,7 @@ class CronJobCreate(BaseModel):
     enabled_toolsets: Optional[List[str]] = None
     workdir: Optional[str] = None
     no_agent: bool = False
+    response_contract: Optional[Dict[str, Any]] = None
 
 
 class CronJobUpdate(BaseModel):
@@ -738,4 +739,3 @@ class _PluginProvidersPutBody(BaseModel):
 
 class _PluginVisibilityBody(BaseModel):
     hidden: bool
-

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -12424,6 +12424,7 @@ def _create_cron_job_sync(body: CronJobCreate, profile: Optional[str] = None):
             enabled_toolsets=_cron_string_list(body.enabled_toolsets),
             workdir=_cron_optional_text(body.workdir),
             no_agent=no_agent,
+            response_contract=body.response_contract,
         )
     except HTTPException:
         raise

--- a/tests/cron/test_jobs.py
+++ b/tests/cron/test_jobs.py
@@ -484,6 +484,32 @@ class TestMarkJobRun:
         assert updated["last_error"] is None
         assert updated["last_delivery_error"] == "platform 'telegram' not configured"
 
+    def test_response_contract_failure_has_distinct_status_and_error(self, tmp_cron_dir):
+        job = create_job(
+            prompt="Report",
+            schedule="every 1h",
+            response_contract={"required_patterns": ["prepare_actual_sleep_calendar_update"]},
+        )
+
+        mark_job_run(
+            job["id"],
+            success=False,
+            error="Response contract failed: missing required pattern(s)",
+            response_contract_error="missing required pattern(s): 'prepare_actual_sleep_calendar_update'",
+            status="response_contract_failed",
+        )
+
+        updated = get_job(job["id"])
+        assert updated["response_contract"] == {
+            "required_patterns": ["prepare_actual_sleep_calendar_update"],
+            "forbidden_patterns": [],
+            "on_failure": "fail",
+        }
+        assert updated["last_status"] == "response_contract_failed"
+        assert updated["last_response_contract_error"] == (
+            "missing required pattern(s): 'prepare_actual_sleep_calendar_update'"
+        )
+
 
     def test_recurring_cron_not_disabled_when_croniter_missing(self, tmp_cron_dir, monkeypatch):
         """Regression test for issue #16265.

--- a/tests/cron/test_jobs.py
+++ b/tests/cron/test_jobs.py
@@ -277,6 +277,17 @@ class TestUpdateJob:
         fetched = get_job(job["id"])
         assert fetched["name"] == "New Name"
 
+    def test_empty_response_contract_clears_existing_contract(self, tmp_cron_dir):
+        job = create_job(
+            prompt="Check server status",
+            schedule="every 1h",
+            response_contract={"required_patterns": ["done"]},
+        )
+
+        updated = update_job(job["id"], {"response_contract": {}})
+
+        assert updated["response_contract"] is None
+
 
 class TestPauseResumeJob:
     def test_pause_sets_state(self, tmp_cron_dir):
@@ -494,8 +505,8 @@ class TestMarkJobRun:
         mark_job_run(
             job["id"],
             success=False,
-            error="Response contract failed: missing required pattern(s)",
-            response_contract_error="missing required pattern(s): 'prepare_actual_sleep_calendar_update'",
+            error="Response contract failed: required response content is missing",
+            response_contract_error="required response content is missing",
             status="response_contract_failed",
         )
 
@@ -507,7 +518,7 @@ class TestMarkJobRun:
         }
         assert updated["last_status"] == "response_contract_failed"
         assert updated["last_response_contract_error"] == (
-            "missing required pattern(s): 'prepare_actual_sleep_calendar_update'"
+            "required response content is missing"
         )
 
 

--- a/tests/cron/test_run_one_job.py
+++ b/tests/cron/test_run_one_job.py
@@ -78,7 +78,25 @@ def test_run_one_job_success_sequence(monkeypatch):
     assert calls[-1] == ("mark", "j2", True)
 
 
-def test_run_one_job_response_contract_failure_suppresses_delivery(monkeypatch):
+@pytest.mark.parametrize(
+    ("response_contract", "contract_error"),
+    [
+        (
+            {
+                "required_patterns": ["prepare_actual_sleep_calendar_update"],
+                "on_failure": "fail",
+            },
+            "required response content is missing",
+        ),
+        (
+            {"required_patterns": [123], "on_failure": "fail"},
+            "stored response contract is invalid",
+        ),
+    ],
+)
+def test_run_one_job_response_contract_failure_suppresses_delivery(
+    monkeypatch, response_contract, contract_error
+):
     delivered = []
     marked = []
     finished = []
@@ -91,7 +109,12 @@ def test_run_one_job_response_contract_failure_suppresses_delivery(monkeypatch):
         "run_job",
         lambda *_a, **_kw: (True, "raw output", "Calendar update prepared", None),
     )
-    monkeypatch.setattr(s, "save_job_output", lambda jid, out: f"/tmp/{jid}.txt")
+    saved = []
+    monkeypatch.setattr(
+        s,
+        "save_job_output",
+        lambda jid, out: saved.append((jid, out)) or f"/tmp/{jid}.txt",
+    )
     monkeypatch.setattr(
         s,
         "_deliver_result",
@@ -113,28 +136,22 @@ def test_run_one_job_response_contract_failure_suppresses_delivery(monkeypatch):
             "id": "contract-job",
             "name": "weekly plan",
             "deliver": "telegram",
-            "response_contract": {
-                "required_patterns": ["prepare_actual_sleep_calendar_update"],
-                "on_failure": "fail",
-            },
+            "response_contract": response_contract,
         }
     ) is True
 
     assert delivered == []
+    assert saved == []
     assert marked == [
         (
             (
                 "contract-job",
                 False,
-                "Response contract failed: missing required pattern(s): "
-                "'prepare_actual_sleep_calendar_update'",
+                f"Response contract failed: {contract_error}",
             ),
             {
                 "delivery_error": None,
-                "response_contract_error": (
-                    "missing required pattern(s): "
-                    "'prepare_actual_sleep_calendar_update'"
-                ),
+                "response_contract_error": contract_error,
                 "status": "response_contract_failed",
             },
         )
@@ -144,8 +161,7 @@ def test_run_one_job_response_contract_failure_suppresses_delivery(monkeypatch):
             ("exec-contract",),
             {
                 "success": False,
-                "error": "Response contract failed: missing required pattern(s): "
-                "'prepare_actual_sleep_calendar_update'",
+                "error": f"Response contract failed: {contract_error}",
                 "delivery_outcome": "suppressed",
             },
         )
@@ -366,4 +382,3 @@ def test_run_one_job_installs_secret_scope_under_multiplex(monkeypatch, tmp_path
     assert scope_during_run["base_url"] == "https://openrouter.ai/api/v1"
     # And it was torn down after run_one_job returned (no leak).
     assert ss.current_secret_scope() is None
-

--- a/tests/cron/test_run_one_job.py
+++ b/tests/cron/test_run_one_job.py
@@ -78,6 +78,80 @@ def test_run_one_job_success_sequence(monkeypatch):
     assert calls[-1] == ("mark", "j2", True)
 
 
+def test_run_one_job_response_contract_failure_suppresses_delivery(monkeypatch):
+    delivered = []
+    marked = []
+    finished = []
+
+    monkeypatch.setattr(s, "create_execution", lambda *_a, **_kw: {"id": "exec-contract"})
+    monkeypatch.setattr(s, "claim_dispatch", lambda _job_id: True)
+    monkeypatch.setattr(s, "mark_execution_running", lambda _execution_id: None)
+    monkeypatch.setattr(
+        s,
+        "run_job",
+        lambda *_a, **_kw: (True, "raw output", "Calendar update prepared", None),
+    )
+    monkeypatch.setattr(s, "save_job_output", lambda jid, out: f"/tmp/{jid}.txt")
+    monkeypatch.setattr(
+        s,
+        "_deliver_result",
+        lambda job, content, **_kw: delivered.append((job["id"], content)),
+    )
+    monkeypatch.setattr(
+        s,
+        "mark_job_run",
+        lambda *args, **kwargs: marked.append((args, kwargs)),
+    )
+    monkeypatch.setattr(
+        s,
+        "finish_execution",
+        lambda *args, **kwargs: finished.append((args, kwargs)),
+    )
+
+    assert s.run_one_job(
+        {
+            "id": "contract-job",
+            "name": "weekly plan",
+            "deliver": "telegram",
+            "response_contract": {
+                "required_patterns": ["prepare_actual_sleep_calendar_update"],
+                "on_failure": "fail",
+            },
+        }
+    ) is True
+
+    assert delivered == []
+    assert marked == [
+        (
+            (
+                "contract-job",
+                False,
+                "Response contract failed: missing required pattern(s): "
+                "'prepare_actual_sleep_calendar_update'",
+            ),
+            {
+                "delivery_error": None,
+                "response_contract_error": (
+                    "missing required pattern(s): "
+                    "'prepare_actual_sleep_calendar_update'"
+                ),
+                "status": "response_contract_failed",
+            },
+        )
+    ]
+    assert finished == [
+        (
+            ("exec-contract",),
+            {
+                "success": False,
+                "error": "Response contract failed: missing required pattern(s): "
+                "'prepare_actual_sleep_calendar_update'",
+                "delivery_outcome": "suppressed",
+            },
+        )
+    ]
+
+
 def test_run_one_job_exception_delivers_failure_alert(monkeypatch):
     """An exception escaping the run body must not become a silent error row."""
     delivered = []
@@ -292,5 +366,4 @@ def test_run_one_job_installs_secret_scope_under_multiplex(monkeypatch, tmp_path
     assert scope_during_run["base_url"] == "https://openrouter.ai/api/v1"
     # And it was torn down after run_one_job returned (no leak).
     assert ss.current_secret_scope() is None
-
 

--- a/tests/cron/test_run_one_job.py
+++ b/tests/cron/test_run_one_job.py
@@ -92,6 +92,10 @@ def test_run_one_job_success_sequence(monkeypatch):
             {"required_patterns": [123], "on_failure": "fail"},
             "stored response contract is invalid",
         ),
+        (
+            {"forbidden_patterns": ["Calendar update"], "on_failure": "fail"},
+            "forbidden response content is present",
+        ),
     ],
 )
 def test_run_one_job_response_contract_failure_suppresses_delivery(

--- a/tests/gateway/test_api_server_jobs.py
+++ b/tests/gateway/test_api_server_jobs.py
@@ -170,6 +170,25 @@ class TestCreateJob:
                 assert data["retry_create"] is False
                 assert "private callback URL and token" not in data["error"]
 
+    @pytest.mark.asyncio
+    async def test_create_job_rejects_invalid_response_contract(self, adapter):
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch(f"{_MOD}._CRON_AVAILABLE", True), patch(
+                f"{_MOD}._cron_create",
+                side_effect=ValueError("response_contract.required_patterns must be a list"),
+            ):
+                resp = await cli.post("/api/jobs", json={
+                    "name": "test-job",
+                    "schedule": "*/5 * * * *",
+                    "prompt": "do something",
+                    "response_contract": {"required_patterns": "preview"},
+                })
+
+                assert resp.status == 400
+                data = await resp.json()
+                assert data["error"] == "response_contract.required_patterns must be a list"
+
 
     @pytest.mark.asyncio
     async def test_create_job_prompt_too_long(self, adapter):
@@ -244,6 +263,23 @@ class TestUpdateJob:
                 assert "evil_field" not in sanitized
                 assert "__proto__" not in sanitized
                 assert sanitized["response_contract"] == {"forbidden_patterns": ["unsafe"]}
+
+    @pytest.mark.asyncio
+    async def test_update_job_rejects_invalid_response_contract(self, adapter):
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch(f"{_MOD}._CRON_AVAILABLE", True), patch(
+                f"{_MOD}._cron_update",
+                side_effect=ValueError("response_contract requires required_patterns or forbidden_patterns"),
+            ):
+                resp = await cli.patch(
+                    f"/api/jobs/{VALID_JOB_ID}",
+                    json={"response_contract": {}},
+                )
+
+                assert resp.status == 400
+                data = await resp.json()
+                assert data["error"] == "response_contract requires required_patterns or forbidden_patterns"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_api_server_jobs.py
+++ b/tests/gateway/test_api_server_jobs.py
@@ -122,6 +122,7 @@ class TestCreateJob:
                     "name": "test-job",
                     "schedule": "*/5 * * * *",
                     "prompt": "do something",
+                    "response_contract": {"required_patterns": ["preview"]},
                 }, headers={
                     "X-Forwarded-For": "203.0.113.11",
                     "User-Agent": "cron-client",
@@ -138,6 +139,7 @@ class TestCreateJob:
                 assert call_kwargs["origin"]["chat_id"] == "api"
                 assert call_kwargs["origin"]["forwarded_for"] == "203.0.113.11"
                 assert call_kwargs["origin"]["user_agent"] == "cron-client"
+                assert call_kwargs["response_contract"] == {"required_patterns": ["preview"]}
 
 
     @pytest.mark.asyncio
@@ -230,6 +232,7 @@ class TestUpdateJob:
                     f"/api/jobs/{VALID_JOB_ID}",
                     json={
                         "name": "new-name",
+                        "response_contract": {"forbidden_patterns": ["unsafe"]},
                         "evil_field": "malicious",
                         "__proto__": "hack",
                     },
@@ -240,6 +243,7 @@ class TestUpdateJob:
                 assert "name" in sanitized
                 assert "evil_field" not in sanitized
                 assert "__proto__" not in sanitized
+                assert sanitized["response_contract"] == {"forbidden_patterns": ["unsafe"]}
 
 
 # ---------------------------------------------------------------------------
@@ -497,4 +501,3 @@ class TestCronPromptScanParity:
                 data = await resp.json()
                 assert "Blocked" in data["error"] or "threat" in data["error"].lower()
                 mock_create.assert_not_called()
-

--- a/tests/hermes_cli/test_cron.py
+++ b/tests/hermes_cli/test_cron.py
@@ -236,6 +236,58 @@ def test_cron_create_failure_returns_nonzero(monkeypatch, capsys):
     assert "Failed to create job: boom" in out
 
 
+def test_cron_create_forwards_response_contract(monkeypatch):
+    captured = {}
+    monkeypatch.setattr(
+        cron_cli,
+        "_cron_api",
+        lambda **kwargs: captured.update(kwargs)
+        or {
+            "success": True,
+            "job_id": "job-1",
+            "name": "refresh docs",
+            "schedule": "every day",
+            "next_run_at": "tomorrow",
+        },
+    )
+    args = SimpleNamespace(
+        schedule="every day",
+        prompt="refresh docs",
+        name=None,
+        deliver=None,
+        repeat=None,
+        skill=None,
+        skills=None,
+        script=None,
+        workdir=None,
+        no_agent=False,
+        response_contract='{"required_patterns": ["preview"]}',
+    )
+
+    assert cron_cli.cron_create(args) == 0
+    assert captured["response_contract"] == {"required_patterns": ["preview"]}
+
+
+def test_cron_create_rejects_non_object_response_contract(monkeypatch, capsys):
+    monkeypatch.setattr(cron_cli, "_cron_api", lambda **kwargs: pytest.fail("must not run"))
+    args = SimpleNamespace(
+        schedule="every day",
+        prompt="refresh docs",
+        name=None,
+        deliver=None,
+        repeat=None,
+        skill=None,
+        skills=None,
+        script=None,
+        workdir=None,
+        no_agent=False,
+        response_contract="[]",
+    )
+
+    assert cron_cli.cron_create(args) == 1
+    assert "JSON object" in capsys.readouterr().out
+
+
 class TestCronRunBackgroundDispatch:
     """`hermes cron run` must not report 'failed' when the run was dispatched
     to the background delegation worker.

--- a/tests/hermes_cli/test_web_server_cron_profiles.py
+++ b/tests/hermes_cli/test_web_server_cron_profiles.py
@@ -167,6 +167,32 @@ def test_dashboard_create_reports_saved_but_unregistered(
     assert "private callback URL and token" not in str(exc_info.value.detail)
 
 
+def test_dashboard_create_forwards_response_contract(isolated_profiles, monkeypatch):
+    from hermes_cli import web_server
+
+    captured = {}
+    monkeypatch.setattr(
+        web_server,
+        "_call_cron_for_profile",
+        lambda profile, action, **kwargs: captured.update(
+            profile=profile, action=action, **kwargs
+        )
+        or {"id": "contract-job"},
+    )
+
+    job = web_server._create_cron_job_sync(
+        web_server.CronJobCreate(
+            prompt="managed by named profile",
+            schedule="every 1h",
+            response_contract={"required_patterns": ["preview"]},
+        ),
+        profile="worker_alpha",
+    )
+
+    assert job == {"id": "contract-job"}
+    assert captured["response_contract"] == {"required_patterns": ["preview"]}
+
+
 def test_notify_cron_provider_scopes_store_and_runtime_home_together(
     isolated_profiles,
     monkeypatch,

--- a/tests/tools/test_cronjob_tools.py
+++ b/tests/tools/test_cronjob_tools.py
@@ -246,6 +246,26 @@ class TestUnifiedCronjobTool:
         assert listing["jobs"][0]["name"] == "Server Check"
         assert listing["jobs"][0]["state"] == "scheduled"
 
+    def test_create_response_contract_is_exposed_in_job_details(self):
+        created = json.loads(
+            cronjob(
+                action="create",
+                prompt="Prepare the actual sleep calendar update.",
+                schedule="every 1h",
+                response_contract={
+                    "required_patterns": ["prepare_actual_sleep_calendar_update"],
+                    "forbidden_patterns": ["actual_sleep_context"],
+                },
+            )
+        )
+
+        assert created["success"] is True
+        assert created["job"]["response_contract"] == {
+            "required_patterns": ["prepare_actual_sleep_calendar_update"],
+            "forbidden_patterns": ["actual_sleep_context"],
+            "on_failure": "fail",
+        }
+
     def test_list_handles_partial_legacy_job_records(self):
         from cron.jobs import save_jobs
 

--- a/tests/tools/test_cronjob_tools.py
+++ b/tests/tools/test_cronjob_tools.py
@@ -261,8 +261,8 @@ class TestUnifiedCronjobTool:
 
         assert created["success"] is True
         assert created["job"]["response_contract"] == {
-            "required_patterns": ["prepare_actual_sleep_calendar_update"],
-            "forbidden_patterns": ["actual_sleep_context"],
+            "required_pattern_count": 1,
+            "forbidden_pattern_count": 1,
             "on_failure": "fail",
         }
 

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -654,7 +654,12 @@ def _format_job(job: Dict[str, Any]) -> Dict[str, Any]:
     if job.get("monitor_state"):
         result["monitor_state"] = job["monitor_state"]
     if job.get("response_contract"):
-        result["response_contract"] = job["response_contract"]
+        contract = job["response_contract"]
+        result["response_contract"] = {
+            "required_pattern_count": len(contract.get("required_patterns", [])),
+            "forbidden_pattern_count": len(contract.get("forbidden_patterns", [])),
+            "on_failure": contract.get("on_failure"),
+        }
     if job.get("no_agent"):
         result["no_agent"] = True
     if job.get("enabled_toolsets"):

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -638,6 +638,7 @@ def _format_job(job: Dict[str, Any]) -> Dict[str, Any]:
         "last_run_at": job.get("last_run_at"),
         "last_status": job.get("last_status"),
         "last_delivery_error": job.get("last_delivery_error"),
+        "last_response_contract_error": job.get("last_response_contract_error"),
         "enabled": job.get("enabled", True),
         # Derive from enabled so half-paused records never render as paused.
         "state": effective_job_state(job),
@@ -652,6 +653,8 @@ def _format_job(job: Dict[str, Any]) -> Dict[str, Any]:
         result["monitor_url"] = job["monitor_url"]
     if job.get("monitor_state"):
         result["monitor_state"] = job["monitor_state"]
+    if job.get("response_contract"):
+        result["response_contract"] = job["response_contract"]
     if job.get("no_agent"):
         result["no_agent"] = True
     if job.get("enabled_toolsets"):
@@ -1164,6 +1167,7 @@ def cronjob(
     attach_to_session: Optional[bool] = None,
     monitor_script: Optional[str] = None,
     monitor_url: Optional[str] = None,
+    response_contract: Optional[Dict[str, Any]] = None,
     task_id: str = None,
     session_id: Optional[str] = None,
 ) -> str:
@@ -1254,6 +1258,7 @@ def cronjob(
                     attach_to_session=attach_to_session,
                     monitor_script=_normalize_optional_job_value(monitor_script),
                     monitor_url=_normalize_optional_job_value(monitor_url),
+                    response_contract=response_contract,
                 )
             except CronSchedulerRegistrationError as exc:
                 _partial = exc.to_dict()
@@ -1476,6 +1481,8 @@ def cronjob(
                 updates["monitor_url"] = (
                     _normalize_optional_job_value(monitor_url) if monitor_url else None
                 )
+            if response_contract is not None:
+                updates["response_contract"] = response_contract
             if monitor_script is not None or monitor_url is not None:
                 eff_mon_script = (
                     updates["monitor_script"] if "monitor_script" in updates else job.get("monitor_script")
@@ -1624,6 +1631,28 @@ Scheduling from cron-run sessions is disabled by default and enabled via cron.al
                 "type": "string",
                 "description": "Optional http(s) URL used as the monitor source instead of a script — fetched with a bounded GET (30s timeout, 256KB cap) each tick. Same hash-suppression semantics as monitor_script. Mutually exclusive with monitor_script. On update, pass empty string to clear."
             },
+            "response_contract": {
+                "type": "object",
+                "properties": {
+                    "required_patterns": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                        "description": "Literal strings that must appear in the final response.",
+                    },
+                    "forbidden_patterns": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                        "description": "Literal strings that must not appear in the final response.",
+                    },
+                    "on_failure": {
+                        "type": "string",
+                        "enum": ["fail"],
+                        "default": "fail",
+                    },
+                },
+                "additionalProperties": False,
+                "description": "Optional fail-closed final-response check. A contract failure is stored separately and the invalid response is not delivered.",
+            },
             "no_agent": {
                 "type": "boolean",
                 "default": False,
@@ -1727,6 +1756,7 @@ registry.register(
         no_agent=args.get("no_agent"),
         monitor_script=args.get("monitor_script"),
         monitor_url=args.get("monitor_url"),
+        response_contract=args.get("response_contract"),
         task_id=kw.get("task_id"),
         session_id=kw.get("session_id"),
     ),

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -2245,6 +2245,11 @@ export interface CronJobMutation {
   context_from?: string[] | null;
   enabled_toolsets?: string[] | null;
   workdir?: string | null;
+  response_contract?: {
+    required_patterns?: string[];
+    forbidden_patterns?: string[];
+    on_failure?: "fail";
+  } | null;
 }
 
 export interface CronJob {
@@ -2275,6 +2280,12 @@ export interface CronJob {
   last_status?: string | null;
   last_error?: string | null;
   last_delivery_error?: string | null;
+  last_response_contract_error?: string | null;
+  response_contract?: {
+    required_patterns?: string[];
+    forbidden_patterns?: string[];
+    on_failure?: "fail";
+  } | null;
 }
 
 export interface CronDeliveryTarget {

--- a/web/src/lib/cron-job.test.ts
+++ b/web/src/lib/cron-job.test.ts
@@ -24,6 +24,7 @@ function form(overrides: Partial<CronJobFormState> = {}): CronJobFormState {
     context_from: "",
     enabled_toolsets: [],
     workdir: "",
+    response_contract: "",
     ...overrides,
   };
 }
@@ -68,7 +69,22 @@ describe("buildCronJobPayload", () => {
       context_from: null,
       enabled_toolsets: null,
       workdir: null,
+      response_contract: null,
     });
+  });
+
+  it("parses an editable response contract", () => {
+    const payload = buildCronJobPayload(
+      form({ response_contract: '{"required_patterns":["preview"]}' }),
+    );
+
+    expect(payload.response_contract).toEqual({ required_patterns: ["preview"] });
+  });
+
+  it("rejects a non-object response contract", () => {
+    expect(() => buildCronJobPayload(form({ response_contract: "[]" }))).toThrow(
+      "Response contract must be a JSON object",
+    );
   });
 });
 
@@ -96,6 +112,7 @@ describe("cronJobFormFromJob", () => {
       schedule_display: "every 1h",
       context_from: ["upstream-a", "upstream-b"],
       enabled_toolsets: ["web"],
+      response_contract: "",
     };
 
     expect(cronJobFormFromJob(job)).toMatchObject({
@@ -103,6 +120,16 @@ describe("cronJobFormFromJob", () => {
       context_from: "upstream-a\nupstream-b",
       enabled_toolsets: ["web"],
     });
+  });
+
+  it("formats a stored response contract for editing", () => {
+    const job: CronJob = {
+      id: "contract-job",
+      enabled: true,
+      response_contract: { required_patterns: ["preview"] },
+    };
+
+    expect(cronJobFormFromJob(job).response_contract).toContain("preview");
   });
 
   it("prefers one-shot run_at over the human display string", () => {

--- a/web/src/lib/cron-job.ts
+++ b/web/src/lib/cron-job.ts
@@ -14,6 +14,7 @@ export interface CronJobFormState {
   context_from: string;
   enabled_toolsets: string[];
   workdir: string;
+  response_contract: string;
 }
 
 /** Split a comma/newline list (or array) into trimmed, non-empty items. */
@@ -44,6 +45,20 @@ function asString(value: unknown): string {
   return typeof value === "string" ? value : "";
 }
 
+function responseContractToText(value: unknown): string {
+  return value && typeof value === "object" ? JSON.stringify(value, null, 2) : "";
+}
+
+function parseResponseContract(value: string): CronJobMutation["response_contract"] {
+  const text = value.trim();
+  if (!text) return null;
+  const parsed: unknown = JSON.parse(text);
+  if (!parsed || Array.isArray(parsed) || typeof parsed !== "object") {
+    throw new Error("Response contract must be a JSON object");
+  }
+  return parsed as CronJobMutation["response_contract"];
+}
+
 /** Build the create/update payload. Optional fields collapse to null so an
  * update explicitly clears them rather than leaving stale values. */
 export function buildCronJobPayload(form: CronJobFormState): CronJobMutation {
@@ -63,6 +78,7 @@ export function buildCronJobPayload(form: CronJobFormState): CronJobMutation {
     context_from: contextFrom.length > 0 ? contextFrom : null,
     enabled_toolsets: enabledToolsets.length > 0 ? enabledToolsets : null,
     workdir: optionalText(form.workdir),
+    response_contract: parseResponseContract(form.response_contract),
   };
 }
 
@@ -91,5 +107,6 @@ export function cronJobFormFromJob(job: CronJob): CronJobFormState {
     context_from: listToText(job.context_from),
     enabled_toolsets: splitCronList(job.enabled_toolsets),
     workdir: asString(job.workdir),
+    response_contract: responseContractToText(job.response_contract),
   };
 }

--- a/web/src/pages/CronPage.tsx
+++ b/web/src/pages/CronPage.tsx
@@ -147,6 +147,7 @@ function emptyCronJobForm(): CronJobEditorState {
     context_from: "",
     enabled_toolsets: [],
     workdir: "",
+    response_contract: "",
     scheduleState: { ...DEFAULT_SCHEDULE_STATE },
   };
 }
@@ -288,6 +289,17 @@ function CronAdvancedFields({
             value={form.workdir}
             onChange={(e) => update("workdir", e.target.value)}
             placeholder="/absolute/project/path"
+          />
+        </div>
+
+        <div className="grid gap-1">
+          <Label htmlFor={`${idPrefix}-response-contract`}>Response contract (JSON)</Label>
+          <textarea
+            id={`${idPrefix}-response-contract`}
+            className="flex min-h-[96px] w-full border border-border bg-background/40 px-3 py-2 text-xs font-courier shadow-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-foreground/30 focus-visible:border-foreground/25"
+            placeholder='{"required_patterns":["preview"],"forbidden_patterns":["error"]}'
+            value={form.response_contract}
+            onChange={(e) => update("response_contract", e.target.value)}
           />
         </div>
 
@@ -685,7 +697,13 @@ export default function CronPage() {
   }, [resourceProfile]);
 
   const handleCreate = async () => {
-    const payload = buildCronJobPayloadFromEditor(createForm);
+    let payload;
+    try {
+      payload = buildCronJobPayloadFromEditor(createForm);
+    } catch (e) {
+      showToast(`${t.config.failedToSave}: ${e}`, "error");
+      return;
+    }
     if (
       !payload.schedule ||
       (!payload.no_agent && !cronJobHasExecutionContent(payload))
@@ -713,7 +731,13 @@ export default function CronPage() {
 
   const handleEdit = async () => {
     if (!editJob) return;
-    const payload = buildCronJobPayloadFromEditor(editForm);
+    let payload;
+    try {
+      payload = buildCronJobPayloadFromEditor(editForm);
+    } catch (e) {
+      showToast(`${t.config.failedToSave}: ${e}`, "error");
+      return;
+    }
     if (
       !payload.schedule ||
       (!payload.no_agent && !cronJobHasExecutionContent(payload))


### PR DESCRIPTION
## Summary
- Add opt-in per-job response contracts with required and forbidden literal patterns.
- Fail closed before output persistence or delivery, record a distinct response_contract_failed status, and redact configured literals from public tool summaries.
- Expose contract declaration through the cron tool, CLI, API, and dashboard.

Closes #87647

## Validation
- Targeted cron, API, CLI, and dashboard suite: 215 passed.
- Public cron tool smoke test: create/list contract plus required and malformed-contract validation.
- Independent final review passed across code quality, security, requirements, test coverage, and design.

## Validation gap
Frontend TypeScript/Vitest checks could not run locally because the installed Node v25.9.0 fails this repository engine constraint (Node >=22.22.0). Frontend contract handling was reviewed and has dedicated tests.