### PR TITLE
feat(roadmaps): durable roadmaps store contract + projects.db schema

### DIFF
--- a/hermes_cli/projects_db.py
+++ b/hermes_cli/projects_db.py
@@ -31,6 +31,7 @@ import sqlite3
 import time
 from dataclasses import dataclass, field
 from pathlib import Path
+from types import MappingProxyType
 from typing import Iterable, List, Optional
 
 from hermes_cli.sqlite_util import add_column_if_missing as _add_column_if_missing, write_txn
@@ -93,6 +94,128 @@ CREATE TABLE IF NOT EXISTS discovered_repos (
     label         TEXT,
     last_seen     INTEGER NOT NULL
 );
+
+-- Roadmaps Phase 1: additive durable plan/execution schema.  The profile_id
+-- columns are application scope inside this per-profile database; the database
+-- path resolved by get_hermes_home() remains the actual profile boundary.
+CREATE TABLE IF NOT EXISTS roadmaps (
+    profile_id TEXT NOT NULL CHECK (length(trim(replace(replace(replace(profile_id, char(9), ''), char(10), ''), char(13), ''))) > 0),
+    project_id TEXT NOT NULL CHECK (length(trim(replace(replace(replace(project_id, char(9), ''), char(10), ''), char(13), ''))) > 0) REFERENCES projects(id) ON DELETE CASCADE,
+    roadmap_id TEXT NOT NULL CHECK (length(trim(replace(replace(replace(roadmap_id, char(9), ''), char(10), ''), char(13), ''))) > 0),
+    title TEXT NOT NULL,
+    purpose TEXT,
+    lifecycle_state TEXT NOT NULL CHECK (lifecycle_state IN ('draft','proposed','validated','in_progress','blocked','completed','archived')),
+    active_version INTEGER CHECK (active_version IS NULL OR active_version >= 1),
+    created_by TEXT NOT NULL CHECK (length(trim(replace(replace(replace(created_by, char(9), ''), char(10), ''), char(13), ''))) > 0),
+    updated_by TEXT NOT NULL CHECK (length(trim(replace(replace(replace(updated_by, char(9), ''), char(10), ''), char(13), ''))) > 0),
+    created_at INTEGER NOT NULL,
+    updated_at INTEGER NOT NULL,
+    PRIMARY KEY (profile_id, project_id, roadmap_id),
+    FOREIGN KEY (profile_id, project_id, roadmap_id, active_version)
+      REFERENCES roadmap_versions(profile_id, project_id, roadmap_id, version)
+      DEFERRABLE INITIALLY DEFERRED
+);
+
+CREATE TABLE IF NOT EXISTS roadmap_versions (
+    profile_id TEXT NOT NULL CHECK (length(trim(replace(replace(replace(profile_id, char(9), ''), char(10), ''), char(13), ''))) > 0),
+    project_id TEXT NOT NULL CHECK (length(trim(replace(replace(replace(project_id, char(9), ''), char(10), ''), char(13), ''))) > 0),
+    roadmap_id TEXT NOT NULL CHECK (length(trim(replace(replace(replace(roadmap_id, char(9), ''), char(10), ''), char(13), ''))) > 0),
+    version INTEGER NOT NULL CHECK (version >= 1),
+    state TEXT NOT NULL CHECK (state IN ('draft','proposed','validated','superseded','archived')),
+    source TEXT,
+    reason TEXT,
+    created_by TEXT NOT NULL CHECK (length(trim(replace(replace(replace(created_by, char(9), ''), char(10), ''), char(13), ''))) > 0),
+    created_at INTEGER NOT NULL,
+    content_hash TEXT,
+    PRIMARY KEY (profile_id, project_id, roadmap_id, version),
+    FOREIGN KEY (profile_id, project_id, roadmap_id)
+      REFERENCES roadmaps(profile_id, project_id, roadmap_id) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS roadmap_nodes (
+    profile_id TEXT NOT NULL CHECK (length(trim(replace(replace(replace(profile_id, char(9), ''), char(10), ''), char(13), ''))) > 0),
+    project_id TEXT NOT NULL CHECK (length(trim(replace(replace(replace(project_id, char(9), ''), char(10), ''), char(13), ''))) > 0),
+    roadmap_id TEXT NOT NULL CHECK (length(trim(replace(replace(replace(roadmap_id, char(9), ''), char(10), ''), char(13), ''))) > 0),
+    version INTEGER NOT NULL,
+    node_id TEXT NOT NULL CHECK (length(trim(replace(replace(replace(node_id, char(9), ''), char(10), ''), char(13), ''))) > 0),
+    parent_node_id TEXT,
+    kind TEXT NOT NULL CHECK (kind IN ('objective','phase','milestone','step','decision')),
+    title TEXT NOT NULL,
+    description TEXT,
+    state TEXT NOT NULL CHECK (state IN ('planned','ready','in_progress','blocked','completed','archived')),
+    progress INTEGER NOT NULL DEFAULT 0 CHECK (progress BETWEEN 0 AND 100),
+    owner_agent TEXT CHECK (owner_agent IS NULL OR length(trim(replace(replace(replace(owner_agent, char(9), ''), char(10), ''), char(13), ''))) > 0),
+    block_reason TEXT,
+    created_at INTEGER NOT NULL,
+    updated_at INTEGER NOT NULL,
+    PRIMARY KEY (profile_id, project_id, roadmap_id, version, node_id),
+    FOREIGN KEY (profile_id, project_id, roadmap_id, version)
+      REFERENCES roadmap_versions(profile_id, project_id, roadmap_id, version) ON DELETE CASCADE,
+    FOREIGN KEY (profile_id, project_id, roadmap_id, version, parent_node_id)
+      REFERENCES roadmap_nodes(profile_id, project_id, roadmap_id, version, node_id),
+    CHECK (parent_node_id IS NULL OR (length(trim(replace(replace(replace(parent_node_id, char(9), ''), char(10), ''), char(13), ''))) > 0 AND parent_node_id <> node_id))
+);
+
+CREATE TABLE IF NOT EXISTS roadmap_relations (
+    profile_id TEXT NOT NULL CHECK (length(trim(replace(replace(replace(profile_id, char(9), ''), char(10), ''), char(13), ''))) > 0),
+    project_id TEXT NOT NULL CHECK (length(trim(replace(replace(replace(project_id, char(9), ''), char(10), ''), char(13), ''))) > 0),
+    roadmap_id TEXT NOT NULL CHECK (length(trim(replace(replace(replace(roadmap_id, char(9), ''), char(10), ''), char(13), ''))) > 0),
+    version INTEGER NOT NULL,
+    relation_id TEXT NOT NULL CHECK (length(trim(replace(replace(replace(relation_id, char(9), ''), char(10), ''), char(13), ''))) > 0),
+    from_node_id TEXT NOT NULL CHECK (length(trim(replace(replace(replace(from_node_id, char(9), ''), char(10), ''), char(13), ''))) > 0),
+    to_node_id TEXT NOT NULL CHECK (length(trim(replace(replace(replace(to_node_id, char(9), ''), char(10), ''), char(13), ''))) > 0),
+    kind TEXT NOT NULL CHECK (kind IN ('depends_on','blocks','enables','follows','validates','supersedes')),
+    state TEXT NOT NULL DEFAULT 'active' CHECK (state IN ('active','superseded','invalid')),
+    reason TEXT,
+    PRIMARY KEY (profile_id, project_id, roadmap_id, version, relation_id),
+    FOREIGN KEY (profile_id, project_id, roadmap_id, version, from_node_id)
+      REFERENCES roadmap_nodes(profile_id, project_id, roadmap_id, version, node_id) ON DELETE CASCADE,
+    FOREIGN KEY (profile_id, project_id, roadmap_id, version, to_node_id)
+      REFERENCES roadmap_nodes(profile_id, project_id, roadmap_id, version, node_id) ON DELETE CASCADE,
+    CHECK (from_node_id <> to_node_id)
+);
+
+CREATE TABLE IF NOT EXISTS roadmap_todos (
+    profile_id TEXT NOT NULL CHECK (length(trim(replace(replace(replace(profile_id, char(9), ''), char(10), ''), char(13), ''))) > 0),
+    project_id TEXT NOT NULL CHECK (length(trim(replace(replace(replace(project_id, char(9), ''), char(10), ''), char(13), ''))) > 0),
+    roadmap_id TEXT NOT NULL CHECK (length(trim(replace(replace(replace(roadmap_id, char(9), ''), char(10), ''), char(13), ''))) > 0),
+    version INTEGER NOT NULL,
+    todo_id TEXT NOT NULL CHECK (length(trim(replace(replace(replace(todo_id, char(9), ''), char(10), ''), char(13), ''))) > 0),
+    node_id TEXT CHECK (node_id IS NULL OR length(trim(replace(replace(replace(node_id, char(9), ''), char(10), ''), char(13), ''))) > 0),
+    title TEXT NOT NULL,
+    state TEXT NOT NULL CHECK (state IN ('open','in_progress','done','cancelled')),
+    position INTEGER NOT NULL DEFAULT 0,
+    created_at INTEGER NOT NULL,
+    updated_at INTEGER NOT NULL,
+    PRIMARY KEY (profile_id, project_id, roadmap_id, version, todo_id),
+    FOREIGN KEY (profile_id, project_id, roadmap_id, version)
+      REFERENCES roadmap_versions(profile_id, project_id, roadmap_id, version) ON DELETE CASCADE,
+    FOREIGN KEY (profile_id, project_id, roadmap_id, version, node_id)
+      REFERENCES roadmap_nodes(profile_id, project_id, roadmap_id, version, node_id)
+);
+
+-- Durable Roadmaps session links.  Only the stored/lineage session id belongs
+-- here: runtime ids identify one transient execution and must never persist.
+CREATE TABLE IF NOT EXISTS roadmap_sessions (
+    profile_id TEXT NOT NULL CHECK (length(trim(replace(replace(replace(profile_id, char(9), ''), char(10), ''), char(13), ''))) > 0),
+    project_id TEXT NOT NULL CHECK (length(trim(replace(replace(replace(project_id, char(9), ''), char(10), ''), char(13), ''))) > 0),
+    roadmap_id TEXT NOT NULL CHECK (length(trim(replace(replace(replace(roadmap_id, char(9), ''), char(10), ''), char(13), ''))) > 0),
+    stored_session_id TEXT NOT NULL CHECK (length(trim(replace(replace(replace(stored_session_id, char(9), ''), char(10), ''), char(13), ''))) > 0),
+    kind TEXT NOT NULL CHECK (kind IN ('vision')),
+    node_id TEXT CHECK (node_id IS NULL),
+    plan_version INTEGER CHECK (plan_version IS NULL OR plan_version >= 1),
+    state TEXT NOT NULL CHECK (state IN ('active','closed')),
+    actor TEXT NOT NULL CHECK (length(trim(replace(replace(replace(actor, char(9), ''), char(10), ''), char(13), ''))) > 0),
+    created_at INTEGER NOT NULL,
+    updated_at INTEGER NOT NULL,
+    PRIMARY KEY (profile_id, project_id, roadmap_id, stored_session_id, kind),
+    FOREIGN KEY (profile_id, project_id, roadmap_id)
+      REFERENCES roadmaps(profile_id, project_id, roadmap_id) ON DELETE CASCADE
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_roadmap_sessions_active_vision
+    ON roadmap_sessions(profile_id, project_id, roadmap_id)
+    WHERE kind = 'vision' AND state = 'active';
 """
 
 
@@ -149,19 +272,324 @@ def _normalize_path(path: str) -> str:
 # Connection management
 # ---------------------------------------------------------------------------
 
-_INITIALIZED_PATHS: set[str] = set()
+_ROADMAP_TABLES = (
+    "roadmaps",
+    "roadmap_versions",
+    "roadmap_nodes",
+    "roadmap_relations",
+    "roadmap_todos",
+    "roadmap_sessions",
+)
+_ROADMAP_INDEXES = ("idx_roadmap_sessions_active_vision",)
+
+# Core schema is checked independently of Roadmaps so a partial legacy DB is repaired.
+_CORE_TABLES = ("projects", "project_folders", "project_meta", "discovered_repos")
+_CORE_INDEXES = ("idx_project_folders_path",)
+
+# Required independently from the column contract: ``slug`` is a stable
+# project handle and must remain unique even when a legacy table has the right
+# columns but weakened constraints.
+_CORE_UNIQUE_COLUMNS = MappingProxyType({"projects": (("slug",),)})
+
+# Required core columns are deliberately independent from SCHEMA_SQL.  Optional
+# project columns are migrated separately below, so they are not part of this
+# contract and may be added by later versions without invalidating old stores.
+_CORE_SCHEMA_CONTRACT = MappingProxyType(
+    {
+        "projects": (
+            (("id", "TEXT", 0, 1), ("slug", "TEXT", 1, 0),
+             ("name", "TEXT", 1, 0), ("created_at", "INTEGER", 1, 0),
+             ("archived", "INTEGER", 1, 0)),
+            (),
+        ),
+        "project_folders": (
+            (("project_id", "TEXT", 1, 1), ("path", "TEXT", 1, 2),
+             ("label", "TEXT", 0, 0), ("is_primary", "INTEGER", 1, 0),
+             ("added_at", "INTEGER", 1, 0)),
+            (("projects", ("project_id",), ("id",), "NO ACTION", "CASCADE"),),
+        ),
+        "project_meta": (
+            (("key", "TEXT", 0, 1), ("value", "TEXT", 0, 0)),
+            (),
+        ),
+        "discovered_repos": (
+            (("root", "TEXT", 0, 1), ("label", "TEXT", 0, 0),
+             ("last_seen", "INTEGER", 1, 0)),
+            (),
+        ),
+    }
+)
+
+# Exact CHECK expressions, maintained independently from SCHEMA_SQL.
+_ROADMAP_CHECK_CONTRACT = MappingProxyType({
+    "roadmaps": ("length(trim(replace(replace(replace(profile_id, char(9), ''), char(10), ''), char(13), ''))) > 0", "length(trim(replace(replace(replace(project_id, char(9), ''), char(10), ''), char(13), ''))) > 0", "length(trim(replace(replace(replace(roadmap_id, char(9), ''), char(10), ''), char(13), ''))) > 0", "lifecycle_state in ('draft','proposed','validated','in_progress','blocked','completed','archived')", "active_version is null or active_version >= 1", "length(trim(replace(replace(replace(created_by, char(9), ''), char(10), ''), char(13), ''))) > 0", "length(trim(replace(replace(replace(updated_by, char(9), ''), char(10), ''), char(13), ''))) > 0"),
+    "roadmap_versions": ("length(trim(replace(replace(replace(profile_id, char(9), ''), char(10), ''), char(13), ''))) > 0", "length(trim(replace(replace(replace(project_id, char(9), ''), char(10), ''), char(13), ''))) > 0", "length(trim(replace(replace(replace(roadmap_id, char(9), ''), char(10), ''), char(13), ''))) > 0", "version >= 1", "state in ('draft','proposed','validated','superseded','archived')", "length(trim(replace(replace(replace(created_by, char(9), ''), char(10), ''), char(13), ''))) > 0"),
+    "roadmap_nodes": ("length(trim(replace(replace(replace(profile_id, char(9), ''), char(10), ''), char(13), ''))) > 0", "length(trim(replace(replace(replace(project_id, char(9), ''), char(10), ''), char(13), ''))) > 0", "length(trim(replace(replace(replace(roadmap_id, char(9), ''), char(10), ''), char(13), ''))) > 0", "length(trim(replace(replace(replace(node_id, char(9), ''), char(10), ''), char(13), ''))) > 0", "kind in ('objective','phase','milestone','step','decision')", "state in ('planned','ready','in_progress','blocked','completed','archived')", "progress between 0 and 100", "owner_agent is null or length(trim(replace(replace(replace(owner_agent, char(9), ''), char(10), ''), char(13), ''))) > 0", "parent_node_id is null or (length(trim(replace(replace(replace(parent_node_id, char(9), ''), char(10), ''), char(13), ''))) > 0 and parent_node_id <> node_id)"),
+    "roadmap_relations": ("length(trim(replace(replace(replace(profile_id, char(9), ''), char(10), ''), char(13), ''))) > 0", "length(trim(replace(replace(replace(project_id, char(9), ''), char(10), ''), char(13), ''))) > 0", "length(trim(replace(replace(replace(roadmap_id, char(9), ''), char(10), ''), char(13), ''))) > 0", "length(trim(replace(replace(replace(relation_id, char(9), ''), char(10), ''), char(13), ''))) > 0", "length(trim(replace(replace(replace(from_node_id, char(9), ''), char(10), ''), char(13), ''))) > 0", "length(trim(replace(replace(replace(to_node_id, char(9), ''), char(10), ''), char(13), ''))) > 0", "kind in ('depends_on','blocks','enables','follows','validates','supersedes')", "state in ('active','superseded','invalid')", "from_node_id <> to_node_id"),
+    "roadmap_todos": ("length(trim(replace(replace(replace(profile_id, char(9), ''), char(10), ''), char(13), ''))) > 0", "length(trim(replace(replace(replace(project_id, char(9), ''), char(10), ''), char(13), ''))) > 0", "length(trim(replace(replace(replace(roadmap_id, char(9), ''), char(10), ''), char(13), ''))) > 0", "length(trim(replace(replace(replace(todo_id, char(9), ''), char(10), ''), char(13), ''))) > 0", "node_id is null or length(trim(replace(replace(replace(node_id, char(9), ''), char(10), ''), char(13), ''))) > 0", "state in ('open','in_progress','done','cancelled')"),
+    "roadmap_sessions": ("length(trim(replace(replace(replace(profile_id, char(9), ''), char(10), ''), char(13), ''))) > 0", "length(trim(replace(replace(replace(project_id, char(9), ''), char(10), ''), char(13), ''))) > 0", "length(trim(replace(replace(replace(roadmap_id, char(9), ''), char(10), ''), char(13), ''))) > 0", "length(trim(replace(replace(replace(stored_session_id, char(9), ''), char(10), ''), char(13), ''))) > 0", "kind in ('vision')", "node_id is null", "plan_version is null or plan_version >= 1", "state in ('active','closed')", "length(trim(replace(replace(replace(actor, char(9), ''), char(10), ''), char(13), ''))) > 0"),
+})
+
+
+# Independent runtime contract: this must not be derived from SCHEMA_SQL, or a
+# weakened DDL would redefine what the validator considers compatible.
+_ROADMAP_SCHEMA_CONTRACT = MappingProxyType(
+    {
+        "roadmaps": (
+            (("profile_id", "TEXT", 1, 1), ("project_id", "TEXT", 1, 2),
+             ("roadmap_id", "TEXT", 1, 3), ("title", "TEXT", 1, 0),
+             ("purpose", "TEXT", 0, 0), ("lifecycle_state", "TEXT", 1, 0),
+             ("active_version", "INTEGER", 0, 0), ("created_by", "TEXT", 1, 0),
+             ("updated_by", "TEXT", 1, 0), ("created_at", "INTEGER", 1, 0),
+             ("updated_at", "INTEGER", 1, 0)),
+            (("roadmap_versions", ("profile_id", "project_id", "roadmap_id", "active_version"),
+              ("profile_id", "project_id", "roadmap_id", "version"), "NO ACTION", "NO ACTION"),
+             ("projects", ("project_id",), ("id",), "NO ACTION", "CASCADE")),
+            ("primary key", "foreign key", "check", "deferrable initially deferred",
+             "lifecycle_state text not null check", "active_version integer check"),
+        ),
+        "roadmap_versions": (
+            (("profile_id", "TEXT", 1, 1), ("project_id", "TEXT", 1, 2),
+             ("roadmap_id", "TEXT", 1, 3), ("version", "INTEGER", 1, 4),
+             ("state", "TEXT", 1, 0), ("source", "TEXT", 0, 0), ("reason", "TEXT", 0, 0),
+             ("created_by", "TEXT", 1, 0), ("created_at", "INTEGER", 1, 0),
+             ("content_hash", "TEXT", 0, 0)),
+            (("roadmaps", ("profile_id", "project_id", "roadmap_id"),
+              ("profile_id", "project_id", "roadmap_id"), "NO ACTION", "CASCADE"),),
+            ("primary key", "foreign key", "check", "state text not null check", "version integer not null check"),
+        ),
+        "roadmap_nodes": (
+            (("profile_id", "TEXT", 1, 1), ("project_id", "TEXT", 1, 2),
+             ("roadmap_id", "TEXT", 1, 3), ("version", "INTEGER", 1, 4),
+             ("node_id", "TEXT", 1, 5), ("parent_node_id", "TEXT", 0, 0),
+             ("kind", "TEXT", 1, 0), ("title", "TEXT", 1, 0), ("description", "TEXT", 0, 0),
+             ("state", "TEXT", 1, 0), ("progress", "INTEGER", 1, 0), ("owner_agent", "TEXT", 0, 0),
+             ("block_reason", "TEXT", 0, 0),
+             ("created_at", "INTEGER", 1, 0), ("updated_at", "INTEGER", 1, 0)),
+            (("roadmap_nodes", ("profile_id", "project_id", "roadmap_id", "version", "parent_node_id"),
+              ("profile_id", "project_id", "roadmap_id", "version", "node_id"), "NO ACTION", "NO ACTION"),
+             ("roadmap_versions", ("profile_id", "project_id", "roadmap_id", "version"),
+              ("profile_id", "project_id", "roadmap_id", "version"), "NO ACTION", "CASCADE")),
+            ("primary key", "foreign key", "check", "progress integer not null default 0 check", "parent_node_id is null"),
+        ),
+        "roadmap_relations": (
+            (("profile_id", "TEXT", 1, 1), ("project_id", "TEXT", 1, 2),
+             ("roadmap_id", "TEXT", 1, 3), ("version", "INTEGER", 1, 4),
+             ("relation_id", "TEXT", 1, 5), ("from_node_id", "TEXT", 1, 0),
+             ("to_node_id", "TEXT", 1, 0), ("kind", "TEXT", 1, 0),
+             ("state", "TEXT", 1, 0), ("reason", "TEXT", 0, 0)),
+            (("roadmap_nodes", ("profile_id", "project_id", "roadmap_id", "version", "from_node_id"),
+              ("profile_id", "project_id", "roadmap_id", "version", "node_id"), "NO ACTION", "CASCADE"),
+             ("roadmap_nodes", ("profile_id", "project_id", "roadmap_id", "version", "to_node_id"),
+              ("profile_id", "project_id", "roadmap_id", "version", "node_id"), "NO ACTION", "CASCADE")),
+            ("primary key", "foreign key", "check", "from_node_id <> to_node_id", "state text not null default 'active' check"),
+        ),
+        "roadmap_todos": (
+            (("profile_id", "TEXT", 1, 1), ("project_id", "TEXT", 1, 2),
+             ("roadmap_id", "TEXT", 1, 3), ("version", "INTEGER", 1, 4),
+             ("todo_id", "TEXT", 1, 5), ("node_id", "TEXT", 0, 0), ("title", "TEXT", 1, 0),
+             ("state", "TEXT", 1, 0), ("position", "INTEGER", 1, 0),
+             ("created_at", "INTEGER", 1, 0), ("updated_at", "INTEGER", 1, 0)),
+            (("roadmap_nodes", ("profile_id", "project_id", "roadmap_id", "version", "node_id"),
+              ("profile_id", "project_id", "roadmap_id", "version", "node_id"), "NO ACTION", "NO ACTION"),
+             ("roadmap_versions", ("profile_id", "project_id", "roadmap_id", "version"),
+              ("profile_id", "project_id", "roadmap_id", "version"), "NO ACTION", "CASCADE")),
+            ("primary key", "foreign key", "check", "state text not null check", "node_id text check"),
+        ),
+        "roadmap_sessions": (
+            (("profile_id", "TEXT", 1, 1), ("project_id", "TEXT", 1, 2),
+             ("roadmap_id", "TEXT", 1, 3), ("stored_session_id", "TEXT", 1, 4),
+             ("kind", "TEXT", 1, 5), ("node_id", "TEXT", 0, 0),
+             ("plan_version", "INTEGER", 0, 0), ("state", "TEXT", 1, 0),
+             ("actor", "TEXT", 1, 0), ("created_at", "INTEGER", 1, 0),
+             ("updated_at", "INTEGER", 1, 0)),
+            (("roadmaps", ("profile_id", "project_id", "roadmap_id"),
+              ("profile_id", "project_id", "roadmap_id"), "NO ACTION", "CASCADE"),),
+            ("primary key", "foreign key", "check", "state text not null check"),
+        ),
+    }
+)
+
+
+def _roadmap_schema_contract() -> MappingProxyType:
+    """Return the immutable, source-independent Roadmaps contract."""
+    return _ROADMAP_SCHEMA_CONTRACT
+
+
+def _normalize_schema_sql(sql: str) -> str:
+    return re.sub(r"\s+", " ", sql.strip()).lower()
+
+
+def _check_definitions(sql: str) -> tuple[str, ...]:
+    sql = _normalize_schema_sql(sql)
+    checks = []
+    start = 0
+    while (start := sql.find("check (", start)) >= 0:
+        pos, depth = start + len("check ("), 1
+        while depth:
+            depth += sql[pos] == "("
+            depth -= sql[pos] == ")"
+            pos += 1
+        checks.append(sql[start + len("check ("):pos - 1])
+        start = pos
+    return tuple(checks)
+
+
+def _validate_core_schema(
+    conn: sqlite3.Connection, *, only_existing: bool = False
+) -> None:
+    """Validate the independent Projects/core schema contract.
+
+    ``CREATE TABLE IF NOT EXISTS`` cannot repair a weakened pre-existing table;
+    reject such a table before any Roadmaps DDL is executed.  Required columns
+    are matched by name, allowing additive columns (including legacy optional
+    project columns) without over-constraining future schema extensions.
+    """
+    present = {
+        row[0]
+        for row in conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name IN (?, ?, ?, ?)",
+            _CORE_TABLES,
+        )
+    }
+    if only_existing and not present:
+        return
+    for table, (expected_columns, expected_foreign_keys) in _CORE_SCHEMA_CONTRACT.items():
+        if table not in present:
+            if only_existing:
+                continue
+            raise sqlite3.DatabaseError(f"incompatible core schema: missing {table}")
+        actual_by_name = {
+            row[1]: (row[2].upper(), row[3], row[5])
+            for row in conn.execute(f"PRAGMA table_info({table})")
+        }
+        if any(actual_by_name.get(name) != (column_type, notnull, pk)
+               for name, column_type, notnull, pk in expected_columns):
+            raise sqlite3.DatabaseError(f"incompatible core schema: {table}")
+
+        grouped: dict[int, list[tuple]] = {}
+        for row in conn.execute(f"PRAGMA foreign_key_list({table})"):
+            grouped.setdefault(row[0], []).append(row)
+        actual_foreign_keys = {
+            (rows[0][2], tuple(row[3] for row in rows), tuple(row[4] for row in rows),
+             rows[0][5], rows[0][6])
+            for rows in grouped.values()
+        }
+        if not set(expected_foreign_keys).issubset(actual_foreign_keys):
+            raise sqlite3.DatabaseError(f"incompatible core schema: {table}")
+
+    for table, required_columns in _CORE_UNIQUE_COLUMNS.items():
+        if table not in present:
+            continue
+        unique_indexes = []
+        for row in conn.execute(f"PRAGMA index_list({table})"):
+            if row[2]:
+                unique_indexes.append(tuple(index_row[2] for index_row in conn.execute(
+                    f"PRAGMA index_info({row[1]})"
+                )))
+        if not any(columns in unique_indexes for columns in required_columns):
+            raise sqlite3.DatabaseError(
+                f"incompatible core schema: {table} requires unique slug"
+            )
+
+    index = conn.execute(
+        "SELECT 1 FROM sqlite_master WHERE type='index' AND name=?",
+        ("idx_project_folders_path",),
+    ).fetchone()
+    if index and tuple(row[2] for row in conn.execute(
+        "PRAGMA index_info(idx_project_folders_path)"
+    )) != ("path",):
+        raise sqlite3.DatabaseError("incompatible core schema: idx_project_folders_path")
+    if not index and "project_folders" in present:
+        raise sqlite3.DatabaseError("incompatible core schema: idx_project_folders_path")
+
+
+def _validate_roadmaps_schema(
+    conn: sqlite3.Connection, *, only_existing: bool = False
+) -> None:
+    """Reject pre-existing Roadmaps tables that are weaker than the DDL."""
+    contract = _roadmap_schema_contract()
+    present = {
+        row[0]
+        for row in conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name IN (?, ?, ?, ?, ?, ?)",
+            _ROADMAP_TABLES,
+        )
+    }
+    if only_existing and not present:
+        return
+    for table in _ROADMAP_TABLES:
+        if table not in present:
+            if only_existing:
+                continue
+            raise sqlite3.DatabaseError(f"incompatible Roadmaps schema: missing {table}")
+        expected_columns, expected_foreign_keys, _ = contract[table]
+        actual_columns = tuple(
+            (row[1], row[2].upper(), row[3], row[5])
+            for row in conn.execute(f"PRAGMA table_info({table})")
+        )
+        grouped: dict[int, list[tuple]] = {}
+        for row in conn.execute(f"PRAGMA foreign_key_list({table})"):
+            grouped.setdefault(row[0], []).append(row)
+        actual_foreign_keys = {
+            (rows[0][2], tuple(row[3] for row in rows), tuple(row[4] for row in rows),
+             rows[0][5], rows[0][6])
+            for rows in grouped.values()
+        }
+        if actual_columns != expected_columns or actual_foreign_keys != set(expected_foreign_keys):
+            raise sqlite3.DatabaseError(f"incompatible Roadmaps schema: {table}")
+        actual_sql = _normalize_schema_sql(
+            conn.execute(
+                "SELECT sql FROM sqlite_master WHERE type='table' AND name=?", (table,)
+            ).fetchone()[0]
+        )
+        if _check_definitions(actual_sql) != _ROADMAP_CHECK_CONTRACT[table]:
+            raise sqlite3.DatabaseError(f"incompatible Roadmaps schema: {table}")
+
+    index = conn.execute(
+        "SELECT sql FROM sqlite_master WHERE type='index' AND name=?",
+        ("idx_roadmap_sessions_active_vision",),
+    ).fetchone()
+    if index is not None:
+        actual_index_sql = _normalize_schema_sql(index[0])
+        expected_index_sql = _normalize_schema_sql(
+            "CREATE UNIQUE INDEX idx_roadmap_sessions_active_vision "
+            "ON roadmap_sessions(profile_id, project_id, roadmap_id) "
+            "WHERE kind = 'vision' AND state = 'active'"
+        )
+        if actual_index_sql != expected_index_sql:
+            raise sqlite3.DatabaseError(
+                "incompatible Roadmaps schema: idx_roadmap_sessions_active_vision"
+            )
+    elif not only_existing and "roadmap_sessions" in present:
+        raise sqlite3.DatabaseError(
+            "incompatible Roadmaps schema: idx_roadmap_sessions_active_vision"
+        )
+
+
+def _validate_foreign_key_integrity(conn: sqlite3.Connection) -> None:
+    """Reject persisted orphan rows instead of silently accepting repaired DDL."""
+    violations = conn.execute("PRAGMA foreign_key_check").fetchall()
+    if violations:
+        details = "; ".join(
+            f"{row[0]} rowid={row[1]} parent={row[2]} fk={row[3]}"
+            for row in violations[:5]
+        )
+        if len(violations) > 5:
+            details += f"; ... ({len(violations)} total)"
+        raise sqlite3.DatabaseError(f"foreign key violations detected: {details}")
 
 
 def connect(db_path: Optional[Path] = None) -> sqlite3.Connection:
     """Open (and initialize if needed) the per-profile projects DB.
 
     WAL with DELETE fallback for network filesystems (shared helper from
-    ``hermes_state``). Schema init is idempotent (``CREATE TABLE IF NOT
-    EXISTS`` + additive migrations) and cached per-path per-process.
+    ``hermes_state``). Schema init is idempotent (``CREATE TABLE IF NOT EXISTS``
+    + additive migrations). Roadmaps compatibility is checked on every connection; the
+ per-process path cache is never treated as schema authority.
     """
     path = db_path if db_path is not None else projects_db_path()
     path.parent.mkdir(parents=True, exist_ok=True)
-    resolved = str(path.resolve())
     conn = sqlite3.connect(str(path))
     try:
         conn.row_factory = sqlite3.Row
@@ -169,12 +597,51 @@ def connect(db_path: Optional[Path] = None) -> sqlite3.Connection:
 
         apply_wal_with_fallback(conn, db_label="projects.db")
         conn.execute("PRAGMA foreign_keys=ON")
-        if resolved not in _INITIALIZED_PATHS:
+        # Additive column migrations run before schema validation so a legacy
+        # DB (created before optional columns like roadmap_nodes.block_reason
+        # existed) upgrades in place instead of being rejected as incompatible.
+        _migrate_add_optional_columns(conn)
+        # Validate any pre-existing target before CREATE IF NOT EXISTS can hide
+        # a weakened same-column schema. This also avoids creating a partial
+        # Roadmaps schema before rejecting an incompatible table.
+        _validate_roadmaps_schema(conn, only_existing=True)
+        _validate_core_schema(conn, only_existing=True)
+        roadmap_schema_complete = all(
+            conn.execute(
+                "SELECT 1 FROM sqlite_master WHERE type='table' AND name=?", (table,)
+            ).fetchone()
+            for table in _ROADMAP_TABLES
+        ) and all(
+            conn.execute(
+                "SELECT 1 FROM sqlite_master WHERE type='index' AND name=?", (index,)
+            ).fetchone()
+            for index in _ROADMAP_INDEXES
+        )
+        core_schema_complete = all(
+            conn.execute(
+                "SELECT 1 FROM sqlite_master WHERE type='table' AND name=?", (table,)
+            ).fetchone()
+            for table in _CORE_TABLES
+        ) and all(
+            conn.execute(
+                "SELECT 1 FROM sqlite_master WHERE type IN ('index', 'table') AND name=?",
+                (index,),
+            ).fetchone()
+            for index in _CORE_INDEXES
+        )
+        if not roadmap_schema_complete or not core_schema_complete:
             conn.executescript(SCHEMA_SQL)
-            _migrate_add_optional_columns(conn)
-            _INITIALIZED_PATHS.add(resolved)
+        # Retry additive legacy-column migration on every successful open. This
+        # also covers databases whose Roadmaps tables already existed.
+        _migrate_add_optional_columns(conn)
+        _validate_core_schema(conn)
+        _validate_roadmaps_schema(conn)
+        _validate_foreign_key_integrity(conn)
     except Exception:
-        conn.close()
+        try:
+            conn.rollback()
+        finally:
+            conn.close()
         raise
     return conn
 
@@ -202,13 +669,31 @@ def connect_closing(db_path: Optional[Path] = None):
 # open so a legacy DB upgrades in place.
 _OPTIONAL_PROJECT_COLUMNS = ("board_slug", "primary_path", "icon", "color")
 
+# TEXT columns added to `roadmap_nodes` after the Phase 1 port; additive like
+# the projects columns above, and only applied when the table already exists
+# (a fresh store creates the full schema from SCHEMA_SQL instead).
+_OPTIONAL_ROADMAP_NODE_COLUMNS = ("block_reason",)
+
 
 def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
     """Add columns introduced after v1 to legacy DBs (safe on every open)."""
-    cols = {row["name"] for row in conn.execute("PRAGMA table_info(projects)")}
-    for col in _OPTIONAL_PROJECT_COLUMNS:
-        if col not in cols:
-            _add_column_if_missing(conn, "projects", col, f"{col} TEXT")
+    project_table = conn.execute(
+        "SELECT 1 FROM sqlite_master WHERE type='table' AND name='projects'"
+    ).fetchone()
+    if project_table is not None:
+        cols = {row["name"] for row in conn.execute("PRAGMA table_info(projects)")}
+        for col in _OPTIONAL_PROJECT_COLUMNS:
+            if col not in cols:
+                _add_column_if_missing(conn, "projects", col, f"{col} TEXT")
+
+    node_table = conn.execute(
+        "SELECT 1 FROM sqlite_master WHERE type='table' AND name='roadmap_nodes'"
+    ).fetchone()
+    if node_table is not None:
+        node_cols = {row["name"] for row in conn.execute("PRAGMA table_info(roadmap_nodes)")}
+        for col in _OPTIONAL_ROADMAP_NODE_COLUMNS:
+            if col not in node_cols:
+                _add_column_if_missing(conn, "roadmap_nodes", col, f"{col} TEXT")
 
 
 # ---------------------------------------------------------------------------

--- a/src/roadmaps_contract.py
+++ b/src/roadmaps_contract.py
@@ -1,0 +1,331 @@
+"""Pure, read-only invariants for the Roadmaps Phase 0 contract.
+
+This module deliberately has no Hermes imports, database access, filesystem writes,
+or network surface. Repository implementations in this module are in-memory test
+fixtures only; ``projects.db`` remains the durable backend authority.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+import hashlib
+import json
+import re
+from types import MappingProxyType
+from typing import Any, Mapping, Protocol, Sequence, TypeAlias
+
+
+class DuplicateEventConflict(ValueError):
+    """An event id was reused for a different event payload or identity."""
+
+
+class StaleEventError(ValueError):
+    """An event would move an aggregate to an older or equal version."""
+
+
+_IDENTIFIER_FIELDS = frozenset({
+    "profile_id", "project_id", "roadmap_id", "node_id", "event_id",
+    "aggregate_id", "actor", "causation_id", "correlation_id",
+})
+_ALLOWED_AGGREGATE_TYPES = frozenset({"roadmap", "node", "todo", "report", "proof"})
+_ALLOWED_RELATION_KINDS = frozenset({"depends_on", "validates", "blocks", "contains", "derived_from"})
+_EVENT_TYPE = re.compile(r"^[a-z][a-z0-9]*(?:\.[a-z][a-z0-9]*)+$")
+
+
+def _identifier(value: object, field: str, *, optional: bool = False) -> str | None:
+    if optional and value is None:
+        return None
+    if not isinstance(value, str) or not value or value != value.strip():
+        raise ValueError(f"invalid {field}: must be a non-empty trimmed string")
+    if "/" in value or "\\" in value or any(ord(char) < 32 or ord(char) == 127 for char in value):
+        raise ValueError(f"invalid {field}: path separators and control characters are forbidden")
+    return value
+
+
+def _freeze(value: Any, path: str = "payload") -> Any:
+    if isinstance(value, Mapping):
+        frozen: dict[str, Any] = {}
+        for key, item in value.items():
+            if not isinstance(key, str):
+                raise TypeError(f"{path} keys must be strings")
+            frozen[key] = _freeze(item, f"{path}.{key}")
+        return MappingProxyType(frozen)
+    if isinstance(value, list):
+        return tuple(_freeze(item, f"{path}[]") for item in value)
+    if isinstance(value, tuple):
+        return tuple(_freeze(item, f"{path}[]") for item in value)
+    if isinstance(value, (Scope, QualifiedNodeKey, Relation, EventEnvelope)):
+        return value
+    if value is None or isinstance(value, (str, int, float, bool)):
+        if isinstance(value, float) and (value != value or value in (float("inf"), float("-inf"))):
+            raise TypeError(f"{path} must contain finite JSON values")
+        return value
+    raise TypeError(f"{path} contains unsupported value type {type(value).__name__}")
+
+
+def _json_value(value: Any) -> Any:
+    if isinstance(value, Mapping):
+        return {key: _json_value(item) for key, item in value.items()}
+    if isinstance(value, tuple):
+        return [_json_value(item) for item in value]
+    return value
+
+
+def _payload_hash(payload: Mapping[str, object]) -> str:
+    encoded = json.dumps(_json_value(payload), sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode()
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _utc(value: object, field: str) -> datetime:
+    if not isinstance(value, datetime) or value.tzinfo is None or value.utcoffset() is None:
+        raise ValueError(f"{field} must be timezone-aware")
+    return value.astimezone(timezone.utc)
+
+
+@dataclass(frozen=True, slots=True)
+class Scope:
+    profile_id: str
+    project_id: str
+    roadmap_id: str
+
+    def __post_init__(self) -> None:
+        for field in ("profile_id", "project_id", "roadmap_id"):
+            _identifier(getattr(self, field), field)
+
+    def as_tuple(self) -> tuple[str, str, str]:
+        return self.profile_id, self.project_id, self.roadmap_id
+
+
+@dataclass(frozen=True, slots=True)
+class QualifiedNodeKey:
+    scope: Scope
+    node_id: str
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.scope, Scope):
+            raise TypeError("scope must be a Scope")
+        _identifier(self.node_id, "node_id")
+
+    def as_tuple(self) -> tuple[str, str, str, str]:
+        return (*self.scope.as_tuple(), self.node_id)
+
+
+@dataclass(frozen=True, slots=True)
+class Relation:
+    from_node: QualifiedNodeKey
+    to_node: QualifiedNodeKey
+    kind: str = "depends_on"
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.from_node, QualifiedNodeKey) or not isinstance(self.to_node, QualifiedNodeKey):
+            raise TypeError("relations must reference QualifiedNodeKey values")
+        if self.from_node.scope != self.to_node.scope:
+            raise ValueError("relations must reference nodes in the same scope")
+        if not isinstance(self.kind, str):
+            raise TypeError("relation kind must be a string")
+        if self.kind not in _ALLOWED_RELATION_KINDS:
+            raise ValueError(f"invalid relation kind: {self.kind!r}")
+
+
+@dataclass(frozen=True, slots=True)
+class EventEnvelope:
+    schema_version: int
+    event_id: str
+    event_type: str
+    aggregate_type: str
+    aggregate_id: str
+    scope: Scope
+    actor: str
+    occurred_at: datetime
+    received_at: datetime
+    causation_id: str | None
+    correlation_id: str | None
+    aggregate_version: int
+    payload_hash: str
+
+    def __post_init__(self) -> None:
+        if type(self.schema_version) is not int or self.schema_version != 1:
+            raise ValueError("schema_version must be 1")
+        if not isinstance(self.scope, Scope):
+            raise TypeError("scope must be a Scope")
+        for field in ("event_id", "aggregate_id", "actor"):
+            _identifier(getattr(self, field), field)
+        if not isinstance(self.event_type, str) or _EVENT_TYPE.fullmatch(self.event_type) is None:
+            raise ValueError("event_type must be a lowercase dot-qualified string")
+        if not isinstance(self.aggregate_type, str):
+            raise TypeError("aggregate_type must be a string")
+        if self.aggregate_type not in _ALLOWED_AGGREGATE_TYPES:
+            raise ValueError(f"invalid aggregate_type: {self.aggregate_type!r}")
+        _identifier(self.causation_id, "causation_id", optional=True)
+        _identifier(self.correlation_id, "correlation_id", optional=True)
+        if type(self.aggregate_version) is not int or self.aggregate_version < 1:
+            raise ValueError("aggregate_version must be a positive integer")
+        occurred = _utc(self.occurred_at, "occurred_at")
+        received = _utc(self.received_at, "received_at")
+        if not isinstance(self.payload_hash, str) or re.fullmatch(r"[0-9a-f]{64}", self.payload_hash) is None:
+            raise ValueError("payload_hash must be a sha256 hex digest")
+        object.__setattr__(self, "occurred_at", occurred)
+        object.__setattr__(self, "received_at", received)
+
+
+    @classmethod
+    def create(
+        cls, *, event_id: str, scope: Scope, aggregate_id: str, payload: Mapping[str, object],
+        event_type: str,
+        aggregate_type: str = "roadmap", actor: str = "contract-test", aggregate_version: int = 1,
+        causation_id: str | None = None, correlation_id: str | None = None,
+        occurred_at: datetime | None = None, received_at: datetime | None = None,
+    ) -> "EventEnvelope":
+        now = datetime.now(timezone.utc)
+        if not isinstance(payload, Mapping):
+            raise TypeError("payload must be a mapping")
+        frozen_payload = _freeze(payload)
+        return cls(
+            schema_version=1, event_id=event_id, event_type=event_type, aggregate_type=aggregate_type,
+            aggregate_id=aggregate_id, scope=scope, actor=actor,
+            occurred_at=occurred_at if occurred_at is not None else now,
+            received_at=received_at if received_at is not None else now,
+            causation_id=causation_id, correlation_id=correlation_id,
+            aggregate_version=aggregate_version, payload_hash=_payload_hash(frozen_payload),
+        )
+
+    def ensure_same_identity(self, other: "EventEnvelope") -> None:
+        if not isinstance(other, EventEnvelope):
+            raise TypeError("other must be an EventEnvelope")
+        if self.event_id != other.event_id:
+            raise ValueError("events have different event_id values")
+        # Timestamps are part of identity: a replay is idempotent only when the
+        # complete envelope metadata is byte-for-byte equivalent after UTC
+        # normalization. Payload content is represented by its required hash.
+        comparable = (
+            self.scope, self.event_type, self.aggregate_type, self.aggregate_id, self.actor,
+            self.aggregate_version, self.payload_hash, self.causation_id,
+            self.correlation_id, self.occurred_at, self.received_at,
+        )
+        other_comparable = (
+            other.scope, other.event_type, other.aggregate_type, other.aggregate_id, other.actor,
+            other.aggregate_version, other.payload_hash, other.causation_id,
+            other.correlation_id, other.occurred_at, other.received_at,
+        )
+        if comparable != other_comparable:
+            raise DuplicateEventConflict(f"event_id {self.event_id!r} has conflicting payload or identity")
+
+
+class RoadmapRepository(Protocol):
+    """Read-only repository boundary; this protocol contains no persistence behavior."""
+
+    def list(self, *, profile_id: str, project_id: str) -> tuple[Scope, ...]: ...
+    def get(self, scope: Scope) -> Mapping[str, object]: ...
+    def get_snapshot(self, scope: Scope) -> Mapping[str, object]: ...
+    def get_events_after(self, scope: Scope, cursor: int) -> tuple[EventEnvelope, ...]: ...
+
+
+class FixtureRoadmapRepository:
+    """Injected, immutable in-memory repository used only by contract tests."""
+
+    def __init__(self, scope: Scope, snapshot: Mapping[str, object], events: Sequence[EventEnvelope] = ()) -> None:
+        if not isinstance(scope, Scope):
+            raise TypeError("scope must be a Scope")
+        self._scope = scope
+        frozen_snapshot = _freeze(snapshot)
+        if not isinstance(frozen_snapshot, Mapping):
+            raise TypeError("snapshot must be a mapping")
+        self._snapshot = frozen_snapshot
+        self._events = tuple(events)
+        for event in self._events:
+            if not isinstance(event, EventEnvelope):
+                raise TypeError("events must contain only EventEnvelope values")
+            if event.scope != self._scope:
+                raise ValueError("events must belong to the repository scope")
+
+    def list(self, *, profile_id: str, project_id: str) -> tuple[Scope, ...]:
+        return (self._scope,) if (profile_id, project_id) == self._scope.as_tuple()[:2] else ()
+
+    def get(self, scope: Scope) -> Mapping[str, object]:
+        if scope != self._scope:
+            raise KeyError(scope)
+        return self._snapshot
+
+    def get_snapshot(self, scope: Scope) -> Mapping[str, object]:
+        return self.get(scope)
+
+    def get_events_after(self, scope: Scope, cursor: int) -> tuple[EventEnvelope, ...]:
+        if scope != self._scope:
+            raise KeyError(scope)
+        if type(cursor) is not int or cursor < 0:
+            raise ValueError("cursor must be a non-negative integer")
+        return replay_events(self._events, cursor=cursor)
+
+
+PLAN_TRANSITIONS: dict[str, frozenset[str]] = {
+    "draft": frozenset({"proposed"}), "proposed": frozenset({"validated", "revision_requested"}),
+    "validated": frozenset({"in_progress", "revision_requested"}),
+    "in_progress": frozenset({"blocked", "completed", "revision_requested"}),
+    "blocked": frozenset({"in_progress", "revision_requested"}),
+    "completed": frozenset({"archived", "revision_requested"}),
+    "revision_requested": frozenset({"proposed", "archived"}), "archived": frozenset(),
+}
+NODE_TRANSITIONS: dict[str, frozenset[str]] = {
+    "planned": frozenset({"ready"}), "ready": frozenset({"in_progress"}),
+    "in_progress": frozenset({"blocked", "completed"}), "blocked": frozenset({"in_progress", "completed"}),
+    "completed": frozenset({"archived"}), "archived": frozenset(),
+}
+
+
+def _transition(table: Mapping[str, frozenset[str]], kind: str, current: str, target: str) -> str:
+    if target not in table.get(current, frozenset()):
+        raise ValueError(f"invalid {kind} transition: {current!r} -> {target!r}")
+    return target
+
+
+def transition_plan(current: str, target: str) -> str:
+    return _transition(PLAN_TRANSITIONS, "plan", current, target)
+
+
+def transition_node(current: str, target: str) -> str:
+    return _transition(NODE_TRANSITIONS, "node", current, target)
+
+
+def replay_events(events: Sequence[EventEnvelope], cursor: int = 0) -> tuple[EventEnvelope, ...]:
+    """Validate the complete stream, then return the suffix after ``cursor``."""
+    if type(cursor) is not int or cursor < 0 or cursor > len(events):
+        raise ValueError("cursor must be within the event stream")
+    versions: dict[tuple[Scope, str, str], int] = {}
+    identities: dict[str, EventEnvelope] = {}
+    for event in events:
+        if not isinstance(event, EventEnvelope):
+            raise TypeError("events must contain only EventEnvelope values")
+        previous = identities.get(event.event_id)
+        if previous is not None:
+            previous.ensure_same_identity(event)
+            # An exactly identical duplicate is an idempotent replay, not a
+            # second application of the same aggregate version.
+            continue
+        identities[event.event_id] = event
+        key = (event.scope, event.aggregate_type, event.aggregate_id)
+        if event.aggregate_version <= versions.get(key, 0):
+            raise StaleEventError(
+                f"aggregate {event.aggregate_id!r} received non-increasing version {event.aggregate_version}"
+            )
+        versions[key] = event.aggregate_version
+    emitted_ids: set[str] = {event.event_id for event in events[:cursor]}
+    unique_suffix: list[EventEnvelope] = []
+    for event in events[cursor:]:
+        if event.event_id not in emitted_ids:
+            unique_suffix.append(event)
+            emitted_ids.add(event.event_id)
+    return tuple(unique_suffix)
+
+
+def build_fixture(scope: Scope) -> Mapping[str, object]:
+    """Return a small in-memory fixture; never persist or mutate external state."""
+    nodes = (QualifiedNodeKey(scope, "objective"), QualifiedNodeKey(scope, "step-1"), QualifiedNodeKey(scope, "proof-1"))
+    return MappingProxyType({
+        "scope": scope, "plan_snapshot": MappingProxyType({"version": 1, "state": "validated"}),
+        "execution_state": "ready", "reported_state": "none", "verification_state": "unverified",
+        "todos": (), "nodes": nodes, "relations": (Relation(nodes[1], nodes[2], "validates"),),
+    })
+
+
+FixtureRepository: TypeAlias = FixtureRoadmapRepository

--- a/tests/hermes_cli/test_projects_db_roadmaps.py
+++ b/tests/hermes_cli/test_projects_db_roadmaps.py
@@ -1,0 +1,319 @@
+"""Integration tests for the Roadmaps schema in the real projects store."""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import projects_db as pdb
+
+
+TABLES = {
+    "roadmaps",
+    "roadmap_versions",
+    "roadmap_nodes",
+    "roadmap_relations",
+    "roadmap_sessions",
+    "roadmap_todos",
+}
+
+ROADMAP_COLUMNS = {
+    "roadmaps": "profile_id TEXT, project_id TEXT, roadmap_id TEXT, title TEXT, purpose TEXT, lifecycle_state TEXT, active_version INTEGER, created_by TEXT, updated_by TEXT, created_at INTEGER, updated_at INTEGER",
+    "roadmap_versions": "profile_id TEXT, project_id TEXT, roadmap_id TEXT, version INTEGER, state TEXT, source TEXT, reason TEXT, created_by TEXT, created_at INTEGER, content_hash TEXT",
+    "roadmap_nodes": "profile_id TEXT, project_id TEXT, roadmap_id TEXT, version INTEGER, node_id TEXT, parent_node_id TEXT, kind TEXT, title TEXT, description TEXT, state TEXT, progress INTEGER, owner_agent TEXT, block_reason TEXT, created_at INTEGER, updated_at INTEGER",
+    "roadmap_relations": "profile_id TEXT, project_id TEXT, roadmap_id TEXT, version INTEGER, relation_id TEXT, from_node_id TEXT, to_node_id TEXT, kind TEXT, state TEXT, reason TEXT",
+    "roadmap_sessions": "profile_id TEXT, project_id TEXT, roadmap_id TEXT, stored_session_id TEXT, kind TEXT, node_id TEXT, plan_version INTEGER, state TEXT, actor TEXT, created_at INTEGER, updated_at INTEGER",
+    "roadmap_todos": "profile_id TEXT, project_id TEXT, roadmap_id TEXT, version INTEGER, todo_id TEXT, node_id TEXT, title TEXT, state TEXT, position INTEGER, created_at INTEGER, updated_at INTEGER",
+}
+
+
+def _open(path: Path) -> sqlite3.Connection:
+    return pdb.connect(db_path=path)
+
+
+def _seed(conn: sqlite3.Connection, profile: str = "profile-a", project: str = "project-a") -> None:
+    conn.execute("INSERT INTO projects(id, slug, name, created_at) VALUES (?, ?, ?, ?)", (project, project, project, 1))
+    conn.execute(
+        "INSERT INTO roadmaps VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        (profile, project, "roadmap-a", "Roadmap", None, "draft", None, "actor", "actor", 1, 1),
+    )
+    conn.execute(
+        "INSERT INTO roadmap_versions VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        (profile, project, "roadmap-a", 1, "draft", "test", None, "actor", 1, None),
+    )
+    conn.execute(
+        "INSERT INTO roadmap_nodes VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        (profile, project, "roadmap-a", 1, "node-a", None, "objective", "A", None, "planned", 0, None, None, 1, 1),
+    )
+    conn.commit()
+
+
+def test_real_store_creates_roadmaps_schema_idempotently_and_preserves_legacy(tmp_path: Path) -> None:
+    path = tmp_path / "profile" / "projects.db"
+    first = _open(path)
+    assert first.execute("PRAGMA foreign_keys").fetchone()[0] == 1
+    first.execute("CREATE TABLE legacy (id INTEGER PRIMARY KEY, value TEXT)")
+    first.execute("INSERT INTO legacy VALUES (1, 'keep')")
+    first.execute("CREATE INDEX legacy_value ON legacy(value)")
+    first.commit()
+    first.close()
+
+    second = _open(path)
+    assert {row[0] for row in second.execute("SELECT name FROM sqlite_master WHERE type='table' AND name LIKE 'roadmap%'")} == TABLES
+    assert second.execute("SELECT value FROM legacy WHERE id=1").fetchone()[0] == "keep"
+    assert "legacy_value" in {row[1] for row in second.execute("PRAGMA index_list(legacy)")}
+    second.close()
+
+    third = _open(path)
+    assert {row[0] for row in third.execute("SELECT name FROM sqlite_master WHERE type='table' AND name LIKE 'roadmap%'")} == TABLES
+    third.close()
+
+
+def test_real_store_enforces_active_version_and_qualified_node_relation_todo_scope(tmp_path: Path) -> None:
+    conn = _open(tmp_path / "projects.db")
+    _seed(conn)
+
+    conn.execute("UPDATE roadmaps SET active_version=1")
+    conn.commit()
+    with pytest.raises(sqlite3.IntegrityError):
+        conn.execute("UPDATE roadmaps SET active_version=99")
+        conn.commit()
+    conn.rollback()
+
+    with pytest.raises(sqlite3.IntegrityError):
+        conn.execute(
+            "INSERT INTO roadmap_nodes VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            ("profile-b", "project-a", "roadmap-a", 1, "foreign", None, "step", "bad", None, "planned", 0, None, None, 1, 1),
+        )
+    with pytest.raises(sqlite3.IntegrityError):
+        conn.execute(
+            "INSERT INTO roadmap_relations VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            ("profile-a", "project-a", "roadmap-a", 1, "rel", "node-a", "missing", "depends_on", "active", None),
+        )
+    with pytest.raises(sqlite3.IntegrityError):
+        conn.execute(
+            "INSERT INTO roadmap_todos VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            ("profile-a", "project-a", "roadmap-a", 1, "todo", "missing", "T", "open", 0, 1, 1),
+        )
+    conn.close()
+
+
+def test_roadmap_sessions_schema_enforces_durable_vision_contract(tmp_path: Path) -> None:
+    conn = _open(tmp_path / "projects.db")
+    _seed(conn)
+
+    columns = {row[1] for row in conn.execute("PRAGMA table_info(roadmap_sessions)")}
+    assert columns == {
+        "profile_id", "project_id", "roadmap_id", "stored_session_id", "kind",
+        "node_id", "plan_version", "state", "actor", "created_at", "updated_at",
+    }
+    assert "runtime_session_id" not in columns
+
+    conn.execute(
+        "INSERT INTO roadmap_sessions "
+        "(profile_id, project_id, roadmap_id, stored_session_id, kind, state, actor, created_at, updated_at) "
+        "VALUES ('profile-a', 'project-a', 'roadmap-a', 'stored-1', 'vision', 'active', 'actor', 1, 1)"
+    )
+    with pytest.raises(sqlite3.IntegrityError):
+        conn.execute(
+            "INSERT INTO roadmap_sessions "
+            "(profile_id, project_id, roadmap_id, stored_session_id, kind, state, actor, created_at, updated_at) "
+            "VALUES ('profile-a', 'project-a', 'roadmap-a', 'stored-2', 'vision', 'active', 'actor', 1, 1)"
+        )
+    with pytest.raises(sqlite3.IntegrityError):
+        conn.execute(
+            "INSERT INTO roadmap_sessions "
+            "(profile_id, project_id, roadmap_id, stored_session_id, kind, state, actor, created_at, updated_at) "
+            "VALUES ('profile-a', 'project-a', 'roadmap-a', 'stored-x', 'node', 'closed', 'actor', 1, 1)"
+        )
+    conn.rollback()
+
+    conn.execute("DELETE FROM roadmaps WHERE roadmap_id='roadmap-a'")
+    conn.commit()
+    assert conn.execute("SELECT COUNT(*) FROM roadmap_sessions").fetchone()[0] == 0
+    conn.close()
+
+
+def test_connect_additively_restores_missing_roadmap_sessions_table(tmp_path: Path) -> None:
+    path = tmp_path / "projects.db"
+    raw = sqlite3.connect(path)
+    raw.executescript(pdb.SCHEMA_SQL)
+    raw.execute("DROP TABLE roadmap_sessions")
+    raw.commit()
+    raw.close()
+
+    conn = _open(path)
+    assert conn.execute(
+        "SELECT 1 FROM sqlite_master WHERE type='table' AND name='roadmap_sessions'"
+    ).fetchone() is not None
+    conn.close()
+
+
+def test_real_store_preserves_project_cascade_and_isolates_db_paths(tmp_path: Path) -> None:
+    first = _open(tmp_path / "a" / "projects.db")
+    second = _open(tmp_path / "b" / "projects.db")
+    _seed(first, "profile-a")
+    _seed(second, "profile-b")
+    assert first.execute("SELECT profile_id FROM roadmaps").fetchone()[0] == "profile-a"
+    assert second.execute("SELECT profile_id FROM roadmaps").fetchone()[0] == "profile-b"
+
+    first.execute("DELETE FROM projects WHERE id='project-a'")
+    first.commit()
+    for table in TABLES:
+        assert first.execute(f"SELECT COUNT(*) FROM {table}").fetchone()[0] == 0
+    assert second.execute("SELECT COUNT(*) FROM roadmaps").fetchone()[0] == 1
+    first.close()
+    second.close()
+
+
+def test_real_store_keeps_deferred_runtime_tables_out_of_phase_one(tmp_path: Path) -> None:
+    conn = _open(tmp_path / "projects.db")
+    names = {row[0] for row in conn.execute("SELECT name FROM sqlite_master WHERE type='table'")}
+    assert not names.intersection({"reports", "proofs", "events", "agent_projections"})
+    conn.close()
+
+
+@pytest.mark.parametrize("table", sorted(TABLES))
+def test_real_store_rejects_same_columns_without_roadmap_constraints(
+    tmp_path: Path, table: str
+) -> None:
+    path = tmp_path / f"{table}.db"
+    raw = sqlite3.connect(path)
+    raw.execute(f"CREATE TABLE {table} ({ROADMAP_COLUMNS[table]})")
+    raw.commit()
+    raw.close()
+
+    with pytest.raises((sqlite3.DatabaseError, ValueError), match=table):
+        _open(path)
+
+
+def test_connect_rejects_weakened_core_projects_without_roadmaps_residue(tmp_path: Path) -> None:
+    path = tmp_path / "projects.db"
+    raw = sqlite3.connect(path)
+    raw.execute(
+        "CREATE TABLE projects ("
+        "id TEXT, slug TEXT, name TEXT, description TEXT, icon TEXT, color TEXT, "
+        "board_slug TEXT, primary_path TEXT, created_at INTEGER, archived INTEGER)"
+    )
+    raw.commit()
+    raw.close()
+
+    with pytest.raises((sqlite3.DatabaseError, ValueError), match="projects"):
+        _open(path)
+
+    check = sqlite3.connect(path)
+    names = {
+        row[0]
+        for row in check.execute("SELECT name FROM sqlite_master WHERE type='table'")
+    }
+    assert not names.intersection(TABLES)
+    check.close()
+
+
+def test_connect_rejects_projects_with_non_unique_slug_without_roadmaps_residue(tmp_path: Path) -> None:
+    path = tmp_path / "projects.db"
+    raw = sqlite3.connect(path)
+    raw.execute(
+        "CREATE TABLE projects ("
+        "id TEXT PRIMARY KEY, slug TEXT NOT NULL, name TEXT NOT NULL, "
+        "description TEXT, icon TEXT, color TEXT, board_slug TEXT, "
+        "primary_path TEXT, created_at INTEGER NOT NULL, archived INTEGER NOT NULL)"
+    )
+    raw.commit()
+    raw.close()
+
+    with pytest.raises(sqlite3.DatabaseError, match="projects"):
+        _open(path)
+
+    check = sqlite3.connect(path)
+    names = {row[0] for row in check.execute("SELECT name FROM sqlite_master WHERE type='table'")}
+    assert not names.intersection(TABLES)
+    check.close()
+
+
+def test_connect_rejects_orphan_roadmaps_after_restoring_missing_projects(tmp_path: Path) -> None:
+    path = tmp_path / "projects.db"
+    raw = sqlite3.connect(path)
+    raw.executescript(pdb.SCHEMA_SQL)
+    raw.execute(
+        "INSERT INTO roadmaps VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        ("profile-a", "missing-project", "roadmap-a", "Roadmap", None, "draft", None, "actor", "actor", 1, 1),
+    )
+    raw.execute("DROP TABLE projects")
+    raw.commit()
+    raw.close()
+
+    with pytest.raises(sqlite3.DatabaseError, match="foreign key"):
+        _open(path)
+
+
+def test_connect_retries_optional_project_column_migration_with_complete_roadmaps_schema(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "projects.db"
+    raw = sqlite3.connect(path)
+    raw.executescript(pdb.SCHEMA_SQL.replace("    board_slug    TEXT,\n", ""))
+    raw.commit()
+    raw.close()
+
+    conn = _open(path)
+    assert "board_slug" in {
+        row[1] for row in conn.execute("PRAGMA table_info(projects)")
+    }
+    conn.close()
+
+
+def test_connect_rejects_roadmap_check_contract_tampering(tmp_path: Path) -> None:
+    path = tmp_path / "projects.db"
+    raw = sqlite3.connect(path)
+    raw.executescript(pdb.SCHEMA_SQL)
+    original = raw.execute(
+        "SELECT sql FROM sqlite_master WHERE type='table' AND name='roadmaps'"
+    ).fetchone()[0]
+    tampered = original.replace("'archived'))", "'archived','bogus'))")
+    assert tampered != original
+    raw.execute("PRAGMA writable_schema=ON")
+    raw.execute(
+        "UPDATE sqlite_master SET sql=? WHERE type='table' AND name='roadmaps'",
+        (tampered,),
+    )
+    raw.commit()
+    raw.close()
+
+    with pytest.raises((sqlite3.DatabaseError, ValueError), match="roadmaps"):
+        _open(path)
+
+
+def test_connect_restores_missing_core_schema_with_complete_roadmaps(tmp_path: Path) -> None:
+    path = tmp_path / "projects.db"
+    raw = sqlite3.connect(path)
+    raw.executescript(pdb.SCHEMA_SQL)
+    raw.execute("DROP TABLE projects")
+    raw.commit()
+    raw.close()
+
+    conn = _open(path)
+    names = {
+        row[0]
+        for row in conn.execute("SELECT name FROM sqlite_master WHERE type='table'")
+    }
+    assert {"projects", "project_folders", "project_meta", "discovered_repos"}.issubset(names)
+    assert TABLES.issubset(names)
+    assert "idx_project_folders_path" in {
+        row[1] for row in conn.execute("PRAGMA index_list(project_folders)")
+    }
+    conn.close()
+
+
+def test_real_store_reinitializes_after_database_file_is_replaced(tmp_path: Path) -> None:
+    path = tmp_path / "projects.db"
+    first = _open(path)
+    first.close()
+    path.unlink()
+
+    second = _open(path)
+    names = {row[0] for row in second.execute("SELECT name FROM sqlite_master WHERE type='table'")}
+    assert TABLES.issubset(names)
+    second.close()

--- a/tests/test_roadmaps_contract.py
+++ b/tests/test_roadmaps_contract.py
@@ -1,0 +1,216 @@
+"""Executable Phase 0 invariants for the pure Roadmaps contract."""
+
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+import sys
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parents[1] / "src"))
+
+from roadmaps_contract import (  # noqa: E402
+    DuplicateEventConflict,
+    EventEnvelope,
+    FixtureRoadmapRepository,
+    QualifiedNodeKey,
+    Relation,
+    Scope,
+    StaleEventError,
+    build_fixture,
+    replay_events,
+    transition_node,
+    transition_plan,
+)
+
+
+@pytest.fixture
+def scope() -> Scope:
+    return Scope("profile-a", "project-a", "roadmap-a")
+
+
+def event(scope: Scope, *, version: int = 1, event_id: str | None = None, payload: dict | None = None, event_type: str = "roadmap.node.progressed") -> EventEnvelope:
+    return EventEnvelope.create(
+        event_id=event_id or f"evt-{version}", scope=scope, aggregate_id="roadmap-a",
+        aggregate_version=version, payload=payload or {"state": "ready", "nested": {"items": [1, 2]}},
+        event_type=event_type,
+        occurred_at=datetime(2026, 8, 14, 12, 0, tzinfo=timezone(timedelta(hours=2))),
+        received_at=datetime(2026, 8, 14, 12, 1, tzinfo=timezone.utc),
+    )
+
+
+def test_scope_and_qualified_node_key_preserve_profile_project_roadmap_identity(scope: Scope) -> None:
+    assert scope.as_tuple() == ("profile-a", "project-a", "roadmap-a")
+    assert QualifiedNodeKey(scope, "node-1").as_tuple() == ("profile-a", "project-a", "roadmap-a", "node-1")
+
+
+def test_cross_profile_project_and_roadmap_relations_are_rejected(scope: Scope) -> None:
+    source = QualifiedNodeKey(scope, "from")
+    for other in (Scope("profile-b", "project-a", "roadmap-a"), Scope("profile-a", "project-b", "roadmap-a"), Scope("profile-a", "project-a", "roadmap-b")):
+        with pytest.raises(ValueError, match="same scope"):
+            Relation(source, QualifiedNodeKey(other, "to"))
+
+
+def test_relation_kind_and_identifiers_are_strict(scope: Scope) -> None:
+    with pytest.raises(ValueError, match="relation kind"):
+        Relation(QualifiedNodeKey(scope, "from"), QualifiedNodeKey(scope, "to"), "unknown")
+    with pytest.raises(TypeError, match="relation kind"):
+        Relation(QualifiedNodeKey(scope, "from"), QualifiedNodeKey(scope, "to"), 3)  # type: ignore[arg-type]
+    for bad in ("", " trimmed", "trimmed ", "a/b", "a\\b", "a\x00b", 3):
+        with pytest.raises((ValueError, TypeError)):
+            Scope(bad, "project-a", "roadmap-a")  # type: ignore[arg-type]
+    with pytest.raises(ValueError):
+        QualifiedNodeKey(scope, "node/id")
+
+
+def test_event_hash_is_deterministic_and_payload_is_not_retained(scope: Scope) -> None:
+    source = {"nested": {"items": [1, 2]}, "state": "ready"}
+    first = event(scope, payload=source)
+    second = EventEnvelope.create(event_id="other", scope=scope, aggregate_id="roadmap-a", event_type="roadmap.node.progressed", payload={"nested": {"items": [1, 2]}, "state": "ready"}, occurred_at=first.occurred_at, received_at=first.received_at)
+    assert first.payload_hash == second.payload_hash
+    source["nested"]["items"].append(3)
+    source["state"] = "blocked"
+    assert first.payload_hash == second.payload_hash
+    assert not hasattr(first, "payload")
+
+
+def test_event_timestamps_are_aware_and_normalized_to_utc(scope: Scope) -> None:
+    current = event(scope)
+    assert current.occurred_at.tzinfo is timezone.utc
+    assert current.occurred_at.hour == 10
+    assert current.received_at.tzinfo is timezone.utc
+
+
+def test_event_constructor_rejects_arbitrary_hash_and_invalid_identity(scope: Scope) -> None:
+    current = event(scope)
+    with pytest.raises(ValueError, match="payload_hash"):
+        EventEnvelope(1, "evt", "roadmap.node.progressed", "roadmap", "roadmap-a", scope, "actor", current.occurred_at, current.received_at, None, None, 1, "arbitrary")
+    with pytest.raises(ValueError, match="schema_version"):
+        EventEnvelope(2, current.event_id, current.event_type, current.aggregate_type, current.aggregate_id, scope, current.actor, current.occurred_at, current.received_at, None, None, 1, current.payload_hash)
+    with pytest.raises(TypeError, match="payload"):
+        EventEnvelope.create(event_id="evt-payload", scope=scope, aggregate_id="roadmap-a", event_type="roadmap.node.progressed", payload=None)  # type: ignore[arg-type]
+    with pytest.raises(TypeError, match="aggregate_type"):
+        EventEnvelope.create(event_id="evt-type", scope=scope, aggregate_id="roadmap-a", event_type="roadmap.node.progressed", aggregate_type=3, payload={})  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize("bad_event_type", ("", " roadmap.node.progressed", "roadmap.node.progressed ", "roadmap/node", "roadmap\x00node", 3, None))
+def test_event_type_is_required_and_strict(scope: Scope, bad_event_type: object) -> None:
+    with pytest.raises((ValueError, TypeError), match="event_type"):
+        EventEnvelope.create(event_id="evt-type", scope=scope, aggregate_id="roadmap-a", event_type=bad_event_type, payload={})  # type: ignore[arg-type]
+
+
+def test_duplicate_event_id_with_different_event_type_is_rejected(scope: Scope) -> None:
+    first = event(scope, event_id="evt-1")
+    different = event(scope, event_id="evt-1", event_type="roadmap.node.completed")
+    with pytest.raises(DuplicateEventConflict):
+        replay_events((first, different))
+
+
+def test_duplicate_event_id_with_different_payload_is_rejected(scope: Scope) -> None:
+    first = event(scope, event_id="evt-1")
+    different = event(scope, event_id="evt-1", payload={"state": "blocked"})
+    with pytest.raises(DuplicateEventConflict):
+        first.ensure_same_identity(different)
+
+
+def test_duplicate_event_id_with_same_payload_is_idempotent(scope: Scope) -> None:
+    first = event(scope, event_id="evt-1")
+    replay = event(scope, event_id="evt-1")
+    assert first.ensure_same_identity(replay) is None
+
+
+def test_replay_identical_duplicate_event_id_is_idempotent(scope: Scope) -> None:
+    first = event(scope, event_id="evt-1")
+    assert replay_events((first, first)) == (first,)
+
+
+def test_duplicate_event_id_with_different_version_is_rejected(scope: Scope) -> None:
+    first = event(scope, event_id="evt-1", version=1)
+    different = event(scope, event_id="evt-1", version=2)
+    with pytest.raises(DuplicateEventConflict):
+        replay_events((first, different))
+
+
+@pytest.mark.parametrize("field", ("actor", "correlation_id"))
+def test_duplicate_event_id_with_different_metadata_is_rejected(scope: Scope, field: str) -> None:
+    first = event(scope, event_id="evt-1")
+    kwargs = {field: "different-actor" if field == "actor" else "corr-2"}
+    different = EventEnvelope.create(
+        event_id=first.event_id, scope=scope, aggregate_id=first.aggregate_id,
+        event_type="roadmap.node.progressed",
+        aggregate_version=first.aggregate_version, payload={"state": "ready", "nested": {"items": [1, 2]}},
+        actor=kwargs.get("actor", first.actor), correlation_id=kwargs.get("correlation_id"),
+        occurred_at=first.occurred_at, received_at=first.received_at,
+    )
+    with pytest.raises(DuplicateEventConflict):
+        replay_events((first, different))
+
+
+def test_duplicate_event_id_with_different_timestamp_is_rejected(scope: Scope) -> None:
+    first = event(scope, event_id="evt-1")
+    different = EventEnvelope.create(
+        event_id=first.event_id, scope=scope, aggregate_id=first.aggregate_id,
+        event_type="roadmap.node.progressed",
+        aggregate_version=first.aggregate_version, payload={"state": "ready", "nested": {"items": [1, 2]}},
+        occurred_at=first.occurred_at + timedelta(seconds=1), received_at=first.received_at,
+    )
+    with pytest.raises(DuplicateEventConflict):
+        replay_events((first, different))
+
+
+def test_replay_from_cursor_returns_only_new_events(scope: Scope) -> None:
+    stream = (event(scope, version=1), event(scope, version=2), event(scope, version=3))
+    assert replay_events(stream, cursor=2) == stream[2:]
+
+
+def test_replay_deduplicates_duplicates_after_cursor(scope: Scope) -> None:
+    first = event(scope, version=1, event_id="evt-1")
+    second = event(scope, version=2, event_id="evt-2")
+    assert replay_events((first, second, first, second), cursor=0) == (first, second)
+    assert replay_events((first, second, first, second), cursor=2) == ()
+
+
+def test_fixture_repository_deduplicates_duplicate_events(scope: Scope) -> None:
+    first = event(scope, version=1, event_id="evt-1")
+    second = event(scope, version=2, event_id="evt-2")
+    repository = FixtureRoadmapRepository(scope, build_fixture(scope), (first, second, first, second))
+    assert repository.get_events_after(scope, 0) == (first, second)
+
+
+def test_replay_rejects_late_or_regressive_aggregate_version(scope: Scope) -> None:
+    with pytest.raises(StaleEventError):
+        replay_events((event(scope, version=1), event(scope, version=3), event(scope, version=2)))
+
+
+def test_fixture_repository_rejects_non_monotonic_stream(scope: Scope) -> None:
+    repository = FixtureRoadmapRepository(scope, build_fixture(scope), (event(scope, version=1), event(scope, version=3), event(scope, version=2)))
+    with pytest.raises(StaleEventError):
+        repository.get_events_after(scope, 0)
+
+
+def test_fixture_repository_rejects_event_outside_scope(scope: Scope) -> None:
+    other_scope = Scope("profile-a", "project-a", "roadmap-b")
+    with pytest.raises(ValueError, match="scope"):
+        FixtureRoadmapRepository(scope, build_fixture(scope), (event(other_scope),))
+
+
+def test_fixture_repository_is_injected_read_only_and_does_not_write(tmp_path: Path, scope: Scope) -> None:
+    before = {path.relative_to(tmp_path) for path in tmp_path.rglob("*")}
+    repository = FixtureRoadmapRepository(scope, build_fixture(scope), (event(scope, version=1), event(scope, version=2)))
+    assert repository.list(profile_id="profile-a", project_id="project-a") == (scope,)
+    assert repository.get_snapshot(scope)["scope"] == scope
+    assert repository.get_snapshot(scope)["todos"] == ()
+    assert repository.get_events_after(scope, 1)[0].aggregate_version == 2
+    assert not any(name in dir(repository) for name in ("save", "write", "update", "delete", "persist"))
+    with pytest.raises(TypeError):
+        repository.get(scope)["new"] = "mutation"  # type: ignore[index]
+    assert before == {path.relative_to(tmp_path) for path in tmp_path.rglob("*")}
+
+
+def test_terminal_transitions_are_rejected_and_essential_transitions_are_valid() -> None:
+    assert transition_plan("draft", "proposed") == "proposed"
+    assert transition_plan("validated", "in_progress") == "in_progress"
+    assert transition_node("planned", "ready") == "ready"
+    assert transition_node("blocked", "completed") == "completed"
+    for transition in (("archived", "draft", transition_plan), ("archived", "ready", transition_node), ("completed", "in_progress", transition_node)):
+        with pytest.raises(ValueError):
+            transition[2](transition[0], transition[1])

--- a/tests/test_roadmaps_store_phase1_contract.py
+++ b/tests/test_roadmaps_store_phase1_contract.py
@@ -1,0 +1,571 @@
+"""Phase 1 SQLite contract tests.
+
+These tests are deliberately self-contained even though the runtime
+``hermes_cli/projects_db.py`` is present in this worktree: porting the DDL to
+that runtime is a separate task.  The DDL is a preparatory contract, not a
+replacement backend implementation.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+
+ROADMAPS_SCHEMA = """
+CREATE TABLE IF NOT EXISTS roadmaps (
+    profile_id TEXT NOT NULL CHECK (length(trim(replace(replace(replace(profile_id, char(9), ''), char(10), ''), char(13), ''))) > 0),
+    project_id TEXT NOT NULL CHECK (length(trim(replace(replace(replace(project_id, char(9), ''), char(10), ''), char(13), ''))) > 0) REFERENCES projects(id) ON DELETE CASCADE,
+    roadmap_id TEXT NOT NULL CHECK (length(trim(replace(replace(replace(roadmap_id, char(9), ''), char(10), ''), char(13), ''))) > 0),
+    title TEXT NOT NULL,
+    purpose TEXT,
+    lifecycle_state TEXT NOT NULL CHECK (lifecycle_state IN
+        ('draft','proposed','validated','in_progress','blocked','completed','archived')),
+    active_version INTEGER CHECK (active_version IS NULL OR active_version >= 1),
+    created_by TEXT NOT NULL CHECK (length(trim(replace(replace(replace(created_by, char(9), ''), char(10), ''), char(13), ''))) > 0),
+    updated_by TEXT NOT NULL CHECK (length(trim(replace(replace(replace(updated_by, char(9), ''), char(10), ''), char(13), ''))) > 0),
+    created_at INTEGER NOT NULL,
+    updated_at INTEGER NOT NULL,
+    PRIMARY KEY (profile_id, project_id, roadmap_id),
+    FOREIGN KEY (profile_id, project_id, roadmap_id, active_version)
+      REFERENCES roadmap_versions(profile_id, project_id, roadmap_id, version)
+      DEFERRABLE INITIALLY DEFERRED
+);
+CREATE TABLE IF NOT EXISTS roadmap_versions (
+    profile_id TEXT NOT NULL CHECK (length(trim(replace(replace(replace(profile_id, char(9), ''), char(10), ''), char(13), ''))) > 0),
+    project_id TEXT NOT NULL CHECK (length(trim(replace(replace(replace(project_id, char(9), ''), char(10), ''), char(13), ''))) > 0),
+    roadmap_id TEXT NOT NULL CHECK (length(trim(replace(replace(replace(roadmap_id, char(9), ''), char(10), ''), char(13), ''))) > 0),
+    version INTEGER NOT NULL CHECK (version >= 1),
+    state TEXT NOT NULL CHECK (state IN ('draft','proposed','validated','superseded','archived')),
+    source TEXT,
+    reason TEXT,
+    created_by TEXT NOT NULL CHECK (length(trim(replace(replace(replace(created_by, char(9), ''), char(10), ''), char(13), ''))) > 0),
+    created_at INTEGER NOT NULL,
+    content_hash TEXT,
+    PRIMARY KEY (profile_id, project_id, roadmap_id, version),
+    FOREIGN KEY (profile_id, project_id, roadmap_id)
+      REFERENCES roadmaps(profile_id, project_id, roadmap_id) ON DELETE CASCADE
+);
+CREATE TABLE IF NOT EXISTS roadmap_nodes (
+    profile_id TEXT NOT NULL CHECK (length(trim(replace(replace(replace(profile_id, char(9), ''), char(10), ''), char(13), ''))) > 0),
+    project_id TEXT NOT NULL CHECK (length(trim(replace(replace(replace(project_id, char(9), ''), char(10), ''), char(13), ''))) > 0),
+    roadmap_id TEXT NOT NULL CHECK (length(trim(replace(replace(replace(roadmap_id, char(9), ''), char(10), ''), char(13), ''))) > 0),
+    version INTEGER NOT NULL,
+    node_id TEXT NOT NULL CHECK (length(trim(replace(replace(replace(node_id, char(9), ''), char(10), ''), char(13), ''))) > 0),
+    parent_node_id TEXT,
+    kind TEXT NOT NULL CHECK (kind IN ('objective','phase','milestone','step','decision')),
+    title TEXT NOT NULL,
+    description TEXT,
+    state TEXT NOT NULL CHECK (state IN ('planned','ready','in_progress','blocked','completed','archived')),
+    progress INTEGER NOT NULL DEFAULT 0 CHECK (progress BETWEEN 0 AND 100),
+    owner_agent TEXT CHECK (owner_agent IS NULL OR length(trim(replace(replace(replace(owner_agent, char(9), ''), char(10), ''), char(13), ''))) > 0),
+    block_reason TEXT,
+    created_at INTEGER NOT NULL,
+    updated_at INTEGER NOT NULL,
+    PRIMARY KEY (profile_id, project_id, roadmap_id, version, node_id),
+    FOREIGN KEY (profile_id, project_id, roadmap_id, version)
+      REFERENCES roadmap_versions(profile_id, project_id, roadmap_id, version) ON DELETE CASCADE,
+    FOREIGN KEY (profile_id, project_id, roadmap_id, version, parent_node_id)
+      REFERENCES roadmap_nodes(profile_id, project_id, roadmap_id, version, node_id),
+    CHECK (parent_node_id IS NULL OR (length(trim(replace(replace(replace(parent_node_id, char(9), ''), char(10), ''), char(13), ''))) > 0 AND parent_node_id <> node_id))
+);
+CREATE TABLE IF NOT EXISTS roadmap_relations (
+    profile_id TEXT NOT NULL CHECK (length(trim(replace(replace(replace(profile_id, char(9), ''), char(10), ''), char(13), ''))) > 0),
+    project_id TEXT NOT NULL CHECK (length(trim(replace(replace(replace(project_id, char(9), ''), char(10), ''), char(13), ''))) > 0),
+    roadmap_id TEXT NOT NULL CHECK (length(trim(replace(replace(replace(roadmap_id, char(9), ''), char(10), ''), char(13), ''))) > 0),
+    version INTEGER NOT NULL,
+    relation_id TEXT NOT NULL CHECK (length(trim(replace(replace(replace(relation_id, char(9), ''), char(10), ''), char(13), ''))) > 0),
+    from_node_id TEXT NOT NULL CHECK (length(trim(replace(replace(replace(from_node_id, char(9), ''), char(10), ''), char(13), ''))) > 0),
+    to_node_id TEXT NOT NULL CHECK (length(trim(replace(replace(replace(to_node_id, char(9), ''), char(10), ''), char(13), ''))) > 0),
+    kind TEXT NOT NULL CHECK (kind IN ('depends_on','blocks','enables','follows','validates','supersedes')),
+    state TEXT NOT NULL DEFAULT 'active' CHECK (state IN ('active','superseded','invalid')),
+    reason TEXT,
+    PRIMARY KEY (profile_id, project_id, roadmap_id, version, relation_id),
+    FOREIGN KEY (profile_id, project_id, roadmap_id, version, from_node_id)
+      REFERENCES roadmap_nodes(profile_id, project_id, roadmap_id, version, node_id) ON DELETE CASCADE,
+    FOREIGN KEY (profile_id, project_id, roadmap_id, version, to_node_id)
+      REFERENCES roadmap_nodes(profile_id, project_id, roadmap_id, version, node_id) ON DELETE CASCADE,
+    CHECK (from_node_id <> to_node_id)
+);
+CREATE TABLE IF NOT EXISTS roadmap_todos (
+    profile_id TEXT NOT NULL CHECK (length(trim(replace(replace(replace(profile_id, char(9), ''), char(10), ''), char(13), ''))) > 0),
+    project_id TEXT NOT NULL CHECK (length(trim(replace(replace(replace(project_id, char(9), ''), char(10), ''), char(13), ''))) > 0),
+    roadmap_id TEXT NOT NULL CHECK (length(trim(replace(replace(replace(roadmap_id, char(9), ''), char(10), ''), char(13), ''))) > 0),
+    version INTEGER NOT NULL,
+    todo_id TEXT NOT NULL CHECK (length(trim(replace(replace(replace(todo_id, char(9), ''), char(10), ''), char(13), ''))) > 0),
+    node_id TEXT CHECK (node_id IS NULL OR length(trim(replace(replace(replace(node_id, char(9), ''), char(10), ''), char(13), ''))) > 0),
+    title TEXT NOT NULL,
+    state TEXT NOT NULL CHECK (state IN ('open','in_progress','done','cancelled')),
+    position INTEGER NOT NULL DEFAULT 0,
+    created_at INTEGER NOT NULL,
+    updated_at INTEGER NOT NULL,
+    PRIMARY KEY (profile_id, project_id, roadmap_id, version, todo_id),
+    FOREIGN KEY (profile_id, project_id, roadmap_id, version)
+      REFERENCES roadmap_versions(profile_id, project_id, roadmap_id, version) ON DELETE CASCADE,
+    FOREIGN KEY (profile_id, project_id, roadmap_id, version, node_id)
+      REFERENCES roadmap_nodes(profile_id, project_id, roadmap_id, version, node_id)
+);
+"""
+
+
+# This is intentionally independent of ``ROADMAPS_SCHEMA``.  Checking only
+# names would accept a table with the right API-shaped columns but no PK, FK,
+# NOT NULL, or CHECK constraints.
+_SCHEMA_CONTRACT = {
+    "roadmaps": {
+        "columns": (("profile_id", "TEXT", 1, 1), ("project_id", "TEXT", 1, 2),
+                    ("roadmap_id", "TEXT", 1, 3), ("title", "TEXT", 1, 0),
+                    ("purpose", "TEXT", 0, 0), ("lifecycle_state", "TEXT", 1, 0),
+                    ("active_version", "INTEGER", 0, 0), ("created_by", "TEXT", 1, 0),
+                    ("updated_by", "TEXT", 1, 0), ("created_at", "INTEGER", 1, 0),
+                    ("updated_at", "INTEGER", 1, 0)),
+        "fks": (("roadmap_versions", ("profile_id", "project_id", "roadmap_id", "active_version"),
+                 ("profile_id", "project_id", "roadmap_id", "version"), "NO ACTION"),
+                ("projects", ("project_id",), ("id",), "CASCADE")),
+        "sql_markers": ("primary key", "foreign key", "check", "deferrable initially deferred",
+                         "lifecycle_state text not null check", "active_version integer check"),
+    },
+    "roadmap_versions": {
+        "columns": (("profile_id", "TEXT", 1, 1), ("project_id", "TEXT", 1, 2),
+                    ("roadmap_id", "TEXT", 1, 3), ("version", "INTEGER", 1, 4),
+                    ("state", "TEXT", 1, 0), ("source", "TEXT", 0, 0), ("reason", "TEXT", 0, 0),
+                    ("created_by", "TEXT", 1, 0), ("created_at", "INTEGER", 1, 0),
+                    ("content_hash", "TEXT", 0, 0)),
+        "fks": (("roadmaps", ("profile_id", "project_id", "roadmap_id"),
+                 ("profile_id", "project_id", "roadmap_id"), "CASCADE"),),
+        "sql_markers": ("primary key", "foreign key", "check", "state text not null check", "version integer not null check"),
+    },
+    "roadmap_nodes": {
+        "columns": (("profile_id", "TEXT", 1, 1), ("project_id", "TEXT", 1, 2),
+                    ("roadmap_id", "TEXT", 1, 3), ("version", "INTEGER", 1, 4),
+                    ("node_id", "TEXT", 1, 5), ("parent_node_id", "TEXT", 0, 0),
+                    ("kind", "TEXT", 1, 0), ("title", "TEXT", 1, 0), ("description", "TEXT", 0, 0),
+                    ("state", "TEXT", 1, 0), ("progress", "INTEGER", 1, 0), ("owner_agent", "TEXT", 0, 0),
+                    ("block_reason", "TEXT", 0, 0),
+                    ("created_at", "INTEGER", 1, 0), ("updated_at", "INTEGER", 1, 0)),
+        "fks": (("roadmap_nodes", ("profile_id", "project_id", "roadmap_id", "version", "parent_node_id"),
+                 ("profile_id", "project_id", "roadmap_id", "version", "node_id"), "NO ACTION"),
+                ("roadmap_versions", ("profile_id", "project_id", "roadmap_id", "version"),
+                 ("profile_id", "project_id", "roadmap_id", "version"), "CASCADE")),
+        "sql_markers": ("primary key", "foreign key", "check", "progress integer not null default 0 check",
+                         "parent_node_id is null"),
+    },
+    "roadmap_relations": {
+        "columns": (("profile_id", "TEXT", 1, 1), ("project_id", "TEXT", 1, 2),
+                    ("roadmap_id", "TEXT", 1, 3), ("version", "INTEGER", 1, 4),
+                    ("relation_id", "TEXT", 1, 5), ("from_node_id", "TEXT", 1, 0),
+                    ("to_node_id", "TEXT", 1, 0), ("kind", "TEXT", 1, 0),
+                    ("state", "TEXT", 1, 0), ("reason", "TEXT", 0, 0)),
+        "fks": (("roadmap_nodes", ("profile_id", "project_id", "roadmap_id", "version", "from_node_id"),
+                 ("profile_id", "project_id", "roadmap_id", "version", "node_id"), "CASCADE"),
+                ("roadmap_nodes", ("profile_id", "project_id", "roadmap_id", "version", "to_node_id"),
+                 ("profile_id", "project_id", "roadmap_id", "version", "node_id"), "CASCADE")),
+        "sql_markers": ("primary key", "foreign key", "check", "from_node_id <> to_node_id", "state text not null default 'active' check"),
+    },
+    "roadmap_todos": {
+        "columns": (("profile_id", "TEXT", 1, 1), ("project_id", "TEXT", 1, 2),
+                    ("roadmap_id", "TEXT", 1, 3), ("version", "INTEGER", 1, 4),
+                    ("todo_id", "TEXT", 1, 5), ("node_id", "TEXT", 0, 0), ("title", "TEXT", 1, 0),
+                    ("state", "TEXT", 1, 0), ("position", "INTEGER", 1, 0),
+                    ("created_at", "INTEGER", 1, 0), ("updated_at", "INTEGER", 1, 0)),
+        "fks": (("roadmap_nodes", ("profile_id", "project_id", "roadmap_id", "version", "node_id"),
+                 ("profile_id", "project_id", "roadmap_id", "version", "node_id"), "NO ACTION"),
+                ("roadmap_versions", ("profile_id", "project_id", "roadmap_id", "version"),
+                 ("profile_id", "project_id", "roadmap_id", "version"), "CASCADE")),
+        "sql_markers": ("primary key", "foreign key", "check", "state text not null check", "node_id text check"),
+    },
+}
+
+
+def _validate_schema_contract(conn: sqlite3.Connection) -> None:
+    for table, expected in _SCHEMA_CONTRACT.items():
+        actual_columns = tuple(
+            (row[1], row[2].upper(), row[3], row[5])
+            for row in conn.execute(f"PRAGMA table_info({table})")
+        )
+        if actual_columns != expected["columns"]:
+            raise RuntimeError(f"incompatible existing {table} table columns")
+
+        grouped: dict[int, list[tuple]] = {}
+        for row in conn.execute(f"PRAGMA foreign_key_list({table})"):
+            grouped.setdefault(row[0], []).append(row)
+        actual_fks = tuple(
+            (rows[0][2], tuple(row[3] for row in rows), tuple(row[4] for row in rows), rows[0][6])
+            for fk_id, rows in sorted(grouped.items())
+        )
+        if set(actual_fks) != set(expected["fks"]):
+            raise RuntimeError(f"incompatible existing {table} table foreign keys")
+
+        sql = conn.execute(
+            "SELECT sql FROM sqlite_master WHERE type='table' AND name=?", (table,)
+        ).fetchone()[0].lower()
+        if any(marker not in " ".join(sql.split()) for marker in expected["sql_markers"]):
+            raise RuntimeError(f"incompatible existing {table} table constraints")
+
+
+def open_contract_db(path: Path, *, fail_after_statement: int | None = None) -> sqlite3.Connection:
+    """Create the isolated contract DB, atomically, without runtime imports.
+
+    ``projects_db.connect()`` has a separate porting obligation to make its
+    existing initialization transaction atomic; this helper only proves the
+    DDL contract and deliberately does not emulate that runtime.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(path)
+    conn.execute("PRAGMA foreign_keys=ON")
+    statements = [
+        "CREATE TABLE IF NOT EXISTS projects (id TEXT PRIMARY KEY, name TEXT NOT NULL)",
+        *(statement.strip() for statement in ROADMAPS_SCHEMA.split(";") if statement.strip()),
+    ]
+    try:
+        conn.execute("BEGIN IMMEDIATE")
+        for index, statement in enumerate(statements):
+            conn.execute(statement)
+            if fail_after_statement is not None and index == fail_after_statement:
+                raise RuntimeError("injected fixture failure")
+        _validate_schema_contract(conn)
+        conn.commit()
+    except Exception:
+        conn.rollback()
+        conn.close()
+        raise
+    return conn
+
+
+def seed_scope(conn: sqlite3.Connection, profile: str = "profile-a", project: str = "project-a") -> None:
+    conn.execute("INSERT INTO projects(id, name) VALUES (?, ?)", (project, project))
+    conn.execute(
+        "INSERT INTO roadmaps VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        (profile, project, "roadmap-a", "Roadmap", None, "draft", None, "test", "test", 1, 1),
+    )
+    conn.execute(
+        "INSERT INTO roadmap_versions VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        (profile, project, "roadmap-a", 1, "draft", "test", None, "test", 1, None),
+    )
+    conn.execute(
+        "INSERT INTO roadmap_nodes VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        (profile, project, "roadmap-a", 1, "node-a", None, "objective", "A", None, "planned", 0, None, None, 1, 1),
+    )
+    conn.commit()
+
+
+def test_initialization_is_idempotent_and_uses_only_explicit_db_path(tmp_path: Path) -> None:
+    path = tmp_path / "profile-a" / "projects.db"
+    first = open_contract_db(path)
+    first.close()
+    second = open_contract_db(path)
+    tables = {
+        row[0] for row in second.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name LIKE 'roadmap%'")
+    }
+    assert tables == {"roadmaps", "roadmap_versions", "roadmap_nodes", "roadmap_relations", "roadmap_todos"}
+    assert not (tmp_path / "roadmaps.db").exists()
+    second.close()
+
+
+def test_deferred_reports_proofs_events_and_agent_projections_are_absent(tmp_path: Path) -> None:
+    conn = open_contract_db(tmp_path / "projects.db")
+    names = {row[0] for row in conn.execute("SELECT name FROM sqlite_master WHERE type='table'")}
+    assert not names.intersection({"reports", "proofs", "events", "agent_projections", "roadmap_reports"})
+    conn.close()
+
+
+def test_two_db_paths_are_isolated_profiles(tmp_path: Path) -> None:
+    first = open_contract_db(tmp_path / "a" / "projects.db")
+    second = open_contract_db(tmp_path / "b" / "projects.db")
+    seed_scope(first, "profile-a")
+    seed_scope(second, "profile-b")
+    assert first.execute("SELECT profile_id FROM roadmaps").fetchone()[0] == "profile-a"
+    assert second.execute("SELECT profile_id FROM roadmaps").fetchone()[0] == "profile-b"
+    first.close()
+    second.close()
+
+
+def test_foreign_keys_enforce_project_and_qualified_scope(tmp_path: Path) -> None:
+    conn = open_contract_db(tmp_path / "projects.db")
+    with pytest.raises(sqlite3.IntegrityError):
+        conn.execute(
+            "INSERT INTO roadmaps VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            ("profile-a", "missing", "r", "R", None, "draft", None, "x", "x", 1, 1),
+        )
+    seed_scope(conn)
+    with pytest.raises(sqlite3.IntegrityError):
+        conn.execute(
+            "INSERT INTO roadmap_nodes VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            ("profile-b", "project-a", "roadmap-a", 1, "foreign", None, "step", "bad", None, "planned", 0, None, None, 1, 1),
+        )
+    conn.close()
+
+
+def test_project_delete_cascades_roadmap_rows(tmp_path: Path) -> None:
+    conn = open_contract_db(tmp_path / "projects.db")
+    seed_scope(conn)
+    conn.execute("DELETE FROM projects WHERE id=?", ("project-a",))
+    conn.commit()
+    for table in ("roadmaps", "roadmap_versions", "roadmap_nodes"):
+        assert conn.execute(f"SELECT COUNT(*) FROM {table}").fetchone()[0] == 0
+    conn.close()
+
+
+def test_duplicate_ids_are_rejected_within_the_qualified_scope(tmp_path: Path) -> None:
+    conn = open_contract_db(tmp_path / "projects.db")
+    seed_scope(conn)
+    with pytest.raises(sqlite3.IntegrityError):
+        conn.execute(
+            "INSERT INTO roadmap_nodes VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            ("profile-a", "project-a", "roadmap-a", 1, "node-a", None, "step", "duplicate", None, "planned", 0, None, None, 1, 1),
+        )
+    conn.close()
+
+
+def test_relations_cannot_cross_scope_or_reference_missing_nodes(tmp_path: Path) -> None:
+    conn = open_contract_db(tmp_path / "projects.db")
+    seed_scope(conn)
+    with pytest.raises(sqlite3.IntegrityError):
+        conn.execute(
+            "INSERT INTO roadmap_relations VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            ("profile-a", "project-a", "roadmap-a", 1, "rel", "node-a", "missing", "depends_on", "active", None),
+        )
+    conn.close()
+
+
+def test_sqlite_schema_exposes_constraints_and_deferred_active_version_fk(tmp_path: Path) -> None:
+    conn = open_contract_db(tmp_path / "projects.db")
+    assert conn.execute("PRAGMA foreign_keys").fetchone()[0] == 1
+    assert tuple(
+        (row[1], row[2].upper(), row[3], row[5])
+        for row in conn.execute("PRAGMA table_info(roadmaps)")
+    ) == _SCHEMA_CONTRACT["roadmaps"]["columns"]
+    fks = conn.execute("PRAGMA foreign_key_list(roadmaps)").fetchall()
+    assert any(row[2] == "roadmap_versions" and row[3] == "profile_id" for row in fks)
+    assert list(conn.execute("PRAGMA index_list(roadmap_versions)"))
+    assert list(conn.execute("PRAGMA index_list(roadmap_nodes)"))
+    conn.close()
+
+
+def test_active_version_must_reference_same_roadmap_version(tmp_path: Path) -> None:
+    conn = open_contract_db(tmp_path / "projects.db")
+    conn.execute("INSERT INTO projects VALUES (?, ?)", ("project-a", "A"))
+    conn.execute(
+        "INSERT INTO roadmaps VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        ("profile-a", "project-a", "r", "R", None, "draft", 1, "actor", "actor", 1, 1),
+    )
+    # The pointer may precede its version inside one transaction.
+    conn.execute(
+        "INSERT INTO roadmap_versions VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        ("profile-a", "project-a", "r", 1, "draft", "test", None, "actor", 1, None),
+    )
+    assert conn.execute("SELECT active_version FROM roadmaps").fetchone()[0] == 1
+    conn.commit()
+    conn.close()
+
+
+def test_unresolved_active_version_fails_at_commit(tmp_path: Path) -> None:
+    conn = open_contract_db(tmp_path / "projects.db")
+    conn.execute("INSERT INTO projects VALUES (?, ?)", ("project-a", "A"))
+    conn.execute(
+        "INSERT INTO roadmaps VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        ("profile-a", "project-a", "r", "R", None, "draft", 99, "actor", "actor", 1, 1),
+    )
+    assert conn.execute("SELECT active_version FROM roadmaps").fetchone()[0] == 99
+    with pytest.raises(sqlite3.IntegrityError):
+        conn.commit()
+    conn.rollback()
+    conn.close()
+
+
+@pytest.mark.parametrize("other_scope", [
+    ("profile-b", "project-a", "roadmap-a"),
+    ("profile-a", "project-b", "roadmap-a"),
+    ("profile-a", "project-a", "roadmap-b"),
+])
+def test_active_version_cannot_be_satisfied_by_other_scope(
+    tmp_path: Path, other_scope: tuple[str, str, str]
+) -> None:
+    conn = open_contract_db(tmp_path / "projects.db")
+    conn.executemany("INSERT INTO projects VALUES (?, ?)", [("project-a", "A"), ("project-b", "B")])
+    for profile, project, roadmap in (("profile-a", "project-a", "roadmap-a"), other_scope):
+        conn.execute(
+            "INSERT INTO roadmaps VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            (profile, project, roadmap, "R", None, "draft", None, "actor", "actor", 1, 1),
+        )
+    conn.execute(
+        "UPDATE roadmaps SET active_version=1 WHERE profile_id='profile-a' AND project_id='project-a' AND roadmap_id='roadmap-a'"
+    )
+    conn.execute(
+        "INSERT INTO roadmap_versions VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        (*other_scope, 1, "draft", "test", None, "actor", 1, None),
+    )
+    with pytest.raises(sqlite3.IntegrityError):
+        conn.commit()
+    conn.close()
+
+
+def test_project_fk_is_not_profile_qualified_within_one_projects_db(tmp_path: Path) -> None:
+    """profile_id is application validation; projects.db owns project identity."""
+    conn = open_contract_db(tmp_path / "projects.db")
+    conn.execute("INSERT INTO projects VALUES (?, ?)", ("project-a", "A"))
+    for profile, roadmap in (("profile-a", "roadmap-a"), ("profile-b", "roadmap-b")):
+        conn.execute(
+            "INSERT INTO roadmaps VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            (profile, "project-a", roadmap, "R", None, "draft", None, "actor", "actor", 1, 1),
+        )
+    conn.commit()
+    assert conn.execute("SELECT COUNT(*) FROM roadmaps").fetchone()[0] == 2
+    conn.close()
+
+
+@pytest.mark.parametrize("table,column,value", [
+    ("roadmaps", "profile_id", " "), ("roadmaps", "project_id", ""),
+    ("roadmaps", "roadmap_id", "\t"), ("roadmaps", "created_by", " "),
+    ("roadmap_nodes", "node_id", " "), ("roadmap_relations", "relation_id", ""),
+    ("roadmap_todos", "todo_id", "\t"),
+])
+def test_empty_and_whitespace_identifiers_and_actors_are_rejected(
+    tmp_path: Path, table: str, column: str, value: str
+) -> None:
+    conn = open_contract_db(tmp_path / "projects.db")
+    seed_scope(conn)
+    if table == "roadmaps":
+        values = ["profile-a", "project-a", "bad", "R", None, "draft", None, "actor", "actor", 1, 1]
+        values[{"profile_id": 0, "project_id": 1, "roadmap_id": 2, "created_by": 7}[column]] = value
+        sql = "INSERT INTO roadmaps VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
+    elif table == "roadmap_nodes":
+        values = ["profile-a", "project-a", "roadmap-a", 1, "bad", None, "step", "B", None, "planned", 0, None, None, 1, 1]
+        values[4] = value
+        sql = "INSERT INTO roadmap_nodes VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
+    elif table == "roadmap_relations":
+        values = ["profile-a", "project-a", "roadmap-a", 1, "bad", "node-a", "node-a", "depends_on", "active", None]
+        values[4] = value
+        sql = "INSERT INTO roadmap_relations VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
+    else:
+        values = ["profile-a", "project-a", "roadmap-a", 1, "bad", None, "T", "open", 0, 1, 1]
+        values[4] = value
+        sql = "INSERT INTO roadmap_todos VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
+    with pytest.raises(sqlite3.IntegrityError):
+        conn.execute(sql, values)
+    conn.close()
+
+
+def test_nodes_reject_missing_and_self_parent(tmp_path: Path) -> None:
+    conn = open_contract_db(tmp_path / "projects.db")
+    seed_scope(conn)
+    for parent in ("missing", "child"):
+        with pytest.raises(sqlite3.IntegrityError):
+            conn.execute(
+                "INSERT INTO roadmap_nodes VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                ("profile-a", "project-a", "roadmap-a", 1, "child", parent, "step", "B", None, "planned", 0, None, None, 1, 1),
+            )
+    conn.close()
+
+
+def test_relations_reject_self_and_cross_scope_endpoints(tmp_path: Path) -> None:
+    conn = open_contract_db(tmp_path / "projects.db")
+    seed_scope(conn)
+    for from_node, to_node, profile in (("node-a", "node-a", "profile-a"), ("node-a", "node-a", "profile-b")):
+        with pytest.raises(sqlite3.IntegrityError):
+            conn.execute(
+                "INSERT INTO roadmap_relations VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                (profile, "project-a", "roadmap-a", 1, "rel-" + profile, from_node, to_node, "depends_on", "active", None),
+            )
+    with pytest.raises(sqlite3.IntegrityError):
+        conn.execute(
+            "INSERT INTO roadmap_relations VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            ("profile-a", "project-a", "roadmap-a", 1, "bad-state", "node-a", "node-a", "depends_on", "bogus", None),
+        )
+    conn.close()
+
+
+def test_todos_reject_missing_node_and_cross_scope_node(tmp_path: Path) -> None:
+    conn = open_contract_db(tmp_path / "projects.db")
+    seed_scope(conn)
+    for node, profile in (("missing", "profile-a"), ("node-a", "profile-b")):
+        with pytest.raises(sqlite3.IntegrityError):
+            conn.execute(
+                "INSERT INTO roadmap_todos VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                (profile, "project-a", "roadmap-a", 1, "todo-" + profile, node, "T", "open", 0, 1, 1),
+            )
+    conn.close()
+
+
+def test_additive_migration_preserves_multiple_legacy_tables_and_rows(tmp_path: Path) -> None:
+    path = tmp_path / "legacy.db"
+    conn = sqlite3.connect(path)
+    conn.execute("CREATE TABLE legacy_settings (key TEXT PRIMARY KEY, value TEXT)")
+    conn.execute("INSERT INTO legacy_settings VALUES ('keep', 'yes')")
+    conn.execute("CREATE TABLE legacy_audit (id INTEGER PRIMARY KEY, detail TEXT)")
+    conn.execute("INSERT INTO legacy_audit VALUES (1, 'preserve')")
+    conn.execute("CREATE TABLE projects (id TEXT PRIMARY KEY, name TEXT NOT NULL)")
+    conn.execute("CREATE INDEX legacy_audit_detail ON legacy_audit(detail)")
+    conn.execute("INSERT INTO projects VALUES ('legacy-project', 'Legacy')")
+    conn.commit()
+    conn.close()
+
+    migrated = open_contract_db(path)
+    assert migrated.execute("SELECT value FROM legacy_settings WHERE key='keep'").fetchone()[0] == "yes"
+    assert migrated.execute("SELECT detail FROM legacy_audit WHERE id=1").fetchone()[0] == "preserve"
+    assert migrated.execute("SELECT name FROM projects WHERE id='legacy-project'").fetchone()[0] == "Legacy"
+    assert "legacy_audit_detail" in {row[1] for row in migrated.execute("PRAGMA index_list(legacy_audit)")}
+    migrated.close()
+
+
+def test_incompatible_existing_roadmaps_table_is_rejected(tmp_path: Path) -> None:
+    path = tmp_path / "incompatible.db"
+    conn = sqlite3.connect(path)
+    conn.execute("CREATE TABLE roadmaps (id INTEGER PRIMARY KEY, note TEXT)")
+    conn.commit()
+    conn.close()
+    with pytest.raises(RuntimeError, match="incompatible existing roadmaps table"):
+        open_contract_db(path)
+    check = sqlite3.connect(path)
+    assert {row[0] for row in check.execute("SELECT name FROM sqlite_master WHERE type='table'")} == {"roadmaps"}
+    check.close()
+
+
+def test_same_columns_without_constraints_are_rejected_without_residue(tmp_path: Path) -> None:
+    path = tmp_path / "weakened.db"
+    conn = sqlite3.connect(path)
+    # Deliberately preserve every column name/type while removing NOT NULL,
+    # PK, FK, and CHECK constraints. A name-only compatibility check would
+    # incorrectly accept this table.
+    conn.execute("""
+        CREATE TABLE roadmaps (
+            profile_id TEXT, project_id TEXT, roadmap_id TEXT, title TEXT,
+            purpose TEXT, lifecycle_state TEXT, active_version INTEGER,
+            created_by TEXT, updated_by TEXT, created_at INTEGER, updated_at INTEGER
+        )
+    """)
+    conn.commit()
+    conn.close()
+
+    with pytest.raises(RuntimeError, match="incompatible existing roadmaps table"):
+        open_contract_db(path)
+
+    check = sqlite3.connect(path)
+    assert {
+        row[0] for row in check.execute("SELECT name FROM sqlite_master WHERE type='table'")
+    } == {"roadmaps"}
+    check.close()
+
+
+def test_fixture_failure_rolls_back_new_roadmap_tables_and_preserves_legacy(tmp_path: Path) -> None:
+    path = tmp_path / "injected-failure.db"
+    conn = sqlite3.connect(path)
+    conn.execute("CREATE TABLE legacy (id INTEGER PRIMARY KEY, value TEXT)")
+    conn.execute("INSERT INTO legacy VALUES (1, 'keep')")
+    conn.execute("CREATE INDEX legacy_value ON legacy(value)")
+    conn.commit()
+    conn.close()
+
+    with pytest.raises(RuntimeError, match="injected fixture failure"):
+        open_contract_db(path, fail_after_statement=2)
+
+    check = sqlite3.connect(path)
+    assert check.execute("SELECT value FROM legacy WHERE id=1").fetchone()[0] == "keep"
+    assert "legacy_value" in {row[1] for row in check.execute("PRAGMA index_list(legacy)")}
+    assert not {
+        row[0] for row in check.execute("SELECT name FROM sqlite_master WHERE type='table'")
+    }.intersection({"roadmaps", "roadmap_versions", "roadmap_nodes", "roadmap_relations", "roadmap_todos"})
+    check.close()


### PR DESCRIPTION
Part 1/5 of the Roadmaps orchestration feature (Kanban model). Adds the pure state-machine contract (`src/roadmaps_contract.py`) and the additive roadmaps schema in `projects.db` (roadmaps, roadmap_versions, roadmap_nodes, roadmap_relations, roadmap_todos, roadmap_sessions), with 76 tests. No UI, no RPC surface yet — store layer only.