### PR TITLE
fix(desktop): hydrate unscoped cross-profile sessions

### DIFF
--- a/hermes_cli/web_routers/sessions.py
+++ b/hermes_cli/web_routers/sessions.py
@@ -22,6 +22,7 @@ from fastapi import APIRouter, HTTPException, Query, Request  # noqa: F401
 from fastapi.encoders import jsonable_encoder
 from fastapi.responses import StreamingResponse
 
+from hermes_cli import profiles as profiles_mod
 from hermes_cli.web_deps import late
 from hermes_cli.web_models import (
     BulkDeleteSessions,
@@ -613,8 +614,8 @@ async def get_session_messages(
             detail="order must be one of: oldest, latest",
         )
 
-    def _read():
-        db = _open_session_db_for_profile(profile, read_only=True)
+    def _read_from(candidate_profile: Optional[str]):
+        db = _open_session_db_for_profile(candidate_profile, read_only=True)
         try:
             sid = db.resolve_session_id(session_id)
             if not sid:
@@ -638,11 +639,36 @@ async def get_session_messages(
         finally:
             db.close()
 
-    result = await asyncio.to_thread(_read)
+    def _read():
+        result = _read_from(profile)
+        if result is not None or profile:
+            return profile, result
+
+        # Backward compatibility for remote Desktop clients that omit the
+        # owning profile when opening a cross-profile sidebar/cron session.
+        # Search only after the launch DB misses and accept only a unique match.
+        matches = []
+        try:
+            infos = profiles_mod.list_profiles()
+        except Exception:
+            infos = []
+        for info in infos:
+            candidate = str(info.name)
+            try:
+                candidate_result = _read_from(candidate)
+            except (HTTPException, OSError):
+                continue
+            if candidate_result is not None:
+                matches.append((candidate, candidate_result))
+                if len(matches) > 1:
+                    return None, None
+        return matches[0] if matches else (None, None)
+
+    resolved_profile, result = await asyncio.to_thread(_read)
     if result is None:
         raise HTTPException(status_code=404, detail="Session not found")
     sid, _limit, messages = result
-    return {
+    response = {
         "session_id": sid,
         "messages": messages,
         "pagination": {
@@ -652,6 +678,9 @@ async def get_session_messages(
             "returned": len(messages),
         },
     }
+    if resolved_profile:
+        response["profile"] = resolved_profile
+    return response
 
 
 @manage_router.delete("/api/sessions/{session_id}")

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -1892,6 +1892,36 @@ class TestWebServerEndpoints:
         assert payload["limit"] == 3
         assert len(payload["sessions"]) == 3
 
+    def test_get_session_messages_auto_resolves_unique_cross_profile_session(self, monkeypatch):
+        """Remote Desktop clients may omit ``profile`` for sidebar cron rows."""
+        from hermes_state import SessionDB
+        from hermes_cli import profiles as profiles_mod
+
+        worker_home = profiles_mod.get_profile_dir("worker")
+        worker_home.mkdir(parents=True)
+        worker_db = SessionDB(db_path=worker_home / "state.db")
+        try:
+            worker_db.create_session(session_id="remote-cron-only", source="cron")
+            worker_db.append_message(
+                "remote-cron-only", role="assistant", content="visible remotely"
+            )
+        finally:
+            worker_db.close()
+
+        monkeypatch.setattr(
+            profiles_mod,
+            "list_profiles",
+            lambda: [SimpleNamespace(name="worker", path=worker_home)],
+        )
+
+        response = self.client.get("/api/sessions/remote-cron-only/messages")
+
+        assert response.status_code == 200
+        assert response.json()["profile"] == "worker"
+        assert [message["content"] for message in response.json()["messages"]] == [
+            "visible remotely"
+        ]
+
     def test_get_session_messages_rejects_negative_limit(self):
         """limit=-1 previously bypassed the documented 500-row clamp because
         min(-1, 500) == -1, which SQLite treats as 'no limit'."""


### PR DESCRIPTION
## Summary

- fall back across local profile session stores when an unscoped transcript request misses the launch profile
- accept only a unique match, so ambiguous IDs still return 404 rather than hydrating the wrong agent
- return the resolved owning profile for client reconciliation

## Why

Remote Desktop clients can receive profile-tagged cron/sidebar rows from the machine dashboard but issue `GET /api/sessions/<id>/messages` without the `profile` query parameter. The dashboard then searches only its launch profile: the primary profile works, while every other agent opens as a blank transcript. Explicit `?profile=<agent>` succeeds.

The server fallback is backward compatibility for deployed Desktop bundles and also protects mixed-version client/server upgrades. Explicitly scoped requests retain the existing fast path.

## Tests

```text
uv run --with pytest --with fastapi --with httpx pytest \
  tests/hermes_cli/test_web_server.py::TestWebServerEndpoints::test_get_session_messages_auto_resolves_unique_cross_profile_session \
  tests/hermes_cli/test_web_server.py::TestWebServerEndpoints::test_get_session_messages_rejects_negative_limit \
  tests/hermes_cli/test_web_server.py::TestWebServerEndpoints::test_get_session_messages_omitted_limit_defaults_to_500 -q

3 passed
```