### PR TITLE
fix(ntfy): support YAML platform configuration

### DIFF
--- a/plugins/platforms/ntfy/adapter.py
+++ b/plugins/platforms/ntfy/adapter.py
@@ -576,6 +576,34 @@ async def _standalone_send(
         return {"error": f"ntfy standalone send failed: {e}"}
 
 
+def _apply_yaml_config(yaml_cfg: dict, ntfy_cfg: dict) -> Optional[dict]:
+    """Bridge ``config.yaml`` ``platforms.ntfy.extra`` into the ``NTFY_*``
+    env variables the adapter reads, so a config.yaml-only setup (no ``NTFY_*``
+    env vars) passes ``check_requirements`` and connects at gateway startup.
+
+    Implements the ``apply_yaml_config_fn`` contract (see
+    ``gateway.platform_registry.PlatformEntry``).  Mirrors the
+    Slack/Telegram/Buzz pattern.  Explicit environment variables win over
+    YAML — every assignment is guarded by ``not os.getenv(...)`` so an env
+    override survives a config.yaml update.  Token/secret material
+    (``token``) is never bridged from config.yaml into the environment.
+    """
+    if not isinstance(ntfy_cfg, dict):
+        return None
+    extra = ntfy_cfg.get("extra", ntfy_cfg) or {}
+    if not isinstance(extra, dict):
+        return None
+    for src, env in (
+        ("topic", "NTFY_TOPIC"),
+        ("server", "NTFY_SERVER_URL"),
+        ("publish_topic", "NTFY_PUBLISH_TOPIC"),
+    ):
+        val = extra.get(src)
+        if val is not None and str(val).strip() and not os.getenv(env):
+            os.environ[env] = str(val).strip()
+    return None
+
+
 def register(ctx) -> None:
     """Plugin entry point — called by the Hermes plugin system at startup."""
     ctx.register_platform(
@@ -591,6 +619,11 @@ def register(ctx) -> None:
         # env-only setups show up in `hermes gateway status` without
         # instantiating the HTTP client.
         env_enablement_fn=_env_enablement,
+        # Bridge config.yaml platforms.ntfy.extra -> NTFY_* env vars so a
+        # config.yaml-only setup passes check_fn at gateway startup (secret
+        # token stays out of the bridge). Mirrors the Slack/Telegram/Buzz
+        # pattern; env vars win over YAML.
+        apply_yaml_config_fn=_apply_yaml_config,
         # Cron home-channel delivery support — `deliver=ntfy` cron jobs
         # route to NTFY_HOME_CHANNEL when set.
         cron_deliver_env_var="NTFY_HOME_CHANNEL",

--- a/tests/gateway/test_ntfy_plugin.py
+++ b/tests/gateway/test_ntfy_plugin.py
@@ -15,6 +15,7 @@ the ``platform_registry``.
 from __future__ import annotations
 
 import asyncio
+import os
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -489,5 +490,68 @@ class TestTruncateHelper:
 
     def test_short_message_passes_through(self):
         assert _ntfy._truncate_body("hi", context="test") == b"hi"
+
+
+# ---------------------------------------------------------------------------
+# 13. _apply_yaml_config — config.yaml bridge (apply_yaml_config_fn contract)
+# ---------------------------------------------------------------------------
+
+
+class TestApplyYamlConfig:
+    """``_apply_yaml_config`` bridges ``platforms.ntfy.extra`` into ``NTFY_*``
+    env vars (the ``apply_yaml_config_fn`` contract), so a config.yaml-only
+    setup passes ``check_requirements`` at gateway startup. Explicit env vars
+    win over YAML, and token/secret material is never bridged."""
+
+    @pytest.fixture(autouse=True)
+    def _clean_env(self, monkeypatch):
+        for var in (
+            "NTFY_TOPIC",
+            "NTFY_SERVER_URL",
+            "NTFY_PUBLISH_TOPIC",
+            "NTFY_TOKEN",
+        ):
+            monkeypatch.delenv(var, raising=False)
+
+    def test_yaml_topic_satisfies_check_requirements(self, monkeypatch):
+        # No NTFY_TOPIC in env; config carries platforms.ntfy.extra.topic.
+        monkeypatch.setattr(_ntfy, "HTTPX_AVAILABLE", True)
+        assert check_requirements() is False  # env-only gate fails without env
+        _ntfy._apply_yaml_config({}, {"extra": {"topic": "yaml-only-topic"}})
+        assert os.getenv("NTFY_TOPIC") == "yaml-only-topic"
+        assert check_requirements() is True
+
+    def test_env_precedence_over_yaml(self, monkeypatch):
+        monkeypatch.setenv("NTFY_TOPIC", "env-topic")
+        _ntfy._apply_yaml_config({}, {"extra": {"topic": "yaml-topic"}})
+        assert os.getenv("NTFY_TOPIC") == "env-topic"
+
+    def test_server_and_publish_topic_bridge(self):
+        _ntfy._apply_yaml_config(
+            {}, {"extra": {"server": "https://ntfy.example", "publish_topic": "pub"}}
+        )
+        assert os.getenv("NTFY_SERVER_URL") == "https://ntfy.example"
+        assert os.getenv("NTFY_PUBLISH_TOPIC") == "pub"
+
+    def test_token_never_bridged(self):
+        _ntfy._apply_yaml_config({}, {"extra": {"topic": "t", "token": "secret-token"}})
+        assert os.getenv("NTFY_TOPIC") == "t"
+        assert "NTFY_TOKEN" not in os.environ
+
+    def test_malformed_extra_handled_safely(self):
+        assert _ntfy._apply_yaml_config({}, {"extra": "not-a-dict"}) is None
+        assert _ntfy._apply_yaml_config({}, {"extra": None}) is None
+        assert _ntfy._apply_yaml_config({}, None) is None
+        assert os.getenv("NTFY_TOPIC") is None
+
+    def test_register_exposes_bridge(self):
+        captured = {}
+
+        class _Ctx:
+            def register_platform(self, **kwargs):
+                captured.update(kwargs)
+
+        register(_Ctx())
+        assert captured.get("apply_yaml_config_fn") is _ntfy._apply_yaml_config
 
 


### PR DESCRIPTION
## What does this PR do?

The ntfy platform adapter currently relies on env-backed values such as
`NTFY_TOPIC`, but unlike the other built-in platform adapters it does not
register an `apply_yaml_config_fn`.

As a result, an ntfy setup configured only through
`platforms.ntfy.extra` does not populate the env-backed values used by the
adapter's requirement/startup path.

This change adds the missing native YAML-config bridge for ntfy using the
existing `apply_yaml_config_fn` plugin contract.

## Changes

- Add `_apply_yaml_config()` to the ntfy adapter.
- Bridge supported non-secret values from `platforms.ntfy.extra`:
  - `topic` -> `NTFY_TOPIC`
  - `server` -> `NTFY_SERVER_URL`
  - `publish_topic` -> `NTFY_PUBLISH_TOPIC`
- Preserve explicit environment variables when already set; env values take
  precedence over YAML.
- Do not copy `token` or other secret material from YAML into the process
  environment.
- Handle malformed/non-dict `extra` configuration without crashing.
- Register the bridge through `apply_yaml_config_fn` in
  `ctx.register_platform()`.

## Why?

Hermes already provides a native `apply_yaml_config_fn` hook for platform
adapters. Other built-in adapters use this hook to translate YAML
configuration into the values their runtime paths consume.

ntfy was missing that bridge, so a YAML-only topic configuration could not
satisfy its env-backed requirement check.

This keeps ntfy aligned with the existing platform-plugin configuration
contract without introducing ntfy-specific core changes.

## Tests

Baseline on pristine upstream:

- The focused YAML-bridge tests fail because the ntfy adapter has no
  `_apply_yaml_config` hook.

After the change:

- Focused YAML bridge tests: **6/6 passed**
- Full `tests/gateway/test_ntfy_plugin.py`: **36/36 passed**
- Official `scripts/run_tests.sh tests/gateway/test_ntfy_plugin.py`:
  **36 passed, exit 0**
- `scripts/check-windows-footguns.py`: **passed**, no findings in the two
  changed files

Tests cover:

- YAML-only topic configuration reaching the env-backed requirement path
- environment precedence over YAML
- server and publish-topic bridging
- token/secret non-bridging
- malformed config handling
- native plugin registration of `apply_yaml_config_fn`

No live ntfy network requests are made by these tests.

## Type of Change

- [x] Bug fix / configuration consistency improvement

## Platform

Tested on Windows 11.

The change uses the existing cross-platform Hermes platform-plugin
configuration contract; no Linux/macOS runtime testing is claimed here.
