### PR TITLE
fix(agent): apply large-context watchdog accommodations to all codex_responses transports

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1048,7 +1048,7 @@ def _resolve_nonstream_watchdogs(agent, api_kwargs: dict) -> _NonStreamWatchdogs
     openai_codex_backend = _is_openai_codex_backend(agent)
     est_tokens = estimate_request_context_tokens(api_kwargs)
     codex_floor = 0.0
-    if codex and openai_codex_backend:
+    if codex:
         # Raise the stale floor for large payloads so healthy gateway-scale
         # requests aren't aborted mid-prefill.
         codex_floor = openai_codex_stale_timeout_floor(est_tokens)
@@ -1070,20 +1070,20 @@ def _resolve_nonstream_watchdogs(agent, api_kwargs: dict) -> _NonStreamWatchdogs
     ttfb_timeout = env_float("HERMES_CODEX_TTFB_TIMEOUT_SECONDS", 120.0)
     if ttfb_timeout <= 0:
         ttfb_enabled = False
-    elif openai_codex_backend:
+    elif codex:
         # Large requests legitimately spend tens of seconds in admission/prefill before the
         # first SSE event: scale the cutoff up to the idle default unless TTFB_STRICT is set.
         disable_above = env_float("HERMES_CODEX_TTFB_DISABLE_ABOVE_TOKENS", 10_000.0)
         strict = os.environ.get("HERMES_CODEX_TTFB_STRICT", "").strip().lower() in {"1", "true", "yes", "on"}
         if not strict and disable_above > 0 and est_tokens >= disable_above and ttfb_timeout < idle_default:
-            logger.info("Scaling openai-codex no-event TTFB watchdog from %.0fs to %.0fs "
+            logger.info("Scaling codex-responses no-event TTFB watchdog from %.0fs to %.0fs "
                 "for large request (context=~%s tokens >= %.0f). "
                 "Set HERMES_CODEX_TTFB_STRICT=1 to keep the smaller cutoff.", ttfb_timeout, idle_default,
                 f"{est_tokens:,}", disable_above)
             ttfb_timeout = idle_default
         ttfb_cap = env_float("HERMES_CODEX_TTFB_MAX_SECONDS", 120.0)
         if ttfb_cap > 0 and ttfb_timeout > ttfb_cap:
-            logger.info("Capping openai-codex no-event TTFB timeout from %.0fs to %.0fs "
+            logger.info("Capping codex-responses no-event TTFB timeout from %.0fs to %.0fs "
                 "(context=~%s tokens). Set HERMES_CODEX_TTFB_MAX_SECONDS to tune.", ttfb_timeout, ttfb_cap,
                 f"{est_tokens:,}")
             ttfb_timeout = ttfb_cap

--- a/tests/agent/test_responses_watchdog_accommodations.py
+++ b/tests/agent/test_responses_watchdog_accommodations.py
@@ -1,0 +1,136 @@
+"""Regression tests for #86444 - large-context watchdog accommodations for codex_responses transports.
+
+Ensures:
+1. xAI Responses transport (api_mode="codex_responses", provider="xai-oauth") receives
+   the large-context stale timeout floor (e.g. 1200s at >100K tokens, 900s at >50K tokens)
+   in interruptible_api_call. A baseline short timeout of 0.2s is elevated so a 0.5s call succeeds without stale_call_kill.
+2. Large requests scale TTFB timeout for xai-oauth (codex_responses) instead of killing at a short TTFB cutoff.
+"""
+
+from __future__ import annotations
+
+import sys
+import time
+import types
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+sys.modules.setdefault("fire", types.SimpleNamespace(Fire=lambda *a, **k: None))
+sys.modules.setdefault("firecrawl", types.SimpleNamespace(Firecrawl=object))
+sys.modules.setdefault("fal_client", types.SimpleNamespace())
+
+
+def _make_mock_agent(provider="xai-oauth", api_mode="codex_responses", base_url="https://api.x.ai/v1"):
+    agent = MagicMock()
+    agent.provider = provider
+    agent.api_mode = api_mode
+    agent.base_url = base_url
+    agent._base_url_lower = base_url.lower()
+    agent._base_url_hostname = "api.x.ai"
+    agent._emit_status = lambda *a, **k: None
+    agent._buffer_status = lambda *a, **k: None
+    agent._touch_activity = lambda *a, **k: None
+    agent._codex_stream_last_event_ts = None
+    agent._interrupt_requested = False
+    agent.timeout = 180.0
+    agent._compute_non_stream_stale_timeout = lambda api_kwargs: 0.2
+    return agent
+
+
+def test_xai_responses_receives_stale_timeout_floor_in_api_call(monkeypatch):
+    """interruptible_api_call elevates stale timeout to context floor (>=900s) for xai-oauth codex_responses.
+    
+    When baseline _compute_non_stream_stale_timeout is 0.2s and TTFB watchdog is disabled (0),
+    a 0.5s execution would fail with stale_call_kill on base (stale timeout at 0.2s), but passes when the floor elevates it to >=900s.
+    """
+    from agent import chat_completion_helpers as h
+
+    agent = _make_mock_agent(provider="xai-oauth", api_mode="codex_responses", base_url="https://api.x.ai/v1")
+    assert h._is_openai_codex_backend(agent) is False
+
+    monkeypatch.setenv("HERMES_CODEX_TTFB_TIMEOUT_SECONDS", "0")
+    closes = []
+    monkeypatch.setattr(agent, "_create_request_openai_client", lambda **k: SimpleNamespace())
+    monkeypatch.setattr(agent, "_close_request_openai_client", lambda *a, **k: None)
+    monkeypatch.setattr(
+        agent, "_abort_request_openai_client",
+        lambda c, reason=None: closes.append(reason),
+    )
+
+    # 65k tokens estimate -> floor is >=900.0s
+    large_text = "word " * 65_000
+    api_kwargs = {"messages": [{"role": "user", "content": large_text}], "stream": False}
+
+    sentinel = SimpleNamespace(ok=True)
+    stop = {"flag": False}
+
+    def fake_hang_or_delay(api_kwargs, client=None, on_first_delta=None):
+        deadline = time.time() + 0.5
+        while time.time() < deadline and not stop["flag"] and not agent._interrupt_requested:
+            time.sleep(0.02)
+        if "stale_call_kill" in closes:
+            raise RuntimeError("aborted by stale kill")
+        return sentinel
+
+    monkeypatch.setattr(agent, "_run_codex_stream", fake_hang_or_delay)
+
+    try:
+        res = h.interruptible_api_call(agent, api_kwargs)
+        assert res is sentinel
+        assert "stale_call_kill" not in closes
+    finally:
+        stop["flag"] = True
+
+
+def test_xai_responses_ttfb_scaled_for_large_requests(monkeypatch):
+    """Large requests scale TTFB timeout for xai-oauth (codex_responses) instead of killing at small TTFB cutoff."""
+    from agent import chat_completion_helpers as h
+
+    agent = _make_mock_agent(provider="xai-oauth", api_mode="codex_responses", base_url="https://api.x.ai/v1")
+    assert h._is_openai_codex_backend(agent) is False
+
+    monkeypatch.setenv("HERMES_CODEX_TTFB_TIMEOUT_SECONDS", "0.2")
+
+    closes = []
+    monkeypatch.setattr(agent, "_create_request_openai_client", lambda **k: SimpleNamespace())
+    monkeypatch.setattr(agent, "_close_request_openai_client", lambda *a, **k: None)
+    monkeypatch.setattr(
+        agent, "_abort_request_openai_client",
+        lambda c, reason=None: closes.append(reason),
+    )
+
+    # 1. Small request (<10k tokens) should trip TTFB watchdog at 0.2s
+    stop_small = {"flag": False}
+
+    def fake_hang_small(api_kwargs, client=None, on_first_delta=None):
+        deadline = time.time() + 5
+        while time.time() < deadline and not stop_small["flag"] and not agent._interrupt_requested:
+            time.sleep(0.02)
+        raise RuntimeError("hang")
+
+    monkeypatch.setattr(agent, "_run_codex_stream", fake_hang_small)
+
+    try:
+        with pytest.raises(TimeoutError):
+            h.interruptible_api_call(agent, {"messages": [{"role": "user", "content": "hello"}], "stream": True})
+        assert "codex_ttfb_kill" in closes
+    finally:
+        stop_small["flag"] = True
+
+    # 2. Large request (>50k tokens) scales TTFB timeout to 120s, so it does NOT trip at 0.2s
+    closes.clear()
+    large_text = "word " * 65_000
+    stop_large = {"flag": False}
+
+    def fake_stream_delayed(api_kwargs, client=None, on_first_delta=None):
+        # Sleeps for 0.5s (longer than the initial 0.2s TTFB cutoff)
+        time.sleep(0.5)
+        return SimpleNamespace(ok=True)
+
+    monkeypatch.setattr(agent, "_run_codex_stream", fake_stream_delayed)
+
+    result = h.interruptible_api_call(agent, {"messages": [{"role": "user", "content": large_text}], "stream": True})
+    assert result.ok is True
+    assert "codex_ttfb_kill" not in closes


### PR DESCRIPTION
## What does this PR do?

In `agent/chat_completion_helpers.py`, large-context watchdog accommodations (`openai_codex_stale_timeout_floor()`, `_codex_hard_timeout`, and TTFB large-request timeout auto-scaling via `HERMES_CODEX_TTFB_DISABLE_ABOVE_TOKENS`) were gated on `_openai_codex_backend = _is_openai_codex_backend(agent)`.

While `_codex_watchdog_enabled` correctly activates for all `api_mode == "codex_responses"` transports (including xAI OAuth / Grok via `https://api.x.ai/v1`), the accompanying accommodations were skipped for non-OpenAI Responses API backends. Consequently, large reasoning requests (e.g. `grok-4.5` at ~88k–95k tokens of context with `reasoning_effort: high`) were aborted after 120s by the unscaled TTFB/stale watchdogs even when the model was actively generating.

This PR applies the large-context stale timeout floor, the hard ceiling backstop, and the large-request TTFB auto-scaling to all `codex_responses` transports (`_codex_watchdog_enabled`).

## Related Issue

Fixes #86444

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/chat_completion_helpers.py`: In `interruptible_api_call`, gate `openai_codex_stale_timeout_floor()`, `_codex_hard_timeout`, and TTFB large-request timeout auto-scaling on `_codex_watchdog_enabled` rather than `_openai_codex_backend`.
- `agent/chat_completion_helpers.py`: Updated log messages to refer to `codex-responses` instead of `openai-codex`.
- `tests/agent/test_responses_watchdog_accommodations.py`: Added regression test suite proving stale timeout floor elevation and TTFB large-request scaling for `xai-oauth` and non-OpenAI Responses API transports (verified to fail on exact base `56526bc0d3` and pass on `a75c3d7ec6`).

## How to Test

Run the regression suite covering stale timeout floor elevation and TTFB large-request scaling for xAI OAuth and non-OpenAI Responses API transports:

```bash
pytest tests/agent/test_responses_watchdog_accommodations.py tests/agent/test_codex_ttfb_watchdog.py
```

The tests assert that `openai_codex_stale_timeout_floor` and TTFB auto-scaling apply for any `api_mode == "codex_responses"` transport, not just OpenAI backends.

## Checklist

### Code
- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15.7 (darwin 24.6.0)

### Documentation & Housekeeping
- [x] I've considered cross-platform impact (Windows, macOS, Linux) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) - or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior - or N/A