### PR TITLE
feat(desktop): add wrap-lines toggle to the review diff pane

### DIFF
--- a/apps/desktop/src/app/right-sidebar/review/index.tsx
+++ b/apps/desktop/src/app/right-sidebar/review/index.tsx
@@ -29,6 +29,7 @@ import {
   $reviewRevertTarget,
   $reviewSelectedPath,
   $reviewTreeMode,
+  $reviewWrapLines,
   cancelRevert,
   clearReviewSelection,
   closeReview,
@@ -37,6 +38,7 @@ import {
   requestRevert,
   stageReviewFile,
   toggleReviewTreeMode,
+  toggleReviewWrapLines,
   unstageReviewFile
 } from '@/store/review'
 
@@ -62,6 +64,7 @@ export function ReviewPane() {
   const diffLoading = useStore($reviewDiffLoading)
   const revertTarget = useStore($reviewRevertTarget)
   const treeMode = useStore($reviewTreeMode)
+  const wrapLines = useStore($reviewWrapLines)
 
   const selectedFile = files.find(file => file.path === selectedPath)
   const hasFiles = files.length > 0
@@ -99,6 +102,17 @@ export function ReviewPane() {
               variant="ghost"
             >
               <Codicon name={treeMode === 'tree' ? 'list-flat' : 'list-tree'} size="0.8125rem" />
+            </Button>
+          </Tip>
+          <Tip label={wrapLines ? t.rightSidebar.unwrapLines : t.rightSidebar.wrapLines}>
+            <Button
+              aria-label={wrapLines ? t.rightSidebar.unwrapLines : t.rightSidebar.wrapLines}
+              className={ACTION_BTN}
+              onClick={toggleReviewWrapLines}
+              size="icon-xs"
+              variant={wrapLines ? 'secondary' : 'ghost'}
+            >
+              <Codicon name="word-wrap" size="0.8125rem" />
             </Button>
           </Tip>
           <Tip label={c.stageAll}>
@@ -199,7 +213,7 @@ export function ReviewPane() {
                 <DiffSkeleton />
               ) : null
             ) : diff ? (
-              <FileDiffPanel className="mx-0 mb-0 h-full max-h-none" diff={diff} path={selectedFile.path} virtualized />
+              <FileDiffPanel className="mx-0 mb-0 h-full max-h-none" diff={diff} path={selectedFile.path} virtualized wrap={wrapLines} />
             ) : (
               <div className="py-6 text-center text-[0.66rem] text-muted-foreground/60">{c.noDiff}</div>
             )}

--- a/apps/desktop/src/components/chat/diff-lines.test.tsx
+++ b/apps/desktop/src/components/chat/diff-lines.test.tsx
@@ -1,0 +1,47 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+
+import { FileDiffPanel } from './diff-lines'
+
+// One add hunk over two context lines. No `path` is passed so the panel takes
+// the plain (non-Shiki) path — no dynamic import, deterministic DOM.
+const DIFF = `diff --git a/notes.txt b/notes.txt
+index 0000001..0000002 100644
+--- a/notes.txt
++++ b/notes.txt
+@@ -1,2 +1,3 @@
+ keep this line
++add a line that is long enough to wrap
+`
+
+describe('FileDiffPanel wrap', () => {
+  it('renders lines non-wrapping by default', () => {
+    render(<FileDiffPanel diff={DIFF} />)
+
+    const added = screen.getByText('add a line that is long enough to wrap')
+
+    expect(added.className).toContain('whitespace-pre')
+    expect(added.className).not.toContain('whitespace-pre-wrap')
+  })
+
+  it('swaps lines to the wrapping classes when wrap is on', () => {
+    render(<FileDiffPanel diff={DIFF} wrap />)
+
+    const added = screen.getByText('add a line that is long enough to wrap')
+    const context = screen.getByText('keep this line')
+
+    expect(added.className).toContain('whitespace-pre-wrap')
+    expect(added.className).toContain('break-words')
+    expect(added.className.split(/\s+/)).not.toContain('whitespace-pre')
+    expect(context.className).toContain('whitespace-pre-wrap')
+  })
+
+  it('keeps the wrap classes in the windowed shell used by the review pane', () => {
+    render(<FileDiffPanel diff={DIFF} virtualized wrap />)
+
+    const added = screen.getByText('add a line that is long enough to wrap')
+
+    expect(added.className).toContain('whitespace-pre-wrap')
+    expect(added.className.split(/\s+/)).not.toContain('whitespace-pre')
+  })
+})

--- a/apps/desktop/src/components/chat/diff-lines.tsx
+++ b/apps/desktop/src/components/chat/diff-lines.tsx
@@ -51,7 +51,12 @@ const DIFF_KIND_TEXT: Record<DiffKind, string> = {
 }
 
 const DIFF_LINE_BASE = 'block min-w-max whitespace-pre border-l-2 px-2.5 py-px'
+// Wrapped variant: long lines break instead of forcing a horizontal scroll
+// (the Review pane's wrap toggle). `min-w-max`/`whitespace-pre` drop so text
+// flows; `break-words` keeps pathological tokens (URLs) from overflowing.
+const DIFF_LINE_BASE_WRAP = 'block whitespace-pre-wrap break-words border-l-2 px-2.5 py-px'
 const PREVIEW_DIFF_LINE_BASE = 'block h-5 min-w-max whitespace-pre px-2.5 leading-5'
+const PREVIEW_DIFF_LINE_BASE_WRAP = 'block whitespace-pre-wrap break-words px-2.5 py-px leading-5'
 const PREVIEW_CHUNK_LINES = 200
 const PREVIEW_LINE_PX = 20
 const PREVIEW_OVERSCAN_LINES = 400
@@ -275,12 +280,14 @@ function parseFullFileDiff(diff: string, fullText: string): DiffLine[] {
 }
 
 /** Exported for the lazily-loaded SyntaxDiff (syntax-diff.tsx). */
-export function DiffBody({ lines, syntax }: { lines: DiffLine[]; syntax?: boolean }) {
+export function DiffBody({ lines, syntax, wrap }: { lines: DiffLine[]; syntax?: boolean; wrap?: boolean }) {
+  const lineClass = wrap ? DIFF_LINE_BASE_WRAP : DIFF_LINE_BASE
+
   return (
     <>
       {lines.map((line, index) => (
         <span
-          className={cn(DIFF_LINE_BASE, DIFF_KIND_TINT[line.kind], !syntax && DIFF_KIND_TEXT[line.kind])}
+          className={cn(lineClass, DIFF_KIND_TINT[line.kind], !syntax && DIFF_KIND_TEXT[line.kind])}
           key={`${index}-${line.text}`}
         >
           {line.text || ' '}
@@ -324,13 +331,17 @@ function PreviewDiffRows({
   afterLines = 0,
   beforeLines = 0,
   chunks,
-  tokens
+  tokens,
+  wrap
 }: {
   afterLines?: number
   beforeLines?: number
   chunks: Array<LineChunk<DiffLine>>
   tokens?: ThemedToken[][] | null
+  wrap?: boolean
 }) {
+  const lineClass = wrap ? PREVIEW_DIFF_LINE_BASE_WRAP : PREVIEW_DIFF_LINE_BASE
+
   return (
     <>
       {beforeLines > 0 && <div aria-hidden style={{ height: beforeLines * PREVIEW_LINE_PX }} />}
@@ -341,7 +352,7 @@ function PreviewDiffRows({
             const rowTokens = tokens?.[index] ?? []
 
             return (
-              <span className={cn(PREVIEW_DIFF_LINE_BASE, DIFF_KIND_TINT[line.kind])} key={`${index}-${line.text}`}>
+              <span className={cn(lineClass, DIFF_KIND_TINT[line.kind])} key={`${index}-${line.text}`}>
                 {rowTokens.length > 0
                   ? rowTokens.map((token, tokenIndex) => (
                       <span key={`${tokenIndex}-${token.offset}`} style={tokenStyle(token)}>
@@ -365,7 +376,8 @@ function TokenizedDiffBody({
   chunked = false,
   chunks,
   language,
-  lines
+  lines,
+  wrap
 }: {
   afterLines?: number
   beforeLines?: number
@@ -373,6 +385,7 @@ function TokenizedDiffBody({
   chunks?: Array<LineChunk<DiffLine>>
   language: string
   lines: DiffLine[]
+  wrap?: boolean
 }) {
   const code = React.useMemo(() => lines.map(line => line.text).join('\n'), [lines])
   const theme = useThemeName()
@@ -408,9 +421,10 @@ function TokenizedDiffBody({
         afterLines={afterLines}
         beforeLines={beforeLines}
         chunks={chunks ?? chunkLines(lines, PREVIEW_CHUNK_LINES)}
+        wrap={wrap}
       />
     ) : (
-      <DiffBody lines={lines} />
+      <DiffBody lines={lines} wrap={wrap} />
     )
   }
 
@@ -421,9 +435,12 @@ function TokenizedDiffBody({
         beforeLines={beforeLines}
         chunks={chunks ?? chunkLines(lines, PREVIEW_CHUNK_LINES)}
         tokens={tokens}
+        wrap={wrap}
       />
     )
   }
+
+  const lineClass = wrap ? PREVIEW_DIFF_LINE_BASE_WRAP : PREVIEW_DIFF_LINE_BASE
 
   return (
     <>
@@ -431,7 +448,7 @@ function TokenizedDiffBody({
         const rowTokens = tokens[index] ?? []
 
         return (
-          <span className={cn(PREVIEW_DIFF_LINE_BASE, DIFF_KIND_TINT[line.kind])} key={`${index}-${line.text}`}>
+          <span className={cn(lineClass, DIFF_KIND_TINT[line.kind])} key={`${index}-${line.text}`}>
             {rowTokens.length > 0
               ? rowTokens.map((token, tokenIndex) => (
                   <span key={`${tokenIndex}-${token.offset}`} style={tokenStyle(token)}>
@@ -448,8 +465,9 @@ function TokenizedDiffBody({
 
 // Shiki transformer: tag each `.line` with the diff tint for its kind, so the
 // syntax-highlighted output keeps add/remove backgrounds + the gutter accent.
-// Exported for the lazily-loaded SyntaxDiff (syntax-diff.tsx).
-export function diffLineTransformer(kinds: DiffKind[]): ShikiTransformer {
+// Exported for the lazily-loaded SyntaxDiff (syntax-diff.tsx). `wrap` swaps the
+// line class for the wrapping variant (no horizontal overflow).
+export function diffLineTransformer(kinds: DiffKind[], wrap = false): ShikiTransformer {
   return {
     line(node, line) {
       const kind = kinds[line - 1] ?? 'context'
@@ -460,18 +478,18 @@ export function diffLineTransformer(kinds: DiffKind[]): ShikiTransformer {
           ? [String(node.properties.className)]
           : []
 
-      node.properties.className = [...existing, DIFF_LINE_BASE, DIFF_KIND_TINT[kind]]
+      node.properties.className = [...existing, wrap ? DIFF_LINE_BASE_WRAP : DIFF_LINE_BASE, DIFF_KIND_TINT[kind]]
     }
   }
 }
 
-function SyntaxDiff({ language, lines }: { language: string; lines: DiffLine[] }) {
+function SyntaxDiff({ language, lines, wrap }: { language: string; lines: DiffLine[]; wrap?: boolean }) {
   // The Shiki hook lives in a lazily-loaded module (syntax-diff.tsx) so the
   // multi-MB shiki chunk stays off the cold-start path. Until it (and the
   // highlight itself) resolves, show the plain colored diff — no flash.
   return (
-    <React.Suspense fallback={<DiffBody lines={lines} />}>
-      <LazySyntaxDiff language={language} lines={lines} />
+    <React.Suspense fallback={<DiffBody lines={lines} wrap={wrap} />}>
+      <LazySyntaxDiff language={language} lines={lines} wrap={wrap} />
     </React.Suspense>
   )
 }
@@ -569,6 +587,11 @@ interface FileDiffPanelProps {
    *  diff in a scrolling pane (the review panel), so only visible rows mount
    *  instead of highlighting every line. `showLineNumbers` implies windowing. */
   virtualized?: boolean
+  /** Wrap long lines instead of scrolling horizontally. Designed for the
+   *  line-number-free review pane: fixed-row virtualization can't measure
+   *  wrapped rows, so with `wrap` every chunk mounts and the scroller just
+   *  scrolls vertically (fine for the doc-sized diffs that need wrapping). */
+  wrap?: boolean
 }
 
 export function FileDiffPanel({
@@ -577,7 +600,8 @@ export function FileDiffPanel({
   fullText,
   path,
   showLineNumbers = false,
-  virtualized = false
+  virtualized = false,
+  wrap = false
 }: FileDiffPanelProps) {
   const lines = React.useMemo(
     () => (fullText != null ? parseFullFileDiff(diff, fullText) : parseDiff(diff)),
@@ -593,7 +617,11 @@ export function FileDiffPanel({
     totalRows: lines.length
   })
 
-  const visibleLineChunks = lineChunks.slice(startChunk, endChunk + 1)
+  // Wrapped rows are variable-height, so the fixed-row window math can't slice
+  // them: mount every chunk (the scroller shell stays) and let it scroll.
+  const visibleLineChunks = wrap ? lineChunks : lineChunks.slice(startChunk, endChunk + 1)
+  const effectiveBeforeRows = wrap ? 0 : beforeRows
+  const effectiveAfterRows = wrap ? 0 : afterRows
 
   const language = shikiLanguageForFilename(path)
   const canHighlight = Boolean(language) && !exceedsHighlightBudget(fullText ?? diff)
@@ -604,23 +632,29 @@ export function FileDiffPanel({
   // are small/clamped, so they let Shiki own the rows (SyntaxDiff).
   const windowedBody = canHighlight ? (
     <TokenizedDiffBody
-      afterLines={afterRows}
-      beforeLines={beforeRows}
+      afterLines={effectiveAfterRows}
+      beforeLines={effectiveBeforeRows}
       chunked
       chunks={visibleLineChunks}
       language={language}
       lines={lines}
+      wrap={wrap}
     />
   ) : (
-    <PreviewDiffRows afterLines={afterRows} beforeLines={beforeRows} chunks={visibleLineChunks} />
+    <PreviewDiffRows
+      afterLines={effectiveAfterRows}
+      beforeLines={effectiveBeforeRows}
+      chunks={visibleLineChunks}
+      wrap={wrap}
+    />
   )
 
   const compactBody = !canHighlight ? (
-    <DiffBody lines={lines} />
+    <DiffBody lines={lines} wrap={wrap} />
   ) : fullText != null ? (
-    <TokenizedDiffBody language={language} lines={lines} />
+    <TokenizedDiffBody language={language} lines={lines} wrap={wrap} />
   ) : (
-    <SyntaxDiff language={language} lines={lines} />
+    <SyntaxDiff language={language} lines={lines} wrap={wrap} />
   )
 
   if (!windowed) {

--- a/apps/desktop/src/components/chat/syntax-diff.tsx
+++ b/apps/desktop/src/components/chat/syntax-diff.tsx
@@ -13,9 +13,17 @@ import { useShikiHighlighter } from 'react-shiki'
 import { DiffBody, type DiffLine, diffLineTransformer } from '@/components/chat/diff-lines'
 import { SHIKI_THEME } from '@/components/chat/shiki-highlighter'
 
-export default function SyntaxDiff({ language, lines }: { language: string; lines: DiffLine[] }) {
+export default function SyntaxDiff({
+  language,
+  lines,
+  wrap
+}: {
+  language: string
+  lines: DiffLine[]
+  wrap?: boolean
+}) {
   const code = useMemo(() => lines.map(line => line.text).join('\n'), [lines])
-  const transformers = useMemo(() => [diffLineTransformer(lines.map(line => line.kind))], [lines])
+  const transformers = useMemo(() => [diffLineTransformer(lines.map(line => line.kind), wrap)], [lines, wrap])
 
   const highlighted = useShikiHighlighter(code, language, SHIKI_THEME, {
     defaultColor: 'light-dark()',
@@ -23,5 +31,5 @@ export default function SyntaxDiff({ language, lines }: { language: string; line
   })
 
   // Until Shiki resolves, show the plain colored diff so there's no flash.
-  return (highlighted as ReactNode) ?? <DiffBody lines={lines} />
+  return (highlighted as ReactNode) ?? <DiffBody lines={lines} wrap={wrap} />
 }

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -2712,6 +2712,8 @@ export const en: Translations = {
     folderTip: cwd => cwd,
     openFolder: 'Open folder',
     refreshTree: 'Refresh tree',
+    wrapLines: 'Wrap lines',
+    unwrapLines: 'Unwrap lines',
     collapseAll: 'Collapse all folders',
     previewUnavailable: 'Preview unavailable',
     couldNotPreview: path => `Could not preview ${path}`,

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -2299,6 +2299,8 @@ export interface Translations {
     folderTip: (cwd: string) => string
     openFolder: string
     refreshTree: string
+    wrapLines: string
+    unwrapLines: string
     collapseAll: string
     previewUnavailable: string
     couldNotPreview: (path: string) => string

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -2887,6 +2887,8 @@ export const zh: Translations = {
     folderTip: cwd => cwd,
     openFolder: '打开文件夹',
     refreshTree: '刷新文件树',
+    wrapLines: '自动换行',
+    unwrapLines: '取消自动换行',
     collapseAll: '折叠所有文件夹',
     previewUnavailable: '预览不可用',
     couldNotPreview: path => `无法预览 ${path}`,

--- a/apps/desktop/src/store/review.test.ts
+++ b/apps/desktop/src/store/review.test.ts
@@ -18,6 +18,7 @@ import {
   $reviewShipBusy,
   $reviewShipInfo,
   $reviewTreeMode,
+  $reviewWrapLines,
   cancelRevert,
   clearReviewSelection,
   closeReview,
@@ -34,6 +35,7 @@ import {
   selectReviewFile,
   stageReviewFile,
   toggleReviewTreeMode,
+  toggleReviewWrapLines,
   unstageReviewFile
 } from './review'
 import { $currentCwd } from './session'
@@ -96,6 +98,7 @@ beforeEach(() => {
   $reviewCommitMsgBusy.set(false)
   $reviewRevertTarget.set(undefined)
   $reviewScopeCwd.set(null)
+  $reviewWrapLines.set(false)
   $currentCwd.set('/repo')
 })
 
@@ -237,6 +240,14 @@ describe('view state', () => {
     expect($reviewTreeMode.get()).toBe('list')
     toggleReviewTreeMode()
     expect($reviewTreeMode.get()).toBe('tree')
+  })
+
+  it('toggleReviewWrapLines flips the wrap preference', () => {
+    $reviewWrapLines.set(false)
+    toggleReviewWrapLines()
+    expect($reviewWrapLines.get()).toBe(true)
+    toggleReviewWrapLines()
+    expect($reviewWrapLines.get()).toBe(false)
   })
 
   it('openReview opens the pane and kicks off a refresh', async () => {

--- a/apps/desktop/src/store/review.ts
+++ b/apps/desktop/src/store/review.ts
@@ -31,6 +31,7 @@ export const REVIEW_PANE_ID = 'review'
 const OPEN_KEY = 'hermes.desktop.reviewOpen'
 const COMMIT_DEFAULT_KEY = 'hermes.desktop.reviewCommitDefault'
 const TREE_MODE_KEY = 'hermes.desktop.reviewTreeMode'
+const WRAP_LINES_KEY = 'hermes.desktop.reviewWrapLines'
 const SELECTED_KEY = 'hermes.desktop.reviewSelectedPath'
 const REVIEW_REFRESH_DEBOUNCE_MS = 100
 const SHIP_INFO_STALE_MS = 30_000
@@ -56,6 +57,14 @@ export const $reviewTreeMode = persistentAtom<ReviewTreeMode>(TREE_MODE_KEY, 'tr
 
 export function toggleReviewTreeMode(): void {
   $reviewTreeMode.set($reviewTreeMode.get() === 'tree' ? 'list' : 'tree')
+}
+
+// Persisted so a relaunch restores whether long diff lines wrap instead of
+// scrolling horizontally (long markdown lines read better wrapped).
+export const $reviewWrapLines = persistentAtom(WRAP_LINES_KEY, false, Codecs.bool)
+
+export function toggleReviewWrapLines(): void {
+  $reviewWrapLines.set(!$reviewWrapLines.get())
 }
 
 export const $reviewFiles = atom<HermesReviewFile[]>([])


### PR DESCRIPTION
## Summary

The Review pane renders diff lines with `whitespace-pre` / `min-w-max`, so long lines (very common in markdown documentation) overflow horizontally and force Shift+wheel scrolling. This adds a persisted **wrap-lines toggle** to the review pane header: when enabled, lines render with `whitespace-pre-wrap` + `break-words` and flow instead of overflowing.

## Details

- New `wrap` prop on `FileDiffPanel`, threaded through `DiffBody`, `PreviewDiffRows`, `TokenizedDiffBody`, the Shiki `diffLineTransformer`, and the lazy `SyntaxDiff`.
- Review header gets a `word-wrap` codicon button (tooltip "Wrap lines"/"Unwrap lines"), persisted via `hermes.desktop.reviewWrapLines` (`persistentAtom`, same pattern as the tree-mode toggle).
- Fixed-row virtualization can't measure wrapped rows, so with `wrap` on the panel mounts every chunk (the scroller shell stays) and just scrolls vertically — fine for the doc-sized diffs that need wrapping.
- i18n: `wrapLines`/`unwrapLines` keys added to `en.ts`, `types.ts`, and the full `zh.ts` locale (other locales are partial overrides of `en`).

## Testing

- `npm run typecheck` (renderer + electron + e2e tsconfigs) ✅
- `npx vitest run src/store/review.test.ts src/components/chat/diff-lines.test.tsx src/i18n` ✅ (69 tests, including new toggle + render assertions)
- eslint on all touched files ✅

Feature requested by Rafa (desktop app user) — his first experience with the review pane was doc diffs overflowing the pane.