### PR TITLE
fix(desktop): dedupe auto-speak when reply id changes after stream

### DIFF
--- a/apps/desktop/src/app/chat/composer/hooks/auto-speak-dedupe.test.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/auto-speak-dedupe.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  clearSpokenReplyBook,
+  createSpokenReplyBook,
+  isAssistantReplyAlreadySpoken,
+  markAssistantReplySpoken
+} from './auto-speak-dedupe'
+
+describe('auto-speak-dedupe', () => {
+  it('marks and matches by message id', () => {
+    const book = createSpokenReplyBook()
+    markAssistantReplySpoken(book, { id: 'stream-1', text: 'hello' })
+    expect(
+      isAssistantReplyAlreadySpoken(book, { id: 'stream-1', pending: false, text: 'hello' })
+    ).toBe(true)
+    expect(
+      isAssistantReplyAlreadySpoken(book, { id: 'other', pending: false, text: 'different' })
+    ).toBe(false)
+  })
+
+  it('treats completed same-text under a new id as already spoken (stream→final)', () => {
+    const book = createSpokenReplyBook()
+    markAssistantReplySpoken(book, { id: 'stream-temp', text: 'Hello world' })
+
+    // Final hydration replaces the id; body unchanged.
+    expect(
+      isAssistantReplyAlreadySpoken(book, {
+        id: 'final-permanent',
+        pending: false,
+        text: 'Hello world'
+      })
+    ).toBe(true)
+  })
+
+  it('does not block a later distinct reply with different text', () => {
+    const book = createSpokenReplyBook()
+    markAssistantReplySpoken(book, { id: 'a', text: 'first answer' })
+
+    expect(
+      isAssistantReplyAlreadySpoken(book, {
+        id: 'b',
+        pending: false,
+        text: 'second answer'
+      })
+    ).toBe(false)
+  })
+
+  it('does not text-dedupe while the bubble is still pending/streaming', () => {
+    const book = createSpokenReplyBook()
+    markAssistantReplySpoken(book, { id: 'old', text: 'partial' })
+
+    // Streaming growth can share a prefix with a prior mark if mis-ordered;
+    // only completed bubbles use text equality.
+    expect(
+      isAssistantReplyAlreadySpoken(book, {
+        id: 'stream-2',
+        pending: true,
+        text: 'partial'
+      })
+    ).toBe(false)
+  })
+
+  it('clearSpokenReplyBook resets id and text memory (session switch)', () => {
+    const book = createSpokenReplyBook()
+    markAssistantReplySpoken(book, { id: 'a', text: 'hi' })
+    clearSpokenReplyBook(book)
+    expect(
+      isAssistantReplyAlreadySpoken(book, { id: 'a', pending: false, text: 'hi' })
+    ).toBe(false)
+  })
+})

--- a/apps/desktop/src/app/chat/composer/hooks/auto-speak-dedupe.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/auto-speak-dedupe.ts
@@ -1,0 +1,59 @@
+/**
+ * Dedupes auto-speak / voice-conversation "already spoken" tracking.
+ *
+ * Desktop often re-emits the same completed assistant bubble under a new id
+ * when stream → final hydration lands. Id-only tracking then re-fires
+ * `/api/audio/speak-stream` after the first clip goes idle (~seconds later).
+ */
+
+export type SpokenReplyBook = {
+  ids: Set<string>
+  /** Full speakable text of the last completed reply we marked spoken. */
+  text: string | null
+}
+
+export function createSpokenReplyBook(): SpokenReplyBook {
+  return { ids: new Set(), text: null }
+}
+
+export function clearSpokenReplyBook(book: SpokenReplyBook): void {
+  book.ids.clear()
+  book.text = null
+}
+
+export function markAssistantReplySpoken(
+  book: SpokenReplyBook,
+  reply: { id: string; text?: string | null }
+): void {
+  book.ids.add(reply.id)
+  const text = reply.text?.trim()
+  if (text) {
+    book.text = text
+  }
+}
+
+/**
+ * True when this assistant bubble should not be spoken again.
+ * - Same message id already spoken, or
+ * - Completed bubble whose text matches the last spoken completed text
+ *   (stream id replaced by final id with identical body).
+ */
+export function isAssistantReplyAlreadySpoken(
+  book: SpokenReplyBook,
+  reply: { id: string; pending?: boolean; text: string }
+): boolean {
+  if (book.ids.has(reply.id)) {
+    return true
+  }
+
+  const text = reply.text.trim()
+  if (!text) {
+    return false
+  }
+
+  if (!reply.pending && book.text !== null && text === book.text) {
+    return true
+  }
+
+  return false
+}

--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-voice.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-voice.ts
@@ -17,6 +17,12 @@ import { onComposerVoiceToggleRequest } from '../focus'
 import { useComposerScope } from '../scope'
 import type { ChatBarProps } from '../types'
 
+import {
+  clearSpokenReplyBook,
+  createSpokenReplyBook,
+  isAssistantReplyAlreadySpoken,
+  markAssistantReplySpoken
+} from './auto-speak-dedupe'
 import { useAutoSpeakReplies } from './use-auto-speak-replies'
 import { useVoiceConversation } from './use-voice-conversation'
 import { useVoiceRecorder } from './use-voice-recorder'
@@ -62,9 +68,17 @@ export function useComposerVoice({
   // A tile's composer speaks ITS transcript, not the primary chat's.
   const { $messages } = useComposerScope()
   const [voiceConversationActive, setVoiceConversationActive] = useState(false)
-  const lastSpokenIdRef = useRef<string | null>(null)
+  // Id + completed-text book: stream→final hydration changes message ids while
+  // the body stays the same; id-only tracking double-opens speak-stream (#87652).
+  const spokenBookRef = useRef(createSpokenReplyBook())
   const ownsWakeIndicatorRef = useRef(false)
   const voiceStartRequest = useStore($voiceConversationStartRequest)
+  const spokenSessionRef = useRef(sessionId)
+
+  if (spokenSessionRef.current !== sessionId) {
+    spokenSessionRef.current = sessionId
+    clearSpokenReplyBook(spokenBookRef.current)
+  }
 
   const { dictate, voiceActivityState, voiceStatus } = useVoiceRecorder({
     focusInput,
@@ -78,7 +92,7 @@ export function useComposerVoice({
     const messages = $messages.get()
     const last = messages.findLast(m => m.role === 'assistant' && !m.hidden)
 
-    if (!last || last.id === lastSpokenIdRef.current) {
+    if (!last) {
       return null
     }
 
@@ -88,11 +102,19 @@ export function useComposerVoice({
       return null
     }
 
-    return {
+    const reply = {
       id: last.id,
       pending: Boolean(last.pending),
       text
     }
+
+    if (isAssistantReplyAlreadySpoken(spokenBookRef.current, reply)) {
+      // Migrate book if final id replaced stream id for the same body.
+      markAssistantReplySpoken(spokenBookRef.current, reply)
+      return null
+    }
+
+    return reply
   }
 
   /**
@@ -100,14 +122,23 @@ export function useComposerVoice({
    * in order — narration interims AND the final answer, not just whichever
    * bubble happens to be last. See `collectUnspokenTurnSpeech`.
    */
-  const pendingTurnResponse = () => collectUnspokenTurnSpeech($messages.get(), lastSpokenIdRef.current)
+  const pendingTurnResponse = () => {
+    const book = spokenBookRef.current
+    // Prefer the most recently marked id when present; text-dedupe is handled
+    // when consuming individual bubbles via auto-speak.
+    const lastId = book.ids.size > 0 ? [...book.ids].at(-1)! : null
+    return collectUnspokenTurnSpeech($messages.get(), lastId)
+  }
 
   const consumePendingResponse = () => {
     const messages = $messages.get()
     const last = messages.findLast(m => m.role === 'assistant' && !m.hidden)
 
     if (last) {
-      lastSpokenIdRef.current = last.id
+      markAssistantReplySpoken(spokenBookRef.current, {
+        id: last.id,
+        text: chatMessageText(last)
+      })
     }
   }
 


### PR DESCRIPTION
## Problem

With Desktop **Read responses aloud** enabled, one assistant reply opens **two** `/api/audio/speak-stream` WebSockets ~4s apart and Edge TTS generates twice (reporter logs on Windows + remote backend).

## Root cause

`useComposerVoice` tracked only `lastSpokenId`. After stream completion, message hydration often **replaces the assistant id** while keeping the same body. Auto-speak:

1. Marks the stream id spoken and opens speak-stream  
2. Playback ends → `$voicePlayback` idle re-arms the selector  
3. Final id ≠ lastSpokenId → treated as a new reply → second WebSocket  

## Fix

- Small pure book (`auto-speak-dedupe.ts`): spoken **ids** + last completed **text**
- Skip completed replies whose text already matches the last spoken body (stream→final)
- Migrate the final id into the book when text-deduped
- Clear the book on session switch

## Why it matters

Double TTS is user-visible (hears every reply twice) and doubles remote speak-stream load.

## Test plan

```bash
cd apps/desktop
npm run test:ui -- src/app/chat/composer/hooks/auto-speak-dedupe.test.ts
```

**5 passed** @ `a6c3056e7`

## Risk

Low. Only widens “already spoken” detection for completed same-text id swaps. Distinct next replies still speak. Pending/streaming bubbles do not use text equality.

## Closest work

`none found` open PRs on #87652 / duplicate speak-stream.

Fixes #87652

### Acceptance retest (2026-08-18)
Rebased onto current `main`. Mini proof @ `24ed9d3de`: apps/desktop auto-speak-dedupe.test.ts — 5 passed.
